### PR TITLE
feat(terminal): equalize pane sizes after a split behind a setting

### DIFF
--- a/src/renderer/src/components/settings/TerminalPaneAppearanceSection.tsx
+++ b/src/renderer/src/components/settings/TerminalPaneAppearanceSection.tsx
@@ -1,6 +1,6 @@
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY } from '../../../../shared/constants'
-import { NumberField, SettingsSubsectionHeader } from './SettingsFormControls'
+import { NumberField, SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
 import { clampNumber, resolvePaneStyleOptions } from '@/lib/terminal-theme'
 import { translate } from '@/i18n/i18n'
@@ -86,6 +86,34 @@ export function TerminalPaneAppearanceSection({
             onChange={(value) =>
               updateSettings({
                 terminalDividerThicknessPx: clampNumber(value, 1, 32)
+              })
+            }
+          />
+        </SearchableSetting>
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.TerminalAppearanceSection.equalizePanesOnSplit.title',
+            'Equalize Panes After Split'
+          )}
+          description={translate(
+            'auto.components.settings.TerminalAppearanceSection.equalizePanesOnSplit.description',
+            'Give every pane in the tab an equal share after a split, instead of halving only the active pane. Sizes you drag afterwards are kept.'
+          )}
+          keywords={['pane', 'split', 'equalize', 'even', 'balance', 'resize', 'layout']}
+        >
+          <SettingsSwitchRow
+            label={translate(
+              'auto.components.settings.TerminalAppearanceSection.equalizePanesOnSplit.title',
+              'Equalize Panes After Split'
+            )}
+            description={translate(
+              'auto.components.settings.TerminalAppearanceSection.equalizePanesOnSplit.description',
+              'Give every pane in the tab an equal share after a split, instead of halving only the active pane. Sizes you drag afterwards are kept.'
+            )}
+            checked={settings.terminalEqualizePanesOnSplit}
+            onChange={() =>
+              updateSettings({
+                terminalEqualizePanesOnSplit: !settings.terminalEqualizePanesOnSplit
               })
             }
           />

--- a/src/renderer/src/components/settings/terminal-pane-appearance-search.ts
+++ b/src/renderer/src/components/settings/terminal-pane-appearance-search.ts
@@ -30,6 +30,25 @@ export const getTerminalPaneAppearanceSearchEntries = createLocalizedCatalog(() 
       ...translateSearchKeyword('auto.components.settings.terminal.search.781f49d942', 'divider'),
       ...translateSearchKeyword('auto.components.settings.terminal.search.f637a7dee9', 'thickness')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.terminal.search.equalizePanesOnSplit.title',
+      'Equalize Panes After Split'
+    ),
+    description: translate(
+      'auto.components.settings.terminal.search.equalizePanesOnSplit.description',
+      'Give every pane in the tab an equal share after a split, instead of halving only the active pane. Sizes you drag afterwards are kept.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.terminal.search.846a7a1204', 'pane'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.split', 'split'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.equalize', 'equalize'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.even', 'even'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.balance', 'balance'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.resize', 'resize'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.layout', 'layout')
+    ]
   }
 ])
 

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -4,7 +4,7 @@ export type { SearchState, SearchNavigationDirection } from './terminal-keyboard
 
 export {
   resolveTerminalKeyboardShortcutAction,
-  recordKeyboardCreatedTerminalPaneSplit,
+  completeKeyboardCreatedTerminalPaneSplit,
   matchSearchNavigate,
   runTerminalSearchNavigation,
   matchFileSearchShortcut

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-shortcut-matching.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-shortcut-matching.ts
@@ -8,7 +8,10 @@ import {
   type TerminalShortcutPolicy
 } from '../../../../shared/keybindings'
 import { isFindQueryTooLarge } from '@/lib/find-query-bounds'
-import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
+import {
+  completeCreatedTerminalPaneSplit,
+  type TerminalPaneSplitCompletion
+} from './terminal-pane-split-completion'
 
 export function resolveTerminalKeyboardShortcutAction(
   event: Parameters<typeof resolveTerminalShortcutAction>[0],
@@ -42,11 +45,13 @@ export function resolveTerminalKeyboardShortcutAction(
   )
 }
 
-export function recordKeyboardCreatedTerminalPaneSplit(
+export function completeKeyboardCreatedTerminalPaneSplit(
   createdPane: unknown,
-  args: { source: 'contextual_tour' | 'keyboard'; direction: 'vertical' | 'horizontal' }
+  args: Omit<TerminalPaneSplitCompletion, 'source'> & {
+    source: 'contextual_tour' | 'keyboard'
+  }
 ): boolean {
-  return recordCreatedTerminalPaneSplit(createdPane, args)
+  return completeCreatedTerminalPaneSplit(createdPane, args)
 }
 
 export function isEditableTarget(target: EventTarget | null): boolean {

--- a/src/renderer/src/components/terminal-pane/terminal-pane-lifecycle-primitives.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-lifecycle-primitives.ts
@@ -4,10 +4,12 @@ import type { PtyTransport } from './pty-transport'
 import type { PaneCwdMap } from './resolve-split-cwd'
 import { writeTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { RESET_KITTY_KEYBOARD_PROTOCOL } from '../../../../shared/terminal-mode-reset-profiles'
-import type { TerminalPaneSplitSource } from '../../../../shared/feature-education-telemetry'
 import type { HttpLinkSourceOwner } from '@/lib/http-link-routing'
 import { resolveLocalhostHttpLinkDisplayUrl } from '@/lib/http-link-routing'
-import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
+import {
+  completeCreatedTerminalPaneSplit,
+  type TerminalPaneSplitCompletion
+} from './terminal-pane-split-completion'
 import { PRIMARY_SELECTION_MAX_LENGTH } from '@/lib/primary-selection'
 
 /** Writes a transport-agnostic interrupt reset without running xterm work inline. */
@@ -18,15 +20,11 @@ export function resetTerminalKeyboardProtocolAfterInterrupt(terminal: Terminal):
   })
 }
 
-export function recordRuntimeCreatedTerminalPaneSplit(
+export function completeRuntimeCreatedTerminalPaneSplit(
   createdPane: unknown,
-  args: {
-    source: TerminalPaneSplitSource
-    direction: 'vertical' | 'horizontal'
-    telemetrySuppressed?: boolean
-  }
+  args: TerminalPaneSplitCompletion
 ): boolean {
-  return recordCreatedTerminalPaneSplit(createdPane, args)
+  return completeCreatedTerminalPaneSplit(createdPane, args)
 }
 
 export type TerminalScrollbackPaneManager = {

--- a/src/renderer/src/components/terminal-pane/terminal-pane-mount-events.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-mount-events.ts
@@ -7,7 +7,7 @@ import { useAppStore } from '@/store'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import {
   splitPaneWithOneShotStartup,
-  recordRuntimeCreatedTerminalPaneSplit
+  completeRuntimeCreatedTerminalPaneSplit
 } from './terminal-pane-lifecycle-primitives'
 import { applyTerminalPaneCloseRequest } from './terminal-pane-lifecycle-close'
 import {
@@ -55,19 +55,21 @@ export function installTerminalPaneMountEvents(args: {
         const createdPane = splitPaneWithOneShotStartup(ptyDeps, { command: detail.command }, () =>
           mgr.splitPane(sourcePaneId, detail.direction, splitOptions)
         )
-        recordRuntimeCreatedTerminalPaneSplit(createdPane, {
+        completeRuntimeCreatedTerminalPaneSplit(createdPane, {
           source: detail.telemetrySource ?? 'command',
-          direction: detail.direction
+          direction: detail.direction,
+          equalizeTarget: { tabId: deps.tabId, manager: mgr }
         })
       } else {
         const createdPane = mgr.splitPane(sourcePaneId, detail.direction, splitOptions)
         const telemetrySuppressed = createdPane
           ? consumePendingWebRuntimeSplitMirrorTelemetry(detail.sourcePtyId, detail.direction)
           : false
-        recordRuntimeCreatedTerminalPaneSplit(createdPane, {
+        completeRuntimeCreatedTerminalPaneSplit(createdPane, {
           source: detail.telemetrySource ?? 'command',
           direction: detail.direction,
-          telemetrySuppressed
+          telemetrySuppressed,
+          equalizeTarget: { tabId: deps.tabId, manager: mgr }
         })
       }
     }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-completion.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-completion.test.ts
@@ -1,15 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import {
+  completeCreatedTerminalPaneSplit,
+  type TerminalPaneSplitEqualizeTarget
+} from './terminal-pane-split-completion'
 
 const mocks = vi.hoisted(() => ({
   recordFeatureInteraction: vi.fn(),
-  trackTerminalPaneSplit: vi.fn()
+  trackTerminalPaneSplit: vi.fn(),
+  settings: { terminalEqualizePanesOnSplit: false } as Record<string, unknown> | null,
+  expandedPaneByTabId: {} as Record<string, boolean>
 }))
 
 vi.mock('@/store', () => ({
   useAppStore: {
     getState: () => ({
-      recordFeatureInteraction: mocks.recordFeatureInteraction
+      recordFeatureInteraction: mocks.recordFeatureInteraction,
+      settings: mocks.settings,
+      expandedPaneByTabId: mocks.expandedPaneByTabId
     })
   }
 }))
@@ -18,15 +25,23 @@ vi.mock('@/lib/feature-education-telemetry', () => ({
   trackTerminalPaneSplit: mocks.trackTerminalPaneSplit
 }))
 
-describe('recordCreatedTerminalPaneSplit', () => {
+function makeEqualizeTarget(): TerminalPaneSplitEqualizeTarget & {
+  manager: { equalizePaneSizes: Mock<() => void> }
+} {
+  return { tabId: 'tab-1', manager: { equalizePaneSizes: vi.fn<() => void>() } }
+}
+
+describe('completeCreatedTerminalPaneSplit', () => {
   beforeEach(() => {
     mocks.recordFeatureInteraction.mockReset()
     mocks.trackTerminalPaneSplit.mockReset()
+    mocks.settings = { terminalEqualizePanesOnSplit: false }
+    mocks.expandedPaneByTabId = {}
   })
 
   it('does not record durable split completion when no pane was created', () => {
     expect(
-      recordCreatedTerminalPaneSplit(null, {
+      completeCreatedTerminalPaneSplit(null, {
         source: 'keyboard',
         direction: 'vertical'
       })
@@ -38,7 +53,7 @@ describe('recordCreatedTerminalPaneSplit', () => {
 
   it('records durable split completion and telemetry after a pane is created', () => {
     expect(
-      recordCreatedTerminalPaneSplit(
+      completeCreatedTerminalPaneSplit(
         { id: 2 },
         {
           source: 'context_menu',
@@ -56,7 +71,7 @@ describe('recordCreatedTerminalPaneSplit', () => {
 
   it('keeps durable split completion when mirrored runtime telemetry is suppressed', () => {
     expect(
-      recordCreatedTerminalPaneSplit(
+      completeCreatedTerminalPaneSplit(
         { id: 2 },
         {
           source: 'command',
@@ -68,5 +83,76 @@ describe('recordCreatedTerminalPaneSplit', () => {
 
     expect(mocks.recordFeatureInteraction).toHaveBeenCalledWith('terminal-pane-split')
     expect(mocks.trackTerminalPaneSplit).not.toHaveBeenCalled()
+  })
+
+  it('equalizes the tab after a split when terminalEqualizePanesOnSplit is on', () => {
+    mocks.settings = { terminalEqualizePanesOnSplit: true }
+    const target = makeEqualizeTarget()
+
+    completeCreatedTerminalPaneSplit(
+      { id: 2 },
+      { source: 'keyboard', direction: 'vertical', equalizeTarget: target }
+    )
+
+    expect(target.manager.equalizePaneSizes).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves split ratios alone when the setting is off', () => {
+    const target = makeEqualizeTarget()
+
+    completeCreatedTerminalPaneSplit(
+      { id: 2 },
+      { source: 'keyboard', direction: 'vertical', equalizeTarget: target }
+    )
+
+    expect(target.manager.equalizePaneSizes).not.toHaveBeenCalled()
+  })
+
+  it('does not equalize when the split failed', () => {
+    mocks.settings = { terminalEqualizePanesOnSplit: true }
+    const target = makeEqualizeTarget()
+
+    completeCreatedTerminalPaneSplit(null, {
+      source: 'keyboard',
+      direction: 'vertical',
+      equalizeTarget: target
+    })
+
+    expect(target.manager.equalizePaneSizes).not.toHaveBeenCalled()
+  })
+
+  it('does not equalize while the tab has an expanded pane', () => {
+    mocks.settings = { terminalEqualizePanesOnSplit: true }
+    mocks.expandedPaneByTabId = { 'tab-1': true }
+    const target = makeEqualizeTarget()
+
+    completeCreatedTerminalPaneSplit(
+      { id: 2 },
+      { source: 'keyboard', direction: 'vertical', equalizeTarget: target }
+    )
+
+    expect(target.manager.equalizePaneSizes).not.toHaveBeenCalled()
+  })
+
+  it('does not equalize for callers that rebuild a persisted layout', () => {
+    mocks.settings = { terminalEqualizePanesOnSplit: true }
+
+    expect(
+      completeCreatedTerminalPaneSplit({ id: 2 }, { source: 'command', direction: 'vertical' })
+    ).toBe(true)
+
+    expect(mocks.recordFeatureInteraction).toHaveBeenCalledWith('terminal-pane-split')
+  })
+
+  it('tolerates settings that have not hydrated yet', () => {
+    mocks.settings = null
+    const target = makeEqualizeTarget()
+
+    completeCreatedTerminalPaneSplit(
+      { id: 2 },
+      { source: 'keyboard', direction: 'vertical', equalizeTarget: target }
+    )
+
+    expect(target.manager.equalizePaneSizes).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-completion.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-completion.ts
@@ -2,13 +2,21 @@ import { trackTerminalPaneSplit } from '@/lib/feature-education-telemetry'
 import { useAppStore } from '@/store'
 import type { TerminalPaneSplitSource } from '../../../../shared/feature-education-telemetry'
 
+/** Minimal manager surface: split completion only ever equalizes. */
+export type TerminalPaneSplitEqualizeTarget = {
+  tabId: string
+  manager: { equalizePaneSizes: () => void }
+}
+
 export type TerminalPaneSplitCompletion = {
   source: TerminalPaneSplitSource
   direction: 'vertical' | 'horizontal'
   telemetrySuppressed?: boolean
+  /** Omitted by paths that rebuild a persisted layout, which must keep its stored ratios. */
+  equalizeTarget?: TerminalPaneSplitEqualizeTarget
 }
 
-export function recordCreatedTerminalPaneSplit(
+export function completeCreatedTerminalPaneSplit(
   createdPane: unknown,
   completion: TerminalPaneSplitCompletion
 ): boolean {
@@ -22,5 +30,23 @@ export function recordCreatedTerminalPaneSplit(
       direction: completion.direction
     })
   }
+  equalizePanesAfterSplit(completion.equalizeTarget)
   return true
+}
+
+/** Applies terminalEqualizePanesOnSplit at split time only, so later sash drags survive. */
+function equalizePanesAfterSplit(target: TerminalPaneSplitEqualizeTarget | undefined): void {
+  if (!target) {
+    return
+  }
+  const state = useAppStore.getState()
+  if (!state.settings?.terminalEqualizePanesOnSplit) {
+    return
+  }
+  // Why: an expanded pane owns every flex value; equalizing under it is invisible
+  // and lost on collapse, so the manual equalize command bails the same way.
+  if (state.expandedPaneByTabId[target.tabId]) {
+    return
+  }
+  target.manager.equalizePaneSizes()
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.test.ts
@@ -6,7 +6,7 @@ import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-in
 import { createDeferred } from './pty-connection-test-async'
 
 const mocks = vi.hoisted(() => ({
-  recordCreatedTerminalPaneSplit: vi.fn(),
+  completeCreatedTerminalPaneSplit: vi.fn(),
   resolveSplitCwd: vi.fn(),
   splitWebRuntimeTerminal: vi.fn()
 }))
@@ -20,7 +20,7 @@ vi.mock('./resolve-split-cwd', () => ({
 }))
 
 vi.mock('./terminal-pane-split-completion', () => ({
-  recordCreatedTerminalPaneSplit: mocks.recordCreatedTerminalPaneSplit
+  completeCreatedTerminalPaneSplit: mocks.completeCreatedTerminalPaneSplit
 }))
 
 function makeManager(splitPane: ReturnType<typeof vi.fn>): PaneManager {
@@ -29,7 +29,7 @@ function makeManager(splitPane: ReturnType<typeof vi.fn>): PaneManager {
 
 describe('splitTerminalPaneWithInheritedCwd', () => {
   beforeEach(() => {
-    mocks.recordCreatedTerminalPaneSplit.mockReset()
+    mocks.completeCreatedTerminalPaneSplit.mockReset()
     mocks.resolveSplitCwd.mockReset()
     mocks.splitWebRuntimeTerminal.mockReset()
     mocks.splitWebRuntimeTerminal.mockReturnValue(false)
@@ -81,9 +81,10 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
     })
 
     expect(splitPane).toHaveBeenCalledWith(1, 'horizontal', { cwd: '/cached' })
-    expect(mocks.recordCreatedTerminalPaneSplit).toHaveBeenCalledWith(createdPane, {
+    expect(mocks.completeCreatedTerminalPaneSplit).toHaveBeenCalledWith(createdPane, {
       source: 'keyboard',
-      direction: 'horizontal'
+      direction: 'horizontal',
+      equalizeTarget: { tabId: 'tab-1', manager: expect.objectContaining({ splitPane }) }
     })
   })
 
@@ -126,9 +127,14 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
     })
     expect(staleSplitPane).not.toHaveBeenCalled()
     expect(liveSplitPane).toHaveBeenCalledWith(1, 'vertical', { cwdPromise: cwd.promise })
-    expect(mocks.recordCreatedTerminalPaneSplit).toHaveBeenCalledWith(createdPane, {
+    expect(mocks.completeCreatedTerminalPaneSplit).toHaveBeenCalledWith(createdPane, {
       source: 'keyboard',
-      direction: 'vertical'
+      direction: 'vertical',
+      // Why: the live manager, not the stale one captured at call time, owns the equalize.
+      equalizeTarget: {
+        tabId: 'tab-1',
+        manager: expect.objectContaining({ splitPane: liveSplitPane })
+      }
     })
 
     const spawnHints = liveSplitPane.mock.calls[0]?.[2] as
@@ -207,6 +213,6 @@ describe('splitTerminalPaneWithInheritedCwd', () => {
 
     expect(staleSplitPane).not.toHaveBeenCalled()
     expect(mocks.resolveSplitCwd).not.toHaveBeenCalled()
-    expect(mocks.recordCreatedTerminalPaneSplit).not.toHaveBeenCalled()
+    expect(mocks.completeCreatedTerminalPaneSplit).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-with-inherited-cwd.ts
@@ -3,7 +3,7 @@ import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import { splitWebRuntimeTerminal } from '@/runtime/web-runtime-session'
 import type { PtyTransport } from './pty-transport'
 import { resolveSplitCwd, type PaneCwdMap } from './resolve-split-cwd'
-import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
+import { completeCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 
 export function splitTerminalPaneWithInheritedCwd(args: {
   worktreeId: string
@@ -34,9 +34,10 @@ export function splitTerminalPaneWithInheritedCwd(args: {
   const cached = args.paneCwdMap.get(args.pane.id)
   if (cached?.confirmed && cached.cwd) {
     const createdPane = manager.splitPane(args.pane.id, args.direction, { cwd: cached.cwd })
-    recordCreatedTerminalPaneSplit(createdPane, {
+    completeCreatedTerminalPaneSplit(createdPane, {
       source: args.source,
-      direction: args.direction
+      direction: args.direction,
+      equalizeTarget: { tabId: args.tabId, manager }
     })
     return
   }
@@ -50,8 +51,9 @@ export function splitTerminalPaneWithInheritedCwd(args: {
       fallbackCwd: args.fallbackCwd
     })
   const createdPane = manager.splitPane(paneId, args.direction, { cwdPromise })
-  recordCreatedTerminalPaneSplit(createdPane, {
+  completeCreatedTerminalPaneSplit(createdPane, {
     source: args.source,
-    direction: args.direction
+    direction: args.direction,
+    equalizeTarget: { tabId: args.tabId, manager }
   })
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-split-writer-paths.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-split-writer-paths.test.ts
@@ -1,18 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { recordKeyboardCreatedTerminalPaneSplit } from './keyboard-handlers'
-import { recordContextMenuCreatedTerminalPaneSplit } from './use-terminal-pane-split-actions'
-import { recordRuntimeCreatedTerminalPaneSplit } from './use-terminal-pane-lifecycle'
+import { completeKeyboardCreatedTerminalPaneSplit } from './keyboard-handlers'
+import { completeContextMenuCreatedTerminalPaneSplit } from './use-terminal-pane-split-actions'
+import { completeRuntimeCreatedTerminalPaneSplit } from './use-terminal-pane-lifecycle'
 
 const mocks = vi.hoisted(() => ({
   recordFeatureInteraction: vi.fn(),
-  trackTerminalPaneSplit: vi.fn()
+  trackTerminalPaneSplit: vi.fn(),
+  settings: { terminalEqualizePanesOnSplit: true } as Record<string, unknown>
 }))
 
 vi.mock('@/store', () => ({
   useAppStore: {
     getState: () => ({
       activeContextualTourId: null,
-      recordFeatureInteraction: mocks.recordFeatureInteraction
+      recordFeatureInteraction: mocks.recordFeatureInteraction,
+      settings: mocks.settings,
+      expandedPaneByTabId: {}
     })
   }
 }))
@@ -25,11 +28,12 @@ describe('terminal split writer paths', () => {
   beforeEach(() => {
     mocks.recordFeatureInteraction.mockReset()
     mocks.trackTerminalPaneSplit.mockReset()
+    mocks.settings = { terminalEqualizePanesOnSplit: true }
   })
 
   it('does not record keyboard split completion when the local split fails', () => {
     expect(
-      recordKeyboardCreatedTerminalPaneSplit(null, {
+      completeKeyboardCreatedTerminalPaneSplit(null, {
         source: 'keyboard',
         direction: 'vertical'
       })
@@ -41,7 +45,7 @@ describe('terminal split writer paths', () => {
 
   it('records context-menu split completion after the local split succeeds', () => {
     expect(
-      recordContextMenuCreatedTerminalPaneSplit(
+      completeContextMenuCreatedTerminalPaneSplit(
         { id: 2 },
         {
           source: 'context_menu',
@@ -59,7 +63,7 @@ describe('terminal split writer paths', () => {
 
   it('records runtime split completion after SPLIT_TERMINAL_PANE_EVENT creates a pane', () => {
     expect(
-      recordRuntimeCreatedTerminalPaneSplit(
+      completeRuntimeCreatedTerminalPaneSplit(
         { id: 2 },
         {
           source: 'command',
@@ -77,7 +81,7 @@ describe('terminal split writer paths', () => {
 
   it('keeps runtime split completion when mirrored telemetry is suppressed', () => {
     expect(
-      recordRuntimeCreatedTerminalPaneSplit(
+      completeRuntimeCreatedTerminalPaneSplit(
         { id: 2 },
         {
           source: 'command',
@@ -89,5 +93,25 @@ describe('terminal split writer paths', () => {
 
     expect(mocks.recordFeatureInteraction).toHaveBeenCalledWith('terminal-pane-split')
     expect(mocks.trackTerminalPaneSplit).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['keyboard', completeKeyboardCreatedTerminalPaneSplit],
+    ['context menu', completeContextMenuCreatedTerminalPaneSplit],
+    ['runtime', completeRuntimeCreatedTerminalPaneSplit]
+  ] as const)('equalizes panes on the %s split path when the setting is on', (_path, complete) => {
+    const equalizePaneSizes = vi.fn<() => void>()
+
+    complete(
+      { id: 2 },
+      {
+        // Why: the only telemetry source all three writer paths accept.
+        source: 'contextual_tour',
+        direction: 'vertical',
+        equalizeTarget: { tabId: 'tab-1', manager: { equalizePaneSizes } }
+      }
+    )
+
+    expect(equalizePaneSizes).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -29,7 +29,7 @@ export {
   resolvePaneLinkCwd,
   resolvePaneSeedCwd,
   resolveQueuedInitialCwd,
-  recordRuntimeCreatedTerminalPaneSplit,
+  completeRuntimeCreatedTerminalPaneSplit,
   shouldDetachPaneTransportOnUnmount,
   terminalSelectionExceedsPrimaryLimit,
   splitPaneWithOneShotStartup

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-split-actions.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-split-actions.ts
@@ -6,18 +6,20 @@ import {
   REQUEST_ACTIVE_TERMINAL_PANE_SPLIT_EVENT,
   type RequestActiveTerminalPaneSplitDetail
 } from '@/constants/terminal'
-import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
+import {
+  completeCreatedTerminalPaneSplit,
+  type TerminalPaneSplitCompletion
+} from './terminal-pane-split-completion'
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
 import { useAppStore } from '@/store'
 
-export function recordContextMenuCreatedTerminalPaneSplit(
+export function completeContextMenuCreatedTerminalPaneSplit(
   createdPane: unknown,
-  args: {
+  args: Omit<TerminalPaneSplitCompletion, 'source'> & {
     source: 'contextual_tour' | 'context_menu'
-    direction: 'vertical' | 'horizontal'
   }
 ): boolean {
-  return recordCreatedTerminalPaneSplit(createdPane, args)
+  return completeCreatedTerminalPaneSplit(createdPane, args)
 }
 
 type UseTerminalPaneSplitActionsDeps = {

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -77,6 +77,10 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').confirmClosePinnedTab).toBe(true)
   })
 
+  it('keeps split halving as the default so deliberately uneven layouts survive', () => {
+    expect(getDefaultSettings('/tmp').terminalEqualizePanesOnSplit).toBe(false)
+  })
+
   it('keeps file-editor word wrapping enabled by default', () => {
     expect(getDefaultSettings('/tmp').editorWordWrap).toBe(true)
   })

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -100,6 +100,8 @@ export function buildDefaultSettings(args: {
     terminalQuickCommands: getDefaultTerminalQuickCommands(),
     // Why: opt-in only, matching Ghostty's default (upgrades never enable it unexpectedly).
     terminalFocusFollowsMouse: false,
+    // Why: opt-in only — a small side pane is a deliberate layout that halving preserves.
+    terminalEqualizePanesOnSplit: false,
     windowBackgroundBlur: false,
     minimizeToTrayOnClose: false,
     // Why: default-on everywhere so it round-trips across platforms; only darwin acts on it.

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -177,6 +177,8 @@ export type GlobalSettings = {
   /** 'auto' resolves to PowerShell 7+ when present, else falls back to inbox Windows PowerShell. */
   terminalWindowsPowerShellImplementation: 'auto' | 'powershell.exe' | 'pwsh.exe'
   terminalFocusFollowsMouse: boolean
+  /** Equalizes the tab's pane sizes when a split completes; off so deliberately uneven layouts keep today's halving. */
+  terminalEqualizePanesOnSplit: boolean
   /** X11/gnome-terminal "copy on select": selecting text auto-copies to the clipboard; default off. */
   terminalClipboardOnSelect: boolean
   /** Enables OSC 52 clipboard writes for TUIs (tmux/Zellij/nvim, incl. over SSH); default on. Clipboard *queries* stay blocked and payload size is capped, so this is write-only exposure. */


### PR DESCRIPTION
## ELI5

Turn on a setting and a split leaves every pane in the tab the same size, instead of halving only the pane you were in.

## What Changed

New `terminalEqualizePanesOnSplit` setting (Settings → Appearance → Terminal Panes), default off.

- When on, a completed split equalizes the tab's panes through the existing `PaneManager.equalizePaneSizes()` — no new layout math
- Only split completion triggers it, so a ratio you drag afterwards survives
- Skipped while a pane is expanded, matching the manual `terminal.equalizePaneSizes` command
- Renamed `recordCreatedTerminalPaneSplit` and its three writer-path wrappers to `complete*`, now that they settle layout as well as telemetry

Which split callers equalize:

| Split caller | Equalizes | Reason |
|---|---|---|
| Keyboard / context menu / tour / mobile | Yes | User-initiated |
| CLI `orca split`, web-runtime mirror | Yes | User-initiated on one side |
| Layout restore, live reconciliation | No | Must keep persisted ratios |

## Why

A split halves only the active pane, so with 3+ panes the layout drifts and has to be repaired by hand after every split. A chord maps to exactly one action, so "split, then equalize" cannot be bound to a single shortcut — binding both to one key makes Orca drop both overrides as conflicting.

A setting rather than a new default: a deliberately uneven layout, such as a small side pane, relies on today's halving.

## Linked Issue

Fixes #18077

## Visual Proof

<!-- REQUIRED for UI / behavior changes. Please attach a BEFORE and AFTER that can easily tabbed/switched. Use videos for when appropriate over screenshots -->

## Testing

**実施済み**

- [x] Split completion equalizes only when the setting is on, the tab has no expanded pane, and the caller is a user-initiated split — `pnpm test src/renderer/src/components/terminal-pane` (441 files, 4232 passed)
- [x] Settings toggle and search entry render — `pnpm test src/renderer/src/components/settings` (173 files, 1161 passed)
- [x] `pnpm tc`, `oxlint` (exit 0, no new findings), `pnpm run check:code-quality:changed` (0 findings)

**要確認（レビュー前に実施）**

- [ ] 3-pane layout equalizes on split, macOS: 1. Settings → Appearance → Terminal Panes → enable *Equalize Panes After Split* → 2. split twice in one tab → 3. all three panes are thirds, not 50/25/25
- [ ] Dragged ratios survive: 4. drag a sash off-center → 5. switch tabs and back → the dragged ratio is still there
- [ ] Setting off keeps today's halving, and a saved layout restores with its stored ratios after an app restart
- [ ] Attach before/after screenshots of the 3-pane split

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Opus 5 (Claude Code).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Off by default, so existing layouts are unchanged until opted in. No platform-specific code. On a remote/web client the split happens on the host and mirrors back through the split-request handler, which equalizes on the client the same way.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
