### PR TITLE
fix(i18n): drop the stale TerminalPane.minimumContrast entries from the runtime catalog (main red again)

### DIFF
--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -1503,16 +1503,7 @@
           "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent.",
           "ask_before_closing_running_terminals_title": "Ask Before Closing Running Terminals",
           "cc8c5ca224": "Windows default",
-          "d78fc4fdef": "Loading distributions",
-          "minimumContrast": {
-            "automatic": "Automatic: {{light}} on light backgrounds, {{dark}} on dark.",
-            "description": "Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.",
-            "disabled": "Correction off. Programs that rely on low contrast, like Powerline separators, render as sent.",
-            "pinned": "Targets {{ratio}}:1 contrast for foreground colors, where possible.",
-            "placeholder": "Auto",
-            "suffix": "blank = automatic, 1 = off",
-            "title": "Minimum Contrast Ratio"
-          }
+          "d78fc4fdef": "Loading distributions"
         },
         "TerminalSettingsPreview": {
           "d06664e889": "dark"


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 |

<!-- /orca-pr-loc -->

## ELI5

#19566 deleted seven unused English strings from `en.json`. #19544 was tested against a `main` that still had them, so it merged a regenerated shipped catalog that *includes* those seven — and now the catalog names strings that no longer exist. The check that compares the two fails again on every PR. This regenerates the shipped catalog from the current `en.json`; the only change is removing the seven stale entries.

## Root cause

- `ea102a9` (#19566, 08:45:52Z) removed `auto.components.settings.TerminalPane.minimumContrast.*` (7 orphans, zero call sites) from `en.json`.
- `12f53da` (#19544, 09:14:59Z) merged a `sync:localization-runtime-catalog` regeneration that **adds** those 7 to `en-runtime-required.json`. Its `static analysis` was green because the run validated `Merge ca06b4a into d346d6f` — a base from **before** #19566, where `en.json` still contained the keys and the regen was consistent (its log: "covers en.json: 1687 of 14196").
- `generate-runtime-required-english-catalog.mjs` classifies a shipped entry with no `en.json` counterpart as **`contradicting`** (`catalogEntries.get(key) === undefined !== shipped.get(key)`), and any `contradicting` is a hard exit 1. It is *not* `superfluous` — that class requires the key to still exist in `en.json`.

Measured on a literal detached checkout of `main@12f53da`: exit 1, "Shipped entries whose text disagrees with en.json:" followed by exactly the 7 keys. Flattened-JSON check: 7 shipped keys with no `en.json` entry, 0 genuine text mismatches.

## The fix

`pnpm run sync:localization-runtime-catalog` — the non-destructive script that writes only `en-runtime-required.json` (not the destructive `sync:localization-catalog`) — regenerated from the current `en.json`. The diff is exactly the inverse of #19544's hunk: −10/+1, the seven entries and their block removed. No other key added, removed, or changed.

## Verification (on `main@12f53da` + this commit)

| Check | Result |
| --- | --- |
| `verify:localization-runtime-catalog` (the failing step) | exit 0 — "covers en.json: 1680 of 14189" |
| `verify:localization-catalog` | exit 0 (output identical to untouched main; control run) |
| `verify:localization-coverage` | exit 0 |
| `oxfmt --check en-runtime-required.json` | clean |

## Systemic

This is the **third** stale-base incident on `main` today, and this one re-broke a lane fixed 29 minutes earlier. Same mechanism as #19542/#19551: a PR's checks are green against the base snapshotted at trigger time, not the base it lands on. Nothing warned anyone — the PR was green, and `main` has no push-triggered CI to surface the break after merge. The control that prevents this is a **strict status check / up-to-date-base requirement** on `main`, which currently has no branch protection or rulesets at all.
