### PR TITLE
perf(terminal): own retained tail rows so they stop pinning their chunks

### DIFF
--- a/src/main/runtime/orca-runtime-schedule-wait-blocked-check.ts
+++ b/src/main/runtime/orca-runtime-schedule-wait-blocked-check.ts
@@ -16,6 +16,7 @@ import {
   computeTerminalTailWaitState,
   tailGainedNewerBlockedReason
 } from './terminal-wait-tail-state'
+import { ownRetainedString } from '../../shared/own-retained-string'
 import type { ProcessedAgentStatusChunk } from '../../shared/agent-status-osc'
 import { createAgentStatusOscProcessor } from '../../shared/agent-status-osc'
 import type { RuntimePtyTitleTrackerEntry } from './runtime-terminal-state-records'
@@ -32,7 +33,9 @@ export class OrcaRuntimeWithScheduleWaitBlockedCheck extends OrcaRuntimeWithOnPt
     // plus the concatenation the pattern flattens anyway.
     const keywordWindow = `${state.keywordCarry}${appendedText}`.toLowerCase()
     const keywordHit = WAIT_BLOCKED_KEYWORD_PATTERN.test(keywordWindow)
-    state.keywordCarry = keywordWindow.slice(-WAIT_BLOCKED_KEYWORD_CARRY_CHARS)
+    // Why own: this 31-char carry lives per PTY until the next chunk, and un-owned it pins the
+    // whole lowercased window — a full copy of the chunk.
+    state.keywordCarry = ownRetainedString(keywordWindow.slice(-WAIT_BLOCKED_KEYWORD_CARRY_CHARS))
     appendWaitBlockedCarry(state.appended, appendedText)
     const elapsed = at - state.lastAt
     if (keywordHit || elapsed >= WAIT_BLOCKED_CHECK_MIN_INTERVAL_MS || elapsed < 0) {

--- a/src/main/runtime/terminal-tail-buffer.ts
+++ b/src/main/runtime/terminal-tail-buffer.ts
@@ -1,4 +1,5 @@
 import { containsTerminalVerticalLineControl } from './terminal-ansi-normalization'
+import { ownRetainedString } from '../../shared/own-retained-string'
 import { carryTerminalTailSentinelMatches } from './terminal-tail-sentinel-index'
 import {
   applyTerminalLineControls,
@@ -171,11 +172,13 @@ export function appendNormalizedToTailBuffer(
   const pieces = processTerminalTailCompleteSegments(segments.completeSegments)
   const newlyCompletedLines: string[] = []
   for (const piece of pieces) {
-    newlyCompletedLines.push(trimTerminalLineRight(piece))
+    // Why own: every retained row is sliced from this chunk but outlives it by up to
+    // MAX_TAIL_LINES chunks, so an un-owned row pins its whole 64 KiB chunk.
+    newlyCompletedLines.push(ownRetainedString(trimTerminalLineRight(piece)))
   }
   const partialResult = applyTerminalLineControls(segments.partialSegment)
   const nextPartialLine = trimTerminalLineRight(partialResult.text)
-  const retainedPartialLine = nextPartialLine.slice(-MAX_TAIL_PARTIAL_CHARS)
+  const retainedPartialLine = ownRetainedString(nextPartialLine.slice(-MAX_TAIL_PARTIAL_CHARS))
   const newCompleteLines = segments.completeLineCount
   const omittedNewCompleteLines = newCompleteLines - pieces.length
 

--- a/src/main/runtime/terminal-tail-redraw-buffer.ts
+++ b/src/main/runtime/terminal-tail-redraw-buffer.ts
@@ -2,6 +2,7 @@ import {
   hasCanonicalNumericCsiParams,
   parseAnsiControlSequence
 } from './terminal-ansi-normalization'
+import { ownRetainedString } from '../../shared/own-retained-string'
 import { clampTerminalPreviewCursor, trimTerminalLineRight } from './terminal-tail-line-controls'
 import { MAX_TAIL_CHARS, MAX_TAIL_LINES, MAX_TAIL_PARTIAL_CHARS } from './terminal-tail-limits'
 
@@ -241,7 +242,11 @@ function finalizeRetainedTerminalRows(
 
   return {
     lines,
-    partialLine,
+    // Why only the partial: redraw rows are built character by character and never sliced from
+    // the chunk, but the partial is re-sliced from its own row on every chunk, so it alone can
+    // accumulate a backing string across frames. Owning the rows too costs 20-36% on TUI floods
+    // for no measured retention.
+    partialLine: ownRetainedString(partialLine),
     redrawCursor,
     truncated,
     newCompleteLines,

--- a/src/main/runtime/terminal-tail-row-retention.test.ts
+++ b/src/main/runtime/terminal-tail-row-retention.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as ownership from '../../shared/own-retained-string'
+import { appendNormalizedToTailBuffer } from './terminal-tail-buffer'
+
+const SPINNER = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴']
+
+/** A Claude Code / Codex spinner chunk: many CR-redraw frames, then one completed line. */
+function spinnerChunk(index: number, chunkChars: number): string {
+  const parts: string[] = []
+  let length = 0
+  let frame = 0
+  while (length < chunkChars - 64) {
+    const piece = `\r${SPINNER[frame % SPINNER.length]} Thinking... (${frame}s) esc to interrupt`
+    parts.push(piece)
+    length += piece.length
+    frame += 1
+  }
+  parts.push(`\rstep ${index} done\n`)
+  return parts.join('')
+}
+
+function collectHeap(): number {
+  const gc = (globalThis as { gc?: () => void }).gc
+  if (!gc) {
+    throw new Error('global.gc unavailable - config/vitest.config.ts must pass --expose-gc')
+  }
+  void /reset/.test('reset')
+  gc()
+  gc()
+  return process.memoryUsage().heapUsed
+}
+
+describe('retained terminal tail row storage', () => {
+  it('does not pin one chunk per retained row across a spinner workload', () => {
+    let lines: string[] = []
+    let partialLine = ''
+    for (let index = 0; index < 4; index += 1) {
+      const warm = appendNormalizedToTailBuffer(lines, partialLine, spinnerChunk(index, 4096))
+      lines = warm.lines
+      partialLine = warm.partialLine
+    }
+
+    lines = []
+    partialLine = ''
+    const chunkChars = 64 * 1024
+    const chunkCount = 200
+    const before = collectHeap()
+    // Why build each chunk inside the loop: a pre-built array would pin every chunk itself.
+    for (let index = 0; index < chunkCount; index += 1) {
+      const next = appendNormalizedToTailBuffer(lines, partialLine, spinnerChunk(index, chunkChars))
+      lines = next.lines
+      partialLine = next.partialLine
+    }
+    const retained = collectHeap() - before
+
+    expect(lines).toHaveLength(chunkCount)
+    const tailChars = lines.reduce((sum, line) => sum + line.length, 0) + partialLine.length
+    expect(tailChars).toBeLessThan(8 * 1024)
+    // Un-owned, each of the 200 rows pins its own 64 Ki chunk: about 25 MB.
+    expect(retained).toBeLessThan(4 * 1024 * 1024)
+    expect(lines.at(-1)).toBe(`step ${chunkCount - 1} done`)
+  })
+
+  it('routes every retained row and partial line through ownRetainedString', () => {
+    const own = vi.spyOn(ownership, 'ownRetainedString')
+    try {
+      const chunk = `${'x'.repeat(16 * 1024)}\nsecond line\ntrailing partial`
+      const result = appendNormalizedToTailBuffer([], '', chunk)
+
+      expect(result.lines).toEqual(['x'.repeat(16 * 1024), 'second line'])
+      expect(result.partialLine).toBe('trailing partial')
+      expect(own.mock.calls.map(([value]) => value)).toEqual([
+        'x'.repeat(16 * 1024),
+        'second line',
+        'trailing partial'
+      ])
+    } finally {
+      own.mockRestore()
+    }
+  })
+
+  it('owns the redraw partial line without re-owning carried rows', () => {
+    const own = vi.spyOn(ownership, 'ownRetainedString')
+    try {
+      const seeded = appendNormalizedToTailBuffer([], '', 'row one\nrow two\nrow three\n')
+      own.mockClear()
+      // \x1b[2A drives the multiline redraw builder rather than the plain path.
+      const redrawn = appendNormalizedToTailBuffer(
+        seeded.lines,
+        seeded.partialLine,
+        '\x1b[2A\x1b[Krewritten two'
+      )
+
+      expect(redrawn.lines).toEqual(['row one'])
+      expect(redrawn.partialLine).toBe('rewritten two')
+      // One call for the partial only: redraw rows are built character by character.
+      expect(own).toHaveBeenCalledTimes(1)
+      expect(own).toHaveBeenLastCalledWith('rewritten two')
+    } finally {
+      own.mockRestore()
+    }
+  })
+
+  it('keeps completed lines and the tail transcript sharing the same owned rows', () => {
+    const result = appendNormalizedToTailBuffer([], '', 'alpha line\nbeta line\n')
+    expect(result.newlyCompletedLines).toEqual(['alpha line', 'beta line'])
+    // The transcript keeps these exact strings, so owning them covers it transitively.
+    result.newlyCompletedLines.forEach((line, index) => {
+      expect(result.lines[index]).toBe(line)
+    })
+  })
+})

--- a/src/main/runtime/wait-blocked-keyword-carry-retention.test.ts
+++ b/src/main/runtime/wait-blocked-keyword-carry-retention.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as ownership from '../../shared/own-retained-string'
+import { OrcaRuntimeWithScheduleWaitBlockedCheck } from './orca-runtime-schedule-wait-blocked-check'
+import { WAIT_BLOCKED_KEYWORD_CARRY_CHARS } from './orca-runtime-postlude'
+import type { createWaitBlockedCheckState } from './wait-blocked-check-state'
+
+type ScheduleHost = {
+  waitBlockedCheckStateByPtyId: Map<string, ReturnType<typeof createWaitBlockedCheckState>>
+  runWaitBlockedCheck: () => void
+  scheduleWaitBlockedCheck: (ptyId: string, appendedText: string, at: number) => void
+}
+
+function createScheduleHost(): ScheduleHost {
+  const prototype = OrcaRuntimeWithScheduleWaitBlockedCheck.prototype as unknown as ScheduleHost
+  return {
+    waitBlockedCheckStateByPtyId: new Map(),
+    runWaitBlockedCheck: () => {},
+    scheduleWaitBlockedCheck: prototype.scheduleWaitBlockedCheck
+  }
+}
+
+describe('wait-blocked keyword carry storage', () => {
+  it('owns the carry so it stops pinning the lowercased chunk window', () => {
+    const own = vi.spyOn(ownership, 'ownRetainedString')
+    try {
+      const host = createScheduleHost()
+      const chunk = `${'Building Project '.repeat(4096)}tail-marker-text`
+      host.scheduleWaitBlockedCheck('pty-1', chunk, 0)
+
+      const carry = host.waitBlockedCheckStateByPtyId.get('pty-1')?.keywordCarry
+      expect(carry).toBe(chunk.toLowerCase().slice(-WAIT_BLOCKED_KEYWORD_CARRY_CHARS))
+      expect(carry).toHaveLength(WAIT_BLOCKED_KEYWORD_CARRY_CHARS)
+      expect(own).toHaveBeenCalledTimes(1)
+      expect(own).toHaveBeenLastCalledWith(carry)
+    } finally {
+      own.mockRestore()
+    }
+  })
+
+  it('keeps the carry joined to the next chunk so split keywords still match', () => {
+    const host = createScheduleHost()
+    host.scheduleWaitBlockedCheck('pty-2', `${'x'.repeat(8 * 1024)}press`, 0)
+    const carry = host.waitBlockedCheckStateByPtyId.get('pty-2')?.keywordCarry
+    expect(carry?.endsWith('press')).toBe(true)
+    host.scheduleWaitBlockedCheck('pty-2', ' ENTER to continue', 1)
+    expect(host.waitBlockedCheckStateByPtyId.get('pty-2')?.keywordCarry).toBe(
+      `${carry} enter to continue`.slice(-WAIT_BLOCKED_KEYWORD_CARRY_CHARS)
+    )
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​162 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​162 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps the last couple of thousand lines of each terminal so it can show you a preview and let you scroll back. Each of those lines is snipped out of the big blob of text the terminal sent, and JavaScript stores a snippet as "a pointer into the original blob" rather than as its own little string — so the whole blob has to stay in memory as long as any snippet from it survives. With an agent spinner running (the `⠋ Thinking...` line Claude Code and Codex redraw over and over), every batch of output leaves exactly one line behind, so the terminal ends up quietly holding on to *every* batch: a 5 KB preview was keeping 37 MB alive. This change makes Orca copy each kept line into its own small string, so each batch can be thrown away as soon as it has been processed. Memory drops to under a fifth of a megabyte and it is not measurably slower.

Follow-up to #19396.

## The leak

#19396 fixed pending terminal-control fragments, which pin at most one chunk per PTY. This is the much larger instance of the same pattern.

`appendNormalizedToTailBuffer` retains up to `MAX_TAIL_LINES` (2000) rows plus a partial line. On the plain path each retained row comes from `combinedChunk.slice(...)` via `splitRetainedTerminalTailSegments` and `applyTerminalLineControls` (`terminal-tail-line-controls.ts:54,60,86`), so each row is a V8 `SlicedString` pinning the whole chunk it arrived in.

A spinner workload is the worst case, and it is also the common case: a chunk of CR-redraw frames collapses to *one* retained line, so N chunks leave N rows, each pinning a different chunk.

Measured (Node 24, `--expose-gc`, chunks generated inside the loop so nothing else pins them; the two variants are interleaved round-robin in one process and the order is verified not to matter):

| Workload | tail size | before | after |
| --- | --- | ---: | ---: |
| 400 × 64 Ki-char spinner chunks | 400 rows / 5,090 chars | **37.55 MB** | **0.18 MB** |
| 1600 × 16 Ki-char spinner chunks | 1600 rows / 21,290 chars | **46.89 MB** | **0.09 MB** |

CPU is unchanged within the measurement noise: 239 → 236 and 212 → 243 µs/chunk at 64 Ki, 55 → 55 µs/chunk at 16 Ki.

## The fix

`ownRetainedString` (from #19396) is applied at the boundaries where a value actually enters the retained tail:

- **Plain path** (`terminal-tail-buffer.ts`) — each `newlyCompletedLines` entry and `retainedPartialLine`. These are exactly the values the review identified as sufficient, and only these: rows carried from the previous tail are already owned, and the transcript keeps the *same string objects* as `newlyCompletedLines`, so it is covered transitively (asserted by a test).
- **Redraw path** (`terminal-tail-redraw-buffer.ts`) — the partial line only. The multiline redraw builder never slices `normalizedChunk`; it writes rows character by character from single-character reads, so its rows cannot pin a chunk. Only the partial is re-sliced from its own row on every frame. Owning its rows and newly-completed lines as well was measured on a 200 × 64 Ki fullscreen-TUI cursor-up workload: **no** retention difference (the ~0.2 MB delta reverses when the variant order is reversed, i.e. it is the in-flight chunk, not a leak) and a CPU cost on TUI floods. So that is not done.
- **`orca-runtime-schedule-wait-blocked-check.ts`** — `keywordCarry`. 31 characters, held per PTY until the next chunk, pinning the whole lowercased `${carry}${appendedText}` window: a full-size copy of every chunk.

## Tests

`src/main/runtime/terminal-tail-row-retention.test.ts`:

- forced-GC spinner fixture — 200 × 64 Ki chunks must retain under 4 MiB (it measures **13.16 MB** with the fix removed, so it is red/green);
- deterministic `vi.spyOn(ownership, 'ownRetainedString')` assertions that every completed row and the partial line are routed through it, in call order;
- an assertion that the redraw path owns only its partial line;
- an assertion that `newlyCompletedLines` and the tail rows are the same objects, which is what makes the transcript covered transitively.

`src/main/runtime/wait-blocked-keyword-carry-retention.test.ts` covers the carry being owned, its exact contents, and that a keyword split across two chunks still matches.

## Validation

- New tests: 6 passed. Tail-buffer, whitespace, sentinel-index, redraw-window equivalence and tail-wait-memo suites: 54 passed.
- Full `src/main/runtime`: 7,356 passed / 21 skipped. Three unrelated files timed out under full-suite load on a busy host (`orchestration-adopted-run-binding`, `terminal-output-frame-chunks-equivalence`, `structured-agent-session-runtime-exit`) and all pass in isolation.
- `oxlint` clean; `pnpm run check:code-quality:changed`: 0 new findings across 12 changed files.

## Scope

Existing caps (`MAX_TAIL_LINES`, `MAX_TAIL_CHARS`, `MAX_TAIL_PARTIAL_CHARS`), right-trimming, sentinel carrying, redraw-window equivalence, transcript ordering and the preview are all unchanged — this only changes the *storage* of strings whose contents are identical. Execution authority, wire formats, folder/git identity and mobile UI are untouched, and the code is provider-independent so local, daemon, SSH and remote runtimes share it. Not measured: live Electron memory, Linux/Windows/WSL/SSH hosts, and production incidence.
