### PR TITLE
perf: index selected-host SSH leases by PTY

### DIFF
--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.test.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.test.ts
@@ -1,190 +1,136 @@
-import { describe, expect, it, vi } from "vitest";
-import {
-  getDefaultPersistedState,
-  getDefaultWorkspaceSession,
-} from "../../../shared/constants";
-import type { SshRemotePtyLease } from "../../../shared/ssh-types";
-import { toComparableRelaySshPtyId } from "../../../shared/ssh-pty-id";
-import { clearSshRemotePtyBindingsForLeases } from "./ssh-pty-binding-cleanup";
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../../shared/constants'
+import type { SshRemotePtyLease } from '../../../shared/ssh-types'
+import { toComparableRelaySshPtyId } from '../../../shared/ssh-pty-id'
+import { clearSshRemotePtyBindingsForLeases } from './ssh-pty-binding-cleanup'
 
 function fixture(count: number) {
-  const state = getDefaultPersistedState("/home/test");
-  state.workspaceSession = getDefaultWorkspaceSession();
-  state.workspaceSession.tabsByWorktree.wt = Array.from(
-    { length: count },
-    (_, i) => ({
-      id: `tab-${i}`,
-      worktreeId: "wt",
-      ptyId: `pty-${i}`,
-      title: "",
-      customTitle: null,
-      color: null,
-      sortOrder: i,
-      createdAt: 1,
-    }),
-  );
+  const state = getDefaultPersistedState('/home/test')
+  state.workspaceSession = getDefaultWorkspaceSession()
+  state.workspaceSession.tabsByWorktree.wt = Array.from({ length: count }, (_, i) => ({
+    id: `tab-${i}`,
+    worktreeId: 'wt',
+    ptyId: `pty-${i}`,
+    title: '',
+    customTitle: null,
+    color: null,
+    sortOrder: i,
+    createdAt: 1
+  }))
   const leases: SshRemotePtyLease[] = Array.from({ length: count }, (_, i) => ({
-    targetId: "ssh-one",
+    targetId: 'ssh-one',
     ptyId: `pty-${i}`,
     tabId: `tab-${i}`,
-    worktreeId: "wt",
-    state: "detached",
+    worktreeId: 'wt',
+    state: 'detached',
     createdAt: 1,
-    updatedAt: 1,
-  }));
+    updatedAt: 1
+  }))
   return {
     state,
     leases,
     toComparablePtyId: vi.fn((_target: string, ptyId: string) => ptyId),
-    scheduleSave: vi.fn(),
-  };
+    scheduleSave: vi.fn()
+  }
 }
 
-describe("SSH binding cleanup indexing", () => {
-  it("normalizes each binding once across a large lease inventory", () => {
-    const operations = fixture(1000);
+describe('SSH binding cleanup indexing', () => {
+  it('normalizes each binding once across a large lease inventory', () => {
+    const operations = fixture(1000)
+    expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(true)
+    expect(operations.toComparablePtyId).toHaveBeenCalledTimes(1000)
     expect(
-      clearSshRemotePtyBindingsForLeases(
-        operations,
-        "ssh-one",
-        operations.leases,
-      ),
-    ).toBe(true);
-    expect(operations.toComparablePtyId).toHaveBeenCalledTimes(1000);
-    expect(
-      operations.state.workspaceSession!.tabsByWorktree.wt.every(
-        (tab) => tab.ptyId === null,
-      ),
-    ).toBe(true);
-    expect(operations.scheduleSave).toHaveBeenCalledTimes(1);
-  });
+      operations.state.workspaceSession!.tabsByWorktree.wt.every((tab) => tab.ptyId === null)
+    ).toBe(true)
+    expect(operations.scheduleSave).toHaveBeenCalledTimes(1)
+  })
 
-  it("retains foreign hosts and conflicting tab/workspace leases", () => {
-    const operations = fixture(4);
-    operations.leases[0].targetId = "ssh-two";
-    operations.leases[1].tabId = "other-tab";
-    operations.leases[2].worktreeId = "other-workspace";
-    delete operations.leases[3].tabId;
-    clearSshRemotePtyBindingsForLeases(
-      operations,
-      "ssh-one",
-      operations.leases,
-    );
-    expect(
-      operations.state.workspaceSession!.tabsByWorktree.wt.map(
-        (tab) => tab.ptyId,
-      ),
-    ).toEqual(["pty-0", "pty-1", "pty-2", null]);
-  });
+  it('retains foreign hosts and conflicting tab/workspace leases', () => {
+    const operations = fixture(4)
+    operations.leases[0].targetId = 'ssh-two'
+    operations.leases[1].tabId = 'other-tab'
+    operations.leases[2].worktreeId = 'other-workspace'
+    delete operations.leases[3].tabId
+    clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)
+    expect(operations.state.workspaceSession!.tabsByWorktree.wt.map((tab) => tab.ptyId)).toEqual([
+      'pty-0',
+      'pty-1',
+      'pty-2',
+      null
+    ])
+  })
 
-  it("matches layout leaves against every lease for a PTY while preserving leaf conflicts", () => {
-    const operations = fixture(1);
-    const session = operations.state.workspaceSession!;
-    session.tabsByWorktree.wt[0].ptyId = null;
-    session.terminalLayoutsByTabId["tab-0"] = {
+  it('matches layout leaves against every lease for a PTY while preserving leaf conflicts', () => {
+    const operations = fixture(1)
+    const session = operations.state.workspaceSession!
+    session.tabsByWorktree.wt[0].ptyId = null
+    session.terminalLayoutsByTabId['tab-0'] = {
       root: null,
       activeLeafId: null,
       expandedLeafId: null,
       ptyIdsByLeafId: {
-        matched: "pty-0",
-        protected: "pty-0",
-        wildcard: "pty-1",
-      },
-    };
-    const lease = operations.leases[0];
+        matched: 'pty-0',
+        protected: 'pty-0',
+        wildcard: 'pty-1'
+      }
+    }
+    const lease = operations.leases[0]
     operations.leases = [
-      { ...lease, leafId: "wrong" },
-      { ...lease, leafId: "matched" },
-      { ...lease, ptyId: "pty-1" },
-    ];
-    expect(
-      clearSshRemotePtyBindingsForLeases(
-        operations,
-        "ssh-one",
-        operations.leases,
-      ),
-    ).toBe(true);
-    expect(session.terminalLayoutsByTabId["tab-0"].ptyIdsByLeafId).toEqual({
-      protected: "pty-0",
-    });
-    expect(operations.toComparablePtyId).toHaveBeenCalledTimes(3);
-  });
+      { ...lease, leafId: 'wrong' },
+      { ...lease, leafId: 'matched' },
+      { ...lease, ptyId: 'pty-1' }
+    ]
+    expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(true)
+    expect(session.terminalLayoutsByTabId['tab-0'].ptyIdsByLeafId).toEqual({
+      protected: 'pty-0'
+    })
+    expect(operations.toComparablePtyId).toHaveBeenCalledTimes(3)
+  })
 
-  it("normalizes app-form binding ids onto the relay-form lease key", () => {
+  it('normalizes app-form binding ids onto the relay-form lease key', () => {
     // Leases store the relay-local id; sessions may hold the app-wide "ssh:<target>@@<id>" form.
     // The index key is the normalized form, so both spellings still name the same PTY.
-    const operations = fixture(1);
-    operations.toComparablePtyId = vi.fn(toComparableRelaySshPtyId);
-    operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId =
-      "ssh:ssh-one@@pty-0";
+    const operations = fixture(1)
+    operations.toComparablePtyId = vi.fn(toComparableRelaySshPtyId)
+    operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId = 'ssh:ssh-one@@pty-0'
 
-    expect(
-      clearSshRemotePtyBindingsForLeases(
-        operations,
-        "ssh-one",
-        operations.leases,
-      ),
-    ).toBe(true);
-    expect(
-      operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId,
-    ).toBeNull();
-  });
+    expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(true)
+    expect(operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId).toBeNull()
+  })
 
-  it("keeps a binding whose app-form id names a different SSH target", () => {
+  it('keeps a binding whose app-form id names a different SSH target', () => {
     // Relay-local ids collide across targets ("pty-0" exists on every host). Clearing ssh-one must
     // never scrub a pane still bound to a live ssh-two shell.
-    const operations = fixture(1);
-    operations.toComparablePtyId = vi.fn(toComparableRelaySshPtyId);
-    operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId =
-      "ssh:ssh-two@@pty-0";
+    const operations = fixture(1)
+    operations.toComparablePtyId = vi.fn(toComparableRelaySshPtyId)
+    operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId = 'ssh:ssh-two@@pty-0'
 
-    expect(
-      clearSshRemotePtyBindingsForLeases(
-        operations,
-        "ssh-one",
-        operations.leases,
-      ),
-    ).toBe(false);
-    expect(operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId).toBe(
-      "ssh:ssh-two@@pty-0",
-    );
-    expect(operations.scheduleSave).not.toHaveBeenCalled();
-  });
+    expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(false)
+    expect(operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId).toBe('ssh:ssh-two@@pty-0')
+    expect(operations.scheduleSave).not.toHaveBeenCalled()
+  })
 
-  it("keeps every binding when no lease names its PTY", () => {
+  it('keeps every binding when no lease names its PTY', () => {
     // A bucket miss must fail closed: leak a stale id rather than unbind a live pane.
-    const operations = fixture(2);
+    const operations = fixture(2)
     for (const lease of operations.leases) {
-      lease.ptyId = `unrelated-${lease.ptyId}`;
+      lease.ptyId = `unrelated-${lease.ptyId}`
     }
 
-    expect(
-      clearSshRemotePtyBindingsForLeases(
-        operations,
-        "ssh-one",
-        operations.leases,
-      ),
-    ).toBe(false);
-    expect(
-      operations.state.workspaceSession!.tabsByWorktree.wt.map(
-        (tab) => tab.ptyId,
-      ),
-    ).toEqual(["pty-0", "pty-1"]);
-    expect(operations.scheduleSave).not.toHaveBeenCalled();
-  });
+    expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(false)
+    expect(operations.state.workspaceSession!.tabsByWorktree.wt.map((tab) => tab.ptyId)).toEqual([
+      'pty-0',
+      'pty-1'
+    ])
+    expect(operations.scheduleSave).not.toHaveBeenCalled()
+  })
 
-  it("does not index leases when the session holds no bindings to check", () => {
-    const operations = fixture(500);
-    operations.state.workspaceSession!.tabsByWorktree = {};
-    operations.state.workspaceSession!.terminalLayoutsByTabId = {};
+  it('does not index leases when the session holds no bindings to check', () => {
+    const operations = fixture(500)
+    operations.state.workspaceSession!.tabsByWorktree = {}
+    operations.state.workspaceSession!.terminalLayoutsByTabId = {}
 
-    expect(
-      clearSshRemotePtyBindingsForLeases(
-        operations,
-        "ssh-one",
-        operations.leases,
-      ),
-    ).toBe(false);
-    expect(operations.toComparablePtyId).not.toHaveBeenCalled();
-  });
-});
+    expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(false)
+    expect(operations.toComparablePtyId).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.test.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.test.ts
@@ -1,82 +1,190 @@
-import { describe, expect, it, vi } from 'vitest'
-import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../../shared/constants'
-import type { SshRemotePtyLease } from '../../../shared/ssh-types'
-import { clearSshRemotePtyBindingsForLeases } from './ssh-pty-binding-cleanup'
+import { describe, expect, it, vi } from "vitest";
+import {
+  getDefaultPersistedState,
+  getDefaultWorkspaceSession,
+} from "../../../shared/constants";
+import type { SshRemotePtyLease } from "../../../shared/ssh-types";
+import { toComparableRelaySshPtyId } from "../../../shared/ssh-pty-id";
+import { clearSshRemotePtyBindingsForLeases } from "./ssh-pty-binding-cleanup";
 
 function fixture(count: number) {
-  const state = getDefaultPersistedState('/home/test')
-  state.workspaceSession = getDefaultWorkspaceSession()
-  state.workspaceSession.tabsByWorktree.wt = Array.from({ length: count }, (_, i) => ({
-    id: `tab-${i}`,
-    worktreeId: 'wt',
-    ptyId: `pty-${i}`,
-    title: '',
-    customTitle: null,
-    color: null,
-    sortOrder: i,
-    createdAt: 1
-  }))
+  const state = getDefaultPersistedState("/home/test");
+  state.workspaceSession = getDefaultWorkspaceSession();
+  state.workspaceSession.tabsByWorktree.wt = Array.from(
+    { length: count },
+    (_, i) => ({
+      id: `tab-${i}`,
+      worktreeId: "wt",
+      ptyId: `pty-${i}`,
+      title: "",
+      customTitle: null,
+      color: null,
+      sortOrder: i,
+      createdAt: 1,
+    }),
+  );
   const leases: SshRemotePtyLease[] = Array.from({ length: count }, (_, i) => ({
-    targetId: 'ssh-one',
+    targetId: "ssh-one",
     ptyId: `pty-${i}`,
     tabId: `tab-${i}`,
-    worktreeId: 'wt',
-    state: 'detached',
+    worktreeId: "wt",
+    state: "detached",
     createdAt: 1,
-    updatedAt: 1
-  }))
+    updatedAt: 1,
+  }));
   return {
     state,
     leases,
     toComparablePtyId: vi.fn((_target: string, ptyId: string) => ptyId),
-    scheduleSave: vi.fn()
-  }
+    scheduleSave: vi.fn(),
+  };
 }
 
-describe('SSH binding cleanup indexing', () => {
-  it('normalizes each binding once across a large lease inventory', () => {
-    const operations = fixture(1000)
-    expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(true)
-    expect(operations.toComparablePtyId).toHaveBeenCalledTimes(1000)
+describe("SSH binding cleanup indexing", () => {
+  it("normalizes each binding once across a large lease inventory", () => {
+    const operations = fixture(1000);
     expect(
-      operations.state.workspaceSession!.tabsByWorktree.wt.every((tab) => tab.ptyId === null)
-    ).toBe(true)
-    expect(operations.scheduleSave).toHaveBeenCalledTimes(1)
-  })
+      clearSshRemotePtyBindingsForLeases(
+        operations,
+        "ssh-one",
+        operations.leases,
+      ),
+    ).toBe(true);
+    expect(operations.toComparablePtyId).toHaveBeenCalledTimes(1000);
+    expect(
+      operations.state.workspaceSession!.tabsByWorktree.wt.every(
+        (tab) => tab.ptyId === null,
+      ),
+    ).toBe(true);
+    expect(operations.scheduleSave).toHaveBeenCalledTimes(1);
+  });
 
-  it('retains foreign hosts and conflicting tab/workspace leases', () => {
-    const operations = fixture(4)
-    operations.leases[0].targetId = 'ssh-two'
-    operations.leases[1].tabId = 'other-tab'
-    operations.leases[2].worktreeId = 'other-workspace'
-    delete operations.leases[3].tabId
-    clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)
-    expect(operations.state.workspaceSession!.tabsByWorktree.wt.map((tab) => tab.ptyId)).toEqual([
-      'pty-0',
-      'pty-1',
-      'pty-2',
-      null
-    ])
-  })
-})
+  it("retains foreign hosts and conflicting tab/workspace leases", () => {
+    const operations = fixture(4);
+    operations.leases[0].targetId = "ssh-two";
+    operations.leases[1].tabId = "other-tab";
+    operations.leases[2].worktreeId = "other-workspace";
+    delete operations.leases[3].tabId;
+    clearSshRemotePtyBindingsForLeases(
+      operations,
+      "ssh-one",
+      operations.leases,
+    );
+    expect(
+      operations.state.workspaceSession!.tabsByWorktree.wt.map(
+        (tab) => tab.ptyId,
+      ),
+    ).toEqual(["pty-0", "pty-1", "pty-2", null]);
+  });
 
-it('matches layout leaves against every lease for a PTY while preserving leaf conflicts', () => {
-  const operations = fixture(1)
-  const session = operations.state.workspaceSession!
-  session.tabsByWorktree.wt[0].ptyId = null
-  session.terminalLayoutsByTabId['tab-0'] = {
-    root: null,
-    activeLeafId: null,
-    expandedLeafId: null,
-    ptyIdsByLeafId: { matched: 'pty-0', protected: 'pty-0', wildcard: 'pty-1' }
-  }
-  const lease = operations.leases[0]
-  operations.leases = [
-    { ...lease, leafId: 'wrong' },
-    { ...lease, leafId: 'matched' },
-    { ...lease, ptyId: 'pty-1' }
-  ]
-  expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(true)
-  expect(session.terminalLayoutsByTabId['tab-0'].ptyIdsByLeafId).toEqual({ protected: 'pty-0' })
-  expect(operations.toComparablePtyId).toHaveBeenCalledTimes(3)
-})
+  it("matches layout leaves against every lease for a PTY while preserving leaf conflicts", () => {
+    const operations = fixture(1);
+    const session = operations.state.workspaceSession!;
+    session.tabsByWorktree.wt[0].ptyId = null;
+    session.terminalLayoutsByTabId["tab-0"] = {
+      root: null,
+      activeLeafId: null,
+      expandedLeafId: null,
+      ptyIdsByLeafId: {
+        matched: "pty-0",
+        protected: "pty-0",
+        wildcard: "pty-1",
+      },
+    };
+    const lease = operations.leases[0];
+    operations.leases = [
+      { ...lease, leafId: "wrong" },
+      { ...lease, leafId: "matched" },
+      { ...lease, ptyId: "pty-1" },
+    ];
+    expect(
+      clearSshRemotePtyBindingsForLeases(
+        operations,
+        "ssh-one",
+        operations.leases,
+      ),
+    ).toBe(true);
+    expect(session.terminalLayoutsByTabId["tab-0"].ptyIdsByLeafId).toEqual({
+      protected: "pty-0",
+    });
+    expect(operations.toComparablePtyId).toHaveBeenCalledTimes(3);
+  });
+
+  it("normalizes app-form binding ids onto the relay-form lease key", () => {
+    // Leases store the relay-local id; sessions may hold the app-wide "ssh:<target>@@<id>" form.
+    // The index key is the normalized form, so both spellings still name the same PTY.
+    const operations = fixture(1);
+    operations.toComparablePtyId = vi.fn(toComparableRelaySshPtyId);
+    operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId =
+      "ssh:ssh-one@@pty-0";
+
+    expect(
+      clearSshRemotePtyBindingsForLeases(
+        operations,
+        "ssh-one",
+        operations.leases,
+      ),
+    ).toBe(true);
+    expect(
+      operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId,
+    ).toBeNull();
+  });
+
+  it("keeps a binding whose app-form id names a different SSH target", () => {
+    // Relay-local ids collide across targets ("pty-0" exists on every host). Clearing ssh-one must
+    // never scrub a pane still bound to a live ssh-two shell.
+    const operations = fixture(1);
+    operations.toComparablePtyId = vi.fn(toComparableRelaySshPtyId);
+    operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId =
+      "ssh:ssh-two@@pty-0";
+
+    expect(
+      clearSshRemotePtyBindingsForLeases(
+        operations,
+        "ssh-one",
+        operations.leases,
+      ),
+    ).toBe(false);
+    expect(operations.state.workspaceSession!.tabsByWorktree.wt[0].ptyId).toBe(
+      "ssh:ssh-two@@pty-0",
+    );
+    expect(operations.scheduleSave).not.toHaveBeenCalled();
+  });
+
+  it("keeps every binding when no lease names its PTY", () => {
+    // A bucket miss must fail closed: leak a stale id rather than unbind a live pane.
+    const operations = fixture(2);
+    for (const lease of operations.leases) {
+      lease.ptyId = `unrelated-${lease.ptyId}`;
+    }
+
+    expect(
+      clearSshRemotePtyBindingsForLeases(
+        operations,
+        "ssh-one",
+        operations.leases,
+      ),
+    ).toBe(false);
+    expect(
+      operations.state.workspaceSession!.tabsByWorktree.wt.map(
+        (tab) => tab.ptyId,
+      ),
+    ).toEqual(["pty-0", "pty-1"]);
+    expect(operations.scheduleSave).not.toHaveBeenCalled();
+  });
+
+  it("does not index leases when the session holds no bindings to check", () => {
+    const operations = fixture(500);
+    operations.state.workspaceSession!.tabsByWorktree = {};
+    operations.state.workspaceSession!.terminalLayoutsByTabId = {};
+
+    expect(
+      clearSshRemotePtyBindingsForLeases(
+        operations,
+        "ssh-one",
+        operations.leases,
+      ),
+    ).toBe(false);
+    expect(operations.toComparablePtyId).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.test.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../../shared/constants'
+import type { SshRemotePtyLease } from '../../../shared/ssh-types'
+import { clearSshRemotePtyBindingsForLeases } from './ssh-pty-binding-cleanup'
+
+function fixture(count: number) {
+  const state = getDefaultPersistedState('/home/test')
+  state.workspaceSession = getDefaultWorkspaceSession()
+  state.workspaceSession.tabsByWorktree.wt = Array.from({ length: count }, (_, i) => ({
+    id: `tab-${i}`,
+    worktreeId: 'wt',
+    ptyId: `pty-${i}`,
+    title: '',
+    customTitle: null,
+    color: null,
+    sortOrder: i,
+    createdAt: 1
+  }))
+  const leases: SshRemotePtyLease[] = Array.from({ length: count }, (_, i) => ({
+    targetId: 'ssh-one',
+    ptyId: `pty-${i}`,
+    tabId: `tab-${i}`,
+    worktreeId: 'wt',
+    state: 'detached',
+    createdAt: 1,
+    updatedAt: 1
+  }))
+  return {
+    state,
+    leases,
+    toComparablePtyId: vi.fn((_target: string, ptyId: string) => ptyId),
+    scheduleSave: vi.fn()
+  }
+}
+
+describe('SSH binding cleanup indexing', () => {
+  it('normalizes each binding once across a large lease inventory', () => {
+    const operations = fixture(1000)
+    expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(true)
+    expect(operations.toComparablePtyId).toHaveBeenCalledTimes(1000)
+    expect(
+      operations.state.workspaceSession!.tabsByWorktree.wt.every((tab) => tab.ptyId === null)
+    ).toBe(true)
+    expect(operations.scheduleSave).toHaveBeenCalledTimes(1)
+  })
+
+  it('retains foreign hosts and conflicting tab/workspace leases', () => {
+    const operations = fixture(4)
+    operations.leases[0].targetId = 'ssh-two'
+    operations.leases[1].tabId = 'other-tab'
+    operations.leases[2].worktreeId = 'other-workspace'
+    delete operations.leases[3].tabId
+    clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)
+    expect(operations.state.workspaceSession!.tabsByWorktree.wt.map((tab) => tab.ptyId)).toEqual([
+      'pty-0',
+      'pty-1',
+      'pty-2',
+      null
+    ])
+  })
+})
+
+it('matches layout leaves against every lease for a PTY while preserving leaf conflicts', () => {
+  const operations = fixture(1)
+  const session = operations.state.workspaceSession!
+  session.tabsByWorktree.wt[0].ptyId = null
+  session.terminalLayoutsByTabId['tab-0'] = {
+    root: null,
+    activeLeafId: null,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { matched: 'pty-0', protected: 'pty-0', wildcard: 'pty-1' }
+  }
+  const lease = operations.leases[0]
+  operations.leases = [
+    { ...lease, leafId: 'wrong' },
+    { ...lease, leafId: 'matched' },
+    { ...lease, ptyId: 'pty-1' }
+  ]
+  expect(clearSshRemotePtyBindingsForLeases(operations, 'ssh-one', operations.leases)).toBe(true)
+  expect(session.terminalLayoutsByTabId['tab-0'].ptyIdsByLeafId).toEqual({ protected: 'pty-0' })
+  expect(operations.toComparablePtyId).toHaveBeenCalledTimes(3)
+})

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.ts
@@ -9,6 +9,7 @@ export type SshPtyBindingCleanupOperations = {
   scheduleSave: () => void
 }
 
+/** `binding.ptyId` must already be in lease-comparable (relay) form; callers normalize it. */
 function sshRemotePtyLeaseMayReferenceBinding(
   lease: SshRemotePtyLease,
   binding: {
@@ -48,21 +49,28 @@ export function clearSshRemotePtyBindingsForLeases(
   if (!leases?.length) {
     return false
   }
-  const leasesByPtyId = new Map<string, SshRemotePtyLease[]>()
-  for (const lease of leases) {
-    if (lease.targetId !== targetId) {
-      continue
-    }
-    const entries = leasesByPtyId.get(lease.ptyId)
-    if (entries) {
-      entries.push(lease)
-    } else {
-      leasesByPtyId.set(lease.ptyId, [lease])
-    }
-  }
+  // Keyed by the stored (relay) pty id, which is the only form a lease holds; every lookup below
+  // normalizes the binding id to that form first, so a bucket miss means "no lease names this pty"
+  // and the binding is KEPT. Failing closed here leaves a stale id to be retired on reattach,
+  // where clearing on a bad match would strand a live remote shell behind a respawned pane.
+  let leasesByPtyId: Map<string, SshRemotePtyLease[]> | undefined
   const referencesBinding = (
     binding: Parameters<typeof sshRemotePtyLeaseMayReferenceBinding>[1]
   ): boolean => {
+    if (!leasesByPtyId) {
+      leasesByPtyId = new Map()
+      for (const lease of leases) {
+        if (lease.targetId !== targetId) {
+          continue
+        }
+        const entries = leasesByPtyId.get(lease.ptyId)
+        if (entries) {
+          entries.push(lease)
+        } else {
+          leasesByPtyId.set(lease.ptyId, [lease])
+        }
+      }
+    }
     const ptyId = operations.toComparablePtyId(binding.targetId, binding.ptyId)
     return (leasesByPtyId.get(ptyId) ?? []).some((lease) =>
       sshRemotePtyLeaseMayReferenceBinding(lease, { ...binding, ptyId })

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.ts
@@ -10,7 +10,6 @@ export type SshPtyBindingCleanupOperations = {
 }
 
 function sshRemotePtyLeaseMayReferenceBinding(
-  operations: SshPtyBindingCleanupOperations,
   lease: SshRemotePtyLease,
   binding: {
     ptyId: string
@@ -20,8 +19,7 @@ function sshRemotePtyLeaseMayReferenceBinding(
     leafId?: string
   }
 ): boolean {
-  const bindingPtyId = operations.toComparablePtyId(binding.targetId, binding.ptyId)
-  if (lease.targetId !== binding.targetId || lease.ptyId !== bindingPtyId) {
+  if (lease.targetId !== binding.targetId || lease.ptyId !== binding.ptyId) {
     return false
   }
   // Why: target removal is destructive; scrub matching bindings before deleting the lease, else removing the tombstone can revive stale PTY ids.
@@ -50,6 +48,26 @@ export function clearSshRemotePtyBindingsForLeases(
   if (!leases?.length) {
     return false
   }
+  const leasesByPtyId = new Map<string, SshRemotePtyLease[]>()
+  for (const lease of leases) {
+    if (lease.targetId !== targetId) {
+      continue
+    }
+    const entries = leasesByPtyId.get(lease.ptyId)
+    if (entries) {
+      entries.push(lease)
+    } else {
+      leasesByPtyId.set(lease.ptyId, [lease])
+    }
+  }
+  const referencesBinding = (
+    binding: Parameters<typeof sshRemotePtyLeaseMayReferenceBinding>[1]
+  ): boolean => {
+    const ptyId = operations.toComparablePtyId(binding.targetId, binding.ptyId)
+    return (leasesByPtyId.get(ptyId) ?? []).some((lease) =>
+      sshRemotePtyLeaseMayReferenceBinding(lease, { ...binding, ptyId })
+    )
+  }
   let changed = false
   const sessions = new Set(
     [
@@ -62,14 +80,7 @@ export function clearSshRemotePtyBindingsForLeases(
       for (const tab of tabs) {
         if (
           tab.ptyId &&
-          leases.some((lease) =>
-            sshRemotePtyLeaseMayReferenceBinding(operations, lease, {
-              ptyId: tab.ptyId!,
-              worktreeId,
-              targetId,
-              tabId: tab.id
-            })
-          )
+          referencesBinding({ ptyId: tab.ptyId, worktreeId, targetId, tabId: tab.id })
         ) {
           tab.ptyId = null
           changed = true
@@ -92,16 +103,7 @@ export function clearSshRemotePtyBindingsForLeases(
       const worktreeId = worktreeIdByTabId.get(tabId)
       const nextBindings = Object.fromEntries(
         Object.entries(bindings).filter(
-          ([leafId, ptyId]) =>
-            !leases.some((lease) =>
-              sshRemotePtyLeaseMayReferenceBinding(operations, lease, {
-                ptyId,
-                targetId,
-                worktreeId,
-                tabId,
-                leafId
-              })
-            )
+          ([leafId, ptyId]) => !referencesBinding({ ptyId, targetId, worktreeId, tabId, leafId })
         )
       )
       if (Object.keys(nextBindings).length !== Object.keys(bindings).length) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​136 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​136 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## ELI5

When you use a terminal on a remote machine over SSH, Orca remembers a "lease": a note saying "this pane is attached to that shell over there". When a lease goes away — you remove the SSH host, close a tab, or one pane takes over from another — Orca has to go through your saved workspace and erase the notes that pointed at it. Otherwise a stale note can later make a pane try to reattach to a shell that no longer exists.

The old code checked every saved pane against every single lease. With 1,000 panes and 1,000 leases that is a million comparisons, and each one re-did the same ID-format conversion. Now Orca sorts the leases into labelled pigeonholes by shell ID once, converts each pane's ID one time, and looks in exactly one pigeonhole.

The safety-critical part is that this is a *lookup change only*, not a decision change. Which notes get erased is byte-for-byte the same set as before. And if the lookup ever came up empty, Orca keeps the note rather than erasing it — so the worst case is a stale note that gets cleaned up on the next reattach, never a live remote shell being cut loose from its pane.

## What Changed / Why

- `clearSshRemotePtyBindingsForLeases` replaced a per-binding `leases.some(...)` scan with a `Map<comparablePtyId, lease[]>` bucket lookup. 1,000 bindings × 1,000 leases: 1,000,000 predicate evaluations and normalizations → 1,000 normalizations and one bucket probe each.
- **Equivalence proof.** The old predicate rejected unless `lease.ptyId === toComparablePtyId(binding.targetId, binding.ptyId)`, and `binding.targetId` is the function's `targetId` at both call sites. The bucket is keyed on exactly that string and pre-filtered on exactly that target, so it selects the same lease subset; the full predicate (worktree/tab/leaf conflict rules) still runs on every candidate. `toComparableRelaySshPtyId` is pure, so hoisting it out of the inner loop cannot change its result.
- **Fails closed.** A bucket miss yields `[]`, `.some()` is `false`, and the binding is KEPT. Per `docs/reference/ssh-execution-boundary.md`, an over-eager clear is the dangerous direction: it strands a `live` remote shell behind a pane that respawns cold. A missed clear only leaves a stale id, which `attachStablePaneOwner` retires on the relay's own absence answer.
- The index is now built lazily, on the first binding actually checked, so a target with leases but no persisted bindings pays nothing — the previous eager build was a small regression against the old short-circuit.
- Added coverage the identity-stub tests could not reach: real `toComparableRelaySshPtyId` normalization of an app-form id (`ssh:<target>@@<id>`) onto a relay-form lease key; a same-suffix id belonging to a **different** SSH target left untouched; a bucket miss leaving all bindings intact with no save scheduled; and no indexing at all when there are no bindings. The normalization test is mutation-verified — keying the index on the raw binding id fails it.

Reconnect, host flap and app restart are unaffected: this function is only reached from lease removal, pane supersession and target removal, and it does not read connectivity or lease state.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 7 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

