### PR TITLE
fix(gitlab): preserve concurrent titles when marking MRs ready (STA-6045)

### DIFF
--- a/src/main/gitlab/client-mr-review-actions.test.ts
+++ b/src/main/gitlab/client-mr-review-actions.test.ts
@@ -228,39 +228,9 @@ describe('gitlab client — MR operations', () => {
       )
     })
 
-    it('fetches the current title before marking a merge request ready', async () => {
-      glabExecFileAsyncMock
-        .mockResolvedValueOnce({ stdout: JSON.stringify({ title: 'Draft: Fresh title' }) })
-        .mockResolvedValueOnce({ stdout: '{}' })
-
-      await expect(
-        updateMR('/repo', 12, { readyForReview: true }, 'upstream', 'conn-1')
-      ).resolves.toEqual({ ok: true })
-
-      expect(glabExecFileAsyncMock).toHaveBeenNthCalledWith(
-        1,
-        ['api', '--hostname', 'git.internal', 'projects/g%2Fp/merge_requests/12'],
-        {}
-      )
-      expect(glabExecFileAsyncMock).toHaveBeenNthCalledWith(
-        2,
-        [
-          'api',
-          '--hostname',
-          'git.internal',
-          '-X',
-          'PUT',
-          'projects/g%2Fp/merge_requests/12',
-          '-f',
-          'title=Fresh title'
-        ],
-        {}
-      )
-    })
-
-    it('treats a freshly markerless title as already ready', async () => {
+    it('uses GitLab SetDraft mutation without reading or writing the title', async () => {
       glabExecFileAsyncMock.mockResolvedValueOnce({
-        stdout: JSON.stringify({ title: 'Fresh title' })
+        stdout: JSON.stringify({ data: { mergeRequestSetDraft: { mergeRequest: { iid: '12' }, errors: [] } } })
       })
 
       await expect(
@@ -268,16 +238,24 @@ describe('gitlab client — MR operations', () => {
       ).resolves.toEqual({ ok: true })
 
       expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+      const args = glabExecFileAsyncMock.mock.calls[0][0] as string[]
+      expect(args.slice(0, 3)).toEqual(['api', '--hostname', 'git.internal'])
+      expect(args).toContain('graphql')
+      expect(args.join(' ')).toContain('mergeRequestSetDraft')
+      expect(args.join(' ')).toContain('"draft":false')
     })
 
-    it('rejects a draft marker that would leave an empty title', async () => {
-      glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: JSON.stringify({ title: 'Draft:' }) })
-
+    it.each([
+      { addLabels: [] },
+      { removeLabels: [] },
+      { body: '' },
+      { title: 'New title' }
+    ])('rejects ready combined with update %s', async (update) => {
       await expect(
-        updateMR('/repo', 12, { readyForReview: true }, 'upstream', 'conn-1')
-      ).resolves.toEqual({ ok: false, error: 'Title is required' })
+        updateMR('/repo', 12, { readyForReview: true, ...update }, 'upstream', 'conn-1')
+      ).resolves.toEqual({ ok: false, error: 'Cannot update the title while marking a merge request ready' })
 
-      expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+      expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/gitlab/client-mr-review-actions.test.ts
+++ b/src/main/gitlab/client-mr-review-actions.test.ts
@@ -230,7 +230,9 @@ describe('gitlab client — MR operations', () => {
 
     it('uses GitLab SetDraft mutation without reading or writing the title', async () => {
       glabExecFileAsyncMock.mockResolvedValueOnce({
-        stdout: JSON.stringify({ data: { mergeRequestSetDraft: { mergeRequest: { iid: '12' }, errors: [] } } })
+        stdout: JSON.stringify({
+          data: { mergeRequestSetDraft: { mergeRequest: { iid: '12' }, errors: [] } }
+        })
       })
 
       await expect(
@@ -246,17 +248,81 @@ describe('gitlab client — MR operations', () => {
     })
 
     it.each([
-      { addLabels: [] },
-      { removeLabels: [] },
-      { body: '' },
-      { title: 'New title' }
-    ])('rejects ready combined with update %s', async (update) => {
+      ['malformed JSON', 'not-json', 'Malformed GitLab GraphQL response'],
+      [
+        'missing mutation payload',
+        JSON.stringify({ data: {} }),
+        'GitLab rejected the merge request readiness mutation'
+      ],
+      [
+        'invalid draft-success field',
+        JSON.stringify({ data: { mergeRequestSetDraft: { errors: [], mergeRequest: null } } }),
+        'GitLab rejected the merge request readiness mutation'
+      ],
+      [
+        'GraphQL top-level errors',
+        JSON.stringify({
+          errors: [{ message: 'boom' }],
+          data: { mergeRequestSetDraft: { errors: [], mergeRequest: { iid: '12' } } }
+        }),
+        'GitLab GraphQL mutation failed'
+      ],
+      [
+        'payload errors',
+        JSON.stringify({
+          data: { mergeRequestSetDraft: { errors: ['denied'], mergeRequest: { iid: '12' } } }
+        }),
+        'GitLab rejected the merge request readiness mutation'
+      ]
+    ])('rejects ready mutation with %s and releases admission', async (_label, stdout, error) => {
+      glabExecFileAsyncMock.mockResolvedValueOnce({ stdout })
       await expect(
-        updateMR('/repo', 12, { readyForReview: true, ...update }, 'upstream', 'conn-1')
-      ).resolves.toEqual({ ok: false, error: 'Cannot update the title while marking a merge request ready' })
-
-      expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
+        updateMR('/repo', 12, { readyForReview: true }, 'upstream', 'conn-1')
+      ).resolves.toEqual({ ok: false, error })
+      expect(releaseMock).toHaveBeenCalledTimes(1)
+      expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
     })
+
+    it('reports rejected CLI promise without REST fallback and releases admission', async () => {
+      glabExecFileAsyncMock.mockRejectedValueOnce(new Error('timeout while contacting GitLab'))
+      await expect(
+        updateMR('/repo', 12, { readyForReview: true }, 'upstream', 'conn-1')
+      ).resolves.toMatchObject({ ok: false })
+      expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+      expect(releaseMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses one atomic semantic mutation during same MR title edit race', async () => {
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          data: { mergeRequestSetDraft: { errors: [], mergeRequest: { iid: '12' } } }
+        })
+      })
+      await expect(
+        updateMR('/repo', 12, { readyForReview: true }, 'upstream', 'conn-1')
+      ).resolves.toEqual({ ok: true })
+      expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+      expect((glabExecFileAsyncMock.mock.calls[0][0] as string[]).join(' ')).toContain(
+        'mergeRequestSetDraft'
+      )
+      expect((glabExecFileAsyncMock.mock.calls[0][0] as string[]).join(' ')).not.toContain(
+        'merge_requests/12'
+      )
+    })
+
+    it.each([{ addLabels: [] }, { removeLabels: [] }, { body: '' }, { title: 'New title' }])(
+      'rejects ready combined with update %s',
+      async (update) => {
+        await expect(
+          updateMR('/repo', 12, { readyForReview: true, ...update }, 'upstream', 'conn-1')
+        ).resolves.toEqual({
+          ok: false,
+          error: 'Cannot update the title while marking a merge request ready'
+        })
+
+        expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
+      }
+    )
   })
 
   describe('resolveMRDiscussion', () => {

--- a/src/main/gitlab/merge-request-update.ts
+++ b/src/main/gitlab/merge-request-update.ts
@@ -45,17 +45,23 @@ export async function updateMR(
         }
 
         const endpoint = `projects/${encodedProject(projectRef.path)}/merge_requests/${iid}`
-        let title = updates.title?.trim()
+        const title = updates.title?.trim()
+        // GitLab owns the draft/title transition atomically; a REST title read followed by PUT
+        // races with concurrent title edits on the same MR.
         if (updates.readyForReview) {
+          const query = `mutation UpdateMergeRequest($input: MergeRequestUpdateInput!) { updateMergeRequest(input: $input) { mergeRequest { iid } errors } }`
+          const variables = JSON.stringify({ input: { projectPath: projectRef.path, iid: String(iid), draft: false } })
           const response = await glabExecFileAsync(
-            ['api', ...glabHostnameArgs(projectRef, connectionId), endpoint],
+            ['api', ...glabHostnameArgs(projectRef, connectionId), 'graphql', '-f', `query=${query}`, '-f', `variables=${variables}`],
             glabRepoExecOptions(repoPath, connectionId, localGitOptions)
           )
-          const currentTitle = (JSON.parse(response.stdout) as { title?: unknown }).title
-          if (typeof currentTitle !== 'string') {
-            return { ok: false, error: 'Could not read the current merge request title' }
-          }
-          title = stripGitLabDraftTitlePrefix(currentTitle) ?? undefined
+          let payload: unknown
+          try { payload = JSON.parse(response.stdout) } catch { return { ok: false, error: 'Malformed GitLab GraphQL response' } }
+          const root = payload as { errors?: unknown; data?: { updateMergeRequest?: { errors?: unknown; mergeRequest?: unknown } } }
+          if (Array.isArray(root.errors) && root.errors.length > 0) return { ok: false, error: 'GitLab GraphQL mutation failed' }
+          const mutation = root.data?.updateMergeRequest
+          if (!mutation || !Array.isArray(mutation.errors) || mutation.errors.length > 0 || !mutation.mergeRequest) return { ok: false, error: 'GitLab rejected the merge request readiness mutation' }
+          return { ok: true }
         }
 
         const fields: string[] = []

--- a/src/main/gitlab/merge-request-update.ts
+++ b/src/main/gitlab/merge-request-update.ts
@@ -11,7 +11,6 @@ import {
   type ProjectRef
 } from './gl-utils'
 import { encodedProject } from './project-path-encoding'
-import { stripGitLabDraftTitlePrefix } from './merge-request-draft-title'
 import { withProjectRef } from './merge-request-project-resolution'
 
 export async function updateMR(
@@ -40,7 +39,13 @@ export async function updateMR(
       }
       await acquire()
       try {
-        if (updates.readyForReview && (updates.title !== undefined || updates.body !== undefined || updates.addLabels !== undefined || updates.removeLabels !== undefined)) {
+        if (
+          updates.readyForReview &&
+          (updates.title !== undefined ||
+            updates.body !== undefined ||
+            updates.addLabels !== undefined ||
+            updates.removeLabels !== undefined)
+        ) {
           return { ok: false, error: 'Cannot update the title while marking a merge request ready' }
         }
 
@@ -50,17 +55,43 @@ export async function updateMR(
         // races with concurrent title edits on the same MR.
         if (updates.readyForReview) {
           const query = `mutation UpdateMergeRequest($input: MergeRequestSetDraftInput!) { mergeRequestSetDraft(input: $input) { mergeRequest { iid } errors } }`
-          const variables = JSON.stringify({ input: { projectPath: projectRef.path, iid: String(iid), draft: false } })
+          const variables = JSON.stringify({
+            input: { projectPath: projectRef.path, iid: String(iid), draft: false }
+          })
           const response = await glabExecFileAsync(
-            ['api', ...glabHostnameArgs(projectRef, connectionId), 'graphql', '-f', `query=${query}`, '-f', `variables=${variables}`],
+            [
+              'api',
+              ...glabHostnameArgs(projectRef, connectionId),
+              'graphql',
+              '-f',
+              `query=${query}`,
+              '-f',
+              `variables=${variables}`
+            ],
             glabRepoExecOptions(repoPath, connectionId, localGitOptions)
           )
           let payload: unknown
-          try { payload = JSON.parse(response.stdout) } catch { return { ok: false, error: 'Malformed GitLab GraphQL response' } }
-          const root = payload as { errors?: unknown; data?: { mergeRequestSetDraft?: { errors?: unknown; mergeRequest?: unknown } } }
-          if (Array.isArray(root.errors) && root.errors.length > 0) return { ok: false, error: 'GitLab GraphQL mutation failed' }
+          try {
+            payload = JSON.parse(response.stdout)
+          } catch {
+            return { ok: false, error: 'Malformed GitLab GraphQL response' }
+          }
+          const root = payload as {
+            errors?: unknown
+            data?: { mergeRequestSetDraft?: { errors?: unknown; mergeRequest?: unknown } }
+          }
+          if (Array.isArray(root.errors) && root.errors.length > 0) {
+            return { ok: false, error: 'GitLab GraphQL mutation failed' }
+          }
           const mutation = root.data?.mergeRequestSetDraft
-          if (!mutation || !Array.isArray(mutation.errors) || mutation.errors.length > 0 || !mutation.mergeRequest) return { ok: false, error: 'GitLab rejected the merge request readiness mutation' }
+          if (
+            !mutation ||
+            !Array.isArray(mutation.errors) ||
+            mutation.errors.length > 0 ||
+            !mutation.mergeRequest
+          ) {
+            return { ok: false, error: 'GitLab rejected the merge request readiness mutation' }
+          }
           return { ok: true }
         }
 

--- a/src/main/gitlab/merge-request-update.ts
+++ b/src/main/gitlab/merge-request-update.ts
@@ -40,7 +40,7 @@ export async function updateMR(
       }
       await acquire()
       try {
-        if (updates.readyForReview && updates.title !== undefined) {
+        if (updates.readyForReview && (updates.title !== undefined || updates.body !== undefined || (updates.addLabels ?? []).some((label) => label.trim()) || (updates.removeLabels ?? []).some((label) => label.trim()))) {
           return { ok: false, error: 'Cannot update the title while marking a merge request ready' }
         }
 
@@ -49,7 +49,7 @@ export async function updateMR(
         // GitLab owns the draft/title transition atomically; a REST title read followed by PUT
         // races with concurrent title edits on the same MR.
         if (updates.readyForReview) {
-          const query = `mutation UpdateMergeRequest($input: MergeRequestUpdateInput!) { updateMergeRequest(input: $input) { mergeRequest { iid } errors } }`
+          const query = `mutation UpdateMergeRequest($input: MergeRequestSetDraftInput!) { mergeRequestSetDraft(input: $input) { mergeRequest { iid } errors } }`
           const variables = JSON.stringify({ input: { projectPath: projectRef.path, iid: String(iid), draft: false } })
           const response = await glabExecFileAsync(
             ['api', ...glabHostnameArgs(projectRef, connectionId), 'graphql', '-f', `query=${query}`, '-f', `variables=${variables}`],
@@ -57,9 +57,9 @@ export async function updateMR(
           )
           let payload: unknown
           try { payload = JSON.parse(response.stdout) } catch { return { ok: false, error: 'Malformed GitLab GraphQL response' } }
-          const root = payload as { errors?: unknown; data?: { updateMergeRequest?: { errors?: unknown; mergeRequest?: unknown } } }
+          const root = payload as { errors?: unknown; data?: { mergeRequestSetDraft?: { errors?: unknown; mergeRequest?: unknown } } }
           if (Array.isArray(root.errors) && root.errors.length > 0) return { ok: false, error: 'GitLab GraphQL mutation failed' }
-          const mutation = root.data?.updateMergeRequest
+          const mutation = root.data?.mergeRequestSetDraft
           if (!mutation || !Array.isArray(mutation.errors) || mutation.errors.length > 0 || !mutation.mergeRequest) return { ok: false, error: 'GitLab rejected the merge request readiness mutation' }
           return { ok: true }
         }

--- a/src/main/gitlab/merge-request-update.ts
+++ b/src/main/gitlab/merge-request-update.ts
@@ -40,7 +40,7 @@ export async function updateMR(
       }
       await acquire()
       try {
-        if (updates.readyForReview && (updates.title !== undefined || updates.body !== undefined || (updates.addLabels ?? []).some((label) => label.trim()) || (updates.removeLabels ?? []).some((label) => label.trim()))) {
+        if (updates.readyForReview && (updates.title !== undefined || updates.body !== undefined || updates.addLabels !== undefined || updates.removeLabels !== undefined)) {
           return { ok: false, error: 'Cannot update the title while marking a merge request ready' }
         }
 


### PR DESCRIPTION
## Summary

GitLab readiness now uses the semantic `mergeRequestSetDraft` operation, so marking a merge request ready no longer reads and rewrites a caller snapshot of its title. This removes the stale title overwrite path while preserving independent title, description, and label updates.

## Behavior and tradeoffs

- Readiness must be requested separately from metadata updates.
- Unsupported mutations, malformed responses, provider errors, and command failures return explicit errors.
- Existing host, SSH, WSL, project resolution, and admission-release paths remain in use.
- Older runtimes retain the previous behavior until updated.

## Validation

The focused GitLab test file passes 24 tests. Changed files pass lint and formatting, and direct installed-Node noEmit checks pass for node, web, and CLI composites. A private harness executes the actual old and new adapter functions against a stateful modeled transport: the old GET/PUT path overwrites a concurrent same-MR title, while the new semantic mutation preserves it; a different-MR control preserves the sibling title. This models transport behavior and is not live GitLab validation.

Live GitLab, Electron, SSH/WSL mixed-version, and native dependency validation remain outstanding.
