### PR TITLE
fix: preserve saved and mirrored conversation names in sidebar

### DIFF
--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -31,6 +31,76 @@ describe('getAgentRowConversationName', () => {
     )
   })
 
+  it.each([
+    ['codex', true],
+    ['codex', false],
+    ['claude', true],
+    ['claude', false]
+  ] as const)('uses the saved %s conversation title with generated titles %s', (agent, enabled) => {
+    const tab = makeTab({
+      aiVaultTitle: { agent, sessionId: 'saved-session', title: '  Slack intake reliability  ' },
+      generatedTitle: 'Generated fallback',
+      title: 'Codex ready'
+    })
+    expect(getAgentRowConversationName(tab, agent, enabled)).toBe('Slack intake reliability')
+  })
+
+  it.each([
+    [{ customTitle: 'Manual rename' }, 'Manual rename'],
+    [{ quickCommandLabel: 'Run tests' }, 'Run tests'],
+    [{ title: 'OC | native session name' }, 'OC | native session name']
+  ] as const)(
+    'keeps explicit and OpenCode titles ahead of saved conversation titles: %s',
+    (override, expected) => {
+      const tab = makeTab({
+        aiVaultTitle: { agent: 'codex', sessionId: 'saved-session', title: 'Saved conversation' },
+        generatedTitle: 'Generated fallback',
+        title: 'Codex ready',
+        ...override
+      })
+      expect(getAgentRowConversationName(tab, 'codex', true)).toBe(expected)
+    }
+  )
+
+  it('falls through a blank saved title to generated and live titles', () => {
+    const tab = makeTab({
+      aiVaultTitle: { agent: 'codex', sessionId: 'saved-session', title: '   ' },
+      generatedTitle: 'Generated fallback',
+      title: 'Fix replay guard'
+    })
+    expect(getAgentRowConversationName(tab, 'codex', true)).toBe('Generated fallback')
+    expect(getAgentRowConversationName(tab, 'codex', false)).toBe('Fix replay guard')
+  })
+
+  it('never uses a tab saved-session name for split-pane rows', () => {
+    const tab = makeTab({
+      aiVaultTitle: { agent: 'codex', sessionId: 'focused-session', title: 'Focused conversation' },
+      title: 'Focused live title'
+    })
+    expect(getAgentRowConversationName(tab, 'codex', true, 'Sibling conversation')).toBe(
+      'Sibling conversation'
+    )
+    expect(getAgentRowConversationName(tab, 'codex', true, null)).toBeNull()
+    expect(getAgentRowConversationName(tab, 'codex', false, '')).toBeNull()
+    expect(getAgentRowConversationName(tab, 'codex', true, undefined)).toBe('Focused conversation')
+  })
+
+  it('preserves generated tab names when suppressing saved split-pane session names', () => {
+    const tab = makeTab({
+      aiVaultTitle: { agent: 'codex', sessionId: 'focused-session', title: 'Focused conversation' },
+      generatedTitle: 'Shared generated name',
+      title: 'Focused live title'
+    })
+    expect(getAgentRowConversationName(tab, 'codex', true, 'Sibling conversation')).toBe(
+      'Shared generated name'
+    )
+    expect(getAgentRowConversationName(tab, 'codex', true, null)).toBe('Shared generated name')
+    expect(getAgentRowConversationName(tab, 'codex', false, 'Sibling conversation')).toBe(
+      'Sibling conversation'
+    )
+    expect(getAgentRowConversationName(tab, 'codex', false, null)).toBeNull()
+  })
+
   it('uses the generated title only when generated titles are enabled', () => {
     const tab = makeTab({ generatedTitle: 'Fix intake flow', title: '✳ Investigate replay bug' })
     expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Fix intake flow')

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -211,6 +211,37 @@ describe('getAgentRowConversationName', () => {
     expect(getAgentRowConversationName(makeTab({ title: 'Agent' }), 'claude', false)).toBeNull()
   })
 
+  it.each(['Audit Slack automation gaps', '  Audit Slack automation gaps  '])(
+    'recovers a mirrored live title also stored as defaultTitle: %s',
+    (defaultTitle) => {
+      const tab = makeTab({ title: 'Audit Slack automation gaps', defaultTitle })
+      expect(getAgentRowConversationName(tab, 'codex', false)).toBe('Audit Slack automation gaps')
+    }
+  )
+
+  it('keeps a split pane name when it matches the mirrored tab default', () => {
+    const tab = makeTab({ title: 'Focused task', defaultTitle: 'Sibling task' })
+    expect(getAgentRowConversationName(tab, 'codex', false, 'Sibling task')).toBe('Sibling task')
+    expect(getAgentRowConversationName(tab, 'codex', false, null)).toBeNull()
+    expect(
+      getAgentRowConversationName(
+        { ...tab, customTitle: 'Manual name' },
+        'codex',
+        false,
+        'Sibling task'
+      )
+    ).toBe('Manual name')
+  })
+
+  it.each(['Done', 'Ready (orca)', 'Codex', 'Codex ready', '~/orca/workspaces', 'Terminal', 'Terminal 72'])(
+    'still suppresses non-name live titles matching the mirrored default: %s',
+    (title) => {
+      expect(
+        getAgentRowConversationName(makeTab({ title, defaultTitle: title }), 'codex', false)
+      ).toBeNull()
+    }
+  )
+
   it('rejects empty, glyph-only, and default terminal titles', () => {
     expect(getAgentRowConversationName(makeTab(), 'claude', false)).toBeNull()
     expect(getAgentRowConversationName(makeTab({ title: '✳' }), 'claude', false)).toBeNull()

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -1,7 +1,7 @@
 // Resolves the stable "conversation name" an agent row can show instead of the
 // live last-message preview. Sources, in the same precedence the tab bar uses
 // (tab-title-resolution.ts): manual rename → quick-command label → OpenCode's
-// semantic session title → Orca's generated title → the agent-set live title.
+// semantic session title → saved AI Vault title → Orca's generated title → live title.
 // Live titles are accepted only when they carry a real name — pure status,
 // identity-echo, and spinner/cwd titles yield null so callers keep the
 // last-message label.
@@ -15,7 +15,7 @@ import type { TerminalTab } from './terminal-tab-types'
 
 export type ConversationNameTab = Pick<
   TerminalTab,
-  'customTitle' | 'quickCommandLabel' | 'generatedTitle' | 'title' | 'defaultTitle'
+  'customTitle' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedTitle' | 'title' | 'defaultTitle'
 >
 
 // Why: synthetic status titles ("Codex ready", "Cursor - action required") are
@@ -133,6 +133,11 @@ export function getAgentRowConversationName(
     paneLiveTitle === undefined ? (tab.title?.trim() ?? '') : (paneLiveTitle?.trim() ?? '')
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle
+  }
+  // A saved session title belongs to one conversation, not sibling split panes.
+  const savedTitle = paneLiveTitle === undefined ? tab.aiVaultTitle?.title.trim() : ''
+  if (savedTitle) {
+    return savedTitle
   }
   const generatedTitle = generatedTitlesEnabled ? tab.generatedTitle?.trim() : ''
   if (generatedTitle) {

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -38,7 +38,7 @@ const AGENT_IDENTITY_ALIASES_LOWER: Readonly<Record<string, readonly string[]>> 
 }
 
 const STATUS_WITH_CONTEXT_RE = /^(?:ready|idle|done)(?:\s+\([^)]*\))?$/i
-const DEFAULT_TERMINAL_TITLE_RE = /^terminal \d+$/i
+const DEFAULT_TERMINAL_TITLE_RE = /^terminal(?: \d+)?$/i
 
 function isIdentityStatusTitle(titleLower: string, identityLower: string): boolean {
   return (
@@ -81,8 +81,7 @@ function isCwdLikeTitle(title: string): boolean {
 function conversationNameFromLiveTitle(
   liveTitle: string,
   agentType: AgentType | null | undefined,
-  agentTypeLabelLower: string,
-  defaultTitle: string | undefined
+  agentTypeLabelLower: string
 ): string | null {
   const stripped = stripLeadingAgentTitleDecorationOrEmpty(liveTitle.trim()).trim()
   if (!stripped) {
@@ -100,9 +99,7 @@ function conversationNameFromLiveTitle(
   ) {
     return null
   }
-  if (defaultTitle && stripped === defaultTitle.trim()) {
-    return null
-  }
+  // Mirrored tabs can retain a real conversation name as their defaultTitle.
   return stripped
 }
 
@@ -149,7 +146,6 @@ export function getAgentRowConversationName(
   return conversationNameFromLiveTitle(
     liveTitle,
     agentType,
-    formatAgentTypeLabel(agentType).toLowerCase(),
-    tab.defaultTitle
+    formatAgentTypeLabel(agentType).toLowerCase()
   )
 }


### PR DESCRIPTION
The paired Mac tab bar can show a meaningful Codex conversation name while its sidebar row shows `Done - Codex`. Remote terminal mirroring seeds the first live title as `defaultTitle`; the sidebar then rejects that same meaningful title. Saved AI Vault names were also omitted by the sidebar resolver.

Use the existing semantic filters to reject status, agent identity, cwd and generic Terminal titles, without vetoing a meaningful live name because it equals `defaultTitle`. Existing mirrored records recover without migration. Also honor saved AI Vault titles for single-pane rows, preserving split-pane identity and explicit-name priority.

Addresses #10250 for these sidebar cases; related #9707. Host `customTitle` transport to paired clients remains a separate limitation and is not changed here. Renaming directly on the Mac client remains a supported workaround before this ships.

Validation:
- Mirror regressions before fix: 3 failed, 28 passed.
- Final conversation-name and tab-title suites: 44 passed across 2 files.
- `git diff --check`: clean.
- Opus independently reviewed the mirrored-title fix; Codex verified filters and added coverage for the bare `Terminal` placeholder. Earlier saved-title change had Fable review.

Follow-up validation on Node 24.20.0 and Vitest 4.1.11: both focused suites pass (44 tests, 327ms) using the exact unchanged shared source in an isolated dependency directory and minimal configuration. The full project runner/typecheck and paired Mac visual verification have not run; upstream CI/review and a client build remain necessary. This PR is ready for review. No installed app was modified.
