### PR TITLE
fix(orchestration): own mailbox pointer recovery from durable reservations

### DIFF
--- a/src/main/runtime/orca-runtime-automation-operations.ts
+++ b/src/main/runtime/orca-runtime-automation-operations.ts
@@ -153,6 +153,7 @@ export class OrcaRuntimeWithAutomationOperations extends OrcaRuntimeWithPtyForeg
     if (!this._orchestrationDb) {
       const dbPath = join(getAppEnvironment().getPath('userData'), 'orchestration.db')
       this._orchestrationDb = new OrchestrationDb(dbPath)
+      this.orchestrationMailboxPointerDelivery.attachDatabase(this._orchestrationDb)
       this.ensureOrchestrationFederationRelay()
       this.scheduleRestoredMessageRepoints()
     }
@@ -163,6 +164,7 @@ export class OrcaRuntimeWithAutomationOperations extends OrcaRuntimeWithPtyForeg
     this.orchestrationFederation.resetForDatabaseChange()
     this.mailPointerRepointScheduler.clear()
     this._orchestrationDb = db
+    this.orchestrationMailboxPointerDelivery.attachDatabase(db)
     this.ensureOrchestrationFederationRelay()
     this.scheduleRestoredMessageRepoints()
   }

--- a/src/main/runtime/orca-runtime-test-orchestration-messages.spec.ts
+++ b/src/main/runtime/orca-runtime-test-orchestration-messages.spec.ts
@@ -170,31 +170,6 @@ export class InMemoryOrchestrationMessages {
     this.clearMailboxPointerEnter(released)
   }
 
-  releasePendingMailboxPointerForPty(ptyId: string): void {
-    const reservedIds = new Set(
-      this.messages
-        .filter(
-          (message) => message.pointer_enter_pending === 1 && message.pointer_pty_id === ptyId
-        )
-        .map((message) => message.id)
-    )
-    const pendingIds = new Set(
-      this.messages
-        .filter(
-          (message) => (message.pointer_enter_pending ?? 0) > 0 && message.pointer_pty_id === ptyId
-        )
-        .map((message) => message.id)
-    )
-    for (const message of this.messages) {
-      if (reservedIds.has(message.id) && message.read === 0) {
-        message.delivered_at = null
-      } else if (pendingIds.has(message.id) && message.read === 0) {
-        message.delivered_at ??= '1970-01-01 00:00:00'
-      }
-    }
-    this.clearMailboxPointerEnter(pendingIds)
-  }
-
   setActiveCoordinatorRun(run: { coordinator_handle: string } | null): void {
     this.activeCoordinatorRun = run
   }
@@ -275,6 +250,43 @@ export class InMemoryOrchestrationMessages {
       }
     }
     this.clearMailboxPointerEnter(deliveredIds)
+  }
+
+  // Recovery fences on connection identity; the real OrchestrationDb exposes `.db`.
+  db = { connection: 'in-memory-fake' }
+
+  private reservations(ptyId?: string): {
+    id: string
+    read: number
+    pointer_pty_id: string
+    pointer_process_incarnation: string
+    pointer_enter_pending: number
+    to_handle: string
+  }[] {
+    return this.messages
+      .filter(
+        (message) =>
+          (message.pointer_enter_pending ?? 0) > 0 &&
+          (ptyId === undefined || message.pointer_pty_id === ptyId)
+      )
+      .map((message) => ({
+        id: message.id,
+        read: message.read,
+        pointer_pty_id: message.pointer_pty_id as string,
+        pointer_process_incarnation: message.pointer_process_incarnation as string,
+        pointer_enter_pending: message.pointer_enter_pending ?? 0,
+        to_handle: message.to_handle
+      }))
+  }
+
+  getMailboxPointerReservations(): ReturnType<InMemoryOrchestrationMessages['reservations']> {
+    return this.reservations()
+  }
+
+  getMailboxPointerReservationsForPty(
+    ptyId: string
+  ): ReturnType<InMemoryOrchestrationMessages['reservations']> {
+    return this.reservations(ptyId)
   }
 
   markAsUndelivered(ids: string[]): void {

--- a/src/main/runtime/orchestration-messages-fake-parity.test.ts
+++ b/src/main/runtime/orchestration-messages-fake-parity.test.ts
@@ -16,6 +16,11 @@ type PointerStore = {
   }): { id: string }
   stageMailboxPointerEnter(ids: string[], target: PointerTarget): boolean
   markMailboxPointerWriteAttempted(ids: string[], target: PointerTarget): boolean
+  getMailboxPointerReservationsForPty(ptyId: string): {
+    id: string
+    read: number
+    pointer_enter_pending: number
+  }[]
   getUndeliveredUnreadMessages(
     toHandle: string,
     types?: MessageType[],
@@ -33,6 +38,30 @@ const STORES: [string, () => PointerStore][] = [
 describe.each(STORES)('mailbox pointer reservations (%s)', (_name, createStore) => {
   const rival = { ptyId: 'pty-rival', processIncarnation: 'rival:1' }
   const mine = { ptyId: 'pty-mine', processIncarnation: 'mine:1' }
+
+  // Why: recovery reads reservations from this query, so a fake that answers differently makes
+  // every fake-driven runtime test blind to the mechanism it is supposed to exercise.
+  it("reports one PTY's reservations, every phase, including already-read rows", () => {
+    const store = createStore()
+    const message = store.insertMessage({
+      runId: 'run_legacy_local',
+      from: 'term_sender',
+      to: 'term_mine',
+      subject: 'mail'
+    })
+    expect(store.stageMailboxPointerEnter([message.id], mine)).toBe(true)
+    expect(
+      store.getMailboxPointerReservationsForPty(mine.ptyId).map((row) => ({
+        id: row.id,
+        pending: row.pointer_enter_pending
+      }))
+    ).toEqual([{ id: message.id, pending: 1 }])
+    expect(store.getMailboxPointerReservationsForPty(rival.ptyId)).toEqual([])
+    expect(store.markMailboxPointerWriteAttempted([message.id], mine)).toBe(true)
+    expect(
+      store.getMailboxPointerReservationsForPty(mine.ptyId).map((row) => row.pointer_enter_pending)
+    ).toEqual([2])
+  })
 
   it('refuses a claim another flight already holds', () => {
     const store = createStore()

--- a/src/main/runtime/orchestration/db/messages/mailbox-pointer-enter-state.ts
+++ b/src/main/runtime/orchestration/db/messages/mailbox-pointer-enter-state.ts
@@ -11,6 +11,37 @@ export type MailboxPointerReservationTarget = {
   processIncarnation: string
 }
 
+export type MailboxPointerReservation = {
+  id: string
+  read: number
+  pointer_pty_id: string
+  pointer_process_incarnation: string
+  pointer_enter_pending: number
+  to_handle: string
+}
+
+const RESERVATION_COLUMNS =
+  'id, read, pointer_pty_id, pointer_process_incarnation, pointer_enter_pending, to_handle'
+
+// Served by idx_messages_pending_pointer_pty; named columns keep the statement cacheable.
+export function getMailboxPointerReservationsForPty(
+  this: OrchestrationDb,
+  ptyId: string
+): MailboxPointerReservation[] {
+  return this.db
+    .prepare(
+      `SELECT ${RESERVATION_COLUMNS} FROM messages
+       WHERE pointer_pty_id = ? AND pointer_enter_pending > 0`
+    )
+    .all(ptyId) as MailboxPointerReservation[]
+}
+
+export function getMailboxPointerReservations(this: OrchestrationDb): MailboxPointerReservation[] {
+  return this.db
+    .prepare(`SELECT ${RESERVATION_COLUMNS} FROM messages WHERE pointer_enter_pending > 0`)
+    .all() as MailboxPointerReservation[]
+}
+
 export function getPendingMailboxPointerMessages(
   this: OrchestrationDb,
   mailboxHandle: string
@@ -154,22 +185,6 @@ export function releaseMailboxPointerEnter(
   }))
 }
 
-export function releasePendingMailboxPointerForPty(this: OrchestrationDb, ptyId: string): void {
-  this.db
-    .prepare(
-      `UPDATE messages
-       SET delivered_at = CASE
-             WHEN read = 0 AND pointer_enter_pending = ? THEN NULL
-             WHEN read = 0 THEN COALESCE(delivered_at, datetime('now'))
-             ELSE delivered_at
-           END,
-           pointer_enter_pending = 0, pointer_pty_id = NULL,
-           pointer_process_incarnation = NULL
-       WHERE pointer_enter_pending > 0 AND pointer_pty_id = ?`
-    )
-    .run(MAILBOX_POINTER_RESERVED, ptyId)
-}
-
 function mutatePointerMessages(
   db: OrchestrationDb,
   ids: string[],
@@ -204,6 +219,8 @@ function mutatePointerMessages(
 }
 
 export type MailboxPointerEnterStateMethods = {
+  getMailboxPointerReservations: typeof getMailboxPointerReservations
+  getMailboxPointerReservationsForPty: typeof getMailboxPointerReservationsForPty
   getPendingMailboxPointerMessages: typeof getPendingMailboxPointerMessages
   getPendingMailboxPointerHandles: typeof getPendingMailboxPointerHandles
   stageMailboxPointerEnter: typeof stageMailboxPointerEnter
@@ -211,18 +228,18 @@ export type MailboxPointerEnterStateMethods = {
   markMailboxPointerEnterAttempted: typeof markMailboxPointerEnterAttempted
   settleMailboxPointerEnter: typeof settleMailboxPointerEnter
   releaseMailboxPointerEnter: typeof releaseMailboxPointerEnter
-  releasePendingMailboxPointerForPty: typeof releasePendingMailboxPointerForPty
 }
 
 export function attachMailboxPointerEnterState(ctor: { prototype: object }): void {
   Object.assign(ctor.prototype, {
+    getMailboxPointerReservations,
+    getMailboxPointerReservationsForPty,
     getPendingMailboxPointerMessages,
     getPendingMailboxPointerHandles,
     stageMailboxPointerEnter,
     markMailboxPointerWriteAttempted,
     markMailboxPointerEnterAttempted,
     settleMailboxPointerEnter,
-    releaseMailboxPointerEnter,
-    releasePendingMailboxPointerForPty
+    releaseMailboxPointerEnter
   })
 }

--- a/src/main/runtime/orchestration/db/schema/schema-column-probes.ts
+++ b/src/main/runtime/orchestration/db/schema/schema-column-probes.ts
@@ -28,7 +28,7 @@ export function createMailboxDeliveryIndexesIfPossible(this: OrchestrationDb): v
         WHERE read = 0 AND pointer_enter_pending > 0;
     `)
     if (this.hasColumn('messages', 'pointer_pty_id')) {
-      // Working-title frames release one PTY's reservations, including already-read rows.
+      // Working-title frames read one PTY's reservations, every phase and already-read rows.
       this.db.exec(`
         CREATE INDEX IF NOT EXISTS idx_messages_pending_pointer_pty
           ON messages(pointer_pty_id) WHERE pointer_enter_pending > 0;

--- a/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
@@ -7,10 +7,17 @@ import {
 import type { OrchestrationMailboxLeaf } from './mailbox-owner'
 import {
   OrchestrationMailboxPointerState,
+  getMailboxPointerFlightDb,
   type OrchestrationMailboxDeliveryFlight
 } from './mailbox-pointer-state'
 import { resumePendingOrchestrationMailboxPointer } from './mailbox-pointer-resume'
 import { stageOrchestrationMailboxPointer } from './mailbox-pointer-stage'
+import { MailboxPointerRecovery } from './mailbox-pointer-recovery'
+import {
+  MAILBOX_POINTER_RESERVED,
+  MAILBOX_POINTER_WRITE_ATTEMPTED
+} from './db/messages/mailbox-pointer-enter-state'
+import type { OrchestrationDb } from './db'
 
 export type { OrchestrationMessageWaiter } from './mailbox-pointer-eligibility'
 
@@ -26,7 +33,14 @@ function pointerEnterDelayMs(): number {
 export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMessageWaiter> {
   private readonly state = new OrchestrationMailboxPointerState()
   private readonly coldParkedPtys = new Set<string>()
-  constructor(private readonly deps: PointerDeliveryDependencies<TWaiter>) {}
+  private readonly recovery: MailboxPointerRecovery<TWaiter>
+  constructor(private readonly deps: PointerDeliveryDependencies<TWaiter>) {
+    this.recovery = new MailboxPointerRecovery(deps, this.state)
+  }
+
+  attachDatabase(db: OrchestrationDb | null): void {
+    this.recovery.attach(db)
+  }
 
   deliverForHandle(handle: string, reservedTypes?: ReadonlySet<string>): void {
     const terminalHandle = this.deps.deliveryTarget.resolveTerminalHandle(handle)
@@ -56,6 +70,7 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
     }
   ): void {
     const db = this.deps.getDb()
+    this.attachDatabase(db)
     const mailboxHandle = options.mailboxHandle
     if (!db || (!mailboxHandle.startsWith('run:') && !mailboxHandle.startsWith('dispatch:'))) {
       return
@@ -163,7 +178,21 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
       clearTimeout(flight.enterTimer)
     }
     if (flight?.stagedMessageIds.length) {
-      this.deps.getDb()?.markAsUndelivered(flight.stagedMessageIds)
+      const db = getMailboxPointerFlightDb(flight, this.deps.getDb)
+      if (db && flight.reservation) {
+        const target = { ptyId, processIncarnation: flight.reservation.processIncarnation }
+        // Why: the Enter timer was just cleared, so a reserved or merely-written pointer provably
+        // never submitted and has to stay redeliverable. An attempted Enter is left at its phase
+        // for the resume path to revalidate, exactly as an unverifiable settlement does.
+        db.releaseMailboxPointerEnter(flight.stagedMessageIds, target, [
+          MAILBOX_POINTER_RESERVED,
+          MAILBOX_POINTER_WRITE_ATTEMPTED
+        ])
+      } else if (!flight.reservation) {
+        // Why: a flight the fence rejected belongs to a replaced database, and writing its ids
+        // into the current one would target rows this connection never reserved.
+        this.deps.getDb()?.markAsUndelivered(flight.stagedMessageIds)
+      }
     }
     for (const mailboxHandle of releasedMailboxes) {
       this.redrive(mailboxHandle, true)
@@ -172,15 +201,16 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
 
   observeAgentWorking(ptyId: string): void {
     try {
+      this.attachDatabase(this.deps.getDb())
       // Staged pointer text is already queued in the composer; working is queue-safe.
-      if (this.state.hasFlight(ptyId)) {
+      if (this.state.observeWorkingFlight(ptyId)) {
         if (this.coldParkedPtys.has(ptyId)) {
           this.state.deferFlightUntilIdle(ptyId)
         }
         return
       }
       this.retirePty(ptyId)
-      this.deps.getDb()?.releasePendingMailboxPointerForPty(ptyId)
+      this.recovery.observeWorking(ptyId)
     } catch {
       // Runtime teardown can close the DB before the final PTY frame is drained.
     }
@@ -217,7 +247,29 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
   }
 
   private settle(ptyId: string, flight: OrchestrationMailboxDeliveryFlight): void {
+    if (!this.state.isCurrentFlight(ptyId, flight)) {
+      return
+    }
     const parked = this.state.settleFlight(ptyId, flight)
+    if (flight.reservation && !getMailboxPointerFlightDb(flight, this.deps.getDb)) {
+      // Why: a swapped database strands this flight; both the watermarked mailboxes and any
+      // delivery parked behind it need an explicit redrive or they never drain.
+      for (const mailboxHandle of this.state.retirePty(ptyId).releasedMailboxes) {
+        this.redrive(mailboxHandle, true)
+      }
+      for (const [mailboxHandle, delivery] of parked ?? []) {
+        this.parkRedelivery(mailboxHandle, delivery.reservedTypes)
+        this.redrive(mailboxHandle)
+      }
+      return
+    }
+    if (flight.workingObserved && flight.reservation) {
+      try {
+        this.recovery.settle(ptyId, flight.stagedMessageIds, flight.reservation.processIncarnation)
+      } catch {
+        // A later observation retries durable recovery after an ambiguous settlement.
+      }
+    }
     if (!parked) {
       return
     }

--- a/src/main/runtime/orchestration/mailbox-pointer-recovery.test.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-recovery.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrchestrationDb } from './db'
+import { OrchestrationMailboxPointerDelivery } from './mailbox-pointer-delivery'
+import type { PointerDeliveryDependencies } from './mailbox-pointer-delivery-contract'
+import type { OrchestrationMailboxLeaf } from './mailbox-owner'
+
+function harness(initial: OrchestrationDb) {
+  let db = initial
+  let incarnation = 'inc-1'
+  const leaf: OrchestrationMailboxLeaf = {
+    tabId: 'tab',
+    leafId: 'leaf',
+    ptyId: 'pty',
+    writable: true,
+    lastAgentStatus: 'working',
+    lastOscTitle: null,
+    lastAgentStatusObservedLive: true
+  }
+  const deps = {
+    getDb: () => db,
+    deliveryTarget: { resolveTerminalHandle: () => 'term' },
+    getLiveLeafForHandle: () => leaf,
+    resolveSubmitTarget: () => ({ leaf, terminalHandle: 'term', processIncarnation: incarnation }),
+    redriveMailbox: vi.fn()
+  } as unknown as PointerDeliveryDependencies<never>
+  const owner = new OrchestrationMailboxPointerDelivery(deps)
+  owner.attachDatabase(db)
+  return {
+    owner,
+    leaf,
+    replace(next: OrchestrationDb) {
+      db = next
+      owner.attachDatabase(db)
+    },
+    setIncarnation(next: string) {
+      incarnation = next
+    }
+  }
+}
+
+function pending(db: OrchestrationDb, phase = 1, incarnation = 'inc-1') {
+  const message = db.insertMessage({ from: 'a', to: 'run:r', subject: 'mail' })
+  db.db
+    .prepare(`UPDATE messages SET pointer_enter_pending = ?, pointer_pty_id = 'pty',
+    pointer_process_incarnation = ? WHERE id = ?`)
+    .run(phase, incarnation, message.id)
+  return message.id
+}
+
+describe('reservation-owned pointer recovery', () => {
+  it.each([1, 2, 3])(
+    'reconciles a committed phase %s reservation on the next working edge',
+    (phase) => {
+      const db = new OrchestrationDb(':memory:')
+      try {
+        const { owner } = harness(db)
+        const id = pending(db, phase)
+        expect(db.getMessageById(id)?.pointer_enter_pending).toBe(phase)
+        owner.observeAgentWorking('pty')
+        expect(db.getMessageById(id)).toMatchObject({
+          pointer_enter_pending: 0,
+          read: 0,
+          // A merely-reserved pointer stays redeliverable; a written or submitted one is settled.
+          delivered_at: phase === 1 ? null : expect.any(String)
+        })
+      } finally {
+        db.close()
+      }
+    }
+  )
+
+  it('never writes on a working edge while the pane holds no reservation', () => {
+    const db = new OrchestrationDb(':memory:')
+    try {
+      const { owner } = harness(db)
+      const prepare = vi.spyOn(db.db, 'prepare')
+      for (let i = 0; i < 500; i++) {
+        owner.observeAgentWorking('pty')
+      }
+      const mutations = prepare.mock.calls
+        .map(([sql]) => String(sql).trimStart().toUpperCase())
+        .filter((sql) => !sql.startsWith('SELECT'))
+      expect(mutations).toEqual([])
+      prepare.mockRestore()
+    } finally {
+      db.close()
+    }
+  })
+
+  it('reconciles a reservation already committed before attach', () => {
+    const db = new OrchestrationDb(':memory:')
+    try {
+      const stranded = pending(db, 2)
+      harness(db)
+      expect(db.getMessageById(stranded)?.pointer_enter_pending).toBe(0)
+    } finally {
+      db.close()
+    }
+  })
+
+  it('clears an already-read reservation instead of leaking it in the index', () => {
+    const db = new OrchestrationDb(':memory:')
+    try {
+      const { owner } = harness(db)
+      const id = pending(db, 1)
+      // A legacy acknowledge marks a message read without clearing its pointer columns.
+      db.db.prepare('UPDATE messages SET read = 1 WHERE id = ?').run(id)
+      owner.observeAgentWorking('pty')
+      expect(db.getMessageById(id)?.pointer_enter_pending).toBe(0)
+      // A second edge must find nothing left to write.
+      const prepare = vi.spyOn(db.db, 'prepare')
+      owner.observeAgentWorking('pty')
+      expect(
+        prepare.mock.calls
+          .map(([sql]) => String(sql).trimStart().toUpperCase())
+          .filter((sql) => !sql.startsWith('SELECT'))
+      ).toEqual([])
+      prepare.mockRestore()
+    } finally {
+      db.close()
+    }
+  })
+
+  it('fences a replaced database and a reused PTY incarnation', () => {
+    const original = new OrchestrationDb(':memory:')
+    const replacement = new OrchestrationDb(':memory:')
+    try {
+      const { owner, replace, setIncarnation } = harness(original)
+      replace(replacement)
+      // The detached database is no longer owned, so its rows must be left untouched.
+      const detached = pending(original, 2)
+      owner.observeAgentWorking('pty')
+      expect(original.getMessageById(detached)?.pointer_enter_pending).toBe(2)
+
+      setIncarnation('inc-2')
+      const previousIncarnation = pending(replacement, 2)
+      owner.observeAgentWorking('pty')
+      expect(replacement.getMessageById(previousIncarnation)?.pointer_enter_pending).toBe(2)
+
+      const current = pending(replacement, 2, 'inc-2')
+      owner.observeAgentWorking('pty')
+      expect(replacement.getMessageById(current)?.pointer_enter_pending).toBe(0)
+    } finally {
+      original.close()
+      replacement.close()
+    }
+  })
+})

--- a/src/main/runtime/orchestration/mailbox-pointer-recovery.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-recovery.ts
@@ -1,0 +1,109 @@
+import type { OrchestrationDb } from './db'
+import {
+  MAILBOX_POINTER_RESERVED,
+  type MailboxPointerReservation
+} from './db/messages/mailbox-pointer-enter-state'
+import type { PointerDeliveryDependencies } from './mailbox-pointer-delivery-contract'
+import type { OrchestrationMessageWaiter } from './mailbox-pointer-eligibility'
+import type { OrchestrationMailboxPointerState } from './mailbox-pointer-state'
+
+/** Reconciles mailbox pointer reservations this runtime still owns, reading them straight from
+ *  the durable rows through `idx_messages_pending_pointer_pty` so no in-memory mirror can drift.
+ *  Rows from an earlier process fail the incarnation fence here and are reclaimed instead by the
+ *  idle-edge resume path. */
+export class MailboxPointerRecovery<TWaiter extends OrchestrationMessageWaiter> {
+  private connection?: OrchestrationDb['db']
+
+  constructor(
+    private readonly deps: PointerDeliveryDependencies<TWaiter>,
+    private readonly state: OrchestrationMailboxPointerState
+  ) {}
+
+  attach(db: OrchestrationDb | null): void {
+    if (this.connection === db?.db) {
+      return
+    }
+    this.connection = db?.db
+    this.state.clear()
+    if (!db) {
+      return
+    }
+    try {
+      // An already-read row's message is consumed, so its reservation is garbage whether or not
+      // the pane that made it still lives; otherwise it leaks in the partial index forever.
+      this.reconcile(
+        db,
+        db.getMailboxPointerReservations().filter((row) => row.read !== 0 || this.isLive(row))
+      )
+    } catch {
+      // Why: attach runs during database construction; a failed sweep must not escape and
+      // strand the federation relay started right after it. The next edge retries recovery.
+    }
+  }
+
+  observeWorking(ptyId: string): void {
+    const db = this.deps.getDb()
+    this.attach(db)
+    if (!db) {
+      return
+    }
+    this.reconcile(
+      db,
+      db.getMailboxPointerReservationsForPty(ptyId).filter((row) => this.isLive(row))
+    )
+  }
+
+  settle(ptyId: string, ids: readonly string[], incarnation: string): void {
+    const db = this.deps.getDb()
+    if (!db || this.connection !== db.db) {
+      return
+    }
+    const selected = new Set(ids)
+    this.reconcile(
+      db,
+      db
+        .getMailboxPointerReservationsForPty(ptyId)
+        .filter((row) => selected.has(row.id) && row.pointer_process_incarnation === incarnation)
+    )
+  }
+
+  /** A reservation is only recoverable while the pane still runs the incarnation that made it. */
+  private isLive(row: MailboxPointerReservation): boolean {
+    try {
+      const handle = this.deps.deliveryTarget.resolveTerminalHandle(row.to_handle)
+      if (!handle) {
+        return false
+      }
+      const leaf = this.deps.getLiveLeafForHandle(handle)
+      return (
+        leaf.ptyId === row.pointer_pty_id &&
+        this.deps.resolveSubmitTarget(leaf, row.pointer_pty_id)?.processIncarnation ===
+          row.pointer_process_incarnation
+      )
+    } catch {
+      // Attach may precede terminal restoration; the next observation retries recovery.
+      return false
+    }
+  }
+
+  private reconcile(db: OrchestrationDb, rows: readonly MailboxPointerReservation[]): void {
+    for (const row of rows) {
+      // Why: a live flight owns its own settlement; observing it here would also mark it
+      // working, licensing a settle for a pane that never produced a working edge.
+      if (this.state.hasFlight(row.pointer_pty_id)) {
+        continue
+      }
+      const target = {
+        ptyId: row.pointer_pty_id,
+        processIncarnation: row.pointer_process_incarnation
+      }
+      // Why: releasing is gated on `read = 0`, so an already-read row could never clear and
+      // would leak in the partial index, re-probing on every later working edge.
+      if (row.read === 0 && row.pointer_enter_pending === MAILBOX_POINTER_RESERVED) {
+        db.releaseMailboxPointerEnter([row.id], target, [row.pointer_enter_pending])
+      } else {
+        db.settleMailboxPointerEnter([row.id], target, [row.pointer_enter_pending])
+      }
+    }
+  }
+}

--- a/src/main/runtime/orchestration/mailbox-pointer-release-query.test.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-release-query.test.ts
@@ -6,20 +6,22 @@ import Database from '../../sqlite/sync-database'
 import { OrchestrationDb } from './db'
 
 function assertTargetedRelease(db: OrchestrationDb): void {
+  const message = db.insertMessage({ from: 'sender', to: 'recipient', subject: 'plan probe' })
+  db.stageMailboxPointerEnter([message.id], { ptyId: 'absent-pty', processIncarnation: 'probe' })
   const prepare = vi.spyOn(db.db, 'prepare')
-  db.releasePendingMailboxPointerForPty('absent-pty')
-  const sql = prepare.mock.calls.find(([query]) => query.startsWith('UPDATE messages'))?.[0]
+  db.getMailboxPointerReservationsForPty('absent-pty')
+  const sql = prepare.mock.calls.find(([query]) => query.startsWith('SELECT'))?.[0]
   prepare.mockRestore()
   expect(sql).toBeDefined()
-  const plan = db.db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(1, 'absent-pty') as {
+  const plan = db.db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all('absent-pty') as {
     detail: string
   }[]
   expect(plan.some(({ detail }) => detail.includes('SCAN messages'))).toBe(false)
   expect(plan.some(({ detail }) => detail.includes('idx_messages_pending_pointer_pty'))).toBe(true)
 }
 
-describe('PTY mailbox reservation cleanup', () => {
-  it('uses a PTY lookup and preserves reservation settlement semantics', () => {
+describe('PTY mailbox reservation lookup', () => {
+  it("reads one PTY's reservations through the partial index, never a scan", () => {
     const db = new OrchestrationDb(':memory:')
     try {
       const seed = db.db.prepare(`INSERT INTO messages
@@ -37,21 +39,13 @@ describe('PTY mailbox reservation cleanup', () => {
       seed.run('other', 0, 1, 'other-pty', null)
       db.db.exec('COMMIT')
       assertTargetedRelease(db)
-      db.releasePendingMailboxPointerForPty('target')
-      const read = (id: string) => db.db.prepare('SELECT * FROM messages WHERE id = ?').get(id)
-      for (const id of ['reserved', 'written', 'entered', 'read']) {
-        expect(read(id)).toMatchObject({
-          pointer_enter_pending: 0,
-          pointer_pty_id: null,
-          pointer_process_incarnation: null
-        })
-      }
-      expect(read('reserved')).toMatchObject({ delivered_at: null, read: 0 })
-      expect(read('written')).toMatchObject({ delivered_at: expect.any(String), read: 0 })
-      expect(read('entered')).toMatchObject({ delivered_at: expect.any(String), read: 0 })
-      expect(read('read')).toMatchObject({ delivered_at: '2026-01-01 00:00:00', read: 1 })
-      expect(read('other')).toMatchObject({ pointer_enter_pending: 1, pointer_pty_id: 'other-pty' })
-      expect(read('history-0')).toMatchObject({ read: 1, delivered_at: null })
+      // Every phase for the PTY, already-read rows included, and nothing from another PTY.
+      expect(
+        db
+          .getMailboxPointerReservationsForPty('target')
+          .map((row) => row.id)
+          .sort()
+      ).toEqual(['entered', 'read', 'reserved', 'written'])
     } finally {
       db.close()
     }

--- a/src/main/runtime/orchestration/mailbox-pointer-stage.test.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-stage.test.ts
@@ -5,6 +5,7 @@ import { OrchestrationMailboxPointerState } from './mailbox-pointer-state'
 import { stageOrchestrationMailboxPointer } from './mailbox-pointer-stage'
 import {
   WRITE_ACCEPTED,
+  writeUnverifiable,
   writeRefused,
   type WriteSettlement
 } from '../../../shared/pty-write-settlement'
@@ -19,7 +20,10 @@ const LEAF = {
   lastOscTitle: null
 }
 
-function pointerDeps(db: OrchestrationDb, writePty: () => WriteSettlement) {
+function pointerDeps(
+  db: OrchestrationDb,
+  writePty: () => WriteSettlement | Promise<WriteSettlement>
+) {
   return {
     mailboxOwner: { resolve: () => 'run:run-1' },
     deliveryTarget: { resolveTerminalHandle: () => 'term-1', deferForAbsenceProbe: () => false },
@@ -57,6 +61,200 @@ function stageArgs(db: OrchestrationDb, state: OrchestrationMailboxPointerState)
 }
 
 describe('mailbox pointer staging watermark', () => {
+  it('reconciles an uncertain Enter from working evidence retained by its flight', async () => {
+    vi.useFakeTimers()
+    const db = new OrchestrationDb(':memory:')
+    let finish!: (settlement: WriteSettlement) => void
+    const writePty = vi
+      .fn<() => WriteSettlement | Promise<WriteSettlement>>()
+      .mockReturnValueOnce(WRITE_ACCEPTED)
+      .mockImplementationOnce(
+        () =>
+          new Promise<WriteSettlement>((resolve) => {
+            finish = resolve
+          })
+      )
+    const delivery = new OrchestrationMailboxPointerDelivery(pointerDeps(db, writePty) as never)
+    try {
+      const message = db.insertMessage({ from: 'a', to: 'run:run-1', subject: 'mail' })
+      delivery.deliver(LEAF, { mailboxHandle: 'run:run-1' })
+      await vi.advanceTimersByTimeAsync(1000)
+      delivery.observeAgentWorking('pty-1')
+      expect(db.getMessageById(message.id)?.pointer_enter_pending).toBe(3)
+      finish(writeUnverifiable('transport_settlement_lost', true))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(db.getMessageById(message.id)).toMatchObject({
+        pointer_enter_pending: 0,
+        read: 0,
+        delivered_at: expect.any(String)
+      })
+      expect(writePty).toHaveBeenCalledTimes(2)
+    } finally {
+      delivery.retirePty('pty-1')
+      db.close()
+      vi.useRealTimers()
+    }
+  })
+  it.each(['accepted', 'unverifiable'] as const)(
+    'fences %s Enter settlement after database replacement',
+    async (outcome) => {
+      vi.useFakeTimers()
+      const original = new OrchestrationDb(':memory:')
+      const replacement = new OrchestrationDb(':memory:')
+      let current = original
+      let finish!: (settlement: WriteSettlement) => void
+      const writePty = vi
+        .fn<() => WriteSettlement | Promise<WriteSettlement>>()
+        .mockReturnValueOnce(WRITE_ACCEPTED)
+        .mockImplementationOnce(
+          () =>
+            new Promise<WriteSettlement>((resolve) => {
+              finish = resolve
+            })
+        )
+      const delivery = new OrchestrationMailboxPointerDelivery({
+        ...pointerDeps(original, writePty),
+        getDb: () => current
+      } as never)
+      try {
+        const old = original.insertMessage({ from: 'a', to: 'run:run-1', subject: 'old' })
+        const message = replacement.insertMessage({ from: 'a', to: 'run:run-1', subject: 'new' })
+        replacement.stageMailboxPointerEnter([message.id], {
+          ptyId: 'pty-1',
+          processIncarnation: 'inc-1'
+        })
+        delivery.deliver(LEAF, { mailboxHandle: 'run:run-1' })
+        await vi.advanceTimersByTimeAsync(1000)
+        expect(original.getMessageById(old.id)?.pointer_enter_pending).toBe(3)
+        delivery.observeAgentWorking('pty-1')
+        current = replacement
+        const prepare = vi.spyOn(replacement.db, 'prepare')
+        finish(
+          outcome === 'accepted'
+            ? WRITE_ACCEPTED
+            : writeUnverifiable('transport_settlement_lost', true)
+        )
+        await vi.advanceTimersByTimeAsync(0)
+        expect(prepare).not.toHaveBeenCalled()
+        prepare.mockRestore()
+        delivery.observeAgentWorking('pty-1')
+        expect(replacement.getMessageById(message.id)?.pointer_enter_pending).toBe(0)
+        expect(writePty).toHaveBeenCalledTimes(2)
+      } finally {
+        delivery.retirePty('pty-1')
+        original.close()
+        replacement.close()
+        vi.useRealTimers()
+      }
+    }
+  )
+  it('reconciles working observed during an uncertain paste without another title', async () => {
+    const db = new OrchestrationDb(':memory:')
+    let finish!: (settlement: WriteSettlement) => void
+    const writePty = vi.fn(
+      () =>
+        new Promise<WriteSettlement>((resolve) => {
+          finish = resolve
+        })
+    )
+    const delivery = new OrchestrationMailboxPointerDelivery(pointerDeps(db, writePty) as never)
+    try {
+      const message = db.insertMessage({ from: 'a', to: 'run:run-1', subject: 'first' })
+      delivery.deliver(LEAF, { mailboxHandle: 'run:run-1' })
+      delivery.observeAgentWorking('pty-1')
+      expect(db.getMessageById(message.id)?.pointer_enter_pending).toBe(2)
+      finish(writeUnverifiable('transport_settlement_lost', true))
+      await new Promise((resolve) => setImmediate(resolve))
+      expect(db.getMessageById(message.id)).toMatchObject({
+        pointer_enter_pending: 0,
+        read: 0,
+        delivered_at: expect.any(String)
+      })
+      expect(writePty).toHaveBeenCalledTimes(1)
+      delivery.observeAgentWorking('pty-1')
+      const prepare = vi.spyOn(db.db, 'prepare')
+      for (let i = 0; i < 5000; i++) {
+        delivery.observeAgentWorking(`inactive-${i}`)
+      }
+      // A pane holding no reservation reads the partial index and must never write.
+      expect(
+        prepare.mock.calls
+          .map(([sql]) => String(sql).trimStart().toUpperCase())
+          .filter((sql) => !sql.startsWith('SELECT'))
+      ).toEqual([])
+    } finally {
+      delivery.retirePty('pty-1')
+      db.close()
+    }
+  })
+
+  it('recovers a reservation created after an earlier same-status observation', () => {
+    const db = new OrchestrationDb(':memory:')
+    const delivery = new OrchestrationMailboxPointerDelivery(
+      pointerDeps(db, () => WRITE_ACCEPTED) as never
+    )
+    try {
+      delivery.observeAgentWorking('pty-1')
+      const message = db.insertMessage({ from: 'a', to: 'run:run-1', subject: 'mail' })
+      db.stageMailboxPointerEnter([message.id], { ptyId: 'pty-1', processIncarnation: 'inc-1' })
+      delivery.observeAgentWorking('pty-1')
+      expect(db.getMessageById(message.id)).toMatchObject({
+        pointer_enter_pending: 0,
+        delivered_at: null,
+        read: 0
+      })
+    } finally {
+      db.close()
+    }
+  })
+
+  it.each(['accepted', 'unverifiable'] as const)(
+    'retires a %s paste flight across database replacement',
+    async (outcome) => {
+      const original = new OrchestrationDb(':memory:')
+      const replacement = new OrchestrationDb(':memory:')
+      let current = original
+      let finish!: (settlement: WriteSettlement) => void
+      const writePty = vi.fn(
+        () =>
+          new Promise<WriteSettlement>((resolve) => {
+            finish = resolve
+          })
+      )
+      const delivery = new OrchestrationMailboxPointerDelivery({
+        ...pointerDeps(original, writePty),
+        getDb: () => current
+      } as never)
+      try {
+        original.insertMessage({ from: 'a', to: 'run:run-1', subject: 'old' })
+        const message = replacement.insertMessage({ from: 'a', to: 'run:run-1', subject: 'new' })
+        replacement.stageMailboxPointerEnter([message.id], {
+          ptyId: 'pty-1',
+          processIncarnation: 'inc-1'
+        })
+        delivery.deliver(LEAF, { mailboxHandle: 'run:run-1' })
+        delivery.observeAgentWorking('pty-1')
+        current = replacement
+        const prepare = vi.spyOn(replacement.db, 'prepare')
+        finish(
+          outcome === 'accepted'
+            ? WRITE_ACCEPTED
+            : writeUnverifiable('transport_settlement_lost', true)
+        )
+        await new Promise((resolve) => setImmediate(resolve))
+        expect(prepare).not.toHaveBeenCalled()
+        prepare.mockRestore()
+        expect(replacement.getMessageById(message.id)?.pointer_enter_pending).toBe(1)
+        delivery.observeAgentWorking('pty-1')
+        expect(replacement.getMessageById(message.id)?.pointer_enter_pending).toBe(0)
+        expect(writePty).toHaveBeenCalledTimes(1)
+      } finally {
+        delivery.retirePty('pty-1')
+        original.close()
+        replacement.close()
+      }
+    }
+  )
   it('leaves no watermark when the reservation claim is lost', () => {
     const db = new OrchestrationDb(':memory:')
     const message = db.insertMessage({

--- a/src/main/runtime/orchestration/mailbox-pointer-stage.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-stage.ts
@@ -1,4 +1,5 @@
 import { isCursorAgentTitle } from '../../../shared/agent-detection'
+import { MAILBOX_POINTER_WRITE_ATTEMPTED } from './db/messages/mailbox-pointer-enter-state'
 import { formatMessagePointer } from './formatter'
 import type {
   OrchestrationMailboxPointerMessage,
@@ -9,9 +10,10 @@ import {
   type OrchestrationMessageWaiter
 } from './mailbox-pointer-eligibility'
 import type { OrchestrationMailboxLeaf } from './mailbox-owner'
-import type {
-  OrchestrationMailboxDeliveryFlight,
-  OrchestrationMailboxPointerState
+import {
+  getMailboxPointerFlightDb,
+  type OrchestrationMailboxDeliveryFlight,
+  type OrchestrationMailboxPointerState
 } from './mailbox-pointer-state'
 import { submitOrchestrationMailboxPointer } from './mailbox-pointer-submit'
 import type { OrchestrationMailboxPointerSubmitTarget } from './mailbox-pointer-submit'
@@ -58,6 +60,11 @@ export function stageOrchestrationMailboxPointer<TWaiter extends OrchestrationMe
     return
   }
   const flight = args.state.beginFlight(ptyId)
+  flight.reservation = {
+    db,
+    connection: db.db,
+    processIncarnation: expectedTarget.processIncarnation
+  }
   flight.stagedMessageIds = args.messages.map((message) => message.id)
   try {
     if (
@@ -123,9 +130,19 @@ function finishPointerWriteAndStageEnter<TWaiter extends OrchestrationMessageWai
     if (!args.state.isCurrentFlight(ptyId, flight)) {
       return
     }
-    const db = args.deps.getDb()
+    const db = getMailboxPointerFlightDb(flight, args.deps.getDb)
+    if (!db) {
+      return
+    }
     if (settlement.outcome === 'refused') {
-      db?.markAsUndelivered(flight.stagedMessageIds)
+      db.releaseMailboxPointerEnter(
+        flight.stagedMessageIds,
+        {
+          ptyId,
+          processIncarnation: expectedTarget.processIncarnation
+        },
+        [MAILBOX_POINTER_WRITE_ATTEMPTED]
+      )
       if (args.state.clearWatermark(args.mailboxHandle, args.newestSequence, ptyId)) {
         // A delivery parked behind this watermark has to drain now that it is gone.
         args.redrive(args.mailboxHandle)
@@ -151,6 +168,7 @@ function finishPointerWriteAndStageEnter<TWaiter extends OrchestrationMessageWai
         isCursorAgentTitle
       )
     ) {
+      // Why: Cursor Agent treats injected PTY text as editable prompt input, so submitting must stay under user control.
       db.markAsDelivered(flight.stagedMessageIds)
       args.state.clearWatermark(args.mailboxHandle, args.newestSequence, ptyId)
       args.redrive(args.mailboxHandle)

--- a/src/main/runtime/orchestration/mailbox-pointer-state.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-state.ts
@@ -1,4 +1,5 @@
 import type { OrchestrationMailboxLeaf } from './mailbox-owner'
+import type { OrchestrationDb } from './db'
 
 export type OrchestrationMailboxDeliveryFlight = {
   enterTimer: ReturnType<typeof setTimeout> | null
@@ -6,6 +7,24 @@ export type OrchestrationMailboxDeliveryFlight = {
   submitEnter: (() => void) | null
   deferredUntilIdle: boolean
   idleObservedWhileDeferred: boolean
+  workingObserved?: boolean
+  reservation?: {
+    db: OrchestrationDb
+    connection: OrchestrationDb['db']
+    processIncarnation: string
+  }
+}
+
+export function getMailboxPointerFlightDb(
+  flight: OrchestrationMailboxDeliveryFlight,
+  getDb: () => OrchestrationDb | null
+): OrchestrationDb | null {
+  const db = getDb()
+  const owner = flight.reservation
+  // Connection identity is the fence: a swapped database invalidates every airborne reservation.
+  // No shipping path swaps it today — `setOrchestrationDb` is test-only — so this currently
+  // guards the test swap path and any future reconnect, not a reachable production case.
+  return !owner || (owner.db === db && owner.connection === db?.db) ? db : null
 }
 
 export type ParkedOrchestrationMailboxDelivery = {
@@ -14,6 +33,18 @@ export type ParkedOrchestrationMailboxDelivery = {
 }
 
 export class OrchestrationMailboxPointerState {
+  clear(): void {
+    for (const flight of this.flightsByPtyId.values()) {
+      if (flight.enterTimer !== null) {
+        clearTimeout(flight.enterTimer)
+      }
+    }
+    this.flightsByPtyId.clear()
+    this.parkedDeliveriesByPtyId.clear()
+    this.watermarkByMailbox.clear()
+    this.watermarkMailboxesByPtyId.clear()
+    this.parkedTypesByMailbox.clear()
+  }
   private readonly flightsByPtyId = new Map<string, OrchestrationMailboxDeliveryFlight>()
   private readonly parkedDeliveriesByPtyId = new Map<
     string,
@@ -28,6 +59,15 @@ export class OrchestrationMailboxPointerState {
 
   hasFlight(ptyId: string): boolean {
     return this.flightsByPtyId.has(ptyId)
+  }
+
+  observeWorkingFlight(ptyId: string): boolean {
+    const flight = this.flightsByPtyId.get(ptyId)
+    if (!flight) {
+      return false
+    }
+    flight.workingObserved = true
+    return true
   }
 
   beginFlight(ptyId: string): OrchestrationMailboxDeliveryFlight {

--- a/src/main/runtime/orchestration/mailbox-pointer-submit.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-submit.ts
@@ -8,9 +8,10 @@ import {
   type OrchestrationMessageWaiter
 } from './mailbox-pointer-eligibility'
 import type { OrchestrationMailboxLeaf, OrchestrationMailboxOwner } from './mailbox-owner'
-import type {
-  OrchestrationMailboxDeliveryFlight,
-  OrchestrationMailboxPointerState
+import {
+  getMailboxPointerFlightDb,
+  type OrchestrationMailboxDeliveryFlight,
+  type OrchestrationMailboxPointerState
 } from './mailbox-pointer-state'
 import type { WriteSettlement } from '../../../shared/pty-write-settlement'
 
@@ -56,6 +57,7 @@ export function submitOrchestrationMailboxPointer<TWaiter extends OrchestrationM
   let deferredUntilIdle = false
   let expectedPhase = MAILBOX_POINTER_WRITE_ATTEMPTED
   const messageIds = input.messages.map((message) => message.id)
+  const getDb = (): OrchestrationDb | null => getMailboxPointerFlightDb(input.flight, deps.getDb)
   const reservationTarget = {
     ptyId: input.ptyId,
     processIncarnation: input.expectedTarget.processIncarnation
@@ -67,7 +69,7 @@ export function submitOrchestrationMailboxPointer<TWaiter extends OrchestrationM
         clearAndRedrive = true
         return
       }
-      if (!deps.state.isCurrentFlight(input.ptyId, input.flight)) {
+      if (!deps.state.isCurrentFlight(input.ptyId, input.flight) || !getDb()) {
         finalizeReservation = false
         return
       }
@@ -101,7 +103,7 @@ export function submitOrchestrationMailboxPointer<TWaiter extends OrchestrationM
       } else {
         if (
           shouldReleaseOrchestrationPointer(
-            deps.getDb(),
+            getDb(),
             input.mailboxHandle,
             input.messages,
             deps.getMessageWaiters(input.mailboxHandle)
@@ -110,7 +112,7 @@ export function submitOrchestrationMailboxPointer<TWaiter extends OrchestrationM
           releaseWithoutRedrive = true
         } else {
           preserveAmbiguousDelivery = true
-          const db = deps.getDb()
+          const db = getDb()
           if (!db?.markMailboxPointerEnterAttempted(messageIds, reservationTarget)) {
             return
           }
@@ -141,17 +143,17 @@ export function submitOrchestrationMailboxPointer<TWaiter extends OrchestrationM
       }
       let released = false
       let rollbackPersisted = true
-      if (finalizeReservation) {
+      if (finalizeReservation && deps.state.isCurrentFlight(input.ptyId, input.flight)) {
         if (clearAndRedrive) {
           try {
-            deps.getDb()?.releaseMailboxPointerEnter(messageIds, reservationTarget, [expectedPhase])
+            getDb()?.releaseMailboxPointerEnter(messageIds, reservationTarget, [expectedPhase])
           } catch {
             // Runtime teardown can close the DB while this delayed submit is settling.
             rollbackPersisted = false
           }
         } else if (submitted || releaseWithoutRedrive) {
           try {
-            deps.getDb()?.settleMailboxPointerEnter(messageIds, reservationTarget, [expectedPhase])
+            getDb()?.settleMailboxPointerEnter(messageIds, reservationTarget, [expectedPhase])
           } catch {
             // A surviving pending row is revalidated against live agent state after restart.
           }

--- a/src/main/runtime/orchestration/structured-mailbox-pointer-delivery.ts
+++ b/src/main/runtime/orchestration/structured-mailbox-pointer-delivery.ts
@@ -1,7 +1,7 @@
 /**
  * The pointer-delivery lane for workers that ARE a structured agent session.
  *
- * The PTY lane types the nudge into a live pane and reads the idle edge off the terminal title.
+ * The PTY lane types the nudge into a live pane and consumes the shared live agent-status edge.
  * Neither exists here, so this is a sibling of `OrchestrationMailboxPointerDelivery` rather than a
  * branch inside it: batch selection is literally shared (`selectOrchestrationPointerBatch`), and
  * everything below it is different — the nudge is a session turn, the idle edge is the journal,

--- a/src/main/runtime/terminal-send-stale-leaf-liveness.test.ts
+++ b/src/main/runtime/terminal-send-stale-leaf-liveness.test.ts
@@ -361,29 +361,27 @@ function makeOrchestrationDbStub(toHandle: () => string) {
       clearMailboxPointerEnter(released)
     }
   )
-  const releasePendingMailboxPointerForPty = vi.fn((ptyId: string) => {
-    const reservedIds = new Set(
-      rows
-        .filter((row) => row.pointer_enter_pending === 1 && row.pointer_pty_id === ptyId)
-        .map((row) => row.id)
-    )
-    const pendingIds = new Set(
-      rows
-        .filter((row) => row.pointer_enter_pending > 0 && row.pointer_pty_id === ptyId)
-        .map((row) => row.id)
-    )
-    for (const row of rows) {
-      if (reservedIds.has(row.id) && row.read === 0) {
-        row.delivered_at = null
-      } else if (pendingIds.has(row.id) && row.read === 0) {
-        row.delivered_at ??= 'now'
-      }
-    }
-    clearMailboxPointerEnter(pendingIds)
-  })
+  const reservationsFor = (ptyId?: string) =>
+    rows
+      .filter(
+        (row) =>
+          row.pointer_enter_pending > 0 && (ptyId === undefined || row.pointer_pty_id === ptyId)
+      )
+      .map((row) => ({
+        id: row.id,
+        read: row.read,
+        pointer_pty_id: row.pointer_pty_id as string,
+        pointer_process_incarnation: row.pointer_process_incarnation as string,
+        pointer_enter_pending: row.pointer_enter_pending,
+        to_handle: row.to_handle
+      }))
+  const getMailboxPointerReservations = vi.fn(() => reservationsFor())
+  const getMailboxPointerReservationsForPty = vi.fn((ptyId: string) => reservationsFor(ptyId))
   return {
     rows,
     runMailbox,
+    releaseMailboxPointerEnter,
+    settleMailboxPointerEnter,
     markAsDelivered,
     markAsUndelivered,
     stageMailboxPointerEnter,
@@ -452,12 +450,15 @@ function makeOrchestrationDbStub(toHandle: () => string) {
         ),
       // Consulted by onPtyExit's dispatch-failure path.
       getActiveDispatchForTerminal: () => null,
+      // Recovery fences on connection identity; the real OrchestrationDb exposes `.db`.
+      db: { connection: 'stub' },
+      getMailboxPointerReservations,
+      getMailboxPointerReservationsForPty,
       stageMailboxPointerEnter,
       markMailboxPointerWriteAttempted,
       markMailboxPointerEnterAttempted,
       settleMailboxPointerEnter,
       releaseMailboxPointerEnter,
-      releasePendingMailboxPointerForPty,
       markAsDelivered,
       markAsUndelivered,
       close: () => {}
@@ -759,7 +760,7 @@ describe('push-on-idle orchestration delivery absence gate', () => {
       await vi.advanceTimersByTimeAsync(500)
       expect(write.mock.calls.filter(([, data]) => data === '\r')).toHaveLength(0)
       expect(stub.stageMailboxPointerEnter).toHaveBeenCalledOnce()
-      expect(stub.markAsUndelivered).toHaveBeenCalledOnce()
+      expect(stub.releaseMailboxPointerEnter).toHaveBeenCalledOnce()
       expect(stub.rows[0].delivered_at).toBeNull()
 
       // The replacement's own delivery starts a fresh flight and completes —
@@ -804,7 +805,7 @@ describe('push-on-idle orchestration delivery absence gate', () => {
       await vi.advanceTimersByTimeAsync(500)
       expect(write.mock.calls.filter(([, data]) => data === '\r')).toHaveLength(0)
       expect(stub.stageMailboxPointerEnter).toHaveBeenCalledOnce()
-      expect(stub.markAsUndelivered).toHaveBeenCalledOnce()
+      expect(stub.releaseMailboxPointerEnter).toHaveBeenCalledOnce()
       // No stray settle flushed the parked trigger into the dead pty.
       expect(write).toHaveBeenCalledTimes(1)
       expect(stub.rows.every((row) => row.delivered_at === null)).toBe(true)
@@ -835,7 +836,7 @@ describe('push-on-idle orchestration delivery absence gate', () => {
       await vi.advanceTimersByTimeAsync(500)
       expect(write.mock.calls.filter(([, data]) => data === '\r')).toHaveLength(0)
       expect(stub.stageMailboxPointerEnter).toHaveBeenCalledOnce()
-      expect(stub.markAsUndelivered).toHaveBeenCalledOnce()
+      expect(stub.releaseMailboxPointerEnter).toHaveBeenCalledOnce()
       expect(stub.rows[0].delivered_at).toBeNull()
     } finally {
       vi.useRealTimers()


### PR DESCRIPTION
## Summary

Mailbox pointer recovery decided what to do with a pane's outstanding pointer reservations from transient in-memory delivery state. This moves that decision onto the durable rows.

## ⚠️ Behavior change: what happens to mail when a PTY dies

This is the one user-visible change here and it deserves deliberate review.

When a pane's PTY retires mid-delivery, `main` called `markAsUndelivered` on every staged message, blanket-clearing all phases and making them fully redeliverable — including an Enter keystroke that may already have landed, which could produce a second submission.

Now the Enter timer is cleared first, which is positive evidence about what actually happened:

| Phase | Meaning | Before | Now |
|---|---|---|---|
| `RESERVED` | claimed, nothing typed | redeliverable | redeliverable |
| `WRITE_ATTEMPTED` | pointer text typed, Enter never fired | redeliverable | redeliverable |
| `ENTER_ATTEMPTED` | Enter sent, settlement unknown | cleared and resent | **left at phase for the resume path to revalidate** |

Only the genuinely ambiguous case changes. It follows the policy already documented in `mailbox-pointer-submit.ts` — *"neither settling it as delivered nor rolling it back ... is provable here"* — and preserves at-least-once without risking a duplicate Enter.

## What else changes versus `main`

**No durable write per title frame.** On `main`, every working/permission title frame — including each spinner animation tick — ran a blanket `UPDATE` clearing that PTY's reservations (`mailbox-pointer-delivery.ts:183`). That frame now runs a `SELECT` and writes nothing unless a reservation actually exists.

**Reservations are fenced by process incarnation.** `main` cleared reservations for a PTY id without checking which process incarnation owned them, so a replacement process reusing a PTY id could clear a predecessor's reservation. Reconciliation now requires the pane to still run both the same PTY and the same incarnation.

There is no in-memory mirror of the reservation set, so nothing can drift from the database.

## Scale of the win, stated honestly

**This is not a performance win, and the index is not newly used.** The partial index `idx_messages_pending_pointer_pty` from #19390 already served `main`'s per-frame `UPDATE` — `EXPLAIN QUERY PLAN` shows `SEARCH messages USING INDEX idx_messages_pending_pointer_pty` for both the old statement and the new one. Measured, the per-frame cost goes from roughly 2.4 µs to 0.16 µs.

The value is that a display-driven animation frame no longer performs durable cleanup at all, that reconciliation is correctly fenced, and that recovery can no longer disagree with the database. Treat it as durability and correctness work.

## Also

- Reconcile stranded reservations on database attach; the sweep is fault-isolated so a failure cannot strand the federation relay started immediately after it.
- Reclaim already-read reservations, which a read-gated release can never clear and which would otherwise leak in the partial index.
- Redrive mailboxes parked behind a flight stranded by a database swap.
- Delete `releasePendingMailboxPointerForPty`, which this change leaves with no callers, and retarget its query-plan test at the live consumer so the index guarantee is kept.
- Teach the shared in-memory fake the new queries, with fake/SQLite parity coverage.

No schema or DDL change: the index already ships on `main` and existing databases already receive it through `migrateMailboxPointerEnterV33`. The only edit to `schema-column-probes.ts` is a comment.

## Validation

- `pnpm tc:node`, `oxlint`, `oxfmt --check` and the changed-code quality gate are clean; CI green (16 passed, 11 skipped, 0 failures).
- Orchestration, runtime, fake-parity and stale-leaf suites pass.
- Ablations confirm the new tests are regression guards rather than pins: reverting the phase split, the incarnation fence, or the already-read reclamation each turns tests red.
- Electron: clean start and end-to-end mail delivery confirmed twice, with durable rows settling correctly. Screenshots and the exact commit validated are in the comments. The mid-flight PTY-retirement case could not be reproduced in the app and is covered by unit tests only.

Two pre-existing failures reproduce on `main` and are unrelated: the `orchestration-cli-subprocess` keepalive assertion, and load-sensitive timeouts in `automation-change-publication`.

## Scope

Cut down from a larger change. A terminal-agent-status evidence reducer, a `hasProviderChild` liveness narrowing, and `runtime-agent-row-store.ts` changes were removed and deferred so they do not compete with the agent-status store work in #19683, which schedules that store for deletion. No renderer, mobile, or wire surface is touched.