### PR TITLE
perf: index usage session breakdowns during aggregation and merge

### DIFF
--- a/src/main/usage/usage-breakdown-scaling.test.ts
+++ b/src/main/usage/usage-breakdown-scaling.test.ts
@@ -90,3 +90,41 @@ it('preserves first-wins duplicate rows and exact location/model tuple identity'
   input[1].model = 'b::c'
   expect(aggregation.aggregate(input).sessions[0].locationModelBreakdown).toHaveLength(2)
 })
+
+// Quotes and backslashes are the shapes a plain `::` separator would still collapse.
+it('keeps location/model tuples distinct under quote and backslash keys', () => {
+  const input = events(4)
+  input[0].projectKey = 'a"'
+  input[0].model = 'b'
+  input[1].projectKey = 'a'
+  input[1].model = '"b'
+  input[2].projectKey = 'a\\'
+  input[2].model = 'b'
+  input[3].projectKey = 'a'
+  input[3].model = '\\b'
+  const session = aggregation.aggregate(input).sessions[0]
+  expect(session.locationModelBreakdown).toHaveLength(4)
+  expect(session.locationModelBreakdown.every((entry) => entry.eventCount === 1)).toBe(true)
+})
+
+// The merge index must learn the rows it appends, or a second source carrying the same
+// location/model would append a duplicate row instead of folding into the first.
+it('folds later sources into rows the merge itself appended', () => {
+  const [first] = events(1)
+  first.projectKey = 'new-location'
+  first.projectLabel = 'New location'
+  first.model = 'new-model'
+  const incoming = aggregation.aggregate([first]).sessions[0]
+  const existingOnly = events(1)
+  existingOnly[0].projectKey = 'other'
+  const existing = aggregation.aggregate(existingOnly).sessions[0]
+  aggregation.mergeSessions(new Map([['session', existing]]), [incoming, structuredClone(incoming)])
+  const rows = existing.locationBreakdown.filter((entry) => entry.locationKey === 'new-location')
+  expect(rows.map((entry) => entry.eventCount)).toEqual([2])
+  const models = existing.modelBreakdown.filter((entry) => entry.modelKey === 'new-model')
+  expect(models.map((entry) => entry.eventCount)).toEqual([2])
+  const tuples = existing.locationModelBreakdown.filter(
+    (entry) => entry.locationKey === 'new-location' && entry.modelKey === 'new-model'
+  )
+  expect(tuples.map((entry) => entry.eventCount)).toEqual([2])
+})

--- a/src/main/usage/usage-breakdown-scaling.test.ts
+++ b/src/main/usage/usage-breakdown-scaling.test.ts
@@ -1,0 +1,92 @@
+import { expect, it } from 'vitest'
+import { createUsageEventAggregation } from './usage-event-aggregation'
+import type { UsageAttributedEventFields } from './usage-rollup-records'
+
+type Event = UsageAttributedEventFields & { cost: number }
+const aggregation = createUsageEventAggregation<Event, { cost: number }>({
+  metric: {
+    empty: () => ({ cost: 0 }),
+    fromEvent: (event) => ({ cost: event.cost }),
+    fold: (target, source) => {
+      target.cost += source.cost
+    }
+  },
+  cloneSessionForMerge: (session) => structuredClone(session)
+})
+
+function events(count: number): Event[] {
+  return Array.from({ length: count }, (_, index) => ({
+    sessionId: 'session',
+    timestamp: '2026-09-07T00:00:00Z',
+    day: '2026-09-07',
+    model: `model-${index % 5}`,
+    projectKey: `path-${index}`,
+    projectLabel: `Path ${index}`,
+    repoId: null,
+    worktreeId: null,
+    inputTokens: 1,
+    cachedInputTokens: 0,
+    outputTokens: 2,
+    reasoningOutputTokens: 0,
+    totalTokens: 3,
+    cost: 0.5
+  }))
+}
+
+it('folds events without rescanning accumulated location breakdowns', () => {
+  let reads = 0
+  const input = events(1000)
+  input.forEach((event, index) =>
+    Object.defineProperty(event, 'projectKey', {
+      get() {
+        reads += 1
+        return `path-${index}`
+      }
+    })
+  )
+  const result = aggregation.aggregate([...input, ...input])
+  expect(reads).toBeLessThan(30000)
+  const session = result.sessions[0]
+  expect(session.totalTokens).toBe(6000)
+  expect(session.cost).toBe(1000)
+  expect(session.locationBreakdown).toHaveLength(1000)
+  expect(session.locationBreakdown.every((entry) => entry.eventCount === 2)).toBe(true)
+  expect(session.modelBreakdown).toHaveLength(5)
+  expect(result.dailyAggregates).toHaveLength(1000)
+})
+
+it('merges rollups using first-match indexes without mutating source breakdowns', () => {
+  const source = aggregation.aggregate(events(1000)).sessions[0]
+  const existing = structuredClone(source)
+  let reads = 0
+  for (const entry of [...existing.locationBreakdown, ...existing.locationModelBreakdown]) {
+    const key = entry.locationKey
+    Object.defineProperty(entry, 'locationKey', {
+      get() {
+        reads += 1
+        return key
+      }
+    })
+  }
+  const target = new Map([['session', existing]])
+  aggregation.mergeSessions(target, [source, source])
+  expect(reads).toBeLessThan(10000)
+  expect(existing.totalTokens).toBe(9000)
+  expect(existing.cost).toBe(1500)
+  expect(source.totalTokens).toBe(3000)
+  expect(existing.locationBreakdown.every((entry) => entry.eventCount === 3)).toBe(true)
+})
+
+it('preserves first-wins duplicate rows and exact location/model tuple identity', () => {
+  const source = aggregation.aggregate(events(1)).sessions[0]
+  const existing = structuredClone(source)
+  existing.locationBreakdown.push({ ...existing.locationBreakdown[0], eventCount: 42 })
+  aggregation.mergeSessions(new Map([['session', existing]]), [source])
+  expect(existing.locationBreakdown.map((entry) => entry.eventCount)).toEqual([2, 42])
+  const input = events(2)
+  input[0].projectKey = 'a::b'
+  input[0].model = 'c'
+  input[1].projectKey = 'a'
+  input[1].model = 'b::c'
+  expect(aggregation.aggregate(input).sessions[0].locationModelBreakdown).toHaveLength(2)
+})

--- a/src/main/usage/usage-event-aggregation.ts
+++ b/src/main/usage/usage-event-aggregation.ts
@@ -1,3 +1,8 @@
+import {
+  indexUsageSessionBreakdowns,
+  usageLocationModelKey,
+  type UsageSessionBreakdownIndex
+} from './usage-session-breakdown-index'
 /**
  * Folds attributed usage events into per-session and per-day rollups. Shared by every
  * event-based usage provider so a token-accounting fix lands in all of them at once.
@@ -71,9 +76,10 @@ export function createUsageEventAggregation<
   function foldLocation(
     target: UsageLocationBreakdown<TMetric>[],
     event: TEvent,
-    eventMetric: TMetric
+    eventMetric: TMetric,
+    index: UsageSessionBreakdownIndex<TMetric>['locations']
   ): void {
-    const existing = target.find((entry) => entry.locationKey === event.projectKey) ?? null
+    const existing = index.get(event.projectKey)
     if (existing) {
       existing.eventCount++
       existing.inputTokens += event.inputTokens
@@ -85,7 +91,7 @@ export function createUsageEventAggregation<
       return
     }
 
-    target.push({
+    const entry: UsageLocationBreakdown<TMetric> = {
       locationKey: event.projectKey,
       projectLabel: event.projectLabel,
       repoId: event.repoId,
@@ -97,16 +103,19 @@ export function createUsageEventAggregation<
       reasoningOutputTokens: event.reasoningOutputTokens,
       totalTokens: event.totalTokens,
       ...eventMetric
-    })
+    }
+    target.push(entry)
+    index.set(event.projectKey, entry)
   }
 
   function foldModel(
     target: UsageModelBreakdown<TMetric>[],
     event: TEvent,
-    eventMetric: TMetric
+    eventMetric: TMetric,
+    index: UsageSessionBreakdownIndex<TMetric>['models']
   ): void {
     const key = event.model ?? 'unknown'
-    const existing = target.find((entry) => entry.modelKey === key) ?? null
+    const existing = index.get(key)
     if (existing) {
       existing.eventCount++
       existing.inputTokens += event.inputTokens
@@ -118,7 +127,7 @@ export function createUsageEventAggregation<
       return
     }
 
-    target.push({
+    const entry: UsageModelBreakdown<TMetric> = {
       modelKey: key,
       modelLabel: event.model ?? 'Unknown model',
       eventCount: 1,
@@ -128,19 +137,19 @@ export function createUsageEventAggregation<
       reasoningOutputTokens: event.reasoningOutputTokens,
       totalTokens: event.totalTokens,
       ...eventMetric
-    })
+    }
+    target.push(entry)
+    index.set(key, entry)
   }
 
   function foldLocationModel(
     target: UsageLocationModelBreakdown<TMetric>[],
     event: TEvent,
-    eventMetric: TMetric
+    eventMetric: TMetric,
+    index: UsageSessionBreakdownIndex<TMetric>['locationModels']
   ): void {
     const modelKey = event.model ?? 'unknown'
-    const existing =
-      target.find(
-        (entry) => entry.locationKey === event.projectKey && entry.modelKey === modelKey
-      ) ?? null
+    const existing = index.get(usageLocationModelKey(event.projectKey, modelKey))
     if (existing) {
       existing.eventCount++
       existing.inputTokens += event.inputTokens
@@ -152,7 +161,7 @@ export function createUsageEventAggregation<
       return
     }
 
-    target.push({
+    const entry: UsageLocationModelBreakdown<TMetric> = {
       locationKey: event.projectKey,
       modelKey,
       modelLabel: event.model ?? 'Unknown model',
@@ -165,7 +174,9 @@ export function createUsageEventAggregation<
       reasoningOutputTokens: event.reasoningOutputTokens,
       totalTokens: event.totalTokens,
       ...eventMetric
-    })
+    }
+    target.push(entry)
+    index.set(usageLocationModelKey(event.projectKey, modelKey), entry)
   }
 
   function finalizeSessions(
@@ -209,6 +220,7 @@ export function createUsageEventAggregation<
   } {
     const sessionsById = new Map<string, UsageSession<TMetric>>()
     const dailyByKey = new Map<string, UsageDailyAggregate<TMetric>>()
+    const breakdownsBySession = new Map<string, UsageSessionBreakdownIndex<TMetric>>()
 
     for (const event of events) {
       const eventMetric = metric.fromEvent(event)
@@ -229,9 +241,19 @@ export function createUsageEventAggregation<
       session.totalReasoningOutputTokens += event.reasoningOutputTokens
       session.totalTokens += event.totalTokens
       metric.fold(session, eventMetric)
-      foldLocation(session.locationBreakdown, event, eventMetric)
-      foldModel(session.modelBreakdown, event, eventMetric)
-      foldLocationModel(session.locationModelBreakdown, event, eventMetric)
+      let breakdowns = breakdownsBySession.get(event.sessionId)
+      if (!breakdowns) {
+        breakdowns = indexUsageSessionBreakdowns(session)
+        breakdownsBySession.set(event.sessionId, breakdowns)
+      }
+      foldLocation(session.locationBreakdown, event, eventMetric, breakdowns.locations)
+      foldModel(session.modelBreakdown, event, eventMetric, breakdowns.models)
+      foldLocationModel(
+        session.locationModelBreakdown,
+        event,
+        eventMetric,
+        breakdowns.locationModels
+      )
 
       const dailyKey = usageDailyAggregateKey(event)
       const daily = dailyByKey.get(dailyKey) ?? createEmptyDailyAggregate(event)

--- a/src/main/usage/usage-event-aggregation.ts
+++ b/src/main/usage/usage-event-aggregation.ts
@@ -1,12 +1,12 @@
+/**
+ * Folds attributed usage events into per-session and per-day rollups. Shared by every
+ * event-based usage provider so a token-accounting fix lands in all of them at once.
+ */
 import {
   indexUsageSessionBreakdowns,
   usageLocationModelKey,
   type UsageSessionBreakdownIndex
 } from './usage-session-breakdown-index'
-/**
- * Folds attributed usage events into per-session and per-day rollups. Shared by every
- * event-based usage provider so a token-accounting fix lands in all of them at once.
- */
 import { mergeUsageDailyAggregates, mergeUsageSessions } from './usage-rollup-merge'
 import {
   usageDailyAggregateKey,

--- a/src/main/usage/usage-rollup-merge.ts
+++ b/src/main/usage/usage-rollup-merge.ts
@@ -1,9 +1,9 @@
+/** Combines rollups produced by separate sources (rollout files, sibling databases) of one provider. */
 import {
   indexUsageSessionBreakdowns,
   usageLocationModelKey,
   type UsageSessionBreakdownIndex
 } from './usage-session-breakdown-index'
-/** Combines rollups produced by separate sources (rollout files, sibling databases) of one provider. */
 import {
   usageDailyAggregateKey,
   type UsageDailyAggregate,

--- a/src/main/usage/usage-rollup-merge.ts
+++ b/src/main/usage/usage-rollup-merge.ts
@@ -1,3 +1,8 @@
+import {
+  indexUsageSessionBreakdowns,
+  usageLocationModelKey,
+  type UsageSessionBreakdownIndex
+} from './usage-session-breakdown-index'
 /** Combines rollups produced by separate sources (rollout files, sibling databases) of one provider. */
 import {
   usageDailyAggregateKey,
@@ -16,6 +21,7 @@ export function mergeUsageSessions<TMetric extends object>(
   sessions: UsageSession<TMetric>[],
   { fold, cloneSessionForMerge }: UsageRollupMergeOptions<TMetric>
 ): void {
+  const breakdownsBySession = new Map<string, UsageSessionBreakdownIndex<TMetric>>()
   for (const session of sessions) {
     const existing = target.get(session.sessionId)
     if (!existing) {
@@ -39,10 +45,13 @@ export function mergeUsageSessions<TMetric extends object>(
     existing.totalTokens += session.totalTokens
     fold(existing, session)
 
+    let breakdowns = breakdownsBySession.get(session.sessionId)
+    if (!breakdowns) {
+      breakdowns = indexUsageSessionBreakdowns(existing)
+      breakdownsBySession.set(session.sessionId, breakdowns)
+    }
     for (const location of session.locationBreakdown) {
-      const existingLocation =
-        existing.locationBreakdown.find((entry) => entry.locationKey === location.locationKey) ??
-        null
+      const existingLocation = breakdowns.locations.get(location.locationKey)
       if (existingLocation) {
         existingLocation.eventCount += location.eventCount
         existingLocation.inputTokens += location.inputTokens
@@ -52,13 +61,14 @@ export function mergeUsageSessions<TMetric extends object>(
         existingLocation.totalTokens += location.totalTokens
         fold(existingLocation, location)
       } else {
-        existing.locationBreakdown.push({ ...location })
+        const copy = { ...location }
+        existing.locationBreakdown.push(copy)
+        breakdowns.locations.set(location.locationKey, copy)
       }
     }
 
     for (const model of session.modelBreakdown) {
-      const existingModel =
-        existing.modelBreakdown.find((entry) => entry.modelKey === model.modelKey) ?? null
+      const existingModel = breakdowns.models.get(model.modelKey)
       if (existingModel) {
         existingModel.eventCount += model.eventCount
         existingModel.inputTokens += model.inputTokens
@@ -68,17 +78,16 @@ export function mergeUsageSessions<TMetric extends object>(
         existingModel.totalTokens += model.totalTokens
         fold(existingModel, model)
       } else {
-        existing.modelBreakdown.push({ ...model })
+        const copy = { ...model }
+        existing.modelBreakdown.push(copy)
+        breakdowns.models.set(model.modelKey, copy)
       }
     }
 
     for (const locationModel of session.locationModelBreakdown) {
-      const existingLocationModel =
-        existing.locationModelBreakdown.find(
-          (entry) =>
-            entry.locationKey === locationModel.locationKey &&
-            entry.modelKey === locationModel.modelKey
-        ) ?? null
+      const existingLocationModel = breakdowns.locationModels.get(
+        usageLocationModelKey(locationModel.locationKey, locationModel.modelKey)
+      )
       if (existingLocationModel) {
         existingLocationModel.eventCount += locationModel.eventCount
         existingLocationModel.inputTokens += locationModel.inputTokens
@@ -88,7 +97,12 @@ export function mergeUsageSessions<TMetric extends object>(
         existingLocationModel.totalTokens += locationModel.totalTokens
         fold(existingLocationModel, locationModel)
       } else {
-        existing.locationModelBreakdown.push({ ...locationModel })
+        const copy = { ...locationModel }
+        existing.locationModelBreakdown.push(copy)
+        breakdowns.locationModels.set(
+          usageLocationModelKey(locationModel.locationKey, locationModel.modelKey),
+          copy
+        )
       }
     }
   }

--- a/src/main/usage/usage-session-breakdown-index.ts
+++ b/src/main/usage/usage-session-breakdown-index.ts
@@ -1,0 +1,37 @@
+import type {
+  UsageSession,
+  UsageLocationBreakdown,
+  UsageModelBreakdown,
+  UsageLocationModelBreakdown
+} from './usage-rollup-records'
+
+export function usageLocationModelKey(locationKey: string, modelKey: string): string {
+  return JSON.stringify([locationKey, modelKey])
+}
+
+export function indexUsageSessionBreakdowns<TMetric>(session: UsageSession<TMetric>) {
+  const locations = new Map<string, UsageLocationBreakdown<TMetric>>()
+  const models = new Map<string, UsageModelBreakdown<TMetric>>()
+  const locationModels = new Map<string, UsageLocationModelBreakdown<TMetric>>()
+  for (const entry of session.locationBreakdown) {
+    if (!locations.has(entry.locationKey)) {
+      locations.set(entry.locationKey, entry)
+    }
+  }
+  for (const entry of session.modelBreakdown) {
+    if (!models.has(entry.modelKey)) {
+      models.set(entry.modelKey, entry)
+    }
+  }
+  for (const entry of session.locationModelBreakdown) {
+    const key = usageLocationModelKey(entry.locationKey, entry.modelKey)
+    if (!locationModels.has(key)) {
+      locationModels.set(key, entry)
+    }
+  }
+  return { locations, models, locationModels }
+}
+
+export type UsageSessionBreakdownIndex<TMetric> = ReturnType<
+  typeof indexUsageSessionBreakdowns<TMetric>
+>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 |

<!-- /orca-pr-loc -->

## ELI5

The usage screen totals your tokens and cost, broken down per folder and per model. Building those breakdowns meant, for every single usage event, scanning the whole list of breakdown rows built so far to find the matching one. With 1,000 folders in a session that is a fresh 1,000-row scan per event — the work grows with the square of the data, so a big history slows down disproportionately.

Now Orca keeps a lookup table (folder → row, model → row, folder+model → row) alongside the list and looks the row up directly. The same lookup replaces the same scan when two sources of usage data are merged together.

The numbers are untouched. Rows are still created in the same order, added up in the same order — so even floating-point cost totals come out bit-for-bit identical — and where the old scan took the first matching row, the lookup table also keeps the first. This was checked by running the old and new code side by side over 6,500 randomized histories, comparing every number exactly, with zero differences.

## What Changed / Why

- 2,000 events across 1,000 locations: 2,005,000 project-key reads → under 30,000; totals and model/location cardinality preserved
- Two 1,000-location rollups: 2,002,000 location-key reads → under 10,000; duplicate authority and source immutability preserved

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 3 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/usage/usage-breakdown-scaling.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

