### PR TITLE
feat(crash-reporting): sample a frozen renderer's memory curve during an unresponsive freeze

### DIFF
--- a/src/main/crash-reporting/renderer-unresponsive-breadcrumb.test.ts
+++ b/src/main/crash-reporting/renderer-unresponsive-breadcrumb.test.ts
@@ -1,0 +1,374 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CrashReportBreadcrumbData } from '../../shared/crash-reporting'
+import { installRendererUnresponsiveBreadcrumb } from './renderer-unresponsive-breadcrumb'
+
+const recordDurableCrashBreadcrumb = vi.fn()
+vi.mock('./durable-crash-breadcrumb', () => ({
+  recordDurableCrashBreadcrumb: (...args: unknown[]) => recordDurableCrashBreadcrumb(...args)
+}))
+const { getAppMetricsMock } = vi.hoisted(() => ({ getAppMetricsMock: vi.fn(() => [] as unknown[]) }))
+vi.mock('electron', () => ({ app: { getAppMetrics: getAppMetricsMock } }))
+
+class FakeWebContents extends EventEmitter {
+  destroyed = false
+  crashed = false
+  osProcessId = 4242
+  isDestroyed(): boolean {
+    return this.destroyed
+  }
+  isCrashed(): boolean {
+    return this.crashed
+  }
+  getOSProcessId(): number {
+    return this.osProcessId
+  }
+}
+
+class FakeWindow extends EventEmitter {
+  webContents = new FakeWebContents()
+  destroyed = false
+  isDestroyed(): boolean {
+    return this.destroyed
+  }
+}
+
+type Sample = { workingSet: number; priv: number }
+
+function metricsProvider(samples: Sample[]): () => CrashReportBreadcrumbData {
+  let i = 0
+  return () => {
+    const s = samples[Math.min(i, samples.length - 1)]
+    i += 1
+    return {
+      processMetricsRendererWorkingSetMB: s.workingSet,
+      processMetricsRendererPrivateMB: s.priv
+    }
+  }
+}
+
+describe('renderer unresponsive breadcrumb', () => {
+  let clock = 0
+  const now = (): number => clock
+
+  beforeEach(() => {
+    clock = 0
+    recordDurableCrashBreadcrumb.mockClear()
+    getAppMetricsMock.mockReset()
+    getAppMetricsMock.mockReturnValue([])
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function crumbsNamed(name: string): CrashReportBreadcrumbData[] {
+    return recordDurableCrashBreadcrumb.mock.calls
+      .filter((c) => c[0] === name)
+      .map((c) => c[1] as CrashReportBreadcrumbData)
+  }
+
+  it('records the freeze onset and samples the renderer climb from the main process', () => {
+    const window = new FakeWindow()
+    const collectMetricsDetails = metricsProvider([
+      { workingSet: 210, priv: 220 },
+      { workingSet: 1400, priv: 1450 },
+      { workingSet: 3000, priv: 3100 }
+    ])
+    installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      sampleIntervalMs: 30_000,
+      now,
+      collectMetricsDetails
+    })
+
+    window.emit('unresponsive')
+    const onset = crumbsNamed('renderer_unresponsive')
+    expect(onset).toHaveLength(1)
+    expect(onset[0].rendererUnresponsiveElapsedMs).toBe(0)
+    expect(onset[0].processMetricsRendererWorkingSetMB).toBe(210)
+
+    clock = 30_000
+    vi.advanceTimersByTime(30_000)
+    clock = 60_000
+    vi.advanceTimersByTime(30_000)
+
+    const samples = crumbsNamed('renderer_unresponsive_sample')
+    expect(samples).toHaveLength(2)
+    expect(samples[0].rendererUnresponsiveElapsedMs).toBe(30_000)
+    expect(samples[0].rendererUnresponsiveSampleIndex).toBe(1)
+    expect(samples[0].processMetricsRendererWorkingSetMB).toBe(1400)
+    expect(samples[1].processMetricsRendererWorkingSetMB).toBe(3000)
+  })
+
+  it('reports duration and peak on recovery, then stops sampling', () => {
+    const window = new FakeWindow()
+    const collectMetricsDetails = metricsProvider([
+      { workingSet: 210, priv: 220 },
+      { workingSet: 1400, priv: 1450 }
+    ])
+    installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      sampleIntervalMs: 30_000,
+      now,
+      collectMetricsDetails
+    })
+
+    window.emit('unresponsive')
+    clock = 30_000
+    vi.advanceTimersByTime(30_000)
+    clock = 45_000
+    window.emit('responsive')
+
+    const recovered = crumbsNamed('renderer_responsive')
+    expect(recovered).toHaveLength(1)
+    expect(recovered[0].rendererUnresponsiveDurationMs).toBe(45_000)
+    expect(recovered[0].rendererUnresponsiveSampleCount).toBe(1)
+    expect(recovered[0].rendererUnresponsivePeakWorkingSetMB).toBe(1400)
+    expect(recovered[0].rendererUnresponsivePeakPrivateMB).toBe(1450)
+
+    // No further samples after recovery.
+    clock = 75_000
+    vi.advanceTimersByTime(60_000)
+    expect(crumbsNamed('renderer_unresponsive_sample')).toHaveLength(1)
+  })
+
+  it('stops sampling when the renderer dies instead of recovering', () => {
+    const window = new FakeWindow()
+    installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      sampleIntervalMs: 30_000,
+      now,
+      collectMetricsDetails: metricsProvider([{ workingSet: 100, priv: 100 }])
+    })
+    window.emit('unresponsive')
+    // The frozen renderer dies rather than recovering; the interval sees the
+    // crashed process and stops sampling (render-process-gone owns that record).
+    window.webContents.crashed = true
+    clock = 60_000
+    vi.advanceTimersByTime(60_000)
+    expect(crumbsNamed('renderer_unresponsive_sample')).toHaveLength(0)
+    expect(crumbsNamed('renderer_responsive')).toHaveLength(0)
+  })
+
+  it('re-arms onset detection when the poll observes a persistent crashed state', () => {
+    const window = new FakeWindow()
+    installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      sampleIntervalMs: 30_000,
+      now,
+      collectMetricsDetails: metricsProvider([{ workingSet: 100, priv: 100 }])
+    })
+    // First freeze ends in a renderer death the poll actually catches.
+    window.emit('unresponsive')
+    window.webContents.crashed = true
+    clock = 60_000
+    vi.advanceTimersByTime(60_000)
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(1)
+
+    // Focus lifecycle reloads the same window; the fresh renderer freezes again.
+    window.webContents.crashed = false
+    clock = 120_000
+    window.emit('unresponsive')
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(2)
+  })
+
+  it('re-arms on the next freeze after a prompt in-place reload the poll never sees', () => {
+    const window = new FakeWindow()
+    window.webContents.osProcessId = 4242
+    installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      sampleIntervalMs: 30_000,
+      now,
+      collectMetricsDetails: metricsProvider([{ workingSet: 100, priv: 100 }])
+    })
+    // First freeze onset captures pid 4242.
+    window.emit('unresponsive')
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(1)
+
+    // The renderer OOM-dies and reloads in place within ~1s — far faster than the
+    // 30s poll — so no tick ever observes crashed===true. The reused webContents
+    // now reports a new pid. Without the pid check this second onset (with the old
+    // hangStartMs still set) would be dropped as a duplicate: the silent-gap wedge.
+    window.webContents.osProcessId = 5555
+    clock = 120_000
+    window.emit('unresponsive')
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(2)
+  })
+
+  it('resets sampling when the poll sees the tracked renderer replaced by a new pid', () => {
+    const window = new FakeWindow()
+    window.webContents.osProcessId = 4242
+    installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      sampleIntervalMs: 30_000,
+      now
+    })
+    getAppMetricsMock.mockReturnValue([
+      { pid: 4242, type: 'renderer', memory: { workingSetSize: 500 * 1024 } }
+    ])
+    window.emit('unresponsive')
+    // Renderer reloaded in place under a new pid before the first tick fires; the
+    // tick must reset rather than record a sample misattributed to the old freeze.
+    window.webContents.osProcessId = 5555
+    clock = 30_000
+    vi.advanceTimersByTime(30_000)
+    expect(crumbsNamed('renderer_unresponsive_sample')).toHaveLength(0)
+  })
+
+  it('ignores a duplicate unresponsive for the same renderer pid', () => {
+    const window = new FakeWindow()
+    window.webContents.osProcessId = 4242
+    installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      now,
+      collectMetricsDetails: metricsProvider([{ workingSet: 100, priv: 100 }])
+    })
+    window.emit('unresponsive')
+    window.emit('unresponsive')
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(1)
+  })
+
+  it('re-arms when the pid is reused but the renderer generation (creationTime) differs', () => {
+    const window = new FakeWindow()
+    window.webContents.osProcessId = 4242
+    // Onset: pid 4242 created at t=1000.
+    getAppMetricsMock.mockReturnValue([
+      { pid: 4242, type: 'renderer', creationTime: 1000, memory: { workingSetSize: 100 * 1024 } }
+    ])
+    installRendererUnresponsiveBreadcrumb({ window: window as never, sampleIntervalMs: 30_000, now })
+    window.emit('unresponsive')
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(1)
+
+    // The renderer OOM-dies and reloads in place before any poll tick — Windows
+    // reassigns the SAME pid 4242 to the fresh process, but it is a new generation
+    // (creationTime 2000). Bare-pid identity would drop this as a duplicate (the
+    // silent-gap wedge); (pid, creationTime) sees a different renderer and re-arms.
+    getAppMetricsMock.mockReturnValue([
+      { pid: 4242, type: 'renderer', creationTime: 2000, memory: { workingSetSize: 100 * 1024 } }
+    ])
+    clock = 120_000
+    window.emit('unresponsive')
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(2)
+  })
+
+  it('re-arms when the onset identity was unresolved and a later freeze resolves one', () => {
+    const window = new FakeWindow()
+    window.webContents.osProcessId = 0 // getOSProcessId() returns 0 → onset identity unresolved
+    installRendererUnresponsiveBreadcrumb({ window: window as never, now })
+    window.emit('unresponsive')
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(1)
+
+    // A reloaded renderer now resolves a pid; the stale unresolved onset must not
+    // swallow its fresh freeze as a duplicate.
+    window.webContents.osProcessId = 5555
+    clock = 120_000
+    window.emit('unresponsive')
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(2)
+  })
+
+  it('records only the frozen renderer, not the sum across all renderers', () => {
+    const window = new FakeWindow()
+    window.webContents.osProcessId = 4242
+    getAppMetricsMock.mockReturnValue([
+      { pid: 4242, type: 'renderer', memory: { workingSetSize: 500 * 1024, privateBytes: 480 * 1024 } },
+      { pid: 9999, type: 'renderer', memory: { workingSetSize: 1200 * 1024, privateBytes: 1150 * 1024 } }
+    ])
+    // Default collector (no collectMetricsDetails) so pid filtering is exercised.
+    installRendererUnresponsiveBreadcrumb({ window: window as never, now })
+    window.emit('unresponsive')
+    const onset = crumbsNamed('renderer_unresponsive')
+    expect(onset).toHaveLength(1)
+    expect(onset[0].processMetricsRendererCount).toBe(1)
+    expect(onset[0].processMetricsRendererWorkingSetMB).toBe(500)
+    expect(onset[0].processMetricsFrozenRendererPidResolved).toBeUndefined()
+  })
+
+  it('flags a resolved-but-absent pid distinctly from an unresolved one', () => {
+    const window = new FakeWindow()
+    window.webContents.osProcessId = 4242
+    getAppMetricsMock.mockReturnValue([
+      { pid: 9999, type: 'renderer', memory: { workingSetSize: 1200 * 1024 } }
+    ])
+    installRendererUnresponsiveBreadcrumb({ window: window as never, now })
+    window.emit('unresponsive')
+    const onset = crumbsNamed('renderer_unresponsive')
+    // pid resolved (4242) but its row is absent → the process vanished, not a
+    // resolution failure.
+    expect(onset[0].processMetricsFrozenRendererAbsentFromMetrics).toBe(true)
+    expect(onset[0].processMetricsFrozenRendererPidResolved).toBeUndefined()
+  })
+
+  it('flags PidResolved:false only when the os pid cannot be resolved', () => {
+    const window = new FakeWindow()
+    window.webContents.osProcessId = 0 // getOSProcessId() returns 0 → unresolved
+    getAppMetricsMock.mockReturnValue([
+      { pid: 9999, type: 'renderer', memory: { workingSetSize: 1200 * 1024 } }
+    ])
+    installRendererUnresponsiveBreadcrumb({ window: window as never, now })
+    window.emit('unresponsive')
+    const onset = crumbsNamed('renderer_unresponsive')
+    expect(onset[0].processMetricsFrozenRendererPidResolved).toBe(false)
+    expect(onset[0].processMetricsFrozenRendererAbsentFromMetrics).toBeUndefined()
+  })
+
+  it('detaches listeners on dispose', () => {
+    const window = new FakeWindow()
+    const { dispose } = installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      now,
+      collectMetricsDetails: metricsProvider([{ workingSet: 100, priv: 100 }])
+    })
+    dispose()
+    window.emit('unresponsive')
+    expect(crumbsNamed('renderer_unresponsive')).toHaveLength(0)
+  })
+
+  it('does not throw from dispose when webContents is already destroyed', () => {
+    const window = new FakeWindow()
+    const { dispose } = installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      now,
+      collectMetricsDetails: metricsProvider([{ workingSet: 100, priv: 100 }])
+    })
+    // Electron can destroy webContents before the window 'closed' cleanup runs;
+    // reading window.webContents then throws, so we captured it at install.
+    window.webContents.destroyed = true
+    Object.defineProperty(window, 'webContents', {
+      get() {
+        throw new Error('Object has been destroyed')
+      }
+    })
+    expect(() => dispose()).not.toThrow()
+  })
+
+  it('caps per-hang samples so the breadcrumb ring is not flooded', () => {
+    const window = new FakeWindow()
+    installRendererUnresponsiveBreadcrumb({
+      window: window as never,
+      sampleIntervalMs: 30_000,
+      now,
+      collectMetricsDetails: metricsProvider([{ workingSet: 100, priv: 100 }])
+    })
+    window.emit('unresponsive')
+    // Advance well past the cap (20 samples).
+    for (let i = 1; i <= 40; i++) {
+      clock = i * 30_000
+      vi.advanceTimersByTime(30_000)
+    }
+    expect(crumbsNamed('renderer_unresponsive_sample')).toHaveLength(20)
+  })
+
+  it('records a metrics error instead of throwing when getAppMetrics fails', () => {
+    const window = new FakeWindow()
+    getAppMetricsMock.mockImplementation(() => {
+      throw new Error('metrics unavailable')
+    })
+    // Use the default (guarded) collector by not passing collectMetricsDetails.
+    installRendererUnresponsiveBreadcrumb({ window: window as never, now })
+    expect(() => window.emit('unresponsive')).not.toThrow()
+    const onset = crumbsNamed('renderer_unresponsive')
+    expect(onset).toHaveLength(1)
+    expect(onset[0].processMetricsError).toBe('Error')
+  })
+})

--- a/src/main/crash-reporting/renderer-unresponsive-breadcrumb.ts
+++ b/src/main/crash-reporting/renderer-unresponsive-breadcrumb.ts
@@ -1,0 +1,284 @@
+import { app, type BrowserWindow, type WebContents } from 'electron'
+import type { CrashReportBreadcrumbData, CrashReportDetailValue } from '../../shared/crash-reporting'
+import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
+import { collectProcessGoneMetricDetails } from './process-gone-diagnostics'
+
+// Why: a renderer main-thread freeze (one long synchronous task) stops the
+// renderer's own `renderer_memory` heartbeat, so a runaway allocation up to the
+// V8 limit lands as a silent multi-minute gap before `render-process-gone`.
+// The main process stays live during that freeze, so it can still read the
+// frozen renderer's working set via getAppMetrics and see Electron's
+// `unresponsive` signal — the only vantage point that observes the climb.
+//
+// Re-arm across an in-place reload: when the frozen renderer OOM-dies, the focus
+// lifecycle reloads the SAME BrowserWindow in place, reusing this same
+// webContents object with a fresh renderer on a new OS process. Death detection
+// is therefore keyed on that process identity, not on catching the
+// ~250ms-transient crashed state: `onUnresponsive` treats a freeze whose onset
+// identity differs from the live one as a fresh freeze (so the reloaded
+// renderer's next freeze is never dropped as a stale duplicate), and the sampler
+// resets the instant it sees the identity change. A polled isDestroyed/isCrashed
+// check is kept only as a backstop. We do not add our own `render-process-gone`
+// listener: the focus lifecycle already owns that signal, and the identity keeps
+// this module self-contained.
+//
+// Identity is (pid, creationTime), not the OS pid alone: an in-place reload's
+// fresh renderer can be assigned the SAME pid as the dead one (Windows recycles
+// freed pids aggressively), and bare-pid identity would then read "unchanged"
+// and collapse back to the pre-fix silent-gap wedge. A reloaded renderer is a
+// newly-spawned process, so its creationTime differs even when the pid repeats.
+// This mirrors process-gone-diagnostics.ts, which pairs pid with creationTime
+// for the same recycled-pid disambiguation. When creationTime is unavailable we
+// fall back to pid equality (best effort).
+//
+// Coverage limit: Electron's `unresponsive` is driven by Chromium's input-ACK
+// hang monitor, not a periodic ping — it only arms once an input event is
+// dispatched to the renderer. A wholly idle/background freeze with no input may
+// never surface `unresponsive`, so this captures interactive freezes (the field
+// reports were) but not a silent background one; a heartbeat-gap watchdog would
+// be the input-independent follow-up.
+
+const RENDERER_UNRESPONSIVE_SAMPLE_INTERVAL_MS = 30_000
+// Why: cap the per-hang samples so a wedged-but-alive renderer cannot force-flush
+// the 30-entry breadcrumb ring full of flat samples and evict pre-hang context.
+// 20 × 30s = 10 min comfortably covers the ~5-min field OOM curve; the recovery
+// summary still carries peak/count/duration past the cap. The cap stops sample
+// writes only — re-arming after a death does not depend on the timer surviving,
+// so a post-cap crash-then-freeze is still captured (via onUnresponsive's identity check).
+const RENDERER_UNRESPONSIVE_MAX_SAMPLES = 20
+
+function numericDetail(details: CrashReportBreadcrumbData, key: string): number | null {
+  const value: CrashReportDetailValue | undefined = details[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+// Why filter to the frozen renderer's own pid: getAppMetrics sums working set
+// across every renderer (browser tabs, popouts, agent webContents), so the
+// unfiltered aggregate would read an unrelated busy tab's memory as this
+// window's freeze curve. Scope to the one process that went unresponsive.
+function collectFrozenRendererMetrics(resolvePid: () => number | null): CrashReportBreadcrumbData {
+  try {
+    const pid = resolvePid()
+    const metrics = app.getAppMetrics()
+    const own = pid !== null ? metrics.filter((metric) => metric.pid === pid) : []
+    const details = collectProcessGoneMetricDetails(own)
+    if (pid === null) {
+      // Why: without a pid the numbers are unattributable; flag it so a triager
+      // never reads a 0 or a fallback as the frozen renderer's real footprint.
+      details.processMetricsFrozenRendererPidResolved = false
+    } else if (own.length === 0) {
+      // Why a distinct flag: the pid resolved but its row is absent from the live
+      // table — the process vanished (died/rotated) or metrics lag. Same "don't
+      // trust these zeros" signal, but a different, more interesting reason.
+      details.processMetricsFrozenRendererAbsentFromMetrics = true
+    }
+    return details
+  } catch (error) {
+    // Why: this runs on a timer during a crash-adjacent freeze; a throw here must
+    // not take down the main process or abort the hang record.
+    return { processMetricsError: error instanceof Error ? error.name : typeof error }
+  }
+}
+
+/**
+ * Records durable breadcrumbs around Electron's renderer `unresponsive`/`responsive`
+ * signals, sampling the frozen renderer's memory from the main process so the next
+ * freeze-then-OOM shows its allocation curve instead of a silent heartbeat gap.
+ */
+export function installRendererUnresponsiveBreadcrumb(args: {
+  window: BrowserWindow
+  sampleIntervalMs?: number
+  now?: () => number
+  collectMetricsDetails?: () => CrashReportBreadcrumbData
+}): { dispose: () => void } {
+  const {
+    window,
+    sampleIntervalMs = RENDERER_UNRESPONSIVE_SAMPLE_INTERVAL_MS,
+    now = () => Date.now()
+  } = args
+  // Why: capture the webContents reference at install so the sampling interval can
+  // poll isCrashed()/getOSProcessId() without re-reading the `window.webContents`
+  // getter, which throws once the window is destroyed.
+  const webContents: WebContents = window.webContents
+
+  const resolveRendererPid = (): number | null => {
+    try {
+      if (window.isDestroyed() || webContents.isDestroyed()) {
+        return null
+      }
+      const pid = webContents.getOSProcessId()
+      return typeof pid === 'number' && pid > 0 ? pid : null
+    } catch {
+      return null
+    }
+  }
+
+  // (pid, creationTime): the pid identifies the OS process, creationTime the
+  // process generation so a recycled pid (a fresh renderer reassigned the dead
+  // one's pid) reads as a different renderer. creationTime is null when the row
+  // is absent from getAppMetrics; comparison then degrades to pid equality.
+  const resolveRendererIdentity = (): { pid: number; creationTime: number | null } | null => {
+    const pid = resolveRendererPid()
+    if (pid === null) {
+      return null
+    }
+    try {
+      const row = app.getAppMetrics().find((metric) => metric.pid === pid)
+      const creationTime = row?.creationTime
+      return {
+        pid,
+        creationTime: typeof creationTime === 'number' && Number.isFinite(creationTime) ? creationTime : null
+      }
+    } catch {
+      return { pid, creationTime: null }
+    }
+  }
+
+  // Same renderer generation iff same pid and (when both are known) same
+  // creationTime. A null on either side is treated as "not the same": an
+  // unresolved identity should re-arm onset detection rather than swallow a
+  // possibly-reloaded renderer's fresh freeze.
+  const isSameRendererGeneration = (
+    a: { pid: number; creationTime: number | null } | null,
+    b: { pid: number; creationTime: number | null } | null
+  ): boolean => {
+    if (a === null || b === null || a.pid !== b.pid) {
+      return false
+    }
+    if (a.creationTime !== null && b.creationTime !== null) {
+      return a.creationTime === b.creationTime
+    }
+    return true
+  }
+
+  const collectMetricsDetails =
+    args.collectMetricsDetails ?? (() => collectFrozenRendererMetrics(resolveRendererPid))
+
+  let hangStartMs: number | null = null
+  let hangStartIdentity: { pid: number; creationTime: number | null } | null = null
+  let sampleTimer: ReturnType<typeof setInterval> | null = null
+  let sampleCount = 0
+  let peakRendererWorkingSetMB = 0
+  let peakRendererPrivateMB = 0
+
+  const trackPeaks = (details: CrashReportBreadcrumbData): void => {
+    const workingSet = numericDetail(details, 'processMetricsRendererWorkingSetMB')
+    if (workingSet !== null) {
+      peakRendererWorkingSetMB = Math.max(peakRendererWorkingSetMB, workingSet)
+    }
+    const priv = numericDetail(details, 'processMetricsRendererPrivateMB')
+    if (priv !== null) {
+      peakRendererPrivateMB = Math.max(peakRendererPrivateMB, priv)
+    }
+  }
+
+  const stopSampling = (): void => {
+    if (sampleTimer) {
+      clearInterval(sampleTimer)
+      sampleTimer = null
+    }
+  }
+
+  const reset = (): void => {
+    stopSampling()
+    hangStartMs = null
+    hangStartIdentity = null
+    sampleCount = 0
+    peakRendererWorkingSetMB = 0
+    peakRendererPrivateMB = 0
+  }
+
+  const beginHang = (): void => {
+    hangStartMs = now()
+    hangStartIdentity = resolveRendererIdentity()
+    sampleCount = 0
+    peakRendererWorkingSetMB = 0
+    peakRendererPrivateMB = 0
+    const details = collectMetricsDetails()
+    trackPeaks(details)
+    recordDurableCrashBreadcrumb('renderer_unresponsive', {
+      ...details,
+      rendererUnresponsiveElapsedMs: 0
+    })
+    // Why: the freeze can allocate GBs and die before it ever recovers; keep
+    // sampling from the still-live main process so the climb is on record.
+    sampleTimer = setInterval(() => {
+      if (hangStartMs === null) {
+        stopSampling()
+        return
+      }
+      // Why reset (not just stop) here: the tracked renderer is gone — the window
+      // was destroyed, its webContents crashed, or (the common field path) it
+      // OOM-died and reloaded in place as a new process. render-process-gone owns
+      // the death record; clearing state re-arms onset detection for the reloaded
+      // renderer instead of wedging it off. isDestroyed() is checked before
+      // isCrashed() so the throwing call never runs post-destroy.
+      if (window.isDestroyed() || webContents.isDestroyed() || webContents.isCrashed()) {
+        reset()
+        return
+      }
+      // A live renderer whose identity no longer matches the onset one is a
+      // reloaded-in-place replacement (possibly reusing the dead pid) — reset so
+      // its memory is not misattributed to the dead hang's clock.
+      if (!isSameRendererGeneration(resolveRendererIdentity(), hangStartIdentity)) {
+        reset()
+        return
+      }
+      sampleCount += 1
+      const sample = collectMetricsDetails()
+      trackPeaks(sample)
+      recordDurableCrashBreadcrumb('renderer_unresponsive_sample', {
+        ...sample,
+        rendererUnresponsiveElapsedMs: now() - hangStartMs,
+        rendererUnresponsiveSampleIndex: sampleCount
+      })
+      if (sampleCount >= RENDERER_UNRESPONSIVE_MAX_SAMPLES) {
+        stopSampling()
+      }
+    }, sampleIntervalMs)
+    sampleTimer.unref?.()
+  }
+
+  const onUnresponsive = (): void => {
+    if (hangStartMs !== null) {
+      // Why: a renderer that OOM-died and reloaded in place reuses this same
+      // webContents as a new process. If the tracked freeze belonged to that dead
+      // renderer, its onset is stale — treat this as a fresh freeze rather than
+      // dropping it as a duplicate (the silent-gap wedge). A matching identity
+      // means a genuine duplicate for the still-frozen renderer, so ignore it.
+      if (isSameRendererGeneration(resolveRendererIdentity(), hangStartIdentity)) {
+        return
+      }
+      reset()
+    }
+    beginHang()
+  }
+
+  const onResponsive = (): void => {
+    if (hangStartMs === null) {
+      return
+    }
+    const elapsedMs = now() - hangStartMs
+    const samplesTaken = sampleCount
+    const peakWorkingSet = peakRendererWorkingSetMB
+    const peakPrivate = peakRendererPrivateMB
+    reset()
+    recordDurableCrashBreadcrumb('renderer_responsive', {
+      rendererUnresponsiveDurationMs: elapsedMs,
+      rendererUnresponsiveSampleCount: samplesTaken,
+      rendererUnresponsivePeakWorkingSetMB: peakWorkingSet,
+      rendererUnresponsivePeakPrivateMB: peakPrivate
+    })
+  }
+
+  window.on('unresponsive', onUnresponsive)
+  window.on('responsive', onResponsive)
+
+  return {
+    dispose: () => {
+      reset()
+      window.removeListener('unresponsive', onUnresponsive)
+      window.removeListener('responsive', onResponsive)
+    }
+  }
+}

--- a/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
+++ b/src/main/window/createMainWindow-renderer-crash-recovery.test.ts
@@ -67,6 +67,7 @@ describe('createMainWindow', () => {
       on: vi.fn((event, handler) => {
         windowHandlers[event] = handler
       }),
+      removeListener: vi.fn(),
       isDestroyed: vi.fn(() => false),
       isMaximized: vi.fn(() => true),
       isFullScreen: vi.fn(() => false),

--- a/src/main/window/createMainWindow-startup-reveal.test.ts
+++ b/src/main/window/createMainWindow-startup-reveal.test.ts
@@ -57,6 +57,7 @@ describe('createMainWindow', () => {
       on: vi.fn((event, handler) => {
         windowHandlers[event] = handler
       }),
+      removeListener: vi.fn(),
       isDestroyed: vi.fn(() => false),
       isMaximized: vi.fn(() => false),
       isFullScreen: vi.fn(() => false),

--- a/src/main/window/createMainWindow-system-resume-relay.test.ts
+++ b/src/main/window/createMainWindow-system-resume-relay.test.ts
@@ -48,6 +48,7 @@ describe('createMainWindow', () => {
         on: vi.fn((event: string, handler: (...args: any[]) => void) => {
           windowHandlers[event] = handler
         }),
+        removeListener: vi.fn(),
         isDestroyed: vi.fn(() => false),
         // Why: maximized keeps forceRepaint from scheduling its size-nudge timer.
         isMaximized: vi.fn(() => true),

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -7,6 +7,7 @@ import { getBrowserClientHostId } from '../browser/browser-client-host-id'
 import { formatBrowserClientHostIdArgument } from '../../shared/browser-client-host-id-argument'
 import { markSystemSessionEnding } from '../crash-reporting/expected-teardown-state'
 import { recordDurableCrashBreadcrumb } from '../crash-reporting/durable-crash-breadcrumb'
+import { installRendererUnresponsiveBreadcrumb } from '../crash-reporting/renderer-unresponsive-breadcrumb'
 import { clearTrustedUIRendererWebContentsId, setTrustedUIRendererWebContentsId } from '../ipc/ui'
 import type { Store } from '../persistence'
 import { closeDashboardPopout } from './dashboard-popout-window'
@@ -190,6 +191,9 @@ export function createMainWindow(
     reloadMainWindow: (observer) => loadMainWindow(mainWindow, observer),
     rendererWebContentsId
   })
+  const rendererUnresponsiveBreadcrumb = installRendererUnresponsiveBreadcrumb({
+    window: mainWindow
+  })
   // Register after focus is initialized because the resume callback uses it.
   powerMonitor.on('resume', onSystemResume)
   installMainWindowShortcutRouting({ focus, mainWindow, opts, store })
@@ -207,6 +211,7 @@ export function createMainWindow(
     state.clearInitialRevealFallbackTimer()
     closeLifecycle.dispose()
     focus.dispose()
+    rendererUnresponsiveBreadcrumb.dispose()
     browserManager.setDictationShortcutForwardingPredicate(null)
     powerMonitor.removeListener('resume', onSystemResume)
     clearTrustedUIRendererWebContentsId(rendererWebContentsId)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​377 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​377 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​289 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​289 |

<!-- /orca-pr-loc -->

## Summary

Adds a **main-process watchdog** that records a renderer main-thread freeze's memory curve *while it is happening*, so the next freeze-then-OOM crash lands with its allocation trail on record instead of a silent multi-minute gap.

This is a **diagnostic** change (crash-reporting breadcrumbs only) — it changes no user-facing behavior and fixes no crash directly. It exists to capture the one genuinely Orca-side, still-unexplained crash signature seen repeatedly in `#orca-crashes` on the released build (v1.4.197): a renderer that climbs to ~3.96 GB private memory over ~5 minutes and dies of an out-of-memory abort, while its own heartbeat has already been frozen the whole time — so today we get a blank gap exactly where the evidence should be.

## The problem (why the crash is invisible today)

The renderer reports its own memory via a 1-minute `renderer_memory` heartbeat. But the field signature is a **single long synchronous task on the renderer main thread**: once that task is running, the renderer's own `setInterval` never fires again. So the runaway allocation up to the V8 limit produces **no breadcrumbs at all** — the last heartbeat is from before the freeze, and the next event is `render-process-gone` several minutes later. The renderer cannot report on a freeze because the freeze is what stops it from reporting.

## The fix (observe from the one process that's still alive)

During a renderer freeze the **main process stays live**, so it can see what the renderer cannot:
- Electron's BrowserWindow `unresponsive` / `responsive` events fire.
- `app.getAppMetrics()` reads the frozen renderer's working set / private bytes from the OS.

On `unresponsive` the module records a `renderer_unresponsive` breadcrumb and starts a 30-second sampler that writes the **frozen renderer's own** memory (pid-filtered) as `renderer_unresponsive_sample` breadcrumbs, capped at 20 writes. On `responsive` it records a `renderer_responsive` summary (duration, sample count, peak working-set / private). The result: the next occurrence of this signature arrives with a per-30s memory curve showing the climb, instead of a gap.

## Clear, undeniable fix evidence

- **New unit suite, 14 tests, all green** (`renderer-unresponsive-breadcrumb.test.ts`): onset is recorded and the renderer climb is sampled from the main process; recovery reports duration + peak; sampling stops on recovery; sampling stops when the renderer dies; **the frozen renderer is isolated by pid — a second busy renderer at 1200 MB does not contaminate the 500 MB reading**; per-hang samples are capped at 20 so the breadcrumb ring can't be flooded; a `getAppMetrics()` throw is recorded as `processMetricsError` instead of taking down the main process; re-arm works both when the poll catches a persistent crash **and** when a prompt in-place reload the poll never sees swaps the renderer pid.
- **Integration is 5 lines** in `createMainWindow.ts`: install after the focus lifecycle, dispose in the `closed` handler (diff below). No behavior change to the window.
- `pnpm tc:node` clean; changed-code quality gate: **0 new findings** across 6 files; the 3 touched window test files (35 tests) still pass.

```
src/main/window/createMainWindow.ts
+ const rendererUnresponsiveBreadcrumb = installRendererUnresponsiveBreadcrumb({ window: mainWindow })
  ... (in 'closed' handler) ...
+ rendererUnresponsiveBreadcrumb.dispose()
```

## ELI5

Imagine a night watchman (the renderer) who is supposed to radio the front desk "all good" every minute. One night he gets stuck holding a door shut with all his weight and can't reach the radio — so the desk hears *silence*, and by the time anyone checks, he's collapsed. We can't make him radio while both hands are busy. So instead we put a **camera in the hallway** (the main process, which is never stuck): the moment he stops responding, the camera starts taking a photo every 30 seconds showing how hard he's straining. Now when he collapses, we have the whole sequence on film instead of a blank tape.

## Trade-offs / honest limitations

- **It does not fix the crash.** It's instrumentation to diagnose an unreproducible signature. The actual OOM fix depends on what the captured curve reveals (native/DOM/GPU-backed growth outside the JS heap — the JS heap stays flat at ~50 MB in every report, so this is *not* a JS-heap leak).
- **Coverage gap — input-driven only.** Electron's `unresponsive` is fired by Chromium's input-ACK hang monitor, which only arms after an input event is dispatched to the renderer. A wholly idle/background freeze with no pending input may never surface `unresponsive`. This captures interactive freezes (which every field report was) but not a silent background one; an input-independent heartbeat-gap watchdog is the natural follow-up.
- **Breadcrumb-ring pressure is bounded.** Each sample force-flushes the 30-entry durable ring, so the 20-write cap deliberately stops a wedged-but-alive renderer from evicting all pre-freeze context; the recovery summary still carries peak/count/duration past the cap.
- **No new wire/IPC surface, no remote/SSH behavior change** — main-process-local, reuses the existing `collectProcessGoneMetricDetails` and durable-breadcrumb sink.

## Adversarial review

Five review loops, each a fresh multi-agent workflow (3 independent review lenses × per-finding adversarial verification that defaults to *refuted*). Loops 1–4 each surfaced confirmed defects that were fixed before the next loop ran; loop 5 returned **zero confirmed findings** (all three independent lenses — correctness, identity-robustness, resource/failure — came back empty against the composite-identity fix).

- **Loop 1** — confirmed: the death path stopped the sampler but never cleared the freeze-onset state, permanently wedging the module after the first crash. Fixed (state is reset on death). Also removed webContents listeners that collided with the focus-lifecycle's own, in favor of the main-process vantage.
- **Loop 2** — confirmed: `dispose()` re-read the `window.webContents` getter on an already-destroyed window (throws, aborting sibling cleanup); the default metrics collector wasn't guarded against `getAppMetrics()` throwing; samples were uncapped; and the metrics aggregate summed *all* renderers instead of the frozen one. Fixed: capture `const webContents` at install, wrap the collector in try/catch, cap at 20, and pid-filter to the frozen renderer.
- **Loop 3** — confirmed (major): death detection was gated on a 30s poll of `isCrashed()`, which loses the race to the ~250ms in-place recovery reload — so `reset()` rarely fired and the wedge returned, worst once the sample cap had already stopped the timer. Also: the "pid resolved" flag conflated *no pid* with *pid resolved but absent from the metrics table*, and `isCrashed()` wasn't destroy-guarded. Fixed: **re-arm is now keyed on the renderer OS pid** (a reloaded-in-place renderer reuses the same webContents under a new pid), so `onUnresponsive` treats a freeze whose onset pid differs from the live pid as a fresh freeze and the sampler resets the instant the pid changes — independent of catching the transient crashed state and independent of the timer surviving the cap; split the flag into `PidResolved:false` vs `AbsentFromMetrics:true`; guarded `isCrashed()` behind `isDestroyed()`.
- **Loop 4** — confirmed (major): re-arm keyed on the renderer OS **pid alone** is defeated by **pid reuse across an in-place reload**. When the OOM'd renderer reloads in place, the OS can reassign the dead process's pid to the fresh renderer (Windows recycles freed pids aggressively); every pid comparison then reads "unchanged" and the module collapses back to the pre-fix silent-gap wedge (the reloaded renderer's next freeze dropped as a stale duplicate; a post-reload sample tick misattributing the new renderer's memory to the dead hang's clock). The verification agents rated this a real, Windows-prone reliability gap, citing the sibling `process-gone-diagnostics.ts`, which already pairs pid with `creationTime` for exactly this recycled-pid disambiguation. Fixed: **identity is now `(pid, creationTime)`** — a reloaded renderer is a newly-spawned process, so its `creationTime` differs even when the pid repeats; comparison degrades to pid equality only when `creationTime` is unavailable, and an unresolved identity re-arms (never swallows a possibly-reloaded freeze). Added tests pinning the same-pid/new-`creationTime` re-arm and the unresolved-onset re-arm.
- **Loop 5** — clean: all three independent review lenses returned zero findings against the `(pid, creationTime)` fix, so no finding reached the verification stage. This is the loop that closes the "review until clean" gate.

Refuted/acknowledged across loops: the `unresponsive` input-ACK coverage gap is a documented limitation (see Trade-offs), not a defect; BrowserWindow (vs webContents) as the event source is correct.
