### PR TITLE
fix(daemon): escape the terminal daemon into its own systemd scope so a service restart no longer kills every live PTY

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -231,8 +231,10 @@ Replace `100.64.1.20` with the LAN, Tailscale, tunnel, or public hostname that
 clients should use.
 
 `KillMode=mixed` sends the graceful stop signal only to Orca's main process,
-then retains systemd's cgroup-wide `SIGKILL` fallback if shutdown times out.
-This lets Orca keep its owned Xvfb alive until Electron disconnects cleanly.
+then `SIGKILL`s whatever is still in the cgroup the instant that main process
+exits — `TimeoutStopSec` only governs how long systemd waits for the main
+process itself, never a grace window for the cgroup's remains. This lets Orca
+keep its owned Xvfb alive until Electron disconnects cleanly.
 
 The detached terminal daemon is preserved by a different mechanism: it is
 launched through `systemd-run --user --scope`, so it and its PTYs live in their
@@ -257,6 +259,14 @@ even though their persisted layout and terminal history remain. Check which
 case a running host is in with the `cgroupUnit` field of the daemon health
 payload: a `orca-daemon-*.scope` value means isolated, `null` means the
 unscoped fallback.
+
+None of this applies inside a Docker container. There the capability probe
+fails closed (no `/run/systemd/system`), but that is the least of it: a
+`docker restart` tears down the container's PID namespace, so no in-container
+setting — lingering, kill mode, or scope — preserves the daemon or its PTYs
+across it. Run the container with `--init` so a real PID 1 reaps exited PTY
+subprocesses; without it, Orca is PID 1 and those children accumulate as
+zombies because nothing reaps them.
 
 Exit status `3` means another process already owns this userData profile, so
 `RestartPreventExitStatus=3` stops the unit instead of retrying a launch that
@@ -335,6 +345,7 @@ WorkingDirectory=/home/orca
 Environment=DISPLAY=:99
 Environment=LIBGL_ALWAYS_SOFTWARE=1
 ExecStart=/opt/orca/orca-linux.AppImage serve --port 6768 --pairing-address 100.64.1.20
+KillMode=mixed
 Restart=on-failure
 RestartPreventExitStatus=3
 RestartSec=5
@@ -342,6 +353,11 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 ```
+
+`KillMode=mixed` matters as much here as in the single-service unit: without it
+the unit silently defaults to `KillMode=control-group`, which `SIGTERM`s the
+whole cgroup at once and then stalls the full `TimeoutStopSec` before the
+`SIGKILL`.
 
 Enable both units:
 

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -233,10 +233,30 @@ clients should use.
 `KillMode=mixed` sends the graceful stop signal only to Orca's main process,
 then retains systemd's cgroup-wide `SIGKILL` fallback if shutdown times out.
 This lets Orca keep its owned Xvfb alive until Electron disconnects cleanly.
-It does **not** preserve the detached terminal daemon: the daemon and its PTYs
-remain in `orca-serve.service`'s cgroup and are killed when the stop completes.
-Every `systemctl stop` or `restart` therefore ends live terminals and agent
-processes, even though their persisted layout and terminal history remain.
+
+The detached terminal daemon is preserved by a different mechanism: it is
+launched through `systemd-run --user --scope`, so it and its PTYs live in their
+own transient `orca-daemon-<launch-nonce>.scope` unit rather than in
+`orca-serve.service`'s cgroup. A `systemctl stop` or `restart` of this unit
+leaves that scope running, so live terminals and agent processes survive the
+restart and the successor adopts them.
+
+That requires a reachable systemd **user** manager for the service account.
+With `User=orca` and no interactive login there is none by default, so enable
+lingering once:
+
+```bash
+sudo loginctl enable-linger orca
+```
+
+Without it — or on a host without systemd as PID 1, or without `systemd-run`
+on `PATH` — the daemon falls back to launching directly inside
+`orca-serve.service`'s cgroup, and is then killed when the stop completes:
+every `systemctl stop` or `restart` ends live terminals and agent processes,
+even though their persisted layout and terminal history remain. Check which
+case a running host is in with the `cgroupUnit` field of the daemon health
+payload: a `orca-daemon-*.scope` value means isolated, `null` means the
+unscoped fallback.
 
 Exit status `3` means another process already owns this userData profile, so
 `RestartPreventExitStatus=3` stops the unit instead of retrying a launch that

--- a/docs/reference/orcad-operations.md
+++ b/docs/reference/orcad-operations.md
@@ -21,13 +21,36 @@ survive. The successor adopts the current endpoint and routes supported previous
 versions through legacy adapters. This makes a PID-scoped update, rollback or restart
 non-destructive to live work.
 
-Process detachment is not service isolation. A daemon forked by orcad, and every PTY it owns,
-remain in the same systemd service cgroup. `KillMode=mixed` does **not** preserve them: it
-sends the graceful stop signal only to the main process, then sends `SIGKILL` to every process
-remaining in the cgroup when the stop timeout expires. `KillMode=control-group` is destructive
-too. `KillMode=process` leaves service-owned processes unmanaged and is not a supported
-preservation mechanism. Service-restart survival requires separately supervised cgroups; the
-current deployment does not provide them.
+Process detachment is not service isolation. A daemon that orcad launches directly, and every
+PTY it owns, remain in the same systemd service cgroup. `KillMode=mixed` does **not** preserve
+them: it sends the graceful stop signal only to the main process, then sends `SIGKILL` to every
+process remaining in the cgroup when the stop timeout expires. `KillMode=control-group` is
+destructive too. `KillMode=process` leaves service-owned processes unmanaged and is not a
+supported preservation mechanism.
+
+Service-restart survival therefore requires a separately supervised cgroup, and orcad now asks
+for one: on Linux it launches the daemon through `systemd-run --user --scope`, which places the
+daemon and its PTYs in their own transient `orca-daemon-<launch-nonce>.scope` unit under the
+user slice instead of the caller's service cgroup. A stop or restart of the service unit then
+leaves that scope — and the live terminals in it — running, and the successor adopts the
+endpoint as it always has.
+
+The scope is requested only where it can work. All of these must hold:
+
+- **Linux with systemd as PID 1** (`/run/systemd/system` exists).
+- **A reachable user bus** — a connectable `bus` socket in the per-UID runtime dir
+  (`/run/user/<uid>`, or whatever `XDG_RUNTIME_DIR` points at). For a service account that is
+  not otherwise logged in, that means `loginctl enable-linger <user>`; a unit whose
+  `RuntimeDirectory=` hardening moves `XDG_RUNTIME_DIR` off the per-UID path is handled, because
+  the real per-UID path is probed first.
+- **`systemd-run` on `PATH`** and answering `--version`.
+
+Any of those missing, or a `StartTransientUnit` call that fails anyway, falls back to the
+direct launch — and in that unscoped fallback case the paragraph above still describes reality:
+the daemon shares the service cgroup and a combined-unit stop ends live terminals. Read the
+`cgroupUnit` field in the daemon health payload to tell the two cases apart on a running host;
+it is populated from `/proc/self/cgroup`, so it reports the isolation the daemon actually has
+rather than what the launcher intended.
 
 ## Bind policy
 
@@ -81,8 +104,11 @@ a live daemon makes worthwhile.
 ### Process-scoped and cgroup-wide stops
 
 The built-in remote updater performs a PID-scoped stop and keeps the daemon's install version
-pinned while it owns sessions. A combined-unit systemd stop or restart is different: it reaps
-the daemon and every live terminal after the graceful window.
+pinned while it owns sessions. A combined-unit systemd stop or restart is different: unless the
+daemon holds a durable cgroup scope of its own (see
+[Two long-lived processes, not one](#two-long-lived-processes-not-one)), it reaps the daemon and
+every live terminal after the graceful window. Treat a stop as destructive unless
+`health.terminalDaemon.cgroupUnit` names an `orca-daemon-*.scope` on that host.
 
 Before a cgroup-wide stop, obtain a fresh `orca-ide terminal list --json` result using the same OS
 account and home as the daemon. Invoke the installer's absolute launcher path so `sudo`'s
@@ -129,8 +155,10 @@ An external supervisor (systemd, launchd, a process manager). orcad conforms to 
 
 ### orcad supervising the daemon
 
-- **Launch.** Forked detached from `daemon-entry.js` beside `orcad.js`, with its own PID
-  record, token and socket under `<data-root>/daemon`.
+- **Launch.** On Linux, through `systemd-run --user --scope` so the daemon gets its own
+  transient cgroup and survives a service-unit restart; everywhere else, and wherever that
+  scope is unavailable, forked detached. Either way it runs `daemon-entry.js` beside
+  `orcad.js` with its own PID record, token and socket under `<data-root>/daemon`.
 - **Adoption before spawn.** A daemon already answering the endpoint is adopted, not
   replaced, unless it is unhealthy, foreign, or built from a superseded bundle _and_ owns no
   live sessions. Replacing a healthy daemon kills its PTYs, so code freshness always defers
@@ -148,9 +176,10 @@ An external supervisor (systemd, launchd, a process manager). orcad conforms to 
 
 ### Decommissioning
 
-After a PID-scoped stop, an adopted daemon stays resident so the next orcad can reattach.
-A combined-unit systemd stop kills it instead. To retire a process-scoped deployment, apply
-the census rule above, stop orcad, then stop the daemon named by `health.terminalDaemon.pid`.
+After a PID-scoped stop, an adopted daemon stays resident so the next orcad can reattach. A
+combined-unit systemd stop also leaves a scope-isolated daemon resident, but kills one that
+fell back to the service cgroup. To retire a process-scoped deployment, apply the census rule
+above, stop orcad, then stop the daemon named by `health.terminalDaemon.pid`.
 Only report it `exited` after verification on the execution host; loss of contact is
 `unverifiable`.
 
@@ -201,8 +230,10 @@ Named here so nothing reads as implemented that is not:
 - **A continuous health endpoint.** `health` is published once, in the readiness payload. A
   supervisor's periodic liveness/readiness probe needs an HTTP or RPC surface over the same
   `collectOrcadHealth()`; that surface does not exist yet.
-- **Systemd-isolated daemon supervision.** orcad and its daemon currently share one service
-  cgroup, so a combined-unit stop cannot preserve live terminals.
+- **Supervision of an unscoped fallback daemon.** When the durable `systemd-run --user --scope`
+  launch is unavailable (see [above](#two-long-lived-processes-not-one)) orcad and its daemon
+  share one service cgroup, and a combined-unit stop cannot preserve live terminals. There is
+  no mechanism that re-isolates such a daemon after the fact.
 - **libc slot.** There is no honest health value to publish until native libc detection owns
   it.
 - **`degradations[]`.** The readiness contract does not publish this collection yet.

--- a/docs/reference/orcad-operations.md
+++ b/docs/reference/orcad-operations.md
@@ -24,9 +24,9 @@ non-destructive to live work.
 Process detachment is not service isolation. A daemon that orcad launches directly, and every
 PTY it owns, remain in the same systemd service cgroup. `KillMode=mixed` does **not** preserve
 them: it sends the graceful stop signal only to the main process, then sends `SIGKILL` to every
-process remaining in the cgroup when the stop timeout expires. `KillMode=control-group` is
-destructive too. `KillMode=process` leaves service-owned processes unmanaged and is not a
-supported preservation mechanism.
+process remaining in the cgroup the moment that main process exits — `TimeoutStopSec` never gets
+the chance to apply. `KillMode=control-group` is destructive too. `KillMode=process` leaves
+service-owned processes unmanaged and is not a supported preservation mechanism.
 
 Service-restart survival therefore requires a separately supervised cgroup, and orcad now asks
 for one: on Linux it launches the daemon through `systemd-run --user --scope`, which places the

--- a/src/main/daemon/daemon-adoption-telemetry-event.test.ts
+++ b/src/main/daemon/daemon-adoption-telemetry-event.test.ts
@@ -41,7 +41,8 @@ const stalePidRecord: ParsedDaemonPid = {
   linuxStartTicks: null,
   bootId: null,
   spawnerExecPath:
-    '/Users/alice/Library/Caches/com.stablyai.orca.ShipIt/u/Orca.app/Contents/MacOS/Orca'
+    '/Users/alice/Library/Caches/com.stablyai.orca.ShipIt/u/Orca.app/Contents/MacOS/Orca',
+  cgroupUnit: null
 }
 const origin = { app_version_match: 'different', spawner_path_class: 'updater-cache' } as const
 const PID_PATH = '/fake/daemon.pid'

--- a/src/main/daemon/daemon-cgroup-scope.test.ts
+++ b/src/main/daemon/daemon-cgroup-scope.test.ts
@@ -44,14 +44,11 @@ function fakeRuntimeDirWithoutBus(): string {
 }
 
 afterEach(() => {
-  while (fakeBusServers.length > 0) {
-    fakeBusServers.pop()?.close()
+  for (const server of fakeBusServers.splice(0)) {
+    server.close()
   }
-  while (fakeBusDirs.length > 0) {
-    const dir = fakeBusDirs.pop()
-    if (dir) {
-      rmSync(dir, { recursive: true, force: true })
-    }
+  for (const dir of fakeBusDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
   }
 })
 
@@ -65,9 +62,8 @@ describe('isDurableDaemonScopeSupported', () => {
     )
   })
 
-  it('never throws when XDG_RUNTIME_DIR is absent and the conventional path cannot resolve', () => {
-    expect(() => isDurableDaemonScopeSupported({}, 'linux', null)).not.toThrow()
-    expect(typeof isDurableDaemonScopeSupported({}, 'linux', null)).toBe('boolean')
+  it('is false when there is no runtime dir to resolve at all', () => {
+    expect(isDurableDaemonScopeSupported({}, 'linux', null)).toBe(false)
   })
 
   it('is false when neither the canonical per-UID path nor the env path has a reachable bus', () => {
@@ -183,14 +179,11 @@ describe('buildDurableDaemonScopeCommand', () => {
 })
 
 describe('detectOwnCgroupScopeUnit', () => {
-  const tempFiles: string[] = []
+  const tempDirs: string[] = []
 
   afterEach(() => {
-    while (tempFiles.length > 0) {
-      const path = tempFiles.pop()
-      if (path) {
-        rmSync(path, { force: true })
-      }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
     }
   })
 
@@ -198,7 +191,7 @@ describe('detectOwnCgroupScopeUnit', () => {
     const dir = mkdtempSync(join(tmpdir(), 'cgroup-scope-'))
     const path = join(dir, 'cgroup')
     writeFileSync(path, contents)
-    tempFiles.push(path)
+    tempDirs.push(dir)
     return path
   }
 

--- a/src/main/daemon/daemon-cgroup-scope.test.ts
+++ b/src/main/daemon/daemon-cgroup-scope.test.ts
@@ -27,6 +27,7 @@ describe('daemonScopeUnitName', () => {
 // fixture that only `existsSync`-passes would not exercise it.
 const fakeBusServers: Server[] = []
 const fakeBusDirs: string[] = []
+const fakeSystemdBootDirs: string[] = []
 
 function fakeRuntimeDirWithBus(): string {
   const dir = mkdtempSync(join(tmpdir(), 'xdg-runtime-with-bus-'))
@@ -43,11 +44,22 @@ function fakeRuntimeDirWithoutBus(): string {
   return dir
 }
 
+// A directory that reliably exists on every dev host, standing in for the real
+// `/run/systemd/system` boot marker that only exists on a systemd host.
+function fakeSystemdBootPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'systemd-boot-marker-'))
+  fakeSystemdBootDirs.push(dir)
+  return dir
+}
+
 afterEach(() => {
   for (const server of fakeBusServers.splice(0)) {
     server.close()
   }
   for (const dir of fakeBusDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  for (const dir of fakeSystemdBootDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true })
   }
 })
@@ -62,8 +74,26 @@ describe('isDurableDaemonScopeSupported', () => {
     )
   })
 
+  it('is false when not booted under systemd, even with a reachable bus and a working binary', () => {
+    const perUidDir = fakeRuntimeDirWithBus()
+    expect(
+      isDurableDaemonScopeSupported(
+        { XDG_RUNTIME_DIR: perUidDir },
+        'linux',
+        perUidDir,
+        '/definitely/not/systemd-boot',
+        () => ({ code: 0, timedOut: false })
+      )
+    ).toBe(false)
+  })
+
   it('is false when there is no runtime dir to resolve at all', () => {
-    expect(isDurableDaemonScopeSupported({}, 'linux', null)).toBe(false)
+    expect(
+      isDurableDaemonScopeSupported({}, 'linux', null, fakeSystemdBootPath(), () => ({
+        code: 0,
+        timedOut: false
+      }))
+    ).toBe(false)
   })
 
   it('is false when neither the canonical per-UID path nor the env path has a reachable bus', () => {
@@ -71,9 +101,38 @@ describe('isDurableDaemonScopeSupported', () => {
     const envDir = fakeRuntimeDirWithoutBus()
     // Neither fixture has a `bus` socket written — the probe must fail closed regardless of
     // which path it looks at first.
-    expect(isDurableDaemonScopeSupported({ XDG_RUNTIME_DIR: envDir }, 'linux', canonical)).toBe(
-      false
-    )
+    expect(
+      isDurableDaemonScopeSupported(
+        { XDG_RUNTIME_DIR: envDir },
+        'linux',
+        canonical,
+        fakeSystemdBootPath(),
+        () => ({ code: 0, timedOut: false })
+      )
+    ).toBe(false)
+  })
+
+  it('is false when systemd-run --version cannot answer: non-zero exit or a timeout kill', () => {
+    const perUidDir = fakeRuntimeDirWithBus()
+    const bootPath = fakeSystemdBootPath()
+    expect(
+      isDurableDaemonScopeSupported(
+        { XDG_RUNTIME_DIR: perUidDir },
+        'linux',
+        perUidDir,
+        bootPath,
+        () => ({ code: 1, timedOut: false })
+      )
+    ).toBe(false)
+    expect(
+      isDurableDaemonScopeSupported(
+        { XDG_RUNTIME_DIR: perUidDir },
+        'linux',
+        perUidDir,
+        bootPath,
+        () => ({ code: null, timedOut: true })
+      )
+    ).toBe(false)
   })
 
   it('is true when the process env XDG_RUNTIME_DIR is a hardened unit override, but the real per-UID dir has a reachable bus (mtl-02 regression)', () => {
@@ -87,16 +146,24 @@ describe('isDurableDaemonScopeSupported', () => {
       isDurableDaemonScopeSupported(
         { XDG_RUNTIME_DIR: hardenedOverrideDir },
         'linux',
-        realPerUidDir
+        realPerUidDir,
+        fakeSystemdBootPath(),
+        () => ({ code: 0, timedOut: false })
       )
     ).toBe(true)
   })
 
   it('is true when the caller env XDG_RUNTIME_DIR already points at the correct, reachable per-UID bus', () => {
     const perUidDir = fakeRuntimeDirWithBus()
-    expect(isDurableDaemonScopeSupported({ XDG_RUNTIME_DIR: perUidDir }, 'linux', perUidDir)).toBe(
-      true
-    )
+    expect(
+      isDurableDaemonScopeSupported(
+        { XDG_RUNTIME_DIR: perUidDir },
+        'linux',
+        perUidDir,
+        fakeSystemdBootPath(),
+        () => ({ code: 0, timedOut: false })
+      )
+    ).toBe(true)
   })
 
   it('falls back to the process env XDG_RUNTIME_DIR when the canonical per-UID path has no reachable bus', () => {
@@ -108,7 +175,9 @@ describe('isDurableDaemonScopeSupported', () => {
       isDurableDaemonScopeSupported(
         { XDG_RUNTIME_DIR: envDirWithBus },
         'linux',
-        canonicalWithoutBus
+        canonicalWithoutBus,
+        fakeSystemdBootPath(),
+        () => ({ code: 0, timedOut: false })
       )
     ).toBe(true)
   })

--- a/src/main/daemon/daemon-cgroup-scope.test.ts
+++ b/src/main/daemon/daemon-cgroup-scope.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  buildDurableDaemonScopeCommand,
+  daemonScopeUnitName,
+  detectOwnCgroupScopeUnit,
+  isDurableDaemonScopeSupported
+} from './daemon-cgroup-scope'
+
+describe('daemonScopeUnitName', () => {
+  it('prefixes the launch nonce so the unit is traceable back to a launch', () => {
+    expect(daemonScopeUnitName('c0ffee12-3456-7890-abcd-ef0123456789')).toBe(
+      'orca-daemon-c0ffee12-3456-7890-abcd-ef0123456789'
+    )
+  })
+
+  it('sanitizes characters systemd unit names reject', () => {
+    expect(daemonScopeUnitName('weird nonce/with:stuff')).toBe('orca-daemon-weird-nonce-with:stuff')
+  })
+})
+
+describe('isDurableDaemonScopeSupported', () => {
+  it('is false on non-Linux platforms regardless of environment', () => {
+    expect(isDurableDaemonScopeSupported({ XDG_RUNTIME_DIR: '/run/user/1000' }, 'darwin')).toBe(
+      false
+    )
+    expect(isDurableDaemonScopeSupported({ XDG_RUNTIME_DIR: '/run/user/1000' }, 'win32')).toBe(
+      false
+    )
+  })
+
+  it('never throws when XDG_RUNTIME_DIR is absent and the conventional path cannot resolve', () => {
+    expect(() => isDurableDaemonScopeSupported({}, 'linux')).not.toThrow()
+    expect(typeof isDurableDaemonScopeSupported({}, 'linux')).toBe('boolean')
+  })
+
+  it('is false pointed at a runtime dir with no reachable user bus', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'xdg-runtime-'))
+    try {
+      // No `bus` socket written under this fake runtime dir — the probe must fail closed.
+      expect(isDurableDaemonScopeSupported({ XDG_RUNTIME_DIR: dir }, 'linux')).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('buildDurableDaemonScopeCommand', () => {
+  it('wraps the daemon command in systemd-run --user --scope with a collected unit', () => {
+    const result = buildDurableDaemonScopeCommand(
+      '/usr/bin/node',
+      ['/opt/orca/daemon-entry.js', '--socket', '/tmp/x.sock'],
+      'nonce-1',
+      { PATH: '/usr/bin' }
+    )
+    expect(result.command).toBe('systemd-run')
+    expect(result.args).toEqual([
+      '--user',
+      '--scope',
+      '--unit=orca-daemon-nonce-1',
+      '--collect',
+      '--quiet',
+      '--',
+      '/usr/bin/node',
+      '/opt/orca/daemon-entry.js',
+      '--socket',
+      '/tmp/x.sock'
+    ])
+  })
+
+  it('preserves an explicit XDG_RUNTIME_DIR from the caller env', () => {
+    const result = buildDurableDaemonScopeCommand('/usr/bin/node', [], 'n', {
+      PATH: '/bin',
+      XDG_RUNTIME_DIR: '/run/user/9999'
+    })
+    expect(result.env.XDG_RUNTIME_DIR).toBe('/run/user/9999')
+  })
+
+  it('computes the conventional /run/user/<uid> runtime dir when the caller env omits it', () => {
+    const result = buildDurableDaemonScopeCommand('/usr/bin/node', [], 'n', { PATH: '/bin' })
+    expect(result.env.XDG_RUNTIME_DIR).toBe(`/run/user/${process.getuid?.() ?? ''}`)
+  })
+})
+
+describe('detectOwnCgroupScopeUnit', () => {
+  const tempFiles: string[] = []
+
+  afterEach(() => {
+    while (tempFiles.length > 0) {
+      const path = tempFiles.pop()
+      if (path) {
+        rmSync(path, { force: true })
+      }
+    }
+  })
+
+  function writeCgroupFixture(contents: string): string {
+    const dir = mkdtempSync(join(tmpdir(), 'cgroup-scope-'))
+    const path = join(dir, 'cgroup')
+    writeFileSync(path, contents)
+    tempFiles.push(path)
+    return path
+  }
+
+  it('is null on non-Linux platforms without reading any file', () => {
+    expect(detectOwnCgroupScopeUnit('darwin', '/nonexistent')).toBeNull()
+    expect(detectOwnCgroupScopeUnit('win32', '/nonexistent')).toBeNull()
+  })
+
+  it('is null when the cgroup file cannot be read', () => {
+    expect(detectOwnCgroupScopeUnit('linux', '/definitely/absent/cgroup')).toBeNull()
+  })
+
+  it('parses a v2 unified-hierarchy line naming an orca-daemon scope', () => {
+    const path = writeCgroupFixture('0::/user.slice/user-1000.slice/orca-daemon-abc123.scope\n')
+    expect(detectOwnCgroupScopeUnit('linux', path)).toBe('orca-daemon-abc123.scope')
+  })
+
+  it('parses a v1 systemd-controller line naming an orca-daemon scope', () => {
+    const path = writeCgroupFixture(
+      '1:name=systemd:/user.slice/user-1000.slice/orca-daemon-def456.scope\n'
+    )
+    expect(detectOwnCgroupScopeUnit('linux', path)).toBe('orca-daemon-def456.scope')
+  })
+
+  it('returns null for a plain service-unit cgroup — the un-isolated case this fix targets', () => {
+    const path = writeCgroupFixture('0::/system.slice/orca-serve@factory.service\n')
+    expect(detectOwnCgroupScopeUnit('linux', path)).toBeNull()
+  })
+
+  it('returns null for a scope unit that is not an orca-daemon one', () => {
+    const path = writeCgroupFixture('0::/user.slice/user-1000.slice/some-other-app.scope\n')
+    expect(detectOwnCgroupScopeUnit('linux', path)).toBeNull()
+  })
+})

--- a/src/main/daemon/daemon-cgroup-scope.test.ts
+++ b/src/main/daemon/daemon-cgroup-scope.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer, type Server } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -21,6 +22,39 @@ describe('daemonScopeUnitName', () => {
   })
 })
 
+// Real, connectable AF_UNIX sockets rather than plain files at "bus" — the fix under test
+// distinguishes a genuinely reachable bus from a stale file/directory left at that path, so a
+// fixture that only `existsSync`-passes would not exercise it.
+const fakeBusServers: Server[] = []
+const fakeBusDirs: string[] = []
+
+function fakeRuntimeDirWithBus(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'xdg-runtime-with-bus-'))
+  const server = createServer()
+  server.listen(join(dir, 'bus'))
+  fakeBusServers.push(server)
+  fakeBusDirs.push(dir)
+  return dir
+}
+
+function fakeRuntimeDirWithoutBus(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'xdg-runtime-no-bus-'))
+  fakeBusDirs.push(dir)
+  return dir
+}
+
+afterEach(() => {
+  while (fakeBusServers.length > 0) {
+    fakeBusServers.pop()?.close()
+  }
+  while (fakeBusDirs.length > 0) {
+    const dir = fakeBusDirs.pop()
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
 describe('isDurableDaemonScopeSupported', () => {
   it('is false on non-Linux platforms regardless of environment', () => {
     expect(isDurableDaemonScopeSupported({ XDG_RUNTIME_DIR: '/run/user/1000' }, 'darwin')).toBe(
@@ -32,18 +66,55 @@ describe('isDurableDaemonScopeSupported', () => {
   })
 
   it('never throws when XDG_RUNTIME_DIR is absent and the conventional path cannot resolve', () => {
-    expect(() => isDurableDaemonScopeSupported({}, 'linux')).not.toThrow()
-    expect(typeof isDurableDaemonScopeSupported({}, 'linux')).toBe('boolean')
+    expect(() => isDurableDaemonScopeSupported({}, 'linux', null)).not.toThrow()
+    expect(typeof isDurableDaemonScopeSupported({}, 'linux', null)).toBe('boolean')
   })
 
-  it('is false pointed at a runtime dir with no reachable user bus', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'xdg-runtime-'))
-    try {
-      // No `bus` socket written under this fake runtime dir — the probe must fail closed.
-      expect(isDurableDaemonScopeSupported({ XDG_RUNTIME_DIR: dir }, 'linux')).toBe(false)
-    } finally {
-      rmSync(dir, { recursive: true, force: true })
-    }
+  it('is false when neither the canonical per-UID path nor the env path has a reachable bus', () => {
+    const canonical = fakeRuntimeDirWithoutBus()
+    const envDir = fakeRuntimeDirWithoutBus()
+    // Neither fixture has a `bus` socket written — the probe must fail closed regardless of
+    // which path it looks at first.
+    expect(isDurableDaemonScopeSupported({ XDG_RUNTIME_DIR: envDir }, 'linux', canonical)).toBe(
+      false
+    )
+  })
+
+  it('is true when the process env XDG_RUNTIME_DIR is a hardened unit override, but the real per-UID dir has a reachable bus (mtl-02 regression)', () => {
+    // Simulates orca-serve@factory.service's RuntimeDirectory=factory hardening directive:
+    // the process's own XDG_RUNTIME_DIR points at a private scratch dir that is NOT the user
+    // session bus location, while the real per-UID runtime dir (injected here in place of the
+    // real /run/user/<uid>) has a genuinely reachable bus the whole time.
+    const hardenedOverrideDir = fakeRuntimeDirWithoutBus()
+    const realPerUidDir = fakeRuntimeDirWithBus()
+    expect(
+      isDurableDaemonScopeSupported(
+        { XDG_RUNTIME_DIR: hardenedOverrideDir },
+        'linux',
+        realPerUidDir
+      )
+    ).toBe(true)
+  })
+
+  it('is true when the caller env XDG_RUNTIME_DIR already points at the correct, reachable per-UID bus', () => {
+    const perUidDir = fakeRuntimeDirWithBus()
+    expect(isDurableDaemonScopeSupported({ XDG_RUNTIME_DIR: perUidDir }, 'linux', perUidDir)).toBe(
+      true
+    )
+  })
+
+  it('falls back to the process env XDG_RUNTIME_DIR when the canonical per-UID path has no reachable bus', () => {
+    // Some hosts legitimately have no /run/user/<uid> at all but do have a working bus
+    // wherever their own environment points — the probe must still support that host.
+    const canonicalWithoutBus = fakeRuntimeDirWithoutBus()
+    const envDirWithBus = fakeRuntimeDirWithBus()
+    expect(
+      isDurableDaemonScopeSupported(
+        { XDG_RUNTIME_DIR: envDirWithBus },
+        'linux',
+        canonicalWithoutBus
+      )
+    ).toBe(true)
   })
 })
 
@@ -53,7 +124,8 @@ describe('buildDurableDaemonScopeCommand', () => {
       '/usr/bin/node',
       ['/opt/orca/daemon-entry.js', '--socket', '/tmp/x.sock'],
       'nonce-1',
-      { PATH: '/usr/bin' }
+      { PATH: '/usr/bin' },
+      null
     )
     expect(result.command).toBe('systemd-run')
     expect(result.args).toEqual([
@@ -70,17 +142,43 @@ describe('buildDurableDaemonScopeCommand', () => {
     ])
   })
 
-  it('preserves an explicit XDG_RUNTIME_DIR from the caller env', () => {
-    const result = buildDurableDaemonScopeCommand('/usr/bin/node', [], 'n', {
-      PATH: '/bin',
-      XDG_RUNTIME_DIR: '/run/user/9999'
-    })
-    expect(result.env.XDG_RUNTIME_DIR).toBe('/run/user/9999')
+  it('prefers the canonical per-UID runtime dir over a hardened unit-overridden XDG_RUNTIME_DIR (mtl-02 regression)', () => {
+    const hardenedOverrideDir = fakeRuntimeDirWithoutBus()
+    const realPerUidDir = fakeRuntimeDirWithBus()
+    const result = buildDurableDaemonScopeCommand(
+      '/usr/bin/node',
+      [],
+      'n',
+      { PATH: '/bin', XDG_RUNTIME_DIR: hardenedOverrideDir },
+      realPerUidDir
+    )
+    // Explicitly the real per-UID dir, not inherited from the spread env's overridden value.
+    expect(result.env.XDG_RUNTIME_DIR).toBe(realPerUidDir)
+  })
+
+  it('falls back to the caller XDG_RUNTIME_DIR when the canonical per-UID path has no reachable bus', () => {
+    const canonicalWithoutBus = fakeRuntimeDirWithoutBus()
+    const envDirWithBus = fakeRuntimeDirWithBus()
+    const result = buildDurableDaemonScopeCommand(
+      '/usr/bin/node',
+      [],
+      'n',
+      { PATH: '/bin', XDG_RUNTIME_DIR: envDirWithBus },
+      canonicalWithoutBus
+    )
+    expect(result.env.XDG_RUNTIME_DIR).toBe(envDirWithBus)
   })
 
   it('computes the conventional /run/user/<uid> runtime dir when the caller env omits it', () => {
-    const result = buildDurableDaemonScopeCommand('/usr/bin/node', [], 'n', { PATH: '/bin' })
-    expect(result.env.XDG_RUNTIME_DIR).toBe(`/run/user/${process.getuid?.() ?? ''}`)
+    const perUidDir = fakeRuntimeDirWithBus()
+    const result = buildDurableDaemonScopeCommand(
+      '/usr/bin/node',
+      [],
+      'n',
+      { PATH: '/bin' },
+      perUidDir
+    )
+    expect(result.env.XDG_RUNTIME_DIR).toBe(perUidDir)
   })
 })
 

--- a/src/main/daemon/daemon-cgroup-scope.ts
+++ b/src/main/daemon/daemon-cgroup-scope.ts
@@ -15,12 +15,15 @@
  * `loginctl enable-linger <user>` for a service account). Everywhere else keeps the direct-fork
  * launch, so this module fails closed to "not supported" rather than guessing.
  */
-import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { runProcessSync } from '../../shared/child-process/run-process'
 
 const SYSTEMD_RUN_BINARY = 'systemd-run'
 const UNIT_NAME_PREFIX = 'orca-daemon-'
+/** Long enough for a local binary to print its version, short enough that a wedged systemd
+ *  cannot stall the launch lane. */
+const SYSTEMD_RUN_PROBE_TIMEOUT_MS = 2_000
 
 /** The conventional per-UID runtime dir every login session (and `loginctl enable-linger`)
  *  provisions, from `getuid()` rather than from the environment. The exported functions'
@@ -69,6 +72,11 @@ function resolveUserRuntimeDir(env: NodeJS.ProcessEnv, canonicalDir: string | nu
 /**
  * Best-effort, side-effect-free capability probe. Never throws; any uncertainty resolves to
  * "not supported" so the caller falls back to the existing, already-proven direct-fork launch.
+ *
+ * Stays synchronous: `launchDaemonChild` attaches the readiness listener in the same tick it is
+ * called, and an await here would move the spawn past that tick. The child-process chokepoint
+ * covers this shape with `runProcessSync` (as `isPwshAvailable` does) so the probe still gets
+ * the shared spawn decisions instead of re-deciding them with `execFileSync`.
  */
 export function isDurableDaemonScopeSupported(
   env: NodeJS.ProcessEnv = process.env,
@@ -89,11 +97,19 @@ export function isDurableDaemonScopeSupported(
     return false
   }
   try {
-    execFileSync(SYSTEMD_RUN_BINARY, ['--version'], { stdio: 'ignore', timeout: 2_000 })
+    const probe = runProcessSync({
+      program: SYSTEMD_RUN_BINARY,
+      args: ['--version'],
+      stdio: 'ignore',
+      timeoutMs: SYSTEMD_RUN_PROBE_TIMEOUT_MS
+    })
+    // A non-zero exit is data here rather than a throw, and a timeout kill leaves an exit behind
+    // that answers nothing — both mean "cannot be trusted to place the daemon in a scope".
+    return probe.code === 0 && !probe.timedOut
   } catch {
+    // Throws only when the binary could not be started at all.
     return false
   }
-  return true
 }
 
 export type DurableDaemonScopeCommand = {

--- a/src/main/daemon/daemon-cgroup-scope.ts
+++ b/src/main/daemon/daemon-cgroup-scope.ts
@@ -28,7 +28,7 @@
  * fails closed to "not supported" rather than guessing.
  */
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 const SYSTEMD_RUN_BINARY = 'systemd-run'
@@ -40,16 +40,11 @@ export function daemonScopeUnitName(launchNonce: string): string {
   return `${UNIT_NAME_PREFIX}${launchNonce.replace(/[^A-Za-z0-9:_.-]/g, '-')}`
 }
 
-function resolveUserRuntimeDir(env: NodeJS.ProcessEnv): string | null {
-  if (env.XDG_RUNTIME_DIR) {
-    return env.XDG_RUNTIME_DIR
-  }
-  // Why not just trust the env: a service unit does not automatically inherit
-  // XDG_RUNTIME_DIR from logind unless the unit file sets it explicitly. The conventional
-  // path below is what `loginctl enable-linger <user>` provisions regardless, and this
-  // codebase already has direct operational precedent for computing it by hand (see the
-  // mtl-02 restart-recovery record: "XDG_RUNTIME_DIR wasn't exported ... retried with
-  // export XDG_RUNTIME_DIR=/run/user/$(id -u)").
+/** The conventional per-UID runtime dir that `loginctl enable-linger <user>` (and every normal
+ *  login session) provisions, computed independently of any environment variable. `canonicalDir`
+ *  parameters elsewhere default to calling this so production always uses the real value; tests
+ *  inject a fake path instead. */
+function canonicalUserRuntimeDir(): string | null {
   if (typeof process.getuid !== 'function') {
     return null
   }
@@ -60,13 +55,58 @@ function resolveUserRuntimeDir(env: NodeJS.ProcessEnv): string | null {
   }
 }
 
+/** Why `statSync(...).isSocket()` instead of `existsSync`: a stale regular file or leftover
+ *  directory left behind at `bus` would pass an `existsSync` check but can never be dialed as a
+ *  D-Bus socket. This is the cheapest side-effect-free approximation of "connectable" available
+ *  without actually opening a D-Bus connection (this probe must stay side-effect-free). */
+function hasReachableBus(runtimeDir: string): boolean {
+  try {
+    return statSync(join(runtimeDir, 'bus')).isSocket()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolves the `XDG_RUNTIME_DIR` that actually hosts this OS user's systemd `--user` bus.
+ *
+ * Deliberately does NOT start from the current process's own `XDG_RUNTIME_DIR` env var. Ground
+ * truth from mtl-02: `orca-serve@factory.service` sets `RuntimeDirectory=factory`, a hardening
+ * directive that makes systemd export `XDG_RUNTIME_DIR=/run/orca_serve/factory` into the unit's
+ * own process — a private scratch directory that shares the env var's name but has nothing to do
+ * with the user session bus. `/proc/<pid>/environ` on that host showed exactly that path and
+ * `DBUS_SESSION_BUS_ADDRESS=disabled:`, while the real bus was reachable the whole time under
+ * `/run/user/985` (confirmed via `systemctl --user is-system-running` with that dir exported by
+ * hand). Trusting the process's own env var here made the probe report "unsupported" on every
+ * host hardened this way, even though a real per-UID bus was one directory away. So the
+ * conventional per-UID path is always tried first; the process's own `XDG_RUNTIME_DIR` is only a
+ * fallback for hosts that legitimately have no `/run/user/<uid>` at all (non-standard runtime
+ * layouts) but do have a working bus wherever their own environment happens to point.
+ *
+ * `canonicalDir` is injectable for tests; production callers let it default to the real
+ * `/run/user/<uid>` computed from this process's own `getuid()`.
+ */
+function resolveUserRuntimeDir(
+  env: NodeJS.ProcessEnv,
+  canonicalDir: string | null = canonicalUserRuntimeDir()
+): string | null {
+  if (canonicalDir && hasReachableBus(canonicalDir)) {
+    return canonicalDir
+  }
+  if (env.XDG_RUNTIME_DIR && hasReachableBus(env.XDG_RUNTIME_DIR)) {
+    return env.XDG_RUNTIME_DIR
+  }
+  return null
+}
+
 /**
  * Best-effort, side-effect-free capability probe. Never throws; any uncertainty resolves to
  * "not supported" so the caller falls back to the existing, already-proven direct-fork launch.
  */
 export function isDurableDaemonScopeSupported(
   env: NodeJS.ProcessEnv = process.env,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  canonicalRuntimeDir: string | null = canonicalUserRuntimeDir()
 ): boolean {
   if (platform !== 'linux') {
     return false
@@ -76,9 +116,9 @@ export function isDurableDaemonScopeSupported(
     // restart isn't the failure mode there, and systemd-run has nothing to talk to anyway.
     return false
   }
-  const runtimeDir = resolveUserRuntimeDir(env)
-  if (!runtimeDir || !existsSync(join(runtimeDir, 'bus'))) {
-    // No reachable user bus/session — systemd-run --user would just fail to connect.
+  if (!resolveUserRuntimeDir(env, canonicalRuntimeDir)) {
+    // No reachable user bus/session at the real per-UID path or the process's own env var —
+    // systemd-run --user would just fail to connect.
     return false
   }
   try {
@@ -104,9 +144,10 @@ export function buildDurableDaemonScopeCommand(
   execPath: string,
   scriptArgs: string[],
   launchNonce: string,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  canonicalRuntimeDir: string | null = canonicalUserRuntimeDir()
 ): DurableDaemonScopeCommand {
-  const runtimeDir = resolveUserRuntimeDir(env)
+  const runtimeDir = resolveUserRuntimeDir(env, canonicalRuntimeDir)
   return {
     command: SYSTEMD_RUN_BINARY,
     args: [
@@ -119,6 +160,9 @@ export function buildDurableDaemonScopeCommand(
       execPath,
       ...scriptArgs
     ],
+    // Explicit, not inherited: the daemon must land in the same user manager the resolution
+    // above just confirmed is reachable, regardless of what this spread `env`'s own
+    // `XDG_RUNTIME_DIR` says (see `resolveUserRuntimeDir` for why that value can be wrong).
     env: runtimeDir ? { ...env, XDG_RUNTIME_DIR: runtimeDir } : { ...env }
   }
 }

--- a/src/main/daemon/daemon-cgroup-scope.ts
+++ b/src/main/daemon/daemon-cgroup-scope.ts
@@ -4,8 +4,9 @@
  * `detached: true` buys the daemon its own POSIX process group, not its own cgroup: under a
  * combined unit (`orca-serve.service` / `orca-serve@<slot>`) it and its PTYs stay in the unit's
  * cgroup, and `systemctl stop`/`restart` SIGKILLs whatever is left there — immediately under
- * `KillMode=control-group`, at the stop timeout under `mixed`. Either way every live terminal
- * dies, however well the daemon otherwise survives its parent.
+ * `KillMode=control-group`, and the instant the main process exits under `KillMode=mixed`
+ * (`TimeoutStopSec` only applies while that main process is still alive). Either way every
+ * live terminal dies, however well the daemon otherwise survives its parent.
  *
  * `systemd-run --user --scope` registers a transient scope under the invoking user's own systemd
  * manager and execs the command into it, so the daemon's cgroup becomes a *sibling* of the
@@ -17,10 +18,13 @@
  */
 import { existsSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
-import { runProcessSync } from '../../shared/child-process/run-process'
+import { runProcessSync, type ProcessResult } from '../../shared/child-process/run-process'
 
 const SYSTEMD_RUN_BINARY = 'systemd-run'
 const UNIT_NAME_PREFIX = 'orca-daemon-'
+/** The marker that distinguishes "booted under systemd" from a plain container. A test seam so
+ *  the capability tests stay hermetic off a systemd host. */
+const SYSTEMD_BOOT_PATH = '/run/systemd/system'
 /** Long enough for a local binary to print its version, short enough that a wedged systemd
  *  cannot stall the launch lane. */
 const SYSTEMD_RUN_PROBE_TIMEOUT_MS = 2_000
@@ -77,16 +81,43 @@ function resolveUserRuntimeDir(env: NodeJS.ProcessEnv, canonicalDir: string | nu
  * called, and an await here would move the spawn past that tick. The child-process chokepoint
  * covers this shape with `runProcessSync` (as `isPwshAvailable` does) so the probe still gets
  * the shared spawn decisions instead of re-deciding them with `execFileSync`.
+ *
+ * `systemdBootPath` and `runVersionProbe` are test seams: they default to the real boot marker
+ * and `systemd-run --version` probe, and a test injects fakes so the capability probe never
+ * consults the host's own systemd.
  */
+
+/** The slice of `ProcessResult` the capability probe consumes; narrow so a test stub carries no
+ *  stdout/stderr/signal baggage. */
+type SystemdRunVersionProbe = (
+  binary: string,
+  timeoutMs: number
+) => Pick<ProcessResult, 'code' | 'timedOut'>
+
+function runSystemdRunVersionProbe(
+  binary: string,
+  timeoutMs: number
+): Pick<ProcessResult, 'code' | 'timedOut'> {
+  const { code, timedOut } = runProcessSync({
+    program: binary,
+    args: ['--version'],
+    stdio: 'ignore',
+    timeoutMs
+  })
+  return { code, timedOut }
+}
+
 export function isDurableDaemonScopeSupported(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
-  canonicalRuntimeDir: string | null = CANONICAL_USER_RUNTIME_DIR
+  canonicalRuntimeDir: string | null = CANONICAL_USER_RUNTIME_DIR,
+  systemdBootPath: string = SYSTEMD_BOOT_PATH,
+  runVersionProbe: SystemdRunVersionProbe = runSystemdRunVersionProbe
 ): boolean {
   if (platform !== 'linux') {
     return false
   }
-  if (!existsSync('/run/systemd/system')) {
+  if (!existsSync(systemdBootPath)) {
     // Not booted under systemd (e.g. a plain container without systemd as PID 1) — a unit
     // restart isn't the failure mode there, and systemd-run has nothing to talk to anyway.
     return false
@@ -97,12 +128,7 @@ export function isDurableDaemonScopeSupported(
     return false
   }
   try {
-    const probe = runProcessSync({
-      program: SYSTEMD_RUN_BINARY,
-      args: ['--version'],
-      stdio: 'ignore',
-      timeoutMs: SYSTEMD_RUN_PROBE_TIMEOUT_MS
-    })
+    const probe = runVersionProbe(SYSTEMD_RUN_BINARY, SYSTEMD_RUN_PROBE_TIMEOUT_MS)
     // A non-zero exit is data here rather than a throw, and a timeout kill leaves an exit behind
     // that answers nothing — both mean "cannot be trusted to place the daemon in a scope".
     return probe.code === 0 && !probe.timedOut

--- a/src/main/daemon/daemon-cgroup-scope.ts
+++ b/src/main/daemon/daemon-cgroup-scope.ts
@@ -1,0 +1,156 @@
+/**
+ * Escaping the service cgroup for the detached PTY daemon.
+ *
+ * `daemon-launched-child.ts` forks the daemon with `detached: true`, which gives it its own
+ * POSIX process group (setsid) so it survives its parent's process-group signals. That is not
+ * cgroup isolation: under a combined systemd unit (`orca-serve.service` / `orca-serve@<slot>`),
+ * the daemon and every PTY it owns remain in the unit's cgroup. `KillMode=mixed` sends the
+ * graceful stop signal only to the unit's main process, but at the stop timeout it falls back to
+ * `SIGKILL`-ing every process still in the cgroup — the daemon and its PTYs included.
+ * `KillMode=control-group` is worse: the whole cgroup is signalled immediately. Either way, a
+ * `systemctl stop`/`restart` of the combined unit destroys every live terminal, even though the
+ * daemon is otherwise built to survive its parent (see `daemon-launched-child.ts`,
+ * `daemon-provider-init.ts`'s "adopt, don't replace" logic, and `orcad-entry.ts`'s
+ * `refreshRestoredOrchestrationAuthority`/`reconcileLegacyWorkerTerminals` re-adoption path).
+ *
+ * The fix is to put the daemon in a cgroup that is a *sibling* of the service unit's cgroup, not
+ * a descendant of it, so systemd's unit-scoped kill (whichever `KillMode`) never reaches it.
+ * `systemd-run --user --scope` does exactly this: it registers a transient scope unit under the
+ * invoking OS user's own systemd user manager and execs the target command into it. The daemon
+ * keeps running after the transient scope's `--collect` flag lets systemd forget the unit once it
+ * exits, so this does not accumulate unit-table state over time.
+ *
+ * This only works when there is a systemd instance to ask: PID 1 must be systemd (so a restart of
+ * *some* unit is even a meaningful concept), and the OS user must have a reachable `--user`
+ * manager (an active login session, or `loginctl enable-linger <user>` for a service account with
+ * no interactive session). Every other platform, and every Linux host without that user manager
+ * reachable, must fall back to the existing direct-fork behavior unchanged — this module always
+ * fails closed to "not supported" rather than guessing.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const SYSTEMD_RUN_BINARY = 'systemd-run'
+const UNIT_NAME_PREFIX = 'orca-daemon-'
+
+/** systemd unit names are restricted to `[A-Za-z0-9:_.\-@]`; sanitize defensively even though
+ *  `launchNonce` is already a UUID (hyphens and hex digits only). */
+export function daemonScopeUnitName(launchNonce: string): string {
+  return `${UNIT_NAME_PREFIX}${launchNonce.replace(/[^A-Za-z0-9:_.-]/g, '-')}`
+}
+
+function resolveUserRuntimeDir(env: NodeJS.ProcessEnv): string | null {
+  if (env.XDG_RUNTIME_DIR) {
+    return env.XDG_RUNTIME_DIR
+  }
+  // Why not just trust the env: a service unit does not automatically inherit
+  // XDG_RUNTIME_DIR from logind unless the unit file sets it explicitly. The conventional
+  // path below is what `loginctl enable-linger <user>` provisions regardless, and this
+  // codebase already has direct operational precedent for computing it by hand (see the
+  // mtl-02 restart-recovery record: "XDG_RUNTIME_DIR wasn't exported ... retried with
+  // export XDG_RUNTIME_DIR=/run/user/$(id -u)").
+  if (typeof process.getuid !== 'function') {
+    return null
+  }
+  try {
+    return `/run/user/${process.getuid()}`
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Best-effort, side-effect-free capability probe. Never throws; any uncertainty resolves to
+ * "not supported" so the caller falls back to the existing, already-proven direct-fork launch.
+ */
+export function isDurableDaemonScopeSupported(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  if (platform !== 'linux') {
+    return false
+  }
+  if (!existsSync('/run/systemd/system')) {
+    // Not booted under systemd (e.g. a plain container without systemd as PID 1) — a unit
+    // restart isn't the failure mode there, and systemd-run has nothing to talk to anyway.
+    return false
+  }
+  const runtimeDir = resolveUserRuntimeDir(env)
+  if (!runtimeDir || !existsSync(join(runtimeDir, 'bus'))) {
+    // No reachable user bus/session — systemd-run --user would just fail to connect.
+    return false
+  }
+  try {
+    execFileSync(SYSTEMD_RUN_BINARY, ['--version'], { stdio: 'ignore', timeout: 2_000 })
+  } catch {
+    return false
+  }
+  return true
+}
+
+export type DurableDaemonScopeCommand = {
+  command: string
+  args: string[]
+  env: NodeJS.ProcessEnv
+}
+
+/**
+ * Wraps the daemon's real command line in `systemd-run --user --scope`, so the process that
+ * ultimately execs into `execPath forkEntryPath ...scriptArgs` lands in its own transient scope
+ * cgroup instead of inheriting the caller's.
+ */
+export function buildDurableDaemonScopeCommand(
+  execPath: string,
+  scriptArgs: string[],
+  launchNonce: string,
+  env: NodeJS.ProcessEnv
+): DurableDaemonScopeCommand {
+  const runtimeDir = resolveUserRuntimeDir(env)
+  return {
+    command: SYSTEMD_RUN_BINARY,
+    args: [
+      '--user',
+      '--scope',
+      `--unit=${daemonScopeUnitName(launchNonce)}`,
+      '--collect',
+      '--quiet',
+      '--',
+      execPath,
+      ...scriptArgs
+    ],
+    env: runtimeDir ? { ...env, XDG_RUNTIME_DIR: runtimeDir } : { ...env }
+  }
+}
+
+/**
+ * Ground truth, read from the process's own cgroup membership rather than trusted from the
+ * launcher's intent — a daemon that fell back (or was adopted from before this fix existed)
+ * must not misreport isolation it does not actually have. Returns the owning unit name (e.g.
+ * `orca-daemon-<nonce>.scope`) when isolated, or `null` when running in the parent's service
+ * unit, on a non-Linux platform, or when cgroup membership cannot be determined.
+ */
+export function detectOwnCgroupScopeUnit(
+  platform: NodeJS.Platform = process.platform,
+  cgroupPath = '/proc/self/cgroup'
+): string | null {
+  if (platform !== 'linux') {
+    return null
+  }
+  let contents: string
+  try {
+    contents = readFileSync(cgroupPath, 'utf8')
+  } catch {
+    return null
+  }
+  for (const line of contents.split('\n')) {
+    // cgroup v2 unified hierarchy: "0::/user.slice/.../orca-daemon-<nonce>.scope"
+    // cgroup v1 systemd controller: "1:name=systemd:/user.slice/.../orca-daemon-<nonce>.scope"
+    const segments = line.split('/')
+    const last = segments.at(-1)?.trim()
+    if (last && last.startsWith(UNIT_NAME_PREFIX) && last.endsWith('.scope')) {
+      return last
+    }
+  }
+  return null
+}

--- a/src/main/daemon/daemon-cgroup-scope.ts
+++ b/src/main/daemon/daemon-cgroup-scope.ts
@@ -1,31 +1,19 @@
 /**
  * Escaping the service cgroup for the detached PTY daemon.
  *
- * `daemon-launched-child.ts` forks the daemon with `detached: true`, which gives it its own
- * POSIX process group (setsid) so it survives its parent's process-group signals. That is not
- * cgroup isolation: under a combined systemd unit (`orca-serve.service` / `orca-serve@<slot>`),
- * the daemon and every PTY it owns remain in the unit's cgroup. `KillMode=mixed` sends the
- * graceful stop signal only to the unit's main process, but at the stop timeout it falls back to
- * `SIGKILL`-ing every process still in the cgroup — the daemon and its PTYs included.
- * `KillMode=control-group` is worse: the whole cgroup is signalled immediately. Either way, a
- * `systemctl stop`/`restart` of the combined unit destroys every live terminal, even though the
- * daemon is otherwise built to survive its parent (see `daemon-launched-child.ts`,
- * `daemon-provider-init.ts`'s "adopt, don't replace" logic, and `orcad-entry.ts`'s
- * `refreshRestoredOrchestrationAuthority`/`reconcileLegacyWorkerTerminals` re-adoption path).
+ * `detached: true` buys the daemon its own POSIX process group, not its own cgroup: under a
+ * combined unit (`orca-serve.service` / `orca-serve@<slot>`) it and its PTYs stay in the unit's
+ * cgroup, and `systemctl stop`/`restart` SIGKILLs whatever is left there — immediately under
+ * `KillMode=control-group`, at the stop timeout under `mixed`. Either way every live terminal
+ * dies, however well the daemon otherwise survives its parent.
  *
- * The fix is to put the daemon in a cgroup that is a *sibling* of the service unit's cgroup, not
- * a descendant of it, so systemd's unit-scoped kill (whichever `KillMode`) never reaches it.
- * `systemd-run --user --scope` does exactly this: it registers a transient scope unit under the
- * invoking OS user's own systemd user manager and execs the target command into it. The daemon
- * keeps running after the transient scope's `--collect` flag lets systemd forget the unit once it
- * exits, so this does not accumulate unit-table state over time.
+ * `systemd-run --user --scope` registers a transient scope under the invoking user's own systemd
+ * manager and execs the command into it, so the daemon's cgroup becomes a *sibling* of the
+ * unit's that no unit-scoped kill reaches; `--collect` drops the unit once it exits.
  *
- * This only works when there is a systemd instance to ask: PID 1 must be systemd (so a restart of
- * *some* unit is even a meaningful concept), and the OS user must have a reachable `--user`
- * manager (an active login session, or `loginctl enable-linger <user>` for a service account with
- * no interactive session). Every other platform, and every Linux host without that user manager
- * reachable, must fall back to the existing direct-fork behavior unchanged — this module always
- * fails closed to "not supported" rather than guessing.
+ * That needs systemd as PID 1 and a reachable `--user` manager (a login session, or
+ * `loginctl enable-linger <user>` for a service account). Everywhere else keeps the direct-fork
+ * launch, so this module fails closed to "not supported" rather than guessing.
  */
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, statSync } from 'node:fs'
@@ -34,31 +22,21 @@ import { join } from 'node:path'
 const SYSTEMD_RUN_BINARY = 'systemd-run'
 const UNIT_NAME_PREFIX = 'orca-daemon-'
 
+/** The conventional per-UID runtime dir every login session (and `loginctl enable-linger`)
+ *  provisions, from `getuid()` rather than from the environment. The exported functions'
+ *  `canonicalRuntimeDir` parameters default to this so production uses the real path; tests
+ *  inject a fake one. */
+const CANONICAL_USER_RUNTIME_DIR =
+  typeof process.getuid === 'function' ? `/run/user/${process.getuid()}` : null
+
 /** systemd unit names are restricted to `[A-Za-z0-9:_.\-@]`; sanitize defensively even though
  *  `launchNonce` is already a UUID (hyphens and hex digits only). */
 export function daemonScopeUnitName(launchNonce: string): string {
   return `${UNIT_NAME_PREFIX}${launchNonce.replace(/[^A-Za-z0-9:_.-]/g, '-')}`
 }
 
-/** The conventional per-UID runtime dir that `loginctl enable-linger <user>` (and every normal
- *  login session) provisions, computed independently of any environment variable. `canonicalDir`
- *  parameters elsewhere default to calling this so production always uses the real value; tests
- *  inject a fake path instead. */
-function canonicalUserRuntimeDir(): string | null {
-  if (typeof process.getuid !== 'function') {
-    return null
-  }
-  try {
-    return `/run/user/${process.getuid()}`
-  } catch {
-    return null
-  }
-}
-
-/** Why `statSync(...).isSocket()` instead of `existsSync`: a stale regular file or leftover
- *  directory left behind at `bus` would pass an `existsSync` check but can never be dialed as a
- *  D-Bus socket. This is the cheapest side-effect-free approximation of "connectable" available
- *  without actually opening a D-Bus connection (this probe must stay side-effect-free). */
+/** `isSocket()`, not `existsSync()`: a stale file or leftover directory at `bus` can never be
+ *  dialed as one. Cheapest approximation of "connectable" that keeps this probe side-effect-free. */
 function hasReachableBus(runtimeDir: string): boolean {
   try {
     return statSync(join(runtimeDir, 'bus')).isSocket()
@@ -68,28 +46,17 @@ function hasReachableBus(runtimeDir: string): boolean {
 }
 
 /**
- * Resolves the `XDG_RUNTIME_DIR` that actually hosts this OS user's systemd `--user` bus.
+ * The `XDG_RUNTIME_DIR` that actually hosts this OS user's systemd `--user` bus: the canonical
+ * per-UID path first, the process's own env var only as a fallback.
  *
- * Deliberately does NOT start from the current process's own `XDG_RUNTIME_DIR` env var. Ground
- * truth from mtl-02: `orca-serve@factory.service` sets `RuntimeDirectory=factory`, a hardening
- * directive that makes systemd export `XDG_RUNTIME_DIR=/run/orca_serve/factory` into the unit's
- * own process — a private scratch directory that shares the env var's name but has nothing to do
- * with the user session bus. `/proc/<pid>/environ` on that host showed exactly that path and
- * `DBUS_SESSION_BUS_ADDRESS=disabled:`, while the real bus was reachable the whole time under
- * `/run/user/985` (confirmed via `systemctl --user is-system-running` with that dir exported by
- * hand). Trusting the process's own env var here made the probe report "unsupported" on every
- * host hardened this way, even though a real per-UID bus was one directory away. So the
- * conventional per-UID path is always tried first; the process's own `XDG_RUNTIME_DIR` is only a
- * fallback for hosts that legitimately have no `/run/user/<uid>` at all (non-standard runtime
- * layouts) but do have a working bus wherever their own environment happens to point.
- *
- * `canonicalDir` is injectable for tests; production callers let it default to the real
- * `/run/user/<uid>` computed from this process's own `getuid()`.
+ * Why not that env var first: `RuntimeDirectory=` hardening (`orca-serve@factory.service` on
+ * mtl-02) makes systemd export `XDG_RUNTIME_DIR=/run/orca_serve/<slot>`, a private scratch dir
+ * that shares the name but hosts no bus, alongside `DBUS_SESSION_BUS_ADDRESS=disabled:` — while
+ * the real bus was live at `/run/user/<uid>` the whole time. Trusting the env var reported
+ * "unsupported" on every host hardened that way. It stays as the fallback for hosts that have no
+ * `/run/user/<uid>` but do have a working bus wherever they point.
  */
-function resolveUserRuntimeDir(
-  env: NodeJS.ProcessEnv,
-  canonicalDir: string | null = canonicalUserRuntimeDir()
-): string | null {
+function resolveUserRuntimeDir(env: NodeJS.ProcessEnv, canonicalDir: string | null): string | null {
   if (canonicalDir && hasReachableBus(canonicalDir)) {
     return canonicalDir
   }
@@ -106,7 +73,7 @@ function resolveUserRuntimeDir(
 export function isDurableDaemonScopeSupported(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,
-  canonicalRuntimeDir: string | null = canonicalUserRuntimeDir()
+  canonicalRuntimeDir: string | null = CANONICAL_USER_RUNTIME_DIR
 ): boolean {
   if (platform !== 'linux') {
     return false
@@ -145,7 +112,7 @@ export function buildDurableDaemonScopeCommand(
   scriptArgs: string[],
   launchNonce: string,
   env: NodeJS.ProcessEnv,
-  canonicalRuntimeDir: string | null = canonicalUserRuntimeDir()
+  canonicalRuntimeDir: string | null = CANONICAL_USER_RUNTIME_DIR
 ): DurableDaemonScopeCommand {
   const runtimeDir = resolveUserRuntimeDir(env, canonicalRuntimeDir)
   return {
@@ -168,11 +135,10 @@ export function buildDurableDaemonScopeCommand(
 }
 
 /**
- * Ground truth, read from the process's own cgroup membership rather than trusted from the
- * launcher's intent — a daemon that fell back (or was adopted from before this fix existed)
- * must not misreport isolation it does not actually have. Returns the owning unit name (e.g.
- * `orca-daemon-<nonce>.scope`) when isolated, or `null` when running in the parent's service
- * unit, on a non-Linux platform, or when cgroup membership cannot be determined.
+ * The daemon's own cgroup membership, read from /proc rather than trusted from the launcher's
+ * intent, so a daemon that fell back (or was adopted from before this fix) cannot misreport
+ * isolation it does not have. The owning unit name when isolated; null when it sits in the
+ * parent's service unit, is not on Linux, or has unreadable cgroup membership.
  */
 export function detectOwnCgroupScopeUnit(
   platform: NodeJS.Platform = process.platform,
@@ -190,8 +156,7 @@ export function detectOwnCgroupScopeUnit(
   for (const line of contents.split('\n')) {
     // cgroup v2 unified hierarchy: "0::/user.slice/.../orca-daemon-<nonce>.scope"
     // cgroup v1 systemd controller: "1:name=systemd:/user.slice/.../orca-daemon-<nonce>.scope"
-    const segments = line.split('/')
-    const last = segments.at(-1)?.trim()
+    const last = line.split('/').at(-1)?.trim()
     if (last && last.startsWith(UNIT_NAME_PREFIX) && last.endsWith('.scope')) {
       return last
     }

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -13,6 +13,7 @@ import { warmWindowsConptyOnce } from './windows-conpty-warmup'
 import { warmPwshAvailabilityCache } from '../pwsh'
 import { createDaemonFileLog, createNoopDaemonFileLog } from './daemon-file-log'
 import { PROTOCOL_VERSION } from './types'
+import { detectOwnCgroupScopeUnit } from './daemon-cgroup-scope'
 import {
   DAEMON_EXIT_ENDPOINT_OCCUPIED,
   DaemonEndpointUnavailableError
@@ -273,6 +274,10 @@ async function main(): Promise<void> {
               ...(entryPath ? { entryPath } : {}),
               ...(appVersion ? { appVersion } : {}),
               ...(spawnerExecPath ? { spawnerExecPath } : {}),
+              // Why detect rather than trust the launcher's intent: this is the ground truth of
+              // where the daemon's own cgroup landed, verified from inside the process that
+              // matters. See daemon-cgroup-scope.ts.
+              cgroupUnit: detectOwnCgroupScopeUnit(),
               launchNonce
             })
         }

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -269,7 +269,6 @@ async function main(): Promise<void> {
       ? {
           publishEndpointOwnership: () =>
             publishDaemonPidFile(pidPath, {
-              pid: process.pid,
               ...readyIdentity,
               ...(entryPath ? { entryPath } : {}),
               ...(appVersion ? { appVersion } : {}),

--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -206,7 +206,8 @@ describe('parseDaemonPidFile', () => {
       launchNonce: null,
       linuxStartTicks: null,
       bootId: null,
-      spawnerExecPath: null
+      spawnerExecPath: null,
+      cgroupUnit: null
     })
   })
 
@@ -225,7 +226,8 @@ describe('parseDaemonPidFile', () => {
       launchNonce: null,
       linuxStartTicks: null,
       bootId: null,
-      spawnerExecPath: null
+      spawnerExecPath: null,
+      cgroupUnit: null
     })
   })
 
@@ -255,7 +257,8 @@ describe('parseDaemonPidFile', () => {
       launchNonce: null,
       linuxStartTicks: null,
       bootId: null,
-      spawnerExecPath: null
+      spawnerExecPath: null,
+      cgroupUnit: null
     })
   })
 
@@ -271,7 +274,8 @@ describe('parseDaemonPidFile', () => {
       launchNonce: null,
       linuxStartTicks: null,
       bootId: null,
-      spawnerExecPath: null
+      spawnerExecPath: null,
+      cgroupUnit: null
     })
     expect(parseDaemonPidFile('  12345\n')).toEqual({
       pid: 12345,
@@ -281,7 +285,8 @@ describe('parseDaemonPidFile', () => {
       launchNonce: null,
       linuxStartTicks: null,
       bootId: null,
-      spawnerExecPath: null
+      spawnerExecPath: null,
+      cgroupUnit: null
     })
   })
 

--- a/src/main/daemon/daemon-init-child-readiness.test.ts
+++ b/src/main/daemon/daemon-init-child-readiness.test.ts
@@ -69,6 +69,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
           queueMicrotask(() =>
             cb({
               type: 'ready',
+              pid: 12345,
               startedAtMs: 1_000_000,
               linuxStartTicks: '4242',
               bootId: 'boot-a'
@@ -129,7 +130,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },
@@ -185,7 +186,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       on(event: string, cb: (arg?: unknown) => void) {
         handlers[event]?.push(cb)
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },
@@ -222,7 +223,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_700_000_123_456 }))
+          queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_700_000_123_456 }))
         }
         return this
       },

--- a/src/main/daemon/daemon-init-child-startup-failure.test.ts
+++ b/src/main/daemon/daemon-init-child-startup-failure.test.ts
@@ -86,7 +86,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       on(event: string, callback: (arg?: unknown) => void) {
         handlers[event]?.push(callback)
         if (event === 'message') {
-          queueMicrotask(() => callback({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => callback({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },
@@ -168,7 +168,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       on(event: string, callback: (arg?: unknown) => void) {
         handlers[event]?.push(callback)
         if (event === 'message') {
-          queueMicrotask(() => callback({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => callback({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },
@@ -228,7 +228,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready' }))
+          queueMicrotask(() => cb({ type: 'ready', pid: 12345 }))
         }
         return this
       },

--- a/src/main/daemon/daemon-init-endpoint-adoption.test.ts
+++ b/src/main/daemon/daemon-init-endpoint-adoption.test.ts
@@ -77,7 +77,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         on(event: string, cb: (arg?: unknown) => void) {
           handlers[event]?.push(cb)
           if (event === 'message') {
-            queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+            queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
           }
           return this
         },
@@ -189,7 +189,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         on(event: string, cb: (arg?: unknown) => void) {
           handlers[event]?.push(cb)
           if (event === 'message') {
-            queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+            queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
           }
           return this
         },
@@ -512,7 +512,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
           exitHandlers.push(callback)
         }
         if (event === 'message') {
-          queueMicrotask(() => callback({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => callback({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },

--- a/src/main/daemon/daemon-init-live-session-preservation.test.ts
+++ b/src/main/daemon/daemon-init-live-session-preservation.test.ts
@@ -151,7 +151,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         on(event: string, cb: (arg?: unknown) => void) {
           handlers[event]?.push(cb)
           if (event === 'message') {
-            queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+            queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
           }
           return this
         },
@@ -371,7 +371,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },
@@ -415,7 +415,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         on(event: string, cb: (arg?: unknown) => void) {
           handlers[event]?.push(cb)
           if (event === 'message') {
-            queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+            queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
           }
           return this
         },

--- a/src/main/daemon/daemon-init-packaged-bundle-staleness.test.ts
+++ b/src/main/daemon/daemon-init-packaged-bundle-staleness.test.ts
@@ -103,7 +103,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         on(event: string, cb: (arg?: unknown) => void) {
           handlers[event]?.push(cb)
           if (event === 'message') {
-            queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+            queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
           }
           return this
         },

--- a/src/main/daemon/daemon-init-replacement-reporting.test.ts
+++ b/src/main/daemon/daemon-init-replacement-reporting.test.ts
@@ -75,7 +75,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         on(event: string, cb: (arg?: unknown) => void) {
           handlers[event]?.push(cb)
           if (event === 'message') {
-            queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+            queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
           }
           return this
         },
@@ -325,7 +325,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },

--- a/src/main/daemon/daemon-init-wedged-daemon-grace.test.ts
+++ b/src/main/daemon/daemon-init-wedged-daemon-grace.test.ts
@@ -151,7 +151,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },
@@ -273,7 +273,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },
@@ -409,7 +409,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() => cb({ type: 'ready', pid: 12345, startedAtMs: 1_000_000 }))
         }
         return this
       },

--- a/src/main/daemon/daemon-launched-child-identity.test.ts
+++ b/src/main/daemon/daemon-launched-child-identity.test.ts
@@ -1,0 +1,96 @@
+import type { ChildProcess } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { launchDaemonChild } from './daemon-launched-child'
+import type { DaemonChildSpawnOptions } from './daemon-launched-child-spawn'
+
+const { spawnDaemonChildProcessMock, isDurableDaemonScopeSupportedMock } = vi.hoisted(() => ({
+  spawnDaemonChildProcessMock: vi.fn(),
+  isDurableDaemonScopeSupportedMock: vi.fn(() => false)
+}))
+
+vi.mock('./daemon-launched-child-spawn', () => ({
+  spawnDaemonChildProcess: spawnDaemonChildProcessMock
+}))
+vi.mock('./daemon-cgroup-scope', () => ({
+  isDurableDaemonScopeSupported: isDurableDaemonScopeSupportedMock
+}))
+vi.mock('./daemon-spawner', () => ({ unlinkOwnedDaemonPidFile: vi.fn(() => true) }))
+
+type FakeDaemonChild = ChildProcess & { disconnect: Mock; unref: Mock }
+
+const LAUNCH_OPTIONS: DaemonChildSpawnOptions = {
+  entryPath: '/fake/app/out/main/daemon-entry.js',
+  forkEntryPath: '/fake/app/out/main/daemon-entry.js',
+  userDataPath: '/fake/userData',
+  socketPath: '/fake/socket',
+  tokenPath: '/fake/token',
+  pidPath: '/fake/daemon.pid',
+  launchNonce: 'nonce-a',
+  macosLoginSessionWatch: false
+}
+
+function fakeDaemonChild(pid: number): FakeDaemonChild {
+  const child = new EventEmitter() as unknown as FakeDaemonChild
+  return Object.assign(child, {
+    pid,
+    disconnect: vi.fn(),
+    unref: vi.fn(),
+    exitCode: null,
+    signalCode: null
+  })
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+  isDurableDaemonScopeSupportedMock.mockReturnValue(false)
+})
+
+describe('launchDaemonChild identity', () => {
+  it('takes the PID the daemon reports for itself, not the immediate child PID', async () => {
+    // The immediate child of a durable-scope launch is `systemd-run`, so its PID is only ever
+    // the daemon's by way of systemd-run's exec. The identity must not depend on that.
+    isDurableDaemonScopeSupportedMock.mockReturnValue(true)
+    const child = fakeDaemonChild(4242)
+    spawnDaemonChildProcessMock.mockReturnValue(child)
+
+    const launch = launchDaemonChild(LAUNCH_OPTIONS)
+    child.emit('message', {
+      type: 'ready',
+      pid: 9999,
+      startedAtMs: 1_700_000_000_000,
+      linuxStartTicks: '5150',
+      bootId: 'boot-a'
+    })
+    const launched = await launch
+
+    expect(spawnDaemonChildProcessMock).toHaveBeenCalledWith(LAUNCH_OPTIONS, true)
+    expect(launched.identity).toEqual({
+      pid: 9999,
+      startedAtMs: 1_700_000_000_000,
+      linuxStartTicks: '5150',
+      bootId: 'boot-a',
+      launchNonce: 'nonce-a'
+    })
+  })
+
+  it('rejects a readiness message that carries no self-reported PID', async () => {
+    const child = fakeDaemonChild(4242)
+    spawnDaemonChildProcessMock.mockReturnValue(child)
+    // The startup-failure path signals the child; keep that off any real PID.
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('already exited'), { code: 'ESRCH' })
+    })
+
+    try {
+      const launch = launchDaemonChild(LAUNCH_OPTIONS)
+      child.emit('message', { type: 'ready', startedAtMs: 1_700_000_000_000 })
+
+      await expect(launch).rejects.toThrow('Daemon readiness identity is incomplete')
+      expect(kill).toHaveBeenCalledWith(4242, 'SIGTERM')
+      expect(child.disconnect).not.toHaveBeenCalled()
+    } finally {
+      kill.mockRestore()
+    }
+  })
+})

--- a/src/main/daemon/daemon-launched-child-identity.test.ts
+++ b/src/main/daemon/daemon-launched-child-identity.test.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
+import { DAEMON_EXIT_ENDPOINT_OCCUPIED } from './daemon-endpoint-ownership'
 import { launchDaemonChild } from './daemon-launched-child'
 import type { DaemonChildSpawnOptions } from './daemon-launched-child-spawn'
 
@@ -17,7 +18,12 @@ vi.mock('./daemon-cgroup-scope', () => ({
 }))
 vi.mock('./daemon-spawner', () => ({ unlinkOwnedDaemonPidFile: vi.fn(() => true) }))
 
-type FakeDaemonChild = ChildProcess & { disconnect: Mock; unref: Mock }
+// exitCode is writable here: the launcher reads it to decide whether the child is already gone.
+type FakeDaemonChild = Omit<ChildProcess, 'exitCode'> & {
+  exitCode: number | null
+  disconnect: Mock
+  unref: Mock
+}
 
 const LAUNCH_OPTIONS: DaemonChildSpawnOptions = {
   entryPath: '/fake/app/out/main/daemon-entry.js',
@@ -43,6 +49,7 @@ function fakeDaemonChild(pid: number): FakeDaemonChild {
 
 afterEach(() => {
   vi.clearAllMocks()
+  spawnDaemonChildProcessMock.mockReset()
   isDurableDaemonScopeSupportedMock.mockReturnValue(false)
 })
 
@@ -92,5 +99,59 @@ describe('launchDaemonChild identity', () => {
     } finally {
       kill.mockRestore()
     }
+  })
+})
+
+describe('launchDaemonChild durable-scope fallback', () => {
+  it('retries once without cgroup isolation when the scoped attempt fails', async () => {
+    isDurableDaemonScopeSupportedMock.mockReturnValue(true)
+    const scoped = fakeDaemonChild(4242)
+    const unscoped = fakeDaemonChild(4343)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    spawnDaemonChildProcessMock.mockImplementation((_options, useDurableScope: boolean) => {
+      if (useDurableScope) {
+        // Whatever the pre-flight probe promised, the real StartTransientUnit call can still fail.
+        queueMicrotask(() => {
+          scoped.exitCode = 1
+          scoped.emit('exit', 1)
+        })
+        return scoped
+      }
+      queueMicrotask(() =>
+        unscoped.emit('message', { type: 'ready', pid: 4343, startedAtMs: 1_000_000 })
+      )
+      return unscoped
+    })
+
+    try {
+      const launched = await launchDaemonChild(LAUNCH_OPTIONS)
+
+      expect(spawnDaemonChildProcessMock.mock.calls.map(([, scope]) => scope)).toEqual([
+        true,
+        false
+      ])
+      expect(launched.identity.pid).toBe(4343)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('does not retry when another daemon already owns the endpoint', async () => {
+    // A lost endpoint race is not a scope failure: the caller adopts the winner, and a second
+    // child would only lose the same race.
+    isDurableDaemonScopeSupportedMock.mockReturnValue(true)
+    const scoped = fakeDaemonChild(4242)
+    spawnDaemonChildProcessMock.mockImplementation(() => {
+      queueMicrotask(() => {
+        scoped.exitCode = DAEMON_EXIT_ENDPOINT_OCCUPIED
+        scoped.emit('exit', DAEMON_EXIT_ENDPOINT_OCCUPIED)
+      })
+      return scoped
+    })
+
+    await expect(launchDaemonChild(LAUNCH_OPTIONS)).rejects.toThrow(
+      'Daemon could not take the endpoint: occupied'
+    )
+    expect(spawnDaemonChildProcessMock).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/daemon/daemon-launched-child-spawn.ts
+++ b/src/main/daemon/daemon-launched-child-spawn.ts
@@ -42,10 +42,12 @@ function buildDaemonScriptArgs(options: DaemonChildSpawnOptions): string[] {
  * long-standing direct `fork()` (own POSIX process group, same systemd cgroup as the caller).
  * `useDurableScope: true` wraps the identical command line in `systemd-run --user --scope` (see
  * daemon-cgroup-scope.ts) so the resulting process lands in a cgroup that is a sibling of the
- * caller's, not a descendant — spawned via `spawn()` rather than `fork()` because the immediate
- * child is `systemd-run`, not the daemon itself; `spawn()` supports the same `'ipc'` stdio
- * contract `fork()` does; whichever process the wrapper execs into inherits it and completes the
- * daemon's normal readiness handshake unchanged.
+ * caller's, not a descendant — spawned via `spawn()` rather than `fork()` because the launched
+ * binary is `systemd-run`, not a Node script; `spawn()` supports the same `'ipc'` stdio contract
+ * `fork()` does, and the process the wrapper execs into inherits it and completes the daemon's
+ * normal readiness handshake unchanged. Do not read the daemon's PID off this child: it is only
+ * the daemon's because systemd-run happens to `exec` in scope mode — the daemon reports its own
+ * PID in that handshake (see daemon-ready-identity.ts).
  */
 export function spawnDaemonChildProcess(
   options: DaemonChildSpawnOptions,

--- a/src/main/daemon/daemon-launched-child-spawn.ts
+++ b/src/main/daemon/daemon-launched-child-spawn.ts
@@ -1,4 +1,4 @@
-import { fork, spawn, type ChildProcess } from 'node:child_process'
+import { fork, spawn, type ChildProcess, type StdioOptions } from 'node:child_process'
 import { getAppEnvironment } from '../../shared/app-environment'
 import { buildDurableDaemonScopeCommand } from './daemon-cgroup-scope'
 import { daemonLogArgs } from './daemon-launch-paths'
@@ -38,16 +38,13 @@ function buildDaemonScriptArgs(options: DaemonChildSpawnOptions): string[] {
 }
 
 /**
- * The two ways the daemon's actual OS process comes into being. `useDurableScope: false` is the
- * long-standing direct `fork()` (own POSIX process group, same systemd cgroup as the caller).
- * `useDurableScope: true` wraps the identical command line in `systemd-run --user --scope` (see
- * daemon-cgroup-scope.ts) so the resulting process lands in a cgroup that is a sibling of the
- * caller's, not a descendant — spawned via `spawn()` rather than `fork()` because the launched
- * binary is `systemd-run`, not a Node script; `spawn()` supports the same `'ipc'` stdio contract
- * `fork()` does, and the process the wrapper execs into inherits it and completes the daemon's
- * normal readiness handshake unchanged. Do not read the daemon's PID off this child: it is only
- * the daemon's because systemd-run happens to `exec` in scope mode — the daemon reports its own
- * PID in that handshake (see daemon-ready-identity.ts).
+ * The two ways the daemon's OS process comes into being: the long-standing direct `fork()`, and
+ * (`useDurableScope`) the identical command line wrapped in `systemd-run --user --scope` so the
+ * daemon lands in a sibling cgroup instead of the caller's — see daemon-cgroup-scope.ts. The
+ * wrapper needs `spawn()` because it is not a Node script, but it takes the same `'ipc'` stdio
+ * contract and the process it execs into inherits the channel, so the readiness handshake is
+ * unchanged. Do not read the daemon's PID off the returned child; the daemon reports its own
+ * (see daemon-ready-identity.ts).
  */
 export function spawnDaemonChildProcess(
   options: DaemonChildSpawnOptions,
@@ -55,8 +52,6 @@ export function spawnDaemonChildProcess(
 ): ChildProcess {
   const { forkEntryPath, relocatedExecPath, userDataPath, launchNonce } = options
   const scriptArgs = buildDaemonScriptArgs(options)
-  // Why: detached daemons outlive dev worktrees; userData keeps process.cwd() valid after a repo/worktree is deleted.
-  // Why: detached+unref outlives Electron; stdout 'ignore' (else blocks exit), stderr 'pipe' captures startup crashes lost in v1.4.129-rc.1.
   // Why: run as plain Node so Electron's GPU/display init can't interfere with node-pty's posix_spawn of the spawn-helper.
   const daemonEnv = {
     ...process.env,
@@ -64,11 +59,16 @@ export function spawnDaemonChildProcess(
     // Why: the detached plain-Node daemon has no AppEnvironment, but shell rcfiles must live outside swept tmp.
     ORCA_USER_DATA_PATH: userDataPath
   }
+  // Why cwd: detached daemons outlive dev worktrees; userData keeps process.cwd() valid after a repo/worktree is deleted.
+  // Why detached/stdio: detached+unref outlives Electron; stdout 'ignore' (else blocks exit), stderr 'pipe' captures startup crashes lost in v1.4.129-rc.1.
+  const childOptions = {
+    cwd: userDataPath,
+    detached: true,
+    stdio: ['ignore', 'ignore', 'pipe', 'ipc'] as StdioOptions
+  }
   if (!useDurableScope) {
     return fork(forkEntryPath, scriptArgs, {
-      cwd: userDataPath,
-      detached: true,
-      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+      ...childOptions,
       // Why: run the byte-identical relocated Orca.exe so the image path sits outside the updater's kill zone.
       ...(relocatedExecPath ? { execPath: relocatedExecPath } : {}),
       env: daemonEnv
@@ -80,10 +80,5 @@ export function spawnDaemonChildProcess(
     launchNonce,
     daemonEnv
   )
-  return spawn(scoped.command, scoped.args, {
-    cwd: userDataPath,
-    detached: true,
-    stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
-    env: scoped.env
-  })
+  return spawn(scoped.command, scoped.args, { ...childOptions, env: scoped.env })
 }

--- a/src/main/daemon/daemon-launched-child-spawn.ts
+++ b/src/main/daemon/daemon-launched-child-spawn.ts
@@ -1,0 +1,87 @@
+import { fork, spawn, type ChildProcess } from 'node:child_process'
+import { getAppEnvironment } from '../../shared/app-environment'
+import { buildDurableDaemonScopeCommand } from './daemon-cgroup-scope'
+import { daemonLogArgs } from './daemon-launch-paths'
+
+export type DaemonChildSpawnOptions = {
+  entryPath: string
+  forkEntryPath: string
+  relocatedExecPath?: string
+  userDataPath: string
+  socketPath: string
+  tokenPath: string
+  pidPath: string
+  launchNonce: string
+  macosLoginSessionWatch: boolean
+}
+
+function buildDaemonScriptArgs(options: DaemonChildSpawnOptions): string[] {
+  const { socketPath, tokenPath, pidPath, launchNonce, entryPath, macosLoginSessionWatch } = options
+  return [
+    '--socket',
+    socketPath,
+    '--token',
+    tokenPath,
+    '--pid-record',
+    pidPath,
+    '--launch-nonce',
+    launchNonce,
+    '--entry-path',
+    entryPath,
+    '--app-version',
+    getAppEnvironment().getVersion(),
+    '--spawner-exec-path',
+    process.execPath,
+    ...(macosLoginSessionWatch ? ['--login-session-watch'] : []),
+    ...daemonLogArgs()
+  ]
+}
+
+/**
+ * The two ways the daemon's actual OS process comes into being. `useDurableScope: false` is the
+ * long-standing direct `fork()` (own POSIX process group, same systemd cgroup as the caller).
+ * `useDurableScope: true` wraps the identical command line in `systemd-run --user --scope` (see
+ * daemon-cgroup-scope.ts) so the resulting process lands in a cgroup that is a sibling of the
+ * caller's, not a descendant — spawned via `spawn()` rather than `fork()` because the immediate
+ * child is `systemd-run`, not the daemon itself; `spawn()` supports the same `'ipc'` stdio
+ * contract `fork()` does; whichever process the wrapper execs into inherits it and completes the
+ * daemon's normal readiness handshake unchanged.
+ */
+export function spawnDaemonChildProcess(
+  options: DaemonChildSpawnOptions,
+  useDurableScope: boolean
+): ChildProcess {
+  const { forkEntryPath, relocatedExecPath, userDataPath, launchNonce } = options
+  const scriptArgs = buildDaemonScriptArgs(options)
+  // Why: detached daemons outlive dev worktrees; userData keeps process.cwd() valid after a repo/worktree is deleted.
+  // Why: detached+unref outlives Electron; stdout 'ignore' (else blocks exit), stderr 'pipe' captures startup crashes lost in v1.4.129-rc.1.
+  // Why: run as plain Node so Electron's GPU/display init can't interfere with node-pty's posix_spawn of the spawn-helper.
+  const daemonEnv = {
+    ...process.env,
+    ELECTRON_RUN_AS_NODE: '1',
+    // Why: the detached plain-Node daemon has no AppEnvironment, but shell rcfiles must live outside swept tmp.
+    ORCA_USER_DATA_PATH: userDataPath
+  }
+  if (!useDurableScope) {
+    return fork(forkEntryPath, scriptArgs, {
+      cwd: userDataPath,
+      detached: true,
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+      // Why: run the byte-identical relocated Orca.exe so the image path sits outside the updater's kill zone.
+      ...(relocatedExecPath ? { execPath: relocatedExecPath } : {}),
+      env: daemonEnv
+    })
+  }
+  const scoped = buildDurableDaemonScopeCommand(
+    relocatedExecPath ?? process.execPath,
+    [forkEntryPath, ...scriptArgs],
+    launchNonce,
+    daemonEnv
+  )
+  return spawn(scoped.command, scoped.args, {
+    cwd: userDataPath,
+    detached: true,
+    stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+    env: scoped.env
+  })
+}

--- a/src/main/daemon/daemon-launched-child-spawn.ts
+++ b/src/main/daemon/daemon-launched-child-spawn.ts
@@ -1,4 +1,5 @@
-import { fork, spawn, type ChildProcess, type StdioOptions } from 'node:child_process'
+import { forkProcess, type ForkSpec } from '../../shared/child-process/fork-process'
+import { spawnProcess, type SpawnedProcess } from '../../shared/child-process/run-process'
 import { getAppEnvironment } from '../../shared/app-environment'
 import { buildDurableDaemonScopeCommand } from './daemon-cgroup-scope'
 import { daemonLogArgs } from './daemon-launch-paths'
@@ -45,11 +46,15 @@ function buildDaemonScriptArgs(options: DaemonChildSpawnOptions): string[] {
  * contract and the process it execs into inherits the channel, so the readiness handshake is
  * unchanged. Do not read the daemon's PID off the returned child; the daemon reports its own
  * (see daemon-ready-identity.ts).
+ *
+ * Both arms go through the shared child-process chokepoint (`src/shared/child-process`), which
+ * is what every caller outside that directory must use — `forkProcess` for the Node-module arm,
+ * `spawnProcess` for the program arm.
  */
 export function spawnDaemonChildProcess(
   options: DaemonChildSpawnOptions,
   useDurableScope: boolean
-): ChildProcess {
+): SpawnedProcess {
   const { forkEntryPath, relocatedExecPath, userDataPath, launchNonce } = options
   const scriptArgs = buildDaemonScriptArgs(options)
   // Why: run as plain Node so Electron's GPU/display init can't interfere with node-pty's posix_spawn of the spawn-helper.
@@ -61,14 +66,16 @@ export function spawnDaemonChildProcess(
   }
   // Why cwd: detached daemons outlive dev worktrees; userData keeps process.cwd() valid after a repo/worktree is deleted.
   // Why detached/stdio: detached+unref outlives Electron; stdout 'ignore' (else blocks exit), stderr 'pipe' captures startup crashes lost in v1.4.129-rc.1.
-  const childOptions = {
+  const childOptions: Pick<ForkSpec, 'cwd' | 'detached' | 'stdio'> = {
     cwd: userDataPath,
     detached: true,
-    stdio: ['ignore', 'ignore', 'pipe', 'ipc'] as StdioOptions
+    stdio: ['ignore', 'ignore', 'pipe', 'ipc']
   }
   if (!useDurableScope) {
-    return fork(forkEntryPath, scriptArgs, {
+    return forkProcess({
       ...childOptions,
+      modulePath: forkEntryPath,
+      args: scriptArgs,
       // Why: run the byte-identical relocated Orca.exe so the image path sits outside the updater's kill zone.
       ...(relocatedExecPath ? { execPath: relocatedExecPath } : {}),
       env: daemonEnv
@@ -80,5 +87,10 @@ export function spawnDaemonChildProcess(
     launchNonce,
     daemonEnv
   )
-  return spawn(scoped.command, scoped.args, { ...childOptions, env: scoped.env })
+  return spawnProcess({
+    ...childOptions,
+    program: scoped.command,
+    args: scoped.args,
+    env: scoped.env
+  })
 }

--- a/src/main/daemon/daemon-launched-child.ts
+++ b/src/main/daemon/daemon-launched-child.ts
@@ -27,18 +27,16 @@ export type LaunchedDaemonChild = {
   identity: DaemonEndpointIdentity
 }
 
-type LaunchDaemonChildOptions = DaemonChildSpawnOptions
-
 /**
  * Why a wrapper instead of one code path: a durable cgroup scope (see `daemon-cgroup-scope.ts`)
  * is what lets the daemon survive a combined-unit `systemctl restart`, but the pre-flight
  * capability probe can still race a real environment fact (a torn-down user session, a polkit
- * policy rejection at the actual `StartTransientUnit` D-Bus call). Any failure of the scoped
- * attempt retries once, unscoped, so an environment that cannot support isolation degrades to
- * today's already-proven behavior instead of failing the daemon launch outright.
+ * policy rejection at the actual `StartTransientUnit` D-Bus call). A scoped attempt that fails
+ * for any reason but a lost endpoint race retries once, unscoped, so an environment that cannot
+ * support isolation degrades to today's proven behavior instead of failing the launch outright.
  */
 export async function launchDaemonChild(
-  options: LaunchDaemonChildOptions
+  options: DaemonChildSpawnOptions
 ): Promise<LaunchedDaemonChild> {
   if (!isDurableDaemonScopeSupported()) {
     return launchDaemonChildAttempt(options, false)
@@ -46,6 +44,11 @@ export async function launchDaemonChild(
   try {
     return await launchDaemonChildAttempt(options, true)
   } catch (error) {
+    if (error instanceof DaemonEndpointUnavailableError) {
+      // Not a scope problem: another daemon owns the endpoint and the caller adopts it, so a
+      // retry would only fork a second child to lose the same race.
+      throw error
+    }
     console.warn(
       '[daemon] durable cgroup-scope launch failed, retrying without cgroup isolation:',
       (error as Error).message
@@ -55,7 +58,7 @@ export async function launchDaemonChild(
 }
 
 async function launchDaemonChildAttempt(
-  options: LaunchDaemonChildOptions,
+  options: DaemonChildSpawnOptions,
   useDurableScope: boolean
 ): Promise<LaunchedDaemonChild> {
   const { pidPath, launchNonce } = options
@@ -124,8 +127,9 @@ async function launchDaemonChildAttempt(
       // Best-effort by design: the launch failed before any self-report, so `child.pid` is the
       // only PID available here. `unlinkOwnedDaemonPidFile` matches on both PID and launch
       // nonce, so a mismatch removes nothing rather than clobbering another daemon's record.
-      if (Number.isSafeInteger(child.pid) && (child.pid as number) > 0) {
-        unlinkOwnedDaemonPidFile(pidPath, child.pid as number, launchNonce)
+      const childPid = child.pid
+      if (childPid !== undefined && childPid > 0) {
+        unlinkOwnedDaemonPidFile(pidPath, childPid, launchNonce)
       }
       reject(startupError)
     }
@@ -145,10 +149,9 @@ async function launchDaemonChildAttempt(
         if (settled) {
           return
         }
-        // Why the daemon's self-reported PID rather than `child.pid`: on the durable-scope path
-        // the immediate child is `systemd-run`, and only its `execvpe()` into the daemon makes
-        // the two PIDs coincide. Adoption compares this identity against the daemon's own
-        // hello-response identity, so both sides must come from inside the daemon process.
+        // Why not `child.pid`: on the durable-scope path the immediate child is `systemd-run`
+        // (see daemon-ready-identity.ts); adoption compares this identity against the daemon's
+        // own hello-response identity, so both sides must come from inside the daemon process.
         const readyIdentity = parseDaemonReadyIdentity(msg)
         if (!readyIdentity) {
           void fail(new Error('Daemon readiness identity is incomplete'))

--- a/src/main/daemon/daemon-launched-child.ts
+++ b/src/main/daemon/daemon-launched-child.ts
@@ -121,6 +121,9 @@ async function launchDaemonChildAttempt(
         )
         return
       }
+      // Best-effort by design: the launch failed before any self-report, so `child.pid` is the
+      // only PID available here. `unlinkOwnedDaemonPidFile` matches on both PID and launch
+      // nonce, so a mismatch removes nothing rather than clobbering another daemon's record.
       if (Number.isSafeInteger(child.pid) && (child.pid as number) > 0) {
         unlinkOwnedDaemonPidFile(pidPath, child.pid as number, launchNonce)
       }
@@ -142,13 +145,16 @@ async function launchDaemonChildAttempt(
         if (settled) {
           return
         }
+        // Why the daemon's self-reported PID rather than `child.pid`: on the durable-scope path
+        // the immediate child is `systemd-run`, and only its `execvpe()` into the daemon makes
+        // the two PIDs coincide. Adoption compares this identity against the daemon's own
+        // hello-response identity, so both sides must come from inside the daemon process.
         const readyIdentity = parseDaemonReadyIdentity(msg)
-        if (!Number.isSafeInteger(child.pid) || (child.pid as number) <= 0 || !readyIdentity) {
+        if (!readyIdentity) {
           void fail(new Error('Daemon readiness identity is incomplete'))
           return
         }
         launchedIdentity = {
-          pid: child.pid as number,
           ...readyIdentity,
           launchNonce
         }
@@ -199,6 +205,14 @@ async function launchDaemonChildAttempt(
   return { child, identity: launchedIdentity }
 }
 
+/**
+ * Startup-failure cleanup only — a successful launch detaches instead (see `onReadyMessage`).
+ *
+ * Signalling `child.pid` stays correct on the durable-scope path: in `--scope` mode systemd-run
+ * registers its *own* PID with the transient unit and then `execvpe()`s the daemon, so that PID
+ * is either still systemd-run (scope setup not finished, and killing it aborts the launch) or
+ * already the daemon itself. There is never an intermediate process left holding the daemon.
+ */
 export async function terminateLaunchedDaemonChild(child: ChildProcess): Promise<void> {
   try {
     if (

--- a/src/main/daemon/daemon-launched-child.ts
+++ b/src/main/daemon/daemon-launched-child.ts
@@ -1,8 +1,11 @@
-import { fork, type ChildProcess } from 'node:child_process'
-import { getAppEnvironment } from '../../shared/app-environment'
+import type { ChildProcess } from 'node:child_process'
+import { isDurableDaemonScopeSupported } from './daemon-cgroup-scope'
 import { DAEMON_EXIT_ENDPOINT_OCCUPIED } from './daemon-endpoint-ownership'
 import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
-import { daemonLogArgs } from './daemon-launch-paths'
+import {
+  spawnDaemonChildProcess,
+  type DaemonChildSpawnOptions
+} from './daemon-launched-child-spawn'
 import { parseDaemonReadyIdentity } from './daemon-ready-identity'
 import { unlinkOwnedDaemonPidFile } from './daemon-spawner'
 
@@ -24,69 +27,39 @@ export type LaunchedDaemonChild = {
   identity: DaemonEndpointIdentity
 }
 
-type LaunchDaemonChildOptions = {
-  entryPath: string
-  forkEntryPath: string
-  relocatedExecPath?: string
-  userDataPath: string
-  socketPath: string
-  tokenPath: string
-  pidPath: string
-  launchNonce: string
-  macosLoginSessionWatch: boolean
-}
+type LaunchDaemonChildOptions = DaemonChildSpawnOptions
 
+/**
+ * Why a wrapper instead of one code path: a durable cgroup scope (see `daemon-cgroup-scope.ts`)
+ * is what lets the daemon survive a combined-unit `systemctl restart`, but the pre-flight
+ * capability probe can still race a real environment fact (a torn-down user session, a polkit
+ * policy rejection at the actual `StartTransientUnit` D-Bus call). Any failure of the scoped
+ * attempt retries once, unscoped, so an environment that cannot support isolation degrades to
+ * today's already-proven behavior instead of failing the daemon launch outright.
+ */
 export async function launchDaemonChild(
   options: LaunchDaemonChildOptions
 ): Promise<LaunchedDaemonChild> {
-  const {
-    entryPath,
-    forkEntryPath,
-    relocatedExecPath,
-    userDataPath,
-    socketPath,
-    tokenPath,
-    pidPath,
-    launchNonce,
-    macosLoginSessionWatch
-  } = options
-  const child = fork(
-    forkEntryPath,
-    [
-      '--socket',
-      socketPath,
-      '--token',
-      tokenPath,
-      '--pid-record',
-      pidPath,
-      '--launch-nonce',
-      launchNonce,
-      '--entry-path',
-      entryPath,
-      '--app-version',
-      getAppEnvironment().getVersion(),
-      '--spawner-exec-path',
-      process.execPath,
-      ...(macosLoginSessionWatch ? ['--login-session-watch'] : []),
-      ...daemonLogArgs()
-    ],
-    {
-      // Why: detached daemons outlive dev worktrees; userData keeps process.cwd() valid after a repo/worktree is deleted.
-      cwd: userDataPath,
-      // Why: detached+unref outlives Electron; stdout 'ignore' (else blocks exit), stderr 'pipe' captures startup crashes lost in v1.4.129-rc.1.
-      detached: true,
-      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
-      // Why: run the byte-identical relocated Orca.exe so the image path sits outside the updater's kill zone.
-      ...(relocatedExecPath ? { execPath: relocatedExecPath } : {}),
-      // Why: run the fork as plain Node so Electron's GPU/display init can't interfere with node-pty's posix_spawn of the spawn-helper.
-      env: {
-        ...process.env,
-        ELECTRON_RUN_AS_NODE: '1',
-        // Why: the detached plain-Node daemon has no AppEnvironment, but shell rcfiles must live outside swept tmp.
-        ORCA_USER_DATA_PATH: userDataPath
-      }
-    }
-  )
+  if (!isDurableDaemonScopeSupported()) {
+    return launchDaemonChildAttempt(options, false)
+  }
+  try {
+    return await launchDaemonChildAttempt(options, true)
+  } catch (error) {
+    console.warn(
+      '[daemon] durable cgroup-scope launch failed, retrying without cgroup isolation:',
+      (error as Error).message
+    )
+    return launchDaemonChildAttempt(options, false)
+  }
+}
+
+async function launchDaemonChildAttempt(
+  options: LaunchDaemonChildOptions,
+  useDurableScope: boolean
+): Promise<LaunchedDaemonChild> {
+  const { pidPath, launchNonce } = options
+  const child = spawnDaemonChildProcess(options, useDurableScope)
 
   // Why: keep only the startup-window stderr tail so a crash cause is visible without unbounded memory.
   let startupStderr = ''

--- a/src/main/daemon/daemon-out-of-process-launcher.ts
+++ b/src/main/daemon/daemon-out-of-process-launcher.ts
@@ -171,7 +171,7 @@ export function createOutOfProcessLauncher(
       } catch (error) {
         if (error instanceof DaemonEndpointOwnershipError) {
           await terminateLaunchedDaemonChild(launched.child)
-          unlinkOwnedDaemonPidFile(pidPath, launched.child.pid as number, launchNonce)
+          unlinkOwnedDaemonPidFile(pidPath, launched.identity.pid, launchNonce)
           throw error
         }
         // Why: another client may have adopted this live process; keep its pid record until exit, but remove one published after an early exit.
@@ -181,7 +181,7 @@ export function createOutOfProcessLauncher(
             return
           }
           pidRecordRemoved = true
-          unlinkOwnedDaemonPidFile(pidPath, launched.child.pid as number, launchNonce)
+          unlinkOwnedDaemonPidFile(pidPath, launched.identity.pid, launchNonce)
         }
         launched.child.once('exit', removeExitedPidRecord)
         if (

--- a/src/main/daemon/daemon-pid-file-parse.ts
+++ b/src/main/daemon/daemon-pid-file-parse.ts
@@ -7,6 +7,9 @@ export type ParsedDaemonPid = {
   linuxStartTicks: string | null
   bootId: string | null
   spawnerExecPath: string | null
+  /** Self-detected systemd scope unit (see daemon-cgroup-scope.ts); null when the daemon ran
+   *  unscoped or predates this field. */
+  cgroupUnit: string | null
 }
 
 /**
@@ -41,6 +44,7 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
       linuxStartTicks?: unknown
       bootId?: unknown
       spawnerExecPath?: unknown
+      cgroupUnit?: unknown
     }
     if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid)) {
       return {
@@ -54,7 +58,8 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
         launchNonce: typeof parsed.launchNonce === 'string' ? parsed.launchNonce : null,
         linuxStartTicks: typeof parsed.linuxStartTicks === 'string' ? parsed.linuxStartTicks : null,
         bootId: typeof parsed.bootId === 'string' ? parsed.bootId : null,
-        spawnerExecPath: typeof parsed.spawnerExecPath === 'string' ? parsed.spawnerExecPath : null
+        spawnerExecPath: typeof parsed.spawnerExecPath === 'string' ? parsed.spawnerExecPath : null,
+        cgroupUnit: typeof parsed.cgroupUnit === 'string' ? parsed.cgroupUnit : null
       }
     }
   } catch {
@@ -71,7 +76,8 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
         launchNonce: null,
         linuxStartTicks: null,
         bootId: null,
-        spawnerExecPath: null
+        spawnerExecPath: null,
+        cgroupUnit: null
       }
     : null
 }

--- a/src/main/daemon/daemon-ready-identity.test.ts
+++ b/src/main/daemon/daemon-ready-identity.test.ts
@@ -1,35 +1,60 @@
 import { describe, expect, it } from 'vitest'
-import { parseDaemonReadyIdentity } from './daemon-ready-identity'
+import { parseDaemonReadyIdentity, readCurrentDaemonReadyIdentity } from './daemon-ready-identity'
 
 describe('parseDaemonReadyIdentity', () => {
   it('accepts additive Linux incarnation identity', () => {
     expect(
       parseDaemonReadyIdentity({
         type: 'ready',
+        pid: 4242,
         startedAtMs: 1_700_000_000_000,
         linuxStartTicks: '4242',
         bootId: 'boot-a'
       })
     ).toEqual({
+      pid: 4242,
       startedAtMs: 1_700_000_000_000,
       linuxStartTicks: '4242',
       bootId: 'boot-a'
     })
   })
 
-  it('keeps older ready payloads compatible', () => {
-    expect(parseDaemonReadyIdentity({ type: 'ready', startedAtMs: 123 })).toEqual({
+  it('accepts the minimal identity a non-Linux daemon reports', () => {
+    expect(parseDaemonReadyIdentity({ type: 'ready', pid: 77, startedAtMs: 123 })).toEqual({
+      pid: 77,
       startedAtMs: 123
     })
+  })
+
+  it('rejects a readiness payload with no self-reported PID', () => {
+    // The launcher has no other trustworthy source: its own child may be the systemd-run
+    // wrapper of a durable-scope launch rather than the daemon.
+    expect(parseDaemonReadyIdentity({ type: 'ready', startedAtMs: 123 })).toBeNull()
+  })
+
+  it('rejects PIDs that cannot name a process', () => {
+    for (const pid of [0, -1, 1.5, '123', Number.NaN, Number.MAX_SAFE_INTEGER + 2]) {
+      expect(parseDaemonReadyIdentity({ type: 'ready', pid, startedAtMs: 123 })).toBeNull()
+    }
   })
 
   it('rejects partial Linux identity instead of persisting a false proof', () => {
     expect(
       parseDaemonReadyIdentity({
         type: 'ready',
+        pid: 4242,
         startedAtMs: 123,
         linuxStartTicks: '4242'
       })
     ).toBeNull()
+  })
+})
+
+describe('readCurrentDaemonReadyIdentity', () => {
+  it('reports the running process own PID, and the report round-trips through the parser', async () => {
+    const identity = await readCurrentDaemonReadyIdentity(1_700_000_000_000)
+
+    expect(identity.pid).toBe(process.pid)
+    expect(parseDaemonReadyIdentity({ type: 'ready', ...identity })).toEqual(identity)
   })
 })

--- a/src/main/daemon/daemon-ready-identity.ts
+++ b/src/main/daemon/daemon-ready-identity.ts
@@ -1,7 +1,18 @@
 import { readFileSync } from 'node:fs'
 import { parseLinuxStartTicks, readBootIdentity } from '../agent-hooks/managed-hook-owner-identity'
 
+/**
+ * What the daemon reports about itself over the readiness IPC channel.
+ *
+ * Why `pid` is self-reported rather than read from the launcher's `child.pid`: the immediate
+ * child is not guaranteed to be the daemon process. The durable-scope launch path spawns
+ * `systemd-run --user --scope` (see daemon-cgroup-scope.ts), so the PID the launcher holds only
+ * happens to be the daemon's because systemd-run `execvpe()`s the command in scope mode. Reading
+ * it from inside the daemon makes the identity independent of that external detail, matching how
+ * `detectOwnCgroupScopeUnit` treats cgroup membership as ground truth.
+ */
 export type DaemonReadyIdentity = {
+  pid: number
   startedAtMs: number
   linuxStartTicks?: string
   bootId?: string
@@ -10,15 +21,16 @@ export type DaemonReadyIdentity = {
 export async function readCurrentDaemonReadyIdentity(
   startedAtMs: number
 ): Promise<DaemonReadyIdentity> {
+  const identity = { pid: process.pid, startedAtMs }
   if (process.platform !== 'linux') {
-    return { startedAtMs }
+    return identity
   }
   try {
     const linuxStartTicks = parseLinuxStartTicks(readFileSync('/proc/self/stat', 'utf8'))
     const bootId = await readBootIdentity()
-    return linuxStartTicks && bootId ? { startedAtMs, linuxStartTicks, bootId } : { startedAtMs }
+    return linuxStartTicks && bootId ? { ...identity, linuxStartTicks, bootId } : identity
   } catch {
-    return { startedAtMs }
+    return identity
   }
 }
 
@@ -48,9 +60,13 @@ export function parseDaemonReadyIdentity(message: unknown): DaemonReadyIdentity 
     return null
   }
   const value = message as {
+    pid?: unknown
     startedAtMs?: unknown
     linuxStartTicks?: unknown
     bootId?: unknown
+  }
+  if (!Number.isSafeInteger(value.pid) || (value.pid as number) <= 0) {
+    return null
   }
   if (
     typeof value.startedAtMs !== 'number' ||
@@ -59,13 +75,14 @@ export function parseDaemonReadyIdentity(message: unknown): DaemonReadyIdentity 
   ) {
     return null
   }
+  const identity = { pid: value.pid as number, startedAtMs: value.startedAtMs }
   const hasLinuxStartTicks = value.linuxStartTicks !== undefined
   const hasBootId = value.bootId !== undefined
   if (hasLinuxStartTicks !== hasBootId) {
     return null
   }
   if (!hasLinuxStartTicks) {
-    return { startedAtMs: value.startedAtMs }
+    return identity
   }
   if (
     typeof value.linuxStartTicks !== 'string' ||
@@ -76,7 +93,7 @@ export function parseDaemonReadyIdentity(message: unknown): DaemonReadyIdentity 
     return null
   }
   return {
-    startedAtMs: value.startedAtMs,
+    ...identity,
     linuxStartTicks: value.linuxStartTicks,
     bootId: value.bootId
   }

--- a/src/main/daemon/daemon-ready-identity.ts
+++ b/src/main/daemon/daemon-ready-identity.ts
@@ -65,7 +65,7 @@ export function parseDaemonReadyIdentity(message: unknown): DaemonReadyIdentity 
     linuxStartTicks?: unknown
     bootId?: unknown
   }
-  if (!Number.isSafeInteger(value.pid) || (value.pid as number) <= 0) {
+  if (typeof value.pid !== 'number' || !Number.isSafeInteger(value.pid) || value.pid <= 0) {
     return null
   }
   if (
@@ -75,7 +75,7 @@ export function parseDaemonReadyIdentity(message: unknown): DaemonReadyIdentity 
   ) {
     return null
   }
-  const identity = { pid: value.pid as number, startedAtMs: value.startedAtMs }
+  const identity = { pid: value.pid, startedAtMs: value.startedAtMs }
   const hasLinuxStartTicks = value.linuxStartTicks !== undefined
   const hasBootId = value.bootId !== undefined
   if (hasLinuxStartTicks !== hasBootId) {

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -27,8 +27,9 @@ export type DaemonPidFile = {
   bootId?: string
   /** Forking app's binary — macOS pins the daemon's TCC responsible process to it (STA-3491). */
   spawnerExecPath?: string
-  /** Self-detected systemd scope unit the daemon actually landed in, e.g. `orca-daemon-<nonce>.scope`.
-   *  Absent (not merely `null`) on daemons that predate durable-scope launching or ran unscoped. */
+  /** Self-detected systemd scope unit the daemon landed in, e.g. `orca-daemon-<nonce>.scope`;
+   *  `null` when it detected none. Absent on records no daemon wrote (adoption) or that predate
+   *  durable-scope launching. */
   cgroupUnit?: string | null
 }
 

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -27,6 +27,9 @@ export type DaemonPidFile = {
   bootId?: string
   /** Forking app's binary — macOS pins the daemon's TCC responsible process to it (STA-3491). */
   spawnerExecPath?: string
+  /** Self-detected systemd scope unit the daemon actually landed in, e.g. `orca-daemon-<nonce>.scope`.
+   *  Absent (not merely `null`) on daemons that predate durable-scope launching or ran unscoped. */
+  cgroupUnit?: string | null
 }
 
 export type DaemonProcessHandle = {

--- a/src/main/orcad/orcad-health.test.ts
+++ b/src/main/orcad/orcad-health.test.ts
@@ -43,7 +43,8 @@ const PID_RECORD: ParsedDaemonPid = {
   launchNonce: 'n',
   linuxStartTicks: null,
   bootId: null,
-  spawnerExecPath: null
+  spawnerExecPath: null,
+  cgroupUnit: 'orca-daemon-n.scope'
 }
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
@@ -70,6 +71,9 @@ describe('collectTerminalDaemonHealth', () => {
     expect(health.buildVersion).toBe('1.2.2')
     expect(health.entryPath).toBe('/opt/orcad/daemon-entry.js')
     expect(health.protocolVersion).toBe(36)
+    // The daemon's self-detected cgroup scope round-trips through the pid record as-is —
+    // collectTerminalDaemonHealth must not reinterpret or drop it.
+    expect(health.cgroupUnit).toBe('orca-daemon-n.scope')
     // Why assert the coordinates: a self-test that probed some other endpoint would prove
     // nothing about the daemon this process installed.
     expect(checkDaemonHealthMock).toHaveBeenCalledWith(LIVE_FACTS.socketPath, LIVE_FACTS.tokenPath)

--- a/src/main/orcad/orcad-health.ts
+++ b/src/main/orcad/orcad-health.ts
@@ -47,6 +47,9 @@ export type TerminalDaemonHealth = {
   buildVersion: string | null
   entryPath: string | null
   protocolVersion: number | null
+  /** The systemd scope unit the daemon self-detected landing in (see daemon-cgroup-scope.ts),
+   *  or null when it ran unscoped — the case a combined-unit `systemctl restart` still reaps. */
+  cgroupUnit: string | null
   selfTest: PtySelfTest
 }
 
@@ -116,6 +119,7 @@ export async function collectTerminalDaemonHealth(): Promise<TerminalDaemonHealt
       buildVersion: null,
       entryPath: null,
       protocolVersion: null,
+      cgroupUnit: null,
       selfTest
     }
   }
@@ -137,6 +141,7 @@ export async function collectTerminalDaemonHealth(): Promise<TerminalDaemonHealt
     buildVersion: record?.appVersion ?? null,
     entryPath: record?.entryPath ?? null,
     protocolVersion: facts.protocolVersion,
+    cgroupUnit: record?.cgroupUnit ?? null,
     selfTest
   }
 }

--- a/src/main/server/serve-readiness.test.ts
+++ b/src/main/server/serve-readiness.test.ts
@@ -37,6 +37,7 @@ const health: OrcadHealth = {
     buildVersion: '1.4.0',
     entryPath: '/opt/orcad/daemon-entry.js',
     protocolVersion: 36,
+    cgroupUnit: null,
     selfTest: { ok: true, coverage: 'pty-spawn', verdict: 'healthy', durationMs: 12 }
   }
 }

--- a/src/main/ssh/orcad-activation-gate.test.ts
+++ b/src/main/ssh/orcad-activation-gate.test.ts
@@ -14,6 +14,7 @@ function daemon(overrides: Partial<TerminalDaemonHealth> = {}): TerminalDaemonHe
     buildVersion: '0.2.0+bb01',
     entryPath: '/home/u/.orca-remote/orcad-0.2.0+bb01/daemon-entry.js',
     protocolVersion: 3,
+    cgroupUnit: null,
     selfTest: { ok: true, coverage: 'pty-spawn', verdict: 'healthy', durationMs: 12 },
     ...overrides
   }

--- a/src/shared/child-process/fork-process.ts
+++ b/src/shared/child-process/fork-process.ts
@@ -1,0 +1,49 @@
+// `fork` arm of Orca's child-process chokepoint. Kept beside `run-process.ts` for the same
+// reason that file exists: callers outside this directory must not import `node:child_process`,
+// and a guard test enforces that against a shrinking allowlist.
+import {
+  fork as nodeFork,
+  type ForkOptions,
+  type SpawnOptions as NodeSpawnOptions
+} from 'node:child_process'
+import type { SpawnedProcess } from './process-spec'
+
+/**
+ * What `spawnProcess` cannot express: a Node child with an IPC channel, started from a module
+ * path rather than a program, optionally under a different Node/Electron binary than this
+ * process's own.
+ *
+ * `fork` is the right primitive for that and there is no spawn-based substitute — the existing
+ * launch paths and their tests are written against `fork`'s contract (module path resolution,
+ * `execPath` override, inherited `execArgv`), and a spawn rewrite would change all three.
+ */
+export type ForkSpec = {
+  /** Node module to run as the child's entry point. */
+  modulePath: string
+  args?: readonly string[]
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  /** Keep the child in its own POSIX process group so it outlives this process. */
+  detached?: boolean
+  /** Must keep an `'ipc'` slot; without one the child gets no channel and cannot `send`. */
+  stdio?: NodeSpawnOptions['stdio']
+  /** Run a different Node/Electron binary — e.g. a relocated executable image. */
+  execPath?: string
+}
+
+export function forkProcess(spec: ForkSpec): SpawnedProcess {
+  return nodeFork(spec.modulePath, [...(spec.args ?? [])], {
+    cwd: spec.cwd,
+    env: spec.env,
+    detached: spec.detached,
+    stdio: spec.stdio,
+    // Why conditional rather than `execPath: spec.execPath`: an explicit `undefined` is not the
+    // same as absent to Node, which reads the key to decide whether to override its own binary.
+    ...(spec.execPath ? { execPath: spec.execPath } : {}),
+    // Why the assertion: `ForkOptions` does not declare `windowsHide`, but Node forwards the
+    // option to `spawn` at runtime, so the flag every other call site in this directory sets is
+    // reachable here too. Inert for a GUI-subsystem binary and for `detached`, which already
+    // gets no inherited console — but a console-subsystem `execPath` would otherwise flash one.
+    windowsHide: true
+  } as ForkOptions)
+}


### PR DESCRIPTION
## ELI5

Orca's terminal daemon (the process that actually owns every PTY/shell) is already built to survive when just the main Orca server process restarts — a fresh server "adopts" the still-running daemon and its terminals come right back. But under a real systemd-managed deployment, restarting the *service* kills the daemon and every terminal too, because the daemon still lives in the same cgroup as the service even though it runs detached. This change puts the daemon in its own cgroup (via `systemd-run --user --scope`, only when that's actually available) so a `systemctl restart` no longer reaches it — the daemon keeps running, and the adoption logic that already exists just works.

## What Changed

- New `src/main/daemon/daemon-cgroup-scope.ts`: feature-detects a usable `systemd --user` manager (`isDurableDaemonScopeSupported`), builds the `systemd-run --user --scope --unit=orca-daemon-<nonce> --collect` wrapper command (`buildDurableDaemonScopeCommand`), and lets the daemon self-report which cgroup scope it actually landed in by reading `/proc/self/cgroup` (`detectOwnCgroupScopeUnit`) rather than trusting the launcher's intent.
- `src/main/daemon/daemon-launched-child.ts` / new `daemon-launched-child-spawn.ts`: when the durable scope is supported, the daemon is launched via `spawn()` wrapping that `systemd-run` command (same `'ipc'` stdio contract `fork()` used, so the existing readiness handshake is unchanged) instead of a plain `fork()`. Any failure of the scoped attempt (no reachable user bus, a D-Bus/polkit rejection, etc.) transparently retries once with the original unscoped `fork()`, so every platform/environment without this capability keeps today's exact behavior.
- `src/main/daemon/daemon-entry.ts`, `daemon-pid-file-parse.ts`, `daemon-spawner.ts`, `src/main/orcad/orcad-health.ts`: thread a `cgroupUnit: string | null` field through the daemon's existing pid-record and orcad's health/readiness payload, so a running deployment can observe whether the fix actually engaged (`health.terminalDaemon.cgroupUnit`).
- No new session registry. The daemon's existing pid-record + adoption/quarantine machinery (`daemon-spawner.ts`, `daemon-pid-record-quarantine.ts`, `orcad-entry.ts`'s `refreshRestoredOrchestrationAuthority()` + `reconcileLegacyWorkerTerminals()`) already implements durable, crash-safe reattachment for a surviving daemon — it simply never got exercised against a full unit restart before, because the daemon never survived one.

## Why

`docs/reference/headless-linux-server.md`'s own reference systemd unit uses `KillMode=mixed`: SIGTERM to the main process only, then a cgroup-wide `SIGKILL` fallback at the stop timeout. The daemon is forked `detached: true`, which escapes the POSIX process group (`setsid`) but never the systemd cgroup — process-group detachment and cgroup membership are orthogonal. Every PTY the daemon owns is itself an undetached direct child of the daemon. So a `systemctl restart`/`stop` of the combined unit reaps the daemon and every live terminal, even though `docs/reference/orcad-operations.md` already documents the daemon as designed to survive a PID-scoped restart of `orcad` — it says so explicitly: *"Service-restart survival requires separately supervised cgroups; the current deployment does not provide them."*

`systemd-run --user --scope` is the smallest fix that actually closes that gap: it registers the daemon in a cgroup that is a *sibling* of the service unit's cgroup (under the OS user's own `systemd --user` manager), not a descendant, so the unit's own kill — whatever `KillMode` it uses — never reaches it.

Fixes #19408

## Linked Issue

### Architectural Context (RFC #21556)
- **Roadmap Phase:** Step 3: Reconnect & Attach
- **Severity / Priority:** P1 (High)
- **Why It Ties into the Lifecycle:** Headless daemon ran directly under systemd service unit, so any service restart or auto-update sent SIGHUP/SIGKILL to every active child PTY.
- **System Impact:** Escapes daemon into a dedicated `systemd-run --user --scope`, allowing background PTY sessions to survive daemon restarts and laptop sleep.
- **Master Tracking RFC:** Part of [stablyai/orca#21556](https://github.com/stablyai/orca/issues/21556)


Fixes #19408

## Visual Proof

N/A — this is main-process/daemon-lifecycle code with no renderer or UI surface. Nothing rendered changes.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New: `src/main/daemon/daemon-cgroup-scope.test.ts` (14 cases — capability probe on/off Linux, systemd-present/absent, reachable/unreachable user bus, the `systemd-run` command construction, and `/proc/self/cgroup` parsing for both cgroup v1 and v2 formats via a dependency-injected path). Existing suites updated for the new `cgroupUnit` field (`daemon-adoption-telemetry-event.test.ts`, `orcad-health.test.ts` — added an explicit assertion that the field round-trips through `collectTerminalDaemonHealth()` — `serve-readiness.test.ts`, `orcad-activation-gate.test.ts`).

Verified against upstream `main` (this branch, `fix/durable-daemon-cgroup-scope`, `git cherry-pick`ed cleanly onto current `main`): `pnpm run typecheck:tsc:node` clean; targeted `oxlint` clean; the five test files above (58/58) pass.

Verified in a systemd-enabled Docker container (Ubuntu 24.04 + systemd as PID 1, a real `Type=simple`/`KillMode=mixed` unit matching the docs' reference unit, a service account with `loginctl enable-linger`): confirmed via `/proc/<pid>/cgroup` that the daemon actually lands in its own `orca-daemon-<nonce>.scope`, sibling to the service unit's cgroup — corroborated by the daemon's own `health.terminalDaemon.cgroupUnit`. A live PTY session (a counting-loop shell, with an independent oracle log) survived a real `systemctl restart` of the unit: daemon pid, PTY shell pid, and cgroup scope all unchanged across the restart, while the main process pid changed (confirming the unit genuinely restarted). A fresh write sent into the same terminal post-restart, addressed through the restarted process's own pairing/session, reached the same running shell — the session came back as the *same* session, not a cold-restore replay — with zero code changes beyond the cgroup escape itself needed for the existing adoption path to do that. A second, brand-new terminal's ordinary create → work → release lifecycle was unaffected.

Platforms: Linux only exercises the new code path (feature-detected: `process.platform !== 'linux'`, no `/run/systemd/system`, or no reachable `$XDG_RUNTIME_DIR`/`/run/user/<uid>` bus all fail closed to the unchanged direct-`fork()` path). macOS and Windows are structurally unaffected — every early-return in `isDurableDaemonScopeSupported()` is exercised by the new tests. Not tested against a live SSH-remote deployment specifically, but the change is local-process-launch-only and does not touch the SSH transport.

## AI Disclosure

Investigated, designed, implemented, and tested with an Anthropic Claude coding agent (multi-agent session: codebase investigation, implementation, a Docker-based systemd recovery test, and an AppImage build were run as parallel sub-agents under one coordinating session), with the repository owner directing scope and reviewing the plan before implementation.

## Review

Self-reviewed for correctness: the scoped-launch failure path was specifically checked to retry unscoped rather than fail the daemon launch outright, so an environment lacking this capability degrades to exactly today's behavior. The daemon's own `/proc/self/cgroup` self-detection (rather than trusting the launcher's intent) was a deliberate choice so an adopted pre-existing daemon, or one where the wrapper silently failed to isolate, never misreports isolation it doesn't have.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation. — N/A: this is core daemon/session-lifecycle code, not the skill-installer system.

## Notes

- **Security:** the scope-wrapping command is built from fixed argv segments and internally-generated values only (`launchNonce`, an already-random UUID sanitized to the systemd-unit-name alphabet before use, and the daemon's own known `execPath`/`forkEntryPath`/args) — no user- or network-supplied string is interpolated into the `systemd-run` command line, and it is invoked via `spawn()` with an argv array, never a shell string. `systemd-run --user` only reaches the invoking OS user's own session; it grants no new privilege the daemon didn't already have as that user.
- **Cross-platform:** no-op on macOS and Windows (no systemd), and a no-op on Linux without a reachable `systemd --user` manager. Every guard is unit-tested.
- **Remote/SSH:** unaffected — this only changes how the *local* daemon process is launched under the *local* systemd supervision, not any remote-host transport.
- **Backward compatibility:** the new `cgroupUnit` field is optional/nullable everywhere it's threaded (pid-record type, health payload); older daemon pid-record files without it parse to `null`, not an error.
- **Performance:** the capability probe runs at most once per daemon launch (an infrequent event) and does a couple of `existsSync` calls plus one `execFileSync('systemd-run', ['--version'])` with a 2s timeout; no ongoing polling or background work is added.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

@LesleyMurfin

