### PR TITLE
fix(native-chat): expand Claude slash commands sent with an attachment

### DIFF
--- a/src/main/claude/claude-structured-dispatch-content.test.ts
+++ b/src/main/claude/claude-structured-dispatch-content.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
+import { claudeDispatchMessageContent } from './claude-structured-dispatch-content'
+
+function userMessage(blocks: AgentJournalMessageItem['blocks']): AgentJournalMessageItem {
+  return { kind: 'message', role: 'user', blocks }
+}
+
+const REMOTE_IMAGE = { type: 'image-ref' as const, url: 'https://example.test/a.png' }
+
+describe('claudeDispatchMessageContent', () => {
+  it('puts the text block last so a slash command still expands with an attachment', async () => {
+    const content = await claudeDispatchMessageContent(
+      // The composer builds text-then-images; Claude only treats a leading `/` as a
+      // command when the LAST block is text.
+      userMessage([{ type: 'text', text: '/goal ship the parser' }, REMOTE_IMAGE])
+    )
+
+    expect(content).toEqual([
+      { type: 'image', source: { type: 'url', url: 'https://example.test/a.png' } },
+      { type: 'text', text: '/goal ship the parser' }
+    ])
+  })
+
+  it('keeps every image ahead of the text and preserves each side’s order', async () => {
+    const second = { type: 'image-ref' as const, url: 'https://example.test/b.png' }
+
+    const content = await claudeDispatchMessageContent(
+      userMessage([{ type: 'text', text: 'look' }, REMOTE_IMAGE, second])
+    )
+
+    expect(content.map((part) => (part as { type: string }).type)).toEqual([
+      'image',
+      'image',
+      'text'
+    ])
+    expect(content[0]).toEqual({
+      type: 'image',
+      source: { type: 'url', url: 'https://example.test/a.png' }
+    })
+    expect(content[1]).toEqual({
+      type: 'image',
+      source: { type: 'url', url: 'https://example.test/b.png' }
+    })
+  })
+
+  it('sends text alone unchanged', async () => {
+    const content = await claudeDispatchMessageContent(userMessage([{ type: 'text', text: 'hi' }]))
+
+    expect(content).toEqual([{ type: 'text', text: 'hi' }])
+  })
+
+  it('sends an image with no text', async () => {
+    const content = await claudeDispatchMessageContent(userMessage([REMOTE_IMAGE]))
+
+    expect(content).toEqual([
+      { type: 'image', source: { type: 'url', url: 'https://example.test/a.png' } }
+    ])
+  })
+
+  it('rejects a message with no renderable block', async () => {
+    await expect(
+      claudeDispatchMessageContent(userMessage([{ type: 'text', text: '' }]))
+    ).rejects.toThrow('Claude dispatch requires text or an image')
+  })
+
+  it('rejects a non-user message', async () => {
+    await expect(
+      claudeDispatchMessageContent({
+        ...userMessage([{ type: 'text', text: 'hi' }]),
+        role: 'assistant'
+      })
+    ).rejects.toThrow('Claude dispatch accepts only user messages')
+  })
+})

--- a/src/main/claude/claude-structured-dispatch-content.test.ts
+++ b/src/main/claude/claude-structured-dispatch-content.test.ts
@@ -144,6 +144,19 @@ describe('claudeDispatchInvokesSlashCommand', () => {
     ).toBe(false)
   })
 
+  it('reads the joined prompt, so a command behind leading prose is not one', async () => {
+    // Keeping the blocks separate would leave `/goal ship` trailing and falsely claim a command.
+    const content = await claudeDispatchMessageContent(
+      userMessage([
+        { type: 'text', text: 'take a look' },
+        { type: 'text', text: '/goal ship' }
+      ])
+    )
+
+    expect(content).toEqual([{ type: 'text', text: 'take a look\n/goal ship' }])
+    expect(claudeDispatchInvokesSlashCommand(content)).toBe(false)
+  })
+
   it('matches untrimmed, as Claude does, and ignores a promptless turn', () => {
     expect(claudeDispatchInvokesSlashCommand([{ type: 'text', text: '  /goal ship' }])).toBe(false)
     expect(claudeDispatchInvokesSlashCommand([{ type: 'text', text: 'ship it' }])).toBe(false)

--- a/src/main/claude/claude-structured-dispatch-content.test.ts
+++ b/src/main/claude/claude-structured-dispatch-content.test.ts
@@ -1,6 +1,17 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
-import { claudeDispatchMessageContent } from './claude-structured-dispatch-content'
+import {
+  claudeDispatchInvokesSlashCommand,
+  claudeDispatchMessageContent
+} from './claude-structured-dispatch-content'
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
 
 function userMessage(blocks: AgentJournalMessageItem['blocks']): AgentJournalMessageItem {
   return { kind: 'message', role: 'user', blocks }
@@ -71,5 +82,71 @@ describe('claudeDispatchMessageContent', () => {
         role: 'assistant'
       })
     ).rejects.toThrow('Claude dispatch accepts only user messages')
+  })
+
+  it('joins several text blocks so a command is not stranded ahead of trailing prose', async () => {
+    // Appending each block would leave `thanks` trailing, and Claude reads only that block.
+    const content = await claudeDispatchMessageContent(
+      userMessage([
+        { type: 'text', text: '/goal ship' },
+        REMOTE_IMAGE,
+        { type: 'text', text: 'thanks' }
+      ])
+    )
+
+    expect(content).toEqual([
+      { type: 'image', source: { type: 'url', url: 'https://example.test/a.png' } },
+      { type: 'text', text: '/goal ship\nthanks' }
+    ])
+    expect(claudeDispatchInvokesSlashCommand(content)).toBe(true)
+  })
+
+  it('puts a locally attached image ahead of the text, the shape the composer sends', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'claude-dispatch-content-'))
+    const path = join(dir, 'shot.png')
+    await writeFile(path, PNG)
+
+    try {
+      const content = await claudeDispatchMessageContent(
+        userMessage([
+          { type: 'text', text: '/goal ship' },
+          { type: 'image-ref', path }
+        ])
+      )
+
+      expect(content).toEqual([
+        {
+          type: 'image',
+          source: { type: 'base64', media_type: 'image/png', data: PNG.toString('base64') }
+        },
+        { type: 'text', text: '/goal ship' }
+      ])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('claudeDispatchInvokesSlashCommand', () => {
+  it('reads the trailing prompt Claude recovers, not any text block', () => {
+    expect(
+      claudeDispatchInvokesSlashCommand([
+        { type: 'image', source: { type: 'url', url: 'https://example.test/a.png' } },
+        { type: 'text', text: '/goal ship' }
+      ])
+    ).toBe(true)
+    // The pre-fix order: Claude recovers no prompt at all, so no command runs.
+    expect(
+      claudeDispatchInvokesSlashCommand([
+        { type: 'text', text: '/goal ship' },
+        { type: 'image', source: { type: 'url', url: 'https://example.test/a.png' } }
+      ])
+    ).toBe(false)
+  })
+
+  it('matches untrimmed, as Claude does, and ignores a promptless turn', () => {
+    expect(claudeDispatchInvokesSlashCommand([{ type: 'text', text: '  /goal ship' }])).toBe(false)
+    expect(claudeDispatchInvokesSlashCommand([{ type: 'text', text: 'ship it' }])).toBe(false)
+    expect(claudeDispatchInvokesSlashCommand([])).toBe(false)
   })
 })

--- a/src/main/claude/claude-structured-dispatch-content.ts
+++ b/src/main/claude/claude-structured-dispatch-content.ts
@@ -140,10 +140,7 @@ export function claudeDispatchContentKey(content: readonly unknown[]): string {
   const digest = createHash('sha256')
   const summary = content
     .map((part) => {
-      const record =
-        typeof part === 'object' && part !== null && !Array.isArray(part)
-          ? (part as Record<string, unknown>)
-          : null
+      const record = claudeRecord(part)
       const type = typeof record?.type === 'string' ? record.type : 'unknown'
       if (type === 'text') {
         return `text:${typeof record?.text === 'string' ? record.text.length : 0}`
@@ -159,10 +156,7 @@ export function claudeDispatchContentKey(content: readonly unknown[]): string {
     })
     .join(',')
   for (const [index, part] of content.entries()) {
-    const record =
-      typeof part === 'object' && part !== null && !Array.isArray(part)
-        ? (part as Record<string, unknown>)
-        : null
+    const record = claudeRecord(part)
     const type = typeof record?.type === 'string' ? record.type : 'unknown'
     digest.update(`${index}:${type}:`)
     if (type === 'text' && typeof record?.text === 'string') {

--- a/src/main/claude/claude-structured-dispatch-content.ts
+++ b/src/main/claude/claude-structured-dispatch-content.ts
@@ -3,6 +3,7 @@ import { open } from 'node:fs/promises'
 import { extname } from 'node:path'
 import type { AgentJournalMessageItem } from '../../shared/agent-session-journal-types'
 import type { NativeChatBlock } from '../../shared/native-chat-types'
+import { claudeRecord } from './claude-structured-item-translation'
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
 const MAX_IMAGE_COUNT = 20
@@ -88,29 +89,47 @@ async function imageContent(
   }
 }
 
+/**
+ * Claude encodes a user turn as attachment blocks followed by the typed text, and recovers the
+ * typed prompt by reading only the trailing text block. Verified against the real CLI over
+ * stream-json: a body ending in an image has no recoverable prompt, so its `/command` reaches
+ * the model as prose instead of being expanded.
+ */
 export async function claudeDispatchMessageContent(
   body: AgentJournalMessageItem
 ): Promise<unknown[]> {
   if (body.role !== 'user') {
     throw new Error('Claude dispatch accepts only user messages')
   }
-  // Claude reads a streamed user message as a slash-command invocation only when the LAST
-  // content block is text, so images must precede the prompt or `/command` arrives as prose.
   const images: unknown[] = []
-  const texts: unknown[] = []
+  const texts: string[] = []
   const imageBudget: ImageBudget = { count: 0, localBytes: 0 }
   for (const block of body.blocks as NativeChatBlock[]) {
     if (block.type === 'text' && block.text.length > 0) {
-      texts.push({ type: 'text', text: block.text })
+      texts.push(block.text)
     } else if (block.type === 'image-ref') {
       images.push(await imageContent(block, imageBudget))
     }
   }
-  const content = [...images, ...texts]
+  // Join rather than append each block: only the trailing text is read as the prompt, so several
+  // text blocks would silently discard every one but the last.
+  const content = texts.length > 0 ? [...images, { type: 'text', text: texts.join('\n') }] : images
   if (content.length === 0) {
     throw new Error('Claude dispatch requires text or an image')
   }
   return content
+}
+
+/** The prompt Claude recovers from a dispatch, or null when the turn carries no prompt. */
+function claudeDispatchPrompt(content: readonly unknown[]): string | null {
+  const last = claudeRecord(content.at(-1))
+  return last?.type === 'text' && typeof last.text === 'string' ? last.text : null
+}
+
+/** Mirrors how Claude decides a turn is a command. Untrimmed on purpose: Claude does not trim
+ *  here either, so leading whitespace really does mean no command runs. */
+export function claudeDispatchInvokesSlashCommand(content: readonly unknown[]): boolean {
+  return claudeDispatchPrompt(content)?.startsWith('/') === true
 }
 
 /**

--- a/src/main/claude/claude-structured-dispatch-content.ts
+++ b/src/main/claude/claude-structured-dispatch-content.ts
@@ -94,15 +94,19 @@ export async function claudeDispatchMessageContent(
   if (body.role !== 'user') {
     throw new Error('Claude dispatch accepts only user messages')
   }
-  const content: unknown[] = []
+  // Claude reads a streamed user message as a slash-command invocation only when the LAST
+  // content block is text, so images must precede the prompt or `/command` arrives as prose.
+  const images: unknown[] = []
+  const texts: unknown[] = []
   const imageBudget: ImageBudget = { count: 0, localBytes: 0 }
   for (const block of body.blocks as NativeChatBlock[]) {
     if (block.type === 'text' && block.text.length > 0) {
-      content.push({ type: 'text', text: block.text })
+      texts.push({ type: 'text', text: block.text })
     } else if (block.type === 'image-ref') {
-      content.push(await imageContent(block, imageBudget))
+      images.push(await imageContent(block, imageBudget))
     }
   }
+  const content = [...images, ...texts]
   if (content.length === 0) {
     throw new Error('Claude dispatch requires text or an image')
   }

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -452,6 +452,18 @@ describe('Claude structured dispatch image limits', () => {
       state: 'accepted',
       providerIdentity: { uuid: 'command-result-uuid' }
     })
+    // The sent order is the fix: the waiter's verdict alone was already what it is today.
+    expect(session.connection.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: {
+          role: 'user',
+          content: [
+            { type: 'image', source: { type: 'url', url: 'https://example.test/a.png' } },
+            { type: 'text', text: '/permissions' }
+          ]
+        }
+      })
+    )
   })
 
   it('does not take a result receipt for leading whitespace Claude never reads as a command', async () => {

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -423,6 +423,61 @@ describe('Claude structured dispatch image limits', () => {
     })
   })
 
+  it('accepts a slash command sent with an attachment from its result receipt', async () => {
+    const session = sessionFor()
+    const dispatched = dispatchClaudeTurn(
+      session,
+      {
+        clientMessageId: 'client-1',
+        body: userMessage([
+          { type: 'text', text: '/permissions' },
+          { type: 'image-ref', url: 'https://example.test/a.png' }
+        ])
+      },
+      100
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+    // The mapper moves the image ahead of the prompt, so Claude runs the command and replies
+    // with a result receipt instead of a user replay.
+    expect(
+      resolveClaudeReplayWaiter(session, {
+        type: 'result',
+        subtype: 'success',
+        session_id: 'provider-session',
+        uuid: 'command-result-uuid'
+      })
+    ).toBe(false)
+
+    await expect(dispatched).resolves.toMatchObject({
+      state: 'accepted',
+      providerIdentity: { uuid: 'command-result-uuid' }
+    })
+  })
+
+  it('does not take a result receipt for leading whitespace Claude never reads as a command', async () => {
+    const session = sessionFor()
+    const dispatched = dispatchClaudeTurn(
+      session,
+      {
+        clientMessageId: 'client-1',
+        body: userMessage([{ type: 'text', text: '  /permissions' }])
+      },
+      100
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+    expect(
+      resolveClaudeReplayWaiter(session, {
+        type: 'result',
+        subtype: 'success',
+        session_id: 'provider-session',
+        uuid: 'unrelated-result-uuid'
+      })
+    ).toBe(false)
+
+    await expect(dispatched).resolves.toMatchObject({ state: 'unknown' })
+  })
+
   it('correlates a later slash-command result by user_message_uuid despite a timed-out slash waiter', async () => {
     const session = sessionFor()
     const first = dispatchClaudeTurn(

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -12,6 +12,7 @@ import type { ClaudeDispatchWaiter, ClaudeSession } from './claude-structured-se
 import { readClaudeFrameString } from './claude-structured-init-proof'
 import {
   claudeDispatchContentKey,
+  claudeDispatchInvokesSlashCommand,
   claudeDispatchMessageContent
 } from './claude-structured-dispatch-content'
 
@@ -231,9 +232,9 @@ export async function dispatchClaudeTurn(
     return { state: 'rejected', reason: (error as Error).message }
   }
   const dispatchSequence = ++session.dispatchSequence
-  const acceptsResult = input.body.blocks.some(
-    (block) => block.type === 'text' && block.text.trimStart().startsWith('/')
-  )
+  // Read the sent content, not the journal blocks: only the mapped trailing prompt decides
+  // whether Claude runs a command, so the two cannot disagree about which frame settles this.
+  const acceptsResult = claudeDispatchInvokesSlashCommand(content)
   const sentUuid = randomUUID()
   const replay = waitForReplay(
     session,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​232 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​232 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## Problem

In structured native chat on the Claude route, a slash command sent with an image attached is **not expanded**. The command text reaches the model as prose, and the deterministic local expansion is lost.

The mechanism is an encoding one, not a parser quirk. Claude encodes a user turn as **attachment blocks followed by the typed text**, and on the streamed-input path it inverts that encoding: it recovers "what the user typed" from the **trailing text block** and treats everything before it as attachments. A body whose last block is an image therefore has no recoverable prompt at all, so nothing is ever matched against a leading `/`.

The composer builds the send body as text-then-images (`structuredAgentSessionSendBody` in `src/shared/structured-agent-session-outbox.ts`), and `claudeDispatchMessageContent` preserved that order verbatim — so the trailing block was an image whenever anything was attached.

What happens after the command fails to expand is up to the model, which is why this is easy to miss: it may decline, it may answer *about* the command instead of running it, or it may non-deterministically re-route through the Skill tool and appear to work at the cost of an extra model turn and tool call. The free, deterministic local expansion is lost either way.

**Which commands are actually affected.** Not `/review`, `/init` or `/compact`: those are claimed client-side by `dispatchStructuredAgentSessionComposerCommand` (`src/shared/structured-agent-session-composer.ts`) against the curated list in `src/shared/native-chat-slash-commands.ts` and never reach this mapper. The commands that do traverse it are **user, project and plugin commands, and skills** — for example `/security-review` or any project command under `.claude/commands/`.

## Fix

Emit the dispatch content in Claude's own shape: attachment blocks first, then a single trailing text block carrying the prompt. Images-before-text is also the order Claude prefers for vision, so the reorder is unconditional rather than gated on a leading `/`.

Two details matter beyond simply moving text to the end:

- **One trailing text block, not several.** A plain partition into `[...images, ...texts]` still strands a command whenever a body carries more than one text block: `[text("/cmd"), image, text("thanks")]` would map to `[image, "/cmd", "thanks"]`, and only `"thanks"` is read as the prompt, so the command is silently dropped. Joining the text blocks into one trailing block makes the property the fix depends on hold for any body, instead of only for the single-text-block shape today's producers happen to emit.
- **`acceptsResult` is derived from the same sent content.** It previously used `blocks.some(block => block.text.trimStart().startsWith('/'))` over the pre-mapping journal blocks — a second, different model of "is this a command" that could disagree with the first. It is now `claudeDispatchInvokesSlashCommand(content)`, read from the content actually sent. That also removes a real over-match: Claude does **not** trim before testing for `/`, so a prompt with leading whitespace never runs a command, while the old predicate armed a waiter expecting a completed-command frame that could not arrive.

Fixed in the Claude mapper rather than in the shared send body on purpose: that body also defines rendered journal block order for every provider, so changing it there would move the blast radius well outside this bug. The reorder is not user-visible — the transcript renders the submitted body, and the provider's echo of a user turn is explicitly discarded in favour of it (`journal-reducer.ts`).

## Verification

**Real-CLI A/B against the shipping binary** in `--input-format stream-json`, same blocks, only the order differing, with a text-only control on both sides:

| content | result |
| :--- | :--- |
| `[text("/help")]` (control) | expanded locally, $0, no model turn |
| `[text("/help"), image]` (before) | **not** expanded — real model turn, command arrives as prose |
| `[image, text("/help")]` (after) | expanded locally, $0 — identical to the control |
| `[image, text("/cmd\nthanks")]` (joined) | expanded, attachment still in context |
| `[image, text("/cmd"), text("thanks")]` | **not** expanded — why the partition alone is not enough |
| `[text("  /cmd")]` | **not** expanded — Claude does not trim |

A custom project command sent as `[image, text("/cmd")]` expands *and* the model still sees the attachment, so the fix does not trade one silent failure for another.

**Unit tests** — `claude-structured-dispatch-content.test.ts` (10 cases): ordering with one and multiple attachments, the local-path attachment shape the composer actually sends, multi-text-block joining, text-only, image-only, both error paths, and the recognition predicate. `claude-structured-dispatch.test.ts` adds two cases pinning `acceptsResult` at the dispatch layer.

Ablation re-run at the current head — with the mapper reverted, the ordering cases fail and the regression guards stay green, so the tests bind to the behaviour being fixed rather than passing incidentally.

- `pnpm test src/main/claude` — 706 passed / 5 skipped. The one failure, `claude-tui-resume-real-binary.integration.test.ts`, is environmental (it spawns a real TUI and shells out to `ps`) and fails identically with this branch's production files reverted to `main`.
- `tsc --noEmit` on the node, cli and web projects — all exit 0.
- `pnpm run check:code-quality:changed` — 0 new findings across 4 files (incl. type-aware + React Doctor).
