### PR TITLE
fix(runtime): recover graph publishers without reviving retired renderers

### DIFF
--- a/src/main/runtime/orca-runtime-attach-window.ts
+++ b/src/main/runtime/orca-runtime-attach-window.ts
@@ -7,6 +7,9 @@ import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
 
 export class OrcaRuntimeWithAttachWindow extends OrcaRuntimeWithNotifySshStateChanged {
   attachWindow(windowId: number): void {
+    if (this.retiredGraphWindowIds.has(windowId)) {
+      return
+    }
     if (this.authoritativeWindowId === HEADLESS_RUNTIME_WINDOW_ID) {
       if (
         this.pendingHeadlessPromotionWindowId !== null &&

--- a/src/main/runtime/orca-runtime-core.ts
+++ b/src/main/runtime/orca-runtime-core.ts
@@ -351,5 +351,5 @@ export type RuntimeCommandSurfaceHost<T> = T & RuntimeInstalledCommandSurfaces
 
 export type RuntimeRendererReloadFence = Readonly<{
   revision: number
-  recovery: 'renderer' | 'headless' | 'reloading'
+  recovery: 'renderer' | 'headless' | 'reloading' | 'unavailable'
 }>

--- a/src/main/runtime/orca-runtime-has-terminals-for-worktree.ts
+++ b/src/main/runtime/orca-runtime-has-terminals-for-worktree.ts
@@ -143,7 +143,7 @@ export class OrcaRuntimeWithHasTerminalsForWorktree extends OrcaRuntimeWithStopE
       this.beginGraphReload(windowId, reason === 'renderer-process-gone')
     }
     this.graphReloadLifecycle.settleActive('failure')
-    if (reason === 'renderer-frame-unavailable') {
+    if (reason === 'renderer-frame-unavailable' && !this.shouldRestoreHeadlessGraph(windowId)) {
       // A failed send does not retire the document or its live PTY bindings.
       this.graphStatus = 'unavailable'
       this.setTerminalSideEffectConsumerAvailable(false)

--- a/src/main/runtime/orca-runtime-has-terminals-for-worktree.ts
+++ b/src/main/runtime/orca-runtime-has-terminals-for-worktree.ts
@@ -42,13 +42,14 @@ export class OrcaRuntimeWithHasTerminalsForWorktree extends OrcaRuntimeWithStopE
         recovery: this.shouldRestoreHeadlessGraph(windowId) ? 'headless' : 'reloading'
       }
     }
-    if (this.graphStatus !== 'ready') {
-      return null
-    }
-    return { revision: this.beginGraphReload(windowId), recovery: 'renderer' }
+    const recovery = this.graphStatus === 'ready' ? 'renderer' : 'unavailable'
+    return { revision: this.beginGraphReload(windowId), recovery }
   }
 
-  protected beginGraphReload(windowId: number): number {
+  protected beginGraphReload(windowId: number, retireDocument = true): number {
+    if (retireDocument && this.rendererGeneration !== null) {
+      this.retiredRendererGenerations.add(this.rendererGeneration)
+    }
     // Why: the rebuilt graph decides whether an incarnation survived; do not stale proven process identities before that comparison.
     this.rendererGraphEpoch += 1
     this.graphStatus = 'reloading'
@@ -85,7 +86,14 @@ export class OrcaRuntimeWithHasTerminalsForWorktree extends OrcaRuntimeWithStopE
       this.restoreHeadlessGraphAuthority()
       return false
     }
-    if (fence.recovery === 'renderer') {
+    if (fence.recovery === 'renderer' || fence.recovery === 'unavailable') {
+      if (this.rendererGeneration !== null) {
+        this.retiredRendererGenerations.delete(this.rendererGeneration)
+      }
+      if (fence.recovery === 'unavailable') {
+        this.graphStatus = 'unavailable'
+        return true
+      }
       const restoresPublishedInventory =
         this.sessionTabsInventoryPublicationEpoch === this.rendererGraphEpoch - 1
       this.graphStatus = 'ready'
@@ -120,19 +128,32 @@ export class OrcaRuntimeWithHasTerminalsForWorktree extends OrcaRuntimeWithStopE
 
   markGraphReloadFailed(
     windowId: number,
-    _reason: 'renderer-frame-unavailable' | 'renderer-process-gone'
+    reason: 'renderer-frame-unavailable' | 'renderer-process-gone'
   ): void {
     if (windowId !== this.authoritativeWindowId) {
       return
     }
+    if (reason === 'renderer-process-gone' && this.rendererGeneration !== null) {
+      this.retiredRendererGenerations.add(this.rendererGeneration)
+    }
     if (this.graphStatus === 'ready') {
-      this.beginGraphReload(windowId)
+      this.beginGraphReload(windowId, reason === 'renderer-process-gone')
     }
     this.graphReloadLifecycle.settleActive('failure')
+    if (reason === 'renderer-frame-unavailable') {
+      // A failed send does not retire the document or its live PTY bindings.
+      this.graphStatus = 'unavailable'
+      this.setTerminalSideEffectConsumerAvailable(false)
+      this.refreshWritableFlags()
+      return
+    }
     this.transitionGraphReloadToTerminalState(windowId)
   }
 
   markGraphUnavailable(windowId: number): void {
+    if (windowId !== HEADLESS_RUNTIME_WINDOW_ID) {
+      this.retiredGraphWindowIds.add(windowId)
+    }
     if (
       this.authoritativeWindowId === HEADLESS_RUNTIME_WINDOW_ID &&
       windowId === this.pendingHeadlessPromotionWindowId

--- a/src/main/runtime/orca-runtime-has-terminals-for-worktree.ts
+++ b/src/main/runtime/orca-runtime-has-terminals-for-worktree.ts
@@ -42,6 +42,9 @@ export class OrcaRuntimeWithHasTerminalsForWorktree extends OrcaRuntimeWithStopE
         recovery: this.shouldRestoreHeadlessGraph(windowId) ? 'headless' : 'reloading'
       }
     }
+    if (this.graphStatus === 'unavailable' && this.rendererGeneration === null) {
+      return null
+    }
     const recovery = this.graphStatus === 'ready' ? 'renderer' : 'unavailable'
     return { revision: this.beginGraphReload(windowId), recovery }
   }

--- a/src/main/runtime/orca-runtime-runtime-id.ts
+++ b/src/main/runtime/orca-runtime-runtime-id.ts
@@ -80,6 +80,10 @@ export class OrcaRuntimeWithRuntimeId {
 
   protected pendingHeadlessPromotionWindowId: number | null = null
 
+  protected readonly retiredRendererGenerations = new Set<string>()
+
+  protected readonly retiredGraphWindowIds = new Set<number>()
+
   protected rendererGeneration: string | null = null
 
   protected readonly graphReloadLifecycle = new RuntimeGraphReloadLifecycle({

--- a/src/main/runtime/orca-runtime-sync-window-graph.ts
+++ b/src/main/runtime/orca-runtime-sync-window-graph.ts
@@ -34,36 +34,41 @@ export class OrcaRuntimeWithSyncWindowGraph extends OrcaRuntimeWithAttachWindow 
     // malformed persisted/mirrored graphs before authority or graph state is
     // changed; choosing a winner would route PTYs to the wrong worktree.
     assertUniqueRuntimeGraphTabIds(graph.tabs)
-    if (
-      windowId !== HEADLESS_RUNTIME_WINDOW_ID &&
-      this.authoritativeWindowId === HEADLESS_RUNTIME_WINDOW_ID &&
-      this.headlessGraphFallbackAvailable
-    ) {
-      if (windowId !== this.pendingHeadlessPromotionWindowId) {
-        throw new Error('Runtime graph publisher does not match the pending desktop promotion')
-      }
-      // Why: a renderer may publish after a failed promotion was restored to
-      // headless authority; accepting that late healthy graph is self-healing.
-      this.attachWindow(windowId)
-    }
-    if (this.authoritativeWindowId === null) {
-      this.authoritativeWindowId = windowId
-    }
-    if (windowId !== this.authoritativeWindowId) {
-      throw new Error('Runtime graph publisher does not match the authoritative window')
-    }
     const rendererGeneration =
       windowId === HEADLESS_RUNTIME_WINDOW_ID
         ? null
         : 'rendererGeneration' in graph && typeof graph.rendererGeneration === 'string'
           ? graph.rendererGeneration
           : undefined
+    if (this.retiredGraphWindowIds.has(windowId)) {
+      throw new Error('Runtime graph publisher belongs to a retired window')
+    }
     if (
       typeof rendererGeneration === 'string' &&
-      rendererGeneration === this.rendererGeneration &&
-      this.graphStatus !== 'ready'
+      this.retiredRendererGenerations.has(rendererGeneration)
     ) {
       throw new Error('Runtime graph publisher belongs to a superseded renderer generation')
+    }
+    const promotesHeadless =
+      windowId !== HEADLESS_RUNTIME_WINDOW_ID &&
+      this.authoritativeWindowId === HEADLESS_RUNTIME_WINDOW_ID &&
+      this.headlessGraphFallbackAvailable
+    if (promotesHeadless && windowId !== this.pendingHeadlessPromotionWindowId) {
+      throw new Error('Runtime graph publisher does not match the pending desktop promotion')
+    }
+    if (
+      !promotesHeadless &&
+      this.authoritativeWindowId !== null &&
+      windowId !== this.authoritativeWindowId
+    ) {
+      throw new Error('Runtime graph publisher does not match the authoritative window')
+    }
+    // Admission precedes promotion persistence, reload settlement, and authority adoption.
+    if (promotesHeadless) {
+      this.attachWindow(windowId)
+    }
+    if (this.authoritativeWindowId === null) {
+      this.authoritativeWindowId = windowId
     }
     if (windowId === HEADLESS_RUNTIME_WINDOW_ID) {
       this.headlessGraphFallbackAvailable = true
@@ -87,7 +92,7 @@ export class OrcaRuntimeWithSyncWindowGraph extends OrcaRuntimeWithAttachWindow 
 
     // Why: renderer reloads can briefly republish the same leaf with no ptyId;
     // keep live CLI handles usable while the UI graph rebuilds.
-    const preserveLivePtysDuringReload = this.graphStatus === 'reloading'
+    const preserveLivePtysDuringReload = this.graphStatus !== 'ready'
     for (const leaf of lifecycleLeaves) {
       if (leaf.ptyId) {
         if (leaf.parked) {
@@ -262,6 +267,7 @@ export class OrcaRuntimeWithSyncWindowGraph extends OrcaRuntimeWithAttachWindow 
       }
     }
     const isAuthoritativeGraphPublisher = windowId === this.authoritativeWindowId
+    this.notifier?.graphPublicationAccepted?.(windowId)
     this.markGraphReady(windowId)
     if (
       isAuthoritativeGraphPublisher &&
@@ -274,6 +280,9 @@ export class OrcaRuntimeWithSyncWindowGraph extends OrcaRuntimeWithAttachWindow 
       }
     }
     if (rendererGeneration !== undefined) {
+      if (this.rendererGeneration !== null && this.rendererGeneration !== rendererGeneration) {
+        this.retiredRendererGenerations.add(this.rendererGeneration)
+      }
       this.rendererGeneration = rendererGeneration
     }
     for (const leaf of this.leaves.values()) {

--- a/src/main/runtime/orca-runtime-tests/terminal-handles-and-agent-status.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-handles-and-agent-status.spec.ts
@@ -300,14 +300,14 @@ describe('OrcaRuntimeService', () => {
     expect(read.tail).toEqual(['after omitted leaf'])
   })
 
-  it('keeps preallocated terminal handles valid after graph unavailable during reload', async () => {
+  it('keeps preallocated terminal handles valid after the graph window closes and a successor publishes', async () => {
     const runtime = new OrcaRuntimeService(store)
     const handle = runtime.preAllocateHandleForPty('pty-1')
 
     syncSinglePty(runtime)
     runtime.markGraphUnavailable(1)
-    runtime.attachWindow(1)
-    runtime.syncWindowGraph(1, {
+    runtime.attachWindow(2)
+    runtime.syncWindowGraph(2, {
       tabs: [],
       leaves: []
     })

--- a/src/main/runtime/runtime-graph-publisher-authority.test.ts
+++ b/src/main/runtime/runtime-graph-publisher-authority.test.ts
@@ -99,7 +99,8 @@ describe('runtime graph publisher authority', () => {
       tabId: 'duplicate',
       worktreeId: 'folder:fixture',
       title: 'tab',
-      activeLeafId: null
+      activeLeafId: null,
+      layout: null
     }
     expect(() => runtime.syncWindowGraph(1, { ...graph(), tabs: [tab, tab] })).toThrow(
       'duplicate_runtime_tab_id'

--- a/src/main/runtime/runtime-graph-publisher-authority.test.ts
+++ b/src/main/runtime/runtime-graph-publisher-authority.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeRendererSyncWindowGraph } from '../../shared/runtime-types'
+import { createRuntimeRendererNotificationSender } from '../window/runtime-renderer-notification-sender'
+import { OrcaRuntimeService } from './orca-runtime'
+import { RUNTIME_GRAPH_RELOAD_TIMEOUT_MS } from './runtime-graph-reload-lifecycle'
+
+function graph(rendererGeneration = 'current'): RuntimeRendererSyncWindowGraph {
+  return { rendererGeneration, tabs: [], leaves: [], mobileSessionTabs: [] }
+}
+
+function publishedRuntime() {
+  const runtime = new OrcaRuntimeService()
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, graph())
+  return runtime
+}
+
+function snapshot(runtime: OrcaRuntimeService) {
+  const state = runtime as unknown as {
+    tabs: Map<string, unknown>
+    leaves: Map<string, unknown>
+    rendererGeneration: string | null
+    pendingHeadlessPromotionWindowId: number | null
+  }
+  return {
+    status: runtime.getStatus(),
+    tabs: structuredClone([...state.tabs]),
+    leaves: structuredClone([...state.leaves]),
+    generation: state.rendererGeneration,
+    promotion: state.pendingHeadlessPromotionWindowId
+  }
+}
+
+afterEach(() => vi.useRealTimers())
+
+describe('runtime graph publisher authority', () => {
+  it('recovers the current document after notification failure without changing its generation', () => {
+    const runtime = publishedRuntime()
+    runtime.markGraphReloadFailed(1, 'renderer-frame-unavailable')
+    expect(runtime.getStatus().graphStatus).toBe('unavailable')
+    expect(runtime.syncWindowGraph(1, graph()).graphStatus).toBe('ready')
+  })
+
+  it.each(['reloading', 'timeout', 'successor', 'process-gone'])(
+    'fences a retired document after %s without mutating publication authority',
+    async (phase) => {
+      vi.useFakeTimers()
+      const runtime = publishedRuntime()
+      if (phase === 'process-gone') {
+        runtime.markGraphReloadFailed(1, 'renderer-process-gone')
+      } else {
+        runtime.markRendererReloading(1)
+      }
+      if (phase === 'timeout') {
+        await vi.advanceTimersByTimeAsync(RUNTIME_GRAPH_RELOAD_TIMEOUT_MS)
+      }
+      if (phase === 'successor') {
+        runtime.syncWindowGraph(1, graph('successor'))
+      }
+      const before = snapshot(runtime)
+      expect(() => runtime.syncWindowGraph(1, graph())).toThrow('superseded renderer generation')
+      expect(snapshot(runtime)).toEqual(before)
+      expect(runtime.syncWindowGraph(1, graph('new-document')).graphStatus).toBe('ready')
+    }
+  )
+
+  it.each(['ready', 'unavailable'])(
+    'restores publication eligibility when navigation from %s is cancelled',
+    (initial) => {
+      const runtime = publishedRuntime()
+      if (initial === 'unavailable') {
+        runtime.markGraphReloadFailed(1, 'renderer-frame-unavailable')
+      }
+      const fence = runtime.markRendererReloading(1)!
+      expect(runtime.markRendererReloadCancelled(1, fence)).toBe(true)
+      expect(runtime.syncWindowGraph(1, graph()).graphStatus).toBe('ready')
+    }
+  )
+
+  it('rejects a closed window before it can reclaim null authority or attach', () => {
+    const runtime = publishedRuntime()
+    runtime.markGraphUnavailable(1)
+    const before = snapshot(runtime)
+    expect(() => runtime.syncWindowGraph(1, graph())).toThrow('retired window')
+    expect(snapshot(runtime)).toEqual(before)
+    runtime.attachWindow(1)
+    expect(snapshot(runtime)).toEqual(before)
+    runtime.attachWindow(2)
+    expect(runtime.syncWindowGraph(2, graph('new-window')).graphStatus).toBe('ready')
+  })
+
+  it('preflights duplicate tabs before headless promotion and preserves a valid successor', () => {
+    const runtime = new OrcaRuntimeService()
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+    runtime.attachWindow(1)
+    runtime.markGraphReloadFailed(1, 'renderer-process-gone')
+    const before = snapshot(runtime)
+    const tab = {
+      tabId: 'duplicate',
+      worktreeId: 'folder:fixture',
+      title: 'tab',
+      activeLeafId: null
+    }
+    expect(() => runtime.syncWindowGraph(1, { ...graph(), tabs: [tab, tab] })).toThrow(
+      'duplicate_runtime_tab_id'
+    )
+    expect(snapshot(runtime)).toEqual(before)
+    expect(() => runtime.syncWindowGraph(2, graph())).toThrow('pending desktop promotion')
+    expect(snapshot(runtime)).toEqual(before)
+    expect(runtime.syncWindowGraph(1, graph()).graphStatus).toBe('ready')
+  })
+
+  it('preserves generation-absent runtime callers through reload', () => {
+    const runtime = new OrcaRuntimeService()
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    runtime.markRendererReloading(1)
+    expect(runtime.syncWindowGraph(1, { tabs: [], leaves: [] }).graphStatus).toBe('ready')
+  })
+
+  it.each(['repo::/fixture', 'folder:fixture'])(
+    'recovers mobile inventory and the existing PTY incarnation for %s',
+    async (worktreeId) => {
+      vi.useFakeTimers()
+      const runtime = new OrcaRuntimeService()
+      runtime.registerPty('pty', worktreeId, null, {
+        tabId: 'tab',
+        leafId: 'leaf',
+        incarnationId: 'same-process'
+      })
+      const publication: RuntimeRendererSyncWindowGraph = {
+        ...graph(),
+        tabs: [{ tabId: 'tab', worktreeId, title: 'Terminal', activeLeafId: 'leaf', layout: null }],
+        leaves: [{ tabId: 'tab', worktreeId, leafId: 'leaf', paneRuntimeId: 1, ptyId: 'pty' }],
+        mobileSessionTabs: [
+          {
+            worktree: worktreeId,
+            publicationEpoch: 'current',
+            snapshotVersion: 1,
+            activeGroupId: null,
+            activeTabId: 'tab::leaf',
+            activeTabType: 'terminal',
+            tabs: [
+              {
+                type: 'terminal',
+                id: 'tab::leaf',
+                parentTabId: 'tab',
+                leafId: 'leaf',
+                title: 'Terminal',
+                isActive: true
+              }
+            ]
+          }
+        ]
+      }
+      const events: unknown[] = []
+      runtime.onMobileSessionTabsChanged((event) => events.push(event))
+      runtime.syncWindowGraph(1, publication)
+      await vi.advanceTimersByTimeAsync(100)
+      const before = snapshot(runtime)
+      runtime.markGraphReloadFailed(1, 'renderer-frame-unavailable')
+      runtime.syncWindowGraph(1, {
+        ...publication,
+        leaves: [{ ...publication.leaves[0], ptyId: null }]
+      })
+      await vi.advanceTimersByTimeAsync(100)
+      const after = snapshot(runtime)
+      expect(after.leaves).toEqual(before.leaves)
+      expect(after.status.graphStatus).toBe('ready')
+      expect(events.length).toBeGreaterThan(0)
+      expect(events.at(-1)).toMatchObject({
+        worktree: worktreeId,
+        tabs: [expect.objectContaining({ type: 'terminal', title: 'Terminal' })]
+      })
+      const ptys = (runtime as unknown as { ptysById: Map<string, { incarnationId: string }> })
+        .ptysById
+      expect(ptys.get('pty')?.incarnationId).toBe('same-process')
+    }
+  )
+
+  it('restores the notification owner before graph callbacks attempt delivery', () => {
+    const runtime = publishedRuntime()
+    const send = vi.fn().mockImplementationOnce(() => {
+      throw new Error('frame unavailable')
+    })
+    const sender = createRuntimeRendererNotificationSender({
+      isWindowDestroyed: () => false,
+      webContents: { isDestroyed: () => false, send },
+      onFailure: (reason) => runtime.markGraphReloadFailed(1, reason),
+      warn: vi.fn()
+    })
+    runtime.setNotifier({
+      graphPublicationAccepted: (windowId: number) => {
+        if (windowId === 1) {
+          sender.onGraphPublicationAccepted()
+        }
+      }
+    } as never)
+    expect(sender.send('repos:changed')).toBe(false)
+    const delivery = vi.fn(() => expect(sender.send('ui:createTerminal')).toBe(true))
+    const callbacks = (runtime as unknown as { graphSyncCallbacks: (() => void)[] })
+      .graphSyncCallbacks
+    callbacks.push(delivery)
+    runtime.syncWindowGraph(1, graph())
+    expect(delivery).toHaveBeenCalledOnce()
+    expect(send).toHaveBeenCalledTimes(2)
+    callbacks.splice(callbacks.indexOf(delivery), 1)
+    sender.close()
+    runtime.syncWindowGraph(1, graph())
+    expect(sender.send('repos:changed')).toBe(false)
+  })
+})

--- a/src/main/runtime/runtime-graph-publisher-authority.test.ts
+++ b/src/main/runtime/runtime-graph-publisher-authority.test.ts
@@ -111,6 +111,18 @@ describe('runtime graph publisher authority', () => {
     expect(runtime.syncWindowGraph(1, graph()).graphStatus).toBe('ready')
   })
 
+  it('keeps headless fallback available after a promotion notification send fails', () => {
+    const runtime = new OrcaRuntimeService()
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+    runtime.attachWindow(1)
+    runtime.markGraphReloadFailed(1, 'renderer-frame-unavailable')
+    expect(runtime.getStatus()).toMatchObject({
+      authoritativeWindowId: 0,
+      graphStatus: 'ready'
+    })
+    expect(runtime.syncWindowGraph(1, graph()).graphStatus).toBe('ready')
+  })
+
   it('preserves generation-absent runtime callers through reload', () => {
     const runtime = new OrcaRuntimeService()
     runtime.syncWindowGraph(1, { tabs: [], leaves: [] })

--- a/src/main/runtime/runtime-graph-recovery-mailbox.test.ts
+++ b/src/main/runtime/runtime-graph-recovery-mailbox.test.ts
@@ -1,0 +1,59 @@
+import { rmSync } from 'node:fs'
+import { afterEach, expect, it, vi } from 'vitest'
+import {
+  createDatabase,
+  createRuntime,
+  createBoundRun,
+  insertDirectRunMessage,
+  driveToLiveIdle,
+  pointerCount,
+  temporaryDirectories,
+  TAB_ID,
+  LEAF_ID,
+  PTY_ID,
+  WORKTREE_ID
+} from './orchestration-mailbox-notification-test-harness'
+
+afterEach(() => {
+  vi.useRealTimers()
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+it('offers pending mailbox work to its existing owner when current graph publication recovers', async () => {
+  vi.useFakeTimers()
+  const db = createDatabase('orca-graph-recovery-mailbox-')
+  try {
+    const { runtime, write } = createRuntime(db)
+    const publication = {
+      rendererGeneration: 'mailbox-document',
+      tabs: [
+        {
+          tabId: TAB_ID,
+          worktreeId: WORKTREE_ID,
+          title: 'Codex',
+          activeLeafId: LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: [
+        { tabId: TAB_ID, worktreeId: WORKTREE_ID, leafId: LEAF_ID, paneRuntimeId: 1, ptyId: PTY_ID }
+      ]
+    }
+    runtime.syncWindowGraph(1, publication)
+    const run = createBoundRun(db, 'Graph recovery')
+    await driveToLiveIdle(runtime)
+    runtime.markGraphReloadFailed(1, 'renderer-frame-unavailable')
+    insertDirectRunMessage(db, run.id, 'Queued while graph unavailable')
+    expect(pointerCount(write)).toBe(0)
+    runtime.syncWindowGraph(1, publication)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(pointerCount(write)).toBe(1)
+    runtime.syncWindowGraph(1, publication)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(pointerCount(write)).toBe(1)
+  } finally {
+    db.close()
+  }
+})

--- a/src/main/runtime/runtime-notifier-contract.ts
+++ b/src/main/runtime/runtime-notifier-contract.ts
@@ -21,6 +21,7 @@ import type {
 type DriverState = RuntimeTerminalDriverState
 
 export type RuntimeNotifier = {
+  graphPublicationAccepted?: (windowId: number) => void
   automationsChanged?(payload: {
     selector?: { kind: 'self' } | { kind: 'ssh'; targetId: string } | { kind: 'orphan' }
     reason?: 'definition' | 'run' | 'usage'

--- a/src/main/window/runtime-renderer-notification-sender.test.ts
+++ b/src/main/window/runtime-renderer-notification-sender.test.ts
@@ -92,10 +92,27 @@ describe('runtime renderer notification sender', () => {
     expect(fixture.onFailure).toHaveBeenNthCalledWith(2, 'renderer-process-gone')
   })
 
+  it('reports process loss even after a recoverable send failure suspended delivery', () => {
+    const fixture = createSender({
+      send: () => {
+        throw new Error('frame unavailable')
+      }
+    })
+    fixture.sender.send('repos:changed')
+    fixture.sender.onRendererProcessGone()
+    fixture.sender.onRendererProcessGone()
+    expect(fixture.onFailure.mock.calls).toEqual([
+      ['renderer-frame-unavailable'],
+      ['renderer-process-gone']
+    ])
+    expect(fixture.warn).toHaveBeenCalledOnce()
+  })
+
   it('keeps close terminal when renderer lifecycle events arrive late', () => {
     const fixture = createSender()
 
     fixture.sender.close()
+    fixture.sender.onGraphPublicationAccepted()
     fixture.sender.onMainFrameLoadFinished()
     fixture.sender.onMainFrameReloadStarted()
     fixture.sender.onRendererProcessGone()

--- a/src/main/window/runtime-renderer-notification-sender.ts
+++ b/src/main/window/runtime-renderer-notification-sender.ts
@@ -15,18 +15,21 @@ export function createRuntimeRendererNotificationSender(args: {
   onMainFrameReloadStarted: () => void
   onMainFrameReloadCancelled: () => void
   onMainFrameLoadFinished: () => void
+  onGraphPublicationAccepted: () => void
   onRendererProcessGone: () => void
   close: () => void
 } {
   let available = true
   let warningEmitted = false
   let closed = false
+  let failureReason: RuntimeRendererGraphFailureReason | null = null
   const warn = args.warn ?? ((message: string) => console.warn(message))
   const suspend = (reason: RuntimeRendererGraphFailureReason): void => {
-    if (closed || (!available && warningEmitted)) {
+    if (closed || failureReason === reason || failureReason === 'renderer-process-gone') {
       return
     }
     available = false
+    failureReason = reason
     if (!warningEmitted) {
       warningEmitted = true
       warn(`[runtime-graph] Renderer notifications suspended: ${reason}`)
@@ -55,6 +58,7 @@ export function createRuntimeRendererNotificationSender(args: {
       }
       available = false
       warningEmitted = false
+      failureReason = null
     },
     onMainFrameReloadCancelled: () => {
       if (closed) {
@@ -62,6 +66,7 @@ export function createRuntimeRendererNotificationSender(args: {
       }
       available = true
       warningEmitted = false
+      failureReason = null
     },
     onMainFrameLoadFinished: () => {
       if (closed) {
@@ -69,6 +74,15 @@ export function createRuntimeRendererNotificationSender(args: {
       }
       available = true
       warningEmitted = false
+      failureReason = null
+    },
+    onGraphPublicationAccepted: () => {
+      if (closed || args.isWindowDestroyed() || args.webContents.isDestroyed()) {
+        return
+      }
+      available = true
+      warningEmitted = false
+      failureReason = null
     },
     onRendererProcessGone: () => suspend('renderer-process-gone'),
     close: () => {

--- a/src/main/window/runtime-window-lifecycle.ts
+++ b/src/main/window/runtime-window-lifecycle.ts
@@ -36,6 +36,11 @@ export function registerRuntimeWindowLifecycle(
   })
   const send = rendererNotifications.send
   runtime.setNotifier({
+    graphPublicationAccepted: (windowId) => {
+      if (windowId === mainWindow.id && activeRuntimeNotifierToken === notifierToken) {
+        rendererNotifications.onGraphPublicationAccepted()
+      }
+    },
     worktreesChanged: (repoId, renamed) => {
       // Why: clear scan caches before the renderer handles this event, so it can't read stale TTL entries after a mutation.
       runWorktreeChangeInvalidators(repoId)

--- a/src/main/window/runtime-window-publication-recovery.test.ts
+++ b/src/main/window/runtime-window-publication-recovery.test.ts
@@ -1,0 +1,46 @@
+import { EventEmitter } from 'node:events'
+import type { BrowserWindow } from 'electron'
+import { expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../runtime/orca-runtime'
+import type { RuntimeNotifier } from '../runtime/runtime-notifier-contract'
+import { registerRuntimeWindowLifecycle } from './runtime-window-lifecycle'
+
+vi.mock('electron', () => ({ ipcMain: new EventEmitter() }))
+
+function windowFixture(id: number) {
+  const window = new EventEmitter()
+  const webContents = new EventEmitter()
+  const send = vi.fn()
+  Object.assign(webContents, { isDestroyed: () => false, send })
+  Object.assign(window, { id, isDestroyed: () => false, webContents })
+  return { window: window as BrowserWindow, webContents, send }
+}
+
+it('accepted publication resumes only the matching window notifier and never a closed sender', () => {
+  const runtime = new OrcaRuntimeService()
+  const first = windowFixture(1)
+  registerRuntimeWindowLifecycle(first.window, runtime)
+  const graph = { tabs: [], leaves: [], rendererGeneration: 'first' }
+  runtime.syncWindowGraph(1, graph)
+  const internals = runtime as unknown as { notifier: RuntimeNotifier }
+  first.send.mockImplementationOnce(() => {
+    throw new Error('frame unavailable')
+  })
+  internals.notifier.reposChanged()
+  expect(runtime.getStatus().graphStatus).toBe('unavailable')
+  runtime.syncWindowGraph(1, graph)
+  internals.notifier.reposChanged()
+  expect(first.send).toHaveBeenCalledTimes(2)
+
+  const oldNotifier = internals.notifier
+  first.window.emit('closed')
+  const second = windowFixture(2)
+  registerRuntimeWindowLifecycle(second.window, runtime)
+  runtime.syncWindowGraph(2, { ...graph, rendererGeneration: 'second' })
+  oldNotifier.graphPublicationAccepted?.(1)
+  oldNotifier.reposChanged()
+  expect(first.send).toHaveBeenCalledTimes(2)
+  internals.notifier.reposChanged()
+  expect(second.send).toHaveBeenCalledOnce()
+  second.window.emit('closed')
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​349 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​346 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 |

<!-- /orca-pr-loc -->

## ELI5

A temporary failure sending a desktop notification could permanently lock the still-running renderer out of publishing its tabs. Keep document retirement separate from graph readiness so the current renderer can recover while old documents stay fenced.

## What Changed

- Preflight duplicate tabs, retired windows/documents, and publisher authority before headless promotion or authority adoption.
- Retire documents on navigation/process loss, preserve retirement after timeout and successor publication, and restore eligibility only for an accepted navigation cancellation.
- Preserve live PTY bindings and idle evidence after a notification-send failure. Resume the matching window notifier before accepted graph publication offers pending delivery to its existing owners.
- Preserve initial startup, headless promotion, folder workspaces, and generation-absent runtime callers.

## Why

The former same-generation/non-ready predicate conflated a recoverable send failure with document replacement. Narrowing it to only `reloading` would admit timed-out or already-replaced documents. Explicit retirement removes that ambiguity; retries alone cannot repair it. No generic notification replay or renderer retry loop is added.

## Linked Issue

Related: [STA-5523](https://linear.app/stably/issue/STA-5523). This draft does not establish closure of the original packaged-startup incident.

## Visual Proof

| during-unavailable.png | surviving-terminal.png |
|---|---|
| ![during-unavailable.png](https://github.com/stablyai/orca/blob/91e14367caafafa7e4cac4598331fbf23544436b/during-unavailable.png?raw=true) | ![surviving-terminal.png](https://github.com/stablyai/orca/blob/91e14367caafafa7e4cac4598331fbf23544436b/surviving-terminal.png?raw=true) |

Hidden Electron/CDP fault-injection evidence at `863d57ef79adba58c3b4a435afe40c6a48e9355a`. The final head additionally preserves headless fallback on promotion send failure, covered by a new regression; the rendered proof predates that narrow change. A QA-only build transform exposed the isolated runtime to the main inspector; no fault hook is included in the source diff.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

50 focused tests pass, plus 140 existing graph/window/reload/headless tests (1,120 unrelated tests filtered out). Node, web, and CLI TypeScript projects pass sequentially; changed-file oxlint and diff whitespace checks pass. Restoring the old predicate caused eight regression failures; the committed source was restored byte for byte.

macOS hidden Electron: one injected notification-send failure produced `unavailable` while the terminal remained rendered. Creating a terminal through the real New Terminal menu restored `ready` with the same renderer generation and original PTY incarnation. A subsequent main notification rendered a new tab; the original terminal displayed before/after markers, and the host published an authoritative three-tab mobile inventory. The window remained hidden.

The synthetic profile path exceeded the daemon socket limit, so the app fell back to local PTYs. Daemon-backed recovery, paired mobile fault injection, real SSH, Linux, and Windows remain unverified. Initial dependency bootstrap failed before running tests; direct installed Vitest then ran successfully. Full repository suites and production packaging were not run.

## Review

Draft — awaiting fresh independent review of the exact head. No merge or ticket closure requested.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer content is copied or translated.

## Checklist

- [x] Focused on graph publisher admission and recovery
- [x] Explained the failure mechanism and resulting behavior
- [x] Self-reviewed; independent review remains pending
- [x] Cross-platform, SSH, folder-workspace, and wire compatibility considered
- [ ] Full repository lint/typecheck/test/build gate (targeted validation above; CI remains to be assessed)
