### PR TITLE
perf: index Resource Manager labels and accumulated workspace rows

### DIFF
--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -573,3 +573,59 @@ describe('mergeSnapshotAndSessions', () => {
     expect(out[0].worktrees[0].sessions[0].bound).toBe(false)
   })
 })
+
+it('indexes tab labels when merging a large resource inventory', () => {
+  let reads = 0
+  const tabs = Array.from({ length: 1000 }, (_, i) => ({
+    ...makeTab(`tab-${i}`, `Terminal ${i}`),
+    get id() {
+      reads++
+      return `tab-${i}`
+    },
+    ptyId: `pty-${i}`
+  }))
+  const sessions: DaemonSession[] = tabs.map((_, i) => ({
+    id: `pty-${i}`,
+    cwd: '/repo',
+    title: '',
+    agentOwnership: 'unknown'
+  }))
+  const result = mergeSnapshotAndSessions(
+    null,
+    sessions,
+    baseCtx({ tabsByWorktree: { 'repo::/repo': tabs } })
+  )
+  expect(reads).toBeLessThan(5000)
+  expect(result[0].worktrees[0].sessions.map((session) => session.label)).toEqual(
+    Array.from({ length: 1000 }, (_, i) => `Terminal ${i}`)
+  )
+})
+
+it('does not scan accumulated worktree rows for unrelated daemon sessions', () => {
+  const sessions: DaemonSession[] = Array.from({ length: 1000 }, (_, i) => ({
+    id: `opaque-${i}`,
+    cwd: '',
+    title: '',
+    agentOwnership: 'unknown'
+  }))
+  const find = Array.prototype.find
+  let scanned = 0
+  Array.prototype.find = function (this: unknown[], ...args: Parameters<typeof find>) {
+    const first = this[0] as { sessions?: unknown; hasLocalSamples?: unknown } | undefined
+    if (first?.sessions && first.hasLocalSamples !== undefined) {
+      scanned += this.length
+    }
+    return find.apply(this, args)
+  }
+  let merged: ReturnType<typeof mergeSnapshotAndSessions>
+  try {
+    merged = mergeSnapshotAndSessions(null, sessions, baseCtx())
+  } finally {
+    Array.prototype.find = find
+  }
+  expect(scanned).toBe(0)
+  expect(merged[0].worktrees).toHaveLength(1000)
+  expect(merged[0].worktrees.every((row) => row.sessions[0].agentOwnership === 'unknown')).toBe(
+    true
+  )
+})

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -629,3 +629,74 @@ it('does not scan accumulated worktree rows for unrelated daemon sessions', () =
     true
   )
 })
+
+const LEAF = '11111111-1111-4111-8111-111111111111'
+
+// The tab index replaces `tabs.findIndex`, which resolves to the first match; a duplicated tab id
+// must not start resolving to the last one and relabel a session with a stranger's title.
+it('resolves a duplicated tab id to the first tab, as the replaced scan did', () => {
+  const first = makeTab('dup', 'First tab')
+  const second = makeTab('dup', 'Second tab')
+  const wt: WorktreeMemory = {
+    worktreeId: 'orca::/Users/me/Triton',
+    worktreeName: 'Triton',
+    repoId: 'orca',
+    repoName: 'ORCA',
+    cpu: 0,
+    memory: 0,
+    history: [],
+    sessions: [{ sessionId: 'pty-1', paneKey: `dup:${LEAF}`, pid: 5, cpu: 0, memory: 0 }]
+  }
+  const out = mergeSnapshotAndSessions(
+    makeSnapshot([wt]),
+    [],
+    baseCtx({ tabsByWorktree: { 'orca::/Users/me/Triton': [first, second] } })
+  )
+  expect(out[0].worktrees[0].sessions[0].label).toBe('First tab')
+})
+
+// A tab id present in another worktree must not leak a label across worktrees.
+it('keeps tab labels scoped to their own worktree', () => {
+  const wt: WorktreeMemory = {
+    worktreeId: 'orca::/Users/me/Triton',
+    worktreeName: 'Triton',
+    repoId: 'orca',
+    repoName: 'ORCA',
+    cpu: 0,
+    memory: 0,
+    history: [],
+    sessions: [{ sessionId: 'pty-1', paneKey: `shared:${LEAF}`, pid: 5, cpu: 0, memory: 0 }]
+  }
+  const out = mergeSnapshotAndSessions(
+    makeSnapshot([wt]),
+    [],
+    baseCtx({ tabsByWorktree: { 'orca::/Users/me/Other': [makeTab('shared', 'Elsewhere')] } })
+  )
+  expect(out[0].worktrees[0].sessions[0].label).toBe('pid 5')
+})
+
+// findWorktreeRow replaces `repo.worktrees.find`, which returns the first row; a snapshot that
+// repeats a worktree must keep later daemon sessions landing on that same first row.
+it('attaches later daemon sessions to the first row of a duplicated worktree', () => {
+  const wt = (name: string): WorktreeMemory => ({
+    worktreeId: 'orca::/Users/me/Triton',
+    worktreeName: name,
+    repoId: 'orca',
+    repoName: 'ORCA',
+    cpu: 0,
+    memory: 0,
+    history: [],
+    sessions: []
+  })
+  const out = mergeSnapshotAndSessions(
+    makeSnapshot([wt('first'), wt('second')]),
+    [{ id: 'orca::/Users/me/Triton@@late', cwd: '', title: '', agentOwnership: 'unknown' }],
+    baseCtx()
+  )
+  expect(out[0].worktrees).toHaveLength(2)
+  expect(out[0].worktrees[0].worktreeName).toBe('first')
+  expect(out[0].worktrees[0].sessions.map((s) => s.sessionId)).toEqual([
+    'orca::/Users/me/Triton@@late'
+  ])
+  expect(out[0].worktrees[1].sessions).toEqual([])
+})

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -35,7 +35,10 @@ import type {
   UnifiedSessionRow,
   UnifiedWorktreeRow
 } from './resource-usage-merge-types'
-import { buildResourceSessionBindingIndex } from './resource-session-bindings'
+import {
+  buildResourceSessionBindingIndex,
+  type ResourceSessionBindingIndex
+} from './resource-session-bindings'
 
 // ─── Helpers ────────────────────────────────────────────────────────
 
@@ -67,13 +70,13 @@ function parsePaneKey(paneKey: string | null): { tabId: string; leafId: string }
 function resolveSnapshotSessionLabel(
   session: SessionMemory,
   worktreeId: string,
-  ctx: MergeContext
+  index: ResourceSessionBindingIndex
 ): string {
   const parsed = parsePaneKey(session.paneKey)
   if (parsed) {
-    const tabs = ctx.tabsByWorktree[worktreeId] ?? []
-    const tabIndex = tabs.findIndex((t) => t.id === parsed.tabId)
-    const tab = tabIndex !== -1 ? tabs[tabIndex] : undefined
+    const match = index.tabsByIdByWorktree.get(worktreeId)?.get(parsed.tabId)
+    const tab = match?.tab
+    const tabIndex = match?.index ?? -1
     if (tab) {
       const custom = tab.customTitle?.trim()
       if (custom) {
@@ -93,12 +96,11 @@ function resolveDaemonSessionLabel(
   session: DaemonSession,
   resolvedWorktreeId: string | null,
   tabId: string | null,
-  ctx: MergeContext
+  ctx: MergeContext,
+  index: ResourceSessionBindingIndex
 ): string {
   if (tabId && resolvedWorktreeId) {
-    const tabs = ctx.tabsByWorktree[resolvedWorktreeId] ?? []
-    const tabIndex = tabs.findIndex((t) => t.id === tabId)
-    const tab = tabIndex !== -1 ? tabs[tabIndex] : undefined
+    const tab = index.tabsByIdByWorktree.get(resolvedWorktreeId)?.get(tabId)?.tab
     if (tab) {
       const custom = tab.customTitle?.trim()
       if (custom) {
@@ -140,11 +142,12 @@ export function mergeSnapshotAndSessions(
   ctx: MergeContext
 ): UnifiedProjectGroup[] {
   const repos = new Map<string, UnifiedProjectGroup>()
+  const worktreeRowsByRepo = new Map<string, Map<string, UnifiedWorktreeRow>>()
   const seenSessionIds = new Set<string>()
   // Why: pre-build O(1) lookup indices once per merge. This includes live
   // ptyIdsByTabId plus deferred-reattach wake hints, so restored inactive
   // sessions do not appear as Resource Manager orphans before their pane mounts.
-  const index = buildResourceSessionBindingIndex(ctx)
+  const index = buildResourceSessionBindingIndex(ctx, true)
   const boundPtyIds = index.boundPtyIds
   // Why: the daemon list is the only place agent ownership is reported. Snapshot-derived rows
   // describe the same sessions by id, so carry it across rather than inventing an answer; a
@@ -184,6 +187,7 @@ export function mergeSnapshotAndSessions(
       worktrees: []
     }
     repos.set(repoId, next)
+    worktreeRowsByRepo.set(repoId, new Map())
     return next
   }
 
@@ -191,7 +195,15 @@ export function mergeSnapshotAndSessions(
     repo: UnifiedProjectGroup,
     worktreeId: string
   ): UnifiedWorktreeRow | undefined {
-    return repo.worktrees.find((w) => w.worktreeId === worktreeId)
+    return worktreeRowsByRepo.get(repo.repoId)?.get(worktreeId)
+  }
+
+  function appendWorktreeRow(repo: UnifiedProjectGroup, row: UnifiedWorktreeRow): void {
+    repo.worktrees.push(row)
+    const rows = worktreeRowsByRepo.get(repo.repoId)!
+    if (!rows.has(row.worktreeId)) {
+      rows.set(row.worktreeId, row)
+    }
   }
 
   // ── Step 1: ingest snapshot worktrees as the local-truth foundation.
@@ -210,7 +222,7 @@ export function mergeSnapshotAndSessions(
           sessionId: s.sessionId,
           paneKey: s.paneKey,
           pid: s.pid,
-          label: resolveSnapshotSessionLabel(s, wt.worktreeId, ctx),
+          label: resolveSnapshotSessionLabel(s, wt.worktreeId, index),
           bound: ctx.workspaceSessionReady && boundPtyIds.has(s.sessionId),
           agentOwnership: ownershipBySessionId.get(s.sessionId) ?? 'unknown',
           tabId,
@@ -219,7 +231,7 @@ export function mergeSnapshotAndSessions(
           hasLocalSamples: true
         }
       })
-      repo.worktrees.push({
+      appendWorktreeRow(repo, {
         worktreeId: wt.worktreeId,
         worktreeName: wt.worktreeName,
         repoId: wt.repoId,
@@ -291,14 +303,14 @@ export function mergeSnapshotAndSessions(
         sessions: [],
         browsers: []
       }
-      repo.worktrees.push(row)
+      appendWorktreeRow(repo, row)
     }
 
     row.sessions.push({
       sessionId: session.id,
       paneKey: null,
       pid: 0,
-      label: resolveDaemonSessionLabel(session, worktreeId, tabId, ctx),
+      label: resolveDaemonSessionLabel(session, worktreeId, tabId, ctx, index),
       bound: ctx.workspaceSessionReady && boundPtyIds.has(session.id),
       agentOwnership: session.agentOwnership,
       tabId,
@@ -331,7 +343,7 @@ export function mergeSnapshotAndSessions(
         sessions: [],
         browsers: []
       }
-      repo.worktrees.push(row)
+      appendWorktreeRow(repo, row)
     }
     row.browsers = browsers
   }

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -147,7 +147,7 @@ export function mergeSnapshotAndSessions(
   // Why: pre-build O(1) lookup indices once per merge. This includes live
   // ptyIdsByTabId plus deferred-reattach wake hints, so restored inactive
   // sessions do not appear as Resource Manager orphans before their pane mounts.
-  const index = buildResourceSessionBindingIndex(ctx, true)
+  const index = buildResourceSessionBindingIndex(ctx)
   const boundPtyIds = index.boundPtyIds
   // Why: the daemon list is the only place agent ownership is reported. Snapshot-derived rows
   // describe the same sessions by id, so carry it across rather than inventing an answer; a

--- a/src/renderer/src/components/status-bar/resource-session-bindings.ts
+++ b/src/renderer/src/components/status-bar/resource-session-bindings.ts
@@ -35,27 +35,23 @@ function addBinding(
 }
 
 export function buildResourceSessionBindingIndex(
-  inputs: ResourceSessionBindingInputs,
-  includeTabLabels = false
+  inputs: ResourceSessionBindingInputs
 ): ResourceSessionBindingIndex {
   const ptyIdToTabId = new Map<string, string>()
   const tabIdToWorktreeId = new Map<string, string>()
   const tabsByIdByWorktree: ResourceSessionBindingIndex['tabsByIdByWorktree'] = new Map()
 
   for (const [worktreeId, tabs] of Object.entries(inputs.tabsByWorktree)) {
-    const byId = includeTabLabels
-      ? new Map<string, { tab: TerminalTab; index: number }>()
-      : undefined
+    const byId = new Map<string, { tab: TerminalTab; index: number }>()
     tabs.forEach((tab, index) => {
       const id = tab.id
       tabIdToWorktreeId.set(id, worktreeId)
-      if (byId && !byId.has(id)) {
+      // First tab wins, matching the findIndex scan this index replaces.
+      if (!byId.has(id)) {
         byId.set(id, { tab, index })
       }
     })
-    if (byId) {
-      tabsByIdByWorktree.set(worktreeId, byId)
-    }
+    tabsByIdByWorktree.set(worktreeId, byId)
   }
 
   for (const [tabId, ptyIds] of Object.entries(inputs.ptyIdsByTabId)) {

--- a/src/renderer/src/components/status-bar/resource-session-bindings.ts
+++ b/src/renderer/src/components/status-bar/resource-session-bindings.ts
@@ -20,6 +20,7 @@ export type ResourceSessionBindingIndex = {
   ptyIdToTabId: Map<string, string>
   tabIdToWorktreeId: Map<string, string>
   boundPtyIds: Set<string>
+  tabsByIdByWorktree: Map<string, Map<string, { tab: TerminalTab; index: number }>>
 }
 
 function addBinding(
@@ -34,14 +35,26 @@ function addBinding(
 }
 
 export function buildResourceSessionBindingIndex(
-  inputs: ResourceSessionBindingInputs
+  inputs: ResourceSessionBindingInputs,
+  includeTabLabels = false
 ): ResourceSessionBindingIndex {
   const ptyIdToTabId = new Map<string, string>()
   const tabIdToWorktreeId = new Map<string, string>()
+  const tabsByIdByWorktree: ResourceSessionBindingIndex['tabsByIdByWorktree'] = new Map()
 
   for (const [worktreeId, tabs] of Object.entries(inputs.tabsByWorktree)) {
-    for (const tab of tabs) {
-      tabIdToWorktreeId.set(tab.id, worktreeId)
+    const byId = includeTabLabels
+      ? new Map<string, { tab: TerminalTab; index: number }>()
+      : undefined
+    tabs.forEach((tab, index) => {
+      const id = tab.id
+      tabIdToWorktreeId.set(id, worktreeId)
+      if (byId && !byId.has(id)) {
+        byId.set(id, { tab, index })
+      }
+    })
+    if (byId) {
+      tabsByIdByWorktree.set(worktreeId, byId)
     }
   }
 
@@ -81,6 +94,7 @@ export function buildResourceSessionBindingIndex(
   return {
     ptyIdToTabId,
     tabIdToWorktreeId,
+    tabsByIdByWorktree,
     boundPtyIds: inputs.workspaceSessionReady ? new Set(ptyIdToTabId.keys()) : new Set()
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​127 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​127 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |

<!-- /orca-pr-loc -->

## ELI5

Resource Manager lists every terminal Orca is running, grouped by project and workspace, with a friendly name for each row ("Terminal 3", the tab's custom title, and so on).

To build that list it had to answer the same two questions over and over:

1. "Which tab does this terminal belong to, so I can borrow its name?" — answered by scanning the whole list of tabs from the start, once per terminal.
2. "Have I already made a row for this workspace?" — answered by scanning every row created so far, once per terminal.

Both scans get slower the more terminals you have, so the cost grew with the *square* of the list. With 1,000 sessions open that was roughly half a million tab reads and another half a million row scans for one refresh of the panel — and the panel refreshes as usage numbers tick.

Now Orca builds two small lookup tables once at the start and answers both questions instantly. Same rows, same names, same order.

The two tie-breaking rules the old scans quietly relied on are preserved and now have tests: when two tabs share an ID, the *first* one wins (so a session can't suddenly get a stranger's title), and when a workspace appears twice, later terminals still attach to the *first* row.

Review change on top of the original: the label table was originally built only when a caller opted in with a flag, while the type claimed it was always there — a future caller could have read it, silently got nothing, and shipped sessions labelled "pid 1234" instead of their tab name. The flag is gone; the table is always built. The only other caller is the orphan-session counter, which is memoized and runs only while the panel is open, so it does not measurably care.


## What Changed / Why

- 1,000 sessions: 502,500 tab-ID reads → under 5,000; 499,500 accumulated-row scans → zero; binding-only callers skip label maps

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 21 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

