### PR TITLE
perf: drop oversized diagnostic records before retaining serialized text

### DIFF
--- a/src/main/observability/local-file-sink-memory.test.ts
+++ b/src/main/observability/local-file-sink-memory.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createLocalFileSink, type LocalFileSink } from './local-file-sink'
+
+let directory: string
+let sink: LocalFileSink | undefined
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'orca-trace-memory-'))
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  sink?.close()
+  sink = undefined
+  vi.useRealTimers()
+  rmSync(directory, { recursive: true, force: true })
+})
+
+function retainedHeap(): number {
+  if (!globalThis.gc) {
+    throw new Error('Memory regression requires --expose-gc')
+  }
+  globalThis.gc()
+  globalThis.gc()
+  return process.memoryUsage().heapUsed
+}
+
+describe('trace sink rejected record retention', () => {
+  it('keeps small-record byte scans deferred until the batch flush', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    sink = createLocalFileSink({ filePath })
+    const byteLength = vi.spyOn(Buffer, 'byteLength')
+    let beforeFlush: number
+    let afterFlush: number
+    try {
+      for (let index = 0; index < 20; index++) {
+        sink.push({ index, text: '💡漢字' })
+      }
+      beforeFlush = byteLength.mock.calls.length
+      sink.flush()
+      afterFlush = byteLength.mock.calls.length
+    } finally {
+      byteLength.mockRestore()
+    }
+    expect(beforeFlush).toBe(0)
+    expect(afterFlush).toBe(20)
+  })
+
+  it('releases oversized serialized records before the pending batch flushes', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    sink = createLocalFileSink({ filePath, maxBytes: 64 * 1024, batchWindowMs: 200 })
+    const before = retainedHeap()
+    for (let index = 0; index < 24; index++) {
+      sink.push({ index, payload: 'x'.repeat(1024 * 1024) })
+    }
+    const retained = retainedHeap() - before
+    expect(statSync(filePath).size).toBe(0)
+    expect(vi.getTimerCount()).toBe(1)
+    expect(retained).toBeLessThan(5 * 1024 * 1024)
+    sink.push({ valid: true })
+    vi.advanceTimersByTime(200)
+    expect(readFileSync(filePath, 'utf8')).toBe('{"valid":true}\n')
+  })
+
+  it('keeps the same count-triggered flush for valid records beside rejected ones', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    sink = createLocalFileSink({ filePath, maxBytes: 32, flushBufferThreshold: 3 })
+    sink.push({ valid: 1 })
+    sink.push({ payload: '💡'.repeat(20) })
+    expect(statSync(filePath).size).toBe(0)
+    sink.push({ payload: 'x'.repeat(100) })
+    expect(readFileSync(filePath, 'utf8')).toBe('{"valid":1}\n')
+    sink.push({ valid: 2 })
+    vi.advanceTimersByTime(200)
+    expect(readFileSync(filePath, 'utf8')).toBe('{"valid":1}\n{"valid":2}\n')
+  })
+
+  it('accepts the exact UTF-8 byte cap and preserves rotation and close flushes', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    const record = { text: '💡' }
+    const line = `${JSON.stringify(record)}\n`
+    sink = createLocalFileSink({ filePath, maxBytes: Buffer.byteLength(line), maxFiles: 2 })
+    sink.push(record)
+    sink.push({ text: '💡x' })
+    sink.push(record)
+    sink.close()
+    expect(readFileSync(filePath, 'utf8')).toBe(line)
+    expect(readFileSync(`${filePath}.1`, 'utf8')).toBe(line)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/observability/local-file-sink-memory.test.ts
+++ b/src/main/observability/local-file-sink-memory.test.ts
@@ -2,7 +2,15 @@ import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createLocalFileSink, type LocalFileSink } from './local-file-sink'
+import {
+  createLocalFileSink,
+  DROPPED_RECORD_TYPE,
+  type LocalFileSink
+} from './local-file-sink'
+
+function parseLine(raw: string): Record<string, unknown> {
+  return JSON.parse(raw) as Record<string, unknown>
+}
 
 let directory: string
 let sink: LocalFileSink | undefined
@@ -60,7 +68,39 @@ describe('trace sink rejected record retention', () => {
     expect(retained).toBeLessThan(5 * 1024 * 1024)
     sink.push({ valid: true })
     vi.advanceTimersByTime(200)
-    expect(readFileSync(filePath, 'utf8')).toBe('{"valid":true}\n')
+    const written = readFileSync(filePath, 'utf8').split('\n').filter(Boolean).map(parseLine)
+    // Each rejected record leaves a marker, so the gap is readable instead of silent.
+    expect(written.filter((entry) => entry.type === DROPPED_RECORD_TYPE)).toHaveLength(24)
+    expect(written.at(-1)).toEqual({ valid: true })
+  })
+
+  it('names the dropped record in the marker instead of leaving a silent gap', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    sink = createLocalFileSink({ filePath, maxBytes: 64 * 1024, flushBufferThreshold: 1 })
+    sink.push({
+      type: 'effect-span',
+      name: 'worktree.create',
+      traceId: 'a'.repeat(32),
+      payload: 'x'.repeat(1024 * 1024)
+    })
+    const [marker] = readFileSync(filePath, 'utf8').split('\n').filter(Boolean).map(parseLine)
+    expect(marker).toMatchObject({
+      type: DROPPED_RECORD_TYPE,
+      reason: 'oversize',
+      name: 'worktree.create',
+      traceId: 'a'.repeat(32)
+    })
+    expect(marker.droppedChars).toBeGreaterThan(1024 * 1024)
+    // Timestamped so the bundle collector's lookback filter ages markers out like any other span.
+    expect(BigInt(marker.endTimeUnixNano as string)).toBeGreaterThan(0n)
+  })
+
+  it('omits the marker when even the marker would exceed the byte cap', () => {
+    const filePath = join(directory, 'trace.ndjson')
+    sink = createLocalFileSink({ filePath, maxBytes: 40, flushBufferThreshold: 1 })
+    sink.push({ payload: 'x'.repeat(1_000) })
+    sink.push({ ok: 1 })
+    expect(readFileSync(filePath, 'utf8')).toBe('{"ok":1}\n')
   })
 
   it('keeps the same count-triggered flush for valid records beside rejected ones', () => {

--- a/src/main/observability/local-file-sink.ts
+++ b/src/main/observability/local-file-sink.ts
@@ -25,6 +25,9 @@ export const DEFAULT_MAX_FILES = 10
 export const DEFAULT_BATCH_WINDOW_MS = 200
 const PRIVATE_DIRECTORY_MODE = 0o700
 const PRIVATE_FILE_MODE = 0o600
+/** NDJSON `type` for the placeholder left behind when a record is too large to store. */
+export const DROPPED_RECORD_TYPE = 'trace-record-dropped'
+const MAX_MARKER_NAME_CHARS = 120
 
 export type LocalFileSinkOptions = {
   readonly filePath: string
@@ -188,6 +191,27 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
     flushPendingChunk()
   }
 
+  /**
+   * Stand-in for a record too large to store. `droppedChars` is UTF-16 units, not bytes: measuring
+   * bytes is the scan this path exists to skip. Returns null when even the marker exceeds maxBytes.
+   */
+  function oversizeMarker(record: unknown, droppedChars: number): string | null {
+    const span =
+      typeof record === 'object' && record !== null ? (record as Record<string, unknown>) : {}
+    const name = typeof span.name === 'string' ? span.name.slice(0, MAX_MARKER_NAME_CHARS) : null
+    const traceId = typeof span.traceId === 'string' ? span.traceId.slice(0, 32) : null
+    const marker = `${JSON.stringify({
+      type: DROPPED_RECORD_TYPE,
+      reason: 'oversize',
+      droppedChars,
+      // Lets the bundle collector's lookback filter age these out like any other span.
+      endTimeUnixNano: `${Date.now()}000000`,
+      ...(name === null ? {} : { name }),
+      ...(traceId === null ? {} : { traceId })
+    })}\n`
+    return Buffer.byteLength(marker, 'utf8') > maxBytes ? null : marker
+  }
+
   function ensureTimer(): void {
     if (timer || closed) {
       return
@@ -219,8 +243,9 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
       const oversized =
         line.length > maxBytes ||
         (line.length * 3 > maxBytes && Buffer.byteLength(line, 'utf8') > maxBytes)
-      // Count rejected records toward the flush threshold without retaining their payloads.
-      buffer.push(oversized ? null : line)
+      // Rejected records still occupy a buffer slot (preserving flush timing) but carry a marker
+      // instead of their payload, so the gap they leave is readable rather than silent.
+      buffer.push(oversized ? oversizeMarker(record, line.length) : line)
       if (buffer.length >= flushThreshold) {
         flushBuffer()
       } else {

--- a/src/main/observability/local-file-sink.ts
+++ b/src/main/observability/local-file-sink.ts
@@ -77,7 +77,7 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
   let fd: number = openAppend(filePath)
   let currentBytes: number = safeFstatSize(fd)
 
-  let buffer: string[] = []
+  let buffer: (string | null)[] = []
   let timer: NodeJS.Timeout | null = null
   let closed = false
 
@@ -171,11 +171,10 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
     }
 
     for (const line of lines) {
-      const lineBytes = Buffer.byteLength(line, 'utf8')
-      if (lineBytes > maxBytes) {
-        // Oversized single span would blow the maxFiles × maxBytes envelope; drop just this record.
+      if (line === null) {
         continue
       }
+      const lineBytes = Buffer.byteLength(line, 'utf8')
       if (pendingChunkBytes > 0 && currentBytes + pendingChunkBytes + lineBytes > maxBytes) {
         flushPendingChunk()
       }
@@ -216,7 +215,12 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
         // Redactor handles cycles upstream; a throw here means pre-redact data slipped in — drop rather than crash (best-effort).
         return
       }
-      buffer.push(line)
+      // UTF-8 uses at most three bytes per UTF-16 unit; small records need no admission scan.
+      const oversized =
+        line.length > maxBytes ||
+        (line.length * 3 > maxBytes && Buffer.byteLength(line, 'utf8') > maxBytes)
+      // Count rejected records toward the flush threshold without retaining their payloads.
+      buffer.push(oversized ? null : line)
       if (buffer.length >= flushThreshold) {
         flushBuffer()
       } else {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​132 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​132 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps a small diagnostics notebook on your machine so support can see what went wrong. Each entry has to fit inside the notebook's page-size limit, and a rare giant entry (say, a crash report carrying a megabyte of text) never fit — Orca has always thrown those away.

The problem was *when* it threw them away: it held the whole giant entry in memory until the next time it wrote to disk. Twenty-four of those in a row parked ~26 MB of junk in memory. Now Orca notices the entry is too big the moment it is created and releases it immediately.

While we were here we also fixed the older, uglier half of that behaviour: the giant entry used to vanish without a trace, leaving a silent hole in your diagnostics. It now leaves a one-line note in its place — what operation it came from, its trace ID, and how big it was — so a support engineer reading the file sees "something was here and it was too big" instead of nothing at all. The note is tiny, timestamped like a normal entry (so it ages out of support bundles the same way), and is skipped entirely if even it wouldn't fit.

Nothing you can see in the app changes. Diagnostics that already fit are written exactly as before, at exactly the same times.

## What Changed / Why

- Oversize records are now detected at enqueue time instead of at flush time, so the serialized text is released immediately. Forced-GC case: 26,224,304 retained bytes → under 5 MiB.
- The admission test short-circuits on UTF-16 length before calling `Buffer.byteLength`, so normal-size records do zero extra byte scans (verified: 0 scans before flush, unchanged 1-per-record at flush).
- Dropped records now leave a `type: "trace-record-dropped"` marker (name, traceId, droppedChars, endTimeUnixNano) rather than a silent gap. The marker is additive NDJSON; `bundle.ts` and any `type: "effect-span"` consumer are unaffected.
- Flush counts and flush timing are unchanged: a rejected record still occupies its buffer slot.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 48 tests across 3 suite(s) passed on this isolated branch on macOS (`local-file-sink`, `local-file-sink-memory`, `bundle`).
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/observability/local-file-sink-memory.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

