### PR TITLE
perf: cache AI-vault project attribution by host and cwd

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-project-key.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-project-key.ts
@@ -1,0 +1,34 @@
+import type { ProjectHostSetup } from '../../../../shared/project-types'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+export function toAiVaultProjectKey(
+  projectId: string | null | undefined,
+  repoId?: string | null
+): string | null {
+  if (projectId) {
+    // Why: legacy projections can already use repo-prefixed project ids; wrapping
+    // them again would split active scope and resolved session keys.
+    return projectId.startsWith('repo:') ? projectId : `project:${projectId}`
+  }
+  return repoId ? `repo:${repoId}` : null
+}
+
+export function resolveActiveProjectKey(
+  activeRepo: Repo | null,
+  activeWorktree: Worktree | null,
+  setupByRepoId: ReadonlyMap<string, ProjectHostSetup>
+): string | null {
+  if (activeWorktree?.projectId) {
+    return toAiVaultProjectKey(activeWorktree.projectId, activeWorktree.repoId)
+  }
+
+  const setup =
+    (activeRepo ? setupByRepoId.get(activeRepo.id) : null) ??
+    (activeWorktree ? setupByRepoId.get(activeWorktree.repoId) : null)
+  if (setup) {
+    return toAiVaultProjectKey(setup.projectId, setup.repoId || activeRepo?.id)
+  }
+
+  return toAiVaultProjectKey(null, activeRepo?.id ?? activeWorktree?.repoId ?? null)
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { ProjectHostSetupProjection } from '../../../../shared/project-host-setup-projection'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import type { Project, ProjectHostSetup } from '../../../../shared/project-types'
+import * as paths from '../../../../shared/cross-platform-path'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import {
@@ -600,3 +601,47 @@ function makeProjection(
     ...overrides
   }
 }
+
+it('shares project attribution only within the same host and raw cwd during one build', () => {
+  const repos = Array.from({ length: 200 }, (_, i) =>
+    makeRepo({ id: `repo-${i}`, path: `/repo-${i}` })
+  )
+  const sessions = Array.from({ length: 1000 }, (_, i) => ({
+    ...baseSession,
+    id: String(i),
+    cwd: '/repo-199/sub'
+  }))
+  let comparisons = 0
+  const original = paths.createNormalizedPathInsideOrEqualMatcher
+  const spy = vi
+    .spyOn(paths, 'createNormalizedPathInsideOrEqualMatcher')
+    .mockImplementation((root) => {
+      const matches = original(root)
+      return (cwd) => {
+        comparisons++
+        return matches(cwd)
+      }
+    })
+  let result: ReturnType<typeof buildAiVaultSessionProjectById>
+  try {
+    result = buildAiVaultSessionProjectById({
+      repos,
+      worktrees: [],
+      projectHostSetupProjection: { projects: [], setups: [] },
+      sessions
+    })
+    expect(comparisons).toBe(200)
+  } finally {
+    spy.mockRestore()
+  }
+  expect(result.get('0')?.key).toBe('repo:repo-199')
+  expect(result.get('0')).toEqual(result.get('999'))
+  expect(result.get('0')).not.toBe(result.get('999'))
+  const hosts = buildAiVaultSessionProjectById({
+    repos,
+    worktrees: [],
+    projectHostSetupProjection: { projects: [], setups: [] },
+    sessions: [sessions[0], { ...sessions[0], id: 'remote', executionHostId: 'ssh:other' }]
+  })
+  expect(hosts.get('remote')?.kind).toBe('folder')
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts
@@ -602,46 +602,108 @@ function makeProjection(
   }
 }
 
-it('shares project attribution only within the same host and raw cwd during one build', () => {
-  const repos = Array.from({ length: 200 }, (_, i) =>
-    makeRepo({ id: `repo-${i}`, path: `/repo-${i}` })
-  )
-  const sessions = Array.from({ length: 1000 }, (_, i) => ({
-    ...baseSession,
-    id: String(i),
-    cwd: '/repo-199/sub'
-  }))
-  let comparisons = 0
-  const original = paths.createNormalizedPathInsideOrEqualMatcher
-  const spy = vi
-    .spyOn(paths, 'createNormalizedPathInsideOrEqualMatcher')
-    .mockImplementation((root) => {
-      const matches = original(root)
-      return (cwd) => {
-        comparisons++
-        return matches(cwd)
-      }
-    })
-  let result: ReturnType<typeof buildAiVaultSessionProjectById>
-  try {
-    result = buildAiVaultSessionProjectById({
+describe('AI vault session project attribution reuse', () => {
+  it('shares project attribution only within the same host and raw cwd during one build', () => {
+    const repos = Array.from({ length: 200 }, (_, i) =>
+      makeRepo({ id: `repo-${i}`, path: `/repo-${i}` })
+    )
+    const sessions = Array.from({ length: 1000 }, (_, i) => ({
+      ...baseSession,
+      id: String(i),
+      cwd: '/repo-199/sub'
+    }))
+    let comparisons = 0
+    const original = paths.createNormalizedPathInsideOrEqualMatcher
+    const spy = vi
+      .spyOn(paths, 'createNormalizedPathInsideOrEqualMatcher')
+      .mockImplementation((root) => {
+        const matches = original(root)
+        return (cwd) => {
+          comparisons++
+          return matches(cwd)
+        }
+      })
+    let result: ReturnType<typeof buildAiVaultSessionProjectById>
+    try {
+      result = buildAiVaultSessionProjectById({
+        repos,
+        worktrees: [],
+        projectHostSetupProjection: { projects: [], setups: [] },
+        sessions
+      })
+      expect(comparisons).toBe(200)
+    } finally {
+      spy.mockRestore()
+    }
+    expect(result.get('0')?.key).toBe('repo:repo-199')
+    expect(result.get('0')).toEqual(result.get('999'))
+    expect(result.get('0')).not.toBe(result.get('999'))
+    const hosts = buildAiVaultSessionProjectById({
       repos,
       worktrees: [],
       projectHostSetupProjection: { projects: [], setups: [] },
-      sessions
+      sessions: [sessions[0], { ...sessions[0], id: 'remote', executionHostId: 'ssh:other' }]
     })
-    expect(comparisons).toBe(200)
-  } finally {
-    spy.mockRestore()
-  }
-  expect(result.get('0')?.key).toBe('repo:repo-199')
-  expect(result.get('0')).toEqual(result.get('999'))
-  expect(result.get('0')).not.toBe(result.get('999'))
-  const hosts = buildAiVaultSessionProjectById({
-    repos,
-    worktrees: [],
-    projectHostSetupProjection: { projects: [], setups: [] },
-    sessions: [sessions[0], { ...sessions[0], id: 'remote', executionHostId: 'ssh:other' }]
+    expect(hosts.get('remote')?.kind).toBe('folder')
   })
-  expect(hosts.get('remote')?.kind).toBe('folder')
+
+  it('gives sessions on one host distinct attribution per cwd', () => {
+    // Guards the cwd half of the cache key: a host-only key would hand every
+    // session the first session's project.
+    const repos = [
+      makeRepo({ id: 'repo-a', path: '/repo-a' }),
+      makeRepo({ id: 'repo-b', path: '/repo-b' })
+    ]
+    const result = buildAiVaultSessionProjectById({
+      repos,
+      worktrees: [],
+      projectHostSetupProjection: makeProjection({}),
+      sessions: [
+        { ...baseSession, id: 'a1', cwd: '/repo-a/sub' },
+        { ...baseSession, id: 'b1', cwd: '/repo-b/sub' },
+        { ...baseSession, id: 'a2', cwd: '/repo-a/other' },
+        { ...baseSession, id: 'none', cwd: '/elsewhere/sub' }
+      ]
+    })
+
+    expect(result.get('a1')?.key).toBe('repo:repo-a')
+    expect(result.get('a2')?.key).toBe('repo:repo-a')
+    expect(result.get('b1')?.key).toBe('repo:repo-b')
+    expect(result.get('none')?.kind).toBe('folder')
+  })
+
+  it('keys on the raw cwd so equivalent spellings still resolve correctly', () => {
+    // The key is deliberately NOT canonicalized: two spellings of one folder miss
+    // each other's entry and are recomputed, which is correct but unshared.
+    const repos = [makeRepo({ id: 'repo-win', path: 'C:\\Users\\Ada\\repo' })]
+    const result = buildAiVaultSessionProjectById({
+      repos,
+      worktrees: [],
+      projectHostSetupProjection: makeProjection({}),
+      sessions: [
+        { ...baseSession, id: 'back', cwd: 'C:\\Users\\Ada\\repo\\app' },
+        { ...baseSession, id: 'fwd', cwd: 'c:/users/ada/repo/app' },
+        { ...baseSession, id: 'trail', cwd: 'C:/Users/Ada/repo/app/' }
+      ]
+    })
+
+    for (const id of ['back', 'fwd', 'trail']) {
+      expect({ id, key: result.get(id)?.key }).toEqual({ id, key: 'repo:repo-win' })
+    }
+  })
+
+  it('separates sessions that carry no cwd from sessions that do', () => {
+    const result = buildAiVaultSessionProjectById({
+      repos: [makeRepo({ id: 'repo-a', path: '/repo-a' })],
+      worktrees: [],
+      projectHostSetupProjection: makeProjection({}),
+      sessions: [
+        { ...baseSession, id: 'empty', cwd: '' },
+        { ...baseSession, id: 'real', cwd: '/repo-a/sub' }
+      ]
+    })
+
+    expect(result.get('empty')?.kind).toBe('unknown')
+    expect(result.get('real')?.key).toBe('repo:repo-a')
+  })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-projects.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-projects.ts
@@ -1,3 +1,5 @@
+import { resolveActiveProjectKey, toAiVaultProjectKey } from './ai-vault-project-key'
+export { toAiVaultProjectKey } from './ai-vault-project-key'
 import {
   getRepoExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
@@ -19,8 +21,7 @@ import {
   type AiVaultSessionProject
 } from '../../../../shared/ai-vault-session-filters'
 
-// Why: the plain project descriptor moved to /shared (so the lifted filter core
-// stays renderer-free). Re-export it here for renderer import parity.
+// Preserve renderer imports of the renderer-free descriptor.
 export type { AiVaultSessionProject } from '../../../../shared/ai-vault-session-filters'
 
 export type AiVaultProjectContext = {
@@ -92,25 +93,25 @@ export function buildAiVaultSessionProjectById({
     setupByRepoId
   )
   const sessionProjectById = new Map<string, AiVaultSessionProject>()
+  const projectsByHostAndCwd = new Map<
+    ExecutionHostId | null,
+    Map<string | null, AiVaultSessionProject>
+  >()
   for (const session of sessions) {
-    sessionProjectById.set(
-      session.id,
-      resolveSessionProject(session, candidates, projectLabelByKey)
-    )
+    const host = normalizeExecutionHostId(session.executionHostId)
+    let projectsByCwd = projectsByHostAndCwd.get(host)
+    if (!projectsByCwd) {
+      projectsByCwd = new Map()
+      projectsByHostAndCwd.set(host, projectsByCwd)
+    }
+    let project = projectsByCwd.get(session.cwd)
+    if (!project) {
+      project = resolveSessionProject(session, candidates, projectLabelByKey)
+      projectsByCwd.set(session.cwd, project)
+    }
+    sessionProjectById.set(session.id, { ...project })
   }
   return sessionProjectById
-}
-
-export function toAiVaultProjectKey(
-  projectId: string | null | undefined,
-  repoId?: string | null
-): string | null {
-  if (projectId) {
-    // Why: legacy projections can already use repo-prefixed project ids; wrapping
-    // them again would split active scope and resolved session keys.
-    return projectId.startsWith('repo:') ? projectId : `project:${projectId}`
-  }
-  return repoId ? `repo:${repoId}` : null
 }
 
 function buildSetupByRepoId(
@@ -318,23 +319,4 @@ function folderProject(cwd: string): AiVaultSessionProject {
     key: folderGroupKey(cwd),
     label: folderLabel(cwd)
   }
-}
-
-function resolveActiveProjectKey(
-  activeRepo: Repo | null,
-  activeWorktree: Worktree | null,
-  setupByRepoId: ReadonlyMap<string, ProjectHostSetup>
-): string | null {
-  if (activeWorktree?.projectId) {
-    return toAiVaultProjectKey(activeWorktree.projectId, activeWorktree.repoId)
-  }
-
-  const setup =
-    (activeRepo ? setupByRepoId.get(activeRepo.id) : null) ??
-    (activeWorktree ? setupByRepoId.get(activeWorktree.repoId) : null)
-  if (setup) {
-    return toAiVaultProjectKey(setup.projectId, setup.repoId || activeRepo?.id)
-  }
-
-  return toAiVaultProjectKey(null, activeRepo?.id ?? activeWorktree?.repoId ?? null)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​108 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​107 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

## ELI5

Agent Session History labels each past session with the project it belongs to. To do that it takes the session's folder and asks every known repo and worktree "is this folder inside you?".

The catch: sessions come in groups. Fifty sessions from the same repo all have the same folder, so Orca was asking the exact same question fifty times and getting the exact same answer. With 1,000 sessions and 200 repos that is 200,000 folder comparisons where 200 would do.

Now, while building one batch of labels, Orca remembers the answer for each folder it has already looked up and reuses it. 200,000 comparisons become 200.

Two things keep this honest:

- **The same folder on a different machine is a different question.** A session recorded on an SSH host must never inherit the label of a local project that happens to sit at the same path, so the remembered answer is filed under the machine *and* the folder.
- **The memory is thrown away as soon as the batch finishes.** It is not a long-lived cache, so it cannot go stale, cannot grow without bound, and there is nothing to invalidate when you add a repo or switch worktrees — the next batch simply starts empty.

Every session still gets its own label object, so nothing can be accidentally shared or mutated between sessions. Labels are unchanged.

## What Changed / Why

- `buildAiVaultSessionProjectById` now memoizes `resolveSessionProject` in a `Map<host, Map<cwd, project>>` for the duration of one build. 1,000 sessions / 200 repos: 200,000 root comparisons to 200.
- **The key is exactly the function's free variables.** `resolveSessionProject` reads only `session.cwd` and `normalizeExecutionHostId(session.executionHostId)`; `candidates` and `projectLabelByKey` are built before the loop and never mutated by it (the `.sort()` inside runs on a fresh `.filter()` result, not on `candidates`). So a hit is provably the same value the call would have returned.
- **The cwd key is deliberately raw, not canonicalized.** `C:\Foo` and `c:/foo` therefore land in separate entries and are each resolved independently. That is a missed *sharing* opportunity, never a wrong answer — a raw key can only miss, and a miss recomputes. Canonicalizing the key would be the risky direction, since it could merge two cwds the resolver treats differently.
- **Bounded and invalidated by construction.** The map is function-local, sized by the distinct `(host, cwd)` pairs in the batch, and released on return. There is no cap to tune, no eviction policy, and no cross-call staleness: a repo, worktree or cwd change is picked up because the next build starts from an empty map.
- Each session still receives its own object (`{ ...project }`), so no two sessions alias one descriptor.
- `toAiVaultProjectKey` and `resolveActiveProjectKey` moved to `ai-vault-project-key.ts` (re-exported for import parity); no behavior change.
- New coverage, each mutation-verified against the corresponding key half: distinct attribution per cwd on one host (dropping `cwd` from the key previously passed the entire suite); a Windows spelling triple (`\` / `/` / trailing separator) all resolving to the same repo; and a session with no cwd kept separate from one that has it. The pre-existing suite already covered host isolation.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 22 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/components/right-sidebar/ai-vault-session-projects.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

