### PR TITLE
feat(status-bar): choose 5-hour, weekly, or both usage windows

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui-pairing-local-fields.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui-pairing-local-fields.test.ts
@@ -39,6 +39,7 @@ describe('client UI RPC pairing-local field seams', () => {
   // Driven off the census so a field added to PAIRING_LOCAL_UI_FIELDS without wiring a seam
   // fails here rather than shipping. Sample values are what a paired web client actually sends.
   const pairingLocalSamples: Record<(typeof PAIRING_LOCAL_UI_FIELDS)[number], unknown> = {
+    statusBarUsageWindows: 'weekly',
     automationHostFilter: { kind: 'host', hostKey: 'authority:desktop|selector:self' },
     hideWorkspacesFromOtherDevices: true,
     manualRepoOrder: [

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -170,6 +170,7 @@ const UiUpdateFields = z
     statusBarVisible: z.boolean().optional(),
     usagePercentageDisplay: z.enum(['used', 'remaining']).optional(),
     statusBarUsageMode: z.enum(['verbose', 'compact']).optional(),
+    statusBarUsageWindows: z.enum(['session', 'weekly', 'both']).optional(),
     dismissedUpdateVersion: NullableString.optional(),
     lastUpdateCheckAt: z.number().finite().nullable().optional(),
     pendingUpdateNudgeId: NullableString.optional(),

--- a/src/renderer/src/components/status-bar/StatusBarProviderSegment.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarProviderSegment.tsx
@@ -6,6 +6,8 @@ import {
   type UsagePercentageDisplay
 } from '../../../../shared/usage-percentage-display'
 import type { StatusBarUsageMode } from '../../../../shared/status-bar-usage-mode'
+import type { StatusBarUsageWindows } from '../../../../shared/status-bar-usage-windows'
+import { selectStatusBarProviderWindows } from './status-bar-provider-windows'
 import { ProviderIcon, clampUsedPercent, getProviderUsageStatusLabel } from './tooltip'
 import { getTightestUsageSection } from './UsageRosterPanel'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
@@ -174,12 +176,14 @@ export function ProviderSegment({
   p,
   compact,
   display,
-  mode = 'verbose'
+  mode = 'verbose',
+  windows = 'both'
 }: {
   p: ProviderRateLimits | null
   compact: boolean
   display: UsagePercentageDisplay
   mode?: StatusBarUsageMode
+  windows?: StatusBarUsageWindows
 }): React.JSX.Element {
   const provider = p?.provider ?? 'claude'
   const statusLabel = p ? getProviderUsageStatusLabel(p) : ''
@@ -228,25 +232,35 @@ export function ProviderSegment({
 
   // Has data (ok, fetching with stale data, or error with stale data)
   const isStale = p.status === 'error'
+  const visibleProvider = selectStatusBarProviderWindows(p, windows)
+  const visibleTightest =
+    visibleProvider === p ? tightest : getTightestUsageSection(visibleProvider)
 
   return (
     <span className="inline-flex items-center gap-1.5">
       <ProviderIcon provider={provider} />
-      {mode === 'verbose' ? (
+      {!visibleTightest ? (
+        tightest ? (
+          <span>--</span>
+        ) : null
+      ) : mode === 'verbose' ? (
         <>
-          {tightest && !compact ? (
-            <MiniBar usedPct={clampUsedPercent(tightest.window.usedPercent)} display={display} />
+          {!compact ? (
+            <MiniBar
+              usedPct={clampUsedPercent(visibleTightest.window.usedPercent)}
+              display={display}
+            />
           ) : null}
-          <VerboseProviderUsage p={p} display={display} />
+          <VerboseProviderUsage p={visibleProvider} display={display} />
         </>
-      ) : tightest ? (
+      ) : (
         <WindowLabel
-          w={tightest.window}
-          label={tightest.label}
+          w={visibleTightest.window}
+          label={visibleTightest.label}
           display={display}
           showLabel={!compact}
         />
-      ) : null}
+      )}
       {isStale && <AlertTriangle size={11} className="text-muted-foreground/80" />}
     </span>
   )

--- a/src/renderer/src/components/status-bar/StatusBarSurface.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarSurface.tsx
@@ -85,6 +85,8 @@ export function StatusBarSurface({
     showResourceUsage,
     showSsh,
     statusBarUsageMode,
+    statusBarUsageWindows,
+    setStatusBarUsageWindows,
     usageMenuFocusHandoff,
     usageMenuOpen,
     usagePercentageDisplay
@@ -141,6 +143,7 @@ export function StatusBarSurface({
                         compact={compact}
                         display={usagePercentageDisplay}
                         mode={statusBarUsageMode}
+                        windows={statusBarUsageWindows}
                       />
                     )
                   )}
@@ -163,6 +166,8 @@ export function StatusBarSurface({
                   display={usagePercentageDisplay}
                   statusBarUsageMode={statusBarUsageMode}
                   onStatusBarUsageModeChange={setStatusBarUsageMode}
+                  statusBarUsageWindows={statusBarUsageWindows}
+                  onStatusBarUsageWindowsChange={setStatusBarUsageWindows}
                   isRefreshing={isRefreshing || anyFetching}
                   onRefresh={handleRefresh}
                   onOpenProvider={handleOpenProviderAccounts}

--- a/src/renderer/src/components/status-bar/StatusBarUsageWindowsControl.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarUsageWindowsControl.tsx
@@ -1,0 +1,31 @@
+import { SettingsSegmentedControl } from '@/components/settings/SettingsFormControls'
+import { translate } from '@/i18n/i18n'
+import type { StatusBarUsageWindows } from '../../../../shared/status-bar-usage-windows'
+
+export function StatusBarUsageWindowsControl({
+  value,
+  onChange
+}: {
+  value: StatusBarUsageWindows
+  onChange: (windows: StatusBarUsageWindows) => void
+}): React.JSX.Element {
+  return (
+    <div className="space-y-1 px-3.5 pb-2.5">
+      <span className="text-[11px] text-muted-foreground">
+        {translate('statusBar.usageWindows.label', 'Footer windows')}
+      </span>
+      <SettingsSegmentedControl<StatusBarUsageWindows>
+        value={value}
+        onChange={onChange}
+        ariaLabel={translate('statusBar.usageWindows.label', 'Footer windows')}
+        size="sm"
+        equalWidth
+        options={[
+          { value: 'session', label: translate('statusBar.usageWindows.session', '5-hour') },
+          { value: 'weekly', label: translate('statusBar.usageWindows.weekly', 'Weekly') },
+          { value: 'both', label: translate('statusBar.usageWindows.both', 'Both') }
+        ]}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
@@ -115,6 +115,8 @@ describe('UsageRow', () => {
           display="used"
           statusBarUsageMode="verbose"
           onStatusBarUsageModeChange={() => {}}
+          statusBarUsageWindows="both"
+          onStatusBarUsageWindowsChange={() => {}}
           isRefreshing={false}
           onRefresh={() => {}}
           onOpenProvider={() => {}}
@@ -269,7 +271,9 @@ describe('UsageRosterPanel density picker', () => {
 
   function renderPanel(
     statusBarUsageMode: 'verbose' | 'compact',
-    onStatusBarUsageModeChange: (mode: 'verbose' | 'compact') => void
+    onStatusBarUsageModeChange: (mode: 'verbose' | 'compact') => void,
+    onStatusBarUsageWindowsChange = vi.fn(),
+    statusBarUsageWindows: 'session' | 'weekly' | 'both' = 'both'
   ): void {
     act(() => {
       root.render(
@@ -279,6 +283,8 @@ describe('UsageRosterPanel density picker', () => {
             display="used"
             statusBarUsageMode={statusBarUsageMode}
             onStatusBarUsageModeChange={onStatusBarUsageModeChange}
+            statusBarUsageWindows={statusBarUsageWindows}
+            onStatusBarUsageWindowsChange={onStatusBarUsageWindowsChange}
             isRefreshing={false}
             onRefresh={() => {}}
             onOpenProvider={() => {}}
@@ -324,5 +330,23 @@ describe('UsageRosterPanel density picker', () => {
       segmentButton('Compact').click()
     })
     expect(onStatusBarUsageModeChange).toHaveBeenLastCalledWith('compact')
+  })
+
+  it('switches footer windows independently of detail mode', () => {
+    const onModeChange = vi.fn()
+    const onWindowsChange = vi.fn()
+    renderPanel('compact', onModeChange, onWindowsChange, 'weekly')
+
+    expect(segmentButton('Weekly').getAttribute('aria-checked')).toBe('true')
+    expect(segmentButton('Both').getAttribute('aria-checked')).toBe('false')
+    for (const [label, value] of [
+      ['5-hour', 'session'],
+      ['Weekly', 'weekly'],
+      ['Both', 'both']
+    ]) {
+      act(() => segmentButton(label).click())
+      expect(onWindowsChange).toHaveBeenLastCalledWith(value)
+    }
+    expect(onModeChange).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
@@ -16,6 +16,8 @@ import { getProviderDisplayName } from './usage-error-copy'
 import { formatPlanLabel, usageTextColorClass } from './usage-roster-formatting'
 import { getUsageRosterRowState, type UsageRosterRowState } from './usage-roster-row-state'
 import type { StatusBarUsageMode } from '../../../../shared/status-bar-usage-mode'
+import type { StatusBarUsageWindows } from '../../../../shared/status-bar-usage-windows'
+import { StatusBarUsageWindowsControl } from './StatusBarUsageWindowsControl'
 
 type ProviderId = ProviderRateLimits['provider']
 export type UsageSection = { label: string; window: RateLimitWindow }
@@ -192,6 +194,8 @@ export function UsageRosterPanel({
   display,
   statusBarUsageMode,
   onStatusBarUsageModeChange,
+  statusBarUsageWindows,
+  onStatusBarUsageWindowsChange,
   isRefreshing,
   onRefresh,
   onOpenProvider,
@@ -205,6 +209,8 @@ export function UsageRosterPanel({
   display: UsagePercentageDisplay
   statusBarUsageMode: StatusBarUsageMode
   onStatusBarUsageModeChange: (mode: StatusBarUsageMode) => void
+  statusBarUsageWindows: StatusBarUsageWindows
+  onStatusBarUsageWindowsChange: (windows: StatusBarUsageWindows) => void
   isRefreshing: boolean
   onRefresh: () => void
   onOpenProvider: (provider: ProviderId) => void
@@ -285,6 +291,10 @@ export function UsageRosterPanel({
           ]}
         />
       </div>
+      <StatusBarUsageWindowsControl
+        value={statusBarUsageWindows}
+        onChange={onStatusBarUsageWindowsChange}
+      />
       <div className="border-t border-border/70" />
       {sorted.map((p) => {
         const state = getUsageRosterRowState(p, usedSections(p).length > 0)

--- a/src/renderer/src/components/status-bar/provider-segment-window-selection.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-window-selection.test.tsx
@@ -1,0 +1,113 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import { ProviderSegment } from './StatusBarProviderSegment'
+import { selectStatusBarProviderWindows } from './status-bar-provider-windows'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, values?: Record<string, string>) => {
+    let result = fallback
+    for (const [key, value] of Object.entries(values ?? {})) {
+      result = result.replace(`{{${key}}}`, value)
+    }
+    return result
+  }
+}))
+vi.mock('@/lib/agent-catalog', () => ({ AgentIcon: () => null }))
+
+const limits: ProviderRateLimits = {
+  provider: 'claude',
+  session: { usedPercent: 90, windowMinutes: 300, resetsAt: null, resetDescription: null },
+  weekly: { usedPercent: 40, windowMinutes: 10080, resetsAt: null, resetDescription: null },
+  updatedAt: 0,
+  error: null,
+  status: 'ok'
+}
+
+describe('footer window selection', () => {
+  it.each(['claude', 'codex'] as const)(
+    'filters %s labels and summary bars to the selected window',
+    (provider) => {
+      for (const windows of ['session', 'weekly'] as const) {
+        for (const mode of ['verbose', 'compact'] as const) {
+          for (const compact of [false, true]) {
+            for (const display of ['used', 'remaining'] as const) {
+              const markup = renderToStaticMarkup(
+                <ProviderSegment
+                  p={{ ...limits, provider }}
+                  compact={compact}
+                  display={display}
+                  mode={mode}
+                  windows={windows}
+                />
+              )
+              const used = windows === 'session' ? 90 : 40
+              const otherUsed = windows === 'session' ? 40 : 90
+              const shown = display === 'used' ? used : 100 - used
+              const hidden = display === 'used' ? otherUsed : 100 - otherUsed
+              const suffix = display === 'used' ? 'used' : 'left'
+              expect(markup).toContain(`${shown}% ${suffix}`)
+              expect(markup).not.toContain(`${hidden}% ${suffix}`)
+              if (mode === 'verbose' && !compact) {
+                expect(markup).toContain(`width:${shown}%`)
+              }
+            }
+          }
+        }
+      }
+    }
+  )
+
+  it('keeps both windows by default and respects remaining percentages', () => {
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={limits} compact={false} display="remaining" />
+    )
+    expect(markup).toContain('10% left')
+    expect(markup).toContain('60% left')
+    expect(selectStatusBarProviderWindows(limits, 'both')).toBe(limits)
+  })
+
+  it('does not fall back to a hidden window while fetching or using stale data', () => {
+    for (const status of ['ok', 'fetching', 'error'] as const) {
+      const markup = renderToStaticMarkup(
+        <ProviderSegment
+          p={{ ...limits, weekly: null, status }}
+          compact={false}
+          display="used"
+          windows="weekly"
+        />
+      )
+      expect(markup).toContain('--')
+      expect(markup).not.toContain('90%')
+      expect(markup).not.toContain('···')
+    }
+  })
+
+  it('includes model-specific weekly limits without mutating the detail snapshot', () => {
+    const provider = { ...limits, fableWeekly: { ...limits.weekly!, usedPercent: 70 } }
+    const weekly = selectStatusBarProviderWindows(provider, 'weekly')
+    expect(weekly.session).toBeNull()
+    expect(weekly.fableWeekly).toBe(provider.fableWeekly)
+    expect(selectStatusBarProviderWindows(provider, 'session').fableWeekly).toBeNull()
+    expect(provider.session).toBe(limits.session)
+  })
+
+  it('preserves monthly-only and named-bucket providers', () => {
+    const monthly: ProviderRateLimits = {
+      ...limits,
+      provider: 'grok',
+      session: null,
+      weekly: null,
+      monthly: { ...limits.session!, windowMinutes: 43200 }
+    }
+    const buckets: ProviderRateLimits = {
+      ...limits,
+      provider: 'gemini',
+      buckets: [{ ...limits.session!, name: 'Pro' }]
+    }
+    for (const windows of ['session', 'weekly'] as const) {
+      expect(selectStatusBarProviderWindows(monthly, windows)).toBe(monthly)
+      expect(selectStatusBarProviderWindows(buckets, windows)).toBe(buckets)
+    }
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-provider-windows.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-windows.ts
@@ -1,0 +1,24 @@
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import type { StatusBarUsageWindows } from '../../../../shared/status-bar-usage-windows'
+
+export function selectStatusBarProviderWindows(
+  provider: ProviderRateLimits,
+  windows: StatusBarUsageWindows
+): ProviderRateLimits {
+  if (
+    windows === 'both' ||
+    provider.buckets?.length ||
+    (!provider.session && !provider.weekly && !provider.fableWeekly)
+  ) {
+    return provider
+  }
+
+  return {
+    ...provider,
+    session: windows === 'session' ? provider.session : null,
+    weekly: windows === 'weekly' ? provider.weekly : null,
+    fableWeekly: windows === 'weekly' ? provider.fableWeekly : null,
+    // Do not substitute a monthly limit for an absent selected window.
+    monthly: null
+  }
+}

--- a/src/renderer/src/components/status-bar/use-status-bar-controller.ts
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller.ts
@@ -5,6 +5,7 @@ import { selectFloatingWorkspaceHasUnread } from '../../store/selectors'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 import { normalizeUsagePercentageDisplay } from '../../../../shared/usage-percentage-display'
 import { normalizeStatusBarUsageMode } from '../../../../shared/status-bar-usage-mode'
+import { normalizeStatusBarUsageWindows } from '../../../../shared/status-bar-usage-windows'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
@@ -23,6 +24,10 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   )
   const statusBarUsageMode = normalizeStatusBarUsageMode(useAppStore((s) => s.statusBarUsageMode))
   const setStatusBarUsageMode = useAppStore((s) => s.setStatusBarUsageMode)
+  const statusBarUsageWindows = normalizeStatusBarUsageWindows(
+    useAppStore((s) => s.statusBarUsageWindows)
+  )
+  const setStatusBarUsageWindows = useAppStore((s) => s.setStatusBarUsageWindows)
   const [usageMenuOpen, setUsageMenuOpen] = useState(false)
   const usageMenuFocusHandoff = useStatusBarMenuFocusHandoff()
   const statusBarVisible = useAppStore((s) => s.statusBarVisible)
@@ -264,6 +269,8 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     showSsh,
     statusBarItems,
     statusBarUsageMode,
+    statusBarUsageWindows,
+    setStatusBarUsageWindows,
     toggleStatusBarItem,
     usageMenuFocusHandoff,
     usageMenuOpen,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17761,5 +17761,13 @@
     "title": "Orca keeps failing to load",
     "stalledMessage": "The app window stopped responding while reloading after a crash.",
     "crashLoopMessage": "The app window crashed repeatedly and stopped reloading automatically."
+  },
+  "statusBar": {
+    "usageWindows": {
+      "label": "Footer windows",
+      "session": "5-hour",
+      "weekly": "Weekly",
+      "both": "Both"
+    }
   }
 }

--- a/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
+++ b/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
@@ -257,6 +257,37 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(store.getState().statusBarUsageMode).toBe('verbose')
   })
 
+  it.each(['session', 'weekly', 'both'] as const)(
+    'persists and restores %s footer windows',
+    (windows) => {
+      const setUI = vi.fn().mockResolvedValue(undefined)
+      vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+      const store = createUIStore()
+      expect(store.getState().statusBarUsageWindows).toBe('both')
+
+      store.getState().setStatusBarUsageWindows(windows)
+      expect(store.getState().statusBarUsageWindows).toBe(windows)
+      expect(setUI).toHaveBeenCalledWith({ statusBarUsageWindows: windows })
+
+      const restored = createUIStore()
+      restored.getState().hydratePersistedUI(makePersistedUI(setUI.mock.calls[0][0]))
+      expect(restored.getState().statusBarUsageWindows).toBe(windows)
+    }
+  )
+
+  it.each([undefined, null, 'unknown'])(
+    'defaults legacy or invalid footer windows (%s) to both',
+    (value) => {
+      const store = createUIStore()
+      store.getState().hydratePersistedUI(
+        makePersistedUI({
+          statusBarUsageWindows: value as PersistedUIState['statusBarUsageWindows']
+        })
+      )
+      expect(store.getState().statusBarUsageWindows).toBe('both')
+    }
+  )
+
   it('clamps persisted workspace board column width', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
@@ -20,6 +20,7 @@ import type { CustomPet } from '../../../../../shared/pet-types'
 import type { ReleaseChannel } from '../../../../../shared/release-channel'
 import type { ChangelogData, UpdateStatus } from '../../../../../shared/update-status-types'
 import type { StatusBarUsageMode } from '../../../../../shared/status-bar-usage-mode'
+import type { StatusBarUsageWindows } from '../../../../../shared/status-bar-usage-windows'
 import type { PersistedUIWriteBaseline } from '../persisted-ui-write-baseline'
 import type { UISliceCore } from './ui-slice-contract-core'
 
@@ -106,6 +107,8 @@ export type UISlicePreferences = {
   setUsagePercentageDisplay: (display: UsagePercentageDisplay) => void
   statusBarUsageMode: StatusBarUsageMode
   setStatusBarUsageMode: (mode: StatusBarUsageMode) => void
+  statusBarUsageWindows: StatusBarUsageWindows
+  setStatusBarUsageWindows: (windows: StatusBarUsageWindows) => void
 }
 
 export type UISliceSurfaces = {

--- a/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
@@ -35,6 +35,7 @@ import { clampCombinedDiffFileTreeWidth } from '../../../../../shared/combined-d
 import { parsePersistedAutomationHostFilter } from '../../../../../shared/automation-host-filter'
 import { normalizeUsagePercentageDisplay } from '../../../../../shared/usage-percentage-display'
 import { normalizeStatusBarUsageMode } from '../../../../../shared/status-bar-usage-mode'
+import { normalizeStatusBarUsageWindows } from '../../../../../shared/status-bar-usage-windows'
 import { normalizeBrowserPageZoomLevel } from '../../../../../shared/browser-page-zoom'
 import { normalizeKagiSessionLink } from '../../../../../shared/browser-url'
 import { isReleaseChannel } from '../../../../../shared/release-channel'
@@ -203,6 +204,7 @@ export function createUiHydrationActions(set: UISliceSet, _get: UISliceGet): Par
           statusBarVisible: ui.statusBarVisible ?? true,
           usagePercentageDisplay: normalizeUsagePercentageDisplay(ui.usagePercentageDisplay),
           statusBarUsageMode: normalizeStatusBarUsageMode(ui.statusBarUsageMode),
+          statusBarUsageWindows: normalizeStatusBarUsageWindows(ui.statusBarUsageWindows),
           // Why: default true so existing users see the pet on first enabling the flag; only an explicit Hide persists false.
           petVisible: ui.petVisible ?? ui.sidekickVisible ?? true,
           petSize: clampPetSize(ui.petSize ?? ui.sidekickSize ?? PET_SIZE_DEFAULT, {

--- a/src/renderer/src/store/slices/ui/ui-slice-preference-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-preference-actions.ts
@@ -22,6 +22,10 @@ import {
 } from '../../../../../shared/status-bar-usage-mode'
 import type { WorkspaceHostScope } from '../../../../../shared/ui-chrome-types'
 import {
+  DEFAULT_STATUS_BAR_USAGE_WINDOWS,
+  normalizeStatusBarUsageWindows
+} from '../../../../../shared/status-bar-usage-windows'
+import {
   normalizeExecutionHostOrder,
   normalizeExecutionHostScope,
   normalizeVisibleExecutionHostIds
@@ -296,6 +300,12 @@ export function createUiPreferenceActions(set: UISliceSet, get: UISliceGet): Par
       })
     },
     statusBarUsageMode: DEFAULT_STATUS_BAR_USAGE_MODE,
+    statusBarUsageWindows: DEFAULT_STATUS_BAR_USAGE_WINDOWS,
+    setStatusBarUsageWindows: (windows) => {
+      const normalized = normalizeStatusBarUsageWindows(windows)
+      window.api.ui.set({ statusBarUsageWindows: normalized }).catch(console.error)
+      set({ statusBarUsageWindows: normalized })
+    },
     setStatusBarUsageMode: (mode) => {
       const normalized = normalizeStatusBarUsageMode(mode)
       window.api.ui.set({ statusBarUsageMode: normalized }).catch(console.error)

--- a/src/renderer/src/web/preload-api/web-preference-normalization.ts
+++ b/src/renderer/src/web/preload-api/web-preference-normalization.ts
@@ -15,6 +15,7 @@ import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { PairedUiState, PairingLocalUiField } from '../../../../shared/pairing-local-ui-fields'
 import type { PersistedUIState } from '../../../../shared/persisted-ui-state-types'
 import { normalizeStatusBarUsageMode } from '../../../../shared/status-bar-usage-mode'
+import { normalizeStatusBarUsageWindows } from '../../../../shared/status-bar-usage-windows'
 import { normalizeTerminalCustomThemes } from '../../../../shared/terminal-custom-themes'
 import {
   normalizeTuiAgentArgsRecord,
@@ -54,6 +55,9 @@ export function mergeWebUIState(
     ),
     statusBarUsageMode: normalizeStatusBarUsageMode(
       safeUpdates.statusBarUsageMode ?? base.statusBarUsageMode
+    ),
+    statusBarUsageWindows: normalizeStatusBarUsageWindows(
+      safeUpdates.statusBarUsageWindows ?? base.statusBarUsageWindows
     )
   }
 }
@@ -65,6 +69,7 @@ export function mergeHostWebUIState(
   // Why `satisfies Record<...>` rather than a `Pick<...>` annotation: every member is optional in
   // PersistedUIState, so Pick would accept a literal that silently skipped a newly added member.
   const pinned = {
+    statusBarUsageWindows: normalizeStatusBarUsageWindows(local.statusBarUsageWindows),
     automationHostFilter: local.automationHostFilter,
     hideWorkspacesFromOtherDevices: local.hideWorkspacesFromOtherDevices === true,
     manualRepoOrder: local.manualRepoOrder,

--- a/src/renderer/src/web/web-preload-api-ui.test.ts
+++ b/src/renderer/src/web/web-preload-api-ui.test.ts
@@ -14,9 +14,7 @@ import {
 } from './web-preload-api-test-harness'
 
 describe('web before-unload persistence', () => {
-  beforeEach(() => {
-    vi.resetModules()
-  })
+  beforeEach(() => vi.resetModules())
 
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -461,6 +459,7 @@ describe('web UI preload API', () => {
   // without wiring the web read seam fails here rather than shipping. The host sample differs from
   // the browser's for every field, so only the pin makes this pass.
   const browserLocalUiSamples: Record<PairingLocalUiField, unknown> = {
+    statusBarUsageWindows: 'weekly',
     automationHostFilter: { kind: 'host', hostKey: 'browser-local-host-key' },
     hideWorkspacesFromOtherDevices: true,
     manualRepoOrder: [{ hostId: 'runtime:web-env-1', repoId: 'repo-b' }],
@@ -476,6 +475,7 @@ describe('web UI preload API', () => {
     manuallyUnreadTurnsByPaneKey: { 'tab-1:leaf-1': 321 }
   }
   const hostUiSamples: Record<PairingLocalUiField, unknown> = {
+    statusBarUsageWindows: 'session',
     automationHostFilter: { kind: 'all' },
     hideWorkspacesFromOtherDevices: false,
     manualRepoOrder: [{ hostId: 'local', repoId: 'repo-a' }],

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,6 +14,7 @@ import { DEFAULT_WORKTREE_CARD_PROPERTIES } from './worktree/card-properties'
 import { DEFAULT_AGENTS_GROUP_BY, DEFAULT_AGENTS_READ_FILTER } from './agents-view-thread-filters'
 import { DEFAULT_USAGE_PERCENTAGE_DISPLAY } from './usage-percentage-display'
 import { DEFAULT_STATUS_BAR_USAGE_MODE } from './status-bar-usage-mode'
+import { DEFAULT_STATUS_BAR_USAGE_WINDOWS } from './status-bar-usage-windows'
 import { buildDefaultSettings } from './default-global-settings'
 import { DEFAULT_SETUP_AGENT_STARTUP_POLICY } from './setup-agent-startup-policy'
 import { DEFAULT_BROWSER_PAGE_ZOOM_LEVEL } from './browser-page-zoom'
@@ -70,10 +71,7 @@ function defaultTerminalFontFamily(): string {
   if (platform === 'win32') {
     return 'Cascadia Mono'
   }
-  if (platform === 'linux') {
-    return 'DejaVu Sans Mono'
-  }
-  return 'SF Mono' // macOS default
+  return platform === 'linux' ? 'DejaVu Sans Mono' : 'SF Mono'
 }
 
 export const getDefaultPrimarySelectionMiddleClickPaste = (
@@ -295,7 +293,7 @@ export function getDefaultUIState(): PersistedUIState {
     statusBarVisible: true,
     usagePercentageDisplay: DEFAULT_USAGE_PERCENTAGE_DISPLAY,
     statusBarUsageMode: DEFAULT_STATUS_BAR_USAGE_MODE,
-    statusBarUsageWindows: 'both',
+    statusBarUsageWindows: DEFAULT_STATUS_BAR_USAGE_WINDOWS,
     dismissedUpdateVersion: null,
     lastUpdateCheckAt: null,
     trustedOrcaHooks: {},

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -295,6 +295,7 @@ export function getDefaultUIState(): PersistedUIState {
     statusBarVisible: true,
     usagePercentageDisplay: DEFAULT_USAGE_PERCENTAGE_DISPLAY,
     statusBarUsageMode: DEFAULT_STATUS_BAR_USAGE_MODE,
+    statusBarUsageWindows: 'both',
     dismissedUpdateVersion: null,
     lastUpdateCheckAt: null,
     trustedOrcaHooks: {},

--- a/src/shared/pairing-local-ui-fields.test.ts
+++ b/src/shared/pairing-local-ui-fields.test.ts
@@ -6,6 +6,7 @@ describe('pairing-local UI fields', () => {
   // preload, so a field added here without wiring every seam would otherwise ship silently.
   it('census: the set is exactly the fields no pairing may exchange', () => {
     expect([...PAIRING_LOCAL_UI_FIELDS]).toEqual([
+      'statusBarUsageWindows',
       'automationHostFilter',
       'hideWorkspacesFromOtherDevices',
       'manualRepoOrder',

--- a/src/shared/pairing-local-ui-fields.ts
+++ b/src/shared/pairing-local-ui-fields.ts
@@ -6,6 +6,8 @@ import type { PersistedUIState } from './persisted-ui-state-types'
 // the receiver's answer with one computed for somebody else. They must be stripped on the way to a
 // host (ui.set) and pinned to the local value on the way back (ui.get).
 export const PAIRING_LOCAL_UI_FIELDS = [
+  // Footer presentation belongs to this viewport; older hosts reject new UI keys.
+  'statusBarUsageWindows',
   // Its hostKey names authorities only the writing client can resolve — a paired
   // client's `desktop` is a different machine — and old hosts reject the unknown key.
   'automationHostFilter',

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -5,6 +5,7 @@ import type { ContextualTourId } from './contextual-tours'
 import type { FeatureInteractionState } from './feature-interactions'
 import type { UsagePercentageDisplay } from './usage-percentage-display'
 import type { StatusBarUsageMode } from './status-bar-usage-mode'
+import type { StatusBarUsageWindows } from './status-bar-usage-windows'
 import type { PersistedTrustedOrcaHooks } from './orca-yaml-hook-types'
 import type { CustomPet } from './pet-types'
 import type {
@@ -124,6 +125,7 @@ export type PersistedUIState = {
   usagePercentageDisplay?: UsagePercentageDisplay
   /** Client-side footer presentation; verbose preserves the pre-roster all-window default. */
   statusBarUsageMode?: StatusBarUsageMode
+  statusBarUsageWindows?: StatusBarUsageWindows
   dismissedUpdateVersion: string | null
   lastUpdateCheckAt: number | null
   /** Dev-only update channel override; absent means the build's own channel. */

--- a/src/shared/status-bar-usage-windows.ts
+++ b/src/shared/status-bar-usage-windows.ts
@@ -1,0 +1,7 @@
+export type StatusBarUsageWindows = 'session' | 'weekly' | 'both'
+
+export const DEFAULT_STATUS_BAR_USAGE_WINDOWS: StatusBarUsageWindows = 'both'
+
+export function normalizeStatusBarUsageWindows(value: unknown): StatusBarUsageWindows {
+  return value === 'session' || value === 'weekly' ? value : DEFAULT_STATUS_BAR_USAGE_WINDOWS
+}

--- a/tests/e2e/status-bar-usage-windows.spec.ts
+++ b/tests/e2e/status-bar-usage-windows.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+test('selects footer windows independently of percentage display and restores the choice', async ({
+  orcaPage,
+  electronApp
+}, testInfo) => {
+  await waitForSessionReady(orcaPage)
+  await orcaPage.setViewportSize({ width: 1100, height: 800 })
+  async function seedUsage() {
+    await orcaPage.evaluate(() => {
+      const store = window.__store!
+      const windowOf = (usedPercent: number, windowMinutes: number) => ({
+        usedPercent,
+        windowMinutes,
+        resetsAt: null,
+        resetDescription: null
+      })
+      store.setState({
+        statusBarVisible: true,
+        statusBarItems: ['claude', 'codex'],
+        detectedAgentIds: ['claude', 'codex'],
+        rateLimits: {
+          ...store.getState().rateLimits,
+          claude: {
+            provider: 'claude',
+            session: windowOf(90, 300),
+            weekly: windowOf(40, 10080),
+            status: 'ok',
+            error: null,
+            updatedAt: Date.now()
+          },
+          codex: {
+            provider: 'codex',
+            session: windowOf(70, 300),
+            weekly: windowOf(30, 10080),
+            status: 'ok',
+            error: null,
+            updatedAt: Date.now()
+          }
+        }
+      })
+    })
+  }
+  await seedUsage()
+  const footer = orcaPage.getByRole('button', { name: 'Usage', exact: true })
+  for (const display of ['used', 'remaining'] as const) {
+    for (const mode of ['verbose', 'compact'] as const) {
+      await orcaPage.evaluate(
+        ({ display, mode }) => {
+          window.__store!.getState().setUsagePercentageDisplay(display)
+          window.__store!.getState().setStatusBarUsageMode(mode)
+        },
+        { display, mode }
+      )
+      for (const [label, value] of [
+        ['5-hour', 'session'],
+        ['Weekly', 'weekly'],
+        ['Both', 'both']
+      ] as const) {
+        await footer.click()
+        const picker = orcaPage.getByRole('radiogroup', { name: 'Footer windows' })
+        await picker.getByRole('radio', { name: label, exact: true }).click()
+        await expect(picker.getByRole('radio', { name: label, exact: true })).toBeChecked()
+        await orcaPage.keyboard.press('Escape')
+        const sessionPercent = display === 'used' ? '90% used' : '10% left'
+        const weeklyPercent = display === 'used' ? '40% used' : '60% left'
+        if (value === 'weekly') {
+          await expect(footer).toContainText(weeklyPercent)
+          await expect(footer).not.toContainText(sessionPercent)
+        } else {
+          await expect(footer).toContainText(sessionPercent)
+          const weeklyExpectation =
+            value === 'both' && mode === 'verbose' ? expect(footer) : expect(footer).not
+          await weeklyExpectation.toContainText(weeklyPercent)
+        }
+      }
+    }
+  }
+
+  await orcaPage.evaluate(() => {
+    window.__store!.getState().setStatusBarUsageMode('verbose')
+    window.__store!.getState().setStatusBarUsageWindows('weekly')
+  })
+  await expect
+    .poll(() => orcaPage.evaluate(async () => (await window.api.ui.get()).statusBarUsageWindows))
+    .toBe('weekly')
+  await orcaPage.reload()
+  await waitForSessionReady(orcaPage)
+  await seedUsage()
+  await expect(footer).toContainText('60% left')
+  await expect(footer).not.toContainText('10% left')
+
+  for (const theme of ['light', 'dark'] as const) {
+    await orcaPage.evaluate((theme) => window.__store!.getState().updateSettings({ theme }), theme)
+    for (const windows of ['both', 'weekly'] as const) {
+      await orcaPage.evaluate(
+        (windows) => window.__store!.getState().setStatusBarUsageWindows(windows),
+        windows
+      )
+      await footer.press('Enter')
+      await expect(orcaPage.getByRole('radiogroup', { name: 'Footer windows' })).toBeVisible()
+      await electronApp.evaluate(({ BrowserWindow }) => {
+        for (const window of BrowserWindow.getAllWindows()) {
+          window.webContents.invalidate()
+        }
+      })
+      await orcaPage.screenshot({
+        path: testInfo.outputPath(`${theme}-${windows}.png`),
+        animations: 'disabled'
+      })
+      await testInfo.attach(`${theme}-${windows}`, {
+        path: testInfo.outputPath(`${theme}-${windows}.png`),
+        contentType: 'image/png'
+      })
+      await orcaPage.keyboard.press('Escape')
+    }
+  }
+})


### PR DESCRIPTION
## ELI5

Users can choose whether the bottom-left usage footer shows their 5-hour allowance, weekly allowance, or both. The choice is saved, so it survives reloads and upgrades. Someone watching their weekly budget can keep that number visible even when their 5-hour limit is more consumed.

## What Changed

- Add a **Footer windows** selector beside the existing Detailed/Compact control: **5-hour**, **Weekly**, **Both** (default).
- Reuse the existing UI persistence, hydration, segmented control, window labels, and percentage formatting. Filter only the footer's numbers and summary bar; keep the full provider snapshot and usage details intact.
- Preserve Used/Remaining and density behavior. Compact still selects the tightest eligible window; Both + Detailed shows both windows. Monthly-only and named-bucket providers retain their existing display. A missing selected window shows `--` rather than substituting the hidden limit.
- Keep the preference local to each paired client's viewport, using the existing pairing-local field mechanism. Older hosts never receive the new key.

## Why

Detailed/Compact controls density, and Used/Remaining controls how percentages are expressed. Neither lets users choose which time window matters to them. A small independent preference fits the existing architecture without changing usage collection or adding a custom-format language.

Related: #16937 / #16768 propose a broader usage-format template. This PR provides a focused three-choice control and does not include those theme/template changes.

## Linked Issue

Fixes #19630

## Visual Proof

| Theme | Before | After (Weekly) |
| --- | --- | --- |
| Dark | ![before-dark.png](https://github.com/user-attachments/assets/7c106d6e-d4b2-4b41-9c9c-005c4dcc0358) | ![after-dark.png](https://github.com/user-attachments/assets/f31b122c-0bc3-44c2-97ab-55cc3fa58538) |
| Light | ![before-light.png](https://github.com/user-attachments/assets/5e4ac360-2a98-45d4-9420-bd5d0fe96cbd) | ![after-light.png](https://github.com/user-attachments/assets/952fff3b-18cf-493a-bad9-a0bf689c209f) |

Windows, isolated test profiles, identical synthetic quotas. Before uses the base revision's footer components; after selects Weekly. Screenshots captured from hidden Electron renderers through Playwright, with animations finished for capture. Images are attachments, not committed files.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Agent-driven UI testing on Windows; no physical macOS/Linux or live SSH run was performed.

- **Pass:** 158 tests across seven focused suites covering window filtering, Used/Remaining, Detailed/Compact, narrow layouts, missing/stale data, monthly/bucket compatibility, persistence/defaults, and pairing-local isolation.
- **Pass:** hidden Electron E2E selecting all three windows with both percentage modes and both density modes, then reloading and verifying persistence; light/dark visual checks.
- **Pass:** `pnpm typecheck`, `pnpm build`, changed-file Oxlint and type-aware lint, formatting, localization catalog/runtime/extraction/coverage checks, `git diff --check`.
- **Full-check limitations:** `pnpm lint` reaches the generated skill bundle manifest check and fails on the untouched `resources/skills/{current-manifest,snapshot-registry,release-mapping}.json` artifacts in this checkout. `pnpm test` was attempted and stopped after roughly ten minutes following numerous failures outside the changed files (including SSH process mocks, structured agent sessions, Windows shell/path contracts, and generated skill fixtures). No full-suite pass is claimed. The separate E2E-wide typecheck also reports pre-existing errors outside the added spec. CI should cover the supported platform matrix.

To reproduce the UI flow: open the footer Usage menu, choose each Footer windows option, switch Used/Remaining and Detailed/Compact, then reload. In Weekly mode, the footer shows weekly percentages while provider details still show all windows.

## AI Disclosure

Implemented and checked with OpenAI Codex (GPT-6), at the contributor's request. Test execution and visual inspection were agent-driven.

## Review

- **Cross-platform:** no platform-specific paths, shortcuts, process calls, or native APIs in feature code; Windows verified locally, macOS/Linux left to CI.
- **SSH/remote/local:** presentation-only filtering; provider reads and execution routing are unchanged. Pairing tests verify the preference is persisted locally, omitted from host writes, and protected from incoming host state. Folder workspaces and Git worktrees use the same footer.
- **Agents/integrations:** provider-neutral selection of session/weekly windows, including model-specific weekly limits; monthly-only and named-bucket displays preserved. No authentication or Git-provider changes.
- **Performance:** no new polling, timers, subscriptions to external services, or usage requests. Both reuses the original provider snapshot and existing summary calculation.
- **UI:** existing segmented control and theme tokens; independent from percentage display and density; full details remain accessible; four English strings use the localization system.
- **Security/backwards compatibility:** no secrets or new executable input. Optional persisted enum defaults to Both for absent/invalid values; older paired hosts do not see the new field. Native mobile UI is unchanged.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No release/version bump. This PR changes footer presentation only.

The two small compactions called out by automated review are behavior-preserving: the font fallback expression keeps `constants.ts` within its 300-code-line rule after adding the shared default import and property; the `beforeEach` shorthand offsets the two new pairing-fixture entries without changing module-reset behavior. No line-limit rules are disabled or raised. Comments follow AGENTS.md's concise, non-obvious-comment guidance rather than adding blanket docstrings to unchanged functions.

## Author

GitHub: @husman2012. X (Twitter): not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — limitations documented above
