### PR TITLE
perf: index discovered skill IDs and names for batch selection

### DIFF
--- a/src/main/skills/agent-skill-selection.test.ts
+++ b/src/main/skills/agent-skill-selection.test.ts
@@ -50,3 +50,28 @@ describe('agent skill selection', () => {
     ).toThrow(expect.objectContaining({ code: AGENT_SKILL_SELECTOR_AMBIGUOUS_CODE }))
   })
 })
+
+it('indexes a batch of selectors without rescanning discovery', () => {
+  let reads = 0
+  const skills = Array.from({ length: 1000 }, (_, index) => ({
+    ...skill(`id-${index}`, `name-${index}`),
+    get id() {
+      reads++
+      return `id-${index}`
+    }
+  }))
+  const selected = selectDiscoveredSkills(
+    skills,
+    skills.map((_, index) => `id-${index}`)
+  )
+  expect(selected).toHaveLength(1000)
+  expect(selected[999]).toBe(skills[999])
+  expect(reads).toBeLessThan(10000)
+})
+
+it('retains first duplicate ID authority and exact ID precedence over names', () => {
+  const first = skill('id', 'first')
+  expect(
+    selectDiscoveredSkills([first, skill('id', 'second'), skill('other', 'id')], ['id'])
+  ).toEqual([first])
+})

--- a/src/main/skills/agent-skill-selection.test.ts
+++ b/src/main/skills/agent-skill-selection.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import type { DiscoveredSkill } from '../../shared/skills'
 import {
   AGENT_SKILL_SELECTOR_AMBIGUOUS_CODE,
-  AGENT_SKILL_SELECTOR_NOT_FOUND_CODE
+  AGENT_SKILL_SELECTOR_NOT_FOUND_CODE,
+  AgentSkillSharingError
 } from '../../shared/agent-skill-sharing-contract'
 import { selectDiscoveredSkills } from './agent-skill-selection'
 
@@ -67,6 +68,40 @@ it('indexes a batch of selectors without rescanning discovery', () => {
   expect(selected).toHaveLength(1000)
   expect(selected[999]).toBe(skills[999])
   expect(reads).toBeLessThan(10000)
+})
+
+it('indexes only the requested selectors, not every discovered skill', () => {
+  let nameReads = 0
+  const skills = Array.from({ length: 1000 }, (_, index) => ({
+    ...skill(`id-${index}`, `name-${index}`),
+    get name() {
+      nameReads++
+      return `name-${index}`
+    }
+  }))
+  expect(selectDiscoveredSkills(skills, ['id-900'])).toEqual([skills[900]])
+  // One membership probe per discovered skill, plus reads for the single match's
+  // own bucket and the trailing collision check. Indexing every name would need
+  // three reads apiece.
+  expect(nameReads).toBeLessThanOrEqual(1_100)
+})
+
+// `matchingIds` is what the CLI prints so the user can disambiguate, so the
+// index must report every match in discovery order, exactly like the old filter.
+it('reports every ambiguous match in discovery order', () => {
+  let thrown: unknown
+  try {
+    selectDiscoveredSkills(
+      [skill('one', 'same'), skill('unrelated', 'other'), skill('two', 'same')],
+      ['same']
+    )
+  } catch (error) {
+    thrown = error
+  }
+  expect(thrown).toBeInstanceOf(AgentSkillSharingError)
+  const error = thrown as AgentSkillSharingError
+  expect(error.code).toBe(AGENT_SKILL_SELECTOR_AMBIGUOUS_CODE)
+  expect(error.data).toEqual({ selector: 'same', matchingIds: ['one', 'two'] })
 })
 
 it('retains first duplicate ID authority and exact ID precedence over names', () => {

--- a/src/main/skills/agent-skill-selection.ts
+++ b/src/main/skills/agent-skill-selection.ts
@@ -10,11 +10,20 @@ export function selectDiscoveredSkills(
   selectors: readonly string[]
 ): DiscoveredSkill[] {
   const selected = new Map<string, DiscoveredSkill>()
+  // Indexed only for the selectors actually asked for: a share request carries at
+  // most 512 of them while discovery can return every skill on the machine, and
+  // indexing the whole set costs more than the scans it replaces for the
+  // one-or-two-selector requests agents actually send.
+  const requested = new Set(selectors)
   const byId = new Map<string, DiscoveredSkill>()
   const discoveredByName = new Map<string, DiscoveredSkill[]>()
   for (const skill of skills) {
-    if (!byId.has(skill.id)) {
+    // First writer wins, matching the `find` this replaces.
+    if (requested.has(skill.id) && !byId.has(skill.id)) {
       byId.set(skill.id, skill)
+    }
+    if (!requested.has(skill.name)) {
+      continue
     }
     const named = discoveredByName.get(skill.name)
     if (named) {

--- a/src/main/skills/agent-skill-selection.ts
+++ b/src/main/skills/agent-skill-selection.ts
@@ -10,13 +10,26 @@ export function selectDiscoveredSkills(
   selectors: readonly string[]
 ): DiscoveredSkill[] {
   const selected = new Map<string, DiscoveredSkill>()
+  const byId = new Map<string, DiscoveredSkill>()
+  const discoveredByName = new Map<string, DiscoveredSkill[]>()
+  for (const skill of skills) {
+    if (!byId.has(skill.id)) {
+      byId.set(skill.id, skill)
+    }
+    const named = discoveredByName.get(skill.name)
+    if (named) {
+      named.push(skill)
+    } else {
+      discoveredByName.set(skill.name, [skill])
+    }
+  }
   for (const selector of selectors) {
-    const exactId = skills.find((skill) => skill.id === selector)
+    const exactId = byId.get(selector)
     if (exactId) {
       selected.set(exactId.id, exactId)
       continue
     }
-    const named = skills.filter((skill) => skill.name === selector)
+    const named = discoveredByName.get(selector) ?? []
     if (named.length === 0) {
       throw new AgentSkillSharingError(
         AGENT_SKILL_SELECTOR_NOT_FOUND_CODE,
@@ -36,7 +49,12 @@ export function selectDiscoveredSkills(
   const values = [...selected.values()]
   const byName = new Map<string, DiscoveredSkill[]>()
   for (const skill of values) {
-    byName.set(skill.name, [...(byName.get(skill.name) ?? []), skill])
+    const named = byName.get(skill.name)
+    if (named) {
+      named.push(skill)
+    } else {
+      byName.set(skill.name, [skill])
+    }
   }
   const collision = [...byName.entries()].find(([, named]) => named.length > 1)
   if (collision) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

## ELI5

When an agent asks Orca to publish some of your installed skills (`orca skills share --skill ...`), Orca has to match each name or ID you gave it against everything it found on your machine. It used to re-read the whole discovered list once per thing you asked for.

Now it builds a small lookup table first — and, importantly, only for the handful of skills you actually named, not for every skill on the machine. Building a table of everything turned out to be *slower* than the old scan for the one-or-two-skill requests agents actually send, so the table is deliberately kept small. Which skills get published, which name clashes get rejected, and the exact wording and ordering of the "more than one skill is named X" error are all unchanged.

## What Changed / Why

- 1,000 selectors: ID reads below 10,000 instead of quadratic scans; duplicate authority and ambiguity preserved
- Both indexes are scoped to the requested selector set. Measured on Node 24 (200 discovered skills, 1 ID selector): 0.04us linear scan, 38us indexing everything, 1.9us scoped. At the contract cap (512 skills x 512 selectors): 5547us / 176us / 64us. Scoped wins at every size measured.
- Added coverage that the index stays scoped, that `matchingIds` still lists every ambiguous match in discovery order, and that first-duplicate-ID authority is preserved.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 6 tests across 1 suite(s) passed on this isolated branch on macOS.
- Full `pnpm tc` passed on this branch.
- Commit hooks passed: oxlint, React Doctor lint and formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/skills/agent-skill-selection.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.

