### PR TITLE
Unify tab surface selection across workspace activation

### DIFF
--- a/src/renderer/src/store/slices/folder-workspace-activation-and-activity.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-activation-and-activity.test.ts
@@ -47,6 +47,29 @@ function makeFolderWorkspace(overrides: Partial<FolderWorkspace> = {}): FolderWo
   }
 }
 
+function rememberedBrowserSurface(workspaceKey: string): Partial<AppState> {
+  return {
+    browserTabsByWorktree: {
+      [workspaceKey]: [
+        {
+          id: 'remembered',
+          worktreeId: workspaceKey,
+          url: 'about:blank',
+          title: 'Browser',
+          loading: false,
+          faviconUrl: null,
+          canGoBack: false,
+          canGoForward: false,
+          loadError: null,
+          createdAt: 1
+        }
+      ]
+    },
+    activeBrowserTabIdByWorktree: { [workspaceKey]: 'remembered' },
+    activeTabTypeByWorktree: { [workspaceKey]: 'browser' }
+  }
+}
+
 type FolderWorkspaceUpdateArgs = {
   folderWorkspaceId: string
   updates: Partial<FolderWorkspace>
@@ -135,7 +158,7 @@ describe('folder workspace generic activation and activity', () => {
       store.getState().createUnifiedTab(workspaceKey, contentType, { id: 'selected' })
       store.setState({ activeTabTypeByWorktree: { [workspaceKey]: 'editor' } })
 
-      store.getState().setActiveWorktree(workspaceKey, executionHostId)
+      store.getState().setActiveFolderWorkspace(folder.id, executionHostId)
 
       expect(store.getState().activeWorkspaceExecutionHostId).toBe(executionHostId)
       expect(store.getState().activeTabType).toBe(contentType)
@@ -149,6 +172,7 @@ describe('folder workspace generic activation and activity', () => {
     const workspaceKey = folderWorkspaceKey(folder.id)
     const store = seedLocalFolderStore(folder)
     store.setState({
+      ...rememberedBrowserSurface(workspaceKey),
       groupsByWorktree: {
         [workspaceKey]: [
           {
@@ -159,28 +183,26 @@ describe('folder workspace generic activation and activity', () => {
           }
         ]
       },
-      activeGroupIdByWorktree: { [workspaceKey]: 'empty' },
-      browserTabsByWorktree: {
-        [workspaceKey]: [
-          {
-            id: 'remembered',
-            worktreeId: workspaceKey,
-            url: 'about:blank',
-            title: 'Browser',
-            loading: false,
-            faviconUrl: null,
-            canGoBack: false,
-            canGoForward: false,
-            loadError: null,
-            createdAt: 1
-          }
-        ]
-      },
-      activeBrowserTabIdByWorktree: { [workspaceKey]: 'remembered' },
-      activeTabTypeByWorktree: { [workspaceKey]: 'browser' }
+      activeGroupIdByWorktree: { [workspaceKey]: 'empty' }
     } as Partial<AppState>)
 
-    store.getState().setActiveWorktree(workspaceKey)
+    store.getState().setActiveFolderWorkspace(folder.id)
+
+    expect(store.getState().activeTabType).toBe('terminal')
+    expect(store.getState().activeBrowserTabId).toBe('remembered')
+  })
+
+  it('keeps layout-only folder ownership above remembered browser state', () => {
+    const folder = makeFolderWorkspace()
+    const workspaceKey = folderWorkspaceKey(folder.id)
+    const store = seedLocalFolderStore(folder)
+    store.setState({
+      ...rememberedBrowserSurface(workspaceKey),
+      groupsByWorktree: {},
+      layoutByWorktree: { [workspaceKey]: { type: 'leaf', groupId: 'pending' } }
+    } as Partial<AppState>)
+
+    store.getState().setActiveFolderWorkspace(folder.id)
 
     expect(store.getState().activeTabType).toBe('terminal')
     expect(store.getState().activeBrowserTabId).toBe('remembered')

--- a/src/renderer/src/store/slices/folder-workspace-activation-and-activity.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-activation-and-activity.test.ts
@@ -121,6 +121,71 @@ describe('folder workspace generic activation and activity', () => {
     })
   })
 
+  it.each([
+    ['simulator', 'local'],
+    ['agent-session', 'local'],
+    ['simulator', 'ssh:test-host'],
+    ['agent-session', 'ssh:test-host']
+  ] as const)(
+    'restores a folder %s tab on %s using its concrete visible type',
+    (contentType, executionHostId) => {
+      const folder = makeFolderWorkspace({ executionHostId })
+      const workspaceKey = folderWorkspaceKey(folder.id)
+      const store = seedLocalFolderStore(folder)
+      store.getState().createUnifiedTab(workspaceKey, contentType, { id: 'selected' })
+      store.setState({ activeTabTypeByWorktree: { [workspaceKey]: 'editor' } })
+
+      store.getState().setActiveWorktree(workspaceKey, executionHostId)
+
+      expect(store.getState().activeWorkspaceExecutionHostId).toBe(executionHostId)
+      expect(store.getState().activeTabType).toBe(contentType)
+      expect(store.getState().activeTabTypeByWorktree[workspaceKey]).toBe(contentType)
+      expect(store.getState().getActiveTab(workspaceKey)?.id).toBe('selected')
+    }
+  )
+
+  it('does not let remembered browser state select content in an empty folder group', () => {
+    const folder = makeFolderWorkspace()
+    const workspaceKey = folderWorkspaceKey(folder.id)
+    const store = seedLocalFolderStore(folder)
+    store.setState({
+      groupsByWorktree: {
+        [workspaceKey]: [
+          {
+            id: 'empty',
+            worktreeId: workspaceKey,
+            activeTabId: null,
+            tabOrder: []
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [workspaceKey]: 'empty' },
+      browserTabsByWorktree: {
+        [workspaceKey]: [
+          {
+            id: 'remembered',
+            worktreeId: workspaceKey,
+            url: 'about:blank',
+            title: 'Browser',
+            loading: false,
+            faviconUrl: null,
+            canGoBack: false,
+            canGoForward: false,
+            loadError: null,
+            createdAt: 1
+          }
+        ]
+      },
+      activeBrowserTabIdByWorktree: { [workspaceKey]: 'remembered' },
+      activeTabTypeByWorktree: { [workspaceKey]: 'browser' }
+    } as Partial<AppState>)
+
+    store.getState().setActiveWorktree(workspaceKey)
+
+    expect(store.getState().activeTabType).toBe('terminal')
+    expect(store.getState().activeBrowserTabId).toBe('remembered')
+  })
+
   it('coalesces repeated activity persistence while keeping local activity current', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/renderer/src/store/slices/folder-workspace-activation-and-activity.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-activation-and-activity.test.ts
@@ -208,6 +208,36 @@ describe('folder workspace generic activation and activity', () => {
     expect(store.getState().activeBrowserTabId).toBe('remembered')
   })
 
+  it('falls back to an open file when nothing else owns the folder surface', () => {
+    const folder = makeFolderWorkspace()
+    const workspaceKey = folderWorkspaceKey(folder.id)
+    const store = seedLocalFolderStore(folder)
+    store.setState({
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      // Why: the remembered browser tab is gone, so only the open file is left to show.
+      activeBrowserTabIdByWorktree: { [workspaceKey]: 'closed' },
+      browserTabsByWorktree: { [workspaceKey]: [] },
+      activeTabTypeByWorktree: { [workspaceKey]: 'browser' },
+      openFiles: [
+        {
+          id: 'fallback-file',
+          worktreeId: workspaceKey,
+          filePath: '/workspace/folder/file',
+          relativePath: 'file',
+          language: 'plaintext',
+          isDirty: false,
+          mode: 'edit'
+        }
+      ]
+    } as Partial<AppState>)
+
+    store.getState().setActiveFolderWorkspace(folder.id)
+
+    expect(store.getState().activeTabType).toBe('editor')
+    expect(store.getState().activeFileId).toBe('fallback-file')
+  })
+
   it('coalesces repeated activity persistence while keeping local activity current', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/renderer/src/store/slices/tabs/tab-selection-contract.test.ts
+++ b/src/renderer/src/store/slices/tabs/tab-selection-contract.test.ts
@@ -182,16 +182,24 @@ describe('tab selection and hydration ownership', () => {
     expect(state.groupsByWorktree[workspace][0].activeTabId).toBe('selected')
   })
 
-  it.each(['terminal', 'editor', 'browser'] as const)(
-    'restores legacy %s selection when unified groups are absent',
-    (activeTabType) => {
+  it.each([
+    ['terminal', 'terminal', 'remembered-file'],
+    ['editor', 'editor', 'remembered-file'],
+    ['browser', 'browser', 'remembered-file'],
+    // Why: nothing renders a remembered agent-session/simulator once its tab is gone, so the browser
+    // surface takes over and must not leave the remembered file selected underneath it.
+    ['agent-session', 'browser', null],
+    ['simulator', 'browser', null]
+  ] as const)(
+    'projects legacy %s memory as %s when unified groups are absent',
+    (activeTabType, visible, activeFileId) => {
       const state = selectionState(null)
       state.groupsByWorktree = {}
       state.activeTabTypeByWorktree[workspace] = activeTabType
       expect(activate(state)).toEqual({
-        activeTabType,
+        activeTabType: visible,
         activeTabId: 'remembered-terminal',
-        activeFileId: 'remembered-file',
+        activeFileId,
         activeBrowserTabId: 'remembered-browser'
       })
     }

--- a/src/renderer/src/store/slices/tabs/tab-selection-contract.test.ts
+++ b/src/renderer/src/store/slices/tabs/tab-selection-contract.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest'
+import type { Tab, TabContentType } from '../../../../../shared/tab-types'
+import { buildHydratedTabState } from '../tabs-hydration'
+import { resolveActivatedWorktreeSurface } from '../worktrees/session/active-worktree-surface'
+import { deriveActiveSurfaceForWorktree } from './tabs-surface'
+
+type SelectionState = Parameters<typeof resolveActivatedWorktreeSurface>[0]
+
+const workspace = 'repo::/workspace'
+function selectedTab(contentType: TabContentType): Tab {
+  return {
+    id: 'selected',
+    entityId: 'selected-entity',
+    groupId: 'group',
+    worktreeId: workspace,
+    contentType,
+    label: 'Selected',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function selectionState(tab: Tab | null): SelectionState {
+  return {
+    rightSidebarExplorerViewByWorktree: {},
+    activeGroupIdByWorktree: { [workspace]: 'group' },
+    groupsByWorktree: {
+      [workspace]: [
+        {
+          id: 'group',
+          worktreeId: workspace,
+          activeTabId: tab?.id ?? null,
+          tabOrder: tab ? [tab.id] : []
+        }
+      ]
+    },
+    unifiedTabsByWorktree: { [workspace]: tab ? [tab] : [] },
+    layoutByWorktree: {},
+    activeTabIdByWorktree: { [workspace]: 'remembered-terminal' },
+    activeFileIdByWorktree: { [workspace]: 'remembered-file' },
+    activeBrowserTabIdByWorktree: { [workspace]: 'remembered-browser' },
+    activeTabTypeByWorktree: { [workspace]: 'browser' },
+    tabsByWorktree: {
+      [workspace]: [
+        {
+          id: 'remembered-terminal',
+          worktreeId: workspace,
+          ptyId: null,
+          title: 'Terminal',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    },
+    browserTabsByWorktree: {
+      [workspace]: [
+        {
+          id: 'remembered-browser',
+          worktreeId: workspace,
+          url: 'about:blank',
+          title: 'Browser',
+          loading: false,
+          faviconUrl: null,
+          canGoBack: false,
+          canGoForward: false,
+          loadError: null,
+          createdAt: 1
+        }
+      ]
+    },
+    openFiles: [
+      {
+        id: 'remembered-file',
+        worktreeId: workspace,
+        filePath: '/workspace/file',
+        relativePath: 'file',
+        language: 'plaintext',
+        isDirty: false,
+        mode: 'edit'
+      }
+    ]
+  }
+}
+
+function activate(state: SelectionState) {
+  const { restoredRightSidebarExplorerView: _view, ...surface } = resolveActivatedWorktreeSurface(
+    state,
+    workspace,
+    undefined,
+    null
+  )
+  return surface
+}
+
+describe('tab selection and hydration ownership', () => {
+  it.each([
+    ['terminal', 'terminal'],
+    ['editor', 'editor'],
+    ['diff', 'editor'],
+    ['conflict-review', 'editor'],
+    ['check-details', 'editor'],
+    ['browser', 'browser'],
+    ['simulator', 'simulator'],
+    ['agent-session', 'agent-session']
+  ] as const)(
+    'projects %s selection while retaining other remembered surfaces',
+    (kind, visible) => {
+      const state = selectionState(selectedTab(kind))
+      const expected = {
+        activeTabType: visible,
+        activeTabId: kind === 'terminal' ? 'selected-entity' : 'remembered-terminal',
+        activeFileId: visible === 'editor' ? 'selected-entity' : 'remembered-file',
+        activeBrowserTabId: kind === 'browser' ? 'selected-entity' : 'remembered-browser'
+      }
+      expect(deriveActiveSurfaceForWorktree(state, workspace)).toEqual(expected)
+      expect(activate(state)).toEqual(expected)
+    }
+  )
+
+  it('keeps empty groups authoritative over remembered browser/editor surfaces', () => {
+    const state = selectionState(null)
+    expect(activate(state).activeTabType).toBe('terminal')
+    expect(deriveActiveSurfaceForWorktree(state, workspace).activeTabType).toBe('terminal')
+  })
+
+  it('keeps layout-only ownership authoritative during staged hydration', () => {
+    const state = selectionState(null)
+    state.groupsByWorktree = {}
+    state.layoutByWorktree = { [workspace]: { type: 'leaf', groupId: 'pending' } }
+    expect(activate(state).activeTabType).toBe('terminal')
+    expect(deriveActiveSurfaceForWorktree(state, workspace).activeTabType).toBe('terminal')
+  })
+
+  it('distinguishes workspace restoration from group-focus legacy fallback', () => {
+    const state = selectionState(null)
+    state.groupsByWorktree = {}
+    state.activeTabTypeByWorktree[workspace] = 'terminal'
+    expect(activate(state).activeTabType).toBe('terminal')
+    expect(deriveActiveSurfaceForWorktree(state, workspace).activeTabType).toBe('browser')
+  })
+
+  it('does not select a preferred tab owned by another group', () => {
+    const state = selectionState(selectedTab('browser'))
+    state.unifiedTabsByWorktree[workspace].push({
+      ...selectedTab('editor'),
+      id: 'foreign',
+      groupId: 'other'
+    })
+    expect(resolveActivatedWorktreeSurface(state, workspace, 'foreign', null).activeTabType).toBe(
+      'terminal'
+    )
+  })
+
+  it('resolves stale active-group IDs to the first group consistently', () => {
+    const state = selectionState(selectedTab('simulator'))
+    state.activeGroupIdByWorktree[workspace] = 'removed'
+    expect(activate(state).activeTabType).toBe('simulator')
+    expect(deriveActiveSurfaceForWorktree(state, workspace).activeTabType).toBe('simulator')
+  })
+
+  it('requires group ownership even for an explicit preferred tab during hydration', () => {
+    const state = selectionState(selectedTab('simulator'))
+    state.groupsByWorktree = {}
+    state.activeTabTypeByWorktree[workspace] = 'terminal'
+    expect(resolveActivatedWorktreeSurface(state, workspace, 'selected', null).activeTabType).toBe(
+      'terminal'
+    )
+  })
+
+  it('honors a preferred tab in the selected group without mutating selection', () => {
+    const state = selectionState(selectedTab('browser'))
+    const preferred = { ...selectedTab('simulator'), id: 'preferred' }
+    state.unifiedTabsByWorktree[workspace].push(preferred)
+    state.groupsByWorktree[workspace][0].tabOrder.push(preferred.id)
+    expect(
+      resolveActivatedWorktreeSurface(state, workspace, preferred.id, null).activeTabType
+    ).toBe('simulator')
+    expect(state.groupsByWorktree[workspace][0].activeTabId).toBe('selected')
+  })
+
+  it.each(['terminal', 'editor', 'browser'] as const)(
+    'restores legacy %s selection when unified groups are absent',
+    (activeTabType) => {
+      const state = selectionState(null)
+      state.groupsByWorktree = {}
+      state.activeTabTypeByWorktree[workspace] = activeTabType
+      expect(activate(state)).toEqual({
+        activeTabType,
+        activeTabId: 'remembered-terminal',
+        activeFileId: 'remembered-file',
+        activeBrowserTabId: 'remembered-browser'
+      })
+    }
+  )
+
+  it('hydrates unified selection without allowing conflicting legacy memories to choose it', () => {
+    const tab = selectedTab('simulator')
+    const state = selectionState(tab)
+    const session = {
+      activeRepoId: null,
+      activeWorktreeId: workspace,
+      activeTabId: 'remembered-terminal',
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      unifiedTabs: state.unifiedTabsByWorktree,
+      tabGroups: state.groupsByWorktree,
+      activeGroupIdByWorktree: state.activeGroupIdByWorktree,
+      activeTabTypeByWorktree: { [workspace]: 'browser' as const },
+      activeTabIdByWorktree: state.activeTabIdByWorktree
+    }
+    const before = structuredClone(session)
+    const hydrated = buildHydratedTabState(session, new Set([workspace]))
+    expect(activate({ ...state, ...hydrated }).activeTabType).toBe('simulator')
+    expect(session).toEqual(before)
+  })
+})

--- a/src/renderer/src/store/slices/tabs/tabs-surface.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-surface.ts
@@ -9,6 +9,7 @@ export function deriveActiveSurfaceForWorktree(
     | 'activeFileIdByWorktree'
     | 'activeGroupIdByWorktree'
     | 'activeTabIdByWorktree'
+    | 'activeTabTypeByWorktree'
     | 'browserTabsByWorktree'
     | 'groupsByWorktree'
     | 'layoutByWorktree'
@@ -17,7 +18,8 @@ export function deriveActiveSurfaceForWorktree(
     | 'unifiedTabsByWorktree'
   >,
   worktreeId: string,
-  preferredGroupId?: string | null
+  preferredGroupId?: string | null,
+  options?: { preferredTabId?: string; legacySelection?: 'remembered-type' }
 ): {
   activeBrowserTabId: string | null
   activeFileId: string | null
@@ -28,10 +30,12 @@ export function deriveActiveSurfaceForWorktree(
   const activeGroupId = preferredGroupId ?? state.activeGroupIdByWorktree[worktreeId] ?? null
   const activeGroup =
     (activeGroupId ? groups.find((group) => group.id === activeGroupId) : null) ?? groups[0] ?? null
+  const activeUnifiedTabId = options?.preferredTabId ?? activeGroup?.activeTabId
   const activeUnifiedTab =
-    activeGroup?.activeTabId != null
+    activeUnifiedTabId != null
       ? ((state.unifiedTabsByWorktree[worktreeId] ?? []).find(
-          (tab) => tab.id === activeGroup.activeTabId && tab.groupId === activeGroup.id
+          (tab) =>
+            tab.id === activeUnifiedTabId && activeGroup != null && tab.groupId === activeGroup.id
         ) ?? null)
       : null
   const restoredFileId = state.activeFileIdByWorktree[worktreeId] ?? null
@@ -49,6 +53,11 @@ export function deriveActiveSurfaceForWorktree(
     ? terminalTabs.some((tab) => tab.id === restoredTerminalTabId)
     : false
   const hasGroupOwnedSurface = groups.length > 0 || Boolean(state.layoutByWorktree[worktreeId])
+
+  const restoreLegacyType = options?.legacySelection === 'remembered-type'
+  const restoredTabType = restoreLegacyType
+    ? (state.activeTabTypeByWorktree[worktreeId] ?? 'terminal')
+    : null
 
   let activeFileId: string | null
   let activeBrowserTabId: string | null
@@ -76,8 +85,21 @@ export function deriveActiveSurfaceForWorktree(
     activeBrowserTabId = browserTabStillOpen ? restoredBrowserTabId : (browserTabs[0]?.id ?? null)
     // Why: focusing an empty split should target its default terminal area, not the previously active browser/editor in another group.
     activeTabType = 'terminal'
-  } else if (browserTabStillOpen) {
+  } else if (restoredTabType === 'terminal') {
     activeFileId = fileStillOpen ? restoredFileId : null
+    activeBrowserTabId = browserTabStillOpen ? restoredBrowserTabId : (browserTabs[0]?.id ?? null)
+    activeTabType = 'terminal'
+  } else if (restoredTabType === 'editor' && fileStillOpen) {
+    activeFileId = restoredFileId
+    activeBrowserTabId = browserTabStillOpen ? restoredBrowserTabId : (browserTabs[0]?.id ?? null)
+    activeTabType = 'editor'
+  } else if (browserTabStillOpen) {
+    activeFileId =
+      !restoreLegacyType || restoredTabType === 'browser'
+        ? fileStillOpen
+          ? restoredFileId
+          : null
+        : null
     activeBrowserTabId = restoredBrowserTabId
     activeTabType = 'browser'
   } else if (fileStillOpen) {

--- a/src/renderer/src/store/slices/tabs/tabs-surface.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-surface.ts
@@ -2,21 +2,23 @@ import type { AppState } from '../../types'
 import { toVisibleTabType } from '../../../../../shared/tab-types'
 import type { WorkspaceVisibleTabType } from '../../../../../shared/tab-types'
 
+export type ActiveSurfaceSourceState = Pick<
+  AppState,
+  | 'activeBrowserTabIdByWorktree'
+  | 'activeFileIdByWorktree'
+  | 'activeGroupIdByWorktree'
+  | 'activeTabIdByWorktree'
+  | 'activeTabTypeByWorktree'
+  | 'browserTabsByWorktree'
+  | 'groupsByWorktree'
+  | 'layoutByWorktree'
+  | 'openFiles'
+  | 'tabsByWorktree'
+  | 'unifiedTabsByWorktree'
+>
+
 export function deriveActiveSurfaceForWorktree(
-  state: Pick<
-    AppState,
-    | 'activeBrowserTabIdByWorktree'
-    | 'activeFileIdByWorktree'
-    | 'activeGroupIdByWorktree'
-    | 'activeTabIdByWorktree'
-    | 'activeTabTypeByWorktree'
-    | 'browserTabsByWorktree'
-    | 'groupsByWorktree'
-    | 'layoutByWorktree'
-    | 'openFiles'
-    | 'tabsByWorktree'
-    | 'unifiedTabsByWorktree'
-  >,
+  state: ActiveSurfaceSourceState,
   worktreeId: string,
   preferredGroupId?: string | null,
   options?: { preferredTabId?: string; legacySelection?: 'remembered-type' }
@@ -58,6 +60,9 @@ export function deriveActiveSurfaceForWorktree(
   const restoredTabType = restoreLegacyType
     ? (state.activeTabTypeByWorktree[worktreeId] ?? 'terminal')
     : null
+  // Why: only a remembered browser type — or group focus, which remembers no type at all — may keep
+  // the remembered file selected under the browser surface; a stale agent-session/simulator clears it.
+  const keepRememberedFileUnderBrowser = restoredTabType === null || restoredTabType === 'browser'
 
   let activeFileId: string | null
   let activeBrowserTabId: string | null
@@ -94,12 +99,7 @@ export function deriveActiveSurfaceForWorktree(
     activeBrowserTabId = browserTabStillOpen ? restoredBrowserTabId : (browserTabs[0]?.id ?? null)
     activeTabType = 'editor'
   } else if (browserTabStillOpen) {
-    activeFileId =
-      !restoreLegacyType || restoredTabType === 'browser'
-        ? fileStillOpen
-          ? restoredFileId
-          : null
-        : null
+    activeFileId = keepRememberedFileUnderBrowser && fileStillOpen ? restoredFileId : null
     activeBrowserTabId = restoredBrowserTabId
     activeTabType = 'browser'
   } else if (fileStillOpen) {
@@ -128,20 +128,7 @@ export function deriveActiveSurfaceForWorktree(
 }
 
 export function buildActiveSurfacePatch(
-  state: Pick<
-    AppState,
-    | 'activeBrowserTabIdByWorktree'
-    | 'activeFileIdByWorktree'
-    | 'activeGroupIdByWorktree'
-    | 'activeTabIdByWorktree'
-    | 'activeTabTypeByWorktree'
-    | 'browserTabsByWorktree'
-    | 'groupsByWorktree'
-    | 'layoutByWorktree'
-    | 'openFiles'
-    | 'tabsByWorktree'
-    | 'unifiedTabsByWorktree'
-  >,
+  state: ActiveSurfaceSourceState,
   worktreeId: string,
   preferredGroupId?: string | null
 ): Pick<

--- a/src/renderer/src/store/slices/worktrees/session/active-worktree-surface.ts
+++ b/src/renderer/src/store/slices/worktrees/session/active-worktree-surface.ts
@@ -1,10 +1,10 @@
 import type { AppState } from '../../../types'
 import type { WorkspaceVisibleTabType } from '../../../../../../shared/tab-types'
+import type { ActiveSurfaceSourceState } from '../../tabs/tabs-surface'
 import { deriveActiveSurfaceForWorktree } from '../../tabs/tabs-surface'
 
 export function resolveActivatedWorktreeSurface(
-  s: Parameters<typeof deriveActiveSurfaceForWorktree>[0] &
-    Pick<AppState, 'rightSidebarExplorerViewByWorktree'>,
+  s: ActiveSurfaceSourceState & Pick<AppState, 'rightSidebarExplorerViewByWorktree'>,
   worktreeId: string,
   preferredActiveUnifiedTabId: string | undefined,
   reconciledActiveTabId: string | null

--- a/src/renderer/src/store/slices/worktrees/session/active-worktree-surface.ts
+++ b/src/renderer/src/store/slices/worktrees/session/active-worktree-surface.ts
@@ -1,9 +1,10 @@
 import type { AppState } from '../../../types'
 import type { WorkspaceVisibleTabType } from '../../../../../../shared/tab-types'
-import { toVisibleTabType } from '../../../../../../shared/tab-types'
+import { deriveActiveSurfaceForWorktree } from '../../tabs/tabs-surface'
 
 export function resolveActivatedWorktreeSurface(
-  s: AppState,
+  s: Parameters<typeof deriveActiveSurfaceForWorktree>[0] &
+    Pick<AppState, 'rightSidebarExplorerViewByWorktree'>,
   worktreeId: string,
   preferredActiveUnifiedTabId: string | undefined,
   reconciledActiveTabId: string | null
@@ -16,107 +17,11 @@ export function resolveActivatedWorktreeSurface(
   activeTabType: WorkspaceVisibleTabType
   activeTabId: string | null
 } {
-  // Why: Search lives under Explorer, so the files/search sub-route must switch with the worktree, not leak the prior one.
-  const restoredRightSidebarExplorerView =
-    s.rightSidebarExplorerViewByWorktree?.[worktreeId] ?? 'files'
-  const restoredFileId = s.activeFileIdByWorktree[worktreeId] ?? null
-  const restoredBrowserTabId = s.activeBrowserTabIdByWorktree[worktreeId] ?? null
-  const restoredTabType = s.activeTabTypeByWorktree[worktreeId] ?? 'terminal'
-  const activeGroupId =
-    s.activeGroupIdByWorktree[worktreeId] ?? s.groupsByWorktree[worktreeId]?.[0]?.id ?? null
-  const activeGroup = activeGroupId
-    ? ((s.groupsByWorktree[worktreeId] ?? []).find((group) => group.id === activeGroupId) ?? null)
-    : null
-  const activeUnifiedTabId =
-    preferredActiveUnifiedTabId ?? reconciledActiveTabId ?? activeGroup?.activeTabId ?? null
-  const activeUnifiedTab =
-    activeUnifiedTabId != null
-      ? ((s.unifiedTabsByWorktree[worktreeId] ?? []).find(
-          (tab) => tab.id === activeUnifiedTabId && (!activeGroup || tab.groupId === activeGroup.id)
-        ) ?? null)
-      : null
-  // Verify the restored file still exists in openFiles
-  const fileStillOpen = restoredFileId
-    ? s.openFiles.some((f) => f.id === restoredFileId && f.worktreeId === worktreeId)
-    : false
-  const browserTabs = s.browserTabsByWorktree[worktreeId] ?? []
-  const browserTabStillOpen = restoredBrowserTabId
-    ? browserTabs.some((tab) => tab.id === restoredBrowserTabId)
-    : false
-  const hasGroupOwnedSurface =
-    (s.groupsByWorktree[worktreeId]?.length ?? 0) > 0 || Boolean(s.layoutByWorktree[worktreeId])
-
-  // Why: restore from the reconciled tab-group model first; preferring legacy fallbacks can show a blank worktree.
-  let activeFileId: string | null
-  let activeBrowserTabId: string | null
-  let activeTabType: WorkspaceVisibleTabType
-  if (activeUnifiedTab) {
-    activeFileId =
-      activeUnifiedTab.contentType === 'editor' ||
-      activeUnifiedTab.contentType === 'diff' ||
-      activeUnifiedTab.contentType === 'conflict-review' ||
-      activeUnifiedTab.contentType === 'check-details'
-        ? activeUnifiedTab.entityId
-        : fileStillOpen
-          ? restoredFileId
-          : null
-    activeBrowserTabId =
-      activeUnifiedTab.contentType === 'browser'
-        ? activeUnifiedTab.entityId
-        : browserTabStillOpen
-          ? restoredBrowserTabId
-          : (browserTabs[0]?.id ?? null)
-    activeTabType = toVisibleTabType(activeUnifiedTab.contentType)
-  } else if (hasGroupOwnedSurface) {
-    activeFileId = fileStillOpen ? restoredFileId : null
-    activeBrowserTabId = browserTabStillOpen ? restoredBrowserTabId : (browserTabs[0]?.id ?? null)
-    activeTabType = 'terminal'
-  } else if (restoredTabType === 'terminal') {
-    activeFileId = fileStillOpen ? restoredFileId : null
-    activeBrowserTabId = browserTabStillOpen ? restoredBrowserTabId : (browserTabs[0]?.id ?? null)
-    activeTabType = 'terminal'
-  } else if (restoredTabType === 'browser' && browserTabStillOpen) {
-    activeFileId = fileStillOpen ? restoredFileId : null
-    activeBrowserTabId = restoredBrowserTabId
-    activeTabType = 'browser'
-  } else if (restoredTabType === 'editor' && fileStillOpen) {
-    activeFileId = restoredFileId
-    activeBrowserTabId = browserTabStillOpen ? restoredBrowserTabId : (browserTabs[0]?.id ?? null)
-    activeTabType = 'editor'
-  } else if (browserTabStillOpen) {
-    activeFileId = null
-    activeBrowserTabId = restoredBrowserTabId
-    activeTabType = 'browser'
-  } else if (fileStillOpen) {
-    activeFileId = restoredFileId
-    activeBrowserTabId = browserTabs[0]?.id ?? null
-    activeTabType = 'editor'
-  } else {
-    const fallbackFile = s.openFiles.find((f) => f.worktreeId === worktreeId)
-    const fallbackBrowserTab = browserTabs[0] ?? null
-    activeFileId = fallbackFile?.id ?? null
-    activeBrowserTabId = browserTabStillOpen
-      ? restoredBrowserTabId
-      : (fallbackBrowserTab?.id ?? null)
-    activeTabType = fallbackFile ? 'editor' : fallbackBrowserTab ? 'browser' : 'terminal'
-  }
-
-  // Why: restore the last-active terminal tab so the user returns to where they left, not tab 0.
-  const restoredTabId = s.activeTabIdByWorktree[worktreeId] ?? null
-  const worktreeTabs = s.tabsByWorktree[worktreeId] ?? []
-  const tabStillExists = restoredTabId ? worktreeTabs.some((t) => t.id === restoredTabId) : false
-  const activeTabId =
-    activeUnifiedTab?.contentType === 'terminal'
-      ? activeUnifiedTab.entityId
-      : tabStillExists
-        ? restoredTabId
-        : (worktreeTabs[0]?.id ?? null)
-
   return {
-    restoredRightSidebarExplorerView,
-    activeFileId,
-    activeBrowserTabId,
-    activeTabType,
-    activeTabId
+    restoredRightSidebarExplorerView: s.rightSidebarExplorerViewByWorktree?.[worktreeId] ?? 'files',
+    ...deriveActiveSurfaceForWorktree(s, worktreeId, undefined, {
+      legacySelection: 'remembered-type',
+      preferredTabId: preferredActiveUnifiedTabId ?? reconciledActiveTabId ?? undefined
+    })
   }
 }

--- a/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
+++ b/src/renderer/src/store/slices/worktrees/session/set-active-folder-workspace.ts
@@ -8,6 +8,7 @@ import {
   folderWorkspaceMatchesHost
 } from '../listing/detected-worktree-meta'
 import { shouldDeferActivationTerminalPrep } from './activation-terminal-prep'
+import { deriveActiveSurfaceForWorktree } from '../../tabs/tabs-surface'
 
 export function createSetActiveFolderWorkspace(
   set: WorktreeSliceSet,
@@ -28,72 +29,11 @@ export function createSetActiveFolderWorkspace(
     const reconciledActiveTabId =
       get().reconcileWorktreeTabModel(workspaceKey).activeRenderableTabId
     set((s) => {
-      const restoredFileId = s.activeFileIdByWorktree[workspaceKey] ?? null
-      const restoredBrowserTabId = s.activeBrowserTabIdByWorktree[workspaceKey] ?? null
-      const restoredTabType = s.activeTabTypeByWorktree[workspaceKey] ?? 'terminal'
-      const activeGroupId =
-        s.activeGroupIdByWorktree[workspaceKey] ?? s.groupsByWorktree[workspaceKey]?.[0]?.id ?? null
-      const activeGroup = activeGroupId
-        ? ((s.groupsByWorktree[workspaceKey] ?? []).find((group) => group.id === activeGroupId) ??
-          null)
-        : null
-      const activeUnifiedTabId = reconciledActiveTabId ?? activeGroup?.activeTabId ?? null
-      const activeUnifiedTab =
-        activeUnifiedTabId != null
-          ? ((s.unifiedTabsByWorktree[workspaceKey] ?? []).find(
-              (tab) =>
-                tab.id === activeUnifiedTabId && (!activeGroup || tab.groupId === activeGroup.id)
-            ) ?? null)
-          : null
-      const fileStillOpen = restoredFileId
-        ? s.openFiles.some((file) => file.id === restoredFileId && file.worktreeId === workspaceKey)
-        : false
-      const browserTabs = s.browserTabsByWorktree[workspaceKey] ?? []
-      const browserTabStillOpen = restoredBrowserTabId
-        ? browserTabs.some((tab) => tab.id === restoredBrowserTabId)
-        : false
-      const worktreeTabs = s.tabsByWorktree[workspaceKey] ?? []
-      const restoredTabId = s.activeTabIdByWorktree[workspaceKey] ?? null
-      const tabStillExists = restoredTabId
-        ? worktreeTabs.some((tab) => tab.id === restoredTabId)
-        : false
-      const activeFileId =
-        activeUnifiedTab?.contentType === 'editor' ||
-        activeUnifiedTab?.contentType === 'diff' ||
-        activeUnifiedTab?.contentType === 'conflict-review' ||
-        activeUnifiedTab?.contentType === 'check-details'
-          ? activeUnifiedTab.entityId
-          : fileStillOpen
-            ? restoredFileId
-            : null
-      const activeBrowserTabId =
-        activeUnifiedTab?.contentType === 'browser'
-          ? activeUnifiedTab.entityId
-          : browserTabStillOpen
-            ? restoredBrowserTabId
-            : (browserTabs[0]?.id ?? null)
-      const activeTabType =
-        activeUnifiedTab?.contentType === 'terminal'
-          ? 'terminal'
-          : activeUnifiedTab?.contentType === 'browser'
-            ? 'browser'
-            : activeUnifiedTab
-              ? 'editor'
-              : restoredTabType === 'browser' && browserTabStillOpen
-                ? 'browser'
-                : restoredTabType === 'editor' && fileStillOpen
-                  ? 'editor'
-                  : fileStillOpen
-                    ? 'editor'
-                    : browserTabs.length > 0
-                      ? 'browser'
-                      : 'terminal'
-      const activeTabId =
-        activeUnifiedTab?.contentType === 'terminal'
-          ? activeUnifiedTab.entityId
-          : tabStillExists
-            ? restoredTabId
-            : (worktreeTabs[0]?.id ?? null)
+      const { activeFileId, activeBrowserTabId, activeTabType, activeTabId } =
+        deriveActiveSurfaceForWorktree(s, workspaceKey, undefined, {
+          legacySelection: 'remembered-type',
+          preferredTabId: reconciledActiveTabId ?? undefined
+        })
       const nextEverActivated = s.everActivatedWorktreeIds.has(workspaceKey)
         ? s.everActivatedWorktreeIds
         : new Set([...s.everActivatedWorktreeIds, workspaceKey])


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​345 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​345 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​200 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​146 |

<!-- /orca-pr-loc -->

## What was broken

Every workspace in Orca has to answer one question when you open it: **what should be showing right now?** A terminal, a file editor, a browser tab, an AI chat, or a mobile emulator.

For **folder workspaces** (Open Folder, as opposed to git worktrees), that question was answered wrongly for two kinds of tab:

> Open a folder workspace, select an AI chat tab (or a mobile emulator tab), switch to another workspace, then switch back — you get a **code editor** instead of your chat or emulator.

The cause: the folder-workspace code treated *anything that isn't a terminal and isn't a browser* as a file editor. AI chat and emulator tabs fell into that bucket. Git worktrees never had this bug, because they used a different piece of code that classified tabs properly.

## Why the bug existed

That "what should be showing?" logic was written **three separate times**:

| Copy | Used when | Correct? |
| :--- | :--- | :--- |
| `tabs-surface.ts` | you click between tab groups | yes |
| `active-worktree-surface.ts` | you open a **git worktree** | yes |
| inline in `set-active-folder-workspace.ts` | you open a **folder workspace** | **no** — the buggy one |

Three copies of one decision means they drift apart, and the folder copy had drifted the furthest. Fixing only the symptom would have meant adding a fourth special case to the copy that was already wrong.

## What this PR does

Deletes two of the three copies. All three paths now call the same function, so a folder workspace and a git worktree answer the question identically. That is where the −146 production lines come from.

The shared function gains one option, because restoring a workspace genuinely differs from clicking between tab groups: **restoring** honours the surface you were last on, while **clicking a group** picks based on what's actually available in it. That difference was already real; it's now written down in one place instead of implied by three.

## Two side effects, both making folder workspaces match git worktrees

Neither is a bug fix — they're consequences of folder workspaces now sharing the git logic. Both are pinned by tests:

1. **A folder workspace with a split layout but no tabs opens on the terminal area** rather than reopening a remembered browser tab. Your browser tab is still remembered, just not auto-selected.
2. **If nothing else is available and you have a file open, that file opens** rather than falling back to the terminal.

## Linked Issue

User-requested tab selection/hydration architecture follow-up; no issue number supplied.

## Visual Proof

Validated in a dev Electron build over CDP and posted as a separate comment, [Electron QA — rendered validation](https://github.com/stablyai/orca/pull/19635#issuecomment-5593955607) — 9 screenshots.

Confirmed on screen: a folder workspace restores its **AI chat** surface and its **mobile emulator** surface after switching away and back (the bug above), terminal/editor/browser tabs on a git worktree each restore correctly, and no surface leaks between workspaces. The renderer was verified to be serving this branch's code before capture, rather than assumed.

Not covered: SSH/remote hosts, split layouts, keyboard navigation between workspaces, a folder workspace with a browser tab selected, and chat/emulator tabs on a git worktree.

## Testing

- [x] Manually tested in Electron (see Visual Proof).
- [x] **Every new folder test fails against pre-PR code: 7 of 7.** The tests drive the real folder entry point (`setActiveFolderWorkspace`), not `setActiveWorktree` — those are separate code paths and only the former reaches the code this PR rewrote.
- [x] `src/renderer/src/store/slices` — 325 files / 3123 tests pass.
- [x] `pnpm tc:web` clean.
- [x] `pnpm run check:code-quality:changed` — 0 findings across all 5 changed files.
- [x] No `max-lines` disable or per-file bump added.

## Follow-up (not in this PR)

A workspace remembers its last surface as a *kind* (`activeTabTypeByWorktree`) rather than a specific tab. A kind is satisfiable by any tab of that kind, so restoring one has to re-check availability against a second remembered id — which is why the restoration and group-focus rules differ at all. Persisting the last-active **tab id** alongside the existing type would make that check total (it resolves or it doesn't), letting both paths share one unconditional fallback.

That touches the persisted session shape and the existing `activeTabTypeByWorktree` consumers, so it belongs in its own change under `docs/reference/remote-wire-compatibility.md` (new field optional; old clients keep reading the current one).

## Review

Reviewed across four independent lanes: correctness with ablation, architecture/precedent, and a readiness checklist at the start and end. Two follow-up commits added the folder-path test coverage that was missing, made one load-bearing condition legible, and named a type. Detail in the [review status comment](https://github.com/stablyai/orca/pull/19635#issuecomment-5593969635).

## Agent skill upstream boundary

- [x] Not applicable; no agent-skill source changed.

## Checklist

- [x] Small and focused.
- [x] Architecture rationale and intended differences documented.
- [x] Before/after rendered evidence attached.
- [x] Cross-platform and SSH/remote impact considered; renderer-only state, no platform-specific operations added.
- [x] Targeted tests, renderer typecheck, changed-code lint pass.
