### PR TITLE
test(e2e): allow background browser titles to settle

### DIFF
--- a/tests/e2e/browser-tab.spec.ts
+++ b/tests/e2e/browser-tab.spec.ts
@@ -285,7 +285,8 @@ async function waitForTabIdByExactTitle(
       const tab = tabs.find((candidate) => candidate.textContent?.trim() === exactTitle)
       return tab?.getAttribute('data-tab-id') ?? null
     }, title)
-  await expect.poll(resolveTabId, { timeout: 10_000 }).not.toBeNull()
+  // Background tabs may commit their document title after the guest load settles.
+  await expect.poll(resolveTabId, { timeout: 30_000 }).not.toBeNull()
   return (await resolveTabId()) as string
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Problem\nThe main E2E shard intermittently failed when a background browser tab's document title had not propagated within 10 seconds.\n\n## Fix\nAllow the title propagation assertion 30 seconds, covering delayed Chromium guest load/title commits under CI contention.\n\n## Validation\n- git diff --check