### PR TITLE
Fix sidebar create menu E2E races

### DIFF
--- a/src/renderer/src/components/sidebar/sidebar-header-actions.tsx
+++ b/src/renderer/src/components/sidebar/sidebar-header-actions.tsx
@@ -49,7 +49,9 @@ function SidebarCreateMenu({
   // Why: the tour highlights this trigger, so the handoff has to fire from the
   // menu item rather than the button that now only opens the menu.
   const handleCreateWorkspace = useCallback(() => {
-    openWorkspaceCreationComposerWithTourHandoff()
+    // Why: opening after Radix tears down the menu prevents its focus restoration
+    // from treating the new dialog as an outside interaction.
+    window.setTimeout(openWorkspaceCreationComposerWithTourHandoff, 0)
   }, [])
 
   return (

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -459,7 +459,7 @@ test.describe('Create Workspace', () => {
       // portaled outside the dialog element, so locate it page-wide.
       const suggestion = orcaPage.getByRole('option', { name: linkedWorkspacePattern })
       await expect(suggestion).toBeVisible()
-      await suggestion.click()
+      await orcaPage.keyboard.press('Enter')
 
       const createButton = dialog.getByRole('button', { name: /Create (Workspace|Worktree)/i })
       await expect(createButton).toBeEnabled()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

Fixes the dropdown-to-composer transition race and selects the highlighted smart-input suggestion through its keyboard path.\n\nValidation: ? Verifying lockfile against supply-chain policies (1391 entries)...
Progress: resolved 39, reused 38, downloaded 1, added 38
✓ Lockfile passes supply-chain policies (1391 entries in 1.7s)
Lockfile is up to date, resolution step is skipped
Packages: +39 -28
+++++++++++++++++++++++++++++++++++++++----------------------------
Progress: resolved 39, reused 38, downloaded 1, added 39, done
. postinstall$ node config/scripts/rebuild-native-deps.mjs
. postinstall: [rebuild] Skipping optional Electron rebuild modules: cpu-features
. postinstall: [rebuild] Electron package binary is missing; installing Electron package binary.
. postinstall: [electron-package] Electron package binary is missing; running Electron install.
. postinstall: [electron-package] Published Electron 43.6.0 to /Users/jinjingliang/Documents/projects/orca/.git/orca-cache/electron/43.6.0-darwin-arm64
. postinstall: [electron-package] Repaired Electron path.txt -> Electron.app/Contents/MacOS/Electron
. postinstall: [rebuild] Patched node-pty build artifacts are missing; rebuilding from source.
. postinstall: Done
. prepare$ husky
. prepare: Done

dependencies:
- react-i18next 17.0.8
+ react-i18next 17.0.13

devDependencies:
- dompurify 3.4.13
+ dompurify 3.4.14
- electron 43.4.1
+ electron 43.6.0

Done in 10.2s using pnpm v12.0.0; targeted Electron E2E repeated 3× (9/9).