### PR TITLE
fix(agents): resume Cursor TUI sessions after Orca restart

### DIFF
--- a/mobile/src/session/ai-vault-resume-launch.test.ts
+++ b/mobile/src/session/ai-vault-resume-launch.test.ts
@@ -140,6 +140,23 @@ describe('buildMobileAiVaultResumeLaunch', () => {
     })
   })
 
+  it('routes Cursor through the resumable-agent startup plan', () => {
+    const launch = buildMobileAiVaultResumeLaunch({
+      session: session({
+        agent: 'cursor',
+        sessionId: '668320d2-2fd8-4888-b33c-2a466fec86e7'
+      }),
+      hostPlatform: 'darwin'
+    })
+
+    expect(launch).toMatchObject({
+      command:
+        "cd '/Users/ada/repo' && cursor-agent '--yolo' '--resume' '668320d2-2fd8-4888-b33c-2a466fec86e7'",
+      launchConfig: { agentCommand: "cursor-agent '--yolo'" },
+      launchAgent: 'cursor'
+    })
+  })
+
   it('preserves an arbitrary OMP transcript locator for later cold resume', () => {
     const launch = buildMobileAiVaultResumeLaunch({
       session: session({

--- a/src/main/agent-hooks/server-cursor-normalization.test.ts
+++ b/src/main/agent-hooks/server-cursor-normalization.test.ts
@@ -38,6 +38,20 @@ describe('Cursor hook normalization', () => {
     expect(result?.payload.prompt).toBe('add a README')
   })
 
+  it('captures the Cursor provider session from conversation_id', () => {
+    const conversationId = '668320d2-2fd8-4888-b33c-2a466fec86e7'
+    const result = _internals.normalizeHookPayload(
+      'cursor',
+      buildBody({
+        hook_event_name: 'beforeSubmitPrompt',
+        prompt: 'add a README',
+        conversation_id: conversationId
+      }),
+      'production'
+    )
+    expect(result?.providerSession).toEqual({ key: 'session_id', id: conversationId })
+  })
+
   it('stop maps to done', () => {
     const result = _internals.normalizeHookPayload(
       'cursor',

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { RESUMABLE_TUI_AGENTS, type ResumableTuiAgent } from '../../../shared/agent-session-resume'
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/terminal-tab-types'
 import {
@@ -701,20 +702,10 @@ describe('live resume anchors do not block hibernation (#10238 regression)', () 
   // Why: setAgentStatus writes an `origin: 'live'` anchor for EVERY resumable agent the
   // moment its turn ends, but only Pi/OMP/prime-agent were exempted from the
   // already-sleeping rejection — so no Claude or Codex pane could ever hibernate.
-  const NON_PI_AGENTS = [
-    'claude',
-    'codex',
-    'gemini',
-    'antigravity',
-    'opencode',
-    'mimo-code',
-    'droid',
-    'grok',
-    'devin',
-    'copilot',
-    'kimi',
-    'cursor'
-  ] as const
+  const LIVE_ANCHOR_EXEMPT_AGENTS = new Set<ResumableTuiAgent>(['pi', 'omp', 'prime-agent'])
+  const NON_PI_AGENTS = RESUMABLE_TUI_AGENTS.filter(
+    (agent) => !LIVE_ANCHOR_EXEMPT_AGENTS.has(agent)
+  )
 
   function liveAnchor(
     agent: string,

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -712,7 +712,8 @@ describe('live resume anchors do not block hibernation (#10238 regression)', () 
     'grok',
     'devin',
     'copilot',
-    'kimi'
+    'kimi',
+    'cursor'
   ] as const
 
   function liveAnchor(

--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -153,8 +153,25 @@ describe('ai vault resume command runtime', () => {
   })
 
   it('follows the live Windows shell for non-resumable agents in the fallback path', () => {
-    // Why: agents without a TUI startup plan (e.g. cursor) queue through the
-    // shared-builder fallback, which must quote for the live shell too (#6152).
+    // Why: agents without a TUI startup plan queue through the shared-builder
+    // fallback, which must quote for the live shell too (#6152).
+    const state = makeState({ worktreePath: 'C:\\Users\\alice\\repo' })
+
+    expect(
+      buildQueuedAiVaultResumeCommand({
+        state,
+        worktreeId: 'repo-1::worktree-1',
+        session: {
+          agent: 'hermes',
+          sessionId: 'session one',
+          cwd: 'C:\\Users\\alice\\repo',
+          codexHome: null
+        }
+      })
+    ).toBe("hermes --resume 'session one'")
+  })
+
+  it('queues a Cursor resume through the TUI startup plan', () => {
     const state = makeState({ worktreePath: 'C:\\Users\\alice\\repo' })
 
     expect(
@@ -168,7 +185,7 @@ describe('ai vault resume command runtime', () => {
           codexHome: null
         }
       })
-    ).toBe("cursor-agent --resume 'session one'")
+    ).toBe("cursor-agent '--yolo' '--resume' 'session one'")
   })
 
   it('queues a PowerShell-valid local OMP resume by absolute transcript path', () => {

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { RESUMABLE_TUI_AGENTS } from '../../../shared/agent-session-resume'
 import {
+  AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   RUNTIME_CAPABILITIES
@@ -11,6 +12,12 @@ describe('agentResumeHostAuthorityCapability', () => {
   it('gates Kimi resume behind its own capability', () => {
     expect(agentResumeHostAuthorityCapability('kimi')).toBe(
       AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+    )
+  })
+
+  it('gates Cursor resume behind its own capability', () => {
+    expect(agentResumeHostAuthorityCapability('cursor')).toBe(
+      AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY
     )
   })
 
@@ -28,6 +35,10 @@ describe('agentResumeHostAuthorityCapability', () => {
 
   it('advertises the Kimi resume capability from the host', () => {
     expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY)
+  })
+
+  it('advertises the Cursor resume capability from the host', () => {
+    expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY)
   })
 
   it('pins the gate for every resumable agent so a new member is a deliberate decision', () => {
@@ -51,7 +62,8 @@ describe('agentResumeHostAuthorityCapability', () => {
       'prime-agent': undefined,
       copilot: undefined,
       omp: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
-      kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+      kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+      cursor: AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY
     })
   })
 })

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
@@ -9,22 +9,12 @@ import {
 import { agentResumeHostAuthorityCapability } from './agent-resume-host-authority-capability'
 
 describe('agentResumeHostAuthorityCapability', () => {
-  it('gates Kimi resume behind its own capability', () => {
-    expect(agentResumeHostAuthorityCapability('kimi')).toBe(
-      AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
-    )
-  })
-
-  it('gates Cursor resume behind its own capability', () => {
-    expect(agentResumeHostAuthorityCapability('cursor')).toBe(
-      AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY
-    )
-  })
-
-  it('keeps the OMP resume-path gate', () => {
-    expect(agentResumeHostAuthorityCapability('omp')).toBe(
-      AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY
-    )
+  it.each([
+    ['kimi', AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY],
+    ['cursor', AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY],
+    ['omp', AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY]
+  ] as const)('gates %s resume behind its own capability', (agent, capability) => {
+    expect(agentResumeHostAuthorityCapability(agent)).toBe(capability)
   })
 
   it('leaves agents shipped with host authority on the generic probe', () => {
@@ -33,12 +23,11 @@ describe('agentResumeHostAuthorityCapability', () => {
     expect(agentResumeHostAuthorityCapability(undefined)).toBeUndefined()
   })
 
-  it('advertises the Kimi resume capability from the host', () => {
-    expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY)
-  })
-
-  it('advertises the Cursor resume capability from the host', () => {
-    expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY)
+  it.each([
+    AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+    AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY
+  ])('advertises %s from the host', (capability) => {
+    expect(RUNTIME_CAPABILITIES).toContain(capability)
   })
 
   it('pins the gate for every resumable agent so a new member is a deliberate decision', () => {

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
@@ -1,6 +1,7 @@
 import type { ResumableTuiAgent } from '../../../shared/agent-session-resume'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import {
+  AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   type RuntimeCapability
@@ -30,7 +31,8 @@ const RESUME_HOST_AUTHORITY_CAPABILITY_BY_AGENT = {
   // Ungated to match how main shipped copilot resume; gating it is its own change.
   copilot: undefined,
   omp: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
-  kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+  kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+  cursor: AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY
 } satisfies Record<ResumableTuiAgent, RuntimeCapability | undefined>
 
 export function agentResumeHostAuthorityCapability(

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
@@ -35,6 +35,8 @@ const RESUME_HOST_AUTHORITY_CAPABILITY_BY_AGENT = {
   cursor: AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY
 } satisfies Record<ResumableTuiAgent, RuntimeCapability | undefined>
 
+/** Capability a remote host must advertise before `ensureAgentSession` may include this agent.
+ *  Cursor needs its own gate because adding it grows the host enum. */
 export function agentResumeHostAuthorityCapability(
   agent: TuiAgent | null | undefined
 ): RuntimeCapability | undefined {

--- a/src/renderer/src/runtime/remote-agent-session-launch.test.ts
+++ b/src/renderer/src/runtime/remote-agent-session-launch.test.ts
@@ -15,6 +15,10 @@ vi.mock('./runtime-rpc-client', () => ({
   runtimeEnvironmentSupportsCapability: mocks.supportsCapability
 }))
 
+import {
+  AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY,
+  AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+} from '../../../shared/protocol-version'
 import { RuntimeRpcCallError } from './runtime-rpc-client'
 import { runRemoteAgentSessionLaunch } from './remote-agent-session-launch'
 import { agentResumeHostAuthorityCapability } from './agent-resume-host-authority-capability'
@@ -45,41 +49,30 @@ describe('remote agent-session launch routing', () => {
     expect(legacy).not.toHaveBeenCalled()
   })
 
-  it('falls back to legacy when an older host lacks the Kimi resume capability', async () => {
-    const hostAuthority = vi.fn().mockResolvedValue('structured')
-    const legacy = vi.fn().mockResolvedValue('legacy')
-    mocks.supportsCapability.mockResolvedValue(false)
+  it.each([
+    ['kimi', AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY],
+    ['cursor', AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY]
+  ] as const)(
+    'falls back to legacy when an older host lacks the %s resume capability',
+    async (agent, expectedCapability) => {
+      const hostAuthority = vi.fn().mockResolvedValue('structured')
+      const legacy = vi.fn().mockResolvedValue('legacy')
+      mocks.supportsCapability.mockResolvedValue(false)
 
-    // Why: an old host rejects the widened agent enum with invalid_argument, which is not a
-    // fallback code — so the probe, not the error handler, has to keep the pane alive.
-    await expect(
-      runRemoteAgentSessionLaunch({
-        environmentId: 'env-1',
-        hostAuthority,
-        hostAuthorityCapability: agentResumeHostAuthorityCapability('kimi'),
-        legacy
-      })
-    ).resolves.toBe('legacy')
-    expect(mocks.supportsCapability).toHaveBeenCalledWith('env-1', 'agent-session.kimi-resume.v1')
-    expect(hostAuthority).not.toHaveBeenCalled()
-  })
-
-  it('falls back to legacy when an older host lacks the Cursor resume capability', async () => {
-    const hostAuthority = vi.fn().mockResolvedValue('structured')
-    const legacy = vi.fn().mockResolvedValue('legacy')
-    mocks.supportsCapability.mockResolvedValue(false)
-
-    await expect(
-      runRemoteAgentSessionLaunch({
-        environmentId: 'env-1',
-        hostAuthority,
-        hostAuthorityCapability: agentResumeHostAuthorityCapability('cursor'),
-        legacy
-      })
-    ).resolves.toBe('legacy')
-    expect(mocks.supportsCapability).toHaveBeenCalledWith('env-1', 'agent-session.cursor-resume.v1')
-    expect(hostAuthority).not.toHaveBeenCalled()
-  })
+      // Why: an old host rejects the widened agent enum with invalid_argument, which is not a
+      // fallback code — so the probe, not the error handler, has to keep the pane alive.
+      await expect(
+        runRemoteAgentSessionLaunch({
+          environmentId: 'env-1',
+          hostAuthority,
+          hostAuthorityCapability: agentResumeHostAuthorityCapability(agent),
+          legacy
+        })
+      ).resolves.toBe('legacy')
+      expect(mocks.supportsCapability).toHaveBeenCalledWith('env-1', expectedCapability)
+      expect(hostAuthority).not.toHaveBeenCalled()
+    }
+  )
 
   it('preserves the exact legacy path when the capability is absent', async () => {
     const hostAuthority = vi.fn().mockResolvedValue('structured')

--- a/src/renderer/src/runtime/remote-agent-session-launch.test.ts
+++ b/src/renderer/src/runtime/remote-agent-session-launch.test.ts
@@ -64,6 +64,23 @@ describe('remote agent-session launch routing', () => {
     expect(hostAuthority).not.toHaveBeenCalled()
   })
 
+  it('falls back to legacy when an older host lacks the Cursor resume capability', async () => {
+    const hostAuthority = vi.fn().mockResolvedValue('structured')
+    const legacy = vi.fn().mockResolvedValue('legacy')
+    mocks.supportsCapability.mockResolvedValue(false)
+
+    await expect(
+      runRemoteAgentSessionLaunch({
+        environmentId: 'env-1',
+        hostAuthority,
+        hostAuthorityCapability: agentResumeHostAuthorityCapability('cursor'),
+        legacy
+      })
+    ).resolves.toBe('legacy')
+    expect(mocks.supportsCapability).toHaveBeenCalledWith('env-1', 'agent-session.cursor-resume.v1')
+    expect(hostAuthority).not.toHaveBeenCalled()
+  })
+
   it('preserves the exact legacy path when the capability is absent', async () => {
     const hostAuthority = vi.fn().mockResolvedValue('structured')
     const legacy = vi.fn().mockResolvedValue('legacy')

--- a/src/renderer/src/store/slices/agent-status-quit-capture-resumable-agents.test.ts
+++ b/src/renderer/src/store/slices/agent-status-quit-capture-resumable-agents.test.ts
@@ -3,77 +3,54 @@ import type { AppState } from '../types'
 import { createTestStore, makeTab } from './store-test-helpers'
 
 describe('quit-time capture for newly resumable agents', () => {
-  it('checkpoints a live Kimi provider session before quit-time capture', () => {
-    const store = createTestStore()
-    store.setState({
-      tabsByWorktree: {
-        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
-      }
-    } as Partial<AppState>)
-
-    store.getState().setAgentStatus(
-      'tab-1:leaf-1',
-      {
-        state: 'working',
-        prompt: 'finish the task',
-        agentType: 'kimi'
-      },
-      'Kimi',
-      { updatedAt: 10, stateStartedAt: 10 },
-      { tabId: 'tab-1', worktreeId: 'wt-1' },
-      {
-        providerSession: {
-          key: 'session_id',
-          id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201'
-        }
-      }
-    )
-
-    // Why: this is the #15155 regression — without kimi in RESUMABLE_TUI_AGENTS no sleeping
-    // record is ever captured, so restart drops the session instead of resuming it.
-    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toMatchObject({
+  it.each([
+    {
       agent: 'kimi',
-      worktreeId: 'wt-1',
-      tabId: 'tab-1',
-      providerSession: { key: 'session_id', id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' },
-      origin: 'live'
-    })
-  })
-
-  it('checkpoints a live Cursor provider session before quit-time capture', () => {
-    const store = createTestStore()
-    store.setState({
-      tabsByWorktree: {
-        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
-      }
-    } as Partial<AppState>)
-
-    store.getState().setAgentStatus(
-      'tab-1:leaf-1',
-      {
-        state: 'working',
-        prompt: 'finish the task',
-        agentType: 'cursor'
-      },
-      'Cursor Agent',
-      { updatedAt: 10, stateStartedAt: 10 },
-      { tabId: 'tab-1', worktreeId: 'wt-1' },
-      {
-        providerSession: {
-          key: 'session_id',
-          id: '668320d2-2fd8-4888-b33c-2a466fec86e7'
-        }
-      }
-    )
-
-    // Why: this is the #18668 regression — without cursor in RESUMABLE_TUI_AGENTS no sleeping
-    // record is ever captured, so restart restores an empty shell instead of cursor-agent.
-    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toMatchObject({
+      displayName: 'Kimi',
+      sessionId: 'session_431324d7-2165-42f0-9ecd-9f93437b3201',
+      issue: '#15155'
+    },
+    {
       agent: 'cursor',
-      worktreeId: 'wt-1',
-      tabId: 'tab-1',
-      providerSession: { key: 'session_id', id: '668320d2-2fd8-4888-b33c-2a466fec86e7' },
-      origin: 'live'
-    })
-  })
+      displayName: 'Cursor Agent',
+      sessionId: '668320d2-2fd8-4888-b33c-2a466fec86e7',
+      issue: '#18668'
+    }
+  ] as const)(
+    'checkpoints a live $agent provider session before quit-time capture ($issue)',
+    ({ agent, displayName, sessionId }) => {
+      const store = createTestStore()
+      store.setState({
+        tabsByWorktree: {
+          'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+        }
+      } as Partial<AppState>)
+
+      store.getState().setAgentStatus(
+        'tab-1:leaf-1',
+        {
+          state: 'working',
+          prompt: 'finish the task',
+          agentType: agent
+        },
+        displayName,
+        { updatedAt: 10, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        {
+          providerSession: {
+            key: 'session_id',
+            id: sessionId
+          }
+        }
+      )
+
+      expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toMatchObject({
+        agent,
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        providerSession: { key: 'session_id', id: sessionId },
+        origin: 'live'
+      })
+    }
+  )
 })

--- a/src/renderer/src/store/slices/agent-status-quit-capture-resumable-agents.test.ts
+++ b/src/renderer/src/store/slices/agent-status-quit-capture-resumable-agents.test.ts
@@ -39,4 +39,41 @@ describe('quit-time capture for newly resumable agents', () => {
       origin: 'live'
     })
   })
+
+  it('checkpoints a live Cursor provider session before quit-time capture', () => {
+    const store = createTestStore()
+    store.setState({
+      tabsByWorktree: {
+        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+      }
+    } as Partial<AppState>)
+
+    store.getState().setAgentStatus(
+      'tab-1:leaf-1',
+      {
+        state: 'working',
+        prompt: 'finish the task',
+        agentType: 'cursor'
+      },
+      'Cursor Agent',
+      { updatedAt: 10, stateStartedAt: 10 },
+      { tabId: 'tab-1', worktreeId: 'wt-1' },
+      {
+        providerSession: {
+          key: 'session_id',
+          id: '668320d2-2fd8-4888-b33c-2a466fec86e7'
+        }
+      }
+    )
+
+    // Why: this is the #18668 regression — without cursor in RESUMABLE_TUI_AGENTS no sleeping
+    // record is ever captured, so restart restores an empty shell instead of cursor-agent.
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toMatchObject({
+      agent: 'cursor',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      providerSession: { key: 'session_id', id: '668320d2-2fd8-4888-b33c-2a466fec86e7' },
+      origin: 'live'
+    })
+  })
 })

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -28,6 +28,10 @@ describe('agent session resume metadata', () => {
     expect(isResumableTuiAgent('kimi')).toBe(true)
   })
 
+  it('treats Cursor as a resumable TUI agent', () => {
+    expect(isResumableTuiAgent('cursor')).toBe(true)
+  })
+
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],
@@ -63,7 +67,14 @@ describe('agent session resume metadata', () => {
       'kimi',
       { session_id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' },
       { key: 'session_id', id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' }
-    ]
+    ],
+    [
+      'cursor',
+      { conversation_id: '668320d2-2fd8-4888-b33c-2a466fec86e7' },
+      { key: 'session_id', id: '668320d2-2fd8-4888-b33c-2a466fec86e7' }
+    ],
+    ['cursor', { session_id: 'cursor-session' }, { key: 'session_id', id: 'cursor-session' }],
+    ['cursor', { conversationId: 'cursor-camel' }, { key: 'session_id', id: 'cursor-camel' }]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
   })
@@ -94,13 +105,18 @@ describe('agent session resume metadata', () => {
       'kimi',
       { key: 'session_id', id: 'session_431324d7' },
       ['kimi', '--session', 'session_431324d7']
+    ],
+    [
+      'cursor',
+      { key: 'session_id', id: '668320d2-2fd8-4888-b33c-2a466fec86e7' },
+      ['cursor-agent', '--resume', '668320d2-2fd8-4888-b33c-2a466fec86e7']
     ]
   ] as const)('builds %s resume argv', (agent, providerSession, expected) => {
     expect(getAgentResumeArgv(agent, providerSession)).toEqual(expected)
   })
 
   it('rejects unsupported sources and unsafe ids', () => {
-    expect(extractAgentProviderSession('cursor', { session_id: 'cursor-session' })).toBeNull()
+    expect(extractAgentProviderSession('amp', { session_id: 'amp-session' })).toBeNull()
     expect(normalizeAgentProviderSession({ key: 'session_id', id: 'bad\nid' })).toBeNull()
     expect(normalizeAgentProviderSession({ key: 'session_id', id: '--last' })).toBeNull()
     expect(extractAgentProviderSession('codex', { session_id: '--last' })).toBeNull()

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -74,7 +74,12 @@ describe('agent session resume metadata', () => {
       { key: 'session_id', id: '668320d2-2fd8-4888-b33c-2a466fec86e7' }
     ],
     ['cursor', { session_id: 'cursor-session' }, { key: 'session_id', id: 'cursor-session' }],
-    ['cursor', { conversationId: 'cursor-camel' }, { key: 'session_id', id: 'cursor-camel' }]
+    ['cursor', { conversationId: 'cursor-camel' }, { key: 'session_id', id: 'cursor-camel' }],
+    [
+      'cursor',
+      { sessionId: 'cursor-session-camel' },
+      { key: 'session_id', id: 'cursor-session-camel' }
+    ]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
   })

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -88,6 +88,7 @@ export function hasUnsafeProviderSessionIdChars(value: string): boolean {
   return false
 }
 
+/** Reject empty, over-long, dashed, or control-character session ids before they become argv. */
 function normalizeSessionId(value: unknown): string | null {
   if (typeof value !== 'string') {
     return null

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -105,6 +105,7 @@ function normalizeSessionId(value: unknown): string | null {
   return trimmed
 }
 
+/** First usable session id among the payload keys this agent actually posts. */
 function readSessionId(record: Record<string, unknown>, keys: readonly string[]): string | null {
   for (const key of keys) {
     const normalized = normalizeSessionId(record[key])
@@ -135,6 +136,7 @@ function readTranscriptPathFromKeys(
   return undefined
 }
 
+/** Attach a hook transcript path when present so native chat can open the real file. */
 function withTranscriptPath(
   metadata: AgentProviderSessionMetadata,
   payload: Record<string, unknown>,

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -77,6 +77,7 @@ export type SleepingAgentSessionRecord = {
 const RESUMABLE_TUI_AGENT_SET: ReadonlySet<string> = new Set(RESUMABLE_TUI_AGENTS)
 const PROVIDER_SESSION_ID_MAX_LENGTH = 512
 
+/** True when a session id contains control characters that must not reach argv or the PTY. */
 export function hasUnsafeProviderSessionIdChars(value: string): boolean {
   for (let i = 0; i < value.length; i += 1) {
     const code = value.charCodeAt(i)
@@ -147,6 +148,7 @@ export function isResumableTuiAgent(value: unknown): value is ResumableTuiAgent 
   return typeof value === 'string' && RESUMABLE_TUI_AGENT_SET.has(value)
 }
 
+/** Validate persisted or relayed session metadata with the same id rules as hook payloads. */
 export function normalizeAgentProviderSession(raw: unknown): AgentProviderSessionMetadata | null {
   if (typeof raw !== 'object' || raw === null) {
     return null

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -142,6 +142,7 @@ function withTranscriptPath(
   return transcriptPath ? { ...metadata, transcriptPath } : metadata
 }
 
+/** True when quit/restore may inject a provider resume command into the pane. */
 export function isResumableTuiAgent(value: unknown): value is ResumableTuiAgent {
   return typeof value === 'string' && RESUMABLE_TUI_AGENT_SET.has(value)
 }
@@ -182,6 +183,8 @@ export function agentProviderSessionsEqual(
   )
 }
 
+/** Read the CLI resume locator from a hook payload. Cursor's conversation_id is stored as
+ *  session_id because `cursor-agent --resume` takes that id, the same way Claude uses `--resume`. */
 export function extractAgentProviderSession(
   source: AgentHookSource,
   payload: Record<string, unknown>
@@ -256,6 +259,7 @@ export function extractAgentProviderSession(
   }
 }
 
+/** Argv for the agent's resume CLI. Cursor is `cursor-agent --resume <id>`, matching AI Vault. */
 export function getAgentResumeArgv(
   agent: ResumableTuiAgent,
   providerSession: AgentProviderSessionMetadata,

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -239,8 +239,7 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['session_id', 'sessionId'])
       return id ? { key: 'session_id', id } : null
     }
-    // Why: Cursor's hook conversation_id (also session_id / camelCase) is the
-    // CLI `--resume` locator, matching the AI Vault scanner.
+    // Why: Cursor hook conversation_id (also session_id / camelCase) is the CLI --resume locator.
     case 'cursor': {
       const id = readSessionId(payload, [
         'conversation_id',

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -16,7 +16,8 @@ export const RESUMABLE_TUI_AGENTS = [
   'omp',
   'prime-agent',
   'copilot',
-  'kimi'
+  'kimi',
+  'cursor'
 ] as const satisfies readonly TuiAgent[]
 
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
@@ -238,8 +239,18 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['session_id', 'sessionId'])
       return id ? { key: 'session_id', id } : null
     }
+    // Why: Cursor's hook conversation_id (also session_id / camelCase) is the
+    // CLI `--resume` locator, matching the AI Vault scanner.
+    case 'cursor': {
+      const id = readSessionId(payload, [
+        'conversation_id',
+        'conversationId',
+        'session_id',
+        'sessionId'
+      ])
+      return id ? { key: 'session_id', id } : null
+    }
     case 'amp':
-    case 'cursor':
     case 'command-code':
     case 'hermes':
       return null
@@ -291,5 +302,8 @@ export function getAgentResumeArgv(
     // Why: Kimi resumes by id with --session; sessions are work-dir-scoped (enforced by callers).
     case 'kimi':
       return providerSession.key === 'session_id' ? ['kimi', '--session', id] : null
+    // Why: space-separated `--resume <id>` matches AI Vault's Cursor invocation.
+    case 'cursor':
+      return providerSession.key === 'session_id' ? ['cursor-agent', '--resume', id] : null
   }
 }

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -160,6 +160,11 @@ export const AGENT_SESSION_STATUS_FEED_RUNTIME_CAPABILITY = 'agent-session.statu
 // older host answers the unknown member with invalid_argument — a code the launch fallback does
 // not retry on — so clients must probe before taking the host-authority path.
 export const AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY = 'agent-session.kimi-resume.v1' as const
+// Why: adding cursor to RESUMABLE_TUI_AGENTS grows terminal.ensureAgentSession's enum, and an
+// older host answers the unknown member with invalid_argument — a code the launch fallback does
+// not retry on — so clients must probe before taking the host-authority path.
+export const AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY =
+  'agent-session.cursor-resume.v1' as const
 // Why: older runtimes strip mutation owner fields, so clients must fence writes before RPC.
 export const FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY = 'files.mutation-ownership.v1' as const
 export const FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE =
@@ -260,6 +265,7 @@ export const RUNTIME_CAPABILITIES = [
   STRUCTURED_AGENT_SESSION_RESUME_HISTORY_RUNTIME_CAPABILITY,
   AGENT_SESSION_STATUS_FEED_RUNTIME_CAPABILITY,
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+  AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY,
   FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
   GITHUB_MARK_PR_READY_RUNTIME_CAPABILITY,
   GITLAB_READY_FOR_REVIEW_RUNTIME_CAPABILITY,

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -160,9 +160,7 @@ export const AGENT_SESSION_STATUS_FEED_RUNTIME_CAPABILITY = 'agent-session.statu
 // older host answers the unknown member with invalid_argument — a code the launch fallback does
 // not retry on — so clients must probe before taking the host-authority path.
 export const AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY = 'agent-session.kimi-resume.v1' as const
-// Why: adding cursor to RESUMABLE_TUI_AGENTS grows terminal.ensureAgentSession's enum, and an
-// older host answers the unknown member with invalid_argument — a code the launch fallback does
-// not retry on — so clients must probe before taking the host-authority path.
+// Why: same enum-growth gate as kimi — older hosts answer invalid_argument.
 export const AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY =
   'agent-session.cursor-resume.v1' as const
 // Why: older runtimes strip mutation owner fields, so clients must fence writes before RPC.

--- a/src/shared/tui-agent-startup-cursor-resume.test.ts
+++ b/src/shared/tui-agent-startup-cursor-resume.test.ts
@@ -28,4 +28,15 @@ describe('Cursor resume startup plan', () => {
 
     expect(plan?.launchCommand).toBe(`cursor-agent "--yolo" "--resume" "${SESSION.id}"`)
   })
+
+  it('honors a command override', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'cursor',
+      providerSession: SESSION,
+      cmdOverrides: { cursor: 'cursor-agent --banner' },
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe(`cursor-agent --banner '--resume' '${SESSION.id}'`)
+  })
 })

--- a/src/shared/tui-agent-startup-cursor-resume.test.ts
+++ b/src/shared/tui-agent-startup-cursor-resume.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { buildAgentResumeStartupPlan } from './tui-agent-startup'
+
+const SESSION = { key: 'session_id' as const, id: '668320d2-2fd8-4888-b33c-2a466fec86e7' }
+
+describe('Cursor resume startup plan', () => {
+  it('appends the AI Vault --resume form after YOLO args', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'cursor',
+      providerSession: SESSION,
+      cmdOverrides: {},
+      agentArgs: '--yolo',
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe(`cursor-agent '--yolo' '--resume' '${SESSION.id}'`)
+  })
+
+  it('quotes the resume argv for cmd.exe', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'cursor',
+      providerSession: SESSION,
+      cmdOverrides: {},
+      agentArgs: '--yolo',
+      platform: 'win32',
+      shell: 'cmd'
+    })
+
+    expect(plan?.launchCommand).toBe(`cursor-agent "--yolo" "--resume" "${SESSION.id}"`)
+  })
+})


### PR DESCRIPTION
## ELI5

After an Orca restart, a Cursor pane used to come back as an empty shell. It now relaunches `cursor-agent --resume <id>`, the same way a Claude pane already relaunches `claude --resume <id>`.

## What Changed

- Add `cursor` to `RESUMABLE_TUI_AGENTS`.
- Extract the Cursor hook conversation id (`conversation_id` / `session_id`, snake or camel) and store it as `{ key: 'session_id', id }`.
- Build resume argv as `cursor-agent --resume <id>`.
- Gate remote host authority on a new runtime capability, `agent-session.cursor-resume.v1`, so an older host does not see an unknown `ensureAgentSession` enum member and fail with `invalid_argument`.

## Why

Quit capture never wrote a Cursor provider session, so restore had nothing to inject into the PTY. `launchAgent: "cursor"` is identity metadata, not a command replay. Restore now follows the same `--resume` path Claude already uses. Remote hosts probe a new capability so an older server degrades instead of failing.

## Linked Issue

Fixes #18668

## Visual Proof

N/A — no chrome or layout change. Restore injects a PTY command after restart. Verified locally: Cursor pane → one prompt → quit Orca → restore relaunches `cursor-agent --resume <id>`.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Unit coverage: session extract + argv, quit-time sleeping record, hook payload normalize, TUI startup quoting (linux + win32 + command override), host-authority capability map, remote launch fallback on an old host, AI Vault + mobile resume command, hibernation live-anchor list derived from `RESUMABLE_TUI_AGENTS`.

Platforms actually tested: macOS local restart. Linux/Windows quoting is unit-tested; SSH is covered by the capability gate (old host keeps the legacy launch path).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Known gap (out of scope): quit before the first prompt still has no `conversation_id`, so restore still creates an empty shell. Same class as a pane that never posted a hook id.

Remote wire: new optional capability only. Mixed client/host is safe; an old host is probed and then uses legacy launch.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)