### PR TITLE
fix(terminal): resume agents with the pane's own Windows shell on the host path

### DIFF
--- a/src/main/runtime/agent-resume-startup-shell-resolution.test.ts
+++ b/src/main/runtime/agent-resume-startup-shell-resolution.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAgentResumeStartupShell } from './agent-resume-startup-shell-resolution'
+
+describe('resolveAgentResumeStartupShell', () => {
+  it('uses the client shell for a local win32 target', () => {
+    expect(
+      resolveAgentResumeStartupShell({
+        requestedStartupShell: 'cmd',
+        platform: 'win32',
+        isRemote: false,
+        terminalWindowsShell: 'powershell.exe'
+      })
+    ).toBe('cmd')
+  })
+
+  it('falls back to the global setting when the client sends nothing', () => {
+    expect(
+      resolveAgentResumeStartupShell({
+        platform: 'win32',
+        isRemote: false,
+        terminalWindowsShell: 'cmd.exe'
+      })
+    ).toBe('cmd')
+  })
+
+  it('ignores the client shell for a remote target', () => {
+    expect(
+      resolveAgentResumeStartupShell({
+        requestedStartupShell: 'cmd',
+        platform: 'win32',
+        isRemote: true,
+        terminalWindowsShell: 'powershell.exe'
+      })
+    ).toBeUndefined()
+  })
+
+  it('ignores the client shell for a non-Windows target', () => {
+    for (const platform of ['linux', 'darwin'] as const) {
+      expect(
+        resolveAgentResumeStartupShell({
+          requestedStartupShell: 'powershell',
+          platform,
+          isRemote: false,
+          terminalWindowsShell: 'powershell.exe'
+        })
+      ).toBeUndefined()
+    }
+  })
+})

--- a/src/main/runtime/agent-resume-startup-shell-resolution.ts
+++ b/src/main/runtime/agent-resume-startup-shell-resolution.ts
@@ -1,0 +1,29 @@
+import { resolveLocalWindowsAgentStartupShell } from '../../shared/windows-terminal-shell'
+import type { AgentStartupShell } from '../../shared/tui-agent-startup-shell'
+
+/**
+ * Startup shell for a host-authority agent resume.
+ *
+ * A client may report the shell its pane actually runs, which is the only way a
+ * per-tab override reaches the host (#12320, #13095). That report describes one
+ * local native-Windows pane, so it is honoured only for a local win32 target:
+ * accepting it for a remote or non-Windows target would let a request pick a
+ * quoting mode the target shell does not use. Every other case keeps the host's
+ * own resolution from the global `terminalWindowsShell` setting.
+ */
+export function resolveAgentResumeStartupShell(args: {
+  requestedStartupShell?: AgentStartupShell
+  platform: NodeJS.Platform
+  isRemote: boolean
+  terminalWindowsShell?: string | null
+}): AgentStartupShell | undefined {
+  const hostShell = resolveLocalWindowsAgentStartupShell({
+    platform: args.platform,
+    isRemote: args.isRemote,
+    terminalWindowsShell: args.terminalWindowsShell
+  })
+  if (args.platform !== 'win32' || args.isRemote) {
+    return hostShell
+  }
+  return args.requestedStartupShell ?? hostShell
+}

--- a/src/main/runtime/orca-runtime-get-agent-session-execution-namespace.ts
+++ b/src/main/runtime/orca-runtime-get-agent-session-execution-namespace.ts
@@ -133,11 +133,13 @@ export class OrcaRuntimeWithGetAgentSessionExecutionNamespace extends OrcaRuntim
     // Why: `workspace.repo` is display metadata and may be a row from another host; the launch
     // shape must match the PTY route this scope already resolved.
     const isRemote = Boolean(workspace.connectionId)
-    const shell = resolveLocalWindowsAgentStartupShell({
-      platform,
-      isRemote,
-      terminalWindowsShell: settings.terminalWindowsShell
-    })
+    const shell =
+      request.startupShell ??
+      resolveLocalWindowsAgentStartupShell({
+        platform,
+        isRemote,
+        terminalWindowsShell: settings.terminalWindowsShell
+      })
     const startup = buildAgentResumeStartupPlan({
       agent: request.agent,
       providerSession: identity.providerSession,

--- a/src/main/runtime/orca-runtime-get-agent-session-execution-namespace.ts
+++ b/src/main/runtime/orca-runtime-get-agent-session-execution-namespace.ts
@@ -11,7 +11,7 @@ import type {
 } from '../../shared/agent-session-host-authority'
 import { canonicalizeAgentSessionIdentity } from './agent-session-claim-identity'
 import { isTuiAgentEnabled } from '../../shared/tui-agent-selection'
-import { resolveLocalWindowsAgentStartupShell } from '../../shared/windows-terminal-shell'
+import { resolveAgentResumeStartupShell } from './agent-resume-startup-shell-resolution'
 import { buildAgentResumeStartupPlan } from '../../shared/tui-agent-startup'
 import {
   resolveTuiAgentLaunchArgs,
@@ -133,13 +133,12 @@ export class OrcaRuntimeWithGetAgentSessionExecutionNamespace extends OrcaRuntim
     // Why: `workspace.repo` is display metadata and may be a row from another host; the launch
     // shape must match the PTY route this scope already resolved.
     const isRemote = Boolean(workspace.connectionId)
-    const shell =
-      request.startupShell ??
-      resolveLocalWindowsAgentStartupShell({
-        platform,
-        isRemote,
-        terminalWindowsShell: settings.terminalWindowsShell
-      })
+    const shell = resolveAgentResumeStartupShell({
+      requestedStartupShell: request.startupShell,
+      platform,
+      isRemote,
+      terminalWindowsShell: settings.terminalWindowsShell
+    })
     const startup = buildAgentResumeStartupPlan({
       agent: request.agent,
       providerSession: identity.providerSession,

--- a/src/main/runtime/rpc/methods/agent-session.startup-shell.test.ts
+++ b/src/main/runtime/rpc/methods/agent-session.startup-shell.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { EnsureAgentSessionParams } from './agent-session'
+
+/**
+ * `startupShell` lets the client tell the host which shell the pane runs, so a
+ * per-tab override survives an app restart (#12320, #13095). The field is
+ * optional: an older client omits it and the host keeps resolving the shell
+ * from the global `terminalWindowsShell` setting.
+ */
+describe('ensureAgentSession startupShell', () => {
+  const base = {
+    kind: 'explicit' as const,
+    worktree: 'C:/repo',
+    agent: 'claude' as const,
+    providerSession: { key: 'session_id' as const, id: 'sess-1234' }
+  }
+
+  it('accepts every startup-shell family', () => {
+    for (const startupShell of ['posix', 'powershell', 'cmd'] as const) {
+      expect(EnsureAgentSessionParams.safeParse({ ...base, startupShell }).success).toBe(true)
+    }
+  })
+
+  it('accepts a request without the field', () => {
+    expect(EnsureAgentSessionParams.safeParse(base).success).toBe(true)
+  })
+
+  it('rejects a shell name outside the union', () => {
+    for (const startupShell of ['fish', 'PowerShell', '', 'bash']) {
+      expect(EnsureAgentSessionParams.safeParse({ ...base, startupShell }).success).toBe(false)
+    }
+  })
+})

--- a/src/main/runtime/rpc/methods/agent-session.startup-shell.test.ts
+++ b/src/main/runtime/rpc/methods/agent-session.startup-shell.test.ts
@@ -6,6 +6,9 @@ import { EnsureAgentSessionParams } from './agent-session'
  * per-tab override survives an app restart (#12320, #13095). The field is
  * optional: an older client omits it and the host keeps resolving the shell
  * from the global `terminalWindowsShell` setting.
+ *
+ * The host additionally honours it only for a local win32 target; the schema's
+ * job is to keep the value inside the known shell union.
  */
 describe('ensureAgentSession startupShell', () => {
   const base = {

--- a/src/main/runtime/rpc/methods/agent-session.ts
+++ b/src/main/runtime/rpc/methods/agent-session.ts
@@ -133,7 +133,12 @@ const ExplicitEnsure = z
     agentArgs: AgentArgs.optional(),
     launchPreferences: LaunchPreferences.optional(),
     presentation: Presentation.optional(),
-    placement: Placement.optional()
+    placement: Placement.optional(),
+    // Why: quoting must follow the shell the pane actually runs. The per-tab
+    // override lives in renderer state, so the client resolves it and sends the
+    // result; without it the host falls back to the global setting (#12320,
+    // #13095) and a tab whose shell differs gets literal quote characters.
+    startupShell: z.enum(['posix', 'powershell', 'cmd']).optional()
   })
   .strict()
   .superRefine((value, context) => {

--- a/src/renderer/src/components/terminal-pane/agent-resume-startup-shell.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-resume-startup-shell.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The host-authority resume request must carry the shell the pane actually
+ * runs. Without it the host resolves the shell from the global
+ * `terminalWindowsShell` setting alone, so a tab with a per-tab override is
+ * quoted for the wrong shell after an app restart (#12320, #13095).
+ */
+
+const storeState: {
+  tabsByWorktree: Record<string, { id: string; shellOverride?: string }[]>
+  settings?: { terminalWindowsShell?: string | null }
+} = { tabsByWorktree: {}, settings: {} }
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => storeState }
+}))
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: () => null
+}))
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getExecutionHostIdForWorktree: () => 'local'
+}))
+
+function setNavigatorUserAgent(userAgent: string): () => void {
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { platform: userAgent.includes('Windows') ? 'Win32' : 'MacIntel', userAgent }
+  })
+  return () => {
+    if (original) {
+      Object.defineProperty(globalThis, 'navigator', original)
+    } else {
+      delete (globalThis as { navigator?: Navigator }).navigator
+    }
+  }
+}
+
+async function resolveShell(args: {
+  tabShellOverride?: string
+  globalShell?: string | null
+  worktreeId?: string | undefined
+}): Promise<string | undefined> {
+  storeState.tabsByWorktree = {
+    'wt-1': [
+      { id: 'tab-1', ...(args.tabShellOverride ? { shellOverride: args.tabShellOverride } : {}) }
+    ]
+  }
+  storeState.settings = { terminalWindowsShell: args.globalShell ?? null }
+  const { resolveAgentResumeStartupShellForPane } = await import('./agent-resume-startup-shell')
+  return resolveAgentResumeStartupShellForPane(
+    'worktreeId' in args ? args.worktreeId : 'wt-1',
+    'tab-1'
+  )
+}
+
+describe('resolveAgentResumeStartupShellForPane on a Windows client', () => {
+  let restoreNavigator: () => void
+
+  beforeEach(() => {
+    vi.resetModules()
+    restoreNavigator = setNavigatorUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+  })
+
+  afterEach(() => {
+    restoreNavigator()
+  })
+
+  it('prefers the per-tab override over the global setting', async () => {
+    expect(await resolveShell({ tabShellOverride: 'cmd.exe', globalShell: 'powershell.exe' })).toBe(
+      'cmd'
+    )
+    expect(
+      await resolveShell({ tabShellOverride: 'git-bash', globalShell: 'powershell.exe' })
+    ).toBe('posix')
+    expect(await resolveShell({ tabShellOverride: 'powershell.exe', globalShell: 'cmd.exe' })).toBe(
+      'powershell'
+    )
+  })
+
+  it('falls back to the global setting when the tab has no override', async () => {
+    expect(await resolveShell({ globalShell: 'cmd.exe' })).toBe('cmd')
+    expect(await resolveShell({ globalShell: 'wsl.exe' })).toBe('posix')
+  })
+
+  it('returns undefined without a worktree so the host keeps its own resolution', async () => {
+    expect(
+      await resolveShell({ tabShellOverride: 'cmd.exe', worktreeId: undefined })
+    ).toBeUndefined()
+  })
+})
+
+describe('resolveAgentResumeStartupShellForPane on a non-Windows client', () => {
+  let restoreNavigator: () => void
+
+  beforeEach(() => {
+    vi.resetModules()
+    restoreNavigator = setNavigatorUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+  })
+
+  afterEach(() => {
+    restoreNavigator()
+  })
+
+  it('sends no shell, leaving the platform default in place', async () => {
+    expect(
+      await resolveShell({ tabShellOverride: 'cmd.exe', globalShell: 'cmd.exe' })
+    ).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/agent-resume-startup-shell.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-resume-startup-shell.test.ts
@@ -5,21 +5,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
  * runs. Without it the host resolves the shell from the global
  * `terminalWindowsShell` setting alone, so a tab with a per-tab override is
  * quoted for the wrong shell after an app restart (#12320, #13095).
+ *
+ * The value must also be withheld whenever the client cannot classify the
+ * target, so the host keeps its own platform-aware resolution.
  */
 
 const storeState: {
   tabsByWorktree: Record<string, { id: string; shellOverride?: string }[]>
   settings?: { terminalWindowsShell?: string | null }
-} = { tabsByWorktree: {}, settings: {} }
+  worktreesByRepo: unknown
+} = { tabsByWorktree: {}, settings: {}, worktreesByRepo: {} }
 
-vi.mock('@/store', () => ({
-  useAppStore: { getState: () => storeState }
-}))
-vi.mock('@/lib/connection-context', () => ({
-  getConnectionId: () => null
-}))
+let connectionId: string | null = null
+let executionHostId: string | null = 'local'
+let worktreePath: string | undefined = 'C:\\repo\\feature'
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => storeState } }))
+vi.mock('@/lib/connection-context', () => ({ getConnectionId: () => connectionId }))
 vi.mock('@/lib/worktree-runtime-owner', () => ({
-  getExecutionHostIdForWorktree: () => 'local'
+  getExecutionHostIdForWorktree: () => executionHostId
+}))
+vi.mock('@/store/worktree-repo-index', () => ({
+  getIndexedWorktreeById: () => (worktreePath ? { path: worktreePath } : undefined)
 }))
 
 function setNavigatorUserAgent(userAgent: string): () => void {
@@ -55,11 +62,14 @@ async function resolveShell(args: {
   )
 }
 
-describe('resolveAgentResumeStartupShellForPane on a Windows client', () => {
+describe('resolveAgentResumeStartupShellForPane on a local Windows pane', () => {
   let restoreNavigator: () => void
 
   beforeEach(() => {
     vi.resetModules()
+    connectionId = null
+    executionHostId = 'local'
+    worktreePath = 'C:\\repo\\feature'
     restoreNavigator = setNavigatorUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
   })
 
@@ -91,11 +101,45 @@ describe('resolveAgentResumeStartupShellForPane on a Windows client', () => {
   })
 })
 
+describe('resolveAgentResumeStartupShellForPane withholds a shell it cannot classify', () => {
+  let restoreNavigator: () => void
+
+  beforeEach(() => {
+    vi.resetModules()
+    connectionId = null
+    executionHostId = 'local'
+    worktreePath = 'C:\\repo\\feature'
+    restoreNavigator = setNavigatorUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+  })
+
+  afterEach(() => {
+    restoreNavigator()
+  })
+
+  it('sends nothing for a WSL worktree, which runs a POSIX shell', async () => {
+    worktreePath = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\dev\\repo'
+    expect(await resolveShell({ tabShellOverride: 'cmd.exe' })).toBeUndefined()
+  })
+
+  it('sends nothing for an SSH workspace', async () => {
+    connectionId = 'conn-1'
+    expect(await resolveShell({ tabShellOverride: 'cmd.exe' })).toBeUndefined()
+  })
+
+  it('sends nothing for a non-local execution host', async () => {
+    executionHostId = 'environment:env-1'
+    expect(await resolveShell({ tabShellOverride: 'cmd.exe' })).toBeUndefined()
+  })
+})
+
 describe('resolveAgentResumeStartupShellForPane on a non-Windows client', () => {
   let restoreNavigator: () => void
 
   beforeEach(() => {
     vi.resetModules()
+    connectionId = null
+    executionHostId = 'local'
+    worktreePath = '/home/dev/repo'
     restoreNavigator = setNavigatorUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
   })
 

--- a/src/renderer/src/components/terminal-pane/agent-resume-startup-shell.ts
+++ b/src/renderer/src/components/terminal-pane/agent-resume-startup-shell.ts
@@ -1,0 +1,41 @@
+import { useAppStore } from '@/store'
+import { resolveWindowsShellOverride } from '@/lib/pane-manager/windows-pty-compatibility'
+import { resolveLocalWindowsAgentStartupShell } from '../../../../shared/windows-terminal-shell'
+import { getConnectionId } from '@/lib/connection-context'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { parseExecutionHostId } from '../../../../shared/execution-host'
+import { CLIENT_PLATFORM } from '@/lib/new-workspace'
+import type { AgentStartupShell } from '../../../../shared/tui-agent-startup-shell'
+
+/**
+ * Startup-shell family for a pane's host-authority agent resume.
+ *
+ * The host resolves this from the global `terminalWindowsShell` setting, which
+ * misses a per-tab shell override; the renderer's own cold-restore path already
+ * honours the override (#12320, #13095). Resolving it here and sending it with
+ * the request keeps both restore paths on the same shell for the same pane.
+ *
+ * Returns `undefined` when the platform default is correct, which leaves the
+ * request field absent and the host on its existing behaviour.
+ */
+export function resolveAgentResumeStartupShellForPane(
+  worktreeId: string | undefined,
+  tabId: string | undefined
+): AgentStartupShell | undefined {
+  if (!worktreeId) {
+    return undefined
+  }
+  const state = useAppStore.getState()
+  const tab = (state.tabsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === tabId)
+  const executionHostId = getExecutionHostIdForWorktree(state, worktreeId)
+  return resolveLocalWindowsAgentStartupShell({
+    platform: CLIENT_PLATFORM,
+    isRemote:
+      Boolean(getConnectionId(worktreeId)) ||
+      parseExecutionHostId(executionHostId)?.kind !== 'local',
+    terminalWindowsShell: resolveWindowsShellOverride(
+      tab?.shellOverride,
+      state.settings?.terminalWindowsShell
+    )
+  })
+}

--- a/src/renderer/src/components/terminal-pane/agent-resume-startup-shell.ts
+++ b/src/renderer/src/components/terminal-pane/agent-resume-startup-shell.ts
@@ -1,38 +1,49 @@
 import { useAppStore } from '@/store'
 import { resolveWindowsShellOverride } from '@/lib/pane-manager/windows-pty-compatibility'
-import { resolveLocalWindowsAgentStartupShell } from '../../../../shared/windows-terminal-shell'
+import { getIndexedWorktreeById } from '@/store/worktree-repo-index'
 import { getConnectionId } from '@/lib/connection-context'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { resolveLocalWindowsAgentStartupShell } from '../../../../shared/windows-terminal-shell'
 import { parseExecutionHostId } from '../../../../shared/execution-host'
+import { isWslUncPath } from '../../../../shared/wsl-paths'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import type { AgentStartupShell } from '../../../../shared/tui-agent-startup-shell'
 
 /**
- * Startup-shell family for a pane's host-authority agent resume.
+ * Startup-shell family for a pane's host-authority agent resume, or `undefined`
+ * when the host's own resolution is already correct.
  *
- * The host resolves this from the global `terminalWindowsShell` setting, which
- * misses a per-tab shell override; the renderer's own cold-restore path already
- * honours the override (#12320, #13095). Resolving it here and sending it with
- * the request keeps both restore paths on the same shell for the same pane.
+ * The host resolves the shell from the global `terminalWindowsShell` setting,
+ * which misses a per-tab override; the renderer's cold-restore path already
+ * honours the override (#12320, #13095), so the same pane is quoted differently
+ * depending on how it is restored. Sending the resolved value closes that gap.
  *
- * Returns `undefined` when the platform default is correct, which leaves the
- * request field absent and the host on its existing behaviour.
+ * Deliberately narrow: only a local, native-Windows pane reports a shell. A WSL
+ * worktree, a WSL-pinned project, an SSH workspace, or a non-local execution
+ * host runs a POSIX shell that the client cannot classify from renderer state
+ * alone, and guessing there would push Windows quoting into a POSIX shell — the
+ * same #12320 failure, one dimension over. Those cases return `undefined` and
+ * leave the host on its existing platform-aware resolution.
  */
 export function resolveAgentResumeStartupShellForPane(
   worktreeId: string | undefined,
   tabId: string | undefined
 ): AgentStartupShell | undefined {
-  if (!worktreeId) {
+  if (!worktreeId || CLIENT_PLATFORM !== 'win32') {
     return undefined
   }
   const state = useAppStore.getState()
+  const isRemote =
+    Boolean(getConnectionId(worktreeId)) ||
+    parseExecutionHostId(getExecutionHostIdForWorktree(state, worktreeId))?.kind !== 'local'
+  const worktreePath = getIndexedWorktreeById(state.worktreesByRepo, worktreeId)?.path
+  if (isRemote || (worktreePath && isWslUncPath(worktreePath))) {
+    return undefined
+  }
   const tab = (state.tabsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === tabId)
-  const executionHostId = getExecutionHostIdForWorktree(state, worktreeId)
   return resolveLocalWindowsAgentStartupShell({
-    platform: CLIENT_PLATFORM,
-    isRemote:
-      Boolean(getConnectionId(worktreeId)) ||
-      parseExecutionHostId(executionHostId)?.kind !== 'local',
+    platform: 'win32',
+    isRemote: false,
     terminalWindowsShell: resolveWindowsShellOverride(
       tab?.shellOverride,
       state.settings?.terminalWindowsShell

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -59,6 +59,7 @@ import {
   RemoteRuntimePtyRecoveryState
 } from './remote-runtime-pty-recovery-state'
 import { createBrowserUuid } from '@/lib/browser-uuid'
+import { resolveAgentResumeStartupShellForPane } from './agent-resume-startup-shell'
 import {
   createAgentSessionCreateOperation,
   withAgentSessionCreateOperationId
@@ -2207,6 +2208,7 @@ export function createRemoteRuntimePtyTransport(
         const resumeProviderSessionToSend = options.resumeProviderSession ?? resumeProviderSession
         const launchTokenToSend = options.launchToken ?? launchToken
         const launchAgentToSend = options.launchAgent ?? launchAgent
+        const agentResumeStartupShell = resolveAgentResumeStartupShellForPane(worktreeId, tabId)
         const legacyCreateParams = {
           worktree: toRuntimeTerminalWorktreeSelector(worktreeId),
           clientMutationId: terminalCreateMutationId,
@@ -2267,6 +2269,10 @@ export function createRemoteRuntimePtyTransport(
                         ? { launchPreferences: agentLaunchPreferences }
                         : {}),
                       placement: { tabId, leafId },
+                      // Why: quoting must follow the shell this pane actually runs;
+                      // the host would otherwise fall back to the global setting and
+                      // send PowerShell quotes into a cmd.exe/Git Bash tab (#12320).
+                      ...(agentResumeStartupShell ? { startupShell: agentResumeStartupShell } : {}),
                       presentation: 'background'
                     },
                     timeoutMs

--- a/src/shared/agent-session-host-authority.ts
+++ b/src/shared/agent-session-host-authority.ts
@@ -8,6 +8,7 @@ import type { RuntimeTerminalCreate, RuntimeTerminalPresentation } from './runti
 import { isTerminalLeafId } from './stable-pane-id'
 import { isValidTerminalTabId } from './terminal-tab-id'
 import type { TuiAgent } from './tui-agent'
+import type { AgentStartupShell } from './tui-agent-startup-shell'
 
 export { AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY as AGENT_SESSION_HOST_AUTHORITY_CAPABILITY } from './protocol-version'
 
@@ -112,6 +113,11 @@ export type RuntimeEnsureAgentSessionRequest =
       launchPreferences?: AgentLaunchPreferences
       presentation?: RuntimeTerminalPresentation
       placement?: { tabId?: string; leafId?: string }
+      /** Startup-shell family the pane actually runs, resolved by the client from
+       *  the per-tab override before the global `terminalWindowsShell` setting.
+       *  Omission keeps the host's global-setting resolution, so an older client
+       *  behaves exactly as before. */
+      startupShell?: AgentStartupShell
     }
 
 export type RuntimeEnsureAgentSessionResult = {


### PR DESCRIPTION
## ELI5

A tab can be set to run cmd.exe or Git Bash even when the app-wide setting says PowerShell. When Orca restarts an agent inside the running app it remembers that; when it restores the agent after the whole app was restarted, it forgets and quotes the command for PowerShell. The agent then gets quote characters it does not understand and refuses to resume. This sends the tab's real shell along with the restore request.

## What Changed

| File | Change |
|---|---|
| `src/shared/agent-session-host-authority.ts` | `RuntimeEnsureAgentSessionRequest` (explicit) gains an optional `startupShell: AgentStartupShell` |
| `src/main/runtime/rpc/methods/agent-session.ts` | `ExplicitEnsure` accepts `startupShell` as `z.enum(['posix','powershell','cmd'])`, still `.strict()` |
| `src/main/runtime/orca-runtime-get-agent-session-execution-namespace.ts` | prefers `request.startupShell`, falling back to the existing `resolveLocalWindowsAgentStartupShell(...)` call |
| `src/renderer/src/components/terminal-pane/agent-resume-startup-shell.ts` (new) | resolves the pane's shell from the per-tab override then the global setting, and withholds it for a WSL worktree, an SSH workspace, a non-local execution host, or a non-Windows client |
| `src/main/runtime/agent-resume-startup-shell-resolution.ts` (new) | host-side boundary: the request value is honoured only for a local win32 target, otherwise the global-setting resolution stands |
| `src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts` | sends `startupShell` with the `terminal.ensureAgentSession` request |

The `terminal.createAgentSession` branch of the same call site is deliberately untouched; this PR is scoped to resume.

## Why

#13095 established that a queued command must be quoted for the shell the pane actually runs, not the configured dialect, and #12476 added a per-tab override to the renderer resume path for that reason. The host-authority path never received the same input: it resolves the shell from `settings.terminalWindowsShell` alone, and the request carries no shell field, so a tab whose shell differs from the global setting is quoted wrongly whenever it is restored through the host — which is what happens after a full app restart or a reboot. The result is the failure #12320 reported (`error: unexpected argument ''<id>'' found`), through a path that issue did not cover.

Sending the already-resolved value is the smaller of the two possible fixes. Resolving it host-side would require the host to look up a tab's override by `placement.tabId`, which is renderer-owned state; the renderer already computes exactly this value for its own cold-restore path, so this keeps both paths on one source of truth.

Backwards compatible in both directions: the field is optional, an older client that omits it leaves the host on its current global-setting resolution, and a newer client talking to an older host has the field dropped by that host's schema rather than failing the request.

## Linked Issue

Fixes #19611

## Visual Proof

N/A — no UI change. The user-visible difference is that an agent tab with a per-tab shell override resumes after an app restart instead of printing an argument error; the argv difference is asserted in the tests below.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Tested on Windows 11 (Node 24, pnpm 12). Focused suites + typecheck passed locally; the full suite is left to CI.

- `pnpm typecheck`: `tsconfig.node.json`, `tsconfig.tc.cli.json`, `tsconfig.tc.web.json` — 0 errors.
- Focused vitest — 6 files, 99 tests, all green: `agent-resume-startup-shell-resolution` (new), `agent-session.startup-shell` (new), `agent-resume-startup-shell` (new), `agent-session`, `agent-resume-launch-target`, `tui-agent-startup`.
- Adjacent regression check — 4 files, 71 tests, all green: `tui-agent-startup`, `tui-agent-startup-shell`, `sleeping-agent-session-launch-windows-quoting`, `ai-vault-omp-cold-resume`.
- `pnpm lint`: the localization-runtime-catalog sub-check fails on this machine for `auto.components.settings.TerminalPane.minimumContrast.*`, which are not touched here; confirmed identical on an unmodified `main` via `git stash`. Every other sub-check passes.

New coverage: the per-tab override winning over the global setting for cmd.exe / Git Bash / PowerShell; the fallback to the global setting when a tab has no override; `undefined` when there is no worktree, so the host keeps its own resolution; nothing sent for a WSL worktree, an SSH workspace, a non-local execution host, or a non-Windows client; the host honouring the request value only for a local win32 target and ignoring it when remote or off win32; and the schema accepting each shell family, accepting a request without the field, and rejecting a value outside the union.

Manual: with the global shell on PowerShell and one tab overridden to cmd.exe, start an agent there, fully quit Orca, reopen. Before this change the pane relaunches and the CLI rejects the quoted session id; after it, the pane resumes.

## AI Disclosure

An AI assistant helped investigate the symptom and gather information about the affected code paths. The fix, the tests, and this description were written by me.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- Cross-platform: `resolveLocalWindowsAgentStartupShell` already returns `undefined` off Windows and for remote panes, so nothing is sent and nothing changes on macOS, Linux, or SSH/remote sessions.
- Security: the value is validated against the existing three-member `AgentStartupShell` union by a strict schema; it selects a quoting function and is never interpolated into a command.
- Performance: one store read per resume request.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` for screenshots — no UI change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm typecheck` passes locally; focused and adjacent suites pass; `pnpm lint` passes except a pre-existing unrelated failure documented above; full `pnpm test` and `pnpm build` left to CI