### PR TITLE
fix(terminal): fold-safe CAN/SUB and double-ESC handling in partial-escape tail

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -5825,7 +5825,7 @@
       "invariant": "After a TUI exits or is killed, reveal, reattach, snapshot replay, or renderer remount must not deliver terminal-owned mouse or alternate-screen protocol bytes to the surviving shell. Recovery is an ordered output barrier in the daemon session data path: an OSC 133;D completing while the alternate screen is still active pauses the stream at that exact byte boundary, a fresh execution-host process inspection proves shell ownership, and on proof a mode reset is injected as in-stream output so every consumer converges by parsing the same bytes and the queued post-boundary shell output (the prompt) lands on the normal buffer. Snapshots are pure reads. Any failure — refuted proof, timeout, queue overflow, session death, disposal — flushes the queue unmodified, preserving incumbent behavior; later command or mode bytes revoke proof. Clean alternate-screen exits prove ownership asynchronously without pausing.",
       "oracle": "Run one fixed child-TUI journey for normal exit and cleanup-free SIGKILL. Assert renderer and host normal-buffer/non-mouse state, host snapshot terminalOwner metadata, exact PTY writes with no post-exit mouse report, unrelated-pane survival, post-boundary prompt output preserved (normal exit), ordered proof invalidation, bounded settlement and bail-out flush, one inspection per unclean episode with zero scans for ordinary output, split-escape safety at every chunk boundary, and old/new client-host fallback parity.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/terminal-shell-lifecycle-scanner.test.ts src/main/daemon/terminal-shell-recovery-barrier.test.ts src/main/daemon/session-shell-recovery.test.ts src/main/daemon/session.test.ts src/main/daemon/terminal-host-concurrent-create.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/daemon-restore-scrollback-depth.test.ts src/main/daemon/terminal-checkpoint-serializer.test.ts src/main/providers/agent-foreground-process.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/mobile-subscribe-integration.test.ts src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts src/renderer/src/components/terminal-pane/pty-connection-hidden-codex-queries.test.ts src/renderer/src/components/terminal-pane/pty-connection-reattach-mode-reset.test.ts src/renderer/src/components/terminal-pane/pty-connection-daemon-snapshot-replay.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-snapshot-escape-tail.test.ts --reporter=dot",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/terminal-shell-lifecycle-scanner.test.ts src/main/daemon/terminal-shell-recovery-barrier.test.ts src/main/daemon/session-shell-recovery.test.ts src/main/daemon/session.test.ts src/main/daemon/terminal-host-concurrent-create.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/daemon/daemon-restore-scrollback-depth.test.ts src/main/daemon/terminal-checkpoint-serializer.test.ts src/main/providers/agent-foreground-process.test.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/mobile-subscribe-integration.test.ts src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts src/renderer/src/components/terminal-pane/pty-connection-hidden-codex-queries.test.ts src/renderer/src/components/terminal-pane/pty-connection-reattach-mode-reset.test.ts src/renderer/src/components/terminal-pane/pty-connection-daemon-snapshot-replay.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-snapshot-escape-tail.test.ts src/shared/terminal-partial-escape-tail.test.ts src/shared/terminal-partial-escape-tail.fuzz.test.ts --reporter=dot",
         "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts --reporter=dot",
         "pnpm exec electron-vite build --mode e2e",
         "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-hidden-child-tui-kill-mode-reset.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
@@ -5847,6 +5847,8 @@
         "src/renderer/src/components/terminal-pane/pty-connection-reattach-mode-reset.test.ts",
         "src/renderer/src/components/terminal-pane/pty-connection-daemon-snapshot-replay.test.ts",
         "src/renderer/src/components/terminal-pane/remote-runtime-pty-snapshot-escape-tail.test.ts",
+        "src/shared/terminal-partial-escape-tail.test.ts",
+        "src/shared/terminal-partial-escape-tail.fuzz.test.ts",
         "tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts",
         "tests/e2e/terminal-hidden-child-tui-kill-mode-reset.spec.ts"
       ],
@@ -5866,6 +5868,13 @@
           "assertions": [
             "post-kill shell output survives into the normalized snapshot instead of the discarded alt buffer",
             "a snapshot taken during a split escape keeps the pending tail intact and stale proof is revoked by the completing bytes"
+          ]
+        },
+        {
+          "file": "src/shared/terminal-partial-escape-tail.fuzz.test.ts",
+          "assertions": [
+            "the pending tail this gate threads over the wire folds identically at every code-unit split of the combined stream, including boundaries landing inside oscEsc/stringEsc",
+            "the split sweep runs over an alphabet carrying CAN, SUB, doubled ESC inside OSC/DCS/SOS/PM/APC, BEL, C1 ST, NUL, DEL, intermediates, CJK, astral, and lone surrogates"
           ]
         },
         {

--- a/src/shared/terminal-partial-escape-tail.fuzz.test.ts
+++ b/src/shared/terminal-partial-escape-tail.fuzz.test.ts
@@ -10,6 +10,10 @@ import {
 // input, and must preserve the fold property extract(a + b) === extract(extract(a) + b).
 // A 25.6M-case out-of-band sweep (exhaustive len<=5, 2000 x 16 KB random chunks, every BMP code
 // unit) found 0 divergences; this is the CI-sized slice of it.
+// The fold half re-splits every combined stream at every code-unit boundary; the alphabet and
+// SEQUENCES deliberately carry CAN/SUB and doubled ESC inside OSC/DCS/SOS/PM/APC, because two
+// fold breaks in those exact states shipped undetected while the fold check was only asserted
+// on already-normalized pendings (where it is a tautology).
 
 const oracle = (pending: string, chunk: string): string => {
   const tail = extractPartialEscapeTail(pending + chunk)
@@ -22,6 +26,7 @@ const ALPHABET = [
   '\x18',
   '\x1a',
   '\x07',
+  '\x00',
   '\\',
   '[',
   ']',
@@ -30,6 +35,7 @@ const ALPHABET = [
   '^',
   '_',
   '(',
+  ' ',
   '0',
   ';',
   'm',
@@ -37,6 +43,7 @@ const ALPHABET = [
   '\x7f',
   '\x9c',
   'é',
+  '中',
   '\u{1f600}',
   '\ud83d',
   '\udc00'
@@ -66,7 +73,17 @@ const SEQUENCES = [
   '\x1b7',
   '\x1b[?1049h',
   '\x1b]52;c;aGVsbG8=\x1b\\',
-  'ab\x1b[2Jcd'
+  'ab\x1b[2Jcd',
+  // CAN/SUB aborting from inside a string sequence, and from inside its ESC state.
+  '\x1b]0;title\x18rest',
+  '\x1bPx\x1b\x18X0abc',
+  '\x1bP data\x1b\x1arest',
+  '\x1b]0;t\x1b\x18\x1b[1m',
+  // A second ESC inside OSC/DCS opens its own sequence at that ESC, not at the first one.
+  '\x1b] \x1b\x1b^',
+  '\x1b]0;t\x1b\x1b\x1b[3',
+  '\x1bPq\x1b\x1b]0;x\x07',
+  '\x1bX sos \x1b\x1bP'
 ]
 
 // Yields {text, depth} because an astral symbol is two UTF-16 code units: filtering on
@@ -91,6 +108,26 @@ function* stringsUpTo(maxDepth: number): Generator<{ depth: number; text: string
 
 describe('advancePartialEscapeTail differential fuzz', () => {
   let checked = 0
+  let foldSplits = 0
+  // Why the sweep and not just `advance(extract(pending), chunk)`: every PENDINGS entry is
+  // already a tail, so `extract(pending) === pending` makes that form a tautology. Only
+  // re-splitting the combined stream lands a boundary inside oscEsc/stringEsc, where the
+  // CAN/SUB abort and the second-ESC restart live.
+  const checkFolds = (text: string): void => {
+    if (text.length > 32) {
+      return // keeps the cap corpus (5000-char chunks) out of an O(n^2) sweep
+    }
+    const whole = extractPartialEscapeTail(text)
+    for (let cut = 0; cut <= text.length; cut++) {
+      foldSplits++
+      const folded = extractPartialEscapeTail(
+        extractPartialEscapeTail(text.slice(0, cut)) + text.slice(cut)
+      )
+      if (folded !== whole) {
+        expect.fail(`fold property broke: ${JSON.stringify({ text, cut, whole, folded })}`)
+      }
+    }
+  }
   const check = (pending: string, chunk: string): void => {
     checked++
     const actual = advancePartialEscapeTail(pending, chunk)
@@ -104,6 +141,7 @@ describe('advancePartialEscapeTail differential fuzz', () => {
     ) {
       expect.fail(`fold property broke: ${JSON.stringify({ pending, chunk })}`)
     }
+    checkFolds(pending + chunk)
   }
 
   it('matches the unguarded oracle on every chunk up to length 4', () => {
@@ -149,6 +187,7 @@ describe('advancePartialEscapeTail differential fuzz', () => {
   })
 
   it('ran the whole corpus', () => {
-    expect(checked).toBe(593_468)
+    expect(checked).toBe(963_819)
+    expect(foldSplits).toBe(6_236_429)
   })
 })

--- a/src/shared/terminal-partial-escape-tail.test.ts
+++ b/src/shared/terminal-partial-escape-tail.test.ts
@@ -50,6 +50,26 @@ describe('extractPartialEscapeTail', () => {
     expect(extractPartialEscapeTail('\x1b\x18\x1b[3')).toBe('\x1b[3')
   })
 
+  it('aborts to ground on CAN/SUB inside a string sequence', () => {
+    // ESC inside DCS/SOS/PM/APC parks in stringEsc; a CAN/SUB there aborts to ground rather
+    // than being re-read as the byte after an ESC (which used to leave a bogus `\x1b\x18…` tail
+    // and broke the fold, since extract() of the prefix drops to ground).
+    expect(extractPartialEscapeTail('\x1bPx\x1b\x18X0abc')).toBe('')
+    expect(extractPartialEscapeTail('\x1bPx\x1b\x1aX0abc')).toBe('')
+    // Same state reached through OSC (oscEsc).
+    expect(extractPartialEscapeTail('\x1b]0;t\x1b\x18rest')).toBe('')
+    // A fresh sequence after the abort is still tracked.
+    expect(extractPartialEscapeTail('\x1bPx\x1b\x18\x1b[3')).toBe('\x1b[3')
+  })
+
+  it('starts the new sequence at the second ESC inside OSC/DCS', () => {
+    // ESC ESC in oscEsc/stringEsc: the second ESC opens its own sequence at itself, not one
+    // byte earlier — matching xterm, and required for the fold to agree at that boundary.
+    expect(extractPartialEscapeTail('\x1b] \x1b\x1b^')).toBe('\x1b^')
+    expect(extractPartialEscapeTail('\x1bPq\x1b\x1b[3')).toBe('\x1b[3')
+    expect(extractPartialEscapeTail('\x1b]0;t\x1b\x1b')).toBe('\x1b')
+  })
+
   it('is fold-safe across chunk boundaries', () => {
     // extract(a + b) === extract(extract(a) + b) — the invariant ingest relies on.
     const cases: [string, string][] = [
@@ -59,7 +79,12 @@ describe('extractPartialEscapeTail', () => {
       ['clean', '\x1b[1'],
       // Fold-safety must hold across the CAN abort too.
       ['\x1b', '\x18after'],
-      ['\x1b ', '\x18after']
+      ['\x1b ', '\x18after'],
+      // Boundary landing inside stringEsc/oscEsc — the two states that used to break the fold.
+      ['\x1bPx\x1b\x18', 'X0abc'],
+      ['\x1b]0;t\x1b\x1a', 'X0abc'],
+      ['\x1b] \x1b\x1b', '^'],
+      ['\x1bPq\x1b\x1b', '[3']
     ]
     for (const [a, b] of cases) {
       expect(extractPartialEscapeTail(extractPartialEscapeTail(a) + b)).toBe(

--- a/src/shared/terminal-partial-escape-tail.ts
+++ b/src/shared/terminal-partial-escape-tail.ts
@@ -116,9 +116,11 @@ export function extractPartialEscapeTail(stream: string): string {
         if (code === 0x5c) {
           state = 'ground' // ESC \ = ST terminates the OSC
         } else {
-          // The ESC aborted the OSC and opened a new sequence at i-1.
-          start = i - 1
-          state = code === ESC ? 'esc' : stateAfterEscByte(code)
+          // The ESC aborted the OSC and opened a new sequence at i-1 — except a
+          // second ESC starts its own sequence at i, and CAN/SUB abort to ground.
+          start = code === ESC ? i : i - 1
+          state =
+            code === ESC ? 'esc' : code === CAN || code === SUB ? 'ground' : stateAfterEscByte(code)
         }
         break
       case 'string':
@@ -132,8 +134,9 @@ export function extractPartialEscapeTail(stream: string): string {
         if (code === 0x5c) {
           state = 'ground'
         } else {
-          start = i - 1
-          state = code === ESC ? 'esc' : stateAfterEscByte(code)
+          start = code === ESC ? i : i - 1
+          state =
+            code === ESC ? 'esc' : code === CAN || code === SUB ? 'ground' : stateAfterEscByte(code)
         }
         break
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​64 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

When output arrives from a terminal, it can get cut in half mid-escape-sequence — the first half in one read, the rest in the next. Orca keeps track of that dangling half ("the pending tail") so a snapshot can replay it and the sequence finishes exactly as it would have live.

For that to work, the tracker has to give the same answer whether it sees the bytes all at once or split across two reads. That's the fold property: `extract(a + b) === extract(extract(a) + b)`.

In two situations it didn't. If a read happened to break at exactly the wrong byte, Orca remembered a *different* dangling tail than the real one — so after a snapshot restore the next chunk could render as literal garbage instead of completing the sequence. This PR makes both cases agree.

## The bugs

Both live in `src/shared/terminal-partial-escape-tail.ts`, in the `oscEsc` / `stringEsc` branch that handles "an ESC showed up inside an OSC/DCS/SOS/PM/APC string but didn't terminate it".

**1. CAN/SUB abort inside a string sequence.** The aborting byte was routed through `stateAfterEscByte`, which maps a C0 byte back to `esc` — it never re-applied the CAN/SUB abort-to-ground that every other state does.

```
extractPartialEscapeTail('\x1bPx\x1b\x18X0abc')
  whole stream  ->  "\x1b\x18X0abc"
  split at 5    ->  extract("\x1bPx\x1b\x18") = "\x1b\x18", then extract("\x1b\x18" + "X0abc") = ""
```

`""` is correct: CAN aborts the sequence, nothing is left pending.

**2. Double ESC inside OSC/DCS.** A second ESC opened its new sequence at `i - 1` (the *first* ESC) instead of at itself.

```
extractPartialEscapeTail('\x1b] \x1b\x1b^')
  whole stream  ->  "\x1b\x1b^"
  split at 5    ->  "\x1b^"
```

Here the **fold** is the correct one — xterm starts the new sequence at the second ESC, so `"\x1b^"` is right and the whole-stream answer was wrong.

## The fix

Two lines at each of the two sites:

```ts
start = code === ESC ? i : i - 1
state =
  code === ESC ? 'esc' : code === CAN || code === SUB ? 'ground' : stateAfterEscByte(code)
```

## Fuzz numbers

Fold-property fuzz over random VT streams, split at every code-unit boundary (plus a 3-way fold), with an alphabet carrying CAN, SUB, doubled ESC inside OSC/DCS/SOS/PM/APC, BEL, C1 ST, NUL, DEL, CSI/OSC/DCS introducers, intermediates, CJK, astral emoji, and lone/split surrogates. Identical PRNG stream before and after:

| seed | splits | failures before | failures after |
| --- | --- | --- | --- |
| 12345 | 1,248,301 | **421** | **0** |
| 1 | 832,172 | 294 | 0 |
| 7 | 830,281 | 370 | 0 |
| 99 | 831,395 | 283 | 0 |
| 2026 | 832,882 | 412 | 0 |

## Why these survived: the fold check was a tautology

The module's fuzz asserted the fold as `advance(extract(pending), chunk) === extract(pending + chunk)`. Every `PENDINGS` entry is already a tail, so `extract(pending) === pending` and the assertion could never fail. Nothing ever landed a split boundary *inside* `oscEsc`/`stringEsc`.

Replaced with a sweep that re-splits each combined stream at every code-unit boundary (6.24M split checks in CI, ~2.3s added), and extended the corpus so this is permanently covered:

- `ALPHABET` += NUL, `0x20` intermediate, CJK (CAN/SUB/ESC were already there).
- `SEQUENCES` += 8 cases with CAN/SUB aborts from inside string state and doubled ESC inside OSC/DCS/SOS/PM/APC.

Verified red/green: reverting only `terminal-partial-escape-tail.ts` to `main` makes the extended fuzz fail with exactly these two shapes.

```
fold property broke: {"text":"]0;ti","cut":8,"whole":"","folded":""}
fold property broke: {"text":"PxX0abc","cut":5,"whole":"X0abc","folded":""}
```

Plus focused regression tests in `terminal-partial-escape-tail.test.ts` for both exact inputs.

## Reliability gate

No gate covered this module. `terminal-session.shell-owned-mode-recovery` already claims *"split-escape safety at every chunk boundary"* in its oracle and gates the two suites that thread `pendingEscapeTailAnsi` over the wire — but never ran the producer's own suite. Added both suites to its command/`testFiles` with an `assertionRef`. `pnpm run check:reliability-gates` passes (109 gates).

## Pre-existing, and independent of the in-flight perf PRs

These bugs are **pre-existing on `main`** — reproduced on unmodified `origin/main` before any change here. They were not introduced by the in-flight terminal perf work. In particular **#19393 (`nwparker/perf-terminal-ground-scan-20260907`) is neutral on them**: it changes how the ground-state scan is walked and does not touch the `oscEsc`/`stringEsc` transitions, so it neither causes nor fixes either case. This PR is a standalone semantic fix branched directly off `main` and carries none of those perf changes.

## Verification

- `src/shared/terminal-partial-escape-tail.test.ts`, `.fuzz.test.ts` — 16 passed
- `hidden-reveal-reconciliation.fuzz.test.ts` (other direct importer) — passed
- `headless-emulator*`, `reattach-snapshot`, `terminal-snapshot-serialize-roundtrip` (downstream of the only production importer, `headless-emulator.ts`) — 107 passed
- `session-shell-recovery.test.ts`, `terminal-multiplex-escape-tail.test.ts` — passed
- `oxlint` clean; `pnpm run check:code-quality:changed` — 0 new findings across 3 files
- `pnpm run check:reliability-gates` — passed

Note: `remote-runtime-pty-snapshot-escape-tail.test.ts` fails on this branch **and identically on unmodified `main`** (import error in `terminal-pty-ack-gate.ts`) — pre-existing and unrelated to this change.
