### PR TITLE
perf: check tunnel queue capacity before copying frame payloads

### DIFF
--- a/src/shared/browser-network-tunnel-stream-framing.test.ts
+++ b/src/shared/browser-network-tunnel-stream-framing.test.ts
@@ -171,25 +171,45 @@ describe('browser network tunnel stream framing', () => {
     expect(writer.queuedBytes).toBe(0)
     expect(onError).not.toHaveBeenCalled()
   })
-})
 
-it('rejects saturated writer frames before encoding and copying their payloads', () => {
-  const writer = new BrowserNetworkTunnelStreamFrameWriter(
-    () => {},
-    () => {},
-    { maxQueuedFrames: 1 }
-  )
-  const frame = new Uint8Array(65536)
-  expect(writer.send(frame)).toBe(true)
-  const set = vi.spyOn(Uint8Array.prototype, 'set')
-  try {
-    for (let index = 0; index < 1000; index += 1) {
-      expect(writer.send(frame)).toBe(false)
+  it('rejects saturated writer frames before encoding and copying their payloads', () => {
+    const writer = new BrowserNetworkTunnelStreamFrameWriter(
+      () => {},
+      () => {},
+      { maxQueuedFrames: 1 }
+    )
+    const frame = new Uint8Array(65536)
+    expect(writer.send(frame)).toBe(true)
+    const set = vi.spyOn(Uint8Array.prototype, 'set')
+    try {
+      for (let index = 0; index < 1000; index += 1) {
+        expect(writer.send(frame)).toBe(false)
+      }
+      expect(set.mock.calls.length).toBe(0)
+      expect(writer.queuedBytes).toBe(65540)
+    } finally {
+      set.mockRestore()
+      writer.close()
     }
-    expect(set.mock.calls.length).toBe(0)
-    expect(writer.queuedBytes).toBe(65540)
-  } finally {
-    set.mockRestore()
+  })
+
+  it('admits a frame that exactly fills the byte cap and rejects one byte past it', () => {
+    const writer = new BrowserNetworkTunnelStreamFrameWriter(
+      () => {},
+      () => {},
+      { maxQueuedBytes: 158 }
+    )
+    expect(writer.send(new Uint8Array(100))).toBe(true)
+    expect(writer.queuedBytes).toBe(104)
+    expect(writer.send(new Uint8Array(51))).toBe(false)
+    expect(writer.send(new Uint8Array(50))).toBe(true)
+    expect(writer.queuedBytes).toBe(158)
     writer.close()
-  }
+  })
+
+  it('encodes exactly the byte count writer admission reserves', () => {
+    for (const size of [1, 2, 255, 4096, 65536, 64 * 1024 + 16]) {
+      expect(encodeBrowserNetworkTunnelStreamFrame(new Uint8Array(size)).byteLength).toBe(4 + size)
+    }
+  })
 })

--- a/src/shared/browser-network-tunnel-stream-framing.test.ts
+++ b/src/shared/browser-network-tunnel-stream-framing.test.ts
@@ -172,3 +172,24 @@ describe('browser network tunnel stream framing', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 })
+
+it('rejects saturated writer frames before encoding and copying their payloads', () => {
+  const writer = new BrowserNetworkTunnelStreamFrameWriter(
+    () => {},
+    () => {},
+    { maxQueuedFrames: 1 }
+  )
+  const frame = new Uint8Array(65536)
+  expect(writer.send(frame)).toBe(true)
+  const set = vi.spyOn(Uint8Array.prototype, 'set')
+  try {
+    for (let index = 0; index < 1000; index += 1) {
+      expect(writer.send(frame)).toBe(false)
+    }
+    expect(set.mock.calls.length).toBe(0)
+    expect(writer.queuedBytes).toBe(65540)
+  } finally {
+    set.mockRestore()
+    writer.close()
+  }
+})

--- a/src/shared/browser-network-tunnel-stream-framing.ts
+++ b/src/shared/browser-network-tunnel-stream-framing.ts
@@ -134,16 +134,16 @@ export class BrowserNetworkTunnelStreamFrameWriter {
     if (this.closed) {
       return false
     }
+    if (
+      this.retainedBytes + LENGTH_BYTES + frame.byteLength > this.maxQueuedBytes ||
+      this.frames.length + (this.writing ? 1 : 0) >= this.maxQueuedFrames
+    ) {
+      return false
+    }
     let encoded: Uint8Array
     try {
       encoded = encodeBrowserNetworkTunnelStreamFrame(frame)
     } catch {
-      return false
-    }
-    if (
-      this.retainedBytes + encoded.byteLength > this.maxQueuedBytes ||
-      this.frames.length + (this.writing ? 1 : 0) >= this.maxQueuedFrames
-    ) {
       return false
     }
     this.frames.push(encoded)

--- a/src/shared/browser-network-tunnel-stream-framing.ts
+++ b/src/shared/browser-network-tunnel-stream-framing.ts
@@ -4,11 +4,16 @@ const DEFAULT_MAX_RETAINED_BYTES = 2 * 1024 * 1024
 const DEFAULT_MAX_QUEUED_BYTES = 1024 * 1024
 const DEFAULT_MAX_QUEUED_FRAMES = 512
 
+// Single source of truth so writer admission reserves exactly what encoding allocates.
+function encodedFrameByteLength(frame: Uint8Array): number {
+  return LENGTH_BYTES + frame.byteLength
+}
+
 export function encodeBrowserNetworkTunnelStreamFrame(frame: Uint8Array): Uint8Array {
   if (frame.byteLength === 0 || frame.byteLength > DEFAULT_MAX_FRAME_BYTES) {
     throw new Error('browser_tunnel_stream_frame_invalid')
   }
-  const encoded = new Uint8Array(LENGTH_BYTES + frame.byteLength)
+  const encoded = new Uint8Array(encodedFrameByteLength(frame))
   new DataView(encoded.buffer).setUint32(0, frame.byteLength, false)
   encoded.set(frame, LENGTH_BYTES)
   return encoded
@@ -135,7 +140,7 @@ export class BrowserNetworkTunnelStreamFrameWriter {
       return false
     }
     if (
-      this.retainedBytes + LENGTH_BYTES + frame.byteLength > this.maxQueuedBytes ||
+      this.retainedBytes + encodedFrameByteLength(frame) > this.maxQueuedBytes ||
       this.frames.length + (this.writing ? 1 : 0) >= this.maxQueuedFrames
     ) {
       return false


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

Orca's browser tunnel (used when the browser's traffic has to travel to a WSL machine) has an outbox. Each thing you want to send is wrapped in an envelope and dropped in that outbox, and the outbox has a hard size limit so a stalled connection can never eat unlimited memory.

The old code wrote the envelope first and only then checked whether the outbox had room. If it did not, the freshly written envelope was thrown straight in the bin. When the far side stalls this happens over and over: a thousand rejected 64 KB messages meant copying 64 MB of data purely to throw it away — extra CPU and garbage collection exactly when the connection is already struggling.

Now the room check happens first, so a message that cannot fit is turned away before anything is copied.

The decision itself is unchanged, to the byte. The size the check reserves is now computed by the same helper the envelope writer uses, so the two cannot drift apart. A message that exactly fills the outbox is still accepted, one byte more is still refused, nothing is dropped or reordered, and nothing about the bytes on the wire changes.

## What Changed / Why

- 1,000 rejected 64 KB frames: 65,536,000 copied payload bytes eliminated

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 17 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/shared/browser-network-tunnel-stream-framing.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

