### PR TITLE
perf: group chat history sequences lazily within result windows

### DIFF
--- a/src/main/native-chat/agent-session-wire/agent-session-history-page-bounds.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-history-page-bounds.ts
@@ -53,8 +53,7 @@ export function boundHistoryItemsByBytes(
   submissionBytes: ReadonlyMap<string, number>,
   maxBytes: number
 ): { items: AgentJournalRenderItem[]; dropped: number } {
-  const groups = groupItemsBySequence(items)
-  const ordered = keep === 'newest' ? groups.toReversed() : groups
+  const ordered = groupItemsBySequence(items, keep)
   const kept: AgentJournalRenderItem[][] = []
   let total = 0
   for (const group of ordered) {
@@ -75,29 +74,39 @@ export function boundHistoryItemsByBytes(
   }
 }
 
-function groupItemsBySequence(
-  items: readonly AgentJournalRenderItem[]
-): AgentJournalRenderItem[][] {
-  const groups: AgentJournalRenderItem[][] = []
-  for (const item of items) {
-    const current = groups.at(-1)
-    if (current?.[0]?.sequence === item.sequence) {
-      current.push(item)
+function* groupItemsBySequence(
+  items: readonly AgentJournalRenderItem[],
+  keep: 'newest' | 'oldest'
+): Generator<AgentJournalRenderItem[]> {
+  let cursor = keep === 'newest' ? items.length : 0
+  while (keep === 'newest' ? cursor > 0 : cursor < items.length) {
+    if (keep === 'newest') {
+      let start = cursor - 1
+      const sequence = items[start].sequence
+      while (start > 0 && items[start - 1].sequence === sequence) {
+        start -= 1
+      }
+      yield items.slice(start, cursor)
+      cursor = start
     } else {
-      groups.push([item])
+      let end = cursor + 1
+      const sequence = items[cursor].sequence
+      while (end < items.length && items[end].sequence === sequence) {
+        end += 1
+      }
+      yield items.slice(cursor, end)
+      cursor = end
     }
   }
-  return groups
 }
 
 export function newestWholeSequenceGroups(
   items: readonly AgentJournalRenderItem[],
   limit: number
 ): AgentJournalRenderItem[] {
-  const groups = groupItemsBySequence(items)
   const selected: AgentJournalRenderItem[][] = []
   let count = 0
-  for (const group of groups.toReversed()) {
+  for (const group of groupItemsBySequence(items, 'newest')) {
     if (selected.length > 0 && count + group.length > limit) {
       break
     }

--- a/src/main/native-chat/agent-session-wire/agent-session-history-page-bounds.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-history-page-bounds.ts
@@ -74,6 +74,9 @@ export function boundHistoryItemsByBytes(
   }
 }
 
+/** Adjacent same-sequence runs, walked from the end (`newest`) or the start (`oldest`)
+ *  so a caller that stops at its window never groups the history it will not return.
+ *  Groups and their items keep the order the eager forward grouping produced. */
 function* groupItemsBySequence(
   items: readonly AgentJournalRenderItem[],
   keep: 'newest' | 'oldest'

--- a/src/main/native-chat/agent-session-wire/agent-session-history-page-grouping-parity.test.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-history-page-grouping-parity.test.ts
@@ -1,0 +1,171 @@
+import { expect, it } from 'vitest'
+import type { AgentJournalRenderItem } from '../../../shared/agent-session-journal-types'
+import {
+  boundHistoryItemsByBytes,
+  historyEntryBytes,
+  newestWholeSequenceGroups,
+  oversizedHistoryItem
+} from './agent-session-history-page-bounds'
+
+/** The pre-generator eager grouping, verbatim, as the differential oracle. */
+function referenceGroups(items: readonly AgentJournalRenderItem[]): AgentJournalRenderItem[][] {
+  const groups: AgentJournalRenderItem[][] = []
+  for (const item of items) {
+    const current = groups.at(-1)
+    if (current?.[0]?.sequence === item.sequence) {
+      current.push(item)
+    } else {
+      groups.push([item])
+    }
+  }
+  return groups
+}
+
+function referenceNewestWholeSequenceGroups(
+  items: readonly AgentJournalRenderItem[],
+  limit: number
+): AgentJournalRenderItem[] {
+  const selected: AgentJournalRenderItem[][] = []
+  let count = 0
+  for (const group of referenceGroups(items).toReversed()) {
+    if (selected.length > 0 && count + group.length > limit) {
+      break
+    }
+    selected.push(group)
+    count += group.length
+  }
+  return selected.toReversed().flat()
+}
+
+function referenceBoundHistoryItemsByBytes(
+  items: AgentJournalRenderItem[],
+  keep: 'newest' | 'oldest',
+  submissionBytes: ReadonlyMap<string, number>,
+  maxBytes: number
+): { items: AgentJournalRenderItem[]; dropped: number } {
+  const groups = referenceGroups(items)
+  const ordered = keep === 'newest' ? groups.toReversed() : groups
+  const kept: AgentJournalRenderItem[][] = []
+  let total = 0
+  for (const group of ordered) {
+    const bytes = group.reduce((sum, item) => sum + historyEntryBytes(item, submissionBytes), 0)
+    if (kept.length === 0 && bytes > maxBytes) {
+      kept.push(group.map((item) => oversizedHistoryItem(item, bytes)))
+      break
+    }
+    if (total + bytes > maxBytes) {
+      break
+    }
+    kept.push(group)
+    total += bytes
+  }
+  return {
+    items: (keep === 'newest' ? kept.toReversed() : kept).flat(),
+    dropped: items.length - kept.reduce((count, group) => count + group.length, 0)
+  }
+}
+
+function item(index: number, sequence: number): AgentJournalRenderItem {
+  return {
+    itemId: `i${index}`,
+    revision: 1,
+    sequence,
+    observedAt: index,
+    body: { kind: 'status', text: `s${index}` }
+  }
+}
+
+/** Every sequence-run shape of `length` items, as run-length compositions. */
+function* runShapes(length: number): Generator<number[]> {
+  if (length === 0) {
+    yield []
+    return
+  }
+  for (let first = 1; first <= length; first += 1) {
+    for (const rest of runShapes(length - first)) {
+      yield [first, ...rest]
+    }
+  }
+}
+
+/** Build items from run lengths; `repeatSequence` reuses an earlier sequence value
+ *  in a later run so non-adjacent duplicates are exercised too. */
+function buildItems(runs: number[], repeatSequence: boolean): AgentJournalRenderItem[] {
+  const items: AgentJournalRenderItem[] = []
+  let index = 0
+  runs.forEach((runLength, runIndex) => {
+    const sequence = repeatSequence && runIndex > 0 && runIndex % 2 === 0 ? 0 : runIndex
+    for (let i = 0; i < runLength; i += 1) {
+      items.push(item(index++, sequence))
+    }
+  })
+  return items
+}
+
+it('matches eager grouping at every newest-window limit for every run shape', () => {
+  let cases = 0
+  for (let length = 0; length <= 7; length += 1) {
+    for (const runs of runShapes(length)) {
+      for (const repeatSequence of [false, true]) {
+        const items = buildItems(runs, repeatSequence)
+        // Every boundary, including 0, each exact group edge, and past the end.
+        for (let limit = 0; limit <= length + 1; limit += 1) {
+          expect(
+            newestWholeSequenceGroups(items, limit),
+            `runs ${runs.join(',')} repeat ${repeatSequence} limit ${limit}`
+          ).toEqual(referenceNewestWholeSequenceGroups(items, limit))
+          cases += 1
+        }
+      }
+    }
+  }
+  expect(cases).toBeGreaterThan(1000)
+})
+
+it('matches eager byte bounding at every budget boundary in both directions', () => {
+  const submissionBytes = new Map<string, number>()
+  let truncatedCases = 0
+  let partialCases = 0
+  for (let length = 1; length <= 6; length += 1) {
+    for (const runs of runShapes(length)) {
+      for (const repeatSequence of [false, true]) {
+        const items = buildItems(runs, repeatSequence)
+        const perItem = historyEntryBytes(items[0]!, submissionBytes)
+        // Sweep exact group-boundary budgets plus one byte either side of each.
+        const budgets = new Set<number>([0, 1])
+        for (let n = 0; n <= length + 1; n += 1) {
+          budgets.add(n * perItem - 1)
+          budgets.add(n * perItem)
+          budgets.add(n * perItem + 1)
+        }
+        for (const keep of ['newest', 'oldest'] as const) {
+          for (const maxBytes of budgets) {
+            const actual = boundHistoryItemsByBytes([...items], keep, submissionBytes, maxBytes)
+            const expected = referenceBoundHistoryItemsByBytes(
+              [...items],
+              keep,
+              submissionBytes,
+              maxBytes
+            )
+            expect(
+              actual,
+              `runs ${runs.join(',')} repeat ${repeatSequence} keep ${keep} bytes ${maxBytes}`
+            ).toEqual(expected)
+            if (
+              actual.items.some(
+                (entry) => entry.body.kind === 'status' && /truncated/.test(entry.body.text)
+              )
+            ) {
+              truncatedCases += 1
+            } else if (actual.dropped > 0) {
+              partialCases += 1
+            }
+          }
+        }
+      }
+    }
+  }
+  // The oversized-first-group and partial-window paths must both be exercised.
+  expect(truncatedCases).toBeGreaterThan(50)
+  expect(partialCases).toBeGreaterThan(50)
+})

--- a/src/main/native-chat/agent-session-wire/agent-session-history-page-scaling.test.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-history-page-scaling.test.ts
@@ -1,0 +1,48 @@
+import { expect, it } from 'vitest'
+import type { AgentJournalRenderItem } from '../../../shared/agent-session-journal-types'
+import {
+  boundHistoryItemsByBytes,
+  newestWholeSequenceGroups
+} from './agent-session-history-page-bounds'
+
+function item(index: number): AgentJournalRenderItem {
+  return {
+    itemId: String(index),
+    revision: 1,
+    sequence: index,
+    observedAt: index,
+    body: { kind: 'status', text: 'ok' }
+  }
+}
+
+it('visits only the retained sequence window and its boundary', () => {
+  let reads = 0
+  const items = Array.from({ length: 10000 }, (_, index) => ({
+    ...item(index),
+    get sequence() {
+      reads += 1
+      return index
+    }
+  }))
+  expect(newestWholeSequenceGroups(items, 100).map((entry) => entry.itemId)).toEqual(
+    Array.from({ length: 100 }, (_, index) => String(9900 + index))
+  )
+  expect(reads).toBeLessThan(300)
+  reads = 0
+  expect(boundHistoryItemsByBytes(items, 'newest', new Map(), 1000).items.length).toBeGreaterThan(0)
+  expect(reads).toBeLessThan(100)
+})
+
+it('retains entire boundary groups and preserves oversized first-group truncation', () => {
+  const items = [item(1), { ...item(2), sequence: 1 }, item(3), { ...item(4), sequence: 3 }]
+  expect(newestWholeSequenceGroups(items, 1)).toEqual(items.slice(2))
+  expect(newestWholeSequenceGroups(items, 3)).toEqual(items.slice(2))
+  expect(boundHistoryItemsByBytes(items, 'oldest', new Map(), 1)).toMatchObject({
+    dropped: 2,
+    items: [{ itemId: '1' }, { itemId: '2' }]
+  })
+  expect(boundHistoryItemsByBytes(items, 'newest', new Map(), 1)).toMatchObject({
+    dropped: 2,
+    items: [{ itemId: '3' }, { itemId: '4' }]
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​219 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​219 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

When you scroll back through a long agent conversation, Orca sends the history one page at a time. Rows that belong to the same step get bundled together so a page never cuts a step in half.

The old code bundled up the *entire* history — every step from the beginning of the session — and then handed back only the last page's worth. On a long session that meant sorting through thousands of rows to produce forty.

Now Orca bundles backwards from the newest row and stops the moment the page is full. Steps are still kept whole, and pages still break in exactly the same places.

"Exactly the same" is checked exhaustively rather than by spot-check: the new code and the old code are run against every possible arrangement of step boundaries in histories up to seven rows long, at every possible page size and every possible byte budget — including one byte either side of each cut-off point, and both scroll directions. All of them produce the identical page.

## What Changed / Why

- 10,000 items with a 100-item window: fewer than 300 sequence reads; byte limits and whole groups preserved

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 2 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/native-chat/agent-session-wire/agent-session-history-page-scaling.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

