### PR TITLE
fix(skills): backfill the discovery scan cwd from the worktree id

### DIFF
--- a/src/main/runtime/rpc/methods/skills.test.ts
+++ b/src/main/runtime/rpc/methods/skills.test.ts
@@ -9,7 +9,7 @@ vi.mock('../../../skills/skill-discovery-target', () => ({
   resolveSkillDiscoveryTarget: vi.fn((target) => ({ kind: 'native-host', cwd: target?.cwd })),
   discoverSkillsOnTarget: vi.fn(async () => ({ skills: [], sources: [], scannedAt: 1 }))
 }))
-import { SKILL_METHODS } from './skills'
+import { resolveDiscoveryTarget, SKILL_METHODS } from './skills'
 import {
   discoverSkillsOnTarget,
   resolveSkillDiscoveryTarget
@@ -345,5 +345,34 @@ describe('skill management RPC', () => {
 
     expect(previewSharedSkillInstallRequest).toHaveBeenCalledOnce()
     expect(removeSharedSkillInstallRequest).toHaveBeenCalledOnce()
+  })
+})
+
+describe('resolveDiscoveryTarget cwd backfill', () => {
+  const runtime = {
+    resolveProjectRuntimeForWorktree: vi.fn(() => undefined)
+  } as unknown as Parameters<typeof resolveDiscoveryTarget>[1]
+
+  it('recovers the cwd a worktree id already carries for a caller that sent none', () => {
+    const target = resolveDiscoveryTarget({ worktreeId: 'repo-1::/repo/worktree' }, runtime)
+    expect(target).toMatchObject({ kind: 'native-host', cwd: '/repo/worktree' })
+  })
+
+  it('strips a folder workspace suffix so plugin settings resolve against the real folder', () => {
+    const target = resolveDiscoveryTarget(
+      { worktreeId: 'repo-1::/repo/folder::workspace:11111111-2222-3333-4444-555555555555' },
+      runtime
+    )
+    expect(target).toMatchObject({ kind: 'native-host', cwd: '/repo/folder' })
+  })
+
+  it('keeps an explicit cwd and stays undefined without one', () => {
+    expect(
+      resolveDiscoveryTarget({ cwd: '/explicit', worktreeId: 'repo-1::/repo/worktree' }, runtime)
+    ).toMatchObject({ kind: 'native-host', cwd: '/explicit' })
+    expect(resolveDiscoveryTarget({}, runtime)).toMatchObject({
+      kind: 'native-host',
+      cwd: undefined
+    })
   })
 })

--- a/src/main/runtime/rpc/methods/skills.ts
+++ b/src/main/runtime/rpc/methods/skills.ts
@@ -8,6 +8,7 @@ import {
   type SkillDeleteRequestDependencies
 } from '../../../skills/skill-delete/request-service'
 import type { SkillDiscoveryTargetSchema } from '../../../../shared/skills'
+import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree/id'
 import {
   SkillInstallPreviewRequestSchema,
   SkillInstallRequestSchema,
@@ -45,10 +46,17 @@ export function resolveDiscoveryTarget(
   params: z.infer<typeof SkillDiscoveryTargetSchema>,
   runtime: Pick<OrcaRuntimeService, 'resolveProjectRuntimeForWorktree'>
 ) {
+  // Why: plugin enablement lives in the worktree's own .claude/settings.json,
+  // so a caller that knows only the worktree id (a paired phone) still needs
+  // the scan to see project plugin roots — recover the cwd the id carries.
+  const cwd =
+    params.cwd ??
+    (params.worktreeId ? splitWorktreeIdForFilesystem(params.worktreeId)?.worktreePath : undefined)
   const target = params.projectRuntime
-    ? params
+    ? { ...params, cwd }
     : {
         ...params,
+        cwd,
         projectRuntime: runtime.resolveProjectRuntimeForWorktree(params.worktreeId)
       }
   return resolveSkillDiscoveryTarget(target)


### PR DESCRIPTION
## ELI5

When a paired phone asks "what skills does this worktree have?", it only names the worktree. The scan needs the worktree's folder path to find project-level plugin settings — without it, every plugin-provided skill silently vanished from the answer the phone got, even though the desktop saw them fine.

## What Changed

`resolveDiscoveryTarget` now recovers the `cwd` from the worktree id itself (via the same `splitWorktreeIdForFilesystem` folder workspaces use, including the `::workspace:` suffix strip) when the caller didn't send one. Callers that send a `cwd` (the desktop renderer) are unaffected; callers that send only a `worktreeId` now get plugin roots enumerated against the right project settings, matching the desktop's result exactly (verified: 113 skills either way on a repo with plugin-enabled skills, vs 107 missing all plugin skills before).

## Why

Plugin enablement lives in the worktree's own `.claude/settings.json` (`enabledPlugins`), so the plugin root enumeration only runs when the discovery target carries a cwd. The executing runtime owns this resolution — the worktree id already embeds the path, so no caller needs to change.

## Linked Issue

#19678 (this is the desktop-side enabler the mobile work there builds on; it also stands alone for any remote caller).

## Visual Proof

N/A — no UI change; behavior parity for remote discovery callers.

## Testing

- [x] Automated tests added/updated: three new unit cases in `skills.test.ts` covering the id-embedded cwd, the folder-workspace suffix strip, and explicit-cwd precedence
- [x] I manually tested these changes locally — verified live against a running runtime via direct RPC probes (before/after skill counts incl. plugin roots)

## AI Disclosure

Claude (Anthropic) implemented the change; the approach and testing were reviewed by the fork owner.

## Review

- Security: cwd is derived from the host's own worktree id namespace, not caller-supplied paths; no new input trust
- Cross-platform: path split uses the shared worktree-id helper (Windows/WSL/SSH ids unchanged in behavior); WSL resolution untouched
- SSH/remote: this is precisely the remote-caller parity fix; loss-of-contact semantics unaffected
- Performance: string split per discovery call, negligible

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote impact considered
- [x] `pnpm typecheck` and the touched test files pass locally (full suites green on the source branch)