### PR TITLE
fix(terminal): finish a paste in the terminal that started it instead of cancelling on a focus blip

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-paste-target-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-target-state.test.ts
@@ -158,6 +158,21 @@ describe('terminal paste target state', () => {
     ).toBe(true)
   })
 
+  it('keeps keyboard-owned paste current when the dispatch snapshot caught a deferred window-focus reclaim on body', () => {
+    const terminalInput = makeElement('textarea', ['xterm-helper-textarea'])
+    const body = makeElement('body')
+    const paneContainer = makePaneContainer(terminalInput)
+
+    expect(
+      isTerminalPanePasteFocusCurrent({
+        requireSameFocusedElement: true,
+        activeElementAtDispatch: body,
+        paneContainer,
+        activeElement: terminalInput
+      })
+    ).toBe(true)
+  })
+
   it('keeps keyboard-owned paste current when xterm replaces its helper textarea', () => {
     const originalTerminalInput = makeElement('textarea', ['xterm-helper-textarea'])
     const replacementTerminalInput = makeElement('textarea', ['xterm-helper-textarea'])

--- a/src/renderer/src/components/terminal-pane/terminal-paste-target-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-target-state.ts
@@ -54,7 +54,13 @@ export function isTerminalPanePasteFocusCurrent({
   if (!requireSameFocusedElement || activeElementAtDispatch === null) {
     return true
   }
-  if (!paneContainer.contains(activeElementAtDispatch)) {
+  // Why: a window-blur/refocus cycle (Cmd+Tab away and back) can leave the dispatch
+  // snapshot on body while regular-terminal-focus-ownership.ts's reclaim is still
+  // deferred to the next frame; only a real, different element proves staleness.
+  if (
+    !isInertDocumentFocus(activeElementAtDispatch) &&
+    !paneContainer.contains(activeElementAtDispatch)
+  ) {
     return false
   }
   if (activeElement === activeElementAtDispatch) {


### PR DESCRIPTION
## ELI5

Switching back to Orca and pasting into a terminal right away no longer trips the "Paste cancelled: terminal focus changed before paste started." toast. The paste finishes in the terminal that started it; a genuinely stale target (pane closed, focus moved to another real control) is still cancelled as before.

## What Changed

One guard in `isTerminalPanePasteFocusCurrent` (`src/renderer/src/components/terminal-pane/terminal-paste-target-state.ts`). The dispatch-time focus snapshot is now treated the same way the final focus already is: a transient `body`/`html` snapshot is inert and falls through to the existing final-focus checks, and only a real, different element outside the pane proves the target is stale. Plus a regression test for that case.

## Why

Fixes #18594.

Cmd+V routes through the Edit menu accelerator (`register-app-menu.ts`) to `onAppMenuPaste` (`terminal-pane-paste-listeners.ts`), which snapshots `document.activeElement` at dispatch, then awaits the clipboard IPC read before `executeTerminalPastePlan` checks the target is still current. When the window regains OS focus after a blur (Cmd+Tab away to copy, Cmd+Tab back), `resyncTerminalFocusForWindowFocus` (`regular-terminal-focus-ownership.ts`) deliberately defers reclaiming the xterm helper's DOM focus to the next animation frame so a click during reactivation is not yanked back. A paste fired in that frame snapshots `document.body`, and `paneContainer.contains(body)` is always false (body is an ancestor, never a descendant), so the check rejected the paste before the deferred refocus landed, even though focus resolved to the correct terminal moments later. The final-focus side of the same check already tolerated a transient `body`/`html` ("macOS dictation and clipboard permission handoffs can transiently blur xterm to body"); the dispatch-time side did not.

The deferred reclaim is explicitly cross-platform (its comment notes an earlier Linux report), and the guard is platform-agnostic, so the fix applies to macOS, Linux, and Windows alike. The Wayland "stale clipboard content" comment on the issue is a different problem and is not addressed here.

## Linked Issue

Fixes #18594

## Visual Proof

No recording attached: the change removes a spurious toast in a one-frame race that is hard to capture on video. Reviewer steps below reproduce it; I will add a recording if you want one.

## Testing

- New test in `terminal-paste-target-state.test.ts`: dispatch snapshot on `body`, final focus on the real xterm helper, target must stay current. RED before the fix (`1 failed | 10 passed (11)`), GREEN after (`11 passed (11)`).
- Sibling suites (coordinator, runtime, executor, operation order, programmatic paste, global effects): 6 files / 62 tests passed. Whole `terminal-pane/` directory: 441 files / 4237 tests passed, 1 skipped.
- `pnpm run check:code-quality:changed`: 0 new findings across all three checks. `oxfmt` on touched files: clean. `pnpm tc:web`: clean (no main-process files touched).
- Platforms: unit tests and typecheck on macOS; not exercised in a running app or on Linux/Windows.
- Reviewer steps: focus a terminal pane, switch to another app and copy text, switch back and press Cmd+V (Ctrl+V) immediately. Before: the toast could appear and nothing was pasted. After: the paste lands in that terminal. Then click into an unrelated input and paste: still cancelled, as designed.

- [ ] I manually tested these changes locally (verified by the unit test and typecheck; not run in the app)
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Fable 5.1 (planning and review) and Claude Sonnet 5 (implementation) in Claude Code, driven by @tan7vir.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security surface, no path or shortcut changes, renderer-only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason (see Visual Proof)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted lint, typecheck, and tests run locally; CI to cover the full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
