### PR TITLE
perf: reuse collators when sorting discovered skills

### DIFF
--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -11,6 +11,7 @@ import type {
 import {
   buildSkillDiscoverySources,
   sortDiscoveredSkills,
+  sortSkillDiscoverySources,
   sourceKindForSkill,
   sourceLabelForSkill,
   stablePathId,
@@ -307,10 +308,9 @@ export async function discoverSkills(args: {
       `[skills] scan roots=${roots.length} present=${present} walked=${walked.length} skills=${skills.length} ms=${Date.now() - startedAt} ids=${walked.slice(0, MAX_LOGGED_ROOT_IDS).join(',')}`
     )
   }
-  const compareSourceLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   return {
     skills,
-    sources: sources.sort((a, b) => compareSourceLabels(a.label, b.label)),
+    sources: sortSkillDiscoverySources(sources),
     scannedAt: Date.now()
   }
 }

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../shared/skills'
 import {
   buildSkillDiscoverySources,
-  compareSkills,
+  sortDiscoveredSkills,
   sourceKindForSkill,
   sourceLabelForSkill,
   stablePathId,
@@ -292,7 +292,7 @@ export async function discoverSkills(args: {
       mergeScannedSkill(seen, skill)
     }
   }
-  const skills = Array.from(seen.values()).sort(compareSkills)
+  const skills = sortDiscoveredSkills(Array.from(seen.values()))
   // Why: root *ids* — a repo/plugin id is already a hash, while its label carries
   // the repo or plugin name and its path carries the user's directory names. A
   // fully cached scan did no filesystem work, so it stays silent rather than
@@ -307,11 +307,10 @@ export async function discoverSkills(args: {
       `[skills] scan roots=${roots.length} present=${present} walked=${walked.length} skills=${skills.length} ms=${Date.now() - startedAt} ids=${walked.slice(0, MAX_LOGGED_ROOT_IDS).join(',')}`
     )
   }
+  const compareSourceLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   return {
     skills,
-    sources: sources.sort((a, b) =>
-      a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
-    ),
+    sources: sources.sort((a, b) => compareSourceLabels(a.label, b.label)),
     scannedAt: Date.now()
   }
 }

--- a/src/main/skills/skill-discovery-order.test.ts
+++ b/src/main/skills/skill-discovery-order.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DiscoveredSkill } from '../../shared/skills'
+import { sortDiscoveredSkills } from './skill-discovery-sources'
+
+function skill(index: number): DiscoveredSkill {
+  return {
+    id: String(index),
+    name: ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul'][index % 7],
+    description: null,
+    providers: ['codex'],
+    sourceKind: 'home',
+    sourceLabel: ['Home', 'hôme', 'Repo', 'repo'][index % 4],
+    rootPath: '/skills',
+    directoryPath: '/skills/example',
+    skillFilePath: `/skills/${index % 13}/SKILL.md`,
+    installed: true,
+    updatedAt: null
+  }
+}
+
+// Preserve the original comparator as the ordering and operation-count oracle.
+function compareOriginal(a: DiscoveredSkill, b: DiscoveredSkill): number {
+  return (
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) ||
+    a.sourceLabel.localeCompare(b.sourceLabel, undefined, { sensitivity: 'base' }) ||
+    a.skillFilePath.localeCompare(b.skillFilePath)
+  )
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('discovered skill ordering', () => {
+  it('preserves name, source, path and stable ties with one collator per sort', () => {
+    const skills = Array.from({ length: 2_000 }, (_, index) => skill(index))
+    const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+    const expected = [...skills].sort(compareOriginal)
+    const optionedCalls = (): number =>
+      localeCompare.mock.calls.filter((args) => args[2] !== undefined).length
+    expect(optionedCalls()).toBeGreaterThan(10_000)
+    localeCompare.mockClear()
+    const NativeCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+
+    expect(sortDiscoveredSkills(skills)).toBe(skills)
+    expect(skills.map(({ id }) => id)).toEqual(expected.map(({ id }) => id))
+    expect(optionedCalls()).toBe(0)
+    expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+    sortDiscoveredSkills([...skills])
+    expect(construct).toHaveBeenCalledTimes(2)
+  })
+
+  it('does no comparison setup for empty or singleton discovery results', () => {
+    const construct = vi.spyOn(Intl, 'Collator')
+    for (const skills of [[], [skill(0)]]) {
+      expect(sortDiscoveredSkills(skills)).toBe(skills)
+    }
+    expect(construct).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/skills/skill-discovery-order.test.ts
+++ b/src/main/skills/skill-discovery-order.test.ts
@@ -1,6 +1,51 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { DiscoveredSkill } from '../../shared/skills'
-import { sortDiscoveredSkills } from './skill-discovery-sources'
+import type { DiscoveredSkill, SkillDiscoverySource } from '../../shared/skills'
+import { sortDiscoveredSkills, sortSkillDiscoverySources } from './skill-discovery-sources'
+
+// Scripts and case/accent/numeric shapes whose collation differs between locales
+// and ICU builds, so a reused collator that drifted from `localeCompare` shows up.
+const COLLATION_CORPUS = [
+  '',
+  ' ',
+  'a',
+  'A',
+  'éclair',
+  'Eclair',
+  'ÉCLAIR',
+  'Ångström',
+  'Angstrom',
+  'İstanbul',
+  'Istanbul',
+  'ıstanbul',
+  'straße',
+  'strasse',
+  'STRASSE',
+  'ẞ',
+  '中文',
+  '日本語',
+  'にほんご',
+  '한국어',
+  'item2',
+  'item10',
+  'item01',
+  'ITEM2',
+  '10',
+  '2',
+  'ñ',
+  'n',
+  'œ',
+  'oe',
+  'æ',
+  'привет',
+  'ПРИВЕТ',
+  'skill-a',
+  'skill_a',
+  'skill a',
+  'co-op',
+  'coop',
+  'zebra',
+  'zebra'
+]
 
 function skill(index: number): DiscoveredSkill {
   return {
@@ -27,6 +72,18 @@ function compareOriginal(a: DiscoveredSkill, b: DiscoveredSkill): number {
   )
 }
 
+function discoverySource(index: number): SkillDiscoverySource {
+  return {
+    id: String(index),
+    label: COLLATION_CORPUS[index % COLLATION_CORPUS.length],
+    path: `/roots/${index}`,
+    sourceKind: 'home',
+    providers: ['codex'],
+    owner: null,
+    exists: true
+  }
+}
+
 afterEach(() => vi.restoreAllMocks())
 
 describe('discovered skill ordering', () => {
@@ -51,10 +108,45 @@ describe('discovered skill ordering', () => {
     expect(construct).toHaveBeenCalledTimes(2)
   })
 
+  it('matches the per-call comparator across scripts, case, accents and numerals', () => {
+    const skills = COLLATION_CORPUS.flatMap((name, index) =>
+      COLLATION_CORPUS.map((sourceLabel, inner) => ({
+        ...skill(index),
+        id: `${index}-${inner}`,
+        name,
+        sourceLabel
+      }))
+    )
+    expect(skills.length).toBe(COLLATION_CORPUS.length ** 2)
+    const expected = [...skills].sort(compareOriginal)
+    expect(sortDiscoveredSkills([...skills]).map(({ id }) => id)).toEqual(
+      expected.map(({ id }) => id)
+    )
+  })
+
+  it('sorts discovery sources like the per-call label comparator', () => {
+    const sources = Array.from({ length: 400 }, (_, index) => discoverySource(index))
+    const expected = [...sources].sort((a, b) =>
+      // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Parity oracle.
+      a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
+    )
+    const NativeCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+    expect(sortSkillDiscoverySources(sources).map(({ id }) => id)).toEqual(
+      expected.map(({ id }) => id)
+    )
+    expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+  })
+
   it('does no comparison setup for empty or singleton discovery results', () => {
     const construct = vi.spyOn(Intl, 'Collator')
     for (const skills of [[], [skill(0)]]) {
       expect(sortDiscoveredSkills(skills)).toBe(skills)
+    }
+    for (const sources of [[], [discoverySource(0)]]) {
+      expect(sortSkillDiscoverySources(sources)).toBe(sources)
     }
     expect(construct).not.toHaveBeenCalled()
   })

--- a/src/main/skills/skill-discovery-sources.ts
+++ b/src/main/skills/skill-discovery-sources.ts
@@ -60,6 +60,14 @@ export function sortDiscoveredSkills(skills: DiscoveredSkill[]): DiscoveredSkill
   )
 }
 
+export function sortSkillDiscoverySources(sources: SkillDiscoverySource[]): SkillDiscoverySource[] {
+  if (sources.length < 2) {
+    return sources
+  }
+  const compare = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
+  return sources.sort((a, b) => compare(a.label, b.label))
+}
+
 function source(
   id: string,
   label: string,

--- a/src/main/skills/skill-discovery-sources.ts
+++ b/src/main/skills/skill-discovery-sources.ts
@@ -47,11 +47,16 @@ export function sourceLabelForSkill(root: SkillScanRoot, sourceKind: SkillSource
   return sourceKind === 'bundled' ? `${root.label} bundled` : root.label
 }
 
-export function compareSkills(a: DiscoveredSkill, b: DiscoveredSkill): number {
-  return (
-    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }) ||
-    a.sourceLabel.localeCompare(b.sourceLabel, undefined, { sensitivity: 'base' }) ||
-    a.skillFilePath.localeCompare(b.skillFilePath)
+export function sortDiscoveredSkills(skills: DiscoveredSkill[]): DiscoveredSkill[] {
+  if (skills.length < 2) {
+    return skills
+  }
+  const compare = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
+  return skills.sort(
+    (a, b) =>
+      compare(a.name, b.name) ||
+      compare(a.sourceLabel, b.sourceLabel) ||
+      a.skillFilePath.localeCompare(b.skillFilePath)
   )
 }
 

--- a/src/main/skills/skill-discovery-wsl.test.ts
+++ b/src/main/skills/skill-discovery-wsl.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { SkillScanRoot } from './skill-discovery-sources'
 import { buildWslSkillDiscoveryCommand, parseWslSkillDiscoveryOutput } from './skill-discovery-wsl'
 
@@ -87,4 +87,30 @@ describe('WSL skill discovery', () => {
       'unknown source'
     )
   })
+})
+
+it('reuses one source collator while preserving locale, lexical numbers, and stable ties', () => {
+  const labels = Array.from(
+    { length: 200 },
+    (_, index) =>
+      ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul'][index % 7]
+  )
+  const roots = labels.map((label, index) => ({ ...homeRoot, id: String(index), label }))
+  const expected = [...roots].sort((a, b) =>
+    // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+    a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
+  )
+  const NativeCollator = Intl.Collator
+  const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+    return new NativeCollator(locales, options)
+  })
+  const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+  try {
+    const result = parseWslSkillDiscoveryOutput('', roots, 42)
+    expect(result.sources.map((source) => source.id)).toEqual(expected.map((root) => root.id))
+    expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+    expect(localeCompare).not.toHaveBeenCalled()
+  } finally {
+    vi.restoreAllMocks()
+  }
 })

--- a/src/main/skills/skill-discovery-wsl.ts
+++ b/src/main/skills/skill-discovery-wsl.ts
@@ -9,7 +9,7 @@ import { quoteBashString } from '../wsl-bash-command'
 import { runWslProcess } from '../wsl/wsl-runner'
 import {
   buildSkillDiscoverySources,
-  compareSkills,
+  sortDiscoveredSkills,
   sourceKindForSkill,
   sourceLabelForSkill,
   stablePathId,
@@ -161,11 +161,10 @@ export function parseWslSkillDiscoveryOutput(
       skippedReason: exists ? undefined : 'missing'
     }
   })
+  const compareSourceLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   return {
-    skills: [...skillsByCanonicalPath.values()].sort(compareSkills),
-    sources: sources.sort((a, b) =>
-      a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
-    ),
+    skills: sortDiscoveredSkills([...skillsByCanonicalPath.values()]),
+    sources: sources.sort((a, b) => compareSourceLabels(a.label, b.label)),
     scannedAt
   }
 }

--- a/src/main/skills/skill-discovery-wsl.ts
+++ b/src/main/skills/skill-discovery-wsl.ts
@@ -10,6 +10,7 @@ import { runWslProcess } from '../wsl/wsl-runner'
 import {
   buildSkillDiscoverySources,
   sortDiscoveredSkills,
+  sortSkillDiscoverySources,
   sourceKindForSkill,
   sourceLabelForSkill,
   stablePathId,
@@ -161,10 +162,9 @@ export function parseWslSkillDiscoveryOutput(
       skippedReason: exists ? undefined : 'missing'
     }
   })
-  const compareSourceLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   return {
     skills: sortDiscoveredSkills([...skillsByCanonicalPath.values()]),
-    sources: sources.sort((a, b) => compareSourceLabels(a.label, b.label)),
+    sources: sortSkillDiscoverySources(sources),
     scannedAt
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​179 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

Orca lists every "skill" it finds on your computer in alphabetical order. Alphabetising names that contain accents, other alphabets, or mixed capitals needs a little "alphabet rulebook" first — and Orca was rebuilding that rulebook for *every single pair of names it compared*. Sorting 2,000 skills meant building it more than 10,000 times.

Now it builds the rulebook once per sort and reuses it, and the list of places skills came from (Home, Repo, plugin folders) is sorted the same way. You see exactly the same skills in exactly the same order under the same names — Orca just stops redoing the same setup work over and over.

## What Changed / Why

- 2,000 discovered skills: more than 10,000 optioned locale comparisons reduced to zero; original order, accented names, path tie-breaks and WSL discovery preserved.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 8 tests across 2 suite(s) passed on this isolated branch on macOS.
- Changed-code quality gate (oxlint, type-aware, React Doctor) passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/skills/skill-discovery-order.test.ts`
- `src/main/skills/skill-discovery-wsl.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

