### PR TITLE
fix(native-chat): place effort to the right of model picker

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
@@ -220,7 +220,12 @@ describe('NativeChatSessionOptionPickers', () => {
       />
     )
     await waitFor(() =>
-      expect(screen.getAllByTestId('dropdown-root')[1]?.getAttribute('data-open')).toBe('true')
+      expect(
+        screen
+          .getByRole('button', { name: 'Model Opus 4.8' })
+          .closest('[data-testid="dropdown-root"]')
+          ?.getAttribute('data-open')
+      ).toBe('true')
     )
 
     rerender(
@@ -232,7 +237,12 @@ describe('NativeChatSessionOptionPickers', () => {
       />
     )
     await waitFor(() =>
-      expect(screen.getAllByTestId('dropdown-root')[0]?.getAttribute('data-open')).toBe('true')
+      expect(
+        screen
+          .getByRole('button', { name: 'Effort High' })
+          .closest('[data-testid="dropdown-root"]')
+          ?.getAttribute('data-open')
+      ).toBe('true')
     )
   })
 
@@ -270,8 +280,8 @@ describe('NativeChatSessionOptionPickers', () => {
     )
     expect(
       screen
-        .getByRole('button', { name: 'Effort High · Fast' })
-        .compareDocumentPosition(screen.getByRole('button', { name: 'Model Opus 4.8' })) &
+        .getByRole('button', { name: 'Model Opus 4.8' })
+        .compareDocumentPosition(screen.getByRole('button', { name: 'Effort High · Fast' })) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).not.toBe(0)
 

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
@@ -241,6 +241,29 @@ function NativeChatSessionOptionPickersInner({
 
   return (
     <div className="flex min-w-0 items-center gap-0.5">
+      <DropdownMenu
+        key={`model:${requestedModelSequence ?? 'idle'}`}
+        defaultOpen={requestedModelSequence !== null}
+      >
+        <PickerTrigger
+          label={nativeChatModelPillLabel(model)}
+          tooltipLabel={modelTooltip}
+          disabled={isWorking || pendingId !== null}
+          disabledReason={modelReason}
+          dispatched={sessionOptionDispatchUnconfirmed(model)}
+        />
+        <DropdownMenuContent align="start" side="top" collisionPadding={8} className="w-64">
+          {modelReason && !model.settable ? (
+            <DropdownMenuLabel className="font-normal">{modelReason}</DropdownMenuLabel>
+          ) : null}
+          <DescriptorMenuRows
+            descriptor={model}
+            pending={pendingId !== null}
+            setValue={(value) => setOption(model, value)}
+            invokeAction={() => invokeAction(model)}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
       {options.length > 0 ? (
         <DropdownMenu
           key={`options:${requestedOptionsSequence ?? 'idle'}`}
@@ -275,29 +298,6 @@ function NativeChatSessionOptionPickersInner({
           </DropdownMenuContent>
         </DropdownMenu>
       ) : null}
-      <DropdownMenu
-        key={`model:${requestedModelSequence ?? 'idle'}`}
-        defaultOpen={requestedModelSequence !== null}
-      >
-        <PickerTrigger
-          label={nativeChatModelPillLabel(model)}
-          tooltipLabel={modelTooltip}
-          disabled={isWorking || pendingId !== null}
-          disabledReason={modelReason}
-          dispatched={sessionOptionDispatchUnconfirmed(model)}
-        />
-        <DropdownMenuContent align="start" side="top" collisionPadding={8} className="w-64">
-          {modelReason && !model.settable ? (
-            <DropdownMenuLabel className="font-normal">{modelReason}</DropdownMenuLabel>
-          ) : null}
-          <DescriptorMenuRows
-            descriptor={model}
-            pending={pendingId !== null}
-            setValue={(value) => setOption(model, value)}
-            invokeAction={() => invokeAction(model)}
-          />
-        </DropdownMenuContent>
-      </DropdownMenu>
     </div>
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Put the effort selector immediately to the right of the model picker in both legacy and restructured native chat.

## What Changed

Reorder the existing dropdowns in `NativeChatSessionOptionPickers`, shared by both chat modes. Update the existing order assertion and locate slash-command dropdowns by their accessible labels instead of position.

## Why

The composer previously rendered effort before model. Rendering model first also gives keyboard navigation the requested order.

## Linked Issue

Direct user request; no issue supplied.

## Visual Proof

Captured from this worktree in a hidden Electron dev instance via Playwright CDP (`ORCA_BACKGROUND_LAUNCH=1`). Full app screenshots; legacy Claude and restructured Codex.

| Mode | Before | After |
| --- | --- | --- |
| Legacy native chat | ![legacy-before.png](https://github.com/user-attachments/assets/b57cdc5b-0c32-4113-aec5-a62e60647ad3) | ![legacy-after.png](https://github.com/user-attachments/assets/6df6b06d-d657-4b76-b51d-591ad442a584) |
| Restructured native chat | ![structured-before.png](https://github.com/user-attachments/assets/b596267f-b859-433b-9cbe-63f38a2f2522) | ![structured-after.png](https://github.com/user-attachments/assets/5e7b6791-15fa-4ca2-8e70-6a82e0939d98) |

## Testing

- [x] Manually tested on macOS using hidden Electron/CDP: checked rendered order and selected effort in both chat modes.
- [x] Existing tests updated: 17 tests pass across the session-option picker and composer-action suites.
- `pnpm tc:web` passes.
- Targeted oxlint and commit-hook React lint/format checks pass.
- Playwright bounding-box checks confirm effort sits to the right of model on the same row in both modes.
- Linux, Windows, and SSH were not exercised. This changes shared JSX order only; no execution, wire, path, shortcut, or workspace-type behavior changes.

## Review

The same picker is used by legacy `NativeChatResolvedView` and `NativeChatStructuredSession` through `NativeChatComposer`. Dropdown callbacks, styling, and available choices are unchanged.

## Agent skill upstream boundary

- [x] Not applicable; no skill source changes.

## Checklist

- [x] Small and focused
- [x] What and why explained
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform and SSH impact considered
- [ ] Full repository lint/tests/build: CI to cover; targeted checks and renderer typecheck passed locally
