### PR TITLE
test(orchestration): pin the Run-required contract for unbound direct mail

### DIFF
--- a/tests/e2e/orchestration-idle-mail-delivery.spec.ts
+++ b/tests/e2e/orchestration-idle-mail-delivery.spec.ts
@@ -35,6 +35,7 @@ import {
   waitForPaneIdentitySnapshot
 } from './helpers/terminal'
 import { RuntimeClient, type RuntimeRpcSuccess } from '../../src/cli/runtime-client'
+import { RuntimeRpcFailureError } from '../../src/cli/runtime/types'
 import type { RuntimeTerminalListResult } from '../../src/shared/runtime-types'
 import {
   CODEX_IDLE_TITLE,
@@ -350,7 +351,10 @@ test.describe('orchestration push-on-idle mail delivery', () => {
     await expectSubmitted(pane)
   })
 
-  test('keeps unbound direct mail durable without pointing to an unsafe check', async ({
+  // #19542 deleted the legacy-Run write fallback, so a sender in no Run has
+  // nowhere to file mail to a bare handle: the send is refused outright, which
+  // is what keeps an unsafe pointer out of the pane on the next idle frame.
+  test('refuses unbound direct mail from a sender in no Run instead of pushing it', async ({
     orcaPage,
     electronApp
   }) => {
@@ -360,17 +364,32 @@ test.describe('orchestration push-on-idle mail delivery', () => {
     await driveToLiveIdle(client, pane)
 
     const stdinBeforeScan = pane.agent.readStdin()
-    const messageId = await sendMail(client, pane.handle, { subject: 'Unbound direct mail' })
+    const refusal = await sendMail(client, pane.handle, { subject: 'Unbound direct mail' }).then(
+      () => undefined,
+      (error: unknown) => error
+    )
+    // Why runtime_error and not run_required: insertMessage throws a plain
+    // Error, which the dispatcher passes through with its message and no
+    // recovery data — the sibling no-recipient path is the one that adds it.
+    // The request-id suffix and stamp are the client's durable-mutation bookkeeping.
+    expect(refusal).toBeInstanceOf(RuntimeRpcFailureError)
+    expect(refusal).toMatchObject({
+      code: 'runtime_error',
+      message: expect.stringContaining('Run is required')
+    })
+    expect((refusal as RuntimeRpcFailureError).data).toEqual({
+      orchestrationRequestId: expect.any(String)
+    })
+    expect(readMailbox(userDataDir, pane.handle)).toEqual([])
+
+    // A busy→idle edge is the push trigger. Walking one proves the refusal left
+    // nothing behind for the scan to point at, not merely that the push was slow.
     pane.agent.setTitle(CODEX_WORKING_TITLE)
     await waitForObservedTitle(client, pane.handle, CODEX_WORKING_TITLE)
     pane.agent.setTitle(CODEX_IDLE_TITLE)
     await waitForObservedTitle(client, pane.handle, CODEX_IDLE_TITLE)
 
-    expect(readMailRow(userDataDir, messageId)).toMatchObject({
-      to_handle: pane.handle,
-      read: 0,
-      delivered_at: null
-    })
+    expect(readMailbox(userDataDir, pane.handle)).toEqual([])
     expect(pane.agent.readStdin()).toBe(stdinBeforeScan)
   })
 

--- a/tests/e2e/orchestration-idle-mail-delivery.spec.ts
+++ b/tests/e2e/orchestration-idle-mail-delivery.spec.ts
@@ -377,9 +377,14 @@ test.describe('orchestration push-on-idle mail delivery', () => {
       code: 'runtime_error',
       message: expect.stringContaining('Run is required')
     })
-    expect((refusal as RuntimeRpcFailureError).data).toEqual({
-      orchestrationRequestId: expect.any(String)
-    })
+    // Pins that the SERVER attached no orchestrationSkillRecoveryData, without
+    // freezing whatever else the client may stamp alongside its request id.
+    const refusalData = (refusal as RuntimeRpcFailureError).data
+    expect(refusalData).toMatchObject({ orchestrationRequestId: expect.any(String) })
+    expect(refusalData).not.toHaveProperty('effectsApplied')
+    expect(refusalData).not.toHaveProperty('guide')
+    expect(refusalData).not.toHaveProperty('nextCommandArgs')
+    expect(refusalData).not.toHaveProperty('nextSteps')
     expect(readMailbox(userDataDir, pane.handle)).toEqual([])
 
     // A busy→idle edge is the push trigger. Walking one proves the refusal left
@@ -389,6 +394,8 @@ test.describe('orchestration push-on-idle mail delivery', () => {
     pane.agent.setTitle(CODEX_IDLE_TITLE)
     await waitForObservedTitle(client, pane.handle, CODEX_IDLE_TITLE)
 
+    // The ledger only proves anything once the push window has fully elapsed.
+    await orcaPage.waitForTimeout(NO_DELIVERY_SETTLE_MS)
     expect(readMailbox(userDataDir, pane.handle)).toEqual([])
     expect(pane.agent.readStdin()).toBe(stdinBeforeScan)
   })


### PR DESCRIPTION
## ELI5

One E2E test still expected the pre-#19542 world where mail to a bare terminal handle from a sender in no Run was quietly filed under the legacy Run. #19542 made that a hard refusal, so the test now pins the refusal instead.

## What Changed

- `tests/e2e/orchestration-idle-mail-delivery.spec.ts`: the test `keeps unbound direct mail durable without pointing to an unsafe check` is rewritten as `refuses unbound direct mail from a sender in no Run instead of pushing it`, keeping its position and the spec's structure. It now asserts, in order:
  1. `orchestration.send` from the non-Run test client to the pane's bare handle rejects with a `RuntimeRpcFailureError` whose `code` is `runtime_error` and whose `message` contains `Run is required`.
  2. Its `data` carries the client's own durable-mutation stamp (`orchestrationRequestId`, from `src/cli/runtime/client-error-recovery.ts`) and has **none** of the server-side `orchestrationSkillRecoveryData()` keys (`effectsApplied`, `guide`, `nextCommandArgs`, `nextSteps`) — pinning that the server attached no recovery data, without freezing the client stamp's exact shape (an exact `toEqual` would go red with no product change if `orchestration-recovery-command.ts` ever mapped `orchestration.send` to an `originalCommand`).
  3. `readMailbox(userDataDir, pane.handle)` is `[]` immediately after the rejection.
  4. After walking a busy→idle edge on the pane (the push trigger) and letting `NO_DELIVERY_SETTLE_MS` elapse so the push window (microtask + 500 ms Enter delay) is fully covered, the mailbox is still `[]` and the fake agent's stdin ledger is byte-identical to its pre-send snapshot — no pointer, no synthesized Enter.
- No product code changed. Neighbouring tests untouched.

## Why

#19542 (`98fdbc4ade`, "file federated worker mail under the coordinator Run") deleted every `?? LEGACY_RUN_ID` write fallback; its body states the intended contract directly:

> All four `?? LEGACY_RUN_ID` write fallbacks are deleted (`message-insert.ts`, `task-store.ts`, `decision-gate-store.ts`, `check-worker.ts`). A missing Run now throws instead of misfiling.

On the send path, `recipient-routing.ts` resolves a bare handle with a live pane but no Run/Dispatch to `runId: params.senderRunId`; the E2E client is in no Run, so `insertMessage` throws `Run is required` (`src/main/runtime/orchestration/db/messages/message-insert.ts`). The old test asserted the pre-#19542 outcome (row stored with `read: 0, delivered_at: null`), so it fails with that error at `sendMail`. #19542 touched no E2E file and `e2e.yml` only runs on schedule/dispatch, which is how it slipped past PR CI.

It is the only remaining red spec on main's scheduled E2E and on the 1.4.199 release branch: runs 34284171625 and 34298315442.

The new test keeps the title's original intent — unbound direct mail must never be pushed into an idle pane — and states the mechanism that now guarantees it: nothing is stored, so the idle scan has nothing to point at.

## Linked Issue

N/A — follow-up to #19542; no separate issue filed.

## Visual Proof

N/A — test-only change to an E2E spec; no UI or interaction change.

## Testing

All run locally on macOS (darwin arm64) in a fresh worktree (origin/main `210ac1f77c` + these commits), `pnpm install` from scratch.

Second commit `238d2d797a` (review tightenings: absence checks on the recovery keys, settle window before the ledger read):

| Command | Result |
| --- | --- |
| `SKIP_BUILD=1 ORCA_BACKGROUND_LAUNCH=1 npx playwright test tests/e2e/orchestration-idle-mail-delivery.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 -g "unbound direct mail"` | **1 passed (8.9s)**, exit 0 |
| `pnpm run check:code-quality:changed` | passed: 0 new findings across 1 changed file |
| pre-commit hook (oxlint, oxlint react-doctor, oxfmt --write) | passed; oxfmt made no changes |
| Not re-run at this commit: whole spec file, `typecheck:e2e` | the second commit only edits the same test body (no new imports or symbols); the whole-file 12/12 below is from the first commit |

First commit `b09788541a`:

| Command | Result |
| --- | --- |
| `SKIP_BUILD=1 ORCA_BACKGROUND_LAUNCH=1 npx playwright test tests/e2e/orchestration-idle-mail-delivery.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1` (whole file) | **12 passed (2.5m)**, 0 failed, exit 0 |
| same, `-g "unbound direct mail"` (the rewritten test alone; first run included `pnpm run ensure:electron-runtime` + the globalSetup build) | **1 passed**, exit 0 |
| same single test, first draft of the assertion (`message: 'Run is required'` exact, `data: undefined`) | **failed** — real wire shape is message suffixed with ` Orchestration mutation request ID: <uuid>.` and `data: { orchestrationRequestId }` from the client's durable-mutation recovery; assertion corrected to that observed shape (this is what the committed test pins) |
| `pnpm run check:code-quality:changed` | passed: 0 new findings (code quality, type-aware, React Doctor) across 1 changed file |
| `pnpm run typecheck:e2e` | exit 1 with **197 errors, all pre-existing in other files; 0 in the changed spec** — `config/tsconfig.e2e.json` documents this project as not yet enforced (~198 known errors) |
| `git diff --check` | clean |
| pre-commit hook (oxlint, oxlint react-doctor, oxfmt --write) | passed; oxfmt made no changes (committed file is byte-identical to what the e2e run executed) |
| Not run: `pnpm tc` (node/cli/web) | no `src/` change, so nothing for those projects to see; the E2E-specific project above covers the changed file |
| Not run: Linux / Windows / SSH | E2E suite is not in PR CI; `e2e.yml` runs on schedule/dispatch — the next scheduled main run and a re-run on the 1.4.199 release branch are the real gate |

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Follow-up (not done here, product code deliberately untouched)

- The refusal surfaces as a bare `Error('Run is required')` from `insertMessage`, which `mapRuntimeError` (`src/main/runtime/rpc/errors.ts`) flattens to wire code `runtime_error` with no recovery data. The sibling no-recipient path a few lines earlier in `send-methods.ts` throws `OrchestrationError('run_required', ..., orchestrationSkillRecoveryData())` (`effectsApplied`, `guide`, `nextSteps`). If the unbound-handle refusal should be equally actionable for agents (`run_required` + recovery data), that is a product change; this test's `code`/`data` assertions are the ones to update with it. Same applies to the other three writers #19542 hardened (`task-store.ts`, `decision-gate-store.ts`, `check-worker.ts`).

## Review

## Agent skill upstream boundary

N/A
