### PR TITLE
perf: scope activation inventory to the owning host and workspace

### DIFF
--- a/src/main/ipc/pty-activation-inventory-scope.test.ts
+++ b/src/main/ipc/pty-activation-inventory-scope.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest'
+import { setupPtyIpcSuite } from './pty-ipc-test-harness'
+import { registerSshPtyProvider, getLocalPtyProvider } from './pty'
+import { installPtyInspectIpcHandlers } from './pty/ipc/inspect'
+import { ptyOwnership } from './pty/provider/ownership-state'
+
+vi.mock('electron', () => import('./pty-ipc-mock-registry').then((m) => m.electronModuleMock()))
+vi.mock('fs', () => import('./pty-ipc-mock-registry').then((m) => m.fsModuleMock()))
+vi.mock('node-pty', () => import('./pty-ipc-mock-registry').then((m) => m.nodePtyModuleMock()))
+vi.mock('node:child_process', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).childProcessModuleMock(await importOriginal())
+)
+vi.mock('../opencode/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.openCodeHookServiceModuleMock())
+)
+vi.mock('../mimo/hook-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.mimoHookServiceModuleMock())
+)
+vi.mock('../agent-hooks/server', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.agentHookServerModuleMock())
+)
+vi.mock('../pi/titlebar-extension-service', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.piTitlebarExtensionModuleMock())
+)
+vi.mock('../pwsh', () => import('./pty-ipc-mock-registry').then((m) => m.pwshModuleMock()))
+vi.mock('../wsl', async (importOriginal) =>
+  (await import('./pty-ipc-mock-registry')).wslModuleMock(await importOriginal())
+)
+vi.mock('../telemetry/client', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.telemetryClientModuleMock())
+)
+vi.mock('../telemetry/classify-error', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.classifyErrorModuleMock())
+)
+vi.mock('../cli/linux-terminal-orca-cli-shim', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.linuxCliShimModuleMock())
+)
+vi.mock('../memory/pty-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.ptyRegistryModuleMock())
+)
+vi.mock('../agent-hooks/migration-unsupported-pty-state', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.migrationUnsupportedPtyModuleMock())
+)
+vi.mock('../codex/codex-pane-account-registry', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexPaneAccountRegistryModuleMock())
+)
+vi.mock('../codex/codex-state-db-backfill-recovery', () =>
+  import('./pty-ipc-mock-registry').then((m) => m.codexBackfillRecoveryModuleMock())
+)
+
+describe('scoped activation PTY inventory', () => {
+  const { handlers, installDaemonTestProvider } = setupPtyIpcSuite()
+
+  function install() {
+    const localList = vi.fn(async () => [{ id: 'local', cwd: '/', title: 'shell' }])
+    installDaemonTestProvider({ listProcesses: localList })
+    const remoteLists = Array.from({ length: 50 }, (_, index) => {
+      const list = vi.fn(async () => [
+        {
+          id: `ssh:host-${index}@@pty-1`,
+          cwd: '/remote',
+          title: 'agent',
+          worktreeId: 'repo::/remote'
+        }
+      ])
+      registerSshPtyProvider(`host-${index}`, {
+        ...getLocalPtyProvider(),
+        listProcesses: list,
+        providesAgentSessionOwnerListings: () => true
+      })
+      return list
+    })
+    const startup = vi.fn(async () => {})
+    installPtyInspectIpcHandlers({ getLocalPtyProviderStartupPromise: startup })
+    const list = (scope?: unknown) => handlers.get('pty:listSessions')!(null, scope)
+    return { localList, remoteLists, startup, list }
+  }
+
+  it('queries only the chosen SSH provider and preserves workspace and ownership evidence', async () => {
+    const { list, localList, remoteLists, startup } = install()
+    expect(await list({ connectionId: 'host-17' })).toEqual([
+      {
+        id: 'ssh:host-17@@pty-1',
+        cwd: '/remote',
+        title: 'agent',
+        worktreeId: 'repo::/remote',
+        agentOwnership: 'absent'
+      }
+    ])
+    expect(remoteLists[17]).toHaveBeenCalledOnce()
+    expect(remoteLists.reduce((count, mock) => count + mock.mock.calls.length, 0)).toBe(1)
+    expect(localList).not.toHaveBeenCalled()
+    expect(startup).not.toHaveBeenCalled()
+    expect(ptyOwnership.get('ssh:host-17@@pty-1')).toBe('host-17')
+  })
+
+  it('waits for local startup and never visits remote providers for a local scope', async () => {
+    const { list, localList, remoteLists, startup } = install()
+    let release!: () => void
+    startup.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        })
+    )
+    const pending = list({ connectionId: null })
+    expect(localList).not.toHaveBeenCalled()
+    release()
+    await pending
+    expect(localList).toHaveBeenCalledOnce()
+    expect(remoteLists.every((mock) => mock.mock.calls.length === 0)).toBe(true)
+  })
+
+  it('propagates selected-host failure and never substitutes the local inventory', async () => {
+    const { list, localList, remoteLists } = install()
+    remoteLists[3].mockRejectedValue(new Error('relay unavailable'))
+    await expect(list({ connectionId: 'host-3' })).rejects.toThrow('relay unavailable')
+    await expect(list({ connectionId: 'missing' })).rejects.toThrow('No PTY provider')
+    expect(localList).not.toHaveBeenCalled()
+  })
+
+  it.each([null, {}, { connectionId: '' }, { connectionId: 42 }])(
+    'rejects malformed scope %j before inventory admission',
+    async (scope) => {
+      const { list, localList, remoteLists } = install()
+      await expect(list(scope)).rejects.toThrow('invalid_pty_session_list_scope')
+      expect(localList).not.toHaveBeenCalled()
+      expect(remoteLists.every((mock) => mock.mock.calls.length === 0)).toBe(true)
+    }
+  )
+
+  it('preserves unscoped diagnostic inventory and its remote-error fallback', async () => {
+    const { list, localList, remoteLists } = install()
+    remoteLists[3].mockRejectedValue(new Error('relay unavailable'))
+    expect(await list()).toHaveLength(50)
+    expect(localList).toHaveBeenCalledOnce()
+    expect(remoteLists.every((mock) => mock.mock.calls.length === 1)).toBe(true)
+  })
+})

--- a/src/main/ipc/pty/ipc/inspect.ts
+++ b/src/main/ipc/pty/ipc/inspect.ts
@@ -6,10 +6,11 @@ import {
   PtyProcessListAdmission,
   visitPtyProcessListingsInBatches
 } from '../../../providers/pty-process-list-admission'
-import type { PtyListedSession } from '../../../../shared/pty-listed-session'
+import type { PtyListedSession, PtySessionListScope } from '../../../../shared/pty-listed-session'
 import { ptyOwnership } from '../provider/ownership-state'
 import {
   getProviderForPty,
+  getProvider,
   hasPtyProviderForInspection,
   registeredPtyProviders,
   sshProviders,
@@ -40,37 +41,58 @@ export function installPtyInspectIpcHandlers(deps: {
     )
   }
 
-  ipcMain.handle('pty:listSessions', async (): Promise<PtyListedSession[]> => {
-    const deduped = new Map<string, PtyListedSession>()
-    const admission = new PtyProcessListAdmission()
-    await visitPtyProcessListingsInBatches(
-      registeredPtyProviders(),
-      ({ provider, connectionId }) =>
-        connectionId === null ? provider.listProcesses() : provider.listProcesses().catch(() => []),
-      ({ provider, connectionId }, sessions) => {
-        for (const rawSession of sessions) {
-          const session = admission.admit(rawSession)
-          // Why: kill actions only send back the PTY id, so rebuild ownership while listing to keep reconnect-discovered remote sessions routed to their provider.
-          ptyOwnership.set(session.id, connectionId)
-          deduped.set(session.id, {
-            id: session.id,
-            cwd: session.cwd,
-            title: session.title,
-            // Why: the renderer's binding map is empty during restore, so ownership is the only
-            // liveness evidence it has. Absence is authoritative only from a provider that
-            // serializes claims — otherwise it is 'unknown', never 'absent' (#8459).
-            agentOwnership:
-              (session.agentSessionOwners?.length ?? 0) > 0
-                ? 'present'
-                : provider.providesAgentSessionOwnerListings?.(session.id) === true
-                  ? 'absent'
-                  : 'unknown'
-          })
+  ipcMain.handle(
+    'pty:listSessions',
+    async (_event, scope?: PtySessionListScope): Promise<PtyListedSession[]> => {
+      if (scope !== undefined) {
+        if (
+          !scope ||
+          (scope.connectionId !== null &&
+            (typeof scope.connectionId !== 'string' || !scope.connectionId.trim()))
+        ) {
+          throw new Error('invalid_pty_session_list_scope')
+        }
+        // Select the daemon only after startup has handed off ownership.
+        if (scope.connectionId === null) {
+          await getLocalPtyProviderStartupPromise()
         }
       }
-    )
-    return Array.from(deduped.values())
-  })
+      const deduped = new Map<string, PtyListedSession>()
+      const admission = new PtyProcessListAdmission()
+      await visitPtyProcessListingsInBatches(
+        scope === undefined
+          ? registeredPtyProviders()
+          : [{ provider: getProvider(scope.connectionId), connectionId: scope.connectionId }],
+        ({ provider, connectionId }) =>
+          connectionId === null || scope !== undefined
+            ? provider.listProcesses()
+            : provider.listProcesses().catch(() => []),
+        ({ provider, connectionId }, sessions) => {
+          for (const rawSession of sessions) {
+            const session = admission.admit(rawSession)
+            // Why: kill actions only send back the PTY id, so rebuild ownership while listing to keep reconnect-discovered remote sessions routed to their provider.
+            ptyOwnership.set(session.id, connectionId)
+            deduped.set(session.id, {
+              id: session.id,
+              cwd: session.cwd,
+              title: session.title,
+              ...(session.worktreeId !== undefined ? { worktreeId: session.worktreeId } : {}),
+              // Why: the renderer's binding map is empty during restore, so ownership is the only
+              // liveness evidence it has. Absence is authoritative only from a provider that
+              // serializes claims — otherwise it is 'unknown', never 'absent' (#8459).
+              agentOwnership:
+                (session.agentSessionOwners?.length ?? 0) > 0
+                  ? 'present'
+                  : provider.providesAgentSessionOwnerListings?.(session.id) === true
+                    ? 'absent'
+                    : 'unknown'
+            })
+          }
+        }
+      )
+      return Array.from(deduped.values())
+    }
+  )
 
   ipcMain.handle(
     'pty:getAuthoritativeBufferSnapshotCapabilities',

--- a/src/preload/api/pty-api.ts
+++ b/src/preload/api/pty-api.ts
@@ -4,7 +4,7 @@ import type {
 } from '../../shared/agent-session-resume'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
-import type { PtyListedSession } from '../../shared/pty-listed-session'
+import type { PtyListedSession, PtySessionListScope } from '../../shared/pty-listed-session'
 import type { PtyMainDeliveryDiagnostics } from '../../shared/pty-delivery-diagnostics'
 import type { PtyModelRestoreNeededEvent } from '../../shared/pty-model-restore-marker'
 import type {
@@ -123,7 +123,7 @@ export type PtyApi = {
   confirmForegroundProcess: (id: string) => Promise<string | null>
   getCwd: (id: string) => Promise<string>
   getSize: (id: string) => Promise<{ cols: number; rows: number } | null>
-  listSessions: () => Promise<PtyListedSession[]>
+  listSessions: (scope?: PtySessionListScope) => Promise<PtyListedSession[]>
   getAuthoritativeBufferSnapshotCapabilities?: (
     ids: string[]
   ) => Promise<{ id: string; authoritative: boolean | null }[]>

--- a/src/preload/api/pty-bridge-session-control.ts
+++ b/src/preload/api/pty-bridge-session-control.ts
@@ -7,7 +7,7 @@ import type {
   SleepingAgentLaunchConfig
 } from '../../shared/agent-session-resume'
 import type { TuiAgent } from '../../shared/tui-agent'
-import type { PtyListedSession } from '../../shared/pty-listed-session'
+import type { PtyListedSession, PtySessionListScope } from '../../shared/pty-listed-session'
 import type {
   PtyRendererDeliveryHealthReply,
   PtyRendererDeliveryStateReport
@@ -150,7 +150,8 @@ export const ptySessionControlApi = {
   },
   kill: (id: string, opts?: { keepHistory?: boolean }): Promise<void> =>
     ipcRenderer.invoke('pty:kill', { id, keepHistory: opts?.keepHistory ?? false }),
-  listSessions: (): Promise<PtyListedSession[]> => ipcRenderer.invoke('pty:listSessions'),
+  listSessions: (scope?: PtySessionListScope): Promise<PtyListedSession[]> =>
+    ipcRenderer.invoke('pty:listSessions', scope),
   getAuthoritativeBufferSnapshotCapabilities: (
     ids: string[]
   ): Promise<{ id: string; authoritative: boolean | null }[]> =>

--- a/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
+++ b/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
@@ -309,7 +309,20 @@ describe('activating a folder workspace whose last terminal was closed', () => {
     vi.stubGlobal('window', {
       api: {
         runtime: {
-          call: vi.fn(async () => ({ ok: true, result: { snapshots: [] } }))
+          // A `session.tabs.list` answer must name the scope it listed, or the gate refuses it and
+          // blocks — which would leave the row empty for the wrong reason.
+          call: vi.fn(async () => ({
+            ok: true,
+            result: {
+              worktree: FOLDER_KEY,
+              publicationEpoch: 'epoch-1',
+              snapshotVersion: 1,
+              activeGroupId: null,
+              activeTabId: null,
+              activeTabType: null,
+              tabs: []
+            }
+          }))
         },
         pty: { listSessions: vi.fn(async () => []) }
       }

--- a/src/renderer/src/lib/worktree-activation-pty-inventory.test.ts
+++ b/src/renderer/src/lib/worktree-activation-pty-inventory.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { resolveActivationPtyListScope } from './worktree-activation-pty-inventory'
+
+const worktreeId = 'repo::/workspace'
+
+describe('activation inventory execution scope', () => {
+  it('keeps a known local repo usable before unrelated runtime catalogs hydrate', () => {
+    expect(
+      resolveActivationPtyListScope(
+        {
+          repos: [{ id: 'repo' }],
+          runtimeEnvironments: [],
+          runtimeEnvironmentCatalogHydrated: false,
+          activeWorktreeId: 'other::/remote',
+          activeWorkspaceExecutionHostId: 'ssh:other'
+        },
+        worktreeId
+      )
+    ).toEqual({ connectionId: null })
+  })
+
+  it('does not use the native repo fallback for an explicitly owned worktree', () => {
+    expect(() =>
+      resolveActivationPtyListScope(
+        {
+          repos: [{ id: 'repo' }],
+          worktreesByRepo: { repo: [{ id: worktreeId, repoId: 'repo', hostId: 'runtime:hub' }] }
+        },
+        worktreeId
+      )
+    ).toThrow('provider unavailable')
+  })
+
+  it.each(['local', 'ssh:remote%20box'] as const)('resolves only %s', (hostId) => {
+    expect(
+      resolveActivationPtyListScope(
+        {
+          repos: [{ id: 'repo', executionHostId: hostId }]
+        },
+        worktreeId
+      )
+    ).toEqual({ connectionId: hostId === 'local' ? null : 'remote box' })
+  })
+
+  it('resolves folder workspaces without a Git worktree row', () => {
+    expect(
+      resolveActivationPtyListScope(
+        {
+          folderWorkspaces: [{ id: 'folder', projectGroupId: 'group', connectionId: 'box' }]
+        },
+        folderWorkspaceKey('folder')
+      )
+    ).toEqual({ connectionId: 'box' })
+  })
+
+  it('does not choose a provider for missing or ambiguous ownership', () => {
+    expect(() => resolveActivationPtyListScope({}, worktreeId)).toThrow('provider unavailable')
+    expect(() =>
+      resolveActivationPtyListScope(
+        {
+          repos: [
+            { id: 'repo', executionHostId: 'local' },
+            { id: 'repo', executionHostId: 'ssh:box' }
+          ]
+        },
+        worktreeId
+      )
+    ).toThrow('provider unavailable')
+  })
+
+  it('never routes a paired host or its nested SSH target through client providers', () => {
+    for (const hostId of ['runtime:hub', 'ssh:nested'] as const) {
+      expect(() =>
+        resolveActivationPtyListScope(
+          {
+            worktreesByRepo: {
+              repo: [{ id: worktreeId, repoId: 'repo', hostId, runtimeOwnerEnvironmentId: 'hub' }]
+            }
+          },
+          worktreeId
+        )
+      ).toThrow('provider unavailable')
+    }
+  })
+})

--- a/src/renderer/src/lib/worktree-activation-pty-inventory.test.ts
+++ b/src/renderer/src/lib/worktree-activation-pty-inventory.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
-import { resolveActivationPtyListScope } from './worktree-activation-pty-inventory'
+import {
+  listActivationPtySessions,
+  resolveActivationPtyListScope
+} from './worktree-activation-pty-inventory'
 
 const worktreeId = 'repo::/workspace'
+
+afterEach(() => vi.unstubAllGlobals())
+
+function stubListSessions(impl: (scope?: unknown) => Promise<unknown[]>) {
+  const listSessions = vi.fn(impl)
+  vi.stubGlobal('window', { api: { pty: { listSessions } } })
+  return listSessions
+}
 
 describe('activation inventory execution scope', () => {
   it('keeps a known local repo usable before unrelated runtime catalogs hydrate', () => {
@@ -21,7 +32,7 @@ describe('activation inventory execution scope', () => {
   })
 
   it('does not use the native repo fallback for an explicitly owned worktree', () => {
-    expect(() =>
+    expect(
       resolveActivationPtyListScope(
         {
           repos: [{ id: 'repo' }],
@@ -29,7 +40,7 @@ describe('activation inventory execution scope', () => {
         },
         worktreeId
       )
-    ).toThrow('provider unavailable')
+    ).toBeUndefined()
   })
 
   it.each(['local', 'ssh:remote%20box'] as const)('resolves only %s', (hostId) => {
@@ -55,8 +66,8 @@ describe('activation inventory execution scope', () => {
   })
 
   it('does not choose a provider for missing or ambiguous ownership', () => {
-    expect(() => resolveActivationPtyListScope({}, worktreeId)).toThrow('provider unavailable')
-    expect(() =>
+    expect(resolveActivationPtyListScope({}, worktreeId)).toBeUndefined()
+    expect(
       resolveActivationPtyListScope(
         {
           repos: [
@@ -66,12 +77,12 @@ describe('activation inventory execution scope', () => {
         },
         worktreeId
       )
-    ).toThrow('provider unavailable')
+    ).toBeUndefined()
   })
 
   it('never routes a paired host or its nested SSH target through client providers', () => {
     for (const hostId of ['runtime:hub', 'ssh:nested'] as const) {
-      expect(() =>
+      expect(
         resolveActivationPtyListScope(
           {
             worktreesByRepo: {
@@ -80,7 +91,64 @@ describe('activation inventory execution scope', () => {
           },
           worktreeId
         )
-      ).toThrow('provider unavailable')
+      ).toBeUndefined()
     }
+  })
+})
+
+describe('activation inventory census', () => {
+  it('asks only the owning provider when the client can name one', async () => {
+    const listSessions = stubListSessions(async () => [{ id: 'ssh:box@@pty-1' }])
+    await expect(
+      listActivationPtySessions({ repos: [{ id: 'repo', executionHostId: 'ssh:box' }] }, worktreeId)
+    ).resolves.toEqual([{ id: 'ssh:box@@pty-1' }])
+    expect(listSessions).toHaveBeenCalledExactlyOnceWith({ connectionId: 'box' })
+  })
+
+  // A paired peer's PTYs never enter this client's registry, so refusing to answer would strand the
+  // workspace with no surface at all; the unscoped inventory is the shipped answer for it.
+  it('falls back to the unscoped inventory for a workspace it cannot scope', async () => {
+    const listSessions = stubListSessions(async () => [])
+    await expect(
+      listActivationPtySessions(
+        {
+          worktreesByRepo: {
+            repo: [
+              {
+                id: worktreeId,
+                repoId: 'repo',
+                hostId: 'runtime:hub',
+                runtimeOwnerEnvironmentId: 'hub'
+              }
+            ]
+          }
+        },
+        worktreeId
+      )
+    ).resolves.toEqual([])
+    expect(listSessions).toHaveBeenCalledExactlyOnceWith()
+  })
+
+  it('retries unscoped when the selected relay is detached, and only then', async () => {
+    const detached = stubListSessions(async (scope) => {
+      if (scope) {
+        throw new Error(
+          'Error invoking remote method: Error: No PTY provider for connection "box": the SSH relay for this host is not attached'
+        )
+      }
+      return [{ id: 'local-1' }]
+    })
+    await expect(
+      listActivationPtySessions({ repos: [{ id: 'repo', executionHostId: 'ssh:box' }] }, worktreeId)
+    ).resolves.toEqual([{ id: 'local-1' }])
+    expect(detached.mock.calls).toEqual([[{ connectionId: 'box' }], []])
+
+    const refused = stubListSessions(async () => {
+      throw new Error('relay unavailable')
+    })
+    await expect(
+      listActivationPtySessions({ repos: [{ id: 'repo', executionHostId: 'ssh:box' }] }, worktreeId)
+    ).rejects.toThrow('relay unavailable')
+    expect(refused).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/lib/worktree-activation-pty-inventory.ts
+++ b/src/renderer/src/lib/worktree-activation-pty-inventory.ts
@@ -1,0 +1,49 @@
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import { parseExecutionHostId } from '../../../shared/execution-host'
+import type { PtySessionListScope } from '../../../shared/pty-listed-session'
+import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
+import { getRuntimeEnvironmentIdForWorktree } from './worktree-runtime-owner'
+import {
+  resolveIndexedRepoOwner,
+  resolveIndexedWorktreeOwner
+} from './worktree-runtime-owner-index'
+import {
+  resolveWorktreeOperationRouteResult,
+  type WorktreeOperationRouteState
+} from './worktree-operation-route'
+
+export function resolveActivationPtyListScope(
+  state: WorktreeOperationRouteState,
+  worktreeId: string
+): PtySessionListScope {
+  if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    return { connectionId: null }
+  }
+  const resolution = resolveWorktreeOperationRouteResult(state, worktreeId)
+  if (resolution.kind === 'missing' && !getRuntimeEnvironmentIdForWorktree(state, worktreeId)) {
+    const repo = resolveIndexedRepoOwner(state.repos, getRepoIdFromWorktreeId(worktreeId))
+    const worktree = resolveIndexedWorktreeOwner(state.worktreesByRepo, worktreeId)
+    // A known native repo remains usable while the unrelated runtime catalog hydrates.
+    if (
+      repo.kind === 'resolved' &&
+      !(state.activeWorktreeId === worktreeId && state.activeWorkspaceExecutionHostId) &&
+      (worktree.kind === 'missing' ||
+        (worktree.kind === 'resolved' &&
+          !worktree.owner.hostId &&
+          !worktree.owner.runtimeOwnerEnvironmentId)) &&
+      !repo.owner.connectionId &&
+      (!repo.owner.executionHostId || repo.owner.executionHostId === 'local')
+    ) {
+      return { connectionId: null }
+    }
+  }
+  if (resolution.kind !== 'resolved' || resolution.route.runtimeEnvironmentId) {
+    throw new Error('workspace activation provider unavailable')
+  }
+  const host = parseExecutionHostId(resolution.route.executionHostId)
+  if (!host || host.kind === 'runtime') {
+    // Paired hosts own their activation; a client inventory cannot authorize a writer there.
+    throw new Error('workspace activation provider unavailable')
+  }
+  return { connectionId: host.kind === 'ssh' ? host.targetId : null }
+}

--- a/src/renderer/src/lib/worktree-activation-pty-inventory.ts
+++ b/src/renderer/src/lib/worktree-activation-pty-inventory.ts
@@ -1,6 +1,6 @@
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { parseExecutionHostId } from '../../../shared/execution-host'
-import type { PtySessionListScope } from '../../../shared/pty-listed-session'
+import type { PtyListedSession, PtySessionListScope } from '../../../shared/pty-listed-session'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 import { getRuntimeEnvironmentIdForWorktree } from './worktree-runtime-owner'
 import {
@@ -12,10 +12,23 @@ import {
   type WorktreeOperationRouteState
 } from './worktree-operation-route'
 
+/** Main rejects a scoped list with this prefix when the relay is detached (pty/provider/registry.ts). */
+const DETACHED_PROVIDER_REJECTION = 'No PTY provider for connection'
+
+/**
+ * The one provider that owns this workspace's PTYs, or `undefined` when the client cannot name a
+ * provider it could reach.
+ *
+ * Why `undefined` rather than a throw: a paired-runtime workspace is never in this client's PTY
+ * registry at all, so refusing to answer turns a healthy peer workspace into a `blocked` gate, and
+ * activation then leaves it with no surface whatsoever. Falling back to the unscoped diagnostic
+ * inventory reproduces the shipped answer for exactly those workspaces while the scoped fast path
+ * still covers local, folder and attached-SSH ones.
+ */
 export function resolveActivationPtyListScope(
   state: WorktreeOperationRouteState,
   worktreeId: string
-): PtySessionListScope {
+): PtySessionListScope | undefined {
   if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
     return { connectionId: null }
   }
@@ -38,12 +51,37 @@ export function resolveActivationPtyListScope(
     }
   }
   if (resolution.kind !== 'resolved' || resolution.route.runtimeEnvironmentId) {
-    throw new Error('workspace activation provider unavailable')
+    return undefined
   }
   const host = parseExecutionHostId(resolution.route.executionHostId)
   if (!host || host.kind === 'runtime') {
     // Paired hosts own their activation; a client inventory cannot authorize a writer there.
-    throw new Error('workspace activation provider unavailable')
+    return undefined
   }
   return { connectionId: host.kind === 'ssh' ? host.targetId : null }
+}
+
+/**
+ * Activation's PTY census, scoped to the owning host whenever the client can name one.
+ *
+ * A detached relay is loss of contact, not evidence about the host, and it must not strand the
+ * workspace: fall back to the same unscoped inventory that shipped so the gate still reaches a
+ * verdict. Every other rejection is a real answer from the selected host and propagates.
+ */
+export async function listActivationPtySessions(
+  state: WorktreeOperationRouteState,
+  worktreeId: string
+): Promise<PtyListedSession[]> {
+  const scope = resolveActivationPtyListScope(state, worktreeId)
+  if (!scope) {
+    return window.api.pty.listSessions()
+  }
+  try {
+    return await window.api.pty.listSessions(scope)
+  } catch (error) {
+    if (!String((error as Error)?.message ?? error).includes(DETACHED_PROVIDER_REJECTION)) {
+      throw error
+    }
+    return window.api.pty.listSessions()
+  }
 }

--- a/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
@@ -655,7 +655,10 @@ describe('worktree agent activation gate', () => {
 
   it.each([
     ['ssh:box@@pty-1', WORKTREE_ID],
-    [`${WORKTREE_ID}@@legacy`, '']
+    [`${WORKTREE_ID}@@legacy`, ''],
+    // A relay seeds worktreeId from the host's own ORCA_WORKTREE_ID, so a foreign value must not
+    // hide a session the minted id already claims for this workspace.
+    [`${WORKTREE_ID}@@stale-env`, 'other-repo::/elsewhere']
   ])(
     'adopts %s using workspace metadata or the legacy ID fallback',
     async (livePtyId, worktreeId) => {

--- a/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.test.ts
@@ -653,6 +653,30 @@ describe('worktree agent activation gate', () => {
     await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
   })
 
+  it.each([
+    ['ssh:box@@pty-1', WORKTREE_ID],
+    [`${WORKTREE_ID}@@legacy`, '']
+  ])(
+    'adopts %s using workspace metadata or the legacy ID fallback',
+    async (livePtyId, worktreeId) => {
+      const { deps, createTab, resume } = testDeps({
+        sessions: [{ ...listed(livePtyId), worktreeId }],
+        surfaceOwners: new Map([
+          [livePtyId, { paneKey: `tab-live:${LIVE_LEAF_ID}`, ptyId: livePtyId, tabId: 'tab-live' }]
+        ])
+      })
+      const store = deps.getState()
+      seedExistingSurface(store, { tabId: 'tab-live', leafId: LIVE_LEAF_ID })
+
+      await expect(runWorktreeAgentActivationGate(WORKTREE_ID, deps)).resolves.toBe('adopted')
+      expect(createTab).not.toHaveBeenCalled()
+      expect(resume).not.toHaveBeenCalled()
+      expect(store.terminalLayoutsByTabId['tab-live']?.ptyIdsByLeafId).toEqual({
+        [LIVE_LEAF_ID]: livePtyId
+      })
+    }
+  )
+
   it('adopts a host surface hydrated under a differently spelled workspace id', async () => {
     const livePtyId = `${WORKTREE_ID}@@live-agent`
     const { deps, createTab } = testDeps({

--- a/src/renderer/src/lib/worktree-agent-activation-gate.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.ts
@@ -4,7 +4,7 @@ import { parsePtySessionId, PTY_SESSION_ID_SEPARATOR } from '../../../shared/pty
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { worktreeIdsEqual } from '../../../shared/worktree/id'
-import { resolveActivationPtyListScope } from './worktree-activation-pty-inventory'
+import { listActivationPtySessions } from './worktree-activation-pty-inventory'
 import {
   resumeSleepingAgentSessionsForWorktree,
   type ResumeSleepingAgentSessionsOptions
@@ -195,10 +195,13 @@ export async function runWorktreeAgentActivationGate(
     return 'blocked'
   }
 
-  const liveWorkspaceSessions = sessions.filter((session) =>
-    session.worktreeId
-      ? worktreeIdsEqual(session.worktreeId, worktreeId)
-      : sessionBelongsToWorkspace(session.id, worktreeId)
+  // Why either signal rather than a preference: a relay row's worktreeId can be seeded from the
+  // host's own ORCA_WORKTREE_ID, so it must widen the id-prefix match, never replace it — a session
+  // dropped from this set is a live agent the gate would fork a second writer onto.
+  const liveWorkspaceSessions = sessions.filter(
+    (session) =>
+      (session.worktreeId !== undefined && worktreeIdsEqual(session.worktreeId, worktreeId)) ||
+      sessionBelongsToWorkspace(session.id, worktreeId)
   )
   const liveWorkspacePtyIds = new Set(liveWorkspaceSessions.map((session) => session.id))
   for (const owner of structuredInventory?.ownerBySessionId.values() ?? []) {
@@ -272,9 +275,7 @@ export function gateWorktreeAgentActivation(
     listSessions: () =>
       typeof window === 'undefined'
         ? Promise.resolve([])
-        : window.api.pty.listSessions(
-            resolveActivationPtyListScope(useAppStore.getState(), worktreeId)
-          ),
+        : listActivationPtySessions(useAppStore.getState(), worktreeId),
     listSurfaceOwners: readWorktreeLiveTerminalSurfaceOwners,
     hasStructuredSession: readWorktreeStructuredActivationInventory,
     resume: resumeSleepingAgentSessionsForWorktree

--- a/src/renderer/src/lib/worktree-agent-activation-gate.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-gate.ts
@@ -3,6 +3,8 @@ import type { PtyListedSession } from '../../../shared/pty-listed-session'
 import { parsePtySessionId, PTY_SESSION_ID_SEPARATOR } from '../../../shared/pty-session-id-format'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
+import { worktreeIdsEqual } from '../../../shared/worktree/id'
+import { resolveActivationPtyListScope } from './worktree-activation-pty-inventory'
 import {
   resumeSleepingAgentSessionsForWorktree,
   type ResumeSleepingAgentSessionsOptions
@@ -194,7 +196,9 @@ export async function runWorktreeAgentActivationGate(
   }
 
   const liveWorkspaceSessions = sessions.filter((session) =>
-    sessionBelongsToWorkspace(session.id, worktreeId)
+    session.worktreeId
+      ? worktreeIdsEqual(session.worktreeId, worktreeId)
+      : sessionBelongsToWorkspace(session.id, worktreeId)
   )
   const liveWorkspacePtyIds = new Set(liveWorkspaceSessions.map((session) => session.id))
   for (const owner of structuredInventory?.ownerBySessionId.values() ?? []) {
@@ -266,7 +270,11 @@ export function gateWorktreeAgentActivation(
     getState: () => useAppStore.getState(),
     awaitReady: waitForWorkspaceSessionReady,
     listSessions: () =>
-      typeof window === 'undefined' ? Promise.resolve([]) : window.api.pty.listSessions(),
+      typeof window === 'undefined'
+        ? Promise.resolve([])
+        : window.api.pty.listSessions(
+            resolveActivationPtyListScope(useAppStore.getState(), worktreeId)
+          ),
     listSurfaceOwners: readWorktreeLiveTerminalSurfaceOwners,
     hasStructuredSession: readWorktreeStructuredActivationInventory,
     resume: resumeSleepingAgentSessionsForWorktree

--- a/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
@@ -111,10 +111,12 @@ function stubInventory(args?: {
 } {
   const worktree = makeWorktree()
   const runtimeCall = vi.fn(async ({ method }: { method: string }) => {
-    if (method === 'session.tabs.listAll') {
+    if (method === 'session.tabs.list') {
       return {
         ok: true,
-        result: { snapshots: args?.structured ? [structuredSnapshot(worktree.id)] : [] }
+        result: args?.structured
+          ? structuredSnapshot(worktree.id)
+          : { ...structuredSnapshot(worktree.id), tabs: [] }
       }
     }
     if (method === 'agentSession.handoffStatus') {
@@ -282,14 +284,18 @@ describe('worktree agent activation seam', () => {
   it('does not spawn before a structured chat tab hydrates', async () => {
     const worktree = makeWorktree()
     useAppStore.setState(baseState())
-    const { runtimeCall } = stubInventory({ structured: true })
+    const { runtimeCall, listSessions } = stubInventory({ structured: true })
 
     expect(activateAndRevealWorktree(worktree.id)).toEqual({ primaryTabId: null })
     await waitForWorktreeAgentActivationGateForTests(worktree.id)
 
     expect(useAppStore.getState().unifiedTabsByWorktree[worktree.id] ?? []).toHaveLength(0)
     expect(useAppStore.getState().tabsByWorktree[worktree.id] ?? []).toHaveLength(0)
-    expect(runtimeCall).toHaveBeenCalledWith({ method: 'session.tabs.listAll', params: {} })
+    expect(runtimeCall).toHaveBeenCalledWith({
+      method: 'session.tabs.list',
+      params: { worktree: `id:${worktree.id}` }
+    })
+    expect(listSessions).toHaveBeenCalledExactlyOnceWith({ connectionId: null })
     expect(runtimeCall).toHaveBeenCalledWith({
       method: 'agentSession.handoffStatus',
       params: { sessionId: 'chat-1' }

--- a/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
+++ b/src/renderer/src/lib/worktree-agent-activation-seam.test.ts
@@ -301,4 +301,46 @@ describe('worktree agent activation seam', () => {
       params: { sessionId: 'chat-1' }
     })
   })
+
+  // A peer owns its own PTYs, so this client can never scope an inventory at it. Scoping must not
+  // turn that into a refusal: 'blocked' would also skip the sleeping-agent resume below.
+  it('still reaches a verdict for a paired-runtime-owned workspace', async () => {
+    const worktree = makeWorktree()
+    useAppStore.setState({
+      ...baseState(),
+      worktreesByRepo: { [worktree.repoId]: [{ ...worktree, hostId: 'runtime:env-1' }] }
+    })
+    const { listSessions } = stubInventory()
+
+    expect(activateAndRevealWorktree(worktree.id)).toEqual({ primaryTabId: null })
+    await expect(waitForWorktreeAgentActivationGateForTests(worktree.id)).resolves.toBe('empty')
+    expect(listSessions).toHaveBeenCalledExactlyOnceWith()
+  })
+
+  // Loss of contact with the relay is not evidence about the host, and once the sync has stopped
+  // without an answer the bounded floor in workspace-terminal-host-authority.ts hands seeding back
+  // to this client — a detached provider must not turn that into a permanently empty workspace.
+  it('still seeds a pane when the selected SSH relay is detached', async () => {
+    const worktree = makeWorktree()
+    useAppStore.setState({
+      ...baseState(),
+      worktreesByRepo: { [worktree.repoId]: [{ ...worktree, hostId: 'ssh:box' }] },
+      remoteWorkspaceSyncStatusByTargetId: { box: { phase: 'offline' } as never }
+    })
+    const { listSessions } = stubInventory()
+    listSessions.mockImplementation(async (scope?: unknown) => {
+      if (scope) {
+        throw new Error('No PTY provider for connection "box": the SSH relay is not attached')
+      }
+      return []
+    })
+
+    expect(activateAndRevealWorktree(worktree.id)).toEqual({ primaryTabId: null })
+    await expect(waitForWorktreeAgentActivationGateForTests(worktree.id)).resolves.toBe('empty')
+    expect(listSessions.mock.calls).toEqual([[{ connectionId: 'box' }], []])
+    await vi.waitFor(() =>
+      expect(useAppStore.getState().tabsByWorktree[worktree.id] ?? []).toHaveLength(1)
+    )
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]?.[0]?.ptyId).toBeNull()
+  })
 })

--- a/src/renderer/src/lib/worktree-agent-structured-inventory.test.ts
+++ b/src/renderer/src/lib/worktree-agent-structured-inventory.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readWorktreeStructuredActivationInventory } from './worktree-agent-structured-inventory'
+
+const worktree = 'repo::/workspace'
+afterEach(() => vi.unstubAllGlobals())
+
+function install(result: unknown, ok = true) {
+  const call = vi.fn(async ({ method }: { method: string }) => {
+    if (method === 'agentSession.handoffStatus') {
+      return { ok: true, result: { owner: 'native' } }
+    }
+    return { ok, result }
+  })
+  vi.stubGlobal('window', { api: { runtime: { call } } })
+  return call
+}
+
+describe('structured activation inventory scope', () => {
+  it('requests one workspace snapshot and retains structured handoff evidence', async () => {
+    const call = install({
+      worktree,
+      tabs: [
+        { type: 'terminal', id: 'terminal' },
+        { type: 'agent-session', sessionId: 'agent' }
+      ]
+    })
+    const result = await readWorktreeStructuredActivationInventory(worktree)
+    expect(call.mock.calls[0][0]).toEqual({
+      method: 'session.tabs.list',
+      params: { worktree: `id:${worktree}` }
+    })
+    expect(call).toHaveBeenCalledTimes(2)
+    expect(result && result.ownerBySessionId.get('agent')).toEqual({ owner: 'native' })
+  })
+
+  it('does not request handoffs for a workspace without structured tabs', async () => {
+    const call = install({ worktree, tabs: [] })
+    expect(await readWorktreeStructuredActivationInventory(worktree)).toBe(false)
+    expect(call).toHaveBeenCalledOnce()
+  })
+
+  it.each([null, {}, { worktree: 'other::/workspace', tabs: [] }, { worktree }])(
+    'rejects unreadable or wrong-workspace replies',
+    async (result) => {
+      install(result)
+      await expect(readWorktreeStructuredActivationInventory(worktree)).rejects.toThrow(
+        'scope unavailable'
+      )
+    }
+  )
+
+  it('does not interpret an RPC failure as an empty workspace', async () => {
+    install(null, false)
+    await expect(readWorktreeStructuredActivationInventory(worktree)).rejects.toThrow(
+      'inventory unavailable'
+    )
+  })
+})

--- a/src/renderer/src/lib/worktree-agent-structured-inventory.ts
+++ b/src/renderer/src/lib/worktree-agent-structured-inventory.ts
@@ -1,4 +1,6 @@
 import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
+import { worktreeIdsEqual } from '../../../shared/worktree/id'
 
 export type StructuredActivationInventory = {
   snapshot: RuntimeMobileSessionTabsResult
@@ -17,17 +19,23 @@ export async function readWorktreeStructuredActivationInventory(
   if (typeof window === 'undefined') {
     return false
   }
-  const response = await window.api.runtime.call({ method: 'session.tabs.listAll', params: {} })
+  const response = await window.api.runtime.call({
+    method: 'session.tabs.list',
+    params: { worktree: toRuntimeWorktreeSelector(worktreeId) }
+  })
   if (!response.ok) {
     throw new Error('structured session inventory unavailable')
   }
-  const result = response.result as { snapshots?: RuntimeMobileSessionTabsResult[] }
-  const snapshot = (result.snapshots ?? []).find(
-    (candidate) =>
-      candidate.worktree === worktreeId &&
-      candidate.tabs.some((tab) => tab.type === 'agent-session')
-  )
-  if (!snapshot) {
+  const snapshot = response.result as RuntimeMobileSessionTabsResult
+  if (
+    !snapshot ||
+    typeof snapshot.worktree !== 'string' ||
+    !worktreeIdsEqual(snapshot.worktree, worktreeId) ||
+    !Array.isArray(snapshot.tabs)
+  ) {
+    throw new Error('structured session inventory scope unavailable')
+  }
+  if (!snapshot.tabs.some((tab) => tab.type === 'agent-session')) {
     return false
   }
   const ownerBySessionId = new Map<

--- a/src/renderer/src/lib/worktree-reactivation-tab-forkbomb.test.ts
+++ b/src/renderer/src/lib/worktree-reactivation-tab-forkbomb.test.ts
@@ -4,8 +4,26 @@ import { useAppStore, type AppState } from '@/store'
 import { activateAndRevealWorktree } from './worktree-activation'
 import { waitForWorktreeAgentActivationGateForTests } from './worktree-agent-activation-gate'
 import { makeCreatedAgentWorktree as makeWorktree } from '@/lib/worktree-activation-created-agent-test-state'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
 
 const initialAppStoreState = useAppStore.getState()
+
+/**
+ * A `session.tabs.list` answer holding no agent-session tab. The gate asks the host for one
+ * workspace's snapshot rather than the whole `session.tabs.listAll` inventory, and refuses an answer
+ * that does not name the scope it listed — so the fake host has to report its worktree.
+ */
+function emptySessionTabsSnapshot(worktreeId: string): RuntimeMobileSessionTabsResult {
+  return {
+    worktree: worktreeId,
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: []
+  }
+}
 
 function baseState(worktree: ReturnType<typeof makeWorktree>): Partial<AppState> {
   return {
@@ -120,7 +138,7 @@ describe('STA-1111 worktree reopen does not fork-bomb tabs', () => {
                     hostScope: { hostIds: ['local'], omittedHostIds: [] }
                   }
                 }
-              : { ok: true, result: { snapshots: [] } }
+              : { ok: true, result: emptySessionTabsSnapshot(worktree.id) }
           )
         },
         pty: {
@@ -161,7 +179,7 @@ describe('STA-1111 worktree reopen does not fork-bomb tabs', () => {
     vi.stubGlobal('window', {
       api: {
         runtime: {
-          call: vi.fn(async () => ({ ok: true, result: { snapshots: [] } }))
+          call: vi.fn(async () => ({ ok: true, result: emptySessionTabsSnapshot(worktree.id) }))
         },
         pty: { listSessions: vi.fn(async () => []) }
       }

--- a/src/shared/pty-listed-session.ts
+++ b/src/shared/pty-listed-session.ts
@@ -8,6 +8,9 @@
  */
 export type AgentOwnershipEvidence = 'present' | 'absent' | 'unknown'
 
+/** Omission requests diagnostic inventory; an explicit null selects only the local provider. */
+export type PtySessionListScope = { connectionId: string | null }
+
 /**
  * One row of `pty:listSessions`. Shared so the main handler, both preload surfaces, and the
  * renderer cannot drift on which evidence the UI is allowed to see.
@@ -16,6 +19,7 @@ export type PtyListedSession = {
   id: string
   cwd: string
   title: string
+  worktreeId?: string
   /**
    * Agent ownership as the listing provider could establish it. Destructive actions must treat
    * anything other than `absent` as live work: discarding this distinction is what let Resource


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​464 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​457 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​176 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​45 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 |

<!-- /orca-pr-loc -->

## ELI5

When you click into a workspace that has no terminal open yet, Orca first takes a census: is there already an agent or shell running here that it should reattach to, rather than starting a second one on top of it? Getting that wrong is expensive — two copies of the same agent writing to the same transcript.

The census used to ask *every* machine Orca is connected to, and ask each of them for *every* workspace's tabs, then sift the answers. On a laptop paired with a dozen SSH boxes that is dozens of round trips to answer a question about one folder on one machine. This change works out which machine actually owns the workspace you clicked, asks only that machine, and asks it only about that workspace.

Two rules are kept intact while narrowing the question. First, "we could not reach the machine" is never read as "nothing is running there" — if the owning host can't answer, Orca declines to start a second agent rather than guessing. Second, if Orca cannot work out which machine owns the workspace at all — a workspace hosted on a paired peer, or an SSH box whose connection has dropped — it falls back to the old wide census instead of refusing, so you still get a usable terminal pane instead of an empty window.

A live terminal is now also matched to its workspace by the workspace the host reports for it, *in addition to* the older method of reading it out of the terminal's ID. Either signal counts, so a terminal is never lost from the census because one of the two disagrees.

Tests cover the narrowed census, the reconnect and dropped-relay cases, paired-peer workspaces, folder workspaces, and malformed requests.

## What Changed / Why

- With 50 SSH providers, a selected-host request visits one provider instead of 51; local requests visit no SSH providers. Structured inventory uses the existing single-workspace RPC

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Activation inventory is scoped to the execution host through existing ownership resolution; tests cover scoped inventory, structured-session lookup and fallback behavior. Existing remote RPC formats are retained; optional scope fields are desktop IPC additions.

## Testing

- 60 tests across 5 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/ipc/pty-activation-inventory-scope.test.ts`
- `src/renderer/src/lib/worktree-activation-pty-inventory.test.ts`
- `src/renderer/src/lib/worktree-agent-activation-gate.test.ts`
- `src/renderer/src/lib/worktree-agent-activation-seam.test.ts`
- `src/renderer/src/lib/worktree-agent-structured-inventory.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

