### PR TITLE
perf: index VM feature restoration and precompute sorting identities

### DIFF
--- a/src/shared/ephemeral-vm-runtime-feature-sorting.test.ts
+++ b/src/shared/ephemeral-vm-runtime-feature-sorting.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from 'vitest'
+import { featureIdentity, sortRuntimeFeatures } from './ephemeral-vm-runtime-feature-store'
+import { mergeRuntimeFeatures } from './ephemeral-vm-runtime-rollback-projection'
+
+it('computes each runtime identity once per sort with identical stable ordering', () => {
+  let reads = 0
+  const features = Array.from({ length: 2000 }, (_, i) => ({
+    get id() {
+      reads++
+      return `vm-${(i * 173) % 1999}`
+    },
+    recipeId: i % 2 ? 'Éclair' : 'eclair',
+    createdAt: i % 11
+  }))
+  const expected = [...features].sort((a, b) =>
+    featureIdentity(a).localeCompare(featureIdentity(b))
+  )
+  expect(reads).toBeGreaterThan(20_000)
+  reads = 0
+  const sorted = sortRuntimeFeatures(features)
+  expect(reads).toBe(2000)
+  sorted.forEach((entry, index) => expect(entry).toBe(expected[index]))
+  const required = { ...features[0], replacement: true }
+  const merged = new Map(features.map((entry) => [featureIdentity(entry), entry]))
+  merged.set(featureIdentity(required), required)
+  const expectedMerged = [...merged.values()].sort((a, b) =>
+    featureIdentity(a).localeCompare(featureIdentity(b))
+  )
+  reads = 0
+  const actual = mergeRuntimeFeatures(features, [required])
+  expect(reads).toBeLessThanOrEqual(4000)
+  actual.forEach((entry, index) => expect(entry).toBe(expectedMerged[index]))
+})

--- a/src/shared/ephemeral-vm-runtime-feature-store.ts
+++ b/src/shared/ephemeral-vm-runtime-feature-store.ts
@@ -143,7 +143,7 @@ function mergeFeatureEntries(
   for (const entry of required) {
     merged.set(featureIdentity(entry), entry)
   }
-  return sortFeatures([...merged.values()])
+  return sortRuntimeFeatures([...merged.values()])
 }
 
 export function featureEntryFromRuntime(
@@ -164,11 +164,26 @@ export function featureEntryFromRuntime(
   }
 }
 
-export function restoreRuntimeFeatures(
-  runtime: EphemeralVmRuntimeRecord,
+export function restoreRuntimeFeatureList(
+  runtimes: readonly EphemeralVmRuntimeRecord[],
   features: readonly EphemeralVmRuntimeFeatureEntry[]
+): EphemeralVmRuntimeRecord[] {
+  const byIdentity = new Map<string, EphemeralVmRuntimeFeatureEntry>()
+  for (const feature of features) {
+    const identity = featureIdentity(feature)
+    if (!byIdentity.has(identity)) {
+      byIdentity.set(identity, feature)
+    }
+  }
+  return runtimes.map((runtime) =>
+    restoreRuntimeFeatures(runtime, byIdentity.get(featureIdentity(runtime)))
+  )
+}
+
+function restoreRuntimeFeatures(
+  runtime: EphemeralVmRuntimeRecord,
+  feature: EphemeralVmRuntimeFeatureEntry | undefined
 ): EphemeralVmRuntimeRecord {
-  const feature = features.find((entry) => featureIdentity(entry) === featureIdentity(runtime))
   if (!feature) {
     return runtime
   }
@@ -225,15 +240,16 @@ function parseFeatureRecords(records: unknown[]): EphemeralVmRuntimeFeatureStore
       features.push(parsed.data)
     }
   }
-  return { writable: true, features: sortFeatures(features), retainedRecords }
+  return { writable: true, features: sortRuntimeFeatures(features), retainedRecords }
 }
 
-function sortFeatures(
-  features: readonly EphemeralVmRuntimeFeatureEntry[]
-): EphemeralVmRuntimeFeatureEntry[] {
-  return [...features].sort((left, right) =>
-    featureIdentity(left).localeCompare(featureIdentity(right))
-  )
+export function sortRuntimeFeatures<T extends { id: string; recipeId: string; createdAt: number }>(
+  features: readonly T[]
+): T[] {
+  return features
+    .map((feature) => ({ feature, identity: featureIdentity(feature) }))
+    .sort((left, right) => left.identity.localeCompare(right.identity))
+    .map(({ feature }) => feature)
 }
 
 function runtimeFeatureStoreValue(
@@ -242,6 +258,6 @@ function runtimeFeatureStoreValue(
 ): { version: 1; records: unknown[] } {
   return {
     version: 1,
-    records: [...sortFeatures(features), ...snapshot.retainedRecords]
+    records: [...sortRuntimeFeatures(features), ...snapshot.retainedRecords]
   }
 }

--- a/src/shared/ephemeral-vm-runtime-rollback-projection.ts
+++ b/src/shared/ephemeral-vm-runtime-rollback-projection.ts
@@ -1,4 +1,4 @@
-import { featureIdentity } from './ephemeral-vm-runtime-feature-store'
+import { featureIdentity, sortRuntimeFeatures } from './ephemeral-vm-runtime-feature-store'
 import {
   RollbackEphemeralVmRuntimeRecordSchema,
   type EphemeralVmRuntimeRecord
@@ -32,9 +32,7 @@ export function mergeRuntimeFeatures<T extends { id: string; recipeId: string; c
   for (const entry of required) {
     merged.set(featureIdentity(entry), entry)
   }
-  return [...merged.values()].sort((left, right) =>
-    featureIdentity(left).localeCompare(featureIdentity(right))
-  )
+  return sortRuntimeFeatures([...merged.values()])
 }
 
 export function runtimeFeatureListsEqual<

--- a/src/shared/ephemeral-vm-runtime-store-rollback.test.ts
+++ b/src/shared/ephemeral-vm-runtime-store-rollback.test.ts
@@ -13,6 +13,8 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   getEphemeralVmRuntimeFeatureStorePath,
+  featureIdentity,
+  restoreRuntimeFeatureList,
   MAX_EPHEMERAL_VM_RUNTIME_FEATURE_STORE_FILE_BYTES
 } from './ephemeral-vm-runtime-feature-store'
 import {
@@ -284,5 +286,39 @@ describe('ephemeral VM runtime store rollback projection', () => {
       'provisioned-runtime',
       'ordinary-runtime'
     ])
+  })
+})
+
+describe('runtime feature restoration scaling', () => {
+  it('indexes feature identities once and preserves unmatched runtime references', () => {
+    let reads = 0
+    const runtimes = Array.from({ length: 1000 }, (_, i) => runtimeRecord({ id: `runtime-${i}` }))
+    const features = runtimes.map((runtime) => ({
+      get id() {
+        reads++
+        return runtime.id
+      },
+      recipeId: runtime.recipeId,
+      createdAt: runtime.createdAt,
+      recipeCheckoutMode: 'provisioned-root' as const
+    }))
+    for (const runtime of runtimes) {
+      expect(
+        features.find((entry) => featureIdentity(entry) === featureIdentity(runtime))
+      ).toBeDefined()
+    }
+    expect(reads).toBe(500_500)
+    reads = 0
+    const restored = restoreRuntimeFeatureList(runtimes, features)
+    expect(reads).toBe(1000)
+    expect(restored.map((runtime) => runtime.id)).toEqual(runtimes.map((runtime) => runtime.id))
+    expect(restored.every((runtime) => runtime.recipe?.checkoutMode === 'provisioned-root')).toBe(
+      true
+    )
+    expect(restoreRuntimeFeatureList([runtimes[0]], [])[0]).toBe(runtimes[0])
+    const first = { ...features[0], recipeCheckoutMode: 'orca-worktree' as const }
+    expect(
+      restoreRuntimeFeatureList([runtimes[0]], [first, features[0]])[0].recipe?.checkoutMode
+    ).toBe('orca-worktree')
   })
 })

--- a/src/shared/ephemeral-vm-runtime-store.ts
+++ b/src/shared/ephemeral-vm-runtime-store.ts
@@ -8,7 +8,7 @@ import {
   featureEntryFromRuntime,
   featureIdentity,
   readEphemeralVmRuntimeFeatureStore,
-  restoreRuntimeFeatures,
+  restoreRuntimeFeatureList,
   runtimeFeaturesEqual,
   writeEphemeralVmRuntimeFeatureStore,
   type EphemeralVmRuntimeFeatureStoreSnapshot
@@ -225,9 +225,9 @@ function readEphemeralVmRuntimeStore(userDataPath: string): LoadedEphemeralVmRun
     const features = readEphemeralVmRuntimeFeatureStore(userDataPath)
     const store: EphemeralVmRuntimeStore = {
       version: 1,
-      runtimes: parsed.runtimes
-        .map((entry) => restoreRuntimeFeatures(entry, features.features))
-        .sort(compareRuntimeRecords)
+      runtimes: restoreRuntimeFeatureList(parsed.runtimes, features.features).sort(
+        compareRuntimeRecords
+      )
     }
     if (features.writable && !RollbackEphemeralVmRuntimeStoreSchema.safeParse(persisted).success) {
       try {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |

<!-- /orca-pr-loc -->

## ELI5

Orca remembers a few extra details about each cloud VM you've used, stored in a
separate little file next to the main list. On startup it has to match each VM in
the main list to its details in that file.

It used to do that by re-reading the whole details file from the top for every
single VM — with 1,000 VMs that's half a million lookups. Now it reads the details
file once, builds a lookup table, and matches each VM instantly (1,000 lookups).

The same trick is applied to sorting: instead of recalculating each VM's name tag
every time the sorter compares two of them (tens of thousands of times), it works
the tag out once per VM and sorts using that.

Nothing about what you see changes. The saved file, the order VMs appear in, and
which details win when two entries clash are all exactly the same as before —
Orca just stops redoing the same arithmetic.

## What Changed / Why

- 1,000 runtimes: 500,500 feature-ID reads → 1,000; first-wins identity, unmatched references and rollback contracts preserved
- 2,000 entries: over 20,000 identity reads → 2,000 per sort; stable ordering and merge overwrite parity against original comparator

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 12 tests across 2 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/shared/ephemeral-vm-runtime-feature-sorting.test.ts`
- `src/shared/ephemeral-vm-runtime-store-rollback.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

