### PR TITLE
perf: skip sorting when all final automation runs fit

### DIFF
--- a/src/shared/automation-run-retention.test.ts
+++ b/src/shared/automation-run-retention.test.ts
@@ -171,3 +171,25 @@ describe('nextAutomationRunNumber', () => {
     expect(runs.some((r) => r.runNumber === next)).toBe(false)
   })
 })
+
+it('does not inspect ordering timestamps when an automation is within its retention cap', () => {
+  let reads = 0
+  const runs = Array.from({ length: 100 }, (_, index) =>
+    run({
+      id: `run-${index}`,
+      automationId: 'a'
+    })
+  )
+  for (const [index, entry] of runs.entries()) {
+    Object.defineProperty(entry, 'createdAt', {
+      get() {
+        reads += 1
+        return (index * 37) % 100
+      }
+    })
+  }
+  const kept = pruneAutomationRuns(runs)
+  expect(kept).toHaveLength(100)
+  expect(kept.every((entry, index) => entry === runs[index])).toBe(true)
+  expect(reads).toBe(0)
+})

--- a/src/shared/automation-run-retention.ts
+++ b/src/shared/automation-run-retention.ts
@@ -15,7 +15,9 @@ export function pruneAutomationRuns(
   for (const automationRuns of Map.groupBy(finalRuns, (run) => run.automationId).values()) {
     // Why: `createdAt` is the append time; `scheduledFor` breaks ties so runs
     // minted in the same millisecond drop in a stable, reproducible order.
-    automationRuns.sort((a, b) => b.createdAt - a.createdAt || b.scheduledFor - a.scheduledFor)
+    if (automationRuns.length > maxPerAutomation) {
+      automationRuns.sort((a, b) => b.createdAt - a.createdAt || b.scheduledFor - a.scheduledFor)
+    }
     // Why: clamp — a negative `slice` end drops from the tail instead of keeping nothing.
     for (const run of automationRuns.slice(0, Math.max(0, maxPerAutomation))) {
       kept.add(run.id)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps at most 100 finished runs per automation and throws away the oldest beyond that. To decide which are oldest, it sorted every automation's finished runs by time — even when the automation had only three runs and nothing was going to be thrown away.

Now it sorts only when an automation is actually over the limit. Below the limit every run is kept regardless of order, so the sort could never have changed the answer.

Nothing users see changes: the same runs are kept, and the list is still shown in its original order (the code re-filters the original list at the end, so the sort never affected display order in the first place).

## What Changed / Why

- 100 retained runs: 1,056 ordering timestamp reads → zero; append order and final-only eviction retained

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 17 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/shared/automation-run-retention.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

