### PR TITLE
fix(codex): resume account switches without losing history or resetting goal budgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "dev": "pnpm run ensure:electron-runtime && node config/scripts/run-electron-vite-dev.mjs",
     "dev-stable-name": "pnpm run ensure:electron-runtime && node config/scripts/run-electron-vite-dev.mjs --stable-name",
     "dev:web": "vite --config vite.web.config.ts --host 127.0.0.1",
-    "build:relay": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON config/scripts/build-relay.mjs",
+    "build:relay": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON config/scripts/build-relay.mjs",
     "build:computer-macos": "node config/scripts/build-computer-macos.mjs",
     "build:keyboard-layout-macos": "node config/scripts/build-keyboard-layout-macos.mjs",
     "build:notification-status-macos": "node config/scripts/build-notification-status-macos.mjs",

--- a/src/main/codex/codex-account-session-bridge.test.ts
+++ b/src/main/codex/codex-account-session-bridge.test.ts
@@ -1,10 +1,21 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import * as sessionLinkModule from './codex-session-link'
 import {
   _internals,
   bridgeCodexSessionsIntoAccountHome,
+  linkCodexRolloutIntoAccountHome,
   startCodexAccountSessionBridgeInBackground
 } from './codex-account-session-bridge'
 
@@ -161,5 +172,153 @@ describe('startCodexAccountSessionBridgeInBackground', () => {
 
     expect(readFileSync(rolloutPath(firstTarget, ROLLOUT_A), 'utf-8')).toBe('session\n')
     expect(readFileSync(rolloutPath(secondTarget, ROLLOUT_A), 'utf-8')).toBe('session\n')
+  })
+})
+
+describe('linkCodexRolloutIntoAccountHome', () => {
+  it('places one named rollout under the target home ahead of the whole-tree sweep', () => {
+    const sourceHome = join(workspaceRoot, 'account-a')
+    const targetHome = join(workspaceRoot, 'account-b')
+    const rolloutFilePath = writeRollout(sourceHome, ROLLOUT_A, 'session\n')
+
+    const linkedPath = linkCodexRolloutIntoAccountHome({
+      sourceCodexHomePath: sourceHome,
+      targetCodexHomePath: targetHome,
+      rolloutFilePath
+    })
+
+    expect(linkedPath).toBe(rolloutPath(targetHome, ROLLOUT_A))
+    expect(readFileSync(rolloutPath(targetHome, ROLLOUT_A), 'utf-8')).toBe('session\n')
+    expect(statSync(rolloutPath(targetHome, ROLLOUT_A)).ino).toBe(statSync(rolloutFilePath).ino)
+  })
+
+  it('reports the existing path when the sweep already linked that rollout', () => {
+    const sourceHome = join(workspaceRoot, 'account-a')
+    const targetHome = join(workspaceRoot, 'account-b')
+    const rolloutFilePath = writeRollout(sourceHome, ROLLOUT_A, 'session\n')
+    writeRollout(targetHome, ROLLOUT_A, 'already-there\n')
+
+    expect(
+      linkCodexRolloutIntoAccountHome({
+        sourceCodexHomePath: sourceHome,
+        targetCodexHomePath: targetHome,
+        rolloutFilePath
+      })
+    ).toBe(rolloutPath(targetHome, ROLLOUT_A))
+    expect(readFileSync(rolloutPath(targetHome, ROLLOUT_A), 'utf-8')).toBe('already-there\n')
+  })
+
+  // skipIf: symlink creation on Windows needs elevation or Developer Mode.
+  it.skipIf(process.platform === 'win32')(
+    'replaces a symlink the sweep left so the hardlink can still land',
+    () => {
+      const sourceHome = join(workspaceRoot, 'account-a')
+      const targetHome = join(workspaceRoot, 'account-b')
+      const rolloutFilePath = writeRollout(sourceHome, ROLLOUT_B, 'session\n')
+      const targetFilePath = rolloutPath(targetHome, ROLLOUT_B)
+      mkdirSync(join(targetFilePath, '..'), { recursive: true })
+      symlinkSync(rolloutFilePath, targetFilePath)
+
+      expect(
+        linkCodexRolloutIntoAccountHome({
+          sourceCodexHomePath: sourceHome,
+          targetCodexHomePath: targetHome,
+          rolloutFilePath
+        })
+      ).toBe(targetFilePath)
+      expect(lstatSync(targetFilePath).isSymbolicLink()).toBe(false)
+      expect(statSync(targetFilePath).ino).toBe(statSync(rolloutFilePath).ino)
+    }
+  )
+
+  it('refuses a rollout that lies outside the source home sessions tree', () => {
+    const sourceHome = join(workspaceRoot, 'account-a')
+    const targetHome = join(workspaceRoot, 'account-b')
+    const strayPath = join(workspaceRoot, 'elsewhere', 'rollout-2026-07-20T10-00-00-aaaa.jsonl')
+    mkdirSync(join(strayPath, '..'), { recursive: true })
+    writeFileSync(strayPath, 'session\n')
+
+    expect(
+      linkCodexRolloutIntoAccountHome({
+        sourceCodexHomePath: sourceHome,
+        targetCodexHomePath: targetHome,
+        rolloutFilePath: strayPath
+      })
+    ).toBeNull()
+  })
+
+  it('falls back to copying the rollout file when hardlink fails (e.g. cross-volume EXDEV on Windows)', () => {
+    const sourceHome = join(workspaceRoot, 'account-a')
+    const targetHome = join(workspaceRoot, 'account-b')
+    const rolloutFilePath = writeRollout(sourceHome, ROLLOUT_B, 'copied session content\n')
+    const targetFilePath = rolloutPath(targetHome, ROLLOUT_B)
+
+    const hardlinkSpy = vi
+      .spyOn(sessionLinkModule, 'tryHardlinkCodexSessionFile')
+      .mockReturnValue(false)
+    try {
+      const linkedPath = linkCodexRolloutIntoAccountHome({
+        sourceCodexHomePath: sourceHome,
+        targetCodexHomePath: targetHome,
+        rolloutFilePath
+      })
+
+      expect(linkedPath).toBe(targetFilePath)
+      expect(readFileSync(targetFilePath, 'utf-8')).toBe('copied session content\n')
+      expect(lstatSync(targetFilePath).isFile()).toBe(true)
+      expect(lstatSync(targetFilePath).isSymbolicLink()).toBe(false)
+    } finally {
+      hardlinkSpy.mockRestore()
+    }
+  })
+
+  it('handles Windows extended path prefix (\\\\?\\) in paths properly', () => {
+    const sourceHome = join(workspaceRoot, 'account-a')
+    const targetHome = join(workspaceRoot, 'account-b')
+    const rolloutFilePath = writeRollout(sourceHome, ROLLOUT_A, 'session-extended\n')
+    const targetFilePath = rolloutPath(targetHome, ROLLOUT_A)
+
+    const extendedRolloutPath = `\\\\?\\${rolloutFilePath}`
+    const extendedSourceHome = `\\\\?\\${sourceHome}`
+    const linkedPath = linkCodexRolloutIntoAccountHome({
+      sourceCodexHomePath: extendedSourceHome,
+      targetCodexHomePath: targetHome,
+      rolloutFilePath: extendedRolloutPath
+    })
+
+    expect(linkedPath).toBe(targetFilePath)
+    expect(readFileSync(targetFilePath, 'utf-8')).toBe('session-extended\n')
+  })
+
+  it('does not copy over a racing background sweep rollout if hardlink fails', () => {
+    const sourceHome = join(workspaceRoot, 'account-a')
+    const targetHome = join(workspaceRoot, 'account-b')
+    const rolloutFilePath = writeRollout(sourceHome, ROLLOUT_B, 'original session\n')
+    const targetFilePath = rolloutPath(targetHome, ROLLOUT_B)
+
+    // Simulate racing background sweep placing the file right before copy attempt
+    const copySpy = vi.spyOn(sessionLinkModule, 'tryCopyCodexSessionFile')
+    const hardlinkSpy = vi
+      .spyOn(sessionLinkModule, 'tryHardlinkCodexSessionFile')
+      .mockImplementation(() => {
+        // Background sweep placed the file!
+        writeRollout(targetHome, ROLLOUT_B, 'racing linked session\n')
+        return false
+      })
+
+    try {
+      const linkedPath = linkCodexRolloutIntoAccountHome({
+        sourceCodexHomePath: sourceHome,
+        targetCodexHomePath: targetHome,
+        rolloutFilePath
+      })
+
+      expect(linkedPath).toBe(targetFilePath)
+      expect(readFileSync(targetFilePath, 'utf-8')).toBe('racing linked session\n')
+      expect(copySpy).not.toHaveBeenCalled()
+    } finally {
+      hardlinkSpy.mockRestore()
+      copySpy.mockRestore()
+    }
   })
 })

--- a/src/main/codex/codex-account-session-bridge.test.ts
+++ b/src/main/codex/codex-account-session-bridge.test.ts
@@ -196,7 +196,7 @@ describe('linkCodexRolloutIntoAccountHome', () => {
     const sourceHome = join(workspaceRoot, 'account-a')
     const targetHome = join(workspaceRoot, 'account-b')
     const rolloutFilePath = writeRollout(sourceHome, ROLLOUT_A, 'session\n')
-    writeRollout(targetHome, ROLLOUT_A, 'already-there\n')
+    writeRollout(targetHome, ROLLOUT_A, 'session\n')
 
     expect(
       linkCodexRolloutIntoAccountHome({
@@ -205,8 +205,27 @@ describe('linkCodexRolloutIntoAccountHome', () => {
         rolloutFilePath
       })
     ).toBe(rolloutPath(targetHome, ROLLOUT_A))
-    expect(readFileSync(rolloutPath(targetHome, ROLLOUT_A), 'utf-8')).toBe('already-there\n')
+    expect(readFileSync(rolloutPath(targetHome, ROLLOUT_A), 'utf-8')).toBe('session\n')
   })
+
+  it.each(['', 'divergent history\n', 'sess'])(
+    'refuses and preserves an invalid existing copy: %j',
+    (contents) => {
+      const sourceHome = join(workspaceRoot, 'account-a')
+      const targetHome = join(workspaceRoot, 'account-b')
+      const rolloutFilePath = writeRollout(sourceHome, ROLLOUT_A, 'session\n')
+      const target = writeRollout(targetHome, ROLLOUT_A, contents)
+      expect(
+        linkCodexRolloutIntoAccountHome({
+          sourceCodexHomePath: sourceHome,
+          targetCodexHomePath: targetHome,
+          rolloutFilePath
+        })
+      ).toBeNull()
+      expect(readFileSync(target, 'utf8')).toBe(contents)
+      expect(readFileSync(rolloutFilePath, 'utf8')).toBe('session\n')
+    }
+  )
 
   // skipIf: symlink creation on Windows needs elevation or Developer Mode.
   it.skipIf(process.platform === 'win32')(
@@ -302,7 +321,7 @@ describe('linkCodexRolloutIntoAccountHome', () => {
       .spyOn(sessionLinkModule, 'tryHardlinkCodexSessionFile')
       .mockImplementation(() => {
         // Background sweep placed the file!
-        writeRollout(targetHome, ROLLOUT_B, 'racing linked session\n')
+        writeRollout(targetHome, ROLLOUT_B, 'original session\n')
         return false
       })
 
@@ -314,7 +333,7 @@ describe('linkCodexRolloutIntoAccountHome', () => {
       })
 
       expect(linkedPath).toBe(targetFilePath)
-      expect(readFileSync(targetFilePath, 'utf-8')).toBe('racing linked session\n')
+      expect(readFileSync(targetFilePath, 'utf-8')).toBe('original session\n')
       expect(copySpy).not.toHaveBeenCalled()
     } finally {
       hardlinkSpy.mockRestore()

--- a/src/main/codex/codex-account-session-bridge.ts
+++ b/src/main/codex/codex-account-session-bridge.ts
@@ -1,6 +1,7 @@
 import { existsSync, lstatSync, mkdirSync, unlinkSync } from 'node:fs'
 import { dirname, isAbsolute, join, relative } from 'node:path'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { codexRolloutContentMatches } from './codex-rollout-content-match'
 import { listCodexSessionRolloutFilesIncrementally } from './codex-session-file-listing'
 import type { CodexSessionBridgeIncrementalOptions } from './codex-session-file-listing'
 import {
@@ -127,7 +128,7 @@ export function linkCodexRolloutIntoAccountHome(args: {
     return null
   }
   const targetFilePath = join(targetSessionsRoot, relativePath)
-  if (isCodexResumableRollout(targetFilePath)) {
+  if (codexRolloutContentMatches(cleanRolloutPath, targetFilePath)) {
     return targetFilePath
   }
   try {
@@ -140,19 +141,19 @@ export function linkCodexRolloutIntoAccountHome(args: {
     console.warn('[codex-account-session-bridge] Failed to prepare session path:', error)
     return null
   }
-  if (tryHardlinkCodexSessionFile(args.rolloutFilePath, targetFilePath)) {
-    return targetFilePath
+  if (tryHardlinkCodexSessionFile(cleanRolloutPath, targetFilePath)) {
+    return codexRolloutContentMatches(cleanRolloutPath, targetFilePath) ? targetFilePath : null
   }
   // Why re-check before copy: the background sweep walks the same tree, so it
   // can hardlink this rollout in the gap between removeSymlinkAt and tryHardlink.
   // Returning the freshly-linked rollout preserves the shared inode instead of
   // overwriting it with a diverging copy.
-  if (isCodexResumableRollout(targetFilePath)) {
+  if (codexRolloutContentMatches(cleanRolloutPath, targetFilePath)) {
     return targetFilePath
   }
   // Windows / cross-volume fallback: copy the rollout file so Codex can resume it
-  if (tryCopyCodexSessionFile(args.rolloutFilePath, targetFilePath)) {
-    return targetFilePath
+  if (tryCopyCodexSessionFile(cleanRolloutPath, targetFilePath)) {
+    return codexRolloutContentMatches(cleanRolloutPath, targetFilePath) ? targetFilePath : null
   }
   return null
 }
@@ -167,16 +168,6 @@ function removeSymlinkAt(filePath: string): void {
     return
   }
   unlinkSync(filePath)
-}
-
-/** A path Codex will actually list: a real file, never a symlink to one. */
-function isCodexResumableRollout(filePath: string): boolean {
-  try {
-    const stats = lstatSync(filePath)
-    return stats.isFile() && !stats.isSymbolicLink()
-  } catch {
-    return false
-  }
 }
 
 /**

--- a/src/main/codex/codex-account-session-bridge.ts
+++ b/src/main/codex/codex-account-session-bridge.ts
@@ -1,9 +1,13 @@
-import { existsSync, mkdirSync } from 'node:fs'
-import { dirname, join, relative } from 'node:path'
+import { existsSync, lstatSync, mkdirSync, unlinkSync } from 'node:fs'
+import { dirname, isAbsolute, join, relative } from 'node:path'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { listCodexSessionRolloutFilesIncrementally } from './codex-session-file-listing'
 import type { CodexSessionBridgeIncrementalOptions } from './codex-session-file-listing'
-import { linkCodexSessionFile } from './codex-session-link'
+import {
+  linkCodexSessionFile,
+  tryCopyCodexSessionFile,
+  tryHardlinkCodexSessionFile
+} from './codex-session-link'
 
 /**
  * Bridges Codex history between Orca-managed Codex homes.
@@ -79,6 +83,100 @@ export async function bridgeCodexSessionsIntoAccountHome(args: {
     }
   }
   return summary
+}
+
+function stripWindowsExtendedPathPrefix(filePath: string): string {
+  if (filePath.startsWith('\\\\.\\')) {
+    return filePath
+  }
+  if (filePath.startsWith('\\\\?\\')) {
+    return filePath.match(/^\\\\\?\\([A-Za-z]:[\\/][\s\S]*)$/)?.[1] ?? filePath
+  }
+  return filePath
+}
+
+/**
+ * Links or copies one named rollout into the target home ahead of the whole-tree bridge.
+ *
+ * Why: the background bridge walks every source home and can take seconds on a
+ * large history. An account-switch restart has to resume one specific
+ * conversation immediately, so it places that rollout first and lets the sweep
+ * catch up.
+ *
+ * Tries hardlink first to preserve single-file identity. If hardlink fails
+ * (e.g. cross-volume move or Windows permission limits), it safely falls back
+ * to copyFileSync. Codex resume can directly read copied regular JSONL files.
+ * Returns the target file path, or null when it could not be placed.
+ */
+export function linkCodexRolloutIntoAccountHome(args: {
+  sourceCodexHomePath: string
+  targetCodexHomePath: string
+  rolloutFilePath: string
+}): string | null {
+  const cleanSourceHome = stripWindowsExtendedPathPrefix(args.sourceCodexHomePath)
+  const cleanRolloutPath = stripWindowsExtendedPathPrefix(args.rolloutFilePath)
+  const sourceSessionsRoot = join(cleanSourceHome, 'sessions')
+  const targetSessionsRoot = join(
+    stripWindowsExtendedPathPrefix(args.targetCodexHomePath),
+    'sessions'
+  )
+  const relativePath = relative(sourceSessionsRoot, cleanRolloutPath)
+  // Why: a rollout outside the source home's sessions tree has no place in the
+  // target tree either; refusing beats inventing a path from `..` segments.
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    return null
+  }
+  const targetFilePath = join(targetSessionsRoot, relativePath)
+  if (isCodexResumableRollout(targetFilePath)) {
+    return targetFilePath
+  }
+  try {
+    mkdirSync(dirname(targetFilePath), { recursive: true })
+    // Why unlink first: the sweep may already have left a symlink at this exact
+    // path, and a hardlink onto an occupied path fails EEXIST — which would make
+    // the conversation permanently unmovable rather than merely unlisted.
+    removeSymlinkAt(targetFilePath)
+  } catch (error) {
+    console.warn('[codex-account-session-bridge] Failed to prepare session path:', error)
+    return null
+  }
+  if (tryHardlinkCodexSessionFile(args.rolloutFilePath, targetFilePath)) {
+    return targetFilePath
+  }
+  // Why re-check before copy: the background sweep walks the same tree, so it
+  // can hardlink this rollout in the gap between removeSymlinkAt and tryHardlink.
+  // Returning the freshly-linked rollout preserves the shared inode instead of
+  // overwriting it with a diverging copy.
+  if (isCodexResumableRollout(targetFilePath)) {
+    return targetFilePath
+  }
+  // Windows / cross-volume fallback: copy the rollout file so Codex can resume it
+  if (tryCopyCodexSessionFile(args.rolloutFilePath, targetFilePath)) {
+    return targetFilePath
+  }
+  return null
+}
+
+/** Clears a symlink standing where a real file has to go; leaves real files alone. */
+function removeSymlinkAt(filePath: string): void {
+  try {
+    if (!lstatSync(filePath).isSymbolicLink()) {
+      return
+    }
+  } catch {
+    return
+  }
+  unlinkSync(filePath)
+}
+
+/** A path Codex will actually list: a real file, never a symlink to one. */
+function isCodexResumableRollout(filePath: string): boolean {
+  try {
+    const stats = lstatSync(filePath)
+    return stats.isFile() && !stats.isSymbolicLink()
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/src/main/codex/codex-account-switch-resume-repin.test.ts
+++ b/src/main/codex/codex-account-switch-resume-repin.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveCodexAccountSwitchResumeHome } from './codex-account-switch-resume-repin'
+
+const ORIGIN = '/data/codex-accounts/account-a/home'
+const SELECTED = '/data/codex-accounts/account-b/home'
+const TRANSCRIPT = `${ORIGIN}/sessions/2026/08/16/rollout-2026-08-16T00-00-00-abc.jsonl`
+
+describe('resolveCodexAccountSwitchResumeHome', () => {
+  it('moves the resume onto the selected account once its rollout is listed there', () => {
+    const linkRollout = vi.fn(() => `${SELECTED}/sessions/2026/08/16/rollout-x.jsonl`)
+
+    expect(
+      resolveCodexAccountSwitchResumeHome({
+        originCodexHomePath: ORIGIN,
+        selectedCodexHomePath: SELECTED,
+        transcriptPath: TRANSCRIPT,
+        linkRollout
+      })
+    ).toEqual({ outcome: 'moved', codexHomePath: SELECTED })
+    expect(linkRollout).toHaveBeenCalledWith({
+      sourceCodexHomePath: ORIGIN,
+      targetCodexHomePath: SELECTED,
+      rolloutFilePath: TRANSCRIPT
+    })
+  })
+
+  it('reports a pane already on the selected account as nothing to move', () => {
+    const linkRollout = vi.fn(() => `${ORIGIN}/sessions/x.jsonl`)
+
+    expect(
+      resolveCodexAccountSwitchResumeHome({
+        originCodexHomePath: ORIGIN,
+        selectedCodexHomePath: `${ORIGIN}/`,
+        transcriptPath: TRANSCRIPT,
+        linkRollout
+      })
+    ).toEqual({ outcome: 'already-there' })
+    // Why asserted: treating this as a give-up would discard a conversation that
+    // was never at risk, since the pane's own account is the selected one.
+    expect(linkRollout).not.toHaveBeenCalled()
+  })
+
+  it('reports the system default as unmovable without attempting a link', () => {
+    const linkRollout = vi.fn(() => `${SELECTED}/sessions/x.jsonl`)
+
+    expect(
+      resolveCodexAccountSwitchResumeHome({
+        originCodexHomePath: ORIGIN,
+        selectedCodexHomePath: null,
+        transcriptPath: TRANSCRIPT,
+        linkRollout
+      })
+    ).toEqual({ outcome: 'unmovable' })
+    expect(linkRollout).not.toHaveBeenCalled()
+  })
+
+  it('reports a refused link as unmovable rather than resuming on the old account', () => {
+    expect(
+      resolveCodexAccountSwitchResumeHome({
+        originCodexHomePath: ORIGIN,
+        selectedCodexHomePath: SELECTED,
+        transcriptPath: TRANSCRIPT,
+        linkRollout: vi.fn(() => null)
+      })
+    ).toEqual({ outcome: 'unmovable' })
+  })
+
+  it('reports a thrown link as unmovable', () => {
+    expect(
+      resolveCodexAccountSwitchResumeHome({
+        originCodexHomePath: ORIGIN,
+        selectedCodexHomePath: SELECTED,
+        transcriptPath: TRANSCRIPT,
+        linkRollout: vi.fn(() => {
+          throw new Error('EPERM')
+        })
+      })
+    ).toEqual({ outcome: 'unmovable' })
+  })
+})

--- a/src/main/codex/codex-account-switch-resume-repin.test.ts
+++ b/src/main/codex/codex-account-switch-resume-repin.test.ts
@@ -40,7 +40,7 @@ describe('resolveCodexAccountSwitchResumeHome', () => {
     expect(linkRollout).not.toHaveBeenCalled()
   })
 
-  it('reports the system default as unmovable without attempting a link', () => {
+  it('reports an unresolved selection as unmovable without attempting a link', () => {
     const linkRollout = vi.fn(() => `${SELECTED}/sessions/x.jsonl`)
 
     expect(

--- a/src/main/codex/codex-account-switch-resume-repin.ts
+++ b/src/main/codex/codex-account-switch-resume-repin.ts
@@ -1,0 +1,63 @@
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { linkCodexRolloutIntoAccountHome } from './codex-account-session-bridge'
+
+/**
+ * Where an account-switch restart should resume from.
+ *
+ * `already-there` is not a move at all: the pane's own account is the selected
+ * one, so the ordinary resume is correct and nothing may be given up.
+ * `moved` means the conversation is listed under the selected account and can
+ * be resumed there. `unmovable` means it cannot be, and the caller has to
+ * choose between the account the user asked for and the conversation; it picks
+ * the account, because that is what the user pressed the button for.
+ */
+export type CodexAccountSwitchResumeOutcome =
+  | { outcome: 'already-there' }
+  | { outcome: 'moved'; codexHomePath: string }
+  | { outcome: 'unmovable' }
+
+/**
+ * Moves an account-switch restart's resume onto the newly selected account.
+ *
+ * Why: the ordinary resume path pins CODEX_HOME to the home that owns the
+ * rollout. That is right for a cold restore (the pane comes back as the account
+ * that recorded the conversation) and wrong for an account switch, where it
+ * relaunches the pane under the account the user just left, so the switch
+ * appears to do nothing. Rollouts are linked/copied across managed homes, so the
+ * same conversation resumes under the selected account once its file is listed
+ * there.
+ */
+export function resolveCodexAccountSwitchResumeHome(args: {
+  originCodexHomePath: string
+  selectedCodexHomePath: string | null
+  transcriptPath: string
+  linkRollout?: typeof linkCodexRolloutIntoAccountHome
+}): CodexAccountSwitchResumeOutcome {
+  const selected = args.selectedCodexHomePath
+  // Why: the system default runs Codex against the user's own ~/.codex, which
+  // Orca never writes into, so the rollout can never be listed there.
+  if (!selected) {
+    return { outcome: 'unmovable' }
+  }
+  if (
+    normalizeRuntimePathForComparison(selected) ===
+    normalizeRuntimePathForComparison(args.originCodexHomePath)
+  ) {
+    return { outcome: 'already-there' }
+  }
+  const link = args.linkRollout ?? linkCodexRolloutIntoAccountHome
+  try {
+    const linkedPath = link({
+      sourceCodexHomePath: args.originCodexHomePath,
+      targetCodexHomePath: selected,
+      rolloutFilePath: args.transcriptPath
+    })
+    return linkedPath ? { outcome: 'moved', codexHomePath: selected } : { outcome: 'unmovable' }
+  } catch (error) {
+    // Why not fall back to the origin: resuming there relaunches the pane on the
+    // account the user just left, which is the bug this whole path exists to
+    // fix. Losing the conversation is the smaller failure, and the pane says so.
+    console.warn('[codex-account-switch] Failed to link rollout into selected home:', error)
+    return { outcome: 'unmovable' }
+  }
+}

--- a/src/main/codex/codex-account-switch-resume-repin.ts
+++ b/src/main/codex/codex-account-switch-resume-repin.ts
@@ -1,16 +1,7 @@
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { linkCodexRolloutIntoAccountHome } from './codex-account-session-bridge'
 
-/**
- * Where an account-switch restart should resume from.
- *
- * `already-there` is not a move at all: the pane's own account is the selected
- * one, so the ordinary resume is correct and nothing may be given up.
- * `moved` means the conversation is listed under the selected account and can
- * be resumed there. `unmovable` means it cannot be, and the caller has to
- * choose between the account the user asked for and the conversation; it picks
- * the account, because that is what the user pressed the button for.
- */
+/** Result of placing the verified transcript in the selected account home. */
 export type CodexAccountSwitchResumeOutcome =
   | { outcome: 'already-there' }
   | { outcome: 'moved'; codexHomePath: string }
@@ -34,8 +25,7 @@ export function resolveCodexAccountSwitchResumeHome(args: {
   linkRollout?: typeof linkCodexRolloutIntoAccountHome
 }): CodexAccountSwitchResumeOutcome {
   const selected = args.selectedCodexHomePath
-  // Why: the system default runs Codex against the user's own ~/.codex, which
-  // Orca never writes into, so the rollout can never be listed there.
+  // System-default selections supply their resolved home explicitly.
   if (!selected) {
     return { outcome: 'unmovable' }
   }
@@ -54,9 +44,6 @@ export function resolveCodexAccountSwitchResumeHome(args: {
     })
     return linkedPath ? { outcome: 'moved', codexHomePath: selected } : { outcome: 'unmovable' }
   } catch (error) {
-    // Why not fall back to the origin: resuming there relaunches the pane on the
-    // account the user just left, which is the bug this whole path exists to
-    // fix. Losing the conversation is the smaller failure, and the pane says so.
     console.warn('[codex-account-switch] Failed to link rollout into selected home:', error)
     return { outcome: 'unmovable' }
   }

--- a/src/main/codex/codex-rollout-content-match.ts
+++ b/src/main/codex/codex-rollout-content-match.ts
@@ -1,0 +1,50 @@
+import { closeSync, fstatSync, lstatSync, openSync, readSync } from 'node:fs'
+
+/** Existing copies must match the verified source before they can be resumed. */
+export function codexRolloutContentMatches(sourcePath: string, targetPath: string): boolean {
+  const descriptors: number[] = []
+  try {
+    if (!lstatSync(targetPath).isFile()) {
+      return false
+    }
+    const source = openSync(sourcePath, 'r')
+    descriptors.push(source)
+    const target = openSync(targetPath, 'r')
+    descriptors.push(target)
+    const sourceStat = fstatSync(source)
+    const targetStat = fstatSync(target)
+    if (!sourceStat.isFile() || sourceStat.size === 0) {
+      return false
+    }
+    if (
+      sourceStat.ino !== 0 &&
+      sourceStat.dev === targetStat.dev &&
+      sourceStat.ino === targetStat.ino
+    ) {
+      return true
+    }
+    if (sourceStat.size !== targetStat.size) {
+      return false
+    }
+    const left = Buffer.alloc(64 * 1024)
+    const right = Buffer.alloc(left.length)
+    for (let offset = 0; offset < sourceStat.size;) {
+      const length = Math.min(left.length, sourceStat.size - offset)
+      const count = readSync(source, left, 0, length, offset)
+      if (count !== length || readSync(target, right, 0, length, offset) !== length) {
+        return false
+      }
+      if (!left.subarray(0, length).equals(right.subarray(0, length))) {
+        return false
+      }
+      offset += length
+    }
+    return fstatSync(source).size === sourceStat.size && fstatSync(target).size === targetStat.size
+  } catch {
+    return false
+  } finally {
+    for (const descriptor of descriptors) {
+      closeSync(descriptor)
+    }
+  }
+}

--- a/src/main/codex/codex-session-link.ts
+++ b/src/main/codex/codex-session-link.ts
@@ -1,4 +1,4 @@
-import { linkSync, symlinkSync } from 'node:fs'
+import { copyFileSync, linkSync, symlinkSync } from 'node:fs'
 
 /**
  * Attempts a hardlink so resume sees one physical JSONL session log.
@@ -8,6 +8,19 @@ export function tryHardlinkCodexSessionFile(sourcePath: string, targetPath: stri
     // Why: Codex resume ignores symlinked JSONL sessions, while a hardlink
     // preserves one physical log without copy divergence.
     linkSync(sourcePath, targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Attempts a copy so resume sees a real JSONL session log when hardlink fails
+ * (e.g. cross-volume EXDEV, non-elevated Windows without symlink privilege, or restrictive filesystems).
+ */
+export function tryCopyCodexSessionFile(sourcePath: string, targetPath: string): boolean {
+  try {
+    copyFileSync(sourcePath, targetPath)
     return true
   } catch {
     return false

--- a/src/main/codex/codex-session-link.ts
+++ b/src/main/codex/codex-session-link.ts
@@ -1,4 +1,13 @@
-import { copyFileSync, linkSync, symlinkSync } from 'node:fs'
+import {
+  constants,
+  copyFileSync,
+  linkSync,
+  mkdtempSync,
+  rmdirSync,
+  symlinkSync,
+  unlinkSync
+} from 'node:fs'
+import { join } from 'node:path'
 
 /**
  * Attempts a hardlink so resume sees one physical JSONL session log.
@@ -19,11 +28,29 @@ export function tryHardlinkCodexSessionFile(sourcePath: string, targetPath: stri
  * (e.g. cross-volume EXDEV, non-elevated Windows without symlink privilege, or restrictive filesystems).
  */
 export function tryCopyCodexSessionFile(sourcePath: string, targetPath: string): boolean {
+  let temporaryDirectory: string | undefined
   try {
-    copyFileSync(sourcePath, targetPath)
+    temporaryDirectory = mkdtempSync(`${targetPath}.`)
+    const temporaryPath = join(temporaryDirectory, 'rollout.tmp')
+    copyFileSync(sourcePath, temporaryPath, constants.COPYFILE_EXCL)
+    // Publish the complete copy without replacing a concurrent bridge or divergent history.
+    linkSync(temporaryPath, targetPath)
     return true
   } catch {
     return false
+  } finally {
+    if (temporaryDirectory) {
+      try {
+        unlinkSync(join(temporaryDirectory, 'rollout.tmp'))
+      } catch {
+        /* Copy may have failed. */
+      }
+      try {
+        rmdirSync(temporaryDirectory)
+      } catch {
+        /* Preserve unexpected contents. */
+      }
+    }
   }
 }
 

--- a/src/main/codex/codex-thread-goal-transfer.test.ts
+++ b/src/main/codex/codex-thread-goal-transfer.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as CodexAppServerSessionModule from './codex-app-server-session'
+
+const runCodexAppServerSession = vi.fn()
+
+vi.mock('./codex-app-server-session', async (importOriginal) => {
+  const actual = await importOriginal<typeof CodexAppServerSessionModule>()
+  return { ...actual, runCodexAppServerSession }
+})
+vi.mock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+vi.mock('../win32-utils', () => ({
+  getSpawnArgsForWindows: (command: string, args: string[]) => ({
+    spawnCmd: command,
+    spawnArgs: args
+  })
+}))
+
+const { CodexAppServerUnsupportedError } = await import('./codex-app-server-session')
+const { _internals, parseCodexThreadGoal, transferCodexThreadGoalBetweenHomes } =
+  await import('./codex-thread-goal-transfer')
+
+const ORIGIN = '/data/codex-accounts/a/home'
+const TARGET = '/data/codex-accounts/b/home'
+const THREAD = '01a006a6-1d07-70a1-bad5-f9110d5845c0'
+
+/** Answers the get session with `goal`, then records every method the set session calls. */
+function stubSessions(goal: unknown, calls: { method: string; params: unknown }[]): void {
+  let sessionIndex = 0
+  runCodexAppServerSession.mockImplementation(async (_invocation, body) => {
+    const isGet = sessionIndex === 0
+    sessionIndex += 1
+    return body({
+      request: async (method: string, params: unknown) => {
+        calls.push({ method, params })
+        return isGet ? goal : {}
+      }
+    })
+  })
+}
+
+describe('parseCodexThreadGoal', () => {
+  it('reads a goal wrapped in a `goal` envelope and one returned bare', () => {
+    expect(
+      parseCodexThreadGoal({
+        goal: { objective: 'ship it', status: 'active' }
+      })
+    ).toEqual({
+      objective: 'ship it',
+      status: 'active'
+    })
+    expect(parseCodexThreadGoal({ objective: 'ship it' })).toEqual({
+      objective: 'ship it'
+    })
+  })
+
+  it('clears a limit the previous account hit so the goal runs on the new one', () => {
+    // Why both spellings: the app-server speaks camelCase and rejects anything
+    // else, while the goals DB stores the same states with underscores.
+    for (const status of ['usageLimited', 'budgetLimited', 'usage_limited', 'budget_limited']) {
+      expect(parseCodexThreadGoal({ objective: 'a', status })?.status).toBe('active')
+    }
+  })
+
+  it('keeps a status the user chose', () => {
+    for (const status of ['paused', 'blocked', 'complete', 'active']) {
+      expect(parseCodexThreadGoal({ objective: 'a', status })?.status).toBe(status)
+    }
+  })
+
+  it('drops a status the app-server would reject rather than lose the objective', () => {
+    expect(parseCodexThreadGoal({ objective: 'a', status: 'archived' })).toEqual({
+      objective: 'a'
+    })
+  })
+
+  it('accepts either spelling of the budget field', () => {
+    expect(parseCodexThreadGoal({ objective: 'a', token_budget: 500 })?.tokenBudget).toBe(500)
+    expect(parseCodexThreadGoal({ objective: 'a', tokenBudget: 500 })?.tokenBudget).toBe(500)
+  })
+
+  it('reports no goal for an empty objective or a non-object answer', () => {
+    expect(parseCodexThreadGoal({ objective: '   ' })).toBeNull()
+    expect(parseCodexThreadGoal(null)).toBeNull()
+  })
+})
+
+describe('transferCodexThreadGoalBetweenHomes', () => {
+  beforeEach(() => {
+    runCodexAppServerSession.mockReset()
+    _internals.resetGoalRpcCapability()
+  })
+
+  it('carries the objective, status and budget but never the usage counters', async () => {
+    const calls: { method: string; params: unknown }[] = []
+    stubSessions(
+      {
+        goal: {
+          objective: 'ship it',
+          status: 'active',
+          tokenBudget: 500,
+          tokensUsed: 420,
+          timeUsedSeconds: 90
+        }
+      },
+      calls
+    )
+
+    await expect(
+      transferCodexThreadGoalBetweenHomes({
+        threadId: THREAD,
+        originCodexHomePath: ORIGIN,
+        targetCodexHomePath: TARGET
+      })
+    ).resolves.toBe('transferred')
+
+    expect(calls.map((call) => call.method)).toEqual([
+      'thread/goal/get',
+      'thread/read',
+      'thread/goal/set'
+    ])
+    expect(calls[2].params).toEqual({
+      threadId: THREAD,
+      objective: 'ship it',
+      status: 'active',
+      tokenBudget: 500
+    })
+  })
+
+  it('writes nothing when the thread has no goal', async () => {
+    const calls: { method: string; params: unknown }[] = []
+    stubSessions({ goal: null }, calls)
+
+    await expect(
+      transferCodexThreadGoalBetweenHomes({
+        threadId: THREAD,
+        originCodexHomePath: ORIGIN,
+        targetCodexHomePath: TARGET
+      })
+    ).resolves.toBe('no-goal')
+    expect(calls.map((call) => call.method)).toEqual(['thread/goal/get'])
+  })
+
+  it('skips the RPCs entirely when the account did not move', async () => {
+    await expect(
+      transferCodexThreadGoalBetweenHomes({
+        threadId: THREAD,
+        originCodexHomePath: ORIGIN,
+        targetCodexHomePath: `${ORIGIN}/`
+      })
+    ).resolves.toBe('skipped')
+    expect(runCodexAppServerSession).not.toHaveBeenCalled()
+  })
+
+  it('remembers an unsupported CLI and stops probing it', async () => {
+    runCodexAppServerSession.mockRejectedValue(
+      new CodexAppServerUnsupportedError('no such method: thread/goal/get')
+    )
+
+    const args = {
+      threadId: THREAD,
+      originCodexHomePath: ORIGIN,
+      targetCodexHomePath: TARGET
+    }
+    await expect(transferCodexThreadGoalBetweenHomes(args)).resolves.toBe('unsupported')
+    await expect(transferCodexThreadGoalBetweenHomes(args)).resolves.toBe('unsupported')
+    expect(runCodexAppServerSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a transient RPC failure without marking the CLI unsupported', async () => {
+    runCodexAppServerSession.mockRejectedValueOnce(new Error('spawn EAGAIN'))
+
+    const args = {
+      threadId: THREAD,
+      originCodexHomePath: ORIGIN,
+      targetCodexHomePath: TARGET
+    }
+    await expect(transferCodexThreadGoalBetweenHomes(args)).resolves.toBe('failed')
+
+    const calls: { method: string; params: unknown }[] = []
+    stubSessions({ goal: { objective: 'still here' } }, calls)
+    await expect(transferCodexThreadGoalBetweenHomes(args)).resolves.toBe('transferred')
+  })
+})

--- a/src/main/codex/codex-thread-goal-transfer.test.ts
+++ b/src/main/codex/codex-thread-goal-transfer.test.ts
@@ -56,9 +56,26 @@ describe('parseCodexThreadGoal', () => {
   it('clears a limit the previous account hit so the goal runs on the new one', () => {
     // Why both spellings: the app-server speaks camelCase and rejects anything
     // else, while the goals DB stores the same states with underscores.
-    for (const status of ['usageLimited', 'budgetLimited', 'usage_limited', 'budget_limited']) {
+    for (const status of ['usageLimited', 'usage_limited']) {
       expect(parseCodexThreadGoal({ objective: 'a', status })?.status).toBe('active')
     }
+  })
+
+  it('preserves budget exhaustion and subtracts consumption', () => {
+    expect(
+      parseCodexThreadGoal({
+        objective: 'a',
+        status: 'budget_limited',
+        tokenBudget: 500,
+        tokensUsed: 500
+      })
+    ).toEqual({ objective: 'a', status: 'budgetLimited', tokenBudget: 1 })
+    expect(
+      parseCodexThreadGoal({ objective: 'a', status: 'active', tokenBudget: 500, tokensUsed: 420 })
+    ).toEqual({ objective: 'a', status: 'active', tokenBudget: 80 })
+    expect(
+      parseCodexThreadGoal({ objective: 'a', status: 'active', tokenBudget: 500 })?.status
+    ).toBe('paused')
   })
 
   it('keeps a status the user chose', () => {
@@ -122,7 +139,7 @@ describe('transferCodexThreadGoalBetweenHomes', () => {
       threadId: THREAD,
       objective: 'ship it',
       status: 'active',
-      tokenBudget: 500
+      tokenBudget: 80
     })
   })
 

--- a/src/main/codex/codex-thread-goal-transfer.ts
+++ b/src/main/codex/codex-thread-goal-transfer.ts
@@ -1,0 +1,224 @@
+import { resolveCodexCommand } from '../codex-cli/command'
+import { getSpawnArgsForWindows } from '../win32-utils'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import {
+  CodexAppServerCapabilityCache,
+  getCodexAppServerHostKey
+} from './codex-app-server-capability-cache'
+import {
+  isCodexAppServerUnsupportedError,
+  runCodexAppServerSession,
+  type CodexAppServerInvocation
+} from './codex-app-server-session'
+
+/**
+ * Carries a thread's `/goal` across an account-switch restart.
+ *
+ * Why only part of it: Codex stores goals in a per-home sqlite DB, so a thread
+ * resumed under another account starts with no goal at all. The objective, the
+ * budget and the user's own pause/block/complete state are what the user loses
+ * and what Codex's own RPCs can restore. Everything the previous account
+ * metered stays behind: the usage counters, and the limit statuses derived from
+ * them. Hitting a limit is a fact about the account being left, and the account
+ * being moved to has its own headroom — which is usually the whole reason for
+ * the switch.
+ *
+ * Orca never touches Codex's sqlite directly; `thread/goal/get` and
+ * `thread/goal/set` are the app-server's own surface for this.
+ */
+
+// Why so short: the restart awaits this before the PTY exists, so every second
+// here is a second the user stares at an empty pane. A goal that does not
+// arrive in time is a smaller loss than a terminal that feels hung.
+const GOAL_RPC_TIMEOUT_MS = 4_000
+const GOAL_TRANSFER_DEADLINE_MS = 6_000
+
+// Why remapped rather than dropped: leaving the status unset would let the new
+// account inherit whatever default Codex applies, and an active goal must stay
+// active across the move. See #12098 — the limit is what triggered the switch.
+//
+// Why these exact spellings: the app-server's own enum, not the sqlite column's.
+// `thread/goal/set` answers a snake_case status with "unknown variant
+// `usage_limited`, expected one of `active`, `paused`, `blocked`, `usageLimited`,
+// `budgetLimited`, `complete`" — so the wire names are camelCase even though the
+// goals DB stores them with underscores. Both are accepted on the way in, since
+// a read that ever returns the DB spelling must still be recognised as a limit.
+const ACCOUNT_METERED_GOAL_STATUSES = new Set([
+  'usageLimited',
+  'budgetLimited',
+  'usage_limited',
+  'budget_limited'
+])
+const CODEX_GOAL_STATUSES = new Set([
+  'active',
+  'paused',
+  'blocked',
+  'usageLimited',
+  'budgetLimited',
+  'complete'
+])
+const GOAL_STATUS_AFTER_ACCOUNT_MOVE = 'active'
+
+// Why dedicated: the shared cache answers for a different method surface, and
+// one CLI can expose that one while lacking the goal RPCs.
+const goalRpcCapabilityCache = new CodexAppServerCapabilityCache()
+
+export type CodexTransferableThreadGoal = {
+  objective: string
+  status?: string
+  tokenBudget?: number
+}
+
+export function parseCodexThreadGoal(value: unknown): CodexTransferableThreadGoal | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const goal = (value as { goal?: unknown }).goal ?? value
+  if (!goal || typeof goal !== 'object') {
+    return null
+  }
+  const record = goal as Record<string, unknown>
+  const objective = record.objective
+  if (typeof objective !== 'string' || objective.trim().length === 0) {
+    return null
+  }
+  const status = resolveGoalStatusAfterAccountMove(record.status)
+  const tokenBudget = record.tokenBudget ?? record.token_budget
+  return {
+    objective,
+    ...(status ? { status } : {}),
+    ...(typeof tokenBudget === 'number' && Number.isFinite(tokenBudget) ? { tokenBudget } : {})
+  }
+}
+
+function resolveGoalStatusAfterAccountMove(status: unknown): string | null {
+  if (typeof status !== 'string' || status.length === 0) {
+    return null
+  }
+  if (ACCOUNT_METERED_GOAL_STATUSES.has(status)) {
+    return GOAL_STATUS_AFTER_ACCOUNT_MOVE
+  }
+  // Why dropped rather than forwarded: `thread/goal/set` rejects a status it does
+  // not know, and that rejection would fail the whole transfer — losing the
+  // objective too, over a field the new account can default for itself.
+  return CODEX_GOAL_STATUSES.has(status) ? status : null
+}
+
+function buildGoalInvocation(codexHomePath: string): CodexAppServerInvocation {
+  const command = resolveCodexCommand()
+  const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, ['app-server'])
+  return {
+    command: spawnCmd,
+    args: spawnArgs,
+    cliPath: command,
+    // Why: the daemon environment can carry another account's CODEX_HOME, which
+    // would read or write the wrong account's goals DB.
+    env: { CODEX_HOME: codexHomePath },
+    timeoutMs: GOAL_RPC_TIMEOUT_MS
+  }
+}
+
+/**
+ * Copies one thread's goal from the origin home into the target home.
+ *
+ * Best-effort by construction: the restart it accompanies must proceed whether
+ * or not this succeeds, so every failure resolves to a reason string instead of
+ * throwing. Returns 'transferred' only when the target accepted the goal.
+ */
+export async function transferCodexThreadGoalBetweenHomes(args: {
+  threadId: string
+  originCodexHomePath: string
+  targetCodexHomePath: string
+  nowMs?: number
+}): Promise<'transferred' | 'no-goal' | 'unsupported' | 'skipped' | 'failed'> {
+  if (
+    normalizeRuntimePathForComparison(args.originCodexHomePath) ===
+    normalizeRuntimePathForComparison(args.targetCodexHomePath)
+  ) {
+    return 'skipped'
+  }
+  // Why native only: an account-switch restart is a host-lane action, and the
+  // managed homes it moves between are host homes.
+  const hostKey = getCodexAppServerHostKey({ kind: 'native' })
+  const nowMs = args.nowMs ?? Date.now()
+  if (
+    !goalRpcCapabilityCache.isKnownSupported(hostKey) &&
+    !goalRpcCapabilityCache.shouldTry(hostKey, nowMs)
+  ) {
+    return 'unsupported'
+  }
+  try {
+    return await withTransferDeadline(async () => {
+      const goal = await readCodexThreadGoal(args.threadId, args.originCodexHomePath)
+      goalRpcCapabilityCache.rememberSupported(hostKey)
+      if (!goal) {
+        return 'no-goal' as const
+      }
+      await writeCodexThreadGoal(args.threadId, args.targetCodexHomePath, goal)
+      return 'transferred' as const
+    })
+  } catch (error) {
+    if (isCodexAppServerUnsupportedError(error)) {
+      goalRpcCapabilityCache.rememberUnsupported(hostKey, nowMs)
+      return 'unsupported'
+    }
+    console.warn('[codex-thread-goal] Failed to carry the goal across the account switch:', error)
+    return 'failed'
+  }
+}
+
+/**
+ * Bounds the whole transfer, not each RPC.
+ *
+ * Why a race rather than a shorter per-session timeout alone: the transfer runs
+ * two app-server sessions back to back, so per-session bounds still add up. The
+ * abandoned work is safe to leave running — each session SIGKILLs its own child
+ * when its deadline lapses.
+ */
+async function withTransferDeadline<T extends string>(
+  run: () => Promise<T>
+): Promise<T | 'failed'> {
+  let timer: NodeJS.Timeout | undefined
+  const deadline = new Promise<'failed'>((resolve) => {
+    timer = setTimeout(() => resolve('failed'), GOAL_TRANSFER_DEADLINE_MS)
+  })
+  try {
+    return await Promise.race([run(), deadline])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function readCodexThreadGoal(
+  threadId: string,
+  codexHomePath: string
+): Promise<CodexTransferableThreadGoal | null> {
+  return runCodexAppServerSession(buildGoalInvocation(codexHomePath), async (rpc) =>
+    parseCodexThreadGoal(await rpc.request('thread/goal/get', { threadId }))
+  )
+}
+
+async function writeCodexThreadGoal(
+  threadId: string,
+  codexHomePath: string,
+  goal: CodexTransferableThreadGoal
+): Promise<void> {
+  await runCodexAppServerSession(buildGoalInvocation(codexHomePath), async (rpc) => {
+    // Why thread/read first: the rollout was hardlinked into this home moments
+    // ago, so its thread row may not exist yet. thread/read is Codex's own lazy
+    // indexing path and is what makes the thread addressable for the set below.
+    await rpc.request('thread/read', { threadId })
+    await rpc.request('thread/goal/set', {
+      threadId,
+      objective: goal.objective,
+      ...(goal.status ? { status: goal.status } : {}),
+      ...(goal.tokenBudget !== undefined ? { tokenBudget: goal.tokenBudget } : {})
+    })
+  })
+}
+
+export const _internals = {
+  resetGoalRpcCapability: (): void => {
+    goalRpcCapabilityCache.clear()
+  }
+}

--- a/src/main/codex/codex-thread-goal-transfer.ts
+++ b/src/main/codex/codex-thread-goal-transfer.ts
@@ -11,44 +11,11 @@ import {
   type CodexAppServerInvocation
 } from './codex-app-server-session'
 
-/**
- * Carries a thread's `/goal` across an account-switch restart.
- *
- * Why only part of it: Codex stores goals in a per-home sqlite DB, so a thread
- * resumed under another account starts with no goal at all. The objective, the
- * budget and the user's own pause/block/complete state are what the user loses
- * and what Codex's own RPCs can restore. Everything the previous account
- * metered stays behind: the usage counters, and the limit statuses derived from
- * them. Hitting a limit is a fact about the account being left, and the account
- * being moved to has its own headroom — which is usually the whole reason for
- * the switch.
- *
- * Orca never touches Codex's sqlite directly; `thread/goal/get` and
- * `thread/goal/set` are the app-server's own surface for this.
- */
+/** Transfers goals through Codex RPC, preserving the remaining user budget. */
 
-// Why so short: the restart awaits this before the PTY exists, so every second
-// here is a second the user stares at an empty pane. A goal that does not
-// arrive in time is a smaller loss than a terminal that feels hung.
+// Bound each app-server session without leaving an abandoned write running.
 const GOAL_RPC_TIMEOUT_MS = 4_000
-const GOAL_TRANSFER_DEADLINE_MS = 6_000
 
-// Why remapped rather than dropped: leaving the status unset would let the new
-// account inherit whatever default Codex applies, and an active goal must stay
-// active across the move. See #12098 — the limit is what triggered the switch.
-//
-// Why these exact spellings: the app-server's own enum, not the sqlite column's.
-// `thread/goal/set` answers a snake_case status with "unknown variant
-// `usage_limited`, expected one of `active`, `paused`, `blocked`, `usageLimited`,
-// `budgetLimited`, `complete`" — so the wire names are camelCase even though the
-// goals DB stores them with underscores. Both are accepted on the way in, since
-// a read that ever returns the DB spelling must still be recognised as a limit.
-const ACCOUNT_METERED_GOAL_STATUSES = new Set([
-  'usageLimited',
-  'budgetLimited',
-  'usage_limited',
-  'budget_limited'
-])
 const CODEX_GOAL_STATUSES = new Set([
   'active',
   'paused',
@@ -57,7 +24,6 @@ const CODEX_GOAL_STATUSES = new Set([
   'budgetLimited',
   'complete'
 ])
-const GOAL_STATUS_AFTER_ACCOUNT_MOVE = 'active'
 
 // Why dedicated: the shared cache answers for a different method surface, and
 // one CLI can expose that one while lacking the goal RPCs.
@@ -82,12 +48,28 @@ export function parseCodexThreadGoal(value: unknown): CodexTransferableThreadGoa
   if (typeof objective !== 'string' || objective.trim().length === 0) {
     return null
   }
-  const status = resolveGoalStatusAfterAccountMove(record.status)
+  let status = resolveGoalStatusAfterAccountMove(record.status)
   const tokenBudget = record.tokenBudget ?? record.token_budget
+  const tokensUsed = record.tokensUsed ?? record.tokens_used
+  let remainingBudget: number | undefined
+  if (typeof tokenBudget === 'number' && Number.isFinite(tokenBudget) && tokenBudget > 0) {
+    if (typeof tokensUsed === 'number' && Number.isFinite(tokensUsed) && tokensUsed >= 0) {
+      remainingBudget = Math.max(1, tokenBudget - tokensUsed)
+      if (tokensUsed >= tokenBudget && status !== 'complete') {
+        status = 'budgetLimited'
+      }
+    } else {
+      // An unknown consumed budget must not silently become a fresh spending allowance.
+      remainingBudget = tokenBudget
+      if (status !== 'complete' && status !== 'budgetLimited') {
+        status = 'paused'
+      }
+    }
+  }
   return {
     objective,
     ...(status ? { status } : {}),
-    ...(typeof tokenBudget === 'number' && Number.isFinite(tokenBudget) ? { tokenBudget } : {})
+    ...(remainingBudget !== undefined ? { tokenBudget: remainingBudget } : {})
   }
 }
 
@@ -95,8 +77,11 @@ function resolveGoalStatusAfterAccountMove(status: unknown): string | null {
   if (typeof status !== 'string' || status.length === 0) {
     return null
   }
-  if (ACCOUNT_METERED_GOAL_STATUSES.has(status)) {
-    return GOAL_STATUS_AFTER_ACCOUNT_MOVE
+  if (status === 'usageLimited' || status === 'usage_limited') {
+    return 'active'
+  }
+  if (status === 'budget_limited') {
+    return 'budgetLimited'
   }
   // Why dropped rather than forwarded: `thread/goal/set` rejects a status it does
   // not know, and that rejection would fail the whole transfer — losing the
@@ -118,13 +103,7 @@ function buildGoalInvocation(codexHomePath: string): CodexAppServerInvocation {
   }
 }
 
-/**
- * Copies one thread's goal from the origin home into the target home.
- *
- * Best-effort by construction: the restart it accompanies must proceed whether
- * or not this succeeds, so every failure resolves to a reason string instead of
- * throwing. Returns 'transferred' only when the target accepted the goal.
- */
+/** Reports transfer failures so the restart can refuse to lose a known goal. */
 export async function transferCodexThreadGoalBetweenHomes(args: {
   threadId: string
   originCodexHomePath: string
@@ -148,7 +127,7 @@ export async function transferCodexThreadGoalBetweenHomes(args: {
     return 'unsupported'
   }
   try {
-    return await withTransferDeadline(async () => {
+    return await (async () => {
       const goal = await readCodexThreadGoal(args.threadId, args.originCodexHomePath)
       goalRpcCapabilityCache.rememberSupported(hostKey)
       if (!goal) {
@@ -156,7 +135,7 @@ export async function transferCodexThreadGoalBetweenHomes(args: {
       }
       await writeCodexThreadGoal(args.threadId, args.targetCodexHomePath, goal)
       return 'transferred' as const
-    })
+    })()
   } catch (error) {
     if (isCodexAppServerUnsupportedError(error)) {
       goalRpcCapabilityCache.rememberUnsupported(hostKey, nowMs)
@@ -164,28 +143,6 @@ export async function transferCodexThreadGoalBetweenHomes(args: {
     }
     console.warn('[codex-thread-goal] Failed to carry the goal across the account switch:', error)
     return 'failed'
-  }
-}
-
-/**
- * Bounds the whole transfer, not each RPC.
- *
- * Why a race rather than a shorter per-session timeout alone: the transfer runs
- * two app-server sessions back to back, so per-session bounds still add up. The
- * abandoned work is safe to leave running — each session SIGKILLs its own child
- * when its deadline lapses.
- */
-async function withTransferDeadline<T extends string>(
-  run: () => Promise<T>
-): Promise<T | 'failed'> {
-  let timer: NodeJS.Timeout | undefined
-  const deadline = new Promise<'failed'>((resolve) => {
-    timer = setTimeout(() => resolve('failed'), GOAL_TRANSFER_DEADLINE_MS)
-  })
-  try {
-    return await Promise.race([run(), deadline])
-  } finally {
-    clearTimeout(timer)
   }
 }
 

--- a/src/main/ipc/pty/host-env/codex-resume.ts
+++ b/src/main/ipc/pty/host-env/codex-resume.ts
@@ -31,6 +31,7 @@ export type PrepareCodexResumeHomeArgs = {
   target: CodexAccountSelectionTarget
   launchEnv?: NodeJS.ProcessEnv
   workspacePath?: string
+  accountSwitchRestart?: boolean
 }
 
 export function prepareCodexResumeHome(
@@ -50,7 +51,8 @@ export function prepareCodexResumeHome(
       providerSession,
       target: args.target,
       launchEnv: args.launchEnv,
-      workspacePath: args.workspacePath
+      workspacePath: args.workspacePath,
+      accountSwitchRestart: args.accountSwitchRestart === true
     })
   }
 }

--- a/src/main/ipc/pty/host-env/types.ts
+++ b/src/main/ipc/pty/host-env/types.ts
@@ -55,6 +55,7 @@ export type PrepareCodexSessionResume = (args: {
   target: CodexAccountSelectionTarget
   launchEnv?: NodeJS.ProcessEnv
   workspacePath?: string
+  accountSwitchRestart?: boolean
 }) => Promise<CodexSessionResumePreparation | null>
 
 export type CodexHomePtySpawnedLifecycleArgs = {

--- a/src/main/ipc/pty/ipc/spawn-env-codex.ts
+++ b/src/main/ipc/pty/ipc/spawn-env-codex.ts
@@ -40,7 +40,8 @@ export async function assemblePtyIpcSpawnCodexEnv(ctx: PtyIpcSpawnState): Promis
         providerSession: args.resumeProviderSession,
         target: ctx.codexSelectionTarget,
         launchEnv: ctx.baseEnv,
-        workspacePath: ctx.cwd
+        workspacePath: ctx.cwd,
+        accountSwitchRestart: args.codexAccountSwitchRestart === true
       })
   ctx.codexResumeLaunch = codexResumePreparation
     ? await ctx.deps.resolveCodexResumeLaunch(args.command, codexResumePreparation)

--- a/src/main/ipc/pty/ipc/spawn-types.ts
+++ b/src/main/ipc/pty/ipc/spawn-types.ts
@@ -33,6 +33,7 @@ export type PtySpawnIpcArgs = {
   commandDelivery?: 'renderer' | 'provider'
   launchConfig?: SleepingAgentLaunchConfig
   resumeProviderSession?: AgentProviderSessionMetadata
+  codexAccountSwitchRestart?: boolean
   launchToken?: unknown
   launchAgent?: TuiAgent
   startupCommandDelivery?: StartupCommandDelivery
@@ -102,6 +103,7 @@ export type PtySpawnIpcDeps = {
     target: CodexAccountSelectionTarget
     launchEnv?: NodeJS.ProcessEnv
     workspacePath?: string
+    accountSwitchRestart?: boolean
   }) => PreparedCodexResumeHome | null
   noCodexResumeLaunch: (command: string | undefined) => CodexResumeLaunch
   resolveCodexResumeLaunch: (

--- a/src/main/ipc/pty/runtime/controller-deps.ts
+++ b/src/main/ipc/pty/runtime/controller-deps.ts
@@ -32,6 +32,7 @@ export type PtyRuntimeControllerDeps = {
     target: CodexAccountSelectionTarget
     launchEnv?: NodeJS.ProcessEnv
     workspacePath?: string
+    accountSwitchRestart?: boolean
   }) => PreparedCodexResumeHome | null
   resolveCodexResumeLaunch: (
     command: string | undefined,

--- a/src/main/ipc/pty/runtime/spawn-preflight.ts
+++ b/src/main/ipc/pty/runtime/spawn-preflight.ts
@@ -124,7 +124,8 @@ export async function prepareRuntimePtySpawn(
         providerSession: args.resumeProviderSession,
         target: ctx.codexSelectionTarget,
         launchEnv: args.env,
-        workspacePath: ctx.cwd
+        workspacePath: ctx.cwd,
+        accountSwitchRestart: args.codexAccountSwitchRestart === true
       })
   const codexResumeLaunch = codexResumePreparation
     ? await ctx.deps.resolveCodexResumeLaunch(args.command, codexResumePreparation)

--- a/src/main/ipc/pty/runtime/spawn-state.ts
+++ b/src/main/ipc/pty/runtime/spawn-state.ts
@@ -96,6 +96,7 @@ export type RuntimePtySpawnArgs = {
   env?: Record<string, string>
   envToDelete?: string[]
   resumeProviderSession?: AgentProviderSessionMetadata
+  codexAccountSwitchRestart?: boolean
   connectionId?: string | null
   worktreeId?: string
   preAllocatedHandle?: string

--- a/src/main/startup/codex-session-resume-launch.test.ts
+++ b/src/main/startup/codex-session-resume-launch.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  selected: vi.fn(),
+  system: vi.fn(),
+  link: vi.fn(),
+  transfer: vi.fn()
+}))
+vi.mock('electron', () => ({ app: { getPath: () => '/orca' } }))
+vi.mock('./main-process-state', () => ({
+  mainProcessState: {
+    store: { getSettings: () => ({}) },
+    codexRuntimeHome: {
+      resolveSelectedHostAccountCodexHomePathForResume: mocks.selected,
+      isHostSystemDefaultRealHome: mocks.system,
+      getHostCodexHomePathsForSessionDiscovery: () => ['/origin']
+    }
+  }
+}))
+vi.mock('../codex/codex-session-resume-preparation', () => ({
+  prepareCodexSessionResume: async (args: {
+    resolveVerifiedResumeHome: (source: unknown) => Promise<string>
+  }) => ({
+    outcome: 'resume',
+    codexHomePath: await args.resolveVerifiedResumeHome({
+      homePath: '/origin',
+      transcriptPath: '/origin/sessions/thread.jsonl'
+    })
+  })
+}))
+vi.mock('../codex/codex-legacy-session-resume', () => ({
+  prepareLegacySharedCodexSessionResume: async () => ({ useRealCodexHome: false })
+}))
+vi.mock('../codex/codex-account-session-bridge', () => ({
+  linkCodexRolloutIntoAccountHome: mocks.link
+}))
+vi.mock('../codex/codex-thread-goal-transfer', () => ({
+  transferCodexThreadGoalBetweenHomes: mocks.transfer
+}))
+vi.mock('../codex/codex-home-paths', () => ({
+  getSystemCodexHomePath: () => '/system',
+  getOrcaManagedCodexHomePath: () => '/shared'
+}))
+vi.mock('../codex/hook-service', () => ({
+  codexHookService: { refreshRuntimeUserHooksForLaunchPrep: vi.fn() }
+}))
+vi.mock('../codex/codex-real-home-hook-install', () => ({ ensureRealHomeCodexHookState: vi.fn() }))
+vi.mock('../agent-hooks/managed-agent-hook-controls', () => ({
+  isAgentStatusHooksEnabled: () => false
+}))
+vi.mock('../agent-trust-presets', () => ({ markCodexProjectTrusted: vi.fn() }))
+
+const { prepareCodexSessionResumeForLaunch } = await import('./codex-session-resume-launch')
+const launch = () =>
+  prepareCodexSessionResumeForLaunch({
+    providerSession: {
+      key: 'session_id',
+      id: 'thread',
+      transcriptPath: '/origin/sessions/thread.jsonl'
+    },
+    target: { runtime: 'host' },
+    accountSwitchRestart: true
+  })
+
+beforeEach(() => {
+  mocks.selected.mockReturnValue(null)
+  mocks.system.mockReturnValue(true)
+  mocks.link.mockReturnValue('/system/sessions/thread.jsonl')
+  mocks.transfer.mockResolvedValue('no-goal')
+})
+
+describe('account-switch launch preparation', () => {
+  it('resumes in the real home when system default is selected', async () => {
+    await expect(launch()).resolves.toMatchObject({ outcome: 'resume', codexHomePath: '/system' })
+    expect(mocks.link).toHaveBeenCalledWith(
+      expect.objectContaining({ targetCodexHomePath: '/system' })
+    )
+  })
+  it('refuses an unsafe bridge instead of silently creating a fresh conversation', async () => {
+    mocks.link.mockReturnValue(null)
+    await expect(launch()).rejects.toThrow('Cannot safely resume')
+  })
+  it('surfaces failed goal transfer', async () => {
+    mocks.transfer.mockResolvedValue('failed')
+    await expect(launch()).rejects.toThrow('Could not transfer')
+  })
+})

--- a/src/main/startup/codex-session-resume-launch.ts
+++ b/src/main/startup/codex-session-resume-launch.ts
@@ -15,21 +15,15 @@ import { resolveCodexAccountSwitchResumeHome } from '../codex/codex-account-swit
 import { transferCodexThreadGoalBetweenHomes } from '../codex/codex-thread-goal-transfer'
 import { mainProcessState as state } from './main-process-state'
 
-/**
- * Repins an account-switch restart onto the selected account, carrying the goal.
- *
- * Returns null when the switch has to give the conversation up: the user asked
- * for an account, and honouring that beats keeping them on the one they left.
- * The caller turns that into a `fresh` outcome, which drops the resume argv and
- * tells the pane its conversation did not come along.
- */
+/** Repins explicit account switches; unsafe moves fail without starting a fresh thread. */
 async function moveCodexResumeToSelectedAccount(args: {
   originHome: string
   transcriptPath: string
   threadId: string
-}): Promise<string | null> {
+}): Promise<string> {
   const selectedHome =
-    state.codexRuntimeHome?.resolveSelectedHostAccountCodexHomePathForResume() ?? null
+    state.codexRuntimeHome?.resolveSelectedHostAccountCodexHomePathForResume() ??
+    (state.codexRuntimeHome?.isHostSystemDefaultRealHome() ? getSystemCodexHomePath() : null)
   const move = resolveCodexAccountSwitchResumeHome({
     originCodexHomePath: args.originHome,
     selectedCodexHomePath: selectedHome,
@@ -39,13 +33,23 @@ async function moveCodexResumeToSelectedAccount(args: {
     return args.originHome
   }
   if (move.outcome === 'unmovable') {
-    return null
+    throw new Error(
+      'Cannot safely resume this conversation in the selected Codex account. The original transcript has been preserved.'
+    )
   }
-  await transferCodexThreadGoalBetweenHomes({
+  const goalTransfer = await transferCodexThreadGoalBetweenHomes({
     threadId: args.threadId,
     originCodexHomePath: args.originHome,
     targetCodexHomePath: move.codexHomePath
   })
+  if (goalTransfer === 'failed') {
+    throw new Error(
+      'Could not transfer the Codex goal. Retry the account switch before continuing this conversation.'
+    )
+  }
+  if (goalTransfer === 'unsupported') {
+    console.warn('[codex-account-switch] This Codex CLI does not support goal transfer.')
+  }
   return move.codexHomePath
 }
 
@@ -72,7 +76,6 @@ export async function prepareCodexSessionResumeForLaunch(args: {
   // readable alias wins. A throw here refuses the whole resume instead
   // (#STA-4422).
   const selectedAccountCodexHome = runtimeHome.resolveSelectedHostAccountCodexHomePathForResume()
-  let accountSwitchGaveUpResume = false
   // Why: a `fresh` outcome must skip migration, trust and hook repair entirely — there is
   // no verified origin home to prepare, so the PTY layer drops the resume argv (#10793).
   const preparation = await prepareCodexSessionResume({
@@ -125,10 +128,6 @@ export async function prepareCodexSessionResumeForLaunch(args: {
             threadId: args.providerSession.id
           })
         : originHome
-      if (movedHome === null) {
-        accountSwitchGaveUpResume = true
-        return originHome
-      }
       const resumeHome = movedHome
       if (args.workspacePath) {
         try {
@@ -159,12 +158,6 @@ export async function prepareCodexSessionResumeForLaunch(args: {
       return resumeHome
     }
   })
-  if (accountSwitchGaveUpResume) {
-    // Why claimedCodexProvenance: the rollout is real and was verified — the
-    // account move is what it could not survive — so the pane owes the user the
-    // "your conversation did not come along" notice rather than silence.
-    return { outcome: 'fresh', claimedCodexProvenance: true }
-  }
   return preparation.outcome === 'resume'
     ? {
         ...preparation,

--- a/src/main/startup/codex-session-resume-launch.ts
+++ b/src/main/startup/codex-session-resume-launch.ts
@@ -11,13 +11,50 @@ import { isAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-con
 import { markCodexProjectTrusted } from '../agent-trust-presets'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { resolveCodexAccountSwitchResumeHome } from '../codex/codex-account-switch-resume-repin'
+import { transferCodexThreadGoalBetweenHomes } from '../codex/codex-thread-goal-transfer'
 import { mainProcessState as state } from './main-process-state'
+
+/**
+ * Repins an account-switch restart onto the selected account, carrying the goal.
+ *
+ * Returns null when the switch has to give the conversation up: the user asked
+ * for an account, and honouring that beats keeping them on the one they left.
+ * The caller turns that into a `fresh` outcome, which drops the resume argv and
+ * tells the pane its conversation did not come along.
+ */
+async function moveCodexResumeToSelectedAccount(args: {
+  originHome: string
+  transcriptPath: string
+  threadId: string
+}): Promise<string | null> {
+  const selectedHome =
+    state.codexRuntimeHome?.resolveSelectedHostAccountCodexHomePathForResume() ?? null
+  const move = resolveCodexAccountSwitchResumeHome({
+    originCodexHomePath: args.originHome,
+    selectedCodexHomePath: selectedHome,
+    transcriptPath: args.transcriptPath
+  })
+  if (move.outcome === 'already-there') {
+    return args.originHome
+  }
+  if (move.outcome === 'unmovable') {
+    return null
+  }
+  await transferCodexThreadGoalBetweenHomes({
+    threadId: args.threadId,
+    originCodexHomePath: args.originHome,
+    targetCodexHomePath: move.codexHomePath
+  })
+  return move.codexHomePath
+}
 
 export async function prepareCodexSessionResumeForLaunch(args: {
   providerSession: AgentProviderSessionMetadata
   target: CodexAccountSelectionTarget
   launchEnv?: NodeJS.ProcessEnv
   workspacePath?: string
+  accountSwitchRestart?: boolean
 }): Promise<CodexSessionResumePreparation | null> {
   const runtimeHome = state.codexRuntimeHome
   const store = state.store
@@ -35,6 +72,7 @@ export async function prepareCodexSessionResumeForLaunch(args: {
   // readable alias wins. A throw here refuses the whole resume instead
   // (#STA-4422).
   const selectedAccountCodexHome = runtimeHome.resolveSelectedHostAccountCodexHomePathForResume()
+  let accountSwitchGaveUpResume = false
   // Why: a `fresh` outcome must skip migration, trust and hook repair entirely — there is
   // no verified origin home to prepare, so the PTY layer drops the resume argv (#10793).
   const preparation = await prepareCodexSessionResume({
@@ -79,7 +117,19 @@ export async function prepareCodexSessionResumeForLaunch(args: {
           error
         )
       }
-      const resumeHome = migrated.useRealCodexHome ? systemHomePath : sessionSource.homePath
+      const originHome = migrated.useRealCodexHome ? systemHomePath : sessionSource.homePath
+      const movedHome = args.accountSwitchRestart
+        ? await moveCodexResumeToSelectedAccount({
+            originHome,
+            transcriptPath: sessionSource.transcriptPath,
+            threadId: args.providerSession.id
+          })
+        : originHome
+      if (movedHome === null) {
+        accountSwitchGaveUpResume = true
+        return originHome
+      }
+      const resumeHome = movedHome
       if (args.workspacePath) {
         try {
           await markCodexProjectTrusted(args.workspacePath)
@@ -109,6 +159,12 @@ export async function prepareCodexSessionResumeForLaunch(args: {
       return resumeHome
     }
   })
+  if (accountSwitchGaveUpResume) {
+    // Why claimedCodexProvenance: the rollout is real and was verified — the
+    // account move is what it could not survive — so the pane owes the user the
+    // "your conversation did not come along" notice rather than silence.
+    return { outcome: 'fresh', claimedCodexProvenance: true }
+  }
   return preparation.outcome === 'resume'
     ? {
         ...preparation,

--- a/src/preload/api/pty-api.ts
+++ b/src/preload/api/pty-api.ts
@@ -30,6 +30,7 @@ export type PtyApi = {
     commandDelivery?: 'renderer' | 'provider'
     launchConfig?: SleepingAgentLaunchConfig
     resumeProviderSession?: AgentProviderSessionMetadata
+    codexAccountSwitchRestart?: boolean
     launchToken?: string
     launchAgent?: TuiAgent
     startupCommandDelivery?: StartupCommandDelivery

--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -14,7 +14,22 @@ function isInsideHiddenTree(element: HTMLElement): boolean {
 type RestartNotice = {
   previousAccountLabel: string
   nextAccountLabel: string
+  /** null is the system default. undefined means the notice did not name one. */
+  nextAccountId?: string | null
   homeRouteChanged?: true
+}
+
+/**
+ * True when restarting will start a new conversation instead of continuing this one.
+ *
+ * Why only the system default: a managed account gets the rollout listed under
+ * its own home, so the conversation follows the switch. The system default runs
+ * Codex against the user's own ~/.codex, which Orca never writes into, so there
+ * is nowhere to list it — and the user deserves to know that before pressing
+ * Restart, not after the pane comes back empty.
+ */
+function startsFreshConversation(notice: RestartNotice): boolean {
+  return notice.homeRouteChanged !== true && notice.nextAccountId === null
 }
 
 export default function CodexRestartChip({
@@ -139,11 +154,17 @@ function LoudRestartOverlay({
                 'auto.components.CodexRestartChip.e6b7139d2a',
                 'Restart this session to load your current Codex configuration.'
               )
-            : translate(
-                'auto.components.CodexRestartChip.9375620cc3',
-                'Restart this session to use {{value0}}. It stays on the previous account until you do.',
-                { value0: restartNotice.nextAccountLabel }
-              )}
+            : startsFreshConversation(restartNotice)
+              ? translate(
+                  'auto.components.CodexRestartChip.b7d31e05a9',
+                  'Restarting this terminal switches it to {{value0}}, and this conversation will not come along: the terminal starts a new one. To carry a conversation across a switch, add a separate Codex account and switch to that instead.',
+                  { value0: restartNotice.nextAccountLabel }
+                )
+              : translate(
+                  'auto.components.CodexRestartChip.5c1f8ab470',
+                  'Restarting this terminal switches it to {{value0}}. Your work carries over, and new usage is counted against the account you switch to.',
+                  { value0: restartNotice.nextAccountLabel }
+                )}
         </div>
         <div className="mt-1 flex flex-wrap justify-end gap-2">
           <Button type="button" variant="outline" size="sm" onClick={onDismiss}>

--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -19,19 +19,6 @@ type RestartNotice = {
   homeRouteChanged?: true
 }
 
-/**
- * True when restarting will start a new conversation instead of continuing this one.
- *
- * Why only the system default: a managed account gets the rollout listed under
- * its own home, so the conversation follows the switch. The system default runs
- * Codex against the user's own ~/.codex, which Orca never writes into, so there
- * is nowhere to list it — and the user deserves to know that before pressing
- * Restart, not after the pane comes back empty.
- */
-function startsFreshConversation(notice: RestartNotice): boolean {
-  return notice.homeRouteChanged !== true && notice.nextAccountId === null
-}
-
 export default function CodexRestartChip({
   isVisible = true,
   ptyId,
@@ -154,17 +141,11 @@ function LoudRestartOverlay({
                 'auto.components.CodexRestartChip.e6b7139d2a',
                 'Restart this session to load your current Codex configuration.'
               )
-            : startsFreshConversation(restartNotice)
-              ? translate(
-                  'auto.components.CodexRestartChip.b7d31e05a9',
-                  'Restarting this terminal switches it to {{value0}}, and this conversation will not come along: the terminal starts a new one. To carry a conversation across a switch, add a separate Codex account and switch to that instead.',
-                  { value0: restartNotice.nextAccountLabel }
-                )
-              : translate(
-                  'auto.components.CodexRestartChip.5c1f8ab470',
-                  'Restarting this terminal switches it to {{value0}}. Your work carries over, and new usage is counted against the account you switch to.',
-                  { value0: restartNotice.nextAccountLabel }
-                )}
+            : translate(
+                'auto.components.CodexRestartChip.accountResume',
+                'Restarting this terminal switches it to {{value0}} and resumes this conversation when supported. Check /goal after switching; unavailable goal transfer may require restoring it manually.',
+                { value0: restartNotice.nextAccountLabel }
+              )}
         </div>
         <div className="mt-1 flex flex-wrap justify-end gap-2">
           <Button type="button" variant="outline" size="sm" onClick={onDismiss}>

--- a/src/renderer/src/components/codex-restart-chip.test.tsx
+++ b/src/renderer/src/components/codex-restart-chip.test.tsx
@@ -16,7 +16,7 @@ let forgetStalePanes: ReturnType<typeof vi.fn>
 let root: Root
 
 function notice(previousAccountLabel: string, nextAccountLabel: string) {
-  return { previousAccountLabel, nextAccountLabel }
+  return { previousAccountLabel, nextAccountLabel, nextAccountId: 'account-next' }
 }
 
 function button(scope: ParentNode, label: string): HTMLButtonElement {
@@ -63,8 +63,29 @@ describe('CodexRestartChip pane ownership', () => {
     })
 
     expect(container.textContent).toContain('Codex is still signed in as old-two@example.com')
-    expect(container.textContent).toContain('Restart this session to use new-two@example.com')
+    expect(container.textContent).toContain(
+      'Restarting this terminal switches it to new-two@example.com'
+    )
     expect(container.textContent).not.toContain('old-one@example.com')
+  })
+
+  it('warns before the press when switching to the system default loses the conversation', async () => {
+    useAppStore.setState({
+      codexRestartNoticeByPtyId: {
+        [PTY_ONE]: {
+          previousAccountLabel: 'old-one@example.com',
+          nextAccountLabel: 'System default',
+          nextAccountId: null
+        }
+      }
+    })
+
+    await act(async () => {
+      root.render(<CodexRestartChip ptyId={PTY_ONE} />)
+    })
+
+    expect(container.textContent).toContain('this conversation will not come along')
+    expect(container.textContent).toContain('add a separate Codex account')
   })
 
   it('uses configuration wording for a home-route restart', async () => {

--- a/src/renderer/src/components/codex-restart-chip.test.tsx
+++ b/src/renderer/src/components/codex-restart-chip.test.tsx
@@ -69,7 +69,7 @@ describe('CodexRestartChip pane ownership', () => {
     expect(container.textContent).not.toContain('old-one@example.com')
   })
 
-  it('warns before the press when switching to the system default loses the conversation', async () => {
+  it('describes supported resume and goal verification for system-default switches', async () => {
     useAppStore.setState({
       codexRestartNoticeByPtyId: {
         [PTY_ONE]: {
@@ -84,8 +84,8 @@ describe('CodexRestartChip pane ownership', () => {
       root.render(<CodexRestartChip ptyId={PTY_ONE} />)
     })
 
-    expect(container.textContent).toContain('this conversation will not come along')
-    expect(container.textContent).toContain('add a separate Codex account')
+    expect(container.textContent).toContain('resumes this conversation when supported')
+    expect(container.textContent).toContain('Check /goal after switching')
   })
 
   it('uses configuration wording for a home-route restart', async () => {

--- a/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.ts
+++ b/src/renderer/src/components/terminal-pane/codex-detached-pane-restart.ts
@@ -16,7 +16,7 @@ import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { singlePaneLayoutSnapshot } from '@/store/slices/terminal-helpers'
 import { hasRegisteredRuntimeTerminalTab } from '@/runtime/sync-runtime-graph'
-import { CODEX_ACCOUNT_RESTART_STARTUP } from '@/lib/codex-session-restart'
+import { buildCodexAccountRestartStartup } from '@/lib/codex-account-restart-startup'
 import { isForeignMachineCodexPtyId } from '@/lib/codex-pane-selection-lane'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import {
@@ -175,9 +175,13 @@ async function executeDetachedCodexPaneRestart(
     }
     const store = useAppStore.getState()
     store.suppressPtyExit(ptyId)
-    store.clearTabPtyId(located.tab.id, ptyId)
-    store.consumeSuppressedPtyExit(ptyId)
-    store.queueTabStartupCommand(located.tab.id, { ...CODEX_ACCOUNT_RESTART_STARTUP })
+    const restartStartup = buildCodexAccountRestartStartup({
+      tabId: located.tab.id,
+      leafId: located.leafId,
+      worktreeId: located.worktreeId,
+      shellOverride: located.tab.shellOverride
+    })
+    store.queueTabStartupCommand(located.tab.id, { ...restartStartup })
     store.clearCodexRestartNotice(ptyId)
     killReplacedCodexPanePty(ptyId)
     return
@@ -206,6 +210,13 @@ async function executeDetachedCodexPaneRestart(
     return
   }
 
+  const restartStartup = buildCodexAccountRestartStartup({
+    tabId: tab.id,
+    leafId,
+    worktreeId,
+    shellOverride: tab.shellOverride
+  })
+
   // Hidden replacements converge on mount; provider sizing must not delay ownership transfer.
   const spawned = await window.api.pty.spawn({
     cols: 80,
@@ -213,9 +224,15 @@ async function executeDetachedCodexPaneRestart(
     ...(cwd ? { cwd } : {}),
     cwdFallback: 'worktree',
     env: buildPaneIdentityEnv(state, worktreeId, tab.id, leafId),
-    command: CODEX_ACCOUNT_RESTART_STARTUP.command,
-    startupCommandDelivery: CODEX_ACCOUNT_RESTART_STARTUP.startupCommandDelivery,
-    launchAgent: CODEX_ACCOUNT_RESTART_STARTUP.launchAgent,
+    command: restartStartup.command,
+    startupCommandDelivery: restartStartup.startupCommandDelivery,
+    launchAgent: restartStartup.launchAgent,
+    codexAccountSwitchRestart: restartStartup.codexAccountSwitchRestart,
+    ...(restartStartup.env ? { env: restartStartup.env } : {}),
+    ...(restartStartup.launchConfig ? { launchConfig: restartStartup.launchConfig } : {}),
+    ...(restartStartup.resumeProviderSession
+      ? { resumeProviderSession: restartStartup.resumeProviderSession }
+      : {}),
     worktreeId,
     tabId: tab.id,
     leafId,

--- a/src/renderer/src/components/terminal-pane/ipc-pty-spawn-request.ts
+++ b/src/renderer/src/components/terminal-pane/ipc-pty-spawn-request.ts
@@ -24,6 +24,7 @@ export async function spawnIpcPty(
     commandDelivery,
     launchConfig,
     resumeProviderSession,
+    codexAccountSwitchRestart,
     launchToken,
     launchAgent,
     startupCommandDelivery,
@@ -56,6 +57,9 @@ export async function spawnIpcPty(
       : {}),
     ...((connectOptions.resumeProviderSession ?? resumeProviderSession)
       ? { resumeProviderSession: connectOptions.resumeProviderSession ?? resumeProviderSession }
+      : {}),
+    ...((connectOptions.codexAccountSwitchRestart ?? codexAccountSwitchRestart)
+      ? { codexAccountSwitchRestart: true }
       : {}),
     ...((connectOptions.launchToken ?? launchToken)
       ? { launchToken: connectOptions.launchToken ?? launchToken }

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -28,6 +28,7 @@ export type PtyPaneStartup = {
   envToDelete?: string[]
   launchConfig?: SleepingAgentLaunchConfig
   resumeProviderSession?: AgentProviderSessionMetadata
+  codexAccountSwitchRestart?: boolean
   launchToken?: string
   launchAgent?: TuiAgent
   /** Explicit CLI override for host-owned agent launches; omission uses host settings. */

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-input-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-input-recovery.ts
@@ -85,6 +85,9 @@ export function installPtyInputRecovery(session: ConnectPanePtySession): void {
     ...(session.paneStartup?.resumeProviderSession
       ? { resumeProviderSession: session.paneStartup.resumeProviderSession }
       : {}),
+    ...(session.paneStartup?.codexAccountSwitchRestart
+      ? { codexAccountSwitchRestart: session.paneStartup.codexAccountSwitchRestart }
+      : {}),
     ...((session.paneStartup?.initialAgentStatus?.prompt ?? session.paneStartup?.draftPrompt)
       ? {
           agentPrompt:

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -161,6 +161,7 @@ export type PtyTransport = {
     envToDelete?: string[]
     launchConfig?: SleepingAgentLaunchConfig
     resumeProviderSession?: AgentProviderSessionMetadata
+    codexAccountSwitchRestart?: boolean
     launchToken?: string
     launchAgent?: TuiAgent
     startupCommandDelivery?: StartupCommandDelivery
@@ -250,6 +251,7 @@ export type IpcPtyTransportOptions = {
   commandDelivery?: 'renderer' | 'provider'
   launchConfig?: SleepingAgentLaunchConfig
   resumeProviderSession?: AgentProviderSessionMetadata
+  codexAccountSwitchRestart?: boolean
   agentPrompt?: string
   agentPromptDelivery?: AgentPromptDelivery
   agentArgsOverride?: string | null

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-process-exit-actions.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-process-exit-actions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect } from 'react'
 import { useAppStore } from '../../store'
 import { CODEX_ACCOUNT_RESTART_STARTUP } from '@/lib/codex-session-restart'
+import { buildCodexAccountRestartStartup } from '@/lib/codex-account-restart-startup'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { connectPanePty } from './pty-connection'
 import { bindPanePtyId } from '@/lib/pane-manager/mobile-fit-overrides'
@@ -237,7 +238,18 @@ export function useTerminalPaneProcessExitActions(controller: TerminalPaneCloseC
         continue
       }
       if (consumePendingCodexPaneRestart(ptyId)) {
-        handleRestartCodexPane(pane.id)
+        const terminalTab = useAppStore
+          .getState()
+          .tabsByWorktree[worktreeId]?.find((tab) => tab.id === tabId)
+        handleRestartCodexPane(
+          pane.id,
+          buildCodexAccountRestartStartup({
+            tabId,
+            leafId: pane.leafId,
+            worktreeId,
+            shellOverride: terminalTab?.shellOverride
+          })
+        )
       }
     }
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- Preserve the pre-split dependency contract.

--- a/src/renderer/src/lib/codex-account-restart-startup.test.ts
+++ b/src/renderer/src/lib/codex-account-restart-startup.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import type { ProjectExecutionRuntimeResolution } from '../../../shared/project-execution-runtime'
+import type * as localPreflightContext from '@/lib/local-preflight-context'
+import { buildCodexAccountRestartStartup } from './codex-account-restart-startup'
+
+let projectRuntimeContext: ProjectExecutionRuntimeResolution | undefined
+
+vi.mock('@/lib/local-preflight-context', async (importOriginal) => ({
+  ...(await importOriginal<typeof localPreflightContext>()),
+  getLocalProjectExecutionRuntimeContext: () => projectRuntimeContext
+}))
+
+const TAB_ID = 'tab-1'
+const LEAF_ID = '0195f2ce-1111-4000-8000-000000000001'
+const WORKTREE_ID = 'wt1'
+const SESSION_ID = '01a006a6-1d07-70a1-bad5-f9110d5845c0'
+
+function seedAgentStatus(entry: Record<string, unknown> | null): void {
+  const paneKey = makePaneKey(TAB_ID, LEAF_ID)
+  useAppStore.setState({
+    agentStatusByPaneKey: entry ? { [paneKey]: { paneKey, tabId: TAB_ID, ...entry } } : {},
+    agentLaunchConfigByPaneKey: {},
+    sleepingAgentSessionsByPaneKey: {}
+  } as never)
+}
+
+const build = (): ReturnType<typeof buildCodexAccountRestartStartup> =>
+  buildCodexAccountRestartStartup({ tabId: TAB_ID, leafId: LEAF_ID, worktreeId: WORKTREE_ID })
+
+describe('buildCodexAccountRestartStartup', () => {
+  beforeEach(() => {
+    seedAgentStatus(null)
+    projectRuntimeContext = undefined
+  })
+
+  it('names the session so the relaunch continues the conversation', () => {
+    // Why this is load-bearing: relaunching a bare `codex` starts a brand new
+    // conversation, so moving the pane's account without this loses the very
+    // work the restart card promises to carry over.
+    seedAgentStatus({
+      agentType: 'codex',
+      state: 'idle',
+      providerSession: { key: 'session_id', id: SESSION_ID }
+    })
+
+    const startup = build()
+
+    expect(startup.command).toContain('resume')
+    expect(startup.command).toContain(SESSION_ID)
+    expect(startup.resumeProviderSession?.id).toBe(SESSION_ID)
+  })
+
+  it('keeps the account-switch marks that make main repin the launch home', () => {
+    seedAgentStatus({
+      agentType: 'codex',
+      state: 'idle',
+      providerSession: { key: 'session_id', id: SESSION_ID }
+    })
+
+    const startup = build()
+
+    expect(startup.codexAccountSwitchRestart).toBe(true)
+    expect(startup.launchAgent).toBe('codex')
+    expect(startup.startupCommandDelivery).toBe('shell-ready')
+  })
+
+  it('falls back to a bare relaunch when the pane has no Codex session to name', () => {
+    // Why not a resume argv anyway: naming a session that does not exist fails
+    // the launch outright, which is worse than a fresh conversation.
+    const startup = build()
+
+    expect(startup.command).toBe('codex')
+    expect(startup.resumeProviderSession).toBeUndefined()
+    expect(startup.codexAccountSwitchRestart).toBe(true)
+  })
+
+  it('uses the persisted record when the live status entry is gone', () => {
+    // Why: agentStatusByPaneKey does not survive an Orca restart, but the shell
+    // does — and a restart in that window must still name the conversation.
+    seedAgentStatus(null)
+    useAppStore.setState({
+      sleepingAgentSessionsByPaneKey: {
+        [makePaneKey(TAB_ID, LEAF_ID)]: {
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: SESSION_ID }
+        }
+      }
+    } as never)
+
+    const startup = build()
+
+    expect(startup.command).toContain(SESSION_ID)
+    expect(startup.resumeProviderSession?.id).toBe(SESSION_ID)
+  })
+
+  it('keeps the bare relaunch for a resolved WSL runtime', () => {
+    // Why: main repins and links the rollout for host lanes only, so a WSL
+    // pane's resume argv would name a conversation its new home does not list
+    // — failing the launch outright instead of at least starting clean.
+    seedAgentStatus({
+      agentType: 'codex',
+      state: 'idle',
+      providerSession: { key: 'session_id', id: SESSION_ID }
+    })
+    projectRuntimeContext = {
+      status: 'resolved',
+      runtime: {
+        kind: 'wsl',
+        hostPlatform: 'wsl',
+        projectId: 'project-1',
+        distro: 'Ubuntu',
+        reason: 'project-override',
+        cacheKey: 'repo-1:wsl:Ubuntu'
+      }
+    }
+
+    const startup = build()
+
+    expect(startup.command).toBe('codex')
+    expect(startup.resumeProviderSession).toBeUndefined()
+    expect(startup.codexAccountSwitchRestart).toBe(true)
+  })
+
+  it('falls back when the pane is running another agent', () => {
+    seedAgentStatus({
+      agentType: 'claude',
+      state: 'idle',
+      providerSession: { key: 'session_id', id: SESSION_ID }
+    })
+
+    expect(build().command).toBe('codex')
+  })
+})

--- a/src/renderer/src/lib/codex-account-restart-startup.ts
+++ b/src/renderer/src/lib/codex-account-restart-startup.ts
@@ -1,0 +1,122 @@
+import { useAppStore } from '@/store'
+import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
+import { resolveAgentResumeLaunchTarget } from '@/lib/agent-resume-launch-target'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import { normalizeAgentProviderSession } from '../../../shared/agent-session-resume'
+import {
+  resolveTuiAgentLaunchArgs,
+  resolveTuiAgentLaunchEnv
+} from '../../../shared/tui-agent-launch-defaults'
+import type {
+  AgentProviderSessionMetadata,
+  SleepingAgentLaunchConfig
+} from '../../../shared/agent-session-resume'
+import { CODEX_ACCOUNT_RESTART_STARTUP } from './codex-session-restart'
+
+export type CodexAccountRestartStartup = {
+  command: string
+  startupCommandDelivery: 'shell-ready'
+  launchAgent: 'codex'
+  codexAccountSwitchRestart: true
+  env?: Record<string, string>
+  launchConfig?: SleepingAgentLaunchConfig
+  resumeProviderSession?: AgentProviderSessionMetadata
+}
+
+/**
+ * The startup an account-switch restart runs.
+ *
+ * Why not a plain `codex`: relaunching the CLI with no argv starts a brand new
+ * conversation. Moving the pane's `CODEX_HOME` to the selected account only
+ * decides which account the new session belongs to — the conversation follows
+ * just when the relaunch asks for it by id, which is what the restart card
+ * promises. Main has already listed the rollout under the selected account by
+ * the time the CLI reads it.
+ *
+ * Falls back to the bare restart when the pane has no resumable Codex session
+ * (nothing was running, or the agent never reported one), because a resume argv
+ * for a session that does not exist fails the launch outright.
+ */
+export function buildCodexAccountRestartStartup(args: {
+  tabId: string
+  leafId?: string | null
+  worktreeId: string
+  shellOverride?: string
+}): CodexAccountRestartStartup {
+  if (!args.leafId) {
+    return CODEX_ACCOUNT_RESTART_STARTUP
+  }
+  const state = useAppStore.getState()
+  const paneKey = makePaneKey(args.tabId, args.leafId)
+  const entry = state.agentStatusByPaneKey[paneKey]
+  // Why the sleeping record is consulted too: agentStatusByPaneKey is in-memory
+  // only, so a pane whose shell outlived an Orca restart has no live entry until
+  // Codex emits its next hook — and a restart in that window would relaunch bare
+  // while the card promised the conversation would carry.
+  const sleeping = state.sleepingAgentSessionsByPaneKey[paneKey]
+  const agentType = entry?.agentType ?? sleeping?.agent
+  if (agentType !== 'codex') {
+    return CODEX_ACCOUNT_RESTART_STARTUP
+  }
+  const providerSession =
+    normalizeAgentProviderSession(entry?.providerSession) ??
+    normalizeAgentProviderSession(sleeping?.providerSession)
+  if (!providerSession) {
+    return CODEX_ACCOUNT_RESTART_STARTUP
+  }
+  const projectRuntime = getLocalProjectExecutionRuntimeContext(state, args.worktreeId)
+  // Why WSL keeps the bare relaunch: main repins and links the rollout for host
+  // lanes only, so a WSL pane would ask its new account's home to resume a
+  // conversation that home does not list — a blank session where a fresh one at
+  // least starts clean. See prepareCodexSessionResumeForLaunch.
+  if (projectRuntime?.status === 'resolved' && projectRuntime.runtime.kind === 'wsl') {
+    return CODEX_ACCOUNT_RESTART_STARTUP
+  }
+  const worktree = state.getKnownWorktreeById(args.worktreeId)
+  const repo = worktree ? state.repos.find((entry) => entry.id === worktree.repoId) : null
+  const launchConfig =
+    (entry ? state.getAgentLaunchConfigForStatusEntry(entry) : undefined) ?? sleeping?.launchConfig
+  // Why the pane's own shell: the resume argv is quoted for the shell that will
+  // run it, and a tab can override the machine's default.
+  const resumeTarget = resolveAgentResumeLaunchTarget({
+    projectRuntime,
+    connectionId: repo?.connectionId,
+    executionHostId: getExecutionHostIdForWorktree(state, args.worktreeId),
+    worktreePath: worktree?.path,
+    terminalWindowsShell: state.settings?.terminalWindowsShell,
+    tabShellOverride: args.shellOverride
+  })
+  const startupPlan = buildAgentResumeStartupPlan({
+    agent: 'codex',
+    providerSession,
+    cmdOverrides: state.settings?.agentCmdOverrides ?? {},
+    agentArgs:
+      launchConfig !== undefined
+        ? launchConfig.agentArgs
+        : resolveTuiAgentLaunchArgs('codex', state.settings?.agentDefaultArgs),
+    agentEnv:
+      launchConfig !== undefined
+        ? launchConfig.agentEnv
+        : resolveTuiAgentLaunchEnv('codex', state.settings?.agentDefaultEnv),
+    ...(launchConfig?.agentCommand ? { agentCommand: launchConfig.agentCommand } : {}),
+    ...(launchConfig?.ompResumeFilePath
+      ? { ompResumeFilePath: launchConfig.ompResumeFilePath }
+      : {}),
+    platform: resumeTarget.platform,
+    shell: resumeTarget.shell
+  })
+  if (!startupPlan) {
+    return CODEX_ACCOUNT_RESTART_STARTUP
+  }
+  return {
+    ...CODEX_ACCOUNT_RESTART_STARTUP,
+    command: startupPlan.launchCommand,
+    ...(startupPlan.env ? { env: startupPlan.env } : {}),
+    launchConfig: startupPlan.launchConfig,
+    // Why it rides along: main only repins the launch home for a spawn that
+    // names the session it is resuming, so dropping this drops the account move.
+    resumeProviderSession: providerSession
+  }
+}

--- a/src/renderer/src/lib/codex-session-restart.ts
+++ b/src/renderer/src/lib/codex-session-restart.ts
@@ -31,10 +31,14 @@ import type { TuiAgent } from '../../../shared/tui-agent'
 // launch prep (project trust pre-mark) only for launchAgent 'codex', so without
 // it a restart respawn could race the account handoff and record a launch
 // account the pane does not actually read.
+// Why codexAccountSwitchRestart: without it main pins the relaunch to the home
+// that owns the resumed session, so the pane comes back on the account the user
+// just left and the switch appears to do nothing.
 export const CODEX_ACCOUNT_RESTART_STARTUP = {
   command: 'codex',
   startupCommandDelivery: 'shell-ready',
-  launchAgent: 'codex'
+  launchAgent: 'codex',
+  codexAccountSwitchRestart: true
 } as const
 
 export type CodexPaneScanResult = {

--- a/src/renderer/src/store/terminals/terminal-actions.ts
+++ b/src/renderer/src/store/terminals/terminal-actions.ts
@@ -205,6 +205,7 @@ export type TerminalActions = {
       envToDelete?: string[]
       launchConfig?: SleepingAgentLaunchConfig
       resumeProviderSession?: AgentProviderSessionMetadata
+      codexAccountSwitchRestart?: boolean
       launchToken?: string
       launchAgent?: TuiAgent
       agentArgsOverride?: string | null

--- a/src/renderer/src/store/terminals/terminal-state.ts
+++ b/src/renderer/src/store/terminals/terminal-state.ts
@@ -58,6 +58,7 @@ export type TerminalState = {
       envToDelete?: string[]
       launchConfig?: SleepingAgentLaunchConfig
       resumeProviderSession?: AgentProviderSessionMetadata
+      codexAccountSwitchRestart?: boolean
       launchToken?: string
       launchAgent?: TuiAgent
       agentArgsOverride?: string | null


### PR DESCRIPTION
## ELI5

When changing Codex accounts, restarting a native terminal should continue the existing conversation in the selected account. A failed history transfer must not quietly start an empty conversation.

## What Changed

Carry resume metadata through the account-restart path and repin the verified rollout to the selected native account, including system default. Prefer a hardlink; for cross-volume copies, publish a complete temporary copy with an exclusive same-volume link. Compare existing copies with the source and reject empty, stale or divergent files without overwriting them.

Transfer /goal through app-server RPC where supported. Preserve budget-limited status and subtract tokens already consumed; unknown consumption pauses a budgeted goal. A failed transfer blocks restart. Unsupported goal RPCs retain the compatibility path, with restart text asking the user to verify /goal. WSL retains its existing fresh-start fallback.

## Why

An ordinary resume pins CODEX_HOME to the history owner, which is wrong for an explicit account switch. Switching must select the new credentials without treating an invalid copy as successful or replenishing the user's goal budget.

## Linked Issue

Related to #18486 and #12098.

## Visual Proof

Pending: this draft changes restart explanatory text. No live user session was interrupted for a demonstration. Renderer behavior is covered by the restart-chip tests; a rendered before/after and live account round trip remain to be attached.

## Testing

- [x] Windows automated regression coverage: 75 passed, 1 platform-specific symlink test skipped across eight account/startup/renderer test files.
- [x] Follow-up copy/goal/launch tests: 32 passed, 1 skipped after the final functional change.
- [x] Final local integration: 153 passed, 1 platform-specific test skipped across 13 files, including the token-deduplication fix from #19152 and preserved local startup customizations. This is broader than this PR alone.
- [x] Node/CLI/web typecheck passed.
- [x] Windows desktop build and unpacked Electron packaging passed. The integrated package started headlessly in a disposable profile; a second instance exited with code 3 while the first stayed alive. Packaged main bytes matched the build output.
- [x] Targeted oxlint, React Doctor and oxfmt passed in the commit hook.
- [ ] Live authenticated account-switch round trip, macOS/Linux, WSL/SSH integration and rendered screenshots.

## AI Disclosure

Implemented and audited with Codex (GPT-6), following earlier agent-assisted work.

## Review

The initial implementation adapted the account-resume approach and code from @tonite31's #14877. This PR retains that provenance and adds native system-default handling, conservative file-copy checks and budget preservation. It does not implement in-place authentication replacement. Filesystems that cannot publish the temporary copy via hardlink fail safely. Copied logs require the origin writer to have stopped; divergent histories require recovery rather than automatic overwrite.

## Agent skill upstream boundary

- [x] Not applicable; no skill-installer code or material changed.

