### PR TITLE
fix(e2e): use URL polling for browser tab validation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,14 +104,13 @@ jobs:
     needs: [build, prepare-native-cache]
     if: inputs.test_files == ''
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Fourteen scheduled runs averaged 24.6 minutes per shard; shards 4
-          # and 9 repeatedly hit the 30-minute cap. A 12-way trial still left
-          # one 30-minute shard, so 14 gives the suite enough failure headroom.
+          # Fourteen scheduled runs averaged 24.6 minutes per shard; 35 minutes
+          # leaves setup and failure-artifact headroom after a 29-minute suite.
           - shard: '1/14'
             shard_name: 1-of-14
           - shard: '2/14'

--- a/tests/e2e/browser-tab.spec.ts
+++ b/tests/e2e/browser-tab.spec.ts
@@ -299,10 +299,19 @@ async function expectBrowserTabActive(
 
 async function expectBrowserTabOpenedInBackground(
   page: Parameters<typeof getActiveWorktreeId>[0],
+  worktreeId: string,
   sourceTabId: string,
+  url: string,
   title: string
 ): Promise<void> {
-  const openedTabId = await waitForTabIdByExactTitle(page, title)
+  let openedTabId: string | null = null
+  await expect
+    .poll(async () => {
+      openedTabId =
+        (await getBrowserTabs(page, worktreeId)).find((tab) => tab.url === url)?.id ?? null
+      return openedTabId
+    })
+    .not.toBeNull()
   await expect(page.locator(`[data-browser-overlay-tab-id="${sourceTabId}"]`)).toHaveCSS(
     'opacity',
     '1'
@@ -311,6 +320,9 @@ async function expectBrowserTabOpenedInBackground(
     'opacity',
     '0'
   )
+  await switchToBrowserTab(page, worktreeId, openedTabId!)
+  await expectBrowserTabActive(page, title)
+  await switchToBrowserTab(page, worktreeId, sourceTabId)
 }
 
 async function readBrowserInputValue(
@@ -665,7 +677,13 @@ test.describe('Browser Tab', () => {
       await orcaPage
         .getByRole('menuitem', { name: 'Open Link In Orca Browser', exact: true })
         .click()
-      await expectBrowserTabOpenedInBackground(orcaPage, sourceTab!.id, 'Linked destination')
+      await expectBrowserTabOpenedInBackground(
+        orcaPage,
+        worktreeId,
+        sourceTab!.id,
+        new URL('/destination', linkServer.sourceUrl).href,
+        'Linked destination'
+      )
       await clickBrowserLink(orcaPage, sourceTab!.id, '#frame-link', {
         frameSelector: '#link-frame'
       })
@@ -678,19 +696,33 @@ test.describe('Browser Tab', () => {
       })
       await expectBrowserTabOpenedInBackground(
         orcaPage,
+        worktreeId,
         sourceTab!.id,
+        new URL('/frame-modifier-destination', linkServer.sourceUrl).href,
         'Frame modifier destination'
       )
       await clickBrowserLink(orcaPage, sourceTab!.id, '#frame-middle-link', {
         button: 'middle',
         frameSelector: '#link-frame'
       })
-      await expectBrowserTabOpenedInBackground(orcaPage, sourceTab!.id, 'Frame middle destination')
+      await expectBrowserTabOpenedInBackground(
+        orcaPage,
+        worktreeId,
+        sourceTab!.id,
+        new URL('/frame-middle-destination', linkServer.sourceUrl).href,
+        'Frame middle destination'
+      )
 
       await clickBrowserLink(orcaPage, sourceTab!.id, '#modifier-link', {
         modifiers: process.platform === 'darwin' ? ['meta'] : ['control']
       })
-      await expectBrowserTabOpenedInBackground(orcaPage, sourceTab!.id, 'Modifier destination')
+      await expectBrowserTabOpenedInBackground(
+        orcaPage,
+        worktreeId,
+        sourceTab!.id,
+        new URL('/modifier-destination', linkServer.sourceUrl).href,
+        'Modifier destination'
+      )
 
       await clickBrowserLink(orcaPage, sourceTab!.id, '#frame-shift-middle-link', {
         button: 'middle',
@@ -708,7 +740,13 @@ test.describe('Browser Tab', () => {
       await expect(orcaPage.locator('[data-tab-id]')).toHaveCount(tabCountBeforeCancelledClick)
 
       await clickBrowserLink(orcaPage, sourceTab!.id, '#middle-link', { button: 'middle' })
-      await expectBrowserTabOpenedInBackground(orcaPage, sourceTab!.id, 'Middle-click destination')
+      await expectBrowserTabOpenedInBackground(
+        orcaPage,
+        worktreeId,
+        sourceTab!.id,
+        new URL('/middle-destination', linkServer.sourceUrl).href,
+        'Middle-click destination'
+      )
       await expect
         .poll(() => electronApp.evaluate(({ BaseWindow }) => BaseWindow.getAllWindows().length), {
           timeout: 5_000

--- a/tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts
+++ b/tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts
@@ -27,7 +27,7 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
     const workspace = state.createBrowserTab(
       worktreeId,
       'data:text/html,<title>Remote browser proof</title>',
-      { activate: false, title: 'Remote browser proof' }
+      { activate: true, title: 'Remote browser proof' }
     )
     return { worktreeId, workspaceId: workspace.id }
   })

--- a/tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts
+++ b/tests/e2e/paired-cmd-j-host-qualified-tabs.spec.ts
@@ -24,6 +24,8 @@ test('routes same-id browser and simulator Cmd-J rows to their owning paired hos
     if (!worktreeId) {
       throw new Error('Host has no active worktree for the paired Cmd-J fixture')
     }
+    // Why: only an activated host tab lands in a rendered group, which is what the seeding step
+    // below requires of the mirrored remote group before it will seed the collision rows.
     const workspace = state.createBrowserTab(
       worktreeId,
       'data:text/html,<title>Remote browser proof</title>',

--- a/tests/e2e/paired-remote-browser-link-open-routing.spec.ts
+++ b/tests/e2e/paired-remote-browser-link-open-routing.spec.ts
@@ -121,6 +121,32 @@ async function readRemotePaneUrls(page: Page, worktreeId: string): Promise<strin
   }, worktreeId)
 }
 
+/**
+ * The link opens with `focusOnCreate: false`, and a group only renders its active tab, so the new
+ * background tab never mounts a `remote-browser-pane` — the mirrored handle is the only observable
+ * the client publishes for it. The URL lands a beat after the handle, hence the polled pair.
+ */
+async function expectMirroredRemoteHandles(
+  page: Page,
+  worktreeId: string,
+  expected: { count: number; linkUrl: string }
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const urls = await readRemotePaneUrls(page, worktreeId)
+        return (
+          urls.length === expected.count && urls.some((url) => url.startsWith(expected.linkUrl))
+        )
+      },
+      {
+        timeout: 60_000,
+        message: 'the client never mirrored the link as a remote handle carrying its URL'
+      }
+    )
+    .toBe(true)
+}
+
 /** The client mirrors host browser tabs on its own; this finds the mirrored page for one URL. */
 async function findMirroredPage(
   page: Page,
@@ -299,15 +325,16 @@ test('opens a remote pane link on the pane runtime and refuses to fall back to t
         message: 'the runtime process never held a page for the link'
       })
       .toHaveLength(1)
-    // The cold background page is mirrored as a handle before it publishes its loaded URL.
-    await expect
-      .poll(async () => (await readRemotePaneUrls(page, worktreeId)).length, { timeout: 60_000 })
-      .toBe(remoteHandleCountBeforeOpen + 1)
+    await expectMirroredRemoteHandles(page, worktreeId, {
+      count: remoteHandleCountBeforeOpen + 1,
+      linkUrl: fixture.linkUrl
+    })
     expect(await readLocalBrowserViewUrls(page)).toHaveLength(0)
 
     // Drop every tab except the pane's, so the next act drives the pane it started with against a
     // host that no longer holds the link.
     await closeBrowserTabsExceptPane(page, worktreeId, fixture.paneUrl)
+    // The background link tab never mounted a pane, so its handle going away is the mirror's signal.
     await expect
       .poll(async () => (await readRemotePaneUrls(page, worktreeId)).length, { timeout: 60_000 })
       .toBe(remoteHandleCountBeforeOpen)
@@ -349,9 +376,10 @@ test('opens a remote pane link on the pane runtime and refuses to fall back to t
       .toHaveLength(1)
     expect(await readOwnedPageUrls(client!.app, fixture.linkUrl)).toHaveLength(0)
     expect(await readLocalBrowserViewUrls(page)).toHaveLength(0)
-    await expect
-      .poll(async () => (await readRemotePaneUrls(page, worktreeId)).length, { timeout: 60_000 })
-      .toBe(remoteHandleCountBeforeOpen + 1)
+    await expectMirroredRemoteHandles(page, worktreeId, {
+      count: remoteHandleCountBeforeOpen + 1,
+      linkUrl: fixture.linkUrl
+    })
 
     // The store drops the tab synchronously and only then fires browser.tabClose, so settle the
     // mirror, host inventory, and host guest before act 3 reads them as its own baseline.

--- a/tests/e2e/paired-remote-browser-link-open-routing.spec.ts
+++ b/tests/e2e/paired-remote-browser-link-open-routing.spec.ts
@@ -276,8 +276,7 @@ test('opens a remote pane link on the pane runtime and refuses to fall back to t
     }
     expect(pane.handleEnvironmentId).toBe(environmentId)
     await focusMirroredPage(page, worktreeId, pane.pageId)
-    const paneCountBeforeOpen = await page.getByTestId('remote-browser-pane').count()
-
+    const remoteHandleCountBeforeOpen = (await readRemotePaneUrls(page, worktreeId)).length
     // Act 1: server placement. The user asked for pages to live on the server, so the link must
     // land on the runtime and be streamed back — nothing renders here.
     await pinClientHostedPlacement(page, false)
@@ -300,21 +299,18 @@ test('opens a remote pane link on the pane runtime and refuses to fall back to t
         message: 'the runtime process never held a page for the link'
       })
       .toHaveLength(1)
-    // One more remote pane, and still nothing rendered by this machine's own browser.
-    await expect(page.getByTestId('remote-browser-pane')).toHaveCount(paneCountBeforeOpen + 1, {
-      timeout: 60_000
-    })
-    expect(await readRemotePaneUrls(page, worktreeId)).toContainEqual(
-      expect.stringContaining(fixture.linkUrl)
-    )
+    // The cold background page is mirrored as a handle before it publishes its loaded URL.
+    await expect
+      .poll(async () => (await readRemotePaneUrls(page, worktreeId)).length, { timeout: 60_000 })
+      .toBe(remoteHandleCountBeforeOpen + 1)
     expect(await readLocalBrowserViewUrls(page)).toHaveLength(0)
 
     // Drop every tab except the pane's, so the next act drives the pane it started with against a
     // host that no longer holds the link.
     await closeBrowserTabsExceptPane(page, worktreeId, fixture.paneUrl)
-    await expect(page.getByTestId('remote-browser-pane')).toHaveCount(paneCountBeforeOpen, {
-      timeout: 60_000
-    })
+    await expect
+      .poll(async () => (await readRemotePaneUrls(page, worktreeId)).length, { timeout: 60_000 })
+      .toBe(remoteHandleCountBeforeOpen)
     await expect
       .poll(
         async () =>
@@ -353,7 +349,9 @@ test('opens a remote pane link on the pane runtime and refuses to fall back to t
       .toHaveLength(1)
     expect(await readOwnedPageUrls(client!.app, fixture.linkUrl)).toHaveLength(0)
     expect(await readLocalBrowserViewUrls(page)).toHaveLength(0)
-    await expect(page.getByTestId('remote-browser-pane')).toHaveCount(paneCountBeforeOpen + 1)
+    await expect
+      .poll(async () => (await readRemotePaneUrls(page, worktreeId)).length, { timeout: 60_000 })
+      .toBe(remoteHandleCountBeforeOpen + 1)
 
     // The store drops the tab synchronously and only then fires browser.tabClose, so settle the
     // mirror, host inventory, and host guest before act 3 reads them as its own baseline.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​84 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

## Problem

E2E tests were flaky and timing out due to race conditions in browser tab validation. Tests relied on title matching (`waitForTabIdByExactTitle`) and DOM element counts, which were unreliable when pages loaded slowly or asynchronously.

## Solution

Switch to URL-based polling with `expect.poll()` for more robust tab state detection:
- Replace title-matching assertions with URL validation via `getBrowserTabs().find(tab => tab.url === url)`
- Replace DOM element counting (`toHaveCount()`) with polling remote pane URL counts
- Extend CI timeout from 30 to 35 minutes to provide failure artifact headroom after suite completion
- Add explicit tab-switching verification to ensure opened tabs are actually accessible

## Testing

- Updated `expectBrowserTabOpenedInBackground` to validate via URL polling, then switch to and verify the new tab is active
- Changed paired test assertions to poll `readRemotePaneUrls()` counts instead of `getByTestId('remote-browser-pane').toHaveCount()`
- All call sites updated to pass required `worktreeId` and `url` parameters for URL-based validation

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)