### PR TITLE
perf: lazily index case-insensitive Windows environment keys

### DIFF
--- a/src/shared/windows-environment-expansion.test.ts
+++ b/src/shared/windows-environment-expansion.test.ts
@@ -4,6 +4,33 @@ import {
   expandWindowsPathEnvironmentVariables
 } from './windows-environment-expansion'
 
+/** The per-miss `Object.keys().find()` form the lazy index replaced; the differential oracle. */
+function referenceExpand(value: string, env: Readonly<Record<string, string | undefined>>): string {
+  return value.replace(/%([^%]+)%/g, (match, name: string) => {
+    const exactValue = env[name]
+    if (typeof exactValue === 'string') {
+      return exactValue
+    }
+    const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name.toLowerCase())
+    const fallback = key ? env[key] : undefined
+    return typeof fallback === 'string' ? fallback : match
+  })
+}
+
+function countingEnv(source: Record<string, string | undefined>): {
+  env: Record<string, string | undefined>
+  enumerations: () => number
+} {
+  let enumerations = 0
+  const env = new Proxy(source, {
+    ownKeys(target) {
+      enumerations += 1
+      return Reflect.ownKeys(target)
+    }
+  })
+  return { env, enumerations: () => enumerations }
+}
+
 describe('expandWindowsEnvironmentVariables', () => {
   it('expands names case-insensitively and preserves unknown variables', () => {
     expect(
@@ -17,6 +44,59 @@ describe('expandWindowsEnvironmentVariables', () => {
     expect(expandWindowsEnvironmentVariables('before%EMPTY%after', { EMPTY: '' })).toBe(
       'beforeafter'
     )
+  })
+
+  it('enumerates fallback keys once for a PATH containing repeated mixed-case variables', () => {
+    const { env, enumerations } = countingEnv({ ROOT: 'C:\\root', OTHER: 'unused' })
+    const value = Array.from({ length: 1000 }, () => '%root%').join(';')
+    expect(expandWindowsEnvironmentVariables(value, env)).toBe(
+      Array(1000).fill('C:\\root').join(';')
+    )
+    expect(enumerations()).toBe(1)
+  })
+
+  it('never enumerates when every name resolves by exact case', () => {
+    const { env, enumerations } = countingEnv({ ROOT: 'C:\\root', EMPTY: '' })
+    expect(expandWindowsEnvironmentVariables('%ROOT%;%EMPTY%;plain', env)).toBe('C:\\root;;plain')
+    expect(enumerations()).toBe(0)
+  })
+
+  it('preserves exact casing authority and first fallback keys including undefined values', () => {
+    const env = { Root: undefined, ROOT: 'upper', root: 'lower' }
+    expect(expandWindowsEnvironmentVariables('%ROOT%:%root%:%rOoT%', env)).toBe(
+      'upper:lower:%rOoT%'
+    )
+  })
+
+  // Why: the fallback index keeps the first insertion-order key per lowercase name, so a later
+  // duplicate casing never wins even when the first one is the shadowed value.
+  it('resolves an inexact name to the first case variant, not the last', () => {
+    const env = { Path: 'first', PATH: 'second', pAtH: 'third' }
+    expect(expandWindowsEnvironmentVariables('%PaTh%', env)).toBe('first')
+  })
+
+  it('does not resolve names from the prototype chain', () => {
+    for (const name of ['__proto__', 'constructor', 'toString', 'hasOwnProperty']) {
+      expect(expandWindowsEnvironmentVariables(`%${name}%`, { ROOT: 'x' })).toBe(`%${name}%`)
+    }
+  })
+
+  it('matches the per-miss lookup oracle across randomized mixed-case environments', () => {
+    const names = ['PATH', 'Path', 'path', 'pAtH', 'ROOT', 'root', 'Temp', 'TEMP', 'MISSING']
+    const values = ['a', '', 'C:\\x', undefined]
+    let seed = 0x9e3779b9
+    const next = (): number => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff
+    for (let index = 0; index < 4000; index += 1) {
+      const env: Record<string, string | undefined> = {}
+      for (let entry = 0; entry < Math.floor(next() * 5); entry += 1) {
+        env[names[Math.floor(next() * names.length)]!] = values[Math.floor(next() * values.length)]
+      }
+      const value = Array.from(
+        { length: Math.floor(next() * 6) },
+        () => `%${names[Math.floor(next() * names.length)]}%`
+      ).join(';')
+      expect(expandWindowsEnvironmentVariables(value, env)).toBe(referenceExpand(value, env))
+    }
   })
 })
 
@@ -43,25 +123,4 @@ describe('expandWindowsPathEnvironmentVariables', () => {
 
     expect(env.PATH).toBe('%ROOT%/bin:/usr/bin')
   })
-})
-
-it('enumerates fallback keys once for a PATH containing repeated mixed-case variables', () => {
-  let enumerations = 0
-  const env = new Proxy(
-    { ROOT: 'C:\\root', OTHER: 'unused' },
-    {
-      ownKeys(target) {
-        enumerations += 1
-        return Reflect.ownKeys(target)
-      }
-    }
-  )
-  const value = Array.from({ length: 1000 }, () => '%root%').join(';')
-  expect(expandWindowsEnvironmentVariables(value, env)).toBe(Array(1000).fill('C:\\root').join(';'))
-  expect(enumerations).toBe(1)
-})
-
-it('preserves exact casing authority and first fallback keys including undefined values', () => {
-  const env = { Root: undefined, ROOT: 'upper', root: 'lower' }
-  expect(expandWindowsEnvironmentVariables('%ROOT%:%root%:%rOoT%', env)).toBe('upper:lower:%rOoT%')
 })

--- a/src/shared/windows-environment-expansion.test.ts
+++ b/src/shared/windows-environment-expansion.test.ts
@@ -44,3 +44,24 @@ describe('expandWindowsPathEnvironmentVariables', () => {
     expect(env.PATH).toBe('%ROOT%/bin:/usr/bin')
   })
 })
+
+it('enumerates fallback keys once for a PATH containing repeated mixed-case variables', () => {
+  let enumerations = 0
+  const env = new Proxy(
+    { ROOT: 'C:\\root', OTHER: 'unused' },
+    {
+      ownKeys(target) {
+        enumerations += 1
+        return Reflect.ownKeys(target)
+      }
+    }
+  )
+  const value = Array.from({ length: 1000 }, () => '%root%').join(';')
+  expect(expandWindowsEnvironmentVariables(value, env)).toBe(Array(1000).fill('C:\\root').join(';'))
+  expect(enumerations).toBe(1)
+})
+
+it('preserves exact casing authority and first fallback keys including undefined values', () => {
+  const env = { Root: undefined, ROOT: 'upper', root: 'lower' }
+  expect(expandWindowsEnvironmentVariables('%ROOT%:%root%:%rOoT%', env)).toBe('upper:lower:%rOoT%')
+})

--- a/src/shared/windows-environment-expansion.ts
+++ b/src/shared/windows-environment-expansion.ts
@@ -1,22 +1,25 @@
-function getEnvironmentVariable(
-  env: Readonly<Record<string, string | undefined>>,
-  name: string
-): string | undefined {
-  const exactValue = env[name]
-  if (typeof exactValue === 'string') {
-    return exactValue
-  }
-  const key = Object.keys(env).find((candidate) => candidate.toLowerCase() === name.toLowerCase())
-  const value = key ? env[key] : undefined
-  return typeof value === 'string' ? value : undefined
-}
-
 export function expandWindowsEnvironmentVariables(
   value: string,
   env: Readonly<Record<string, string | undefined>>
 ): string {
+  let keysByLowerName: Map<string, string> | undefined
   return value.replace(/%([^%]+)%/g, (match, name: string) => {
-    return getEnvironmentVariable(env, name) ?? match
+    const exact = env[name]
+    if (typeof exact === 'string') {
+      return exact
+    }
+    if (!keysByLowerName) {
+      keysByLowerName = new Map()
+      for (const key of Object.keys(env)) {
+        const lower = key.toLowerCase()
+        if (!keysByLowerName.has(lower)) {
+          keysByLowerName.set(lower, key)
+        }
+      }
+    }
+    const key = keysByLowerName.get(name.toLowerCase())
+    const replacement = key ? env[key] : undefined
+    return typeof replacement === 'string' ? replacement : match
   })
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

On Windows, a `PATH` can contain placeholders like `%LOCALAPPDATA%in`, and Orca fills those in before launching a terminal. Windows treats variable names as case-insensitive, so `%localappdata%` has to find `LOCALAPPDATA` too.

Orca first tries the name exactly as written. If that misses, it has to fall back to a case-insensitive search. The old code re-scanned the entire environment from scratch for every placeholder it could not match exactly — so a `PATH` with a thousand mixed-case placeholders scanned the whole environment a thousand times.

Now the first miss builds a small lookup table once and every later miss reuses it. If nothing misses — the common case, because real Windows environments already match on the first try — the table is never built at all, so nothing got slower.

The answers are unchanged. An exactly matching name still wins over any case-insensitive one; when several entries differ only in capitalisation the same one is still chosen (the first one, exactly as before); a name whose value is unset still leaves the `%PLACEHOLDER%` text in place rather than blanking it; and unknown names are still left alone. This is verified against the old lookup on 4,000 randomised mixed-case environments plus explicit `Path`/`PATH`/`pAtH` and unset-value cases.

## What Changed / Why

- 1,000 mixed-case PATH substitutions: 1,000 environment enumerations → 1; exact-case precedence, undefined-first fallback, unknowns and non-Windows behavior retained

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 6 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/shared/windows-environment-expansion.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

