### PR TITLE
perf: reuse collators when scanning Warp themes

### DIFF
--- a/src/main/warp-themes/directory-entry-order.ts
+++ b/src/main/warp-themes/directory-entry-order.ts
@@ -1,0 +1,11 @@
+// Warp theme discovery walks user home and app-data trees, so callers filter to
+// the entries they want *before* sorting: same resulting order (the comparator is
+// a total order over a stable sort), without collating the hundreds of unrelated
+// names a home directory holds.
+export function sortDirectoryEntriesByName<T extends { name: string }>(entries: T[]): T[] {
+  if (entries.length < 2) {
+    return entries
+  }
+  const compare = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
+  return entries.sort((left, right) => compare(left.name, right.name))
+}

--- a/src/main/warp-themes/discovery.test.ts
+++ b/src/main/warp-themes/discovery.test.ts
@@ -70,6 +70,51 @@ describe('getWarpThemeDirectories', () => {
     }
   })
 
+  it('collates only the Warp entries in a crowded home directory', () => {
+    platformMock.mockReturnValue('darwin')
+    const noise = Array.from({ length: 500 }, (_, index) => directoryEntry(`project-${index}`))
+    const warpNames = ['.warp-zebra', '.warp-Ångström', '.warp-éclair']
+    readdirSyncMock.mockReturnValue([...noise, ...warpNames.map(directoryEntry)])
+    const expected = [...warpNames].sort((a, b) =>
+      // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+      a.localeCompare(b, undefined, { sensitivity: 'base' })
+    )
+    const NativeCollator = Intl.Collator
+    const compares: string[][] = []
+    vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      const collator = new NativeCollator(locales, options)
+      return {
+        ...collator,
+        compare: (left: string, right: string) => {
+          compares.push([left, right])
+          return collator.compare(left, right)
+        }
+      }
+    })
+    try {
+      expect(getWarpThemeDirectories().slice(6)).toEqual(
+        expected.map((name) => `/Users/alice/${name}/themes`)
+      )
+      // Filtering first keeps the crowd out of ICU: only Warp names are collated.
+      expect(compares.flat().every((name) => name.startsWith('.warp'))).toBe(true)
+      expect(compares.length).toBeLessThan(10)
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('skips a directory scan that finds no dynamic Warp entries', () => {
+    platformMock.mockReturnValue('darwin')
+    readdirSyncMock.mockReturnValue([directoryEntry('Documents'), fileEntry('.warprc')])
+    const construct = vi.spyOn(Intl, 'Collator')
+    try {
+      expect(getWarpThemeDirectories()).toHaveLength(6)
+      expect(construct).not.toHaveBeenCalled()
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
+
   it('returns macOS Warp channel theme directories in stable-first order', () => {
     platformMock.mockReturnValue('darwin')
     expect(getWarpThemeDirectories()).toEqual([

--- a/src/main/warp-themes/discovery.test.ts
+++ b/src/main/warp-themes/discovery.test.ts
@@ -43,6 +43,33 @@ describe('getWarpThemeDirectories', () => {
     readdirSyncMock.mockReturnValue([])
   })
 
+  it('sorts dynamic directories with one collator and preserves locale ties', () => {
+    platformMock.mockReturnValue('darwin')
+    const names = ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul'].map(
+      (name) => `.warp-${name}`
+    )
+    readdirSyncMock.mockReturnValue(names.map(directoryEntry))
+    const expected = [...names].sort((a, b) =>
+      // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+      a.localeCompare(b, undefined, { sensitivity: 'base' })
+    )
+    const NativeCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+    const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+    try {
+      expect(getWarpThemeDirectories().slice(6)).toEqual(
+        expected.map((name) => `/Users/alice/${name}/themes`)
+      )
+      expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+      expect(localeCompare).not.toHaveBeenCalled()
+    } finally {
+      construct.mockRestore()
+      localeCompare.mockRestore()
+    }
+  })
+
   it('returns macOS Warp channel theme directories in stable-first order', () => {
     platformMock.mockReturnValue('darwin')
     expect(getWarpThemeDirectories()).toEqual([

--- a/src/main/warp-themes/discovery.ts
+++ b/src/main/warp-themes/discovery.ts
@@ -18,9 +18,9 @@ const WARP_CHANNELS = [
 
 function readDirectoryEntries(directoryPath: string): Dirent[] {
   try {
-    return readdirSync(directoryPath, { withFileTypes: true }).sort((left, right) =>
-      left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
-    )
+    const entries = readdirSync(directoryPath, { withFileTypes: true })
+    const compareNames = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
+    return entries.sort((left, right) => compareNames(left.name, right.name))
   } catch {
     return []
   }

--- a/src/main/warp-themes/discovery.ts
+++ b/src/main/warp-themes/discovery.ts
@@ -2,6 +2,7 @@ import { readdirSync } from 'node:fs'
 import type { Dirent } from 'node:fs'
 import { homedir, platform } from 'node:os'
 import path from 'node:path'
+import { sortDirectoryEntriesByName } from './directory-entry-order'
 
 const WARP_CHANNELS = [
   { macName: '.warp', linuxName: 'warp-terminal', windowsName: 'Warp' },
@@ -16,11 +17,14 @@ const WARP_CHANNELS = [
   }
 ]
 
-function readDirectoryEntries(directoryPath: string): Dirent[] {
+function readDirectoryEntries(
+  directoryPath: string,
+  include: (entry: Dirent) => boolean
+): Dirent[] {
   try {
-    const entries = readdirSync(directoryPath, { withFileTypes: true })
-    const compareNames = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
-    return entries.sort((left, right) => compareNames(left.name, right.name))
+    return sortDirectoryEntriesByName(
+      readdirSync(directoryPath, { withFileTypes: true }).filter(include)
+    )
   } catch {
     return []
   }
@@ -57,9 +61,10 @@ function getMacWarpThemeDirectories(home: string): string[] {
   return warpThemeDirectoriesFromDataHomes(
     [
       ...WARP_CHANNELS.map((channel) => pathImpl.join(home, channel.macName)),
-      ...readDirectoryEntries(home)
-        .filter((entry) => entry.isDirectory() && entry.name.startsWith('.warp'))
-        .map((entry) => pathImpl.join(home, entry.name))
+      ...readDirectoryEntries(
+        home,
+        (entry) => entry.isDirectory() && entry.name.startsWith('.warp')
+      ).map((entry) => pathImpl.join(home, entry.name))
     ],
     pathImpl
   )
@@ -77,13 +82,11 @@ function getLinuxWarpThemeDirectories(home: string): string[] {
   return warpThemeDirectoriesFromDataHomes(
     [
       ...WARP_CHANNELS.map((channel) => pathImpl.join(dataHome, channel.linuxName)),
-      ...readDirectoryEntries(dataHome)
-        .filter(
-          (entry) =>
-            entry.isDirectory() &&
-            (entry.name === 'warp-terminal' || entry.name.startsWith('warp-'))
-        )
-        .map((entry) => pathImpl.join(dataHome, entry.name))
+      ...readDirectoryEntries(
+        dataHome,
+        (entry) =>
+          entry.isDirectory() && (entry.name === 'warp-terminal' || entry.name.startsWith('warp-'))
+      ).map((entry) => pathImpl.join(dataHome, entry.name))
     ],
     pathImpl
   )
@@ -102,10 +105,7 @@ function getWindowsWarpThemeDirectories(home: string): string[] {
       path.win32
     )
   }
-  for (const entry of readDirectoryEntries(warpAppData)) {
-    if (!entry.isDirectory()) {
-      continue
-    }
+  for (const entry of readDirectoryEntries(warpAppData, (entry) => entry.isDirectory())) {
     addDedupeDirectory(
       directories,
       seenDirectories,

--- a/src/main/warp-themes/manual-warp-theme-files.test.ts
+++ b/src/main/warp-themes/manual-warp-theme-files.test.ts
@@ -1,0 +1,34 @@
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({ BrowserWindow: {}, dialog: {} }))
+
+import { createManualWarpThemeFileCandidates } from './manual-warp-theme-files'
+
+describe('manual theme ordering', () => {
+  it('reuses one collator for labels and path ties without changing the selected order', () => {
+    const names = ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul']
+    const paths = Array.from({ length: 200 }, (_, index) =>
+      path.join('themes', names[index % names.length]!, `${names[(index * 3) % names.length]}.yaml`)
+    )
+    const expected = [...paths].sort(
+      (a, b) =>
+        // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+        path.basename(a).localeCompare(path.basename(b), undefined, { sensitivity: 'base' }) ||
+        // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+        a.localeCompare(b, undefined, { sensitivity: 'base' })
+    )
+    const NativeCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+    const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+    try {
+      expect(createManualWarpThemeFileCandidates(paths).map((file) => file.path)).toEqual(expected)
+      expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+      expect(localeCompare).not.toHaveBeenCalled()
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
+})

--- a/src/main/warp-themes/manual-warp-theme-files.test.ts
+++ b/src/main/warp-themes/manual-warp-theme-files.test.ts
@@ -31,4 +31,17 @@ describe('manual theme ordering', () => {
       vi.restoreAllMocks()
     }
   })
+
+  it('returns a single dialog selection without collating', () => {
+    const construct = vi.spyOn(Intl, 'Collator')
+    try {
+      expect(createManualWarpThemeFileCandidates([]).map((file) => file.path)).toEqual([])
+      expect(createManualWarpThemeFileCandidates(['a/one.yaml']).map((file) => file.path)).toEqual([
+        'a/one.yaml'
+      ])
+      expect(construct).not.toHaveBeenCalled()
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
 })

--- a/src/main/warp-themes/manual-warp-theme-files.ts
+++ b/src/main/warp-themes/manual-warp-theme-files.ts
@@ -5,22 +5,25 @@ import type { WarpThemeImportSkippedFile } from '../../shared/terminal-custom-th
 import { isYamlFile, MAX_THEME_FILES, type ThemeFileCandidate } from './theme-file-scanner'
 
 export function createManualWarpThemeFileCandidates(filePaths: string[]): ThemeFileCandidate[] {
+  const candidates = filePaths.map((filePath) => ({
+    path: filePath,
+    label: path.basename(filePath),
+    contentHashDiscriminator: true
+  }))
+  // Picking a single file is the common dialog outcome and needs no collation.
+  if (candidates.length < 2) {
+    return candidates
+  }
   const compareLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
-  return filePaths
-    .map((filePath) => ({
-      path: filePath,
-      label: path.basename(filePath),
-      contentHashDiscriminator: true
-    }))
-    .sort((left, right) => {
-      const labelComparison = compareLabels(left.label, right.label)
-      if (labelComparison !== 0) {
-        return labelComparison
-      }
-      // Why: manual dialogs can return selections in click order. Sort only in
-      // main so duplicate basenames get deterministic IDs without persisting paths.
-      return compareLabels(left.path, right.path)
-    })
+  return candidates.sort((left, right) => {
+    const labelComparison = compareLabels(left.label, right.label)
+    if (labelComparison !== 0) {
+      return labelComparison
+    }
+    // Why: manual dialogs can return selections in click order. Sort only in
+    // main so duplicate basenames get deterministic IDs without persisting paths.
+    return compareLabels(left.path, right.path)
+  })
 }
 
 export function manualWarpThemeContentDiscriminator(label: string, content: string): string {

--- a/src/main/warp-themes/manual-warp-theme-files.ts
+++ b/src/main/warp-themes/manual-warp-theme-files.ts
@@ -2,14 +2,10 @@ import { createHash } from 'node:crypto'
 import path from 'node:path'
 import { BrowserWindow, dialog, type OpenDialogOptions, type WebContents } from 'electron'
 import type { WarpThemeImportSkippedFile } from '../../shared/terminal-custom-themes'
-import {
-  compareThemeFileLabels,
-  isYamlFile,
-  MAX_THEME_FILES,
-  type ThemeFileCandidate
-} from './theme-file-scanner'
+import { isYamlFile, MAX_THEME_FILES, type ThemeFileCandidate } from './theme-file-scanner'
 
 export function createManualWarpThemeFileCandidates(filePaths: string[]): ThemeFileCandidate[] {
+  const compareLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   return filePaths
     .map((filePath) => ({
       path: filePath,
@@ -17,13 +13,13 @@ export function createManualWarpThemeFileCandidates(filePaths: string[]): ThemeF
       contentHashDiscriminator: true
     }))
     .sort((left, right) => {
-      const labelComparison = compareThemeFileLabels(left, right)
+      const labelComparison = compareLabels(left.label, right.label)
       if (labelComparison !== 0) {
         return labelComparison
       }
       // Why: manual dialogs can return selections in click order. Sort only in
       // main so duplicate basenames get deterministic IDs without persisting paths.
-      return left.path.localeCompare(right.path, undefined, { sensitivity: 'base' })
+      return compareLabels(left.path, right.path)
     })
 }
 

--- a/src/main/warp-themes/theme-file-scanner.test.ts
+++ b/src/main/warp-themes/theme-file-scanner.test.ts
@@ -1,0 +1,35 @@
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { expect, it, vi } from 'vitest'
+import { scanWarpThemeDirectory } from './theme-file-scanner'
+
+it('reuses one collator per directory while preserving capped scan order', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'orca-theme-order-'))
+  const names = ['éclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul']
+  try {
+    await Promise.all(names.map((name) => writeFile(path.join(directory, `${name}.yaml`), '')))
+    await mkdir(path.join(directory, 'nested'))
+    await writeFile(path.join(directory, 'nested', 'theme.yaml'), '')
+    const expected = (await readdir(directory))
+      // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+      .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+      .map((name) => (name === 'nested' ? path.join(name, 'theme.yaml') : name))
+    const NativeCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+    const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+    try {
+      const result = await scanWarpThemeDirectory(directory, undefined, { themeFileLimit: 6 })
+      expect(result.files.map((file) => file.label)).toEqual(expected.slice(0, 6))
+      expect(result.themeFileLimitHit).toBe(true)
+      expect(construct).toHaveBeenCalledTimes(2)
+      expect(localeCompare).not.toHaveBeenCalled()
+    } finally {
+      vi.restoreAllMocks()
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})

--- a/src/main/warp-themes/theme-file-scanner.test.ts
+++ b/src/main/warp-themes/theme-file-scanner.test.ts
@@ -24,7 +24,8 @@ it('reuses one collator per directory while preserving capped scan order', async
       const result = await scanWarpThemeDirectory(directory, undefined, { themeFileLimit: 6 })
       expect(result.files.map((file) => file.label)).toEqual(expected.slice(0, 6))
       expect(result.themeFileLimitHit).toBe(true)
-      expect(construct).toHaveBeenCalledTimes(2)
+      // One directory needs collation; the single-entry nested folder needs none.
+      expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
       expect(localeCompare).not.toHaveBeenCalled()
     } finally {
       vi.restoreAllMocks()

--- a/src/main/warp-themes/theme-file-scanner.ts
+++ b/src/main/warp-themes/theme-file-scanner.ts
@@ -44,17 +44,6 @@ export function isYamlFile(filePath: string): boolean {
   return YAML_EXTENSIONS.has(path.extname(filePath).toLowerCase())
 }
 
-export function compareThemeFileLabels(
-  left: ThemeFileCandidate,
-  right: ThemeFileCandidate
-): number {
-  return left.label.localeCompare(right.label, undefined, { sensitivity: 'base' })
-}
-
-function compareDirentNames(left: Dirent<string>, right: Dirent<string>): number {
-  return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
-}
-
 function isYamlFileEntry(entry: Dirent<string>): boolean {
   return (entry.isFile() || entry.isSymbolicLink()) && isYamlFile(entry.name)
 }
@@ -141,7 +130,8 @@ async function collectYamlFilesFromDirectory(
     return
   }
 
-  const sortedEntries = entries.sort(compareDirentNames)
+  const compareNames = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
+  const sortedEntries = entries.sort((left, right) => compareNames(left.name, right.name))
   if (previewBudgetExpiredWhileReading) {
     return
   }

--- a/src/main/warp-themes/theme-file-scanner.ts
+++ b/src/main/warp-themes/theme-file-scanner.ts
@@ -2,6 +2,7 @@ import { opendir } from 'node:fs/promises'
 import type { Dirent } from 'node:fs'
 import path from 'node:path'
 import type { WarpThemeImportSkippedFile } from '../../shared/terminal-custom-themes'
+import { sortDirectoryEntriesByName } from './directory-entry-order'
 
 export const MAX_THEME_FILES = 200
 const MAX_THEME_DIRECTORY_DEPTH = 3
@@ -130,11 +131,10 @@ async function collectYamlFilesFromDirectory(
     return
   }
 
-  const compareNames = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
-  const sortedEntries = entries.sort((left, right) => compareNames(left.name, right.name))
   if (previewBudgetExpiredWhileReading) {
     return
   }
+  const sortedEntries = sortDirectoryEntriesByName(entries)
   if (entryLimitHit && !budget.entryLimitReported) {
     skippedFiles.push({
       label: relativeDirectory || sourceLabel,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​50 | 0 |

<!-- /orca-pr-loc -->

## ELI5

When you import terminal colour themes from Warp, Orca looks through Warp's folders and lists what it finds in alphabetical order. Alphabetising names with accents or non-English characters needs a little "alphabet rulebook", and Orca was rebuilding that rulebook for every single pair of names it compared.

Now it builds the rulebook once per folder, and only after narrowing the list down to the Warp folders it actually cares about, instead of alphabetising every item in your home directory first. Folders with nothing to sort, and picking one theme file by hand, skip the rulebook entirely. The themes you see and the order they appear in are exactly the same; Orca just does far less busywork getting there.

## What Changed / Why

- One collator per sort replaces repeated locale-option setup in Warp theme discovery and bounded recursive scans; original ordering and tie behavior are preserved.
- Directory entries are filtered to Warp candidates *before* the sort, so a crowded home directory no longer feeds hundreds of unrelated names through ICU. Filtering commutes with a stable total-order sort, so the emitted order is identical.
- Empty/singleton directories, single-file manual picks, and scans abandoned to the preview budget now skip collation entirely.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 13 tests across 3 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/warp-themes/discovery.test.ts`
- `src/main/warp-themes/manual-warp-theme-files.test.ts`
- `src/main/warp-themes/theme-file-scanner.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

