### PR TITLE
perf: skip folder-scope construction for separate repository imports

### DIFF
--- a/src/main/project-groups/nested-repo-import.test.ts
+++ b/src/main/project-groups/nested-repo-import.test.ts
@@ -150,6 +150,30 @@ describe('createNestedProjectGroupResolver', () => {
     expect(resolver.getCreatedGroups()).toEqual([])
   })
 
+  it('leaves every separate-import repo ungrouped even when repo paths are supplied', () => {
+    const { groups, createGroup } = createGroupRecorder()
+    const repoPaths = [
+      '/workspace/services/api',
+      '/workspace/services/worker',
+      '/workspace/platform/packages/shared'
+    ]
+    const resolver = createNestedProjectGroupResolver({
+      parentPath: '/workspace',
+      groupName: 'workspace',
+      mode: 'separate',
+      repoPaths,
+      createGroup
+    })
+
+    expect(repoPaths.map((repoPath) => resolver.getGroupForRepo(repoPath))).toEqual([
+      undefined,
+      undefined,
+      undefined
+    ])
+    expect(resolver.getRootGroup()).toBeUndefined()
+    expect(groups).toEqual([])
+  })
+
   it('preserves filesystem root parent paths when creating the root group', () => {
     const groups: ProjectGroup[] = []
     const resolver = createNestedProjectGroupResolver({

--- a/src/main/project-groups/nested-repo-import.test.ts
+++ b/src/main/project-groups/nested-repo-import.test.ts
@@ -138,7 +138,9 @@ describe('createNestedProjectGroupResolver', () => {
       parentPath: '/workspace',
       groupName: 'workspace',
       mode: 'separate',
-      repoPaths: ['/workspace/services/api', '/workspace/services/worker'],
+      get repoPaths(): readonly string[] {
+        throw new Error('separate imports must not build unused folder scopes')
+      },
       createGroup: () => {
         throw new Error('should not create a group')
       }

--- a/src/main/project-groups/nested-repo-import.ts
+++ b/src/main/project-groups/nested-repo-import.ts
@@ -150,10 +150,10 @@ export function createNestedProjectGroupResolver(args: {
   createGroup: (input: CreateGroupInput) => ProjectGroup
 }): NestedProjectGroupResolver {
   const createdGroups: ProjectGroup[] = []
-  const folderScopes = buildSparseFolderScopes({
-    parentPath: args.parentPath,
-    repoPaths: args.repoPaths ?? []
-  })
+  const folderScopes =
+    args.mode === 'group'
+      ? buildSparseFolderScopes({ parentPath: args.parentPath, repoPaths: args.repoPaths ?? [] })
+      : []
   const folderScopesByRelativePath = new Map(
     folderScopes.map((scope) => [scope.relativePath, scope])
   )

--- a/src/main/project-groups/nested-repo-import.ts
+++ b/src/main/project-groups/nested-repo-import.ts
@@ -150,10 +150,12 @@ export function createNestedProjectGroupResolver(args: {
   createGroup: (input: CreateGroupInput) => ProjectGroup
 }): NestedProjectGroupResolver {
   const createdGroups: ProjectGroup[] = []
-  const folderScopes =
-    args.mode === 'group'
-      ? buildSparseFolderScopes({ parentPath: args.parentPath, repoPaths: args.repoPaths ?? [] })
-      : []
+  // Every folder-scope read sits behind ensureRootGroup, so outside group mode the scopes are
+  // unreachable. One flag drives both so the skip can never drift from the guard that justifies it.
+  const createsGroups = args.mode === 'group'
+  const folderScopes = createsGroups
+    ? buildSparseFolderScopes({ parentPath: args.parentPath, repoPaths: args.repoPaths ?? [] })
+    : []
   const folderScopesByRelativePath = new Map(
     folderScopes.map((scope) => [scope.relativePath, scope])
   )
@@ -161,7 +163,7 @@ export function createNestedProjectGroupResolver(args: {
   let rootGroup: ProjectGroup | undefined
 
   const ensureRootGroup = (): ProjectGroup | undefined => {
-    if (args.mode !== 'group') {
+    if (!createsGroups) {
       return undefined
     }
     if (rootGroup) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

When you point Orca at a folder full of repositories, the import dialog gives you two choices: **group them** (Orca builds a sidebar folder tree — "services", "packages" — so related repos sit together) or **import them separately** (every repo lands as its own flat entry, no tree).

Orca was building the folder tree in *both* cases. In the "separately" case it then threw the whole tree away without ever looking at it, because nothing downstream in that mode can create a group.

This change simply doesn't build it. Same imports, same repos, same sidebar — just no wasted work walking every repo path and every one of its parent folders.

What you see is unchanged either way: grouped imports still get the identical folder tree, and separate imports still get flat, ungrouped repos.

## What Changed / Why

- `buildSparseFolderScopes` now runs only in `group` mode. The scopes it produces are read in exactly two places (`getGroupForRepo`, `ensureFolderScopeGroup`), and both return early behind `ensureRootGroup`, which is a no-op outside `group` mode — so in `separate` mode they were provably unreachable.
- The mode test is now a single `createsGroups` flag shared by the skip and by `ensureRootGroup`, so the two can never drift apart if a third import mode is ever added.
- Coverage: a throwing `repoPaths` getter proves the scan never happens in `separate` mode, plus a new test that a `separate` import with a real multi-level repo list still yields no root group, no folder groups, and `undefined` for every repo. Grouped-mode tree shape and the POSIX-root / Windows-drive-root cases are unchanged and still pass.
- Both callers (`nested-repo-import-handler`, `loaded-state-adaptation`) pass `mode` as a fixed literal, so the construction-time read cannot disagree with later calls.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 14 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/project-groups/nested-repo-import.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

