### PR TITLE
fix(agent-hooks): force C numeric locale on POSIX curl timeouts

### DIFF
--- a/src/main/agent-hooks/hook-post-command.ts
+++ b/src/main/agent-hooks/hook-post-command.ts
@@ -1,11 +1,19 @@
 import type { AgentHookSource } from '../../shared/agent-hook-relay'
 import { ORCA_HOOK_RAW_JSON_TRANSPORT } from '../../shared/agent-hook-types'
 
+// Why: curl parses --connect-timeout/--max-time with locale-sensitive strtod.
+// Comma-decimal locales reject `0.5` before opening a socket, so every hook
+// silently falls into the restart spool (#19578). Scoped to LC_NUMERIC so
+// spool_json_escape keeps UTF-8 LC_CTYPE for non-ASCII worktree paths.
+export function posixCurlCommand(curlCommand = 'curl'): string {
+  return `LC_NUMERIC=C ${curlCommand}`
+}
+
 export function buildPosixAgentHookPostCommand(
   source: AgentHookSource,
   options: { curlCommand?: string; indent?: string } = {}
 ): string[] {
-  const curlCommand = options.curlCommand ?? 'curl'
+  const curlCommand = posixCurlCommand(options.curlCommand ?? 'curl')
   const indent = options.indent ?? '  '
   return [
     `if [ "\${ORCA_AGENT_HOOK_TRANSPORT:-}" = "${ORCA_HOOK_RAW_JSON_TRANSPORT}" ] && command -v base64 >/dev/null 2>&1 && command -v tr >/dev/null 2>&1; then`,

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -915,6 +915,18 @@ describe('buildPosixAgentHookPostCommand', () => {
     expect(command).toContain('Content-Type: application/x-www-form-urlencoded')
     expect(command).toContain('--data-urlencode "payload@-"')
   })
+
+  it('forces C numeric locale on every curl invocation so fractional timeouts parse', () => {
+    const command = buildPosixAgentHookPostCommand('claude').join('\n')
+    expect(command).toContain('| LC_NUMERIC=C curl -sS')
+    expect(command).not.toMatch(/\|\s+curl\b/)
+
+    const custom = buildPosixAgentHookPostCommand('codex', { curlCommand: '"$curl_bin"' }).join(
+      '\n'
+    )
+    expect(custom).toContain('| LC_NUMERIC=C "$curl_bin" -sS')
+    expect(custom).not.toMatch(/\|\s+"\$curl_bin"/)
+  })
 })
 
 describe('buildWindowsAgentHookCurlPostCommand', () => {

--- a/src/main/agent-hooks/managed-hook-timeout.test.ts
+++ b/src/main/agent-hooks/managed-hook-timeout.test.ts
@@ -4,7 +4,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { spawn, spawnSync } from 'node:child_process'
 import { createServer, type Server, type Socket } from 'node:net'
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
@@ -202,11 +202,32 @@ describe('managed agent hook timeouts', () => {
           (process.platform === 'win32' && command.includes('-EncodedCommand'))
       )
       expect(carriers).toBeGreaterThan(0)
+      if (process.platform !== 'win32') {
+        assertPosixCurlUsesCNumericLocale(
+          readFileSync(join(homeDir, '.orca', 'agent-hooks', 'droid-hook.sh'), 'utf8'),
+          'droid'
+        )
+      }
     } finally {
       homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
       rmSync(homeDir, { recursive: true, force: true })
     }
   })
+
+  function assertPosixCurlUsesCNumericLocale(content: string, label: string): void {
+    expect(content, `${label} wrapper missing curl transport`).toContain('curl')
+    expect(content, `${label} wrapper missing --connect-timeout`).toContain('--connect-timeout')
+    expect(content, `${label} wrapper missing --max-time`).toContain('--max-time')
+    expect(content, `${label} wrapper missing C numeric locale for curl`).toMatch(
+      /LC_NUMERIC=C (?:curl|"\$curl_bin")/
+    )
+    expect(content, `${label} wrapper posts curl without C numeric locale`).not.toMatch(
+      /\|\s+curl\b/
+    )
+    expect(content, `${label} wrapper posts curl_bin without C numeric locale`).not.toMatch(
+      /\|\s+"\$curl_bin"/
+    )
+  }
 
   it('bounds every generated POSIX curl wrapper with --connect-timeout and --max-time', async () => {
     let curlWrappersChecked = 0
@@ -217,19 +238,85 @@ describe('managed agent hook timeouts', () => {
         if (!path.endsWith('.sh')) {
           continue
         }
-        expect(content, `${agent} wrapper missing curl transport`).toContain('curl')
-        expect(content, `${agent} wrapper missing --connect-timeout`).toContain('--connect-timeout')
-        expect(content, `${agent} wrapper missing --max-time`).toContain('--max-time')
+        assertPosixCurlUsesCNumericLocale(content, `${agent} ${path}`)
         curlWrappersChecked += 1
       }
     }
     const kimi = createFakeSftp()
     await new KimiHookService().installRemote(kimi.sftp, REMOTE_HOME)
     const kimiWrapper = kimi.fs.files.get(`${REMOTE_HOME}/.orca/agent-hooks/kimi-hook.sh`)!
-    expect(kimiWrapper, 'kimi wrapper missing --connect-timeout').toContain('--connect-timeout')
-    expect(kimiWrapper, 'kimi wrapper missing --max-time').toContain('--max-time')
+    assertPosixCurlUsesCNumericLocale(kimiWrapper, 'kimi')
     curlWrappersChecked += 1
     expect(curlWrappersChecked).toBeGreaterThan(0)
+  })
+
+  describe('comma-decimal curl locale', () => {
+    let tempDir: string | null = null
+
+    afterEach(() => {
+      if (tempDir) {
+        rmSync(tempDir, { recursive: true, force: true })
+        tempDir = null
+      }
+    })
+
+    it.skipIf(process.platform === 'win32')(
+      'overrides a comma-decimal LC_NUMERIC so curl still receives C',
+      async () => {
+        const { sftp, fs } = createFakeSftp()
+        await new GeminiHookService().installRemote(sftp, REMOTE_HOME)
+        const wrapperBody = fs.files.get(`${REMOTE_HOME}/.orca/agent-hooks/gemini-hook.sh`)!
+
+        tempDir = mkdtempSync(join(tmpdir(), 'orca-hook-lc-numeric-'))
+        const binDir = join(tempDir, 'bin')
+        mkdirSync(binDir)
+        const observed = join(tempDir, 'lc-numeric')
+        writeFileSync(
+          join(binDir, 'curl'),
+          `#!/bin/sh\nprintf '%s' "$LC_NUMERIC" > "${observed}"\nexit 0\n`
+        )
+        chmodSync(join(binDir, 'curl'), 0o755)
+        const scriptPath = join(tempDir, 'gemini-hook.sh')
+        writeFileSync(scriptPath, wrapperBody, 'utf8')
+        chmodSync(scriptPath, 0o755)
+
+        await new Promise<void>((resolve, reject) => {
+          const child = spawn('sh', [scriptPath], {
+            env: {
+              ...process.env,
+              PATH: `${binDir}:${process.env.PATH ?? ''}`,
+              LC_NUMERIC: 'de_DE.UTF-8',
+              ORCA_AGENT_HOOK_ENDPOINT: '',
+              ORCA_AGENT_HOOK_PORT: '9',
+              ORCA_AGENT_HOOK_TOKEN: 'test-token',
+              ORCA_PANE_KEY: 'pane-1',
+              ORCA_TAB_ID: 'tab-1',
+              ORCA_WORKTREE_ID: 'wt-1'
+            },
+            stdio: ['pipe', 'ignore', 'ignore']
+          })
+          const timeout = setTimeout(() => {
+            child.kill('SIGKILL')
+            reject(new Error('hook script exceeded test timeout'))
+          }, 10_000)
+          child.on('error', (error) => {
+            clearTimeout(timeout)
+            reject(error)
+          })
+          child.on('close', (status) => {
+            clearTimeout(timeout)
+            if (status === 0) {
+              resolve()
+              return
+            }
+            reject(new Error(`hook script exited ${String(status)}`))
+          })
+          child.stdin.end('{"hook_event_name":"Stop"}')
+        })
+
+        expect(readFileSync(observed, 'utf8')).toBe('C')
+      }
+    )
   })
 
   describe('dead-endpoint transport budget', () => {

--- a/src/main/antigravity/hook-script.ts
+++ b/src/main/antigravity/hook-script.ts
@@ -1,3 +1,4 @@
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 import {
   buildPosixHookPayloadCapture,
   buildPosixHookSpoolLines,
@@ -68,7 +69,9 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
     // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
     // command line (EDR command-line false positives). Wire body is identical.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/antigravity" \\',
+    'printf \'%s\' "$payload" | ' +
+      posixCurlCommand() +
+      ' -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/antigravity" \\',
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',

--- a/src/main/antigravity/hook-service.test.ts
+++ b/src/main/antigravity/hook-service.test.ts
@@ -111,7 +111,7 @@ describe('AntigravityHookService', () => {
       expect(script).not.toContain('if [ -z "$payload" ]; then\n  exit 0\nfi')
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
       // on the curl command line (EDR oversized-command-line false positive).
-      expect(script).toContain('printf \'%s\' "$payload" | curl')
+      expect(script).toContain('printf \'%s\' "$payload" | LC_NUMERIC=C curl')
       expect(script).toContain('--data-urlencode "payload@-"')
       expect(script).not.toContain('--data-urlencode "payload=${payload}"')
     }

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -716,7 +716,7 @@ describe('ClaudeHookService.installRemote', () => {
       script!.indexOf('#!/bin/sh') + '#!/bin/sh\n'.length
     )
     // Why: payload stays on stdin, while metadata headers avoid URL-encoded IDS signatures.
-    expect(script).toContain('printf \'%s\' "$payload" | curl')
+    expect(script).toContain('printf \'%s\' "$payload" | LC_NUMERIC=C curl')
     expect(script).toContain('-H "Content-Type: application/json"')
     expect(script).toContain('orca_hook_metadata=$(printf')
     expect(script).toContain('unset ORCA_AGENT_HOOK_TRANSPORT')

--- a/src/main/claude/statusline-script.test.ts
+++ b/src/main/claude/statusline-script.test.ts
@@ -29,6 +29,8 @@ describe('getManagedStatusLineScript (posix)', () => {
     expect(endpointIndex).toBeLessThan(curlIndex)
     expect(script).toContain('/statusline/claude')
     expect(script).toContain('--data-urlencode "payload@-"')
+    expect(script).toContain('| LC_NUMERIC=C curl -sS')
+    expect(script).not.toMatch(/\|\s+curl\b/)
   })
 
   it('returns the posix script even on win32 when targeting a remote', () => {

--- a/src/main/claude/statusline-script.ts
+++ b/src/main/claude/statusline-script.ts
@@ -1,3 +1,4 @@
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 import {
   buildWindowsHookStdinDrainEpilogue,
   WINDOWS_HOOK_STDIN_DRAIN_LABEL,
@@ -163,7 +164,7 @@ export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'):
     'if [ -n "$orca_statusline_now" ]; then',
     '  printf \'%s\' "$orca_statusline_now" >"$orca_statusline_stamp" 2>/dev/null || :',
     'fi',
-    `printf '%s' "$payload" | curl -sS -X POST "http://127.0.0.1:\${ORCA_AGENT_HOOK_PORT}${CLAUDE_STATUSLINE_PATHNAME}" \\`,
+    `printf '%s' "$payload" | ${posixCurlCommand()} -sS -X POST "http://127.0.0.1:\${ORCA_AGENT_HOOK_PORT}${CLAUDE_STATUSLINE_PATHNAME}" \\`,
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',

--- a/src/main/command-code/command-code-managed-script.ts
+++ b/src/main/command-code/command-code-managed-script.ts
@@ -1,3 +1,4 @@
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 import { buildWindowsAgentHookPostCommand } from '../agent-hooks/installer-utils'
 import {
   buildPosixHookPayloadCapture,
@@ -128,7 +129,9 @@ export function buildCommandCodeManagedScript(
     // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
     // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
     // command line (EDR command-line false positives). Wire body is identical.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/command-code" \\',
+    'printf \'%s\' "$payload" | ' +
+      posixCurlCommand() +
+      ' -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/command-code" \\',
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',

--- a/src/main/copilot/copilot-managed-script.ts
+++ b/src/main/copilot/copilot-managed-script.ts
@@ -1,3 +1,4 @@
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 import { getSharedManagedScriptPath } from '../agent-hooks/installer-utils'
 import {
   buildPosixHookPayloadCapture,
@@ -70,7 +71,9 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
     // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
     // command line (EDR command-line false positives). Wire body is identical.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/copilot" \\',
+    'printf \'%s\' "$payload" | ' +
+      posixCurlCommand() +
+      ' -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/copilot" \\',
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',

--- a/src/main/cursor/hook-script.ts
+++ b/src/main/cursor/hook-script.ts
@@ -3,6 +3,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand
 } from '../agent-hooks/installer-utils'
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 import {
   buildPosixHookPayloadCapture,
   buildPosixHookSpoolLines,
@@ -70,7 +71,9 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     'fi',
     // Why: post form fields because path-bearing worktree IDs are unsafe in hand-built JSON.
     // Why: pipe payload to curl stdin to keep large output off the command line.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/cursor" \\',
+    'printf \'%s\' "$payload" | ' +
+      posixCurlCommand() +
+      ' -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/cursor" \\',
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -137,7 +137,7 @@ describe('CursorHookService', () => {
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
       // on the curl command line (EDR oversized-command-line false positive).
       expect(script).toContain(`payload=$(${POSIX_HOOK_STDIN_READER})`)
-      expect(script).toContain('printf \'%s\' "$payload" | curl')
+      expect(script).toContain('printf \'%s\' "$payload" | LC_NUMERIC=C curl')
       expect(script).toContain('--data-urlencode "payload@-"')
       expect(script).not.toContain('--data-urlencode "payload=${payload}"')
     }

--- a/src/main/devin/hook-service.test.ts
+++ b/src/main/devin/hook-service.test.ts
@@ -67,9 +67,11 @@ describe('DevinHookService', () => {
     expect(script).toContain('/hook/devin')
     // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
     // on the curl command line (EDR oversized-command-line false positive).
-    expect(script).toContain('printf \'%s\' "$payload" | curl')
     expect(script).toContain('--data-urlencode "payload@-"')
     expect(script).not.toContain('--data-urlencode "payload=${payload}"')
+    if (process.platform !== 'win32') {
+      expect(script).toContain('printf \'%s\' "$payload" | LC_NUMERIC=C curl')
+    }
   })
 
   it('preserves unrelated keys in Devin config when installing hooks', () => {

--- a/src/main/devin/hook-service.ts
+++ b/src/main/devin/hook-service.ts
@@ -17,6 +17,7 @@ import {
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue
 } from '../agent-hooks/hook-stdin-contract'
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 import {
   applyDevinManagedHooks,
   DEVIN_EVENTS,
@@ -68,7 +69,9 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     'fi',
     // Why: worktreeId embeds a filesystem path, so hand-building JSON in shell is unsafe (quotes/newlines); post as form fields instead.
     // Why: pipe payload to curl's stdin (payload@-) not an inline arg, so large tool output stays off the command line (EDR false positives).
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/devin" \\',
+    'printf \'%s\' "$payload" | ' +
+      posixCurlCommand() +
+      ' -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/devin" \\',
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -28,6 +28,7 @@ import {
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue
 } from '../agent-hooks/hook-stdin-contract'
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 
 // Why: SessionStart is installed (not just listened for) so that resuming a
 // droid session via `droid --resume` resets the per-pane prompt/tool caches
@@ -107,7 +108,9 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
     // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
     // command line (EDR command-line false positives). Wire body is identical.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/droid" \\',
+    'printf \'%s\' "$payload" | ' +
+      posixCurlCommand() +
+      ' -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/droid" \\',
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',

--- a/src/main/gemini/hook-service.ts
+++ b/src/main/gemini/hook-service.ts
@@ -28,6 +28,7 @@ import {
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue
 } from '../agent-hooks/hook-stdin-contract'
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 
 // Why: Gemini has no permission-prompt hook (approvals are inline UI), so Orca can't show a waiting state — upstream limitation.
 // Why: Gemini's pre-tool event is BeforeTool, not Claude/Codex's PreToolUse; sweep stale PreToolUse entries below.
@@ -84,7 +85,9 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     'fi',
     // Why: worktreeId embeds a path, so post form fields, not hand-built JSON that breaks on quotes/newlines.
     // Why: pipe payload via curl stdin (`payload@-`) so large tool output stays off the command line (EDR false positives).
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/gemini" \\',
+    'printf \'%s\' "$payload" | ' +
+      posixCurlCommand() +
+      ' -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/gemini" \\',
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',

--- a/src/main/grok/grok-hook-script.ts
+++ b/src/main/grok/grok-hook-script.ts
@@ -3,6 +3,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsCmdHookCommand
 } from '../agent-hooks/installer-utils'
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 import {
   buildPosixHookPayloadCapture,
   buildPosixHookSpoolLines
@@ -48,7 +49,9 @@ export function getGrokManagedScript(target: 'local' | 'posix' = 'local'): strin
     `if [ -n "\${GROK_HOME:-}" ] && [ "\${#GROK_HOME}" -le ${GROK_HOME_ENVELOPE_MAX_LENGTH} ]; then`,
     '  grok_home=$GROK_HOME',
     'fi',
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/grok" \\',
+    'printf \'%s\' "$payload" | ' +
+      posixCurlCommand() +
+      ' -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/grok" \\',
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -297,7 +297,7 @@ describe('GrokHookService', () => {
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
       // on the curl command line (EDR oversized-command-line false positive).
       expect(script).toContain(`payload=$(${POSIX_HOOK_STDIN_READER})`)
-      expect(script).toContain('printf \'%s\' "$payload" | curl')
+      expect(script).toContain('printf \'%s\' "$payload" | LC_NUMERIC=C curl')
       expect(script).toContain('--data-urlencode "payload@-"')
       expect(script).toContain('${#GROK_HOME}" -le 4096')
       expect(script).toContain('--data-urlencode "grokHome=${grok_home}"')

--- a/src/main/kimi/hook-service.test.ts
+++ b/src/main/kimi/hook-service.test.ts
@@ -57,9 +57,11 @@ describe('KimiHookService', () => {
     expect(script).toContain('/hook/kimi')
     // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
     // on the curl command line (EDR oversized-command-line false positive).
-    expect(script).toContain('printf \'%s\' "$payload" | curl')
     expect(script).toContain('--data-urlencode "payload@-"')
     expect(script).not.toContain('--data-urlencode "payload=${payload}"')
+    if (process.platform !== 'win32') {
+      expect(script).toContain('printf \'%s\' "$payload" | LC_NUMERIC=C curl')
+    }
     // The command Kimi runs points at the managed script via sh.
     expect(config).toContain('agent-hooks/kimi-hook.sh')
   })

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -28,6 +28,7 @@ import {
   buildPosixHookPayloadCapture,
   buildPosixHookSpoolLines
 } from '../agent-hooks/hook-stdin-contract'
+import { posixCurlCommand } from '../agent-hooks/hook-post-command'
 import {
   applyManagedKimiHooks,
   KIMI_HOOK_EVENTS,
@@ -99,7 +100,9 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
     // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
     // command line (EDR command-line false positives). Wire body is identical.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/kimi" \\',
+    'printf \'%s\' "$payload" | ' +
+      posixCurlCommand() +
+      ' -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/kimi" \\',
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',


### PR DESCRIPTION
## ELI5

On Linux desktops that use a comma as the decimal separator (Russian, German, French, Spanish, …), every agent hook script asks `curl` for a 0.5s connect timeout. `curl` reads that number with the locale, rejects `0.5` as invalid, and never opens a socket. The script then silently writes the event to a restart-only spool, so Chat UI and agent status freeze until Orca is restarted.

This change prefixes every POSIX hook `curl` invocation with `LC_NUMERIC=C` so the existing fractional timeouts keep working, without switching the rest of the script to `LC_ALL=C` (that would break UTF-8 path escaping).

## What Changed

- Added `posixCurlCommand()` so POSIX hook posts run as `LC_NUMERIC=C curl` (or `LC_NUMERIC=C $curl_bin` for Codex).
- Applied it in the shared post helper and every hardcoded POSIX wrapper, including Claude statusline.
- Windows `curl.exe` paths are unchanged.
- Tests now require the locale prefix on generated wrappers and prove a fake `curl` still sees `LC_NUMERIC=C` when the parent locale uses a comma decimal.

## Why

`curl` parses `--connect-timeout` / `--max-time` with locale-sensitive `strtod`. Under `LC_NUMERIC=ru_RU.UTF-8` (and other comma-decimal locales) `0.5` is a usage error *before a socket is opened*. The `|| spool_hook_event` fallback then parks every event until the next app start, which looks like a flaky Chat UI.

Scoping the override to `LC_NUMERIC` (not `LC_ALL`) keeps UTF-8 `LC_CTYPE` for `spool_json_escape`, which runs `sed` over worktree paths that can contain non-ASCII characters.

## Linked Issue

Fixes #19578

## Visual Proof

N/A — no UI or interaction change. Generated POSIX hook scripts now prefix `curl` with `LC_NUMERIC=C`; Chat UI / status delivery is restored on comma-decimal locales because the POST actually leaves the machine.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally — Windows runner cannot reproduce POSIX `curl`+locale; CI Linux coverage is the live path. Locally ran the unit tests that execute on Windows.

Verified locally (Windows, Node 24, vitest 4.1.11):

- `src/main/agent-hooks/managed-hook-timeout.test.ts`
- `src/main/claude/statusline-script.test.ts`
- `src/main/agent-hooks/installer-utils.test.ts` (locale assertions)
- related Claude / Antigravity / Grok / Cursor / Devin install assertions

The live fake-`curl` locale test is `skipIf(win32)` and is intended to run on Linux/macOS CI.

## AI Disclosure

Implemented with Cursor Grok 4.6.

## Review

- **Cross-platform:** POSIX scripts only. Windows cmd/`curl.exe` wrappers are untouched. Git Bash Kimi hooks on Windows also go through the POSIX `.sh` path and pick up the prefix.
- **SSH/remote:** Remote installs write the same POSIX wrappers (`getManagedScript('posix')` / `installRemote`), so SSH/WSL guests with comma-decimal locales are covered.
- **Agents:** Claude, OpenClaude, Codex, Gemini, Antigravity, Cursor, Command Code, Grok, Copilot, Devin, Droid, Kimi, plus Claude statusline.
- **Performance:** One env assignment on the `curl` argv. No extra processes.
- **Security:** No new network surface. Does not use `LC_ALL=C`.
- **UI:** No visual change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Relevant unit tests pass locally; full `pnpm lint` / `pnpm typecheck` / `pnpm build` left to CI