### PR TITLE
Preserve Atuin history across Bash prompt cycles

### DIFF
--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -192,10 +192,13 @@ __orca_osc133_epilogue() {
 }
 # Install before array composition strands bash-preexec's scalar-only installer in a later element.
 if [[ -n "${bash_preexec_imported:-}${__bp_imported:-}" && -n "${__bp_install_string:-}" && "${PROMPT_COMMAND[*]:-}" == *"$__bp_install_string"* ]]; then
-  __bp_trap_string="$(trap -p DEBUG)"
-  trap - DEBUG
-  __bp_install
-  unset __bp_preexec_interactive_mode
+  # Why the install string rather than its body: 0.6.0 hands off the live DEBUG
+  # trap through __bp_trap_string, 0.7.0+ expands to `__bp_install "$_"` and reads
+  # the trap itself. Hardcoding either shape drops the user's trap on the other.
+  eval "$__bp_install_string"
+  # Installing ends in bash-preexec's own __bp_interactive_mode, which would bill
+  # the rest of this rcfile as the user's first command; clear it the way it does.
+  __bp_preexec_interactive_mode=""
 fi
 __orca_normalize_prompt_command_part() {
   local __orca_value="$1" __orca_output_name="$2" __orca_character __orca_chunk

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -190,6 +190,13 @@ __orca_osc133_epilogue() {
     __orca_ready_marker=""
   fi
 }
+# Install before array composition strands bash-preexec's scalar-only installer in a later element.
+if [[ -n "${bash_preexec_imported:-}${__bp_imported:-}" && -n "${__bp_install_string:-}" && "${PROMPT_COMMAND[*]:-}" == *"$__bp_install_string"* ]]; then
+  __bp_trap_string="$(trap -p DEBUG)"
+  trap - DEBUG
+  __bp_install
+  unset __bp_preexec_interactive_mode
+fi
 __orca_normalize_prompt_command_part() {
   local __orca_value="$1" __orca_output_name="$2" __orca_character __orca_chunk
   local __orca_value_length=${#1} __orca_suffix_length=0 __orca_backslash_length=0

--- a/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
+++ b/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
@@ -120,10 +120,13 @@ __orca_osc133_epilogue() {
 }
 # Install before array composition strands bash-preexec's scalar-only installer in a later element.
 if [[ -n "\${bash_preexec_imported:-}\${__bp_imported:-}" && -n "\${__bp_install_string:-}" && "\${PROMPT_COMMAND[*]:-}" == *"$__bp_install_string"* ]]; then
-  __bp_trap_string="$(trap -p DEBUG)"
-  trap - DEBUG
-  __bp_install
-  unset __bp_preexec_interactive_mode
+  # Why the install string rather than its body: 0.6.0 hands off the live DEBUG
+  # trap through __bp_trap_string, 0.7.0+ expands to \`__bp_install "$_"\` and reads
+  # the trap itself. Hardcoding either shape drops the user's trap on the other.
+  eval "$__bp_install_string"
+  # Installing ends in bash-preexec's own __bp_interactive_mode, which would bill
+  # the rest of this rcfile as the user's first command; clear it the way it does.
+  __bp_preexec_interactive_mode=""
 fi
 ${BASH_PROMPT_COMMAND_COMPOSITION_BLOCK}
 __orca_prepend_prompt_command "__orca_osc133_precmd"

--- a/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
+++ b/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
@@ -118,6 +118,13 @@ __orca_osc133_epilogue() {
     __orca_ready_marker=""
   fi
 }
+# Install before array composition strands bash-preexec's scalar-only installer in a later element.
+if [[ -n "\${bash_preexec_imported:-}\${__bp_imported:-}" && -n "\${__bp_install_string:-}" && "\${PROMPT_COMMAND[*]:-}" == *"$__bp_install_string"* ]]; then
+  __bp_trap_string="$(trap -p DEBUG)"
+  trap - DEBUG
+  __bp_install
+  unset __bp_preexec_interactive_mode
+fi
 ${BASH_PROMPT_COMMAND_COMPOSITION_BLOCK}
 __orca_prepend_prompt_command "__orca_osc133_precmd"
 __orca_append_prompt_command '__orca_in_debug_capture=1; __orca_prompt_had_functrace=""; if [[ -o functrace ]]; then __orca_prompt_had_functrace=1; set +T; fi; __orca_outer_debug_trap_spec="$(trap -p DEBUG)"; [[ -z "$__orca_prompt_had_functrace" ]] || set -T; unset __orca_prompt_had_functrace __orca_in_debug_capture'

--- a/src/main/daemon/shell-ready-atuin.node-pty.test.ts
+++ b/src/main/daemon/shell-ready-atuin.node-pty.test.ts
@@ -1,3 +1,18 @@
+/**
+ * End-to-end proof that a real Atuin, driven by a real bash-preexec, records
+ * every command exactly once under the daemon Bash wrapper.
+ *
+ * Why opt-in rather than a CI job: it needs a PTY plus two third-party binaries
+ * that no default job installs, and fetching them per run would put a network
+ * download in front of every unit-test lane. The shell contract it protects —
+ * finishing bash-preexec's pending deferred install across its 0.6.0 and 0.7.0+
+ * install-string shapes without dropping a user DEBUG trap — runs by default in
+ * shell-ready-bash-preexec-deferred-install.test.ts. Run this one against real
+ * releases when touching that install:
+ *
+ *   ORCA_TEST_BASH_PREEXEC=/path/to/bash-preexec.sh \
+ *   ORCA_TEST_ATUIN=/path/to/atuin pnpm test src/main/daemon/shell-ready-atuin.node-pty.test.ts
+ */
 import { spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
@@ -7,7 +22,6 @@ import { expect, it } from 'vitest'
 import type { IPty } from 'node-pty'
 import { getDaemonBashShellReadyRcfileContent } from './daemon-bash-shell-ready-rcfile'
 
-// Set ORCA_TEST_BASH_PREEXEC to an installed bash-preexec.sh to exercise real Atuin.
 const bashPreexec = process.env.ORCA_TEST_BASH_PREEXEC
 const bash = process.env.ORCA_TEST_BASH ?? 'bash'
 const atuin = process.env.ORCA_TEST_ATUIN ?? 'atuin'

--- a/src/main/daemon/shell-ready-atuin.node-pty.test.ts
+++ b/src/main/daemon/shell-ready-atuin.node-pty.test.ts
@@ -1,0 +1,132 @@
+import { spawnSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it } from 'vitest'
+import type { IPty } from 'node-pty'
+import { getDaemonBashShellReadyRcfileContent } from './daemon-bash-shell-ready-rcfile'
+
+// Set ORCA_TEST_BASH_PREEXEC to an installed bash-preexec.sh to exercise real Atuin.
+const bashPreexec = process.env.ORCA_TEST_BASH_PREEXEC
+const bash = process.env.ORCA_TEST_BASH ?? 'bash'
+const atuin = process.env.ORCA_TEST_ATUIN ?? 'atuin'
+
+it.skipIf(process.platform === 'win32' || !bashPreexec)(
+  'records real Atuin history across three daemon Bash prompt cycles',
+  async () => {
+    const home = mkdtempSync(join(tmpdir(), 'orca-atuin-'))
+    const config = join(home, 'atuin')
+    mkdirSync(config)
+    const env = {
+      PATH: process.env.PATH ?? '/usr/bin:/bin',
+      HOME: home,
+      ATUIN_SESSION: randomUUID(),
+      ATUIN_CONFIG_DIR: config,
+      XDG_CONFIG_HOME: join(home, 'config'),
+      XDG_DATA_HOME: join(home, 'data'),
+      XDG_STATE_HOME: join(home, 'state'),
+      XDG_CACHE_HOME: join(home, 'cache'),
+      HISTFILE: join(home, 'bash_history'),
+      ORCA_SHELL_FEATURES: 'ready',
+      TERM: 'xterm-256color',
+      ORCA_TEST_BASH_PREEXEC: bashPreexec!,
+      ORCA_TEST_ATUIN: atuin
+    }
+    writeFileSync(
+      join(config, 'config.toml'),
+      [
+        ...Object.entries({
+          db_path: 'history.db',
+          record_store_path: 'records.db',
+          key_path: 'key',
+          session_path: 'session'
+        }).map(([key, file]) => `${key} = ${JSON.stringify(join(config, file))}`),
+        'auto_sync = false',
+        'update_check = false',
+        ''
+      ].join('\n')
+    )
+    const prompt = 'ORCA_ATUIN_PROMPT> '
+    writeFileSync(
+      join(home, '.bash_profile'),
+      [
+        'source "$ORCA_TEST_BASH_PREEXEC"',
+        'eval "$("$ORCA_TEST_ATUIN" init bash --disable-up-arrow --disable-ctrl-r)"',
+        `PS1='${prompt}'`,
+        ''
+      ].join('\n')
+    )
+    const rcfile = join(home, 'rcfile')
+    writeFileSync(rcfile, getDaemonBashShellReadyRcfileContent())
+    const commands = ['true # atuin-first', 'false # atuin-second', 'true # atuin-third']
+    const oscC = '\x1b]133;C\x07'
+    const oscD = '\x1b]133;D;'
+    let proc: IPty | undefined
+    let exited = false
+    try {
+      // Defer native loading so unconfigured integration runs can skip without a built node-pty.
+      const pty = await import('node-pty')
+      const version = spawnSync(atuin, ['--version'], { env, encoding: 'utf8', timeout: 5000 })
+      expect(version.error).toBeUndefined()
+      expect(version.status, version.stderr).toBe(0)
+      proc = pty.spawn(bash, ['--noprofile', '--rcfile', rcfile, '-i'], {
+        name: 'xterm-256color',
+        cols: 120,
+        rows: 24,
+        cwd: home,
+        env
+      })
+      let output = ''
+      proc.onData((chunk) => {
+        output += chunk
+      })
+      const exit = new Promise<number>((resolve) => {
+        proc!.onExit(({ exitCode }) => {
+          exited = true
+          resolve(exitCode)
+        })
+      })
+      await expect.poll(() => output.includes(prompt), { timeout: 10_000 }).toBe(true)
+      expect(output).not.toContain(oscC)
+      expect(output).not.toContain(oscD)
+      for (const [index, command] of commands.entries()) {
+        const offset = output.length
+        proc.write(`${command}\r`)
+        await expect
+          .poll(() => output.slice(offset).includes(prompt), { timeout: 10_000 })
+          .toBe(true)
+        const cycle = output.slice(offset)
+        expect.soft(cycle.split(oscC)).toHaveLength(2)
+        expect.soft(cycle.split(oscD)).toHaveLength(2)
+        expect.soft(cycle).toContain(`${oscD}${index === 1 ? 1 : 0}\x07`)
+      }
+      // Atuin finishes history writes asynchronously after each prompt.
+      await expect
+        .poll(
+          () => {
+            const history = spawnSync(atuin, ['history', 'list', '--format', '{command}'], {
+              env,
+              encoding: 'utf8',
+              timeout: 5000
+            })
+            expect(history.error).toBeUndefined()
+            expect(history.status, history.stderr).toBe(0)
+            const recorded = history.stdout.split('\n')
+            return commands.map((command) => recorded.filter((line) => line === command).length)
+          },
+          { timeout: 10_000 }
+        )
+        .toEqual([1, 1, 1])
+      proc.write('exit 0\r')
+      await expect.poll(() => exited, { timeout: 5000 }).toBe(true)
+      expect(await exit).toBe(0)
+    } finally {
+      if (proc && !exited) {
+        proc.kill()
+        await expect.poll(() => exited, { timeout: 5000 }).toBe(true)
+      }
+      rmSync(home, { recursive: true, force: true })
+    }
+  }
+)

--- a/src/main/daemon/shell-ready-bash-preexec-deferred-install.test.ts
+++ b/src/main/daemon/shell-ready-bash-preexec-deferred-install.test.ts
@@ -1,0 +1,169 @@
+/**
+ * The daemon bash wrapper finishes bash-preexec's *pending* deferred install
+ * before it composes PROMPT_COMMAND. bash-preexec publishes that pending work as
+ * `$__bp_install_string`, and both its body and what installing does to the
+ * DEBUG trap changed between releases:
+ *
+ *   0.6.0   `__bp_trap_string="$(trap -p DEBUG)"; trap - DEBUG; __bp_install`
+ *           — the caller captures the live DEBUG trap, __bp_install adopts it.
+ *   0.7.0+  `__bp_install "$_"`
+ *           — on bash 5.3+ preexec hooks through PS0 and the DEBUG trap is
+ *           never touched, so it must simply be left alone.
+ *
+ * Expanding one release's body on the other silently drops a user DEBUG trap,
+ * so these stubs pin both shapes against a real bash. They reproduce the
+ * deferred-install contract only; the third-party script and Atuin itself stay
+ * in the opt-in shell-ready-atuin.node-pty.test.ts, which needs a PTY plus
+ * binaries no default CI job installs.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getDaemonBashShellReadyRcfileContent } from './daemon-bash-shell-ready-rcfile'
+import {
+  expectBashOsc133Lifecycle,
+  runInteractiveBashRcfile
+} from './daemon-bash-wrapper-osc133-fixture'
+
+const describePosix = process.platform === 'win32' ? describe.skip : describe
+const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
+const itWithBash = hasBash ? it : it.skip
+
+const READ_LAST_HISTORY_ENTRY = [
+  '  local this_command',
+  '  this_command="$(builtin history 1)"',
+  '  this_command="${this_command#"${this_command%%[![:space:]]*}"}"',
+  '  this_command="${this_command#* }"',
+  '  this_command="${this_command#"${this_command%%[![:space:]]*}"}"'
+]
+
+const SHARED_STUB = [
+  'preexec_functions=()',
+  'precmd_functions=()',
+  'bash_preexec_imported="defined"',
+  '__bp_imported="defined"',
+  '__bp_preexec_interactive_mode=""',
+  '__user_preexec() { printf \'USER_PREEXEC:%s\\n\' "$1"; }',
+  '__bp_precmd_invoke_cmd() { local f; for f in "${precmd_functions[@]}"; do "$f"; done; }',
+  '__bp_interactive_mode() { __bp_preexec_interactive_mode="on"; }',
+  '__bp_finish_install() {',
+  "  PROMPT_COMMAND='__bp_precmd_invoke_cmd'$'\\n''__bp_interactive_mode'",
+  '  preexec_functions+=(__user_preexec)',
+  '  __bp_interactive_mode',
+  '}',
+  // A DEBUG trap the user owns, armed before bash-preexec is sourced.
+  'trap \'printf "USER_DEBUG:%s\\n" "$BASH_COMMAND"\' DEBUG'
+]
+
+const PENDING_INSTALL_BY_VERSION = {
+  // 0.6.0 hooks preexec into DEBUG and re-publishes the caller's captured trap
+  // as a preexec function.
+  '0.6.0': [
+    '__bp_last_hist=""',
+    '__bp_preexec_invoke_exec() {',
+    '  (( ${__bp_inside:-0} > 0 )) && return',
+    '  [[ -n "${__bp_preexec_interactive_mode:-}" ]] || return',
+    '  local __bp_inside=1',
+    ...READ_LAST_HISTORY_ENTRY,
+    '  [[ -n "$this_command" && "$this_command" != "$__bp_last_hist" ]] || return',
+    '  __bp_last_hist="$this_command"',
+    '  __bp_preexec_interactive_mode=""',
+    '  local f',
+    '  for f in "${preexec_functions[@]}"; do "$f" "$this_command"; done',
+    '}',
+    '__bp_install() {',
+    '  set -o functrace',
+    "  trap '__bp_preexec_invoke_exec' DEBUG",
+    '  eval "local trap_argv=(${__bp_trap_string:-})"',
+    '  local prior_trap=${trap_argv[2]:-}',
+    '  unset __bp_trap_string',
+    '  if [[ -n "$prior_trap" ]]; then',
+    "    eval '__bp_original_debug_trap() {",
+    '      \'"$prior_trap"\'',
+    "    }'",
+    '    preexec_functions+=(__bp_original_debug_trap)',
+    '  fi',
+    '  __bp_finish_install',
+    '}',
+    '__bp_install_string=$\'__bp_trap_string="$(trap -p DEBUG)"\\ntrap - DEBUG\\n__bp_install\''
+  ],
+  // 0.7.0 on bash 5.3+ hooks preexec into PS0 and leaves DEBUG to its owner.
+  '0.7.0': [
+    '__bp_invoke_preexec_from_ps0() {',
+    '  [[ -n "${__bp_preexec_interactive_mode:-}" ]] || return 0',
+    ...READ_LAST_HISTORY_ENTRY,
+    '  [[ -n "$this_command" ]] || return 0',
+    '  local f',
+    '  for f in "${preexec_functions[@]}"; do "$f" "$this_command"; done',
+    '}',
+    '__bp_install() {',
+    "  PS0=${PS0-}'$(__bp_invoke_preexec_from_ps0)'",
+    '  __bp_finish_install',
+    '}',
+    '__bp_install_string=\'__bp_install "$_"\''
+  ]
+} as const
+
+type PreexecVersion = keyof typeof PENDING_INSTALL_BY_VERSION
+
+function pendingInstallProfile(version: PreexecVersion, extra: string[] = []): string {
+  return [
+    ...SHARED_STUB,
+    ...PENDING_INSTALL_BY_VERSION[version],
+    ...extra,
+    // The install bash-preexec defers into PROMPT_COMMAND, still pending.
+    'PROMPT_COMMAND="$__bp_install_string"'
+  ].join('\n')
+}
+
+describePosix('daemon bash wrapper finishing a pending bash-preexec install', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'orca-bash-preexec-'))
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  for (const version of Object.keys(PENDING_INSTALL_BY_VERSION) as PreexecVersion[]) {
+    itWithBash(`keeps the user DEBUG trap and records each command once on ${version}`, () => {
+      writeFileSync(join(home, '.bash_profile'), pendingInstallProfile(version))
+
+      const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), home)
+
+      // The install ran: its preexec dispatch sees the user's commands, once each.
+      expect(output.split('USER_PREEXEC:true')).toHaveLength(2)
+      expect(output.split('USER_PREEXEC:false')).toHaveLength(2)
+      expect(output).not.toContain('USER_PREEXEC:__orca')
+      // The user's DEBUG trap still runs against those commands.
+      expect(output.split('USER_DEBUG:true')).toHaveLength(2)
+      expect(output.split('USER_DEBUG:false')).toHaveLength(2)
+      expectBashOsc133Lifecycle(output)
+    })
+  }
+
+  itWithBash('clears bash-preexec interactive mode for the bootstrap window', () => {
+    writeFileSync(
+      join(home, '.bash_profile'),
+      pendingInstallProfile('0.7.0', [
+        // Runs at the first prompt, before bash-preexec re-arms interactive mode.
+        '__bp_report_once() {',
+        '  [[ -z "${__bp_reported:-}" ]] || return 0',
+        '  __bp_reported=1',
+        '  printf \'IMODE:[%s]\\n\' "${__bp_preexec_interactive_mode-MISSING}"',
+        '}',
+        'precmd_functions+=(__bp_report_once)'
+      ])
+    )
+
+    const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), home)
+
+    // Left "on", installing bills the rest of the rcfile as the user's first command;
+    // unset instead of cleared, bash-preexec loses a name it declares and owns.
+    expect(output).toContain('IMODE:[]')
+  })
+})

--- a/src/main/shell-wrapper-generated-file-snapshot.test.ts
+++ b/src/main/shell-wrapper-generated-file-snapshot.test.ts
@@ -76,7 +76,7 @@ const CONTRACT_GLOBALS = new Set([
   'PS1', // Bash appends its non-printing Readline readiness marker.
   'CURSOR',
   'ZDOTDIR',
-  '__bp_trap_string', // bash-preexec's own handoff into __bp_install, which unsets it.
+  '__bp_preexec_interactive_mode', // bash-preexec declares it; we only clear it, as it does.
   'precmd_functions',
   'preexec_functions'
 ])

--- a/src/main/shell-wrapper-generated-file-snapshot.test.ts
+++ b/src/main/shell-wrapper-generated-file-snapshot.test.ts
@@ -76,6 +76,7 @@ const CONTRACT_GLOBALS = new Set([
   'PS1', // Bash appends its non-printing Readline readiness marker.
   'CURSOR',
   'ZDOTDIR',
+  '__bp_trap_string', // bash-preexec's own handoff into __bp_install, which unsets it.
   'precmd_functions',
   'preexec_functions'
 ])


### PR DESCRIPTION
## ELI5

Orca rearranged Bash’s command hooks before bash-preexec had finished installing them. Atuin loaded, but could not record commands. Finish the pending installation first so Atuin and Orca can both observe commands.

## What Changed

Install a pending bash-preexec hook before Orca composes `PROMPT_COMMAND`, preserving its DEBUG-trap handoff and interactive state. Retain the real Atuin/node-pty regression covering three prompt cycles, their exit statuses, history entries, and Orca OSC 133 lifecycle markers. Update the generated wrapper fixture and its temporary-global allowance.

## Why

bash-preexec’s deferred installer expects a scalar `PROMPT_COMMAND`. Orca’s array composition leaves its installation string stranded in a later element. Installing before composition preserves Atuin recording without replacing Orca’s lifecycle hooks.

## Linked Issue

Fixes #14294

Author: @instantepiphany (Jordan Cran). No X/Twitter account.

## Visual Proof

N/A

No visual change: this repairs shell history recording and preserves existing terminal lifecycle markers; no UI layout or rendering changes.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local Linux verification:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/shell-ready-atuin.node-pty.test.ts src/main/daemon/shell-ready-bash-wrapper.test.ts src/main/daemon/bash-prompt-command-composition.test.ts src/main/shell-wrapper-generated-file-snapshot.test.ts`: exit 0, four files and 51 tests passed, including real Atuin 18.19.
- The same real-Atuin regression fails against the upstream wrapper: none of the three commands are recorded, and an extra OSC command-start marker is emitted.
- Isolated real Bash/Atuin execution independently reproduced missing history before the repair and recorded commands after it.
- `pnpm typecheck`: passed.
- `pnpm build`: passed.
- `pnpm lint` / `pnpm test`: all remaining failures also occurred on the tested base commit (`bba68b1bdd`).

The real-Atuin fixture is opt-in through `ORCA_TEST_BASH_PREEXEC`; normal runs skip it if bash-preexec is not supplied. Verification used bash-preexec 0.6.0 and Atuin 18.19, with `ORCA_TEST_ATUIN` pointing to the Atuin executable. Runtime tests used isolated HOME/config/data with Atuin sync and update checks disabled.

macOS, native Windows, mobile, and end-to-end SSH terminal execution were not tested.

## AI Disclosure

AI assistance from GPT-6-Astra and GPT-5.6-Terra was used to prepare the change, tests, and this description. The review below covers correctness, security, compatibility, and performance.

## Review

- Correctness: the installer runs only when bash-preexec import state, its installation string, and that pending string in `PROMPT_COMMAND` are present. Installed or absent integrations keep the existing path. The negative control fails and the repair passes without changing assertions.
- Security: no new network, credential, process-spawning, or filesystem API in the repair. It invokes already-loaded user shell integration code, within the existing startup trust boundary.
- Cross-platform: only the Bash wrapper changes; no OS paths or keyboard conventions added. Native Windows shell implementations are untouched. Bash 3.2/macOS runtime compatibility was not exercised.
- Local/remote/SSH and folder workspaces: the daemon fileset continues to generate the same wrapper through its existing path; no local fallback, repository assumption, or wire format change. Remote shell profiles remain owned by the execution host.
- Agents/integrations/providers: Orca OSC 133 lifecycle remains intact across the three tested prompt cycles. Other shells and agent preflights are untouched; no GitHub-specific runtime logic is introduced. Other integrations were not exhaustively exercised.
- Performance: the extra conditional and trap capture occur during startup only, not once per command. No extra hot-path allocation or subprocess is introduced by this patch.
- UI/mobile: no visual changes or mobile implementation changes.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No version or release changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass — typecheck/build pass; lint/full-suite failures remain as documented above
