### PR TITLE
fix(orchestration): recover exact federated worker retirement

### DIFF
--- a/src/main/runtime/orca-runtime-get-orchestration-dispatch-authority.ts
+++ b/src/main/runtime/orca-runtime-get-orchestration-dispatch-authority.ts
@@ -17,6 +17,7 @@ import { getAppEnvironment } from '../../shared/app-environment'
 import type { FleetAgentStatusEvidence } from '../../shared/orchestration-fleet-agent-status-evidence'
 import { readOrchestrationFleetAgentStatusSnapshot } from './orchestration-fleet-agent-status-snapshot'
 import { resolveStructuredWorkerAuthority } from './structured-worker-authority'
+import { matchesProcessIncarnation } from './orchestration/worker-terminal-process-liveness'
 
 export class OrcaRuntimeWithGetOrchestrationDispatchAuthority extends OrcaRuntimeWithVerifyOrchestrationCompatibilityCaller {
   /** Every pane key this PTY could be addressed by, including restored receipts. */
@@ -240,5 +241,27 @@ export class OrcaRuntimeWithGetOrchestrationDispatchAuthority extends OrcaRuntim
         ? resolveLocalProjectRuntimeForWorktreeId(this.requireStore(), pty.worktreeId)
         : undefined
     })
+  }
+  /** Recover an expired handle only for the recorded process incarnation on its owning host. */
+  resolveTerminalHandleByProcessIncarnation(
+    processIncarnation: string,
+    serializedHostScope: string | null
+  ): string | null {
+    if (!processIncarnation || !serializedHostScope) {
+      return null
+    }
+    // Do not split colon-bearing PTY or incarnation IDs.
+    for (const [ptyId, pty] of this.ptysById) {
+      if (!matchesProcessIncarnation(ptyId, pty.incarnationId, processIncarnation)) {
+        continue
+      }
+      const hostScope = this.getOrchestrationCompatibilityHostScope(pty)
+      if (!hostScope || JSON.stringify(hostScope) !== serializedHostScope) {
+        // A different-host match must not hide a later same-host match.
+        continue
+      }
+      return this.issuePtyHandle(pty)
+    }
+    return null
   }
 }

--- a/src/main/runtime/orca-runtime-terminal-handle-incarnation.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-handle-incarnation.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
+import { makePaneKey } from '../../shared/stable-pane-id'
 
 const PTY_ID = 'ssh:target@@relay-pty'
 const WORKTREE_ID = 'repo::/worktree'
 const TAB_ID = 'tab-terminal'
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
+/** A runtime whose pty controller captures every write for assertion. */
 function makeRuntime(): { runtime: OrcaRuntimeService; writes: string[] } {
   const writes: string[] = []
   const runtime = new OrcaRuntimeService(null)
@@ -20,6 +22,7 @@ function makeRuntime(): { runtime: OrcaRuntimeService; writes: string[] } {
   return { runtime, writes }
 }
 
+/** Attach a window and publish a one-tab, one-leaf terminal graph. */
 function syncGraph(runtime: OrcaRuntimeService): void {
   runtime.attachWindow(1)
   runtime.syncWindowGraph(1, {
@@ -44,6 +47,7 @@ function syncGraph(runtime: OrcaRuntimeService): void {
   })
 }
 
+/** (Re)register the fixture pty leaf under the given incarnation id. */
 function register(runtime: OrcaRuntimeService, incarnationId: string): void {
   runtime.registerPty(PTY_ID, WORKTREE_ID, 'target', {
     tabId: TAB_ID,
@@ -179,5 +183,137 @@ describe('runtime terminal handle incarnation fencing', () => {
       handle: replacementHandle,
       status: 'running'
     })
+  })
+})
+
+describe('resolveTerminalHandleByProcessIncarnation direct fencing', () => {
+  const LOCAL_SCOPE = JSON.stringify({ kind: 'local', hostId: 'local' })
+  // PTY_ID ('ssh:target@@relay-pty') derives connectionId 'target' via parseAppSshPtyId, so its
+  // host scope is ssh:target rather than local.
+  const SSH_TARGET_SCOPE = JSON.stringify({ kind: 'ssh', targetId: 'target' })
+
+  /** Register a pty leaf directly, optionally under a connection and incarnation. */
+  function seedPty(
+    runtime: OrcaRuntimeService,
+    ptyId: string,
+    incarnationId: string | null,
+    connectionId: string | null = null
+  ): void {
+    runtime.registerPty(ptyId, WORKTREE_ID, connectionId, {
+      tabId: TAB_ID,
+      leafId: LEAF_ID,
+      ...(incarnationId ? { incarnationId } : {})
+    })
+  }
+
+  /** Call the private resolveTerminalHandleByProcessIncarnation on the runtime. */
+  function resolve(
+    runtime: OrcaRuntimeService,
+    processIncarnation: string,
+    serializedHostScope: string | null
+  ): string | null {
+    return (
+      runtime as unknown as {
+        resolveTerminalHandleByProcessIncarnation(
+          processIncarnation: string,
+          serializedHostScope: string | null
+        ): string | null
+      }
+    ).resolveTerminalHandleByProcessIncarnation(processIncarnation, serializedHostScope)
+  }
+
+  it('mints a live handle for a pty whose exact incarnation and host scope match', () => {
+    const { runtime } = makeRuntime()
+    seedPty(runtime, PTY_ID, 'incarnation-1')
+    const handle = resolve(runtime, `${PTY_ID}:incarnation-1`, SSH_TARGET_SCOPE)
+    expect(handle).toMatch(/^term_/)
+    // Re-minting the same live pty is idempotent.
+    expect(resolve(runtime, `${PTY_ID}:incarnation-1`, SSH_TARGET_SCOPE)).toBe(handle)
+  })
+
+  it('returns null when the recorded incarnationId no longer matches the live pty', () => {
+    const { runtime } = makeRuntime()
+    seedPty(runtime, PTY_ID, 'incarnation-1')
+    expect(resolve(runtime, `${PTY_ID}:incarnation-2`, LOCAL_SCOPE)).toBeNull()
+  })
+
+  it('returns null when the live pty has no incarnationId (legacy runtimeId:ptyId:gen never reaps)', () => {
+    const { runtime } = makeRuntime()
+    seedPty(runtime, PTY_ID, null)
+    // A modern-shaped probe cannot match a pty that carries no incarnationId...
+    expect(resolve(runtime, `${PTY_ID}:incarnation-1`, LOCAL_SCOPE)).toBeNull()
+    // ...and the legacy `${runtimeId}:${ptyId}:${ptyGeneration}` shape stays fail-closed rather
+    // than reap on a ptyGeneration guess.
+    expect(resolve(runtime, `runtime_test:${PTY_ID}:0`, LOCAL_SCOPE)).toBeNull()
+  })
+
+  it('returns null when the host scope does not match', () => {
+    const { runtime } = makeRuntime()
+    seedPty(runtime, PTY_ID, 'incarnation-1')
+    expect(
+      resolve(runtime, `${PTY_ID}:incarnation-1`, JSON.stringify({ kind: 'ssh', targetId: 'nope' }))
+    ).toBeNull()
+  })
+
+  it('returns null when no host scope is supplied (fails closed)', () => {
+    const { runtime } = makeRuntime()
+    seedPty(runtime, PTY_ID, 'incarnation-1')
+    expect(resolve(runtime, `${PTY_ID}:incarnation-1`, null)).toBeNull()
+  })
+
+  it('resolves a colon-bearing SSH/relay incarnationId that lastIndexOf would mis-split', () => {
+    const { runtime } = makeRuntime()
+    // PTY_ID already carries ':' and '@@'; the incarnationId itself also carries colons.
+    seedPty(runtime, PTY_ID, 'relay:conn-3:incarnation-9', 'target')
+    const handle = resolve(
+      runtime,
+      `${PTY_ID}:relay:conn-3:incarnation-9`,
+      JSON.stringify({ kind: 'ssh', targetId: 'target' })
+    )
+    expect(handle).toMatch(/^term_/)
+  })
+
+  it('resolves a Windows repo::C:\\path@@1 ptyId', () => {
+    const { runtime } = makeRuntime()
+    const windowsPtyId = 'repo::C:\\path@@1'
+    seedPty(runtime, windowsPtyId, 'incarnation-win')
+    const handle = resolve(runtime, `${windowsPtyId}:incarnation-win`, LOCAL_SCOPE)
+    expect(handle).toMatch(/^term_/)
+  })
+
+  it('keeps scanning past a colon-ambiguous decoy in another host scope to the genuine match', () => {
+    const { runtime } = makeRuntime()
+    // One process-incarnation string, two colon-ambiguous pty ids that both satisfy the exact
+    // matcher: 'relay' + 'conn:incarnation-1' AND 'relay:conn' + 'incarnation-1' both stringify to
+    // 'relay:conn:incarnation-1'. The decoy is registered FIRST and lives in a different host scope
+    // (ssh:decoy); the genuine pty is local and registered later.
+    const processIncarnation = 'relay:conn:incarnation-1'
+    const DECOY_TAB_ID = 'tab-decoy'
+    const DECOY_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+    const GENUINE_TAB_ID = 'tab-genuine'
+    const GENUINE_LEAF_ID = '33333333-3333-4333-8333-333333333333'
+    runtime.registerPty('relay', WORKTREE_ID, 'decoy', {
+      tabId: DECOY_TAB_ID,
+      leafId: DECOY_LEAF_ID,
+      incarnationId: 'conn:incarnation-1'
+    })
+    runtime.registerPty('relay:conn', WORKTREE_ID, null, {
+      tabId: GENUINE_TAB_ID,
+      leafId: GENUINE_LEAF_ID,
+      incarnationId: 'incarnation-1'
+    })
+
+    // Before the fix, the earlier decoy's host-scope mismatch returned null and suppressed the
+    // genuine same-scope pty entirely. `continue` lets the scan reach it.
+    const handle = resolve(runtime, processIncarnation, LOCAL_SCOPE)
+    expect(handle).toMatch(/^term_/)
+    // getTerminalProcessIncarnation cannot separate the two (both stringify to
+    // 'relay:conn:incarnation-1'), so pin the remint to the GENUINE pane. The paneKey is the only
+    // terminal-specific observable that distinguishes the genuine leaf from the same-incarnation
+    // decoy; this fails if the resolver ever mints the decoy's handle instead of the genuine pty's.
+    const genuinePaneKey = makePaneKey(GENUINE_TAB_ID, GENUINE_LEAF_ID)
+    const decoyPaneKey = makePaneKey(DECOY_TAB_ID, DECOY_LEAF_ID)
+    expect(runtime.getTerminalPaneKey(handle!)).toBe(genuinePaneKey)
+    expect(runtime.getTerminalPaneKey(handle!)).not.toBe(decoyPaneKey)
   })
 })

--- a/src/main/runtime/orchestration/worker-terminal-process-liveness.test.ts
+++ b/src/main/runtime/orchestration/worker-terminal-process-liveness.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { matchesProcessIncarnation } from './worker-terminal-process-liveness'
+
+describe('matchesProcessIncarnation', () => {
+  it.each([
+    {
+      name: 'an exact ptyId:incarnation match',
+      ptyId: 'pty-1',
+      incarnationId: 'incarnation-1' as string | null | undefined,
+      processIncarnation: 'pty-1:incarnation-1',
+      expected: true
+    },
+    {
+      name: 'a Windows repo::C:\\path@@1 ptyId whose incarnation matches',
+      ptyId: 'repo::C:\\path@@1',
+      incarnationId: 'incarnation-win' as string | null | undefined,
+      processIncarnation: 'repo::C:\\path@@1:incarnation-win',
+      expected: true
+    },
+    {
+      name: 'a colon-bearing relay incarnationId that a lastIndexOf split would mangle',
+      ptyId: 'relay-pty',
+      incarnationId: 'relay:conn-3:incarnation-9' as string | null | undefined,
+      processIncarnation: 'relay-pty:relay:conn-3:incarnation-9',
+      expected: true
+    },
+    {
+      name: 'a whitespace-dirty incarnationId (lost contact is never a match)',
+      ptyId: 'pty-1',
+      incarnationId: ' incarnation-1' as string | null | undefined,
+      processIncarnation: 'pty-1: incarnation-1',
+      expected: false
+    },
+    {
+      name: 'an empty-string incarnationId',
+      ptyId: 'pty-1',
+      incarnationId: '' as string | null | undefined,
+      processIncarnation: 'pty-1:',
+      expected: false
+    },
+    {
+      name: 'an absent (null) incarnationId',
+      ptyId: 'pty-1',
+      incarnationId: null as string | null | undefined,
+      processIncarnation: 'pty-1:incarnation-1',
+      expected: false
+    },
+    {
+      name: 'an absent (undefined) incarnationId',
+      ptyId: 'pty-1',
+      incarnationId: undefined as string | null | undefined,
+      processIncarnation: 'pty-1:incarnation-1',
+      expected: false
+    },
+    {
+      name: 'a prefix-decoy ptyId (@@1) against a longer live pty (@@10)',
+      ptyId: 'repo::C:\\path@@1',
+      incarnationId: 'inc-1' as string | null | undefined,
+      processIncarnation: 'repo::C:\\path@@10:inc-1',
+      expected: false
+    }
+  ])('returns $expected for $name', ({ ptyId, incarnationId, processIncarnation, expected }) => {
+    expect(matchesProcessIncarnation(ptyId, incarnationId, processIncarnation)).toBe(expected)
+  })
+
+  it('rejects a partial prefix that is not colon-delimited', () => {
+    // 'pty-10' is not the pty 'pty-1'; the `${ptyId}:` fence keeps them distinct.
+    expect(matchesProcessIncarnation('pty-1', 'inc', 'pty-10:inc')).toBe(false)
+  })
+})

--- a/src/main/runtime/orchestration/worker-terminal-process-liveness.ts
+++ b/src/main/runtime/orchestration/worker-terminal-process-liveness.ts
@@ -5,6 +5,21 @@ import type { PtyProcessInfo } from '../../providers/pty-process-info'
 export type { WorkerTerminalHostScope } from '../../../shared/worker-terminal-host-scope'
 export { parseWorkerTerminalHostScope } from '../../../shared/worker-terminal-host-scope'
 
+/** Compare full identity without splitting colon-bearing IDs. */
+export function matchesProcessIncarnation(
+  ptyId: string,
+  incarnationId: string | null | undefined,
+  processIncarnation: string
+): boolean {
+  if (!incarnationId || incarnationId !== incarnationId.trim()) {
+    return false
+  }
+  if (!processIncarnation.startsWith(`${ptyId}:`)) {
+    return false
+  }
+  return `${ptyId}:${incarnationId}` === processIncarnation
+}
+
 export function classifyWorkerTerminalProcessIncarnation(
   processIncarnation: string,
   sessions: readonly PtyProcessInfo[]
@@ -13,13 +28,9 @@ export function classifyWorkerTerminalProcessIncarnation(
     processIncarnation.startsWith(`${session.id}:`)
   )
   if (
-    possibleMatches.some((session) => {
-      const incarnationId = session.incarnationId
-      if (!incarnationId || incarnationId !== incarnationId.trim()) {
-        return false
-      }
-      return `${session.id}:${incarnationId}` === processIncarnation
-    })
+    possibleMatches.some((session) =>
+      matchesProcessIncarnation(session.id, session.incarnationId, processIncarnation)
+    )
   ) {
     return 'live'
   }

--- a/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-release-host.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-release-host.ts
@@ -1,3 +1,5 @@
+import { remoteAttachmentLeaseIsCurrent } from './federation-terminal-release-lease'
+import { recoverExitedFederationRelease } from './federation-release-exit-recovery'
 import { describeUnconfirmedAgentStop } from '../../../../../../shared/pty-liveness-verdict'
 import type { RemoteDispatchAttachmentRow } from '../../../../orchestration/types'
 import type {
@@ -106,10 +108,11 @@ export async function releaseRemoteAttachment(args: {
   }
   const resource = requested.resource
   if (!observation.exact || !observation.terminal) {
-    if (
-      args.mode === 'recovery' &&
-      (observation.status === 'missing' || observation.status === 'unattached')
-    ) {
+    if (observation.status === 'missing' || observation.status === 'unattached') {
+      const recovered = await recoverExitedFederationRelease(runtime, attachment, resource)
+      if (recovered) {
+        return recovered
+      }
       return {
         dispatchId: attachment.dispatch_id,
         state: 'release_pending',
@@ -264,28 +267,6 @@ export async function releaseRemoteAttachment(args: {
     archive: archiveSummary(released),
     output: projectArchivedOutputLiveness(output, 'exited')
   }
-}
-
-function remoteAttachmentLeaseIsCurrent(
-  runtime: OrcaRuntimeService,
-  attachment: RemoteDispatchAttachmentRow,
-  observation: Awaited<ReturnType<typeof inspectRemoteAttachment>>,
-  resource: WorkerTerminalResourceRow
-): boolean {
-  const db = runtime.getOrchestrationDb()
-  return Boolean(
-    observation.exact &&
-    observation.terminal?.handle === resource.terminal_handle &&
-    attachment.terminal_handle === resource.terminal_handle &&
-    resource.owner_dispatch_id === attachment.dispatch_id &&
-    resource.ownership_state === 'owned' &&
-    db.isRemoteAttachmentProcessCurrent({
-      dispatchId: attachment.dispatch_id,
-      paneKey: runtime.getTerminalPaneKey(resource.terminal_handle),
-      processIncarnation: runtime.getTerminalProcessIncarnation(resource.terminal_handle)
-    }) &&
-    !db.workerTerminalResourceHasIdentityConflict(resource.id)
-  )
 }
 
 function retainedReason(resource: WorkerTerminalResourceRow): WorkerTerminalRetainedReason {

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-attachment-observation.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-attachment-observation.ts
@@ -36,21 +36,33 @@ export async function inspectRemoteAttachment(
   if (!attachment?.terminal_handle) {
     return { terminal: null, exact: false, status: 'unattached' }
   }
-  const terminal = await runtime.showTerminal(attachment.terminal_handle).catch(() => null)
+  const resource = db.getWorkerTerminalResourceByOwner(dispatchId)
+  let terminalHandle = attachment.terminal_handle
+  let terminal = await runtime.showTerminal(terminalHandle).catch(() => null)
+  if (!terminal && resource?.process_incarnation === attachment.process_incarnation) {
+    const recovered = runtime.resolveTerminalHandleByProcessIncarnation(
+      attachment.process_incarnation ?? '',
+      resource.host_scope
+    )
+    if (recovered) {
+      terminalHandle = recovered
+      terminal = await runtime.showTerminal(terminalHandle).catch(() => null)
+    }
+  }
   if (!terminal) {
     return { terminal: null, exact: false, status: 'missing' }
   }
   const exact = db.isRemoteAttachmentProcessCurrent({
     dispatchId,
-    paneKey: runtime.getTerminalPaneKey(attachment.terminal_handle),
-    processIncarnation: runtime.getTerminalProcessIncarnation(attachment.terminal_handle)
+    paneKey: runtime.getTerminalPaneKey(terminalHandle),
+    processIncarnation: runtime.getTerminalProcessIncarnation(terminalHandle)
   })
   if (!exact) {
     return { terminal, exact, status: 'identity_changed' }
   }
   // Why: transport loss clears `connected` for every remote PTY; only the execution host can certify exit.
   const agentWait = terminal.agentWait
-  const verdict = runtime.getTerminalLivenessVerdict?.(attachment.terminal_handle) ?? null
+  const verdict = runtime.getTerminalLivenessVerdict?.(terminalHandle) ?? null
   if (verdict?.status === 'unverifiable') {
     return { terminal, exact, status: 'unverifiable', reason: verdict.reason, agentWait }
   }
@@ -60,9 +72,7 @@ export async function inspectRemoteAttachment(
     // The host owns a connected local pane, so its own connected flag is host evidence of life,
     // exactly as worker-show reads it. Nothing weaker earns a claim: a disconnected pane or an
     // SSH-scoped one (contact, not the process) stays unverifiable, never `exited`.
-    const currentHostScope = runtime.getOrchestrationDispatchAuthority?.(
-      attachment.terminal_handle
-    )?.hostScope
+    const currentHostScope = runtime.getOrchestrationDispatchAuthority?.(terminalHandle)?.hostScope
     const persistedHostScope = parseWorkerTerminalHostScope(
       db.getWorkerTerminalResourceByOwner(dispatchId)?.host_scope ?? null
     )

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-incarnation-recovery.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-incarnation-recovery.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../../../shared/protocol-version'
+import { OrcaRuntimeService } from '../../../../orca-runtime'
+import { OrchestrationDb } from '../../../../orchestration/db'
+import { ORCHESTRATION_METHODS } from '../../orchestration'
+
+const DISPATCH = 'ctx_recovered'
+const PANE = 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const PTY = 'ssh:relay:pty-worker'
+const INCARNATION = 'inc:worker'
+const STALE = 'term_expired'
+const HOST = JSON.stringify({ kind: 'local', hostId: 'local' })
+
+describe('federation incarnation recovery', () => {
+  let db: OrchestrationDb
+  let runtime: OrcaRuntimeService
+
+  beforeEach(() => {
+    db = new OrchestrationDb(':memory:')
+    runtime = new OrcaRuntimeService(null)
+    runtime.setOrchestrationDb(db)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.registerPty(PTY, 'folder-workspace', null, {
+      tabId: 'tab_worker',
+      leafId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      incarnationId: INCARNATION
+    })
+    vi.spyOn(runtime, 'closeTerminal').mockResolvedValue({ ptyKilled: true } as never)
+    vi.spyOn(runtime, 'readTerminal').mockResolvedValue({
+      entries: [{ cursor: 1, text: 'durable worker output' }],
+      nextCursor: 1,
+      tail: ['durable worker output'],
+      truncated: false
+    } as never)
+  })
+
+  afterEach(() => db.close())
+
+  function attach(hostScope: string | null = HOST) {
+    db.createRemoteDispatchAttachment({
+      dispatchId: DISPATCH,
+      taskId: 'task_worker',
+      homePeerFingerprint: 'home',
+      protocolVersion: ORCHESTRATION_CONTRACT_VERSION,
+      runtimeEpoch: runtime.getRuntimeId(),
+      mutationReceipt: {
+        callerFingerprint: 'home',
+        requestId: 'attach',
+        method: 'orchestration.federationAttachStart',
+        payloadHash: 'hash'
+      }
+    })
+    db.prepareRemoteAttachmentAuthority({
+      dispatchId: DISPATCH,
+      paneKey: PANE,
+      processIncarnation: `${PTY}:${INCARNATION}`,
+      worktreeId: 'folder-workspace',
+      terminalHandle: STALE,
+      setupState: 'not_applicable',
+      effects: [],
+      hostScope,
+      terminalOwnership: 'created'
+    })
+    db.markRemoteAttachmentReady(DISPATCH)
+  }
+
+  function settle() {
+    db.recordRemoteAttachmentStage({
+      dispatchId: DISPATCH,
+      state: 'succeeded',
+      stage: 'worker_reported'
+    })
+  }
+
+  function call(name: string) {
+    const method = ORCHESTRATION_METHODS.find(
+      (candidate) => candidate.name === `orchestration.${name}`
+    )!
+    return method.handler(method.params!.parse({ dispatchId: DISPATCH }), {
+      runtime,
+      authenticatedCallerFingerprint: 'home'
+    } as never)
+  }
+
+  it('reads and stops the same live incarnation through a newly resolved handle', async () => {
+    attach()
+    await expect(runtime.showTerminal(STALE)).rejects.toThrow()
+    const current = runtime.resolveTerminalHandleByProcessIncarnation(
+      `${PTY}:${INCARNATION}`,
+      HOST
+    )!
+    expect(current).not.toBe(STALE)
+    await expect(call('federationShow')).resolves.toMatchObject({
+      observation: { exactWorker: true, status: 'live' }
+    })
+    await call('federationRead')
+    expect(runtime.readTerminal).toHaveBeenCalledWith(current, {
+      cursor: undefined,
+      limit: undefined
+    })
+    await expect(call('federationStop')).resolves.toMatchObject({ state: 'stopped' })
+    expect(runtime.closeTerminal).toHaveBeenCalledWith(current)
+  })
+
+  it('archives before releasing the recovered terminal, retaining the durable lease identity', async () => {
+    attach()
+    settle()
+    const current = runtime.resolveTerminalHandleByProcessIncarnation(
+      `${PTY}:${INCARNATION}`,
+      HOST
+    )!
+    vi.mocked(runtime.closeTerminal).mockImplementation(async (handle) => {
+      expect(db.getWorkerTerminalArchive(DISPATCH)).toBeDefined()
+      expect(handle).toBe(current)
+      return { ptyKilled: true } as never
+    })
+    await expect(call('federationRelease')).resolves.toMatchObject({ state: 'released' })
+    expect(db.getWorkerTerminalResourceByOwner(DISPATCH)).toMatchObject({
+      terminal_handle: STALE,
+      release_state: 'released'
+    })
+    expect(runtime.closeTerminal).toHaveBeenCalledTimes(1)
+    await expect(call('federationRelease')).resolves.toMatchObject({ state: 'already_released' })
+    expect(runtime.closeTerminal).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    null,
+    JSON.stringify({ kind: 'ssh', targetId: 'other-host' }),
+    JSON.stringify({ kind: 'wsl', hostId: 'local', distro: 'Ubuntu' })
+  ])('retains close intent when the host scope cannot match: %s', async (scope) => {
+    attach(scope)
+    settle()
+    await expect(call('federationRelease')).resolves.toMatchObject({ state: 'release_pending' })
+    expect(db.getWorkerTerminalResourceByOwner(DISPATCH)?.release_state).toBe('requested')
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+  })
+
+  it('does not recover a recycled PTY incarnation', async () => {
+    attach()
+    runtime.registerPty(PTY, 'folder-workspace', null, {
+      tabId: 'tab_worker',
+      leafId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      incarnationId: 'replacement'
+    })
+    await expect(call('federationStop')).resolves.toMatchObject({
+      state: 'stop_unknown',
+      processAction: 'none'
+    })
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+  })
+
+  it('retains user ownership even when the terminal can be recovered', async () => {
+    attach()
+    settle()
+    db.markWorkerTerminalUserOwned(PANE)
+    await expect(call('federationRelease')).resolves.toMatchObject({
+      state: 'retained',
+      reason: 'user_takeover'
+    })
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+  })
+
+  it.each(['live', 'unverifiable', 'exited'] as const)(
+    'recovers lost close acknowledgement after restart only for host verdict %s',
+    async (verdict) => {
+      attach()
+      settle()
+      vi.mocked(runtime.closeTerminal).mockRejectedValueOnce(new Error('endpoint is not connected'))
+      await expect(call('federationRelease')).resolves.toMatchObject({ state: 'release_pending' })
+      expect(db.getWorkerTerminalArchive(DISPATCH)).toBeDefined()
+      runtime = new OrcaRuntimeService(null)
+      runtime.setOrchestrationDb(db)
+      const inspect = vi
+        .spyOn(runtime, 'inspectTerminalProcessIncarnationLiveness')
+        .mockResolvedValue(verdict)
+      const close = vi.spyOn(runtime, 'closeTerminal')
+      await expect(call('federationRelease')).resolves.toMatchObject({
+        state: verdict === 'exited' ? 'released' : 'release_pending'
+      })
+      expect(inspect).toHaveBeenCalledWith(`${PTY}:${INCARNATION}`, HOST)
+      expect(close).not.toHaveBeenCalled()
+    }
+  )
+
+  it('refuses release if the process changes while its output is archived', async () => {
+    attach()
+    settle()
+    vi.mocked(runtime.readTerminal).mockImplementation(async () => {
+      runtime.registerPty(PTY, 'folder-workspace', null, {
+        tabId: 'tab_worker',
+        leafId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        incarnationId: 'replacement'
+      })
+      return { tail: ['last output'], entries: [], truncated: false } as never
+    })
+    await expect(call('federationRelease')).resolves.toMatchObject({ state: 'retained' })
+    expect(runtime.closeTerminal).not.toHaveBeenCalled()
+  })
+
+  it('does not settle a failed kill and retries the same incarnation', async () => {
+    attach()
+    settle()
+    vi.mocked(runtime.closeTerminal).mockResolvedValueOnce({
+      ptyKilled: false,
+      ptyStopVerdict: 'unverifiable'
+    } as never)
+    await expect(call('federationRelease')).resolves.toMatchObject({ state: 'release_unknown' })
+    expect(db.getWorkerTerminalResourceByOwner(DISPATCH)?.release_state).toBe('unknown')
+    await expect(call('federationRelease')).resolves.toMatchObject({ state: 'released' })
+    expect(runtime.closeTerminal).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-release-exit-recovery.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-release-exit-recovery.ts
@@ -1,0 +1,58 @@
+import type { OrcaRuntimeService } from '../../../../orca-runtime'
+import type { RemoteDispatchAttachmentRow } from '../../../../orchestration/types'
+import type { WorkerTerminalResourceRow } from '../../../../orchestration/worker-terminal-ownership'
+import { summarizeWorkerOutputArchive } from '../../../../orchestration/worker-output-archive'
+import type { WorkerReleaseReceipt } from '../worker/worker-release-completion'
+
+/** A lost close acknowledgement can settle only from host exit proof and a committed archive. */
+export async function recoverExitedFederationRelease(
+  runtime: OrcaRuntimeService,
+  attachment: RemoteDispatchAttachmentRow,
+  resource: WorkerTerminalResourceRow
+): Promise<WorkerReleaseReceipt | null> {
+  const db = runtime.getOrchestrationDb()
+  const archive = db.getWorkerTerminalArchive(attachment.dispatch_id)
+  if (
+    !archive ||
+    archive.resource_id !== resource.id ||
+    !resource.process_incarnation ||
+    resource.process_incarnation !== attachment.process_incarnation
+  ) {
+    return null
+  }
+  const verdict = await runtime.inspectTerminalProcessIncarnationLiveness(
+    resource.process_incarnation,
+    resource.host_scope
+  )
+  if (verdict !== 'exited') {
+    return null
+  }
+  const current = db.getWorkerTerminalResourceByOwner(attachment.dispatch_id)
+  if (
+    current?.id !== resource.id ||
+    current.process_incarnation !== resource.process_incarnation ||
+    current.host_scope !== resource.host_scope ||
+    current.ownership_state !== 'owned' ||
+    db.workerTerminalResourceHasIdentityConflict(resource.id)
+  ) {
+    return null
+  }
+  const summary = summarizeWorkerOutputArchive(archive)
+  const releasing = db.commitWorkerTerminalArchiveForRelease({
+    dispatchId: attachment.dispatch_id,
+    resourceId: resource.id,
+    archiveSource: summary.source,
+    archiveStatus: summary.status
+  })
+  if (releasing.ownership_state !== 'owned' || releasing.release_state !== 'releasing') {
+    return null
+  }
+  db.settleWorkerTerminalRelease(resource.id)
+  db.recordRemoteAttachmentStage({ dispatchId: attachment.dispatch_id, stage: 'released' })
+  return {
+    dispatchId: attachment.dispatch_id,
+    state: 'released',
+    processAction: 'closed_exited_terminal',
+    archive: summary
+  }
+}

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-terminal-release-lease.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-terminal-release-lease.ts
@@ -1,0 +1,31 @@
+import type { OrcaRuntimeService } from '../../../../orca-runtime'
+import type { RemoteDispatchAttachmentRow } from '../../../../orchestration/types'
+import type { WorkerTerminalResourceRow } from '../../../../orchestration/worker-terminal-ownership'
+import type { inspectRemoteAttachment } from './federation-attachment-observation'
+
+export function remoteAttachmentLeaseIsCurrent(
+  runtime: OrcaRuntimeService,
+  attachment: RemoteDispatchAttachmentRow,
+  observation: Awaited<ReturnType<typeof inspectRemoteAttachment>>,
+  resource: WorkerTerminalResourceRow
+): boolean {
+  const db = runtime.getOrchestrationDb()
+  return Boolean(
+    observation.exact &&
+    observation.terminal &&
+    attachment.terminal_handle === resource.terminal_handle &&
+    resource.owner_dispatch_id === attachment.dispatch_id &&
+    resource.ownership_state === 'owned' &&
+    (observation.terminal.handle === resource.terminal_handle ||
+      resource.host_scope ===
+        JSON.stringify(
+          runtime.getOrchestrationDispatchAuthority(observation.terminal.handle)?.hostScope
+        )) &&
+    db.isRemoteAttachmentProcessCurrent({
+      dispatchId: attachment.dispatch_id,
+      paneKey: runtime.getTerminalPaneKey(observation.terminal.handle),
+      processIncarnation: runtime.getTerminalProcessIncarnation(observation.terminal.handle)
+    }) &&
+    !db.workerTerminalResourceHasIdentityConflict(resource.id)
+  )
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​423 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​423 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​40 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 |

<!-- /orca-pr-loc -->

## ELI5

A saved worker terminal address can expire while its process is still running. Federation now finds that same process on its recorded host, allowing read, stop, and release to reach it.

## What Changed

Recover the current handle from the exact process incarnation and durable worker-resource host scope, then recheck pane identity and ownership before closing. Preserve requested release when inventory is unavailable, and finish a lost close acknowledgment after restart only with host-certified exit and a previously committed output archive.

The shared runtime resolver, incarnation matcher, and their existing tests are adapted from the open PR #18790 (comments shortened). This is its missing federation counterpart; its local worker changes remain in that PR. Reconcile the shared prerequisite when merging either PR. No attachment schema migration is needed because current resources already persist host scope.

## Linked Issue

Covers the stale-handle federation mechanism in [STA-6751](https://linear.app/stably/issue/STA-6751), plus federation pending-close recovery. Does not claim the entire historical leak family fixed; local worker recovery remains #18790, compatible empty-daemon retirement remains #19403, and automation ownership is separate work. Legacy attachments lacking host-scoped ownership remain non-reapable.

## Visual Proof

N/A — runtime identity and retirement only, with no rendered UI change.

## Testing

All checks ran on macOS with `ORCA_BACKGROUND_LAUNCH=1`; no app window or existing user session was touched.

- 70 tests passed across six focused federation, local release-recovery, runtime handle, and incarnation-liveness files.
- New federation tests cover real runtime resolution with an in-memory DB, archive-before-close, changed incarnation during archive, user takeover, local/SSH/WSL host mismatch, failed kill and retry, and lost acknowledgment after a simulated runtime restart under each host verdict.
- Disabling federation recovery produces 7 failures among the 12 new tests; restoring it gives 12/12 passing.
- `pnpm tc:node`, changed-code quality, formatting, and `git diff --check` pass.

## Reliability and limitations

Invariant: `agent-session.provider-ownership` — a cleanup may act only on the recorded incarnation and host; unavailable inventory never establishes exit. The oracle checks which exact terminal is closed and whether durable intent/archive survives failure. Existing release-recovery tests provide the matching lower-layer regression coverage; dedicated registered reliability-gate and real reconnect/RSS/process-count validation remain gaps.

Local and simulated SSH/WSL scope isolation are covered. Real daemon, SSH, WSL, mobile, Linux and Windows execution are untested; no platform command, remote frame, or provider-specific branch was introduced. Folder workspaces are covered. Mixed-version peers use unchanged RPC shapes and optional host data stays fail-closed. The only recovery scan is linear over tracked PTYs after an unresolved handle; no polling or subprocess was added.

PTY close is spied in the federation tests, so these counts prove control-plane behavior, not OS memory reclamation. RSS and OS process counts were not measured, and registry settlement is not presented as a memory-leak fix. A missing archive stays pending even after exit.

## Review

Draft for review; not authorized to merge.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer material changed.
