### PR TITLE
perf(desktop): eliminate repeated work across 75 audited paths

### DIFF
--- a/config/performance-audit-2026-09-07.md
+++ b/config/performance-audit-2026-09-07.md
@@ -1,0 +1,301 @@
+# Desktop performance audit — September 7, 2026
+
+Mobile app excluded. The desktop checklist scan and the confirmed-finding fixes
+are implemented in the current worktree. Validation combines operation-count and
+retention tests, integration contracts, type/quality checks, and hidden Electron
+rendering checks. Real-network and Windows/Linux runtime measurements are outside
+the evidence collected here; this is not a claim that every application path is fast.
+
+## Completed scope: 75 verified fix groups
+
+75 distinct fix groups implemented with passing targeted evidence. The user stopped further expansion and requested one completed PR. The original eleven rows below
+remain fixes 1–11 in their original order. New findings are counted once per
+independent cause, after regression and operation-count evidence pass.
+
+| Fix | Change                                                                                 | Evidence                                                                                                                                                             |
+| --- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 12  | Browser-close focus cleanup uses one closed-page ID set                                | 1,000 pages and 1,000 unrelated focus keys: 2,006,000 page ID reads → under 10,000; preserved page/tab ID collision behavior                                         |
+| 13  | Metadata read-path pruning waits until the earliest possible expiry                    | 10,000 hits across 500 entries: 5,010,000 timestamp reads → 10,000; exact TTL cleanup, clear and clock rollback covered                                              |
+| 14  | Skill-update convergence indexes observable placements by locked name                  | 1,000 locks × 1,000 placements: 1,000,000 name reads → 1,000; unknown/digest/topology eligibility contracts preserved                                                |
+| 15  | Separate nested-repo imports skip unused folder-scope construction                     | Repo-path accessor is never visited in separate mode; existing grouped import and cross-platform contracts pass; original fails the no-access test                   |
+| 16  | Workspace terminal close indexes neighbor order and remaining membership               | Closing last of 1,001 tabs: 503,503 order-entry reads → under 6,000; duplicate legacy order and MRU behavior preserved                                               |
+| 17  | Task-page selection reuses normalization instead of intersecting twice                 | 1,000 persisted IDs: 512,500 repo-ID reads → under 40,000; preferred, missing and empty selection fallback preserved                                                 |
+| 18  | Backfill date expansion checks cardinality before allocating the range                 | 2000–2026 marker: 9,747 rejected date-loop iterations → zero; leap day, inclusive limit and future-clock ranges preserved                                            |
+| 19  | VM feature restoration indexes identity once across the loaded runtime list            | 1,000 runtimes: 500,500 feature-ID reads → 1,000; first-wins identity, unmatched references and rollback contracts preserved                                         |
+| 20  | VM feature sorts precompute identity strings and share the existing sorter             | 2,000 entries: over 20,000 identity reads → 2,000 per sort; stable ordering and merge overwrite parity against original comparator                                   |
+| 21  | Batch deletion reuses normalized path matchers                                         | 1,000 directories: 1,998,000 path reads → 2,000; original fails count test; POSIX, Windows, UNC, WSL, repeated-reference and boundary contracts pass                 |
+| 22  | Document title-only refresh preserves unchanged store state                            | 200 identical title refreshes: 200 subscriber notifications → zero; genuine title edits and visit bumps still publish                                                |
+| 23  | Browser history normalizes only retained candidates and reuses unchanged rows          | 10,000 unique URLs: 10,200 URL reads → 400; repeated normalized pruning returns the same session; recency, dedupe and repair covered                                 |
+| 24  | Document history dedupe indexes workspace/path identity                                | 10,000 legacy entries: 1,009,704 workspace-ID reads → 20,000; newest unique visits, cap and tuple identity preserved                                                 |
+| 25  | Project identity succession indexes prior memberships                                  | 1,000 bulk promotions: 1,000,000 prior source-list reads → 1,000; overlap weights, duplicate membership, stable ties and runtime preference transfer preserved       |
+| 26  | Browser palette indexes unified workspace tabs                                         | 1,000 browser workspaces: 1,001,000 entity-ID reads → under 6,000; duplicate and host-ownership exclusions covered                                                   |
+| 27  | Project catalog construction appends to its owned source list                          | 2,000 sources of one project: 1,999,000 accumulating-array elements copied → under 10,000; source order/dedupe and timestamp contracts pass                          |
+| 28  | Terminal binding replay lazily indexes prior workspace tabs                            | 1,000 bindings: 502,500 prior tab-ID reads → under 10,000; ambiguity, removed-leaf and host fences retained                                                          |
+| 29  | SSH binding cleanup indexes selected-host leases by PTY                                | 1,000 bindings: normalization once per binding; foreign host and conflicting tab/workspace evidence preserved; retirement integration tests pass                     |
+| 30  | Limited tool pairing stops once retained pairs are complete                            | 10,000 trailing tool blocks: zero visited after the retained pair completes; FIFO parity for generated sequences, stray results and unusual limits                   |
+| 31  | Tool attribution allocates replacement blocks only on rejection                        | 1,000 valid prose messages: zero discarded block appends; valid message identity and orphan-result removal preserved                                                 |
+| 32  | AI-vault root filtering/depth truncation prepare root matchers once                    | 1,000 sessions × 100 roots: 200,000 normalizations → 1,100 per operation; WSL aliases preserved                                                                      |
+| 33  | AI-vault query matching reads only needed text                                         | Empty/repo/path queries across 1,000 sessions: 3,000 preview-array reads → zero; plain-text matching retained                                                        |
+| 34  | AI-vault ordering parses timestamps once per retained session                          | More than 26,000 parses → 2,000; invalid-date sort parity                                                                                                            |
+| 35  | AI-vault project attribution reuses results within host/cwd tuples                     | 1,000 sessions/200 repos: 200,000 root comparisons → 200; host isolation and distinct result objects retained                                                        |
+| 36  | Checks-panel cwd attribution selects the best candidate in one pass                    | 300 nested roots: 4,778 normalizations → at most 901; current-path ties and WSL/prior-path matching retained                                                         |
+| 37  | Jira table sort precomputes priority/date keys                                         | 2,000 issues: 43,796 priority reads → 4,000; date reads → 2,000; grouping contracts pass                                                                             |
+| 38  | Linear/Jira aggregate sorting shares cached updatedAt keys                             | More than 10,000 timestamp reads → 2,000; in-place identity and invalid-date ordering parity; provider integration tests                                             |
+| 39  | External automation run sorting parses mapped dates once                               | Hermes/OpenClaw: over 28,000 parses → 2,000 each; invalid-date ID fallback retained                                                                                  |
+| 40  | Project table sorting/grouping indexes option and iteration order                      | 1,000 options: 8,653,118 sorting ID reads → 1,000; grouping also 1,000; missing metadata and stable ties retained                                                    |
+| 41  | Clone URL prefill stops at the first usable source and lazily indexes fallback lookups | First usable source: 500,500 repo-ID reads → 1; all-missing fallback bounded by source/repo counts; credential stripping and duplicate authority retained            |
+| 42  | Work-item mutations clone only changed pages                                           | Missing mutation plus one update across 20 pages: 42 arrays → 2; sparse pages, nulls and duplicate matches preserved                                                 |
+| 43  | Pane alias migration stores singleton or ambiguity per tab                             | 2,000 repeated legacy rows: 2,001,000 copied elements → under 10,000; ambiguous aliases withheld; singleton aliases retained                                         |
+| 44  | Resource Manager indexes tab labels and accumulated worktree rows                      | 1,000 sessions: 502,500 tab-ID reads → under 5,000; 499,500 accumulated-row scans → zero; binding-only callers skip label maps                                       |
+| 45  | Skill bundle failure reporting indexes selected IDs                                    | 1,000 selected skills: 500,500 selection reads → at most 2,000; manifest order and cancelled/failed statuses preserved                                               |
+| 46  | Terminal adoption topology validates MRU membership with group sets                    | 1,000 restored tabs: 501,501 tab-order reads → at most 3,000; duplicate, foreign-recent and foreign-active groups rejected                                           |
+| 47  | Windows variable expansion lazily indexes case-insensitive keys                        | 1,000 mixed-case PATH substitutions: 1,000 environment enumerations → 1; exact-case precedence, undefined-first fallback, unknowns and non-Windows behavior retained |
+| 48  | Worker transcript roster twins use counted text membership                             | 1,000 matching rosters: 499,500 shifted array entries → zero; existing exact-before-positional, missing-twin and newer-host fallback contracts pass                  |
+| 49  | Automation retention skips ordering when all final runs fit                            | 100 retained runs: 1,056 ordering timestamp reads → zero; append order and final-only eviction retained                                                              |
+| 50  | Git history parser reads eight header fields without splitting commit bodies           | 10,000-line body: 10,012 materialized newline fields → zero; body bytes, incomplete headers, legacy Git decorations and subjects preserved                           |
+
+Fixes 32–40 have original-code negative controls in `/tmp/orca-perf-32-40-negative.log` (fix 38 compares directly against the original algorithm). Fixes 41–50 have negative controls in `/tmp/orca-perf-41-50-negative.log`: all ten suites reject the original implementations through twelve new regression failures, while 53 other tests pass. Fixed sources were restored in a `finally` block before final validation. These are operation/allocation reductions, not claims of measured UI latency improvements.
+
+| Fix | Change                                                                        | Evidence                                                                                                                                                                  |
+| --- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 51  | Usage event aggregation indexes location/model breakdowns within each session | 2,000 events across 1,000 locations: 2,005,000 project-key reads → under 30,000; totals and model/location cardinality preserved                                          |
+| 52  | Usage rollup merging reuses first-match breakdown indexes within a merge      | Two 1,000-location rollups: 2,002,000 location-key reads → under 10,000; duplicate authority and source immutability preserved                                            |
+| 53  | Codex ordinal retention indexes forgotten turns separately                    | 1,000 streamed items with 256 forgotten turns: 256,000 active-flag reads → zero; reactivation continuity and byte/entry eviction covered                                  |
+| 54  | Claude usage attribution caches matched and unmatched cwd results per batch   | 1,000 turns/100 worktrees: 100,000 containment checks → at most 200; nested path and unscoped fallback retained                                                           |
+| 55  | Usage summaries select highest totals in one pass                             | 2,000 totals: over 10,000 comparisons/reads → 2,000; first ties, negatives and malformed nonfinite fallback match original ordering; shared by Claude, Codex and OpenCode |
+| 56  | Workspace-space compaction sums omitted sizes as numbers                      | 10,000 top-level items: 9,953 intermediate Other objects → zero; retained rows and omitted byte totals unchanged                                                          |
+| 57  | Codex trust upsert consumes ordered unique scan ranges directly               | 1,000 repeated trust blocks: 1,003,998 start-offset reads → under 5,000; upsert/removal contract suites pass                                                              |
+| 58  | Host-balanced listings retire exhausted host buckets                          | 1,000 singleton hosts and one large host: 1,001,000 bucket-entry reads → 2,000; original round-robin selection and row order preserved                                    |
+
+Fixes 51–58: `/tmp/orca-perf-51-58-negative.log` records seven expected failures against original production code; fix 55 compares the original sort directly. Targeted results: `/tmp/orca-perf-51-52.log`, `/tmp/orca-perf-53.log`, `/tmp/orca-perf-54-55.log`, `/tmp/orca-perf-56-57.log`, `/tmp/orca-perf-58.log`. Final static checks passed for the completed scope.
+
+| Fix | Change                                                                   | Evidence                                                                                                                 |
+| --- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| 59  | Pane-key removal probes requested keys                                   | 200 absent removals across 1,000 records: full-record enumeration eliminated; inherited and nonenumerable keys preserved |
+| 60  | Document addresses short-circuit the current workspace root              | Current-root matches avoid reading the global worktree catalog; existing address contracts pass                          |
+| 61  | Pending chat ask replay uses a FIFO cursor                               | 2,000 calls/results: 1,999,000 shifted slots eliminated; replay order retained                                           |
+| 62  | Browser tunnel writer checks capacity before encoding                    | 1,000 rejected 64 KB frames: 65,536,000 copied payload bytes eliminated                                                  |
+| 63  | Plugin audit reads materialize only recent lines                         | 10,000 records: full line splitting eliminated for a 200-row window; unusual limits and malformed records retain parity  |
+| 64  | Windows command-line budgets count escapes directly                      | 30,000-character argument: 12,000 regex match entries eliminated; UTF-16 quoting parity                                  |
+| 65  | Pane equalization caches subtree weights per call                        | 200 nested splits: children enumeration bounded below 500; flex output and unchanged second call preserved               |
+| 66  | History windows group sequences lazily                                   | 10,000 items with a 100-item window: fewer than 300 sequence reads; byte limits and whole groups preserved               |
+| 67  | Foreground agent selection memoizes ancestry                             | 1,000 mixed agent/helper processes: 499,500 parent reads reduced to at most 1,000                                        |
+| 68  | Sidebar delete anchors measure each row once before sorting              | 200 mounted rows: at most 201 geometry measurements; no focus or window activation in test                               |
+| 69  | Linear primary-team selection indexes selected IDs and chooses a minimum | 1,000 teams: 500,500 selected-ID reads reduced to 1,000; selected and fallback ordering preserved                        |
+| 70  | GitLab diff counts scan line prefixes without splitting                  | 30,000 diff lines: line-array allocation eliminated; exact addition/deletion counts preserved                            |
+| 71  | JSONL scanning concatenates only the carried first line                  | 100 chunks with 100,000 lines: copied bytes below 1,000; UTF-8, CRLF, stop offsets and partial tails preserved           |
+| 72  | Skill selection indexes discovered IDs and names                         | 1,000 selectors: ID reads below 10,000 instead of quadratic scans; duplicate authority and ambiguity preserved           |
+| 73  | OS-opened markdown buffering stops merging at its queue cap              | 10,000 paths: fewer than 100 membership probes; first 32 paths retained in order                                         |
+| 74  | File matching skips fuzzy ranking when exact matches fill the window     | 10,000 matching basenames: zero fuzzy-ranking calls; deduplication and remaining-slot behavior preserved                 |
+| 75  | Authoritative session group rebasing indexes membership                  | 1,000 recent tabs: fewer than 10 array membership probes; retired IDs pruned and active fallback preserved               |
+
+Fixes 59–69: eleven expected regression failures against original production files (`/tmp/orca-perf-59-69-negative.log`), with 47 other tests passing. Fixes 70–75: six expected failures with 50 other tests passing (`/tmp/orca-perf-70-75-negative.log`). Fixed production sources were restored after each negative-control run. These measure avoided work and allocations, not end-to-end latency.
+
+The first three continuation count tests fail with original production files and pass with the
+fixes. `/tmp/orca-perf-12-14-negative.log` records the negative controls;
+`/tmp/orca-perf-12-15.log` records 63 passing tests across seven relevant suites.
+`/tmp/orca-perf-15-16-negative.log` and `/tmp/orca-perf-17-18-negative.log`
+record original-code failures for fixes 15–18. Fixes 19–20 compare directly with
+original algorithms. Additional passing selections: terminal close 7 tests;
+task selection 19; backfill dates 11; VM feature and rollback 19.
+Fixes 21–28 have original-code negative controls in `/tmp/orca-perf-21-negative.log`,
+`/tmp/orca-perf-22-24-negative.log` and `/tmp/orca-perf-25-28-negative.log`.
+Checks through fix 25 passed (`/tmp/orca-perf-12-25-tc.log` and
+`/tmp/orca-perf-12-25-quality.log`); final checks now cover all 50 groups (results below).
+
+## Implemented changes
+
+| Path                             | Removed work                                                                     | Regression evidence                                                                                                                                                                        |
+| -------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Editor Git-status reconciliation | Building the status-path index without an eligible conflict editor               | Ten refreshes × 10,000 entries: 100,000 path reads → zero; original implementation fails the count test                                                                                    |
+| Filesystem folder authorization  | Scanning all candidate repos after finding a local match                         | 100 scopes × 1,000 repos: 100,000 path checks → 100, with identical authorized roots                                                                                                       |
+| Browser SOCKS route opening      | Recopying accumulated pending input on every fragment                            | 1,024 fragments: zero repeated concatenations, under 3× payload copying; original performs 1,024 concatenations                                                                            |
+| Skills and Warp theme sorting    | Repeated locale-option setup inside inline and named comparators                 | One collator per sort, old-order parity including ties, names with accents, path tie-breakers and capped recursive scans; 2,000 discovered skills: over 10,000 optioned comparisons → zero |
+| Sidebar lineage drag selection   | Rescanning descendants of selected ancestors                                     | 2,000 nested selected rows: 3,998,000 depth reads → 2,000; generated old-algorithm parity                                                                                                  |
+| Editor session owner restoration | Searching all prior restored files for each new file                             | 2,000 files: 6,005,000 path reads → under 40,000; legacy IDs, runtime ownership and duplicates covered                                                                                     |
+| Active-file restoration          | Searching all restored files per workspace                                       | 1,000 workspaces: over 500,000 property reads → under 6,000; first-file and missing-ID fallback parity                                                                                     |
+| Frontmatter restoration          | Hidden override × workspace migration-map lookups                                | 1,000 × 1,000 case: 1,000,000 reads → 1,000; one sparse override still costs one lookup in a large map                                                                                     |
+| Local diagnostic sink            | Retaining serialized records already known to exceed the write cap               | Forced-GC case: 26,224,304 retained bytes → under 5 MiB; flush count/timing and small-record scan timing preserved                                                                         |
+| Watcher metadata queue           | Starting queued stats after their subscription closes                            | Zero starts for 32 queued canceled records; an active canceled batch stops after its eight in-flight calls                                                                                 |
+| Workspace activation inventory   | Visiting unrelated PTY providers and reading every structured workspace snapshot | With 50 SSH providers, a selected-host request visits one provider instead of 51; local requests visit no SSH providers. Structured inventory uses the existing single-workspace RPC       |
+
+No UI layout, color, shortcut, remote protocol schema, or Git command changes.
+Activation now selects its execution host through existing ownership resolution.
+The optional scope and workspace metadata additions are desktop IPC fields; remote
+providers still receive their existing listing request. No persistent caches added. The browser byte limit, diagnostic
+flush policy, watcher concurrency limit, and live-event fallback remain intact.
+
+## Verification
+
+All tests used `ORCA_BACKGROUND_LAUNCH=1`; no visible application windows launched.
+Electron used isolated test profiles and the existing Playwright CDP-backed fixture.
+
+- Combined run: **447 tests passed across 52 suites**, including all changed
+  subsystems and existing hidden-terminal delivery, snapshot recovery, cursor-read,
+  liveness, startup-ordering, session-write and browser-cleanup contracts.
+- Existing performance contracts: **74 tests passed across 11 suites**, covering
+  SQLite preparation/schema parity, parser behavior, highlighting cache,
+  filesystem concurrency, queued disposal, retained memory and store identity.
+- Activation-gate and cooperative-yield tests: **31 passed across two suites**.
+- Transcript/cancellation checks: **20 passed across four suites**. The SSH
+  cancellation test here verifies error identity, not connection timing.
+- Resumed coverage pass: **226 passed across 23 suites** for Git and provider
+  caches, metadata identity, visibility polling, virtualized lists, scanner
+  cancellation, browser cleanup and bounded RPC long polls.
+- Traversal/lifecycle pass: **115 passed across 15 suites** for live scan budgets,
+  deep/wide directory shapes, model disposal, screencast limits, hidden WebGL
+  retention, parked resize and execution-host-scoped terminal listing.
+- Named skill-comparator follow-up: **37 passed across five suites**, including
+  native and WSL discovery integration. The parity/count test invokes the old
+  comparator directly, then proves the new sort removes optioned comparisons.
+- Subscription/snapshot follow-up: **17 passed across four suites** for terminal,
+  sidebar and source-control subscription budgets and dashboard row-cache reuse.
+  Together these resumed runs contain 395 passing tests; some suites overlap the
+  earlier runs, so their counts must not be added as distinct coverage.
+- Activation follow-up: **117 tests across ten suites**, covering the real
+  activation seam, provider admission counts, local startup barrier, selected-host
+  errors, folder/SSH/runtime identity, workspace metadata and duplicate-writer gates.
+- Hidden Electron: **two tests passed, none skipped**, for interactive typing
+  and rich synchronized TUI restore. Typing echo: **19.2 ms median, 43.6 ms worst**,
+  16 samples. Restore checks verified withheld renderer output, main-owned snapshot
+  source, final frame contents and cursor recovery; its screenshot was inspected.
+- Full `pnpm tc` and `pnpm run check:code-quality:changed` passed after the latest
+  production changes. `git diff --check` passed.
+- `pnpm audit:perf` found no production warnings. Its sole warning is the unchanged
+  accumulating reference buffer in `src/shared/relay-frame-buffer.test.ts`. The
+  resumed invocation reports 20,800 source files and six rules; this is rule
+  coverage, not a manual review of every file.
+
+Negative controls temporarily restored the original implementations and failed
+new count/retention tests for status indexing, SOCKS buffering, lineage selection,
+owner restoration, diagnostic retention and watcher cancellation. Other new
+projection tests compare counts and results directly with the old algorithms.
+Original files were restored to their fixed state before combined verification.
+
+Counts prove removed work, not end-to-end latency. Tests ran on macOS. Mocked
+remote tests establish routing/cancellation behavior, not real SSH RTT or Windows
+and Linux runtime behavior. React testing-library emitted existing act-environment
+warnings; its assertions passed.
+
+## Activation fix and preserved boundaries
+
+`gateWorktreeAgentActivation` now passes an explicit provider scope to the existing
+`pty:listSessions` IPC. Omission retains the diagnostic all-provider behavior;
+`connectionId: null` selects only local, and a string selects only that SSH
+provider. Local selection waits for the daemon startup handoff. A missing or
+failed selected SSH provider rejects the request, which the gate treats as
+uncertainty rather than permission to resume another writer.
+
+The gate uses existing workspace route/owner indexes. Missing and ambiguous
+owners cannot authorize a local lookup, and paired hosts retain host-owned
+activation rather than consulting the client's providers. A positively known
+native repo remains usable before the unrelated runtime catalog hydrates,
+including when activation settles after selection moves to another workspace.
+Folder workspaces do not require a Git worktree row.
+
+Provider-recorded `worktreeId` now survives desktop listing projection, allowing
+opaque SSH PTY IDs to match their workspace without guessing from ID syntax.
+Legacy listings, including empty workspace metadata, retain the existing minted-ID
+fallback. Agent ownership evidence,
+listing admission caps and PTY ownership rebuilding remain intact. The existing
+surface census still refuses incomplete ownership answers; it was not removed.
+
+Structured activation uses the already-supported `session.tabs.list` with an
+explicit workspace selector, replacing `session.tabs.listAll`. Failed, malformed
+or mismatched replies reject; the selected workspace's structured handoff checks
+remain unchanged. No new remote opcode, schema or provider operation is required.
+
+The manual comparator pass also found `compareSkills`, used by native and WSL
+discovery but invisible to the inline-comparator lint rule. Both callers now use
+`sortDiscoveredSkills`. Its collator lives for one sort; empty/singleton results
+allocate none, and the original path tie-breaker remains.
+
+## Checklist coverage ledger
+
+This ledger gives every supplied desktop scenario a disposition. Source review
+and contract tests are sampled evidence, not an exhaustive review of every file
+or proof of rendered latency. "Existing" means no additional defect was
+established in the reviewed path; it does not certify the entire category.
+
+| Checklist scenario                   | Reviewed path or evidence                                                                                          | Disposition                                                                           |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| UI input lag                         | Sidebar lineage expansion count/parity; editor reconciliation; virtualized source-control rows                     | Measured fixes; packaged frame gaps still unmeasured                                  |
+| Frozen terminal                      | Hidden WebGL retention, parked resize, restored-snapshot and repaint contracts                                     | Hidden rich-frame switch/restore passed; native-focus scenarios remain excluded       |
+| Terminal throughput                  | Existing hidden delivery, cursor-read, snapshot and resize contracts                                               | Live typing echo checked; full flood/throughput profiling not measured                |
+| Terminal session listing             | Activation gate → global inspect IPC; scoped runtime census                                                        | Host-scoped activation fix; provider-count and ownership tests pass                   |
+| Hidden/background terminals          | Hidden delivery and main-owned snapshot recovery tests; parked WebGL retention                                     | Hidden output suppression and snapshot restore verified in Electron                   |
+| Scrollback persistence               | `use-app-session-persistence.ts` explicitly avoids periodic scrollback capture; periodic capture records agent IDs | Existing; lifecycle contracts exercised                                               |
+| Append-only files and stream carries | Transcript tail reader/cancellation; SOCKS opening buffer                                                          | Buffer fix measured; incremental transcript contracts pass                            |
+| Retained backing allocations         | Growing buffer transfer, terminal output queue retention, local diagnostic sink                                    | Measured fixes plus existing forced-GC contract                                       |
+| Persistence writes                   | Session-write field gates and allocation/deferred-write tests; hydration projections                               | Measured hydration fixes; existing persistence gates retained                         |
+| Polling                              | Visibility interval/timeout poller, coalesced poll runner, rate-limit polling visibility and retry backoff         | Existing; no new polling change                                                       |
+| Cooperative yielding                 | `shared/event-loop-yield.ts`: immediate/MessageChannel scheduling with timer fallback                              | Existing contract passes; pacing timers preserved                                     |
+| Subprocess churn                     | Worktree scan sharing, sparse annotations and upstream negative-cache contracts                                    | Existing sampled safeguards; activation provider fanout removed                       |
+| Startup latency                      | First-window deferral, ready ordering and asynchronous plugin startup                                              | Existing ordering contracts; end-to-end startup timing not measured                   |
+| React render churn                   | App shell/task-page subscription boundaries, virtual lists and store identity contracts                            | Existing sampled safeguards; full React profiling not measured                        |
+| React store-map subscription churn   | Sidebar details, terminal-pane and source-control subscription budget suites                                       | Existing subscription-count contracts; packaged background-flood counts not measured  |
+| Store subscriber hot path            | Session-write subscriber reference gates and per-worktree projections                                              | Existing allocation/deferred-write contracts                                          |
+| Store arrays recreated on refresh    | File Explorer projection churn and store identity tests                                                            | Existing; hydration indexing fixes measured separately                                |
+| Collection/path fanout               | Authorization short-circuit, hydration indexes, sidebar traversal, inline and named comparators                    | Measured fixes; named-comparator lint blind spot manually checked                     |
+| React effects                        | Read-only App shell and resource-inventory lifecycle review                                                        | No effect edits; repository lifecycle contracts used for read-only review             |
+| Large lists/diffs/trees              | Source-control, activity, File Explorer, search, AI-vault and CSV virtualization                                   | Existing; mounted-row contracts pass for selected lists                               |
+| Parsers and incremental documents    | Markdown tokenizer nonmatch and highlighting-cache performance contracts                                           | Existing; malformed/nonmatch contracts pass                                           |
+| Filesystem watching                  | Parcel event delivery, child lifecycle, event batching and stale projection tests                                  | Canceled queue starts removed; live fallback preserved                                |
+| Filesystem traversal/space scans     | Fixed-worker entry traversal and retained-listing budget; capacity/control tests                                   | Existing; deep/wide, failure and iterator-close cases pass                            |
+| Queued and abandoned work            | Watcher cancellation, transcript cancellation, bounded RPC long polls                                              | Measured watcher fix; real SSH connect cancellation timing not measured               |
+| Editor/Monaco                        | Retained-model lifecycle, diff-model prefix disposal, comment decorator model swap                                 | Existing cleanup contracts; no Monaco behavior change                                 |
+| Electron/webview                     | Guest lifecycle, retained browser registry, screencast teardown/backpressure                                       | Existing mocked guest lifecycle contracts; rendered terminal checks passed            |
+| High-frequency IPC/snapshots         | Screencast shared budgets/latest-frame pacer; bounded remote workspace snapshot cache and dashboard row cache      | Existing sampled safeguards; no wire changes; clone cost unmeasured                   |
+| Resource leaks                       | Browser cleanup, model disposal, canceled subscriptions, retained agent status, hidden WebGL                       | Selected close/failure/retention contracts pass; full native-handle soak not measured |
+| Memory growth                        | Diagnostic payload retention; bounded metadata, review, diff and workspace snapshot caches                         | Measured sink fix; existing eviction/identity contracts                               |
+| Cache/dedupe                         | Worktree generation/deadline/distro keys, metadata auth-generation invalidation, hosted-review host identity       | Existing cache bounds and stale-settlement tests                                      |
+| SQL preparation and contention       | SQLite statement reuse/schema column parity; OpenCode scanner bounds                                               | Existing compile/schema contracts; live lock contention unmeasured                    |
+| Diagnostics/telemetry                | Disabled persistence diagnostics skip serialization; capped local file sink                                        | Measured rejected-payload retention fix                                               |
+| RPC/WebSocket (desktop/shared)       | Runtime long-poll caps, heartbeat lifecycle and browser stream pacing                                              | Existing selected transport contracts; mobile app excluded                            |
+| TypeScript/runtime hot paths         | Hydration/path indexes, named comparator search, full typecheck                                                    | Measured runtime fixes; full typecheck passed                                         |
+
+## Evidence limits and artifacts
+
+Every checklist category has a disposition above. The identified fixes have
+count, retention or ordering evidence; selected lifecycle and rendering checks
+passed. The unmeasured items are limits of this audit's evidence, not assertions
+of defects or promises of universal regression freedom. Native-focus/visible-window
+tests were not run on the user's desktop. Real SSH RTT and Windows/Linux execution
+were not measured; host boundaries were exercised through contract tests.
+
+Following the user's renewed instruction to continue, repository terminal,
+execution-host, ownership and remote-compatibility contracts were used in place
+of unavailable companion skills. Background-launch and isolated-profile policies
+remained enforced.
+
+Validation checkpoint at fix 50 (superseded by the final 75-fix checks below):
+
+- 442 tests across 58 changed suites passed (`/tmp/orca-perf-50-changed-tests.log`).
+- 126 tests across 12 additional contract suites passed (`/tmp/orca-perf-50-contracts.log`): 568 tests across 70 distinct suites in these final selections.
+- The final iteration fixture type correction was rechecked in its 12-test suite (`/tmp/orca-perf-50-final-fixture.log`); this is included in the 568, not additional coverage.
+- Full `ORCA_BACKGROUND_LAUNCH=1 pnpm tc` passed (`/tmp/orca-perf-50-tc.log`).
+- Changed-code quality, type-aware quality and React Doctor passed for all 124 changed code files (`/tmp/orca-perf-50-quality.log`). `git diff --check` passed.
+- Hidden Electron typing and rich-frame restore results above were collected during fixes 1–11. The later collection-transform changes were validated through unit and integration contracts; those rendered measurements were not rerun or presented as measurements of later fixes.
+
+Current-session artifacts:
+
+- `/tmp/orca-activation-scope-final-contracts.log`: activation unit/integration results.
+- `/tmp/orca-activation-final-typecheck.log` and
+  `/tmp/orca-activation-final-quality.log`: final static checks.
+- `/tmp/orca-perf-hidden-e2e-results.json`: rendered results and typing samples.
+- `/tmp/orca-perf-hidden-e2e-artifacts/`: hidden-renderer screenshot.
+- `/tmp/orca-perf-coverage-files.txt` and
+  `/tmp/orca-perf-lifecycle-coverage-files.txt`: expanded contract selections.
+
+## Final validation at 75 fixes
+
+- 569 tests across 82 changed suites passed (`/tmp/orca-perf-75-tests.log`).
+- 72 additional tests across four unchanged contract suites passed: SSH reattach cardinality, tab-create menu, native chat asks and pane-tree operations (`/tmp/orca-perf-75-contracts.log`). Final selection: 641 tests across 86 distinct suites.
+- Full `ORCA_BACKGROUND_LAUNCH=1 pnpm tc` passed (`/tmp/orca-perf-75-tc.log`).
+- Changed-code, type-aware and React Doctor quality gates passed across 179 code files (`/tmp/orca-perf-75-quality.log`).
+- `git diff --check` passed.
+- Negative controls through fix 75 and the earlier rendered evidence retain the limits described above. Final renderer collection changes were checked through automated contracts; no new visible-window run was performed.
+
+The completed scope is packaged as one draft PR. No deployment is included.
+
+Final commit-hook cleanup extracted SOCKS upstream delivery and AI-vault project-key formatting into focused modules without changing behavior. All 41 tests across their four relevant suites passed after extraction (`/tmp/orca-perf-75-extractions.log`); these overlap the earlier coverage and are not added to the total.

--- a/src/main/ai-vault/session-scanner-jsonl-reader.test.ts
+++ b/src/main/ai-vault/session-scanner-jsonl-reader.test.ts
@@ -1,0 +1,65 @@
+import { expect, it, vi } from 'vitest'
+import { consumeCompleteJsonlLines } from './session-scanner-jsonl-reader'
+
+const source = vi.hoisted(() => ({ chunks: [] as Buffer[] }))
+vi.mock('../native-chat/wsl-transcript-fs-access', () => ({
+  openTranscriptReadStream: async function* () {
+    yield* source.chunks
+  }
+}))
+
+it('copies only the carried line when the next chunk contains many complete lines', async () => {
+  source.chunks = Array.from({ length: 100 }, () => Buffer.from(`${'a\n'.repeat(1000)}x`))
+  const original = Buffer.concat
+  let copied = 0
+  const concat = vi.spyOn(Buffer, 'concat').mockImplementation((chunks, total) => {
+    copied += total ?? chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+    return original(chunks, total)
+  })
+  let lines = 0
+  let result: Awaited<ReturnType<typeof consumeCompleteJsonlLines>>
+  try {
+    result = await consumeCompleteJsonlLines({
+      path: '/log',
+      start: 0,
+      onLine: () => {
+        lines += 1
+      }
+    })
+  } finally {
+    concat.mockRestore()
+  }
+  expect(lines).toBe(100000)
+  expect(result!).toEqual({ consumedThrough: 200099, trailingPartialLine: 'x', bytesRead: 200100 })
+  expect(copied).toBeLessThan(1000)
+})
+
+it('preserves UTF-8/CRLF carry, byte callbacks and stop offsets', async () => {
+  source.chunks = [Buffer.from('ab\r'), Buffer.from('\ncd\npartial')]
+  const lines: string[] = []
+  expect(
+    await consumeCompleteJsonlLines({
+      path: '/log',
+      start: 5,
+      onLine: () => {},
+      onLineBytes: (line) => lines.push(line.toString())
+    })
+  ).toEqual({ consumedThrough: 12, trailingPartialLine: 'partial', bytesRead: 14 })
+  expect(lines).toEqual(['ab', 'cd'])
+  let stopped = false
+  expect(
+    await consumeCompleteJsonlLines({
+      path: '/log',
+      start: 5,
+      onLine: () => {
+        stopped = true
+      },
+      shouldStop: () => stopped
+    })
+  ).toEqual({ consumedThrough: 9, trailingPartialLine: null, bytesRead: 14 })
+  const unicode = Buffer.from('🦀\n')
+  source.chunks = [unicode.subarray(0, 2), unicode.subarray(2)]
+  const onLine = vi.fn()
+  await consumeCompleteJsonlLines({ path: '/log', start: 0, onLine })
+  expect(onLine).toHaveBeenCalledWith('🦀')
+})

--- a/src/main/ai-vault/session-scanner-jsonl-reader.ts
+++ b/src/main/ai-vault/session-scanner-jsonl-reader.ts
@@ -36,23 +36,25 @@ export async function consumeCompleteJsonlLines(args: {
       remainderLength += chunk.length
       continue
     }
-    const data =
-      remainderLength > 0
-        ? Buffer.concat([...remainderParts, chunk], remainderLength + chunk.length)
-        : chunk
-    remainderParts = []
-    remainderLength = 0
+    const data = chunk
+    const carriedLength = remainderLength
     let lineStart = 0
     let newlineIndex = data.indexOf(NEWLINE_BYTE, lineStart)
     while (newlineIndex !== -1) {
-      let lineEnd = newlineIndex
-      if (lineEnd > lineStart && data[lineEnd - 1] === CARRIAGE_RETURN_BYTE) {
-        lineEnd--
-      }
+      const line =
+        remainderLength > 0
+          ? Buffer.concat(
+              [...remainderParts, data.subarray(lineStart, newlineIndex)],
+              remainderLength + newlineIndex - lineStart
+            )
+          : data.subarray(lineStart, newlineIndex)
+      remainderParts = []
+      remainderLength = 0
+      const lineEnd = line.at(-1) === CARRIAGE_RETURN_BYTE ? line.length - 1 : line.length
       if (args.onLineBytes) {
-        args.onLineBytes(data.subarray(lineStart, lineEnd))
+        args.onLineBytes(line.subarray(0, lineEnd))
       } else {
-        args.onLine(data.toString('utf-8', lineStart, lineEnd))
+        args.onLine(line.toString('utf-8', 0, lineEnd))
       }
       lineStart = newlineIndex + 1
       if (args.shouldStop?.()) {
@@ -61,7 +63,7 @@ export async function consumeCompleteJsonlLines(args: {
       }
       newlineIndex = data.indexOf(NEWLINE_BYTE, lineStart)
     }
-    consumedThrough += lineStart
+    consumedThrough += carriedLength + lineStart
     if (stopped) {
       remainderParts = []
       remainderLength = 0

--- a/src/main/automations/external-job-mappers.ts
+++ b/src/main/automations/external-job-mappers.ts
@@ -71,7 +71,7 @@ function mapExternalRuns({
     .map((run, index) => {
       const runAt = asString(run.run_at) ?? asString(run.runAt)
       const id = asString(run.id) ?? `${jobId}:${runAt ?? index}`
-      return {
+      const mapped: ExternalAutomationRun = {
         id,
         managerId,
         provider,
@@ -83,15 +83,15 @@ function mapExternalRuns({
         error: asString(run.error),
         outputPath: asString(run.output_path) ?? asString(run.outputPath)
       }
+      return { run: mapped, time: runAt ? Date.parse(runAt) : Number.NaN }
     })
     .sort((a, b) => {
-      const aTime = a.runAt ? Date.parse(a.runAt) : Number.NaN
-      const bTime = b.runAt ? Date.parse(b.runAt) : Number.NaN
-      if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
-        return bTime - aTime
+      if (Number.isFinite(a.time) && Number.isFinite(b.time)) {
+        return b.time - a.time
       }
-      return b.id.localeCompare(a.id)
+      return b.run.id.localeCompare(a.run.id)
     })
+    .map(({ run }) => run)
 }
 
 function hermesScheduleDisplay(job: ExternalJobRecord): string {

--- a/src/main/automations/external-job-run-sorting.test.ts
+++ b/src/main/automations/external-job-run-sorting.test.ts
@@ -1,0 +1,38 @@
+import { expect, it, vi } from 'vitest'
+import { mapHermesJobs, mapOpenClawJobs } from './external-job-mappers'
+
+it.each([mapHermesJobs, mapOpenClawJobs])(
+  'parses run dates once and preserves provider fallback ordering',
+  (mapJobs) => {
+    const runs = Array.from({ length: 2000 }, (_, i) => ({
+      id: String(i),
+      run_at:
+        i % 137 === 0
+          ? 'invalid'
+          : new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString(),
+      output_content: `Output ${i}`,
+      status: 'completed'
+    }))
+    const parse = vi.spyOn(Date, 'parse')
+    let expected: typeof runs
+    let jobs: ReturnType<typeof mapHermesJobs>
+    try {
+      expected = [...runs].sort((a, b) => {
+        const left = Date.parse(a.run_at),
+          right = Date.parse(b.run_at)
+        return Number.isFinite(left) && Number.isFinite(right)
+          ? right - left
+          : b.id.localeCompare(a.id)
+      })
+      expect(parse.mock.calls.length).toBeGreaterThan(10_000)
+      parse.mockClear()
+      jobs = mapJobs('manager', [{ id: 'job', runs }])
+      expect(parse).toHaveBeenCalledTimes(2000)
+    } finally {
+      parse.mockRestore()
+    }
+    expect(jobs[0].runs.map((run) => run.id)).toEqual(expected.map((run) => run.id))
+    expect(jobs[0].runs.every((run) => run.outputContent === `Output ${run.id}`)).toBe(true)
+    expect(jobs[0].runs.every((run) => !('time' in run))).toBe(true)
+  }
+)

--- a/src/main/browser/remote-browser-socks-buffering.test.ts
+++ b/src/main/browser/remote-browser-socks-buffering.test.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from 'node:events'
+import { createServer, type Socket } from 'node:net'
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RemoteBrowserSocksServer } from './remote-browser-socks-server'
+
+vi.mock('node:net', () => ({
+  createServer: vi.fn(() => ({ listening: false }))
+}))
+
+function setup() {
+  const upstream = new PassThrough()
+  const write = vi.spyOn(upstream, 'write')
+  const opened = Promise.withResolvers<PassThrough>()
+  const open = vi.fn(() => opened.promise)
+  const server = new RemoteBrowserSocksServer({ open })
+  const socket = Object.assign(new EventEmitter(), {
+    remoteAddress: '127.0.0.1',
+    destroyed: false,
+    write: vi.fn(() => true),
+    pause: vi.fn(),
+    end: vi.fn((_reply, callback) => callback()),
+    pipe: vi.fn(),
+    destroy: vi.fn(() => {
+      socket.destroyed = true
+      socket.emit('close')
+    })
+  })
+  const accept = vi.mocked(createServer).mock.calls.at(-1)![0] as (socket: Socket) => void
+  accept(socket as unknown as Socket)
+  socket.emit('data', Buffer.from([5, 1, 0]))
+  socket.emit('data', Buffer.from([5, 1, 0, 1, 127, 0, 0, 1, 1, 187]))
+  return { server, socket, upstream, write, opened, open }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('pending browser SOCKS route buffering', () => {
+  it('copies fragmented pending bytes linearly and forwards every byte at the existing cap', async () => {
+    const { server, socket, upstream, write, opened } = setup()
+    const payload = Buffer.alloc(256 * 1024)
+    for (let index = 0; index < payload.length; index += 1) {
+      payload[index] = index % 251
+    }
+    let copiedBytes = 0
+    const originalCopy = Buffer.prototype.copy
+    const copy = vi.spyOn(Buffer.prototype, 'copy').mockImplementation(function (target, ...args) {
+      const copied = originalCopy.call(this, target, ...args)
+      copiedBytes += copied
+      return copied
+    })
+    const concat = vi.spyOn(Buffer, 'concat')
+    try {
+      for (let index = 0; index < payload.length; index += 256) {
+        socket.emit('data', payload.subarray(index, index + 256))
+      }
+      expect(concat.mock.calls.length).toBe(0)
+      expect(copiedBytes).toBeLessThan(payload.length * 3)
+      opened.resolve(upstream)
+      await vi.waitFor(() => expect(write).toHaveBeenCalledTimes(1))
+      expect(write.mock.calls[0][0]).toEqual(payload)
+    } finally {
+      copy.mockRestore()
+      concat.mockRestore()
+      await server.close()
+      upstream.destroy()
+    }
+  })
+
+  it('rejects one byte beyond the cap and destroys a late upstream without forwarding', async () => {
+    const { server, socket, upstream, write, opened, open } = setup()
+    try {
+      await vi.waitFor(() => expect(open).toHaveBeenCalledTimes(1))
+      socket.emit('data', Buffer.alloc(256 * 1024))
+      expect(socket.destroyed).toBe(false)
+      socket.emit('data', Buffer.from([1]))
+      expect(socket.destroyed).toBe(true)
+      expect(socket.end.mock.calls[0][0][1]).toBe(1)
+      opened.resolve(upstream)
+      await vi.waitFor(() => expect(upstream.destroyed).toBe(true))
+      expect(write).not.toHaveBeenCalled()
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('discards pending input on client close while the route is opening', async () => {
+    const { server, socket, upstream, write, opened, open } = setup()
+    try {
+      await vi.waitFor(() => expect(open).toHaveBeenCalledTimes(1))
+      socket.emit('data', Buffer.from('pending request'))
+      socket.destroy()
+      opened.resolve(upstream)
+      await vi.waitFor(() => expect(upstream.destroyed).toBe(true))
+      expect(write).not.toHaveBeenCalled()
+    } finally {
+      await server.close()
+    }
+  })
+})

--- a/src/main/browser/remote-browser-socks-server.ts
+++ b/src/main/browser/remote-browser-socks-server.ts
@@ -1,5 +1,7 @@
+import { pipeUpstreamToClient } from './remote-browser-socks-upstream'
 import { createServer, type Server, type Socket } from 'node:net'
 import type { Duplex } from 'node:stream'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 
 const SOCKS_VERSION = 5
 const SOCKS_NO_AUTH = 0
@@ -106,10 +108,13 @@ export class RemoteBrowserSocksServer {
     this.clients.add(socket)
     let phase: 'greeting' | 'request' | 'opening' | 'connected' | 'closed' = 'greeting'
     let buffered = Buffer.alloc(0)
+    const pendingUpstream = new GrowingByteBuffer()
     const timeout = setTimeout(() => socket.destroy(), HANDSHAKE_TIMEOUT_MS)
     const cleanup = (): void => {
       phase = 'closed'
       clearTimeout(timeout)
+      buffered = Buffer.alloc(0)
+      pendingUpstream.clear()
       this.clients.delete(socket)
     }
     const finishFailure = (reply: Uint8Array): void => {
@@ -119,6 +124,7 @@ export class RemoteBrowserSocksServer {
       phase = 'closed'
       clearTimeout(timeout)
       buffered = Buffer.alloc(0)
+      pendingUpstream.clear()
       socket.pause()
       socket.end(reply, () => socket.destroy())
     }
@@ -127,13 +133,15 @@ export class RemoteBrowserSocksServer {
       if (phase === 'closed' || phase === 'connected') {
         return
       }
-      buffered = Buffer.concat([buffered, chunk])
       if (phase === 'opening') {
-        if (buffered.byteLength > MAX_PENDING_UPSTREAM_BYTES) {
+        if (pendingUpstream.byteLength + chunk.byteLength > MAX_PENDING_UPSTREAM_BYTES) {
           fail(1)
+        } else {
+          pendingUpstream.append(chunk)
         }
         return
       }
+      buffered = Buffer.concat([buffered, chunk])
       if (phase === 'greeting' && buffered.byteLength > MAX_HANDSHAKE_BYTES) {
         fail(1)
         return
@@ -181,6 +189,8 @@ export class RemoteBrowserSocksServer {
         return
       }
       phase = 'opening'
+      pendingUpstream.append(buffered)
+      buffered = Buffer.alloc(0)
       void Promise.resolve()
         .then(() => this.open(normalizeListenerWildcard(parsed.target)))
         .then(
@@ -193,9 +203,8 @@ export class RemoteBrowserSocksServer {
             clearTimeout(timeout)
             socket.off('data', onData)
             socket.write(SUCCESS_RESPONSE)
-            if (buffered.byteLength > 0) {
-              upstream.write(buffered)
-              buffered = Buffer.alloc(0)
+            if (pendingUpstream.byteLength > 0) {
+              upstream.write(pendingUpstream.takeBuffer())
             }
             socket.pipe(upstream)
             pipeUpstreamToClient(upstream, socket)
@@ -210,22 +219,6 @@ export class RemoteBrowserSocksServer {
     socket.once('error', cleanup)
     socket.once('close', cleanup)
   }
-}
-
-function pipeUpstreamToClient(upstream: Duplex, socket: Socket): void {
-  upstream.on('data', (chunk: Buffer) => {
-    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-    const accepted = socket.write(bytes, (error) => {
-      if (!error && 'settleRead' in upstream && typeof upstream.settleRead === 'function') {
-        upstream.settleRead(bytes.byteLength)
-      }
-    })
-    if (!accepted) {
-      upstream.pause()
-    }
-  })
-  socket.on('drain', () => upstream.resume())
-  upstream.once('end', () => socket.end())
 }
 
 function parseSocksRequest(buffer: Uint8Array): SocksRequest | null | undefined {

--- a/src/main/browser/remote-browser-socks-upstream.ts
+++ b/src/main/browser/remote-browser-socks-upstream.ts
@@ -1,0 +1,18 @@
+import type { Socket } from 'node:net'
+import type { Duplex } from 'node:stream'
+
+export function pipeUpstreamToClient(upstream: Duplex, socket: Socket): void {
+  upstream.on('data', (chunk: Buffer) => {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    const accepted = socket.write(bytes, (error) => {
+      if (!error && 'settleRead' in upstream && typeof upstream.settleRead === 'function') {
+        upstream.settleRead(bytes.byteLength)
+      }
+    })
+    if (!accepted) {
+      upstream.pause()
+    }
+  })
+  socket.on('drain', () => upstream.resume())
+  upstream.once('end', () => socket.end())
+}

--- a/src/main/claude-usage/claude-usage-report-aggregation.ts
+++ b/src/main/claude-usage/claude-usage-report-aggregation.ts
@@ -1,3 +1,4 @@
+import { highestUsageKey } from '../usage/highest-usage-key'
 import type {
   ClaudeUsageBreakdownKind,
   ClaudeUsageBreakdownRow,
@@ -56,9 +57,8 @@ export function buildSummary(
     }
   }
 
-  const topModel = [...byModel.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
-  const topProject =
-    [...byProject.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
+  const topModel = highestUsageKey(byModel)
+  const topProject = highestUsageKey(byProject)
 
   return {
     scope,

--- a/src/main/claude-usage/worktree-attribution-scaling.test.ts
+++ b/src/main/claude-usage/worktree-attribution-scaling.test.ts
@@ -1,0 +1,53 @@
+import { expect, it, vi } from 'vitest'
+import { attributeClaudeUsageTurns } from './worktree-attribution'
+import type { ClaudeUsageParsedTurn } from './types'
+
+vi.mock('node:fs/promises', () => ({ realpath: async (path: string) => path }))
+
+it('resolves repeated nested and unmatched cwd paths once per attribution batch', async () => {
+  const lookup = new Map(
+    Array.from({ length: 100 }, (_, index) => [
+      `/repo-${String(index).padStart(3, '0')}`,
+      {
+        repoId: `repo-${index}`,
+        worktreeId: `wt-${index}`,
+        path: `/repo-${index}`,
+        displayName: `Repo ${index}`
+      }
+    ])
+  )
+  const input: ClaudeUsageParsedTurn[] = Array.from({ length: 1000 }, (_, index) => ({
+    sessionId: String(index),
+    timestamp: '2026-09-07T00:00:00Z',
+    model: null,
+    cwd: index % 2 === 0 ? '/repo-099/nested' : '/outside',
+    gitBranch: null,
+    inputTokens: 1,
+    outputTokens: 1,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    cacheWrite1hTokens: 0
+  }))
+  const original = String.prototype.startsWith
+  let comparisons = 0
+  const spy = vi.spyOn(String.prototype, 'startsWith').mockImplementation(function (
+    this: string,
+    search: string,
+    position?: number
+  ) {
+    if (search.slice(0, 6) === '/repo-') {
+      comparisons += 1
+    }
+    return original.call(this, search, position)
+  })
+  let result: Awaited<ReturnType<typeof attributeClaudeUsageTurns>>
+  try {
+    result = await attributeClaudeUsageTurns(input, lookup)
+  } finally {
+    spy.mockRestore()
+  }
+  expect(comparisons).toBeLessThanOrEqual(200)
+  expect(result![0].worktreeId).toBe('wt-99')
+  expect(result![1].worktreeId).toBeNull()
+  expect(result![1].projectKey).toBe('cwd:/outside')
+})

--- a/src/main/claude-usage/worktree-attribution.ts
+++ b/src/main/claude-usage/worktree-attribution.ts
@@ -105,7 +105,7 @@ export async function attributeClaudeUsageTurns(
   worktreeLookup: Map<string, ClaudeUsageWorktreeRef>
 ): Promise<ClaudeUsageAttributedTurn[]> {
   const attributed: ClaudeUsageAttributedTurn[] = []
-  const canonicalCwdByPath = new Map<string, string>()
+  const worktreeByCwd = new Map<string, ClaudeUsageWorktreeRef | null>()
 
   for (const turn of turns) {
     const day = localDayFromTimestamp(turn.timestamp)
@@ -119,14 +119,12 @@ export async function attributeClaudeUsageTurns(
     let projectLabel = getDefaultProjectLabel(turn.cwd)
 
     if (turn.cwd) {
-      let canonicalCwd = canonicalCwdByPath.get(turn.cwd)
-      if (canonicalCwd === undefined) {
-        // Why: Claude transcripts repeat the same cwd for many consecutive
-        // turns. Cache realpath work so attribution scales with unique paths.
-        canonicalCwd = await canonicalizePath(turn.cwd)
-        canonicalCwdByPath.set(turn.cwd, canonicalCwd)
+      let worktree = worktreeByCwd.get(turn.cwd)
+      if (worktree === undefined) {
+        const canonicalCwd = await canonicalizePath(turn.cwd)
+        worktree = findContainingWorktree(canonicalCwd, worktreeLookup)
+        worktreeByCwd.set(turn.cwd, worktree)
       }
-      const worktree = findContainingWorktree(canonicalCwd, worktreeLookup)
       if (worktree) {
         repoId = worktree.repoId
         worktreeId = worktree.worktreeId

--- a/src/main/codex-usage/codex-usage-rollup-projections.ts
+++ b/src/main/codex-usage/codex-usage-rollup-projections.ts
@@ -1,3 +1,4 @@
+import { highestUsageKey } from '../usage/highest-usage-key'
 import type {
   CodexUsageBreakdownKind,
   CodexUsageBreakdownRow,
@@ -57,9 +58,8 @@ export function buildSummary(
     }
   }
 
-  const topModel = [...byModel.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
-  const topProject =
-    [...byProject.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
+  const topModel = highestUsageKey(byModel)
+  const topProject = highestUsageKey(byProject)
 
   return {
     scope,

--- a/src/main/codex/codex-session-backfill-scan-dates.test.ts
+++ b/src/main/codex/codex-session-backfill-scan-dates.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   compareCodexSessionBackfillDates,
   expandCodexSessionBackfillDatesThroughToday,
@@ -98,5 +98,36 @@ describe('codex session backfill scan dates', () => {
     expect(
       expandCodexSessionBackfillDatesThroughToday([['2026', '01', '01']], ['2026', '08', '07'], 31)
     ).toBeNull()
+  })
+})
+
+describe('bounded backfill range construction', () => {
+  it('does not allocate rejected dates for a decades-old pending marker', () => {
+    const advance = vi.spyOn(Date.prototype, 'setUTCDate')
+    try {
+      expect(
+        expandCodexSessionBackfillDatesThroughToday(
+          [['2000', '01', '01']],
+          ['2026', '09', '07'],
+          31
+        )
+      ).toBeNull()
+      expect(advance).not.toHaveBeenCalled()
+    } finally {
+      advance.mockRestore()
+    }
+  })
+
+  it('keeps exact, fractional, leap-day and future-clock bounds', () => {
+    const dates = [['2024', '02', '28']] as [string, string, string][]
+    expect(expandCodexSessionBackfillDatesThroughToday(dates, ['2024', '03', '01'], 3)).toEqual([
+      ['2024', '02', '28'],
+      ['2024', '02', '29'],
+      ['2024', '03', '01']
+    ])
+    expect(expandCodexSessionBackfillDatesThroughToday(dates, ['2024', '03', '01'], 2.5)).toBeNull()
+    expect(
+      expandCodexSessionBackfillDatesThroughToday([['2024', '03', '01']], ['2024', '02', '28'], 3)
+    ).toEqual(expandCodexSessionBackfillDatesThroughToday(dates, ['2024', '03', '01'], 3))
   })
 })

--- a/src/main/codex/codex-session-backfill-scan-dates.ts
+++ b/src/main/codex/codex-session-backfill-scan-dates.ts
@@ -99,8 +99,13 @@ export function expandCodexSessionBackfillDatesThroughToday(
     return []
   }
   const bounds = mergeCodexSessionBackfillDates(dates, [today])
-  const range = getCodexSessionBackfillDatesBetween(toUtcDate(bounds[0]), toUtcDate(bounds.at(-1)!))
-  return range.length > maxDates ? null : range
+  const first = toUtcDate(bounds[0])
+  const last = toUtcDate(bounds.at(-1)!)
+  const dateCount = (last.getTime() - first.getTime()) / 86_400_000 + 1
+  if (dateCount > maxDates) {
+    return null
+  }
+  return getCodexSessionBackfillDatesBetween(first, last)
 }
 
 function toUtcDate([year, month, day]: readonly string[]): Date {

--- a/src/main/codex/codex-turn-ordinals.test.ts
+++ b/src/main/codex/codex-turn-ordinals.test.ts
@@ -1,0 +1,59 @@
+import { expect, it } from 'vitest'
+import {
+  CodexTurnOrdinals,
+  MAX_CODEX_TURN_ORDINAL_BYTES,
+  MAX_CODEX_TURN_ORDINAL_ENTRIES
+} from './codex-turn-ordinals'
+
+it('does not rescan the forgotten window for each new streamed item', () => {
+  const ordinals = new CodexTurnOrdinals()
+  for (let index = 0; index < MAX_CODEX_TURN_ORDINAL_ENTRIES; index += 1) {
+    ordinals.ordinalFor('thread', String(index), 'item')
+    ordinals.forgetTurn('thread', String(index))
+  }
+  const turns = (ordinals as unknown as { turns: Map<string, { active: boolean }> }).turns
+  let reads = 0
+  for (const turn of turns.values()) {
+    let active = turn.active
+    Object.defineProperty(turn, 'active', {
+      get() {
+        reads += 1
+        return active
+      },
+      set(value: boolean) {
+        active = value
+      }
+    })
+  }
+  for (let index = 0; index < 1000; index += 1) {
+    expect(ordinals.ordinalFor('thread', 'live', String(index))).toBe(index)
+  }
+  expect(reads).toBe(0)
+  expect(ordinals.forgottenTurnCount).toBe(MAX_CODEX_TURN_ORDINAL_ENTRIES)
+})
+
+it('retains ordinal continuity on late reactivation and evicts oldest forgotten turns', () => {
+  const ordinals = new CodexTurnOrdinals()
+  expect(ordinals.ordinalFor('t', 'first', 'a')).toBe(0)
+  ordinals.forgetTurn('t', 'first')
+  expect(ordinals.ordinalFor('t', 'first', 'b')).toBe(1)
+  expect(ordinals.forgottenTurnCount).toBe(0)
+  ordinals.forgetTurn('t', 'first')
+  for (let index = 0; index < MAX_CODEX_TURN_ORDINAL_ENTRIES; index += 1) {
+    ordinals.ordinalFor('t', String(index), 'a')
+    ordinals.forgetTurn('t', String(index))
+  }
+  expect(ordinals.forgottenTurnCount).toBe(MAX_CODEX_TURN_ORDINAL_ENTRIES)
+  expect(ordinals.ordinalFor('t', 'first', 'c')).toBe(0)
+})
+
+it('keeps byte eviction bounded for active and forgotten turns', () => {
+  const ordinals = new CodexTurnOrdinals()
+  for (let index = 0; index < 4000; index += 1) {
+    ordinals.ordinalFor('thread', 'live', `${index}-${'x'.repeat(240)}`)
+  }
+  expect(ordinals.bytes).toBeLessThanOrEqual(MAX_CODEX_TURN_ORDINAL_BYTES)
+  ordinals.forgetTurn('thread', 'live')
+  expect(ordinals.bytes).toBeLessThan(100)
+  expect(ordinals.forgottenTurnCount).toBe(1)
+})

--- a/src/main/codex/codex-turn-ordinals.ts
+++ b/src/main/codex/codex-turn-ordinals.ts
@@ -14,15 +14,10 @@ export class CodexTurnOrdinals {
     { assigned: Map<string, number>; next: number; active: boolean }
   >()
   private retainedBytes = 0
+  private readonly forgottenTurns = new Set<string>()
 
   get forgottenTurnCount(): number {
-    let count = 0
-    for (const turn of this.turns.values()) {
-      if (!turn.active) {
-        count += 1
-      }
-    }
-    return count
+    return this.forgottenTurns.size
   }
 
   get bytes(): number {
@@ -48,12 +43,13 @@ export class CodexTurnOrdinals {
 
   private trimForgotten(): void {
     while (this.forgottenTurnCount > MAX_CODEX_TURN_ORDINAL_ENTRIES) {
-      const oldest = [...this.turns.entries()].find(([, turn]) => !turn.active)?.[0]
+      const oldest = this.forgottenTurns.values().next().value
       if (!oldest) {
         break
       }
       const removed = this.turns.get(oldest)
       this.turns.delete(oldest)
+      this.forgottenTurns.delete(oldest)
       if (removed) {
         this.retainedBytes = Math.max(
           0,
@@ -68,7 +64,7 @@ export class CodexTurnOrdinals {
   private trimBytes(currentTurnKey: string): void {
     this.trimForgotten()
     while (this.retainedBytes > MAX_CODEX_TURN_ORDINAL_BYTES) {
-      const forgotten = [...this.turns.entries()].find(([, turn]) => !turn.active)?.[0]
+      const forgotten = this.forgottenTurns.values().next().value
       const oldest = forgotten ?? this.turns.keys().next().value
       if (typeof oldest !== 'string') {
         break
@@ -90,6 +86,7 @@ export class CodexTurnOrdinals {
         break
       }
       this.turns.delete(oldest)
+      this.forgottenTurns.delete(oldest)
       this.retainedBytes = Math.max(
         0,
         this.retainedBytes -
@@ -112,6 +109,7 @@ export class CodexTurnOrdinals {
         this.turns.set(turnKey, turn)
       }
       turn.active = true
+      this.forgottenTurns.delete(turnKey)
     }
     const itemKey = this.keyPart(codexItemId)
     const existing = turn.assigned.get(itemKey)
@@ -136,6 +134,8 @@ export class CodexTurnOrdinals {
       )
       turn.assigned = new Map()
       turn.active = false
+      this.forgottenTurns.delete(turnKey)
+      this.forgottenTurns.add(turnKey)
       this.retainedBytes = Math.max(0, this.retainedBytes - assignedBytes)
       this.turns.delete(turnKey)
       this.turns.set(turnKey, turn)

--- a/src/main/codex/config-toml-hook-trust-edit.ts
+++ b/src/main/codex/config-toml-hook-trust-edit.ts
@@ -56,7 +56,10 @@ function upsertTrustBlocks(
   hash: string,
   explicitEnabled?: boolean
 ): string {
-  const ranges = getUniqueTrustBlockRanges(content, keys)
+  const ranges = findHookTrustBlockRanges(
+    content,
+    new Set(keys.map(normalizeCodexHookTrustLookupKey))
+  )
   if (ranges.length === 0) {
     return appendTrustBlocks(content, keys, hash, explicitEnabled ?? true)
   }
@@ -72,21 +75,6 @@ function upsertTrustBlocks(
     cursor = range.end
   })
   return deduped + content.slice(cursor)
-}
-
-function getUniqueTrustBlockRanges(
-  content: string,
-  keys: readonly string[]
-): HookTrustBlockRange[] {
-  const normalizedKeys = new Set(keys.map(normalizeCodexHookTrustLookupKey))
-  return findHookTrustBlockRanges(content, normalizedKeys)
-    .filter(
-      (range, index, ranges) =>
-        ranges.findIndex(
-          (candidate) => candidate.start === range.start && candidate.end === range.end
-        ) === index
-    )
-    .sort((left, right) => left.start - right.start)
 }
 
 function isBlockDisabled(content: string, range: HookTrustBlockRange): boolean {

--- a/src/main/codex/config-toml-hook-trust-scaling.test.ts
+++ b/src/main/codex/config-toml-hook-trust-scaling.test.ts
@@ -1,0 +1,38 @@
+import type * as HookTrustBlocks from './config-toml-hook-trust-blocks'
+import { expect, it, vi } from 'vitest'
+import { upsertHookTrustContent } from './config-toml-hook-trust-edit'
+
+const counts = vi.hoisted(() => ({ starts: 0 }))
+vi.mock('./config-toml-hook-trust-blocks', async (importOriginal) => {
+  const actual = await importOriginal<typeof HookTrustBlocks>()
+  return {
+    ...actual,
+    findHookTrustBlockRanges: (...args: Parameters<typeof actual.findHookTrustBlockRanges>) =>
+      actual.findHookTrustBlockRanges(...args).map((range) => ({
+        ...range,
+        get start() {
+          counts.starts += 1
+          return range.start
+        }
+      }))
+  }
+})
+
+it('consumes monotonically scanned trust ranges without pairwise deduplication', () => {
+  const header = '[hooks.state."/foo/hooks.json:pre_tool_use:0:0"]'
+  const content = `${header}\nenabled = true\ntrusted_hash = "old"\n`.repeat(1000)
+  counts.starts = 0
+  const result = upsertHookTrustContent(content, [
+    {
+      sourcePath: '/foo/hooks.json',
+      eventLabel: 'pre_tool_use',
+      groupIndex: 0,
+      handlerIndex: 0,
+      command: '/bin/echo hi',
+      trustedHash: 'updated'
+    }
+  ])
+  expect(counts.starts).toBeLessThan(5000)
+  expect(result.split(header)).toHaveLength(2)
+  expect(result).toContain('trusted_hash = "updated"')
+})

--- a/src/main/gitlab/mr-file-diffs.ts
+++ b/src/main/gitlab/mr-file-diffs.ts
@@ -25,19 +25,23 @@ export function countDiffLines(diff: string): { additions: number; deletions: nu
   // diff line `---<content>`, colliding with the `--- a/file` header — so it must
   // be counted once inside a hunk, not skipped.
   let inHunk = false
-  for (const line of diff.split('\n')) {
-    if (line.startsWith('@@')) {
+  let cursor = 0
+  while (cursor < diff.length) {
+    if (diff.startsWith('@@', cursor)) {
       inHunk = true
-      continue
+    } else if (inHunk) {
+      const prefix = diff.charCodeAt(cursor)
+      if (prefix === 43) {
+        additions += 1
+      } else if (prefix === 45) {
+        deletions += 1
+      }
     }
-    if (!inHunk) {
-      continue
+    const newline = diff.indexOf('\n', cursor)
+    if (newline === -1) {
+      break
     }
-    if (line.startsWith('+')) {
-      additions += 1
-    } else if (line.startsWith('-')) {
-      deletions += 1
-    }
+    cursor = newline + 1
   }
   return { additions, deletions }
 }

--- a/src/main/gitlab/work-item-details.test.ts
+++ b/src/main/gitlab/work-item-details.test.ts
@@ -459,3 +459,14 @@ describe('countDiffLines', () => {
     expect(countDiffLines('@@ -1 +1 @@\n-@@ old\n+@@ new')).toEqual({ additions: 1, deletions: 1 })
   })
 })
+
+it('counts large diff prefixes without allocating a string array for every line', () => {
+  const diff = `--- a/file\n+++ b/file\n@@ -1 +1 @@\n${'-old\n+new\n context\n'.repeat(10000)}`
+  const split = vi.spyOn(String.prototype, 'split')
+  try {
+    expect(countDiffLines(diff)).toEqual({ additions: 10000, deletions: 10000 })
+    expect(split.mock.calls.length).toBe(0)
+  } finally {
+    split.mockRestore()
+  }
+})

--- a/src/main/ipc/filesystem-allowed-roots.test.ts
+++ b/src/main/ipc/filesystem-allowed-roots.test.ts
@@ -8,6 +8,7 @@ import { listRepoWorktreeGraph } from '../repo-worktrees'
 import type * as ProjectGroupsModule from '../../shared/project-groups'
 import { buildProjectGroupChildIndex, getProjectGroupSubtreeIds } from '../../shared/project-groups'
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
+import type * as CrossPlatformPathModule from '../../shared/cross-platform-path'
 import { getWorktreeMirrorDistro } from '../project-runtime-git-options'
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../shared/project-group-types'
@@ -30,6 +31,13 @@ vi.mock('../../shared/project-groups', async () => {
     buildProjectGroupChildIndex: vi.fn(actual.buildProjectGroupChildIndex),
     getProjectGroupSubtreeIds: vi.fn(actual.getProjectGroupSubtreeIds)
   }
+})
+
+vi.mock('../../shared/cross-platform-path', async () => {
+  const actual = await vi.importActual<typeof CrossPlatformPathModule>(
+    '../../shared/cross-platform-path'
+  )
+  return { ...actual, isPathInsideOrEqual: vi.fn(actual.isPathInsideOrEqual) }
 })
 
 type StoreFixture = {
@@ -257,6 +265,42 @@ beforeEach(() => {
 })
 
 describe('getAllowedRoots', () => {
+  it('stops scanning repositories when a local candidate settles each folder scope', () => {
+    const fixture: StoreFixture = {
+      repos: Array.from({ length: 1_000 }, (_, index) =>
+        makeRepo({ id: `repo-${index}`, path: `/folders/root/repo-${index}` })
+      ),
+      projects: [],
+      projectGroups: [],
+      folderWorkspaces: Array.from({ length: 100 }, (_, index) =>
+        makeWorkspace({ id: `folder-${index}`, folderPath: '/folders/root' })
+      )
+    }
+    const { store } = makeCountingStore(fixture)
+    vi.mocked(isPathInsideOrEqual).mockClear()
+    const actual = getAllowedRoots(store)
+    expect(isPathInsideOrEqual).toHaveBeenCalledTimes(100)
+    vi.mocked(isPathInsideOrEqual).mockClear()
+    expect(actual).toEqual(referenceAllowedRoots(store))
+    expect(isPathInsideOrEqual).toHaveBeenCalledTimes(100_000)
+  })
+
+  it('preserves empty, remote-only, mixed and explicit remote folder scopes in any repo order', () => {
+    const fixture = makeMixedFixture()
+    fixture.repos.push(
+      makeRepo({
+        id: 'local-in-remote-group',
+        path: '/local/mixed',
+        projectGroupId: 'group-remote'
+      })
+    )
+    for (let index = 0; index < fixture.repos.length; index += 1) {
+      fixture.repos.push(fixture.repos.shift()!)
+      const { store } = makeCountingStore(fixture)
+      expect(getAllowedRoots(store)).toEqual(referenceAllowedRoots(store))
+    }
+  })
+
   it('produces the same roots as the pre-change implementation', () => {
     const { store } = makeCountingStore(makeMixedFixture())
 

--- a/src/main/ipc/filesystem-allowed-roots.ts
+++ b/src/main/ipc/filesystem-allowed-roots.ts
@@ -27,20 +27,6 @@ export function getLocalRepos(store: Store) {
   return filterLocalRepos(store.getRepos())
 }
 
-function getFolderScopeCandidateRepos(
-  folderPath: string,
-  projectGroupId: string,
-  childGroupIndex: ProjectGroupChildIndex,
-  repos: readonly Repo[]
-): Repo[] {
-  const groupIds = collectProjectGroupSubtreeIds(childGroupIndex, projectGroupId)
-  return repos.filter(
-    (repo) =>
-      (typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)) ||
-      isPathInsideOrEqual(folderPath, repo.path)
-  )
-}
-
 function isRemoteOnlyFolderScope(
   folderPath: string,
   projectGroupId: string,
@@ -51,13 +37,21 @@ function isRemoteOnlyFolderScope(
   if (connectionId) {
     return true
   }
-  const candidates = getFolderScopeCandidateRepos(
-    folderPath,
-    projectGroupId,
-    childGroupIndex,
-    repos
-  )
-  return candidates.length > 0 && candidates.every((repo) => Boolean(repo.connectionId))
+  const groupIds = collectProjectGroupSubtreeIds(childGroupIndex, projectGroupId)
+  let hasRemoteCandidate = false
+  for (const repo of repos) {
+    if (
+      (typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)) ||
+      isPathInsideOrEqual(folderPath, repo.path)
+    ) {
+      // One local candidate settles the scope without scanning the remaining repositories.
+      if (!repo.connectionId) {
+        return false
+      }
+      hasRemoteCandidate = true
+    }
+  }
+  return hasRemoteCandidate
 }
 
 function getFolderWorkspaceConnectionId(

--- a/src/main/ipc/parcel-watcher-event-cancellation.test.ts
+++ b/src/main/ipc/parcel-watcher-event-cancellation.test.ts
@@ -1,0 +1,103 @@
+import { setImmediate } from 'node:timers/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+const { statMock } = vi.hoisted(() => ({ statMock: vi.fn() }))
+vi.mock('node:fs/promises', () => ({ stat: statMock }))
+import {
+  createWatcherProcessEventDeliveryQueue,
+  prepareWatcherProcessEvents
+} from './parcel-watcher-event-delivery'
+
+const delivery = { includeDirectoryMetadata: true, maxEventsPerBatch: 100 }
+const directory = { isDirectory: () => true }
+const events = (prefix: string, count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    type: 'update' as const,
+    path: `/${prefix}/${index}`
+  }))
+beforeEach(() => {
+  statMock.mockReset()
+})
+
+describe('closed watcher metadata work', () => {
+  it('removes queued lookups before a new live subscription needs their slots', async () => {
+    const gate = Promise.withResolvers<void>()
+    statMock.mockImplementation(async (path: string) => {
+      if (path.startsWith('/held/')) {
+        await gate.promise
+      }
+      return directory
+    })
+    const held = prepareWatcherProcessEvents(events('held', 8), delivery)
+    await setImmediate()
+    expect(statMock.mock.calls.length).toBe(8)
+    const deliver = vi.fn(async () => undefined)
+    const onError = vi.fn()
+    const queue = createWatcherProcessEventDeliveryQueue(delivery, deliver, onError)
+    let live: ReturnType<typeof prepareWatcherProcessEvents> | undefined
+    try {
+      queue.enqueue(events('closed', 32))
+      queue.close()
+      live = prepareWatcherProcessEvents(events('live', 1), delivery)
+      gate.resolve()
+      expect(await live).toEqual([{ type: 'update', path: '/live/0', isDirectory: true }])
+      await held
+      await setImmediate()
+      expect(statMock.mock.calls.map(([path]) => path)).toEqual([
+        ...events('held', 8).map((event) => event.path),
+        '/live/0'
+      ])
+      expect(deliver).not.toHaveBeenCalled()
+      expect(onError).not.toHaveBeenCalled()
+    } finally {
+      gate.resolve()
+      queue.close()
+      await held
+      await live
+    }
+  })
+
+  it('lets active stats settle without starting the rest of a closed batch', async () => {
+    const gate = Promise.withResolvers<void>()
+    statMock.mockImplementation(async () => {
+      await gate.promise
+      return directory
+    })
+    const deliver = vi.fn(async () => undefined)
+    const onError = vi.fn()
+    const queue = createWatcherProcessEventDeliveryQueue(delivery, deliver, onError)
+    try {
+      queue.enqueue(events('active', 32))
+      await setImmediate()
+      expect(statMock.mock.calls.length).toBe(8)
+      queue.close()
+      gate.resolve()
+      await setImmediate()
+      expect(statMock.mock.calls.length).toBe(8)
+      expect(deliver).not.toHaveBeenCalled()
+      expect(onError).not.toHaveBeenCalled()
+      await prepareWatcherProcessEvents(events('next', 8), delivery)
+      expect(statMock.mock.calls.length).toBe(16)
+    } finally {
+      gate.resolve()
+      queue.close()
+      await setImmediate()
+    }
+  })
+
+  it('still delivers file-like invalidations for live stat failures and skips deleted paths', async () => {
+    statMock.mockRejectedValue(new Error('file vanished'))
+    expect(
+      await prepareWatcherProcessEvents(
+        [
+          { type: 'update', path: '/vanished' },
+          { type: 'delete', path: '/deleted' }
+        ],
+        delivery
+      )
+    ).toEqual([
+      { type: 'update', path: '/vanished', isDirectory: false },
+      { type: 'delete', path: '/deleted' }
+    ])
+    expect(statMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/parcel-watcher-event-delivery.ts
+++ b/src/main/ipc/parcel-watcher-event-delivery.ts
@@ -1,4 +1,6 @@
 import { stat } from 'node:fs/promises'
+import { PrioritySemaphore } from '../../shared/priority-semaphore'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import type { Event as ParcelWatcherEvent } from '@parcel/watcher'
 import { MAX_BATCHED_WATCHER_EVENTS } from './filesystem-watcher-event-batch'
 import type {
@@ -7,70 +9,37 @@ import type {
 } from './parcel-watcher-process-protocol'
 
 const DIRECTORY_STAT_CONCURRENCY = 8
-let activeDirectoryStats = 0
-const directoryStatWaiters: (() => void)[] = []
+const directoryStatSlots = new PrioritySemaphore(DIRECTORY_STAT_CONCURRENCY)
 
 export type WatcherProcessEventDeliveryQueue = {
   enqueue(events: readonly ParcelWatcherEvent[]): void
   close(): void
 }
 
-async function acquireDirectoryStatSlot(): Promise<void> {
-  if (activeDirectoryStats < DIRECTORY_STAT_CONCURRENCY) {
-    activeDirectoryStats++
-    return
-  }
-  await new Promise<void>((resolve) => directoryStatWaiters.push(resolve))
-}
-
-function releaseDirectoryStatSlot(): void {
-  const next = directoryStatWaiters.shift()
-  if (next) {
-    // Transfer the existing slot directly so a newly arriving task cannot
-    // overtake this waiter and temporarily exceed the global budget.
-    next()
-    return
-  }
-  activeDirectoryStats--
-}
-
-async function statWatcherEventPath(eventPath: string): Promise<boolean> {
-  await acquireDirectoryStatSlot()
+async function statWatcherEventPath(eventPath: string, signal?: AbortSignal): Promise<boolean> {
+  const release = await directoryStatSlots.acquire(0, signal)
   try {
+    signal?.throwIfAborted()
     return (await stat(eventPath)).isDirectory()
   } finally {
-    releaseDirectoryStatSlot()
+    release()
   }
-}
-
-async function mapWithConcurrency<T, R>(
-  items: readonly T[],
-  limit: number,
-  mapper: (item: T) => Promise<R>
-): Promise<R[]> {
-  const results = Array.from<R>({ length: items.length })
-  let cursor = 0
-  const lane = async (): Promise<void> => {
-    while (cursor < items.length) {
-      const index = cursor++
-      results[index] = await mapper(items[index])
-    }
-  }
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, lane))
-  return results
 }
 
 async function mapWatcherEvent(
   event: ParcelWatcherEvent,
-  includeDirectoryMetadata: boolean
+  includeDirectoryMetadata: boolean,
+  signal?: AbortSignal
 ): Promise<WatcherProcessEvent> {
+  signal?.throwIfAborted()
   if (!includeDirectoryMetadata || event.type === 'delete') {
     return { type: event.type, path: event.path }
   }
   let isDirectory = false
   try {
-    isDirectory = await statWatcherEventPath(event.path)
+    isDirectory = await statWatcherEventPath(event.path, signal)
   } catch {
+    signal?.throwIfAborted()
     // Why: a path can vanish between the native event and metadata lookup.
     // Treat unknown metadata as a file-like event so parent invalidation still runs.
   }
@@ -79,8 +48,10 @@ async function mapWatcherEvent(
 
 export async function prepareWatcherProcessEvents(
   events: readonly ParcelWatcherEvent[],
-  delivery: WatcherProcessDeliveryOptions | undefined
+  delivery: WatcherProcessDeliveryOptions | undefined,
+  signal?: AbortSignal
 ): Promise<WatcherProcessEvent[] | null> {
+  signal?.throwIfAborted()
   if (delivery?.maxEventsPerBatch !== undefined && events.length > delivery.maxEventsPerBatch) {
     return null
   }
@@ -88,7 +59,7 @@ export async function prepareWatcherProcessEvents(
     return events.map((event) => ({ type: event.type, path: event.path }))
   }
   return mapWithConcurrency(events, DIRECTORY_STAT_CONCURRENCY, (event) =>
-    mapWatcherEvent(event, true)
+    mapWatcherEvent(event, true, signal)
   )
 }
 
@@ -99,6 +70,7 @@ export function createWatcherProcessEventDeliveryQueue(
   onError: (error: unknown) => void
 ): WatcherProcessEventDeliveryQueue {
   const eventLimit = delivery?.maxEventsPerBatch ?? MAX_BATCHED_WATCHER_EVENTS
+  const controller = new AbortController()
   let active = true
   let draining = false
   let pendingOverflow = false
@@ -119,7 +91,7 @@ export function createWatcherProcessEventDeliveryQueue(
           await deliver(null)
           continue
         }
-        const prepared = await prepareWatcherProcessEvents(events, delivery)
+        const prepared = await prepareWatcherProcessEvents(events, delivery, controller.signal)
         if (active) {
           await deliver(prepared)
         }
@@ -153,6 +125,7 @@ export function createWatcherProcessEventDeliveryQueue(
     },
     close(): void {
       active = false
+      controller.abort()
       pendingEvents = []
       pendingOverflow = false
     }

--- a/src/main/ipc/pty-activation-inventory-scope.test.ts
+++ b/src/main/ipc/pty-activation-inventory-scope.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest'
+import { setupPtyIpcSuite } from './pty-ipc-test-harness'
+import { registerSshPtyProvider, getLocalPtyProvider } from './pty'
+import { installPtyInspectIpcHandlers } from './pty/ipc/inspect'
+import { ptyOwnership } from './pty/provider/ownership-state'
+
+vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
+vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
+vi.mock('node-pty', () => import('./pty-ipc-mock-registry').then((m) => m.nodePtyModuleMock()))
+vi.mock('node:child_process', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).childProcessModuleMock(await importOriginal())
+)
+vi.mock('../opencode/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.openCodeHookServiceModuleMock())
+)
+vi.mock('../mimo/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.mimoHookServiceModuleMock())
+)
+vi.mock('../agent-hooks/server', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.agentHookServerModuleMock())
+)
+vi.mock('../pi/titlebar-extension-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.piTitlebarExtensionModuleMock())
+)
+vi.mock('../pwsh', () => import('./pty-ipc-mock-registry').then((m) => m.pwshModuleMock()))
+vi.mock('../wsl', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).wslModuleMock(await importOriginal())
+)
+vi.mock('../telemetry/client', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.telemetryClientModuleMock())
+)
+vi.mock('../telemetry/classify-error', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.classifyErrorModuleMock())
+)
+vi.mock('../cli/linux-terminal-orca-cli-shim', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.linuxCliShimModuleMock())
+)
+vi.mock('../memory/pty-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.ptyRegistryModuleMock())
+)
+vi.mock('../agent-hooks/migration-unsupported-pty-state', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.migrationUnsupportedPtyModuleMock())
+)
+vi.mock('../codex/codex-pane-account-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexPaneAccountRegistryModuleMock())
+)
+vi.mock('../codex/codex-state-db-backfill-recovery', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexBackfillRecoveryModuleMock())
+)
+
+describe('scoped activation PTY inventory', () => {
+  const { handlers, installDaemonTestProvider } = setupPtyIpcSuite()
+
+  function install() {
+    const localList = vi.fn(async () => [{ id: 'local', cwd: '/', title: 'shell' }])
+    installDaemonTestProvider({ listProcesses: localList })
+    const remoteLists = Array.from({ length: 50 }, (_, index) => {
+      const list = vi.fn(async () => [
+        {
+          id: `ssh:host-${index}@@pty-1`,
+          cwd: '/remote',
+          title: 'agent',
+          worktreeId: 'repo::/remote'
+        }
+      ])
+      registerSshPtyProvider(`host-${index}`, {
+        ...getLocalPtyProvider(),
+        listProcesses: list,
+        providesAgentSessionOwnerListings: () => true
+      })
+      return list
+    })
+    const startup = vi.fn(async () => {})
+    installPtyInspectIpcHandlers({ getLocalPtyProviderStartupPromise: startup })
+    const list = (scope?: unknown) => handlers.get('pty:listSessions')!(null, scope)
+    return { localList, remoteLists, startup, list }
+  }
+
+  it('queries only the chosen SSH provider and preserves workspace and ownership evidence', async () => {
+    const { list, localList, remoteLists, startup } = install()
+    expect(await list({ connectionId: 'host-17' })).toEqual([
+      {
+        id: 'ssh:host-17@@pty-1',
+        cwd: '/remote',
+        title: 'agent',
+        worktreeId: 'repo::/remote',
+        agentOwnership: 'absent'
+      }
+    ])
+    expect(remoteLists[17]).toHaveBeenCalledOnce()
+    expect(remoteLists.reduce((count, mock) => count + mock.mock.calls.length, 0)).toBe(1)
+    expect(localList).not.toHaveBeenCalled()
+    expect(startup).not.toHaveBeenCalled()
+    expect(ptyOwnership.get('ssh:host-17@@pty-1')).toBe('host-17')
+  })
+
+  it('waits for local startup and never visits remote providers for a local scope', async () => {
+    const { list, localList, remoteLists, startup } = install()
+    let release!: () => void
+    startup.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        })
+    )
+    const pending = list({ connectionId: null })
+    expect(localList).not.toHaveBeenCalled()
+    release()
+    await pending
+    expect(localList).toHaveBeenCalledOnce()
+    expect(remoteLists.every((mock) => mock.mock.calls.length === 0)).toBe(true)
+  })
+
+  it('propagates selected-host failure and never substitutes the local inventory', async () => {
+    const { list, localList, remoteLists } = install()
+    remoteLists[3].mockRejectedValue(new Error('relay unavailable'))
+    await expect(list({ connectionId: 'host-3' })).rejects.toThrow('relay unavailable')
+    await expect(list({ connectionId: 'missing' })).rejects.toThrow('No PTY provider')
+    expect(localList).not.toHaveBeenCalled()
+  })
+
+  it.each([null, {}, { connectionId: '' }, { connectionId: 42 }])(
+    'rejects malformed scope %j before inventory admission',
+    async (scope) => {
+      const { list, localList, remoteLists } = install()
+      await expect(list(scope)).rejects.toThrow('invalid_pty_session_list_scope')
+      expect(localList).not.toHaveBeenCalled()
+      expect(remoteLists.every((mock) => mock.mock.calls.length === 0)).toBe(true)
+    }
+  )
+
+  it('preserves unscoped diagnostic inventory and its remote-error fallback', async () => {
+    const { list, localList, remoteLists } = install()
+    remoteLists[3].mockRejectedValue(new Error('relay unavailable'))
+    expect(await list()).toHaveLength(50)
+    expect(localList).toHaveBeenCalledOnce()
+    expect(remoteLists.every((mock) => mock.mock.calls.length === 1)).toBe(true)
+  })
+})

--- a/src/main/ipc/pty/ipc/inspect.ts
+++ b/src/main/ipc/pty/ipc/inspect.ts
@@ -6,10 +6,11 @@ import {
   PtyProcessListAdmission,
   visitPtyProcessListingsInBatches
 } from '../../../providers/pty-process-list-admission'
-import type { PtyListedSession } from '../../../../shared/pty-listed-session'
+import type { PtyListedSession, PtySessionListScope } from '../../../../shared/pty-listed-session'
 import { ptyOwnership } from '../provider/ownership-state'
 import {
   getProviderForPty,
+  getProvider,
   hasPtyProviderForInspection,
   registeredPtyProviders,
   sshProviders,
@@ -40,37 +41,58 @@ export function installPtyInspectIpcHandlers(deps: {
     )
   }
 
-  ipcMain.handle('pty:listSessions', async (): Promise<PtyListedSession[]> => {
-    const deduped = new Map<string, PtyListedSession>()
-    const admission = new PtyProcessListAdmission()
-    await visitPtyProcessListingsInBatches(
-      registeredPtyProviders(),
-      ({ provider, connectionId }) =>
-        connectionId === null ? provider.listProcesses() : provider.listProcesses().catch(() => []),
-      ({ provider, connectionId }, sessions) => {
-        for (const rawSession of sessions) {
-          const session = admission.admit(rawSession)
-          // Why: kill actions only send back the PTY id, so rebuild ownership while listing to keep reconnect-discovered remote sessions routed to their provider.
-          ptyOwnership.set(session.id, connectionId)
-          deduped.set(session.id, {
-            id: session.id,
-            cwd: session.cwd,
-            title: session.title,
-            // Why: the renderer's binding map is empty during restore, so ownership is the only
-            // liveness evidence it has. Absence is authoritative only from a provider that
-            // serializes claims — otherwise it is 'unknown', never 'absent' (#8459).
-            agentOwnership:
-              (session.agentSessionOwners?.length ?? 0) > 0
-                ? 'present'
-                : provider.providesAgentSessionOwnerListings?.(session.id) === true
-                  ? 'absent'
-                  : 'unknown'
-          })
+  ipcMain.handle(
+    'pty:listSessions',
+    async (_event, scope?: PtySessionListScope): Promise<PtyListedSession[]> => {
+      if (scope !== undefined) {
+        if (
+          !scope ||
+          (scope.connectionId !== null &&
+            (typeof scope.connectionId !== 'string' || !scope.connectionId.trim()))
+        ) {
+          throw new Error('invalid_pty_session_list_scope')
+        }
+        // Select the daemon only after startup has handed off ownership.
+        if (scope.connectionId === null) {
+          await getLocalPtyProviderStartupPromise()
         }
       }
-    )
-    return Array.from(deduped.values())
-  })
+      const deduped = new Map<string, PtyListedSession>()
+      const admission = new PtyProcessListAdmission()
+      await visitPtyProcessListingsInBatches(
+        scope === undefined
+          ? registeredPtyProviders()
+          : [{ provider: getProvider(scope.connectionId), connectionId: scope.connectionId }],
+        ({ provider, connectionId }) =>
+          connectionId === null || scope !== undefined
+            ? provider.listProcesses()
+            : provider.listProcesses().catch(() => []),
+        ({ provider, connectionId }, sessions) => {
+          for (const rawSession of sessions) {
+            const session = admission.admit(rawSession)
+            // Why: kill actions only send back the PTY id, so rebuild ownership while listing to keep reconnect-discovered remote sessions routed to their provider.
+            ptyOwnership.set(session.id, connectionId)
+            deduped.set(session.id, {
+              id: session.id,
+              cwd: session.cwd,
+              title: session.title,
+              ...(session.worktreeId !== undefined ? { worktreeId: session.worktreeId } : {}),
+              // Why: the renderer's binding map is empty during restore, so ownership is the only
+              // liveness evidence it has. Absence is authoritative only from a provider that
+              // serializes claims — otherwise it is 'unknown', never 'absent' (#8459).
+              agentOwnership:
+                (session.agentSessionOwners?.length ?? 0) > 0
+                  ? 'present'
+                  : provider.providesAgentSessionOwnerListings?.(session.id) === true
+                    ? 'absent'
+                    : 'unknown'
+            })
+          }
+        }
+      )
+      return Array.from(deduped.values())
+    }
+  )
 
   ipcMain.handle(
     'pty:getAuthoritativeBufferSnapshotCapabilities',

--- a/src/main/jira/jira-issue-search.ts
+++ b/src/main/jira/jira-issue-search.ts
@@ -1,3 +1,4 @@
+import { sortByUpdatedAtDescending } from '../../shared/updated-at-order'
 import type { JiraIssue, JiraIssueFilter, JiraSiteSelection } from '../../shared/jira-types'
 import { acquire, release } from './request-queue'
 import { apiBasePath, jiraRequest, type JiraClientForSite } from './authenticated-request'
@@ -18,9 +19,7 @@ function clampLimit(limit: number | undefined, fallback = 30): number {
 }
 
 function sortAndLimitIssues(issues: JiraIssue[], limit: number): JiraIssue[] {
-  return issues
-    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-    .slice(0, limit)
+  return sortByUpdatedAtDescending(issues).slice(0, limit)
 }
 
 function filterToJql(filter: JiraIssueFilter): string {

--- a/src/main/linear/linear-issue-query-support.ts
+++ b/src/main/linear/linear-issue-query-support.ts
@@ -1,3 +1,4 @@
+import { sortByUpdatedAtDescending } from '../../shared/updated-at-order'
 import type { LinearIssue } from '../../shared/linear/issue-types'
 import type { LinearWorkspaceSelection } from '../../shared/linear/workspace-types'
 import { LINEAR_ISSUE_API_PAGE_SIZE_MAX } from '../../shared/linear/issue-read-limits'
@@ -30,18 +31,14 @@ export async function mapIssueForWorkspace(
 }
 
 export function sortAndLimitIssues(issues: LinearIssue[], limit: number): LinearIssue[] {
-  return issues
-    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-    .slice(0, limit)
+  return sortByUpdatedAtDescending(issues).slice(0, limit)
 }
 
 export function sortLimitAndDescribeIssues(
   issues: LinearIssue[],
   limit: number
 ): { items: LinearIssue[]; clipped: boolean } {
-  const sorted = issues.sort(
-    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-  )
+  const sorted = sortByUpdatedAtDescending(issues)
   return {
     items: sorted.slice(0, limit),
     clipped: sorted.length > limit

--- a/src/main/native-chat/agent-session-wire/agent-session-history-page-bounds.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-history-page-bounds.ts
@@ -53,8 +53,7 @@ export function boundHistoryItemsByBytes(
   submissionBytes: ReadonlyMap<string, number>,
   maxBytes: number
 ): { items: AgentJournalRenderItem[]; dropped: number } {
-  const groups = groupItemsBySequence(items)
-  const ordered = keep === 'newest' ? groups.toReversed() : groups
+  const ordered = groupItemsBySequence(items, keep)
   const kept: AgentJournalRenderItem[][] = []
   let total = 0
   for (const group of ordered) {
@@ -75,29 +74,39 @@ export function boundHistoryItemsByBytes(
   }
 }
 
-function groupItemsBySequence(
-  items: readonly AgentJournalRenderItem[]
-): AgentJournalRenderItem[][] {
-  const groups: AgentJournalRenderItem[][] = []
-  for (const item of items) {
-    const current = groups.at(-1)
-    if (current?.[0]?.sequence === item.sequence) {
-      current.push(item)
+function* groupItemsBySequence(
+  items: readonly AgentJournalRenderItem[],
+  keep: 'newest' | 'oldest'
+): Generator<AgentJournalRenderItem[]> {
+  let cursor = keep === 'newest' ? items.length : 0
+  while (keep === 'newest' ? cursor > 0 : cursor < items.length) {
+    if (keep === 'newest') {
+      let start = cursor - 1
+      const sequence = items[start].sequence
+      while (start > 0 && items[start - 1].sequence === sequence) {
+        start -= 1
+      }
+      yield items.slice(start, cursor)
+      cursor = start
     } else {
-      groups.push([item])
+      let end = cursor + 1
+      const sequence = items[cursor].sequence
+      while (end < items.length && items[end].sequence === sequence) {
+        end += 1
+      }
+      yield items.slice(cursor, end)
+      cursor = end
     }
   }
-  return groups
 }
 
 export function newestWholeSequenceGroups(
   items: readonly AgentJournalRenderItem[],
   limit: number
 ): AgentJournalRenderItem[] {
-  const groups = groupItemsBySequence(items)
   const selected: AgentJournalRenderItem[][] = []
   let count = 0
-  for (const group of groups.toReversed()) {
+  for (const group of groupItemsBySequence(items, 'newest')) {
     if (selected.length > 0 && count + group.length > limit) {
       break
     }

--- a/src/main/native-chat/agent-session-wire/agent-session-history-page-scaling.test.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-history-page-scaling.test.ts
@@ -1,0 +1,48 @@
+import { expect, it } from 'vitest'
+import type { AgentJournalRenderItem } from '../../../shared/agent-session-journal-types'
+import {
+  boundHistoryItemsByBytes,
+  newestWholeSequenceGroups
+} from './agent-session-history-page-bounds'
+
+function item(index: number): AgentJournalRenderItem {
+  return {
+    itemId: String(index),
+    revision: 1,
+    sequence: index,
+    observedAt: index,
+    body: { kind: 'status', text: 'ok' }
+  }
+}
+
+it('visits only the retained sequence window and its boundary', () => {
+  let reads = 0
+  const items = Array.from({ length: 10000 }, (_, index) => ({
+    ...item(index),
+    get sequence() {
+      reads += 1
+      return index
+    }
+  }))
+  expect(newestWholeSequenceGroups(items, 100).map((entry) => entry.itemId)).toEqual(
+    Array.from({ length: 100 }, (_, index) => String(9900 + index))
+  )
+  expect(reads).toBeLessThan(300)
+  reads = 0
+  expect(boundHistoryItemsByBytes(items, 'newest', new Map(), 1000).items.length).toBeGreaterThan(0)
+  expect(reads).toBeLessThan(100)
+})
+
+it('retains entire boundary groups and preserves oversized first-group truncation', () => {
+  const items = [item(1), { ...item(2), sequence: 1 }, item(3), { ...item(4), sequence: 3 }]
+  expect(newestWholeSequenceGroups(items, 1)).toEqual(items.slice(2))
+  expect(newestWholeSequenceGroups(items, 3)).toEqual(items.slice(2))
+  expect(boundHistoryItemsByBytes(items, 'oldest', new Map(), 1)).toMatchObject({
+    dropped: 2,
+    items: [{ itemId: '1' }, { itemId: '2' }]
+  })
+  expect(boundHistoryItemsByBytes(items, 'newest', new Map(), 1)).toMatchObject({
+    dropped: 2,
+    items: [{ itemId: '3' }, { itemId: '4' }]
+  })
+})

--- a/src/main/observability/local-file-sink-memory.test.ts
+++ b/src/main/observability/local-file-sink-memory.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createLocalFileSink, type LocalFileSink } from './local-file-sink'
+
+let directory: string
+let sink: LocalFileSink | undefined
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'orca-trace-memory-'))
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  sink?.close()
+  sink = undefined
+  vi.useRealTimers()
+  rmSync(directory, { recursive: true, force: true })
+})
+
+function retainedHeap(): number {
+  if (!globalThis.gc) {
+    throw new Error('Memory regression requires --expose-gc')
+  }
+  globalThis.gc()
+  globalThis.gc()
+  return process.memoryUsage().heapUsed
+}
+
+describe('trace sink rejected record retention', () => {
+  it('keeps small-record byte scans deferred until the batch flush', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    sink = createLocalFileSink({ filePath })
+    const byteLength = vi.spyOn(Buffer, 'byteLength')
+    let beforeFlush: number
+    let afterFlush: number
+    try {
+      for (let index = 0; index < 20; index++) {
+        sink.push({ index, text: '💡漢字' })
+      }
+      beforeFlush = byteLength.mock.calls.length
+      sink.flush()
+      afterFlush = byteLength.mock.calls.length
+    } finally {
+      byteLength.mockRestore()
+    }
+    expect(beforeFlush).toBe(0)
+    expect(afterFlush).toBe(20)
+  })
+
+  it('releases oversized serialized records before the pending batch flushes', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    sink = createLocalFileSink({ filePath, maxBytes: 64 * 1024, batchWindowMs: 200 })
+    const before = retainedHeap()
+    for (let index = 0; index < 24; index++) {
+      sink.push({ index, payload: 'x'.repeat(1024 * 1024) })
+    }
+    const retained = retainedHeap() - before
+    expect(statSync(filePath).size).toBe(0)
+    expect(vi.getTimerCount()).toBe(1)
+    expect(retained).toBeLessThan(5 * 1024 * 1024)
+    sink.push({ valid: true })
+    vi.advanceTimersByTime(200)
+    expect(readFileSync(filePath, 'utf8')).toBe('{"valid":true}\n')
+  })
+
+  it('keeps the same count-triggered flush for valid records beside rejected ones', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    sink = createLocalFileSink({ filePath, maxBytes: 32, flushBufferThreshold: 3 })
+    sink.push({ valid: 1 })
+    sink.push({ payload: '💡'.repeat(20) })
+    expect(statSync(filePath).size).toBe(0)
+    sink.push({ payload: 'x'.repeat(100) })
+    expect(readFileSync(filePath, 'utf8')).toBe('{"valid":1}\n')
+    sink.push({ valid: 2 })
+    vi.advanceTimersByTime(200)
+    expect(readFileSync(filePath, 'utf8')).toBe('{"valid":1}\n{"valid":2}\n')
+  })
+
+  it('accepts the exact UTF-8 byte cap and preserves rotation and close flushes', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    const record = { text: '💡' }
+    const line = `${JSON.stringify(record)}\n`
+    sink = createLocalFileSink({ filePath, maxBytes: Buffer.byteLength(line), maxFiles: 2 })
+    sink.push(record)
+    sink.push({ text: '💡x' })
+    sink.push(record)
+    sink.close()
+    expect(readFileSync(filePath, 'utf8')).toBe(line)
+    expect(readFileSync(`${filePath}.1`, 'utf8')).toBe(line)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/observability/local-file-sink.ts
+++ b/src/main/observability/local-file-sink.ts
@@ -77,7 +77,7 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
   let fd: number = openAppend(filePath)
   let currentBytes: number = safeFstatSize(fd)
 
-  let buffer: string[] = []
+  let buffer: (string | null)[] = []
   let timer: NodeJS.Timeout | null = null
   let closed = false
 
@@ -171,11 +171,10 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
     }
 
     for (const line of lines) {
-      const lineBytes = Buffer.byteLength(line, 'utf8')
-      if (lineBytes > maxBytes) {
-        // Oversized single span would blow the maxFiles × maxBytes envelope; drop just this record.
+      if (line === null) {
         continue
       }
+      const lineBytes = Buffer.byteLength(line, 'utf8')
       if (pendingChunkBytes > 0 && currentBytes + pendingChunkBytes + lineBytes > maxBytes) {
         flushPendingChunk()
       }
@@ -216,7 +215,12 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
         // Redactor handles cycles upstream; a throw here means pre-redact data slipped in — drop rather than crash (best-effort).
         return
       }
-      buffer.push(line)
+      // UTF-8 uses at most three bytes per UTF-16 unit; small records need no admission scan.
+      const oversized =
+        line.length > maxBytes ||
+        (line.length * 3 > maxBytes && Buffer.byteLength(line, 'utf8') > maxBytes)
+      // Count rejected records toward the flush threshold without retaining their payloads.
+      buffer.push(oversized ? null : line)
       if (buffer.length >= flushThreshold) {
         flushBuffer()
       } else {

--- a/src/main/opencode-usage/snapshot-rollups.ts
+++ b/src/main/opencode-usage/snapshot-rollups.ts
@@ -1,3 +1,4 @@
+import { highestUsageKey } from '../usage/highest-usage-key'
 import type {
   OpenCodeUsageBreakdownKind,
   OpenCodeUsageBreakdownRow,
@@ -47,9 +48,8 @@ export function buildOpenCodeUsageSummary(
     byProject.set(row.projectLabel, (byProject.get(row.projectLabel) ?? 0) + row.totalTokens)
   }
 
-  const topModel = [...byModel.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
-  const topProject =
-    [...byProject.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
+  const topModel = highestUsageKey(byModel)
+  const topProject = highestUsageKey(byProject)
 
   return {
     scope,

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.test.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../../shared/constants'
+import type { SshRemotePtyLease } from '../../../shared/ssh-types'
+import { clearSshRemotePtyBindingsForLeases } from './ssh-pty-binding-cleanup'
+
+function fixture(count: number) {
+  const state = getDefaultPersistedState('/home/test')
+  state.workspaceSession = getDefaultWorkspaceSession()
+  state.workspaceSession.tabsByWorktree.wt = Array.from({ length: count }, (_, i) => ({
+    id: `tab-${i}`,
+    worktreeId: 'wt',
+    ptyId: `pty-${i}`,
+    title: '',
+    customTitle: null,
+    color: null,
+    sortOrder: i,
+    createdAt: 1
+  }))
+  const leases: SshRemotePtyLease[] = Array.from({ length: count }, (_, i) => ({
+    targetId: 'ssh-one',
+    ptyId: `pty-${i}`,
+    tabId: `tab-${i}`,
+    worktreeId: 'wt',
+    state: 'detached',
+    createdAt: 1,
+    updatedAt: 1
+  }))
+  return {
+    state,
+    leases,
+    toComparablePtyId: vi.fn((_target: string, ptyId: string) => ptyId),
+    scheduleSave: vi.fn()
+  }
+}
+
+describe('SSH binding cleanup indexing', () => {
+  it('normalizes each binding once across a large lease inventory', () => {
+    const operations = fixture(1000)
+    expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(true)
+    expect(operations.toComparablePtyId).toHaveBeenCalledTimes(1000)
+    expect(
+      operations.state.workspaceSession!.tabsByWorktree.wt.every((tab) => tab.ptyId === null)
+    ).toBe(true)
+    expect(operations.scheduleSave).toHaveBeenCalledTimes(1)
+  })
+
+  it('retains foreign hosts and conflicting tab/workspace leases', () => {
+    const operations = fixture(4)
+    operations.leases[0].targetId = 'ssh-two'
+    operations.leases[1].tabId = 'other-tab'
+    operations.leases[2].worktreeId = 'other-workspace'
+    delete operations.leases[3].tabId
+    clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)
+    expect(operations.state.workspaceSession!.tabsByWorktree.wt.map((tab) => tab.ptyId)).toEqual([
+      'pty-0',
+      'pty-1',
+      'pty-2',
+      null
+    ])
+  })
+})
+
+it('matches layout leaves against every lease for a PTY while preserving leaf conflicts', () => {
+  const operations = fixture(1)
+  const session = operations.state.workspaceSession!
+  session.tabsByWorktree.wt[0].ptyId = null
+  session.terminalLayoutsByTabId['tab-0'] = {
+    root: null,
+    activeLeafId: null,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { matched: 'pty-0', protected: 'pty-0', wildcard: 'pty-1' }
+  }
+  const lease = operations.leases[0]
+  operations.leases = [
+    { ...lease, leafId: 'wrong' },
+    { ...lease, leafId: 'matched' },
+    { ...lease, ptyId: 'pty-1' }
+  ]
+  expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(true)
+  expect(session.terminalLayoutsByTabId['tab-0'].ptyIdsByLeafId).toEqual({ protected: 'pty-0' })
+  expect(operations.toComparablePtyId).toHaveBeenCalledTimes(3)
+})

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.ts
@@ -10,7 +10,6 @@ export type SshPtyBindingCleanupOperations = {
 }
 
 function sshRemotePtyLeaseMayReferenceBinding(
-  operations: SshPtyBindingCleanupOperations,
   lease: SshRemotePtyLease,
   binding: {
     ptyId: string
@@ -20,8 +19,7 @@ function sshRemotePtyLeaseMayReferenceBinding(
     leafId?: string
   }
 ): boolean {
-  const bindingPtyId = operations.toComparablePtyId(binding.targetId, binding.ptyId)
-  if (lease.targetId !== binding.targetId || lease.ptyId !== bindingPtyId) {
+  if (lease.targetId !== binding.targetId || lease.ptyId !== binding.ptyId) {
     return false
   }
   // Why: target removal is destructive; scrub matching bindings before deleting the lease, else removing the tombstone can revive stale PTY ids.
@@ -50,6 +48,26 @@ export function clearSshRemotePtyBindingsForLeases(
   if (!leases?.length) {
     return false
   }
+  const leasesByPtyId = new Map<string, SshRemotePtyLease[]>()
+  for (const lease of leases) {
+    if (lease.targetId !== targetId) {
+      continue
+    }
+    const entries = leasesByPtyId.get(lease.ptyId)
+    if (entries) {
+      entries.push(lease)
+    } else {
+      leasesByPtyId.set(lease.ptyId, [lease])
+    }
+  }
+  const referencesBinding = (
+    binding: Parameters<typeof sshRemotePtyLeaseMayReferenceBinding>[1]
+  ): boolean => {
+    const ptyId = operations.toComparablePtyId(binding.targetId, binding.ptyId)
+    return (leasesByPtyId.get(ptyId) ?? []).some((lease) =>
+      sshRemotePtyLeaseMayReferenceBinding(lease, { ...binding, ptyId })
+    )
+  }
   let changed = false
   const sessions = new Set(
     [
@@ -62,14 +80,7 @@ export function clearSshRemotePtyBindingsForLeases(
       for (const tab of tabs) {
         if (
           tab.ptyId &&
-          leases.some((lease) =>
-            sshRemotePtyLeaseMayReferenceBinding(operations, lease, {
-              ptyId: tab.ptyId!,
-              worktreeId,
-              targetId,
-              tabId: tab.id
-            })
-          )
+          referencesBinding({ ptyId: tab.ptyId, worktreeId, targetId, tabId: tab.id })
         ) {
           tab.ptyId = null
           changed = true
@@ -92,16 +103,7 @@ export function clearSshRemotePtyBindingsForLeases(
       const worktreeId = worktreeIdByTabId.get(tabId)
       const nextBindings = Object.fromEntries(
         Object.entries(bindings).filter(
-          ([leafId, ptyId]) =>
-            !leases.some((lease) =>
-              sshRemotePtyLeaseMayReferenceBinding(operations, lease, {
-                ptyId,
-                targetId,
-                worktreeId,
-                tabId,
-                leafId
-              })
-            )
+          ([leafId, ptyId]) => !referencesBinding({ ptyId, targetId, worktreeId, tabId, leafId })
         )
       )
       if (Object.keys(nextBindings).length !== Object.keys(bindings).length) {

--- a/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.test.ts
+++ b/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.test.ts
@@ -169,3 +169,24 @@ describe('workspace session terminal binding replay', () => {
     })
   })
 })
+
+it('indexes prior tabs once when replaying a large workspace snapshot', () => {
+  let reads = 0
+  const prior = session(null)
+  prior.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) => ({
+    ...terminalTab('worktree', `tab-${i}`, `pty-${i}`),
+    get id() {
+      reads++
+      return `tab-${i}`
+    }
+  }))
+  const incoming = session(null)
+  incoming.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) =>
+    terminalTab('worktree', `tab-${i}`, null)
+  )
+  preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
+  expect(reads).toBeLessThan(10_000)
+  expect(incoming.tabsByWorktree.worktree.map((tab) => tab.ptyId)).toEqual(
+    Array.from({ length: 1000 }, (_, i) => `pty-${i}`)
+  )
+})

--- a/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.ts
+++ b/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.ts
@@ -93,6 +93,7 @@ export function preserveMissingWorkspaceSessionTerminalBindings(
     if (!priorList) {
       continue
     }
+    let priorById: Map<string, (typeof priorList)[number]> | undefined
     for (const tab of tabs) {
       if (ambiguousTabIds.has(tab.id)) {
         continue
@@ -100,7 +101,8 @@ export function preserveMissingWorkspaceSessionTerminalBindings(
       if (tab.ptyId) {
         continue
       }
-      const priorTab = priorList.find((candidate) => candidate.id === tab.id)
+      priorById ??= new Map(priorList.map((candidate) => [candidate.id, candidate]))
+      const priorTab = priorById.get(tab.id)
       const incomingLayout = nextLayouts[tab.id]
       const priorLayout = priorLayouts[tab.id]
       const priorPtyLeafId = priorLayout

--- a/src/main/persistence/restoring-sessions/pane-alias-normalization-scaling.test.ts
+++ b/src/main/persistence/restoring-sessions/pane-alias-normalization-scaling.test.ts
@@ -1,0 +1,36 @@
+import { expect, it, vi } from 'vitest'
+import type { MigrationUnsupportedPtyEntry } from '../../../shared/agent-status-types'
+import { legacyMigrationUnsupportedRowsToAliasEntries } from './pane-alias-normalization'
+
+vi.mock('../../agent-hooks/server', () => ({ agentHookServer: {} }))
+
+it('retains only the ambiguity verdict when many legacy rows name the same tab', () => {
+  const row: MigrationUnsupportedPtyEntry = {
+    ptyId: 'pty',
+    tabId: 'tab',
+    paneKey: 'tab:11111111-1111-4111-8111-111111111111',
+    reason: 'legacy-numeric-pane-key',
+    source: 'local',
+    updatedAt: 1
+  }
+  const rows = Array.from({ length: 2000 }, () => row)
+  const iterator = Array.prototype[Symbol.iterator]
+  let copied = 0
+  Array.prototype[Symbol.iterator] = function (this: unknown[]) {
+    if (this[0] === row) {
+      copied += this.length
+    }
+    return iterator.call(this)
+  }
+  let aliases: ReturnType<typeof legacyMigrationUnsupportedRowsToAliasEntries>
+  try {
+    aliases = legacyMigrationUnsupportedRowsToAliasEntries(rows)
+  } finally {
+    Array.prototype[Symbol.iterator] = iterator
+  }
+  expect(copied).toBeLessThan(10_000)
+  expect(aliases).toEqual([])
+  const unique = legacyMigrationUnsupportedRowsToAliasEntries([row])
+  expect(unique.map((entry) => entry.legacyPaneKey)).toEqual(['tab:0', 'tab:1'])
+  expect(unique.every((entry) => entry.stablePaneKey === row.paneKey)).toBe(true)
+})

--- a/src/main/persistence/restoring-sessions/pane-alias-normalization.ts
+++ b/src/main/persistence/restoring-sessions/pane-alias-normalization.ts
@@ -14,21 +14,17 @@ export function legacyMigrationUnsupportedRowsToAliasEntries(
   const normalizedEntries = normalizeMigrationUnsupportedPtyEntries(entries).filter(
     (entry) => entry.tabId && entry.paneKey && parsePaneKey(entry.paneKey)
   )
-  const entriesByTabId = new Map<string, MigrationUnsupportedPtyEntry[]>()
+  const entriesByTabId = new Map<string, MigrationUnsupportedPtyEntry | null>()
   for (const entry of normalizedEntries) {
     const tabId = entry.tabId
     if (!tabId) {
       continue
     }
-    entriesByTabId.set(tabId, [...(entriesByTabId.get(tabId) ?? []), entry])
+    entriesByTabId.set(tabId, entriesByTabId.has(tabId) ? null : entry)
   }
   const aliasEntries: LegacyPaneKeyAliasEntry[] = []
-  for (const [tabId, tabEntries] of entriesByTabId) {
-    if (tabEntries.length !== 1) {
-      continue
-    }
-    const [entry] = tabEntries
-    if (!entry.paneKey) {
+  for (const [tabId, entry] of entriesByTabId) {
+    if (!entry?.paneKey) {
       continue
     }
     // Why: pre-stable rows lack the old numeric key; only synthesize single-pane aliases when the row is unambiguous.

--- a/src/main/plugins/plugin-audit-log-scaling.test.ts
+++ b/src/main/plugins/plugin-audit-log-scaling.test.ts
@@ -1,0 +1,42 @@
+import { expect, it, vi } from 'vitest'
+import { PluginAuditLog } from './plugin-audit-log'
+
+const source = vi.hoisted(() => ({ content: '' }))
+vi.mock('node:fs/promises', () => ({
+  readFile: async (path: string) => (path.endsWith('.1') ? '' : source.content)
+}))
+
+it('extracts the recent window without splitting all historical log records', async () => {
+  source.content = `${Array.from({ length: 10000 }, (_, ts) => JSON.stringify({ ts })).join('\n')}\n`
+  const split = vi.spyOn(String.prototype, 'split')
+  let entries: Awaited<ReturnType<PluginAuditLog['readRecent']>>
+  try {
+    entries = await new PluginAuditLog('/logs').readRecent(200)
+    expect(split.mock.calls.length).toBe(0)
+  } finally {
+    split.mockRestore()
+  }
+  expect(entries!.map((entry) => entry.ts)).toEqual(
+    Array.from({ length: 200 }, (_, index) => 9800 + index)
+  )
+})
+
+it('preserves blank, malformed, unterminated and unusual-limit selection', async () => {
+  source.content = '\n{"ts":1}\n\ninvalid\n \n{"ts":2}'
+  const original = (limit: number) =>
+    source.content
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .slice(-limit)
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line)]
+        } catch {
+          return []
+        }
+      })
+  const log = new PluginAuditLog('/logs')
+  for (const limit of [1, 2, 3, 4, 5, 0, -1, 0.5, 1.5, Infinity, Number.NaN]) {
+    expect(await log.readRecent(limit)).toEqual(original(limit))
+  }
+})

--- a/src/main/plugins/plugin-audit-log.ts
+++ b/src/main/plugins/plugin-audit-log.ts
@@ -71,8 +71,8 @@ export class PluginAuditLog {
         [this.rotatedFilePath, this.filePath].map((path) => readFile(path, 'utf8').catch(() => ''))
       )
       const text = rotated + current
-      const lines = text.split('\n').filter((line) => line.length > 0)
-      return lines.slice(-limit).flatMap((line) => {
+      const lines = recentAuditLines(text, limit)
+      return lines.flatMap((line) => {
         try {
           return [JSON.parse(line) as PluginAuditEntry]
         } catch {
@@ -83,4 +83,27 @@ export class PluginAuditLog {
       return []
     }
   }
+}
+
+function recentAuditLines(text: string, limit: number): string[] {
+  if (!Number.isFinite(limit) || limit < 1) {
+    return text
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .slice(-limit)
+  }
+  const lines: string[] = []
+  let end = text.length
+  const count = Math.trunc(limit)
+  while (end > 0 && lines.length < count) {
+    const start = text.lastIndexOf('\n', end - 1) + 1
+    if (start < end) {
+      lines.push(text.slice(start, end))
+    }
+    if (start === 0) {
+      break
+    }
+    end = start - 1
+  }
+  return lines.toReversed()
 }

--- a/src/main/project-groups/nested-repo-import.test.ts
+++ b/src/main/project-groups/nested-repo-import.test.ts
@@ -138,7 +138,9 @@ describe('createNestedProjectGroupResolver', () => {
       parentPath: '/workspace',
       groupName: 'workspace',
       mode: 'separate',
-      repoPaths: ['/workspace/services/api', '/workspace/services/worker'],
+      get repoPaths(): readonly string[] {
+        throw new Error('separate imports must not build unused folder scopes')
+      },
       createGroup: () => {
         throw new Error('should not create a group')
       }

--- a/src/main/project-groups/nested-repo-import.ts
+++ b/src/main/project-groups/nested-repo-import.ts
@@ -150,10 +150,10 @@ export function createNestedProjectGroupResolver(args: {
   createGroup: (input: CreateGroupInput) => ProjectGroup
 }): NestedProjectGroupResolver {
   const createdGroups: ProjectGroup[] = []
-  const folderScopes = buildSparseFolderScopes({
-    parentPath: args.parentPath,
-    repoPaths: args.repoPaths ?? []
-  })
+  const folderScopes =
+    args.mode === 'group'
+      ? buildSparseFolderScopes({ parentPath: args.parentPath, repoPaths: args.repoPaths ?? [] })
+      : []
   const folderScopesByRelativePath = new Map(
     folderScopes.map((scope) => [scope.relativePath, scope])
   )

--- a/src/main/runtime/runtime-terminal-orphan-topology-validation.test.ts
+++ b/src/main/runtime/runtime-terminal-orphan-topology-validation.test.ts
@@ -1,0 +1,71 @@
+import { expect, it } from 'vitest'
+import type { RuntimeTerminalOrphanAdoptionRequest } from '../../shared/runtime-types'
+import { validateRuntimeTerminalOrphanTopology } from './runtime-terminal-orphan-topology-validation'
+
+function fixture(count: number): RuntimeTerminalOrphanAdoptionRequest {
+  const ids = Array.from({ length: count }, (_, index) => `tab-${index}`)
+  return {
+    worktree: 'folder-workspace',
+    expectedTopologyRevision: 1,
+    claims: ids.map((tabId) => ({
+      tabId,
+      leafId: tabId,
+      terminal: tabId,
+      ptyId: tabId,
+      incarnationId: tabId
+    })) as RuntimeTerminalOrphanAdoptionRequest['claims'],
+    topology: {
+      tabs: ids.map((tabId) => ({
+        tabId,
+        root: { type: 'leaf', leafId: tabId },
+        activeLeafId: tabId,
+        expandedLeafId: null
+      })),
+      groups: [{ id: 'g', activeTabId: ids[0], tabOrder: ids, recentTabIds: ids.toReversed() }]
+    }
+  }
+}
+
+it('validates large restored MRU lists with linear tab-order reads', () => {
+  const request = fixture(1000)
+  let reads = 0
+  const group = request.topology!.groups[0]
+  group.tabOrder = new Proxy(group.tabOrder, {
+    get(target, key, receiver) {
+      if (typeof key === 'string' && /^\d+$/.test(key)) {
+        reads += 1
+      }
+      return Reflect.get(target, key, receiver)
+    }
+  })
+  expect(
+    validateRuntimeTerminalOrphanTopology(
+      request,
+      request.claims.map((claim) => ({ claim }))
+    ).topologyTabsById.size
+  ).toBe(1000)
+  expect(reads).toBeLessThanOrEqual(3000)
+})
+
+it.each(['duplicate', 'foreign-recent', 'foreign-active'])(
+  'rejects %s group membership',
+  (kind) => {
+    const request = fixture(2)
+    const group = request.topology!.groups[0]
+    if (kind === 'duplicate') {
+      group.tabOrder.push(group.tabOrder[0])
+    }
+    if (kind === 'foreign-recent') {
+      group.recentTabIds = ['foreign']
+    }
+    if (kind === 'foreign-active') {
+      group.activeTabId = 'foreign'
+    }
+    expect(() =>
+      validateRuntimeTerminalOrphanTopology(
+        request,
+        request.claims.map((claim) => ({ claim }))
+      )
+    ).toThrow('terminal_orphan_topology_invalid')
+  }
+)

--- a/src/main/runtime/runtime-terminal-orphan-topology-validation.ts
+++ b/src/main/runtime/runtime-terminal-orphan-topology-validation.ts
@@ -54,7 +54,8 @@ export function validateRuntimeTerminalOrphanTopology(
   const seenGroupIds = new Set<string>()
   const groupedTabIds = new Set<string>()
   for (const group of topologyGroups) {
-    if (seenGroupIds.has(group.id) || !group.tabOrder.includes(group.activeTabId)) {
+    const groupTabIds = new Set(group.tabOrder)
+    if (seenGroupIds.has(group.id) || !groupTabIds.has(group.activeTabId)) {
       throw new Error('terminal_orphan_topology_invalid')
     }
     seenGroupIds.add(group.id)
@@ -64,7 +65,7 @@ export function validateRuntimeTerminalOrphanTopology(
       }
       groupedTabIds.add(tabId)
     }
-    if (group.recentTabIds?.some((tabId) => !group.tabOrder.includes(tabId))) {
+    if (group.recentTabIds?.some((tabId) => !groupTabIds.has(tabId))) {
       throw new Error('terminal_orphan_topology_invalid')
     }
   }

--- a/src/main/runtime/workspace-session-membership-scaling.test.ts
+++ b/src/main/runtime/workspace-session-membership-scaling.test.ts
@@ -1,0 +1,52 @@
+import { expect, it, vi } from 'vitest'
+import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import { rebaseWorkspaceSessionTerminalMembership } from './workspace-session-terminal-membership-authority'
+
+it('rebases a large group without rescanning tab order for every recent tab', () => {
+  const ids = Array.from({ length: 1000 }, (_, index) => `tab-${index}`)
+  const session: WorkspaceSessionState = {
+    activeRepoId: 'repo',
+    activeWorktreeId: 'repo::/workspace',
+    activeTabId: null,
+    tabsByWorktree: {
+      'repo::/workspace': ids.map((id, index) => ({
+        id,
+        worktreeId: 'repo::/workspace',
+        ptyId: null,
+        title: id,
+        customTitle: null,
+        color: null,
+        sortOrder: index,
+        createdAt: 0
+      }))
+    },
+    terminalLayoutsByTabId: {},
+    terminalTopologyRevisionByRepoId: { repo: 1 },
+    tabGroups: {
+      'repo::/workspace': [
+        {
+          id: 'group',
+          worktreeId: 'repo::/workspace',
+          activeTabId: 'missing',
+          tabOrder: [...ids, 'missing'],
+          recentTabIds: [...ids, 'missing']
+        }
+      ]
+    }
+  }
+  const includes = vi.spyOn(Array.prototype, 'includes')
+  let result: WorkspaceSessionState
+  let probes: number
+  try {
+    result = rebaseWorkspaceSessionTerminalMembership(session, session)
+    probes = includes.mock.calls.length
+  } finally {
+    includes.mockRestore()
+  }
+  expect(probes).toBeLessThan(10)
+  expect(result.tabGroups?.['repo::/workspace'][0]).toMatchObject({
+    tabOrder: ids,
+    recentTabIds: ids,
+    activeTabId: ids[0]
+  })
+})

--- a/src/main/runtime/workspace-session-terminal-membership-authority.ts
+++ b/src/main/runtime/workspace-session-terminal-membership-authority.ts
@@ -93,11 +93,10 @@ function rebaseTabGroups(
     if (tabOrder.length === 0) {
       return []
     }
+    const tabIds = new Set(tabOrder)
     const activeTabId =
-      group.activeTabId && tabOrder.includes(group.activeTabId)
-        ? group.activeTabId
-        : (tabOrder[0] ?? null)
-    const recentTabIds = group.recentTabIds?.filter((tabId) => tabOrder.includes(tabId))
+      group.activeTabId && tabIds.has(group.activeTabId) ? group.activeTabId : (tabOrder[0] ?? null)
+    const recentTabIds = group.recentTabIds?.filter((tabId) => tabIds.has(tabId))
     return [
       {
         ...group,

--- a/src/main/skills/agent-skill-selection.test.ts
+++ b/src/main/skills/agent-skill-selection.test.ts
@@ -50,3 +50,28 @@ describe('agent skill selection', () => {
     ).toThrow(expect.objectContaining({ code: AGENT_SKILL_SELECTOR_AMBIGUOUS_CODE }))
   })
 })
+
+it('indexes a batch of selectors without rescanning discovery', () => {
+  let reads = 0
+  const skills = Array.from({ length: 1000 }, (_, index) => ({
+    ...skill(`id-${index}`, `name-${index}`),
+    get id() {
+      reads++
+      return `id-${index}`
+    }
+  }))
+  const selected = selectDiscoveredSkills(
+    skills,
+    skills.map((_, index) => `id-${index}`)
+  )
+  expect(selected).toHaveLength(1000)
+  expect(selected[999]).toBe(skills[999])
+  expect(reads).toBeLessThan(10000)
+})
+
+it('retains first duplicate ID authority and exact ID precedence over names', () => {
+  const first = skill('id', 'first')
+  expect(
+    selectDiscoveredSkills([first, skill('id', 'second'), skill('other', 'id')], ['id'])
+  ).toEqual([first])
+})

--- a/src/main/skills/agent-skill-selection.ts
+++ b/src/main/skills/agent-skill-selection.ts
@@ -10,13 +10,26 @@ export function selectDiscoveredSkills(
   selectors: readonly string[]
 ): DiscoveredSkill[] {
   const selected = new Map<string, DiscoveredSkill>()
+  const byId = new Map<string, DiscoveredSkill>()
+  const discoveredByName = new Map<string, DiscoveredSkill[]>()
+  for (const skill of skills) {
+    if (!byId.has(skill.id)) {
+      byId.set(skill.id, skill)
+    }
+    const named = discoveredByName.get(skill.name)
+    if (named) {
+      named.push(skill)
+    } else {
+      discoveredByName.set(skill.name, [skill])
+    }
+  }
   for (const selector of selectors) {
-    const exactId = skills.find((skill) => skill.id === selector)
+    const exactId = byId.get(selector)
     if (exactId) {
       selected.set(exactId.id, exactId)
       continue
     }
-    const named = skills.filter((skill) => skill.name === selector)
+    const named = discoveredByName.get(selector) ?? []
     if (named.length === 0) {
       throw new AgentSkillSharingError(
         AGENT_SKILL_SELECTOR_NOT_FOUND_CODE,
@@ -36,7 +49,12 @@ export function selectDiscoveredSkills(
   const values = [...selected.values()]
   const byName = new Map<string, DiscoveredSkill[]>()
   for (const skill of values) {
-    byName.set(skill.name, [...(byName.get(skill.name) ?? []), skill])
+    const named = byName.get(skill.name)
+    if (named) {
+      named.push(skill)
+    } else {
+      byName.set(skill.name, [skill])
+    }
   }
   const collision = [...byName.entries()].find(([, named]) => named.length > 1)
   if (collision) {

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../shared/skills'
 import {
   buildSkillDiscoverySources,
-  compareSkills,
+  sortDiscoveredSkills,
   sourceKindForSkill,
   sourceLabelForSkill,
   stablePathId,
@@ -292,7 +292,7 @@ export async function discoverSkills(args: {
       mergeScannedSkill(seen, skill)
     }
   }
-  const skills = Array.from(seen.values()).sort(compareSkills)
+  const skills = sortDiscoveredSkills(Array.from(seen.values()))
   // Why: root *ids* — a repo/plugin id is already a hash, while its label carries
   // the repo or plugin name and its path carries the user's directory names. A
   // fully cached scan did no filesystem work, so it stays silent rather than
@@ -307,11 +307,10 @@ export async function discoverSkills(args: {
       `[skills] scan roots=${roots.length} present=${present} walked=${walked.length} skills=${skills.length} ms=${Date.now() - startedAt} ids=${walked.slice(0, MAX_LOGGED_ROOT_IDS).join(',')}`
     )
   }
+  const compareSourceLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   return {
     skills,
-    sources: sources.sort((a, b) =>
-      a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
-    ),
+    sources: sources.sort((a, b) => compareSourceLabels(a.label, b.label)),
     scannedAt: Date.now()
   }
 }

--- a/src/main/skills/skill-cloud-grant-installation.test.ts
+++ b/src/main/skills/skill-cloud-grant-installation.test.ts
@@ -133,3 +133,38 @@ describe('installSkillCloudGrant', () => {
     )
   })
 })
+
+it.each(['skill-install-cancelled', 'skill-install-filesystem-failed'])(
+  'indexes selected IDs when reporting %s',
+  async (code) => {
+    let reads = 0
+    const ids = Array.from({ length: 1000 }, (_, index) => `skill-${index}`)
+    const selectedSkillIds = new Proxy(ids, {
+      get(target, key, receiver) {
+        if (typeof key === 'string' && /^\d+$/.test(key)) {
+          reads += 1
+        }
+        return Reflect.get(target, key, receiver)
+      }
+    })
+    const skills = ids.map((id) => ({ id, name: id, digest: 'a'.repeat(64), files: [] }))
+    const bundleGrant = {
+      ...grant,
+      version: { ...grant.version, manifest: { skills, bundleDigest: 'c'.repeat(64) } }
+    } as unknown as SkillCloudDownloadGrant
+    const runtime = {
+      installSharedSkillBundleRequest: vi.fn().mockRejectedValue(new Error(code))
+    } as unknown as OrcaRuntimeService
+    const result = await installSkillBundleCloudGrant(runtime, bundleGrant, {
+      operationId: 'op',
+      selectedSkillIds,
+      destination: { scope: 'global' }
+    })
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') {
+      expect(result.value.skills.map((skill) => skill.skillId)).toEqual(ids)
+      expect(result.value.status).toBe(code.includes('cancelled') ? 'cancelled' : 'failed')
+    }
+    expect(reads).toBeLessThanOrEqual(2000)
+  }
+)

--- a/src/main/skills/skill-cloud-grant-installation.ts
+++ b/src/main/skills/skill-cloud-grant-installation.ts
@@ -49,6 +49,7 @@ function bundleFailureResult(
   if (!('skills' in manifest)) {
     throw new Error('skill-bundle-cloud-manifest-required')
   }
+  const selectedSkillIds = new Set(request.selectedSkillIds)
   return {
     operationId: request.operationId,
     packageId: request.package.packageId,
@@ -56,7 +57,7 @@ function bundleFailureResult(
     bundleDigest: request.package.bundleDigest,
     status: failure.category === 'cancelled' ? 'cancelled' : 'failed',
     skills: manifest.skills
-      .filter((skill) => request.selectedSkillIds.includes(skill.id))
+      .filter((skill) => selectedSkillIds.has(skill.id))
       .map((skill) => ({
         skillId: skill.id,
         name: skill.name,

--- a/src/main/skills/skill-discovery-order.test.ts
+++ b/src/main/skills/skill-discovery-order.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DiscoveredSkill } from '../../shared/skills'
+import { sortDiscoveredSkills } from './skill-discovery-sources'
+
+function skill(index: number): DiscoveredSkill {
+  return {
+    id: String(index),
+    name: ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul'][index % 7],
+    description: null,
+    providers: ['codex'],
+    sourceKind: 'home',
+    sourceLabel: ['Home', 'hôme', 'Repo', 'repo'][index % 4],
+    rootPath: '/skills',
+    directoryPath: '/skills/example',
+    skillFilePath: `/skills/${index % 13}/SKILL.md`,
+    installed: true,
+    updatedAt: null
+  }
+}
+
+// Preserve the original comparator as the ordering and operation-count oracle.
+function compareOriginal(a: DiscoveredSkill, b: DiscoveredSkill): number {
+  return (
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) ||
+    a.sourceLabel.localeCompare(b.sourceLabel, undefined, { sensitivity: 'base' }) ||
+    a.skillFilePath.localeCompare(b.skillFilePath)
+  )
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('discovered skill ordering', () => {
+  it('preserves name, source, path and stable ties with one collator per sort', () => {
+    const skills = Array.from({ length: 2_000 }, (_, index) => skill(index))
+    const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+    const expected = [...skills].sort(compareOriginal)
+    const optionedCalls = (): number =>
+      localeCompare.mock.calls.filter((args) => args[2] !== undefined).length
+    expect(optionedCalls()).toBeGreaterThan(10_000)
+    localeCompare.mockClear()
+    const NativeCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+
+    expect(sortDiscoveredSkills(skills)).toBe(skills)
+    expect(skills.map(({ id }) => id)).toEqual(expected.map(({ id }) => id))
+    expect(optionedCalls()).toBe(0)
+    expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+    sortDiscoveredSkills([...skills])
+    expect(construct).toHaveBeenCalledTimes(2)
+  })
+
+  it('does no comparison setup for empty or singleton discovery results', () => {
+    const construct = vi.spyOn(Intl, 'Collator')
+    for (const skills of [[], [skill(0)]]) {
+      expect(sortDiscoveredSkills(skills)).toBe(skills)
+    }
+    expect(construct).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/skills/skill-discovery-sources.ts
+++ b/src/main/skills/skill-discovery-sources.ts
@@ -47,11 +47,16 @@ export function sourceLabelForSkill(root: SkillScanRoot, sourceKind: SkillSource
   return sourceKind === 'bundled' ? `${root.label} bundled` : root.label
 }
 
-export function compareSkills(a: DiscoveredSkill, b: DiscoveredSkill): number {
-  return (
-    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) ||
-    a.sourceLabel.localeCompare(b.sourceLabel, undefined, { sensitivity: 'base' }) ||
-    a.skillFilePath.localeCompare(b.skillFilePath)
+export function sortDiscoveredSkills(skills: DiscoveredSkill[]): DiscoveredSkill[] {
+  if (skills.length < 2) {
+    return skills
+  }
+  const compare = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
+  return skills.sort(
+    (a, b) =>
+      compare(a.name, b.name) ||
+      compare(a.sourceLabel, b.sourceLabel) ||
+      a.skillFilePath.localeCompare(b.skillFilePath)
   )
 }
 

--- a/src/main/skills/skill-discovery-wsl.test.ts
+++ b/src/main/skills/skill-discovery-wsl.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { SkillScanRoot } from './skill-discovery-sources'
 import { buildWslSkillDiscoveryCommand, parseWslSkillDiscoveryOutput } from './skill-discovery-wsl'
 
@@ -87,4 +87,30 @@ describe('WSL skill discovery', () => {
       'unknown source'
     )
   })
+})
+
+it('reuses one source collator while preserving locale, lexical numbers, and stable ties', () => {
+  const labels = Array.from(
+    { length: 200 },
+    (_, index) =>
+      ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul'][index % 7]
+  )
+  const roots = labels.map((label, index) => ({ ...homeRoot, id: String(index), label }))
+  const expected = [...roots].sort((a, b) =>
+    // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+    a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
+  )
+  const NativeCollator = Intl.Collator
+  const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+    return new NativeCollator(locales, options)
+  })
+  const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+  try {
+    const result = parseWslSkillDiscoveryOutput('', roots, 42)
+    expect(result.sources.map((source) => source.id)).toEqual(expected.map((root) => root.id))
+    expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+    expect(localeCompare).not.toHaveBeenCalled()
+  } finally {
+    vi.restoreAllMocks()
+  }
 })

--- a/src/main/skills/skill-discovery-wsl.ts
+++ b/src/main/skills/skill-discovery-wsl.ts
@@ -9,7 +9,7 @@ import { quoteBashString } from '../wsl-bash-command'
 import { runWslProcess } from '../wsl/wsl-runner'
 import {
   buildSkillDiscoverySources,
-  compareSkills,
+  sortDiscoveredSkills,
   sourceKindForSkill,
   sourceLabelForSkill,
   stablePathId,
@@ -161,11 +161,10 @@ export function parseWslSkillDiscoveryOutput(
       skippedReason: exists ? undefined : 'missing'
     }
   })
+  const compareSourceLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   return {
-    skills: [...skillsByCanonicalPath.values()].sort(compareSkills),
-    sources: sources.sort((a, b) =>
-      a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
-    ),
+    skills: sortDiscoveredSkills([...skillsByCanonicalPath.values()]),
+    sources: sources.sort((a, b) => compareSourceLabels(a.label, b.label)),
     scannedAt
   }
 }

--- a/src/main/skills/skill-update-convergence.test.ts
+++ b/src/main/skills/skill-update-convergence.test.ts
@@ -169,4 +169,24 @@ describe('convergableSkillNames', () => {
     )
     expect([...result]).toEqual(['orca-cli'])
   })
+  it('indexes placements once across many independent locked skills', () => {
+    let nameReads = 0
+    const installations = Array.from({ length: 1000 }, (_, index) => ({
+      ...placement(`skill-${index}`, index % 2 ? 2 : 1),
+      get name() {
+        nameReads++
+        return `skill-${index}`
+      }
+    }))
+    const locks = new Map(installations.map((entry) => [entry.name, STUB.gitTreeSha!]))
+    const snapshots = Object.fromEntries([...locks.keys()].map((name) => [name, [PRE_STUB, STUB]]))
+    nameReads = 0
+    expect([...convergableSkillNames(installations, locks, snapshots)]).toEqual(
+      [...locks.keys()].filter((_, index) => index % 2 === 1)
+    )
+    expect(nameReads).toBeLessThanOrEqual(1000)
+    nameReads = 0
+    expect([...convergableSkillNames(installations, new Map(), snapshots)]).toEqual([])
+    expect(nameReads).toBe(0)
+  })
 })

--- a/src/main/skills/skill-update-convergence.ts
+++ b/src/main/skills/skill-update-convergence.ts
@@ -28,18 +28,33 @@ export function convergableSkillNames(
   knownSnapshots: Readonly<Record<string, SkillKnownSnapshot[]>>
 ): ReadonlySet<string> {
   const convergable = new Set(globalSkillLocks.keys())
+  if (convergable.size === 0) {
+    return convergable
+  }
+  const observableByName = new Map<string, SkillFreshnessInstallation[]>()
+  for (const entry of installations) {
+    const name = entry.name
+    if (
+      !globalSkillLocks.has(name) ||
+      !SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(entry.topology) ||
+      !entry.observedPackageDigest
+    ) {
+      continue
+    }
+    const entries = observableByName.get(name)
+    if (entries) {
+      entries.push(entry)
+    } else {
+      observableByName.set(name, [entry])
+    }
+  }
   for (const [name, lockHash] of globalSkillLocks) {
     // Why: judged only over the placements the command writes, like eligibility
     // itself. A plugin-cache or repo copy is never the command's to converge, so
     // it must neither gate the name nor rescue it — an unidentifiable cache copy
     // (or one parked at the lock's own revision) would otherwise defeat the gate
     // and re-arm the unwinnable update.
-    const observable = installations.filter(
-      (entry) =>
-        entry.name === name &&
-        SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(entry.topology) &&
-        entry.observedPackageDigest
-    )
+    const observable = observableByName.get(name) ?? []
     if (observable.length === 0) {
       continue
     }

--- a/src/main/startup/os-opened-markdown-files.test.ts
+++ b/src/main/startup/os-opened-markdown-files.test.ts
@@ -304,3 +304,23 @@ describe('resolveOpenedMarkdownDocuments', () => {
     expect(authorizeExternalPath).not.toHaveBeenCalled()
   })
 })
+
+it('stops merging an OS file batch at the pending delivery cap', () => {
+  const state = new OsOpenedMarkdownFileState()
+  const includes = vi.spyOn(Array.prototype, 'includes')
+  let probes: number
+  try {
+    state.captureFilePaths(
+      Array.from({ length: 10000 }, (_, index) => resolve(`/notes/${index}.md`))
+    )
+    probes = includes.mock.calls.length
+  } finally {
+    includes.mockRestore()
+  }
+  expect(probes).toBeLessThan(100)
+  expect(state.consume()).toEqual(
+    Array.from({ length: MAX_PENDING_OS_OPENED_MARKDOWN_FILES }, (_, index) =>
+      resolve(`/notes/${index}.md`)
+    )
+  )
+})

--- a/src/main/startup/os-opened-markdown-files.ts
+++ b/src/main/startup/os-opened-markdown-files.ts
@@ -106,6 +106,9 @@ export class OsOpenedMarkdownFileState {
     }
     const merged = [...this.pending]
     for (const filePath of filePaths) {
+      if (merged.length >= MAX_PENDING_OS_OPENED_MARKDOWN_FILES) {
+        break
+      }
       if (!merged.includes(filePath)) {
         merged.push(filePath)
       }

--- a/src/main/usage/highest-usage-key.test.ts
+++ b/src/main/usage/highest-usage-key.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from 'vitest'
+import { highestUsageKey } from './highest-usage-key'
+
+it('reads each total once instead of sorting all projects for one winner', () => {
+  let reads = 0
+  const entries = Array.from({ length: 2000 }, (_, index): [string, number] => {
+    const pair: [string, number] = [String(index), (index * 173) % 2000]
+    Object.defineProperty(pair, '1', {
+      get() {
+        reads += 1
+        return (index * 173) % 2000
+      }
+    })
+    return pair
+  })
+  const totals = new Map(entries)
+  Object.defineProperty(totals, Symbol.iterator, { value: () => entries[Symbol.iterator]() })
+  reads = 0
+  const expected = [...totals].sort((left, right) => right[1] - left[1])[0][0]
+  expect(reads).toBeGreaterThan(10000)
+  reads = 0
+  expect(highestUsageKey(totals)).toBe(expected)
+  expect(reads).toBe(2000)
+})
+
+it('preserves empty, first-tie, negative and nonfinite ordering behavior', () => {
+  for (const values of [
+    [],
+    [1, 1, 0],
+    [-4, -2],
+    [1, Number.NaN, 2],
+    [Infinity, Infinity, 1],
+    [-Infinity, -Infinity]
+  ]) {
+    const totals = new Map(values.map((value, index) => [String(index), value]))
+    expect(highestUsageKey(totals)).toBe(
+      [...totals].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
+    )
+  }
+})

--- a/src/main/usage/highest-usage-key.ts
+++ b/src/main/usage/highest-usage-key.ts
@@ -1,0 +1,14 @@
+export function highestUsageKey(totals: ReadonlyMap<string, number>): string | null {
+  let bestKey: string | null = null
+  let bestTotal = Number.NEGATIVE_INFINITY
+  for (const [key, total] of totals) {
+    if (Number.isNaN(total)) {
+      return [...totals].sort((left, right) => right[1] - left[1])[0]?.[0] ?? null
+    }
+    if (bestKey === null || total > bestTotal) {
+      bestKey = key
+      bestTotal = total
+    }
+  }
+  return bestKey
+}

--- a/src/main/usage/usage-breakdown-scaling.test.ts
+++ b/src/main/usage/usage-breakdown-scaling.test.ts
@@ -1,0 +1,92 @@
+import { expect, it } from 'vitest'
+import { createUsageEventAggregation } from './usage-event-aggregation'
+import type { UsageAttributedEventFields } from './usage-rollup-records'
+
+type Event = UsageAttributedEventFields & { cost: number }
+const aggregation = createUsageEventAggregation<Event, { cost: number }>({
+  metric: {
+    empty: () => ({ cost: 0 }),
+    fromEvent: (event) => ({ cost: event.cost }),
+    fold: (target, source) => {
+      target.cost += source.cost
+    }
+  },
+  cloneSessionForMerge: (session) => structuredClone(session)
+})
+
+function events(count: number): Event[] {
+  return Array.from({ length: count }, (_, index) => ({
+    sessionId: 'session',
+    timestamp: '2026-09-07T00:00:00Z',
+    day: '2026-09-07',
+    model: `model-${index % 5}`,
+    projectKey: `path-${index}`,
+    projectLabel: `Path ${index}`,
+    repoId: null,
+    worktreeId: null,
+    inputTokens: 1,
+    cachedInputTokens: 0,
+    outputTokens: 2,
+    reasoningOutputTokens: 0,
+    totalTokens: 3,
+    cost: 0.5
+  }))
+}
+
+it('folds events without rescanning accumulated location breakdowns', () => {
+  let reads = 0
+  const input = events(1000)
+  input.forEach((event, index) =>
+    Object.defineProperty(event, 'projectKey', {
+      get() {
+        reads += 1
+        return `path-${index}`
+      }
+    })
+  )
+  const result = aggregation.aggregate([...input, ...input])
+  expect(reads).toBeLessThan(30000)
+  const session = result.sessions[0]
+  expect(session.totalTokens).toBe(6000)
+  expect(session.cost).toBe(1000)
+  expect(session.locationBreakdown).toHaveLength(1000)
+  expect(session.locationBreakdown.every((entry) => entry.eventCount === 2)).toBe(true)
+  expect(session.modelBreakdown).toHaveLength(5)
+  expect(result.dailyAggregates).toHaveLength(1000)
+})
+
+it('merges rollups using first-match indexes without mutating source breakdowns', () => {
+  const source = aggregation.aggregate(events(1000)).sessions[0]
+  const existing = structuredClone(source)
+  let reads = 0
+  for (const entry of [...existing.locationBreakdown, ...existing.locationModelBreakdown]) {
+    const key = entry.locationKey
+    Object.defineProperty(entry, 'locationKey', {
+      get() {
+        reads += 1
+        return key
+      }
+    })
+  }
+  const target = new Map([['session', existing]])
+  aggregation.mergeSessions(target, [source, source])
+  expect(reads).toBeLessThan(10000)
+  expect(existing.totalTokens).toBe(9000)
+  expect(existing.cost).toBe(1500)
+  expect(source.totalTokens).toBe(3000)
+  expect(existing.locationBreakdown.every((entry) => entry.eventCount === 3)).toBe(true)
+})
+
+it('preserves first-wins duplicate rows and exact location/model tuple identity', () => {
+  const source = aggregation.aggregate(events(1)).sessions[0]
+  const existing = structuredClone(source)
+  existing.locationBreakdown.push({ ...existing.locationBreakdown[0], eventCount: 42 })
+  aggregation.mergeSessions(new Map([['session', existing]]), [source])
+  expect(existing.locationBreakdown.map((entry) => entry.eventCount)).toEqual([2, 42])
+  const input = events(2)
+  input[0].projectKey = 'a::b'
+  input[0].model = 'c'
+  input[1].projectKey = 'a'
+  input[1].model = 'b::c'
+  expect(aggregation.aggregate(input).sessions[0].locationModelBreakdown).toHaveLength(2)
+})

--- a/src/main/usage/usage-event-aggregation.ts
+++ b/src/main/usage/usage-event-aggregation.ts
@@ -1,3 +1,8 @@
+import {
+  indexUsageSessionBreakdowns,
+  usageLocationModelKey,
+  type UsageSessionBreakdownIndex
+} from './usage-session-breakdown-index'
 /**
  * Folds attributed usage events into per-session and per-day rollups. Shared by every
  * event-based usage provider so a token-accounting fix lands in all of them at once.
@@ -71,9 +76,10 @@ export function createUsageEventAggregation<
   function foldLocation(
     target: UsageLocationBreakdown<TMetric>[],
     event: TEvent,
-    eventMetric: TMetric
+    eventMetric: TMetric,
+    index: UsageSessionBreakdownIndex<TMetric>['locations']
   ): void {
-    const existing = target.find((entry) => entry.locationKey === event.projectKey) ?? null
+    const existing = index.get(event.projectKey)
     if (existing) {
       existing.eventCount++
       existing.inputTokens += event.inputTokens
@@ -85,7 +91,7 @@ export function createUsageEventAggregation<
       return
     }
 
-    target.push({
+    const entry: UsageLocationBreakdown<TMetric> = {
       locationKey: event.projectKey,
       projectLabel: event.projectLabel,
       repoId: event.repoId,
@@ -97,16 +103,19 @@ export function createUsageEventAggregation<
       reasoningOutputTokens: event.reasoningOutputTokens,
       totalTokens: event.totalTokens,
       ...eventMetric
-    })
+    }
+    target.push(entry)
+    index.set(event.projectKey, entry)
   }
 
   function foldModel(
     target: UsageModelBreakdown<TMetric>[],
     event: TEvent,
-    eventMetric: TMetric
+    eventMetric: TMetric,
+    index: UsageSessionBreakdownIndex<TMetric>['models']
   ): void {
     const key = event.model ?? 'unknown'
-    const existing = target.find((entry) => entry.modelKey === key) ?? null
+    const existing = index.get(key)
     if (existing) {
       existing.eventCount++
       existing.inputTokens += event.inputTokens
@@ -118,7 +127,7 @@ export function createUsageEventAggregation<
       return
     }
 
-    target.push({
+    const entry: UsageModelBreakdown<TMetric> = {
       modelKey: key,
       modelLabel: event.model ?? 'Unknown model',
       eventCount: 1,
@@ -128,19 +137,19 @@ export function createUsageEventAggregation<
       reasoningOutputTokens: event.reasoningOutputTokens,
       totalTokens: event.totalTokens,
       ...eventMetric
-    })
+    }
+    target.push(entry)
+    index.set(key, entry)
   }
 
   function foldLocationModel(
     target: UsageLocationModelBreakdown<TMetric>[],
     event: TEvent,
-    eventMetric: TMetric
+    eventMetric: TMetric,
+    index: UsageSessionBreakdownIndex<TMetric>['locationModels']
   ): void {
     const modelKey = event.model ?? 'unknown'
-    const existing =
-      target.find(
-        (entry) => entry.locationKey === event.projectKey && entry.modelKey === modelKey
-      ) ?? null
+    const existing = index.get(usageLocationModelKey(event.projectKey, modelKey))
     if (existing) {
       existing.eventCount++
       existing.inputTokens += event.inputTokens
@@ -152,7 +161,7 @@ export function createUsageEventAggregation<
       return
     }
 
-    target.push({
+    const entry: UsageLocationModelBreakdown<TMetric> = {
       locationKey: event.projectKey,
       modelKey,
       modelLabel: event.model ?? 'Unknown model',
@@ -165,7 +174,9 @@ export function createUsageEventAggregation<
       reasoningOutputTokens: event.reasoningOutputTokens,
       totalTokens: event.totalTokens,
       ...eventMetric
-    })
+    }
+    target.push(entry)
+    index.set(usageLocationModelKey(event.projectKey, modelKey), entry)
   }
 
   function finalizeSessions(
@@ -209,6 +220,7 @@ export function createUsageEventAggregation<
   } {
     const sessionsById = new Map<string, UsageSession<TMetric>>()
     const dailyByKey = new Map<string, UsageDailyAggregate<TMetric>>()
+    const breakdownsBySession = new Map<string, UsageSessionBreakdownIndex<TMetric>>()
 
     for (const event of events) {
       const eventMetric = metric.fromEvent(event)
@@ -229,9 +241,19 @@ export function createUsageEventAggregation<
       session.totalReasoningOutputTokens += event.reasoningOutputTokens
       session.totalTokens += event.totalTokens
       metric.fold(session, eventMetric)
-      foldLocation(session.locationBreakdown, event, eventMetric)
-      foldModel(session.modelBreakdown, event, eventMetric)
-      foldLocationModel(session.locationModelBreakdown, event, eventMetric)
+      let breakdowns = breakdownsBySession.get(event.sessionId)
+      if (!breakdowns) {
+        breakdowns = indexUsageSessionBreakdowns(session)
+        breakdownsBySession.set(event.sessionId, breakdowns)
+      }
+      foldLocation(session.locationBreakdown, event, eventMetric, breakdowns.locations)
+      foldModel(session.modelBreakdown, event, eventMetric, breakdowns.models)
+      foldLocationModel(
+        session.locationModelBreakdown,
+        event,
+        eventMetric,
+        breakdowns.locationModels
+      )
 
       const dailyKey = usageDailyAggregateKey(event)
       const daily = dailyByKey.get(dailyKey) ?? createEmptyDailyAggregate(event)

--- a/src/main/usage/usage-rollup-merge.ts
+++ b/src/main/usage/usage-rollup-merge.ts
@@ -1,3 +1,8 @@
+import {
+  indexUsageSessionBreakdowns,
+  usageLocationModelKey,
+  type UsageSessionBreakdownIndex
+} from './usage-session-breakdown-index'
 /** Combines rollups produced by separate sources (rollout files, sibling databases) of one provider. */
 import {
   usageDailyAggregateKey,
@@ -16,6 +21,7 @@ export function mergeUsageSessions<TMetric extends object>(
   sessions: UsageSession<TMetric>[],
   { fold, cloneSessionForMerge }: UsageRollupMergeOptions<TMetric>
 ): void {
+  const breakdownsBySession = new Map<string, UsageSessionBreakdownIndex<TMetric>>()
   for (const session of sessions) {
     const existing = target.get(session.sessionId)
     if (!existing) {
@@ -39,10 +45,13 @@ export function mergeUsageSessions<TMetric extends object>(
     existing.totalTokens += session.totalTokens
     fold(existing, session)
 
+    let breakdowns = breakdownsBySession.get(session.sessionId)
+    if (!breakdowns) {
+      breakdowns = indexUsageSessionBreakdowns(existing)
+      breakdownsBySession.set(session.sessionId, breakdowns)
+    }
     for (const location of session.locationBreakdown) {
-      const existingLocation =
-        existing.locationBreakdown.find((entry) => entry.locationKey === location.locationKey) ??
-        null
+      const existingLocation = breakdowns.locations.get(location.locationKey)
       if (existingLocation) {
         existingLocation.eventCount += location.eventCount
         existingLocation.inputTokens += location.inputTokens
@@ -52,13 +61,14 @@ export function mergeUsageSessions<TMetric extends object>(
         existingLocation.totalTokens += location.totalTokens
         fold(existingLocation, location)
       } else {
-        existing.locationBreakdown.push({ ...location })
+        const copy = { ...location }
+        existing.locationBreakdown.push(copy)
+        breakdowns.locations.set(location.locationKey, copy)
       }
     }
 
     for (const model of session.modelBreakdown) {
-      const existingModel =
-        existing.modelBreakdown.find((entry) => entry.modelKey === model.modelKey) ?? null
+      const existingModel = breakdowns.models.get(model.modelKey)
       if (existingModel) {
         existingModel.eventCount += model.eventCount
         existingModel.inputTokens += model.inputTokens
@@ -68,17 +78,16 @@ export function mergeUsageSessions<TMetric extends object>(
         existingModel.totalTokens += model.totalTokens
         fold(existingModel, model)
       } else {
-        existing.modelBreakdown.push({ ...model })
+        const copy = { ...model }
+        existing.modelBreakdown.push(copy)
+        breakdowns.models.set(model.modelKey, copy)
       }
     }
 
     for (const locationModel of session.locationModelBreakdown) {
-      const existingLocationModel =
-        existing.locationModelBreakdown.find(
-          (entry) =>
-            entry.locationKey === locationModel.locationKey &&
-            entry.modelKey === locationModel.modelKey
-        ) ?? null
+      const existingLocationModel = breakdowns.locationModels.get(
+        usageLocationModelKey(locationModel.locationKey, locationModel.modelKey)
+      )
       if (existingLocationModel) {
         existingLocationModel.eventCount += locationModel.eventCount
         existingLocationModel.inputTokens += locationModel.inputTokens
@@ -88,7 +97,12 @@ export function mergeUsageSessions<TMetric extends object>(
         existingLocationModel.totalTokens += locationModel.totalTokens
         fold(existingLocationModel, locationModel)
       } else {
-        existing.locationModelBreakdown.push({ ...locationModel })
+        const copy = { ...locationModel }
+        existing.locationModelBreakdown.push(copy)
+        breakdowns.locationModels.set(
+          usageLocationModelKey(locationModel.locationKey, locationModel.modelKey),
+          copy
+        )
       }
     }
   }

--- a/src/main/usage/usage-session-breakdown-index.ts
+++ b/src/main/usage/usage-session-breakdown-index.ts
@@ -1,0 +1,37 @@
+import type {
+  UsageSession,
+  UsageLocationBreakdown,
+  UsageModelBreakdown,
+  UsageLocationModelBreakdown
+} from './usage-rollup-records'
+
+export function usageLocationModelKey(locationKey: string, modelKey: string): string {
+  return JSON.stringify([locationKey, modelKey])
+}
+
+export function indexUsageSessionBreakdowns<TMetric>(session: UsageSession<TMetric>) {
+  const locations = new Map<string, UsageLocationBreakdown<TMetric>>()
+  const models = new Map<string, UsageModelBreakdown<TMetric>>()
+  const locationModels = new Map<string, UsageLocationModelBreakdown<TMetric>>()
+  for (const entry of session.locationBreakdown) {
+    if (!locations.has(entry.locationKey)) {
+      locations.set(entry.locationKey, entry)
+    }
+  }
+  for (const entry of session.modelBreakdown) {
+    if (!models.has(entry.modelKey)) {
+      models.set(entry.modelKey, entry)
+    }
+  }
+  for (const entry of session.locationModelBreakdown) {
+    const key = usageLocationModelKey(entry.locationKey, entry.modelKey)
+    if (!locationModels.has(key)) {
+      locationModels.set(key, entry)
+    }
+  }
+  return { locations, models, locationModels }
+}
+
+export type UsageSessionBreakdownIndex<TMetric> = ReturnType<
+  typeof indexUsageSessionBreakdowns<TMetric>
+>

--- a/src/main/warp-themes/discovery.test.ts
+++ b/src/main/warp-themes/discovery.test.ts
@@ -43,6 +43,33 @@ describe('getWarpThemeDirectories', () => {
     readdirSyncMock.mockReturnValue([])
   })
 
+  it('sorts dynamic directories with one collator and preserves locale ties', () => {
+    platformMock.mockReturnValue('darwin')
+    const names = ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul'].map(
+      (name) => `.warp-${name}`
+    )
+    readdirSyncMock.mockReturnValue(names.map(directoryEntry))
+    const expected = [...names].sort((a, b) =>
+      // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+      a.localeCompare(b, undefined, { sensitivity: 'base' })
+    )
+    const NativeCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+    const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+    try {
+      expect(getWarpThemeDirectories().slice(6)).toEqual(
+        expected.map((name) => `/Users/alice/${name}/themes`)
+      )
+      expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+      expect(localeCompare).not.toHaveBeenCalled()
+    } finally {
+      construct.mockRestore()
+      localeCompare.mockRestore()
+    }
+  })
+
   it('returns macOS Warp channel theme directories in stable-first order', () => {
     platformMock.mockReturnValue('darwin')
     expect(getWarpThemeDirectories()).toEqual([

--- a/src/main/warp-themes/discovery.ts
+++ b/src/main/warp-themes/discovery.ts
@@ -18,9 +18,9 @@ const WARP_CHANNELS = [
 
 function readDirectoryEntries(directoryPath: string): Dirent[] {
   try {
-    return readdirSync(directoryPath, { withFileTypes: true }).sort((left, right) =>
-      left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
-    )
+    const entries = readdirSync(directoryPath, { withFileTypes: true })
+    const compareNames = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
+    return entries.sort((left, right) => compareNames(left.name, right.name))
   } catch {
     return []
   }

--- a/src/main/warp-themes/manual-warp-theme-files.test.ts
+++ b/src/main/warp-themes/manual-warp-theme-files.test.ts
@@ -1,0 +1,34 @@
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({ BrowserWindow: {}, dialog: {} }))
+
+import { createManualWarpThemeFileCandidates } from './manual-warp-theme-files'
+
+describe('manual theme ordering', () => {
+  it('reuses one collator for labels and path ties without changing the selected order', () => {
+    const names = ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul']
+    const paths = Array.from({ length: 200 }, (_, index) =>
+      path.join('themes', names[index % names.length]!, `${names[(index * 3) % names.length]}.yaml`)
+    )
+    const expected = [...paths].sort(
+      (a, b) =>
+        // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+        path.basename(a).localeCompare(path.basename(b), undefined, { sensitivity: 'base' }) ||
+        // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+        a.localeCompare(b, undefined, { sensitivity: 'base' })
+    )
+    const NativeCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+    const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+    try {
+      expect(createManualWarpThemeFileCandidates(paths).map((file) => file.path)).toEqual(expected)
+      expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+      expect(localeCompare).not.toHaveBeenCalled()
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
+})

--- a/src/main/warp-themes/manual-warp-theme-files.ts
+++ b/src/main/warp-themes/manual-warp-theme-files.ts
@@ -2,14 +2,10 @@ import { createHash } from 'node:crypto'
 import path from 'node:path'
 import { BrowserWindow, dialog, type OpenDialogOptions, type WebContents } from 'electron'
 import type { WarpThemeImportSkippedFile } from '../../shared/terminal-custom-themes'
-import {
-  compareThemeFileLabels,
-  isYamlFile,
-  MAX_THEME_FILES,
-  type ThemeFileCandidate
-} from './theme-file-scanner'
+import { isYamlFile, MAX_THEME_FILES, type ThemeFileCandidate } from './theme-file-scanner'
 
 export function createManualWarpThemeFileCandidates(filePaths: string[]): ThemeFileCandidate[] {
+  const compareLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   return filePaths
     .map((filePath) => ({
       path: filePath,
@@ -17,13 +13,13 @@ export function createManualWarpThemeFileCandidates(filePaths: string[]): ThemeF
       contentHashDiscriminator: true
     }))
     .sort((left, right) => {
-      const labelComparison = compareThemeFileLabels(left, right)
+      const labelComparison = compareLabels(left.label, right.label)
       if (labelComparison !== 0) {
         return labelComparison
       }
       // Why: manual dialogs can return selections in click order. Sort only in
       // main so duplicate basenames get deterministic IDs without persisting paths.
-      return left.path.localeCompare(right.path, undefined, { sensitivity: 'base' })
+      return compareLabels(left.path, right.path)
     })
 }
 

--- a/src/main/warp-themes/theme-file-scanner.test.ts
+++ b/src/main/warp-themes/theme-file-scanner.test.ts
@@ -1,0 +1,35 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { expect, it, vi } from 'vitest'
+import { scanWarpThemeDirectory } from './theme-file-scanner'
+
+it('reuses one collator per directory while preserving capped scan order', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'orca-theme-order-'))
+  const names = ['éclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul']
+  try {
+    await Promise.all(names.map((name) => writeFile(path.join(directory, `${name}.yaml`), '')))
+    await mkdir(path.join(directory, 'nested'))
+    await writeFile(path.join(directory, 'nested', 'theme.yaml'), '')
+    const expected = (await readdir(directory))
+      // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+      .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+      .map((name) => (name === 'nested' ? path.join(name, 'theme.yaml') : name))
+    const NativeCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+    const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+    try {
+      const result = await scanWarpThemeDirectory(directory, undefined, { themeFileLimit: 6 })
+      expect(result.files.map((file) => file.label)).toEqual(expected.slice(0, 6))
+      expect(result.themeFileLimitHit).toBe(true)
+      expect(construct).toHaveBeenCalledTimes(2)
+      expect(localeCompare).not.toHaveBeenCalled()
+    } finally {
+      vi.restoreAllMocks()
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})

--- a/src/main/warp-themes/theme-file-scanner.ts
+++ b/src/main/warp-themes/theme-file-scanner.ts
@@ -44,17 +44,6 @@ export function isYamlFile(filePath: string): boolean {
   return YAML_EXTENSIONS.has(path.extname(filePath).toLowerCase())
 }
 
-export function compareThemeFileLabels(
-  left: ThemeFileCandidate,
-  right: ThemeFileCandidate
-): number {
-  return left.label.localeCompare(right.label, undefined, { sensitivity: 'base' })
-}
-
-function compareDirentNames(left: Dirent<string>, right: Dirent<string>): number {
-  return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
-}
-
 function isYamlFileEntry(entry: Dirent<string>): boolean {
   return (entry.isFile() || entry.isSymbolicLink()) && isYamlFile(entry.name)
 }
@@ -141,7 +130,8 @@ async function collectYamlFilesFromDirectory(
     return
   }
 
-  const sortedEntries = entries.sort(compareDirentNames)
+  const compareNames = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
+  const sortedEntries = entries.sort((left, right) => compareNames(left.name, right.name))
   if (previewBudgetExpiredWhileReading) {
     return
   }

--- a/src/preload/api/pty-api.ts
+++ b/src/preload/api/pty-api.ts
@@ -4,7 +4,7 @@ import type {
 } from '../../shared/agent-session-resume'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
-import type { PtyListedSession } from '../../shared/pty-listed-session'
+import type { PtyListedSession, PtySessionListScope } from '../../shared/pty-listed-session'
 import type { PtyMainDeliveryDiagnostics } from '../../shared/pty-delivery-diagnostics'
 import type { PtyModelRestoreNeededEvent } from '../../shared/pty-model-restore-marker'
 import type {
@@ -123,7 +123,7 @@ export type PtyApi = {
   confirmForegroundProcess: (id: string) => Promise<string | null>
   getCwd: (id: string) => Promise<string>
   getSize: (id: string) => Promise<{ cols: number; rows: number } | null>
-  listSessions: () => Promise<PtyListedSession[]>
+  listSessions: (scope?: PtySessionListScope) => Promise<PtyListedSession[]>
   getAuthoritativeBufferSnapshotCapabilities?: (
     ids: string[]
   ) => Promise<{ id: string; authoritative: boolean | null }[]>

--- a/src/preload/api/pty-bridge-session-control.ts
+++ b/src/preload/api/pty-bridge-session-control.ts
@@ -7,7 +7,7 @@ import type {
   SleepingAgentLaunchConfig
 } from '../../shared/agent-session-resume'
 import type { TuiAgent } from '../../shared/tui-agent'
-import type { PtyListedSession } from '../../shared/pty-listed-session'
+import type { PtyListedSession, PtySessionListScope } from '../../shared/pty-listed-session'
 import type {
   PtyRendererDeliveryHealthReply,
   PtyRendererDeliveryStateReport
@@ -150,7 +150,8 @@ export const ptySessionControlApi = {
   },
   kill: (id: string, opts?: { keepHistory?: boolean }): Promise<void> =>
     ipcRenderer.invoke('pty:kill', { id, keepHistory: opts?.keepHistory ?? false }),
-  listSessions: (): Promise<PtyListedSession[]> => ipcRenderer.invoke('pty:listSessions'),
+  listSessions: (scope?: PtySessionListScope): Promise<PtyListedSession[]> =>
+    ipcRenderer.invoke('pty:listSessions', scope),
   getAuthoritativeBufferSnapshotCapabilities: (
     ids: string[]
   ): Promise<{ id: string; authoritative: boolean | null }[]> =>

--- a/src/renderer/src/components/github-project/group-sort.test.ts
+++ b/src/renderer/src/components/github-project/group-sort.test.ts
@@ -347,3 +347,86 @@ describe('groupRows', () => {
     expect(groups.map((g) => g.key)).toEqual(['opt_a', '__empty__'])
   })
 })
+
+it('indexes field ordering once for grouping and sorting a large project table', () => {
+  let reads = 0
+  const field: GitHubProjectField = {
+    kind: 'single-select',
+    id: 'field',
+    name: 'Status',
+    dataType: 'SINGLE_SELECT',
+    options: Array.from({ length: 1000 }, (_, i) => ({
+      get id() {
+        reads++
+        return `option-${i}`
+      },
+      name: String(i),
+      color: 'GRAY'
+    }))
+  }
+  const rows = Array.from({ length: 1000 }, (_, i) =>
+    makeRow(String(i), i, {
+      field: {
+        kind: 'single-select',
+        fieldId: 'field',
+        optionId: `option-${(i * 173) % 1000}`,
+        name: String((i * 173) % 1000),
+        color: 'GRAY'
+      }
+    })
+  )
+  const view = { ...makeView(field, { field, direction: 'ASC' }), groupByFields: [field] }
+  const table = makeTable(view, rows)
+  const sorted = sortRows(table, rows)
+  expect(reads).toBe(1000)
+  expect(
+    sorted.map((row) =>
+      Number(
+        row.fieldValuesByFieldId.field.kind === 'single-select' &&
+          row.fieldValuesByFieldId.field.name
+      )
+    )
+  ).toEqual(Array.from({ length: 1000 }, (_, i) => i))
+  reads = 0
+  const groups = groupRows(table, rows)
+  expect(reads).toBe(1000)
+  expect(groups.map((group) => group.key)).toEqual(
+    Array.from({ length: 1000 }, (_, i) => `option-${i}`)
+  )
+})
+
+it('uses the first iteration ordering and metadata when legacy field IDs repeat', () => {
+  const field: GitHubProjectField = {
+    kind: 'iteration',
+    id: 'iteration',
+    name: 'Iteration',
+    dataType: 'ITERATION',
+    iterations: [
+      { id: 'a', title: 'First', startDate: '2026-01-01', duration: 7, completed: true },
+      { id: 'b', title: 'Second', startDate: '2026-02-01', duration: 14, completed: false },
+      { id: 'a', title: 'Duplicate', startDate: '2026-03-01', duration: 21, completed: false }
+    ]
+  }
+  const rows = ['b', 'a'].map((id, index) =>
+    makeRow(id, index, {
+      iteration: {
+        kind: 'iteration',
+        fieldId: 'iteration',
+        iterationId: id,
+        title: id,
+        startDate: '2026-01-01',
+        duration: 7
+      }
+    })
+  )
+  const table = makeTable(
+    { ...makeView(field, { field, direction: 'ASC' }), groupByFields: [field] },
+    rows
+  )
+  expect(sortRows(table, rows).map((row) => row.id)).toEqual(['a', 'b'])
+  expect(groupRows(table, rows)[0].iteration).toEqual({
+    startDate: '2026-01-01',
+    duration: 7,
+    completed: true
+  })
+})

--- a/src/renderer/src/components/jira-issue-sorter.ts
+++ b/src/renderer/src/components/jira-issue-sorter.ts
@@ -55,6 +55,21 @@ export function sortJiraIssues(
   orderDirection: JiraIssueSortDirection,
   jiraPrioritiesBySite: JiraPrioritiesBySite = new Map()
 ): JiraIssue[] {
+  const numericKeys = new Map<JiraIssue, number>()
+  if (issues.length > 1 && (orderBy === 'priority' || orderBy === 'updated')) {
+    for (const issue of issues) {
+      numericKeys.set(
+        issue,
+        orderBy === 'updated'
+          ? new Date(issue.updatedAt).getTime()
+          : getJiraPriorityWeight(
+              issue.priority?.name,
+              issue.priority?.id,
+              jiraPrioritiesBySite.get(issue.siteId ?? '')
+            )
+      )
+    }
+  }
   return [...issues].sort((a, b) => {
     let comparison = 0
     if (orderBy === 'key') {
@@ -64,17 +79,13 @@ export function sortJiraIssues(
     } else if (orderBy === 'status') {
       comparison = 0
     } else if (orderBy === 'priority') {
-      const prioritiesA = jiraPrioritiesBySite.get(a.siteId ?? '')
-      const prioritiesB = jiraPrioritiesBySite.get(b.siteId ?? '')
-      const weightA = getJiraPriorityWeight(a.priority?.name, a.priority?.id, prioritiesA)
-      const weightB = getJiraPriorityWeight(b.priority?.name, b.priority?.id, prioritiesB)
-      comparison = weightA - weightB
+      comparison = numericKeys.get(a)! - numericKeys.get(b)!
     } else if (orderBy === 'assignee') {
       const userA = a.assignee?.displayName ?? ''
       const userB = b.assignee?.displayName ?? ''
       comparison = userA.localeCompare(userB)
     } else if (orderBy === 'updated') {
-      comparison = new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime()
+      comparison = numericKeys.get(a)! - numericKeys.get(b)!
     }
     return orderDirection === 'asc' ? comparison : -comparison
   })

--- a/src/renderer/src/components/linear-issue-attribute-filter-primary-team.test.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-primary-team.test.ts
@@ -36,3 +36,32 @@ describe('resolveLinearIssueAttributeFilterPrimaryTeam', () => {
     ).toBe('t-a')
   })
 })
+
+it('selects a primary team without pairwise membership checks or sorting all teams', () => {
+  let reads = 0
+  let nameReads = 0
+  const availableTeams = Array.from({ length: 1000 }, (_, index) => ({
+    id: `team-${index}`,
+    key: String(index),
+    get name() {
+      nameReads += 1
+      return String((index * 173) % 1000).padStart(4, '0')
+    }
+  }))
+  const selectedTeamIds = new Proxy(
+    availableTeams.map((team) => team.id),
+    {
+      get(target, key, receiver) {
+        if (typeof key === 'string' && /^\d+$/.test(key)) {
+          reads += 1
+        }
+        return Reflect.get(target, key, receiver)
+      }
+    }
+  )
+  expect(resolveLinearIssueAttributeFilterPrimaryTeam({ selectedTeamIds, availableTeams })).toBe(
+    availableTeams[0]
+  )
+  expect(reads).toBeLessThanOrEqual(1000)
+  expect(nameReads).toBeLessThan(5000)
+})

--- a/src/renderer/src/components/linear-issue-attribute-filter-primary-team.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-primary-team.ts
@@ -14,17 +14,19 @@ export function resolveLinearIssueAttributeFilterPrimaryTeam(options: {
   availableTeams: LinearTeam[]
 }): LinearTeam | null {
   const { selectedTeamIds, availableTeams } = options
-  if (availableTeams.length === 0) {
-    return null
+  const selectedIds = new Set(selectedTeamIds)
+  let firstAvailable: LinearTeam | null = null
+  let firstSelected: LinearTeam | null = null
+  for (const team of availableTeams) {
+    if (!firstAvailable || compareTeamNameId(team, firstAvailable) < 0) {
+      firstAvailable = team
+    }
+    if (
+      selectedIds.has(team.id) &&
+      (!firstSelected || compareTeamNameId(team, firstSelected) < 0)
+    ) {
+      firstSelected = team
+    }
   }
-  if (selectedTeamIds.length === 0) {
-    return [...availableTeams].sort(compareTeamNameId)[0] ?? null
-  }
-  const selected = availableTeams
-    .filter((team) => selectedTeamIds.includes(team.id))
-    .sort(compareTeamNameId)
-  if (selected.length > 0) {
-    return selected[0] ?? null
-  }
-  return [...availableTeams].sort(compareTeamNameId)[0] ?? null
+  return firstSelected ?? firstAvailable
 }

--- a/src/renderer/src/components/right-sidebar/ai-vault-project-key.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-project-key.ts
@@ -1,0 +1,34 @@
+import type { ProjectHostSetup } from '../../../../shared/project-types'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+export function toAiVaultProjectKey(
+  projectId: string | null | undefined,
+  repoId?: string | null
+): string | null {
+  if (projectId) {
+    // Why: legacy projections can already use repo-prefixed project ids; wrapping
+    // them again would split active scope and resolved session keys.
+    return projectId.startsWith('repo:') ? projectId : `project:${projectId}`
+  }
+  return repoId ? `repo:${repoId}` : null
+}
+
+export function resolveActiveProjectKey(
+  activeRepo: Repo | null,
+  activeWorktree: Worktree | null,
+  setupByRepoId: ReadonlyMap<string, ProjectHostSetup>
+): string | null {
+  if (activeWorktree?.projectId) {
+    return toAiVaultProjectKey(activeWorktree.projectId, activeWorktree.repoId)
+  }
+
+  const setup =
+    (activeRepo ? setupByRepoId.get(activeRepo.id) : null) ??
+    (activeWorktree ? setupByRepoId.get(activeWorktree.repoId) : null)
+  if (setup) {
+    return toAiVaultProjectKey(setup.projectId, setup.repoId || activeRepo?.id)
+  }
+
+  return toAiVaultProjectKey(null, activeRepo?.id ?? activeWorktree?.repoId ?? null)
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ProjectHostSetupProjection } from '../../../../shared/project-host-setup-projection'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import type { Project, ProjectHostSetup } from '../../../../shared/project-types'
+import * as paths from '../../../../shared/cross-platform-path'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import {
@@ -600,3 +601,47 @@ function makeProjection(
     ...overrides
   }
 }
+
+it('shares project attribution only within the same host and raw cwd during one build', () => {
+  const repos = Array.from({ length: 200 }, (_, i) =>
+    makeRepo({ id: `repo-${i}`, path: `/repo-${i}` })
+  )
+  const sessions = Array.from({ length: 1000 }, (_, i) => ({
+    ...baseSession,
+    id: String(i),
+    cwd: '/repo-199/sub'
+  }))
+  let comparisons = 0
+  const original = paths.createNormalizedPathInsideOrEqualMatcher
+  const spy = vi
+    .spyOn(paths, 'createNormalizedPathInsideOrEqualMatcher')
+    .mockImplementation((root) => {
+      const matches = original(root)
+      return (cwd) => {
+        comparisons++
+        return matches(cwd)
+      }
+    })
+  let result: ReturnType<typeof buildAiVaultSessionProjectById>
+  try {
+    result = buildAiVaultSessionProjectById({
+      repos,
+      worktrees: [],
+      projectHostSetupProjection: { projects: [], setups: [] },
+      sessions
+    })
+    expect(comparisons).toBe(200)
+  } finally {
+    spy.mockRestore()
+  }
+  expect(result.get('0')?.key).toBe('repo:repo-199')
+  expect(result.get('0')).toEqual(result.get('999'))
+  expect(result.get('0')).not.toBe(result.get('999'))
+  const hosts = buildAiVaultSessionProjectById({
+    repos,
+    worktrees: [],
+    projectHostSetupProjection: { projects: [], setups: [] },
+    sessions: [sessions[0], { ...sessions[0], id: 'remote', executionHostId: 'ssh:other' }]
+  })
+  expect(hosts.get('remote')?.kind).toBe('folder')
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-projects.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-projects.ts
@@ -1,3 +1,5 @@
+import { resolveActiveProjectKey, toAiVaultProjectKey } from './ai-vault-project-key'
+export { toAiVaultProjectKey } from './ai-vault-project-key'
 import {
   getRepoExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
@@ -19,8 +21,7 @@ import {
   type AiVaultSessionProject
 } from '../../../../shared/ai-vault-session-filters'
 
-// Why: the plain project descriptor moved to /shared (so the lifted filter core
-// stays renderer-free). Re-export it here for renderer import parity.
+// Preserve renderer imports of the renderer-free descriptor.
 export type { AiVaultSessionProject } from '../../../../shared/ai-vault-session-filters'
 
 export type AiVaultProjectContext = {
@@ -92,25 +93,25 @@ export function buildAiVaultSessionProjectById({
     setupByRepoId
   )
   const sessionProjectById = new Map<string, AiVaultSessionProject>()
+  const projectsByHostAndCwd = new Map<
+    ExecutionHostId | null,
+    Map<string | null, AiVaultSessionProject>
+  >()
   for (const session of sessions) {
-    sessionProjectById.set(
-      session.id,
-      resolveSessionProject(session, candidates, projectLabelByKey)
-    )
+    const host = normalizeExecutionHostId(session.executionHostId)
+    let projectsByCwd = projectsByHostAndCwd.get(host)
+    if (!projectsByCwd) {
+      projectsByCwd = new Map()
+      projectsByHostAndCwd.set(host, projectsByCwd)
+    }
+    let project = projectsByCwd.get(session.cwd)
+    if (!project) {
+      project = resolveSessionProject(session, candidates, projectLabelByKey)
+      projectsByCwd.set(session.cwd, project)
+    }
+    sessionProjectById.set(session.id, { ...project })
   }
   return sessionProjectById
-}
-
-export function toAiVaultProjectKey(
-  projectId: string | null | undefined,
-  repoId?: string | null
-): string | null {
-  if (projectId) {
-    // Why: legacy projections can already use repo-prefixed project ids; wrapping
-    // them again would split active scope and resolved session keys.
-    return projectId.startsWith('repo:') ? projectId : `project:${projectId}`
-  }
-  return repoId ? `repo:${repoId}` : null
 }
 
 function buildSetupByRepoId(
@@ -318,23 +319,4 @@ function folderProject(cwd: string): AiVaultSessionProject {
     key: folderGroupKey(cwd),
     label: folderLabel(cwd)
   }
-}
-
-function resolveActiveProjectKey(
-  activeRepo: Repo | null,
-  activeWorktree: Worktree | null,
-  setupByRepoId: ReadonlyMap<string, ProjectHostSetup>
-): string | null {
-  if (activeWorktree?.projectId) {
-    return toAiVaultProjectKey(activeWorktree.projectId, activeWorktree.repoId)
-  }
-
-  const setup =
-    (activeRepo ? setupByRepoId.get(activeRepo.id) : null) ??
-    (activeWorktree ? setupByRepoId.get(activeWorktree.repoId) : null)
-  if (setup) {
-    return toAiVaultProjectKey(setup.projectId, setup.repoId || activeRepo?.id)
-  }
-
-  return toAiVaultProjectKey(null, activeRepo?.id ?? activeWorktree?.repoId ?? null)
 }

--- a/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { Worktree } from '../../../../shared/worktree/types'
 import {
   resolveChecksPanelTerminalPtyId,
@@ -141,4 +141,23 @@ describe('resolveChecksPanelWorktreeFromTerminalCwd', () => {
     expect(resolveChecksPanelWorktreeFromTerminalCwd('repo/src', [target])).toBeNull()
     expect(resolveChecksPanelWorktreeFromTerminalCwd('', [target])).toBeNull()
   })
+})
+
+it('selects the deepest cwd match without comparator-time path normalization', () => {
+  const worktrees = Array.from({ length: 300 }, (_, i) =>
+    worktree({
+      id: String(i),
+      path: `/repo${'/a'.repeat((i * 173) % 300)}`
+    })
+  )
+  const deepest = worktrees.find((candidate) => candidate.path.length === '/repo'.length + 299 * 2)
+  const normalize = vi.spyOn(String.prototype, 'normalize')
+  try {
+    expect(resolveChecksPanelWorktreeFromTerminalCwd(`/repo${'/a'.repeat(300)}`, worktrees)).toBe(
+      deepest
+    )
+    expect(normalize.mock.calls.length).toBeLessThanOrEqual(901)
+  } finally {
+    normalize.mockRestore()
+  }
 })

--- a/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-terminal-worktree.ts
@@ -1,7 +1,7 @@
 import { parseWslUncPath } from '../../../../shared/wsl-paths'
 import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree/id'
 import {
-  isPathInsideOrEqual,
+  createNormalizedPathInsideOrEqualMatcher,
   isRuntimePathAbsolute,
   normalizeRuntimePathForComparison
 } from '../../../../shared/cross-platform-path'
@@ -18,6 +18,7 @@ type WorktreeCandidate = {
   worktree: Worktree
   path: string
   source: 'current-path' | 'prior-path'
+  normalizedPathLength: number
 }
 
 /** Resolve the active terminal PTY that should provide Checks panel cwd context. */
@@ -54,10 +55,16 @@ export function resolveChecksPanelWorktreeFromTerminalCwd(
     return null
   }
 
-  const best = buildWorktreeCandidates(worktrees)
-    .filter((candidate) => isTerminalCwdInsideWorktree(candidate.path, terminalCwd))
-    .sort(compareWorktreeCandidates)[0]
-
+  const normalizedCwd = normalizeRuntimePathForComparison(terminalCwd)
+  let best: WorktreeCandidate | undefined
+  for (const candidate of buildWorktreeCandidates(worktrees)) {
+    if (!isTerminalCwdInsideWorktree(candidate.path, normalizedCwd)) {
+      continue
+    }
+    if (!best || compareWorktreeCandidates(candidate, best) < 0) {
+      best = candidate
+    }
+  }
   return best?.worktree ?? null
 }
 
@@ -65,7 +72,12 @@ function buildWorktreeCandidates(worktrees: readonly Worktree[]): WorktreeCandid
   const candidates: WorktreeCandidate[] = []
   for (const worktree of worktrees) {
     if (hasUsablePath(worktree.path)) {
-      candidates.push({ worktree, path: worktree.path, source: 'current-path' })
+      candidates.push({
+        worktree,
+        path: worktree.path,
+        source: 'current-path',
+        normalizedPathLength: normalizeRuntimePathForComparison(worktree.path).length
+      })
     }
 
     for (const priorWorktreeId of worktree.priorWorktreeIds ?? []) {
@@ -73,7 +85,12 @@ function buildWorktreeCandidates(worktrees: readonly Worktree[]): WorktreeCandid
       if (!parsed || parsed.repoId !== worktree.repoId || !hasUsablePath(parsed.worktreePath)) {
         continue
       }
-      candidates.push({ worktree, path: parsed.worktreePath, source: 'prior-path' })
+      candidates.push({
+        worktree,
+        path: parsed.worktreePath,
+        source: 'prior-path',
+        normalizedPathLength: normalizeRuntimePathForComparison(parsed.worktreePath).length
+      })
     }
   }
   return candidates
@@ -85,19 +102,17 @@ function hasUsablePath(pathValue: string): boolean {
 }
 
 function isTerminalCwdInsideWorktree(worktreePath: string, terminalCwd: string): boolean {
-  if (isPathInsideOrEqual(worktreePath, terminalCwd)) {
+  if (createNormalizedPathInsideOrEqualMatcher(worktreePath)(terminalCwd)) {
     return true
   }
 
   // Windows hosts store WSL worktrees as UNC paths, while the terminal reports Linux paths.
   const wslPath = parseWslUncPath(worktreePath)
-  return wslPath ? isPathInsideOrEqual(wslPath.linuxPath, terminalCwd) : false
+  return wslPath ? createNormalizedPathInsideOrEqualMatcher(wslPath.linuxPath)(terminalCwd) : false
 }
 
 function compareWorktreeCandidates(left: WorktreeCandidate, right: WorktreeCandidate): number {
-  const lengthDifference =
-    normalizeRuntimePathForComparison(right.path).length -
-    normalizeRuntimePathForComparison(left.path).length
+  const lengthDifference = right.normalizedPathLength - left.normalizedPathLength
   if (lengthDifference !== 0) {
     return lengthDifference
   }

--- a/src/renderer/src/components/right-sidebar/file-explorer-batch-deletion.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-batch-deletion.test.ts
@@ -13,6 +13,27 @@ function node(path: string, isDirectory = false): TreeNode {
 }
 
 describe('selectDeletionRoots', () => {
+  it('normalizes each selected path once instead of once per possible parent', () => {
+    let reads = 0
+    const nodes = Array.from({ length: 1000 }, (_, i) => ({
+      ...node(`/repo/directory-${i}`, true),
+      get path() {
+        reads++
+        return `/repo/directory-${i}`
+      }
+    }))
+    const selected = selectDeletionRoots(nodes)
+    expect(reads).toBe(2000)
+    selected.forEach((entry, index) => expect(entry).toBe(nodes[index]))
+  })
+
+  it('preserves WSL case-sensitive paths while accepting UNC aliases', () => {
+    const parent = node('//wsl.localhost/Ubuntu/Repo', true)
+    const child = node('//wsl$/ubuntu/Repo/file')
+    const outside = node('//wsl$/ubuntu/repo/file')
+    expect(selectDeletionRoots([parent, child, outside])).toEqual([parent, outside])
+  })
+
   it('keeps unrelated files and directories', () => {
     const nodes = [node('/repo/a.ts'), node('/repo/b.ts'), node('/repo/docs', true)]
     expect(selectDeletionRoots(nodes)).toEqual(nodes)

--- a/src/renderer/src/components/right-sidebar/file-explorer-batch-deletion.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-batch-deletion.ts
@@ -1,14 +1,26 @@
-import { isPathEqualOrDescendant } from './file-explorer-paths'
+import {
+  createNormalizedPathInsideOrEqualMatcher,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
 import type { TreeNode } from './file-explorer-types'
 
 // Why: skip descendants of other selected directories — deleting a parent
 // already removes the child, and issuing both requests races on the
 // now-missing path and produces spurious errors.
 export function selectDeletionRoots(nodes: TreeNode[]): TreeNode[] {
-  const directories = nodes.filter((node) => node.isDirectory)
-  return nodes.filter(
-    (n) => !directories.some((other) => other !== n && isPathEqualOrDescendant(n.path, other.path))
-  )
+  const directories = nodes
+    .filter((node) => node.isDirectory)
+    .map((node) => ({
+      node,
+      matches: createNormalizedPathInsideOrEqualMatcher(node.path)
+    }))
+  if (directories.length === 0) {
+    return [...nodes]
+  }
+  return nodes.filter((node) => {
+    const candidate = normalizeRuntimePathForComparison(node.path)
+    return !directories.some((other) => other.node !== node && other.matches(candidate))
+  })
 }
 
 type RunBatchDeletionParams = {

--- a/src/renderer/src/components/sidebar/worktree-context-menu-policy.ts
+++ b/src/renderer/src/components/sidebar/worktree-context-menu-policy.ts
@@ -171,9 +171,10 @@ export function preserveDeleteSiblingPosition(scope: HTMLElement | null): () => 
   if (!(sidebar instanceof HTMLElement) || !(row instanceof HTMLElement)) {
     return () => {}
   }
-  const rows = Array.from(
-    sidebar.querySelectorAll<HTMLElement>('[data-worktree-virtual-row]')
-  ).sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top)
+  const rows = Array.from(sidebar.querySelectorAll<HTMLElement>('[data-worktree-virtual-row]'))
+    .map((element) => ({ element, top: element.getBoundingClientRect().top }))
+    .sort((a, b) => a.top - b.top)
+    .map(({ element }) => element)
   const rowIndex = rows.indexOf(row)
   const anchorRow = rows[rowIndex + 1] ?? rows[rowIndex - 1] ?? null
   const anchorKey = anchorRow?.getAttribute('data-worktree-virtual-row-key')

--- a/src/renderer/src/components/sidebar/worktree-delete-position-scaling.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-position-scaling.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment happy-dom
+import { expect, it } from 'vitest'
+import { preserveDeleteSiblingPosition } from './worktree-context-menu-policy'
+
+it('measures each mounted sidebar row once when choosing a delete-position anchor', () => {
+  const sidebar = document.createElement('div')
+  sidebar.setAttribute('data-worktree-sidebar', '')
+  let measurements = 0
+  const rows = Array.from({ length: 200 }, (_, index) => {
+    const row = document.createElement('div')
+    row.setAttribute('data-worktree-virtual-row', '')
+    row.setAttribute('data-worktree-virtual-row-key', String(index))
+    row.getBoundingClientRect = () => {
+      measurements += 1
+      return { top: (index * 73) % 200 } as DOMRect
+    }
+    sidebar.append(row)
+    return row
+  })
+  expect(typeof preserveDeleteSiblingPosition(rows[100])).toBe('function')
+  expect(measurements).toBeLessThanOrEqual(201)
+})

--- a/src/renderer/src/components/sidebar/worktree-lineage-expansion.performance.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-expansion.performance.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  expandDraggedWorktreeIdsForVisibleLineage,
+  type WorktreeDragLineageRow
+} from './worktree-manual-order'
+
+// Preserve the original traversal as an independent ordering oracle.
+function referenceExpansion(
+  rows: readonly WorktreeDragLineageRow[],
+  draggedIds: readonly string[]
+) {
+  const dragged = new Set(draggedIds)
+  const expanded = new Set(draggedIds)
+  const rowIds = new Set(rows.map((row) => row.worktreeId))
+  for (let index = 0; index < rows.length; index++) {
+    const row = rows[index]
+    if (!dragged.has(row.worktreeId)) {
+      continue
+    }
+    for (let cursor = index + 1; cursor < rows.length; cursor++) {
+      const child = rows[cursor]
+      if (child.depth <= row.depth) {
+        break
+      }
+      expanded.add(child.worktreeId)
+    }
+  }
+  const result = rows.filter((row) => expanded.has(row.worktreeId)).map((row) => row.worktreeId)
+  for (const id of draggedIds) {
+    if (!rowIds.has(id) && !result.includes(id)) {
+      result.push(id)
+    }
+  }
+  return result
+}
+
+describe('visible lineage expansion scaling', () => {
+  it('reads each depth once even when every ancestor is selected', () => {
+    let depthReads = 0
+    const rows = Array.from({ length: 2_000 }, (_, index) => ({
+      worktreeId: `wt-${index}`,
+      get depth() {
+        depthReads++
+        return index
+      }
+    }))
+    const selected = rows.map((row) => row.worktreeId)
+    expect(referenceExpansion(rows, selected)).toEqual(selected)
+    expect(depthReads).toBe(rows.length * (rows.length - 1))
+    depthReads = 0
+    expect(expandDraggedWorktreeIdsForVisibleLineage(rows, selected)).toEqual(selected)
+    expect(depthReads).toBe(rows.length)
+  })
+
+  it('deduplicates many absent selected rows without searching the growing result', () => {
+    const selected = Array.from({ length: 5_000 }, (_, index) => `missing-${index}`)
+    const includes = vi.spyOn(Array.prototype, 'includes')
+    let calls: number
+    let result: string[]
+    try {
+      result = expandDraggedWorktreeIdsForVisibleLineage([], [...selected, ...selected])
+      calls = includes.mock.calls.length
+    } finally {
+      includes.mockRestore()
+    }
+    expect(result).toEqual(selected)
+    expect(calls).toBe(0)
+  })
+
+  it('matches the previous algorithm across duplicate rows, missing IDs and depth boundaries', () => {
+    let seed = 12345
+    function random(limit: number): number {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+      return seed % limit
+    }
+    const depths = [-1, 0, 1, 2, 3, 20, Infinity, -Infinity, Number.NaN]
+    for (let sample = 0; sample < 500; sample++) {
+      const rows = Array.from({ length: random(40) }, () => ({
+        worktreeId: `wt-${random(20)}`,
+        depth: depths[random(depths.length)]
+      }))
+      const selected = Array.from({ length: random(20) }, () => `wt-${random(25)}`)
+      expect(expandDraggedWorktreeIdsForVisibleLineage(rows, selected)).toEqual(
+        referenceExpansion(rows, selected)
+      )
+    }
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-manual-order.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.ts
@@ -41,17 +41,18 @@ export function expandDraggedWorktreeIdsForVisibleLineage(
   const expandedSet = new Set(draggedIds)
   const rowIdSet = new Set(rows.map((row) => row.worktreeId))
 
-  for (let index = 0; index < rows.length; index++) {
-    const row = rows[index]!
-    if (!draggedSet.has(row.worktreeId)) {
-      continue
+  let ancestorDepth: number | undefined
+  for (const row of rows) {
+    const depth = row.depth
+    if (ancestorDepth !== undefined && depth <= ancestorDepth) {
+      ancestorDepth = undefined
     }
-    for (let cursor = index + 1; cursor < rows.length; cursor++) {
-      const child = rows[cursor]!
-      if (child.depth <= row.depth) {
-        break
-      }
-      expandedSet.add(child.worktreeId)
+    if (ancestorDepth !== undefined) {
+      expandedSet.add(row.worktreeId)
+    }
+    // Nested selections are already covered; NaN preserves an unterminated legacy scan.
+    if (draggedSet.has(row.worktreeId) && (ancestorDepth === undefined || Number.isNaN(depth))) {
+      ancestorDepth = depth
     }
   }
 
@@ -62,8 +63,9 @@ export function expandDraggedWorktreeIdsForVisibleLineage(
     }
   }
   for (const id of draggedIds) {
-    if (!rowIdSet.has(id) && !expandedIds.includes(id)) {
+    if (!rowIdSet.has(id)) {
       expandedIds.push(id)
+      rowIdSet.add(id)
     }
   }
   return expandedIds

--- a/src/renderer/src/components/skills/skill-delete-copy.test.ts
+++ b/src/renderer/src/components/skills/skill-delete-copy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { SkillDeletePlan } from '../../../../shared/skill-delete-contract'
 import {
   skillDeleteBlockedLines,
@@ -143,4 +143,38 @@ describe('skillDeleteResultLines', () => {
       skillDeleteResultLines([{ id: 'a', name: 'a', status: 'deleted', removedPaths: ['/x'] }])
     ).toEqual([])
   })
+})
+
+it('sorts deletion roots once with unchanged case, accent, and number ordering', () => {
+  const labels = ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul']
+  const expected = [...labels].sort((a, b) =>
+    // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+    a.localeCompare(b, undefined, { sensitivity: 'base' })
+  )
+  const NativeCollator = Intl.Collator
+  const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+    return new NativeCollator(locales, options)
+  })
+  const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+  try {
+    const summary = skillDeletePlacementSummary(
+      plan([
+        {
+          id: 'a',
+          name: 'demo',
+          canonicalPath: '/root/demo/SKILL.md',
+          placements: labels.map((rootLabel) => ({
+            path: '/root/demo',
+            kind: 'canonical',
+            rootLabel
+          }))
+        }
+      ])
+    )
+    expect(summary).toContain(expected.join(', '))
+    expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+    expect(localeCompare).not.toHaveBeenCalled()
+  } finally {
+    vi.restoreAllMocks()
+  }
 })

--- a/src/renderer/src/components/skills/skill-delete-copy.ts
+++ b/src/renderer/src/components/skills/skill-delete-copy.ts
@@ -73,8 +73,9 @@ export function skillDeletePlacementSummary(plan: SkillDeletePlan): string | nul
     folders > 0 ? foldersLabel(folders) : null,
     links > 0 ? linksLabel(links) : null
   ].filter((part): part is string => part !== null)
+  const compareLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   const roots = [...new Set(placements.map((placement) => placement.rootLabel))].sort((a, b) =>
-    a.localeCompare(b, undefined, { sensitivity: 'base' })
+    compareLabels(a, b)
   )
   return translate(
     'auto.components.skills.SkillDelete.placementSummaryParts',

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -573,3 +573,59 @@ describe('mergeSnapshotAndSessions', () => {
     expect(out[0].worktrees[0].sessions[0].bound).toBe(false)
   })
 })
+
+it('indexes tab labels when merging a large resource inventory', () => {
+  let reads = 0
+  const tabs = Array.from({ length: 1000 }, (_, i) => ({
+    ...makeTab(`tab-${i}`, `Terminal ${i}`),
+    get id() {
+      reads++
+      return `tab-${i}`
+    },
+    ptyId: `pty-${i}`
+  }))
+  const sessions: DaemonSession[] = tabs.map((_, i) => ({
+    id: `pty-${i}`,
+    cwd: '/repo',
+    title: '',
+    agentOwnership: 'unknown'
+  }))
+  const result = mergeSnapshotAndSessions(
+    null,
+    sessions,
+    baseCtx({ tabsByWorktree: { 'repo::/repo': tabs } })
+  )
+  expect(reads).toBeLessThan(5000)
+  expect(result[0].worktrees[0].sessions.map((session) => session.label)).toEqual(
+    Array.from({ length: 1000 }, (_, i) => `Terminal ${i}`)
+  )
+})
+
+it('does not scan accumulated worktree rows for unrelated daemon sessions', () => {
+  const sessions: DaemonSession[] = Array.from({ length: 1000 }, (_, i) => ({
+    id: `opaque-${i}`,
+    cwd: '',
+    title: '',
+    agentOwnership: 'unknown'
+  }))
+  const find = Array.prototype.find
+  let scanned = 0
+  Array.prototype.find = function (this: unknown[], ...args: Parameters<typeof find>) {
+    const first = this[0] as { sessions?: unknown; hasLocalSamples?: unknown } | undefined
+    if (first?.sessions && first.hasLocalSamples !== undefined) {
+      scanned += this.length
+    }
+    return find.apply(this, args)
+  }
+  let merged: ReturnType<typeof mergeSnapshotAndSessions>
+  try {
+    merged = mergeSnapshotAndSessions(null, sessions, baseCtx())
+  } finally {
+    Array.prototype.find = find
+  }
+  expect(scanned).toBe(0)
+  expect(merged[0].worktrees).toHaveLength(1000)
+  expect(merged[0].worktrees.every((row) => row.sessions[0].agentOwnership === 'unknown')).toBe(
+    true
+  )
+})

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -35,7 +35,10 @@ import type {
   UnifiedSessionRow,
   UnifiedWorktreeRow
 } from './resource-usage-merge-types'
-import { buildResourceSessionBindingIndex } from './resource-session-bindings'
+import {
+  buildResourceSessionBindingIndex,
+  type ResourceSessionBindingIndex
+} from './resource-session-bindings'
 
 // ─── Helpers ────────────────────────────────────────────────────────
 
@@ -67,13 +70,13 @@ function parsePaneKey(paneKey: string | null): { tabId: string; leafId: string }
 function resolveSnapshotSessionLabel(
   session: SessionMemory,
   worktreeId: string,
-  ctx: MergeContext
+  index: ResourceSessionBindingIndex
 ): string {
   const parsed = parsePaneKey(session.paneKey)
   if (parsed) {
-    const tabs = ctx.tabsByWorktree[worktreeId] ?? []
-    const tabIndex = tabs.findIndex((t) => t.id === parsed.tabId)
-    const tab = tabIndex !== -1 ? tabs[tabIndex] : undefined
+    const match = index.tabsByIdByWorktree.get(worktreeId)?.get(parsed.tabId)
+    const tab = match?.tab
+    const tabIndex = match?.index ?? -1
     if (tab) {
       const custom = tab.customTitle?.trim()
       if (custom) {
@@ -93,12 +96,11 @@ function resolveDaemonSessionLabel(
   session: DaemonSession,
   resolvedWorktreeId: string | null,
   tabId: string | null,
-  ctx: MergeContext
+  ctx: MergeContext,
+  index: ResourceSessionBindingIndex
 ): string {
   if (tabId && resolvedWorktreeId) {
-    const tabs = ctx.tabsByWorktree[resolvedWorktreeId] ?? []
-    const tabIndex = tabs.findIndex((t) => t.id === tabId)
-    const tab = tabIndex !== -1 ? tabs[tabIndex] : undefined
+    const tab = index.tabsByIdByWorktree.get(resolvedWorktreeId)?.get(tabId)?.tab
     if (tab) {
       const custom = tab.customTitle?.trim()
       if (custom) {
@@ -140,11 +142,12 @@ export function mergeSnapshotAndSessions(
   ctx: MergeContext
 ): UnifiedProjectGroup[] {
   const repos = new Map<string, UnifiedProjectGroup>()
+  const worktreeRowsByRepo = new Map<string, Map<string, UnifiedWorktreeRow>>()
   const seenSessionIds = new Set<string>()
   // Why: pre-build O(1) lookup indices once per merge. This includes live
   // ptyIdsByTabId plus deferred-reattach wake hints, so restored inactive
   // sessions do not appear as Resource Manager orphans before their pane mounts.
-  const index = buildResourceSessionBindingIndex(ctx)
+  const index = buildResourceSessionBindingIndex(ctx, true)
   const boundPtyIds = index.boundPtyIds
   // Why: the daemon list is the only place agent ownership is reported. Snapshot-derived rows
   // describe the same sessions by id, so carry it across rather than inventing an answer; a
@@ -184,6 +187,7 @@ export function mergeSnapshotAndSessions(
       worktrees: []
     }
     repos.set(repoId, next)
+    worktreeRowsByRepo.set(repoId, new Map())
     return next
   }
 
@@ -191,7 +195,15 @@ export function mergeSnapshotAndSessions(
     repo: UnifiedProjectGroup,
     worktreeId: string
   ): UnifiedWorktreeRow | undefined {
-    return repo.worktrees.find((w) => w.worktreeId === worktreeId)
+    return worktreeRowsByRepo.get(repo.repoId)?.get(worktreeId)
+  }
+
+  function appendWorktreeRow(repo: UnifiedProjectGroup, row: UnifiedWorktreeRow): void {
+    repo.worktrees.push(row)
+    const rows = worktreeRowsByRepo.get(repo.repoId)!
+    if (!rows.has(row.worktreeId)) {
+      rows.set(row.worktreeId, row)
+    }
   }
 
   // ── Step 1: ingest snapshot worktrees as the local-truth foundation.
@@ -210,7 +222,7 @@ export function mergeSnapshotAndSessions(
           sessionId: s.sessionId,
           paneKey: s.paneKey,
           pid: s.pid,
-          label: resolveSnapshotSessionLabel(s, wt.worktreeId, ctx),
+          label: resolveSnapshotSessionLabel(s, wt.worktreeId, index),
           bound: ctx.workspaceSessionReady && boundPtyIds.has(s.sessionId),
           agentOwnership: ownershipBySessionId.get(s.sessionId) ?? 'unknown',
           tabId,
@@ -219,7 +231,7 @@ export function mergeSnapshotAndSessions(
           hasLocalSamples: true
         }
       })
-      repo.worktrees.push({
+      appendWorktreeRow(repo, {
         worktreeId: wt.worktreeId,
         worktreeName: wt.worktreeName,
         repoId: wt.repoId,
@@ -291,14 +303,14 @@ export function mergeSnapshotAndSessions(
         sessions: [],
         browsers: []
       }
-      repo.worktrees.push(row)
+      appendWorktreeRow(repo, row)
     }
 
     row.sessions.push({
       sessionId: session.id,
       paneKey: null,
       pid: 0,
-      label: resolveDaemonSessionLabel(session, worktreeId, tabId, ctx),
+      label: resolveDaemonSessionLabel(session, worktreeId, tabId, ctx, index),
       bound: ctx.workspaceSessionReady && boundPtyIds.has(session.id),
       agentOwnership: session.agentOwnership,
       tabId,
@@ -331,7 +343,7 @@ export function mergeSnapshotAndSessions(
         sessions: [],
         browsers: []
       }
-      repo.worktrees.push(row)
+      appendWorktreeRow(repo, row)
     }
     row.browsers = browsers
   }

--- a/src/renderer/src/components/status-bar/resource-session-bindings.ts
+++ b/src/renderer/src/components/status-bar/resource-session-bindings.ts
@@ -20,6 +20,7 @@ export type ResourceSessionBindingIndex = {
   ptyIdToTabId: Map<string, string>
   tabIdToWorktreeId: Map<string, string>
   boundPtyIds: Set<string>
+  tabsByIdByWorktree: Map<string, Map<string, { tab: TerminalTab; index: number }>>
 }
 
 function addBinding(
@@ -34,14 +35,26 @@ function addBinding(
 }
 
 export function buildResourceSessionBindingIndex(
-  inputs: ResourceSessionBindingInputs
+  inputs: ResourceSessionBindingInputs,
+  includeTabLabels = false
 ): ResourceSessionBindingIndex {
   const ptyIdToTabId = new Map<string, string>()
   const tabIdToWorktreeId = new Map<string, string>()
+  const tabsByIdByWorktree: ResourceSessionBindingIndex['tabsByIdByWorktree'] = new Map()
 
   for (const [worktreeId, tabs] of Object.entries(inputs.tabsByWorktree)) {
-    for (const tab of tabs) {
-      tabIdToWorktreeId.set(tab.id, worktreeId)
+    const byId = includeTabLabels
+      ? new Map<string, { tab: TerminalTab; index: number }>()
+      : undefined
+    tabs.forEach((tab, index) => {
+      const id = tab.id
+      tabIdToWorktreeId.set(id, worktreeId)
+      if (byId && !byId.has(id)) {
+        byId.set(id, { tab, index })
+      }
+    })
+    if (byId) {
+      tabsByIdByWorktree.set(worktreeId, byId)
     }
   }
 
@@ -81,6 +94,7 @@ export function buildResourceSessionBindingIndex(
   return {
     ptyIdToTabId,
     tabIdToWorktreeId,
+    tabsByIdByWorktree,
     boundPtyIds: inputs.workspaceSessionReady ? new Set(ptyIdToTabId.keys()) : new Set()
   }
 }

--- a/src/renderer/src/components/tab-bar/tab-create-entry-file-matches.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-file-matches.test.ts
@@ -1,0 +1,38 @@
+import { expect, it, vi } from 'vitest'
+import { prepareQuickOpenFiles } from '../quick-open-search'
+import { findExistingFileMatches } from './tab-create-entry-file-matches'
+import type * as QuickOpenSearch from '../quick-open-search'
+
+const ranking = vi.hoisted(() => ({ calls: 0 }))
+vi.mock('../quick-open-search', async (importOriginal) => {
+  const original = await importOriginal<typeof QuickOpenSearch>()
+  return {
+    ...original,
+    rankQuickOpenFiles: (...args: Parameters<typeof original.rankQuickOpenFiles>) => {
+      ranking.calls++
+      return original.rankQuickOpenFiles(...args)
+    }
+  }
+})
+
+it('skips fuzzy ranking when exact matches fill the requested window', () => {
+  const files = prepareQuickOpenFiles(
+    Array.from({ length: 10000 }, (_, index) => `${index}/readme.md`)
+  )
+  ranking.calls = 0
+  const matches = findExistingFileMatches('readme.md', files, 10)
+  expect(matches.map((match) => match.relativePath)).toEqual(
+    files.slice(0, 10).map((file) => file.path)
+  )
+  expect(matches.every((match) => match.matchKind === 'exact-basename')).toBe(true)
+  expect(ranking.calls).toBe(0)
+})
+
+it('deduplicates exact paths and still fills remaining slots with fuzzy matches', () => {
+  const files = prepareQuickOpenFiles(['a.md', 'a.md', 'other/a.md', 'abc.md'])
+  expect(findExistingFileMatches('a.md', files, 4)).toEqual([
+    { kind: 'existing-file', matchKind: 'exact-path', relativePath: 'a.md' },
+    { kind: 'existing-file', matchKind: 'exact-basename', relativePath: 'other/a.md' },
+    { kind: 'existing-file', matchKind: 'fuzzy', relativePath: 'abc.md' }
+  ])
+})

--- a/src/renderer/src/components/tab-bar/tab-create-entry-file-matches.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-file-matches.ts
@@ -71,14 +71,15 @@ export function findExistingFileMatches(
       matchKind: 'exact-basename' as const,
       relativePath: file.path
     }))
+  const exactMatches = dedupeMatches([...exactPathMatches, ...exactBasenameMatches])
+  if (exactMatches.length >= limit) {
+    return exactMatches.slice(0, limit)
+  }
   const fuzzyMatches = rankQuickOpenFiles(normalizedQuery, indexedFiles, limit).map((file) => ({
     kind: 'existing-file' as const,
     matchKind: 'fuzzy' as const,
     relativePath: file.path
   }))
 
-  return dedupeMatches([...exactPathMatches, ...exactBasenameMatches, ...fuzzyMatches]).slice(
-    0,
-    limit
-  )
+  return dedupeMatches([...exactMatches, ...fuzzyMatches]).slice(0, limit)
 }

--- a/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
@@ -16,27 +16,29 @@ export function patchTaskPageGitHubWorkItemPages(
   patch: Partial<GitHubWorkItem>,
   shouldPatch?: (item: GitHubWorkItem) => boolean
 ): (GitHubWorkItem[] | null)[] {
-  let changed = false
-  const nextPages = pages.map((page) => {
+  let nextPages: (GitHubWorkItem[] | null)[] | undefined
+  pages.forEach((page, pageIndex) => {
     if (!page) {
-      return null
+      return
     }
-    let pageChanged = false
-    const nextPage = page.map((item) => {
+    let nextPage: GitHubWorkItem[] | undefined
+    page.forEach((item, itemIndex) => {
       if (
         item.id !== itemKey.id ||
         item.repoId !== itemKey.repoId ||
         (shouldPatch && !shouldPatch(item))
       ) {
-        return item
+        return
       }
-      changed = true
-      pageChanged = true
-      return { ...item, ...patch }
+      nextPage ??= page.slice()
+      nextPage[itemIndex] = { ...item, ...patch }
     })
-    return pageChanged ? nextPage : page
+    if (nextPage) {
+      nextPages ??= pages.slice()
+      nextPages[pageIndex] = nextPage
+    }
   })
-  return changed ? nextPages : (pages as (GitHubWorkItem[] | null)[])
+  return nextPages ?? (pages as (GitHubWorkItem[] | null)[])
 }
 
 /** Match each item to pending/confirmed authority by repoId + itemId + remembered sourceScope. */

--- a/src/renderer/src/components/task-page-initial-selection-scaling.test.tsx
+++ b/src/renderer/src/components/task-page-initial-selection-scaling.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import type { Repo } from '../../../shared/repo-types'
+import type { TaskPageStoreBindingsModel } from './use-task-page-store-bindings'
+import { useTaskPageRepoSelection } from './use-task-page-repo-selection'
+
+function resolveSelection(repos: Repo[], persisted: string[], preferred?: string) {
+  let selected: readonly string[] = []
+  function Probe() {
+    const model = {
+      repos,
+      settings: { defaultRepoSelection: persisted },
+      pageData: { preselectedRepoId: preferred },
+      linearStatus: {},
+      jiraStatus: {},
+      preflightStatus: null
+    } as unknown as TaskPageStoreBindingsModel
+    useTaskPageRepoSelection(model)
+    selected = [
+      ...(model as TaskPageStoreBindingsModel & { resolvedInitialSelection: ReadonlySet<string> })
+        .resolvedInitialSelection
+    ]
+    return null
+  }
+  renderToString(<Probe />)
+  return selected
+}
+
+describe('task page initial repo selection', () => {
+  it('normalizes persisted selections without a repository scan for every stored ID', () => {
+    let reads = 0
+    const repos: Repo[] = Array.from({ length: 1000 }, (_, index) => ({
+      get id() {
+        reads++
+        return `repo-${index}`
+      },
+      path: `/repos/${index}`,
+      displayName: `Repo ${index}`,
+      badgeColor: '',
+      addedAt: index,
+      kind: 'git'
+    }))
+    const persisted = Array.from({ length: 1000 }, (_, index) => `repo-${index}`)
+    expect(resolveSelection(repos, persisted)).toEqual(persisted)
+    expect(reads).toBeLessThan(40_000)
+  })
+
+  it('retains preferred selection, missing-ID fallback, and explicit empty defaults', () => {
+    const repos: Repo[] = ['a', 'b'].map((id) => ({
+      id,
+      path: `/repos/${id}`,
+      displayName: id,
+      badgeColor: '',
+      addedAt: 0,
+      kind: 'git'
+    }))
+    expect(resolveSelection(repos, ['b'], 'a')).toEqual(['a'])
+    expect(resolveSelection(repos, ['missing'])).toEqual(['a', 'b'])
+    expect(resolveSelection(repos, [])).toEqual(['a', 'b'])
+    expect(resolveSelection(repos, ['missing', 'b', 'b'])).toEqual(['b'])
+  })
+})

--- a/src/renderer/src/components/task-page-jira-sorting.test.ts
+++ b/src/renderer/src/components/task-page-jira-sorting.test.ts
@@ -266,4 +266,37 @@ describe('TaskPage Jira sorting functionality', () => {
       expect(sorted[2].assignee?.displayName).toBe('Bob')
     })
   })
+  it('computes expensive numeric sort keys once per issue', () => {
+    let priorityReads = 0
+    let dateReads = 0
+    const issues = Array.from({ length: 2000 }, (_, i) => ({
+      ...jiraIssue(`ALP-${i}`, `Issue ${i}`, 'Open'),
+      get priority() {
+        priorityReads++
+        return { id: String(i % 3), name: ['High', 'Low', 'Medium'][i % 3] }
+      },
+      get updatedAt() {
+        dateReads++
+        return new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString()
+      }
+    }))
+    const expected = [...issues].sort(
+      (a, b) =>
+        getJiraPriorityWeight(a.priority.name, a.priority.id) -
+        getJiraPriorityWeight(b.priority.name, b.priority.id)
+    )
+    expect(priorityReads).toBeGreaterThan(20_000)
+    priorityReads = 0
+    const actual = sortJiraIssues(issues, 'priority', 'asc')
+    expect(priorityReads).toBe(4000)
+    actual.forEach((issue, i) => expect(issue).toBe(expected[i]))
+    const byDate = [...issues].sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )
+    expect(dateReads).toBeGreaterThan(20_000)
+    dateReads = 0
+    const sorted = sortJiraIssues(issues, 'updated', 'desc')
+    expect(dateReads).toBe(2000)
+    sorted.forEach((issue, i) => expect(issue).toBe(byDate[i]))
+  })
 })

--- a/src/renderer/src/components/task-page-mutation-page-allocation.test.ts
+++ b/src/renderer/src/components/task-page-mutation-page-allocation.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from 'vitest'
+import type { GitHubWorkItem } from '../../../shared/github/work-item-types'
+import { patchTaskPageGitHubWorkItemPages } from './task-page-github-work-item-mutation-pages'
+
+function item(id: string): GitHubWorkItem {
+  return {
+    id,
+    type: 'issue',
+    number: 1,
+    title: id,
+    state: 'open',
+    url: '',
+    labels: [],
+    updatedAt: '',
+    author: '',
+    repoId: 'repo'
+  }
+}
+
+it('avoids allocating copies of unaffected pages during an item mutation', () => {
+  const pages = Array.from({ length: 20 }, (_, p) =>
+    Array.from({ length: 200 }, (_, i) => item(`${p}:${i}`))
+  )
+  const inputs = new Set<unknown>([pages, ...pages])
+  const map = Array.prototype.map
+  const slice = Array.prototype.slice
+  let allocations = 0
+  Array.prototype.map = function <T, U>(
+    this: T[],
+    callback: (value: T, index: number, array: T[]) => U,
+    thisArg?: unknown
+  ): U[] {
+    if (inputs.has(this)) {
+      allocations++
+    }
+    return Reflect.apply(map, this, [callback, thisArg]) as U[]
+  }
+  Array.prototype.slice = function (this: unknown[], ...args: Parameters<typeof slice>) {
+    if (inputs.has(this)) {
+      allocations++
+    }
+    return slice.apply(this, args)
+  }
+  let result: ReturnType<typeof patchTaskPageGitHubWorkItemPages>
+  let unchanged: ReturnType<typeof patchTaskPageGitHubWorkItemPages>
+  try {
+    unchanged = patchTaskPageGitHubWorkItemPages(
+      pages,
+      { id: 'missing', repoId: 'repo' },
+      { title: 'New' }
+    )
+    result = patchTaskPageGitHubWorkItemPages(
+      pages,
+      { id: '19:199', repoId: 'repo' },
+      { title: 'New' }
+    )
+  } finally {
+    Array.prototype.map = map
+    Array.prototype.slice = slice
+  }
+  expect(allocations).toBe(2)
+  expect(unchanged).toBe(pages)
+  expect(result[0]).toBe(pages[0])
+  expect(result[19]?.[199].title).toBe('New')
+  expect(pages[19][199].title).toBe('19:199')
+})
+
+it('preserves sparse pages, null pages, duplicate matches and predicate exclusions', () => {
+  const page = [item('match'), item('match')]
+  delete page[0]
+  const pages = [page, null, [item('match'), item('match')]]
+  const patched = patchTaskPageGitHubWorkItemPages(
+    pages,
+    { id: 'match', repoId: 'repo' },
+    { title: 'new' },
+    (row) => row !== pages[2]?.[0]
+  )
+  expect(0 in patched[0]!).toBe(false)
+  expect(patched[1]).toBeNull()
+  expect(patched[2]?.map((row) => row.title)).toEqual(['match', 'new'])
+})

--- a/src/renderer/src/components/use-task-page-repo-selection.ts
+++ b/src/renderer/src/components/use-task-page-repo-selection.ts
@@ -51,11 +51,7 @@ export function useTaskPageRepoSelection(model: TaskPageStoreBindingsModel) {
     }
     const persisted = settings?.defaultRepoSelection
     if (Array.isArray(persisted)) {
-      const filtered = persisted.filter((id) => eligibleRepos.some((r) => r.id === id))
-      if (filtered.length > 0) {
-        return normalizeTaskRepoSelection(eligibleRepos, new Set(filtered))
-      }
-      // Why: empty after filtering (all persisted repos removed) falls through to the automatic default so the page never renders an empty selection.
+      return normalizeTaskRepoSelection(eligibleRepos, new Set(persisted))
     }
     return getDefaultTaskRepoSelection(eligibleRepos)
   }, [eligibleRepos, pageData.preselectedRepoId, settings?.defaultRepoSelection])

--- a/src/renderer/src/hooks/metadata-request-cache.test.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.test.ts
@@ -183,4 +183,60 @@ describe('metadata-request-cache', () => {
     expect(store.cache.has('repo-0:labels')).toBe(false)
     expect(store.cache.get('repo-500:labels')?.data).toEqual(['label-500'])
   })
+  it('avoids full-cache sweeps on fresh reads but releases all expired payloads when due', async () => {
+    const store = createMetadataRequestStore<number>()
+    for (let i = 0; i < 500; i++) {
+      await loadMetadata(
+        store,
+        String(i),
+        async () => i,
+        () => i
+      )
+    }
+    let reads = 0
+    for (const entry of store.cache.values()) {
+      const fetchedAt = entry.fetchedAt
+      Object.defineProperty(entry, 'fetchedAt', {
+        get: () => {
+          reads++
+          return fetchedAt
+        }
+      })
+    }
+    for (let i = 0; i < 10_000; i++) {
+      expect(getFreshMetadata(store, '499', 1000)?.data).toBe(499)
+    }
+    expect(reads).toBeLessThanOrEqual(10_000)
+    expect(getFreshMetadata(store, '499', 300_498)?.data).toBe(499)
+    expect([...store.cache.keys()]).toEqual(['499'])
+    expect(getFreshMetadata(store, 'missing', 300_499)).toBeNull()
+    expect(store.cache.size).toBe(0)
+  })
+
+  it('reschedules expiry after clear and a fetch whose clock moved backwards', async () => {
+    const store = createMetadataRequestStore<number>()
+    await loadMetadata(
+      store,
+      'later',
+      async () => 1,
+      () => 20_000
+    )
+    await loadMetadata(
+      store,
+      'earlier',
+      async () => 2,
+      () => 10_000
+    )
+    expect(getFreshMetadata(store, 'later', 310_000)?.data).toBe(1)
+    expect(store.cache.has('earlier')).toBe(false)
+    clearMetadataRequestStore(store)
+    await loadMetadata(
+      store,
+      'new',
+      async () => 3,
+      () => 0
+    )
+    expect(getFreshMetadata(store, 'missing', 300_000)).toBeNull()
+    expect(store.cache.size).toBe(0)
+  })
 })

--- a/src/renderer/src/hooks/metadata-request-cache.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.ts
@@ -14,6 +14,7 @@ export type MetadataRequestStore<T> = {
   cache: Map<string, CachedMetadata<T>>
   inflight: Map<string, Promise<T>>
   failures: Map<string, CachedMetadataFailure>
+  nextCacheExpiryAt: number
   generation: number
 }
 
@@ -22,6 +23,7 @@ export function createMetadataRequestStore<T>(): MetadataRequestStore<T> {
     cache: new Map(),
     inflight: new Map(),
     failures: new Map(),
+    nextCacheExpiryAt: Infinity,
     generation: 0
   }
 }
@@ -29,6 +31,7 @@ export function createMetadataRequestStore<T>(): MetadataRequestStore<T> {
 export function clearMetadataRequestStore<T>(store: MetadataRequestStore<T>): void {
   store.generation += 1
   store.cache.clear()
+  store.nextCacheExpiryAt = Infinity
   store.inflight.clear()
   store.failures.clear()
 }
@@ -38,9 +41,12 @@ function pruneMetadataCache<T>(
   now: number,
   maxEntries = MAX_METADATA_CACHE_ENTRIES
 ): void {
+  store.nextCacheExpiryAt = Infinity
   for (const [key, entry] of store.cache) {
     if (now - entry.fetchedAt >= METADATA_TTL) {
       store.cache.delete(key)
+    } else {
+      store.nextCacheExpiryAt = Math.min(store.nextCacheExpiryAt, entry.fetchedAt + METADATA_TTL)
     }
   }
   if (store.cache.size <= maxEntries) {
@@ -57,7 +63,9 @@ export function getFreshMetadata<T>(
   key: string,
   now = Date.now()
 ): CachedMetadata<T> | null {
-  pruneMetadataCache(store, now)
+  if (now >= store.nextCacheExpiryAt) {
+    pruneMetadataCache(store, now)
+  }
   const entry = store.cache.get(key)
   if (!entry || now - entry.fetchedAt >= METADATA_TTL) {
     return null

--- a/src/renderer/src/lib/browser-palette-page-entries.test.ts
+++ b/src/renderer/src/lib/browser-palette-page-entries.test.ts
@@ -452,3 +452,41 @@ function browserUnifiedTab(
     createdAt: 0
   }
 }
+
+it('indexes workspace tabs when building a large browser palette', () => {
+  let reads = 0
+  const workspaces = Array.from({ length: 1000 }, (_, i) =>
+    makeWorkspace({ id: `workspace-${i}`, activePageId: `page-${i}` })
+  )
+  const tabs: Tab[] = workspaces.map((workspace, i) => ({
+    id: `tab-${i}`,
+    get entityId() {
+      reads++
+      return workspace.id
+    },
+    groupId: 'group-1',
+    worktreeId: 'wt-1',
+    contentType: 'browser',
+    label: 'Example',
+    customLabel: null,
+    color: null,
+    sortOrder: i,
+    createdAt: 0
+  }))
+  const pages = Object.fromEntries(
+    workspaces.map((workspace, i) => [
+      workspace.id,
+      [makePage({ id: `page-${i}`, workspaceId: workspace.id })]
+    ])
+  )
+  const entries = buildFixture({
+    worktrees: [worktreeA],
+    browserTabsByWorktree: { 'wt-1': workspaces },
+    browserPagesByWorkspace: pages,
+    unifiedTabsByWorktree: { 'wt-1': tabs }
+  })
+  expect(reads).toBeLessThan(6000)
+  expect(entries.map((entry) => entry.workspace.id)).toEqual(
+    workspaces.map((workspace) => workspace.id)
+  )
+})

--- a/src/renderer/src/lib/browser-palette-page-entries.ts
+++ b/src/renderer/src/lib/browser-palette-page-entries.ts
@@ -70,9 +70,13 @@ export function buildSearchableBrowserPages({
       worktreeOrder.get(getPaletteWorktreeIdentity(worktree)) ??
       worktreeOrder.get(worktree.id) ??
       Number.MAX_SAFE_INTEGER
+    const unifiedBrowserTabsByWorkspaceId = new Map<string, Tab>()
     const focusedAtByWorkspaceId = new Map<string, number>()
     const unifiedTabs = unifiedTabsByWorktree?.[worktree.id] ?? []
     for (const tab of unifiedTabs) {
+      if (tab.contentType === 'browser' && !unifiedBrowserTabsByWorkspaceId.has(tab.entityId)) {
+        unifiedBrowserTabsByWorkspaceId.set(tab.entityId, tab)
+      }
       if (
         tab.contentType === 'browser' &&
         isUnifiedTabOwnedByWorktree(tab, worktree, ambiguousWorktreeIds) &&
@@ -88,13 +92,12 @@ export function buildSearchableBrowserPages({
       ) {
         continue
       }
-      const workspaceTabs = unifiedTabs.filter(
-        (tab) => tab.contentType === 'browser' && tab.entityId === workspace.id
-      )
-      const unifiedTab = workspaceTabs.find((tab) =>
-        isUnifiedTabOwnedByWorktree(tab, worktree, ambiguousWorktreeIds)
-      )
-      if (!unifiedTab && (workspaceTabs.length > 0 || ambiguousWorktreeIds.has(worktree.id))) {
+      const candidate = unifiedBrowserTabsByWorkspaceId.get(workspace.id)
+      const unifiedTab =
+        candidate && isUnifiedTabOwnedByWorktree(candidate, worktree, ambiguousWorktreeIds)
+          ? candidate
+          : undefined
+      if (!unifiedTab && (candidate || ambiguousWorktreeIds.has(worktree.id))) {
         continue
       }
       if (unifiedTab && duplicateTabIds.has(unifiedTab.id)) {

--- a/src/renderer/src/lib/pane-manager/pane-tree-equalization-scaling.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-equalization-scaling.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment happy-dom
+import { expect, it } from 'vitest'
+import { equalizePaneSplitSizes } from './pane-tree-equalization'
+
+it('computes nested same-axis pane weights once per split', () => {
+  const pane = () => {
+    const element = document.createElement('div')
+    element.className = 'pane'
+    return element
+  }
+  let root = pane()
+  let reads = 0
+  const children = Object.getOwnPropertyDescriptor(Element.prototype, 'children')!.get!
+  for (let index = 0; index < 200; index += 1) {
+    const split = document.createElement('div')
+    split.className = 'pane-split'
+    split.append(pane(), root)
+    Object.defineProperty(split, 'children', {
+      get() {
+        reads += 1
+        return children.call(this)
+      }
+    })
+    root = split
+  }
+  expect(equalizePaneSplitSizes(root)).toBe(true)
+  expect(reads).toBeLessThan(500)
+  expect((root.lastElementChild as HTMLElement).style.flex).toBe('200 1 0%')
+  expect(equalizePaneSplitSizes(root)).toBe(false)
+})

--- a/src/renderer/src/lib/pane-manager/pane-tree-equalization.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-equalization.ts
@@ -11,16 +11,26 @@ function getSplitDirection(split: HTMLElement): 'vertical' | 'horizontal' {
   return split.classList.contains('is-horizontal') ? 'horizontal' : 'vertical'
 }
 
-function getEqualizeWeight(el: HTMLElement, direction: 'vertical' | 'horizontal'): number {
+function getEqualizeWeight(
+  el: HTMLElement,
+  direction: 'vertical' | 'horizontal',
+  weights: Map<HTMLElement, number>
+): number {
   if (!el.classList.contains('pane-split') || getSplitDirection(el) !== direction) {
     return 1
   }
 
+  const cached = weights.get(el)
+  if (cached !== undefined) {
+    return cached
+  }
   const children = findPaneChildren(el)
-  return Math.max(
+  const weight = Math.max(
     1,
-    children.reduce((sum, child) => sum + getEqualizeWeight(child, direction), 0)
+    children.reduce((sum, child) => sum + getEqualizeWeight(child, direction, weights), 0)
   )
+  weights.set(el, weight)
+  return weight
 }
 
 export function equalizePaneSplitSizes(root: HTMLElement | null): boolean {
@@ -28,6 +38,7 @@ export function equalizePaneSplitSizes(root: HTMLElement | null): boolean {
     return false
   }
 
+  const weights = new Map<HTMLElement, number>()
   let changed = false
   const visit = (el: HTMLElement): void => {
     if (!el.classList.contains('pane-split')) {
@@ -40,7 +51,7 @@ export function equalizePaneSplitSizes(root: HTMLElement | null): boolean {
       for (const child of children) {
         // Why: same-axis nested splits need pane-count weighting so three
         // side-by-side panes become thirds, not 50/25/25.
-        const weight = getEqualizeWeight(child, direction)
+        const weight = getEqualizeWeight(child, direction, weights)
         const nextFlex = `${weight} 1 0%`
         if (child.style.flex !== nextFlex) {
           child.style.flex = nextFlex

--- a/src/renderer/src/lib/project-clone-url-prefill.test.ts
+++ b/src/renderer/src/lib/project-clone-url-prefill.test.ts
@@ -62,4 +62,38 @@ describe('resolveProjectCloneUrlPrefill', () => {
       )
     ).toBe('https://github.com/acme/second.git')
   })
+  it('stops on the first usable source and indexes later misses only once', () => {
+    let reads = 0
+    const repos = Array.from({ length: 1000 }, (_, i) => ({
+      ...repo(`repo-${i}`, 'https://gitlab.com/acme/repo.git'),
+      get id() {
+        reads++
+        return `repo-${i}`
+      }
+    }))
+    const sourceIds = Array.from({ length: 1000 }, (_, i) => `repo-${i}`)
+    expect(resolveProjectCloneUrlPrefill([project(sourceIds)], repos, 'project-orca')).toBe(
+      'https://gitlab.com/acme/repo.git'
+    )
+    expect(reads).toBe(1)
+    reads = 0
+    expect(
+      resolveProjectCloneUrlPrefill(
+        [project(sourceIds.map((id) => `missing-${id}`))],
+        repos,
+        'project-orca'
+      )
+    ).toBe('')
+    expect(reads).toBeLessThanOrEqual(2000)
+  })
+
+  it('keeps the first duplicate repo authoritative when building the fallback index', () => {
+    expect(
+      resolveProjectCloneUrlPrefill(
+        [project(['missing', 'duplicate'])],
+        [repo('duplicate', ''), repo('duplicate', 'https://gitlab.com/acme/repo.git')],
+        'project-orca'
+      )
+    ).toBe('')
+  })
 })

--- a/src/renderer/src/lib/project-clone-url-prefill.ts
+++ b/src/renderer/src/lib/project-clone-url-prefill.ts
@@ -22,8 +22,23 @@ export function resolveProjectCloneUrlPrefill(
   }
   const sourceRepoIds =
     projects.find((candidate) => candidate.id === selectedProjectId)?.sourceRepoIds ?? []
-  const remoteUrl = sourceRepoIds
-    .map((sourceId) => repos.find((repo) => repo.id === sourceId)?.gitRemoteIdentity?.remoteUrl)
-    .find((url): url is string => Boolean(url))
-  return remoteUrl ? stripCredentialsFromMessage(remoteUrl) : ''
+  let reposById: Map<string, Repo> | undefined
+  for (let index = 0; index < sourceRepoIds.length; index++) {
+    if (index > 0 && !reposById) {
+      reposById = new Map()
+      for (const repo of repos) {
+        const id = repo.id
+        if (!reposById.has(id)) {
+          reposById.set(id, repo)
+        }
+      }
+    }
+    const sourceId = sourceRepoIds[index]
+    const source = reposById ? reposById.get(sourceId) : repos.find((repo) => repo.id === sourceId)
+    const remoteUrl = source?.gitRemoteIdentity?.remoteUrl
+    if (remoteUrl) {
+      return stripCredentialsFromMessage(remoteUrl)
+    }
+  }
+  return ''
 }

--- a/src/renderer/src/lib/workspace-doc-address-input.test.ts
+++ b/src/renderer/src/lib/workspace-doc-address-input.test.ts
@@ -145,3 +145,14 @@ describe('resolveWorkspaceDocAddressTarget', () => {
     ).toEqual({ status: 'unsupported', message: 'no channel' })
   })
 })
+
+it('resolves a current-workspace address without enumerating unrelated workspace roots', () => {
+  const state = makeState()
+  state.allWorktrees = vi.fn(() => {
+    throw new Error('unnecessary global workspace enumeration')
+  })
+  expect(
+    resolveWorkspaceDocAddressTarget(state, CURRENT, '/home/alice/wt1/docs/index.html').status
+  ).toBe('workspace-doc')
+  expect(state.allWorktrees).not.toHaveBeenCalled()
+})

--- a/src/renderer/src/lib/workspace-doc-address-input.ts
+++ b/src/renderer/src/lib/workspace-doc-address-input.ts
@@ -19,7 +19,6 @@ function ownedWorktreeRoots(
   currentWorktreeId: string
 ): { worktreeId: string; root: string }[] {
   const roots: { worktreeId: string; root: string }[] = []
-  const currentPath = state.getKnownWorktreeById(currentWorktreeId)?.path ?? null
   for (const worktree of state.allWorktrees()) {
     if (worktree.id !== currentWorktreeId && worktree.path) {
       roots.push({ worktreeId: worktree.id, root: worktree.path })
@@ -34,7 +33,7 @@ function ownedWorktreeRoots(
   // Most-specific root first (after the current worktree), so a file inside a nested workspace is
   // attributed to that workspace and not to the outer one that lexically contains it too.
   roots.sort((a, b) => b.root.length - a.root.length)
-  return currentPath ? [{ worktreeId: currentWorktreeId, root: currentPath }, ...roots] : roots
+  return roots
 }
 
 function planToTarget(
@@ -79,6 +78,10 @@ export function resolveWorkspaceDocAddressTarget(
     // routed through dot segments could claim a workspace it then escapes.
     if (input.split(/[\\/]+/).some((segment) => segment === '..' || segment === '.')) {
       return { status: 'not-a-workspace-doc' }
+    }
+    const currentPath = state.getKnownWorktreeById(currentWorktreeId)?.path
+    if (currentPath && getRelativePathInsideRoot(input, currentPath)) {
+      return planToTarget(state, currentWorktreeId, input)
     }
     for (const { worktreeId, root } of ownedWorktreeRoots(state, currentWorktreeId)) {
       if (getRelativePathInsideRoot(input, root)) {

--- a/src/renderer/src/lib/worktree-activation-pty-inventory.test.ts
+++ b/src/renderer/src/lib/worktree-activation-pty-inventory.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { resolveActivationPtyListScope } from './worktree-activation-pty-inventory'
+
+const worktreeId = 'repo::/workspace'
+
+describe('activation inventory execution scope', () => {
+  it('keeps a known local repo usable before unrelated runtime catalogs hydrate', () => {
+    expect(
+      resolveActivationPtyListScope(
+        {
+          repos: [{ id: 'repo' }],
+          runtimeEnvironments: [],
+          runtimeEnvironmentCatalogHydrated: false,
+          activeWorktreeId: 'other::/remote',
+          activeWorkspaceExecutionHostId: 'ssh:other'
+        },
+        worktreeId
+      )
+    ).toEqual({ connectionId: null })
+  })
+
+  it('does not use the native repo fallback for an explicitly owned worktree', () => {
+    expect(() =>
+      resolveActivationPtyListScope(
+        {
+          repos: [{ id: 'repo' }],
+          worktreesByRepo: { repo: [{ id: worktreeId, repoId: 'repo', hostId: 'runtime:hub' }] }
+        },
+        worktreeId
+      )
+    ).toThrow('provider unavailable')
+  })
+
+  it.each(['local', 'ssh:remote%20box'] as const)('resolves only %s', (hostId) => {
+    expect(
+      resolveActivationPtyListScope(
+        {
+          repos: [{ id: 'repo', executionHostId: hostId }]
+        },
+        worktreeId
+      )
+    ).toEqual({ connectionId: hostId === 'local' ? null : 'remote box' })
+  })
+
+  it('resolves folder workspaces without a Git worktree row', () => {
+    expect(
+      resolveActivationPtyListScope(
+        {
+          folderWorkspaces: [{ id: 'folder', projectGroupId: 'group', connectionId: 'box' }]
+        },
+        folderWorkspaceKey('folder')
+      )
+    ).toEqual({ connectionId: 'box' })
+  })
+
+  it('does not choose a provider for missing or ambiguous ownership', () => {
+    expect(() => resolveActivationPtyListScope({}, worktreeId)).toThrow('provider unavailable')
+    expect(() =>
+      resolveActivationPtyListScope(
+        {
+          repos: [
+            { id: 'repo', executionHostId: 'local' },
+            { id: 'repo', executionHostId: 'ssh:box' }
+          ]
+        },
+        worktreeId
+      )
+    ).toThrow('provider unavailable')
+  })
+
+  it('never routes a paired host or its nested SSH target through client providers', () => {
+    for (const hostId of ['runtime:hub', 'ssh:nested'] as const) {
+      expect(() =>
+        resolveActivationPtyListScope(
+          {
+            worktreesByRepo: {
+              repo: [{ id: worktreeId, repoId: 'repo', hostId, runtimeOwnerEnvironmentId: 'hub' }]
+            }
+          },
+          worktreeId
+        )
+      ).toThrow('provider unavailable')
+    }
+  })
+})

--- a/src/renderer/src/lib/worktree-activation-pty-inventory.ts
+++ b/src/renderer/src/lib/worktree-activation-pty-inventory.ts
@@ -1,0 +1,49 @@
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import { parseExecutionHostId } from '../../../shared/execution-host'
+import type { PtySessionListScope } from '../../../shared/pty-listed-session'
+import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
+import { getRuntimeEnvironmentIdForWorktree } from './worktree-runtime-owner'
+import {
+  resolveIndexedRepoOwner,
+  resolveIndexedWorktreeOwner
+} from './worktree-runtime-owner-index'
+import {
+  resolveWorktreeOperationRouteResult,
+  type WorktreeOperationRouteState
+} from './worktree-operation-route'
+
+export function resolveActivationPtyListScope(
+  state: WorktreeOperationRouteState,
+  worktreeId: string
+): PtySessionListScope {
+  if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    return { connectionId: null }
+  }
+  const resolution = resolveWorktreeOperationRouteResult(state, worktreeId)
+  if (resolution.kind === 'missing' && !getRuntimeEnvironmentIdForWorktree(state, worktreeId)) {
+    const repo = resolveIndexedRepoOwner(state.repos, getRepoIdFromWorktreeId(worktreeId))
+    const worktree = resolveIndexedWorktreeOwner(state.worktreesByRepo, worktreeId)
+    // A known native repo remains usable while the unrelated runtime catalog hydrates.
+    if (
+      repo.kind === 'resolved' &&
+      !(state.activeWorktreeId === worktreeId && state.activeWorkspaceExecutionHostId) &&
+      (worktree.kind === 'missing' ||
+        (worktree.kind === 'resolved' &&
+          !worktree.owner.hostId &&
+          !worktree.owner.runtimeOwnerEnvironmentId)) &&
+      !repo.owner.connectionId &&
+      (!repo.owner.executionHostId || repo.owner.executionHostId === 'local')
+    ) {
+      return { connectionId: null }
+    }
+  }
+  if (resolution.kind !== 'resolved' || resolution.route.runtimeEnvironmentId) {
+    throw new Error('workspace activation provider unavailable')
+  }
+  const host = parseExecutionHostId(resolution.route.executionHostId)
+  if (!host || host.kind === 'runtime') {
+    // Paired hosts own their activation; a client inventory cannot authorize a writer there.
+    throw new Error('workspace activation provider unavailable')
+  }
+  return { connectionId: host.kind === 'ssh' ? host.targetId : null }
+}

--- a/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
@@ -653,6 +653,30 @@ describe('worktree agent activation gate', () => {
     await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
   })
 
+  it.each([
+    ['ssh:box@@pty-1', WORKTREE_ID],
+    [`${WORKTREE_ID}@@legacy`, '']
+  ])(
+    'adopts %s using workspace metadata or the legacy ID fallback',
+    async (livePtyId, worktreeId) => {
+      const { deps, createTab, resume } = testDeps({
+        sessions: [{ ...listed(livePtyId), worktreeId }],
+        surfaceOwners: new Map([
+          [livePtyId, { paneKey: `tab-live:${LIVE_LEAF_ID}`, ptyId: livePtyId, tabId: 'tab-live' }]
+        ])
+      })
+      const store = deps.getState()
+      seedExistingSurface(store, { tabId: 'tab-live', leafId: LIVE_LEAF_ID })
+
+      await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+      expect(createTab).not.toHaveBeenCalled()
+      expect(resume).not.toHaveBeenCalled()
+      expect(store.terminalLayoutsByTabId['tab-live']?.ptyIdsByLeafId).toEqual({
+        [LIVE_LEAF_ID]: livePtyId
+      })
+    }
+  )
+
   it('adopts a host surface hydrated under a differently spelled workspace id', async () => {
     const livePtyId = `${WORKTREE_ID}@@live-agent`
     const { deps, createTab } = testDeps({

--- a/src/renderer/src/lib/worktree-agent-activation-gate.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.ts
@@ -3,6 +3,8 @@ import type { PtyListedSession } from '../../../shared/pty-listed-session'
 import { parsePtySessionId, PTY_SESSION_ID_SEPARATOR } from '../../../shared/pty-session-id-format'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
+import { worktreeIdsEqual } from '../../../shared/worktree/id'
+import { resolveActivationPtyListScope } from './worktree-activation-pty-inventory'
 import {
   resumeSleepingAgentSessionsForWorktree,
   type ResumeSleepingAgentSessionsOptions
@@ -194,7 +196,9 @@ export async function runWorktreeAgentActivationGate(
   }
 
   const liveWorkspaceSessions = sessions.filter((session) =>
-    sessionBelongsToWorkspace(session.id, worktreeId)
+    session.worktreeId
+      ? worktreeIdsEqual(session.worktreeId, worktreeId)
+      : sessionBelongsToWorkspace(session.id, worktreeId)
   )
   const liveWorkspacePtyIds = new Set(liveWorkspaceSessions.map((session) => session.id))
   for (const owner of structuredInventory?.ownerBySessionId.values() ?? []) {
@@ -266,7 +270,11 @@ export function gateWorktreeAgentActivation(
     getState: () => useAppStore.getState(),
     awaitReady: waitForWorkspaceSessionReady,
     listSessions: () =>
-      typeof window === 'undefined' ? Promise.resolve([]) : window.api.pty.listSessions(),
+      typeof window === 'undefined'
+        ? Promise.resolve([])
+        : window.api.pty.listSessions(
+            resolveActivationPtyListScope(useAppStore.getState(), worktreeId)
+          ),
     listSurfaceOwners: readWorktreeLiveTerminalSurfaceOwners,
     hasStructuredSession: readWorktreeStructuredActivationInventory,
     resume: resumeSleepingAgentSessionsForWorktree

--- a/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
@@ -111,10 +111,12 @@ function stubInventory(args?: {
 } {
   const worktree = makeWorktree()
   const runtimeCall = vi.fn(async ({ method }: { method: string }) => {
-    if (method === 'session.tabs.listAll') {
+    if (method === 'session.tabs.list') {
       return {
         ok: true,
-        result: { snapshots: args?.structured ? [structuredSnapshot(worktree.id)] : [] }
+        result: args?.structured
+          ? structuredSnapshot(worktree.id)
+          : { ...structuredSnapshot(worktree.id), tabs: [] }
       }
     }
     if (method === 'agentSession.handoffStatus') {
@@ -282,14 +284,18 @@ describe('worktree agent activation seam', () => {
   it('does not spawn before a structured chat tab hydrates', async () => {
     const worktree = makeWorktree()
     useAppStore.setState(baseState())
-    const { runtimeCall } = stubInventory({ structured: true })
+    const { runtimeCall, listSessions } = stubInventory({ structured: true })
 
     expect(activateAndRevealWorktree(worktree.id)).toEqual({ primaryTabId: null })
     await waitForWorktreeAgentActivationGateForTests(worktree.id)
 
     expect(useAppStore.getState().unifiedTabsByWorktree[worktree.id] ?? []).toHaveLength(0)
     expect(useAppStore.getState().tabsByWorktree[worktree.id] ?? []).toHaveLength(0)
-    expect(runtimeCall).toHaveBeenCalledWith({ method: 'session.tabs.listAll', params: {} })
+    expect(runtimeCall).toHaveBeenCalledWith({
+      method: 'session.tabs.list',
+      params: { worktree: `id:${worktree.id}` }
+    })
+    expect(listSessions).toHaveBeenCalledExactlyOnceWith({ connectionId: null })
     expect(runtimeCall).toHaveBeenCalledWith({
       method: 'agentSession.handoffStatus',
       params: { sessionId: 'chat-1' }

--- a/src/renderer/src/lib/worktree-agent-structured-inventory.test.ts
+++ b/src/renderer/src/lib/worktree-agent-structured-inventory.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readWorktreeStructuredActivationInventory } from './worktree-agent-structured-inventory'
+
+const worktree = 'repo::/workspace'
+afterEach(() => vi.unstubAllGlobals())
+
+function install(result: unknown, ok = true) {
+  const call = vi.fn(async ({ method }: { method: string }) => {
+    if (method === 'agentSession.handoffStatus') {
+      return { ok: true, result: { owner: 'native' } }
+    }
+    return { ok, result }
+  })
+  vi.stubGlobal('window', { api: { runtime: { call } } })
+  return call
+}
+
+describe('structured activation inventory scope', () => {
+  it('requests one workspace snapshot and retains structured handoff evidence', async () => {
+    const call = install({
+      worktree,
+      tabs: [
+        { type: 'terminal', id: 'terminal' },
+        { type: 'agent-session', sessionId: 'agent' }
+      ]
+    })
+    const result = await readWorktreeStructuredActivationInventory(worktree)
+    expect(call.mock.calls[0][0]).toEqual({
+      method: 'session.tabs.list',
+      params: { worktree: `id:${worktree}` }
+    })
+    expect(call).toHaveBeenCalledTimes(2)
+    expect(result && result.ownerBySessionId.get('agent')).toEqual({ owner: 'native' })
+  })
+
+  it('does not request handoffs for a workspace without structured tabs', async () => {
+    const call = install({ worktree, tabs: [] })
+    expect(await readWorktreeStructuredActivationInventory(worktree)).toBe(false)
+    expect(call).toHaveBeenCalledOnce()
+  })
+
+  it.each([null, {}, { worktree: 'other::/workspace', tabs: [] }, { worktree }])(
+    'rejects unreadable or wrong-workspace replies',
+    async (result) => {
+      install(result)
+      await expect(readWorktreeStructuredActivationInventory(worktree)).rejects.toThrow(
+        'scope unavailable'
+      )
+    }
+  )
+
+  it('does not interpret an RPC failure as an empty workspace', async () => {
+    install(null, false)
+    await expect(readWorktreeStructuredActivationInventory(worktree)).rejects.toThrow(
+      'inventory unavailable'
+    )
+  })
+})

--- a/src/renderer/src/lib/worktree-agent-structured-inventory.ts
+++ b/src/renderer/src/lib/worktree-agent-structured-inventory.ts
@@ -1,4 +1,6 @@
 import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
+import { worktreeIdsEqual } from '../../../shared/worktree/id'
 
 export type StructuredActivationInventory = {
   snapshot: RuntimeMobileSessionTabsResult
@@ -17,17 +19,23 @@ export async function readWorktreeStructuredActivationInventory(
   if (typeof window === 'undefined') {
     return false
   }
-  const response = await window.api.runtime.call({ method: 'session.tabs.listAll', params: {} })
+  const response = await window.api.runtime.call({
+    method: 'session.tabs.list',
+    params: { worktree: toRuntimeWorktreeSelector(worktreeId) }
+  })
   if (!response.ok) {
     throw new Error('structured session inventory unavailable')
   }
-  const result = response.result as { snapshots?: RuntimeMobileSessionTabsResult[] }
-  const snapshot = (result.snapshots ?? []).find(
-    (candidate) =>
-      candidate.worktree === worktreeId &&
-      candidate.tabs.some((tab) => tab.type === 'agent-session')
-  )
-  if (!snapshot) {
+  const snapshot = response.result as RuntimeMobileSessionTabsResult
+  if (
+    !snapshot ||
+    typeof snapshot.worktree !== 'string' ||
+    !worktreeIdsEqual(snapshot.worktree, worktreeId) ||
+    !Array.isArray(snapshot.tabs)
+  ) {
+    throw new Error('structured session inventory scope unavailable')
+  }
+  if (!snapshot.tabs.some((tab) => tab.type === 'agent-session')) {
     return false
   }
   const ownerBySessionId = new Map<

--- a/src/renderer/src/store/slices/agent-status-pane-keyed-records.test.ts
+++ b/src/renderer/src/store/slices/agent-status-pane-keyed-records.test.ts
@@ -3,7 +3,8 @@ import {
   RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX,
   RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX,
   boundRecentlyClosedAgentStatusTabIds,
-  boundRecentlyRetiredAgentStatusPaneKeys
+  boundRecentlyRetiredAgentStatusPaneKeys,
+  removePaneKeys
 } from './agent-status-pane-keyed-records'
 
 function keyRecord(keys: readonly string[]): Record<string, true> {
@@ -107,4 +108,28 @@ describe('boundRecentlyClosedAgentStatusTabIds', () => {
     expect(next.t0).toBeUndefined()
     expect(next.fresh).toBe(true)
   })
+})
+
+it('does not enumerate unrelated pane records when removing absent keys', () => {
+  let enumerations = 0
+  const record = new Proxy(
+    Object.fromEntries(Array.from({ length: 1000 }, (_, index) => [`tab-${index}:leaf`, index])),
+    {
+      ownKeys(target) {
+        enumerations += 1
+        return Reflect.ownKeys(target)
+      }
+    }
+  )
+  for (let index = 0; index < 200; index += 1) {
+    expect(removePaneKeys(record, new Set(['absent:leaf']))).toBe(record)
+  }
+  expect(enumerations).toBe(0)
+})
+
+it('removes enumerable undefined values without removing inherited or hidden keys', () => {
+  const record = { visible: undefined }
+  Object.defineProperty(record, 'hidden', { value: 1, enumerable: false })
+  expect(removePaneKeys(record, new Set(['hidden', 'toString']))).toBe(record)
+  expect(Object.hasOwn(removePaneKeys(record, new Set(['visible'])), 'visible')).toBe(false)
 })

--- a/src/renderer/src/store/slices/agent-status-pane-keyed-records.ts
+++ b/src/renderer/src/store/slices/agent-status-pane-keyed-records.ts
@@ -83,7 +83,9 @@ export function removePaneKeys<T>(
   record: Record<string, T>,
   paneKeys: ReadonlySet<string>
 ): Record<string, T> {
-  const matchingKeys = Object.keys(record).filter((key) => paneKeys.has(key))
+  const matchingKeys = [...paneKeys].filter((key) =>
+    Object.prototype.propertyIsEnumerable.call(record, key)
+  )
   if (matchingKeys.length === 0) {
     return record
   }

--- a/src/renderer/src/store/slices/browser-cleanup-close.test.ts
+++ b/src/renderer/src/store/slices/browser-cleanup-close.test.ts
@@ -151,4 +151,57 @@ describe('closeBrowserTab with reason cleanup', () => {
 
     expect(recordFeatureInteraction).toHaveBeenCalledWith('terminal-tabs')
   })
+  it('clears focus for closed pages without rescanning pages for unrelated focus entries', () => {
+    const { store, workspaceId } = storeWithOnlyBrowserTab()
+    const original = store.getState().browserPagesByWorkspace[workspaceId][0]
+    let idReads = 0
+    const pages = Array.from({ length: 1000 }, (_, index) => ({
+      ...original,
+      get id() {
+        idReads++
+        return `closed-${index}`
+      }
+    }))
+    const unrelated = Object.fromEntries(
+      Array.from({ length: 1000 }, (_, i) => [`other-${i}`, true as const])
+    )
+    store.setState({
+      browserPagesByWorkspace: { [workspaceId]: pages },
+      pendingAddressBarFocusByPageId: { ...unrelated, 'closed-999': true, [workspaceId]: true },
+      pendingAddressBarFocusByTabId: { ...unrelated, 'closed-999': true, [workspaceId]: true }
+    })
+    idReads = 0
+    store.getState().closeBrowserTab(workspaceId, { reason: 'cleanup' })
+    expect(store.getState().pendingAddressBarFocusByPageId).toEqual({
+      ...unrelated,
+      [workspaceId]: true
+    })
+    expect(store.getState().pendingAddressBarFocusByTabId).toEqual(unrelated)
+    expect(idReads).toBeLessThan(10_000)
+  })
+})
+
+describe('workspace document history title refresh', () => {
+  it('does not publish unchanged titles but preserves real visits and title changes', () => {
+    const store = createTestStore()
+    const location = {
+      kind: 'workspace-doc' as const,
+      worktreeId: WT,
+      filePath: '/path/wt1/doc.html'
+    }
+    store.getState().recordWorkspaceDocVisit(location, 'Document')
+    const history = store.getState().workspaceDocHistory
+    const listener = vi.fn()
+    const unsubscribe = store.subscribe(listener)
+    for (let i = 0; i < 200; i++) {
+      store.getState().recordWorkspaceDocVisit(location, 'Document', { bump: false })
+    }
+    expect(listener).not.toHaveBeenCalled()
+    expect(store.getState().workspaceDocHistory).toBe(history)
+    store.getState().recordWorkspaceDocVisit(location, 'Renamed', { bump: false })
+    expect(store.getState().workspaceDocHistory[0]).toEqual({ ...history[0], title: 'Renamed' })
+    store.getState().recordWorkspaceDocVisit(location, 'Renamed')
+    expect(store.getState().workspaceDocHistory[0].visitCount).toBe(2)
+    unsubscribe()
+  })
 })

--- a/src/renderer/src/store/slices/browser/browser-close-actions.ts
+++ b/src/renderer/src/store/slices/browser/browser-close-actions.ts
@@ -135,14 +135,15 @@ export function createBrowserCloseActions(
         }
         delete nextRecentlyClosedBrowserPagesByWorkspace[tabId]
 
+        const closedPageIds = new Set(closedPages.map((page) => page.id))
         const nextPendingAddressBarFocusByPageId = Object.fromEntries(
           Object.entries(s.pendingAddressBarFocusByPageId).filter(
-            ([pageId]) => !closedPages.some((page) => page.id === pageId)
+            ([pageId]) => !closedPageIds.has(pageId)
           )
         )
         const nextPendingAddressBarFocusByTabId = Object.fromEntries(
           Object.entries(s.pendingAddressBarFocusByTabId).filter(
-            ([focusId]) => focusId !== tabId && !closedPages.some((page) => page.id === focusId)
+            ([focusId]) => focusId !== tabId && !closedPageIds.has(focusId)
           )
         )
 

--- a/src/renderer/src/store/slices/browser/browser-history-actions.ts
+++ b/src/renderer/src/store/slices/browser/browser-history-actions.ts
@@ -37,6 +37,14 @@ export function createBrowserHistoryActions(
           title ?? existing?.title,
           docLocation
         )
+        if (
+          existing &&
+          !bump &&
+          normalizedTitle === existing.title &&
+          s.workspaceDocHistory.length <= MAX_WORKSPACE_DOC_HISTORY_ENTRIES
+        ) {
+          return s
+        }
         const next: WorkspaceDocHistoryEntry[] = existing
           ? s.workspaceDocHistory.map((entry) =>
               entry === existing

--- a/src/renderer/src/store/slices/editor-hydration-scaling.test.ts
+++ b/src/renderer/src/store/slices/editor-hydration-scaling.test.ts
@@ -1,0 +1,44 @@
+import { expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
+import { createTestStore } from './store-test-helpers'
+import { createStoreSessionMockApi } from './store-session-test-harness'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+createStoreSessionMockApi()
+
+it('restores a large editor session without rescanning earlier file owners', () => {
+  const store = createTestStore()
+  const count = 2_000
+  let pathReads = 0
+  const files = Array.from({ length: count }, (_, index) => ({
+    get filePath() {
+      pathReads++
+      return `/project/file-${index}.ts`
+    },
+    relativePath: `file-${index}.ts`,
+    worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+    language: 'typescript',
+    runtimeEnvironmentId: index % 2 ? ' peer ' : null,
+    dirtyDraftContent: `unsaved ${index}`
+  }))
+  const session: WorkspaceSessionState = {
+    activeRepoId: null,
+    activeWorktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    openFilesByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: files }
+  }
+  store.setState({ activeWorktreeId: FLOATING_TERMINAL_WORKTREE_ID })
+  store.getState().hydrateEditorSession(session)
+  const state = store.getState()
+  expect(state.openFiles).toHaveLength(count)
+  expect(pathReads).toBeLessThan(count * 20)
+  for (let index = 0; index < count; index++) {
+    const file = state.openFiles[index]
+    expect(file.filePath).toBe(`/project/file-${index}.ts`)
+    expect(state.editorDrafts[file.id]).toBe(`unsaved ${index}`)
+  }
+  expect(state.activeFileId).toBe(state.openFiles[0].id)
+})

--- a/src/renderer/src/store/slices/editor/actions/hydrate-editor-session.ts
+++ b/src/renderer/src/store/slices/editor/actions/hydrate-editor-session.ts
@@ -7,14 +7,14 @@ import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
 import type { WorkspaceVisibleTabType } from '../../../../../../shared/tab-types'
 import type { OpenFile } from '../types/open-file'
 import { buildValidWorktreeIdsForSessionHydration } from '../../degraded-repo-worktree-validity'
-import { buildOwnedEditorFileId, isSameEditorOwner } from '../file-ids/editor-file-ids'
+import { buildOwnedEditorFileId } from '../file-ids/editor-file-ids'
+import { resolveHydratedEditorFileSelection } from '../file-ids/hydrated-editor-file-selection'
+import { resolveHydratedEditorFrontmatter } from '../file-ids/hydrated-editor-frontmatter'
 import {
   addEditorFileIdMigration,
-  migrateEditorFileId,
   migrateHydratedEditorTabsAndGroups,
-  resolveLegacyHydratedEditorFileId,
-  shouldHydrateWithOwnedEditorFileId,
-  type LegacyHydratedEditorFile
+  LegacyHydratedEditorFileIndex,
+  shouldHydrateWithOwnedEditorFileId
 } from '../file-ids/hydrated-editor-file-ids'
 
 export function createHydrateEditorSession(
@@ -42,7 +42,7 @@ export function createHydrateEditorSession(
         const openFiles: OpenFile[] = []
         const editorDrafts: Record<string, string> = {}
         const usedOpenFileIds = new Set<string>()
-        const legacyHydratedOpenFiles: LegacyHydratedEditorFile[] = []
+        const legacyFileIndex = new LegacyHydratedEditorFileIndex()
         const editorFileIdMigrationsByWorktree: Record<string, Map<string, string>> = {}
         for (const [worktreeId, files] of Object.entries(openFilesByWorktree)) {
           if (!validWorktreeIds.has(worktreeId)) {
@@ -50,20 +50,10 @@ export function createHydrateEditorSession(
           }
           for (const pf of files) {
             // Split tabs share one OpenFile; repeated records for the same owner are corruption.
-            if (
-              legacyHydratedOpenFiles.some(
-                (file) =>
-                  file.filePath === pf.filePath &&
-                  isSameEditorOwner(file, worktreeId, pf.runtimeEnvironmentId)
-              )
-            ) {
+            if (legacyFileIndex.hasOwner(pf, worktreeId)) {
               continue
             }
-            const legacyId = resolveLegacyHydratedEditorFileId(
-              legacyHydratedOpenFiles,
-              pf,
-              worktreeId
-            )
+            const legacyId = legacyFileIndex.resolve(pf, worktreeId)
             // Why: floating/runtime-owned files need IDs that survive peers disappearing between restarts; collision-based IDs drift when the path is no longer open elsewhere.
             const ownedId = buildOwnedEditorFileId(pf.filePath, worktreeId, pf.runtimeEnvironmentId)
             const id =
@@ -78,7 +68,7 @@ export function createHydrateEditorSession(
             usedOpenFileIds.add(id)
             // Why: map from the collision-derived legacy id; keying by filePath would collapse same-path local/runtime tabs onto the last owner to hydrate.
             addEditorFileIdMigration(editorFileIdMigrationsByWorktree, worktreeId, legacyId, id)
-            legacyHydratedOpenFiles.push({
+            legacyFileIndex.add({
               id: legacyId,
               filePath: pf.filePath,
               worktreeId,
@@ -117,47 +107,21 @@ export function createHydrateEditorSession(
 
         // Why: use the store's activeWorktreeId — hydrateWorkspaceSession may have nulled an invalid ID, and we must respect that.
         const activeWorktreeId = s.activeWorktreeId
-        const fallbackActiveFileId = activeWorktreeId
-          ? (openFiles.find((f) => f.worktreeId === activeWorktreeId)?.id ?? null)
-          : null
-        const persistedActiveFileId = activeWorktreeId
-          ? migrateEditorFileId(
-              editorFileIdMigrationsByWorktree,
-              activeWorktreeId,
-              persistedActiveFileIdByWorktree[activeWorktreeId]
-            )
-          : null
-        // Why: the persisted active file may be gone (worktree validation or stale path), so verify it exists in the restored set.
-        const activeFileExists = persistedActiveFileId
-          ? openFiles.some(
-              (f) => f.id === persistedActiveFileId && f.worktreeId === activeWorktreeId
-            )
-          : false
-        // Why: the previous active surface may have been a transient diff/conflict tab (not restored), so promote the first restored edit file.
-        const nextActiveFileId = activeFileExists ? persistedActiveFileId : fallbackActiveFileId
+        const {
+          activeFileId: nextActiveFileId,
+          activeFileIdByWorktree: filteredActiveFileIdByWorktree
+        } = resolveHydratedEditorFileSelection({
+          openFiles,
+          validWorktreeIds,
+          activeWorktreeId,
+          persistedActiveFileIds: persistedActiveFileIdByWorktree,
+          migrations: editorFileIdMigrationsByWorktree
+        })
         const activeTabType: WorkspaceVisibleTabType =
           activeWorktreeId && persistedActiveTabTypeByWorktree[activeWorktreeId]
             ? persistedActiveTabTypeByWorktree[activeWorktreeId]
             : 'terminal'
 
-        // Filter per-worktree maps to only valid worktrees with valid file references
-        const filteredActiveFileIdByWorktree = Object.fromEntries(
-          [...validWorktreeIds].flatMap((wId) => {
-            const persistedFileId = migrateEditorFileId(
-              editorFileIdMigrationsByWorktree,
-              wId,
-              persistedActiveFileIdByWorktree[wId]
-            )
-            if (
-              persistedFileId &&
-              openFiles.some((f) => f.id === persistedFileId && f.worktreeId === wId)
-            ) {
-              return [[wId, persistedFileId]]
-            }
-            const fallbackFileId = openFiles.find((f) => f.worktreeId === wId)?.id
-            return fallbackFileId ? [[wId, fallbackFileId]] : []
-          })
-        )
         const filteredActiveTabTypeByWorktree = Object.fromEntries(
           Object.entries(persistedActiveTabTypeByWorktree).filter(([wId, tabType]) => {
             if (!validWorktreeIds.has(wId)) {
@@ -174,26 +138,11 @@ export function createHydrateEditorSession(
         // Why: transient diff/conflict surfaces aren't restored, so clear a stale "editor" marker and fall back to terminal.
         const nextActiveTabType =
           nextActiveFileId || activeTabType !== 'editor' ? activeTabType : 'terminal'
-        const openFileIds = new Set(openFiles.map((file) => file.id))
-        // Why: visible is the default, so restore only per-file hide overrides (`false`); legacy `true` entries collapse to the default.
-        const hiddenFrontmatterEntries = new Map<string, boolean>()
-        for (const [persistedFileId, visible] of Object.entries(
-          persistedMarkdownFrontmatterVisible
-        )) {
-          if (visible) {
-            continue
-          }
-          if (openFileIds.has(persistedFileId)) {
-            hiddenFrontmatterEntries.set(persistedFileId, false)
-          }
-          for (const migrations of Object.values(editorFileIdMigrationsByWorktree)) {
-            const migratedFileId = migrations.get(persistedFileId)
-            if (migratedFileId && openFileIds.has(migratedFileId)) {
-              hiddenFrontmatterEntries.set(migratedFileId, false)
-            }
-          }
-        }
-        const markdownFrontmatterVisible = Object.fromEntries(hiddenFrontmatterEntries)
+        const markdownFrontmatterVisible = resolveHydratedEditorFrontmatter(
+          persistedMarkdownFrontmatterVisible,
+          usedOpenFileIds,
+          editorFileIdMigrationsByWorktree
+        )
 
         return {
           openFiles,

--- a/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-file-ids.ts
+++ b/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-file-ids.ts
@@ -4,12 +4,7 @@ import type { PersistedOpenFile } from '../../../../../../shared/workspace-sessi
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../../../shared/constants'
 import type { OpenFile } from '../types/open-file'
 import { isEditorTabContentType } from '../tabs/editor-tab-content-type'
-import {
-  buildOwnedEditorFileId,
-  isEditorFileIdOccupiedByOtherOwner,
-  isSameEditorOwner,
-  runtimeOwnerKey
-} from './editor-file-ids'
+import { buildOwnedEditorFileId, runtimeOwnerKey } from './editor-file-ids'
 
 export function shouldHydrateWithOwnedEditorFileId(
   worktreeId: string,
@@ -39,29 +34,58 @@ export type LegacyHydratedEditorFile = Pick<
   'id' | 'filePath' | 'worktreeId' | 'runtimeEnvironmentId' | 'markdownPreviewSourceFileId'
 >
 
-export function resolveLegacyHydratedEditorFileId(
-  files: readonly LegacyHydratedEditorFile[],
-  persistedFile: PersistedOpenFile,
-  worktreeId: string
-): string {
-  const existing = files.find(
-    (file) =>
-      file.filePath === persistedFile.filePath &&
-      isSameEditorOwner(file, worktreeId, persistedFile.runtimeEnvironmentId)
-  )
-  if (existing) {
-    return existing.id
+export class LegacyHydratedEditorFileIndex {
+  private readonly filesByPath = new Map<string, Map<string, string>>()
+  private readonly ownersById = new Map<string, Set<string>>()
+
+  private ownerKey(worktreeId: string, runtimeEnvironmentId: string | null | undefined): string {
+    return JSON.stringify([worktreeId, runtimeOwnerKey(runtimeEnvironmentId)])
   }
-  return files.some((file) =>
-    isEditorFileIdOccupiedByOtherOwner(
-      file,
-      persistedFile.filePath,
-      worktreeId,
-      persistedFile.runtimeEnvironmentId
+
+  hasOwner(file: PersistedOpenFile, worktreeId: string): boolean {
+    return (
+      this.filesByPath
+        .get(file.filePath)
+        ?.has(this.ownerKey(worktreeId, file.runtimeEnvironmentId)) ?? false
     )
-  )
-    ? buildOwnedEditorFileId(persistedFile.filePath, worktreeId, persistedFile.runtimeEnvironmentId)
-    : persistedFile.filePath
+  }
+
+  resolve(file: PersistedOpenFile, worktreeId: string): string {
+    const owner = this.ownerKey(worktreeId, file.runtimeEnvironmentId)
+    const existing = this.filesByPath.get(file.filePath)?.get(owner)
+    if (existing !== undefined) {
+      return existing
+    }
+    const occupied = this.ownersById.get(file.filePath)
+    return occupied && (occupied.size > 1 || !occupied.has(owner))
+      ? buildOwnedEditorFileId(file.filePath, worktreeId, file.runtimeEnvironmentId)
+      : file.filePath
+  }
+
+  add(file: LegacyHydratedEditorFile): void {
+    const owner = this.ownerKey(file.worktreeId, file.runtimeEnvironmentId)
+    let files = this.filesByPath.get(file.filePath)
+    if (!files) {
+      files = new Map()
+      this.filesByPath.set(file.filePath, files)
+    }
+    if (!files.has(owner)) {
+      files.set(owner, file.id)
+    }
+    this.addIdOwner(file.id, owner)
+    if (file.markdownPreviewSourceFileId !== undefined) {
+      this.addIdOwner(file.markdownPreviewSourceFileId, owner)
+    }
+  }
+
+  private addIdOwner(id: string, owner: string): void {
+    let owners = this.ownersById.get(id)
+    if (!owners) {
+      owners = new Set()
+      this.ownersById.set(id, owners)
+    }
+    owners.add(owner)
+  }
 }
 
 export function migrateEditorFileId(

--- a/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-file-index.test.ts
+++ b/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-file-index.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { PersistedOpenFile } from '../../../../../../shared/workspace-session-state-types'
+import {
+  LegacyHydratedEditorFileIndex,
+  type LegacyHydratedEditorFile
+} from './hydrated-editor-file-ids'
+import {
+  buildOwnedEditorFileId,
+  isEditorFileIdOccupiedByOtherOwner,
+  isSameEditorOwner
+} from './editor-file-ids'
+
+function persisted(filePath: string, runtimeEnvironmentId: string | null): PersistedOpenFile {
+  return {
+    filePath,
+    runtimeEnvironmentId,
+    relativePath: filePath,
+    worktreeId: '',
+    language: 'text'
+  }
+}
+
+function referenceId(
+  files: LegacyHydratedEditorFile[],
+  file: PersistedOpenFile,
+  worktreeId: string
+) {
+  const existing = files.find(
+    (prior) =>
+      prior.filePath === file.filePath &&
+      isSameEditorOwner(prior, worktreeId, file.runtimeEnvironmentId)
+  )
+  if (existing) {
+    return existing.id
+  }
+  return files.some((prior) =>
+    isEditorFileIdOccupiedByOtherOwner(prior, file.filePath, worktreeId, file.runtimeEnvironmentId)
+  )
+    ? buildOwnedEditorFileId(file.filePath, worktreeId, file.runtimeEnvironmentId)
+    : file.filePath
+}
+
+describe('legacy hydrated editor file index', () => {
+  it('matches the old lookup for mixed owners, first-wins duplicates and ID reservations', () => {
+    const index = new LegacyHydratedEditorFileIndex()
+    const prior: LegacyHydratedEditorFile[] = []
+    const paths = [
+      '/same.ts',
+      'C:\\work\\same.ts',
+      '/other.ts',
+      'editor:folder:local:%2Fsame.ts',
+      '',
+      '/preview.md'
+    ]
+    const worktrees = ['folder:one', 'wt:two', 'floating-terminals']
+    const runtimes = [null, '', ' ', 'local', 'peer', ' peer ', 'a:b', '["a","b"]']
+    for (let step = 0; step < 120; step++) {
+      for (const filePath of paths) {
+        for (const worktreeId of worktrees) {
+          for (const runtime of runtimes) {
+            const file = persisted(filePath, runtime)
+            expect(index.hasOwner(file, worktreeId)).toBe(
+              prior.some(
+                (row) => row.filePath === filePath && isSameEditorOwner(row, worktreeId, runtime)
+              )
+            )
+            expect(index.resolve(file, worktreeId)).toBe(referenceId(prior, file, worktreeId))
+          }
+        }
+      }
+      const row: LegacyHydratedEditorFile = {
+        filePath: paths[step % paths.length],
+        id: paths[(step * 3) % paths.length],
+        worktreeId: worktrees[Math.floor(step / paths.length) % worktrees.length],
+        runtimeEnvironmentId: runtimes[Math.floor(step / worktrees.length) % runtimes.length],
+        ...(step % 4 === 0 ? { markdownPreviewSourceFileId: '/preview.md' } : {})
+      }
+      index.add(row)
+      prior.push(row)
+    }
+  })
+})

--- a/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-file-selection.ts
+++ b/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-file-selection.ts
@@ -1,0 +1,40 @@
+import type { OpenFile } from '../types/open-file'
+import { migrateEditorFileId } from './hydrated-editor-file-ids'
+
+export function resolveHydratedEditorFileSelection(args: {
+  openFiles: readonly Pick<OpenFile, 'id' | 'worktreeId'>[]
+  validWorktreeIds: ReadonlySet<string>
+  activeWorktreeId: string | null
+  persistedActiveFileIds: Record<string, string | null>
+  migrations: Record<string, Map<string, string>>
+}): { activeFileId: string | null; activeFileIdByWorktree: Record<string, string> } {
+  const workspaces = new Map<string, { firstFileId: string; ids: Set<string> }>()
+  for (const file of args.openFiles) {
+    let workspace = workspaces.get(file.worktreeId)
+    if (!workspace) {
+      workspace = { firstFileId: file.id, ids: new Set() }
+      workspaces.set(file.worktreeId, workspace)
+    }
+    workspace.ids.add(file.id)
+  }
+  const selectedId = (worktreeId: string): string | null => {
+    const workspace = workspaces.get(worktreeId)
+    const persistedId = migrateEditorFileId(
+      args.migrations,
+      worktreeId,
+      args.persistedActiveFileIds[worktreeId]
+    )
+    return persistedId && workspace?.ids.has(persistedId)
+      ? persistedId
+      : (workspace?.firstFileId ?? null)
+  }
+  return {
+    activeFileId: args.activeWorktreeId ? selectedId(args.activeWorktreeId) : null,
+    activeFileIdByWorktree: Object.fromEntries(
+      [...args.validWorktreeIds].flatMap((worktreeId) => {
+        const fileId = selectedId(worktreeId)
+        return fileId ? [[worktreeId, fileId]] : []
+      })
+    )
+  }
+}

--- a/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-frontmatter.ts
+++ b/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-frontmatter.ts
@@ -1,0 +1,50 @@
+export function resolveHydratedEditorFrontmatter(
+  persistedVisibility: Record<string, boolean>,
+  openFileIds: ReadonlySet<string>,
+  migrationsByWorktree: Record<string, Map<string, string>>
+): Record<string, boolean> {
+  const hiddenIds = new Set(
+    Object.entries(persistedVisibility)
+      .filter(([, visible]) => !visible)
+      .map(([id]) => id)
+  )
+  if (hiddenIds.size === 0) {
+    return {}
+  }
+  const migratedIds = new Map<string, string[]>()
+  const addMigration = (from: string, to: string | undefined): void => {
+    if (!to || !openFileIds.has(to)) {
+      return
+    }
+    const targets = migratedIds.get(from)
+    if (targets) {
+      targets.push(to)
+    } else {
+      migratedIds.set(from, [to])
+    }
+  }
+  for (const migrations of Object.values(migrationsByWorktree)) {
+    // Scan the smaller side so sparse overrides never pay for a large migration map.
+    if (migrations.size < hiddenIds.size) {
+      for (const [from, to] of migrations) {
+        if (hiddenIds.has(from)) {
+          addMigration(from, to)
+        }
+      }
+    } else {
+      for (const from of hiddenIds) {
+        addMigration(from, migrations.get(from))
+      }
+    }
+  }
+  const hidden = new Map<string, boolean>()
+  for (const persistedId of hiddenIds) {
+    if (openFileIds.has(persistedId)) {
+      hidden.set(persistedId, false)
+    }
+    for (const migratedId of migratedIds.get(persistedId) ?? []) {
+      hidden.set(migratedId, false)
+    }
+  }
+  return Object.fromEntries(hidden)
+}

--- a/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-projections.test.ts
+++ b/src/renderer/src/store/slices/editor/file-ids/hydrated-editor-projections.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import { resolveHydratedEditorFileSelection } from './hydrated-editor-file-selection'
+import { resolveHydratedEditorFrontmatter } from './hydrated-editor-frontmatter'
+import { migrateEditorFileId } from './hydrated-editor-file-ids'
+
+type SelectionInput = Parameters<typeof resolveHydratedEditorFileSelection>[0]
+function referenceSelection(args: SelectionInput) {
+  const select = (worktreeId: string) => {
+    const persisted = migrateEditorFileId(
+      args.migrations,
+      worktreeId,
+      args.persistedActiveFileIds[worktreeId]
+    )
+    return persisted &&
+      args.openFiles.some((file) => file.id === persisted && file.worktreeId === worktreeId)
+      ? persisted
+      : (args.openFiles.find((file) => file.worktreeId === worktreeId)?.id ?? null)
+  }
+  return {
+    activeFileId: args.activeWorktreeId ? select(args.activeWorktreeId) : null,
+    activeFileIdByWorktree: Object.fromEntries(
+      [...args.validWorktreeIds].flatMap((worktreeId) => {
+        const fileId = select(worktreeId)
+        return fileId ? [[worktreeId, fileId]] : []
+      })
+    )
+  }
+}
+
+function referenceFrontmatter(
+  visibility: Record<string, boolean>,
+  openIds: Set<string>,
+  migrations: Record<string, Map<string, string>>
+) {
+  const hidden = new Map<string, boolean>()
+  for (const [id, visible] of Object.entries(visibility)) {
+    if (visible) {
+      continue
+    }
+    if (openIds.has(id)) {
+      hidden.set(id, false)
+    }
+    for (const migration of Object.values(migrations)) {
+      const target = migration.get(id)
+      if (target && openIds.has(target)) {
+        hidden.set(target, false)
+      }
+    }
+  }
+  return Object.fromEntries(hidden)
+}
+
+class CountedMigrations extends Map<string, string> {
+  reads = 0
+  override get(key: string): string | undefined {
+    this.reads++
+    return super.get(key)
+  }
+  override *[Symbol.iterator](): MapIterator<[string, string]> {
+    for (const entry of super[Symbol.iterator]()) {
+      this.reads++
+      yield entry
+    }
+  }
+}
+
+describe('hydrated editor selection', () => {
+  it('indexes files once across many workspace selections', () => {
+    const count = 1_000
+    let reads = 0
+    const files = Array.from({ length: count }, (_, index) => ({
+      get id() {
+        reads++
+        return `file-${index}`
+      },
+      get worktreeId() {
+        reads++
+        return `folder:${index}`
+      }
+    }))
+    const args: SelectionInput = {
+      openFiles: files,
+      validWorktreeIds: new Set(files.map((file) => file.worktreeId)),
+      activeWorktreeId: 'folder:999',
+      persistedActiveFileIds: Object.fromEntries(files.map((file) => [file.worktreeId, file.id])),
+      migrations: {}
+    }
+    reads = 0
+    const expected = referenceSelection(args)
+    expect(reads).toBeGreaterThan((count * count) / 2)
+    reads = 0
+    expect(resolveHydratedEditorFileSelection(args)).toEqual(expected)
+    expect(reads).toBeLessThan(count * 6)
+  })
+
+  it('preserves owner checks, migration, first-file fallbacks and empty IDs', () => {
+    for (let sample = 0; sample < 100; sample++) {
+      const args: SelectionInput = {
+        openFiles: Array.from({ length: 20 }, (_, index) => ({
+          id: (index + sample) % 7 ? `file-${(index + sample) % 9}` : '',
+          worktreeId: `wt-${(index * 3 + sample) % 5}`
+        })),
+        activeWorktreeId: sample % 3 ? `wt-${sample % 7}` : null,
+        validWorktreeIds: new Set(Array.from({ length: 7 }, (_, index) => `wt-${index}`)),
+        persistedActiveFileIds: {
+          'wt-0': 'legacy',
+          'wt-1': 'file-3',
+          'wt-2': 'absent',
+          'wt-3': ''
+        },
+        migrations: { 'wt-0': new Map([['legacy', 'file-1']]) }
+      }
+      expect(resolveHydratedEditorFileSelection(args)).toEqual(referenceSelection(args))
+    }
+  })
+})
+
+describe('hydrated frontmatter migration', () => {
+  it('avoids workspace-by-override fanout', () => {
+    const count = 1_000
+    const visibility = Object.fromEntries(
+      Array.from({ length: count }, (_, i) => [`old-${i}`, false])
+    )
+    const openIds = new Set(Array.from({ length: count }, (_, i) => `new-${i}`))
+    const migrations = Object.fromEntries(
+      Array.from({ length: count }, (_, i) => [
+        `wt-${i}`,
+        new CountedMigrations([[`old-${i}`, `new-${i}`]])
+      ])
+    )
+    const expected = referenceFrontmatter(visibility, openIds, migrations)
+    expect(Object.values(migrations).reduce((sum, map) => sum + map.reads, 0)).toBe(count * count)
+    for (const map of Object.values(migrations)) {
+      map.reads = 0
+    }
+    expect(resolveHydratedEditorFrontmatter(visibility, openIds, migrations)).toEqual(expected)
+    expect(Object.values(migrations).reduce((sum, map) => sum + map.reads, 0)).toBe(count)
+  })
+
+  it('does no migration scan without overrides and one lookup for a sparse override', () => {
+    const map = new CountedMigrations(
+      Array.from({ length: 10_000 }, (_, i) => [`old-${i}`, `new-${i}`])
+    )
+    const ids = new Set(['new-9999'])
+    expect(resolveHydratedEditorFrontmatter({ 'old-0': true }, ids, { wt: map })).toEqual({})
+    expect(map.reads).toBe(0)
+    expect(resolveHydratedEditorFrontmatter({ 'old-9999': false }, ids, { wt: map })).toEqual({
+      'new-9999': false
+    })
+    expect(map.reads).toBe(1)
+  })
+
+  it('preserves insertion order, multiple owners, direct IDs and missing targets', () => {
+    for (let sample = 0; sample < 50; sample++) {
+      const visibility = Object.fromEntries(
+        Array.from({ length: 15 }, (_, i) => [`file-${i}`, (i + sample) % 4 === 0])
+      )
+      const ids = new Set(Array.from({ length: 10 }, (_, i) => `file-${(i + sample) % 16}`))
+      const migrations = Object.fromEntries(
+        Array.from({ length: 5 }, (_, w) => [
+          `wt-${w}`,
+          new Map(
+            Array.from({ length: 8 }, (_, i) => [
+              `file-${(i + w) % 15}`,
+              `file-${(i + sample) % 17}`
+            ])
+          )
+        ])
+      )
+      expect(Object.entries(resolveHydratedEditorFrontmatter(visibility, ids, migrations))).toEqual(
+        Object.entries(referenceFrontmatter(visibility, ids, migrations))
+      )
+    }
+  })
+})

--- a/src/renderer/src/store/slices/editor/git/git-status-reconciliation.perf.test.ts
+++ b/src/renderer/src/store/slices/editor/git/git-status-reconciliation.perf.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
+import type { OpenFile } from '../types/open-file'
+import { reconcileOpenFilesForStatus } from './git-status-reconciliation'
+
+function openFile(overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id: 'file',
+    filePath: '/repo/file.ts',
+    relativePath: 'file.ts',
+    worktreeId: 'wt',
+    language: 'typescript',
+    isDirty: false,
+    mode: 'edit',
+    ...overrides
+  }
+}
+
+const conflict: NonNullable<OpenFile['conflict']> = {
+  kind: 'conflict-editable',
+  conflictKind: 'both_modified',
+  conflictStatus: 'unresolved',
+  conflictStatusSource: 'git'
+}
+
+function countedEntries(count: number): { entries: GitStatusEntry[]; reads: () => number } {
+  let reads = 0
+  const entries = Array.from({ length: count }, (_, index): GitStatusEntry => ({
+    get path() {
+      reads++
+      return `file-${index}.ts`
+    },
+    status: 'modified',
+    area: 'unstaged',
+    conflictKind: conflict.conflictKind,
+    conflictStatus: conflict.conflictStatus,
+    conflictStatusSource: conflict.conflictStatusSource
+  }))
+  return { entries, reads: () => reads }
+}
+
+describe('open conflict status indexing', () => {
+  it.each([true, false])(
+    'skips status rows without eligible open conflicts (complete=%s)',
+    (complete) => {
+      const { entries, reads } = countedEntries(10_000)
+      const files = [
+        openFile(),
+        openFile({ worktreeId: 'folder:other', conflict }),
+        openFile({ mode: 'conflict-review', conflict }),
+        openFile({ mode: 'check-details', conflict })
+      ]
+
+      for (let refresh = 0; refresh < 10; refresh++) {
+        expect(reconcileOpenFilesForStatus(files, 'wt', entries, complete)).toBe(files)
+      }
+      expect(reads()).toBe(0)
+    }
+  )
+
+  it('builds one index for all open conflicts and rebuilds it on the next snapshot', () => {
+    const { entries, reads } = countedEntries(1_000)
+    const files = Array.from({ length: 100 }, (_, index) =>
+      openFile({ id: `file-${index}`, relativePath: `file-${index}.ts`, conflict })
+    )
+    expect(reconcileOpenFilesForStatus(files, 'wt', entries, true)).toBe(files)
+    expect(reads()).toBe(1_000)
+
+    const resolved: GitStatusEntry = {
+      path: 'file-0.ts',
+      status: 'modified',
+      area: 'unstaged',
+      conflictKind: 'both_modified',
+      conflictStatus: 'resolved_locally',
+      conflictStatusSource: 'session'
+    }
+    const updated = reconcileOpenFilesForStatus(files, 'wt', [...entries, resolved], true)
+    expect(reads()).toBe(2_000)
+    expect(updated[0].conflict?.conflictStatus).toBe('resolved_locally')
+    expect(updated[1]).toBe(files[1])
+  })
+})

--- a/src/renderer/src/store/slices/editor/git/git-status-reconciliation.ts
+++ b/src/renderer/src/store/slices/editor/git/git-status-reconciliation.ts
@@ -132,7 +132,7 @@ export function reconcileOpenFilesForStatus(
   nextEntries: GitStatusEntry[],
   statusIsComplete: boolean
 ): OpenFile[] {
-  const entriesByPath = new Map(nextEntries.map((entry) => [entry.path, entry]))
+  let entriesByPath: Map<string, GitStatusEntry> | undefined
   let changed = false
 
   const nextOpenFiles = openFiles.flatMap((file) => {
@@ -144,10 +144,13 @@ export function reconcileOpenFilesForStatus(
       return [file]
     }
 
-    const entry = entriesByPath.get(file.relativePath)
     if (!file.conflict) {
       return [file]
     }
+
+    // Most refreshes have no open conflicts and need no status-path index.
+    entriesByPath ??= new Map(nextEntries.map((entry) => [entry.path, entry]))
+    const entry = entriesByPath.get(file.relativePath)
 
     // Why: a capped snapshot cannot prove that an omitted conflict was resolved.
     if (!entry && !statusIsComplete) {

--- a/src/shared/ai-vault-session-depth.test.ts
+++ b/src/shared/ai-vault-session-depth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { AiVaultListResult, AiVaultSession } from './ai-vault-types'
 import {
   aiVaultScanLimit,
@@ -82,4 +82,20 @@ describe('Agent Session History depth', () => {
     ])
     expect(truncateAiVaultListResult(loaded, 'unlimited')).toBe(loaded)
   })
+})
+
+it('normalizes scope roots and candidate cwd once per truncation pass', () => {
+  const loaded = result(
+    Array.from({ length: 1000 }, (_, i) => session(`id-${i}`, `/other/${i}`, i))
+  )
+  const scopes = Array.from({ length: 100 }, (_, i) => `/repo/${i}`)
+  const normalize = vi.spyOn(String.prototype, 'normalize')
+  let selected: AiVaultListResult
+  try {
+    selected = truncateAiVaultListResult(loaded, 10, scopes)
+    expect(normalize.mock.calls.length).toBeLessThanOrEqual(1100)
+  } finally {
+    normalize.mockRestore()
+  }
+  expect(selected.sessions).toEqual(loaded.sessions.slice(0, 10))
 })

--- a/src/shared/ai-vault-session-depth.ts
+++ b/src/shared/ai-vault-session-depth.ts
@@ -1,4 +1,7 @@
-import { isPathInsideOrEqual } from './cross-platform-path'
+import {
+  createNormalizedPathInsideOrEqualMatcher,
+  normalizeRuntimePathForComparison
+} from './cross-platform-path'
 import type { AiVaultListArgs, AiVaultListResult } from './ai-vault-types'
 
 export const DEFAULT_AI_VAULT_SCAN_LIMIT = 1000
@@ -40,10 +43,12 @@ export function truncateAiVaultListResult(
   }
   const selectedIds = new Set(result.sessions.slice(0, depth).map((session) => session.id))
   if (scopePaths.length > 0) {
+    const scopeMatchers = scopePaths.map(createNormalizedPathInsideOrEqualMatcher)
     let scopedCount = 0
     for (const session of result.sessions) {
       const cwd = session.cwd
-      if (cwd && scopePaths.some((scopePath) => isPathInsideOrEqual(scopePath, cwd))) {
+      const normalizedCwd = cwd ? normalizeRuntimePathForComparison(cwd) : null
+      if (normalizedCwd !== null && scopeMatchers.some((matches) => matches(normalizedCwd))) {
         selectedIds.add(session.id)
         if (++scopedCount >= depth) {
           break

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { AiVaultSession } from './ai-vault-types'
 import {
   agentLabel,
@@ -197,4 +197,96 @@ describe('/shared ai-vault-session-filters (lifted core)', () => {
   it('builds preview search text from conversation turns', () => {
     expect(sessionPreviewSearchText(baseSession)).toContain('scope tabs')
   })
+})
+
+it('prepares workspace path matching once for a large session filter pass', () => {
+  const sessions = Array.from({ length: 1000 }, (_, i) => ({
+    ...baseSession,
+    id: String(i),
+    cwd: `/other/${i}`
+  }))
+  const activeWorktreePaths = Array.from({ length: 100 }, (_, i) => `/repo/${i}`)
+  const normalize = vi.spyOn(String.prototype, 'normalize')
+  try {
+    expect(
+      filterAiVaultSessions(sessions, {
+        query: '',
+        agents: ['claude'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths,
+        hideEmptySessions: false
+      })
+    ).toEqual([])
+    expect(normalize.mock.calls.length).toBeLessThanOrEqual(1100)
+  } finally {
+    normalize.mockRestore()
+  }
+})
+
+it('does not read transcript previews for empty or field-only queries', () => {
+  let reads = 0
+  const sessions = Array.from({ length: 1000 }, (_, i) => ({
+    ...baseSession,
+    id: String(i),
+    get previewMessages() {
+      reads++
+      return baseSession.previewMessages
+    }
+  }))
+  for (const query of ['', 'repo:repo', 'path:app']) {
+    expect(
+      filterAiVaultSessions(sessions, {
+        query,
+        agents: ['claude'],
+        scope: 'all',
+        sort: 'updated',
+        activeWorktreePaths: [],
+        hideEmptySessions: false
+      })
+    ).toHaveLength(1000)
+  }
+  expect(reads).toBe(0)
+  expect(
+    filterAiVaultSessions(sessions, {
+      query: 'scope',
+      agents: ['claude'],
+      scope: 'all',
+      sort: 'updated',
+      activeWorktreePaths: [],
+      hideEmptySessions: false
+    })
+  ).toHaveLength(1000)
+  expect(reads).toBeGreaterThan(0)
+})
+
+it('parses each sort timestamp once with original ordering, including invalid dates', () => {
+  const sessions = Array.from({ length: 2000 }, (_, i) => ({
+    ...baseSession,
+    id: String(i),
+    updatedAt:
+      i % 131 === 0 ? 'invalid' : new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString()
+  }))
+  const parse = vi.spyOn(Date, 'parse')
+  let actual: AiVaultSession[]
+  let expected: AiVaultSession[]
+  try {
+    expected = [...sessions].sort(
+      (a, b) => Date.parse(b.updatedAt ?? b.modifiedAt) - Date.parse(a.updatedAt ?? a.modifiedAt)
+    )
+    expect(parse.mock.calls.length).toBeGreaterThan(10_000)
+    parse.mockClear()
+    actual = filterAiVaultSessions(sessions, {
+      query: '',
+      agents: ['claude'],
+      scope: 'all',
+      sort: 'updated',
+      activeWorktreePaths: [],
+      hideEmptySessions: false
+    })
+    expect(parse).toHaveBeenCalledTimes(2000)
+  } finally {
+    parse.mockRestore()
+  }
+  actual.forEach((session, i) => expect(session).toBe(expected[i]))
 })

--- a/src/shared/ai-vault-session-filters.ts
+++ b/src/shared/ai-vault-session-filters.ts
@@ -3,7 +3,7 @@
 // Metro only watches mobile/ + repo-root src/shared, never src/renderer.
 // INVARIANT: /shared is a leaf — this module must NOT import from src/renderer.
 import {
-  isPathInsideOrEqual,
+  createNormalizedPathInsideOrEqualMatcher,
   normalizeRuntimePathForComparison,
   normalizeRuntimePathSeparators
 } from './cross-platform-path'
@@ -79,45 +79,50 @@ export function filterAiVaultSessions(
 
   const agentSet = new Set(filters.agents)
   const parsedQuery = parseVaultQuery(filters.query)
+  const workspaceMatchers =
+    filters.scope === 'workspace'
+      ? filters.activeWorktreePaths.map(createAiVaultWorkspaceMatcher)
+      : []
 
-  return sessions
-    .filter((session) => {
-      if (!agentSet.has(session.agent)) {
+  const filtered = sessions.filter((session) => {
+    if (!agentSet.has(session.agent)) {
+      return false
+    }
+    // Hide plain empty sessions, but keep sessions with resumable content
+    // (some parsers only learn turns from previews, e.g. Grok) and zero-turn
+    // sessions that still carry recoverable content (queued prompts /
+    // subagent transcripts) so a lost conversation is surfaced distinctly.
+    if (
+      filters.hideEmptySessions &&
+      !isAiVaultSessionResumableContent(session) &&
+      !isAiVaultSessionRecoverableEmpty(session)
+    ) {
+      return false
+    }
+    if (filters.scope === 'workspace') {
+      const cwd = session.cwd
+      const normalizedCwd = cwd ? normalizeRuntimePathForComparison(cwd) : null
+      if (normalizedCwd === null || !workspaceMatchers.some((matches) => matches(normalizedCwd))) {
         return false
       }
-      // Hide plain empty sessions, but keep sessions with resumable content
-      // (some parsers only learn turns from previews, e.g. Grok) and zero-turn
-      // sessions that still carry recoverable content (queued prompts /
-      // subagent transcripts) so a lost conversation is surfaced distinctly.
-      if (
-        filters.hideEmptySessions &&
-        !isAiVaultSessionResumableContent(session) &&
-        !isAiVaultSessionRecoverableEmpty(session)
-      ) {
+    }
+    if (filters.scope === 'project') {
+      if (!filters.activeProjectKey) {
         return false
       }
-      if (filters.scope === 'workspace') {
-        const cwd = session.cwd
-        if (
-          !cwd ||
-          !filters.activeWorktreePaths.some((pathValue) =>
-            isAiVaultSessionInWorkspacePath(pathValue, cwd)
-          )
-        ) {
-          return false
-        }
+      if (filters.sessionProjectById?.get(session.id)?.key !== filters.activeProjectKey) {
+        return false
       }
-      if (filters.scope === 'project') {
-        if (!filters.activeProjectKey) {
-          return false
-        }
-        if (filters.sessionProjectById?.get(session.id)?.key !== filters.activeProjectKey) {
-          return false
-        }
-      }
-      return matchesQuery(session, parsedQuery, filters)
-    })
-    .sort((left, right) => compareSessions(left, right, filters.sort))
+    }
+    return matchesQuery(session, parsedQuery, filters)
+  })
+  if (filtered.length < 2) {
+    return filtered
+  }
+  return filtered
+    .map((session) => ({ session, time: sessionSortTime(session, filters.sort) }))
+    .sort((left, right) => right.time - left.time)
+    .map(({ session }) => session)
 }
 
 export function groupAiVaultSessions(
@@ -206,48 +211,48 @@ function matchesQuery(
   parsed: ParsedQuery,
   filters: Pick<AiVaultSessionFilterState, 'sessionProjectById' | 'projectLabelByKey'>
 ): boolean {
-  const searchable = [
-    session.title,
-    session.sessionId,
-    session.agent,
-    session.branch,
-    session.model,
-    session.cwd,
-    session.filePath,
-    sessionPreviewSearchText(session)
-  ]
-    .filter(Boolean)
-    .join(' ')
-    .toLowerCase()
-
-  if (parsed.terms.some((term) => !searchable.includes(term))) {
-    return false
+  if (parsed.terms.length > 0) {
+    const searchable = [
+      session.title,
+      session.sessionId,
+      session.agent,
+      session.branch,
+      session.model,
+      session.cwd,
+      session.filePath,
+      sessionPreviewSearchText(session)
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+    if (parsed.terms.some((term) => !searchable.includes(term))) {
+      return false
+    }
   }
-
-  const sessionProject = filters.sessionProjectById?.get(session.id)
-  const repoLabel = (
-    sessionProject?.kind === 'repo'
-      ? (filters.projectLabelByKey?.get(sessionProject.key) ?? sessionProject.label)
-      : folderLabel(session.cwd)
-  ).toLowerCase()
-  if (parsed.repoTerms.some((term) => !repoLabel.includes(term))) {
-    return false
+  if (parsed.repoTerms.length > 0) {
+    const sessionProject = filters.sessionProjectById?.get(session.id)
+    const repoLabel = (
+      sessionProject?.kind === 'repo'
+        ? (filters.projectLabelByKey?.get(sessionProject.key) ?? sessionProject.label)
+        : folderLabel(session.cwd)
+    ).toLowerCase()
+    if (parsed.repoTerms.some((term) => !repoLabel.includes(term))) {
+      return false
+    }
   }
-
-  const pathSearch = `${session.cwd ?? ''} ${session.filePath}`.toLowerCase()
-  if (parsed.pathTerms.some((term) => !pathSearch.includes(term))) {
-    return false
+  if (parsed.pathTerms.length > 0) {
+    const pathSearch = `${session.cwd ?? ''} ${session.filePath}`.toLowerCase()
+    if (parsed.pathTerms.some((term) => !pathSearch.includes(term))) {
+      return false
+    }
   }
 
   return true
 }
 
-function compareSessions(left: AiVaultSession, right: AiVaultSession, sort: AiVaultSort): number {
-  const leftValue = sort === 'created' ? left.createdAt : left.updatedAt
-  const rightValue = sort === 'created' ? right.createdAt : right.updatedAt
-  const leftTime = Date.parse(leftValue ?? left.modifiedAt)
-  const rightTime = Date.parse(rightValue ?? right.modifiedAt)
-  return rightTime - leftTime
+function sessionSortTime(session: AiVaultSession, sort: AiVaultSort): number {
+  const value = sort === 'created' ? session.createdAt : session.updatedAt
+  return Date.parse(value ?? session.modifiedAt)
 }
 
 function getGroupIdentity(
@@ -276,19 +281,15 @@ function getGroupIdentity(
   return { key: folderGroupKey(session.cwd), label: folderLabel(session.cwd) }
 }
 
-function isAiVaultSessionInWorkspacePath(workspacePath: string, sessionCwd: string): boolean {
-  if (isPathInsideOrEqual(workspacePath, sessionCwd)) {
-    return true
-  }
-
+function createAiVaultWorkspaceMatcher(workspacePath: string): (normalizedCwd: string) => boolean {
+  const matches = createNormalizedPathInsideOrEqualMatcher(workspacePath)
   const workspaceWslPath = parseWslUncPath(workspacePath)
   if (!workspaceWslPath) {
-    return false
+    return matches
   }
-
-  // WSL agent transcripts record Linux cwd values even when Orca stores the
-  // active worktree as a Windows UNC path.
-  return isPathInsideOrEqual(workspaceWslPath.linuxPath, sessionCwd)
+  // WSL transcripts record Linux cwd even when the workspace uses a UNC path.
+  const matchesLinux = createNormalizedPathInsideOrEqualMatcher(workspaceWslPath.linuxPath)
+  return (cwd) => matches(cwd) || matchesLinux(cwd)
 }
 
 function tokenizeQuery(query: string): string[] {

--- a/src/shared/automation-run-retention.test.ts
+++ b/src/shared/automation-run-retention.test.ts
@@ -171,3 +171,25 @@ describe('nextAutomationRunNumber', () => {
     expect(runs.some((r) => r.runNumber === next)).toBe(false)
   })
 })
+
+it('does not inspect ordering timestamps when an automation is within its retention cap', () => {
+  let reads = 0
+  const runs = Array.from({ length: 100 }, (_, index) =>
+    run({
+      id: `run-${index}`,
+      automationId: 'a'
+    })
+  )
+  for (const [index, entry] of runs.entries()) {
+    Object.defineProperty(entry, 'createdAt', {
+      get() {
+        reads += 1
+        return (index * 37) % 100
+      }
+    })
+  }
+  const kept = pruneAutomationRuns(runs)
+  expect(kept).toHaveLength(100)
+  expect(kept.every((entry, index) => entry === runs[index])).toBe(true)
+  expect(reads).toBe(0)
+})

--- a/src/shared/automation-run-retention.ts
+++ b/src/shared/automation-run-retention.ts
@@ -15,7 +15,9 @@ export function pruneAutomationRuns(
   for (const automationRuns of Map.groupBy(finalRuns, (run) => run.automationId).values()) {
     // Why: `createdAt` is the append time; `scheduledFor` breaks ties so runs
     // minted in the same millisecond drop in a stable, reproducible order.
-    automationRuns.sort((a, b) => b.createdAt - a.createdAt || b.scheduledFor - a.scheduledFor)
+    if (automationRuns.length > maxPerAutomation) {
+      automationRuns.sort((a, b) => b.createdAt - a.createdAt || b.scheduledFor - a.scheduledFor)
+    }
     // Why: clamp — a negative `slice` end drops from the tail instead of keeping nothing.
     for (const run of automationRuns.slice(0, Math.max(0, maxPerAutomation))) {
       kept.add(run.id)

--- a/src/shared/browser-network-tunnel-stream-framing.test.ts
+++ b/src/shared/browser-network-tunnel-stream-framing.test.ts
@@ -172,3 +172,24 @@ describe('browser network tunnel stream framing', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 })
+
+it('rejects saturated writer frames before encoding and copying their payloads', () => {
+  const writer = new BrowserNetworkTunnelStreamFrameWriter(
+    () => {},
+    () => {},
+    { maxQueuedFrames: 1 }
+  )
+  const frame = new Uint8Array(65536)
+  expect(writer.send(frame)).toBe(true)
+  const set = vi.spyOn(Uint8Array.prototype, 'set')
+  try {
+    for (let index = 0; index < 1000; index += 1) {
+      expect(writer.send(frame)).toBe(false)
+    }
+    expect(set.mock.calls.length).toBe(0)
+    expect(writer.queuedBytes).toBe(65540)
+  } finally {
+    set.mockRestore()
+    writer.close()
+  }
+})

--- a/src/shared/browser-network-tunnel-stream-framing.ts
+++ b/src/shared/browser-network-tunnel-stream-framing.ts
@@ -134,16 +134,16 @@ export class BrowserNetworkTunnelStreamFrameWriter {
     if (this.closed) {
       return false
     }
+    if (
+      this.retainedBytes + LENGTH_BYTES + frame.byteLength > this.maxQueuedBytes ||
+      this.frames.length + (this.writing ? 1 : 0) >= this.maxQueuedFrames
+    ) {
+      return false
+    }
     let encoded: Uint8Array
     try {
       encoded = encodeBrowserNetworkTunnelStreamFrame(frame)
     } catch {
-      return false
-    }
-    if (
-      this.retainedBytes + encoded.byteLength > this.maxQueuedBytes ||
-      this.frames.length + (this.writing ? 1 : 0) >= this.maxQueuedFrames
-    ) {
       return false
     }
     this.frames.push(encoded)

--- a/src/shared/ephemeral-vm-runtime-feature-sorting.test.ts
+++ b/src/shared/ephemeral-vm-runtime-feature-sorting.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from 'vitest'
+import { featureIdentity, sortRuntimeFeatures } from './ephemeral-vm-runtime-feature-store'
+import { mergeRuntimeFeatures } from './ephemeral-vm-runtime-rollback-projection'
+
+it('computes each runtime identity once per sort with identical stable ordering', () => {
+  let reads = 0
+  const features = Array.from({ length: 2000 }, (_, i) => ({
+    get id() {
+      reads++
+      return `vm-${(i * 173) % 1999}`
+    },
+    recipeId: i % 2 ? 'Éclair' : 'eclair',
+    createdAt: i % 11
+  }))
+  const expected = [...features].sort((a, b) =>
+    featureIdentity(a).localeCompare(featureIdentity(b))
+  )
+  expect(reads).toBeGreaterThan(20_000)
+  reads = 0
+  const sorted = sortRuntimeFeatures(features)
+  expect(reads).toBe(2000)
+  sorted.forEach((entry, index) => expect(entry).toBe(expected[index]))
+  const required = { ...features[0], replacement: true }
+  const merged = new Map(features.map((entry) => [featureIdentity(entry), entry]))
+  merged.set(featureIdentity(required), required)
+  const expectedMerged = [...merged.values()].sort((a, b) =>
+    featureIdentity(a).localeCompare(featureIdentity(b))
+  )
+  reads = 0
+  const actual = mergeRuntimeFeatures(features, [required])
+  expect(reads).toBeLessThanOrEqual(4000)
+  actual.forEach((entry, index) => expect(entry).toBe(expectedMerged[index]))
+})

--- a/src/shared/ephemeral-vm-runtime-feature-store.ts
+++ b/src/shared/ephemeral-vm-runtime-feature-store.ts
@@ -143,7 +143,7 @@ function mergeFeatureEntries(
   for (const entry of required) {
     merged.set(featureIdentity(entry), entry)
   }
-  return sortFeatures([...merged.values()])
+  return sortRuntimeFeatures([...merged.values()])
 }
 
 export function featureEntryFromRuntime(
@@ -164,11 +164,26 @@ export function featureEntryFromRuntime(
   }
 }
 
-export function restoreRuntimeFeatures(
-  runtime: EphemeralVmRuntimeRecord,
+export function restoreRuntimeFeatureList(
+  runtimes: readonly EphemeralVmRuntimeRecord[],
   features: readonly EphemeralVmRuntimeFeatureEntry[]
+): EphemeralVmRuntimeRecord[] {
+  const byIdentity = new Map<string, EphemeralVmRuntimeFeatureEntry>()
+  for (const feature of features) {
+    const identity = featureIdentity(feature)
+    if (!byIdentity.has(identity)) {
+      byIdentity.set(identity, feature)
+    }
+  }
+  return runtimes.map((runtime) =>
+    restoreRuntimeFeatures(runtime, byIdentity.get(featureIdentity(runtime)))
+  )
+}
+
+function restoreRuntimeFeatures(
+  runtime: EphemeralVmRuntimeRecord,
+  feature: EphemeralVmRuntimeFeatureEntry | undefined
 ): EphemeralVmRuntimeRecord {
-  const feature = features.find((entry) => featureIdentity(entry) === featureIdentity(runtime))
   if (!feature) {
     return runtime
   }
@@ -225,15 +240,16 @@ function parseFeatureRecords(records: unknown[]): EphemeralVmRuntimeFeatureStore
       features.push(parsed.data)
     }
   }
-  return { writable: true, features: sortFeatures(features), retainedRecords }
+  return { writable: true, features: sortRuntimeFeatures(features), retainedRecords }
 }
 
-function sortFeatures(
-  features: readonly EphemeralVmRuntimeFeatureEntry[]
-): EphemeralVmRuntimeFeatureEntry[] {
-  return [...features].sort((left, right) =>
-    featureIdentity(left).localeCompare(featureIdentity(right))
-  )
+export function sortRuntimeFeatures<T extends { id: string; recipeId: string; createdAt: number }>(
+  features: readonly T[]
+): T[] {
+  return features
+    .map((feature) => ({ feature, identity: featureIdentity(feature) }))
+    .sort((left, right) => left.identity.localeCompare(right.identity))
+    .map(({ feature }) => feature)
 }
 
 function runtimeFeatureStoreValue(
@@ -242,6 +258,6 @@ function runtimeFeatureStoreValue(
 ): { version: 1; records: unknown[] } {
   return {
     version: 1,
-    records: [...sortFeatures(features), ...snapshot.retainedRecords]
+    records: [...sortRuntimeFeatures(features), ...snapshot.retainedRecords]
   }
 }

--- a/src/shared/ephemeral-vm-runtime-rollback-projection.ts
+++ b/src/shared/ephemeral-vm-runtime-rollback-projection.ts
@@ -1,4 +1,4 @@
-import { featureIdentity } from './ephemeral-vm-runtime-feature-store'
+import { featureIdentity, sortRuntimeFeatures } from './ephemeral-vm-runtime-feature-store'
 import {
   RollbackEphemeralVmRuntimeRecordSchema,
   type EphemeralVmRuntimeRecord
@@ -32,9 +32,7 @@ export function mergeRuntimeFeatures<T extends { id: string; recipeId: string; c
   for (const entry of required) {
     merged.set(featureIdentity(entry), entry)
   }
-  return [...merged.values()].sort((left, right) =>
-    featureIdentity(left).localeCompare(featureIdentity(right))
-  )
+  return sortRuntimeFeatures([...merged.values()])
 }
 
 export function runtimeFeatureListsEqual<

--- a/src/shared/ephemeral-vm-runtime-store-rollback.test.ts
+++ b/src/shared/ephemeral-vm-runtime-store-rollback.test.ts
@@ -13,6 +13,8 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   getEphemeralVmRuntimeFeatureStorePath,
+  featureIdentity,
+  restoreRuntimeFeatureList,
   MAX_EPHEMERAL_VM_RUNTIME_FEATURE_STORE_FILE_BYTES
 } from './ephemeral-vm-runtime-feature-store'
 import {
@@ -284,5 +286,39 @@ describe('ephemeral VM runtime store rollback projection', () => {
       'provisioned-runtime',
       'ordinary-runtime'
     ])
+  })
+})
+
+describe('runtime feature restoration scaling', () => {
+  it('indexes feature identities once and preserves unmatched runtime references', () => {
+    let reads = 0
+    const runtimes = Array.from({ length: 1000 }, (_, i) => runtimeRecord({ id: `runtime-${i}` }))
+    const features = runtimes.map((runtime) => ({
+      get id() {
+        reads++
+        return runtime.id
+      },
+      recipeId: runtime.recipeId,
+      createdAt: runtime.createdAt,
+      recipeCheckoutMode: 'provisioned-root' as const
+    }))
+    for (const runtime of runtimes) {
+      expect(
+        features.find((entry) => featureIdentity(entry) === featureIdentity(runtime))
+      ).toBeDefined()
+    }
+    expect(reads).toBe(500_500)
+    reads = 0
+    const restored = restoreRuntimeFeatureList(runtimes, features)
+    expect(reads).toBe(1000)
+    expect(restored.map((runtime) => runtime.id)).toEqual(runtimes.map((runtime) => runtime.id))
+    expect(restored.every((runtime) => runtime.recipe?.checkoutMode === 'provisioned-root')).toBe(
+      true
+    )
+    expect(restoreRuntimeFeatureList([runtimes[0]], [])[0]).toBe(runtimes[0])
+    const first = { ...features[0], recipeCheckoutMode: 'orca-worktree' as const }
+    expect(
+      restoreRuntimeFeatureList([runtimes[0]], [first, features[0]])[0].recipe?.checkoutMode
+    ).toBe('orca-worktree')
   })
 })

--- a/src/shared/ephemeral-vm-runtime-store.ts
+++ b/src/shared/ephemeral-vm-runtime-store.ts
@@ -8,7 +8,7 @@ import {
   featureEntryFromRuntime,
   featureIdentity,
   readEphemeralVmRuntimeFeatureStore,
-  restoreRuntimeFeatures,
+  restoreRuntimeFeatureList,
   runtimeFeaturesEqual,
   writeEphemeralVmRuntimeFeatureStore,
   type EphemeralVmRuntimeFeatureStoreSnapshot
@@ -225,9 +225,9 @@ function readEphemeralVmRuntimeStore(userDataPath: string): LoadedEphemeralVmRun
     const features = readEphemeralVmRuntimeFeatureStore(userDataPath)
     const store: EphemeralVmRuntimeStore = {
       version: 1,
-      runtimes: parsed.runtimes
-        .map((entry) => restoreRuntimeFeatures(entry, features.features))
-        .sort(compareRuntimeRecords)
+      runtimes: restoreRuntimeFeatureList(parsed.runtimes, features.features).sort(
+        compareRuntimeRecords
+      )
     }
     if (features.writable && !RollbackEphemeralVmRuntimeStoreSchema.safeParse(persisted).success) {
       try {

--- a/src/shared/foreground-process-selection.test.ts
+++ b/src/shared/foreground-process-selection.test.ts
@@ -49,3 +49,19 @@ describe('selectForegroundProcessCandidate', () => {
     })
   })
 })
+
+it('memoizes shared ancestry while validating a long agent/helper lineage', () => {
+  let reads = 0
+  const candidates = Array.from({ length: 1000 }, (_, index) => ({
+    pid: index + 1,
+    get ppid() {
+      reads += 1
+      return index
+    },
+    depth: index,
+    stat: 'S+',
+    command: index % 2 === 0 ? 'omp' : 'codex'
+  }))
+  expect(selectForegroundProcessCandidate(candidates)?.candidate.pid).toBe(1)
+  expect(reads).toBeLessThanOrEqual(1000)
+})

--- a/src/shared/foreground-process-selection.ts
+++ b/src/shared/foreground-process-selection.ts
@@ -40,10 +40,11 @@ export function selectForegroundProcessCandidate(
     const outer = [...recognized].sort(
       (left, right) => left.candidate.depth - right.candidate.depth
     )[0]
+    const ancestry = new Map<number, boolean>()
     if (
       !outer ||
       !recognized.every((entry) =>
-        isAncestorOrSelf(outer.candidate, entry.candidate, candidatesByPid)
+        isAncestorOrSelf(outer.candidate, entry.candidate, candidatesByPid, ancestry)
       )
     ) {
       // Distinct sibling agents do not provide a trustworthy identity.
@@ -66,15 +67,32 @@ function foregroundCandidateScore(candidate: ForegroundProcessCandidate): number
 function isAncestorOrSelf(
   ancestor: ForegroundProcessCandidate,
   descendant: ForegroundProcessCandidate,
-  candidatesByPid: ReadonlyMap<number, ForegroundProcessCandidate>
+  candidatesByPid: ReadonlyMap<number, ForegroundProcessCandidate>,
+  ancestry: Map<number, boolean>
 ): boolean {
   let currentPid = descendant.pid
+  const visited = new Set<number>()
+  let matches = true
   while (currentPid !== ancestor.pid) {
+    const cached = ancestry.get(currentPid)
+    if (cached !== undefined) {
+      matches = cached
+      break
+    }
+    if (visited.has(currentPid)) {
+      matches = false
+      break
+    }
+    visited.add(currentPid)
     const current = candidatesByPid.get(currentPid)
     if (!current) {
-      return false
+      matches = false
+      break
     }
     currentPid = current.ppid
   }
-  return true
+  for (const pid of visited) {
+    ancestry.set(pid, matches)
+  }
+  return matches
 }

--- a/src/shared/git-history-log-parser.ts
+++ b/src/shared/git-history-log-parser.ts
@@ -112,7 +112,18 @@ export function parseGitHistoryLog(stdout: string): GitHistoryItem[] {
       continue
     }
 
-    const lines = record.split('\n')
+    const lines: string[] = []
+    let messageStart = 0
+    for (let field = 0; field < 8; field += 1) {
+      const newline = record.indexOf('\n', messageStart)
+      if (newline === -1) {
+        lines.push(record.slice(messageStart))
+        messageStart = record.length
+        break
+      }
+      lines.push(record.slice(messageStart, newline))
+      messageStart = newline + 1
+    }
     const hash = lines[0]?.trim() ?? ''
     if (!/^[0-9a-fA-F]{40,64}$/.test(hash)) {
       continue
@@ -125,7 +136,7 @@ export function parseGitHistoryLog(stdout: string): GitHistoryItem[] {
     const decorateField = lines[6] ?? ''
     const isLegacyGit = decorateField === UNEXPANDED_DECORATE_PLACEHOLDER
     const decorations = isLegacyGit ? (lines[7] ?? '') : decorateField
-    const message = lines.slice(8).join('\n').replace(/\n$/, '')
+    const message = record.slice(messageStart).replace(/\n$/, '')
 
     items.push({
       id: hash,

--- a/src/shared/git-history-message-allocation.test.ts
+++ b/src/shared/git-history-message-allocation.test.ts
@@ -1,0 +1,45 @@
+import { expect, it, vi } from 'vitest'
+import { parseGitHistoryLog } from './git-history-log-parser'
+
+it('keeps a multiline commit body intact without materializing every message line', () => {
+  const message = `subject\n\n${'body line\n'.repeat(10000)}`
+  const record = [
+    'a'.repeat(40),
+    'Author',
+    'email',
+    '1700000000',
+    '1700000000',
+    '',
+    '',
+    '',
+    message
+  ].join('\n')
+  const original = String.prototype.split
+  let allocatedFields = 0
+  const spy = vi.spyOn(String.prototype, 'split').mockImplementation(function (
+    this: string,
+    separator: string | RegExp | { [Symbol.split](value: string, limit?: number): string[] },
+    limit?: number
+  ) {
+    const result = Reflect.apply(original, this, [separator, limit]) as string[]
+    if (separator === '\n' && String(this).includes('body line')) {
+      allocatedFields += result.length
+    }
+    return result
+  })
+  let result: ReturnType<typeof parseGitHistoryLog>
+  try {
+    result = parseGitHistoryLog(`${record}\n\0`)
+  } finally {
+    spy.mockRestore()
+  }
+  expect(result![0].message).toBe(message)
+  expect(result![0].subject).toBe('subject')
+  expect(allocatedFields).toBe(0)
+})
+
+it('preserves incomplete header and empty body behavior', () => {
+  for (const suffix of ['', '\nAuthor', '\nAuthor\nemail\n0\n0\n\n\n']) {
+    expect(parseGitHistoryLog(`${'a'.repeat(40)}${suffix}\0`)[0].message).toBe('')
+  }
+})

--- a/src/shared/github/project-group-sort.ts
+++ b/src/shared/github/project-group-sort.ts
@@ -52,10 +52,28 @@ function hasNonEmptyFieldValue(value: ProjectFieldValue | undefined): boolean {
 // Array.sort's behavior implementation-defined and skips later tie-breaks.
 const UNKNOWN_INDEX_SENTINEL = Number.MAX_SAFE_INTEGER
 
+function createFieldOrderIndex(field: GitHubProjectField): ReadonlyMap<string, number> {
+  const entries =
+    field.kind === 'iteration'
+      ? (field.iterations ?? [])
+      : field.kind === 'single-select'
+        ? (field.options ?? [])
+        : []
+  const indices = new Map<string, number>()
+  entries.forEach((entry, index) => {
+    const id = entry.id
+    if (!indices.has(id)) {
+      indices.set(id, index)
+    }
+  })
+  return indices
+}
+
 // Preserve the mobile mirror's fallback for partial ordering metadata.
 function getFieldValueForGrouping(
   row: GitHubProjectRow,
-  field: GitHubProjectField
+  field: GitHubProjectField,
+  orderIndex: ReadonlyMap<string, number>
 ): { key: string; label: string; orderHint: number; iteration: ProjectGroup['iteration'] } {
   const value = row.fieldValuesByFieldId[field.id]
   if (!hasNonEmptyFieldValue(value)) {
@@ -68,8 +86,8 @@ function getFieldValueForGrouping(
   }
   if (field.kind === 'iteration' && value.kind === 'iteration') {
     const iterations = field.iterations ?? []
-    const idx = iterations.findIndex((iteration) => iteration.id === value.iterationId)
-    const meta = iterations.find((iteration) => iteration.id === value.iterationId)
+    const idx = orderIndex.get(value.iterationId) ?? -1
+    const meta = iterations[idx]
     return {
       key: value.iterationId,
       label: value.title || meta?.title || 'Iteration',
@@ -80,7 +98,7 @@ function getFieldValueForGrouping(
     }
   }
   if (field.kind === 'single-select' && value.kind === 'single-select') {
-    const idx = (field.options ?? []).findIndex((option) => option.id === value.optionId)
+    const idx = orderIndex.get(value.optionId) ?? -1
     return {
       key: value.optionId,
       label: value.name,
@@ -123,6 +141,7 @@ export function groupRows(
   if (!groupField) {
     return [{ key: 'all', label: '', iteration: null, rows: rowsInOrder }]
   }
+  const groupOrderIndex = createFieldOrderIndex(groupField)
   const buckets = new Map<
     string,
     {
@@ -133,7 +152,11 @@ export function groupRows(
     }
   >()
   for (const row of rowsInOrder) {
-    const { key, label, orderHint, iteration } = getFieldValueForGrouping(row, groupField)
+    const { key, label, orderHint, iteration } = getFieldValueForGrouping(
+      row,
+      groupField,
+      groupOrderIndex
+    )
     let bucket = buckets.get(key)
     if (!bucket) {
       bucket = { label, orderHint, iteration, rows: [] }
@@ -163,7 +186,12 @@ export function groupRows(
   }))
 }
 
-function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProjectSort): number {
+function compareSort(
+  a: GitHubProjectRow,
+  b: GitHubProjectRow,
+  sort: GitHubProjectSort,
+  orderIndex: ReadonlyMap<string, number>
+): number {
   const field = sort.field
   const aValue = a.fieldValuesByFieldId[field.id]
   const bValue = b.fieldValuesByFieldId[field.id]
@@ -180,9 +208,8 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
     aValue.kind === 'single-select' &&
     bValue.kind === 'single-select'
   ) {
-    const options = field.options ?? []
-    const aIdx = options.findIndex((option) => option.id === aValue.optionId)
-    const bIdx = options.findIndex((option) => option.id === bValue.optionId)
+    const aIdx = orderIndex.get(aValue.optionId) ?? -1
+    const bIdx = orderIndex.get(bValue.optionId) ?? -1
     cmp =
       (aIdx === -1 ? UNKNOWN_INDEX_SENTINEL : aIdx) - (bIdx === -1 ? UNKNOWN_INDEX_SENTINEL : bIdx)
   } else if (
@@ -190,9 +217,8 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
     aValue.kind === 'iteration' &&
     bValue.kind === 'iteration'
   ) {
-    const iterations = field.iterations ?? []
-    const aIdx = iterations.findIndex((iteration) => iteration.id === aValue.iterationId)
-    const bIdx = iterations.findIndex((iteration) => iteration.id === bValue.iterationId)
+    const aIdx = orderIndex.get(aValue.iterationId) ?? -1
+    const bIdx = orderIndex.get(bValue.iterationId) ?? -1
     cmp =
       (aIdx === -1 ? UNKNOWN_INDEX_SENTINEL : aIdx) - (bIdx === -1 ? UNKNOWN_INDEX_SENTINEL : bIdx)
   } else if (aValue.kind === 'number' && bValue.kind === 'number') {
@@ -214,11 +240,14 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
 }
 
 export function sortRows(table: GitHubProjectTable, rows: GitHubProjectRow[]): GitHubProjectRow[] {
-  const sorts = table.selectedView.sortByFields
+  const sorts = table.selectedView.sortByFields.map((sort) => ({
+    sort,
+    orderIndex: createFieldOrderIndex(sort.field)
+  }))
   const out = [...rows]
   out.sort((a, b) => {
-    for (const sort of sorts) {
-      const cmp = compareSort(a, b, sort)
+    for (const { sort, orderIndex } of sorts) {
+      const cmp = compareSort(a, b, sort, orderIndex)
       if (cmp !== 0) {
         return cmp
       }

--- a/src/shared/growing-byte-buffer.test.ts
+++ b/src/shared/growing-byte-buffer.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it } from 'vitest'
 import { GrowingByteBuffer } from './growing-byte-buffer'
 
 describe('GrowingByteBuffer', () => {
+  it('transfers binary bytes without changing them on clear or reuse', () => {
+    const buffer = new GrowingByteBuffer()
+    const bytes = Buffer.from([0, 255, 128, 10, 0])
+    buffer.append(bytes.subarray(0, 2))
+    buffer.append(bytes.subarray(2))
+    const taken = buffer.takeBuffer()
+    expect(taken).toEqual(bytes)
+    expect(buffer.byteLength).toBe(0)
+    expect(buffer.takeBuffer()).toEqual(Buffer.alloc(0))
+    buffer.append(Buffer.alloc(1024, 7))
+    buffer.clear()
+    expect(taken).toEqual(bytes)
+  })
+
   it('retains 100,000 one-byte fragments in one growable allocation', () => {
     const buffer = new GrowingByteBuffer()
     const expected = Buffer.alloc(100_000)

--- a/src/shared/growing-byte-buffer.ts
+++ b/src/shared/growing-byte-buffer.ts
@@ -93,6 +93,12 @@ export class GrowingByteBuffer {
     return value
   }
 
+  takeBuffer(): Buffer {
+    const value = this.storage.subarray(0, this.length)
+    this.clear()
+    return value
+  }
+
   clear(): void {
     this.storage = Buffer.alloc(0)
     this.length = 0

--- a/src/shared/host-balanced-listing-page.ts
+++ b/src/shared/host-balanced-listing-page.ts
@@ -28,22 +28,25 @@ export function selectHostBalancedPage<TRow>(
     }
   })
   const buckets = [...indicesByHost.values()]
-  const cursors = buckets.map(() => 0)
   const chosen: number[] = []
-  while (chosen.length < limit) {
-    let advanced = false
-    for (let bucket = 0; bucket < buckets.length && chosen.length < limit; bucket += 1) {
-      const cursor = cursors[bucket] ?? 0
-      const index = buckets[bucket]?.[cursor]
-      if (index !== undefined) {
-        chosen.push(index)
-        cursors[bucket] = cursor + 1
-        advanced = true
+  let activeCount = buckets.length
+  let round = 0
+  while (chosen.length < limit && activeCount > 0) {
+    let nextActiveCount = 0
+    for (
+      let bucketIndex = 0;
+      bucketIndex < activeCount && chosen.length < limit;
+      bucketIndex += 1
+    ) {
+      const bucket = buckets[bucketIndex]
+      chosen.push(bucket[round])
+      if (bucket.length > round + 1) {
+        buckets[nextActiveCount] = bucket
+        nextActiveCount += 1
       }
     }
-    if (!advanced) {
-      break
-    }
+    activeCount = nextActiveCount
+    round += 1
   }
   return chosen.sort((left, right) => left - right).map((index) => rows[index] as TRow)
 }

--- a/src/shared/host-balanced-listing-scaling.test.ts
+++ b/src/shared/host-balanced-listing-scaling.test.ts
@@ -1,0 +1,38 @@
+import { expect, it, vi } from 'vitest'
+import { selectHostBalancedPage } from './host-balanced-listing-page'
+
+it('retires exhausted host buckets from subsequent listing rounds', () => {
+  const rows = [
+    ...Array.from({ length: 1000 }, (_, index) => ({ host: `host-${index}`, id: index })),
+    ...Array.from({ length: 2000 }, (_, index) => ({ host: 'large-host', id: 1000 + index }))
+  ]
+  const original = Map.prototype.values
+  let reads = 0
+  const spy = vi
+    .spyOn(Map.prototype, 'values')
+    .mockImplementation(function (this: Map<string, number[]>) {
+      const iterator = original.call(this)
+      if (!this.has('large-host')) {
+        return iterator
+      }
+      return iterator.map(
+        (bucket: number[]) =>
+          new Proxy(bucket, {
+            get(target, key, receiver) {
+              if (typeof key === 'string' && /^\d+$/.test(key)) {
+                reads += 1
+              }
+              return Reflect.get(target, key, receiver)
+            }
+          })
+      )
+    })
+  let result: typeof rows
+  try {
+    result = selectHostBalancedPage(rows, 2000, (row) => row.host)
+  } finally {
+    spy.mockRestore()
+  }
+  expect(result!.map((row) => row.id)).toEqual(Array.from({ length: 2000 }, (_, index) => index))
+  expect(reads).toBeLessThanOrEqual(2000)
+})

--- a/src/shared/native-chat-ask-scaling.test.ts
+++ b/src/shared/native-chat-ask-scaling.test.ts
@@ -1,0 +1,33 @@
+import { expect, it, vi } from 'vitest'
+import { extractPendingAsk } from './native-chat-ask'
+import type { NativeChatMessage } from './native-chat-types'
+
+it('replays large call/result batches without shifting outstanding questions', () => {
+  const blocks: NativeChatMessage['blocks'] = Array.from({ length: 2000 }, () => ({
+    type: 'tool-call',
+    name: 'AskUserQuestion',
+    input: { questions: [{ question: 'Continue?' }] }
+  }))
+  blocks.push(
+    ...Array.from({ length: 2000 }, () => ({ type: 'tool-result' as const, output: 'yes' }))
+  )
+  const original = Array.prototype.shift
+  let shifted = 0
+  const spy = vi.spyOn(Array.prototype, 'shift').mockImplementation(function (this: unknown[]) {
+    const first = this[0]
+    if (first && typeof first === 'object' && 'questions' in first) {
+      shifted += this.length - 1
+    }
+    return original.call(this)
+  })
+  let result: ReturnType<typeof extractPendingAsk>
+  try {
+    result = extractPendingAsk([
+      { id: 'm', role: 'assistant', timestamp: 1, source: 'transcript', blocks }
+    ])
+  } finally {
+    spy.mockRestore()
+  }
+  expect(result!).toBeNull()
+  expect(shifted).toBe(0)
+})

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -102,6 +102,7 @@ export function parseAskFromStatus(
 export function extractPendingAsk(messages: readonly NativeChatMessage[]): AskPrompt | null {
   let pending: AskPrompt | null = null
   const outstanding: (AskPrompt | null)[] = []
+  let outstandingHead = 0
   for (const message of messages) {
     // A new user turn (or an interrupt row) ends the turn that owns whatever
     // calls are still in flight: their results never arrive, and `tool_use_id`
@@ -111,6 +112,7 @@ export function extractPendingAsk(messages: readonly NativeChatMessage[]): AskPr
     // composer (#11761). Claude's tool-result turns decode as role 'tool'.
     if (message.role === 'user' || isInterruptedStatusMessage(message)) {
       outstanding.length = 0
+      outstandingHead = 0
       pending = null
     }
     for (const block of message.blocks) {
@@ -120,8 +122,13 @@ export function extractPendingAsk(messages: readonly NativeChatMessage[]): AskPr
           pending = parsed
         }
         outstanding.push(parsed)
-      } else if (block.type === 'tool-result' && outstanding.length > 0) {
-        const resolved = outstanding.shift()
+      } else if (block.type === 'tool-result' && outstandingHead < outstanding.length) {
+        const resolved = outstanding[outstandingHead]
+        outstanding[outstandingHead++] = null
+        if (outstandingHead === outstanding.length) {
+          outstanding.length = 0
+          outstandingHead = 0
+        }
         if (resolved && resolved === pending) {
           pending = null
         }

--- a/src/shared/native-chat-tool-attribution-allocation.test.ts
+++ b/src/shared/native-chat-tool-attribution-allocation.test.ts
@@ -1,0 +1,38 @@
+import { expect, it } from 'vitest'
+import { foldToolMessages } from './native-chat-tool-fold'
+import type { NativeChatBlock, NativeChatMessage } from './native-chat-types'
+
+function message(id: string, blocks: NativeChatBlock[]): NativeChatMessage {
+  return { id, role: 'assistant', blocks, timestamp: null, source: 'transcript' }
+}
+
+it('does not append valid prose blocks to discarded attribution arrays', () => {
+  const prose: NativeChatBlock = { type: 'text', text: 'Ordinary prose' }
+  const messages = Array.from({ length: 1000 }, (_, i) => message(String(i), [prose]))
+  const push = Array.prototype.push
+  let appends = 0
+  Array.prototype.push = function (this: unknown[], ...items: unknown[]) {
+    if (items[0] === prose) {
+      appends += items.length
+    }
+    return push.apply(this, items)
+  }
+  let output: NativeChatMessage[]
+  try {
+    output = foldToolMessages(messages)
+  } finally {
+    Array.prototype.push = push
+  }
+  expect(appends).toBe(0)
+  output.forEach((entry, i) => expect(entry).toBe(messages[i]))
+})
+
+it('removes only unattributable results while preserving subsequent call/result pairs', () => {
+  const text: NativeChatBlock = { type: 'text', text: 'Prose' }
+  const call: NativeChatBlock = { type: 'tool-call', name: 'read', input: {} }
+  const result: NativeChatBlock = { type: 'tool-result', output: 'done' }
+  const input = message('one', [text, result, text, call, result, result, text])
+  expect(foldToolMessages([input])[0].blocks).toEqual([text, text, call, result, text])
+  expect(input.blocks).toHaveLength(7)
+  expect(foldToolMessages([message('two', [result])])).toEqual([])
+})

--- a/src/shared/native-chat-tool-fold.ts
+++ b/src/shared/native-chat-tool-fold.ts
@@ -52,20 +52,22 @@ function isInterruptionBoundary(message: NativeChatMessage): boolean {
 
 /** Drop tool results the renderer cannot pair within their folded message. */
 function dropUnattributableToolResults(message: NativeChatMessage): NativeChatMessage | null {
-  const blocks: NativeChatBlock[] = []
+  let blocks: NativeChatBlock[] | undefined
   let unansweredCalls = 0
-  for (const block of message.blocks) {
+  for (let index = 0; index < message.blocks.length; index++) {
+    const block = message.blocks[index]
     if (isToolCallBlock(block)) {
       unansweredCalls += 1
     } else if (isToolResultBlock(block)) {
       if (unansweredCalls === 0) {
+        blocks ??= message.blocks.slice(0, index)
         continue
       }
       unansweredCalls -= 1
     }
-    blocks.push(block)
+    blocks?.push(block)
   }
-  if (blocks.length === message.blocks.length) {
+  if (!blocks) {
     return message
   }
   return blocks.length > 0 ? { ...message, blocks } : null
@@ -141,15 +143,16 @@ export function pairToolBlocks(
   limit = Infinity
 ): NativeChatToolPair[] {
   const pairs: NativeChatToolPair[] = []
-  const callSlots: (number | null)[] = []
+  const callSlots: number[] = []
   let resultOrdinal = 0
   for (const block of blocks) {
+    if (pairs.length >= limit && resultOrdinal >= callSlots.length) {
+      break
+    }
     if (block.type === 'tool-call') {
       if (pairs.length < limit) {
         callSlots.push(pairs.length)
         pairs.push({ call: block })
-      } else {
-        callSlots.push(null)
       }
       continue
     }
@@ -163,9 +166,7 @@ export function pairToolBlocks(
       }
     } else {
       resultOrdinal += 1
-      if (slot !== null) {
-        pairs[slot]!.result = block
-      }
+      pairs[slot]!.result = block
     }
   }
   return pairs

--- a/src/shared/native-chat-tool-pair-limit.test.ts
+++ b/src/shared/native-chat-tool-pair-limit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { pairToolBlocks, type NativeChatToolPair } from './native-chat-tool-fold'
+import type { NativeChatBlock } from './native-chat-types'
+
+function original(blocks: readonly NativeChatBlock[], limit: number): NativeChatToolPair[] {
+  const pairs: NativeChatToolPair[] = []
+  const slots: (number | null)[] = []
+  let ordinal = 0
+  for (const block of blocks) {
+    if (block.type === 'tool-call') {
+      if (pairs.length < limit) {
+        slots.push(pairs.length)
+        pairs.push({ call: block })
+      } else {
+        slots.push(null)
+      }
+    } else if (block.type === 'tool-result') {
+      const slot = slots[ordinal]
+      if (slot === undefined) {
+        if (pairs.length < limit) {
+          pairs.push({ result: block })
+        }
+      } else {
+        ordinal++
+        if (slot !== null) {
+          pairs[slot].result = block
+        }
+      }
+    }
+  }
+  return pairs
+}
+
+const call: NativeChatBlock = { type: 'tool-call', name: 'read', input: {} }
+const result: NativeChatBlock = { type: 'tool-result', output: 'done' }
+
+describe('tool pair limits', () => {
+  it('stops visiting blocks once retained pairs are fully answered', () => {
+    let reads = 0
+    const tail = Array.from({ length: 10000 }, () => ({
+      get type() {
+        reads++
+        return 'tool-call' as const
+      },
+      name: 'read',
+      input: {}
+    }))
+    expect(pairToolBlocks([call, result, ...tail], 1)).toEqual([{ call, result }])
+    expect(reads).toBe(0)
+  })
+
+  it('preserves FIFO and stray-result behavior across finite and unlimited limits', () => {
+    for (let seed = 0; seed < 128; seed++) {
+      const blocks = Array.from({ length: 30 }, (_, i) =>
+        (seed * 13 + i * 17) % 7 < 3
+          ? call
+          : (seed + i) % 3
+            ? result
+            : { type: 'text' as const, text: 'hi' }
+      )
+      for (const limit of [0, 1, 2, 5, 0.5, -1, Infinity, Number.NaN]) {
+        expect(pairToolBlocks(blocks, limit)).toEqual(original(blocks, limit))
+      }
+    }
+    expect(pairToolBlocks([call, call, result, result], 1)).toEqual(
+      original([call, call, result, result], 1)
+    )
+  })
+})

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -684,3 +684,33 @@ describe('getProjectHostSetupWorktreeMeta host selection', () => {
     expect(getProjectHostSetupWorktreeMeta(setups, sshRepo).hostId).toBe('ssh:build-box')
   })
 })
+
+it('appends project source IDs without repeatedly copying an accumulating array', () => {
+  const repos = Array.from({ length: 2000 }, (_, i) =>
+    repo({
+      id: `source-${i}`,
+      path: `/repos/${i}`,
+      displayName: `Repo ${i}`,
+      upstream: { owner: 'acme', repo: 'project' }
+    })
+  )
+  let copied = 0
+  const iterator = Array.prototype[Symbol.iterator]
+  Array.prototype[Symbol.iterator] = function (this: unknown[]) {
+    if (this[0] === 'source-0') {
+      copied += this.length
+    }
+    return iterator.call(this)
+  }
+  let result: ReturnType<typeof projectHostSetupProjectionFromRepos>
+  try {
+    result = projectHostSetupProjectionFromRepos([...repos, repos[0]])
+  } finally {
+    Array.prototype[Symbol.iterator] = iterator
+  }
+  expect(copied).toBeLessThan(10_000)
+  expect(result.projects).toHaveLength(1)
+  expect(result.projects[0].sourceRepoIds).toEqual(repos.map((repo) => repo.id))
+  expect(result.setups).toHaveLength(2001)
+  expect(repos[0].displayName).toBe('Repo 0')
+})

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -10,6 +10,7 @@ import type { Repo } from './repo-types'
 
 type ProjectAccumulator = {
   project: Project
+  sourceRepoIds: Set<string>
 }
 
 export type ProjectHostSetupProjection = {
@@ -262,19 +263,15 @@ function createProjectFromRepo(repo: Repo): Project {
   }
 }
 
-function mergeProjectRepo(project: Project, repo: Repo): Project {
-  const sourceRepoIds = project.sourceRepoIds.includes(repo.id)
-    ? project.sourceRepoIds
-    : [...project.sourceRepoIds, repo.id]
-  // Why unknown-aware on both sides: the accumulator itself carries 0 when the first repo of the
-  // project had no addedAt, so a plain min() would let repo order decide the project's createdAt.
-  const addedAt = catalogTimestampFromAddedAt(repo.addedAt)
-  return {
-    ...project,
-    sourceRepoIds,
-    createdAt: mergeCatalogCreatedAt(project.createdAt, addedAt),
-    updatedAt: mergeCatalogUpdatedAt(project.updatedAt, addedAt)
+function mergeProjectRepo(accumulator: ProjectAccumulator, repo: Repo): void {
+  const { project, sourceRepoIds } = accumulator
+  if (!sourceRepoIds.has(repo.id)) {
+    sourceRepoIds.add(repo.id)
+    project.sourceRepoIds.push(repo.id)
   }
+  const addedAt = catalogTimestampFromAddedAt(repo.addedAt)
+  project.createdAt = mergeCatalogCreatedAt(project.createdAt, addedAt)
+  project.updatedAt = mergeCatalogUpdatedAt(project.updatedAt, addedAt)
 }
 
 function createSetupFromRepo(repo: Repo, projectId: string): ProjectHostSetup {
@@ -312,15 +309,15 @@ export function projectHostSetupProjectionFromRepos(
   for (const repo of repos) {
     const projectId = getProjectId(repo)
     const existing = projectById.get(projectId)
-    const project = existing
-      ? mergeProjectRepo(existing.project, repo)
-      : createProjectFromRepo(repo)
+    if (existing) {
+      mergeProjectRepo(existing, repo)
+    } else {
+      const project = createProjectFromRepo(repo)
+      projectById.set(projectId, { project, sourceRepoIds: new Set(project.sourceRepoIds) })
+    }
     // Why normalize here: a repo row is untrusted persisted/wire data too, and these
     // constructors copy repo.path / repo.id straight onto fields consumers call .trim() on.
     const setup = normalizeProjectHostSetupRow(createSetupFromRepo(repo, projectId))
-    projectById.set(projectId, {
-      project
-    })
     setups.push(setup)
   }
 

--- a/src/shared/project-identity-succession.test.ts
+++ b/src/shared/project-identity-succession.test.ts
@@ -135,4 +135,43 @@ describe('carryProjectStateThroughIdentityChange', () => {
     expect(result.projects[1]?.localWindowsRuntimePreference).toBeUndefined()
     expect([...result.remappedProjectIds]).toEqual([['repo:r1', 'git:host/acme/left']])
   })
+  it('visits prior repo memberships once for a bulk identity promotion', () => {
+    let reads = 0
+    const previous = Array.from({ length: 1000 }, (_, i) => ({
+      ...makeProject({ id: `old-${i}`, localWindowsRuntimePreference: { kind: 'windows-host' } }),
+      get sourceRepoIds() {
+        reads++
+        return [`repo-${i}`]
+      }
+    }))
+    const projected = Array.from({ length: 1000 }, (_, i) =>
+      makeProject({ id: `new-${i}`, sourceRepoIds: [`repo-${i}`] })
+    )
+    const result = carryProjectStateThroughIdentityChange(projected, previous)
+    expect(reads).toBe(1000)
+    expect([...result.remappedProjectIds]).toEqual(
+      previous.map((row, i) => [row.id, projected[i].id])
+    )
+    expect(
+      result.projects.every((row) => row.localWindowsRuntimePreference?.kind === 'windows-host')
+    ).toBe(true)
+  })
+
+  it('retains duplicate membership weight and stable prior-row ties', () => {
+    const projected = makeProject({ id: 'new', sourceRepoIds: ['b', 'a', 'b'] })
+    const first = makeProject({
+      id: 'old',
+      sourceRepoIds: ['a', 'a'],
+      localWindowsRuntimePreference: { kind: 'windows-host' }
+    })
+    const second = makeProject({
+      id: 'old',
+      sourceRepoIds: ['b', 'b'],
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+    const result = carryProjectStateThroughIdentityChange([projected], [first, second])
+    expect(result.projects[0].localWindowsRuntimePreference).toEqual(
+      first.localWindowsRuntimePreference
+    )
+  })
 })

--- a/src/shared/project-identity-succession.ts
+++ b/src/shared/project-identity-succession.ts
@@ -17,10 +17,6 @@ function carryUserState(projected: Project, previous: Project): Project {
     : projected
 }
 
-function countSharedRepoIds(sourceRepoIds: readonly string[], other: ReadonlySet<string>): number {
-  return sourceRepoIds.reduce((count, repoId) => (other.has(repoId) ? count + 1 : count), 0)
-}
-
 function compareStrings(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0
 }
@@ -45,15 +41,34 @@ export function carryProjectStateThroughIdentityChange(
   // Why: a prior row that still exists under its own id is live, not a predecessor.
   const orphanedPrevious = previousProjects.filter((project) => !projectedIds.has(project.id))
   const unmatched = projectedProjects.filter((project) => !previousById.has(project.id))
+  const previousIndicesByRepo = new Map<string, number[]>()
+  if (unmatched.length > 0) {
+    orphanedPrevious.forEach((previous, index) => {
+      for (const repoId of previous.sourceRepoIds) {
+        const indices = previousIndicesByRepo.get(repoId)
+        if (indices) {
+          indices.push(index)
+        } else {
+          previousIndicesByRepo.set(repoId, [index])
+        }
+      }
+    })
+  }
   const candidates = unmatched.flatMap((project) => {
-    const repoIds = new Set(project.sourceRepoIds)
-    return orphanedPrevious
-      .map((previous) => ({
+    const overlaps = new Map<number, number>()
+    for (const repoId of new Set(project.sourceRepoIds)) {
+      for (const index of previousIndicesByRepo.get(repoId) ?? []) {
+        overlaps.set(index, (overlaps.get(index) ?? 0) + 1)
+      }
+    }
+    // Preserve input order when the candidate comparator ties on legacy duplicate IDs.
+    return [...overlaps]
+      .sort(([left], [right]) => left - right)
+      .map(([index, shared]) => ({
         project,
-        previous,
-        shared: countSharedRepoIds(previous.sourceRepoIds, repoIds)
+        previous: orphanedPrevious[index],
+        shared
       }))
-      .filter((candidate) => candidate.shared > 0)
   })
   candidates.sort(
     (left, right) =>

--- a/src/shared/pty-listed-session.ts
+++ b/src/shared/pty-listed-session.ts
@@ -8,6 +8,9 @@
  */
 export type AgentOwnershipEvidence = 'present' | 'absent' | 'unknown'
 
+/** Omission requests diagnostic inventory; an explicit null selects only the local provider. */
+export type PtySessionListScope = { connectionId: string | null }
+
 /**
  * One row of `pty:listSessions`. Shared so the main handler, both preload surfaces, and the
  * renderer cannot drift on which evidence the UI is allowed to see.
@@ -16,6 +19,7 @@ export type PtyListedSession = {
   id: string
   cwd: string
   title: string
+  worktreeId?: string
   /**
    * Agent ownership as the listing provider could establish it. Destructive actions must treat
    * anything other than `absent` as live work: discarding this distinction is what let Resource

--- a/src/shared/updated-at-order.test.ts
+++ b/src/shared/updated-at-order.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from 'vitest'
+import { sortByUpdatedAtDescending } from './updated-at-order'
+
+it('reads each timestamp once and preserves in-place ordering including invalid dates', () => {
+  let reads = 0
+  const entries = Array.from({ length: 2000 }, (_, i) => ({
+    id: i,
+    get updatedAt() {
+      reads++
+      return i % 137 === 0
+        ? 'invalid'
+        : new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString()
+    }
+  }))
+  const expected = [...entries].sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  )
+  expect(reads).toBeGreaterThan(10_000)
+  reads = 0
+  expect(sortByUpdatedAtDescending(entries)).toBe(entries)
+  expect(reads).toBe(2000)
+  entries.forEach((entry, i) => expect(entry).toBe(expected[i]))
+})

--- a/src/shared/updated-at-order.ts
+++ b/src/shared/updated-at-order.ts
@@ -1,0 +1,8 @@
+/** Sorts in place; invalid dates retain the native comparator's stable tie behavior. */
+export function sortByUpdatedAtDescending<T extends { updatedAt: string }>(items: T[]): T[] {
+  if (items.length < 2) {
+    return items
+  }
+  const timestamps = new Map(items.map((item) => [item, new Date(item.updatedAt).getTime()]))
+  return items.sort((left, right) => timestamps.get(right)! - timestamps.get(left)!)
+}

--- a/src/shared/windows-command-line-budget.test.ts
+++ b/src/shared/windows-command-line-budget.test.ts
@@ -1,0 +1,25 @@
+import { expect, it, vi } from 'vitest'
+import { commandLineLength } from './windows-command-line-budget'
+
+it('counts quote-dense payloads without allocating a match array', () => {
+  const args = ['node.exe', '-e', '"\\abc'.repeat(6000)]
+  const expected = args.reduce(
+    (total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0),
+    0
+  )
+  const match = vi.spyOn(String.prototype, 'match')
+  try {
+    expect(commandLineLength(args)).toBe(expected)
+    expect(match.mock.calls.length).toBe(0)
+  } finally {
+    match.mockRestore()
+  }
+})
+
+it('preserves empty, Unicode, backslash and quote budget estimates', () => {
+  for (const args of [[], [''], ['🦀', 'é', '\\', '"'], ['a\\\\"b', 'plain']]) {
+    expect(commandLineLength(args)).toBe(
+      args.reduce((total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0), 0)
+    )
+  }
+})

--- a/src/shared/windows-command-line-budget.ts
+++ b/src/shared/windows-command-line-budget.ts
@@ -24,5 +24,15 @@ export const MAX_COMMAND_LINE_CHARS = 30_000
  * quote-heavy ~26KB script on argv and over the real limit.
  */
 export function commandLineLength(args: readonly string[]): number {
-  return args.reduce((total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0), 0)
+  let total = 0
+  for (const arg of args) {
+    total += arg.length + 3
+    for (let index = 0; index < arg.length; index += 1) {
+      const code = arg.charCodeAt(index)
+      if (code === 34 || code === 92) {
+        total += 1
+      }
+    }
+  }
+  return total
 }

--- a/src/shared/windows-environment-expansion.test.ts
+++ b/src/shared/windows-environment-expansion.test.ts
@@ -44,3 +44,24 @@ describe('expandWindowsPathEnvironmentVariables', () => {
     expect(env.PATH).toBe('%ROOT%/bin:/usr/bin')
   })
 })
+
+it('enumerates fallback keys once for a PATH containing repeated mixed-case variables', () => {
+  let enumerations = 0
+  const env = new Proxy(
+    { ROOT: 'C:\\root', OTHER: 'unused' },
+    {
+      ownKeys(target) {
+        enumerations += 1
+        return Reflect.ownKeys(target)
+      }
+    }
+  )
+  const value = Array.from({ length: 1000 }, () => '%root%').join(';')
+  expect(expandWindowsEnvironmentVariables(value, env)).toBe(Array(1000).fill('C:\\root').join(';'))
+  expect(enumerations).toBe(1)
+})
+
+it('preserves exact casing authority and first fallback keys including undefined values', () => {
+  const env = { Root: undefined, ROOT: 'upper', root: 'lower' }
+  expect(expandWindowsEnvironmentVariables('%ROOT%:%root%:%rOoT%', env)).toBe('upper:lower:%rOoT%')
+})

--- a/src/shared/windows-environment-expansion.ts
+++ b/src/shared/windows-environment-expansion.ts
@@ -1,22 +1,25 @@
-function getEnvironmentVariable(
-  env: Readonly<Record<string, string | undefined>>,
-  name: string
-): string | undefined {
-  const exactValue = env[name]
-  if (typeof exactValue === 'string') {
-    return exactValue
-  }
-  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name.toLowerCase())
-  const value = key ? env[key] : undefined
-  return typeof value === 'string' ? value : undefined
-}
-
 export function expandWindowsEnvironmentVariables(
   value: string,
   env: Readonly<Record<string, string | undefined>>
 ): string {
+  let keysByLowerName: Map<string, string> | undefined
   return value.replace(/%([^%]+)%/g, (match, name: string) => {
-    return getEnvironmentVariable(env, name) ?? match
+    const exact = env[name]
+    if (typeof exact === 'string') {
+      return exact
+    }
+    if (!keysByLowerName) {
+      keysByLowerName = new Map()
+      for (const key of Object.keys(env)) {
+        const lower = key.toLowerCase()
+        if (!keysByLowerName.has(lower)) {
+          keysByLowerName.set(lower, key)
+        }
+      }
+    }
+    const key = keysByLowerName.get(name.toLowerCase())
+    const replacement = key ? env[key] : undefined
+    return typeof replacement === 'string' ? replacement : match
   })
 }
 

--- a/src/shared/worker-transcript-text-scaling.test.ts
+++ b/src/shared/worker-transcript-text-scaling.test.ts
@@ -1,0 +1,42 @@
+import { expect, it, vi } from 'vitest'
+import { formatWorkerTranscriptMessage } from './worker-transcript-text'
+import type { NativeChatMessage } from './native-chat-types'
+
+it('does not shift the remaining twin list for each matching roster', () => {
+  const blocks: NativeChatMessage['blocks'] = Array.from({ length: 1000 }, (_, index) => ({
+    type: 'subagent-group',
+    groupId: `g-${index}`,
+    agents: [{ id: 'child', label: 'task', state: 'working' }]
+  }))
+  blocks.push(
+    ...Array.from({ length: 1000 }, () => ({
+      type: 'text' as const,
+      text: 'Kicked off 1 subagent'
+    }))
+  )
+  const original = Array.prototype.splice
+  let shifted = 0
+  const spy = vi.spyOn(Array.prototype, 'splice').mockImplementation(function (
+    this: unknown[],
+    ...args: [number, number, ...unknown[]]
+  ) {
+    if (this[0] === 'Kicked off 1 subagent') {
+      shifted += this.length - args[0] - args[1]
+    }
+    return original.apply(this, args)
+  })
+  let output: string
+  try {
+    output = formatWorkerTranscriptMessage({
+      id: 'm',
+      role: 'assistant',
+      timestamp: 1,
+      source: 'transcript',
+      blocks
+    })
+  } finally {
+    spy.mockRestore()
+  }
+  expect(output!).toBe(`[assistant] ${Array(1000).fill('Kicked off 1 subagent').join('\n')}`)
+  expect(shifted).toBe(0)
+})

--- a/src/shared/worker-transcript-text.ts
+++ b/src/shared/worker-transcript-text.ts
@@ -56,27 +56,30 @@ export function formatWorkerTranscriptMessage(message: NativeChatMessage): strin
  *  twice. A group left with no twin prints its own: the wire admits a roster that
  *  arrived without one, and dropping that would lose the sentence altogether. */
 function claimSubagentGroupTwins(blocks: NativeChatMessage['blocks']): Map<number, string> {
-  const twins: string[] = []
+  const twins = new Map<string, number>()
+  let remainingTwins = 0
   const groups: { index: number; sentence: string }[] = []
   blocks.forEach((block, index) => {
     if (block.type === 'text' && isSubagentGroupFallbackText(block.text)) {
-      twins.push(block.text)
+      twins.set(block.text, (twins.get(block.text) ?? 0) + 1)
+      remainingTwins += 1
     } else if (block.type === 'subagent-group') {
       groups.push({ index, sentence: subagentGroupFallbackText(block.agents) })
     }
   })
   const standIns = new Map<number, string>()
   const unclaimed = groups.filter((group) => {
-    const exact = twins.indexOf(group.sentence)
-    if (exact === -1) {
+    const count = twins.get(group.sentence) ?? 0
+    if (count === 0) {
       return true
     }
-    twins.splice(exact, 1)
+    twins.set(group.sentence, count - 1)
+    remainingTwins -= 1
     return false
   })
   for (const group of unclaimed) {
-    if (twins.length > 0) {
-      twins.pop()
+    if (remainingTwins > 0) {
+      remainingTwins -= 1
       continue
     }
     standIns.set(group.index, `[subagents] ${group.sentence}`)

--- a/src/shared/workspace-doc-history.test.ts
+++ b/src/shared/workspace-doc-history.test.ts
@@ -53,4 +53,36 @@ describe('normalizeWorkspaceDocHistoryEntries', () => {
     expect(normalizeWorkspaceDocHistoryTitle('', DOC)).toBe('a.html')
     expect(normalizeWorkspaceDocHistoryTitle('Report', DOC)).toBe('Report')
   })
+  it('indexes document identity while deduplicating a large legacy history', () => {
+    let reads = 0
+    const entries = Array.from({ length: 10_000 }, (_, i) =>
+      entry({
+        docLocation: {
+          kind: 'workspace-doc',
+          get worktreeId() {
+            reads++
+            return 'wt-1'
+          },
+          filePath: `/repo/${i % 99}.html`
+        },
+        lastVisitedAt: i
+      })
+    )
+    const result = normalizeWorkspaceDocHistoryEntries(entries)
+    expect(reads).toBeLessThanOrEqual(20_000)
+    expect(result).toHaveLength(99)
+    expect(result.map((row) => row.lastVisitedAt)).toEqual(
+      Array.from({ length: 99 }, (_, i) => 9999 - i)
+    )
+  })
+
+  it('keeps workspace and file identity separate, including separator-like text', () => {
+    const locations = [
+      { kind: 'workspace-doc' as const, worktreeId: 'a::b', filePath: 'c' },
+      { kind: 'workspace-doc' as const, worktreeId: 'a', filePath: 'b::c' },
+      { kind: 'workspace-doc' as const, worktreeId: 'a', filePath: 'B::c' }
+    ]
+    const entries = locations.map((docLocation) => entry({ docLocation }))
+    expect(normalizeWorkspaceDocHistoryEntries(entries)).toEqual(entries)
+  })
 })

--- a/src/shared/workspace-doc-history.ts
+++ b/src/shared/workspace-doc-history.ts
@@ -1,4 +1,3 @@
-import { browserPageDocLocationsEqual } from './browser-page-doc-location'
 import type { BrowserPageDocLocation } from './browser-workspace-types'
 import { isDocPreviewUrl } from './doc-preview-scheme'
 
@@ -32,6 +31,7 @@ export function normalizeWorkspaceDocHistoryEntries(
   entries: readonly WorkspaceDocHistoryEntry[]
 ): WorkspaceDocHistoryEntry[] {
   const normalized: WorkspaceDocHistoryEntry[] = []
+  const seenPathsByWorktree = new Map<string, Set<string>>()
   const candidates = [...entries].sort((a, b) => b.lastVisitedAt - a.lastVisitedAt)
   for (const entry of candidates) {
     if (
@@ -41,10 +41,15 @@ export function normalizeWorkspaceDocHistoryEntries(
     ) {
       continue
     }
-    if (
-      normalized.some((kept) => browserPageDocLocationsEqual(kept.docLocation, entry.docLocation))
-    ) {
+    const { worktreeId, filePath } = entry.docLocation
+    const seenPaths = seenPathsByWorktree.get(worktreeId)
+    if (seenPaths?.has(filePath)) {
       continue
+    }
+    if (seenPaths) {
+      seenPaths.add(filePath)
+    } else {
+      seenPathsByWorktree.set(worktreeId, new Set([filePath]))
     }
     normalized.push({
       ...entry,

--- a/src/shared/workspace-session-browser-history.test.ts
+++ b/src/shared/workspace-session-browser-history.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { getDefaultWorkspaceSession } from './constants'
 import {
   MAX_BROWSER_HISTORY_ENTRIES,
-  normalizeBrowserHistoryEntries
+  normalizeBrowserHistoryEntries,
+  pruneWorkspaceSessionBrowserHistory
 } from './workspace-session-browser-history'
 
 describe('normalizeBrowserHistoryEntries', () => {
@@ -19,5 +21,46 @@ describe('normalizeBrowserHistoryEntries', () => {
     expect(normalized).toHaveLength(MAX_BROWSER_HISTORY_ENTRIES)
     expect(normalized[0]?.url).toBe('https://example.com/499')
     expect(normalized.at(-1)?.url).toBe('https://example.com/300')
+  })
+  it('stops reading URLs once enough unique recent entries have been retained', () => {
+    let reads = 0
+    const history = Array.from({ length: 10_000 }, (_, index) => ({
+      get url() {
+        reads++
+        return `https://example.com/${index}`
+      },
+      normalizedUrl: `https://example.com/${index}`,
+      title: `Example ${index}`,
+      lastVisitedAt: index,
+      visitCount: 1
+    }))
+    const normalized = normalizeBrowserHistoryEntries(history)
+    expect(reads).toBeLessThanOrEqual(400)
+    expect(normalized).toHaveLength(200)
+    expect(normalized[0]).toBe(history[9999])
+    expect(normalized[199]).toBe(history[9800])
+  })
+
+  it('preserves the session on repeated normalization while still repairing and deduplicating history', () => {
+    const entry = {
+      url: 'https://example.com/page',
+      normalizedUrl: 'https://example.com/page',
+      title: 'Page',
+      lastVisitedAt: 1,
+      visitCount: 1
+    }
+    const session = { ...getDefaultWorkspaceSession(), browserUrlHistory: [entry] }
+    for (let i = 0; i < 100; i++) {
+      expect(pruneWorkspaceSessionBrowserHistory(session)).toBe(session)
+    }
+    const repaired = normalizeBrowserHistoryEntries([
+      { ...entry, normalizedUrl: 'incorrect', lastVisitedAt: 3 },
+      { ...entry, lastVisitedAt: 2 }
+    ])
+    expect(repaired).toEqual([{ ...entry, lastVisitedAt: 3 }])
+    expect(
+      normalizeBrowserHistoryEntries([{ ...entry, url: 'https://EXAMPLE.com/page' }])[0]
+        .normalizedUrl
+    ).toBe(entry.normalizedUrl)
   })
 })

--- a/src/shared/workspace-session-browser-history.ts
+++ b/src/shared/workspace-session-browser-history.ts
@@ -24,25 +24,21 @@ export function normalizeBrowserHistoryEntries(
 ): BrowserHistoryEntry[] {
   const seen = new Set<string>()
   const normalizedEntries: BrowserHistoryEntry[] = []
-  const candidates = entries
-    .map((entry) => {
-      const safeUrl = redactKagiSessionToken(entry.url)
-      return {
-        entry,
-        safeUrl,
-        key: normalizeBrowserHistoryUrl(safeUrl)
-      }
-    })
-    // Why: persisted history from older builds or schema repair may not be in
-    // recency order; the cap must keep recent visits, not arbitrary file order.
-    .sort((a, b) => b.entry.lastVisitedAt - a.entry.lastVisitedAt)
+  // Persisted history may be unordered; normalize only until the retained cap is filled.
+  const candidates = [...entries].sort((a, b) => b.lastVisitedAt - a.lastVisitedAt)
 
-  for (const { entry, safeUrl, key } of candidates) {
+  for (const entry of candidates) {
+    const safeUrl = redactKagiSessionToken(entry.url)
+    const key = normalizeBrowserHistoryUrl(safeUrl)
     if (seen.has(key)) {
       continue
     }
     seen.add(key)
-    normalizedEntries.push({ ...entry, url: safeUrl, normalizedUrl: key })
+    normalizedEntries.push(
+      entry.url === safeUrl && entry.normalizedUrl === key
+        ? entry
+        : { ...entry, url: safeUrl, normalizedUrl: key }
+    )
     if (normalizedEntries.length >= MAX_BROWSER_HISTORY_ENTRIES) {
       break
     }

--- a/src/shared/workspace-session-terminal-tab-close.test.ts
+++ b/src/shared/workspace-session-terminal-tab-close.test.ts
@@ -230,4 +230,35 @@ describe('closeTerminalTabInWorkspaceSession', () => {
     expect(current.tabsByWorktree[WORKTREE_ID]).toEqual([])
     expect(current.terminalLayoutsByTabId).toEqual({})
   })
+  it('selects the previous neighbor in linear work when closing the last of many tabs', () => {
+    let reads = 0
+    const ids = Array.from({ length: 1000 }, (_, i) => `tab-${i}`)
+    const tabOrder = [...ids, 'terminal-1']
+    for (let i = 0; i < tabOrder.length; i++) {
+      const value = tabOrder[i]
+      Object.defineProperty(tabOrder, i, {
+        get: () => {
+          reads++
+          return value
+        }
+      })
+    }
+    const initial = session()
+    initial.tabGroups![WORKTREE_ID][0].tabOrder = tabOrder
+    initial.tabGroups![WORKTREE_ID][0].recentTabIds = []
+    const result = closeTerminalTabInWorkspaceSession(initial, WORKTREE_ID, 'terminal-1')
+    expect(result.session.tabGroups![WORKTREE_ID][0].activeTabId).toBe('tab-999')
+    expect(result.session.tabGroups![WORKTREE_ID][0].tabOrder).toEqual(ids)
+    expect(reads).toBeLessThan(6000)
+  })
+
+  it('preserves first-occurrence neighbor semantics for duplicate legacy order entries', () => {
+    const initial = session()
+    initial.tabGroups![WORKTREE_ID][0].tabOrder = ['a', 'terminal-1', 'a', 'b']
+    initial.tabGroups![WORKTREE_ID][0].recentTabIds = ['absent', 'terminal-1']
+    const result = closeTerminalTabInWorkspaceSession(initial, WORKTREE_ID, 'terminal-1')
+    expect(result.session.tabGroups![WORKTREE_ID][0].activeTabId).toBe('b')
+    expect(result.session.tabGroups![WORKTREE_ID][0].tabOrder).toEqual(['a', 'a', 'b'])
+    expect(result.session.tabGroups![WORKTREE_ID][0].recentTabIds).toEqual([])
+  })
 })

--- a/src/shared/workspace-session-terminal-tab-close.ts
+++ b/src/shared/workspace-session-terminal-tab-close.ts
@@ -8,18 +8,26 @@ export type WorkspaceSessionTerminalTabCloseResult = {
   pinned: boolean
 }
 
-function pickNextActiveTab(group: TabGroup, closingIds: ReadonlySet<string>): string | null {
-  const remaining = group.tabOrder.filter((id) => !closingIds.has(id))
+function pickNextActiveTab(
+  group: TabGroup,
+  closingIds: ReadonlySet<string>,
+  remaining: readonly string[],
+  remainingIds: ReadonlySet<string>
+): string | null {
   for (let index = (group.recentTabIds?.length ?? 0) - 1; index >= 0; index -= 1) {
     const id = group.recentTabIds![index]
-    if (remaining.includes(id)) {
+    if (remainingIds.has(id)) {
       return id
     }
   }
+  const firstIndices = new Map<string, number>()
+  group.tabOrder.forEach((id, index) => {
+    if (!firstIndices.has(id)) {
+      firstIndices.set(id, index)
+    }
+  })
   const closingIndex = group.tabOrder.findIndex((id) => closingIds.has(id))
-  return (
-    remaining.find((id) => group.tabOrder.indexOf(id) > closingIndex) ?? remaining.at(-1) ?? null
-  )
+  return remaining.find((id) => firstIndices.get(id)! > closingIndex) ?? remaining.at(-1) ?? null
 }
 
 function pruneGroupLayout(
@@ -186,16 +194,17 @@ export function closeTerminalTabInWorkspaceSession(
   const nextGroups = (session.tabGroups?.[worktreeId] ?? [])
     .map((group) => {
       const tabOrder = group.tabOrder.filter((id) => !closedVisibleIds.has(id))
+      const remainingIds = new Set(tabOrder)
       const activeTabId = closedVisibleIds.has(group.activeTabId ?? '')
-        ? pickNextActiveTab(group, closedVisibleIds)
-        : group.activeTabId && tabOrder.includes(group.activeTabId)
+        ? pickNextActiveTab(group, closedVisibleIds, tabOrder, remainingIds)
+        : group.activeTabId && remainingIds.has(group.activeTabId)
           ? group.activeTabId
           : (tabOrder[0] ?? null)
       return {
         ...group,
         tabOrder,
         activeTabId,
-        recentTabIds: group.recentTabIds?.filter((id) => tabOrder.includes(id))
+        recentTabIds: group.recentTabIds?.filter((id) => remainingIds.has(id))
       }
     })
     .filter((group) => group.tabOrder.length > 0)

--- a/src/shared/workspace-space-compaction.test.ts
+++ b/src/shared/workspace-space-compaction.test.ts
@@ -1,0 +1,50 @@
+import { expect, it, vi } from 'vitest'
+import { compactWorkspaceSpaceItems } from './workspace-space-compaction'
+import type { WorkspaceSpaceItem } from './workspace-space-types'
+
+it('sums omitted sizes without constructing a replacement object per omitted item', () => {
+  const items: WorkspaceSpaceItem[] = Array.from({ length: 10000 }, (_, index) => ({
+    name: String(index),
+    path: String(index),
+    kind: 'file',
+    sizeBytes: index
+  }))
+  const original = Array.prototype.reduce
+  let objectAccumulators = 0
+  const spy = vi.spyOn(Array.prototype, 'reduce').mockImplementation(function (
+    this: unknown[],
+    callback,
+    initial: unknown
+  ) {
+    if (initial && typeof initial === 'object' && 'name' in initial && initial.name === 'Other') {
+      objectAccumulators += this.length
+    }
+    return Reflect.apply(original, this, [callback, initial])
+  })
+  let result: ReturnType<typeof compactWorkspaceSpaceItems>
+  try {
+    result = compactWorkspaceSpaceItems(items)
+  } finally {
+    spy.mockRestore()
+  }
+  expect(objectAccumulators).toBe(0)
+  expect(result!.topLevelItems).toHaveLength(48)
+  expect(result!.omittedTopLevelItemCount).toBe(9953)
+  expect(result!.omittedTopLevelSizeBytes).toBe((9952 * 9953) / 2)
+  expect(result!.topLevelItems[0]).toBe(items[9999])
+  expect(items[0].sizeBytes).toBe(0)
+})
+
+it('preserves small-list size ties and empty results', () => {
+  expect(compactWorkspaceSpaceItems([]).topLevelItems).toEqual([])
+  const items: WorkspaceSpaceItem[] = ['b', 'a'].map((name) => ({
+    name,
+    path: name,
+    kind: 'file',
+    sizeBytes: 1
+  }))
+  expect(compactWorkspaceSpaceItems(items).topLevelItems.map((item) => item.name)).toEqual([
+    'a',
+    'b'
+  ])
+})

--- a/src/shared/workspace-space-compaction.ts
+++ b/src/shared/workspace-space-compaction.ts
@@ -19,23 +19,20 @@ export function compactWorkspaceSpaceItems(items: WorkspaceSpaceItem[]): {
   }
 
   const visible = sorted.slice(0, WORKSPACE_SPACE_MAX_TOP_LEVEL_ITEMS - 1)
-  const omitted = sorted.slice(WORKSPACE_SPACE_MAX_TOP_LEVEL_ITEMS - 1)
-  const other = omitted.reduce<WorkspaceSpaceItem>(
-    (acc, item) => ({
-      ...acc,
-      sizeBytes: acc.sizeBytes + item.sizeBytes
-    }),
-    {
-      name: 'Other',
-      path: '',
-      kind: 'other',
-      sizeBytes: 0
-    }
-  )
+  let omittedSizeBytes = 0
+  for (let index = visible.length; index < sorted.length; index += 1) {
+    omittedSizeBytes += sorted[index].sizeBytes
+  }
+  const other: WorkspaceSpaceItem = {
+    name: 'Other',
+    path: '',
+    kind: 'other',
+    sizeBytes: omittedSizeBytes
+  }
 
   return {
     topLevelItems: [...visible, other],
-    omittedTopLevelItemCount: omitted.length,
+    omittedTopLevelItemCount: sorted.length - visible.length,
     omittedTopLevelSizeBytes: other.sizeBytes
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 82 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3780 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3766 |
| Prod | 98 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1706 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​851 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​855 |

<!-- /orca-pr-loc -->

## ELI5

Large desktop sessions repeatedly scan, sort, copy, or notify over the same data. This audit removes 75 independently verified sources of that work while preserving ordering, ownership, retention limits, and compatibility behavior.

## What Changed

- Reduce repeated collection scans with operation-scoped indexes, cached sort keys, and single-pass selection.
- Stop processing once bounded result windows or queues are full, and avoid discarded serialization and payload copies.
- Reduce renderer subscription/notification churn and hidden-terminal resource work.
- Add regression evidence and a numbered ledger in `config/performance-audit-2026-09-07.md`. The ledger describes every fix and the limits of the measurements.

## Why

For example, 1,000-location usage rollup merges performed 2,002,000 key reads; the indexed merge stays below 10,000. Rejecting 1,000 full-queue 64 KB tunnel frames now avoids 65,536,000 copied payload bytes. These are measured operation/allocation reductions; they do not claim equivalent end-to-end latency improvements.

## Linked Issue

User-requested desktop performance audit; no issue was supplied.

## Visual Proof

N/A — these changes preserve visual presentation. Earlier hidden Electron typing/restore measurements and screenshot artifact locations are documented in the audit; later collection changes were validated through contracts. No test windows were shown or focused.

## Testing

- [x] Automated tests added/updated.
- 569 tests across 82 changed suites passed on macOS, with `ORCA_BACKGROUND_LAUNCH=1`.
- 72 additional tests across four contract suites passed (641 tests across 86 distinct suites total).
- Full `pnpm tc` passed.
- Changed-code, type-aware, and React Doctor quality gates passed across 179 code files; `git diff --check` passed.
- Original-production negative controls reject the new scaling assertions through fix 75; sources were restored after each run.
- Windows/Linux and real-network SSH execution were not measured locally. Relevant platform, host-ownership, folder-workspace, provider, and wire contracts are covered by tests.
- Full build and full-repository lint/test runs are left to CI.

## Review

This is a broad audit collected into one draft PR at the user's request. Use the numbered ledger to review independent fix groups. Mobile application code is excluded; desktop/shared execution behavior still respects remote ownership and mixed-version contracts.

## Agent skill upstream boundary

- [x] This change copies or translates no upstream skill-installer material.

## Checklist

- [x] Explained changes and evidence.
- [x] Cross-platform, SSH/remote, folder-workspace and compatibility impacts considered.
- [x] Local typecheck and changed-code quality passed.
- [ ] Full CI build and repository checks pass.

Final commit-hook cleanup extracted SOCKS upstream delivery and AI-vault project-key formatting into focused modules without changing behavior. All 41 tests across their four relevant suites passed after extraction (`/tmp/orca-perf-75-extractions.log`); these overlap the earlier coverage and are not added to the total.
