### PR TITLE
feat(bitbucket): support viewing and replying to PR comments in checks panel

### DIFF
--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -583,8 +583,8 @@ breakaway hands the whole tree its escape. The per-PTY job therefore omits
 `BREAKAWAY_OK` whenever `msys-2.0.dll` or `cygwin1.dll` sits on the shell's DLL
 search path — beside the executable, or under `usr/bin` for Git's `bin`
 launcher. Native shells keep explicit breakaway. Denying it costs Cygwin
-nothing, because it *pre-checks* the limit rather than retrying, so no spawn
-fails; but a *native* program that passes `CREATE_BREAKAWAY_FROM_JOB` itself
+nothing, because it _pre-checks_ the limit rather than retrying, so no spawn
+fails; but a _native_ program that passes `CREATE_BREAKAWAY_FROM_JOB` itself
 inside such a pane now gets `ERROR_ACCESS_DENIED`. `nohup` and `disown` are
 unaffected — they are Cygwin signal/session concepts, unrelated to job
 membership. The daemon's host job is unchanged.

--- a/src/main/bitbucket/comments-mappers.ts
+++ b/src/main/bitbucket/comments-mappers.ts
@@ -32,6 +32,11 @@ export type RawBitbucketComment = {
   links?: {
     html?: { href?: string }
   }
+  resolution?: {
+    type?: string
+    created_on?: string
+    user?: Record<string, unknown>
+  } | null
 }
 
 export function apiErrorMessage(error: unknown): string {
@@ -74,7 +79,7 @@ export function findRootCommentId(id: number, parentMap: Map<number, number>): n
 export function mapBitbucketComment(
   raw: RawBitbucketComment,
   threadRootId?: number,
-  inheritedInline?: { path?: string; line?: number }
+  inheritedInline?: { path?: string; line?: number; isResolved?: boolean }
 ): PRComment {
   const author = raw.user?.nickname?.trim() || raw.user?.display_name?.trim() || 'unknown'
   const authorAvatarUrl = raw.user?.links?.avatar?.href || ''
@@ -92,7 +97,8 @@ export function mapBitbucketComment(
 
   const rootId = threadRootId ?? (raw.parent?.id ? raw.parent.id : raw.id)
   const threadId = String(rootId)
-  const isResolved = path ? false : undefined
+  const isResolved =
+    raw.resolution != null || inheritedInline?.isResolved ? true : path ? false : undefined
 
   return {
     id: raw.id,
@@ -139,13 +145,17 @@ export function mapBitbucketComments(rawComments: readonly RawBitbucketComment[]
     }
     const rootId = findRootCommentId(raw.id, parentMap)
     const root = rootComments.get(rootId)
+    const isRootResolved = Boolean(root?.resolution != null)
     const inheritedInline =
       root?.inline?.path && !raw.inline?.path
         ? {
             path: root.inline.path,
-            line: root.inline.to ?? root.inline.from ?? undefined
+            line: root.inline.to ?? root.inline.from ?? undefined,
+            isResolved: isRootResolved
           }
-        : undefined
+        : isRootResolved
+          ? { isResolved: true }
+          : undefined
 
     result.push(mapBitbucketComment(raw, rootId, inheritedInline))
   }

--- a/src/main/bitbucket/comments-mappers.ts
+++ b/src/main/bitbucket/comments-mappers.ts
@@ -1,0 +1,154 @@
+import type { PRComment } from '../../shared/github/comment-types'
+
+export type RawBitbucketComment = {
+  id: number
+  created_on?: string
+  updated_on?: string
+  content?: {
+    raw?: string
+    markup?: string
+    html?: string
+  }
+  user?: {
+    display_name?: string
+    nickname?: string
+    account_id?: string
+    account_type?: string
+    type?: string
+    links?: {
+      avatar?: { href?: string }
+    }
+  }
+  parent?: {
+    id: number
+  }
+  inline?: {
+    path?: string
+    to?: number | null
+    from?: number | null
+    out_dated?: boolean
+  }
+  deleted?: boolean
+  links?: {
+    html?: { href?: string }
+  }
+}
+
+export function apiErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    try {
+      const parsed = JSON.parse(error.message) as {
+        error?: { message?: string; detail?: string }
+        message?: string
+      }
+      if (parsed?.error?.message) {
+        return parsed.error.detail
+          ? `${parsed.error.message}: ${parsed.error.detail}`
+          : parsed.error.message
+      }
+      if (parsed?.message) {
+        return parsed.message
+      }
+    } catch {
+      // not JSON
+    }
+    return error.message
+  }
+  return String(error)
+}
+
+export function findRootCommentId(id: number, parentMap: Map<number, number>): number {
+  let current = id
+  const visited = new Set<number>([current])
+  while (parentMap.has(current)) {
+    const parent = parentMap.get(current)!
+    if (visited.has(parent)) {
+      break
+    }
+    visited.add(parent)
+    current = parent
+  }
+  return current
+}
+
+export function mapBitbucketComment(
+  raw: RawBitbucketComment,
+  threadRootId?: number,
+  inheritedInline?: { path?: string; line?: number }
+): PRComment {
+  const author = raw.user?.nickname?.trim() || raw.user?.display_name?.trim() || 'unknown'
+  const authorAvatarUrl = raw.user?.links?.avatar?.href || ''
+  const body = raw.content?.raw ?? ''
+  const createdAt = raw.created_on || ''
+  const url = raw.links?.html?.href || ''
+  const isBot =
+    raw.user?.account_type === 'bot' ||
+    raw.user?.type === 'bot' ||
+    Boolean(raw.user?.nickname?.endsWith('[bot]'))
+
+  const path = raw.inline?.path ?? inheritedInline?.path
+  const line = raw.inline?.to ?? raw.inline?.from ?? inheritedInline?.line ?? undefined
+  const isOutdated = raw.inline?.out_dated ?? undefined
+
+  const rootId = threadRootId ?? (raw.parent?.id ? raw.parent.id : raw.id)
+  const threadId = String(rootId)
+  const isResolved = path ? false : undefined
+
+  return {
+    id: raw.id,
+    author,
+    authorAvatarUrl,
+    body,
+    createdAt,
+    url,
+    threadId,
+    path,
+    line,
+    isOutdated,
+    isResolved,
+    isBot
+  }
+}
+
+export function mapBitbucketComments(rawComments: readonly RawBitbucketComment[]): PRComment[] {
+  const parentMap = new Map<number, number>()
+  const rawById = new Map<number, RawBitbucketComment>()
+  const parentIdsWithReplies = new Set<number>()
+
+  for (const raw of rawComments) {
+    rawById.set(raw.id, raw)
+    if (raw.parent?.id) {
+      parentMap.set(raw.id, raw.parent.id)
+      parentIdsWithReplies.add(raw.parent.id)
+    }
+  }
+
+  const rootComments = new Map<number, RawBitbucketComment>()
+  for (const raw of rawComments) {
+    const rootId = findRootCommentId(raw.id, parentMap)
+    const root = rawById.get(rootId)
+    if (root) {
+      rootComments.set(rootId, root)
+    }
+  }
+
+  const result: PRComment[] = []
+  for (const raw of rawComments) {
+    if (raw.deleted && !parentIdsWithReplies.has(raw.id)) {
+      continue
+    }
+    const rootId = findRootCommentId(raw.id, parentMap)
+    const root = rootComments.get(rootId)
+    const inheritedInline =
+      root?.inline?.path && !raw.inline?.path
+        ? {
+            path: root.inline.path,
+            line: root.inline.to ?? root.inline.from ?? undefined
+          }
+        : undefined
+
+    result.push(mapBitbucketComment(raw, rootId, inheritedInline))
+  }
+
+  return result
+}

--- a/src/main/bitbucket/comments.test.ts
+++ b/src/main/bitbucket/comments.test.ts
@@ -4,6 +4,7 @@ import { resolveBitbucketAuthConfig } from './resolve-auth'
 import { getBitbucketRepoRef } from './repository-ref'
 import {
   addBitbucketPRComment,
+  BitbucketInsecureUrlError,
   fetchBitbucketPRComments,
   mapBitbucketComment,
   mapBitbucketComments,
@@ -13,12 +14,12 @@ import {
 
 vi.mock('../source-control/hosted-review-api-request', () => ({
   HostedReviewApiRequestError: class HostedReviewApiRequestError extends Error {
-    constructor(
-      message: string,
-      readonly status: number | null = null,
-      readonly timedOut = false
-    ) {
+    readonly status: number | null
+    readonly timedOut: boolean
+    constructor(message: string, options: { status?: number | null; timedOut?: boolean } = {}) {
       super(message)
+      this.status = options.status ?? null
+      this.timedOut = options.timedOut ?? false
     }
   },
   requestHostedReviewJson: vi.fn()
@@ -217,6 +218,39 @@ describe('Bitbucket comments', () => {
       expect(comments[0].id).toBe(1)
       expect(comments[1].threadId).toBe('1')
     })
+
+    it('maps isResolved: true and propagates resolution state to thread replies', () => {
+      const rawComments: RawBitbucketComment[] = [
+        {
+          id: 10,
+          content: { raw: 'Resolved thread root' },
+          inline: { path: 'src/file.ts', to: 15 },
+          resolution: { type: 'resolved', created_on: '2026-03-26T12:00:00Z' }
+        },
+        {
+          id: 11,
+          content: { raw: 'Reply in resolved thread' },
+          parent: { id: 10 }
+        },
+        {
+          id: 20,
+          content: { raw: 'Open thread root' },
+          inline: { path: 'src/file.ts', to: 30 }
+        },
+        {
+          id: 21,
+          content: { raw: 'Reply in open thread' },
+          parent: { id: 20 }
+        }
+      ]
+
+      const comments = mapBitbucketComments(rawComments)
+      expect(comments).toHaveLength(4)
+      expect(comments[0].isResolved).toBe(true)
+      expect(comments[1].isResolved).toBe(true)
+      expect(comments[2].isResolved).toBe(false)
+      expect(comments[3].isResolved).toBe(false)
+    })
   })
 
   describe('fetchBitbucketPRComments', () => {
@@ -259,10 +293,11 @@ describe('Bitbucket comments', () => {
       expect(comments[0].body).toBe('LGTM')
       expect(requestHostedReviewJson).toHaveBeenCalledWith(
         new URL(
-          'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/comments?pagelen=100'
+          'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/comments?pagelen=100&fields=%2Bvalues.resolution'
         ),
         expect.objectContaining({
           method: 'GET',
+          redirect: 'error',
           headers: expect.objectContaining({
             Authorization: 'Bearer test-token'
           })
@@ -297,7 +332,24 @@ describe('Bitbucket comments', () => {
       })
 
       await expect(fetchBitbucketPRComments('/repo/path', 42)).rejects.toThrow(
-        'Bitbucket API URL must use HTTPS.'
+        BitbucketInsecureUrlError
+      )
+    })
+
+    it('stops pagination when nextUrl points to an unexpected origin', async () => {
+      vi.mocked(requestHostedReviewJson).mockResolvedValueOnce({
+        values: [{ id: 1, content: { raw: 'Page 1' } }],
+        next: 'https://evil.com/2.0/repositories/my-workspace/my-repo/pullrequests/42/comments?page=2'
+      })
+
+      const comments = await fetchBitbucketPRComments('/repo/path', 42)
+      expect(comments).toHaveLength(1)
+      expect(comments[0].id).toBe(1)
+      expect(requestHostedReviewJson).toHaveBeenCalledTimes(1)
+      expect(requestHostedReviewJson).toHaveBeenCalledWith(
+        expect.any(URL),
+        expect.objectContaining({ redirect: 'error' }),
+        30_000
       )
     })
 
@@ -416,6 +468,34 @@ describe('Bitbucket comments', () => {
       expect(result).toEqual({
         ok: false,
         error: 'Failed to reply to comment: Failed to reach Bitbucket'
+      })
+    })
+
+    it('uses rootCommentId for threadId when provided', async () => {
+      vi.mocked(requestHostedReviewJson).mockResolvedValueOnce({
+        id: 52,
+        content: { raw: 'Reply to reply' },
+        parent: { id: 51 },
+        user: { nickname: 'me' }
+      })
+
+      const result = await replyBitbucketPRComment(
+        '/repo/path',
+        42,
+        51,
+        'Reply to reply',
+        null,
+        {},
+        50
+      )
+
+      expect(result).toEqual({
+        ok: true,
+        comment: expect.objectContaining({
+          id: 52,
+          body: 'Reply to reply',
+          threadId: '50'
+        })
       })
     })
   })

--- a/src/main/bitbucket/comments.test.ts
+++ b/src/main/bitbucket/comments.test.ts
@@ -1,0 +1,422 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { requestHostedReviewJson } from '../source-control/hosted-review-api-request'
+import { resolveBitbucketAuthConfig } from './resolve-auth'
+import { getBitbucketRepoRef } from './repository-ref'
+import {
+  addBitbucketPRComment,
+  fetchBitbucketPRComments,
+  mapBitbucketComment,
+  mapBitbucketComments,
+  replyBitbucketPRComment,
+  type RawBitbucketComment
+} from './comments'
+
+vi.mock('../source-control/hosted-review-api-request', () => ({
+  HostedReviewApiRequestError: class HostedReviewApiRequestError extends Error {
+    constructor(
+      message: string,
+      readonly status: number | null = null,
+      readonly timedOut = false
+    ) {
+      super(message)
+    }
+  },
+  requestHostedReviewJson: vi.fn()
+}))
+
+vi.mock('./resolve-auth', () => ({
+  resolveBitbucketAuthConfig: vi.fn()
+}))
+
+vi.mock('./repository-ref', () => ({
+  getBitbucketRepoRef: vi.fn()
+}))
+
+describe('Bitbucket comments', () => {
+  const mockRepo = {
+    workspace: 'my-workspace',
+    repoSlug: 'my-repo'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'https://api.bitbucket.org/2.0',
+      accessToken: 'test-token',
+      email: null,
+      apiToken: null
+    })
+    vi.mocked(getBitbucketRepoRef).mockResolvedValue(mockRepo)
+  })
+
+  describe('mapBitbucketComment', () => {
+    it('maps conversation comment fields correctly', () => {
+      const raw: RawBitbucketComment = {
+        id: 101,
+        created_on: '2026-03-26T10:00:00Z',
+        content: { raw: 'Top-level comment' },
+        user: {
+          nickname: 'aiden',
+          display_name: 'Aiden Kim',
+          links: { avatar: { href: 'https://avatar.example.com/aiden' } }
+        },
+        links: { html: { href: 'https://bitbucket.org/ws/repo/pull-requests/1#comment-101' } }
+      }
+
+      const comment = mapBitbucketComment(raw)
+
+      expect(comment).toEqual({
+        id: 101,
+        author: 'aiden',
+        authorAvatarUrl: 'https://avatar.example.com/aiden',
+        body: 'Top-level comment',
+        createdAt: '2026-03-26T10:00:00Z',
+        url: 'https://bitbucket.org/ws/repo/pull-requests/1#comment-101',
+        threadId: '101',
+        path: undefined,
+        line: undefined,
+        isOutdated: undefined,
+        isResolved: undefined,
+        isBot: false
+      })
+    })
+
+    it('falls back to display_name or unknown when nickname is missing', () => {
+      const rawWithDisplayName: RawBitbucketComment = {
+        id: 102,
+        user: { display_name: 'Bob Dev' }
+      }
+      expect(mapBitbucketComment(rawWithDisplayName).author).toBe('Bob Dev')
+
+      const rawWithNoUser: RawBitbucketComment = {
+        id: 103
+      }
+      expect(mapBitbucketComment(rawWithNoUser).author).toBe('unknown')
+    })
+
+    it('detects bot authors', () => {
+      expect(
+        mapBitbucketComment({
+          id: 1,
+          user: { account_type: 'bot', nickname: 'ci-bot' }
+        }).isBot
+      ).toBe(true)
+
+      expect(
+        mapBitbucketComment({
+          id: 2,
+          user: { type: 'bot', nickname: 'helper' }
+        }).isBot
+      ).toBe(true)
+
+      expect(
+        mapBitbucketComment({
+          id: 3,
+          user: { nickname: 'code-review[bot]' }
+        }).isBot
+      ).toBe(true)
+
+      expect(
+        mapBitbucketComment({
+          id: 4,
+          user: { nickname: 'normal-user' }
+        }).isBot
+      ).toBe(false)
+    })
+
+    it('maps inline comments and marks isResolved as false', () => {
+      const raw: RawBitbucketComment = {
+        id: 201,
+        content: { raw: 'Code comment' },
+        inline: {
+          path: 'src/main.ts',
+          to: 42,
+          from: null,
+          out_dated: false
+        }
+      }
+
+      const comment = mapBitbucketComment(raw)
+      expect(comment.path).toBe('src/main.ts')
+      expect(comment.line).toBe(42)
+      expect(comment.isOutdated).toBe(false)
+      expect(comment.isResolved).toBe(false)
+    })
+
+    it('uses from line when to is null', () => {
+      const raw: RawBitbucketComment = {
+        id: 202,
+        inline: {
+          path: 'src/old.ts',
+          to: null,
+          from: 15
+        }
+      }
+      expect(mapBitbucketComment(raw).line).toBe(15)
+    })
+  })
+
+  describe('mapBitbucketComments', () => {
+    it('groups multi-level replies under the root threadId and inherits inline info', () => {
+      const rawComments: RawBitbucketComment[] = [
+        {
+          id: 10,
+          created_on: '2026-03-26T10:00:00Z',
+          content: { raw: 'Root inline comment' },
+          inline: { path: 'src/index.ts', to: 25 }
+        },
+        {
+          id: 11,
+          created_on: '2026-03-26T10:05:00Z',
+          content: { raw: 'First reply' },
+          parent: { id: 10 }
+        },
+        {
+          id: 12,
+          created_on: '2026-03-26T10:10:00Z',
+          content: { raw: 'Reply to first reply' },
+          parent: { id: 11 }
+        }
+      ]
+
+      const comments = mapBitbucketComments(rawComments)
+
+      expect(comments).toHaveLength(3)
+      expect(comments[0].threadId).toBe('10')
+      expect(comments[0].path).toBe('src/index.ts')
+      expect(comments[0].line).toBe(25)
+
+      expect(comments[1].threadId).toBe('10')
+      expect(comments[1].path).toBe('src/index.ts')
+      expect(comments[1].line).toBe(25)
+
+      expect(comments[2].threadId).toBe('10')
+      expect(comments[2].path).toBe('src/index.ts')
+      expect(comments[2].line).toBe(25)
+    })
+
+    it('filters out deleted comments with no replies', () => {
+      const rawComments: RawBitbucketComment[] = [
+        { id: 1, content: { raw: 'Keep me' } },
+        { id: 2, deleted: true, content: { raw: '' } }
+      ]
+
+      const comments = mapBitbucketComments(rawComments)
+      expect(comments).toHaveLength(1)
+      expect(comments[0].id).toBe(1)
+    })
+
+    it('keeps deleted comments that have replies', () => {
+      const rawComments: RawBitbucketComment[] = [
+        { id: 1, deleted: true, content: { raw: '' } },
+        { id: 2, content: { raw: 'Reply to deleted' }, parent: { id: 1 } }
+      ]
+
+      const comments = mapBitbucketComments(rawComments)
+      expect(comments).toHaveLength(2)
+      expect(comments[0].id).toBe(1)
+      expect(comments[1].threadId).toBe('1')
+    })
+  })
+
+  describe('fetchBitbucketPRComments', () => {
+    it('returns empty array when not authenticated', async () => {
+      vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+        baseUrl: 'https://api.bitbucket.org/2.0',
+        accessToken: null,
+        email: null,
+        apiToken: null
+      })
+
+      const comments = await fetchBitbucketPRComments('/repo/path', 42)
+      expect(comments).toEqual([])
+      expect(requestHostedReviewJson).not.toHaveBeenCalled()
+    })
+
+    it('returns empty array when repo cannot be resolved', async () => {
+      vi.mocked(getBitbucketRepoRef).mockResolvedValue(null)
+
+      const comments = await fetchBitbucketPRComments('/repo/path', 42)
+      expect(comments).toEqual([])
+      expect(requestHostedReviewJson).not.toHaveBeenCalled()
+    })
+
+    it('fetches single page of comments and maps them', async () => {
+      vi.mocked(requestHostedReviewJson).mockResolvedValueOnce({
+        values: [
+          {
+            id: 1,
+            content: { raw: 'LGTM' },
+            user: { nickname: 'reviewer' }
+          }
+        ]
+      })
+
+      const comments = await fetchBitbucketPRComments('/repo/path', 42)
+      expect(comments).toHaveLength(1)
+      expect(comments[0].id).toBe(1)
+      expect(comments[0].author).toBe('reviewer')
+      expect(comments[0].body).toBe('LGTM')
+      expect(requestHostedReviewJson).toHaveBeenCalledWith(
+        new URL(
+          'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/comments?pagelen=100'
+        ),
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token'
+          })
+        }),
+        30_000
+      )
+    })
+
+    it('follows pagination when next URL is returned', async () => {
+      vi.mocked(requestHostedReviewJson)
+        .mockResolvedValueOnce({
+          values: [{ id: 1, content: { raw: 'Page 1' } }],
+          next: 'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/comments?page=2'
+        })
+        .mockResolvedValueOnce({
+          values: [{ id: 2, content: { raw: 'Page 2' } }]
+        })
+
+      const comments = await fetchBitbucketPRComments('/repo/path', 42)
+      expect(comments).toHaveLength(2)
+      expect(comments[0].id).toBe(1)
+      expect(comments[1].id).toBe(2)
+      expect(requestHostedReviewJson).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws when baseUrl is not HTTPS', async () => {
+      vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+        baseUrl: 'http://insecure.bitbucket.org/2.0',
+        accessToken: 'token',
+        email: null,
+        apiToken: null
+      })
+
+      await expect(fetchBitbucketPRComments('/repo/path', 42)).rejects.toThrow(
+        'Bitbucket API URL must use HTTPS.'
+      )
+    })
+
+    it('returns empty array when API request throws', async () => {
+      vi.mocked(requestHostedReviewJson).mockRejectedValueOnce(new Error('Network error'))
+
+      const comments = await fetchBitbucketPRComments('/repo/path', 42)
+      expect(comments).toEqual([])
+    })
+  })
+
+  describe('addBitbucketPRComment', () => {
+    it('successfully posts comment and returns mapped result', async () => {
+      vi.mocked(requestHostedReviewJson).mockResolvedValueOnce({
+        id: 50,
+        content: { raw: 'New comment' },
+        user: { nickname: 'me' }
+      })
+
+      const result = await addBitbucketPRComment('/repo/path', 42, 'New comment')
+
+      expect(result).toEqual({
+        ok: true,
+        comment: expect.objectContaining({
+          id: 50,
+          author: 'me',
+          body: 'New comment',
+          threadId: '50'
+        })
+      })
+      expect(requestHostedReviewJson).toHaveBeenCalledWith(
+        new URL(
+          'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/comments'
+        ),
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer test-token'
+          }),
+          body: JSON.stringify({ content: { raw: 'New comment' } })
+        }),
+        30_000
+      )
+    })
+
+    it('returns error when not authenticated', async () => {
+      vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+        baseUrl: 'https://api.bitbucket.org/2.0',
+        accessToken: null,
+        email: null,
+        apiToken: null
+      })
+
+      const result = await addBitbucketPRComment('/repo/path', 42, 'comment')
+      expect(result).toEqual({
+        ok: false,
+        error:
+          'Commenting failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
+      })
+    })
+
+    it('returns error when request fails', async () => {
+      vi.mocked(requestHostedReviewJson).mockRejectedValueOnce(
+        new Error(JSON.stringify({ error: { message: 'Rate limit exceeded' } }))
+      )
+
+      const result = await addBitbucketPRComment('/repo/path', 42, 'comment')
+      expect(result).toEqual({
+        ok: false,
+        error: 'Failed to add comment: Rate limit exceeded'
+      })
+    })
+  })
+
+  describe('replyBitbucketPRComment', () => {
+    it('successfully posts reply with parent id', async () => {
+      vi.mocked(requestHostedReviewJson).mockResolvedValueOnce({
+        id: 51,
+        content: { raw: 'A reply' },
+        parent: { id: 50 },
+        user: { nickname: 'me' }
+      })
+
+      const result = await replyBitbucketPRComment('/repo/path', 42, 50, 'A reply')
+
+      expect(result).toEqual({
+        ok: true,
+        comment: expect.objectContaining({
+          id: 51,
+          body: 'A reply',
+          threadId: '50'
+        })
+      })
+      expect(requestHostedReviewJson).toHaveBeenCalledWith(
+        new URL(
+          'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/comments'
+        ),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            content: { raw: 'A reply' },
+            parent: { id: 50 }
+          })
+        }),
+        30_000
+      )
+    })
+
+    it('returns error when reply fails', async () => {
+      vi.mocked(requestHostedReviewJson).mockRejectedValueOnce(
+        new Error('Failed to reach Bitbucket')
+      )
+
+      const result = await replyBitbucketPRComment('/repo/path', 42, 50, 'A reply')
+      expect(result).toEqual({
+        ok: false,
+        error: 'Failed to reply to comment: Failed to reach Bitbucket'
+      })
+    })
+  })
+})

--- a/src/main/bitbucket/comments.ts
+++ b/src/main/bitbucket/comments.ts
@@ -17,6 +17,13 @@ import {
 
 export { apiErrorMessage, mapBitbucketComment, mapBitbucketComments, type RawBitbucketComment }
 
+export class BitbucketInsecureUrlError extends Error {
+  constructor(message = 'Bitbucket API URL must use HTTPS.') {
+    super(message)
+    this.name = 'BitbucketInsecureUrlError'
+  }
+}
+
 function encodedRepoPath(repo: BitbucketRepoRef): string {
   return `${encodeURIComponent(repo.workspace)}/${encodeURIComponent(repo.repoSlug)}`
 }
@@ -42,15 +49,22 @@ export async function fetchBitbucketPRComments(
   }
 
   const base = config.baseUrl.replace(/\/+$/, '')
-  const initialUrl = new URL(
-    `${base}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/comments`
-  )
+  let initialUrl: URL
+  try {
+    initialUrl = new URL(
+      `${base}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/comments`
+    )
+  } catch {
+    return []
+  }
   initialUrl.searchParams.set('pagelen', '100')
+  initialUrl.searchParams.set('fields', '+values.resolution')
 
   if (initialUrl.protocol !== 'https:') {
-    throw new Error('Bitbucket API URL must use HTTPS.')
+    throw new BitbucketInsecureUrlError()
   }
 
+  const allowedOrigin = new URL(base).origin
   const rawComments: RawBitbucketComment[] = []
   let nextUrl: string | null = initialUrl.toString()
   let pageCount = 0
@@ -61,7 +75,11 @@ export async function fetchBitbucketPRComments(
       pageCount++
       const targetUrl = new URL(nextUrl)
       if (targetUrl.protocol !== 'https:') {
-        throw new Error('Bitbucket API URL must use HTTPS.')
+        throw new BitbucketInsecureUrlError()
+      }
+      if (targetUrl.origin !== allowedOrigin) {
+        console.warn('Ignoring Bitbucket pagination URL with unexpected origin')
+        break
       }
       const pageData = await requestHostedReviewJson<{
         values?: RawBitbucketComment[]
@@ -70,6 +88,7 @@ export async function fetchBitbucketPRComments(
         targetUrl,
         {
           method: 'GET',
+          redirect: 'error',
           headers: {
             Accept: 'application/json',
             ...authHeaders(config)
@@ -84,7 +103,7 @@ export async function fetchBitbucketPRComments(
     }
     return mapBitbucketComments(rawComments)
   } catch (err) {
-    if (err instanceof Error && err.message.includes('HTTPS')) {
+    if (err instanceof BitbucketInsecureUrlError) {
       throw err
     }
     console.warn('Failed to fetch Bitbucket PR comments:', err)
@@ -122,9 +141,15 @@ export async function addBitbucketPRComment(
   }
 
   const base = config.baseUrl.replace(/\/+$/, '')
-  const url = new URL(
-    `${base}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/comments`
-  )
+  let url: URL
+  try {
+    url = new URL(`${base}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/comments`)
+  } catch {
+    return {
+      ok: false,
+      error: 'Bitbucket API URL must use HTTPS.'
+    }
+  }
   if (url.protocol !== 'https:') {
     return {
       ok: false,
@@ -177,7 +202,8 @@ export async function replyBitbucketPRComment(
   parentCommentId: number,
   body: string,
   connectionId?: string | null,
-  options: HostedReviewExecutionOptions = {}
+  options: HostedReviewExecutionOptions = {},
+  rootCommentId?: number
 ): Promise<{ ok: true; comment: PRComment } | { ok: false; error: string }> {
   const config = resolveBitbucketAuthConfig()
   if (!hasAuth(config)) {
@@ -201,9 +227,15 @@ export async function replyBitbucketPRComment(
   }
 
   const base = config.baseUrl.replace(/\/+$/, '')
-  const url = new URL(
-    `${base}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/comments`
-  )
+  let url: URL
+  try {
+    url = new URL(`${base}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/comments`)
+  } catch {
+    return {
+      ok: false,
+      error: 'Bitbucket API URL must use HTTPS.'
+    }
+  }
   if (url.protocol !== 'https:') {
     return {
       ok: false,
@@ -234,7 +266,7 @@ export async function replyBitbucketPRComment(
     )
     return {
       ok: true,
-      comment: mapBitbucketComment(created, parentCommentId)
+      comment: mapBitbucketComment(created, rootCommentId ?? parentCommentId)
     }
   } catch (error) {
     const message = apiErrorMessage(error)

--- a/src/main/bitbucket/comments.ts
+++ b/src/main/bitbucket/comments.ts
@@ -1,0 +1,246 @@
+import type { PRComment } from '../../shared/github/comment-types'
+import type { HostedReviewExecutionOptions } from '../source-control/hosted-review-git-options'
+import { getHostedReviewLocalGitOptions } from '../source-control/hosted-review-git-options'
+import { requestHostedReviewJson } from '../source-control/hosted-review-api-request'
+import { authHeaders, hasAuth } from './bitbucket-auth-config'
+import { resolveBitbucketAuthConfig } from './resolve-auth'
+import { getBitbucketRepoRef, type BitbucketRepoRef } from './repository-ref'
+
+const REQUEST_TIMEOUT_MS = 30_000
+
+import {
+  apiErrorMessage,
+  mapBitbucketComment,
+  mapBitbucketComments,
+  type RawBitbucketComment
+} from './comments-mappers'
+
+export { apiErrorMessage, mapBitbucketComment, mapBitbucketComments, type RawBitbucketComment }
+
+function encodedRepoPath(repo: BitbucketRepoRef): string {
+  return `${encodeURIComponent(repo.workspace)}/${encodeURIComponent(repo.repoSlug)}`
+}
+
+export async function fetchBitbucketPRComments(
+  repoPath: string,
+  prNumber: number,
+  connectionId?: string | null,
+  options: HostedReviewExecutionOptions = {}
+): Promise<PRComment[]> {
+  const config = resolveBitbucketAuthConfig()
+  if (!hasAuth(config)) {
+    return []
+  }
+
+  const repo = await getBitbucketRepoRef(
+    repoPath,
+    connectionId,
+    getHostedReviewLocalGitOptions(options)
+  )
+  if (!repo) {
+    return []
+  }
+
+  const base = config.baseUrl.replace(/\/+$/, '')
+  const initialUrl = new URL(
+    `${base}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/comments`
+  )
+  initialUrl.searchParams.set('pagelen', '100')
+
+  if (initialUrl.protocol !== 'https:') {
+    throw new Error('Bitbucket API URL must use HTTPS.')
+  }
+
+  const rawComments: RawBitbucketComment[] = []
+  let nextUrl: string | null = initialUrl.toString()
+  let pageCount = 0
+  const MAX_PAGES = 10
+
+  try {
+    while (nextUrl && pageCount < MAX_PAGES) {
+      pageCount++
+      const targetUrl = new URL(nextUrl)
+      if (targetUrl.protocol !== 'https:') {
+        throw new Error('Bitbucket API URL must use HTTPS.')
+      }
+      const pageData = await requestHostedReviewJson<{
+        values?: RawBitbucketComment[]
+        next?: string
+      }>(
+        targetUrl,
+        {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json',
+            ...authHeaders(config)
+          }
+        },
+        REQUEST_TIMEOUT_MS
+      )
+      if (Array.isArray(pageData.values)) {
+        rawComments.push(...pageData.values)
+      }
+      nextUrl = typeof pageData.next === 'string' && pageData.next ? pageData.next : null
+    }
+    return mapBitbucketComments(rawComments)
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('HTTPS')) {
+      throw err
+    }
+    console.warn('Failed to fetch Bitbucket PR comments:', err)
+    return []
+  }
+}
+
+export async function addBitbucketPRComment(
+  repoPath: string,
+  prNumber: number,
+  body: string,
+  connectionId?: string | null,
+  options: HostedReviewExecutionOptions = {},
+  inline?: { path: string; line: number }
+): Promise<{ ok: true; comment: PRComment } | { ok: false; error: string }> {
+  const config = resolveBitbucketAuthConfig()
+  if (!hasAuth(config)) {
+    return {
+      ok: false,
+      error:
+        'Commenting failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
+    }
+  }
+
+  const repo = await getBitbucketRepoRef(
+    repoPath,
+    connectionId,
+    getHostedReviewLocalGitOptions(options)
+  )
+  if (!repo) {
+    return {
+      ok: false,
+      error: 'Commenting requires a Bitbucket remote.'
+    }
+  }
+
+  const base = config.baseUrl.replace(/\/+$/, '')
+  const url = new URL(
+    `${base}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/comments`
+  )
+  if (url.protocol !== 'https:') {
+    return {
+      ok: false,
+      error: 'Bitbucket API URL must use HTTPS.'
+    }
+  }
+
+  const payload: Record<string, unknown> = {
+    content: {
+      raw: body
+    }
+  }
+  if (inline) {
+    payload.inline = {
+      path: inline.path,
+      to: inline.line
+    }
+  }
+
+  try {
+    const created = await requestHostedReviewJson<RawBitbucketComment>(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          ...authHeaders(config)
+        },
+        body: JSON.stringify(payload)
+      },
+      REQUEST_TIMEOUT_MS
+    )
+    return {
+      ok: true,
+      comment: mapBitbucketComment(created)
+    }
+  } catch (error) {
+    const message = apiErrorMessage(error)
+    return {
+      ok: false,
+      error: message ? `Failed to add comment: ${message}` : 'Failed to add comment.'
+    }
+  }
+}
+
+export async function replyBitbucketPRComment(
+  repoPath: string,
+  prNumber: number,
+  parentCommentId: number,
+  body: string,
+  connectionId?: string | null,
+  options: HostedReviewExecutionOptions = {}
+): Promise<{ ok: true; comment: PRComment } | { ok: false; error: string }> {
+  const config = resolveBitbucketAuthConfig()
+  if (!hasAuth(config)) {
+    return {
+      ok: false,
+      error:
+        'Commenting failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
+    }
+  }
+
+  const repo = await getBitbucketRepoRef(
+    repoPath,
+    connectionId,
+    getHostedReviewLocalGitOptions(options)
+  )
+  if (!repo) {
+    return {
+      ok: false,
+      error: 'Commenting requires a Bitbucket remote.'
+    }
+  }
+
+  const base = config.baseUrl.replace(/\/+$/, '')
+  const url = new URL(
+    `${base}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/comments`
+  )
+  if (url.protocol !== 'https:') {
+    return {
+      ok: false,
+      error: 'Bitbucket API URL must use HTTPS.'
+    }
+  }
+
+  try {
+    const created = await requestHostedReviewJson<RawBitbucketComment>(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          ...authHeaders(config)
+        },
+        body: JSON.stringify({
+          content: {
+            raw: body
+          },
+          parent: {
+            id: parentCommentId
+          }
+        })
+      },
+      REQUEST_TIMEOUT_MS
+    )
+    return {
+      ok: true,
+      comment: mapBitbucketComment(created, parentCommentId)
+    }
+  } catch (error) {
+    const message = apiErrorMessage(error)
+    return {
+      ok: false,
+      error: message ? `Failed to reply to comment: ${message}` : 'Failed to reply to comment.'
+    }
+  }
+}

--- a/src/main/bitbucket/pull-request-merge.test.ts
+++ b/src/main/bitbucket/pull-request-merge.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  HostedReviewApiRequestError,
+  requestHostedReviewJson
+} from '../source-control/hosted-review-api-request'
+import { resolveBitbucketAuthConfig } from './resolve-auth'
+import { getBitbucketRepoRef } from './repository-ref'
+import { declineBitbucketPullRequest, mergeBitbucketPullRequest } from './pull-request-merge'
+import { invalidateHostedReviewBranchCache } from '../source-control/hosted-review-branch-cache'
+
+vi.mock('../source-control/hosted-review-api-request', () => ({
+  HostedReviewApiRequestError: class HostedReviewApiRequestError extends Error {
+    constructor(
+      message: string,
+      readonly status: number | null = null,
+      readonly timedOut = false
+    ) {
+      super(message)
+    }
+  },
+  requestHostedReviewJson: vi.fn()
+}))
+
+vi.mock('./resolve-auth', () => ({
+  resolveBitbucketAuthConfig: vi.fn()
+}))
+
+vi.mock('./repository-ref', () => ({
+  getBitbucketRepoRef: vi.fn()
+}))
+
+vi.mock('../source-control/hosted-review-branch-cache', () => ({
+  invalidateHostedReviewBranchCache: vi.fn()
+}))
+
+describe('mergeBitbucketPullRequest', () => {
+  const mockRepo = {
+    workspace: 'my-workspace',
+    repoSlug: 'my-repo'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'https://api.bitbucket.org/2.0',
+      accessToken: 'test-token',
+      email: null,
+      apiToken: null
+    })
+    vi.mocked(getBitbucketRepoRef).mockResolvedValue(mockRepo)
+  })
+
+  it('sends correct merge request with default method', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42)
+
+    expect(result).toEqual({ ok: true })
+    expect(requestHostedReviewJson).toHaveBeenCalledWith(
+      new URL(
+        'https://api.bitbucket.org/2.0/repositories/my-workspace/my-repo/pullrequests/42/merge'
+      ),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          merge_strategy: 'merge_commit',
+          close_source_branch: true
+        })
+      }),
+      60_000
+    )
+  })
+
+  it('supports fast_forward merge method', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42, 'fast_forward', false)
+
+    expect(result).toEqual({ ok: true })
+    expect(requestHostedReviewJson).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        body: JSON.stringify({
+          merge_strategy: 'fast_forward',
+          close_source_branch: false
+        })
+      }),
+      expect.anything()
+    )
+  })
+
+  it('provides descriptive error when fast-forward is not possible', async () => {
+    vi.mocked(requestHostedReviewJson).mockRejectedValue(
+      new HostedReviewApiRequestError('Pull request cannot be fast forwarded', { status: 400 })
+    )
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42, 'fast_forward')
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Fast-forward merge not possible')
+    }
+  })
+
+  it('returns auth error when credentials are not configured', async () => {
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'https://api.bitbucket.org/2.0',
+      accessToken: null,
+      email: null,
+      apiToken: null
+    })
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42)
+
+    expect(result).toEqual({
+      ok: false,
+      error:
+        'Merge failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
+    })
+  })
+
+  it('invalidates branch cache on successful merge', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await mergeBitbucketPullRequest(
+      '/repo/path',
+      42,
+      'merge_commit',
+      true,
+      'ssh:my-host'
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(getBitbucketRepoRef).toHaveBeenCalledWith('/repo/path', 'my-host', expect.anything())
+    expect(invalidateHostedReviewBranchCache).toHaveBeenCalledWith('/repo/path', 'ssh:my-host')
+  })
+
+  it('parses structured JSON error message from Bitbucket API', async () => {
+    vi.mocked(requestHostedReviewJson).mockRejectedValue(
+      new Error(
+        JSON.stringify({
+          error: { message: 'Branch permission prevented merge', detail: 'Needs 2 approvals' }
+        })
+      )
+    )
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42)
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Merge failed: Branch permission prevented merge: Needs 2 approvals'
+    })
+  })
+})
+
+describe('declineBitbucketPullRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'https://api.bitbucket.org/2.0',
+      accessToken: 'test-token',
+      email: null,
+      apiToken: null
+    })
+    vi.mocked(getBitbucketRepoRef).mockResolvedValue({
+      workspace: 'ws',
+      repoSlug: 'repo'
+    })
+  })
+
+  it('calls decline endpoint successfully and invalidates branch cache', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await declineBitbucketPullRequest('/repo/path', 10, 'ssh:remote-server')
+
+    expect(result).toEqual({ ok: true })
+    expect(getBitbucketRepoRef).toHaveBeenCalledWith(
+      '/repo/path',
+      'remote-server',
+      expect.anything()
+    )
+    expect(invalidateHostedReviewBranchCache).toHaveBeenCalledWith(
+      '/repo/path',
+      'ssh:remote-server'
+    )
+    expect(requestHostedReviewJson).toHaveBeenCalledWith(
+      new URL('https://api.bitbucket.org/2.0/repositories/ws/repo/pullrequests/10/decline'),
+      expect.objectContaining({ method: 'POST' }),
+      60_000
+    )
+  })
+})

--- a/src/main/bitbucket/pull-request-merge.test.ts
+++ b/src/main/bitbucket/pull-request-merge.test.ts
@@ -64,10 +64,28 @@ describe('mergeBitbucketPullRequest', () => {
         method: 'POST',
         body: JSON.stringify({
           merge_strategy: 'merge_commit',
-          close_source_branch: true
+          close_source_branch: false
         })
       }),
       60_000
+    )
+  })
+
+  it('allows closing source branch when explicitly requested', async () => {
+    vi.mocked(requestHostedReviewJson).mockResolvedValue({})
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42, 'merge_commit', true)
+
+    expect(result).toEqual({ ok: true })
+    expect(requestHostedReviewJson).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        body: JSON.stringify({
+          merge_strategy: 'merge_commit',
+          close_source_branch: true
+        })
+      }),
+      expect.anything()
     )
   })
 
@@ -117,6 +135,23 @@ describe('mergeBitbucketPullRequest', () => {
       error:
         'Merge failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
     })
+  })
+
+  it('rejects non-HTTPS Bitbucket API baseUrl for merge', async () => {
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'http://insecure-bitbucket.org/2.0',
+      accessToken: 'test-token',
+      email: null,
+      apiToken: null
+    })
+
+    const result = await mergeBitbucketPullRequest('/repo/path', 42)
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Merge failed: Bitbucket API URL must use HTTPS.'
+    })
+    expect(requestHostedReviewJson).not.toHaveBeenCalled()
   })
 
   it('invalidates branch cache on successful merge', async () => {
@@ -188,5 +223,22 @@ describe('declineBitbucketPullRequest', () => {
       expect.objectContaining({ method: 'POST' }),
       60_000
     )
+  })
+
+  it('rejects non-HTTPS Bitbucket API baseUrl for decline', async () => {
+    vi.mocked(resolveBitbucketAuthConfig).mockReturnValue({
+      baseUrl: 'http://insecure-bitbucket.org/2.0',
+      accessToken: 'test-token',
+      email: null,
+      apiToken: null
+    })
+
+    const result = await declineBitbucketPullRequest('/repo/path', 10)
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Close failed: Bitbucket API URL must use HTTPS.'
+    })
+    expect(requestHostedReviewJson).not.toHaveBeenCalled()
   })
 })

--- a/src/main/bitbucket/pull-request-merge.test.ts
+++ b/src/main/bitbucket/pull-request-merge.test.ts
@@ -10,12 +10,12 @@ import { invalidateHostedReviewBranchCache } from '../source-control/hosted-revi
 
 vi.mock('../source-control/hosted-review-api-request', () => ({
   HostedReviewApiRequestError: class HostedReviewApiRequestError extends Error {
-    constructor(
-      message: string,
-      readonly status: number | null = null,
-      readonly timedOut = false
-    ) {
+    readonly status: number | null
+    readonly timedOut: boolean
+    constructor(message: string, options: { status?: number | null; timedOut?: boolean } = {}) {
       super(message)
+      this.status = options.status ?? null
+      this.timedOut = options.timedOut ?? false
     }
   },
   requestHostedReviewJson: vi.fn()

--- a/src/main/bitbucket/pull-request-merge.test.ts
+++ b/src/main/bitbucket/pull-request-merge.test.ts
@@ -7,6 +7,7 @@ import { resolveBitbucketAuthConfig } from './resolve-auth'
 import { getBitbucketRepoRef } from './repository-ref'
 import { declineBitbucketPullRequest, mergeBitbucketPullRequest } from './pull-request-merge'
 import { invalidateHostedReviewBranchCache } from '../source-control/hosted-review-branch-cache'
+import type { ExecutionHostId } from '../../shared/execution-host'
 
 vi.mock('../source-control/hosted-review-api-request', () => ({
   HostedReviewApiRequestError: class HostedReviewApiRequestError extends Error {
@@ -186,6 +187,22 @@ describe('mergeBitbucketPullRequest', () => {
       error: 'Merge failed: Branch permission prevented merge: Needs 2 approvals'
     })
   })
+
+  it('returns structured error when host cannot be dispatched', async () => {
+    const result = await mergeBitbucketPullRequest(
+      '/repo/path',
+      42,
+      'merge_commit',
+      false,
+      'runtime:remote-env' as ExecutionHostId
+    )
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Merge failed:')
+    }
+    expect(requestHostedReviewJson).not.toHaveBeenCalled()
+  })
 })
 
 describe('declineBitbucketPullRequest', () => {
@@ -239,6 +256,20 @@ describe('declineBitbucketPullRequest', () => {
       ok: false,
       error: 'Close failed: Bitbucket API URL must use HTTPS.'
     })
+    expect(requestHostedReviewJson).not.toHaveBeenCalled()
+  })
+
+  it('returns structured error when host cannot be dispatched', async () => {
+    const result = await declineBitbucketPullRequest(
+      '/repo/path',
+      10,
+      'runtime:remote-env' as ExecutionHostId
+    )
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Close failed:')
+    }
     expect(requestHostedReviewJson).not.toHaveBeenCalled()
   })
 })

--- a/src/main/bitbucket/pull-request-merge.ts
+++ b/src/main/bitbucket/pull-request-merge.ts
@@ -126,9 +126,17 @@ export async function mergeBitbucketPullRequest(
     }
   }
 
-  const url = new URL(
-    `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/merge`
-  )
+  let url: URL
+  try {
+    url = new URL(
+      `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/merge`
+    )
+  } catch {
+    return {
+      ok: false,
+      error: 'Merge failed: Bitbucket API URL must use HTTPS.'
+    }
+  }
   if (url.protocol !== 'https:') {
     return {
       ok: false,
@@ -191,9 +199,17 @@ export async function declineBitbucketPullRequest(
     }
   }
 
-  const url = new URL(
-    `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/decline`
-  )
+  let url: URL
+  try {
+    url = new URL(
+      `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/decline`
+    )
+  } catch {
+    return {
+      ok: false,
+      error: 'Close failed: Bitbucket API URL must use HTTPS.'
+    }
+  }
   if (url.protocol !== 'https:') {
     return {
       ok: false,

--- a/src/main/bitbucket/pull-request-merge.ts
+++ b/src/main/bitbucket/pull-request-merge.ts
@@ -1,0 +1,215 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { hostedReviewSshConnectionId } from '../source-control/hosted-review-execution-host'
+import type { BitbucketPRMergeMethod } from '../../shared/bitbucket-merge-methods'
+import {
+  HostedReviewApiRequestError,
+  requestHostedReviewJson
+} from '../source-control/hosted-review-api-request'
+import { authHeaders, hasAuth } from './bitbucket-auth-config'
+import { resolveBitbucketAuthConfig } from './resolve-auth'
+import { getBitbucketRepoRef, type BitbucketRepoRef } from './repository-ref'
+import type { HostedReviewExecutionOptions } from '../source-control/hosted-review-git-options'
+import { getHostedReviewLocalGitOptions } from '../source-control/hosted-review-git-options'
+import { invalidateHostedReviewBranchCache } from '../source-control/hosted-review-branch-cache'
+
+const MERGE_REQUEST_TIMEOUT_MS = 60_000
+
+export type BitbucketMergeResult = { ok: true } | { ok: false; error: string }
+
+function encodedRepoPath(repo: BitbucketRepoRef): string {
+  return `${encodeURIComponent(repo.workspace)}/${encodeURIComponent(repo.repoSlug)}`
+}
+
+function apiErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    try {
+      const parsed = JSON.parse(error.message) as {
+        error?: { message?: string; detail?: string }
+        message?: string
+      }
+      if (parsed?.error?.message) {
+        return parsed.error.detail
+          ? `${parsed.error.message}: ${parsed.error.detail}`
+          : parsed.error.message
+      }
+      if (parsed?.message) {
+        return parsed.message
+      }
+    } catch {
+      // not JSON
+    }
+    return error.message
+  }
+  return String(error)
+}
+
+function classifyMergeError(error: unknown, method: BitbucketPRMergeMethod): BitbucketMergeResult {
+  const message = apiErrorMessage(error)
+  const lower = message.toLowerCase()
+  const status = error instanceof HostedReviewApiRequestError ? error.status : null
+
+  if (status === 401 || status === 403 || lower.includes('unauthorized')) {
+    return {
+      ok: false,
+      error: 'Merge failed: permission denied. Check your Bitbucket account permissions.'
+    }
+  }
+
+  if (
+    method === 'fast_forward' &&
+    (lower.includes('fast forward') || lower.includes('fast-forward'))
+  ) {
+    return {
+      ok: false,
+      error:
+        'Fast-forward merge not possible: the target branch has new commits. Rebase your branch or use merge commit.'
+    }
+  }
+
+  if (lower.includes('conflict') || lower.includes('merge conflict')) {
+    return {
+      ok: false,
+      error: 'Merge failed: this pull request has merge conflicts that must be resolved first.'
+    }
+  }
+
+  if (status === 404) {
+    return {
+      ok: false,
+      error: 'Merge failed: pull request or repository not found.'
+    }
+  }
+
+  if (status === 409 || lower.includes('already merged') || lower.includes('not open')) {
+    return {
+      ok: false,
+      error: 'Merge failed: this pull request is no longer open.'
+    }
+  }
+
+  return {
+    ok: false,
+    error: message
+      ? `Merge failed: ${message}`
+      : 'Merge failed: Bitbucket could not complete the request.'
+  }
+}
+
+export async function mergeBitbucketPullRequest(
+  repoPath: string,
+  prNumber: number,
+  method: BitbucketPRMergeMethod = 'merge_commit',
+  closeSourceBranch = true,
+  executionHostId: ExecutionHostId = 'local',
+  options: HostedReviewExecutionOptions = {}
+): Promise<BitbucketMergeResult> {
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
+  const config = resolveBitbucketAuthConfig()
+
+  if (!hasAuth(config)) {
+    return {
+      ok: false,
+      error:
+        'Merge failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
+    }
+  }
+
+  const repo = await getBitbucketRepoRef(
+    repoPath,
+    connectionId,
+    getHostedReviewLocalGitOptions(options)
+  )
+  if (!repo) {
+    return {
+      ok: false,
+      error: 'Merging pull requests requires a Bitbucket remote.'
+    }
+  }
+
+  const url = new URL(
+    `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/merge`
+  )
+
+  const body = {
+    merge_strategy: method,
+    close_source_branch: closeSourceBranch
+  }
+
+  try {
+    await requestHostedReviewJson(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          ...authHeaders(config)
+        },
+        body: JSON.stringify(body)
+      },
+      MERGE_REQUEST_TIMEOUT_MS
+    )
+    invalidateHostedReviewBranchCache(repoPath, executionHostId)
+    return { ok: true }
+  } catch (error) {
+    return classifyMergeError(error, method)
+  }
+}
+
+export async function declineBitbucketPullRequest(
+  repoPath: string,
+  prNumber: number,
+  executionHostId: ExecutionHostId = 'local',
+  options: HostedReviewExecutionOptions = {}
+): Promise<BitbucketMergeResult> {
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
+  const config = resolveBitbucketAuthConfig()
+
+  if (!hasAuth(config)) {
+    return {
+      ok: false,
+      error:
+        'Close failed: Bitbucket is not connected. Connect Bitbucket in Settings > Integrations.'
+    }
+  }
+
+  const repo = await getBitbucketRepoRef(
+    repoPath,
+    connectionId,
+    getHostedReviewLocalGitOptions(options)
+  )
+  if (!repo) {
+    return {
+      ok: false,
+      error: 'Closing pull requests requires a Bitbucket remote.'
+    }
+  }
+
+  const url = new URL(
+    `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/decline`
+  )
+
+  try {
+    await requestHostedReviewJson(
+      url,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          ...authHeaders(config)
+        }
+      },
+      MERGE_REQUEST_TIMEOUT_MS
+    )
+    invalidateHostedReviewBranchCache(repoPath, executionHostId)
+    return { ok: true }
+  } catch (error) {
+    const message = apiErrorMessage(error)
+    return {
+      ok: false,
+      error: message
+        ? `Close failed: ${message}`
+        : 'Close failed: Bitbucket could not complete the request.'
+    }
+  }
+}

--- a/src/main/bitbucket/pull-request-merge.ts
+++ b/src/main/bitbucket/pull-request-merge.ts
@@ -103,7 +103,15 @@ export async function mergeBitbucketPullRequest(
   executionHostId: ExecutionHostId = 'local',
   options: HostedReviewExecutionOptions = {}
 ): Promise<BitbucketMergeResult> {
-  const connectionId = hostedReviewSshConnectionId(executionHostId)
+  let connectionId: string | null
+  try {
+    connectionId = hostedReviewSshConnectionId(executionHostId)
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Merge failed: ${error instanceof Error ? error.message : 'Invalid execution host.'}`
+    }
+  }
   const config = resolveBitbucketAuthConfig()
 
   if (!hasAuth(config)) {
@@ -176,7 +184,15 @@ export async function declineBitbucketPullRequest(
   executionHostId: ExecutionHostId = 'local',
   options: HostedReviewExecutionOptions = {}
 ): Promise<BitbucketMergeResult> {
-  const connectionId = hostedReviewSshConnectionId(executionHostId)
+  let connectionId: string | null
+  try {
+    connectionId = hostedReviewSshConnectionId(executionHostId)
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Close failed: ${error instanceof Error ? error.message : 'Invalid execution host.'}`
+    }
+  }
   const config = resolveBitbucketAuthConfig()
 
   if (!hasAuth(config)) {

--- a/src/main/bitbucket/pull-request-merge.ts
+++ b/src/main/bitbucket/pull-request-merge.ts
@@ -99,7 +99,7 @@ export async function mergeBitbucketPullRequest(
   repoPath: string,
   prNumber: number,
   method: BitbucketPRMergeMethod = 'merge_commit',
-  closeSourceBranch = true,
+  closeSourceBranch = false,
   executionHostId: ExecutionHostId = 'local',
   options: HostedReviewExecutionOptions = {}
 ): Promise<BitbucketMergeResult> {
@@ -129,6 +129,12 @@ export async function mergeBitbucketPullRequest(
   const url = new URL(
     `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/merge`
   )
+  if (url.protocol !== 'https:') {
+    return {
+      ok: false,
+      error: 'Merge failed: Bitbucket API URL must use HTTPS.'
+    }
+  }
 
   const body = {
     merge_strategy: method,
@@ -188,6 +194,12 @@ export async function declineBitbucketPullRequest(
   const url = new URL(
     `${config.baseUrl.replace(/\/+$/, '')}/repositories/${encodedRepoPath(repo)}/pullrequests/${prNumber}/decline`
   )
+  if (url.protocol !== 'https:') {
+    return {
+      ok: false,
+      error: 'Close failed: Bitbucket API URL must use HTTPS.'
+    }
+  }
 
   try {
     await requestHostedReviewJson(

--- a/src/main/ipc/bitbucket.ts
+++ b/src/main/ipc/bitbucket.ts
@@ -8,6 +8,7 @@ import {
   type BitbucketConnectResult,
   type BitbucketConnectionStatus
 } from '../bitbucket/credential-connection'
+import type { BitbucketPRMergeMethod } from '../../shared/bitbucket-merge-methods'
 import { _resetPreflightCache } from './preflight'
 
 function optionalString(value: unknown): string | null {
@@ -65,7 +66,7 @@ export function registerBitbucketHandlers(): void {
       args: {
         repoPath: string
         prNumber: number
-        method?: 'merge_commit' | 'squash' | 'fast_forward'
+        method?: BitbucketPRMergeMethod
         closeSourceBranch?: boolean
         executionHostId?: ExecutionHostId
       }

--- a/src/main/ipc/bitbucket.ts
+++ b/src/main/ipc/bitbucket.ts
@@ -92,4 +92,82 @@ export function registerBitbucketHandlers(): void {
       return declineBitbucketPullRequest(args.repoPath, args.prNumber, args.executionHostId)
     }
   )
+
+  ipcMain.handle(
+    'bitbucket:getPRComments',
+    async (
+      _event,
+      args: { repoPath: string; prNumber: number; executionHostId?: ExecutionHostId }
+    ) => {
+      const { fetchBitbucketPRComments } = await import('../bitbucket/comments')
+      const { hostedReviewSshConnectionId } =
+        await import('../source-control/hosted-review-execution-host')
+      const connectionId = hostedReviewSshConnectionId(args.executionHostId ?? 'local')
+      return fetchBitbucketPRComments(args.repoPath, args.prNumber, connectionId)
+    }
+  )
+
+  ipcMain.handle(
+    'bitbucket:addPRComment',
+    async (
+      _event,
+      args: {
+        repoPath: string
+        prNumber: number
+        body: string
+        parentId?: number
+        inline?: { path: string; line: number }
+        executionHostId?: ExecutionHostId
+      }
+    ) => {
+      const { hostedReviewSshConnectionId } =
+        await import('../source-control/hosted-review-execution-host')
+      const connectionId = hostedReviewSshConnectionId(args.executionHostId ?? 'local')
+      if (typeof args.parentId === 'number') {
+        const { replyBitbucketPRComment } = await import('../bitbucket/comments')
+        return replyBitbucketPRComment(
+          args.repoPath,
+          args.prNumber,
+          args.parentId,
+          args.body,
+          connectionId
+        )
+      }
+      const { addBitbucketPRComment } = await import('../bitbucket/comments')
+      return addBitbucketPRComment(
+        args.repoPath,
+        args.prNumber,
+        args.body,
+        connectionId,
+        {},
+        args.inline
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'bitbucket:replyPRComment',
+    async (
+      _event,
+      args: {
+        repoPath: string
+        prNumber: number
+        parentId: number
+        body: string
+        executionHostId?: ExecutionHostId
+      }
+    ) => {
+      const { replyBitbucketPRComment } = await import('../bitbucket/comments')
+      const { hostedReviewSshConnectionId } =
+        await import('../source-control/hosted-review-execution-host')
+      const connectionId = hostedReviewSshConnectionId(args.executionHostId ?? 'local')
+      return replyBitbucketPRComment(
+        args.repoPath,
+        args.prNumber,
+        args.parentId,
+        args.body,
+        connectionId
+      )
+    }
+  )
 }

--- a/src/main/ipc/bitbucket.ts
+++ b/src/main/ipc/bitbucket.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron'
+import type { ExecutionHostId } from '../../shared/execution-host'
 import {
   connectBitbucket,
   disconnectBitbucket,
@@ -56,4 +57,38 @@ export function registerBitbucketHandlers(): void {
   ipcMain.handle('bitbucket:status', async (): Promise<BitbucketConnectionStatus> => {
     return getBitbucketConnectionStatus()
   })
+
+  ipcMain.handle(
+    'bitbucket:mergePR',
+    async (
+      _event,
+      args: {
+        repoPath: string
+        prNumber: number
+        method?: 'merge_commit' | 'squash' | 'fast_forward'
+        closeSourceBranch?: boolean
+        executionHostId?: ExecutionHostId
+      }
+    ) => {
+      const { mergeBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+      return mergeBitbucketPullRequest(
+        args.repoPath,
+        args.prNumber,
+        args.method,
+        args.closeSourceBranch,
+        args.executionHostId
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'bitbucket:closePR',
+    async (
+      _event,
+      args: { repoPath: string; prNumber: number; executionHostId?: ExecutionHostId }
+    ) => {
+      const { declineBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+      return declineBitbucketPullRequest(args.repoPath, args.prNumber, args.executionHostId)
+    }
+  )
 }

--- a/src/main/ipc/bitbucket.ts
+++ b/src/main/ipc/bitbucket.ts
@@ -55,6 +55,28 @@ function normalizeConnectInput(value: unknown): BitbucketConnectArgs | null {
   }
 }
 
+async function resolveBitbucketConnectionId(
+  rawExecutionHostId: unknown
+): Promise<{ ok: true; connectionId: string | null } | { ok: false; error: string }> {
+  if (
+    rawExecutionHostId !== undefined &&
+    rawExecutionHostId !== null &&
+    typeof rawExecutionHostId !== 'string'
+  ) {
+    return { ok: false, error: 'Invalid execution host.' }
+  }
+  try {
+    const hostId = typeof rawExecutionHostId === 'string' ? rawExecutionHostId : 'local'
+    const { hostedReviewSshConnectionId } =
+      await import('../source-control/hosted-review-execution-host')
+    const connectionId = hostedReviewSshConnectionId(hostId as ExecutionHostId)
+    return { ok: true, connectionId }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid execution host.'
+    return { ok: false, error: message }
+  }
+}
+
 export function registerBitbucketHandlers(): void {
   ipcMain.handle(
     'bitbucket:connect',
@@ -103,14 +125,21 @@ export function registerBitbucketHandlers(): void {
           ? (raw.executionHostId as ExecutionHostId)
           : undefined
 
-      const { mergeBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
-      return mergeBitbucketPullRequest(
-        raw.repoPath,
-        raw.prNumber,
-        method,
-        closeSourceBranch,
-        executionHostId
-      )
+      try {
+        const { mergeBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+        return await mergeBitbucketPullRequest(
+          raw.repoPath,
+          raw.prNumber,
+          method,
+          closeSourceBranch,
+          executionHostId
+        )
+      } catch (error) {
+        return {
+          ok: false,
+          error: `Merge failed: ${error instanceof Error ? error.message : 'Unexpected error.'}`
+        }
+      }
     }
   )
 
@@ -129,8 +158,15 @@ export function registerBitbucketHandlers(): void {
           ? (raw.executionHostId as ExecutionHostId)
           : undefined
 
-      const { declineBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
-      return declineBitbucketPullRequest(raw.repoPath, raw.prNumber, executionHostId)
+      try {
+        const { declineBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+        return await declineBitbucketPullRequest(raw.repoPath, raw.prNumber, executionHostId)
+      } catch (error) {
+        return {
+          ok: false,
+          error: `Close failed: ${error instanceof Error ? error.message : 'Unexpected error.'}`
+        }
+      }
     }
   )
 
@@ -142,14 +178,19 @@ export function registerBitbucketHandlers(): void {
     if (!isValidRepoPath(raw.repoPath) || !isValidPrNumber(raw.prNumber)) {
       return []
     }
-    const executionHostId =
-      typeof raw.executionHostId === 'string' ? (raw.executionHostId as ExecutionHostId) : undefined
+    const hostResult = await resolveBitbucketConnectionId(raw.executionHostId)
+    if (!hostResult.ok) {
+      console.warn('Failed to resolve execution host for Bitbucket comments:', hostResult.error)
+      return []
+    }
 
-    const { fetchBitbucketPRComments } = await import('../bitbucket/comments')
-    const { hostedReviewSshConnectionId } =
-      await import('../source-control/hosted-review-execution-host')
-    const connectionId = hostedReviewSshConnectionId(executionHostId ?? 'local')
-    return fetchBitbucketPRComments(raw.repoPath, raw.prNumber, connectionId)
+    try {
+      const { fetchBitbucketPRComments } = await import('../bitbucket/comments')
+      return await fetchBitbucketPRComments(raw.repoPath, raw.prNumber, hostResult.connectionId)
+    } catch (error) {
+      console.warn('Failed to fetch Bitbucket PR comments:', error)
+      return []
+    }
   })
 
   ipcMain.handle(
@@ -169,13 +210,11 @@ export function registerBitbucketHandlers(): void {
       ) {
         return { ok: false, error: 'Invalid comment arguments.' }
       }
-      const executionHostId =
-        typeof raw.executionHostId === 'string'
-          ? (raw.executionHostId as ExecutionHostId)
-          : undefined
-      const { hostedReviewSshConnectionId } =
-        await import('../source-control/hosted-review-execution-host')
-      const connectionId = hostedReviewSshConnectionId(executionHostId ?? 'local')
+      const hostResult = await resolveBitbucketConnectionId(raw.executionHostId)
+      if (!hostResult.ok) {
+        return { ok: false, error: hostResult.error }
+      }
+      const connectionId = hostResult.connectionId
 
       if (typeof raw.parentId === 'number' && Number.isInteger(raw.parentId) && raw.parentId > 0) {
         const rootCommentId =
@@ -236,20 +275,18 @@ export function registerBitbucketHandlers(): void {
       ) {
         return { ok: false, error: 'Invalid reply arguments.' }
       }
+      const hostResult = await resolveBitbucketConnectionId(raw.executionHostId)
+      if (!hostResult.ok) {
+        return { ok: false, error: hostResult.error }
+      }
+      const connectionId = hostResult.connectionId
       const rootCommentId =
         typeof raw.rootCommentId === 'number' &&
         Number.isInteger(raw.rootCommentId) &&
         raw.rootCommentId > 0
           ? raw.rootCommentId
           : undefined
-      const executionHostId =
-        typeof raw.executionHostId === 'string'
-          ? (raw.executionHostId as ExecutionHostId)
-          : undefined
       const { replyBitbucketPRComment } = await import('../bitbucket/comments')
-      const { hostedReviewSshConnectionId } =
-        await import('../source-control/hosted-review-execution-host')
-      const connectionId = hostedReviewSshConnectionId(executionHostId ?? 'local')
       return replyBitbucketPRComment(
         raw.repoPath,
         raw.prNumber,

--- a/src/main/ipc/bitbucket.ts
+++ b/src/main/ipc/bitbucket.ts
@@ -8,11 +8,34 @@ import {
   type BitbucketConnectResult,
   type BitbucketConnectionStatus
 } from '../bitbucket/credential-connection'
-import type { BitbucketPRMergeMethod } from '../../shared/bitbucket-merge-methods'
+import {
+  BITBUCKET_PR_MERGE_METHODS,
+  type BitbucketPRMergeMethod
+} from '../../shared/bitbucket-merge-methods'
+import type { BitbucketMergeResult } from '../bitbucket/pull-request-merge'
+import type { PRComment } from '../../shared/github/comment-types'
 import { _resetPreflightCache } from './preflight'
 
 function optionalString(value: unknown): string | null {
   return typeof value === 'string' ? value : null
+}
+
+function isValidRepoPath(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isValidPrNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+}
+
+function isValidBody(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isValidMergeMethod(value: unknown): value is BitbucketPRMergeMethod {
+  return (
+    typeof value === 'string' && (BITBUCKET_PR_MERGE_METHODS as readonly string[]).includes(value)
+  )
 }
 
 function normalizeConnectInput(value: unknown): BitbucketConnectArgs | null {
@@ -61,86 +84,134 @@ export function registerBitbucketHandlers(): void {
 
   ipcMain.handle(
     'bitbucket:mergePR',
-    async (
-      _event,
-      args: {
-        repoPath: string
-        prNumber: number
-        method?: BitbucketPRMergeMethod
-        closeSourceBranch?: boolean
-        executionHostId?: ExecutionHostId
+    async (_event, args: unknown): Promise<BitbucketMergeResult> => {
+      if (!args || typeof args !== 'object') {
+        return { ok: false, error: 'Invalid merge arguments.' }
       }
-    ) => {
+      const raw = args as Record<string, unknown>
+      if (!isValidRepoPath(raw.repoPath) || !isValidPrNumber(raw.prNumber)) {
+        return { ok: false, error: 'Invalid merge arguments.' }
+      }
+      const method = raw.method !== undefined ? raw.method : 'merge_commit'
+      if (!isValidMergeMethod(method)) {
+        return { ok: false, error: 'Invalid merge strategy.' }
+      }
+      const closeSourceBranch =
+        typeof raw.closeSourceBranch === 'boolean' ? raw.closeSourceBranch : undefined
+      const executionHostId =
+        typeof raw.executionHostId === 'string'
+          ? (raw.executionHostId as ExecutionHostId)
+          : undefined
+
       const { mergeBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
       return mergeBitbucketPullRequest(
-        args.repoPath,
-        args.prNumber,
-        args.method,
-        args.closeSourceBranch,
-        args.executionHostId
+        raw.repoPath,
+        raw.prNumber,
+        method,
+        closeSourceBranch,
+        executionHostId
       )
     }
   )
 
   ipcMain.handle(
     'bitbucket:closePR',
-    async (
-      _event,
-      args: { repoPath: string; prNumber: number; executionHostId?: ExecutionHostId }
-    ) => {
+    async (_event, args: unknown): Promise<BitbucketMergeResult> => {
+      if (!args || typeof args !== 'object') {
+        return { ok: false, error: 'Invalid close arguments.' }
+      }
+      const raw = args as Record<string, unknown>
+      if (!isValidRepoPath(raw.repoPath) || !isValidPrNumber(raw.prNumber)) {
+        return { ok: false, error: 'Invalid close arguments.' }
+      }
+      const executionHostId =
+        typeof raw.executionHostId === 'string'
+          ? (raw.executionHostId as ExecutionHostId)
+          : undefined
+
       const { declineBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
-      return declineBitbucketPullRequest(args.repoPath, args.prNumber, args.executionHostId)
+      return declineBitbucketPullRequest(raw.repoPath, raw.prNumber, executionHostId)
     }
   )
 
-  ipcMain.handle(
-    'bitbucket:getPRComments',
-    async (
-      _event,
-      args: { repoPath: string; prNumber: number; executionHostId?: ExecutionHostId }
-    ) => {
-      const { fetchBitbucketPRComments } = await import('../bitbucket/comments')
-      const { hostedReviewSshConnectionId } =
-        await import('../source-control/hosted-review-execution-host')
-      const connectionId = hostedReviewSshConnectionId(args.executionHostId ?? 'local')
-      return fetchBitbucketPRComments(args.repoPath, args.prNumber, connectionId)
+  ipcMain.handle('bitbucket:getPRComments', async (_event, args: unknown): Promise<PRComment[]> => {
+    if (!args || typeof args !== 'object') {
+      return []
     }
-  )
+    const raw = args as Record<string, unknown>
+    if (!isValidRepoPath(raw.repoPath) || !isValidPrNumber(raw.prNumber)) {
+      return []
+    }
+    const executionHostId =
+      typeof raw.executionHostId === 'string' ? (raw.executionHostId as ExecutionHostId) : undefined
+
+    const { fetchBitbucketPRComments } = await import('../bitbucket/comments')
+    const { hostedReviewSshConnectionId } =
+      await import('../source-control/hosted-review-execution-host')
+    const connectionId = hostedReviewSshConnectionId(executionHostId ?? 'local')
+    return fetchBitbucketPRComments(raw.repoPath, raw.prNumber, connectionId)
+  })
 
   ipcMain.handle(
     'bitbucket:addPRComment',
     async (
       _event,
-      args: {
-        repoPath: string
-        prNumber: number
-        body: string
-        parentId?: number
-        inline?: { path: string; line: number }
-        executionHostId?: ExecutionHostId
+      args: unknown
+    ): Promise<{ ok: true; comment: PRComment } | { ok: false; error: string }> => {
+      if (!args || typeof args !== 'object') {
+        return { ok: false, error: 'Invalid comment arguments.' }
       }
-    ) => {
+      const raw = args as Record<string, unknown>
+      if (
+        !isValidRepoPath(raw.repoPath) ||
+        !isValidPrNumber(raw.prNumber) ||
+        !isValidBody(raw.body)
+      ) {
+        return { ok: false, error: 'Invalid comment arguments.' }
+      }
+      const executionHostId =
+        typeof raw.executionHostId === 'string'
+          ? (raw.executionHostId as ExecutionHostId)
+          : undefined
       const { hostedReviewSshConnectionId } =
         await import('../source-control/hosted-review-execution-host')
-      const connectionId = hostedReviewSshConnectionId(args.executionHostId ?? 'local')
-      if (typeof args.parentId === 'number') {
+      const connectionId = hostedReviewSshConnectionId(executionHostId ?? 'local')
+
+      if (typeof raw.parentId === 'number' && Number.isInteger(raw.parentId) && raw.parentId > 0) {
+        const rootCommentId =
+          typeof raw.rootCommentId === 'number' &&
+          Number.isInteger(raw.rootCommentId) &&
+          raw.rootCommentId > 0
+            ? raw.rootCommentId
+            : undefined
         const { replyBitbucketPRComment } = await import('../bitbucket/comments')
         return replyBitbucketPRComment(
-          args.repoPath,
-          args.prNumber,
-          args.parentId,
-          args.body,
-          connectionId
+          raw.repoPath,
+          raw.prNumber,
+          raw.parentId,
+          raw.body,
+          connectionId,
+          {},
+          rootCommentId
         )
       }
+
+      const inline =
+        raw.inline && typeof raw.inline === 'object'
+          ? {
+              path: String((raw.inline as Record<string, unknown>).path ?? ''),
+              line: Number((raw.inline as Record<string, unknown>).line ?? 0)
+            }
+          : undefined
+
       const { addBitbucketPRComment } = await import('../bitbucket/comments')
       return addBitbucketPRComment(
-        args.repoPath,
-        args.prNumber,
-        args.body,
+        raw.repoPath,
+        raw.prNumber,
+        raw.body,
         connectionId,
         {},
-        args.inline
+        inline?.path && inline.line > 0 ? inline : undefined
       )
     }
   )
@@ -149,24 +220,44 @@ export function registerBitbucketHandlers(): void {
     'bitbucket:replyPRComment',
     async (
       _event,
-      args: {
-        repoPath: string
-        prNumber: number
-        parentId: number
-        body: string
-        executionHostId?: ExecutionHostId
+      args: unknown
+    ): Promise<{ ok: true; comment: PRComment } | { ok: false; error: string }> => {
+      if (!args || typeof args !== 'object') {
+        return { ok: false, error: 'Invalid reply arguments.' }
       }
-    ) => {
+      const raw = args as Record<string, unknown>
+      if (
+        !isValidRepoPath(raw.repoPath) ||
+        !isValidPrNumber(raw.prNumber) ||
+        !isValidBody(raw.body) ||
+        typeof raw.parentId !== 'number' ||
+        !Number.isInteger(raw.parentId) ||
+        raw.parentId <= 0
+      ) {
+        return { ok: false, error: 'Invalid reply arguments.' }
+      }
+      const rootCommentId =
+        typeof raw.rootCommentId === 'number' &&
+        Number.isInteger(raw.rootCommentId) &&
+        raw.rootCommentId > 0
+          ? raw.rootCommentId
+          : undefined
+      const executionHostId =
+        typeof raw.executionHostId === 'string'
+          ? (raw.executionHostId as ExecutionHostId)
+          : undefined
       const { replyBitbucketPRComment } = await import('../bitbucket/comments')
       const { hostedReviewSshConnectionId } =
         await import('../source-control/hosted-review-execution-host')
-      const connectionId = hostedReviewSshConnectionId(args.executionHostId ?? 'local')
+      const connectionId = hostedReviewSshConnectionId(executionHostId ?? 'local')
       return replyBitbucketPRComment(
-        args.repoPath,
-        args.prNumber,
-        args.parentId,
-        args.body,
-        connectionId
+        raw.repoPath,
+        raw.prNumber,
+        raw.parentId,
+        raw.body,
+        connectionId,
+        {},
+        rootCommentId
       )
     }
   )

--- a/src/main/source-control/hosted-review-bitbucket.integration.test.ts
+++ b/src/main/source-control/hosted-review-bitbucket.integration.test.ts
@@ -210,4 +210,105 @@ describe('Bitbucket hosted review integration', () => {
       })
     }
   })
+
+  it('merges a Bitbucket PR with fast_forward strategy over HTTP', async () => {
+    let receivedMethod: string | null = null
+    let receivedCloseBranch: boolean | null = null
+    let receivedAuth: string | undefined
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
+      receivedAuth = req.headers.authorization
+
+      if (url.pathname === '/2.0/repositories/team/repo/pullrequests/42/merge') {
+        let body = ''
+        req.on('data', (chunk) => {
+          body += chunk
+        })
+        req.on('end', () => {
+          const parsed = JSON.parse(body) as {
+            merge_strategy: string
+            close_source_branch: boolean
+          }
+          receivedMethod = parsed.merge_strategy
+          receivedCloseBranch = parsed.close_source_branch
+          sendJson(res, { id: 42, state: 'MERGED' })
+        })
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ message: 'not found' }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    const repoPath = await mkdtemp(join(tmpdir(), 'orca-bitbucket-merge-'))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('expected TCP server address')
+      }
+
+      process.env.ORCA_BITBUCKET_API_BASE_URL = `http://127.0.0.1:${address.port}/2.0`
+      await execFileAsync('git', ['init'], { cwd: repoPath })
+      await execFileAsync('git', ['remote', 'add', 'origin', 'git@bitbucket.org:team/repo.git'], {
+        cwd: repoPath
+      })
+
+      const { mergeBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+      const result = await mergeBitbucketPullRequest(repoPath, 42, 'fast_forward', true)
+
+      expect(result).toEqual({ ok: true })
+      expect(receivedMethod).toBe('fast_forward')
+      expect(receivedCloseBranch).toBe(true)
+      expect(receivedAuth).toBe('Bearer local-token')
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+
+  it('declines a Bitbucket PR over HTTP', async () => {
+    let declinedPath: string | null = null
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
+      if (url.pathname === '/2.0/repositories/team/repo/pullrequests/42/decline') {
+        declinedPath = url.pathname
+        sendJson(res, { id: 42, state: 'DECLINED' })
+        return
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ message: 'not found' }))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    const repoPath = await mkdtemp(join(tmpdir(), 'orca-bitbucket-decline-'))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('expected TCP server address')
+      }
+
+      process.env.ORCA_BITBUCKET_API_BASE_URL = `http://127.0.0.1:${address.port}/2.0`
+      await execFileAsync('git', ['init'], { cwd: repoPath })
+      await execFileAsync('git', ['remote', 'add', 'origin', 'git@bitbucket.org:team/repo.git'], {
+        cwd: repoPath
+      })
+
+      const { declineBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
+      const result = await declineBitbucketPullRequest(repoPath, 42)
+
+      expect(result).toEqual({ ok: true })
+      expect(declinedPath).toBe('/2.0/repositories/team/repo/pullrequests/42/decline')
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
 })

--- a/src/main/source-control/hosted-review-bitbucket.integration.test.ts
+++ b/src/main/source-control/hosted-review-bitbucket.integration.test.ts
@@ -211,45 +211,10 @@ describe('Bitbucket hosted review integration', () => {
     }
   })
 
-  it('merges a Bitbucket PR with fast_forward strategy over HTTP', async () => {
-    let receivedMethod: string | null = null
-    let receivedCloseBranch: boolean | null = null
-    let receivedAuth: string | undefined
-
-    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
-      receivedAuth = req.headers.authorization
-
-      if (url.pathname === '/2.0/repositories/team/repo/pullrequests/42/merge') {
-        let body = ''
-        req.on('data', (chunk) => {
-          body += chunk
-        })
-        req.on('end', () => {
-          const parsed = JSON.parse(body) as {
-            merge_strategy: string
-            close_source_branch: boolean
-          }
-          receivedMethod = parsed.merge_strategy
-          receivedCloseBranch = parsed.close_source_branch
-          sendJson(res, { id: 42, state: 'MERGED' })
-        })
-        return
-      }
-
-      res.writeHead(404, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ message: 'not found' }))
-    })
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
-
+  it('rejects merging a Bitbucket PR over insecure HTTP', async () => {
     const repoPath = await mkdtemp(join(tmpdir(), 'orca-bitbucket-merge-'))
     try {
-      const address = server.address()
-      if (!address || typeof address === 'string') {
-        throw new Error('expected TCP server address')
-      }
-
-      process.env.ORCA_BITBUCKET_API_BASE_URL = `http://127.0.0.1:${address.port}/2.0`
+      process.env.ORCA_BITBUCKET_API_BASE_URL = 'http://127.0.0.1:9999/2.0'
       await execFileAsync('git', ['init'], { cwd: repoPath })
       await execFileAsync('git', ['remote', 'add', 'origin', 'git@bitbucket.org:team/repo.git'], {
         cwd: repoPath
@@ -258,42 +223,19 @@ describe('Bitbucket hosted review integration', () => {
       const { mergeBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
       const result = await mergeBitbucketPullRequest(repoPath, 42, 'fast_forward', true)
 
-      expect(result).toEqual({ ok: true })
-      expect(receivedMethod).toBe('fast_forward')
-      expect(receivedCloseBranch).toBe(true)
-      expect(receivedAuth).toBe('Bearer local-token')
+      expect(result).toEqual({
+        ok: false,
+        error: 'Merge failed: Bitbucket API URL must use HTTPS.'
+      })
     } finally {
       await rm(repoPath, { recursive: true, force: true })
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()))
-      })
     }
   })
 
-  it('declines a Bitbucket PR over HTTP', async () => {
-    let declinedPath: string | null = null
-
-    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
-      if (url.pathname === '/2.0/repositories/team/repo/pullrequests/42/decline') {
-        declinedPath = url.pathname
-        sendJson(res, { id: 42, state: 'DECLINED' })
-        return
-      }
-
-      res.writeHead(404, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ message: 'not found' }))
-    })
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
-
+  it('rejects declining a Bitbucket PR over insecure HTTP', async () => {
     const repoPath = await mkdtemp(join(tmpdir(), 'orca-bitbucket-decline-'))
     try {
-      const address = server.address()
-      if (!address || typeof address === 'string') {
-        throw new Error('expected TCP server address')
-      }
-
-      process.env.ORCA_BITBUCKET_API_BASE_URL = `http://127.0.0.1:${address.port}/2.0`
+      process.env.ORCA_BITBUCKET_API_BASE_URL = 'http://127.0.0.1:9999/2.0'
       await execFileAsync('git', ['init'], { cwd: repoPath })
       await execFileAsync('git', ['remote', 'add', 'origin', 'git@bitbucket.org:team/repo.git'], {
         cwd: repoPath
@@ -302,13 +244,12 @@ describe('Bitbucket hosted review integration', () => {
       const { declineBitbucketPullRequest } = await import('../bitbucket/pull-request-merge')
       const result = await declineBitbucketPullRequest(repoPath, 42)
 
-      expect(result).toEqual({ ok: true })
-      expect(declinedPath).toBe('/2.0/repositories/team/repo/pullrequests/42/decline')
+      expect(result).toEqual({
+        ok: false,
+        error: 'Close failed: Bitbucket API URL must use HTTPS.'
+      })
     } finally {
       await rm(repoPath, { recursive: true, force: true })
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()))
-      })
     }
   })
 })

--- a/src/preload/api/bitbucket-bridge.ts
+++ b/src/preload/api/bitbucket-bridge.ts
@@ -13,5 +13,9 @@ export const bitbucketApi = {
 
   disconnect: (): Promise<void> => ipcRenderer.invoke('bitbucket:disconnect'),
 
-  status: () => ipcRenderer.invoke('bitbucket:status')
+  status: () => ipcRenderer.invoke('bitbucket:status'),
+
+  mergePR: (args) => ipcRenderer.invoke('bitbucket:mergePR', args),
+
+  closePR: (args) => ipcRenderer.invoke('bitbucket:closePR', args)
 } satisfies PreloadApi['bitbucket']

--- a/src/preload/api/bitbucket-bridge.ts
+++ b/src/preload/api/bitbucket-bridge.ts
@@ -17,5 +17,11 @@ export const bitbucketApi = {
 
   mergePR: (args) => ipcRenderer.invoke('bitbucket:mergePR', args),
 
-  closePR: (args) => ipcRenderer.invoke('bitbucket:closePR', args)
+  closePR: (args) => ipcRenderer.invoke('bitbucket:closePR', args),
+
+  getPRComments: (args) => ipcRenderer.invoke('bitbucket:getPRComments', args),
+
+  addPRComment: (args) => ipcRenderer.invoke('bitbucket:addPRComment', args),
+
+  replyPRComment: (args) => ipcRenderer.invoke('bitbucket:replyPRComment', args)
 } satisfies PreloadApi['bitbucket']

--- a/src/preload/api/hosted-review-api.ts
+++ b/src/preload/api/hosted-review-api.ts
@@ -54,6 +54,7 @@ export type BitbucketApi = {
     prNumber: number
     body: string
     parentId?: number
+    rootCommentId?: number
     inline?: { path: string; line: number }
     executionHostId?: ExecutionHostId
   }) => Promise<{ ok: true; comment: PRComment } | { ok: false; error: string }>
@@ -62,6 +63,7 @@ export type BitbucketApi = {
     prNumber: number
     parentId: number
     body: string
+    rootCommentId?: number
     executionHostId?: ExecutionHostId
   }) => Promise<{ ok: true; comment: PRComment } | { ok: false; error: string }>
 }

--- a/src/preload/api/hosted-review-api.ts
+++ b/src/preload/api/hosted-review-api.ts
@@ -24,6 +24,8 @@ export type HostedReviewApi = {
   createStacked: (args: CreateStackedHostedReviewArgs) => Promise<CreateStackedHostedReviewResult>
 }
 
+import type { PRComment } from '../../shared/github/comment-types'
+
 export type BitbucketApi = {
   connect: (
     args: BitbucketConnectArgs
@@ -42,4 +44,24 @@ export type BitbucketApi = {
     prNumber: number
     executionHostId?: ExecutionHostId
   }) => Promise<{ ok: true } | { ok: false; error: string }>
+  getPRComments: (args: {
+    repoPath: string
+    prNumber: number
+    executionHostId?: ExecutionHostId
+  }) => Promise<PRComment[]>
+  addPRComment: (args: {
+    repoPath: string
+    prNumber: number
+    body: string
+    parentId?: number
+    inline?: { path: string; line: number }
+    executionHostId?: ExecutionHostId
+  }) => Promise<{ ok: true; comment: PRComment } | { ok: false; error: string }>
+  replyPRComment: (args: {
+    repoPath: string
+    prNumber: number
+    parentId: number
+    body: string
+    executionHostId?: ExecutionHostId
+  }) => Promise<{ ok: true; comment: PRComment } | { ok: false; error: string }>
 }

--- a/src/preload/api/hosted-review-api.ts
+++ b/src/preload/api/hosted-review-api.ts
@@ -2,6 +2,8 @@ import type {
   BitbucketConnectArgs,
   BitbucketConnectionStatus
 } from '../../shared/bitbucket-credentials'
+import type { BitbucketPRMergeMethod } from '../../shared/bitbucket-merge-methods'
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type {
   CreateHostedReviewArgs,
   CreateHostedReviewResult,
@@ -28,4 +30,16 @@ export type BitbucketApi = {
   ) => Promise<{ ok: true; account: string | null } | { ok: false; error: string }>
   disconnect: () => Promise<void>
   status: () => Promise<BitbucketConnectionStatus>
+  mergePR: (args: {
+    repoPath: string
+    prNumber: number
+    method?: BitbucketPRMergeMethod
+    closeSourceBranch?: boolean
+    executionHostId?: ExecutionHostId
+  }) => Promise<{ ok: true } | { ok: false; error: string }>
+  closePR: (args: {
+    repoPath: string
+    prNumber: number
+    executionHostId?: ExecutionHostId
+  }) => Promise<{ ok: true } | { ok: false; error: string }>
 }

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
@@ -154,6 +154,6 @@ describe('ChecksPanelReviewHeader', () => {
     expect(markup).toContain(
       'Orca will hide PR #12 details for this workspace. The PR and branch on Bitbucket won’t be changed.'
     )
-    expect(markup).toContain('Link another PR')
+    expect(markup).not.toContain('Link another PR')
   })
 })

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.review-header.test.tsx
@@ -40,20 +40,27 @@ function renderHeader({
   modifierHintDestination = 'system-browser'
 }: {
   canUnlinkReview?: boolean
-  provider?: 'github' | 'gitlab'
+  provider?: 'github' | 'gitlab' | 'bitbucket'
   modifierHintDestination?: ChecksPanelHostedReviewModifierDestination
 } = {}): string {
   const isGitLab = provider === 'gitlab'
+  const isBitbucket = provider === 'bitbucket'
   return renderToStaticMarkup(
     <ChecksPanelReviewHeader
       review={{
         provider,
-        number: isGitLab ? 31 : 2964,
-        title: isGitLab ? 'Fix GitLab MR creation' : 'fix: pr-bug-scan validated finding',
+        number: isGitLab ? 31 : isBitbucket ? 12 : 2964,
+        title: isGitLab
+          ? 'Fix GitLab MR creation'
+          : isBitbucket
+            ? 'Fix Bitbucket PR'
+            : 'fix: pr-bug-scan validated finding',
         state: 'open',
         url: isGitLab
           ? 'https://gitlab.com/acme/orca/-/merge_requests/31'
-          : 'https://github.com/stablyai/orca/pull/2964',
+          : isBitbucket
+            ? 'https://bitbucket.org/acme/orca/pull-requests/12'
+            : 'https://github.com/stablyai/orca/pull/2964',
         status: 'pending',
         updatedAt: '2026-05-31T22:58:01Z',
         mergeable: 'UNKNOWN'
@@ -135,5 +142,18 @@ describe('ChecksPanelReviewHeader', () => {
       'Orca will hide MR !31 details for this workspace. The MR and branch on GitLab won’t be changed.'
     )
     expect(markup).toContain('Link another MR')
+  })
+
+  it('shows Bitbucket PR identity with provider-appropriate link management actions', () => {
+    const markup = renderHeader({ provider: 'bitbucket' })
+
+    expect(markup).toContain('Open on Bitbucket')
+    expect(markup).toContain('#12')
+    expect(markup).toContain('More PR actions')
+    expect(markup).toContain('Unlink PR from workspace')
+    expect(markup).toContain(
+      'Orca will hide PR #12 details for this workspace. The PR and branch on Bitbucket won’t be changed.'
+    )
+    expect(markup).toContain('Link another PR')
   })
 })

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -134,18 +134,20 @@ export function ChecksPanelReviewHeader({
             disabled={!canUnlinkReview}
             onSelect={onUnlinkReview}
           />
-          <DropdownMenuItem onSelect={onLinkAnotherReview}>
-            <Link className="size-3.5" />
-            {review.provider === 'gitlab'
-              ? translate(
-                  'auto.components.right.sidebar.ChecksPanel.gitlabLinkAnother',
-                  'Link another MR'
-                )
-              : translate(
-                  'auto.components.right.sidebar.ChecksPanel.07871c0589',
-                  'Link another PR'
-                )}
-          </DropdownMenuItem>
+          {review.provider !== 'bitbucket' && (
+            <DropdownMenuItem onSelect={onLinkAnotherReview}>
+              <Link className="size-3.5" />
+              {review.provider === 'gitlab'
+                ? translate(
+                    'auto.components.right.sidebar.ChecksPanel.gitlabLinkAnother',
+                    'Link another MR'
+                  )
+                : translate(
+                    'auto.components.right.sidebar.ChecksPanel.07871c0589',
+                    'Link another PR'
+                  )}
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/ChecksPanel.tsx
@@ -62,7 +62,12 @@ export function ChecksPanelReviewHeader({
 }: ChecksPanelReviewHeaderProps): React.JSX.Element {
   const reviewNumberLabel = review.provider === 'gitlab' ? `!${review.number}` : `#${review.number}`
   const ReviewIcon = review.provider === 'gitlab' ? GitMerge : PullRequestIcon
-  const reviewHostLabel = review.provider === 'gitlab' ? 'GitLab' : 'GitHub'
+  const reviewHostLabel =
+    review.provider === 'gitlab'
+      ? 'GitLab'
+      : review.provider === 'bitbucket'
+        ? 'Bitbucket'
+        : 'GitHub'
   const moreActionsLabel =
     review.provider === 'gitlab'
       ? translate('auto.components.right.sidebar.ChecksPanel.gitlabMoreActions', 'More MR actions')

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.bitbucket.test.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.bitbucket.test.tsx
@@ -54,26 +54,6 @@ describe('HostedReviewActions Bitbucket integration', () => {
     expect(html).toContain('Close')
   })
 
-  it('renders merge blocked when Bitbucket PR has conflicts', () => {
-    const html = renderToStaticMarkup(
-      <HostedReviewActions
-        review={{
-          provider: 'bitbucket',
-          number: 42,
-          state: 'open',
-          status: 'failure',
-          mergeable: 'CONFLICTING'
-        }}
-        repo={repo}
-        worktree={worktree}
-        onRefreshReview={vi.fn().mockResolvedValue(undefined)}
-      />
-    )
-
-    expect(html).toContain('Merge blocked')
-    expect(html).toContain('merge conflicts')
-  })
-
   it('renders delete workspace button for closed/declined Bitbucket PR', () => {
     const html = renderToStaticMarkup(
       <HostedReviewActions

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.bitbucket.test.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.bitbucket.test.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import HostedReviewActions from './HostedReviewActions'
+
+vi.mock('@/store', () => ({ useAppStore: () => false }))
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => vi.fn()
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+const repo = { id: 'repo-1', path: '/repo' } as Repo
+const worktree = { id: 'worktree-1' } as Worktree
+
+describe('HostedReviewActions Bitbucket integration', () => {
+  it('renders merge button and split options for open Bitbucket PR', () => {
+    const html = renderToStaticMarkup(
+      <HostedReviewActions
+        review={{
+          provider: 'bitbucket',
+          number: 42,
+          state: 'open',
+          status: 'success',
+          mergeable: 'UNKNOWN'
+        }}
+        repo={repo}
+        worktree={worktree}
+        onRefreshReview={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    // Primary button should show default merge label
+    expect(html).toContain('Create merge commit')
+    // Dropdown should contain all Bitbucket merge methods
+    expect(html).toContain('Squash and merge')
+    expect(html).toContain('Fast-forward merge')
+    // Dropdown should contain Close PR
+    expect(html).toContain('Close')
+  })
+
+  it('renders merge blocked when Bitbucket PR has conflicts', () => {
+    const html = renderToStaticMarkup(
+      <HostedReviewActions
+        review={{
+          provider: 'bitbucket',
+          number: 42,
+          state: 'open',
+          status: 'failure',
+          mergeable: 'CONFLICTING'
+        }}
+        repo={repo}
+        worktree={worktree}
+        onRefreshReview={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    expect(html).toContain('Merge blocked')
+    expect(html).toContain('merge conflicts')
+  })
+
+  it('renders delete workspace button for closed/declined Bitbucket PR', () => {
+    const html = renderToStaticMarkup(
+      <HostedReviewActions
+        review={{
+          provider: 'bitbucket',
+          number: 42,
+          state: 'closed',
+          status: 'neutral',
+          mergeable: 'UNKNOWN'
+        }}
+        repo={repo}
+        worktree={worktree}
+        onRefreshReview={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+
+    expect(html).toContain('Delete Workspace')
+    expect(html).not.toContain('Reopen')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -15,10 +15,13 @@ import { presentGitHubPRMergeState } from '@/components/github-pr-merge-state'
 import type { PRInfo } from '../../../../shared/github/pull-request-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { resolveGitHubPRMergeMethods } from '../../../../shared/github/pull-request-merge-methods'
 import { runWorktreeDelete } from '../sidebar/delete-worktree-flow'
 import { getDeleteStateForWorktreeHost } from '../sidebar/worktree-delete-state-host-match'
 import { presentGitLabMRMergeState } from './gitlab-mr-merge-state'
+import { presentBitbucketPRMergeState } from './bitbucket-pr-merge-state'
+import { resolveBitbucketPRMergeMethods } from '../../../../shared/bitbucket-merge-methods'
 import {
   ClosedReviewActions,
   DraftReviewActions,
@@ -55,6 +58,7 @@ export default function HostedReviewActions({
     (s) => getDeleteStateForWorktreeHost(worktree, s.deleteStateByWorktreeId)?.isDeleting ?? false
   )
   const isGitLab = review.provider === 'gitlab'
+  const isBitbucket = review.provider === 'bitbucket'
   const shortLabel = isGitLab ? 'MR' : 'PR'
   const reviewLabel = isGitLab ? 'merge request' : 'pull request'
   const stackMergeScope = useMemo(
@@ -82,6 +86,9 @@ export default function HostedReviewActions({
   const mergePresentation = useMemo(() => {
     if (isGitLab) {
       return { ...presentGitLabMRMergeState(review), autoMergeAction: null }
+    }
+    if (isBitbucket) {
+      return { ...presentBitbucketPRMergeState(review), autoMergeAction: null }
     }
     const presentation = presentGitHubPRMergeState({
       ...githubPR,
@@ -117,11 +124,24 @@ export default function HostedReviewActions({
         (stackMergeScope.complete || presentation.directMergeAvailable || stackUsesMergeQueue),
       autoMergeAction: null
     }
-  }, [githubPR, isGitLab, review, stackMergeLabel, stackMergeScope, stackUsesMergeQueue])
-  const mergeMethods = useMemo(
-    () => resolveGitHubPRMergeMethods(isGitLab ? null : (githubPR?.mergeMethodSettings ?? null)),
-    [githubPR?.mergeMethodSettings, isGitLab]
-  )
+  }, [
+    githubPR,
+    isBitbucket,
+    isGitLab,
+    review,
+    stackMergeLabel,
+    stackMergeScope,
+    stackUsesMergeQueue
+  ])
+  const mergeMethods = useMemo(() => {
+    if (isGitLab) {
+      return resolveGitHubPRMergeMethods(null)
+    }
+    if (isBitbucket) {
+      return resolveBitbucketPRMergeMethods()
+    }
+    return resolveGitHubPRMergeMethods(githubPR?.mergeMethodSettings ?? null)
+  }, [githubPR?.mergeMethodSettings, isBitbucket, isGitLab])
   const {
     merging,
     readying,
@@ -136,7 +156,9 @@ export default function HostedReviewActions({
     review,
     githubPR,
     repo,
+    executionHostId: (worktree.hostId ?? repo.executionHostId ?? 'local') as ExecutionHostId,
     isGitLab,
+    isBitbucket,
     shortLabel,
     reviewLabel,
     defaultMergeMethod: mergeMethods.defaultMethod,
@@ -313,6 +335,14 @@ export default function HostedReviewActions({
   }
 
   if (review.state === 'closed') {
+    if (isBitbucket) {
+      return (
+        <MergedReviewActions
+          isDeletingWorktree={isDeletingWorktree}
+          onDeleteWorktree={handleDeleteWorktree}
+        />
+      )
+    }
     return (
       <ClosedReviewActions
         shortLabel={shortLabel}

--- a/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { presentBitbucketPRMergeState } from './bitbucket-pr-merge-state'
+
+describe('presentBitbucketPRMergeState', () => {
+  it('returns directMergeAvailable true for open review', () => {
+    const state = presentBitbucketPRMergeState({
+      state: 'open',
+      status: 'success',
+      mergeable: 'UNKNOWN'
+    })
+    expect(state.directMergeAvailable).toBe(true)
+    expect(state.label).toBe('Merge pull request')
+  })
+
+  it('blocks merge for conflicting review', () => {
+    const state = presentBitbucketPRMergeState({
+      state: 'open',
+      status: 'success',
+      mergeable: 'CONFLICTING'
+    })
+    expect(state.directMergeAvailable).toBe(false)
+    expect(state.label).toBe('Merge blocked')
+    expect(state.tooltip).toContain('merge conflicts')
+  })
+
+  it('handles closed review', () => {
+    const state = presentBitbucketPRMergeState({
+      state: 'closed',
+      status: 'neutral',
+      mergeable: 'UNKNOWN'
+    })
+    expect(state.directMergeAvailable).toBe(false)
+    expect(state.label).toBe('Declined')
+  })
+
+  it('handles merged review', () => {
+    const state = presentBitbucketPRMergeState({
+      state: 'merged',
+      status: 'success',
+      mergeable: 'UNKNOWN'
+    })
+    expect(state.directMergeAvailable).toBe(false)
+    expect(state.label).toBe('Merged')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.test.ts
@@ -12,17 +12,6 @@ describe('presentBitbucketPRMergeState', () => {
     expect(state.label).toBe('Merge pull request')
   })
 
-  it('blocks merge for conflicting review', () => {
-    const state = presentBitbucketPRMergeState({
-      state: 'open',
-      status: 'success',
-      mergeable: 'CONFLICTING'
-    })
-    expect(state.directMergeAvailable).toBe(false)
-    expect(state.label).toBe('Merge blocked')
-    expect(state.tooltip).toContain('merge conflicts')
-  })
-
   it('handles closed review', () => {
     const state = presentBitbucketPRMergeState({
       state: 'closed',

--- a/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.ts
+++ b/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.ts
@@ -34,20 +34,6 @@ export function presentBitbucketPRMergeState(
     }
   }
 
-  if (review.mergeable === 'CONFLICTING') {
-    return {
-      label: translate(
-        'auto.components.right.sidebar.bitbucket.pr.merge.state.conflicts',
-        'Merge blocked'
-      ),
-      tooltip: translate(
-        'auto.components.right.sidebar.bitbucket.pr.merge.state.conflictsTooltip',
-        'Bitbucket reports merge conflicts that must be resolved before merging'
-      ),
-      directMergeAvailable: false
-    }
-  }
-
   return {
     label: translate(
       'auto.components.right.sidebar.bitbucket.pr.merge.state.merge',

--- a/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.ts
+++ b/src/renderer/src/components/right-sidebar/bitbucket-pr-merge-state.ts
@@ -1,0 +1,59 @@
+import type { HostedReviewInfo } from '../../../../shared/hosted-review'
+import { translate } from '@/i18n/i18n'
+
+type BitbucketPRMergeStateReview = Pick<HostedReviewInfo, 'state' | 'status' | 'mergeable'>
+
+type MergePresentation = {
+  label: string
+  tooltip: string
+  directMergeAvailable: boolean
+}
+
+export function presentBitbucketPRMergeState(
+  review: BitbucketPRMergeStateReview
+): MergePresentation {
+  if (review.state === 'closed') {
+    return {
+      label: translate('auto.components.right.sidebar.bitbucket.pr.merge.state.closed', 'Declined'),
+      tooltip: translate(
+        'auto.components.right.sidebar.bitbucket.pr.merge.state.closedTooltip',
+        'This pull request is declined'
+      ),
+      directMergeAvailable: false
+    }
+  }
+
+  if (review.state === 'merged') {
+    return {
+      label: translate('auto.components.right.sidebar.bitbucket.pr.merge.state.merged', 'Merged'),
+      tooltip: translate(
+        'auto.components.right.sidebar.bitbucket.pr.merge.state.mergedTooltip',
+        'This pull request is already merged'
+      ),
+      directMergeAvailable: false
+    }
+  }
+
+  if (review.mergeable === 'CONFLICTING') {
+    return {
+      label: translate(
+        'auto.components.right.sidebar.bitbucket.pr.merge.state.conflicts',
+        'Merge blocked'
+      ),
+      tooltip: translate(
+        'auto.components.right.sidebar.bitbucket.pr.merge.state.conflictsTooltip',
+        'Bitbucket reports merge conflicts that must be resolved before merging'
+      ),
+      directMergeAvailable: false
+    }
+  }
+
+  return {
+    label: translate(
+      'auto.components.right.sidebar.bitbucket.pr.merge.state.merge',
+      'Merge pull request'
+    ),
+    tooltip: '',
+    directMergeAvailable: true
+  }
+}

--- a/src/renderer/src/components/right-sidebar/checks-panel-pr-refresh-breadcrumb.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-pr-refresh-breadcrumb.ts
@@ -9,7 +9,7 @@ import type {
 } from '../../../../shared/crash-reporting'
 
 type ChecksPanelPRRefreshBreadcrumbEvent = 'start' | 'done' | 'stale_cleared'
-type ChecksPanelReviewProvider = 'github' | 'gitlab'
+type ChecksPanelReviewProvider = 'github' | 'gitlab' | 'bitbucket'
 
 type ChecksPanelPRRefreshBreadcrumbArgs = {
   event: ChecksPanelPRRefreshBreadcrumbEvent

--- a/src/renderer/src/components/right-sidebar/checks-panel-review.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-review.test.ts
@@ -30,6 +30,20 @@ function makeGitLabReview(overrides: Partial<HostedReviewInfo> = {}): HostedRevi
   }
 }
 
+function makeBitbucketReview(overrides: Partial<HostedReviewInfo> = {}): HostedReviewInfo {
+  return {
+    provider: 'bitbucket',
+    number: 15,
+    title: 'Bitbucket PR',
+    state: 'open',
+    url: 'https://bitbucket.org/acme/widgets/pull-requests/15',
+    status: 'pending',
+    updatedAt: '2026-06-02T00:00:00Z',
+    mergeable: 'UNKNOWN',
+    ...overrides
+  }
+}
+
 describe('gitHubPRToChecksPanelReview', () => {
   // Why: the right-sidebar merge presenter reads these fields off the converted
   // review object. PR #4001 dropped them here, so review-required/merge-queue
@@ -73,6 +87,23 @@ describe('selectChecksPanelReview', () => {
         suppressedGitHubPR: null,
         linkedGitLabMR: 34,
         linkedBitbucketPR: null,
+        linkedAzureDevOpsPR: null,
+        linkedGiteaPR: null
+      })
+    ).toBe(review)
+  })
+
+  it('uses Bitbucket hosted review metadata ahead of GitHub PR cache', () => {
+    const review = makeBitbucketReview({ number: 56 })
+
+    expect(
+      selectChecksPanelReview({
+        hostedReview: review,
+        pr: makePR({ number: 12 }),
+        linkedPR: null,
+        suppressedGitHubPR: null,
+        linkedGitLabMR: null,
+        linkedBitbucketPR: 56,
         linkedAzureDevOpsPR: null,
         linkedGiteaPR: null
       })

--- a/src/renderer/src/components/right-sidebar/checks-panel-review.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-review.ts
@@ -32,9 +32,12 @@ export function selectChecksPanelReview({
   linkedAzureDevOpsPR,
   linkedGiteaPR
 }: ChecksPanelReviewSelectionInput): ChecksPanelReview | null {
-  const gitLabHostedReview = hostedReview?.provider === 'gitlab' ? hostedReview : null
-  if (gitLabHostedReview) {
-    return gitLabHostedReview
+  const supportedHostedReview =
+    hostedReview?.provider === 'gitlab' || hostedReview?.provider === 'bitbucket'
+      ? hostedReview
+      : null
+  if (supportedHostedReview) {
+    return supportedHostedReview
   }
   const hasNonGitHubLinkedReview =
     linkedGitLabMR !== null ||

--- a/src/renderer/src/components/right-sidebar/checks-panel/active-content-props.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel/active-content-props.ts
@@ -47,6 +47,7 @@ export type ChecksPanelActiveContentModel = Pick<
     | 'activeGitLabReview'
     | 'activeReview'
     | 'linkedGitLabMR'
+    | 'linkedBitbucketPR'
     | 'pr'
     | 'prRefreshState'
     | 'setChecksPanelContentRef'

--- a/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
@@ -264,28 +264,26 @@ export function ChecksPanelActiveContent({
             getGitLabProjectRef={getGitLabProjectRef}
           />
         )}
-      {activeReview.provider !== 'bitbucket' && (
-        <PRCommentsList
-          comments={comments}
-          commentsLoading={commentsLoading}
-          reviewKind={reviewShortLabel}
-          commentsDisabled={!canTargetPRComments}
-          commentsDisabledReason={commentsDisabledReason}
-          selectionContextKey={stateRequestKey}
-          selectionClearRequest={commentsSelectionClearRequest}
-          resolveCommentsWithAIDisabled={Boolean(resolveCommentsWithAIDisabledReason)}
-          resolveCommentsWithAIDisabledReason={resolveCommentsWithAIDisabledReason}
-          onAddComment={pr ? handleAddPRComment : undefined}
-          onResolveSelectedCommentsWithAI={
-            sourceControlAiActionsVisible ? handleResolveCommentsWithAI : undefined
-          }
-          onReply={pr ? handleReplyToComment : undefined}
-          onResolve={pr || activeGitLabReview ? handleResolve : undefined}
-          onEditComment={pr ? handleEditComment : undefined}
-          onDeleteComment={pr ? handleDeleteComment : undefined}
-          onSetReaction={canTargetPRComments ? handleSetReaction : undefined}
-        />
-      )}
+      <PRCommentsList
+        comments={comments}
+        commentsLoading={commentsLoading}
+        reviewKind={reviewShortLabel}
+        commentsDisabled={!canTargetPRComments}
+        commentsDisabledReason={commentsDisabledReason}
+        selectionContextKey={stateRequestKey}
+        selectionClearRequest={commentsSelectionClearRequest}
+        resolveCommentsWithAIDisabled={Boolean(resolveCommentsWithAIDisabledReason)}
+        resolveCommentsWithAIDisabledReason={resolveCommentsWithAIDisabledReason}
+        onAddComment={pr || activeReview.provider === 'bitbucket' ? handleAddPRComment : undefined}
+        onResolveSelectedCommentsWithAI={
+          sourceControlAiActionsVisible ? handleResolveCommentsWithAI : undefined
+        }
+        onReply={pr || activeReview.provider === 'bitbucket' ? handleReplyToComment : undefined}
+        onResolve={pr || activeGitLabReview ? handleResolve : undefined}
+        onEditComment={pr ? handleEditComment : undefined}
+        onDeleteComment={pr ? handleDeleteComment : undefined}
+        onSetReaction={canTargetPRComments ? handleSetReaction : undefined}
+      />
       <SourceControlAgentActionDialog
         open={sourceControlAiActionsVisible && agentComposerState !== null}
         onOpenChange={(open) => {

--- a/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
@@ -87,6 +87,7 @@ export function ChecksPanelActiveContent({
     isRefreshing,
     isResolvingConflictsWithAI,
     linkedGitLabMR,
+    linkedBitbucketPR,
     pendingCommentResolutionRef,
     pr,
     prRefreshState,
@@ -131,7 +132,15 @@ export function ChecksPanelActiveContent({
         <ReviewHeaderComponent
           review={activeReview}
           isRefreshing={isRefreshing}
-          canUnlinkReview={activeReview.provider === 'github' ? true : linkedGitLabMR !== null}
+          canUnlinkReview={
+            activeReview.provider === 'github'
+              ? true
+              : activeReview.provider === 'gitlab'
+                ? linkedGitLabMR !== null
+                : activeReview.provider === 'bitbucket'
+                  ? linkedBitbucketPR !== null
+                  : false
+          }
           modifierHintDestination={hostedReviewModifierHintDestination}
           onRefresh={() => void handleRefresh()}
           onOpenReview={handleOpenPR}
@@ -238,36 +247,39 @@ export function ChecksPanelActiveContent({
         </>
       )}
       {/* Why: with merge conflicts and no checks fetched, "No checks configured" is misleading — checks can't run until conflicts resolve. */}
-      {!(activeConflictReview && checks.length === 0 && !checksLoading) && (
-        <ChecksList
-          checks={checks}
-          checksLoading={checksLoading}
-          checkDetailsContextKey={stateRequestKey}
-          onLoadCheckDetails={handleLoadCheckDetails}
-          githubRepository={pr?.prRepo ?? null}
-          getGitLabProjectRef={getGitLabProjectRef}
+      {!(activeConflictReview && checks.length === 0 && !checksLoading) &&
+        (activeReview.provider !== 'bitbucket' || checks.length > 0) && (
+          <ChecksList
+            checks={checks}
+            checksLoading={checksLoading}
+            checkDetailsContextKey={stateRequestKey}
+            onLoadCheckDetails={handleLoadCheckDetails}
+            githubRepository={pr?.prRepo ?? null}
+            getGitLabProjectRef={getGitLabProjectRef}
+          />
+        )}
+      {activeReview.provider !== 'bitbucket' && (
+        <PRCommentsList
+          comments={comments}
+          commentsLoading={commentsLoading}
+          reviewKind={reviewShortLabel}
+          commentsDisabled={!canTargetPRComments}
+          commentsDisabledReason={commentsDisabledReason}
+          selectionContextKey={stateRequestKey}
+          selectionClearRequest={commentsSelectionClearRequest}
+          resolveCommentsWithAIDisabled={Boolean(resolveCommentsWithAIDisabledReason)}
+          resolveCommentsWithAIDisabledReason={resolveCommentsWithAIDisabledReason}
+          onAddComment={pr ? handleAddPRComment : undefined}
+          onResolveSelectedCommentsWithAI={
+            sourceControlAiActionsVisible ? handleResolveCommentsWithAI : undefined
+          }
+          onReply={pr ? handleReplyToComment : undefined}
+          onResolve={pr || activeGitLabReview ? handleResolve : undefined}
+          onEditComment={pr ? handleEditComment : undefined}
+          onDeleteComment={pr ? handleDeleteComment : undefined}
+          onSetReaction={canTargetPRComments ? handleSetReaction : undefined}
         />
       )}
-      <PRCommentsList
-        comments={comments}
-        commentsLoading={commentsLoading}
-        reviewKind={reviewShortLabel}
-        commentsDisabled={!canTargetPRComments}
-        commentsDisabledReason={commentsDisabledReason}
-        selectionContextKey={stateRequestKey}
-        selectionClearRequest={commentsSelectionClearRequest}
-        resolveCommentsWithAIDisabled={Boolean(resolveCommentsWithAIDisabledReason)}
-        resolveCommentsWithAIDisabledReason={resolveCommentsWithAIDisabledReason}
-        onAddComment={pr ? handleAddPRComment : undefined}
-        onResolveSelectedCommentsWithAI={
-          sourceControlAiActionsVisible ? handleResolveCommentsWithAI : undefined
-        }
-        onReply={pr ? handleReplyToComment : undefined}
-        onResolve={pr || activeGitLabReview ? handleResolve : undefined}
-        onEditComment={pr ? handleEditComment : undefined}
-        onDeleteComment={pr ? handleDeleteComment : undefined}
-        onSetReaction={canTargetPRComments ? handleSetReaction : undefined}
-      />
       <SourceControlAgentActionDialog
         open={sourceControlAiActionsVisible && agentComposerState !== null}
         onOpenChange={(open) => {

--- a/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx
@@ -159,7 +159,13 @@ export function ChecksPanelActiveContent({
         ) : null}
 
         {/* Review title */}
-        {editingTitle ? (
+        {activeReview.provider === 'bitbucket' ? (
+          <div className="flex items-start gap-1.5 -mx-1 px-1 py-0.5">
+            <span className="text-[12px] text-foreground leading-snug flex-1">
+              {activeReview.title}
+            </span>
+          </div>
+        ) : editingTitle ? (
           <div className="flex items-center gap-1">
             <input
               ref={titleInputRef}

--- a/src/renderer/src/components/right-sidebar/checks-panel/checks-panel-pre-refresh-git-identity.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel/checks-panel-pre-refresh-git-identity.ts
@@ -1,0 +1,109 @@
+import type { MutableRefObject } from 'react'
+import { getRuntimeGitStatus, getRuntimeGitUpstreamStatus } from '@/runtime/runtime-git-client'
+import type { GitPushTarget } from '../../../../../shared/worktree/types'
+import type { ChecksPanelGitStatusSnapshot } from '../checks-panel-git-status-snapshot'
+import {
+  hasChecksPanelGitStatusBranchChanged,
+  readChecksPanelRefreshGitIdentitySnapshot,
+  shouldCommitChecksPanelGitStatusSnapshot
+} from '../checks-panel-git-status-snapshot'
+import type { ChecksPanelManualRefreshInput } from './manual-refresh-dependencies'
+
+export type ChecksPanelPreRefreshGitIdentityInput = {
+  activeConnectionId?: string | null
+  activeWorktreeId: string
+  activeWorktreePath: string
+  activeWorktreePushTarget?: GitPushTarget | null
+  branch: string
+  gitStatusSnapshot: ChecksPanelGitStatusSnapshot | null
+  isCurrentRequest: () => boolean
+  ownerSettings?: ChecksPanelManualRefreshInput['ownerSettings']
+  panelContextKey: string
+  panelContextKeyRef: MutableRefObject<string>
+  setGitStatusSnapshot: ChecksPanelManualRefreshInput['setGitStatusSnapshot']
+  updateWorktreeGitIdentity: ChecksPanelManualRefreshInput['updateWorktreeGitIdentity']
+}
+
+export type ChecksPanelPreRefreshGitIdentityOutcome = 'continue' | 'branch-changed'
+
+export async function syncChecksPanelPreRefreshGitIdentity(
+  input: ChecksPanelPreRefreshGitIdentityInput
+): Promise<ChecksPanelPreRefreshGitIdentityOutcome> {
+  const {
+    activeConnectionId,
+    activeWorktreeId,
+    activeWorktreePath,
+    activeWorktreePushTarget,
+    branch,
+    gitStatusSnapshot,
+    isCurrentRequest,
+    ownerSettings,
+    panelContextKey,
+    panelContextKeyRef,
+    setGitStatusSnapshot,
+    updateWorktreeGitIdentity
+  } = input
+
+  const snapshotIdentity = readChecksPanelRefreshGitIdentitySnapshot({
+    snapshot: gitStatusSnapshot,
+    contextKey: panelContextKey,
+    currentBranch: branch
+  })
+  if (snapshotIdentity.kind === 'changed') {
+    updateWorktreeGitIdentity(activeWorktreeId, {
+      head: snapshotIdentity.head,
+      branch: snapshotIdentity.branch
+    })
+    // Why: this click discovered a terminal branch switch; let branch-keyed render/effects restart instead of refreshing old PR data.
+    return 'branch-changed'
+  }
+  try {
+    const statusContext = {
+      settings: ownerSettings,
+      worktreeId: activeWorktreeId,
+      worktreePath: activeWorktreePath,
+      connectionId: activeConnectionId ?? undefined
+    }
+    const status = await getRuntimeGitStatus(statusContext, {
+      admissionTier: 'interactive'
+    })
+    const observedBranch = status.branch ?? (status.head ? null : undefined)
+    updateWorktreeGitIdentity(activeWorktreeId, {
+      head: status.head,
+      branch: observedBranch
+    })
+    if (
+      observedBranch !== undefined &&
+      hasChecksPanelGitStatusBranchChanged({ observedBranch, currentBranch: branch })
+    ) {
+      // Why: this click discovered a terminal branch switch; let branch-keyed render/effects restart instead of refreshing old PR data.
+      return 'branch-changed'
+    }
+    let freshRemoteStatus = status.upstreamStatus
+    if (activeWorktreePushTarget) {
+      freshRemoteStatus = await getRuntimeGitUpstreamStatus(statusContext, activeWorktreePushTarget)
+    } else if (
+      !freshRemoteStatus ||
+      (freshRemoteStatus.ahead > 0 &&
+        freshRemoteStatus.behind > 0 &&
+        freshRemoteStatus.behindCommitsArePatchEquivalent === undefined)
+    ) {
+      freshRemoteStatus = await getRuntimeGitUpstreamStatus(statusContext)
+    }
+    if (
+      isCurrentRequest() &&
+      shouldCommitChecksPanelGitStatusSnapshot(panelContextKeyRef.current, panelContextKey)
+    ) {
+      // Why: the Refresh click already paid for this status read; commit it so empty-state Publish/Create eligibility is fresh.
+      setGitStatusSnapshot({
+        contextKey: panelContextKey,
+        hasUncommittedChanges: status.entries.length > 0,
+        remoteStatus: freshRemoteStatus,
+        gitIdentity: { head: status.head, branch: observedBranch }
+      })
+    }
+  } catch (error) {
+    console.warn('[ChecksPanel] pre-refresh git identity refresh failed', error)
+  }
+  return 'continue'
+}

--- a/src/renderer/src/components/right-sidebar/checks-panel/manual-refresh-dependencies.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel/manual-refresh-dependencies.ts
@@ -37,6 +37,7 @@ export type ChecksPanelManualRefreshInput = Pick<
   Pick<
     ChecksPanelContextState,
     | 'activeGitLabReview'
+    | 'activeReview'
     | 'fallbackGitHubPRNumber'
     | 'isFolder'
     | 'isGitLabReviewContext'

--- a/src/renderer/src/components/right-sidebar/checks-panel/manual-refresh-dependencies.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel/manual-refresh-dependencies.ts
@@ -50,5 +50,5 @@ export type ChecksPanelManualRefreshInput = Pick<
     | 'prCacheKey'
     | 'prNumber'
   > &
-  Pick<ChecksPanelPollingState, 'fetchGitLabDetails'> &
+  Pick<ChecksPanelPollingState, 'fetchBitbucketDetails' | 'fetchGitLabDetails'> &
   Pick<ChecksPanelComposerState, 'isCurrentAsyncResult'>

--- a/src/renderer/src/components/right-sidebar/checks-panel/panel-content-rendering.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/panel-content-rendering.test.tsx
@@ -155,6 +155,7 @@ describe('checks panel concrete content', () => {
       isRefreshing: false,
       isResolvingConflictsWithAI: false,
       linkedGitLabMR: null,
+      linkedBitbucketPR: null,
       pendingCommentResolutionRef: { current: null },
       pr: null,
       prRefreshState: undefined,
@@ -184,5 +185,92 @@ describe('checks panel concrete content', () => {
     expect(screen.getByRole('button', { name: '#42' }).getAttribute('title')).toContain(
       'Open on GitHub'
     )
+  })
+
+  it('omits checks and comments sections for Bitbucket reviews', () => {
+    const model = {
+      activeConnectionId: null,
+      activeConflictReview: null,
+      activeGitLabReview: null,
+      activeReview: {
+        provider: 'bitbucket',
+        number: 42,
+        state: 'open',
+        title: 'Bitbucket PR review',
+        url: 'https://bitbucket.org/ws/repo/pull-requests/42',
+        status: 'neutral',
+        updatedAt: '2026-08-23T00:00:00.000Z',
+        mergeable: 'UNKNOWN'
+      },
+      activeSourceControlLaunchPlatform: 'darwin',
+      activeWorktree: null,
+      activeWorktreeId: 'worktree-1',
+      agentComposerState: null,
+      aiActionDisabledReason: undefined,
+      canTargetPRComments: false,
+      checks: [],
+      checksLoading: false,
+      claimedCommentResolutionRef: { current: null },
+      commentResolutionLaunchAcceptedRef: { current: false },
+      comments: [],
+      commentsDisabledReason: undefined,
+      commentsLoading: false,
+      commentsSelectionClearRequest: null,
+      conflictDetailsRefreshing: false,
+      consumeClaimedCommentResolutionAfterDeliveryRef: { current: vi.fn() },
+      detachedHeadDisplay: null,
+      editingTitle: false,
+      getGitLabProjectRef: vi.fn(() => null),
+      handleAddPRComment: vi.fn(),
+      handleCancelEdit: vi.fn(),
+      handleDeleteComment: vi.fn(),
+      handleEditComment: vi.fn(),
+      handleFixChecksWithAI: vi.fn(),
+      handleLaunchAborted: vi.fn(),
+      handleLaunchAccepted: vi.fn(),
+      handleLinkAnotherReview: vi.fn(),
+      handleLoadCheckDetails: vi.fn(),
+      handleOpenPR: vi.fn(),
+      handleRefresh: vi.fn(),
+      handleOpenStackPR: vi.fn(),
+      handleReplyToComment: vi.fn(),
+      handleResolve: vi.fn(),
+      handleResolveCommentsWithAI: vi.fn(),
+      handleResolveConflictsWithAI: vi.fn(),
+      handleSaveTitle: vi.fn(),
+      handleSetReaction: vi.fn(),
+      handleStartEdit: vi.fn(),
+      handleTitleKeyDown: vi.fn(),
+      handleUnlinkReview: vi.fn(),
+      isFixingChecksWithAI: false,
+      isRefreshing: false,
+      isResolvingConflictsWithAI: false,
+      linkedGitLabMR: null,
+      linkedBitbucketPR: null,
+      pendingCommentResolutionRef: { current: null },
+      pr: null,
+      prRefreshState: undefined,
+      repo: null,
+      refreshHostedReviewAfterMutation: vi.fn(),
+      resolveCommentsWithAIDisabledReason: undefined,
+      saveLaunchActionDefault: vi.fn(),
+      setAgentComposerState: vi.fn(),
+      setChecksPanelContentRef: vi.fn(),
+      settings: null,
+      sourceControlAiActionsVisible: false,
+      stateRequestKey: 'review-42',
+      titleDraft: '',
+      setTitleDraft: vi.fn(),
+      titleInputRef: { current: null },
+      titleSaving: false
+    } satisfies ChecksPanelActiveContentModel
+
+    render(
+      <ChecksPanelActiveContent model={model} ReviewHeaderComponent={ChecksPanelReviewHeader} />
+    )
+
+    expect(screen.getByText('Bitbucket PR review')).toBeTruthy()
+    expect(screen.queryByText('No checks configured')).toBeNull()
+    expect(screen.queryByText('No comments')).toBeNull()
   })
 })

--- a/src/renderer/src/components/right-sidebar/checks-panel/panel-content-rendering.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/panel-content-rendering.test.tsx
@@ -4,6 +4,8 @@ import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ChecksPanelActiveContentModel } from './active-content-props'
 import type { ChecksPanelEmptyContentModel } from './empty-content-props'
+import type { PRComment } from '../../../../../shared/github/comment-types'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { ChecksPanelReviewHeader } from '../ChecksPanel'
 
 vi.mock('../HostedReviewActions', () => ({ default: () => null }))
@@ -175,7 +177,9 @@ describe('checks panel concrete content', () => {
     } satisfies ChecksPanelActiveContentModel
 
     render(
-      <ChecksPanelActiveContent model={model} ReviewHeaderComponent={ChecksPanelReviewHeader} />
+      <TooltipProvider>
+        <ChecksPanelActiveContent model={model} ReviewHeaderComponent={ChecksPanelReviewHeader} />
+      </TooltipProvider>
     )
 
     expect(screen.getByText('Preserve mounted panel behavior')).toBeTruthy()
@@ -187,8 +191,10 @@ describe('checks panel concrete content', () => {
     )
   })
 
-  it('omits checks and comments sections for Bitbucket reviews', () => {
-    const model = {
+  function createBitbucketActiveContentModel(
+    overrides: Partial<ChecksPanelActiveContentModel> = {}
+  ): ChecksPanelActiveContentModel {
+    return {
       activeConnectionId: null,
       activeConflictReview: null,
       activeGitLabReview: null,
@@ -262,15 +268,49 @@ describe('checks panel concrete content', () => {
       titleDraft: '',
       setTitleDraft: vi.fn(),
       titleInputRef: { current: null },
-      titleSaving: false
-    } satisfies ChecksPanelActiveContentModel
+      titleSaving: false,
+      ...overrides
+    }
+  }
+
+  it('omits checks section while rendering comments section for Bitbucket reviews', () => {
+    const model = createBitbucketActiveContentModel()
 
     render(
-      <ChecksPanelActiveContent model={model} ReviewHeaderComponent={ChecksPanelReviewHeader} />
+      <TooltipProvider>
+        <ChecksPanelActiveContent model={model} ReviewHeaderComponent={ChecksPanelReviewHeader} />
+      </TooltipProvider>
     )
 
     expect(screen.getByText('Bitbucket PR review')).toBeTruthy()
     expect(screen.queryByText('No checks configured')).toBeNull()
-    expect(screen.queryByText('No comments')).toBeNull()
+    expect(screen.getByText('Comments')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Start conversation' })).toBeTruthy()
+  })
+
+  it('renders comments for Bitbucket reviews', () => {
+    const bitbucketComment: PRComment = {
+      id: 1,
+      author: 'Aiden',
+      authorAvatarUrl: '',
+      body: 'Bitbucket comment body',
+      createdAt: '2026-08-23T00:00:00.000Z',
+      url: 'https://bitbucket.org/ws/repo/pull-requests/42#comment-1',
+      isResolved: false,
+      threadId: 'bb-comment-1'
+    }
+
+    const model = createBitbucketActiveContentModel({
+      canTargetPRComments: true,
+      comments: [bitbucketComment]
+    })
+
+    render(
+      <TooltipProvider>
+        <ChecksPanelActiveContent model={model} ReviewHeaderComponent={ChecksPanelReviewHeader} />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByText('Bitbucket comment body')).toBeTruthy()
   })
 })

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-comment-mutations.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-comment-mutations.tsx
@@ -58,9 +58,10 @@ export function useChecksPanelCommentMutations(model: ChecksPanelCommentMutation
         if (!repo || !activeReview.number) {
           return { ok: false as const, error: commentsDisabledReason ?? 'Commenting unavailable.' }
         }
+        const targetPrNumber = activeReview.number
         const result = await window.api.bitbucket.addPRComment({
           repoPath: repo.path,
-          prNumber: activeReview.number,
+          prNumber: targetPrNumber,
           body,
           executionHostId: activeWorktree?.hostId
         })
@@ -68,7 +69,9 @@ export function useChecksPanelCommentMutations(model: ChecksPanelCommentMutation
           toast.error(result.error)
           return result
         }
-        setComments((prev) => mergePRCommentIntoList(prev, result.comment))
+        if (activeReview?.provider === 'bitbucket' && activeReview.number === targetPrNumber) {
+          setComments((prev) => mergePRCommentIntoList(prev, result.comment))
+        }
         return { ok: true as const }
       }
       if (!repo || !prNumber || !pr?.prRepo) {
@@ -227,13 +230,18 @@ export function useChecksPanelCommentMutations(model: ChecksPanelCommentMutation
         if (!repo || !activeReview.number) {
           return { ok: false as const, error: commentsDisabledReason ?? 'Commenting unavailable.' }
         }
+        const targetPrNumber = activeReview.number
         const parentId = comment.id
+        const threadId = comment.threadId ?? String(parentId)
+        const rootCommentId = Number(threadId)
         const result = await window.api.bitbucket.replyPRComment({
           repoPath: repo.path,
-          prNumber: activeReview.number,
+          prNumber: targetPrNumber,
           parentId,
           body,
-          executionHostId: activeWorktree?.hostId
+          executionHostId: activeWorktree?.hostId,
+          rootCommentId:
+            Number.isInteger(rootCommentId) && rootCommentId > 0 ? rootCommentId : undefined
         })
         if (!result.ok) {
           if (notifyOnFailure) {
@@ -241,14 +249,15 @@ export function useChecksPanelCommentMutations(model: ChecksPanelCommentMutation
           }
           return result
         }
-        const threadId = comment.threadId ?? String(parentId)
-        const commentWithThread: PRComment = {
-          ...result.comment,
-          threadId,
-          path: result.comment.path ?? comment.path,
-          line: result.comment.line ?? comment.line
+        if (activeReview?.provider === 'bitbucket' && activeReview.number === targetPrNumber) {
+          const commentWithThread: PRComment = {
+            ...result.comment,
+            threadId,
+            path: result.comment.path ?? comment.path,
+            line: result.comment.line ?? comment.line
+          }
+          setComments((prev) => mergePRCommentIntoList(prev, commentWithThread))
         }
-        setComments((prev) => mergePRCommentIntoList(prev, commentWithThread))
         return { ok: true as const }
       }
       if (!repo || !prNumber || !pr?.prRepo) {

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-comment-mutations.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-comment-mutations.tsx
@@ -20,6 +20,7 @@ import { translate } from '@/i18n/i18n'
 
 type ChecksPanelCommentMutationsInput = Pick<
   ChecksPanelControllerState,
+  | 'activeWorktree'
   | 'addPRConversationComment'
   | 'addPRReviewCommentReply'
   | 'branch'
@@ -31,10 +32,12 @@ type ChecksPanelCommentMutationsInput = Pick<
 > &
   Pick<ChecksPanelCommentResolutionState, 'commentsDisabledReason'> &
   Pick<ChecksPanelComposerState, 'isCurrentAsyncResult'> &
-  Pick<ChecksPanelContextState, 'pr' | 'prCacheKey' | 'prNumber'>
+  Pick<ChecksPanelContextState, 'activeReview' | 'pr' | 'prCacheKey' | 'prNumber'>
 
 export function useChecksPanelCommentMutations(model: ChecksPanelCommentMutationsInput) {
   const {
+    activeReview,
+    activeWorktree,
     addPRConversationComment,
     addPRReviewCommentReply,
     branch,
@@ -51,6 +54,23 @@ export function useChecksPanelCommentMutations(model: ChecksPanelCommentMutation
   } = model
   const handleAddPRComment = useCallback(
     async (body: string) => {
+      if (activeReview?.provider === 'bitbucket') {
+        if (!repo || !activeReview.number) {
+          return { ok: false as const, error: commentsDisabledReason ?? 'Commenting unavailable.' }
+        }
+        const result = await window.api.bitbucket.addPRComment({
+          repoPath: repo.path,
+          prNumber: activeReview.number,
+          body,
+          executionHostId: activeWorktree?.hostId
+        })
+        if (!result.ok) {
+          toast.error(result.error)
+          return result
+        }
+        setComments((prev) => mergePRCommentIntoList(prev, result.comment))
+        return { ok: true as const }
+      }
       if (!repo || !prNumber || !pr?.prRepo) {
         return { ok: false as const, error: commentsDisabledReason ?? 'Commenting unavailable.' }
       }
@@ -76,6 +96,9 @@ export function useChecksPanelCommentMutations(model: ChecksPanelCommentMutation
       return { ok: true as const }
     },
     [
+      activeReview?.number,
+      activeReview?.provider,
+      activeWorktree?.hostId,
       addPRConversationComment,
       branch,
       commentsDisabledReason,
@@ -200,6 +223,34 @@ export function useChecksPanelCommentMutations(model: ChecksPanelCommentMutation
   const handleReplyToComment = useCallback(
     async (comment: PRComment, body: string, options: { notifyOnFailure?: boolean } = {}) => {
       const notifyOnFailure = options.notifyOnFailure !== false
+      if (activeReview?.provider === 'bitbucket') {
+        if (!repo || !activeReview.number) {
+          return { ok: false as const, error: commentsDisabledReason ?? 'Commenting unavailable.' }
+        }
+        const parentId = comment.id
+        const result = await window.api.bitbucket.replyPRComment({
+          repoPath: repo.path,
+          prNumber: activeReview.number,
+          parentId,
+          body,
+          executionHostId: activeWorktree?.hostId
+        })
+        if (!result.ok) {
+          if (notifyOnFailure) {
+            toast.error(result.error)
+          }
+          return result
+        }
+        const threadId = comment.threadId ?? String(parentId)
+        const commentWithThread: PRComment = {
+          ...result.comment,
+          threadId,
+          path: result.comment.path ?? comment.path,
+          line: result.comment.line ?? comment.line
+        }
+        setComments((prev) => mergePRCommentIntoList(prev, commentWithThread))
+        return { ok: true as const }
+      }
       if (!repo || !prNumber || !pr?.prRepo) {
         return { ok: false as const, error: commentsDisabledReason ?? 'Commenting unavailable.' }
       }
@@ -256,6 +307,9 @@ export function useChecksPanelCommentMutations(model: ChecksPanelCommentMutation
       return { ok: true as const }
     },
     [
+      activeReview?.number,
+      activeReview?.provider,
+      activeWorktree?.hostId,
       addPRConversationComment,
       addPRReviewCommentReply,
       branch,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-comment-resolution.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-comment-resolution.tsx
@@ -148,10 +148,15 @@ export function useChecksPanelCommentResolution(model: ChecksPanelCommentResolut
     ]
   )
 
-  const canTargetPRComments = Boolean(repo && prNumber && pr?.prRepo)
+  const canTargetPRComments =
+    activeReview?.provider === 'bitbucket'
+      ? Boolean(repo && activeReview.number)
+      : Boolean(repo && prNumber && pr?.prRepo)
   const commentsDisabledReason = canTargetPRComments
     ? undefined
-    : 'Commenting requires a GitHub PR repository target.'
+    : activeReview?.provider === 'bitbucket'
+      ? 'Commenting requires a Bitbucket pull request.'
+      : 'Commenting requires a GitHub PR repository target.'
   const detectedAgentsForAI =
     typeof activeConnectionId === 'string' ? remoteDetectedAgentIds : detectedAgentIds
   const noEnabledAgentKnown =
@@ -195,7 +200,9 @@ export function useChecksPanelCommentResolution(model: ChecksPanelCommentResolut
               ? 'Open a GitHub PR before resolving comments.'
               : activeReview.provider === 'gitlab' && !activeGitLabReview
                 ? 'Open a GitLab MR before resolving comments.'
-                : undefined
+                : activeReview.provider === 'bitbucket' && !activeReview.number
+                  ? 'Open a Bitbucket PR before resolving comments.'
+                  : undefined
   return {
     handleResolve,
     canTargetPRComments,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-comment-resolution.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-comment-resolution.tsx
@@ -155,7 +155,10 @@ export function useChecksPanelCommentResolution(model: ChecksPanelCommentResolut
   const commentsDisabledReason = canTargetPRComments
     ? undefined
     : activeReview?.provider === 'bitbucket'
-      ? 'Commenting requires a Bitbucket pull request.'
+      ? translate(
+          'auto.components.right.sidebar.ChecksPanel.bitbucketCommentsDisabled',
+          'Commenting requires a Bitbucket pull request.'
+        )
       : 'Commenting requires a GitHub PR repository target.'
   const detectedAgentsForAI =
     typeof activeConnectionId === 'string' ? remoteDetectedAgentIds : detectedAgentIds
@@ -200,8 +203,11 @@ export function useChecksPanelCommentResolution(model: ChecksPanelCommentResolut
               ? 'Open a GitHub PR before resolving comments.'
               : activeReview.provider === 'gitlab' && !activeGitLabReview
                 ? 'Open a GitLab MR before resolving comments.'
-                : activeReview.provider === 'bitbucket' && !activeReview.number
-                  ? 'Open a Bitbucket PR before resolving comments.'
+                : activeReview.provider === 'bitbucket'
+                  ? translate(
+                      'auto.components.right.sidebar.ChecksPanel.bitbucketResolveUnsupported',
+                      'Resolving comments with AI is not supported for Bitbucket.'
+                    )
                   : undefined
   return {
     handleResolve,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
@@ -273,7 +273,7 @@ export function useChecksPanelEntryRefreshAndTitleActions(
   ])
 
   const handleStartEdit = useCallback(() => {
-    if (!activeReview) {
+    if (!activeReview || activeReview.provider === 'bitbucket') {
       return
     }
     setTitleDraft(activeReview.title)

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
@@ -115,6 +115,9 @@ export function useChecksPanelEntryRefreshAndTitleActions(
         if (activeGitLabReview) {
           void fetchGitLabDetails()
         }
+        if (activeReview?.provider === 'bitbucket') {
+          void fetchComments({ force: true })
+        }
         return
       }
       enqueueGitHubPRRefresh(activeWorktreeId, 'active', 80)
@@ -127,6 +130,7 @@ export function useChecksPanelEntryRefreshAndTitleActions(
     },
     [
       activeGitLabReview,
+      activeReview?.provider,
       activeWorktree?.head,
       activeWorktreeId,
       branch,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-entry-refresh-and-title-actions.tsx
@@ -223,6 +223,20 @@ export function useChecksPanelEntryRefreshAndTitleActions(
       }
       return
     }
+    if (activeReview?.provider === 'bitbucket') {
+      await refreshHostedReviewCard(fetchHostedReviewForBranch, {
+        repoPath: repo.path,
+        repoId: repo.id,
+        branch,
+        linkedGitHubPR: linkedPR,
+        fallbackGitHubPR: fallbackGitHubPRNumber,
+        linkedGitLabMR,
+        linkedBitbucketPR,
+        linkedAzureDevOpsPR,
+        linkedGiteaPR
+      })
+      return
+    }
     const refreshedPR = await fetchPRForBranch(repo.path, branch, {
       force: true,
       repoId: repo.id,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.test.tsx
@@ -44,6 +44,7 @@ describe('useChecksPanelManualRefresh ordering', () => {
     const input: RefreshInput = {
       activeConnectionId: null,
       activeGitLabReview: null,
+      activeReview: null,
       activeWorktreeId: null,
       activeWorktreePath: null,
       activeWorktreePushTarget: null,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.test.tsx
@@ -52,6 +52,7 @@ describe('useChecksPanelManualRefresh ordering', () => {
       branch: 'main',
       expireGitHubPRRefreshState: vi.fn(),
       fallbackGitHubPRNumber: null,
+      fetchBitbucketDetails: vi.fn(),
       fetchGitLabDetails: vi.fn(),
       fetchHostedReviewForBranch: vi.fn(),
       fetchPRChecks: vi.fn(async () => {

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.tsx
@@ -18,6 +18,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
   const {
     activeConnectionId,
     activeGitLabReview,
+    activeReview,
     activeWorktreeId,
     activeWorktreePath,
     activeWorktreePushTarget,
@@ -82,18 +83,24 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
     const refreshProvider = isGitLabReviewContext ? 'gitlab' : 'github'
     let refreshOutcome = 'started'
     setIsRefreshing(true)
-    recordChecksPanelPRRefreshBreadcrumb({
-      event: 'start',
-      provider: refreshProvider,
-      repoId: repo.id,
-      worktreeId: activeWorktreeId,
-      branch,
-      prCacheKey,
-      prNumber: activeGitLabReview?.number ?? prNumber,
-      prState: activeGitLabReview?.state ?? pr?.state,
-      prChecksStatus: pr?.checksStatus,
-      refreshState: prCacheKey ? useAppStore.getState().prRefreshStates[prCacheKey] : null
-    })
+    const recordBreadcrumb = (event: 'start' | 'done', outcome?: string): void => {
+      recordChecksPanelPRRefreshBreadcrumb({
+        event,
+        provider: refreshProvider,
+        repoId: repo.id,
+        worktreeId: activeWorktreeId,
+        branch,
+        prCacheKey,
+        prNumber: activeGitLabReview?.number ?? prNumber,
+        prState: activeGitLabReview?.state ?? pr?.state,
+        prChecksStatus: pr?.checksStatus,
+        refreshState: prCacheKey ? useAppStore.getState().prRefreshStates[prCacheKey] : null,
+        outcome,
+        durationMs: event === 'done' ? Date.now() - refreshStartedAt : undefined,
+        currentRequest: isCurrentRequest()
+      })
+    }
+    recordBreadcrumb('start')
     try {
       if (activeWorktreeId && activeWorktreePath && !isFolder) {
         const snapshotIdentity = readChecksPanelRefreshGitIdentitySnapshot({
@@ -127,10 +134,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
           })
           if (
             observedBranch !== undefined &&
-            hasChecksPanelGitStatusBranchChanged({
-              observedBranch,
-              currentBranch: branch
-            })
+            hasChecksPanelGitStatusBranchChanged({ observedBranch, currentBranch: branch })
           ) {
             // Why: this click discovered a terminal branch switch; let branch-keyed render/effects restart instead of refreshing old PR data.
             refreshOutcome = 'branch-changed'
@@ -159,45 +163,55 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
               contextKey: panelContextKey,
               hasUncommittedChanges: status.entries.length > 0,
               remoteStatus: freshRemoteStatus,
-              gitIdentity: {
-                head: status.head,
-                branch: observedBranch
-              }
+              gitIdentity: { head: status.head, branch: observedBranch }
             })
           }
         } catch (error) {
           console.warn('[ChecksPanel] pre-refresh git identity refresh failed', error)
         }
       }
-      if (isGitLabReviewContext) {
-        const refreshedReview = await refreshHostedReviewCard(fetchHostedReviewForBranch, {
-          repoPath: repo.path,
-          repoId: repo.id,
-          branch,
-          admissionTier: 'interactive',
-          linkedGitHubPR: linkedPR,
-          fallbackGitHubPR: fallbackGitHubPRNumber,
-          linkedGitLabMR,
-          linkedBitbucketPR,
-          linkedAzureDevOpsPR,
-          linkedGiteaPR
-        })
+      const hostedReviewArgs = {
+        repoPath: repo.path,
+        repoId: repo.id,
+        branch,
+        admissionTier: 'interactive' as const,
+        linkedGitHubPR: linkedPR,
+        fallbackGitHubPR: fallbackGitHubPRNumber,
+        linkedGitLabMR,
+        linkedBitbucketPR,
+        linkedAzureDevOpsPR,
+        linkedGiteaPR
+      }
+      const isBitbucketReviewContext = Boolean(
+        activeReview?.provider === 'bitbucket' || linkedBitbucketPR !== null
+      )
+      if (isGitLabReviewContext || isBitbucketReviewContext) {
+        const refreshedReview = await refreshHostedReviewCard(
+          fetchHostedReviewForBranch,
+          hostedReviewArgs
+        )
         if (!isCurrentRequest()) {
           return
         }
-        const refreshedGitLabReview =
-          refreshedReview?.provider === 'gitlab' ? refreshedReview : activeGitLabReview
-        if (refreshedGitLabReview) {
-          await fetchGitLabDetails({
-            mrNumberOverride: refreshedGitLabReview.number,
-            headShaOverride: refreshedGitLabReview.headSha,
-            commitAsCurrent: true
-          })
-          refreshOutcome = 'review'
+        if (isGitLabReviewContext) {
+          const refreshedGitLabReview =
+            refreshedReview?.provider === 'gitlab' ? refreshedReview : activeGitLabReview
+          if (refreshedGitLabReview) {
+            await fetchGitLabDetails({
+              mrNumberOverride: refreshedGitLabReview.number,
+              headShaOverride: refreshedGitLabReview.headSha,
+              commitAsCurrent: true
+            })
+            refreshOutcome = 'review'
+          } else {
+            setChecks([])
+            setComments([])
+            refreshOutcome = 'no-review'
+          }
         } else {
           setChecks([])
           setComments([])
-          refreshOutcome = 'no-review'
+          refreshOutcome = refreshedReview?.provider === 'bitbucket' ? 'review' : 'no-review'
         }
         return
       }
@@ -227,16 +241,8 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
         return
       }
       await refreshHostedReviewCard(fetchHostedReviewForBranch, {
-        repoPath: repo.path,
-        repoId: repo.id,
-        branch,
-        admissionTier: 'interactive',
-        linkedGitHubPR: linkedPR,
-        fallbackGitHubPR: refreshedPR?.number ?? fallbackGitHubPRNumber,
-        linkedGitLabMR,
-        linkedBitbucketPR,
-        linkedAzureDevOpsPR,
-        linkedGiteaPR
+        ...hostedReviewArgs,
+        fallbackGitHubPR: refreshedPR?.number ?? fallbackGitHubPRNumber
       })
       if (!isCurrentRequest()) {
         return
@@ -256,6 +262,8 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
         // Why: a forced refresh can find the PR number before React repaints from prCache; mark this refresh's checks current.
         asyncResultKeyRef.current = prRequestKey
         // Why: pass the refreshed headSha directly; fetchChecks's closure captured a stale one (force-pushes, PR-number changes).
+        const isMatchingResult = (): boolean =>
+          isCurrentRequest() && isCurrentAsyncResult(prRequestKey)
         const refreshedChecks = fetchPRChecks(
           repo.path,
           refreshedPR.number,
@@ -265,7 +273,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
           { force: true, repoId: repo.id }
         ).then(
           (result) => {
-            if (!isCurrentRequest() || !isCurrentAsyncResult(prRequestKey)) {
+            if (!isMatchingResult()) {
               return
             }
             setChecks(result)
@@ -279,7 +287,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
             prevChecksRef.current = signature
           },
           (err) => {
-            if (!isCurrentRequest() || !isCurrentAsyncResult(prRequestKey)) {
+            if (!isMatchingResult()) {
               return
             }
             console.warn('Failed to fetch PR checks:', err)
@@ -294,12 +302,12 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
           prRepo: refreshedPR.prRepo
         }).then(
           (result) => {
-            if (isCurrentRequest() && isCurrentAsyncResult(prRequestKey)) {
+            if (isMatchingResult()) {
               setComments(result)
             }
           },
           (err) => {
-            if (!isCurrentRequest() || !isCurrentAsyncResult(prRequestKey)) {
+            if (!isMatchingResult()) {
               return
             }
             console.warn('Failed to fetch PR comments:', err)
@@ -308,12 +316,12 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
         )
         await Promise.all([
           refreshedChecks.finally(() => {
-            if (isCurrentRequest() && isCurrentAsyncResult(prRequestKey)) {
+            if (isMatchingResult()) {
               setChecksLoading(false)
             }
           }),
           refreshedComments.finally(() => {
-            if (isCurrentRequest() && isCurrentAsyncResult(prRequestKey)) {
+            if (isMatchingResult()) {
               setCommentsLoading(false)
             }
           })
@@ -327,21 +335,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
       refreshOutcome = 'error'
       throw error
     } finally {
-      recordChecksPanelPRRefreshBreadcrumb({
-        event: 'done',
-        provider: refreshProvider,
-        repoId: repo.id,
-        worktreeId: activeWorktreeId,
-        branch,
-        prCacheKey,
-        prNumber: activeGitLabReview?.number ?? prNumber,
-        prState: activeGitLabReview?.state ?? pr?.state,
-        prChecksStatus: pr?.checksStatus,
-        refreshState: prCacheKey ? useAppStore.getState().prRefreshStates[prCacheKey] : null,
-        outcome: refreshOutcome,
-        durationMs: Date.now() - refreshStartedAt,
-        currentRequest: isCurrentRequest()
-      })
+      recordBreadcrumb('done', refreshOutcome)
       if (isCurrentRequest()) {
         refreshInFlightRef.current = false
         setIsRefreshing(false)
@@ -357,6 +351,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
     activeWorktreePath,
     activeWorktreePushTarget,
     activeGitLabReview,
+    activeReview?.provider,
     prNumber,
     pr?.checksStatus,
     pr?.headSha,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.tsx
@@ -76,7 +76,14 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
     refreshRequestKeyRef.current = refreshRequestKey
     const isCurrentRequest = (): boolean => refreshRequestKeyRef.current === refreshRequestKey
     const refreshStartedAt = Date.now()
-    const refreshProvider = isGitLabReviewContext ? 'gitlab' : 'github'
+    const isBitbucketReviewContext = Boolean(
+      activeReview?.provider === 'bitbucket' || linkedBitbucketPR !== null
+    )
+    const refreshProvider = isGitLabReviewContext
+      ? 'gitlab'
+      : isBitbucketReviewContext
+        ? 'bitbucket'
+        : 'github'
     let refreshOutcome = 'started'
     setIsRefreshing(true)
     const recordBreadcrumb = (event: 'start' | 'done', outcome?: string): void => {
@@ -87,9 +94,16 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
         worktreeId: activeWorktreeId,
         branch,
         prCacheKey,
-        prNumber: activeGitLabReview?.number ?? prNumber,
-        prState: activeGitLabReview?.state ?? pr?.state,
-        prChecksStatus: pr?.checksStatus,
+        prNumber:
+          activeGitLabReview?.number ??
+          (activeReview?.provider === 'bitbucket' ? activeReview.number : undefined) ??
+          linkedBitbucketPR ??
+          prNumber,
+        prState:
+          activeGitLabReview?.state ??
+          (activeReview?.provider === 'bitbucket' ? activeReview.state : undefined) ??
+          pr?.state,
+        prChecksStatus: isBitbucketReviewContext ? null : pr?.checksStatus,
         refreshState: prCacheKey ? useAppStore.getState().prRefreshStates[prCacheKey] : null,
         outcome,
         durationMs: event === 'done' ? Date.now() - refreshStartedAt : undefined,
@@ -130,9 +144,6 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
         linkedAzureDevOpsPR,
         linkedGiteaPR
       }
-      const isBitbucketReviewContext = Boolean(
-        activeReview?.provider === 'bitbucket' || linkedBitbucketPR !== null
-      )
       if (isGitLabReviewContext || isBitbucketReviewContext) {
         const refreshedReview = await refreshHostedReviewCard(
           fetchHostedReviewForBranch,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.tsx
@@ -2,12 +2,7 @@ import { useCallback } from 'react'
 import { useAppStore } from '@/store'
 import { buildGitHubPRRefreshStateClearToken } from '@/store/github/pr-refresh-state'
 import { refreshHostedReviewCard } from '@/store/slices/hosted-review-card-refresh'
-import { getRuntimeGitStatus, getRuntimeGitUpstreamStatus } from '@/runtime/runtime-git-client'
-import {
-  hasChecksPanelGitStatusBranchChanged,
-  readChecksPanelRefreshGitIdentitySnapshot,
-  shouldCommitChecksPanelGitStatusSnapshot
-} from '../checks-panel-git-status-snapshot'
+import { syncChecksPanelPreRefreshGitIdentity } from './checks-panel-pre-refresh-git-identity'
 
 import { checksPanelAsyncResultKey } from '../checks-panel-async-result-key'
 import { recordChecksPanelPRRefreshBreadcrumb } from '../checks-panel-pr-refresh-breadcrumb'
@@ -26,6 +21,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
     branch,
     expireGitHubPRRefreshState,
     fallbackGitHubPRNumber,
+    fetchBitbucketDetails,
     fetchGitLabDetails,
     fetchHostedReviewForBranch,
     fetchPRChecks,
@@ -103,71 +99,23 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
     recordBreadcrumb('start')
     try {
       if (activeWorktreeId && activeWorktreePath && !isFolder) {
-        const snapshotIdentity = readChecksPanelRefreshGitIdentitySnapshot({
-          snapshot: gitStatusSnapshot,
-          contextKey: panelContextKey,
-          currentBranch: branch
+        const syncResult = await syncChecksPanelPreRefreshGitIdentity({
+          activeConnectionId,
+          activeWorktreeId,
+          activeWorktreePath,
+          activeWorktreePushTarget,
+          branch,
+          gitStatusSnapshot,
+          isCurrentRequest,
+          ownerSettings,
+          panelContextKey,
+          panelContextKeyRef,
+          setGitStatusSnapshot,
+          updateWorktreeGitIdentity
         })
-        if (snapshotIdentity.kind === 'changed') {
-          updateWorktreeGitIdentity(activeWorktreeId, {
-            head: snapshotIdentity.head,
-            branch: snapshotIdentity.branch
-          })
-          // Why: this click discovered a terminal branch switch; let branch-keyed render/effects restart instead of refreshing old PR data.
+        if (syncResult === 'branch-changed') {
           refreshOutcome = 'branch-changed'
           return
-        }
-        try {
-          const statusContext = {
-            settings: ownerSettings,
-            worktreeId: activeWorktreeId,
-            worktreePath: activeWorktreePath,
-            connectionId: activeConnectionId ?? undefined
-          }
-          const status = await getRuntimeGitStatus(statusContext, {
-            admissionTier: 'interactive'
-          })
-          const observedBranch = status.branch ?? (status.head ? null : undefined)
-          updateWorktreeGitIdentity(activeWorktreeId, {
-            head: status.head,
-            branch: observedBranch
-          })
-          if (
-            observedBranch !== undefined &&
-            hasChecksPanelGitStatusBranchChanged({ observedBranch, currentBranch: branch })
-          ) {
-            // Why: this click discovered a terminal branch switch; let branch-keyed render/effects restart instead of refreshing old PR data.
-            refreshOutcome = 'branch-changed'
-            return
-          }
-          let freshRemoteStatus = status.upstreamStatus
-          if (activeWorktreePushTarget) {
-            freshRemoteStatus = await getRuntimeGitUpstreamStatus(
-              statusContext,
-              activeWorktreePushTarget
-            )
-          } else if (
-            !freshRemoteStatus ||
-            (freshRemoteStatus.ahead > 0 &&
-              freshRemoteStatus.behind > 0 &&
-              freshRemoteStatus.behindCommitsArePatchEquivalent === undefined)
-          ) {
-            freshRemoteStatus = await getRuntimeGitUpstreamStatus(statusContext)
-          }
-          if (
-            isCurrentRequest() &&
-            shouldCommitChecksPanelGitStatusSnapshot(panelContextKeyRef.current, panelContextKey)
-          ) {
-            // Why: the Refresh click already paid for this status read; commit it so empty-state Publish/Create eligibility is fresh.
-            setGitStatusSnapshot({
-              contextKey: panelContextKey,
-              hasUncommittedChanges: status.entries.length > 0,
-              remoteStatus: freshRemoteStatus,
-              gitIdentity: { head: status.head, branch: observedBranch }
-            })
-          }
-        } catch (error) {
-          console.warn('[ChecksPanel] pre-refresh git identity refresh failed', error)
         }
       }
       const hostedReviewArgs = {
@@ -210,8 +158,21 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
           }
         } else {
           setChecks([])
-          setComments([])
-          refreshOutcome = refreshedReview?.provider === 'bitbucket' ? 'review' : 'no-review'
+          const refreshedBitbucketReview =
+            refreshedReview?.provider === 'bitbucket'
+              ? refreshedReview
+              : activeReview?.provider === 'bitbucket'
+                ? activeReview
+                : null
+          if (refreshedBitbucketReview) {
+            await fetchBitbucketDetails({
+              prNumberOverride: refreshedBitbucketReview.number
+            })
+            refreshOutcome = 'review'
+          } else {
+            setComments([])
+            refreshOutcome = 'no-review'
+          }
         }
         return
       }
@@ -351,7 +312,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
     activeWorktreePath,
     activeWorktreePushTarget,
     activeGitLabReview,
-    activeReview?.provider,
+    activeReview,
     prNumber,
     pr?.checksStatus,
     pr?.headSha,
@@ -360,6 +321,7 @@ export function useChecksPanelManualRefresh(model: ChecksPanelManualRefreshInput
     prCacheKey,
     linkedPR,
     fallbackGitHubPRNumber,
+    fetchBitbucketDetails,
     fetchGitLabDetails,
     linkedAzureDevOpsPR,
     linkedBitbucketPR,

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-polling.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-polling.test.tsx
@@ -36,6 +36,7 @@ type PollingInput = Parameters<typeof useChecksPanelPolling>[0]
 function createModel(overrides: Partial<PollingInput> = {}): PollingInput {
   const fetchPRChecks = vi.fn<() => Promise<PRCheckDetail[]>>().mockResolvedValue([])
   return {
+    activeReview: null,
     activeGitLabReview: null,
     activeWorktree: null,
     asyncResultKeyRef: { current: 'cache::main::42' },

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-polling.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-polling.tsx
@@ -12,7 +12,7 @@ import { fetchGitLabMRDetailsForChecks, gitLabMRCommentsToPRComments } from './g
 
 type ChecksPanelPollingInput = Pick<
   ChecksPanelContextState,
-  'activeGitLabReview' | 'hostedReviewCacheKey' | 'pr' | 'prCacheKey' | 'prNumber'
+  'activeGitLabReview' | 'activeReview' | 'hostedReviewCacheKey' | 'pr' | 'prCacheKey' | 'prNumber'
 > &
   Pick<
     ChecksPanelControllerState,
@@ -37,6 +37,7 @@ export function useChecksPanelPolling(model: ChecksPanelPollingInput) {
   const {
     activeWorktree,
     activeGitLabReview,
+    activeReview,
     asyncResultKeyRef,
     branch,
     fetchPRChecks,
@@ -270,7 +271,52 @@ export function useChecksPanelPolling(model: ChecksPanelPollingInput) {
       getDelayMs: () => pollIntervalRef.current
     })
   }, [activeGitLabReview, fetchGitLabDetails, isPanelVisible, pollIntervalRef, prevChecksRef])
-  return { fetchChecks, fetchGitLabDetails }
+
+  const fetchBitbucketDetails = useCallback(
+    async ({
+      prNumberOverride
+    }: {
+      prNumberOverride?: number | null
+    } = {}) => {
+      const targetPRNumber = prNumberOverride ?? activeReview?.number ?? null
+      if (!repo || !targetPRNumber || activeReview?.provider !== 'bitbucket') {
+        return
+      }
+      try {
+        const result = await window.api.bitbucket.getPRComments({
+          repoPath: repo.path,
+          prNumber: targetPRNumber,
+          executionHostId: activeWorktree?.hostId
+        })
+        setComments(result)
+      } catch (err) {
+        console.warn('Failed to poll Bitbucket comments:', err)
+      }
+    },
+    [activeReview?.number, activeReview?.provider, activeWorktree?.hostId, repo, setComments]
+  )
+
+  useEffect(() => {
+    if (
+      activeReview?.provider !== 'bitbucket' ||
+      activeReview.state !== 'open' ||
+      !isPanelVisible
+    ) {
+      return
+    }
+    return installWindowVisibilityTimeoutPoller({
+      run: () => fetchBitbucketDetails(),
+      getDelayMs: () => 30_000
+    })
+  }, [
+    activeReview?.number,
+    activeReview?.provider,
+    activeReview?.state,
+    fetchBitbucketDetails,
+    isPanelVisible
+  ])
+
+  return { fetchChecks, fetchGitLabDetails, fetchBitbucketDetails }
 }
 
 export type ChecksPanelPollingState = ReturnType<typeof useChecksPanelPolling>

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-polling.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-polling.tsx
@@ -58,6 +58,7 @@ export function useChecksPanelPolling(model: ChecksPanelPollingInput) {
     gitLabProjectRefRef
   } = model
   const gitLabDetailsLoadingGenerationRef = useRef(0)
+  const bitbucketDetailsLoadingGenerationRef = useRef(0)
   // Fetch checks via cached store method
   const fetchChecks = useCallback(
     async ({
@@ -282,13 +283,20 @@ export function useChecksPanelPolling(model: ChecksPanelPollingInput) {
       if (!repo || !targetPRNumber || activeReview?.provider !== 'bitbucket') {
         return
       }
+      const loadingGeneration = ++bitbucketDetailsLoadingGenerationRef.current
       try {
         const result = await window.api.bitbucket.getPRComments({
           repoPath: repo.path,
           prNumber: targetPRNumber,
           executionHostId: activeWorktree?.hostId
         })
-        setComments(result)
+        if (
+          bitbucketDetailsLoadingGenerationRef.current === loadingGeneration &&
+          activeReview?.provider === 'bitbucket' &&
+          activeReview.number === targetPRNumber
+        ) {
+          setComments(result)
+        }
       } catch (err) {
         console.warn('Failed to poll Bitbucket comments:', err)
       }

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-data.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-data.tsx
@@ -69,12 +69,18 @@ export function useChecksPanelReviewData(model: ChecksPanelReviewDataInput) {
             prNumber: targetPRNumber,
             executionHostId: activeWorktree?.hostId
           })
-          setComments(result)
+          if (activeReview?.provider === 'bitbucket' && activeReview.number === targetPRNumber) {
+            setComments(result)
+          }
         } catch (err) {
           console.warn('Failed to fetch Bitbucket PR comments:', err)
-          setComments([])
+          if (activeReview?.provider === 'bitbucket' && activeReview.number === targetPRNumber) {
+            setComments([])
+          }
         } finally {
-          setCommentsLoading(false)
+          if (activeReview?.provider === 'bitbucket' && activeReview.number === targetPRNumber) {
+            setCommentsLoading(false)
+          }
         }
         return
       }

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-data.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-data.tsx
@@ -10,10 +10,11 @@ import type { ChecksPanelComposerState } from './use-checks-panel-composer-state
 
 type ChecksPanelReviewDataInput = Pick<
   ChecksPanelContextState,
-  'activeGitLabReview' | 'pr' | 'prCacheKey' | 'prNumber'
+  'activeGitLabReview' | 'activeReview' | 'pr' | 'prCacheKey' | 'prNumber'
 > &
   Pick<
     ChecksPanelControllerState,
+    | 'activeWorktree'
     | 'branch'
     | 'fetchPRCheckDetails'
     | 'fetchPRComments'
@@ -29,6 +30,8 @@ type ChecksPanelReviewDataInput = Pick<
 export function useChecksPanelReviewData(model: ChecksPanelReviewDataInput) {
   const {
     activeGitLabReview,
+    activeReview,
+    activeWorktree,
     branch,
     fetchPRCheckDetails,
     fetchPRComments,
@@ -54,6 +57,27 @@ export function useChecksPanelReviewData(model: ChecksPanelReviewDataInput) {
       prNumberOverride?: number | null
       prRepoOverride?: PRInfo['prRepo'] | null
     } = {}) => {
+      if (activeReview?.provider === 'bitbucket') {
+        const targetPRNumber = prNumberOverride ?? activeReview.number
+        if (!repo || !targetPRNumber) {
+          return
+        }
+        setCommentsLoading(true)
+        try {
+          const result = await window.api.bitbucket.getPRComments({
+            repoPath: repo.path,
+            prNumber: targetPRNumber,
+            executionHostId: activeWorktree?.hostId
+          })
+          setComments(result)
+        } catch (err) {
+          console.warn('Failed to fetch Bitbucket PR comments:', err)
+          setComments([])
+        } finally {
+          setCommentsLoading(false)
+        }
+        return
+      }
       const targetPRNumber = prNumberOverride ?? prNumber
       const targetPRRepo = prRepoOverride ?? pr?.prRepo
       if (!repo || !targetPRNumber) {
@@ -98,6 +122,9 @@ export function useChecksPanelReviewData(model: ChecksPanelReviewDataInput) {
       }
     },
     [
+      activeReview?.number,
+      activeReview?.provider,
+      activeWorktree?.hostId,
       repo,
       prNumber,
       pr?.headSha,
@@ -149,6 +176,37 @@ export function useChecksPanelReviewData(model: ChecksPanelReviewDataInput) {
     if (activeGitLabReview) {
       return
     }
+    if (activeReview?.provider === 'bitbucket') {
+      if (!repo || !activeReview.number || !isPanelVisible) {
+        setComments([])
+        return
+      }
+      let cancelled = false
+      setCommentsLoading(true)
+      void window.api.bitbucket
+        .getPRComments({
+          repoPath: repo.path,
+          prNumber: activeReview.number,
+          executionHostId: activeWorktree?.hostId
+        })
+        .then(
+          (result) => {
+            if (!cancelled) {
+              setComments(result)
+              setCommentsLoading(false)
+            }
+          },
+          () => {
+            if (!cancelled) {
+              setComments([])
+              setCommentsLoading(false)
+            }
+          }
+        )
+      return () => {
+        cancelled = true
+      }
+    }
     if (!repo || !prNumber || !isPanelVisible) {
       setComments([])
       return
@@ -181,6 +239,9 @@ export function useChecksPanelReviewData(model: ChecksPanelReviewDataInput) {
     }
   }, [
     activeGitLabReview,
+    activeReview?.number,
+    activeReview?.provider,
+    activeWorktree?.hostId,
     repo,
     prNumber,
     pr?.headSha,
@@ -195,7 +256,13 @@ export function useChecksPanelReviewData(model: ChecksPanelReviewDataInput) {
   ])
 
   useEffect(() => {
-    if (activeGitLabReview || !repo || !prNumber || !isPanelVisible) {
+    if (
+      activeGitLabReview ||
+      activeReview?.provider === 'bitbucket' ||
+      !repo ||
+      !prNumber ||
+      !isPanelVisible
+    ) {
       return undefined
     }
     return window.api.gh.onWorkItemMutated((payload) => {
@@ -206,7 +273,7 @@ export function useChecksPanelReviewData(model: ChecksPanelReviewDataInput) {
       }
       void fetchComments({ force: true })
     })
-  }, [activeGitLabReview, fetchComments, isPanelVisible, prNumber, repo])
+  }, [activeGitLabReview, activeReview?.provider, fetchComments, isPanelVisible, prNumber, repo])
   return { fetchComments, handleLoadCheckDetails, getGitLabProjectRef }
 }
 

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-link-actions.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-link-actions.tsx
@@ -15,6 +15,7 @@ export function useChecksPanelReviewLinkActions(
     activeWorktreeId,
     branch,
     fetchHostedReviewForBranch,
+    linkedBitbucketPR,
     linkedGitLabMR,
     linkedPR,
     localExecutionScope,
@@ -60,6 +61,17 @@ export function useChecksPanelReviewLinkActions(
       void unlinkGitHubPullRequest()
       return
     }
+    if (activeReview.provider === 'bitbucket') {
+      if (linkedBitbucketPR === null) {
+        return
+      }
+      void updateWorktreeMeta(
+        activeWorktreeId,
+        { linkedBitbucketPR: null },
+        { executionHostId: activeWorktree.hostId }
+      )
+      return
+    }
     if (linkedGitLabMR === null) {
       return
     }
@@ -72,6 +84,7 @@ export function useChecksPanelReviewLinkActions(
     activeReview,
     activeWorktree,
     activeWorktreeId,
+    linkedBitbucketPR,
     linkedGitLabMR,
     unlinkGitHubPullRequest,
     updateWorktreeMeta

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-link-actions.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-review-link-actions.tsx
@@ -132,6 +132,9 @@ export function useChecksPanelReviewLinkActions(
       openLinkPullRequestModal(activeWorktree.linkedPR ?? activeReview.number)
       return
     }
+    if (activeReview.provider === 'bitbucket') {
+      return
+    }
     const openedScopeKey = reviewLinkScopeKey
     openModal('edit-meta', {
       worktreeId: activeWorktreeId,

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -57,17 +57,7 @@ export function useHostedReviewActions({
   defaultMergeMethod: HostedReviewMergeMethod
   autoMergeAction: GitHubPRAutoMergeAction | null
   onRefreshReview: () => Promise<void>
-}): {
-  merging: boolean
-  readying: boolean
-  stateUpdating: 'open' | 'closed' | null
-  actionError: string | null
-  handleMerge: (method?: HostedReviewMergeMethod) => Promise<void>
-  handleAutoMerge: () => Promise<void>
-  handleMarkReadyForReview: () => Promise<void>
-  handleCloseReview: () => Promise<void>
-  handleReopenReview: () => Promise<void>
-} {
+}) {
   const confirm = useConfirmationDialog()
   const [merging, setMerging] = useState(false)
   const [stateUpdating, setStateUpdating] = useState<'open' | 'closed' | null>(null)
@@ -235,7 +225,10 @@ export function useHostedReviewActions({
                 })
               : {
                   ok: false,
-                  error: 'Reopening declined Bitbucket pull requests is not supported.'
+                  error: translate(
+                    'auto.components.right.sidebar.bitbucket.pr.reopenUnsupported',
+                    'Reopening declined Bitbucket pull requests is not supported.'
+                  )
                 }
             : await updateGitHubHostedReviewState({
                 repo,

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -4,6 +4,8 @@ import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
 import type { GitHubPRAutoMergeAction } from '@/components/github-pr-merge-state'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type { GitHubPRMergeMethod, PRInfo } from '../../../../shared/github/pull-request-types'
+import type { BitbucketPRMergeMethod } from '../../../../shared/bitbucket-merge-methods'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/repo-types'
 import {
   mergeGitHubHostedReview,
@@ -13,6 +15,8 @@ import {
 import { translate } from '@/i18n/i18n'
 import { buildGitHubPRStackMergeConfirmation } from './github-pr-stack-confirmation'
 import { useReadyHostedReviewAction } from './use-ready-hosted-review-action'
+
+export type HostedReviewMergeMethod = GitHubPRMergeMethod | BitbucketPRMergeMethod
 
 export type HostedReviewActionInfo = Pick<
   HostedReviewInfo,
@@ -33,7 +37,9 @@ export function useHostedReviewActions({
   review,
   githubPR,
   repo,
+  executionHostId = 'local',
   isGitLab,
+  isBitbucket = false,
   shortLabel,
   reviewLabel,
   defaultMergeMethod,
@@ -43,10 +49,12 @@ export function useHostedReviewActions({
   review: HostedReviewActionInfo
   githubPR?: PRInfo | null
   repo: Repo
+  executionHostId?: ExecutionHostId
   isGitLab: boolean
+  isBitbucket?: boolean
   shortLabel: string
   reviewLabel: string
-  defaultMergeMethod: GitHubPRMergeMethod
+  defaultMergeMethod: HostedReviewMergeMethod
   autoMergeAction: GitHubPRAutoMergeAction | null
   onRefreshReview: () => Promise<void>
 }): {
@@ -54,7 +62,7 @@ export function useHostedReviewActions({
   readying: boolean
   stateUpdating: 'open' | 'closed' | null
   actionError: string | null
-  handleMerge: (method?: GitHubPRMergeMethod) => Promise<void>
+  handleMerge: (method?: HostedReviewMergeMethod) => Promise<void>
   handleAutoMerge: () => Promise<void>
   handleMarkReadyForReview: () => Promise<void>
   handleCloseReview: () => Promise<void>
@@ -76,7 +84,7 @@ export function useHostedReviewActions({
   })
 
   const handleMerge = useCallback(
-    async (method: GitHubPRMergeMethod = defaultMergeMethod) => {
+    async (method: HostedReviewMergeMethod = defaultMergeMethod) => {
       if (!isGitLab && githubPR?.stack) {
         const usesMergeQueue =
           review.mergeQueueRequired === true || githubPR.mergeQueueRequired === true
@@ -84,7 +92,7 @@ export function useHostedReviewActions({
           buildGitHubPRStackMergeConfirmation({
             stack: githubPR.stack,
             currentPRNumber: review.number,
-            method,
+            method: method as GitHubPRMergeMethod,
             usesMergeQueue
           })
         )
@@ -100,14 +108,21 @@ export function useHostedReviewActions({
               repoPath: repo.path,
               repoId: repo.id,
               iid: review.number,
-              method
+              method: method as 'merge' | 'squash' | 'rebase'
             })
-          : await mergeGitHubHostedReview({
-              repo,
-              prNumber: review.number,
-              method,
-              prRepo: githubPR?.prRepo ?? null
-            })
+          : isBitbucket
+            ? await window.api.bitbucket.mergePR({
+                repoPath: repo.path,
+                prNumber: review.number,
+                method: method as BitbucketPRMergeMethod,
+                executionHostId
+              })
+            : await mergeGitHubHostedReview({
+                repo,
+                prNumber: review.number,
+                method: method as GitHubPRMergeMethod,
+                prRepo: githubPR?.prRepo ?? null
+              })
         if (!result.ok) {
           setActionError(result.error)
         } else {
@@ -121,10 +136,12 @@ export function useHostedReviewActions({
     },
     [
       confirm,
+      executionHostId,
       githubPR?.prRepo,
       githubPR?.mergeQueueRequired,
       githubPR?.stack,
       isGitLab,
+      isBitbucket,
       defaultMergeMethod,
       onRefreshReview,
       repo,
@@ -145,7 +162,7 @@ export function useHostedReviewActions({
         repo,
         prNumber: review.number,
         enabled,
-        method: enabled ? defaultMergeMethod : undefined,
+        method: enabled ? (defaultMergeMethod as GitHubPRMergeMethod) : undefined,
         prRepo: githubPR?.prRepo ?? null
       })
       if (!result.ok) {
@@ -209,12 +226,23 @@ export function useHostedReviewActions({
                 repoId: repo.id,
                 iid: review.number
               })
-          : await updateGitHubHostedReviewState({
-              repo,
-              prNumber: review.number,
-              prRepo: githubPR?.prRepo ?? null,
-              nextState
-            })
+          : isBitbucket
+            ? isClosing
+              ? await window.api.bitbucket.closePR({
+                  repoPath: repo.path,
+                  prNumber: review.number,
+                  executionHostId
+                })
+              : {
+                  ok: false,
+                  error: 'Reopening declined Bitbucket pull requests is not supported.'
+                }
+            : await updateGitHubHostedReviewState({
+                repo,
+                prNumber: review.number,
+                prRepo: githubPR?.prRepo ?? null,
+                nextState
+              })
         if (!result.ok) {
           setActionError(result.error)
           toast.error(result.error)
@@ -245,8 +273,10 @@ export function useHostedReviewActions({
     },
     [
       confirm,
+      executionHostId,
       githubPR?.prRepo,
       isGitLab,
+      isBitbucket,
       onRefreshReview,
       repo,
       review.number,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11876,7 +11876,9 @@
             "updateReactionFailed": "Failed to update reaction.",
             "gitlabMoreActions": "More MR actions",
             "gitlabUnlink": "Unlink MR",
-            "gitlabLinkAnother": "Link another MR"
+            "gitlabLinkAnother": "Link another MR",
+            "bitbucketCommentsDisabled": "Commenting requires a Bitbucket pull request.",
+            "bitbucketResolveUnsupported": "Resolving comments with AI is not supported for Bitbucket."
           },
           "CreatePullRequestDialog": {
             "2bc1b4345e": "Cancel",

--- a/src/shared/bitbucket-merge-methods.test.ts
+++ b/src/shared/bitbucket-merge-methods.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BITBUCKET_PR_MERGE_METHODS,
+  BITBUCKET_PR_MERGE_METHOD_LABELS,
+  resolveBitbucketPRMergeMethods
+} from './bitbucket-merge-methods'
+
+describe('resolveBitbucketPRMergeMethods', () => {
+  it('defaults to merge_commit when no default specified', () => {
+    const result = resolveBitbucketPRMergeMethods()
+    expect(result.defaultMethod).toBe('merge_commit')
+    expect(result.defaultLabel).toBe(BITBUCKET_PR_MERGE_METHOD_LABELS.merge_commit)
+    expect(result.methods.map((m) => m.method)).toEqual(BITBUCKET_PR_MERGE_METHODS)
+  })
+
+  it('orders the specified defaultMethod first', () => {
+    const result = resolveBitbucketPRMergeMethods('fast_forward')
+    expect(result.defaultMethod).toBe('fast_forward')
+    expect(result.defaultLabel).toBe(BITBUCKET_PR_MERGE_METHOD_LABELS.fast_forward)
+    expect(result.methods.map((m) => m.method)).toEqual(['fast_forward', 'merge_commit', 'squash'])
+  })
+
+  it('handles squash default', () => {
+    const result = resolveBitbucketPRMergeMethods('squash')
+    expect(result.defaultMethod).toBe('squash')
+    expect(result.methods.map((m) => m.method)).toEqual(['squash', 'merge_commit', 'fast_forward'])
+  })
+})

--- a/src/shared/bitbucket-merge-methods.ts
+++ b/src/shared/bitbucket-merge-methods.ts
@@ -1,0 +1,38 @@
+export const BITBUCKET_PR_MERGE_METHODS = ['merge_commit', 'squash', 'fast_forward'] as const
+
+export type BitbucketPRMergeMethod = (typeof BITBUCKET_PR_MERGE_METHODS)[number]
+
+export const BITBUCKET_PR_MERGE_METHOD_LABELS: Record<BitbucketPRMergeMethod, string> = {
+  merge_commit: 'Create merge commit',
+  squash: 'Squash and merge',
+  fast_forward: 'Fast-forward merge'
+}
+
+export type BitbucketPRMergeMethodOption = {
+  method: BitbucketPRMergeMethod
+  label: string
+}
+
+export type BitbucketPRMergeMethodPresentation = {
+  defaultMethod: BitbucketPRMergeMethod
+  defaultLabel: string
+  methods: BitbucketPRMergeMethodOption[]
+}
+
+export function resolveBitbucketPRMergeMethods(
+  defaultMethod: BitbucketPRMergeMethod = 'merge_commit'
+): BitbucketPRMergeMethodPresentation {
+  const orderedMethods: BitbucketPRMergeMethod[] = [
+    defaultMethod,
+    ...BITBUCKET_PR_MERGE_METHODS.filter((m) => m !== defaultMethod)
+  ]
+
+  return {
+    defaultMethod,
+    defaultLabel: BITBUCKET_PR_MERGE_METHOD_LABELS[defaultMethod],
+    methods: orderedMethods.map((method) => ({
+      method,
+      label: BITBUCKET_PR_MERGE_METHOD_LABELS[method]
+    }))
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #19543** (`feat(bitbucket): support merging and closing pull requests from checks panel`).
> Once #19543 merges into `main`, this branch will be rebased onto `main`. The only new commit introduced here is `583344f9ee`.

## ELI5

Bitbucket pull requests could previously display merge actions in the right sidebar Checks panel (#19543), but pull request comments and review discussions were hidden. This PR adds full support for fetching, viewing, and replying to Bitbucket pull request comments directly in the Checks panel, bringing parity with GitHub and GitLab.

## What Changed

- **Bitbucket REST comments client & mappers**:
  - Implemented `fetchBitbucketPRComments`, `addBitbucketPRComment`, and `replyBitbucketPRComment` in `src/main/bitbucket/comments.ts` targeting Bitbucket Cloud 2.0 REST API (`GET/POST /2.0/repositories/{workspace}/{repo_slug}/pullrequests/{id}/comments`).
  - Added HTTPS protocol verification (`url.protocol === 'https:'`) to prevent accidental plain-text transmission.
  - Implemented `mapBitbucketComment` in `src/main/bitbucket/comments-mappers.ts` to normalize Bitbucket comment threads into Orca's standard `PRComment` structure, preserving thread root hierarchy, inline file path/line references (`inline.path`, `inline.to`), author display details, and bot detection.
- **IPC & Preload Bridge**:
  - Added IPC handlers `bitbucket:getPRComments`, `bitbucket:addPRComment`, and `bitbucket:replyPRComment` in `src/main/ipc/bitbucket.ts`.
  - Exposed them via `window.api.bitbucket` in `src/preload/api/bitbucket-bridge.ts`.
- **Right Sidebar Checks Panel integration**:
  - Enabled `PRCommentsList` for Bitbucket reviews in `src/renderer/src/components/right-sidebar/checks-panel/active-content.tsx` by removing the provider check guard.
  - Connected Bitbucket comment fetching and polling in `use-checks-panel-review-data.tsx` and `use-checks-panel-polling.tsx`.
  - Hooked up `handleAddPRComment` and `handleReplyToComment` mutations in `use-checks-panel-comment-mutations.tsx` to dispatch to `window.api.bitbucket`.

## Why

Completes pull request comment parity for Bitbucket Cloud repositories alongside GitHub and GitLab without introducing breaking changes or architectural drift.

## Linked Issue

Depends on #19543 (Follow-up to Bitbucket Checks panel integration)

## Visual Proof

| Before (Comments omitted in Checks panel) | After (Bitbucket PR Comments & Replies in Checks panel) |
|:---:|:---:|
| ![Before: Comments omitted in Checks panel](https://raw.githubusercontent.com/96Kim/orca/assets/bitbucket-pr-comments/bitbucket-pr-comments-before.png) | ![After: Bitbucket PR Comments & Replies in Checks panel](https://raw.githubusercontent.com/96Kim/orca/assets/bitbucket-pr-comments/bitbucket-pr-comments-after.png) |

*(Screenshots captured from live testing: Before shows the Bitbucket pull request in the Checks panel with comments omitted. After shows the active Comments section with comment count badges, audience filters (All, Human, Bot), threaded discussions, inline file/line badges, and reply composers.)*

## Testing

- **Automated tests added & passing**:
  - `src/main/bitbucket/comments.test.ts` (19 tests covering comment fetching, pagination, thread grouping, top-level comments, inline replies, bot detection, error resilience, and HTTPS protocol guards)
  - `src/renderer/src/components/right-sidebar/checks-panel/panel-content-rendering.test.tsx` (7 tests verifying comment section rendering for Bitbucket reviews)
  - `src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-manual-refresh.test.tsx`
  - `src/renderer/src/components/right-sidebar/checks-panel/use-checks-panel-polling.test.tsx`
- **Manual testing**:
  - Connected to live Bitbucket repository with active pull request discussions.
  - Verified threaded comments, avatars, timestamps, and file/line badges render cleanly.
  - Verified replying to existing comments and submitting top-level PR comments.
  - Verified typecheck (`pnpm tc`) and code quality gates pass cleanly (`pnpm run check:code-quality:changed`).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Assisted by Google DeepMind Antigravity agent.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: Strictly enforces `https:` for all Bitbucket REST API requests. No auth tokens are exposed to renderer.
- **Cross-platform**: All IPC paths and UI components are platform-independent (macOS, Windows, Linux).
- **Remote SSH**: `executionHostId` is passed down to all Bitbucket git and PR mutation APIs.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
