### PR TITLE
fix(i18n): drop orphan TerminalPane.minimumContrast entries that broke main static analysis

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8627,15 +8627,6 @@
             "fastDescription": "Extra multiplier while scrolling with a modifier key.",
             "tui": "TUI",
             "tuiDescription": "Discrete wheel reports for full-screen terminal apps."
-          },
-          "minimumContrast": {
-            "title": "Minimum Contrast Ratio",
-            "description": "Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.",
-            "automatic": "Automatic: {{light}} on light backgrounds, {{dark}} on dark.",
-            "disabled": "Correction off. Programs that rely on low contrast, like Powerline separators, render as sent.",
-            "pinned": "Targets {{ratio}}:1 contrast for foreground colors, where possible.",
-            "placeholder": "Auto",
-            "suffix": "blank = automatic, 1 = off"
           }
         },
         "TerminalSettingsPreview": {


### PR DESCRIPTION
## ELI5

`main` has failed the `static analysis` check for **every** PR since 07:39Z today. #18126 added seven English strings to `en.json` that no code reads, and a CI check that decides which English strings must ship in the app's boot bundle treats "no code reads it" as "might be built dynamically, so it must ship." It then noticed those seven were not in the shipped catalog and failed. This PR deletes the seven unused strings — the actual problem — rather than the catalog that correctly flagged them.

## Relationship to #19544 / #19337 (read this first)

Two open PRs currently carry a *regenerated* `en-runtime-required.json` that adds these 7 orphans to the shipped catalog. If either merges first, `main` goes green — and this PR becomes the **follow-up cleanup**, not the fix. Stated plainly and without blame (those PRs were fixing their own red, not making a policy choice): **the regenerate variant makes the check pass by adding the dead keys to the list of things that must ship.** That is the tool built to prevent boot-bundle dead weight being used to authorise it.

This PR is safe to land in either order:
- **Before theirs:** the failing step exits 0 (proven below); their later regeneration then re-adds nothing, because the keys are gone from `en.json`.
- **After theirs:** the two changes touch different files and do not conflict. Deleting the keys from `en.json` leaves their 7 shipped entries classified by the generator as `superfluous` — explicitly *"harmless; sync to drop them"* — not `missing` or `contradicting`, so the check stays green. No second break.

## Root cause

#18126 (`53852c9`, "make the contrast floor user-configurable") added **two** `minimumContrast` blocks to `en.json`:

- `auto.components.settings.terminal.search.minimumContrast.*` — referenced by `terminal-typography-search.ts`. **Kept.**
- `auto.components.settings.TerminalPane.minimumContrast.*` (7 entries) — referenced by **nothing**. The shipped `TerminalContrastSetting.tsx` reads `auto.components.settings.contrast.*` instead. **These are the orphans this PR removes.**

`generate-runtime-required-english-catalog.mjs` keeps an entry as runtime-required when *no call site with a literal default references it* (its own doc comment: a dynamic key could still resolve it). So an **unreferenced** entry is by construction runtime-required — `literalFallbacksByKey.get(key)` is `undefined` and it lands in `required`. The seven orphans therefore became required, `en-runtime-required.json` was never regenerated in #18126, and `verify:localization-runtime-catalog` has failed on every merge-ref since.

**This failure mode recurs on any rename that leaves leftovers behind** — every unreferenced key is silently promoted to runtime-required. Whether that deserves a lint is a separate call; it is worth naming.

## Why delete rather than regenerate

Regenerating would also turn the check green — by shipping seven strings nothing will ever read, which is precisely the *"dead weight in the boot bundle"* the generator's comment says it exists to prevent. Deleting is the root cause.

Before deleting, I established there is no dynamic path that can produce `auto.components.settings.TerminalPane.minimumContrast.*` (the exact hazard the check guards against):

- **Literal references:** zero across `src/`, `mobile/`, `tests/` (`.ts/.tsx/.json/.snap`), excluding `en.json` itself.
- **Template-literal key builders under `auto.components.settings.`:** exactly one in the whole tree — `plugin-chrome-allowlist.test.ts:43`, a *consumer* (`path.startsWith(...)` over paths read from the catalog), not a producer.
- **String-concat key builders under that namespace:** zero.
- **`minimumContrast` token near any `translate`/`t(`/key usage:** only the kept `terminal.search.minimumContrast.*` literals and the unrelated `terminalMinimumContrastRatio` setting-value reads.
- **Other locales (`es/fr/ja/ko/zh`) and mobile catalogs:** none carry the block; no translation is stranded.
- The check's own scanner (`ts.isStringLiteralLike` in `verify-localization-catalog.mjs`) classifies keys the same way, so what it can't see, neither can i18next via a literal.

`git blame` attributes the block solely to `53852c9`; the sibling `TerminalPane.scrollSpeed.*` follows the normal pattern (literal refs in `TerminalInteractionSection.tsx`), which is what the orphans were evidently meant to be before the component was pointed at `settings.contrast.*`.

## The "10 insertions vs 7 orphans" question, closed

A regenerate dry-run reports 10 insertions / 1 deletion. Key-level diff over the flattened JSON: **ADDED 7 (exactly the orphans), REMOVED 0, CHANGED 0.** The line count is 7 leaves + 2 brace lines + the predecessor line rewritten to add a trailing comma (−1/+1). There are no "other 3." Decisive control: on `main` + this delete, `--fix` regenerates a **byte-identical** `en-runtime-required.json` (`cmp` exit 0). Nothing remains to add.

## Evidence this is a main break, not a PR-side one

- **Clean worktree of `main@53852c9` with no other changes** → `verify:localization-runtime-catalog` exits 1 with exactly these 7 keys.
- **PR runs since #18126 merged (07:39Z): 6 failed, 1 succeeded.** The single success (#19356) merged against `96c6aa2` — the commit *before* `53852c9`. Every run merged against `53852c9` or later fails the identical step with the identical 7 keys.
- **`main` HEAD (`d346d6f`) still has zero `minimumContrast` entries in `en-runtime-required.json`.**

## Systemic: three gaps that compound

**#18126's own `static analysis` job was `cancelled` at 05:48Z and it was merged at 07:39Z anyway.** On its head SHA: `cancelled:17, failure:1, skipped:4` — **zero required checks reached `success`**, and no later run was created for that head. Had the job run, this step would have failed and the break would never have reached `main`. Twenty-four minutes later a second, independent break landed (#19542 + #19551, 16 seconds apart; fixed in the companion orchestration PR). The full cause:

1. **cancelled ≠ failed** — a cancelled required check reads as "not failing."
2. **No up-to-date-base requirement** — "green alone" treated as "green together."
3. **No post-merge signal on `main`** — `pr.yml` is `pull_request`-only; `main` gets no CI on push, so neither break was ever red on `main` itself.

The first two are fixed by branch protection with strict status checks, which `main` cannot have because it has **no branch protection and no rulesets at all**. The third needs a push trigger on `main`.

## Verification

On the fixed tree (`origin/main` `d346d6f` + this commit), locally and confirmed identically in this PR's own CI (`static analysis` → `success`):

| Check | Result |
| --- | --- |
| `verify:localization-runtime-catalog` (the failing step) | exit 0 — "covers en.json: 1680 of 14189" |
| `verify:localization-catalog` | exit 0 — 14383 references verified |
| `verify:localization-extraction` | exit 0 — orphan count **1557 → 1550** (exactly the 7) |
| `verify:localization-coverage` | exit 0 |
| all 9 i18n unit tests that load `en.json` | 123 passed |
| `oxfmt --check en.json` | clean |

Diff is exactly the 9 lines of the orphan block and the trailing comma on its predecessor; `en-runtime-required.json` is untouched; the referenced `terminal.search.minimumContrast` block is intact.

This PR's `verify` is red only because of the second, unrelated `main` break (shard 3/8), fixed in the companion PR.
