### PR TITLE
refactor: unify workspace tab activation orchestration

### DIFF
--- a/src/renderer/src/components/tab-group/useTabGroupActivationCommands.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupActivationCommands.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Tab } from '../../../../shared/tab-types'
+import type { TabGroupWorktreeSnapshot } from './useTabGroupItemProjections'
+
+const mocks = vi.hoisted(() => ({
+  store: {
+    focusGroup: vi.fn(),
+    activateTab: vi.fn(),
+    setActiveTab: vi.fn(),
+    setActiveTabType: vi.fn(),
+    setActiveFile: vi.fn(),
+    setActiveBrowserTab: vi.fn()
+  },
+  focusTerminalTabSurface: vi.fn(),
+  activateWebRuntimeSessionTab: vi.fn(),
+  isWebRuntimeSessionActive: vi.fn(),
+  browserWorkspaceHasRemoteOwner: vi.fn()
+}))
+vi.mock('react', () => ({ useCallback: (callback: unknown) => callback }))
+vi.mock('../../store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: typeof mocks.store) => unknown) => selector(mocks.store),
+    {
+      getState: () => mocks.store
+    }
+  )
+}))
+vi.mock('../../lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: mocks.focusTerminalTabSurface
+}))
+vi.mock('../../runtime/web-runtime-session', () => ({
+  activateWebRuntimeSessionTab: mocks.activateWebRuntimeSessionTab,
+  isWebRuntimeSessionActive: mocks.isWebRuntimeSessionActive
+}))
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: () => 'remote-1'
+}))
+vi.mock('@/runtime/remote-browser-tab-ownership', () => ({
+  browserWorkspaceHasRemoteOwner: mocks.browserWorkspaceHasRemoteOwner
+}))
+vi.mock('@/lib/structured-agent-session-tab-activation', () => ({
+  activateStructuredAgentSessionTab: vi.fn()
+}))
+
+import { useTabGroupActivationCommands } from './useTabGroupActivationCommands'
+
+function useCommands(contentType: Tab['contentType']) {
+  const tab: Tab = {
+    id: 'unified-1',
+    entityId: 'entity-1',
+    worktreeId: 'folder:one',
+    groupId: 'group-1',
+    contentType,
+    label: '',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+  return useTabGroupActivationCommands({
+    groupId: tab.groupId,
+    worktreeId: tab.worktreeId,
+    groupTabs: [tab],
+    worktreeState: {
+      terminalLayoutsByTabId: { 'entity-1': { activeLeafId: 'leaf-2' } }
+    } as unknown as TabGroupWorktreeSnapshot
+  })
+}
+
+describe('tab group activation content effects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.isWebRuntimeSessionActive.mockReturnValue(true)
+    mocks.browserWorkspaceHasRemoteOwner.mockReturnValue(true)
+  })
+
+  it('selects the terminal entity, routes its runtime, and restores the active leaf', () => {
+    useCommands('terminal').activateTerminal('entity-1')
+    expect(mocks.store.focusGroup).toHaveBeenCalledWith('folder:one', 'group-1')
+    expect(mocks.store.activateTab.mock.calls[0][0]).toBe('unified-1')
+    expect(mocks.store.focusGroup.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.store.activateTab.mock.invocationCallOrder[0]
+    )
+    expect(mocks.activateWebRuntimeSessionTab).toHaveBeenCalledWith({
+      worktreeId: 'folder:one',
+      tabId: 'entity-1',
+      environmentId: 'remote-1'
+    })
+    expect(mocks.store.setActiveTab).toHaveBeenCalledWith('entity-1')
+    expect(mocks.store.setActiveTabType).toHaveBeenCalledWith('terminal')
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('entity-1', 'leaf-2')
+  })
+
+  it.each([true, false])(
+    'preserves browser ownership routing (remote owner: %s)',
+    (remoteOwner) => {
+      mocks.browserWorkspaceHasRemoteOwner.mockReturnValue(remoteOwner)
+      useCommands('browser').activateBrowser('entity-1')
+      expect(mocks.activateWebRuntimeSessionTab).toHaveBeenCalledTimes(remoteOwner ? 1 : 0)
+      if (remoteOwner) {
+        expect(mocks.activateWebRuntimeSessionTab).toHaveBeenCalledWith({
+          worktreeId: 'folder:one',
+          tabId: 'unified-1',
+          environmentId: 'remote-1'
+        })
+      }
+      expect(mocks.store.setActiveBrowserTab).toHaveBeenCalledWith('entity-1')
+      expect(mocks.store.setActiveTabType).toHaveBeenCalledWith('browser')
+    }
+  )
+
+  it.each(['editor', 'diff', 'simulator'] as const)('preserves %s surface effects', (type) => {
+    useCommands(type).activateEditor('unified-1')
+    expect(mocks.store.setActiveTabType).toHaveBeenCalledWith(
+      type === 'simulator' ? 'simulator' : 'editor'
+    )
+    expect(mocks.store.setActiveFile).toHaveBeenCalledTimes(type === 'simulator' ? 0 : 1)
+    if (type !== 'simulator') {
+      expect(mocks.store.setActiveFile).toHaveBeenCalledWith('entity-1')
+    }
+  })
+
+  it('ignores targets absent from the group', () => {
+    const actions = useCommands('terminal')
+    actions.activateTerminal('missing')
+    actions.activateBrowser('missing')
+    actions.activateEditor('missing')
+    expect(mocks.store.focusGroup).not.toHaveBeenCalled()
+    expect(mocks.store.activateTab).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/tab-group/useTabGroupActivationCommands.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupActivationCommands.ts
@@ -1,3 +1,4 @@
+import { activateWorkspaceTab } from '@/lib/workspace-tab-activation'
 import { useCallback } from 'react'
 import type { Tab } from '../../../../shared/tab-types'
 import { useAppStore } from '../../store'
@@ -38,8 +39,7 @@ export function useTabGroupActivationCommands({
       if (!item) {
         return
       }
-      focusGroup(worktreeId, groupId)
-      activateTab(item.id)
+      activateWorkspaceTab({ focusGroup, activateTab }, { worktreeId, groupId, tabId: item.id })
       const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
         useAppStore.getState(),
         worktreeId
@@ -96,8 +96,7 @@ export function useTabGroupActivationCommands({
       if (!item) {
         return
       }
-      focusGroup(worktreeId, groupId)
-      activateTab(item.id)
+      activateWorkspaceTab({ focusGroup, activateTab }, { worktreeId, groupId, tabId: item.id })
       if (item.contentType === 'simulator') {
         setActiveTabType('simulator')
         // simulator has no editor file entity
@@ -117,8 +116,7 @@ export function useTabGroupActivationCommands({
       if (!item) {
         return
       }
-      focusGroup(worktreeId, groupId)
-      activateTab(item.id)
+      activateWorkspaceTab({ focusGroup, activateTab }, { worktreeId, groupId, tabId: item.id })
       const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
         useAppStore.getState(),
         worktreeId

--- a/src/renderer/src/lib/browser-workspace-tab-activation.ts
+++ b/src/renderer/src/lib/browser-workspace-tab-activation.ts
@@ -1,3 +1,4 @@
+import { activateWorkspaceTab } from './workspace-tab-activation'
 import { useAppStore } from '@/store'
 import type { Tab } from '../../../shared/tab-types'
 import type { ExecutionHostId } from '../../../shared/execution-host'
@@ -51,8 +52,11 @@ export function activateBrowserWorkspaceTab(params: BrowserWorkspaceTabTarget): 
     return false
   }
   const state = useAppStore.getState()
-  state.focusGroup(params.worktreeId, unifiedTab.groupId)
-  state.activateTab(unifiedTab.id, { worktreeId: params.worktreeId })
+  activateWorkspaceTab(state, {
+    worktreeId: params.worktreeId,
+    groupId: unifiedTab.groupId,
+    tabId: unifiedTab.id
+  })
   state.setActiveBrowserTab(params.workspaceId)
   if (params.pageId) {
     state.setActiveBrowserPage(params.workspaceId, params.pageId)

--- a/src/renderer/src/lib/simulator-tab-palette-activation.ts
+++ b/src/renderer/src/lib/simulator-tab-palette-activation.ts
@@ -1,3 +1,4 @@
+import { activateWorkspaceTab } from './workspace-tab-activation'
 import { useAppStore } from '@/store'
 import type { ExecutionHostId } from '../../../shared/execution-host'
 import { activateAndRevealWorktree } from './worktree-activation'
@@ -57,8 +58,7 @@ export function activateSimulatorTabPaletteResult({
   }
 
   const state = useAppStore.getState()
-  state.focusGroup(worktreeId, tab.groupId)
-  state.activateTab(tab.id, { worktreeId })
+  activateWorkspaceTab(state, { worktreeId, groupId: tab.groupId, tabId: tab.id })
   state.setActiveTab(tab.id)
   state.setActiveTabType('simulator')
   return { status: 'activated', tabId: tab.id }

--- a/src/renderer/src/lib/structured-agent-session-tab-activation.ts
+++ b/src/renderer/src/lib/structured-agent-session-tab-activation.ts
@@ -1,3 +1,4 @@
+import { activateWorkspaceTab } from './workspace-tab-activation'
 import { getRuntimeEnvironmentIdForWorktree } from './worktree-runtime-owner'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
@@ -14,8 +15,7 @@ export function activateStructuredAgentSessionTab(args: {
   if (!tab) {
     return false
   }
-  state.focusGroup(args.worktreeId, tab.groupId)
-  state.activateTab(tab.id, { worktreeId: args.worktreeId })
+  activateWorkspaceTab(state, { worktreeId: args.worktreeId, groupId: tab.groupId, tabId: tab.id })
   state.setActiveTabType('agent-session', args.worktreeId)
   const environmentId = getRuntimeEnvironmentIdForWorktree(state, args.worktreeId)
   void callRuntimeRpc(

--- a/src/renderer/src/lib/tab-number-shortcuts.ts
+++ b/src/renderer/src/lib/tab-number-shortcuts.ts
@@ -1,3 +1,4 @@
+import { activateWorkspaceTab } from './workspace-tab-activation'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
@@ -63,8 +64,7 @@ export function activateTabNumberShortcut(index: number): boolean {
 
   const worktreeId = target.worktreeId
   const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(store, worktreeId)
-  store.focusGroup(worktreeId, target.groupId)
-  store.activateTab(target.id)
+  activateWorkspaceTab(store, { worktreeId, groupId: target.groupId, tabId: target.id })
 
   if (target.contentType === 'terminal') {
     if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {

--- a/src/renderer/src/lib/workspace-tab-activation.ts
+++ b/src/renderer/src/lib/workspace-tab-activation.ts
@@ -1,0 +1,16 @@
+import type { AppState } from '@/store/types'
+
+type WorkspaceTabActivationTarget = {
+  worktreeId: string
+  groupId: string
+  tabId: string
+}
+
+// Callers resolve the target and own workspace activation and content-specific effects.
+export function activateWorkspaceTab(
+  state: Pick<AppState, 'focusGroup' | 'activateTab'>,
+  target: WorkspaceTabActivationTarget
+): void {
+  state.focusGroup(target.worktreeId, target.groupId)
+  state.activateTab(target.tabId, { worktreeId: target.worktreeId })
+}

--- a/src/renderer/src/lib/workspace-tab-palette-activation.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-activation.ts
@@ -1,3 +1,4 @@
+import { activateWorkspaceTab } from './workspace-tab-activation'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import {
@@ -121,8 +122,7 @@ export function activateWorkspaceTabPaletteResult(
   }
 
   const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, result.worktreeId)
-  state.focusGroup(result.worktreeId, result.groupId)
-  state.activateTab(result.tabId, { worktreeId: result.worktreeId })
+  activateWorkspaceTab(state, result)
 
   if (result.contentType === 'terminal') {
     if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {

--- a/src/renderer/src/store/slices/tabs/tabs-focus-actions.test.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-focus-actions.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createTabsFocusActions } from './tabs-focus-actions'
+
+function makeState() {
+  return {
+    activeWorktreeId: 'wt-1',
+    unifiedTabsByWorktree: {
+      'wt-1': [
+        {
+          id: 'tab-terminal',
+          contentType: 'terminal',
+          entityId: 'term-1',
+          groupId: 'group-1',
+          isPreview: true,
+          lastFocusedAt: 0
+        },
+        {
+          id: 'tab-file',
+          contentType: 'file',
+          entityId: 'file-1',
+          groupId: 'group-1',
+          isPreview: true,
+          lastFocusedAt: 0
+        }
+      ]
+    },
+    groupsByWorktree: {
+      'wt-1': [
+        {
+          id: 'group-1',
+          activeTabId: 'tab-file',
+          tabOrder: ['tab-terminal', 'tab-file'],
+          recentTabIds: []
+        }
+      ]
+    },
+    activeGroupIdByWorktree: { 'wt-1': 'group-1' },
+    unreadTerminalTabs: { 'term-1': true }
+  }
+}
+
+describe('createTabsFocusActions.activateTab', () => {
+  it('activates the matching tab, clears preview, updates MRU, and dismisses active terminal unread state', () => {
+    let state = makeState()
+    const set = (updater: (s: typeof state) => typeof state) => {
+      state = { ...state, ...updater(state) }
+    }
+    const actions = createTabsFocusActions(set as never, (() => state) as never)
+    actions.activateTab('tab-terminal')
+    expect(state.groupsByWorktree['wt-1'][0].activeTabId).toBe('tab-terminal')
+    expect(state.groupsByWorktree['wt-1'][0].recentTabIds).toEqual(['tab-terminal'])
+    expect(state.unifiedTabsByWorktree['wt-1'][0].isPreview).toBe(false)
+    expect(state.unreadTerminalTabs).toEqual({})
+  })
+
+  it('preserves preview when requested and leaves nonterminal unread state alone', () => {
+    let state = makeState()
+    const unread = state.unreadTerminalTabs
+    const set = (updater: (s: typeof state) => typeof state) => {
+      state = { ...state, ...updater(state) }
+    }
+    const actions = createTabsFocusActions(set as never, (() => state) as never)
+    actions.activateTab('tab-file', { preservePreview: true })
+    expect(state.unifiedTabsByWorktree['wt-1'][1].isPreview).toBe(true)
+    expect(state.unreadTerminalTabs).toBe(unread)
+  })
+
+  it('selects tabs in a background workspace without activating that workspace or clearing its unread signal', () => {
+    let state = { ...makeState(), activeWorktreeId: 'folder:other' }
+    const unread = state.unreadTerminalTabs
+    const set = (updater: (s: typeof state) => typeof state) => {
+      state = { ...state, ...updater(state) }
+    }
+    const actions = createTabsFocusActions(set as never, (() => state) as never)
+    actions.activateTab('tab-terminal')
+    expect(state.groupsByWorktree['wt-1'][0].activeTabId).toBe('tab-terminal')
+    expect(state.activeWorktreeId).toBe('folder:other')
+    expect(state.unreadTerminalTabs).toBe(unread)
+  })
+
+  it('does not fall back to another workspace when an explicit workspace does not contain the tab', () => {
+    const state = makeState()
+    const set = vi.fn()
+    const actions = createTabsFocusActions(set as never, (() => state) as never)
+    actions.activateTab('tab-terminal', { worktreeId: 'folder:other' })
+    expect(set.mock.calls[0][0](state)).toEqual({})
+  })
+
+  it('ignores unknown ids without mutating state', () => {
+    const state = makeState()
+    const set = vi.fn()
+    const actions = createTabsFocusActions(set as never, (() => state) as never)
+    actions.activateTab('missing')
+    expect(set).toHaveBeenCalled()
+    expect(set.mock.calls[0][0](state)).toEqual({})
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## ELI5
Tab activation now has one small shared handoff: focus the requested group, then use the unified tab store with an explicit workspace scope.

## What Changed
Added `activateWorkspaceTab` and reused it across palette, browser, simulator, structured-session, tab-number, and tab-group activation paths. Added characterization tests for store semantics and content-specific terminal/browser/editor effects.

## Why
The store remains the owner of tab selection, MRU, preview promotion, and unread acknowledgement. Workspace activation and content effects remain in their existing callers.

## Linked Issue
Follow-up to #19621.

## Visual Proof
N/A — no visual layout change.

## Testing
- Targeted Vitest: 8 files, 47 tests passed.
- `pnpm tc:web` passed.
- `pnpm run check:code-quality:changed` passed.
- Electron/CDP validation is blocked because the required `$electron` skill is unavailable in this environment; no desktop automation was used.

## Checklist
- [x] Small and focused
- [x] Automated tests added
- [x] Cross-platform and remote scope considered
- [ ] Electron/CDP validation (blocked as stated above)
