### PR TITLE
perf: avoid repeated pending SOCKS payload copies

### DIFF
--- a/src/main/browser/remote-browser-socks-buffering.test.ts
+++ b/src/main/browser/remote-browser-socks-buffering.test.ts
@@ -8,7 +8,7 @@ vi.mock('node:net', () => ({
   createServer: vi.fn(() => ({ listening: false }))
 }))
 
-function setup() {
+function setup(requestTail: Buffer = Buffer.alloc(0)) {
   const upstream = new PassThrough()
   const write = vi.spyOn(upstream, 'write')
   const opened = Promise.withResolvers<PassThrough>()
@@ -29,7 +29,7 @@ function setup() {
   const accept = vi.mocked(createServer).mock.calls.at(-1)![0] as (socket: Socket) => void
   accept(socket as unknown as Socket)
   socket.emit('data', Buffer.from([5, 1, 0]))
-  socket.emit('data', Buffer.from([5, 1, 0, 1, 127, 0, 0, 1, 1, 187]))
+  socket.emit('data', Buffer.concat([Buffer.from([5, 1, 0, 1, 127, 0, 0, 1, 1, 187]), requestTail]))
   return { server, socket, upstream, write, opened, open }
 }
 
@@ -62,6 +62,23 @@ describe('pending browser SOCKS route buffering', () => {
     } finally {
       copy.mockRestore()
       concat.mockRestore()
+      await server.close()
+      upstream.destroy()
+    }
+  })
+
+  it('keeps request-tail bytes ahead of later fragments in the pending payload', async () => {
+    const tail = Buffer.from('GET / HTTP/1.1\r\n')
+    const { server, socket, upstream, write, opened } = setup(tail)
+    const rest = Buffer.from('Host: example.com\r\n\r\n')
+    try {
+      for (const byte of rest) {
+        socket.emit('data', Buffer.from([byte]))
+      }
+      opened.resolve(upstream)
+      await vi.waitFor(() => expect(write).toHaveBeenCalledTimes(1))
+      expect(write.mock.calls[0][0]).toEqual(Buffer.concat([tail, rest]))
+    } finally {
       await server.close()
       upstream.destroy()
     }

--- a/src/main/browser/remote-browser-socks-buffering.test.ts
+++ b/src/main/browser/remote-browser-socks-buffering.test.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from 'node:events'
+import { createServer, type Socket } from 'node:net'
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RemoteBrowserSocksServer } from './remote-browser-socks-server'
+
+vi.mock('node:net', () => ({
+  createServer: vi.fn(() => ({ listening: false }))
+}))
+
+function setup() {
+  const upstream = new PassThrough()
+  const write = vi.spyOn(upstream, 'write')
+  const opened = Promise.withResolvers<PassThrough>()
+  const open = vi.fn(() => opened.promise)
+  const server = new RemoteBrowserSocksServer({ open })
+  const socket = Object.assign(new EventEmitter(), {
+    remoteAddress: '127.0.0.1',
+    destroyed: false,
+    write: vi.fn(() => true),
+    pause: vi.fn(),
+    end: vi.fn((_reply, callback) => callback()),
+    pipe: vi.fn(),
+    destroy: vi.fn(() => {
+      socket.destroyed = true
+      socket.emit('close')
+    })
+  })
+  const accept = vi.mocked(createServer).mock.calls.at(-1)![0] as (socket: Socket) => void
+  accept(socket as unknown as Socket)
+  socket.emit('data', Buffer.from([5, 1, 0]))
+  socket.emit('data', Buffer.from([5, 1, 0, 1, 127, 0, 0, 1, 1, 187]))
+  return { server, socket, upstream, write, opened, open }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('pending browser SOCKS route buffering', () => {
+  it('copies fragmented pending bytes linearly and forwards every byte at the existing cap', async () => {
+    const { server, socket, upstream, write, opened } = setup()
+    const payload = Buffer.alloc(256 * 1024)
+    for (let index = 0; index < payload.length; index += 1) {
+      payload[index] = index % 251
+    }
+    let copiedBytes = 0
+    const originalCopy = Buffer.prototype.copy
+    const copy = vi.spyOn(Buffer.prototype, 'copy').mockImplementation(function (target, ...args) {
+      const copied = originalCopy.call(this, target, ...args)
+      copiedBytes += copied
+      return copied
+    })
+    const concat = vi.spyOn(Buffer, 'concat')
+    try {
+      for (let index = 0; index < payload.length; index += 256) {
+        socket.emit('data', payload.subarray(index, index + 256))
+      }
+      expect(concat.mock.calls.length).toBe(0)
+      expect(copiedBytes).toBeLessThan(payload.length * 3)
+      opened.resolve(upstream)
+      await vi.waitFor(() => expect(write).toHaveBeenCalledTimes(1))
+      expect(write.mock.calls[0][0]).toEqual(payload)
+    } finally {
+      copy.mockRestore()
+      concat.mockRestore()
+      await server.close()
+      upstream.destroy()
+    }
+  })
+
+  it('rejects one byte beyond the cap and destroys a late upstream without forwarding', async () => {
+    const { server, socket, upstream, write, opened, open } = setup()
+    try {
+      await vi.waitFor(() => expect(open).toHaveBeenCalledTimes(1))
+      socket.emit('data', Buffer.alloc(256 * 1024))
+      expect(socket.destroyed).toBe(false)
+      socket.emit('data', Buffer.from([1]))
+      expect(socket.destroyed).toBe(true)
+      expect(socket.end.mock.calls[0][0][1]).toBe(1)
+      opened.resolve(upstream)
+      await vi.waitFor(() => expect(upstream.destroyed).toBe(true))
+      expect(write).not.toHaveBeenCalled()
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('discards pending input on client close while the route is opening', async () => {
+    const { server, socket, upstream, write, opened, open } = setup()
+    try {
+      await vi.waitFor(() => expect(open).toHaveBeenCalledTimes(1))
+      socket.emit('data', Buffer.from('pending request'))
+      socket.destroy()
+      opened.resolve(upstream)
+      await vi.waitFor(() => expect(upstream.destroyed).toBe(true))
+      expect(write).not.toHaveBeenCalled()
+    } finally {
+      await server.close()
+    }
+  })
+})

--- a/src/main/browser/remote-browser-socks-server.ts
+++ b/src/main/browser/remote-browser-socks-server.ts
@@ -1,7 +1,7 @@
-import { pipeUpstreamToClient } from './remote-browser-socks-upstream'
 import { createServer, type Server, type Socket } from 'node:net'
 import type { Duplex } from 'node:stream'
 import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
+import { pipeUpstreamToClient } from './remote-browser-socks-upstream'
 
 const SOCKS_VERSION = 5
 const SOCKS_NO_AUTH = 0

--- a/src/main/browser/remote-browser-socks-server.ts
+++ b/src/main/browser/remote-browser-socks-server.ts
@@ -1,5 +1,7 @@
+import { pipeUpstreamToClient } from './remote-browser-socks-upstream'
 import { createServer, type Server, type Socket } from 'node:net'
 import type { Duplex } from 'node:stream'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 
 const SOCKS_VERSION = 5
 const SOCKS_NO_AUTH = 0
@@ -106,10 +108,13 @@ export class RemoteBrowserSocksServer {
     this.clients.add(socket)
     let phase: 'greeting' | 'request' | 'opening' | 'connected' | 'closed' = 'greeting'
     let buffered = Buffer.alloc(0)
+    const pendingUpstream = new GrowingByteBuffer()
     const timeout = setTimeout(() => socket.destroy(), HANDSHAKE_TIMEOUT_MS)
     const cleanup = (): void => {
       phase = 'closed'
       clearTimeout(timeout)
+      buffered = Buffer.alloc(0)
+      pendingUpstream.clear()
       this.clients.delete(socket)
     }
     const finishFailure = (reply: Uint8Array): void => {
@@ -119,6 +124,7 @@ export class RemoteBrowserSocksServer {
       phase = 'closed'
       clearTimeout(timeout)
       buffered = Buffer.alloc(0)
+      pendingUpstream.clear()
       socket.pause()
       socket.end(reply, () => socket.destroy())
     }
@@ -127,13 +133,15 @@ export class RemoteBrowserSocksServer {
       if (phase === 'closed' || phase === 'connected') {
         return
       }
-      buffered = Buffer.concat([buffered, chunk])
       if (phase === 'opening') {
-        if (buffered.byteLength > MAX_PENDING_UPSTREAM_BYTES) {
+        if (pendingUpstream.byteLength + chunk.byteLength > MAX_PENDING_UPSTREAM_BYTES) {
           fail(1)
+        } else {
+          pendingUpstream.append(chunk)
         }
         return
       }
+      buffered = Buffer.concat([buffered, chunk])
       if (phase === 'greeting' && buffered.byteLength > MAX_HANDSHAKE_BYTES) {
         fail(1)
         return
@@ -181,6 +189,8 @@ export class RemoteBrowserSocksServer {
         return
       }
       phase = 'opening'
+      pendingUpstream.append(buffered)
+      buffered = Buffer.alloc(0)
       void Promise.resolve()
         .then(() => this.open(normalizeListenerWildcard(parsed.target)))
         .then(
@@ -193,9 +203,8 @@ export class RemoteBrowserSocksServer {
             clearTimeout(timeout)
             socket.off('data', onData)
             socket.write(SUCCESS_RESPONSE)
-            if (buffered.byteLength > 0) {
-              upstream.write(buffered)
-              buffered = Buffer.alloc(0)
+            if (pendingUpstream.byteLength > 0) {
+              upstream.write(pendingUpstream.takeBuffer())
             }
             socket.pipe(upstream)
             pipeUpstreamToClient(upstream, socket)
@@ -210,22 +219,6 @@ export class RemoteBrowserSocksServer {
     socket.once('error', cleanup)
     socket.once('close', cleanup)
   }
-}
-
-function pipeUpstreamToClient(upstream: Duplex, socket: Socket): void {
-  upstream.on('data', (chunk: Buffer) => {
-    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
-    const accepted = socket.write(bytes, (error) => {
-      if (!error && 'settleRead' in upstream && typeof upstream.settleRead === 'function') {
-        upstream.settleRead(bytes.byteLength)
-      }
-    })
-    if (!accepted) {
-      upstream.pause()
-    }
-  })
-  socket.on('drain', () => upstream.resume())
-  upstream.once('end', () => socket.end())
 }
 
 function parseSocksRequest(buffer: Uint8Array): SocksRequest | null | undefined {

--- a/src/main/browser/remote-browser-socks-upstream.ts
+++ b/src/main/browser/remote-browser-socks-upstream.ts
@@ -1,0 +1,18 @@
+import type { Socket } from 'node:net'
+import type { Duplex } from 'node:stream'
+
+export function pipeUpstreamToClient(upstream: Duplex, socket: Socket): void {
+  upstream.on('data', (chunk: Buffer) => {
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    const accepted = socket.write(bytes, (error) => {
+      if (!error && 'settleRead' in upstream && typeof upstream.settleRead === 'function') {
+        upstream.settleRead(bytes.byteLength)
+      }
+    })
+    if (!accepted) {
+      upstream.pause()
+    }
+  })
+  socket.on('drain', () => upstream.resume())
+  upstream.once('end', () => socket.end())
+}

--- a/src/shared/growing-byte-buffer.test.ts
+++ b/src/shared/growing-byte-buffer.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it } from 'vitest'
 import { GrowingByteBuffer } from './growing-byte-buffer'
 
 describe('GrowingByteBuffer', () => {
+  it('transfers binary bytes without changing them on clear or reuse', () => {
+    const buffer = new GrowingByteBuffer()
+    const bytes = Buffer.from([0, 255, 128, 10, 0])
+    buffer.append(bytes.subarray(0, 2))
+    buffer.append(bytes.subarray(2))
+    const taken = buffer.takeBuffer()
+    expect(taken).toEqual(bytes)
+    expect(buffer.byteLength).toBe(0)
+    expect(buffer.takeBuffer()).toEqual(Buffer.alloc(0))
+    buffer.append(Buffer.alloc(1024, 7))
+    buffer.clear()
+    expect(taken).toEqual(bytes)
+  })
+
   it('retains 100,000 one-byte fragments in one growable allocation', () => {
     const buffer = new GrowingByteBuffer()
     const expected = Buffer.alloc(100_000)

--- a/src/shared/growing-byte-buffer.ts
+++ b/src/shared/growing-byte-buffer.ts
@@ -93,6 +93,12 @@ export class GrowingByteBuffer {
     return value
   }
 
+  takeBuffer(): Buffer {
+    const value = this.storage.subarray(0, this.length)
+    this.clear()
+    return value
+  }
+
   clear(): void {
     this.storage = Buffer.alloc(0)
     this.length = 0

--- a/src/shared/growing-byte-buffer.ts
+++ b/src/shared/growing-byte-buffer.ts
@@ -93,6 +93,7 @@ export class GrowingByteBuffer {
     return value
   }
 
+  // Returns a view over the released storage, not a copy; the buffer never writes to it again.
   takeBuffer(): Buffer {
     const value = this.storage.subarray(0, this.length)
     this.clear()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## ELI5

When Orca's remote browser opens a website through your remote machine, there is a short gap between "the browser starts sending" and "the tunnel to the remote side is actually ready". Orca holds those early bytes in a waiting room and delivers them the moment the tunnel opens.

The old waiting room was rebuilt from scratch every time a new piece of data showed up: take everything collected so far, copy it, and glue the new piece on the end. That is fine for two or three pieces. It is terrible for a thousand — the first bytes get re-copied a thousand times. A browser that dribbles out 256 KB in small fragments could make Orca shuffle gigabytes of memory for a single connection, which shows up as the app hitching.

Now the waiting room is one buffer that quietly grows as it fills, so each byte is copied about once no matter how many fragments arrive.

Nothing about what the website receives changes. The same bytes arrive in the same order, the 256 KB waiting-room limit is unchanged, a connection that goes one byte over is still refused with the same error, and bytes are still thrown away if the browser hangs up before the tunnel opens.

## What Changed / Why

- 1,024 fragments: zero repeated concatenations, under 3× payload copying; original performs 1,024 concatenations

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 15 tests across 3 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/browser/remote-browser-socks-buffering.test.ts`
- `src/shared/growing-byte-buffer.test.ts`
- `src/main/browser/remote-browser-socks-server.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

