### PR TITLE
refactor(ai-vault): split the session scanner into a transcript reader and consumers

### DIFF
--- a/src/main/ai-vault/remote-session-file-stat.ts
+++ b/src/main/ai-vault/remote-session-file-stat.ts
@@ -13,7 +13,13 @@ export async function statRemoteSessionFile(
   agent: AiVaultAgent,
   executionHostId: ExecutionHostId,
   issues: AiVaultScanIssue[],
-  options?: { missingIsExpected?: boolean; signal?: AbortSignal }
+  options?: {
+    missingIsExpected?: boolean
+    signal?: AbortSignal
+    // Lets a caller tell a missing path from a failed stat, which both report
+    // as null; the issue is recorded either way before this rethrows.
+    rethrowFailures?: boolean
+  }
 ): Promise<FileWithMtime | null> {
   try {
     throwIfAiVaultScanCancelled(options?.signal)
@@ -31,13 +37,17 @@ export async function statRemoteSessionFile(
     }
   } catch (error) {
     throwIfAiVaultScanCancelled(options?.signal)
-    if (!options?.missingIsExpected || !isMissingRemoteSessionPathError(error)) {
+    const missing = isMissingRemoteSessionPathError(error)
+    if (!options?.missingIsExpected || !missing) {
       recordSessionScanIssue(issues, {
         executionHostId,
         agent,
         path,
         message: errorMessage(error)
       })
+    }
+    if (options?.rethrowFailures && !missing) {
+      throw error
     }
     return null
   }

--- a/src/main/ai-vault/remote-session-parse-cache.ts
+++ b/src/main/ai-vault/remote-session-parse-cache.ts
@@ -1,5 +1,6 @@
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import type { RemoteScannerContext, RemoteSessionCandidate } from './remote-session-scanner-types'
+import { sidecarUnchanged, type SessionSidecarObservation } from './session-sidecar-stat'
 
 // Matches the local scanner's cap. The relay sidecar is forked with
 // --max-old-space-size=384, and a retained session row is a title, a preview
@@ -11,6 +12,7 @@ type RemoteSessionParseCacheEntry = {
   mtimeMs: number
   sizeBytes: number | null
   hostKey: string
+  sidecar?: SessionSidecarObservation
   session: AiVaultSession | null
 }
 
@@ -55,13 +57,15 @@ function storeEntry(path: string, entry: RemoteSessionParseCacheEntry): void {
  * (#13753). The local scanner has had `parseAgentSessionFileCached` for exactly
  * this reason; this is its remote counterpart.
  *
- * `(mtimeMs, sizeBytes)` is a sound validity key here because discovery already
- * folds a source's `contentDependencyPath` stat into both fields
- * (remote-session-scanner-discovery.ts), so a metadata-only transcript whose
- * companion file changed still looks changed. Sources whose parse reads a file
- * discovery does not stat — Codex looks its title up in `session_index.jsonl` —
- * are not covered by that key and pass `refreshReusedSession` to re-derive the
- * uncovered part without touching the transcript.
+ * `(mtimeMs, sizeBytes)` covers the transcript, and the sidecar observation
+ * discovery records beside it (remote-session-scanner-discovery.ts) covers a
+ * source's companion file, so a metadata-only transcript whose companion
+ * changed still looks changed. Remote Cline is the only such source; remote
+ * Cursor streams transcript content with no sibling to read. Sources whose
+ * parse reads a file discovery does not stat — Codex looks its title up in
+ * `session_index.jsonl` — are not covered by either and pass
+ * `refreshReusedSession` to re-derive the uncovered part without touching the
+ * transcript.
  *
  * Only a completed parse is stored. A read that threw stays uncached so a
  * transient filesystem failure cannot pin a wrong answer for the corpus's life.
@@ -80,7 +84,10 @@ export async function parseRemoteSessionFileCached(args: {
     entry !== undefined &&
     entry.hostKey === args.hostKey &&
     entry.mtimeMs === file.mtimeMs &&
-    (entry.sizeBytes === null || file.sizeBytes === undefined || entry.sizeBytes === file.sizeBytes)
+    (entry.sizeBytes === null ||
+      file.sizeBytes === undefined ||
+      entry.sizeBytes === file.sizeBytes) &&
+    sidecarUnchanged(entry.sidecar, file.sidecar)
   if (unchanged) {
     if (args.stats) {
       args.stats.reused++
@@ -101,6 +108,7 @@ export async function parseRemoteSessionFileCached(args: {
     mtimeMs: file.mtimeMs,
     sizeBytes: file.sizeBytes ?? null,
     hostKey: args.hostKey,
+    sidecar: file.sidecar,
     session
   })
   return session

--- a/src/main/ai-vault/remote-session-scanner-discovery.ts
+++ b/src/main/ai-vault/remote-session-scanner-discovery.ts
@@ -4,6 +4,7 @@ import type { ExecutionHostId } from '../../shared/execution-host'
 import { joinRemotePath } from '../ssh/ssh-remote-platform'
 import { isMissingRemoteSessionPathError, statRemoteSessionFile } from './remote-session-file-stat'
 import type { FileWithMtime } from './session-scanner-types'
+import type { SessionSidecarObservation } from './session-sidecar-stat'
 import { errorMessage } from './session-scanner-values'
 import { mapRemoteScanBatches } from './remote-session-scan-batching'
 import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
@@ -62,21 +63,37 @@ async function statRemoteCandidateFile(
     return file
   }
   const sidecarPath = source.contentDependencyPath(path)
-  const sidecar = await statRemoteSessionFile(
-    context.provider,
-    sidecarPath,
-    source.agent,
-    context.executionHostId,
-    issues,
-    { missingIsExpected: true, signal: context.signal }
-  )
   // Recorded beside the transcript's own stat, never folded into it: one key
   // cannot mean both "the transcript grew" and "the sibling changed".
-  return {
-    ...file,
-    sidecar: sidecar
+  return { ...file, sidecar: await observeRemoteSidecar(source, context, sidecarPath, issues) }
+}
+
+/**
+ * A stat that failed for any reason other than a missing path is `'unknown'`,
+ * not `'none'`: serving the cached session over an unreadable sibling would
+ * publish metadata nobody can currently see. `statRemoteSessionFile` already
+ * recorded the issue for the failure.
+ */
+async function observeRemoteSidecar(
+  source: RemoteSessionSource,
+  context: RemoteScannerContext,
+  sidecarPath: string,
+  issues: AiVaultScanIssue[]
+): Promise<SessionSidecarObservation> {
+  try {
+    const sidecar = await statRemoteSessionFile(
+      context.provider,
+      sidecarPath,
+      source.agent,
+      context.executionHostId,
+      issues,
+      { missingIsExpected: true, signal: context.signal, rethrowFailures: true }
+    )
+    return sidecar
       ? { path: sidecarPath, mtimeMs: sidecar.mtimeMs, sizeBytes: sidecar.sizeBytes ?? 0 }
       : 'none'
+  } catch {
+    return 'unknown'
   }
 }
 

--- a/src/main/ai-vault/remote-session-scanner-discovery.ts
+++ b/src/main/ai-vault/remote-session-scanner-discovery.ts
@@ -61,23 +61,22 @@ async function statRemoteCandidateFile(
   if (!file || !source.contentDependencyPath) {
     return file
   }
-  const dependency = await statRemoteSessionFile(
+  const sidecarPath = source.contentDependencyPath(path)
+  const sidecar = await statRemoteSessionFile(
     context.provider,
-    source.contentDependencyPath(path),
+    sidecarPath,
     source.agent,
     context.executionHostId,
     issues,
     { missingIsExpected: true, signal: context.signal }
   )
-  if (!dependency) {
-    return file
-  }
-  const mtimeMs = Math.max(file.mtimeMs, dependency.mtimeMs)
+  // Recorded beside the transcript's own stat, never folded into it: one key
+  // cannot mean both "the transcript grew" and "the sibling changed".
   return {
     ...file,
-    mtimeMs,
-    modifiedAt: new Date(mtimeMs).toISOString(),
-    sizeBytes: (file.sizeBytes ?? 0) + (dependency.sizeBytes ?? 0)
+    sidecar: sidecar
+      ? { path: sidecarPath, mtimeMs: sidecar.mtimeMs, sizeBytes: sidecar.sizeBytes ?? 0 }
+      : 'none'
   }
 }
 

--- a/src/main/ai-vault/remote-session-sidecar-observation.test.ts
+++ b/src/main/ai-vault/remote-session-sidecar-observation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { scanRemoteAiVaultSessions } from './remote-session-scanner'
+import { MemoryRemoteProvider } from './remote-session-scanner-test-fixtures'
+import { resetRemoteSessionParseCacheForTests } from './remote-session-parse-cache'
+
+describe('remote sidecar observations', () => {
+  const sessionId = '1786466194549_sidecar'
+  const sessionDir = `/home/ada/.cline/data/sessions/${sessionId}`
+  const messagesPath = `${sessionDir}/${sessionId}.messages.json`
+
+  function addCline(provider: MemoryRemoteProvider, firstPrompt: string): void {
+    provider.addFile(
+      `${sessionDir}/${sessionId}.json`,
+      JSON.stringify({
+        version: 1,
+        session_id: sessionId,
+        started_at: '2026-08-11T16:36:34.551Z',
+        cwd: '/home/ada/repo'
+      }),
+      10
+    )
+    provider.addFile(
+      messagesPath,
+      JSON.stringify({
+        version: 1,
+        updated_at: '2026-08-11T16:38:00.000Z',
+        sessionId,
+        messages: [{ role: 'user', content: [{ type: 'text', text: firstPrompt }] }]
+      }),
+      11
+    )
+  }
+
+  const scan = (provider: MemoryRemoteProvider): ReturnType<typeof scanRemoteAiVaultSessions> =>
+    scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+
+  it('re-parses when a messages-file stat fails rather than serving the cached row', async () => {
+    resetRemoteSessionParseCacheForTests()
+    const provider = new MemoryRemoteProvider()
+    addCline(provider, 'first prompt')
+    expect((await scan(provider)).sessions[0]).toMatchObject({ title: 'first prompt' })
+
+    // The sidecar changed underneath, and its stat now fails for a reason that
+    // is not "missing": nothing about it may be assumed, so the row is re-read.
+    addCline(provider, 'second prompt')
+    provider.failStat(
+      messagesPath,
+      Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    )
+
+    const refused = await scan(provider)
+
+    expect(refused.sessions[0]).toMatchObject({ title: 'second prompt' })
+    expect(refused.issues.map((issue) => issue.path)).toContain(messagesPath)
+  })
+
+  it('treats a genuinely missing messages file as no sidecar, not as unknown', async () => {
+    resetRemoteSessionParseCacheForTests()
+    const provider = new MemoryRemoteProvider()
+    provider.addFile(
+      `${sessionDir}/${sessionId}.json`,
+      JSON.stringify({
+        version: 1,
+        session_id: sessionId,
+        started_at: '2026-08-11T16:36:34.551Z',
+        cwd: '/home/ada/repo'
+      }),
+      10
+    )
+
+    const first = await scan(provider)
+    const second = await scan(provider)
+
+    expect(first.issues).toEqual([])
+    expect(second.issues).toEqual([])
+    expect(second.sessions[0]?.sessionId).toBe(sessionId)
+  })
+})

--- a/src/main/ai-vault/session-newest-files.test.ts
+++ b/src/main/ai-vault/session-newest-files.test.ts
@@ -1,0 +1,31 @@
+import { expect, it } from 'vitest'
+import { SessionNewestFiles } from './session-newest-files'
+import type { FileWithMtime } from './session-scanner-types'
+
+function file(i: number): FileWithMtime {
+  const mtimeMs = (i * 7919) % 997
+  return { path: String(i), mtimeMs, modifiedAt: new Date(mtimeMs).toISOString() }
+}
+
+it('retains at most 12 of 100,000 candidates with stable newest-first ties', () => {
+  const all = Array.from({ length: 100_000 }, (_, i) => file(i))
+  const retained = new SessionNewestFiles(12)
+  let peak = 0
+  for (const candidate of all) {
+    retained.add(candidate)
+    peak = Math.max(peak, retained.size)
+  }
+  expect(peak).toBe(12)
+  expect(retained.newest()).toEqual(all.sort((a, b) => b.mtimeMs - a.mtimeMs).slice(0, 12))
+})
+
+it('supports full backfill and empty requests', () => {
+  const all = new SessionNewestFiles(Infinity)
+  const none = new SessionNewestFiles(0)
+  for (let i = 0; i < 100; i++) {
+    all.add(file(i))
+    none.add(file(i))
+  }
+  expect(all.newest()).toHaveLength(100)
+  expect(none.newest()).toEqual([])
+})

--- a/src/main/ai-vault/session-newest-files.ts
+++ b/src/main/ai-vault/session-newest-files.ts
@@ -1,0 +1,50 @@
+import type { FileWithMtime } from './session-scanner-types'
+
+/** Retain only the requested newest files, preserving traversal order on ties. */
+export class SessionNewestFiles {
+  private readonly files: FileWithMtime[] = []
+
+  private readonly limit: number
+
+  constructor(limit: number) {
+    this.limit = Math.max(0, Math.trunc(limit) || 0)
+  }
+
+  add(file: FileWithMtime): void {
+    // The backfill enumerates with no limit; skip the insert search entirely.
+    if (!Number.isFinite(this.limit)) {
+      this.files.push(file)
+      return
+    }
+    if (this.limit <= 0) {
+      return
+    }
+    const last = this.files.at(-1)
+    if (this.files.length >= this.limit && last && file.mtimeMs <= last.mtimeMs) {
+      return
+    }
+    let low = 0
+    let high = this.files.length
+    while (low < high) {
+      const middle = (low + high) >>> 1
+      if (this.files[middle].mtimeMs >= file.mtimeMs) {
+        low = middle + 1
+      } else {
+        high = middle
+      }
+    }
+    this.files.splice(low, 0, file)
+    if (this.files.length > this.limit) {
+      this.files.pop()
+    }
+  }
+
+  get size(): number {
+    return this.files.length
+  }
+
+  /** The unbounded path appends in traversal order, so the sort is not redundant. */
+  newest(): FileWithMtime[] {
+    return [...this.files].sort((a, b) => b.mtimeMs - a.mtimeMs)
+  }
+}

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -29,9 +29,12 @@ import {
   parseAgentSessionFileCached,
   resetSessionParseCacheForTests,
   seedSessionParseCache,
+  snapshotSessionParseCacheForPersistence,
   type PersistedSessionParseCacheEntry,
   type SessionParseStats
 } from './session-scanner-parse-cache'
+import { getSessionParseCacheEntry } from './session-parse-cache-store'
+import type { SessionSidecarObservation } from './session-sidecar-stat'
 import { isolatedScanRoots } from './session-scanner-test-fixtures'
 import { parseClaudeSessionFile } from './session-scanner-primary-parsers'
 import type { FileWithMtime, SessionFileCandidate } from './session-scanner-types'
@@ -524,5 +527,40 @@ describe('session parse cache persistence', () => {
     expect(await readdir(root)).toEqual(expect.arrayContaining(['blocker']))
     expect((await readdir(root)).filter((name) => name.endsWith('.tmp'))).toEqual([])
     debugSpy.mockRestore()
+  })
+})
+
+describe('sidecar observations survive the round trip', () => {
+  const OBSERVATIONS: [string, SessionSidecarObservation | undefined][] = [
+    ['an object', { path: '/chats/a/meta.json', mtimeMs: 42, sizeBytes: 7 }],
+    ['none', 'none'],
+    ['unknown', 'unknown'],
+    ['absent', undefined]
+  ]
+
+  it.each(OBSERVATIONS)('restores %s exactly', async (_label, sidecar) => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    const path = await writeTranscript(root)
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    await ensureSessionParseCacheLoaded()
+
+    const stats = createSessionParseStats()
+    await parseAgentSessionFileCached(await claudeCandidate(path), process.platform, stats)
+    const seeded = snapshotSessionParseCacheForPersistence().map(
+      ([entryPath, entry]): [string, PersistedSessionParseCacheEntry] => [
+        entryPath,
+        sidecar === undefined ? entry : { ...entry, sidecar }
+      ]
+    )
+    resetSessionParseCacheForTests()
+    seedSessionParseCache(seeded)
+    scheduleSessionParseCachePersist(stats)
+    await flushSessionParseCachePersistForTests()
+
+    simulateRestart(cacheFile)
+    await ensureSessionParseCacheLoaded()
+
+    expect(getSessionParseCacheEntry(path)?.sidecar).toEqual(sidecar)
   })
 })

--- a/src/main/ai-vault/session-parse-cache-persistence.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.ts
@@ -11,6 +11,7 @@ import {
   type PersistedSessionParseCacheEntry,
   type SessionParseStats
 } from './session-scanner-parse-cache'
+import type { SessionSidecarObservation } from './session-sidecar-stat'
 
 // Bump when the persisted entry layout or cached session semantics change; a
 // mismatched file is discarded whole.
@@ -181,15 +182,35 @@ function parsePersistedEntry(item: unknown): [string, PersistedSessionParseCache
   if (entry.session !== null && typeof entry.session !== 'object') {
     return null
   }
+  const sidecar = parsePersistedSidecar(entry.sidecar)
   return [
     path,
     {
       mtimeMs: entry.mtimeMs,
       sizeBytes: entry.sizeBytes,
       platform: entry.platform as NodeJS.Platform,
-      session: entry.session as PersistedSessionParseCacheEntry['session']
+      session: entry.session as PersistedSessionParseCacheEntry['session'],
+      ...(sidecar === undefined ? {} : { sidecar })
     }
   ]
+}
+
+// Why: added after SCHEMA_VERSION 2 shipped, so a file an older build wrote has
+// no such field. Absent (or unreadable) means unknown, which costs one re-parse
+// of the rows that have a sibling and nothing at all for the rest.
+function parsePersistedSidecar(value: unknown): SessionSidecarObservation | undefined {
+  if (value === 'none' || value === 'unknown') {
+    return value
+  }
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+  const record = value as Record<string, unknown>
+  return typeof record.path === 'string' &&
+    typeof record.mtimeMs === 'number' &&
+    typeof record.sizeBytes === 'number'
+    ? { path: record.path, mtimeMs: record.mtimeMs, sizeBytes: record.sizeBytes }
+    : undefined
 }
 
 async function persistSnapshot(current: SessionParseCachePersistenceOptions): Promise<void> {

--- a/src/main/ai-vault/session-parse-cache-store.ts
+++ b/src/main/ai-vault/session-parse-cache-store.ts
@@ -1,0 +1,98 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import type { ResumableSessionParseState } from './session-scanner-types'
+import type { TranscriptMessageChannel } from './session-transcript-channel'
+
+// Sized past the default recency cap (1000) plus the in-scope cap (2000) so a
+// full steady-state result set stays resident between forced rescans.
+const MAX_CACHE_ENTRIES = 4096
+
+export type SessionParseResumePoint = {
+  state: ResumableSessionParseState
+  // Byte offset just past the last complete ('\n'-terminated) line consumed;
+  // a trailing unterminated line is deliberately left before this point.
+  byteOffset: number
+  // Bound to the cached state, which keeps the reference its parsers were built
+  // with; a resumed read re-points this channel instead of replacing it.
+  channel: TranscriptMessageChannel
+}
+
+export type SessionParseCacheEntry = {
+  mtimeMs: number
+  sizeBytes: number | null
+  platform: NodeJS.Platform
+  session: AiVaultSession | null
+  resume: SessionParseResumePoint | null
+}
+
+const cache = new Map<string, SessionParseCacheEntry>()
+
+export function resetSessionParseCacheForTests(): void {
+  cache.clear()
+}
+
+// Drops one entry after its file is deleted. Cleanliness, not correctness:
+// discovery walks disk first, so a trashed file is never rediscovered anyway.
+export function invalidateSessionParseCacheEntry(path: string): void {
+  cache.delete(path)
+}
+
+// Persisted subset of a cache entry: the non-serializable `resume` parser
+// state is dropped (see session-parse-cache-persistence.ts).
+export type PersistedSessionParseCacheEntry = Omit<SessionParseCacheEntry, 'resume'>
+
+export function snapshotSessionParseCacheForPersistence(): [
+  string,
+  PersistedSessionParseCacheEntry
+][] {
+  return [...cache].map(([path, entry]): [string, PersistedSessionParseCacheEntry] => [
+    path,
+    {
+      mtimeMs: entry.mtimeMs,
+      sizeBytes: entry.sizeBytes,
+      platform: entry.platform,
+      session: entry.session
+    }
+  ])
+}
+
+// Seeded entries carry `resume: null`: after a restart an unchanged file is a
+// cache hit; a file that changed while the app was closed pays one full
+// (not incremental) re-parse.
+export function seedSessionParseCache(
+  entries: Iterable<[string, PersistedSessionParseCacheEntry]>
+): void {
+  const list = [...entries]
+  // Snapshot order is oldest→newest (LRU); an over-cap list keeps the newest
+  // tail rather than seeding the oldest entries and dropping the tail.
+  for (const [path, entry] of list.slice(Math.max(0, list.length - MAX_CACHE_ENTRIES))) {
+    if (cache.size >= MAX_CACHE_ENTRIES) {
+      return
+    }
+    // In-process entries are always fresher than persisted ones; never clobber.
+    if (cache.has(path)) {
+      continue
+    }
+    cache.set(path, {
+      mtimeMs: entry.mtimeMs,
+      sizeBytes: entry.sizeBytes,
+      platform: entry.platform,
+      session: entry.session,
+      resume: null
+    })
+  }
+}
+
+export function getSessionParseCacheEntry(path: string): SessionParseCacheEntry | undefined {
+  return cache.get(path)
+}
+
+export function storeSessionParseCacheEntry(path: string, entry: SessionParseCacheEntry): void {
+  cache.delete(path)
+  cache.set(path, entry)
+  if (cache.size > MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next()
+    if (!oldest.done) {
+      cache.delete(oldest.value)
+    }
+  }
+}

--- a/src/main/ai-vault/session-parse-cache-store.ts
+++ b/src/main/ai-vault/session-parse-cache-store.ts
@@ -1,5 +1,6 @@
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import type { ResumableSessionParseState } from './session-scanner-types'
+import type { SessionSidecarObservation } from './session-sidecar-stat'
 import type { TranscriptMessageChannel } from './session-transcript-channel'
 
 // Sized past the default recency cap (1000) plus the in-scope cap (2000) so a
@@ -21,6 +22,12 @@ export type SessionParseCacheEntry = {
   sizeBytes: number | null
   platform: NodeJS.Platform
   session: AiVaultSession | null
+  // What the sibling file looked like when `session` was built. Tracked apart
+  // from the transcript's key so each can go stale on its own.
+  sidecar?: SessionSidecarObservation
+  // The session the transcript alone produced, before any sibling was merged
+  // onto it. In-memory only: without it a sibling change costs one re-parse.
+  foldSession?: AiVaultSession | null
   resume: SessionParseResumePoint | null
 }
 
@@ -37,8 +44,10 @@ export function invalidateSessionParseCacheEntry(path: string): void {
 }
 
 // Persisted subset of a cache entry: the non-serializable `resume` parser
-// state is dropped (see session-parse-cache-persistence.ts).
-export type PersistedSessionParseCacheEntry = Omit<SessionParseCacheEntry, 'resume'>
+// state is dropped, and `foldSession` with it, so a restart pays one re-parse
+// for a session whose sibling moved rather than storing every row twice
+// (see session-parse-cache-persistence.ts).
+export type PersistedSessionParseCacheEntry = Omit<SessionParseCacheEntry, 'resume' | 'foldSession'>
 
 export function snapshotSessionParseCacheForPersistence(): [
   string,
@@ -50,7 +59,8 @@ export function snapshotSessionParseCacheForPersistence(): [
       mtimeMs: entry.mtimeMs,
       sizeBytes: entry.sizeBytes,
       platform: entry.platform,
-      session: entry.session
+      session: entry.session,
+      ...(entry.sidecar === undefined ? {} : { sidecar: entry.sidecar })
     }
   ])
 }
@@ -77,6 +87,9 @@ export function seedSessionParseCache(
       sizeBytes: entry.sizeBytes,
       platform: entry.platform,
       session: entry.session,
+      // Absent in files an older build wrote; `sidecarUnchanged` reads that as
+      // unknown, so such a row re-enriches on its first scan.
+      sidecar: entry.sidecar,
       resume: null
     })
   }

--- a/src/main/ai-vault/session-parse-file-lane.ts
+++ b/src/main/ai-vault/session-parse-file-lane.ts
@@ -1,0 +1,28 @@
+const pending = new Map<string, Promise<unknown>>()
+
+/**
+ * Serializes parses of one transcript path.
+ *
+ * Two callers really do overlap on the same file: a forced refresh aborts the
+ * running scan while its in-flight parse keeps going as the replacement scan
+ * starts it again, and `session-title-file-reader.ts` parses on its own, with
+ * no scan involved. Overlapping reads share the cached resume point's message
+ * channel, so the second `beginRead` would drop the first read's consumers and
+ * the first `finishRead` would hand them the wrong outcome; the later store
+ * could also move the cursor backwards.
+ */
+export async function inSessionParseFileLane<T>(path: string, parse: () => Promise<T>): Promise<T> {
+  const previous = pending.get(path)
+  const run = (async () => {
+    await previous?.catch(() => undefined)
+    return parse()
+  })()
+  pending.set(path, run)
+  try {
+    return await run
+  } finally {
+    if (pending.get(path) === run) {
+      pending.delete(path)
+    }
+  }
+}

--- a/src/main/ai-vault/session-scanner-accumulator.ts
+++ b/src/main/ai-vault/session-scanner-accumulator.ts
@@ -75,10 +75,13 @@ export function accumulatorFoldResumeState(
   accumulator: SessionAccumulator,
   consumeRecordLine: (accumulator: SessionAccumulator, line: string) => void,
   // Runs per finalize, for agents whose metadata lives in a sibling file the
-  // fold never sees; it may only fill fields the transcript left empty.
-  enrichBeforeFinalize?: (accumulator: SessionAccumulator) => Promise<void>
+  // fold never sees; it may only fill fields the transcript left empty, and
+  // returns 'refused' when it could not read that file at all.
+  enrichBeforeFinalize?: (accumulator: SessionAccumulator) => Promise<'refused' | void>
 ): ResumableSessionParseState {
+  let enrichmentRefused = false
   return {
+    isCacheable: () => !enrichmentRefused,
     consumeLine: (line) => consumeRecordLine(accumulator, line),
     clone: () =>
       accumulatorFoldResumeState(
@@ -93,7 +96,7 @@ export function accumulatorFoldResumeState(
     // accumulating appended lines after this session object is handed out.
     finalize: async (platform, options) => {
       const snapshot = cloneSessionAccumulator(accumulator)
-      await enrichBeforeFinalize?.(snapshot)
+      enrichmentRefused = (await enrichBeforeFinalize?.(snapshot)) === 'refused'
       return finalizeSession(snapshot, platform, options)
     }
   }

--- a/src/main/ai-vault/session-scanner-accumulator.ts
+++ b/src/main/ai-vault/session-scanner-accumulator.ts
@@ -23,6 +23,12 @@ import {
   normalizePreviewText,
   timestampMs
 } from './session-scanner-values'
+import { NO_TRANSCRIPT_MESSAGES, type TranscriptMessageSink } from './session-transcript-consumers'
+import {
+  boundedText,
+  transcriptMessageRole,
+  transcriptMessagesFromContent
+} from './session-transcript-message-content'
 
 const SESSION_PREVIEW_MESSAGE_LIMIT = 5
 
@@ -30,9 +36,12 @@ export function createAccumulator(args: {
   agent: AiVaultAgent
   file: FileWithMtime
   sessionId: string
+  // Where every decoded message goes; absent for one-shot parses with no reader.
+  messages?: TranscriptMessageSink
 }): SessionAccumulator {
   return {
     agent: args.agent,
+    messages: args.messages ?? NO_TRANSCRIPT_MESSAGES,
     sessionId: args.sessionId,
     title: null,
     fallbackTitle: null,
@@ -64,19 +73,29 @@ export function cloneSessionAccumulator(accumulator: SessionAccumulator): Sessio
 // closure state (claude, codex) build their own ResumableSessionParseState.
 export function accumulatorFoldResumeState(
   accumulator: SessionAccumulator,
-  consumeRecordLine: (accumulator: SessionAccumulator, line: string) => void
+  consumeRecordLine: (accumulator: SessionAccumulator, line: string) => void,
+  // Runs per finalize, for agents whose metadata lives in a sibling file the
+  // fold never sees; it may only fill fields the transcript left empty.
+  enrichBeforeFinalize?: (accumulator: SessionAccumulator) => Promise<void>
 ): ResumableSessionParseState {
   return {
     consumeLine: (line) => consumeRecordLine(accumulator, line),
     clone: () =>
-      accumulatorFoldResumeState(cloneSessionAccumulator(accumulator), consumeRecordLine),
+      accumulatorFoldResumeState(
+        cloneSessionAccumulator(accumulator),
+        consumeRecordLine,
+        enrichBeforeFinalize
+      ),
     touchFile: (file) => {
       accumulator.modifiedAt = file.modifiedAt
     },
     // Finalize a snapshot: the live accumulator (and its preview array) keeps
     // accumulating appended lines after this session object is handed out.
-    finalize: (platform, options) =>
-      finalizeSession(cloneSessionAccumulator(accumulator), platform, options)
+    finalize: async (platform, options) => {
+      const snapshot = cloneSessionAccumulator(accumulator)
+      await enrichBeforeFinalize?.(snapshot)
+      return finalizeSession(snapshot, platform, options)
+    }
   }
 }
 
@@ -161,8 +180,13 @@ export function addPreviewMessage(
     // Why: Claude meta/injected turns still preview, but must not seed the
     // copyable first-prompt row.
     seedFirstUserPrompt?: boolean
+    // Set false by callers that already published this record's messages.
+    publishMessage?: boolean
   }
 ): void {
+  if (args.publishMessage !== false && accumulator.messages.active) {
+    publishTranscriptMessage(accumulator, args.role, args.text, args.timestamp)
+  }
   // Seeded before the preview-empty return so the copy body never depends on
   // preview-only normalization rules.
   seedFullFirstUserPrompt(
@@ -199,13 +223,39 @@ export function addPreviewContent(
     () => extractFullFirstUserPromptText(content),
     options?.seedFirstUserPrompt
   )
+  // Published from the content value, not the preview string: a consumer needs
+  // the whole turn, including the tool blocks the 220-char preview drops.
+  if (accumulator.messages.active) {
+    for (const message of transcriptMessagesFromContent(role, content, timestampIso(timestamp))) {
+      accumulator.messages.push(message)
+    }
+  }
   addPreviewMessage(accumulator, {
     role,
     text: extractPreviewContentText(content),
     timestamp,
     // Content path already seeded above when capture is enabled.
-    seedFirstUserPrompt: false
+    seedFirstUserPrompt: false,
+    publishMessage: false
   })
+}
+
+/** One already-flattened turn; the content path publishes per block instead. */
+function publishTranscriptMessage(
+  accumulator: SessionAccumulator,
+  role: AiVaultSessionPreviewMessage['role'],
+  text: string | null,
+  timestamp: unknown
+): void {
+  const messageRole = transcriptMessageRole(role)
+  const messageText = text === null ? null : boundedText(text)
+  if (messageRole && messageText) {
+    accumulator.messages.push({
+      role: messageRole,
+      text: messageText,
+      timestamp: timestampIso(timestamp)
+    })
+  }
 }
 
 /**

--- a/src/main/ai-vault/session-scanner-accumulator.ts
+++ b/src/main/ai-vault/session-scanner-accumulator.ts
@@ -73,32 +73,22 @@ export function cloneSessionAccumulator(accumulator: SessionAccumulator): Sessio
 // closure state (claude, codex) build their own ResumableSessionParseState.
 export function accumulatorFoldResumeState(
   accumulator: SessionAccumulator,
-  consumeRecordLine: (accumulator: SessionAccumulator, line: string) => void,
-  // Runs per finalize, for agents whose metadata lives in a sibling file the
-  // fold never sees; it may only fill fields the transcript left empty, and
-  // returns 'refused' when it could not read that file at all.
-  enrichBeforeFinalize?: (accumulator: SessionAccumulator) => Promise<'refused' | void>
+  consumeRecordLine: (accumulator: SessionAccumulator, line: string) => void
 ): ResumableSessionParseState {
-  let enrichmentRefused = false
   return {
-    isCacheable: () => !enrichmentRefused,
     consumeLine: (line) => consumeRecordLine(accumulator, line),
     clone: () =>
-      accumulatorFoldResumeState(
-        cloneSessionAccumulator(accumulator),
-        consumeRecordLine,
-        enrichBeforeFinalize
-      ),
+      accumulatorFoldResumeState(cloneSessionAccumulator(accumulator), consumeRecordLine),
     touchFile: (file) => {
       accumulator.modifiedAt = file.modifiedAt
     },
     // Finalize a snapshot: the live accumulator (and its preview array) keeps
     // accumulating appended lines after this session object is handed out.
-    finalize: async (platform, options) => {
-      const snapshot = cloneSessionAccumulator(accumulator)
-      enrichmentRefused = (await enrichBeforeFinalize?.(snapshot)) === 'refused'
-      return finalizeSession(snapshot, platform, options)
-    }
+    // A sibling file's metadata is merged onto this result by the parse cache,
+    // never into the fold, so re-merging it later starts from what the
+    // transcript alone said (see session-scanner-sidecar-enrichment.ts).
+    finalize: (platform, options) =>
+      finalizeSession(cloneSessionAccumulator(accumulator), platform, options)
   }
 }
 
@@ -118,7 +108,7 @@ export function finalizeSession(
   const title =
     accumulator.title ||
     accumulator.fallbackTitle ||
-    `${aiVaultAgentLabel(accumulator.agent)} ${sessionId.slice(0, 8)}`
+    generatedSessionTitle(accumulator.agent, sessionId)
 
   const executionHostId = options.executionHostId ?? LOCAL_EXECUTION_HOST_ID
 
@@ -157,6 +147,15 @@ export function finalizeSession(
     }),
     subagent: null
   }
+}
+
+/**
+ * The title a session gets when neither the transcript nor the agent named it.
+ * Exported so a later merge can tell "the fold found no title" from a real one
+ * without re-deriving the string (session-scanner-sidecar-enrichment.ts).
+ */
+export function generatedSessionTitle(agent: AiVaultAgent, sessionId: string): string {
+  return `${aiVaultAgentLabel(agent)} ${sessionId.slice(0, 8)}`
 }
 
 export function updateTimeline(accumulator: SessionAccumulator, timestamp: unknown): void {

--- a/src/main/ai-vault/session-scanner-agent-parser.ts
+++ b/src/main/ai-vault/session-scanner-agent-parser.ts
@@ -16,6 +16,7 @@ import { parseCursorSessionFile } from './session-scanner-cursor-parser'
 import { parseHermesSessionFile } from './session-scanner-hermes-parser'
 import { parseOpenCodeSessionFile } from './session-scanner-opencode-parser'
 import type { SessionFileCandidate } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 
 /**
  * Parse a single agent session file into an `AiVaultSession`. Routes to the
@@ -24,25 +25,33 @@ import type { SessionFileCandidate } from './session-scanner-types'
  * `parseOpenCodeSqliteSession` instead of the legacy JSON parser.
  * @param candidate - The session file candidate to parse.
  * @param platform - The platform to use for resume command generation.
+ * @param messages - Where the parser publishes every decoded message.
  * @returns The parsed `AiVaultSession`, or `null` if parsing fails.
  */
 export async function parseAgentSessionFile(
   candidate: SessionFileCandidate,
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   switch (candidate.agent) {
     case 'claude':
-      return parseClaudeSessionFile(candidate.file, platform)
+      return parseClaudeSessionFile(candidate.file, platform, messages)
     case 'codex':
-      return parseCodexSessionFile(candidate.file, platform, candidate.codexHome)
+      return parseCodexSessionFile(
+        candidate.file,
+        platform,
+        candidate.codexHome,
+        undefined,
+        messages
+      )
     case 'gemini':
-      return parseGeminiSessionFile(candidate.file, platform)
+      return parseGeminiSessionFile(candidate.file, platform, messages)
     case 'antigravity':
-      return parseAntigravitySessionFile(candidate.file, platform)
+      return parseAntigravitySessionFile(candidate.file, platform, messages)
     case 'copilot':
-      return parseCopilotSessionFile(candidate.file, platform)
+      return parseCopilotSessionFile(candidate.file, platform, messages)
     case 'cursor':
-      return parseCursorSessionFile(candidate.file, platform)
+      return parseCursorSessionFile(candidate.file, platform, messages)
     case 'opencode': {
       // Why: OpenCode 1.17.x sessions are read from SQLite via a synthetic
       // <dbPath>#<sessionId> candidate path. Legacy file-based sessions use
@@ -55,29 +64,29 @@ export async function parseAgentSessionFile(
           platform
         })
       }
-      return parseOpenCodeSessionFile(candidate.file, platform)
+      return parseOpenCodeSessionFile(candidate.file, platform, messages)
     }
     case 'grok':
-      return parseGrokSessionFile(candidate.file, platform)
+      return parseGrokSessionFile(candidate.file, platform, messages)
     case 'hermes':
-      return parseHermesSessionFile(candidate.file, platform)
+      return parseHermesSessionFile(candidate.file, platform, messages)
     case 'rovo':
-      return parseRovoSessionFile(candidate.file, platform)
+      return parseRovoSessionFile(candidate.file, platform, messages)
     case 'openclaw':
-      return parseMessageGraphSessionFile('openclaw', candidate.file, platform)
+      return parseMessageGraphSessionFile('openclaw', candidate.file, platform, messages)
     case 'pi':
-      return parseMessageGraphSessionFile('pi', candidate.file, platform)
+      return parseMessageGraphSessionFile('pi', candidate.file, platform, messages)
     case 'omp':
-      return parseMessageGraphSessionFile('omp', candidate.file, platform)
+      return parseMessageGraphSessionFile('omp', candidate.file, platform, messages)
     case 'prime-agent':
-      return parseMessageGraphSessionFile('prime-agent', candidate.file, platform)
+      return parseMessageGraphSessionFile('prime-agent', candidate.file, platform, messages)
     case 'droid':
-      return parseDroidSessionFile(candidate.file, platform)
+      return parseDroidSessionFile(candidate.file, platform, messages)
     case 'cline':
-      return parseClineSessionFile(candidate.file, platform)
+      return parseClineSessionFile(candidate.file, platform, messages)
     case 'devin':
-      return parseDevinSessionFile(candidate.file, platform)
+      return parseDevinSessionFile(candidate.file, platform, messages)
     case 'kimi':
-      return parseKimiSessionFile(candidate.file, platform)
+      return parseKimiSessionFile(candidate.file, platform, messages)
   }
 }

--- a/src/main/ai-vault/session-scanner-agent-parser.ts
+++ b/src/main/ai-vault/session-scanner-agent-parser.ts
@@ -6,7 +6,10 @@ import { parseClineSessionFile } from './session-scanner-cline-parser'
 import { parseGrokSessionFile } from './session-scanner-grok-parser'
 import { parseMessageGraphSessionFile, parseRovoSessionFile } from './session-scanner-graph-parsers'
 import { parseKimiSessionFile } from './session-scanner-kimi-parser'
-import { splitOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
+import {
+  looksLikeOpenCodeSqliteCandidate,
+  splitOpenCodeSqliteCandidate
+} from './session-scanner-opencode-sqlite-paths'
 import { parseOpenCodeSqliteSessionViaWorker } from './session-scanner-opencode-sqlite-worker-spawn'
 import { parseClaudeSessionFile } from './session-scanner-primary-parsers'
 import { parseGeminiSessionFile } from './session-scanner-gemini-parsers'
@@ -17,6 +20,15 @@ import { parseHermesSessionFile } from './session-scanner-hermes-parser'
 import { parseOpenCodeSessionFile } from './session-scanner-opencode-parser'
 import type { SessionFileCandidate } from './session-scanner-types'
 import type { TranscriptMessageSink } from './session-transcript-consumers'
+
+/**
+ * False when a parser decodes its messages somewhere the channel cannot reach.
+ * OpenCode's SQLite sessions are read on a worker thread, so their messages
+ * never come back over the sink and the read must not be reported as complete.
+ */
+export function parserPublishesMessages(candidate: SessionFileCandidate): boolean {
+  return candidate.agent !== 'opencode' || !looksLikeOpenCodeSqliteCandidate(candidate.file.path)
+}
 
 /**
  * Parse a single agent session file into an `AiVaultSession`. Routes to the

--- a/src/main/ai-vault/session-scanner-agent-sources.ts
+++ b/src/main/ai-vault/session-scanner-agent-sources.ts
@@ -8,6 +8,7 @@ import {
   clineMessagesPathForMetadata,
   isClineSessionMetadataPath
 } from './session-scanner-cline-parser'
+import { cursorChatMetaPath } from './session-scanner-cursor-chat-meta'
 import { resolveKimiSessionsDir } from './session-scanner-kimi-paths'
 import { OMP_SESSION_ARTIFACT_DIR_PATTERN } from './session-scanner-omp-subagent-transcripts'
 import { claudeProjectsRootDirs, OMP_SESSIONS_DIR, sessionRootDirs } from './session-scanner-roots'
@@ -61,8 +62,9 @@ export type AiVaultAgentSource = {
   rootDirs: (options: AiVaultScanOptions, wslHomeDirs: readonly string[]) => string[]
   extensions: readonly string[]
   filePredicate?: (filePath: string) => boolean
-  // A sibling whose stat participates in candidate freshness and recency.
-  contentDependencyPath?: (filePath: string) => string
+  // A sibling whose stat participates in candidate freshness and recency; async
+  // for agents that have to look the sibling up rather than derive its path.
+  contentDependencyPath?: (filePath: string) => string | undefined | Promise<string | undefined>
   // Return false to skip a directory; depth 0 is a child of the root.
   directoryPredicate?: (name: string, depth: number) => boolean
   // Roots that are alternates for one install rather than distinct locations,
@@ -126,7 +128,8 @@ export const AI_VAULT_AGENT_SOURCES: AiVaultAgentSourceTable = {
         'projects'
       ]),
     extensions: ['.jsonl'],
-    filePredicate: (filePath) => pathSegments(filePath).includes('agent-transcripts')
+    filePredicate: (filePath) => pathSegments(filePath).includes('agent-transcripts'),
+    contentDependencyPath: cursorChatMetaPath
   },
   grok: {
     rootDirs: (options, wslHomeDirs) =>

--- a/src/main/ai-vault/session-scanner-antigravity-parser.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-parser.ts
@@ -15,6 +15,7 @@ import type {
   ResumableSessionParseState,
   SessionAccumulator
 } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import { extractString, normalizeTitleText, parseJsonObject } from './session-scanner-values'
 
 type ParserSessionOptions = {
@@ -24,12 +25,13 @@ type ParserSessionOptions = {
 
 export async function parseAntigravitySessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const input = openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan')
   const lines = createInterface({ input, crlfDelay: Infinity })
   try {
-    return await parseAntigravitySessionLines({ file, lines, platform })
+    return await parseAntigravitySessionLines({ file, lines, platform, messages })
   } finally {
     // readline.close() leaves the underlying stream open; destroy it so a
     // mid-parse throw cannot leak the gated transcript handle.
@@ -54,13 +56,14 @@ export async function parseAntigravitySessionContent(
 }
 
 export function createAntigravitySessionResumeState(
-  file: FileWithMtime
+  file: FileWithMtime,
+  messages?: TranscriptMessageSink
 ): ResumableSessionParseState {
   const sessionId = antigravityConversationIdFromTranscriptPath(file.path) ?? ''
   // Why: the transcript has no cwd/model fields. Workspace enrichment is a
   // separate, conservative history join; protobuf/SQLite blobs are unstable.
   return accumulatorFoldResumeState(
-    createAccumulator({ agent: 'antigravity', file, sessionId }),
+    createAccumulator({ agent: 'antigravity', file, sessionId, messages }),
     consumeAntigravityRecordLine
   )
 }
@@ -70,8 +73,9 @@ async function parseAntigravitySessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
+  messages?: TranscriptMessageSink
 }): Promise<AiVaultSession | null> {
-  const state = createAntigravitySessionResumeState(args.file)
+  const state = createAntigravitySessionResumeState(args.file, args.messages)
   for await (const line of args.lines) {
     state.consumeLine(line)
   }

--- a/src/main/ai-vault/session-scanner-candidates.ts
+++ b/src/main/ai-vault/session-scanner-candidates.ts
@@ -1,0 +1,46 @@
+import { readCodexRolloutSessionMetaId } from '../codex/codex-rollout-session-meta'
+import { codexRolloutHardlinkIdentity, dedupeCodexRolloutAliases } from './codex-session-root-dedup'
+import { antigravityHistoryPathForBrainDir } from './session-scanner-antigravity-paths'
+import { codexHomeForSessionsDir } from './session-scanner-codex-paths'
+import { DEFAULT_CODEX_HOME_DIR } from './session-scanner-source-discovery'
+import type {
+  AiVaultScanOptions,
+  SessionFileCandidate,
+  SessionFileDiscovery
+} from './session-scanner-types'
+
+/** Newest-first parse candidates for a discovery set, with Codex hardlink aliases collapsed. */
+export async function sessionCandidatesFromDiscoveries(
+  discoveries: SessionFileDiscovery[],
+  options: AiVaultScanOptions
+): Promise<SessionFileCandidate[]> {
+  return dedupeCodexRolloutAliases(
+    discoveries
+      .flatMap((discovery) =>
+        discovery.files.map((file): SessionFileCandidate => ({
+          agent: discovery.agent,
+          file,
+          codexHome:
+            discovery.agent === 'codex'
+              ? codexHomeForSessionsDir(
+                  discovery.rootDir,
+                  options.defaultCodexHomeDir ?? DEFAULT_CODEX_HOME_DIR
+                )
+              : null,
+          antigravityHistoryPath:
+            discovery.agent === 'antigravity'
+              ? antigravityHistoryPathForBrainDir(discovery.rootDir)
+              : undefined
+        }))
+      )
+      .sort((left, right) => right.file.mtimeMs - left.file.mtimeMs),
+    {
+      isCodex: (candidate) => candidate.agent === 'codex',
+      getFilePath: (candidate) => candidate.file.path,
+      getCodexHome: (candidate) => candidate.codexHome,
+      getHardlinkIdentity: (candidate) => codexRolloutHardlinkIdentity(candidate.file)
+    },
+    (filePath) => readCodexRolloutSessionMetaId(filePath, options.signal, 'scan'),
+    options.signal
+  )
+}

--- a/src/main/ai-vault/session-scanner-cline-parser.ts
+++ b/src/main/ai-vault/session-scanner-cline-parser.ts
@@ -9,6 +9,7 @@ import {
   updateTimeline
 } from './session-scanner-accumulator'
 import type { FileWithMtime } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   arrayValue,
   asRecord,
@@ -35,7 +36,8 @@ export function clineMessagesPathForMetadata(filePath: string): string {
 
 export async function parseClineSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messageSink?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const metadataContent = await wslGatedReadFile(file.path, 'utf-8', 'scan')
   let messagesContent: string | null = null
@@ -52,7 +54,7 @@ export async function parseClineSessionFile(
       throw error
     }
   }
-  return parseClineSessionContent(file, metadataContent, messagesContent, platform)
+  return parseClineSessionContent(file, metadataContent, messagesContent, platform, {}, messageSink)
 }
 
 function isMissingSessionPathError(error: unknown): boolean {
@@ -68,7 +70,8 @@ export function parseClineSessionContent(
   metadataContent: string,
   messagesContent: string | null,
   platform: NodeJS.Platform = process.platform,
-  options: ParserSessionOptions = {}
+  options: ParserSessionOptions = {},
+  messageSink?: TranscriptMessageSink
 ): AiVaultSession | null {
   const metadata = parseJsonRecord(metadataContent)
   if (!metadata) {
@@ -76,7 +79,12 @@ export function parseClineSessionContent(
   }
   const pathSegments = file.path.replace(/\\/g, '/').split('/').filter(Boolean)
   const sessionId = extractString(metadata.session_id) ?? pathSegments.at(-2) ?? ''
-  const accumulator = createAccumulator({ agent: 'cline', file, sessionId })
+  const accumulator = createAccumulator({
+    agent: 'cline',
+    file,
+    sessionId,
+    messages: messageSink
+  })
   accumulator.cwd = extractString(metadata.cwd) ?? extractString(metadata.workspace_root)
   accumulator.model = extractString(metadata.model)
   updateTimeline(accumulator, metadata.started_at)

--- a/src/main/ai-vault/session-scanner-codex-parser.ts
+++ b/src/main/ai-vault/session-scanner-codex-parser.ts
@@ -22,6 +22,7 @@ import type {
   ResumableSessionParseState,
   SessionAccumulator
 } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   addCodexUsage,
   asRecord,
@@ -29,18 +30,22 @@ import {
   extractModel,
   extractString,
   normalizeCodexUsage,
-  normalizeTitleText,
   parseJsonObject,
   subtractCodexUsage
 } from './session-scanner-values'
 import { remoteSessionContentLines } from './remote-session-content-lines'
 import { readCodexTimelineOnlyRecord } from './session-scanner-codex-record-fast-path'
+import {
+  extractCodexSessionMetadataTitle,
+  isCodexWorkerSession
+} from './session-scanner-codex-session-meta'
 
 export async function parseCodexSessionFile(
   file: FileWithMtime,
   platform: NodeJS.Platform = process.platform,
   codexHome: string | null = null,
-  executionHostId?: ExecutionHostId
+  executionHostId?: ExecutionHostId,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const lines = createInterface({
     input: openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan'),
@@ -53,6 +58,7 @@ export async function parseCodexSessionFile(
     platform,
     codexHome,
     executionHostId,
+    messages,
     titleReader: (sessionId) => readCodexSessionIndexTitle(file.path, codexHome, sessionId)
   })
 }
@@ -89,12 +95,16 @@ type CodexSessionParseState = {
   titleSource: 'meta' | 'user' | null
 }
 
-function createCodexParseState(file: FileWithMtime): CodexSessionParseState {
+function createCodexParseState(
+  file: FileWithMtime,
+  messages?: TranscriptMessageSink
+): CodexSessionParseState {
   return {
     accumulator: createAccumulator({
       agent: 'codex',
       file,
-      sessionId: sessionIdFromFileName(file.path)
+      sessionId: sessionIdFromFileName(file.path),
+      messages
     }),
     previousTotals: null,
     rejectedWorkerSession: false,
@@ -257,10 +267,13 @@ async function finalizeCodexParseState(
 
 export function createCodexSessionResumeState(
   file: FileWithMtime,
-  codexHome: string | null
+  codexHome: string | null,
+  messages?: TranscriptMessageSink
 ): ResumableSessionParseState {
-  return codexResumeStateFromParseState(createCodexParseState(file), codexHome, (sessionId) =>
-    readCodexSessionIndexTitle(file.path, codexHome, sessionId)
+  return codexResumeStateFromParseState(
+    createCodexParseState(file, messages),
+    codexHome,
+    (sessionId) => readCodexSessionIndexTitle(file.path, codexHome, sessionId)
   )
 }
 
@@ -298,8 +311,9 @@ async function parseCodexSessionLines(args: {
   executionHostId?: ExecutionHostId
   executionHostPlatform?: NodeJS.Platform | null
   titleReader?: (sessionId: string) => Promise<string | null>
+  messages?: TranscriptMessageSink
 }): Promise<AiVaultSession | null> {
-  const state = createCodexParseState(args.file)
+  const state = createCodexParseState(args.file, args.messages)
   for await (const line of args.lines) {
     consumeCodexRecordLine(state, line)
     if (state.rejectedWorkerSession) {
@@ -313,22 +327,4 @@ async function parseCodexSessionLines(args: {
     executionHostId: args.executionHostId,
     executionHostPlatform: args.executionHostPlatform
   })
-}
-
-function isCodexWorkerSession(payload: Record<string, unknown>): boolean {
-  const threadSource = extractString(payload.thread_source) ?? extractString(payload.threadSource)
-  if (threadSource) {
-    return threadSource.toLowerCase() !== 'user'
-  }
-
-  const source = asRecord(payload.source)
-  return Boolean(asRecord(source?.subagent))
-}
-
-function extractCodexSessionMetadataTitle(payload: Record<string, unknown>): string | null {
-  return (
-    normalizeTitleText(extractString(payload.title) ?? '') ??
-    normalizeTitleText(extractString(payload.thread_name) ?? '') ??
-    normalizeTitleText(extractString(payload.threadName) ?? '')
-  )
 }

--- a/src/main/ai-vault/session-scanner-codex-session-meta.ts
+++ b/src/main/ai-vault/session-scanner-codex-session-meta.ts
@@ -1,0 +1,22 @@
+import { asRecord, extractString, normalizeTitleText } from './session-scanner-values'
+
+// Field readers for Codex's `session_meta` record, whose key spelling has drifted
+// across Codex releases (snake_case rollouts, camelCase app-server rollouts).
+
+export function isCodexWorkerSession(payload: Record<string, unknown>): boolean {
+  const threadSource = extractString(payload.thread_source) ?? extractString(payload.threadSource)
+  if (threadSource) {
+    return threadSource.toLowerCase() !== 'user'
+  }
+
+  const source = asRecord(payload.source)
+  return Boolean(asRecord(source?.subagent))
+}
+
+export function extractCodexSessionMetadataTitle(payload: Record<string, unknown>): string | null {
+  return (
+    normalizeTitleText(extractString(payload.title) ?? '') ??
+    normalizeTitleText(extractString(payload.thread_name) ?? '') ??
+    normalizeTitleText(extractString(payload.threadName) ?? '')
+  )
+}

--- a/src/main/ai-vault/session-scanner-copilot-parser.ts
+++ b/src/main/ai-vault/session-scanner-copilot-parser.ts
@@ -8,6 +8,7 @@ import type {
   ResumableSessionParseState,
   SessionAccumulator
 } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   accumulatorFoldResumeState,
   addPreviewMessage,
@@ -32,13 +33,14 @@ type ParserSessionOptions = {
 
 export async function parseCopilotSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const lines = createInterface({
     input: openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan'),
     crlfDelay: Infinity
   })
-  return parseCopilotSessionLines({ file, lines, platform })
+  return parseCopilotSessionLines({ file, lines, platform, messages })
 }
 
 export async function parseCopilotSessionContent(
@@ -107,9 +109,17 @@ function consumeCopilotRecordLine(accumulator: SessionAccumulator, line: string)
   }
 }
 
-export function createCopilotSessionResumeState(file: FileWithMtime): ResumableSessionParseState {
+export function createCopilotSessionResumeState(
+  file: FileWithMtime,
+  messages?: TranscriptMessageSink
+): ResumableSessionParseState {
   return accumulatorFoldResumeState(
-    createAccumulator({ agent: 'copilot', file, sessionId: sessionIdFromFileName(file.path) }),
+    createAccumulator({
+      agent: 'copilot',
+      file,
+      sessionId: sessionIdFromFileName(file.path),
+      messages
+    }),
     consumeCopilotRecordLine
   )
 }
@@ -119,8 +129,9 @@ async function parseCopilotSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
+  messages?: TranscriptMessageSink
 }): Promise<AiVaultSession | null> {
-  const state = createCopilotSessionResumeState(args.file)
+  const state = createCopilotSessionResumeState(args.file, args.messages)
   for await (const line of args.lines) {
     state.consumeLine(line)
   }

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
@@ -1,0 +1,300 @@
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-error'
+
+// Why: a refused WSL read is the one build failure that must not be cached.
+let failNextChatsReaddir = false
+let chatsRootReads = 0
+vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
+  const actual = await importOriginal<typeof WslTranscriptFsAccess>()
+  return {
+    ...actual,
+    wslGatedReaddir: (
+      ...args: Parameters<typeof actual.wslGatedReaddir>
+    ): ReturnType<typeof actual.wslGatedReaddir> => {
+      if (args[0].endsWith('chats')) {
+        chatsRootReads += 1
+      }
+      if (failNextChatsReaddir && args[0].includes('workspace-hash')) {
+        failNextChatsReaddir = false
+        return Promise.reject(new WslTranscriptFsError('timeout', 'wsl fs timed out'))
+      }
+      return actual.wslGatedReaddir(...args)
+    }
+  }
+})
+import type * as WslTranscriptFsAccess from '../native-chat/wsl-transcript-fs-access'
+import {
+  cursorChatMetaPath,
+  readCursorChatMeta,
+  resetCursorChatMetaIndexCacheForTests,
+  withCursorChatMetaScan
+} from './session-scanner-cursor-chat-meta'
+import {
+  createCursorSessionResumeState,
+  parseCursorSessionContent,
+  parseCursorSessionFile
+} from './session-scanner-cursor-parser'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { AI_VAULT_AGENT_SOURCES } from './session-scanner-agent-sources'
+import { discoverFiles } from './session-scanner-discovery'
+import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
+
+// Cursor's real meta.json keys (~/.cursor/chats/<md5 of cwd>/<uuid>/meta.json, 2026-09).
+type CursorMetaFixture = {
+  schemaVersion: number
+  createdAtMs: number
+  updatedAtMs: number
+  cwd: string
+  hasConversation: boolean
+  title?: string
+}
+
+const CREATED_AT_MS = 1_787_039_612_017
+const UPDATED_AT_MS = 1_787_039_640_532
+
+let tempRoots: string[] = []
+
+afterEach(async () => {
+  resetCursorChatMetaIndexCacheForTests()
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
+  tempRoots = []
+})
+
+async function createCursorHome(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-cursor-chat-meta-'))
+  tempRoots.push(root)
+  const cursorHome = join(root, '.cursor')
+  await mkdir(cursorHome, { recursive: true })
+  return cursorHome
+}
+
+async function writeTranscript(
+  cursorHome: string,
+  projectSlug: string,
+  chatId: string,
+  lines: string[]
+): Promise<string> {
+  const chatDir = join(cursorHome, 'projects', projectSlug, 'agent-transcripts', chatId)
+  await mkdir(chatDir, { recursive: true })
+  const transcriptPath = join(chatDir, `${chatId}.jsonl`)
+  await writeFile(transcriptPath, lines.map((line) => `${line}\n`).join(''))
+  return transcriptPath
+}
+
+async function writeChatMeta(
+  cursorHome: string,
+  workspaceHash: string,
+  chatId: string,
+  meta: Partial<CursorMetaFixture> = {}
+): Promise<string> {
+  const chatDir = join(cursorHome, 'chats', workspaceHash, chatId)
+  await mkdir(chatDir, { recursive: true })
+  const metaPath = join(chatDir, 'meta.json')
+  await writeFile(
+    metaPath,
+    JSON.stringify({
+      schemaVersion: 1,
+      createdAtMs: CREATED_AT_MS,
+      updatedAtMs: UPDATED_AT_MS,
+      cwd: '/private/tmp/workspace',
+      hasConversation: true,
+      ...meta
+    } satisfies CursorMetaFixture)
+  )
+  return metaPath
+}
+
+function fileWithMtime(path: string): FileWithMtime {
+  return { path, mtimeMs: 1, modifiedAt: new Date(1).toISOString() }
+}
+
+describe('cursor chat meta', () => {
+  it('resolves the meta.json under the workspace hash that holds the chat id', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'aa37220647fb7ce5eb044aa4bda60807', 'other-chat')
+    const metaPath = await writeChatMeta(cursorHome, '96fa26ac0f433670ebec73ecef20b47b', 'chat-1', {
+      title: 'Shell Command Hostname'
+    })
+    const transcriptPath = await writeTranscript(cursorHome, 'private-tmp-workspace', 'chat-1', [])
+
+    expect(await cursorChatMetaPath(transcriptPath)).toBe(metaPath)
+    expect(await readCursorChatMeta(transcriptPath)).toEqual({
+      title: 'Shell Command Hostname',
+      cwd: '/private/tmp/workspace',
+      createdAt: new Date(CREATED_AT_MS).toISOString(),
+      updatedAt: new Date(UPDATED_AT_MS).toISOString()
+    })
+  })
+
+  it('re-indexes after a chat appears under an already indexed workspace', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-first')
+    const firstTranscript = await writeTranscript(cursorHome, 'slug', 'chat-first', [])
+    expect(await cursorChatMetaPath(firstTranscript)).toBeDefined()
+
+    const laterMetaPath = await writeChatMeta(cursorHome, 'workspace-hash', 'chat-later')
+    const laterTranscript = await writeTranscript(cursorHome, 'slug', 'chat-later', [])
+
+    expect(await cursorChatMetaPath(laterTranscript)).toBe(laterMetaPath)
+  })
+
+  it('does not cache a metadata index whose build was refused by the WSL gate', async () => {
+    const cursorHome = await createCursorHome()
+    const metaPath = await writeChatMeta(cursorHome, 'workspace-hash', 'chat-refused')
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-refused', [])
+
+    failNextChatsReaddir = true
+    await expect(cursorChatMetaPath(transcriptPath)).rejects.toBeInstanceOf(WslTranscriptFsError)
+    // The next scan rebuilds instead of replaying the rejected promise.
+    await expect(cursorChatMetaPath(transcriptPath)).resolves.toBe(metaPath)
+  })
+
+  it('validates the index once per scan, not once per transcript', async () => {
+    const cursorHome = await createCursorHome()
+    const transcripts: string[] = []
+    for (const chatId of ['chat-a', 'chat-b', 'chat-c']) {
+      await writeChatMeta(cursorHome, 'workspace-hash', chatId)
+      transcripts.push(await writeTranscript(cursorHome, 'slug', chatId, []))
+    }
+    chatsRootReads = 0
+
+    const inScan = await withCursorChatMetaScan(() =>
+      Promise.all(transcripts.map((path) => cursorChatMetaPath(path)))
+    )
+    expect(inScan.every(Boolean)).toBe(true)
+    expect(chatsRootReads).toBe(1)
+
+    // Outside a scan every lookup re-validates, which is what the parse path needs.
+    chatsRootReads = 0
+    await Promise.all(transcripts.map((path) => cursorChatMetaPath(path)))
+    expect(chatsRootReads).toBe(3)
+  })
+
+  it('yields nothing and does not throw when there is no chats tree', async () => {
+    const cursorHome = await createCursorHome()
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-orphan', [])
+
+    await expect(cursorChatMetaPath(transcriptPath)).resolves.toBeUndefined()
+    await expect(readCursorChatMeta(transcriptPath)).resolves.toBeNull()
+    await expect(readCursorChatMeta('/nowhere/near/cursor/chat.jsonl')).resolves.toBeNull()
+  })
+
+  it('yields nothing and does not throw when meta.json is malformed', async () => {
+    const cursorHome = await createCursorHome()
+    const chatDir = join(cursorHome, 'chats', 'workspace-hash', 'chat-bad')
+    await mkdir(chatDir, { recursive: true })
+    await writeFile(join(chatDir, 'meta.json'), '{ not json')
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-bad', [])
+
+    await expect(readCursorChatMeta(transcriptPath)).resolves.toBeNull()
+  })
+})
+
+describe('cursor discovery meta dependency', () => {
+  it('folds meta.json into candidate freshness so a rewrite invalidates the parse cache', async () => {
+    const cursorHome = await createCursorHome()
+    const metaPath = await writeChatMeta(cursorHome, 'workspace-hash', 'chat-7')
+    await writeTranscript(cursorHome, 'slug', 'chat-7', [])
+    const issues: AiVaultScanIssue[] = []
+    const discover = (): Promise<SessionFileDiscovery> =>
+      discoverFiles({
+        rootDir: join(cursorHome, 'projects'),
+        limit: 10,
+        agent: 'cursor',
+        issues,
+        extensions: [...AI_VAULT_AGENT_SOURCES.cursor.extensions],
+        filePredicate: AI_VAULT_AGENT_SOURCES.cursor.filePredicate,
+        contentDependencyPath: AI_VAULT_AGENT_SOURCES.cursor.contentDependencyPath
+      })
+
+    const before = (await discover()).files[0]
+    const future = new Date(Date.now() + 10_000)
+    await utimes(metaPath, future, future)
+    const after = (await discover()).files[0]
+
+    expect(after?.mtimeMs).toBeGreaterThan(before?.mtimeMs ?? 0)
+    expect(issues).toEqual([])
+  })
+})
+
+describe('cursor parser chat meta fallback', () => {
+  it('fills cwd, timestamps and title from meta.json', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-2', { title: 'Named From Meta' })
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-2', [
+      JSON.stringify({ role: 'assistant', message: { content: 'hello' } })
+    ])
+
+    const session = await parseCursorSessionFile(fileWithMtime(transcriptPath), 'darwin')
+
+    expect(session?.cwd).toBe('/private/tmp/workspace')
+    expect(session?.title).toBe('Named From Meta')
+    expect(session?.createdAt).toBe(new Date(CREATED_AT_MS).toISOString())
+    expect(session?.updatedAt).toBe(new Date(UPDATED_AT_MS).toISOString())
+  })
+
+  it('keeps a transcript title and timestamps over meta.json', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-3', { title: 'Meta Title' })
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-3', [
+      JSON.stringify({
+        role: 'user',
+        message: { content: 'transcript first prompt' },
+        timestamp: '2026-01-01T00:00:00.000Z'
+      })
+    ])
+
+    const session = await parseCursorSessionFile(fileWithMtime(transcriptPath), 'darwin')
+
+    expect(session?.title).toBe('transcript first prompt')
+    expect(session?.createdAt).toBe('2026-01-01T00:00:00.000Z')
+    // cwd is never in the transcript, so it still comes from meta.json.
+    expect(session?.cwd).toBe('/private/tmp/workspace')
+  })
+
+  it('builds the resume command from the meta.json cwd', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-4', { cwd: '/repo/from-meta' })
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-4', [
+      JSON.stringify({ role: 'user', message: { content: 'hi' } })
+    ])
+
+    const session = await parseCursorSessionFile(fileWithMtime(transcriptPath), 'darwin')
+
+    expect(session?.resumeCommand).toContain('/repo/from-meta')
+  })
+
+  it('leaves remote content parses to the transcript alone', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-5', { title: 'Meta Title' })
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-5', [])
+
+    const session = await parseCursorSessionContent(
+      fileWithMtime(transcriptPath),
+      `${JSON.stringify({ role: 'assistant', message: { content: 'remote' } })}\n`,
+      'linux'
+    )
+
+    expect(session?.cwd).toBeNull()
+    expect(session?.title).not.toBe('Meta Title')
+  })
+
+  it('applies the fallback on every finalize of a resumed parse', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-6', { title: 'Resumed Meta' })
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-6', [])
+
+    const state = createCursorSessionResumeState(fileWithMtime(transcriptPath))
+    state.consumeLine(JSON.stringify({ role: 'assistant', message: { content: 'first' } }))
+    const first = await state.finalize('darwin')
+    state.consumeLine(JSON.stringify({ role: 'assistant', message: { content: 'second' } }))
+    const second = await state.finalize('darwin')
+
+    expect(first?.cwd).toBe('/private/tmp/workspace')
+    expect(second?.title).toBe('Resumed Meta')
+    expect(second?.messageCount).toBe(2)
+  })
+})

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
@@ -8,6 +8,7 @@ import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-error'
 let failNextChatsReaddir = false
 let failNextChatsRootReaddir = false
 let failMetaJsonReads = false
+let failMetaJsonStats = false
 let chatsRootReads = 0
 vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
   const actual = await importOriginal<typeof WslTranscriptFsAccess>()
@@ -36,6 +37,14 @@ vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
         return Promise.reject(new WslTranscriptFsError('timeout', 'wsl fs timed out'))
       }
       return actual.wslGatedReadFile(...args)
+    },
+    wslGatedStat: (
+      ...args: Parameters<typeof actual.wslGatedStat>
+    ): ReturnType<typeof actual.wslGatedStat> => {
+      if (failMetaJsonStats && String(args[0]).endsWith('meta.json')) {
+        return Promise.reject(new WslTranscriptFsError('timeout', 'wsl fs timed out'))
+      }
+      return actual.wslGatedStat(...args)
     }
   }
 })
@@ -55,7 +64,12 @@ import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 import { AI_VAULT_AGENT_SOURCES } from './session-scanner-agent-sources'
 import { discoverFiles } from './session-scanner-discovery'
 import { scanAiVaultSessions } from './session-scanner'
-import { resetSessionParseCacheForTests } from './session-scanner-parse-cache'
+import {
+  createSessionParseStats,
+  parseAgentSessionFileCached,
+  resetSessionParseCacheForTests
+} from './session-scanner-parse-cache'
+import { appendFile, stat, truncate } from 'node:fs/promises'
 import { isolatedScanRoots } from './session-scanner-test-fixtures'
 import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
 
@@ -79,6 +93,7 @@ afterEach(async () => {
   resetSessionParseCacheForTests()
   failNextChatsRootReaddir = false
   failMetaJsonReads = false
+  failMetaJsonStats = false
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   tempRoots = []
 })
@@ -320,28 +335,28 @@ describe('cursor parser chat meta fallback', () => {
   })
 })
 
-describe('cursor chat meta scan failures', () => {
-  async function writeCursorScanFixture(chatIds: string[]): Promise<{
-    cursorHome: string
-    scanOptions: ReturnType<typeof isolatedScanRoots> & { cursorProjectsDir: string }
-  }> {
-    const cursorHome = await createCursorHome()
-    for (const chatId of chatIds) {
-      await writeChatMeta(cursorHome, 'workspace-hash', chatId, { cwd: `/tmp/ws-${chatId}` })
-      await writeTranscript(cursorHome, 'slug', chatId, [
-        JSON.stringify({ role: 'user', message: { content: [{ type: 'text', text: chatId }] } })
-      ])
-    }
-    const root = join(cursorHome, '..')
-    return {
-      cursorHome,
-      scanOptions: {
-        ...isolatedScanRoots(root),
-        cursorProjectsDir: join(cursorHome, 'projects')
-      }
+async function writeCursorScanFixture(chatIds: string[]): Promise<{
+  cursorHome: string
+  scanOptions: ReturnType<typeof isolatedScanRoots> & { cursorProjectsDir: string }
+}> {
+  const cursorHome = await createCursorHome()
+  for (const chatId of chatIds) {
+    await writeChatMeta(cursorHome, 'workspace-hash', chatId, { cwd: `/tmp/ws-${chatId}` })
+    await writeTranscript(cursorHome, 'slug', chatId, [
+      JSON.stringify({ role: 'user', message: { content: [{ type: 'text', text: chatId }] } })
+    ])
+  }
+  const root = join(cursorHome, '..')
+  return {
+    cursorHome,
+    scanOptions: {
+      ...isolatedScanRoots(root),
+      cursorProjectsDir: join(cursorHome, 'projects')
     }
   }
+}
 
+describe('cursor chat meta scan failures', () => {
   it('lists cursor sessions without metadata when the chats tree is refused, then heals', async () => {
     const { cursorHome, scanOptions } = await writeCursorScanFixture(['chat-a', 'chat-b'])
     resetSessionParseCacheForTests()
@@ -382,6 +397,7 @@ describe('cursor chat meta scan failures', () => {
     expect(refused.issues[0].path).toBe(join(cursorHome, 'chats'))
 
     failMetaJsonReads = false
+    failMetaJsonStats = false
     const healed = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
     expect(healed.issues).toEqual([])
     expect(
@@ -401,5 +417,107 @@ describe('cursor chat meta scan failures', () => {
 
     expect(result.sessions.filter((session) => session.agent === 'cursor')).toHaveLength(3)
     expect(chatsRootReads).toBe(1)
+  })
+})
+
+describe('cursor chat meta cache keys', () => {
+  async function cursorCandidate(cursorHome: string): Promise<FileWithMtime> {
+    const issues: AiVaultScanIssue[] = []
+    const discovery = await discoverFiles({
+      rootDir: join(cursorHome, 'projects'),
+      limit: 10,
+      agent: 'cursor',
+      issues,
+      extensions: [...AI_VAULT_AGENT_SOURCES.cursor.extensions],
+      filePredicate: AI_VAULT_AGENT_SOURCES.cursor.filePredicate,
+      contentDependencyPath: AI_VAULT_AGENT_SOURCES.cursor.contentDependencyPath
+    })
+    return discovery.files[0]
+  }
+
+  function parseCursor(file: FileWithMtime, stats = createSessionParseStats()) {
+    return withCursorChatMetaScan(async () => {
+      await parseAgentSessionFileCached({ agent: 'cursor', file, codexHome: null }, 'darwin', stats)
+      return stats
+    })
+  }
+
+  async function writeOneCursorChat(): Promise<{ cursorHome: string; transcriptPath: string }> {
+    const cursorHome = await createCursorHome()
+    // A padded title makes meta.json larger than one transcript line.
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-key', { title: 'x'.repeat(400) })
+    const transcriptPath = await writeTranscript(
+      cursorHome,
+      'slug',
+      'chat-key',
+      [1, 2, 3].map((index) =>
+        JSON.stringify({
+          role: 'user',
+          message: { content: [{ type: 'text', text: `ask ${index}` }] }
+        })
+      )
+    )
+    return { cursorHome, transcriptPath }
+  }
+
+  it('re-reads a transcript truncated by less than its meta.json size', async () => {
+    const { cursorHome, transcriptPath } = await writeOneCursorChat()
+    resetSessionParseCacheForTests()
+    await parseCursor(await cursorCandidate(cursorHome))
+
+    const metaSize = (
+      await stat(join(cursorHome, 'chats', 'workspace-hash', 'chat-key', 'meta.json'))
+    ).size
+    const transcriptSize = (await stat(transcriptPath)).size
+    // Inside the window where the folded meta.json size hides the truncation.
+    const truncatedTo = transcriptSize - 20
+    expect(metaSize).toBeGreaterThan(20)
+    await truncate(transcriptPath, truncatedTo)
+
+    const stats = await parseCursor(await cursorCandidate(cursorHome))
+    expect(stats.incremental).toBe(0)
+    expect(stats.fullParses).toBe(1)
+  })
+
+  it('keeps the resume cursor when a refused meta.json read poisons the key', async () => {
+    const { cursorHome, transcriptPath } = await writeOneCursorChat()
+    resetSessionParseCacheForTests()
+    await parseCursor(await cursorCandidate(cursorHome))
+
+    // A cache hit never reads meta.json, so the refusal needs a changed file.
+    await appendFile(
+      transcriptPath,
+      `${JSON.stringify({ role: 'user', message: { content: [{ type: 'text', text: 'ask 4' }] } })}\n`
+    )
+    failMetaJsonReads = true
+    const refused = await parseCursor(await cursorCandidate(cursorHome))
+    expect(refused.incremental).toBe(1)
+
+    // The poisoned key must force a re-read, but not a full one: the resume
+    // point survives, so the next healthy scan resumes at the stored offset.
+    failMetaJsonReads = false
+    const healed = await parseCursor(await cursorCandidate(cursorHome))
+    expect(healed.incremental).toBe(1)
+    expect(healed.fullParses).toBe(0)
+  })
+
+  it('lists a cursor session whose meta.json stat is refused instead of dropping it', async () => {
+    const { scanOptions } = await writeCursorScanFixture(['chat-a'])
+    resetSessionParseCacheForTests()
+
+    // Only the stat is refused, so the parse still reads meta.json; what the
+    // refusal costs is the cache key, which now omits that sibling.
+    failMetaJsonStats = true
+    const refused = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+    expect(refused.sessions.filter((session) => session.agent === 'cursor')).toHaveLength(1)
+    expect(refused.issues).toHaveLength(1)
+    expect(refused.issues[0].agent).toBe('cursor')
+
+    failMetaJsonStats = false
+    const healed = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+    expect(healed.issues).toEqual([])
+    expect(healed.sessions.find((session) => session.agent === 'cursor')?.cwd).toBe(
+      '/tmp/ws-chat-a'
+    )
   })
 })

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
@@ -6,6 +6,7 @@ import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-error'
 
 // Why: a refused WSL read is the one build failure that must not be cached.
 let failNextChatsReaddir = false
+let failNextChatsRootReaddir = false
 let chatsRootReads = 0
 vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
   const actual = await importOriginal<typeof WslTranscriptFsAccess>()
@@ -16,6 +17,10 @@ vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
     ): ReturnType<typeof actual.wslGatedReaddir> => {
       if (args[0].endsWith('chats')) {
         chatsRootReads += 1
+        if (failNextChatsRootReaddir) {
+          failNextChatsRootReaddir = false
+          return Promise.reject(new WslTranscriptFsError('timeout', 'wsl fs timed out'))
+        }
       }
       if (failNextChatsReaddir && args[0].includes('workspace-hash')) {
         failNextChatsReaddir = false
@@ -40,6 +45,9 @@ import {
 import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 import { AI_VAULT_AGENT_SOURCES } from './session-scanner-agent-sources'
 import { discoverFiles } from './session-scanner-discovery'
+import { scanAiVaultSessions } from './session-scanner'
+import { resetSessionParseCacheForTests } from './session-scanner-parse-cache'
+import { isolatedScanRoots } from './session-scanner-test-fixtures'
 import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
 
 // Cursor's real meta.json keys (~/.cursor/chats/<md5 of cwd>/<uuid>/meta.json, 2026-09).
@@ -59,6 +67,8 @@ let tempRoots: string[] = []
 
 afterEach(async () => {
   resetCursorChatMetaIndexCacheForTests()
+  resetSessionParseCacheForTests()
+  failNextChatsRootReaddir = false
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   tempRoots = []
 })
@@ -147,7 +157,8 @@ describe('cursor chat meta', () => {
     const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-refused', [])
 
     failNextChatsReaddir = true
-    await expect(cursorChatMetaPath(transcriptPath)).rejects.toBeInstanceOf(WslTranscriptFsError)
+    // A refusal degrades to "no metadata" rather than taking the session down.
+    await expect(cursorChatMetaPath(transcriptPath)).resolves.toBeUndefined()
     // The next scan rebuilds instead of replaying the rejected promise.
     await expect(cursorChatMetaPath(transcriptPath)).resolves.toBe(metaPath)
   })
@@ -296,5 +307,64 @@ describe('cursor parser chat meta fallback', () => {
     expect(first?.cwd).toBe('/private/tmp/workspace')
     expect(second?.title).toBe('Resumed Meta')
     expect(second?.messageCount).toBe(2)
+  })
+})
+
+describe('cursor chat meta scan failures', () => {
+  async function writeCursorScanFixture(chatIds: string[]): Promise<{
+    cursorHome: string
+    scanOptions: ReturnType<typeof isolatedScanRoots> & { cursorProjectsDir: string }
+  }> {
+    const cursorHome = await createCursorHome()
+    for (const chatId of chatIds) {
+      await writeChatMeta(cursorHome, 'workspace-hash', chatId, { cwd: `/tmp/ws-${chatId}` })
+      await writeTranscript(cursorHome, 'slug', chatId, [
+        JSON.stringify({ role: 'user', message: { content: [{ type: 'text', text: chatId }] } })
+      ])
+    }
+    const root = join(cursorHome, '..')
+    return {
+      cursorHome,
+      scanOptions: {
+        ...isolatedScanRoots(root),
+        cursorProjectsDir: join(cursorHome, 'projects')
+      }
+    }
+  }
+
+  it('lists cursor sessions without metadata when the chats tree is refused, then heals', async () => {
+    const { cursorHome, scanOptions } = await writeCursorScanFixture(['chat-a', 'chat-b'])
+    resetSessionParseCacheForTests()
+
+    failNextChatsRootReaddir = true
+    const refused = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+    const refusedCursor = refused.sessions.filter((session) => session.agent === 'cursor')
+    expect(refusedCursor).toHaveLength(2)
+    expect(refusedCursor.map((session) => session.cwd)).toEqual([null, null])
+    // One issue for the chats root, not one per transcript.
+    expect(refused.issues).toHaveLength(1)
+    expect(refused.issues[0].path).toBe(join(cursorHome, 'chats'))
+    expect(refused.issues[0].agent).toBe('cursor')
+
+    // The refused scan must not leave a metadata-less entry that looks unchanged.
+    const healed = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+    expect(healed.issues).toEqual([])
+    expect(
+      healed.sessions
+        .filter((session) => session.agent === 'cursor')
+        .map((session) => session.cwd)
+        .sort()
+    ).toEqual(['/tmp/ws-chat-a', '/tmp/ws-chat-b'])
+  })
+
+  it('reads the chats root once per scan across discovery and parse', async () => {
+    const { scanOptions } = await writeCursorScanFixture(['chat-a', 'chat-b', 'chat-c'])
+    resetSessionParseCacheForTests()
+    chatsRootReads = 0
+
+    const result = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+
+    expect(result.sessions.filter((session) => session.agent === 'cursor')).toHaveLength(3)
+    expect(chatsRootReads).toBe(1)
   })
 })

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
@@ -8,7 +8,7 @@ import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-error'
 let failNextChatsReaddir = false
 let failNextChatsRootReaddir = false
 let failMetaJsonReads = false
-let failMetaJsonStats = false
+let failMetaJsonStats: false | true | 'eacces' = false
 let chatsRootReads = 0
 vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
   const actual = await importOriginal<typeof WslTranscriptFsAccess>()
@@ -42,7 +42,11 @@ vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
       ...args: Parameters<typeof actual.wslGatedStat>
     ): ReturnType<typeof actual.wslGatedStat> => {
       if (failMetaJsonStats && String(args[0]).endsWith('meta.json')) {
-        return Promise.reject(new WslTranscriptFsError('timeout', 'wsl fs timed out'))
+        return Promise.reject(
+          failMetaJsonStats === 'eacces'
+            ? Object.assign(new Error('permission denied'), { code: 'EACCES' })
+            : new WslTranscriptFsError('timeout', 'wsl fs timed out')
+        )
       }
       return actual.wslGatedStat(...args)
     }
@@ -464,6 +468,28 @@ describe('cursor chat meta scan failures', () => {
     expect(entry?.resume).not.toBeNull()
 
     failMetaJsonReads = false
+    const healed = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+    expect(healed.issues).toEqual([])
+    expect(healed.sessions.find((session) => session.agent === 'cursor')?.cwd).toBe(
+      '/tmp/ws-chat-a'
+    )
+  })
+
+  it('treats a local EACCES on the sidecar stat as unknown, not as absent', async () => {
+    const { scanOptions } = await writeCursorScanFixture(['chat-a'])
+    resetSessionParseCacheForTests()
+
+    // On mac/Linux/Windows the gated stat is a bare fs stat, so a permissions
+    // failure is not a WslTranscriptFsError and must not read as "no sidecar".
+    failMetaJsonStats = 'eacces'
+    const refused = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+    const listed = refused.sessions.find((session) => session.agent === 'cursor')
+    expect(listed?.sessionId).toBeTruthy()
+    expect(refused.issues).toHaveLength(1)
+    expect(refused.issues[0].agent).toBe('cursor')
+    expect(getSessionParseCacheEntry(listed?.filePath ?? '')?.sidecar).toBe('unknown')
+
+    failMetaJsonStats = false
     const healed = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
     expect(healed.issues).toEqual([])
     expect(healed.sessions.find((session) => session.agent === 'cursor')?.cwd).toBe(

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
@@ -7,6 +7,7 @@ import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-error'
 // Why: a refused WSL read is the one build failure that must not be cached.
 let failNextChatsReaddir = false
 let failNextChatsRootReaddir = false
+let failMetaJsonReads = false
 let chatsRootReads = 0
 vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
   const actual = await importOriginal<typeof WslTranscriptFsAccess>()
@@ -27,6 +28,14 @@ vi.mock('../native-chat/wsl-transcript-fs-access', async (importOriginal) => {
         return Promise.reject(new WslTranscriptFsError('timeout', 'wsl fs timed out'))
       }
       return actual.wslGatedReaddir(...args)
+    },
+    wslGatedReadFile: (
+      ...args: Parameters<typeof actual.wslGatedReadFile>
+    ): ReturnType<typeof actual.wslGatedReadFile> => {
+      if (failMetaJsonReads && String(args[0]).endsWith('meta.json')) {
+        return Promise.reject(new WslTranscriptFsError('timeout', 'wsl fs timed out'))
+      }
+      return actual.wslGatedReadFile(...args)
     }
   }
 })
@@ -69,6 +78,7 @@ afterEach(async () => {
   resetCursorChatMetaIndexCacheForTests()
   resetSessionParseCacheForTests()
   failNextChatsRootReaddir = false
+  failMetaJsonReads = false
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   tempRoots = []
 })
@@ -347,6 +357,31 @@ describe('cursor chat meta scan failures', () => {
     expect(refused.issues[0].agent).toBe('cursor')
 
     // The refused scan must not leave a metadata-less entry that looks unchanged.
+    const healed = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+    expect(healed.issues).toEqual([])
+    expect(
+      healed.sessions
+        .filter((session) => session.agent === 'cursor')
+        .map((session) => session.cwd)
+        .sort()
+    ).toEqual(['/tmp/ws-chat-a', '/tmp/ws-chat-b'])
+  })
+
+  it('does not cache an un-enriched session when only its meta.json read is refused', async () => {
+    const { cursorHome, scanOptions } = await writeCursorScanFixture(['chat-a', 'chat-b'])
+    resetSessionParseCacheForTests()
+
+    // Discovery stats meta.json fine, so the cache key already covers it; only
+    // the parse-time read is refused.
+    failMetaJsonReads = true
+    const refused = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+    const refusedCursor = refused.sessions.filter((session) => session.agent === 'cursor')
+    expect(refusedCursor).toHaveLength(2)
+    expect(refusedCursor.map((session) => session.cwd)).toEqual([null, null])
+    expect(refused.issues).toHaveLength(1)
+    expect(refused.issues[0].path).toBe(join(cursorHome, 'chats'))
+
+    failMetaJsonReads = false
     const healed = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
     expect(healed.issues).toEqual([])
     expect(

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, rm, stat, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -55,12 +55,8 @@ import {
   resetCursorChatMetaIndexCacheForTests,
   withCursorChatMetaScan
 } from './session-scanner-cursor-chat-meta'
-import {
-  createCursorSessionResumeState,
-  parseCursorSessionContent,
-  parseCursorSessionFile
-} from './session-scanner-cursor-parser'
-import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { parseCursorSessionContent } from './session-scanner-cursor-parser'
+import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
 import { AI_VAULT_AGENT_SOURCES } from './session-scanner-agent-sources'
 import { discoverFiles } from './session-scanner-discovery'
 import { scanAiVaultSessions } from './session-scanner'
@@ -68,12 +64,17 @@ import {
   createSessionParseStats,
   parseAgentSessionFileCached,
   resetSessionParseCacheForTests,
-  UNMATCHABLE_MTIME_MS
+  seedSessionParseCache,
+  snapshotSessionParseCacheForPersistence,
+  type SessionParseStats
 } from './session-scanner-parse-cache'
-import { getSessionParseCacheEntry } from './session-parse-cache-store'
-import { appendFile, stat, truncate } from 'node:fs/promises'
+import {
+  getSessionParseCacheEntry,
+  type PersistedSessionParseCacheEntry
+} from './session-parse-cache-store'
 import { isolatedScanRoots } from './session-scanner-test-fixtures'
-import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
+import type { FileWithMtime } from './session-scanner-types'
+import type { SessionSidecarStat } from './session-sidecar-stat'
 
 // Cursor's real meta.json keys (~/.cursor/chats/<md5 of cwd>/<uuid>/meta.json, 2026-09).
 type CursorMetaFixture = {
@@ -231,111 +232,34 @@ describe('cursor chat meta', () => {
   })
 })
 
-describe('cursor discovery meta dependency', () => {
-  it('folds meta.json into candidate freshness so a rewrite invalidates the parse cache', async () => {
-    const cursorHome = await createCursorHome()
-    const metaPath = await writeChatMeta(cursorHome, 'workspace-hash', 'chat-7')
-    await writeTranscript(cursorHome, 'slug', 'chat-7', [])
-    const issues: AiVaultScanIssue[] = []
-    const discover = (): Promise<SessionFileDiscovery> =>
-      discoverFiles({
-        rootDir: join(cursorHome, 'projects'),
-        limit: 10,
-        agent: 'cursor',
-        issues,
-        extensions: [...AI_VAULT_AGENT_SOURCES.cursor.extensions],
-        filePredicate: AI_VAULT_AGENT_SOURCES.cursor.filePredicate,
-        contentDependencyPath: AI_VAULT_AGENT_SOURCES.cursor.contentDependencyPath
-      })
-
-    const before = (await discover()).files[0]
-    const future = new Date(Date.now() + 10_000)
-    await utimes(metaPath, future, future)
-    const after = (await discover()).files[0]
-
-    expect(after?.mtimeMs).toBeGreaterThan(before?.mtimeMs ?? 0)
-    expect(issues).toEqual([])
+async function cursorCandidate(cursorHome: string): Promise<FileWithMtime> {
+  const issues: AiVaultScanIssue[] = []
+  const discovery = await discoverFiles({
+    rootDir: join(cursorHome, 'projects'),
+    limit: 10,
+    agent: 'cursor',
+    issues,
+    extensions: [...AI_VAULT_AGENT_SOURCES.cursor.extensions],
+    filePredicate: AI_VAULT_AGENT_SOURCES.cursor.filePredicate,
+    contentDependencyPath: AI_VAULT_AGENT_SOURCES.cursor.contentDependencyPath
   })
-})
+  return discovery.files[0]
+}
 
-describe('cursor parser chat meta fallback', () => {
-  it('fills cwd, timestamps and title from meta.json', async () => {
-    const cursorHome = await createCursorHome()
-    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-2', { title: 'Named From Meta' })
-    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-2', [
-      JSON.stringify({ role: 'assistant', message: { content: 'hello' } })
-    ])
-
-    const session = await parseCursorSessionFile(fileWithMtime(transcriptPath), 'darwin')
-
-    expect(session?.cwd).toBe('/private/tmp/workspace')
-    expect(session?.title).toBe('Named From Meta')
-    expect(session?.createdAt).toBe(new Date(CREATED_AT_MS).toISOString())
-    expect(session?.updatedAt).toBe(new Date(UPDATED_AT_MS).toISOString())
-  })
-
-  it('keeps a transcript title and timestamps over meta.json', async () => {
-    const cursorHome = await createCursorHome()
-    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-3', { title: 'Meta Title' })
-    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-3', [
-      JSON.stringify({
-        role: 'user',
-        message: { content: 'transcript first prompt' },
-        timestamp: '2026-01-01T00:00:00.000Z'
-      })
-    ])
-
-    const session = await parseCursorSessionFile(fileWithMtime(transcriptPath), 'darwin')
-
-    expect(session?.title).toBe('transcript first prompt')
-    expect(session?.createdAt).toBe('2026-01-01T00:00:00.000Z')
-    // cwd is never in the transcript, so it still comes from meta.json.
-    expect(session?.cwd).toBe('/private/tmp/workspace')
-  })
-
-  it('builds the resume command from the meta.json cwd', async () => {
-    const cursorHome = await createCursorHome()
-    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-4', { cwd: '/repo/from-meta' })
-    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-4', [
-      JSON.stringify({ role: 'user', message: { content: 'hi' } })
-    ])
-
-    const session = await parseCursorSessionFile(fileWithMtime(transcriptPath), 'darwin')
-
-    expect(session?.resumeCommand).toContain('/repo/from-meta')
-  })
-
-  it('leaves remote content parses to the transcript alone', async () => {
-    const cursorHome = await createCursorHome()
-    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-5', { title: 'Meta Title' })
-    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-5', [])
-
-    const session = await parseCursorSessionContent(
-      fileWithMtime(transcriptPath),
-      `${JSON.stringify({ role: 'assistant', message: { content: 'remote' } })}\n`,
-      'linux'
+/** The production path: the parse cache owns the sidecar merge, not the parser. */
+function parseCursorCached(
+  file: FileWithMtime,
+  stats: SessionParseStats = createSessionParseStats()
+): Promise<{ session: AiVaultSession | null; stats: SessionParseStats }> {
+  return withCursorChatMetaScan(async () => {
+    const session = await parseAgentSessionFileCached(
+      { agent: 'cursor', file, codexHome: null },
+      'darwin',
+      stats
     )
-
-    expect(session?.cwd).toBeNull()
-    expect(session?.title).not.toBe('Meta Title')
+    return { session, stats }
   })
-
-  it('applies the fallback on every finalize of a resumed parse', async () => {
-    const cursorHome = await createCursorHome()
-    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-6', { title: 'Resumed Meta' })
-    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-6', [])
-
-    const state = createCursorSessionResumeState(fileWithMtime(transcriptPath))
-    state.consumeLine(JSON.stringify({ role: 'assistant', message: { content: 'first' } }))
-    const first = await state.finalize('darwin')
-    state.consumeLine(JSON.stringify({ role: 'assistant', message: { content: 'second' } }))
-    const second = await state.finalize('darwin')
-
-    expect(first?.cwd).toBe('/private/tmp/workspace')
-    expect(second?.title).toBe('Resumed Meta')
-    expect(second?.messageCount).toBe(2)
-  })
-})
+}
 
 async function writeCursorScanFixture(chatIds: string[]): Promise<{
   cursorHome: string
@@ -358,6 +282,146 @@ async function writeCursorScanFixture(chatIds: string[]): Promise<{
   }
 }
 
+describe('cursor discovery sidecar observation', () => {
+  it('records meta.json beside the transcript stat instead of folding it in', async () => {
+    const cursorHome = await createCursorHome()
+    const metaPath = await writeChatMeta(cursorHome, 'workspace-hash', 'chat-7')
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-7', [])
+
+    const before = await cursorCandidate(cursorHome)
+    const future = new Date(Date.now() + 10_000)
+    await utimes(metaPath, future, future)
+    const after = await cursorCandidate(cursorHome)
+
+    // The transcript's own key is untouched by a sibling rewrite.
+    const transcriptStat = await stat(transcriptPath)
+    expect(after.mtimeMs).toBe(transcriptStat.mtimeMs)
+    expect(after.sizeBytes).toBe(transcriptStat.size)
+    expect(after.mtimeMs).toBe(before.mtimeMs)
+    // The sibling is observed separately, and it did move.
+    expect(before.sidecar).toMatchObject({ path: metaPath })
+    expect(after.sidecar).toMatchObject({ path: metaPath })
+    expect((after.sidecar as SessionSidecarStat).mtimeMs).toBeGreaterThan(
+      (before.sidecar as SessionSidecarStat).mtimeMs
+    )
+  })
+})
+
+describe('cursor sidecar enrichment', () => {
+  it('fills cwd, timestamps and title from meta.json', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-2', { title: 'Named From Meta' })
+    await writeTranscript(cursorHome, 'slug', 'chat-2', [
+      JSON.stringify({ role: 'assistant', message: { content: 'hello' } })
+    ])
+    resetSessionParseCacheForTests()
+
+    const { session } = await parseCursorCached(await cursorCandidate(cursorHome))
+
+    expect(session?.cwd).toBe('/private/tmp/workspace')
+    expect(session?.title).toBe('Named From Meta')
+    expect(session?.createdAt).toBe(new Date(CREATED_AT_MS).toISOString())
+    expect(session?.updatedAt).toBe(new Date(UPDATED_AT_MS).toISOString())
+  })
+
+  it('keeps a transcript title and timestamps over meta.json', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-3', { title: 'Meta Title' })
+    await writeTranscript(cursorHome, 'slug', 'chat-3', [
+      JSON.stringify({
+        role: 'user',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        message: { content: 'transcript first prompt' }
+      })
+    ])
+    resetSessionParseCacheForTests()
+
+    const { session } = await parseCursorCached(await cursorCandidate(cursorHome))
+
+    expect(session?.title).toBe('transcript first prompt')
+    expect(session?.createdAt).toBe('2026-01-01T00:00:00.000Z')
+    // cwd is never in the transcript, so it still comes from meta.json.
+    expect(session?.cwd).toBe('/private/tmp/workspace')
+  })
+
+  it('builds the resume command from the meta.json cwd', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-4', { cwd: '/repo/from-meta' })
+    await writeTranscript(cursorHome, 'slug', 'chat-4', [
+      JSON.stringify({ role: 'user', message: { content: 'hi' } })
+    ])
+    resetSessionParseCacheForTests()
+
+    const { session } = await parseCursorCached(await cursorCandidate(cursorHome))
+
+    expect(session?.resumeCommand).toContain('/repo/from-meta')
+  })
+
+  it('leaves remote content parses to the transcript alone', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-5', { title: 'Meta Title' })
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-5', [])
+
+    const session = await parseCursorSessionContent(
+      fileWithMtime(transcriptPath),
+      `${JSON.stringify({ role: 'assistant', message: { content: 'remote' } })}\n`,
+      'linux'
+    )
+
+    expect(session?.cwd).toBeNull()
+    expect(session?.title).not.toBe('Meta Title')
+  })
+
+  it('re-enriches without a parse when only the sidecar is rewritten', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-8', { cwd: '/repo/first' })
+    await writeTranscript(cursorHome, 'slug', 'chat-8', [
+      JSON.stringify({ role: 'user', message: { content: 'hi' } })
+    ])
+    resetSessionParseCacheForTests()
+    await parseCursorCached(await cursorCandidate(cursorHome))
+
+    const future = new Date(Date.now() + 10_000)
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-8', { cwd: '/repo/second' })
+    await utimes(join(cursorHome, 'chats', 'workspace-hash', 'chat-8', 'meta.json'), future, future)
+
+    const { session, stats } = await parseCursorCached(await cursorCandidate(cursorHome))
+
+    // The transcript is not re-read: the merge runs over the stored fold result.
+    expect(stats.reused).toBe(1)
+    expect(stats.fullParses).toBe(0)
+    expect(stats.incremental).toBe(0)
+    // A rewritten cwd REPLACES the merged one; `??=` on the cached session could
+    // never do this, because the cached cwd is already non-null.
+    expect(session?.cwd).toBe('/repo/second')
+    expect(session?.resumeCommand).toContain('/repo/second')
+  })
+
+  it('treats a persisted entry with no sidecar as unknown and enriches once', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-9', { cwd: '/repo/persisted' })
+    await writeTranscript(cursorHome, 'slug', 'chat-9', [
+      JSON.stringify({ role: 'user', message: { content: 'hi' } })
+    ])
+    resetSessionParseCacheForTests()
+    await parseCursorCached(await cursorCandidate(cursorHome))
+
+    // What a build older than the sidecar field wrote: no such key.
+    const persisted = snapshotSessionParseCacheForPersistence().map(
+      ([path, entry]): [string, PersistedSessionParseCacheEntry] => {
+        const { sidecar: _sidecar, ...rest } = entry
+        return [path, rest]
+      }
+    )
+    resetSessionParseCacheForTests()
+    seedSessionParseCache(persisted)
+
+    const { session, stats } = await parseCursorCached(await cursorCandidate(cursorHome))
+    expect(stats.reused).toBe(0)
+    expect(session?.cwd).toBe('/repo/persisted')
+  })
+})
+
 describe('cursor chat meta scan failures', () => {
   it('lists cursor sessions without metadata when the chats tree is refused, then heals', async () => {
     const { cursorHome, scanOptions } = await writeCursorScanFixture(['chat-a', 'chat-b'])
@@ -373,7 +437,6 @@ describe('cursor chat meta scan failures', () => {
     expect(refused.issues[0].path).toBe(join(cursorHome, 'chats'))
     expect(refused.issues[0].agent).toBe('cursor')
 
-    // The refused scan must not leave a metadata-less entry that looks unchanged.
     const healed = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
     expect(healed.issues).toEqual([])
     expect(
@@ -384,142 +447,34 @@ describe('cursor chat meta scan failures', () => {
     ).toEqual(['/tmp/ws-chat-a', '/tmp/ws-chat-b'])
   })
 
-  it('does not cache an un-enriched session when only its meta.json read is refused', async () => {
-    const { cursorHome, scanOptions } = await writeCursorScanFixture(['chat-a', 'chat-b'])
+  it('re-enriches after a refused meta.json read without losing the resume cursor', async () => {
+    const { scanOptions } = await writeCursorScanFixture(['chat-a'])
     resetSessionParseCacheForTests()
 
-    // Discovery stats meta.json fine, so the cache key already covers it; only
-    // the parse-time read is refused.
     failMetaJsonReads = true
     const refused = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
-    const refusedCursor = refused.sessions.filter((session) => session.agent === 'cursor')
-    expect(refusedCursor).toHaveLength(2)
-    expect(refusedCursor.map((session) => session.cwd)).toEqual([null, null])
+    const listed = refused.sessions.find((session) => session.agent === 'cursor')
+    expect(listed?.cwd).toBeNull()
     expect(refused.issues).toHaveLength(1)
-    expect(refused.issues[0].path).toBe(join(cursorHome, 'chats'))
-    // The un-enriched parse is kept only under an unmatchable key.
-    expect(
-      refused.sessions
-        .filter((session) => session.agent === 'cursor')
-        .map((session) => getSessionParseCacheEntry(session.filePath)?.mtimeMs)
-    ).toEqual([UNMATCHABLE_MTIME_MS, UNMATCHABLE_MTIME_MS])
+
+    // The sibling alone is unknown; the transcript's work and its resume point
+    // are kept, so the next healthy scan merges without re-reading bytes.
+    const entry = getSessionParseCacheEntry(listed?.filePath ?? '')
+    expect(entry?.sidecar).toBe('unknown')
+    expect(entry?.resume).not.toBeNull()
 
     failMetaJsonReads = false
-    failMetaJsonStats = false
     const healed = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
     expect(healed.issues).toEqual([])
-    expect(
-      healed.sessions
-        .filter((session) => session.agent === 'cursor')
-        .map((session) => session.cwd)
-        .sort()
-    ).toEqual(['/tmp/ws-chat-a', '/tmp/ws-chat-b'])
-  })
-
-  it('reads the chats root once per scan across discovery and parse', async () => {
-    const { scanOptions } = await writeCursorScanFixture(['chat-a', 'chat-b', 'chat-c'])
-    resetSessionParseCacheForTests()
-    chatsRootReads = 0
-
-    const result = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
-
-    expect(result.sessions.filter((session) => session.agent === 'cursor')).toHaveLength(3)
-    expect(chatsRootReads).toBe(1)
-  })
-})
-
-describe('cursor chat meta cache keys', () => {
-  async function cursorCandidate(cursorHome: string): Promise<FileWithMtime> {
-    const issues: AiVaultScanIssue[] = []
-    const discovery = await discoverFiles({
-      rootDir: join(cursorHome, 'projects'),
-      limit: 10,
-      agent: 'cursor',
-      issues,
-      extensions: [...AI_VAULT_AGENT_SOURCES.cursor.extensions],
-      filePredicate: AI_VAULT_AGENT_SOURCES.cursor.filePredicate,
-      contentDependencyPath: AI_VAULT_AGENT_SOURCES.cursor.contentDependencyPath
-    })
-    return discovery.files[0]
-  }
-
-  function parseCursor(file: FileWithMtime, stats = createSessionParseStats()) {
-    return withCursorChatMetaScan(async () => {
-      await parseAgentSessionFileCached({ agent: 'cursor', file, codexHome: null }, 'darwin', stats)
-      return stats
-    })
-  }
-
-  async function writeOneCursorChat(): Promise<{ cursorHome: string; transcriptPath: string }> {
-    const cursorHome = await createCursorHome()
-    // A padded title makes meta.json larger than one transcript line.
-    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-key', { title: 'x'.repeat(400) })
-    const transcriptPath = await writeTranscript(
-      cursorHome,
-      'slug',
-      'chat-key',
-      [1, 2, 3].map((index) =>
-        JSON.stringify({
-          role: 'user',
-          message: { content: [{ type: 'text', text: `ask ${index}` }] }
-        })
-      )
+    expect(healed.sessions.find((session) => session.agent === 'cursor')?.cwd).toBe(
+      '/tmp/ws-chat-a'
     )
-    return { cursorHome, transcriptPath }
-  }
-
-  it('re-reads a transcript truncated by less than its meta.json size', async () => {
-    const { cursorHome, transcriptPath } = await writeOneCursorChat()
-    resetSessionParseCacheForTests()
-    await parseCursor(await cursorCandidate(cursorHome))
-
-    const metaSize = (
-      await stat(join(cursorHome, 'chats', 'workspace-hash', 'chat-key', 'meta.json'))
-    ).size
-    const transcriptSize = (await stat(transcriptPath)).size
-    // Inside the window where the folded meta.json size hides the truncation.
-    const truncatedTo = transcriptSize - 20
-    expect(metaSize).toBeGreaterThan(20)
-    await truncate(transcriptPath, truncatedTo)
-
-    const stats = await parseCursor(await cursorCandidate(cursorHome))
-    expect(stats.incremental).toBe(0)
-    expect(stats.fullParses).toBe(1)
-  })
-
-  it('keeps the resume cursor when a refused meta.json read poisons the key', async () => {
-    const { cursorHome, transcriptPath } = await writeOneCursorChat()
-    resetSessionParseCacheForTests()
-    await parseCursor(await cursorCandidate(cursorHome))
-
-    // A cache hit never reads meta.json, so the refusal needs a changed file.
-    await appendFile(
-      transcriptPath,
-      `${JSON.stringify({ role: 'user', message: { content: [{ type: 'text', text: 'ask 4' }] } })}\n`
-    )
-    failMetaJsonReads = true
-    const refused = await parseCursor(await cursorCandidate(cursorHome))
-    expect(refused.incremental).toBe(1)
-
-    // Pin the mechanism, not just its effect: the entry is kept under a key no
-    // stat can produce, and it still carries the fold to resume from.
-    const poisoned = getSessionParseCacheEntry(transcriptPath)
-    expect(poisoned?.mtimeMs).toBe(UNMATCHABLE_MTIME_MS)
-    expect(poisoned?.resume).not.toBeNull()
-
-    // So the next healthy scan re-reads, but only the appended bytes.
-    failMetaJsonReads = false
-    const healed = await parseCursor(await cursorCandidate(cursorHome))
-    expect(healed.incremental).toBe(1)
-    expect(healed.fullParses).toBe(0)
   })
 
   it('lists a cursor session whose meta.json stat is refused instead of dropping it', async () => {
     const { scanOptions } = await writeCursorScanFixture(['chat-a'])
     resetSessionParseCacheForTests()
 
-    // Only the stat is refused, so the parse still reads meta.json; what the
-    // refusal costs is the cache key, which now omits that sibling.
     failMetaJsonStats = true
     const refused = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
     expect(refused.sessions.filter((session) => session.agent === 'cursor')).toHaveLength(1)
@@ -532,5 +487,40 @@ describe('cursor chat meta cache keys', () => {
     expect(healed.sessions.find((session) => session.agent === 'cursor')?.cwd).toBe(
       '/tmp/ws-chat-a'
     )
+  })
+
+  it('reads the chats root once per scan across discovery and parse', async () => {
+    const { scanOptions } = await writeCursorScanFixture(['chat-a', 'chat-b', 'chat-c'])
+    resetSessionParseCacheForTests()
+    chatsRootReads = 0
+
+    const result = await scanAiVaultSessions({ ...scanOptions, platform: 'darwin', limit: 20 })
+
+    expect(result.sessions.filter((session) => session.agent === 'cursor')).toHaveLength(3)
+    expect(chatsRootReads).toBe(1)
+  })
+
+  it('resumes an appended transcript after a refused sidecar scan', async () => {
+    const cursorHome = await createCursorHome()
+    await writeChatMeta(cursorHome, 'workspace-hash', 'chat-r', { cwd: '/repo/resume' })
+    const transcriptPath = await writeTranscript(cursorHome, 'slug', 'chat-r', [
+      JSON.stringify({ role: 'user', message: { content: 'one' } })
+    ])
+    resetSessionParseCacheForTests()
+    await parseCursorCached(await cursorCandidate(cursorHome))
+
+    await appendFile(
+      transcriptPath,
+      `${JSON.stringify({ role: 'user', message: { content: 'two' } })}\n`
+    )
+    failMetaJsonReads = true
+    const { stats: refusedStats } = await parseCursorCached(await cursorCandidate(cursorHome))
+    expect(refusedStats.incremental).toBe(1)
+
+    failMetaJsonReads = false
+    const { session, stats } = await parseCursorCached(await cursorCandidate(cursorHome))
+    expect(stats.reused).toBe(1)
+    expect(stats.fullParses).toBe(0)
+    expect(session?.cwd).toBe('/repo/resume')
   })
 })

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.test.ts
@@ -67,8 +67,10 @@ import { scanAiVaultSessions } from './session-scanner'
 import {
   createSessionParseStats,
   parseAgentSessionFileCached,
-  resetSessionParseCacheForTests
+  resetSessionParseCacheForTests,
+  UNMATCHABLE_MTIME_MS
 } from './session-scanner-parse-cache'
+import { getSessionParseCacheEntry } from './session-parse-cache-store'
 import { appendFile, stat, truncate } from 'node:fs/promises'
 import { isolatedScanRoots } from './session-scanner-test-fixtures'
 import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
@@ -395,6 +397,12 @@ describe('cursor chat meta scan failures', () => {
     expect(refusedCursor.map((session) => session.cwd)).toEqual([null, null])
     expect(refused.issues).toHaveLength(1)
     expect(refused.issues[0].path).toBe(join(cursorHome, 'chats'))
+    // The un-enriched parse is kept only under an unmatchable key.
+    expect(
+      refused.sessions
+        .filter((session) => session.agent === 'cursor')
+        .map((session) => getSessionParseCacheEntry(session.filePath)?.mtimeMs)
+    ).toEqual([UNMATCHABLE_MTIME_MS, UNMATCHABLE_MTIME_MS])
 
     failMetaJsonReads = false
     failMetaJsonStats = false
@@ -493,8 +501,13 @@ describe('cursor chat meta cache keys', () => {
     const refused = await parseCursor(await cursorCandidate(cursorHome))
     expect(refused.incremental).toBe(1)
 
-    // The poisoned key must force a re-read, but not a full one: the resume
-    // point survives, so the next healthy scan resumes at the stored offset.
+    // Pin the mechanism, not just its effect: the entry is kept under a key no
+    // stat can produce, and it still carries the fold to resume from.
+    const poisoned = getSessionParseCacheEntry(transcriptPath)
+    expect(poisoned?.mtimeMs).toBe(UNMATCHABLE_MTIME_MS)
+    expect(poisoned?.resume).not.toBeNull()
+
+    // So the next healthy scan re-reads, but only the appended bytes.
     failMetaJsonReads = false
     const healed = await parseCursor(await cursorCandidate(cursorHome))
     expect(healed.incremental).toBe(1)

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.ts
@@ -1,0 +1,221 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { basename, dirname, join } from 'node:path'
+import { wslGatedReaddir, wslGatedStat } from '../native-chat/wsl-transcript-fs-access'
+import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
+import { timestampIso } from './session-scanner-accumulator'
+import { extractString, normalizeTitleText, readJsonObjectIfExists } from './session-scanner-values'
+
+// Cursor keeps a chat's transcript and its metadata in two unrelated trees:
+// <cursor>/projects/<slug>/agent-transcripts/<uuid>/<uuid>.jsonl holds the
+// messages, while <cursor>/chats/<md5 of cwd>/<uuid>/meta.json holds the cwd,
+// title and timestamps. The md5 hashes the very cwd we are looking for, so the
+// only way across is an index of the chat directories.
+
+const CURSOR_CHATS_DIR = 'chats'
+const CURSOR_CHAT_META_FILE = 'meta.json'
+const CURSOR_TRANSCRIPTS_DIR = 'agent-transcripts'
+const CURSOR_PROJECTS_DIR = 'projects'
+// Why: custom and WSL Cursor homes can vary over a long-lived main process.
+const CURSOR_CHAT_META_INDEX_CACHE_MAX = 8
+
+export type CursorChatMeta = {
+  title: string | null
+  cwd: string | null
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+type CursorChatMetaIndexEntry = {
+  signature: string
+  metaPathByChatId: Map<string, string>
+}
+
+const cursorChatMetaIndexCache = new Map<string, Promise<CursorChatMetaIndexEntry>>()
+// Why: validating the cache costs a readdir plus a stat per workspace, and
+// discovery asks once per transcript; one scan sees the tree once instead.
+const scanScopedIndex = new AsyncLocalStorage<Map<string, Promise<Map<string, string>>>>()
+
+export function resetCursorChatMetaIndexCacheForTests(): void {
+  cursorChatMetaIndexCache.clear()
+}
+
+/** Runs one discovery scan; every Cursor transcript inside it shares a single validated index read. */
+export function withCursorChatMetaScan<T>(fn: () => Promise<T>): Promise<T> {
+  return scanScopedIndex.run(new Map(), fn)
+}
+
+/** Path a discovery stat can watch so a rewritten meta.json invalidates the parse cache. */
+export async function cursorChatMetaPath(transcriptPath: string): Promise<string | undefined> {
+  const chatsRoot = cursorChatsRootFromTranscriptPath(transcriptPath)
+  const chatId = cursorChatIdFromTranscriptPath(transcriptPath)
+  if (!chatsRoot || !chatId) {
+    return undefined
+  }
+  const index = await readCursorChatMetaIndexOncePerScan(chatsRoot)
+  return index.get(chatId)
+}
+
+function readCursorChatMetaIndexOncePerScan(chatsRoot: string): Promise<Map<string, string>> {
+  const scan = scanScopedIndex.getStore()
+  if (!scan) {
+    return readCursorChatMetaIndex(chatsRoot)
+  }
+  let pending = scan.get(chatsRoot)
+  if (!pending) {
+    pending = readCursorChatMetaIndex(chatsRoot)
+    scan.set(chatsRoot, pending)
+  }
+  return pending
+}
+
+export async function readCursorChatMeta(transcriptPath: string): Promise<CursorChatMeta | null> {
+  const metaPath = await cursorChatMetaPath(transcriptPath)
+  if (!metaPath) {
+    return null
+  }
+  const record = await readJsonObjectIfExists(metaPath)
+  if (!record) {
+    return null
+  }
+  return {
+    title: normalizeTitleText(extractString(record.title) ?? ''),
+    cwd: extractString(record.cwd),
+    createdAt: timestampIso(record.createdAtMs),
+    updatedAt: timestampIso(record.updatedAtMs)
+  }
+}
+
+function cursorChatIdFromTranscriptPath(transcriptPath: string): string | null {
+  const chatDir = dirname(transcriptPath)
+  return basename(dirname(chatDir)) === CURSOR_TRANSCRIPTS_DIR ? basename(chatDir) : null
+}
+
+function cursorChatsRootFromTranscriptPath(transcriptPath: string): string | null {
+  let currentDir = dirname(transcriptPath)
+  while (currentDir && dirname(currentDir) !== currentDir) {
+    // The chats tree is a sibling of the projects tree, custom Cursor homes included.
+    if (basename(currentDir) === CURSOR_PROJECTS_DIR) {
+      return join(dirname(currentDir), CURSOR_CHATS_DIR)
+    }
+    currentDir = dirname(currentDir)
+  }
+  return null
+}
+
+async function readCursorChatMetaIndex(chatsRoot: string): Promise<Map<string, string>> {
+  let workspaceDirs: string[]
+  try {
+    workspaceDirs = (await wslGatedReaddir(chatsRoot, 'scan'))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+  } catch (error) {
+    // Why: a refused WSL read is not "no chats"; letting it through keeps the
+    // session out of the parse cache instead of caching it without metadata.
+    if (error instanceof WslTranscriptFsError) {
+      throw error
+    }
+    return new Map()
+  }
+  const signature = await readCursorChatsSignature(chatsRoot, workspaceDirs)
+  const cached = await readCachedCursorChatMetaIndex(chatsRoot, signature)
+  if (cached) {
+    return cached
+  }
+  const pending = buildCursorChatMetaIndex(chatsRoot, workspaceDirs).then((metaPathByChatId) => ({
+    signature,
+    metaPathByChatId
+  }))
+  storeCursorChatMetaIndexEntry(chatsRoot, pending)
+  // Why: a rejected build (a refused WSL read) must not be served from the
+  // cache forever; the next scan rebuilds while this one still sees the error.
+  pending.catch(() => {
+    if (cursorChatMetaIndexCache.get(chatsRoot) === pending) {
+      cursorChatMetaIndexCache.delete(chatsRoot)
+    }
+  })
+  return (await pending).metaPathByChatId
+}
+
+// Why: a new chat only bumps its own workspace directory, so the chats root's
+// own mtime would keep serving an index that is missing the newest sessions.
+async function readCursorChatsSignature(
+  chatsRoot: string,
+  workspaceDirs: string[]
+): Promise<string> {
+  const parts = await Promise.all(
+    workspaceDirs.map(async (name) => {
+      try {
+        const dirStat = await wslGatedStat(join(chatsRoot, name), 'scan')
+        return `${name}:${dirStat.mtimeMs}`
+      } catch {
+        return `${name}:?`
+      }
+    })
+  )
+  return parts.join('|')
+}
+
+async function buildCursorChatMetaIndex(
+  chatsRoot: string,
+  workspaceDirs: string[]
+): Promise<Map<string, string>> {
+  const metaPathByChatId = new Map<string, string>()
+  for (const workspaceDir of workspaceDirs) {
+    let chatDirs
+    try {
+      chatDirs = await wslGatedReaddir(join(chatsRoot, workspaceDir), 'scan')
+    } catch (error) {
+      if (error instanceof WslTranscriptFsError) {
+        throw error
+      }
+      continue
+    }
+    for (const chatDir of chatDirs) {
+      // Why: the same chat id never appears under two workspace hashes, so the
+      // first hit wins and a duplicate would only cost a wasted read.
+      if (chatDir.isDirectory() && !metaPathByChatId.has(chatDir.name)) {
+        metaPathByChatId.set(
+          chatDir.name,
+          join(chatsRoot, workspaceDir, chatDir.name, CURSOR_CHAT_META_FILE)
+        )
+      }
+    }
+  }
+  return metaPathByChatId
+}
+
+async function readCachedCursorChatMetaIndex(
+  chatsRoot: string,
+  signature: string
+): Promise<Map<string, string> | undefined> {
+  const cached = cursorChatMetaIndexCache.get(chatsRoot)
+  if (!cached) {
+    return undefined
+  }
+  const entry = await cached
+  if (entry.signature !== signature) {
+    return undefined
+  }
+  // Why: a concurrent scan can replace this Promise while it resolves; only the
+  // still-current entry may refresh recency without bypassing the cap.
+  if (cursorChatMetaIndexCache.get(chatsRoot) === cached) {
+    cursorChatMetaIndexCache.delete(chatsRoot)
+    cursorChatMetaIndexCache.set(chatsRoot, cached)
+  }
+  return entry.metaPathByChatId
+}
+
+function storeCursorChatMetaIndexEntry(
+  chatsRoot: string,
+  pending: Promise<CursorChatMetaIndexEntry>
+): void {
+  cursorChatMetaIndexCache.delete(chatsRoot)
+  cursorChatMetaIndexCache.set(chatsRoot, pending)
+  if (cursorChatMetaIndexCache.size > CURSOR_CHAT_META_INDEX_CACHE_MAX) {
+    const oldest = cursorChatMetaIndexCache.keys().next()
+    if (!oldest.done) {
+      cursorChatMetaIndexCache.delete(oldest.value)
+    }
+  }
+}

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.ts
@@ -31,17 +31,32 @@ type CursorChatMetaIndexEntry = {
 }
 
 const cursorChatMetaIndexCache = new Map<string, Promise<CursorChatMetaIndexEntry>>()
-// Why: validating the cache costs a readdir plus a stat per workspace, and
-// discovery asks once per transcript; one scan sees the tree once instead.
-const scanScopedIndex = new AsyncLocalStorage<Map<string, Promise<Map<string, string>>>>()
+
+type CursorChatMetaScan = {
+  index: Map<string, Promise<Map<string, string>>>
+  // Chats roots this scan could not read, reported once by the scan owner.
+  refusals: Map<string, string>
+}
+
+// Why: validating the module cache costs a readdir of the chats root plus a stat
+// per workspace, and it cannot be skipped because the signature is built from
+// those stats. Discovery asks once per transcript and finalize asks again, so
+// the scope has to span both phases for one scan to see the tree once.
+const scanScopedIndex = new AsyncLocalStorage<CursorChatMetaScan>()
 
 export function resetCursorChatMetaIndexCacheForTests(): void {
   cursorChatMetaIndexCache.clear()
 }
 
-/** Runs one discovery scan; every Cursor transcript inside it shares a single validated index read. */
+/** Runs one whole scan, discovery and parse; every Cursor transcript in it shares one index read. */
 export function withCursorChatMetaScan<T>(fn: () => Promise<T>): Promise<T> {
-  return scanScopedIndex.run(new Map(), fn)
+  return scanScopedIndex.run({ index: new Map(), refusals: new Map() }, fn)
+}
+
+/** Chats roots the current scan was refused, for the caller to report as scan issues. */
+export function cursorChatMetaRefusals(): { chatsRoot: string; message: string }[] {
+  const scan = scanScopedIndex.getStore()
+  return scan ? [...scan.refusals].map(([chatsRoot, message]) => ({ chatsRoot, message })) : []
 }
 
 /** Path a discovery stat can watch so a rewritten meta.json invalidates the parse cache. */
@@ -58,14 +73,41 @@ export async function cursorChatMetaPath(transcriptPath: string): Promise<string
 function readCursorChatMetaIndexOncePerScan(chatsRoot: string): Promise<Map<string, string>> {
   const scan = scanScopedIndex.getStore()
   if (!scan) {
-    return readCursorChatMetaIndex(chatsRoot)
+    return readCursorChatMetaIndexOrNone(chatsRoot)
   }
-  let pending = scan.get(chatsRoot)
+  let pending = scan.index.get(chatsRoot)
   if (!pending) {
-    pending = readCursorChatMetaIndex(chatsRoot)
-    scan.set(chatsRoot, pending)
+    pending = readCursorChatMetaIndexOrNone(chatsRoot)
+    scan.index.set(chatsRoot, pending)
   }
   return pending
+}
+
+/**
+ * A refused WSL read is not "no chats", but it must not take the transcript
+ * down with it: before this join a stalled distro could not hide a Cursor
+ * session at all. Degrade to no metadata for the scan and report the root once.
+ * The cache stays honest without the throw, because discovery then stats no
+ * meta.json, so the entry's recorded size omits it and the next healthy scan
+ * sees a changed file and re-reads it.
+ */
+async function readCursorChatMetaIndexOrNone(chatsRoot: string): Promise<Map<string, string>> {
+  try {
+    return await readCursorChatMetaIndex(chatsRoot)
+  } catch (error) {
+    if (!(error instanceof WslTranscriptFsError)) {
+      throw error
+    }
+    recordCursorChatMetaRefusal(chatsRoot, error.message)
+    return new Map()
+  }
+}
+
+function recordCursorChatMetaRefusal(chatsRoot: string, message: string): void {
+  const scan = scanScopedIndex.getStore()
+  if (scan && !scan.refusals.has(chatsRoot)) {
+    scan.refusals.set(chatsRoot, message)
+  }
 }
 
 export async function readCursorChatMeta(transcriptPath: string): Promise<CursorChatMeta | null> {
@@ -73,7 +115,20 @@ export async function readCursorChatMeta(transcriptPath: string): Promise<Cursor
   if (!metaPath) {
     return null
   }
-  const record = await readJsonObjectIfExists(metaPath)
+  let record: Record<string, unknown> | null
+  try {
+    record = await readJsonObjectIfExists(metaPath)
+  } catch (error) {
+    if (!(error instanceof WslTranscriptFsError)) {
+      throw error
+    }
+    // Same trade as the index read: enrichment never costs the session itself.
+    recordCursorChatMetaRefusal(
+      cursorChatsRootFromTranscriptPath(transcriptPath) ?? metaPath,
+      error.message
+    )
+    return null
+  }
   if (!record) {
     return null
   }

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.ts
@@ -36,8 +36,8 @@ type CursorChatMetaScan = {
   index: Map<string, Promise<Map<string, string>>>
   // Chats roots this scan could not read, reported once by the scan owner.
   refusals: Map<string, string>
-  // Transcripts whose own meta.json read was refused after discovery had
-  // already folded that file's stat into their parse-cache key.
+  // Transcripts whose own meta.json read was refused, so the metadata merged
+  // onto them is not what the file on disk says.
   refusedTranscripts: Set<string>
 }
 
@@ -60,10 +60,9 @@ export function withCursorChatMetaScan<T>(fn: () => Promise<T>): Promise<T> {
 }
 
 /**
- * True when this transcript's own meta.json read was refused. Discovery had
- * already stat'd that file into the candidate's cache key, so caching the
- * un-enriched parse would leave it looking unchanged until Cursor rewrites
- * meta.json. The parse is used and then not cached.
+ * True when this transcript's own meta.json read was refused, so the caller
+ * records the sidecar as unknown rather than as the observation discovery made.
+ * The transcript's own work and its resume point are kept either way.
  */
 export function wasCursorChatMetaRefused(transcriptPath: string): boolean {
   return scanScopedIndex.getStore()?.refusedTranscripts.has(transcriptPath) ?? false
@@ -103,9 +102,9 @@ function readCursorChatMetaIndexOncePerScan(chatsRoot: string): Promise<Map<stri
  * A refused WSL read is not "no chats", but it must not take the transcript
  * down with it: before this join a stalled distro could not hide a Cursor
  * session at all. Degrade to no metadata for the scan and report the root once.
- * The cache stays honest without the throw, because discovery then stats no
- * meta.json, so the entry's recorded size omits it and the next healthy scan
- * sees a changed file and re-reads it.
+ * The session still lists from its transcript alone, and the sidecar is
+ * recorded as unknown, so the next healthy scan merges the real metadata in
+ * without re-reading a byte of the transcript.
  */
 async function readCursorChatMetaIndexOrNone(chatsRoot: string): Promise<Map<string, string>> {
   try {

--- a/src/main/ai-vault/session-scanner-cursor-chat-meta.ts
+++ b/src/main/ai-vault/session-scanner-cursor-chat-meta.ts
@@ -36,6 +36,9 @@ type CursorChatMetaScan = {
   index: Map<string, Promise<Map<string, string>>>
   // Chats roots this scan could not read, reported once by the scan owner.
   refusals: Map<string, string>
+  // Transcripts whose own meta.json read was refused after discovery had
+  // already folded that file's stat into their parse-cache key.
+  refusedTranscripts: Set<string>
 }
 
 // Why: validating the module cache costs a readdir of the chats root plus a stat
@@ -50,7 +53,20 @@ export function resetCursorChatMetaIndexCacheForTests(): void {
 
 /** Runs one whole scan, discovery and parse; every Cursor transcript in it shares one index read. */
 export function withCursorChatMetaScan<T>(fn: () => Promise<T>): Promise<T> {
-  return scanScopedIndex.run({ index: new Map(), refusals: new Map() }, fn)
+  return scanScopedIndex.run(
+    { index: new Map(), refusals: new Map(), refusedTranscripts: new Set() },
+    fn
+  )
+}
+
+/**
+ * True when this transcript's own meta.json read was refused. Discovery had
+ * already stat'd that file into the candidate's cache key, so caching the
+ * un-enriched parse would leave it looking unchanged until Cursor rewrites
+ * meta.json. The parse is used and then not cached.
+ */
+export function wasCursorChatMetaRefused(transcriptPath: string): boolean {
+  return scanScopedIndex.getStore()?.refusedTranscripts.has(transcriptPath) ?? false
 }
 
 /** Chats roots the current scan was refused, for the caller to report as scan issues. */
@@ -122,11 +138,14 @@ export async function readCursorChatMeta(transcriptPath: string): Promise<Cursor
     if (!(error instanceof WslTranscriptFsError)) {
       throw error
     }
-    // Same trade as the index read: enrichment never costs the session itself.
+    // The session still lists, but unlike the index read this transcript's key
+    // already includes meta.json's stat, so the caller must not cache the
+    // un-enriched result. One issue per chats root, as for a refused index.
     recordCursorChatMetaRefusal(
       cursorChatsRootFromTranscriptPath(transcriptPath) ?? metaPath,
       error.message
     )
+    scanScopedIndex.getStore()?.refusedTranscripts.add(transcriptPath)
     return null
   }
   if (!record) {

--- a/src/main/ai-vault/session-scanner-cursor-parser.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.ts
@@ -8,6 +8,7 @@ import type {
   ResumableSessionParseState,
   SessionAccumulator
 } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   accumulatorFoldResumeState,
   addPreviewContent,
@@ -22,6 +23,7 @@ import {
   extractString,
   parseJsonObject
 } from './session-scanner-values'
+import { readCursorChatMeta } from './session-scanner-cursor-chat-meta'
 
 type ParserSessionOptions = {
   executionHostId?: ExecutionHostId
@@ -30,13 +32,14 @@ type ParserSessionOptions = {
 
 export async function parseCursorSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const lines = createInterface({
     input: openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan'),
     crlfDelay: Infinity
   })
-  return parseCursorSessionLines({ file, lines, platform })
+  return parseCursorSessionLines({ file, lines, platform, messages })
 }
 
 export async function parseCursorSessionContent(
@@ -50,7 +53,8 @@ export async function parseCursorSessionContent(
     file,
     lines: remoteSessionContentLines(content, signal),
     platform,
-    options
+    options,
+    enrichFromChatMeta: false
   })
 }
 
@@ -75,11 +79,40 @@ function consumeCursorRecordLine(accumulator: SessionAccumulator, line: string):
   }
 }
 
-export function createCursorSessionResumeState(file: FileWithMtime): ResumableSessionParseState {
+export function createCursorSessionResumeState(
+  file: FileWithMtime,
+  // Remote hosts stream transcript content only, with no sibling meta.json to read.
+  enrichFromChatMeta = true,
+  messages?: TranscriptMessageSink
+): ResumableSessionParseState {
   return accumulatorFoldResumeState(
-    createAccumulator({ agent: 'cursor', file, sessionId: sessionIdFromFileName(file.path) }),
-    consumeCursorRecordLine
+    createAccumulator({
+      agent: 'cursor',
+      file,
+      sessionId: sessionIdFromFileName(file.path),
+      messages
+    }),
+    consumeCursorRecordLine,
+    enrichFromChatMeta ? (accumulator) => applyCursorChatMeta(accumulator, file.path) : undefined
   )
+}
+
+/** Fills only what the transcript never recorded; its own records always win. */
+async function applyCursorChatMeta(
+  accumulator: SessionAccumulator,
+  transcriptPath: string
+): Promise<void> {
+  if (accumulator.cwd && accumulator.createdAt && accumulator.updatedAt && accumulator.title) {
+    return
+  }
+  const meta = await readCursorChatMeta(transcriptPath)
+  if (!meta) {
+    return
+  }
+  accumulator.title ??= meta.title
+  accumulator.cwd ??= meta.cwd
+  accumulator.createdAt ??= meta.createdAt
+  accumulator.updatedAt ??= meta.updatedAt
 }
 
 async function parseCursorSessionLines(args: {
@@ -87,8 +120,14 @@ async function parseCursorSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
+  enrichFromChatMeta?: boolean
+  messages?: TranscriptMessageSink
 }): Promise<AiVaultSession | null> {
-  const state = createCursorSessionResumeState(args.file)
+  const state = createCursorSessionResumeState(
+    args.file,
+    args.enrichFromChatMeta ?? true,
+    args.messages
+  )
   for await (const line of args.lines) {
     state.consumeLine(line)
   }

--- a/src/main/ai-vault/session-scanner-cursor-parser.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.ts
@@ -23,7 +23,6 @@ import {
   extractString,
   parseJsonObject
 } from './session-scanner-values'
-import { readCursorChatMeta, wasCursorChatMetaRefused } from './session-scanner-cursor-chat-meta'
 
 type ParserSessionOptions = {
   executionHostId?: ExecutionHostId
@@ -53,8 +52,7 @@ export async function parseCursorSessionContent(
     file,
     lines: remoteSessionContentLines(content, signal),
     platform,
-    options,
-    enrichFromChatMeta: false
+    options
   })
 }
 
@@ -81,8 +79,6 @@ function consumeCursorRecordLine(accumulator: SessionAccumulator, line: string):
 
 export function createCursorSessionResumeState(
   file: FileWithMtime,
-  // Remote hosts stream transcript content only, with no sibling meta.json to read.
-  enrichFromChatMeta = true,
   messages?: TranscriptMessageSink
 ): ResumableSessionParseState {
   return accumulatorFoldResumeState(
@@ -92,27 +88,8 @@ export function createCursorSessionResumeState(
       sessionId: sessionIdFromFileName(file.path),
       messages
     }),
-    consumeCursorRecordLine,
-    enrichFromChatMeta ? (accumulator) => applyCursorChatMeta(accumulator, file.path) : undefined
+    consumeCursorRecordLine
   )
-}
-
-/** Fills only what the transcript never recorded; its own records always win. */
-async function applyCursorChatMeta(
-  accumulator: SessionAccumulator,
-  transcriptPath: string
-): Promise<'refused' | void> {
-  if (accumulator.cwd && accumulator.createdAt && accumulator.updatedAt && accumulator.title) {
-    return
-  }
-  const meta = await readCursorChatMeta(transcriptPath)
-  if (!meta) {
-    return wasCursorChatMetaRefused(transcriptPath) ? 'refused' : undefined
-  }
-  accumulator.title ??= meta.title
-  accumulator.cwd ??= meta.cwd
-  accumulator.createdAt ??= meta.createdAt
-  accumulator.updatedAt ??= meta.updatedAt
 }
 
 async function parseCursorSessionLines(args: {
@@ -120,14 +97,9 @@ async function parseCursorSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
-  enrichFromChatMeta?: boolean
   messages?: TranscriptMessageSink
 }): Promise<AiVaultSession | null> {
-  const state = createCursorSessionResumeState(
-    args.file,
-    args.enrichFromChatMeta ?? true,
-    args.messages
-  )
+  const state = createCursorSessionResumeState(args.file, args.messages)
   for await (const line of args.lines) {
     state.consumeLine(line)
   }

--- a/src/main/ai-vault/session-scanner-cursor-parser.ts
+++ b/src/main/ai-vault/session-scanner-cursor-parser.ts
@@ -23,7 +23,7 @@ import {
   extractString,
   parseJsonObject
 } from './session-scanner-values'
-import { readCursorChatMeta } from './session-scanner-cursor-chat-meta'
+import { readCursorChatMeta, wasCursorChatMetaRefused } from './session-scanner-cursor-chat-meta'
 
 type ParserSessionOptions = {
   executionHostId?: ExecutionHostId
@@ -101,13 +101,13 @@ export function createCursorSessionResumeState(
 async function applyCursorChatMeta(
   accumulator: SessionAccumulator,
   transcriptPath: string
-): Promise<void> {
+): Promise<'refused' | void> {
   if (accumulator.cwd && accumulator.createdAt && accumulator.updatedAt && accumulator.title) {
     return
   }
   const meta = await readCursorChatMeta(transcriptPath)
   if (!meta) {
-    return
+    return wasCursorChatMetaRefused(transcriptPath) ? 'refused' : undefined
   }
   accumulator.title ??= meta.title
   accumulator.cwd ??= meta.cwd

--- a/src/main/ai-vault/session-scanner-devin-parser.ts
+++ b/src/main/ai-vault/session-scanner-devin-parser.ts
@@ -29,24 +29,30 @@ export async function parseDevinSessionFile(
   platform: NodeJS.Platform = process.platform,
   messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
-  return parseDevinSessionContent(
+  return parseDevinSessionRecord(
     file,
     await wslGatedReadFile(file.path, 'utf-8', 'scan'),
     platform,
     {},
-    undefined,
     messages
   )
 }
 
-/** Remote content parses have no reader attached; the sink stays undefined. */
-
+/** Remote transcript content, streamed from a host that has no reader attached. */
 export function parseDevinSessionContent(
   file: FileWithMtime,
   content: string,
   platform: NodeJS.Platform = process.platform,
-  options: ParserSessionOptions = {},
-  _signal?: AbortSignal,
+  options: ParserSessionOptions = {}
+): AiVaultSession | null {
+  return parseDevinSessionRecord(file, content, platform, options)
+}
+
+function parseDevinSessionRecord(
+  file: FileWithMtime,
+  content: string,
+  platform: NodeJS.Platform,
+  options: ParserSessionOptions,
   messages?: TranscriptMessageSink
 ): AiVaultSession | null {
   const record = asRecord(JSON.parse(content) as unknown)

--- a/src/main/ai-vault/session-scanner-devin-parser.ts
+++ b/src/main/ai-vault/session-scanner-devin-parser.ts
@@ -2,6 +2,7 @@ import { wslGatedReadFile } from '../native-chat/wsl-transcript-fs-access'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import type { FileWithMtime } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   addPreviewContent,
   createAccumulator,
@@ -25,20 +26,28 @@ type ParserSessionOptions = {
 
 export async function parseDevinSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   return parseDevinSessionContent(
     file,
     await wslGatedReadFile(file.path, 'utf-8', 'scan'),
-    platform
+    platform,
+    {},
+    undefined,
+    messages
   )
 }
+
+/** Remote content parses have no reader attached; the sink stays undefined. */
 
 export function parseDevinSessionContent(
   file: FileWithMtime,
   content: string,
   platform: NodeJS.Platform = process.platform,
-  options: ParserSessionOptions = {}
+  options: ParserSessionOptions = {},
+  _signal?: AbortSignal,
+  messages?: TranscriptMessageSink
 ): AiVaultSession | null {
   const record = asRecord(JSON.parse(content) as unknown)
   if (!record) {
@@ -48,7 +57,7 @@ export function parseDevinSessionContent(
     extractString(record.session_id) ??
     extractString(record.sessionId) ??
     sessionIdFromFileName(file.path)
-  const accumulator = createAccumulator({ agent: 'devin', file, sessionId })
+  const accumulator = createAccumulator({ agent: 'devin', file, sessionId, messages })
   const agentRecord = asRecord(record.agent)
   accumulator.model =
     extractString(agentRecord?.model_name) ??

--- a/src/main/ai-vault/session-scanner-discovery.ts
+++ b/src/main/ai-vault/session-scanner-discovery.ts
@@ -1,10 +1,11 @@
 import type { Dirent } from 'node:fs'
 import { extname, join } from 'node:path'
+import { SessionNewestFiles } from './session-newest-files'
 import type { AiVaultAgent, AiVaultScanIssue } from '../../shared/ai-vault-types'
 import { wslGatedReaddir, wslGatedStat } from '../native-chat/wsl-transcript-fs-access'
 import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
 import { recordSessionScanIssue } from './session-scan-issues'
-import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
+import type { SessionFileDiscovery } from './session-scanner-types'
 import { errorMessage } from './session-scanner-values'
 
 export async function discoverFiles(args: {
@@ -14,16 +15,45 @@ export async function discoverFiles(args: {
   issues: AiVaultScanIssue[]
   extensions: string[]
   filePredicate?: (path: string) => boolean
-  contentDependencyPath?: (path: string) => string
+  contentDependencyPath?: (path: string) => string | undefined | Promise<string | undefined>
   directoryPredicate?: (name: string, depth: number) => boolean
 }): Promise<SessionFileDiscovery> {
-  let paths: string[]
+  const files = new SessionNewestFiles(args.limit)
   try {
-    paths = await walkSessionFiles(args.rootDir, args.agent, args.issues, {
-      extensions: new Set(args.extensions),
-      filePredicate: args.filePredicate,
-      directoryPredicate: args.directoryPredicate
-    })
+    await forEachSessionFile(
+      args.rootDir,
+      args.agent,
+      args.issues,
+      {
+        extensions: new Set(args.extensions),
+        filePredicate: args.filePredicate,
+        directoryPredicate: args.directoryPredicate
+      },
+      async (path) => {
+        try {
+          const fileStat = await wslGatedStat(path, 'scan')
+          const dependencyStat = await optionalContentDependencyStat(
+            await args.contentDependencyPath?.(path)
+          )
+          const mtimeMs = Math.max(fileStat.mtimeMs, dependencyStat?.mtimeMs ?? 0)
+          files.add({
+            path,
+            mtimeMs,
+            modifiedAt: new Date(mtimeMs).toISOString(),
+            sizeBytes: fileStat.size + (dependencyStat?.size ?? 0),
+            dev: fileStat.dev,
+            ino: fileStat.ino,
+            nlink: fileStat.nlink
+          })
+        } catch (err) {
+          recordSessionScanIssue(args.issues, {
+            agent: args.agent,
+            path,
+            message: errorMessage(err)
+          })
+        }
+      }
+    )
   } catch (err) {
     // Why: discoverAiVaultSessionSources fans out with Promise.all, so one
     // stalled distro would otherwise reject the whole vault scan — including
@@ -38,34 +68,7 @@ export async function discoverFiles(args: {
     })
     return { agent: args.agent, rootDir: args.rootDir, files: [] }
   }
-  const files: FileWithMtime[] = []
-  for (const path of paths) {
-    try {
-      const fileStat = await wslGatedStat(path, 'scan')
-      const dependencyStat = await optionalContentDependencyStat(args.contentDependencyPath?.(path))
-      const mtimeMs = Math.max(fileStat.mtimeMs, dependencyStat?.mtimeMs ?? 0)
-      files.push({
-        path,
-        mtimeMs,
-        modifiedAt: new Date(mtimeMs).toISOString(),
-        sizeBytes: fileStat.size + (dependencyStat?.size ?? 0),
-        dev: fileStat.dev,
-        ino: fileStat.ino,
-        nlink: fileStat.nlink
-      })
-    } catch (err) {
-      recordSessionScanIssue(args.issues, {
-        agent: args.agent,
-        path,
-        message: errorMessage(err)
-      })
-    }
-  }
-  return {
-    agent: args.agent,
-    rootDir: args.rootDir,
-    files: files.sort((left, right) => right.mtimeMs - left.mtimeMs).slice(0, args.limit)
-  }
+  return { agent: args.agent, rootDir: args.rootDir, files: files.newest() }
 }
 
 async function optionalContentDependencyStat(
@@ -85,21 +88,39 @@ async function optionalContentDependencyStat(
   }
 }
 
+export type SessionFileWalkOptions = {
+  extensions: Set<string>
+  filePredicate?: (path: string) => boolean
+  // Return false to skip descending into a directory; depth 0 is a child of
+  // rootDir, so pruned subtrees are never stat'd or parsed.
+  directoryPredicate?: (name: string, depth: number) => boolean
+  readDirectory?: (dirPath: string) => Promise<Dirent[]>
+  signal?: AbortSignal
+}
+
+/** Collecting form for callers that want every match; bounded scans stream. */
 export async function walkSessionFiles(
   dirPath: string,
   agent: AiVaultAgent,
   issues: AiVaultScanIssue[],
-  options: {
-    extensions: Set<string>
-    filePredicate?: (path: string) => boolean
-    // Return false to skip descending into a directory; depth 0 is a child of
-    // rootDir, so pruned subtrees are never stat'd or parsed.
-    directoryPredicate?: (name: string, depth: number) => boolean
-    readDirectory?: (dirPath: string) => Promise<Dirent[]>
-    signal?: AbortSignal
-  },
-  depth = 0
+  options: SessionFileWalkOptions
 ): Promise<string[]> {
+  const files: string[] = []
+  await forEachSessionFile(dirPath, agent, issues, options, async (path) => {
+    files.push(path)
+  })
+  return files
+}
+
+/** Streams matches to `onFile` so a bounded consumer never retains the whole tree. */
+export async function forEachSessionFile(
+  dirPath: string,
+  agent: AiVaultAgent,
+  issues: AiVaultScanIssue[],
+  options: SessionFileWalkOptions,
+  onFile: (path: string) => Promise<void>,
+  depth = 0
+): Promise<void> {
   options.signal?.throwIfAborted()
   let entries
   try {
@@ -113,10 +134,9 @@ export async function walkSessionFiles(
     if (error instanceof WslTranscriptFsError) {
       throw error
     }
-    return []
+    return
   }
 
-  const files: string[] = []
   for (const entry of entries) {
     options.signal?.throwIfAborted()
     const fullPath = join(dirPath, entry.name)
@@ -124,7 +144,7 @@ export async function walkSessionFiles(
       // Skip whole subtrees an agent never wants (e.g. subagent transcripts),
       // avoiding the readdir cost of descending into them.
       if (options.directoryPredicate?.(entry.name, depth) ?? true) {
-        files.push(...(await walkSessionFiles(fullPath, agent, issues, options, depth + 1)))
+        await forEachSessionFile(fullPath, agent, issues, options, onFile, depth + 1)
       }
       continue
     }
@@ -133,8 +153,7 @@ export async function walkSessionFiles(
       options.extensions.has(extname(entry.name).toLowerCase()) &&
       (options.filePredicate?.(fullPath) ?? true)
     ) {
-      files.push(fullPath)
+      await onFile(fullPath)
     }
   }
-  return files
 }

--- a/src/main/ai-vault/session-scanner-discovery.ts
+++ b/src/main/ai-vault/session-scanner-discovery.ts
@@ -19,6 +19,7 @@ export async function discoverFiles(args: {
   directoryPredicate?: (name: string, depth: number) => boolean
 }): Promise<SessionFileDiscovery> {
   const files = new SessionNewestFiles(args.limit)
+  let refusedDependency = false
   try {
     await forEachSessionFile(
       args.rootDir,
@@ -32,15 +33,27 @@ export async function discoverFiles(args: {
       async (path) => {
         try {
           const fileStat = await wslGatedStat(path, 'scan')
-          const dependencyStat = await optionalContentDependencyStat(
-            await args.contentDependencyPath?.(path)
-          )
-          const mtimeMs = Math.max(fileStat.mtimeMs, dependencyStat?.mtimeMs ?? 0)
+          const dependencyPath = await args.contentDependencyPath?.(path)
+          const dependencyStat = await optionalContentDependencyStat(dependencyPath)
+          if (dependencyStat === 'refused' && !refusedDependency) {
+            // One issue per root: a refused sibling is a property of the tree,
+            // not of each transcript that happens to point at it.
+            refusedDependency = true
+            recordSessionScanIssue(args.issues, {
+              agent: args.agent,
+              path: dependencyPath ?? args.rootDir,
+              message: 'Session metadata could not be read this scan.'
+            })
+          }
+          const dependency = dependencyStat === 'refused' ? null : dependencyStat
+          const mtimeMs = Math.max(fileStat.mtimeMs, dependency?.mtimeMs ?? 0)
           files.add({
             path,
             mtimeMs,
             modifiedAt: new Date(mtimeMs).toISOString(),
-            sizeBytes: fileStat.size + (dependencyStat?.size ?? 0),
+            sizeBytes: fileStat.size + (dependency?.size ?? 0),
+            dependencySizeBytes: dependency?.size,
+            ...(dependencyStat === 'refused' ? { contentDependencyRefused: true } : {}),
             dev: fileStat.dev,
             ino: fileStat.ino,
             nlink: fileStat.nlink
@@ -71,9 +84,15 @@ export async function discoverFiles(args: {
   return { agent: args.agent, rootDir: args.rootDir, files: files.newest() }
 }
 
+/**
+ * A refused sibling stat is not "no sibling": it must not take the transcript
+ * down with it, and it must not silently produce a cache key that omits the
+ * sibling and then looks current forever. Report it as `refused` so the caller
+ * lists the file, notes the tree once, and marks the key untrustworthy.
+ */
 async function optionalContentDependencyStat(
   filePath: string | undefined
-): Promise<{ mtimeMs: number; size: number } | null> {
+): Promise<{ mtimeMs: number; size: number } | 'refused' | null> {
   if (!filePath) {
     return null
   }
@@ -82,7 +101,7 @@ async function optionalContentDependencyStat(
     return { mtimeMs: fileStat.mtimeMs, size: fileStat.size }
   } catch (error) {
     if (error instanceof WslTranscriptFsError) {
-      throw error
+      return 'refused'
     }
     return null
   }

--- a/src/main/ai-vault/session-scanner-discovery.ts
+++ b/src/main/ai-vault/session-scanner-discovery.ts
@@ -1,6 +1,7 @@
 import type { Dirent } from 'node:fs'
 import { extname, join } from 'node:path'
 import { SessionNewestFiles } from './session-newest-files'
+import type { SessionSidecarObservation } from './session-sidecar-stat'
 import type { AiVaultAgent, AiVaultScanIssue } from '../../shared/ai-vault-types'
 import { wslGatedReaddir, wslGatedStat } from '../native-chat/wsl-transcript-fs-access'
 import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
@@ -19,7 +20,7 @@ export async function discoverFiles(args: {
   directoryPredicate?: (name: string, depth: number) => boolean
 }): Promise<SessionFileDiscovery> {
   const files = new SessionNewestFiles(args.limit)
-  let refusedDependency = false
+  let refusedSidecar = false
   try {
     await forEachSessionFile(
       args.rootDir,
@@ -33,27 +34,24 @@ export async function discoverFiles(args: {
       async (path) => {
         try {
           const fileStat = await wslGatedStat(path, 'scan')
-          const dependencyPath = await args.contentDependencyPath?.(path)
-          const dependencyStat = await optionalContentDependencyStat(dependencyPath)
-          if (dependencyStat === 'refused' && !refusedDependency) {
+          const sidecarPath = await args.contentDependencyPath?.(path)
+          const sidecar = await observeSessionSidecar(sidecarPath)
+          if (sidecar === 'unknown' && !refusedSidecar) {
             // One issue per root: a refused sibling is a property of the tree,
             // not of each transcript that happens to point at it.
-            refusedDependency = true
+            refusedSidecar = true
             recordSessionScanIssue(args.issues, {
               agent: args.agent,
-              path: dependencyPath ?? args.rootDir,
+              path: sidecarPath ?? args.rootDir,
               message: 'Session metadata could not be read this scan.'
             })
           }
-          const dependency = dependencyStat === 'refused' ? null : dependencyStat
-          const mtimeMs = Math.max(fileStat.mtimeMs, dependency?.mtimeMs ?? 0)
           files.add({
             path,
-            mtimeMs,
-            modifiedAt: new Date(mtimeMs).toISOString(),
-            sizeBytes: fileStat.size + (dependency?.size ?? 0),
-            dependencySizeBytes: dependency?.size,
-            ...(dependencyStat === 'refused' ? { contentDependencyRefused: true } : {}),
+            mtimeMs: fileStat.mtimeMs,
+            modifiedAt: new Date(fileStat.mtimeMs).toISOString(),
+            sizeBytes: fileStat.size,
+            sidecar,
             dev: fileStat.dev,
             ino: fileStat.ino,
             nlink: fileStat.nlink
@@ -86,24 +84,20 @@ export async function discoverFiles(args: {
 
 /**
  * A refused sibling stat is not "no sibling": it must not take the transcript
- * down with it, and it must not silently produce a cache key that omits the
- * sibling and then looks current forever. Report it as `refused` so the caller
- * lists the file, notes the tree once, and marks the key untrustworthy.
+ * down with it, and it must not read as absent either, or the parse cache would
+ * treat the session as current forever. Report it as `unknown`.
  */
-async function optionalContentDependencyStat(
+async function observeSessionSidecar(
   filePath: string | undefined
-): Promise<{ mtimeMs: number; size: number } | 'refused' | null> {
+): Promise<SessionSidecarObservation> {
   if (!filePath) {
-    return null
+    return 'none'
   }
   try {
     const fileStat = await wslGatedStat(filePath, 'scan')
-    return { mtimeMs: fileStat.mtimeMs, size: fileStat.size }
+    return { path: filePath, mtimeMs: fileStat.mtimeMs, sizeBytes: fileStat.size }
   } catch (error) {
-    if (error instanceof WslTranscriptFsError) {
-      return 'refused'
-    }
-    return null
+    return error instanceof WslTranscriptFsError ? 'unknown' : 'none'
   }
 }
 

--- a/src/main/ai-vault/session-scanner-discovery.ts
+++ b/src/main/ai-vault/session-scanner-discovery.ts
@@ -83,9 +83,11 @@ export async function discoverFiles(args: {
 }
 
 /**
- * A refused sibling stat is not "no sibling": it must not take the transcript
- * down with it, and it must not read as absent either, or the parse cache would
- * treat the session as current forever. Report it as `unknown`.
+ * A sibling that cannot be statted is not "no sibling": it must not take the
+ * transcript down with it, and it must not read as absent either, or the parse
+ * cache would treat a session enriched from a file nobody can see as current
+ * forever. Only a genuinely missing path is `'none'`; every other failure —
+ * a stalled WSL distro, EACCES, EIO — is `'unknown'`.
  */
 async function observeSessionSidecar(
   filePath: string | undefined
@@ -97,8 +99,19 @@ async function observeSessionSidecar(
     const fileStat = await wslGatedStat(filePath, 'scan')
     return { path: filePath, mtimeMs: fileStat.mtimeMs, sizeBytes: fileStat.size }
   } catch (error) {
-    return error instanceof WslTranscriptFsError ? 'unknown' : 'none'
+    return isMissingSidecarError(error) ? 'none' : 'unknown'
   }
+}
+
+function isMissingSidecarError(error: unknown): boolean {
+  if (error instanceof WslTranscriptFsError) {
+    return false
+  }
+  const code =
+    error && typeof error === 'object' && 'code' in error && typeof error.code === 'string'
+      ? error.code
+      : null
+  return code === 'ENOENT' || code === 'ENOTDIR'
 }
 
 export type SessionFileWalkOptions = {

--- a/src/main/ai-vault/session-scanner-droid-parser.ts
+++ b/src/main/ai-vault/session-scanner-droid-parser.ts
@@ -8,6 +8,7 @@ import type {
   ResumableSessionParseState,
   SessionAccumulator
 } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   accumulatorFoldResumeState,
   addPreviewMessage,
@@ -32,12 +33,13 @@ type ParserSessionOptions = {
 
 export async function parseDroidSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const input = openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan')
   const lines = createInterface({ input, crlfDelay: Infinity })
   try {
-    return await parseDroidSessionLines({ file, lines, platform })
+    return await parseDroidSessionLines({ file, lines, platform, messages })
   } finally {
     // readline.close() leaves the underlying stream open; destroy it so a
     // mid-parse throw cannot leak the gated transcript handle.
@@ -94,9 +96,17 @@ function consumeDroidRecordLine(accumulator: SessionAccumulator, line: string): 
   }
 }
 
-export function createDroidSessionResumeState(file: FileWithMtime): ResumableSessionParseState {
+export function createDroidSessionResumeState(
+  file: FileWithMtime,
+  messages?: TranscriptMessageSink
+): ResumableSessionParseState {
   return accumulatorFoldResumeState(
-    createAccumulator({ agent: 'droid', file, sessionId: sessionIdFromFileName(file.path) }),
+    createAccumulator({
+      agent: 'droid',
+      file,
+      sessionId: sessionIdFromFileName(file.path),
+      messages
+    }),
     consumeDroidRecordLine
   )
 }
@@ -106,8 +116,9 @@ async function parseDroidSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
+  messages?: TranscriptMessageSink
 }): Promise<AiVaultSession | null> {
-  const state = createDroidSessionResumeState(args.file)
+  const state = createDroidSessionResumeState(args.file, args.messages)
   for await (const line of args.lines) {
     state.consumeLine(line)
   }

--- a/src/main/ai-vault/session-scanner-gemini-parsers.ts
+++ b/src/main/ai-vault/session-scanner-gemini-parsers.ts
@@ -8,6 +8,7 @@ import type {
   ResumableSessionParseState,
   SessionAccumulator
 } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   accumulatorFoldResumeState,
   addPreviewContent,
@@ -27,16 +28,19 @@ import {
 
 export async function parseGeminiSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   if (file.path.endsWith('.jsonl')) {
-    return parseGeminiJsonlSessionFile(file, platform)
+    return parseGeminiJsonlSessionFile(file, platform, messages)
   }
 
   return parseGeminiJsonSessionContent(
     file,
     await wslGatedReadFile(file.path, 'utf-8', 'scan'),
-    platform
+    platform,
+    {},
+    messages
   )
 }
 
@@ -62,7 +66,8 @@ function parseGeminiJsonSessionContent(
   file: FileWithMtime,
   content: string,
   platform: NodeJS.Platform,
-  options: ResumableParseFinalizeOptions = {}
+  options: ResumableParseFinalizeOptions = {},
+  messages?: TranscriptMessageSink
 ): AiVaultSession | null {
   const record = asRecord(JSON.parse(content) as unknown)
   if (!record) {
@@ -71,7 +76,8 @@ function parseGeminiJsonSessionContent(
   const accumulator = createAccumulator({
     agent: 'gemini',
     file,
-    sessionId: extractString(record.sessionId) ?? sessionIdFromFileName(file.path)
+    sessionId: extractString(record.sessionId) ?? sessionIdFromFileName(file.path),
+    messages
   })
   updateTimeline(accumulator, extractString(record.startTime))
   updateTimeline(accumulator, extractString(record.lastUpdated))
@@ -83,13 +89,14 @@ function parseGeminiJsonSessionContent(
 
 export async function parseGeminiJsonlSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const lines = createInterface({
     input: openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan'),
     crlfDelay: Infinity
   })
-  return parseGeminiJsonlSessionLines({ file, lines, platform })
+  return parseGeminiJsonlSessionLines({ file, lines, platform, messages })
 }
 
 function consumeGeminiJsonlRecordLine(accumulator: SessionAccumulator, line: string): void {
@@ -114,10 +121,16 @@ function consumeGeminiJsonlRecordLine(accumulator: SessionAccumulator, line: str
 // Resumable only for the JSONL log format; Gemini's legacy single-JSON
 // session documents are rewritten in place and must be re-read whole.
 export function createGeminiJsonlSessionResumeState(
-  file: FileWithMtime
+  file: FileWithMtime,
+  messages?: TranscriptMessageSink
 ): ResumableSessionParseState {
   return accumulatorFoldResumeState(
-    createAccumulator({ agent: 'gemini', file, sessionId: sessionIdFromFileName(file.path) }),
+    createAccumulator({
+      agent: 'gemini',
+      file,
+      sessionId: sessionIdFromFileName(file.path),
+      messages
+    }),
     consumeGeminiJsonlRecordLine
   )
 }
@@ -127,8 +140,9 @@ async function parseGeminiJsonlSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ResumableParseFinalizeOptions
+  messages?: TranscriptMessageSink
 }): Promise<AiVaultSession | null> {
-  const state = createGeminiJsonlSessionResumeState(args.file)
+  const state = createGeminiJsonlSessionResumeState(args.file, args.messages)
   for await (const line of args.lines) {
     state.consumeLine(line)
   }

--- a/src/main/ai-vault/session-scanner-graph-parsers.ts
+++ b/src/main/ai-vault/session-scanner-graph-parsers.ts
@@ -10,6 +10,7 @@ import type {
   ResumableSessionParseState,
   SessionAccumulator
 } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   accumulatorFoldResumeState,
   addPreviewContent,
@@ -38,7 +39,8 @@ type ParserSessionOptions = {
 
 export async function parseRovoSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const metadata = asRecord(
     JSON.parse(await wslGatedReadFile(file.path, 'utf-8', 'scan')) as unknown
@@ -49,7 +51,8 @@ export async function parseRovoSessionFile(
   const accumulator = createAccumulator({
     agent: 'rovo',
     file,
-    sessionId: basename(dirname(file.path))
+    sessionId: basename(dirname(file.path)),
+    messages
   })
   accumulator.title = firstString(metadata, ['title', 'name', 'summary'])
   accumulator.cwd = firstString(metadata, [
@@ -174,12 +177,13 @@ export type MessageGraphAgent = 'openclaw' | 'pi' | 'omp' | 'prime-agent'
 export async function parseMessageGraphSessionFile(
   agent: MessageGraphAgent,
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const input = openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan')
   const lines = createInterface({ input, crlfDelay: Infinity })
   try {
-    return await parseMessageGraphSessionLines({ agent, file, lines, platform })
+    return await parseMessageGraphSessionLines({ agent, file, lines, platform, messages })
   } finally {
     // readline.close() leaves the underlying stream open; destroy it so a
     // mid-parse throw cannot leak the gated transcript handle.
@@ -245,10 +249,11 @@ function consumeMessageGraphRecordLine(accumulator: SessionAccumulator, line: st
 
 export function createMessageGraphSessionResumeState(
   agent: MessageGraphAgent,
-  file: FileWithMtime
+  file: FileWithMtime,
+  messages?: TranscriptMessageSink
 ): ResumableSessionParseState {
   const state = accumulatorFoldResumeState(
-    createAccumulator({ agent, file, sessionId: sessionIdFromFileName(file.path) }),
+    createAccumulator({ agent, file, sessionId: sessionIdFromFileName(file.path), messages }),
     consumeMessageGraphRecordLine
   )
   // Why: only OMP materializes task-subagent transcripts beside its sessions
@@ -263,8 +268,9 @@ async function parseMessageGraphSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
+  messages?: TranscriptMessageSink
 }): Promise<AiVaultSession | null> {
-  const state = createMessageGraphSessionResumeState(args.agent, args.file)
+  const state = createMessageGraphSessionResumeState(args.agent, args.file, args.messages)
   for await (const line of args.lines) {
     state.consumeLine(line)
   }

--- a/src/main/ai-vault/session-scanner-grok-parser.ts
+++ b/src/main/ai-vault/session-scanner-grok-parser.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import { createInterface } from 'node:readline'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import type { FileWithMtime, SessionAccumulator } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   addPreviewMessage,
   createAccumulator,
@@ -34,7 +35,8 @@ const GROK_USER_QUERY_PREVIEW_SCAN_LIMIT = 4096
 
 export async function parseGrokSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const record = asRecord(JSON.parse(await wslGatedReadFile(file.path, 'utf-8', 'scan')) as unknown)
   if (!record) {
@@ -42,7 +44,7 @@ export async function parseGrokSessionFile(
   }
   const info = asRecord(record.info)
   const sessionId = extractString(info?.id) ?? sessionIdFromFileName(dirname(file.path))
-  const accumulator = createAccumulator({ agent: 'grok', file, sessionId })
+  const accumulator = createAccumulator({ agent: 'grok', file, sessionId, messages })
   accumulator.cwd = extractString(info?.cwd)
   accumulator.title =
     normalizeTitleText(extractString(record.generated_title) ?? '') ??

--- a/src/main/ai-vault/session-scanner-hermes-parser.ts
+++ b/src/main/ai-vault/session-scanner-hermes-parser.ts
@@ -28,24 +28,30 @@ export async function parseHermesSessionFile(
   platform: NodeJS.Platform = process.platform,
   messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
-  return parseHermesSessionContent(
+  return parseHermesSessionRecord(
     file,
     await wslGatedReadFile(file.path, 'utf-8', 'scan'),
     platform,
     {},
-    undefined,
     messages
   )
 }
 
-/** Remote content parses have no reader attached; the sink stays undefined. */
-
+/** Remote transcript content, streamed from a host that has no reader attached. */
 export async function parseHermesSessionContent(
   file: FileWithMtime,
   content: string,
   platform: NodeJS.Platform = process.platform,
-  options: ParserSessionOptions = {},
-  _signal?: AbortSignal,
+  options: ParserSessionOptions = {}
+): Promise<AiVaultSession | null> {
+  return parseHermesSessionRecord(file, content, platform, options)
+}
+
+async function parseHermesSessionRecord(
+  file: FileWithMtime,
+  content: string,
+  platform: NodeJS.Platform,
+  options: ParserSessionOptions,
   messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const record = asRecord(JSON.parse(content) as unknown)

--- a/src/main/ai-vault/session-scanner-hermes-parser.ts
+++ b/src/main/ai-vault/session-scanner-hermes-parser.ts
@@ -2,6 +2,7 @@ import { wslGatedReadFile } from '../native-chat/wsl-transcript-fs-access'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import type { FileWithMtime } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   addPreviewContent,
   createAccumulator,
@@ -24,20 +25,28 @@ type ParserSessionOptions = {
 
 export async function parseHermesSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   return parseHermesSessionContent(
     file,
     await wslGatedReadFile(file.path, 'utf-8', 'scan'),
-    platform
+    platform,
+    {},
+    undefined,
+    messages
   )
 }
+
+/** Remote content parses have no reader attached; the sink stays undefined. */
 
 export async function parseHermesSessionContent(
   file: FileWithMtime,
   content: string,
   platform: NodeJS.Platform = process.platform,
-  options: ParserSessionOptions = {}
+  options: ParserSessionOptions = {},
+  _signal?: AbortSignal,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const record = asRecord(JSON.parse(content) as unknown)
   if (!record) {
@@ -46,7 +55,8 @@ export async function parseHermesSessionContent(
   const accumulator = createAccumulator({
     agent: 'hermes',
     file,
-    sessionId: extractString(record.session_id) ?? sessionIdFromFileName(file.path)
+    sessionId: extractString(record.session_id) ?? sessionIdFromFileName(file.path),
+    messages
   })
   accumulator.model = extractString(record.model)
   accumulator.cwd = extractString(record.cwd)

--- a/src/main/ai-vault/session-scanner-kimi-parser.ts
+++ b/src/main/ai-vault/session-scanner-kimi-parser.ts
@@ -16,6 +16,7 @@ import {
   readKimiWorkDirBySessionId
 } from './session-scanner-kimi-paths'
 import type { FileWithMtime, SessionAccumulator } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   asRecord,
   extractContentText,
@@ -32,7 +33,8 @@ import {
 // session_index.jsonl; model/messages/tokens come from the wire transcript.
 export async function parseKimiSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   let stateRecord: Record<string, unknown> | null
   try {
@@ -53,7 +55,7 @@ export async function parseKimiSessionFile(
   }
 
   const sessionId = kimiSessionIdFromStatePath(file.path)
-  const accumulator = createAccumulator({ agent: 'kimi', file, sessionId })
+  const accumulator = createAccumulator({ agent: 'kimi', file, sessionId, messages })
 
   // Why: Kimi sessions are work-dir-scoped — the resume command must `cd` into
   // the original directory or the CLI rejects it. That path lives only in the

--- a/src/main/ai-vault/session-scanner-opencode-parser.ts
+++ b/src/main/ai-vault/session-scanner-opencode-parser.ts
@@ -3,6 +3,7 @@ import { WslTranscriptFsError } from '../native-chat/wsl-transcript-fs-gate'
 import { join } from 'node:path'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import type { FileWithMtime, SessionAccumulator } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   addPreviewMessage,
   createAccumulator,
@@ -25,14 +26,15 @@ import {
 
 export async function parseOpenCodeSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const record = asRecord(JSON.parse(await wslGatedReadFile(file.path, 'utf-8', 'scan')) as unknown)
   if (!record) {
     return null
   }
   const sessionId = extractString(record.id) ?? sessionIdFromFileName(file.path)
-  const accumulator = createAccumulator({ agent: 'opencode', file, sessionId })
+  const accumulator = createAccumulator({ agent: 'opencode', file, sessionId, messages })
   accumulator.title = normalizeTitleText(extractString(record.title) ?? '')
   accumulator.cwd = extractString(record.directory)
   updateTimeline(accumulator, timeObjectValue(record.time, 'created'))

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-schema.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-schema.ts
@@ -1,0 +1,29 @@
+import type SyncDatabase from '../sqlite/sync-database'
+import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
+
+// Why: OpenCode's schema has moved more than once, so every read probes for the
+// columns it names. These are the two shapes the session parser depends on;
+// keeping them here stops each reader from inventing its own partial gate.
+
+/** Enough of `message` to count a session's turns. */
+export function canCountOpenCodeMessages(db: SyncDatabase): boolean {
+  return (
+    tableExists(db, 'message') &&
+    columnExists(db, 'message', 'session_id') &&
+    columnExists(db, 'message', 'data')
+  )
+}
+
+/** Enough of `message`×`part` to read a session's parts in turn order. */
+export function canReadOpenCodeMessageParts(db: SyncDatabase): boolean {
+  return (
+    canCountOpenCodeMessages(db) &&
+    columnExists(db, 'message', 'id') &&
+    // Every parts read orders by it; unprobed, a schema without it throws mid-read.
+    columnExists(db, 'message', 'time_created') &&
+    tableExists(db, 'part') &&
+    columnExists(db, 'part', 'message_id') &&
+    columnExists(db, 'part', 'time_created') &&
+    columnExists(db, 'part', 'data')
+  )
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -1,4 +1,4 @@
-import type { Worker } from 'node:worker_threads'
+import { LazyWorkerThreadHost, type WorkerThreadFactory } from '../lazy-worker-thread-host'
 import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
 import type {
   OpenCodeSqliteListRequest,
@@ -11,9 +11,10 @@ import type { SessionFileCandidate } from './session-scanner-types'
 import { errorMessage } from './session-scanner-values'
 
 // Why (#8864): a lazily-spawned, unref'd worker runs OpenCode SQLite reads off
-// the main-process event loop. Lifecycle (idle teardown, FIFO one-at-a-time
-// dispatch, per-call timeouts, respawn-on-fault) mirrors src/main/speech/
-// stt-service.ts. The default spawn + shared singleton live in
+// the main-process event loop. This module owns the request half (FIFO
+// one-at-a-time dispatch, per-call timeouts, respawn-on-fault); the thread's
+// own lifetime belongs to LazyWorkerThreadHost, shared with the port-scan probe
+// client. The default spawn + shared singleton live in
 // session-scanner-opencode-sqlite-worker-spawn.ts.
 
 export const LIST_TIMEOUT_MS = 30_000
@@ -24,8 +25,6 @@ export const IDLE_TEARDOWN_MS = 30_000
 // spin a crash loop. Reset on any successful response, after draining, and when a
 // fresh scan burst starts from idle (so the cap is per-scan, not process-wide).
 export const MAX_CONSECUTIVE_DEATHS = 3
-
-export type WorkerFactory = () => Worker
 
 // Omit<union, 'id'> collapses to the shared keys, so omit each member and let
 // the client stamp the correlation id.
@@ -53,20 +52,27 @@ class OpenCodeSqliteWorkerUnavailableError extends Error {}
  * no worker can be spawned rather than moving SQLite work onto the main thread.
  */
 export class OpenCodeSqliteWorkerClient {
-  private worker: Worker | null = null
   private active: PendingCall | null = null
   private queue: PendingCall[] = []
-  private idleTimer: NodeJS.Timeout | null = null
   private consecutiveDeaths = 0
   private nextId = 1
-  private loggedWorkerUnavailable = false
-  private cleanupWorkerListeners: (() => void) | null = null
-  private readonly workerFactory: WorkerFactory
-  private readonly log: (message: string) => void
+  private readonly host: LazyWorkerThreadHost<OpenCodeSqliteWorkerResponse>
 
-  constructor(options: { workerFactory: WorkerFactory; log?: (message: string) => void }) {
-    this.workerFactory = options.workerFactory
-    this.log = options.log ?? ((message) => console.warn(message))
+  constructor(options: { workerFactory: WorkerThreadFactory; log?: (message: string) => void }) {
+    const log = options.log ?? ((message: string) => console.warn(message))
+    this.host = new LazyWorkerThreadHost<OpenCodeSqliteWorkerResponse>({
+      factory: options.workerFactory,
+      idleTeardownMs: IDLE_TEARDOWN_MS,
+      onMessage: (response) => this.onMessage(response),
+      onError: (error) => this.onWorkerFault(error),
+      onExit: (code) => this.onWorkerExit(code),
+      isIdle: () => !this.active && this.queue.length === 0,
+      // Why (#8864): never fall back to synchronous SQLite reads here; a missing
+      // bundle or resource-exhausted spawn must omit OpenCode history rather than
+      // reintroduce the main-process hang this worker boundary prevents.
+      onUnavailable: (err) =>
+        log(`OpenCode SQLite worker unavailable; skipping its history. ${errorMessage(err)}`)
+    })
   }
 
   /**
@@ -167,7 +173,7 @@ export class OpenCodeSqliteWorkerClient {
     if (this.active || this.queue.length === 0) {
       return
     }
-    const worker = this.ensureWorker()
+    const worker = this.host.ensure()
     if (!worker) {
       this.failQueuedAsUnavailable()
       return
@@ -177,45 +183,12 @@ export class OpenCodeSqliteWorkerClient {
       return
     }
     this.active = call
-    this.clearIdleTimer()
+    this.host.clearIdleTimer()
     // Timeout clock starts at dispatch (not enqueue): a batch may enqueue up to
     // 8 parses at once, and a queue-inclusive timeout would fire falsely.
     call.timer = setTimeout(() => this.onTimeout(call), call.timeoutMs)
     call.timer.unref?.()
     worker.postMessage(call.request)
-  }
-
-  private ensureWorker(): Worker | null {
-    if (this.worker) {
-      return this.worker
-    }
-    try {
-      const worker = this.workerFactory()
-      const onMessage = (response: OpenCodeSqliteWorkerResponse): void => this.onMessage(response)
-      const onError = (error: Error): void => this.onWorkerFault(error)
-      const onExit = (code: number): void => this.onWorkerExit(code)
-      worker.on('message', onMessage)
-      worker.on('error', onError)
-      worker.on('exit', onExit)
-      this.cleanupWorkerListeners = () => {
-        worker.off('message', onMessage)
-        worker.off('error', onError)
-        worker.off('exit', onExit)
-      }
-      // Never keep the app alive for a scan worker.
-      worker.unref?.()
-      this.worker = worker
-      return worker
-    } catch (err) {
-      // Why (#8864): never fall back to synchronous SQLite reads here; a missing
-      // bundle or resource-exhausted spawn must omit OpenCode history rather than
-      // reintroduce the main-process hang this worker boundary prevents.
-      if (!this.loggedWorkerUnavailable) {
-        this.loggedWorkerUnavailable = true
-        this.log(`OpenCode SQLite worker unavailable; skipping its history. ${errorMessage(err)}`)
-      }
-      return null
-    }
   }
 
   private onMessage(response: OpenCodeSqliteWorkerResponse): void {
@@ -243,7 +216,7 @@ export class OpenCodeSqliteWorkerClient {
     // A clean self-exit is not a death, but the stale handle must be dropped
     // or the next dispatch would post into the dead worker and stall to timeout.
     if (code === 0 && !this.active && this.queue.length === 0) {
-      this.destroyWorker()
+      this.host.destroy()
       return
     }
     this.onWorkerFault(new Error(`OpenCode SQLite worker exited with code ${code}`))
@@ -251,7 +224,7 @@ export class OpenCodeSqliteWorkerClient {
 
   private onWorkerFault(error: Error): void {
     const failed = this.active
-    this.destroyWorker()
+    this.host.destroy()
     this.consecutiveDeaths++
     if (failed) {
       this.settle(failed, () => failed.reject(error))
@@ -302,46 +275,7 @@ export class OpenCodeSqliteWorkerClient {
     if (this.queue.length > 0) {
       this.pump()
     } else {
-      this.scheduleIdleTeardown()
+      this.host.scheduleIdleTeardown()
     }
-  }
-
-  private scheduleIdleTeardown(): void {
-    this.clearIdleTimer()
-    if (!this.worker) {
-      return
-    }
-    this.idleTimer = setTimeout(() => this.teardownIfIdle(), IDLE_TEARDOWN_MS)
-    this.idleTimer.unref?.()
-  }
-
-  private teardownIfIdle(): void {
-    this.idleTimer = null
-    // Only tear down with nothing active AND nothing queued: a request arriving
-    // as the timer fires must never be lost to a self-exiting worker.
-    if (this.active || this.queue.length > 0) {
-      return
-    }
-    this.destroyWorker()
-  }
-
-  private clearIdleTimer(): void {
-    if (this.idleTimer) {
-      clearTimeout(this.idleTimer)
-      this.idleTimer = null
-    }
-  }
-
-  private destroyWorker(): void {
-    this.clearIdleTimer()
-    const worker = this.worker
-    this.worker = null
-    if (!worker) {
-      return
-    }
-    this.cleanupWorkerListeners?.()
-    this.cleanupWorkerListeners = null
-    worker.removeAllListeners()
-    void worker.terminate().catch(() => undefined)
   }
 }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.ts
@@ -10,6 +10,10 @@ import {
   shouldCaptureFullFirstUserPrompt
 } from './session-scanner-first-user-prompt'
 import { readOpenCodeDatabase } from './session-scanner-opencode-sqlite-open'
+import {
+  canCountOpenCodeMessages,
+  canReadOpenCodeMessageParts
+} from './session-scanner-opencode-sqlite-schema'
 import { normalizeTitleText } from './session-scanner-values'
 import type SyncDatabase from '../sqlite/sync-database'
 import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
@@ -68,14 +72,6 @@ function sessionColumnSelect(db: SyncDatabase, columnName: string): string {
 
 function sessionNumberColumnSelect(db: SyncDatabase, columnName: string): string {
   return columnExists(db, 'session', columnName) ? `s.${columnName}` : '0'
-}
-
-function canCountOpenCodeMessages(db: SyncDatabase): boolean {
-  return (
-    tableExists(db, 'message') &&
-    columnExists(db, 'message', 'session_id') &&
-    columnExists(db, 'message', 'data')
-  )
 }
 
 function buildSessionQuery(db: SyncDatabase): string {
@@ -154,14 +150,7 @@ function extractPartText(partData: string): string | null {
 }
 
 function readFirstUserPromptFromOpenCodeDb(db: SyncDatabase, sessionId: string): string | null {
-  if (
-    !canCountOpenCodeMessages(db) ||
-    !tableExists(db, 'part') ||
-    !columnExists(db, 'message', 'id') ||
-    !columnExists(db, 'part', 'message_id') ||
-    !columnExists(db, 'part', 'time_created') ||
-    !columnExists(db, 'part', 'data')
-  ) {
+  if (!canReadOpenCodeMessageParts(db)) {
     return null
   }
 
@@ -206,14 +195,7 @@ function readFirstUserPromptFromOpenCodeDb(db: SyncDatabase, sessionId: string):
 }
 
 function buildPreviewQuery(db: SyncDatabase): string | null {
-  if (
-    !canCountOpenCodeMessages(db) ||
-    !tableExists(db, 'part') ||
-    !columnExists(db, 'message', 'id') ||
-    !columnExists(db, 'part', 'message_id') ||
-    !columnExists(db, 'part', 'time_created') ||
-    !columnExists(db, 'part', 'data')
-  ) {
+  if (!canReadOpenCodeMessageParts(db)) {
     return null
   }
   return `SELECT json_extract(m.data, '$.role') AS role,

--- a/src/main/ai-vault/session-scanner-parse-cache-agents.test.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache-agents.test.ts
@@ -205,6 +205,61 @@ describe('codex-specific resume behavior', () => {
 })
 
 describe('non-resumable formats keep reuse-only caching', () => {
+  it('re-parses cline when only its messages sidecar changed', async () => {
+    const root = await makeTempDir()
+    const sessionDir = join(root, 'cline-1')
+    await mkdir(sessionDir, { recursive: true })
+    const metadataPath = join(sessionDir, 'cline-1.json')
+    const messagesPath = join(sessionDir, 'cline-1.messages.json')
+    await writeFile(
+      metadataPath,
+      JSON.stringify({
+        session_id: 'cline-1',
+        cwd: '/tmp/cline',
+        started_at: '2026-05-01T10:00:00Z'
+      })
+    )
+    const writeMessages = (text: string): Promise<void> =>
+      writeFile(
+        messagesPath,
+        JSON.stringify({
+          updated_at: '2026-05-01T10:00:01Z',
+          messages: [{ role: 'user', content: [{ type: 'text', text }] }]
+        })
+      )
+    await writeMessages('first ask')
+
+    // Cline reads the sidecar as part of its parse, so a change to it has to
+    // re-parse; there is no metadata-only merge to re-run.
+    const candidate = async (): Promise<SessionFileCandidate> => {
+      const base = await candidateFor('cline', metadataPath)
+      const sidecarStat = await stat(messagesPath)
+      return {
+        ...base,
+        file: {
+          ...base.file,
+          sidecar: {
+            path: messagesPath,
+            mtimeMs: sidecarStat.mtimeMs,
+            sizeBytes: sidecarStat.size
+          }
+        }
+      }
+    }
+
+    const stats = createSessionParseStats()
+    const seeded = await parseAgentSessionFileCached(await candidate(), process.platform, stats)
+    expect(seeded?.title).toBe('first ask')
+    await parseAgentSessionFileCached(await candidate(), process.platform, stats)
+    expect(stats).toMatchObject({ fullParses: 1, reused: 1 })
+
+    await writeMessages('second ask, rather longer than the first')
+    const rewritten = await parseAgentSessionFileCached(await candidate(), process.platform, stats)
+
+    expect(rewritten?.title).toBe('second ask, rather longer than the first')
+    expect(stats).toMatchObject({ fullParses: 2, reused: 1 })
+  })
+
   it('re-parses a changed grok summary fully and reuses it when unchanged', async () => {
     const root = await makeTempDir()
     const sessionDir = join(root, 'session-1')

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -1,7 +1,5 @@
-import { readTranscriptSlice } from '../native-chat/wsl-transcript-fs-access'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import { createAntigravitySessionResumeState } from './session-scanner-antigravity-parser'
-import { parseAgentSessionFile } from './session-scanner-agent-parser'
 import { createCodexSessionResumeState } from './session-scanner-codex-parser'
 import { createDroidSessionResumeState } from './session-scanner-droid-parser'
 import { createMessageGraphSessionResumeState } from './session-scanner-graph-parsers'
@@ -13,27 +11,25 @@ import { countSubagentTranscripts } from './session-scanner-subagent-transcripts
 import { countOmpSubagentTranscripts } from './session-scanner-omp-subagent-transcripts'
 import type { ResumableSessionParseState, SessionFileCandidate } from './session-scanner-types'
 import { refreshCachedCodexTitle } from './session-scanner-codex-cached-title'
-import { consumeCompleteJsonlLines } from './session-scanner-jsonl-reader'
+import {
+  getSessionParseCacheEntry,
+  storeSessionParseCacheEntry,
+  type SessionParseCacheEntry
+} from './session-parse-cache-store'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
+import {
+  readResumableTranscript,
+  readWholeTranscript,
+  type TranscriptReadStats
+} from './session-transcript-reader'
 
-// Sized past the default recency cap (1000) plus the in-scope cap (2000) so a
-// full steady-state result set stays resident between forced rescans.
-const MAX_CACHE_ENTRIES = 4096
-const NEWLINE_BYTE = 0x0a
-
-type ResumePoint = {
-  state: ResumableSessionParseState
-  // Byte offset just past the last complete ('\n'-terminated) line consumed;
-  // a trailing unterminated line is deliberately left before this point.
-  byteOffset: number
-}
-
-type SessionParseCacheEntry = {
-  mtimeMs: number
-  sizeBytes: number | null
-  platform: NodeJS.Platform
-  session: AiVaultSession | null
-  resume: ResumePoint | null
-}
+export {
+  invalidateSessionParseCacheEntry,
+  resetSessionParseCacheForTests,
+  seedSessionParseCache,
+  snapshotSessionParseCacheForPersistence,
+  type PersistedSessionParseCacheEntry
+} from './session-parse-cache-store'
 
 // Incremental append-parsing applies only to transcripts that are append-only
 // JSONL line-folds. Whole-JSON documents (grok/rovo/devin/hermes/gemini-json)
@@ -44,31 +40,32 @@ type SessionParseCacheEntry = {
 // cached state instead, never pay for a throwaway accumulator.
 function resumableStateFactoryFor(
   candidate: SessionFileCandidate
-): (() => ResumableSessionParseState) | null {
+): ((messages: TranscriptMessageSink) => ResumableSessionParseState) | null {
   switch (candidate.agent) {
     case 'claude':
-      return () => createClaudeSessionResumeState(candidate.file)
+      return (messages) => createClaudeSessionResumeState(candidate.file, messages)
     case 'codex':
-      return () => createCodexSessionResumeState(candidate.file, candidate.codexHome)
+      return (messages) =>
+        createCodexSessionResumeState(candidate.file, candidate.codexHome, messages)
     case 'cursor':
-      return () => createCursorSessionResumeState(candidate.file)
+      return (messages) => createCursorSessionResumeState(candidate.file, true, messages)
     case 'copilot':
-      return () => createCopilotSessionResumeState(candidate.file)
+      return (messages) => createCopilotSessionResumeState(candidate.file, messages)
     case 'droid':
-      return () => createDroidSessionResumeState(candidate.file)
+      return (messages) => createDroidSessionResumeState(candidate.file, messages)
     case 'openclaw':
     case 'pi':
     case 'omp':
     case 'prime-agent': {
       const agent = candidate.agent
-      return () => createMessageGraphSessionResumeState(agent, candidate.file)
+      return (messages) => createMessageGraphSessionResumeState(agent, candidate.file, messages)
     }
     case 'gemini':
       return candidate.file.path.endsWith('.jsonl')
-        ? () => createGeminiJsonlSessionResumeState(candidate.file)
+        ? (messages) => createGeminiJsonlSessionResumeState(candidate.file, messages)
         : null
     case 'antigravity':
-      return () => createAntigravitySessionResumeState(candidate.file)
+      return (messages) => createAntigravitySessionResumeState(candidate.file, messages)
     case 'devin':
     case 'grok':
     case 'hermes':
@@ -80,98 +77,23 @@ function resumableStateFactoryFor(
   }
 }
 
-export type SessionParseStats = {
+export type SessionParseStats = TranscriptReadStats & {
   reused: number
-  incremental: number
-  fullParses: number
-  // Transcripts the parser already excluded (Codex workers), re-listed after a
-  // write and dismissed without reading. Counted apart from `incremental` so a
-  // scan span still shows how much work the early stop actually removed.
-  earlyStopped: number
-  bytesRead: number
 }
 
 export function createSessionParseStats(): SessionParseStats {
   return { reused: 0, incremental: 0, fullParses: 0, earlyStopped: 0, bytesRead: 0 }
 }
 
-const cache = new Map<string, SessionParseCacheEntry>()
-
-export function resetSessionParseCacheForTests(): void {
-  cache.clear()
-}
-
-// Drops one entry after its file is deleted. Cleanliness, not correctness:
-// discovery walks disk first, so a trashed file is never rediscovered anyway.
-export function invalidateSessionParseCacheEntry(path: string): void {
-  cache.delete(path)
-}
-
-// Persisted subset of a cache entry: the non-serializable `resume` parser
-// state is dropped (see session-parse-cache-persistence.ts).
-export type PersistedSessionParseCacheEntry = Omit<SessionParseCacheEntry, 'resume'>
-
-export function snapshotSessionParseCacheForPersistence(): [
-  string,
-  PersistedSessionParseCacheEntry
-][] {
-  return [...cache].map(([path, entry]): [string, PersistedSessionParseCacheEntry] => [
-    path,
-    {
-      mtimeMs: entry.mtimeMs,
-      sizeBytes: entry.sizeBytes,
-      platform: entry.platform,
-      session: entry.session
-    }
-  ])
-}
-
-// Seeded entries carry `resume: null`: after a restart an unchanged file is a
-// cache hit; a file that changed while the app was closed pays one full
-// (not incremental) re-parse.
-export function seedSessionParseCache(
-  entries: Iterable<[string, PersistedSessionParseCacheEntry]>
-): void {
-  const list = [...entries]
-  // Snapshot order is oldest→newest (LRU); an over-cap list keeps the newest
-  // tail rather than seeding the oldest entries and dropping the tail.
-  for (const [path, entry] of list.slice(Math.max(0, list.length - MAX_CACHE_ENTRIES))) {
-    if (cache.size >= MAX_CACHE_ENTRIES) {
-      return
-    }
-    // In-process entries are always fresher than persisted ones; never clobber.
-    if (cache.has(path)) {
-      continue
-    }
-    cache.set(path, {
-      mtimeMs: entry.mtimeMs,
-      sizeBytes: entry.sizeBytes,
-      platform: entry.platform,
-      session: entry.session,
-      resume: null
-    })
-  }
-}
-
-function storeEntry(path: string, entry: SessionParseCacheEntry): void {
-  cache.delete(path)
-  cache.set(path, entry)
-  if (cache.size > MAX_CACHE_ENTRIES) {
-    const oldest = cache.keys().next()
-    if (!oldest.done) {
-      cache.delete(oldest.value)
-    }
-  }
-}
-
 /**
- * Parse a session file, reusing prior work where the file is provably
- * unchanged (mtime+size) and, for append-only JSONL transcripts (Claude,
- * Codex, Cursor, Copilot, Droid, OpenClaw/Pi/OMP, Gemini-JSONL), resuming the
- * parse from the last consumed byte when the file only grew. This is what
- * keeps the renderer's ~5s forced rescans from re-reading gigabytes of
- * transcripts (STA-1278/STA-1417: main process pegging one core during
- * multi-agent workloads).
+ * The session list's cursor over the transcript reader: it remembers what each
+ * file looked like when it was last listed, reuses that work where the file is
+ * provably unchanged (mtime+size), and otherwise asks the reader to resume from
+ * the last consumed byte or re-read the file whole. This is what keeps the
+ * renderer's ~5s forced rescans from re-reading gigabytes of transcripts
+ * (STA-1278/STA-1417: main process pegging one core during multi-agent
+ * workloads). Other consumers of the reader keep their own equivalent cursor
+ * and never consult this one.
  */
 export async function parseAgentSessionFileCached(
   candidate: SessionFileCandidate,
@@ -179,7 +101,7 @@ export async function parseAgentSessionFileCached(
   stats?: SessionParseStats
 ): Promise<AiVaultSession | null> {
   const { file } = candidate
-  const entry = cache.get(file.path)
+  const entry = getSessionParseCacheEntry(file.path)
 
   const unchanged =
     entry !== undefined &&
@@ -187,56 +109,30 @@ export async function parseAgentSessionFileCached(
     entry.mtimeMs === file.mtimeMs &&
     (entry.sizeBytes === null || file.sizeBytes === undefined || entry.sizeBytes === file.sizeBytes)
   if (unchanged) {
-    if (stats) {
-      stats.reused++
-    }
-    // A zero-turn transcript usually never changes again, but its sibling
-    // subagent dir (Claude `<session>/subagents/`, OMP's same-named artifact
-    // dir) can gain files after the parent's last write (a still-running
-    // subagent finishing). The mtime+size key can't see that, so refresh the
-    // cheap directory count on reuse.
-    if (entry.session && entry.session.messageCount === 0) {
-      const subagentTranscriptCount =
-        candidate.agent === 'claude'
-          ? await countSubagentTranscripts(file.path)
-          : candidate.agent === 'omp'
-            ? await countOmpSubagentTranscripts(file.path)
-            : null
-      if (
-        subagentTranscriptCount !== null &&
-        subagentTranscriptCount !== entry.session.subagentTranscriptCount
-      ) {
-        entry.session = { ...entry.session, subagentTranscriptCount }
-      }
-    }
-    // Codex titles come from session_index.jsonl, which mtime+size can't see.
-    // Remote counterpart: remote-session-scanner.ts's reusedCodexTitleRefresh.
-    if (entry.session && candidate.agent === 'codex') {
-      entry.session = await refreshCachedCodexTitle(candidate, entry.session)
-    }
-    storeEntry(file.path, entry)
-    return entry.session
+    return reuseCachedSession(candidate, entry, stats)
   }
 
   const stateFactory = resumableStateFactoryFor(candidate)
   if (stateFactory) {
-    const parsed = await parseResumableCandidate({
+    const read = await readResumableTranscript({
       candidate,
       platform,
-      entry,
-      stats,
-      stateFactory
+      resume: entry?.platform === platform ? entry.resume : null,
+      stateFactory,
+      stats
     })
-    storeEntry(file.path, parsed)
-    return parsed.session
+    storeSessionParseCacheEntry(file.path, {
+      mtimeMs: file.mtimeMs,
+      sizeBytes: file.sizeBytes ?? null,
+      platform,
+      session: read.session,
+      resume: read.resume
+    })
+    return read.session
   }
 
-  if (stats) {
-    stats.fullParses++
-    stats.bytesRead += file.sizeBytes ?? 0
-  }
-  const session = await parseAgentSessionFile(candidate, platform)
-  storeEntry(file.path, {
+  const session = await readWholeTranscript({ candidate, platform, stats })
+  storeSessionParseCacheEntry(file.path, {
     mtimeMs: file.mtimeMs,
     sizeBytes: file.sizeBytes ?? null,
     platform,
@@ -246,79 +142,38 @@ export async function parseAgentSessionFileCached(
   return session
 }
 
-async function parseResumableCandidate(args: {
-  candidate: SessionFileCandidate
-  platform: NodeJS.Platform
-  entry: SessionParseCacheEntry | undefined
+async function reuseCachedSession(
+  candidate: SessionFileCandidate,
+  entry: SessionParseCacheEntry,
   stats?: SessionParseStats
-  stateFactory: () => ResumableSessionParseState
-}): Promise<SessionParseCacheEntry> {
-  const { file } = args.candidate
-  const resume = args.entry?.platform === args.platform ? args.entry.resume : null
-  const canResume =
-    resume !== null &&
-    resume !== undefined &&
-    typeof file.sizeBytes === 'number' &&
-    file.sizeBytes >= resume.byteOffset &&
-    (resume.byteOffset === 0 || (await endsWithNewlineAt(file.path, resume.byteOffset)))
-
-  // Clone before consuming: a failed read must not corrupt the cached state,
-  // or the next resume would double-count the lines applied before the error.
-  const state = canResume ? resume.state.clone() : args.stateFactory()
-  const startOffset = canResume ? resume.byteOffset : 0
-  // Mirrors the reader's entry guard so a dismissed transcript is not reported
-  // as an incremental parse that read nothing.
-  const stoppedBeforeRead = state.shouldStop?.() === true
-  if (args.stats) {
-    if (stoppedBeforeRead) {
-      args.stats.earlyStopped++
-    } else if (canResume) {
-      args.stats.incremental++
-    } else {
-      args.stats.fullParses++
+): Promise<AiVaultSession | null> {
+  if (stats) {
+    stats.reused++
+  }
+  // A zero-turn transcript usually never changes again, but its sibling
+  // subagent dir (Claude `<session>/subagents/`, OMP's same-named artifact
+  // dir) can gain files after the parent's last write (a still-running
+  // subagent finishing). The mtime+size key can't see that, so refresh the
+  // cheap directory count on reuse.
+  if (entry.session && entry.session.messageCount === 0) {
+    const subagentTranscriptCount =
+      candidate.agent === 'claude'
+        ? await countSubagentTranscripts(candidate.file.path)
+        : candidate.agent === 'omp'
+          ? await countOmpSubagentTranscripts(candidate.file.path)
+          : null
+    if (
+      subagentTranscriptCount !== null &&
+      subagentTranscriptCount !== entry.session.subagentTranscriptCount
+    ) {
+      entry.session = { ...entry.session, subagentTranscriptCount }
     }
   }
-
-  const readResult = await consumeCompleteJsonlLines({
-    path: file.path,
-    start: startOffset,
-    onLine: (line) => state.consumeLine(line),
-    // Bound: the optional hooks are declared as methods, so a parser written
-    // with method syntax must not lose `this` on the way into the reader.
-    onLineBytes: state.consumeLineBytes?.bind(state),
-    shouldStop: state.shouldStop?.bind(state)
-  })
-  if (args.stats) {
-    args.stats.bytesRead += readResult.bytesRead
+  // Codex titles come from session_index.jsonl, which mtime+size can't see.
+  // Remote counterpart: remote-session-scanner.ts's reusedCodexTitleRefresh.
+  if (entry.session && candidate.agent === 'codex') {
+    entry.session = await refreshCachedCodexTitle(candidate, entry.session)
   }
-
-  // The stat this scan displays is current even when nothing new was consumed.
-  state.touchFile(file)
-
-  // Keep parity with the one-shot parser: a final unterminated line is shown,
-  // but stays out of the resumable state so the (possibly still-growing) line
-  // is re-read once complete instead of being half-counted.
-  let displayState = state
-  if (readResult.trailingPartialLine !== null) {
-    displayState = state.clone()
-    displayState.consumeLine(readResult.trailingPartialLine)
-  }
-
-  return {
-    mtimeMs: file.mtimeMs,
-    sizeBytes: file.sizeBytes ?? null,
-    platform: args.platform,
-    session: await displayState.finalize(args.platform),
-    resume: { state, byteOffset: readResult.consumedThrough }
-  }
-}
-
-// A resume point is only valid if it still sits just past a line break;
-// anything else means the file was rewritten, not appended. Heuristic: a
-// grown rewrite keeping '\n' at exactly this byte would slip through, but
-// agent transcripts are append-only so that trade is accepted (worst case is
-// a stale vault row until the file is next truncated or the app restarts).
-async function endsWithNewlineAt(path: string, offset: number): Promise<boolean> {
-  const slice = await readTranscriptSlice(path, offset - 1, 1, 'scan')
-  return slice.length === 1 && slice[0] === NEWLINE_BYTE
+  storeSessionParseCacheEntry(candidate.file.path, entry)
+  return entry.session
 }

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -18,6 +18,11 @@ import {
   type SessionParseCacheEntry
 } from './session-parse-cache-store'
 import type { TranscriptMessageSink } from './session-transcript-consumers'
+import { sidecarUnchanged } from './session-sidecar-stat'
+import {
+  enrichSessionFromSidecar,
+  sidecarEnrichesWithoutReparse
+} from './session-scanner-sidecar-enrichment'
 import {
   readResumableTranscript,
   readWholeTranscript,
@@ -49,7 +54,7 @@ function resumableStateFactoryFor(
       return (messages) =>
         createCodexSessionResumeState(candidate.file, candidate.codexHome, messages)
     case 'cursor':
-      return (messages) => createCursorSessionResumeState(candidate.file, true, messages)
+      return (messages) => createCursorSessionResumeState(candidate.file, messages)
     case 'copilot':
       return (messages) => createCopilotSessionResumeState(candidate.file, messages)
     case 'droid':
@@ -77,10 +82,6 @@ function resumableStateFactoryFor(
       return null
   }
 }
-
-// No stat can report it, so `unchanged` is always false for such an entry
-// while its resume point stays usable.
-export const UNMATCHABLE_MTIME_MS = -1
 
 export type SessionParseStats = TranscriptReadStats & {
   reused: number
@@ -120,13 +121,27 @@ async function parseCachedInLane(
   const { file } = candidate
   const entry = getSessionParseCacheEntry(file.path)
 
-  const unchanged =
+  const transcriptUnchanged =
     entry !== undefined &&
     entry.platform === platform &&
     entry.mtimeMs === file.mtimeMs &&
     (entry.sizeBytes === null || file.sizeBytes === undefined || entry.sizeBytes === file.sizeBytes)
-  if (unchanged) {
-    return reuseCachedSession(candidate, entry, stats)
+  if (transcriptUnchanged) {
+    if (sidecarUnchanged(entry.sidecar, file.sidecar)) {
+      return reuseCachedSession(candidate, entry, stats)
+    }
+    // Only the sibling moved. For an agent whose sibling just adds metadata,
+    // re-merge it onto the stored fold result; the transcript is not re-read.
+    if (sidecarEnrichesWithoutReparse(candidate) && entry.foldSession !== undefined) {
+      const enriched = await enrichSessionFromSidecar(candidate, entry.foldSession, platform)
+      entry.session = enriched.session
+      entry.sidecar = enriched.refused ? 'unknown' : file.sidecar
+      storeSessionParseCacheEntry(file.path, entry)
+      if (stats) {
+        stats.reused++
+      }
+      return entry.session
+    }
   }
 
   const stateFactory = resumableStateFactoryFor(candidate)
@@ -138,19 +153,20 @@ async function parseCachedInLane(
       stateFactory,
       stats
     })
-    // The parse is usable but its key may not be: a sibling the key covers went
-    // unread, so the real key would look current on the next scan. Keep the
-    // entry for its resume cursor under a key no stat can produce, or a distro
-    // that keeps refusing would force a full re-read of every rescan.
-    const trustworthyKey = read.cacheable && !file.contentDependencyRefused
+    const enriched = await enrichSessionFromSidecar(candidate, read.session, platform)
     storeSessionParseCacheEntry(file.path, {
-      mtimeMs: trustworthyKey ? file.mtimeMs : UNMATCHABLE_MTIME_MS,
+      mtimeMs: file.mtimeMs,
       sizeBytes: file.sizeBytes ?? null,
       platform,
-      session: read.session,
+      session: enriched.session,
+      // A refused sibling leaves the transcript's own work cached and resumable;
+      // only the sibling is recorded as unknown, so the next healthy scan
+      // re-merges it without re-reading the transcript.
+      sidecar: enriched.refused ? 'unknown' : file.sidecar,
+      foldSession: read.session,
       resume: read.resume
     })
-    return read.session
+    return enriched.session
   }
 
   const session = await readWholeTranscript({ candidate, platform, stats })
@@ -159,6 +175,9 @@ async function parseCachedInLane(
     sizeBytes: file.sizeBytes ?? null,
     platform,
     session,
+    // A whole-file parse reads the sibling itself, so a change to it re-parses.
+    sidecar: file.sidecar,
+    foldSession: session,
     resume: null
   })
   return session

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -14,6 +14,7 @@ import type { ResumableSessionParseState, SessionFileCandidate } from './session
 import { refreshCachedCodexTitle } from './session-scanner-codex-cached-title'
 import {
   getSessionParseCacheEntry,
+  invalidateSessionParseCacheEntry,
   storeSessionParseCacheEntry,
   type SessionParseCacheEntry
 } from './session-parse-cache-store'
@@ -134,13 +135,19 @@ async function parseCachedInLane(
       stateFactory,
       stats
     })
-    storeSessionParseCacheEntry(file.path, {
-      mtimeMs: file.mtimeMs,
-      sizeBytes: file.sizeBytes ?? null,
-      platform,
-      session: read.session,
-      resume: read.resume
-    })
+    if (read.cacheable) {
+      storeSessionParseCacheEntry(file.path, {
+        mtimeMs: file.mtimeMs,
+        sizeBytes: file.sizeBytes ?? null,
+        platform,
+        session: read.session,
+        resume: read.resume
+      })
+    } else {
+      // The parse is usable but its key is not: a sibling the key covers went
+      // unread, so an entry stored now would look current on the next scan.
+      invalidateSessionParseCacheEntry(file.path)
+    }
     return read.session
   }
 

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -1,4 +1,5 @@
 import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { inSessionParseFileLane } from './session-parse-file-lane'
 import { createAntigravitySessionResumeState } from './session-scanner-antigravity-parser'
 import { createCodexSessionResumeState } from './session-scanner-codex-parser'
 import { createDroidSessionResumeState } from './session-scanner-droid-parser'
@@ -96,6 +97,18 @@ export function createSessionParseStats(): SessionParseStats {
  * and never consult this one.
  */
 export async function parseAgentSessionFileCached(
+  candidate: SessionFileCandidate,
+  platform: NodeJS.Platform,
+  stats?: SessionParseStats
+): Promise<AiVaultSession | null> {
+  // The whole lookup-read-store sequence runs in the lane: a concurrent parse of
+  // the same path shares this entry's resume point and its message channel.
+  return inSessionParseFileLane(candidate.file.path, () =>
+    parseCachedInLane(candidate, platform, stats)
+  )
+}
+
+async function parseCachedInLane(
   candidate: SessionFileCandidate,
   platform: NodeJS.Platform,
   stats?: SessionParseStats

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -80,7 +80,7 @@ function resumableStateFactoryFor(
 
 // No stat can report it, so `unchanged` is always false for such an entry
 // while its resume point stays usable.
-const UNMATCHABLE_MTIME_MS = -1
+export const UNMATCHABLE_MTIME_MS = -1
 
 export type SessionParseStats = TranscriptReadStats & {
   reused: number

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -14,7 +14,6 @@ import type { ResumableSessionParseState, SessionFileCandidate } from './session
 import { refreshCachedCodexTitle } from './session-scanner-codex-cached-title'
 import {
   getSessionParseCacheEntry,
-  invalidateSessionParseCacheEntry,
   storeSessionParseCacheEntry,
   type SessionParseCacheEntry
 } from './session-parse-cache-store'
@@ -79,6 +78,10 @@ function resumableStateFactoryFor(
   }
 }
 
+// No stat can report it, so `unchanged` is always false for such an entry
+// while its resume point stays usable.
+const UNMATCHABLE_MTIME_MS = -1
+
 export type SessionParseStats = TranscriptReadStats & {
   reused: number
 }
@@ -135,19 +138,18 @@ async function parseCachedInLane(
       stateFactory,
       stats
     })
-    if (read.cacheable) {
-      storeSessionParseCacheEntry(file.path, {
-        mtimeMs: file.mtimeMs,
-        sizeBytes: file.sizeBytes ?? null,
-        platform,
-        session: read.session,
-        resume: read.resume
-      })
-    } else {
-      // The parse is usable but its key is not: a sibling the key covers went
-      // unread, so an entry stored now would look current on the next scan.
-      invalidateSessionParseCacheEntry(file.path)
-    }
+    // The parse is usable but its key may not be: a sibling the key covers went
+    // unread, so the real key would look current on the next scan. Keep the
+    // entry for its resume cursor under a key no stat can produce, or a distro
+    // that keeps refusing would force a full re-read of every rescan.
+    const trustworthyKey = read.cacheable && !file.contentDependencyRefused
+    storeSessionParseCacheEntry(file.path, {
+      mtimeMs: trustworthyKey ? file.mtimeMs : UNMATCHABLE_MTIME_MS,
+      sizeBytes: file.sizeBytes ?? null,
+      platform,
+      session: read.session,
+      resume: read.resume
+    })
     return read.session
   }
 

--- a/src/main/ai-vault/session-scanner-primary-parsers.ts
+++ b/src/main/ai-vault/session-scanner-primary-parsers.ts
@@ -10,6 +10,7 @@ import type {
   ResumableSessionParseState,
   SessionAccumulator
 } from './session-scanner-types'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 import {
   addPreviewContent,
   createAccumulator,
@@ -42,12 +43,16 @@ export type ClaudeSessionParseState = {
   firstUserTitle: string | null
 }
 
-export function createClaudeSessionParseState(file: FileWithMtime): ClaudeSessionParseState {
+export function createClaudeSessionParseState(
+  file: FileWithMtime,
+  messages?: TranscriptMessageSink
+): ClaudeSessionParseState {
   return {
     accumulator: createAccumulator({
       agent: 'claude',
       file,
-      sessionId: sessionIdFromFileName(file.path)
+      sessionId: sessionIdFromFileName(file.path),
+      messages
     }),
     metaTitle: null,
     generatedTitle: null,
@@ -188,8 +193,11 @@ export async function finalizeClaudeSessionParseState(
   return finalizeSession(snapshot.accumulator, platform, options)
 }
 
-export function createClaudeSessionResumeState(file: FileWithMtime): ResumableSessionParseState {
-  return claudeResumeStateFromParseState(createClaudeSessionParseState(file))
+export function createClaudeSessionResumeState(
+  file: FileWithMtime,
+  messages?: TranscriptMessageSink
+): ResumableSessionParseState {
+  return claudeResumeStateFromParseState(createClaudeSessionParseState(file, messages))
 }
 
 function claudeResumeStateFromParseState(
@@ -207,13 +215,14 @@ function claudeResumeStateFromParseState(
 
 export async function parseClaudeSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  messages?: TranscriptMessageSink
 ): Promise<AiVaultSession | null> {
   const lines = createInterface({
     input: openTranscriptReadStream(file.path, { encoding: 'utf-8' }, 'scan'),
     crlfDelay: Infinity
   })
-  return parseClaudeSessionLines({ file, lines, platform })
+  return parseClaudeSessionLines({ file, lines, platform, messages })
 }
 
 export async function parseClaudeSessionContent(
@@ -236,8 +245,9 @@ async function parseClaudeSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
+  messages?: TranscriptMessageSink
 }): Promise<AiVaultSession | null> {
-  const state = createClaudeSessionParseState(args.file)
+  const state = createClaudeSessionParseState(args.file, args.messages)
   for await (const line of args.lines) {
     consumeClaudeSessionLine(state, line)
   }

--- a/src/main/ai-vault/session-scanner-sidecar-enrichment.ts
+++ b/src/main/ai-vault/session-scanner-sidecar-enrichment.ts
@@ -1,0 +1,79 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { buildAiVaultResumeCommand } from '../../shared/ai-vault-resume-command'
+import { generatedSessionTitle } from './session-scanner-accumulator'
+import { readCursorChatMeta, wasCursorChatMetaRefused } from './session-scanner-cursor-chat-meta'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+/**
+ * Merges an agent's sibling file onto the session its transcript alone
+ * produced. Kept out of the fold and applied here so it is a pure function of
+ * (fold result, sibling): re-running it starts from what the transcript said,
+ * never from a previous merge, so a rewritten sibling replaces the fields it
+ * supplied last time instead of losing to them.
+ *
+ * The reuse-time counterpart of session-scanner-codex-cached-title.ts, for
+ * agents whose sibling the transcript key cannot see.
+ */
+
+export type SidecarEnrichment = {
+  session: AiVaultSession | null
+  /** The sibling could not be read; the caller records the observation as unknown. */
+  refused: boolean
+}
+
+/** True when the sibling only adds metadata, so a change to it needs no re-parse. */
+export function sidecarEnrichesWithoutReparse(candidate: SessionFileCandidate): boolean {
+  return candidate.agent === 'cursor'
+}
+
+export async function enrichSessionFromSidecar(
+  candidate: SessionFileCandidate,
+  foldSession: AiVaultSession | null,
+  platform: NodeJS.Platform
+): Promise<SidecarEnrichment> {
+  if (candidate.agent !== 'cursor' || !foldSession) {
+    return { session: foldSession, refused: false }
+  }
+  const meta = await readCursorChatMeta(candidate.file.path)
+  if (!meta) {
+    return { session: foldSession, refused: wasCursorChatMetaRefused(candidate.file.path) }
+  }
+  return { session: mergeCursorChatMeta(foldSession, meta, platform), refused: false }
+}
+
+/** Fills only what the transcript never recorded; its own records always win. */
+export function mergeCursorChatMeta(
+  session: AiVaultSession,
+  meta: {
+    title: string | null
+    cwd: string | null
+    createdAt: string | null
+    updatedAt: string | null
+  },
+  platform: NodeJS.Platform
+): AiVaultSession {
+  // A generated title means the fold found none, so the sibling's may stand in.
+  const named = session.title !== generatedSessionTitle(session.agent, session.sessionId)
+  const cwd = session.cwd ?? meta.cwd
+  const merged: AiVaultSession = {
+    ...session,
+    title: named ? session.title : (meta.title ?? session.title),
+    cwd,
+    createdAt: session.createdAt ?? meta.createdAt,
+    updatedAt: session.updatedAt ?? meta.updatedAt
+  }
+  if (cwd === session.cwd) {
+    return merged
+  }
+  // The resume command embeds the cwd, so it has to be rebuilt with it.
+  return {
+    ...merged,
+    resumeCommand: buildAiVaultResumeCommand({
+      agent: merged.agent,
+      sessionId: merged.sessionId,
+      resumeFilePath: merged.filePath,
+      cwd,
+      platform
+    })
+  }
+}

--- a/src/main/ai-vault/session-scanner-source-discovery.ts
+++ b/src/main/ai-vault/session-scanner-source-discovery.ts
@@ -4,6 +4,7 @@ import { discoverFiles } from './session-scanner-discovery'
 import { opencodeDiscoveries } from './session-scanner-opencode-sources'
 import { antigravityDiscoveries } from './session-scanner-antigravity-sources'
 import { AI_VAULT_AGENT_SOURCES, type AiVaultAgentSource } from './session-scanner-agent-sources'
+import { withCursorChatMetaScan } from './session-scanner-cursor-chat-meta'
 import { normalizedWslHomeDirs } from './session-scanner-roots'
 import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner-types'
 
@@ -17,25 +18,27 @@ export async function discoverAiVaultSessionSources(args: {
   const { options, limitPerAgent, issues } = args
   const wslHomeDirs = normalizedWslHomeDirs(options.wslHomeDirs)
 
-  return Promise.all([
-    // Why: OpenCode 1.17.x migrated sessions from per-session JSON files to a
-    // SQLite DB. discoverOpenCodeSessions runs both the file scanner (legacy)
-    // and the SQLite scanner (1.17.x); dedup by sessionId happens inside.
-    ...opencodeDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
-    ...antigravityDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
-    ...Object.entries(AI_VAULT_AGENT_SOURCES).flatMap(([agent, source]) =>
-      source
-        ? agentDiscoveries(
-            agent as AiVaultAgent,
-            source,
-            options,
-            wslHomeDirs,
-            limitPerAgent,
-            issues
-          )
-        : []
-    )
-  ])
+  return withCursorChatMetaScan(() =>
+    Promise.all([
+      // Why: OpenCode 1.17.x migrated sessions from per-session JSON files to a
+      // SQLite DB. discoverOpenCodeSessions runs both the file scanner (legacy)
+      // and the SQLite scanner (1.17.x); dedup by sessionId happens inside.
+      ...opencodeDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
+      ...antigravityDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
+      ...Object.entries(AI_VAULT_AGENT_SOURCES).flatMap(([agent, source]) =>
+        source
+          ? agentDiscoveries(
+              agent as AiVaultAgent,
+              source,
+              options,
+              wslHomeDirs,
+              limitPerAgent,
+              issues
+            )
+          : []
+      )
+    ])
+  )
 }
 
 function agentDiscoveries(

--- a/src/main/ai-vault/session-scanner-source-discovery.ts
+++ b/src/main/ai-vault/session-scanner-source-discovery.ts
@@ -4,7 +4,6 @@ import { discoverFiles } from './session-scanner-discovery'
 import { opencodeDiscoveries } from './session-scanner-opencode-sources'
 import { antigravityDiscoveries } from './session-scanner-antigravity-sources'
 import { AI_VAULT_AGENT_SOURCES, type AiVaultAgentSource } from './session-scanner-agent-sources'
-import { withCursorChatMetaScan } from './session-scanner-cursor-chat-meta'
 import { normalizedWslHomeDirs } from './session-scanner-roots'
 import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner-types'
 
@@ -18,27 +17,27 @@ export async function discoverAiVaultSessionSources(args: {
   const { options, limitPerAgent, issues } = args
   const wslHomeDirs = normalizedWslHomeDirs(options.wslHomeDirs)
 
-  return withCursorChatMetaScan(() =>
-    Promise.all([
-      // Why: OpenCode 1.17.x migrated sessions from per-session JSON files to a
-      // SQLite DB. discoverOpenCodeSessions runs both the file scanner (legacy)
-      // and the SQLite scanner (1.17.x); dedup by sessionId happens inside.
-      ...opencodeDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
-      ...antigravityDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
-      ...Object.entries(AI_VAULT_AGENT_SOURCES).flatMap(([agent, source]) =>
-        source
-          ? agentDiscoveries(
-              agent as AiVaultAgent,
-              source,
-              options,
-              wslHomeDirs,
-              limitPerAgent,
-              issues
-            )
-          : []
-      )
-    ])
-  )
+  // The Cursor chat-meta scan scope is owned by scanAiVaultSessions: it has to
+  // span parse as well, and finalize runs after this returns.
+  return Promise.all([
+    // Why: OpenCode 1.17.x migrated sessions from per-session JSON files to a
+    // SQLite DB. discoverOpenCodeSessions runs both the file scanner (legacy)
+    // and the SQLite scanner (1.17.x); dedup by sessionId happens inside.
+    ...opencodeDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
+    ...antigravityDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
+    ...Object.entries(AI_VAULT_AGENT_SOURCES).flatMap(([agent, source]) =>
+      source
+        ? agentDiscoveries(
+            agent as AiVaultAgent,
+            source,
+            options,
+            wslHomeDirs,
+            limitPerAgent,
+            issues
+          )
+        : []
+    )
+  ])
 }
 
 function agentDiscoveries(

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -99,6 +99,9 @@ export type ResumableSessionParseState = {
   // Lets a parser terminate an excluded transcript without draining the file.
   shouldStop?(): boolean
   clone(): ResumableSessionParseState
+  // False when the last finalize could not read metadata the session needs, so
+  // its result must not be stored under a key that will look unchanged.
+  isCacheable?(): boolean
   // Refresh per-scan file metadata (mtime display string) without re-parsing.
   touchFile(file: FileWithMtime): void
   finalize(

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -5,6 +5,7 @@ import type {
   AiVaultSessionPreviewMessage
 } from '../../shared/ai-vault-types'
 import type { ExecutionHostId } from '../../shared/execution-host'
+import type { TranscriptMessageSink } from './session-transcript-consumers'
 
 export type AiVaultScanOptions = {
   claudeProjectsDir?: string
@@ -108,6 +109,9 @@ export type ResumableSessionParseState = {
 
 export type SessionAccumulator = {
   agent: AiVaultAgent
+  // Every decoded message this fold sees also goes here, for the reader's
+  // consumers. Shared by clones on purpose: one read, one message stream.
+  messages: TranscriptMessageSink
   sessionId: string
   title: string | null
   fallbackTitle: string | null

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../shared/ai-vault-types'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import type { TranscriptMessageSink } from './session-transcript-consumers'
+import type { SessionSidecarObservation } from './session-sidecar-stat'
 
 export type AiVaultScanOptions = {
   claudeProjectsDir?: string
@@ -55,16 +56,12 @@ export type FileWithMtime = {
   modifiedAt: string
   // Present when discovery statted the file; lets the parse cache detect
   // unchanged/truncated files without a second stat. Synthetic candidates
-  // such as OpenCode SQLite rows omit it. Includes a content dependency's size
-  // when the agent declares one, so it is a cache key, not a file length.
+  // such as OpenCode SQLite rows omit it. The transcript's own length: a byte
+  // offset into it may be compared against this directly.
   sizeBytes?: number
-  // How much of `sizeBytes` belongs to the content dependency rather than the
-  // transcript. A byte offset into the transcript may only be compared against
-  // `sizeBytes` minus this.
-  dependencySizeBytes?: number
-  // The dependency could not be statted this scan, so `sizeBytes` silently
-  // omits it and the resulting parse must not be cached under that key.
-  contentDependencyRefused?: boolean
+  // What discovery saw of the agent's sibling file, tracked apart from the
+  // transcript's own stat (see session-sidecar-stat.ts).
+  sidecar?: SessionSidecarObservation
   // Present when discovery can prove filesystem identity. Codex dual-root
   // scans use a multi-link inode to collapse only actual hardlink aliases.
   dev?: number
@@ -107,9 +104,6 @@ export type ResumableSessionParseState = {
   // Lets a parser terminate an excluded transcript without draining the file.
   shouldStop?(): boolean
   clone(): ResumableSessionParseState
-  // False when the last finalize could not read metadata the session needs, so
-  // its result must not be stored under a key that will look unchanged.
-  isCacheable?(): boolean
   // Refresh per-scan file metadata (mtime display string) without re-parsing.
   touchFile(file: FileWithMtime): void
   finalize(

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -55,8 +55,16 @@ export type FileWithMtime = {
   modifiedAt: string
   // Present when discovery statted the file; lets the parse cache detect
   // unchanged/truncated files without a second stat. Synthetic candidates
-  // such as OpenCode SQLite rows omit it.
+  // such as OpenCode SQLite rows omit it. Includes a content dependency's size
+  // when the agent declares one, so it is a cache key, not a file length.
   sizeBytes?: number
+  // How much of `sizeBytes` belongs to the content dependency rather than the
+  // transcript. A byte offset into the transcript may only be compared against
+  // `sizeBytes` minus this.
+  dependencySizeBytes?: number
+  // The dependency could not be statted this scan, so `sizeBytes` silently
+  // omits it and the resulting parse must not be cached under that key.
+  contentDependencyRefused?: boolean
   // Present when discovery can prove filesystem identity. Codex dual-root
   // scans use a multi-link inode to collapse only actual hardlink aliases.
   dev?: number

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -25,6 +25,7 @@ import {
 import { recordSessionScanIssue } from './session-scan-issues'
 import { discoverInScopeClaudeFiles } from './session-scanner-scope-discovery'
 import { discoverAiVaultSessionSources } from './session-scanner-source-discovery'
+import { cursorChatMetaRefusals, withCursorChatMetaScan } from './session-scanner-cursor-chat-meta'
 import type {
   AiVaultScanOptions,
   SessionFileCandidate,
@@ -53,75 +54,87 @@ export async function scanAiVaultSessions(
   // The span makes scan cost visible in the local trace file: STA-1278-style
   // "one core pegged" reports need to show whether transcript scanning is the
   // subsystem burning CPU, and how much of each scan the cache absorbed.
-  return withSpan('aiVault.scan', async (span) => {
-    const limit = options.unlimited
-      ? Number.POSITIVE_INFINITY
-      : clampPositiveInteger(options.limit, DEFAULT_AI_VAULT_SCAN_LIMIT)
-    const limitPerAgent = options.unlimited
-      ? Number.POSITIVE_INFINITY
-      : clampPositiveInteger(options.limitPerAgent, limit * SESSION_PARSE_CANDIDATE_MULTIPLIER)
-    const platform = options.platform ?? process.platform
-    const executionHostId = options.executionHostId ?? LOCAL_EXECUTION_HOST_ID
-    const issues: AiVaultScanIssue[] = []
-    const parseStats = createSessionParseStats()
-    const antigravityWorkspaceResolver = createAntigravityWorkspaceResolver(
-      readLocalAntigravityHistory
-    )
-    // Why: persisted entries must be seeded before any candidate is parsed, or
-    // the cold scan gains nothing from the cache file (#9210).
-    throwIfAiVaultScanCancelled(options.signal)
-    await ensureSessionParseCacheLoaded()
-    const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
-    throwIfAiVaultScanCancelled(options.signal)
+  // The Cursor chat-meta scope spans discovery AND parse: its sibling meta.json
+  // is looked up in both phases, and one scan must read the chats tree once.
+  return withSpan('aiVault.scan', (span) =>
+    withCursorChatMetaScan(async () => {
+      const limit = options.unlimited
+        ? Number.POSITIVE_INFINITY
+        : clampPositiveInteger(options.limit, DEFAULT_AI_VAULT_SCAN_LIMIT)
+      const limitPerAgent = options.unlimited
+        ? Number.POSITIVE_INFINITY
+        : clampPositiveInteger(options.limitPerAgent, limit * SESSION_PARSE_CANDIDATE_MULTIPLIER)
+      const platform = options.platform ?? process.platform
+      const executionHostId = options.executionHostId ?? LOCAL_EXECUTION_HOST_ID
+      const issues: AiVaultScanIssue[] = []
+      const parseStats = createSessionParseStats()
+      const antigravityWorkspaceResolver = createAntigravityWorkspaceResolver(
+        readLocalAntigravityHistory
+      )
+      // Why: persisted entries must be seeded before any candidate is parsed, or
+      // the cold scan gains nothing from the cache file (#9210).
+      throwIfAiVaultScanCancelled(options.signal)
+      await ensureSessionParseCacheLoaded()
+      const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
+      throwIfAiVaultScanCancelled(options.signal)
 
-    const candidates = await sessionCandidatesFromDiscoveries(discoveries, options)
+      const candidates = await sessionCandidatesFromDiscoveries(discoveries, options)
 
-    const parsedSessions = await parseSessionCandidates({
-      candidates: candidates.slice(0, limit * SESSION_PARSE_CANDIDATE_MULTIPLIER),
-      limit,
-      platform,
-      executionHostId,
-      issues,
-      parseStats,
-      signal: options.signal,
-      antigravityWorkspaceResolver
+      const parsedSessions = await parseSessionCandidates({
+        candidates: candidates.slice(0, limit * SESSION_PARSE_CANDIDATE_MULTIPLIER),
+        limit,
+        platform,
+        executionHostId,
+        issues,
+        parseStats,
+        signal: options.signal,
+        antigravityWorkspaceResolver
+      })
+
+      const cappedSessions = dedupeCodexSessionsBySessionId(parsedSessions)
+        .sort((left, right) => sessionSortTime(right) - sessionSortTime(left))
+        .slice(0, limit)
+
+      const scopeSessions = await scanInScopeSessions({
+        discoveries,
+        scopePaths: options.scopePaths ?? [],
+        limit,
+        alreadyParsedFilePaths: new Set(cappedSessions.map((session) => session.filePath)),
+        platform,
+        executionHostId,
+        issues,
+        parseStats,
+        signal: options.signal
+      })
+      // Scope discovery can return without parsing anything, so an abort landing
+      // here would otherwise persist and return a cancelled scan as complete.
+      throwIfAiVaultScanCancelled(options.signal)
+      for (const refusal of cursorChatMetaRefusals()) {
+        // One issue per refused chats root, not one per Cursor transcript.
+        recordSessionScanIssue(issues, {
+          agent: 'cursor',
+          path: refusal.chatsRoot,
+          message: refusal.message
+        })
+      }
+
+      span.setAttribute('candidates', candidates.length)
+      span.setAttribute('reused', parseStats.reused)
+      span.setAttribute('incremental', parseStats.incremental)
+      span.setAttribute('fullParses', parseStats.fullParses)
+      span.setAttribute('earlyStopped', parseStats.earlyStopped)
+      span.setAttribute('bytesRead', parseStats.bytesRead)
+      span.setAttribute('issues', issues.length)
+
+      scheduleSessionParseCachePersist(parseStats)
+
+      return {
+        sessions: mergeSessions(cappedSessions, scopeSessions),
+        issues: issues.map((issue) => ({ executionHostId, ...issue })),
+        scannedAt: new Date().toISOString()
+      }
     })
-
-    const cappedSessions = dedupeCodexSessionsBySessionId(parsedSessions)
-      .sort((left, right) => sessionSortTime(right) - sessionSortTime(left))
-      .slice(0, limit)
-
-    const scopeSessions = await scanInScopeSessions({
-      discoveries,
-      scopePaths: options.scopePaths ?? [],
-      limit,
-      alreadyParsedFilePaths: new Set(cappedSessions.map((session) => session.filePath)),
-      platform,
-      executionHostId,
-      issues,
-      parseStats,
-      signal: options.signal
-    })
-    // Scope discovery can return without parsing anything, so an abort landing
-    // here would otherwise persist and return a cancelled scan as complete.
-    throwIfAiVaultScanCancelled(options.signal)
-
-    span.setAttribute('candidates', candidates.length)
-    span.setAttribute('reused', parseStats.reused)
-    span.setAttribute('incremental', parseStats.incremental)
-    span.setAttribute('fullParses', parseStats.fullParses)
-    span.setAttribute('earlyStopped', parseStats.earlyStopped)
-    span.setAttribute('bytesRead', parseStats.bytesRead)
-    span.setAttribute('issues', issues.length)
-
-    scheduleSessionParseCachePersist(parseStats)
-
-    return {
-      sessions: mergeSessions(cappedSessions, scopeSessions),
-      issues: issues.map((issue) => ({ executionHostId, ...issue })),
-      scannedAt: new Date().toISOString()
-    }
-  })
+  )
 }
 
 // In-scope sessions are guaranteed regardless of the recency cap, so the global

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -6,19 +6,13 @@ import type {
 import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../shared/execution-host'
 import { withSpan } from '../observability/tracer'
 import { sessionSortTime } from './session-scanner-accumulator'
-import {
-  codexRolloutHardlinkIdentity,
-  dedupeCodexRolloutAliases,
-  dedupeCodexSessionsBySessionId
-} from './codex-session-root-dedup'
-import { readCodexRolloutSessionMetaId } from '../codex/codex-rollout-session-meta'
+import { dedupeCodexSessionsBySessionId } from './codex-session-root-dedup'
 import {
   createAntigravityWorkspaceResolver,
   readLocalAntigravityHistory,
   type AntigravityWorkspaceResolver
 } from './session-scanner-antigravity-history'
-import { antigravityHistoryPathForBrainDir } from './session-scanner-antigravity-paths'
-import { codexHomeForSessionsDir } from './session-scanner-codex-paths'
+import { sessionCandidatesFromDiscoveries } from './session-scanner-candidates'
 import {
   ensureSessionParseCacheLoaded,
   scheduleSessionParseCachePersist
@@ -30,10 +24,7 @@ import {
 } from './session-scanner-parse-cache'
 import { recordSessionScanIssue } from './session-scan-issues'
 import { discoverInScopeClaudeFiles } from './session-scanner-scope-discovery'
-import {
-  DEFAULT_CODEX_HOME_DIR,
-  discoverAiVaultSessionSources
-} from './session-scanner-source-discovery'
+import { discoverAiVaultSessionSources } from './session-scanner-source-discovery'
 import type {
   AiVaultScanOptions,
   SessionFileCandidate,
@@ -83,35 +74,7 @@ export async function scanAiVaultSessions(
     const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
     throwIfAiVaultScanCancelled(options.signal)
 
-    const candidates = await dedupeCodexRolloutAliases(
-      discoveries
-        .flatMap((discovery) =>
-          discovery.files.map((file): SessionFileCandidate => ({
-            agent: discovery.agent,
-            file,
-            codexHome:
-              discovery.agent === 'codex'
-                ? codexHomeForSessionsDir(
-                    discovery.rootDir,
-                    options.defaultCodexHomeDir ?? DEFAULT_CODEX_HOME_DIR
-                  )
-                : null,
-            antigravityHistoryPath:
-              discovery.agent === 'antigravity'
-                ? antigravityHistoryPathForBrainDir(discovery.rootDir)
-                : undefined
-          }))
-        )
-        .sort((left, right) => right.file.mtimeMs - left.file.mtimeMs),
-      {
-        isCodex: (candidate) => candidate.agent === 'codex',
-        getFilePath: (candidate) => candidate.file.path,
-        getCodexHome: (candidate) => candidate.codexHome,
-        getHardlinkIdentity: (candidate) => codexRolloutHardlinkIdentity(candidate.file)
-      },
-      (filePath) => readCodexRolloutSessionMetaId(filePath, options.signal, 'scan'),
-      options.signal
-    )
+    const candidates = await sessionCandidatesFromDiscoveries(discoveries, options)
 
     const parsedSessions = await parseSessionCandidates({
       candidates: candidates.slice(0, limit * SESSION_PARSE_CANDIDATE_MULTIPLIER),

--- a/src/main/ai-vault/session-sidecar-stat.test.ts
+++ b/src/main/ai-vault/session-sidecar-stat.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from 'vitest'
+import { sidecarUnchanged, type SessionSidecarStat } from './session-sidecar-stat'
+
+const META: SessionSidecarStat = { path: '/chats/a/meta.json', mtimeMs: 100, sizeBytes: 20 }
+
+it('holds when the agent has no sidecar at all', () => {
+  expect(sidecarUnchanged('none', 'none')).toBe(true)
+  expect(sidecarUnchanged(undefined, undefined)).toBe(true)
+  expect(sidecarUnchanged(undefined, 'none')).toBe(true)
+})
+
+it('holds only for an identical observation', () => {
+  expect(sidecarUnchanged({ ...META }, META)).toBe(true)
+  expect(sidecarUnchanged({ ...META, mtimeMs: 101 }, META)).toBe(false)
+  expect(sidecarUnchanged({ ...META, sizeBytes: 21 }, META)).toBe(false)
+  expect(sidecarUnchanged({ ...META, path: '/chats/b/meta.json' }, META)).toBe(false)
+})
+
+it('never concludes anything from an unreadable sidecar', () => {
+  expect(sidecarUnchanged('unknown', META)).toBe(false)
+  expect(sidecarUnchanged(META, 'unknown')).toBe(false)
+  expect(sidecarUnchanged('unknown', 'unknown')).toBe(false)
+})
+
+it('reads a missing cached observation as unknown, not as absent', () => {
+  // An entry seeded from a cache file older than the field.
+  expect(sidecarUnchanged(undefined, META)).toBe(false)
+  expect(sidecarUnchanged('none', META)).toBe(false)
+})

--- a/src/main/ai-vault/session-sidecar-stat.test.ts
+++ b/src/main/ai-vault/session-sidecar-stat.test.ts
@@ -1,29 +1,74 @@
-import { expect, it } from 'vitest'
-import { sidecarUnchanged, type SessionSidecarStat } from './session-sidecar-stat'
+import { describe, expect, it } from 'vitest'
+import { sidecarUnchanged, type SessionSidecarObservation } from './session-sidecar-stat'
 
-const META: SessionSidecarStat = { path: '/chats/a/meta.json', mtimeMs: 100, sizeBytes: 20 }
+const META = { path: '/chats/a/meta.json', mtimeMs: 100, sizeBytes: 20 } as const
+const OTHER = { path: '/chats/a/meta.json', mtimeMs: 101, sizeBytes: 20 } as const
 
-it('holds when the agent has no sidecar at all', () => {
-  expect(sidecarUnchanged('none', 'none')).toBe(true)
+type Named = [label: string, value: SessionSidecarObservation | undefined]
+
+const ENTRIES: Named[] = [
+  ['undefined', undefined],
+  ["'none'", 'none'],
+  ["'unknown'", 'unknown'],
+  ['object', { ...META }]
+]
+const OBSERVED: Named[] = [
+  ['undefined', undefined],
+  ["'none'", 'none'],
+  ["'unknown'", 'unknown'],
+  ['same object', { ...META }],
+  ['different object', { ...OTHER }]
+]
+
+// entry (row) x observed (column). A `true` cell is a cache hit.
+const TRUTH_TABLE: Record<string, Record<string, boolean>> = {
+  undefined: {
+    undefined: true,
+    "'none'": true,
+    "'unknown'": false,
+    'same object': false,
+    'different object': false
+  },
+  "'none'": {
+    undefined: true,
+    "'none'": true,
+    "'unknown'": false,
+    'same object': false,
+    'different object': false
+  },
+  "'unknown'": {
+    undefined: false,
+    "'none'": false,
+    "'unknown'": false,
+    'same object': false,
+    'different object': false
+  },
+  object: {
+    undefined: false,
+    "'none'": false,
+    "'unknown'": false,
+    'same object': true,
+    'different object': false
+  }
+}
+
+describe.each(ENTRIES)('cached %s', (entryLabel, entry) => {
+  it.each(OBSERVED)(`vs observed %s`, (observedLabel, observed) => {
+    expect(sidecarUnchanged(entry, observed)).toBe(TRUTH_TABLE[entryLabel][observedLabel])
+  })
+})
+
+it('treats a vanished sidecar as a change, not as "never had one"', () => {
+  expect(sidecarUnchanged({ ...META }, 'none')).toBe(false)
+})
+
+it('never concludes anything from an unreadable sidecar, in either position', () => {
+  expect(sidecarUnchanged('unknown', 'none')).toBe(false)
+  expect(sidecarUnchanged('unknown', { ...META })).toBe(false)
+  expect(sidecarUnchanged({ ...META }, 'unknown')).toBe(false)
+})
+
+it('keeps an agent with no sidecar at all a cache hit', () => {
   expect(sidecarUnchanged(undefined, undefined)).toBe(true)
   expect(sidecarUnchanged(undefined, 'none')).toBe(true)
-})
-
-it('holds only for an identical observation', () => {
-  expect(sidecarUnchanged({ ...META }, META)).toBe(true)
-  expect(sidecarUnchanged({ ...META, mtimeMs: 101 }, META)).toBe(false)
-  expect(sidecarUnchanged({ ...META, sizeBytes: 21 }, META)).toBe(false)
-  expect(sidecarUnchanged({ ...META, path: '/chats/b/meta.json' }, META)).toBe(false)
-})
-
-it('never concludes anything from an unreadable sidecar', () => {
-  expect(sidecarUnchanged('unknown', META)).toBe(false)
-  expect(sidecarUnchanged(META, 'unknown')).toBe(false)
-  expect(sidecarUnchanged('unknown', 'unknown')).toBe(false)
-})
-
-it('reads a missing cached observation as unknown, not as absent', () => {
-  // An entry seeded from a cache file older than the field.
-  expect(sidecarUnchanged(undefined, META)).toBe(false)
-  expect(sidecarUnchanged('none', META)).toBe(false)
 })

--- a/src/main/ai-vault/session-sidecar-stat.ts
+++ b/src/main/ai-vault/session-sidecar-stat.ts
@@ -1,0 +1,45 @@
+// Why: some agents keep part of a session beside its transcript — Cursor's
+// chat meta.json, Cline's messages file. Folding that file's stat into the
+// transcript's own mtime/size makes one key mean two things, so a byte offset
+// into the transcript can no longer be compared against it and a refused read
+// of the sibling takes the transcript down with it. The sidecar is observed
+// separately and compared separately.
+
+export type SessionSidecarStat = {
+  path: string
+  mtimeMs: number
+  sizeBytes: number
+}
+
+export type SessionSidecarObservation =
+  | SessionSidecarStat
+  /** This agent declares no sidecar, or it does not exist. */
+  | 'none'
+  /** It could not be read this scan; nothing may be concluded from its absence. */
+  | 'unknown'
+
+/**
+ * Whether a cached observation still describes what discovery just saw.
+ *
+ * Asymmetric on purpose: `file` is observed now, so a missing value means the
+ * agent has no sidecar, while `entry` may predate the field (an entry seeded
+ * from a cache file an older build wrote), so a missing value means unknown.
+ */
+export function sidecarUnchanged(
+  entry: SessionSidecarObservation | undefined,
+  file: SessionSidecarObservation | undefined
+): boolean {
+  const observed = file ?? 'none'
+  if (observed === 'none') {
+    return true
+  }
+  if (observed === 'unknown') {
+    return false
+  }
+  return (
+    typeof entry === 'object' &&
+    entry.path === observed.path &&
+    entry.mtimeMs === observed.mtimeMs &&
+    entry.sizeBytes === observed.sizeBytes
+  )
+}

--- a/src/main/ai-vault/session-sidecar-stat.ts
+++ b/src/main/ai-vault/session-sidecar-stat.ts
@@ -24,17 +24,21 @@ export type SessionSidecarObservation =
  * Asymmetric on purpose: `file` is observed now, so a missing value means the
  * agent has no sidecar, while `entry` may predate the field (an entry seeded
  * from a cache file an older build wrote), so a missing value means unknown.
+ *
+ * `'none'` is a claim, not an absence of one: a sidecar that was there and is
+ * gone changed, and one that was unreadable last time is still unknown now.
  */
 export function sidecarUnchanged(
   entry: SessionSidecarObservation | undefined,
   file: SessionSidecarObservation | undefined
 ): boolean {
   const observed = file ?? 'none'
-  if (observed === 'none') {
-    return true
-  }
-  if (observed === 'unknown') {
+  if (observed === 'unknown' || entry === 'unknown') {
     return false
+  }
+  if (observed === 'none') {
+    // Absent now: a hit only if it was absent before, or the agent never had one.
+    return entry === undefined || entry === 'none'
   }
   return (
     typeof entry === 'object' &&

--- a/src/main/ai-vault/session-title-file-reader.ts
+++ b/src/main/ai-vault/session-title-file-reader.ts
@@ -31,6 +31,9 @@ async function readOneTitle(
     if (!stats.isFile() || signal?.aborted) {
       return null
     }
+    // Why: this key is a raw lstat with no content dependency, so it only
+    // matches the scanner's for providers that declare none — today claude and
+    // codex, which is all this request type carries.
     const session = await parseAgentSessionFileCached(
       {
         agent: request.agent,

--- a/src/main/ai-vault/session-transcript-channel.ts
+++ b/src/main/ai-vault/session-transcript-channel.ts
@@ -1,0 +1,92 @@
+import {
+  hasTranscriptConsumers,
+  transcriptConsumers,
+  type TranscriptMessage,
+  type TranscriptMessageSink,
+  type TranscriptReadConsumer,
+  type TranscriptReadOutcome,
+  type TranscriptReadStart
+} from './session-transcript-consumers'
+
+/**
+ * The sink a parser pushes into, and the fan-out to every registered consumer.
+ *
+ * One channel belongs to one file for as long as its resumable parse state
+ * lives, because the cached state (and every clone of it) holds this reference.
+ * A read re-points the channel at that read's consumers instead of replacing it.
+ */
+export class TranscriptMessageChannel implements TranscriptMessageSink {
+  private readers: TranscriptReadConsumer[] = []
+
+  private muted = false
+
+  /** True while a read is open with at least one consumer attached. */
+  get active(): boolean {
+    return this.readers.length > 0
+  }
+
+  beginRead(start: TranscriptReadStart): void {
+    this.muted = false
+    this.readers = []
+    // Keeps a scan with no consumers allocation-free on its hottest path.
+    if (!hasTranscriptConsumers()) {
+      return
+    }
+    for (const consumer of transcriptConsumers()) {
+      try {
+        const reader = consumer.beginRead(start)
+        if (reader) {
+          this.readers.push(reader)
+        }
+      } catch {
+        // A consumer that cannot open this read simply does not see it.
+      }
+    }
+  }
+
+  push(message: TranscriptMessage): void {
+    if (this.muted || this.readers.length === 0) {
+      return
+    }
+    // A throwing consumer is dropped for the rest of the read rather than
+    // failing the parse; it then gets no `finish`, so it never records a cursor
+    // for a stream it did not see in full.
+    let index = 0
+    while (index < this.readers.length) {
+      try {
+        this.readers[index].message(message)
+        index++
+      } catch {
+        this.readers.splice(index, 1)
+      }
+    }
+  }
+
+  /**
+   * Suppresses emission for a display-only re-read: the trailing unterminated
+   * line is shown in the list but is re-read once complete, so emitting it here
+   * would hand every consumer the same line twice. `fn` must be synchronous.
+   */
+  mute<T>(fn: () => T): T {
+    const previous = this.muted
+    this.muted = true
+    try {
+      return fn()
+    } finally {
+      this.muted = previous
+    }
+  }
+
+  finishRead(outcome: TranscriptReadOutcome): void {
+    const readers = this.readers
+    this.readers = []
+    this.muted = false
+    for (const reader of readers) {
+      try {
+        reader.finish(outcome)
+      } catch {
+        // A consumer failure must never fail the session list.
+      }
+    }
+  }
+}

--- a/src/main/ai-vault/session-transcript-consumers.test.ts
+++ b/src/main/ai-vault/session-transcript-consumers.test.ts
@@ -1,0 +1,212 @@
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it } from 'vitest'
+import { scanAiVaultSessions } from './session-scanner'
+import { resetSessionParseCacheForTests } from './session-scanner-parse-cache'
+import { isolatedScanRoots, jsonLines } from './session-scanner-test-fixtures'
+import {
+  registerTranscriptConsumer,
+  resetTranscriptConsumersForTests,
+  type TranscriptMessage,
+  type TranscriptReadOutcome,
+  type TranscriptReadStart
+} from './session-transcript-consumers'
+
+type RecordedRead = {
+  start: TranscriptReadStart
+  messages: TranscriptMessage[]
+  outcome: TranscriptReadOutcome | null
+}
+
+function recordingConsumer(): { reads: RecordedRead[]; unregister: () => void } {
+  const reads: RecordedRead[] = []
+  const unregister = registerTranscriptConsumer({
+    beginRead: (start) => {
+      const read: RecordedRead = { start, messages: [], outcome: null }
+      reads.push(read)
+      return {
+        message: (message) => read.messages.push(message),
+        finish: (outcome) => {
+          read.outcome = outcome
+        }
+      }
+    }
+  })
+  return { reads, unregister }
+}
+
+function textsFor(reads: RecordedRead[], agent: string): string[] {
+  return reads
+    .filter((read) => read.start.candidate.agent === agent)
+    .flatMap((read) => read.messages.map((message) => `${message.role}:${message.text}`))
+}
+
+let tempRoots: string[] = []
+
+afterEach(async () => {
+  resetTranscriptConsumersForTests()
+  resetSessionParseCacheForTests()
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
+  tempRoots = []
+})
+
+function claudeTurns(from: number, to: number): unknown[] {
+  const records: unknown[] = []
+  for (let index = from; index <= to; index++) {
+    records.push({
+      type: 'user',
+      sessionId: 'claude-session',
+      timestamp: `2026-05-01T10:0${index}:00.000Z`,
+      cwd: '/tmp/claude',
+      message: { role: 'user', content: `ask ${index}` }
+    })
+    records.push({
+      type: 'assistant',
+      sessionId: 'claude-session',
+      timestamp: `2026-05-01T10:0${index}:01.000Z`,
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: `reply ${index}` },
+          { type: 'tool_use', name: 'Bash', input: { command: `ls ${index}` } }
+        ]
+      }
+    })
+  }
+  return records
+}
+
+async function writeClaudeFixture(): Promise<{
+  root: string
+  roots: ReturnType<typeof isolatedScanRoots>
+  transcript: string
+}> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-transcript-consumers-'))
+  tempRoots.push(root)
+  const roots = isolatedScanRoots(root)
+  const transcript = join(roots.claudeProjectsDir, 'project', 'claude-session.jsonl')
+  await mkdir(join(roots.claudeProjectsDir, 'project'), { recursive: true })
+  await writeFile(transcript, `${jsonLines(claudeTurns(1, 4))}\n`)
+  return { root, roots, transcript }
+}
+
+it('delivers one message stream to every registered consumer', async () => {
+  const { roots } = await writeClaudeFixture()
+  const first = recordingConsumer()
+  const second = recordingConsumer()
+
+  const result = await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
+
+  expect(result.issues).toEqual([])
+  const stream = textsFor(first.reads, 'claude')
+  expect(stream).toEqual(textsFor(second.reads, 'claude'))
+  expect(stream).toEqual([
+    'user:ask 1',
+    'assistant:reply 1',
+    'tool:Bash: ls 1',
+    'user:ask 2',
+    'assistant:reply 2',
+    'tool:Bash: ls 2',
+    'user:ask 3',
+    'assistant:reply 3',
+    'tool:Bash: ls 3',
+    'user:ask 4',
+    'assistant:reply 4',
+    'tool:Bash: ls 4'
+  ])
+  // The list's own fold keeps only the newest five preview turns, so the stream
+  // is demonstrably the reader's, not a projection of the session row.
+  const session = result.sessions.find((entry) => entry.agent === 'claude')
+  expect(session?.previewMessages).toHaveLength(5)
+  expect(session?.messageCount).toBe(8)
+})
+
+it('leaves the session list identical whether or not a consumer is registered', async () => {
+  const withoutConsumer = await writeClaudeFixture()
+  const bare = await scanAiVaultSessions({
+    ...withoutConsumer.roots,
+    platform: 'darwin',
+    limit: 20
+  })
+
+  resetSessionParseCacheForTests()
+  recordingConsumer()
+  const observed = await scanAiVaultSessions({
+    ...withoutConsumer.roots,
+    platform: 'darwin',
+    limit: 20
+  })
+
+  expect(observed.sessions).toEqual(bare.sessions)
+})
+
+it('replays only the appended lines on a resumed read', async () => {
+  const { roots, transcript } = await writeClaudeFixture()
+  const consumer = recordingConsumer()
+  await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
+  const firstRead = consumer.reads.at(-1)
+  expect(firstRead?.start.mode).toBe('replace')
+  expect(firstRead?.start.previousByteOffset).toBe(0)
+  expect(firstRead?.outcome?.incomplete).toBe(false)
+
+  await appendFile(transcript, `${jsonLines(claudeTurns(5, 5))}\n`)
+  consumer.reads.length = 0
+  await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
+
+  const resumed = consumer.reads.find((read) => read.start.candidate.agent === 'claude')
+  expect(resumed?.start.mode).toBe('append')
+  expect(resumed?.start.previousByteOffset).toBe(firstRead?.outcome?.byteOffset)
+  expect(textsFor(consumer.reads, 'claude')).toEqual([
+    'user:ask 5',
+    'assistant:reply 5',
+    'tool:Bash: ls 5'
+  ])
+})
+
+it('publishes a trailing unterminated line once, when it is complete', async () => {
+  const { roots, transcript } = await writeClaudeFixture()
+  const consumer = recordingConsumer()
+  await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
+
+  // A half-written record: the list shows it, the stream must not carry it yet.
+  const [partial] = claudeTurns(5, 5)
+  await appendFile(transcript, JSON.stringify(partial))
+  consumer.reads.length = 0
+  await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
+  expect(textsFor(consumer.reads, 'claude')).toEqual([])
+
+  await appendFile(transcript, '\n')
+  consumer.reads.length = 0
+  await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
+  expect(textsFor(consumer.reads, 'claude')).toEqual(['user:ask 5'])
+})
+
+it('keeps the session list working when a consumer throws', async () => {
+  const { roots } = await writeClaudeFixture()
+  registerTranscriptConsumer({
+    beginRead: () => ({
+      message: () => {
+        throw new Error('consumer exploded')
+      },
+      finish: () => undefined
+    })
+  })
+  const healthy = recordingConsumer()
+
+  const result = await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
+
+  expect(result.issues).toEqual([])
+  expect(result.sessions.find((entry) => entry.agent === 'claude')?.messageCount).toBe(8)
+  expect(textsFor(healthy.reads, 'claude')).toHaveLength(12)
+})
+
+it('skips a read a consumer declines without disturbing the others', async () => {
+  const { roots } = await writeClaudeFixture()
+  registerTranscriptConsumer({ beginRead: () => null })
+  const healthy = recordingConsumer()
+
+  await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
+
+  expect(textsFor(healthy.reads, 'claude')).toHaveLength(12)
+})

--- a/src/main/ai-vault/session-transcript-consumers.test.ts
+++ b/src/main/ai-vault/session-transcript-consumers.test.ts
@@ -1,10 +1,29 @@
-import { appendFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, expect, it } from 'vitest'
+import { afterEach, expect, it, vi } from 'vitest'
 import { scanAiVaultSessions } from './session-scanner'
-import { resetSessionParseCacheForTests } from './session-scanner-parse-cache'
+import {
+  parseAgentSessionFileCached,
+  resetSessionParseCacheForTests
+} from './session-scanner-parse-cache'
 import { isolatedScanRoots, jsonLines } from './session-scanner-test-fixtures'
+import type { FileWithMtime, SessionFileCandidate } from './session-scanner-types'
+import { readWholeTranscript } from './session-transcript-reader'
+
+const OPENCODE_SQLITE_SESSION = {
+  id: 'local:opencode:sqlite-session:db',
+  agent: 'opencode' as const,
+  sessionId: 'sqlite-session'
+}
+
+// Stands in for the worker thread: the point is that its messages never come
+// back over the channel, not what the SQLite read returns.
+vi.mock('./session-scanner-opencode-sqlite-worker-spawn', async (importOriginal) => ({
+  ...(await importOriginal<typeof OpenCodeSqliteWorkerSpawn>()),
+  parseOpenCodeSqliteSessionViaWorker: () => Promise.resolve(OPENCODE_SQLITE_SESSION)
+}))
+import type * as OpenCodeSqliteWorkerSpawn from './session-scanner-opencode-sqlite-worker-spawn'
 import {
   registerTranscriptConsumer,
   resetTranscriptConsumersForTests,
@@ -209,4 +228,71 @@ it('skips a read a consumer declines without disturbing the others', async () =>
   await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
 
   expect(textsFor(healthy.reads, 'claude')).toHaveLength(12)
+})
+
+async function claudeCandidate(transcript: string): Promise<SessionFileCandidate> {
+  const stats = await stat(transcript)
+  const file: FileWithMtime = {
+    path: transcript,
+    mtimeMs: stats.mtimeMs,
+    modifiedAt: stats.mtime.toISOString(),
+    sizeBytes: stats.size
+  }
+  return { agent: 'claude', file, codexHome: null }
+}
+
+it('serializes overlapping parses of one path so no consumer read is orphaned', async () => {
+  const { transcript } = await writeClaudeFixture()
+  // Seed a resume point: the channel it stores is what concurrent reads share.
+  await parseAgentSessionFileCached(await claudeCandidate(transcript), 'darwin')
+
+  await appendFile(transcript, `${jsonLines(claudeTurns(5, 5))}\n`)
+  const consumer = recordingConsumer()
+  const appended = await claudeCandidate(transcript)
+
+  const [first, second] = await Promise.all([
+    parseAgentSessionFileCached(appended, 'darwin'),
+    parseAgentSessionFileCached(appended, 'darwin')
+  ])
+
+  // Every read that opened must also close, or its consumer keeps a half-read
+  // stream forever and never learns the outcome.
+  expect(consumer.reads.filter((read) => read.outcome === null)).toEqual([])
+  expect(consumer.reads).toHaveLength(1)
+  expect(consumer.reads[0].start.mode).toBe('append')
+  expect(textsFor(consumer.reads, 'claude')).toEqual([
+    'user:ask 5',
+    'assistant:reply 5',
+    'tool:Bash: ls 5'
+  ])
+  // The later caller reuses the stored entry rather than moving the cursor back.
+  expect(first?.messageCount).toBe(10)
+  expect(second?.messageCount).toBe(10)
+})
+
+it('reports a read whose parser cannot publish its messages as not complete', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'orca-transcript-opencode-'))
+  tempRoots.push(root)
+  const dbPath = join(root, 'opencode.db')
+  await writeFile(dbPath, '')
+  const consumer = recordingConsumer()
+
+  const session = await readWholeTranscript({
+    candidate: {
+      agent: 'opencode',
+      codexHome: null,
+      file: {
+        path: `${dbPath}#sqlite-session`,
+        mtimeMs: 1,
+        modifiedAt: new Date(1).toISOString(),
+        sizeBytes: 10
+      }
+    },
+    platform: 'darwin'
+  })
+
+  expect(session).toEqual(OPENCODE_SQLITE_SESSION)
+  expect(consumer.reads).toHaveLength(1)
+  expect(consumer.reads[0].messages).toEqual([])
+  expect(consumer.reads[0].outcome?.incomplete).toBe(true)
 })

--- a/src/main/ai-vault/session-transcript-consumers.test.ts
+++ b/src/main/ai-vault/session-transcript-consumers.test.ts
@@ -296,3 +296,35 @@ it('reports a read whose parser cannot publish its messages as not complete', as
   expect(consumer.reads[0].messages).toEqual([])
   expect(consumer.reads[0].outcome?.incomplete).toBe(true)
 })
+
+it('reports the transcript size, not the cache key, as a whole-file read offset', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'orca-transcript-cline-'))
+  tempRoots.push(root)
+  const roots = isolatedScanRoots(root)
+  // Cline is whole-file and declares a sibling content dependency, so its cache
+  // key covers two files while the read covers one.
+  const sessionDir = join(roots.clineSessionsDir, 'cline-session')
+  await mkdir(sessionDir, { recursive: true })
+  const metadataPath = join(sessionDir, 'cline-session.json')
+  await writeFile(
+    metadataPath,
+    JSON.stringify({
+      session_id: 'cline-session',
+      started_at: '2026-05-01T10:00:00.000Z',
+      cwd: '/tmp/cline'
+    })
+  )
+  await writeFile(
+    join(sessionDir, 'cline-session.messages.json'),
+    JSON.stringify({
+      updated_at: '2026-05-01T10:00:01.000Z',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'x'.repeat(400) }] }]
+    })
+  )
+  const consumer = recordingConsumer()
+
+  await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
+
+  const read = consumer.reads.find((entry) => entry.start.candidate.agent === 'cline')
+  expect(read?.outcome?.byteOffset).toBe((await stat(metadataPath)).size)
+})

--- a/src/main/ai-vault/session-transcript-consumers.ts
+++ b/src/main/ai-vault/session-transcript-consumers.ts
@@ -1,0 +1,81 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+// Why: the transcript reader owns discovery, per-file cursors and decoding; a
+// consumer only folds the message stream. Registering a second consumer (a
+// search index, a digest) must not require touching the reader or the parse
+// cache, so the reader publishes reads rather than knowing who reads them.
+
+export type TranscriptMessageRole = 'user' | 'assistant' | 'tool'
+
+export type TranscriptMessage = {
+  role: TranscriptMessageRole
+  /** Untruncated decoded text; caps and redaction are consumer policy. */
+  text: string
+  timestamp: string | null
+}
+
+/** Where a parser hands its decoded messages; the reader supplies the instance. */
+export type TranscriptMessageSink = {
+  /** False when nobody is listening: parsers skip the extraction entirely. */
+  readonly active: boolean
+  push(message: TranscriptMessage): void
+}
+
+export const NO_TRANSCRIPT_MESSAGES: TranscriptMessageSink = {
+  active: false,
+  push: () => undefined
+}
+
+export type TranscriptReadStart = {
+  candidate: SessionFileCandidate
+  /** `replace`: the whole file is being re-read; `append`: a resumed read. */
+  mode: 'replace' | 'append'
+  /** Byte offset the messages of this read continue from. */
+  previousByteOffset: number
+}
+
+export type TranscriptReadOutcome = {
+  /** Null when the parser rejected the file (an excluded Codex worker transcript). */
+  session: AiVaultSession | null
+  /** Byte offset just past the last complete line this read consumed. */
+  byteOffset: number
+  /** The read did not cover the whole span; its messages are not the whole file. */
+  incomplete: boolean
+}
+
+/** One consumer's view of one file read. */
+export type TranscriptReadConsumer = {
+  message(message: TranscriptMessage): void
+  finish(outcome: TranscriptReadOutcome): void
+}
+
+export type TranscriptConsumer = {
+  /**
+   * Open this read, or return null to ignore it. A consumer whose own cursor is
+   * behind `previousByteOffset` declines here and re-reads on its own schedule;
+   * it must never ask another consumer where it is.
+   */
+  beginRead(start: TranscriptReadStart): TranscriptReadConsumer | null
+}
+
+const consumers = new Set<TranscriptConsumer>()
+
+export function registerTranscriptConsumer(consumer: TranscriptConsumer): () => void {
+  consumers.add(consumer)
+  return () => {
+    consumers.delete(consumer)
+  }
+}
+
+export function transcriptConsumers(): readonly TranscriptConsumer[] {
+  return [...consumers]
+}
+
+export function hasTranscriptConsumers(): boolean {
+  return consumers.size > 0
+}
+
+export function resetTranscriptConsumersForTests(): void {
+  consumers.clear()
+}

--- a/src/main/ai-vault/session-transcript-consumers.ts
+++ b/src/main/ai-vault/session-transcript-consumers.ts
@@ -40,7 +40,11 @@ export type TranscriptReadOutcome = {
   session: AiVaultSession | null
   /** Byte offset just past the last complete line this read consumed. */
   byteOffset: number
-  /** The read did not cover the whole span; its messages are not the whole file. */
+  /**
+   * The messages of this read are not the whole span: the read failed part way,
+   * or the parser decodes where the channel cannot reach it. A consumer must
+   * not record a cursor for an incomplete read.
+   */
   incomplete: boolean
 }
 

--- a/src/main/ai-vault/session-transcript-message-content.test.ts
+++ b/src/main/ai-vault/session-transcript-message-content.test.ts
@@ -1,0 +1,61 @@
+import { expect, it } from 'vitest'
+import { transcriptMessagesFromContent } from './session-transcript-message-content'
+
+const AT = '2026-05-01T10:00:00.000Z'
+
+it('keeps a plain string turn under the record role', () => {
+  expect(transcriptMessagesFromContent('user', 'just words', AT)).toEqual([
+    { role: 'user', text: 'just words', timestamp: AT }
+  ])
+})
+
+it('drops turns whose role a consumer cannot use', () => {
+  expect(transcriptMessagesFromContent('system', 'boot', AT)).toEqual([])
+  expect(transcriptMessagesFromContent('unknown', 'noise', AT)).toEqual([])
+})
+
+it('joins text blocks and appends tool blocks as their own messages', () => {
+  expect(
+    transcriptMessagesFromContent(
+      'assistant',
+      [
+        { type: 'text', text: 'first' },
+        { type: 'tool_use', name: 'Bash', input: { command: 'ls -la', description: 'ignored' } },
+        { type: 'thinking', text: 'second' },
+        { type: 'image', source: {} }
+      ],
+      AT
+    )
+  ).toEqual([
+    { role: 'assistant', text: 'first\nsecond', timestamp: AT },
+    { role: 'tool', text: 'Bash: ls -la', timestamp: AT }
+  ])
+})
+
+it('reads a tool result carried on a user record as a tool message', () => {
+  expect(
+    transcriptMessagesFromContent(
+      'user',
+      [{ type: 'tool_result', content: [{ type: 'text', text: 'exit 0' }] }],
+      AT
+    )
+  ).toEqual([{ role: 'tool', text: 'exit 0', timestamp: AT }])
+})
+
+it('names a tool call even with no recognisable argument', () => {
+  expect(
+    transcriptMessagesFromContent('assistant', [{ type: 'tool_use', name: 'Read', input: {} }], AT)
+  ).toEqual([{ role: 'tool', text: 'Read', timestamp: AT }])
+})
+
+it('emits nothing for blank or absent content', () => {
+  expect(transcriptMessagesFromContent('user', '   ', AT)).toEqual([])
+  expect(transcriptMessagesFromContent('user', null, AT)).toEqual([])
+  expect(transcriptMessagesFromContent('assistant', [{ type: 'tool_use' }], AT)).toEqual([])
+})
+
+it('does not apply the list preview cap', () => {
+  const long = 'x'.repeat(5000)
+  const [message] = transcriptMessagesFromContent('user', [{ type: 'text', text: long }], AT)
+  expect(message.text).toHaveLength(5000)
+})

--- a/src/main/ai-vault/session-transcript-message-content.ts
+++ b/src/main/ai-vault/session-transcript-message-content.ts
@@ -1,0 +1,138 @@
+import { asRecord } from './session-scanner-record-value'
+import { sliceAtCodeUnitLimit } from './session-scanner-text-normalization'
+import type { AiVaultSessionPreviewMessage } from '../../shared/ai-vault-types'
+import type { TranscriptMessage, TranscriptMessageRole } from './session-transcript-consumers'
+
+// Safety bound only: a consumer applies its own caps. Matches the first-prompt
+// copy path's ceiling so one pathological paste cannot dominate a scan.
+const TRANSCRIPT_MESSAGE_TEXT_LIMIT = 256 * 1024
+const TOOL_ARGUMENT_SCAN_LIMIT = 2000
+
+const TEXT_BLOCK_TYPES = new Set(['text', 'input_text', 'output_text', 'thinking', 'reasoning'])
+// The argument that identifies what a tool call actually did.
+const TOOL_INPUT_KEYS = ['command', 'cmd', 'file_path', 'path', 'pattern', 'query', 'description']
+
+type PreviewRole = AiVaultSessionPreviewMessage['role']
+
+/** Only conversational roles reach consumers; system/unknown turns are noise. */
+export function transcriptMessageRole(role: PreviewRole): TranscriptMessageRole | null {
+  return role === 'user' || role === 'assistant' || role === 'tool' ? role : null
+}
+
+export function toolCallText(name: unknown, input: unknown): string | null {
+  const toolName = typeof name === 'string' && name.trim() ? name.trim() : null
+  const inputRecord = asRecord(input)
+  let argument: string | null = null
+  if (inputRecord) {
+    for (const key of TOOL_INPUT_KEYS) {
+      const value = inputRecord[key]
+      if (typeof value === 'string' && value.trim()) {
+        argument = value
+        break
+      }
+    }
+  } else if (typeof input === 'string' && input.trim()) {
+    argument = input
+  }
+  if (!toolName && !argument) {
+    return null
+  }
+  const bounded = argument ? sliceAtCodeUnitLimit(argument, TOOL_ARGUMENT_SCAN_LIMIT) : null
+  return toolName && bounded ? `${toolName}: ${bounded}` : (toolName ?? bounded)
+}
+
+/** Flattens a tool_result body (a string, or an array of text blocks). */
+function toolResultText(content: unknown): string | null {
+  if (typeof content === 'string') {
+    return content.trim() ? content : null
+  }
+  if (!Array.isArray(content)) {
+    return null
+  }
+  const parts: string[] = []
+  let length = 0
+  for (const item of content) {
+    const text = typeof item === 'string' ? item : asRecord(item)?.text
+    if (typeof text === 'string' && text) {
+      parts.push(text)
+      length += text.length
+      if (length >= TRANSCRIPT_MESSAGE_TEXT_LIMIT) {
+        break
+      }
+    }
+  }
+  const joined = parts.join('\n')
+  return joined.trim() ? joined : null
+}
+
+/**
+ * Splits one provider content value into the messages it decodes to. Text
+ * blocks keep the record's role; tool_use and tool_result blocks become `tool`
+ * messages whichever record carried them (Claude stores tool results on user
+ * records), so a consumer never has to know a provider's record shapes.
+ */
+export function transcriptMessagesFromContent(
+  role: PreviewRole,
+  content: unknown,
+  timestamp: string | null
+): TranscriptMessage[] {
+  const messages: TranscriptMessage[] = []
+  const textRole = transcriptMessageRole(role)
+  if (typeof content === 'string') {
+    const text = boundedText(content)
+    return text && textRole ? [{ role: textRole, text, timestamp }] : []
+  }
+  const blocks = Array.isArray(content) ? content : content != null ? [content] : []
+  const textParts: string[] = []
+  for (const block of blocks) {
+    if (typeof block === 'string') {
+      textParts.push(block)
+      continue
+    }
+    const item = asRecord(block)
+    if (!item) {
+      continue
+    }
+    const type = typeof item.type === 'string' ? item.type : null
+    if (type === 'tool_use') {
+      pushMessage(messages, 'tool', toolCallText(item.name, item.input), timestamp)
+      continue
+    }
+    if (type === 'tool_result') {
+      pushMessage(messages, 'tool', toolResultText(item.content), timestamp)
+      continue
+    }
+    if (type !== null && !TEXT_BLOCK_TYPES.has(type)) {
+      continue
+    }
+    const text = typeof item.text === 'string' ? item.text : item.content
+    if (typeof text === 'string' && text) {
+      textParts.push(text)
+    }
+  }
+  if (textRole && textParts.length > 0) {
+    // The record's own words lead; its tool blocks follow in transcript order.
+    const text = boundedText(textParts.join('\n'))
+    if (text) {
+      messages.unshift({ role: textRole, text, timestamp })
+    }
+  }
+  return messages
+}
+
+function pushMessage(
+  messages: TranscriptMessage[],
+  role: TranscriptMessageRole,
+  text: string | null,
+  timestamp: string | null
+): void {
+  const bounded = text === null ? null : boundedText(text)
+  if (bounded) {
+    messages.push({ role, text: bounded, timestamp })
+  }
+}
+
+export function boundedText(value: string): string | null {
+  const bounded = sliceAtCodeUnitLimit(value, TRANSCRIPT_MESSAGE_TEXT_LIMIT)
+  return bounded.trim() ? bounded : null
+}

--- a/src/main/ai-vault/session-transcript-reader.ts
+++ b/src/main/ai-vault/session-transcript-reader.ts
@@ -1,0 +1,149 @@
+import { readTranscriptSlice } from '../native-chat/wsl-transcript-fs-access'
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { parseAgentSessionFile } from './session-scanner-agent-parser'
+import { consumeCompleteJsonlLines } from './session-scanner-jsonl-reader'
+import type { ResumableSessionParseState, SessionFileCandidate } from './session-scanner-types'
+import type { SessionParseResumePoint } from './session-parse-cache-store'
+import { TranscriptMessageChannel } from './session-transcript-channel'
+
+const NEWLINE_BYTE = 0x0a
+
+// Why: this layer owns reading a transcript and nothing else. It decides where
+// a read starts, drives the parser, publishes the decoded messages to every
+// registered consumer, and reports where the read ended. Which of those results
+// are cached, listed or indexed belongs to the callers.
+
+export type TranscriptReadStats = {
+  incremental: number
+  fullParses: number
+  // Transcripts the parser already excluded (Codex workers), re-listed after a
+  // write and dismissed without reading. Counted apart from `incremental` so a
+  // scan span still shows how much work the early stop actually removed.
+  earlyStopped: number
+  bytesRead: number
+}
+
+export type ResumableTranscriptRead = {
+  session: AiVaultSession | null
+  /** The fold to resume from next time, and the channel bound to it. */
+  resume: SessionParseResumePoint
+}
+
+/**
+ * Read an append-only transcript, resuming from `resume` when the file only
+ * grew and the recorded offset still sits on a line boundary. Anything else
+ * (a rewrite, a truncation, a platform change) re-reads the whole file.
+ */
+export async function readResumableTranscript(args: {
+  candidate: SessionFileCandidate
+  platform: NodeJS.Platform
+  resume: SessionParseResumePoint | null
+  stateFactory: (messages: TranscriptMessageChannel) => ResumableSessionParseState
+  stats?: TranscriptReadStats
+}): Promise<ResumableTranscriptRead> {
+  const { file } = args.candidate
+  const resume = args.resume
+  const canResume =
+    resume !== null &&
+    typeof file.sizeBytes === 'number' &&
+    file.sizeBytes >= resume.byteOffset &&
+    (resume.byteOffset === 0 || (await endsWithNewlineAt(file.path, resume.byteOffset)))
+
+  // Clone before consuming: a failed read must not corrupt the cached state,
+  // or the next resume would double-count the lines applied before the error.
+  const channel = canResume ? resume.channel : new TranscriptMessageChannel()
+  const state = canResume ? resume.state.clone() : args.stateFactory(channel)
+  const startOffset = canResume ? resume.byteOffset : 0
+  // Mirrors the reader's entry guard so a dismissed transcript is not reported
+  // as an incremental parse that read nothing.
+  const stoppedBeforeRead = state.shouldStop?.() === true
+  if (args.stats) {
+    if (stoppedBeforeRead) {
+      args.stats.earlyStopped++
+    } else if (canResume) {
+      args.stats.incremental++
+    } else {
+      args.stats.fullParses++
+    }
+  }
+
+  channel.beginRead({
+    candidate: args.candidate,
+    mode: canResume ? 'append' : 'replace',
+    previousByteOffset: startOffset
+  })
+  try {
+    const readResult = await consumeCompleteJsonlLines({
+      path: file.path,
+      start: startOffset,
+      onLine: (line) => state.consumeLine(line),
+      // Bound: the optional hooks are declared as methods, so a parser written
+      // with method syntax must not lose `this` on the way into the reader.
+      onLineBytes: state.consumeLineBytes?.bind(state),
+      shouldStop: state.shouldStop?.bind(state)
+    })
+    if (args.stats) {
+      args.stats.bytesRead += readResult.bytesRead
+    }
+
+    // The stat this scan displays is current even when nothing new was consumed.
+    state.touchFile(file)
+
+    // Keep parity with the one-shot parser: a final unterminated line is shown,
+    // but stays out of the resumable state so the (possibly still-growing) line
+    // is re-read once complete instead of being half-counted.
+    let displayState = state
+    if (readResult.trailingPartialLine !== null) {
+      const partialLine = readResult.trailingPartialLine
+      displayState = state.clone()
+      channel.mute(() => displayState.consumeLine(partialLine))
+    }
+
+    const session = await displayState.finalize(args.platform)
+    channel.finishRead({ session, byteOffset: readResult.consumedThrough, incomplete: false })
+    return {
+      session,
+      resume: { state, byteOffset: readResult.consumedThrough, channel }
+    }
+  } catch (error) {
+    channel.finishRead({ session: null, byteOffset: startOffset, incomplete: true })
+    throw error
+  }
+}
+
+/**
+ * Read a transcript whose format is rewritten in place rather than appended
+ * (whole-JSON documents, Kimi's state doc, OpenCode). There is no cursor to
+ * keep, so every read is a whole-file `replace`.
+ */
+export async function readWholeTranscript(args: {
+  candidate: SessionFileCandidate
+  platform: NodeJS.Platform
+  stats?: TranscriptReadStats
+}): Promise<AiVaultSession | null> {
+  const { file } = args.candidate
+  if (args.stats) {
+    args.stats.fullParses++
+    args.stats.bytesRead += file.sizeBytes ?? 0
+  }
+  const channel = new TranscriptMessageChannel()
+  channel.beginRead({ candidate: args.candidate, mode: 'replace', previousByteOffset: 0 })
+  try {
+    const session = await parseAgentSessionFile(args.candidate, args.platform, channel)
+    channel.finishRead({ session, byteOffset: file.sizeBytes ?? 0, incomplete: false })
+    return session
+  } catch (error) {
+    channel.finishRead({ session: null, byteOffset: 0, incomplete: true })
+    throw error
+  }
+}
+
+// A resume point is only valid if it still sits just past a line break;
+// anything else means the file was rewritten, not appended. Heuristic: a
+// grown rewrite keeping '\n' at exactly this byte would slip through, but
+// agent transcripts are append-only so that trade is accepted (worst case is
+// a stale vault row until the file is next truncated or the app restarts).
+async function endsWithNewlineAt(path: string, offset: number): Promise<boolean> {
+  const slice = await readTranscriptSlice(path, offset - 1, 1, 'scan')
+  return slice.length === 1 && slice[0] === NEWLINE_BYTE
+}

--- a/src/main/ai-vault/session-transcript-reader.ts
+++ b/src/main/ai-vault/session-transcript-reader.ts
@@ -2,24 +2,11 @@ import { readTranscriptSlice } from '../native-chat/wsl-transcript-fs-access'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import { parseAgentSessionFile, parserPublishesMessages } from './session-scanner-agent-parser'
 import { consumeCompleteJsonlLines } from './session-scanner-jsonl-reader'
-import type {
-  FileWithMtime,
-  ResumableSessionParseState,
-  SessionFileCandidate
-} from './session-scanner-types'
+import type { ResumableSessionParseState, SessionFileCandidate } from './session-scanner-types'
 import type { SessionParseResumePoint } from './session-parse-cache-store'
 import { TranscriptMessageChannel } from './session-transcript-channel'
 
 const NEWLINE_BYTE = 0x0a
-
-/**
- * The transcript's own length. `sizeBytes` is a cache key that also covers a
- * content dependency (Cursor's meta.json), so comparing a byte offset into the
- * transcript against it would tolerate a truncation the size of that sibling.
- */
-function transcriptSizeBytes(file: FileWithMtime): number | undefined {
-  return file.sizeBytes === undefined ? undefined : file.sizeBytes - (file.dependencySizeBytes ?? 0)
-}
 
 // Why: this layer owns reading a transcript and nothing else. It decides where
 // a read starts, drives the parser, publishes the decoded messages to every
@@ -40,8 +27,6 @@ export type ResumableTranscriptRead = {
   session: AiVaultSession | null
   /** The fold to resume from next time, and the channel bound to it. */
   resume: SessionParseResumePoint
-  /** False when the parse missed metadata it needed; the result must not be cached. */
-  cacheable: boolean
 }
 
 /**
@@ -58,11 +43,10 @@ export async function readResumableTranscript(args: {
 }): Promise<ResumableTranscriptRead> {
   const { file } = args.candidate
   const resume = args.resume
-  const transcriptSize = transcriptSizeBytes(file)
   const canResume =
     resume !== null &&
-    typeof transcriptSize === 'number' &&
-    transcriptSize >= resume.byteOffset &&
+    typeof file.sizeBytes === 'number' &&
+    file.sizeBytes >= resume.byteOffset &&
     (resume.byteOffset === 0 || (await endsWithNewlineAt(file.path, resume.byteOffset)))
 
   // Clone before consuming: a failed read must not corrupt the cached state,
@@ -119,8 +103,7 @@ export async function readResumableTranscript(args: {
     channel.finishRead({ session, byteOffset: readResult.consumedThrough, incomplete: false })
     return {
       session,
-      resume: { state, byteOffset: readResult.consumedThrough, channel },
-      cacheable: displayState.isCacheable?.() ?? true
+      resume: { state, byteOffset: readResult.consumedThrough, channel }
     }
   } catch (error) {
     channel.finishRead({ session: null, byteOffset: startOffset, incomplete: true })
@@ -139,17 +122,16 @@ export async function readWholeTranscript(args: {
   stats?: TranscriptReadStats
 }): Promise<AiVaultSession | null> {
   const { file } = args.candidate
-  const transcriptSize = transcriptSizeBytes(file) ?? 0
   if (args.stats) {
     args.stats.fullParses++
-    args.stats.bytesRead += transcriptSize
+    args.stats.bytesRead += file.sizeBytes ?? 0
   }
   const publishes = parserPublishesMessages(args.candidate)
   const channel = new TranscriptMessageChannel()
   channel.beginRead({ candidate: args.candidate, mode: 'replace', previousByteOffset: 0 })
   try {
     const session = await parseAgentSessionFile(args.candidate, args.platform, channel)
-    channel.finishRead({ session, byteOffset: transcriptSize, incomplete: !publishes })
+    channel.finishRead({ session, byteOffset: file.sizeBytes ?? 0, incomplete: !publishes })
     return session
   } catch (error) {
     channel.finishRead({ session: null, byteOffset: 0, incomplete: true })

--- a/src/main/ai-vault/session-transcript-reader.ts
+++ b/src/main/ai-vault/session-transcript-reader.ts
@@ -27,6 +27,8 @@ export type ResumableTranscriptRead = {
   session: AiVaultSession | null
   /** The fold to resume from next time, and the channel bound to it. */
   resume: SessionParseResumePoint
+  /** False when the parse missed metadata it needed; the result must not be cached. */
+  cacheable: boolean
 }
 
 /**
@@ -103,7 +105,8 @@ export async function readResumableTranscript(args: {
     channel.finishRead({ session, byteOffset: readResult.consumedThrough, incomplete: false })
     return {
       session,
-      resume: { state, byteOffset: readResult.consumedThrough, channel }
+      resume: { state, byteOffset: readResult.consumedThrough, channel },
+      cacheable: displayState.isCacheable?.() ?? true
     }
   } catch (error) {
     channel.finishRead({ session: null, byteOffset: startOffset, incomplete: true })

--- a/src/main/ai-vault/session-transcript-reader.ts
+++ b/src/main/ai-vault/session-transcript-reader.ts
@@ -1,6 +1,6 @@
 import { readTranscriptSlice } from '../native-chat/wsl-transcript-fs-access'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
-import { parseAgentSessionFile } from './session-scanner-agent-parser'
+import { parseAgentSessionFile, parserPublishesMessages } from './session-scanner-agent-parser'
 import { consumeCompleteJsonlLines } from './session-scanner-jsonl-reader'
 import type { ResumableSessionParseState, SessionFileCandidate } from './session-scanner-types'
 import type { SessionParseResumePoint } from './session-parse-cache-store'
@@ -126,11 +126,12 @@ export async function readWholeTranscript(args: {
     args.stats.fullParses++
     args.stats.bytesRead += file.sizeBytes ?? 0
   }
+  const publishes = parserPublishesMessages(args.candidate)
   const channel = new TranscriptMessageChannel()
   channel.beginRead({ candidate: args.candidate, mode: 'replace', previousByteOffset: 0 })
   try {
     const session = await parseAgentSessionFile(args.candidate, args.platform, channel)
-    channel.finishRead({ session, byteOffset: file.sizeBytes ?? 0, incomplete: false })
+    channel.finishRead({ session, byteOffset: file.sizeBytes ?? 0, incomplete: !publishes })
     return session
   } catch (error) {
     channel.finishRead({ session: null, byteOffset: 0, incomplete: true })

--- a/src/main/ai-vault/session-transcript-reader.ts
+++ b/src/main/ai-vault/session-transcript-reader.ts
@@ -2,11 +2,24 @@ import { readTranscriptSlice } from '../native-chat/wsl-transcript-fs-access'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import { parseAgentSessionFile, parserPublishesMessages } from './session-scanner-agent-parser'
 import { consumeCompleteJsonlLines } from './session-scanner-jsonl-reader'
-import type { ResumableSessionParseState, SessionFileCandidate } from './session-scanner-types'
+import type {
+  FileWithMtime,
+  ResumableSessionParseState,
+  SessionFileCandidate
+} from './session-scanner-types'
 import type { SessionParseResumePoint } from './session-parse-cache-store'
 import { TranscriptMessageChannel } from './session-transcript-channel'
 
 const NEWLINE_BYTE = 0x0a
+
+/**
+ * The transcript's own length. `sizeBytes` is a cache key that also covers a
+ * content dependency (Cursor's meta.json), so comparing a byte offset into the
+ * transcript against it would tolerate a truncation the size of that sibling.
+ */
+function transcriptSizeBytes(file: FileWithMtime): number | undefined {
+  return file.sizeBytes === undefined ? undefined : file.sizeBytes - (file.dependencySizeBytes ?? 0)
+}
 
 // Why: this layer owns reading a transcript and nothing else. It decides where
 // a read starts, drives the parser, publishes the decoded messages to every
@@ -45,10 +58,11 @@ export async function readResumableTranscript(args: {
 }): Promise<ResumableTranscriptRead> {
   const { file } = args.candidate
   const resume = args.resume
+  const transcriptSize = transcriptSizeBytes(file)
   const canResume =
     resume !== null &&
-    typeof file.sizeBytes === 'number' &&
-    file.sizeBytes >= resume.byteOffset &&
+    typeof transcriptSize === 'number' &&
+    transcriptSize >= resume.byteOffset &&
     (resume.byteOffset === 0 || (await endsWithNewlineAt(file.path, resume.byteOffset)))
 
   // Clone before consuming: a failed read must not corrupt the cached state,
@@ -125,16 +139,17 @@ export async function readWholeTranscript(args: {
   stats?: TranscriptReadStats
 }): Promise<AiVaultSession | null> {
   const { file } = args.candidate
+  const transcriptSize = transcriptSizeBytes(file) ?? 0
   if (args.stats) {
     args.stats.fullParses++
-    args.stats.bytesRead += file.sizeBytes ?? 0
+    args.stats.bytesRead += transcriptSize
   }
   const publishes = parserPublishesMessages(args.candidate)
   const channel = new TranscriptMessageChannel()
   channel.beginRead({ candidate: args.candidate, mode: 'replace', previousByteOffset: 0 })
   try {
     const session = await parseAgentSessionFile(args.candidate, args.platform, channel)
-    channel.finishRead({ session, byteOffset: file.sizeBytes ?? 0, incomplete: !publishes })
+    channel.finishRead({ session, byteOffset: transcriptSize, incomplete: !publishes })
     return session
   } catch (error) {
     channel.finishRead({ session: null, byteOffset: 0, incomplete: true })

--- a/src/main/lazy-worker-thread-host.ts
+++ b/src/main/lazy-worker-thread-host.ts
@@ -1,0 +1,102 @@
+import type { Worker } from 'node:worker_threads'
+
+export type WorkerThreadFactory = () => Worker
+
+/**
+ * Owns the lifetime of one lazily-spawned worker thread: spawn on demand,
+ * listener wiring, teardown, and idle expiry. It holds no request state, so
+ * every decision about which call a message belongs to stays with its client,
+ * and a failed spawn is reported rather than thrown so the client can fail its
+ * queued calls closed instead of moving the work back onto the main thread.
+ */
+export class LazyWorkerThreadHost<TResponse> {
+  private worker: Worker | null = null
+  private idleTimer: NodeJS.Timeout | null = null
+  private cleanupListeners: (() => void) | null = null
+  private reportedUnavailable = false
+
+  constructor(
+    private readonly options: {
+      factory: WorkerThreadFactory
+      idleTeardownMs: number
+      onMessage: (response: TResponse) => void
+      onError: (error: Error) => void
+      onExit: (code: number) => void
+      /** Nothing active and nothing queued, checked again when the idle timer fires. */
+      isIdle: () => boolean
+      /** First spawn failure only: a repeating one must not repeat the log. */
+      onUnavailable: (error: unknown) => void
+    }
+  ) {}
+
+  get current(): Worker | null {
+    return this.worker
+  }
+
+  /** The live worker, spawning one if needed; null when no worker can be had. */
+  ensure(): Worker | null {
+    if (this.worker) {
+      return this.worker
+    }
+    try {
+      const worker = this.options.factory()
+      const onMessage = (response: TResponse): void => this.options.onMessage(response)
+      const onError = (error: Error): void => this.options.onError(error)
+      const onExit = (code: number): void => this.options.onExit(code)
+      worker.on('message', onMessage)
+      worker.on('error', onError)
+      worker.on('exit', onExit)
+      this.cleanupListeners = () => {
+        worker.off('message', onMessage)
+        worker.off('error', onError)
+        worker.off('exit', onExit)
+      }
+      // Never keep the app alive for background work.
+      worker.unref?.()
+      this.worker = worker
+      return worker
+    } catch (err) {
+      if (!this.reportedUnavailable) {
+        this.reportedUnavailable = true
+        this.options.onUnavailable(err)
+      }
+      return null
+    }
+  }
+
+  destroy(): void {
+    this.clearIdleTimer()
+    const worker = this.worker
+    this.worker = null
+    if (!worker) {
+      return
+    }
+    this.cleanupListeners?.()
+    this.cleanupListeners = null
+    worker.removeAllListeners()
+    void worker.terminate().catch(() => undefined)
+  }
+
+  scheduleIdleTeardown(): void {
+    this.clearIdleTimer()
+    if (!this.worker) {
+      return
+    }
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null
+      // Re-checked here: a request arriving as the timer fires must never be
+      // lost to a self-exiting worker.
+      if (this.options.isIdle()) {
+        this.destroy()
+      }
+    }, this.options.idleTeardownMs)
+    this.idleTimer.unref?.()
+  }
+
+  clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer)
+      this.idleTimer = null
+    }
+  }
+}

--- a/src/main/ports/port-scan-command-client.ts
+++ b/src/main/ports/port-scan-command-client.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs'
 import { getAppEnvironment, hasAppEnvironment } from '../../shared/app-environment'
 import { join } from 'node:path'
 import { Worker } from 'node:worker_threads'
+import { LazyWorkerThreadHost, type WorkerThreadFactory } from '../lazy-worker-thread-host'
 import {
   PORT_SCAN_COMMAND_TIMEOUT_MS,
   PortScanCommandTimeoutError,
@@ -11,11 +12,10 @@ import {
 
 // Why (#11161): a lazily-spawned, unref'd worker runs the port scan's probe
 // spawns off the Electron main-process event loop, because libuv performs
-// process creation inline on the calling thread. Lifecycle (FIFO one-at-a-time
-// dispatch, per-call deadlines, respawn-on-fault, idle teardown, fail-closed)
-// mirrors src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts;
-// the duplicated ~150 lines are cheaper than a premature shared abstraction, so
-// a third adopter should extract one.
+// process creation inline on the calling thread. This module owns the request
+// half (FIFO one-at-a-time dispatch, per-call deadlines, respawn-on-fault); the
+// thread's own lifetime belongs to LazyWorkerThreadHost, shared with
+// src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts.
 //
 // This module used to contain the literal text require('electron'), which fails the
 // plain-Node entry guard even inside a try/catch. It reads the AppEnvironment port
@@ -36,7 +36,7 @@ export const MAX_CONSECUTIVE_DEATHS = 3
 export const MAX_QUEUED_CALLS = 8
 
 export type PortScanCommandResult = { stdout: string; spawnMs: number }
-export type PortScanWorkerFactory = () => Worker
+export type PortScanWorkerFactory = WorkerThreadFactory
 
 // Distinguishes "no worker at all" from a timeout or crash so the scanner can
 // log it once and callers never mistake it for a command timeout.
@@ -62,20 +62,27 @@ type PendingCall = {
  * be spawned rather than moving process creation back onto the main thread.
  */
 export class PortScanCommandClient {
-  private worker: Worker | null = null
   private active: PendingCall | null = null
   private queue: PendingCall[] = []
-  private idleTimer: NodeJS.Timeout | null = null
   private consecutiveDeaths = 0
   private nextId = 1
-  private loggedWorkerUnavailable = false
-  private cleanupWorkerListeners: (() => void) | null = null
-  private readonly workerFactory: PortScanWorkerFactory
-  private readonly log: (message: string) => void
+  private readonly host: LazyWorkerThreadHost<PortScanCommandResponse>
 
   constructor(options: { workerFactory: PortScanWorkerFactory; log?: (message: string) => void }) {
-    this.workerFactory = options.workerFactory
-    this.log = options.log ?? ((message) => console.warn(message))
+    const log = options.log ?? ((message: string) => console.warn(message))
+    this.host = new LazyWorkerThreadHost<PortScanCommandResponse>({
+      factory: options.workerFactory,
+      idleTeardownMs: IDLE_TEARDOWN_MS,
+      onMessage: (response) => this.onMessage(response),
+      onError: (error) => this.onWorkerFault(error),
+      onExit: (code) => this.onWorkerExit(code),
+      isIdle: () => !this.active && this.queue.length === 0,
+      // Why (#11161): never fall back to in-process execFile here; a missing
+      // bundle must report port scanning as unavailable rather than reintroduce
+      // the main-thread freeze this worker boundary exists to prevent.
+      onUnavailable: (err) =>
+        log(`[workspace-ports] probe worker unavailable. ${errorMessage(err)}`)
+    })
   }
 
   /**
@@ -109,7 +116,7 @@ export class PortScanCommandClient {
     if (this.active || this.queue.length === 0) {
       return
     }
-    const worker = this.ensureWorker()
+    const worker = this.host.ensure()
     if (!worker) {
       this.failQueuedAsUnavailable()
       return
@@ -119,46 +126,13 @@ export class PortScanCommandClient {
       return
     }
     this.active = call
-    this.clearIdleTimer()
+    this.host.clearIdleTimer()
     // Why (#11161): one at a time. uv_spawn blocks the worker's own loop, so a
     // second concurrent request would have its deadline armed while the first
     // spawn is still stalling the thread, producing a false timeout.
     call.timer = setTimeout(() => this.onDeadline(call), CALL_DEADLINE_MS)
     call.timer.unref?.()
     worker.postMessage(call.request)
-  }
-
-  private ensureWorker(): Worker | null {
-    if (this.worker) {
-      return this.worker
-    }
-    try {
-      const worker = this.workerFactory()
-      const onMessage = (response: PortScanCommandResponse): void => this.onMessage(response)
-      const onError = (error: Error): void => this.onWorkerFault(error)
-      const onExit = (code: number): void => this.onWorkerExit(code)
-      worker.on('message', onMessage)
-      worker.on('error', onError)
-      worker.on('exit', onExit)
-      this.cleanupWorkerListeners = () => {
-        worker.off('message', onMessage)
-        worker.off('error', onError)
-        worker.off('exit', onExit)
-      }
-      // Never keep the app alive for a port scan.
-      worker.unref?.()
-      this.worker = worker
-      return worker
-    } catch (err) {
-      // Why (#11161): never fall back to in-process execFile here; a missing
-      // bundle must report port scanning as unavailable rather than reintroduce
-      // the main-thread freeze this worker boundary exists to prevent.
-      if (!this.loggedWorkerUnavailable) {
-        this.loggedWorkerUnavailable = true
-        this.log(`[workspace-ports] probe worker unavailable. ${errorMessage(err)}`)
-      }
-      return null
-    }
   }
 
   private onMessage(response: PortScanCommandResponse): void {
@@ -191,7 +165,7 @@ export class PortScanCommandClient {
     // A clean self-exit is not a death, but the stale handle must be dropped or
     // the next dispatch would post into a dead worker and stall to its deadline.
     if (code === 0 && !this.active && this.queue.length === 0) {
-      this.destroyWorker()
+      this.host.destroy()
       return
     }
     this.onWorkerFault(new Error(`Port scan probe worker exited with code ${code}`))
@@ -199,7 +173,7 @@ export class PortScanCommandClient {
 
   private onWorkerFault(error: Error): void {
     const failed = this.active
-    this.destroyWorker()
+    this.host.destroy()
     this.consecutiveDeaths++
     if (failed) {
       this.settle(failed, () => failed.reject(error))
@@ -248,49 +222,10 @@ export class PortScanCommandClient {
     if (this.queue.length > 0) {
       this.pump()
     } else {
-      this.scheduleIdleTeardown()
+      // Terminating can orphan a probe child mid-spawn; the worker reaps what it
+      // can on exit, and every probe here is short-lived.
+      this.host.scheduleIdleTeardown()
     }
-  }
-
-  private scheduleIdleTeardown(): void {
-    this.clearIdleTimer()
-    if (!this.worker) {
-      return
-    }
-    this.idleTimer = setTimeout(() => this.teardownIfIdle(), IDLE_TEARDOWN_MS)
-    this.idleTimer.unref?.()
-  }
-
-  private teardownIfIdle(): void {
-    this.idleTimer = null
-    // Only tear down with nothing active AND nothing queued: a request arriving
-    // as the timer fires must never be lost to a self-exiting worker.
-    if (this.active || this.queue.length > 0) {
-      return
-    }
-    this.destroyWorker()
-  }
-
-  private clearIdleTimer(): void {
-    if (this.idleTimer) {
-      clearTimeout(this.idleTimer)
-      this.idleTimer = null
-    }
-  }
-
-  private destroyWorker(): void {
-    this.clearIdleTimer()
-    const worker = this.worker
-    this.worker = null
-    if (!worker) {
-      return
-    }
-    this.cleanupWorkerListeners?.()
-    this.cleanupWorkerListeners = null
-    worker.removeAllListeners()
-    // Terminating can orphan a probe child mid-spawn; the worker reaps what it
-    // can on exit, and every probe here is short-lived.
-    void worker.terminate().catch(() => undefined)
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1225 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1225 |
| Prod | 44 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2036 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​740 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1296 |

<!-- /orca-pr-loc -->

## Summary

First of a stacked split of #18112 (agent session search). This PR only restructures the existing ai-vault scanner so a second reader of the same transcripts can be added later without touching the scanner. Nothing user-visible changes except Cursor sessions gaining a workspace and timestamps.

**Reader / consumer split.** The scanner's only output was the Session History summary, so any other reader of transcripts had to hook the parse itself. Now:

- `session-transcript-reader.ts` owns each file read: resume from the byte cursor when the file only grew and the offset sits on a line boundary, otherwise re-read whole; drive the parser; report where the read ended.
- `session-transcript-channel.ts` fans every decoded message out per read.
- `session-transcript-consumers.ts` is the registry. A consumer opts in per read with `beginRead(start)`, receives `message(...)` calls, and gets `finish({ byteOffset, incomplete })`. Consumers keep their own cursor and never query each other.
- The session list stays a fold inside the parser (it needs cwd, branch, tokens, which the stream deliberately omits) and is the only consumer here.
- Parsers take an optional `TranscriptMessageSink` parameter instead of a module-global scope.

**Also in this PR**

- Cursor: read `chats/<md5 of cwd>/<uuid>/meta.json` for cwd, title, timestamps. Cursor transcripts carry only role and message, so these sessions had no workspace match before. Local file reads only; SSH content parses opt out.
- OpenCode: extract `LazyWorkerThreadHost` (shared with the port-scan probe) and probe the schema before querying so a changed OpenCode layout degrades instead of throwing mid-read.
- Discovery: keep the newest-N set with a bounded insert instead of sorting every file.
- Codex parser: `session_meta` field readers split into their own module (the file was at the line limit).

**Deliberately not in this PR** (later PRs in the stack): any search index or FTS table, inode identity on resume points, a Codex state-DB metadata fallback.

## Verification

- `pnpm tc`, `tc:node`; `src/main` + `src/shared` tests (4,056 files / 41,347 tests); `check:code-quality:changed` and `check:react-doctor:changed`, 0 new findings.
- Session list equivalence against `origin/main` (e80fae0c4d): fixture scans for all 18 providers cold, 8 resumable providers appended with an unterminated last line, and one Cursor transcript with a `meta.json`. 26 of 27 sessions byte-identical. The Cursor session gains `cwd`, `createdAt`, `updatedAt`, and a `cd` prefix on `resumeCommand`; title unchanged.
- `session-transcript-consumers.test.ts`: two independent consumers receive the same 12-message stream; append-mode replays only new lines; a trailing unterminated line is published once; a throwing or declining consumer does not affect the list.

Not verified: WSL and SSH equivalence (fixtures ran on macOS).

