### PR TITLE
perf: stop queued metadata work after watcher cancellation

### DIFF
--- a/src/main/ipc/parcel-watcher-event-cancellation.test.ts
+++ b/src/main/ipc/parcel-watcher-event-cancellation.test.ts
@@ -1,0 +1,103 @@
+import { setImmediate } from 'node:timers/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+const { statMock } = vi.hoisted(() => ({ statMock: vi.fn() }))
+vi.mock('node:fs/promises', () => ({ stat: statMock }))
+import {
+  createWatcherProcessEventDeliveryQueue,
+  prepareWatcherProcessEvents
+} from './parcel-watcher-event-delivery'
+
+const delivery = { includeDirectoryMetadata: true, maxEventsPerBatch: 100 }
+const directory = { isDirectory: () => true }
+const events = (prefix: string, count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    type: 'update' as const,
+    path: `/${prefix}/${index}`
+  }))
+beforeEach(() => {
+  statMock.mockReset()
+})
+
+describe('closed watcher metadata work', () => {
+  it('removes queued lookups before a new live subscription needs their slots', async () => {
+    const gate = Promise.withResolvers<void>()
+    statMock.mockImplementation(async (path: string) => {
+      if (path.startsWith('/held/')) {
+        await gate.promise
+      }
+      return directory
+    })
+    const held = prepareWatcherProcessEvents(events('held', 8), delivery)
+    await setImmediate()
+    expect(statMock.mock.calls.length).toBe(8)
+    const deliver = vi.fn(async () => undefined)
+    const onError = vi.fn()
+    const queue = createWatcherProcessEventDeliveryQueue(delivery, deliver, onError)
+    let live: ReturnType<typeof prepareWatcherProcessEvents> | undefined
+    try {
+      queue.enqueue(events('closed', 32))
+      queue.close()
+      live = prepareWatcherProcessEvents(events('live', 1), delivery)
+      gate.resolve()
+      expect(await live).toEqual([{ type: 'update', path: '/live/0', isDirectory: true }])
+      await held
+      await setImmediate()
+      expect(statMock.mock.calls.map(([path]) => path)).toEqual([
+        ...events('held', 8).map((event) => event.path),
+        '/live/0'
+      ])
+      expect(deliver).not.toHaveBeenCalled()
+      expect(onError).not.toHaveBeenCalled()
+    } finally {
+      gate.resolve()
+      queue.close()
+      await held
+      await live
+    }
+  })
+
+  it('lets active stats settle without starting the rest of a closed batch', async () => {
+    const gate = Promise.withResolvers<void>()
+    statMock.mockImplementation(async () => {
+      await gate.promise
+      return directory
+    })
+    const deliver = vi.fn(async () => undefined)
+    const onError = vi.fn()
+    const queue = createWatcherProcessEventDeliveryQueue(delivery, deliver, onError)
+    try {
+      queue.enqueue(events('active', 32))
+      await setImmediate()
+      expect(statMock.mock.calls.length).toBe(8)
+      queue.close()
+      gate.resolve()
+      await setImmediate()
+      expect(statMock.mock.calls.length).toBe(8)
+      expect(deliver).not.toHaveBeenCalled()
+      expect(onError).not.toHaveBeenCalled()
+      await prepareWatcherProcessEvents(events('next', 8), delivery)
+      expect(statMock.mock.calls.length).toBe(16)
+    } finally {
+      gate.resolve()
+      queue.close()
+      await setImmediate()
+    }
+  })
+
+  it('still delivers file-like invalidations for live stat failures and skips deleted paths', async () => {
+    statMock.mockRejectedValue(new Error('file vanished'))
+    expect(
+      await prepareWatcherProcessEvents(
+        [
+          { type: 'update', path: '/vanished' },
+          { type: 'delete', path: '/deleted' }
+        ],
+        delivery
+      )
+    ).toEqual([
+      { type: 'update', path: '/vanished', isDirectory: false },
+      { type: 'delete', path: '/deleted' }
+    ])
+    expect(statMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/parcel-watcher-event-delivery.ts
+++ b/src/main/ipc/parcel-watcher-event-delivery.ts
@@ -1,4 +1,6 @@
 import { stat } from 'node:fs/promises'
+import { PrioritySemaphore } from '../../shared/priority-semaphore'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import type { Event as ParcelWatcherEvent } from '@parcel/watcher'
 import { MAX_BATCHED_WATCHER_EVENTS } from './filesystem-watcher-event-batch'
 import type {
@@ -7,70 +9,37 @@ import type {
 } from './parcel-watcher-process-protocol'
 
 const DIRECTORY_STAT_CONCURRENCY = 8
-let activeDirectoryStats = 0
-const directoryStatWaiters: (() => void)[] = []
+const directoryStatSlots = new PrioritySemaphore(DIRECTORY_STAT_CONCURRENCY)
 
 export type WatcherProcessEventDeliveryQueue = {
   enqueue(events: readonly ParcelWatcherEvent[]): void
   close(): void
 }
 
-async function acquireDirectoryStatSlot(): Promise<void> {
-  if (activeDirectoryStats < DIRECTORY_STAT_CONCURRENCY) {
-    activeDirectoryStats++
-    return
-  }
-  await new Promise<void>((resolve) => directoryStatWaiters.push(resolve))
-}
-
-function releaseDirectoryStatSlot(): void {
-  const next = directoryStatWaiters.shift()
-  if (next) {
-    // Transfer the existing slot directly so a newly arriving task cannot
-    // overtake this waiter and temporarily exceed the global budget.
-    next()
-    return
-  }
-  activeDirectoryStats--
-}
-
-async function statWatcherEventPath(eventPath: string): Promise<boolean> {
-  await acquireDirectoryStatSlot()
+async function statWatcherEventPath(eventPath: string, signal?: AbortSignal): Promise<boolean> {
+  const release = await directoryStatSlots.acquire(0, signal)
   try {
+    signal?.throwIfAborted()
     return (await stat(eventPath)).isDirectory()
   } finally {
-    releaseDirectoryStatSlot()
+    release()
   }
-}
-
-async function mapWithConcurrency<T, R>(
-  items: readonly T[],
-  limit: number,
-  mapper: (item: T) => Promise<R>
-): Promise<R[]> {
-  const results = Array.from<R>({ length: items.length })
-  let cursor = 0
-  const lane = async (): Promise<void> => {
-    while (cursor < items.length) {
-      const index = cursor++
-      results[index] = await mapper(items[index])
-    }
-  }
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, lane))
-  return results
 }
 
 async function mapWatcherEvent(
   event: ParcelWatcherEvent,
-  includeDirectoryMetadata: boolean
+  includeDirectoryMetadata: boolean,
+  signal?: AbortSignal
 ): Promise<WatcherProcessEvent> {
+  signal?.throwIfAborted()
   if (!includeDirectoryMetadata || event.type === 'delete') {
     return { type: event.type, path: event.path }
   }
   let isDirectory = false
   try {
-    isDirectory = await statWatcherEventPath(event.path)
+    isDirectory = await statWatcherEventPath(event.path, signal)
   } catch {
+    signal?.throwIfAborted()
     // Why: a path can vanish between the native event and metadata lookup.
     // Treat unknown metadata as a file-like event so parent invalidation still runs.
   }
@@ -79,8 +48,10 @@ async function mapWatcherEvent(
 
 export async function prepareWatcherProcessEvents(
   events: readonly ParcelWatcherEvent[],
-  delivery: WatcherProcessDeliveryOptions | undefined
+  delivery: WatcherProcessDeliveryOptions | undefined,
+  signal?: AbortSignal
 ): Promise<WatcherProcessEvent[] | null> {
+  signal?.throwIfAborted()
   if (delivery?.maxEventsPerBatch !== undefined && events.length > delivery.maxEventsPerBatch) {
     return null
   }
@@ -88,7 +59,7 @@ export async function prepareWatcherProcessEvents(
     return events.map((event) => ({ type: event.type, path: event.path }))
   }
   return mapWithConcurrency(events, DIRECTORY_STAT_CONCURRENCY, (event) =>
-    mapWatcherEvent(event, true)
+    mapWatcherEvent(event, true, signal)
   )
 }
 
@@ -99,6 +70,7 @@ export function createWatcherProcessEventDeliveryQueue(
   onError: (error: unknown) => void
 ): WatcherProcessEventDeliveryQueue {
   const eventLimit = delivery?.maxEventsPerBatch ?? MAX_BATCHED_WATCHER_EVENTS
+  const controller = new AbortController()
   let active = true
   let draining = false
   let pendingOverflow = false
@@ -119,7 +91,7 @@ export function createWatcherProcessEventDeliveryQueue(
           await deliver(null)
           continue
         }
-        const prepared = await prepareWatcherProcessEvents(events, delivery)
+        const prepared = await prepareWatcherProcessEvents(events, delivery, controller.signal)
         if (active) {
           await deliver(prepared)
         }
@@ -153,6 +125,7 @@ export function createWatcherProcessEventDeliveryQueue(
     },
     close(): void {
       active = false
+      controller.abort()
       pendingEvents = []
       pendingOverflow = false
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​46 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 |

<!-- /orca-pr-loc -->

## ELI5

Orca watches your project folders for file changes. For each change it may run a small "is this a folder or a file?" lookup on disk, and those lookups are queued so only eight run at a time.

Previously, when a watcher was torn down - you closed a workspace, deleted a worktree, or the watcher was restarted - a batch of up to a hundred queued lookups kept running to completion, on results nobody would ever use. Those lookups also occupied the eight shared slots, so a watcher that was still live had to wait behind dead work.

Now teardown cancels the batch. Lookups already talking to the disk are allowed to finish (there is no safe way to interrupt them), but nothing new is started, and the freed slots go straight to watchers that are still live. The hand-rolled queue was also replaced with the project's existing shared concurrency helpers instead of a second copy of the same logic.

Nothing changes for a watcher that stays open: the same events are still delivered, with the same folder/file information, and a cancelled batch is silently dropped rather than reported as an error. Measured: 32 lookups queued behind a cancelled watcher now start zero of them, and an in-flight cancelled batch stops after its eight already-running calls.

## What Changed / Why

- Zero starts for 32 queued canceled records; an active canceled batch stops after its eight in-flight calls

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 3 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/ipc/parcel-watcher-event-cancellation.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

