### PR TITLE
perf: resolve current-workspace document addresses before catalog scans

### DIFF
--- a/src/renderer/src/lib/workspace-doc-address-input.test.ts
+++ b/src/renderer/src/lib/workspace-doc-address-input.test.ts
@@ -144,15 +144,51 @@ describe('resolveWorkspaceDocAddressTarget', () => {
       resolveWorkspaceDocAddressTarget(makeState(), CURRENT, '/home/alice/wt1/x.html')
     ).toEqual({ status: 'unsupported', message: 'no channel' })
   })
-})
 
-it('resolves a current-workspace address without enumerating unrelated workspace roots', () => {
-  const state = makeState()
-  state.allWorktrees = vi.fn(() => {
-    throw new Error('unnecessary global workspace enumeration')
+  it('resolves a current-workspace address without enumerating unrelated workspace roots', () => {
+    const state = makeState()
+    state.allWorktrees = vi.fn(() => {
+      throw new Error('unnecessary global workspace enumeration')
+    })
+    expect(
+      resolveWorkspaceDocAddressTarget(state, CURRENT, '/home/alice/wt1/docs/index.html').status
+    ).toBe('workspace-doc')
+    expect(state.allWorktrees).not.toHaveBeenCalled()
   })
-  expect(
-    resolveWorkspaceDocAddressTarget(state, CURRENT, '/home/alice/wt1/docs/index.html').status
-  ).toBe('workspace-doc')
-  expect(state.allWorktrees).not.toHaveBeenCalled()
+
+  // The current worktree outranks every other root, including a more specific one nested inside it.
+  it('keeps the current worktree ahead of a workspace nested inside it', () => {
+    const state = makeState()
+    const nestedInsideCurrent = {
+      ...state,
+      allWorktrees: () => [
+        ...state.allWorktrees(),
+        { id: 'repo3::/home/alice/wt1/vendor', path: '/home/alice/wt1/vendor' }
+      ]
+    } as typeof state
+
+    expect(
+      resolveWorkspaceDocAddressTarget(
+        nestedInsideCurrent,
+        CURRENT,
+        '/home/alice/wt1/vendor/index.html'
+      )
+    ).toMatchObject({ status: 'workspace-doc', docLocation: { worktreeId: CURRENT } })
+  })
+
+  it('short-circuits for a folder workspace that is the current workspace', () => {
+    const state = makeState()
+    const folderCurrent = {
+      ...state,
+      getKnownWorktreeById: (id: string) =>
+        id === 'folder:folder-1' ? { id: 'folder:folder-1', path: '/srv/site' } : undefined,
+      allWorktrees: vi.fn(() => {
+        throw new Error('unnecessary global workspace enumeration')
+      })
+    } as unknown as AppState
+
+    expect(
+      resolveWorkspaceDocAddressTarget(folderCurrent, 'folder:folder-1', '/srv/site/index.html')
+    ).toMatchObject({ status: 'workspace-doc', docLocation: { worktreeId: 'folder:folder-1' } })
+  })
 })

--- a/src/renderer/src/lib/workspace-doc-address-input.test.ts
+++ b/src/renderer/src/lib/workspace-doc-address-input.test.ts
@@ -145,3 +145,14 @@ describe('resolveWorkspaceDocAddressTarget', () => {
     ).toEqual({ status: 'unsupported', message: 'no channel' })
   })
 })
+
+it('resolves a current-workspace address without enumerating unrelated workspace roots', () => {
+  const state = makeState()
+  state.allWorktrees = vi.fn(() => {
+    throw new Error('unnecessary global workspace enumeration')
+  })
+  expect(
+    resolveWorkspaceDocAddressTarget(state, CURRENT, '/home/alice/wt1/docs/index.html').status
+  ).toBe('workspace-doc')
+  expect(state.allWorktrees).not.toHaveBeenCalled()
+})

--- a/src/renderer/src/lib/workspace-doc-address-input.ts
+++ b/src/renderer/src/lib/workspace-doc-address-input.ts
@@ -19,7 +19,6 @@ function ownedWorktreeRoots(
   currentWorktreeId: string
 ): { worktreeId: string; root: string }[] {
   const roots: { worktreeId: string; root: string }[] = []
-  const currentPath = state.getKnownWorktreeById(currentWorktreeId)?.path ?? null
   for (const worktree of state.allWorktrees()) {
     if (worktree.id !== currentWorktreeId && worktree.path) {
       roots.push({ worktreeId: worktree.id, root: worktree.path })
@@ -34,7 +33,7 @@ function ownedWorktreeRoots(
   // Most-specific root first (after the current worktree), so a file inside a nested workspace is
   // attributed to that workspace and not to the outer one that lexically contains it too.
   roots.sort((a, b) => b.root.length - a.root.length)
-  return currentPath ? [{ worktreeId: currentWorktreeId, root: currentPath }, ...roots] : roots
+  return roots
 }
 
 function planToTarget(
@@ -79,6 +78,10 @@ export function resolveWorkspaceDocAddressTarget(
     // routed through dot segments could claim a workspace it then escapes.
     if (input.split(/[\\/]+/).some((segment) => segment === '..' || segment === '.')) {
       return { status: 'not-a-workspace-doc' }
+    }
+    const currentPath = state.getKnownWorktreeById(currentWorktreeId)?.path
+    if (currentPath && getRelativePathInsideRoot(input, currentPath)) {
+      return planToTarget(state, currentWorktreeId, input)
     }
     for (const { worktreeId, root } of ownedWorktreeRoots(state, currentWorktreeId)) {
       if (getRelativePathInsideRoot(input, root)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

When you type a file path into Orca's address bar, Orca has to figure out which of your open workspaces that file belongs to before it can show it to you.

It used to answer that question by listing every workspace you have open and checking them one by one — even when the file was sitting right in the workspace you were already looking at, which is almost always the case.

Now it checks the workspace you're currently in first, and only goes looking through the full list if the file isn't there. Same answer, less rummaging. The current workspace was already the first thing checked in the old list, so the file you open is exactly the file you opened before.

## What Changed / Why

- Current-root matches avoid reading the global worktree catalog; existing address contracts pass

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 10 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/lib/workspace-doc-address-input.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

