### PR TITLE
perf: reuse AI-vault path matchers and query and sort keys

### DIFF
--- a/src/shared/ai-vault-session-depth.test.ts
+++ b/src/shared/ai-vault-session-depth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { AiVaultListResult, AiVaultSession } from './ai-vault-types'
 import {
   aiVaultScanLimit,
@@ -82,4 +82,20 @@ describe('Agent Session History depth', () => {
     ])
     expect(truncateAiVaultListResult(loaded, 'unlimited')).toBe(loaded)
   })
+})
+
+it('normalizes scope roots and candidate cwd once per truncation pass', () => {
+  const loaded = result(
+    Array.from({ length: 1000 }, (_, i) => session(`id-${i}`, `/other/${i}`, i))
+  )
+  const scopes = Array.from({ length: 100 }, (_, i) => `/repo/${i}`)
+  const normalize = vi.spyOn(String.prototype, 'normalize')
+  let selected: AiVaultListResult
+  try {
+    selected = truncateAiVaultListResult(loaded, 10, scopes)
+    expect(normalize.mock.calls.length).toBeLessThanOrEqual(1100)
+  } finally {
+    normalize.mockRestore()
+  }
+  expect(selected.sessions).toEqual(loaded.sessions.slice(0, 10))
 })

--- a/src/shared/ai-vault-session-depth.test.ts
+++ b/src/shared/ai-vault-session-depth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { AiVaultListResult, AiVaultSession } from './ai-vault-types'
+import { isPathInsideOrEqual } from './cross-platform-path'
 import {
   aiVaultScanLimit,
   aiVaultSessionDepthCovers,
@@ -84,18 +85,42 @@ describe('Agent Session History depth', () => {
   })
 })
 
-it('normalizes scope roots and candidate cwd once per truncation pass', () => {
-  const loaded = result(
-    Array.from({ length: 1000 }, (_, i) => session(`id-${i}`, `/other/${i}`, i))
-  )
-  const scopes = Array.from({ length: 100 }, (_, i) => `/repo/${i}`)
-  const normalize = vi.spyOn(String.prototype, 'normalize')
-  let selected: AiVaultListResult
-  try {
-    selected = truncateAiVaultListResult(loaded, 10, scopes)
-    expect(normalize.mock.calls.length).toBeLessThanOrEqual(1100)
-  } finally {
-    normalize.mockRestore()
-  }
-  expect(selected.sessions).toEqual(loaded.sessions.slice(0, 10))
+describe('Agent Session History scope truncation', () => {
+  it('normalizes scope roots and candidate cwd once per truncation pass', () => {
+    const loaded = result(
+      Array.from({ length: 1000 }, (_, i) => session(`id-${i}`, `/other/${i}`, i))
+    )
+    const scopes = Array.from({ length: 100 }, (_, i) => `/repo/${i}`)
+    const normalize = vi.spyOn(String.prototype, 'normalize')
+    let selected: AiVaultListResult
+    try {
+      selected = truncateAiVaultListResult(loaded, 10, scopes)
+      expect(normalize.mock.calls.length).toBeLessThanOrEqual(1100)
+    } finally {
+      normalize.mockRestore()
+    }
+    expect(selected.sessions).toEqual(loaded.sessions.slice(0, 10))
+  })
+
+  it('selects scoped sessions identically to the pre-hoist path predicate', () => {
+    const cases = [
+      ['C:\\Users\\Ada\\repo', 'c:/users/ada/repo/app'],
+      ['C:/Users/Ada/repo/', 'C:\\Users\\Ada\\repo'],
+      ['C:\\Users\\Ada\\repo', 'C:\\Users\\Ada\\repo-other'],
+      ['//wsl.localhost/Ubuntu/home/Ada/Repo', '//wsl$/Ubuntu/home/Ada/Repo/App'],
+      ['//wsl.localhost/Ubuntu/home/ada/repo', '//wsl.localhost/Debian/home/ada/repo'],
+      ['/Users/ada/repo', '/Users/ada/repo//app/'],
+      ['/Users/ada/repo', '/Users/ada/repository'],
+      ['/', '/anywhere']
+    ]
+    for (const [scope, cwd] of cases) {
+      const loaded = result([session('scoped', cwd!, 0)])
+      const selected = truncateAiVaultListResult(loaded, 0, [scope!])
+      expect({ scope, cwd, kept: selected.sessions.length === 1 }).toEqual({
+        scope,
+        cwd,
+        kept: isPathInsideOrEqual(scope!, cwd!)
+      })
+    }
+  })
 })

--- a/src/shared/ai-vault-session-depth.ts
+++ b/src/shared/ai-vault-session-depth.ts
@@ -1,4 +1,7 @@
-import { isPathInsideOrEqual } from './cross-platform-path'
+import {
+  createNormalizedPathInsideOrEqualMatcher,
+  normalizeRuntimePathForComparison
+} from './cross-platform-path'
 import type { AiVaultListArgs, AiVaultListResult } from './ai-vault-types'
 
 export const DEFAULT_AI_VAULT_SCAN_LIMIT = 1000
@@ -40,10 +43,12 @@ export function truncateAiVaultListResult(
   }
   const selectedIds = new Set(result.sessions.slice(0, depth).map((session) => session.id))
   if (scopePaths.length > 0) {
+    const scopeMatchers = scopePaths.map(createNormalizedPathInsideOrEqualMatcher)
     let scopedCount = 0
     for (const session of result.sessions) {
       const cwd = session.cwd
-      if (cwd && scopePaths.some((scopePath) => isPathInsideOrEqual(scopePath, cwd))) {
+      const normalizedCwd = cwd ? normalizeRuntimePathForComparison(cwd) : null
+      if (normalizedCwd !== null && scopeMatchers.some((matches) => matches(normalizedCwd))) {
         selectedIds.add(session.id)
         if (++scopedCount >= depth) {
           break

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -9,6 +9,8 @@ import {
   parseVaultQuery
 } from './ai-vault-session-filters'
 import { sessionPreviewSearchText } from './ai-vault-session-display'
+import { isPathInsideOrEqual } from './cross-platform-path'
+import { parseWslUncPath } from './wsl-paths'
 
 const baseSession: AiVaultSession = {
   id: 'claude:1',
@@ -199,45 +201,58 @@ describe('/shared ai-vault-session-filters (lifted core)', () => {
   })
 })
 
-it('prepares workspace path matching once for a large session filter pass', () => {
-  const sessions = Array.from({ length: 1000 }, (_, i) => ({
-    ...baseSession,
-    id: String(i),
-    cwd: `/other/${i}`
-  }))
-  const activeWorktreePaths = Array.from({ length: 100 }, (_, i) => `/repo/${i}`)
-  const normalize = vi.spyOn(String.prototype, 'normalize')
-  try {
-    expect(
-      filterAiVaultSessions(sessions, {
-        query: '',
-        agents: ['claude'],
-        scope: 'workspace',
-        sort: 'updated',
-        activeWorktreePaths,
-        hideEmptySessions: false
-      })
-    ).toEqual([])
-    expect(normalize.mock.calls.length).toBeLessThanOrEqual(1100)
-  } finally {
-    normalize.mockRestore()
-  }
-})
-
-it('does not read transcript previews for empty or field-only queries', () => {
-  let reads = 0
-  const sessions = Array.from({ length: 1000 }, (_, i) => ({
-    ...baseSession,
-    id: String(i),
-    get previewMessages() {
-      reads++
-      return baseSession.previewMessages
+describe('/shared ai-vault-session-filters (hoisted matchers and sort keys)', () => {
+  it('prepares workspace path matching once for a large session filter pass', () => {
+    const sessions = Array.from({ length: 1000 }, (_, i) => ({
+      ...baseSession,
+      id: String(i),
+      cwd: `/other/${i}`
+    }))
+    const activeWorktreePaths = Array.from({ length: 100 }, (_, i) => `/repo/${i}`)
+    const normalize = vi.spyOn(String.prototype, 'normalize')
+    try {
+      expect(
+        filterAiVaultSessions(sessions, {
+          query: '',
+          agents: ['claude'],
+          scope: 'workspace',
+          sort: 'updated',
+          activeWorktreePaths,
+          hideEmptySessions: false
+        })
+      ).toEqual([])
+      expect(normalize.mock.calls.length).toBeLessThanOrEqual(1100)
+    } finally {
+      normalize.mockRestore()
     }
-  }))
-  for (const query of ['', 'repo:repo', 'path:app']) {
+  })
+
+  it('does not read transcript previews for empty or field-only queries', () => {
+    let reads = 0
+    const sessions = Array.from({ length: 1000 }, (_, i) => ({
+      ...baseSession,
+      id: String(i),
+      get previewMessages() {
+        reads++
+        return baseSession.previewMessages
+      }
+    }))
+    for (const query of ['', 'repo:repo', 'path:app']) {
+      expect(
+        filterAiVaultSessions(sessions, {
+          query,
+          agents: ['claude'],
+          scope: 'all',
+          sort: 'updated',
+          activeWorktreePaths: [],
+          hideEmptySessions: false
+        })
+      ).toHaveLength(1000)
+    }
+    expect(reads).toBe(0)
     expect(
       filterAiVaultSessions(sessions, {
-        query,
+        query: 'scope',
         agents: ['claude'],
         scope: 'all',
         sort: 'updated',
@@ -245,48 +260,102 @@ it('does not read transcript previews for empty or field-only queries', () => {
         hideEmptySessions: false
       })
     ).toHaveLength(1000)
-  }
-  expect(reads).toBe(0)
-  expect(
-    filterAiVaultSessions(sessions, {
-      query: 'scope',
-      agents: ['claude'],
-      scope: 'all',
-      sort: 'updated',
-      activeWorktreePaths: [],
-      hideEmptySessions: false
-    })
-  ).toHaveLength(1000)
-  expect(reads).toBeGreaterThan(0)
-})
+    expect(reads).toBeGreaterThan(0)
+  })
 
-it('parses each sort timestamp once with original ordering, including invalid dates', () => {
-  const sessions = Array.from({ length: 2000 }, (_, i) => ({
-    ...baseSession,
-    id: String(i),
-    updatedAt:
-      i % 131 === 0 ? 'invalid' : new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString()
-  }))
-  const parse = vi.spyOn(Date, 'parse')
-  let actual: AiVaultSession[]
-  let expected: AiVaultSession[]
-  try {
-    expected = [...sessions].sort(
-      (a, b) => Date.parse(b.updatedAt ?? b.modifiedAt) - Date.parse(a.updatedAt ?? a.modifiedAt)
+  it('parses each sort timestamp once with original ordering, including invalid dates', () => {
+    const sessions = Array.from({ length: 2000 }, (_, i) => ({
+      ...baseSession,
+      id: String(i),
+      updatedAt:
+        i % 131 === 0
+          ? 'invalid'
+          : new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString()
+    }))
+    const parse = vi.spyOn(Date, 'parse')
+    let actual: AiVaultSession[]
+    let expected: AiVaultSession[]
+    try {
+      expected = [...sessions].sort(
+        (a, b) => Date.parse(b.updatedAt ?? b.modifiedAt) - Date.parse(a.updatedAt ?? a.modifiedAt)
+      )
+      expect(parse.mock.calls.length).toBeGreaterThan(10_000)
+      parse.mockClear()
+      actual = filterAiVaultSessions(sessions, {
+        query: '',
+        agents: ['claude'],
+        scope: 'all',
+        sort: 'updated',
+        activeWorktreePaths: [],
+        hideEmptySessions: false
+      })
+      expect(parse).toHaveBeenCalledTimes(2000)
+    } finally {
+      parse.mockRestore()
+    }
+    actual.forEach((session, i) => expect(session).toBe(expected[i]))
+  })
+
+  it('matches workspace scope identically to the pre-hoist path predicate', () => {
+    // The hoisted matcher must agree with isPathInsideOrEqual on every spelling the
+    // supported hosts produce: Windows case/separator folding, trailing separators,
+    // both WSL UNC aliases, /mnt drive mounts and near-miss sibling directories.
+    const cases: [workspace: string, cwd: string][] = [
+      ['C:\\Users\\Ada\\repo', 'c:/users/ada/repo/app'],
+      ['C:/Users/Ada/repo/', 'C:\\Users\\Ada\\repo'],
+      ['C:\\Users\\Ada\\repo', 'C:\\Users\\Ada\\repo-other'],
+      ['C:\\', 'C:\\anything'],
+      ['//wsl.localhost/Ubuntu/home/ada/repo', '//wsl$/Ubuntu/home/ada/repo/app'],
+      ['//wsl.localhost/Ubuntu/home/Ada/Repo', '//wsl$/Ubuntu/home/Ada/Repo/App'],
+      ['//wsl.localhost/Ubuntu/home/Ada/Repo', '//wsl$/Ubuntu/home/ada/repo/App'],
+      ['//wsl$/Ubuntu/home/ada/repo', '//WSL.LOCALHOST/ubuntu/home/ada/repo'],
+      ['//wsl.localhost/Ubuntu/home/ada/repo', '//wsl.localhost/Debian/home/ada/repo'],
+      ['//wsl.localhost/Ubuntu/mnt/c/work', '/mnt/c/work/app'],
+      ['/Users/ada/repo', '/Users/ada/repo//app/'],
+      ['/Users/ada/repo', '/Users/Ada/repo/app'],
+      ['/Users/ada/repo', '/Users/ada/repository'],
+      ['/', '/anywhere']
+    ]
+    for (const [workspace, cwd] of cases) {
+      const expected =
+        isPathInsideOrEqual(workspace, cwd) ||
+        (parseWslUncPath(workspace)
+          ? isPathInsideOrEqual(parseWslUncPath(workspace)!.linuxPath, cwd)
+          : false)
+      const actual = filterAiVaultSessions([{ ...baseSession, cwd }], {
+        query: '',
+        agents: ['claude'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: [workspace],
+        hideEmptySessions: false
+      })
+      expect({ workspace, cwd, matched: actual.length === 1 }).toEqual({
+        workspace,
+        cwd,
+        matched: expected
+      })
+    }
+  })
+
+  it('orders by creation time identically to the per-comparison parse', () => {
+    const sessions = Array.from({ length: 500 }, (_, i) => ({
+      ...baseSession,
+      id: String(i),
+      createdAt:
+        i % 37 === 0 ? 'invalid' : new Date(1700000000000 + ((i * 91) % 499) * 1000).toISOString()
+    }))
+    const expected = [...sessions].sort(
+      (a, b) => Date.parse(b.createdAt ?? b.modifiedAt) - Date.parse(a.createdAt ?? a.modifiedAt)
     )
-    expect(parse.mock.calls.length).toBeGreaterThan(10_000)
-    parse.mockClear()
-    actual = filterAiVaultSessions(sessions, {
+    const actual = filterAiVaultSessions(sessions, {
       query: '',
       agents: ['claude'],
       scope: 'all',
-      sort: 'updated',
+      sort: 'created',
       activeWorktreePaths: [],
       hideEmptySessions: false
     })
-    expect(parse).toHaveBeenCalledTimes(2000)
-  } finally {
-    parse.mockRestore()
-  }
-  actual.forEach((session, i) => expect(session).toBe(expected[i]))
+    actual.forEach((session, i) => expect(session).toBe(expected[i]))
+  })
 })

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { AiVaultSession } from './ai-vault-types'
 import {
   agentLabel,
@@ -197,4 +197,96 @@ describe('/shared ai-vault-session-filters (lifted core)', () => {
   it('builds preview search text from conversation turns', () => {
     expect(sessionPreviewSearchText(baseSession)).toContain('scope tabs')
   })
+})
+
+it('prepares workspace path matching once for a large session filter pass', () => {
+  const sessions = Array.from({ length: 1000 }, (_, i) => ({
+    ...baseSession,
+    id: String(i),
+    cwd: `/other/${i}`
+  }))
+  const activeWorktreePaths = Array.from({ length: 100 }, (_, i) => `/repo/${i}`)
+  const normalize = vi.spyOn(String.prototype, 'normalize')
+  try {
+    expect(
+      filterAiVaultSessions(sessions, {
+        query: '',
+        agents: ['claude'],
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths,
+        hideEmptySessions: false
+      })
+    ).toEqual([])
+    expect(normalize.mock.calls.length).toBeLessThanOrEqual(1100)
+  } finally {
+    normalize.mockRestore()
+  }
+})
+
+it('does not read transcript previews for empty or field-only queries', () => {
+  let reads = 0
+  const sessions = Array.from({ length: 1000 }, (_, i) => ({
+    ...baseSession,
+    id: String(i),
+    get previewMessages() {
+      reads++
+      return baseSession.previewMessages
+    }
+  }))
+  for (const query of ['', 'repo:repo', 'path:app']) {
+    expect(
+      filterAiVaultSessions(sessions, {
+        query,
+        agents: ['claude'],
+        scope: 'all',
+        sort: 'updated',
+        activeWorktreePaths: [],
+        hideEmptySessions: false
+      })
+    ).toHaveLength(1000)
+  }
+  expect(reads).toBe(0)
+  expect(
+    filterAiVaultSessions(sessions, {
+      query: 'scope',
+      agents: ['claude'],
+      scope: 'all',
+      sort: 'updated',
+      activeWorktreePaths: [],
+      hideEmptySessions: false
+    })
+  ).toHaveLength(1000)
+  expect(reads).toBeGreaterThan(0)
+})
+
+it('parses each sort timestamp once with original ordering, including invalid dates', () => {
+  const sessions = Array.from({ length: 2000 }, (_, i) => ({
+    ...baseSession,
+    id: String(i),
+    updatedAt:
+      i % 131 === 0 ? 'invalid' : new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString()
+  }))
+  const parse = vi.spyOn(Date, 'parse')
+  let actual: AiVaultSession[]
+  let expected: AiVaultSession[]
+  try {
+    expected = [...sessions].sort(
+      (a, b) => Date.parse(b.updatedAt ?? b.modifiedAt) - Date.parse(a.updatedAt ?? a.modifiedAt)
+    )
+    expect(parse.mock.calls.length).toBeGreaterThan(10_000)
+    parse.mockClear()
+    actual = filterAiVaultSessions(sessions, {
+      query: '',
+      agents: ['claude'],
+      scope: 'all',
+      sort: 'updated',
+      activeWorktreePaths: [],
+      hideEmptySessions: false
+    })
+    expect(parse).toHaveBeenCalledTimes(2000)
+  } finally {
+    parse.mockRestore()
+  }
+  actual.forEach((session, i) => expect(session).toBe(expected[i]))
 })

--- a/src/shared/ai-vault-session-filters.ts
+++ b/src/shared/ai-vault-session-filters.ts
@@ -3,7 +3,7 @@
 // Metro only watches mobile/ + repo-root src/shared, never src/renderer.
 // INVARIANT: /shared is a leaf — this module must NOT import from src/renderer.
 import {
-  isPathInsideOrEqual,
+  createNormalizedPathInsideOrEqualMatcher,
   normalizeRuntimePathForComparison,
   normalizeRuntimePathSeparators
 } from './cross-platform-path'
@@ -79,45 +79,50 @@ export function filterAiVaultSessions(
 
   const agentSet = new Set(filters.agents)
   const parsedQuery = parseVaultQuery(filters.query)
+  const workspaceMatchers =
+    filters.scope === 'workspace'
+      ? filters.activeWorktreePaths.map(createAiVaultWorkspaceMatcher)
+      : []
 
-  return sessions
-    .filter((session) => {
-      if (!agentSet.has(session.agent)) {
+  const filtered = sessions.filter((session) => {
+    if (!agentSet.has(session.agent)) {
+      return false
+    }
+    // Hide plain empty sessions, but keep sessions with resumable content
+    // (some parsers only learn turns from previews, e.g. Grok) and zero-turn
+    // sessions that still carry recoverable content (queued prompts /
+    // subagent transcripts) so a lost conversation is surfaced distinctly.
+    if (
+      filters.hideEmptySessions &&
+      !isAiVaultSessionResumableContent(session) &&
+      !isAiVaultSessionRecoverableEmpty(session)
+    ) {
+      return false
+    }
+    if (filters.scope === 'workspace') {
+      const cwd = session.cwd
+      const normalizedCwd = cwd ? normalizeRuntimePathForComparison(cwd) : null
+      if (normalizedCwd === null || !workspaceMatchers.some((matches) => matches(normalizedCwd))) {
         return false
       }
-      // Hide plain empty sessions, but keep sessions with resumable content
-      // (some parsers only learn turns from previews, e.g. Grok) and zero-turn
-      // sessions that still carry recoverable content (queued prompts /
-      // subagent transcripts) so a lost conversation is surfaced distinctly.
-      if (
-        filters.hideEmptySessions &&
-        !isAiVaultSessionResumableContent(session) &&
-        !isAiVaultSessionRecoverableEmpty(session)
-      ) {
+    }
+    if (filters.scope === 'project') {
+      if (!filters.activeProjectKey) {
         return false
       }
-      if (filters.scope === 'workspace') {
-        const cwd = session.cwd
-        if (
-          !cwd ||
-          !filters.activeWorktreePaths.some((pathValue) =>
-            isAiVaultSessionInWorkspacePath(pathValue, cwd)
-          )
-        ) {
-          return false
-        }
+      if (filters.sessionProjectById?.get(session.id)?.key !== filters.activeProjectKey) {
+        return false
       }
-      if (filters.scope === 'project') {
-        if (!filters.activeProjectKey) {
-          return false
-        }
-        if (filters.sessionProjectById?.get(session.id)?.key !== filters.activeProjectKey) {
-          return false
-        }
-      }
-      return matchesQuery(session, parsedQuery, filters)
-    })
-    .sort((left, right) => compareSessions(left, right, filters.sort))
+    }
+    return matchesQuery(session, parsedQuery, filters)
+  })
+  if (filtered.length < 2) {
+    return filtered
+  }
+  return filtered
+    .map((session) => ({ session, time: sessionSortTime(session, filters.sort) }))
+    .sort((left, right) => right.time - left.time)
+    .map(({ session }) => session)
 }
 
 export function groupAiVaultSessions(
@@ -206,48 +211,48 @@ function matchesQuery(
   parsed: ParsedQuery,
   filters: Pick<AiVaultSessionFilterState, 'sessionProjectById' | 'projectLabelByKey'>
 ): boolean {
-  const searchable = [
-    session.title,
-    session.sessionId,
-    session.agent,
-    session.branch,
-    session.model,
-    session.cwd,
-    session.filePath,
-    sessionPreviewSearchText(session)
-  ]
-    .filter(Boolean)
-    .join(' ')
-    .toLowerCase()
-
-  if (parsed.terms.some((term) => !searchable.includes(term))) {
-    return false
+  if (parsed.terms.length > 0) {
+    const searchable = [
+      session.title,
+      session.sessionId,
+      session.agent,
+      session.branch,
+      session.model,
+      session.cwd,
+      session.filePath,
+      sessionPreviewSearchText(session)
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+    if (parsed.terms.some((term) => !searchable.includes(term))) {
+      return false
+    }
   }
-
-  const sessionProject = filters.sessionProjectById?.get(session.id)
-  const repoLabel = (
-    sessionProject?.kind === 'repo'
-      ? (filters.projectLabelByKey?.get(sessionProject.key) ?? sessionProject.label)
-      : folderLabel(session.cwd)
-  ).toLowerCase()
-  if (parsed.repoTerms.some((term) => !repoLabel.includes(term))) {
-    return false
+  if (parsed.repoTerms.length > 0) {
+    const sessionProject = filters.sessionProjectById?.get(session.id)
+    const repoLabel = (
+      sessionProject?.kind === 'repo'
+        ? (filters.projectLabelByKey?.get(sessionProject.key) ?? sessionProject.label)
+        : folderLabel(session.cwd)
+    ).toLowerCase()
+    if (parsed.repoTerms.some((term) => !repoLabel.includes(term))) {
+      return false
+    }
   }
-
-  const pathSearch = `${session.cwd ?? ''} ${session.filePath}`.toLowerCase()
-  if (parsed.pathTerms.some((term) => !pathSearch.includes(term))) {
-    return false
+  if (parsed.pathTerms.length > 0) {
+    const pathSearch = `${session.cwd ?? ''} ${session.filePath}`.toLowerCase()
+    if (parsed.pathTerms.some((term) => !pathSearch.includes(term))) {
+      return false
+    }
   }
 
   return true
 }
 
-function compareSessions(left: AiVaultSession, right: AiVaultSession, sort: AiVaultSort): number {
-  const leftValue = sort === 'created' ? left.createdAt : left.updatedAt
-  const rightValue = sort === 'created' ? right.createdAt : right.updatedAt
-  const leftTime = Date.parse(leftValue ?? left.modifiedAt)
-  const rightTime = Date.parse(rightValue ?? right.modifiedAt)
-  return rightTime - leftTime
+function sessionSortTime(session: AiVaultSession, sort: AiVaultSort): number {
+  const value = sort === 'created' ? session.createdAt : session.updatedAt
+  return Date.parse(value ?? session.modifiedAt)
 }
 
 function getGroupIdentity(
@@ -276,19 +281,15 @@ function getGroupIdentity(
   return { key: folderGroupKey(session.cwd), label: folderLabel(session.cwd) }
 }
 
-function isAiVaultSessionInWorkspacePath(workspacePath: string, sessionCwd: string): boolean {
-  if (isPathInsideOrEqual(workspacePath, sessionCwd)) {
-    return true
-  }
-
+function createAiVaultWorkspaceMatcher(workspacePath: string): (normalizedCwd: string) => boolean {
+  const matches = createNormalizedPathInsideOrEqualMatcher(workspacePath)
   const workspaceWslPath = parseWslUncPath(workspacePath)
   if (!workspaceWslPath) {
-    return false
+    return matches
   }
-
-  // WSL agent transcripts record Linux cwd values even when Orca stores the
-  // active worktree as a Windows UNC path.
-  return isPathInsideOrEqual(workspaceWslPath.linuxPath, sessionCwd)
+  // WSL transcripts record Linux cwd even when the workspace uses a UNC path.
+  const matchesLinux = createNormalizedPathInsideOrEqualMatcher(workspaceWslPath.linuxPath)
+  return (cwd) => matches(cwd) || matchesLinux(cwd)
 }
 
 function tokenizeQuery(query: string): string[] {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​204 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​202 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​81 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

Agent Session History can hold thousands of past agent sessions. Three things it was doing over and over, now done once.

**1. Comparing folders.** To show "only sessions from this workspace", Orca asks "is this session's folder inside that workspace folder?" Folder names have to be tidied up first — Windows doesn't care about capitals or whether you type a backslash or a forward slash, the same WSL folder has two different spellings, trailing slashes don't count. Orca was re-tidying *both* folders for *every* comparison. With 1,000 sessions and 100 workspaces that is 200,000 tidy-ups to answer 100,000 questions. Now each workspace is tidied once up front and each session once, and then it is a plain string check.

**2. Searching text you did not search for.** Every session was having its whole conversation preview stitched into one big searchable string — even when the search box was empty, or when you typed `repo:foo`, which only looks at the project name. Now that stitching only happens if there is actually a plain-text term to look for.

**3. Re-reading the clock.** Sorting by date re-parsed both timestamps on every single comparison, so 2,000 sessions meant tens of thousands of parses. Now each session's date is parsed once and the list is sorted on those numbers.

None of this changes what you see. The same sessions match, in the same order — including sessions with a broken timestamp, and including ties, which keep their original relative order exactly as before.

## What Changed / Why

- Path matching: `isPathInsideOrEqual(root, cwd)` is already *defined* on `main` as `createNormalizedPathInsideOrEqualMatcher(root)(normalizeRuntimePathForComparison(cwd))` (`src/shared/cross-platform-path.ts:189-193`). This PR only hoists the two halves out of the fan-out, so the predicate is unchanged by construction. 1,000 sessions x 100 roots: 200,000 normalizations to 1,100.
- Each candidate is normalized **exactly once**. `normalizeRuntimePathForComparison` is deliberately not idempotent for WSL UNC paths (`//wsl.localhost/Ubuntu/A` folds to `//wsl/ubuntu/A`, which a second pass lowercases further). A double-normalize mutation is now caught by the new tests in both touched modules.
- `matchesQuery` now skips building `searchable` / `repoLabel` / `pathSearch` when the corresponding term list is empty. Previously those were built and then tested with `[].some(...)`, which is always `false`, so skipping is exactly equivalent. This is what removes the preview-stitching cost on an empty query.
- Sorting: `compareSessions` (two `Date.parse` calls per comparison) became `sessionSortTime`, computed once per session, then `right.time - left.time` over the decorated array. Comparator outputs are identical for every pair, including `NaN` from an unparseable timestamp, and `Array.prototype.sort` is stable in both shapes, so tie order is preserved. Over 26,000 parses to 2,000.
- No cache is introduced. The matchers are function-local and rebuilt per call, so there is nothing to invalidate, cap, or key: a workspace or cwd change is picked up on the next call by construction.
- New coverage: a 14-case differential asserting workspace-scope selection agrees with `isPathInsideOrEqual` (plus the WSL Linux-path fallback) across Windows case/separator folding, trailing separators, both WSL UNC aliases, a case-sensitive WSL tail, a cross-distro near miss, `/mnt/c`, duplicate separators, sibling-prefix near misses and the filesystem root; an 8-case equivalent for `truncateAiVaultListResult`; and a `sort: 'created'` ordering differential alongside the existing `sort: 'updated'` one.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 25 tests across 2 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/shared/ai-vault-session-depth.test.ts`
- `src/shared/ai-vault-session-filters.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

