### PR TITLE
perf: index tab membership when rebasing authoritative sessions

### DIFF
--- a/src/main/runtime/workspace-session-membership-scaling.test.ts
+++ b/src/main/runtime/workspace-session-membership-scaling.test.ts
@@ -1,4 +1,5 @@
 import { expect, it, vi } from 'vitest'
+import type { TabGroup } from '../../shared/tab-types'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import { rebaseWorkspaceSessionTerminalMembership } from './workspace-session-terminal-membership-authority'
 
@@ -49,4 +50,74 @@ it('rebases a large group without rescanning tab order for every recent tab', ()
     recentTabIds: ids,
     activeTabId: ids[0]
   })
+})
+
+// Why: the rebased session is the host-authoritative one, so a tab id the host no
+// longer has must not survive into it. `activeTabId` already failed closed; the
+// filtered `recentTabIds` used to be dropped when it emptied, letting the `...group`
+// spread put the unfiltered array back.
+it('drops tab ids the host no longer has from group membership, failing closed', () => {
+  const buildSession = (
+    activeTabId: string | null,
+    recentTabIds: string[] | undefined
+  ): WorkspaceSessionState =>
+    ({
+      activeRepoId: 'repo',
+      activeWorktreeId: 'repo::/workspace',
+      activeTabId: null,
+      tabsByWorktree: {
+        'repo::/workspace': ['kept-a', 'kept-b'].map((id, index) => ({
+          id,
+          worktreeId: 'repo::/workspace',
+          ptyId: null,
+          title: id,
+          customTitle: null,
+          color: null,
+          sortOrder: index,
+          createdAt: 0
+        }))
+      },
+      terminalLayoutsByTabId: {},
+      terminalTopologyRevisionByRepoId: { repo: 1 },
+      tabGroups: {
+        'repo::/workspace': [
+          {
+            id: 'group',
+            worktreeId: 'repo::/workspace',
+            activeTabId,
+            tabOrder: ['kept-a', 'closed-on-host', 'kept-b'],
+            ...(recentTabIds ? { recentTabIds } : {})
+          }
+        ]
+      }
+    }) as WorkspaceSessionState
+
+  const rebase = (
+    activeTabId: string | null,
+    recentTabIds: string[] | undefined
+  ): TabGroup | undefined => {
+    const session = buildSession(activeTabId, recentTabIds)
+    return rebaseWorkspaceSessionTerminalMembership(session, session).tabGroups?.[
+      'repo::/workspace'
+    ][0]
+  }
+
+  // Every recent id is stale: the array must empty, not revert to the stale one.
+  expect(rebase('kept-b', ['closed-on-host'])).toMatchObject({
+    tabOrder: ['kept-a', 'kept-b'],
+    activeTabId: 'kept-b',
+    recentTabIds: []
+  })
+  // Mixed: only the host-known ids survive, in order.
+  expect(rebase('kept-a', ['closed-on-host', 'kept-b', 'closed-on-host', 'kept-a'])).toMatchObject({
+    recentTabIds: ['kept-b', 'kept-a']
+  })
+  // A stale active tab falls back to the first surviving tab, never to the stale id.
+  expect(rebase('closed-on-host', ['kept-a'])).toMatchObject({
+    activeTabId: 'kept-a',
+    recentTabIds: ['kept-a']
+  })
+  expect(rebase(null, undefined)).toMatchObject({ activeTabId: 'kept-a' })
+  // A group that never carried recentTabIds must not gain the key.
+  expect(rebase('kept-a', undefined)).not.toHaveProperty('recentTabIds')
 })

--- a/src/main/runtime/workspace-session-membership-scaling.test.ts
+++ b/src/main/runtime/workspace-session-membership-scaling.test.ts
@@ -1,0 +1,52 @@
+import { expect, it, vi } from 'vitest'
+import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import { rebaseWorkspaceSessionTerminalMembership } from './workspace-session-terminal-membership-authority'
+
+it('rebases a large group without rescanning tab order for every recent tab', () => {
+  const ids = Array.from({ length: 1000 }, (_, index) => `tab-${index}`)
+  const session: WorkspaceSessionState = {
+    activeRepoId: 'repo',
+    activeWorktreeId: 'repo::/workspace',
+    activeTabId: null,
+    tabsByWorktree: {
+      'repo::/workspace': ids.map((id, index) => ({
+        id,
+        worktreeId: 'repo::/workspace',
+        ptyId: null,
+        title: id,
+        customTitle: null,
+        color: null,
+        sortOrder: index,
+        createdAt: 0
+      }))
+    },
+    terminalLayoutsByTabId: {},
+    terminalTopologyRevisionByRepoId: { repo: 1 },
+    tabGroups: {
+      'repo::/workspace': [
+        {
+          id: 'group',
+          worktreeId: 'repo::/workspace',
+          activeTabId: 'missing',
+          tabOrder: [...ids, 'missing'],
+          recentTabIds: [...ids, 'missing']
+        }
+      ]
+    }
+  }
+  const includes = vi.spyOn(Array.prototype, 'includes')
+  let result: WorkspaceSessionState
+  let probes: number
+  try {
+    result = rebaseWorkspaceSessionTerminalMembership(session, session)
+    probes = includes.mock.calls.length
+  } finally {
+    includes.mockRestore()
+  }
+  expect(probes).toBeLessThan(10)
+  expect(result.tabGroups?.['repo::/workspace'][0]).toMatchObject({
+    tabOrder: ids,
+    recentTabIds: ids,
+    activeTabId: ids[0]
+  })
+})

--- a/src/main/runtime/workspace-session-terminal-membership-authority.ts
+++ b/src/main/runtime/workspace-session-terminal-membership-authority.ts
@@ -93,11 +93,10 @@ function rebaseTabGroups(
     if (tabOrder.length === 0) {
       return []
     }
+    const tabIds = new Set(tabOrder)
     const activeTabId =
-      group.activeTabId && tabOrder.includes(group.activeTabId)
-        ? group.activeTabId
-        : (tabOrder[0] ?? null)
-    const recentTabIds = group.recentTabIds?.filter((tabId) => tabOrder.includes(tabId))
+      group.activeTabId && tabIds.has(group.activeTabId) ? group.activeTabId : (tabOrder[0] ?? null)
+    const recentTabIds = group.recentTabIds?.filter((tabId) => tabIds.has(tabId))
     return [
       {
         ...group,

--- a/src/main/runtime/workspace-session-terminal-membership-authority.ts
+++ b/src/main/runtime/workspace-session-terminal-membership-authority.ts
@@ -102,7 +102,9 @@ function rebaseTabGroups(
         ...group,
         tabOrder,
         activeTabId,
-        ...(recentTabIds && recentTabIds.length > 0 ? { recentTabIds } : {})
+        // Why assigned even when it filters to empty: omitting the key lets `...group`
+        // re-introduce the unfiltered array, persisting ids for tabs the host dropped.
+        ...(group.recentTabIds ? { recentTabIds: recentTabIds ?? [] } : {})
       }
     ]
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​123 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​123 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Your terminal tabs live in groups. The host machine — not the client UI — is the authority on which tabs actually exist. When a client sends its view of the tabs, Orca "rebases" it: it keeps the host's list of real tabs and throws away anything the client thinks exists but the host doesn't.

Part of that check asks, for each entry in the group's recently-used list, "is this tab still real?" The old code answered by re-reading the whole tab list from the start, every single time. With 1,000 tabs and 1,000 recent entries that's a million comparisons. The new code writes the tab ids onto an index card once, then each lookup is instant.

Same tabs kept, same tab stays active, same recently-used order.

While reviewing this we also found a related bug and fixed it here: if **every** entry in a group's recently-used list named a tab the host had closed, the pruned list was discarded and the original, entirely-stale list was written back into the authoritative session. Now those ids are always dropped.

## What Changed / Why

- Build a `Set` of the group's valid tab ids once per group and use `Set.has` for the active-tab check and the recents filter, instead of an `Array.includes` rescan per entry. 1,000 recent tabs: fewer than 10 array membership probes.
- `Array.includes` and `Set.has` both use SameValueZero, and the ids are strings, so the membership answer is identical by construction.
- **Bug fix (pre-existing, found in review):** `rebaseTabGroups` spread `...group` first and then re-attached `recentTabIds` only when the filtered list was non-empty. When the filter emptied the list, the omission let the spread restore the unfiltered array, persisting tab ids the host no longer had. The key is now assigned whenever the group carried one, even if it filters to empty.

This PR contains only this focused change and its regression coverage. It targets `main` independently of the other desktop audit PRs. Measurements describe operation/allocation reductions, not end-to-end latency gains.

## Linked Issue

User-requested desktop performance audit; no issue supplied.

## Visual Proof

N/A — no visual design change. Behavior and performance invariants are checked by automated regression tests.

## Testing

- 2 tests in this suite, plus `host-terminal-close-persistence-durability.test.ts` (9 total) and 131 tests across the 18 downstream `recentTabIds` consumer suites (`sync-runtime-graph`, `web-session-terminal-orphan-topology`, `recent-tab-switching`), all passing on macOS.
- **Differential test of the `includes` → `Set.has` change: 4,000 randomized sessions, 0 divergences.** Ran the real `rebaseWorkspaceSessionTerminalMembership` under both implementations and byte-compared the serialized `tabGroups` and `activeTabIdByWorktree`. Sessions varied prior/incoming tab sets independently (so tabs appear, disappear and diverge between client and host), 0–3 groups per session, groups with empty `tabOrder`, groups whose `activeTabId` was `null` / valid / unknown, `recentTabIds` present or absent, and deliberately injected `ghost` / `missing` ids in `tabOrder`, `activeTabId` and `recentTabIds`.
- **Session authority (`docs/reference/ssh-execution-boundary.md`):** this path carries no liveness verdict — it does not produce or consume `live` / `unverifiable` / `exited`, and does not decide whether a PTY is running. It only filters client-proposed tab-group ordering down to the host-authoritative tab set. `validTabIds` is still derived solely from the prior (host) session's tabs plus rebased unified tabs; that derivation is untouched.
- **No mis-attribution:** the index is built per group from a `tabOrder` that has already been filtered by `validTabIds`, so it is a subset of host-known ids and cannot be shared or leaked between groups. It is rebuilt each iteration, so there is no cross-group stale index.
- **Fails closed:** an `activeTabId` the host does not have falls back to the first surviving tab (never to the unknown id), and the group is dropped entirely when `tabOrder` filters to empty. New tests pin the all-stale, mixed-stale, stale-active, absent-recents and never-had-recents cases, and mutation-checking confirms the recents assertion fails against the pre-fix code.
- §02: the `Set` is function-local and per group, so there is no unbounded growth or long-lived index; no new casts and no `JSON.parse`.
- §07: no platform-dependent behaviour — pure in-memory id set operations.
- Commit hooks passed: oxlint, oxfmt formatting; `git diff --cached --check` passed.
- All tests ran with `ORCA_BACKGROUND_LAUNCH=1`. No visible test window was launched.
- Full build and Windows/Linux/live SSH validation remain for CI; host/provider contracts are preserved.

Test files:

- `src/main/runtime/workspace-session-membership-scaling.test.ts`

## Agent skill upstream boundary

- [x] No upstream skill-installer material copied or translated.

## Checklist

- [x] Focused change with regression evidence.
- [x] Typecheck and pre-commit checks passed independently.
- [x] Cross-platform, folder-workspace and SSH ownership considered.
- [ ] Full CI build and repository checks pass.
