### PR TITLE
fix(lint): preserve deliberate collator benchmark baselines

### DIFF
--- a/config/scripts/locale-collator-sort-benchmark.mjs
+++ b/config/scripts/locale-collator-sort-benchmark.mjs
@@ -129,6 +129,7 @@ for (const count of [36, 50, 250]) {
   const issues = makeJiraIssues(count)
   const before = () =>
     [...issues]
+      // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Baseline measures per-comparison setup against a reused collator.
       .sort((a, b) => a.key.localeCompare(b.key, undefined, { numeric: true }))
       .map((issue) => issue.key)
   const after = () => sortJiraIssues(issues, 'key', 'asc').map((issue) => issue.key)
@@ -142,6 +143,7 @@ for (const count of [36, 50, 250]) {
 for (const count of [10, 50, 250]) {
   const values = makeBaseSensitivityValues(count)
   const before = () =>
+    // oxlint-disable-next-line sort-comparator-performance/no-repeated-collator -- Baseline measures per-comparison setup against a reused collator.
     [...values].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
   const after = () => [...values].sort(compareBaseSensitivityLocaleText)
   assertSameOrder(before, after, `base ${count}`)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

The static-analysis workflow runs on pull requests, not main pushes. Collator warnings accumulated on main without being caught there, then blocked unrelated PRs because lint checks the whole repository.

## What Changed

Add two line-specific lint exceptions for the benchmark's deliberate per-comparison collation baselines. The five reported production sites already reuse collators on this main baseline, so they need no further changes. Hoisting the benchmark's baseline calls would invalidate its measurement of per-call setup versus a reused collator.

Sort order is preserved exactly: this patch changes comments only, leaving locales, options, comparison code, and tie-breakers untouched.

## Linked Issue

Standalone repository lint blocker reported through orchestration; no linked issue was supplied.

## Visual Proof

N/A — comments only; no UI or behavior change.

## Testing

- `pnpm exec oxlint --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings` passes; JSON rerun confirms zero warnings and zero errors across 23,663 files.
- `pnpm exec oxlint src config tests mobile --deny-warnings --format json` also reports zero diagnostics, including the collator rule.
- 74 focused tests pass across 10 files covering the lint rule, benchmark schedule, skill discovery and ordering, Warp discovery/manual ordering, deletion copy, locale collators, and automation sorting.
- `node config/scripts/locale-collator-sort-benchmark.mjs` completes all nine fixtures with identical before/after sort order.
- Validated locally on macOS; no platform, SSH, mobile, or wire behavior changes. Typecheck intentionally not run; no lockfile changes included.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill content changed.
