### PR TITLE
Paste an OS-copied file into the terminal as its full shell-escaped path

### DIFF
--- a/src/main/window/clipboard-file-paths-read.test.ts
+++ b/src/main/window/clipboard-file-paths-read.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  GNOME_COPIED_FILES_FORMAT,
+  MACOS_FILENAMES_FORMAT,
+  MACOS_FILE_URL_FORMAT,
+  URI_LIST_FORMAT,
+  WINDOWS_FILE_NAME_FORMAT,
+  readClipboardFilePaths,
+  type ClipboardFilePathsDeps
+} from './clipboard-file-paths-read'
+
+function makeDeps(
+  platform: NodeJS.Platform,
+  clipboard: Record<string, string | Buffer>
+): ClipboardFilePathsDeps {
+  return {
+    platform,
+    read: (format) => {
+      const value = clipboard[format]
+      return typeof value === 'string' ? value : ''
+    },
+    readBuffer: (format) => {
+      const value = clipboard[format]
+      if (value === undefined) {
+        return Buffer.alloc(0)
+      }
+      return Buffer.isBuffer(value) ? value : Buffer.from(value, 'utf8')
+    }
+  }
+}
+
+const FINDER_PROPERTY_LIST = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<array>
+\t<string>/Users/me/project/App.tsx</string>
+\t<string>/Users/me/notes/spec.md</string>
+</array>
+</plist>`
+
+describe('readClipboardFilePaths', () => {
+  it('reads every file of a macOS multi-file copy from the filenames list', () => {
+    // Matches a real Finder copy: the filenames list carries the POSIX paths
+    // while public.file-url carries only an inode reference to the first item.
+    const paths = readClipboardFilePaths(
+      makeDeps('darwin', {
+        [MACOS_FILENAMES_FORMAT]: FINDER_PROPERTY_LIST,
+        [MACOS_FILE_URL_FORMAT]: 'file:///.file/id=6571367.71479400'
+      })
+    )
+    expect(paths).toEqual(['/Users/me/project/App.tsx', '/Users/me/notes/spec.md'])
+  })
+
+  it('pastes nothing rather than an unusable macOS file reference URL', () => {
+    expect(
+      readClipboardFilePaths(
+        makeDeps('darwin', { [MACOS_FILE_URL_FORMAT]: 'file:///.file/id=6571367.71479400' })
+      )
+    ).toEqual([])
+  })
+
+  it('falls back to the macOS file-url flavor when no filenames list is present', () => {
+    const paths = readClipboardFilePaths(
+      makeDeps('darwin', {
+        [MACOS_FILE_URL_FORMAT]: 'file:///Users/me/project/My%20App.tsx'
+      })
+    )
+    expect(paths).toEqual(['/Users/me/project/My App.tsx'])
+  })
+
+  it('reads a macOS flavor that only answers as a buffer', () => {
+    const paths = readClipboardFilePaths({
+      platform: 'darwin',
+      read: () => '',
+      readBuffer: (format) =>
+        format === MACOS_FILE_URL_FORMAT
+          ? Buffer.from('file:///Users/me/project/App.tsx', 'utf8')
+          : Buffer.alloc(0)
+    })
+    expect(paths).toEqual(['/Users/me/project/App.tsx'])
+  })
+
+  it('reads the Windows Explorer file name flavor as UTF-16', () => {
+    const paths = readClipboardFilePaths(
+      makeDeps('win32', {
+        [WINDOWS_FILE_NAME_FORMAT]: Buffer.from(
+          'C:\\Users\\Name\\My Project\\file.txt\0',
+          'utf16le'
+        )
+      })
+    )
+    expect(paths).toEqual(['C:\\Users\\Name\\My Project\\file.txt'])
+  })
+
+  it('prefers the GNOME copied-files payload on Linux', () => {
+    const paths = readClipboardFilePaths(
+      makeDeps('linux', {
+        [GNOME_COPIED_FILES_FORMAT]: 'copy\nfile:///home/me/a.txt\nfile:///home/me/b.txt',
+        [URI_LIST_FORMAT]: 'file:///home/me/stale.txt'
+      })
+    )
+    expect(paths).toEqual(['/home/me/a.txt', '/home/me/b.txt'])
+  })
+
+  it('falls back to text/uri-list for KDE file managers', () => {
+    const paths = readClipboardFilePaths(
+      makeDeps('linux', { [URI_LIST_FORMAT]: 'file:///home/me/a.txt\r\n' })
+    )
+    expect(paths).toEqual(['/home/me/a.txt'])
+  })
+
+  it('returns nothing for a text-only clipboard', () => {
+    expect(readClipboardFilePaths(makeDeps('darwin', { 'text/plain': 'deploy now' }))).toEqual([])
+    expect(readClipboardFilePaths(makeDeps('win32', { 'text/plain': 'deploy now' }))).toEqual([])
+    expect(readClipboardFilePaths(makeDeps('linux', { 'text/plain': 'deploy now' }))).toEqual([])
+  })
+
+  it('survives a clipboard read that throws', () => {
+    const readBuffer = vi.fn(() => {
+      throw new Error('clipboard busy')
+    })
+    expect(
+      readClipboardFilePaths({
+        platform: 'darwin',
+        read: () => {
+          throw new Error('clipboard busy')
+        },
+        readBuffer
+      })
+    ).toEqual([])
+    expect(readBuffer).toHaveBeenCalled()
+  })
+})

--- a/src/main/window/clipboard-file-paths-read.ts
+++ b/src/main/window/clipboard-file-paths-read.ts
@@ -1,0 +1,87 @@
+import {
+  CLIPBOARD_FILE_PATH_MAX_ENTRIES,
+  parseClipboardFileUriList,
+  parseMacOsFilenamesPropertyList
+} from '../../shared/clipboard-file-paths'
+import { isRuntimePathAbsolute } from '../../shared/cross-platform-path'
+
+export const MACOS_FILENAMES_FORMAT = 'NSFilenamesPboardType'
+export const MACOS_FILE_URL_FORMAT = 'public.file-url'
+export const WINDOWS_FILE_NAME_FORMAT = 'FileNameW'
+export const GNOME_COPIED_FILES_FORMAT = 'x-special/gnome-copied-files'
+export const URI_LIST_FORMAT = 'text/uri-list'
+
+// Injected so the platform branching is unit-testable without the real OS
+// clipboard, matching clipboard-file-copy.ts.
+export type ClipboardFilePathsDeps = {
+  platform: NodeJS.Platform
+  read: (format: string) => string
+  readBuffer: (format: string) => Buffer
+}
+
+// Why: the flavors are read by their native names rather than filtered through
+// `availableFormats()`, which reports Chromium's normalized MIME names — a
+// macOS file copy advertises only `text/uri-list`, whose read is empty.
+function readText(deps: ClipboardFilePathsDeps, format: string): string {
+  try {
+    const text = deps.read(format)
+    if (text) {
+      return text
+    }
+  } catch {
+    // Fall through to the buffer flavor.
+  }
+  try {
+    return deps.readBuffer(format).toString('utf8')
+  } catch {
+    return ''
+  }
+}
+
+function readDarwinFilePaths(deps: ClipboardFilePathsDeps): string[] {
+  // The legacy filenames list is the only flavor that carries every file of a
+  // multi-file Finder copy; `public.file-url` exposes just the first item.
+  const listedPaths = parseMacOsFilenamesPropertyList(readText(deps, MACOS_FILENAMES_FORMAT))
+  if (listedPaths.length > 0) {
+    return listedPaths
+  }
+  return parseClipboardFileUriList(readText(deps, MACOS_FILE_URL_FORMAT))
+}
+
+function readWin32FilePaths(deps: ClipboardFilePathsDeps): string[] {
+  // Why: Electron exposes no CF_HDROP reader, so Explorer's compatibility
+  // FileNameW flavor is the only path available — it carries the first file.
+  let decoded: string
+  try {
+    decoded = deps.readBuffer(WINDOWS_FILE_NAME_FORMAT).toString('utf16le')
+  } catch {
+    return []
+  }
+  const path = decoded.split('\0')[0]?.trim() ?? ''
+  return path && isRuntimePathAbsolute(path, 'windows') ? [path] : []
+}
+
+function readLinuxFilePaths(deps: ClipboardFilePathsDeps): string[] {
+  // GNOME-family managers carry the copy/cut verb line; KDE writes a bare list.
+  for (const format of [GNOME_COPIED_FILES_FORMAT, URI_LIST_FORMAT]) {
+    const paths = parseClipboardFileUriList(readText(deps, format))
+    if (paths.length > 0) {
+      return paths
+    }
+  }
+  return []
+}
+
+/**
+ * Read the file entries an OS file manager put on the clipboard, as absolute
+ * client-local paths. Returns an empty list when the clipboard holds no files.
+ */
+export function readClipboardFilePaths(deps: ClipboardFilePathsDeps): string[] {
+  const paths =
+    deps.platform === 'darwin'
+      ? readDarwinFilePaths(deps)
+      : deps.platform === 'win32'
+        ? readWin32FilePaths(deps)
+        : readLinuxFilePaths(deps)
+  return paths.slice(0, CLIPBOARD_FILE_PATH_MAX_ENTRIES)
+}

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -31,6 +31,7 @@ import {
   type ClipboardFileDeps,
   type ClipboardFileResult
 } from './clipboard-file-copy'
+import { readClipboardFilePaths, type ClipboardFilePathsDeps } from './clipboard-file-paths-read'
 import {
   cleanupExpiredRemoteClipboardFiles,
   scheduleLegacyRemoteClipboardFileCleanup,
@@ -86,6 +87,7 @@ export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:writeSelectionText')
   ipcMain.removeHandler('clipboard:writeImage')
   ipcMain.removeHandler('clipboard:writeFile')
+  ipcMain.removeHandler('clipboard:readFilePaths')
   ipcMain.removeHandler('clipboard:saveImageAsTempFile')
   ipcMain.removeHandler('clipboard:readImageThumbnail')
 
@@ -137,6 +139,12 @@ export function registerClipboardHandlers(store: Store): void {
       return saveClipboardImageBufferForTarget(image.toPNG(), args)
     }
   )
+  // Why: a file copied in Finder/Explorer reaches the text flavor as its
+  // display name only, so pasting it into a terminal needs the file flavors.
+  ipcMain.handle('clipboard:readFilePaths', (event): string[] => {
+    assertTrustedClipboardSender(event)
+    return readClipboardFilePaths(makeClipboardFilePathsDeps())
+  })
   // Why: copy the actual file to the OS clipboard so pasting in Finder/Explorer
   // drops the file itself, not its path as text.
   ipcMain.handle(
@@ -249,6 +257,14 @@ function makeClipboardFileDeps(
     resolveFilePath,
     writeBuffer: (format, buffer) => clipboard.writeBuffer(format, buffer),
     runCommand
+  }
+}
+
+function makeClipboardFilePathsDeps(): ClipboardFilePathsDeps {
+  return {
+    platform: process.platform,
+    read: (format) => clipboard.read(format),
+    readBuffer: (format) => clipboard.readBuffer(format)
   }
 }
 

--- a/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
+++ b/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
@@ -96,6 +96,7 @@ export const uiClipboardAndWindowControlsApi = {
   }): Promise<string | null> => ipcRenderer.invoke('clipboard:saveImageAsTempFile', args),
   readClipboardImageThumbnail: (): Promise<ClipboardImageThumbnail | null> =>
     ipcRenderer.invoke('clipboard:readImageThumbnail'),
+  readClipboardFilePaths: (): Promise<string[]> => ipcRenderer.invoke('clipboard:readFilePaths'),
   writeClipboardText: (text: string): Promise<void> =>
     ipcRenderer.invoke('clipboard:writeText', text),
   writeTerminalClipboardText: (text: string): Promise<void> =>

--- a/src/preload/api/ui-window-api.ts
+++ b/src/preload/api/ui-window-api.ts
@@ -14,6 +14,7 @@ export type UiWindowApi = {
     runtimeEnvironmentId?: string | null
   }) => Promise<string | null>
   readClipboardImageThumbnail: () => Promise<ClipboardImageThumbnail | null>
+  readClipboardFilePaths: () => Promise<string[]>
   writeClipboardText: (text: string) => Promise<void>
   writeTerminalClipboardText: (text: string) => Promise<void>
   writeSelectionClipboardText: (text: string) => Promise<void>

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.ts
@@ -1,0 +1,42 @@
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+import { handleNativeTerminalFileDrop } from './terminal-native-file-drop'
+
+export type PasteClipboardFilePathsArgs = {
+  manager: PaneManager | null
+  paneTransports: Map<number, PtyTransport>
+  worktreeId: string
+  tabId: string
+  cwd: string | undefined
+  paneLeafId: string
+  paths: string[]
+}
+
+/**
+ * Paste files copied in an OS file manager into a terminal pane by reusing the
+ * native drop pipeline, so a pasted file behaves exactly like a dropped one:
+ * local paths stay in place, SSH and runtime worktrees upload into
+ * `.orca/drops` first, and every path lands shell-escaped for the target shell.
+ */
+export async function pasteClipboardFilePathsIntoTerminal({
+  manager,
+  paneTransports,
+  worktreeId,
+  tabId,
+  cwd,
+  paneLeafId,
+  paths
+}: PasteClipboardFilePathsArgs): Promise<boolean> {
+  if (!manager || paths.length === 0) {
+    return false
+  }
+  await handleNativeTerminalFileDrop({
+    manager,
+    paneTransports,
+    worktreeId,
+    tabId,
+    cwd,
+    data: { paths, target: 'terminal', paneLeafId }
+  })
+  return true
+}

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -389,3 +389,153 @@ describe('terminal clipboard paste', () => {
     expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
   })
 })
+
+describe('terminal clipboard file paste', () => {
+  it('pastes the full paths of a file copied in the OS file manager, not its display name', async () => {
+    const pasteText = vi.fn()
+    const pasteFilePaths = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('App.tsx'),
+      readClipboardFilePaths: vi.fn().mockResolvedValue(['/Users/me/project/src/App.tsx']),
+      pasteFilePaths,
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText
+    })
+
+    expect(pasteFilePaths).toHaveBeenCalledWith(['/Users/me/project/src/App.tsx'])
+    expect(pasteText).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'pasted', kind: 'file-path' })
+  })
+
+  it('pastes every path of a multi-file copy', async () => {
+    const pasteFilePaths = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('App.tsx\nspec.md'),
+      readClipboardFilePaths: vi
+        .fn()
+        .mockResolvedValue(['/Users/me/project/App.tsx', '/Users/me/notes/spec.md']),
+      pasteFilePaths,
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText: vi.fn()
+    })
+
+    expect(pasteFilePaths).toHaveBeenCalledWith([
+      '/Users/me/project/App.tsx',
+      '/Users/me/notes/spec.md'
+    ])
+  })
+
+  it('keeps path-shaped text pastes off the clipboard file probe', async () => {
+    const readClipboardFilePaths = vi.fn()
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('cd /Users/me/project && pnpm test'),
+      readClipboardFilePaths,
+      pasteFilePaths: vi.fn(),
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText
+    })
+
+    expect(readClipboardFilePaths).not.toHaveBeenCalled()
+    expect(pasteText).toHaveBeenCalledWith('cd /Users/me/project && pnpm test')
+  })
+
+  it('pastes text when the file probe answers without a path list', async () => {
+    const pasteFilePaths = vi.fn()
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('git status'),
+      readClipboardFilePaths: vi.fn().mockResolvedValue(undefined),
+      pasteFilePaths,
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText
+    })
+
+    expect(pasteFilePaths).not.toHaveBeenCalled()
+    expect(pasteText).toHaveBeenCalledWith('git status')
+  })
+
+  it('keeps copied text that only looks like a file name', async () => {
+    const pasteFilePaths = vi.fn()
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('README.md'),
+      readClipboardFilePaths: vi.fn().mockResolvedValue([]),
+      pasteFilePaths,
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText
+    })
+
+    expect(pasteFilePaths).not.toHaveBeenCalled()
+    expect(pasteText).toHaveBeenCalledWith('README.md')
+  })
+
+  it('keeps the text when the clipboard carries files plus unrelated text', async () => {
+    const pasteFilePaths = vi.fn()
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('deploy now'),
+      readClipboardFilePaths: vi.fn().mockResolvedValue(['/Users/me/project/App.tsx']),
+      pasteFilePaths,
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText
+    })
+
+    expect(pasteFilePaths).not.toHaveBeenCalled()
+    expect(pasteText).toHaveBeenCalledWith('deploy now')
+  })
+
+  it('falls back to the clipboard image path when the file probe fails', async () => {
+    const pasteText = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      readClipboardFilePaths: vi.fn().mockRejectedValue(new Error('clipboard busy')),
+      pasteFilePaths: vi.fn(),
+      saveClipboardImageAsTempFile: vi.fn().mockResolvedValue('/tmp/orca-paste-1-id.png'),
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1-id.png', {
+      forceBracketedPaste: true,
+      recoverImagePasteWebglAtlas: true
+    })
+    expect(result).toEqual({ status: 'pasted', kind: 'image-path' })
+  })
+
+  it('reports a rejected file paste instead of silently pasting the display name', async () => {
+    const pasteText = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('App.tsx'),
+      readClipboardFilePaths: vi.fn().mockResolvedValue(['/Users/me/project/App.tsx']),
+      pasteFilePaths: vi.fn().mockResolvedValue(false),
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText
+    })
+
+    expect(pasteText).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'skipped', reason: 'file-paste-rejected' })
+  })
+
+  it('leaves paste unchanged when the file-path route is not wired', async () => {
+    const readClipboardFilePaths = vi.fn()
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('App.tsx'),
+      readClipboardFilePaths,
+      saveClipboardImageAsTempFile: vi.fn(),
+      pasteText
+    })
+
+    expect(readClipboardFilePaths).not.toHaveBeenCalled()
+    expect(pasteText).toHaveBeenCalledWith('App.tsx')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -3,6 +3,10 @@ import {
   type ReadClipboardTextOptions
 } from '../../../../shared/clipboard-text'
 import {
+  clipboardTextIsCopiedFileNames,
+  couldClipboardTextBeCopiedFileNames
+} from '../../../../shared/clipboard-file-paths'
+import {
   TERMINAL_PASTE_MAX_BYTES,
   type TerminalPasteTextOptions
 } from './terminal-paste-coordinator'
@@ -14,6 +18,8 @@ type SaveClipboardImageAsTempFile = (args?: {
 
 type PasteTerminalClipboardDeps = {
   readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
+  readClipboardFilePaths?: () => Promise<string[]>
+  pasteFilePaths?: (paths: string[]) => Promise<boolean | void> | boolean | void
   saveClipboardImageAsTempFile: SaveClipboardImageAsTempFile
   pasteText: (
     text: string,
@@ -28,11 +34,12 @@ type PasteTerminalClipboardDeps = {
 }
 
 export type TerminalClipboardPasteResult =
-  | { status: 'pasted'; kind: 'image-path' | 'text' }
+  | { status: 'pasted'; kind: 'file-path' | 'image-path' | 'text' }
   | {
       status: 'skipped'
       reason:
         | 'empty'
+        | 'file-paste-rejected'
         | 'image-paste-failed'
         | 'image-paste-rejected'
         | 'text-paste-failed'
@@ -40,8 +47,35 @@ export type TerminalClipboardPasteResult =
         | 'text-too-large'
     }
 
+/**
+ * Resolve the files an OS file manager copied, but only for clipboard text that
+ * could be their display names — every other paste skips the extra IPC round
+ * trip. Returns an empty list when the clipboard carries real text or no files.
+ */
+async function readCopiedFilePathsForPaste(
+  text: string,
+  readClipboardFilePaths: (() => Promise<string[]>) | undefined
+): Promise<string[]> {
+  if (!readClipboardFilePaths || !couldClipboardTextBeCopiedFileNames(text)) {
+    return []
+  }
+  let paths: string[]
+  try {
+    paths = await readClipboardFilePaths()
+  } catch {
+    return []
+  }
+  // Why: an older paired host or web client may answer without a path list.
+  if (!Array.isArray(paths) || paths.length === 0 || !clipboardTextIsCopiedFileNames(text, paths)) {
+    return []
+  }
+  return paths
+}
+
 export async function pasteTerminalClipboard({
   readClipboardText,
+  readClipboardFilePaths,
+  pasteFilePaths,
   saveClipboardImageAsTempFile,
   pasteText,
   connectionId,
@@ -62,6 +96,20 @@ export async function pasteTerminalClipboard({
     // Why: browser clipboard text reads can fail for image-only clipboards.
     // Still try the image path so Cmd/Ctrl+V works for screenshots.
   }
+  // Why: a Finder/Explorer file copy reaches the text flavor as the display
+  // name only, so the file flavors decide the paste before the text does —
+  // matching the drop pipeline, which resolves and shell-escapes full paths.
+  if (pasteFilePaths) {
+    const filePaths = await readCopiedFilePathsForPaste(text, readClipboardFilePaths)
+    if (filePaths.length > 0) {
+      const result = await pasteFilePaths(filePaths)
+      if (result === false) {
+        return { status: 'skipped', reason: 'file-paste-rejected' }
+      }
+      return { status: 'pasted', kind: 'file-path' }
+    }
+  }
+
   if (text) {
     try {
       const textOptions =

--- a/src/renderer/src/components/terminal-pane/terminal-pane-paste-execution.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-paste-execution.ts
@@ -21,6 +21,7 @@ import { formatTerminalPasteExecutionError } from './terminal-paste-errors'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { pasteClipboardFilePathsIntoTerminal } from './terminal-clipboard-file-paste'
 import type { ReadClipboardTextOptions } from '../../../../shared/clipboard-text'
 import type { TerminalPaneCloseController } from './use-terminal-pane-close-actions'
 
@@ -36,6 +37,7 @@ export function createTerminalPanePasteExecution(
   shortcutPlatform: NodeJS.Platform
 ) {
   const {
+    cwd,
     forceBracketedMultilineTextPaste,
     managerRef,
     paneTransportsRef,
@@ -132,6 +134,17 @@ export function createTerminalPanePasteExecution(
     const activeElementAtDispatch = document.activeElement
     void pasteTerminalClipboard({
       readClipboardText,
+      readClipboardFilePaths: window.api.ui.readClipboardFilePaths,
+      pasteFilePaths: (paths) =>
+        pasteClipboardFilePathsIntoTerminal({
+          manager: managerRef.current,
+          paneTransports: paneTransportsRef.current,
+          worktreeId,
+          tabId,
+          cwd,
+          paneLeafId: pane.leafId,
+          paths
+        }),
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
       connectionId,
       runtimeEnvironmentId,

--- a/src/renderer/src/components/terminal-pane/terminal-pane-paste-listeners.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-paste-listeners.ts
@@ -9,6 +9,7 @@ import {
 } from './terminal-clipboard-event-paste'
 import { assertClipboardTextWithinLimitWithYield } from '../../../../shared/clipboard-text'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { pasteClipboardFilePathsIntoTerminal } from './terminal-clipboard-file-paste'
 import { APP_MENU_PASTE_EVENT } from '@/lib/app-menu-paste'
 import {
   APP_MENU_SELECTION_ACTION_EVENT,
@@ -42,10 +43,13 @@ export function registerTerminalPanePasteListeners({
   shortcutPlatform: NodeJS.Platform
 }): () => void {
   const {
+    cwd,
     forceBracketedMultilineTextPaste,
     keybindings,
     managerRef,
+    paneTransportsRef,
     setTerminalError,
+    tabId,
     worktreeId
   } = controller
   const { executePanePasteText, pasteFromClipboard } = execution
@@ -186,6 +190,17 @@ export function registerTerminalPanePasteListeners({
     )
     void pasteTerminalClipboard({
       readClipboardText: window.api.ui.readClipboardText,
+      readClipboardFilePaths: window.api.ui.readClipboardFilePaths,
+      pasteFilePaths: (paths) =>
+        pasteClipboardFilePathsIntoTerminal({
+          manager: managerRef.current,
+          paneTransports: paneTransportsRef.current,
+          worktreeId,
+          tabId,
+          cwd,
+          paneLeafId: pane.leafId,
+          paths
+        }),
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
       connectionId,
       runtimeEnvironmentId,

--- a/src/renderer/src/web/preload-api/web-ui-api.ts
+++ b/src/renderer/src/web/preload-api/web-ui-api.ts
@@ -133,6 +133,8 @@ export function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       return saveClipboardImageAsTempFileInRuntime(contentBase64, args)
     },
     readClipboardImageThumbnail: () => readClipboardImageThumbnail().catch(() => null),
+    // The browser clipboard exposes no OS file entries, so paste stays text-only.
+    readClipboardFilePaths: () => Promise.resolve([]),
     writeClipboardText: writeWebClipboardText,
     writeTerminalClipboardText: writeWebClipboardText,
     writeSelectionClipboardText: () =>

--- a/src/shared/clipboard-file-paths.test.ts
+++ b/src/shared/clipboard-file-paths.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  clipboardTextIsCopiedFileNames,
+  couldClipboardTextBeCopiedFileNames,
+  parseClipboardFileUriList,
+  parseMacOsFilenamesPropertyList
+} from './clipboard-file-paths'
+
+function makeFilenamesPropertyList(paths: string[]): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    '<array>',
+    ...paths.map((path) => `\t<string>${path}</string>`),
+    '</array>',
+    '</plist>'
+  ].join('\n')
+}
+
+describe('parseMacOsFilenamesPropertyList', () => {
+  it('reads every path from a multi-file Finder copy', () => {
+    expect(
+      parseMacOsFilenamesPropertyList(
+        makeFilenamesPropertyList(['/Users/me/project/App.tsx', '/Users/me/notes/spec.md'])
+      )
+    ).toEqual(['/Users/me/project/App.tsx', '/Users/me/notes/spec.md'])
+  })
+
+  it('decodes XML entities in file names', () => {
+    expect(
+      parseMacOsFilenamesPropertyList(
+        makeFilenamesPropertyList(['/Users/me/a &amp; b/r&#233;sum&#233;.txt'])
+      )
+    ).toEqual(['/Users/me/a & b/résumé.txt'])
+  })
+
+  it('drops relative entries and non-list payloads', () => {
+    expect(
+      parseMacOsFilenamesPropertyList(makeFilenamesPropertyList(['relative/path.txt']))
+    ).toEqual([])
+    expect(
+      parseMacOsFilenamesPropertyList('<plist><string>/Users/me/a.txt</string></plist>')
+    ).toEqual([])
+  })
+})
+
+describe('parseClipboardFileUriList', () => {
+  it('reads a KDE-style text/uri-list', () => {
+    expect(
+      parseClipboardFileUriList('file:///home/me/a.txt\r\nfile:///home/me/b%20c.txt\r\n')
+    ).toEqual(['/home/me/a.txt', '/home/me/b c.txt'])
+  })
+
+  it('skips the GNOME copy verb line and comments', () => {
+    expect(parseClipboardFileUriList('copy\n# comment\nfile:///home/me/a.txt')).toEqual([
+      '/home/me/a.txt'
+    ])
+  })
+
+  it('reads a Windows drive path from a file URL', () => {
+    expect(parseClipboardFileUriList('file:///C:/Users/Name/My%20Project/file.txt')).toEqual([
+      'C:/Users/Name/My Project/file.txt'
+    ])
+  })
+
+  it('ignores non-file schemes', () => {
+    expect(parseClipboardFileUriList('https://example.com/a.txt')).toEqual([])
+  })
+
+  it('ignores the macOS file reference URL Finder puts on public.file-url', () => {
+    expect(parseClipboardFileUriList('file:///.file/id=6571367.71479400')).toEqual([])
+  })
+})
+
+describe('couldClipboardTextBeCopiedFileNames', () => {
+  it('accepts empty text and bare display names', () => {
+    expect(couldClipboardTextBeCopiedFileNames('')).toBe(true)
+    expect(couldClipboardTextBeCopiedFileNames('App.tsx')).toBe(true)
+    expect(couldClipboardTextBeCopiedFileNames('App.tsx\nspec.md')).toBe(true)
+  })
+
+  it('rejects text that carries path separators, tabs, padding, or blank lines', () => {
+    expect(couldClipboardTextBeCopiedFileNames('/Users/me/App.tsx')).toBe(false)
+    expect(couldClipboardTextBeCopiedFileNames('C:\\Users\\me\\App.tsx')).toBe(false)
+    expect(couldClipboardTextBeCopiedFileNames('a\tb')).toBe(false)
+    expect(couldClipboardTextBeCopiedFileNames(' App.tsx')).toBe(false)
+    expect(couldClipboardTextBeCopiedFileNames('App.tsx\n\nspec.md')).toBe(false)
+  })
+
+  it('rejects long prose that happens to have no separator', () => {
+    expect(couldClipboardTextBeCopiedFileNames('x'.repeat(256))).toBe(false)
+  })
+})
+
+describe('clipboardTextIsCopiedFileNames', () => {
+  it('matches the display names of the copied files', () => {
+    expect(clipboardTextIsCopiedFileNames('App.tsx', ['/Users/me/project/App.tsx'])).toBe(true)
+    expect(
+      clipboardTextIsCopiedFileNames('App.tsx\nspec.md', [
+        '/Users/me/project/App.tsx',
+        '/Users/me/notes/spec.md'
+      ])
+    ).toBe(true)
+    expect(clipboardTextIsCopiedFileNames('', ['/Users/me/project/App.tsx'])).toBe(true)
+  })
+
+  it('keeps real text that is unrelated to the copied files', () => {
+    expect(clipboardTextIsCopiedFileNames('deploy now', ['/Users/me/project/App.tsx'])).toBe(false)
+    expect(clipboardTextIsCopiedFileNames('App.tsx\nApp.tsx', ['/Users/me/project/App.tsx'])).toBe(
+      false
+    )
+  })
+})

--- a/src/shared/clipboard-file-paths.ts
+++ b/src/shared/clipboard-file-paths.ts
@@ -1,0 +1,127 @@
+import { getRuntimePathBasename, isRuntimePathAbsolute } from './cross-platform-path'
+import { fileUriToFilesystemPath } from './file-uri-path'
+import { NATIVE_FILE_DROP_MAX_PATHS } from './native-file-drop'
+
+// A copied file name stays well under any filesystem limit; the cap only keeps
+// the name-shaped clipboard probe off large text payloads.
+const MAX_COPIED_FILE_NAME_LENGTH = 255
+
+export const CLIPBOARD_FILE_PATH_MAX_ENTRIES = NATIVE_FILE_DROP_MAX_PATHS
+
+// macOS file *reference* URLs (`file:///.file/id=6571367.71479400`) name an
+// inode, not a location. Finder's `public.file-url` is always one, and it
+// resolves through no shell, so only the real path flavors are usable.
+const MACOS_FILE_REFERENCE_PREFIX = '/.file/'
+
+function toClipboardFilePath(fileUri: string): string | null {
+  let url: URL
+  try {
+    url = new URL(fileUri)
+  } catch {
+    return null
+  }
+  const path = fileUriToFilesystemPath(url)
+  if (!path || !isRuntimePathAbsolute(path) || path.startsWith(MACOS_FILE_REFERENCE_PREFIX)) {
+    return null
+  }
+  return path
+}
+
+/**
+ * Parse a `text/uri-list` payload, including the GNOME `x-special/copied-files`
+ * variant whose first line is the `copy` / `cut` verb rather than a URI.
+ */
+export function parseClipboardFileUriList(payload: string): string[] {
+  const paths: string[] = []
+  for (const line of payload.split(/\r?\n/)) {
+    const entry = line.trim()
+    // `#` starts a comment in the uri-list spec; the verb line has no scheme.
+    if (!entry || entry.startsWith('#') || !entry.includes(':')) {
+      continue
+    }
+    const path = toClipboardFilePath(entry)
+    if (path) {
+      paths.push(path)
+    }
+  }
+  return paths.slice(0, CLIPBOARD_FILE_PATH_MAX_ENTRIES)
+}
+
+const PROPERTY_LIST_STRING_ENTRY = /<string>([\s\S]*?)<\/string>/g
+const XML_ENTITY = /&(amp|lt|gt|quot|apos|#(\d+));/g
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(XML_ENTITY, (match, name: string, codePoint?: string) => {
+    if (codePoint) {
+      const parsed = Number.parseInt(codePoint, 10)
+      return Number.isFinite(parsed) ? String.fromCodePoint(parsed) : match
+    }
+    switch (name) {
+      case 'amp':
+        return '&'
+      case 'lt':
+        return '<'
+      case 'gt':
+        return '>'
+      case 'quot':
+        return '"'
+      case 'apos':
+        return "'"
+      default:
+        return match
+    }
+  })
+}
+
+/**
+ * Parse the `NSFilenamesPboardType` XML property list macOS writes alongside
+ * `public.file-url`. Electron exposes only the first pasteboard item, so this
+ * list is the sole way to see every file in a multi-file Finder copy.
+ */
+export function parseMacOsFilenamesPropertyList(payload: string): string[] {
+  if (!payload.includes('<array>')) {
+    return []
+  }
+  const paths: string[] = []
+  for (const [, entry] of payload.matchAll(PROPERTY_LIST_STRING_ENTRY)) {
+    const path = decodeXmlEntities(entry).trim()
+    if (path && isRuntimePathAbsolute(path)) {
+      paths.push(path)
+    }
+  }
+  return paths.slice(0, CLIPBOARD_FILE_PATH_MAX_ENTRIES)
+}
+
+/**
+ * True when the clipboard text could be the display names macOS/Explorer put
+ * beside a copied file, so only those pastes pay for the file-path IPC probe.
+ */
+export function couldClipboardTextBeCopiedFileNames(text: string): boolean {
+  if (text === '') {
+    return true
+  }
+  const lines = text.split('\n')
+  if (lines.length > CLIPBOARD_FILE_PATH_MAX_ENTRIES) {
+    return false
+  }
+  return lines.every(
+    (line) =>
+      line.length > 0 &&
+      line.length <= MAX_COPIED_FILE_NAME_LENGTH &&
+      !/[\\/\t]/.test(line) &&
+      line.trim() === line
+  )
+}
+
+/**
+ * True when the clipboard text is just the copied files' display names, so
+ * replacing it with the full paths cannot discard real text a user copied.
+ */
+export function clipboardTextIsCopiedFileNames(text: string, paths: readonly string[]): boolean {
+  if (text === '') {
+    return true
+  }
+  const names = new Set(paths.map((path) => getRuntimePathBasename(path)))
+  const lines = text.split('\n')
+  return lines.length <= paths.length && lines.every((line) => names.has(line))
+}


### PR DESCRIPTION
## ELI5

Copy a file in Finder or Explorer, paste it into an Orca terminal, and you got just the file's name — `App.tsx` — instead of the path the agent actually needs. Now you get the full path, quoted for your shell, exactly like dragging the file in already did.

## What Changed

- New `clipboard:readFilePaths` IPC returns the file entries an OS file manager put on the clipboard, as absolute client-local paths (`src/main/window/clipboard-file-paths-read.ts`), with the parsing kept in `src/shared/clipboard-file-paths.ts`.
- Terminal paste consults those file entries before the text flavor, and hands the resolved paths to the **existing native-drop pipeline** (`handleNativeTerminalFileDrop`) instead of growing a second path-writing route.
- The web client returns an empty list, so paired/browser sessions keep today's text-only behavior.

Because the paths go through the drop pipeline, a pasted file behaves exactly like a dropped one:

| Worktree | Behavior |
|---|---|
| Local | path pasted in place, shell-escaped |
| Local WSL | translated to the distro path, POSIX quoting |
| SSH | uploaded to `${worktreePath}/.orca/drops`, remote path pasted |
| Remote runtime | uploaded through the runtime, runtime path pasted |

Three details came out of reading a **real Finder pasteboard** rather than a synthetic one, and they are where review attention is most valuable:

1. **The flavors are read by their native names, not filtered through `availableFormats()`.** Chromium reports normalized MIME names there — a macOS file copy advertises only `text/uri-list`, and reading *that* name returns an empty string. Gating on the format list silently disables the feature (my first draft did exactly that, and only testing against the running app caught it).
2. **`NSFilenamesPboardType` is the only usable macOS flavor.** It carries POSIX paths and every file of a multi-file copy. Finder's `public.file-url` is a file *reference* URL — `file:///.file/id=6571367.71479400` — which names an inode, resolves through no shell, and would paste as a nonsense absolute path, so those are rejected.
3. **Windows has no equivalent list.** Electron exposes no CF_HDROP reader, so `FileNameW` gives the first file only — a documented limit of this change, not a regression.

For the record, a real `Cmd+C` on one file in Finder puts this on the pasteboard:

```
public.utf8-plain-text  = "Quarterly Report.txt"        <- the display name; what paste used to insert
public.file-url         = "file:///.file/id=6571367.71479400"  <- an inode reference, not a path
NSFilenamesPboardType   = ["/Users/me/Downloads/orca-demo/Quarterly Report.txt"]  <- the real path
```

## Why

`pasteTerminalClipboard` read only the clipboard's **text** flavor. On macOS a Finder-copied file reaches that flavor as its display name, so the terminal received `App.tsx` and agents got a path that does not resolve. Users had to fall back to `Cmd+Option+C` (Copy as Pathname) or drag-and-drop. Other terminals (cmux/Ghostty) paste the full path.

The conversion helpers (`fileUriToFilesystemPath`) and the whole path-writing pipeline already existed — they were simply never wired into paste. This change wires them, rather than adding a parallel implementation.

Ordinary pastes are untouched, by two guards:

- the file probe only runs for clipboard text that *could* be copied display names (no path separators, no tabs, no blank lines, ≤255 chars per line), so a normal text paste costs zero extra IPC;
- the paths are used only when the text is exactly those files' base names, so text a user genuinely copied is never replaced.

## Linked Issue

Fixes #7777

## Visual Proof

Same file, same terminal, one real `Cmd+C` in Finder each time. The only difference is the code: **before** is `a62cfeda` with this branch checked out to its parent; **after** is this branch.

**Before** — the terminal receives the display name, unquoted (two shell words):

<!-- 1-before-filename-only.png -->

**After** — the full path, shell-escaped for the space in the file name:

<!-- 2-after-full-path.png -->

## Testing

Platforms actually exercised: **macOS 26.4, local worktree**. Linux/Windows/SSH paths are covered by unit tests and by the drop pipeline this change reuses, not by hands-on runs — please flag if you want a Windows check before merge.

Manual (macOS, `pnpm dev`):

1. Open a project, open a terminal pane.
2. In Finder, select a file and press `Cmd+C`.
3. Focus the terminal and press `Cmd+V`.
4. The full, shell-escaped path is inserted (verified with a path containing CJK characters). Repeat with several files selected — every path is inserted, space-separated.

I also verified the IPC end to end against the running app over CDP: a single-file copy returned `["/…/package.json"]` and a two-file copy returned both paths.

Automated: 29 new tests across `src/shared/clipboard-file-paths.test.ts`, `src/main/window/clipboard-file-paths-read.test.ts`, and `src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts`, covering macOS single/multi-file, the file-reference URL rejection, the buffer-only flavor fallback, Windows UTF-16 `FileNameW`, GNOME vs KDE Linux payloads, throwing clipboard reads, a response without a path list, and the text-preserving guards.

`pnpm lint`, `pnpm typecheck`, and `pnpm build` pass locally. `pnpm test`: 75 481 passed; the 15 failures are all pre-existing or environmental on my machine — `skill-recipe-shell` and `structured-agent-session-adoption-replay` fail identically with my changes stashed, the `*.electron.test.ts` browser tests and `claude-tui-resume-real-binary` need environments I do not have, and `tests/e2e/cross-version-wire/*` needs full git history (my clone is `--depth=1`).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Author

William Men

## AI Disclosure

Written with Claude (Opus 5) in Claude Code, driven and reviewed by me.

## Review

Agent code review of this change:

- **Cross-platform**: no hardcoded separators; paths flow through `isRuntimePathAbsolute` / `getRuntimePathBasename` and the existing `shellEscapePath(path, targetShell)`. Platform branching is injected and unit-tested for darwin/win32/linux. Windows is limited to the first file of a multi-file copy (Electron exposes no CF_HDROP reader) — a smaller improvement there, never a regression.
- **SSH / remote / local**: no new host assumptions. Clipboard paths are client-local by definition and are handed to the drop pipeline, which already uploads for SSH and runtime worktrees and resolves WSL paths; local worktrees stay reference-in-place. `cwd` is threaded through so folder workspaces (not just git worktrees) resolve a worktree path.
- **Remote wire**: no wire change. The web/paired client returns `[]`, and the renderer tolerates a response that is not an array, so an older host cannot break paste.
- **Agents / integrations**: provider-neutral; nothing agent- or provider-specific. Image paste, bracketed paste, and the stale-Ctrl+C protection paths are untouched and still covered by their existing tests.
- **Performance**: no cost on the hot path — the probe is skipped entirely unless the clipboard text is display-name-shaped, and it is at most two synchronous clipboard reads in the main process.
- **UI quality**: no new UI. Failure feedback reuses the drop pipeline's existing toasts.
- **Security**: the new IPC is gated by `assertTrustedClipboardSender` (the strict main-window check, not the looser text-sender one). It only reads paths the user themself put on the clipboard, returns nothing but absolute paths, and caps the list at `NATIVE_FILE_DROP_MAX_PATHS`. No file contents are read and no path is executed — the pasted text still requires the user to press Enter.

## Agent skill upstream boundary

- [x] Not applicable — this change touches clipboard and terminal paste only.

## Notes

Reviewer attention is most valuable on the three pasteboard details above: whether reading flavors by native name (bypassing `availableFormats()`) is acceptable, whether rejecting file-reference URLs outright is right or they should be resolved, and whether the Windows first-file-only limit should block this or ship as-is.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
