### PR TITLE
fix: preserve macOS screenshot thumbnail drops for agents

### DIFF
--- a/config/tsconfig.tc.web.json
+++ b/config/tsconfig.tc.web.json
@@ -11,6 +11,7 @@
     "../src/preload/close-active-tab-payload-admission.ts",
     "../src/preload/e2e-config.ts",
     "../src/preload/gitlab.ts",
+    "../src/preload/native-screenshot-drop.ts",
     "../src/preload/preload-runtime-support.ts",
     "../src/preload/renderer-heap-statistics-reader.ts",
     "../src/preload/renderer-process-memory-reader.ts",

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -41,6 +41,7 @@ import { readWindowsClipboardImageFileAsPng } from './clipboard-windows-image-fi
 import { buildClipboardImageThumbnail } from './clipboard-image-thumbnail'
 import { writeClipboardTextAndVerify } from './clipboard-text-write-verify'
 import { isDashboardPopoutRenderer } from './dashboard-popout-window'
+import { registerNativeScreenshotDropHandler } from './native-screenshot-drop'
 
 let trustedClipboardRendererWebContentsId: number | null = null
 
@@ -87,6 +88,7 @@ function runCommand(command: string, args: string[], stdin?: string): Promise<vo
 }
 
 export function registerClipboardHandlers(store: Store): void {
+  registerNativeScreenshotDropHandler(assertTrustedClipboardSender)
   ipcMain.removeHandler('clipboard:readText')
   ipcMain.removeHandler('clipboard:readSelectionText')
   ipcMain.removeHandler('clipboard:writeText')

--- a/src/main/window/native-screenshot-drop.test.ts
+++ b/src/main/window/native-screenshot-drop.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CLIPBOARD_IMAGE_MAX_SOURCE_BYTES } from '../../shared/clipboard-image'
+
+const mocks = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+  createFromBuffer: vi.fn(),
+  save: vi.fn()
+}))
+vi.mock('electron', () => ({
+  ipcMain: { handle: mocks.handle, removeHandler: mocks.removeHandler },
+  nativeImage: { createFromBuffer: mocks.createFromBuffer }
+}))
+vi.mock('./clipboard-image-temp-file', () => ({ saveClipboardImageBufferAsTempFile: mocks.save }))
+
+import { registerNativeScreenshotDropHandler } from './native-screenshot-drop'
+
+describe('dropped screenshot persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    mocks.createFromBuffer.mockReturnValue({
+      isEmpty: () => false,
+      getSize: () => ({ width: 10, height: 10 }),
+      toPNG: () => Buffer.from('encoded PNG')
+    })
+    mocks.save.mockResolvedValue('/tmp/orca-paste-owned.png')
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  function handler(authorize = vi.fn()): (event: unknown, bytes: unknown) => Promise<string> {
+    registerNativeScreenshotDropHandler(authorize)
+    return mocks.handle.mock.calls[0][1]
+  }
+
+  it('normalizes bytes to PNG using the existing authorized temp-file writer', async () => {
+    const authorize = vi.fn()
+    const event = { sender: 'owning-renderer' }
+    expect(await handler(authorize)(event, new Uint8Array([1, 2, 3]))).toBe(
+      '/tmp/orca-paste-owned.png'
+    )
+    expect(authorize).toHaveBeenCalledWith(event)
+    expect(mocks.save).toHaveBeenCalledWith(Buffer.from('encoded PNG'))
+  })
+
+  it('denies an untrusted sender before decoding or writing', async () => {
+    const authorize = vi.fn(() => {
+      throw new Error('Unauthorized')
+    })
+    await expect(handler(authorize)({}, new Uint8Array([1]))).rejects.toThrow('Unauthorized')
+    expect(mocks.createFromBuffer).not.toHaveBeenCalled()
+    expect(mocks.save).not.toHaveBeenCalled()
+  })
+
+  it.each([null, '/private/file.png', { byteLength: 1 }])(
+    'rejects malformed input %s',
+    async (bytes) => {
+      await expect(handler()({}, bytes)).rejects.toThrow('Invalid dropped screenshot')
+      expect(mocks.save).not.toHaveBeenCalled()
+    }
+  )
+
+  it('rejects oversized input before decoding', async () => {
+    await expect(
+      handler()({}, new Uint8Array(CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1))
+    ).rejects.toThrow('too large')
+    expect(mocks.createFromBuffer).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid image data and oversized dimensions', async () => {
+    const invoke = handler()
+    mocks.createFromBuffer.mockReturnValue({ isEmpty: () => true })
+    await expect(invoke({}, new Uint8Array([1]))).rejects.toThrow('Invalid dropped screenshot')
+    mocks.createFromBuffer.mockReturnValue({
+      isEmpty: () => false,
+      getSize: () => ({ width: 1e9, height: 1e9 })
+    })
+    await expect(invoke({}, new Uint8Array([1]))).rejects.toThrow('too large')
+    expect(mocks.save).not.toHaveBeenCalled()
+  })
+
+  it('rejects calls on other operating systems', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    await expect(handler()({}, new Uint8Array([1]))).rejects.toThrow('Invalid dropped screenshot')
+    expect(mocks.save).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/native-screenshot-drop.ts
+++ b/src/main/window/native-screenshot-drop.ts
@@ -1,0 +1,26 @@
+import { ipcMain, nativeImage, type IpcMainInvokeEvent } from 'electron'
+import {
+  assertClipboardImageByteLengthWithinLimit,
+  assertClipboardImageDimensionsWithinLimit
+} from '../../shared/clipboard-image'
+import { saveClipboardImageBufferAsTempFile } from './clipboard-image-temp-file'
+
+export function registerNativeScreenshotDropHandler(
+  assertTrustedSender: (event: IpcMainInvokeEvent) => void
+): void {
+  const channel = 'terminal:saveDroppedScreenshot'
+  ipcMain.removeHandler(channel)
+  ipcMain.handle(channel, async (event, bytes: unknown) => {
+    assertTrustedSender(event)
+    if (process.platform !== 'darwin' || !(bytes instanceof Uint8Array)) {
+      throw new Error('Invalid dropped screenshot')
+    }
+    assertClipboardImageByteLengthWithinLimit(bytes.byteLength)
+    const image = nativeImage.createFromBuffer(Buffer.from(bytes))
+    if (image.isEmpty()) {
+      throw new Error('Invalid dropped screenshot')
+    }
+    assertClipboardImageDimensionsWithinLimit(image.getSize())
+    return saveClipboardImageBufferAsTempFile(image.toPNG())
+  })
+}

--- a/src/preload/native-screenshot-drop.test.ts
+++ b/src/preload/native-screenshot-drop.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CLIPBOARD_IMAGE_MAX_SOURCE_BYTES } from '../shared/clipboard-image'
+import { preserveNativeScreenshotDrop } from './native-screenshot-drop'
+
+const source =
+  '/var/folders/ab/user/T/TemporaryItems/NSIRD_screencaptureui_123/Screenshot 2026-09-08 at 6.55.16 PM.png'
+
+function droppedFile(size = 3) {
+  return { size, arrayBuffer: vi.fn(async () => new Uint8Array([1, 2, 3]).buffer) }
+}
+
+describe('native screenshot drops', () => {
+  it.each([source, `/private${source}`])('stages File bytes before relaying %s', async (path) => {
+    const file = droppedFile()
+    const save = vi.fn(async () => '/tmp/orca-paste-screenshot.png')
+    const payload = {
+      target: 'terminal' as const,
+      paths: ['/workspace/readme.md', path],
+      tabId: 'original-tab',
+      paneLeafId: 'original-pane'
+    }
+    const result = await preserveNativeScreenshotDrop(
+      payload,
+      new Map([[path, file]]),
+      'darwin',
+      save
+    )
+    expect(save).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]))
+    expect(result).toEqual({
+      ...payload,
+      paths: ['/workspace/readme.md', '/tmp/orca-paste-screenshot.png']
+    })
+    expect(payload.paths[1]).toBe(path)
+  })
+
+  it('preserves composer scope and drop order while saving asynchronously', async () => {
+    const file = droppedFile()
+    let complete!: (value: string) => void
+    const save = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          complete = resolve
+        })
+    )
+    const pending = preserveNativeScreenshotDrop(
+      { target: 'composer', paths: [source, '/tmp/other.png'], scopeKey: 'original-composer' },
+      new Map([[source, file]]),
+      'darwin',
+      save
+    )
+    await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+    complete('/tmp/preserved.png')
+    expect(await pending).toEqual({
+      target: 'composer',
+      paths: ['/tmp/preserved.png', '/tmp/other.png'],
+      scopeKey: 'original-composer'
+    })
+  })
+
+  it.each(['linux', 'win32'])('does not read dropped files on %s', async (platform) => {
+    const file = droppedFile()
+    const save = vi.fn()
+    const payload = { target: 'terminal' as const, paths: [source] }
+    expect(
+      await preserveNativeScreenshotDrop(payload, new Map([[source, file]]), platform, save)
+    ).toBe(payload)
+    expect(file.arrayBuffer).not.toHaveBeenCalled()
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('leaves saved screenshots and non-agent drops alone', async () => {
+    const file = droppedFile()
+    const save = vi.fn()
+    const path = '/Users/alice/Desktop/Screenshot.png'
+    expect(
+      await preserveNativeScreenshotDrop(
+        { target: 'terminal', paths: [path] },
+        new Map([[path, file]]),
+        'darwin',
+        save
+      )
+    ).toEqual({ target: 'terminal', paths: [path] })
+    const payload = {
+      target: 'file-explorer' as const,
+      paths: [source],
+      destinationDir: '/project'
+    }
+    expect(
+      await preserveNativeScreenshotDrop(payload, new Map([[source, file]]), 'darwin', save)
+    ).toBe(payload)
+    expect(file.arrayBuffer).not.toHaveBeenCalled()
+  })
+
+  it('rejects oversized images before reading their bytes', async () => {
+    const file = droppedFile(CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1)
+    const save = vi.fn()
+    await expect(
+      preserveNativeScreenshotDrop(
+        { target: 'terminal', paths: [source] },
+        new Map([[source, file]]),
+        'darwin',
+        save
+      )
+    ).rejects.toThrow('too large')
+    expect(file.arrayBuffer).not.toHaveBeenCalled()
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('does not relay the inaccessible source when reading or saving fails', async () => {
+    const file = droppedFile()
+    const save = vi.fn().mockRejectedValue(new Error('disk full'))
+    const args: Parameters<typeof preserveNativeScreenshotDrop> = [
+      { target: 'terminal' as const, paths: [source] },
+      new Map([[source, file]]),
+      'darwin',
+      save
+    ]
+    await expect(preserveNativeScreenshotDrop(...args)).rejects.toThrow('disk full')
+    file.arrayBuffer.mockRejectedValue(new Error('File no longer available'))
+    await expect(preserveNativeScreenshotDrop(...args)).rejects.toThrow('File no longer available')
+    expect(save).toHaveBeenCalledOnce()
+  })
+})

--- a/src/preload/native-screenshot-drop.ts
+++ b/src/preload/native-screenshot-drop.ts
@@ -1,0 +1,33 @@
+import { assertClipboardImageByteLengthWithinLimit } from '../shared/clipboard-image'
+import type { NativeFileDropPayload } from '../shared/native-file-drop'
+
+type DroppedFile = Pick<File, 'size' | 'arrayBuffer'>
+
+const screenshotPath =
+  /^\/(?:private\/)?var\/folders\/[^/]+\/[^/]+\/T\/TemporaryItems\/NSIRD_screencaptureui_[^/]+\/[^/]+\.(?:png|jpe?g|tiff?|heic)$/i
+
+export async function preserveNativeScreenshotDrop(
+  payload: NativeFileDropPayload,
+  files: ReadonlyMap<string, DroppedFile>,
+  platform: string,
+  saveImage: (bytes: Uint8Array) => Promise<string>
+): Promise<NativeFileDropPayload> {
+  if (platform !== 'darwin' || (payload.target !== 'terminal' && payload.target !== 'composer')) {
+    return payload
+  }
+
+  const paths: string[] = []
+  for (const sourcePath of payload.paths) {
+    const file = files.get(sourcePath)
+    if (!file || !screenshotPath.test(sourcePath)) {
+      paths.push(sourcePath)
+      continue
+    }
+    assertClipboardImageByteLengthWithinLimit(file.size)
+    // Chromium can read the dropped File even when CLI processes cannot open its macOS path.
+    const bytes = new Uint8Array(await file.arrayBuffer())
+    assertClipboardImageByteLengthWithinLimit(bytes.byteLength)
+    paths.push(await saveImage(bytes))
+  }
+  return { ...payload, paths }
+}

--- a/src/preload/preload-runtime-support.ts
+++ b/src/preload/preload-runtime-support.ts
@@ -4,6 +4,7 @@ import { createBrowserFindSubscriptions } from './browser-find-subscriptions'
 import { registerRendererRestartIpcRelays } from './renderer-restart-wiring'
 import { createUpdaterQuitAbortRelay } from '../shared/renderer-restart-preparation'
 import { ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT } from '../shared/updater-renderer-events'
+import { preserveNativeScreenshotDrop } from './native-screenshot-drop'
 import {
   ORCA_INTERNAL_FILE_DRAG_TYPE,
   createNativeFileDropPayload,
@@ -127,10 +128,12 @@ export function installNativeFileDropHandlers(): void {
         return
       }
       const paths: string[] = []
+      const droppedFiles = new Map<string, File>()
       for (let index = 0; index < files.length; index += 1) {
         const filePath = webUtils.getPathForFile(files[index])
         if (filePath) {
           paths.push(filePath)
+          droppedFiles.set(filePath, files[index])
         }
       }
       if (paths.length === 0 || resolution?.target === 'rejected') {
@@ -138,7 +141,11 @@ export function installNativeFileDropHandlers(): void {
       }
       const payload = createNativeFileDropPayload(resolution, paths)
       if (payload) {
-        ipcRenderer.send('terminal:file-dropped-from-preload', payload)
+        void preserveNativeScreenshotDrop(payload, droppedFiles, process.platform, (bytes) =>
+          ipcRenderer.invoke('terminal:saveDroppedScreenshot', bytes)
+        )
+          .then((prepared) => ipcRenderer.send('terminal:file-dropped-from-preload', prepared))
+          .catch((error: unknown) => console.error('Failed to preserve dropped screenshot:', error))
       }
     },
     true


### PR DESCRIPTION
## ELI5

Dragging the floating macOS screenshot thumbnail into a Codex terminal can leave the agent with a path it cannot read (`Operation not permitted`). Preserve the dropped image as an Orca-owned PNG before handing it to the existing agent attachment flow.

## What Changed

- Keep the native dropped `File` long enough to read its bytes in preload, instead of relying on a later CLI read of the protected source path.
- Stage only macOS `TemporaryItems/NSIRD_screencaptureui_*` images dropped into terminals or composers. Preserve the original tab, pane, composer scope, and file order.
- Reuse the clipboard PNG/temp-file writer and its external-path authorization. The new local IPC handler checks the trusted sender, platform, input type, image size, and dimensions.
- Leave ordinary file drops and existing SSH/runtime uploads on their existing paths; remote destinations receive the staged local copy through the existing upload flow.

## Why

Observed on Orca 1.4.198 with local Codex on macOS: dragging the floating screenshot thumbnail produced a path under `/var/folders/.../T/TemporaryItems/NSIRD_screencaptureui_.../`. Both the agent image reader and a plain file read failed with `EPERM`; a screenshot saved to Desktop was readable. The existing drop handler already uses bracketed paste for image paths, but retains the protected original path.

The reporting user verified the built test app on macOS on 2026-09-08: dragging the floating screenshot thumbnail into local Codex worked and the image was readable. The fix relies on Chromium's dropped `File` access instead of assuming a Node/CLI process can open the same path.

## Linked Issue

Related: #2842 (image attachments regressing to visible temporary paths). This report concerns native thumbnail drag/drop and access to the original macOS file, not the clipboard/Ctrl+C case fixed by #2950.

## Visual Proof

Screenshots supplied by the reporting user from the manual macOS check.

**Before — installed Orca:** dragging the floating screenshot thumbnail inserts the protected `TemporaryItems/NSIRD_screencaptureui_*` path. The agent could not read the source file (`Operation not permitted`).

![Before: screenshot thumbnail becomes a protected temporary file path](https://github.com/user-attachments/assets/9db40c38-0839-4a07-a15e-b16fbe5f68b9)

**After — test build from this PR:** the same workflow produces an `[Image #1]` attachment in local Codex. The reporting user also confirmed that the image is readable.

![After: Codex recognizes the dropped screenshot as Image 1](https://github.com/user-attachments/assets/dd765577-3972-4759-b994-22322dfb5b56)

Verified manually: local macOS Codex. Composer and SSH/runtime manual checks remain pending. No layout or styling changes.

## Testing

- [x] The reporting user manually tested the built app: floating macOS screenshot thumbnail → local Codex (0.153.4, GPT-6 Astra), and confirmed the image is readable.
- [x] Automated tests added for staging, route preservation, ordinary files, platform guards, failures, size limits, and trusted IPC access.
- Passed: 63 tests across the two new suites, clipboard IPC/temp-file suites, and terminal native/internal drop suites.
- Passed: full `pnpm typecheck`, `pnpm build`, changed-file oxlint/format checks, and pre-commit checks.
- Full `pnpm lint` stopped at the runtime localization catalog check for existing `TerminalPane.minimumContrast.*` keys. No localization files or keys are changed here.
- Full `pnpm test`: 76,593 passed, 11 failed, 418 skipped; 9 failing files and one unhandled rejection. Failures are outside the changed suites: cross-version fixtures require tags/history absent from this shallow checkout; the real Claude test stopped at workspace trust; WebRTC's baseline observed no UDP packets; a transcript-watcher test observed a duplicate callback; and the runtime localization catalog has the same seven-key drift reported by lint. These failures were inspected but not fixed or all reproduced on baseline, so this is not a green full-suite claim.
- Checks used macOS arm64, Node 22.23.1 (the locally installed Node 24 binary cannot start due to a missing Homebrew dylib), pnpm 12 entrypoint; nested scripts resolved pnpm 9.4.0. Re-run on the supported Node 24 CI environment.

## AI Disclosure

Prepared with OpenAI Codex / GPT-6 Astra, directed by @darker0n.

## Review

Self-review: macOS-only staging with other platforms unchanged; no SSH/mobile wire change; no Git or provider-specific behavior; no worktree-only assumption; agent-neutral PNG paths; sequential, size-bounded image processing outside hot paths. The new IPC accepts image bytes from the trusted app renderer, never an arbitrary destination path. Storage and authorization reuse the existing clipboard implementation. Local macOS thumbnail-drop acceptance was confirmed by the reporting user. Composer and SSH/runtime manual acceptance remain unverified. On staging failure, preload logs the error and does not forward the unreadable original path; user-facing failure feedback could be improved before merge.

## Agent skill upstream boundary

- [x] Not applicable: no skill source or registry changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] All full checks pass (see Testing)

X/Twitter handle: not provided.


