### PR TITLE
perf: stop filesystem authorization at the first matching root

### DIFF
--- a/src/main/ipc/filesystem-allowed-roots.test.ts
+++ b/src/main/ipc/filesystem-allowed-roots.test.ts
@@ -8,6 +8,7 @@ import { listRepoWorktreeGraph } from '../repo-worktrees'
 import type * as ProjectGroupsModule from '../../shared/project-groups'
 import { buildProjectGroupChildIndex, getProjectGroupSubtreeIds } from '../../shared/project-groups'
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
+import type * as CrossPlatformPathModule from '../../shared/cross-platform-path'
 import { getWorktreeMirrorDistro } from '../project-runtime-git-options'
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../shared/project-group-types'
@@ -30,6 +31,13 @@ vi.mock('../../shared/project-groups', async () => {
     buildProjectGroupChildIndex: vi.fn(actual.buildProjectGroupChildIndex),
     getProjectGroupSubtreeIds: vi.fn(actual.getProjectGroupSubtreeIds)
   }
+})
+
+vi.mock('../../shared/cross-platform-path', async () => {
+  const actual = await vi.importActual<typeof CrossPlatformPathModule>(
+    '../../shared/cross-platform-path'
+  )
+  return { ...actual, isPathInsideOrEqual: vi.fn(actual.isPathInsideOrEqual) }
 })
 
 type StoreFixture = {
@@ -257,6 +265,42 @@ beforeEach(() => {
 })
 
 describe('getAllowedRoots', () => {
+  it('stops scanning repositories when a local candidate settles each folder scope', () => {
+    const fixture: StoreFixture = {
+      repos: Array.from({ length: 1_000 }, (_, index) =>
+        makeRepo({ id: `repo-${index}`, path: `/folders/root/repo-${index}` })
+      ),
+      projects: [],
+      projectGroups: [],
+      folderWorkspaces: Array.from({ length: 100 }, (_, index) =>
+        makeWorkspace({ id: `folder-${index}`, folderPath: '/folders/root' })
+      )
+    }
+    const { store } = makeCountingStore(fixture)
+    vi.mocked(isPathInsideOrEqual).mockClear()
+    const actual = getAllowedRoots(store)
+    expect(isPathInsideOrEqual).toHaveBeenCalledTimes(100)
+    vi.mocked(isPathInsideOrEqual).mockClear()
+    expect(actual).toEqual(referenceAllowedRoots(store))
+    expect(isPathInsideOrEqual).toHaveBeenCalledTimes(100_000)
+  })
+
+  it('preserves empty, remote-only, mixed and explicit remote folder scopes in any repo order', () => {
+    const fixture = makeMixedFixture()
+    fixture.repos.push(
+      makeRepo({
+        id: 'local-in-remote-group',
+        path: '/local/mixed',
+        projectGroupId: 'group-remote'
+      })
+    )
+    for (let index = 0; index < fixture.repos.length; index += 1) {
+      fixture.repos.push(fixture.repos.shift()!)
+      const { store } = makeCountingStore(fixture)
+      expect(getAllowedRoots(store)).toEqual(referenceAllowedRoots(store))
+    }
+  })
+
   it('produces the same roots as the pre-change implementation', () => {
     const { store } = makeCountingStore(makeMixedFixture())
 

--- a/src/main/ipc/filesystem-allowed-roots.ts
+++ b/src/main/ipc/filesystem-allowed-roots.ts
@@ -27,20 +27,6 @@ export function getLocalRepos(store: Store) {
   return filterLocalRepos(store.getRepos())
 }
 
-function getFolderScopeCandidateRepos(
-  folderPath: string,
-  projectGroupId: string,
-  childGroupIndex: ProjectGroupChildIndex,
-  repos: readonly Repo[]
-): Repo[] {
-  const groupIds = collectProjectGroupSubtreeIds(childGroupIndex, projectGroupId)
-  return repos.filter(
-    (repo) =>
-      (typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)) ||
-      isPathInsideOrEqual(folderPath, repo.path)
-  )
-}
-
 function isRemoteOnlyFolderScope(
   folderPath: string,
   projectGroupId: string,
@@ -51,13 +37,21 @@ function isRemoteOnlyFolderScope(
   if (connectionId) {
     return true
   }
-  const candidates = getFolderScopeCandidateRepos(
-    folderPath,
-    projectGroupId,
-    childGroupIndex,
-    repos
-  )
-  return candidates.length > 0 && candidates.every((repo) => Boolean(repo.connectionId))
+  const groupIds = collectProjectGroupSubtreeIds(childGroupIndex, projectGroupId)
+  let hasRemoteCandidate = false
+  for (const repo of repos) {
+    if (
+      (typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)) ||
+      isPathInsideOrEqual(folderPath, repo.path)
+    ) {
+      // One local candidate settles the scope without scanning the remaining repositories.
+      if (!repo.connectionId) {
+        return false
+      }
+      hasRemoteCandidate = true
+    }
+  }
+  return hasRemoteCandidate
 }
 
 function getFolderWorkspaceConnectionId(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

Before Orca lets the app read or write a file, it works out which folders on your machine are in bounds. Part of that is deciding whether a folder scope is "remote only" - meaning everything under it lives on an SSH host, so no local folder should be authorized. It used to answer that by collecting *every* repository belonging to the scope into a list, then checking whether all of them were remote.

Now it walks the repositories once and stops the moment it finds a single local one, because one local repository already proves the scope is not remote-only. The authorized folder list is identical: a test replays the old algorithm side by side, including with the repositories in every rotation of their order, and across empty, remote-only, mixed, and explicitly-remote scopes. With 100 folder scopes over 1,000 repositories, path comparisons drop from 100,000 to 100.

## What Changed / Why

- 100 scopes × 1,000 repos: 100,000 path checks → 100, with identical authorized roots

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 8 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/ipc/filesystem-allowed-roots.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

