### PR TITLE
perf: preserve store state on unchanged document titles

### DIFF
--- a/src/renderer/src/store/slices/browser/browser-history-actions.ts
+++ b/src/renderer/src/store/slices/browser/browser-history-actions.ts
@@ -9,7 +9,8 @@ import {
 import {
   MAX_WORKSPACE_DOC_HISTORY_ENTRIES,
   normalizeWorkspaceDocHistoryEntries,
-  normalizeWorkspaceDocHistoryTitle
+  normalizeWorkspaceDocHistoryTitle,
+  workspaceDocHistoryEntriesEqual
 } from '../../../../../shared/workspace-doc-history'
 import { browserPageDocLocationsEqual } from '../../../../../shared/browser-page-doc-location'
 import { ORCA_BROWSER_BLANK_URL } from '../../../../../shared/constants'
@@ -37,24 +38,25 @@ export function createBrowserHistoryActions(
           title ?? existing?.title,
           docLocation
         )
+        const updated: WorkspaceDocHistoryEntry | null = existing
+          ? {
+              ...existing,
+              title: normalizedTitle,
+              ...(bump ? { lastVisitedAt: now, visitCount: existing.visitCount + 1 } : {})
+            }
+          : null
+        // A repeated title-updated event from a live preview changes nothing; hand back the same
+        // state so no subscriber re-renders. Over the cap the old path still had trimming to do.
         if (
           existing &&
-          !bump &&
-          normalizedTitle === existing.title &&
+          updated &&
+          workspaceDocHistoryEntriesEqual(updated, existing) &&
           s.workspaceDocHistory.length <= MAX_WORKSPACE_DOC_HISTORY_ENTRIES
         ) {
           return s
         }
-        const next: WorkspaceDocHistoryEntry[] = existing
-          ? s.workspaceDocHistory.map((entry) =>
-              entry === existing
-                ? {
-                    ...entry,
-                    title: normalizedTitle,
-                    ...(bump ? { lastVisitedAt: now, visitCount: entry.visitCount + 1 } : {})
-                  }
-                : entry
-            )
+        const next: WorkspaceDocHistoryEntry[] = updated
+          ? s.workspaceDocHistory.map((entry) => (entry === existing ? updated : entry))
           : [
               { docLocation, title: normalizedTitle, lastVisitedAt: now, visitCount: 1 },
               ...s.workspaceDocHistory

--- a/src/renderer/src/store/slices/browser/browser-history-actions.ts
+++ b/src/renderer/src/store/slices/browser/browser-history-actions.ts
@@ -37,6 +37,14 @@ export function createBrowserHistoryActions(
           title ?? existing?.title,
           docLocation
         )
+        if (
+          existing &&
+          !bump &&
+          normalizedTitle === existing.title &&
+          s.workspaceDocHistory.length <= MAX_WORKSPACE_DOC_HISTORY_ENTRIES
+        ) {
+          return s
+        }
         const next: WorkspaceDocHistoryEntry[] = existing
           ? s.workspaceDocHistory.map((entry) =>
               entry === existing

--- a/src/renderer/src/store/slices/workspace-document-title-refresh.test.ts
+++ b/src/renderer/src/store/slices/workspace-document-title-refresh.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+import { createStoreCascadesMockApi } from './store-cascades-test-harness'
+
+createStoreCascadesMockApi()
+const WT = 'repo1::/path/wt1'
+
+describe('workspace document history title refresh', () => {
+  it('does not publish unchanged titles but preserves real visits and title changes', () => {
+    const store = createTestStore()
+    const location = {
+      kind: 'workspace-doc' as const,
+      worktreeId: WT,
+      filePath: '/path/wt1/doc.html'
+    }
+    store.getState().recordWorkspaceDocVisit(location, 'Document')
+    const history = store.getState().workspaceDocHistory
+    const listener = vi.fn()
+    const unsubscribe = store.subscribe(listener)
+    for (let i = 0; i < 200; i++) {
+      store.getState().recordWorkspaceDocVisit(location, 'Document', { bump: false })
+    }
+    expect(listener).not.toHaveBeenCalled()
+    expect(store.getState().workspaceDocHistory).toBe(history)
+    store.getState().recordWorkspaceDocVisit(location, 'Renamed', { bump: false })
+    expect(store.getState().workspaceDocHistory[0]).toEqual({ ...history[0], title: 'Renamed' })
+    store.getState().recordWorkspaceDocVisit(location, 'Renamed')
+    expect(store.getState().workspaceDocHistory[0].visitCount).toBe(2)
+    unsubscribe()
+  })
+})

--- a/src/renderer/src/store/slices/workspace-document-title-refresh.test.ts
+++ b/src/renderer/src/store/slices/workspace-document-title-refresh.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createTestStore } from './store-test-helpers'
 import { createStoreCascadesMockApi } from './store-cascades-test-harness'
+import {
+  MAX_WORKSPACE_DOC_HISTORY_ENTRIES,
+  workspaceDocHistoryEntriesEqual,
+  type WorkspaceDocHistoryEntry
+} from '../../../../shared/workspace-doc-history'
 
 createStoreCascadesMockApi()
 const WT = 'repo1::/path/wt1'
@@ -27,5 +32,56 @@ describe('workspace document history title refresh', () => {
     store.getState().recordWorkspaceDocVisit(location, 'Renamed')
     expect(store.getState().workspaceDocHistory[0].visitCount).toBe(2)
     unsubscribe()
+  })
+
+  it('still trims an over-cap history that a persisted state carried in', () => {
+    const store = createTestStore()
+    const location = {
+      kind: 'workspace-doc' as const,
+      worktreeId: WT,
+      filePath: '/path/wt1/doc-0.html'
+    }
+    const overCap: WorkspaceDocHistoryEntry[] = Array.from(
+      { length: MAX_WORKSPACE_DOC_HISTORY_ENTRIES + 5 },
+      (_unused, index) => ({
+        docLocation: {
+          kind: 'workspace-doc' as const,
+          worktreeId: WT,
+          filePath: `/path/wt1/doc-${index}.html`
+        },
+        title: `Doc ${index}`,
+        lastVisitedAt: 1_000 - index,
+        visitCount: 1
+      })
+    )
+    store.setState({ workspaceDocHistory: overCap })
+
+    // The title is already current, but skipping here would strand the list above its cap forever.
+    store.getState().recordWorkspaceDocVisit(location, 'Doc 0', { bump: false })
+
+    expect(store.getState().workspaceDocHistory).toHaveLength(MAX_WORKSPACE_DOC_HISTORY_ENTRIES)
+    expect(store.getState().workspaceDocHistory[0].title).toBe('Doc 0')
+  })
+
+  it('compares every entry field, so an added field cannot be silently dropped', () => {
+    const base: WorkspaceDocHistoryEntry = {
+      docLocation: { kind: 'workspace-doc', worktreeId: WT, filePath: '/path/wt1/doc.html' },
+      title: 'Document',
+      lastVisitedAt: 10,
+      visitCount: 1
+    }
+    expect(workspaceDocHistoryEntriesEqual(base, { ...base })).toBe(true)
+    expect(workspaceDocHistoryEntriesEqual(base, { ...base, title: 'Other' })).toBe(false)
+    expect(workspaceDocHistoryEntriesEqual(base, { ...base, visitCount: 2 })).toBe(false)
+    expect(workspaceDocHistoryEntriesEqual(base, { ...base, lastVisitedAt: 11 })).toBe(false)
+    expect(
+      workspaceDocHistoryEntriesEqual(base, { ...base, docLocation: { ...base.docLocation } })
+    ).toBe(false)
+    expect(
+      workspaceDocHistoryEntriesEqual(base, {
+        ...base,
+        ...({ faviconUrl: 'x' } as Partial<WorkspaceDocHistoryEntry>)
+      })
+    ).toBe(false)
   })
 })

--- a/src/shared/workspace-doc-history.ts
+++ b/src/shared/workspace-doc-history.ts
@@ -16,6 +16,21 @@ export type WorkspaceDocHistoryEntry = {
 
 export const MAX_WORKSPACE_DOC_HISTORY_ENTRIES = 100
 
+/**
+ * Shallow-equal over whatever keys an entry actually carries, rather than a hand-listed subset, so
+ * a field added to `WorkspaceDocHistoryEntry` later cannot slip past a skip-if-unchanged check.
+ */
+export function workspaceDocHistoryEntriesEqual(
+  left: WorkspaceDocHistoryEntry,
+  right: WorkspaceDocHistoryEntry
+): boolean {
+  const leftKeys = Object.keys(left) as (keyof WorkspaceDocHistoryEntry)[]
+  return (
+    leftKeys.length === Object.keys(right).length &&
+    leftKeys.every((key) => Object.is(left[key], right[key]))
+  )
+}
+
 /** The title fence the page store applies, for history rows: a url-as-title falls back to the file. */
 export function normalizeWorkspaceDocHistoryTitle(
   title: string | null | undefined,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |

<!-- /orca-pr-loc -->

## ELI5

When you preview an HTML document in Orca's browser pane, the page can announce its own title — and some pages announce it over and over (a clock, a live dashboard, a page that re-sets `document.title` on a timer). Orca listens to every one of those announcements so the document's name in the address-bar history dropdown stays accurate.

The problem: Orca rewrote its history list on *every* announcement, even when the title was byte-for-byte the same one it already had. Rewriting the list hands every part of the app watching it a brand-new list, so they all re-check themselves for nothing. 200 identical announcements meant 200 pointless wake-ups.

Now Orca first works out what the row *would* become, compares it to the row it already has, and if they are identical it hands back the exact same list — so nothing downstream wakes up at all. Measured: 200 notifications down to zero.

Genuine changes are untouched. Rename the document and the new title publishes immediately. Open the document again and its visit count and last-opened time update as before. And if the stored history is somehow over its 100-entry cap (an older or hand-edited saved session), the trim still runs rather than being skipped forever.

## What Changed / Why

- `recordWorkspaceDocVisit` now builds the candidate entry once and returns the unchanged state object when that candidate is field-for-field equal to the stored entry. Zustand skips notification entirely when an updater returns the same state, so no subscriber re-renders.
- The equality is a shallow compare over `Object.keys(entry)` (`workspaceDocHistoryEntriesEqual`), not a hand-listed subset of fields. A field added to `WorkspaceDocHistoryEntry` later therefore forces a publish rather than being silently swallowed by the skip — the failure direction is "publish anyway", never "drop an update".
- The skip is additionally gated on `workspaceDocHistory.length <= MAX_WORKSPACE_DOC_HISTORY_ENTRIES`, because the old path also ran `normalizeWorkspaceDocHistoryEntries` (dedupe + trim to 100) whenever the list was over cap. Without that gate a persisted over-cap list would never get trimmed again.
- No title update can be dropped: a differing title, a `bump` visit (`visitCount` always increments, so a bump is never equal), a first visit, and an over-cap list all fall through to the publishing path.
- No persisted-contract change: the same entries are written, only the array identity is reused when nothing changed.
- Coverage: 200 identical refreshes produce zero notifications and the identical array reference; a rename publishes; a bump increments `visitCount`; an over-cap seeded history is still trimmed to 100 on an unchanged-title refresh; and the equality helper is pinned against title, `visitCount`, `lastVisitedAt`, a fresh `docLocation` object, and an extra unknown key.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 1 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/store/slices/workspace-document-title-refresh.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

