### PR TITLE
fix(sidebar): never label a worker row with the worker-task_ placeholder

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration/federation/federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation.ts
@@ -1,3 +1,4 @@
+import { buildOrchestrationWorkerTerminalTitle } from '../../../../../../shared/orchestration-worker-terminal-title'
 import type { TuiAgent } from '../../../../../../shared/tui-agent'
 import { buildDispatchPreamble } from '../../../../orchestration/preamble'
 import { OrchestrationError } from '../../../../orchestration/orchestration-error'
@@ -182,7 +183,7 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
               // its CLI is `cursor-agent`); resolve through the TUI agent config.
               startupAgent: agent as TuiAgent,
               ...(launch.preferences ? { launchPreferences: launch.preferences } : {}),
-              title: `worker-${params.taskId}`,
+              title: buildOrchestrationWorkerTerminalTitle(params.taskId),
               presentation: 'background'
             })
             terminalHandle = terminal.handle

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-topology.ts
@@ -1,5 +1,6 @@
 import type { AgentLaunchPreferences } from '../../../../../../shared/agent-session-host-authority'
 import { narrowStructuredLaunchSeedOptions } from '../../../../../../shared/native-chat-session-option-defaults'
+import { buildOrchestrationWorkerTerminalTitle } from '../../../../../../shared/orchestration-worker-terminal-title'
 import type { TuiAgent } from '../../../../../../shared/tui-agent'
 import type { OrcaRuntimeService } from '../../../../orca-runtime'
 import type { OrchestrationDb } from '../../../../orchestration/db'
@@ -70,7 +71,7 @@ export async function createExistingWorktreeWorkerTerminal(args: {
     // configured launcher instead of executing the raw id.
     startupAgent: args.agent,
     ...(args.launchPreferences ? { launchPreferences: args.launchPreferences } : {}),
-    title: `worker-${args.taskId}`,
+    title: buildOrchestrationWorkerTerminalTitle(args.taskId),
     // Why: dispatching a worker is background work; it must not pull the sidebar
     // to the worker's workspace while the user is reading somewhere else.
     surfaceOwner: false

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
@@ -233,6 +233,28 @@ describe('useAgentRowConversationName', () => {
       )
     })
 
+    it('yields no name for a worker pane still on the dispatch placeholder', () => {
+      // Why: a dispatched worker pane is titled `worker-task_<id>` until its
+      // agent titles itself; the row must fall back to the task name and must
+      // not borrow the sibling pane's title from the tab snapshot.
+      storeState.current = {
+        settings: {},
+        tabsByWorktree: {
+          'wt-1': [
+            { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '\u2733 Linear work log' }
+          ]
+        },
+        terminalLayoutsByTabId: { 'tab-1': SPLIT_LAYOUT },
+        runtimePaneTitlesByTabId: {
+          'tab-1': { 1: '\u2733 Linear work log', 2: 'worker-task_f6116b98166e' }
+        }
+      }
+      expect(useAgentRowConversationName(splitRow(LEAF_A, '\u2733 Linear work log'))).toBe(
+        'Linear work log'
+      )
+      expect(useAgentRowConversationName(splitRow(LEAF_B, '\u2733 Linear work log'))).toBeNull()
+    })
+
     it('leaves a single-leaf tab on its tab title', () => {
       storeState.current = {
         settings: {},
@@ -250,6 +272,38 @@ describe('useAgentRowConversationName', () => {
         'Redis cache'
       )
     })
+  })
+
+  it('yields no name for a single-pane worker tab on the dispatch placeholder', () => {
+    storeState.current = {
+      settings: {},
+      tabsByWorktree: {
+        'wt-1': [
+          { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: 'worker-task_f6116b98166e' }
+        ]
+      }
+    }
+    const worker = makeAgent({
+      tab: { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: 'worker-task_f6116b98166e' }
+    } as Partial<DashboardAgentRow>)
+    expect(useAgentRowConversationName(worker)).toBeNull()
+  })
+
+  it('keeps a manual rename ahead of the dispatch placeholder', () => {
+    storeState.current = {
+      settings: {},
+      tabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'tab-1',
+            worktreeId: 'wt-1',
+            customTitle: 'Patient sync spike',
+            title: 'worker-task_f6116b98166e'
+          }
+        ]
+      }
+    }
+    expect(useAgentRowConversationName(makeAgent())).toBe('Patient sync spike')
   })
 
   it('honors the generated-titles setting for generated names', () => {

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -65,6 +65,61 @@ describe('getAgentRowConversationName', () => {
     expect(getAgentRowConversationName(generated, 'claude', true, null)).toBe('Fix intake flow')
   })
 
+  it('rejects the dispatch worker placeholder so the task name can show instead', () => {
+    // Why: a worker pane carries `worker-task_<id>` until its agent titles
+    // itself; surfacing it would hide the orchestration task name.
+    expect(
+      getAgentRowConversationName(makeTab({ title: 'worker-task_f6116b98166e' }), 'claude', false)
+    ).toBeNull()
+    // A remote host mints its own ids, so the shape is matched, not a known id.
+    expect(
+      getAgentRowConversationName(makeTab({ title: 'worker-task_remote-1' }), 'codex', false)
+    ).toBeNull()
+    expect(
+      getAgentRowConversationName(
+        makeTab({ title: '\u2733 worker-task_f6116b98166e' }),
+        'claude',
+        false
+      )
+    ).toBeNull()
+    // A real title that merely starts with the same word is still a name.
+    expect(
+      getAgentRowConversationName(makeTab({ title: 'worker-task_ retry policy' }), 'claude', false)
+    ).toBe('worker-task_ retry policy')
+    expect(
+      getAgentRowConversationName(makeTab({ title: 'worker-pool sizing' }), 'claude', false)
+    ).toBe('worker-pool sizing')
+  })
+
+  it('keeps names above the worker placeholder without crossing panes', () => {
+    const tab = makeTab({
+      customTitle: 'Patient sync spike',
+      title: 'worker-task_f6116b98166e'
+    })
+    expect(getAgentRowConversationName(tab, 'claude', false)).toBe('Patient sync spike')
+    const quick = makeTab({ quickCommandLabel: 'Run tests', title: 'worker-task_f6116b98166e' })
+    expect(getAgentRowConversationName(quick, 'claude', false)).toBe('Run tests')
+    const generated = makeTab({
+      generatedTitle: 'Fix intake flow',
+      title: 'worker-task_f6116b98166e'
+    })
+    expect(getAgentRowConversationName(generated, 'claude', true)).toBe('Fix intake flow')
+    // Split panes: a placeholder pane yields null rather than borrowing the
+    // sibling tab title, and a real sibling pane title still wins.
+    const split = makeTab({ title: 'Linear work log' })
+    expect(
+      getAgentRowConversationName(split, 'claude', false, 'worker-task_f6116b98166e')
+    ).toBeNull()
+    expect(
+      getAgentRowConversationName(
+        makeTab({ title: 'worker-task_f6116b98166e' }),
+        'claude',
+        false,
+        'Redis cache strategy'
+      )
+    ).toBe('Redis cache strategy')
+  })
+
   it('strips leading status decoration from agent-set titles', () => {
     expect(
       getAgentRowConversationName(makeTab({ title: '✳ Fix patient intake flow' }), 'claude', false)

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -10,6 +10,7 @@ import { isClaudeManagementTitle } from './agent-title-core'
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { formatAgentTypeLabel } from './agent-type-label'
 import { isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
+import { isOrchestrationWorkerTerminalTitle } from './orchestration-worker-terminal-title'
 import { SYNTHETIC_AGENT_TITLE_PROFILES } from './synthetic-agent-title'
 import type { TerminalTab } from './terminal-tab-types'
 
@@ -96,7 +97,11 @@ function conversationNameFromLiveTitle(
     STATUS_WITH_CONTEXT_RE.test(stripped) ||
     DEFAULT_TERMINAL_TITLE_RE.test(stripped) ||
     isClaudeManagementTitle(stripped) ||
-    isCwdLikeTitle(stripped)
+    isCwdLikeTitle(stripped) ||
+    // Why: `worker-task_…` is the dispatch placeholder a worker pane carries
+    // until its agent titles itself. Preferring it would hide the orchestration
+    // task name the row falls back to.
+    isOrchestrationWorkerTerminalTitle(stripped)
   ) {
     return null
   }

--- a/src/shared/orchestration-worker-terminal-title.test.ts
+++ b/src/shared/orchestration-worker-terminal-title.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildOrchestrationWorkerTerminalTitle,
+  isOrchestrationWorkerTerminalTitle
+} from './orchestration-worker-terminal-title'
+
+describe('orchestration worker terminal title', () => {
+  it('recognises every title it builds', () => {
+    for (const taskId of ['task_f6116b98166e', 'task_remote-1', 'task_ABC_123']) {
+      expect(
+        isOrchestrationWorkerTerminalTitle(buildOrchestrationWorkerTerminalTitle(taskId))
+      ).toBe(true)
+    }
+  })
+
+  it('does not claim titles that merely start the same way', () => {
+    for (const title of [
+      'worker-pool sizing',
+      'worker-task_ retry policy',
+      'worker-task_',
+      'worker-run_f6116b98166e',
+      'the worker-task_f6116b98166e pane'
+    ]) {
+      expect(isOrchestrationWorkerTerminalTitle(title)).toBe(false)
+    }
+  })
+})

--- a/src/shared/orchestration-worker-terminal-title.ts
+++ b/src/shared/orchestration-worker-terminal-title.ts
@@ -1,0 +1,18 @@
+// The title a dispatched worker terminal is created with, before its agent
+// publishes one of its own. It identifies the pane for `terminal ls` and logs;
+// it is an infrastructure handle, not a conversation name, so name resolution
+// must recognise and reject it (agent-row-conversation-name.ts).
+const ORCHESTRATION_WORKER_TERMINAL_TITLE_RE = /^worker-task_[A-Za-z0-9_-]+$/
+
+export function buildOrchestrationWorkerTerminalTitle(taskId: string): string {
+  return `worker-${taskId}`
+}
+
+/**
+ * Whether `title` is the placeholder above. Matched by shape rather than by a
+ * known task id: a paired remote host mints its own ids and may be older than
+ * this client, so the client can never enumerate the ids it will be sent.
+ */
+export function isOrchestrationWorkerTerminalTitle(title: string): boolean {
+  return ORCHESTRATION_WORKER_TERMINAL_TITLE_RE.test(title)
+}


### PR DESCRIPTION
## Problem

A dispatched worker terminal is created with `title: worker-${taskId}` (`worker-topology.ts`, `federation.ts`) so the pane is identifiable in `terminal ls` and logs. `createTerminal` writes that into the pty's **live** title, and `getAgentRowConversationName` accepted any non-status live title as a conversation name. The sidebar row therefore showed `worker-task_f6116b98166e` instead of the semantic orchestration task name it otherwise falls back to (`getAgentRowPrimaryText` → `orchestration.displayName` → `taskTitle` → TASK-body preview).

The placeholder outlives the dispatch for any agent that never publishes a title of its own — notably hook-less agents over SSH, which is exactly where the row label matters most.

## Fix

Classify the placeholder the way the resolver already classifies every other non-name live title (`'Agent'`, identity/status echoes, spinner+cwd paths): it yields `null`, so the caller keeps its own label.

- New `src/shared/orchestration-worker-terminal-title.ts` holds both the builder and the recogniser, so the two emit sites and the resolver cannot drift apart.
- Matched by **shape**, not by a known task id. A paired remote or SSH host mints its own ids and may be an older build, so the client can never enumerate the ids it will be sent. No wire change, no capability negotiation, and mixed-version pairs are covered.

Priority is unchanged and re-pinned by tests: manual rename → quick-command label → OpenCode session title → generated title → live title. A split pane that rejects its own placeholder yields `null` rather than borrowing the sibling's tab title, preserving per-pane identity.

## Not done, deliberately

Titling the terminal with the task title at the emit site instead. It would leave every already-running worker and every older paired host still showing the placeholder, and it would put an unbounded user string where a stable pane identifier is wanted.

## Tests

- `src/shared/orchestration-worker-terminal-title.test.ts` — round-trip, and negatives (`worker-pool sizing`, `worker-run_…`, embedded occurrences).
- `src/shared/agent-row-conversation-name.test.ts` — placeholder rejected (including behind a spinner decoration and with a remote-shaped id); custom/quick-command/generated titles still win; split-pane placeholder yields `null` and does not borrow the sibling title.
- `src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts` — same at the hook level, single-pane and split-pane.

## Verification

- `pnpm tc` — clean
- `pnpm test src/shared/` — 678 files, 7544 passed
- `pnpm test src/main/runtime/rpc/methods/orchestration/` — 70 files, 637 passed
- `pnpm test src/renderer/src/components/dashboard/ …` — 28 files, 218 passed
- `pnpm run check:code-quality:changed` — 0 new findings across 8 changed files
- `pnpm format`

No Electron run: the change is pure label resolution and is pinned at both the resolver and hook layers; reproducing it live needs a real dispatched worker inside a running app.

## Overlap with #19614

That PR inserts a saved-AI-Vault-title branch between the OpenCode check and the generated-title check in `getAgentRowConversationName`. This PR only adds a predicate to `conversationNameFromLiveTitle`'s rejection list plus an import. Different regions of the same file; either order rebases cleanly, and the saved title sits above the live title so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014s2fqqx2F2sbCsRJ36Uiyn