### PR TITLE
fix(cli): target the spawning terminal's workspace, including Folder Workspaces

### DIFF
--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -35,10 +35,13 @@ vi.mock('./runtime-client', () => {
 })
 
 import { main } from './index'
+import { useOrcaTerminalWorkspaceEnvironment } from './index-test-harness'
 import { RuntimeClientError } from './runtime-client'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from './test-fixtures'
 
 describe('orca cli browser page targeting', () => {
+  useOrcaTerminalWorkspaceEnvironment()
+
   beforeEach(() => {
     callMock.mockReset()
   })

--- a/src/cli/caller-workspace-selector.test.ts
+++ b/src/cli/caller-workspace-selector.test.ts
@@ -16,10 +16,13 @@ import {
 const FOLDER_KEY = 'folder:52d2e7a3-c08f-4d0e-9771-f7581df19b6c'
 const WORKTREE_ID = 'repo::/tmp/repo/feature'
 
+/** A path alone keeps the local single-host shape; the object form names the host that owns it. */
+type WorktreeFixture = string | { path: string; repoId?: string; hostId?: string }
+
 function makeClient(
-  worktreePaths: readonly string[] = [],
+  worktreePaths: readonly WorktreeFixture[] = [],
   isRemote = false,
-  folderWorkspaces: readonly { id: string; folderPath: string }[] = []
+  folderWorkspaces: readonly { id: string; folderPath: string; connectionId?: string | null }[] = []
 ) {
   const call = vi.fn(async (method: string) => {
     if (method === 'folderWorkspace.list') {
@@ -28,7 +31,15 @@ function makeClient(
     if (method !== 'worktree.list') {
       throw new Error(`unexpected method ${method}`)
     }
-    const worktrees = worktreePaths.map((path) => ({ id: `repo::${path}`, path }))
+    const worktrees = worktreePaths.map((entry) => {
+      const fixture: Exclude<WorktreeFixture, string> =
+        typeof entry === 'string' ? { path: entry } : entry
+      return {
+        id: `${fixture.repoId ?? 'repo'}::${fixture.path}`,
+        path: fixture.path,
+        hostId: fixture.hostId
+      }
+    })
     return { result: { worktrees, totalCount: worktrees.length, truncated: false } }
   })
   return { client: { isRemote, call } as unknown as RuntimeClient, call }
@@ -211,6 +222,42 @@ describe('resolving the current directory against every managed workspace', () =
     ).resolves.toBe('id:repo::/tmp/tickets/API-783/pos_frontend')
     // Why: the worktree already answers the question, so the folder catalog is never read.
     expect(call).toHaveBeenCalledOnce()
+  })
+
+  it('prefers the local worktree over one at the same path on a paired host', async () => {
+    // Why: a repo checked out at the same absolute path on an SSH-paired host lists alongside the
+    // local one, and a local directory can only be inside the local copy.
+    const { client } = makeClient([
+      { path: '/home/msmit/Source/cloud_backend', repoId: 'remote-repo', hostId: 'ssh:dev-box' },
+      { path: '/home/msmit/Source/cloud_backend', repoId: 'local-repo', hostId: 'local' }
+    ])
+
+    await expect(
+      resolveCurrentWorktreeSelector('/home/msmit/Source/cloud_backend/src', client)
+    ).resolves.toBe('id:local-repo::/home/msmit/Source/cloud_backend')
+  })
+
+  it('falls through to the Folder Workspace when only a paired host claims that path', async () => {
+    const { client, call } = makeClient(
+      [{ path: '/tmp/tickets/API-783/pos_frontend', hostId: 'ssh:dev-box' }],
+      false,
+      TICKET_FOLDER
+    )
+
+    await expect(
+      resolveCurrentWorktreeSelector('/tmp/tickets/API-783/pos_frontend/src', client)
+    ).resolves.toBe('folder:folder-1')
+    expect(call).toHaveBeenNthCalledWith(2, 'folderWorkspace.list')
+  })
+
+  it('refuses a Folder Workspace whose folder lives on a paired host', async () => {
+    const { client } = makeClient([], false, [
+      { id: 'folder-remote', folderPath: '/tmp/tickets/API-783', connectionId: 'dev-box' }
+    ])
+
+    await expect(
+      resolveCurrentWorktreeSelector('/tmp/tickets/API-783/notes', client)
+    ).rejects.toMatchObject({ code: 'selector_not_found' })
   })
 
   it('refuses a directory no managed workspace contains', async () => {

--- a/src/cli/caller-workspace-selector.test.ts
+++ b/src/cli/caller-workspace-selector.test.ts
@@ -1,0 +1,159 @@
+/**
+ * The CLI runs inside terminals Orca spawned, and Orca stamps each of those with the workspace
+ * that owns it. Only the emulator commands used to read that stamp, so a browser or terminal
+ * command issued from a Folder Workspace fell through to whichever workspace the UI had focused.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeClient } from './runtime-client'
+import { useOrcaTerminalWorkspaceEnvironment } from './index-test-harness'
+import {
+  getBrowserWorktreeSelector,
+  getEmulatorWorktreeSelector,
+  resolveCallerWorkspaceSelector
+} from './selectors'
+
+const FOLDER_KEY = 'folder:52d2e7a3-c08f-4d0e-9771-f7581df19b6c'
+const WORKTREE_ID = 'repo::/tmp/repo/feature'
+
+function makeClient(worktreePaths: readonly string[] = [], isRemote = false) {
+  const call = vi.fn(async (method: string) => {
+    if (method !== 'worktree.list') {
+      throw new Error(`unexpected method ${method}`)
+    }
+    const worktrees = worktreePaths.map((path) => ({ id: `repo::${path}`, path }))
+    return { result: { worktrees, totalCount: worktrees.length, truncated: false } }
+  })
+  return { client: { isRemote, call } as unknown as RuntimeClient, call }
+}
+
+function flags(entries: Record<string, string | boolean> = {}): Map<string, string | boolean> {
+  return new Map(Object.entries(entries))
+}
+
+describe('the workspace an unscoped CLI command targets', () => {
+  useOrcaTerminalWorkspaceEnvironment()
+
+  it('names the git worktree the calling terminal belongs to', async () => {
+    process.env.ORCA_WORKTREE_ID = WORKTREE_ID
+    const { client, call } = makeClient()
+
+    await expect(getBrowserWorktreeSelector(flags(), '/elsewhere', client)).resolves.toBe(
+      `id:${WORKTREE_ID}`
+    )
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('names the folder workspace the calling terminal belongs to', async () => {
+    process.env.ORCA_WORKTREE_ID = FOLDER_KEY
+    process.env.ORCA_WORKSPACE_ID = FOLDER_KEY
+    const { client } = makeClient()
+
+    await expect(getBrowserWorktreeSelector(flags(), '/elsewhere', client)).resolves.toBe(
+      FOLDER_KEY
+    )
+  })
+
+  it('falls back to the folder workspace id when only the workspace stamp survives', async () => {
+    process.env.ORCA_WORKSPACE_ID = FOLDER_KEY
+    const { client } = makeClient()
+
+    await expect(getBrowserWorktreeSelector(flags(), '/elsewhere', client)).resolves.toBe(
+      FOLDER_KEY
+    )
+  })
+
+  it('prefers the worktree stamp over a stale parent workspace stamp', async () => {
+    process.env.ORCA_WORKSPACE_ID = 'folder:stale-parent'
+    process.env.ORCA_WORKTREE_ID = WORKTREE_ID
+    const { client } = makeClient()
+
+    await expect(getBrowserWorktreeSelector(flags(), '/elsewhere', client)).resolves.toBe(
+      `id:${WORKTREE_ID}`
+    )
+  })
+
+  it('ignores a workspace stamp that names no folder workspace', async () => {
+    process.env.ORCA_WORKSPACE_ID = 'worktree:repo::/tmp/repo/feature'
+    const { client, call } = makeClient(['/tmp/repo/feature'])
+
+    await expect(
+      getBrowserWorktreeSelector(flags(), '/tmp/repo/feature/src', client)
+    ).resolves.toBe(`id:${WORKTREE_ID}`)
+    expect(call).toHaveBeenCalledWith('worktree.list', { limit: 10_000 })
+  })
+
+  it('lets an explicit selector outrank the terminal it was typed in', async () => {
+    process.env.ORCA_WORKTREE_ID = FOLDER_KEY
+    const { client } = makeClient()
+
+    await expect(
+      getBrowserWorktreeSelector(flags({ worktree: 'identity:other' }), '/elsewhere', client)
+    ).resolves.toBe('identity:other')
+  })
+
+  it('keeps `--worktree all` unscoped inside an Orca terminal', async () => {
+    process.env.ORCA_WORKTREE_ID = FOLDER_KEY
+    const { client } = makeClient()
+
+    await expect(
+      getBrowserWorktreeSelector(flags({ worktree: 'all' }), '/elsewhere', client)
+    ).resolves.toBeUndefined()
+  })
+
+  it('keeps `--worktree current` meaning the current directory', async () => {
+    // Why: `current` is the caller asking about cwd explicitly, so the terminal stamp must not win.
+    process.env.ORCA_WORKTREE_ID = FOLDER_KEY
+    const { client } = makeClient(['/tmp/repo/feature'])
+
+    await expect(
+      getBrowserWorktreeSelector(flags({ worktree: 'current' }), '/tmp/repo/feature/src', client)
+    ).resolves.toBe(`id:${WORKTREE_ID}`)
+  })
+
+  it('resolves from the current directory outside an Orca terminal', async () => {
+    const { client } = makeClient(['/tmp/repo/feature'])
+
+    await expect(
+      getBrowserWorktreeSelector(flags(), '/tmp/repo/feature/src', client)
+    ).resolves.toBe(`id:${WORKTREE_ID}`)
+  })
+
+  it('stays unscoped for a directory no workspace claims', async () => {
+    const { client } = makeClient(['/tmp/repo/feature'])
+
+    await expect(
+      getBrowserWorktreeSelector(flags(), '/tmp/unmanaged', client)
+    ).resolves.toBeUndefined()
+  })
+
+  it('leaves a remote client on server-side focus', async () => {
+    process.env.ORCA_WORKTREE_ID = WORKTREE_ID
+    const { client, call } = makeClient([], true)
+
+    await expect(
+      getBrowserWorktreeSelector(flags(), '/tmp/repo/feature', client)
+    ).resolves.toBeUndefined()
+    await expect(
+      getEmulatorWorktreeSelector(flags(), '/tmp/repo/feature', client)
+    ).resolves.toBeUndefined()
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('refuses a remote `worktree current` rather than reading the client environment', async () => {
+    process.env.ORCA_WORKTREE_ID = WORKTREE_ID
+    const { client } = makeClient([], true)
+
+    await expect(resolveCallerWorkspaceSelector('/tmp/repo/feature', client)).rejects.toMatchObject(
+      { code: 'invalid_argument' }
+    )
+  })
+
+  it('gives emulator commands the same terminal workspace', async () => {
+    process.env.ORCA_WORKTREE_ID = FOLDER_KEY
+    const { client } = makeClient()
+
+    await expect(getEmulatorWorktreeSelector(flags(), '/elsewhere', client)).resolves.toBe(
+      FOLDER_KEY
+    )
+  })
+})

--- a/src/cli/caller-workspace-selector.test.ts
+++ b/src/cli/caller-workspace-selector.test.ts
@@ -9,14 +9,22 @@ import { useOrcaTerminalWorkspaceEnvironment } from './index-test-harness'
 import {
   getBrowserWorktreeSelector,
   getEmulatorWorktreeSelector,
-  resolveCallerWorkspaceSelector
+  resolveCallerWorkspaceSelector,
+  resolveCurrentWorktreeSelector
 } from './selectors'
 
 const FOLDER_KEY = 'folder:52d2e7a3-c08f-4d0e-9771-f7581df19b6c'
 const WORKTREE_ID = 'repo::/tmp/repo/feature'
 
-function makeClient(worktreePaths: readonly string[] = [], isRemote = false) {
+function makeClient(
+  worktreePaths: readonly string[] = [],
+  isRemote = false,
+  folderWorkspaces: readonly { id: string; folderPath: string }[] = []
+) {
   const call = vi.fn(async (method: string) => {
+    if (method === 'folderWorkspace.list') {
+      return { result: { folderWorkspaces } }
+    }
     if (method !== 'worktree.list') {
       throw new Error(`unexpected method ${method}`)
     }
@@ -155,5 +163,47 @@ describe('the workspace an unscoped CLI command targets', () => {
     await expect(getEmulatorWorktreeSelector(flags(), '/elsewhere', client)).resolves.toBe(
       FOLDER_KEY
     )
+  })
+})
+
+describe('resolving the current directory against every managed workspace', () => {
+  useOrcaTerminalWorkspaceEnvironment()
+
+  const TICKET_FOLDER = [{ id: 'folder-1', folderPath: '/tmp/tickets/API-783' }]
+
+  it('resolves a Folder Workspace root that matches no git worktree', async () => {
+    const { client, call } = makeClient([], false, TICKET_FOLDER)
+
+    await expect(resolveCurrentWorktreeSelector('/tmp/tickets/API-783', client)).resolves.toBe(
+      'folder:folder-1'
+    )
+    expect(call).toHaveBeenNthCalledWith(1, 'worktree.list', { limit: 10_000 })
+    expect(call).toHaveBeenNthCalledWith(2, 'folderWorkspace.list')
+  })
+
+  it('resolves a subdirectory of a Folder Workspace to that folder', async () => {
+    const { client } = makeClient([], false, TICKET_FOLDER)
+
+    await expect(
+      resolveCurrentWorktreeSelector('/tmp/tickets/API-783/notes', client)
+    ).resolves.toBe('folder:folder-1')
+  })
+
+  it('prefers a git worktree nested inside the ticket folder', async () => {
+    const { client, call } = makeClient(['/tmp/tickets/API-783/pos_frontend'], false, TICKET_FOLDER)
+
+    await expect(
+      resolveCurrentWorktreeSelector('/tmp/tickets/API-783/pos_frontend/src', client)
+    ).resolves.toBe('id:repo::/tmp/tickets/API-783/pos_frontend')
+    // Why: the worktree already answers the question, so the folder catalog is never read.
+    expect(call).toHaveBeenCalledOnce()
+  })
+
+  it('refuses a directory no managed workspace contains', async () => {
+    const { client } = makeClient(['/tmp/repo/feature'], false, TICKET_FOLDER)
+
+    await expect(resolveCurrentWorktreeSelector('/tmp/elsewhere', client)).rejects.toMatchObject({
+      code: 'selector_not_found'
+    })
   })
 })

--- a/src/cli/caller-workspace-selector.test.ts
+++ b/src/cli/caller-workspace-selector.test.ts
@@ -134,6 +134,20 @@ describe('the workspace an unscoped CLI command targets', () => {
     ).resolves.toBeUndefined()
   })
 
+  it('refuses to run unscoped when the terminal names a workspace it cannot resolve', async () => {
+    // A `worktree:` stamp is a legal workspace key that is not a Folder Workspace, so the caller
+    // falls through to cwd — and from a directory no workspace claims, there is no answer left.
+    process.env.ORCA_WORKSPACE_ID = 'worktree:repo::/tmp/repo/gone'
+    const { client } = makeClient(['/tmp/repo/feature'])
+
+    await expect(
+      getBrowserWorktreeSelector(flags(), '/tmp/unmanaged', client)
+    ).rejects.toMatchObject({
+      code: 'selector_not_found',
+      message: expect.stringContaining('worktree:repo::/tmp/repo/gone')
+    })
+  })
+
   it('leaves a remote client on server-side focus', async () => {
     process.env.ORCA_WORKTREE_ID = WORKTREE_ID
     const { client, call } = makeClient([], true)

--- a/src/cli/caller-workspace-selector.ts
+++ b/src/cli/caller-workspace-selector.ts
@@ -1,0 +1,103 @@
+import { resolve as resolvePath } from 'node:path'
+import type { RuntimeWorktreeListResult, RuntimeWorktreeRecord } from '../shared/runtime-types'
+import { isPathInsideOrEqual } from '../shared/cross-platform-path'
+import type { RuntimeClient } from './runtime-client'
+import { RuntimeClientError } from './runtime/types'
+
+export function assertLocalCwdWorktreeSelector(selector: string, client: RuntimeClient): void {
+  if (!client.isRemote) {
+    return
+  }
+  // Why: a paired CLI's cwd belongs to the client machine, not the runtime
+  // server, so cwd-derived worktree selectors are only valid locally.
+  throw new RuntimeClientError(
+    'invalid_argument',
+    `${selector} is a local cwd shortcut and cannot be resolved against a remote runtime. Pass an explicit server-side worktree selector such as identity:<identity>, id:<repo-id>::<path>, name:<displayName>, branch:<branch>, issue:<number>, or path:<absolute-server-path>.`
+  )
+}
+
+export async function resolveCurrentWorktreeSelector(
+  cwd: string,
+  client: RuntimeClient
+): Promise<string> {
+  assertLocalCwdWorktreeSelector('current', client)
+
+  const currentPath = resolvePath(cwd)
+  const worktrees = await client.call<RuntimeWorktreeListResult>('worktree.list', {
+    limit: 10_000
+  })
+  let enclosingWorktree: RuntimeWorktreeRecord | undefined
+  let enclosingPathLength = -1
+  for (const worktree of worktrees.result.worktrees) {
+    const worktreePath = resolvePath(worktree.path)
+    if (
+      !isPathInsideOrEqual(worktreePath, currentPath) ||
+      worktreePath.length <= enclosingPathLength
+    ) {
+      continue
+    }
+    enclosingWorktree = worktree
+    enclosingPathLength = worktreePath.length
+  }
+
+  if (!enclosingWorktree) {
+    throw new RuntimeClientError(
+      'selector_not_found',
+      `No Orca-managed worktree contains the current directory: ${currentPath}`
+    )
+  }
+
+  // Why: users expect "active/current" to mean the enclosing managed worktree
+  // even from nested subdirectories. Resolve to the concrete runtime id here:
+  // duplicate repo registrations can expose the same Git worktree path, and a
+  // path selector would throw selector_ambiguous after losing the repo id.
+  return `id:${enclosingWorktree.id}`
+}
+
+/**
+ * The workspace Orca stamped into the terminal this CLI was invoked from, or undefined outside one.
+ *
+ * Why `id:` for a git worktree: a bare worktree id is also matched against paths and branches, so
+ * only the explicit form narrows to the repo that owns it. A folder workspace key is already
+ * unambiguous and is the form the runtime's folder resolvers accept.
+ */
+export function getOrcaTerminalWorkspaceSelector(): string | undefined {
+  const worktreeId = process.env.ORCA_WORKTREE_ID?.trim()
+  if (worktreeId) {
+    return worktreeId.startsWith('folder:') ? worktreeId : `id:${worktreeId}`
+  }
+  const workspaceId = process.env.ORCA_WORKSPACE_ID?.trim()
+  return workspaceId?.startsWith('folder:') ? workspaceId : undefined
+}
+
+/**
+ * The workspace a command targets when the caller named none.
+ *
+ * Why the terminal environment outranks cwd: Orca stamps every terminal it spawns with the
+ * workspace that owns it, and that is the workspace the caller means — a Folder Workspace root
+ * matches no git worktree at all, and an agent that has cd'd into a child repo still speaks for
+ * the workspace its terminal belongs to.
+ */
+export async function resolveCallerWorkspaceSelector(
+  cwd: string,
+  client: RuntimeClient
+): Promise<string> {
+  assertLocalCwdWorktreeSelector('current', client)
+  return getOrcaTerminalWorkspaceSelector() ?? (await resolveCurrentWorktreeSelector(cwd, client))
+}
+
+/** The same default, for commands that may run unscoped rather than fail. */
+export async function resolveOptionalCallerWorkspaceSelector(
+  cwd: string,
+  client: RuntimeClient
+): Promise<string | undefined> {
+  if (client.isRemote) {
+    return undefined
+  }
+  try {
+    return await resolveCallerWorkspaceSelector(cwd, client)
+  } catch {
+    // Not inside a managed workspace — no filter
+    return undefined
+  }
+}

--- a/src/cli/caller-workspace-selector.ts
+++ b/src/cli/caller-workspace-selector.ts
@@ -116,6 +116,11 @@ export async function resolveCallerWorkspaceSelector(
   return getOrcaTerminalWorkspaceSelector() ?? (await resolveCurrentWorktreeSelector(cwd, client))
 }
 
+/** The workspace stamp Orca put in this terminal, even when it names nothing the CLI can resolve. */
+function getOrcaTerminalWorkspaceStamp(): string | undefined {
+  return process.env.ORCA_WORKTREE_ID?.trim() || process.env.ORCA_WORKSPACE_ID?.trim() || undefined
+}
+
 /** The same default, for commands that may run unscoped rather than fail. */
 export async function resolveOptionalCallerWorkspaceSelector(
   cwd: string,
@@ -126,8 +131,17 @@ export async function resolveOptionalCallerWorkspaceSelector(
   }
   try {
     return await resolveCallerWorkspaceSelector(cwd, client)
-  } catch {
-    // Not inside a managed workspace — no filter
-    return undefined
+  } catch (error) {
+    const terminalWorkspace = getOrcaTerminalWorkspaceStamp()
+    if (!terminalWorkspace) {
+      // Not inside a managed workspace — no filter
+      return undefined
+    }
+    // Why: running unscoped from an Orca terminal hands the command to whichever workspace the
+    // app has focused, so an agent silently drives someone else's screen. Refuse instead.
+    throw new RuntimeClientError(
+      'selector_not_found',
+      `This terminal belongs to Orca workspace ${terminalWorkspace}, which could not be resolved: ${error instanceof Error ? error.message : String(error)}. Pass an explicit --worktree selector, or --worktree all to run unscoped.`
+    )
   }
 }

--- a/src/cli/caller-workspace-selector.ts
+++ b/src/cli/caller-workspace-selector.ts
@@ -2,6 +2,7 @@ import { resolve as resolvePath } from 'node:path'
 import type { RuntimeWorktreeListResult } from '../shared/runtime-types'
 import type { FolderWorkspace } from '../shared/folder-workspace-types'
 import { isPathInsideOrEqual } from '../shared/cross-platform-path'
+import { parseExecutionHostId } from '../shared/execution-host'
 import { folderWorkspaceKey } from '../shared/workspace-scope'
 import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime/types'
@@ -19,6 +20,27 @@ export function assertLocalCwdWorktreeSelector(selector: string, client: Runtime
 }
 
 type EnclosingWorkspace = { selector: string; path: string }
+
+/**
+ * Why: both catalogs span every paired host, and the same absolute path exists on more than one of
+ * them — so matching a local directory by path alone can answer with another machine's workspace.
+ * A local cwd can only sit inside a workspace this machine holds, and `runtime:<env>` is how a
+ * paired client addresses rows the connected server holds itself (see
+ * `runtime-repository-registration-controller`, and the runtime note in
+ * `resolveFolderWorkspaceHost`), so only an `ssh:` host — or one this build cannot name at all —
+ * is a different filesystem.
+ */
+function isLocalExecutionHost(hostId: string | null | undefined): boolean {
+  const kind = hostId ? parseExecutionHostId(hostId)?.kind : 'local'
+  return kind === 'local' || kind === 'runtime'
+}
+
+/** Host precedence the renderer's folder resolver uses: the stamp wins, then the legacy SSH field. */
+function isLocalFolderWorkspace(folder: FolderWorkspace): boolean {
+  return folder.executionHostId
+    ? isLocalExecutionHost(folder.executionHostId)
+    : !folder.connectionId?.trim()
+}
 
 function findDeepestEnclosingWorkspace(
   workspaces: readonly EnclosingWorkspace[],
@@ -54,10 +76,12 @@ export async function resolveCurrentWorktreeSelector(
     // Why the concrete runtime id rather than the path: duplicate repo registrations can expose
     // the same Git worktree path, and a path selector would throw selector_ambiguous after
     // losing the repo id.
-    worktrees.result.worktrees.map((worktree) => ({
-      selector: `id:${worktree.id}`,
-      path: worktree.path
-    })),
+    worktrees.result.worktrees
+      .filter((worktree) => isLocalExecutionHost(worktree.hostId))
+      .map((worktree) => ({
+        selector: `id:${worktree.id}`,
+        path: worktree.path
+      })),
     currentPath
   )
   if (enclosingWorktree) {
@@ -69,7 +93,7 @@ export async function resolveCurrentWorktreeSelector(
   // is paid only where this used to fail outright.
   const folders = await client.call<{ folderWorkspaces: FolderWorkspace[] }>('folderWorkspace.list')
   const enclosingFolder = findDeepestEnclosingWorkspace(
-    folders.result.folderWorkspaces.map((folder) => ({
+    folders.result.folderWorkspaces.filter(isLocalFolderWorkspace).map((folder) => ({
       selector: folderWorkspaceKey(folder.id),
       path: folder.folderPath
     })),

--- a/src/cli/caller-workspace-selector.ts
+++ b/src/cli/caller-workspace-selector.ts
@@ -1,6 +1,8 @@
 import { resolve as resolvePath } from 'node:path'
-import type { RuntimeWorktreeListResult, RuntimeWorktreeRecord } from '../shared/runtime-types'
+import type { RuntimeWorktreeListResult } from '../shared/runtime-types'
+import type { FolderWorkspace } from '../shared/folder-workspace-types'
 import { isPathInsideOrEqual } from '../shared/cross-platform-path'
+import { folderWorkspaceKey } from '../shared/workspace-scope'
 import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime/types'
 
@@ -16,6 +18,28 @@ export function assertLocalCwdWorktreeSelector(selector: string, client: Runtime
   )
 }
 
+type EnclosingWorkspace = { selector: string; path: string }
+
+function findDeepestEnclosingWorkspace(
+  workspaces: readonly EnclosingWorkspace[],
+  currentPath: string
+): string | undefined {
+  let enclosingSelector: string | undefined
+  let enclosingPathLength = -1
+  for (const workspace of workspaces) {
+    const workspacePath = resolvePath(workspace.path)
+    if (
+      !isPathInsideOrEqual(workspacePath, currentPath) ||
+      workspacePath.length <= enclosingPathLength
+    ) {
+      continue
+    }
+    enclosingSelector = workspace.selector
+    enclosingPathLength = workspacePath.length
+  }
+  return enclosingSelector
+}
+
 export async function resolveCurrentWorktreeSelector(
   cwd: string,
   client: RuntimeClient
@@ -26,32 +50,38 @@ export async function resolveCurrentWorktreeSelector(
   const worktrees = await client.call<RuntimeWorktreeListResult>('worktree.list', {
     limit: 10_000
   })
-  let enclosingWorktree: RuntimeWorktreeRecord | undefined
-  let enclosingPathLength = -1
-  for (const worktree of worktrees.result.worktrees) {
-    const worktreePath = resolvePath(worktree.path)
-    if (
-      !isPathInsideOrEqual(worktreePath, currentPath) ||
-      worktreePath.length <= enclosingPathLength
-    ) {
-      continue
-    }
-    enclosingWorktree = worktree
-    enclosingPathLength = worktreePath.length
+  const enclosingWorktree = findDeepestEnclosingWorkspace(
+    // Why the concrete runtime id rather than the path: duplicate repo registrations can expose
+    // the same Git worktree path, and a path selector would throw selector_ambiguous after
+    // losing the repo id.
+    worktrees.result.worktrees.map((worktree) => ({
+      selector: `id:${worktree.id}`,
+      path: worktree.path
+    })),
+    currentPath
+  )
+  if (enclosingWorktree) {
+    return enclosingWorktree
   }
 
-  if (!enclosingWorktree) {
+  // Why only once no worktree claims the directory: a Folder Workspace is a folder that groups
+  // git worktrees, so any worktree match is already the deeper of the two, and the catalog read
+  // is paid only where this used to fail outright.
+  const folders = await client.call<{ folderWorkspaces: FolderWorkspace[] }>('folderWorkspace.list')
+  const enclosingFolder = findDeepestEnclosingWorkspace(
+    folders.result.folderWorkspaces.map((folder) => ({
+      selector: folderWorkspaceKey(folder.id),
+      path: folder.folderPath
+    })),
+    currentPath
+  )
+  if (!enclosingFolder) {
     throw new RuntimeClientError(
       'selector_not_found',
-      `No Orca-managed worktree contains the current directory: ${currentPath}`
+      `No Orca-managed workspace contains the current directory: ${currentPath}`
     )
   }
-
-  // Why: users expect "active/current" to mean the enclosing managed worktree
-  // even from nested subdirectories. Resolve to the concrete runtime id here:
-  // duplicate repo registrations can expose the same Git worktree path, and a
-  // path selector would throw selector_ambiguous after losing the repo id.
-  return `id:${enclosingWorktree.id}`
+  return enclosingFolder
 }
 
 /**

--- a/src/cli/caller-workspace-selector.ts
+++ b/src/cli/caller-workspace-selector.ts
@@ -35,11 +35,9 @@ function isLocalExecutionHost(hostId: string | null | undefined): boolean {
   return kind === 'local' || kind === 'runtime'
 }
 
-/** Host precedence the renderer's folder resolver uses: the stamp wins, then the legacy SSH field. */
+/** Why: the daemon's folder rows carry their SSH pin in `connectionId` only. */
 function isLocalFolderWorkspace(folder: FolderWorkspace): boolean {
-  return folder.executionHostId
-    ? isLocalExecutionHost(folder.executionHostId)
-    : !folder.connectionId?.trim()
+  return !folder.connectionId?.trim()
 }
 
 function findDeepestEnclosingWorkspace(

--- a/src/cli/handlers/computer-action-routing.test.ts
+++ b/src/cli/handlers/computer-action-routing.test.ts
@@ -35,9 +35,12 @@ vi.mock('../runtime-client', () => {
 })
 
 import { main } from '../index'
+import { useOrcaTerminalWorkspaceEnvironment } from '../index-test-harness'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from '../test-fixtures'
 
 describe('orca computer action CLI routing', () => {
+  useOrcaTerminalWorkspaceEnvironment()
+
   beforeEach(() => {
     vi.restoreAllMocks()
     callMock.mockReset()

--- a/src/cli/handlers/computer.test.ts
+++ b/src/cli/handlers/computer.test.ts
@@ -17,9 +17,12 @@ vi.mock('../runtime-client', async () => {
 })
 
 import { main } from '../index'
+import { useOrcaTerminalWorkspaceEnvironment } from '../index-test-harness'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from '../test-fixtures'
 
 describe('orca computer observation CLI handlers', () => {
+  useOrcaTerminalWorkspaceEnvironment()
+
   beforeEach(() => {
     vi.restoreAllMocks()
     callMock.mockReset()

--- a/src/cli/handlers/emulator.test.ts
+++ b/src/cli/handlers/emulator.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { callMock, remoteMock } = vi.hoisted(() => ({
   callMock: vi.fn(),
@@ -26,11 +26,11 @@ vi.mock('../runtime-client', async () => {
 })
 
 import { main } from '../index'
+import { useOrcaTerminalWorkspaceEnvironment } from '../index-test-harness'
 import { okFixture, queueFixtures } from '../test-fixtures'
 
 describe('orca emulator CLI handlers', () => {
-  const originalWorkspaceId = process.env.ORCA_WORKSPACE_ID
-  const originalWorktreeId = process.env.ORCA_WORKTREE_ID
+  useOrcaTerminalWorkspaceEnvironment()
 
   beforeEach(() => {
     vi.restoreAllMocks()
@@ -39,19 +39,6 @@ describe('orca emulator CLI handlers', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
     process.exitCode = undefined
-  })
-
-  afterEach(() => {
-    if (originalWorkspaceId === undefined) {
-      delete process.env.ORCA_WORKSPACE_ID
-    } else {
-      process.env.ORCA_WORKSPACE_ID = originalWorkspaceId
-    }
-    if (originalWorktreeId === undefined) {
-      delete process.env.ORCA_WORKTREE_ID
-    } else {
-      process.env.ORCA_WORKTREE_ID = originalWorktreeId
-    }
   })
 
   it('resolves relative APK paths before calling the runtime', async () => {
@@ -111,7 +98,7 @@ describe('orca emulator CLI handlers', () => {
 
   it('uses the current git worktree exported by the Orca terminal', async () => {
     process.env.ORCA_WORKSPACE_ID = 'folder:stale-parent'
-    process.env.ORCA_WORKTREE_ID = 'repo-1::/repo/project '
+    process.env.ORCA_WORKTREE_ID = 'repo-1::/repo/project'
     callMock.mockResolvedValue(
       okFixture('req_attach', {
         attached: true,
@@ -124,7 +111,7 @@ describe('orca emulator CLI handlers', () => {
     expect(callMock).toHaveBeenCalledOnce()
     expect(callMock).toHaveBeenCalledWith(
       'emulator.attach',
-      { device: 'device-1', worktree: 'repo-1::/repo/project ', focus: false },
+      { device: 'device-1', worktree: 'id:repo-1::/repo/project', focus: false },
       { timeoutMs: 180_000 }
     )
   })

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -22,6 +22,7 @@ import {
 import {
   getOptionalWorktreeSelector,
   getRequiredWorktreeSelector,
+  resolveCallerWorkspaceSelector,
   resolveCurrentWorktreeSelector
 } from '../selectors'
 import { isTuiAgent } from '../../shared/tui-agent-config'
@@ -126,14 +127,11 @@ function getOptionalSetupDecision(
   if (setup !== undefined && setup !== 'run' && setup !== 'skip' && setup !== 'inherit') {
     throw new RuntimeClientError('invalid_argument', '--setup must be one of: run, skip, inherit')
   }
-  if (flags.get('run-hooks') === true) {
-    if (setup !== undefined && setup !== 'run') {
-      throw new RuntimeClientError(
-        'invalid_argument',
-        'Choose either --run-hooks or --setup run, not contradictory setup flags.'
-      )
-    }
-    return setup
+  if (flags.get('run-hooks') === true && setup !== undefined && setup !== 'run') {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Choose either --run-hooks or --setup run, not contradictory setup flags.'
+    )
   }
   return setup
 }
@@ -201,7 +199,7 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
   },
   'worktree current': async ({ client, cwd, json }) => {
     const result = await client.call<{ worktree: RuntimeWorktreeRecord }>('worktree.show', {
-      worktree: await resolveCurrentWorktreeSelector(cwd, client)
+      worktree: await resolveCallerWorkspaceSelector(cwd, client)
     })
     printResult(result, json, formatWorktreeShow)
   },

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -2,6 +2,7 @@ import type { CommandSpec } from './args'
 import { findCommandSpec, isCommandGroup, supportsBrowserPageFlag } from './args'
 import { unknownCommandData } from './command-suggestion'
 import { formatSkillsCommandFlagHelp } from './skills-command-flag-help'
+import { formatWorktreeSelectorFlagHelp } from './worktree-selector-flag-help'
 import { ROOT_HELP_TEXT_PRIMARY } from './root-help-text-primary'
 import { ROOT_HELP_TEXT_SECONDARY } from './root-help-text-secondary'
 
@@ -73,18 +74,16 @@ export function formatGroupHelp(specs: CommandSpec[], group: string): string {
 
 function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
   const command = commandPath.join(' ')
-  const skillsHelp = formatSkillsCommandFlagHelp(command, flag)
-  if (skillsHelp) {
-    return skillsHelp
+  const scopedHelp =
+    formatSkillsCommandFlagHelp(command, flag) ?? formatWorktreeSelectorFlagHelp(command, flag)
+  if (scopedHelp) {
+    return scopedHelp
   }
   if (command === 'terminal close' && flag === 'tab') {
     return '--tab                  Close the whole tab and wait for durable persistence'
   }
   if (command === 'linear issue' && flag === 'id') {
     return '--id <id>             Linear issue key, id, or URL'
-  }
-  if (command === 'linear issue' && flag === 'workspace') {
-    return '--workspace <id>      Connected Linear workspace id'
   }
   if (command === 'linear search' && flag === 'query') {
     return '--query <text>        Text to search across Linear issues'

--- a/src/cli/index-test-harness.ts
+++ b/src/cli/index-test-harness.ts
@@ -108,6 +108,35 @@ export function pairRuntimeEnvironment(listEnvironmentsMock: Mock, id: string, n
   ])
 }
 
+/**
+ * Clears the workspace stamp Orca exports into its own terminals.
+ *
+ * Why every CLI suite needs it: the CLI now defaults to that workspace, so a developer running
+ * the tests from inside Orca would otherwise retarget every unscoped command under test.
+ */
+export function useOrcaTerminalWorkspaceEnvironment(): void {
+  const originalWorkspaceId = process.env.ORCA_WORKSPACE_ID
+  const originalWorktreeId = process.env.ORCA_WORKTREE_ID
+
+  beforeEach(() => {
+    delete process.env.ORCA_WORKSPACE_ID
+    delete process.env.ORCA_WORKTREE_ID
+  })
+
+  afterEach(() => {
+    if (originalWorkspaceId === undefined) {
+      delete process.env.ORCA_WORKSPACE_ID
+    } else {
+      process.env.ORCA_WORKSPACE_ID = originalWorkspaceId
+    }
+    if (originalWorktreeId === undefined) {
+      delete process.env.ORCA_WORKTREE_ID
+    } else {
+      process.env.ORCA_WORKTREE_ID = originalWorktreeId
+    }
+  })
+}
+
 /** Installs the env-var save/restore + mock-reset hooks shared by the CLI worktree-awareness suites. */
 export function useWorktreeAwarenessEnvironment(mocks: WorktreeAwarenessMocks): void {
   const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE
@@ -116,16 +145,13 @@ export function useWorktreeAwarenessEnvironment(mocks: WorktreeAwarenessMocks): 
   const originalPairingCode = process.env.ORCA_PAIRING_CODE
   const originalRemotePairing = process.env.ORCA_REMOTE_PAIRING
   const originalEnvironment = process.env.ORCA_ENVIRONMENT
-  const originalWorkspaceId = process.env.ORCA_WORKSPACE_ID
-  const originalWorktreeId = process.env.ORCA_WORKTREE_ID
+  useOrcaTerminalWorkspaceEnvironment()
 
   beforeEach(() => {
     mocks.callMock.mockReset()
     delete process.env.ORCA_TERMINAL_HANDLE
     delete process.env.ORCA_USER_DATA_PATH
     delete process.env.ORCA_DEV_CLI_INVOCATION
-    delete process.env.ORCA_WORKSPACE_ID
-    delete process.env.ORCA_WORKTREE_ID
     // Isolate the pane key so claude-teams tests that set it don't leak a
     // senderPaneKey into later orchestration.send assertions.
     delete process.env.ORCA_PANE_KEY
@@ -187,16 +213,6 @@ export function useWorktreeAwarenessEnvironment(mocks: WorktreeAwarenessMocks): 
       delete process.env.ORCA_ENVIRONMENT
     } else {
       process.env.ORCA_ENVIRONMENT = originalEnvironment
-    }
-    if (originalWorkspaceId === undefined) {
-      delete process.env.ORCA_WORKSPACE_ID
-    } else {
-      process.env.ORCA_WORKSPACE_ID = originalWorkspaceId
-    }
-    if (originalWorktreeId === undefined) {
-      delete process.env.ORCA_WORKTREE_ID
-    } else {
-      process.env.ORCA_WORKTREE_ID = originalWorktreeId
     }
   })
 }

--- a/src/cli/index-worktree-selector-resolution.test.ts
+++ b/src/cli/index-worktree-selector-resolution.test.ts
@@ -99,6 +99,20 @@ describe('orca cli worktree awareness', () => {
     expect(logSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('shows the workspace the calling Orca terminal belongs to for `worktree current`', async () => {
+    process.env.ORCA_WORKTREE_ID = 'folder:folder-1'
+    queueFixtures(
+      callMock,
+      okFixture('req_1', { worktree: { id: 'folder:folder-1', branch: '', path: '/tmp/ticket' } })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['worktree', 'current', '--json'], '/tmp/ticket/pos_frontend')
+
+    expect(callMock).toHaveBeenCalledOnce()
+    expect(callMock).toHaveBeenCalledWith('worktree.show', { worktree: 'folder:folder-1' })
+  })
+
   it('resolves the invocation cwd from ORCA_CLI_CWD when no cwd is passed', async () => {
     // Why: the SSH relay bridge runs the CLI on the Orca host with the remote
     // shell's cwd carried in ORCA_CLI_CWD (#7716); cwd-based selectors must

--- a/src/cli/root-help-text-secondary.ts
+++ b/src/cli/root-help-text-secondary.ts
@@ -81,7 +81,7 @@ export const ROOT_HELP_TEXT_SECONDARY = [
   '',
   'Selectors:',
   '  --repo <selector>         Registered repo selector such as id:<id>, name:<name>, or path:<path>',
-  '  --worktree <selector>     Worktree selector such as identity:<identity>, id:<repo-id>::<path>, name:<displayName>, branch:<branch>, issue:<number>, path:<path>, or active/current',
+  '  --worktree <selector>     Workspace selector such as identity:<identity>, id:<repo-id>::<path>, name:<displayName>, branch:<branch>, issue:<number>, path:<path>, folder:<id> (Folder Workspace), or active/current',
   '  --terminal <handle>       Runtime-issued terminal handle returned by `orca terminal list --json`',
   '  --parent-worktree <selector> Parent worktree selector such as identity:<identity>, id:<repo-id>::<path>, branch:<branch>, issue:<number>, path:<path>, or active/current',
   '  --no-parent               Force no parent lineage for unrelated worktree creation/update',

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -1,18 +1,23 @@
 import { resolve as resolvePath } from 'node:path'
-import type {
-  ComputerAppQuery,
-  RuntimeWorktreeListResult,
-  RuntimeWorktreeRecord
-} from '../shared/runtime-types'
+import type { ComputerAppQuery, RuntimeWorktreeListResult } from '../shared/runtime-types'
 import {
-  isPathInsideOrEqual,
   isWslUncPathForCallerLinuxPath,
   isWslUncPathForLinuxMountedPath
 } from '../shared/cross-platform-path'
 import { parseWslUncPath } from '../shared/wsl-paths'
 import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime/types'
+import {
+  assertLocalCwdWorktreeSelector,
+  resolveCurrentWorktreeSelector,
+  resolveOptionalCallerWorkspaceSelector
+} from './caller-workspace-selector'
 import { getOptionalStringFlag, getRequiredStringFlag } from './flags'
+
+export {
+  resolveCallerWorkspaceSelector,
+  resolveCurrentWorktreeSelector
+} from './caller-workspace-selector'
 
 export type BrowserCliTarget = {
   worktree?: string
@@ -89,56 +94,6 @@ export async function normalizeWorktreeSelectorForCaller(
   )
 }
 
-function assertLocalCwdWorktreeSelector(selector: string, client: RuntimeClient): void {
-  if (!client.isRemote) {
-    return
-  }
-  // Why: a paired CLI's cwd belongs to the client machine, not the runtime
-  // server, so cwd-derived worktree selectors are only valid locally.
-  throw new RuntimeClientError(
-    'invalid_argument',
-    `${selector} is a local cwd shortcut and cannot be resolved against a remote runtime. Pass an explicit server-side worktree selector such as identity:<identity>, id:<repo-id>::<path>, name:<displayName>, branch:<branch>, issue:<number>, or path:<absolute-server-path>.`
-  )
-}
-
-export async function resolveCurrentWorktreeSelector(
-  cwd: string,
-  client: RuntimeClient
-): Promise<string> {
-  assertLocalCwdWorktreeSelector('current', client)
-
-  const currentPath = resolvePath(cwd)
-  const worktrees = await client.call<RuntimeWorktreeListResult>('worktree.list', {
-    limit: 10_000
-  })
-  let enclosingWorktree: RuntimeWorktreeRecord | undefined
-  let enclosingPathLength = -1
-  for (const worktree of worktrees.result.worktrees) {
-    const worktreePath = resolvePath(worktree.path)
-    if (
-      !isPathInsideOrEqual(worktreePath, currentPath) ||
-      worktreePath.length <= enclosingPathLength
-    ) {
-      continue
-    }
-    enclosingWorktree = worktree
-    enclosingPathLength = worktreePath.length
-  }
-
-  if (!enclosingWorktree) {
-    throw new RuntimeClientError(
-      'selector_not_found',
-      `No Orca-managed worktree contains the current directory: ${currentPath}`
-    )
-  }
-
-  // Why: users expect "active/current" to mean the enclosing managed worktree
-  // even from nested subdirectories. Resolve to the concrete runtime id here:
-  // duplicate repo registrations can expose the same Git worktree path, and a
-  // path selector would throw selector_ambiguous after losing the repo id.
-  return `id:${enclosingWorktree.id}`
-}
-
 export async function getOptionalWorktreeSelector(
   flags: Map<string, string | boolean>,
   name: string,
@@ -170,8 +125,8 @@ export async function getRequiredWorktreeSelector(
   return await normalizeWorktreeSelectorForCaller(value, cwd, client)
 }
 
-// Why: local browser commands default to the current worktree by auto-resolving
-// from cwd. Remote commands omit worktree so the runtime uses server-side focus.
+// Why: local browser commands default to the workspace the caller's terminal belongs to.
+// Remote commands omit worktree so the runtime uses server-side focus.
 export async function getBrowserWorktreeSelector(
   flags: Map<string, string | boolean>,
   cwd: string,
@@ -188,16 +143,7 @@ export async function getBrowserWorktreeSelector(
     }
     return await normalizeWorktreeSelectorForCaller(value, cwd, client)
   }
-  if (client.isRemote) {
-    return undefined
-  }
-  // Default: auto-resolve from cwd
-  try {
-    return await resolveCurrentWorktreeSelector(cwd, client)
-  } catch {
-    // Not inside a managed worktree — no filter
-    return undefined
-  }
+  return await resolveOptionalCallerWorkspaceSelector(cwd, client)
 }
 
 // Why: mirrors browser's implicit active-tab targeting. When --terminal is
@@ -296,22 +242,7 @@ export async function getEmulatorWorktreeSelector(
     }
     return explicit
   }
-  if (client.isRemote) {
-    return undefined
-  }
-  const terminalWorktreeId = process.env.ORCA_WORKTREE_ID
-  if (terminalWorktreeId?.trim()) {
-    return terminalWorktreeId
-  }
-  const folderWorkspaceId = process.env.ORCA_WORKSPACE_ID?.trim()
-  if (folderWorkspaceId?.startsWith('folder:')) {
-    return folderWorkspaceId
-  }
-  try {
-    return await resolveCurrentWorktreeSelector(cwd, client)
-  } catch {
-    return undefined
-  }
+  return await resolveOptionalCallerWorkspaceSelector(cwd, client)
 }
 
 export async function getEmulatorCommandTarget(

--- a/src/cli/worktree-selector-flag-help.ts
+++ b/src/cli/worktree-selector-flag-help.ts
@@ -1,0 +1,25 @@
+/**
+ * Commands whose `--worktree` still names a git worktree only.
+ *
+ * Everything else merely scopes a workspace — browser tabs, terminals, emulators, computer-use,
+ * `worktree show` — and resolves a Folder Workspace as readily as a git worktree. These read or
+ * mutate the git worktree record itself, so `folder:<id>` has nothing to name for them.
+ */
+const GIT_ONLY_WORKTREE_SELECTOR_COMMANDS = new Set([
+  'worktree set',
+  'worktree rm',
+  'terminal stop',
+  'terminal close',
+  'file open',
+  'file diff',
+  'file open-changed',
+  'orchestration worker-start',
+  'orchestration coordinator-start'
+])
+
+/** Per-flag help for the workspace-scoped `--worktree`, kept out of the help chain it would crowd. */
+export function formatWorktreeSelectorFlagHelp(command: string, flag: string): string | undefined {
+  return flag === 'worktree' && !GIT_ONLY_WORKTREE_SELECTOR_COMMANDS.has(command)
+    ? '--worktree <selector>  Workspace selector such as identity:<identity>, id:<repo-id>::<path>, name:<displayName>, branch:<branch>, issue:<number>, path:<path>, folder:<id>, or active/current'
+    : undefined
+}

--- a/src/main/orcad/electron-serve-browser-process.test.ts
+++ b/src/main/orcad/electron-serve-browser-process.test.ts
@@ -42,7 +42,6 @@ const host: RuntimeBrowserCommandHost = {
   getAgentBrowserBridge: () => null,
   // Why an id distinct from the selector: it proves the registry fences on the
   // resolved worktree id, not on whatever string the caller passed.
-  resolveWorktreeSelector: async (selector) => ({ id: `id-${selector}` }),
   resolveBrowserWorkspace: async (selector) => ({ id: `id-${selector}` }),
   // Unused by the sidecar command paths under test; the daemon's real host is
   // OrcaRuntimeService, which owns the client-hosted registries.

--- a/src/main/orcad/electron-serve-browser-process.ts
+++ b/src/main/orcad/electron-serve-browser-process.ts
@@ -210,7 +210,7 @@ export class ElectronServeBrowserProcess {
     const original = (args[0] ?? {}) as Record<string, unknown>
     const worktreeId =
       typeof original.worktree === 'string'
-        ? (await host.resolveWorktreeSelector(original.worktree)).id
+        ? (await host.resolveBrowserWorkspace(original.worktree)).id
         : undefined
     const params: Record<string, unknown> = { ...original, worktree: undefined }
     const requestedPageId = typeof original.page === 'string' ? original.page : undefined

--- a/src/main/orcad/external-chromium-browser-process.integration.test.ts
+++ b/src/main/orcad/external-chromium-browser-process.integration.test.ts
@@ -36,7 +36,6 @@ describe('ExternalChromiumBrowserProcess integration', () => {
         }
         const commands = provider.factory({
           getAgentBrowserBridge: () => null,
-          resolveWorktreeSelector: async (selector) => ({ id: selector }),
           resolveBrowserWorkspace: async (selector) => ({ id: selector }),
           // Unused by the sidecar command paths under test; the daemon's real host is
           // OrcaRuntimeService, which owns the client-hosted registries.

--- a/src/main/orcad/external-chromium-tab-registry.ts
+++ b/src/main/orcad/external-chromium-tab-registry.ts
@@ -243,7 +243,7 @@ export class ExternalChromiumTabRegistry {
     worktree: unknown
   ): Promise<string | undefined> {
     return typeof worktree === 'string' && worktree
-      ? (await host.resolveWorktreeSelector(worktree)).id
+      ? (await host.resolveBrowserWorkspace(worktree)).id
       : undefined
   }
 }

--- a/src/main/orcad/orcad-browser-provider.test.ts
+++ b/src/main/orcad/orcad-browser-provider.test.ts
@@ -107,7 +107,6 @@ describe('ExternalChromiumBrowserProcess', () => {
     await processHandle.start()
     const commands = processHandle.createCommands({
       getAgentBrowserBridge: () => null,
-      resolveWorktreeSelector: async (selector) => ({ id: selector }),
       resolveBrowserWorkspace: async (selector) => ({ id: selector }),
       // Unused by the sidecar command paths under test; the daemon's real host is
       // OrcaRuntimeService, which owns the client-hosted registries.

--- a/src/main/runtime/browser-tab-create-publication.test.ts
+++ b/src/main/runtime/browser-tab-create-publication.test.ts
@@ -50,7 +50,6 @@ function createCommandHost(
 ): RuntimeBrowserCommandHost {
   const runtimeBrowserPages = new RuntimeBrowserPageRegistry()
   return {
-    resolveWorktreeSelector: async (selector: string) => ({ id: selector.replace(/^id:/, '') }),
     resolveBrowserWorkspace: async (selector: string) => ({ id: selector.replace(/^id:/, '') }),
     getRuntimeBrowserPageRegistry: () => runtimeBrowserPages,
     getAgentBrowserBridge: () =>

--- a/src/main/runtime/orca-runtime-adopt-terminal-orphans-from-inventory.ts
+++ b/src/main/runtime/orca-runtime-adopt-terminal-orphans-from-inventory.ts
@@ -93,7 +93,7 @@ export class OrcaRuntimeWithAdoptTerminalOrphansFromInventory extends OrcaRuntim
   ): Promise<string> {
     if (this.graphStatus !== 'ready') {
       const targetWorktreeId = worktreeSelector
-        ? (await this.resolveWorktreeSelector(worktreeSelector)).id
+        ? (await this.resolveWorkspaceSelector(worktreeSelector)).id
         : null
       const snapshots = targetWorktreeId
         ? [this.getMobileSessionTabsForWorktree(targetWorktreeId)]
@@ -128,7 +128,7 @@ export class OrcaRuntimeWithAdoptTerminalOrphansFromInventory extends OrcaRuntim
     this.assertGraphReady()
 
     const targetWorktreeId = worktreeSelector
-      ? (await this.resolveWorktreeSelector(worktreeSelector)).id
+      ? (await this.resolveWorkspaceSelector(worktreeSelector)).id
       : null
 
     // Prefer the tab's activeLeafId — this is the pane the user last focused.

--- a/src/main/runtime/orca-runtime-browser-client-hosted.test.ts
+++ b/src/main/runtime/orca-runtime-browser-client-hosted.test.ts
@@ -73,7 +73,6 @@ function createHost(overrides: Partial<RuntimeBrowserCommandHost> = {}): Runtime
         }))
       } as unknown as AgentBrowserBridge)
   return {
-    resolveWorktreeSelector: async (selector) => ({ id: selector.replace(/^id:/, '') }),
     resolveBrowserWorkspace: async (selector) => ({ id: selector.replace(/^id:/, '') }),
     getRuntimeBrowserPageRegistry: () => runtimeBrowserPages,
     getAuthoritativeWindow: vi.fn(),

--- a/src/main/runtime/orca-runtime-browser-folder-workspace.test.ts
+++ b/src/main/runtime/orca-runtime-browser-folder-workspace.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Browser commands issued from a Folder Workspace terminal scope themselves by `folder:<id>`.
+ * The git-only selector grammar cannot match that, so every target resolution here has to go
+ * through the folder-aware resolver or the command silently lands in the UI-focused workspace.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
+import type { RuntimeBrowserCommandHost } from './orca-runtime-browser'
+import { RuntimeBrowserPageRegistry } from './runtime-browser-page-registry'
+
+const FOLDER_KEY = 'folder:52d2e7a3-c08f-4d0e-9771-f7581df19b6c'
+
+const {
+  ipcMainOnMock,
+  webContentsFromIdMock,
+  waitForTabRegistrationMock,
+  waitForWorktreeTabRegistrationMock,
+  browserSessionRegistryMock
+} = vi.hoisted(() => ({
+  ipcMainOnMock: vi.fn(),
+  webContentsFromIdMock: vi.fn(),
+  waitForTabRegistrationMock: vi.fn(),
+  waitForWorktreeTabRegistrationMock: vi.fn(),
+  browserSessionRegistryMock: {
+    getDefaultProfile: vi.fn(),
+    getProfile: vi.fn(),
+    resolveKnownPartition: vi.fn(),
+    createProfile: vi.fn()
+  }
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: { on: ipcMainOnMock, removeListener: vi.fn() },
+  webContents: { fromId: webContentsFromIdMock }
+}))
+
+vi.mock('../ipc/browser-tab-registration-wait', () => ({
+  waitForTabRegistration: waitForTabRegistrationMock,
+  waitForWorktreeTabRegistration: waitForWorktreeTabRegistrationMock
+}))
+
+vi.mock('../browser/browser-session-registry', () => ({
+  browserSessionRegistry: browserSessionRegistryMock
+}))
+
+/**
+ * Stands in for the runtime's folder-aware resolver: a `folder:` key is a workspace of its own,
+ * anything else is a git worktree id.
+ */
+function resolveWorkspace(selector: string): { id: string } {
+  const workspaceSelector = selector.startsWith('id:') ? selector.slice(3) : selector
+  if (workspaceSelector.startsWith('folder:')) {
+    return { id: workspaceSelector }
+  }
+  if (!workspaceSelector.includes('::')) {
+    throw new Error('selector_not_found')
+  }
+  return { id: workspaceSelector }
+}
+
+function createHost(overrides: Partial<RuntimeBrowserCommandHost> = {}): RuntimeBrowserCommandHost {
+  const runtimeBrowserPages = new RuntimeBrowserPageRegistry()
+  const bridge = overrides.getAgentBrowserBridge
+    ? overrides.getAgentBrowserBridge()
+    : ({
+        getRegisteredTabs: vi.fn(() => new Map([['page-1', 100]])),
+        getActivePageId: vi.fn(() => 'page-1'),
+        snapshot: vi.fn(async () => ({ snapshot: 'tree', refs: [] }))
+      } as unknown as AgentBrowserBridge)
+  return {
+    resolveBrowserWorkspace: async (selector: string) => resolveWorkspace(selector),
+    getRuntimeBrowserPageRegistry: () => runtimeBrowserPages,
+    getAuthoritativeWindow: vi.fn(),
+    getAvailableAuthoritativeWindow: vi.fn(() => null),
+    getOffscreenBrowserBackend: vi.fn(() => null),
+    ...overrides,
+    getAgentBrowserBridge: () => bridge
+  } as unknown as RuntimeBrowserCommandHost
+}
+
+describe('browser commands targeting a Folder Workspace', () => {
+  beforeEach(() => {
+    ipcMainOnMock.mockReset()
+    webContentsFromIdMock.mockReset()
+    webContentsFromIdMock.mockReturnValue({ isDestroyed: () => false })
+    waitForTabRegistrationMock.mockReset()
+    waitForTabRegistrationMock.mockResolvedValue(undefined)
+    waitForWorktreeTabRegistrationMock.mockReset()
+    waitForWorktreeTabRegistrationMock.mockResolvedValue(undefined)
+    browserSessionRegistryMock.resolveKnownPartition.mockReset()
+    browserSessionRegistryMock.resolveKnownPartition.mockReturnValue('persist:orca-browser')
+  })
+
+  it('snapshots the folder workspace named by the caller, not the focused one', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const snapshot = vi.fn(async () => ({ snapshot: 'tree', refs: [] }))
+    const bridge = {
+      getRegisteredTabs: vi.fn(() => new Map([['page-1', 100]])),
+      getActivePageId: vi.fn(() => 'page-1'),
+      snapshot
+    } as unknown as AgentBrowserBridge
+    const commands = new RuntimeBrowserCommands(createHost({ getAgentBrowserBridge: () => bridge }))
+
+    await commands.browserSnapshot({ worktree: FOLDER_KEY })
+
+    expect(snapshot).toHaveBeenCalledWith(FOLDER_KEY, undefined)
+  })
+
+  it('keeps an explicit page scoped to the folder workspace that was named', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const snapshot = vi.fn(async () => ({ snapshot: 'tree', refs: [] }))
+    const bridge = {
+      getRegisteredTabs: vi.fn(() => new Map([['page-7', 107]])),
+      getActivePageId: vi.fn(() => 'page-7'),
+      snapshot
+    } as unknown as AgentBrowserBridge
+    const commands = new RuntimeBrowserCommands(createHost({ getAgentBrowserBridge: () => bridge }))
+
+    await commands.browserSnapshot({ worktree: `id:${FOLDER_KEY}`, page: 'page-7' })
+
+    expect(snapshot).toHaveBeenCalledWith(FOLDER_KEY, 'page-7')
+  })
+
+  it('creates a tab in the folder workspace the caller named', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const createTab = vi.fn(async () => ({ browserPageId: 'page-new' }))
+    const commands = new RuntimeBrowserCommands(
+      createHost({
+        getOffscreenBrowserBackend: vi.fn(() => ({ createTab, closeTab: vi.fn() }) as never),
+        notifyHeadlessBrowserSessionTabsChanged: vi.fn()
+      })
+    )
+
+    await expect(
+      commands.browserTabCreate({ url: 'https://example.com', worktree: FOLDER_KEY })
+    ).resolves.toEqual({ browserPageId: 'page-new' })
+    expect(createTab).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: FOLDER_KEY, url: 'https://example.com' })
+    )
+  })
+
+  it('still refuses a selector that names no workspace at all', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    const commands = new RuntimeBrowserCommands(createHost())
+
+    await expect(commands.browserSnapshot({ worktree: 'name:gone' })).rejects.toThrow(
+      'selector_not_found'
+    )
+  })
+})

--- a/src/main/runtime/orca-runtime-browser-ghost-session-row-close.test.ts
+++ b/src/main/runtime/orca-runtime-browser-ghost-session-row-close.test.ts
@@ -118,7 +118,6 @@ function createHost(overrides: Partial<RuntimeBrowserCommandHost> = {}): Runtime
           tabList: vi.fn(() => ({ tabs: [] }))
         } as unknown as AgentBrowserBridge)
   return {
-    resolveWorktreeSelector: async (selector: string) => ({ id: selector.replace(/^id:/, '') }),
     resolveBrowserWorkspace: async (selector: string) => ({ id: selector.replace(/^id:/, '') }),
     getRuntimeBrowserPageRegistry: () => runtimeBrowserPages,
     getBrowserHostLeaseRegistry: () => ({ getPlacement: () => undefined }),

--- a/src/main/runtime/orca-runtime-browser-headless.test.ts
+++ b/src/main/runtime/orca-runtime-browser-headless.test.ts
@@ -68,7 +68,6 @@ function createHost(overrides: Partial<RuntimeBrowserCommandHost> = {}): Runtime
         tabList: vi.fn(() => ({ tabs: [] }))
       } as unknown as AgentBrowserBridge)
   return {
-    resolveWorktreeSelector: async (selector) => ({ id: selector.replace(/^id:/, '') }),
     resolveBrowserWorkspace: async (selector) => ({ id: selector.replace(/^id:/, '') }),
     getRuntimeBrowserPageRegistry: () => runtimeBrowserPages,
     getAuthoritativeWindow: vi.fn(),

--- a/src/main/runtime/orca-runtime-browser-screencast-fanout.test.ts
+++ b/src/main/runtime/orca-runtime-browser-screencast-fanout.test.ts
@@ -42,7 +42,7 @@ function createCommandsHost(): RuntimeBrowserCommandHost {
     }))
   } as unknown as AgentBrowserBridge
   return {
-    resolveWorktreeSelector: async () => ({ id: 'wt-1' }),
+    resolveBrowserWorkspace: async () => ({ id: 'wt-1' }),
     getAgentBrowserBridge: () => bridge,
     getRuntimeBrowserPageRegistry: () => runtimeBrowserPages,
     getAvailableAuthoritativeWindow: vi.fn(() => null),

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -97,7 +97,6 @@ function createHost(overrides: Partial<RuntimeBrowserCommandHost> = {}): Runtime
         }))
       } as unknown as AgentBrowserBridge)
   return {
-    resolveWorktreeSelector: async (selector) => ({ id: selector.replace(/^id:/, '') }),
     resolveBrowserWorkspace: async (selector) => ({ id: selector.replace(/^id:/, '') }),
     getRuntimeBrowserPageRegistry: () => runtimeBrowserPages,
     getAuthoritativeWindow: vi.fn(),

--- a/src/main/runtime/orca-runtime-list-managed-worktrees.ts
+++ b/src/main/runtime/orca-runtime-list-managed-worktrees.ts
@@ -114,8 +114,10 @@ export class OrcaRuntimeWithListManagedWorktrees extends OrcaRuntimeWithRestoreS
     )
   }
 
+  // Why the folder-aware resolver: `worktree current` reports `folder:<id>` for a terminal in a
+  // Folder Workspace, and `worktree show` must be able to look that answer back up.
   async showManagedWorktree(worktreeSelector: string) {
-    return await this.resolveWorktreeSelector(worktreeSelector)
+    return await this.resolveBrowserWorkspace(worktreeSelector)
   }
 
   async showManagedTerminalWorkspace(worktreeSelector: string) {

--- a/src/main/runtime/orca-runtime-list-managed-worktrees.ts
+++ b/src/main/runtime/orca-runtime-list-managed-worktrees.ts
@@ -114,10 +114,11 @@ export class OrcaRuntimeWithListManagedWorktrees extends OrcaRuntimeWithRestoreS
     )
   }
 
-  // Why the folder-aware resolver: `worktree current` reports `folder:<id>` for a terminal in a
-  // Folder Workspace, and `worktree show` must be able to look that answer back up.
+  // Why the plain resolver: `worktree current` reports `folder:<id>` for a terminal in a Folder
+  // Workspace, and `worktree show` must look that answer back up — but showing a row is a catalog
+  // read, so it must not gate on the folder path being reachable the way a browser launch does.
   async showManagedWorktree(worktreeSelector: string) {
-    return await this.resolveBrowserWorkspace(worktreeSelector)
+    return await this.resolveWorkspaceSelector(worktreeSelector)
   }
 
   async showManagedTerminalWorkspace(worktreeSelector: string) {

--- a/src/main/runtime/orca-runtime-stop-requested-pty-ids.ts
+++ b/src/main/runtime/orca-runtime-stop-requested-pty-ids.ts
@@ -120,7 +120,9 @@ export class OrcaRuntimeWithStopRequestedPtyIds extends OrcaRuntimeWithRuntimeId
     getExplicitWorktreeId: (selector) => this.getValidatedExplicitWorktreeIdSelector(selector),
     getResolvedCache: () => this.resolvedWorktrees.peek(),
     buildWorktreeFromId: (worktreeId) => this.buildResolvedWorktreeFromId(worktreeId),
-    resolveWorktree: (selector) => this.resolveWorktreeSelector(selector),
+    // Why the folder-aware resolver: a terminal in a Folder Workspace scopes itself by
+    // `folder:<id>`, which the git-only selector grammar cannot match.
+    resolveWorktree: (selector) => this.resolveWorkspaceSelector(selector),
     listKnownWorktrees: (worktreeId, target) =>
       this.listKnownResolvedWorktreesForExplicitTarget(worktreeId, target),
     getWorktreeMap: () => this.getResolvedWorktreeMap(),

--- a/src/main/runtime/orca-runtime-terminal-drivers.ts
+++ b/src/main/runtime/orca-runtime-terminal-drivers.ts
@@ -38,7 +38,6 @@ export class OrcaRuntimeWithTerminalDrivers extends OrcaRuntimeWithFitOverrideLi
   protected readonly edgeCommands = new RuntimeEdgeCommandController({
     browserHost: {
       getAgentBrowserBridge: () => this.agentBrowserBridge,
-      resolveWorktreeSelector: (selector) => this.resolveWorktreeSelector(selector),
       resolveBrowserWorkspace: (selector) => this.resolveBrowserWorkspace(selector),
       getBrowserHostLeaseRegistry: () => getBrowserHostLeaseRegistry(this),
       getRuntimeBrowserPageRegistry: () => getRuntimeBrowserPageRegistry(this),

--- a/src/main/runtime/orca-runtime-tests/worktree-selector-resolution.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/worktree-selector-resolution.spec.ts
@@ -144,6 +144,38 @@ describe('OrcaRuntimeService', () => {
   it.each([
     { label: 'canonical folder workspace selector', selector: TEST_FOLDER_WORKSPACE_KEY },
     { label: 'id-prefixed folder workspace selector', selector: `id:${TEST_FOLDER_WORKSPACE_KEY}` }
+  ])('shows the folder workspace named by a $label', async ({ selector }) => {
+    // Why: `worktree current` reports `folder:<id>` for a terminal in a Folder Workspace, so
+    // `worktree show` has to be able to look that same answer back up.
+    const folderPath = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-show-'))
+    const folderWorkspace = makeFolderWorkspace({ folderPath })
+    const projectGroup = makeFolderProjectGroup({ parentPath: folderPath })
+    const runtime = new OrcaRuntimeService(
+      createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup) as never
+    )
+
+    await expect(runtime.showManagedWorktree(selector)).resolves.toMatchObject({
+      id: TEST_FOLDER_WORKSPACE_KEY,
+      path: folderPath
+    })
+  })
+
+  it('scopes terminal listing to a folder workspace selector', async () => {
+    const folderPath = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-terminals-'))
+    const folderWorkspace = makeFolderWorkspace({ folderPath })
+    const projectGroup = makeFolderProjectGroup({ parentPath: folderPath })
+    const runtime = new OrcaRuntimeService(
+      createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup) as never
+    )
+
+    await expect(runtime.listTerminals(TEST_FOLDER_WORKSPACE_KEY)).resolves.toMatchObject({
+      terminals: []
+    })
+  })
+
+  it.each([
+    { label: 'canonical folder workspace selector', selector: TEST_FOLDER_WORKSPACE_KEY },
+    { label: 'id-prefixed folder workspace selector', selector: `id:${TEST_FOLDER_WORKSPACE_KEY}` }
   ])('reads file explorer paths for a $label', async ({ selector }) => {
     const folderPath = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-files-'))
     await mkdir(join(folderPath, 'src'))

--- a/src/main/runtime/orca-runtime-tests/worktree-selector-resolution.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/worktree-selector-resolution.spec.ts
@@ -147,7 +147,9 @@ describe('OrcaRuntimeService', () => {
   ])('shows the folder workspace named by a $label', async ({ selector }) => {
     // Why: `worktree current` reports `folder:<id>` for a terminal in a Folder Workspace, so
     // `worktree show` has to be able to look that same answer back up.
-    const folderPath = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-show-'))
+    // Why the folder is never created on disk: showing a row is a catalog read, so it answers from
+    // the store through the plain resolver and must not gate on the path the way a browser does.
+    const folderPath = join(tmpdir(), 'orca-runtime-folder-show-missing')
     const folderWorkspace = makeFolderWorkspace({ folderPath })
     const projectGroup = makeFolderProjectGroup({ parentPath: folderPath })
     const runtime = new OrcaRuntimeService(

--- a/src/main/runtime/orca-runtime-transition-graph-reload-to-terminal-state.ts
+++ b/src/main/runtime/orca-runtime-transition-graph-reload-to-terminal-state.ts
@@ -132,11 +132,22 @@ export class OrcaRuntimeWithTransitionGraphReloadToTerminalState extends OrcaRun
     return workspace
   }
 
-  protected async resolveEmulatorWorkspaceId(selector: string): Promise<string> {
+  /**
+   * A CLI workspace selector as a resolved workspace, Folder Workspaces included.
+   *
+   * Why not `resolveBrowserWorkspace`: that one also proves the folder path is usable, which a
+   * listing must not depend on, and its await would move git-only resolution off the caller's
+   * tick — terminal listing fences itself on the graph epoch and needs that tick unchanged.
+   */
+  protected resolveWorkspaceSelector(selector: string): Promise<ResolvedWorktree> {
     const folderWorkspace = this.resolveFolderWorkspaceSelector(selector)
     return folderWorkspace
-      ? folderWorkspaceKey(folderWorkspace.id)
-      : (await this.resolveWorktreeSelector(selector)).id
+      ? Promise.resolve(this.folderWorkspaceToResolvedWorktree(folderWorkspace))
+      : this.resolveWorktreeSelector(selector)
+  }
+
+  protected async resolveEmulatorWorkspaceId(selector: string): Promise<string> {
+    return (await this.resolveWorkspaceSelector(selector)).id
   }
 
   protected async resolveBrowserWorkspace(selector: string): Promise<ResolvedWorktree> {

--- a/src/main/runtime/runtime-browser-commands-active-screencasts-by-page-id.ts
+++ b/src/main/runtime/runtime-browser-commands-active-screencasts-by-page-id.ts
@@ -72,7 +72,9 @@ export class RuntimeBrowserCommandsWithActiveScreencastsByPageId extends Runtime
     return Boolean(guest && !guest.isDestroyed())
   }
 
-  // Why: the CLI sends selectors (e.g. "path:/...") but the bridge keys tabs by "repoId::path"; resolve to that store-compatible id.
+  // Why: the CLI sends selectors (e.g. "path:/..." or "folder:<id>") but the bridge keys tabs by
+  // the workspace id; resolve through the folder-aware resolver so a Folder Workspace terminal
+  // reaches its own tabs instead of falling through to whichever workspace the UI has focused.
   private async resolveBrowserWorktreeId(selector?: string): Promise<string | undefined> {
     if (!selector) {
       // Why: after restart, webviews mount only when the pane is visible; activate the view so persisted tabs become operable via registerGuest.
@@ -87,7 +89,7 @@ export class RuntimeBrowserCommandsWithActiveScreencastsByPageId extends Runtime
       return undefined
     }
 
-    const worktreeId = (await this.host.resolveWorktreeSelector(selector)).id
+    const worktreeId = (await this.host.resolveBrowserWorkspace(selector)).id
     // Why: explicit selectors are user intent, so resolution errors surface (not silently widen scope); only activation stays best-effort.
     const bridge = this.host.getAgentBrowserBridge()
     if (bridge && !this.hasLiveRegisteredBrowserTab(bridge, worktreeId)) {
@@ -112,7 +114,7 @@ export class RuntimeBrowserCommandsWithActiveScreencastsByPageId extends Runtime
     }
 
     const worktreeId = params.worktree
-      ? (await this.host.resolveWorktreeSelector(params.worktree)).id
+      ? (await this.host.resolveBrowserWorkspace(params.worktree)).id
       : undefined
     const bridge = this.host.getAgentBrowserBridge()
     if (bridge && !this.hasLiveRegisteredBrowserPage(bridge, worktreeId, browserPageId)) {

--- a/src/main/runtime/runtime-browser-commands-browser-command-target-params.ts
+++ b/src/main/runtime/runtime-browser-commands-browser-command-target-params.ts
@@ -158,11 +158,7 @@ export function clampOptionalNumber(
 
 export type RuntimeBrowserCommandHost = {
   getAgentBrowserBridge(): AgentBrowserBridge | null
-  resolveWorktreeSelector(selector: string): Promise<{
-    id: string
-    repoId?: string
-    hostId?: ExecutionHostId
-  }>
+  /** Resolves any workspace selector the CLI can send, Folder Workspaces included. */
   resolveBrowserWorkspace(selector: string): Promise<{
     id: string
     repoId?: string

--- a/src/main/runtime/runtime-browser-commands-browser-tab-close.ts
+++ b/src/main/runtime/runtime-browser-commands-browser-tab-close.ts
@@ -64,7 +64,7 @@ export class RuntimeBrowserCommandsWithBrowserTabClose extends RuntimeBrowserCom
         namedPageId &&
         params.worktree &&
         this.retireGhostBrowserSessionRow(
-          (await this.host.resolveWorktreeSelector(params.worktree)).id,
+          (await this.host.resolveBrowserWorkspace(params.worktree)).id,
           namedPageId
         )
       ) {
@@ -74,7 +74,7 @@ export class RuntimeBrowserCommandsWithBrowserTabClose extends RuntimeBrowserCom
     }
     const worktreeId = explicitPage
       ? params.worktree
-        ? (await this.host.resolveWorktreeSelector(params.worktree)).id
+        ? (await this.host.resolveBrowserWorkspace(params.worktree)).id
         : undefined
       : await this.resolveBrowserWorktreeId(params.worktree)
 

--- a/src/main/runtime/runtime-browser-commands-browser-tab-create.ts
+++ b/src/main/runtime/runtime-browser-commands-browser-tab-create.ts
@@ -40,9 +40,7 @@ export class RuntimeBrowserCommandsWithBrowserTabCreate extends RuntimeBrowserCo
       clientKind: caller?.clientKind
     })
     const worktree = params.worktree
-      ? params.placement?.kind === 'client'
-        ? await this.host.resolveBrowserWorkspace(params.worktree)
-        : await this.host.resolveWorktreeSelector(params.worktree)
+      ? await this.host.resolveBrowserWorkspace(params.worktree)
       : undefined
     const worktreeId = worktree?.id
     const sessionPartition = browserSessionRegistry.resolveKnownPartition(params.profileId)

--- a/src/main/runtime/structured-worker-mail-routing.test.ts
+++ b/src/main/runtime/structured-worker-mail-routing.test.ts
@@ -92,7 +92,7 @@ describe('implicit sender resolution refuses to guess', () => {
     return {
       graphStatus: 'ready',
       assertGraphReady: () => {},
-      resolveWorktreeSelector: async () => ({ id: 'wt_1' }),
+      resolveWorkspaceSelector: async () => ({ id: 'wt_1' }),
       tabs: new Map(),
       leaves: new Map(
         leafIds.map((leafId) => [leafId, { tabId: 'tab_1', leafId, worktreeId: 'wt_1' }])
@@ -123,7 +123,7 @@ describe('implicit sender resolution refuses to guess', () => {
     // focus guess left in, proving nothing about it.
     const preReady = {
       graphStatus: 'starting',
-      resolveWorktreeSelector: async () => ({ id: 'wt_1' }),
+      resolveWorkspaceSelector: async () => ({ id: 'wt_1' }),
       getMobileSessionTabsForWorktree: () => ({
         tabs: [{ type: 'terminal', isActive: true, status: 'ready', terminal: 'term_focused' }]
       }),


### PR DESCRIPTION
## ELI5

When you run `orca` from a terminal inside a ticket's Folder Workspace, the command now acts on that workspace. Before, it acted on whatever workspace happened to be focused in the app, so browser tabs opened by an agent landed on the wrong workspace.

## What Changed

Five commits, each reviewable on its own:

1. **`fix(cli): default commands to the spawning terminal's workspace`** — new `caller-workspace-selector.ts` with one shared rule for local clients: explicit flag → `ORCA_WORKTREE_ID` → `ORCA_WORKSPACE_ID` (when it names a folder) → current directory. `getBrowserWorktreeSelector`, `getEmulatorWorktreeSelector` (which also drives `terminal` and `computer` commands) and `worktree current` use it. Only the emulator path read the environment before. Explicit `active`/`current` still means "resolve from cwd"; remote clients are unchanged. A git worktree id from the environment is sent as `id:<id>` so it narrows to its repo. `resolveCurrentWorktreeSelector` moved out of `selectors.ts` to stay inside the line budget; `selectors.ts` re-exports it.
2. **`fix(cli): resolve the current directory against folder workspaces too`** — when no git worktree encloses the directory, `resolveCurrentWorktreeSelector` consults `folderWorkspace.list` and returns `folder:<id>`. The folder read is lazy, so every path that resolved before makes the same calls and returns the same result. Error text is now "No Orca-managed **workspace** contains the current directory".
3. **`fix(runtime): resolve folder workspace selectors for browser commands`** — browser command targets (`resolveBrowserWorktreeId`, `resolveBrowserCommandTarget`, `browserTabCreate`, `browserTabClose`, and the two orcad providers) resolve through the existing folder-aware `resolveBrowserWorkspace`; `browserTabCreate` previously used it only for client-hosted placements, which is the reported bug. The now-unused git-only `resolveWorktreeSelector` port was removed from `RuntimeBrowserCommandHost`. `terminal.resolveActive` / `terminal.list` and `worktree.show` accept `folder:<id>` via a new `resolveWorkspaceSelector` primitive (`resolveEmulatorWorkspaceId` is a wrapper over it). Help text lists `folder:<id>` for the `--worktree` flags that accept it, via `worktree-selector-flag-help.ts`; commands that remain git-only (`worktree set`/`rm`, `terminal stop`/`close`, `file *`, `orchestration *-start`) keep the old text.
4. **`fix(cli): fail instead of silently retargeting the UI-active workspace`** — when the CLI runs inside an Orca terminal and its cwd/stamp resolution fails, it throws `selector_not_found` naming the terminal's workspace and pointing at `--worktree <selector>` / `--worktree all`, instead of passing `worktree: undefined`. Outside an Orca terminal the unscoped fallback is unchanged. An environment-derived selector the runtime cannot resolve surfaces the runtime's own `selector_not_found`.

5. **`fix(cli): match the current directory against local-host workspaces only`** — `worktree.list` and `folderWorkspace.list` both include workspaces on paired SSH hosts, and a path-only match can answer with another machine's workspace when the same path exists on both (it does on my setup). Both candidate lists are now filtered to local-host entries before the deepest-match pass; `runtime:` hosts count as local, matching `resolveFolderWorkspaceHost`, and an unparseable host id is excluded.

Side effect worth stating: `worktree create` with no `--parent-worktree` run from a Folder Workspace root now nests the new worktree under that folder, because the cwd-derived parent can be `folder:<id>` and `resolveParent` already accepts it.

## Why

The terminal already knows its workspace; the CLI just never asked. Using that stamp first is the only signal that survives an agent `cd`-ing into a child repo, and it is what the emulator commands already did. Routing browser targets through the existing folder-aware resolver, rather than a new grammar, keeps one selector vocabulary.

## Linked Issue

Fixes #19699

## Visual Proof

CLI behaviour, so terminal output. From a Folder Workspace root (`~/Source/cloud-worktrees/API-783`):

Before:

```
$ orca worktree current
No Orca-managed worktree contains the current directory: /home/msmit/Source/cloud-worktrees/API-783
$ orca tab create --url https://example.com --json
{"ok":true,...}   # tab created on whichever workspace was focused in the UI
```

After:

```
$ orca worktree current
id: folder:52d2e7a3-c08f-4d0e-9771-f7581df19b6c
repoId: folder-workspace:234d3f27-ee3e-4b49-93b8-bb339700b263
displayName: API-783 : Include disabled POS users in Employees and PosUsers documents

$ cd pos_frontend && orca worktree current
id: de662d09-10c1-40b7-b192-73d19f279ebb::/home/msmit/Source/cloud-worktrees/API-783/pos_frontend

$ orca tab create --url https://example.com    # from the API-783 terminal, another workspace focused
# tab lands on API-783

$ cd /tmp && orca worktree current
No Orca-managed workspace contains the current directory: /tmp
```

## Testing

Linux (self-built from this branch on top of 1.4.199), local host. Manual: the before/after above, plus `orca tab create` from a Folder Workspace terminal while a different workspace was focused; the tab appeared on the Folder Workspace.

Automated:

- `src/cli/caller-workspace-selector.test.ts` (new): local worktree wins over a paired-host worktree at the same path, paired-host-only path falls through, paired-host folder ignored; precedence order, folder stamp fallback, stale parent stamp, explicit selector outranks terminal, `--worktree all`, `--worktree current`, cwd outside an Orca terminal, unmanaged directory, remote client unchanged, remote `worktree current` refused, emulator shares the rule, Folder Workspace root, folder subdirectory, git worktree nested in a folder (folder catalog never read), no-silent-fallback error.
- `src/cli/index-worktree-selector-resolution.test.ts`: `worktree current` inside an Orca terminal.
- `src/main/runtime/orca-runtime-browser-folder-workspace.test.ts` (new): snapshot and tab create target the named folder, explicit page stays scoped to it, unknown selector still refused.
- `src/main/runtime/orca-runtime-tests/worktree-selector-resolution.spec.ts`: `worktree.show` and `terminal.list` with `folder:<id>` and `id:folder:<id>`.
- Updated: `emulator.test.ts` expects `id:`-prefixed env selectors; `browser.test.ts`, `computer.test.ts`, `computer-action-routing.test.ts`, `emulator.test.ts` now isolate `ORCA_WORKTREE_ID`/`ORCA_WORKSPACE_ID` (they failed when run from inside an Orca terminal); browser-host test doubles dropped the removed `resolveWorktreeSelector`.
- `typecheck` clean (all three projects); `pnpm lint` clean, including the localization checks, on the current `main` base. `vitest` over `src/cli/`, `src/main/runtime/`, `src/main/orcad/`: 865 files, 8720 passed, 0 failed. The remaining suites (`src/shared`, the rest of `src/main`, `src/renderer`, `src/preload`, `src/relay`, `tests`) were run in batches on this branch and on `main` at the base commit: the same 20 tests fail on both (bash DEBUG-trap composition, GPU flags, a real-binary Claude resume, scrollback eviction timing), none in files this change touches.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude (claude-fable-5) working under my direction from a written bug report; I reviewed the changes and tested them on my own Orca setup.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

`orca file`, `automation`, `worktree set`/`rm`/`sleep`, `terminal stop`/`close` still resolve git worktrees only. From a Folder Workspace root they now send `folder:<id>` and fail at the runtime with `selector_not_found` instead of failing in the CLI; same outcome, and their help text says so. Remote (SSH-paired) clients keep server-side focus, as before. No renderer or i18n changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
