### PR TITLE
fix(orchestration): accept a missing Run id from older federation coordinators

### DIFF
--- a/src/main/runtime/orchestration/db/contract-constants.ts
+++ b/src/main/runtime/orchestration/db/contract-constants.ts
@@ -3,6 +3,12 @@ import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../shared/protocol-vers
 
 export const LEGACY_RUN_ID = ORCHESTRATION_LEGACY_RUN_ID
 
+// Why: a v1.4.198 coordinator sends no Run id, so its remote workers file mail under a per-attachment stub Run.
+export const FEDERATED_STUB_HOME_RUN_ID_PREFIX = 'run_federated_'
+export function federatedStubHomeRunId(dispatchId: string): string {
+  return `${FEDERATED_STUB_HOME_RUN_ID_PREFIX}${dispatchId}`
+}
+
 export const LEGACY_CONTRACT_VERSION = 0
 export const CURRENT_CONTRACT_VERSION = ORCHESTRATION_CONTRACT_VERSION
 

--- a/src/main/runtime/orchestration/db/federation/federated-stub-home-run-backfill.ts
+++ b/src/main/runtime/orchestration/db/federation/federated-stub-home-run-backfill.ts
@@ -1,0 +1,16 @@
+import type Database from '../../../../sqlite/sync-database'
+import { FEDERATED_STUB_HOME_RUN_ID_PREFIX } from '../contract-constants'
+
+// Why: a rolled-back v1.4.198 host inserts attachments with home_run_id='' after user_version is
+// already 40, so this idempotent repair runs on every open, not only inside the v40 migration.
+export function backfillFederatedStubHomeRuns(db: Database.Database): void {
+  db.exec(`
+    INSERT OR IGNORE INTO runs (id, objective, home_database, consumer_generation, legacy)
+    SELECT '${FEDERATED_STUB_HOME_RUN_ID_PREFIX}' || dispatch_id,
+           'Coordinated from ' || home_peer_fingerprint, 'remote', 0, 0
+    FROM remote_dispatch_attachments WHERE home_run_id = '';
+    UPDATE remote_dispatch_attachments
+    SET home_run_id = '${FEDERATED_STUB_HOME_RUN_ID_PREFIX}' || dispatch_id
+    WHERE home_run_id = '';
+  `)
+}

--- a/src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-create.ts
+++ b/src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-create.ts
@@ -2,13 +2,15 @@ import type { WorkerDispatchState, RemoteDispatchAttachmentRow } from '../../typ
 import { OrchestrationError } from '../../orchestration-error'
 import { ensureMutationReceiptCapacity } from '../../mutation-receipt-capacity'
 import type { OrchestrationDb } from '../orchestration-db'
+import { federatedStubHomeRunId } from '../contract-constants'
 import { insertRemoteDispatchAttachmentRow } from '../dispatch-row-writer'
 
 export function createRemoteDispatchAttachment(
   this: OrchestrationDb,
   params: {
     dispatchId: string
-    runId: string
+    /** Absent from a v1.4.198 coordinator; replaced by a per-attachment stub Run. */
+    runId?: string
     taskId: string
     homePeerFingerprint: string
     protocolVersion: number
@@ -44,7 +46,8 @@ export function createRemoteDispatchAttachment(
         `Remote attachment request ${params.mutationReceipt.requestId} already exists.`
       )
     }
-    if (!params.runId?.trim()) {
+    const runId = params.runId ?? federatedStubHomeRunId(params.dispatchId)
+    if (!runId.trim()) {
       throw new OrchestrationError('invalid_argument', 'Missing Run ID')
     }
     this.db
@@ -52,8 +55,8 @@ export function createRemoteDispatchAttachment(
         `INSERT OR IGNORE INTO runs (id, objective, home_database, consumer_generation, legacy)
          VALUES (?, ?, 'remote', 0, 0)`
       )
-      .run(params.runId, `Coordinated from ${params.homePeerFingerprint}`)
-    this.requireRun(params.runId)
+      .run(runId, `Coordinated from ${params.homePeerFingerprint}`)
+    this.requireRun(runId)
     ensureMutationReceiptCapacity(this.db)
     this.db
       .prepare(
@@ -70,7 +73,7 @@ export function createRemoteDispatchAttachment(
       )
     insertRemoteDispatchAttachmentRow(this.db, {
       dispatchId: params.dispatchId,
-      runId: params.runId,
+      runId,
       taskId: params.taskId,
       homePeerFingerprint: params.homePeerFingerprint,
       protocolVersion: params.protocolVersion,

--- a/src/main/runtime/orchestration/db/orchestration-db.ts
+++ b/src/main/runtime/orchestration/db/orchestration-db.ts
@@ -1,6 +1,7 @@
 import Database from '../../../sqlite/sync-database'
 import { attachOrchestrationDbMethods } from './attach-orchestration-db-methods'
 import { hardenOrchestrationDatabaseFiles } from './database-file-permissions'
+import { backfillFederatedStubHomeRuns } from './federation/federated-stub-home-run-backfill'
 import type { OrchestrationDbMethods } from './orchestration-db-methods'
 import {
   createCoordinatorMailRoutingTrigger,
@@ -28,6 +29,7 @@ class OrchestrationDbCore {
     this.db.pragma('busy_timeout = 5000')
     createTables.call(this as unknown as OrchestrationDb)
     migrate.call(this as unknown as OrchestrationDb)
+    backfillFederatedStubHomeRuns(this.db)
     createCoordinatorMailRoutingTrigger.call(this as unknown as OrchestrationDb)
     rememberCurrentRunCoordinatorHandles.call(this as unknown as OrchestrationDb)
     hardenOrchestrationDatabaseFiles(dbPath)

--- a/src/main/runtime/orchestration/db/schema/create-graph-tables-sql.ts
+++ b/src/main/runtime/orchestration/db/schema/create-graph-tables-sql.ts
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS federated_dispatches (
 );
 
 CREATE TABLE IF NOT EXISTS remote_dispatch_attachments (
-  home_run_id             TEXT NOT NULL,
+  -- DEFAULT: a rolled-back v1.4.198 host still inserts here without a home Run.
+  home_run_id             TEXT NOT NULL DEFAULT '',
   dispatch_id             TEXT PRIMARY KEY,
   task_id                 TEXT NOT NULL,
   home_peer_fingerprint   TEXT NOT NULL,

--- a/src/main/runtime/orchestration/db/schema/federated-home-run-migration.test.ts
+++ b/src/main/runtime/orchestration/db/schema/federated-home-run-migration.test.ts
@@ -1,26 +1,57 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../../shared/protocol-version'
 import { OrchestrationDb } from '../orchestration-db'
+import { federatedStubHomeRunId } from '../contract-constants'
 import { migrateV40 } from './migrate-v40'
 import { importFederatedControlMessage } from '../../federation-control-message'
 
 describe('federated home Run migration', () => {
-  const db = new OrchestrationDb(':memory:')
+  let db: OrchestrationDb
+  beforeEach(() => {
+    db = new OrchestrationDb(':memory:')
+  })
   afterEach(() => db.close())
 
-  it('adds the home Run column and refuses mail for a development placeholder', () => {
+  function importInstruction(dispatchId: string, messageId: string): void {
+    expect(
+      importFederatedControlMessage(db, {
+        dispatchId,
+        messageId,
+        payload: JSON.stringify({ from: 'home', subject: 'Instruction', body: '', type: 'status' })
+      })
+    ).toEqual({ imported: true, type: 'status' })
+  }
+
+  it('backfills a pre-upgrade attachment with a stub home Run that keeps its mailbox', () => {
     db.db.exec('ALTER TABLE remote_dispatch_attachments DROP COLUMN home_run_id')
     db.db.exec(`INSERT INTO remote_dispatch_attachments
       (dispatch_id, task_id, home_peer_fingerprint, runtime_epoch)
       VALUES ('ctx_old', 'task_old', 'home', 'epoch')`)
     migrateV40.call(db, 39)
-    expect(db.getRemoteDispatchAttachment('ctx_old')?.home_run_id).toBe('')
-    expect(() =>
-      importFederatedControlMessage(db, {
-        dispatchId: 'ctx_old',
-        messageId: 'message_old',
-        payload: JSON.stringify({ from: 'home', subject: 'Instruction', body: '', type: 'message' })
-      })
-    ).toThrow('Run not found:')
-    expect(db.getMessageById('message_old')).toBeUndefined()
+    const stubRunId = federatedStubHomeRunId('ctx_old')
+    expect(db.getRemoteDispatchAttachment('ctx_old')?.home_run_id).toBe(stubRunId)
+    expect(db.getRunRaw(stubRunId)).toMatchObject({ home_database: 'remote', legacy: 0 })
+    importInstruction('ctx_old', 'message_old')
+    expect(db.getMessageById('message_old')?.run_id).toBe(stubRunId)
+  })
+
+  it('mints a stub home Run when a v1.4.198 coordinator attaches without a Run id', () => {
+    db.createRemoteDispatchAttachment({
+      dispatchId: 'ctx_legacy_home',
+      taskId: 'task_legacy_home',
+      homePeerFingerprint: 'home',
+      protocolVersion: ORCHESTRATION_CONTRACT_VERSION,
+      runtimeEpoch: 'epoch',
+      mutationReceipt: {
+        callerFingerprint: 'home',
+        requestId: 'request_legacy_home',
+        method: 'orchestration.federationAttachStart',
+        payloadHash: 'legacy_home_payload'
+      }
+    })
+    const stubRunId = federatedStubHomeRunId('ctx_legacy_home')
+    expect(db.getRemoteDispatchAttachment('ctx_legacy_home')?.home_run_id).toBe(stubRunId)
+    importInstruction('ctx_legacy_home', 'message_legacy_home')
+    expect(db.getMessageById('message_legacy_home')?.run_id).toBe(stubRunId)
   })
 })

--- a/src/main/runtime/orchestration/db/schema/federated-home-run-migration.test.ts
+++ b/src/main/runtime/orchestration/db/schema/federated-home-run-migration.test.ts
@@ -1,7 +1,10 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../../shared/protocol-version'
 import { OrchestrationDb } from '../orchestration-db'
-import { federatedStubHomeRunId } from '../contract-constants'
+import { SCHEMA_VERSION, federatedStubHomeRunId } from '../contract-constants'
 import { migrateV40 } from './migrate-v40'
 import { importFederatedControlMessage } from '../../federation-control-message'
 
@@ -12,14 +15,31 @@ describe('federated home Run migration', () => {
   })
   afterEach(() => db.close())
 
-  function importInstruction(dispatchId: string, messageId: string): void {
+  function importInstruction(target: OrchestrationDb, dispatchId: string, messageId: string): void {
     expect(
-      importFederatedControlMessage(db, {
+      importFederatedControlMessage(target, {
         dispatchId,
         messageId,
         payload: JSON.stringify({ from: 'home', subject: 'Instruction', body: '', type: 'status' })
       })
     ).toEqual({ imported: true, type: 'status' })
+  }
+
+  function attachWithoutRunId(target: OrchestrationDb, dispatchId: string, runId?: string): void {
+    target.createRemoteDispatchAttachment({
+      dispatchId,
+      runId,
+      taskId: `task_${dispatchId}`,
+      homePeerFingerprint: 'home',
+      protocolVersion: ORCHESTRATION_CONTRACT_VERSION,
+      runtimeEpoch: 'epoch',
+      mutationReceipt: {
+        callerFingerprint: 'home',
+        requestId: `request_${dispatchId}`,
+        method: 'orchestration.federationAttachStart',
+        payloadHash: `payload_${dispatchId}`
+      }
+    })
   }
 
   it('backfills a pre-upgrade attachment with a stub home Run that keeps its mailbox', () => {
@@ -31,27 +51,55 @@ describe('federated home Run migration', () => {
     const stubRunId = federatedStubHomeRunId('ctx_old')
     expect(db.getRemoteDispatchAttachment('ctx_old')?.home_run_id).toBe(stubRunId)
     expect(db.getRunRaw(stubRunId)).toMatchObject({ home_database: 'remote', legacy: 0 })
-    importInstruction('ctx_old', 'message_old')
+    importInstruction(db, 'ctx_old', 'message_old')
     expect(db.getMessageById('message_old')?.run_id).toBe(stubRunId)
   })
 
   it('mints a stub home Run when a v1.4.198 coordinator attaches without a Run id', () => {
-    db.createRemoteDispatchAttachment({
-      dispatchId: 'ctx_legacy_home',
-      taskId: 'task_legacy_home',
-      homePeerFingerprint: 'home',
-      protocolVersion: ORCHESTRATION_CONTRACT_VERSION,
-      runtimeEpoch: 'epoch',
-      mutationReceipt: {
-        callerFingerprint: 'home',
-        requestId: 'request_legacy_home',
-        method: 'orchestration.federationAttachStart',
-        payloadHash: 'legacy_home_payload'
-      }
-    })
+    attachWithoutRunId(db, 'ctx_legacy_home')
     const stubRunId = federatedStubHomeRunId('ctx_legacy_home')
     expect(db.getRemoteDispatchAttachment('ctx_legacy_home')?.home_run_id).toBe(stubRunId)
-    importInstruction('ctx_legacy_home', 'message_legacy_home')
+    importInstruction(db, 'ctx_legacy_home', 'message_legacy_home')
     expect(db.getMessageById('message_legacy_home')?.run_id).toBe(stubRunId)
+  })
+
+  it('rejects a whitespace-only Run id instead of minting a stub', () => {
+    expect(() => attachWithoutRunId(db, 'ctx_blank', '   ')).toThrow('Missing Run ID')
+    expect(db.getRemoteDispatchAttachment('ctx_blank')).toBeUndefined()
+  })
+
+  it('repairs rows a rolled-back v1.4.198 host inserted after user_version reached 40', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-federated-home-run-'))
+    const dbPath = join(dir, 'orchestration.db')
+    try {
+      const upgraded = new OrchestrationDb(dbPath)
+      expect(upgraded.db.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
+      // v1.4.198's insert shape: no home_run_id column, so the DEFAULT '' lands.
+      upgraded.db.exec(`INSERT INTO remote_dispatch_attachments
+        (dispatch_id, task_id, home_peer_fingerprint, runtime_epoch)
+        VALUES ('ctx_rolled_back', 'task_rolled_back', 'home', 'epoch')`)
+      expect(upgraded.getRemoteDispatchAttachment('ctx_rolled_back')?.home_run_id).toBe('')
+      expect(() =>
+        importFederatedControlMessage(upgraded, {
+          dispatchId: 'ctx_rolled_back',
+          messageId: 'message_refused',
+          payload: JSON.stringify({ from: 'home', subject: 'x', body: '', type: 'status' })
+        })
+      ).toThrow(/Run not found/)
+      upgraded.close()
+
+      const reopened = new OrchestrationDb(dbPath)
+      try {
+        const stubRunId = federatedStubHomeRunId('ctx_rolled_back')
+        expect(reopened.getRemoteDispatchAttachment('ctx_rolled_back')?.home_run_id).toBe(stubRunId)
+        expect(reopened.getRunRaw(stubRunId)).toMatchObject({ home_database: 'remote', legacy: 0 })
+        importInstruction(reopened, 'ctx_rolled_back', 'message_rolled_back')
+        expect(reopened.getMessageById('message_rolled_back')?.run_id).toBe(stubRunId)
+      } finally {
+        reopened.close()
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/runtime/orchestration/db/schema/migrate-v40.ts
+++ b/src/main/runtime/orchestration/db/schema/migrate-v40.ts
@@ -1,11 +1,23 @@
 import type { OrchestrationDb } from '../orchestration-db'
+import { FEDERATED_STUB_HOME_RUN_ID_PREFIX } from '../contract-constants'
 
 export function migrateV40(this: OrchestrationDb, current: number): void {
-  if (current >= 40 || this.hasColumn('remote_dispatch_attachments', 'home_run_id')) {
+  if (current >= 40) {
     return
   }
-  // Federation is unreleased; any development-only rows fail Run validation until reattached.
-  this.db.exec(
-    "ALTER TABLE remote_dispatch_attachments ADD COLUMN home_run_id TEXT NOT NULL DEFAULT ''"
-  )
+  if (!this.hasColumn('remote_dispatch_attachments', 'home_run_id')) {
+    this.db.exec(
+      "ALTER TABLE remote_dispatch_attachments ADD COLUMN home_run_id TEXT NOT NULL DEFAULT ''"
+    )
+  }
+  // Why: workers attached by v1.4.198 keep a mailbox; without a Run their control mail is refused.
+  this.db.exec(`
+    INSERT OR IGNORE INTO runs (id, objective, home_database, consumer_generation, legacy)
+    SELECT '${FEDERATED_STUB_HOME_RUN_ID_PREFIX}' || dispatch_id,
+           'Coordinated from ' || home_peer_fingerprint, 'remote', 0, 0
+    FROM remote_dispatch_attachments WHERE home_run_id = '';
+    UPDATE remote_dispatch_attachments
+    SET home_run_id = '${FEDERATED_STUB_HOME_RUN_ID_PREFIX}' || dispatch_id
+    WHERE home_run_id = '';
+  `)
 }

--- a/src/main/runtime/orchestration/db/schema/migrate-v40.ts
+++ b/src/main/runtime/orchestration/db/schema/migrate-v40.ts
@@ -1,5 +1,5 @@
 import type { OrchestrationDb } from '../orchestration-db'
-import { FEDERATED_STUB_HOME_RUN_ID_PREFIX } from '../contract-constants'
+import { backfillFederatedStubHomeRuns } from '../federation/federated-stub-home-run-backfill'
 
 export function migrateV40(this: OrchestrationDb, current: number): void {
   if (current >= 40) {
@@ -11,13 +11,5 @@ export function migrateV40(this: OrchestrationDb, current: number): void {
     )
   }
   // Why: workers attached by v1.4.198 keep a mailbox; without a Run their control mail is refused.
-  this.db.exec(`
-    INSERT OR IGNORE INTO runs (id, objective, home_database, consumer_generation, legacy)
-    SELECT '${FEDERATED_STUB_HOME_RUN_ID_PREFIX}' || dispatch_id,
-           'Coordinated from ' || home_peer_fingerprint, 'remote', 0, 0
-    FROM remote_dispatch_attachments WHERE home_run_id = '';
-    UPDATE remote_dispatch_attachments
-    SET home_run_id = '${FEDERATED_STUB_HOME_RUN_ID_PREFIX}' || dispatch_id
-    WHERE home_run_id = '';
-  `)
+  backfillFederatedStubHomeRuns(this.db)
 }

--- a/src/main/runtime/orchestration/orchestration-federated-legacy-probe.test.ts
+++ b/src/main/runtime/orchestration/orchestration-federated-legacy-probe.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { LEGACY_RUN_ID, OrchestrationDb } from './db'
-import { SCHEMA_VERSION } from './db/contract-constants'
+import { federatedStubHomeRunId, SCHEMA_VERSION } from './db/contract-constants'
 import { resolveOrchestrationMigrationStartVersion } from './orchestration-schema-version-skew'
 
 describe('federated mailbox legacy-adoption probe', () => {
@@ -17,15 +17,22 @@ describe('federated mailbox legacy-adoption probe', () => {
     }
   })
 
-  function seedMailbox(handle: string, kind: 'message' | 'delivery'): string {
+  function seedMailbox(
+    handle: string,
+    kind: 'message' | 'delivery',
+    homeRunId = 'run_home',
+    mailRunId = LEGACY_RUN_ID
+  ): string {
     directory = mkdtempSync(join(tmpdir(), 'orca-federated-legacy-probe-'))
     const path = join(directory, 'orchestration.db')
     db = new OrchestrationDb(path)
-    db.db.exec(`
-      INSERT INTO remote_dispatch_attachments (
-        dispatch_id, task_id, home_peer_fingerprint, home_run_id, runtime_epoch, state
-      ) VALUES ('ctx_remote', 'task_remote', 'peer_home', 'run_home', 'epoch', 'ready');
-    `)
+    db.db
+      .prepare(
+        `INSERT INTO remote_dispatch_attachments (
+           dispatch_id, task_id, home_peer_fingerprint, home_run_id, runtime_epoch, state
+         ) VALUES ('ctx_remote', 'task_remote', 'peer_home', ?, 'epoch', 'ready')`
+      )
+      .run(homeRunId)
     if (kind === 'message') {
       db.db
         .prepare(
@@ -33,14 +40,14 @@ describe('federated mailbox legacy-adoption probe', () => {
              id, run_id, delivery_contract, from_handle, to_handle, subject, type
            ) VALUES ('msg_probe', ?, 'current_delivery', 'term_home', ?, 'continue', 'dispatch')`
         )
-        .run(LEGACY_RUN_ID, handle)
+        .run(mailRunId, handle)
     } else {
       db.db
         .prepare(
           `INSERT INTO deliveries (id, run_id, mailbox_handle, consumer_generation, message_ids)
            VALUES ('delivery_probe', ?, ?, 0, '[]')`
         )
-        .run(LEGACY_RUN_ID, handle)
+        .run(mailRunId, handle)
     }
     return path
   }
@@ -67,6 +74,27 @@ describe('federated mailbox legacy-adoption probe', () => {
           status: 'outstanding'
         })
       }
+    }
+  )
+
+  it.each(['message', 'delivery'] as const)(
+    'does not treat a stub-home-Run attachment %s as pre-Runs evidence',
+    (kind) => {
+      const stubRunId = federatedStubHomeRunId('ctx_remote')
+      const path = seedMailbox('dispatch:ctx_remote', kind, stubRunId, stubRunId)
+      db!.db
+        .prepare(
+          `INSERT INTO runs (id, objective, home_database, consumer_generation, legacy)
+           VALUES (?, 'Coordinated from peer_home', 'remote', 0, 0)`
+        )
+        .run(stubRunId)
+      expect(
+        resolveOrchestrationMigrationStartVersion(db!.db, SCHEMA_VERSION, SCHEMA_VERSION)
+      ).toBe(SCHEMA_VERSION)
+      db!.close()
+      db = new OrchestrationDb(path)
+      expect(db.getLegacyAdoption()).toBeUndefined()
+      expect(db.getRemoteDispatchAttachment('ctx_remote')?.home_run_id).toBe(stubRunId)
     }
   )
 

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-start-schema.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-start-schema.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { FederationAttachStartParams } from './federation-start-schema'
+
+// The request shape a v1.4.198 coordinator sends: no runId field at all.
+const legacyRequest = {
+  dispatchId: 'ctx_legacy',
+  taskId: 'task_legacy',
+  taskSpec: 'Do the thing',
+  protocolVersion: 3,
+  worktree: 'feature-branch'
+}
+
+describe('FederationAttachStartParams', () => {
+  it('parses a v1.4.198 request that carries no runId', () => {
+    const result = FederationAttachStartParams.safeParse(legacyRequest)
+    expect(result.success, result.success ? undefined : JSON.stringify(result.error.issues)).toBe(
+      true
+    )
+    expect(result.success && result.data.runId).toBeUndefined()
+  })
+
+  it('keeps a v1.4.199 runId verbatim', () => {
+    const result = FederationAttachStartParams.parse({ ...legacyRequest, runId: 'run_home' })
+    expect(result.runId).toBe('run_home')
+  })
+
+  // Pins OptionalString: '' and non-strings drop to undefined (a stub Run is minted downstream);
+  // whitespace-only passes the schema and is refused by createRemoteDispatchAttachment.
+  it('maps an empty or non-string runId to undefined but passes whitespace through', () => {
+    expect(FederationAttachStartParams.parse({ ...legacyRequest, runId: '' }).runId).toBeUndefined()
+    expect(FederationAttachStartParams.parse({ ...legacyRequest, runId: 7 }).runId).toBeUndefined()
+    expect(FederationAttachStartParams.parse({ ...legacyRequest, runId: '   ' }).runId).toBe('   ')
+  })
+
+  it('still requires the dispatch, task, spec, and worktree fields', () => {
+    for (const field of ['dispatchId', 'taskId', 'taskSpec', 'worktree'] as const) {
+      const { [field]: _dropped, ...rest } = legacyRequest
+      expect(FederationAttachStartParams.safeParse(rest).success, field).toBe(false)
+    }
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-start-schema.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-start-schema.ts
@@ -3,7 +3,8 @@ import { OptionalFiniteNumber, OptionalString, requiredString } from '../../../s
 import { OptionalWorkerLaunchPreference } from '../worker/worker-start-schema'
 
 export const FederationAttachStartParams = z.object({
-  runId: requiredString('Missing Run ID'),
+  /** Omitted by v1.4.198 coordinators; the worker host then mints a stub home Run. */
+  runId: OptionalString,
   dispatchId: requiredString('Missing Dispatch ID'),
   taskId: requiredString('Missing Task ID'),
   taskSpec: requiredString('Missing Task spec'),


### PR DESCRIPTION
## ELI5

Orca can run a worker agent on another machine (`orca orchestration worker-start --on <saved-environment>`). The machine that starts it is the **coordinator**; the machine that runs it is the **worker host**.

#19542 fixed a real bug in how the worker host files mail for those workers, but it assumed this cross-machine feature had never shipped. It had (it is in v1.4.198). So after #19542, three things go wrong when the two machines are on different versions:

1. **A coordinator on v1.4.198 can no longer start workers on a host that has updated to v1.4.199.** The host answers `Missing Run ID`, because the old coordinator never sends that field.
2. **Workers that were already running when the host updated go silent.** The update stamps their bookkeeping rows with an empty run id, and every mail operation for them fails from then on. The agent keeps working, but the coordinator never hears it finish.
3. **Rolling the host back to v1.4.198 can fail** if its database was first created by v1.4.199, because the new column has no default.

This PR makes the updated host tolerate all three: it accepts the older request shape, gives pre-existing workers a working mailbox again during the update, and gives the column a safe default. Once both machines are on v1.4.199 nothing changes; the new path is byte-identical.

## How the fix works, in plain terms

Every piece of orchestration mail has to be filed under a **Run** (a coordinator's job). #19542 requires the worker host to know which Run a remote worker belongs to, and it made the coordinator responsible for saying so. An older coordinator does not know how to say so, and rows written before the update never had it recorded.

The fix gives the worker host a way to name that Run itself when nobody told it:

1. **Old coordinator starts a worker.** The host sees the request has no Run id. Instead of refusing, it creates a small placeholder Run named after the dispatch (`run_federated_<dispatchId>`), the same way #19542 already creates a Run row for a real id, and files the worker under it. The coordinator on the other machine never needs to know; it keeps its own real Run locally, as it always did.
2. **Host updates with workers already running.** During the one-time database migration, each existing worker row gets the same placeholder Run created and assigned, instead of an empty id. So when that worker later sends "done" or the coordinator checks on it, the lookup finds a Run and the mail flows.
3. **Host rolls back.** The column now has a default, so the older build's insert (which does not mention the column) succeeds. The same placeholder-Run repair from step 2 also runs every time the database is opened, so rows the rolled-back build wrote with an empty id are fixed the next time the updated build starts, even though the one-time migration has already run.

Why a placeholder Run is safe: the bug #19542 fixed was that mail filed under the *legacy* Run name looked like an old-style database and triggered a destructive cleanup on restart. The placeholder names here can never match that legacy name, and there is a new test that proves the cleanup does not fire on them.

## What Changed

- `runId` is **optional** on `orchestration.federationAttachStart`. When an older coordinator omits it, the worker host mints a deterministic stub Run per attachment (`run_federated_<dispatchId>`) through the same `INSERT OR IGNORE INTO runs` path #19542 already uses for real ids. (`federation-start-schema.ts`, `remote-dispatch-attachment-create.ts`, `contract-constants.ts`)
- `migrate-v40` backfills existing attachment rows with that stub id and inserts the stub `runs` rows in one set-based statement, instead of leaving them at `''`. In-flight workers keep a resolvable mailbox across the update.
- The two backfill statements now live in `backfillFederatedStubHomeRuns` (`db/federation/federated-stub-home-run-backfill.ts`) and run from **both** `migrate-v40` and the `OrchestrationDb` constructor right after `migrate()`, next to the existing on-open `rememberCurrentRunCoordinatorHandles` repair. Both statements are idempotent (`WHERE home_run_id = ''`, `INSERT OR IGNORE`), so an open with nothing to fix is a no-op.
- `create-graph-tables-sql.ts` gives `home_run_id` a `DEFAULT ''` so a rolled-back v1.4.198 host can still insert into a v1.4.199-created table.
- No resolver layer. `check-worker.ts`, `federation-control-message.ts`, and `message-insert.ts` are untouched: a stub Run satisfies their existing `requireRun`.

## Why this does not bring back the bug #19542 fixed

#19542 removed the `?? LEGACY_RUN_ID` fallthrough because a live attachment row filed under `run_legacy_local` made the legacy-adoption probe replay a destructive adoption after restart. Stub ids are `run_federated_<dispatchId>`, never `run_legacy_local`, so stub-Run mail never matches the probe's source-graph query. The attachment-mailbox exclusion #19542 added to `hasConsistentLegacyAdoption` is untouched. A new negative test (`orchestration-federated-legacy-probe.test.ts`, message and delivery variants) seeds a stub-Run attachment with mail and asserts the probe returns `SCHEMA_VERSION` and that reopening creates no `legacy_adoptions` row. The "still replays adoption for a genuine legacy database" cases still pass, so the guard is not over-broad.

## Wire compatibility

One required field made optional on a host-side RPC params schema: Rule 1 of `docs/reference/remote-wire-compatibility.md`. A v1.4.199 coordinator still always sends `runId`. No stream opcode, no published-content change, no capability negotiation. `SCHEMA_VERSION` stays 40.

## Why

Mixed client and host versions are the normal state for paired machines. Federation is released, so the host must keep accepting the shipped request shape and must not strand attachments it already holds.

## Linked Issue

No tracking issue exists; this is a regression from #19542 found while scanning the 1.4.199 release candidate. Happy to file one if wanted.

## Visual Proof

N/A: RPC schema, SQLite migration, and create-table DDL only.

## Testing

- `ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts` over every test file #19542 touched plus the whole `src/main/runtime/rpc/methods/orchestration/federation/` directory: **76 files / 638 tests passed** (`vitest list --filesOnly` confirmed exactly 76 files matched, including all 16 federation RPC tests). Four files from #19542's list no longer exist on main; they were deleted by #19544 and #19608, not renamed.
- The two modified test files at the final head: 2 files / 8 tests passed.
- Second commit (`13a6cda25d`): `ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/db/schema/federated-home-run-migration.test.ts src/main/runtime/rpc/methods/orchestration/federation/federation-start-schema.test.ts`: **2 files / 8 tests passed** (4 migration cases including the on-open repair and a whitespace-only `runId` refusal; 4 schema cases). Ablation: commenting out the constructor call makes the on-open repair test fail on `expected '' to be 'run_federated_ctx_rolled_back'`, so the test depends on the new call.
- Same commit, wider run: the migration test, `orchestration-federated-legacy-probe.test.ts`, `orchestration-all-start-versions-migration.test.ts`, `db/writer-run-required.test.ts`, and the whole `src/main/runtime/rpc/methods/orchestration/federation/` directory: **21 files / 128 tests passed**.
- Same commit: `pnpm run check:code-quality:changed` 0 new findings across 10 changed files; `pnpm exec tsc --noEmit -p config/tsconfig.node.json` clean; `pnpm exec oxfmt --check` on the 5 changed files clean.
- `pnpm run check:code-quality:changed`: 0 new findings across 7 changed files.
- `pnpm exec tsc --noEmit -p config/tsconfig.node.json`: clean.
- `pnpm exec oxfmt --check` on the changed files: clean.
- Not run: `tests/e2e/cross-version-wire/*` (covers the terminal stream and `agentSession.*`, not federation RPC); no live two-host, two-version run.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

### Known gaps (same as #19542 alone, not worsened)

(a) Control mail that a v1.4.198 worker host had already imported under `run_legacy_local` is not re-filed under the stub; the migration deliberately does not rewrite `messages`/`deliveries` rows. That has two visible effects after the host updates. First, `check-worker` reads mail by the attachment's `home_run_id`, so mail filed under the old legacy name is invisible to it. Second, if the coordinator retries the same message id, the host now answers `request_mismatch`: `federation-control-message.ts` compares the existing row's `run_id` with the attachment's (now stub) Run and treats the difference as a conflicting message. Both effects exist with #19542 alone; this PR does not add to them.

(b) Rolled-back host re-attaching workers, then updating again: **closed in this PR** by the on-open repair. The empty-id rows now only exist while the rolled-back v1.4.198 build is running; the first start of the updated build repairs them, and the migration's `user_version` no longer matters.

(c) `OptionalString` maps `''` to `undefined`, so a new coordinator with a bug that sends `runId: ''` silently gets a stub Run instead of an error. `schemas.ts` has no "optional but must be non-empty when present" helper (`OptionalPlainString` keeps `''`, `OptionalString` drops it), so this is left as-is rather than adding a one-off helper; the schema test pins the current behaviour. A whitespace-only `runId` still fails with `Missing Run ID` at the DB layer.

Release: candidate cherry-pick for the 1.4.199 release branch `release/adhoc-1.4.199-daily-202609081832-cherrypicks`. Owner review requested from @Jinwoo-H (author of #19542).

## Review

Please challenge whether a stub Run per attachment is the right shape. Gap (b) is now closed here by the on-open repair; please check that repair is the right place for it versus a v41 migration.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

The DB layer is host-agnostic (native, WSL, and SSH hosts share it). No platform-specific code.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

