### PR TITLE
fix(hibernation): require execution-host evidence before hibernating ssh-hosted panes

### DIFF
--- a/src/renderer/src/lib/agent-hibernation-coordinator.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.ts
@@ -23,12 +23,11 @@ import {
 } from './agent-hibernation-pane-age'
 import { mergePendingTerminalInputActivity } from './terminal-input-activity-coalescing'
 import { getRuntimeEnvironmentIdForWorktree } from './worktree-runtime-owner'
-import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
-import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
-import type {
-  RuntimeTerminalListResult,
-  RuntimeTerminalSummary
-} from '../../../shared/runtime-types'
+import {
+  collectHostPtyLiveness,
+  getHostLivenessTarget,
+  type HostLivenessSample
+} from './agent-hibernation-host-liveness'
 import { getWindowParkVisible, subscribeWindowParkVisibility } from './window-park-visibility'
 
 export const AGENT_HIBERNATION_TICK_MS = 60 * 1000
@@ -58,15 +57,10 @@ const coordinator: AgentHibernationCoordinatorState = {
   now: () => Date.now()
 }
 
-type RuntimePtyLivenessSample = {
-  runtimeLivePtyIdsByWorktreeId: Record<string, string[]>
-  runtimeLivenessRequiredWorktreeIds: string[]
-}
-
 function snapshotFromState(
   state: AppState,
   now: number,
-  runtimeLiveness: RuntimePtyLivenessSample,
+  hostLiveness: HostLivenessSample,
   targetWorktreeId?: string
 ): AgentHibernationPlannerSnapshot {
   return {
@@ -78,8 +72,9 @@ function snapshotFromState(
       : state.tabsByWorktree,
     terminalLayoutsByTabId: state.terminalLayoutsByTabId,
     ptyIdsByTabId: state.ptyIdsByTabId,
-    runtimeLivePtyIdsByWorktreeId: runtimeLiveness.runtimeLivePtyIdsByWorktreeId,
-    runtimeLivenessRequiredWorktreeIds: runtimeLiveness.runtimeLivenessRequiredWorktreeIds,
+    runtimeLivePtyIdsByWorktreeId: hostLiveness.runtimeLivePtyIdsByWorktreeId,
+    runtimeLivenessRequiredWorktreeIds: hostLiveness.runtimeLivenessRequiredWorktreeIds,
+    hostConfirmedLivenessWorktreeIds: hostLiveness.hostConfirmedLivenessWorktreeIds,
     mobileLockedPtyIds: [...getAllDrivers()]
       .filter(([, driver]) => driver.kind === 'mobile')
       .map(([ptyId]) => ptyId),
@@ -96,81 +91,8 @@ function snapshotFromState(
   }
 }
 
-function getRuntimeLivenessTargetWorktrees(
-  state: AppState,
-  targetWorktreeId?: string
-): Map<string, string> {
-  const targets = new Map<string, string>()
-  const worktreeIds = targetWorktreeId
-    ? Object.hasOwn(state.tabsByWorktree, targetWorktreeId)
-      ? [targetWorktreeId]
-      : []
-    : Object.keys(state.tabsByWorktree)
-  for (const worktreeId of worktreeIds) {
-    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
-    if (runtimeEnvironmentId) {
-      targets.set(worktreeId, runtimeEnvironmentId)
-    }
-  }
-  return targets
-}
-
-function getTypedRuntimePtyId(terminal: RuntimeTerminalSummary): string | null {
-  if (terminal.ptyId) {
-    return terminal.ptyId
-  }
-  if (terminal.tabId.startsWith('pty:') && terminal.tabId === terminal.leafId) {
-    return terminal.tabId.slice('pty:'.length) || null
-  }
-  return null
-}
-
-async function collectRuntimePtyLiveness(
-  state: AppState,
-  targetWorktreeId?: string
-): Promise<RuntimePtyLivenessSample> {
-  const targets = getRuntimeLivenessTargetWorktrees(state, targetWorktreeId)
-  const runtimeLivePtyIdsByWorktreeId: Record<string, string[]> = {}
-  const runtimeLivenessRequiredWorktreeIds = [...targets.keys()]
-  await Promise.all(
-    [...targets].map(async ([worktreeId, runtimeEnvironmentId]) => {
-      try {
-        const result = await callRuntimeRpc<RuntimeTerminalListResult>(
-          { kind: 'environment', environmentId: runtimeEnvironmentId },
-          'terminal.list',
-          {
-            worktree: toRuntimeWorktreeSelector(worktreeId),
-            limit: 10_000,
-            requireFreshPtyLiveness: true,
-            includeVisualLayouts: false
-          },
-          { timeoutMs: 10_000 }
-        )
-        if (result.truncated) {
-          return
-        }
-        const ptyIds = new Set<string>()
-        for (const terminal of result.terminals) {
-          if (!terminal.connected || terminal.worktreeId !== worktreeId) {
-            continue
-          }
-          const ptyId = getTypedRuntimePtyId(terminal)
-          if (ptyId) {
-            ptyIds.add(ptyId)
-          }
-        }
-        runtimeLivePtyIdsByWorktreeId[worktreeId] = [...ptyIds].sort()
-      } catch {
-        // Why: stale runtime liveness is unsafe for all-or-nothing hibernation;
-        // omitting the worktree makes the planner fail closed for this pass.
-      }
-    })
-  )
-  return { runtimeLivePtyIdsByWorktreeId, runtimeLivenessRequiredWorktreeIds }
-}
-
 async function currentCandidates(now: number, targetWorktreeId?: string) {
-  const runtimeLiveness = await collectRuntimePtyLiveness(useAppStore.getState(), targetWorktreeId)
+  const hostLiveness = await collectHostPtyLiveness(useAppStore.getState(), targetWorktreeId)
   const freshState = useAppStore.getState()
   // Why: age the PTY bindings from the same state the plan is built from, so a pane
   // observed for the first time this pass cannot also be judged long-idle in it.
@@ -181,14 +103,11 @@ async function currentCandidates(now: number, targetWorktreeId?: string) {
     idleMs: getEffectiveAgentHibernationIdleMs(freshState.settings?.agentHibernationIdleMs)
   })
   return planAgentHibernationCandidates(
-    snapshotFromState(freshState, now, runtimeLiveness, targetWorktreeId)
+    snapshotFromState(freshState, now, hostLiveness, targetWorktreeId)
   )
     .filter((candidate) => {
-      const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
-        freshState,
-        candidate.worktreeId
-      )
-      return !runtimeEnvironmentId || candidate.expectedRuntimePtyIds.length === 1
+      const hostTarget = getHostLivenessTarget(freshState, candidate.worktreeId)
+      return !hostTarget || candidate.expectedRuntimePtyIds.length === 1
     })
     .map((candidate) => ({
       ...candidate,

--- a/src/renderer/src/lib/agent-hibernation-host-liveness.ts
+++ b/src/renderer/src/lib/agent-hibernation-host-liveness.ts
@@ -1,0 +1,154 @@
+import { parseExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
+import { hostScopeCoveredExecutionHost } from '../../../shared/runtime-listing-host-scope'
+import type {
+  RuntimeTerminalListResult,
+  RuntimeTerminalSummary
+} from '../../../shared/runtime-types'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
+import type { AppState } from '@/store/types'
+import {
+  getExecutionHostIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree
+} from './worktree-runtime-owner'
+
+const HOST_LIVENESS_TIMEOUT_MS = 10_000
+const HOST_LIVENESS_LIMIT = 10_000
+
+/**
+ * Where a workspace's fresh PTY-liveness evidence comes from. Hibernation is destructive, so
+ * every host-owned workspace needs host evidence before a pane is shut down — client-side
+ * bookkeeping observes no process (docs/reference/ssh-execution-boundary.md).
+ *
+ * - `runtime-authoritative`: a paired runtime peer owns its own control plane and the whole PTY
+ *   inventory for its worktrees, so its listing replaces the client's view.
+ * - `ssh-confirming`: an SSH box is a dumb execution host driven by this client, so the client's
+ *   own runtime holds the relay provider and its PTY bindings stay authoritative for the surface.
+ *   The host listing only confirms which of those bindings are still alive.
+ */
+export type HostLivenessTarget =
+  | { kind: 'runtime-authoritative'; runtimeEnvironmentId: string }
+  | { kind: 'ssh-confirming'; executionHostId: ExecutionHostId }
+
+export type HostLivenessSample = {
+  runtimeLivePtyIdsByWorktreeId: Record<string, string[]>
+  runtimeLivenessRequiredWorktreeIds: string[]
+  hostConfirmedLivenessWorktreeIds: string[]
+}
+
+export function getHostLivenessTarget(
+  state: AppState,
+  worktreeId: string
+): HostLivenessTarget | null {
+  const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  if (runtimeEnvironmentId) {
+    return { kind: 'runtime-authoritative', runtimeEnvironmentId }
+  }
+  const executionHostId = getExecutionHostIdForWorktree(state, worktreeId)
+  return parseExecutionHostId(executionHostId)?.kind === 'ssh'
+    ? { kind: 'ssh-confirming', executionHostId }
+    : null
+}
+
+export function getHostLivenessTargetWorktrees(
+  state: AppState,
+  targetWorktreeId?: string
+): Map<string, HostLivenessTarget> {
+  const targets = new Map<string, HostLivenessTarget>()
+  const worktreeIds = targetWorktreeId
+    ? Object.hasOwn(state.tabsByWorktree, targetWorktreeId)
+      ? [targetWorktreeId]
+      : []
+    : Object.keys(state.tabsByWorktree)
+  for (const worktreeId of worktreeIds) {
+    const target = getHostLivenessTarget(state, worktreeId)
+    if (target) {
+      targets.set(worktreeId, target)
+    }
+  }
+  return targets
+}
+
+function getTypedRuntimePtyId(terminal: RuntimeTerminalSummary): string | null {
+  if (terminal.ptyId) {
+    return terminal.ptyId
+  }
+  if (terminal.tabId.startsWith('pty:') && terminal.tabId === terminal.leafId) {
+    return terminal.tabId.slice('pty:'.length) || null
+  }
+  return null
+}
+
+/** Live PTY ids the owning host itself reported, or null when it produced no usable evidence. */
+async function readHostLivePtyIds(
+  worktreeId: string,
+  target: HostLivenessTarget
+): Promise<string[] | null> {
+  const result = await callRuntimeRpc<RuntimeTerminalListResult>(
+    // Why: an SSH box has no runtime RPC endpoint of its own. Its relay provider is registered in
+    // THIS client's runtime, so the client's own runtime is the route to the execution host — not
+    // a substitute for it. A paired runtime answers for itself.
+    target.kind === 'runtime-authoritative'
+      ? { kind: 'environment', environmentId: target.runtimeEnvironmentId }
+      : { kind: 'local' },
+    'terminal.list',
+    {
+      worktree: toRuntimeWorktreeSelector(worktreeId),
+      limit: HOST_LIVENESS_LIMIT,
+      requireFreshPtyLiveness: true,
+      includeVisualLayouts: false
+    },
+    { timeoutMs: HOST_LIVENESS_TIMEOUT_MS }
+  )
+  if (result.truncated) {
+    return null
+  }
+  // A listing that did not cover the workspace's own host is not evidence about it: the client's
+  // runtime can answer for its local PTYs while the relay to the SSH box never replied.
+  if (
+    target.kind === 'ssh-confirming' &&
+    !hostScopeCoveredExecutionHost(result.hostScope, target.executionHostId)
+  ) {
+    return null
+  }
+  const ptyIds = new Set<string>()
+  for (const terminal of result.terminals) {
+    if (!terminal.connected || terminal.worktreeId !== worktreeId) {
+      continue
+    }
+    const ptyId = getTypedRuntimePtyId(terminal)
+    if (ptyId) {
+      ptyIds.add(ptyId)
+    }
+  }
+  return [...ptyIds].sort()
+}
+
+export async function collectHostPtyLiveness(
+  state: AppState,
+  targetWorktreeId?: string
+): Promise<HostLivenessSample> {
+  const targets = getHostLivenessTargetWorktrees(state, targetWorktreeId)
+  const runtimeLivePtyIdsByWorktreeId: Record<string, string[]> = {}
+  await Promise.all(
+    [...targets].map(async ([worktreeId, target]) => {
+      try {
+        const ptyIds = await readHostLivePtyIds(worktreeId, target)
+        if (ptyIds) {
+          runtimeLivePtyIdsByWorktreeId[worktreeId] = ptyIds
+        }
+      } catch {
+        // Why: stale host liveness is unsafe for all-or-nothing hibernation; omitting the
+        // worktree makes the planner fail closed for this pass. Loss of contact is never
+        // evidence that a host-owned PTY exited.
+      }
+    })
+  )
+  return {
+    runtimeLivePtyIdsByWorktreeId,
+    runtimeLivenessRequiredWorktreeIds: [...targets.keys()],
+    hostConfirmedLivenessWorktreeIds: [...targets]
+      .filter(([, target]) => target.kind === 'ssh-confirming')
+      .map(([worktreeId]) => worktreeId)
+  }
+}

--- a/src/renderer/src/lib/agent-hibernation-planner-snapshot.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner-snapshot.ts
@@ -12,6 +12,12 @@ export type AgentHibernationPlannerSnapshot = {
   ptyIdsByTabId: Record<string, string[] | undefined>
   runtimeLivePtyIdsByWorktreeId?: Record<string, string[] | undefined>
   runtimeLivenessRequiredWorktreeIds?: string[]
+  /**
+   * Subset of the above whose host evidence CONFIRMS the client's own PTY bindings instead of
+   * replacing them. An SSH box is driven by this client, so the client owns the pane-to-PTY
+   * binding and the host only says which of those are still alive.
+   */
+  hostConfirmedLivenessWorktreeIds?: string[]
   mobileLockedPtyIds: string[]
   agentStatusByPaneKey: Record<string, AgentStatusEntry | undefined>
   sleepingAgentSessionsByPaneKey: Record<string, SleepingAgentSessionRecord | undefined>

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -35,26 +35,41 @@ export function getEffectiveAgentHibernationIdleMs(value: unknown): number {
     : DEFAULT_AGENT_HIBERNATION_IDLE_MS
 }
 
+/**
+ * How a worktree's live-PTY set is established.
+ * - `client`: no host owns this workspace's execution, so the renderer's own bindings stand.
+ * - `host-authoritative`: a paired runtime peer owns the whole inventory; its listing replaces
+ *   the client's view (the renderer's map is empty for remote panes).
+ * - `host-confirming`: this client owns the pane-to-PTY binding and the execution host only
+ *   confirms life, so the two must agree. Strictly narrower than `client`.
+ */
+export type LivePtyEvidenceMode = 'client' | 'host-authoritative' | 'host-confirming'
+
+function toNormalizedPtyIds(ids: readonly (string | undefined)[] | undefined): Set<string> {
+  const normalized = new Set<string>()
+  for (const id of ids ?? []) {
+    if (typeof id === 'string' && id.length > 0) {
+      normalized.add(toRuntimePtyId(id))
+    }
+  }
+  return normalized
+}
+
 function getLivePtyIdsForTab(
   tab: TerminalTab,
   ptyIdsByTabId: Record<string, string[] | undefined>,
   runtimeLivePtyIdsByWorktreeId: Record<string, string[] | undefined> | undefined,
-  runtimeLivenessRequired: boolean
+  mode: LivePtyEvidenceMode
 ): string[] {
-  const ids = new Set<string>()
-  for (const id of runtimeLivePtyIdsByWorktreeId?.[tab.worktreeId] ?? []) {
-    if (typeof id === 'string' && id.length > 0) {
-      ids.add(toRuntimePtyId(id))
-    }
+  const hostIds = toNormalizedPtyIds(runtimeLivePtyIdsByWorktreeId?.[tab.worktreeId])
+  if (mode === 'host-authoritative') {
+    return [...hostIds]
   }
-  if (!runtimeLivenessRequired) {
-    for (const id of ptyIdsByTabId[tab.id] ?? []) {
-      if (typeof id === 'string' && id.length > 0) {
-        ids.add(toRuntimePtyId(id))
-      }
-    }
+  const clientIds = toNormalizedPtyIds(ptyIdsByTabId[tab.id])
+  if (mode === 'host-confirming') {
+    return [...hostIds].filter((id) => clientIds.has(id))
   }
-  return [...ids]
+  return [...new Set([...hostIds, ...clientIds])]
 }
 
 function signatureFor(worktreeId: string, panes: EligiblePane[]): string {
@@ -109,6 +124,7 @@ export function planAgentHibernationCandidates(
   const runtimeLivenessRequiredWorktreeIds = new Set(
     snapshot.runtimeLivenessRequiredWorktreeIds ?? []
   )
+  const hostConfirmedLivenessWorktreeIds = new Set(snapshot.hostConfirmedLivenessWorktreeIds ?? [])
   const agentEntriesByTabId = getAgentEntriesByTabId(snapshot.agentStatusByPaneKey)
   const candidates: AgentHibernationCandidate[] = []
   for (const [worktreeId, tabs] of Object.entries(snapshot.tabsByWorktree)) {
@@ -119,12 +135,18 @@ export function planAgentHibernationCandidates(
     if (!worktreeId || tabs.length === 0) {
       continue
     }
+    const hostEvidenceRequired = runtimeLivenessRequiredWorktreeIds.has(worktreeId)
     if (
-      runtimeLivenessRequiredWorktreeIds.has(worktreeId) &&
+      hostEvidenceRequired &&
       !Object.hasOwn(snapshot.runtimeLivePtyIdsByWorktreeId ?? {}, worktreeId)
     ) {
       continue
     }
+    const evidenceMode: LivePtyEvidenceMode = !hostEvidenceRequired
+      ? 'client'
+      : hostConfirmedLivenessWorktreeIds.has(worktreeId)
+        ? 'host-confirming'
+        : 'host-authoritative'
     for (const tab of tabs) {
       if (foregroundTerminalTabIds.has(tab.id)) {
         continue
@@ -133,7 +155,7 @@ export function planAgentHibernationCandidates(
         tab,
         snapshot.ptyIdsByTabId,
         snapshot.runtimeLivePtyIdsByWorktreeId,
-        runtimeLivenessRequiredWorktreeIds.has(worktreeId)
+        evidenceMode
       )
       if (tabLivePtyIds.length === 0) {
         continue

--- a/src/renderer/src/lib/agent-hibernation-ssh-host-evidence.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-ssh-host-evidence.test.ts
@@ -1,0 +1,351 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { useAppStore } from '@/store'
+import { DEFAULT_AGENT_HIBERNATION_IDLE_MS } from './agent-hibernation-planner'
+import {
+  resetAgentHibernationCoordinatorForTests,
+  startAgentHibernationCoordinator
+} from './agent-hibernation-coordinator'
+import { hydrateDrivers } from './pane-manager/mobile-driver-state'
+import { resetForegroundTerminalTabIdsForTests } from './foreground-terminal-tabs'
+import { resetAgentHibernationOutputActivityForTests } from './agent-hibernation-output-activity'
+import {
+  observeHibernationPtyBindings,
+  resetHibernationPaneAgeForTests
+} from './agent-hibernation-pane-age'
+import { clearRuntimeCompatibilityCacheForTests } from '../runtime/runtime-rpc-client'
+import type { AppState } from '@/store/types'
+
+const NOW = 10_000_000
+const LEAVES = [
+  '11111111-1111-4111-8111-111111111111',
+  '22222222-2222-4222-8222-222222222222',
+  '33333333-3333-4333-8333-333333333333',
+  '44444444-4444-4444-8444-444444444444',
+  '55555555-5555-4555-8555-555555555555'
+]
+const LEAF = LEAVES[0]!
+const SSH_TARGET_ID = 'box-1'
+const SSH_HOST_ID = `ssh:${SSH_TARGET_ID}` as const
+const ptyIdFor = (leafIndex: number): string => `ssh:${SSH_TARGET_ID}@@pty-${leafIndex + 1}`
+
+const mockRuntimeCall = vi.fn()
+const mockRuntimeEnvironmentCall = vi.fn()
+
+vi.stubGlobal('window', {
+  api: {
+    runtime: { call: mockRuntimeCall },
+    runtimeEnvironments: { call: mockRuntimeEnvironmentCall }
+  }
+})
+
+function tab(worktreeId: string): TerminalTab {
+  return {
+    id: 'tab-1',
+    ptyId: null,
+    worktreeId,
+    title: 'Agent',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function layout(leafCount: number): TerminalLayoutSnapshot {
+  const leafIds = LEAVES.slice(0, leafCount)
+  return {
+    root: { type: 'leaf', leafId: LEAF },
+    activeLeafId: LEAF,
+    expandedLeafId: null,
+    ptyIdsByLeafId: Object.fromEntries(leafIds.map((leafId, i) => [leafId, ptyIdFor(i)]))
+  }
+}
+
+function entry(leafId: string, worktreeId: string, index: number): AgentStatusEntry {
+  return {
+    state: 'done',
+    prompt: 'ship it',
+    updatedAt: NOW - DEFAULT_AGENT_HIBERNATION_IDLE_MS - 1,
+    stateStartedAt: NOW - DEFAULT_AGENT_HIBERNATION_IDLE_MS - 1,
+    paneKey: `tab-1:${leafId}`,
+    tabId: 'tab-1',
+    worktreeId,
+    agentType: 'claude',
+    providerSession: { key: 'session_id', id: `session-${index + 1}` },
+    stateHistory: []
+  }
+}
+
+type SshStateOptions = {
+  leafCount?: number
+  worktreeId?: string
+  folderWorkspace?: boolean
+  overrides?: Partial<AppState>
+}
+
+function installEligibleSshState(
+  shutdown = vi.fn().mockResolvedValue(undefined),
+  {
+    leafCount = 1,
+    worktreeId = 'wt-bg',
+    folderWorkspace = false,
+    overrides = {}
+  }: SshStateOptions = {}
+): typeof shutdown {
+  const entries = LEAVES.slice(0, leafCount).map((leafId, i) => entry(leafId, worktreeId, i))
+  useAppStore.setState({
+    settings: {
+      experimentalAgentHibernation: true,
+      agentHibernationIdleMs: DEFAULT_AGENT_HIBERNATION_IDLE_MS
+    } as never,
+    activeWorktreeId: 'wt-active',
+    repos: [],
+    worktreesByRepo: folderWorkspace
+      ? ({} as never)
+      : ({
+          'fixture-repo': [{ id: worktreeId, repoId: 'fixture-repo', hostId: SSH_HOST_ID }]
+        } as never),
+    folderWorkspaces: folderWorkspace
+      ? ([{ id: 'folder-1', connectionId: SSH_TARGET_ID }] as never)
+      : ([] as never),
+    detectedWorktreesByRepo: {},
+    tabsByWorktree: { [worktreeId]: [tab(worktreeId)] },
+    terminalLayoutsByTabId: { 'tab-1': layout(leafCount) },
+    ptyIdsByTabId: { 'tab-1': LEAVES.slice(0, leafCount).map((_, i) => ptyIdFor(i)) },
+    agentStatusByPaneKey: Object.fromEntries(entries.map((e) => [e.paneKey, e])) as never,
+    sleepingAgentSessionsByPaneKey: {},
+    lastTerminalInputAtByPaneKey: {},
+    shutdownCompletedAgentPaneForHibernation: shutdown as never,
+    shutdownWorktreeTerminals: vi.fn() as never,
+    ...overrides
+  })
+  // Why: a pane idle long enough to hibernate has been observed by earlier passes, so seed an
+  // old PTY binding — otherwise the binding-age floor defers every candidate on its first tick.
+  const state = useAppStore.getState()
+  observeHibernationPtyBindings({
+    tabsByWorktree: state.tabsByWorktree,
+    terminalLayoutsByTabId: state.terminalLayoutsByTabId,
+    now: NOW - DEFAULT_AGENT_HIBERNATION_IDLE_MS - 60_000,
+    idleMs: DEFAULT_AGENT_HIBERNATION_IDLE_MS
+  })
+  return shutdown
+}
+
+function sshListResult(
+  ptyIds: string[],
+  worktreeId = 'wt-bg',
+  opts: { truncated?: boolean; hostIds?: string[]; omittedHostIds?: string[] } = {}
+) {
+  return {
+    terminals: ptyIds.map((ptyId) => ({
+      handle: `handle-${ptyId}`,
+      ptyId,
+      worktreeId,
+      worktreePath: '/tmp/wt-bg',
+      branch: 'feature',
+      tabId: `pty:${ptyId}`,
+      leafId: `pty:${ptyId}`,
+      title: 'Agent',
+      connected: true,
+      writable: true,
+      lastOutputAt: null,
+      preview: ''
+    })),
+    totalCount: ptyIds.length,
+    truncated: opts.truncated ?? false,
+    hostScope: {
+      hostIds: opts.hostIds ?? [SSH_HOST_ID],
+      omittedHostIds: opts.omittedHostIds ?? ['local']
+    }
+  }
+}
+
+/** Queue of `terminal.list` answers on the client's own runtime; the last one repeats. */
+function installLocalListResponses(
+  ...responses: (ReturnType<typeof sshListResult> | Error | 'never-resolves')[]
+): void {
+  const queue = [...responses]
+  mockRuntimeCall.mockImplementation((args: { method: string }) => {
+    if (args.method !== 'terminal.list') {
+      return Promise.resolve({ id: 'default', ok: true, result: {} })
+    }
+    const response = queue.length > 1 ? queue.shift()! : (queue[0] ?? new Error('no answer'))
+    if (response === 'never-resolves') {
+      return new Promise(() => {})
+    }
+    if (response instanceof Error) {
+      return Promise.reject(response)
+    }
+    return Promise.resolve({ id: 'terminal-list', ok: true, result: response })
+  })
+}
+
+function terminalListCallCount(): number {
+  return mockRuntimeCall.mock.calls.filter(([args]) => args?.method === 'terminal.list').length
+}
+
+afterEach(() => {
+  resetAgentHibernationCoordinatorForTests()
+  clearRuntimeCompatibilityCacheForTests()
+  resetForegroundTerminalTabIdsForTests()
+  resetAgentHibernationOutputActivityForTests()
+  resetHibernationPaneAgeForTests()
+  hydrateDrivers([])
+  mockRuntimeCall.mockReset()
+  mockRuntimeEnvironmentCall.mockReset()
+  vi.useRealTimers()
+})
+
+// Live validation on a Linux SSH target observed 0 `terminal.list` calls and 5 hibernation
+// shutdowns for a workspace with `hostId: 'ssh:…'`: the fresh-evidence requirement covered
+// paired runtimes only, so an SSH workspace hibernated on client bookkeeping alone.
+describe('ssh-hosted hibernation requires execution-host evidence', () => {
+  it('asks the execution host and hibernates nothing when the relay rejects every tick', async () => {
+    vi.useFakeTimers()
+    installLocalListResponses(new Error('relay unavailable'))
+    const shutdown = installEligibleSshState(vi.fn().mockResolvedValue(undefined), { leafCount: 5 })
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(terminalListCallCount()).toBeGreaterThan(0)
+  })
+
+  it('hibernates nothing while the host listing never resolves', async () => {
+    vi.useFakeTimers()
+    installLocalListResponses('never-resolves')
+    const shutdown = installEligibleSshState(vi.fn().mockResolvedValue(undefined), { leafCount: 5 })
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('hibernates nothing across an alternating good/failed host answer flap', async () => {
+    vi.useFakeTimers()
+    installLocalListResponses(
+      sshListResult([ptyIdFor(0)]),
+      new Error('relay unavailable'),
+      sshListResult([ptyIdFor(0)]),
+      new Error('relay unavailable')
+    )
+    const shutdown = installEligibleSshState()
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(4000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('fails closed on a truncated host listing', async () => {
+    vi.useFakeTimers()
+    installLocalListResponses(sshListResult([ptyIdFor(0)], 'wt-bg', { truncated: true }))
+    const shutdown = installEligibleSshState()
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(4000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the listing did not cover the workspace SSH host', async () => {
+    vi.useFakeTimers()
+    // The client's own runtime answered for its local PTYs; the relay to the box never did.
+    // An empty answer from a host that was not asked is not evidence the PTY exited.
+    installLocalListResponses(
+      sshListResult([], 'wt-bg', { hostIds: ['local'], omittedHostIds: [SSH_HOST_ID] })
+    )
+    const shutdown = installEligibleSshState()
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(4000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the host is too old to publish a listing scope', async () => {
+    vi.useFakeTimers()
+    const { hostScope: _hostScope, ...withoutScope } = sshListResult([ptyIdFor(0)])
+    installLocalListResponses(withoutScope as ReturnType<typeof sshListResult>)
+    const shutdown = installEligibleSshState()
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(4000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('requires host evidence for an SSH folder workspace too', async () => {
+    vi.useFakeTimers()
+    installLocalListResponses(new Error('relay unavailable'))
+    const worktreeId = folderWorkspaceKey('folder-1')
+    const shutdown = installEligibleSshState(vi.fn().mockResolvedValue(undefined), {
+      worktreeId,
+      folderWorkspace: true
+    })
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(4000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(terminalListCallCount()).toBeGreaterThan(0)
+  })
+
+  it('does not widen eligibility to a PTY the client never bound to this tab', async () => {
+    vi.useFakeTimers()
+    installLocalListResponses(sshListResult([ptyIdFor(0)]))
+    const shutdown = installEligibleSshState(vi.fn().mockResolvedValue(undefined), {
+      overrides: { ptyIdsByTabId: { 'tab-1': [] } }
+    })
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(4000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('still hibernates when the reachable SSH host reports the pane PTY live', async () => {
+    vi.useFakeTimers()
+    installLocalListResponses(sshListResult([ptyIdFor(0)]))
+    const shutdown = installEligibleSshState()
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(shutdown).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(shutdown).toHaveBeenCalledWith('wt-bg', {
+      paneKey: `tab-1:${LEAF}`,
+      tabId: 'tab-1',
+      leafId: LEAF,
+      ptyId: ptyIdFor(0)
+    })
+    expect(mockRuntimeCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'terminal.list',
+        params: expect.objectContaining({ requireFreshPtyLiveness: true })
+      })
+    )
+  })
+
+  it('stops hibernating a pane the host stopped reporting between ticks', async () => {
+    vi.useFakeTimers()
+    installLocalListResponses(
+      sshListResult([ptyIdFor(0)]),
+      sshListResult([ptyIdFor(0)]),
+      sshListResult(['ssh:box-1@@pty-other'])
+    )
+    const shutdown = installEligibleSshState()
+    startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
+
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(shutdown).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/runtime-listing-host-scope.test.ts
+++ b/src/shared/runtime-listing-host-scope.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { hostScopeCensusIsComplete } from './runtime-listing-host-scope'
+import {
+  hostScopeCensusIsComplete,
+  hostScopeCoveredExecutionHost
+} from './runtime-listing-host-scope'
 
 /**
  * The gate and the disclosure list answer different questions off the same field. These pin the
@@ -76,6 +79,45 @@ describe('hostScopeCensusIsComplete', () => {
         hostIds: ['local'],
         omittedHostIds: ['runtime:' as never]
       })
+    ).toBe(false)
+  })
+})
+
+// A worktree-scoped listing names every host but the target's as omitted by design, so the
+// unscoped census gate is the wrong question for it. This one asks only whether the host that
+// owns the workspace's PTYs actually answered.
+describe('hostScopeCoveredExecutionHost', () => {
+  it('accepts the scoped listing that covered the workspace SSH host', () => {
+    expect(
+      hostScopeCoveredExecutionHost(
+        { hostIds: ['ssh:box-1'], omittedHostIds: ['local'] },
+        'ssh:box-1'
+      )
+    ).toBe(true)
+  })
+
+  it('refuses a listing that answered only for other hosts', () => {
+    expect(
+      hostScopeCoveredExecutionHost(
+        { hostIds: ['local'], omittedHostIds: ['ssh:box-1'] },
+        'ssh:box-1'
+      )
+    ).toBe(false)
+  })
+
+  it('refuses a host too old to publish a scope, because absence is never coverage', () => {
+    expect(hostScopeCoveredExecutionHost(undefined, 'ssh:box-1')).toBe(false)
+  })
+
+  it('matches two spellings of one percent-encoded target rather than reporting a false gap', () => {
+    expect(
+      hostScopeCoveredExecutionHost({ hostIds: ['ssh:box%2D1'], omittedHostIds: [] }, 'ssh:box-1')
+    ).toBe(true)
+  })
+
+  it('does not let an ssh host stand in for a runtime host of the same name', () => {
+    expect(
+      hostScopeCoveredExecutionHost({ hostIds: ['ssh:env-1'], omittedHostIds: [] }, 'runtime:env-1')
     ).toBe(false)
   })
 })

--- a/src/shared/runtime-listing-host-scope.ts
+++ b/src/shared/runtime-listing-host-scope.ts
@@ -1,4 +1,8 @@
-import { parseExecutionHostId, type ExecutionHostId } from './execution-host'
+import {
+  parseExecutionHostId,
+  type ExecutionHostId,
+  type ParsedExecutionHost
+} from './execution-host'
 
 /**
  * What a bounded listing did and did not cover, by execution host. An absent scope means the
@@ -38,4 +42,36 @@ export function hostScopeCensusIsComplete(scope: RuntimeListingHostScope | undef
     return false
   }
   return scope.omittedHostIds.every((hostId) => parseExecutionHostId(hostId)?.kind === 'runtime')
+}
+
+function hostIdentity(parsed: ParsedExecutionHost): string {
+  return parsed.kind === 'ssh'
+    ? parsed.targetId
+    : parsed.kind === 'runtime'
+      ? parsed.environmentId
+      : parsed.id
+}
+
+/**
+ * Whether a worktree-scoped listing actually covered the workspace's own execution host.
+ *
+ * A scoped listing names every host but the target's as omitted by design, so
+ * `hostScopeCensusIsComplete` — the unscoped gate — is the wrong question here. The right one
+ * is narrower: did the host that owns these PTYs answer? Absence of a scope is never coverage;
+ * a host too old to publish one cannot claim it.
+ */
+export function hostScopeCoveredExecutionHost(
+  scope: RuntimeListingHostScope | undefined,
+  hostId: ExecutionHostId
+): boolean {
+  const expected = parseExecutionHostId(hostId)
+  if (scope === undefined || !expected) {
+    return false
+  }
+  // Compare the decoded identity, not the raw id: two spellings of one percent-encoded target
+  // name the same host, and reading them as different hosts would report a false gap.
+  return scope.hostIds.some((covered) => {
+    const parsed = parseExecutionHostId(covered)
+    return parsed?.kind === expected.kind && hostIdentity(parsed) === hostIdentity(expected)
+  })
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​394 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​393 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​247 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​110 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 |

<!-- /orca-pr-loc -->

## ELI5

Orca can put an idle, finished agent to sleep to free memory: it kills the pane's terminal and keeps enough state to resume it later. Killing a terminal is destructive, so before doing it Orca asks the machine that actually runs the terminal "is this thing still alive?"

It only asked when that machine was a **paired runtime**. If your workspace lived on an **SSH box**, Orca skipped the question entirely and decided from its own local notes. Local notes don't observe a remote process — so a pane could be torn down with no evidence at all from the host that owns it.

This PR makes an SSH workspace answer the same question, through the route SSH actually has: the client's own runtime, which is where the relay provider is registered. If that answer doesn't arrive — or arrives without covering the SSH host — nothing hibernates.

## Observed symptom

Real execution against a live Linux SSH target: a workspace with `hostId: 'ssh:…'` received **0 `terminal.list` calls and 5 hibernation shutdowns**.

Reproduced in a unit test before any change (`agent-hibernation-ssh-host-evidence.test.ts` on unmodified base): with `window.api.runtime.call` rejecting every request, the coordinator issued **0 `terminal.list` calls** and performed **5 shutdowns** across 5 idle done-agent panes. 9 of the 10 new tests fail on the unmodified base.

**This is pre-existing.** It reproduces identically on base `d0506bf5de` and is independent of #19391 (`nwparker/perf-hibernation-inventory-20260907`) — this branch is cut from `main` and does not include or depend on it.

## Mechanism

- `getRuntimeLivenessTargetWorktrees` (`src/renderer/src/lib/agent-hibernation-coordinator.ts:99-116`, pre-fix) built the required-evidence set by keying on `getRuntimeEnvironmentIdForWorktree`.
- `getRuntimeEnvironmentIdForWorktree` (`src/renderer/src/lib/worktree-runtime-owner.ts:57-101`) returns `null` for an `ssh:` host — every branch that could return an id is `parsedHost?.kind === 'runtime' ? … : null`.
- So `ssh:` worktrees never entered `runtimeLivenessRequiredWorktreeIds`, and the gate at `src/renderer/src/lib/agent-hibernation-planner.ts:122-127` (pre-fix) never demanded host evidence for them.
- `getLivePtyIdsForTab` (`agent-hibernation-planner.ts:38-58`, pre-fix) then fell back to the renderer's `ptyIdsByTabId` — client bookkeeping, which observes no process. Per `docs/reference/ssh-execution-boundary.md`, "absence from a client-side set … [is] `unverifiable` by construction."

## Fix shape chosen: (a) — SSH *can* supply host evidence

I checked whether an `ssh:` host can produce the same fresh-liveness evidence a paired runtime does. It can, through a different route:

- `runtimeTargetForExecutionHostId` (`src/renderer/src/runtime/runtime-client-target.ts:14-25`) returns `null` for `ssh:` — "direct SSH cannot use this client path". An SSH box is a dumb execution host with no runtime RPC endpoint of its own.
- But its relay PTY provider is registered in **this client's** runtime. `listProcessesWithHostScopeFromRuntimeController` (`src/main/ipc/pty/runtime/inventory-operations.ts:24-52`) fans out to every registered provider including SSH relays, and `refreshPtyWorktreeRecordsWithControllerInventory` (`src/main/runtime/orca-runtime-refresh-pty-worktree-records-with-controller-inventory.ts:118-127`) folds the answering `ssh:` hosts into `queriedHostIds`.
- `terminal.list` with `requireFreshPtyLiveness: true` on the **local** runtime therefore reads the relay's current session map, and `hostScope.hostIds` names exactly the hosts that answered. This is not a silent substitution: the client's runtime is the *route to* the execution host, not a stand-in for it.

So the fix extends the required-set derivation to include `ssh:` worktrees and fetches their evidence through `{ kind: 'local' }`, exactly like runtime-owned ones. No behavior is lost for reachable SSH hosts (see the control test below), so there is **no outcome-(b) trade-off** to declare.

Two extra gates on the SSH path, both from the boundary doc:

1. **Scope coverage.** A worktree-scoped listing names every other host as omitted by design, so `hostScopeCensusIsComplete` is the wrong question. New `hostScopeCoveredExecutionHost` (`src/shared/runtime-listing-host-scope.ts`) asks the narrow one: did the workspace's own host answer? An absent `hostScope` is never coverage. This catches the case where the client's runtime lists its local PTYs while the relay never replied — an empty answer from a host that was not asked.
2. **No absence-to-`exited` mapping anywhere.** Every failure path (reject, timeout, truncated, uncovered scope, missing scope) omits the worktree from `runtimeLivePtyIdsByWorktreeId`, which makes the planner `continue` past the whole worktree. Absence means skip, never shutdown.

## Monotonicity argument

**Claim:** for every workspace, the post-fix candidate set is a subset of the pre-fix candidate set. No shutdown that did not happen before can newly happen.

`getEligiblePane` is unchanged; the only input that changed is `livePtyIds`, used solely as a membership filter on `pane.runtimePtyId` (which comes from the layout — client state — in both versions). So it suffices to show the live set never grows.

Per evidence mode (`LivePtyEvidenceMode`, one function, three branches — the modes cannot drift because there is a single `getLivePtyIdsForTab`):

- **`client`** (local workspaces, no host owner): `host ∪ client`, byte-identical to pre-fix. Only worktrees in the required set ever get a `host` entry, and those are never in this mode, so the union is `client`. **Unchanged.**
- **`host-authoritative`** (paired runtime): `host`, byte-identical to pre-fix. **Unchanged.**
- **`host-confirming`** (new, `ssh:` only): `host ∩ client ⊆ client` = the pre-fix set for these worktrees. Additionally the whole worktree is skipped whenever evidence is absent. **Strictly narrower.**

The intersection (rather than replacement) is deliberate and is what makes the claim structural rather than empirical: for SSH the client owns the pane-to-PTY binding — unlike a paired runtime, where the renderer's map is legitimately empty for remote panes — so the host only needs to *confirm* it. A test pins this: a host reporting a PTY the client never bound to the tab does not make the pane eligible (that test is the one of the ten that already passes pre-fix).

The set of worktrees requiring evidence only grows (`ssh:` added; nothing removed), so the fail-closed set only widens.

## Coverage

- **Folder workspaces** as well as git worktrees: the required-set derivation uses `getExecutionHostIdForWorktree`, which resolves `folder:` scopes through `getExecutionHostIdForFolderWorkspace`. Test: `requires host evidence for an SSH folder workspace too`.
- **Relay / paired-web topologies**: `window.api.runtime.call` exists in the web preload (`createWebRuntimeApi`, `src/renderer/src/web/web-preload-api.ts:78`) and proxies to the paired host, which is the process that owns the SSH providers. If it is unavailable the call throws and the workspace fails closed.

## Tests

New `src/renderer/src/lib/agent-hibernation-ssh-host-evidence.test.ts` (10 tests; 9 fail on the unmodified base):

| Test | Asserts |
| --- | --- |
| relay rejects every tick (5 panes) | 0 hibernations, host was asked |
| host listing never resolves | 0 hibernations |
| alternating good/failed flap | 0 hibernations |
| truncated listing | 0 hibernations |
| listing did not cover the SSH host | 0 hibernations |
| host too old to publish a scope | 0 hibernations |
| SSH folder workspace, relay down | 0 hibernations, host was asked |
| host reports a PTY the client never bound | 0 hibernations (monotonicity) |
| **control:** reachable host reports the pane PTY live | hibernates after two stable ticks, `requireFreshPtyLiveness: true` sent |
| host stops reporting the PTY between ticks | 0 hibernations |

Plus 5 unit tests for `hostScopeCoveredExecutionHost` in `src/shared/runtime-listing-host-scope.test.ts`.

Existing coordinator / planner / confirmation / visibility / pane-age / output-activity / host-scope / store-sleep suites: **140 passed**.

`oxlint` clean, `pnpm run check:code-quality:changed` clean (0 new findings across 7 files), `check:max-lines-ratchet` OK (no suppression added — the liveness collection was extracted to its own module `agent-hibernation-host-liveness.ts` instead), `typecheck:web` clean. No hibernation gate exists in `config/reliability-gates.jsonc` for these paths.

## Cost note

Requiring evidence means one worktree-scoped `terminal.list` on the client runtime per SSH workspace per hibernation tick (60s), mirroring what paired runtimes already do. Batching that inventory is #19391's concern and is deliberately not entangled here.
