### PR TITLE
perf: parse external automation dates once per run

### DIFF
--- a/src/main/automations/external-job-mappers.ts
+++ b/src/main/automations/external-job-mappers.ts
@@ -71,7 +71,7 @@ function mapExternalRuns({
     .map((run, index) => {
       const runAt = asString(run.run_at) ?? asString(run.runAt)
       const id = asString(run.id) ?? `${jobId}:${runAt ?? index}`
-      return {
+      const mapped: ExternalAutomationRun = {
         id,
         managerId,
         provider,
@@ -83,15 +83,15 @@ function mapExternalRuns({
         error: asString(run.error),
         outputPath: asString(run.output_path) ?? asString(run.outputPath)
       }
+      return { run: mapped, time: runAt ? Date.parse(runAt) : Number.NaN }
     })
     .sort((a, b) => {
-      const aTime = a.runAt ? Date.parse(a.runAt) : Number.NaN
-      const bTime = b.runAt ? Date.parse(b.runAt) : Number.NaN
-      if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
-        return bTime - aTime
+      if (Number.isFinite(a.time) && Number.isFinite(b.time)) {
+        return b.time - a.time
       }
-      return b.id.localeCompare(a.id)
+      return b.run.id.localeCompare(a.run.id)
     })
+    .map(({ run }) => run)
 }
 
 function hermesScheduleDisplay(job: ExternalJobRecord): string {

--- a/src/main/automations/external-job-run-sorting.test.ts
+++ b/src/main/automations/external-job-run-sorting.test.ts
@@ -1,0 +1,38 @@
+import { expect, it, vi } from 'vitest'
+import { mapHermesJobs, mapOpenClawJobs } from './external-job-mappers'
+
+it.each([mapHermesJobs, mapOpenClawJobs])(
+  'parses run dates once and preserves provider fallback ordering',
+  (mapJobs) => {
+    const runs = Array.from({ length: 2000 }, (_, i) => ({
+      id: String(i),
+      run_at:
+        i % 137 === 0
+          ? 'invalid'
+          : new Date(1700000000000 + ((i * 173) % 1999) * 1000).toISOString(),
+      output_content: `Output ${i}`,
+      status: 'completed'
+    }))
+    const parse = vi.spyOn(Date, 'parse')
+    let expected: typeof runs
+    let jobs: ReturnType<typeof mapHermesJobs>
+    try {
+      expected = [...runs].sort((a, b) => {
+        const left = Date.parse(a.run_at),
+          right = Date.parse(b.run_at)
+        return Number.isFinite(left) && Number.isFinite(right)
+          ? right - left
+          : b.id.localeCompare(a.id)
+      })
+      expect(parse.mock.calls.length).toBeGreaterThan(10_000)
+      parse.mockClear()
+      jobs = mapJobs('manager', [{ id: 'job', runs }])
+      expect(parse).toHaveBeenCalledTimes(2000)
+    } finally {
+      parse.mockRestore()
+    }
+    expect(jobs[0].runs.map((run) => run.id)).toEqual(expected.map((run) => run.id))
+    expect(jobs[0].runs.every((run) => run.outputContent === `Output ${run.id}`)).toBe(true)
+    expect(jobs[0].runs.every((run) => !('time' in run))).toBe(true)
+  }
+)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | 0 |

<!-- /orca-pr-loc -->

## ELI5

The scheduled-automation screens (Hermes and OpenClaw) list each job's past runs newest-first. Each run stores its time as text, and that text was being converted into a real date every time two runs were compared — for a job with 2,000 runs, tens of thousands of conversions.

Now each run's time is converted once and reused. The list is in exactly the same order as before, including the existing rule that when a run's time is missing or unreadable, runs are ordered by their ID instead.

## What Changed / Why

- Hermes/OpenClaw: over 28,000 parses → 2,000 each; invalid-date ID fallback retained

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 2 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/automations/external-job-run-sorting.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
