### PR TITLE
perf: measure sidebar row geometry once before sorting delete anchors

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-context-menu-policy.ts
+++ b/src/renderer/src/components/sidebar/worktree-context-menu-policy.ts
@@ -171,9 +171,10 @@ export function preserveDeleteSiblingPosition(scope: HTMLElement | null): () => 
   if (!(sidebar instanceof HTMLElement) || !(row instanceof HTMLElement)) {
     return () => {}
   }
-  const rows = Array.from(
-    sidebar.querySelectorAll<HTMLElement>('[data-worktree-virtual-row]')
-  ).sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top)
+  const rows = Array.from(sidebar.querySelectorAll<HTMLElement>('[data-worktree-virtual-row]'))
+    .map((element) => ({ element, top: element.getBoundingClientRect().top }))
+    .sort((a, b) => a.top - b.top)
+    .map(({ element }) => element)
   const rowIndex = rows.indexOf(row)
   const anchorRow = rows[rowIndex + 1] ?? rows[rowIndex - 1] ?? null
   const anchorKey = anchorRow?.getAttribute('data-worktree-virtual-row-key')

--- a/src/renderer/src/components/sidebar/worktree-delete-position-scaling.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-position-scaling.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment happy-dom
+import { expect, it } from 'vitest'
+import { preserveDeleteSiblingPosition } from './worktree-context-menu-policy'
+
+it('measures each mounted sidebar row once when choosing a delete-position anchor', () => {
+  const sidebar = document.createElement('div')
+  sidebar.setAttribute('data-worktree-sidebar', '')
+  let measurements = 0
+  const rows = Array.from({ length: 200 }, (_, index) => {
+    const row = document.createElement('div')
+    row.setAttribute('data-worktree-virtual-row', '')
+    row.setAttribute('data-worktree-virtual-row-key', String(index))
+    row.getBoundingClientRect = () => {
+      measurements += 1
+      return { top: (index * 73) % 200 } as DOMRect
+    }
+    sidebar.append(row)
+    return row
+  })
+  expect(typeof preserveDeleteSiblingPosition(rows[100])).toBe('function')
+  expect(measurements).toBeLessThanOrEqual(201)
+})

--- a/src/renderer/src/components/sidebar/worktree-delete-position-scaling.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-position-scaling.test.ts
@@ -1,22 +1,68 @@
 // @vitest-environment happy-dom
-import { expect, it } from 'vitest'
+import { afterEach, expect, it, vi } from 'vitest'
 import { preserveDeleteSiblingPosition } from './worktree-context-menu-policy'
 
-it('measures each mounted sidebar row once when choosing a delete-position anchor', () => {
+/** Deterministic non-monotonic tops, so DOM order and visual order genuinely disagree. */
+const topFor = (index: number): number => (index * 73) % 200
+
+function mountSidebar(rowCount: number): {
+  sidebar: HTMLElement
+  rows: HTMLElement[]
+  measurementsByRow: Map<HTMLElement, number>
+} {
   const sidebar = document.createElement('div')
   sidebar.setAttribute('data-worktree-sidebar', '')
-  let measurements = 0
-  const rows = Array.from({ length: 200 }, (_, index) => {
+  const measurementsByRow = new Map<HTMLElement, number>()
+  const rows = Array.from({ length: rowCount }, (_, index) => {
     const row = document.createElement('div')
     row.setAttribute('data-worktree-virtual-row', '')
     row.setAttribute('data-worktree-virtual-row-key', String(index))
     row.getBoundingClientRect = () => {
-      measurements += 1
-      return { top: (index * 73) % 200 } as DOMRect
+      measurementsByRow.set(row, (measurementsByRow.get(row) ?? 0) + 1)
+      return { top: topFor(index) } as DOMRect
     }
     sidebar.append(row)
     return row
   })
-  expect(typeof preserveDeleteSiblingPosition(rows[100])).toBe('function')
-  expect(measurements).toBeLessThanOrEqual(201)
+  document.body.append(sidebar)
+  return { sidebar, rows, measurementsByRow }
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.restoreAllMocks()
+})
+
+it('measures each mounted sidebar row once when choosing a delete-position anchor', () => {
+  const { rows, measurementsByRow } = mountSidebar(200)
+
+  expect(typeof preserveDeleteSiblingPosition(rows[100]!)).toBe('function')
+
+  // 200 rows measured once each, plus the target's own `desiredTop` read.
+  const total = [...measurementsByRow.values()].reduce((sum, count) => sum + count, 0)
+  expect(total).toBe(201)
+})
+
+// Why: hoisting the layout read out of the comparator must not change which row anchors the
+// scroll position — that anchor is what keeps the list still under the user's cursor.
+it('anchors on the same row the pre-hoist comparator sort would have chosen', () => {
+  const { rows, measurementsByRow } = mountSidebar(200)
+  const target = rows[100]!
+
+  // Reference: the original sort, reading layout inside the comparator.
+  const expectedOrder = [...rows].sort(
+    (a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top
+  )
+  const targetIndex = expectedOrder.indexOf(target)
+  const expectedAnchor = expectedOrder[targetIndex + 1] ?? expectedOrder[targetIndex - 1]!
+
+  const restore = preserveDeleteSiblingPosition(target)
+  // Unmount the deleted row so the restore falls through to the anchor it captured.
+  target.remove()
+  measurementsByRow.clear()
+  vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(0)
+
+  restore()
+
+  expect([...measurementsByRow.keys()]).toEqual([expectedAnchor])
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

When you delete a worktree from the sidebar, Orca first notes the row just below it. After the delete it scrolls so that noted row sits exactly where the deleted one was, so the list does not jump under your cursor.

To find "the row just below", it sorts the visible rows by their on-screen position. The old code asked the browser "where is this row?" from inside the sort comparison — and a sort compares each row several times, so the same question got asked over and over. Now each row is asked once, up front, and the sort just compares the numbers it already has.

Nothing moves differently. All the measuring still happens at the same instant as before — in one go, before anything is deleted or re-rendered — so there is no window in which the list could shift between measuring and sorting. A new test rebuilds the anchor with the old comparator-based sort and requires the code to land on the identical row; deliberately reversing the sort makes that test fail, so it is really checking the order.

## What Changed / Why

- Replaced the `getBoundingClientRect()` call inside the sort comparator with a single measuring pass (a Schwartzian transform), so a list of n rows costs n reads instead of O(n log n).
- No stale-geometry window: `preserveDeleteSiblingPosition` is called synchronously at the top of `handleDelete`, before the scroll-anchor event and before the delete intent is deferred, and no DOM write happens between the measuring pass and the sort. Both versions read the same layout state.
- No forced-reflow change: layout is flushed at most once either way, since neither version writes to the DOM between reads. The old repeated reads were served from the browser's cached layout, so the practical saving is small.
- Honest sizing: the sidebar is virtualized, so only the rows in view plus overscan are mounted — realistically tens, not thousands. At that size this is a tidy-up rather than a measurable speedup; its value is that the sort comparator no longer touches layout at all.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- `worktree-delete-position-scaling.test.ts` (2 tests) passes on this branch on macOS: exactly 201 measurements for 200 mounted rows, and the chosen anchor matches the pre-hoist comparator sort.
- Mutation-checked: reversing the sort order makes the anchor test fail, so it is not vacuous.
- Commit hooks passed: oxlint, React Doctor lint and formatting.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched; no focus or window activation occurs in the test.
- Full build and Windows/Linux/live SSH validation remain for CI. This is renderer DOM measurement only, identical for git worktrees and folder workspaces and for local, SSH and relay rows.

Test files:

- `src/renderer/src/components/sidebar/worktree-delete-position-scaling.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
