### PR TITLE
perf: cache update timestamps for Linear and Jira result sorting

### DIFF
--- a/src/main/jira/jira-issue-search.ts
+++ b/src/main/jira/jira-issue-search.ts
@@ -1,3 +1,4 @@
+import { sortByUpdatedAtDescending } from '../../shared/updated-at-order'
 import type { JiraIssue, JiraIssueFilter, JiraSiteSelection } from '../../shared/jira-types'
 import { acquire, release } from './request-queue'
 import { apiBasePath, jiraRequest, type JiraClientForSite } from './authenticated-request'
@@ -18,9 +19,7 @@ function clampLimit(limit: number | undefined, fallback = 30): number {
 }
 
 function sortAndLimitIssues(issues: JiraIssue[], limit: number): JiraIssue[] {
-  return issues
-    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-    .slice(0, limit)
+  return sortByUpdatedAtDescending(issues).slice(0, limit)
 }
 
 function filterToJql(filter: JiraIssueFilter): string {

--- a/src/main/linear/linear-issue-query-support.ts
+++ b/src/main/linear/linear-issue-query-support.ts
@@ -1,3 +1,4 @@
+import { sortByUpdatedAtDescending } from '../../shared/updated-at-order'
 import type { LinearIssue } from '../../shared/linear/issue-types'
 import type { LinearWorkspaceSelection } from '../../shared/linear/workspace-types'
 import { LINEAR_ISSUE_API_PAGE_SIZE_MAX } from '../../shared/linear/issue-read-limits'
@@ -30,18 +31,14 @@ export async function mapIssueForWorkspace(
 }
 
 export function sortAndLimitIssues(issues: LinearIssue[], limit: number): LinearIssue[] {
-  return issues
-    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-    .slice(0, limit)
+  return sortByUpdatedAtDescending(issues).slice(0, limit)
 }
 
 export function sortLimitAndDescribeIssues(
   issues: LinearIssue[],
   limit: number
 ): { items: LinearIssue[]; clipped: boolean } {
-  const sorted = issues.sort(
-    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-  )
+  const sorted = sortByUpdatedAtDescending(issues)
   return {
     items: sorted.slice(0, limit),
     clipped: sorted.length > limit

--- a/src/shared/updated-at-order.test.ts
+++ b/src/shared/updated-at-order.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from 'vitest'
+import { sortByUpdatedAtDescending } from './updated-at-order'
+
+it('reads each timestamp once and preserves in-place ordering including invalid dates', () => {
+  let reads = 0
+  const entries = Array.from({ length: 2000 }, (_, i) => ({
+    id: i,
+    get updatedAt() {
+      reads++
+      return i % 137 === 0
+        ? 'invalid'
+        : new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString()
+    }
+  }))
+  const expected = [...entries].sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  )
+  expect(reads).toBeGreaterThan(10_000)
+  reads = 0
+  expect(sortByUpdatedAtDescending(entries)).toBe(entries)
+  expect(reads).toBe(2000)
+  entries.forEach((entry, i) => expect(entry).toBe(expected[i]))
+})

--- a/src/shared/updated-at-order.ts
+++ b/src/shared/updated-at-order.ts
@@ -1,0 +1,8 @@
+/** Sorts in place; invalid dates retain the native comparator's stable tie behavior. */
+export function sortByUpdatedAtDescending<T extends { updatedAt: string }>(items: T[]): T[] {
+  if (items.length < 2) {
+    return items
+  }
+  const timestamps = new Map(items.map((item) => [item, new Date(item.updatedAt).getTime()]))
+  return items.sort((left, right) => timestamps.get(right)! - timestamps.get(left)!)
+}

--- a/src/shared/updated-at-order.ts
+++ b/src/shared/updated-at-order.ts
@@ -3,6 +3,9 @@ export function sortByUpdatedAtDescending<T extends { updatedAt: string }>(items
   if (items.length < 2) {
     return items
   }
-  const timestamps = new Map(items.map((item) => [item, new Date(item.updatedAt).getTime()]))
+  const timestamps = new Map<T, number>()
+  for (const item of items) {
+    timestamps.set(item, new Date(item.updatedAt).getTime())
+  }
   return items.sort((left, right) => timestamps.get(right)! - timestamps.get(left)!)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## ELI5

When Orca fetches issues from Linear or Jira, it shows them newest-first. Putting them in that order means comparing each issue's "last updated" date against others, and every one of those comparisons was re-reading the date text and converting it into a number.

Now each issue's date is converted once and the sort reuses it. The resulting order is identical, including for issues whose date is missing or can't be understood, which keep the same position they had before.

## What Changed / Why

- More than 10,000 timestamp reads → 2,000; in-place identity and invalid-date ordering parity; provider integration tests

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 1 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/shared/updated-at-order.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
