### PR TITLE
fix(serve): make terminal tab rename survive browser reload

### DIFF
--- a/src/main/runtime/mobile-session-terminal-custom-title.test.ts
+++ b/src/main/runtime/mobile-session-terminal-custom-title.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalTab } from '../../shared/terminal-tab-types'
+import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import { buildHeadlessMobileSessionTerminalTabs } from './mobile-session-terminal-projection'
+import { persistedCustomTitleMissingFromSnapshot } from './orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session'
+import type { RuntimeMobileSessionTerminalTab } from '../../shared/runtime-types'
+
+function makePersistedTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 'tab-1',
+    ptyId: null,
+    worktreeId: 'repo1::/path/wt1',
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ...overrides
+  }
+}
+
+function makeSession(tabs: TerminalTab[]): WorkspaceSessionState {
+  return {
+    tabsByWorktree: { 'repo1::/path/wt1': tabs }
+  } as unknown as WorkspaceSessionState
+}
+
+describe('buildHeadlessMobileSessionTerminalTabs customTitle', () => {
+  it('carries the persisted customTitle into the built tab', () => {
+    const tabs = buildHeadlessMobileSessionTerminalTabs(
+      'repo1::/path/wt1',
+      [makePersistedTab({ customTitle: 'my rename' })],
+      makeSession([])
+    )
+    expect(tabs).toHaveLength(1)
+    expect(tabs[0]!.customTitle).toBe('my rename')
+    // The resolved title already prefers the rename.
+    expect(tabs[0]!.title).toBe('my rename')
+  })
+
+  it('omits customTitle when no rename is persisted', () => {
+    const tabs = buildHeadlessMobileSessionTerminalTabs(
+      'repo1::/path/wt1',
+      [makePersistedTab()],
+      makeSession([])
+    )
+    expect(tabs[0]!.customTitle).toBeUndefined()
+  })
+
+  it('clearing a rename (null customTitle) drops the field', () => {
+    const tabs = buildHeadlessMobileSessionTerminalTabs(
+      'repo1::/path/wt1',
+      [makePersistedTab({ customTitle: null })],
+      makeSession([])
+    )
+    expect(tabs[0]!.customTitle).toBeUndefined()
+  })
+})
+
+function makeSnapshotTab(
+  overrides: Partial<RuntimeMobileSessionTerminalTab> = {}
+): RuntimeMobileSessionTerminalTab {
+  return {
+    type: 'terminal',
+    id: 'tab-1::leaf-1',
+    parentTabId: 'tab-1',
+    leafId: 'leaf-1',
+    title: 'Terminal',
+    isActive: false,
+    ...overrides
+  }
+}
+
+describe('persistedCustomTitleMissingFromSnapshot', () => {
+  it('flags a rename missing from the snapshot', () => {
+    expect(
+      persistedCustomTitleMissingFromSnapshot(
+        [makePersistedTab({ customTitle: 'my rename' })],
+        [makeSnapshotTab()]
+      )
+    ).toBe(true)
+  })
+
+  it('passes when the snapshot already carries the rename', () => {
+    expect(
+      persistedCustomTitleMissingFromSnapshot(
+        [makePersistedTab({ customTitle: 'my rename' })],
+        [makeSnapshotTab({ customTitle: 'my rename' })]
+      )
+    ).toBe(false)
+  })
+
+  it('passes when nothing is persisted', () => {
+    expect(persistedCustomTitleMissingFromSnapshot([makePersistedTab()], [makeSnapshotTab()])).toBe(
+      false
+    )
+  })
+
+  it('ignores tabs absent from the snapshot (handled by rebuild identity)', () => {
+    expect(
+      persistedCustomTitleMissingFromSnapshot(
+        [makePersistedTab({ id: 'tab-other', customTitle: 'rename' })],
+        [makeSnapshotTab()]
+      )
+    ).toBe(false)
+  })
+})

--- a/src/main/runtime/mobile-session-terminal-custom-title.test.ts
+++ b/src/main/runtime/mobile-session-terminal-custom-title.test.ts
@@ -90,6 +90,24 @@ describe('persistedCustomTitleMissingFromSnapshot', () => {
     ).toBe(false)
   })
 
+  it('flags a cleared rename (null persisted) still carried by the snapshot', () => {
+    expect(
+      persistedCustomTitleMissingFromSnapshot(
+        [makePersistedTab({ customTitle: null })],
+        [makeSnapshotTab({ customTitle: 'stale rename' })]
+      )
+    ).toBe(true)
+  })
+
+  it('passes when the rename is cleared on both sides', () => {
+    expect(
+      persistedCustomTitleMissingFromSnapshot(
+        [makePersistedTab({ customTitle: null })],
+        [makeSnapshotTab()]
+      )
+    ).toBe(false)
+  })
+
   it('passes when nothing is persisted', () => {
     expect(persistedCustomTitleMissingFromSnapshot([makePersistedTab()], [makeSnapshotTab()])).toBe(
       false

--- a/src/main/runtime/mobile-session-terminal-projection.ts
+++ b/src/main/runtime/mobile-session-terminal-projection.ts
@@ -36,6 +36,9 @@ export function buildHeadlessMobileSessionTerminalTabs(
             parentTabId: tab.id,
             leafId,
             title,
+            // Why: the persisted manual rename must reach clients even when a live
+            // OSC/agent title would otherwise mask it in the projection chain.
+            ...(tab.customTitle ? { customTitle: tab.customTitle } : {}),
             ...(ptyId ? { ptyId } : {}),
             ...(tab.startupCwd ? { startupCwd: tab.startupCwd } : {}),
             ...(tab.launchAgent ? { launchAgent: tab.launchAgent } : {}),

--- a/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
+++ b/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
 import { OrcaRuntimeWithWaitForSessionTabsInventoryPublication } from './orca-runtime-wait-for-session-tabs-inventory-publication'
+import type { TerminalTab } from '../../shared/terminal-tab-types'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import { getRuntimeBrowserPageRegistry } from './runtime-browser-page-registry'
 import { splitWorktreeIdForFilesystem } from '../../shared/worktree/id'
@@ -26,6 +27,32 @@ import {
   collectBrowserGroupAssignment
 } from './mobile-session-browser-group-projection'
 import { headlessMobileSnapshotContentUnchanged } from './mobile-session-snapshot-equality'
+
+/**
+ * Why: the hydrate skip path is first-wins, so a rename persisted into
+ * workspaceSession after the snapshot was built would never surface. Detect
+ * the gap (persisted `customTitle` absent from the snapshot's terminal tab)
+ * and let the caller fall through to a full rebuild that carries it.
+ */
+export function persistedCustomTitleMissingFromSnapshot(
+  persistedTabs: readonly TerminalTab[],
+  snapshotTabs: readonly RuntimeMobileSessionSnapshotTab[]
+): boolean {
+  const snapshotCustomTitleByParentTabId = new Map<string, string | null>()
+  for (const tab of snapshotTabs) {
+    if (tab.type === 'terminal' && !snapshotCustomTitleByParentTabId.has(tab.parentTabId)) {
+      snapshotCustomTitleByParentTabId.set(tab.parentTabId, tab.customTitle ?? null)
+    }
+  }
+  return persistedTabs.some((tab) => {
+    const persisted = tab.customTitle ?? null
+    return (
+      persisted !== null &&
+      snapshotCustomTitleByParentTabId.has(tab.id) &&
+      snapshotCustomTitleByParentTabId.get(tab.id) !== persisted
+    )
+  })
+}
 
 export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession extends OrcaRuntimeWithWaitForSessionTabsInventoryPublication {
   protected hydrateHeadlessMobileSessionTabsFromWorkspaceSession(
@@ -101,7 +128,10 @@ export class OrcaRuntimeWithHydrateHeadlessMobileSessionTabsFromWorkspaceSession
         existing &&
         existing.tabs.length > 0 &&
         options.force !== true &&
-        options.onlyRuntimeOwnedTerminals !== true
+        options.onlyRuntimeOwnedTerminals !== true &&
+        // Why: a persisted manual rename must win over the first-wins snapshot
+        // merge; skip only when the existing snapshot already carries it.
+        !persistedCustomTitleMissingFromSnapshot(persistedTabs, existing.tabs)
       ) {
         // Why: terminals are stable/persisted so we normally skip a rebuild, but
         // offscreen browser tabs are live and may have been created/closed since.

--- a/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
+++ b/src/main/runtime/orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts
@@ -31,8 +31,8 @@ import { headlessMobileSnapshotContentUnchanged } from './mobile-session-snapsho
 /**
  * Why: the hydrate skip path is first-wins, so a rename persisted into
  * workspaceSession after the snapshot was built would never surface. Detect
- * the gap (persisted `customTitle` absent from the snapshot's terminal tab)
- * and let the caller fall through to a full rebuild that carries it.
+ * any divergence (rename added OR cleared to null while the snapshot still
+ * carries one) and let the caller fall through to a full rebuild.
  */
 export function persistedCustomTitleMissingFromSnapshot(
   persistedTabs: readonly TerminalTab[],
@@ -47,7 +47,6 @@ export function persistedCustomTitleMissingFromSnapshot(
   return persistedTabs.some((tab) => {
     const persisted = tab.customTitle ?? null
     return (
-      persisted !== null &&
       snapshotCustomTitleByParentTabId.has(tab.id) &&
       snapshotCustomTitleByParentTabId.get(tab.id) !== persisted
     )

--- a/src/main/runtime/runtime-mobile-session-projection-custom-title.test.ts
+++ b/src/main/runtime/runtime-mobile-session-projection-custom-title.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  RuntimeMobileSessionTerminalTab,
+  RuntimeMobileSessionTabsSnapshot
+} from '../../shared/runtime-types'
+import { projectRuntimeMobileSessionTabs } from './runtime-mobile-session-projection'
+import type { RuntimeMobileSessionProjectionHost } from './runtime-mobile-session-projection-contract'
+import type { RuntimeLeafRecord, RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
+
+const TAB_ID = 'tab-1'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function makeSnapshotTab(
+  overrides: Partial<RuntimeMobileSessionTerminalTab> = {}
+): RuntimeMobileSessionTerminalTab {
+  return {
+    type: 'terminal',
+    id: `${TAB_ID}::${LEAF_ID}`,
+    parentTabId: TAB_ID,
+    leafId: LEAF_ID,
+    title: 'Terminal',
+    isActive: true,
+    ...overrides
+  }
+}
+
+function makeSnapshot(tabs: RuntimeMobileSessionTerminalTab[]): RuntimeMobileSessionTabsSnapshot {
+  return {
+    worktree: 'repo1::/path/wt1',
+    publicationEpoch: 'headless-hydrated:test',
+    snapshotVersion: 1,
+    activeGroupId: 'g1',
+    activeTabId: tabs[0]?.id ?? null,
+    activeTabType: 'terminal',
+    tabGroups: [{ id: 'g1', activeTabId: TAB_ID, tabOrder: [TAB_ID] }],
+    tabs
+  }
+}
+
+function makeHost(
+  overrides: Partial<RuntimeMobileSessionProjectionHost> = {}
+): RuntimeMobileSessionProjectionHost {
+  const emptyPty = null
+  return {
+    tabs: new Map(),
+    leaves: new Map(),
+    ptysById: new Map(),
+    getLiveBrowserTabs: () => new Map(),
+    getProviderSessionRows: () => undefined,
+    getProviderSessionSnapshot: () => [],
+    getLeafKey: (tabId, leafId) => `${tabId}:${leafId}`,
+    findPty: () => emptyPty,
+    getRetainedStatus: () => null,
+    getTrackedTitle: () => null,
+    issuePtyHandle: () => '',
+    recordPty: () => ({}) as RuntimePtyWorktreeRecord,
+    buildPtyStatus: () => ({}),
+    sanitizeGroups: (groups) => groups,
+    pruneGroupLayout: () => null,
+    collectTabIds: () => new Set(),
+    ...overrides
+  }
+}
+
+function project(
+  tabs: RuntimeMobileSessionTerminalTab[],
+  hostOverrides: Partial<RuntimeMobileSessionProjectionHost> = {}
+): RuntimeMobileSessionTerminalTab[] {
+  const result = projectRuntimeMobileSessionTabs(makeSnapshot(tabs), makeHost(hostOverrides))
+  return result.tabs.filter((tab) => tab.type === 'terminal') as RuntimeMobileSessionTerminalTab[]
+}
+
+describe('projectRuntimeMobileSessionTabs customTitle priority', () => {
+  it('a persisted customTitle beats a fresh OSC leaf title', () => {
+    const leaf = {
+      ptyId: 'pty-1',
+      connected: true,
+      paneTitle: 'Claude working',
+      paneTitleUpdatedAt: 10,
+      lastOscTitle: 'Claude working',
+      lastOscTitleAt: 10
+    } as unknown as RuntimeLeafRecord
+    const projected = project([makeSnapshotTab({ customTitle: 'my rename' })], {
+      leaves: new Map([[`${TAB_ID}:${LEAF_ID}`, leaf]])
+    })
+    expect(projected[0]!.title).toBe('my rename')
+    expect(projected[0]!.customTitle).toBe('my rename')
+  })
+
+  it('a persisted customTitle beats the tracked PTY title', () => {
+    const projected = project([makeSnapshotTab({ customTitle: 'my rename' })], {
+      getTrackedTitle: () => 'Codex working'
+    })
+    expect(projected[0]!.title).toBe('my rename')
+  })
+
+  it('without customTitle, the OSC leaf title still wins', () => {
+    const leaf = {
+      ptyId: 'pty-1',
+      connected: true,
+      paneTitle: 'Claude working',
+      paneTitleUpdatedAt: 10,
+      lastOscTitle: 'Claude working',
+      lastOscTitleAt: 10
+    } as unknown as RuntimeLeafRecord
+    const projected = project([makeSnapshotTab()], {
+      leaves: new Map([[`${TAB_ID}:${LEAF_ID}`, leaf]])
+    })
+    expect(projected[0]!.title).toBe('Claude working')
+    expect(projected[0]!.customTitle).toBeUndefined()
+  })
+
+  it('falls back to snapshot tab title when no rename and no observations', () => {
+    const projected = project([makeSnapshotTab({ title: 'Terminal 2' })])
+    expect(projected[0]!.title).toBe('Terminal 2')
+  })
+})

--- a/src/main/runtime/runtime-mobile-session-projection-custom-title.test.ts
+++ b/src/main/runtime/runtime-mobile-session-projection-custom-title.test.ts
@@ -94,6 +94,23 @@ describe('projectRuntimeMobileSessionTabs customTitle priority', () => {
     expect(projected[0]!.title).toBe('my rename')
   })
 
+  it('does not normalize a manual rename that looks like an agent title', () => {
+    // A manual rename matching the legacy π shape must survive verbatim.
+    const leaf = {
+      ptyId: 'pty-1',
+      connected: true,
+      paneTitle: 'π > session - repo',
+      paneTitleUpdatedAt: 10,
+      lastOscTitle: 'π > session - repo',
+      lastOscTitleAt: 10
+    } as unknown as RuntimeLeafRecord
+    const projected = project([makeSnapshotTab({ customTitle: 'π > session - repo' })], {
+      leaves: new Map([[`${TAB_ID}:${LEAF_ID}`, leaf]])
+    })
+    expect(projected[0]!.title).toBe('π > session - repo')
+    expect(projected[0]!.customTitle).toBe('π > session - repo')
+  })
+
   it('without customTitle, the OSC leaf title still wins', () => {
     const leaf = {
       ptyId: 'pty-1',

--- a/src/main/runtime/runtime-mobile-session-projection.ts
+++ b/src/main/runtime/runtime-mobile-session-projection.ts
@@ -139,17 +139,15 @@ export function projectRuntimeMobileSessionTabs(
     const ownerOptions = { ownerIsLaunch: ownerRecord?.ownerIsLaunch === true }
     // Why: a persisted manual rename outranks every OSC/agent observation; without
     // this the fresh leaf title masks the rename after a browser reload (#serve).
+    // Raw, never normalized — the user typed exactly this.
     const persistedCustomTitle = tab.customTitle ?? syncedTab?.customTitle ?? null
-    const title = normalizeCompatibleAgentTitleForOwner(
+    const title =
       persistedCustomTitle ??
-        trackerOnlyTitle ??
-        leafTitle ??
-        ptyTitle ??
-        syncedTab?.title ??
-        tab.title,
-      ownerAgent,
-      ownerOptions
-    )
+      normalizeCompatibleAgentTitleForOwner(
+        trackerOnlyTitle ?? leafTitle ?? ptyTitle ?? syncedTab?.title ?? tab.title,
+        ownerAgent,
+        ownerOptions
+      )
     const liveTitleEvidence = leafTitle ?? ptyTitle
     // Why: renderer status can precede hook session identity, leaving native chat with no transcript address.
     const rendererStatusAgent =

--- a/src/main/runtime/runtime-mobile-session-projection.ts
+++ b/src/main/runtime/runtime-mobile-session-projection.ts
@@ -137,8 +137,16 @@ export function projectRuntimeMobileSessionTabs(
     const ownerAgent =
       ownerRecord?.agent ?? liveLeafPty?.foregroundAgent ?? pty?.foregroundAgent ?? null
     const ownerOptions = { ownerIsLaunch: ownerRecord?.ownerIsLaunch === true }
+    // Why: a persisted manual rename outranks every OSC/agent observation; without
+    // this the fresh leaf title masks the rename after a browser reload (#serve).
+    const persistedCustomTitle = tab.customTitle ?? syncedTab?.customTitle ?? null
     const title = normalizeCompatibleAgentTitleForOwner(
-      trackerOnlyTitle ?? leafTitle ?? ptyTitle ?? syncedTab?.title ?? tab.title,
+      persistedCustomTitle ??
+        trackerOnlyTitle ??
+        leafTitle ??
+        ptyTitle ??
+        syncedTab?.title ??
+        tab.title,
       ownerAgent,
       ownerOptions
     )
@@ -254,6 +262,7 @@ export function projectRuntimeMobileSessionTabs(
       leafId: tab.leafId,
       title,
       ...(tab.ptyId ? { ptyId: tab.ptyId } : {}),
+      ...(persistedCustomTitle ? { customTitle: persistedCustomTitle } : {}),
       ...(tab.terminalTheme ? { terminalTheme: tab.terminalTheme } : {}),
       ...(launchAgent ? { launchAgent } : {}),
       ...clientAgentStatus,

--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -1503,16 +1503,7 @@
           "ask_before_closing_running_terminals_description": "Show a confirmation before closing a terminal that has a running command or agent.",
           "ask_before_closing_running_terminals_title": "Ask Before Closing Running Terminals",
           "cc8c5ca224": "Windows default",
-          "d78fc4fdef": "Loading distributions",
-          "minimumContrast": {
-            "automatic": "Automatic: {{light}} on light backgrounds, {{dark}} on dark.",
-            "description": "Lifts terminal foreground colors that sit too close to the background. Leave blank for automatic, or set 1 to render program colors exactly as sent.",
-            "disabled": "Correction off. Programs that rely on low contrast, like Powerline separators, render as sent.",
-            "pinned": "Targets {{ratio}}:1 contrast for foreground colors, where possible.",
-            "placeholder": "Auto",
-            "suffix": "blank = automatic, 1 = off",
-            "title": "Minimum Contrast Ratio"
-          }
+          "d78fc4fdef": "Loading distributions"
         },
         "TerminalSettingsPreview": {
           "d06664e889": "dark"

--- a/src/renderer/src/runtime/sync-runtime-graph/graph-publication.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/graph-publication.ts
@@ -82,6 +82,8 @@ export async function syncRuntimeGraph(): Promise<void> {
       tabId: registeredTab.tabId,
       worktreeId: registeredTab.worktreeId,
       title: resolveRuntimeTerminalTitle(tab, generatedTitlesEnabled),
+      // Why: mirrors the persisted rename so main's projection can survive a restart without the tab being mounted.
+      customTitle: tab.customTitle ?? null,
       activeLeafId: activePaneId === null ? null : (manager?.getLeafId(activePaneId) ?? null),
       layout: serializePaneTree(root)
     })
@@ -156,6 +158,7 @@ export async function syncRuntimeGraph(): Promise<void> {
         tabId: tab.id,
         worktreeId,
         title,
+        customTitle: tab.customTitle ?? null,
         activeLeafId:
           savedActiveLeafId && publishedLeafIds.has(savedActiveLeafId)
             ? savedActiveLeafId

--- a/src/renderer/src/runtime/web-session-tabs-sync/terminal-build-custom-title.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/terminal-build-custom-title.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
+import { toWebTerminalSurfaceTabId } from '../../../../shared/terminal-surface-id'
+import { buildMirroredTerminalTabs } from './terminal-build'
+
+const WT = 'repo1::/path/wt1'
+const HOST_TAB_ID = 'host-tab-1'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const SURFACE_ID = `${HOST_TAB_ID}::${LEAF_ID}`
+const LOCAL_TAB_ID = toWebTerminalSurfaceTabId(HOST_TAB_ID)
+
+function makeSnapshot(
+  surfaceOverrides: Record<string, unknown> = {}
+): RuntimeMobileSessionTabsResult {
+  return {
+    worktree: WT,
+    publicationEpoch: 'host-epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: 'g1',
+    activeTabId: SURFACE_ID,
+    activeTabType: 'terminal',
+    tabs: [
+      {
+        type: 'terminal',
+        id: SURFACE_ID,
+        title: 'Terminal',
+        parentTabId: HOST_TAB_ID,
+        leafId: LEAF_ID,
+        isActive: true,
+        status: 'ready',
+        terminal: 'terminal-1',
+        ...surfaceOverrides
+      } as RuntimeMobileSessionTabsResult['tabs'][number]
+    ]
+  }
+}
+
+function makeExisting(customTitle: string | null): Map<string, TerminalTab> {
+  return new Map([
+    [
+      LOCAL_TAB_ID,
+      {
+        id: LOCAL_TAB_ID,
+        ptyId: null,
+        worktreeId: WT,
+        title: 'Terminal',
+        customTitle,
+        color: null,
+        sortOrder: 0,
+        createdAt: 1
+      }
+    ]
+  ])
+}
+
+function mirror(
+  snapshot: RuntimeMobileSessionTabsResult,
+  existing?: Map<string, TerminalTab>
+): TerminalTab {
+  const [mirrored] = buildMirroredTerminalTabs(
+    snapshot,
+    'web-env-1',
+    existing ?? new Map(),
+    {} as Record<string, TerminalLayoutSnapshot>,
+    0,
+    1_700_000_000_000
+  )
+  return mirrored!.tab
+}
+
+describe('buildMirroredTerminalTabs customTitle adoption', () => {
+  it('a fresh browser adopts the host-published customTitle', () => {
+    const tab = mirror(makeSnapshot({ customTitle: 'my rename' }))
+    expect(tab.customTitle).toBe('my rename')
+  })
+
+  it('a fresh browser with no host rename has null customTitle', () => {
+    const tab = mirror(makeSnapshot())
+    expect(tab.customTitle).toBeNull()
+  })
+
+  it('host rename wins over a stale local value', () => {
+    const tab = mirror(makeSnapshot({ customTitle: 'host rename' }), makeExisting('stale'))
+    expect(tab.customTitle).toBe('host rename')
+  })
+
+  it('without a host rename the local rename is retained', () => {
+    const tab = mirror(makeSnapshot(), makeExisting('local rename'))
+    expect(tab.customTitle).toBe('local rename')
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync/terminal-build.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/terminal-build.ts
@@ -173,7 +173,11 @@ export function buildMirroredTerminalTabs(
         ...(existing?.aiVaultTitle ? { aiVaultTitle: existing.aiVaultTitle } : {}),
         ...(quickCommandLabel ? { quickCommandLabel } : {}),
         ...(startupCwd ? { startupCwd } : {}),
-        customTitle: existing?.customTitle ?? null,
+        // Why: the host now publishes the persisted rename; adopt it over any stale local value (fresh browser has none).
+        customTitle:
+          (activeSurface.customTitle ?? surfaces.find((s) => s.customTitle)?.customTitle) ||
+          existing?.customTitle ||
+          null,
         color,
         isPinned,
         ...(viewMode ? { viewMode } : {}),

--- a/src/shared/runtime-mobile-session-tab-contracts.ts
+++ b/src/shared/runtime-mobile-session-tab-contracts.ts
@@ -9,6 +9,8 @@ export type RuntimeMobileSessionTerminalTab = {
   type: 'terminal'
   id: string
   title: string
+  /** Persisted manual rename from workspaceSession; absent on old hosts (wire compatible). */
+  customTitle?: string | null
   quickCommandLabel?: string | null
   parentTabId: string
   leafId: string

--- a/src/shared/runtime-session-contracts.ts
+++ b/src/shared/runtime-session-contracts.ts
@@ -131,6 +131,8 @@ export type RuntimeSyncedTab = {
   tabId: string
   worktreeId: string
   title: string | null
+  /** Persisted manual rename mirrored into the graph sync (optional for wire compat). */
+  customTitle?: string | null
   activeLeafId: string | null
   layout: TerminalPaneLayoutNode | null
 }


### PR DESCRIPTION
Fixes #19582

## ELI5

If you rename a terminal tab in the web/mobile client, the rename vanishes when the tab list is rebuilt (app restart, session reload, worktree switch). Desktop masked this with an in-memory round-trip that is equally lost on restart. This PR makes the manual rename a first-class field that is persisted, projected, and mirrored everywhere.

## What

A manual terminal rename on `orca-serve` is persisted into the workspace session but never surfaced again: the projection chain ignores `customTitle`, the hydrate skip path serves a stale first-wins snapshot, the renderer mirror drops the field, and `RuntimeMobileSessionTerminalTab` has no `customTitle` on the wire. Desktop masks it day-to-day via an in-memory IPC round-trip that is equally lost on app restart.

## Root cause

Four gaps compound: (1) the shared wire contract has no `customTitle` field, (2) tab projection priority drops the persisted rename, (3) the headless hydrate skip path serves the existing snapshot without checking whether a persisted rename is missing from it, and (4) the renderer mirror ignores `incoming.customTitle` when adopting host state.

## How (atomic commits)

1. `feat(shared)`: optional `customTitle?: string | null` on `RuntimeMobileSessionTerminalTab` (wire compatible: new optional field, per remote-wire-compatibility guidance).
2. `fix(main)`: projection priority `customTitle ?? trackerOnlyTitle ?? leafTitle ?? ptyTitle ?? syncedTab?.title ?? tab.title`; publish `customTitle` on built/projected tabs; mirror on `RuntimeSyncedTab`.
3. `fix(main)`: hydrate skip path falls through to rebuild when a persisted `customTitle` is missing from the existing snapshot (narrow gate, no global `force` flip).
4. `fix(main)`: never normalize away a persisted manual rename during tab rebuild.
5. `fix(renderer)`: web session tab mirror adopts `incoming.customTitle` over stale local value.
6. `test`: unit coverage for build, projection priority, hydrate gap, mirror adoption, and rename-clearing.

The OSC tracker path is already fenced (`getUnpersistedTrackedTitleForPty` returns null while a manual `pty.title` is set), so no change was needed there.

One commit (`cb8d1c8a`) regenerates `en-runtime-required.json` only to drop orphan `minimumContrast` entries upstream removed in 2abd8b0fb8 — mechanical catalog sync required by `sync:localization-runtime-catalog`, not a behavioral change.

## Visual proof

N/A — no UI surface changes; terminal tab titles simply retain their persisted value across rebuilds.

## Testing

- `pnpm vitest run src/main/runtime/mobile-session-terminal-custom-title.test.ts src/main/runtime/runtime-mobile-session-projection-custom-title.test.ts src/renderer/src/runtime/web-session-tabs-sync/terminal-build-custom-title.test.ts` — new coverage, all pass
- Node + renderer unit projects pass; `runtime-environments-pairing.test.ts` updated for the catalog-independent handler ordering
- Manually exercised: rename tab in web client → restart server → rename persists; clear rename → falls back to tracker/leaf title

## Platform coverage

- Windows/Linux/macOS desktop: unchanged behavior (in-memory IPC path continues to work; restart now also survives, which it previously did not)
- Web/mobile via orca-serve: primary beneficiary; rename persists across server restart and worktree switch

## Compatibility

- Wire change is additive (new optional field), safe for mixed client/host versions
- No Git commands added or changed; no process-execution changes; no new IPC opcodes

## Linked work

- Fork-side review thread: espetro/orca#3 (same patch, fork layout)
- Fixes #19582

## AI disclosure

Authored with AI assistance (Claude); human-reviewed.

## Review notes

- The hydrate gate is deliberately narrow: it only forces a rebuild when the snapshot is missing a persisted rename, so existing sessions don't pay a rebuild on every hydrate
- `minimumContrast` catalog removal is the only i18n diff; flagged here since the pre-merge check flags it as out of scope

## Checklist

- [x] Wire compatibility considered (additive optional field)
- [x] Cross-platform (macOS/Linux/Windows)
- [x] Folder-workspace and SSH use cases unchanged
- [x] Tests added for every touched projection/hydrate/mirror path