### PR TITLE
perf: track pane alias singleton or ambiguity without copying buckets

### DIFF
--- a/src/main/persistence/restoring-sessions/pane-alias-normalization-scaling.test.ts
+++ b/src/main/persistence/restoring-sessions/pane-alias-normalization-scaling.test.ts
@@ -1,0 +1,36 @@
+import { expect, it, vi } from 'vitest'
+import type { MigrationUnsupportedPtyEntry } from '../../../shared/agent-status-types'
+import { legacyMigrationUnsupportedRowsToAliasEntries } from './pane-alias-normalization'
+
+vi.mock('../../agent-hooks/server', () => ({ agentHookServer: {} }))
+
+it('retains only the ambiguity verdict when many legacy rows name the same tab', () => {
+  const row: MigrationUnsupportedPtyEntry = {
+    ptyId: 'pty',
+    tabId: 'tab',
+    paneKey: 'tab:11111111-1111-4111-8111-111111111111',
+    reason: 'legacy-numeric-pane-key',
+    source: 'local',
+    updatedAt: 1
+  }
+  const rows = Array.from({ length: 2000 }, () => row)
+  const iterator = Array.prototype[Symbol.iterator]
+  let copied = 0
+  Array.prototype[Symbol.iterator] = function (this: unknown[]) {
+    if (this[0] === row) {
+      copied += this.length
+    }
+    return iterator.call(this)
+  }
+  let aliases: ReturnType<typeof legacyMigrationUnsupportedRowsToAliasEntries>
+  try {
+    aliases = legacyMigrationUnsupportedRowsToAliasEntries(rows)
+  } finally {
+    Array.prototype[Symbol.iterator] = iterator
+  }
+  expect(copied).toBeLessThan(10_000)
+  expect(aliases).toEqual([])
+  const unique = legacyMigrationUnsupportedRowsToAliasEntries([row])
+  expect(unique.map((entry) => entry.legacyPaneKey)).toEqual(['tab:0', 'tab:1'])
+  expect(unique.every((entry) => entry.stablePaneKey === row.paneKey)).toBe(true)
+})

--- a/src/main/persistence/restoring-sessions/pane-alias-normalization-scaling.test.ts
+++ b/src/main/persistence/restoring-sessions/pane-alias-normalization-scaling.test.ts
@@ -34,3 +34,81 @@ it('retains only the ambiguity verdict when many legacy rows name the same tab',
   expect(unique.map((entry) => entry.legacyPaneKey)).toEqual(['tab:0', 'tab:1'])
   expect(unique.every((entry) => entry.stablePaneKey === row.paneKey)).toBe(true)
 })
+
+function legacyRow(overrides: Partial<MigrationUnsupportedPtyEntry>): MigrationUnsupportedPtyEntry {
+  return {
+    ptyId: 'pty',
+    tabId: 'tab',
+    paneKey: 'tab:11111111-1111-4111-8111-111111111111',
+    reason: 'legacy-numeric-pane-key',
+    source: 'local',
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+// Ambiguity must fail closed: only an exactly-one row per tab may mint an alias.
+it.each([
+  ['0 rows', 0],
+  ['2 rows', 2],
+  ['3 rows', 3],
+  ['4 rows', 4]
+])('mints no alias for a tab named by %s', (_label, count) => {
+  const rows = Array.from({ length: count }, (_, i) =>
+    legacyRow({
+      ptyId: `pty-${i}`,
+      paneKey: `tab:1111111${i}-1111-4111-8111-111111111111`
+    })
+  )
+  expect(legacyMigrationUnsupportedRowsToAliasEntries(rows)).toEqual([])
+})
+
+it('mints both numeric aliases for a tab named by exactly 1 row', () => {
+  const row = legacyRow({ ptyId: 'pty-solo' })
+  expect(legacyMigrationUnsupportedRowsToAliasEntries([row])).toEqual([
+    {
+      ptyId: 'pty-solo',
+      legacyPaneKey: 'tab:0',
+      stablePaneKey: row.paneKey,
+      updatedAt: 1
+    },
+    {
+      ptyId: 'pty-solo',
+      legacyPaneKey: 'tab:1',
+      stablePaneKey: row.paneKey,
+      updatedAt: 1
+    }
+  ])
+})
+
+it('keeps unambiguous tabs in first-seen order while dropping ambiguous neighbours', () => {
+  const solo = legacyRow({
+    tabId: 'solo',
+    ptyId: 'pty-solo',
+    paneKey: 'solo:11111111-1111-4111-8111-111111111111'
+  })
+  const dupA = legacyRow({
+    tabId: 'dup',
+    ptyId: 'pty-a',
+    paneKey: 'dup:22222222-2222-4222-8222-222222222222'
+  })
+  const dupB = legacyRow({
+    tabId: 'dup',
+    ptyId: 'pty-b',
+    paneKey: 'dup:33333333-3333-4333-8333-333333333333'
+  })
+  const late = legacyRow({
+    tabId: 'late',
+    ptyId: 'pty-late',
+    paneKey: 'late:44444444-4444-4444-8444-444444444444'
+  })
+  // A third row for 'dup' must not resurrect it: ambiguity is sticky, not a parity toggle.
+  const aliases = legacyMigrationUnsupportedRowsToAliasEntries([solo, dupA, dupB, late, dupA])
+  expect(aliases.map((entry) => entry.legacyPaneKey)).toEqual([
+    'solo:0',
+    'solo:1',
+    'late:0',
+    'late:1'
+  ])
+  expect(aliases.every((entry) => entry.ptyId !== 'pty-a' && entry.ptyId !== 'pty-b')).toBe(true)
+})

--- a/src/main/persistence/restoring-sessions/pane-alias-normalization.ts
+++ b/src/main/persistence/restoring-sessions/pane-alias-normalization.ts
@@ -14,21 +14,17 @@ export function legacyMigrationUnsupportedRowsToAliasEntries(
   const normalizedEntries = normalizeMigrationUnsupportedPtyEntries(entries).filter(
     (entry) => entry.tabId && entry.paneKey && parsePaneKey(entry.paneKey)
   )
-  const entriesByTabId = new Map<string, MigrationUnsupportedPtyEntry[]>()
+  const entriesByTabId = new Map<string, MigrationUnsupportedPtyEntry | null>()
   for (const entry of normalizedEntries) {
     const tabId = entry.tabId
     if (!tabId) {
       continue
     }
-    entriesByTabId.set(tabId, [...(entriesByTabId.get(tabId) ?? []), entry])
+    entriesByTabId.set(tabId, entriesByTabId.has(tabId) ? null : entry)
   }
   const aliasEntries: LegacyPaneKeyAliasEntry[] = []
-  for (const [tabId, tabEntries] of entriesByTabId) {
-    if (tabEntries.length !== 1) {
-      continue
-    }
-    const [entry] = tabEntries
-    if (!entry.paneKey) {
+  for (const [tabId, entry] of entriesByTabId) {
+    if (!entry?.paneKey) {
       continue
     }
     // Why: pre-stable rows lack the old numeric key; only synthesize single-pane aliases when the row is unambiguous.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

When Orca starts up it tries to reconnect terminals that were saved by a much older version, which recorded panes as "tab:0" / "tab:1" instead of today's stable IDs. To do that it builds a small translation table from the old name to the new one.

The safety rule has always been: only translate when a tab has **exactly one** saved terminal. If a tab has two or more, Orca can't tell which one "tab:0" meant, so it refuses to guess and writes no translation — the terminal is left to be recovered another way rather than wired to the wrong session.

The old code proved that rule by collecting every saved row for a tab into a list and then checking whether the list had exactly one item. Building those lists meant copying the whole list every time a row was added, so a corrupted save file with 2,000 rows for one tab copied about two million entries just to conclude "more than one — skip it."

Now Orca keeps only the verdict per tab: the single row, or a "more than one" marker. Once a tab is marked ambiguous it stays ambiguous no matter how many more rows arrive. Same answer, ~200x less work on a bad save file.

The refusal-to-guess behaviour is unchanged and is now pinned by tests for 0, 1, 2, 3 and 4 rows per tab, plus a mixed case proving an ambiguous tab can never come back and claim a pane.


## What Changed / Why

- 2,000 repeated legacy rows: 2,001,000 copied elements → under 10,000; ambiguous aliases withheld; singleton aliases retained

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 1 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/persistence/restoring-sessions/pane-alias-normalization-scaling.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

