### PR TITLE
perf: append to owned project source lists without repeated copying

### DIFF
--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -684,3 +684,33 @@ describe('getProjectHostSetupWorktreeMeta host selection', () => {
     expect(getProjectHostSetupWorktreeMeta(setups, sshRepo).hostId).toBe('ssh:build-box')
   })
 })
+
+it('appends project source IDs without repeatedly copying an accumulating array', () => {
+  const repos = Array.from({ length: 2000 }, (_, i) =>
+    repo({
+      id: `source-${i}`,
+      path: `/repos/${i}`,
+      displayName: `Repo ${i}`,
+      upstream: { owner: 'acme', repo: 'project' }
+    })
+  )
+  let copied = 0
+  const iterator = Array.prototype[Symbol.iterator]
+  Array.prototype[Symbol.iterator] = function (this: unknown[]) {
+    if (this[0] === 'source-0') {
+      copied += this.length
+    }
+    return iterator.call(this)
+  }
+  let result: ReturnType<typeof projectHostSetupProjectionFromRepos>
+  try {
+    result = projectHostSetupProjectionFromRepos([...repos, repos[0]])
+  } finally {
+    Array.prototype[Symbol.iterator] = iterator
+  }
+  expect(copied).toBeLessThan(10_000)
+  expect(result.projects).toHaveLength(1)
+  expect(result.projects[0].sourceRepoIds).toEqual(repos.map((repo) => repo.id))
+  expect(result.setups).toHaveLength(2001)
+  expect(repos[0].displayName).toBe('Repo 0')
+})

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -10,6 +10,7 @@ import type { Repo } from './repo-types'
 
 type ProjectAccumulator = {
   project: Project
+  sourceRepoIds: Set<string>
 }
 
 export type ProjectHostSetupProjection = {
@@ -262,19 +263,15 @@ function createProjectFromRepo(repo: Repo): Project {
   }
 }
 
-function mergeProjectRepo(project: Project, repo: Repo): Project {
-  const sourceRepoIds = project.sourceRepoIds.includes(repo.id)
-    ? project.sourceRepoIds
-    : [...project.sourceRepoIds, repo.id]
-  // Why unknown-aware on both sides: the accumulator itself carries 0 when the first repo of the
-  // project had no addedAt, so a plain min() would let repo order decide the project's createdAt.
-  const addedAt = catalogTimestampFromAddedAt(repo.addedAt)
-  return {
-    ...project,
-    sourceRepoIds,
-    createdAt: mergeCatalogCreatedAt(project.createdAt, addedAt),
-    updatedAt: mergeCatalogUpdatedAt(project.updatedAt, addedAt)
+function mergeProjectRepo(accumulator: ProjectAccumulator, repo: Repo): void {
+  const { project, sourceRepoIds } = accumulator
+  if (!sourceRepoIds.has(repo.id)) {
+    sourceRepoIds.add(repo.id)
+    project.sourceRepoIds.push(repo.id)
   }
+  const addedAt = catalogTimestampFromAddedAt(repo.addedAt)
+  project.createdAt = mergeCatalogCreatedAt(project.createdAt, addedAt)
+  project.updatedAt = mergeCatalogUpdatedAt(project.updatedAt, addedAt)
 }
 
 function createSetupFromRepo(repo: Repo, projectId: string): ProjectHostSetup {
@@ -312,15 +309,15 @@ export function projectHostSetupProjectionFromRepos(
   for (const repo of repos) {
     const projectId = getProjectId(repo)
     const existing = projectById.get(projectId)
-    const project = existing
-      ? mergeProjectRepo(existing.project, repo)
-      : createProjectFromRepo(repo)
+    if (existing) {
+      mergeProjectRepo(existing, repo)
+    } else {
+      const project = createProjectFromRepo(repo)
+      projectById.set(projectId, { project, sourceRepoIds: new Set(project.sourceRepoIds) })
+    }
     // Why normalize here: a repo row is untrusted persisted/wire data too, and these
     // constructors copy repo.path / repo.id straight onto fields consumers call .trim() on.
     const setup = normalizeProjectHostSetupRow(createSetupFromRepo(repo, projectId))
-    projectById.set(projectId, {
-      project
-    })
     setups.push(setup)
   }
 

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -8,6 +8,12 @@ import { githubRepoIdentityKey, isDefaultGitHubHost } from './github/repository-
 import type { Project, ProjectHostSetup, ProjectProviderIdentity } from './project-types'
 import type { Repo } from './repo-types'
 
+/**
+ * A projection-local draft. `project` is always freshly built by `createProjectFromRepo`, never a
+ * caller's or persisted row, because `mergeProjectRepo` writes to it in place; seeding it from an
+ * existing `Project` would leak those writes to whoever else holds that row. `sourceRepoIds`
+ * mirrors `project.sourceRepoIds` so membership is a lookup rather than a rescan.
+ */
 type ProjectAccumulator = {
   project: Project
   sourceRepoIds: Set<string>
@@ -263,6 +269,7 @@ function createProjectFromRepo(repo: Repo): Project {
   }
 }
 
+/** Mutates the draft in place — only ever call this on an accumulator this projection owns. */
 function mergeProjectRepo(accumulator: ProjectAccumulator, repo: Repo): void {
   const { project, sourceRepoIds } = accumulator
   if (!sourceRepoIds.has(repo.id)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

Orca groups the repos you've added into "projects" — several repos that point at the
same upstream become one project, and the project keeps a list of which repos it came
from.

It used to build that list by throwing it away and rewriting it from scratch every time
another repo joined. For a project with 2,000 repos that means copying roughly two
million list slots to end up with 2,000. Now it just adds the new repo to the end of the
list it is already building, and keeps a small side lookup so it can tell in one step
whether that repo is already in the list.

The list being appended to is one Orca builds fresh inside this function and hands out
only when it is finished, so nothing you or the rest of the app is holding gets edited
behind your back. Your repo rows are never touched, and every call still hands back its
own separate copy — so the settings screen, the project picker and the new-workspace
dialog all still refresh normally.

The result is identical: same projects, same order, same repos listed under each one,
same duplicate removal, same created/updated dates. This was verified by running 3,000
randomly generated repo catalogues — including Windows drive paths, network shares,
folder workspaces, repeated repo IDs and missing dates — through both the old and new
code; the two outputs are byte-for-byte identical.

## What Changed / Why

- 2,000 sources of one project: 1,999,000 accumulating-array elements copied → under 10,000; source order/dedupe and timestamp contracts pass

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 32 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/shared/project-host-setup-projection.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

