### PR TITLE
test(orchestration): give the stopping-worker task guard a Run (fixes main shard 3/8)

### DIFF
--- a/src/main/runtime/orchestration/db-stopping-worker-task-guard.test.ts
+++ b/src/main/runtime/orchestration/db-stopping-worker-task-guard.test.ts
@@ -12,7 +12,7 @@ describe('a Task whose supervised worker is stopping', () => {
   afterEach(() => db.close())
 
   function localWorker() {
-    const task = db.createTask({ spec: 'local work' })
+    const task = db.createTask({ runId: 'run_legacy_local', spec: 'local work' })
     const { dispatch } = db.createStartingWorkerDispatch({
       taskId: task.id,
       startOptions: {},
@@ -59,7 +59,7 @@ describe('a Task whose supervised worker is stopping', () => {
     })
 
     it('control: still accepts dispatched for an active Dispatch with no supervised worker', () => {
-      const task = db.createTask({ spec: 'unsupervised work' })
+      const task = db.createTask({ runId: 'run_legacy_local', spec: 'unsupervised work' })
       createRootDispatch(db, task.id, 'term_worker')
 
       expect(db.updateTaskStatus(task.id, 'dispatched')?.status).toBe('dispatched')


### PR DESCRIPTION
## ELI5

Two PRs merged to `main` 16 seconds apart. One made "every Task must belong to a Run" a hard rule. The other added a new test that creates a Task without a Run. Each passed CI on its own, because each was tested against a `main` that did not yet contain the other. Together they fail: 7 tests in one file throw `Run is required`, and every PR in the repo has been red on `test / tests node 24 3/8` (and therefore `verify`) since. This PR passes the Run in the new test — 2 lines.

## Root cause

- #19542 (`98fdbc4`, merged 08:03:07Z) changed `createTask` from `task.runId ?? LEGACY_RUN_ID` to `if (!runId) throw new Error('Run is required')`. This was **deliberate**: it migrated every existing test to pass `runId: 'run_legacy_local'` (254 added lines, including inside the two test fixtures it touched) and added `writer-run-required.test.ts` to pin the throw.
- #19551 (`d346d6f`, merged 08:03:23Z) added `db-stopping-worker-task-guard.test.ts` with two bare `createTask` calls — in `localWorker()` (line 15) and a standalone control case (line 62).
- #19551 was validated against `main@15adbd9` (06:35Z); `compare 15adbd9...98fdbc4` = ahead_by 4. #19542's tightening was never in the tree #19551 was tested on. Each PR's own shard 3/8 was green (07:23Z and 07:28Z respectively).

**Neither author could have seen it.** This is not a review-quality failure; the gap is entirely in the merge gate (see below).

## Why fix the test and not `createTask`

Re-loosening `createTask` would undo an intentional, pinned invariant to make a newer test pass — symptom-patching. The stale side is #19551's test. Both bare calls now pass `runId: 'run_legacy_local'`, which is:
- the exact shape #19542 established across the codebase (it introduced no run fixture; the literal *is* the pattern), and
- the run every fresh database already contains: `migrate-v2-v12.ts` inserts the `run_legacy_local` row (`INSERT OR IGNORE INTO runs`) during schema setup, and `create-core-tables-sql.ts` makes it the column default, so `requireRun('run_legacy_local')` passes in the `:memory:` db these tests use.

## Sweep: is this the only stale caller?

Yes, measured two ways:
- **CI:** on a PR with an unfixed tree (#19566, en.json-only change), shards 1, 2, 4–8 were all green; shard 3/8 was the sole casualty, and its 7 failures are all this file.
- **Local, with this fix:** `pnpm test` over `src/main/runtime/orchestration` + `src/main/runtime/rpc/methods/orchestration` → **194 files, 1611 tests, 0 failures.** A brace-aware scan found 106 other bare `createTask({...})` calls; all are benign — 1 is the intentional pin in `writer-run-required.test.ts`, the other 105 are RPC-harness tests where `rpc-test-harness.ts:47` wraps `db.createTask` to inject `runId ?? activeRunId`.

## Evidence this is a main break (measured)

- Clean worktree of `main@d346d6f`, no other changes: `pnpm test db-stopping-worker-task-guard.test.ts` → 7 failed, `Run is required`, exit 1.
- Boundary: PRs whose merge tree includes `d346d6f` fail shard 3/8 (#19544 head `39bc081`, #18112 head `fb56ee4`); a control PR whose run was created 4 min earlier (#19394, pre-`d346d6f`) passed it.
- `main` HEAD is still `d346d6f`; nothing has landed since.

## Systemic: three gaps that compound, not one

Two ungated breaks reached `main` inside 24 minutes:

1. **07:39Z** — #18126 merged with its `static analysis` job **`cancelled`** (0 required checks reached `success` on its head), leaving 7 orphan i18n entries that fail `verify:localization-runtime-catalog` for every PR (fixed separately in #19566).
2. **08:03Z** — #19542 and #19551 merged **16 seconds apart**. The second break would have been caught by the very check the first one skipped.

**Neither author could have seen it.** This is not a review-quality failure. The full cause is three gaps in the merge gate that compound, in this order:

1. **cancelled ≠ failed.** A cancelled required check reads as "not failing," so #18126 merged ungated. Cancelled must be treated as *not verified*.
2. **No up-to-date-base requirement.** "Green alone" was treated as "green together": each of #19542/#19551 was validated against a `main` that did not contain the other, and nothing forced re-validation against the base they actually landed on.
3. **No post-merge signal on `main`.** `pr.yml` triggers on `pull_request` only, and `unit-tests.yml` / `e2e.yml` are `workflow_call`. `main` gets **no CI on push**, so neither break was ever visible on `main` itself — both were observable only as red on other people's PRs. That is why this went hours undetected and why several agents each rediscovered it while debugging their own PR.

The first two are fixed by branch protection with **strict status checks** (required checks + up-to-date base) — which `main` currently cannot have, because it has **no branch protection and no rulesets at all** (both APIs return empty/404). The third needs a push trigger on `main`.

## Why a standalone PR rather than riding along in #19544 / #19337

Both of those PRs currently carry an identical copy of this 2-line change bundled into unrelated feature work (#19544 is +1014/−1592 across 74 files; #19337 is 23 files). Landing it on its own is deliberate:

1. **Reviewability.** Nobody reviewing a 74-file feature PR is reviewing this fix; it rides along invisibly. A standalone PR is the unit a reviewer can actually judge.
2. **Revertability.** If #19544 has to be reverted for its feature content, `main` silently goes red again — the fix leaves with the feature. An independent commit survives that.
3. **It does not block on their timeline.** #19337's `static analysis` is `cancelled` on its current head — the fourth cancelled gate today. Waiting on those PRs means waiting on the exact failure mode this write-up is about.

If either of theirs merges first, this PR becomes a clean no-op on this file and closes.

**This PR's own first CI run demonstrated gap 2.** It was opened at 08:45:33Z; #19566 merged at 08:45:52Z — 19 seconds later. GitHub snapshots the PR base at trigger time, so the first run validated `e958ae5` against the pre-#19566 `main` (`d346d6f`) and failed the runtime-catalog step that #19566 had just fixed. A plain merge of `origin/main` re-ran it against the base it will actually land on. That is exactly the re-validation an up-to-date-base requirement forces.

## Verification

- `pnpm test src/main/runtime/orchestration/db-stopping-worker-task-guard.test.ts` → 7 passed.
- Orchestration-wide sweep above → 194 files / 1611 tests pass.
- `oxlint` and `oxfmt --check` clean on the file. Diff is exactly the two `runId:` additions.
