### PR TITLE
fix(skills): stop asserting readdir order in the skill root walk test

### DIFF
--- a/src/main/skills/skill-root-file-walk.test.ts
+++ b/src/main/skills/skill-root-file-walk.test.ts
@@ -66,10 +66,13 @@ describe('findSkillFiles', () => {
 
     expect(await findSkillFiles(root, 4)).toEqual([join(edge, 'SKILL.md')])
     expect(statPaths).toEqual([])
-    expect(await findSkillFiles(root, 5)).toEqual([
-      join(edge, 'SKILL.md'),
-      join(edge, 'link00', 'SKILL.md')
-    ])
+    // Not a fixed array: `readdir` order decides both the result order and which of the 32
+    // links survives realpath dedup, and NTFS sorts `link00` before `SKILL.md` where APFS does not.
+    const withinDepth = await findSkillFiles(root, 5)
+    const viaLink = withinDepth.filter((path) => /[\\/]link\d{2}[\\/]SKILL\.md$/.test(path))
+    expect(withinDepth).toHaveLength(2)
+    expect(withinDepth).toContain(join(edge, 'SKILL.md'))
+    expect(viaLink).toHaveLength(1)
     expect(statPaths).toHaveLength(32)
   })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem

The Windows **skill sharing release gate** in `.github/workflows/release-cut.yml` fails on one test in `src/main/skills/skill-root-file-walk.test.ts`:

> does not stat directory links beyond the depth bound but still follows in-bound links

That gate blocks `publish-release`, so the failure silently holds up release cuts.

## Root cause

`findSkillFiles` appends results in `readdir` order and dedupes visited directories by `realpath`. The test creates 32 junctions (`link00`..`link31`) all pointing at a single target, so exactly one of them survives dedup — but *which* one wins, and where it lands in the result array, is decided entirely by the order the filesystem enumerated the directory.

- **APFS / ext4** return `SKILL.md` before `link00`.
- **NTFS** enumerates its filename index alphabetically on the uppercased name, and `LINK00` < `SKILL.MD` (`L`=0x4C < `S`=0x53), so Windows returns the two entries in the opposite order.

The old assertion hardcoded both the array order *and* the winning link:

```ts
expect(await findSkillFiles(root, 5)).toEqual([
  join(edge, 'SKILL.md'),
  join(edge, 'link00', 'SKILL.md')
])
```

Same two elements on every platform, opposite order on Windows. **The implementation is correct — only the test was wrong.**

## Fix

Test-only. Assert the actual contract rather than a filesystem-dependent ordering:

- `edge/SKILL.md` is present,
- exactly one result was reached through a `linkNN` directory (proving all 32 collapsed to one realpath),
- two paths total.

The link matcher accepts either path separator, so it holds on win32 backslash paths and regardless of which link wins.

## Provenance

Introduced by #18937 (`perf(skills): skip symlink probes beyond discovery depth`, 2026-09-05). It went unnoticed because the last release cut predated that commit, so the Windows gate had not run against it.

## Verification

- `npx vitest run --config config/vitest.config.ts src/main/skills/skill-root-file-walk.test.ts` — 6/6 pass on macOS.
- The new assertions were checked against mac order, Windows (NTFS) order, win32 backslash paths, and a different winning link; the old assertion fails the last three.
- `oxlint` and `oxfmt --check` clean on the changed file.