### PR TITLE
fix(daemon): preserve attach output sequence baseline

### DIFF
--- a/src/main/daemon/daemon-pty-attach-sequence.test.ts
+++ b/src/main/daemon/daemon-pty-attach-sequence.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import {
+  createMockSubprocess,
+  startDaemonAdapterHarness,
+  waitFor,
+  type DaemonAdapterHarness
+} from './daemon-pty-adapter-test-harness'
+import type { TerminalSnapshot } from './types'
+
+let harness: DaemonAdapterHarness
+let attached: DaemonPtyAdapter
+let subprocess: ReturnType<typeof createMockSubprocess>
+
+beforeEach(async () => {
+  harness = await startDaemonAdapterHarness(() => {
+    subprocess = createMockSubprocess()
+    return subprocess
+  })
+  attached = new DaemonPtyAdapter({
+    socketPath: harness.socketPath,
+    tokenPath: harness.tokenPath,
+    historyPath: join(harness.dir, 'history')
+  })
+})
+
+afterEach(async () => {
+  attached?.dispose()
+  harness?.adapter.dispose()
+  await harness?.server.shutdown()
+  if (harness) {
+    rmSync(harness.dir, { recursive: true, force: true })
+  }
+})
+
+it.each(['spawn', 'attach'] as const)(
+  'keeps the %s stream baseline when history overlay captures newer output',
+  async (operation) => {
+    const sessionId = 'overlay-sequence'
+    const initialData = 'before attach\r\n'
+    const duringOverlay = 'x'.repeat(459)
+    await harness.adapter.spawn({ sessionId, cols: 80, rows: 24 })
+    let initialReceived = ''
+    harness.adapter.onData(({ data }) => (initialReceived += data))
+    subprocess._simulateData(initialData)
+    await waitFor(() => initialReceived === initialData)
+    await harness.adapter.disconnectOnly()
+
+    let streamedChars = 0
+    attached.onData(({ data, sequenceChars }) => {
+      streamedChars += sequenceChars ?? data.length
+    })
+    const overlayTarget = attached as unknown as {
+      overlayDurableRestoreSnapshot(
+        id: string,
+        snapshot: TerminalSnapshot
+      ): Promise<TerminalSnapshot>
+    }
+    const originalOverlay = overlayTarget.overlayDurableRestoreSnapshot.bind(attached)
+    let overlaySequence: number | undefined
+    vi.spyOn(overlayTarget, 'overlayDurableRestoreSnapshot').mockImplementationOnce(
+      async (id, snapshot) => {
+        subprocess._simulateData(duringOverlay)
+        await waitFor(() => streamedChars === duringOverlay.length)
+        const restored = await originalOverlay(id, snapshot)
+        overlaySequence = restored.outputSequence
+        return restored
+      }
+    )
+
+    const result =
+      operation === 'attach'
+        ? await attached.attach(sessionId)
+        : await attached.spawn({ sessionId, cols: 80, rows: 24, attachOnly: true })
+    expect(overlaySequence).toBe(initialData.length + duringOverlay.length)
+    expect(result?.providerSequence).toEqual({
+      value: initialData.length,
+      generation: 'continued'
+    })
+    const runtimeSequence = result!.providerSequence!.value + streamedChars
+    const recovery = await attached.getBufferSnapshot(sessionId, { scrollbackRows: 0 })
+    expect(recovery?.seq).toBe(runtimeSequence)
+
+    const nextOutput = 'next frame\r\n'
+    subprocess._simulateData(nextOutput)
+    await waitFor(() => streamedChars === duringOverlay.length + nextOutput.length)
+    const nextSequence = result!.providerSequence!.value + streamedChars
+    expect(nextSequence - nextOutput.length).toBe(recovery?.seq)
+  }
+)

--- a/src/main/daemon/daemon-pty-spawn-result.ts
+++ b/src/main/daemon/daemon-pty-spawn-result.ts
@@ -281,10 +281,6 @@ export abstract class DaemonPtySpawnResult extends DaemonPtySpawnRequest {
     }
 
     const reattachSnapshot = await this.overlayDurableRestoreSnapshot(sessionId, result.snapshot)
-    const reattachProviderSequence =
-      typeof reattachSnapshot.outputSequence === 'number'
-        ? { value: reattachSnapshot.outputSequence, generation: 'continued' as const }
-        : providerSequence
     const isAltScreen = reattachSnapshot.modes.alternateScreen
     const snapshotPrefix = reattachSnapshot.scrollbackAnsi + reattachSnapshot.rehydrateSequences
     const snapshotFrame = reattachSnapshot.snapshotAnsi
@@ -313,7 +309,8 @@ export abstract class DaemonPtySpawnResult extends DaemonPtySpawnRequest {
             snapshotFrameRestoreAnsi: reattachSnapshot.frameRestoreAnsi
           }
         : {}),
-      ...(reattachProviderSequence ? { providerSequence: reattachProviderSequence } : {}),
+      // Keep the attach baseline: output received during history overlay is already counted live.
+      ...(providerSequence ? { providerSequence } : {}),
       ...(kittyKeyboardFlags !== undefined
         ? { snapshotKittyKeyboardFlags: kittyKeyboardFlags }
         : {}),

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -770,7 +770,7 @@ describe('STA-4091 previously recoverable restore depth', () => {
       expect(overlaid?.seq).toBe(current?.seq)
     })
 
-    it('uses the post-drain sequence for output produced during warm reattach', async () => {
+    it('preserves the attach baseline and counts warm reattach output exactly once', async () => {
       const { id } = await adapter.spawn({
         cols: 80,
         rows: 24,
@@ -778,7 +778,16 @@ describe('STA-4091 previously recoverable restore depth', () => {
         cwd: '/tmp'
       })
       lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
-      await adapter.getBufferSnapshot(id)
+      const baseline = await adapter.getBufferSnapshot(id)
+      expect(baseline?.seq).toEqual(expect.any(Number))
+
+      const duringOverlay = `${FRESH_AFTER_CHECKPOINT}\r\n`
+      let streamedChars = 0
+      adapter.onData(({ id: outputId, data, sequenceChars }) => {
+        if (outputId === id) {
+          streamedChars += sequenceChars ?? data.length
+        }
+      })
 
       const internals = adapter as unknown as {
         client: { request: (method: string, params?: unknown) => Promise<unknown> }
@@ -792,7 +801,7 @@ describe('STA-4091 previously recoverable restore depth', () => {
           !injected
         ) {
           injected = true
-          lastSubprocess.emitData(`${FRESH_AFTER_CHECKPOINT}\r\n`)
+          lastSubprocess.emitData(duringOverlay)
         }
         return request(method, params)
       })
@@ -800,7 +809,10 @@ describe('STA-4091 previously recoverable restore depth', () => {
       const reattach = await adapter.spawn({ cols: 80, rows: 24, sessionId: id, cwd: '/tmp' })
       const current = await adapter.getBufferSnapshot(id, { scrollbackRows: 24 })
       expect(reattach.snapshot).toContain(FRESH_AFTER_CHECKPOINT)
-      expect(reattach.providerSequence?.value).toBe(current?.seq)
+      expect(reattach.providerSequence?.value).toBe(baseline!.seq)
+      await vi.waitFor(() => expect(streamedChars).toBe(duringOverlay.length))
+      expect(current?.seq).toBe(baseline!.seq + duringOverlay.length)
+      expect(reattach.providerSequence!.value + streamedChars).toBe(current!.seq)
     })
   })
 })


### PR DESCRIPTION
## ELI5

Reattached terminal output is counted once.

## What Changed

Keep the attach-time sequence baseline and assert baseline plus streamed output equals the current sequence.

## Why

Using the post-overlay snapshot sequence counts live output twice and causes false stream gaps.

## Linked Issue

Fixes #19595.

## Visual Proof

N/A — internal sequence accounting.

## Testing

178 tests passed on macOS; reverting the fix fails the regression. Node typecheck, changed-file lint and formatting passed.

Full macOS validation (Node 24, pnpm 12): `pnpm lint`, `pnpm typecheck`, `pnpm test --maxWorkers=4`, and `pnpm build` all executed. Typecheck and complete desktop/Web/native build passed.

Full suite at `763963d6a4`: **76,610 passed / 7 failed / 391 skipped**. Final-HEAD serial follow-ups: **23 passed**; performance/timeout failures cleared without relaxing assertions or policies.

Still failing: 4 real Claude CLI startup checks (5/10-second initialization deadlines) and 1 English runtime-catalog test. All reproduced on base `bba68b1`. Full lint fails on the same 7 catalog entries; later extraction/coverage gates passed separately. **Full lint/test are not green.**

- [x] Automated regressions added/updated.
- [ ] Manual native Windows/Linux and live SSH QA: not run.

## AI Disclosure

OpenAI Codex.

## Review

Self-reviewed; Pullfrog reports no new issues. Human review pending.

## Agent skill upstream boundary

- [x] N/A: no upstream agent-skill material copied.

## Notes

No new permissions, platform-specific paths/shortcuts, Git commands or wire fields. Folder workspaces and remote ownership considered; full mobile/platform QA remains unrun.

## Checklist

- [x] Small, focused change; problem and rationale explained.
- [x] Before/after proof attached, or N/A explained.
- [x] Correctness, security and performance reviewed.
- [x] Cross-platform, SSH and compatibility impact considered.
- [x] Full repository lint/typecheck/test/build executed; results above.
- [x] Full typecheck and build passed.
- [ ] Full lint/test green: baseline failures documented above.
