### PR TITLE
perf: skip Git-status indexing without eligible editors

### DIFF
--- a/src/renderer/src/store/slices/editor/git/git-status-reconciliation.perf.test.ts
+++ b/src/renderer/src/store/slices/editor/git/git-status-reconciliation.perf.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
+import type { OpenFile } from '../types/open-file'
+import { reconcileOpenFilesForStatus } from './git-status-reconciliation'
+
+function openFile(overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id: 'file',
+    filePath: '/repo/file.ts',
+    relativePath: 'file.ts',
+    worktreeId: 'wt',
+    language: 'typescript',
+    isDirty: false,
+    mode: 'edit',
+    ...overrides
+  }
+}
+
+const conflict: NonNullable<OpenFile['conflict']> = {
+  kind: 'conflict-editable',
+  conflictKind: 'both_modified',
+  conflictStatus: 'unresolved',
+  conflictStatusSource: 'git'
+}
+
+function countedEntries(count: number): { entries: GitStatusEntry[]; reads: () => number } {
+  let reads = 0
+  const entries = Array.from({ length: count }, (_, index): GitStatusEntry => ({
+    get path() {
+      reads++
+      return `file-${index}.ts`
+    },
+    status: 'modified',
+    area: 'unstaged',
+    conflictKind: conflict.conflictKind,
+    conflictStatus: conflict.conflictStatus,
+    conflictStatusSource: conflict.conflictStatusSource
+  }))
+  return { entries, reads: () => reads }
+}
+
+describe('open conflict status indexing', () => {
+  it.each([true, false])(
+    'skips status rows without eligible open conflicts (complete=%s)',
+    (complete) => {
+      const { entries, reads } = countedEntries(10_000)
+      const files = [
+        openFile(),
+        openFile({ worktreeId: 'folder:other', conflict }),
+        openFile({ mode: 'conflict-review', conflict }),
+        openFile({ mode: 'check-details', conflict })
+      ]
+
+      for (let refresh = 0; refresh < 10; refresh++) {
+        expect(reconcileOpenFilesForStatus(files, 'wt', entries, complete)).toBe(files)
+      }
+      expect(reads()).toBe(0)
+    }
+  )
+
+  it('builds one index for all open conflicts and rebuilds it on the next snapshot', () => {
+    const { entries, reads } = countedEntries(1_000)
+    const files = Array.from({ length: 100 }, (_, index) =>
+      openFile({ id: `file-${index}`, relativePath: `file-${index}.ts`, conflict })
+    )
+    expect(reconcileOpenFilesForStatus(files, 'wt', entries, true)).toBe(files)
+    expect(reads()).toBe(1_000)
+
+    const resolved: GitStatusEntry = {
+      path: 'file-0.ts',
+      status: 'modified',
+      area: 'unstaged',
+      conflictKind: 'both_modified',
+      conflictStatus: 'resolved_locally',
+      conflictStatusSource: 'session'
+    }
+    const updated = reconcileOpenFilesForStatus(files, 'wt', [...entries, resolved], true)
+    expect(reads()).toBe(2_000)
+    expect(updated[0].conflict?.conflictStatus).toBe('resolved_locally')
+    expect(updated[1]).toBe(files[1])
+  })
+})

--- a/src/renderer/src/store/slices/editor/git/git-status-reconciliation.ts
+++ b/src/renderer/src/store/slices/editor/git/git-status-reconciliation.ts
@@ -132,7 +132,7 @@ export function reconcileOpenFilesForStatus(
   nextEntries: GitStatusEntry[],
   statusIsComplete: boolean
 ): OpenFile[] {
-  const entriesByPath = new Map(nextEntries.map((entry) => [entry.path, entry]))
+  let entriesByPath: Map<string, GitStatusEntry> | undefined
   let changed = false
 
   const nextOpenFiles = openFiles.flatMap((file) => {
@@ -144,10 +144,13 @@ export function reconcileOpenFilesForStatus(
       return [file]
     }
 
-    const entry = entriesByPath.get(file.relativePath)
     if (!file.conflict) {
       return [file]
     }
+
+    // Most refreshes have no open conflicts and need no status-path index.
+    entriesByPath ??= new Map(nextEntries.map((entry) => [entry.path, entry]))
+    const entry = entriesByPath.get(file.relativePath)
 
     // Why: a capped snapshot cannot prove that an omitted conflict was resolved.
     if (!entry && !statusIsComplete) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

When Orca refreshes a repository's Git status, it used to build a lookup table of every changed file in that repo — even when nothing on screen needed it. That table is only used to update editor tabs that are currently displaying a merge conflict, which is rare. Now the table is built the first time such a tab is actually found, and skipped entirely when there are none.

Nothing you see changes: conflict banners still appear, update, and clear at exactly the same moments. In a repo with 10,000 changed files, ten status refreshes with no conflict tabs open now do zero lookup work instead of building 100,000 table entries.

## What Changed / Why

- Ten refreshes × 10,000 entries: 100,000 path reads → zero; original implementation fails the count test

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 3 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/store/slices/editor/git/git-status-reconciliation.perf.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

