### PR TITLE
fix(runtime): honor caller deadline and abort on local runtime RPC

### DIFF
--- a/src/renderer/src/runtime/runtime-rpc-client-local-deadline.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client-local-deadline.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { callRuntimeRpc } from './runtime-rpc-client'
+
+const runtimeCall = vi.fn()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  runtimeCall.mockReset()
+  vi.stubGlobal('window', {
+    api: {
+      runtime: { call: runtimeCall },
+      runtimeEnvironments: { call: vi.fn(), subscribe: vi.fn() }
+    }
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('local runtime RPC deadline', () => {
+  it('rejects a stalled local call once the caller deadline elapses', async () => {
+    // Why: a main-process dispatch that never returns used to leave this promise
+    // pending forever, freezing every surface that awaits it (Automations).
+    runtimeCall.mockReturnValue(new Promise(() => {}))
+    const pending = callRuntimeRpc({ kind: 'local' }, 'automation.list', undefined, {
+      timeoutMs: 15_000
+    })
+    const assertion = expect(pending).rejects.toThrow(
+      'Runtime request timed out before automation.list completed'
+    )
+    await vi.advanceTimersByTimeAsync(15_000)
+    await assertion
+  })
+
+  it('rejects a stalled local call when the caller aborts', async () => {
+    runtimeCall.mockReturnValue(new Promise(() => {}))
+    const controller = new AbortController()
+    const pending = callRuntimeRpc({ kind: 'local' }, 'automation.list', undefined, {
+      timeoutMs: 15_000,
+      signal: controller.signal
+    })
+    const assertion = expect(pending).rejects.toThrow('Runtime request aborted')
+    controller.abort()
+    await assertion
+  })
+
+  it('rejects when the caller signal is already aborted', async () => {
+    // Why: an aborted signal never fires 'abort', so a listener-only guard would
+    // leave the promise pending forever.
+    runtimeCall.mockReturnValue(new Promise(() => {}))
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      callRuntimeRpc({ kind: 'local' }, 'automation.list', undefined, {
+        timeoutMs: 15_000,
+        signal: controller.signal
+      })
+    ).rejects.toThrow('Runtime request aborted')
+  })
+
+  it('leaves a call without a caller deadline unbounded', async () => {
+    runtimeCall.mockResolvedValue({
+      id: 'desktop-ipc',
+      ok: true,
+      result: { automations: [] },
+      _meta: { runtimeId: 'local-runtime' }
+    })
+    await expect(
+      callRuntimeRpc({ kind: 'local' }, 'automation.list', undefined, {})
+    ).resolves.toEqual({ automations: [] })
+  })
+})

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -4,6 +4,7 @@ import type { RuntimeCapability } from '../../../shared/protocol-version'
 import { withBrowserPaneUiRuntimeRpcSource } from '../../../shared/runtime-rpc-feature-interaction-source'
 import { assertRuntimeStatusCompatible } from './runtime-protocol-compat'
 import { createRuntimeRpcAbortError } from './abortable-runtime-environment-call'
+import { withLocalRuntimeRpcDeadline } from './runtime-rpc-local-deadline'
 import { callRuntimeEnvironmentWithRevision } from './runtime-rpc-environment-call'
 import { RuntimeRpcCallError, unwrapRuntimeRpcResult } from './runtime-rpc-result'
 import { captureRuntimeEnvironmentRequestRevision } from './runtime-environment-revision'
@@ -81,7 +82,11 @@ export async function callRuntimeRpc<TResult>(
     : params
   const response =
     target.kind === 'local'
-      ? await window.api.runtime.call({ method, params: nextParams })
+      ? await withLocalRuntimeRpcDeadline(
+          window.api.runtime.call({ method, params: nextParams }),
+          method,
+          { timeoutMs: options.timeoutMs, signal: options.signal }
+        )
       : await callRuntimeEnvironmentWithRevision({
           environmentId: target.environmentId,
           method,

--- a/src/renderer/src/runtime/runtime-rpc-local-deadline.ts
+++ b/src/renderer/src/runtime/runtime-rpc-local-deadline.ts
@@ -1,0 +1,54 @@
+import { createRuntimeRpcAbortError } from './abortable-runtime-environment-call'
+
+/**
+ * Bound a local (desktop IPC) runtime RPC with the caller's deadline and abort.
+ *
+ * Why: `ipcRenderer.invoke('runtime:call')` settles only when the main-process
+ * handler returns, and that handler dispatches without a deadline of its own.
+ * The environment path already honours `timeoutMs` and `signal`, so a caller
+ * that asks for either must get it here too. Otherwise a stalled dispatch
+ * leaves the renderer awaiting a promise that never settles, with no way back
+ * to a rendered state.
+ */
+export function withLocalRuntimeRpcDeadline<T>(
+  pending: Promise<T>,
+  method: string,
+  options: { timeoutMs?: number; signal?: AbortSignal }
+): Promise<T> {
+  const { timeoutMs, signal } = options
+  if (timeoutMs === undefined && signal === undefined) {
+    return pending
+  }
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+    const deadline =
+      timeoutMs === undefined
+        ? null
+        : setTimeout(() => {
+            finish(() => reject(new Error(`Runtime request timed out before ${method} completed`)))
+          }, timeoutMs)
+    const finish = (complete: () => void): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (deadline !== null) {
+        clearTimeout(deadline)
+      }
+      signal?.removeEventListener('abort', onAbort)
+      complete()
+    }
+    const onAbort = (): void => finish(() => reject(createRuntimeRpcAbortError()))
+    // Why: an already-aborted signal never fires 'abort', so the listener alone
+    // would leave this promise pending for a caller that aborted before we ran.
+    if (signal?.aborted) {
+      finish(() => reject(createRuntimeRpcAbortError()))
+    } else {
+      signal?.addEventListener('abort', onAbort, { once: true })
+    }
+    pending.then(
+      (value) => finish(() => resolve(value)),
+      (error) => finish(() => reject(error))
+    )
+  })
+}


### PR DESCRIPTION
## ELI5

When a screen asks the app's own backend for data, it can say "give up after 15 seconds." That instruction was being thrown away for local calls, so if the backend never answered, the screen waited forever. Automations is where you notice, since it sits on a loading skeleton and never comes back, even after a restart. This makes the app actually give up when it said it would.

## What Changed

* New `src/renderer/src/runtime/runtime-rpc-local-deadline.ts`. `withLocalRuntimeRpcDeadline` bounds a local runtime RPC with the caller's `timeoutMs` and wires the caller's `AbortSignal`, using the same settle once bookkeeping and the same error message as `callAbortableRuntimeEnvironment`.
* `src/renderer/src/runtime/runtime-rpc-client.ts`. The `target.kind === 'local'` branch passes `options.timeoutMs` and `options.signal` through that helper instead of dropping them.
* New `src/renderer/src/runtime/runtime-rpc-client-local-deadline.test.ts`. Four cases: a stalled local call rejects at the deadline, rejects on abort, rejects when the signal is already aborted, and a call with no caller deadline stays unbounded.

No default deadline is introduced. Long running local RPCs such as `git.fetch` and `worktree.create` pass no `timeoutMs` on purpose, and a blanket default would break them. Only calls that already asked to be bounded become bounded.

## Why

`callRuntimeRpc` honored `timeoutMs` and `signal` on the environment path and silently discarded both on the local path (`runtime-rpc-client.ts:82-92`). Nothing downstream compensated: the preload contract has no deadline on the local call (`src/preload/api/runtime-api.ts:29`, `runtime-bridge.ts:18-19`), and `runtime:call` dispatches with neither a race nor a context `signal` (`src/main/ipc/runtime.ts:62-89`), even though `boundTerminalFitRestore` (`runtime.ts:21-28`) and the `AbortController` in `runtime:subscribe` (`runtime.ts:104`) are both in that file, and `RpcContext.signal` already exists for this purpose (`src/main/runtime/rpc/core.ts:67`).

That made every caller deadline on the local path a no-op. The starkest case is `runtime/client-hosted-browser-row-close.ts`, which defines `CLIENT_HOSTED_ROW_CLOSE_TIMEOUT_MS = 15_000` (line 4) and passes it to a call with a hardcoded `{ kind: 'local' }` target (line 20), so that constant has never had any effect.

Counting with a paren balancing scanner over `src/renderer`, excluding tests and harnesses: 354 `callRuntimeRpc` call sites, 324 passing `timeoutMs` or `signal`, and 266 of those with a target that can resolve to local. A line based grep undercounts this badly, since nearly every call uses a generic and spans multiple lines.

The user visible symptom that led here: `AutomationsPage` mounts with `isLoading = true`, calls `automation.list` with `{ timeoutMs: 15_000 }` against `{ kind: 'local' }`, and its `finally { setIsLoading(false) }` can only run once that promise settles. When it never settles, `AutomationsPageSurface.tsx:260-261` renders the skeleton forever, and since `activeView` is persisted, relaunching lands back on Automations and repeats it.

## Linked Issue

Fixes #19660

## Visual Proof

N/A, no visual change. The fix turns an indefinite skeleton into the page's existing failure path (`setFailedAuthorityKeys`), which already has its own rendering.

## Testing

* `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/automations src/renderer/src/runtime`: 279 files, 2309 tests, all passing.
* Confirmed the new tests fail without the fix. The deadline case and the abort case both hang until vitest's own 5s timeout, which is the reported bug reproduced in a test.
* `pnpm typecheck`: clean.
* `pnpm lint`: clean. The warnings it prints are pre-existing and in files this PR does not touch.
* Full `pnpm test` on this machine: 8320 files, 77069 tests, 12 files and 14 tests failing. Every failure is under `config/scripts`, `src/main/**` or `tests/e2e` (`macos-computer-helper-owner-loss-processes`, `skill-recipe-shell`, `browser-route-webrtc-egress.electron`, `claude-structured-real-cli`, `claude-tui-resume-real-binary`, `codex-cli/command`, `worktree-created-description-real-git`, `release-checkout.unit`). Zero failures under `src/renderer`, which is the only tree this PR touches, and none of the failing files reference the changed module. They need a built CLI entrypoint, a signed in Claude CLI and a WSL/Linux environment that I do not have locally. Flagging the numbers rather than claiming a clean full run.

## AI Disclosure

Investigated and drafted with AI assistance. Every line reference, count and claim in this PR was verified against the source, and the test suite, typecheck and lint were run locally.

## Review

* Cross platform: renderer only, no platform specific APIs. `setTimeout` and `AbortSignal` behave the same across supported targets.
* SSH, remote, local: the environment path is untouched. Only the local path changes, and only for callers that already passed `timeoutMs` or `signal`.
* Performance: one timer and one abort listener per bounded call, both cleared in the settle once `finish` path. Calls with neither option return the original promise unwrapped, so the common case adds nothing.
* Security: no change to the IPC surface, the dispatcher, or any authorization check.
* Behavior change worth flagging: local mutating RPCs that carry a deadline now reject when it elapses, while the underlying IPC keeps running in the main process. `automation.update`, `automation.delete` and `automation.runNow` (`automation-host-client.ts:155/169/177`), `repo.rm`, `repo.update` and the `worktree.*` actions are all in that set. On a host slow enough for the handler to finish just past 15s, a user now sees a failure and may retry an operation that actually succeeded. I chose to accept this rather than special case mutations, because those same methods already behave exactly this way when the target is an environment (`getAutomationOwnerTarget` picks local or environment for the same call), and this PR emits the byte identical error message the environment path emits, so any caller that already handles a remote timeout handles this unchanged. Waiting forever is strictly worse, since it leaves the user with no error and no retry. Happy to gate it to read only methods instead if you would rather land the narrow fix first.

## Known limitation

The deadline is renderer side, so a stalled main process dispatch is abandoned rather than cancelled. Cancelling it properly means passing a `signal` into the unary `dispatch` context in `runtime:call`, the way `runtime:subscribe` already does, and extending the preload contract with `timeoutMs`/`signal`. Both are straightforward given `RpcContext.signal` already exists, but they widen the diff across three layers, so I kept them out and noted them as follow ups in the issue.
