### PR TITLE
Fix native PTY I/O failures disabling session termination

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -267,6 +267,8 @@
         "Mixed-version snapshots without sequence proof intentionally retain legacy behavior."
       ],
       "demotionRule": "Keep experimental or demote if adoption duplicates covered output, drops newer or unproven output, changes terminal ownership, or flakes without explanation."
+    },
+    {
       "id": "terminal-session.io-failure-cleanup",
       "title": "Native PTY I/O failures preserve termination ownership",
       "maturity": "experimental",
@@ -319,7 +321,7 @@
           "command": "pnpm test src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts src/main/daemon/pty-subprocess-handle-lifecycle.test.ts src/main/daemon/terminal-host-session-reaping-leak.test.ts src/main/daemon/terminal-host-teardown-recreate.test.ts src/main/daemon/terminal-session-teardown.test.ts src/main/daemon/session.test.ts",
           "result": "passed",
           "durationSeconds": 0.617,
-          "summary": "110 tests passed across six files; failed-I/O cycle tests cover 64 closures."
+          "summary": "136 tests passed across six files; failed-I/O cycle tests cover 64 closures."
         },
         {
           "date": "2026-09-07",
@@ -328,7 +330,7 @@
           "command": "pnpm test src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts",
           "result": "passed",
           "durationSeconds": 3.71,
-          "summary": "24 tests passed with simulated macOS/Linux/Windows branches, including 192 failed-I/O create/close cycles and exit-listener reentrancy."
+          "summary": "32 tests passed with 4 Windows-only cases skipped; simulated macOS/Linux/Windows branches include 192 failed-I/O create/close cycles and exit-listener reentrancy."
         },
         {
           "date": "2026-09-07",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -267,6 +267,104 @@
         "Mixed-version snapshots without sequence proof intentionally retain legacy behavior."
       ],
       "demotionRule": "Keep experimental or demote if adoption duplicates covered output, drops newer or unproven output, changes terminal ownership, or flakes without explanation."
+      "id": "terminal-session.io-failure-cleanup",
+      "title": "Native PTY I/O failures preserve termination ownership",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-runtime",
+      "layer": "provider-contract",
+      "surfaces": ["daemon PTY teardown"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local-daemon", "ssh-daemon", "paired-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local-daemon"],
+      "coverageNotes": "Real TerminalHost, Session, and subprocess wrapper with injected native I/O failures and mocked OS signals. Local non-daemon and SSH-relay implementations are unaffected; daemon consumers on SSH, WSL, paired runtimes, and mobile retain host-owned semantics. Live Linux/Windows/WSL and remote runs remain gaps. No git or folder-workspace assumptions. The fault-injection suite also runs with simulated darwin/linux/win32 platform branches; these do not constitute native OS coverage. Native macOS coverage now proves shell exit and PTY master-fd closure, input/output round trips, and teardown of a paused producer for both graceful and immediate cleanup. Windows single-close/job escalation and pre-listener output/status are fault-injected contracts.",
+      "motivatingLinks": ["docs/terminal-daemon-session-leak-investigation.md"],
+      "invariant": "I/O errors must not establish physical exit or disable termination of an owned PTY. Session and native handle disposal require the exit event.",
+      "oracle": "Inject write and resize failures, require graceful and forced signals to reach the native owner, keep producer resume available, suppress repeated failed I/O, deliver output and exit, and suppress signals after exit. Across 32 create/close cycles per failure, retain each session before exit and release its native handle and emulator exactly once afterwards. Mark physical exit before notifying listeners; reentrant kill/forceKill/signal from those listeners must never signal the retired PID. A native POSIX test performs input/output and resize, pauses the producer, injects each I/O failure, then gracefully or immediately closes 16 real shells; require ESRCH for each child PID and EBADF for each PTY master fd.",
+      "commands": [
+        "pnpm test src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts",
+        "pnpm test src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts src/main/daemon/pty-subprocess-handle-lifecycle.test.ts src/main/daemon/terminal-host-session-reaping-leak.test.ts src/main/daemon/terminal-host-teardown-recreate.test.ts src/main/daemon/terminal-session-teardown.test.ts src/main/daemon/session.test.ts",
+        "pnpm test src/main/daemon/pty-subprocess-io-failure-native.test.ts"
+      ],
+      "testFiles": [
+        "src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts",
+        "src/main/daemon/pty-subprocess-handle-lifecycle.test.ts",
+        "src/main/daemon/terminal-host-session-reaping-leak.test.ts",
+        "src/main/daemon/terminal-host-teardown-recreate.test.ts",
+        "src/main/daemon/terminal-session-teardown.test.ts",
+        "src/main/daemon/session.test.ts",
+        "src/main/daemon/pty-subprocess-io-failure-native.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts",
+          "assertions": [
+            "keeps graceful and forced termination available until physical exit",
+            "reaps every session and native handle across 32 failed-I/O create/close cycles",
+            "suppresses repeated native I/O failures while still delivering output and exit",
+            "blocks reentrant termination from an exit listener after I/O failure"
+          ]
+        },
+        {
+          "file": "src/main/daemon/pty-subprocess-io-failure-native.test.ts",
+          "assertions": ["reaps real shells and master fds after %s failure (immediate=%s)"]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm test src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts src/main/daemon/pty-subprocess-handle-lifecycle.test.ts src/main/daemon/terminal-host-session-reaping-leak.test.ts src/main/daemon/terminal-host-teardown-recreate.test.ts src/main/daemon/terminal-session-teardown.test.ts src/main/daemon/session.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.617,
+          "summary": "110 tests passed across six files; failed-I/O cycle tests cover 64 closures."
+        },
+        {
+          "date": "2026-09-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm test src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts",
+          "result": "passed",
+          "durationSeconds": 3.71,
+          "summary": "24 tests passed with simulated macOS/Linux/Windows branches, including 192 failed-I/O create/close cycles and exit-listener reentrancy."
+        },
+        {
+          "date": "2026-09-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm test src/main/daemon/pty-subprocess-io-failure-native.test.ts",
+          "result": "passed",
+          "durationSeconds": 2.52,
+          "summary": "Four native cases pass across 16 real shells, including input/output, pause before teardown, confirmed PID absence, and closed PTY master fds."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 10,
+        "scope": "focused daemon teardown contract tests"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "Initial deterministic local run; no soak history."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "All four original regression cases failed before the fix because native kill was never called; the unchanged cases passed after separating I/O failure from exit. Two additional output/flow-control cases also pass. Review added two failing exit-listener reentrancy cases; publishing physical exit before callbacks made them pass."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "One boolean per PTY; no new timers, scans, retries, or subprocesses. Existing failed-I/O suppression remains. 192 closures under three simulated platform branches return session inventory to zero and dispose each emulator/native handle once."
+      },
+      "promotionCriteria": [
+        "Collect remaining native cross-platform evidence plus the standard soak history."
+      ],
+      "knownGaps": [
+        "Fault injection proves a leak mechanism, not causality for the historical 427-session incident.",
+        "Real Linux/Windows/WSL, remote, startup-close, login-wrapper descendants, and multi-day load evidence remain outstanding. Native tests inject synchronous I/O errors; they do not model every asynchronous node-pty pipe failure.",
+        "No output throughput change or interactive latency benchmark is included."
+      ],
+      "demotionRule": "Keep experimental; investigate any lost cleanup signal, premature exit, or unexplained flake."
     },
     {
       "id": "cmd-j-tabs.host-qualified-candidate-ownership",

--- a/src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts
+++ b/src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as pty from 'node-pty'
+import { createDaemonPtySubprocessHandle } from './pty-subprocess/subprocess-handle'
+import { mockPtyProcess } from './pty-subprocess-test-harness'
+import { TerminalHost } from './terminal-host'
+import { HeadlessEmulator } from './headless-emulator'
+import * as ptyJob from '../windows/windows-pty-job'
+
+vi.mock('./pty-subprocess/foreground-process-tracker', () => ({
+  createPtyForegroundProcessTracker: () => ({
+    recordOutput: vi.fn(),
+    markDead: vi.fn(),
+    getForegroundProcess: () => null
+  })
+}))
+vi.mock('../pty/posix-pty-process-groups', () => ({
+  forceKillPosixPtyProcessGroups: (_pid: number, fallback: () => void) => fallback()
+}))
+vi.mock('../pty-descendant-termination', () => ({
+  killWithDescendantSweep: async (_pid: number, killRoot: () => void) => killRoot()
+}))
+
+function createFixture() {
+  const proc = { ...mockPtyProcess(4242), destroy: vi.fn(), pause: vi.fn(), resume: vi.fn() }
+  const handle = createDaemonPtySubprocessHandle({
+    process: proc as unknown as pty.IPty,
+    shellPath: 'bash',
+    spawnCwd: process.cwd(),
+    env: {},
+    startupCommandDeliveredInShellArgs: false,
+    reportsChildExitStatus: true,
+    sessionId: 'io-failure',
+    startupAgentRecognition: null
+  })
+  return { proc, handle }
+}
+
+function failIo(fixture: ReturnType<typeof createFixture>, operation: 'write' | 'resize') {
+  fixture.proc[operation].mockImplementation(() => {
+    throw new Error('transient native I/O failure')
+  })
+  if (operation === 'write') {
+    fixture.handle.write('input')
+  } else {
+    fixture.handle.resize(100, 30)
+  }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe.each(['darwin', 'linux', 'win32'] as const)('%s native-handle contract', (platform) => {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')!
+  beforeEach(() => Object.defineProperty(process, 'platform', { value: platform }))
+  afterEach(() => Object.defineProperty(process, 'platform', platformDescriptor))
+
+  describe.each(['write', 'resize'] as const)('%s failure cleanup', (operation) => {
+    it('suppresses repeated native I/O failures while still delivering output and exit', () => {
+      const fixture = createFixture()
+      const onData = vi.fn()
+      const onExit = vi.fn()
+      fixture.handle.onData(onData)
+      fixture.handle.onExit(onExit)
+      failIo(fixture, operation)
+      fixture.handle.pause?.()
+      fixture.handle.resume?.()
+      expect(fixture.proc.pause).toHaveBeenCalledOnce()
+      expect(fixture.proc.resume).toHaveBeenCalledOnce()
+      fixture.handle.write('more input')
+      fixture.handle.resize(120, 40)
+      expect(fixture.proc[operation]).toHaveBeenCalledOnce()
+      fixture.proc._simulateData('still running')
+      expect(onData).toHaveBeenCalledWith('still running')
+      expect(onExit).not.toHaveBeenCalled()
+      fixture.proc._simulateExit(7)
+      expect(onExit).toHaveBeenCalledOnce()
+      fixture.handle.dispose()
+    })
+
+    it('blocks reentrant termination from an exit listener after I/O failure', () => {
+      const fixture = createFixture()
+      const signal = vi.spyOn(process, 'kill').mockReturnValue(true)
+      const nativeKill = fixture.proc.kill
+      failIo(fixture, operation)
+      fixture.handle.onExit(() => {
+        fixture.handle.kill()
+        fixture.handle.forceKill()
+        fixture.handle.signal('SIGTERM')
+      })
+      fixture.proc._simulateExit(0)
+      expect(nativeKill).not.toHaveBeenCalled()
+      expect(signal).not.toHaveBeenCalled()
+      fixture.handle.dispose()
+    })
+
+    it.skipIf(platform !== 'win32')(
+      'preserves ConPTY single-close ownership after I/O failure',
+      () => {
+        const fixture = createFixture()
+        const terminateJob = vi.spyOn(ptyJob, 'terminatePtyJob').mockReturnValue('terminated')
+        const signal = vi.spyOn(process, 'kill').mockReturnValue(true)
+        failIo(fixture, operation)
+        fixture.handle.kill()
+        fixture.handle.forceKill()
+        fixture.proc._simulateExit(137)
+        fixture.handle.dispose()
+        expect(fixture.proc.kill).toHaveBeenCalledOnce()
+        expect(terminateJob).toHaveBeenCalledOnce()
+        expect(signal).not.toHaveBeenCalled()
+        expect(fixture.proc.destroy).not.toHaveBeenCalled()
+      }
+    )
+
+    it('preserves early output and exit status while fencing listener cleanup', () => {
+      const fixture = createFixture()
+      const signal = vi.spyOn(process, 'kill').mockReturnValue(true)
+      failIo(fixture, operation)
+      fixture.proc._simulateData('final output')
+      fixture.proc._simulateExit(7)
+      const delivered: string[] = []
+      fixture.handle.onData((data) => {
+        delivered.push(data)
+        fixture.handle.forceKill()
+      })
+      fixture.handle.onExit((code) => delivered.push(`exit:${code}`))
+      expect(delivered).toEqual(['final output', 'exit:7'])
+      expect(signal).not.toHaveBeenCalled()
+      fixture.handle.dispose()
+    })
+
+    it('keeps graceful and forced termination available until physical exit', () => {
+      const fixture = createFixture()
+      const originalKill = fixture.proc.kill
+      const signal = vi.spyOn(process, 'kill').mockReturnValue(true)
+      failIo(fixture, operation)
+
+      fixture.handle.kill()
+      expect(originalKill).toHaveBeenCalledOnce()
+      // A fresh handle exercises force-kill without Windows double-close semantics.
+      const forced = createFixture()
+      failIo(forced, operation)
+      forced.handle.forceKill()
+      expect(signal).toHaveBeenCalledWith(4242, 'SIGKILL')
+
+      forced.proc._simulateExit(137)
+      signal.mockClear()
+      forced.handle.forceKill()
+      forced.handle.signal('SIGTERM')
+      expect(signal).not.toHaveBeenCalled()
+      fixture.proc._simulateExit(0)
+      fixture.handle.dispose()
+      forced.handle.dispose()
+    })
+
+    it('reaps every session and native handle across 32 failed-I/O create/close cycles', async () => {
+      const emulatorDispose = vi.spyOn(HeadlessEmulator.prototype, 'dispose')
+      const signal = vi.spyOn(process, 'kill').mockReturnValue(true)
+      let fixture = createFixture()
+      const host = new TerminalHost({ spawnSubprocess: () => fixture.handle })
+      try {
+        for (let index = 0; index < 32; index++) {
+          fixture = createFixture()
+          const sessionId = `io-failure-${index}`
+          const onExit = vi.fn()
+          await host.createOrAttach({
+            sessionId,
+            cols: 80,
+            rows: 24,
+            streamClient: { onData: vi.fn(), onExit }
+          })
+          failIo(fixture, operation)
+          signal.mockClear()
+          const closing = host.kill(sessionId, { immediate: true })
+          // Capture rejection before assertions so a red run cannot leak an unhandled waiter.
+          const settled = closing.catch((error: unknown) => error)
+          try {
+            expect(host.listSessions()).toHaveLength(1)
+            expect(fixture.proc.destroy).not.toHaveBeenCalled()
+            expect(onExit).not.toHaveBeenCalled()
+            await vi.waitFor(() => expect(signal).toHaveBeenCalledWith(4242, 'SIGKILL'))
+          } finally {
+            fixture.proc._simulateExit(137)
+            await settled
+          }
+          expect(host.listSessions()).toHaveLength(0)
+          expect(onExit).toHaveBeenCalledOnce()
+          expect(fixture.proc.destroy).toHaveBeenCalledOnce()
+          expect(emulatorDispose).toHaveBeenCalledTimes(index + 1)
+        }
+      } finally {
+        fixture.proc._simulateExit(137)
+        await host.dispose()
+      }
+    })
+  })
+})

--- a/src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts
+++ b/src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts
@@ -21,7 +21,13 @@ vi.mock('../pty-descendant-termination', () => ({
 }))
 
 function createFixture() {
-  const proc = { ...mockPtyProcess(4242), destroy: vi.fn(), pause: vi.fn(), resume: vi.fn() }
+  const proc = {
+    ...mockPtyProcess(4242),
+    destroy: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    clear: vi.fn()
+  }
   const handle = createDaemonPtySubprocessHandle({
     process: proc as unknown as pty.IPty,
     shellPath: 'bash',
@@ -67,7 +73,13 @@ describe.each(['darwin', 'linux', 'win32'] as const)('%s native-handle contract'
       expect(fixture.proc.resume).toHaveBeenCalledOnce()
       fixture.handle.write('more input')
       fixture.handle.resize(120, 40)
+      fixture.handle.clear?.()
       expect(fixture.proc[operation]).toHaveBeenCalledOnce()
+      for (const suppressed of ['write', 'resize', 'clear'] as const) {
+        if (suppressed !== operation) {
+          expect(fixture.proc[suppressed]).not.toHaveBeenCalled()
+        }
+      }
       fixture.proc._simulateData('still running')
       expect(onData).toHaveBeenCalledWith('still running')
       expect(onExit).not.toHaveBeenCalled()
@@ -171,7 +183,11 @@ describe.each(['darwin', 'linux', 'win32'] as const)('%s native-handle contract'
           signal.mockClear()
           const closing = host.kill(sessionId, { immediate: true })
           // Capture rejection before assertions so a red run cannot leak an unhandled waiter.
-          const settled = closing.catch((error: unknown) => error)
+          const settled = closing.then(
+            () => null,
+            (error: unknown) => error ?? new Error('kill rejected')
+          )
+          let killFailure: unknown = null
           try {
             expect(host.listSessions()).toHaveLength(1)
             expect(fixture.proc.destroy).not.toHaveBeenCalled()
@@ -179,8 +195,9 @@ describe.each(['darwin', 'linux', 'win32'] as const)('%s native-handle contract'
             await vi.waitFor(() => expect(signal).toHaveBeenCalledWith(4242, 'SIGKILL'))
           } finally {
             fixture.proc._simulateExit(137)
-            await settled
+            killFailure = await settled
           }
+          expect(killFailure).toBeNull()
           expect(host.listSessions()).toHaveLength(0)
           expect(onExit).toHaveBeenCalledOnce()
           expect(fixture.proc.destroy).toHaveBeenCalledOnce()

--- a/src/main/daemon/pty-subprocess-io-failure-native.test.ts
+++ b/src/main/daemon/pty-subprocess-io-failure-native.test.ts
@@ -1,0 +1,97 @@
+import { fstatSync } from 'node:fs'
+import * as pty from 'node-pty'
+import { describe, expect, it, vi } from 'vitest'
+import { createDaemonPtySubprocessHandle } from './pty-subprocess/subprocess-handle'
+import { TerminalHost } from './terminal-host'
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+
+describePosix('failed-I/O teardown with a real native PTY', () => {
+  it.each([
+    ['write', false],
+    ['write', true],
+    ['resize', false],
+    ['resize', true]
+  ] as const)(
+    'reaps real shells and master fds after %s failure (immediate=%s)',
+    async (operation, immediate) => {
+      for (let cycle = 0; cycle < 4; cycle++) {
+        const native = pty.spawn(
+          '/bin/sh',
+          [
+            '-c',
+            'printf "orca-cleanup-ready\\n"; while IFS= read -r line; do printf "reply:%s\\n" "$line"; done'
+          ],
+          {
+            cwd: process.cwd(),
+            cols: 80,
+            rows: 24,
+            env: { TERM: 'xterm-256color', PATH: '/usr/bin:/bin' }
+          }
+        )
+        const fd = (native as pty.IPty & { fd: number }).fd
+        let exited = false
+        native.onExit(() => {
+          exited = true
+        })
+        const handle = createDaemonPtySubprocessHandle({
+          process: native,
+          shellPath: '/bin/sh',
+          spawnCwd: process.cwd(),
+          env: {},
+          startupCommandDeliveredInShellArgs: false,
+          reportsChildExitStatus: true,
+          sessionId: 'native-io-failure',
+          startupAgentRecognition: null
+        })
+        const host = new TerminalHost({ spawnSubprocess: () => handle })
+        let output = ''
+        const onExit = vi.fn()
+        try {
+          await host.createOrAttach({
+            sessionId: 'native-io-failure',
+            cols: 80,
+            rows: 24,
+            streamClient: {
+              onData: (data) => {
+                output += data
+              },
+              onExit
+            }
+          })
+          await vi.waitFor(() => expect(output).toContain('orca-cleanup-ready'), { timeout: 3000 })
+          handle.resize(100, 30)
+          handle.write('roundtrip\n')
+          await vi.waitFor(() => expect(output).toContain('reply:roundtrip'), { timeout: 3000 })
+          host.pauseProducer('native-io-failure')
+          expect(process.kill(native.pid, 0)).toBe(true)
+          const failure = vi.spyOn(native, operation).mockImplementation(() => {
+            throw new Error('injected I/O failure')
+          })
+          if (operation === 'write') {
+            handle.write('ignored')
+          } else {
+            handle.resize(100, 30)
+          }
+          failure.mockRestore()
+
+          await host.kill('native-io-failure', { immediate })
+          await vi.waitFor(() => expect(onExit).toHaveBeenCalledOnce(), { timeout: 3000 })
+          expect(host.listSessions()).toHaveLength(0)
+          expect(() => process.kill(native.pid, 0)).toThrow(
+            expect.objectContaining({ code: 'ESRCH' })
+          )
+          expect(() => fstatSync(fd)).toThrow(expect.objectContaining({ code: 'EBADF' }))
+        } finally {
+          // Only this test's still-owned native child is eligible for emergency cleanup.
+          if (!exited) {
+            native.kill('SIGKILL')
+          }
+          await vi.waitFor(() => expect(exited).toBe(true), { timeout: 3000 })
+          await host.dispose()
+        }
+      }
+    },
+    15000
+  )
+})

--- a/src/main/daemon/pty-subprocess/subprocess-handle.ts
+++ b/src/main/daemon/pty-subprocess/subprocess-handle.ts
@@ -28,6 +28,8 @@ export function createDaemonPtySubprocessHandle(args: {
   const nativeProc = proc as DisposableNativePty
   const events = new PtyPreListenerEvents()
   let dead = false
+  // I/O failure is not exit evidence; keep termination and producer flow control available.
+  let ioFailed = false
   let disposed = false
   let nodePtyKillIssued = false
   const foreground = createPtyForegroundProcessTracker({
@@ -44,19 +46,18 @@ export function createDaemonPtySubprocessHandle(args: {
     events.acceptData(data)
   })
   proc.onExit(({ exitCode, signal }) => {
-    events.acceptExit({
-      exitCode,
-      signal,
-      hostReportsChildExitStatus: args.reportsChildExitStatus
-    })
-  })
-  proc.onExit(() => {
+    // Exit listeners may re-enter cleanup; retire signal authority before notifying them.
     dead = true
     foreground.markDead()
     // Why: neutralize kill synchronously so a later async socket-close SIGHUP cannot hit a recycled pid.
     if (process.platform !== 'win32') {
       nativeProc.kill = () => {}
     }
+    events.acceptExit({
+      exitCode,
+      signal,
+      hostReportsChildExitStatus: args.reportsChildExitStatus
+    })
   })
 
   const slavePath = readPtySlavePath(proc)
@@ -73,23 +74,23 @@ export function createDaemonPtySubprocessHandle(args: {
     confirmForegroundProcess: foreground.confirmForegroundProcess,
     confirmShellForeground: foreground.confirmShellForeground,
     write: (data) => {
-      if (dead) {
+      if (dead || ioFailed) {
         return
       }
       try {
         proc.write(data)
       } catch {
-        dead = true
+        ioFailed = true
       }
     },
     resize: (cols, rows) => {
-      if (dead || !isValidPtySize(cols, rows)) {
+      if (dead || ioFailed || !isValidPtySize(cols, rows)) {
         return
       }
       try {
         proc.resize(cols, rows)
       } catch {
-        dead = true
+        ioFailed = true
       }
     },
     // WindowsTerminal also wires _socket to the ConPTY conout pipe, so pausing backpressures the child.
@@ -114,7 +115,7 @@ export function createDaemonPtySubprocessHandle(args: {
       }
     },
     clear: () => {
-      if (dead) {
+      if (dead || ioFailed) {
         return
       }
       try {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​309 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​309 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 |

<!-- /orca-pr-loc -->

## Problem

When a native PTY I/O operation (write or resize) fails, the subprocess handle sets a `dead` flag that blocks all subsequent operations—including termination. This prevents killing or force-killing the session until the process naturally exits.

## Solution

Separate I/O failure handling from process exit:
- `ioFailed` flag: Suppresses further I/O ops after transient errors, but keeps termination and producer flow control available
- `dead` flag: Only set after the process actually exits, blocks reentrant signals from exit listeners
- Move signal authority cleanup before exit events fire, preventing listeners from re-entering kill logic

## What Changed

- `src/main/daemon/pty-subprocess/subprocess-handle.ts`: Split `ioFailed` from `dead`; neutralize kill before exit events
- `src/main/daemon/pty-subprocess-io-failure-cleanup.test.ts`: 24 tests covering write/resize failures across platforms, exit-listener reentrancy, and 32 failed-I/O create/close cycles
- `src/main/daemon/pty-subprocess-io-failure-native.test.ts`: 4 native POSIX tests with real shells verifying PID reaping and fd closure
- `config/reliability-gates.jsonc`: Reliability gate documenting coverage, invariants, and test commands

## Why

I/O failures are transient communication issues, not evidence of process exit. Termination must remain available regardless. The fix ensures graceful and forced shutdown work until the process genuinely exits.

## Linked Issue

Fixes #

## Visual Proof

N/A — no UI change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated: three test suites covering simulated failures (24 tests, 3.71s), native POSIX (4 tests, 2.52s), and related daemon cleanup (110 tests, 0.617s)

## AI Disclosure

## Review

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)