### PR TITLE
Keep empty remote workspaces empty on selection

### DIFF
--- a/src/renderer/src/lib/web-runtime-worktree-terminal-after-wake.ts
+++ b/src/renderer/src/lib/web-runtime-worktree-terminal-after-wake.ts
@@ -24,6 +24,10 @@ export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): v
   }
 
   const tabs = state.tabsByWorktree[worktreeId] ?? []
+  // An empty workspace is a valid selection, not a request for a new terminal.
+  if (tabs.length === 0) {
+    return
+  }
   const hasLivePty = tabs.some((tab) => tabHasLivePty(state.ptyIdsByTabId, tab.id))
   if (hasLivePty) {
     return
@@ -40,7 +44,7 @@ export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): v
   }
 
   const { renderableTabCount } = state.reconcileWorktreeTabModel(worktreeId)
-  if (tabs.length > 0 && renderableTabCount === 0) {
+  if (renderableTabCount === 0) {
     return
   }
 

--- a/src/renderer/src/lib/web-runtime-worktree-terminal-after-wake.ts
+++ b/src/renderer/src/lib/web-runtime-worktree-terminal-after-wake.ts
@@ -12,6 +12,7 @@ import {
 } from '@/runtime/web-runtime-wake-terminal-respawn'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 
+/** Recover retained tab rows after wake; an empty workspace is not a terminal-creation request. */
 export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): void {
   const state = useAppStore.getState()
   const worktree = state.getKnownWorktreeById(worktreeId)
@@ -24,7 +25,6 @@ export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): v
   }
 
   const tabs = state.tabsByWorktree[worktreeId] ?? []
-  // An empty workspace is a valid selection, not a request for a new terminal.
   if (tabs.length === 0) {
     return
   }

--- a/src/renderer/src/lib/worktree-activation-empty-remote.test.ts
+++ b/src/renderer/src/lib/worktree-activation-empty-remote.test.ts
@@ -46,74 +46,50 @@ function makeWorktree(): Worktree {
 }
 
 describe('empty remote worktree activation', () => {
-  it('creates a host terminal when waking an empty remote workspace', async () => {
-    const worktree = makeWorktree()
-    const callRuntimeEnvironment = vi.fn().mockResolvedValueOnce({
-      ok: true,
-      result: {
-        tab: {
-          type: 'terminal',
-          id: 'host-tab-1::leaf-1',
-          parentTabId: 'host-tab-1',
-          leafId: 'leaf-1',
-          title: 'Terminal 1',
-          terminal: 'term_host',
-          status: 'ready',
-          isActive: true
-        },
-        publicationEpoch: 'epoch-1',
-        snapshotVersion: 1
-      }
-    })
-    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
-    vi.stubGlobal('window', {
-      api: {
-        runtimeEnvironments: {
-          call: callRuntimeEnvironment,
-          subscribe: vi.fn()
+  it.each(['unopened', 'closed-last-tab'])(
+    'keeps a %s remote workspace empty on repeated activation',
+    async (kind) => {
+      const worktree = makeWorktree()
+      const callRuntimeEnvironment = vi.fn().mockResolvedValue({ ok: true, result: {} })
+      ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+      vi.stubGlobal('window', {
+        api: {
+          runtimeEnvironments: {
+            call: callRuntimeEnvironment,
+            subscribe: vi.fn()
+          }
         }
-      }
-    })
-
-    useAppStore.setState({
-      repos: [
-        {
-          id: 'repo-1',
-          path: REPO_PATH,
-          displayName: 'repo',
-          badgeColor: '#000000',
-          addedAt: 0
-        }
-      ],
-      worktreesByRepo: { 'repo-1': [worktree] },
-      tabsByWorktree: {},
-      ptyIdsByTabId: {},
-      settings: {
-        ...getDefaultSettings(ORCA_WORKSPACES_PATH),
-        activeRuntimeEnvironmentId: 'web-runtime-1'
-      },
-      reconcileWorktreeTabModel: vi.fn(() => ({
-        renderableTabCount: 0,
-        activeRenderableTabId: null
-      }))
-    })
-
-    ensureWebRuntimeWorktreeTerminalAfterWake(worktree.id)
-    await vi.waitFor(() => {
-      expect(callRuntimeEnvironment).toHaveBeenCalled()
-    })
-
-    expect(callRuntimeEnvironment).toHaveBeenCalledWith(
-      expect.objectContaining({
-        selector: 'web-runtime-1',
-        method: 'session.tabs.createTerminal',
-        params: expect.objectContaining({
-          worktree: `id:${worktree.id}`,
-          activate: false,
-          select: true,
-          navigation: 'caller'
-        })
       })
-    )
-  })
+
+      useAppStore.setState({
+        repos: [
+          {
+            id: 'repo-1',
+            path: REPO_PATH,
+            displayName: 'repo',
+            badgeColor: '#000000',
+            addedAt: 0
+          }
+        ],
+        worktreesByRepo: { 'repo-1': [worktree] },
+        tabsByWorktree: kind === 'closed-last-tab' ? { [worktree.id]: [] } : {},
+        ptyIdsByTabId: {},
+        settings: {
+          ...getDefaultSettings(ORCA_WORKSPACES_PATH),
+          activeRuntimeEnvironmentId: 'web-runtime-1'
+        },
+        reconcileWorktreeTabModel: vi.fn(() => ({
+          renderableTabCount: 0,
+          activeRenderableTabId: null
+        }))
+      })
+
+      ensureWebRuntimeWorktreeTerminalAfterWake(worktree.id)
+      ensureWebRuntimeWorktreeTerminalAfterWake(worktree.id)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(callRuntimeEnvironment).not.toHaveBeenCalled()
+      expect(useAppStore.getState().tabsByWorktree[worktree.id] ?? []).toEqual([])
+    }
+  )
 })

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -188,11 +188,7 @@ export function activateAndRevealWorktree(
     backendStartupTerminalSpawned?: boolean
     /** Install a preserved fallback startup beside setup/default terminals already seeded. */
     createNewTerminalForStartup?: boolean
-    /** Set by callers that navigate here only to open their own non-terminal surface
-     *  (an editor file, a diff). Activation then leaves a closed-last-terminal workspace
-     *  empty instead of adding a shell the user never asked for. Caveat: on a
-     *  runtime-owned workspace with a live web session the host owns terminal creation,
-     *  so ensureWebRuntimeWorktreeTerminalAfterWake may still seed one (matches main). */
+    /** Keep an empty workspace empty when the caller is opening its own non-terminal surface. */
     providesInitialSurface?: boolean
     /** Keep sidebar filters intact when navigating to a hidden target. */
     clearSidebarFilters?: boolean

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -48,6 +48,7 @@ export type ActivateAndRevealResult = {
   primaryTabId: string | null
 }
 
+/** A caller-provided editor or browser surface suppresses terminal reseeding unless startup is explicit. */
 function ensureFolderWorkspaceInitialTerminal(
   folderWorkspace: FolderWorkspace,
   startup?: WorktreeStartupPayload,
@@ -70,6 +71,7 @@ function ensureFolderWorkspaceInitialTerminal(
   return primaryTabId
 }
 
+/** Gate inventory-based activation on both host RPC and PTY inventory support. */
 function canInspectAgentActivationInventory(): boolean {
   return (
     typeof window !== 'undefined' &&
@@ -78,6 +80,7 @@ function canInspectAgentActivationInventory(): boolean {
   )
 }
 
+/** Resolve folder host ownership before applying the same activation policy as git worktrees. */
 export function activateAndRevealFolderWorkspace(
   folderWorkspaceId: string,
   opts?: {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -173,6 +173,7 @@ export function activateAndRevealFolderWorkspace(
   return { primaryTabId }
 }
 
+/** Coordinate host-owned startup and sidebar reveal without seeding an extra caller-owned surface. */
 export function activateAndRevealWorktree(
   worktreeId: string,
   opts?: {

--- a/src/renderer/src/runtime/host-session-mirror-hydration-frame-ordering.test.tsx
+++ b/src/renderer/src/runtime/host-session-mirror-hydration-frame-ordering.test.tsx
@@ -437,21 +437,19 @@ describe('mirror latch verdicts against real stream failures', () => {
     expect(Object.keys(state.automaticAgentResumeClaimsByTabId)).toHaveLength(0)
   })
 
-  it('a spawn that rejects after the patch still settles the frame that landed', async () => {
+  it('an empty snapshot settles the frame without spawning a terminal', async () => {
     renderHook(() => useWebSessionTabsSync())
     await act(settle)
     const paneKey = seedSleepingRecord(MIRROR_TAB_ID, WT, 'codex-session-spawn-reject')
     expect(resumeSleepingAgentSessionsForWorktree(WT)).toBe(0)
 
-    // The wake respawn this frame triggers fails, but the frame it failed after
-    // already reached the store — the host is healthy and has spoken.
-    mocks.createTerminal.mockRejectedValue(new Error('spawn failed'))
+    // An authoritative empty frame releases parked resumes without inventing a terminal.
     await publish(findSubscription('session.tabs.subscribe'), {
       type: 'snapshot',
       ...makeEmptyHostSnapshot(WT)
     })
 
-    expect(mocks.createTerminal).toHaveBeenCalled()
+    expect(mocks.createTerminal).not.toHaveBeenCalled()
     expect(tabIds(WT)).not.toContain(MIRROR_TAB_ID)
     expectReplayedResume(paneKey, WT, 'codex-session-spawn-reject')
   })

--- a/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.test.ts
+++ b/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
   beginWebRuntimeWakeTerminalRespawn,
+  clearAllWebRuntimeWakeTerminalRespawn,
   clearWebRuntimeWakeTerminalRespawnForWorktree,
   endWebRuntimeWakeTerminalRespawn,
-  resetWebRuntimeWakeTerminalRespawnForTests,
-  shouldSkipWebRuntimeWakeTerminalRespawn
+  resetWebRuntimeWakeTerminalRespawnForTests
 } from './web-runtime-wake-terminal-respawn'
 
 describe('web-runtime-wake-terminal-respawn', () => {
@@ -14,17 +14,24 @@ describe('web-runtime-wake-terminal-respawn', () => {
 
   it('dedupes concurrent wake respawn requests for the same worktree', () => {
     expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
-    expect(shouldSkipWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
     expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(false)
     endWebRuntimeWakeTerminalRespawn('wt-1')
-    expect(shouldSkipWebRuntimeWakeTerminalRespawn('wt-1')).toBe(false)
     expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
   })
 
   it('clears wake respawn tracking for a removed worktree', () => {
-    beginWebRuntimeWakeTerminalRespawn('wt-1')
-    clearWebRuntimeWakeTerminalRespawnForWorktree('wt-1')
-    expect(shouldSkipWebRuntimeWakeTerminalRespawn('wt-1')).toBe(false)
     expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
+    expect(beginWebRuntimeWakeTerminalRespawn('wt-2')).toBe(true)
+    clearWebRuntimeWakeTerminalRespawnForWorktree('wt-1')
+    expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
+    expect(beginWebRuntimeWakeTerminalRespawn('wt-2')).toBe(false)
+  })
+
+  it('clears all in-flight worktrees when tracking stops', () => {
+    expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
+    expect(beginWebRuntimeWakeTerminalRespawn('wt-2')).toBe(true)
+    clearAllWebRuntimeWakeTerminalRespawn()
+    expect(beginWebRuntimeWakeTerminalRespawn('wt-1')).toBe(true)
+    expect(beginWebRuntimeWakeTerminalRespawn('wt-2')).toBe(true)
   })
 })

--- a/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.ts
+++ b/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.ts
@@ -1,5 +1,6 @@
 const wakeTerminalRespawnInFlightByWorktree = new Set<string>()
 
+/** Claim one pending wake per workspace so overlapping visibility and activation events cannot duplicate tabs. */
 export function beginWebRuntimeWakeTerminalRespawn(worktreeId: string): boolean {
   if (wakeTerminalRespawnInFlightByWorktree.has(worktreeId)) {
     return false

--- a/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.ts
+++ b/src/renderer/src/runtime/web-runtime-wake-terminal-respawn.ts
@@ -1,9 +1,5 @@
 const wakeTerminalRespawnInFlightByWorktree = new Set<string>()
 
-export function shouldSkipWebRuntimeWakeTerminalRespawn(worktreeId: string): boolean {
-  return wakeTerminalRespawnInFlightByWorktree.has(worktreeId)
-}
-
 export function beginWebRuntimeWakeTerminalRespawn(worktreeId: string): boolean {
   if (wakeTerminalRespawnInFlightByWorktree.has(worktreeId)) {
     return false

--- a/src/renderer/src/runtime/web-session-tabs-sync-eligibility.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-eligibility.test.ts
@@ -2,8 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   shouldSyncAllRuntimeSessionTabs,
   shouldApplyWebSessionTabsSnapshot,
-  shouldBootstrapInitialWebRuntimeTerminal,
-  shouldRespawnWebRuntimeTerminalAfterWake,
   shouldSyncRuntimeSessionTabs
 } from './web-session-tabs-sync'
 import {
@@ -24,7 +22,7 @@ vi.mock('../store', () => ({
 describe('applyWebSessionTabsSnapshot', () => {
   beforeEach(resetWebSessionTabsSyncTestState)
 
-  it('does not bootstrap a terminal from a stale empty active-worktree snapshot', () => {
+  it('rejects a stale empty active-worktree snapshot', () => {
     const ready = makeSnapshot([
       {
         type: 'terminal',
@@ -49,72 +47,6 @@ describe('applyWebSessionTabsSnapshot', () => {
     const staleIsFresh = shouldApplyWebSessionTabsSnapshot(staleEmpty, ENV)
 
     expect(staleIsFresh).toBe(false)
-    expect(
-      shouldBootstrapInitialWebRuntimeTerminal({
-        event: { type: 'snapshot', ...staleEmpty },
-        activeWorktreeId: WT,
-        requestedInitialTerminal: false,
-        snapshotIsFresh: staleIsFresh,
-        localTerminalCount: 0
-      })
-    ).toBe(false)
-  })
-
-  it('does not bootstrap a terminal from a fresh empty snapshot when local terminals already exist', () => {
-    const freshEmpty = makeSnapshot([], {
-      activeGroupId: null,
-      activeTabId: null,
-      activeTabType: null
-    })
-
-    expect(
-      shouldBootstrapInitialWebRuntimeTerminal({
-        event: { type: 'snapshot', ...freshEmpty },
-        activeWorktreeId: WT,
-        requestedInitialTerminal: false,
-        snapshotIsFresh: true,
-        localTerminalCount: 1
-      })
-    ).toBe(false)
-  })
-
-  it('does not respawn after wake when activation already requested a respawn', () => {
-    const freshEmpty = makeSnapshot([], {
-      activeGroupId: null,
-      activeTabId: null,
-      activeTabType: null
-    })
-
-    expect(
-      shouldRespawnWebRuntimeTerminalAfterWake({
-        event: { type: 'snapshot', ...freshEmpty },
-        activeWorktreeId: WT,
-        requestedRespawnAfterWake: false,
-        snapshotIsFresh: true,
-        localTerminalCount: 1,
-        hasLiveLocalPty: false,
-        skipWakeRespawn: true
-      })
-    ).toBe(false)
-  })
-
-  it('respawns a terminal after wake when local slept tabs exist but the host snapshot is empty', () => {
-    const freshEmpty = makeSnapshot([], {
-      activeGroupId: null,
-      activeTabId: null,
-      activeTabType: null
-    })
-
-    expect(
-      shouldRespawnWebRuntimeTerminalAfterWake({
-        event: { type: 'snapshot', ...freshEmpty },
-        activeWorktreeId: WT,
-        requestedRespawnAfterWake: false,
-        snapshotIsFresh: true,
-        localTerminalCount: 1,
-        hasLiveLocalPty: false
-      })
-    ).toBe(true)
   })
 
   it('syncs active session tabs for desktop remote runtime clients using the worktree owner', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync-window-visibility.test.tsx
+++ b/src/renderer/src/runtime/web-session-tabs-sync-window-visibility.test.tsx
@@ -374,9 +374,7 @@ describe('useWebSessionTabsSync window visibility', () => {
     hook.unmount()
   })
 
-  it('does not bootstrap twice when global snapshots race active resume', async () => {
-    const pendingCreate = createDeferred<unknown>()
-    mocks.createTerminal.mockReturnValue(pendingCreate.promise)
+  it('keeps empty workspaces empty when global snapshots race active resume', async () => {
     const hook = renderHook(() => useWebSessionTabsSync())
     await act(settle)
     const snapshot = makeEmptySnapshot()
@@ -389,7 +387,7 @@ describe('useWebSessionTabsSync window visibility', () => {
       type: 'snapshot',
       ...snapshot
     })
-    expect(mocks.createTerminal).toHaveBeenCalledTimes(1)
+    expect(mocks.createTerminal).not.toHaveBeenCalled()
 
     act(() => {
       setDocumentVisibility('hidden')
@@ -407,10 +405,8 @@ describe('useWebSessionTabsSync window visibility', () => {
       type: 'snapshot',
       ...snapshot
     })
-    expect(mocks.createTerminal).toHaveBeenCalledTimes(1)
+    expect(mocks.createTerminal).not.toHaveBeenCalled()
 
-    pendingCreate.resolve(undefined)
-    await act(settle)
     hook.unmount()
   })
 
@@ -882,7 +878,7 @@ describe('useWebSessionTabsSync window visibility', () => {
     mocks.recoverSnapshot.mockImplementationOnce(() => deferredRecovery.promise)
     const hook = renderHook(() => useWebSessionTabsSync())
     await act(settle)
-    const snapshot = makeEmptySnapshot()
+    const snapshot = makeBrowserSnapshot()
 
     await publish(findSubscription('session.tabs.subscribe', ENV_A), {
       type: 'snapshot',
@@ -894,7 +890,7 @@ describe('useWebSessionTabsSync window visibility', () => {
     })
     deferredRecovery.resolve(snapshot)
     await act(settle)
-    expect(mocks.createTerminal).not.toHaveBeenCalled()
+    expect(useAppStore.getState().browserTabsByWorktree[WORKTREE]).toBeUndefined()
 
     act(() => setDocumentVisibility('visible'))
     await act(settle)
@@ -902,7 +898,7 @@ describe('useWebSessionTabsSync window visibility', () => {
       type: 'snapshot',
       ...snapshot
     })
-    expect(mocks.createTerminal).toHaveBeenCalledTimes(1)
+    expect(useAppStore.getState().browserTabsByWorktree[WORKTREE]).toHaveLength(1)
     hook.unmount()
   })
 })

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -26,8 +26,6 @@ export { resolveHostSessionTabIdForWebSessionTab } from './web-session-tabs-sync
 export {
   decideWebSessionTabsSnapshot,
   shouldApplyWebSessionTabsSnapshot,
-  shouldBootstrapInitialWebRuntimeTerminal,
-  shouldRespawnWebRuntimeTerminalAfterWake,
   shouldSyncAllRuntimeSessionTabs,
   shouldSyncRuntimeSessionTabs,
   WEB_SESSION_TABS_FRAME_OUTRANKED

--- a/src/renderer/src/runtime/web-session-tabs-sync/active-session-subscription.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/active-session-subscription.ts
@@ -87,6 +87,7 @@ export function installActiveSessionTabsSubscription({
   }
   const expectedTrackingGeneration = getWebSessionTabsTrackingGeneration(environmentId)
 
+  /** Reject stale recovery results before mirroring host inventory; empty snapshots never create tabs. */
   const applyActiveSnapshot = async (
     event: RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' },
     response: RuntimeRpcResponse<unknown>,

--- a/src/renderer/src/runtime/web-session-tabs-sync/active-session-subscription.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/active-session-subscription.ts
@@ -10,12 +10,7 @@ import {
   recordReceivedWebSessionTabsSnapshot,
   shouldApplyRecoveredWebSessionTabsSnapshot
 } from './tracking'
-import {
-  decideWebSessionTabsSnapshot,
-  shouldBootstrapInitialWebRuntimeTerminal,
-  shouldRespawnWebRuntimeTerminalAfterWake,
-  shouldSyncRuntimeSessionTabs
-} from './tracking-decisions'
+import { decideWebSessionTabsSnapshot, shouldSyncRuntimeSessionTabs } from './tracking-decisions'
 import {
   acceptReplayedWebSessionTabsSnapshot,
   getWebSessionTabsTrackingGeneration
@@ -30,12 +25,6 @@ import {
   hostSessionMirrorSettleForPatchlessFrame,
   type HostSessionMirrorSettle
 } from './mirror-settle'
-import {
-  beginWebRuntimeWakeTerminalRespawn,
-  endWebRuntimeWakeTerminalRespawn,
-  shouldSkipWebRuntimeWakeTerminalRespawn
-} from '../web-runtime-wake-terminal-respawn'
-import { createWebRuntimeSessionTerminal } from '../web-runtime-session'
 import { toRuntimeWorktreeSelector } from '../runtime-worktree-selector'
 import type { SessionTabsStreamEvent } from './state'
 
@@ -97,8 +86,6 @@ export function installActiveSessionTabsSubscription({
     return undefined
   }
   const expectedTrackingGeneration = getWebSessionTabsTrackingGeneration(environmentId)
-  let requestedInitialTerminal = false
-  let requestedRespawnAfterWake = false
 
   const applyActiveSnapshot = async (
     event: RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' },
@@ -133,30 +120,7 @@ export function installActiveSessionTabsSubscription({
     if (event.type === 'snapshot' || isRuntimeSubscriptionReplayResponse(response)) {
       acceptReplayedWebSessionTabsSnapshot(environmentId, recovered.worktree)
     }
-    const recoveredEvent: SessionTabsStreamEvent = { ...recovered, type: event.type }
     const decision = decideWebSessionTabsSnapshot(recovered, environmentId, runtimeId)
-    const syncState = useAppStore.getState()
-    const localTabs = syncState.tabsByWorktree[activeWorktreeId] ?? []
-    const localTerminalCount = localTabs.length
-    const hasLiveLocalPty = localTabs.some(
-      (tab) => (syncState.ptyIdsByTabId[tab.id] ?? []).length > 0
-    )
-    const bootstrap = shouldBootstrapInitialWebRuntimeTerminal({
-      event: recoveredEvent,
-      activeWorktreeId,
-      requestedInitialTerminal,
-      snapshotIsFresh: decision.apply,
-      localTerminalCount
-    })
-    const respawn = shouldRespawnWebRuntimeTerminalAfterWake({
-      event: recoveredEvent,
-      activeWorktreeId,
-      requestedRespawnAfterWake,
-      snapshotIsFresh: decision.apply,
-      localTerminalCount,
-      hasLiveLocalPty,
-      skipWakeRespawn: shouldSkipWebRuntimeWakeTerminalRespawn(activeWorktreeId)
-    })
     let settle: HostSessionMirrorSettle | null = decision.apply
       ? null
       : hostSessionMirrorSettleForPatchlessFrame(decision, environmentId, recovered.worktree, {
@@ -184,28 +148,6 @@ export function installActiveSessionTabsSubscription({
         event.type === 'updated' && !replayed
       )
       visibilitySnapshotAccepted.current(environmentId, recovered, receivedFrame, runtimeId)
-    }
-    try {
-      if (isCurrent() && bootstrap) {
-        requestedInitialTerminal = true
-        await createWebRuntimeSessionTerminal({
-          worktreeId: activeWorktreeId,
-          environmentId,
-          activate: true
-        })
-      } else if (isCurrent() && respawn && beginWebRuntimeWakeTerminalRespawn(activeWorktreeId)) {
-        requestedRespawnAfterWake = true
-        await createWebRuntimeSessionTerminal({
-          worktreeId: activeWorktreeId,
-          environmentId,
-          activate: true,
-          selectWorktree: false
-        }).finally(() => endWebRuntimeWakeTerminalRespawn(activeWorktreeId))
-      }
-    } catch (error) {
-      if (isCurrent()) {
-        console.warn('[web-session-tabs-sync] snapshot follow-up failed:', error)
-      }
     }
     return settle
   }

--- a/src/renderer/src/runtime/web-session-tabs-sync/tracking-decisions.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/tracking-decisions.ts
@@ -3,8 +3,7 @@ import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-
 import {
   latestSessionTabsSnapshotByWorktree,
   replayableSessionTabsSnapshotByWorktree,
-  VISIBILITY_INVENTORY_REMOVAL_EPOCH,
-  type SessionTabsStreamEvent
+  VISIBILITY_INVENTORY_REMOVAL_EPOCH
 } from './state'
 import {
   acceptSessionTabsRuntimeId,
@@ -127,49 +126,6 @@ export function decideWebSessionTabsSnapshot(
   // Why: a mounted mirror that exhausted bounded polling needs fresh host evidence without subscribing to every store write.
   queueAcceptedWebSessionTerminalSnapshot(snapshot, environmentId)
   return WEB_SESSION_TABS_FRAME_APPLIED
-}
-
-export function shouldBootstrapInitialWebRuntimeTerminal(args: {
-  event: SessionTabsStreamEvent
-  activeWorktreeId: string
-  requestedInitialTerminal: boolean
-  snapshotIsFresh: boolean
-  localTerminalCount: number
-}): boolean {
-  return (
-    args.snapshotIsFresh &&
-    args.event.type === 'snapshot' &&
-    args.event.tabs.length === 0 &&
-    args.localTerminalCount === 0 &&
-    !args.requestedInitialTerminal &&
-    args.activeWorktreeId === args.event.worktree
-  )
-}
-
-export function shouldRespawnWebRuntimeTerminalAfterWake(args: {
-  event: SessionTabsStreamEvent
-  activeWorktreeId: string
-  requestedRespawnAfterWake: boolean
-  snapshotIsFresh: boolean
-  localTerminalCount: number
-  hasLiveLocalPty: boolean
-  skipWakeRespawn?: boolean
-}): boolean {
-  if (
-    !args.snapshotIsFresh ||
-    args.requestedRespawnAfterWake ||
-    args.skipWakeRespawn === true ||
-    args.localTerminalCount === 0 ||
-    args.hasLiveLocalPty ||
-    (args.event.type !== 'snapshot' && args.event.type !== 'updated')
-  ) {
-    return false
-  }
-  if (args.activeWorktreeId !== args.event.worktree) {
-    return false
-  }
-  const hostTerminalTabCount = args.event.tabs.filter((tab) => tab.type === 'terminal').length
-  return hostTerminalTabCount === 0
 }
 
 export function shouldSyncRuntimeSessionTabs(args: {

--- a/src/renderer/src/runtime/web-session-tabs-sync/tracking-decisions.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/tracking-decisions.ts
@@ -40,10 +40,12 @@ const WEB_SESSION_TABS_FRAME_UNMIRRORED = {
   settlesHostMirror: false
 } as const satisfies WebSessionTabsSnapshotDecision
 
+/** Floating terminals are client-owned and must not be replaced by same-id host snapshots. */
 function isHostMirroredWorktree(worktreeId: string): boolean {
   return worktreeId !== FLOATING_TERMINAL_WORKTREE_ID
 }
 
+/** Also records publication and inventory evidence; this compatibility predicate is not a pure read. */
 export function shouldApplyWebSessionTabsSnapshot(
   snapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
@@ -52,6 +54,7 @@ export function shouldApplyWebSessionTabsSnapshot(
   return decideWebSessionTabsSnapshot(snapshot, environmentId, runtimeId).apply
 }
 
+/** Fence stale publishers while retaining host-settlement evidence from valid outranked snapshots. */
 export function decideWebSessionTabsSnapshot(
   snapshot: RuntimeMobileSessionTabsResult,
   environmentId: string,
@@ -128,6 +131,7 @@ export function decideWebSessionTabsSnapshot(
   return WEB_SESSION_TABS_FRAME_APPLIED
 }
 
+/** Subscribe only after session hydration identifies the selected workspace and its execution host. */
 export function shouldSyncRuntimeSessionTabs(args: {
   activeWorktreeId?: string | null
   activeWorktreeRuntimeEnvironmentId?: string | null
@@ -140,6 +144,7 @@ export function shouldSyncRuntimeSessionTabs(args: {
   return Boolean(args.activeWorktreeId?.trim())
 }
 
+/** Keep host-wide inventory synchronized even when no workspace is selected. */
 export function shouldSyncAllRuntimeSessionTabs(args: {
   activeRuntimeEnvironmentId: string | null | undefined
   workspaceSessionReady: boolean


### PR DESCRIPTION
## ELI5

Selecting an empty remote workspace leaves it empty.

## What Changed

Remove activation/snapshot auto-creation and the unused wake predicate; preserve manual creation and existing-tab recovery.

## Why

Workspace selection is not permission to create a shell.

## Linked Issue

Fixes #17681.

## Visual Proof

Actual Orca Electron UI in an isolated profile. The same empty folder workspace runs the pre-fix/final wake functions; remote transport is mocked and terminal creation uses an isolated local shell. Not live SSH validation.

**Before — selection creates an unwanted terminal.**

![Before: an empty workspace gains Terminal 1](https://github.com/user-attachments/assets/e4248273-7cf2-4fe9-b5e3-c1b76ead95f2)

**After — selection keeps the workspace empty.**

![After: the workspace stays selected with zero terminal tabs](https://github.com/user-attachments/assets/ea3a50eb-d2f7-4f3f-8584-1b98a9713823)

## Testing

443 tests passed on macOS, covering visibility races, wake recovery, manual creation and folder workspaces. Renderer typecheck, changed-file lint and formatting passed. Electron/CDP before/after capture passed.

Full macOS validation (Node 24, pnpm 12): `pnpm lint`, `pnpm typecheck`, `pnpm test --maxWorkers=4`, and `pnpm build` all executed. Typecheck and complete desktop/Web/native build passed.

Full suite at `ad40e0bf2e`: **76,604 passed / 10 failed / 391 skipped**. Final-HEAD serial follow-ups: **48 passed**; performance/timeout failures cleared without relaxing assertions or policies. Commit `35da23979d` fixes the missed empty-snapshot test expectation; all 16 frame-ordering tests pass.

Still failing: 4 real Claude CLI startup checks (5/10-second initialization deadlines) and 1 English runtime-catalog test. All reproduced on base `bba68b1`. Full lint fails on the same 7 catalog entries; later extraction/coverage gates passed separately. **Full lint/test are not green.**

- [x] Automated regressions added/updated.
- [ ] Manual native Windows/Linux and live SSH QA: not run.

## AI Disclosure

OpenAI Codex.

## Review

Self-reviewed; Pullfrog reports no new issues. Human review pending.

## Agent skill upstream boundary

- [x] N/A: no upstream agent-skill material copied.

## Notes

No new permissions, platform-specific paths/shortcuts, Git commands or wire fields. Folder workspaces and remote ownership considered; full mobile/platform QA remains unrun.

## Checklist

- [x] Small, focused change; problem and rationale explained.
- [x] Before/after proof attached, or N/A explained.
- [x] Correctness, security and performance reviewed.
- [x] Cross-platform, SSH and compatibility impact considered.
- [x] Full repository lint/typecheck/test/build executed; results above.
- [x] Full typecheck and build passed.
- [ ] Full lint/test green: baseline failures documented above.
