### PR TITLE
perf: index selected skills when reporting bundle failures

### DIFF
--- a/src/main/skills/skill-cloud-grant-installation.test.ts
+++ b/src/main/skills/skill-cloud-grant-installation.test.ts
@@ -134,6 +134,57 @@ describe('installSkillCloudGrant', () => {
   })
 })
 
+// The failure report is keyed by user-visible skill IDs, so switching the
+// membership test from `includes` to a Set must not change which entries appear,
+// how often, or in what order.
+it('reports selected manifest entries in manifest order, duplicates and all', async () => {
+  const skills = ['b', 'a', 'dupe', 'dupe', 'unselected'].map((id) => ({
+    id,
+    name: `name-${id}`,
+    digest: 'a'.repeat(64),
+    files: []
+  }))
+  const bundleGrant = {
+    ...grant,
+    version: { ...grant.version, manifest: { skills, bundleDigest: 'c'.repeat(64) } }
+  } as unknown as SkillCloudDownloadGrant
+  const runtime = {
+    installSharedSkillBundleRequest: vi
+      .fn()
+      .mockRejectedValue(new Error('skill-install-filesystem-failed'))
+  } as unknown as OrcaRuntimeService
+  const result = await installSkillBundleCloudGrant(runtime, bundleGrant, {
+    operationId: 'op',
+    // Repeated and unknown selections must be inert, exactly as with `includes`.
+    selectedSkillIds: ['dupe', 'a', 'a', 'b', 'never-in-manifest'],
+    destination: { scope: 'global' }
+  })
+  expect(result.status).toBe('ok')
+  if (result.status === 'ok') {
+    expect(result.value.skills.map((skill) => skill.skillId)).toEqual(['b', 'a', 'dupe', 'dupe'])
+  }
+})
+
+it('reports no skills when nothing was selected', async () => {
+  const skills = [{ id: 'a', name: 'a', digest: 'a'.repeat(64), files: [] }]
+  const bundleGrant = {
+    ...grant,
+    version: { ...grant.version, manifest: { skills, bundleDigest: 'c'.repeat(64) } }
+  } as unknown as SkillCloudDownloadGrant
+  const runtime = {
+    installSharedSkillBundleRequest: vi.fn().mockRejectedValue(new Error('skill-install-cancelled'))
+  } as unknown as OrcaRuntimeService
+  const result = await installSkillBundleCloudGrant(runtime, bundleGrant, {
+    operationId: 'op',
+    selectedSkillIds: [],
+    destination: { scope: 'global' }
+  })
+  expect(result.status).toBe('ok')
+  if (result.status === 'ok') {
+    expect(result.value.skills).toEqual([])
+  }
+})
+
 it.each(['skill-install-cancelled', 'skill-install-filesystem-failed'])(
   'indexes selected IDs when reporting %s',
   async (code) => {

--- a/src/main/skills/skill-cloud-grant-installation.test.ts
+++ b/src/main/skills/skill-cloud-grant-installation.test.ts
@@ -133,3 +133,38 @@ describe('installSkillCloudGrant', () => {
     )
   })
 })
+
+it.each(['skill-install-cancelled', 'skill-install-filesystem-failed'])(
+  'indexes selected IDs when reporting %s',
+  async (code) => {
+    let reads = 0
+    const ids = Array.from({ length: 1000 }, (_, index) => `skill-${index}`)
+    const selectedSkillIds = new Proxy(ids, {
+      get(target, key, receiver) {
+        if (typeof key === 'string' && /^\d+$/.test(key)) {
+          reads += 1
+        }
+        return Reflect.get(target, key, receiver)
+      }
+    })
+    const skills = ids.map((id) => ({ id, name: id, digest: 'a'.repeat(64), files: [] }))
+    const bundleGrant = {
+      ...grant,
+      version: { ...grant.version, manifest: { skills, bundleDigest: 'c'.repeat(64) } }
+    } as unknown as SkillCloudDownloadGrant
+    const runtime = {
+      installSharedSkillBundleRequest: vi.fn().mockRejectedValue(new Error(code))
+    } as unknown as OrcaRuntimeService
+    const result = await installSkillBundleCloudGrant(runtime, bundleGrant, {
+      operationId: 'op',
+      selectedSkillIds,
+      destination: { scope: 'global' }
+    })
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') {
+      expect(result.value.skills.map((skill) => skill.skillId)).toEqual(ids)
+      expect(result.value.status).toBe(code.includes('cancelled') ? 'cancelled' : 'failed')
+    }
+    expect(reads).toBeLessThanOrEqual(2000)
+  }
+)

--- a/src/main/skills/skill-cloud-grant-installation.ts
+++ b/src/main/skills/skill-cloud-grant-installation.ts
@@ -49,6 +49,7 @@ function bundleFailureResult(
   if (!('skills' in manifest)) {
     throw new Error('skill-bundle-cloud-manifest-required')
   }
+  const selectedSkillIds = new Set(request.selectedSkillIds)
   return {
     operationId: request.operationId,
     packageId: request.package.packageId,
@@ -56,7 +57,7 @@ function bundleFailureResult(
     bundleDigest: request.package.bundleDigest,
     status: failure.category === 'cancelled' ? 'cancelled' : 'failed',
     skills: manifest.skills
-      .filter((skill) => request.selectedSkillIds.includes(skill.id))
+      .filter((skill) => selectedSkillIds.has(skill.id))
       .map((skill) => ({
         skillId: skill.id,
         name: skill.name,

--- a/src/renderer/src/components/skills/skill-delete-copy.test.ts
+++ b/src/renderer/src/components/skills/skill-delete-copy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { SkillDeletePlan } from '../../../../shared/skill-delete-contract'
 import {
   skillDeleteBlockedLines,
@@ -143,4 +143,38 @@ describe('skillDeleteResultLines', () => {
       skillDeleteResultLines([{ id: 'a', name: 'a', status: 'deleted', removedPaths: ['/x'] }])
     ).toEqual([])
   })
+})
+
+it('sorts deletion roots once with unchanged case, accent, and number ordering', () => {
+  const labels = ['éclair', 'Eclair', 'item2', 'item10', 'Ångström', 'zebra', 'İstanbul']
+  const expected = [...labels].sort((a, b) =>
+    // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Preserve the old comparator as the parity oracle.
+    a.localeCompare(b, undefined, { sensitivity: 'base' })
+  )
+  const NativeCollator = Intl.Collator
+  const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+    return new NativeCollator(locales, options)
+  })
+  const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+  try {
+    const summary = skillDeletePlacementSummary(
+      plan([
+        {
+          id: 'a',
+          name: 'demo',
+          canonicalPath: '/root/demo/SKILL.md',
+          placements: labels.map((rootLabel) => ({
+            path: '/root/demo',
+            kind: 'canonical',
+            rootLabel
+          }))
+        }
+      ])
+    )
+    expect(summary).toContain(expected.join(', '))
+    expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+    expect(localeCompare).not.toHaveBeenCalled()
+  } finally {
+    vi.restoreAllMocks()
+  }
 })

--- a/src/renderer/src/components/skills/skill-delete-copy.test.ts
+++ b/src/renderer/src/components/skills/skill-delete-copy.test.ts
@@ -172,7 +172,12 @@ it('sorts deletion roots once with unchanged case, accent, and number ordering',
       ])
     )
     expect(summary).toContain(expected.join(', '))
-    expect(construct).toHaveBeenCalledExactlyOnceWith(undefined, { sensitivity: 'base' })
+    // The shared renderer collator is memoised process-wide, so it is built at
+    // most once here and never per comparison.
+    expect(construct.mock.calls.length).toBeLessThanOrEqual(1)
+    for (const call of construct.mock.calls) {
+      expect(call).toEqual([undefined, { sensitivity: 'base' }])
+    }
     expect(localeCompare).not.toHaveBeenCalled()
   } finally {
     vi.restoreAllMocks()

--- a/src/renderer/src/components/skills/skill-delete-copy.ts
+++ b/src/renderer/src/components/skills/skill-delete-copy.ts
@@ -1,4 +1,5 @@
 import { translate } from '@/i18n/i18n'
+import { compareBaseSensitivityLocaleText } from '@/lib/locale-text-collators'
 import type {
   SkillDeleteBlockReason,
   SkillDeletePlan,
@@ -73,9 +74,8 @@ export function skillDeletePlacementSummary(plan: SkillDeletePlan): string | nul
     folders > 0 ? foldersLabel(folders) : null,
     links > 0 ? linksLabel(links) : null
   ].filter((part): part is string => part !== null)
-  const compareLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
-  const roots = [...new Set(placements.map((placement) => placement.rootLabel))].sort((a, b) =>
-    compareLabels(a, b)
+  const roots = [...new Set(placements.map((placement) => placement.rootLabel))].sort(
+    compareBaseSensitivityLocaleText
   )
   return translate(
     'auto.components.skills.SkillDelete.placementSummaryParts',

--- a/src/renderer/src/components/skills/skill-delete-copy.ts
+++ b/src/renderer/src/components/skills/skill-delete-copy.ts
@@ -73,8 +73,9 @@ export function skillDeletePlacementSummary(plan: SkillDeletePlan): string | nul
     folders > 0 ? foldersLabel(folders) : null,
     links > 0 ? linksLabel(links) : null
   ].filter((part): part is string => part !== null)
+  const compareLabels = new Intl.Collator(undefined, { sensitivity: 'base' }).compare
   const roots = [...new Set(placements.map((placement) => placement.rootLabel))].sort((a, b) =>
-    a.localeCompare(b, undefined, { sensitivity: 'base' })
+    compareLabels(a, b)
   )
   return translate(
     'auto.components.skills.SkillDelete.placementSummaryParts',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​126 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

When a shared skill bundle fails to install (or you cancel it), Orca writes a report listing which of the skills you picked were affected. To work out "was this one picked?", it used to re-scan your whole pick list once for every skill in the bundle, so a 1,000-skill bundle meant roughly half a million look-ups.

Now it puts your picks into a lookup table once and checks that instead. The report lists exactly the same skills, in the same order, with the same cancelled-or-failed wording.

The same PR also stops a separate screen — the "Removes N folders across ..." line in the delete-skill confirmation — from rebuilding its alphabetising rulebook on every render, by reusing the one the rest of the app already shares.

## What Changed / Why

- 1,000 selected skills: 500,500 selection reads → at most 2,000; manifest order and cancelled/failed statuses preserved
- The delete-plan root sort now calls `compareBaseSensitivityLocaleText` from `src/renderer/src/lib/locale-text-collators.ts` (already shared by six renderer modules) instead of constructing a second per-call collator with the same options.
- Added parity coverage that repeated, unknown and duplicated selections stay inert and manifest order is preserved, since the membership test moved from `Array.includes` to `Set.has`.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 13 tests across 2 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/skills/skill-cloud-grant-installation.test.ts`
- `src/renderer/src/components/skills/skill-delete-copy.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

