### PR TITLE
fix(native-chat): keep collapsible chevrons beside their header text

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatBackgroundTasksStatus.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatBackgroundTasksStatus.tsx
@@ -49,7 +49,7 @@ export function NativeChatBackgroundTasksStatus(props: {
             <span aria-hidden="true">
               <AgentStateDot state="monitoring" size="md" title={null} />
             </span>
-            <span className="min-w-0 flex-1 truncate">
+            <span className="min-w-0 truncate">
               {translate(
                 'components.native-chat.backgroundTasks.monitoring',
                 'Monitoring background tasks'

--- a/src/renderer/src/components/native-chat/NativeChatSubagentRun.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSubagentRun.tsx
@@ -214,9 +214,7 @@ export function NativeChatSubagentRun({
       >
         <SubagentGlyph />
         <StatusDot state={alertState ?? verdictState} pulsing={working} />
-        <span className={cn('min-w-0 flex-1 truncate', working && 'text-foreground/85')}>
-          {headline}
-        </span>
+        <span className={cn('min-w-0 truncate', working && 'text-foreground/85')}>{headline}</span>
         <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
           {verdict}
           {alert === null ? null : ` +${alert}`}

--- a/src/renderer/src/components/native-chat/NativeChatToolAnnotations.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolAnnotations.tsx
@@ -41,7 +41,7 @@ export function NativeChatCommandMetadata({
     return null
   }
   return (
-    <span className="ml-auto flex shrink-0 gap-1.5 font-mono text-[11px] text-muted-foreground">
+    <span className="flex shrink-0 gap-1.5 font-mono text-[11px] text-muted-foreground">
       {exitCode !== undefined ? (
         <span className={cn(exitCode !== 0 && 'text-destructive')}>
           {translate('components.native-chat.tool.exitCode', 'exit {{value0}}', {

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
@@ -297,7 +297,7 @@ export function NativeChatToolRun({
             rowWord={latestActiveCall.name}
             className="text-muted-foreground"
           />
-          <span className="min-w-0 flex-1 animate-pulse truncate text-foreground/85 motion-reduce:animate-none">
+          <span className="min-w-0 animate-pulse truncate text-foreground/85 motion-reduce:animate-none">
             {nativeChatToolActivityLabel(latestActiveCall)}
           </span>
           {open ? <ChevronRight className="size-3.5 rotate-90 text-muted-foreground" /> : null}

--- a/src/renderer/src/components/native-chat/NativeChatTurnDiffRollup.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTurnDiffRollup.tsx
@@ -29,7 +29,7 @@ export function NativeChatTurnDiffRollup({
           ) : null}
           <ChevronRight
             aria-hidden
-            className="ml-auto size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90 motion-reduce:transition-none"
+            className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90 motion-reduce:transition-none"
           />
         </Button>
       </CollapsibleTrigger>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## Summary

In native chat, several collapsible headers pushed their expand chevron to the far right edge of the row, so the affordance sat far from the text it belonged to (e.g. the "N changed files" turn diff rollup). This keeps the chevron directly after the header text in every native chat collapsible.

One class removed per file:

- `NativeChatTurnDiffRollup.tsx`: drop `ml-auto` on the chevron (the changed-files header).
- `NativeChatBackgroundTasksStatus.tsx`: drop `flex-1` on the "Monitoring background tasks" label.
- `NativeChatToolRun.tsx`: drop `flex-1` on the live activity label in the running tool-run header.
- `NativeChatSubagentRun.tsx`: drop `flex-1` on the subagent headline.
- `NativeChatToolAnnotations.tsx`: drop `ml-auto` on the exit code / duration metadata in tool rows.

Side effect worth noting: in tool rows and subagent rows the chevron follows trailing metadata (exit code, duration, verdict, token count), so that metadata now reads inline after the text rather than right-aligned. Labels keep `min-w-0 truncate`, so truncation behaves as before.

Headers that were already inline and are untouched: the working-status caret, the diff card verb row, and the collapsed tool-run batch header.

## Validation

- `pnpm test` on `NativeChatSubagentRun`, `NativeChatBackgroundTasksStatus`, `NativeChatToolRun`, and `native-chat-turn-diffs`: 85 passed.
- `pnpm run check:code-quality:changed`: 0 new findings across 5 changed files.
- Visual proof: all five surfaces captured in the real Electron app at the PR head, including a same-layout before/after of the changed-files header: https://github.com/stablyai/orca/pull/19656#issuecomment-5594504541

Author: @BrennanKB5
