### PR TITLE
fix(native-chat): preserve structured tool metadata on mobile

### DIFF
--- a/src/main/runtime/rpc/methods/native-chat-rpc-block-sanitize.ts
+++ b/src/main/runtime/rpc/methods/native-chat-rpc-block-sanitize.ts
@@ -1,3 +1,4 @@
+import { sanitizeToolInput } from './native-chat-tool-input-sanitize'
 import {
   MAX_SUBAGENT_FIELD_CHARS,
   normalizeSubagentState
@@ -20,8 +21,6 @@ const MOBILE_BLOCK_CHAR_CAP = 4000
 // record can legally reach 2MB, and shipping that much markdown in one block
 // would freeze the phone.
 const MOBILE_TEXT_BLOCK_CHAR_CAP = 64_000
-const MOBILE_TOOL_INPUT_ITEMS_CAP = 20
-const MOBILE_TOOL_INPUT_NODE_CAP = 100
 // Why: a spawn group's roster is metadata, not a body — provider-supplied agent
 // paths and an open-string lifecycle whose schema declares no maximum, so a
 // journal from a newer build can carry more children and longer strings than
@@ -54,8 +53,7 @@ export function sanitizeNativeChatRpcBlock(
       : block
   }
   if (block.type === 'tool-call') {
-    const budget = { remaining: MOBILE_BLOCK_CHAR_CAP, nodes: MOBILE_TOOL_INPUT_NODE_CAP }
-    return { ...block, input: sanitizeToolInput(block.input, budget, 0) }
+    return { ...block, input: sanitizeToolInput(block.input) }
   }
   if (block.type === 'subagent-group') {
     return {
@@ -76,57 +74,4 @@ export function sanitizeNativeChatRpcBlock(
  *  what `unverifiable` records — clipping it would ship a truncated word. */
 function clipSubagentState(value: NativeChatSubagentState): NativeChatSubagentState {
   return value.length > MAX_SUBAGENT_FIELD_CHARS ? normalizeSubagentState(value) : value
-}
-
-function sanitizeToolInput(
-  value: unknown,
-  budget: { remaining: number; nodes: number },
-  depth: number
-): unknown {
-  budget.nodes--
-  if (budget.nodes < 0 || budget.remaining <= 0) {
-    return '… (truncated)'
-  }
-  if (typeof value === 'string') {
-    const length = Math.min(value.length, budget.remaining)
-    budget.remaining -= length
-    return length < value.length ? `${value.slice(0, length)}… (truncated)` : value
-  }
-  if (!value || typeof value !== 'object' || depth >= 5) {
-    return value && typeof value === 'object' ? '… (truncated)' : value
-  }
-  if (Array.isArray(value)) {
-    const result = value
-      .slice(0, MOBILE_TOOL_INPUT_ITEMS_CAP)
-      .map((item) => sanitizeToolInput(item, budget, depth + 1))
-    if (value.length > MOBILE_TOOL_INPUT_ITEMS_CAP) {
-      result.push('… (truncated)')
-    }
-    return result
-  }
-  const result: Record<string, unknown> = {}
-  let count = 0
-  for (const key in value) {
-    if (!Object.hasOwn(value, key)) {
-      continue
-    }
-    if (count >= MOBILE_TOOL_INPUT_ITEMS_CAP || budget.remaining <= 0) {
-      result['…'] = 'truncated'
-      break
-    }
-    let boundedKey = key.slice(0, Math.min(key.length, budget.remaining, 128))
-    // Why: sibling keys sharing a >=128-char (or budget-truncated) prefix collapse
-    // to the same bounded key; suffix collisions so neither field is silently lost.
-    if (Object.hasOwn(result, boundedKey)) {
-      boundedKey = `${boundedKey}~${count}`
-    }
-    budget.remaining -= boundedKey.length
-    result[boundedKey] = sanitizeToolInput(
-      (value as Record<string, unknown>)[key],
-      budget,
-      depth + 1
-    )
-    count++
-  }
-  return result
 }

--- a/src/main/runtime/rpc/methods/native-chat-tool-input-authority.ts
+++ b/src/main/runtime/rpc/methods/native-chat-tool-input-authority.ts
@@ -4,11 +4,11 @@ import {
   TOOL_PATH_KEYS,
   TOOL_PRIMARY_KEYS
 } from '../../../../shared/native-chat-tool-input-metadata'
-import type { ToolInputProjection } from './native-chat-tool-input-projection'
 import {
   OMIT_INPUT,
   TOOL_INPUT_LIMITS,
-  type InputBudget
+  type InputBudget,
+  type ToolInputProjection
 } from './native-chat-tool-input-projection'
 
 type Argument = { search: boolean | 'unknown'; label: boolean | 'unknown'; value: unknown }

--- a/src/main/runtime/rpc/methods/native-chat-tool-input-authority.ts
+++ b/src/main/runtime/rpc/methods/native-chat-tool-input-authority.ts
@@ -1,0 +1,161 @@
+import {
+  defineToolInputValue,
+  selectToolInputPath,
+  TOOL_PATH_KEYS,
+  TOOL_PRIMARY_KEYS
+} from '../../../../shared/native-chat-tool-input-metadata'
+import type { ToolInputProjection } from './native-chat-tool-input-projection'
+import {
+  OMIT_INPUT,
+  TOOL_INPUT_LIMITS,
+  type InputBudget
+} from './native-chat-tool-input-projection'
+
+type Argument = { search: boolean | 'unknown'; label: boolean | 'unknown'; value: unknown }
+export type InputAuthority = {
+  values: Record<string, unknown>
+  budget: InputBudget
+  omit: Set<string>
+}
+const UNKNOWN_PATH = Symbol('unknown path')
+
+export function planToolInputAuthority(
+  value: object,
+  projection: ToolInputProjection
+): InputAuthority {
+  const budget = { chars: TOOL_INPUT_LIMITS.metadata as number, nodes: TOOL_INPUT_LIMITS.nodes - 1 }
+  const values: Record<string, unknown> = {}
+  const omit = new Set<string>([...TOOL_PATH_KEYS, 'query', 'pattern'])
+  const args = new Map<string, Argument>()
+  const read = (key: string): unknown => projection.read(value, key)
+  const argument = (key: string): Argument => {
+    const cached = args.get(key)
+    if (cached) {
+      return cached
+    }
+    const input = read(key)
+    const result = inspectArgument(input, key, projection)
+    args.set(key, result)
+    return result
+  }
+  const search = (): boolean | 'unknown' => {
+    const query = argument('query').search,
+      pattern = argument('pattern').search
+    return query === true || pattern === true
+      ? true
+      : query === 'unknown' || pattern === 'unknown'
+        ? 'unknown'
+        : false
+  }
+  let prefix: unknown[] | undefined
+  const patch = (): unknown => {
+    const changes = read('changes')
+    if (!Array.isArray(changes)) {
+      return undefined
+    }
+    const length = projection.read(changes, 'length') as number
+    prefix = []
+    for (let index = 0; index < Math.min(length, TOOL_INPUT_LIMITS.items); index++) {
+      const change = projection.read(changes, String(index))
+      if (change !== null && typeof change === 'object') {
+        const path = projection.read(change, 'path')
+        if (typeof path === 'string') {
+          prefix.push({ path })
+          return path
+        }
+        prefix.push(Array.isArray(change) ? [] : {})
+      } else {
+        prefix.push(
+          change === undefined ||
+            typeof change === 'function' ||
+            typeof change === 'symbol' ||
+            typeof change === 'bigint'
+            ? null
+            : change
+        )
+      }
+    }
+    return length > TOOL_INPUT_LIMITS.items ? UNKNOWN_PATH : undefined
+  }
+  const selected = selectToolInputPath(read, search, patch)
+  const reserve = (key: string, input: unknown): boolean => {
+    if (key.length > budget.chars) {
+      return false
+    }
+    budget.chars -= key.length
+    const projected = projection.project(input, budget, 1, true)
+    if (projected === OMIT_INPUT) {
+      return false
+    }
+    defineToolInputValue(values, key, projected)
+    return true
+  }
+  const suppressPrimary = (): void => {
+    for (const key of TOOL_PRIMARY_KEYS) {
+      omit.add(key)
+    }
+  }
+  if (selected === 'unknown' || (selected && selected.value === UNKNOWN_PATH)) {
+    suppressPrimary()
+  } else if (selected && typeof selected.value === 'string' && selected.value.length > 0) {
+    let retained = reserve(selected.key, selected.key === 'changes' ? prefix : selected.value)
+    if (retained && selected.key === 'path') {
+      for (const key of ['query', 'pattern']) {
+        const arg = argument(key)
+        if (arg.search === 'unknown' || (arg.value !== undefined && !reserve(key, arg.value))) {
+          retained = false
+          break
+        }
+      }
+    }
+    if (!retained) {
+      for (const key of Object.keys(values)) {
+        delete values[key]
+      }
+      suppressPrimary()
+    }
+  } else {
+    const query = argument('query')
+    const winner = query.label === false ? argument('pattern') : query
+    const key = query.label === false ? 'pattern' : 'query'
+    if (winner.label === 'unknown' || (winner.label && !reserve(key, winner.value))) {
+      suppressPrimary()
+    }
+  }
+  return { values, budget, omit }
+}
+
+function inspectArgument(value: unknown, key: string, projection: ToolInputProjection): Argument {
+  const unknown: Argument = { search: 'unknown', label: 'unknown', value }
+  if (typeof value === 'string') {
+    if (value.length + key.length > TOOL_INPUT_LIMITS.metadata) {
+      return unknown
+    }
+    const nonblank = projection.nonblank(value)
+    return { search: nonblank, label: nonblank, value }
+  }
+  if (!Array.isArray(value)) {
+    return { search: false, label: false, value }
+  }
+  const length = projection.read(value, 'length') as number
+  if (length > TOOL_INPUT_LIMITS.items) {
+    return unknown
+  }
+  if (length === 0) {
+    return { search: false, label: false, value }
+  }
+  let chars = key.length
+  const parts: string[] = []
+  for (let index = 0; index < length; index++) {
+    const part = projection.read(value, String(index))
+    if (typeof part !== 'string') {
+      return { search: false, label: false, value }
+    }
+    chars += part.length
+    if (chars > TOOL_INPUT_LIMITS.metadata) {
+      return unknown
+    }
+    parts.push(part)
+  }
+  return { search: true, label: parts.some((part) => projection.nonblank(part)), value }
+}

--- a/src/main/runtime/rpc/methods/native-chat-tool-input-boundaries.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat-tool-input-boundaries.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest'
+import { sanitizeToolInput } from './native-chat-tool-input-sanitize'
+import {
+  INPUT_MARKER,
+  inputWork,
+  OMIT_INPUT,
+  ToolInputProjection
+} from './native-chat-tool-input-projection'
+import { sanitizeNativeChatRpcBlock } from './native-chat-rpc-block-sanitize'
+import {
+  createToolInputDisplay,
+  summarizeToolInput
+} from '../../../../shared/native-chat-tool-summary'
+
+function nodes(value: unknown): number {
+  return (
+    1 +
+    (value && typeof value === 'object'
+      ? Object.values(value).reduce<number>((sum, child) => sum + nodes(child), 0)
+      : 0)
+  )
+}
+
+describe('tool projection hard boundaries', () => {
+  for (const count of [99, 100, 101]) {
+    it(`emits at most 100 nodes from ${count}`, () => {
+      let remaining = count - 6
+      const source = Array.from({ length: 5 }, () => {
+        const size = Math.min(20, remaining)
+        remaining -= size
+        return Array(size).fill(0)
+      })
+      expect(nodes(source)).toBe(count)
+      const work = inputWork(),
+        output = sanitizeToolInput(source, work)
+      expect(nodes(output)).toBe(Math.min(100, count))
+      expect(work.openings).toBeLessThanOrEqual(100)
+      expect(work.candidates).toBeLessThanOrEqual(2100)
+    })
+  }
+  for (const count of [19, 20, 21]) {
+    it(`includes markers inside ${count} source array slots`, () => {
+      const output = sanitizeToolInput(Array(count).fill(0)) as unknown[]
+      expect(output.length).toBe(Math.min(count, 20))
+      if (count > 20) {
+        expect(output.at(-1)).toBe(INPUT_MARKER)
+      }
+    })
+  }
+  for (const length of [127, 128, 129]) {
+    it(`keeps key ${length} exact or absent`, () => {
+      const key = 'k'.repeat(length),
+        output = sanitizeToolInput({ [key]: 0 }) as object
+      expect(Object.hasOwn(output, key)).toBe(length <= 128)
+      expect(Object.keys(output).every((item) => item === key || item === '…')).toBe(true)
+    })
+  }
+  for (const depth of [4, 5, 6]) {
+    it(`bounds container depth ${depth}`, () => {
+      let source: unknown = { leaf: true }
+      for (let i = 0; i < depth; i++) {
+        source = [source]
+      }
+      const output = sanitizeToolInput(source)
+      expect(nodes(output)).toBeLessThanOrEqual(6)
+      expect(JSON.stringify(output).includes('truncated')).toBe(depth >= 5)
+    })
+  }
+  it('does not overwrite literal markers, including a late marker', () => {
+    const source = Object.fromEntries([
+      ...Array.from({ length: 21 }, (_, i) => [`k${i}`, i]),
+      ['…', 'literal']
+    ])
+    expect(sanitizeToolInput(source)).not.toHaveProperty('…')
+    expect(sanitizeToolInput({ '…': 'literal', body: 'x'.repeat(5000) })).toHaveProperty(
+      '…',
+      'literal'
+    )
+    expect(summarizeToolInput({ '…': 'literal', ...source })).not.toContain('"…":"…"')
+  })
+  it('charges marker strings and keeps surrogate pairs intact', () => {
+    const output = sanitizeToolInput(`${'x'.repeat(3986)}😀${'x'.repeat(40)}`) as string
+    expect(output.length).toBe(3999)
+    expect(output.endsWith(INPUT_MARKER)).toBe(true)
+    expect(output.charCodeAt(3985)).toBe(120)
+  })
+  for (const source of ['{bad', 'prose', '17', 'null', '"string"']) {
+    it(`opaque fallback ${source}`, () => {
+      const work = inputWork()
+      expect(sanitizeToolInput(source, work)).toBe(source)
+      expect(work.parses).toBe(source.startsWith('{') ? 1 : 0)
+      expect(work.serializations).toBe(0)
+    })
+  }
+  it('bounds deeply nested admitted parsing independently from projection', () => {
+    const source = `${'['.repeat(31999)}0${']'.repeat(31999)}`
+    const work = inputWork(),
+      output = sanitizeToolInput(source, work)
+    expect(work.parses).toBe(1)
+    expect(work.openings).toBe(5)
+    expect((output as string).length).toBeLessThan(100)
+  })
+  it('normalizes exotic values, active cycles and custom array properties safely', () => {
+    const source: unknown[] & { query?: string; path?: string } = [
+      undefined,
+      () => 1,
+      Symbol('x'),
+      1n,
+      Infinity,
+      Number.NaN
+    ]
+    source.push(source)
+    source.query = 'wrong'
+    source.path = '/wrong'
+    const output = sanitizeToolInput(source)
+    expect(output).toEqual([null, null, null, null, null, null, INPUT_MARKER])
+    expect(createToolInputDisplay(source).filePath).toBeNull()
+    expect(createToolInputDisplay(output).filePath).toBeNull()
+  })
+  it('keeps escaped control and Unicode serialization within the enclosing input bound', () => {
+    const input = { query: '\u0000\\"😀\ud800', content: '\u0000'.repeat(6000) }
+    for (const source of [input, JSON.stringify(input)]) {
+      const output = sanitizeToolInput(source)
+      const inner = typeof output === 'string' ? output : JSON.stringify(output)
+      const encoded = JSON.stringify(output),
+        block = JSON.stringify({ type: 'tool-call', name: 'Search', input: output })
+      expect(inner.length).toBeLessThanOrEqual(32768)
+      expect(encoded.length).toBeLessThanOrEqual(196610)
+      expect(Buffer.byteLength(encoded)).toBeLessThanOrEqual(589830)
+      expect(block.length).toBeGreaterThan(encoded.length)
+      expect(createToolInputDisplay(output).label).toBe(createToolInputDisplay(input).label)
+    }
+  })
+  it('performs at most one fallback serialization on an invariant failure', () => {
+    const original = JSON.stringify
+    const spy = vi.spyOn(JSON, 'stringify').mockImplementationOnce(() => 'x'.repeat(32769))
+    const work = inputWork()
+    try {
+      expect(sanitizeToolInput('[1]', work)).toBe('[]')
+      expect(work.serializations).toBe(2)
+    } finally {
+      spy.mockRestore()
+    }
+    expect(JSON.stringify).toBe(original)
+  })
+  it('leaves nonmobile blocks identical', () => {
+    const block = {
+      type: 'tool-call' as const,
+      name: 'Write',
+      input: `{"content":"${'x'.repeat(10000)}"}`
+    }
+    expect(sanitizeNativeChatRpcBlock(block, 'runtime')).toBe(block)
+  })
+  it('charges rejected exact discriminators and caches source descriptor reads', () => {
+    const nested: Record<string, unknown> = {
+      key: Array.from({ length: 20 }, () => ({ child: Array(20).fill(0) }))
+    }
+    const source = { path: '/right', query: nested, pattern: nested, content: 'bulk' }
+    const work = inputWork(),
+      result = sanitizeToolInput(source, work)
+    expect(createToolInputDisplay(result).filePath).toBeNull()
+    expect(work.openings).toBeLessThanOrEqual(100)
+    expect(work.candidates).toBeLessThanOrEqual(21 * work.openings)
+    expect(work.fixedProbes).toBeLessThanOrEqual(190)
+    expect(work.preflightVisits).toBeGreaterThan(90)
+    expect(work.visits - work.preflightVisits!).toBe(1)
+    expect(work.preflight?.candidates).toBe(work.candidates)
+    expect(nodes(result)).toBeLessThanOrEqual(100)
+  })
+  it('measures preflight and emission separately without re-reading reserved argv', () => {
+    const query = [' ', 'needle']
+    const source = { content: 'bulk', query }
+    const reads = vi.spyOn(Object, 'getOwnPropertyDescriptor')
+    const work = inputWork()
+    try {
+      expect(sanitizeToolInput(source, work)).toEqual({ query, content: 'bulk' })
+      expect(work.preflightVisits).toBe(3)
+      expect(work.visits).toBe(5)
+      for (const key of ['length', '0', '1']) {
+        expect(
+          reads.mock.calls.filter(([value, name]) => value === query && name === key)
+        ).toHaveLength(1)
+      }
+    } finally {
+      reads.mockRestore()
+    }
+  })
+  it('does not repeat bounded whitespace scans for identical discriminators', () => {
+    const work = inputWork()
+    const blank = ' '.repeat(500)
+    expect(sanitizeToolInput({ path: '/right', query: blank, pattern: blank }, work)).toEqual({
+      path: '/right',
+      query: blank,
+      pattern: blank
+    })
+    expect(work.whitespace).toBe(500)
+  })
+  it('never refunds rejected exact work or opens containers after exhaustion', () => {
+    const work = inputWork()
+    const projection = new ToolInputProjection(work)
+    const budget = { chars: 1024, nodes: 99 }
+    const nested = { children: Array.from({ length: 20 }, () => Array(20).fill(0)) }
+    expect(projection.project(nested, budget, 1, true)).toBe(OMIT_INPUT)
+    expect(budget.nodes).toBe(0)
+    const rejectedVisits = work.visits
+    expect(projection.project(nested, budget, 1, true)).toBe(OMIT_INPUT)
+    expect(work.visits).toBe(rejectedVisits + 1)
+    const openingCount = work.openings
+    for (let index = openingCount; index < 100; index++) {
+      expect(projection.open({})).toBeDefined()
+    }
+    expect(projection.open({})).toBeUndefined()
+    expect(work.openings).toBe(100)
+    expect(work.candidates).toBeLessThanOrEqual(openingCount * 21)
+  })
+})

--- a/src/main/runtime/rpc/methods/native-chat-tool-input-projection.ts
+++ b/src/main/runtime/rpc/methods/native-chat-tool-input-projection.ts
@@ -1,0 +1,309 @@
+import { defineToolInputValue } from '../../../../shared/native-chat-tool-input-metadata'
+
+export const TOOL_INPUT_LIMITS = {
+  chars: 4000,
+  metadata: 1024,
+  nodes: 100,
+  items: 20,
+  depth: 5,
+  key: 128,
+  acquisition: 64000,
+  serialized: 32768
+} as const
+export const INPUT_MARKER = '… (truncated)'
+export type InputBudget = { chars: number; nodes: number }
+export type InputWork = {
+  preflight?: { openings: number; candidates: number; fixedProbes: number; whitespace: number }
+  visits: number
+  preflightVisits?: number
+  openings: number
+  candidates: number
+  fixedProbes: number
+  whitespace: number
+  parses: number
+  serializations: number
+}
+export const OMIT_INPUT = Symbol('omit tool input')
+export function inputWork(): InputWork {
+  return {
+    openings: 0,
+    candidates: 0,
+    fixedProbes: 0,
+    whitespace: 0,
+    parses: 0,
+    serializations: 0,
+    visits: 0
+  }
+}
+
+export function clipToolInput(text: string, cap: number): string {
+  if (text.length <= cap) {
+    return text
+  }
+  if (cap < INPUT_MARKER.length) {
+    return ''
+  }
+  let end = cap - INPUT_MARKER.length
+  const last = text.charCodeAt(end - 1),
+    next = text.charCodeAt(end)
+  if (last >= 0xd800 && last <= 0xdbff && next >= 0xdc00 && next <= 0xdfff) {
+    end--
+  }
+  return text.slice(0, end) + INPUT_MARKER
+}
+
+type Container = {
+  entries?: [string, PropertyDescriptor][]
+  descriptors: Map<string, PropertyDescriptor | undefined>
+}
+
+export class ToolInputProjection {
+  private containers = new WeakMap<object, Container>()
+  private active = new WeakSet<object>()
+  private whitespaceResults = new Map<string, boolean>()
+  readonly work: InputWork
+
+  constructor(work: InputWork) {
+    this.work = work
+  }
+
+  open(value: object): Container | undefined {
+    const cached = this.containers.get(value)
+    if (cached) {
+      return cached
+    }
+    if (this.work.openings >= TOOL_INPUT_LIMITS.nodes) {
+      return undefined
+    }
+    this.work.openings++
+    const container: Container = { descriptors: new Map() }
+    this.containers.set(value, container)
+    return container
+  }
+
+  descriptor(value: object, key: string, fixed = true): PropertyDescriptor | undefined {
+    const container = this.open(value)
+    if (!container) {
+      return undefined
+    }
+    if (!container.descriptors.has(key)) {
+      if (fixed) {
+        if (this.work.fixedProbes >= 190) {
+          return undefined
+        }
+        this.work.fixedProbes++
+      }
+      container.descriptors.set(key, Object.getOwnPropertyDescriptor(value, key))
+    }
+    return container.descriptors.get(key)
+  }
+
+  read(value: object, key: string): unknown {
+    const descriptor = this.descriptor(value, key)
+    return descriptor && 'value' in descriptor ? descriptor.value : undefined
+  }
+
+  nonblank(value: string): boolean {
+    const cached = this.whitespaceResults.get(value)
+    if (cached !== undefined) {
+      return cached
+    }
+    for (let index = 0; index < value.length; index++) {
+      this.work.whitespace++
+      if (!/\s/.test(value[index])) {
+        this.whitespaceResults.set(value, true)
+        return true
+      }
+    }
+    this.whitespaceResults.set(value, false)
+    return false
+  }
+
+  private entries(value: object): [string, PropertyDescriptor][] | undefined {
+    const container = this.open(value)
+    if (!container) {
+      return undefined
+    }
+    if (container.entries) {
+      return container.entries
+    }
+    const entries: [string, PropertyDescriptor][] = []
+    container.entries = entries
+    for (const key in value) {
+      if (!Object.hasOwn(value, key)) {
+        continue
+      }
+      this.work.candidates++
+      const descriptor = this.descriptor(value, key, false)
+      if (descriptor) {
+        entries.push([key, descriptor])
+      }
+      if (entries.length >= TOOL_INPUT_LIMITS.items + 1) {
+        break
+      }
+    }
+    return entries
+  }
+
+  project(
+    value: unknown,
+    budget: InputBudget,
+    depth: number,
+    exact = false,
+    omit?: ReadonlySet<string>
+  ): unknown {
+    this.work.visits++
+    if (budget.nodes <= 0) {
+      return OMIT_INPUT
+    }
+    if (typeof value === 'string') {
+      if (exact && value.length > budget.chars) {
+        return OMIT_INPUT
+      }
+      const text = clipToolInput(value, budget.chars)
+      budget.nodes--
+      budget.chars -= text.length
+      return text
+    }
+    if (
+      value === null ||
+      typeof value === 'boolean' ||
+      (typeof value === 'number' && Number.isFinite(value))
+    ) {
+      budget.nodes--
+      return value
+    }
+    if (!value || typeof value !== 'object') {
+      return OMIT_INPUT
+    }
+    if (depth >= TOOL_INPUT_LIMITS.depth || this.active.has(value) || !this.open(value)) {
+      return exact ? OMIT_INPUT : this.marker(budget)
+    }
+    budget.nodes--
+    if (!exact && budget.nodes === 0) {
+      return Array.isArray(value) ? [] : {}
+    }
+    this.active.add(value)
+    const result = Array.isArray(value)
+      ? this.array(value, budget, depth, exact)
+      : this.record(value, budget, depth, exact, omit)
+    this.active.delete(value)
+    return result
+  }
+
+  marker(budget: InputBudget): unknown {
+    if (budget.nodes < 1 || budget.chars < INPUT_MARKER.length) {
+      return OMIT_INPUT
+    }
+    budget.nodes--
+    budget.chars -= INPUT_MARKER.length
+    return INPUT_MARKER
+  }
+
+  private array(value: unknown[], budget: InputBudget, depth: number, exact: boolean): unknown {
+    const length = this.descriptor(value, 'length', false)?.value as number
+    if (exact && length > TOOL_INPUT_LIMITS.items) {
+      return OMIT_INPUT
+    }
+    const container = this.open(value)!
+    if (!container.entries) {
+      container.entries = []
+      for (let index = 0; index < Math.min(length, TOOL_INPUT_LIMITS.items + 1); index++) {
+        this.work.candidates++
+        container.entries.push([String(index), this.descriptor(value, String(index), false) ?? {}])
+      }
+    }
+    const result: unknown[] = []
+    const truncated = length > TOOL_INPUT_LIMITS.items
+    const count = Math.min(length, TOOL_INPUT_LIMITS.items - (truncated ? 1 : 0))
+    for (let index = 0; index < count; index++) {
+      if (budget.nodes <= 0) {
+        return exact ? OMIT_INPUT : result
+      }
+      const descriptor = container.entries[index]?.[1]
+      const item = descriptor && 'value' in descriptor ? descriptor.value : undefined
+      let projected = this.project(item, budget, depth + 1, exact)
+      if (projected === OMIT_INPUT) {
+        if (exact) {
+          return OMIT_INPUT
+        }
+        if (budget.nodes <= 0) {
+          break
+        }
+        budget.nodes--
+        projected = null
+      }
+      result.push(projected)
+    }
+    if (truncated) {
+      const marker = this.marker(budget)
+      if (marker !== OMIT_INPUT) {
+        result.push(marker)
+      }
+    }
+    return result
+  }
+
+  private record(
+    value: object,
+    budget: InputBudget,
+    depth: number,
+    exact: boolean,
+    omit?: ReadonlySet<string>
+  ): unknown {
+    const result: Record<string, unknown> = {}
+    const entries = this.entries(value)
+    if (!entries) {
+      return exact ? OMIT_INPUT : result
+    }
+    let count = 0,
+      truncated = entries.length > TOOL_INPUT_LIMITS.items
+    for (const [key, descriptor] of entries) {
+      if (omit?.has(key)) {
+        continue
+      }
+      if (count >= TOOL_INPUT_LIMITS.items - (truncated ? 1 : 0) || budget.nodes <= 0) {
+        truncated = true
+        break
+      }
+      if (!('value' in descriptor)) {
+        if (exact) {
+          return OMIT_INPUT
+        }
+        continue
+      }
+      if (key.length > TOOL_INPUT_LIMITS.key || key.length > budget.chars) {
+        if (exact) {
+          return OMIT_INPUT
+        }
+        truncated = true
+        continue
+      }
+      budget.chars -= key.length
+      const projected = this.project(descriptor.value, budget, depth + 1, exact)
+      if (projected === OMIT_INPUT) {
+        if (exact) {
+          return OMIT_INPUT
+        }
+        continue
+      }
+      defineToolInputValue(result, key, projected)
+      count++
+    }
+    if (truncated && exact) {
+      return OMIT_INPUT
+    }
+    if (
+      truncated &&
+      !this.descriptor(value, '…') &&
+      count < TOOL_INPUT_LIMITS.items &&
+      budget.nodes > 0 &&
+      budget.chars >= 10
+    ) {
+      budget.nodes--
+      budget.chars -= 10
+      defineToolInputValue(result, '…', 'truncated')
+    }
+    return result
+  }
+}

--- a/src/main/runtime/rpc/methods/native-chat-tool-input-sanitize.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat-tool-input-sanitize.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createToolInputDisplay,
+  summarizeToolInput,
+  toolFilePath
+} from '../../../../shared/native-chat-tool-summary'
+import { sanitizeToolInput } from './native-chat-tool-input-sanitize'
+import { inputWork } from './native-chat-tool-input-projection'
+
+function wire(value: unknown, string: boolean): unknown {
+  return JSON.parse(
+    JSON.stringify({ input: sanitizeToolInput(string ? JSON.stringify(value) : value) })
+  ).input
+}
+function structure(value: unknown): unknown {
+  return typeof value === 'string' ? JSON.parse(value) : value
+}
+function budget(value: unknown): { chars: number; nodes: number; slots: number; depth: number } {
+  const result = {
+    chars: typeof value === 'string' ? value.length : 0,
+    nodes: 1,
+    slots: 0,
+    depth: 0
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+    result.slots = entries.length
+    for (const [key, item] of entries) {
+      const child = budget(item)
+      result.chars += child.chars + (Array.isArray(value) ? 0 : key.length)
+      result.nodes += child.nodes
+      result.slots = Math.max(result.slots, child.slots)
+      result.depth = Math.max(result.depth, child.depth + 1)
+    }
+  }
+  return result
+}
+const families: [string, Record<string, unknown>, string | null][] = [
+  ['query string', { query: 'needle' }, 'query'],
+  ['pattern string', { pattern: 'needle' }, 'pattern'],
+  ['query argv', { query: ['alpha', 'beta'] }, 'query'],
+  ['pattern argv', { pattern: ['alpha', 'beta'] }, 'pattern'],
+  ['both nonblank', { query: 'needle', pattern: 'alternate' }, 'query'],
+  ['blank query argv', { query: [''], pattern: 'needle' }, 'pattern'],
+  ['whitespace query argv', { query: [' ', ''], pattern: ['alpha', 'beta'] }, 'pattern'],
+  ['blank query', { query: '  ', pattern: 'needle' }, 'pattern'],
+  ['empty query', { query: [], pattern: 'needle' }, 'pattern'],
+  ['mixed query', { query: ['x', 0], pattern: 'needle' }, 'pattern'],
+  ['mixed pattern', { query: 'needle', pattern: ['x', 0] }, 'query'],
+  ['invalid query', { query: 17, pattern: 'needle' }, 'pattern'],
+  ['whitespace', { query: '  needle  ' }, 'query'],
+  ['oversized', { query: 'x'.repeat(1020), pattern: 'alternate' }, null],
+  ['unknown argv', { query: Array(21).fill('x'), pattern: 'alternate' }, null],
+  ['unknown blank', { query: Array(21).fill(''), pattern: 'alternate' }, null]
+]
+for (const key of ['query', 'pattern']) {
+  for (const shape of ['string', 'argv']) {
+    for (const cost of [1023, 1024, 1025]) {
+      const text = 'x'.repeat(cost - key.length)
+      families.push([
+        `${key} ${shape} ${cost}`,
+        {
+          [key]: shape === 'argv' ? ['', text] : text,
+          ...(key === 'query' ? { pattern: 'alternate' } : { query: [''] })
+        },
+        cost <= 1024 ? key : null
+      ])
+    }
+  }
+}
+for (const length of [19, 20, 21]) {
+  for (const key of ['query', 'pattern']) {
+    families.push([
+      `${key} length ${length}`,
+      { [key]: Array(length).fill('x') },
+      length <= 20 ? key : null
+    ])
+  }
+}
+
+describe('host structural tool input publication', () => {
+  for (const [name, args, winner] of families) {
+    for (const reverse of [false, true]) {
+      for (const placement of ['early', 'bulk', 'wide']) {
+        for (const string of [false, true]) {
+          it(`${name} reverse=${reverse} ${placement} string=${string}`, () => {
+            const metadata = Object.fromEntries(
+              (reverse ? ['pattern', 'query'] : ['query', 'pattern'])
+                .filter((key) => Object.hasOwn(args, key))
+                .map((key) => [key, args[key]])
+            )
+            const bulk = { content: 'x'.repeat(5000) },
+              wide = Object.fromEntries(
+                Array.from({ length: 20 }, (_, i) => [`generic${i}`, 'value'])
+              )
+            const source =
+              placement === 'early'
+                ? { ...metadata, ...bulk }
+                : placement === 'bulk'
+                  ? { ...bulk, ...metadata }
+                  : { ...wide, ...metadata, ...bulk }
+            const input = { ...source, path: '/synthetic/root' }
+            const output = wire(input, string)
+            const projected = structure(output) as Record<string, unknown>
+            const display = createToolInputDisplay(output)
+            expect(typeof output).toBe(string ? 'string' : 'object')
+            expect(display.filePath).toBeNull()
+            if (winner) {
+              expect(projected[winner]).toEqual(args[winner])
+              expect(display.label).toBe(createToolInputDisplay(input).label)
+            } else {
+              expect(projected).not.toHaveProperty('query')
+              expect(projected).not.toHaveProperty('pattern')
+              expect(display.label).not.toBe('alternate')
+            }
+            const actual = budget(projected)
+            expect(actual.chars).toBeLessThanOrEqual(4000)
+            expect(actual.nodes).toBeLessThanOrEqual(100)
+            expect(actual.slots).toBeLessThanOrEqual(20)
+            expect(actual.depth).toBeLessThanOrEqual(5)
+            expect(JSON.stringify(projected).length).toBeLessThanOrEqual(32768)
+          })
+        }
+      }
+    }
+  }
+  for (const string of [false, true]) {
+    for (const [source, target] of [
+      [{ content: 'x'.repeat(5000), file_path: '/right', path: '/wrong' }, '/right'],
+      [{ file_path: 17, path: '/wrong', query: [''], pattern: 'needle' }, null],
+      [{ file_path: '', filePath: '/wrong' }, null],
+      [{ file_path: null, filePath: '/right', query: 'term' }, '/right'],
+      [{ path: '/right', query: ['x', 0], pattern: [] }, '/right'],
+      [{ path: '/scan', query: 'term' }, null],
+      [{ path: '/scan', query: Array(21).fill(''), notebook_path: '/wrong' }, null],
+      [{ file_path: ' ', query: 'term' }, ' '],
+      [{ changes: [{ path: 17 }, { path: '/right' }] }, '/right'],
+      [{ changes: [{ path: '' }, { path: '/wrong' }], query: 'term' }, null],
+      [{ changes: [...Array.from({ length: 19 }, () => ({})), { path: '/right' }] }, '/right'],
+      [{ changes: [...Array.from({ length: 20 }, () => ({})), { path: '/unsupported' }] }, null]
+    ] as const) {
+      it(`authority ${JSON.stringify(source).slice(-100)} string=${string}`, () => {
+        const output = wire(source, string)
+        expect(toolFilePath(output)).toBe(target)
+        if (target !== null) {
+          expect(createToolInputDisplay(output).label).toBe(createToolInputDisplay(source).label)
+        }
+      })
+    }
+  }
+  it('uses own data without running getters or prototype setters in preview', () => {
+    let calls = 0
+    const source = Object.create({ file_path: '/inherited' })
+    Object.defineProperty(source, 'query', {
+      enumerable: true,
+      get() {
+        calls++
+        return 'bad'
+      }
+    })
+    Object.defineProperty(source, 'toJSON', {
+      enumerable: true,
+      value() {
+        calls++
+        return 'bad'
+      }
+    })
+    Object.defineProperty(source, '__proto__', { enumerable: true, value: { safe: true } })
+    source.pattern = 'needle'
+    expect(toolFilePath(source)).toBeNull()
+    expect(createToolInputDisplay(source).label).toBe('needle')
+    expect(summarizeToolInput(source)).toContain('__proto__')
+    const result = sanitizeToolInput(source) as object
+    expect(Object.hasOwn(result, '__proto__')).toBe(true)
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype)
+    expect(calls).toBe(0)
+  })
+  for (const length of [63999, 64000, 64001]) {
+    it(`bounds acquisition ${length}`, () => {
+      const value = `{"query":"needle","content":"${'x'.repeat(length - 31)}"}`
+      expect(value.length).toBe(length)
+      const work = inputWork()
+      const result = sanitizeToolInput(value, work)
+      expect(work.parses).toBe(length <= 64000 ? 1 : 0)
+      expect(work.serializations).toBe(length <= 64000 ? 1 : 0)
+      expect(work.openings).toBeLessThanOrEqual(100)
+      expect(work.candidates).toBeLessThanOrEqual(2100)
+      expect(work.fixedProbes).toBeLessThanOrEqual(190)
+      if (length <= 64000) {
+        expect(createToolInputDisplay(result).label).toBe('needle')
+      } else {
+        expect((result as string).length).toBeLessThanOrEqual(4000)
+      }
+    })
+  }
+})

--- a/src/main/runtime/rpc/methods/native-chat-tool-input-sanitize.ts
+++ b/src/main/runtime/rpc/methods/native-chat-tool-input-sanitize.ts
@@ -1,0 +1,81 @@
+import { defineToolInputValue } from '../../../../shared/native-chat-tool-input-metadata'
+import { planToolInputAuthority } from './native-chat-tool-input-authority'
+import {
+  clipToolInput,
+  inputWork,
+  OMIT_INPUT,
+  ToolInputProjection,
+  TOOL_INPUT_LIMITS,
+  type InputWork
+} from './native-chat-tool-input-projection'
+
+export function sanitizeToolInput(input: unknown, work: InputWork = inputWork()): unknown {
+  const stringInput = typeof input === 'string'
+  let value = input
+  if (stringInput) {
+    if (input.length > TOOL_INPUT_LIMITS.acquisition) {
+      return clipToolInput(input, TOOL_INPUT_LIMITS.chars)
+    }
+    let index = 0
+    while (index < input.length && /\s/.test(input[index])) {
+      work.whitespace++
+      index++
+    }
+    if (input[index] !== '{' && input[index] !== '[') {
+      return clipToolInput(input, TOOL_INPUT_LIMITS.chars)
+    }
+    try {
+      work.parses++
+      value = JSON.parse(input)
+    } catch {
+      return clipToolInput(input, TOOL_INPUT_LIMITS.chars)
+    }
+  }
+  const projection = new ToolInputProjection(work)
+  let result: unknown
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const authority = planToolInputAuthority(value, projection)
+    work.preflight = {
+      openings: work.openings,
+      candidates: work.candidates,
+      fixedProbes: work.fixedProbes,
+      whitespace: work.whitespace
+    }
+    work.preflightVisits = work.visits
+    const budget = {
+      chars: TOOL_INPUT_LIMITS.chars - (TOOL_INPUT_LIMITS.metadata - authority.budget.chars),
+      nodes: authority.budget.nodes + 1
+    }
+    const bulk = projection.project(value, budget, 0, false, authority.omit)
+    const record = authority.values
+    const slots = Object.keys(record).length
+    if (bulk && typeof bulk === 'object') {
+      let count = slots
+      for (const key of Object.keys(bulk)) {
+        if (count >= TOOL_INPUT_LIMITS.items) {
+          break
+        }
+        defineToolInputValue(record, key, (bulk as Record<string, unknown>)[key])
+        count++
+      }
+    }
+    result = record
+  } else {
+    result = projection.project(
+      value,
+      { chars: TOOL_INPUT_LIMITS.chars, nodes: TOOL_INPUT_LIMITS.nodes },
+      0
+    )
+    if (result === OMIT_INPUT) {
+      result = null
+    }
+  }
+  work.serializations++
+  let serialized = JSON.stringify(result)
+  if (serialized.length > TOOL_INPUT_LIMITS.serialized) {
+    result = Array.isArray(value) ? [] : {}
+    work.serializations++
+    serialized = JSON.stringify(result)
+  }
+  return stringInput ? serialized : result
+}

--- a/src/main/runtime/rpc/methods/native-chat.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat.test.ts
@@ -266,6 +266,40 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
     expect(JSON.stringify(input)).toContain('truncated')
   })
 
+  it.each([false, true])(
+    'preserves late tool metadata through readSession string=%s',
+    async (string) => {
+      const source = { content: 'x'.repeat(5000), file_path: 'src/exact-target.ts' }
+      cachedResult.value = {
+        messages: [
+          {
+            ...makeMessage('ignored'),
+            blocks: [
+              {
+                type: 'tool-call',
+                name: 'Write',
+                input: string ? JSON.stringify(source) : source
+              }
+            ]
+          }
+        ]
+      }
+      const result = await readSessionHandler()(
+        { agent: 'codex', sessionId: 's' },
+        ctxWith('mobile')
+      )
+      const message = JSON.parse(
+        JSON.stringify((result as { messages: NativeChatMessage[] }).messages[0])
+      )
+      const input = message.blocks[0].input
+      expect(typeof input).toBe(string ? 'string' : 'object')
+      const projected = string ? JSON.parse(input) : input
+      expect(projected.file_path).toBe(source.file_path)
+      expect(projected.content).toContain('truncated')
+      expect(JSON.stringify(projected).length).toBeLessThan(5000)
+    }
+  )
+
   // The roster block reached mobile through a bare fall-through, uncapped, on the
   // one path that exists to keep the payload off the phone.
   it('bounds a spawn-group roster before sending it to mobile', async () => {
@@ -369,7 +403,7 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
     expect(encoded).toContain('truncated')
   })
 
-  it('keeps sibling tool-call keys that share a 128-char prefix distinct', async () => {
+  it('omits oversized sibling keys without renaming either key', async () => {
     const prefix = 'p'.repeat(128)
     cachedResult.value = {
       messages: [
@@ -394,9 +428,8 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
     }
     const keys = Object.keys(block.input)
 
-    expect(keys).toHaveLength(2)
-    expect(new Set(keys).size).toBe(2)
-    expect(Object.values(block.input)).toEqual(expect.arrayContaining(['first', 'second']))
+    expect(keys).toEqual(['…'])
+    expect(block.input).toEqual({ '…': 'truncated' })
   })
 
   it('passes oversized tool output through intact for runtime (web/desktop) clients', async () => {

--- a/src/shared/native-chat-tool-input-metadata.ts
+++ b/src/shared/native-chat-tool-input-metadata.ts
@@ -1,0 +1,70 @@
+export const TOOL_PATH_KEYS = ['file_path', 'filePath', 'path', 'notebook_path', 'changes'] as const
+export const TOOL_PRIMARY_KEYS = [
+  'query',
+  'pattern',
+  'directory',
+  'command',
+  'cmd',
+  'url',
+  'description'
+] as const
+
+export function ownToolInputValue(value: object, key: PropertyKey): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key)
+  return descriptor && 'value' in descriptor ? descriptor.value : undefined
+}
+
+export function defineToolInputValue(value: object, key: PropertyKey, item: unknown): void {
+  Object.defineProperty(value, key, {
+    value: item,
+    enumerable: true,
+    configurable: true,
+    writable: true
+  })
+}
+
+export type ToolPathSelection = { key: string; value: unknown } | null | 'unknown'
+
+export function selectToolInputPath(
+  read: (key: string) => unknown,
+  search: () => boolean | 'unknown',
+  patch: () => unknown
+): ToolPathSelection {
+  for (const key of ['file_path', 'filePath']) {
+    const value = read(key)
+    if (value != null) {
+      return { key, value }
+    }
+  }
+  const path = read('path')
+  if (path != null) {
+    const classification = search()
+    if (classification === 'unknown') {
+      return 'unknown'
+    }
+    if (!classification) {
+      return { key: 'path', value: path }
+    }
+  }
+  const notebook = read('notebook_path')
+  if (notebook != null) {
+    return { key: 'notebook_path', value: notebook }
+  }
+  const change = patch()
+  return change === undefined ? null : { key: 'changes', value: change }
+}
+
+export function ownToolArgParts(input: unknown): string[] | null {
+  if (!Array.isArray(input) || input.length === 0) {
+    return null
+  }
+  const parts: string[] = []
+  for (let index = 0; index < input.length; index++) {
+    const part = ownToolInputValue(input, index)
+    if (typeof part !== 'string') {
+      return null
+    }
+    parts.push(part)
+  }
+  return parts
+}

--- a/src/shared/native-chat-tool-summary.ts
+++ b/src/shared/native-chat-tool-summary.ts
@@ -1,3 +1,10 @@
+import {
+  defineToolInputValue,
+  ownToolInputValue,
+  ownToolArgParts,
+  selectToolInputPath,
+  TOOL_PRIMARY_KEYS
+} from './native-chat-tool-input-metadata'
 import type { NativeChatMcpIdentity } from './native-chat-tool-identity'
 import { isToolCallBlock, type NativeChatBlock } from './native-chat-types'
 
@@ -11,15 +18,7 @@ const MAX_TOOL_RUN_SUMMARY_PARTS = 3
 // `directory` is a scan root or a listed folder — it labels a row but is
 // deliberately absent from the file-target keys below, because a folder reaches
 // mobile as a tappable open-file link that can only fail.
-const PRIMARY_ARG_KEYS = [
-  'query',
-  'pattern',
-  'directory',
-  'command',
-  'cmd',
-  'url',
-  'description'
-] as const
+const PRIMARY_ARG_KEYS = TOOL_PRIMARY_KEYS
 const BRIEF_ARG_KEYS = ['query', 'pattern', 'directory', 'command', 'cmd'] as const
 // Only the keys that hold a shell command, so a search term or a listed folder
 // cannot stand in for one.
@@ -70,7 +69,7 @@ function describeNormalizedToolInput(input: unknown, path: string | null): strin
   if (path) {
     return summarizeToolPath(path)
   }
-  if (input && typeof input === 'object') {
+  if (isToolInputRecord(input)) {
     // Concrete target/action first; prose `description` only as a last resort.
     const primary = firstPrimaryToolArg(input as Record<string, unknown>, PRIMARY_ARG_KEYS)
     if (primary) {
@@ -132,30 +131,30 @@ export function toolFilePath(input: unknown): string | null {
 }
 
 function normalizedToolFilePath(input: unknown): string | null {
-  if (!input || typeof input !== 'object') {
+  if (!isToolInputRecord(input)) {
     return null
   }
-  const value = input as Record<string, unknown>
-  // A search call's `path` is usually the directory it scanned, so taking it as a
-  // target would label the row with the scan root and link to a folder. Costs the
-  // link on a file-scoped search; a dead link on every other search is worse.
-  const directory = isSearchToolInput(value) ? undefined : value.path
-  const path =
-    value.file_path ??
-    value.filePath ??
-    directory ??
-    value.notebook_path ??
-    firstPatchChangePath(value)
+  const selection = selectToolInputPath(
+    (key) => ownToolInputValue(input, key),
+    () => isSearchToolInput(input),
+    () => firstPatchChangePath(input)
+  )
+  const path = selection && selection !== 'unknown' ? selection.value : undefined
   return typeof path === 'string' && path.length > 0 ? path : null
 }
 
 function firstPatchChangePath(value: Record<string, unknown>): unknown {
-  if (!Array.isArray(value.changes)) {
+  const changes = ownToolInputValue(value, 'changes')
+  if (!Array.isArray(changes)) {
     return undefined
   }
-  for (const change of value.changes) {
-    if (typeof change === 'object' && change !== null && typeof change.path === 'string') {
-      return change.path
+  for (let index = 0; index < changes.length; index++) {
+    const change = ownToolInputValue(changes, index)
+    if (change !== null && typeof change === 'object') {
+      const path = ownToolInputValue(change, 'path')
+      if (typeof path === 'string') {
+        return path
+      }
     }
   }
   return undefined
@@ -163,7 +162,7 @@ function firstPatchChangePath(value: Record<string, unknown>): unknown {
 
 export function briefToolArg(input: unknown): string {
   const normalized = normalizeToolInput(input)
-  if (normalized && typeof normalized === 'object') {
+  if (isToolInputRecord(normalized)) {
     const path = toolFilePath(normalized)
     if (path) {
       const parts = path.split(/[\\/]/).filter(Boolean)
@@ -177,7 +176,7 @@ export function briefToolArg(input: unknown): string {
     // A blank primary key means the call has no brief argument; falling through
     // would stand its raw JSON in for one in the run header. Reaching here with a
     // string key means it was blank — a structured one still earns the preview.
-    if (BRIEF_ARG_KEYS.some((key) => typeof value[key] === 'string')) {
+    if (BRIEF_ARG_KEYS.some((key) => typeof ownToolInputValue(value, key) === 'string')) {
       return ''
     }
   }
@@ -218,7 +217,8 @@ function normalizeToolInput(input: unknown): unknown {
  *  rather than a file target. */
 function isSearchToolInput(value: Record<string, unknown>): boolean {
   return (
-    summarizePrimaryToolArg(value.query) !== null || summarizePrimaryToolArg(value.pattern) !== null
+    summarizePrimaryToolArg(ownToolInputValue(value, 'query')) !== null ||
+    summarizePrimaryToolArg(ownToolInputValue(value, 'pattern')) !== null
   )
 }
 
@@ -229,7 +229,7 @@ function firstPrimaryToolArg(
   keys: readonly string[]
 ): string | null {
   for (const key of keys) {
-    const summary = summarizePrimaryToolArg(value[key])
+    const summary = summarizePrimaryToolArg(ownToolInputValue(value, key))
     if (summary) {
       return summary
     }
@@ -255,8 +255,9 @@ function summarizePrimaryToolArg(input: unknown): string | null {
   if (typeof input === 'string' && input.trim()) {
     return summarizeToolInput(input)
   }
-  if (Array.isArray(input) && input.length > 0 && input.every((part) => typeof part === 'string')) {
-    return summarizeToolInput(input.join(' '))
+  const parts = ownToolArgParts(input)
+  if (parts) {
+    return summarizeToolInput(parts.join(' '))
   }
   return null
 }
@@ -325,7 +326,9 @@ function boundedPreviewValue(value: unknown, depth: number, seen: WeakSet<object
       : value
   }
   if (!value || typeof value !== 'object') {
-    return value
+    return typeof value === 'function' || typeof value === 'symbol' || typeof value === 'bigint'
+      ? undefined
+      : value
   }
   if (seen.has(value)) {
     return '[circular]'
@@ -335,9 +338,10 @@ function boundedPreviewValue(value: unknown, depth: number, seen: WeakSet<object
   }
   seen.add(value)
   if (Array.isArray(value)) {
-    const result = value
-      .slice(0, MAX_PREVIEW_COLLECTION_ITEMS)
-      .map((item) => boundedPreviewValue(item, depth + 1, seen))
+    const result: unknown[] = []
+    for (let index = 0; index < Math.min(value.length, MAX_PREVIEW_COLLECTION_ITEMS); index++) {
+      result.push(boundedPreviewValue(ownToolInputValue(value, index), depth + 1, seen))
+    }
     if (value.length > MAX_PREVIEW_COLLECTION_ITEMS) {
       result.push('…')
     }
@@ -350,10 +354,16 @@ function boundedPreviewValue(value: unknown, depth: number, seen: WeakSet<object
       continue
     }
     if (count >= MAX_PREVIEW_COLLECTION_ITEMS) {
-      result['…'] = '…'
+      if (!Object.hasOwn(value, '…')) {
+        defineToolInputValue(result, '…', '…')
+      }
       break
     }
-    result[key] = boundedPreviewValue((value as Record<string, unknown>)[key], depth + 1, seen)
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor || !('value' in descriptor)) {
+      continue
+    }
+    defineToolInputValue(result, key, boundedPreviewValue(descriptor.value, depth + 1, seen))
     count += 1
   }
   return result


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​449 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​445 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​671 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​95 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​576 |

<!-- /orca-pr-loc -->

## ELI5

Large JSON-string tool arguments could be cut in the middle of JSON, losing the mobile file link or search label. This preserves supported metadata before trimming bulk content and keeps the original object, array, or JSON-string representation.

## What Changed

The existing host publication sanitizer now performs bounded acquisition and one structural projection. It reserves the exact selected file target or supported winning query/pattern before optional content, within the existing 4,000-unit pool; metadata gets at most 1,024 units, output at most 100 value nodes and 20 slots per container. Own-data selection and construction prevent inherited fields, getters, or prototype-like keys from acquiring authority.

Oversized or unsupported metadata deliberately loses its target and some detail instead of producing a clipped or alternate file target. Search arguments whose precedence cannot be established fall back to bounded raw detail. Nonmobile tool-call publication retains block identity.

## Why

The execution host owns publication and can preserve information before delivery. A mobile recovery layer cannot reconstruct arguments already discarded by opaque clipping or source-order budget exhaustion. This changes published content without adding a wire field or opcode.

## Linked Issue

STA-3397 — https://linear.app/stably/issue/STA-3397

## Visual Proof

Pending: no owned mobile emulator is available for observed label/detail/tap validation. No desktop substitute or fabricated screenshot was used.

## Testing

At `1366a8c0d3b82a14c879f3b4e4c3464640fdbd55` on macOS:

- 528 focused tests across four root suites; 11 mobile summary tests.
- Node, web, and CLI typechecks passed sequentially using explicit project configs; direct formatting and lint passed.
- 1,704 actual shipping host/shared-reader controls passed through synthetic enclosing block JSON against release v1.4.197 (`5ee4ace516080891731d100f843b074408a9ce0e`). This includes 1,632 search matrix cases and 72 authority cases. Two release-host label differences match the pinned pre-implementation current reader exactly; full reader parity is not claimed.
- Committed-source ablations: opaque-clipping/bypass at the shipping call failed 5 RPC tests and 824 matrix cases; disabling authority reservation failed 478 matrix cases. Both restores used `cp`, `cmp`, and positive symbol checks; restored controls pass.
- Bounded parse/projection measurements used five synthetic fixtures, 30 iterations each, with work counters; these are empirical observations, not a latency SLA.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

## Review

Fresh independent exact-head architecture review is pending. This author report does not establish CLEAN or READY.

## Agent skill upstream boundary

- [x] Not applicable; no agent-skill source or registry change.

## Notes

Native dependency integrity remains uncertain after a prior failed automatic postinstall. Resumed mobile provisioning used frozen lockfiles and ignore-scripts, with package/workspace/lockfile bytes unchanged. No native rebuild or app launch was performed. Real mobile interaction, full RPC/E2EE transport, and real Windows/Linux/SSH host validation remain unverified; the handler tests use a synthetic transcript and the skew controls use enclosing block JSON. SSH publication ownership, folder-workspace support and platform path spelling remain unchanged.
