### PR TITLE
perf: reuse normalized path matchers for batch deletion

### DIFF
--- a/src/renderer/src/components/right-sidebar/file-explorer-batch-deletion.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-batch-deletion.test.ts
@@ -13,6 +13,27 @@ function node(path: string, isDirectory = false): TreeNode {
 }
 
 describe('selectDeletionRoots', () => {
+  it('normalizes each selected path once instead of once per possible parent', () => {
+    let reads = 0
+    const nodes = Array.from({ length: 1000 }, (_, i) => ({
+      ...node(`/repo/directory-${i}`, true),
+      get path() {
+        reads++
+        return `/repo/directory-${i}`
+      }
+    }))
+    const selected = selectDeletionRoots(nodes)
+    expect(reads).toBe(2000)
+    selected.forEach((entry, index) => expect(entry).toBe(nodes[index]))
+  })
+
+  it('preserves WSL case-sensitive paths while accepting UNC aliases', () => {
+    const parent = node('//wsl.localhost/Ubuntu/Repo', true)
+    const child = node('//wsl$/ubuntu/Repo/file')
+    const outside = node('//wsl$/ubuntu/repo/file')
+    expect(selectDeletionRoots([parent, child, outside])).toEqual([parent, outside])
+  })
+
   it('keeps unrelated files and directories', () => {
     const nodes = [node('/repo/a.ts'), node('/repo/b.ts'), node('/repo/docs', true)]
     expect(selectDeletionRoots(nodes)).toEqual(nodes)

--- a/src/renderer/src/components/right-sidebar/file-explorer-batch-deletion.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-batch-deletion.ts
@@ -1,14 +1,26 @@
-import { isPathEqualOrDescendant } from './file-explorer-paths'
+import {
+  createNormalizedPathInsideOrEqualMatcher,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
 import type { TreeNode } from './file-explorer-types'
 
 // Why: skip descendants of other selected directories — deleting a parent
 // already removes the child, and issuing both requests races on the
 // now-missing path and produces spurious errors.
 export function selectDeletionRoots(nodes: TreeNode[]): TreeNode[] {
-  const directories = nodes.filter((node) => node.isDirectory)
-  return nodes.filter(
-    (n) => !directories.some((other) => other !== n && isPathEqualOrDescendant(n.path, other.path))
-  )
+  const directories = nodes
+    .filter((node) => node.isDirectory)
+    .map((node) => ({
+      node,
+      matches: createNormalizedPathInsideOrEqualMatcher(node.path)
+    }))
+  if (directories.length === 0) {
+    return [...nodes]
+  }
+  return nodes.filter((node) => {
+    const candidate = normalizeRuntimePathForComparison(node.path)
+    return !directories.some((other) => other.node !== node && other.matches(candidate))
+  })
 }
 
 type RunBatchDeletionParams = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

When you select several files and folders in Orca's file explorer and delete them, Orca first drops anything that sits inside another selected folder - deleting the folder already removes them, and asking twice produces spurious "file not found" errors.

To decide that, it compared every selected item against every selected folder. Each comparison re-cleaned both paths from scratch (fixing slashes, drive-letter casing, Windows UNC and WSL spellings), so with 1,000 selected folders the same paths were cleaned roughly two million times.

Now each folder's matcher is built once and each selected path is cleaned once, then the comparisons are plain string checks. With 1,000 selected folders that is 1,998,000 path reads reduced to 2,000.

The decision itself is unchanged - the new code is the same comparison, just with the shared setup hoisted out of the loop. Every existing test for POSIX, Windows drive letters, `\\server\share` UNC, `\\wsl$` vs `\\wsl.localhost` aliases, trailing slashes, lookalike sibling names such as `docs` vs `docs-old`, and repeated selections of the same node passes unchanged on the new implementation; only the new operation-count test distinguishes them.

## What Changed / Why

- 1,000 directories: 1,998,000 path reads → 2,000; original fails count test; POSIX, Windows, UNC, WSL, repeated-reference and boundary contracts pass

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 17 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/components/right-sidebar/file-explorer-batch-deletion.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

