### PR TITLE
perf: stop clone URL discovery at the first usable source

### DIFF
--- a/src/renderer/src/lib/project-clone-url-prefill.test.ts
+++ b/src/renderer/src/lib/project-clone-url-prefill.test.ts
@@ -62,4 +62,38 @@ describe('resolveProjectCloneUrlPrefill', () => {
       )
     ).toBe('https://github.com/acme/second.git')
   })
+  it('stops on the first usable source and indexes later misses only once', () => {
+    let reads = 0
+    const repos = Array.from({ length: 1000 }, (_, i) => ({
+      ...repo(`repo-${i}`, 'https://gitlab.com/acme/repo.git'),
+      get id() {
+        reads++
+        return `repo-${i}`
+      }
+    }))
+    const sourceIds = Array.from({ length: 1000 }, (_, i) => `repo-${i}`)
+    expect(resolveProjectCloneUrlPrefill([project(sourceIds)], repos, 'project-orca')).toBe(
+      'https://gitlab.com/acme/repo.git'
+    )
+    expect(reads).toBe(1)
+    reads = 0
+    expect(
+      resolveProjectCloneUrlPrefill(
+        [project(sourceIds.map((id) => `missing-${id}`))],
+        repos,
+        'project-orca'
+      )
+    ).toBe('')
+    expect(reads).toBeLessThanOrEqual(2000)
+  })
+
+  it('keeps the first duplicate repo authoritative when building the fallback index', () => {
+    expect(
+      resolveProjectCloneUrlPrefill(
+        [project(['missing', 'duplicate'])],
+        [repo('duplicate', ''), repo('duplicate', 'https://gitlab.com/acme/repo.git')],
+        'project-orca'
+      )
+    ).toBe('')
+  })
 })

--- a/src/renderer/src/lib/project-clone-url-prefill.ts
+++ b/src/renderer/src/lib/project-clone-url-prefill.ts
@@ -22,8 +22,23 @@ export function resolveProjectCloneUrlPrefill(
   }
   const sourceRepoIds =
     projects.find((candidate) => candidate.id === selectedProjectId)?.sourceRepoIds ?? []
-  const remoteUrl = sourceRepoIds
-    .map((sourceId) => repos.find((repo) => repo.id === sourceId)?.gitRemoteIdentity?.remoteUrl)
-    .find((url): url is string => Boolean(url))
-  return remoteUrl ? stripCredentialsFromMessage(remoteUrl) : ''
+  let reposById: Map<string, Repo> | undefined
+  for (let index = 0; index < sourceRepoIds.length; index++) {
+    if (index > 0 && !reposById) {
+      reposById = new Map()
+      for (const repo of repos) {
+        const id = repo.id
+        if (!reposById.has(id)) {
+          reposById.set(id, repo)
+        }
+      }
+    }
+    const sourceId = sourceRepoIds[index]
+    const source = reposById ? reposById.get(sourceId) : repos.find((repo) => repo.id === sourceId)
+    const remoteUrl = source?.gitRemoteIdentity?.remoteUrl
+    if (remoteUrl) {
+      return stripCredentialsFromMessage(remoteUrl)
+    }
+  }
+  return ''
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |

<!-- /orca-pr-loc -->

## ELI5

When you open "New workspace" and pick a project, Orca pre-fills the "Clone from URL" box with that project's Git address so you don't have to type it.

To find that address, Orca walks the project's repositories in order and takes the address from the first one that actually has one. The old code walked *every* repository first, collected all their addresses, and only then picked the first non-empty one — so for a project with 1,000 repos it did all 1,000 lookups even when the answer was sitting in repo #1.

Now it stops the moment it finds an address. The address it picks is the same one as before: still the first listed repository that has an address, and still the first entry wins if two repositories share an ID. Credentials embedded in the URL (tokens, passwords) are still stripped out before the box is filled, exactly as before. Nothing you see changes — Orca just stops doing work it had already finished.


## What Changed / Why

- First usable source: 500,500 repo-ID reads → 1; all-missing fallback bounded by source/repo counts; credential stripping and duplicate authority retained

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 7 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/lib/project-clone-url-prefill.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

