### PR TITLE
feat(voice): add optional Whisper Medium (int8) speech model

### DIFF
--- a/docs/site/content/docs/settings.mdx
+++ b/docs/site/content/docs/settings.mdx
@@ -113,6 +113,7 @@ Settings are grouped into panes. Everything here is searchable with `Cmd-,` then
   - **Parakeet TDT-CTC JA** — Japanese.
   - **SenseVoice** — ZH / EN / JA / KO / Cantonese with auto language detection.
   - **Whisper Tiny** — 90+ languages, lower accuracy.
+  - **Whisper Medium (int8)** — 90+ languages, much higher accuracy; larger optional download (~946 MB).
   - **GPT-4o mini / GPT-4o Transcribe** — cloud; needs OpenAI key under the same pane.
 - While listening, a **Listening…** pill shows a **Stop** control; in toggle mode the tooltip also shows the dictation shortcut.
 

--- a/src/main/speech/model-catalog.ts
+++ b/src/main/speech/model-catalog.ts
@@ -112,6 +112,17 @@ export const SPEECH_MODEL_CATALOG: SpeechModelManifest[] = [
     streaming: false
   },
   {
+    id: 'whisper-medium-int8',
+    label: 'Whisper Medium (int8)',
+    description: '90+ languages. Much higher accuracy than Tiny, optional ~946MB download.',
+    type: 'whisper',
+    provider: 'local',
+    language: 'multilingual',
+    ...getSpeechModelDownloadMetadata('whisper-medium-int8'),
+    sampleRate: 16000,
+    streaming: false
+  },
+  {
     id: 'sense-voice-zh-en-ja-ko-yue',
     label: 'SenseVoice',
     description:

--- a/src/main/speech/model-download-catalog.ts
+++ b/src/main/speech/model-download-catalog.ts
@@ -200,6 +200,27 @@ const MODEL_DOWNLOAD_FILES = {
       ]
     ]
   ),
+  'whisper-medium-int8': huggingFaceFiles(
+    'csukuangfj/sherpa-onnx-whisper-medium',
+    '8c31d28503847560985df21f90e14f0c736e075e',
+    [
+      [
+        'medium-encoder.int8.onnx',
+        374_196_283,
+        '1c54582b4d829de0089f6cb63bbbdb3bf7555398bacaf855fbecf1a84dfd193e'
+      ],
+      [
+        'medium-decoder.int8.onnx',
+        571_059_257,
+        '595d00a338a365a7bfa0ca7f296cabc639583bef770ab6130df90f49a6412747'
+      ],
+      [
+        'medium-tokens.txt',
+        816_730,
+        'b34b360dbb493e781e479794586d661700670d65564001f23024971d1f2fa126'
+      ]
+    ]
+  ),
   'sense-voice-zh-en-ja-ko-yue': huggingFaceFiles(
     'csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17',
     '2365baeacb507f821a0c8120fcee3d484dba7a07',


### PR DESCRIPTION
## ELI5

Orca's voice dictation only shipped a tiny transcription model that mangles non-English speech. This PR adds a bigger, much more accurate model as an optional download — nothing changes unless you pick it.

## What Changed

- `src/main/speech/model-download-catalog.ts`: pinned int8 ONNX files for `whisper-medium-int8` from `csukuangfj/sherpa-onnx-whisper-medium` @ `8c31d28` (encoder 374MB + decoder 571MB + tokens, ~946MB total).
- `src/main/speech/model-catalog.ts`: new `whisper-medium-int8` entry (`type: whisper`, multilingual, non-streaming, not recommended by default).
- `docs/site/content/docs/settings.mdx`: listed the new model in the speech-model rundown.

## Why

Whisper Tiny (39M params) mistranscribes non-English dictation badly, pushing users to cloud transcription. Whisper Medium int8 keeps accuracy within ~1% of fp32 at roughly half the size and slots into the existing generic Whisper worker path with no code changes.

## Linked Issue

Relates to #7885 — non-English dictation accuracy; small standalone enhancement.

## Visual Proof

N/A — no UI code changed; the new model appears automatically as a row in the existing catalog-driven Speech Model dropdown.

## Testing

- [x] I manually verified these changes locally (metadata resolution, URL reachability)
- [x] Automated tests: `vitest run src/main/speech/` — 15 files, 86 tests pass; `tsc --noEmit -p config/tsconfig.node.json` clean
- Platforms: Windows (local); change is platform-independent metadata (pinned HTTPS downloads + sha256 verified per file)

## AI Disclosure

Written with AI assistance (Muse Spark coding agent, supervised); hashes and sizes verified against HuggingFace API, tests and typecheck run locally.

## Review

pullfrog: no new issues, hashes confirmed. coderabbit: minimal merge risk, no actionable comments.

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, or registry entries touched.

## Notes

Security: pinned revision + per-file sha256, same pattern as existing models. Backwards compatible: purely additive, defaults unchanged. Performance: opt-in ~946MB download, CPU provider like other local models.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] N/A with reason (no UI change)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (metadata only, N/A)
- [x] `pnpm test` (scoped) and typecheck pass locally