### PR TITLE
fix(agent-hooks): honor Codex launcher home on remote hosts

### DIFF
--- a/src/main/agent-hooks/managed-hook-runtime.test.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.test.ts
@@ -4,12 +4,10 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as NodeChildProcess from 'node:child_process'
 
-const { resolveCodexCommandMock, runCodexAppServerSessionMock } = vi.hoisted(() => ({
-  resolveCodexCommandMock: vi.fn(() => '/stub/codex'),
+const { runCodexAppServerSessionMock } = vi.hoisted(() => ({
   runCodexAppServerSessionMock: vi.fn()
 }))
 
-vi.mock('../codex-cli/command', () => ({ resolveCodexCommand: resolveCodexCommandMock }))
 vi.mock('../codex/codex-app-server-session', () => ({
   runCodexAppServerSession: runCodexAppServerSessionMock
 }))
@@ -48,8 +46,6 @@ function stubProbeFailure(error: Error): void {
 
 beforeEach(() => {
   execFileMock.mockReset()
-  resolveCodexCommandMock.mockReset()
-  resolveCodexCommandMock.mockReturnValue('/stub/codex')
   runCodexAppServerSessionMock.mockReset()
   // Why: `installManagedHooks` proves a skipped probe through the login-shell run log, so the
   // probe must really spawn unless a case above stubs it. The mock loses `promisify.custom`,
@@ -148,15 +144,36 @@ describe.runIf(process.platform !== 'win32')('resolveRelayCodexHome', () => {
     stubCodexHomeProbe('/srv/codex///')
 
     await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/srv/codex')
-    expect(runCodexAppServerSessionMock).toHaveBeenCalledWith(
-      {
-        command: '/stub/codex',
-        args: ['app-server'],
-        cliPath: '/stub/codex',
-        timeoutMs: 8_000
-      },
-      expect.any(Function)
-    )
+  })
+
+  // Why these three are pinned together: each one on its own silently degrades
+  // into the ~/.codex fallback, which reads as "not redirected" rather than as a
+  // failure, so a regression here looks like success.
+  it('asks Codex through a login shell, under the installer s home', async () => {
+    vi.stubEnv('SHELL', '/bin/bash')
+    stubCodexHomeProbe('/srv/codex')
+
+    await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/srv/codex')
+
+    const [invocation] = runCodexAppServerSessionMock.mock.calls[0] ?? []
+    // A launcher wrapper lives on the login shell's PATH only; this process's
+    // PATH is a non-login SSH exec and never has ~/.local/bin on it.
+    expect(invocation).toMatchObject({ command: '/bin/bash', cliPath: null })
+    expect(invocation.args[0]).toBe('-lc')
+    expect(invocation.args[1]).toMatch(/^exec codex .*app-server$/)
+    // Parent and child must agree on which account is being configured...
+    expect(invocation.env).toEqual({ HOME: '/home/orca' })
+    // ...and Orca's own managed-account CODEX_HOME must not be read back.
+    expect(invocation.envToDelete).toEqual(['CODEX_HOME', 'ORCA_CODEX_HOME'])
+  })
+
+  it('passes -c to a login shell that rejects -lc', async () => {
+    vi.stubEnv('SHELL', '/bin/sh')
+    stubCodexHomeProbe('/srv/codex')
+
+    await resolveRelayCodexHome('/home/orca')
+
+    expect(runCodexAppServerSessionMock.mock.calls[0]?.[0].args[0]).toBe('-c')
   })
 
   it.each([

--- a/src/main/agent-hooks/managed-hook-runtime.test.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.test.ts
@@ -1,8 +1,18 @@
-import { chmod, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as NodeChildProcess from 'node:child_process'
+
+const { resolveCodexCommandMock, runCodexAppServerSessionMock } = vi.hoisted(() => ({
+  resolveCodexCommandMock: vi.fn(() => '/stub/codex'),
+  runCodexAppServerSessionMock: vi.fn()
+}))
+
+vi.mock('../codex-cli/command', () => ({ resolveCodexCommand: resolveCodexCommandMock }))
+vi.mock('../codex/codex-app-server-session', () => ({
+  runCodexAppServerSession: runCodexAppServerSessionMock
+}))
 
 // Why: the probe spawns a real login shell, and `resolveRelayGrokHome` swallows every
 // spawn failure into its fallback. Left unmocked this asserts the runner's scheduling
@@ -17,7 +27,8 @@ const { execFile } = await import('node:child_process')
 const execFileMock = vi.mocked(execFile)
 const { execFile: actualExecFile } =
   await vi.importActual<typeof NodeChildProcess>('node:child_process')
-const { installManagedHooks, resolveRelayGrokHome } = await import('./managed-hook-runtime')
+const { installManagedHooks, resolveRelayCodexHome, resolveRelayGrokHome } =
+  await import('./managed-hook-runtime')
 
 type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void
 
@@ -37,6 +48,9 @@ function stubProbeFailure(error: Error): void {
 
 beforeEach(() => {
   execFileMock.mockReset()
+  resolveCodexCommandMock.mockReset()
+  resolveCodexCommandMock.mockReturnValue('/stub/codex')
+  runCodexAppServerSessionMock.mockReset()
   // Why: `installManagedHooks` proves a skipped probe through the login-shell run log, so the
   // probe must really spawn unless a case above stubs it. The mock loses `promisify.custom`,
   // so the real `(error, stdout, stderr)` callback is reshaped into the `{ stdout, stderr }`
@@ -49,6 +63,15 @@ beforeEach(() => {
     )
   }) as unknown as typeof execFile)
 })
+
+function stubCodexHomeProbe(codexHome: unknown): void {
+  runCodexAppServerSessionMock.mockImplementation(
+    async (
+      _invocation: unknown,
+      body: (_rpc: unknown, initializeResult: unknown) => Promise<unknown>
+    ) => body({}, { codexHome })
+  )
+}
 
 const tempHomes: string[] = []
 const tempRoot = process.platform === 'win32' ? tmpdir() : '/tmp'
@@ -120,6 +143,38 @@ describe.runIf(process.platform !== 'win32')('resolveRelayGrokHome', () => {
   })
 })
 
+describe.runIf(process.platform !== 'win32')('resolveRelayCodexHome', () => {
+  it('uses the wrapper-aware home reported by Codex app-server', async () => {
+    stubCodexHomeProbe('/srv/codex///')
+
+    await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/srv/codex')
+    expect(runCodexAppServerSessionMock).toHaveBeenCalledWith(
+      {
+        command: '/stub/codex',
+        args: ['app-server'],
+        cliPath: '/stub/codex',
+        timeoutMs: 8_000
+      },
+      expect.any(Function)
+    )
+  })
+
+  it.each([undefined, '', 'relative/home', '/valid\nsecond-line', 'C:\\Users\\me\\.codex'])(
+    'falls back when app-server reports an invalid home: %s',
+    async (codexHome) => {
+      stubCodexHomeProbe(codexHome)
+
+      await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/home/orca/.codex')
+    }
+  )
+
+  it('falls back when the app-server probe fails or times out', async () => {
+    runCodexAppServerSessionMock.mockRejectedValue(new Error('probe timed out'))
+
+    await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/home/orca/.codex')
+  })
+})
+
 describe.runIf(process.platform !== 'win32')('installManagedHooks', () => {
   it.each([
     ['omitted', undefined],
@@ -156,5 +211,23 @@ describe.runIf(process.platform !== 'win32')('installManagedHooks', () => {
     })
 
     expect((await readdir(home)).sort()).toEqual(['.claude', '.orca', SHELL_NAME, SHELL_RUNS_NAME])
+    expect(runCodexAppServerSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('installs Codex hooks into the home reported by the launcher-aware probe', async () => {
+    const home = await createTempHome()
+    const codexHome = join(home, '.codex-openai')
+    await stubLoginShell(home)
+    stubCodexHomeProbe(codexHome)
+
+    await expect(installManagedHooks({ agents: ['codex'] })).resolves.toEqual({
+      installers: 1,
+      errors: 0
+    })
+
+    await expect(readFile(join(codexHome, 'hooks.json'), 'utf8')).resolves.toContain(
+      'codex-hook.sh'
+    )
+    await expect(stat(join(home, '.codex', 'hooks.json'))).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })

--- a/src/main/agent-hooks/managed-hook-runtime.test.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.test.ts
@@ -159,14 +159,22 @@ describe.runIf(process.platform !== 'win32')('resolveRelayCodexHome', () => {
     )
   })
 
-  it.each([undefined, '', 'relative/home', '/valid\nsecond-line', 'C:\\Users\\me\\.codex'])(
-    'falls back when app-server reports an invalid home: %s',
-    async (codexHome) => {
-      stubCodexHomeProbe(codexHome)
+  it.each([
+    undefined,
+    '',
+    'relative/home',
+    '/valid\nsecond-line',
+    'C:\\Users\\me\\.codex',
+    '/',
+    '//server/home',
+    '/home/orca/../codex',
+    '/home/orca/./codex',
+    '/home//orca/codex'
+  ])('falls back when app-server reports an invalid home: %s', async (codexHome) => {
+    stubCodexHomeProbe(codexHome)
 
-      await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/home/orca/.codex')
-    }
-  )
+    await expect(resolveRelayCodexHome('/home/orca')).resolves.toBe('/home/orca/.codex')
+  })
 
   it('falls back when the app-server probe fails or times out', async () => {
     runCodexAppServerSessionMock.mockRejectedValue(new Error('probe timed out'))

--- a/src/main/agent-hooks/managed-hook-runtime.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.ts
@@ -6,12 +6,17 @@ import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers
 import type { AgentHookTarget } from '../../shared/agent-hook-types'
 import { createManagedHookLocalFilesystem } from './managed-hook-local-filesystem'
 import { withManagedHookInstallLock } from './managed-hook-install-lock'
+import { resolveCodexCommand } from '../codex-cli/command'
+import { runCodexAppServerSession } from '../codex/codex-app-server-session'
+import { getSpawnArgsForWindows } from '../win32-utils'
 import {
   readManagedHookHostIdentity,
   scopeManagedHookHostIdentity
 } from './managed-hook-owner-identity'
 
 const execFileAsync = promisify(execFile)
+const CODEX_HOME_MAX_LENGTH = 4096
+const CODEX_HOME_PROBE_TIMEOUT_MS = 8_000
 const GROK_HOME_MAX_LENGTH = 4096
 const GROK_HOME_PROBE_TIMEOUT_MS = 8_000
 
@@ -22,6 +27,10 @@ export type ManagedHookInstallSummary = {
 
 function defaultGrokHome(home: string): string {
   return `${home.replace(/\/+$/, '') || home}/.grok`
+}
+
+function defaultCodexHome(home: string): string {
+  return `${home.replace(/\/+$/, '') || home}/.codex`
 }
 
 function hasControlCharacter(value: string): boolean {
@@ -35,6 +44,21 @@ function normalizeGrokHome(candidate: string): string | null {
   if (
     candidate.length === 0 ||
     candidate.length > GROK_HOME_MAX_LENGTH ||
+    candidate !== candidate.trim() ||
+    !candidate.startsWith('/') ||
+    candidate.includes('\\') ||
+    hasControlCharacter(candidate)
+  ) {
+    return null
+  }
+  return candidate.replace(/\/+$/, '') || '/'
+}
+
+function normalizeCodexHome(candidate: unknown): string | null {
+  if (
+    typeof candidate !== 'string' ||
+    candidate.length === 0 ||
+    candidate.length > CODEX_HOME_MAX_LENGTH ||
     candidate !== candidate.trim() ||
     !candidate.startsWith('/') ||
     candidate.includes('\\') ||
@@ -73,6 +97,34 @@ export async function resolveRelayGrokHome(home: string, signal?: AbortSignal): 
   }
 }
 
+export async function resolveRelayCodexHome(home: string, signal?: AbortSignal): Promise<string> {
+  const fallback = defaultCodexHome(home)
+  try {
+    signal?.throwIfAborted()
+    const command = resolveCodexCommand()
+    const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, ['app-server'])
+    const resolvedHome = await runCodexAppServerSession(
+      {
+        command: spawnCmd,
+        args: spawnArgs,
+        cliPath: command,
+        timeoutMs: CODEX_HOME_PROBE_TIMEOUT_MS
+      },
+      async (_rpc, initializeResult) =>
+        normalizeCodexHome(
+          initializeResult && typeof initializeResult === 'object'
+            ? (initializeResult as { codexHome?: unknown }).codexHome
+            : undefined
+        )
+    )
+    signal?.throwIfAborted()
+    return resolvedHome ?? fallback
+  } catch {
+    signal?.throwIfAborted()
+    return fallback
+  }
+}
+
 export async function installManagedHooks(options?: {
   signal?: AbortSignal
   hostKeyFingerprint?: string
@@ -85,6 +137,13 @@ export async function installManagedHooks(options?: {
     return { installers: 0, errors: 0 }
   }
   const home = homedir()
+  const resolvedCodexHome = agents.includes('codex')
+    ? await resolveRelayCodexHome(home, options?.signal)
+    : undefined
+  // Why: an explicit dir changes the remote hook script layout. Keep the
+  // legacy ~/.codex contract when the probe confirms or falls back to it.
+  const codexHomeDir = resolvedCodexHome === defaultCodexHome(home) ? undefined : resolvedCodexHome
+  options?.signal?.throwIfAborted()
   const grokHomeDir = await resolveRelayGrokHome(home, options?.signal)
   options?.signal?.throwIfAborted()
   const hostIdentity = scopeManagedHookHostIdentity(
@@ -99,6 +158,7 @@ export async function installManagedHooks(options?: {
         createManagedHookLocalFilesystem(),
         home,
         {
+          codexHomeDir,
           grokHomeDir,
           signal: options?.signal,
           agents

--- a/src/main/agent-hooks/managed-hook-runtime.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.ts
@@ -6,9 +6,8 @@ import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers
 import type { AgentHookTarget } from '../../shared/agent-hook-types'
 import { createManagedHookLocalFilesystem } from './managed-hook-local-filesystem'
 import { withManagedHookInstallLock } from './managed-hook-install-lock'
-import { resolveCodexCommand } from '../codex-cli/command'
+import { CODEX_READ_ONLY_APP_SERVER_ARGS } from '../codex-cli/codex-read-only-app-server-args'
 import { runCodexAppServerSession } from '../codex/codex-app-server-session'
-import { getSpawnArgsForWindows } from '../win32-utils'
 import {
   readManagedHookHostIdentity,
   scopeManagedHookHostIdentity
@@ -77,6 +76,16 @@ function normalizeCodexHome(candidate: unknown): string | null {
   return normalized
 }
 
+/**
+ * The shell an agent PTY starts, and the flag that makes it read the user's
+ * profile — which is what puts a launcher wrapper's directory on `PATH`.
+ */
+function loginShellInvocation(): { shell: string; flag: string } {
+  const shell = resolveLoginShell()
+  const shellName = basename(shell)
+  return { shell, flag: shellName === 'sh' || shellName === 'dash' ? '-c' : '-lc' }
+}
+
 function resolveLoginShell(): string {
   const candidate = process.env.SHELL || userInfo().shell || '/bin/sh'
   if (!candidate.startsWith('/') || candidate.includes('\\') || hasControlCharacter(candidate)) {
@@ -109,13 +118,25 @@ export async function resolveRelayCodexHome(home: string, signal?: AbortSignal):
   const fallback = defaultCodexHome(home)
   try {
     signal?.throwIfAborted()
-    const command = resolveCodexCommand()
-    const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, ['app-server'])
+    // Why the login shell: `resolveCodexCommand()` reads this process's PATH, and
+    // the relay starts over a non-login SSH exec whose PATH has no `~/.local/bin`.
+    // It would resolve the real binary and never see the launcher wrapper that
+    // #19598 is about — the wrapper is reachable only once the profile has run.
+    const { shell, flag } = loginShellInvocation()
     const resolvedHome = await runCodexAppServerSession(
       {
-        command: spawnCmd,
-        args: spawnArgs,
-        cliPath: command,
+        command: shell,
+        args: [flag, `exec codex ${CODEX_READ_ONLY_APP_SERVER_ARGS.join(' ')}`],
+        // Why null: the launcher is the shell, not the CLI, so there is no host
+        // CLI path to pair a `node` against — the wsl.exe case.
+        cliPath: null,
+        // Why pin HOME: parent and child must agree on which account is being
+        // configured. Why strip: Orca exports CODEX_HOME/ORCA_CODEX_HOME for its
+        // own managed accounts, and reading one back would report Orca's answer
+        // as if the host user had redirected there. A redirect the user's profile
+        // or wrapper sets is unaffected — the login shell re-exports it.
+        env: { HOME: home },
+        envToDelete: ['CODEX_HOME', 'ORCA_CODEX_HOME'],
         timeoutMs: CODEX_HOME_PROBE_TIMEOUT_MS
       },
       async (_rpc, initializeResult) =>

--- a/src/main/agent-hooks/managed-hook-runtime.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.ts
@@ -66,7 +66,15 @@ function normalizeCodexHome(candidate: unknown): string | null {
   ) {
     return null
   }
-  return candidate.replace(/\/+$/, '') || '/'
+  const normalized = candidate.replace(/\/+$/, '') || '/'
+  const segments = normalized.split('/').slice(1)
+  if (
+    normalized.startsWith('//') ||
+    segments.some((segment) => segment === '' || segment === '.' || segment === '..')
+  ) {
+    return null
+  }
+  return normalized
 }
 
 function resolveLoginShell(): string {

--- a/src/main/codex/codex-app-server-session.test.ts
+++ b/src/main/codex/codex-app-server-session.test.ts
@@ -12,6 +12,30 @@ afterEach(() => {
 })
 
 describe('runCodexAppServerSession environment', () => {
+  it('exposes the initialize result to the session body', async () => {
+    const server = String.raw`
+      const readline = require('node:readline')
+      readline.createInterface({ input: process.stdin }).on('line', (line) => {
+        const message = JSON.parse(line)
+        if (message.method === 'initialize') {
+          process.stdout.write(JSON.stringify({ id: message.id, result: { codexHome: '/tmp/wrapper-home' } }) + '\n')
+        }
+      })
+    `
+
+    const result = await runCodexAppServerSession(
+      {
+        command: process.execPath,
+        cliPath: null,
+        args: ['-e', server],
+        timeoutMs: 5_000
+      },
+      async (_rpc, initializeResult) => initializeResult
+    )
+
+    expect(result).toEqual({ codexHome: '/tmp/wrapper-home' })
+  })
+
   it('removes inherited variables requested by a default-home invocation', async () => {
     process.env.CODEX_HOME = '/tmp/inherited-managed-home'
     const server = String.raw`

--- a/src/main/codex/codex-app-server-session.test.ts
+++ b/src/main/codex/codex-app-server-session.test.ts
@@ -1,39 +1,60 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { runCodexAppServerSession } from './codex-app-server-session'
 
 const originalCodexHome = process.env.CODEX_HOME
+const tempRoots: string[] = []
 
-afterEach(() => {
+afterEach(async () => {
   if (originalCodexHome === undefined) {
     delete process.env.CODEX_HOME
   } else {
     process.env.CODEX_HOME = originalCodexHome
   }
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
 describe('runCodexAppServerSession environment', () => {
-  it('exposes the initialize result to the session body', async () => {
+  it('exposes the home selected inside a Codex launcher wrapper', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-codex-wrapper-'))
+    tempRoots.push(root)
+    const wrapper = join(root, 'codex')
+    const serverPath = join(root, 'fake-app-server.cjs')
     const server = String.raw`
       const readline = require('node:readline')
       readline.createInterface({ input: process.stdin }).on('line', (line) => {
         const message = JSON.parse(line)
         if (message.method === 'initialize') {
-          process.stdout.write(JSON.stringify({ id: message.id, result: { codexHome: '/tmp/wrapper-home' } }) + '\n')
+          process.stdout.write(JSON.stringify({ id: message.id, result: { codexHome: process.env.CODEX_HOME ?? null } }) + '\n')
         }
       })
     `
+    await writeFile(serverPath, server, 'utf8')
+    await writeFile(
+      wrapper,
+      '#!/bin/sh\nset -eu\nexport CODEX_HOME="$HOME/.codex-openai"\nexec "$ORCA_TEST_NODE" "$ORCA_TEST_APP_SERVER" "$@"\n',
+      'utf8'
+    )
+    await chmod(wrapper, 0o755)
 
     const result = await runCodexAppServerSession(
       {
-        command: process.execPath,
-        cliPath: null,
-        args: ['-e', server],
+        command: wrapper,
+        cliPath: wrapper,
+        args: ['app-server'],
+        env: {
+          HOME: root,
+          ORCA_TEST_NODE: process.execPath,
+          ORCA_TEST_APP_SERVER: serverPath
+        },
         timeoutMs: 5_000
       },
       async (_rpc, initializeResult) => initializeResult
     )
 
-    expect(result).toEqual({ codexHome: '/tmp/wrapper-home' })
+    expect(result).toEqual({ codexHome: join(root, '.codex-openai') })
   })
 
   it('removes inherited variables requested by a default-home invocation', async () => {

--- a/src/main/codex/codex-app-server-session.ts
+++ b/src/main/codex/codex-app-server-session.ts
@@ -92,7 +92,9 @@ export function isCodexMethodNotFoundError(error: unknown): boolean {
  */
 export async function runCodexAppServerSession<T>(
   invocation: CodexAppServerInvocation,
-  body: (rpc: CodexAppServerRpc) => Promise<T>,
+  /** The initialize result is Codex-owned metadata. Consumers must validate
+   *  the fields they read; remote hook setup uses its authoritative codexHome. */
+  body: (rpc: CodexAppServerRpc, initializeResult: unknown) => Promise<T>,
   spawnImpl: CodexAppServerSpawn = spawnCodexAppServerProcess
 ): Promise<T> {
   // Why: a default-home grant must run against the real ~/.codex, so strip an
@@ -256,11 +258,11 @@ export async function runCodexAppServerSession<T>(
 
   try {
     const session = async (): Promise<T> => {
-      await requestRpc('initialize', {
+      const initializeResult = await requestRpc('initialize', {
         clientInfo: { name: 'orca_desktop', title: 'Orca', version: '0.0.0' }
       })
       notify('initialized')
-      return body({ request: requestRpc, notify })
+      return body({ request: requestRpc, notify }, initializeResult)
     }
     // Why: the timeout owns the whole callback, including time between RPCs;
     // killing the child alone cannot settle a callback awaiting unrelated work.

--- a/src/main/codex/codex-app-server-session.ts
+++ b/src/main/codex/codex-app-server-session.ts
@@ -92,8 +92,7 @@ export function isCodexMethodNotFoundError(error: unknown): boolean {
  */
 export async function runCodexAppServerSession<T>(
   invocation: CodexAppServerInvocation,
-  /** The initialize result is Codex-owned metadata. Consumers must validate
-   *  the fields they read; remote hook setup uses its authoritative codexHome. */
+  /** Codex-owned initialize metadata; callers validate the fields they consume. */
   body: (rpc: CodexAppServerRpc, initializeResult: unknown) => Promise<T>,
   spawnImpl: CodexAppServerSpawn = spawnCodexAppServerProcess
 ): Promise<T> {


### PR DESCRIPTION
## ELI5

Some Codex launchers choose a different home directory only after they start. Orca previously installed status hooks into `~/.codex` before it knew about that choice. Orca now asks the launched Codex process which home it actually uses and installs the hooks there.

## What Changed

- Expose the Codex `initialize` response to app-server session consumers.
- Before remote Codex hook installation, launch the resolved Codex command and read its authoritative `codexHome` from `app-server initialize`.
- Validate the reported POSIX path, including rejecting root, dot segments, and ambiguous double-slash forms, then fall back to the existing `~/.codex` behavior on unsupported, invalid, failed, or timed-out probes; cancellation still stops installation.
- Run the probe only when Codex was positively detected in the remote agent allowlist.
- Add regression coverage using an executable launcher wrapper that selects its own home, plus invalid values, probe failure, non-Codex installs, and initialize-result forwarding.

## Why

On remote Linux hosts, a `codex` wrapper can set `CODEX_HOME` internally (for example, `~/.codex-openai`) immediately before it execs the real binary. That value is intentionally not visible in the Orca relay environment or a login-shell probe, so Orca wrote `hooks.json` into the inactive default home. Codex already reports the effective home during its supported app-server handshake, which makes this probe wrapper-aware without parsing launcher scripts or guessing among `.codex-*` directories.

## Linked Issue

Fixes #19598

## Visual Proof

N/A — this changes remote hook installation and has no UI change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified with Node 24 and pnpm 12:

- `vitest` across 8 related files: 111 tests passed.
- `pnpm typecheck`: passed.
- `pnpm build`: passed (existing CSS/chunk-size and macOS deprecation warnings only).
- `pnpm run check:code-quality:changed`: passed with 0 new findings.
- `oxfmt --check` for all 4 changed files and `git diff --check`: passed.
- Live SSH/Linux diagnosis: the launcher had no inherited `CODEX_HOME`, selected `~/.codex-openai` internally, and `codex app-server` reported that effective path in `initialize.codexHome`.

The full `pnpm lint` is not green on the current upstream checkout because `en-runtime-required.json` disagrees with seven existing `TerminalPane.minimumContrast` entries in `en.json`. A full `pnpm test` run was stopped after unrelated relay timing, cross-version checkout, file-watcher, Electron, and real-CLI integration failures; all 111 tests in the changed and adjacent modules pass.

## AI Disclosure

OpenAI Codex was used for diagnosis, implementation, tests, self-review, and PR drafting. The remote behavior and all reported command results were verified against the actual checkout/environment.

## Review

- Security: the Codex-owned path must be a non-root absolute POSIX path, trimmed, no longer than 4096 characters, and contain no control characters, backslashes, empty components, or dot segments. No reported value is interpolated into a shell command.
- Cross-platform: Windows SSH remotes already skip these POSIX managed-hook installers; existing default-home behavior remains unchanged elsewhere.
- Remote SSH: the probe runs inside the relay on the execution host and resolves the same launcher available on that host's `PATH`.
- Backwards compatibility: old/unsupported Codex versions, invalid responses, spawn failures, and timeouts fall back to `~/.codex`.
- Performance: one short-lived app-server handshake runs only when Codex is detected, with an 8-second whole-session bound.
- Mobile/UI: not affected.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Agent Session History custom-path discovery is tracked separately by #12186 / #12733 and is intentionally not changed here.
- The stale CAB `orca-agent` runtime described in the original report is outside this repository's ownership and is intentionally not included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
