### PR TITLE
perf: validate terminal adoption MRU membership with group sets

### DIFF
--- a/src/main/runtime/runtime-terminal-orphan-topology-validation.test.ts
+++ b/src/main/runtime/runtime-terminal-orphan-topology-validation.test.ts
@@ -69,3 +69,83 @@ it.each(['duplicate', 'foreign-recent', 'foreign-active'])(
     ).toThrow('terminal_orphan_topology_invalid')
   }
 )
+
+function validate(request: RuntimeTerminalOrphanAdoptionRequest) {
+  return validateRuntimeTerminalOrphanTopology(
+    request,
+    request.claims.map((claim) => ({ claim }))
+  )
+}
+
+type Groups = NonNullable<RuntimeTerminalOrphanAdoptionRequest['topology']>['groups']
+
+function withGroups(count: number, groups: Groups): RuntimeTerminalOrphanAdoptionRequest {
+  const request = fixture(count)
+  request.topology!.groups = groups
+  return request
+}
+
+// Membership is per-group, but the no-tab-in-two-groups rule is global. Replacing that rule with
+// the per-group set would let one pane be adopted into two groups and cross-wire the session.
+it('rejects a tab claimed by two different groups', () => {
+  expect(() =>
+    validate(
+      withGroups(2, [
+        { id: 'g1', activeTabId: 'tab-0', tabOrder: ['tab-0', 'tab-1'], recentTabIds: [] },
+        { id: 'g2', activeTabId: 'tab-1', tabOrder: ['tab-1'], recentTabIds: [] }
+      ])
+    )
+  ).toThrow('terminal_orphan_topology_invalid')
+})
+
+it('rejects a duplicated group id', () => {
+  expect(() =>
+    validate(
+      withGroups(2, [
+        { id: 'g', activeTabId: 'tab-0', tabOrder: ['tab-0'], recentTabIds: [] },
+        { id: 'g', activeTabId: 'tab-1', tabOrder: ['tab-1'], recentTabIds: [] }
+      ])
+    )
+  ).toThrow('terminal_orphan_topology_invalid')
+})
+
+// Cardinality 0: an empty tab order can never hold the active tab, so adoption must fail closed
+// rather than fall through to an arbitrary pane.
+it('rejects an empty tab order', () => {
+  expect(() =>
+    validate(withGroups(2, [{ id: 'g', activeTabId: 'tab-0', tabOrder: [], recentTabIds: [] }]))
+  ).toThrow('terminal_orphan_topology_invalid')
+})
+
+it('rejects a claimed tab that no group lists', () => {
+  expect(() =>
+    validate(
+      withGroups(2, [{ id: 'g', activeTabId: 'tab-0', tabOrder: ['tab-0'], recentTabIds: [] }])
+    )
+  ).toThrow('terminal_orphan_topology_invalid')
+})
+
+it.each([
+  ['1 tab per group', [['tab-0'], ['tab-1']]],
+  ['both tabs in one group', [['tab-0', 'tab-1']]]
+])('accepts an exactly-covering split with %s', (_label, tabOrders) => {
+  const groups: Groups = tabOrders.map((tabOrder, i) => ({
+    id: `g${i}`,
+    activeTabId: tabOrder[0],
+    tabOrder,
+    // Reverse MRU: every entry must still resolve inside its own group.
+    recentTabIds: tabOrder.toReversed()
+  }))
+  expect(validate(withGroups(2, groups)).topologyTabsById.size).toBe(2)
+})
+
+it.each([
+  ['omitted', undefined],
+  ['empty', [] as string[]]
+])('accepts %s recentTabIds', (_label, recentTabIds) => {
+  expect(
+    validate(
+      withGroups(2, [{ id: 'g', activeTabId: 'tab-0', tabOrder: ['tab-0', 'tab-1'], recentTabIds }])
+    ).topologyTabsById.size
+  ).toBe(2)
+})

--- a/src/main/runtime/runtime-terminal-orphan-topology-validation.test.ts
+++ b/src/main/runtime/runtime-terminal-orphan-topology-validation.test.ts
@@ -1,0 +1,71 @@
+import { expect, it } from 'vitest'
+import type { RuntimeTerminalOrphanAdoptionRequest } from '../../shared/runtime-types'
+import { validateRuntimeTerminalOrphanTopology } from './runtime-terminal-orphan-topology-validation'
+
+function fixture(count: number): RuntimeTerminalOrphanAdoptionRequest {
+  const ids = Array.from({ length: count }, (_, index) => `tab-${index}`)
+  return {
+    worktree: 'folder-workspace',
+    expectedTopologyRevision: 1,
+    claims: ids.map((tabId) => ({
+      tabId,
+      leafId: tabId,
+      terminal: tabId,
+      ptyId: tabId,
+      incarnationId: tabId
+    })) as RuntimeTerminalOrphanAdoptionRequest['claims'],
+    topology: {
+      tabs: ids.map((tabId) => ({
+        tabId,
+        root: { type: 'leaf', leafId: tabId },
+        activeLeafId: tabId,
+        expandedLeafId: null
+      })),
+      groups: [{ id: 'g', activeTabId: ids[0], tabOrder: ids, recentTabIds: ids.toReversed() }]
+    }
+  }
+}
+
+it('validates large restored MRU lists with linear tab-order reads', () => {
+  const request = fixture(1000)
+  let reads = 0
+  const group = request.topology!.groups[0]
+  group.tabOrder = new Proxy(group.tabOrder, {
+    get(target, key, receiver) {
+      if (typeof key === 'string' && /^\d+$/.test(key)) {
+        reads += 1
+      }
+      return Reflect.get(target, key, receiver)
+    }
+  })
+  expect(
+    validateRuntimeTerminalOrphanTopology(
+      request,
+      request.claims.map((claim) => ({ claim }))
+    ).topologyTabsById.size
+  ).toBe(1000)
+  expect(reads).toBeLessThanOrEqual(3000)
+})
+
+it.each(['duplicate', 'foreign-recent', 'foreign-active'])(
+  'rejects %s group membership',
+  (kind) => {
+    const request = fixture(2)
+    const group = request.topology!.groups[0]
+    if (kind === 'duplicate') {
+      group.tabOrder.push(group.tabOrder[0])
+    }
+    if (kind === 'foreign-recent') {
+      group.recentTabIds = ['foreign']
+    }
+    if (kind === 'foreign-active') {
+      group.activeTabId = 'foreign'
+    }
+    expect(() =>
+      validateRuntimeTerminalOrphanTopology(
+        request,
+        request.claims.map((claim) => ({ claim }))
+      )
+    ).toThrow('terminal_orphan_topology_invalid')
+  }
+)

--- a/src/main/runtime/runtime-terminal-orphan-topology-validation.ts
+++ b/src/main/runtime/runtime-terminal-orphan-topology-validation.ts
@@ -54,7 +54,8 @@ export function validateRuntimeTerminalOrphanTopology(
   const seenGroupIds = new Set<string>()
   const groupedTabIds = new Set<string>()
   for (const group of topologyGroups) {
-    if (seenGroupIds.has(group.id) || !group.tabOrder.includes(group.activeTabId)) {
+    const groupTabIds = new Set(group.tabOrder)
+    if (seenGroupIds.has(group.id) || !groupTabIds.has(group.activeTabId)) {
       throw new Error('terminal_orphan_topology_invalid')
     }
     seenGroupIds.add(group.id)
@@ -64,7 +65,7 @@ export function validateRuntimeTerminalOrphanTopology(
       }
       groupedTabIds.add(tabId)
     }
-    if (group.recentTabIds?.some((tabId) => !group.tabOrder.includes(tabId))) {
+    if (group.recentTabIds?.some((tabId) => !groupTabIds.has(tabId))) {
       throw new Error('terminal_orphan_topology_invalid')
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

When a terminal loses its window — an app restart, a crash, an SSH reconnect — Orca can re-attach the still-running process to a fresh tab instead of abandoning your agent mid-run. Before it does that, it checks the whole proposed tab layout for sanity. If anything looks off it refuses outright, because guessing here either abandons a live agent or wires your terminal into somebody else's pane.

Two of those checks ask "is this tab actually in this group's tab list?" — once for the group's active tab, and once for every entry in the group's recently-used list. Each question was answered by walking the whole tab list from the beginning. With 1,000 restored tabs that is about half a million comparisons before a single terminal is re-attached, right at app startup when everything else is also loading.

Now Orca puts the group's tab list into a lookup set once and asks the set. Same question, same answer, ~500,000 comparisons down to about 3,000 reads.

Nothing about *when* Orca re-attaches changes. Set membership and list membership give the identical answer for the plain text IDs involved, and every other guard is untouched: exact process, handle and incarnation matching; refusal when two owners compete for one terminal; refusal when the surface is already taken. It still fails closed — anything unexplained aborts adoption instead of picking a pane.

Review changes on top of the original: added tests pinning the rules the original scan enforced but nothing verified — an empty tab list, a tab claimed by two groups at once, a duplicated group ID, a claimed tab no group lists, an omitted or empty recently-used list, and both valid ways two tabs can be split across groups. The two-groups-one-tab test was checked against a deliberately broken build: swapping the global "no tab in two groups" rule for the new per-group set makes it fail, which is exactly the cross-wiring it exists to prevent.


## What Changed / Why

- 1,000 restored tabs: 501,501 tab-order reads → at most 3,000; duplicate, foreign-recent and foreign-active groups rejected

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 4 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/runtime/runtime-terminal-orphan-topology-validation.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

