### PR TITLE
perf(startup): enable V8 compile cache for the main process and children

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -172,6 +172,32 @@ function createStartupDiagnosticsBanner(chunkName: string): string {
 `
 }
 
+function createCompileCacheBanner(): string {
+  // Why here and not in main-process-preflight: module.enableCompileCache() is not
+  // retroactive — by preflight time the entire static import graph of index.ts has
+  // already been evaluated, so nothing of the main process's own startup would be
+  // cached. Prepending to the bundle entry caches the real startup graph.
+  // No-arg call uses Node's default cache dir (per-user, outside userData), so the
+  // later dev/E2E userData redirect cannot misplace it; entries are keyed by chunk
+  // content hash, which is identical across profiles.
+  return `
+;(() => {
+  try {
+    const nodeModule = require('node:module')
+    if (typeof nodeModule.enableCompileCache === 'function') {
+      const result = nodeModule.enableCompileCache()
+      if (result && result.directory && typeof process !== 'undefined' && process.env) {
+        // Why: child processes (daemon, plugin-host, sidecars) inherit env and reuse the cache.
+        process.env.NODE_COMPILE_CACHE = result.directory
+      }
+    }
+  } catch {
+    // A cache-dir failure must never block startup.
+  }
+})();
+`
+}
+
 function createMainBootstrapPlugin() {
   return {
     name: 'orca-main-bootstrap',
@@ -185,6 +211,7 @@ function createMainBootstrapPlugin() {
       // prelude, too late to handle a missing bootstrap dependency.
       mainChunk.code =
         createBootstrapFatalExitBanner() +
+        createCompileCacheBanner() +
         createStartupDiagnosticsBanner(mainChunk.fileName) +
         mainChunk.code
     }

--- a/src/main/startup/main-process-preflight.ts
+++ b/src/main/startup/main-process-preflight.ts
@@ -32,6 +32,7 @@ import {
 } from '../updater'
 import { getDevInstanceIdentity, shouldApplyPreReadyAppName } from './dev-instance-identity'
 import { enableRendererHeapHeadroom } from './renderer-heap-headroom'
+import { enableMainProcessCompileCache } from './native-code-cache'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from './startup-diagnostics'
 import { startEventLoopStallProbe } from './event-loop-stall-probe'
 import { startMainThreadChurnProbe } from '../diagnostics/main-thread-churn-probe'
@@ -301,6 +302,7 @@ export function runMainProcessPreflight(options: MainProcessPreflightOptions): b
           recordBreadcrumb: (data) => recordDurableCrashBreadcrumb('gpu_crash_hardware', data)
         })
       : null
+  enableMainProcessCompileCache()
   recordCrashBreadcrumb('app_started', {
     packaged: app.isPackaged,
     platform: process.platform,

--- a/src/main/startup/main-process-preflight.ts
+++ b/src/main/startup/main-process-preflight.ts
@@ -302,6 +302,8 @@ export function runMainProcessPreflight(options: MainProcessPreflightOptions): b
           recordBreadcrumb: (data) => recordDurableCrashBreadcrumb('gpu_crash_hardware', data)
         })
       : null
+  // Why: the main graph is already cached by the build-time banner; this only pins
+  // NODE_COMPILE_CACHE for forked children and covers banner-less entry paths.
   enableMainProcessCompileCache()
   recordCrashBreadcrumb('app_started', {
     packaged: app.isPackaged,

--- a/src/main/startup/main-process-ready-foundation.ts
+++ b/src/main/startup/main-process-ready-foundation.ts
@@ -41,6 +41,7 @@ import { registerDocPreviewGrantHandlers } from '../ipc/doc-preview-grant-ipc'
 import { initializeBrowserSessionsForApp } from '../browser/browser-session-startup'
 import { browserSessionRegistry } from '../browser/browser-session-registry'
 import { logStartupMilestone } from './startup-diagnostics'
+import { configureSessionCodeCache } from './native-code-cache'
 import { writeHttp1CompatibilityMarker } from './http1-compatibility-marker'
 import { mainProcessState as state } from './main-process-state'
 import { recordDurableCrashBreadcrumb } from '../crash-reporting/durable-crash-breadcrumb'
@@ -52,6 +53,7 @@ import { isAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-con
 
 export async function initializeReadyFoundation(): Promise<void> {
   logStartupMilestone('app-ready')
+  configureSessionCodeCache(session.defaultSession)
   // Why: a headless automated run must not claim a macOS Dock tile or the menu bar.
   applyBackgroundActivationPolicy({ warn: console.warn })
   installElectronProxyRequestGuard(session.defaultSession)

--- a/src/main/startup/main-process-ready-foundation.ts
+++ b/src/main/startup/main-process-ready-foundation.ts
@@ -41,7 +41,6 @@ import { registerDocPreviewGrantHandlers } from '../ipc/doc-preview-grant-ipc'
 import { initializeBrowserSessionsForApp } from '../browser/browser-session-startup'
 import { browserSessionRegistry } from '../browser/browser-session-registry'
 import { logStartupMilestone } from './startup-diagnostics'
-import { configureSessionCodeCache } from './native-code-cache'
 import { writeHttp1CompatibilityMarker } from './http1-compatibility-marker'
 import { mainProcessState as state } from './main-process-state'
 import { recordDurableCrashBreadcrumb } from '../crash-reporting/durable-crash-breadcrumb'
@@ -53,7 +52,6 @@ import { isAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-con
 
 export async function initializeReadyFoundation(): Promise<void> {
   logStartupMilestone('app-ready')
-  configureSessionCodeCache(session.defaultSession)
   // Why: a headless automated run must not claim a macOS Dock tile or the menu bar.
   applyBackgroundActivationPolicy({ warn: console.warn })
   installElectronProxyRequestGuard(session.defaultSession)

--- a/src/main/startup/native-code-cache.test.ts
+++ b/src/main/startup/native-code-cache.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Session } from 'electron'
+import { configureSessionCodeCache, enableMainProcessCompileCache } from './native-code-cache'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn((name: string) => `/mock/user/data/${name}`)
+  }
+}))
+
+describe('enableMainProcessCompileCache', () => {
+  const originalEnv = process.env.NODE_COMPILE_CACHE
+
+  beforeEach(() => {
+    delete process.env.NODE_COMPILE_CACHE
+  })
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.NODE_COMPILE_CACHE = originalEnv
+    } else {
+      delete process.env.NODE_COMPILE_CACHE
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('enables compile cache and sets process.env.NODE_COMPILE_CACHE', () => {
+    const result = enableMainProcessCompileCache('/tmp/mock-cache')
+    expect(result.enabled).toBe(true)
+    expect(result.directory).toBeTruthy()
+    expect(process.env.NODE_COMPILE_CACHE).toBe(result.directory)
+  })
+
+  it('safely handles missing cache dir fallback', () => {
+    const result = enableMainProcessCompileCache()
+    expect(result.enabled).toBe(true)
+    expect(result.directory).toBeTruthy()
+  })
+})
+
+describe('configureSessionCodeCache', () => {
+  it('calls setCodeCachePath on the target session with app userData Code Cache path', () => {
+    const mockSession: Pick<Session, 'setCodeCachePath'> = {
+      setCodeCachePath: vi.fn()
+    }
+
+    const configured = configureSessionCodeCache(mockSession)
+    expect(configured).toBe(true)
+    expect(mockSession.setCodeCachePath).toHaveBeenCalledWith('/mock/user/data/userData/Code Cache')
+  })
+
+  it('returns false gracefully if setCodeCachePath throws or is missing', () => {
+    expect(configureSessionCodeCache({} as Pick<Session, 'setCodeCachePath'>)).toBe(false)
+  })
+})

--- a/src/main/startup/native-code-cache.test.ts
+++ b/src/main/startup/native-code-cache.test.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { enableMainProcessCompileCache } from './native-code-cache'
 
@@ -18,15 +20,16 @@ describe('enableMainProcessCompileCache', () => {
   })
 
   it('enables compile cache and sets process.env.NODE_COMPILE_CACHE', () => {
-    const result = enableMainProcessCompileCache('/tmp/mock-cache')
+    const result = enableMainProcessCompileCache(join(tmpdir(), 'orca-compile-cache-test'))
     expect(result.enabled).toBe(true)
     expect(result.directory).toBeTruthy()
     expect(process.env.NODE_COMPILE_CACHE).toBe(result.directory)
   })
 
   it('is idempotent: repeat calls keep reporting the enabled state without throwing', () => {
-    const first = enableMainProcessCompileCache('/tmp/mock-cache')
-    const second = enableMainProcessCompileCache('/tmp/mock-cache')
+    const cacheDir = join(tmpdir(), 'orca-compile-cache-test')
+    const first = enableMainProcessCompileCache(cacheDir)
+    const second = enableMainProcessCompileCache(cacheDir)
     expect(first.enabled).toBe(true)
     // Node returns ALREADY_ENABLED with the original directory; the wrapper must
     // still report enabled so callers cannot mistake the state for a failure.

--- a/src/main/startup/native-code-cache.test.ts
+++ b/src/main/startup/native-code-cache.test.ts
@@ -1,12 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Session } from 'electron'
-import { configureSessionCodeCache, enableMainProcessCompileCache } from './native-code-cache'
-
-vi.mock('electron', () => ({
-  app: {
-    getPath: vi.fn((name: string) => `/mock/user/data/${name}`)
-  }
-}))
+import { enableMainProcessCompileCache } from './native-code-cache'
 
 describe('enableMainProcessCompileCache', () => {
   const originalEnv = process.env.NODE_COMPILE_CACHE
@@ -31,25 +24,23 @@ describe('enableMainProcessCompileCache', () => {
     expect(process.env.NODE_COMPILE_CACHE).toBe(result.directory)
   })
 
-  it('safely handles missing cache dir fallback', () => {
+  it('is idempotent: repeat calls keep reporting the enabled state without throwing', () => {
+    const first = enableMainProcessCompileCache('/tmp/mock-cache')
+    const second = enableMainProcessCompileCache('/tmp/mock-cache')
+    expect(first.enabled).toBe(true)
+    // Node returns ALREADY_ENABLED with the original directory; the wrapper must
+    // still report enabled so callers cannot mistake the state for a failure.
+    expect(second.enabled).toBe(true)
+    expect(second.directory).toBeTruthy()
+  })
+
+  it('exposes the runtime enable result shape for the build-banner fallback path', () => {
+    // The build-time banner (electron.vite.config.ts) enables the cache before the
+    // main graph evaluates; this module is the in-process fallback. Both must agree
+    // on the contract: enabled + directory, never throw on a missing cache dir.
     const result = enableMainProcessCompileCache()
     expect(result.enabled).toBe(true)
-    expect(result.directory).toBeTruthy()
-  })
-})
-
-describe('configureSessionCodeCache', () => {
-  it('calls setCodeCachePath on the target session with app userData Code Cache path', () => {
-    const mockSession: Pick<Session, 'setCodeCachePath'> = {
-      setCodeCachePath: vi.fn()
-    }
-
-    const configured = configureSessionCodeCache(mockSession)
-    expect(configured).toBe(true)
-    expect(mockSession.setCodeCachePath).toHaveBeenCalledWith('/mock/user/data/userData/Code Cache')
-  })
-
-  it('returns false gracefully if setCodeCachePath throws or is missing', () => {
-    expect(configureSessionCodeCache({} as Pick<Session, 'setCodeCachePath'>)).toBe(false)
+    expect(typeof result.directory).toBe('string')
+    expect(result.error).toBeUndefined()
   })
 })

--- a/src/main/startup/native-code-cache.ts
+++ b/src/main/startup/native-code-cache.ts
@@ -1,0 +1,63 @@
+import { join } from 'node:path'
+import type { Session } from 'electron'
+import { app } from 'electron'
+
+export type NativeCodeCacheResult = {
+  enabled: boolean
+  directory: string | null
+  error?: string
+}
+
+// Why: persist compiled V8 bytecode to disk so warm launches bypass JS parsing and AST allocation spikes.
+export function enableMainProcessCompileCache(customCacheDir?: string): NativeCodeCacheResult {
+  try {
+    const nodeModule = require('node:module') as {
+      enableCompileCache?: (dir?: string) => { status: number; directory: string }
+    }
+
+    if (typeof nodeModule.enableCompileCache !== 'function') {
+      return { enabled: false, directory: null }
+    }
+
+    const cacheDir =
+      customCacheDir ??
+      process.env.NODE_COMPILE_CACHE ??
+      (typeof app?.getPath === 'function'
+        ? join(app.getPath('userData'), 'compile-cache')
+        : undefined)
+
+    const result = nodeModule.enableCompileCache(cacheDir)
+    if (result && result.directory) {
+      // Why: child processes (daemon, plugin-host, watcher) inherit env and automatically use compile cache.
+      process.env.NODE_COMPILE_CACHE = result.directory
+      return { enabled: true, directory: result.directory }
+    }
+
+    return { enabled: false, directory: null }
+  } catch (error) {
+    return {
+      enabled: false,
+      directory: null,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}
+
+// Why: ensure Chromium session stores compiled web script bytecode persistently in user profile.
+export function configureSessionCodeCache(
+  targetSession: Pick<Session, 'setCodeCachePath'>
+): boolean {
+  try {
+    if (
+      typeof targetSession?.setCodeCachePath === 'function' &&
+      typeof app?.getPath === 'function'
+    ) {
+      const codeCachePath = join(app.getPath('userData'), 'Code Cache')
+      targetSession.setCodeCachePath(codeCachePath)
+      return true
+    }
+    return false
+  } catch {
+    return false
+  }
+}

--- a/src/main/startup/native-code-cache.ts
+++ b/src/main/startup/native-code-cache.ts
@@ -1,5 +1,4 @@
 import { join } from 'node:path'
-import type { Session } from 'electron'
 import { app } from 'electron'
 
 export type NativeCodeCacheResult = {
@@ -8,7 +7,10 @@ export type NativeCodeCacheResult = {
   error?: string
 }
 
-// Why: persist compiled V8 bytecode to disk so warm launches bypass JS parsing and AST allocation spikes.
+// Why: the main-process graph itself is cached by the build-time compile-cache banner
+// prepended to out/main/index.js (see electron.vite.config.ts) — this runtime call is
+// only the idempotent fallback for entry paths that skip the banner. It pins the
+// resolved cache dir into NODE_COMPILE_CACHE so forked children reuse the same cache.
 export function enableMainProcessCompileCache(customCacheDir?: string): NativeCodeCacheResult {
   try {
     const nodeModule = require('node:module') as {
@@ -40,24 +42,5 @@ export function enableMainProcessCompileCache(customCacheDir?: string): NativeCo
       directory: null,
       error: error instanceof Error ? error.message : String(error)
     }
-  }
-}
-
-// Why: ensure Chromium session stores compiled web script bytecode persistently in user profile.
-export function configureSessionCodeCache(
-  targetSession: Pick<Session, 'setCodeCachePath'>
-): boolean {
-  try {
-    if (
-      typeof targetSession?.setCodeCachePath === 'function' &&
-      typeof app?.getPath === 'function'
-    ) {
-      const codeCachePath = join(app.getPath('userData'), 'Code Cache')
-      targetSession.setCodeCachePath(codeCachePath)
-      return true
-    }
-    return false
-  } catch {
-    return false
   }
 }


### PR DESCRIPTION
## ELI5

Node re-parses the same JavaScript on every app launch. This PR turns on Node's on-disk compile cache so warm starts skip parsing/compiling for the main process and its child processes.

## What

Enables `module.enableCompileCache()` for the main process and its child processes at startup.

## Why (and why the original placement was wrong)

CodeRabbit correctly flagged that the first version called `enableCompileCache()` at the tail of preflight — after `index.ts`'s entire static import graph had already evaluated. Since the API is not retroactive, the main process's own startup (the headline claim) was never cached. 4490ea0812 re-architects:

- **Build-time banner**: a new `createCompileCacheBanner()` is prepended to `out/main/index.js` by `createMainBootstrapPlugin()` — the same `generateBundle` mechanism already used for the bootstrap-fatal-exit and startup-diagnostics banners. It executes before Rollup's chunk requires, so the whole main graph is cached from the first launch. Verified in the built bundle: banner at byte ~3.3k, module graph begins at ~8.1k.
- **No-arg call**: Node's default cache dir (per-user, outside `userData`) is used deliberately — preflight redirects `userData` for dev/E2E only after this banner runs; a no-arg enable is immune to that ordering, and chunk cache entries are keyed by content hash so they are safely shared across profiles.
- **Child processes**: the banner pins `process.env.NODE_COMPILE_CACHE` to the resolved directory so forked children (daemon, plugin-host, sidecars) reuse the cache; the runtime `enableMainProcessCompileCache()` remains as an idempotent fallback for banner-less entry paths.
- **Dropped `configureSessionCodeCache`** — `session.setCodeCachePath` to Electron's own default `Code Cache` location was a runtime no-op (h/t review).

## Visual proof

N/A — no UI change; startup timing only.

## Testing

- `pnpm vitest run src/main/startup/native-code-cache.test.ts` — 3 passing (idempotency, env pinning, fallback contract)
- `pnpm tsc --noEmit -p config/tsconfig.node.json` — clean
- `pnpm build:electron-vite` — banner verified in built output before the module graph; banner IIFE executed standalone sets `NODE_COMPILE_CACHE` to the default cache dir

## Platform coverage

- macOS/Linux/Windows: no platform-specific code paths; cache dir resolution is Node's own
- Child-process inheritance relies on env vars, consistent across platforms

## Compatibility

- No IPC, wire, Git, or process-spawn changes
- `enableCompileCache` is a no-op guarded by a feature check on Node versions without it

## AI disclosure

Authored with AI assistance (Claude); human-reviewed.

## Review notes

- Second review round flagged a misleading test that never exercised the fallback branch (process-global one-shot API) — tests were rewritten to test the actual wrapper contract (idempotency + result shape) rather than pretend to reset process-global state

## Checklist

- [x] Cross-platform (macOS/Linux/Windows)
- [x] No new dependencies
- [x] Tests updated for the final architecture