### PR TITLE
fix(omp): deliver transcript paths through status metadata

### DIFF
--- a/src/main/native-chat/session-file-resolver-wsl.test.ts
+++ b/src/main/native-chat/session-file-resolver-wsl.test.ts
@@ -109,6 +109,7 @@ describe('resolveSessionFilePath on a Windows host with WSL', () => {
     async (agent) => {
       READABLE_WSL_UNC_PATHS.delete(ROLLOUT_UNC)
       READABLE_WSL_UNC_PATHS.add(DEBIAN_ROLLOUT_UNC)
+      scanned.hostRootHasRollout = true
 
       await expect(
         resolveSessionFilePath(agent, 'wsl-sess', {
@@ -117,6 +118,7 @@ describe('resolveSessionFilePath on a Windows host with WSL', () => {
           codexSessionsDirs: []
         })
       ).resolves.toBeNull()
+      expect(scanned.dirs).toEqual([])
     }
   )
 

--- a/src/main/native-chat/session-file-resolver-wsl.test.ts
+++ b/src/main/native-chat/session-file-resolver-wsl.test.ts
@@ -87,32 +87,38 @@ describe('resolveSessionFilePath on a Windows host with WSL', () => {
     expect(resolved).toBe(ROLLOUT_UNC)
   })
 
-  it('keeps an attested distro when another guest has the same transcript path', async () => {
-    READABLE_WSL_UNC_PATHS.add(DEBIAN_ROLLOUT_UNC)
+  it.each(['codex', 'omp'] as const)(
+    'keeps an attested distro when another guest has the same transcript path (%s)',
+    async (agent) => {
+      READABLE_WSL_UNC_PATHS.add(DEBIAN_ROLLOUT_UNC)
 
-    const resolved = await resolveSessionFilePath('codex', 'wsl-sess', {
-      transcriptPath: ROLLOUT_LINUX,
-      wslDistro: 'Ubuntu',
-      codexSessionsDirs: []
-    })
-
-    expect(resolved).toBe(ROLLOUT_UNC)
-    expect(vi.mocked(listWslDistrosAsync)).not.toHaveBeenCalled()
-    expect(vi.mocked(getWslHomeAsync)).not.toHaveBeenCalled()
-  })
-
-  it('does not fall through to another guest when the attested path is missing', async () => {
-    READABLE_WSL_UNC_PATHS.delete(ROLLOUT_UNC)
-    READABLE_WSL_UNC_PATHS.add(DEBIAN_ROLLOUT_UNC)
-
-    await expect(
-      resolveSessionFilePath('codex', 'wsl-sess', {
+      const resolved = await resolveSessionFilePath(agent, 'wsl-sess', {
         transcriptPath: ROLLOUT_LINUX,
         wslDistro: 'Ubuntu',
         codexSessionsDirs: []
       })
-    ).resolves.toBeNull()
-  })
+
+      expect(resolved).toBe(ROLLOUT_UNC)
+      expect(vi.mocked(listWslDistrosAsync)).not.toHaveBeenCalled()
+      expect(vi.mocked(getWslHomeAsync)).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['codex', 'omp'] as const)(
+    'does not fall through to another guest when the attested path is missing (%s)',
+    async (agent) => {
+      READABLE_WSL_UNC_PATHS.delete(ROLLOUT_UNC)
+      READABLE_WSL_UNC_PATHS.add(DEBIAN_ROLLOUT_UNC)
+
+      await expect(
+        resolveSessionFilePath(agent, 'wsl-sess', {
+          transcriptPath: ROLLOUT_LINUX,
+          wslDistro: 'Ubuntu',
+          codexSessionsDirs: []
+        })
+      ).resolves.toBeNull()
+    }
+  )
 
   it('does not return a UNC twin that no distro actually has', async () => {
     const resolved = await resolveSessionFilePath('codex', 'wsl-sess', {
@@ -122,18 +128,21 @@ describe('resolveSessionFilePath on a Windows host with WSL', () => {
     expect(resolved).toBeNull()
   })
 
-  it('does not fall back by id from an unattested guest hook path', async () => {
-    READABLE_WSL_UNC_PATHS.delete(ROLLOUT_UNC)
-    scanned.hostRootHasRollout = true
+  it.each(['codex', 'omp'] as const)(
+    'does not fall back by id from an unattested guest hook path (%s)',
+    async (agent) => {
+      READABLE_WSL_UNC_PATHS.delete(ROLLOUT_UNC)
+      scanned.hostRootHasRollout = true
 
-    await expect(
-      resolveSessionFilePath('codex', 'wsl-sess', {
-        transcriptPath: ROLLOUT_LINUX,
-        codexSessionsDirs: ['C:\\host\\sessions']
-      })
-    ).resolves.toBeNull()
-    expect(scanned.dirs).toEqual([])
-  })
+      await expect(
+        resolveSessionFilePath(agent, 'wsl-sess', {
+          transcriptPath: ROLLOUT_LINUX,
+          codexSessionsDirs: ['C:\\host\\sessions']
+        })
+      ).resolves.toBeNull()
+      expect(scanned.dirs).toEqual([])
+    }
+  )
 
   it('does not fall back to a host id match for an unattested guest hook path', async () => {
     scanned.hostRootHasRollout = true

--- a/src/main/pi/agent-status-extension-source.test.ts
+++ b/src/main/pi/agent-status-extension-source.test.ts
@@ -209,11 +209,12 @@ describe('getPiAgentStatusExtensionSource', () => {
     expect(
       harness.fetchMock.mock.calls.map(([_event, init]) => JSON.parse(String(init?.body)).payload)
     ).toEqual([
-      { hook_event_name: 'agent_start', session_id: 'omp-session-8' },
+      { hook_event_name: 'agent_start', session_id: 'omp-session-8', session_file: '/tmp/s' },
       {
         hook_event_name: 'before_agent_start',
         prompt: 'hi',
-        session_id: 'omp-session-9'
+        session_id: 'omp-session-9',
+        session_file: '/tmp/s'
       },
       { hook_event_name: 'agent_end' }
     ])
@@ -261,9 +262,9 @@ describe('getPiAgentStatusExtensionSource', () => {
         hook_event_name: 'message_end',
         role: 'assistant',
         text: 'done',
-        session_id: 'omp-session-9'
+        session_id: 'omp-session-9',
+        session_file: '/tmp/omp-session-9.jsonl'
       })
-      expect(body.payload).not.toHaveProperty('session_file')
       expect(harness.fetchMock.mock.calls[1]?.[0]).toBe('http://127.0.0.1:4321/hook/omp')
       expect(harness.spawnMock).not.toHaveBeenCalled()
       finishDeliveries[1]?.()

--- a/src/main/pi/agent-status-extension-source.ts
+++ b/src/main/pi/agent-status-extension-source.ts
@@ -18,7 +18,7 @@ import { getPiAgentStatusWslCurlSourceLines } from './agent-status-wsl-curl-sour
 export const ORCA_PI_AGENT_STATUS_EXTENSION_FILE = 'orca-agent-status.ts'
 
 export function getPiAgentStatusExtensionSource(kind: PiAgentKind = 'pi'): string {
-  // Why: OMP needs the file only to reject ephemeral sessions; disclose just its resume id.
+  // OMP resumes by id; its persistent file path lets native chat skip discovery.
   const sessionMetadataSourceLines =
     kind !== 'omp'
       ? [
@@ -40,7 +40,7 @@ export function getPiAgentStatusExtensionSource(kind: PiAgentKind = 'pi'): strin
           '  const sessionManager = (ctx as { sessionManager?: { getSessionId?: () => unknown; getSessionFile?: () => unknown } } | null)?.sessionManager',
           '  const sessionId = sessionManager?.getSessionId?.()',
           '  const sessionFile = sessionManager?.getSessionFile?.()',
-          "  runtimeOmpSessionMetadata = typeof sessionId === 'string' && sessionId && typeof sessionFile === 'string' && sessionFile ? { session_id: sessionId } : {}",
+          "  runtimeOmpSessionMetadata = typeof sessionId === 'string' && sessionId && typeof sessionFile === 'string' && sessionFile ? { session_id: sessionId, session_file: sessionFile } : {}",
           '}',
           '',
           'function getPostSessionMetadata(ompRuntime: boolean): Record<string, unknown> {',
@@ -68,7 +68,7 @@ export function getPiAgentStatusExtensionSource(kind: PiAgentKind = 'pi'): strin
           '  const sessionManager = (ctx as { sessionManager?: { getSessionId?: () => unknown; getSessionFile?: () => unknown } } | null)?.sessionManager',
           '  const sessionId = sessionManager?.getSessionId?.()',
           '  const sessionFile = sessionManager?.getSessionFile?.()',
-          "  sessionMetadata = typeof sessionId === 'string' && sessionId && typeof sessionFile === 'string' && sessionFile ? { session_id: sessionId } : {}",
+          "  sessionMetadata = typeof sessionId === 'string' && sessionId && typeof sessionFile === 'string' && sessionFile ? { session_id: sessionId, session_file: sessionFile } : {}",
           '}',
           '',
           'function updateRuntimeOmpSessionMetadata(ctx: unknown): void {',

--- a/src/main/pi/omp-transcript-metadata.test.ts
+++ b/src/main/pi/omp-transcript-metadata.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { extractAgentProviderSession, getAgentResumeArgv } from '../../shared/agent-session-resume'
+import type * as SessionScannerDiscovery from '../ai-vault/session-scanner-discovery'
+import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
+import { resolveSessionFilePath } from '../native-chat/session-file-resolver'
+import { createAgentStatusExtensionHarness } from './agent-status-extension-test-harness'
+
+vi.mock('../ai-vault/session-scanner-discovery', async (importOriginal) => {
+  const actual = await importOriginal<typeof SessionScannerDiscovery>()
+  return { ...actual, walkSessionFiles: vi.fn(actual.walkSessionFiles) }
+})
+
+let root: string
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-omp-metadata-'))
+  vi.mocked(walkSessionFiles).mockClear()
+})
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe.each([
+  ['dedicated OMP', { kind: 'omp' as const }],
+  ['Pi-routed OMP', { kind: 'pi' as const, title: 'omp' }]
+])('%s transcript metadata', (_name, args) => {
+  it('resolves custom files without scanning and retains id-based resume across switches', async () => {
+    const harness = createAgentStatusExtensionHarness(args)
+    for (const id of ['first', 'second']) {
+      const file = join(root, `${id}.jsonl`)
+      await writeFile(file, `${JSON.stringify({ type: 'session', id })}\n`)
+      await harness.callHook('agent_start', undefined, {
+        sessionManager: { getSessionId: () => id, getSessionFile: () => file }
+      })
+      await vi.waitFor(() =>
+        expect(harness.fetchMock).toHaveBeenCalledTimes(id === 'first' ? 1 : 2)
+      )
+      const payload = JSON.parse(String(harness.fetchMock.mock.lastCall?.[1]?.body)).payload
+      const session = extractAgentProviderSession('omp', payload)
+      expect(session).toEqual({ key: 'session_id', id, transcriptPath: file })
+      expect(getAgentResumeArgv('omp', session!)).toEqual(['omp', '--resume', id])
+      expect(getAgentResumeArgv('omp', session!, 'explicit.jsonl')).toEqual([
+        'omp',
+        '--resume',
+        'explicit.jsonl'
+      ])
+      await expect(
+        resolveSessionFilePath('omp', id, {
+          transcriptPath: session!.transcriptPath,
+          ompSessionsDir: join(root, 'unused-default')
+        })
+      ).resolves.toBe(file)
+    }
+    expect(walkSessionFiles).not.toHaveBeenCalled()
+    expect(harness.fsMock.existsSync).not.toHaveBeenCalled()
+  })
+
+  it('publishes planned persistent paths, then resolves after delayed creation', async () => {
+    const harness = createAgentStatusExtensionHarness(args)
+    const file = join(root, 'delayed.jsonl')
+    await harness.callHook('agent_start', undefined, {
+      sessionManager: { getSessionId: () => 'delayed', getSessionFile: () => file }
+    })
+    const payload = JSON.parse(String(harness.fetchMock.mock.lastCall?.[1]?.body)).payload
+    const session = extractAgentProviderSession('omp', payload)!
+    expect(session.transcriptPath).toBe(file)
+    const options = { transcriptPath: session.transcriptPath, ompSessionsDir: join(root, 'empty') }
+    await expect(resolveSessionFilePath('omp', session.id, options)).resolves.toBeNull()
+    expect(walkSessionFiles).toHaveBeenCalledTimes(1)
+    await writeFile(file, '{}\n')
+    vi.mocked(walkSessionFiles).mockClear()
+    await expect(resolveSessionFilePath('omp', session.id, options)).resolves.toBe(file)
+    expect(walkSessionFiles).not.toHaveBeenCalled()
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      resolveSessionFilePath('omp', session.id, options, controller.signal)
+    ).rejects.toThrow()
+    expect(walkSessionFiles).not.toHaveBeenCalled()
+  })
+
+  it.each([undefined, '', 123])(
+    'clears persistent metadata for ephemeral path %s',
+    async (file) => {
+      const harness = createAgentStatusExtensionHarness(args)
+      await harness.callHook('agent_start', undefined, {
+        sessionManager: {
+          getSessionId: () => 'persistent',
+          getSessionFile: () => join(root, 'p.jsonl')
+        }
+      })
+      await harness.callHook('agent_end', undefined, {
+        sessionManager: { getSessionId: () => 'ephemeral', getSessionFile: () => file }
+      })
+      await vi.waitFor(() => expect(harness.fetchMock).toHaveBeenCalledTimes(2))
+      const payload = JSON.parse(String(harness.fetchMock.mock.lastCall?.[1]?.body)).payload
+      expect(payload).toEqual({ hook_event_name: 'agent_end' })
+      expect(extractAgentProviderSession('omp', payload)).toBeNull()
+    }
+  )
+})
+
+it('retains id-based discovery with an old extension and rejects malformed optional paths', async () => {
+  const id = 'legacy-session'
+  const file = join(root, `${id}.jsonl`)
+  await writeFile(file, '{}\n')
+  for (const session_file of [undefined, '', 123, '/bad\npath.jsonl']) {
+    const session = extractAgentProviderSession('omp', { session_id: id, session_file })!
+    expect(session).toEqual({ key: 'session_id', id })
+    expect(getAgentResumeArgv('omp', session)).toEqual(['omp', '--resume', id])
+    await expect(resolveSessionFilePath('omp', id, { ompSessionsDir: root })).resolves.toBe(file)
+  }
+  expect(walkSessionFiles).toHaveBeenCalledTimes(4)
+})

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -227,10 +227,10 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['session_id', 'sessionId'])
       return id ? { key: 'session_id', id } : null
     }
-    // Why: OMP's managed extension reports the authoritative CLI resume id.
+    // OMP keeps id-based resume while optionally locating its native-chat transcript.
     case 'omp': {
       const id = readSessionId(payload, ['session_id'])
-      return id ? { key: 'session_id', id } : null
+      return id ? withTranscriptPath({ key: 'session_id', id }, payload, ['session_file']) : null
     }
     // Why: Copilot's hook `session_id` is also its `~/.copilot/session-state/<id>/`
     // directory name, so the same id is the CLI's resume locator.

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -20,10 +20,8 @@ export function isNativeChatSupportedAgent(agent: string | null | undefined): bo
   return agent != null && NATIVE_CHAT_SUPPORTED_AGENTS.has(agent)
 }
 
-/** Agents whose hook discloses no transcript path (`extractAgentProviderSession`),
- *  so native chat can only reach the session file by scanning a sessions root on
- *  a disk THIS process can read. Under Model-A SSH that disk is the wrong host,
- *  so the chat view must stay closed instead of loading forever. */
+/** Agents whose Model-A SSH transcript reader is not supported. A hook path alone
+ *  does not establish owning-host reads, so OMP remains gated even with metadata. */
 export function nativeChatRequiresLocalTranscript(agent: string | null | undefined): boolean {
   const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
   return transcriptAgent === 'grok' || transcriptAgent === 'omp'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​165 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​128 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

OMP already knows where it stores a conversation. Orca now receives that path so native chat can open an existing custom-directory transcript directly.

## What Changed

Both the dedicated OMP extension and the Pi extension running under OMP publish `session_file`. The existing provider-session extractor retains it as optional `transcriptPath`, feeding the existing execution-host resolver. Session-ID resume, explicit resume-file overrides, ephemeral-session suppression, and the SSH availability gate retain their behavior.

## Why

The path was lost at both the producer and extractor boundaries. Delivering it through the existing metadata owner removes those omissions without introducing another transcript locator.

## Linked Issue

Addresses the metadata-delivery portion of [STA-3650](https://linear.app/stably/issue/STA-3650). Plain-SSH native-chat enablement remains separate and is not claimed complete.

## Visual Proof

Hidden Electron startup was inspected in an isolated profile. The real native-chat IPC reader returned both expected messages from a synthetic custom-directory OMP transcript; the chat view itself was not exercised, so no before/after rendered transcript proof is claimed.

## Testing

- 171 tests pass across eight files, covering both generated producers, exact-path resolution with zero scans, delayed creation, cancellation, session switches, ephemeral sessions, legacy fallback, WSL attestation, and existing remote ingestion/fanout controls.
- Manual loopback HTTP delivery passes for both generated producers with synthetic session managers; the pinned pre-change extractor ignores the optional field and keeps the same resume command.
- Removing either delivery step independently produces four expected test failures; restored files match their committed backups byte-for-byte.
- Scoped lint and the prescribed sequential node/web/CLI typechecks pass. Fresh Electron main/preload development builds pass.
- Real OMP no-inference startup answered its state request but emitted no lifecycle hooks; actual provider persistence, Windows/WSL runtime, SSH runtime, and the rendered chat journey remain unverified.

## Review

Independent architecture review pending. This is a scoped draft, not full-ticket closure or merge approval.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material changed.
