### PR TITLE
perf: index selected team IDs and choose primary team in one pass

### DIFF
--- a/src/renderer/src/components/linear-issue-attribute-filter-primary-team.test.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-primary-team.test.ts
@@ -36,3 +36,32 @@ describe('resolveLinearIssueAttributeFilterPrimaryTeam', () => {
     ).toBe('t-a')
   })
 })
+
+it('selects a primary team without pairwise membership checks or sorting all teams', () => {
+  let reads = 0
+  let nameReads = 0
+  const availableTeams = Array.from({ length: 1000 }, (_, index) => ({
+    id: `team-${index}`,
+    key: String(index),
+    get name() {
+      nameReads += 1
+      return String((index * 173) % 1000).padStart(4, '0')
+    }
+  }))
+  const selectedTeamIds = new Proxy(
+    availableTeams.map((team) => team.id),
+    {
+      get(target, key, receiver) {
+        if (typeof key === 'string' && /^\d+$/.test(key)) {
+          reads += 1
+        }
+        return Reflect.get(target, key, receiver)
+      }
+    }
+  )
+  expect(resolveLinearIssueAttributeFilterPrimaryTeam({ selectedTeamIds, availableTeams })).toBe(
+    availableTeams[0]
+  )
+  expect(reads).toBeLessThanOrEqual(1000)
+  expect(nameReads).toBeLessThan(5000)
+})

--- a/src/renderer/src/components/linear-issue-attribute-filter-primary-team.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-primary-team.ts
@@ -14,17 +14,19 @@ export function resolveLinearIssueAttributeFilterPrimaryTeam(options: {
   availableTeams: LinearTeam[]
 }): LinearTeam | null {
   const { selectedTeamIds, availableTeams } = options
-  if (availableTeams.length === 0) {
-    return null
+  const selectedIds = new Set(selectedTeamIds)
+  let firstAvailable: LinearTeam | null = null
+  let firstSelected: LinearTeam | null = null
+  for (const team of availableTeams) {
+    if (!firstAvailable || compareTeamNameId(team, firstAvailable) < 0) {
+      firstAvailable = team
+    }
+    if (
+      selectedIds.has(team.id) &&
+      (!firstSelected || compareTeamNameId(team, firstSelected) < 0)
+    ) {
+      firstSelected = team
+    }
   }
-  if (selectedTeamIds.length === 0) {
-    return [...availableTeams].sort(compareTeamNameId)[0] ?? null
-  }
-  const selected = availableTeams
-    .filter((team) => selectedTeamIds.includes(team.id))
-    .sort(compareTeamNameId)
-  if (selected.length > 0) {
-    return selected[0] ?? null
-  }
-  return [...availableTeams].sort(compareTeamNameId)[0] ?? null
+  return firstSelected ?? firstAvailable
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

When you filter the Linear issue list by team, Orca has to pick one "main" team to show details for. It picks the alphabetically-first team you selected — or, if you selected none, the alphabetically-first team that exists.

The old way was like sorting an entire deck of cards just to find the lowest card, and checking each card against your whole wishlist one by one. The new way walks the deck once and simply remembers the lowest card seen so far.

Nothing about which team gets picked changes — same team, same alphabetical order, same tie-breaks. It just gets there with less work.

## What Changed / Why

- Replaced two full `Array.sort` calls plus an `Array.includes` scan per team with a single linear pass and a `Set` lookup.
- 1,000 teams: 500,500 selected-ID reads reduced to 1,000; selected and fallback ordering preserved.
- Tie-break parity: `Array.prototype.sort` is stable, and the new min-scan uses a strict `< 0` comparison, so ties still resolve to the earliest team in the original list.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 4 tests across 1 suite(s) passed on this isolated branch on macOS.
- Differential test of old vs new implementation over 200,000 randomized inputs (0–5 teams, duplicate names, duplicate IDs, empty names, accented and numeric names, 0–3 selected IDs including unmatched ones): **200,000 cases, 0 divergences**.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/renderer/src/components/linear-issue-attribute-filter-primary-team.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
