### PR TITLE
feat: add project removal confirmation preference

### DIFF
--- a/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.test.tsx
+++ b/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.test.tsx
@@ -32,6 +32,7 @@ afterEach(() => {
 function renderSection(
   updateSettings: (updates: object) => void | Promise<void>,
   options: {
+    skipRemoveProjectConfirm?: boolean
     defaultsSupported?: boolean
     sourceDefaultsSupported?: boolean
     worktreeVisibilityDefaults?: ReturnType<typeof getDefaultSettings>['worktreeVisibilityDefaults']
@@ -39,6 +40,7 @@ function renderSection(
 ): void {
   const settings = getDefaultSettings('/home/user')
   settings.worktreeVisibilityDefaults = options.worktreeVisibilityDefaults
+  settings.skipRemoveProjectConfirm = options.skipRemoveProjectConfirm ?? false
   act(() => {
     root.render(
       <GeneralWorkspaceSettingsSection
@@ -145,5 +147,18 @@ describe('GeneralWorkspaceSettingsSection external visibility', () => {
     })
     const sourceId = defaults.customSources[0].id
     expect(defaults.sourcePreferences.custom).toEqual({ [sourceId]: 'hide' })
+  })
+})
+
+describe('project removal confirmation setting', () => {
+  it.each([false, true])('can reverse the skip preference from %s', async (skip) => {
+    const updateSettings = vi.fn()
+    renderSection(updateSettings, { skipRemoveProjectConfirm: skip })
+    const control = container.querySelector<HTMLButtonElement>(
+      '#general-skip-remove-project-confirm [role="switch"]'
+    )!
+    expect(control.getAttribute('aria-checked')).toBe(String(!skip))
+    await act(async () => control.click())
+    expect(updateSettings).toHaveBeenCalledWith({ skipRemoveProjectConfirm: !skip })
   })
 })

--- a/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
@@ -135,6 +135,35 @@ export function GeneralWorkspaceSettingsSection({
         </SearchableSetting>
       </div>
 
+      <div id="general-skip-remove-project-confirm" className="scroll-mt-6">
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.GeneralWorkspaceSettingsSection.askBeforeRemovingProjects',
+            'Ask Before Removing Projects'
+          )}
+          description={translate(
+            'auto.components.settings.GeneralWorkspaceSettingsSection.askBeforeRemovingProjectsDescription',
+            'Show a confirmation before removing a project from Orca. VM projects always ask because their files may be deleted.'
+          )}
+          keywords={['remove', 'project', 'confirm', 'dialog', 'skip', 'prompt']}
+        >
+          <SettingsSwitchRow
+            label={translate(
+              'auto.components.settings.GeneralWorkspaceSettingsSection.askBeforeRemovingProjects',
+              'Ask Before Removing Projects'
+            )}
+            description={translate(
+              'auto.components.settings.GeneralWorkspaceSettingsSection.askBeforeRemovingProjectsDescription',
+              'Show a confirmation before removing a project from Orca. VM projects always ask because their files may be deleted.'
+            )}
+            checked={!settings.skipRemoveProjectConfirm}
+            onChange={() =>
+              updateSettings({ skipRemoveProjectConfirm: !settings.skipRemoveProjectConfirm })
+            }
+          />
+        </SearchableSetting>
+      </div>
+
       <div id="general-skip-delete-automation-confirm" className="scroll-mt-6">
         <SearchableSetting
           title={translate(

--- a/src/renderer/src/components/sidebar/RemoveFolderDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/RemoveFolderDialog.test.tsx
@@ -1,6 +1,9 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen, fireEvent } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../../../shared/repo-types'
 
 const mocks = vi.hoisted(() => ({
@@ -15,7 +18,10 @@ const mocks = vi.hoisted(() => ({
     sshTargetLabels: new Map<string, string>(),
     removedSshTargetLabels: new Map<string, string>(),
     closeModal: vi.fn(),
-    removeProject: vi.fn()
+    removeProject: vi.fn(),
+    updateSettingsOrThrow: vi.fn().mockResolvedValue(undefined),
+    openSettingsPage: vi.fn(),
+    openSettingsTarget: vi.fn()
   }
 }))
 
@@ -34,7 +40,9 @@ vi.mock('@/components/ui/dialog', () => ({
 }))
 
 vi.mock('@/components/ui/button', () => ({
-  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>
+  Button: ({ children, onClick }: { children: ReactNode; onClick: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  )
 }))
 
 vi.mock('@/i18n/i18n', () => ({
@@ -61,8 +69,10 @@ function repo(connectionId: string | null, executionHostId: Repo['executionHostI
 }
 
 describe('RemoveFolderDialog', () => {
+  afterEach(cleanup)
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.state.repos = [repo(null, 'local')]
     mocks.state.modalData = {
       repoId: 'repo-1',
       displayName: 'Example',
@@ -81,6 +91,7 @@ describe('RemoveFolderDialog', () => {
     expect(html).toContain('Its VM recipe determines whether the environment')
     expect(html).toContain('files are permanently deleted')
     expect(html).not.toContain('Its files stay on')
+    expect(html).not.toContain('checkbox')
   })
 
   it('keeps the file-preservation promise for ordinary SSH projects', () => {
@@ -90,5 +101,44 @@ describe('RemoveFolderDialog', () => {
 
     expect(html).toContain('Its files stay on Persistent host')
     expect(html).not.toContain('VM recipe')
+  })
+
+  it('saves the preference only when checked and confirmed', () => {
+    render(<RemoveFolderDialog />)
+    fireEvent.click(screen.getByRole('checkbox', { name: "Don't ask again" }))
+    expect(mocks.state.updateSettingsOrThrow).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(mocks.state.updateSettingsOrThrow).toHaveBeenCalledWith({
+      skipRemoveProjectConfirm: true
+    })
+    expect(mocks.state.removeProject).toHaveBeenCalledWith('repo-1', {
+      hostId: 'ssh:target-1',
+      errorFeedback: 'toast'
+    })
+    expect(mocks.state.closeModal).toHaveBeenCalled()
+  })
+
+  it('does not save the preference or remove the project on cancel', () => {
+    render(<RemoveFolderDialog />)
+    fireEvent.click(screen.getByRole('checkbox', { name: "Don't ask again" }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(mocks.state.updateSettingsOrThrow).not.toHaveBeenCalled()
+    expect(mocks.state.removeProject).not.toHaveBeenCalled()
+    expect(mocks.state.closeModal).toHaveBeenCalled()
+  })
+
+  it('leaves confirmation enabled when removing without checking', () => {
+    render(<RemoveFolderDialog />)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(mocks.state.updateSettingsOrThrow).not.toHaveBeenCalled()
+    expect(mocks.state.removeProject).toHaveBeenCalledTimes(1)
+  })
+
+  it('starts unchecked when a cancelled dialog is mounted again', () => {
+    const first = render(<RemoveFolderDialog />)
+    fireEvent.click(screen.getByRole('checkbox'))
+    first.unmount()
+    render(<RemoveFolderDialog />)
+    expect(screen.getByRole('checkbox').getAttribute('aria-checked')).toBe('false')
   })
 })

--- a/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
+import { Checkbox } from '@/components/ui/checkbox'
+import { persistConfirmationSkipPreference } from '@/components/confirmation-skip-preference'
 import {
   Dialog,
   DialogContent,
@@ -25,6 +27,10 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
   const modalData = useAppStore((s) => s.modalData)
   const closeModal = useAppStore((s) => s.closeModal)
   const removeProject = useAppStore((s) => s.removeProject)
+  const updateSettings = useAppStore((s) => s.updateSettingsOrThrow)
+  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+  const [dontAskAgain, setDontAskAgain] = useState(false)
 
   const isOpen = activeModal === 'confirm-remove-folder'
   const repoId = typeof modalData.repoId === 'string' ? modalData.repoId : ''
@@ -55,7 +61,8 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
   // Why: fragment concatenation around the styled name cannot be reordered by
   // SOV locales (#9294). Translate one full sentence with the name as a
   // sentinel token, then split on it to re-apply the inline emphasis.
-  const description = isRuntimeOwnedSshTargetId(sshConnectionId)
+  const isVmProject = isRuntimeOwnedSshTargetId(sshConnectionId)
+  const description = isVmProject
     ? translate(
         'auto.components.sidebar.RemoveFolderDialog.removeDescriptionVmRecipe',
         'This removes {{name}} from Orca. Its VM recipe determines whether the environment and its files are permanently deleted.',
@@ -76,13 +83,32 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
 
   const handleConfirm = useCallback(() => {
     if (repoId) {
+      if (dontAskAgain && !isVmProject) {
+        persistConfirmationSkipPreference({
+          updates: { skipRemoveProjectConfirm: true },
+          settingsSectionId: 'general-skip-remove-project-confirm',
+          updateSettings,
+          openSettingsPage,
+          openSettingsTarget
+        })
+      }
       void removeProject(repoId, {
         ...(hostId ? { hostId } : {}),
         errorFeedback: 'toast'
       })
     }
     closeModal()
-  }, [closeModal, hostId, removeProject, repoId])
+  }, [
+    closeModal,
+    hostId,
+    removeProject,
+    repoId,
+    dontAskAgain,
+    isVmProject,
+    updateSettings,
+    openSettingsPage,
+    openSettingsTarget
+  ])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -106,6 +132,15 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
             {descriptionAfterName}
           </DialogDescription>
         </DialogHeader>
+        {!isVmProject && (
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Checkbox
+              checked={dontAskAgain}
+              onCheckedChange={(checked) => setDontAskAgain(checked === true)}
+            />
+            {translate('auto.components.confirmation.dialog.92bac3217e', "Don't ask again")}
+          </label>
+        )}
         <DialogFooter>
           <Button variant="outline" onClick={() => handleOpenChange(false)}>
             {translate('auto.components.sidebar.RemoveFolderDialog.d36883e046', 'Cancel')}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react'
+import { runProjectRemoval } from './remove-project-flow'
 import { useAppStore } from '@/store'
 import { useShallow } from 'zustand/react/shallow'
 import {
@@ -210,16 +211,13 @@ const WorktreeList = React.memo(function WorktreeList({
     },
     [openModal]
   )
-  const handleRemoveProject = useCallback(
-    (repo: Repo) => {
-      openModal('confirm-remove-folder', {
-        repoId: repo.id,
-        displayName: repo.displayName,
-        hostId: getRepoExecutionHostId(repo)
-      })
-    },
-    [openModal]
-  )
+  const handleRemoveProject = useCallback((repo: Repo) => {
+    runProjectRemoval({
+      repoId: repo.id,
+      displayName: repo.displayName,
+      hostId: getRepoExecutionHostId(repo)
+    })
+  }, [])
   const handleCreateFolderWorkspace = useCallback(
     (projectGroup: ProjectGroup) => {
       if (!projectGroup.parentPath) {

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '@/store'
+import { runProjectRemoval } from './remove-project-flow'
 import { getAllWorktreesFromState, getWorktreeOnHostFromState } from '@/store/selectors'
 import { toWorktreeRemovalTarget } from '../../../../shared/worktree/removal'
 import { findRepoForHost } from '@/store/slices/repo-host-identity'
@@ -55,8 +56,8 @@ export function runWorktreeDelete(worktreeId: string, options: WorktreeDeleteOpt
       settings: state.settings
     })
     const hostId = repo ? getRepoExecutionHostId(repo) : target.hostId
-    // Why: git refuses to delete the primary checkout; users can still remove the owning project from Orca (disk contents kept).
-    state.openModal('confirm-remove-folder', {
+    // Why: git refuses to delete the primary checkout; offer removal of its owning project from Orca.
+    runProjectRemoval({
       repoId: target.repoId,
       displayName: repo?.displayName ?? target.displayName,
       ...(hostId ? { hostId } : {})

--- a/src/renderer/src/components/sidebar/remove-project-flow.test.ts
+++ b/src/renderer/src/components/sidebar/remove-project-flow.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    settings: { skipRemoveProjectConfirm: false, activeRuntimeEnvironmentId: 'local' },
+    repos: [] as Repo[],
+    removeProject: vi.fn().mockResolvedValue(undefined),
+    openModal: vi.fn()
+  }
+}))
+vi.mock('@/store', () => ({ useAppStore: { getState: () => mocks.state } }))
+
+import { runProjectRemoval } from './remove-project-flow'
+
+const localRepo: Repo = {
+  id: 'project',
+  path: '/project',
+  displayName: 'Project',
+  kind: 'git',
+  badgeColor: '#737373',
+  addedAt: 1,
+  executionHostId: 'local'
+}
+const target = { repoId: 'project', displayName: 'Project', hostId: 'local' as const }
+
+describe('runProjectRemoval', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.state.settings.skipRemoveProjectConfirm = false
+    mocks.state.repos = [localRepo]
+  })
+
+  it('asks by default', () => {
+    runProjectRemoval(target)
+    expect(mocks.state.openModal).toHaveBeenCalledWith('confirm-remove-folder', target)
+    expect(mocks.state.removeProject).not.toHaveBeenCalled()
+  })
+
+  it.each(['git', 'folder'] as const)('skips the dialog for an opted-in %s project', (kind) => {
+    mocks.state.settings.skipRemoveProjectConfirm = true
+    mocks.state.repos = [{ ...localRepo, kind }]
+    runProjectRemoval(target)
+    expect(mocks.state.removeProject).toHaveBeenCalledWith('project', {
+      hostId: 'local',
+      errorFeedback: 'toast'
+    })
+    expect(mocks.state.openModal).not.toHaveBeenCalled()
+  })
+
+  it('preserves the selected SSH host when project ids overlap', () => {
+    mocks.state.settings.skipRemoveProjectConfirm = true
+    mocks.state.repos.push({ ...localRepo, executionHostId: 'ssh:remote', connectionId: 'remote' })
+    runProjectRemoval({ ...target, hostId: 'ssh:remote' })
+    expect(mocks.state.removeProject).toHaveBeenCalledWith('project', {
+      hostId: 'ssh:remote',
+      errorFeedback: 'toast'
+    })
+  })
+
+  it('keeps the warning for VM projects even after opting out', () => {
+    mocks.state.settings.skipRemoveProjectConfirm = true
+    mocks.state.repos = [
+      { ...localRepo, connectionId: 'runtime-ssh-vm', executionHostId: 'ssh:runtime-ssh-vm' }
+    ]
+    const vmTarget = { ...target, hostId: 'ssh:runtime-ssh-vm' as const }
+    runProjectRemoval(vmTarget)
+    expect(mocks.state.openModal).toHaveBeenCalledWith('confirm-remove-folder', vmTarget)
+    expect(mocks.state.removeProject).not.toHaveBeenCalled()
+  })
+
+  it('does not skip for an unresolved host', () => {
+    mocks.state.settings.skipRemoveProjectConfirm = true
+    runProjectRemoval({ ...target, hostId: 'ssh:missing' })
+    expect(mocks.state.removeProject).not.toHaveBeenCalled()
+    expect(mocks.state.openModal).toHaveBeenCalled()
+  })
+
+  it('asks again after the preference is re-enabled', () => {
+    mocks.state.settings.skipRemoveProjectConfirm = true
+    runProjectRemoval(target)
+    mocks.state.settings.skipRemoveProjectConfirm = false
+    runProjectRemoval(target)
+    expect(mocks.state.removeProject).toHaveBeenCalledTimes(1)
+    expect(mocks.state.openModal).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/sidebar/remove-project-flow.ts
+++ b/src/renderer/src/components/sidebar/remove-project-flow.ts
@@ -1,0 +1,32 @@
+import { useAppStore } from '@/store'
+import { findRepoForHost } from '@/store/slices/repo-host-identity'
+import {
+  getRepoExecutionHostId,
+  isRuntimeOwnedSshTargetId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
+
+export function runProjectRemoval(target: {
+  repoId: string
+  displayName: string
+  hostId?: ExecutionHostId
+}): void {
+  const state = useAppStore.getState()
+  const repo = findRepoForHost(state.repos, target.repoId, {
+    hostId: target.hostId,
+    settings: state.settings
+  })
+  // VM recipes may destroy the environment and its files; always retain that warning.
+  if (
+    state.settings?.skipRemoveProjectConfirm &&
+    repo &&
+    !isRuntimeOwnedSshTargetId(repo.connectionId)
+  ) {
+    void state.removeProject(repo.id, {
+      hostId: getRepoExecutionHostId(repo),
+      errorFeedback: 'toast'
+    })
+    return
+  }
+  state.openModal('confirm-remove-folder', target)
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7189,7 +7189,9 @@
           "externalWorktrees": "External worktrees",
           "externalWorktreesDescription": "Choose whether worktrees created outside Orca appear by default.",
           "show": "Show",
-          "hide": "Hide"
+          "hide": "Hide",
+          "askBeforeRemovingProjects": "Ask Before Removing Projects",
+          "askBeforeRemovingProjectsDescription": "Show a confirmation before removing a project from Orca. VM projects always ask because their files may be deleted."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "Apply Changes",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6087,6 +6087,8 @@
           "7173352632": "idle"
         },
         "GeneralWorkspaceSettingsSection": {
+          "askBeforeRemovingProjects": "프로젝트 제거 전 확인",
+          "askBeforeRemovingProjectsDescription": "Orca에서 프로젝트를 제거하기 전에 확인합니다. VM 프로젝트는 파일이 삭제될 수 있어 항상 확인합니다.",
           "3d538a98f7": "워크스페이스의 열기 메뉴에서 사용 가능한 앱을 선택하세요.",
           "008f92085f": "앱에서 열기",
           "824b98a0d9": "자동화 및 실행 기록을 삭제하기 전에 확인 메시지를 표시하세요.",
@@ -14301,6 +14303,7 @@
       },
       "confirmation": {
         "dialog": {
+          "92bac3217e": "다시 보지 않기",
           "8490e5d36a": "확인",
           "56f5c60e0c": "취소"
         }

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -185,6 +185,7 @@ export function buildDefaultSettings(args: {
     devPluginPaths: [],
     claudeAgentTeamsDefaultDisabledMigrated: true,
     skipDeleteWorktreeConfirm: false,
+    skipRemoveProjectConfirm: false,
     skipCloseTerminalWithRunningProcessConfirm: false,
     skipDeleteAutomationConfirm: false,
     skipDeleteArtifactConfirm: false,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -337,6 +337,8 @@ export type GlobalSettings = {
   claudeAgentTeamsDefaultDisabledMigrated?: boolean
   /** Why: worktree deletion is destructive (rm -rf of the working dir), so confirm by default. */
   skipDeleteWorktreeConfirm: boolean
+  /** VM project removal always confirms because its recipe may delete files. */
+  skipRemoveProjectConfirm: boolean
   /** Why: closing a terminal with child processes kills foreground work; keep this skip separate from other confirmations. */
   skipCloseTerminalWithRunningProcessConfirm: boolean
   /** Why: deleting an automation also deletes its run history; keep this skip separate from worktree deletion. */

--- a/tests/e2e/project-removal-confirmation.spec.ts
+++ b/tests/e2e/project-removal-confirmation.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+test.use({ minimumSeededWorktreeCount: 1 })
+
+test('project removal preference can be cancelled, saved, and restored', async ({
+  orcaPage
+}, testInfo) => {
+  await waitForSessionReady(orcaPage)
+  await orcaPage.setViewportSize({ width: 1280, height: 800 })
+  await orcaPage.evaluate(() => window.__store!.getState().updateSettings({ uiLanguage: 'en' }))
+  const project = await orcaPage.evaluate(() => {
+    const repo = window.__store!.getState().repos[0]
+    return { name: repo.displayName, path: repo.path }
+  })
+  const actions = orcaPage.getByRole('button', {
+    name: `Project actions for ${project.name}`,
+    exact: true
+  })
+  const header = orcaPage.locator('[data-repo-header-id]').filter({ has: actions })
+  const dialog = orcaPage.getByRole('dialog', { name: 'Remove Project', exact: true })
+  const openRemoval = async (): Promise<void> => {
+    await header.hover()
+    await actions.click()
+    await orcaPage.getByRole('menuitem', { name: 'Remove Project', exact: true }).click()
+  }
+
+  await openRemoval()
+  await expect(dialog.getByRole('checkbox', { name: "Don't ask again" })).not.toBeChecked()
+  await dialog.getByRole('checkbox').check()
+  await orcaPage.screenshot({
+    animations: 'disabled',
+    path: testInfo.outputPath('project-removal-confirmation.png')
+  })
+  await dialog.getByRole('button', { name: 'Cancel', exact: true }).click()
+  await expect(dialog).toBeHidden()
+  await expect(header).toBeVisible()
+
+  await openRemoval()
+  await expect(dialog.getByRole('checkbox')).not.toBeChecked()
+  await dialog.getByRole('checkbox').check()
+  await dialog.getByRole('button', { name: 'Remove', exact: true }).click()
+  await expect(header).toBeHidden()
+  await expect(
+    orcaPage.getByText("We'll skip this confirmation next time.", { exact: true })
+  ).toBeVisible()
+  await orcaPage.getByRole('button', { name: 'Open Settings', exact: true }).click()
+  const setting = orcaPage.getByRole('switch', {
+    name: 'Ask Before Removing Projects',
+    exact: true
+  })
+  await expect(setting).not.toBeChecked()
+  await orcaPage.screenshot({
+    animations: 'disabled',
+    path: testInfo.outputPath('project-removal-settings.png')
+  })
+
+  await orcaPage.evaluate(async (repoPath) => {
+    const state = window.__store!.getState()
+    state.closeSettingsPage()
+    await state.addRepoPath(repoPath)
+  }, project.path)
+  await orcaPage.reload()
+  await waitForSessionReady(orcaPage)
+  await expect(header).toBeVisible()
+  await openRemoval()
+  await expect(header).toBeHidden()
+  await expect(dialog).toBeHidden()
+
+  await orcaPage.evaluate(async (repoPath) => {
+    const state = window.__store!.getState()
+    await state.addRepoPath(repoPath)
+    state.openSettingsPage()
+    state.openSettingsTarget({
+      pane: 'general',
+      repoId: null,
+      sectionId: 'general-skip-remove-project-confirm'
+    })
+  }, project.path)
+  await expect(setting).not.toBeChecked()
+  await setting.click()
+  await expect(setting).toBeChecked()
+  await orcaPage.evaluate(() => window.__store!.getState().closeSettingsPage())
+  await openRemoval()
+  await expect(dialog).toBeVisible()
+  await dialog.getByRole('checkbox').check()
+  await orcaPage.keyboard.press('Escape')
+  await expect(dialog).toBeHidden()
+  await openRemoval()
+  await expect(dialog.getByRole('checkbox')).not.toBeChecked()
+  await orcaPage.keyboard.press('Escape')
+  await orcaPage.evaluate(() =>
+    window.__store!.getState().updateSettings({ uiLanguage: 'ko', theme: 'dark' })
+  )
+  await orcaPage.reload()
+  await waitForSessionReady(orcaPage)
+  await orcaPage.evaluate(() => {
+    const state = window.__store!.getState()
+    const repo = state.repos[0]
+    state.openModal('confirm-remove-folder', {
+      repoId: repo.id,
+      displayName: repo.displayName,
+      hostId: 'local'
+    })
+  })
+  await expect(orcaPage.getByRole('dialog')).toContainText('프로젝트 제거')
+  await expect(orcaPage.getByRole('checkbox', { name: '다시 보지 않기' })).toBeVisible()
+  await orcaPage.screenshot({
+    animations: 'disabled',
+    path: testInfo.outputPath('project-removal-confirmation-ko-dark.png')
+  })
+})


### PR DESCRIPTION
## ELI5

When cleaning up several projects, you can check **Don't ask again** in the removal dialog to skip that confirmation next time. You can turn it back on in Settings. VM projects still require confirmation because their cleanup recipe may delete the environment and its files.

## What Changed

- Add an unchecked **Don't ask again** checkbox to the project removal dialog. Save the preference only when removal is confirmed; cancelling or pressing Escape leaves it unchanged.
- Share the preference between the project menu and the primary worktree's **Remove Project from Orca** action, independently of workspace deletion preferences.
- Add **Ask Before Removing Projects** under General settings, with a settings link in the saved-preference toast. Report persistence failures without showing a success toast.
- Keep VM removal confirmations mandatory, preserve the selected execution host, and add English/Korean copy and regression tests.

## Why

Repeated project cleanup should allow an explicit opt-out from the same confirmation. Confirmation remains the default, and the setting has a visible way to restore it.

## Linked Issue

Related: #17645, for context on project removal confirmation and scope. This PR adds an explicit opt-out; it does **not** resolve that issue's menu placement or removal-scope messaging concerns.

## Visual Proof

| Before | After |
| --- | --- |
| <img width="600" alt="Original project removal dialog" src="https://github.com/user-attachments/assets/752bb439-3618-455a-8bdb-6d72b6f3163a" /> | <img width="600" alt="Project removal dialog with Don't ask again" src="https://github.com/user-attachments/assets/47d54cf0-322a-478c-a806-1562eaa1b094" /> |

<details>
<summary>Korean / dark mode and the setting to restore confirmation</summary>

<img width="800" alt="Korean project removal dialog in dark mode" src="https://github.com/user-attachments/assets/44ee3497-884c-46e8-8cbd-0246d8dd791b" />
<img width="800" alt="Ask Before Removing Projects in General settings" src="https://github.com/user-attachments/assets/7d98e21d-6369-470e-b2dc-660f36e4c47a" />

</details>

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Verified through automated, hidden Electron instances with isolated profiles on macOS:

- **51 tests across 6 files passed:** dialog confirmation/cancellation, Git and folder projects, overlapping local/SSH project IDs, VM warnings, preference restoration, and existing workspace removal behavior.
- **Electron E2E passed:** cancel/reopen, confirm with opt-out, settings navigation, skip after renderer reload, restore confirmation, Escape cancellation, and Korean/dark-mode rendering.
- **Passed:** `pnpm tc`, `pnpm run check:code-quality:changed`, localization catalog/extraction checks, max-lines ratchet, and commit-hook lint/format checks.
- **Built:** Electron in e2e mode and the bundled CLI.

Not run: the full repository test suite, full `pnpm lint`, release/package build, or live Windows/Linux/SSH/mobile validation. The separate `pnpm run typecheck:e2e` reports existing errors outside this spec; `config/tsconfig.e2e.json` documents why that check is not enforced yet.

<details>
<summary>Targeted reproduction commands</summary>

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm test \
  src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.test.tsx \
  src/renderer/src/components/sidebar/RemoveFolderDialog.test.tsx \
  src/renderer/src/components/sidebar/remove-project-flow.test.ts \
  src/renderer/src/components/sidebar/delete-worktree-flow.test.ts \
  src/renderer/src/components/sidebar/worktree-delete-host-qualification.test.ts \
  src/renderer/src/components/confirmation-skip-preference.test.ts
ORCA_BACKGROUND_LAUNCH=1 pnpm run test:e2e tests/e2e/project-removal-confirmation.spec.ts --workers=1
pnpm tc
pnpm run check:code-quality:changed
```

</details>

## Author

GitHub: @Devdha
X (Twitter): not provided.

## AI Disclosure

OpenAI Codex (GPT-6) assisted with implementation, test authoring, automated verification, and the self-review below.

## Review

- **Platforms and integrations:** no new OS-specific APIs, path construction, shortcuts, agent-specific behavior, or Git provider dependencies. Actual runtime validation was on macOS.
- **Local/SSH/remote:** reuse the existing removal action with an explicit host ID and error feedback. Unit tests cover overlapping project IDs on different hosts; live SSH and mobile remain untested.
- **Performance:** resolve the target only when removal is requested; no new polling or background work.
- **UI:** reuse existing checkbox, settings, and toast components. Verify cancellation, restoration, and light/dark rendering.
- **Security and data:** opt-out is off by default and requires explicit confirmation. VM projects always ask. Ordinary project removal still prunes Orca registration/session metadata; preserving files does not imply full recovery of that metadata.
- **Compatibility:** missing preferences continue to show the confirmation. Existing removal RPCs remain in use.

## Agent skill upstream boundary

- [x] Not applicable: no upstream skill-installer material is copied or translated.

## Notes

This contribution contains no version bump or release changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
