### PR TITLE
fix(terminal): preserve transformed output for legacy subscribers

### DIFF
--- a/src/main/runtime/rpc/methods/terminal/stream-schemas.ts
+++ b/src/main/runtime/rpc/methods/terminal/stream-schemas.ts
@@ -30,6 +30,7 @@ export const TerminalSubscribe = TerminalHandle.extend({
   capabilities: z
     .object({
       terminalBinaryStream: z.literal(1).optional(),
+      outputSpan: z.literal(1).optional(),
       desktopViewportClaims: z.literal(1).optional(),
       mobileInputLeaseOnly: z.literal(1).optional(),
       writeUnavailable: z.literal(1).optional()

--- a/src/main/runtime/rpc/methods/terminal/terminal-legacy-display-chunks.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-legacy-display-chunks.ts
@@ -1,0 +1,31 @@
+import {
+  iterateTerminalOutputFrameChunks,
+  type TerminalOutputFrameChunk,
+  type TerminalOutputMeta
+} from '../../terminal-output-frame-chunks'
+
+export function* iterateLegacyTerminalDisplayChunks(
+  data: string,
+  meta: TerminalOutputMeta | undefined,
+  supportsOutputSpan: boolean
+): Generator<TerminalOutputFrameChunk> {
+  if (
+    supportsOutputSpan ||
+    (!meta?.transformed && (meta?.rawLength ?? data.length) === data.length)
+  ) {
+    yield* iterateTerminalOutputFrameChunks(data, meta)
+    return
+  }
+  // Legacy Output carries display text; source metadata remains owned by replay, not this codec.
+  let pending: TerminalOutputFrameChunk | undefined
+  for (const chunk of iterateTerminalOutputFrameChunks(data)) {
+    if (pending) {
+      yield pending
+    }
+    pending = chunk
+  }
+  if (pending) {
+    // Only the final display chunk can carry the source high-water mark without inventing offsets.
+    yield { ...pending, seq: meta?.seq }
+  }
+}

--- a/src/main/runtime/rpc/methods/terminal/terminal-legacy-subscribe-binary.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-legacy-subscribe-binary.ts
@@ -3,7 +3,7 @@ import {
   encodeTerminalStreamFrame,
   encodeTerminalStreamJson
 } from '../../../../../shared/terminal-stream-protocol'
-import { iterateTerminalOutputFrameChunks } from '../../terminal-output-frame-chunks'
+import { iterateLegacyTerminalDisplayChunks } from './terminal-legacy-display-chunks'
 import {
   EMPTY_TERMINAL_REPLY_QUERY_SCAN_STATE,
   scanTerminalReplyQuerySequences,
@@ -107,7 +107,11 @@ export async function runTerminalBinarySubscription(args: TerminalSubscriptionAr
         meta.seq
       )
     }
-    for (const chunk of iterateTerminalOutputFrameChunks(data, meta)) {
+    for (const chunk of iterateLegacyTerminalDisplayChunks(
+      data,
+      meta,
+      params.capabilities?.outputSpan === 1
+    )) {
       sendFrame(chunk.opcode ?? TerminalStreamOpcode.Output, chunk.bytes, chunk.seq)
     }
   })

--- a/src/main/runtime/rpc/methods/terminal/terminal-legacy-subscribe-snapshot.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-legacy-subscribe-snapshot.ts
@@ -143,6 +143,7 @@ export async function publishLegacyBinaryInitialSnapshot(
   emit({
     type: 'subscribed',
     streamId: state.streamId,
+    ...(params.capabilities?.outputSpan === 1 ? { capabilities: { outputSpan: 1 } } : {}),
     lines: read.tail,
     truncated: initialOutputOverflowed || (!sendBinary && isTerminalReadPayloadIncomplete(read)),
     cols: serialized?.cols ?? size?.cols,

--- a/src/main/runtime/rpc/terminal-legacy-display-compatibility.test.ts
+++ b/src/main/runtime/rpc/terminal-legacy-display-compatibility.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from './dispatcher'
+import { SshPtyProvider } from '../../providers/ssh-pty-provider'
+import { TERMINAL_METHODS } from './methods/terminal'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { TerminalOutputMeta } from './terminal-output-frame-chunks'
+import { createSubscriptionRegistryDouble } from './subscription-registry-test-double'
+import { iterateLegacyTerminalDisplayChunks } from './methods/terminal/terminal-legacy-display-chunks'
+import { createJiti } from 'jiti'
+
+// Load the shipped codec without requiring Expo's unrelated application tsconfig.
+const { handleTerminalBinaryFrame } = createJiti(import.meta.url, { moduleCache: false })(
+  '../../../../mobile/src/transport/rpc-client-terminal-binary-frame.ts'
+) as {
+  handleTerminalBinaryFrame: (
+    bytes: Uint8Array,
+    options: {
+      terminalSnapshots: Map<number, unknown>
+      getListener: (streamId: number) => (event: unknown) => void
+    }
+  ) => void
+}
+import {
+  TerminalStreamOpcode,
+  decodeTerminalStreamFrame,
+  decodeTerminalStreamJson,
+  decodeTerminalStreamText
+} from '../../../shared/terminal-stream-protocol'
+import { TERMINAL_STREAM_CHUNK_BYTES } from '../../../shared/terminal-multiplex-flow-control'
+
+async function connect(outputSpan = false, mobile = true) {
+  const registry = createSubscriptionRegistryDouble()
+  const events: Record<string, unknown>[] = []
+  const messages: Record<string, unknown>[] = []
+  const frames: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>[] = []
+  const terminalSnapshots = new Map()
+  let dataListener!: (data: string, meta?: TerminalOutputMeta) => void
+  let resizeListener!: (event: {
+    cols: number
+    rows: number
+    displayMode: string
+    reason: string
+  }) => void
+  let snapshot = { data: 'initial', cols: 80, rows: 24, seq: 10 }
+  const runtime = {
+    getRuntimeId: () => 'compatibility-runtime',
+    resolveLeafForHandle: () => ({ ptyId: 'pty' }),
+    readTerminal: async () => ({ tail: [], truncated: false }),
+    serializeTerminalBuffer: async () => snapshot,
+    serializeAuthoritativeTerminalBuffer: async () => snapshot,
+    getTerminalSize: () => ({ cols: 80, rows: 24 }),
+    getMobileDisplayMode: () => 'auto',
+    getLayout: () => ({ seq: 1 }),
+    isTerminalAlternateScreen: () => false,
+    getRendererTerminalSerializerGenerationForHandle: () => 0,
+    hasHeadlessTerminalState: () => true,
+    handleMobileSubscribe: async () => {
+      dataListener('covered', { seq: 10, rawLength: 10, transformed: true })
+      dataListener('buffered🙂', { seq: 15, rawLength: 5, transformed: true })
+    },
+    handleMobileUnsubscribe: vi.fn(),
+    subscribeToTerminalData: (_: string, listener: typeof dataListener) => {
+      dataListener = listener
+      return vi.fn()
+    },
+    subscribeToTerminalResize: (_: string, listener: typeof resizeListener) => {
+      resizeListener = listener
+      return vi.fn()
+    },
+    subscribeToFitOverrideChanges: () => vi.fn(),
+    subscribeToPtyExit: () => vi.fn(),
+    registerRemoteTerminalViewSubscriber: () => vi.fn(),
+    registerOwnedSubscriptionCleanup: registry.registerOwnedSubscriptionCleanup,
+    waitForTerminal: () => new Promise(() => {})
+  } as unknown as OrcaRuntimeService
+  const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+  const done = dispatcher.dispatchStreaming(
+    {
+      id: 'compatibility',
+      authToken: 'fixture',
+      method: 'terminal.subscribe',
+      params: {
+        terminal: 'term',
+        client: { id: 'client', type: mobile ? 'mobile' : 'desktop' },
+        capabilities: { terminalBinaryStream: 1, ...(outputSpan ? { outputSpan: 1 } : {}) }
+      }
+    },
+    (message) => messages.push(JSON.parse(message).result),
+    {
+      connectionId: 'connection',
+      sendBinary: (bytes) => {
+        const frame = decodeTerminalStreamFrame(bytes)
+        if (!frame) {
+          throw new Error('Host emitted invalid frame')
+        }
+        frames.push(frame)
+        handleTerminalBinaryFrame(new Uint8Array(bytes), {
+          terminalSnapshots,
+          getListener: () => (event) => events.push(event as Record<string, unknown>)
+        })
+      }
+    }
+  )
+  await vi.waitFor(() => expect(resizeListener).toBeDefined())
+  return {
+    events,
+    messages,
+    frames,
+    emit: (data: string, meta?: TerminalOutputMeta) => dataListener(data, meta),
+    resize: () => {
+      snapshot = { data: 'resized🙂', cols: 100, rows: 24, seq: 40 }
+      resizeListener({ cols: 100, rows: 24, displayMode: 'auto', reason: 'apply-layout' })
+    },
+    close: async () => {
+      registry.cleanupSubscription('term:client')
+      await done
+    }
+  }
+}
+
+describe('legacy display publication against the shipped mobile decoder', () => {
+  it('delivers initial/buffered/live/resize/reconnect text without span JSON or lost display', async () => {
+    for (let connection = 0; connection < 2; connection++) {
+      const peer = await connect()
+      try {
+        expect(peer.events.filter((e) => e.type === 'scrollback').map((e) => e.serialized)).toEqual(
+          ['initial']
+        )
+        expect(peer.events.filter((e) => e.type === 'data').map((e) => e.chunk)).toEqual([
+          'buffered🙂'
+        ])
+        for (const [data, rawLength] of [
+          ['\u001b[31m雪🙂\u001b[0m', 30],
+          ['expanded', 1],
+          ['', 9]
+        ] as const) {
+          peer.emit(data, { seq: 40, rawLength, transformed: true, cwd: '/remote/project' })
+        }
+        expect(peer.events.filter((e) => e.type === 'data').map((e) => e.chunk)).toEqual([
+          'buffered🙂',
+          '\u001b[31m雪🙂\u001b[0m',
+          'expanded',
+          ''
+        ])
+        expect(peer.events.some((e) => e.type === 'metadata' && e.cwd === '/remote/project')).toBe(
+          true
+        )
+        peer.resize()
+        await vi.waitFor(() =>
+          expect(
+            peer.events.some((e) => e.type === 'resized' && e.serialized === 'resized🙂')
+          ).toBe(true)
+        )
+        expect(peer.frames.some((f) => f.opcode === TerminalStreamOpcode.OutputSpan)).toBe(false)
+        expect(peer.messages.find((e) => e.type === 'subscribed')?.capabilities).toBeUndefined()
+      } finally {
+        await peer.close()
+      }
+    }
+  })
+
+  it.each([true, false])(
+    'echoes advertised spans and preserves source accounting (mobile=%s)',
+    async (mobile) => {
+      const peer = await connect(true, mobile)
+      try {
+        peer.emit('雪🙂', { seq: 101, rawLength: 17, transformed: true })
+        expect(peer.messages.find((e) => e.type === 'subscribed')?.capabilities).toEqual({
+          outputSpan: 1
+        })
+        const frame = peer.frames.at(-1)!
+        expect(frame.opcode).toBe(TerminalStreamOpcode.OutputSpan)
+        expect(frame.seq).toBe(101)
+        expect(decodeTerminalStreamJson(frame.payload)).toEqual({
+          data: '雪🙂',
+          rawLength: 17,
+          transformed: true
+        })
+      } finally {
+        await peer.close()
+      }
+    }
+  )
+
+  it('also adapts accepted legacy desktop subscriptions without advertising spans', async () => {
+    const peer = await connect(false, false)
+    try {
+      peer.emit('desktop', { seq: 100, rawLength: 2, transformed: true })
+      expect(peer.events.filter((e) => e.type === 'data').map((e) => e.chunk)).toEqual(['desktop'])
+    } finally {
+      await peer.close()
+    }
+  })
+
+  it('delivers transformed SSH provider notifications through the host publisher', async () => {
+    const peer = await connect()
+    let notify!: (method: string, params: Record<string, unknown>) => void
+    const provider = new SshPtyProvider('fixture-connection', {
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn(),
+      onNotification: (listener: typeof notify) => {
+        notify = listener
+        return vi.fn()
+      },
+      isDisposed: () => false
+    } as never)
+    const unsubscribe = provider.onData((event) =>
+      peer.emit(event.data, {
+        seq: event.seq,
+        rawLength: event.sequenceChars,
+        transformed: event.transformed
+      })
+    )
+    try {
+      notify('pty.data', { id: 'pty', data: 'SSH雪🙂', seq: 90, rawLength: 50, transformed: true })
+      notify('pty.data', { id: 'pty', data: '', seq: 99, rawLength: 9, transformed: true })
+      expect(peer.events.filter((e) => e.type === 'data').map((e) => e.chunk)).toEqual([
+        'buffered🙂',
+        'SSH雪🙂',
+        ''
+      ])
+      expect(peer.frames.some((frame) => frame.opcode === TerminalStreamOpcode.OutputSpan)).toBe(
+        false
+      )
+    } finally {
+      unsubscribe()
+      await peer.close()
+    }
+  })
+
+  it('bounds Unicode display chunks without fabricating source offsets or mutating metadata', () => {
+    const text = '雪🙂'.repeat(TERMINAL_STREAM_CHUNK_BYTES)
+    const meta = Object.freeze({ seq: 900, rawLength: 12, transformed: true })
+    const chunks = [...iterateLegacyTerminalDisplayChunks(text, meta, false)]
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.every((chunk) => chunk.bytes.length <= TERMINAL_STREAM_CHUNK_BYTES)).toBe(true)
+    expect(chunks.map((chunk) => decodeTerminalStreamText(chunk.bytes)).join('')).toBe(text)
+    expect(chunks.slice(0, -1).every((chunk) => chunk.seq === undefined)).toBe(true)
+    expect(chunks.at(-1)?.seq).toBe(900)
+    expect(meta).toEqual({ seq: 900, rawLength: 12, transformed: true })
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |

<!-- /orca-pr-loc -->

## ELI5

Older terminal clients silently lose transformed output because they cannot decode OutputSpan frames. The host now sends readable display text to those subscribers using the Output format they already understand.

## What Changed

Legacy `terminal.subscribe` accepts optional `capabilities.outputSpan: 1` and echoes it in the subscription response. Only subscribers that advertise support receive spans. Other subscribers receive Unicode-safe, bounded Output chunks containing the exact display text, including empty display emissions with advancing source offsets.

The adapter runs at publication, after batching and snapshot coverage decisions. It preserves upstream source metadata and leaves multiplex source-range/ack handling unchanged. Large transformed display output retains the source high-water mark on its final chunk; legacy Output does not gain source-range acknowledgements or a new resume contract. No mobile decoder or advertisement changes are required.

## Why

Gating and dropping opcode 15 would still lose output. Choosing the representation at the subscriber boundary removes the decoder mismatch while preserving the host's source accounting.

## Linked Issue

Addresses the legacy display-delivery mechanism in [STA-3482](https://linear.app/stably/issue/STA-3482). This draft does not claim full incident closure.

## Visual Proof

Outstanding: paired mobile before/after rendering. A fresh hidden Electron build launched on this branch with a synthetic home, and its full onboarding screen was inspected through CDP; that is startup smoke coverage, not visual proof of transformed terminal delivery.

## Testing

- [ ] Paired native mobile/E2EE and live SSH reproduction completed
- [x] Automated regression tests added

On macOS: 53 tests passed across seven focused suites, including six new cases running the real host dispatcher/publisher against the shipped mobile codec/handler. Coverage includes initial snapshot and buffered output, Unicode/control sequences, expansion/contraction/empty display, resize snapshot, reconnect, negotiated spans, accepted legacy desktop subscriptions, and SSH provider notification routing with synthetic relay events.

The existing cross-version terminal wire suite passed all 10 tests against v1.4.197 and the v1.4.190 terminal-metadata fixture. These are in-memory production-module pairings, not live network/device tests. All three typechecks passed sequentially (`config/tsconfig.node.json`, `config/tsconfig.tc.web.json`, `config/tsconfig.tc.cli.json`); changed-file oxlint and formatting passed.

After committing, bypassing only the publisher adapter produced three failed and three passing new tests. Restoring the committed publisher byte-for-byte returned all six to passing.

Initial setup failures: dependency postinstall failed during native rebuilding before tests ran; a direct mobile import initially failed on absent Expo tsconfig dependencies; a test-only type import initially failed the node project's file-list check. The test now loads the actual mobile source independently of Expo. The first synthetic Electron profile exceeded Unix socket path limits; a shorter fresh profile launched successfully. No Windows/Linux, live SSH, native mobile or E2EE delivery claim is made.

Reproduce focused validation with `node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/main/runtime/rpc/terminal-legacy-display-compatibility.test.ts` and the existing cross-version terminal wire suite, with `ORCA_BACKGROUND_LAUNCH=1`.

## Review

Validation complete at the source-contract level; awaiting independent architectural review. Paired visual/transport validation remains outstanding. No self-CLEAN or merge-readiness claim.

## Agent skill upstream boundary

- [x] Not applicable; this change copies no upstream skill material.
