### PR TITLE
fix(cli): separate runtime observation failures from startup

### DIFF
--- a/src/cli/cli-error.ts
+++ b/src/cli/cli-error.ts
@@ -44,7 +44,7 @@ export function formatCliError(error: unknown, context: CliErrorContext = {}): s
     )
   }
   if (error instanceof RuntimeClientError && error.code === 'runtime_unavailable') {
-    if (hasOrchestrationRequestId(error.data)) {
+    if (hasOrchestrationRequestId(error.data) || hasRuntimeObservation(error.data)) {
       return message
     }
     return `${message}\nOrca is not running. Run 'orca open' first.`
@@ -77,6 +77,14 @@ export function formatCliError(error: unknown, context: CliErrorContext = {}): s
     return formatMessageWithNextSteps(message, nextStepsFromData(error.response.error.data))
   }
   return message
+}
+
+function hasRuntimeObservation(data: unknown): boolean {
+  return (
+    data !== null &&
+    typeof data === 'object' &&
+    ('statusObservation' in data || 'transportFailure' in data)
+  )
 }
 
 function hasOrchestrationRequestId(data: unknown): boolean {

--- a/src/cli/runtime-client.test.ts
+++ b/src/cli/runtime-client.test.ts
@@ -439,9 +439,11 @@ describe.skipIf(process.platform === 'win32')('RuntimeClient', () => {
 
     expect(failure).toBeInstanceOf(RuntimeClientError)
     expect((failure as RuntimeClientError).message).toBe(
-      'The Orca runtime closed the connection before responding. Restart Orca and try again.'
+      'The Orca runtime closed the connection before responding.'
     )
-    expect((failure as RuntimeClientError).data).toBeUndefined()
+    expect((failure as RuntimeClientError).data).toEqual({
+      transportFailure: { outcome: 'closed' }
+    })
     expect(request).toMatchObject({ method: 'orchestration.workerShow' })
     expect(request).not.toHaveProperty('orchestrationRequestId')
   })

--- a/src/cli/runtime/client.ts
+++ b/src/cli/runtime/client.ts
@@ -10,6 +10,7 @@ import {
 } from '../../shared/orchestration-rpc-contract'
 import type { PairingOffer } from '../../shared/pairing'
 import { launchOrcaApp } from './launch'
+import { isStatusObservationError } from './status-observation'
 import { getDefaultUserDataPath, readMetadata } from './metadata'
 import { getCliStatus, projectRemoteAppStatus } from './status'
 import { sendRequest } from './transport'
@@ -281,8 +282,21 @@ export class RuntimeClient {
     }
 
     const startedAt = Date.now()
+    let observationFailure: RuntimeClientError | undefined
     while (Date.now() - startedAt < timeoutMs) {
-      const status = await this.getCliStatus()
+      let status: RuntimeRpcSuccess<CliStatusResult>
+      try {
+        status = await this.getCliStatus()
+        observationFailure = undefined
+      } catch (error) {
+        if (!isStatusObservationError(error)) {
+          throw error
+        }
+        // Only this invocation's launch authorizes a bounded startup wait.
+        observationFailure = error
+        await delay(250)
+        continue
+      }
       if (status.result.app.desktopWindowStatus === 'blocked') {
         throwDesktopActivationBlocked()
       }
@@ -292,6 +306,9 @@ export class RuntimeClient {
       await delay(250)
     }
 
+    if (observationFailure) {
+      throw observationFailure
+    }
     throw new RuntimeClientError(
       'runtime_open_timeout',
       'Timed out waiting for an Orca desktop window. The runtime may still be running headlessly.'

--- a/src/cli/runtime/metadata.ts
+++ b/src/cli/runtime/metadata.ts
@@ -7,6 +7,7 @@ import {
   type RuntimeMetadata
 } from '../../shared/runtime-bootstrap'
 import { RuntimeClientError } from './types'
+import { statusObservationError } from './status-observation'
 
 export function readMetadata(userDataPath: string): RuntimeMetadata {
   const metadataPath = getRuntimeMetadataPath(userDataPath)
@@ -33,9 +34,16 @@ export function readMetadata(userDataPath: string): RuntimeMetadata {
 export function tryReadMetadata(userDataPath: string): RuntimeMetadata | null {
   const metadataPath = getRuntimeMetadataPath(userDataPath)
   try {
-    return JSON.parse(readFileSync(metadataPath, 'utf8')) as RuntimeMetadata | null
-  } catch {
-    return null
+    const metadata = JSON.parse(readFileSync(metadataPath, 'utf8')) as RuntimeMetadata | null
+    if (!metadata || typeof metadata !== 'object') {
+      throw new Error('Invalid metadata')
+    }
+    return metadata
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code === 'ENOENT') {
+      return null
+    }
+    throw statusObservationError('unverifiable', error)
   }
 }
 

--- a/src/cli/runtime/status-authority.test.ts
+++ b/src/cli/runtime/status-authority.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { getCliStatus } from './status'
+import { RuntimeClient } from './client'
+import { tryReadMetadata } from './metadata'
+import { sendRequest } from './transport'
+import { launchOrcaApp } from './launch'
+import { RuntimeClientError } from './types'
+
+vi.mock('./metadata', () => ({
+  tryReadMetadata: vi.fn(),
+  getDefaultUserDataPath: vi.fn()
+}))
+vi.mock('./runtime-remote-pairing', () => ({
+  resolveRemotePairing: () => null
+}))
+vi.mock('./transport', () => ({ sendRequest: vi.fn() }))
+vi.mock('./launch', () => ({ launchOrcaApp: vi.fn() }))
+const metadata = {
+  runtimeId: 'cached',
+  pid: 123456,
+  startedAt: 1,
+  authToken: 'fixture',
+  transports: [{ kind: 'unix' as const, endpoint: 'fixture' }]
+}
+const ready = {
+  runtimeId: 'cached',
+  graphStatus: 'ready',
+  authoritativeWindowId: 1
+}
+const success = (result: unknown) => ({
+  id: 'fixture',
+  ok: true as const,
+  result,
+  _meta: { runtimeId: 'cached' }
+})
+beforeEach(() => {
+  vi.mocked(tryReadMetadata).mockReturnValue(metadata)
+  vi.spyOn(process, 'kill').mockImplementation(() => {
+    throw Object.assign(new Error('fixture'), { code: 'ESRCH' })
+  })
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  vi.useRealTimers()
+})
+
+it.each([
+  { outcome: 'identity_changed' },
+  { outcome: 'invalid_response' },
+  { outcome: 'closed' },
+  { outcome: 'timeout' },
+  { outcome: 'socket_error', code: 'EPERM', connected: false },
+  { outcome: 'socket_error', code: 'EACCES', connected: false },
+  { outcome: 'socket_error', code: 'ECONNREFUSED', connected: true },
+  { outcome: 'socket_error', code: 'ENOENT' }
+])(
+  'cached exit cannot override failed observation %j or authorize launch',
+  async (transportFailure) => {
+    vi.mocked(sendRequest).mockRejectedValue(
+      new RuntimeClientError('runtime_unavailable', 'fixture', {
+        transportFailure
+      })
+    )
+    await expect(new RuntimeClient('fixture', 100, null, null).openOrca(500)).rejects.toMatchObject(
+      {
+        data: {
+          statusObservation: { process: 'exited', runtime: 'unverifiable' },
+          transportFailure
+        }
+      }
+    )
+    expect(launchOrcaApp).not.toHaveBeenCalled()
+  }
+)
+it('cached exit cannot override authenticated RPC denial', async () => {
+  vi.mocked(sendRequest).mockResolvedValue({
+    id: 'fixture',
+    ok: false,
+    error: { code: 'permission_denied', message: 'fixture' },
+    _meta: { runtimeId: 'cached' }
+  })
+  await expect(new RuntimeClient('fixture', 100, null, null).openOrca(500)).rejects.toMatchObject({
+    code: 'permission_denied'
+  })
+  expect(launchOrcaApp).not.toHaveBeenCalled()
+})
+it.each([
+  {},
+  null,
+  [],
+  true,
+  '',
+  { ...ready, graphStatus: 'starting' },
+  { ...ready, authoritativeWindowId: '1' },
+  { ...ready, desktopWindowStatus: 'bogus' },
+  { ...ready, capabilities: {} },
+  { ...ready, degradations: [{}] },
+  { ...ready, runtimeId: '' }
+])('malformed result %j cannot become reachable success or authorize launch', async (result) => {
+  vi.mocked(sendRequest).mockResolvedValue(success(result))
+  await expect(new RuntimeClient('fixture', 100, null, null).openOrca(500)).rejects.toMatchObject({
+    code: 'invalid_runtime_response'
+  })
+  expect(launchOrcaApp).not.toHaveBeenCalled()
+})
+it('binds result identity to discovery even with a matching envelope', async () => {
+  vi.mocked(sendRequest).mockResolvedValue(success({ ...ready, runtimeId: 'replacement' }))
+  await expect(getCliStatus('fixture')).rejects.toMatchObject({
+    data: { transportFailure: { outcome: 'identity_changed' } }
+  })
+})
+it('valid older status and unknown additive fields outrank cached PID exit', async () => {
+  vi.mocked(sendRequest).mockResolvedValue(
+    success({ ...ready, futureField: true, capabilities: ['future.v1'] })
+  )
+  expect((await getCliStatus('fixture')).result).toMatchObject({
+    app: { running: true, desktopWindowStatus: 'available' },
+    runtime: { state: 'ready', capabilities: ['future.v1'] }
+  })
+  expect(process.kill).not.toHaveBeenCalled()
+})
+it.each(['ENOENT', 'ECONNREFUSED'])(
+  'absent endpoint %s plus cached exit permits one fresh launch',
+  async (code) => {
+    vi.useFakeTimers()
+    vi.mocked(sendRequest)
+      .mockRejectedValueOnce(
+        new RuntimeClientError('runtime_unavailable', 'fixture', {
+          transportFailure: { outcome: 'socket_error', code, connected: false }
+        })
+      )
+      .mockResolvedValue(success(ready))
+    const pending = new RuntimeClient('fixture', 100, null, null).openOrca(500)
+    await vi.runAllTimersAsync()
+    expect((await pending).result.runtime.state).toBe('ready')
+    expect(launchOrcaApp).toHaveBeenCalledOnce()
+  }
+)

--- a/src/cli/runtime/status-metadata.test.ts
+++ b/src/cli/runtime/status-metadata.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { tryReadMetadata } from './metadata'
+import { isStatusObservationError } from './status-observation'
+import { RuntimeClientError } from './types'
+import { formatCliError } from '../cli-error'
+
+vi.mock('node:fs', () => ({ readFileSync: vi.fn() }))
+afterEach(() => vi.restoreAllMocks())
+
+describe('metadata observation and compatibility', () => {
+  it('missing metadata retains legacy discovery result', () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw Object.assign(new Error('fixture'), { code: 'ENOENT' })
+    })
+    expect(tryReadMetadata('synthetic-folder')).toBeNull()
+  })
+  it.each(['EPERM', 'EACCES', 'EIO'])('%s is not evidence of absence', (code) => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw Object.assign(new Error('fixture'), { code })
+    })
+    expect(() => tryReadMetadata('synthetic-folder')).toThrow(
+      'Could not verify Orca runtime status'
+    )
+  })
+  it.each(['{broken', 'null', '42'])('malformed metadata %s cannot authorize launch', (value) => {
+    vi.mocked(readFileSync).mockReturnValue(value)
+    expect(() => tryReadMetadata('synthetic-folder')).toThrow(
+      'Could not verify Orca runtime status'
+    )
+  })
+  it('legacy errors without observation retain their existing handling', () => {
+    const error = new RuntimeClientError('runtime_unavailable', 'legacy')
+    expect(isStatusObservationError(error)).toBe(false)
+    expect(formatCliError(error)).toContain("Run 'orca open'")
+  })
+  it('unknown optional observation versions do not authorize a startup wait', () => {
+    const error = new RuntimeClientError('runtime_unavailable', 'fixture', {
+      statusObservation: { version: 99, target: 'local' }
+    })
+    expect(isStatusObservationError(error)).toBe(false)
+  })
+})

--- a/src/cli/runtime/status-observation.test.ts
+++ b/src/cli/runtime/status-observation.test.ts
@@ -12,7 +12,10 @@ import { RuntimeClient } from './client'
 import { launchOrcaApp } from './launch'
 import { formatCliError, reportCliError } from '../cli-error'
 
-vi.mock('./metadata', () => ({ tryReadMetadata: vi.fn(), getDefaultUserDataPath: vi.fn() }))
+vi.mock('./metadata', () => ({
+  tryReadMetadata: vi.fn(),
+  getDefaultUserDataPath: vi.fn()
+}))
 vi.mock('./runtime-remote-pairing', () => ({ resolveRemotePairing: vi.fn() }))
 vi.mock('./transport', () => ({ sendRequest: vi.fn() }))
 vi.mock('./launch', () => ({ launchOrcaApp: vi.fn() }))
@@ -76,7 +79,9 @@ describe('local status evidence boundary', () => {
     'preserves %s code without a successful state',
     async (code) => {
       vi.mocked(sendRequest).mockRejectedValue(new RuntimeClientError(code, 'test'))
-      await expect(getCliStatus('synthetic-folder')).rejects.toMatchObject({ code })
+      await expect(getCliStatus('synthetic-folder')).rejects.toMatchObject({
+        code
+      })
     }
   )
   it.each(['EPERM', 'EACCES', 'EINVAL'])('PID %s is unverifiable', async (code) => {
@@ -87,7 +92,16 @@ describe('local status evidence boundary', () => {
       data: { statusObservation: { process: 'unverifiable' } }
     })
   })
-  it('positive ESRCH permits stale bootstrap', async () => {
+  it('positive ESRCH and refused endpoint permit stale bootstrap', async () => {
+    vi.mocked(sendRequest).mockRejectedValue(
+      new RuntimeClientError('runtime_unavailable', 'test', {
+        transportFailure: {
+          outcome: 'socket_error',
+          code: 'ECONNREFUSED',
+          connected: false
+        }
+      })
+    )
     vi.mocked(process.kill).mockImplementation(() => {
       throw Object.assign(new Error('test'), { code: 'ESRCH' })
     })
@@ -134,10 +148,17 @@ describe('local status evidence boundary', () => {
     async (graphStatus) => {
       vi.mocked(sendRequest).mockResolvedValue({
         ...ready,
-        result: { ...ready.result, graphStatus, desktopWindowStatus: 'initializing' }
+        result: {
+          ...ready.result,
+          graphStatus,
+          desktopWindowStatus: 'initializing'
+        }
       })
       expect((await getCliStatus('synthetic-folder')).result).toMatchObject({
-        runtime: { state: graphStatus === 'ready' ? 'ready' : 'graph_not_ready', reachable: true },
+        runtime: {
+          state: graphStatus === 'ready' ? 'ready' : 'graph_not_ready',
+          reachable: true
+        },
         graph: { state: graphStatus },
         app: { desktopWindowStatus: 'initializing' }
       })
@@ -151,7 +172,10 @@ describe('local status evidence boundary', () => {
     reportCliError(error, true)
     expect(JSON.parse(log.mock.calls[0][0])).toMatchObject({
       ok: false,
-      error: { code: 'runtime_unavailable', data: { statusObservation: { process: 'live' } } }
+      error: {
+        code: 'runtime_unavailable',
+        data: { statusObservation: { process: 'live' } }
+      }
     })
   })
 })
@@ -159,7 +183,9 @@ describe('local status evidence boundary', () => {
 describe('open owns only its own bounded startup wait', () => {
   const client = () => new RuntimeClient('synthetic-folder', 100, null, null)
   it('does not launch or wait over an existing unobservable runtime', async () => {
-    await expect(client().openOrca(500)).rejects.toMatchObject({ code: 'runtime_unavailable' })
+    await expect(client().openOrca(500)).rejects.toMatchObject({
+      code: 'runtime_unavailable'
+    })
     expect(launchOrcaApp).not.toHaveBeenCalled()
     expect(sendRequest).toHaveBeenCalledTimes(1)
   })

--- a/src/cli/runtime/status-observation.test.ts
+++ b/src/cli/runtime/status-observation.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  RUNTIME_PROTOCOL_VERSION,
+  MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
+} from '../../shared/protocol-version'
+import { getCliStatus } from './status'
+import { resolveRemotePairing } from './runtime-remote-pairing'
+import { tryReadMetadata } from './metadata'
+import { sendRequest } from './transport'
+import { RuntimeClientError } from './types'
+import { RuntimeClient } from './client'
+import { launchOrcaApp } from './launch'
+import { formatCliError, reportCliError } from '../cli-error'
+
+vi.mock('./metadata', () => ({ tryReadMetadata: vi.fn(), getDefaultUserDataPath: vi.fn() }))
+vi.mock('./runtime-remote-pairing', () => ({ resolveRemotePairing: vi.fn() }))
+vi.mock('./transport', () => ({ sendRequest: vi.fn() }))
+vi.mock('./launch', () => ({ launchOrcaApp: vi.fn() }))
+
+const metadata = {
+  runtimeId: 'synthetic-runtime',
+  pid: 424242,
+  authToken: 'synthetic-fixture',
+  startedAt: 1,
+  transports: [{ kind: 'unix' as const, endpoint: 'synthetic-endpoint' }]
+}
+const ready = {
+  id: 'test',
+  ok: true as const,
+  _meta: { runtimeId: metadata.runtimeId },
+  result: {
+    runtimeId: metadata.runtimeId,
+    graphStatus: 'ready',
+    authoritativeWindowId: 1,
+    desktopWindowStatus: 'available'
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(resolveRemotePairing).mockReturnValue(null)
+  vi.mocked(tryReadMetadata).mockReturnValue(metadata)
+  vi.spyOn(process, 'kill').mockReturnValue(true)
+  vi.mocked(sendRequest).mockRejectedValue(new RuntimeClientError('runtime_unavailable', 'test'))
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  vi.useRealTimers()
+})
+
+describe('local status evidence boundary', () => {
+  it.each(['EPERM', 'EACCES', 'ECONNREFUSED', 'ENOENT', 'ETIMEDOUT'])(
+    '%s is observation failure, never startup',
+    async (code) => {
+      vi.mocked(sendRequest).mockRejectedValue(
+        new RuntimeClientError('runtime_unavailable', 'test', {
+          transportFailure: { outcome: 'socket_error', code }
+        })
+      )
+      await expect(getCliStatus('synthetic-folder')).rejects.toMatchObject({
+        code: 'runtime_unavailable',
+        data: {
+          statusObservation: {
+            version: 1,
+            target: 'local',
+            process: 'live',
+            startup: 'unverifiable',
+            runtime: 'unverifiable'
+          },
+          transportFailure: { code }
+        }
+      })
+    }
+  )
+  it.each(['runtime_timeout', 'invalid_runtime_response', 'runtime_unavailable'])(
+    'preserves %s code without a successful state',
+    async (code) => {
+      vi.mocked(sendRequest).mockRejectedValue(new RuntimeClientError(code, 'test'))
+      await expect(getCliStatus('synthetic-folder')).rejects.toMatchObject({ code })
+    }
+  )
+  it.each(['EPERM', 'EACCES', 'EINVAL'])('PID %s is unverifiable', async (code) => {
+    vi.mocked(process.kill).mockImplementation(() => {
+      throw Object.assign(new Error('test'), { code })
+    })
+    await expect(getCliStatus('synthetic-folder')).rejects.toMatchObject({
+      data: { statusObservation: { process: 'unverifiable' } }
+    })
+  })
+  it('positive ESRCH permits stale bootstrap', async () => {
+    vi.mocked(process.kill).mockImplementation(() => {
+      throw Object.assign(new Error('test'), { code: 'ESRCH' })
+    })
+    expect((await getCliStatus('synthetic-folder')).result).toMatchObject({
+      app: { running: false },
+      runtime: { state: 'stale_bootstrap' },
+      graph: { state: 'not_running' }
+    })
+  })
+  it.each([0, -1, Number.NaN, 1.5])('invalid PID %s cannot prove exit', async (pid) => {
+    vi.mocked(tryReadMetadata).mockReturnValue({ ...metadata, pid })
+    await expect(getCliStatus('synthetic-folder')).rejects.toMatchObject({
+      data: { statusObservation: { process: 'unverifiable' } }
+    })
+    expect(process.kill).not.toHaveBeenCalled()
+  })
+  it('incomplete bootstrap with a visible PID cannot prove exit', async () => {
+    vi.mocked(tryReadMetadata).mockReturnValue({ ...metadata, transports: [] })
+    await expect(getCliStatus('synthetic-folder')).rejects.toMatchObject({
+      data: { statusObservation: { process: 'live' } }
+    })
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+  it('RPC rejection never becomes boot progress or republishes arbitrary host data', async () => {
+    vi.mocked(sendRequest).mockResolvedValue({
+      id: 'test',
+      ok: false,
+      error: {
+        code: 'permission_denied',
+        message: 'fixture',
+        data: { privateFixture: 'do-not-copy' }
+      },
+      _meta: { runtimeId: metadata.runtimeId }
+    })
+    const error = await getCliStatus('synthetic-folder').catch((e: unknown) => e)
+    expect(error).toMatchObject({
+      code: 'permission_denied',
+      data: { statusObservation: { process: 'live' } }
+    })
+    expect(JSON.stringify(error)).not.toContain('do-not-copy')
+  })
+  it.each(['ready', 'unavailable', 'reloading'])(
+    'authenticated %s graph remains host-owned without PID probing',
+    async (graphStatus) => {
+      vi.mocked(sendRequest).mockResolvedValue({
+        ...ready,
+        result: { ...ready.result, graphStatus, desktopWindowStatus: 'initializing' }
+      })
+      expect((await getCliStatus('synthetic-folder')).result).toMatchObject({
+        runtime: { state: graphStatus === 'ready' ? 'ready' : 'graph_not_ready', reachable: true },
+        graph: { state: graphStatus },
+        app: { desktopWindowStatus: 'initializing' }
+      })
+      expect(process.kill).not.toHaveBeenCalled()
+    }
+  )
+  it('human and JSON errors retain uncertainty without launch advice', async () => {
+    const error = await getCliStatus('synthetic-folder').catch((e: unknown) => e)
+    expect(formatCliError(error)).not.toMatch(/not running|orca open|Restart Orca/)
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    reportCliError(error, true)
+    expect(JSON.parse(log.mock.calls[0][0])).toMatchObject({
+      ok: false,
+      error: { code: 'runtime_unavailable', data: { statusObservation: { process: 'live' } } }
+    })
+  })
+})
+
+describe('open owns only its own bounded startup wait', () => {
+  const client = () => new RuntimeClient('synthetic-folder', 100, null, null)
+  it('does not launch or wait over an existing unobservable runtime', async () => {
+    await expect(client().openOrca(500)).rejects.toMatchObject({ code: 'runtime_unavailable' })
+    expect(launchOrcaApp).not.toHaveBeenCalled()
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+  })
+  it('waits through observation failure after its own launch and returns positive ready evidence', async () => {
+    vi.useFakeTimers()
+    vi.mocked(tryReadMetadata).mockReturnValueOnce(null)
+    vi.mocked(sendRequest)
+      .mockRejectedValueOnce(new RuntimeClientError('runtime_unavailable', 'test'))
+      .mockResolvedValue(ready)
+    const pending = client().openOrca(1000)
+    await vi.runAllTimersAsync()
+    expect((await pending).result.runtime.state).toBe('ready')
+    expect(launchOrcaApp).toHaveBeenCalledOnce()
+  })
+  it('returns the observation failure at its finite deadline', async () => {
+    vi.useFakeTimers()
+    vi.mocked(tryReadMetadata).mockReturnValueOnce(null)
+    const pending = expect(client().openOrca(500)).rejects.toMatchObject({
+      code: 'runtime_unavailable',
+      data: { statusObservation: { startup: 'unverifiable' } }
+    })
+    await vi.runAllTimersAsync()
+    await pending
+    expect(sendRequest).toHaveBeenCalledTimes(2)
+    expect(launchOrcaApp).toHaveBeenCalledOnce()
+  })
+})
+
+describe('remote status and older optional fields', () => {
+  function remoteClient() {
+    vi.mocked(resolveRemotePairing).mockReturnValue({
+      v: 2,
+      endpoint: 'ws://synthetic.invalid',
+      publicKeyB64: 'synthetic',
+      deviceToken: 'synthetic'
+    })
+    return new RuntimeClient('synthetic-folder', 100, null, null)
+  }
+  it('uses old host window evidence without requiring new observation fields', async () => {
+    const client = remoteClient()
+    vi.spyOn(client, 'call').mockResolvedValue({
+      ...ready,
+      result: {
+        runtimeId: metadata.runtimeId,
+        graphStatus: 'ready',
+        authoritativeWindowId: 2,
+        runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+        minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+        optionalFutureField: 'ignored'
+      }
+    })
+    expect((await client.getCliStatus()).result).toMatchObject({
+      app: { running: true, pid: null, desktopWindowStatus: 'available' },
+      runtime: { state: 'ready', reachable: true }
+    })
+    expect(process.kill).not.toHaveBeenCalled()
+    expect(tryReadMetadata).not.toHaveBeenCalled()
+  })
+  it('remote contact loss rejects without local PID inference or app launch', async () => {
+    const client = remoteClient()
+    const failure = new RuntimeClientError('runtime_unavailable', 'remote observation unavailable')
+    vi.spyOn(client, 'call').mockRejectedValue(failure)
+    await expect(client.openOrca(100)).rejects.toBe(failure)
+    expect(process.kill).not.toHaveBeenCalled()
+    expect(tryReadMetadata).not.toHaveBeenCalled()
+    expect(launchOrcaApp).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/runtime/status-observation.ts
+++ b/src/cli/runtime/status-observation.ts
@@ -1,3 +1,7 @@
+import type { RuntimeMetadata } from '../../shared/runtime-bootstrap'
+import type { RuntimeStatus } from '../../shared/runtime-types'
+import { sendRequest } from './transport'
+import { validateStatusResult } from './status-result'
 import { RuntimeClientError, RuntimeRpcFailureError } from './types'
 
 export type ProcessObservation = 'live' | 'unverifiable' | 'exited'
@@ -54,4 +58,51 @@ export function isStatusObservationError(error: unknown): error is RuntimeClient
     'target' in observation &&
     observation.target === 'local'
   )
+}
+
+// A dead cached PID authorizes launch only when its endpoint also refused connection.
+function isAbsentEndpoint(error: unknown): boolean {
+  if (!(error instanceof RuntimeClientError) || error instanceof RuntimeRpcFailureError) {
+    return false
+  }
+  const data = error.data
+  if (!data || typeof data !== 'object' || !('transportFailure' in data)) {
+    return false
+  }
+  const failure = data.transportFailure
+  return (
+    !!failure &&
+    typeof failure === 'object' &&
+    'outcome' in failure &&
+    failure.outcome === 'socket_error' &&
+    'connected' in failure &&
+    failure.connected === false &&
+    'code' in failure &&
+    (failure.code === 'ENOENT' || failure.code === 'ECONNREFUSED')
+  )
+}
+
+// Only failed connection establishment can combine with cached-process exit as absence.
+export async function observeRuntimeStatus(
+  metadata: RuntimeMetadata
+): Promise<RuntimeStatus | null> {
+  let response
+  try {
+    response = await sendRequest<RuntimeStatus>(metadata, 'status.get', undefined, 1000)
+  } catch (error) {
+    const process = observeLocalProcess(metadata.pid)
+    if (process === 'exited' && isAbsentEndpoint(error)) {
+      return null
+    }
+    throw statusObservationError(process, error)
+  }
+  try {
+    if (response.ok === false) {
+      throw new RuntimeRpcFailureError(response)
+    }
+    validateStatusResult(response.result, metadata.runtimeId)
+    return response.result
+  } catch (error) {
+    throw statusObservationError(observeLocalProcess(metadata.pid), error)
+  }
 }

--- a/src/cli/runtime/status-observation.ts
+++ b/src/cli/runtime/status-observation.ts
@@ -1,0 +1,57 @@
+import { RuntimeClientError, RuntimeRpcFailureError } from './types'
+
+export type ProcessObservation = 'live' | 'unverifiable' | 'exited'
+
+export function observeLocalProcess(pid: number | null | undefined): ProcessObservation {
+  if (!Number.isSafeInteger(pid) || !pid || pid <= 0) {
+    return 'unverifiable'
+  }
+  try {
+    process.kill(pid, 0)
+    return 'live'
+  } catch (error) {
+    return (error as NodeJS.ErrnoException | null)?.code === 'ESRCH' ? 'exited' : 'unverifiable'
+  }
+}
+
+export function statusObservationError(
+  process: ProcessObservation,
+  error: unknown
+): RuntimeClientError {
+  return new RuntimeClientError(
+    error instanceof RuntimeClientError ? error.code : 'runtime_unavailable',
+    'Could not verify Orca runtime status. Process visibility does not establish startup or readiness. Check runtime access from this execution context before retrying.',
+    {
+      statusObservation: {
+        version: 1,
+        target: 'local',
+        process,
+        startup: 'unverifiable',
+        runtime: 'unverifiable',
+        ...(error instanceof RuntimeClientError ? { failure: { code: error.code } } : {})
+      },
+      ...(error instanceof RuntimeClientError &&
+      !(error instanceof RuntimeRpcFailureError) &&
+      error.data &&
+      typeof error.data === 'object' &&
+      'transportFailure' in error.data
+        ? { transportFailure: error.data.transportFailure }
+        : {})
+    }
+  )
+}
+
+export function isStatusObservationError(error: unknown): error is RuntimeClientError {
+  if (!(error instanceof RuntimeClientError) || !error.data || typeof error.data !== 'object') {
+    return false
+  }
+  const observation = 'statusObservation' in error.data ? error.data.statusObservation : null
+  return (
+    !!observation &&
+    typeof observation === 'object' &&
+    'version' in observation &&
+    observation.version === 1 &&
+    'target' in observation &&
+    observation.target === 'local'
+  )
+}

--- a/src/cli/runtime/status-result.ts
+++ b/src/cli/runtime/status-result.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+import { RuntimeClientError } from './types'
+
+// Validate projection inputs; additive host fields and open capability vocabularies survive.
+const statusResultSchema = z
+  .object({
+    runtimeId: z.string().min(1),
+    graphStatus: z.enum(['ready', 'reloading', 'unavailable']),
+    authoritativeWindowId: z.number().int().nonnegative().nullable(),
+    desktopWindowStatus: z.enum(['available', 'openable', 'initializing', 'blocked']).optional(),
+    appVersion: z.string().optional(),
+    capabilities: z.array(z.string()).optional(),
+    degradations: z
+      .array(
+        z
+          .object({
+            code: z.string(),
+            capability: z.string(),
+            message: z.string(),
+            reason: z.string().optional(),
+            detail: z.string().optional()
+          })
+          .passthrough()
+      )
+      .optional(),
+    remoteUpdateSupport: z
+      .object({
+        installMode: z.string(),
+        automatic: z.boolean(),
+        reason: z.string()
+      })
+      .passthrough()
+      .optional(),
+    remoteControl: z.object({ state: z.string() }).passthrough().nullable().optional()
+  })
+  .passthrough()
+
+export function validateStatusResult(result: unknown, runtimeId: string): void {
+  const parsed = statusResultSchema.safeParse(result)
+  if (!parsed.success) {
+    throw new RuntimeClientError(
+      'invalid_runtime_response',
+      'The Orca runtime returned invalid status data.',
+      {
+        transportFailure: { outcome: 'invalid_response' }
+      }
+    )
+  }
+  if (parsed.data.runtimeId !== runtimeId) {
+    throw new RuntimeClientError(
+      'runtime_unavailable',
+      'The Orca runtime changed while observing status.',
+      {
+        transportFailure: { outcome: 'identity_changed' }
+      }
+    )
+  }
+}

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -7,7 +7,8 @@ import {
   projectRemoteAppStatus,
   resolveDesktopWindowStatus
 } from '../../shared/cli-app-status-projection'
-import { RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
+import { RuntimeClientError, RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
+import { observeLocalProcess, statusObservationError } from './status-observation'
 
 export { projectRemoteAppStatus, resolveDesktopWindowStatus }
 
@@ -17,15 +18,20 @@ export async function getCliStatus(
   const metadata = tryReadMetadata(userDataPath)
   const transport = metadata ? findTransport(metadata, 'unix', 'named-pipe') : null
   if (!transport || !metadata?.authToken) {
+    const processObservation = metadata ? observeLocalProcess(metadata.pid) : null
+    if (processObservation && processObservation !== 'exited') {
+      throw statusObservationError(
+        processObservation,
+        new RuntimeClientError('runtime_unavailable', 'Runtime metadata is incomplete.')
+      )
+    }
     return buildCliStatusResponse({
       app: {
         running: false,
         pid: null
       },
       runtime: {
-        // Why: distinguishing "never started" from "was running but died"
-        // gives the user a better signal about what happened. If the metadata
-        // file exists, Orca was running at some point.
+        // Stale bootstrap requires positive local PID absence, not failed observation.
         state: metadata ? 'stale_bootstrap' : 'not_running',
         reachable: false,
         runtimeId: null
@@ -68,21 +74,24 @@ export async function getCliStatus(
         state: graphState
       }
     })
-  } catch {
-    const running = isProcessRunning(metadata.pid)
+  } catch (error) {
+    const processObservation = observeLocalProcess(metadata.pid)
+    if (processObservation !== 'exited') {
+      throw statusObservationError(processObservation, error)
+    }
     return buildCliStatusResponse({
       app: {
-        running,
-        pid: running ? metadata.pid : null
+        running: false,
+        pid: null
       },
       runtime: {
-        state: running ? 'starting' : 'stale_bootstrap',
+        state: 'stale_bootstrap',
         reachable: false,
         connectionState: 'disconnected',
         runtimeId: null
       },
       graph: {
-        state: running ? 'starting' : 'not_running'
+        state: 'not_running'
       }
     })
   }
@@ -96,17 +105,5 @@ function buildCliStatusResponse(result: CliStatusResult): RuntimeRpcSuccess<CliS
     _meta: {
       runtimeId: result.runtime.runtimeId ?? 'none'
     }
-  }
-}
-
-function isProcessRunning(pid: number | null | undefined): boolean {
-  if (!pid || pid <= 0) {
-    return false
-  }
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch {
-    return false
   }
 }

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -1,14 +1,17 @@
-import type { CliStatusResult, RuntimeStatus } from '../../shared/runtime-types'
+import type { CliStatusResult } from '../../shared/runtime-types'
 import { runtimeHostConnectionState } from '../../shared/runtime-host-connection-state'
 import { findTransport } from '../../shared/runtime-bootstrap'
 import { tryReadMetadata } from './metadata'
-import { sendRequest } from './transport'
 import {
   projectRemoteAppStatus,
   resolveDesktopWindowStatus
 } from '../../shared/cli-app-status-projection'
-import { RuntimeClientError, RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
-import { observeLocalProcess, statusObservationError } from './status-observation'
+import { RuntimeClientError, type RuntimeRpcSuccess } from './types'
+import {
+  observeLocalProcess,
+  statusObservationError,
+  observeRuntimeStatus
+} from './status-observation'
 
 export { projectRemoteAppStatus, resolveDesktopWindowStatus }
 
@@ -42,13 +45,10 @@ export async function getCliStatus(
     })
   }
 
-  try {
-    const response = await sendRequest<RuntimeStatus>(metadata, 'status.get', undefined, 1000)
-    if (response.ok === false) {
-      throw new RuntimeRpcFailureError(response)
-    }
-    const graphState = response.result.graphStatus
-    const desktopWindowStatus = resolveDesktopWindowStatus(response.result)
+  const status = await observeRuntimeStatus(metadata)
+  if (status) {
+    const graphState = status.graphStatus
+    const desktopWindowStatus = resolveDesktopWindowStatus(status)
     return buildCliStatusResponse({
       app: {
         running: true,
@@ -60,41 +60,34 @@ export async function getCliStatus(
         reachable: true,
         connectionState: runtimeHostConnectionState({
           hasStatusEntry: true,
-          status: response.result
+          status: status
         }),
-        runtimeId: response.result.runtimeId,
-        ...(response.result.appVersion ? { appVersion: response.result.appVersion } : {}),
-        ...(response.result.remoteUpdateSupport
-          ? { remoteUpdateSupport: response.result.remoteUpdateSupport }
-          : {}),
-        ...(response.result.capabilities ? { capabilities: response.result.capabilities } : {}),
-        ...(response.result.degradations ? { degradations: response.result.degradations } : {})
+        runtimeId: status.runtimeId,
+        ...(status.appVersion ? { appVersion: status.appVersion } : {}),
+        ...(status.remoteUpdateSupport ? { remoteUpdateSupport: status.remoteUpdateSupport } : {}),
+        ...(status.capabilities ? { capabilities: status.capabilities } : {}),
+        ...(status.degradations ? { degradations: status.degradations } : {})
       },
       graph: {
         state: graphState
       }
     })
-  } catch (error) {
-    const processObservation = observeLocalProcess(metadata.pid)
-    if (processObservation !== 'exited') {
-      throw statusObservationError(processObservation, error)
-    }
-    return buildCliStatusResponse({
-      app: {
-        running: false,
-        pid: null
-      },
-      runtime: {
-        state: 'stale_bootstrap',
-        reachable: false,
-        connectionState: 'disconnected',
-        runtimeId: null
-      },
-      graph: {
-        state: 'not_running'
-      }
-    })
   }
+  return buildCliStatusResponse({
+    app: {
+      running: false,
+      pid: null
+    },
+    runtime: {
+      state: 'stale_bootstrap',
+      reachable: false,
+      connectionState: 'disconnected',
+      runtimeId: null
+    },
+    graph: {
+      state: 'not_running'
+    }
+  })
 }
 
 function buildCliStatusResponse(result: CliStatusResult): RuntimeRpcSuccess<CliStatusResult> {

--- a/src/cli/runtime/transport-failure.test.ts
+++ b/src/cli/runtime/transport-failure.test.ts
@@ -48,7 +48,13 @@ describe('transport failure capture', () => {
       expect(error).toMatchObject({
         code: 'runtime_unavailable',
         data: {
-          transportFailure: { outcome: 'socket_error', code, errno: -4048, syscall: 'connect' }
+          transportFailure: {
+            outcome: 'socket_error',
+            code,
+            errno: -4048,
+            syscall: 'connect',
+            connected: false
+          }
         }
       })
       expect(JSON.stringify(error)).not.toContain('private-fixture')
@@ -56,6 +62,14 @@ describe('transport failure capture', () => {
       expect(socket.end).toHaveBeenCalledOnce()
     }
   )
+  it('records connection establishment before a later socket error', async () => {
+    const pending = sendRequest(metadata, 'status.get', undefined, 1000)
+    socket.emit('connect')
+    socket.emit('error', { code: 'ECONNREFUSED' })
+    await expect(pending).rejects.toMatchObject({
+      data: { transportFailure: { outcome: 'socket_error', connected: true } }
+    })
+  })
   it('rejects arbitrary diagnostic text', async () => {
     const pending = sendRequest(metadata, 'status.get', undefined, 1000)
     socket.emit('error', {

--- a/src/cli/runtime/transport-failure.test.ts
+++ b/src/cli/runtime/transport-failure.test.ts
@@ -1,0 +1,125 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendRequest } from './transport'
+import { formatCliError } from '../cli-error'
+
+const { createConnection } = vi.hoisted(() => ({ createConnection: vi.fn() }))
+vi.mock('node:net', () => ({ createConnection }))
+vi.mock('node:crypto', () => ({ randomUUID: () => 'request-1' }))
+const metadata = {
+  runtimeId: 'runtime-1',
+  pid: 42,
+  startedAt: 1,
+  authToken: 'synthetic-fixture',
+  transports: [{ kind: 'named-pipe' as const, endpoint: 'synthetic-endpoint' }]
+}
+class TestSocket extends EventEmitter {
+  setEncoding = vi.fn()
+  write = vi.fn()
+  end = vi.fn()
+  destroy = vi.fn()
+}
+let socket: TestSocket
+beforeEach(() => {
+  socket = new TestSocket()
+  createConnection.mockReturnValue(socket)
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('transport failure capture', () => {
+  it.each(['EPERM', 'EACCES', 'ECONNREFUSED', 'ENOENT'])(
+    'retains native %s without endpoint or message',
+    async (code) => {
+      const pending = sendRequest(metadata, 'status.get', undefined, 1000)
+      socket.emit(
+        'error',
+        Object.assign(new Error('private-fixture'), {
+          code,
+          errno: -4048,
+          syscall: 'connect',
+          address: 'private-fixture',
+          path: 'private-fixture'
+        })
+      )
+      const error = await pending.catch((e: unknown) => e)
+      expect(error).toMatchObject({
+        code: 'runtime_unavailable',
+        data: {
+          transportFailure: { outcome: 'socket_error', code, errno: -4048, syscall: 'connect' }
+        }
+      })
+      expect(JSON.stringify(error)).not.toContain('private-fixture')
+      expect(formatCliError(error)).not.toMatch(/not running|orca open|Restart Orca/)
+      expect(socket.end).toHaveBeenCalledOnce()
+    }
+  )
+  it('rejects arbitrary diagnostic text', async () => {
+    const pending = sendRequest(metadata, 'status.get', undefined, 1000)
+    socket.emit('error', {
+      code: 'sensitive/path',
+      errno: 'sensitive-value',
+      syscall: 'connect sensitive/path'
+    })
+    await expect(pending).rejects.toMatchObject({
+      data: { transportFailure: { outcome: 'socket_error' } }
+    })
+    const error = await pending.catch((e: unknown) => e)
+    expect(JSON.stringify(error)).not.toContain('sensitive')
+  })
+  it('captures early close before the deadline', async () => {
+    const pending = sendRequest(metadata, 'status.get', undefined, 1000)
+    socket.emit('close')
+    await expect(pending).rejects.toMatchObject({
+      code: 'runtime_unavailable',
+      data: { transportFailure: { outcome: 'closed' } }
+    })
+  })
+  it('captures a finite timeout and destroys its socket', async () => {
+    vi.useFakeTimers()
+    const pending = expect(
+      sendRequest(metadata, 'status.get', undefined, 20)
+    ).rejects.toMatchObject({
+      code: 'runtime_timeout',
+      data: { transportFailure: { outcome: 'timeout' } }
+    })
+    await vi.advanceTimersByTimeAsync(20)
+    await pending
+    expect(socket.destroy).toHaveBeenCalledOnce()
+  })
+  it.each([
+    'invalid-json\n',
+    '{}\n',
+    `${JSON.stringify({
+      id: 'wrong-id',
+      ok: true,
+      result: {},
+      _meta: { runtimeId: 'runtime-1' }
+    })}\n`
+  ])('captures invalid frame %s', async (frame) => {
+    const pending = sendRequest(metadata, 'status.get', undefined, 1000)
+    socket.emit('data', frame)
+    await expect(pending).rejects.toMatchObject({
+      code: 'invalid_runtime_response',
+      data: { transportFailure: { outcome: 'invalid_response' } }
+    })
+  })
+  it('rejects a reused endpoint with a different runtime identity', async () => {
+    const pending = sendRequest(metadata, 'status.get', undefined, 1000)
+    socket.emit(
+      'data',
+      `${JSON.stringify({
+        id: 'request-1',
+        ok: true,
+        result: {},
+        _meta: { runtimeId: 'runtime-new' }
+      })}\n`
+    )
+    await expect(pending).rejects.toMatchObject({
+      code: 'runtime_unavailable',
+      data: { transportFailure: { outcome: 'identity_changed' } }
+    })
+  })
+})

--- a/src/cli/runtime/transport-failure.ts
+++ b/src/cli/runtime/transport-failure.ts
@@ -1,5 +1,6 @@
 export type TransportFailure = {
   outcome: 'socket_error' | 'timeout' | 'closed' | 'invalid_response' | 'identity_changed'
+  connected?: boolean
   code?: string
   errno?: number
   syscall?: string

--- a/src/cli/runtime/transport-failure.ts
+++ b/src/cli/runtime/transport-failure.ts
@@ -1,0 +1,21 @@
+export type TransportFailure = {
+  outcome: 'socket_error' | 'timeout' | 'closed' | 'invalid_response' | 'identity_changed'
+  code?: string
+  errno?: number
+  syscall?: string
+}
+
+/** Capture only native diagnostic fields; messages and endpoints may contain secrets. */
+export function socketFailure(error: NodeJS.ErrnoException): TransportFailure {
+  const code =
+    typeof error.code === 'string' && /^E[A-Z0-9_]{1,40}$/.test(error.code) ? error.code : undefined
+  const syscall = ['connect', 'read', 'write', 'pipe'].includes(error.syscall ?? '')
+    ? error.syscall
+    : undefined
+  return {
+    outcome: 'socket_error',
+    ...(code ? { code } : {}),
+    ...(Number.isSafeInteger(error.errno) ? { errno: error.errno } : {}),
+    ...(syscall ? { syscall } : {})
+  }
+}

--- a/src/cli/runtime/transport.test.ts
+++ b/src/cli/runtime/transport.test.ts
@@ -133,8 +133,7 @@ describe.skipIf(process.platform === 'win32')('runtime transport', () => {
     const start = Date.now()
     await expect(sendRequest(metadata, 'status.get', undefined, 60000)).rejects.toMatchObject({
       code: 'runtime_unavailable',
-      message:
-        'The Orca runtime closed the connection before responding. Restart Orca and try again.'
+      message: 'The Orca runtime closed the connection before responding.'
     })
     expect(Date.now() - start).toBeLessThan(5000)
   })

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -1,4 +1,5 @@
 import { createConnection } from 'node:net'
+import { socketFailure } from './transport-failure'
 import { randomUUID } from 'node:crypto'
 import { findTransport, type RuntimeMetadata } from '../../shared/runtime-bootstrap'
 import type { RuntimeOrchestrationEnvelope } from '../../shared/runtime-rpc-envelope'
@@ -45,7 +46,8 @@ export async function sendRequest<TResult>(
       reject(
         new RuntimeClientError(
           'runtime_timeout',
-          'Timed out waiting for the Orca runtime to respond.'
+          'Timed out waiting for the Orca runtime to respond.',
+          { transportFailure: { outcome: 'timeout' } }
         )
       )
     }, timeoutMs)
@@ -68,12 +70,13 @@ export async function sendRequest<TResult>(
     }
 
     socket.setEncoding('utf8')
-    socket.once('error', () => {
+    socket.once('error', (error) => {
       finish({
         ok: false,
         error: new RuntimeClientError(
           'runtime_unavailable',
-          'Could not connect to the running Orca app. Restart Orca and try again.'
+          'Could not communicate with the Orca runtime. Check runtime access from this execution context.',
+          { transportFailure: socketFailure(error) }
         )
       })
     })
@@ -86,7 +89,8 @@ export async function sendRequest<TResult>(
         ok: false,
         error: new RuntimeClientError(
           'runtime_unavailable',
-          'The Orca runtime closed the connection before responding. Restart Orca and try again.'
+          'The Orca runtime closed the connection before responding.',
+          { transportFailure: { outcome: 'closed' } }
         )
       })
     })
@@ -123,7 +127,8 @@ export async function sendRequest<TResult>(
             ok: false,
             error: new RuntimeClientError(
               'invalid_runtime_response',
-              'The Orca runtime returned an invalid response frame.'
+              'The Orca runtime returned an invalid response frame.',
+              { transportFailure: { outcome: 'invalid_response' } }
             )
           })
           return
@@ -149,7 +154,8 @@ export async function sendRequest<TResult>(
             ok: false,
             error: new RuntimeClientError(
               'invalid_runtime_response',
-              'The Orca runtime returned an invalid response frame.'
+              'The Orca runtime returned an invalid response frame.',
+              { transportFailure: { outcome: 'invalid_response' } }
             )
           })
           return
@@ -169,7 +175,8 @@ export async function sendRequest<TResult>(
             ok: false,
             error: new RuntimeClientError(
               'invalid_runtime_response',
-              'The Orca runtime returned a mismatched response id.'
+              'The Orca runtime returned a mismatched response id.',
+              { transportFailure: { outcome: 'invalid_response' } }
             )
           })
           return
@@ -179,7 +186,8 @@ export async function sendRequest<TResult>(
             ok: false,
             error: new RuntimeClientError(
               'runtime_unavailable',
-              'The Orca runtime changed while the request was in flight. Retry the command.'
+              'The Orca runtime changed while the request was in flight. Retry the command.',
+              { transportFailure: { outcome: 'identity_changed' } }
             )
           })
           return

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -34,6 +34,7 @@ export async function sendRequest<TResult>(
     const socket = createConnection(transport.endpoint)
     let lineSegments: string[] = []
     let settled = false
+    let connected = false
     const requestId = randomUUID()
 
     const timeout = setTimeout(() => {
@@ -76,7 +77,7 @@ export async function sendRequest<TResult>(
         error: new RuntimeClientError(
           'runtime_unavailable',
           'Could not communicate with the Orca runtime. Check runtime access from this execution context.',
-          { transportFailure: socketFailure(error) }
+          { transportFailure: { ...socketFailure(error), connected } }
         )
       })
     })
@@ -197,6 +198,7 @@ export async function sendRequest<TResult>(
       }
     })
     socket.on('connect', () => {
+      connected = true
       socket.write(
         `${JSON.stringify({
           id: requestId,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​582 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​578 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​284 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​63 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​221 |

<!-- /orca-pr-loc -->

## ELI5

When the CLI cannot observe Orca, a visible PID does not prove startup progress, and a dead cached PID does not prove a responding replacement runtime is absent. Status now reports those observation failures instead of presenting false STARTING or authorizing another launch.

## What Changed

- Keep local process visibility (`live` / `unverifiable` / `exited`) separate from runtime readiness. Preserve the existing failure envelope and optional versioned `statusObservation`; no new success enum.
- Centralize connected-runtime observation in `observeRuntimeStatus`. Only a socket that never connected and failed with ENOENT/ECONNREFUSED can combine with cached-PID ESRCH to project stale bootstrap. Response identity changes, RPC denials, timeout, early close and invalid responses remain failures even when the cached PID exited.
- Validate the status projection inputs before publishing readiness: runtime identity, graph state, window identity and optional fields consumed by the projection. Require the result identity to match discovery. Retain unknown additive fields, open capability/degradation vocabulary, and the legacy window fallback.
- Preserve missing-discovery behavior and the existing incomplete-bootstrap process check. `open` propagates failed observations before launch; after its own authorized launch it polls for verifiable readiness within the existing deadline loop.

## Why

The former broad catch let cached-process exit override endpoint evidence. The observation owner now separates connection establishment failures from response validation, so a responding peer's failure cannot become stale bootstrap. Status projection consumes validated evidence rather than interpreting transport failure as readiness.

This intentionally changes unverifiable CLI status from success to failure. Remote execution stays host-owned; there is no host publication, RPC opcode, Git/provider or desktop permission change. Optional error diagnostics are additive for mixed-version readers.

## Linked Issue

Related classification portion only: [STA-3813](https://linear.app/stably/issue/STA-3813) and [STA-3969](https://linear.app/stably/issue/STA-3969). This does not resolve native pipe permissions, sandbox/provider access, pre-IPC executable access, or blocked lifecycle delivery.

## Visual Proof

N/A — CLI-only change; no rendered UI changed. A live PID with denied IPC produces `ok: false` with observation uncertainty. A replacement runtime plus cached-PID ESRCH also fails, and `open` never reaches the launch sentinel in that case.

## Testing

Current correction at `26e5cf4a9723648921bfd5f33dc91d576c4816b1`, author validation:

- 126 tests passed, zero failed, across 9 focused status/transport/consumer files with `--config config/vitest.config.ts`.
- 23 finite bundled CLI cases passed, including real Unix socket replies and synthetic permission/PID errors. Replacement identity, RPC denial and malformed status fail; missing discovery and exited-PID/absent-endpoint controls reach a blocked launch sentinel. No app was launched.
- The independent review's three exact-source failing assertions now pass with the updated module dependencies.
- Sequential `npx tsc --noEmit` node, web and CLI projects passed without heap retries. Changed-file oxlint and diff whitespace checks passed after fixing three style findings.
- Committed before ablation: restoring the old status owner caused 21 failures / 30 passes. `cp` restoration, `cmp`, and a nonempty source check confirmed restoration; the same two files then passed 51/51.

No native Windows sandbox/named-pipe, WSL, live SSH, two-release wire, provider, packaged startup or rendered UI validation was performed. The startup deadline loop assumes each awaited status call settles; keepalive refresh is unchanged and is not a hard per-call wall-clock guarantee. Full lint/test/build suites remain for CI.

## Review

Independent review found two P2 architectural gaps at `56426d348ae0209dbb62b03d4546aa589a0c4dfe`: cached-PID exit overriding endpoint evidence and unchecked status results becoming successful observations. This correction addresses both with regression and positive controls. Fresh independent review of `26e5cf4a9723648921bfd5f33dc91d576c4816b1` is pending; the PR remains draft and has no CLEAN or merge-readiness endorsement.

## Agent skill upstream boundary

- [x] Not applicable; no skill installer code changed.

## Notes

Folder workspaces require no Git discovery; GitLab and other providers are unaffected. Base remains pinned at `66420537b7d12d3e64c2d0c494ba690b2fb827b9`; no moving-main readiness claim, merge or rebase.
