### PR TITLE
perf: index terminal neighbor order and remaining membership

### DIFF
--- a/src/shared/workspace-session-terminal-tab-close.test.ts
+++ b/src/shared/workspace-session-terminal-tab-close.test.ts
@@ -230,4 +230,35 @@ describe('closeTerminalTabInWorkspaceSession', () => {
     expect(current.tabsByWorktree[WORKTREE_ID]).toEqual([])
     expect(current.terminalLayoutsByTabId).toEqual({})
   })
+  it('selects the previous neighbor in linear work when closing the last of many tabs', () => {
+    let reads = 0
+    const ids = Array.from({ length: 1000 }, (_, i) => `tab-${i}`)
+    const tabOrder = [...ids, 'terminal-1']
+    for (let i = 0; i < tabOrder.length; i++) {
+      const value = tabOrder[i]
+      Object.defineProperty(tabOrder, i, {
+        get: () => {
+          reads++
+          return value
+        }
+      })
+    }
+    const initial = session()
+    initial.tabGroups![WORKTREE_ID][0].tabOrder = tabOrder
+    initial.tabGroups![WORKTREE_ID][0].recentTabIds = []
+    const result = closeTerminalTabInWorkspaceSession(initial, WORKTREE_ID, 'terminal-1')
+    expect(result.session.tabGroups![WORKTREE_ID][0].activeTabId).toBe('tab-999')
+    expect(result.session.tabGroups![WORKTREE_ID][0].tabOrder).toEqual(ids)
+    expect(reads).toBeLessThan(6000)
+  })
+
+  it('preserves first-occurrence neighbor semantics for duplicate legacy order entries', () => {
+    const initial = session()
+    initial.tabGroups![WORKTREE_ID][0].tabOrder = ['a', 'terminal-1', 'a', 'b']
+    initial.tabGroups![WORKTREE_ID][0].recentTabIds = ['absent', 'terminal-1']
+    const result = closeTerminalTabInWorkspaceSession(initial, WORKTREE_ID, 'terminal-1')
+    expect(result.session.tabGroups![WORKTREE_ID][0].activeTabId).toBe('b')
+    expect(result.session.tabGroups![WORKTREE_ID][0].tabOrder).toEqual(['a', 'a', 'b'])
+    expect(result.session.tabGroups![WORKTREE_ID][0].recentTabIds).toEqual([])
+  })
 })

--- a/src/shared/workspace-session-terminal-tab-close.test.ts
+++ b/src/shared/workspace-session-terminal-tab-close.test.ts
@@ -261,4 +261,87 @@ describe('closeTerminalTabInWorkspaceSession', () => {
     expect(result.session.tabGroups![WORKTREE_ID][0].tabOrder).toEqual(['a', 'a', 'b'])
     expect(result.session.tabGroups![WORKTREE_ID][0].recentTabIds).toEqual([])
   })
+  // Preserve the pre-index selection as an independent oracle: which tab takes focus after a
+  // close is directly user-visible, so the indexed form must agree on every shape.
+  it('matches the pre-index next-active selection across random orders, duplicates and MRU stacks', () => {
+    function referenceNextActive(
+      tabOrder: readonly string[],
+      recentTabIds: readonly string[],
+      closingId: string
+    ): string | null {
+      const remaining = tabOrder.filter((id) => id !== closingId)
+      for (let index = recentTabIds.length - 1; index >= 0; index -= 1) {
+        const id = recentTabIds[index]!
+        if (remaining.includes(id)) {
+          return id
+        }
+      }
+      const closingIndex = tabOrder.indexOf(closingId)
+      return remaining.find((id) => tabOrder.indexOf(id) > closingIndex) ?? remaining.at(-1) ?? null
+    }
+
+    let seed = 987654
+    const random = (limit: number): number => {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+      return seed % limit
+    }
+    const pool = ['a', 'b', 'c', 'd', 'terminal-1']
+    for (let sample = 0; sample < 500; sample++) {
+      const tabOrder = Array.from({ length: 1 + random(6) }, () => pool[random(pool.length)]!)
+      // Keep the closed tab present and at least one survivor, or the group is dropped entirely.
+      tabOrder.splice(random(tabOrder.length + 1), 0, 'terminal-1')
+      if (!tabOrder.some((id) => id !== 'terminal-1')) {
+        tabOrder.push('a')
+      }
+      const recentTabIds = Array.from({ length: random(5) }, () => pool[random(pool.length)]!)
+
+      const initial = session()
+      initial.tabGroups![WORKTREE_ID]![0]!.tabOrder = [...tabOrder]
+      initial.tabGroups![WORKTREE_ID]![0]!.recentTabIds = [...recentTabIds]
+      initial.tabGroups![WORKTREE_ID]![0]!.activeTabId = 'terminal-1'
+      const result = closeTerminalTabInWorkspaceSession(initial, WORKTREE_ID, 'terminal-1')
+
+      expect({
+        tabOrder,
+        recentTabIds,
+        activeTabId: result.session.tabGroups![WORKTREE_ID]![0]!.activeTabId
+      }).toEqual({
+        tabOrder,
+        recentTabIds,
+        activeTabId: referenceNextActive(tabOrder, recentTabIds, 'terminal-1')
+      })
+    }
+  })
+
+  it.each([
+    { name: 'first of three', order: ['terminal-1', 'b', 'c'], expected: 'b' },
+    { name: 'middle of three', order: ['a', 'terminal-1', 'c'], expected: 'c' },
+    { name: 'last of three', order: ['a', 'b', 'terminal-1'], expected: 'b' }
+  ])(
+    'picks the documented neighbor with no MRU history when closing the $name',
+    ({ order, expected }) => {
+      const initial = session()
+      initial.tabGroups![WORKTREE_ID]![0]!.tabOrder = order
+      initial.tabGroups![WORKTREE_ID]![0]!.recentTabIds = []
+      const result = closeTerminalTabInWorkspaceSession(initial, WORKTREE_ID, 'terminal-1')
+      expect(result.session.tabGroups![WORKTREE_ID]![0]!.activeTabId).toBe(expected)
+    }
+  )
+
+  it('prefers the most recent surviving tab over the order neighbor', () => {
+    const initial = session()
+    initial.tabGroups![WORKTREE_ID]![0]!.tabOrder = ['a', 'terminal-1', 'c']
+    initial.tabGroups![WORKTREE_ID]![0]!.recentTabIds = ['c', 'a']
+    const result = closeTerminalTabInWorkspaceSession(initial, WORKTREE_ID, 'terminal-1')
+    expect(result.session.tabGroups![WORKTREE_ID]![0]!.activeTabId).toBe('a')
+  })
+
+  it('leaves the active tab alone when a background tab closes', () => {
+    const initial = session()
+    initial.tabGroups![WORKTREE_ID]![0]!.tabOrder = ['a', 'terminal-1', 'c']
+    initial.tabGroups![WORKTREE_ID]![0]!.activeTabId = 'c'
+    initial.tabGroups![WORKTREE_ID]![0]!.recentTabIds = ['a']
+    const result = closeTerminalTabInWorkspaceSession(initial, WORKTREE_ID, 'terminal-1')
+    expect(result.session.tabGroups![WORKTREE_ID]![0]!.activeTabId).toBe('c')
+  })
 })

--- a/src/shared/workspace-session-terminal-tab-close.ts
+++ b/src/shared/workspace-session-terminal-tab-close.ts
@@ -27,7 +27,10 @@ function pickNextActiveTab(
     }
   })
   const closingIndex = group.tabOrder.findIndex((id) => closingIds.has(id))
-  return remaining.find((id) => firstIndices.get(id)! > closingIndex) ?? remaining.at(-1) ?? null
+  // -1 matches the pre-index `indexOf` miss, so an id outside `group.tabOrder` never wins.
+  return (
+    remaining.find((id) => (firstIndices.get(id) ?? -1) > closingIndex) ?? remaining.at(-1) ?? null
+  )
 }
 
 function pruneGroupLayout(

--- a/src/shared/workspace-session-terminal-tab-close.ts
+++ b/src/shared/workspace-session-terminal-tab-close.ts
@@ -8,18 +8,26 @@ export type WorkspaceSessionTerminalTabCloseResult = {
   pinned: boolean
 }
 
-function pickNextActiveTab(group: TabGroup, closingIds: ReadonlySet<string>): string | null {
-  const remaining = group.tabOrder.filter((id) => !closingIds.has(id))
+function pickNextActiveTab(
+  group: TabGroup,
+  closingIds: ReadonlySet<string>,
+  remaining: readonly string[],
+  remainingIds: ReadonlySet<string>
+): string | null {
   for (let index = (group.recentTabIds?.length ?? 0) - 1; index >= 0; index -= 1) {
     const id = group.recentTabIds![index]
-    if (remaining.includes(id)) {
+    if (remainingIds.has(id)) {
       return id
     }
   }
+  const firstIndices = new Map<string, number>()
+  group.tabOrder.forEach((id, index) => {
+    if (!firstIndices.has(id)) {
+      firstIndices.set(id, index)
+    }
+  })
   const closingIndex = group.tabOrder.findIndex((id) => closingIds.has(id))
-  return (
-    remaining.find((id) => group.tabOrder.indexOf(id) > closingIndex) ?? remaining.at(-1) ?? null
-  )
+  return remaining.find((id) => firstIndices.get(id)! > closingIndex) ?? remaining.at(-1) ?? null
 }
 
 function pruneGroupLayout(
@@ -186,16 +194,17 @@ export function closeTerminalTabInWorkspaceSession(
   const nextGroups = (session.tabGroups?.[worktreeId] ?? [])
     .map((group) => {
       const tabOrder = group.tabOrder.filter((id) => !closedVisibleIds.has(id))
+      const remainingIds = new Set(tabOrder)
       const activeTabId = closedVisibleIds.has(group.activeTabId ?? '')
-        ? pickNextActiveTab(group, closedVisibleIds)
-        : group.activeTabId && tabOrder.includes(group.activeTabId)
+        ? pickNextActiveTab(group, closedVisibleIds, tabOrder, remainingIds)
+        : group.activeTabId && remainingIds.has(group.activeTabId)
           ? group.activeTabId
           : (tabOrder[0] ?? null)
       return {
         ...group,
         tabOrder,
         activeTabId,
-        recentTabIds: group.recentTabIds?.filter((id) => tabOrder.includes(id))
+        recentTabIds: group.recentTabIds?.filter((id) => remainingIds.has(id))
       }
     })
     .filter((group) => group.tabOrder.length > 0)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

When you close a terminal tab, Orca has to decide which tab you land on next. The rule has not changed: it first tries the most recently used tab that is still open, and if there is no usable history it takes the tab to the right, falling back to the one on the left when you closed the rightmost.

What changed is only how it looks things up. The old code answered "is this tab still open?" and "where does this tab sit in the row?" by scanning the whole row of tabs again for each candidate — a list scanned inside a list. With 1,000 tabs open, closing the last one meant about 500,000 lookups. Now the row is turned into a lookup table once per close, so the same answers cost a couple of thousand lookups.

Landing tab is unchanged. A new test runs 500 randomly generated tab rows — including rows with duplicate entries, empty history, and history pointing at already-closed tabs — through both the old and the new logic and requires the same answer every time, plus named tests for closing the first, middle, last, and a background tab, and for history winning over the neighbor rule. Pinned tabs are refused before any of this runs and are untouched.

## What Changed / Why

- `pickNextActiveTab` replaced `remaining.includes(...)` and `group.tabOrder.indexOf(...)` (both O(row) per candidate) with a membership `Set` and a first-occurrence index `Map` built once per close.
- The caller now reuses the same `Set` for the "active tab survived" check and for pruning `recentTabIds`, so the row is no longer rescanned for each of those.
- The first-occurrence `Map` (rather than a plain scan rightwards) is what preserves the legacy duplicate-entry behaviour, where a repeated id keeps the position of its first appearance.
- Closing the last of 1,001 tabs: 503,503 order-entry reads to under 6,000.
- Cost note: the `Map` is built on every close where the active tab is the one closing, so at a realistic 5-20 tabs this is a wash rather than a win. It is bounded by the `tabOrder.filter` and `new Set(tabOrder)` the same reducer already performs unconditionally, so it adds no new complexity class.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- `workspace-session-terminal-tab-close.test.ts` (13 tests) and `persistence-initial-load.test.ts` pass on this branch on macOS (28 tests total).
- Added coverage: a 500-sample differential test against the pre-index selection algorithm, a first/middle/last neighbor matrix, MRU-over-neighbor precedence, and a background close leaving the active tab alone.
- Commit hooks passed: oxlint, React Doctor lint and formatting.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved. This module is host-agnostic session state, so local, WSL, SSH and relay panes all take the same path.

Test files:

- `src/shared/workspace-session-terminal-tab-close.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
