### PR TITLE
fix(native-chat): admit persisted Claude queued prompts and notices

### DIFF
--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -7,6 +7,7 @@ import { selectActiveToolCall } from '../../../src/shared/native-chat-tool-activ
 import { isImageRefBlock, isTextBlock } from '../../../src/shared/native-chat-types'
 import type { NativeChatBlock, NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { MobileMarkdown } from '../components/MobileMarkdown'
+import { MobileNativeChatNoticeRow } from './MobileNativeChatNoticeRow'
 import { MobileNativeChatTurnStatus } from './MobileNativeChatTurnStatus'
 import { ToolRun } from './MobileNativeChatToolRun'
 import type { NativeChatTurnStatus } from './use-mobile-native-chat-turn-status'
@@ -190,6 +191,14 @@ function MobileNativeChatMessageImpl({
       }
     />
   ) : null
+
+  const notice =
+    message.role === 'system'
+      ? message.blocks.find((block) => isTextBlock(block) && block.tone !== undefined)
+      : undefined
+  if (notice && isTextBlock(notice)) {
+    return <MobileNativeChatNoticeRow block={notice} fontScale={fontScale} />
+  }
 
   return (
     <>

--- a/mobile/src/session/MobileNativeChatNoticeRow.test.tsx
+++ b/mobile/src/session/MobileNativeChatNoticeRow.test.tsx
@@ -1,0 +1,101 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { MobileNativeChatMessage } from './MobileNativeChatMessage'
+import { colors } from '../theme/mobile-theme'
+
+const mocks = vi.hoisted(() => ({
+  openURL: vi.fn(async () => {}),
+  copy: vi.fn()
+}))
+vi.mock('react-native', () => ({
+  Image: 'Image',
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
+  Text: 'Text',
+  View: 'View',
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Linking: { openURL: mocks.openURL }
+}))
+vi.mock('expo-clipboard', () => ({ setStringAsync: mocks.copy }))
+vi.mock('lucide-react-native', () => ({
+  ArrowUp: 'ArrowUp',
+  Copy: 'Copy',
+  AlertCircle: 'AlertCircle',
+  AlertTriangle: 'AlertTriangle',
+  Info: 'Info'
+}))
+vi.mock('../components/pr-sidebar/MermaidDiagram', () => ({
+  MermaidDiagram: 'MermaidDiagram'
+}))
+vi.mock('./MobileNativeChatToolRun', () => ({ ToolRun: 'ToolRun' }))
+vi.mock('./MobileNativeChatTurnStatus', () => ({
+  MobileNativeChatTurnStatus: 'MobileNativeChatTurnStatus'
+}))
+
+let renderer: ReactTestRenderer | null = null
+const text = 'Please run `/login`. Read [enrollment](https://example.test/enroll).'
+function render(role: NativeChatMessage['role'], tone?: 'notice' | 'warning' | 'error') {
+  const onOpenFile = vi.fn()
+  act(() => {
+    renderer = create(
+      createElement(MobileNativeChatMessage, {
+        message: {
+          id: 'record',
+          role,
+          timestamp: null,
+          source: 'transcript',
+          blocks: [{ type: 'text', text, ...(tone ? { tone } : {}) }]
+        },
+        fontScale: 1.2,
+        onOpenFile
+      })
+    )
+  })
+  return { root: renderer!.root, onOpenFile }
+}
+afterEach(() => {
+  act(() => renderer?.unmount())
+  renderer = null
+  vi.clearAllMocks()
+})
+
+describe('mobile system notice presentation', () => {
+  it.each([
+    ['notice', 'System notice', 'Info', colors.textMuted],
+    ['warning', 'System warning', 'AlertTriangle', colors.statusAmber],
+    ['error', 'System error', 'AlertCircle', colors.statusRed]
+  ] as const)('keeps %s severity distinct from assistant content', (tone, label, icon, color) => {
+    const { root } = render('system', tone)
+    expect(root.findByType(icon).props.color).toBe(color)
+    expect(root.findAllByType('Text').some((node) => node.props.children === label)).toBe(true)
+    expect(root.findAllByProps({ accessibilityLabel: 'Copy message' })).toHaveLength(0)
+    expect(
+      root.findAllByProps({
+        accessibilityLabel: 'Scroll this message to top'
+      })
+    ).toHaveLength(0)
+  })
+
+  it('uses markdown web links without turning slash commands into file actions', async () => {
+    const { root, onOpenFile } = render('system', 'notice')
+    const command = root.findAllByType('Text').find((node) => node.props.children === '/login')!
+    expect(command).toBeDefined()
+    expect(command.props.onPress).toBeUndefined()
+    const link = root.findAllByType('Text').find((node) => node.props.children === 'enrollment')!
+    await act(async () => link.props.onPress())
+    expect(mocks.openURL).toHaveBeenCalledWith('https://example.test/enroll')
+    expect(onOpenFile).not.toHaveBeenCalled()
+  })
+
+  it('preserves user bubbles and assistant controls without notice impersonation', () => {
+    const { root } = render('user')
+    expect(root.findAllByType('Text').some((node) => node.props.children === text)).toBe(true)
+    expect(root.findAllByType('Info')).toHaveLength(0)
+    act(() => renderer?.unmount())
+    const assistant = render('assistant', 'notice').root
+    expect(assistant.findAllByProps({ accessibilityLabel: 'Copy message' })).toHaveLength(1)
+    expect(assistant.findAllByType('Info')).toHaveLength(0)
+  })
+})

--- a/mobile/src/session/MobileNativeChatNoticeRow.tsx
+++ b/mobile/src/session/MobileNativeChatNoticeRow.tsx
@@ -1,0 +1,45 @@
+import { StyleSheet, Text, View } from 'react-native'
+import { AlertCircle, AlertTriangle, Info } from 'lucide-react-native'
+import type { NativeChatTextBlock } from '../../../src/shared/native-chat-types'
+import { MobileMarkdown } from '../components/MobileMarkdown'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+
+export function MobileNativeChatNoticeRow({
+  block,
+  fontScale
+}: {
+  block: NativeChatTextBlock
+  fontScale: number
+}): React.JSX.Element {
+  const error = block.tone === 'error'
+  const warning = block.tone === 'warning'
+  const Icon = error ? AlertCircle : warning ? AlertTriangle : Info
+  const color = error ? colors.statusRed : warning ? colors.statusAmber : colors.textMuted
+  const label = error ? 'System error' : warning ? 'System warning' : 'System notice'
+  return (
+    <View style={styles.notice}>
+      <View style={styles.heading}>
+        <Icon size={typography.bodySize} color={color} />
+        <Text style={[styles.label, { color, fontSize: typography.bodySize * fontScale }]}>
+          {label}
+        </Text>
+      </View>
+      <MobileMarkdown content={block.text} textScale={1.25 * fontScale} />
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  notice: {
+    marginHorizontal: spacing.lg,
+    marginVertical: spacing.sm,
+    padding: spacing.md,
+    gap: spacing.sm,
+    borderRadius: radii.row,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.borderSubtle,
+    backgroundColor: colors.bgPanel
+  },
+  heading: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm },
+  label: { fontWeight: '500' }
+})

--- a/mobile/src/session/use-mobile-native-chat-session.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.test.ts
@@ -158,6 +158,7 @@ describe('useMobileNativeChatSession', () => {
 
       expect(sendRequest).toHaveBeenCalledTimes(requestsAtCap + 1)
       expect(sendRequest).toHaveBeenLastCalledWith('nativeChat.readSession', {
+        capabilities: { systemNotices: true },
         agent: 'claude',
         sessionId: 'session',
         limit: 60,
@@ -237,6 +238,7 @@ describe('useMobileNativeChatSession', () => {
     expect(state?.hasMore).toBe(true)
     act(() => state?.loadEarlier())
     expect(sendRequest).toHaveBeenCalledWith('nativeChat.readSession', {
+      capabilities: { systemNotices: true },
       agent: 'claude',
       sessionId: 'session',
       limit: 100
@@ -297,6 +299,7 @@ describe('useMobileNativeChatSession', () => {
     act(() => state?.loadEarlier())
 
     expect(sendRequest).toHaveBeenCalledWith('nativeChat.readSession', {
+      capabilities: { systemNotices: true },
       agent: 'claude',
       sessionId: 'session',
       limit: 100
@@ -418,6 +421,7 @@ describe('useMobileNativeChatSession', () => {
     })
 
     expect(sendRequest).toHaveBeenLastCalledWith('nativeChat.readSession', {
+      capabilities: { systemNotices: true },
       agent: 'claude',
       sessionId: 'session',
       limit: 100
@@ -647,7 +651,7 @@ describe('useMobileNativeChatSession transcriptLoading', () => {
 
     expect(subscribe).toHaveBeenCalledWith(
       'nativeChat.subscribe',
-      expect.objectContaining({ capabilities: { transcriptPending: 1 } }),
+      expect.objectContaining({ capabilities: { transcriptPending: 1, systemNotices: true } }),
       expect.any(Function)
     )
     expect(renders.at(-1)).toMatchObject({

--- a/mobile/src/session/use-mobile-native-chat-session.ts
+++ b/mobile/src/session/use-mobile-native-chat-session.ts
@@ -154,7 +154,7 @@ export function useMobileNativeChatSession(args: {
         sessionId,
         limit: limitRef.current,
         subscriptionId: buildNativeChatSubscriptionId(agent, sessionId),
-        capabilities: { transcriptPending: 1 },
+        capabilities: { transcriptPending: 1, systemNotices: true },
         ...(transcriptPath ? { transcriptPath } : {})
       },
       (raw) => {
@@ -240,6 +240,7 @@ export function useMobileNativeChatSession(args: {
     void (async () => {
       try {
         const response = await client.sendRequest('nativeChat.readSession', {
+          capabilities: { systemNotices: true },
           agent,
           sessionId,
           limit: beforeOffset === null ? nextLimit : pageLimit,

--- a/src/main/native-chat/claude-transcript-record-admission.test.ts
+++ b/src/main/native-chat/claude-transcript-record-admission.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
+
+const decode = (record: unknown) => decodeClaudeTranscriptLine(JSON.stringify(record), 'fallback')
+const queued = (attachment: unknown) => ({ type: 'attachment', uuid: 'q1', attachment })
+
+describe('Claude semantic record admission', () => {
+  it('admits the persisted queued prompt with its provider identity and enqueue timestamp', () => {
+    expect(
+      decode({
+        ...queued({ type: 'queued_command', commandMode: 'prompt', prompt: 'check the config' }),
+        timestamp: '2026-06-01T10:00:02.000Z'
+      })
+    ).toEqual({
+      id: 'q1',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'check the config' }],
+      timestamp: Date.parse('2026-06-01T10:00:02.000Z'),
+      source: 'transcript'
+    })
+  })
+
+  it.each([
+    null,
+    {},
+    { type: 'queued_command', prompt: 'missing mode' },
+    { type: 'queued_command', commandMode: 'task-notification', prompt: '<task-notification />' },
+    { type: 'queued_command', commandMode: 'prompt', prompt: '  ' },
+    { type: 'queued_command', commandMode: 'prompt', prompt: { text: 'not a prompt' } },
+    { type: 'other', commandMode: 'prompt', prompt: 'other attachment' }
+  ])('does not impersonate a human for a non-prompt attachment: %j', (attachment) => {
+    expect(decode(queued(attachment))).toBeNull()
+  })
+
+  it('admits informational login copy as a notice, never assistant speech', () => {
+    const text =
+      'Remote Control disconnected — Please run `/login` in Claude Code to enroll this device.'
+    expect(
+      decode({ type: 'system', subtype: 'informational', uuid: 'notice', content: text })
+    ).toEqual({
+      id: 'notice',
+      role: 'system',
+      blocks: [{ type: 'text', text, tone: 'notice' }],
+      timestamp: null,
+      source: 'transcript'
+    })
+  })
+
+  it.each(['warning', 'error'])('preserves provider %s severity', (level) => {
+    expect(decode({ type: 'system', level, message: 'Check your account' })?.blocks).toEqual([
+      { type: 'text', text: 'Check your account', tone: level }
+    ])
+  })
+
+  it.each([
+    { content: [{ type: 'text', text: 'Future notice' }] },
+    { message: { content: [{ type: 'text', text: 'Future notice' }] } },
+    { message: { text: 'Future notice' } },
+    { text: 'Future notice' }
+  ])('keeps extractable copy on an unknown subtype: %j', (copy) => {
+    expect(decode({ type: 'system', subtype: 'future_notice', ...copy })?.blocks).toEqual([
+      { type: 'text', text: 'Future notice', tone: 'notice' }
+    ])
+  })
+
+  it.each([
+    'stop_hook_summary',
+    'turn_duration',
+    'away_summary',
+    'local_command',
+    'hook_callback',
+    'init',
+    'compact_boundary'
+  ])('keeps %s bookkeeping out of the conversation', (subtype) => {
+    expect(decode({ type: 'system', subtype, content: 'Bookkeeping copy' })).toBeNull()
+  })
+
+  it('never dumps unknown payloads or turns tool payloads into system prose', () => {
+    expect(
+      decode({ type: 'system', subtype: 'future', payload: { opaque: 'not display copy' } })
+    ).toBeNull()
+    expect(
+      decode({ type: 'system', content: [{ type: 'tool_result', content: 'not a notice' }] })
+    ).toBeNull()
+    expect(decode({ type: 'telemetry', message: 'not display copy' })).toBeNull()
+  })
+
+  it('preserves synthetic tool results and interruption ownership', () => {
+    expect(
+      decode({
+        type: 'user',
+        isSynthetic: true,
+        message: {
+          content: [
+            { type: 'text', text: 'Injected context' },
+            { type: 'tool_result', content: 'Actual output' }
+          ]
+        }
+      })
+    ).toMatchObject({ role: 'tool', blocks: [{ type: 'tool-result', output: 'Actual output' }] })
+    expect(
+      decode({ type: 'user', interruptedMessageId: 'a1', message: { content: 'boilerplate' } })
+    ).toMatchObject({
+      role: 'system',
+      blocks: [{ type: 'text', text: 'Conversation interrupted' }]
+    })
+  })
+})

--- a/src/main/native-chat/claude-transcript-record-admission.ts
+++ b/src/main/native-chat/claude-transcript-record-admission.ts
@@ -1,0 +1,63 @@
+import type { NativeChatTextBlock } from '../../shared/native-chat-types'
+import { asRecord, extractString } from '../ai-vault/session-scanner-values'
+import { readableProviderFrameText } from './agent-session-wire/unhandled-provider-frame'
+import { claudeContentBlocks } from './transcript-record-blocks'
+
+type ClaudeTranscriptRecordAdmission =
+  | { kind: 'message'; role: 'user' | 'assistant' }
+  | { kind: 'queued-prompt'; blocks: NativeChatTextBlock[] }
+  | { kind: 'notice'; blocks: NativeChatTextBlock[] }
+  | { kind: 'ignored' }
+
+// Persisted bookkeeping has different ownership from structured live frames.
+const BOOKKEEPING_SUBTYPES = new Set([
+  'stop_hook_summary',
+  'turn_duration',
+  'away_summary',
+  'local_command',
+  'hook_callback',
+  'init',
+  'compact_boundary'
+])
+
+function queuedPrompt(record: Record<string, unknown>): ClaudeTranscriptRecordAdmission {
+  const attachment = asRecord(record.attachment)
+  if (attachment?.type !== 'queued_command' || attachment.commandMode !== 'prompt') {
+    return { kind: 'ignored' }
+  }
+  const text = extractString(attachment.prompt)
+  return text ? { kind: 'queued-prompt', blocks: [{ type: 'text', text }] } : { kind: 'ignored' }
+}
+
+function systemNotice(record: Record<string, unknown>): ClaudeTranscriptRecordAdmission {
+  if (BOOKKEEPING_SUBTYPES.has(String(record.subtype))) {
+    return { kind: 'ignored' }
+  }
+  const content = record.content ?? asRecord(record.message)?.content
+  const text =
+    claudeContentBlocks(content)
+      .flatMap((block) => (block.type === 'text' ? [block.text] : []))
+      .join('\n') || readableProviderFrameText(record)
+  if (!text?.trim()) {
+    return { kind: 'ignored' }
+  }
+  const tone = record.level === 'error' || record.level === 'warning' ? record.level : 'notice'
+  return { kind: 'notice', blocks: [{ type: 'text', text, tone }] }
+}
+
+/** Admit provider records by meaning before mapping them into chat roles. */
+export function classifyClaudeTranscriptRecord(
+  record: Record<string, unknown>
+): ClaudeTranscriptRecordAdmission {
+  switch (record.type) {
+    case 'user':
+    case 'assistant':
+      return { kind: 'message', role: record.type }
+    case 'attachment':
+      return queuedPrompt(record)
+    case 'system':
+      return systemNotice(record)
+    default:
+      return { kind: 'ignored' }
+  }
+}

--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -14,6 +14,7 @@ import {
   timestampMs
 } from '../ai-vault/session-scanner-values'
 import { imageSourcePathFromText } from '../../shared/native-chat-image-transcript-markers'
+import { classifyClaudeTranscriptRecord } from './claude-transcript-record-admission'
 import { claudeContentBlocks } from './transcript-record-blocks'
 import { claudeInterruptedMessageId } from './transcript-turn-markers'
 
@@ -78,12 +79,22 @@ export function decodeClaudeTranscriptLine(
   if (!record) {
     return null
   }
-  const role = record.type
-  if (role !== 'user' && role !== 'assistant') {
+  const admission = classifyClaudeTranscriptRecord(record)
+  if (admission.kind === 'ignored') {
     return null
   }
   const timestamp = parseTimestamp(record.timestamp)
   const recordMessageId = extractString(record.uuid) ?? fallbackId
+  if (admission.kind !== 'message') {
+    return {
+      id: recordMessageId,
+      role: admission.kind === 'queued-prompt' ? 'user' : 'system',
+      blocks: admission.blocks,
+      timestamp,
+      source: 'transcript'
+    }
+  }
+  const role = admission.role
   if (claudeInterruptedMessageId(record)) {
     // Why: keep Claude's injected boilerplate out of the user-bubble path while
     // preserving the interruption as a quiet, replayable conversation status.

--- a/src/main/runtime/rpc/methods/native-chat-publication.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat-publication.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { SubscribeNativeChatTranscriptArgs } from '../../../native-chat/transcript-watch'
+import type { RpcContext } from '../core'
+import { decodeClaudeTranscriptLine } from '../../../native-chat/transcript-line-decoders-claude'
+
+const fixture = vi.hoisted(() => ({
+  messages: [] as NativeChatMessage[],
+  subscriptions: [] as SubscribeNativeChatTranscriptArgs[],
+  reads: [] as unknown[]
+}))
+vi.mock('../../../native-chat/transcript-watch', () => ({
+  readNativeChatTranscriptTail: async (args: unknown) => {
+    fixture.reads.push(args)
+    return { messages: fixture.messages, hasMore: true, beforeOffset: 123 }
+  },
+  subscribeNativeChatTranscript: async (args: SubscribeNativeChatTranscriptArgs) => {
+    fixture.subscriptions.push(args)
+    return { watching: true, unsubscribe: vi.fn() }
+  }
+}))
+import { NATIVE_CHAT_METHODS } from './native-chat'
+
+function method(name: string) {
+  const found = NATIVE_CHAT_METHODS.find((entry) => entry.name === name)
+  if (!found?.params) {
+    throw new Error(`Missing ${name}`)
+  }
+  return { ...found, params: found.params }
+}
+function context(clientKind: RpcContext['clientKind']): RpcContext {
+  return {
+    clientKind,
+    runtime: { registerSubscriptionCleanup: vi.fn() } as unknown as RpcContext['runtime']
+  }
+}
+const lifecycle = { state: 'completed', turnId: 'turn', timestamp: 123 } as const
+
+beforeEach(() => {
+  fixture.reads = []
+  fixture.subscriptions = []
+  fixture.messages = [
+    { type: 'user', uuid: 'user', message: { role: 'user', content: 'Prompt' } },
+    {
+      type: 'system',
+      uuid: 'notice',
+      subtype: 'informational',
+      content: 'Please run /login',
+      level: 'warning'
+    },
+    { type: 'assistant', uuid: 'assistant', message: { role: 'assistant', content: 'Reply' } }
+  ].map((record) => {
+    const message = decodeClaudeTranscriptLine(JSON.stringify(record), 'fallback')
+    if (!message) {
+      throw new Error('Fixture must be admitted by real decoder')
+    }
+    return message
+  })
+})
+
+describe.each(['mobile', 'runtime', undefined] as const)(
+  'notice publication to %s',
+  (clientKind) => {
+    it.each([undefined, false, true])(
+      'gates reads, paging and every stream route with capability %s',
+      async (systemNotices) => {
+        const params = {
+          agent: 'claude',
+          sessionId: 'synthetic',
+          limit: 40,
+          ...(systemNotices === undefined ? {} : { capabilities: { systemNotices } })
+        }
+        const expectedIds =
+          systemNotices === true ? ['user', 'notice', 'assistant'] : ['user', 'assistant']
+        const read = method('nativeChat.readSession')
+        for (const beforeOffset of [undefined, 456]) {
+          const result = (await read.handler(
+            read.params.parse({ ...params, beforeOffset }),
+            context(clientKind),
+            vi.fn()
+          )) as { messages: NativeChatMessage[]; hasMore: boolean; beforeOffset: number }
+          expect(result.messages.map((message) => message.id)).toEqual(expectedIds)
+          expect(result).toMatchObject({ hasMore: true, beforeOffset: 123 })
+        }
+        expect(fixture.reads[1]).toMatchObject({ beforeOffset: 456 })
+        const subscribe = method('nativeChat.subscribe')
+        const frames: unknown[] = []
+        // A reconnect creates a fresh subscription and must negotiate again.
+        for (let attempt = 0; attempt < 2; attempt++) {
+          await subscribe.handler(
+            subscribe.params.parse(params),
+            context(clientKind),
+            (frame: unknown) => frames.push(frame)
+          )
+          const callbacks = fixture.subscriptions.at(-1)!
+          callbacks.onInitialSnapshot?.(fixture.messages, true, 123, undefined, lifecycle)
+          callbacks.onReplace?.(fixture.messages, true, 123, lifecycle)
+          callbacks.onAppend(fixture.messages, lifecycle)
+        }
+        expect(frames).toHaveLength(6)
+        for (const frame of frames as { messages: NativeChatMessage[]; lifecycle: unknown }[]) {
+          expect(frame.messages.map((message) => message.id)).toEqual(expectedIds)
+          expect(frame.lifecycle).toEqual(lifecycle)
+          if (systemNotices) {
+            expect(frame.messages[1]).toMatchObject({
+              role: 'system',
+              blocks: [{ type: 'text', text: 'Please run /login', tone: 'warning' }]
+            })
+          }
+        }
+        expect(fixture.messages[1]).toMatchObject({ id: 'notice', role: 'system' })
+        expect(fixture.messages).toHaveLength(3)
+      }
+    )
+  }
+)
+
+it.each([1, 0, 'true', null, {}, []])('rejects malformed notice capability %j', (systemNotices) => {
+  for (const name of ['nativeChat.readSession', 'nativeChat.subscribe']) {
+    expect(
+      method(name).params.safeParse({
+        agent: 'claude',
+        sessionId: 's',
+        capabilities: { systemNotices }
+      }).success
+    ).toBe(false)
+  }
+})
+
+it('keeps the preexisting untoned interruption projection for legacy clients', async () => {
+  fixture.messages = [
+    {
+      id: 'interrupt',
+      role: 'system',
+      timestamp: null,
+      source: 'transcript',
+      blocks: [{ type: 'text', text: 'Interrupted' }]
+    }
+  ]
+  const read = method('nativeChat.readSession')
+  const result = await read.handler(
+    read.params.parse({ agent: 'claude', sessionId: 's' }),
+    context('mobile'),
+    vi.fn()
+  )
+  expect(result).toMatchObject({ messages: fixture.messages })
+})
+
+it('keeps the cursor and hasMore on a legacy page containing only withheld notices', async () => {
+  fixture.messages = [fixture.messages[1]]
+  const read = method('nativeChat.readSession')
+  const result = await read.handler(
+    read.params.parse({ agent: 'claude', sessionId: 's', beforeOffset: 456 }),
+    context('mobile'),
+    vi.fn()
+  )
+  expect(result).toMatchObject({ messages: [], hasMore: true, beforeOffset: 123 })
+  expect(fixture.messages).toHaveLength(1)
+})

--- a/src/main/runtime/rpc/methods/native-chat.ts
+++ b/src/main/runtime/rpc/methods/native-chat.ts
@@ -47,7 +47,12 @@ const NativeChatSession = z.object({
   // A pending snapshot is not authoritative transcript history. Only clients
   // that advertise this semantic may receive one; legacy clients treat it as a
   // settled empty read and can overwrite retention / unblock launch drafts.
-  capabilities: z.object({ transcriptPending: z.literal(1).optional() }).optional(),
+  capabilities: z
+    .object({
+      transcriptPending: z.literal(1).optional(),
+      systemNotices: z.boolean().optional()
+    })
+    .optional(),
   beforeOffset: z.number().int().nonnegative().optional()
 })
 
@@ -75,11 +80,28 @@ function sanitizeMessage(
   }
 }
 
+// Legacy peers render toned system text as agent prose; retain it only in host evidence.
+function publishableMessages(
+  messages: readonly NativeChatMessage[],
+  systemNotices: boolean
+): readonly NativeChatMessage[] {
+  return systemNotices
+    ? messages
+    : messages.filter(
+        (message) =>
+          message.role !== 'system' ||
+          !message.blocks.some((block) => block.type === 'text' && block.tone !== undefined)
+      )
+}
+
 function sanitizeAppendForClient(
   messages: readonly NativeChatMessage[],
-  clientKind: RpcContext['clientKind']
+  clientKind: RpcContext['clientKind'],
+  systemNotices: boolean
 ): NativeChatMessage[] {
-  return messages.map((message) => sanitizeMessage(message, clientKind))
+  return publishableMessages(messages, systemNotices).map((message) =>
+    sanitizeMessage(message, clientKind)
+  )
 }
 
 /** Window a transcript to its most recent `limit` messages so a long session
@@ -100,10 +122,11 @@ function windowTranscript(
 function windowForClient(
   messages: readonly NativeChatMessage[],
   clientKind: RpcContext['clientKind'],
-  limit = MOBILE_NATIVE_CHAT_DEFAULT_WINDOW
+  limit = MOBILE_NATIVE_CHAT_DEFAULT_WINDOW,
+  systemNotices = false
 ): NativeChatMessage[] {
   const windowed = windowTranscript(messages, limit)
-  return windowed.map((message) => sanitizeMessage(message, clientKind))
+  return sanitizeAppendForClient(windowed, clientKind, systemNotices)
 }
 
 export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
@@ -124,7 +147,12 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
       )
       return 'messages' in result
         ? {
-            messages: windowForClient(result.messages, clientKind, limit),
+            messages: windowForClient(
+              result.messages,
+              clientKind,
+              limit,
+              params.capabilities?.systemNotices === true
+            ),
             hasMore: result.hasMore,
             beforeOffset: result.beforeOffset,
             ...(result.lifecycle ? { lifecycle: result.lifecycle } : {})
@@ -187,7 +215,12 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
           // instead of stranding the view at 'loading' when the read keeps throwing.
           emit({
             type: 'snapshot',
-            messages: windowForClient(messages, clientKind, limit),
+            messages: windowForClient(
+              messages,
+              clientKind,
+              limit,
+              params.capabilities?.systemNotices === true
+            ),
             hasMore,
             beforeOffset,
             ...(error ? { error } : {}),
@@ -209,7 +242,12 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
           }
           emit({
             type: 'replacement',
-            messages: windowForClient(messages, clientKind, limit),
+            messages: windowForClient(
+              messages,
+              clientKind,
+              limit,
+              params.capabilities?.systemNotices === true
+            ),
             hasMore,
             beforeOffset,
             ...(lifecycle ? { lifecycle } : {})
@@ -221,7 +259,11 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
           }
           emit({
             type: 'appended',
-            messages: sanitizeAppendForClient(messages, clientKind),
+            messages: sanitizeAppendForClient(
+              messages,
+              clientKind,
+              params.capabilities?.systemNotices === true
+            ),
             ...(lifecycle ? { lifecycle } : {})
           })
         }

--- a/src/renderer/src/components/native-chat/NativeChatNoticeRow.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatNoticeRow.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 import '@testing-library/jest-dom/vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AgentJournalItemBodySchema } from '../../../../shared/agent-session-journal-schemas'
 import { projectStructuredItemsToNativeChat } from '../../../../shared/structured-agent-session-projection'
 import type { AgentJournalStatusItem } from '../../../../shared/agent-session-journal-types'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { MessageRow } from './NativeChatMessageRow'
 
 afterEach(cleanup)
@@ -19,8 +20,45 @@ function renderStatus(body: AgentJournalStatusItem) {
 }
 
 describe('notice rows', () => {
+  it('renders a legacy notice with safe links and no assistant bubble', () => {
+    const message: NativeChatMessage = {
+      id: 'notice',
+      role: 'system',
+      source: 'transcript',
+      timestamp: null,
+      blocks: [
+        {
+          type: 'text',
+          tone: 'notice',
+          text: 'Please run `/login`. Read [enrollment](https://example.test/enroll). <script>bad()</script>'
+        }
+      ]
+    }
+    const onLinkClick = vi.fn((event: React.MouseEvent<HTMLElement>) => event.preventDefault())
+    const { container } = render(
+      <MessageRow
+        message={message}
+        expandSignal={false}
+        onScrollMessageToTop={vi.fn()}
+        onLinkClick={onLinkClick}
+      />
+    )
+    expect(screen.getByText('/login').tagName).toBe('CODE')
+    expect(screen.getByText('/login').closest('a')).toBeNull()
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('.bg-muted\\/20')).not.toBeNull()
+    const link = screen.getByRole('link', { name: 'enrollment' })
+    fireEvent.click(link)
+    expect(onLinkClick).toHaveBeenCalledWith(expect.anything(), 'https://example.test/enroll')
+    expect(container.querySelector('.rounded-tr-sm')).toBeNull()
+  })
+
   it('renders compaction as a centered separator', () => {
-    renderStatus({ kind: 'status', text: 'Context compacted', presentation: 'compaction' })
+    renderStatus({
+      kind: 'status',
+      text: 'Context compacted',
+      presentation: 'compaction'
+    })
     expect(screen.getByRole('separator', { name: 'Context compacted' })).toHaveClass(
       'text-muted-foreground'
     )
@@ -34,7 +72,7 @@ describe('notice rows', () => {
     ['notice', 'text-muted-foreground']
   ])('renders %s using its existing color treatment', (tone, className) => {
     renderStatus({ kind: 'status', text: 'Readable notice', tone })
-    expect(screen.getByText('Readable notice').parentElement?.parentElement).toHaveClass(className)
+    expect(screen.getByText('Readable notice').closest('.space-y-2')).toHaveClass(className)
   })
   it('renders a plan as readable markdown in the card primitive', () => {
     renderStatus({
@@ -78,7 +116,7 @@ describe('notice rows', () => {
       tone: 'future-tone',
       presentation: 'future-presentation'
     })
-    expect(screen.getByText('Future readable text').parentElement?.parentElement).toHaveClass(
+    expect(screen.getByText('Future readable text').closest('.space-y-2')).toHaveClass(
       'text-foreground'
     )
     expect(screen.getByText('Future readable text').parentElement?.querySelector('svg')).toBeNull()
@@ -100,7 +138,11 @@ describe('old-reader compatibility', () => {
     { tone: 'notice' },
     { tone: 'future-tone', presentation: 'future-presentation' }
   ])('accepts new metadata and still renders text with an old reader: %j', (metadata) => {
-    const body = { kind: 'status', text: 'Text survives version skew', ...metadata }
+    const body = {
+      kind: 'status',
+      text: 'Text survives version skew',
+      ...metadata
+    }
     expect(AgentJournalItemBodySchema.safeParse(body).success).toBe(true)
     const oldBody = oldStatusSchema.parse(body) as AgentJournalStatusItem
     expect(oldBody).toEqual({ kind: 'status', text: body.text })

--- a/src/renderer/src/components/native-chat/NativeChatNoticeRow.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatNoticeRow.tsx
@@ -73,7 +73,14 @@ export function NativeChatNoticeRow({
     >
       <div className="flex items-start gap-2">
         {Icon ? <Icon aria-hidden="true" className="mt-0.5 size-4 shrink-0" /> : null}
-        <p className="min-w-0 whitespace-pre-wrap break-words">{block.text}</p>
+        <div className="min-w-0 break-words">
+          <CommentMarkdown
+            content={block.text}
+            className="text-sm"
+            onLinkClick={onLinkClick}
+            allowFileUriLinks={allowFileUriLinks}
+          />
+        </div>
       </div>
       {block.providerFrame ? (
         <ProviderFrameRow

--- a/src/renderer/src/components/native-chat/native-chat-session-transport.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-transport.test.ts
@@ -76,7 +76,13 @@ describe('getNativeChatSessionTransport — selection', () => {
     expect(runtimeEnvironmentsCall).toHaveBeenCalledWith({
       selector: ENV,
       method: 'nativeChat.readSession',
-      params: { agent: 'claude', sessionId: 'sess-1', limit: 40, transcriptPath: '/t/path' },
+      params: {
+        agent: 'claude',
+        sessionId: 'sess-1',
+        limit: 40,
+        transcriptPath: '/t/path',
+        capabilities: { systemNotices: true }
+      },
       timeoutMs: 15_000
     })
     expect(nativeChatReadSession).not.toHaveBeenCalled()
@@ -183,7 +189,9 @@ describe('runtime subscribe', () => {
 
     expect(runtimeEnvironmentsSubscribe).toHaveBeenCalledWith(
       expect.objectContaining({
-        params: expect.objectContaining({ capabilities: { transcriptPending: 1 } })
+        params: expect.objectContaining({
+          capabilities: { transcriptPending: 1, systemNotices: true }
+        })
       }),
       expect.any(Object)
     )
@@ -386,6 +394,9 @@ describe('runtime subscribe', () => {
       drop() // runtime restart / socket dropped mid-stream
       await vi.advanceTimersByTimeAsync(RUNTIME_NATIVE_CHAT_RECONNECT_MS)
       expect(subscribeCount()).toBe(2)
+      for (const [request] of runtimeEnvironmentsSubscribe.mock.calls) {
+        expect(request).toMatchObject({ params: { capabilities: { systemNotices: true } } })
+      }
 
       stop()
       drop() // a late close after teardown must not reconnect

--- a/src/renderer/src/components/native-chat/native-chat-session-transport.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-transport.ts
@@ -57,7 +57,7 @@ function createRuntimeNativeChatTransport(environmentId: string): NativeChatSess
         const result = await callRuntimeRpc<unknown>(
           target,
           'nativeChat.readSession',
-          { agent, sessionId, limit, transcriptPath },
+          { agent, sessionId, limit, transcriptPath, capabilities: { systemNotices: true } },
           { timeoutMs: 15_000 }
         )
         return parseRuntimeNativeChatReadSessionResult(result)
@@ -111,7 +111,7 @@ function createRuntimeNativeChatTransport(environmentId: string): NativeChatSess
                 sessionId,
                 transcriptPath,
                 limit,
-                capabilities: { transcriptPending: 1 }
+                capabilities: { transcriptPending: 1, systemNotices: true }
               },
               timeoutMs: 15_000
             },

--- a/src/renderer/src/web/preload-api/web-native-chat-api.ts
+++ b/src/renderer/src/web/preload-api/web-native-chat-api.ts
@@ -16,7 +16,8 @@ export function createWebNativeChatApi(): NativeChatApi {
           agent,
           sessionId,
           limit,
-          transcriptPath
+          transcriptPath,
+          capabilities: { systemNotices: true }
         })
       ),
     subscribe: (args, onFrame) => {
@@ -46,7 +47,7 @@ export function createWebNativeChatApi(): NativeChatApi {
             subscriptionId: args.subscriptionId,
             transcriptPath: args.transcriptPath,
             limit: args.limit,
-            capabilities: { transcriptPending: 1 }
+            capabilities: { transcriptPending: 1, systemNotices: true }
           },
           {
             onResponse: (response) => {

--- a/src/renderer/src/web/web-preload-api-agent-providers.test.ts
+++ b/src/renderer/src/web/web-preload-api-agent-providers.test.ts
@@ -27,7 +27,9 @@ describe('web native chat preload API', () => {
     }
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {
-        call(): Promise<RuntimeRpcResponse<unknown>> {
+        call(method: string, params: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          expect(method).toBe('nativeChat.readSession')
+          expect(params).toMatchObject({ capabilities: { systemNotices: true } })
           return Promise.resolve({
             id: 'read-1',
             ok: true,
@@ -130,7 +132,9 @@ describe('web native chat preload API', () => {
     )
     await Promise.resolve()
 
-    expect(subscribeParams).toMatchObject({ capabilities: { transcriptPending: 1 } })
+    expect(subscribeParams).toMatchObject({
+      capabilities: { transcriptPending: 1, systemNotices: true }
+    })
 
     // The host's unflushed-transcript frame, then the flush that follows it.
     deliver({ type: 'snapshot', messages: [], hasMore: false, pending: true })

--- a/tests/e2e/claude-transcript-record-replay.unit.test.ts
+++ b/tests/e2e/claude-transcript-record-replay.unit.test.ts
@@ -1,0 +1,107 @@
+import { appendFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Readable } from 'node:stream'
+import { afterEach, describe, expect, it } from 'vitest'
+import { mergeNativeChatMessages } from '../../src/shared/native-chat-merge'
+import {
+  pendingSendsAsMessages,
+  prunePendingSends
+} from '../../src/renderer/src/components/native-chat/native-chat-pending'
+import { orderNativeChatMessages } from '../../src/renderer/src/components/native-chat/native-chat-message-grouping'
+import { decodeClaudeTranscriptLine } from '../../src/main/native-chat/transcript-line-decoders-claude'
+import { readNativeChatTranscript } from '../../src/main/native-chat/transcript-reader'
+import { readNativeChatTranscriptTailFile } from '../../src/main/native-chat/transcript-tail-reader'
+import { decodeTranscriptStream } from '../../src/main/native-chat/transcript-stream-lines'
+
+const lines = [
+  '{"type":"user","uuid":"u1","timestamp":"2026-06-01T10:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"start the long running task"}]}}',
+  '{"type":"assistant","uuid":"a1","timestamp":"2026-06-01T10:00:03.000Z","message":{"content":[{"type":"text","text":"working through the first task now"}]}}',
+  '{"type":"attachment","uuid":"q1","timestamp":"2026-06-01T10:00:02.000Z","attachment":{"type":"queued_command","prompt":"and check the config while you are at it","commandMode":"prompt"}}',
+  '{"type":"assistant","uuid":"a2","timestamp":"2026-06-01T10:00:06.000Z","message":{"content":[{"type":"text","text":"both done"}]}}'
+]
+let root: string
+
+afterEach(async () => {
+  if (root) {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+describe('Claude admitted record replay', () => {
+  it.each(['\n', '\r\n'])(
+    'agrees across full, bounded, append and reconnect reads with %j lines',
+    async (newline) => {
+      root = await mkdtemp(join(tmpdir(), 'orca-claude-admission-'))
+      const filePath = join(root, 'session.jsonl')
+      const initial = lines.slice(0, 2).join(newline) + newline
+      await writeFile(filePath, initial)
+      const base = await readNativeChatTranscriptTailFile(filePath, 10, decodeClaudeTranscriptLine)
+      const appended = lines.slice(2).join(newline) + newline
+      await appendFile(filePath, appended)
+      const incremental = await decodeTranscriptStream(
+        Readable.from([Buffer.from(appended)]),
+        filePath,
+        Buffer.byteLength(initial),
+        decodeClaudeTranscriptLine,
+        false
+      )
+      const merged = mergeNativeChatMessages(base.messages, incremental.messages)
+      const full = await readNativeChatTranscript('claude', 'synthetic', {
+        filePath
+      })
+      expect(full).toEqual({ messages: merged })
+      expect(merged.map((message) => message.id)).toEqual(['u1', 'a1', 'q1', 'a2'])
+      expect(merged[2]?.timestamp).toBe(Date.parse('2026-06-01T10:00:02.000Z'))
+      const tail = await readNativeChatTranscriptTailFile(filePath, 2, decodeClaudeTranscriptLine)
+      expect(tail.messages.map((message) => message.id)).toEqual(['q1', 'a2'])
+      const earlier = await readNativeChatTranscriptTailFile(
+        filePath,
+        2,
+        decodeClaudeTranscriptLine,
+        false,
+        tail.beforeOffset
+      )
+      expect(mergeNativeChatMessages(earlier.messages, tail.messages)).toEqual(merged)
+      expect(mergeNativeChatMessages(merged, tail.messages)).toEqual(merged)
+      const pending = [
+        {
+          id: 'pending-q1',
+          text: 'and check the config while you are at it',
+          sentAt: Date.parse('2026-06-01T10:00:02.000Z'),
+          afterMessageId: 'u1'
+        }
+      ]
+      expect(pendingSendsAsMessages(pending, base.messages)).toHaveLength(1)
+      expect(pendingSendsAsMessages(pending, merged)).toEqual([])
+      expect(prunePendingSends(pending, merged)).toEqual([])
+      // Timestamp ordering is independently owned downstream and remains out of scope.
+      expect(orderNativeChatMessages(merged).map((message) => message.id)).toEqual([
+        'u1',
+        'q1',
+        'a1',
+        'a2'
+      ])
+    }
+  )
+
+  it('keeps fallback notice IDs stable between tail and full readers', async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-claude-notice-'))
+    const filePath = join(root, 'session.jsonl')
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        type: 'system',
+        subtype: 'future_notice',
+        content: 'Please run /login'
+      })}\n`
+    )
+    const full = await readNativeChatTranscript('claude', 'synthetic', {
+      filePath
+    })
+    const tail = await readNativeChatTranscriptTailFile(filePath, 1, decodeClaudeTranscriptLine)
+    expect(tail.messages).toHaveLength(1)
+    expect(full).toEqual({ messages: tail.messages })
+    expect(mergeNativeChatMessages(tail.messages, tail.messages)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## ELI5

Claude can persist queued prompts and login notices outside ordinary user/assistant records. Native Chat discarded those records before examining their content. The shared decoder now admits real queued prompts and readable system notices, and the host publishes notices only to paired clients that can distinguish them from agent speech.

## What changed and why

A Claude-specific semantic classifier admits ordinary messages, queued prompts and readable notices while excluding known bookkeeping and task-notification attachments. Full and bounded/live-tail readers share that owner. Existing UUIDs, timestamps, tool results, image companions, injected-context filtering and interruption handling retain their owners. Desktop notices reuse the existing system notice row and safe Markdown handling; mobile maps already-classified notices into labeled rows with no agent copy controls.

The runtime RPC publication boundary requires `capabilities.systemNotices: true` on reads and subscriptions before publishing toned system messages. Absent or false retains legacy omission; malformed values fail validation. Desktop runtime, web and mobile advertise support for reads, paging and subscriptions/reconnect. Initial snapshots, replacements and appends use the same host projection, preserving underlying record evidence, lifecycle and paging cursors. Same-build local Electron IPC keeps notices.

This addresses content-publication skew under remote-wire Rule 3. Released v1.4.197 mobile otherwise treats non-user notices as agent prose. Old clients do **not** receive this notice fix until upgraded; new clients on old hosts still cannot recover records those hosts discard. There is no new opcode, and old hosts ignore the optional capability.

## Scope

- [STA-4146](https://linear.app/stably/issue/STA-4146): queued-record omission subset only; timestamp-based display ordering remains unchanged.
- [STA-4777](https://linear.app/stably/issue/STA-4777): persisted system-notice omission.

Full causal ordering, structured live paths and Codex output_text normalization remain excluded. Neither ticket is claimed complete.

## Validation at cf4f3a4738bbee4955c69b981907b78c75fc7dd5

- Seven focused root Vitest suites: **112 passed, 0 failed**. Four mobile suites: **55 passed, 0 failed**. Both used `config/vitest.config.ts` (mobile with an absolute config path and mobile root).
- Publication tests cover capability absent/false/true for mobile/runtime/unspecified client kinds, malformed values, reads, paging, initial/replacement/append, reconnect, preserved evidence/lifecycle/cursors, and legacy interruption behavior. Client tests check read/subscription/paging/retry advertisement.
- After committing, removing publication gating caused **7 failures**; cp backup/restore, byte comparison and cmp restored the source, and all **17 publication tests** passed again. Earlier admission and presentation ablations remain documented in author evidence.
- Sequential `npx tsc --noEmit` projects node, tc.web and tc.cli all passed. Commit hooks passed oxlint, React Doctor and formatting.
- Extracted v1.4.197/current host RPC, decoder and mobile message modules passed four pairings and **28 read/stream component observations**. Current/current labels the warning with zero agent copy controls; current/released withholds it without deleting host evidence; released/current retains the old omission. Readers/watchers/native primitives were synthetic and transitive imports came from this checkout: this is **not a live paired-runtime test**.
- Hidden Electron CDP used fresh matched synthetic HOME/data and verified exact checkout identity. The real **Show chat view** toggle displayed the queued prompt once, both replies, bordered notice rows, `/login` as code and enrollment as a link, without telemetry/task XML. Appending a new JSONL notice displayed a distinct warning row. Full-window screenshots are retained in local QA evidence; no public image upload.

Initial failed attempts were corrected and retained: one outdated RPC-argument test expectation, a mobile config path error and incorrect component filename filters, three new-test curly-brace lint errors, and released-module probe setup errors. The first hidden launch exceeded macOS's Unix-socket path limit; a shorter fresh synthetic path resolved it. Both launches were cleaned up through recorded, command-verified process groups.

## Review and remaining gaps

Draft. **Independent architectural re-review pending at cf4f3a4738bbee4955c69b981907b78c75fc7dd5**; the previous P2 publication finding has an implementation fix and author validation, not independent clearance.

Rendered mobile QA is blocked: no task-owned Orca emulator is running. Full live released/current pairing, physical Windows/Linux/WSL/SSH, real provider incident reproduction and external link navigation remain unverified. No merge-readiness or ticket-closure claim.

Author: @BrennanKB5. No upstream skill-installer content copied.
