### PR TITLE
fix(release): restore minified telemetry fallback and prune natives before the arch floor check

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -279,16 +279,6 @@ module.exports = {
     }
   },
   afterPack: async (context) => {
-    // Why: a Linux runner-image glibc bump silently shipped a node-pty pty.node
-    // requiring GLIBC_2.34, crashing the app on startup on Ubuntu 20.04 (#9902).
-    // Fail packaging if any bundled native binary exceeds the supported floor.
-    if (context.electronPlatformName === 'linux') {
-      // Why the arch is passed: symbol-version checks pass happily on a wrong-architecture binary,
-      // so a cross-built slice could ship the host's pty.node and only fail at runtime.
-      verifyLinuxGlibcFloor(context.appOutDir, {
-        targetArch: { 1: 'x64', 3: 'arm64' }[context.arch]
-      })
-    }
     const resourcesDir =
       context.electronPlatformName === 'darwin'
         ? join(
@@ -326,6 +316,18 @@ module.exports = {
     }
     stampPackagedCliVersion(resourcesDir, context.packager.appInfo.version)
     prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName, context.arch)
+    // Why: a Linux runner-image glibc bump silently shipped a node-pty pty.node
+    // requiring GLIBC_2.34, crashing the app on startup on Ubuntu 20.04 (#9902).
+    // Fail packaging if any bundled native binary exceeds the supported floor.
+    // Must follow the prune: a cross-build installs every optional native variant,
+    // so before it the arm64 slice still carries the x64 packages it will not ship.
+    if (context.electronPlatformName === 'linux') {
+      // Why the arch is passed: symbol-version checks pass happily on a wrong-architecture binary,
+      // so a cross-built slice could ship the host's pty.node and only fail at runtime.
+      verifyLinuxGlibcFloor(context.appOutDir, {
+        targetArch: { 1: 'x64', 3: 'arm64' }[context.arch]
+      })
+    }
     verifyPackagedMainRuntimeDeps(resourcesDir)
     // Why: boot the packaged daemon-entry under plain Node, but only for the
     // slice matching the packaging host's arch — daemon-entry.js is JS, yet it

--- a/config/scripts/telemetry-bundle-constant-patterns.mjs
+++ b/config/scripts/telemetry-bundle-constant-patterns.mjs
@@ -1,2 +1,6 @@
-export const BUILD_IDENTITY_RE = /\b(?:const|let|var)\s+BUILD_IDENTITY\s*=\s*"(rc|stable)"/
-export const WRITE_KEY_RE = /\b(?:const|let|var)\s+WRITE_KEY\s*=\s*"(phc_[A-Za-z0-9_-]+)"/
+// The unminified bundle keeps these names. Production minification may rename
+// them, but the injected identity and key remain adjacent in the declaration.
+export const BUILD_IDENTITY_RE = /\b(?:const|let|var)\s+BUILD_IDENTITY\s*=\s*["`](rc|stable)["`]/
+export const WRITE_KEY_RE = /\b(?:const|let|var)\s+WRITE_KEY\s*=\s*["`](phc_[A-Za-z0-9_-]+)["`]/
+export const MINIFIED_TELEMETRY_RE =
+  /\b(?:const|let|var)\s+[$\w]+\s*=\s*["'`](rc|stable)["'`][\s\S]{0,200}?[,$]\s*[$\w]+\s*=\s*["'`](phc_[A-Za-z0-9_-]+)["'`]/

--- a/config/scripts/telemetry-bundle-constant-patterns.test.mjs
+++ b/config/scripts/telemetry-bundle-constant-patterns.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { BUILD_IDENTITY_RE, WRITE_KEY_RE } from './telemetry-bundle-constant-patterns.mjs'
+import {
+  BUILD_IDENTITY_RE,
+  MINIFIED_TELEMETRY_RE,
+  WRITE_KEY_RE
+} from './telemetry-bundle-constant-patterns.mjs'
 
 describe('telemetry bundle constant patterns', () => {
   it.each(['const', 'let', 'var'])('accepts %s declarations', (declaration) => {
@@ -12,5 +16,10 @@ describe('telemetry bundle constant patterns', () => {
     expect('const BUILD_IDENTITY = "dev"').not.toMatch(BUILD_IDENTITY_RE)
     expect('const WRITE_KEY = null').not.toMatch(WRITE_KEY_RE)
     expect('const WRITE_KEY = "example-key"').not.toMatch(WRITE_KEY_RE)
+  })
+
+  it('accepts minified adjacent declarations', () => {
+    const bundle = 'var dde=`stable`,fde=`phc_example-key_123`,pde=(dde===`stable`)'
+    expect(bundle).toMatch(MINIFIED_TELEMETRY_RE)
   })
 })

--- a/config/scripts/verify-telemetry-constants.mjs
+++ b/config/scripts/verify-telemetry-constants.mjs
@@ -38,7 +38,11 @@ import { join, resolve } from 'node:path'
 // `node_modules`). If electron-builder ever drops it, promote this to a
 // direct devDependency in package.json.
 import { extractFile, listPackage } from '@electron/asar'
-import { BUILD_IDENTITY_RE, WRITE_KEY_RE } from './telemetry-bundle-constant-patterns.mjs'
+import {
+  BUILD_IDENTITY_RE,
+  MINIFIED_TELEMETRY_RE,
+  WRITE_KEY_RE
+} from './telemetry-bundle-constant-patterns.mjs'
 
 // Why resolve from import.meta.url instead of cwd: a release runner (or a
 // developer debugging locally) may invoke this script from a non-root cwd.
@@ -156,8 +160,14 @@ function verifyAsar(asarPath) {
 
   const buildIdentityMatch = BUILD_IDENTITY_RE.exec(indexJs)
   const writeKeyMatch = WRITE_KEY_RE.exec(indexJs)
+  const minifiedTelemetryMatch = MINIFIED_TELEMETRY_RE.exec(indexJs)
 
-  if (!buildIdentityMatch) {
+  // Rolldown renames module-local constants in production output. In that
+  // form, verify the adjacent injected identity/key declaration instead.
+  const verifiedIdentity = buildIdentityMatch?.[1] ?? minifiedTelemetryMatch?.[1]
+  const verifiedWriteKey = writeKeyMatch?.[1] ?? minifiedTelemetryMatch?.[2]
+
+  if (!verifiedIdentity) {
     console.error(`::error::BUILD_IDENTITY constant missing or unexpected value in ${asarPath}`)
     const sample = indexJs.match(/.{0,80}BUILD_IDENTITY.{0,80}/g)?.slice(0, 5) ?? []
     for (const line of sample) {
@@ -165,7 +175,7 @@ function verifyAsar(asarPath) {
     }
     return null
   }
-  if (!writeKeyMatch) {
+  if (!verifiedWriteKey) {
     console.error(`::error::PostHog WRITE_KEY missing from ${asarPath}`)
     const sample = indexJs.match(/.{0,80}WRITE_KEY.{0,80}/g)?.slice(0, 5) ?? []
     for (const line of sample) {
@@ -174,7 +184,7 @@ function verifyAsar(asarPath) {
     return null
   }
 
-  return { asarPath, buildIdentity: buildIdentityMatch[1], writeKey: writeKeyMatch[1] }
+  return { asarPath, buildIdentity: verifiedIdentity, writeKey: verifiedWriteKey }
 }
 
 // Why verify every match (not just the first): macOS dual-arch produces one


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

> **Attribution.** This is not a new fix. It ports commit
> [`35f1b0ebb91912c3a38b735d2d845e3b0739e8f0`](https://github.com/stablyai/orca/commit/35f1b0ebb91912c3a38b735d2d845e3b0739e8f0)
> — *"fix(release): validate minified telemetry and prune target natives first"*, authored 2026-09-03 by
> **Jinwoo-H &lt;jinwoo0825@gmail.com&gt;** on the `v1.4.197` release branch. Both halves below were
> diagnosed and written correctly by them at the time; the only thing that went wrong is that the commit
> landed on a release branch and was never merged back to `main`. Credited as `Co-authored-by` on both
> commits here. My contribution is the port, the root-cause write-up, and the verification below.

Both halves are release blockers, and because they never reached `main`, **`main` cannot currently produce a publishable build on any platform.**

`v1.4.197` is diverged from `main`, not an ancestor of it — 4 ahead / 513 behind, merge-base `0f22e1e9051` — which is why the fixes have stayed invisible here.

---

# Half 1 — the telemetry asar verify cannot see a minified constant

Every release build (macOS, Windows, linux-x64, linux-arm64) fails the step **"Verify telemetry constants present in app.asar"**, which blocks `publish-release`:

```
::error::BUILD_IDENTITY constant missing or unexpected value in
dist/mac-arm64/Orca.app/Contents/Resources/app.asar
```

The step runs in both `.github/workflows/release-mac-build.yml:178` and `.github/workflows/release-cut.yml`, so no platform gets past it.

## Root cause

`config/scripts/verify-telemetry-constants.mjs` greps the packed `app.asar` for the module-local declarations `BUILD_IDENTITY` and `WRITE_KEY` from `src/main/telemetry/client.ts:25`. That held when the check was written (**#11019**, 2026-07-28) — and its own comment said exactly what would break it:

> electron-vite's main config is not minified (Vite default for Electron main builds) … NOTE: if `build.minify` is ever enabled on the main bundle, esbuild/terser will rename top-level consts and this regex must be revisited.

**#17527** (`perf(build): minify desktop JavaScript bundles without dropping crash context`, 2026-08-31) did that: it added `minify: 'oxc'` to the main bundle in `electron.vite.config.ts`. oxc renames both module-locals, so the literal string `BUILD_IDENTITY` no longer appears anywhere in the shipped bundle and the regex can never match a production build.

## The fix

`MINIFIED_TELEMETRY_RE` matches the *adjacent injected identity/key pair* rather than the declaration names, which minification preserves. The verify falls back to it only when the named declarations are absent, so unminified builds keep their stricter, name-anchored assertion:

```js
const verifiedIdentity = buildIdentityMatch?.[1] ?? minifiedTelemetryMatch?.[1]
const verifiedWriteKey = writeKeyMatch?.[1] ?? minifiedTelemetryMatch?.[2]
```

The quote class on the named patterns also accepts backticks, which is what oxc emits for these strings. Everything downstream — the cross-arch agreement checks, the `TELEMETRY_ENABLED=false` skip, the failure diagnostics — is unchanged.

## Empirical verification

Built the real bundle locally with the release env vars:

```
ORCA_BUILD_IDENTITY=stable ORCA_POSTHOG_WRITE_KEY=phc_TestKey_abc123 \
  node config/scripts/run-electron-vite-build.mjs
```

then tested the patterns against the 94 `.js` files under `out/main/` (11.3 MB):

| check | result |
| --- | --- |
| bundle contains the literal string `BUILD_IDENTITY` | **false** |
| bundle contains the literal string `WRITE_KEY` | **false** |
| `BUILD_IDENTITY_RE` (before, `"`-only) matches | **false** |
| `BUILD_IDENTITY_RE` (after, backtick-tolerant) matches | **false** |
| `WRITE_KEY_RE` (after) matches | **false** |
| `MINIFIED_TELEMETRY_RE` (restored) matches | **true** |

The fallback recovers `identity=stable`, `writeKey=phc_TestKey_abc123` from the emitted text ``var xde=`stable`,Sde=`phc_TestKey_abc123` ``.

So today's gate is not a true finding about missing constants — the constants *are* correctly injected; the check simply cannot see them.

### Negative control

Rebuilt the same bundle with `ORCA_BUILD_IDENTITY` / `ORCA_POSTHOG_WRITE_KEY` **unset** — the exact regression this gate exists to catch (an `IS_OFFICIAL_BUILD === false` binary shipping silently). With the restored fallback in place:

| pattern | matches |
| --- | --- |
| `BUILD_IDENTITY_RE` | false |
| `WRITE_KEY_RE` | false |
| `MINIFIED_TELEMETRY_RE` | false |

→ the verify still **fails**, as it must. The fallback widens the gate to a minified bundle without weakening what it asserts.

---

# Half 2 — the linux arch floor check inspects natives that get pruned

The linux-arm64 release build fails packaging, deterministically, through all three internal retries:

```
[verify-linux-glibc-floor] 1 bundled native binary is built for the wrong architecture (target arm64):
  resources/node_modules/@parcel/watcher-linux-x64-glibc/watcher.node is x64, expected arm64 (from its own path)
```

## Root cause

In `config/electron-builder.config.cjs`, `verifyLinuxGlibcFloor(...)` ran at the **top** of `afterPack`, before `prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName, context.arch)`. A cross-build installs every optional native variant on purpose, so at check time the arm64 slice still carries the x64 `@parcel/watcher` package that the prune exists to remove. The check rejects a file that was never going to ship.

## The fix

Move the block to immediately after the prune, with a comment recording the ordering constraint. The `#9902` / `GLIBC_2.34` rationale and the "why the arch is passed" note are preserved verbatim. Pure reordering — no change to what is asserted.

`node --check config/electron-builder.config.cjs` passes, and `prunePackagedRuntimeNodeModules` (line 318) now precedes `verifyLinuxGlibcFloor` (line 327).

> Not taken from the `v1.4.197` copy of this file wholesale: that branch is 513 commits behind, so its version also drops the emojibase shortcode resource and the SignPath uninstaller signing hook. Only the reorder is applied here.

---

## Tests

`config/scripts/telemetry-bundle-constant-patterns.test.mjs` regains the `accepts minified adjacent declarations` case that pins the minified shape:

```
npx vitest run --config config/vitest.config.ts \
  config/scripts/telemetry-bundle-constant-patterns.test.mjs
→ Test Files 1 passed (1) | Tests 5 passed (5)
```

`config/scripts/release-blocker-fixes.test.mjs` from the release branch is deliberately **not** ported — its assertions are release-branch-specific (a `>= 1.4.196` version floor and a staging-workflow input check).
