### PR TITLE
perf: index project table option and iteration order

### DIFF
--- a/src/renderer/src/components/github-project/group-sort.test.ts
+++ b/src/renderer/src/components/github-project/group-sort.test.ts
@@ -347,3 +347,86 @@ describe('groupRows', () => {
     expect(groups.map((g) => g.key)).toEqual(['opt_a', '__empty__'])
   })
 })
+
+it('indexes field ordering once for grouping and sorting a large project table', () => {
+  let reads = 0
+  const field: GitHubProjectField = {
+    kind: 'single-select',
+    id: 'field',
+    name: 'Status',
+    dataType: 'SINGLE_SELECT',
+    options: Array.from({ length: 1000 }, (_, i) => ({
+      get id() {
+        reads++
+        return `option-${i}`
+      },
+      name: String(i),
+      color: 'GRAY'
+    }))
+  }
+  const rows = Array.from({ length: 1000 }, (_, i) =>
+    makeRow(String(i), i, {
+      field: {
+        kind: 'single-select',
+        fieldId: 'field',
+        optionId: `option-${(i * 173) % 1000}`,
+        name: String((i * 173) % 1000),
+        color: 'GRAY'
+      }
+    })
+  )
+  const view = { ...makeView(field, { field, direction: 'ASC' }), groupByFields: [field] }
+  const table = makeTable(view, rows)
+  const sorted = sortRows(table, rows)
+  expect(reads).toBe(1000)
+  expect(
+    sorted.map((row) =>
+      Number(
+        row.fieldValuesByFieldId.field.kind === 'single-select' &&
+          row.fieldValuesByFieldId.field.name
+      )
+    )
+  ).toEqual(Array.from({ length: 1000 }, (_, i) => i))
+  reads = 0
+  const groups = groupRows(table, rows)
+  expect(reads).toBe(1000)
+  expect(groups.map((group) => group.key)).toEqual(
+    Array.from({ length: 1000 }, (_, i) => `option-${i}`)
+  )
+})
+
+it('uses the first iteration ordering and metadata when legacy field IDs repeat', () => {
+  const field: GitHubProjectField = {
+    kind: 'iteration',
+    id: 'iteration',
+    name: 'Iteration',
+    dataType: 'ITERATION',
+    iterations: [
+      { id: 'a', title: 'First', startDate: '2026-01-01', duration: 7, completed: true },
+      { id: 'b', title: 'Second', startDate: '2026-02-01', duration: 14, completed: false },
+      { id: 'a', title: 'Duplicate', startDate: '2026-03-01', duration: 21, completed: false }
+    ]
+  }
+  const rows = ['b', 'a'].map((id, index) =>
+    makeRow(id, index, {
+      iteration: {
+        kind: 'iteration',
+        fieldId: 'iteration',
+        iterationId: id,
+        title: id,
+        startDate: '2026-01-01',
+        duration: 7
+      }
+    })
+  )
+  const table = makeTable(
+    { ...makeView(field, { field, direction: 'ASC' }), groupByFields: [field] },
+    rows
+  )
+  expect(sortRows(table, rows).map((row) => row.id)).toEqual(['a', 'b'])
+  expect(groupRows(table, rows)[0].iteration).toEqual({
+    startDate: '2026-01-01',
+    duration: 7,
+    completed: true
+  })
+})

--- a/src/shared/github/project-group-sort.ts
+++ b/src/shared/github/project-group-sort.ts
@@ -52,10 +52,28 @@ function hasNonEmptyFieldValue(value: ProjectFieldValue | undefined): boolean {
 // Array.sort's behavior implementation-defined and skips later tie-breaks.
 const UNKNOWN_INDEX_SENTINEL = Number.MAX_SAFE_INTEGER
 
+function createFieldOrderIndex(field: GitHubProjectField): ReadonlyMap<string, number> {
+  const entries =
+    field.kind === 'iteration'
+      ? (field.iterations ?? [])
+      : field.kind === 'single-select'
+        ? (field.options ?? [])
+        : []
+  const indices = new Map<string, number>()
+  entries.forEach((entry, index) => {
+    const id = entry.id
+    if (!indices.has(id)) {
+      indices.set(id, index)
+    }
+  })
+  return indices
+}
+
 // Preserve the mobile mirror's fallback for partial ordering metadata.
 function getFieldValueForGrouping(
   row: GitHubProjectRow,
-  field: GitHubProjectField
+  field: GitHubProjectField,
+  orderIndex: ReadonlyMap<string, number>
 ): { key: string; label: string; orderHint: number; iteration: ProjectGroup['iteration'] } {
   const value = row.fieldValuesByFieldId[field.id]
   if (!hasNonEmptyFieldValue(value)) {
@@ -68,8 +86,8 @@ function getFieldValueForGrouping(
   }
   if (field.kind === 'iteration' && value.kind === 'iteration') {
     const iterations = field.iterations ?? []
-    const idx = iterations.findIndex((iteration) => iteration.id === value.iterationId)
-    const meta = iterations.find((iteration) => iteration.id === value.iterationId)
+    const idx = orderIndex.get(value.iterationId) ?? -1
+    const meta = iterations[idx]
     return {
       key: value.iterationId,
       label: value.title || meta?.title || 'Iteration',
@@ -80,7 +98,7 @@ function getFieldValueForGrouping(
     }
   }
   if (field.kind === 'single-select' && value.kind === 'single-select') {
-    const idx = (field.options ?? []).findIndex((option) => option.id === value.optionId)
+    const idx = orderIndex.get(value.optionId) ?? -1
     return {
       key: value.optionId,
       label: value.name,
@@ -123,6 +141,7 @@ export function groupRows(
   if (!groupField) {
     return [{ key: 'all', label: '', iteration: null, rows: rowsInOrder }]
   }
+  const groupOrderIndex = createFieldOrderIndex(groupField)
   const buckets = new Map<
     string,
     {
@@ -133,7 +152,11 @@ export function groupRows(
     }
   >()
   for (const row of rowsInOrder) {
-    const { key, label, orderHint, iteration } = getFieldValueForGrouping(row, groupField)
+    const { key, label, orderHint, iteration } = getFieldValueForGrouping(
+      row,
+      groupField,
+      groupOrderIndex
+    )
     let bucket = buckets.get(key)
     if (!bucket) {
       bucket = { label, orderHint, iteration, rows: [] }
@@ -163,7 +186,12 @@ export function groupRows(
   }))
 }
 
-function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProjectSort): number {
+function compareSort(
+  a: GitHubProjectRow,
+  b: GitHubProjectRow,
+  sort: GitHubProjectSort,
+  orderIndex: ReadonlyMap<string, number>
+): number {
   const field = sort.field
   const aValue = a.fieldValuesByFieldId[field.id]
   const bValue = b.fieldValuesByFieldId[field.id]
@@ -180,9 +208,8 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
     aValue.kind === 'single-select' &&
     bValue.kind === 'single-select'
   ) {
-    const options = field.options ?? []
-    const aIdx = options.findIndex((option) => option.id === aValue.optionId)
-    const bIdx = options.findIndex((option) => option.id === bValue.optionId)
+    const aIdx = orderIndex.get(aValue.optionId) ?? -1
+    const bIdx = orderIndex.get(bValue.optionId) ?? -1
     cmp =
       (aIdx === -1 ? UNKNOWN_INDEX_SENTINEL : aIdx) - (bIdx === -1 ? UNKNOWN_INDEX_SENTINEL : bIdx)
   } else if (
@@ -190,9 +217,8 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
     aValue.kind === 'iteration' &&
     bValue.kind === 'iteration'
   ) {
-    const iterations = field.iterations ?? []
-    const aIdx = iterations.findIndex((iteration) => iteration.id === aValue.iterationId)
-    const bIdx = iterations.findIndex((iteration) => iteration.id === bValue.iterationId)
+    const aIdx = orderIndex.get(aValue.iterationId) ?? -1
+    const bIdx = orderIndex.get(bValue.iterationId) ?? -1
     cmp =
       (aIdx === -1 ? UNKNOWN_INDEX_SENTINEL : aIdx) - (bIdx === -1 ? UNKNOWN_INDEX_SENTINEL : bIdx)
   } else if (aValue.kind === 'number' && bValue.kind === 'number') {
@@ -214,11 +240,14 @@ function compareSort(a: GitHubProjectRow, b: GitHubProjectRow, sort: GitHubProje
 }
 
 export function sortRows(table: GitHubProjectTable, rows: GitHubProjectRow[]): GitHubProjectRow[] {
-  const sorts = table.selectedView.sortByFields
+  const sorts = table.selectedView.sortByFields.map((sort) => ({
+    sort,
+    orderIndex: createFieldOrderIndex(sort.field)
+  }))
   const out = [...rows]
   out.sort((a, b) => {
-    for (const sort of sorts) {
-      const cmp = compareSort(a, b, sort)
+    for (const { sort, orderIndex } of sorts) {
+      const cmp = compareSort(a, b, sort, orderIndex)
       if (cmp !== 0) {
         return cmp
       }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

## ELI5

A GitHub Projects table can be sorted and grouped by a column such as Status or Iteration. Those columns aren't sorted alphabetically — they follow the order the options appear in the project's own settings, so "Todo" comes before "In Progress". To honour that, the app had to scan the whole option list to find each row's position, and it did that scan on every single comparison. On a 1,000-row table with 1,000 options that adds up to millions of scans.

Now the app builds a small "option to position" lookup once per sort and per grouping, then reads positions straight out of it. Rows and groups land in exactly the same order as before, including rows pointing at an option that was deleted from the project, and projects where the same option ID appears twice.

## What Changed / Why

- 1,000 options: 8,653,118 sorting ID reads → 1,000; grouping also 1,000; missing metadata and stable ties retained

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 12 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/components/github-project/group-sort.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
