### PR TITLE
perf: count command-line escapes without regex match arrays

### DIFF
--- a/src/shared/windows-command-line-budget.test.ts
+++ b/src/shared/windows-command-line-budget.test.ts
@@ -50,6 +50,23 @@ describe('windows command line budget', () => {
     }
   })
 
+  // Why: the estimator seeks escapes until they look dense, then hands the rest to a
+  // plain scan. Both sides of that switch, and the handover index, must agree.
+  it('counts the same on either side of the dense-escape switch', () => {
+    for (const args of [
+      [`\\"${'x'.repeat(30000)}`],
+      [`${'x'.repeat(30000)}\\"`],
+      [`${'x'.repeat(5000)}${'"\\abc'.repeat(5000)}`],
+      ['"'.repeat(30000)],
+      ['\\'.repeat(30000)],
+      ['ab"cd\\ef'.repeat(4000)],
+      [`${'x'.repeat(255)}"${'x'.repeat(30000)}`],
+      [`${'"x'.repeat(200)}${'y'.repeat(30000)}`]
+    ]) {
+      expect(commandLineLength(args)).toBe(referenceCommandLineLength(args))
+    }
+  })
+
   it('matches the regex oracle across randomized quote-heavy command lines', () => {
     const pieces = [
       '"',

--- a/src/shared/windows-command-line-budget.test.ts
+++ b/src/shared/windows-command-line-budget.test.ts
@@ -1,0 +1,25 @@
+import { expect, it, vi } from 'vitest'
+import { commandLineLength } from './windows-command-line-budget'
+
+it('counts quote-dense payloads without allocating a match array', () => {
+  const args = ['node.exe', '-e', '"\\abc'.repeat(6000)]
+  const expected = args.reduce(
+    (total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0),
+    0
+  )
+  const match = vi.spyOn(String.prototype, 'match')
+  try {
+    expect(commandLineLength(args)).toBe(expected)
+    expect(match.mock.calls.length).toBe(0)
+  } finally {
+    match.mockRestore()
+  }
+})
+
+it('preserves empty, Unicode, backslash and quote budget estimates', () => {
+  for (const args of [[], [''], ['🦀', 'é', '\\', '"'], ['a\\\\"b', 'plain']]) {
+    expect(commandLineLength(args)).toBe(
+      args.reduce((total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0), 0)
+    )
+  }
+})

--- a/src/shared/windows-command-line-budget.test.ts
+++ b/src/shared/windows-command-line-budget.test.ts
@@ -1,25 +1,85 @@
-import { expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { commandLineLength } from './windows-command-line-budget'
 
-it('counts quote-dense payloads without allocating a match array', () => {
-  const args = ['node.exe', '-e', '"\\abc'.repeat(6000)]
-  const expected = args.reduce(
-    (total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0),
-    0
-  )
-  const match = vi.spyOn(String.prototype, 'match')
-  try {
-    expect(commandLineLength(args)).toBe(expected)
-    expect(match.mock.calls.length).toBe(0)
-  } finally {
-    match.mockRestore()
-  }
-})
+/** The regex form this estimator replaced; kept as the differential oracle. */
+function referenceCommandLineLength(args: readonly string[]): number {
+  return args.reduce((total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0), 0)
+}
 
-it('preserves empty, Unicode, backslash and quote budget estimates', () => {
-  for (const args of [[], [''], ['🦀', 'é', '\\', '"'], ['a\\\\"b', 'plain']]) {
-    expect(commandLineLength(args)).toBe(
-      args.reduce((total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0), 0)
-    )
-  }
+describe('windows command line budget', () => {
+  it('counts quote-dense payloads without allocating a match array', () => {
+    const args = ['node.exe', '-e', '"\\abc'.repeat(6000)]
+    const expected = referenceCommandLineLength(args)
+    const match = vi.spyOn(String.prototype, 'match')
+    try {
+      expect(commandLineLength(args)).toBe(expected)
+      expect(match.mock.calls.length).toBe(0)
+    } finally {
+      match.mockRestore()
+    }
+  })
+
+  it('preserves empty, Unicode, backslash and quote budget estimates', () => {
+    for (const args of [[], [''], ['🦀', 'é', '\\', '"'], ['a\\\\"b', 'plain']]) {
+      expect(commandLineLength(args)).toBe(referenceCommandLineLength(args))
+    }
+  })
+
+  // Why: `arg.length` and the scan are both UTF-16 code units, so an astral char must
+  // not shift the index of an escape that follows it.
+  it('counts escapes adjacent to astral characters and lone surrogates', () => {
+    for (const args of [
+      ['🦀\\'],
+      ['\\🦀'],
+      ['🦀"🦀\\🦀'],
+      ['\uD83D'],
+      ['\uDE00'],
+      ['\uD83D\\\uDE00"'],
+      ['\uD800"\uDFFF\\'],
+      ['%PATH%^"\\', 'a^^b', '%%'],
+      ['trailing\\', 'trailing\\\\', '\\\\\\"']
+    ]) {
+      expect(commandLineLength(args)).toBe(referenceCommandLineLength(args))
+    }
+  })
+
+  it('matches the regex oracle across every BMP code unit', () => {
+    for (let unit = 0; unit <= 0xffff; unit += 1) {
+      const args = [String.fromCharCode(unit)]
+      expect(commandLineLength(args)).toBe(referenceCommandLineLength(args))
+    }
+  })
+
+  it('matches the regex oracle across randomized quote-heavy command lines', () => {
+    const pieces = [
+      '"',
+      '\\',
+      '\\\\',
+      '\\"',
+      '"\\',
+      '^',
+      '%VAR%',
+      '🦀',
+      'é',
+      '中文',
+      '\uD83D',
+      '\uDE00',
+      'C:\\Users\\n p\\repo',
+      '/usr/bin/git',
+      '',
+      ' ',
+      'plain'
+    ]
+    let seed = 0x2545f491
+    const next = (): number => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff
+    for (let index = 0; index < 5000; index += 1) {
+      const args = Array.from({ length: Math.floor(next() * 6) }, () =>
+        Array.from(
+          { length: Math.floor(next() * 30) },
+          () => pieces[Math.floor(next() * pieces.length)]
+        ).join('')
+      )
+      expect(commandLineLength(args)).toBe(referenceCommandLineLength(args))
+    }
+  })
 })

--- a/src/shared/windows-command-line-budget.ts
+++ b/src/shared/windows-command-line-budget.ts
@@ -24,5 +24,15 @@ export const MAX_COMMAND_LINE_CHARS = 30_000
  * quote-heavy ~26KB script on argv and over the real limit.
  */
 export function commandLineLength(args: readonly string[]): number {
-  return args.reduce((total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0), 0)
+  let total = 0
+  for (const arg of args) {
+    total += arg.length + 3
+    for (let index = 0; index < arg.length; index += 1) {
+      const code = arg.charCodeAt(index)
+      if (code === 34 || code === 92) {
+        total += 1
+      }
+    }
+  }
+  return total
 }

--- a/src/shared/windows-command-line-budget.ts
+++ b/src/shared/windows-command-line-budget.ts
@@ -26,13 +26,51 @@ export const MAX_COMMAND_LINE_CHARS = 30_000
 export function commandLineLength(args: readonly string[]): number {
   let total = 0
   for (const arg of args) {
-    total += arg.length + 3
-    for (let index = 0; index < arg.length; index += 1) {
-      const code = arg.charCodeAt(index)
-      if (code === 34 || code === 92) {
-        total += 1
-      }
-    }
+    total += arg.length + 3 + countEscapes(arg)
   }
   return total
+}
+
+/** One escape per this many characters is where seeking stops paying off. */
+const DENSE_ESCAPE_RATIO = 4
+/** Leading escapes alone must not condemn a long plain tail to a full scan. */
+const DENSE_ESCAPE_GRACE = 256
+
+/**
+ * Count `"` and `\\` in an argument.
+ *
+ * `indexOf` skips plain runs with a native search, so the cost tracks the number
+ * of escapes rather than the length of the argument — which is what the WSL
+ * runner hands us: one multi-KB script with almost no escapes in it. Past the
+ * density where seeking each escape costs more than reading every character,
+ * a plain scan finishes the rest; that is the quote-dense script's shape.
+ */
+function countEscapes(arg: string): number {
+  let count = 0
+  let scanFrom = 0
+  let quote = arg.indexOf('"')
+  let slash = arg.indexOf('\\')
+  while (quote !== -1 || slash !== -1) {
+    const at = slash === -1 || (quote !== -1 && quote < slash) ? quote : slash
+    if (at === quote) {
+      quote = arg.indexOf('"', at + 1)
+    } else {
+      slash = arg.indexOf('\\', at + 1)
+    }
+    count += 1
+    scanFrom = at + 1
+    if (count * DENSE_ESCAPE_RATIO > at + DENSE_ESCAPE_GRACE) {
+      break
+    }
+  }
+  if (quote === -1 && slash === -1) {
+    return count
+  }
+  for (let index = scanFrom; index < arg.length; index += 1) {
+    const code = arg.charCodeAt(index)
+    if (code === 34 || code === 92) {
+      count += 1
+    }
+  }
+  return count
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 |

<!-- /orca-pr-loc -->

## ELI5

Windows refuses to start a program if the command line is too long, and everything shares that one budget: the program name, the `wsl.exe` wrapper, the login shell, and your actual arguments. Orca therefore estimates the finished length before spawning, so it can move a long script to standard input or split a bulk `git add` into several runs instead of failing outright.

Quotes and backslashes cost extra in that estimate, because Windows escapes them. The old estimator asked a regular expression for the list of every quote and backslash in the argument, then counted that list — building a throwaway array of 12,000 one-character strings just to read its length.

The first version of this PR replaced that with a plain character-by-character scan. That is faster on a quote-dense script, but it is much *slower* on the input this estimator actually sees most often: one multi-KB WSL login script with almost no escapes in it. Reading 30,000 characters one at a time costs the same whether there are 12,000 escapes or none, while the regex's native search skips plain text almost for free.

So the shipped version does neither exclusively. It **seeks** escapes with `indexOf`, which uses the platform's vectorised search to jump over plain runs, so the cost tracks the *number of escapes* rather than the length of the argument. Once escapes turn up densely enough that seeking each one costs more than reading every character, it hands the remainder to a plain scan. Both regimes win, and the estimate itself is unchanged — this is arithmetic, not a change to how anything is quoted or spawned.

## Performance

The original char-loop was a real reversal for this estimator's primary caller. Measured on Windows (`awin`, Node 24.18.0, win32 x64; cross-checked on `win-lowspec`), the char-loop against the regex it replaced:

| Shape | char-loop vs regex |
| :--- | ---: |
| plain 30 KB, zero escapes | **25.5x slower** (0.73 → 18.66 µs) |
| ascii-mixed | 37.8x slower |
| sparse 30 KB, one escape | 34.5x slower |
| unicode 30 KB | 4.95x slower |
| quote-dense 30 KB | 3.1x faster (122 → 39 µs) |
| short argv | 2.5x faster |
| 2 KB path-heavy | 1.3x faster |

`win-lowspec` was worse: 27.5x / 37.4x / 38x on the plain shapes, `half-dense-30KB` flipped to 1.60x slower, and path-heavy went neutral (0.98x). The losing shapes are exactly what `src/main/wsl/wsl-runner.ts` passes (one long script argument, once per WSL spawn); the winning short-argv shape is what `src/main/git/source-control/git-pathspec.ts` passes.

The shipped seek-then-scan hybrid is no worse than the better of the two on every shape, and beats both on the dense ones. Median of best-of-3 isolated Node 24 processes, µs per call (macOS arm64 — Windows is the ground truth for the direction above, this table is the relative comparison):

| Shape | regex | char-loop | **hybrid** | vs regex | vs char-loop |
| :--- | ---: | ---: | ---: | ---: | ---: |
| plain-30KB-zero-escapes | 1.00 | 44.55 | **1.04** | 1.03x | 0.02x |
| ascii-mixed | 1.02 | 44.08 | **1.06** | 1.04x | 0.02x |
| sparse-30KB-one-escape | 1.05 | 54.13 | **1.05** | 1.00x | 0.02x |
| unicode-30KB | 7.81 | 33.10 | **1.62** | 0.21x | 0.05x |
| half-dense-30KB | 61.19 | 57.95 | **35.57** | 0.58x | 0.61x |
| quote-dense-30KB | 118.18 | 58.09 | **31.67** | 0.27x | 0.55x |
| 2KB-path-heavy | 3.73 | 3.90 | **3.75** | 1.00x | 0.96x |
| short-argv | 0.12 | 0.07 | **0.08** | 0.61x | 1.01x |

Adversarial shapes for the density switch, same method: `dense-tail-30KB` 103.4 / 55.6 / **38.0**, `leading-escape-30KB` 1.04 / 49.2 / **1.05**, `all-quotes-30KB` 218.2 / 44.6 / **27.5**, `wsl-login-script-26KB` 12.8 / 53.9 / **8.6**. A naive "seek only" hybrid without the density switch loses badly on `all-quotes-30KB` (276 µs), which is why the switch exists; the 256-character grace before the switch is what keeps `leading-escape-30KB` from falling into a full scan.

Absolute cost is bounded either way (tens of microseconds, once per spawn), so none of this is user-visible. It is corrected because the PR's own rationale was inverted for its primary caller.

## What Changed / Why

- `commandLineLength` seeks `"` and `\` with `indexOf` instead of scanning every character or allocating a regex match array; a plain scan finishes the argument once escapes exceed roughly one in four.
- Estimation-only: both call sites (`wsl-runner.ts:232`, `git-pathspec.ts:56`) compare the result against a threshold. Nothing about quoting or spawning changed, and the `src/shared/child-process/` import-boundary ratchet still passes.
- Differential-tested against **both** the original regex and the char-loop over **391,102** cases: every one of the 65,536 BMP code units alone and flanked by escapes, astral pairs, lone surrogates, trailing backslash runs, `%VAR%`, carets, empty strings and empty argv, 30-40 KB plain/dense/dense-tail/leading-escape strings, 200,000 randomized quote-heavy command lines, and 60,000 randomized raw code-unit strings. **Zero disagreements.**

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 6 tests in `src/shared/windows-command-line-budget.test.ts` passed, including a new case pinning both sides of the dense-escape switch.
- 190 tests across 16 suites passed for the estimator and its dependents: `src/shared/child-process/` (including the import-boundary ratchet), `src/main/wsl/`, `src/main/git/source-control/bulk-pathspec-command-line-budget.test.ts`.
- `oxlint` clean; `pnpm run check:code-quality:changed` reported 0 new findings (code quality, type-aware, React Doctor) across the 2 changed files.
- Commit hooks passed: oxlint, React Doctor lint and formatting.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/shared/windows-command-line-budget.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
