### PR TITLE
Align the Editor-theme with the selected terminal-theme (opt-in)

### DIFF
--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '@/store'
 import { diffViewStateCache, setWithLRU } from '@/lib/scroll-cache'
 import { monaco } from '@/lib/monaco-setup'
 import { computeDiffEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
+import { useMonacoTerminalAlignedTheme } from './use-monaco-terminal-aligned-theme'
 import { useContextualCopySetup } from './useContextualCopySetup'
 import { selectWorktreeDiffComments } from '@/store/worktree-diff-comments-selector'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
@@ -70,6 +71,7 @@ export default function DiffViewer({
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const monacoThemeName = useMonacoTerminalAlignedTheme(settings, isDark)
 
   const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
   const { registerDiffEditor, unregisterDiffEditor } = useDiffEditorRegistration()
@@ -409,7 +411,7 @@ export default function DiffViewer({
             language={language}
             original={originalContent}
             modified={modifiedContent}
-            theme={isDark ? 'vs-dark' : 'vs'}
+            theme={monacoThemeName}
             onMount={handleMount}
             // Why: a file can have multiple live diff tabs, so key models off tab identity (not file path) to avoid cross-tab reuse.
             // Why: Changes mode rotates only the original-side model after HEAD moves, preserving the modified side's undo stack.

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -6,6 +6,7 @@ import type { MarkdownDocument } from '../../../../shared/filesystem-entry-types
 import { useAppStore } from '@/store'
 import '@/lib/monaco-setup'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
+import { useMonacoTerminalAlignedTheme } from './use-monaco-terminal-aligned-theme'
 
 import { useContextualCopySetup } from './useContextualCopySetup'
 import { MonacoGutterContextMenu } from './MonacoGutterContextMenu'
@@ -117,6 +118,7 @@ export default function MonacoEditor({
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const monacoThemeName = useMonacoTerminalAlignedTheme(settings, isDark)
 
   const { queueReveal, cancelScheduledReveal, clearTransientRevealHighlight } =
     useMonacoRevealScheduler()
@@ -231,7 +233,7 @@ export default function MonacoEditor({
         language={language}
         // Why: defaultValue, not controlled value — Orca owns post-mount content sync; a controlled path would double setValue.
         defaultValue={content}
-        theme={isDark ? 'vs-dark' : 'vs'}
+        theme={monacoThemeName}
         onChange={contentSync.handleChange}
         onMount={handleMount}
         options={{

--- a/src/renderer/src/components/editor/use-monaco-terminal-aligned-theme.ts
+++ b/src/renderer/src/components/editor/use-monaco-terminal-aligned-theme.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { monaco } from '@/lib/monaco-setup'
+import { resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
+import { ensureMonacoTerminalAlignedTheme } from '@/lib/monaco-terminal-aligned-theme'
+
+/** Resolves the Monaco theme name for the file editor / diff viewer: the plain light/dark
+ *  editor theme, or (when `editorThemeMatchesTerminal` is on) one mirroring the active terminal theme. */
+export function useMonacoTerminalAlignedTheme(
+  settings: GlobalSettings | null | undefined,
+  isDark: boolean
+): string {
+  return useMemo(() => {
+    const defaultThemeName = isDark ? 'vs-dark' : 'vs'
+    if (!settings?.editorThemeMatchesTerminal) {
+      return defaultThemeName
+    }
+    const terminalAppearance = resolveEffectiveTerminalAppearance(settings)
+    if (!terminalAppearance.theme) {
+      return defaultThemeName
+    }
+    return ensureMonacoTerminalAlignedTheme(
+      monaco,
+      terminalAppearance.themeName,
+      terminalAppearance.theme
+    )
+  }, [isDark, settings])
+}

--- a/src/renderer/src/components/settings/TerminalThemeSections.tsx
+++ b/src/renderer/src/components/settings/TerminalThemeSections.tsx
@@ -290,6 +290,36 @@ export function TerminalThemeCatalogSection({
 
         {advancedContent ? <div className="-mt-4">{advancedContent}</div> : null}
 
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.TerminalThemeSections.editor_theme_matches_terminal',
+            'Match Editor Theme'
+          )}
+          description={translate(
+            'auto.components.settings.TerminalThemeSections.editor_theme_matches_terminal_description',
+            'Color the file editor and diff viewer using the active terminal theme instead of the default light/dark editor theme.'
+          )}
+          keywords={['editor', 'theme', 'terminal', 'match', 'monaco', 'colors']}
+          forceVisible
+        >
+          <SettingsSwitchRow
+            label={translate(
+              'auto.components.settings.TerminalThemeSections.editor_theme_matches_terminal',
+              'Match Editor Theme'
+            )}
+            description={translate(
+              'auto.components.settings.TerminalThemeSections.editor_theme_matches_terminal_description',
+              'Color the file editor and diff viewer using the active terminal theme instead of the default light/dark editor theme.'
+            )}
+            checked={settings.editorThemeMatchesTerminal ?? false}
+            onChange={() =>
+              updateSettings({
+                editorThemeMatchesTerminal: !settings.editorThemeMatchesTerminal
+              })
+            }
+          />
+        </SearchableSetting>
+
         <TerminalSettingsPreview
           title={
             isLightTarget

--- a/src/renderer/src/lib/monaco-terminal-aligned-theme.ts
+++ b/src/renderer/src/lib/monaco-terminal-aligned-theme.ts
@@ -1,0 +1,64 @@
+import type { ITheme } from '@xterm/xterm'
+import type * as monacoEditor from 'monaco-editor'
+import { isTerminalBackgroundLight } from './terminal-title-contrast'
+
+const THEME_NAME_PREFIX = 'orca-terminal-aligned-'
+
+function stripHash(color: string): string {
+  return color.startsWith('#') ? color.slice(1) : color
+}
+
+/** Approximate token→ANSI-color mapping; there's no semantic link between a 16-color terminal
+ *  palette and syntax categories, so this follows the same convention other terminal-theme-to-editor
+ *  converters use (comments dim, strings green, keywords/tags red-ish, etc.). */
+function buildTokenRules(theme: ITheme): monacoEditor.editor.ITokenThemeRule[] {
+  const tokenSources: [string, string | undefined][] = [
+    ['comment', theme.brightBlack ?? theme.black],
+    ['string', theme.green],
+    ['keyword', theme.magenta],
+    ['number', theme.yellow],
+    ['function', theme.blue],
+    ['type', theme.cyan],
+    ['tag', theme.red],
+    ['delimiter', theme.red]
+  ]
+  return tokenSources
+    .filter(([, color]) => Boolean(color))
+    .map(([token, color]) => ({
+      token,
+      foreground: stripHash(color as string),
+      ...(token === 'comment' ? { fontStyle: 'italic' } : {})
+    }))
+}
+
+function buildEditorColors(theme: ITheme): monacoEditor.editor.IColors {
+  const colorSources: [string, string | undefined][] = [
+    ['editor.background', theme.background],
+    ['editor.foreground', theme.foreground],
+    ['editorCursor.foreground', theme.cursor],
+    ['editor.selectionBackground', theme.selectionBackground],
+    ['editorLineNumber.foreground', theme.brightBlack],
+    ['editorLineNumber.activeForeground', theme.foreground]
+  ]
+  const entries = colorSources.filter((entry): entry is [string, string] => Boolean(entry[1]))
+  return Object.fromEntries(entries)
+}
+
+/** Defines (redefining on every call, so edited custom theme colors stay current) and returns the
+ *  Monaco theme name that mirrors `theme`'s colors. Cheap and synchronous — safe to call from a
+ *  render-time memo. */
+export function ensureMonacoTerminalAlignedTheme(
+  monaco: typeof monacoEditor,
+  themeName: string,
+  theme: ITheme
+): string {
+  const monacoThemeName = `${THEME_NAME_PREFIX}${themeName}`
+  const base = isTerminalBackgroundLight(theme.background) ? 'vs' : 'vs-dark'
+  monaco.editor.defineTheme(monacoThemeName, {
+    base,
+    inherit: true,
+    rules: buildTokenRules(theme),
+    colors: buildEditorColors(theme)
+  })
+  return monacoThemeName
+}

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -81,6 +81,7 @@ export function buildDefaultSettings(args: {
     terminalThemeLight: 'Builtin Tango Light',
     terminalCustomThemes: [],
     terminalDividerColorLight: '#d4d4d8',
+    editorThemeMatchesTerminal: false,
     terminalInactivePaneOpacity: args.terminalInactivePaneOpacity,
     terminalActivePaneOpacity: 1,
     terminalPaneOpacityTransitionMs: 140,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -139,6 +139,8 @@ export type GlobalSettings = {
   terminalUseSeparateLightTheme: boolean
   terminalThemeLight: string
   terminalDividerColorLight: string
+  /** When on, the file editor and diff viewer derive their color theme from the active terminal theme instead of the plain light/dark editor default. */
+  editorThemeMatchesTerminal?: boolean
   terminalInactivePaneOpacity: number
   terminalActivePaneOpacity: number
   terminalPaneOpacityTransitionMs: number


### PR DESCRIPTION
## ELI5

<!-- Simple high-level explanation -->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- What problem does this solve, and why is this approach right? -->

## Linked Issue

<!-- Link the issue this PR addresses, there should ALWAYS be one -->

Fixes #

## Visual Proof

<!-- REQUIRED for UI / behavior changes. Please attach a BEFORE and AFTER that can easily tabbed/switched. Use videos for when appropriate over screenshots -->
<!-- If there is truly no visual or interaction change, write exactly: `N/A` and briefly say why. -->
<!-- For attachments NEVER add directly to the PR files (do not commit to files), use `gh image` extension or drag + drop (works for any attachment) -->

## Testing

<!-- How did you verify this? Steps a reviewer can follow. Which platforms did you actually test (macOS / Linux / Windows / SSH)? -->

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->
<!-- Which AI model if anyone was used, please state the details -->

## Review

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
