### PR TITLE
perf: index prior memberships during project identity succession

### DIFF
--- a/src/shared/project-identity-succession.test.ts
+++ b/src/shared/project-identity-succession.test.ts
@@ -135,4 +135,43 @@ describe('carryProjectStateThroughIdentityChange', () => {
     expect(result.projects[1]?.localWindowsRuntimePreference).toBeUndefined()
     expect([...result.remappedProjectIds]).toEqual([['repo:r1', 'git:host/acme/left']])
   })
+  it('visits prior repo memberships once for a bulk identity promotion', () => {
+    let reads = 0
+    const previous = Array.from({ length: 1000 }, (_, i) => ({
+      ...makeProject({ id: `old-${i}`, localWindowsRuntimePreference: { kind: 'windows-host' } }),
+      get sourceRepoIds() {
+        reads++
+        return [`repo-${i}`]
+      }
+    }))
+    const projected = Array.from({ length: 1000 }, (_, i) =>
+      makeProject({ id: `new-${i}`, sourceRepoIds: [`repo-${i}`] })
+    )
+    const result = carryProjectStateThroughIdentityChange(projected, previous)
+    expect(reads).toBe(1000)
+    expect([...result.remappedProjectIds]).toEqual(
+      previous.map((row, i) => [row.id, projected[i].id])
+    )
+    expect(
+      result.projects.every((row) => row.localWindowsRuntimePreference?.kind === 'windows-host')
+    ).toBe(true)
+  })
+
+  it('retains duplicate membership weight and stable prior-row ties', () => {
+    const projected = makeProject({ id: 'new', sourceRepoIds: ['b', 'a', 'b'] })
+    const first = makeProject({
+      id: 'old',
+      sourceRepoIds: ['a', 'a'],
+      localWindowsRuntimePreference: { kind: 'windows-host' }
+    })
+    const second = makeProject({
+      id: 'old',
+      sourceRepoIds: ['b', 'b'],
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+    const result = carryProjectStateThroughIdentityChange([projected], [first, second])
+    expect(result.projects[0].localWindowsRuntimePreference).toEqual(
+      first.localWindowsRuntimePreference
+    )
+  })
 })

--- a/src/shared/project-identity-succession.ts
+++ b/src/shared/project-identity-succession.ts
@@ -17,10 +17,6 @@ function carryUserState(projected: Project, previous: Project): Project {
     : projected
 }
 
-function countSharedRepoIds(sourceRepoIds: readonly string[], other: ReadonlySet<string>): number {
-  return sourceRepoIds.reduce((count, repoId) => (other.has(repoId) ? count + 1 : count), 0)
-}
-
 function compareStrings(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0
 }
@@ -45,15 +41,34 @@ export function carryProjectStateThroughIdentityChange(
   // Why: a prior row that still exists under its own id is live, not a predecessor.
   const orphanedPrevious = previousProjects.filter((project) => !projectedIds.has(project.id))
   const unmatched = projectedProjects.filter((project) => !previousById.has(project.id))
+  const previousIndicesByRepo = new Map<string, number[]>()
+  if (unmatched.length > 0) {
+    orphanedPrevious.forEach((previous, index) => {
+      for (const repoId of previous.sourceRepoIds) {
+        const indices = previousIndicesByRepo.get(repoId)
+        if (indices) {
+          indices.push(index)
+        } else {
+          previousIndicesByRepo.set(repoId, [index])
+        }
+      }
+    })
+  }
   const candidates = unmatched.flatMap((project) => {
-    const repoIds = new Set(project.sourceRepoIds)
-    return orphanedPrevious
-      .map((previous) => ({
+    const overlaps = new Map<number, number>()
+    for (const repoId of new Set(project.sourceRepoIds)) {
+      for (const index of previousIndicesByRepo.get(repoId) ?? []) {
+        overlaps.set(index, (overlaps.get(index) ?? 0) + 1)
+      }
+    }
+    // Preserve input order when the candidate comparator ties on legacy duplicate IDs.
+    return [...overlaps]
+      .sort(([left], [right]) => left - right)
+      .map(([index, shared]) => ({
         project,
-        previous,
-        shared: countSharedRepoIds(previous.sourceRepoIds, repoIds)
+        previous: orphanedPrevious[index],
+        shared
       }))
-      .filter((candidate) => candidate.shared > 0)
   })
   candidates.sort(
     (left, right) =>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |

<!-- /orca-pr-loc -->

## ELI5

A project's internal ID in Orca is derived from the repo behind it, so it can change
on its own — for example when Orca learns the repo's real GitHub address and upgrades
a local-looking ID to a proper one. When that happens Orca has to work out "this new
project row is really the same project as that old one", so your saved per-project
settings (like which Windows/WSL environment that project should run in) follow along
instead of being stranded on a ghost row.

It figures out the pairing by counting how many repos each old row and each new row
have in common, then picking the best match. It used to do that by comparing every new
row against every old row — with 1,000 projects that's a million comparisons.

Now it builds a "which old rows mention this repo" index once, so each new row only
looks at the old rows it could actually match.

The pairings it produces are identical. The same old row wins, ties still break the same
way (including the awkward case where two old rows share an ID), and repos listed twice
still count twice. This was checked by running 4,000 randomly generated project sets
through both the old and new code — including duplicate repo lists, duplicate project
IDs and heavy tie cases — and confirming the matches and the carried-forward settings
come out the same. Nothing on disk changes format, so downgrading to an older Orca
build recomputes the same pairings.

## What Changed / Why

- 1,000 bulk promotions: 1,000,000 prior source-list reads → 1,000; overlap weights, duplicate membership, stable ties and runtime preference transfer preserved

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 8 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/shared/project-identity-succession.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

