### PR TITLE
fix(source-control): remember the Committed on Branch collapse state across workspaces

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-view-state.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-view-state.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { createGlobalSettingsFixture } from '../../../../../../shared/global-settings-test-fixture'
+import type { GlobalSettings } from '../../../../../../shared/global-settings-types'
+import { useSourceControlPanelViewState } from './use-panel-view-state'
+
+/** Mimics the zustand settings slice closely enough for this hook: updateSettings
+ *  merges into the settings object the next render reads back, like the real store does. */
+function createSettingsHarness(initial: GlobalSettings) {
+  let settings = initial
+  const updateSettings = vi.fn(async (updates: Partial<GlobalSettings>) => {
+    settings = { ...settings, ...updates }
+  })
+  return {
+    getSettings: () => settings,
+    updateSettings
+  }
+}
+
+describe('branch section collapse persistence (issue #18616)', () => {
+  it('keeps "Committed on Branch" collapsed across a workspace switch', () => {
+    const harness = createSettingsHarness(createGlobalSettingsFixture())
+    const { result, rerender } = renderHook(
+      (props: { activeWorktreeId: string | null }) =>
+        useSourceControlPanelViewState({
+          activeWorktreeId: props.activeWorktreeId,
+          settings: harness.getSettings(),
+          updateSettings: harness.updateSettings
+        }),
+      { initialProps: { activeWorktreeId: 'worktree-a' } }
+    )
+
+    expect(result.current.collapsedSections.has('branch')).toBe(false)
+
+    act(() => {
+      result.current.toggleSection('branch')
+    })
+    expect(result.current.collapsedSections.has('branch')).toBe(true)
+    expect(harness.updateSettings).toHaveBeenCalledWith({
+      sourceControlBranchSectionCollapsed: true
+    })
+
+    // Switch to a different workspace.
+    rerender({ activeWorktreeId: 'worktree-b' })
+    // Switch back.
+    rerender({ activeWorktreeId: 'worktree-a' })
+
+    expect(result.current.collapsedSections.has('branch')).toBe(true)
+  })
+
+  it('still resets the other sections on a workspace switch', () => {
+    const harness = createSettingsHarness(createGlobalSettingsFixture())
+    const { result, rerender } = renderHook(
+      (props: { activeWorktreeId: string | null }) =>
+        useSourceControlPanelViewState({
+          activeWorktreeId: props.activeWorktreeId,
+          settings: harness.getSettings(),
+          updateSettings: harness.updateSettings
+        }),
+      { initialProps: { activeWorktreeId: 'worktree-a' } }
+    )
+
+    act(() => {
+      result.current.toggleSection('staged')
+    })
+    expect(result.current.collapsedSections.has('staged')).toBe(true)
+
+    rerender({ activeWorktreeId: 'worktree-b' })
+
+    expect(result.current.collapsedSections.has('staged')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-view-state.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-view-state.ts
@@ -7,8 +7,14 @@ import type { SourceControlWorktreeContext } from '../listing/use-worktree-conte
 
 const DEFAULT_COLLAPSED_SECTIONS = ['history'] as const
 
-function createDefaultCollapsedSections(): Set<string> {
-  return new Set(DEFAULT_COLLAPSED_SECTIONS)
+// Why: unlike the other sections, "branch" collapse is a persisted per-user preference (see
+// sourceControlBranchSectionCollapsed), so the per-worktree reset must still honor it.
+function createDefaultCollapsedSections(isBranchSectionCollapsed: boolean): Set<string> {
+  const sections: string[] = [...DEFAULT_COLLAPSED_SECTIONS]
+  if (isBranchSectionCollapsed) {
+    sections.push('branch')
+  }
+  return new Set(sections)
 }
 
 /**
@@ -30,8 +36,9 @@ export function useSourceControlPanelViewState({
   const [fileListScrollElement, setFileListScrollElement] = useState<HTMLDivElement | null>(null)
   const isMac = useMemo(() => navigator.userAgent.includes('Mac'), [])
   const [filterExpanded, setFilterExpanded] = useState(false)
-  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
-    createDefaultCollapsedSections
+  const isBranchSectionCollapsed = settings?.sourceControlBranchSectionCollapsed ?? false
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(() =>
+    createDefaultCollapsedSections(isBranchSectionCollapsed)
   )
   const persistedSourceControlViewMode = normalizeSourceControlViewMode(
     settings?.sourceControlViewMode
@@ -57,7 +64,7 @@ export function useSourceControlPanelViewState({
   if (viewStateWorktreeId !== activeWorktreeId) {
     setViewStateWorktreeId(activeWorktreeId)
     setFilterExpanded(false)
-    setCollapsedSections(createDefaultCollapsedSections())
+    setCollapsedSections(createDefaultCollapsedSections(isBranchSectionCollapsed))
     setCollapsedTreeDirs(new Set())
     setBaseRefDialogOpen(false)
     // Why: don't reset defaultBaseRef here — it's repo-scoped (resolved on activeRepo change); resetting would clobber non-main defaults.
@@ -65,17 +72,24 @@ export function useSourceControlPanelViewState({
     // Why: don't reset commit-in-flight state — it's per-worktree; resetting would re-enable Commit for an incoming worktree mid-commit.
   }
 
-  const toggleSection = useCallback((section: string) => {
-    setCollapsedSections((prev) => {
-      const next = new Set(prev)
-      if (next.has(section)) {
-        next.delete(section)
-      } else {
-        next.add(section)
+  const toggleSection = useCallback(
+    (section: string) => {
+      if (section === 'branch') {
+        // Why: persist like sourceControlViewMode so this section's collapse state survives a workspace switch.
+        updateSettings({ sourceControlBranchSectionCollapsed: !collapsedSections.has('branch') })
       }
-      return next
-    })
-  }, [])
+      setCollapsedSections((prev) => {
+        const next = new Set(prev)
+        if (next.has(section)) {
+          next.delete(section)
+        } else {
+          next.add(section)
+        }
+        return next
+      })
+    },
+    [collapsedSections, updateSettings]
+  )
 
   const toggleTreeDir = useCallback((key: string) => {
     setCollapsedTreeDirs((prev) => {

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -133,6 +133,7 @@ export function buildDefaultSettings(args: {
     sourceControlViewMode: 'list',
     sourceControlGroupOrder: DEFAULT_SOURCE_CONTROL_GROUP_ORDER,
     sourceControlCompareAgainstUpstream: false,
+    sourceControlBranchSectionCollapsed: false,
     showTitlebarAppName: true,
     showTasksButton: true,
     showAutomationsButton: true,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -227,6 +227,8 @@ export type GlobalSettings = {
   sourceControlGroupOrder: SourceControlGroupOrder
   /** Compare base defaults to the branch upstream instead of the repo default; affects only the compare/diff view, not the PR/rebase target. Per-user. */
   sourceControlCompareAgainstUpstream: boolean
+  /** Whether the "Committed on Branch" section starts collapsed. Per-user, not per-workspace, so it survives a workspace switch. */
+  sourceControlBranchSectionCollapsed: boolean
   /** Whether to show the Orca app name in the titlebar. */
   showTitlebarAppName: boolean
   /** Hides the Tasks sidebar button (also removes it from keyboard navigation). */


### PR DESCRIPTION
## ELI5

Collapsing **Committed on Branch** in the Source Control sidebar now sticks when you switch to another workspace and back, the same way the list/tree toggle already does.

## What Changed

- `useSourceControlPanelViewState` (`src/renderer/src/components/right-sidebar/source-control/panel/use-panel-view-state.ts`) keeps every section's collapse state in one local set and deliberately re-seeds it from a fixed default (`history` only) on each worktree switch. `branch` was never in that default, so the section always came back expanded.
- Added `sourceControlBranchSectionCollapsed` to `GlobalSettings` (default `false`). Toggling the branch section writes it through `updateSettings`, and the per-worktree reset now seeds `branch` from that value, so it reopens only if the user expanded it.
- Every other section (Changes, Staged Changes, Untracked Files, Conflicts, History) keeps resetting per worktree, unchanged.
- New test `use-panel-view-state.test.tsx`: collapse the section, switch worktree, assert it is still collapsed and the setting was written. It failed before the fix and passes after.

## Why

The two sibling preferences in the same hook, `sourceControlViewMode` and `sourceControlGroupOrder`, survive workspace switches because they live in `GlobalSettings` ("Per-user, not per-workspace") rather than in the reset-on-switch local state. This fix mirrors that exact mechanism instead of adding a new persistence layer. The preference is per-user on purpose: which sections you want folded is a reading preference, not a property of a workspace.

Loaded settings are spread over `buildDefaultSettings` in both the desktop store (`normalize-loaded-global-settings.ts`) and the web preferences store, so existing settings files without the new key fall back to `false`; paired clients that don't know the key ignore it.

## Linked Issue

Fixes #18616

## Visual Proof

No recording attached: the change is state persistence, and a before/after would show the same panel with the section collapsed instead of expanded after switching workspaces. The reviewer steps below reproduce it in under a minute; I will add a short recording if you want one.

## Testing

- `pnpm test src/renderer/src/components/right-sidebar/source-control/panel/use-panel-view-state.test.tsx`: RED before the fix (`1 failed | 1 passed`), GREEN after (`2 passed`). Sibling suites for the panel, `settings.test.ts`, `GitPane.test.ts`, and `shared/constants.test.ts`: 79 passed.
- `pnpm run check:code-quality:changed`: 0 new findings (code quality, type-aware, React Doctor). `oxfmt` on the touched files: clean. `pnpm tc:web`: clean.
- Platforms: unit tests and typecheck on macOS only; not exercised in a running app or on Linux/Windows.
- Folder workspaces and SSH: the hook keys only on `activeWorktreeId` and the plain per-user `settings` object (not the repo-owner-routed settings), exactly like its siblings, so the preference stays local to the user regardless of which host owns the repo.

- [ ] I manually tested these changes locally (verified by the unit test and typecheck; not run in the app)
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Fable 5.1 (planning and review) and Claude Sonnet 5 (implementation) in Claude Code, driven by @tan7vir.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security surface, no path or shortcut changes, no wire changes beyond one optional settings key that old clients ignore.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason (see Visual Proof)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted lint, typecheck, and tests run locally; CI to cover the full suite)
