### PR TITLE
fix(orchestration): refuse Task re-open under a live worker; allow stop re-issue on a stranded row

### DIFF
--- a/src/main/runtime/orchestration/db-stopping-worker-task-guard.test.ts
+++ b/src/main/runtime/orchestration/db-stopping-worker-task-guard.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { OrchestrationDb } from './db'
+import { createRootDispatch } from './db/root-dispatch-test-fixture'
+
+const PANE_W = 'tab_w:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+describe('a Task whose supervised worker is stopping', () => {
+  let db: OrchestrationDb
+  beforeEach(() => {
+    db = new OrchestrationDb(':memory:')
+  })
+  afterEach(() => db.close())
+
+  function localWorker() {
+    const task = db.createTask({ spec: 'local work' })
+    const { dispatch } = db.createStartingWorkerDispatch({
+      taskId: task.id,
+      startOptions: {},
+      creator: { kind: 'system' },
+      maxDepth: 9
+    })
+    db.prepareStartingWorkerAuthority({
+      dispatchId: dispatch.id,
+      handle: 'term_w',
+      paneKey: PANE_W,
+      processIncarnation: 'inc1',
+      worktreeId: 'wt',
+      effects: [],
+      setupState: 'not_configured'
+    })
+    db.markWorkerDispatchReady(dispatch.id)
+    return { task, dispatch }
+  }
+
+  describe('task-update', () => {
+    it('refuses to re-open the Task while the worker is stopping', () => {
+      const { task, dispatch } = localWorker()
+      db.beginWorkerStop(dispatch.id, 'epoch_home')
+      expect(db.getTask(task.id)?.status).toBe('blocked')
+
+      expect(() => db.updateTaskStatus(task.id, 'dispatched')).toThrowError(
+        expect.objectContaining({
+          code: 'task_not_startable',
+          data: { taskId: task.id, dispatchId: dispatch.id }
+        })
+      )
+      expect(db.getTask(task.id)?.status).toBe('blocked')
+    })
+
+    it('refuses to re-open the Task while the stop outcome is unknown', () => {
+      const { task, dispatch } = localWorker()
+      db.beginWorkerStop(dispatch.id, 'epoch_home')
+      db.markWorkerStopUnknown(dispatch.id, 'the execution host did not answer')
+
+      expect(() => db.updateTaskStatus(task.id, 'dispatched')).toThrowError(
+        expect.objectContaining({ code: 'task_not_startable' })
+      )
+      expect(db.getTask(task.id)?.status).toBe('blocked')
+    })
+
+    it('control: still accepts dispatched for an active Dispatch with no supervised worker', () => {
+      const task = db.createTask({ spec: 'unsupervised work' })
+      createRootDispatch(db, task.id, 'term_worker')
+
+      expect(db.updateTaskStatus(task.id, 'dispatched')?.status).toBe('dispatched')
+    })
+
+    it('control: still accepts dispatched while the supervised worker is ready', () => {
+      const { task } = localWorker()
+
+      expect(db.updateTaskStatus(task.id, 'dispatched')?.status).toBe('dispatched')
+    })
+
+    it('control: a no-op re-assert of dispatched under a stopping worker stays legal', () => {
+      const { task, dispatch } = localWorker()
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      db.beginWorkerStop(dispatch.id, 'epoch_home')
+      // beginWorkerStop moved the Task to blocked; put it back the only way that is not a re-open.
+      db.db.prepare("UPDATE tasks SET status = 'dispatched' WHERE id = ?").run(task.id)
+
+      expect(db.updateTaskStatus(task.id, 'dispatched')?.status).toBe('dispatched')
+    })
+  })
+
+  describe('operator escape', () => {
+    it('accepts a re-issued worker-stop and reaches an honest stop_unknown outcome', () => {
+      const { task, dispatch } = localWorker()
+      db.beginWorkerStop(dispatch.id, 'epoch_dead_runtime')
+
+      // The runtime that owned the first stop died mid-flight; the re-issue is the way out.
+      const reissued = db.beginWorkerStop(dispatch.id, 'epoch_new_runtime')
+      expect(reissued).toMatchObject({ disposition: 'stopping' })
+      expect(db.getWorkerDispatch(dispatch.id)?.runtime_epoch).toBe('epoch_new_runtime')
+
+      db.markWorkerStopUnknown(dispatch.id, 'the execution host did not answer')
+      expect(db.abandonWorkerDispatch(dispatch.id)).toMatchObject({ disposition: 'abandoned' })
+      expect(db.getTask(task.id)?.status).toBe('blocked')
+    })
+
+    it('refuses a re-issue from the runtime whose own stop is still in flight', () => {
+      const { dispatch } = localWorker()
+      db.beginWorkerStop(dispatch.id, 'epoch_this_runtime')
+
+      // The terminal is closing and its exit event has not landed yet. Letting this second pass
+      // record stop_unknown would make the exit read as a crash instead of this stop succeeding.
+      expect(() => db.beginWorkerStop(dispatch.id, 'epoch_this_runtime')).toThrowError(
+        /cannot stop from stopping/
+      )
+
+      // The row is still the one the exit path claims a clean stop from: stopping, same epoch.
+      expect(db.getWorkerDispatch(dispatch.id)).toMatchObject({
+        state: 'stopping',
+        runtime_epoch: 'epoch_this_runtime'
+      })
+      expect(db.settleWorkerStop(dispatch.id).state).toBe('stopped')
+      expect(db.getDispatchContextById(dispatch.id)).toMatchObject({
+        status: 'failed',
+        last_failure: 'stopped'
+      })
+    })
+  })
+})

--- a/src/main/runtime/orchestration/db/tasks/task-status-transition.ts
+++ b/src/main/runtime/orchestration/db/tasks/task-status-transition.ts
@@ -35,18 +35,24 @@ export function updateTaskStatus(
          ORDER BY rowid DESC LIMIT 1`
       )
       .get(id) as { id: string } | undefined
-    const activeWorker = terminalStatus
-      ? (this.db
-          .prepare(
-            `SELECT active.id
+    // Why: a supervised worker owns its Task for as long as it is alive. Every status this
+    // function lets past the active-Dispatch check must clear the same worker check, or the Task
+    // re-opens under a worker whose own lifecycle can no longer settle it (#16904 relay wedge).
+    // A no-op re-assert of `dispatched` re-opens nothing and stays legal.
+    const reopensUnderWorker = requiresActiveDispatch && task.status !== 'dispatched'
+    const activeWorker =
+      terminalStatus || reopensUnderWorker
+        ? (this.db
+            .prepare(
+              `SELECT active.id
              FROM dispatch_contexts active
              JOIN worker_dispatches worker ON worker.dispatch_id = active.id
              WHERE active.task_id = ? AND active.status IN ('pending', 'dispatched')
                AND worker.state NOT IN ('failed', 'succeeded', 'stopped', 'abandoned')
              ORDER BY active.rowid DESC LIMIT 1`
-          )
-          .get(id) as { id: string } | undefined)
-      : undefined
+            )
+            .get(id) as { id: string } | undefined)
+        : undefined
     if (activeWorker) {
       throw new OrchestrationError(
         'task_not_startable',

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-stop.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-stop.ts
@@ -59,7 +59,19 @@ export function beginWorkerStop(
       this.db.exec('COMMIT')
       return { disposition: 'already_settled', worker, dispatch }
     }
-    if (!['ready', 'start_unknown'].includes(worker.state)) {
+    // Why `stopping` under a DIFFERENT epoch is accepted: a stop whose runtime died mid-flight
+    // leaves the row here forever, and refusing the re-issue was the only operator escape
+    // (#16904). Re-running the stop earns the honest outcome — settled, or `stop_unknown`, from
+    // which the worker can be abandoned. It never asserts an exit the runtime did not observe.
+    //
+    // Why the epoch and not just the state: this runtime's own `stopping` row means its stop is
+    // still in flight, and a second pass would record `stop_unknown` over it. The exit event that
+    // follows claims a clean stop only from `stopping` under its own epoch
+    // (failActiveDispatchOnExit), so it would then read the operator's stop as a crash and
+    // escalate it. Same predicate as that reader, so both agree on whose stop this is.
+    const stopStrandedByAnotherRuntime =
+      worker.state === 'stopping' && worker.runtime_epoch !== runtimeEpoch
+    if (!['ready', 'start_unknown'].includes(worker.state) && !stopStrandedByAnotherRuntime) {
       throw new OrchestrationError(
         'dispatch_inactive',
         `Dispatch ${dispatchId} cannot stop from ${worker.state}.`

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-stop.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-stop.ts
@@ -245,8 +245,9 @@ export const ORCHESTRATION_WORKER_STOP_METHODS: RpcMethod[] = [
 
 const activeStopByRuntime = new WeakMap<OrcaRuntimeService, Map<string, Promise<unknown>>>()
 
-/** Two callers stopping one Dispatch: the second reached `beginWorkerStop` after the first moved
- *  the row to `stopping` and got `dispatch_inactive` instead of the first caller's receipt. */
+/** Two callers stopping one Dispatch: coalesced so only one of them closes the terminal. Both are
+ *  in this runtime and so carry one epoch, which `beginWorkerStop` refuses a second time anyway;
+ *  the epoch it does accept belongs to a row a dead runtime stranded, and no caller here holds one. */
 function dedupeWorkerStop(
   runtime: OrcaRuntimeService,
   dispatchId: string,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

Split out of #19347 (the SSH exit-certification half is being redesigned separately).

## What
- **Task re-open guard.** `updateTaskStatus` already refuses `completed`/`failed` while a live supervised worker holds the Task. It now runs the same check when a Task is moved back to `dispatched` from any other status. A no-op re-assert of `dispatched` stays legal.
- **`worker-stop` re-issue on a stranded row.** `beginWorkerStop` accepts a `stopping` row only when its `runtime_epoch` is not this runtime's, meaning the runtime that started the stop died mid-flight. Same-epoch stays refused so an in-flight stop's exit event is still read as that stop succeeding, not as a crash. Same predicate as `failActiveDispatchOnExit`.

## Why
A `task-update --status dispatched` under a `stopping` worker left the Task pointing at a worker whose own lifecycle could no longer settle its report; the throw then rolled back the coordinator's whole `check` batch. No workflow issues that command, so this is defensive.

The stop re-issue: a runtime dying between marking `stopping` and closing the terminal leaves the row stranded. Main already has one escape (`worker-show` marks a foreign-epoch `stopping` row `stop_unknown`, then `worker-abandon` works); this adds the direct one, where re-running `worker-stop` actually attempts the close and lands on an honest `stopped` or `stop_unknown`.

## Not included
The no-throw settlement path, `isLegalLifecycleTransition`, `worker_not_settleable`, and the state-space enumeration test from #19347. With the guard in place the bad triple is unreachable, and no shipped database realistically holds it.

## Review note
CodeRabbit asked to fence `settleWorkerStop`/`markWorkerStopUnknown` by epoch against a re-issue racing the old runtime's pending settle. The runtime id is a per-process UUID; a new epoch exists only after the old process is gone, so its pending settle cannot run. No change.

## Verification
- `db-stopping-worker-task-guard.test.ts`: 7 cases. A/B on unpatched main: 3 fail (both guard cases, the re-issue), 4 controls pass. 7 of 7 with the fix.
- Orchestration + RPC + CLI orchestration suites: 1,800 tests pass. `tc:node`, changed-code quality (0 findings), max-lines ratchet, `git diff --check`.

Source: 3 files, +29 / -10.