### PR TITLE
feat(bitbucket): support merging and closing pull requests from checks panel

### DIFF
--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -583,8 +583,8 @@ breakaway hands the whole tree its escape. The per-PTY job therefore omits
 `BREAKAWAY_OK` whenever `msys-2.0.dll` or `cygwin1.dll` sits on the shell's DLL
 search path — beside the executable, or under `usr/bin` for Git's `bin`
 launcher. Native shells keep explicit breakaway. Denying it costs Cygwin
-nothing, because it *pre-checks* the limit rather than retrying, so no spawn
-fails; but a *native* program that passes `CREATE_BREAKAWAY_FROM_JOB` itself
+nothing, because it _pre-checks_ the limit rather than retrying, so no spawn
+fails; but a _native_ program that passes `CREATE_BREAKAWAY_FROM_JOB` itself
 inside such a pane now gets `ERROR_ACCESS_DENIED`. `nohup` and `disown` are
 unaffected — they are Cygwin signal/session concepts, unrelated to job
 membership. The daemon's host job is unchanged.

--- a/src/main/bitbucket/pull-request-merge.test.ts
+++ b/src/main/bitbucket/pull-request-merge.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  HostedReviewApiRequestError,
+  requestHostedReviewJson
+} from '../source-control/hosted-review-api-request'
+import { resolveBitbucketAuthConfig } from './resolve-auth'
+import { getBitbucketRepoRef } from './repository-ref'
+import { declineBitbucketPullRequest, mergeBitbucketPullRequest } from './pull-request-merge'
+import { invalidateHostedReviewBranchCache } from '../source-control/hosted-review-branch-cache'
+
+vi.mock('../source-control/hosted-review-api-request', () => ({
+  HostedReviewApiRequestError: class HostedReviewApiRequestError extends Error {
+    constructor(
+      message: string,
+      readonly status: number | null = null,
+      readonly timedOut = false
+    ) {
+      super(message)
+    }
+  },
+  requestHostedReviewJson: vi.fn()
+}))
+
+vi.mock('./resolve-auth', () => ({
+  resolveBitbucketAuthConfig: vi.fn()
+}))
+
+vi.mock('./repository-ref', () => ({
+  getBitbucketRepoRef: vi.fn()
+}))
+
+vi.mock('../source-control/hosted-review-branch-cache', () => ({
+  invalidateHostedReviewBranchCache: vi.fn()
+}))
+
+describe('mergeBitbucketPullRequest', () => {
+  const mockRepo = {
+    workspace: 'my-workspace',
+    repoSlug: 'my-repo'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'https://api.bitbucket.org/2.0',
+      accessToken: 'test-token',
+      email: null,
+      apiToken: null
+    })
+    vi.mocked(getBitbucketRepoRef).mockResolvedValue(mockRepo)
+  })
+
+  it('sends correct merge request with default method', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42)
+
+    expect(result).toEqual({ ok: true })
+    expect(requestHostedReviewJson).toHaveBeenCalledWith(
+      new URL(
+        'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/merge'
+      ),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          merge_strategy: 'merge_commit',
+          close_source_branch: true
+        })
+      }),
+      60_000
+    )
+  })
+
+  it('supports fast_forward merge method', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42, 'fast_forward', false)
+
+    expect(result).toEqual({ ok: true })
+    expect(requestHostedReviewJson).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        body: JSON.stringify({
+          merge_strategy: 'fast_forward',
+          close_source_branch: false
+        })
+      }),
+      expect.anything()
+    )
+  })
+
+  it('provides descriptive error when fast-forward is not possible', async () => {
+    vi.mocked(requestHostedReviewJson).mockRejectedValue(
+      new HostedReviewApiRequestError('Pull request cannot be fast forwarded', { status: 400 })
+    )
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42, 'fast_forward')
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Fast-forward merge not possible')
+    }
+  })
+
+  it('returns auth error when credentials are not configured', async () => {
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'https://api.bitbucket.org/2.0',
+      accessToken: null,
+      email: null,
+      apiToken: null
+    })
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42)
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'Merge failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
+    })
+  })
+
+  it('invalidates branch cache on successful merge', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await mergeBitbucketPullRequest(
+      '/repo/path',
+      42,
+      'merge_commit',
+      true,
+      'ssh:my-host'
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(getBitbucketRepoRef).toHaveBeenCalledWith('/repo/path', 'my-host', expect.anything())
+    expect(invalidateHostedReviewBranchCache).toHaveBeenCalledWith('/repo/path', 'ssh:my-host')
+  })
+
+  it('parses structured JSON error message from Bitbucket API', async () => {
+    vi.mocked(requestHostedReviewJson).mockRejectedValue(
+      new Error(
+        JSON.stringify({
+          error: { message: 'Branch permission prevented merge', detail: 'Needs 2 approvals' }
+        })
+      )
+    )
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42)
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Merge failed: Branch permission prevented merge: Needs 2 approvals'
+    })
+  })
+})
+
+describe('declineBitbucketPullRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'https://api.bitbucket.org/2.0',
+      accessToken: 'test-token',
+      email: null,
+      apiToken: null
+    })
+    vi.mocked(getBitbucketRepoRef).mockResolvedValue({
+      workspace: 'ws',
+      repoSlug: 'repo'
+    })
+  })
+
+  it('calls decline endpoint successfully and invalidates branch cache', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await declineBitbucketPullRequest('/repo/path', 10, 'ssh:remote-server')
+
+    expect(result).toEqual({ ok: true })
+    expect(getBitbucketRepoRef).toHaveBeenCalledWith(
+      '/repo/path',
+      'remote-server',
+      expect.anything()
+    )
+    expect(invalidateHostedReviewBranchCache).toHaveBeenCalledWith(
+      '/repo/path',
+      'ssh:remote-server'
+    )
+    expect(requestHostedReviewJson).toHaveBeenCalledWith(
+      new URL('https://api.bitbucket.org/2.0/repositories/ws/repo/pullrequests/10/decline'),
+      expect.objectContaining({ method: 'POST' }),
+      60_000
+    )
+  })
+})

--- a/src/main/bitbucket/pull-request-merge.test.ts
+++ b/src/main/bitbucket/pull-request-merge.test.ts
@@ -64,10 +64,28 @@ describe('mergeBitbucketPullRequest', () => {
         method: 'POST',
         body: JSON.stringify({
           merge_strategy: 'merge_commit',
-          close_source_branch: true
+          close_source_branch: false
         })
       }),
       60_000
+    )
+  })
+
+  it('allows closing source branch when explicitly requested', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42, 'merge_commit', true)
+
+    expect(result).toEqual({ ok: true })
+    expect(requestHostedReviewJson).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        body: JSON.stringify({
+          merge_strategy: 'merge_commit',
+          close_source_branch: true
+        })
+      }),
+      expect.anything()
     )
   })
 
@@ -117,6 +135,23 @@ describe('mergeBitbucketPullRequest', () => {
       error:
         'Merge failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
     })
+  })
+
+  it('rejects non-HTTPS Bitbucket API baseUrl for merge', async () => {
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'http://insecure-bitbucket.org/2.0',
+      accessToken: 'test-token',
+      email: null,
+      apiToken: null
+    })
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42)
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Merge failed: Bitbucket API URL must use HTTPS.'
+    })
+    expect(requestHostedReviewJson).not.toHaveBeenCalled()
   })
 
   it('invalidates branch cache on successful merge', async () => {
@@ -188,5 +223,22 @@ describe('declineBitbucketPullRequest', () => {
       expect.objectContaining({ method: 'POST' }),
       60_000
     )
+  })
+
+  it('rejects non-HTTPS Bitbucket API baseUrl for decline', async () => {
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'http://insecure-bitbucket.org/2.0',
+      accessToken: 'test-token',
+      email: null,
+      apiToken: null
+    })
+
+    const result = await declineBitbucketPullRequest('/repo/path', 10)
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Close failed: Bitbucket API URL must use HTTPS.'
+    })
+    expect(requestHostedReviewJson).not.toHaveBeenCalled()
   })
 })

--- a/src/main/bitbucket/pull-request-merge.ts
+++ b/src/main/bitbucket/pull-request-merge.ts
@@ -1,0 +1,215 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { hostedReviewSshConnectionId } from '../source-control/hosted-review-execution-host'
+import type { BitbucketPRMergeMethod } from '../../shared/bitbucket-merge-methods'
+import {
+  HostedReviewApiRequestError,
+  requestHostedReviewJson
+} from '../source-control/hosted-review-api-request'
+import { authHeaders, hasAuth } from './bitbucket-auth-config'
+import { resolveBitbucketAuthConfig } from './resolve-auth'
+import { getBitbucketRepoRef, type BitbucketRepoRef } from './repository-ref'
+import type { HostedReviewExecutionOptions } from '../source-control/hosted-review-git-options'
+import { getHostedReviewLocalGitOptions } from '../source-control/hosted-review-git-options'
+import { invalidateHostedReviewBranchCache } from '../source-control/hosted-review-branch-cache'
+
+const MERGE_REQUEST_TIMEOUT_MS = 60_000
+
+export type BitbucketMergeResult = { ok: true } | { ok: false; error: string }
+
+function encodedRepoPath(repo: BitbucketRepoRef): string {
+  return `${encodeURIComponent(repo.workspace)}/${encodeURIComponent(repo.repoSlug)}`
+}
+
+function apiErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    try {
+      const parsed = JSON.parse(error.message) as {
+        error?: { message?: string; detail?: string }
+        message?: string
+      }
+      if (parsed?.error?.message) {
+        return parsed.error.detail
+          ? `${parsed.error.message}: ${parsed.error.detail}`
+          : parsed.error.message
+      }
+      if (parsed?.message) {
+        return parsed.message
+      }
+    } catch {
+      // not JSON
+    }
+    return error.message
+  }
+  return String(error)
+}
+
+function classifyMergeError(error: unknown, method: BitbucketPRMergeMethod): BitbucketMergeResult {
+  const message = apiErrorMessage(error)
+  const lower = message.toLowerCase()
+  const status = error instanceof HostedReviewApiRequestError ? error.status : null
+
+  if (status === 401 || status === 403 || lower.includes('unauthorized')) {
+    return {
+      ok: false,
+      error: 'Merge failed: permission denied. Check your Bitbucket account permissions.'
+    }
+  }
+
+  if (
+    method === 'fast_forward' &&
+    (lower.includes('fast forward') || lower.includes('fast-forward'))
+  ) {
+    return {
+      ok: false,
+      error:
+        'Fast-forward merge not possible: the target branch has new commits. Rebase your branch or use merge commit.'
+    }
+  }
+
+  if (lower.includes('conflict') || lower.includes('merge conflict')) {
+    return {
+      ok: false,
+      error: 'Merge failed: this pull request has merge conflicts that must be resolved first.'
+    }
+  }
+
+  if (status === 404) {
+    return {
+      ok: false,
+      error: 'Merge failed: pull request or repository not found.'
+    }
+  }
+
+  if (status === 409 || lower.includes('already merged') || lower.includes('not open')) {
+    return {
+      ok: false,
+      error: 'Merge failed: this pull request is no longer open.'
+    }
+  }
+
+  return {
+    ok: false,
+    error: message
+      ? `Merge failed: ${message}`
+      : 'Merge failed: Bitbucket could not complete the request.'
+  }
+}
+
+export async function mergeBitbucketPullRequest(
+  repoPath: string,
+  prNumber: number,
+  method: BitbucketPRMergeMethod = 'merge_commit',
+  closeSourceBranch = true,
+  executionHostId: ExecutionHostId = 'local',
+  options: HostedReviewExecutionOptions = {}
+): Promise<BitbucketMergeResult> {
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
+  const config = resolveBitbucketAuthConfig()
+
+  if (!hasAuth(config)) {
+    return {
+      ok: false,
+      error:
+        'Merge failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
+    }
+  }
+
+  const repo = await getBitbucketRepoRef(
+    repoPath,
+    connectionId,
+    getHostedReviewLocalGitOptions(options)
+  )
+  if (!repo) {
+    return {
+      ok: false,
+      error: 'Merging pull requests requires a Bitbucket remote.'
+    }
+  }
+
+  const url = new URL(
+    `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/merge`
+  )
+
+  const body = {
+    merge_strategy: method,
+    close_source_branch: closeSourceBranch
+  }
+
+  try {
+    await requestHostedReviewJson(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          ...authHeaders(config)
+        },
+        body: JSON.stringify(body)
+      },
+      MERGE_REQUEST_TIMEOUT_MS
+    )
+    invalidateHostedReviewBranchCache(repoPath, executionHostId)
+    return { ok: true }
+  } catch (error) {
+    return classifyMergeError(error, method)
+  }
+}
+
+export async function declineBitbucketPullRequest(
+  repoPath: string,
+  prNumber: number,
+  executionHostId: ExecutionHostId = 'local',
+  options: HostedReviewExecutionOptions = {}
+): Promise<BitbucketMergeResult> {
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
+  const config = resolveBitbucketAuthConfig()
+
+  if (!hasAuth(config)) {
+    return {
+      ok: false,
+      error:
+        'Close failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
+    }
+  }
+
+  const repo = await getBitbucketRepoRef(
+    repoPath,
+    connectionId,
+    getHostedReviewLocalGitOptions(options)
+  )
+  if (!repo) {
+    return {
+      ok: false,
+      error: 'Closing pull requests requires a Bitbucket remote.'
+    }
+  }
+
+  const url = new URL(
+    `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/decline`
+  )
+
+  try {
+    await requestHostedReviewJson(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          ...authHeaders(config)
+        }
+      },
+      MERGE_REQUEST_TIMEOUT_MS
+    )
+    invalidateHostedReviewBranchCache(repoPath, executionHostId)
+    return { ok: true }
+  } catch (error) {
+    const message = apiErrorMessage(error)
+    return {
+      ok: false,
+      error: message
+        ? `Close failed: ${message}`
+        : 'Close failed: Bitbucket could not complete the request.'
+    }
+  }
+}

--- a/src/main/bitbucket/pull-request-merge.ts
+++ b/src/main/bitbucket/pull-request-merge.ts
@@ -99,7 +99,7 @@ export async function mergeBitbucketPullRequest(
   repoPath: string,
   prNumber: number,
   method: BitbucketPRMergeMethod = 'merge_commit',
-  closeSourceBranch = true,
+  closeSourceBranch = false,
   executionHostId: ExecutionHostId = 'local',
   options: HostedReviewExecutionOptions = {}
 ): Promise<BitbucketMergeResult> {
@@ -129,6 +129,12 @@ export async function mergeBitbucketPullRequest(
   const url = new URL(
     `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/merge`
   )
+  if (url.protocol !== 'https:') {
+    return {
+      ok: false,
+      error: 'Merge failed: Bitbucket API URL must use HTTPS.'
+    }
+  }
 
   const body = {
     merge_strategy: method,
@@ -188,6 +194,12 @@ export async function declineBitbucketPullRequest(
   const url = new URL(
     `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/decline`
   )
+  if (url.protocol !== 'https:') {
+    return {
+      ok: false,
+      error: 'Close failed: Bitbucket API URL must use HTTPS.'
+    }
+  }
 
   try {
     await requestHostedReviewJson(

--- a/src/main/ipc/bitbucket.ts
+++ b/src/main/ipc/bitbucket.ts
@@ -8,6 +8,7 @@ import {
   type BitbucketConnectResult,
   type BitbucketConnectionStatus
 } from '../bitbucket/credential-connection'
+import type { BitbucketPRMergeMethod } from '../../shared/bitbucket-merge-methods'
 import { _resetPreflightCache } from './preflight'
 
 function optionalString(value: unknown): string | null {
@@ -65,7 +66,7 @@ export function registerBitbucketHandlers(): void {
       args: {
         repoPath: string
         prNumber: number
-        method?: 'merge_commit' | 'squash' | 'fast_forward'
+        method?: BitbucketPRMergeMethod
         closeSourceBranch?: boolean
         executionHostId?: ExecutionHostId
       }

--- a/src/main/ipc/bitbucket.ts
+++ b/src/main/ipc/bitbucket.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron'
+import type { ExecutionHostId } from '../../shared/execution-host'
 import {
   connectBitbucket,
   disconnectBitbucket,
@@ -56,4 +57,38 @@ export function registerBitbucketHandlers(): void {
   ipcMain.handle('bitbucket:status', async (): Promise<BitbucketConnectionStatus> => {
     return getBitbucketConnectionStatus()
   })
+
+  ipcMain.handle(
+    'bitbucket:mergePR',
+    async (
+      _event,
+      args: {
+        repoPath: string
+        prNumber: number
+        method?: 'merge_commit' | 'squash' | 'fast_forward'
+        closeSourceBranch?: boolean
+        executionHostId?: ExecutionHostId
+      }
+    ) => {
+      const { mergeBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+      return mergeBitbucketPullRequest(
+        args.repoPath,
+        args.prNumber,
+        args.method,
+        args.closeSourceBranch,
+        args.executionHostId
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'bitbucket:closePR',
+    async (
+      _event,
+      args: { repoPath: string; prNumber: number; executionHostId?: ExecutionHostId }
+    ) => {
+      const { declineBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+      return declineBitbucketPullRequest(args.repoPath, args.prNumber, args.executionHostId)
+    }
+  )
 }

--- a/src/main/source-control/hosted-review-bitbucket.integration.test.ts
+++ b/src/main/source-control/hosted-review-bitbucket.integration.test.ts
@@ -210,4 +210,105 @@ describe('Bitbucket hosted review integration', () => {
       })
     }
   })
+
+  it('merges a Bitbucket PR with fast_forward strategy over HTTP', async () => {
+    let receivedMethod: string | null = null
+    let receivedCloseBranch: boolean | null = null
+    let receivedAuth: string | undefined
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
+      receivedAuth = req.headers.authorization
+
+      if (url.pathname === '/2.0/repositories/team/repo/pullrequests/42/merge') {
+        let body = ''
+        req.on('data', (chunk) => {
+          body += chunk
+        })
+        req.on('end', () => {
+          const parsed = JSON.parse(body) as {
+            merge_strategy: string
+            close_source_branch: boolean
+          }
+          receivedMethod = parsed.merge_strategy
+          receivedCloseBranch = parsed.close_source_branch
+          sendJson(res, { id: 42, state: 'MERGED' })
+        })
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ message: 'not found' }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    const repoPath = await mkdtemp(join(tmpdir(), 'orca-bitbucket-merge-'))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('expected TCP server address')
+      }
+
+      process.env.ORCA_BITBUCKET_API_BASE_URL = `http://127.0.0.1:${address.port}/2.0`
+      await execFileAsync('git', ['init'], { cwd: repoPath })
+      await execFileAsync('git', ['remote', 'add', 'origin', 'git@bitbucket.org:team/repo.git'], {
+        cwd: repoPath
+      })
+
+      const { mergeBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+      const result = await mergeBitbucketPullRequest(repoPath, 42, 'fast_forward', true)
+
+      expect(result).toEqual({ ok: true })
+      expect(receivedMethod).toBe('fast_forward')
+      expect(receivedCloseBranch).toBe(true)
+      expect(receivedAuth).toBe('Bearer local-token')
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+
+  it('declines a Bitbucket PR over HTTP', async () => {
+    let declinedPath: string | null = null
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
+      if (url.pathname === '/2.0/repositories/team/repo/pullrequests/42/decline') {
+        declinedPath = url.pathname
+        sendJson(res, { id: 42, state: 'DECLINED' })
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ message: 'not found' }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    const repoPath = await mkdtemp(join(tmpdir(), 'orca-bitbucket-decline-'))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('expected TCP server address')
+      }
+
+      process.env.ORCA_BITBUCKET_API_BASE_URL = `http://127.0.0.1:${address.port}/2.0`
+      await execFileAsync('git', ['init'], { cwd: repoPath })
+      await execFileAsync('git', ['remote', 'add', 'origin', 'git@bitbucket.org:team/repo.git'], {
+        cwd: repoPath
+      })
+
+      const { declineBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+      const result = await declineBitbucketPullRequest(repoPath, 42)
+
+      expect(result).toEqual({ ok: true })
+      expect(declinedPath).toBe('/2.0/repositories/team/repo/pullrequests/42/decline')
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
 })

--- a/src/preload/api/bitbucket-bridge.ts
+++ b/src/preload/api/bitbucket-bridge.ts
@@ -13,5 +13,9 @@ export const bitbucketApi = {
 
   disconnect: (): Promise<void> => ipcRenderer.invoke('bitbucket:disconnect'),
 
-  status: () => ipcRenderer.invoke('bitbucket:status')
+  status: () => ipcRenderer.invoke('bitbucket:status'),
+
+  mergePR: (args) => ipcRenderer.invoke('bitbucket:mergePR', args),
+
+  closePR: (args) => ipcRenderer.invoke('bitbucket:closePR', args)
 } satisfies PreloadApi['bitbucket']

--- a/src/preload/api/hosted-review-api.ts
+++ b/src/preload/api/hosted-review-api.ts
@@ -2,6 +2,8 @@ import type {
   BitbucketConnectArgs,
   BitbucketConnectionStatus
 } from '../../shared/bitbucket-credentials'
+import type { BitbucketPRMergeMethod } from '../../shared/bitbucket-merge-methods'
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type {
   CreateHostedReviewArgs,
   CreateHostedReviewResult,
@@ -28,4 +30,16 @@ export type BitbucketApi = {
   ) => Promise<{ ok: true; account: string | null } | { ok: false; error: string }>
   disconnect: () => Promise<void>
   status: () => Promise<BitbucketConnectionStatus>
+  mergePR: (args: {
+    repoPath: string
+    prNumber: number
+    method?: BitbucketPRMergeMethod
+    closeSourceBranch?: boolean
+    executionHostId?: ExecutionHostId
+  }) => Promise<{ ok: true } | { ok: false; error: string }>
+  closePR: (args: {
+    repoPath: string
+    prNumber: number
+    executionHostId?: ExecutionHostId
+  }) => Promise<{ ok: true } | { ok: false; error: string }>
 }

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
@@ -154,6 +154,6 @@ describe('ChecksPanelReviewHeader', () => {
     expect(markup).toContain(
       'Orca will hide PR #12 details for this workspace. The PR and branch on Bitbucket won’t be changed.'
     )
-    expect(markup).toContain('Link another PR')
+    expect(markup).not.toContain('Link another PR')
   })
 })

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
@@ -40,20 +40,27 @@ function renderHeader({
   modifierHintDestination = 'system-browser'
 }: {
   canUnlinkReview?: boolean
-  provider?: 'github' | 'gitlab'
+  provider?: 'github' | 'gitlab' | 'bitbucket'
   modifierHintDestination?: ChecksPanelHostedReviewModifierDestination
 } = {}): string {
   const isGitLab = provider === 'gitlab'
+  const isBitbucket = provider === 'bitbucket'
   return renderToStaticMarkup(
     <ChecksPanelReviewHeader
       review={{
         provider,
-        number: isGitLab ? 31 : 2964,
-        title: isGitLab ? 'Fix GitLab MR creation' : 'fix: pr-bug-scan validated finding',
+        number: isGitLab ? 31 : isBitbucket ? 12 : 2964,
+        title: isGitLab
+          ? 'Fix GitLab MR creation'
+          : isBitbucket
+            ? 'Fix Bitbucket PR'
+            : 'fix: pr-bug-scan validated finding',
         state: 'open',
         url: isGitLab
           ? 'https://gitlab.com/acme/orca/-/merge_requests/31'
-          : 'https://github.com/stablyai/orca/pull/2964',
+          : isBitbucket
+            ? 'https://bitbucket.org/acme/orca/pull-requests/12'
+            : 'https://github.com/stablyai/orca/pull/2964',
         status: 'pending',
         updatedAt: '2026-05-31T22:58:01Z',
         mergeable: 'UNKNOWN'
@@ -135,5 +142,18 @@ describe('ChecksPanelReviewHeader', () => {
       'Orca will hide MR !31 details for this workspace. The MR and branch on GitLab won’t be changed.'
     )
     expect(markup).toContain('Link another MR')
+  })
+
+  it('shows Bitbucket PR identity with provider-appropriate link management actions', () => {
+    const markup = renderHeader({ provider: 'bitbucket' })
+
+    expect(markup).toContain('Open on Bitbucket')
+    expect(markup).toContain('#12')
+    expect(markup).toContain('More PR actions')
+    expect(markup).toContain('Unlink PR from workspace')
+    expect(markup).toContain(
+      'Orca will hide PR #12 details for this workspace. The PR and branch on Bitbucket won’t be changed.'
+    )
+    expect(markup).toContain('Link another PR')
   })
 })

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -134,18 +134,20 @@ export function ChecksPanelReviewHeader({
             disabled={!canUnlinkReview}
             onSelect={onUnlinkReview}
           />
-          <DropdownMenuItem onSelect={onLinkAnotherReview}>
-            <Link className="size-3.5" />
-            {review.provider === 'gitlab'
-              ? translate(
-                  'auto.components.right.sidebar.ChecksPanel.gitlabLinkAnother',
-                  'Link another MR'
-                )
-              : translate(
-                  'auto.components.right.sidebar.ChecksPanel.07871c0589',
-                  'Link another PR'
-                )}
-          </DropdownMenuItem>
+          {review.provider !== 'bitbucket' && (
+            <DropdownMenuItem onSelect={onLinkAnotherReview}>
+              <Link className="size-3.5" />
+              {review.provider === 'gitlab'
+                ? translate(
+                    'auto.components.right.sidebar.ChecksPanel.gitlabLinkAnother',
+                    'Link another MR'
+                  )
+                : translate(
+                    'auto.components.right.sidebar.ChecksPanel.07871c0589',
+                    'Link another PR'
+                  )}
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -62,7 +62,12 @@ export function ChecksPanelReviewHeader({
 }: ChecksPanelReviewHeaderProps): React.JSX.Element {
   const reviewNumberLabel = review.provider === 'gitlab' ? `!${review.number}` : `#${review.number}`
   const ReviewIcon = review.provider === 'gitlab' ? GitMerge : PullRequestIcon
-  const reviewHostLabel = review.provider === 'gitlab' ? 'GitLab' : 'GitHub'
+  const reviewHostLabel =
+    review.provider === 'gitlab'
+      ? 'GitLab'
+      : review.provider === 'bitbucket'
+        ? 'Bitbucket'
+        : 'GitHub'
   const moreActionsLabel =
     review.provider === 'gitlab'
       ? translate('auto.components.right.sidebar.ChecksPanel.gitlabMoreActions', 'More MR actions')

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.bitbucket.test.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.bitbucket.test.tsx
@@ -54,26 +54,6 @@ describe('HostedReviewActions Bitbucket integration', () => {
     expect(html).toContain('Close')
   })
 
-  it('renders merge blocked when Bitbucket PR has conflicts', () => {
-    const html = renderToStaticMarkup(
-      <HostedReviewActions
-        review={{
-          provider: 'bitbucket',
-          number: 42,
-          state: 'open',
-          status: 'failure',
-          mergeable: 'CONFLICTING'
-        }}
-        repo={repo}
-        worktree={worktree}
-        onRefreshReview={vi.fn().mockResolvedValue(undefined)}
-      />
-    )
-
-    expect(html).toContain('Merge blocked')
-    expect(html).toContain('merge conflicts')
-  })
-
   it('renders delete workspace button for closed/declined Bitbucket PR', () => {
     const html = renderToStaticMarkup(
       <HostedReviewActions

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.bitbucket.test.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.bitbucket.test.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import HostedReviewActions from './HostedReviewActions'
+
+vi.mock('@/store', () => ({ useAppStore: () => false }))
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => vi.fn()
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+const repo = { id: 'repo-1', path: '/repo' } as Repo
+const worktree = { id: 'worktree-1' } as Worktree
+
+describe('HostedReviewActions Bitbucket integration', () => {
+  it('renders merge button and split options for open Bitbucket PR', () => {
+    const html = renderToStaticMarkup(
+      <HostedReviewActions
+        review={{
+          provider: 'bitbucket',
+          number: 42,
+          state: 'open',
+          status: 'success',
+          mergeable: 'UNKNOWN'
+        }}
+        repo={repo}
+        worktree={worktree}
+        onRefreshReview={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    // Primary button should show default merge label
+    expect(html).toContain('Create merge commit')
+    // Dropdown should contain all Bitbucket merge methods
+    expect(html).toContain('Squash and merge')
+    expect(html).toContain('Fast-forward merge')
+    // Dropdown should contain Close PR
+    expect(html).toContain('Close')
+  })
+
+  it('renders merge blocked when Bitbucket PR has conflicts', () => {
+    const html = renderToStaticMarkup(
+      <HostedReviewActions
+        review={{
+          provider: 'bitbucket',
+          number: 42,
+          state: 'open',
+          status: 'failure',
+          mergeable: 'CONFLICTING'
+        }}
+        repo={repo}
+        worktree={worktree}
+        onRefreshReview={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    expect(html).toContain('Merge blocked')
+    expect(html).toContain('merge conflicts')
+  })
+
+  it('renders delete workspace button for closed/declined Bitbucket PR', () => {
+    const html = renderToStaticMarkup(
+      <HostedReviewActions
+        review={{
+          provider: 'bitbucket',
+          number: 42,
+          state: 'closed',
+          status: 'neutral',
+          mergeable: 'UNKNOWN'
+        }}
+        repo={repo}
+        worktree={worktree}
+        onRefreshReview={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    expect(html).toContain('Delete Workspace')
+    expect(html).not.toContain('Reopen')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -15,10 +15,13 @@ import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
 import type { PRInfo } from '../../../../shared/github/pull-request-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { resolveGitHubPRMergeMethods } from '../../../../shared/github/pull-request-merge-methods'
 import { runWorktreeDelete } from '../sidebar/delete-worktree-flow'
 import { getDeleteStateForWorktreeHost } from '../sidebar/worktree-delete-state-host-match'
 import { presentGitLabMRMergeState } from './gitlab-mr-merge-state'
+import { presentBitbucketPRMergeState } from './bitbucket-pr-merge-state'
+import { resolveBitbucketPRMergeMethods } from '../../../../shared/bitbucket-merge-methods'
 import {
   ClosedReviewActions,
   DraftReviewActions,
@@ -55,6 +58,7 @@ export default function HostedReviewActions({
     (s) => getDeleteStateForWorktreeHost(worktree, s.deleteStateByWorktreeId)?.isDeleting ?? false
   )
   const isGitLab = review.provider === 'gitlab'
+  const isBitbucket = review.provider === 'bitbucket'
   const shortLabel = isGitLab ? 'MR' : 'PR'
   const reviewLabel = isGitLab ? 'merge request' : 'pull request'
   const stackMergeScope = useMemo(
@@ -82,6 +86,9 @@ export default function HostedReviewActions({
   const mergePresentation = useMemo(() => {
     if (isGitLab) {
       return { ...presentGitLabMRMergeState(review), autoMergeAction: null }
+    }
+    if (isBitbucket) {
+      return { ...presentBitbucketPRMergeState(review), autoMergeAction: null }
     }
     const presentation = presentGitHubPRMergeState({
       ...githubPR,
@@ -117,11 +124,24 @@ export default function HostedReviewActions({
         (stackMergeScope.complete || presentation.directMergeAvailable || stackUsesMergeQueue),
       autoMergeAction: null
     }
-  }, [githubPR, isGitLab, review, stackMergeLabel, stackMergeScope, stackUsesMergeQueue])
-  const mergeMethods = useMemo(
-    () => resolveGitHubPRMergeMethods(isGitLab ? null : (githubPR?.mergeMethodSettings ?? null)),
-    [githubPR?.mergeMethodSettings, isGitLab]
-  )
+  }, [
+    githubPR,
+    isBitbucket,
+    isGitLab,
+    review,
+    stackMergeLabel,
+    stackMergeScope,
+    stackUsesMergeQueue
+  ])
+  const mergeMethods = useMemo(() => {
+    if (isGitLab) {
+      return resolveGitHubPRMergeMethods(null)
+    }
+    if (isBitbucket) {
+      return resolveBitbucketPRMergeMethods()
+    }
+    return resolveGitHubPRMergeMethods(githubPR?.mergeMethodSettings ?? null)
+  }, [githubPR?.mergeMethodSettings, isBitbucket, isGitLab])
   const {
     merging,
     readying,
@@ -136,7 +156,9 @@ export default function HostedReviewActions({
     review,
     githubPR,
     repo,
+    executionHostId: (worktree.hostId ?? repo.executionHostId ?? 'local') as ExecutionHostId,
     isGitLab,
+    isBitbucket,
     shortLabel,
     reviewLabel,
     defaultMergeMethod: mergeMethods.defaultMethod,
@@ -313,6 +335,14 @@ export default function HostedReviewActions({
   }
 
   if (review.state === 'closed') {
+    if (isBitbucket) {
+      return (
+        <MergedReviewActions
+          isDeletingWorktree={isDeletingWorktree}
+          onDeleteWorktree={handleDeleteWorktree}
+        />
+      )
+    }
     return (
       <ClosedReviewActions
         shortLabel={shortLabel}

--- a/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { presentBitbucketPRMergeState } from './bitbucket-pr-merge-state'
+
+describe('presentBitbucketPRMergeState', () => {
+  it('returns directMergeAvailable true for open review', () => {
+    const state = presentBitbucketPRMergeState({
+      state: 'open',
+      status: 'success',
+      mergeable: 'UNKNOWN'
+    })
+    expect(state.directMergeAvailable).toBe(true)
+    expect(state.label).toBe('Merge pull request')
+  })
+
+  it('blocks merge for conflicting review', () => {
+    const state = presentBitbucketPRMergeState({
+      state: 'open',
+      status: 'success',
+      mergeable: 'CONFLICTING'
+    })
+    expect(state.directMergeAvailable).toBe(false)
+    expect(state.label).toBe('Merge blocked')
+    expect(state.tooltip).toContain('merge conflicts')
+  })
+
+  it('handles closed review', () => {
+    const state = presentBitbucketPRMergeState({
+      state: 'closed',
+      status: 'neutral',
+      mergeable: 'UNKNOWN'
+    })
+    expect(state.directMergeAvailable).toBe(false)
+    expect(state.label).toBe('Declined')
+  })
+
+  it('handles merged review', () => {
+    const state = presentBitbucketPRMergeState({
+      state: 'merged',
+      status: 'success',
+      mergeable: 'UNKNOWN'
+    })
+    expect(state.directMergeAvailable).toBe(false)
+    expect(state.label).toBe('Merged')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.test.ts
@@ -12,17 +12,6 @@ describe('presentBitbucketPRMergeState', () => {
     expect(state.label).toBe('Merge pull request')
   })
 
-  it('blocks merge for conflicting review', () => {
-    const state = presentBitbucketPRMergeState({
-      state: 'open',
-      status: 'success',
-      mergeable: 'CONFLICTING'
-    })
-    expect(state.directMergeAvailable).toBe(false)
-    expect(state.label).toBe('Merge blocked')
-    expect(state.tooltip).toContain('merge conflicts')
-  })
-
   it('handles closed review', () => {
     const state = presentBitbucketPRMergeState({
       state: 'closed',

--- a/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.ts
+++ b/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.ts
@@ -34,20 +34,6 @@ export function presentBitbucketPRMergeState(
     }
   }
 
-  if (review.mergeable === 'CONFLICTING') {
-    return {
-      label: translate(
-        'auto.components.right.sidebar.bitbucket.pr.merge.state.conflicts',
-        'Merge blocked'
-      ),
-      tooltip: translate(
-        'auto.components.right.sidebar.bitbucket.pr.merge.state.conflictsTooltip',
-        'Bitbucket reports merge conflicts that must be resolved before merging'
-      ),
-      directMergeAvailable: false
-    }
-  }
-
   return {
     label: translate(
       'auto.components.right.sidebar.bitbucket.pr.merge.state.merge',

--- a/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.ts
+++ b/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.ts
@@ -1,0 +1,59 @@
+import type { HostedReviewInfo } from '../../../../shared/hosted-review'
+import { translate } from '@/i18n/i18n'
+
+type BitbucketPRMergeStateReview = Pick<HostedReviewInfo, 'state' | 'status' | 'mergeable'>
+
+type MergePresentation = {
+  label: string
+  tooltip: string
+  directMergeAvailable: boolean
+}
+
+export function presentBitbucketPRMergeState(
+  review: BitbucketPRMergeStateReview
+): MergePresentation {
+  if (review.state === 'closed') {
+    return {
+      label: translate('auto.components.right.sidebar.bitbucket.pr.merge.state.closed', 'Declined'),
+      tooltip: translate(
+        'auto.components.right.sidebar.bitbucket.pr.merge.state.closedTooltip',
+        'This pull request is declined'
+      ),
+      directMergeAvailable: false
+    }
+  }
+
+  if (review.state === 'merged') {
+    return {
+      label: translate('auto.components.right.sidebar.bitbucket.pr.merge.state.merged', 'Merged'),
+      tooltip: translate(
+        'auto.components.right.sidebar.bitbucket.pr.merge.state.mergedTooltip',
+        'This pull request is already merged'
+      ),
+      directMergeAvailable: false
+    }
+  }
+
+  if (review.mergeable === 'CONFLICTING') {
+    return {
+      label: translate(
+        'auto.components.right.sidebar.bitbucket.pr.merge.state.conflicts',
+        'Merge blocked'
+      ),
+      tooltip: translate(
+        'auto.components.right.sidebar.bitbucket.pr.merge.state.conflictsTooltip',
+        'Bitbucket reports merge conflicts that must be resolved before merging'
+      ),
+      directMergeAvailable: false
+    }
+  }
+
+  return {
+    label: translate(
+      'auto.components.right.sidebar.bitbucket.pr.merge.state.merge',
+      'Merge pull request'
+    ),
+    tooltip: '',
+    directMergeAvailable: true
+  }
+}

--- a/src/renderer/src/components/right-sidebar/checks-panel-review.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-review.test.ts
@@ -30,6 +30,20 @@ function makeGitLabReview(overrides: Partial<HostedReviewInfo> = {}): HostedRevi
   }
 }
 
+function makeBitbucketReview(overrides: Partial<HostedReviewInfo> = {}): HostedReviewInfo {
+  return {
+    provider: 'bitbucket',
+    number: 15,
+    title: 'Bitbucket PR',
+    state: 'open',
+    url: 'https://bitbucket.org/acme/widgets/pull-requests/15',
+    status: 'pending',
+    updatedAt: '2026-06-02T00:00:00Z',
+    mergeable: 'UNKNOWN',
+    ...overrides
+  }
+}
+
 describe('gitHubPRToChecksPanelReview', () => {
   // Why: the right-sidebar merge presenter reads these fields off the converted
   // review object. PR #4001 dropped them here, so review-required/merge-queue
@@ -73,6 +87,23 @@ describe('selectChecksPanelReview', () => {
         suppressedGitHubPR: null,
         linkedGitLabMR: 34,
         linkedBitbucketPR: null,
+        linkedAzureDevOpsPR: null,
+        linkedGiteaPR: null
+      })
+    ).toBe(review)
+  })
+
+  it('uses Bitbucket hosted review metadata ahead of GitHub PR cache', () => {
+    const review = makeBitbucketReview({ number: 56 })
+
+    expect(
+      selectChecksPanelReview({
+        hostedReview: review,
+        pr: makePR({ number: 12 }),
+        linkedPR: null,
+        suppressedGitHubPR: null,
+        linkedGitLabMR: null,
+        linkedBitbucketPR: 56,
         linkedAzureDevOpsPR: null,
         linkedGiteaPR: null
       })

--- a/src/renderer/src/components/right-sidebar/checks-panel-review.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-review.ts
@@ -32,9 +32,12 @@ export function selectChecksPanelReview({
   linkedAzureDevOpsPR,
   linkedGiteaPR
 }: ChecksPanelReviewSelectionInput): ChecksPanelReview | null {
-  const gitLabHostedReview = hostedReview?.provider === 'gitlab' ? hostedReview : null
-  if (gitLabHostedReview) {
-    return gitLabHostedReview
+  const supportedHostedReview =
+    hostedReview?.provider === 'gitlab' || hostedReview?.provider === 'bitbucket'
+      ? hostedReview
+      : null
+  if (supportedHostedReview) {
+    return supportedHostedReview
   }
   const hasNonGitHubLinkedReview =
     linkedGitLabMR !== null ||

--- a/src/renderer/src/components/right-sidebar/checks-panel/active-content-props.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel/active-content-props.ts
@@ -47,6 +47,7 @@ export type ChecksPanelActiveContentModel = Pick<
     | 'activeGitLabReview'
     | 'activeReview'
     | 'linkedGitLabMR'
+    | 'linkedBitbucketPR'
     | 'pr'
     | 'prRefreshState'
     | 'setChecksPanelContentRef'

--- a/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
@@ -87,6 +87,7 @@ export function ChecksPanelActiveContent({
     isRefreshing,
     isResolvingConflictsWithAI,
     linkedGitLabMR,
+    linkedBitbucketPR,
     pendingCommentResolutionRef,
     pr,
     prRefreshState,
@@ -131,7 +132,15 @@ export function ChecksPanelActiveContent({
         <ReviewHeaderComponent
           review={activeReview}
           isRefreshing={isRefreshing}
-          canUnlinkReview={activeReview.provider === 'github' ? true : linkedGitLabMR !== null}
+          canUnlinkReview={
+            activeReview.provider === 'github'
+              ? true
+              : activeReview.provider === 'gitlab'
+                ? linkedGitLabMR !== null
+                : activeReview.provider === 'bitbucket'
+                  ? linkedBitbucketPR !== null
+                  : false
+          }
           modifierHintDestination={hostedReviewModifierHintDestination}
           onRefresh={() => void handleRefresh()}
           onOpenReview={handleOpenPR}
@@ -238,36 +247,39 @@ export function ChecksPanelActiveContent({
         </>
       )}
       {/* Why: with merge conflicts and no checks fetched, "No checks configured" is misleading — checks can't run until conflicts resolve. */}
-      {!(activeConflictReview && checks.length === 0 && !checksLoading) && (
-        <ChecksList
-          checks={checks}
-          checksLoading={checksLoading}
-          checkDetailsContextKey={stateRequestKey}
-          onLoadCheckDetails={handleLoadCheckDetails}
-          githubRepository={pr?.prRepo ?? null}
-          getGitLabProjectRef={getGitLabProjectRef}
+      {!(activeConflictReview && checks.length === 0 && !checksLoading) &&
+        (activeReview.provider !== 'bitbucket' || checks.length > 0) && (
+          <ChecksList
+            checks={checks}
+            checksLoading={checksLoading}
+            checkDetailsContextKey={stateRequestKey}
+            onLoadCheckDetails={handleLoadCheckDetails}
+            githubRepository={pr?.prRepo ?? null}
+            getGitLabProjectRef={getGitLabProjectRef}
+          />
+        )}
+      {activeReview.provider !== 'bitbucket' && (
+        <PRCommentsList
+          comments={comments}
+          commentsLoading={commentsLoading}
+          reviewKind={reviewShortLabel}
+          commentsDisabled={!canTargetPRComments}
+          commentsDisabledReason={commentsDisabledReason}
+          selectionContextKey={stateRequestKey}
+          selectionClearRequest={commentsSelectionClearRequest}
+          resolveCommentsWithAIDisabled={Boolean(resolveCommentsWithAIDisabledReason)}
+          resolveCommentsWithAIDisabledReason={resolveCommentsWithAIDisabledReason}
+          onAddComment={pr ? handleAddPRComment : undefined}
+          onResolveSelectedCommentsWithAI={
+            sourceControlAiActionsVisible ? handleResolveCommentsWithAI : undefined
+          }
+          onReply={pr ? handleReplyToComment : undefined}
+          onResolve={pr || activeGitLabReview ? handleResolve : undefined}
+          onEditComment={pr ? handleEditComment : undefined}
+          onDeleteComment={pr ? handleDeleteComment : undefined}
+          onSetReaction={canTargetPRComments ? handleSetReaction : undefined}
         />
       )}
-      <PRCommentsList
-        comments={comments}
-        commentsLoading={commentsLoading}
-        reviewKind={reviewShortLabel}
-        commentsDisabled={!canTargetPRComments}
-        commentsDisabledReason={commentsDisabledReason}
-        selectionContextKey={stateRequestKey}
-        selectionClearRequest={commentsSelectionClearRequest}
-        resolveCommentsWithAIDisabled={Boolean(resolveCommentsWithAIDisabledReason)}
-        resolveCommentsWithAIDisabledReason={resolveCommentsWithAIDisabledReason}
-        onAddComment={pr ? handleAddPRComment : undefined}
-        onResolveSelectedCommentsWithAI={
-          sourceControlAiActionsVisible ? handleResolveCommentsWithAI : undefined
-        }
-        onReply={pr ? handleReplyToComment : undefined}
-        onResolve={pr || activeGitLabReview ? handleResolve : undefined}
-        onEditComment={pr ? handleEditComment : undefined}
-        onDeleteComment={pr ? handleDeleteComment : undefined}
-        onSetReaction={canTargetPRComments ? handleSetReaction : undefined}
-      />
       <SourceControlAgentActionDialog
         open={sourceControlAiActionsVisible && agentComposerState !== null}
         onOpenChange={(open) => {

--- a/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
@@ -159,7 +159,13 @@ export function ChecksPanelActiveContent({
         ) : null}
 
         {/* Review title */}
-        {editingTitle ? (
+        {activeReview.provider === 'bitbucket' ? (
+          <div className="flex items-start gap-1.5 -mx-1 px-1 py-0.5">
+            <span className="text-[12px] text-foreground leading-snug flex-1">
+              {activeReview.title}
+            </span>
+          </div>
+        ) : editingTitle ? (
           <div className="flex items-center gap-1">
             <input
               ref={titleInputRef}

--- a/src/renderer/src/components/right-sidebar/checks-panel/manual-refresh-dependencies.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel/manual-refresh-dependencies.ts
@@ -37,6 +37,7 @@ export type ChecksPanelManualRefreshInput = Pick<
   Pick<
     ChecksPanelContextState,
     | 'activeGitLabReview'
+    | 'activeReview'
     | 'fallbackGitHubPRNumber'
     | 'isFolder'
     | 'isGitLabReviewContext'

--- a/src/renderer/src/components/right-sidebar/checks-panel/panel-content-rendering.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/panel-content-rendering.test.tsx
@@ -155,6 +155,7 @@ describe('checks panel concrete content', () => {
       isRefreshing: false,
       isResolvingConflictsWithAI: false,
       linkedGitLabMR: null,
+      linkedBitbucketPR: null,
       pendingCommentResolutionRef: { current: null },
       pr: null,
       prRefreshState: undefined,
@@ -184,5 +185,92 @@ describe('checks panel concrete content', () => {
     expect(screen.getByRole('button', { name: '#42' }).getAttribute('title')).toContain(
       'Open on GitHub'
     )
+  })
+
+  it('omits checks and comments sections for Bitbucket reviews', () => {
+    const model = {
+      activeConnectionId: null,
+      activeConflictReview: null,
+      activeGitLabReview: null,
+      activeReview: {
+        provider: 'bitbucket',
+        number: 42,
+        state: 'open',
+        title: 'Bitbucket PR review',
+        url: 'https://bitbucket.org/ws/repo/pull-requests/42',
+        status: 'neutral',
+        updatedAt: '2026-08-23T00:00:00.000Z',
+        mergeable: 'UNKNOWN'
+      },
+      activeSourceControlLaunchPlatform: 'darwin',
+      activeWorktree: null,
+      activeWorktreeId: 'worktree-1',
+      agentComposerState: null,
+      aiActionDisabledReason: undefined,
+      canTargetPRComments: false,
+      checks: [],
+      checksLoading: false,
+      claimedCommentResolutionRef: { current: null },
+      commentResolutionLaunchAcceptedRef: { current: false },
+      comments: [],
+      commentsDisabledReason: undefined,
+      commentsLoading: false,
+      commentsSelectionClearRequest: null,
+      conflictDetailsRefreshing: false,
+      consumeClaimedCommentResolutionAfterDeliveryRef: { current: vi.fn() },
+      detachedHeadDisplay: null,
+      editingTitle: false,
+      getGitLabProjectRef: vi.fn(() => null),
+      handleAddPRComment: vi.fn(),
+      handleCancelEdit: vi.fn(),
+      handleDeleteComment: vi.fn(),
+      handleEditComment: vi.fn(),
+      handleFixChecksWithAI: vi.fn(),
+      handleLaunchAborted: vi.fn(),
+      handleLaunchAccepted: vi.fn(),
+      handleLinkAnotherReview: vi.fn(),
+      handleLoadCheckDetails: vi.fn(),
+      handleOpenPR: vi.fn(),
+      handleRefresh: vi.fn(),
+      handleOpenStackPR: vi.fn(),
+      handleReplyToComment: vi.fn(),
+      handleResolve: vi.fn(),
+      handleResolveCommentsWithAI: vi.fn(),
+      handleResolveConflictsWithAI: vi.fn(),
+      handleSaveTitle: vi.fn(),
+      handleSetReaction: vi.fn(),
+      handleStartEdit: vi.fn(),
+      handleTitleKeyDown: vi.fn(),
+      handleUnlinkReview: vi.fn(),
+      isFixingChecksWithAI: false,
+      isRefreshing: false,
+      isResolvingConflictsWithAI: false,
+      linkedGitLabMR: null,
+      linkedBitbucketPR: null,
+      pendingCommentResolutionRef: { current: null },
+      pr: null,
+      prRefreshState: undefined,
+      repo: null,
+      refreshHostedReviewAfterMutation: vi.fn(),
+      resolveCommentsWithAIDisabledReason: undefined,
+      saveLaunchActionDefault: vi.fn(),
+      setAgentComposerState: vi.fn(),
+      setChecksPanelContentRef: vi.fn(),
+      settings: null,
+      sourceControlAiActionsVisible: false,
+      stateRequestKey: 'review-42',
+      titleDraft: '',
+      setTitleDraft: vi.fn(),
+      titleInputRef: { current: null },
+      titleSaving: false
+    } satisfies ChecksPanelActiveContentModel
+
+    render(
+      <ChecksPanelActiveContent model={model} ReviewHeaderComponent={ChecksPanelReviewHeader} />
+    )
+
+    expect(screen.getByText('Bitbucket PR review')).toBeTruthy()
+    expect(screen.queryByText('No checks configured')).toBeNull()
+    expect(screen.queryByText('No comments')).toBeNull()
   })
 })

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
@@ -273,7 +273,7 @@ export function useChecksPanelEntryRefreshAndTitleActions(
   ])
 
   const handleStartEdit = useCallback(() => {
-    if (!activeReview) {
+    if (!activeReview || activeReview.provider === 'bitbucket') {
       return
     }
     setTitleDraft(activeReview.title)

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
@@ -223,6 +223,20 @@ export function useChecksPanelEntryRefreshAndTitleActions(
       }
       return
     }
+    if (activeReview?.provider === 'bitbucket') {
+      await refreshHostedReviewCard(fetchHostedReviewForBranch, {
+        repoPath: repo.path,
+        repoId: repo.id,
+        branch,
+        linkedGitHubPR: linkedPR,
+        fallbackGitHubPR: fallbackGitHubPRNumber,
+        linkedGitLabMR,
+        linkedBitbucketPR,
+        linkedAzureDevOpsPR,
+        linkedGiteaPR
+      })
+      return
+    }
     const refreshedPR = await fetchPRForBranch(repo.path, branch, {
       force: true,
       repoId: repo.id,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.test.tsx
@@ -44,6 +44,7 @@ describe('useChecksPanelManualRefresh ordering', () => {
     const input: RefreshInput = {
       activeConnectionId: null,
       activeGitLabReview: null,
+      activeReview: null,
       activeWorktreeId: null,
       activeWorktreePath: null,
       activeWorktreePushTarget: null,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.tsx
@@ -18,6 +18,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
   const {
     activeConnectionId,
     activeGitLabReview,
+    activeReview,
     activeWorktreeId,
     activeWorktreePath,
     activeWorktreePushTarget,
@@ -82,18 +83,24 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
     const refreshProvider = isGitLabReviewContext ? 'gitlab' : 'github'
     let refreshOutcome = 'started'
     setIsRefreshing(true)
-    recordChecksPanelPRRefreshBreadcrumb({
-      event: 'start',
-      provider: refreshProvider,
-      repoId: repo.id,
-      worktreeId: activeWorktreeId,
-      branch,
-      prCacheKey,
-      prNumber: activeGitLabReview?.number ?? prNumber,
-      prState: activeGitLabReview?.state ?? pr?.state,
-      prChecksStatus: pr?.checksStatus,
-      refreshState: prCacheKey ? useAppStore.getState().prRefreshStates[prCacheKey] : null
-    })
+    const recordBreadcrumb = (event: 'start' | 'done', outcome?: string): void => {
+      recordChecksPanelPRRefreshBreadcrumb({
+        event,
+        provider: refreshProvider,
+        repoId: repo.id,
+        worktreeId: activeWorktreeId,
+        branch,
+        prCacheKey,
+        prNumber: activeGitLabReview?.number ?? prNumber,
+        prState: activeGitLabReview?.state ?? pr?.state,
+        prChecksStatus: pr?.checksStatus,
+        refreshState: prCacheKey ? useAppStore.getState().prRefreshStates[prCacheKey] : null,
+        outcome,
+        durationMs: event === 'done' ? Date.now() - refreshStartedAt : undefined,
+        currentRequest: isCurrentRequest()
+      })
+    }
+    recordBreadcrumb('start')
     try {
       if (activeWorktreeId && activeWorktreePath && !isFolder) {
         const snapshotIdentity = readChecksPanelRefreshGitIdentitySnapshot({
@@ -127,10 +134,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
           })
           if (
             observedBranch !== undefined &&
-            hasChecksPanelGitStatusBranchChanged({
-              observedBranch,
-              currentBranch: branch
-            })
+            hasChecksPanelGitStatusBranchChanged({ observedBranch, currentBranch: branch })
           ) {
             // Why: this click discovered a terminal branch switch; let branch-keyed render/effects restart instead of refreshing old PR data.
             refreshOutcome = 'branch-changed'
@@ -159,45 +163,55 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
               contextKey: panelContextKey,
               hasUncommittedChanges: status.entries.length > 0,
               remoteStatus: freshRemoteStatus,
-              gitIdentity: {
-                head: status.head,
-                branch: observedBranch
-              }
+              gitIdentity: { head: status.head, branch: observedBranch }
             })
           }
         } catch (error) {
           console.warn('[ChecksPanel] pre-refresh git identity refresh failed', error)
         }
       }
-      if (isGitLabReviewContext) {
-        const refreshedReview = await refreshHostedReviewCard(fetchHostedReviewForBranch, {
-          repoPath: repo.path,
-          repoId: repo.id,
-          branch,
-          admissionTier: 'interactive',
-          linkedGitHubPR: linkedPR,
-          fallbackGitHubPR: fallbackGitHubPRNumber,
-          linkedGitLabMR,
-          linkedBitbucketPR,
-          linkedAzureDevOpsPR,
-          linkedGiteaPR
-        })
+      const hostedReviewArgs = {
+        repoPath: repo.path,
+        repoId: repo.id,
+        branch,
+        admissionTier: 'interactive' as const,
+        linkedGitHubPR: linkedPR,
+        fallbackGitHubPR: fallbackGitHubPRNumber,
+        linkedGitLabMR,
+        linkedBitbucketPR,
+        linkedAzureDevOpsPR,
+        linkedGiteaPR
+      }
+      const isBitbucketReviewContext = Boolean(
+        activeReview?.provider === 'bitbucket' || linkedBitbucketPR !== null
+      )
+      if (isGitLabReviewContext || isBitbucketReviewContext) {
+        const refreshedReview = await refreshHostedReviewCard(
+          fetchHostedReviewForBranch,
+          hostedReviewArgs
+        )
         if (!isCurrentRequest()) {
           return
         }
-        const refreshedGitLabReview =
-          refreshedReview?.provider === 'gitlab' ? refreshedReview : activeGitLabReview
-        if (refreshedGitLabReview) {
-          await fetchGitLabDetails({
-            mrNumberOverride: refreshedGitLabReview.number,
-            headShaOverride: refreshedGitLabReview.headSha,
-            commitAsCurrent: true
-          })
-          refreshOutcome = 'review'
+        if (isGitLabReviewContext) {
+          const refreshedGitLabReview =
+            refreshedReview?.provider === 'gitlab' ? refreshedReview : activeGitLabReview
+          if (refreshedGitLabReview) {
+            await fetchGitLabDetails({
+              mrNumberOverride: refreshedGitLabReview.number,
+              headShaOverride: refreshedGitLabReview.headSha,
+              commitAsCurrent: true
+            })
+            refreshOutcome = 'review'
+          } else {
+            setChecks([])
+            setComments([])
+            refreshOutcome = 'no-review'
+          }
         } else {
           setChecks([])
           setComments([])
-          refreshOutcome = 'no-review'
+          refreshOutcome = refreshedReview?.provider === 'bitbucket' ? 'review' : 'no-review'
         }
         return
       }
@@ -227,16 +241,8 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
         return
       }
       await refreshHostedReviewCard(fetchHostedReviewForBranch, {
-        repoPath: repo.path,
-        repoId: repo.id,
-        branch,
-        admissionTier: 'interactive',
-        linkedGitHubPR: linkedPR,
-        fallbackGitHubPR: refreshedPR?.number ?? fallbackGitHubPRNumber,
-        linkedGitLabMR,
-        linkedBitbucketPR,
-        linkedAzureDevOpsPR,
-        linkedGiteaPR
+        ...hostedReviewArgs,
+        fallbackGitHubPR: refreshedPR?.number ?? fallbackGitHubPRNumber
       })
       if (!isCurrentRequest()) {
         return
@@ -256,6 +262,8 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
         // Why: a forced refresh can find the PR number before React repaints from prCache; mark this refresh's checks current.
         asyncResultKeyRef.current = prRequestKey
         // Why: pass the refreshed headSha directly; fetchChecks's closure captured a stale one (force-pushes, PR-number changes).
+        const isMatchingResult = (): boolean =>
+          isCurrentRequest() && isCurrentAsyncResult(prRequestKey)
         const refreshedChecks = fetchPRChecks(
           repo.path,
           refreshedPR.number,
@@ -265,7 +273,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
           { force: true, repoId: repo.id }
         ).then(
           (result) => {
-            if (!isCurrentRequest() || !isCurrentAsyncResult(prRequestKey)) {
+            if (!isMatchingResult()) {
               return
             }
             setChecks(result)
@@ -279,7 +287,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
             prevChecksRef.current = signature
           },
           (err) => {
-            if (!isCurrentRequest() || !isCurrentAsyncResult(prRequestKey)) {
+            if (!isMatchingResult()) {
               return
             }
             console.warn('Failed to fetch PR checks:', err)
@@ -294,12 +302,12 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
           prRepo: refreshedPR.prRepo
         }).then(
           (result) => {
-            if (isCurrentRequest() && isCurrentAsyncResult(prRequestKey)) {
+            if (isMatchingResult()) {
               setComments(result)
             }
           },
           (err) => {
-            if (!isCurrentRequest() || !isCurrentAsyncResult(prRequestKey)) {
+            if (!isMatchingResult()) {
               return
             }
             console.warn('Failed to fetch PR comments:', err)
@@ -308,12 +316,12 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
         )
         await Promise.all([
           refreshedChecks.finally(() => {
-            if (isCurrentRequest() && isCurrentAsyncResult(prRequestKey)) {
+            if (isMatchingResult()) {
               setChecksLoading(false)
             }
           }),
           refreshedComments.finally(() => {
-            if (isCurrentRequest() && isCurrentAsyncResult(prRequestKey)) {
+            if (isMatchingResult()) {
               setCommentsLoading(false)
             }
           })
@@ -327,21 +335,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
       refreshOutcome = 'error'
       throw error
     } finally {
-      recordChecksPanelPRRefreshBreadcrumb({
-        event: 'done',
-        provider: refreshProvider,
-        repoId: repo.id,
-        worktreeId: activeWorktreeId,
-        branch,
-        prCacheKey,
-        prNumber: activeGitLabReview?.number ?? prNumber,
-        prState: activeGitLabReview?.state ?? pr?.state,
-        prChecksStatus: pr?.checksStatus,
-        refreshState: prCacheKey ? useAppStore.getState().prRefreshStates[prCacheKey] : null,
-        outcome: refreshOutcome,
-        durationMs: Date.now() - refreshStartedAt,
-        currentRequest: isCurrentRequest()
-      })
+      recordBreadcrumb('done', refreshOutcome)
       if (isCurrentRequest()) {
         refreshInFlightRef.current = false
         setIsRefreshing(false)
@@ -357,6 +351,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
     activeWorktreePath,
     activeWorktreePushTarget,
     activeGitLabReview,
+    activeReview?.provider,
     prNumber,
     pr?.checksStatus,
     pr?.headSha,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-link-actions.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-link-actions.tsx
@@ -15,6 +15,7 @@ export function useChecksPanelReviewLinkActions(
     activeWorktreeId,
     branch,
     fetchHostedReviewForBranch,
+    linkedBitbucketPR,
     linkedGitLabMR,
     linkedPR,
     localExecutionScope,
@@ -60,6 +61,17 @@ export function useChecksPanelReviewLinkActions(
       void unlinkGitHubPullRequest()
       return
     }
+    if (activeReview.provider === 'bitbucket') {
+      if (linkedBitbucketPR === null) {
+        return
+      }
+      void updateWorktreeMeta(
+        activeWorktreeId,
+        { linkedBitbucketPR: null },
+        { executionHostId: activeWorktree.hostId }
+      )
+      return
+    }
     if (linkedGitLabMR === null) {
       return
     }
@@ -72,6 +84,7 @@ export function useChecksPanelReviewLinkActions(
     activeReview,
     activeWorktree,
     activeWorktreeId,
+    linkedBitbucketPR,
     linkedGitLabMR,
     unlinkGitHubPullRequest,
     updateWorktreeMeta

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-link-actions.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-link-actions.tsx
@@ -132,6 +132,9 @@ export function useChecksPanelReviewLinkActions(
       openLinkPullRequestModal(activeWorktree.linkedPR ?? activeReview.number)
       return
     }
+    if (activeReview.provider === 'bitbucket') {
+      return
+    }
     const openedScopeKey = reviewLinkScopeKey
     openModal('edit-meta', {
       worktreeId: activeWorktreeId,

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -57,17 +57,7 @@ export function useHostedReviewActions({
   defaultMergeMethod: HostedReviewMergeMethod
   autoMergeAction: GitHubPRAutoMergeAction | null
   onRefreshReview: () => Promise<void>
-}): {
-  merging: boolean
-  readying: boolean
-  stateUpdating: 'open' | 'closed' | null
-  actionError: string | null
-  handleMerge: (method?: HostedReviewMergeMethod) => Promise<void>
-  handleAutoMerge: () => Promise<void>
-  handleMarkReadyForReview: () => Promise<void>
-  handleCloseReview: () => Promise<void>
-  handleReopenReview: () => Promise<void>
-} {
+}) {
   const confirm = useConfirmationDialog()
   const [merging, setMerging] = useState(false)
   const [stateUpdating, setStateUpdating] = useState<'open' | 'closed' | null>(null)
@@ -235,7 +225,10 @@ export function useHostedReviewActions({
                 })
               : {
                   ok: false,
-                  error: 'Reopening declined Bitbucket pull requests is not supported.'
+                  error: translate(
+                    'auto.components.right.sidebar.bitbucket.pr.reopenUnsupported',
+                    'Reopening declined Bitbucket pull requests is not supported.'
+                  )
                 }
             : await updateGitHubHostedReviewState({
                 repo,

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -4,6 +4,8 @@ import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
 import type { GitHubPRAutoMergeAction } from '@/components/github-pr-merge-state'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type { GitHubPRMergeMethod, PRInfo } from '../../../../shared/github/pull-request-types'
+import type { BitbucketPRMergeMethod } from '../../../../shared/bitbucket-merge-methods'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/repo-types'
 import {
   mergeGitHubHostedReview,
@@ -13,6 +15,8 @@ import {
 import { translate } from '@/i18n/i18n'
 import { buildGitHubPRStackMergeConfirmation } from './github-pr-stack-confirmation'
 import { useReadyHostedReviewAction } from './use-ready-hosted-review-action'
+
+export type HostedReviewMergeMethod = GitHubPRMergeMethod | BitbucketPRMergeMethod
 
 export type HostedReviewActionInfo = Pick<
   HostedReviewInfo,
@@ -33,7 +37,9 @@ export function useHostedReviewActions({
   review,
   githubPR,
   repo,
+  executionHostId = 'local',
   isGitLab,
+  isBitbucket = false,
   shortLabel,
   reviewLabel,
   defaultMergeMethod,
@@ -43,10 +49,12 @@ export function useHostedReviewActions({
   review: HostedReviewActionInfo
   githubPR?: PRInfo | null
   repo: Repo
+  executionHostId?: ExecutionHostId
   isGitLab: boolean
+  isBitbucket?: boolean
   shortLabel: string
   reviewLabel: string
-  defaultMergeMethod: GitHubPRMergeMethod
+  defaultMergeMethod: HostedReviewMergeMethod
   autoMergeAction: GitHubPRAutoMergeAction | null
   onRefreshReview: () => Promise<void>
 }): {
@@ -54,7 +62,7 @@ export function useHostedReviewActions({
   readying: boolean
   stateUpdating: 'open' | 'closed' | null
   actionError: string | null
-  handleMerge: (method?: GitHubPRMergeMethod) => Promise<void>
+  handleMerge: (method?: HostedReviewMergeMethod) => Promise<void>
   handleAutoMerge: () => Promise<void>
   handleMarkReadyForReview: () => Promise<void>
   handleCloseReview: () => Promise<void>
@@ -76,7 +84,7 @@ export function useHostedReviewActions({
   })
 
   const handleMerge = useCallback(
-    async (method: GitHubPRMergeMethod = defaultMergeMethod) => {
+    async (method: HostedReviewMergeMethod = defaultMergeMethod) => {
       if (!isGitLab && githubPR?.stack) {
         const usesMergeQueue =
           review.mergeQueueRequired === true || githubPR.mergeQueueRequired === true
@@ -84,7 +92,7 @@ export function useHostedReviewActions({
           buildGitHubPRStackMergeConfirmation({
             stack: githubPR.stack,
             currentPRNumber: review.number,
-            method,
+            method: method as GitHubPRMergeMethod,
             usesMergeQueue
           })
         )
@@ -100,14 +108,21 @@ export function useHostedReviewActions({
               repoPath: repo.path,
               repoId: repo.id,
               iid: review.number,
-              method
+              method: method as 'merge' | 'squash' | 'rebase'
             })
-          : await mergeGitHubHostedReview({
-              repo,
-              prNumber: review.number,
-              method,
-              prRepo: githubPR?.prRepo ?? null
-            })
+          : isBitbucket
+            ? await window.api.bitbucket.mergePR({
+                repoPath: repo.path,
+                prNumber: review.number,
+                method: method as BitbucketPRMergeMethod,
+                executionHostId
+              })
+            : await mergeGitHubHostedReview({
+                repo,
+                prNumber: review.number,
+                method: method as GitHubPRMergeMethod,
+                prRepo: githubPR?.prRepo ?? null
+              })
         if (!result.ok) {
           setActionError(result.error)
         } else {
@@ -121,10 +136,12 @@ export function useHostedReviewActions({
     },
     [
       confirm,
+      executionHostId,
       githubPR?.prRepo,
       githubPR?.mergeQueueRequired,
       githubPR?.stack,
       isGitLab,
+      isBitbucket,
       defaultMergeMethod,
       onRefreshReview,
       repo,
@@ -145,7 +162,7 @@ export function useHostedReviewActions({
         repo,
         prNumber: review.number,
         enabled,
-        method: enabled ? defaultMergeMethod : undefined,
+        method: enabled ? (defaultMergeMethod as GitHubPRMergeMethod) : undefined,
         prRepo: githubPR?.prRepo ?? null
       })
       if (!result.ok) {
@@ -209,12 +226,23 @@ export function useHostedReviewActions({
                 repoId: repo.id,
                 iid: review.number
               })
-          : await updateGitHubHostedReviewState({
-              repo,
-              prNumber: review.number,
-              prRepo: githubPR?.prRepo ?? null,
-              nextState
-            })
+          : isBitbucket
+            ? isClosing
+              ? await window.api.bitbucket.closePR({
+                  repoPath: repo.path,
+                  prNumber: review.number,
+                  executionHostId
+                })
+              : {
+                  ok: false,
+                  error: 'Reopening declined Bitbucket pull requests is not supported.'
+                }
+            : await updateGitHubHostedReviewState({
+                repo,
+                prNumber: review.number,
+                prRepo: githubPR?.prRepo ?? null,
+                nextState
+              })
         if (!result.ok) {
           setActionError(result.error)
           toast.error(result.error)
@@ -245,8 +273,10 @@ export function useHostedReviewActions({
     },
     [
       confirm,
+      executionHostId,
       githubPR?.prRepo,
       isGitLab,
+      isBitbucket,
       onRefreshReview,
       repo,
       review.number,

--- a/src/shared/bitbucket-merge-methods.test.ts
+++ b/src/shared/bitbucket-merge-methods.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BITBUCKET_PR_MERGE_METHODS,
+  BITBUCKET_PR_MERGE_METHOD_LABELS,
+  resolveBitbucketPRMergeMethods
+} from './bitbucket-merge-methods'
+
+describe('resolveBitbucketPRMergeMethods', () => {
+  it('defaults to merge_commit when no default specified', () => {
+    const result = resolveBitbucketPRMergeMethods()
+    expect(result.defaultMethod).toBe('merge_commit')
+    expect(result.defaultLabel).toBe(BITBUCKET_PR_MERGE_METHOD_LABELS.merge_commit)
+    expect(result.methods.map((m) => m.method)).toEqual(BITBUCKET_PR_MERGE_METHODS)
+  })
+
+  it('orders the specified defaultMethod first', () => {
+    const result = resolveBitbucketPRMergeMethods('fast_forward')
+    expect(result.defaultMethod).toBe('fast_forward')
+    expect(result.defaultLabel).toBe(BITBUCKET_PR_MERGE_METHOD_LABELS.fast_forward)
+    expect(result.methods.map((m) => m.method)).toEqual(['fast_forward', 'merge_commit', 'squash'])
+  })
+
+  it('handles squash default', () => {
+    const result = resolveBitbucketPRMergeMethods('squash')
+    expect(result.defaultMethod).toBe('squash')
+    expect(result.methods.map((m) => m.method)).toEqual(['squash', 'merge_commit', 'fast_forward'])
+  })
+})

--- a/src/shared/bitbucket-merge-methods.ts
+++ b/src/shared/bitbucket-merge-methods.ts
@@ -1,0 +1,38 @@
+export const BITBUCKET_PR_MERGE_METHODS = ['merge_commit', 'squash', 'fast_forward'] as const
+
+export type BitbucketPRMergeMethod = (typeof BITBUCKET_PR_MERGE_METHODS)[number]
+
+export const BITBUCKET_PR_MERGE_METHOD_LABELS: Record<BitbucketPRMergeMethod, string> = {
+  merge_commit: 'Create merge commit',
+  squash: 'Squash and merge',
+  fast_forward: 'Fast-forward merge'
+}
+
+export type BitbucketPRMergeMethodOption = {
+  method: BitbucketPRMergeMethod
+  label: string
+}
+
+export type BitbucketPRMergeMethodPresentation = {
+  defaultMethod: BitbucketPRMergeMethod
+  defaultLabel: string
+  methods: BitbucketPRMergeMethodOption[]
+}
+
+export function resolveBitbucketPRMergeMethods(
+  defaultMethod: BitbucketPRMergeMethod = 'merge_commit'
+): BitbucketPRMergeMethodPresentation {
+  const orderedMethods: BitbucketPRMergeMethod[] = [
+    defaultMethod,
+    ...BITBUCKET_PR_MERGE_METHODS.filter((m) => m !== defaultMethod)
+  ]
+
+  return {
+    defaultMethod,
+    defaultLabel: BITBUCKET_PR_MERGE_METHOD_LABELS[defaultMethod],
+    methods: orderedMethods.map((method) => ({
+      method,
+      label: BITBUCKET_PR_MERGE_METHOD_LABELS[method]
+    }))
+  }
+}


### PR DESCRIPTION
## ELI5

Bitbucket pull requests could previously be created and viewed in Orca, but could not be merged or declined directly from the right sidebar Checks panel, requiring developers to leave Orca and open a browser. This adds full merge (merge commit, squash, fast-forward) and decline actions for Bitbucket pull requests directly within Orca.

## What Changed

- **Shared merge methods**: Added `resolveBitbucketPRMergeMethods` in `src/shared/bitbucket-merge-methods.ts` supporting `merge_commit`, `squash`, and `fast_forward`.
- **Main process API & IPC**:
  - Implemented `mergeBitbucketPullRequest` and `declineBitbucketPullRequest` against Bitbucket Cloud 2.0 endpoints (`POST /pullrequests/{id}/merge` and `/decline`).
  - Added IPC handlers `bitbucket:mergePR` and `bitbucket:closePR`.
  - Implemented `executionHostId` forwarding to ensure remote SSH execution hosts resolve correctly.
  - Added cache invalidation (`invalidateHostedReviewBranchCache`) on success so PR state updates immediately.
  - Added structured JSON error parsing to surface clean messages (e.g. branch permission rejections or conflict details).
- **Right sidebar UI integration**:
  - Connected Bitbucket reviews in `selectChecksPanelReview` so Bitbucket PRs load in the Checks panel.
  - Integrated Bitbucket merge presentation in `HostedReviewActions` with all three merge methods.
  - Handled Bitbucket `closed` (declined) PRs by rendering `MergedReviewActions` ("Delete Workspace") instead of a non-functional "Reopen PR" button (Bitbucket Cloud API rejects reopening declined PRs with HTTP 400).
  - Cleaned up Checks panel for Bitbucket reviews by omitting empty CI check runs and comment sections until dedicated support lands.

## Why

Completes core PR lifecycle parity for Bitbucket Cloud repositories alongside GitHub and GitLab without introducing breaking changes or architectural drift.

## Linked Issue

N/A (Feature parity with GitHub/GitLab pull request workflows)

## Visual Proof

| Before (PR exists without Checks panel review) | After (Bitbucket PR with Merge Actions in Checks Panel) |
|:---:|:---:|
| ![Before: PR exists without Checks panel review](https://raw.githubusercontent.com/96Kim/orca/assets/bitbucket-pr-merge/bitbucket-pr-before.png) | ![After: Bitbucket PR with Merge Actions in Checks Panel](https://raw.githubusercontent.com/96Kim/orca/assets/bitbucket-pr-merge/bitbucket-pr-after.png) |

*(Screenshots captured from live testing: Before shows the Checks panel when Bitbucket review was not integrated. After shows an open Bitbucket pull request directly rendered with active `Create merge commit` split button, cleanly omitting empty checks and comment sections until dedicated support lands)*

## Testing

- **Automated tests added & passing**:
  - `src/main/bitbucket/pull-request-merge.test.ts` (merge commit, fast-forward, SSH host, cache invalidation, JSON error parsing)
  - `src/renderer/src/components/right-sidebar/HostedReviewActions.bitbucket.test.tsx` (split merge options, conflict blocking, closed/declined UX)
  - `src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.test.ts`
  - `src/shared/bitbucket-merge-methods.test.ts`
  - `src/renderer/src/components/right-sidebar/checks-panel/panel-content-rendering.test.tsx`
- **Manual testing**:
  - Verified on a real Bitbucket Cloud account/repository with live pull requests.
  - Confirmed PR header, status badge, and merge split buttons render accurately.
  - Confirmed typecheck and code quality gates pass cleanly (`pnpm tc`, `pnpm run check:code-quality:changed`).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Assisted by Google DeepMind Antigravity agent.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: No tokens or sensitive data logged or crossed over IPC. Auth headers use existing credential store/env config.
- **Cross-platform**: All IPC and UI paths are platform-independent (macOS, Windows, Linux).
- **Remote SSH**: `executionHostId` is passed down to all Bitbucket git and PR mutation APIs.
- **Deliberately out of scope**:
  - Detailed commit status check runs list in `ChecksList` (planned for follow-up).
  - PR inline comment threads and reviews (planned for follow-up).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
