### PR TITLE
perf: lazily index workspace tabs during terminal binding replay

### DIFF
--- a/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.test.ts
+++ b/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.test.ts
@@ -1,46 +1,46 @@
-import { describe, expect, it } from "vitest";
-import type { WorkspaceSessionState } from "../../../shared/workspace-session-state-types";
-import { preserveMissingWorkspaceSessionTerminalBindings } from "./workspace-session-terminal-binding-replay";
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { preserveMissingWorkspaceSessionTerminalBindings } from './workspace-session-terminal-binding-replay'
 
-const LEAF_ONE = "11111111-1111-4111-8111-111111111111";
-const LEAF_TWO = "22222222-2222-4222-8222-222222222222";
-const WORKTREE_A = "worktree-a";
-const WORKTREE_B = "worktree-b";
+const LEAF_ONE = '11111111-1111-4111-8111-111111111111'
+const LEAF_TWO = '22222222-2222-4222-8222-222222222222'
+const WORKTREE_A = 'worktree-a'
+const WORKTREE_B = 'worktree-b'
 
 function session(ptyId: string | null): WorkspaceSessionState {
   return {
-    activeRepoId: "repo",
-    activeWorktreeId: "worktree",
-    activeTabId: "tab",
+    activeRepoId: 'repo',
+    activeWorktreeId: 'worktree',
+    activeTabId: 'tab',
     tabsByWorktree: {
       worktree: [
         {
-          id: "tab",
-          worktreeId: "worktree",
-          title: "Terminal",
+          id: 'tab',
+          worktreeId: 'worktree',
+          title: 'Terminal',
           customTitle: null,
           color: null,
           sortOrder: 0,
           createdAt: 1,
-          ptyId,
-        },
-      ],
+          ptyId
+        }
+      ]
     },
-    terminalLayoutsByTabId: {},
-  };
+    terminalLayoutsByTabId: {}
+  }
 }
 
 function terminalTab(worktreeId: string, id: string, ptyId: string | null) {
   return {
     id,
     worktreeId,
-    title: "Terminal",
+    title: 'Terminal',
     customTitle: null,
     color: null,
     sortOrder: 0,
     createdAt: 1,
-    ptyId,
-  };
+    ptyId
+  }
 }
 
 const bindingRecovery = {
@@ -48,190 +48,165 @@ const bindingRecovery = {
     new Set(root?.leafId ? [root.leafId] : []),
   getConnectionIdForWorktree: () => null,
   isRestorablePtyBinding: () => true,
-  hasRestorableSshRemotePtyLease: () => false,
-};
+  hasRestorableSshRemotePtyLease: () => false
+}
 
-describe("workspace session terminal binding replay", () => {
-  it("retains a restorable legacy tab binding when neither snapshot has a layout", () => {
-    const prior = session("runtime-pty");
-    const incoming = session(null);
+describe('workspace session terminal binding replay', () => {
+  it('retains a restorable legacy tab binding when neither snapshot has a layout', () => {
+    const prior = session('runtime-pty')
+    const incoming = session(null)
 
-    preserveMissingWorkspaceSessionTerminalBindings(
-      incoming,
-      prior,
-      bindingRecovery as never,
-    );
+    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
 
-    expect(incoming.tabsByWorktree.worktree[0]!.ptyId).toBe("runtime-pty");
-  });
+    expect(incoming.tabsByWorktree.worktree[0]!.ptyId).toBe('runtime-pty')
+  })
 
-  it("does not retain a tab binding whose prior leaf was removed from the layout", () => {
-    const prior = session("runtime-pty");
+  it('does not retain a tab binding whose prior leaf was removed from the layout', () => {
+    const prior = session('runtime-pty')
     prior.terminalLayoutsByTabId.tab = {
-      root: { type: "leaf", leafId: LEAF_ONE },
+      root: { type: 'leaf', leafId: LEAF_ONE },
       activeLeafId: LEAF_ONE,
       expandedLeafId: null,
-      ptyIdsByLeafId: { [LEAF_ONE]: "runtime-pty" },
-    };
-    const incoming = session(null);
+      ptyIdsByLeafId: { [LEAF_ONE]: 'runtime-pty' }
+    }
+    const incoming = session(null)
     incoming.terminalLayoutsByTabId.tab = {
-      root: { type: "leaf", leafId: LEAF_TWO },
+      root: { type: 'leaf', leafId: LEAF_TWO },
       activeLeafId: LEAF_TWO,
       expandedLeafId: null,
-      ptyIdsByLeafId: {},
-    };
+      ptyIdsByLeafId: {}
+    }
 
-    preserveMissingWorkspaceSessionTerminalBindings(
-      incoming,
-      prior,
-      bindingRecovery as never,
-    );
+    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
 
-    expect(incoming.tabsByWorktree.worktree[0]!.ptyId).toBeNull();
-  });
+    expect(incoming.tabsByWorktree.worktree[0]!.ptyId).toBeNull()
+  })
 
-  it("fails closed when one tab id is duplicated across worktrees", () => {
-    const prior = session(null);
+  it('fails closed when one tab id is duplicated across worktrees', () => {
+    const prior = session(null)
     prior.tabsByWorktree = {
-      [WORKTREE_A]: [terminalTab(WORKTREE_A, "duplicate-tab", "pty-a")],
-      [WORKTREE_B]: [terminalTab(WORKTREE_B, "duplicate-tab", "pty-b")],
-    };
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, 'duplicate-tab', 'pty-a')],
+      [WORKTREE_B]: [terminalTab(WORKTREE_B, 'duplicate-tab', 'pty-b')]
+    }
     prior.terminalLayoutsByTabId = {
-      "duplicate-tab": {
-        root: { type: "leaf", leafId: LEAF_ONE },
+      'duplicate-tab': {
+        root: { type: 'leaf', leafId: LEAF_ONE },
         activeLeafId: LEAF_ONE,
         expandedLeafId: null,
-        ptyIdsByLeafId: { [LEAF_ONE]: "pty-a" },
-      },
-    };
-    const incoming = session(null);
+        ptyIdsByLeafId: { [LEAF_ONE]: 'pty-a' }
+      }
+    }
+    const incoming = session(null)
     incoming.tabsByWorktree = {
-      [WORKTREE_A]: [terminalTab(WORKTREE_A, "duplicate-tab", null)],
-      [WORKTREE_B]: [terminalTab(WORKTREE_B, "duplicate-tab", null)],
-    };
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, 'duplicate-tab', null)],
+      [WORKTREE_B]: [terminalTab(WORKTREE_B, 'duplicate-tab', null)]
+    }
     incoming.terminalLayoutsByTabId = {
-      "duplicate-tab": {
-        root: { type: "leaf", leafId: LEAF_ONE },
+      'duplicate-tab': {
+        root: { type: 'leaf', leafId: LEAF_ONE },
         activeLeafId: LEAF_ONE,
         expandedLeafId: null,
-        ptyIdsByLeafId: {},
-      },
-    };
+        ptyIdsByLeafId: {}
+      }
+    }
 
-    preserveMissingWorkspaceSessionTerminalBindings(
-      incoming,
-      prior,
-      bindingRecovery as never,
-    );
+    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
 
-    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBeNull();
-    expect(incoming.tabsByWorktree[WORKTREE_B]![0]!.ptyId).toBeNull();
-    expect(
-      incoming.terminalLayoutsByTabId["duplicate-tab"]?.ptyIdsByLeafId,
-    ).toEqual({});
-  });
+    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBeNull()
+    expect(incoming.tabsByWorktree[WORKTREE_B]![0]!.ptyId).toBeNull()
+    expect(incoming.terminalLayoutsByTabId['duplicate-tab']?.ptyIdsByLeafId).toEqual({})
+  })
 
-  it("still replays bindings for distinct tab ids in separate worktrees", () => {
-    const prior = session(null);
+  it('still replays bindings for distinct tab ids in separate worktrees', () => {
+    const prior = session(null)
     prior.tabsByWorktree = {
-      [WORKTREE_A]: [terminalTab(WORKTREE_A, "tab-a", "pty-a")],
-      [WORKTREE_B]: [terminalTab(WORKTREE_B, "tab-b", "pty-b")],
-    };
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, 'tab-a', 'pty-a')],
+      [WORKTREE_B]: [terminalTab(WORKTREE_B, 'tab-b', 'pty-b')]
+    }
     prior.terminalLayoutsByTabId = {
-      "tab-a": {
-        root: { type: "leaf", leafId: LEAF_ONE },
+      'tab-a': {
+        root: { type: 'leaf', leafId: LEAF_ONE },
         activeLeafId: LEAF_ONE,
         expandedLeafId: null,
-        ptyIdsByLeafId: { [LEAF_ONE]: "pty-a" },
+        ptyIdsByLeafId: { [LEAF_ONE]: 'pty-a' }
       },
-      "tab-b": {
-        root: { type: "leaf", leafId: LEAF_TWO },
+      'tab-b': {
+        root: { type: 'leaf', leafId: LEAF_TWO },
         activeLeafId: LEAF_TWO,
         expandedLeafId: null,
-        ptyIdsByLeafId: { [LEAF_TWO]: "pty-b" },
-      },
-    };
-    const incoming = session(null);
+        ptyIdsByLeafId: { [LEAF_TWO]: 'pty-b' }
+      }
+    }
+    const incoming = session(null)
     incoming.tabsByWorktree = {
-      [WORKTREE_A]: [terminalTab(WORKTREE_A, "tab-a", null)],
-      [WORKTREE_B]: [terminalTab(WORKTREE_B, "tab-b", null)],
-    };
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, 'tab-a', null)],
+      [WORKTREE_B]: [terminalTab(WORKTREE_B, 'tab-b', null)]
+    }
     incoming.terminalLayoutsByTabId = {
-      "tab-a": {
-        root: { type: "leaf", leafId: LEAF_ONE },
+      'tab-a': {
+        root: { type: 'leaf', leafId: LEAF_ONE },
         activeLeafId: LEAF_ONE,
         expandedLeafId: null,
-        ptyIdsByLeafId: {},
+        ptyIdsByLeafId: {}
       },
-      "tab-b": {
-        root: { type: "leaf", leafId: LEAF_TWO },
+      'tab-b': {
+        root: { type: 'leaf', leafId: LEAF_TWO },
         activeLeafId: LEAF_TWO,
         expandedLeafId: null,
-        ptyIdsByLeafId: {},
-      },
-    };
+        ptyIdsByLeafId: {}
+      }
+    }
 
-    preserveMissingWorkspaceSessionTerminalBindings(
-      incoming,
-      prior,
-      bindingRecovery as never,
-    );
+    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
 
-    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBe("pty-a");
-    expect(incoming.tabsByWorktree[WORKTREE_B]![0]!.ptyId).toBe("pty-b");
-    expect(incoming.terminalLayoutsByTabId["tab-a"]?.ptyIdsByLeafId).toEqual({
-      [LEAF_ONE]: "pty-a",
-    });
-    expect(incoming.terminalLayoutsByTabId["tab-b"]?.ptyIdsByLeafId).toEqual({
-      [LEAF_TWO]: "pty-b",
-    });
-  });
-  it("fails closed when one tab id is duplicated inside a single worktree list", () => {
+    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBe('pty-a')
+    expect(incoming.tabsByWorktree[WORKTREE_B]![0]!.ptyId).toBe('pty-b')
+    expect(incoming.terminalLayoutsByTabId['tab-a']?.ptyIdsByLeafId).toEqual({
+      [LEAF_ONE]: 'pty-a'
+    })
+    expect(incoming.terminalLayoutsByTabId['tab-b']?.ptyIdsByLeafId).toEqual({
+      [LEAF_TWO]: 'pty-b'
+    })
+  })
+
+  it('fails closed when one tab id is duplicated inside a single worktree list', () => {
     // Map indexing is last-wins where a linear find was first-wins; the ambiguity
     // fence must skip these ids so the two strategies can never disagree.
-    const prior = session(null);
+    const prior = session(null)
     prior.tabsByWorktree = {
       [WORKTREE_A]: [
-        terminalTab(WORKTREE_A, "duplicate-tab", "pty-first"),
-        terminalTab(WORKTREE_A, "duplicate-tab", "pty-last"),
-      ],
-    };
-    const incoming = session(null);
+        terminalTab(WORKTREE_A, 'duplicate-tab', 'pty-first'),
+        terminalTab(WORKTREE_A, 'duplicate-tab', 'pty-last')
+      ]
+    }
+    const incoming = session(null)
     incoming.tabsByWorktree = {
-      [WORKTREE_A]: [terminalTab(WORKTREE_A, "duplicate-tab", null)],
-    };
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, 'duplicate-tab', null)]
+    }
 
-    preserveMissingWorkspaceSessionTerminalBindings(
-      incoming,
-      prior,
-      bindingRecovery as never,
-    );
+    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
 
-    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBeNull();
-  });
+    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBeNull()
+  })
 
-  it("indexes prior tabs once when replaying a large workspace snapshot", () => {
-    let reads = 0;
-    const prior = session(null);
+  it('indexes prior tabs once when replaying a large workspace snapshot', () => {
+    let reads = 0
+    const prior = session(null)
     prior.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) => ({
-      ...terminalTab("worktree", `tab-${i}`, `pty-${i}`),
+      ...terminalTab('worktree', `tab-${i}`, `pty-${i}`),
       get id() {
-        reads++;
-        return `tab-${i}`;
-      },
-    }));
-    const incoming = session(null);
+        reads++
+        return `tab-${i}`
+      }
+    }))
+    const incoming = session(null)
     incoming.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) =>
-      terminalTab("worktree", `tab-${i}`, null),
-    );
-    preserveMissingWorkspaceSessionTerminalBindings(
-      incoming,
-      prior,
-      bindingRecovery as never,
-    );
-    expect(reads).toBeLessThan(10_000);
+      terminalTab('worktree', `tab-${i}`, null)
+    )
+    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
+    expect(reads).toBeLessThan(10_000)
     expect(incoming.tabsByWorktree.worktree.map((tab) => tab.ptyId)).toEqual(
-      Array.from({ length: 1000 }, (_, i) => `pty-${i}`),
-    );
-  });
-});
+      Array.from({ length: 1000 }, (_, i) => `pty-${i}`)
+    )
+  })
+})

--- a/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.test.ts
+++ b/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.test.ts
@@ -1,46 +1,46 @@
-import { describe, expect, it } from 'vitest'
-import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
-import { preserveMissingWorkspaceSessionTerminalBindings } from './workspace-session-terminal-binding-replay'
+import { describe, expect, it } from "vitest";
+import type { WorkspaceSessionState } from "../../../shared/workspace-session-state-types";
+import { preserveMissingWorkspaceSessionTerminalBindings } from "./workspace-session-terminal-binding-replay";
 
-const LEAF_ONE = '11111111-1111-4111-8111-111111111111'
-const LEAF_TWO = '22222222-2222-4222-8222-222222222222'
-const WORKTREE_A = 'worktree-a'
-const WORKTREE_B = 'worktree-b'
+const LEAF_ONE = "11111111-1111-4111-8111-111111111111";
+const LEAF_TWO = "22222222-2222-4222-8222-222222222222";
+const WORKTREE_A = "worktree-a";
+const WORKTREE_B = "worktree-b";
 
 function session(ptyId: string | null): WorkspaceSessionState {
   return {
-    activeRepoId: 'repo',
-    activeWorktreeId: 'worktree',
-    activeTabId: 'tab',
+    activeRepoId: "repo",
+    activeWorktreeId: "worktree",
+    activeTabId: "tab",
     tabsByWorktree: {
       worktree: [
         {
-          id: 'tab',
-          worktreeId: 'worktree',
-          title: 'Terminal',
+          id: "tab",
+          worktreeId: "worktree",
+          title: "Terminal",
           customTitle: null,
           color: null,
           sortOrder: 0,
           createdAt: 1,
-          ptyId
-        }
-      ]
+          ptyId,
+        },
+      ],
     },
-    terminalLayoutsByTabId: {}
-  }
+    terminalLayoutsByTabId: {},
+  };
 }
 
 function terminalTab(worktreeId: string, id: string, ptyId: string | null) {
   return {
     id,
     worktreeId,
-    title: 'Terminal',
+    title: "Terminal",
     customTitle: null,
     color: null,
     sortOrder: 0,
     createdAt: 1,
-    ptyId
-  }
+    ptyId,
+  };
 }
 
 const bindingRecovery = {
@@ -48,145 +48,190 @@ const bindingRecovery = {
     new Set(root?.leafId ? [root.leafId] : []),
   getConnectionIdForWorktree: () => null,
   isRestorablePtyBinding: () => true,
-  hasRestorableSshRemotePtyLease: () => false
-}
+  hasRestorableSshRemotePtyLease: () => false,
+};
 
-describe('workspace session terminal binding replay', () => {
-  it('retains a restorable legacy tab binding when neither snapshot has a layout', () => {
-    const prior = session('runtime-pty')
-    const incoming = session(null)
+describe("workspace session terminal binding replay", () => {
+  it("retains a restorable legacy tab binding when neither snapshot has a layout", () => {
+    const prior = session("runtime-pty");
+    const incoming = session(null);
 
-    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
+    preserveMissingWorkspaceSessionTerminalBindings(
+      incoming,
+      prior,
+      bindingRecovery as never,
+    );
 
-    expect(incoming.tabsByWorktree.worktree[0]!.ptyId).toBe('runtime-pty')
-  })
+    expect(incoming.tabsByWorktree.worktree[0]!.ptyId).toBe("runtime-pty");
+  });
 
-  it('does not retain a tab binding whose prior leaf was removed from the layout', () => {
-    const prior = session('runtime-pty')
+  it("does not retain a tab binding whose prior leaf was removed from the layout", () => {
+    const prior = session("runtime-pty");
     prior.terminalLayoutsByTabId.tab = {
-      root: { type: 'leaf', leafId: LEAF_ONE },
+      root: { type: "leaf", leafId: LEAF_ONE },
       activeLeafId: LEAF_ONE,
       expandedLeafId: null,
-      ptyIdsByLeafId: { [LEAF_ONE]: 'runtime-pty' }
-    }
-    const incoming = session(null)
+      ptyIdsByLeafId: { [LEAF_ONE]: "runtime-pty" },
+    };
+    const incoming = session(null);
     incoming.terminalLayoutsByTabId.tab = {
-      root: { type: 'leaf', leafId: LEAF_TWO },
+      root: { type: "leaf", leafId: LEAF_TWO },
       activeLeafId: LEAF_TWO,
       expandedLeafId: null,
-      ptyIdsByLeafId: {}
-    }
+      ptyIdsByLeafId: {},
+    };
 
-    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
+    preserveMissingWorkspaceSessionTerminalBindings(
+      incoming,
+      prior,
+      bindingRecovery as never,
+    );
 
-    expect(incoming.tabsByWorktree.worktree[0]!.ptyId).toBeNull()
-  })
+    expect(incoming.tabsByWorktree.worktree[0]!.ptyId).toBeNull();
+  });
 
-  it('fails closed when one tab id is duplicated across worktrees', () => {
-    const prior = session(null)
+  it("fails closed when one tab id is duplicated across worktrees", () => {
+    const prior = session(null);
     prior.tabsByWorktree = {
-      [WORKTREE_A]: [terminalTab(WORKTREE_A, 'duplicate-tab', 'pty-a')],
-      [WORKTREE_B]: [terminalTab(WORKTREE_B, 'duplicate-tab', 'pty-b')]
-    }
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, "duplicate-tab", "pty-a")],
+      [WORKTREE_B]: [terminalTab(WORKTREE_B, "duplicate-tab", "pty-b")],
+    };
     prior.terminalLayoutsByTabId = {
-      'duplicate-tab': {
-        root: { type: 'leaf', leafId: LEAF_ONE },
+      "duplicate-tab": {
+        root: { type: "leaf", leafId: LEAF_ONE },
         activeLeafId: LEAF_ONE,
         expandedLeafId: null,
-        ptyIdsByLeafId: { [LEAF_ONE]: 'pty-a' }
-      }
-    }
-    const incoming = session(null)
-    incoming.tabsByWorktree = {
-      [WORKTREE_A]: [terminalTab(WORKTREE_A, 'duplicate-tab', null)],
-      [WORKTREE_B]: [terminalTab(WORKTREE_B, 'duplicate-tab', null)]
-    }
-    incoming.terminalLayoutsByTabId = {
-      'duplicate-tab': {
-        root: { type: 'leaf', leafId: LEAF_ONE },
-        activeLeafId: LEAF_ONE,
-        expandedLeafId: null,
-        ptyIdsByLeafId: {}
-      }
-    }
-
-    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
-
-    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBeNull()
-    expect(incoming.tabsByWorktree[WORKTREE_B]![0]!.ptyId).toBeNull()
-    expect(incoming.terminalLayoutsByTabId['duplicate-tab']?.ptyIdsByLeafId).toEqual({})
-  })
-
-  it('still replays bindings for distinct tab ids in separate worktrees', () => {
-    const prior = session(null)
-    prior.tabsByWorktree = {
-      [WORKTREE_A]: [terminalTab(WORKTREE_A, 'tab-a', 'pty-a')],
-      [WORKTREE_B]: [terminalTab(WORKTREE_B, 'tab-b', 'pty-b')]
-    }
-    prior.terminalLayoutsByTabId = {
-      'tab-a': {
-        root: { type: 'leaf', leafId: LEAF_ONE },
-        activeLeafId: LEAF_ONE,
-        expandedLeafId: null,
-        ptyIdsByLeafId: { [LEAF_ONE]: 'pty-a' }
+        ptyIdsByLeafId: { [LEAF_ONE]: "pty-a" },
       },
-      'tab-b': {
-        root: { type: 'leaf', leafId: LEAF_TWO },
+    };
+    const incoming = session(null);
+    incoming.tabsByWorktree = {
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, "duplicate-tab", null)],
+      [WORKTREE_B]: [terminalTab(WORKTREE_B, "duplicate-tab", null)],
+    };
+    incoming.terminalLayoutsByTabId = {
+      "duplicate-tab": {
+        root: { type: "leaf", leafId: LEAF_ONE },
+        activeLeafId: LEAF_ONE,
+        expandedLeafId: null,
+        ptyIdsByLeafId: {},
+      },
+    };
+
+    preserveMissingWorkspaceSessionTerminalBindings(
+      incoming,
+      prior,
+      bindingRecovery as never,
+    );
+
+    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBeNull();
+    expect(incoming.tabsByWorktree[WORKTREE_B]![0]!.ptyId).toBeNull();
+    expect(
+      incoming.terminalLayoutsByTabId["duplicate-tab"]?.ptyIdsByLeafId,
+    ).toEqual({});
+  });
+
+  it("still replays bindings for distinct tab ids in separate worktrees", () => {
+    const prior = session(null);
+    prior.tabsByWorktree = {
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, "tab-a", "pty-a")],
+      [WORKTREE_B]: [terminalTab(WORKTREE_B, "tab-b", "pty-b")],
+    };
+    prior.terminalLayoutsByTabId = {
+      "tab-a": {
+        root: { type: "leaf", leafId: LEAF_ONE },
+        activeLeafId: LEAF_ONE,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_ONE]: "pty-a" },
+      },
+      "tab-b": {
+        root: { type: "leaf", leafId: LEAF_TWO },
         activeLeafId: LEAF_TWO,
         expandedLeafId: null,
-        ptyIdsByLeafId: { [LEAF_TWO]: 'pty-b' }
-      }
-    }
-    const incoming = session(null)
+        ptyIdsByLeafId: { [LEAF_TWO]: "pty-b" },
+      },
+    };
+    const incoming = session(null);
     incoming.tabsByWorktree = {
-      [WORKTREE_A]: [terminalTab(WORKTREE_A, 'tab-a', null)],
-      [WORKTREE_B]: [terminalTab(WORKTREE_B, 'tab-b', null)]
-    }
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, "tab-a", null)],
+      [WORKTREE_B]: [terminalTab(WORKTREE_B, "tab-b", null)],
+    };
     incoming.terminalLayoutsByTabId = {
-      'tab-a': {
-        root: { type: 'leaf', leafId: LEAF_ONE },
+      "tab-a": {
+        root: { type: "leaf", leafId: LEAF_ONE },
         activeLeafId: LEAF_ONE,
         expandedLeafId: null,
-        ptyIdsByLeafId: {}
+        ptyIdsByLeafId: {},
       },
-      'tab-b': {
-        root: { type: 'leaf', leafId: LEAF_TWO },
+      "tab-b": {
+        root: { type: "leaf", leafId: LEAF_TWO },
         activeLeafId: LEAF_TWO,
         expandedLeafId: null,
-        ptyIdsByLeafId: {}
-      }
-    }
+        ptyIdsByLeafId: {},
+      },
+    };
 
-    preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
+    preserveMissingWorkspaceSessionTerminalBindings(
+      incoming,
+      prior,
+      bindingRecovery as never,
+    );
 
-    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBe('pty-a')
-    expect(incoming.tabsByWorktree[WORKTREE_B]![0]!.ptyId).toBe('pty-b')
-    expect(incoming.terminalLayoutsByTabId['tab-a']?.ptyIdsByLeafId).toEqual({
-      [LEAF_ONE]: 'pty-a'
-    })
-    expect(incoming.terminalLayoutsByTabId['tab-b']?.ptyIdsByLeafId).toEqual({
-      [LEAF_TWO]: 'pty-b'
-    })
-  })
-})
+    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBe("pty-a");
+    expect(incoming.tabsByWorktree[WORKTREE_B]![0]!.ptyId).toBe("pty-b");
+    expect(incoming.terminalLayoutsByTabId["tab-a"]?.ptyIdsByLeafId).toEqual({
+      [LEAF_ONE]: "pty-a",
+    });
+    expect(incoming.terminalLayoutsByTabId["tab-b"]?.ptyIdsByLeafId).toEqual({
+      [LEAF_TWO]: "pty-b",
+    });
+  });
+  it("fails closed when one tab id is duplicated inside a single worktree list", () => {
+    // Map indexing is last-wins where a linear find was first-wins; the ambiguity
+    // fence must skip these ids so the two strategies can never disagree.
+    const prior = session(null);
+    prior.tabsByWorktree = {
+      [WORKTREE_A]: [
+        terminalTab(WORKTREE_A, "duplicate-tab", "pty-first"),
+        terminalTab(WORKTREE_A, "duplicate-tab", "pty-last"),
+      ],
+    };
+    const incoming = session(null);
+    incoming.tabsByWorktree = {
+      [WORKTREE_A]: [terminalTab(WORKTREE_A, "duplicate-tab", null)],
+    };
 
-it('indexes prior tabs once when replaying a large workspace snapshot', () => {
-  let reads = 0
-  const prior = session(null)
-  prior.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) => ({
-    ...terminalTab('worktree', `tab-${i}`, `pty-${i}`),
-    get id() {
-      reads++
-      return `tab-${i}`
-    }
-  }))
-  const incoming = session(null)
-  incoming.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) =>
-    terminalTab('worktree', `tab-${i}`, null)
-  )
-  preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
-  expect(reads).toBeLessThan(10_000)
-  expect(incoming.tabsByWorktree.worktree.map((tab) => tab.ptyId)).toEqual(
-    Array.from({ length: 1000 }, (_, i) => `pty-${i}`)
-  )
-})
+    preserveMissingWorkspaceSessionTerminalBindings(
+      incoming,
+      prior,
+      bindingRecovery as never,
+    );
+
+    expect(incoming.tabsByWorktree[WORKTREE_A]![0]!.ptyId).toBeNull();
+  });
+
+  it("indexes prior tabs once when replaying a large workspace snapshot", () => {
+    let reads = 0;
+    const prior = session(null);
+    prior.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) => ({
+      ...terminalTab("worktree", `tab-${i}`, `pty-${i}`),
+      get id() {
+        reads++;
+        return `tab-${i}`;
+      },
+    }));
+    const incoming = session(null);
+    incoming.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) =>
+      terminalTab("worktree", `tab-${i}`, null),
+    );
+    preserveMissingWorkspaceSessionTerminalBindings(
+      incoming,
+      prior,
+      bindingRecovery as never,
+    );
+    expect(reads).toBeLessThan(10_000);
+    expect(incoming.tabsByWorktree.worktree.map((tab) => tab.ptyId)).toEqual(
+      Array.from({ length: 1000 }, (_, i) => `pty-${i}`),
+    );
+  });
+});

--- a/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.test.ts
+++ b/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.test.ts
@@ -169,3 +169,24 @@ describe('workspace session terminal binding replay', () => {
     })
   })
 })
+
+it('indexes prior tabs once when replaying a large workspace snapshot', () => {
+  let reads = 0
+  const prior = session(null)
+  prior.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) => ({
+    ...terminalTab('worktree', `tab-${i}`, `pty-${i}`),
+    get id() {
+      reads++
+      return `tab-${i}`
+    }
+  }))
+  const incoming = session(null)
+  incoming.tabsByWorktree.worktree = Array.from({ length: 1000 }, (_, i) =>
+    terminalTab('worktree', `tab-${i}`, null)
+  )
+  preserveMissingWorkspaceSessionTerminalBindings(incoming, prior, bindingRecovery as never)
+  expect(reads).toBeLessThan(10_000)
+  expect(incoming.tabsByWorktree.worktree.map((tab) => tab.ptyId)).toEqual(
+    Array.from({ length: 1000 }, (_, i) => `pty-${i}`)
+  )
+})

--- a/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.ts
+++ b/src/main/persistence/loading-store/workspace-session-terminal-binding-replay.ts
@@ -93,6 +93,7 @@ export function preserveMissingWorkspaceSessionTerminalBindings(
     if (!priorList) {
       continue
     }
+    let priorById: Map<string, (typeof priorList)[number]> | undefined
     for (const tab of tabs) {
       if (ambiguousTabIds.has(tab.id)) {
         continue
@@ -100,7 +101,8 @@ export function preserveMissingWorkspaceSessionTerminalBindings(
       if (tab.ptyId) {
         continue
       }
-      const priorTab = priorList.find((candidate) => candidate.id === tab.id)
+      priorById ??= new Map(priorList.map((candidate) => [candidate.id, candidate]))
+      const priorTab = priorById.get(tab.id)
       const incomingLayout = nextLayouts[tab.id]
       const priorLayout = priorLayouts[tab.id]
       const priorPtyLeafId = priorLayout


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

When Orca saves or reloads your workspace, it has to re-attach each terminal tab to the shell process it was already running, so your terminals don't come back blank.

To do that it compares the new list of tabs against the previously saved list. The old code searched that saved list from the beginning, separately, for every tab that needed re-attaching. With 1,000 tabs that is roughly half a million comparisons — the classic "read the whole address book once per person" problem.

Now it builds a lookup table of the saved tabs once, and only at the moment the first tab actually needs re-attaching. Every tab after that is a direct lookup instead of another full search. If nothing needs re-attaching — the normal case — no table is built at all.

Nothing about *which* shell goes to *which* tab changes. All the existing safety rules still apply, including the one that says: if the same tab ID shows up twice, don't guess — leave that tab alone.

## What Changed / Why

- `preserveMissingWorkspaceSessionTerminalBindings` replaced a per-tab `Array.prototype.find` over the prior tab list with a lazily built `Map`, scoped to a single worktree iteration.
- 1,000 bindings: 502,500 prior tab-ID reads → under 10,000. Ambiguity, removed-leaf and execution-host fences are untouched.
- The index is read-only over the `prior` snapshot, which this function never mutates, so it cannot go stale mid-replay. It is declared inside the per-worktree loop, so it cannot leak across worktrees.
- `Map` construction is last-wins where `find` was first-wins. That difference is unreachable: any tab ID duplicated inside one snapshot is already added to `ambiguousTabIds` and skipped before the lookup. Added regression coverage for the same-worktree duplicate case, which previously only had cross-worktree coverage.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 6 tests across 1 suite(s) passed on this isolated branch on macOS.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/persistence/loading-store/workspace-session-terminal-binding-replay.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
