### PR TITLE
fix(i18n): interpolate the settings-search empty-state query instead of concatenating translated fragments

### DIFF
--- a/config/scripts/locale-cross-locale-key-overrides.mjs
+++ b/config/scripts/locale-cross-locale-key-overrides.mjs
@@ -31,6 +31,13 @@ export const CROSS_LOCALE_KEY_OVERRIDES = {
     zh: '/{{value0}}',
     ja: '/{{value0}}'
   },
+  // Settings-search empty state. ko/zh put the quoted term before the verb phrase, so MT
+  // localized the old leading fragment as a whole clause and the query landed after the
+  // period. The message interpolates now; keep the term inside the quotes.
+  'auto.components.settings.Settings.noSettingsFoundForQuery': {
+    ko: '"{{value0}}"에 대한 설정을 찾을 수 없습니다.',
+    zh: '找不到“{{value0}}”的设置'
+  },
   'auto.components.settings.TasksPane.6b23a34f6d': {
     zh: 'Jira',
     ja: 'Jira'

--- a/config/scripts/locale-ko-key-overrides.json
+++ b/config/scripts/locale-ko-key-overrides.json
@@ -2618,9 +2618,6 @@
   "auto.components.settings.Settings.23931df7e8": {
     "ko": "원격 호스트"
   },
-  "auto.components.settings.Settings.3c88ec55d6": {
-    "ko": "\"에 대한 설정을 찾을 수 없습니다."
-  },
   "auto.components.settings.Settings.3d9adfe6a5": {
     "ko": "전역 terminal, 브라우저, Markdown 탭."
   },

--- a/src/renderer/src/components/settings/settings-page-renderer.tsx
+++ b/src/renderer/src/components/settings/settings-page-renderer.tsx
@@ -106,11 +106,10 @@ export function renderSettingsPage(context: SettingsRenderContext): React.JSX.El
             {navigation.visibleNavSections.length === 0 ? (
               <div className="flex min-h-[24rem] items-center justify-center rounded-2xl border border-dashed border-border/60 bg-card/30 text-sm text-muted-foreground">
                 {translate(
-                  'auto.components.settings.Settings.3c88ec55d6',
-                  'No settings found for "'
+                  'auto.components.settings.Settings.noSettingsFoundForQuery',
+                  'No settings found for "{{value0}}"',
+                  { value0: model.settingsSearchQuery.trim() }
                 )}
-                {model.settingsSearchQuery.trim()}
-                {translate('auto.components.settings.Settings.add3b97ee6', '"')}
               </div>
             ) : (
               <ActiveSettingsSectionProvider value={model.activeSectionId}>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8191,8 +8191,6 @@
           "ad6c529693": "AI Provider Accounts",
           "ec1ba547f7": "Manage AI agents, set a default, and customize commands.",
           "8afa676615": "Agents",
-          "add3b97ee6": "\"",
-          "3c88ec55d6": "No settings found for \"",
           "c7ad095d96": "Loading settings...",
           "acc7bbdefd": "Press ESC again to exit settings",
           "43b68e10f0": "You have unsaved Git AI Author changes. Leaving will discard them.",
@@ -8210,7 +8208,8 @@
           "devDescription": "Dev-only tools for exercising UI states.",
           "linearTitle": "Linear",
           "linearDescription": "How Linear works in Orca, setup checklist, agent skill, and example prompts.",
-          "tasksDescription": "Connect providers, install the Linear skill, and choose what appears in Tasks."
+          "tasksDescription": "Connect providers, install the Linear skill, and choose what appears in Tasks.",
+          "noSettingsFoundForQuery": "No settings found for \"{{value0}}\""
         },
         "SettingsFormControls": {
           "42a4d15a30": "No matching fonts.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -7050,8 +7050,6 @@
           "ad6c529693": "Cuentas de proveedores de IA",
           "ec1ba547f7": "Administra agentes de IA, define uno predeterminado y personaliza comandos.",
           "8afa676615": "Agentes",
-          "add3b97ee6": "\"",
-          "3c88ec55d6": "No se encontraron configuraciones para \"",
           "c7ad095d96": "Cargando ajustes...",
           "acc7bbdefd": "Presiona ESC de nuevo para salir de ajustes",
           "43b68e10f0": "Tienes cambios no guardados de Git AI Author. Al salir se descartarán.",
@@ -7069,7 +7067,8 @@
           "devDescription": "Herramientas solo de desarrollo para probar estados de la UI.",
           "linearTitle": "Linear",
           "linearDescription": "Cómo funciona Linear en Orca, lista de configuración, habilidad del agente y ejemplos de prompts.",
-          "tasksDescription": "Conecta proveedores, instala la habilidad de Linear y elige qué aparece en Tareas."
+          "tasksDescription": "Conecta proveedores, instala la habilidad de Linear y elige qué aparece en Tareas.",
+          "noSettingsFoundForQuery": "No se encontraron configuraciones para \"{{value0}}\""
         },
         "SettingsFormControls": {
           "42a4d15a30": "No hay fuentes coincidentes.",

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -7887,8 +7887,6 @@
           "ad6c529693": "Comptes de fournisseurs d'IA",
           "ec1ba547f7": "Gérez les agents IA, définissez-en un par défaut et personnalisez les commandes.",
           "8afa676615": "Agents",
-          "add3b97ee6": "\"",
-          "3c88ec55d6": "Aucun paramètre trouvé pour \"",
           "c7ad095d96": "Chargement des paramètres...",
           "acc7bbdefd": "Appuyez à nouveau sur ESC pour quitter les paramètres",
           "43b68e10f0": "Vous avez des modifications Git AI Author non enregistrées. Quitter les abandonnera.",
@@ -7906,7 +7904,8 @@
           "devDescription": "Outils réservés au développement pour exercer les états de l'UI.",
           "linearTitle": "Linear",
           "linearDescription": "Fonctionnement de Linear dans Orca, checklist de configuration, skill d'agent et exemples de prompts.",
-          "tasksDescription": "Connectez des fournisseurs, installez le skill Linear et choisissez ce qui apparaît dans Tâches."
+          "tasksDescription": "Connectez des fournisseurs, installez le skill Linear et choisissez ce qui apparaît dans Tâches.",
+          "noSettingsFoundForQuery": "Aucun paramètre trouvé pour \"{{value0}}\""
         },
         "SettingsFormControls": {
           "42a4d15a30": "Aucune police correspondante.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -7072,8 +7072,6 @@
           "ad6c529693": "AI プロバイダーアカウント",
           "ec1ba547f7": "AI Agent を管理し、デフォルトを設定し、コマンドをカスタマイズします。",
           "8afa676615": "Agent",
-          "add3b97ee6": "」",
-          "3c88ec55d6": "検索条件に一致する設定が見つかりませんでした:「",
           "c7ad095d96": "設定を読み込んでいます…",
           "acc7bbdefd": "もう一度 ESC を押して設定を終了します",
           "43b68e10f0": "Git AI Author の変更が保存されていません。離れるとそれらは破棄されます。",
@@ -7091,7 +7089,8 @@
           "devDescription": "UI の状態を確認するための開発者専用ツール。",
           "linearTitle": "Linear",
           "linearDescription": "Orca での Linear の仕組み、セットアップチェックリスト、Agent スキル、プロンプト例。",
-          "tasksDescription": "プロバイダーを接続し、Linear スキルをインストールして、タスクに表示する項目を選択します。"
+          "tasksDescription": "プロバイダーを接続し、Linear スキルをインストールして、タスクに表示する項目を選択します。",
+          "noSettingsFoundForQuery": "検索条件に一致する設定が見つかりませんでした:「{{value0}}」"
         },
         "SettingsFormControls": {
           "42a4d15a30": "一致するフォントがありません。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -7040,8 +7040,6 @@
           "ad6c529693": "AI 제공업체 계정",
           "ec1ba547f7": "AI agents를 관리하고, 기본값을 설정하고, 명령을 사용자 정의하세요.",
           "8afa676615": "에이전트",
-          "add3b97ee6": "\"",
-          "3c88ec55d6": "\"에 대한 설정을 찾을 수 없습니다.",
           "c7ad095d96": "설정 로드 중...",
           "acc7bbdefd": "설정을 종료하려면 ESC를 다시 누르세요.",
           "43b68e10f0": "저장되지 않은 Git AI Author 변경사항이 있습니다. 떠나면 폐기됩니다.",
@@ -7059,7 +7057,8 @@
           "devDescription": "UI 상태를 시험해 보기 위한 개발 전용 도구입니다.",
           "linearTitle": "Linear",
           "linearDescription": "Orca에서 Linear가 작동하는 방식, 설정 체크리스트, 에이전트 스킬, 프롬프트 예시입니다.",
-          "tasksDescription": "제공업체를 연결하고 Linear 스킬을 설치한 다음 작업에 표시할 항목을 선택하세요."
+          "tasksDescription": "제공업체를 연결하고 Linear 스킬을 설치한 다음 작업에 표시할 항목을 선택하세요.",
+          "noSettingsFoundForQuery": "\"{{value0}}\"에 대한 설정을 찾을 수 없습니다."
         },
         "SettingsFormControls": {
           "42a4d15a30": "일치하는 글꼴이 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -7101,8 +7101,6 @@
           "ad6c529693": "AI 提供商账户",
           "ec1ba547f7": "管理 AI 智能体、设置默认值并自定义命令。",
           "8afa676615": "智能体",
-          "add3b97ee6": "”",
-          "3c88ec55d6": "找不到“的设置",
           "c7ad095d96": "正在加载设置...",
           "acc7bbdefd": "再按一次 ESC 退出设置",
           "43b68e10f0": "您有未保存的 Git AI Author 更改。离开将丢弃它们。",
@@ -7120,7 +7118,8 @@
           "devDescription": "仅用于调试 UI 状态的开发工具。",
           "linearTitle": "Linear",
           "linearDescription": "Linear 在 Orca 中的工作方式、设置清单、智能体技能和提示词示例。",
-          "tasksDescription": "连接提供商、安装 Linear 技能并选择要在任务中显示的内容。"
+          "tasksDescription": "连接提供商、安装 Linear 技能并选择要在任务中显示的内容。",
+          "noSettingsFoundForQuery": "找不到“{{value0}}”的设置"
         },
         "SettingsFormControls": {
           "42a4d15a30": "没有匹配的字体。",

--- a/src/renderer/src/i18n/settings-search-empty-message.test.ts
+++ b/src/renderer/src/i18n/settings-search-empty-message.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The settings-search empty state used to render as three sibling JSX nodes:
+ * `translate('...3c88ec55d6', 'No settings found for "')`, the raw query, then
+ * `translate('...add3b97ee6', '"')`. That only reads correctly in languages that
+ * put the quoted term after the verb. Korean and Chinese put it before, so their
+ * translators localized the leading fragment as a whole clause and the query was
+ * appended after the sentence had already ended:
+ *
+ *   "에 대한 설정을 찾을 수 없습니다.screen reader"
+ *   找不到“的设置screen reader”
+ *
+ * No split of a sentence into fixed prefix/suffix fragments can serve both word
+ * orders, so the message is one catalog entry with a `{{value0}}` placeholder and
+ * each locale positions the term itself. These assertions pin that: every locale
+ * that translates the key must carry the placeholder, and the interpolated result
+ * must keep the query inside the quotes with the clause closing after it.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { i18n, translate } from './i18n'
+import en from './locales/en.json'
+import es from './locales/es.json'
+import fr from './locales/fr.json'
+import ja from './locales/ja.json'
+import ko from './locales/ko.json'
+import zh from './locales/zh.json'
+
+const KEY = 'auto.components.settings.Settings.noSettingsFoundForQuery'
+const FALLBACK = 'No settings found for "{{value0}}"'
+const RETIRED_FRAGMENT_KEYS = [
+  'auto.components.settings.Settings.3c88ec55d6',
+  'auto.components.settings.Settings.add3b97ee6'
+]
+const QUERY = 'screen reader'
+
+const CATALOGS: Record<string, unknown> = { en, es, fr, ja, ko, zh }
+
+function lookup(catalog: unknown, key: string): string | undefined {
+  const value = key
+    .split('.')
+    .reduce<unknown>(
+      (node, part) =>
+        node && typeof node === 'object' && !Array.isArray(node)
+          ? (node as Record<string, unknown>)[part]
+          : undefined,
+      catalog
+    )
+  return typeof value === 'string' ? value : undefined
+}
+
+const EXPECTED_MESSAGES: Record<string, string> = {
+  en: 'No settings found for "screen reader"',
+  es: 'No se encontraron configuraciones para "screen reader"',
+  fr: 'Aucun paramètre trouvé pour "screen reader"',
+  ja: '検索条件に一致する設定が見つかりませんでした:「screen reader」',
+  ko: '"screen reader"에 대한 설정을 찾을 수 없습니다.',
+  zh: '找不到“screen reader”的设置'
+}
+
+// The clause each language closes with once the quoted term is in place. A
+// fragment split cannot produce these, because the text has to follow the query.
+const TRAILING_CLAUSES: Record<string, string> = {
+  ko: '에 대한 설정을 찾을 수 없습니다.',
+  zh: '的设置'
+}
+
+describe('settings search empty-state message', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  it('declares one interpolated message instead of prefix and suffix fragments', () => {
+    expect(lookup(en, KEY)).toBe(FALLBACK)
+    for (const retired of RETIRED_FRAGMENT_KEYS) {
+      for (const [locale, catalog] of Object.entries(CATALOGS)) {
+        expect(lookup(catalog, retired), `${locale}: ${retired}`).toBeUndefined()
+      }
+    }
+  })
+
+  it('carries the query placeholder in every locale that translates the key', () => {
+    for (const [locale, catalog] of Object.entries(CATALOGS)) {
+      const value = lookup(catalog, KEY)
+      if (value === undefined) {
+        continue
+      }
+      expect(value, locale).toContain('{{value0}}')
+    }
+  })
+
+  it.each(Object.entries(EXPECTED_MESSAGES))(
+    'renders %s as one sentence with the query inside the quotes',
+    async (locale, expected) => {
+      await i18n.changeLanguage(locale)
+      expect(translate(KEY, FALLBACK, { value0: QUERY })).toBe(expected)
+    }
+  )
+
+  it.each(Object.entries(TRAILING_CLAUSES))(
+    'closes the %s clause after the query rather than appending it',
+    async (locale, trailing) => {
+      await i18n.changeLanguage(locale)
+      const message = translate(KEY, FALLBACK, { value0: QUERY })
+
+      expect(message).toContain(QUERY)
+      expect(message.endsWith(QUERY)).toBe(false)
+      expect(message.endsWith(trailing)).toBe(true)
+      // The clause must start after the query, not before it — the old fragment
+      // split forced the reverse and produced "<clause><query>".
+      expect(message.indexOf(trailing)).toBeGreaterThan(message.indexOf(QUERY))
+    }
+  )
+})

--- a/src/renderer/src/i18n/settings-search-empty-message.test.ts
+++ b/src/renderer/src/i18n/settings-search-empty-message.test.ts
@@ -1,21 +1,16 @@
 /**
- * The settings-search empty state used to render as three sibling JSX nodes:
- * `translate('...3c88ec55d6', 'No settings found for "')`, the raw query, then
- * `translate('...add3b97ee6', '"')`. That only reads correctly in languages that
- * put the quoted term after the verb. Korean and Chinese put it before, so their
- * translators localized the leading fragment as a whole clause and the query was
- * appended after the sentence had already ended:
+ * The empty state used to render as three sibling nodes: a `No settings found for "`
+ * fragment, the raw query, then a `"` fragment. Only languages that put the quoted
+ * term last read correctly that way. Korean and Chinese put it first, so their
+ * translators localized the leading fragment as a whole clause and the query landed
+ * after the sentence had ended: `"에 대한 설정을 찾을 수 없습니다.screen reader"`.
  *
- *   "에 대한 설정을 찾을 수 없습니다.screen reader"
- *   找不到“的设置screen reader”
- *
- * No split of a sentence into fixed prefix/suffix fragments can serve both word
- * orders, so the message is one catalog entry with a `{{value0}}` placeholder and
- * each locale positions the term itself. These assertions pin that: every locale
- * that translates the key must carry the placeholder, and the interpolated result
- * must keep the query inside the quotes with the clause closing after it.
+ * No prefix/suffix split can serve both word orders, so the message is one entry with
+ * a `{{value0}}` placeholder and each locale positions the term itself. The expected
+ * messages below are the assertion: ko and zh carry text *after* the query, which is
+ * exactly what the old shape could not express.
  */
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { i18n, translate } from './i18n'
 import en from './locales/en.json'
@@ -35,6 +30,15 @@ const QUERY = 'screen reader'
 
 const CATALOGS: Record<string, unknown> = { en, es, fr, ja, ko, zh }
 
+const EXPECTED_MESSAGES: Record<string, string> = {
+  en: 'No settings found for "screen reader"',
+  es: 'No se encontraron configuraciones para "screen reader"',
+  fr: 'Aucun paramètre trouvé pour "screen reader"',
+  ja: '検索条件に一致する設定が見つかりませんでした:「screen reader」',
+  ko: '"screen reader"에 대한 설정을 찾을 수 없습니다.',
+  zh: '找不到“screen reader”的设置'
+}
+
 function lookup(catalog: unknown, key: string): string | undefined {
   const value = key
     .split('.')
@@ -48,27 +52,7 @@ function lookup(catalog: unknown, key: string): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
-const EXPECTED_MESSAGES: Record<string, string> = {
-  en: 'No settings found for "screen reader"',
-  es: 'No se encontraron configuraciones para "screen reader"',
-  fr: 'Aucun paramètre trouvé pour "screen reader"',
-  ja: '検索条件に一致する設定が見つかりませんでした:「screen reader」',
-  ko: '"screen reader"에 대한 설정을 찾을 수 없습니다.',
-  zh: '找不到“screen reader”的设置'
-}
-
-// The clause each language closes with once the quoted term is in place. A
-// fragment split cannot produce these, because the text has to follow the query.
-const TRAILING_CLAUSES: Record<string, string> = {
-  ko: '에 대한 설정을 찾을 수 없습니다.',
-  zh: '的设置'
-}
-
 describe('settings search empty-state message', () => {
-  beforeEach(async () => {
-    await i18n.changeLanguage('en')
-  })
-
   it('declares one interpolated message instead of prefix and suffix fragments', () => {
     expect(lookup(en, KEY)).toBe(FALLBACK)
     for (const retired of RETIRED_FRAGMENT_KEYS) {
@@ -78,36 +62,11 @@ describe('settings search empty-state message', () => {
     }
   })
 
-  it('carries the query placeholder in every locale that translates the key', () => {
-    for (const [locale, catalog] of Object.entries(CATALOGS)) {
-      const value = lookup(catalog, KEY)
-      if (value === undefined) {
-        continue
-      }
-      expect(value, locale).toContain('{{value0}}')
-    }
-  })
-
   it.each(Object.entries(EXPECTED_MESSAGES))(
     'renders %s as one sentence with the query inside the quotes',
     async (locale, expected) => {
       await i18n.changeLanguage(locale)
       expect(translate(KEY, FALLBACK, { value0: QUERY })).toBe(expected)
-    }
-  )
-
-  it.each(Object.entries(TRAILING_CLAUSES))(
-    'closes the %s clause after the query rather than appending it',
-    async (locale, trailing) => {
-      await i18n.changeLanguage(locale)
-      const message = translate(KEY, FALLBACK, { value0: QUERY })
-
-      expect(message).toContain(QUERY)
-      expect(message.endsWith(QUERY)).toBe(false)
-      expect(message.endsWith(trailing)).toBe(true)
-      // The clause must start after the query, not before it — the old fragment
-      // split forced the reverse and produced "<clause><query>".
-      expect(message.indexOf(trailing)).toBeGreaterThan(message.indexOf(QUERY))
     }
   )
 })


### PR DESCRIPTION
## ELI5

The Settings "nothing matched" message wasn't one sentence — it was three pieces glued together in JSX: `No settings found for "`, your search term, then `"`. That only works in a language that puts the quoted term last. Korean and Chinese put it first, so their translators saw the leading piece alone, read it as a finished sentence, and translated it as one. The query then landed after the period. This makes the message a single entry with a slot for the term, so each language decides where the term goes.

## What Changed

- `settings-page-renderer.tsx`: three `translate()` fragments become one call with a `{{value0}}` placeholder, matching the existing `translate(key, default, { value0 })` convention.
- New key `auto.components.settings.Settings.noSettingsFoundForQuery` = `No settings found for "{{value0}}"`. The old fragment keys `3c88ec55d6` and `add3b97ee6` are retired from all six catalogs — their values are clause fragments that would be wrong under the new shape, so reusing either key would have kept the bug silently.
- ko and zh get their own word order. es, fr and ja are reassembled from *their own* two existing fragments around the placeholder, so no new translation is invented anywhere.
- ko/zh are pinned in `locale-cross-locale-key-overrides.mjs`, beside the existing entries of the same class. `bootstrap-locale-catalog.mjs` re-runs every leaf through `repairTranslatedValue`, so without the pin a regeneration would take fresh MT output for these two; with it, the pinned word order wins. The stale `3c88ec55d6` entry is removed from `locale-ko-key-overrides.json`.
- New test `src/renderer/src/i18n/settings-search-empty-message.test.ts`.

Catalogs were regenerated with `pnpm sync:localization-catalog` and `pnpm sync:localization-runtime-catalog`; both matched the hand edits, and `en-runtime-required.json` is unchanged because the English value equals the inline default.

## Why

`translate()` returns a string, so splitting a sentence into a fixed prefix and suffix hard-codes one word order into the JSX — and word order is exactly what differs between languages. There is no value for `3c88ec55d6` that reads correctly in both English and Korean.

| locale | old leading fragment | rendered result |
| --- | --- | --- |
| en | `No settings found for "` | ✅ `No settings found for "screen reader"` |
| ko | `"에 대한 설정을 찾을 수 없습니다.` | ❌ `"에 대한 설정을 찾을 수 없습니다.screen reader"` |
| zh | `找不到“的设置` | ❌ `找不到“的设置screen reader”` |
| es | `No se encontraron configuraciones para "` | ✅ `No se encontraron configuraciones para "screen reader"` |
| fr | `Aucun paramètre trouvé pour "` | ✅ `Aucun paramètre trouvé pour "screen reader"` |
| ja | `検索条件に一致する設定が見つかりませんでした:「` | ✅ `検索条件に一致する設定が見つかりませんでした:「screen reader」` |

One catalog entry moves the decision of *where the query goes* out of the JSX and into each locale, which is the only place that can answer it.

## Linked Issue

Fixes #19691

## Visual Proof

Searching Settings for `screen reader` with no matches. These strings are produced from the real catalogs — "before" by concatenating the two retired fragment values as the old JSX did, "after" by `translate()` under each locale — so they are the complete visual difference for a text-only change.

```
ko  before  "에 대한 설정을 찾을 수 없습니다.screen reader"
ko  after   "screen reader"에 대한 설정을 찾을 수 없습니다.
zh  before  找不到“的设置screen reader”
zh  after   找不到“screen reader”的设置
```

en, es, fr and ja are unchanged character for character:

```
No settings found for "screen reader"
No se encontraron configuraciones para "screen reader"
Aucun paramètre trouvé pour "screen reader"
検索条件に一致する設定が見つかりませんでした:「screen reader」
```

## Testing

The test pins two things: `en.json` declares the interpolated message and neither retired key survives in any of the six catalogs, and `translate()` produces the exact expected sentence under each of the six locales.

Exact-message assertions cover the placeholder and the ko/zh word order on their own, so there are no separate assertions for those. Verified by mutation rather than assumed — each of these makes the suite fail:

| mutation | result |
| --- | --- |
| ko value loses `{{value0}}` | 1 failed / 6 passed |
| es value loses `{{value0}}` | 1 failed / 6 passed |
| ko puts the clause before the query | 1 failed / 6 passed |
| zh ends with the query | 1 failed / 6 passed |
| a retired fragment key returns in ja | 1 failed / 6 passed |

With the fix and no mutation: 7 passed. With the test file in place and the rest of
the change reverted to `main`: 6 failed / 1 passed.

The second commit removes three assertions that the exact-match table already made —
a placeholder-presence check, a ko/zh trailing-clause check, and a `beforeEach` no
remaining test depended on. The table above is what proves they were redundant.

Gates on macOS 26.5.1, Node 24.18.0, pnpm 12:

- `pnpm typecheck` — exit 0
- `pnpm lint` — exit 0 (includes `verify:localization-catalog`, `-runtime-catalog`, `-extraction`, `-coverage`)
- `pnpm vitest run src/renderer/src/i18n src/renderer/src/components/settings config/scripts` — see below

`config/scripts/patched-dependencies-frozen-install.test.mjs` fails here: it shells out to a nested `pnpm install` and dies on a missing corepack cache path. It fails identically on a pristine checkout with no local changes, so it is a machine artifact.

Platforms: a renderer string change with no platform-conditional code. Verified on macOS.

- [ ] I manually tested these changes locally — see note
- [x] Automated tests added/updated, or explained why not below

I did not launch a dev build for this one. The before/after strings above come from the real shipped catalogs and the real i18next instance, which for a text-only change is the same evidence a screenshot would give and is checked on every CI run. The original Korean rendering was reported from a dev build on macOS 26.5.1.

## AI Disclosure

Written with Claude Opus 5 in Claude Code.

## Review

- **Cross-platform, remote/SSH, mobile, agents:** no impact. The diff touches one renderer JSX expression, six JSON catalogs and two build-time override files — no platform checks, no path handling, no RPC, no agent or provider code.
- **Backwards compatibility:** both retired keys are removed from all six catalogs together, which keeps `verify-localization-catalog`'s locale-parity check green (a key in a locale but not in `en.json` is a hard failure). Nothing else in the repo referenced either key. A plugin language pack that omits the new key falls back to English as designed.
- **Performance:** three `i18n.t()` calls and three React text children become one, on a path that renders only when a search matches nothing.
- **UI:** same `<div>`, same classes, so layout and truncation are identical. Each locale now owns the whole string, so quotation marks follow its own convention (`「」` ja, `“”` zh) instead of a bare `"`.
- **Security:** the query is rendered as a React text child, so React escapes it; `escapeValue: false` in `i18n.ts` does not apply to JSX children. It was already a raw text child before this change.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

**Same anti-pattern elsewhere — found, not fixed here**, to keep this PR to one topic. Three are visibly wrong in a shipped locale today:

- `new-workspace/smart-workspace-source-row-content.tsx:96-105` — `Use "{name}" as workspace name` split across **four** `translate()` calls; ja localized the *opening* quote as `」`, so it renders `使用」<name>」ワークスペース名として`.
- `settings/BrowserUseExamples.tsx:55-57` — `"` + prompt + `"`; zh renders `”<prompt>”`, ja `」<prompt>」`.
- `settings/MobileEmulatorExamples.tsx:67` — same quote-wrapping shape.

Same shape, prefix fragment plus a value (not visibly broken, but the same defect waiting on a translator): `quick-open-install-rg-guidance.tsx:115`, `github/PRFilterPickers.tsx:204`, `source-control/commit/bulk-action-bar.tsx:46,60`, `checks-tab-check-details.tsx:67`, `pull-request-page/checks/details.tsx:78`, `editor/CheckRunDetailsPanel.tsx:238,244`, `github/CommentCodeContext.tsx:216`, `settings/MobilePairedDevicesSection.tsx:43`, `task-page/github/IssueDialog.tsx:89`, `discuss-item/conversation-tab-timeline.tsx:75`.

A related family — appending a literal English `s` to a translated singular noun, which i18next's plural support would handle: `SearchResultsPane.tsx:74,78`, `checks-panel/conflict-summary.tsx:35`, `checks-panel/triage-strip.tsx:113,142`, `source-control/listing/section-header.tsx:52`, `SkillInstallReviewContent.tsx:83`, `settings/McpConfigSection.tsx:304`.

Happy to follow up on any of these.

## Author

No X account.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after strings attached; no screenshot because the change is text-only
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint` and `pnpm typecheck` pass locally; affected test areas pass apart from one pre-existing environmental failure noted above. Full `pnpm test` and `pnpm build` left to CI.
