### PR TITLE
fix(runtime): hydrate persisted terminals behind a chat-only mobile snapshot

### DIFF
--- a/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
+++ b/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
@@ -12,6 +12,7 @@ import type {
   RuntimeMobileSessionTerminalTab
 } from '../../shared/runtime-types'
 import {
+  buildHeadlessMobileSessionTabGroups,
   collectHeadlessParentTabOrder,
   distributeHeadlessTabsAcrossGroups,
   getHeadlessMobileSessionGroupId,
@@ -97,9 +98,10 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
         }
       }
       const existing = this.mobileSessionTabsByWorktree.get(entryWorktreeId)
+      const hasExistingTerminals = existing?.tabs.some((tab) => tab.type === 'terminal')
       if (
         existing &&
-        existing.tabs.length > 0 &&
+        hasExistingTerminals &&
         options.force !== true &&
         options.onlyRuntimeOwnedTerminals !== true
       ) {
@@ -111,6 +113,11 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
         reconciledWorktreeIds.add(entryWorktreeId)
         continue
       }
+      const preserveNonTerminalSnapshot =
+        existing?.tabs.length > 0 &&
+        !hasExistingTerminals &&
+        options.force !== true &&
+        options.onlyRuntimeOwnedTerminals !== true
       const terminalTabs = buildHeadlessMobileSessionTerminalTabs(
         entryWorktreeId,
         persistedTabs,
@@ -136,7 +143,7 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
       ]
       const groupId = getHeadlessMobileSessionGroupId(entryWorktreeId)
       const mergedTabs =
-        options.onlyRuntimeOwnedTerminals === true && existing
+        (options.onlyRuntimeOwnedTerminals === true || preserveNonTerminalSnapshot) && existing
           ? mergeMobileSessionSnapshotTabs(existing.tabs, tabs)
           : tabs
       const mergedActiveTab =
@@ -156,6 +163,7 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
       const persistedGroups = session.tabGroups?.[entryWorktreeId]
       const persistedLayout = session.tabGroupLayouts?.[entryWorktreeId]
       const hasPersistedSplit =
+        (!preserveNonTerminalSnapshot || !existing?.tabGroups) &&
         options.onlyRuntimeOwnedTerminals !== true &&
         persistedGroups !== undefined &&
         persistedGroups.length > 1
@@ -164,43 +172,50 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
           ? mergedActiveTab.parentTabId
           : mergedActiveTab.id
         : null
-      const nextTabGroups: RuntimeMobileSessionTabGroup[] = hasPersistedSplit
-        ? appendBrowserTabOrder(
-            distributeHeadlessTabsAcrossGroups(
-              persistedGroups.map((group) => ({
-                id: group.id,
-                activeTabId: group.activeTabId,
-                tabOrder: [...group.tabOrder],
-                ...(group.recentTabIds ? { recentTabIds: [...group.recentTabIds] } : {})
-              })),
-              collectHeadlessParentTabOrder(mergedTerminalTabs),
-              activeTopLevelId
-            ),
-            mergedBrowserOrder,
-            undefined,
-            // Why: distribute drops browser ids (terminal-only), so carry each
-            // browser's persisted group forward instead of coalescing left.
-            collectBrowserGroupAssignment(persistedGroups, mergedBrowserOrder)
+      const nextTabGroups: RuntimeMobileSessionTabGroup[] = preserveNonTerminalSnapshot
+        ? buildHeadlessMobileSessionTabGroups(
+            entryWorktreeId,
+            mergedTabs,
+            mergedActiveTab,
+            existing.tabGroups ?? persistedGroups
           )
-        : options.onlyRuntimeOwnedTerminals === true && existing?.tabGroups
+        : hasPersistedSplit
           ? appendBrowserTabOrder(
-              mergeMobileSessionTabGroups(
-                entryWorktreeId,
-                existing.tabGroups,
-                mergedTerminalTabs,
-                mergedActiveTab?.type === 'terminal' ? mergedActiveTab : null
+              distributeHeadlessTabsAcrossGroups(
+                persistedGroups.map((group) => ({
+                  id: group.id,
+                  activeTabId: group.activeTabId,
+                  tabOrder: [...group.tabOrder],
+                  ...(group.recentTabIds ? { recentTabIds: [...group.recentTabIds] } : {})
+                })),
+                collectHeadlessParentTabOrder(mergedTerminalTabs),
+                activeTopLevelId
               ),
-              mergedBrowserOrder
+              mergedBrowserOrder,
+              undefined,
+              // Why: distribute drops browser ids (terminal-only), so carry each
+              // browser's persisted group forward instead of coalescing left.
+              collectBrowserGroupAssignment(persistedGroups, mergedBrowserOrder)
             )
-          : [
-              {
-                id: groupId,
-                activeTabId: mergedActiveTab?.id
-                  ? (activeTab?.parentTabId ?? mergedActiveTab.id)
-                  : (tabOrder[0] ?? null),
-                tabOrder
-              }
-            ]
+          : options.onlyRuntimeOwnedTerminals === true && existing?.tabGroups
+            ? appendBrowserTabOrder(
+                mergeMobileSessionTabGroups(
+                  entryWorktreeId,
+                  existing.tabGroups,
+                  mergedTerminalTabs,
+                  mergedActiveTab?.type === 'terminal' ? mergedActiveTab : null
+                ),
+                mergedBrowserOrder
+              )
+            : [
+                {
+                  id: groupId,
+                  activeTabId: mergedActiveTab?.id
+                    ? (activeTab?.parentTabId ?? mergedActiveTab.id)
+                    : (tabOrder[0] ?? null),
+                  tabOrder
+                }
+              ]
       // Why: merging runtime tabs INTO a renderer publication must not reclass
       // the snapshot as headless-built — the preservation predicate would then
       // treat the renderer's own tabs as runtime-owned and resurrect tabs the
@@ -222,11 +237,13 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
         tabGroups: nextTabGroups,
         // Why: the runtime-owned rebuild runs on every graph sync — carry the
         // existing split layout forward or each sync drops it and fans out.
-        ...(hasPersistedSplit && persistedLayout
-          ? { tabGroupLayout: persistedLayout }
-          : options.onlyRuntimeOwnedTerminals === true && existing?.tabGroupLayout
-            ? { tabGroupLayout: existing.tabGroupLayout }
-            : {}),
+        ...(preserveNonTerminalSnapshot && existing?.tabGroupLayout
+          ? { tabGroupLayout: existing.tabGroupLayout }
+          : hasPersistedSplit && persistedLayout
+            ? { tabGroupLayout: persistedLayout }
+            : options.onlyRuntimeOwnedTerminals === true && existing?.tabGroupLayout
+              ? { tabGroupLayout: existing.tabGroupLayout }
+              : {}),
         tabs: mergedTabs
       }
       // Why: the runtime-owned hydrate runs on EVERY graph sync; when the rebuilt

--- a/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
+++ b/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
@@ -164,8 +164,11 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
         (options.onlyRuntimeOwnedTerminals === true || preserveNonTerminalSnapshot) && existing
           ? mergeMobileSessionSnapshotTabs(existingMergeBaseTabs, tabs)
           : tabs
+      // Why: resolve against the MERGED tabs, not the merge base — the base
+      // drops every existing browser and the live ones return through `tabs`,
+      // so searching the base moves an active live browser onto a terminal.
       const mergedActiveTab =
-        existingMergeBaseTabs?.find((tab) => tab.id === existing?.activeTabId) ??
+        mergedTabs.find((tab) => tab.id === existing?.activeTabId) ??
         activeTab ??
         mergedTabs[0] ??
         null

--- a/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
+++ b/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
 import { OrcaRuntimeWithWaitForSessionTabsInventoryPublication } from './orca-runtime-wait-for-session-tabs-inventory-publication'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import type { TabGroup } from '../../shared/tab-types'
 import { getRuntimeBrowserPageRegistry } from './runtime-browser-page-registry'
 import { splitWorktreeIdForFilesystem } from '../../shared/worktree/id'
 import { buildHeadlessMobileSessionTerminalTabs } from './mobile-session-terminal-projection'
@@ -27,6 +28,17 @@ import {
   collectBrowserGroupAssignment
 } from './mobile-session-browser-group-projection'
 import { headlessMobileSnapshotContentUnchanged } from './mobile-session-snapshot-equality'
+
+// Why: a persisted TabGroup carries `worktreeId`, which the published group
+// shape does not — spreading one onto the wire leaks it to every client.
+function toRuntimeMobileSessionTabGroup(group: TabGroup): RuntimeMobileSessionTabGroup {
+  return {
+    id: group.id,
+    activeTabId: group.activeTabId,
+    tabOrder: [...group.tabOrder],
+    ...(group.recentTabIds ? { recentTabIds: [...group.recentTabIds] } : {})
+  }
+}
 
 export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession extends OrcaRuntimeWithWaitForSessionTabsInventoryPublication {
   protected hydrateHeadlessMobileSessionTabsFromWorkspaceSession(
@@ -142,12 +154,18 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
         ...browserTabs.map((tab) => tab.id)
       ]
       const groupId = getHeadlessMobileSessionGroupId(entryWorktreeId)
+      // Why: `tabs` already carries every live browser, so merging the existing
+      // browser entries back in resurrects a page that closed while the
+      // snapshot was chat-only (the skip branch's reconcile used to prune it).
+      const existingMergeBaseTabs = preserveNonTerminalSnapshot
+        ? existing.tabs.filter((tab) => tab.type !== 'browser')
+        : existing?.tabs
       const mergedTabs =
         (options.onlyRuntimeOwnedTerminals === true || preserveNonTerminalSnapshot) && existing
-          ? mergeMobileSessionSnapshotTabs(existing.tabs, tabs)
+          ? mergeMobileSessionSnapshotTabs(existingMergeBaseTabs, tabs)
           : tabs
       const mergedActiveTab =
-        existing?.tabs.find((tab) => tab.id === existing.activeTabId) ??
+        existingMergeBaseTabs?.find((tab) => tab.id === existing?.activeTabId) ??
         activeTab ??
         mergedTabs[0] ??
         null
@@ -177,17 +195,12 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
             entryWorktreeId,
             mergedTabs,
             mergedActiveTab,
-            existing.tabGroups ?? persistedGroups
+            existing.tabGroups ?? persistedGroups?.map(toRuntimeMobileSessionTabGroup)
           )
         : hasPersistedSplit
           ? appendBrowserTabOrder(
               distributeHeadlessTabsAcrossGroups(
-                persistedGroups.map((group) => ({
-                  id: group.id,
-                  activeTabId: group.activeTabId,
-                  tabOrder: [...group.tabOrder],
-                  ...(group.recentTabIds ? { recentTabIds: [...group.recentTabIds] } : {})
-                })),
+                persistedGroups.map(toRuntimeMobileSessionTabGroup),
                 collectHeadlessParentTabOrder(mergedTerminalTabs),
                 activeTopLevelId
               ),
@@ -216,22 +229,31 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
                   tabOrder
                 }
               ]
-      // Why: merging runtime tabs INTO a renderer publication must not reclass
-      // the snapshot as headless-built — the preservation predicate would then
-      // treat the renderer's own tabs as runtime-owned and resurrect tabs the
-      // renderer later closes. Keep the renderer base epoch with a merge suffix
-      // (idempotent) so ownership stays derivable from the epoch.
+      // Why: merging INTO a non-headless publication must not reclass the
+      // snapshot as headless-built — the preservation predicate would then treat
+      // that publisher's own tabs as runtime-owned and resurrect tabs it later
+      // closes. Applies to both merge paths: the chat-only fall-through also
+      // merges into an existing snapshot, whose base epoch can be a renderer's.
       const mergedIntoRendererPublication =
-        options.onlyRuntimeOwnedTerminals === true &&
+        (options.onlyRuntimeOwnedTerminals === true || preserveNonTerminalSnapshot) &&
         existing !== undefined &&
         !this.isHeadlessBuiltMobileSessionPublicationBase(existing.publicationEpoch)
+      // Why: a group whose last tab is gone is dropped above, so a carried-over
+      // activeGroupId can name a group that no longer exists — reseat it on the
+      // group holding the active tab rather than publishing a dangling id.
+      const preservedActiveGroupId = existing?.activeGroupId ?? groupId
+      const nextActiveGroupId = nextTabGroups.some((group) => group.id === preservedActiveGroupId)
+        ? preservedActiveGroupId
+        : (nextTabGroups.find((group) => group.tabOrder.includes(activeTopLevelId))?.id ??
+          nextTabGroups[0]?.id ??
+          preservedActiveGroupId)
       const nextSnapshot: RuntimeMobileSessionTabsSnapshot = {
         worktree: existing?.worktree ?? entryWorktreeId,
         publicationEpoch: mergedIntoRendererPublication
           ? this.getMergedMobileSessionPublicationEpoch(existing, tabs)
           : `headless-hydrated:${Date.now().toString(36)}`,
         snapshotVersion: (existing?.snapshotVersion ?? 0) + 1,
-        activeGroupId: existing?.activeGroupId ?? groupId,
+        activeGroupId: nextActiveGroupId,
         activeTabId: mergedActiveTab?.id ?? null,
         activeTabType: mergedActiveTab?.type ?? null,
         tabGroups: nextTabGroups,

--- a/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs.test.ts
+++ b/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultWorkspaceSession } from '../../shared/constants'
-import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
+import type {
+  RuntimeMobileSessionSnapshotTab,
+  RuntimeMobileSessionTabsSnapshot
+} from '../../shared/runtime-types'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import * as terminalProjection from './mobile-session-terminal-projection'
 import { OrcaRuntimeService } from './orca-runtime'
@@ -12,10 +15,15 @@ type RuntimeInternals = {
   getAvailableAuthoritativeWindow(): unknown
   getWorkspaceSessionForWorktree(worktreeId: string): WorkspaceSessionState
   mobileSessionTabsByWorktree: Map<string, RuntimeMobileSessionTabsSnapshot>
-  buildHeadlessMobileSessionBrowserTabs: () => never[]
+  buildHeadlessMobileSessionBrowserTabs: () => RuntimeMobileSessionSnapshotTab[]
   reconcileHeadlessMobileSessionBrowserTabs: () => void
   hasServeOrSshOwnedBinding(tab: { ptyId?: string }): boolean
   hasRecentExpiredSshLeasePane(): boolean
+  isHeadlessBuiltMobileSessionPublicationBase(publicationEpoch: string): boolean
+  shouldPreserveHeadlessMobileSessionTab(
+    snapshot: RuntimeMobileSessionTabsSnapshot,
+    tab: RuntimeMobileSessionSnapshotTab
+  ): boolean
   hydrateHeadlessMobileSessionTabsFromWorkspaceSession(
     worktreeId: string,
     options: {
@@ -25,6 +33,21 @@ type RuntimeInternals = {
       force?: boolean
     }
   ): Set<string>
+}
+
+function browserTab(): RuntimeMobileSessionSnapshotTab {
+  return {
+    type: 'browser',
+    id: 'browser',
+    browserWorkspaceId: 'page',
+    browserPageId: 'browser',
+    loading: false,
+    canGoBack: false,
+    canGoForward: false,
+    title: 'Page',
+    url: 'about:blank',
+    isActive: false
+  }
 }
 
 function setup() {
@@ -81,18 +104,10 @@ describe('persisted terminal hydration behind non-terminal snapshots', () => {
   it.each([false, true])('preserves the active chat and its group (browser split: %s)', (split) => {
     const { runtime, session, snapshot } = setup()
     if (split) {
-      snapshot.tabs.push({
-        type: 'browser',
-        id: 'browser',
-        browserWorkspaceId: 'page',
-        browserPageId: 'browser',
-        loading: false,
-        canGoBack: false,
-        canGoForward: false,
-        title: 'Page',
-        url: 'about:blank',
-        isActive: false
-      })
+      const browser = browserTab()
+      snapshot.tabs.push(browser)
+      // The page is still live, so the rebuild republishes it.
+      runtime.buildHeadlessMobileSessionBrowserTabs = vi.fn(() => [browser])
       snapshot.tabGroups!.unshift({
         id: 'browser-group',
         activeTabId: 'browser',
@@ -213,9 +228,99 @@ describe('persisted terminal hydration behind non-terminal snapshots', () => {
       allowAttachedWindow: true,
       force: true
     })
-    expect(runtime.mobileSessionTabsByWorktree.get(WORKTREE)!.tabs.map((tab) => tab.type)).toEqual([
-      'terminal',
-      'terminal'
-    ])
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    expect(result.tabs.map((tab) => tab.type)).toEqual(['terminal', 'terminal'])
+    // Guards the epoch fix below from over-correcting: a plain rebuild that
+    // merges into nothing is headless-built and must say so.
+    expect(result.publicationEpoch.startsWith('headless-hydrated:')).toBe(true)
+  })
+})
+
+describe('chat-only fall-through hygiene', () => {
+  const RENDERER_EPOCH = 'renderer:6b1f0f5c-0b6a-4d31-9d1f-6a0f1d2c3b4e'
+
+  it('carries a renderer base epoch forward instead of reclassing as headless-built', () => {
+    const { runtime, snapshot } = setup()
+    snapshot.publicationEpoch = RENDERER_EPOCH
+
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    expect(result.publicationEpoch).toBe(RENDERER_EPOCH)
+    expect(runtime.isHeadlessBuiltMobileSessionPublicationBase(result.publicationEpoch)).toBe(false)
+    const hydrated = result.tabs.find((tab) => tab.type === 'terminal')!
+    expect(runtime.shouldPreserveHeadlessMobileSessionTab(result, hydrated)).toBe(false)
+  })
+
+  it('keeps a headless base epoch headless-built', () => {
+    const { runtime, snapshot } = setup()
+    snapshot.publicationEpoch = 'headless:seed'
+
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    expect(result.publicationEpoch.startsWith('headless-hydrated:')).toBe(true)
+    expect(runtime.isHeadlessBuiltMobileSessionPublicationBase(result.publicationEpoch)).toBe(true)
+  })
+
+  it('publishes persisted groups in the wire shape, without worktreeId', () => {
+    const { runtime, session, snapshot } = setup()
+    delete snapshot.tabGroups
+    session.tabGroups = {
+      [WORKTREE]: ['left', 'right'].map((id) => ({
+        id,
+        worktreeId: WORKTREE,
+        activeTabId: null,
+        tabOrder: [],
+        recentTabIds: []
+      }))
+    }
+
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    expect(result.tabGroups!.length).toBeGreaterThan(0)
+    for (const group of result.tabGroups!) {
+      expect(Object.keys(group)).not.toContain('worktreeId')
+    }
+  })
+
+  it('drops a browser tab whose page is gone', () => {
+    const { runtime, snapshot } = setup()
+    snapshot.tabs.push(browserTab())
+    snapshot.tabGroups![0]!.tabOrder.push('browser')
+
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    expect(result.tabs.map((tab) => tab.id)).not.toContain('browser')
+    expect(result.tabs.some((tab) => tab.id === CHAT)).toBe(true)
+    expect(result.tabGroups!.flatMap((group) => group.tabOrder)).not.toContain('browser')
+  })
+
+  it('reseats the active group when the stale browser emptied it', () => {
+    const { runtime, snapshot } = setup()
+    snapshot.tabs.push(browserTab())
+    snapshot.tabGroups!.push({ id: 'browser-group', activeTabId: 'browser', tabOrder: ['browser'] })
+    snapshot.activeGroupId = 'browser-group'
+    snapshot.activeTabId = 'browser'
+    snapshot.activeTabType = 'browser'
+
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    expect(result.tabGroups!.map((group) => group.id)).not.toContain('browser-group')
+    expect(result.tabGroups!.some((group) => group.id === result.activeGroupId)).toBe(true)
+    expect(result.tabs.some((tab) => tab.id === result.activeTabId)).toBe(true)
   })
 })

--- a/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs.test.ts
+++ b/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs.test.ts
@@ -306,6 +306,53 @@ describe('chat-only fall-through hygiene', () => {
     expect(result.tabGroups!.flatMap((group) => group.tabOrder)).not.toContain('browser')
   })
 
+  it('keeps a live browser active instead of moving onto a rebuilt terminal', () => {
+    const { runtime, snapshot } = setup()
+    const browser = { ...browserTab(), isActive: true }
+    snapshot.tabs[0]!.isActive = false
+    snapshot.tabs.push(browser)
+    snapshot.tabGroups!.push({ id: 'browser-group', activeTabId: 'browser', tabOrder: ['browser'] })
+    snapshot.activeGroupId = 'browser-group'
+    snapshot.activeTabId = 'browser'
+    snapshot.activeTabType = 'browser'
+    runtime.buildHeadlessMobileSessionBrowserTabs = vi.fn(() => [browser])
+
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    expect(result.activeTabId).toBe('browser')
+    expect(result.activeTabType).toBe('browser')
+    expect(result.activeGroupId).toBe('browser-group')
+    expect(
+      result.tabGroups!.find((group) => group.id === result.activeGroupId)!.tabOrder
+    ).toContain('browser')
+  })
+
+  it('seats the active group on a persisted split when nothing was published yet', () => {
+    const { runtime, session } = setup()
+    runtime.mobileSessionTabsByWorktree.delete(WORKTREE)
+    session.tabGroups = {
+      [WORKTREE]: [
+        { id: 'left', worktreeId: WORKTREE, activeTabId: 'first', tabOrder: ['first'] },
+        { id: 'right', worktreeId: WORKTREE, activeTabId: 'second', tabOrder: ['second'] }
+      ]
+    }
+
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    const activeTab = result.tabs.find((tab) => tab.id === result.activeTabId)!
+    const activeTopLevelId = activeTab.type === 'terminal' ? activeTab.parentTabId : activeTab.id
+    expect(result.tabGroups!.map((group) => group.id)).toEqual(['left', 'right'])
+    expect(
+      result.tabGroups!.find((group) => group.id === result.activeGroupId)?.tabOrder
+    ).toContain(activeTopLevelId)
+  })
+
   it('reseats the active group when the stale browser emptied it', () => {
     const { runtime, snapshot } = setup()
     snapshot.tabs.push(browserTab())

--- a/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs.test.ts
+++ b/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
+import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import * as terminalProjection from './mobile-session-terminal-projection'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const WORKTREE = 'repo::/workspace'
+const CHAT = 'agent-session:chat'
+
+type RuntimeInternals = {
+  getAvailableAuthoritativeWindow(): unknown
+  getWorkspaceSessionForWorktree(worktreeId: string): WorkspaceSessionState
+  mobileSessionTabsByWorktree: Map<string, RuntimeMobileSessionTabsSnapshot>
+  buildHeadlessMobileSessionBrowserTabs: () => never[]
+  reconcileHeadlessMobileSessionBrowserTabs: () => void
+  hasServeOrSshOwnedBinding(tab: { ptyId?: string }): boolean
+  hasRecentExpiredSshLeasePane(): boolean
+  hydrateHeadlessMobileSessionTabsFromWorkspaceSession(
+    worktreeId: string,
+    options: {
+      allowAttachedWindow: boolean
+      onlyRuntimeOwnedTerminals?: boolean
+      runtimeOwnedTerminalCandidateKnown?: boolean
+      force?: boolean
+    }
+  ): Set<string>
+}
+
+function setup() {
+  const runtime = new OrcaRuntimeService() as unknown as RuntimeInternals
+  const session: WorkspaceSessionState = {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: {
+      [WORKTREE]: ['first', 'second'].map((id, sortOrder) => ({
+        id,
+        worktreeId: WORKTREE,
+        ptyId: `renderer-${id}`,
+        title: id,
+        customTitle: null,
+        color: null,
+        sortOrder,
+        createdAt: 1
+      }))
+    },
+    activeTabIdByWorktree: { [WORKTREE]: 'first' }
+  }
+  const snapshot: RuntimeMobileSessionTabsSnapshot = {
+    worktree: WORKTREE,
+    publicationEpoch: 'structured:restore',
+    snapshotVersion: 1,
+    activeGroupId: 'chat-group',
+    activeTabId: CHAT,
+    activeTabType: 'agent-session',
+    tabGroups: [{ id: 'chat-group', activeTabId: CHAT, tabOrder: [CHAT] }],
+    tabs: [
+      {
+        type: 'agent-session',
+        id: CHAT,
+        sessionId: 'chat',
+        agent: 'codex',
+        title: 'Chat',
+        isActive: true
+      }
+    ]
+  }
+  runtime.getAvailableAuthoritativeWindow = () => ({ id: 1 })
+  runtime.getWorkspaceSessionForWorktree = () => session
+  runtime.buildHeadlessMobileSessionBrowserTabs = vi.fn(() => [])
+  runtime.reconcileHeadlessMobileSessionBrowserTabs = vi.fn()
+  runtime.hasServeOrSshOwnedBinding = (tab) => tab.ptyId?.startsWith('serve-') === true
+  runtime.hasRecentExpiredSshLeasePane = () => false
+  runtime.mobileSessionTabsByWorktree.set(WORKTREE, snapshot)
+  const rebuild = vi.spyOn(terminalProjection, 'buildHeadlessMobileSessionTerminalTabs')
+  return { runtime, session, snapshot, rebuild }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('persisted terminal hydration behind non-terminal snapshots', () => {
+  it.each([false, true])('preserves the active chat and its group (browser split: %s)', (split) => {
+    const { runtime, session, snapshot } = setup()
+    if (split) {
+      snapshot.tabs.push({
+        type: 'browser',
+        id: 'browser',
+        browserWorkspaceId: 'page',
+        browserPageId: 'browser',
+        loading: false,
+        canGoBack: false,
+        canGoForward: false,
+        title: 'Page',
+        url: 'about:blank',
+        isActive: false
+      })
+      snapshot.tabGroups!.unshift({
+        id: 'browser-group',
+        activeTabId: 'browser',
+        tabOrder: ['browser']
+      })
+      snapshot.tabGroupLayout = {
+        type: 'split',
+        direction: 'horizontal',
+        ratio: 0.4,
+        first: { type: 'leaf', groupId: 'browser-group' },
+        second: { type: 'leaf', groupId: 'chat-group' }
+      }
+      session.tabGroups = {
+        [WORKTREE]: snapshot.tabGroups!.map((group) => ({ ...group, worktreeId: WORKTREE }))
+      }
+      session.tabGroupLayouts = { [WORKTREE]: snapshot.tabGroupLayout }
+    }
+
+    const reconciled = runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+
+    expect(
+      result.tabs.filter((tab) => tab.type === 'terminal').map((tab) => tab.parentTabId)
+    ).toEqual(['first', 'second'])
+    expect(result.tabs).toEqual(expect.arrayContaining(snapshot.tabs))
+    expect(result.activeTabId).toBe(CHAT)
+    expect(result.activeTabType).toBe('agent-session')
+    expect(result.activeGroupId).toBe('chat-group')
+    expect(result.tabGroups).toContainEqual({
+      id: 'chat-group',
+      activeTabId: CHAT,
+      tabOrder: [CHAT, 'first', 'second']
+    })
+    expect(result.tabGroupLayout).toEqual(snapshot.tabGroupLayout)
+    if (split) {
+      expect(result.tabGroups).toContainEqual(snapshot.tabGroups![0])
+    }
+    expect(reconciled.has(WORKTREE)).toBe(false)
+  })
+
+  it('keeps the existing chat groups ahead of a stale persisted split', () => {
+    const { runtime, session, snapshot } = setup()
+    session.tabGroups = {
+      [WORKTREE]: ['left', 'right'].map((id) => ({
+        id,
+        worktreeId: WORKTREE,
+        activeTabId: null,
+        tabOrder: []
+      }))
+    }
+    session.tabGroupLayouts = {
+      [WORKTREE]: {
+        type: 'split',
+        direction: 'horizontal',
+        ratio: 0.5,
+        first: { type: 'leaf', groupId: 'left' },
+        second: { type: 'leaf', groupId: 'right' }
+      }
+    }
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    expect(result.tabGroups).toEqual([
+      { ...snapshot.tabGroups![0], tabOrder: [CHAT, 'first', 'second'] }
+    ])
+    expect(result.tabGroupLayout).toBeUndefined()
+  })
+
+  it('only reconciles browsers when terminals already exist', () => {
+    const { runtime, snapshot, rebuild } = setup()
+    snapshot.tabs.push({
+      type: 'terminal',
+      id: 'existing::leaf',
+      parentTabId: 'existing',
+      leafId: 'leaf',
+      title: 'Existing',
+      isActive: false
+    })
+
+    const reconciled = runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true
+    })
+
+    expect(reconciled.has(WORKTREE)).toBe(true)
+    expect(rebuild).not.toHaveBeenCalled()
+    expect(runtime.buildHeadlessMobileSessionBrowserTabs).not.toHaveBeenCalled()
+    expect(runtime.reconcileHeadlessMobileSessionBrowserTabs).toHaveBeenCalledWith(
+      WORKTREE,
+      snapshot
+    )
+    expect(runtime.mobileSessionTabsByWorktree.get(WORKTREE)).toBe(snapshot)
+  })
+
+  it('still merges runtime-owned terminals and filters attached renderer terminals', () => {
+    const { runtime, session, snapshot, rebuild } = setup()
+    session.tabsByWorktree[WORKTREE]![1]!.ptyId = 'serve-second'
+
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true,
+      onlyRuntimeOwnedTerminals: true,
+      runtimeOwnedTerminalCandidateKnown: true
+    })
+
+    const result = runtime.mobileSessionTabsByWorktree.get(WORKTREE)!
+    expect(rebuild).toHaveBeenCalledOnce()
+    expect(result.tabs).toEqual([
+      snapshot.tabs[0],
+      expect.objectContaining({ type: 'terminal', parentTabId: 'second', ptyId: 'serve-second' })
+    ])
+  })
+
+  it('still replaces existing tabs on a forced rebuild', () => {
+    const { runtime } = setup()
+    runtime.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(WORKTREE, {
+      allowAttachedWindow: true,
+      force: true
+    })
+    expect(runtime.mobileSessionTabsByWorktree.get(WORKTREE)!.tabs.map((tab) => tab.type)).toEqual([
+      'terminal',
+      'terminal'
+    ])
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​373 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​373 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​49 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 |

<!-- /orca-pr-loc -->

## Defect (on main today)

The headless mobile-tab hydrator skips rebuilding a worktree whenever its snapshot already has any tab. Structured-chat restore runs once per desktop process (from the first \`session.tabs.list\` or subscribe) and publishes a chat-only snapshot for every worktree with a saved chat. Every later \`worktree.activate\` and \`session.tabs.list\` for such a worktree then hits the skip, so its persisted renderer terminals are never built. The phone shows only the chat until the desktop itself opens that workspace. Deterministic for every worktree after the first one touched in the process; timing-dependent for the first.

Found during review of #19387, which shifts the phone's \`worktree.activate\` one status round trip later and would widen the window for the first worktree. This is the owning layer, so it lands first.

## Fix

- Skip only when the existing snapshot already contains a terminal tab. When it has tabs but no terminals, fall through and rebuild.
- The rebuild merges the existing non-browser tabs with the rebuilt terminals (browsers are rebuilt live), keeps the existing active tab and group, and builds groups from the existing groups via the pre-existing \`buildHeadlessMobileSessionTabGroups\`.
- A renderer base epoch is carried forward (not stamped as headless-built), so the renderer-retirement and ownership-release paths keep working. Persisted groups are mapped through the same four-field sanitiser the split branch already used, so \`worktreeId\` does not leak onto the wire.
- An active-group id that no longer names a live group is reseated. This also repairs two pre-existing paths that could publish a dangling id.

Net +39 lines (whitespace-insensitive) in one source file; 13 tests in a new test file driving the real \`OrcaRuntimeService\`.

## Review

Three Opus adversarial rounds on this branch. Round 1 found the epoch reclassification (blocking), the wire leak, and the stale-browser survival; round 2 found a live active browser losing active status to the browser filter. Each fixed with a failing-first test. Final verdict MERGE with all findings closed and no downstream reliance on the old dangling-id behaviour.

## Verification

New test file 13/13, the four sibling runtime test files green, full \`src/main/runtime\` suite 7358 passed, \`tc:node\` clean, changed-code quality and react-doctor 0 findings. The regression test fails on main.

Not to be merged without owner approval. Merge before #19387.