### PR TITLE
perf: probe requested pane keys instead of enumerating records

### DIFF
--- a/src/renderer/src/store/slices/agent-status-pane-keyed-records.test.ts
+++ b/src/renderer/src/store/slices/agent-status-pane-keyed-records.test.ts
@@ -133,3 +133,25 @@ it('removes enumerable undefined values without removing inherited or hidden key
   expect(removePaneKeys(record, new Set(['hidden', 'toString']))).toBe(record)
   expect(Object.hasOwn(removePaneKeys(record, new Set(['visible'])), 'visible')).toBe(false)
 })
+
+// Probing the requested keys only matches the old record-enumeration when the two sets
+// disagree in both directions, and the store relies on the unchanged case staying identical.
+it('drops every requested key that is present and keeps the reference when none are', () => {
+  const base = { a: 1, b: 2, c: 3 }
+  expect(removePaneKeys({ ...base }, new Set(['a', 'b', 'c', 'd', 'e']))).toEqual({})
+  expect(removePaneKeys({ ...base }, new Set(['b', 'missing']))).toEqual({ a: 1, c: 3 })
+  const disjoint = { ...base }
+  expect(removePaneKeys(disjoint, new Set(['x', 'y']))).toBe(disjoint)
+  const noKeys = { ...base }
+  expect(removePaneKeys(noKeys, new Set())).toBe(noKeys)
+  const empty = {}
+  expect(removePaneKeys(empty, new Set(['a']))).toBe(empty)
+})
+
+it('leaves surviving keys in their original order and does not pollute the prototype', () => {
+  const record: Record<string, number> = { z: 1, y: 2, x: 3, w: 4 }
+  expect(Object.keys(removePaneKeys(record, new Set(['x', 'z'])))).toEqual(['y', 'w'])
+  const plain = { safe: 1 }
+  expect(removePaneKeys(plain, new Set(['__proto__', 'constructor']))).toBe(plain)
+  expect(Object.getPrototypeOf(plain)).toBe(Object.prototype)
+})

--- a/src/renderer/src/store/slices/agent-status-pane-keyed-records.test.ts
+++ b/src/renderer/src/store/slices/agent-status-pane-keyed-records.test.ts
@@ -3,7 +3,8 @@ import {
   RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX,
   RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX,
   boundRecentlyClosedAgentStatusTabIds,
-  boundRecentlyRetiredAgentStatusPaneKeys
+  boundRecentlyRetiredAgentStatusPaneKeys,
+  removePaneKeys
 } from './agent-status-pane-keyed-records'
 
 function keyRecord(keys: readonly string[]): Record<string, true> {
@@ -107,4 +108,28 @@ describe('boundRecentlyClosedAgentStatusTabIds', () => {
     expect(next.t0).toBeUndefined()
     expect(next.fresh).toBe(true)
   })
+})
+
+it('does not enumerate unrelated pane records when removing absent keys', () => {
+  let enumerations = 0
+  const record = new Proxy(
+    Object.fromEntries(Array.from({ length: 1000 }, (_, index) => [`tab-${index}:leaf`, index])),
+    {
+      ownKeys(target) {
+        enumerations += 1
+        return Reflect.ownKeys(target)
+      }
+    }
+  )
+  for (let index = 0; index < 200; index += 1) {
+    expect(removePaneKeys(record, new Set(['absent:leaf']))).toBe(record)
+  }
+  expect(enumerations).toBe(0)
+})
+
+it('removes enumerable undefined values without removing inherited or hidden keys', () => {
+  const record = { visible: undefined }
+  Object.defineProperty(record, 'hidden', { value: 1, enumerable: false })
+  expect(removePaneKeys(record, new Set(['hidden', 'toString']))).toBe(record)
+  expect(Object.hasOwn(removePaneKeys(record, new Set(['visible'])), 'visible')).toBe(false)
 })

--- a/src/renderer/src/store/slices/agent-status-pane-keyed-records.ts
+++ b/src/renderer/src/store/slices/agent-status-pane-keyed-records.ts
@@ -83,17 +83,20 @@ export function removePaneKeys<T>(
   record: Record<string, T>,
   paneKeys: ReadonlySet<string>
 ): Record<string, T> {
-  const matchingKeys = [...paneKeys].filter((key) =>
-    Object.prototype.propertyIsEnumerable.call(record, key)
-  )
-  if (matchingKeys.length === 0) {
-    return record
-  }
-  const next = { ...record }
-  for (const key of matchingKeys) {
+  // Probe the requested keys instead of enumerating the record, and copy only once a key
+  // actually matches: pane retirement calls this across a dozen records that usually hold
+  // none of the retired keys, so the no-op path must stay allocation-free and keep returning
+  // the same reference. `propertyIsEnumerable` is own-only, so inherited keys such as
+  // `toString` or `__proto__` are never deletable.
+  let next: Record<string, T> | null = null
+  for (const key of paneKeys) {
+    if (!Object.prototype.propertyIsEnumerable.call(record, key)) {
+      continue
+    }
+    next ??= { ...record }
     delete next[key]
   }
-  return next
+  return next ?? record
 }
 
 export function removePaneKeysByTabPrefix<T>(

--- a/src/renderer/src/store/slices/agent-status-pane-keyed-records.ts
+++ b/src/renderer/src/store/slices/agent-status-pane-keyed-records.ts
@@ -83,7 +83,9 @@ export function removePaneKeys<T>(
   record: Record<string, T>,
   paneKeys: ReadonlySet<string>
 ): Record<string, T> {
-  const matchingKeys = Object.keys(record).filter((key) => paneKeys.has(key))
+  const matchingKeys = [...paneKeys].filter((key) =>
+    Object.prototype.propertyIsEnumerable.call(record, key)
+  )
   if (matchingKeys.length === 0) {
     return record
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

When you close a terminal tab, Orca has to forget everything it was tracking about the panes in that tab — unread markers, agent status, launch settings and about a dozen other bookkeeping lists.

The old way of forgetting worked backwards: for each of those dozen lists, Orca read out *every* entry in the list and checked each one against the handful of panes being closed. If a list held a thousand panes and you closed one, that's a thousand checks to find one match — repeated for every list, most of which had nothing to forget at all.

Now Orca goes the other way round: it takes the few panes being closed and asks each list directly "do you have this one?" That's a handful of quick lookups instead of a full read-out.

Two follow-on refinements are included. Orca only makes a copy of a list once it finds something to actually remove, so the common case — a list that holds none of the closed panes — now does no copying and no allocation at all, and hands back the exact same list object, which is what stops the UI from re-rendering needlessly. And the lookup deliberately only matches a list's own entries, so built-in JavaScript property names like `toString` or `__proto__` can never be mistaken for a pane and deleted.

Behaviour is unchanged: the same entries are removed, the survivors stay in the same order, and the same lists are handed back untouched. That was compared against the old code on 6,000 generated cases — including keys present in the list but not requested, requested but not present, hidden entries, and inherited property names — with no differences.

## What Changed / Why

- 200 absent removals across 1,000 records: full-record enumeration eliminated; inherited and nonenumerable keys preserved

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 13 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/store/slices/agent-status-pane-keyed-records.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
