### PR TITLE
fix(ui): preserve Home and End caret navigation in search inputs

### DIFF
--- a/src/renderer/src/components/new-workspace/smart-workspace-name-input-surface.tsx
+++ b/src/renderer/src/components/new-workspace/smart-workspace-name-input-surface.tsx
@@ -226,6 +226,10 @@ export function renderSmartWorkspaceNameInput(
           tryOpenSourcePopover()
         }}
         onKeyDown={(event) => {
+          // Why: cmdk intercepts Home/End at root and prevents native input caret navigation.
+          if (event.key === 'Home' || event.key === 'End') {
+            event.stopPropagation()
+          }
           if (event.key === 'Tab' && event.shiftKey) {
             const activeTrigger = tabsListRef.current?.querySelector<HTMLElement>(
               `[data-smart-name-mode="${mode}"]`

--- a/src/renderer/src/components/ui/command-caret-navigation.test.tsx
+++ b/src/renderer/src/components/ui/command-caret-navigation.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Command, CommandInput, CommandItem, CommandList } from './command'
+
+describe('CommandInput caret navigation', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root!.unmount()
+      })
+      root = null
+    }
+    container?.remove()
+    container = null
+  })
+
+  it('stops propagation for Home and End keys to preserve native text caret navigation', () => {
+    const onKeyDown = vi.fn()
+    const onCommandRootKeyDown = vi.fn()
+
+    act(() => {
+      root!.render(
+        <div onKeyDown={onCommandRootKeyDown}>
+          <Command>
+            <CommandInput onKeyDown={onKeyDown} placeholder="Search..." />
+            <CommandList>
+              <CommandItem value="item-1">Item 1</CommandItem>
+              <CommandItem value="item-2">Item 2</CommandItem>
+            </CommandList>
+          </Command>
+        </div>
+      )
+    })
+
+    const input = container!.querySelector('input[data-slot="command-input"]') as HTMLInputElement
+    expect(input).not.toBeNull()
+
+    // Test Home key
+    const homeEvent = new KeyboardEvent('keydown', { key: 'Home', bubbles: true, cancelable: true })
+    const stopPropagationSpyHome = vi.spyOn(homeEvent, 'stopPropagation')
+    act(() => {
+      input.dispatchEvent(homeEvent)
+    })
+
+    expect(stopPropagationSpyHome).toHaveBeenCalled()
+    expect(onKeyDown).toHaveBeenCalledTimes(1)
+    expect(onCommandRootKeyDown).not.toHaveBeenCalled()
+    expect(homeEvent.defaultPrevented).toBe(false)
+
+    // Test End key
+    const endEvent = new KeyboardEvent('keydown', { key: 'End', bubbles: true, cancelable: true })
+    const stopPropagationSpyEnd = vi.spyOn(endEvent, 'stopPropagation')
+    act(() => {
+      input.dispatchEvent(endEvent)
+    })
+
+    expect(stopPropagationSpyEnd).toHaveBeenCalled()
+    expect(onKeyDown).toHaveBeenCalledTimes(2)
+    expect(onCommandRootKeyDown).not.toHaveBeenCalled()
+    expect(endEvent.defaultPrevented).toBe(false)
+  })
+
+  it('allows ArrowDown and other navigation keys to bubble to cmdk', () => {
+    const onCommandRootKeyDown = vi.fn()
+
+    act(() => {
+      root!.render(
+        <div onKeyDown={onCommandRootKeyDown}>
+          <Command>
+            <CommandInput placeholder="Search..." />
+            <CommandList>
+              <CommandItem value="item-1">Item 1</CommandItem>
+              <CommandItem value="item-2">Item 2</CommandItem>
+            </CommandList>
+          </Command>
+        </div>
+      )
+    })
+
+    const input = container!.querySelector('input[data-slot="command-input"]') as HTMLInputElement
+    expect(input).not.toBeNull()
+
+    const arrowDownEvent = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      bubbles: true,
+      cancelable: true
+    })
+    const stopPropagationSpy = vi.spyOn(arrowDownEvent, 'stopPropagation')
+    act(() => {
+      input.dispatchEvent(arrowDownEvent)
+    })
+
+    expect(stopPropagationSpy).not.toHaveBeenCalled()
+    expect(onCommandRootKeyDown).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/ui/command-caret-navigation.test.tsx
+++ b/src/renderer/src/components/ui/command-caret-navigation.test.tsx
@@ -4,6 +4,8 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Command, CommandInput, CommandItem, CommandList } from './command'
 
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
 describe('CommandInput caret navigation', () => {
   let root: Root | null = null
   let container: HTMLDivElement | null = null

--- a/src/renderer/src/components/ui/command.tsx
+++ b/src/renderer/src/components/ui/command.tsx
@@ -94,6 +94,7 @@ function CommandInput({
   iconClassName,
   trailing,
   ref,
+  onKeyDown,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input> & {
   wrapperClassName?: string
@@ -117,6 +118,13 @@ function CommandInput({
           'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
+        onKeyDown={(event) => {
+          // Why: cmdk intercepts Home/End at root and prevents native input caret navigation.
+          if (event.key === 'Home' || event.key === 'End') {
+            event.stopPropagation()
+          }
+          onKeyDown?.(event)
+        }}
         {...props}
       />
       {trailing}


### PR DESCRIPTION
## ELI5
When typing in search boxes or command palettes, pressing the Home and End keys now moves the text cursor to the beginning and end of your typed text (and selects text with Shift+Home/End) instead of jumping through the search results list.

## What Changed
- In `CommandInput` (`src/renderer/src/components/ui/command.tsx`), stopped propagation of `Home` and `End` keydown events to prevent root `cmdk` from intercepting them and overriding native input caret movement.
- In `smart-workspace-name-input-surface.tsx`, stopped propagation of `Home` and `End` keydown events in the Smart Workspace input field.
- Added automated unit tests in `command-caret-navigation.test.tsx` verifying `Home`/`End` propagation is stopped while allowing navigation keys (`ArrowDown`) and user `onKeyDown` callbacks to function normally.

## Why
`cmdk` registers a listener at the root container that unconditionally captures `Home` and `End` to jump list selection to the first or last item and calls `preventDefault()`. When typing in an `<input>`, users expect `Home` and `End` to navigate the text caret. Stopping propagation before it reaches `cmdk-root` preserves native browser caret behavior without breaking dropdown list navigation.

## Linked Issue
Fixes #19603

## Visual Proof
Works as expected: caret navigates to start/end of input field on `Home`/`End`.


https://github.com/user-attachments/assets/3086233f-cabe-412e-870f-a76356e90077



## Testing
- [x] I manually tested these changes locally on Windows in Quick Open and New Workspace dialogs
- [x] Automated tests added/updated (`command-caret-navigation.test.tsx`)

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered

