### PR TITLE
perf: index closed browser page IDs during focus cleanup

### DIFF
--- a/src/renderer/src/store/slices/browser-cleanup-close.test.ts
+++ b/src/renderer/src/store/slices/browser-cleanup-close.test.ts
@@ -55,6 +55,24 @@ function storeWithOnlyBrowserTab(): {
   return { store, workspaceId: workspace.id, pageId }
 }
 
+/** Three browser tabs in a known tab-bar order, so neighbor selection is deterministic. */
+function storeWithThreeBrowserTabs(): {
+  store: ReturnType<typeof createTestStore>
+  ids: string[]
+} {
+  const store = createTestStore()
+  seedStore(store, {
+    worktreesByRepo: { repo1: [makeWorktree({ id: WT, repoId: 'repo1', path: '/path/wt1' })] },
+    activeWorktreeId: WT,
+    activeTabType: 'terminal'
+  })
+  const ids = [0, 1, 2].map(
+    (index) =>
+      store.getState().createBrowserTab(WT, `https://example.test/${index}`, { activate: true }).id
+  )
+  return { store, ids }
+}
+
 describe('closeBrowserTab with reason cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -178,5 +196,31 @@ describe('closeBrowserTab with reason cleanup', () => {
     })
     expect(store.getState().pendingAddressBarFocusByTabId).toEqual(unrelated)
     expect(idReads).toBeLessThan(10_000)
+  })
+
+  // Why: the omit path must not hand every pending-focus selector a fresh record on each close.
+  it('keeps the pending focus records identical when the closed tab had no pending entry', () => {
+    const { store, workspaceId } = storeWithOnlyBrowserTab()
+    const pending = { 'other-tab': true as const }
+    store.setState({
+      pendingAddressBarFocusByPageId: pending,
+      pendingAddressBarFocusByTabId: pending
+    })
+
+    store.getState().closeBrowserTab(workspaceId, { reason: 'cleanup' })
+
+    expect(store.getState().pendingAddressBarFocusByPageId).toBe(pending)
+    expect(store.getState().pendingAddressBarFocusByTabId).toBe(pending)
+  })
+
+  // Why: closing a tab the user is not looking at must never move focus, whatever the
+  // pending-address-bar bookkeeping does around it.
+  it('leaves the active browser tab alone when a background tab closes', () => {
+    const { store, ids } = storeWithThreeBrowserTabs()
+    store.getState().setActiveBrowserTab(ids[0]!)
+
+    store.getState().closeBrowserTab(ids[2]!)
+
+    expect(store.getState().activeBrowserTabIdByWorktree[WT]).toBe(ids[0]!)
   })
 })

--- a/src/renderer/src/store/slices/browser-cleanup-close.test.ts
+++ b/src/renderer/src/store/slices/browser-cleanup-close.test.ts
@@ -151,4 +151,32 @@ describe('closeBrowserTab with reason cleanup', () => {
 
     expect(recordFeatureInteraction).toHaveBeenCalledWith('terminal-tabs')
   })
+  it('clears focus for closed pages without rescanning pages for unrelated focus entries', () => {
+    const { store, workspaceId } = storeWithOnlyBrowserTab()
+    const original = store.getState().browserPagesByWorkspace[workspaceId][0]
+    let idReads = 0
+    const pages = Array.from({ length: 1000 }, (_, index) => ({
+      ...original,
+      get id() {
+        idReads++
+        return `closed-${index}`
+      }
+    }))
+    const unrelated = Object.fromEntries(
+      Array.from({ length: 1000 }, (_, i) => [`other-${i}`, true as const])
+    )
+    store.setState({
+      browserPagesByWorkspace: { [workspaceId]: pages },
+      pendingAddressBarFocusByPageId: { ...unrelated, 'closed-999': true, [workspaceId]: true },
+      pendingAddressBarFocusByTabId: { ...unrelated, 'closed-999': true, [workspaceId]: true }
+    })
+    idReads = 0
+    store.getState().closeBrowserTab(workspaceId, { reason: 'cleanup' })
+    expect(store.getState().pendingAddressBarFocusByPageId).toEqual({
+      ...unrelated,
+      [workspaceId]: true
+    })
+    expect(store.getState().pendingAddressBarFocusByTabId).toEqual(unrelated)
+    expect(idReads).toBeLessThan(10_000)
+  })
 })

--- a/src/renderer/src/store/slices/browser/browser-close-actions.ts
+++ b/src/renderer/src/store/slices/browser/browser-close-actions.ts
@@ -135,17 +135,17 @@ export function createBrowserCloseActions(
         }
         delete nextRecentlyClosedBrowserPagesByWorkspace[tabId]
 
-        const closedPageIds = new Set(closedPages.map((page) => page.id))
-        const nextPendingAddressBarFocusByPageId = Object.fromEntries(
-          Object.entries(s.pendingAddressBarFocusByPageId).filter(
-            ([pageId]) => !closedPageIds.has(pageId)
-          )
+        // Why omit rather than rebuild: only the closed ids can match, so this touches the
+        // closed pages instead of every pending entry and keeps the record identity when none did.
+        const closedPageIds = closedPages.map((page) => page.id)
+        const nextPendingAddressBarFocusByPageId = omitRecordKeys(
+          s.pendingAddressBarFocusByPageId,
+          closedPageIds
         )
-        const nextPendingAddressBarFocusByTabId = Object.fromEntries(
-          Object.entries(s.pendingAddressBarFocusByTabId).filter(
-            ([focusId]) => focusId !== tabId && !closedPageIds.has(focusId)
-          )
-        )
+        const nextPendingAddressBarFocusByTabId = omitRecordKeys(s.pendingAddressBarFocusByTabId, [
+          ...closedPageIds,
+          tabId
+        ])
 
         return {
           browserTabsByWorktree: nextBrowserTabsByWorktree,

--- a/src/renderer/src/store/slices/browser/browser-close-actions.ts
+++ b/src/renderer/src/store/slices/browser/browser-close-actions.ts
@@ -135,14 +135,15 @@ export function createBrowserCloseActions(
         }
         delete nextRecentlyClosedBrowserPagesByWorkspace[tabId]
 
+        const closedPageIds = new Set(closedPages.map((page) => page.id))
         const nextPendingAddressBarFocusByPageId = Object.fromEntries(
           Object.entries(s.pendingAddressBarFocusByPageId).filter(
-            ([pageId]) => !closedPages.some((page) => page.id === pageId)
+            ([pageId]) => !closedPageIds.has(pageId)
           )
         )
         const nextPendingAddressBarFocusByTabId = Object.fromEntries(
           Object.entries(s.pendingAddressBarFocusByTabId).filter(
-            ([focusId]) => focusId !== tabId && !closedPages.some((page) => page.id === focusId)
+            ([focusId]) => focusId !== tabId && !closedPageIds.has(focusId)
           )
         )
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps a small note per page saying "when this page appears, put the cursor in the address bar". When you close a browser tab, those notes have to be thrown away so a future tab does not inherit a stale one.

The old code did that the slow way round: it walked through *every* note that exists anywhere and, for each one, walked through *every* page in the tab being closed to see if they matched. Two long lists multiplied together.

Now it just walks the pages of the tab being closed and deletes their notes directly. Same notes get deleted, no others — and if the closed tab had no notes at all, the note list is now left completely untouched instead of being rebuilt from scratch.

Nothing about what you see changes. In particular, which tab you land on after a close is decided by entirely different code that this PR does not touch: the notes changed here are only read when deciding whether to put the cursor in the address bar of a page that is already on screen.

## What Changed / Why

- `closeBrowserTab` cleared `pendingAddressBarFocusByPageId` / `ByTabId` with a `some()` scan nested inside a full `Object.entries` rebuild — O(pending entries x closed pages) and a fresh object on every close.
- Now uses the existing `omitRecordKeys` helper (already imported in this file for the same job), which is O(closed pages) and returns the original record unchanged when nothing matched.
- 1,000 pages and 1,000 unrelated focus keys: 2,006,000 page ID reads to under 10,000; unrelated entries and page/tab ID collision behaviour preserved.
- Next-focus is untouched: the neighbor pick lives at `browser-close-actions.ts:76-82` and `tab-group-state.ts:84-96`, neither of which is in this diff, and the two records this PR rewrites have no reader in any active-tab computation (only `browser-page-focus-actions.ts:74-75`).

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- `browser-cleanup-close.test.ts` (11 tests) plus `browser.test.ts`, `browser-remote-page-lifecycle.test.ts`, `worktree-removal-maps-leak.test.ts`, `browser-workspace-tab-close.test.ts` and `useIpcEvents-close-routing-browser-pages.test.ts` (47 tests) pass on this branch on macOS.
- Added coverage: the pending-focus records keep their identity when the closed tab had no pending entry, and closing a background tab does not move the active tab.
- Commit hooks passed: oxlint, React Doctor lint and formatting.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/store/slices/browser-cleanup-close.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
