### PR TITLE
perf: clone only changed work-item pages

### DIFF
--- a/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
@@ -16,27 +16,29 @@ export function patchTaskPageGitHubWorkItemPages(
   patch: Partial<GitHubWorkItem>,
   shouldPatch?: (item: GitHubWorkItem) => boolean
 ): (GitHubWorkItem[] | null)[] {
-  let changed = false
-  const nextPages = pages.map((page) => {
+  let nextPages: (GitHubWorkItem[] | null)[] | undefined
+  pages.forEach((page, pageIndex) => {
     if (!page) {
-      return null
+      return
     }
-    let pageChanged = false
-    const nextPage = page.map((item) => {
+    let nextPage: GitHubWorkItem[] | undefined
+    page.forEach((item, itemIndex) => {
       if (
         item.id !== itemKey.id ||
         item.repoId !== itemKey.repoId ||
         (shouldPatch && !shouldPatch(item))
       ) {
-        return item
+        return
       }
-      changed = true
-      pageChanged = true
-      return { ...item, ...patch }
+      nextPage ??= page.slice()
+      nextPage[itemIndex] = { ...item, ...patch }
     })
-    return pageChanged ? nextPage : page
+    if (nextPage) {
+      nextPages ??= pages.slice()
+      nextPages[pageIndex] = nextPage
+    }
   })
-  return changed ? nextPages : (pages as (GitHubWorkItem[] | null)[])
+  return nextPages ?? (pages as (GitHubWorkItem[] | null)[])
 }
 
 /** Match each item to pending/confirmed authority by repoId + itemId + remembered sourceScope. */

--- a/src/renderer/src/components/task-page-mutation-page-allocation.test.ts
+++ b/src/renderer/src/components/task-page-mutation-page-allocation.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from 'vitest'
+import type { GitHubWorkItem } from '../../../shared/github/work-item-types'
+import { patchTaskPageGitHubWorkItemPages } from './task-page-github-work-item-mutation-pages'
+
+function item(id: string): GitHubWorkItem {
+  return {
+    id,
+    type: 'issue',
+    number: 1,
+    title: id,
+    state: 'open',
+    url: '',
+    labels: [],
+    updatedAt: '',
+    author: '',
+    repoId: 'repo'
+  }
+}
+
+it('avoids allocating copies of unaffected pages during an item mutation', () => {
+  const pages = Array.from({ length: 20 }, (_, p) =>
+    Array.from({ length: 200 }, (_, i) => item(`${p}:${i}`))
+  )
+  const inputs = new Set<unknown>([pages, ...pages])
+  const map = Array.prototype.map
+  const slice = Array.prototype.slice
+  let allocations = 0
+  Array.prototype.map = function <T, U>(
+    this: T[],
+    callback: (value: T, index: number, array: T[]) => U,
+    thisArg?: unknown
+  ): U[] {
+    if (inputs.has(this)) {
+      allocations++
+    }
+    return Reflect.apply(map, this, [callback, thisArg]) as U[]
+  }
+  Array.prototype.slice = function (this: unknown[], ...args: Parameters<typeof slice>) {
+    if (inputs.has(this)) {
+      allocations++
+    }
+    return slice.apply(this, args)
+  }
+  let result: ReturnType<typeof patchTaskPageGitHubWorkItemPages>
+  let unchanged: ReturnType<typeof patchTaskPageGitHubWorkItemPages>
+  try {
+    unchanged = patchTaskPageGitHubWorkItemPages(
+      pages,
+      { id: 'missing', repoId: 'repo' },
+      { title: 'New' }
+    )
+    result = patchTaskPageGitHubWorkItemPages(
+      pages,
+      { id: '19:199', repoId: 'repo' },
+      { title: 'New' }
+    )
+  } finally {
+    Array.prototype.map = map
+    Array.prototype.slice = slice
+  }
+  expect(allocations).toBe(2)
+  expect(unchanged).toBe(pages)
+  expect(result[0]).toBe(pages[0])
+  expect(result[19]?.[199].title).toBe('New')
+  expect(pages[19][199].title).toBe('19:199')
+})
+
+it('preserves sparse pages, null pages, duplicate matches and predicate exclusions', () => {
+  const page = [item('match'), item('match')]
+  delete page[0]
+  const pages = [page, null, [item('match'), item('match')]]
+  const patched = patchTaskPageGitHubWorkItemPages(
+    pages,
+    { id: 'match', repoId: 'repo' },
+    { title: 'new' },
+    (row) => row !== pages[2]?.[0]
+  )
+  expect(0 in patched[0]!).toBe(false)
+  expect(patched[1]).toBeNull()
+  expect(patched[2]?.map((row) => row.title)).toEqual(['match', 'new'])
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

The Tasks page shows issues and pull requests in pages of rows. When you change one row — assign someone, request a review, close an issue — Orca has to hand React a new copy of the list so the screen updates.

The old code rebuilt *everything*: a fresh copy of every page and a fresh copy of every row on every page, then threw almost all of it away because only one row had actually changed. With 20 pages of 200 rows that was 21 new arrays for a single click, and 21 more even when the row being changed was not present at all.

Now Orca copies only the one page that contains the changed row, and only when something really matched. Everything else is handed back untouched, by reference.

Nothing about *which* rows change is different. The rule for deciding whether a row matches (same item ID, same repository, plus any extra caller filter) is exactly the same code as before, and the update is still applied by copying the whole patch onto the row, so there is no hand-written list of fields that could fall out of date when a new field is added. Gaps in a page, empty pages and rows that appear twice all behave exactly as they did — there are tests for each.


## What Changed / Why

- Missing mutation plus one update across 20 pages: 42 arrays → 2; sparse pages, nulls and duplicate matches preserved

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 2 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/components/task-page-mutation-page-allocation.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

