### PR TITLE
perf: index unified tabs for browser palette entries

### DIFF
--- a/src/renderer/src/lib/browser-palette-page-entries.test.ts
+++ b/src/renderer/src/lib/browser-palette-page-entries.test.ts
@@ -452,3 +452,41 @@ function browserUnifiedTab(
     createdAt: 0
   }
 }
+
+it('indexes workspace tabs when building a large browser palette', () => {
+  let reads = 0
+  const workspaces = Array.from({ length: 1000 }, (_, i) =>
+    makeWorkspace({ id: `workspace-${i}`, activePageId: `page-${i}` })
+  )
+  const tabs: Tab[] = workspaces.map((workspace, i) => ({
+    id: `tab-${i}`,
+    get entityId() {
+      reads++
+      return workspace.id
+    },
+    groupId: 'group-1',
+    worktreeId: 'wt-1',
+    contentType: 'browser',
+    label: 'Example',
+    customLabel: null,
+    color: null,
+    sortOrder: i,
+    createdAt: 0
+  }))
+  const pages = Object.fromEntries(
+    workspaces.map((workspace, i) => [
+      workspace.id,
+      [makePage({ id: `page-${i}`, workspaceId: workspace.id })]
+    ])
+  )
+  const entries = buildFixture({
+    worktrees: [worktreeA],
+    browserTabsByWorktree: { 'wt-1': workspaces },
+    browserPagesByWorkspace: pages,
+    unifiedTabsByWorktree: { 'wt-1': tabs }
+  })
+  expect(reads).toBeLessThan(6000)
+  expect(entries.map((entry) => entry.workspace.id)).toEqual(
+    workspaces.map((workspace) => workspace.id)
+  )
+})

--- a/src/renderer/src/lib/browser-palette-page-entries.test.ts
+++ b/src/renderer/src/lib/browser-palette-page-entries.test.ts
@@ -430,6 +430,31 @@ describe('buildSearchableBrowserPages', () => {
     expect(results.map((result) => result.pageId)).toEqual(['page-1', 'page-4', 'page-2', 'page-3'])
     expect(results[0].isCurrentPage).toBe(true)
   })
+
+  // Why this matters to the workspace index: it keeps the first browser tab per workspace id, so
+  // it would lose a later owned tab if two ever reached the lookup. This pins that they cannot.
+  it('omits a workspace claimed by more than one unified browser tab', () => {
+    const entries = buildFixture({
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          browserUnifiedTab('tab-foreign', 'ws-1', 'wt-2'),
+          browserUnifiedTab('tab-owned', 'ws-1', 'wt-1')
+        ]
+      }
+    })
+
+    expect(entries.some((entry) => entry.workspace.id === 'ws-1')).toBe(false)
+  })
+
+  // Why: a workspace whose only unified tab belongs to another worktree must stay hidden here.
+  it('omits a workspace whose single unified browser tab is not owned by this worktree', () => {
+    const entries = buildFixture({
+      unifiedTabsByWorktree: { 'wt-1': [browserUnifiedTab('tab-foreign', 'ws-1', 'wt-2')] }
+    })
+
+    expect(entries.some((entry) => entry.workspace.id === 'ws-1')).toBe(false)
+    expect(entries.some((entry) => entry.workspace.id === 'ws-2')).toBe(true)
+  })
 })
 
 function browserUnifiedTab(

--- a/src/renderer/src/lib/browser-palette-page-entries.ts
+++ b/src/renderer/src/lib/browser-palette-page-entries.ts
@@ -70,9 +70,13 @@ export function buildSearchableBrowserPages({
       worktreeOrder.get(getPaletteWorktreeIdentity(worktree)) ??
       worktreeOrder.get(worktree.id) ??
       Number.MAX_SAFE_INTEGER
+    const unifiedBrowserTabsByWorkspaceId = new Map<string, Tab>()
     const focusedAtByWorkspaceId = new Map<string, number>()
     const unifiedTabs = unifiedTabsByWorktree?.[worktree.id] ?? []
     for (const tab of unifiedTabs) {
+      if (tab.contentType === 'browser' && !unifiedBrowserTabsByWorkspaceId.has(tab.entityId)) {
+        unifiedBrowserTabsByWorkspaceId.set(tab.entityId, tab)
+      }
       if (
         tab.contentType === 'browser' &&
         isUnifiedTabOwnedByWorktree(tab, worktree, ambiguousWorktreeIds) &&
@@ -88,13 +92,12 @@ export function buildSearchableBrowserPages({
       ) {
         continue
       }
-      const workspaceTabs = unifiedTabs.filter(
-        (tab) => tab.contentType === 'browser' && tab.entityId === workspace.id
-      )
-      const unifiedTab = workspaceTabs.find((tab) =>
-        isUnifiedTabOwnedByWorktree(tab, worktree, ambiguousWorktreeIds)
-      )
-      if (!unifiedTab && (workspaceTabs.length > 0 || ambiguousWorktreeIds.has(worktree.id))) {
+      const candidate = unifiedBrowserTabsByWorkspaceId.get(workspace.id)
+      const unifiedTab =
+        candidate && isUnifiedTabOwnedByWorktree(candidate, worktree, ambiguousWorktreeIds)
+          ? candidate
+          : undefined
+      if (!unifiedTab && (candidate || ambiguousWorktreeIds.has(worktree.id))) {
         continue
       }
       if (unifiedTab && duplicateTabIds.has(unifiedTab.id)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

The Cmd+J / open-tab palette builds one searchable row per open browser page. For each browser window it had to find the matching tab in the tab bar — and it did that by scanning the entire tab list from the start, once per window. Twenty windows meant scanning the whole tab list twenty times.

This code was already walking the tab list once anyway (to read when each window was last focused). Now that same single walk also records which tab belongs to which window, so the later per-window lookups are instant. No extra pass over anything.

What appears in the palette, and in what order, is unchanged. The tricky bit is the rule for a window that has two competing tabs claiming it; a new test pins that such a window is already dropped before this lookup ever runs, which is what makes "take the first tab we saw" safe, plus a test that a window whose only tab belongs to a different worktree still stays hidden.

## What Changed / Why

- `buildSearchableBrowserPages` ran `unifiedTabs.filter(...)` inside the per-workspace loop — O(workspaces x unified tabs) per worktree, per palette rebuild.
- The lookup map is now filled during the `focusedAtByWorkspaceId` pass that already existed, so the change costs no additional traversal and no additional allocation beyond the map itself.
- 1,000 workspaces / 1,000 tabs: 1,001,000 `entityId` reads to under 6,000.
- Equivalence argument: `duplicateWorkspaceIds` (built from every browser unified tab across all worktrees) already `continue`s any workspace claimed by two or more browser tabs, so at most one candidate can reach the lookup. `workspaceTabs.length > 0` and `workspaceTabs.find(isOwned)` therefore reduce exactly to `candidate` and `candidate && isOwned(candidate)`.
- The map is rebuilt per worktree per call from the current props; nothing is cached across renders, so there is no staleness or growth surface.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- `browser-palette-page-entries.test.ts` (17 tests) plus `open-tab-search.test.ts`, `use-open-tab-search.test.ts` and `open-tab-search-retention.test.ts` (47 tests) pass on this branch on macOS.
- Added coverage: a workspace claimed by two unified browser tabs is omitted, and a workspace whose single unified browser tab belongs to another worktree stays hidden.
- Commit hooks passed: oxlint, React Doctor lint and formatting.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved. Execution-host ownership checks are unchanged, so SSH and relay worktrees resolve exactly as before.

Test files:

- `src/renderer/src/lib/browser-palette-page-entries.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
