### PR TITLE
perf: precompute Jira priority and timestamp sorting keys

### DIFF
--- a/src/renderer/src/components/jira-issue-sorter.ts
+++ b/src/renderer/src/components/jira-issue-sorter.ts
@@ -55,6 +55,21 @@ export function sortJiraIssues(
   orderDirection: JiraIssueSortDirection,
   jiraPrioritiesBySite: JiraPrioritiesBySite = new Map()
 ): JiraIssue[] {
+  const numericKeys = new Map<JiraIssue, number>()
+  if (issues.length > 1 && (orderBy === 'priority' || orderBy === 'updated')) {
+    for (const issue of issues) {
+      numericKeys.set(
+        issue,
+        orderBy === 'updated'
+          ? new Date(issue.updatedAt).getTime()
+          : getJiraPriorityWeight(
+              issue.priority?.name,
+              issue.priority?.id,
+              jiraPrioritiesBySite.get(issue.siteId ?? '')
+            )
+      )
+    }
+  }
   return [...issues].sort((a, b) => {
     let comparison = 0
     if (orderBy === 'key') {
@@ -64,17 +79,13 @@ export function sortJiraIssues(
     } else if (orderBy === 'status') {
       comparison = 0
     } else if (orderBy === 'priority') {
-      const prioritiesA = jiraPrioritiesBySite.get(a.siteId ?? '')
-      const prioritiesB = jiraPrioritiesBySite.get(b.siteId ?? '')
-      const weightA = getJiraPriorityWeight(a.priority?.name, a.priority?.id, prioritiesA)
-      const weightB = getJiraPriorityWeight(b.priority?.name, b.priority?.id, prioritiesB)
-      comparison = weightA - weightB
+      comparison = numericKeys.get(a)! - numericKeys.get(b)!
     } else if (orderBy === 'assignee') {
       const userA = a.assignee?.displayName ?? ''
       const userB = b.assignee?.displayName ?? ''
       comparison = userA.localeCompare(userB)
     } else if (orderBy === 'updated') {
-      comparison = new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime()
+      comparison = numericKeys.get(a)! - numericKeys.get(b)!
     }
     return orderDirection === 'asc' ? comparison : -comparison
   })

--- a/src/renderer/src/components/task-page-jira-sorting.test.ts
+++ b/src/renderer/src/components/task-page-jira-sorting.test.ts
@@ -266,4 +266,37 @@ describe('TaskPage Jira sorting functionality', () => {
       expect(sorted[2].assignee?.displayName).toBe('Bob')
     })
   })
+  it('computes expensive numeric sort keys once per issue', () => {
+    let priorityReads = 0
+    let dateReads = 0
+    const issues = Array.from({ length: 2000 }, (_, i) => ({
+      ...jiraIssue(`ALP-${i}`, `Issue ${i}`, 'Open'),
+      get priority() {
+        priorityReads++
+        return { id: String(i % 3), name: ['High', 'Low', 'Medium'][i % 3] }
+      },
+      get updatedAt() {
+        dateReads++
+        return new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString()
+      }
+    }))
+    const expected = [...issues].sort(
+      (a, b) =>
+        getJiraPriorityWeight(a.priority.name, a.priority.id) -
+        getJiraPriorityWeight(b.priority.name, b.priority.id)
+    )
+    expect(priorityReads).toBeGreaterThan(20_000)
+    priorityReads = 0
+    const actual = sortJiraIssues(issues, 'priority', 'asc')
+    expect(priorityReads).toBe(4000)
+    actual.forEach((issue, i) => expect(issue).toBe(expected[i]))
+    const byDate = [...issues].sort(
+      (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    )
+    expect(dateReads).toBeGreaterThan(20_000)
+    dateReads = 0
+    const sorted = sortJiraIssues(issues, 'updated', 'desc')
+    expect(dateReads).toBe(2000)
+    sorted.forEach((issue, i) => expect(issue).toBe(byDate[i]))
+  })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

When you sort your Jira issue list by Priority or by Last updated, the app has to turn each issue into a number it can rank — a priority rank, or a date converted to a number. It used to redo that conversion every single time it compared two issues, so a 2,000-issue list did tens of thousands of conversions instead of 2,000.

Now each issue's number is worked out once, before sorting, and reused. The list comes out in exactly the same order, including issues with no priority set and issues whose "last updated" date is missing or unreadable.

## What Changed / Why

- 2,000 issues: 43,796 priority reads → 4,000; date reads → 2,000; grouping contracts pass

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 15 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/components/task-page-jira-sorting.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
