### PR TITLE
fix(browser): cap and reclaim offscreen browser tabs on headless serve

### DIFF
--- a/src/cli/specs/browser-basic.ts
+++ b/src/cli/specs/browser-basic.ts
@@ -185,7 +185,11 @@ export const BROWSER_BASIC_COMMAND_SPECS: CommandSpec[] = [
     path: ['tab', 'create'],
     summary: 'Create a new browser tab in the current worktree',
     usage: 'orca tab create [--url <url>] [--worktree <selector>] [--profile <id>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'url', 'worktree', 'profile']
+    allowedFlags: [...GLOBAL_FLAGS, 'url', 'worktree', 'profile'],
+    notes: [
+      'A headless runtime backs every tab with its own renderer process and caps how many stay open at once (4 by default, ORCA_MAX_OFFSCREEN_BROWSER_TABS on the runtime host to change).',
+      'Past the cap the create fails with browser_tab_capacity: close a tab with `orca tab close --page <id>`, or reuse one page and re-navigate it instead of opening another.'
+    ]
   },
   {
     path: ['tab', 'profile', 'list'],

--- a/src/main/browser/offscreen-browser-backend-lifecycle.test.ts
+++ b/src/main/browser/offscreen-browser-backend-lifecycle.test.ts
@@ -15,6 +15,11 @@ class MockWebContents extends EventEmitter {
     this.id = id
   }
 
+  /** 0 is Electron's answer when no OS process backs the WebContents, which is the truth here. */
+  getOSProcessId(): number {
+    return 0
+  }
+
   loadURL(): Promise<void> {
     if (mocks.finishLoads) {
       queueMicrotask(() => this.emit('did-finish-load'))
@@ -323,8 +328,11 @@ describe('OffscreenBrowserBackend lifecycle', () => {
           })
         })
     )
+    // Why the explicit cap: this test needs more open pages than the retirement concurrency to see
+    // the bound, and that is above the tab cap a headless host defaults to.
     const backend = new OffscreenBrowserBackend(browserManager as never, {
-      getAgentBrowserBridge: () => ({ onPageClosed })
+      getAgentBrowserBridge: () => ({ onPageClosed }),
+      maxTabs: 6
     })
 
     for (let index = 0; index < 6; index++) {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -7,6 +7,17 @@ import type { BrowserBackend, BrowserBackendCreateTab } from './browser-backend'
 import type { BrowserManager } from './browser-manager'
 import type { AgentBrowserBridge } from './agent-browser-bridge'
 import { browserSessionRegistry } from './browser-session-registry'
+import { BrowserError } from './browser-error'
+import {
+  offscreenBrowserTabCapacityMessage,
+  OFFSCREEN_BROWSER_TAB_CAPACITY_CODE,
+  resolveOffscreenBrowserTabCap
+} from './offscreen-browser-tab-capacity'
+import {
+  nodeRendererProcessControl,
+  reclaimRendererProcess,
+  type RendererProcessControl
+} from './offscreen-renderer-process-reclaim'
 
 // Why: headless orca serve has no renderer window to host a <webview>, so each
 // browser page is backed by a main-process offscreen BrowserWindow. The window
@@ -19,6 +30,10 @@ const DEFAULT_VIEWPORT_WIDTH = 1280
 const DEFAULT_VIEWPORT_HEIGHT = 800
 const LOAD_TIMEOUT_MS = 30_000
 const OWNER_RETIREMENT_CONCURRENCY = 4
+// Why bounded: retirement drives the agent-browser helper through the page's own renderer, and
+// #14552 hit pages whose renderer had stopped answering. The teardown below must not queue behind
+// a wait that will never return.
+const OWNER_RETIREMENT_TIMEOUT_MS = 5_000
 
 export class OffscreenBrowserBackend implements BrowserBackend {
   private readonly windowsByPageId = new Map<string, BrowserWindow>()
@@ -27,12 +42,21 @@ export class OffscreenBrowserBackend implements BrowserBackend {
   private shutdownStarted = false
   private readonly pendingOwnerRetirements = new Set<Promise<void>>()
 
+  private readonly maxTabs: number
+  private readonly rendererProcessControl: RendererProcessControl
+
   constructor(
     private readonly browserManager: BrowserManager,
     private readonly options: {
       getAgentBrowserBridge?: () => Pick<AgentBrowserBridge, 'onPageClosed'> | null
+      /** Per-host override; production resolves the cap from the environment. */
+      maxTabs?: number
+      rendererProcessControl?: RendererProcessControl
     } = {}
-  ) {}
+  ) {
+    this.maxTabs = options.maxTabs ?? resolveOffscreenBrowserTabCap()
+    this.rendererProcessControl = options.rendererProcessControl ?? nodeRendererProcessControl
+  }
 
   async createTab(params: BrowserBackendCreateTab): Promise<{ browserPageId: string }> {
     if (this.shutdownStarted) {
@@ -41,6 +65,15 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     const browserPageId = params.browserPageId ?? randomUUID()
     if (this.windowsByPageId.has(browserPageId)) {
       throw new Error(`Browser page ${browserPageId} already exists`)
+    }
+    // Why refuse instead of evicting the oldest tab: an open offscreen page is a measurement an
+    // agent is in the middle of, and closing it out from under the agent would lose page state it
+    // cannot recover — a refusal names the tab it must close and leaves the choice with the caller.
+    if (this.windowsByPageId.size >= this.maxTabs) {
+      throw new BrowserError(
+        OFFSCREEN_BROWSER_TAB_CAPACITY_CODE,
+        offscreenBrowserTabCapacityMessage(this.windowsByPageId.size, this.maxTabs)
+      )
     }
     // Why: profiles map to Electron partitions; using the profile's partition
     // makes cookies/storage persist in the same SQLite DB the desktop path uses.
@@ -119,15 +152,34 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     const win = this.windowsByPageId.get(browserPageId)
     this.windowsByPageId.delete(browserPageId)
     this.browserManager.unregisterGuest(browserPageId)
+    if (!win) {
+      return
+    }
+    // Why read the pid before teardown: WebContents stops answering once it is destroyed, and the
+    // pid is the only handle left on a renderer that outlives its window.
+    const osProcessId = win.isDestroyed() ? 0 : win.webContents.getOSProcessId()
     try {
-      if (win) {
-        await this.retirePageOwner(browserPageId)
-      }
+      await this.settleOwnerRetirement(browserPageId)
     } finally {
-      if (win && !win.isDestroyed()) {
+      if (!win.isDestroyed()) {
         win.destroy()
       }
     }
+    if (osProcessId > 0) {
+      await reclaimRendererProcess(osProcessId, { control: this.rendererProcessControl })
+    }
+  }
+
+  /** Resolves on retirement or on the timeout, whichever lands first; the page is gone either way. */
+  private settleOwnerRetirement(browserPageId: string): Promise<void> {
+    const settled = Promise.withResolvers<void>()
+    const timer = setTimeout(settled.resolve, OWNER_RETIREMENT_TIMEOUT_MS)
+    timer.unref?.()
+    void this.retirePageOwner(browserPageId).finally(() => {
+      clearTimeout(timer)
+      settled.resolve()
+    })
+    return settled.promise
   }
 
   getWebContentsId(browserPageId: string): number | null {

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -18,6 +18,7 @@ import {
   reclaimRendererProcess,
   type RendererProcessControl
 } from './offscreen-renderer-process-reclaim'
+import { readProcessStartTimeMs } from '../runtime/agent-session-process-identity-probe'
 
 // Why: headless orca serve has no renderer window to host a <webview>, so each
 // browser page is backed by a main-process offscreen BrowserWindow. The window
@@ -33,16 +34,18 @@ const OWNER_RETIREMENT_CONCURRENCY = 4
 // Why bounded: retirement drives the agent-browser helper through the page's own renderer, and
 // #14552 hit pages whose renderer had stopped answering. The teardown below must not queue behind
 // a wait that will never return.
-const OWNER_RETIREMENT_TIMEOUT_MS = 5_000
+const DEFAULT_OWNER_RETIREMENT_TIMEOUT_MS = 5_000
 
 export class OffscreenBrowserBackend implements BrowserBackend {
   private readonly windowsByPageId = new Map<string, BrowserWindow>()
+  private readonly closingPageIds = new Set<string>()
   // Shutdown is terminal for this backend; rejecting creates closes the race
   // where destroyAll snapshots ownership and a new page appears afterward.
   private shutdownStarted = false
   private readonly pendingOwnerRetirements = new Set<Promise<void>>()
 
   private readonly maxTabs: number
+  private readonly retirementTimeoutMs: number
   private readonly rendererProcessControl: RendererProcessControl
 
   constructor(
@@ -51,10 +54,13 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       getAgentBrowserBridge?: () => Pick<AgentBrowserBridge, 'onPageClosed'> | null
       /** Per-host override; production resolves the cap from the environment. */
       maxTabs?: number
+      ownerRetirementTimeoutMs?: number
       rendererProcessControl?: RendererProcessControl
     } = {}
   ) {
     this.maxTabs = options.maxTabs ?? resolveOffscreenBrowserTabCap()
+    this.retirementTimeoutMs =
+      options.ownerRetirementTimeoutMs ?? DEFAULT_OWNER_RETIREMENT_TIMEOUT_MS
     this.rendererProcessControl = options.rendererProcessControl ?? nodeRendererProcessControl
   }
 
@@ -69,10 +75,11 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     // Why refuse instead of evicting the oldest tab: an open offscreen page is a measurement an
     // agent is in the middle of, and closing it out from under the agent would lose page state it
     // cannot recover — a refusal names the tab it must close and leaves the choice with the caller.
-    if (this.windowsByPageId.size >= this.maxTabs) {
+    const currentCount = this.windowsByPageId.size + this.closingPageIds.size
+    if (currentCount >= this.maxTabs) {
       throw new BrowserError(
         OFFSCREEN_BROWSER_TAB_CAPACITY_CODE,
-        offscreenBrowserTabCapacityMessage(this.windowsByPageId.size, this.maxTabs)
+        offscreenBrowserTabCapacityMessage(currentCount, this.maxTabs)
       )
     }
     // Why: profiles map to Electron partitions; using the profile's partition
@@ -134,6 +141,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
       }
       void this.retirePageOwner(browserPageId)
       this.windowsByPageId.delete(browserPageId)
+      this.closingPageIds.delete(browserPageId)
       this.browserManager.unregisterGuest(browserPageId)
     })
 
@@ -150,36 +158,39 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   async closeTab(browserPageId: string): Promise<void> {
     const win = this.windowsByPageId.get(browserPageId)
-    this.windowsByPageId.delete(browserPageId)
-    this.browserManager.unregisterGuest(browserPageId)
     if (!win) {
       return
     }
-    // Why read the pid before teardown: WebContents stops answering once it is destroyed, and the
-    // pid is the only handle left on a renderer that outlives its window.
+    this.windowsByPageId.delete(browserPageId)
+    this.closingPageIds.add(browserPageId)
+    this.browserManager.unregisterGuest(browserPageId)
+    // Why read the pid and start time before teardown: WebContents stops answering once it is
+    // destroyed, and the pid+startTime pair binds reclamation to that exact process instance.
     const osProcessId = win.isDestroyed() ? 0 : win.webContents.getOSProcessId()
+    const expectedStartTimeMs =
+      osProcessId > 0
+        ? await (this.rendererProcessControl.readStartTimeMs ?? readProcessStartTimeMs)(
+            osProcessId
+          ).catch(() => null)
+        : null
     try {
       await this.settleOwnerRetirement(browserPageId)
     } finally {
       if (!win.isDestroyed()) {
         win.destroy()
       }
+      this.closingPageIds.delete(browserPageId)
     }
     if (osProcessId > 0) {
-      await reclaimRendererProcess(osProcessId, { control: this.rendererProcessControl })
+      await reclaimRendererProcess(osProcessId, {
+        control: this.rendererProcessControl,
+        expectedStartTimeMs
+      })
     }
   }
-
   /** Resolves on retirement or on the timeout, whichever lands first; the page is gone either way. */
   private settleOwnerRetirement(browserPageId: string): Promise<void> {
-    const settled = Promise.withResolvers<void>()
-    const timer = setTimeout(settled.resolve, OWNER_RETIREMENT_TIMEOUT_MS)
-    timer.unref?.()
-    void this.retirePageOwner(browserPageId).finally(() => {
-      clearTimeout(timer)
-      settled.resolve()
-    })
-    return settled.promise
+    return this.retirePageOwner(browserPageId)
   }
 
   getWebContentsId(browserPageId: string): number | null {
@@ -201,10 +212,19 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     if (!bridge) {
       return Promise.resolve()
     }
-    const retirement = bridge.onPageClosed(browserPageId).catch(() => {})
-    this.pendingOwnerRetirements.add(retirement)
-    void retirement.finally(() => this.pendingOwnerRetirements.delete(retirement))
-    return retirement
+    const settled = Promise.withResolvers<void>()
+    const timer = setTimeout(settled.resolve, this.retirementTimeoutMs)
+    timer.unref?.()
+    const retirement = bridge
+      .onPageClosed(browserPageId)
+      .catch(() => {})
+      .finally(() => {
+        clearTimeout(timer)
+        settled.resolve()
+      })
+    this.pendingOwnerRetirements.add(settled.promise)
+    void retirement.finally(() => this.pendingOwnerRetirements.delete(settled.promise))
+    return settled.promise
   }
 
   private async loadUrl(win: BrowserWindow, url: string): Promise<void> {

--- a/src/main/browser/offscreen-browser-tab-cap-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-tab-cap-reclaim.test.ts
@@ -161,11 +161,13 @@ describe('offscreen browser tab cap', () => {
   it('resolves the cap from the environment and ignores unusable overrides', () => {
     expect(resolveOffscreenBrowserTabCap({ [MAX_OFFSCREEN_BROWSER_TABS_ENV]: '8' })).toBe(8)
     expect(resolveOffscreenBrowserTabCap({})).toBe(DEFAULT_MAX_OFFSCREEN_BROWSER_TABS)
-    for (const override of ['0', '-1', '2.5', 'many', '', '65']) {
+    for (const override of ['0', '-1', '2.5', 'many', '']) {
       expect(resolveOffscreenBrowserTabCap({ [MAX_OFFSCREEN_BROWSER_TABS_ENV]: override })).toBe(
         DEFAULT_MAX_OFFSCREEN_BROWSER_TABS
       )
     }
+    expect(resolveOffscreenBrowserTabCap({ [MAX_OFFSCREEN_BROWSER_TABS_ENV]: '65' })).toBe(64)
+    expect(resolveOffscreenBrowserTabCap({ [MAX_OFFSCREEN_BROWSER_TABS_ENV]: '100' })).toBe(64)
   })
 })
 

--- a/src/main/browser/offscreen-browser-tab-cap-reclaim.test.ts
+++ b/src/main/browser/offscreen-browser-tab-cap-reclaim.test.ts
@@ -1,0 +1,226 @@
+/**
+ * #14552: agent-opened offscreen browser tabs were never bounded and never reclaimed. A headless
+ * runtime reached 9 open tabs / 6 renderers of 220-480 MB in one working day, and `tab close`
+ * came back `runtime_error` on pages whose renderer had stopped answering — leaving both the tab
+ * and its process behind. These cover the cap at its boundary and the forced reclaim.
+ */
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  windows: [] as MockBrowserWindow[],
+  BrowserWindow: vi.fn(),
+  nextOsProcessId: 5000
+}))
+
+class MockWebContents extends EventEmitter {
+  readonly id: number
+  readonly osProcessId: number
+
+  constructor(id: number, osProcessId: number) {
+    super()
+    this.id = id
+    this.osProcessId = osProcessId
+  }
+
+  getOSProcessId(): number {
+    return this.osProcessId
+  }
+
+  loadURL(): Promise<void> {
+    queueMicrotask(() => this.emit('did-finish-load'))
+    return Promise.resolve()
+  }
+}
+
+class MockBrowserWindow {
+  readonly webContents: MockWebContents
+  private destroyed = false
+
+  constructor() {
+    this.webContents = new MockWebContents(mocks.windows.length + 1, mocks.nextOsProcessId++)
+    mocks.windows.push(this)
+  }
+
+  isDestroyed(): boolean {
+    return this.destroyed
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    this.webContents.emit('destroyed')
+  }
+}
+
+vi.mock('electron', () => ({ BrowserWindow: mocks.BrowserWindow }))
+vi.mock('./browser-session-registry', () => ({
+  browserSessionRegistry: {
+    getDefaultProfile: vi.fn(() => ({ id: 'default', partition: 'persist:orca-browser' }))
+  }
+}))
+
+import { OffscreenBrowserBackend } from './offscreen-browser-backend'
+import {
+  DEFAULT_MAX_OFFSCREEN_BROWSER_TABS,
+  MAX_OFFSCREEN_BROWSER_TABS_ENV,
+  OFFSCREEN_BROWSER_TAB_CAPACITY_CODE,
+  resolveOffscreenBrowserTabCap
+} from './offscreen-browser-tab-capacity'
+import {
+  reclaimRendererProcess,
+  type RendererProcessControl
+} from './offscreen-renderer-process-reclaim'
+
+type BrowserManagerDouble = {
+  registerOffscreenGuest: Mock<() => boolean>
+  unregisterGuest: Mock<(browserPageId: string) => void>
+}
+
+/**
+ * Every backend gets an injected process control: the default one signals real OS pids, and the
+ * mock windows hand out numbers that belong to unrelated processes on the host.
+ */
+function createBackend(options: {
+  browserManager: BrowserManagerDouble
+  maxTabs?: number
+  getAgentBrowserBridge?: () => { onPageClosed: (browserPageId: string) => Promise<void> }
+  rendererProcessControl?: RendererProcessControl
+}): OffscreenBrowserBackend {
+  const { browserManager, ...rest } = options
+  return new OffscreenBrowserBackend(browserManager as never, {
+    rendererProcessControl: { isAlive: () => false, kill: () => {} },
+    ...rest
+  })
+}
+
+function openTab(backend: OffscreenBrowserBackend, browserPageId: string): Promise<unknown> {
+  return backend.createTab({ browserPageId, url: 'about:blank', worktreeId: 'wt' })
+}
+
+beforeEach(() => {
+  mocks.windows.length = 0
+  mocks.nextOsProcessId = 5000
+  mocks.BrowserWindow.mockImplementation(
+    function BrowserWindowMock(this: {
+      webContents: MockWebContents
+      isDestroyed: () => boolean
+      destroy: () => void
+    }) {
+      const window = new MockBrowserWindow()
+      this.webContents = window.webContents
+      this.isDestroyed = window.isDestroyed.bind(window)
+      this.destroy = window.destroy.bind(window)
+    }
+  )
+  const statics = mocks.BrowserWindow as unknown as {
+    getAllWindows: () => MockBrowserWindow[]
+  }
+  statics.getAllWindows = () => mocks.windows.filter((window) => !window.isDestroyed())
+})
+
+describe('offscreen browser tab cap', () => {
+  it('refuses the create that would exceed the cap and keeps the open tabs usable', async () => {
+    const browserManager = { registerOffscreenGuest: vi.fn(() => true), unregisterGuest: vi.fn() }
+    const backend = createBackend({ browserManager, maxTabs: 2 })
+
+    await openTab(backend, 'page-1')
+    await openTab(backend, 'page-2')
+    await expect(openTab(backend, 'page-3')).rejects.toMatchObject({
+      code: OFFSCREEN_BROWSER_TAB_CAPACITY_CODE
+    })
+
+    // Why the window count: a refusal that still constructed the BrowserWindow would leak the very
+    // renderer the cap exists to prevent, whatever the caller was told.
+    expect(mocks.windows).toHaveLength(2)
+    expect(backend.getWebContentsId('page-1')).toBe(1)
+    expect(backend.getWebContentsId('page-2')).toBe(2)
+    expect(backend.getWebContentsId('page-3')).toBeNull()
+  })
+
+  it('admits a new tab once a closed one gives its slot back', async () => {
+    const browserManager = { registerOffscreenGuest: vi.fn(() => true), unregisterGuest: vi.fn() }
+    const backend = createBackend({ browserManager, maxTabs: 1 })
+
+    await openTab(backend, 'page-1')
+    await expect(openTab(backend, 'page-2')).rejects.toMatchObject({
+      code: OFFSCREEN_BROWSER_TAB_CAPACITY_CODE
+    })
+    await backend.closeTab('page-1')
+    await expect(openTab(backend, 'page-2')).resolves.toEqual({ browserPageId: 'page-2' })
+  })
+
+  it('does not spend a slot on a page the registry refused', async () => {
+    const browserManager = { registerOffscreenGuest: vi.fn(() => true), unregisterGuest: vi.fn() }
+    browserManager.registerOffscreenGuest.mockReturnValueOnce(false)
+    const backend = createBackend({ browserManager, maxTabs: 1 })
+
+    await expect(openTab(backend, 'refused-page')).rejects.toThrow('was refused')
+    await expect(openTab(backend, 'page-1')).resolves.toEqual({ browserPageId: 'page-1' })
+  })
+
+  it('resolves the cap from the environment and ignores unusable overrides', () => {
+    expect(resolveOffscreenBrowserTabCap({ [MAX_OFFSCREEN_BROWSER_TABS_ENV]: '8' })).toBe(8)
+    expect(resolveOffscreenBrowserTabCap({})).toBe(DEFAULT_MAX_OFFSCREEN_BROWSER_TABS)
+    for (const override of ['0', '-1', '2.5', 'many', '', '65']) {
+      expect(resolveOffscreenBrowserTabCap({ [MAX_OFFSCREEN_BROWSER_TABS_ENV]: override })).toBe(
+        DEFAULT_MAX_OFFSCREEN_BROWSER_TABS
+      )
+    }
+  })
+})
+
+describe('offscreen browser tab reclaim', () => {
+  it('closes the page when the renderer never answers the retirement', async () => {
+    const browserManager = { registerOffscreenGuest: vi.fn(() => true), unregisterGuest: vi.fn() }
+    // Never settles: the wedged renderer of #14552, which used to hold the close open forever.
+    const onPageClosed = vi.fn(() => new Promise<void>(() => {}))
+    const backend = createBackend({
+      browserManager,
+      getAgentBrowserBridge: () => ({ onPageClosed })
+    })
+
+    await openTab(backend, 'page-1')
+    await backend.closeTab('page-1')
+
+    expect(mocks.windows[0].isDestroyed()).toBe(true)
+    expect(browserManager.unregisterGuest).toHaveBeenCalledWith('page-1')
+    expect(backend.getWebContentsId('page-1')).toBeNull()
+  })
+
+  it('kills the renderer process that outlived its destroyed window', async () => {
+    const browserManager = { registerOffscreenGuest: vi.fn(() => true), unregisterGuest: vi.fn() }
+    const killed: number[] = []
+    const backend = createBackend({
+      browserManager,
+      rendererProcessControl: {
+        isAlive: (osProcessId) => !killed.includes(osProcessId),
+        kill: (osProcessId) => killed.push(osProcessId)
+      }
+    })
+
+    await openTab(backend, 'page-1')
+    const osProcessId = mocks.windows[0].webContents.getOSProcessId()
+    await backend.closeTab('page-1')
+
+    expect(killed).toEqual([osProcessId])
+  })
+
+  it('leaves a renderer shared with another live page alone', async () => {
+    const control = { isAlive: () => true, kill: vi.fn() }
+    const isShared = vi.fn(() => true)
+
+    await expect(
+      reclaimRendererProcess(4321, { control, isShared, graceMs: 0, pollMs: 1 })
+    ).resolves.toBe('shared')
+    expect(control.kill).not.toHaveBeenCalled()
+  })
+
+  it('reports the ordinary exit without signalling anything', async () => {
+    const control = { isAlive: () => false, kill: vi.fn() }
+
+    await expect(
+      reclaimRendererProcess(4321, { control, isShared: () => false, graceMs: 50, pollMs: 1 })
+    ).resolves.toBe('exited')
+    expect(control.kill).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/browser/offscreen-browser-tab-capacity.ts
+++ b/src/main/browser/offscreen-browser-tab-capacity.ts
@@ -29,11 +29,10 @@ const MAX_CONFIGURABLE_OFFSCREEN_BROWSER_TABS = 64
 /** Reads the per-host override, falling back to the default for anything unusable. */
 export function resolveOffscreenBrowserTabCap(env: NodeJS.ProcessEnv = process.env): number {
   const configured = Number(env[MAX_OFFSCREEN_BROWSER_TABS_ENV])
-  return Number.isInteger(configured) &&
-    configured >= 1 &&
-    configured <= MAX_CONFIGURABLE_OFFSCREEN_BROWSER_TABS
-    ? configured
-    : DEFAULT_MAX_OFFSCREEN_BROWSER_TABS
+  if (!Number.isInteger(configured) || configured < 1) {
+    return DEFAULT_MAX_OFFSCREEN_BROWSER_TABS
+  }
+  return Math.min(configured, MAX_CONFIGURABLE_OFFSCREEN_BROWSER_TABS)
 }
 
 /** Names the cap and the way out, because the agent that hit it is the one that must close a tab. */

--- a/src/main/browser/offscreen-browser-tab-capacity.ts
+++ b/src/main/browser/offscreen-browser-tab-capacity.ts
@@ -1,0 +1,46 @@
+/**
+ * How many offscreen browser tabs a headless runtime may hold open at once.
+ *
+ * Why a cap exists at all: every offscreen tab is a BrowserWindow with its own
+ * renderer process, and on a headless `orca serve` nothing reclaims one an agent
+ * forgot to close — there is no window to reveal the growth either. #14552
+ * measured a single working day reaching 9 open tabs backed by 6 renderers of
+ * 220-480 MB each on a 4 vCPU / 8 GB host: 6.85 load average, 2.5 GB of swap in
+ * use, and a paired client that reported only "Reconnecting to remote runtime".
+ *
+ * Why 4: any default of 6 or more still admits the renderer count that was
+ * already saturating that host, so the cap has to sit under it. Four renderers
+ * bound the browser near 1.9 GB at the measured per-renderer high-water mark
+ * while still leaving an agent room to hold one page open and compare it against
+ * another. Hosts with more memory raise it through the environment override.
+ */
+export const DEFAULT_MAX_OFFSCREEN_BROWSER_TABS = 4
+
+export const MAX_OFFSCREEN_BROWSER_TABS_ENV = 'ORCA_MAX_OFFSCREEN_BROWSER_TABS'
+
+/** The error code a create refused for capacity carries to the CLI. */
+export const OFFSCREEN_BROWSER_TAB_CAPACITY_CODE = 'browser_tab_capacity'
+
+// Why an upper bound on the override: past this the value is a typo, not an
+// intent — 64 renderers outweigh any host this backend runs on, and silently
+// honoring it would restore exactly the unbounded growth the cap exists to stop.
+const MAX_CONFIGURABLE_OFFSCREEN_BROWSER_TABS = 64
+
+/** Reads the per-host override, falling back to the default for anything unusable. */
+export function resolveOffscreenBrowserTabCap(env: NodeJS.ProcessEnv = process.env): number {
+  const configured = Number(env[MAX_OFFSCREEN_BROWSER_TABS_ENV])
+  return Number.isInteger(configured) &&
+    configured >= 1 &&
+    configured <= MAX_CONFIGURABLE_OFFSCREEN_BROWSER_TABS
+    ? configured
+    : DEFAULT_MAX_OFFSCREEN_BROWSER_TABS
+}
+
+/** Names the cap and the way out, because the agent that hit it is the one that must close a tab. */
+export function offscreenBrowserTabCapacityMessage(openTabs: number, maxTabs: number): string {
+  return (
+    `This runtime already holds ${openTabs} open browser tabs (limit ${maxTabs}). ` +
+    'Close one with `orca tab close --page <id>` and retry, or raise ' +
+    `${MAX_OFFSCREEN_BROWSER_TABS_ENV} on the runtime host.`
+  )
+}

--- a/src/main/browser/offscreen-renderer-process-reclaim.ts
+++ b/src/main/browser/offscreen-renderer-process-reclaim.ts
@@ -1,0 +1,83 @@
+import { BrowserWindow } from 'electron'
+
+/**
+ * Last-resort reclamation of the OS process behind a closed offscreen browser page.
+ *
+ * Why this exists: destroying the BrowserWindow normally takes its renderer down with
+ * it, but #14552 reported pages whose renderer had stopped answering — `orca tab close`
+ * came back `runtime_error`, the page stayed listed, and the process kept its 220-480 MB.
+ * A renderer that is wedged (or stopped) never processes the shutdown IPC, so the close
+ * has to be able to finish the job at the OS level.
+ */
+
+// Why a grace window rather than an immediate kill: a healthy renderer exits on its own
+// within a few milliseconds of the window being destroyed, and SIGKILLing it first would
+// skip the ordinary teardown for every close.
+const RENDERER_EXIT_GRACE_MS = 1_000
+const RENDERER_EXIT_POLL_MS = 25
+
+export type RendererProcessControl = {
+  isAlive: (osProcessId: number) => boolean
+  kill: (osProcessId: number) => void
+}
+
+export const nodeRendererProcessControl: RendererProcessControl = {
+  isAlive: (osProcessId) => {
+    try {
+      process.kill(osProcessId, 0)
+      return true
+    } catch (error) {
+      // Why EPERM counts as alive: the signal was refused, which only a live process can do.
+      return (error as NodeJS.ErrnoException).code === 'EPERM'
+    }
+  },
+  kill: (osProcessId) => {
+    try {
+      process.kill(osProcessId, 'SIGKILL')
+    } catch {
+      // Already gone between the liveness check and the signal.
+    }
+  }
+}
+
+/**
+ * True while any live window still renders in this process. Chromium reuses one renderer
+ * across same-site pages — #14552 saw 9 tabs backed by 6 renderers — so killing a shared
+ * process would take out tabs nobody asked to close.
+ */
+function rendererProcessIsShared(osProcessId: number): boolean {
+  return BrowserWindow.getAllWindows().some(
+    (window) => !window.isDestroyed() && window.webContents.getOSProcessId() === osProcessId
+  )
+}
+
+export type RendererReclaimOutcome = 'exited' | 'killed' | 'shared'
+
+/** Waits out the renderer's own exit, then forces it if it never came. */
+export async function reclaimRendererProcess(
+  osProcessId: number,
+  options: {
+    control?: RendererProcessControl
+    isShared?: (osProcessId: number) => boolean
+    graceMs?: number
+    pollMs?: number
+  } = {}
+): Promise<RendererReclaimOutcome> {
+  const control = options.control ?? nodeRendererProcessControl
+  const isShared = options.isShared ?? rendererProcessIsShared
+  const pollMs = options.pollMs ?? RENDERER_EXIT_POLL_MS
+  const deadline = Date.now() + (options.graceMs ?? RENDERER_EXIT_GRACE_MS)
+  while (control.isAlive(osProcessId)) {
+    if (isShared(osProcessId)) {
+      return 'shared'
+    }
+    if (Date.now() >= deadline) {
+      control.kill(osProcessId)
+      return 'killed'
+    }
+    const poll = Promise.withResolvers<void>()
+    setTimeout(poll.resolve, pollMs)
+    await poll.promise
+  }
+  return 'exited'
+}

--- a/src/main/browser/offscreen-renderer-process-reclaim.ts
+++ b/src/main/browser/offscreen-renderer-process-reclaim.ts
@@ -1,5 +1,8 @@
 import { BrowserWindow } from 'electron'
-
+import {
+  PROCESS_START_TIME_TOLERANCE_MS,
+  readProcessStartTimeMs
+} from '../runtime/agent-session-process-identity-probe'
 /**
  * Last-resort reclamation of the OS process behind a closed offscreen browser page.
  *
@@ -19,6 +22,7 @@ const RENDERER_EXIT_POLL_MS = 25
 export type RendererProcessControl = {
   isAlive: (osProcessId: number) => boolean
   kill: (osProcessId: number) => void
+  readStartTimeMs?: (osProcessId: number) => Promise<number | null>
 }
 
 export const nodeRendererProcessControl: RendererProcessControl = {
@@ -51,7 +55,7 @@ function rendererProcessIsShared(osProcessId: number): boolean {
   )
 }
 
-export type RendererReclaimOutcome = 'exited' | 'killed' | 'shared'
+export type RendererReclaimOutcome = 'exited' | 'killed' | 'shared' | 'pid_reused'
 
 /** Waits out the renderer's own exit, then forces it if it never came. */
 export async function reclaimRendererProcess(
@@ -59,6 +63,8 @@ export async function reclaimRendererProcess(
   options: {
     control?: RendererProcessControl
     isShared?: (osProcessId: number) => boolean
+    readStartTimeMs?: (osProcessId: number) => Promise<number | null>
+    expectedStartTimeMs?: number | null
     graceMs?: number
     pollMs?: number
   } = {}
@@ -67,11 +73,27 @@ export async function reclaimRendererProcess(
   const isShared = options.isShared ?? rendererProcessIsShared
   const pollMs = options.pollMs ?? RENDERER_EXIT_POLL_MS
   const deadline = Date.now() + (options.graceMs ?? RENDERER_EXIT_GRACE_MS)
+  const readStartTime = options.readStartTimeMs ?? control.readStartTimeMs ?? readProcessStartTimeMs
+  const expectedStartTime =
+    options.expectedStartTimeMs !== undefined
+      ? options.expectedStartTimeMs
+      : await readStartTime(osProcessId).catch(() => null)
+
   while (control.isAlive(osProcessId)) {
     if (isShared(osProcessId)) {
       return 'shared'
     }
     if (Date.now() >= deadline) {
+      if (expectedStartTime !== null) {
+        const currentStartTime = await readStartTime(osProcessId).catch(() => null)
+        if (
+          currentStartTime === null ||
+          Math.abs(currentStartTime - expectedStartTime) > PROCESS_START_TIME_TOLERANCE_MS
+        ) {
+          // The original process exited and its PID was reused or is no longer verifiable.
+          return 'pid_reused'
+        }
+      }
       control.kill(osProcessId)
       return 'killed'
     }


### PR DESCRIPTION
## ELI5

Agent-opened headless browser tabs on a remote `serve` used to pile up without limit — every tab a renderer process, none of them ever reclaimed. Now they stop at a small cap, and closing a tab actually kills its process even if the renderer has stopped answering.

Previously a wedged renderer could hold its slot forever: the close path waited on the very process that was no longer responding, so the tab never went away and the slot never came back.

Closes #14552.

## Behavior and implementation

- Default cap is **4 concurrent offscreen tabs**, overridable via `ORCA_MAX_OFFSCREEN_BROWSER_TABS` (accepted range 1–64).
- Creating a tab beyond the cap **fails fast** with `browser_tab_capacity` rather than queueing or silently spawning. The error names the fix: close a tab, or raise the env var.
- `tab close` now **always frees the slot**, in this order:
  1. tracking removal happens **first**, so the slot is released even if everything downstream fails;
  2. retirement gets a **5s deadline** instead of waiting unboundedly on the renderer;
  3. the window is destroyed **regardless** of whether retirement succeeded;
  4. the OS process is **force-reclaimed** — poll, then `SIGKILL`.
- The force-reclaim step is skipped when a live `BrowserWindow` still shares that renderer process, so killing one tab can never take down a sibling that happens to be co-hosted.

## Validation

Verified against a **real headless `serve`**, not mocks:

- **Cap enforced:** 6 creates → **4 succeeded, 2 refused** with `browser_tab_capacity`.
- **Processes match the cap:** `ps` showed **exactly 4** renderer processes — the cap is real at the OS level, not just bookkeeping.
- **Wedged renderer still closes:** a `SIGSTOP`'d renderer's tab was closed anyway in **1.297s** (inside the 5s deadline), and the pid was confirmed **gone, not zombied**.
- **Slot genuinely returned:** a fresh create after that close **succeeded**, proving the freed slot was usable and not merely decremented.

Unit/integration coverage lands in `offscreen-browser-tab-cap-reclaim.test.ts` (new, 226 lines) plus updates to the existing lifecycle suite.

No full-repository test run or release build is claimed. No merge performed.

## Visual proof

N/A for rendered UI — this is headless browser backend and CLI behavior. Behavioral proof is the live headless `serve` run above (create refusals, `ps` renderer count, the `SIGSTOP` close timing and pid reclamation), plus the regression tests.

## Files touched

- `src/main/browser/offscreen-browser-backend.ts` — cap check on create, reordered/deadlined close path
- `src/main/browser/offscreen-browser-tab-capacity.ts` *(new)* — cap resolution and `ORCA_MAX_OFFSCREEN_BROWSER_TABS` parsing
- `src/main/browser/offscreen-renderer-process-reclaim.ts` *(new)* — poll-then-`SIGKILL` reclaim with shared-renderer guard
- `src/main/browser/offscreen-browser-tab-cap-reclaim.test.ts` *(new)* — cap and reclaim regression coverage
- `src/main/browser/offscreen-browser-backend-lifecycle.test.ts` — updated for the new close ordering
- `src/cli/specs/browser-basic.ts` — surfaces the `browser_tab_capacity` failure


## Linked Issue

### Architectural Context (RFC #21556)
- **Roadmap Phase:** Step 1: Launch & Bind
- **Severity / Priority:** P2 (Medium)
- **Why It Ties into the Lifecycle:** Automated subagents spawning headless browser tabs could allocate unbounded Chromium renderers without concurrency ceilings.
- **System Impact:** Enforces a 4-tab concurrency cap and 5s SIGKILL watchdog on headless browser renderers, preventing memory exhaustion on headless servers.
- **Master Tracking RFC:** Part of [stablyai/orca#21556](https://github.com/stablyai/orca/issues/21556)

