### PR TITLE
fix(native-chat): merge duplicate native-chat-types import

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
@@ -12,7 +12,8 @@ import {
   isToolCallBlock,
   isToolResultBlock,
   type NativeChatBlock,
-  type NativeChatSubagentGroupBlock
+  type NativeChatSubagentGroupBlock,
+  type NativeChatToolCallBlock
 } from '../../../../shared/native-chat-types'
 import { isRenderableSubagentGroup } from '../../../../shared/native-chat-subagent-summary'
 import { diffFromText, diffFromToolCall, type DiffLine } from './native-chat-diff'
@@ -31,7 +32,6 @@ import {
   selectActiveToolCall
 } from '../../../../shared/native-chat-tool-activity'
 import { nativeChatToolRunIconName } from '../../../../shared/native-chat-tool-icon'
-import type { NativeChatToolCallBlock } from '../../../../shared/native-chat-types'
 import { NativeChatTaskList } from './NativeChatTaskList'
 import { buildNativeChatTaskListRows } from './native-chat-task-list-history'
 import { NativeChatDiffView } from './NativeChatDiffView'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |

<!-- /orca-pr-loc -->

## What

#19230 added a second `import type { NativeChatToolCallBlock }` from `shared/native-chat-types` in `NativeChatToolRun.tsx`. The static-analysis job's focused code-quality gate runs `import/no-duplicates` with `--deny-warnings`, so every PR opened on main since 06:50 UTC fails that job. This merges the import into the existing statement. No behavior change.

## Verified

- `oxlint --config config/oxlint-code-quality-native-plugins.json` on the file: clean
- `tsc -p config/tsconfig.web.json`: clean

Unblocks #19696 and anything else opened tonight.