### PR TITLE
fix(activity): show working agents under "unread only" by giving working turns a read receipt

### DIFF
--- a/src/renderer/src/components/activity/activity-event-build-cache.ts
+++ b/src/renderer/src/components/activity/activity-event-build-cache.ts
@@ -87,21 +87,19 @@ export function resolvePaneBuild(
     return { events: cached.events, live: cached.live }
   }
 
-  const events =
-    inputsUnchanged && liveMatchesCache
-      ? cached.events
-      : buildPaneActivityEvents({
-          entry: rowEntry,
-          worktree: request.worktree,
-          repo: request.repo,
-          tab: request.tab,
-          agentType: request.agentType,
-          agentAlive: request.agentAlive,
-          acknowledgedAt: request.acknowledgedAt,
-          clearedAt: request.clearedAt,
-          liveState: request.liveState,
-          migrationUnsupportedPtyId: request.migrationUnsupportedPtyId
-        })
+  // The live turn is itself an event, so a live change always rebuilds the pane's events.
+  const events = buildPaneActivityEvents({
+    entry: rowEntry,
+    worktree: request.worktree,
+    repo: request.repo,
+    tab: request.tab,
+    agentType: request.agentType,
+    agentAlive: request.agentAlive,
+    acknowledgedAt: request.acknowledgedAt,
+    clearedAt: request.clearedAt,
+    liveState: request.liveState,
+    migrationUnsupportedPtyId: request.migrationUnsupportedPtyId
+  })
   const live: ActivityLiveAgentSnapshot | null =
     request.liveState === null
       ? null

--- a/src/renderer/src/components/activity/useActivityUnreadCount.test.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.test.ts
@@ -114,13 +114,14 @@ describe('countActivityUnread source overlap', () => {
 })
 
 describe('countActivityUnread working turns', () => {
-  it('counts fresh working and monitoring, but not historical or retained working', () => {
+  it('counts fresh working, but not monitoring, historical, or retained working', () => {
     const entry = makeEntry({
       state: 'working',
       stateHistory: [{ state: 'working', prompt: 'old', startedAt: 1_000 }]
     })
     expect(countActivityUnread(makeSource(entry), 2_000)).toBe(1)
-    expect(countActivityUnread(makeSource({ ...entry, workingMode: 'monitoring' }), 2_000)).toBe(1)
+    // Monitoring emits no unread event in the list (4b2e3dded0), so the badge must not count it.
+    expect(countActivityUnread(makeSource({ ...entry, workingMode: 'monitoring' }), 2_000)).toBe(0)
     expect(
       countActivityUnread(
         {

--- a/src/renderer/src/components/activity/useActivityUnreadCount.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.ts
@@ -39,9 +39,11 @@ export function countActivityUnread(source: ActivityUnreadCountSource, now = Dat
       }
     }
     // Why: a session-boundary done is an idle connect (STA-3386), not an event to read.
+    // Why 'working' only: a monitoring turn surfaces through the live snapshot, never as an
+    // unread event, so counting it here would light the badge with no unread row to clear.
     if (
       (isHistoricalActivityState(entry.state) ||
-        (live && freshActivityLiveAgentState(entry, now) !== null)) &&
+        (live && freshActivityLiveAgentState(entry, now) === 'working')) &&
       entry.sessionBoundary !== true &&
       mutedAt < entry.stateStartedAt
     ) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Turn on "Show unread only" in the Activity view and every agent that is still working disappears. The filter keeps only threads you have not read, and a working turn never counted as something to read. This PR makes a working turn a turn like any other: unread when it starts, read once you look at it, and unread again when it finishes. Status groups also now sort by how much attention they need instead of by recency.

## What Changed

- **Working turns emit an activity event.** `ActivityEventState` widens from done/blocked/waiting to all agent states. A fresh live `working` turn appends one event with the same read receipt as every other event: `acknowledgedAt < stateStartedAt`. Heartbeats change `updatedAt`, never `stateStartedAt`, so acknowledging a running turn holds until the next turn starts.
- **Monitoring turns do not emit that event.** They surface only through the live snapshot, so a working event would contradict the snapshot signal.
- **Titlebar badge agrees with the list.** `countActivityUnread` counts fresh working turns, ignores monitoring, and subscribes to `agentStatusEpoch` rather than the status map. Same-turn heartbeats cannot change the count, and the live reducer already bumps the epoch when a stale entry revives.
- **Working events bypass the event cap.** They cannot evict a finished row from the 80-event window.
- **Status groups rank by attention.** Waiting, blocked, permission, interrupted, working, monitoring, unverifiable, failed, done, idle. `activityThreadStatusId` is the single classifier behind grouping, labels, and clear-completed.
- Freshness and state predicates move to `activity-event-state.ts`, shared by the event builder and the badge. A dead cached-events branch in the build cache is removed.

## Why

"Show unread only" is an inbox. A new item appears, a read item leaves, a state change brings it back. The alternative considered was a one-line filter change that keeps any live thread visible. That fails the most common action: you read a running agent's output and nothing happens, so the row sits in the unread-only view until the agent finishes with no way to dismiss it. Giving the working turn a receipt is the only model where the user can always act, and it matches how the sidebar and the ack store already treat each turn.

## Linked Issue

Fixes #

## Visual Proof

Pending. Before: enable "Show unread only" with an agent working; the row is absent. After: the row shows with a bell, and clicking it clears the bell and hides it until the turn finishes.

## Testing

- `pnpm test src/renderer/src/components/activity`: 34 files, 190 tests pass
- `pnpm test` on the agent-status store slices and UI slices: 220 tests pass
- `pnpm tc:web` clean, `oxlint` and `oxfmt` clean on changed files
- New tests: identity reuse across working, heartbeats, and the next turn; live-cap preservation with 82 panes; badge freshness through the real store slice (same-turn heartbeat, stale-boundary decay, revive on heartbeat, ack holds); status group ordering
- Tested on macOS. Logic is renderer-only and host-agnostic; the ack stamp is clamped to the turn timestamp so a remote host clock running ahead cannot leave a turn permanently unread.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Performance: the badge recompute is bounded by the live map cap (500) times the history cap (20) and runs only on status epoch bumps, acks, and clears, not on heartbeats. Per-heartbeat rebuild on the Activity page is unchanged in shape from main; one extra event object for the written pane.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
