### PR TITLE
Replace the sidebar create dropdown with two direct action buttons

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.test.tsx
@@ -93,31 +93,16 @@ vi.mock('@/components/ui/popover', () => ({
 let container: HTMLDivElement
 let root: Root
 
-function createButton(): HTMLButtonElement {
-  const button = container.querySelector<HTMLButtonElement>('[aria-label="Create"]')
+function headerButton(label: string): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(`[aria-label="${label}"]`)
   if (!button) {
-    throw new Error('Create button not rendered')
+    throw new Error(`Header button not rendered: ${label}`)
   }
   return button
 }
 
-async function openCreateMenu(): Promise<void> {
-  await act(async () => {
-    // Why not click(): the Radix trigger opens on pointerdown, which happy-dom does not synthesize.
-    createButton().dispatchEvent(
-      new window.PointerEvent('pointerdown', { bubbles: true, button: 0 })
-    )
-  })
-}
-
-function createMenuItem(label: string): HTMLElement {
-  const item = [...document.querySelectorAll<HTMLElement>('[role="menuitem"]')].find((candidate) =>
-    candidate.textContent?.includes(label)
-  )
-  if (!item) {
-    throw new Error(`Create menu item not rendered: ${label}`)
-  }
-  return item
+function createButton(): HTMLButtonElement {
+  return headerButton('New workspace')
 }
 
 beforeEach(() => {
@@ -152,10 +137,9 @@ describe('SidebarHeader', () => {
     })
 
     expect(createButton().disabled).toBe(false)
-    await openCreateMenu()
 
     await act(async () => {
-      createMenuItem('New workspace').click()
+      createButton().click()
     })
 
     expect(mocks.openWorkspaceCreationComposerWithTourHandoff).toHaveBeenCalledTimes(1)
@@ -167,42 +151,53 @@ describe('SidebarHeader', () => {
       root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
     })
 
-    await openCreateMenu()
     await act(async () => {
-      createMenuItem('New workspace').click()
+      createButton().click()
     })
 
     expect(createButton().disabled).toBe(false)
     expect(mocks.openWorkspaceCreationComposerWithTourHandoff).toHaveBeenCalledTimes(1)
   })
 
-  it('offers Add project beside New workspace under the create button', async () => {
+  it('reaches Add project and New workspace in one click each, with no menu', async () => {
     act(() => {
       root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
     })
 
-    await openCreateMenu()
-
-    expect(createMenuItem('New workspace')).toBeTruthy()
-    expect(createMenuItem('Add project')).toBeTruthy()
+    expect(headerButton('New workspace')).toBeTruthy()
+    expect(headerButton('Add project')).toBeTruthy()
+    expect(container.querySelector('[data-slot="dropdown-menu-trigger"]')).toBeNull()
 
     await act(async () => {
-      createMenuItem('Add project').click()
+      headerButton('Add project').click()
     })
 
     expect(mockState.openModal).toHaveBeenCalledWith('add-repo')
     expect(mocks.openWorkspaceCreationComposerWithTourHandoff).not.toHaveBeenCalled()
   })
 
-  it('omits the shortcut hint when workspace creation is unassigned', async () => {
-    mocks.shortcutLabel.current = null
+  it('keeps the create button rightmost so the frequent action stays where it was', () => {
     act(() => {
       root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
     })
 
-    await openCreateMenu()
+    const labels = [...container.querySelectorAll<HTMLElement>('[aria-label]')]
+      .map((node) => node.getAttribute('aria-label'))
+      .filter((label): label is string => label === 'Add project' || label === 'New workspace')
+    expect(labels).toEqual(['Add project', 'New workspace'])
+  })
 
-    expect(document.querySelector('[data-slot="dropdown-menu-shortcut"]')).toBeNull()
+  it('advertises the workspace shortcut on the create tooltip, and omits it when unassigned', () => {
+    act(() => {
+      root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
+    })
+    expect(container.textContent).toContain('⌘N')
+
+    mocks.shortcutLabel.current = null
+    act(() => {
+      root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
+    })
+    expect(container.textContent).not.toContain('⌘N')
   })
 
   it('opens agent activity from the bell button', () => {
@@ -275,16 +270,16 @@ describe('SidebarHeader', () => {
     )
   })
 
-  it('keeps the workspace filter alongside the active bell without Add Project', () => {
+  it('drops both project actions in the agents view, which lists activity, not projects', () => {
     mockState.sidebarBody = 'agents'
     act(() => {
       root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
     })
 
     expect(container.querySelector('[aria-label="Turn off activity view"]')).toBeTruthy()
-    expect(container.querySelector('[aria-label="Create"]')).toBeTruthy()
+    expect(container.querySelector('[aria-label="New workspace"]')).toBeTruthy()
     expect(container.querySelector('[aria-label="Workspace options"]')).toBeNull()
-    expect(container.querySelector('[aria-label="Add Project"]')).toBeNull()
+    expect(container.querySelector('[aria-label="Add project"]')).toBeNull()
   })
 
   it('keeps the activity bell and actions on one row at the default sidebar width', () => {
@@ -297,8 +292,8 @@ describe('SidebarHeader', () => {
     expect(headerClasses.has('flex-wrap')).toBe(false)
     expect(headerClasses.has('h-8')).toBe(true)
     expect(container.querySelector('[aria-label="View activity"]')).toBeTruthy()
-    expect(container.querySelector('[aria-label="Add Project"]')).toBeNull()
-    expect(container.querySelector('[aria-label="Create"]')).toBeTruthy()
+    expect(container.querySelector('[aria-label="Add project"]')).toBeTruthy()
+    expect(container.querySelector('[aria-label="New workspace"]')).toBeTruthy()
   })
 
   it('keeps the same actions on one row at compact width', async () => {
@@ -307,15 +302,14 @@ describe('SidebarHeader', () => {
       root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
     })
 
-    expect(container.querySelector('[aria-label="Add Project"]')).toBeNull()
+    expect(container.querySelector('[aria-label="Add project"]')).toBeTruthy()
     expect(container.querySelector('[aria-label="View activity"]')).toBeTruthy()
-    expect(container.querySelector('[aria-label="Create"]')).toBeTruthy()
+    expect(container.querySelector('[aria-label="New workspace"]')).toBeTruthy()
     expect(container.querySelector('[aria-label="Workspace options"]')).toBeTruthy()
     expect(container.querySelector('[aria-label="More workspace actions"]')).toBeNull()
 
-    await openCreateMenu()
     await act(async () => {
-      createMenuItem('New workspace').click()
+      createButton().click()
     })
     expect(mocks.openWorkspaceCreationComposerWithTourHandoff).toHaveBeenCalledTimes(1)
   })
@@ -340,8 +334,8 @@ describe('SidebarHeader', () => {
     expect(container.querySelector('[aria-label="Open full Agents view"]')).toBeNull()
   })
 
-  // Why: the compact overflow existed only to carry Add Project, which now lives
-  // under the create button, so both widths render one identical header.
+  // Why: the compact overflow existed only to carry Add Project, which now sits
+  // beside the create button, so both widths render one identical header.
   it('renders the same actions on both sides of the old wide-layout breakpoint', () => {
     for (const width of [234, 235]) {
       mockState.sidebarWidth = width
@@ -349,8 +343,8 @@ describe('SidebarHeader', () => {
         root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
       })
       expect(container.querySelector('[aria-label="More workspace actions"]')).toBeNull()
-      expect(container.querySelector('[aria-label="Add Project"]')).toBeNull()
-      expect(container.querySelector('[aria-label="Create"]')).toBeTruthy()
+      expect(container.querySelector('[aria-label="Add project"]')).toBeTruthy()
+      expect(container.querySelector('[aria-label="New workspace"]')).toBeTruthy()
       expect(container.querySelector('[aria-label="Workspace options"]')).toBeTruthy()
     }
   })

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -49,7 +49,9 @@ const SidebarHeader = React.memo(function SidebarHeader({
     <div className="mt-2 flex h-8 min-w-0 items-center justify-between gap-1.5 px-2">
       <div className="flex min-w-0 items-center gap-1">
         <span
-          className="select-none pl-2 pr-0.5 text-xs font-semibold text-muted-foreground/80"
+          // Why truncate: the action cluster is shrink-0, so a long localized title
+          // (es "Espacios de trabajo") otherwise wraps out of the h-8 row.
+          className="min-w-0 truncate select-none pl-2 pr-0.5 text-xs font-semibold text-muted-foreground/80"
           data-sidebar-section-title={groupBy === 'repo' ? 'projects' : 'workspaces'}
         >
           {sidebarTitle}
@@ -125,7 +127,7 @@ const SidebarHeader = React.memo(function SidebarHeader({
         ) : null}
         <SidebarHeaderActions
           onWorkspaceBoardMenuOpenChange={onWorkspaceBoardMenuOpenChange}
-          hideWorkspaceOptions={agentsViewActive}
+          agentsViewActive={agentsViewActive}
         />
       </div>
     </div>

--- a/src/renderer/src/components/sidebar/sidebar-header-actions.tsx
+++ b/src/renderer/src/components/sidebar/sidebar-header-actions.tsx
@@ -1,131 +1,104 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { FolderPlus, GitBranchPlus, Plus } from 'lucide-react'
+import React, { useCallback } from 'react'
+import { FolderPlus, Plus } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuShortcut,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { formatOptionalPrimaryShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
 import { openWorkspaceCreationComposerWithTourHandoff } from '../contextual-tours/workspace-creation-tour-handoff'
 import SidebarWorkspaceOptionsMenu from './SidebarWorkspaceOptionsMenu'
 
-function SidebarCreateMenu({
+function AddProjectButton({
   preserveWorkspaceBoardOpen
 }: {
   preserveWorkspaceBoardOpen: boolean
 }): React.JSX.Element {
   const openModal = useAppStore((s) => s.openModal)
-  const keybindings = useAppStore((s) => s.keybindings)
-  const [open, setOpen] = useState(false)
-  const menuContentRef = useRef<HTMLDivElement | null>(null)
-  // Why primary: workspace.create binds both Mod+N and Mod+Shift+N, and listing
-  // every alias in a two-row menu reads as noise rather than help.
-  const newWorktreeShortcutLabel = formatOptionalPrimaryShortcutLabel(
-    'workspace.create',
-    keybindings
+  const label = translate('auto.components.sidebar.SidebarHeader.addProject', 'Add project')
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          type="button"
+          className="text-muted-foreground"
+          aria-label={label}
+          data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+          onClick={() => openModal('add-repo')}
+        >
+          <FolderPlus className="size-3.5" strokeWidth={2.25} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
   )
-  const boardAttr = preserveWorkspaceBoardOpen ? '' : undefined
+}
 
-  // Why query, not a ref on the item: Radix wraps each item in a roving-focus Slot,
-  // and a second ref on that child conflicts with the one the Slot already owns.
-  // Why at all: Radix highlights the first item only when opened by keyboard, so a
-  // mouse click would otherwise leave Enter with nothing to activate.
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-    const frame = requestAnimationFrame(() =>
-      menuContentRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus()
-    )
-    return () => cancelAnimationFrame(frame)
-  }, [open])
+function NewWorkspaceButton({
+  preserveWorkspaceBoardOpen
+}: {
+  preserveWorkspaceBoardOpen: boolean
+}): React.JSX.Element {
+  const keybindings = useAppStore((s) => s.keybindings)
+  // Why primary: workspace.create binds both Mod+N and Mod+Shift+N, and listing
+  // every alias in a one-line tooltip reads as noise rather than help.
+  const shortcutLabel = formatOptionalPrimaryShortcutLabel('workspace.create', keybindings)
+  const label = translate('auto.components.sidebar.SidebarHeader.92154beb7e', 'New workspace')
 
-  // Why: the tour highlights this trigger, so the handoff has to fire from the
-  // menu item rather than the button that now only opens the menu.
+  // Why the tour handoff here: the tour highlights this button, and it is now
+  // the control that performs the action rather than one that opens a menu.
   const handleCreateWorkspace = useCallback(() => {
-    // Why: opening after Radix tears down the menu prevents its focus restoration
-    // from treating the new dialog as an outside interaction.
-    window.setTimeout(openWorkspaceCreationComposerWithTourHandoff, 0)
+    openWorkspaceCreationComposerWithTourHandoff()
   }, [])
 
   return (
-    <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              type="button"
-              className="text-muted-foreground"
-              aria-label={translate('auto.components.sidebar.SidebarHeader.createMenu', 'Create')}
-              data-workspace-board-preserve-open={boardAttr}
-              data-contextual-tour-target="workspace-create-control"
-            >
-              <Plus className="size-3.5" strokeWidth={2.25} />
-            </Button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" sideOffset={6}>
-          {translate('auto.components.sidebar.SidebarHeader.createMenu', 'Create')}
-        </TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent
-        side="bottom"
-        // Why start: the menu hangs from the button's left edge and opens rightward.
-        align="start"
-        // Keep the panel clear of the trigger: Radix opens on pointerdown, and an
-        // overlapping first item activates on the same click's pointerup.
-        sideOffset={4}
-        ref={menuContentRef}
-        className="w-52 p-1.5"
-        data-workspace-board-preserve-open={boardAttr}
-      >
-        <DropdownMenuItem
-          className="cursor-pointer gap-2.5 py-1.5"
-          onSelect={handleCreateWorkspace}
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          type="button"
+          className="text-muted-foreground"
+          aria-label={label}
+          data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+          data-contextual-tour-target="workspace-create-control"
+          onClick={handleCreateWorkspace}
         >
-          {/* GitBranchPlus matches the create-workspace button on the landing screen. */}
-          <GitBranchPlus className="size-3.5" strokeWidth={2.25} />
-          {translate('auto.components.sidebar.SidebarHeader.92154beb7e', 'New workspace')}
-          {newWorktreeShortcutLabel ? (
-            <DropdownMenuShortcut>{newWorktreeShortcutLabel}</DropdownMenuShortcut>
-          ) : null}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          className="cursor-pointer gap-2.5 py-1.5"
-          onSelect={() => openModal('add-repo')}
-        >
-          <FolderPlus className="size-3.5" strokeWidth={2.25} />
-          {translate('auto.components.sidebar.SidebarHeader.addProject', 'Add project')}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <Plus className="size-3.5" strokeWidth={2.25} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {label}
+        {shortcutLabel ? <span className="ml-1.5 text-background/60">{shortcutLabel}</span> : null}
+      </TooltipContent>
+    </Tooltip>
   )
 }
 
 export function SidebarHeaderActions({
   onWorkspaceBoardMenuOpenChange,
-  hideWorkspaceOptions = false
+  agentsViewActive = false
 }: {
   onWorkspaceBoardMenuOpenChange: (open: boolean) => void
-  hideWorkspaceOptions?: boolean
+  agentsViewActive?: boolean
 }): React.JSX.Element {
   return (
-    <div className="flex shrink-0 items-center gap-1">
-      {hideWorkspaceOptions ? null : (
-        <SidebarWorkspaceOptionsMenu
-          preserveWorkspaceBoardOpen
-          onMenuOpenChange={onWorkspaceBoardMenuOpenChange}
-        />
+    <div className="flex shrink-0 items-center gap-1" data-sidebar-header-actions="">
+      {/* Why both hidden in the agents view: it lists activity, not projects. */}
+      {agentsViewActive ? null : (
+        <>
+          <SidebarWorkspaceOptionsMenu
+            preserveWorkspaceBoardOpen
+            onMenuOpenChange={onWorkspaceBoardMenuOpenChange}
+          />
+          <AddProjectButton preserveWorkspaceBoardOpen />
+        </>
       )}
-      <SidebarCreateMenu preserveWorkspaceBoardOpen />
+      <NewWorkspaceButton preserveWorkspaceBoardOpen />
     </div>
   )
 }

--- a/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.tsx
@@ -4,7 +4,7 @@ import {
   Ellipsis,
   Eye,
   FolderInput,
-  FolderPlus,
+  FolderTree,
   Plus,
   Shapes,
   SlidersHorizontal,
@@ -135,7 +135,8 @@ export function RepoHeaderProjectActionsMenu({
           </DropdownMenuItem>
         ) : null}
         <DropdownMenuItem onSelect={() => actions.onCreateGroupFromRepo(repo)}>
-          <FolderPlus className="size-3.5" />
+          {/* Not FolderPlus: that now means "Add project" in the sidebar header above. */}
+          <FolderTree className="size-3.5" />
           {translate('auto.components.sidebar.WorktreeList.cbfd565f83', 'New group from project')}
         </DropdownMenuItem>
         {projectGroups.length > 0 ? (

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5298,7 +5298,6 @@
           "5c9c7c16aa": "Add a project to create workspaces",
           "a30e34eb5c": "Close workspace board",
           "views": "Sidebar view",
-          "createMenu": "Create",
           "addProject": "Add project"
         },
         "SidebarNav": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4412,7 +4412,6 @@
           "a30e34eb5c": "Cerrar tablero del espacio de trabajo",
           "spaces": "Espacios",
           "views": "Vista de la barra lateral",
-          "createMenu": "Crear",
           "addProject": "Agregar proyecto"
         },
         "SidebarNav": {

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -5044,7 +5044,6 @@
           "49f62c5665": "Tableau des espaces de travail",
           "5c9c7c16aa": "Ajoutez un projet pour créer des espaces de travail",
           "a30e34eb5c": "Fermer le tableau des espaces de travail",
-          "createMenu": "Créer",
           "addProject": "Ajouter un projet"
         },
         "SidebarNav": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4393,7 +4393,6 @@
           "a30e34eb5c": "ワークスペースボードを閉じる",
           "spaces": "スペース",
           "views": "サイドバービュー",
-          "createMenu": "作成",
           "addProject": "プロジェクトを追加"
         },
         "SidebarNav": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4398,7 +4398,6 @@
           "a30e34eb5c": "워크스페이스 보드 닫기",
           "spaces": "스페이스",
           "views": "사이드바 보기",
-          "createMenu": "생성",
           "addProject": "프로젝트 추가"
         },
         "SidebarNav": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4441,7 +4441,6 @@
           "a30e34eb5c": "关闭工作区板",
           "spaces": "空间",
           "views": "侧边栏视图",
-          "createMenu": "创建",
           "addProject": "添加项目"
         },
         "SidebarNav": {
@@ -14287,7 +14286,6 @@
           "filtersSection": "筛选",
           "viewSection": "视图"
         },
-
         "ActivityScopeFilterControls": {
           "resetScope": "显示所有主机和项目"
         },

--- a/tests/e2e/golden-core-flows.spec.ts
+++ b/tests/e2e/golden-core-flows.spec.ts
@@ -471,12 +471,11 @@ test.describe('New-user golden core flow', () => {
       .locator('[data-contextual-tour-target="workspace-create-control"]')
       .first()
     await expect(createControl).toBeVisible()
-    await expect(createControl).toHaveAttribute('aria-label', 'Create')
+    await expect(createControl).toHaveAttribute('aria-label', 'New workspace')
     const createControlBox = await createControl.boundingBox()
     expect(createControlBox?.width ?? 0).toBeGreaterThan(0)
     expect(createControlBox?.height ?? 0).toBeGreaterThan(0)
     await createControl.click()
-    await orcaPage.getByRole('menuitem', { name: /^New workspace/ }).click()
 
     const workspaceName = `golden-new-${Date.now()}`
     await completeWorkspaceCreationTour(orcaPage, workspaceName)

--- a/tests/e2e/helpers/sidebar-project-dialog.ts
+++ b/tests/e2e/helpers/sidebar-project-dialog.ts
@@ -1,14 +1,21 @@
 import { expect, type Page } from '@stablyai/playwright-test'
 
+// Why scoped: the Landing screen renders its own "Add project" button whenever no
+// workspace is open, which is exactly the state these helpers run in.
+function sidebarHeaderActions(page: Page) {
+  return page.locator('[data-sidebar-header-actions]')
+}
+
 export async function openSidebarProjectDialog(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Create', exact: true }).click()
-  await page.getByRole('menuitem', { name: 'Add project', exact: true }).click()
+  await sidebarHeaderActions(page).getByRole('button', { name: 'Add project', exact: true }).click()
   await expect(page.getByRole('dialog', { name: /Add a project/i })).toBeVisible()
 }
 
 export async function openSidebarWorkspaceComposer(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Create', exact: true }).click()
-  const newWorkspaceItem = page.getByRole('menuitem', { name: /^New workspace/ })
-  await expect(newWorkspaceItem).toBeVisible()
-  await newWorkspaceItem.click()
+  const createButton = sidebarHeaderActions(page).getByRole('button', {
+    name: 'New workspace',
+    exact: true
+  })
+  await expect(createButton).toBeVisible()
+  await createButton.click()
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​55 | 0 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​108 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 |

<!-- /orca-pr-loc -->

## Why

#19375 unified the sidebar's two header buttons into one `+` dropdown. That removed the width-dependent layout branching, but it charged the cost to the action people take constantly: **New workspace went from 1 click to 2**, and Add project didn't actually become more discoverable — a menu item is invisible until you open the menu.

## What

The `+` performs an action again instead of opening one. Both controls sit in the header, one click each, always visible.

- **`sidebar-header-actions.tsx`** — dropdown removed. `FolderPlus` → `openModal('add-repo')`, `Plus` → `openWorkspaceCreationComposerWithTourHandoff`, with `+` kept rightmost so muscle memory holds. The `setTimeout(…, 0)` that worked around Radix's focus restoration on menu teardown goes with it — there's no menu to tear down. The tooltip now carries the shortcut (*New workspace ⌘N*), which the deleted menu row was the only place advertising.
- **`SidebarHeader.tsx`** — `min-w-0 truncate` on the title span (see below), and `hideWorkspaceOptions` renamed to `agentsViewActive`, which is what it was always being passed.
- **`repo-header-project-actions.tsx`** — "New group from project" moves to `FolderTree`, so `FolderPlus` means one thing in this sidebar.
- **i18n** — the now-unused `SidebarHeader.createMenu` ("Create") key removed from all six locales.

### The truncate fix isn't cosmetic

`MIN_WIDTH` is 220px. Four 24px buttons plus gaps is 108px, leaving the title 88px. The title span had no `min-w-0` and no `truncate`, so it can't shrink:

| Title | Needs | Without fix |
|---|---|---|
| `Projects` (en) | 59px | fits |
| `Workspaces` (en) | 83px | fits |
| `Espacios de trabajo` (es) | ~110px | **wraps to two lines in a 32px row** |
| `ワークスペース` (ja) | ~90px | wraps; ellipsises with the fix |

Measured live in the app at 220px: with the fix the Spanish title is 16px tall; with `truncate min-w-0` stripped it is 32px tall — two lines filling the entire header row. This was already marginal at three buttons; the fourth makes it certain.

## Two deliberate removals — please sign off

1. **Add project no longer appears in the agents view.** Previously only the options menu was hidden there and the create menu still rendered both items. That view lists activity, not projects, so hiding both is the consistent answer — but it is a capability removal.
2. **`FolderPlus` → `FolderTree`** for "New group from project" is churn in a menu nobody complained about. It's labeled, so the cost is low.

## Verification

Attached over CDP to a dev instance from this worktree:

- Header renders `View activity · Workspace options · Add project · New workspace` — four buttons, 32px row, **at `sidebarWidth: 220`**, the exact minimum.
- One click on `+` opened the Create worktree composer; one click on the folder icon opened "Add a project".
- Spanish two-line failure and its fix measured live, as above.

Gates: sidebar suite (299 files / 2523 tests), contextual-tour tests, `pnpm tc`, changed-code quality gate, and `verify:localization-{catalog,coverage,extraction}` all pass.

### One e2e trap worth knowing about

`Landing.tsx` renders its own button with the accessible name **"Add project"** whenever no workspace is open — exactly the state the sidebar e2e helpers run in. An unscoped `getByRole('button', { name: 'Add project', exact: true })` matches twice and trips Playwright strict mode. The helpers are now scoped to a `data-sidebar-header-actions` hook. The old `name: 'Create'` selector was accidentally protected from this; the rename removed that protection.

**Not yet run:** the Electron e2e specs themselves. The updated selectors are reasoned and scoped, not executed.
