### PR TITLE
perf: cache matched and unmatched Claude usage cwd attribution

### DIFF
--- a/src/main/claude-usage/worktree-attribution-scaling.test.ts
+++ b/src/main/claude-usage/worktree-attribution-scaling.test.ts
@@ -1,0 +1,53 @@
+import { expect, it, vi } from 'vitest'
+import { attributeClaudeUsageTurns } from './worktree-attribution'
+import type { ClaudeUsageParsedTurn } from './types'
+
+vi.mock('node:fs/promises', () => ({ realpath: async (path: string) => path }))
+
+it('resolves repeated nested and unmatched cwd paths once per attribution batch', async () => {
+  const lookup = new Map(
+    Array.from({ length: 100 }, (_, index) => [
+      `/repo-${String(index).padStart(3, '0')}`,
+      {
+        repoId: `repo-${index}`,
+        worktreeId: `wt-${index}`,
+        path: `/repo-${index}`,
+        displayName: `Repo ${index}`
+      }
+    ])
+  )
+  const input: ClaudeUsageParsedTurn[] = Array.from({ length: 1000 }, (_, index) => ({
+    sessionId: String(index),
+    timestamp: '2026-09-07T00:00:00Z',
+    model: null,
+    cwd: index % 2 === 0 ? '/repo-099/nested' : '/outside',
+    gitBranch: null,
+    inputTokens: 1,
+    outputTokens: 1,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    cacheWrite1hTokens: 0
+  }))
+  const original = String.prototype.startsWith
+  let comparisons = 0
+  const spy = vi.spyOn(String.prototype, 'startsWith').mockImplementation(function (
+    this: string,
+    search: string,
+    position?: number
+  ) {
+    if (search.slice(0, 6) === '/repo-') {
+      comparisons += 1
+    }
+    return original.call(this, search, position)
+  })
+  let result: Awaited<ReturnType<typeof attributeClaudeUsageTurns>>
+  try {
+    result = await attributeClaudeUsageTurns(input, lookup)
+  } finally {
+    spy.mockRestore()
+  }
+  expect(comparisons).toBeLessThanOrEqual(200)
+  expect(result![0].worktreeId).toBe('wt-99')
+  expect(result![1].worktreeId).toBeNull()
+  expect(result![1].projectKey).toBe('cwd:/outside')
+})

--- a/src/main/claude-usage/worktree-attribution.ts
+++ b/src/main/claude-usage/worktree-attribution.ts
@@ -105,7 +105,7 @@ export async function attributeClaudeUsageTurns(
   worktreeLookup: Map<string, ClaudeUsageWorktreeRef>
 ): Promise<ClaudeUsageAttributedTurn[]> {
   const attributed: ClaudeUsageAttributedTurn[] = []
-  const canonicalCwdByPath = new Map<string, string>()
+  const worktreeByCwd = new Map<string, ClaudeUsageWorktreeRef | null>()
 
   for (const turn of turns) {
     const day = localDayFromTimestamp(turn.timestamp)
@@ -119,14 +119,12 @@ export async function attributeClaudeUsageTurns(
     let projectLabel = getDefaultProjectLabel(turn.cwd)
 
     if (turn.cwd) {
-      let canonicalCwd = canonicalCwdByPath.get(turn.cwd)
-      if (canonicalCwd === undefined) {
-        // Why: Claude transcripts repeat the same cwd for many consecutive
-        // turns. Cache realpath work so attribution scales with unique paths.
-        canonicalCwd = await canonicalizePath(turn.cwd)
-        canonicalCwdByPath.set(turn.cwd, canonicalCwd)
+      let worktree = worktreeByCwd.get(turn.cwd)
+      if (worktree === undefined) {
+        const canonicalCwd = await canonicalizePath(turn.cwd)
+        worktree = findContainingWorktree(canonicalCwd, worktreeLookup)
+        worktreeByCwd.set(turn.cwd, worktree)
       }
-      const worktree = findContainingWorktree(canonicalCwd, worktreeLookup)
       if (worktree) {
         repoId = worktree.repoId
         worktreeId = worktree.worktreeId


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

Orca's usage screen shows how many Claude tokens you spent on each project. To build it, Orca reads your Claude transcripts and, for every single turn in the conversation, asks "which of my repos does this folder belong to?" It answered that question by walking down the whole list of repos, one at a time, for *every* turn — even though a transcript usually stays in the same folder for hundreds of turns in a row.

This change remembers the answer for each folder it has already looked up. The first turn in a folder still does the full search; every later turn with the same folder reuses the stored answer. It also remembers "this folder isn't in any of your repos", so folders outside your projects stop being re-searched too.

Nothing about the numbers changes — the same turns land in the same projects with the same labels. It's the same lookup, just not repeated. In the test case (1,000 turns across 100 repos) the folder-matching work drops from 100,000 comparisons to 200.

## What Changed / Why

- 1,000 turns/100 worktrees: 100,000 containment checks → at most 200; nested path and unscoped fallback retained

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 1 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/claude-usage/worktree-attribution-scaling.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
