### PR TITLE
perf: index observable skill installations by locked name

### DIFF
--- a/src/main/skills/skill-update-convergence.test.ts
+++ b/src/main/skills/skill-update-convergence.test.ts
@@ -169,6 +169,16 @@ describe('convergableSkillNames', () => {
     )
     expect([...result]).toEqual(['orca-cli'])
   })
+  // A skill directory can legitimately be named `constructor`, and lock names come
+  // straight off disk, so the snapshot lookup must not walk Object.prototype.
+  it('keeps a skill named after an Object prototype key eligible instead of throwing', () => {
+    for (const name of ['constructor', 'toString', 'hasOwnProperty', '__proto__']) {
+      expect([
+        ...convergableSkillNames([placement(name, 1)], new Map([[name, '091d9bcc']]), {})
+      ]).toEqual([name])
+    }
+  })
+
   it('indexes placements once across many independent locked skills', () => {
     let nameReads = 0
     const installations = Array.from({ length: 1000 }, (_, index) => ({

--- a/src/main/skills/skill-update-convergence.test.ts
+++ b/src/main/skills/skill-update-convergence.test.ts
@@ -169,4 +169,24 @@ describe('convergableSkillNames', () => {
     )
     expect([...result]).toEqual(['orca-cli'])
   })
+  it('indexes placements once across many independent locked skills', () => {
+    let nameReads = 0
+    const installations = Array.from({ length: 1000 }, (_, index) => ({
+      ...placement(`skill-${index}`, index % 2 ? 2 : 1),
+      get name() {
+        nameReads++
+        return `skill-${index}`
+      }
+    }))
+    const locks = new Map(installations.map((entry) => [entry.name, STUB.gitTreeSha!]))
+    const snapshots = Object.fromEntries([...locks.keys()].map((name) => [name, [PRE_STUB, STUB]]))
+    nameReads = 0
+    expect([...convergableSkillNames(installations, locks, snapshots)]).toEqual(
+      [...locks.keys()].filter((_, index) => index % 2 === 1)
+    )
+    expect(nameReads).toBeLessThanOrEqual(1000)
+    nameReads = 0
+    expect([...convergableSkillNames(installations, new Map(), snapshots)]).toEqual([])
+    expect(nameReads).toBe(0)
+  })
 })

--- a/src/main/skills/skill-update-convergence.ts
+++ b/src/main/skills/skill-update-convergence.ts
@@ -28,18 +28,33 @@ export function convergableSkillNames(
   knownSnapshots: Readonly<Record<string, SkillKnownSnapshot[]>>
 ): ReadonlySet<string> {
   const convergable = new Set(globalSkillLocks.keys())
+  if (convergable.size === 0) {
+    return convergable
+  }
+  const observableByName = new Map<string, SkillFreshnessInstallation[]>()
+  for (const entry of installations) {
+    const name = entry.name
+    if (
+      !globalSkillLocks.has(name) ||
+      !SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(entry.topology) ||
+      !entry.observedPackageDigest
+    ) {
+      continue
+    }
+    const entries = observableByName.get(name)
+    if (entries) {
+      entries.push(entry)
+    } else {
+      observableByName.set(name, [entry])
+    }
+  }
   for (const [name, lockHash] of globalSkillLocks) {
     // Why: judged only over the placements the command writes, like eligibility
     // itself. A plugin-cache or repo copy is never the command's to converge, so
     // it must neither gate the name nor rescue it — an unidentifiable cache copy
     // (or one parked at the lock's own revision) would otherwise defeat the gate
     // and re-arm the unwinnable update.
-    const observable = installations.filter(
-      (entry) =>
-        entry.name === name &&
-        SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(entry.topology) &&
-        entry.observedPackageDigest
-    )
+    const observable = observableByName.get(name) ?? []
     if (observable.length === 0) {
       continue
     }

--- a/src/main/skills/skill-update-convergence.ts
+++ b/src/main/skills/skill-update-convergence.ts
@@ -58,7 +58,9 @@ export function convergableSkillNames(
     if (observable.length === 0) {
       continue
     }
-    const revisions = knownSnapshots[name] ?? []
+    // `Object.hasOwn`: names come from an on-disk lock file, so a skill called
+    // `constructor` would otherwise read a function off the prototype and throw.
+    const revisions = (Object.hasOwn(knownSnapshots, name) && knownSnapshots[name]) || []
     // Why: the revision each placement resolved to during observation, not a fresh
     // lookup by whole-folder digest. Identity tolerates files the manifest never
     // listed, so a folder holding an agent CLI's sidecar digests to nothing any


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |

<!-- /orca-pr-loc -->

## ELI5

Orca can offer to update the helper "skills" it installed for you, but it first checks each one for a known trap: if its bookkeeping file claims a version that isn't really on disk, the update command would silently do nothing forever, so Orca hides that offer rather than promising work it can't do.

To run that check it used to re-read the full list of installed copies once for every skill it had bookkeeping for. Now it walks the list a single time and files each copy under its skill name, then looks names up directly. Exactly the same skills are offered or hidden; Orca just stops re-reading the same list over and over.

This also fixes a small latent crash: a skill folder named after a built-in JavaScript word (like `constructor`) used to make the whole check blow up, which would have taken the skill-update list down with it.

## What Changed / Why

- 1,000 locks × 1,000 placements: 1,000,000 name reads → 1,000; unknown/digest/topology eligibility contracts preserved
- Realistic scale is ~9 globally-updatable skills against a few dozen placements, so the win here is small and allocation-shaped; the 1,000x fixture exists to pin the complexity, not to claim latency.
- Snapshot lookup now uses `Object.hasOwn`, so a skill directory named `constructor`/`toString` no longer throws a `TypeError` out of the whole freshness inventory (pre-existing; regression-tested).

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 12 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/skills/skill-update-convergence.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

