### PR TITLE
ci(test): retry flaky tests once and surface them in the job summary

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,4 +57,18 @@ jobs:
             --exclude=src/shared/startup-shell-portability.live-shell.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \
-            --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
+            --shard=${{ matrix.shard }}/${{ matrix.shard_total }} 2>&1 | tee vitest-output.log
+
+      # Flaky tests that pass on retry keep the shard green, so surface them
+      # explicitly in the job summary for triage.
+      - name: Report flaky tests
+        if: always()
+        run: |
+          if [ -s vitest-output.log ] && grep -q 'retry x' vitest-output.log; then
+            {
+              echo "### ⚠️ Flaky tests detected (node ${{ matrix.node }}, shard ${{ matrix.shard }}/${{ matrix.shard_total }})"
+              '```'
+              grep 'retry x' vitest-output.log
+              '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -36,6 +36,10 @@ export default defineConfig({
     // the Vitest 5s defaults are too tight for the slowest integration cases.
     hookTimeout: 60_000,
     testTimeout: 30_000,
+    // CI-only: one retry keeps a flaky test from failing a required shard; local
+    // runs stay retry-free so flakiness surfaces for devs. Retried-but-passed
+    // tests are printed by the default reporter and scraped into the job summary.
+    retry: process.env.CI ? 1 : 0,
     // Why: Windows process and shell startup are slower under full-suite load;
     // macOS/Linux keep Vitest's default worker parallelism.
     ...windowsTestWorkerOptions


### PR DESCRIPTION
## What
Adds a single automatic retry for vitest projects that hit flaky tests, and surfaces retried tests in the CI job summary so they remain visible instead of silently passing.

## Why
Flaky tests currently fail a whole CI run, forcing a manual re-run that wastes minutes of queue+runner time and hides which test was actually flaky. One retry, with explicit reporting, keeps signal while removing the toil.

## How
- `config/vitest.config.ts`: enable `retry: 1`
- `.github/workflows/unit-tests.yml`: collect retried test files and print them in the job summary step

Verified against a real runner run locally.