### PR TITLE
feat(sidebar): distinguish projects and nested worktrees

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-card-secondary-rows.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-secondary-rows.tsx
@@ -113,7 +113,7 @@ export function WorktreeCardSecondaryRows({
       )}
 
       {!newCardStyle && lineageChildren && (
-        <div className="-ml-[1.125rem] mt-1.5 w-[calc(100%+1.125rem)] space-y-1">
+        <div className="-ml-[1.125rem] mt-1.5 w-[calc(100%+1.125rem)] space-y-1 shadow-[inset_1px_0_var(--worktree-sidebar-border)]">
           {lineageChildren}
         </div>
       )}

--- a/src/renderer/src/components/sidebar/worktree-card-surface.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-surface.tsx
@@ -59,6 +59,11 @@ export function WorktreeCardSurface({ card }: { card: WorktreeCardController }):
             : isMultiSelected
               ? 'border border-worktree-sidebar-ring/35 bg-worktree-sidebar-accent/70 ring-1 ring-worktree-sidebar-ring/30'
               : 'border border-transparent worktree-sidebar-card-hover',
+        flushSurface &&
+          !isActiveSurface &&
+          !isMultiSelected &&
+          !isLineageDropTarget &&
+          'border-b-worktree-sidebar-border/70',
         isActiveSurface && isMultiSelected && 'ring-1 ring-worktree-sidebar-ring/35',
         revealHighlight && [
           'scroll-to-current-workspace-reveal-highlight',
@@ -95,7 +100,7 @@ export function WorktreeCardSurface({ card }: { card: WorktreeCardController }):
 
       {newCardStyle && lineageChildren ? (
         <div
-          className="mt-1.5 space-y-1"
+          className="mt-1.5 space-y-1 shadow-[inset_1px_0_var(--worktree-sidebar-border)]"
           data-worktree-lineage-children=""
           style={lineageChildrenStyle}
         >

--- a/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
@@ -233,6 +233,8 @@ export function renderWorktreeSectionHeaderRow(args: {
           // Why: no row-level grab — only the title surface below shows the hand;
           // actions use cursor-pointer so … / + never look reorderable.
           'group relative flex h-7 w-full items-center gap-1.5 pr-2 text-left transition-all',
+          (isRepoHeader || isProjectGroupHeader) &&
+            'before:pointer-events-none before:absolute before:inset-x-2 before:top-0 before:border-t before:border-worktree-sidebar-border',
           !(isDraggableRepoHeader || isDraggableProjectGroupHeader) && 'cursor-pointer',
           ctx.highlightedRevealRowKey === row.key &&
             'rounded-md bg-worktree-sidebar-accent ring-1 ring-worktree-sidebar-ring/50',


### PR DESCRIPTION
## ELI5
Projects and their nested worktrees can blend together in the left sidebar. Add quiet dividing lines so each section and child workspace is easier to pick out while keeping the same compact layout.

## What Changed
- Add theme-aware hairlines to project and project-group headers.
- Add a subtle bottom separator to idle sidebar worktree cards and a vertical guide beside nested worktrees, in both existing and experimental card layouts.
- Reuse existing border tokens and surfaces; no extra row height, settings, dependencies or runtime work.

## Why
Layout density and whole-sidebar tint controls do not establish project boundaries. Three existing components can supply those cues without changing virtualization, navigation or drag/drop logic.

## Linked Issue
Fixes #19637

## Visual Proof
Light/detailed before and after, then dark/experimental before and after. Screenshots use synthetic projects in an isolated hidden Electron renderer.

![sidebar-before-detailed-light.png](https://github.com/user-attachments/assets/11062cf3-e0fd-47cf-af5a-85c5a090cf66)
![sidebar-after-detailed-light.png](https://github.com/user-attachments/assets/1a2b365b-2b9d-468a-b6b3-8c8e80f081c2)
![sidebar-before-experimental-dark.png](https://github.com/user-attachments/assets/54da08da-509e-41e8-b70d-e0dce41fe639)
![sidebar-after-experimental-dark.png](https://github.com/user-attachments/assets/50d24c94-ff39-4576-bf52-6b6fe17310bf)

## Testing
- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Windows hidden Electron: visually inspected detailed, compact and experimental layouts in light and dark (six combinations); before/after capture runs passed. Existing focused suites: **63 tests passed** across card lineage, compact hover, real child cards, indentation geometry and active selection CSS. No new implementation-mirroring tests for these visual-only class changes.

`pnpm typecheck`, `pnpm build`, changed-file Oxlint and type-aware lint passed. Design detector: no findings. `pnpm lint` reaches the existing stale generated skill-manifest check and fails on three untouched resources/skills JSON files. A previous full-suite attempt in this checkout encountered unrelated baseline failures and was interrupted; the full suite was not rerun for this styling-only change. CI should cover the full suite. macOS/Linux and live SSH were not run locally.

## AI Disclosure
Implemented with OpenAI Codex (GPT-6).

## Review
Self-review: cross-platform CSS/React only; local/SSH/remote/folder workspace paths and execution behavior unchanged. No agent or integration-specific code. Existing sidebar tokens cover themed and tinted surfaces. No row-height changes, new listeners, file reads, network calls or extra list processing. Existing selection/drop styles retain precedence. No new security surface or wire/persistence changes.

## Agent skill upstream boundary
- [x] Not applicable; no skill-installer material changed.

## Notes
Author: @husman2012. X handle not provided.
Installed app and release versions are unchanged. Theme tokens provide tint compatibility; tinted mode and live SSH were not separately exercised.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) � limitations detailed above
