### PR TITLE
perf: prune metadata caches only when an entry can expire

### DIFF
--- a/src/renderer/src/hooks/metadata-request-cache.test.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.test.ts
@@ -183,4 +183,60 @@ describe('metadata-request-cache', () => {
     expect(store.cache.has('repo-0:labels')).toBe(false)
     expect(store.cache.get('repo-500:labels')?.data).toEqual(['label-500'])
   })
+  it('avoids full-cache sweeps on fresh reads but releases all expired payloads when due', async () => {
+    const store = createMetadataRequestStore<number>()
+    for (let i = 0; i < 500; i++) {
+      await loadMetadata(
+        store,
+        String(i),
+        async () => i,
+        () => i
+      )
+    }
+    let reads = 0
+    for (const entry of store.cache.values()) {
+      const fetchedAt = entry.fetchedAt
+      Object.defineProperty(entry, 'fetchedAt', {
+        get: () => {
+          reads++
+          return fetchedAt
+        }
+      })
+    }
+    for (let i = 0; i < 10_000; i++) {
+      expect(getFreshMetadata(store, '499', 1000)?.data).toBe(499)
+    }
+    expect(reads).toBeLessThanOrEqual(10_000)
+    expect(getFreshMetadata(store, '499', 300_498)?.data).toBe(499)
+    expect([...store.cache.keys()]).toEqual(['499'])
+    expect(getFreshMetadata(store, 'missing', 300_499)).toBeNull()
+    expect(store.cache.size).toBe(0)
+  })
+
+  it('reschedules expiry after clear and a fetch whose clock moved backwards', async () => {
+    const store = createMetadataRequestStore<number>()
+    await loadMetadata(
+      store,
+      'later',
+      async () => 1,
+      () => 20_000
+    )
+    await loadMetadata(
+      store,
+      'earlier',
+      async () => 2,
+      () => 10_000
+    )
+    expect(getFreshMetadata(store, 'later', 310_000)?.data).toBe(1)
+    expect(store.cache.has('earlier')).toBe(false)
+    clearMetadataRequestStore(store)
+    await loadMetadata(
+      store,
+      'new',
+      async () => 3,
+      () => 0
+    )
+    expect(getFreshMetadata(store, 'missing', 300_000)).toBeNull()
+    expect(store.cache.size).toBe(0)
+  })
 })

--- a/src/renderer/src/hooks/metadata-request-cache.test.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.test.ts
@@ -183,6 +183,36 @@ describe('metadata-request-cache', () => {
     expect(store.cache.has('repo-0:labels')).toBe(false)
     expect(store.cache.get('repo-500:labels')?.data).toEqual(['label-500'])
   })
+
+  it('gates the next sweep on the oldest survivor of a capacity eviction', async () => {
+    const store = createMetadataRequestStore<string[]>()
+
+    for (let i = 0; i <= 500; i++) {
+      await loadMetadata(
+        store,
+        `repo-${i}:labels`,
+        () => Promise.resolve([`label-${i}`]),
+        () => i
+      )
+    }
+
+    // repo-0 was evicted for capacity, so the gate must point at repo-1's expiry.
+    expect(store.nextCacheExpiryAt).toBe(1 + 300_000)
+    let reads = 0
+    for (const entry of store.cache.values()) {
+      const { fetchedAt } = entry
+      Object.defineProperty(entry, 'fetchedAt', {
+        get: () => {
+          reads++
+          return fetchedAt
+        }
+      })
+    }
+    expect(getFreshMetadata(store, 'repo-500:labels', 300_000)?.data).toEqual(['label-500'])
+    expect(reads).toBe(1)
+    expect(store.cache.size).toBe(500)
+  })
+
   it('avoids full-cache sweeps on fresh reads but releases all expired payloads when due', async () => {
     const store = createMetadataRequestStore<number>()
     for (let i = 0; i < 500; i++) {

--- a/src/renderer/src/hooks/metadata-request-cache.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.ts
@@ -56,6 +56,10 @@ function pruneMetadataCache<T>(
   for (const [key] of sorted.slice(maxEntries)) {
     store.cache.delete(key)
   }
+  // Why: capacity eviction drops the oldest entries, so the gate computed above
+  // points at an expiry that no longer exists and would force a needless sweep.
+  const oldestSurvivor = sorted[maxEntries - 1]?.[1]
+  store.nextCacheExpiryAt = oldestSurvivor ? oldestSurvivor.fetchedAt + METADATA_TTL : Infinity
 }
 
 export function getFreshMetadata<T>(

--- a/src/renderer/src/hooks/metadata-request-cache.ts
+++ b/src/renderer/src/hooks/metadata-request-cache.ts
@@ -14,6 +14,7 @@ export type MetadataRequestStore<T> = {
   cache: Map<string, CachedMetadata<T>>
   inflight: Map<string, Promise<T>>
   failures: Map<string, CachedMetadataFailure>
+  nextCacheExpiryAt: number
   generation: number
 }
 
@@ -22,6 +23,7 @@ export function createMetadataRequestStore<T>(): MetadataRequestStore<T> {
     cache: new Map(),
     inflight: new Map(),
     failures: new Map(),
+    nextCacheExpiryAt: Infinity,
     generation: 0
   }
 }
@@ -29,6 +31,7 @@ export function createMetadataRequestStore<T>(): MetadataRequestStore<T> {
 export function clearMetadataRequestStore<T>(store: MetadataRequestStore<T>): void {
   store.generation += 1
   store.cache.clear()
+  store.nextCacheExpiryAt = Infinity
   store.inflight.clear()
   store.failures.clear()
 }
@@ -38,9 +41,12 @@ function pruneMetadataCache<T>(
   now: number,
   maxEntries = MAX_METADATA_CACHE_ENTRIES
 ): void {
+  store.nextCacheExpiryAt = Infinity
   for (const [key, entry] of store.cache) {
     if (now - entry.fetchedAt >= METADATA_TTL) {
       store.cache.delete(key)
+    } else {
+      store.nextCacheExpiryAt = Math.min(store.nextCacheExpiryAt, entry.fetchedAt + METADATA_TTL)
     }
   }
   if (store.cache.size <= maxEntries) {
@@ -57,7 +63,9 @@ export function getFreshMetadata<T>(
   key: string,
   now = Date.now()
 ): CachedMetadata<T> | null {
-  pruneMetadataCache(store, now)
+  if (now >= store.nextCacheExpiryAt) {
+    pruneMetadataCache(store, now)
+  }
   const entry = store.cache.get(key)
   if (!entry || now - entry.fetchedAt >= METADATA_TTL) {
     return null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

Orca remembers things it fetched from GitHub, GitLab, Linear and Jira - label lists, assignable users, workflow states - for five minutes each, so it does not re-ask on every dialog. Up to 500 of these are kept at a time.

Every single time it looked something up in that memory, it first walked all 500 remembered items to check whether any had aged out. That is a sweep of the whole store to answer a one-item question.

Now the store records a single number: the moment the earliest item is due to expire. A lookup before that moment skips the sweep entirely, because nothing can have expired yet; the first lookup at or after it does the full sweep exactly as before. Over 10,000 lookups against 500 remembered items that is 5,010,000 timestamp comparisons reduced to 10,000.

The five-minute freshness rule is unchanged - stale data is never served, and expired items are still released on schedule. The tests cover the exact expiry boundary, signing out (which wipes the store and resets the timer), and a system clock that jumps backwards. A follow-up commit also fixes the timer after the store is trimmed for being full: it now points at the oldest item that actually survived the trim, instead of at one that was just discarded, which was costing one unnecessary sweep.

## What Changed / Why

- 10,000 hits across 500 entries: 5,010,000 timestamp reads → 10,000; exact TTL cleanup, clear and clock rollback covered

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 11 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/hooks/metadata-request-cache.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

