### PR TITLE
feat(resource): add identity-free usage evidence CLI

### DIFF
--- a/docs/site/content/docs/agents/usage-tracking.mdx
+++ b/docs/site/content/docs/agents/usage-tracking.mdx
@@ -33,6 +33,19 @@ Rows without live numbers show a short status instead: **Loading usage…**, **n
 
 On the companion app, open the host **Accounts** screen for the same switcher/usage readout. When Codex has earned **rate-limit reset** credits, spend one from that screen (see [Mobile companion](/docs/mobile)).
 
+## Machine-readable evidence (`orca resource status`)
+
+For automation and external orchestration, `orca resource status --json` prints the same normalized usage state the status bar renders, as a stable JSON contract with **no account identity, credentials, or raw provider payloads**:
+
+```bash
+orca resource status --json
+orca resource status --json --refresh
+```
+
+Each provider carries `available`, `status`, `source_updated_at` (when the provider data was last refreshed), `data_age_ms`, `rate_limited` / `retry_at`, and a `windows` list. Each window has `role` (`BURST` / `BUDGET` / `UNKNOWN`), `window_minutes`, `remaining_ratio` (with `remaining_ratio_granularity` — the source is integer percent, so `0.01`), `reset_at`, and `reset_at_source` (always `"unknown"`: the state does not record whether a reset time was reported by the provider directly or derived).
+
+Without `--refresh` the command returns the cached poll snapshot. `--refresh` runs the existing stale-aware provider fetch first; the poll throttle and any `Retry-After` still apply. The command is read-only and never selects accounts or changes credentials. Orca reports the evidence and its timestamps; it applies no freshness or routing policy of its own.
+
 ## Estimated cost (Stats)
 
 The Stats breakdown may show **estimated cost** for known model families (including Claude 5-class and Codex GPT-5.6 rows). Rows marked **• inferred pricing** use Orca’s local price table, not a live bill from the provider. Prefer the provider console for authoritative spend.

--- a/docs/site/content/docs/agents/usage-tracking.mdx
+++ b/docs/site/content/docs/agents/usage-tracking.mdx
@@ -42,7 +42,9 @@ orca resource status --json
 orca resource status --json --refresh
 ```
 
-Each provider carries `available`, `status`, `source_updated_at` (when the provider data was last refreshed), `data_age_ms`, `rate_limited` / `retry_at`, and a `windows` list. Each window has `role` (`BURST` / `BUDGET` / `UNKNOWN`), `window_minutes`, `remaining_ratio` (with `remaining_ratio_granularity` — the source is integer percent, so `0.01`), `reset_at`, and `reset_at_source` (always `"unknown"`: the state does not record whether a reset time was reported by the provider directly or derived).
+Each provider carries `status`, `available` (`true` only when the fetch succeeded **and** at least one window is present — a fetch that succeeded with no windows is `available: false` with `status: "ok"`), `source_updated_at` (when the provider data was last refreshed), `data_age_ms`, `rate_limited` / `retry_at`, and a `windows` list.
+
+Each window has a stable `scope` — `session`, `weekly`, `fableWeekly`, `monthly`, or `bucket` — that identifies the underlying quota (so `weekly` and `fableWeekly`, both 7‑day `BUDGET` windows, stay distinct); `role` (`BURST` / `BUDGET` / `UNKNOWN`) is only the generic capacity horizon. Do not use array position as identity. It also has `window_minutes`, `remaining_ratio` (with `remaining_ratio_granularity` — the source is integer percent, so `0.01`), `reset_at`, `reset_at_source` (always `"unknown"`: the state does not record whether a reset time was reported by the provider directly or derived), and `pool` (the model name) for `bucket` windows.
 
 Without `--refresh` the command returns the cached poll snapshot. `--refresh` runs the existing stale-aware provider fetch first; the poll throttle and any `Retry-After` still apply. The command is read-only and never selects accounts or changes credentials. Orca reports the evidence and its timestamps; it applies no freshness or routing policy of its own.
 

--- a/src/cli/handler-group-manifest.ts
+++ b/src/cli/handler-group-manifest.ts
@@ -23,6 +23,11 @@ export const HANDLER_GROUPS: readonly HandlerGroup[] = [
     load: async () => (await import('./handlers/account.js')).ACCOUNT_HANDLERS
   },
   {
+    name: 'resource',
+    keys: ['resource status'],
+    load: async () => (await import('./handlers/resource.js')).RESOURCE_HANDLERS
+  },
+  {
     name: 'artifacts',
     keys: [
       'artifacts list',

--- a/src/cli/handlers/resource.test.ts
+++ b/src/cli/handlers/resource.test.ts
@@ -17,6 +17,7 @@ const evidence: ResourceEvidence = {
       windows: [
         {
           role: 'BURST',
+          scope: 'session',
           windowMinutes: 300,
           remainingRatio: 0.81,
           remainingRatioGranularity: 0.01,
@@ -71,6 +72,6 @@ describe('resource status CLI handler', () => {
 
     const output = log.mock.calls[0]![0] as string
     expect(output).toContain('codex: available')
-    expect(output).toContain('BURST (300m): ~81% left')
+    expect(output).toContain('session [BURST, 300m]: ~81% left')
   })
 })

--- a/src/cli/handlers/resource.test.ts
+++ b/src/cli/handlers/resource.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeClient } from '../runtime-client'
+import type { HandlerContext } from '../dispatch'
+import type { ResourceEvidence } from '../../shared/resource-evidence-types'
+import { RESOURCE_HANDLERS } from './resource'
+
+const evidence: ResourceEvidence = {
+  queriedAt: '2026-09-09T12:00:00.000Z',
+  providers: {
+    codex: {
+      available: true,
+      status: 'ok',
+      sourceUpdatedAt: '2026-09-09T11:52:00.000Z',
+      dataAgeMs: 480000,
+      rateLimited: false,
+      retryAt: null,
+      windows: [
+        {
+          role: 'BURST',
+          windowMinutes: 300,
+          remainingRatio: 0.81,
+          remainingRatioGranularity: 0.01,
+          resetAt: '2026-09-09T14:38:00.000Z',
+          resetAtSource: 'unknown'
+        }
+      ]
+    }
+  }
+}
+
+function context(call: ReturnType<typeof vi.fn>, overrides: Partial<HandlerContext> = {}): HandlerContext {
+  return {
+    client: { call } as unknown as RuntimeClient,
+    cwd: process.cwd(),
+    json: true,
+    flags: new Map(),
+    ...overrides
+  }
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('resource status CLI handler', () => {
+  it('emits stable, parseable JSON with the evidence and no decorative output', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const call = vi.fn().mockResolvedValue({ id: 'r1', ok: true, result: evidence, _meta: { runtimeId: 't' } })
+
+    await RESOURCE_HANDLERS['resource status']!(context(call))
+
+    expect(call).toHaveBeenCalledWith('resource.status', { refresh: false })
+    expect(log).toHaveBeenCalledTimes(1)
+    const parsed = JSON.parse(log.mock.calls[0]![0] as string)
+    expect(parsed.result.providers.codex.windows[0].role).toBe('BURST')
+    expect(JSON.stringify(parsed)).not.toContain('email')
+  })
+
+  it('maps --refresh to the RPC parameter', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const call = vi.fn().mockResolvedValue({ id: 'r1', ok: true, result: evidence, _meta: { runtimeId: 't' } })
+
+    await RESOURCE_HANDLERS['resource status']!(context(call, { flags: new Map([['refresh', true]]) }))
+
+    expect(call).toHaveBeenCalledWith('resource.status', { refresh: true })
+  })
+
+  it('renders a concise human summary without --json', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const call = vi.fn().mockResolvedValue({ id: 'r1', ok: true, result: evidence, _meta: { runtimeId: 't' } })
+
+    await RESOURCE_HANDLERS['resource status']!(context(call, { json: false }))
+
+    const output = log.mock.calls[0]![0] as string
+    expect(output).toContain('codex: available')
+    expect(output).toContain('BURST (300m): ~81% left')
+  })
+})

--- a/src/cli/handlers/resource.ts
+++ b/src/cli/handlers/resource.ts
@@ -1,0 +1,35 @@
+import type { CommandHandler } from '../dispatch'
+import { printResult } from '../format'
+import type { ResourceEvidence } from '../../shared/resource-evidence-types'
+
+function formatResourceEvidence(evidence: ResourceEvidence): string {
+  const providerNames = Object.keys(evidence.providers) as (keyof ResourceEvidence['providers'])[]
+  const lines = [`Resource evidence (queried ${evidence.queriedAt}):`]
+  if (providerNames.length === 0) {
+    lines.push('  (no provider usage data)')
+    return lines.join('\n')
+  }
+  for (const name of providerNames) {
+    const provider = evidence.providers[name]
+    if (!provider) continue
+    const age = provider.dataAgeMs === null ? 'age unknown' : `${Math.round(provider.dataAgeMs / 1000)}s old`
+    const state = provider.available ? 'available' : provider.status
+    lines.push(`  ${name}: ${state}${provider.rateLimited ? ' (rate-limited)' : ''} — ${age}`)
+    for (const window of provider.windows) {
+      const label = `${window.role}${window.pool ? ` ${window.pool}` : ''} (${window.windowMinutes}m)`
+      const remaining = `~${Math.round(window.remainingRatio * 100)}% left`
+      lines.push(`    ${label}: ${remaining}${window.resetAt ? `, resets ${window.resetAt}` : ''}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+/** CLI handler for `orca resource status [--json] [--refresh]`. Read-only. */
+export const RESOURCE_HANDLERS: Record<string, CommandHandler> = {
+  'resource status': async ({ client, json, flags }) => {
+    const result = await client.call<ResourceEvidence>('resource.status', {
+      refresh: flags.get('refresh') === true
+    })
+    printResult(result, json, formatResourceEvidence)
+  }
+}

--- a/src/cli/handlers/resource.ts
+++ b/src/cli/handlers/resource.ts
@@ -2,6 +2,11 @@ import type { CommandHandler } from '../dispatch'
 import { printResult } from '../format'
 import type { ResourceEvidence } from '../../shared/resource-evidence-types'
 
+/**
+ * One concise line per provider plus one per window, for `orca resource status`
+ * without `--json`. Each window names its `scope` so `weekly` and `fableWeekly`
+ * stay distinct. Machine consumers should use `--json`.
+ */
 function formatResourceEvidence(evidence: ResourceEvidence): string {
   const providerNames = Object.keys(evidence.providers) as (keyof ResourceEvidence['providers'])[]
   const lines = [`Resource evidence (queried ${evidence.queriedAt}):`]
@@ -16,7 +21,8 @@ function formatResourceEvidence(evidence: ResourceEvidence): string {
     const state = provider.available ? 'available' : provider.status
     lines.push(`  ${name}: ${state}${provider.rateLimited ? ' (rate-limited)' : ''} — ${age}`)
     for (const window of provider.windows) {
-      const label = `${window.role}${window.pool ? ` ${window.pool}` : ''} (${window.windowMinutes}m)`
+      const scope = window.pool ? `${window.scope} ${window.pool}` : window.scope
+      const label = `${scope} [${window.role}, ${window.windowMinutes}m]`
       const remaining = `~${Math.round(window.remainingRatio * 100)}% left`
       lines.push(`    ${label}: ${remaining}${window.resetAt ? `, resets ${window.resetAt}` : ''}`)
     }

--- a/src/cli/specs/index.ts
+++ b/src/cli/specs/index.ts
@@ -1,5 +1,6 @@
 import type { CommandSpec } from '../args'
 import { ACCOUNT_COMMAND_SPECS } from './account'
+import { RESOURCE_COMMAND_SPECS } from './resource'
 import { BROWSER_ADVANCED_COMMAND_SPECS } from './browser-advanced'
 import { BROWSER_BASIC_COMMAND_SPECS } from './browser-basic'
 import { AUTOMATION_COMMAND_SPECS } from './automations'
@@ -22,6 +23,7 @@ export const COMMAND_SPECS: CommandSpec[] = [
   ...CORE_COMMAND_SPECS,
   ...ARTIFACT_COMMAND_SPECS,
   ...ACCOUNT_COMMAND_SPECS,
+  ...RESOURCE_COMMAND_SPECS,
   ...PROJECT_COMMAND_SPECS,
   ...FILE_COMMAND_SPECS,
   ...AUTOMATION_COMMAND_SPECS,

--- a/src/cli/specs/resource.ts
+++ b/src/cli/specs/resource.ts
@@ -8,6 +8,7 @@ export const RESOURCE_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'refresh'],
     notes: [
       'Read-only projection of the same rate-limit state the status bar renders: per-provider windows with a remaining ratio (0.01-grained), reset time, source_updated_at and data_age_ms. It never includes account identity, credentials, or raw provider payloads.',
+      'Each window carries a stable scope (session, weekly, fableWeekly, monthly, bucket) that identifies the underlying quota; role (BURST/BUDGET/UNKNOWN) is only the generic capacity horizon. Do not rely on array order.',
       'Returns the cached poll snapshot by default. --refresh runs the existing stale-aware provider fetch first (the poll throttle and Retry-After still apply); it does not force a fetch on every call.',
       'reset_at_source is always "unknown": the underlying state does not record whether a reset time came from the provider directly or was derived.'
     ],

--- a/src/cli/specs/resource.ts
+++ b/src/cli/specs/resource.ts
@@ -1,0 +1,16 @@
+import { GLOBAL_FLAGS, type CommandSpec } from '../args'
+
+export const RESOURCE_COMMAND_SPECS: CommandSpec[] = [
+  {
+    path: ['resource', 'status'],
+    summary: 'Print identity-free provider usage/rate-limit evidence as machine-readable JSON',
+    usage: 'orca resource status [--json] [--refresh]',
+    allowedFlags: [...GLOBAL_FLAGS, 'refresh'],
+    notes: [
+      'Read-only projection of the same rate-limit state the status bar renders: per-provider windows with a remaining ratio (0.01-grained), reset time, source_updated_at and data_age_ms. It never includes account identity, credentials, or raw provider payloads.',
+      'Returns the cached poll snapshot by default. --refresh runs the existing stale-aware provider fetch first (the poll throttle and Retry-After still apply); it does not force a fetch on every call.',
+      'reset_at_source is always "unknown": the underlying state does not record whether a reset time came from the provider directly or was derived.'
+    ],
+    examples: ['orca resource status --json', 'orca resource status --json --refresh']
+  }
+]

--- a/src/main/rate-limits/resource-evidence-projection.test.ts
+++ b/src/main/rate-limits/resource-evidence-projection.test.ts
@@ -52,9 +52,10 @@ function state(overrides: Partial<RateLimitState>): RateLimitState {
 }
 
 describe('projectResourceEvidence', () => {
-  it('projects Codex BURST + BUDGET windows with derived roles and ratios', () => {
+  it('projects Codex BURST + BUDGET windows with derived roles, scopes and ratios', () => {
     const evidence = projectResourceEvidence(
-      state({
+      {
+        ...state({}),
         codex: provider({
           provider: 'codex',
           session: window({ usedPercent: 19, windowMinutes: 300, resetsAt: Date.parse('2026-09-09T14:38:00.000Z') }),
@@ -62,7 +63,7 @@ describe('projectResourceEvidence', () => {
           planType: 'plus',
           rateLimitResetCredits: { availableCount: 0 }
         })
-      }),
+      },
       { queriedAtMs: QUERIED_AT_MS }
     )
 
@@ -75,6 +76,7 @@ describe('projectResourceEvidence', () => {
     expect(codex?.windows).toEqual([
       {
         role: 'BURST',
+        scope: 'session',
         windowMinutes: 300,
         remainingRatio: 0.81,
         remainingRatioGranularity: 0.01,
@@ -83,6 +85,7 @@ describe('projectResourceEvidence', () => {
       },
       {
         role: 'BUDGET',
+        scope: 'weekly',
         windowMinutes: 10080,
         remainingRatio: 0.48,
         remainingRatioGranularity: 0.01,
@@ -95,22 +98,113 @@ describe('projectResourceEvidence', () => {
 
   it('projects a Claude provider the same way', () => {
     const evidence = projectResourceEvidence(
-      state({
+      {
+        ...state({}),
         claude: provider({
           provider: 'claude',
           session: window({ usedPercent: 42, windowMinutes: 300 }),
           weekly: window({ usedPercent: 5, windowMinutes: 10080 })
         })
-      }),
+      },
       { queriedAtMs: QUERIED_AT_MS }
     )
-    expect(evidence.providers.claude?.windows.map((w) => w.role)).toEqual(['BURST', 'BUDGET'])
+    expect(evidence.providers.claude?.windows.map((w) => w.scope)).toEqual(['session', 'weekly'])
     expect(evidence.providers.claude?.windows[1]?.remainingRatio).toBe(0.95)
   })
 
-  it('keeps Gemini per-model buckets as distinct pool windows', () => {
+  it('keeps weekly and fableWeekly distinguishable by scope, not array order', () => {
     const evidence = projectResourceEvidence(
-      state({
+      {
+        ...state({}),
+        claude: provider({
+          provider: 'claude',
+          weekly: window({ usedPercent: 30, windowMinutes: 10080, resetsAt: Date.parse('2026-09-15T00:00:00.000Z') }),
+          fableWeekly: window({ usedPercent: 70, windowMinutes: 10080, resetsAt: Date.parse('2026-09-16T00:00:00.000Z') })
+        })
+      },
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    const windows = evidence.providers.claude?.windows ?? []
+    const byScope = new Map(windows.map((w) => [w.scope, w]))
+    expect(byScope.get('weekly')?.remainingRatio).toBe(0.7)
+    expect(byScope.get('fableWeekly')?.remainingRatio).toBe(0.3)
+    expect(byScope.get('weekly')?.role).toBe('BUDGET')
+    expect(byScope.get('fableWeekly')?.role).toBe('BUDGET')
+    // Both are 10080-minute BUDGET windows: only `scope` tells them apart.
+    expect(new Set(windows.map((w) => w.scope)).size).toBe(2)
+  })
+
+  it('projects a monthly window as BUDGET with scope "monthly"', () => {
+    const evidence = projectResourceEvidence(
+      {
+        ...state({}),
+        opencodeGo: provider({
+          provider: 'opencode-go',
+          monthly: window({ usedPercent: 25, windowMinutes: 43200, resetsAt: Date.parse('2026-10-01T00:00:00.000Z') })
+        })
+      },
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers['opencode-go']?.windows).toEqual([
+      {
+        role: 'BUDGET',
+        scope: 'monthly',
+        windowMinutes: 43200,
+        remainingRatio: 0.75,
+        remainingRatioGranularity: 0.01,
+        resetAt: '2026-10-01T00:00:00.000Z',
+        resetAtSource: 'unknown'
+      }
+    ])
+  })
+
+  it('projects a standalone fableWeekly window with scope "fableWeekly"', () => {
+    const evidence = projectResourceEvidence(
+      {
+        ...state({}),
+        claude: provider({
+          provider: 'claude',
+          fableWeekly: window({ usedPercent: 10, windowMinutes: 10080 })
+        })
+      },
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.claude?.windows).toEqual([
+      {
+        role: 'BUDGET',
+        scope: 'fableWeekly',
+        windowMinutes: 10080,
+        remainingRatio: 0.9,
+        remainingRatioGranularity: 0.01,
+        resetAt: null,
+        resetAtSource: 'unknown'
+      }
+    ])
+  })
+
+  it('gives an unrecognised windowMinutes role UNKNOWN while keeping its scope', () => {
+    const evidence = projectResourceEvidence(
+      {
+        ...state({}),
+        codex: provider({
+          provider: 'codex',
+          weekly: window({ usedPercent: 40, windowMinutes: 4321 })
+        })
+      },
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.codex?.windows[0]).toMatchObject({
+      role: 'UNKNOWN',
+      scope: 'weekly',
+      windowMinutes: 4321,
+      remainingRatio: 0.6
+    })
+  })
+
+  it('keeps Gemini per-model buckets as distinct pool windows with scope "bucket"', () => {
+    const evidence = projectResourceEvidence(
+      {
+        ...state({}),
         gemini: provider({
           provider: 'gemini',
           buckets: [
@@ -118,23 +212,48 @@ describe('projectResourceEvidence', () => {
             { name: 'Pro', usedPercent: 60, windowMinutes: 60, resetsAt: null, resetDescription: null }
           ]
         })
-      }),
+      },
       { queriedAtMs: QUERIED_AT_MS }
     )
     expect(evidence.providers.gemini?.windows).toEqual([
-      { role: 'BURST', windowMinutes: 60, remainingRatio: 0.93, remainingRatioGranularity: 0.01, resetAt: null, resetAtSource: 'unknown', pool: 'Flash' },
-      { role: 'BURST', windowMinutes: 60, remainingRatio: 0.4, remainingRatioGranularity: 0.01, resetAt: null, resetAtSource: 'unknown', pool: 'Pro' }
+      { role: 'BURST', scope: 'bucket', windowMinutes: 60, remainingRatio: 0.93, remainingRatioGranularity: 0.01, resetAt: null, resetAtSource: 'unknown', pool: 'Flash' },
+      { role: 'BURST', scope: 'bucket', windowMinutes: 60, remainingRatio: 0.4, remainingRatioGranularity: 0.01, resetAt: null, resetAtSource: 'unknown', pool: 'Pro' }
+    ])
+  })
+
+  it('emits every scope value using the ProviderRateLimits field name', () => {
+    const evidence = projectResourceEvidence(
+      {
+        ...state({}),
+        codex: provider({
+          provider: 'codex',
+          session: window({ usedPercent: 1, windowMinutes: 300 }),
+          weekly: window({ usedPercent: 1, windowMinutes: 10080 }),
+          fableWeekly: window({ usedPercent: 1, windowMinutes: 10080 }),
+          monthly: window({ usedPercent: 1, windowMinutes: 43200 }),
+          buckets: [{ name: 'B', usedPercent: 1, windowMinutes: 60, resetsAt: null, resetDescription: null }]
+        })
+      },
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.codex?.windows.map((w) => w.scope)).toEqual([
+      'session',
+      'weekly',
+      'fableWeekly',
+      'monthly',
+      'bucket'
     ])
   })
 
   it('exposes whatever Antigravity state is present without inventing reset provenance', () => {
     const evidence = projectResourceEvidence(
-      state({
+      {
+        ...state({}),
         antigravity: provider({
           provider: 'antigravity',
           weekly: window({ usedPercent: 1, windowMinutes: 10080, resetsAt: Date.parse('2026-09-16T00:00:00.000Z') })
         })
-      }),
+      },
       { queriedAtMs: QUERIED_AT_MS }
     )
     expect(evidence.providers.antigravity?.windows[0]?.resetAtSource).toBe('unknown')
@@ -142,23 +261,32 @@ describe('projectResourceEvidence', () => {
 
   it('marks an unavailable/error provider unavailable with no windows', () => {
     const evidence = projectResourceEvidence(
-      state({ codex: provider({ provider: 'codex', status: 'unavailable', error: 'no auth' }) }),
+      { ...state({}), codex: provider({ provider: 'codex', status: 'unavailable', error: 'no auth' }) },
       { queriedAtMs: QUERIED_AT_MS }
     )
     expect(evidence.providers.codex).toMatchObject({ available: false, status: 'unavailable', windows: [] })
   })
 
+  it('marks a fetch that succeeded with no windows available:false but status:ok', () => {
+    const evidence = projectResourceEvidence(
+      { ...state({}), codex: provider({ provider: 'codex', status: 'ok' }) },
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.codex).toMatchObject({ available: false, status: 'ok', windows: [] })
+  })
+
   it('surfaces a rate-limited provider as booleans, not a raw error payload', () => {
     const retryAtMs = Date.parse('2026-09-09T13:00:00.000Z')
     const evidence = projectResourceEvidence(
-      state({
+      {
+        ...state({}),
         codex: provider({
           provider: 'codex',
           status: 'error',
           error: 'HTTP 429 from https://example/usage with token abc',
           usageMetadata: { failureKind: 'rate-limited', retryAtMs }
         })
-      }),
+      },
       { queriedAtMs: QUERIED_AT_MS }
     )
     expect(evidence.providers.codex).toMatchObject({
@@ -176,13 +304,14 @@ describe('projectResourceEvidence', () => {
 
   it('handles a missing source update time as null age', () => {
     const evidence = projectResourceEvidence(
-      state({
+      {
+        ...state({}),
         codex: provider({
           provider: 'codex',
           updatedAt: Number.NaN,
           session: window({ usedPercent: 0, windowMinutes: 300 })
         })
-      }),
+      },
       { queriedAtMs: QUERIED_AT_MS }
     )
     expect(evidence.providers.codex?.sourceUpdatedAt).toBeNull()
@@ -192,12 +321,13 @@ describe('projectResourceEvidence', () => {
   it('never emits account identity fields', () => {
     const serialized = JSON.stringify(
       projectResourceEvidence(
-        state({
+        {
+          ...state({}),
           claude: provider({ provider: 'claude', session: window({ usedPercent: 10, windowMinutes: 300 }) }),
           inactiveClaudeAccounts: [
             { accountId: 'acct-secret', rateLimits: null, updatedAt: 1, isFetching: false }
           ]
-        }),
+        },
         { queriedAtMs: QUERIED_AT_MS }
       )
     )

--- a/src/main/rate-limits/resource-evidence-projection.test.ts
+++ b/src/main/rate-limits/resource-evidence-projection.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ProviderRateLimits,
+  RateLimitState,
+  RateLimitWindow
+} from '../../shared/rate-limit-types'
+import { projectResourceEvidence } from './resource-evidence-projection'
+
+const QUERIED_AT_MS = Date.parse('2026-09-09T12:00:00.000Z')
+
+function window(overrides: Partial<RateLimitWindow>): RateLimitWindow {
+  return {
+    usedPercent: 0,
+    windowMinutes: 300,
+    resetsAt: null,
+    resetDescription: null,
+    ...overrides
+  }
+}
+
+function provider(overrides: Partial<ProviderRateLimits>): ProviderRateLimits {
+  return {
+    provider: 'codex',
+    session: null,
+    weekly: null,
+    updatedAt: Date.parse('2026-09-09T11:52:00.000Z'),
+    error: null,
+    status: 'ok',
+    ...overrides
+  }
+}
+
+function state(overrides: Partial<RateLimitState>): RateLimitState {
+  return {
+    claude: null,
+    codex: null,
+    gemini: null,
+    opencodeGo: null,
+    kimi: null,
+    antigravity: null,
+    minimax: null,
+    grok: null,
+    minimaxCookieConfigured: false,
+    minimaxApiKeyConfigured: false,
+    grokAuthConfigured: false,
+    claudeTarget: { runtime: 'host', wslDistro: null },
+    codexTarget: { runtime: 'host', wslDistro: null },
+    inactiveClaudeAccounts: [],
+    inactiveCodexAccounts: [],
+    ...overrides
+  }
+}
+
+describe('projectResourceEvidence', () => {
+  it('projects Codex BURST + BUDGET windows with derived roles and ratios', () => {
+    const evidence = projectResourceEvidence(
+      state({
+        codex: provider({
+          provider: 'codex',
+          session: window({ usedPercent: 19, windowMinutes: 300, resetsAt: Date.parse('2026-09-09T14:38:00.000Z') }),
+          weekly: window({ usedPercent: 52, windowMinutes: 10080, resetsAt: Date.parse('2026-09-15T10:39:00.000Z') }),
+          planType: 'plus',
+          rateLimitResetCredits: { availableCount: 0 }
+        })
+      }),
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+
+    expect(evidence.queriedAt).toBe('2026-09-09T12:00:00.000Z')
+    const codex = evidence.providers.codex
+    expect(codex).toBeDefined()
+    expect(codex?.available).toBe(true)
+    expect(codex?.sourceUpdatedAt).toBe('2026-09-09T11:52:00.000Z')
+    expect(codex?.dataAgeMs).toBe(QUERIED_AT_MS - Date.parse('2026-09-09T11:52:00.000Z'))
+    expect(codex?.windows).toEqual([
+      {
+        role: 'BURST',
+        windowMinutes: 300,
+        remainingRatio: 0.81,
+        remainingRatioGranularity: 0.01,
+        resetAt: '2026-09-09T14:38:00.000Z',
+        resetAtSource: 'unknown'
+      },
+      {
+        role: 'BUDGET',
+        windowMinutes: 10080,
+        remainingRatio: 0.48,
+        remainingRatioGranularity: 0.01,
+        resetAt: '2026-09-15T10:39:00.000Z',
+        resetAtSource: 'unknown'
+      }
+    ])
+    expect(codex?.extras).toEqual({ planType: 'plus', resetCreditsAvailable: 0 })
+  })
+
+  it('projects a Claude provider the same way', () => {
+    const evidence = projectResourceEvidence(
+      state({
+        claude: provider({
+          provider: 'claude',
+          session: window({ usedPercent: 42, windowMinutes: 300 }),
+          weekly: window({ usedPercent: 5, windowMinutes: 10080 })
+        })
+      }),
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.claude?.windows.map((w) => w.role)).toEqual(['BURST', 'BUDGET'])
+    expect(evidence.providers.claude?.windows[1]?.remainingRatio).toBe(0.95)
+  })
+
+  it('keeps Gemini per-model buckets as distinct pool windows', () => {
+    const evidence = projectResourceEvidence(
+      state({
+        gemini: provider({
+          provider: 'gemini',
+          buckets: [
+            { name: 'Flash', usedPercent: 7, windowMinutes: 60, resetsAt: null, resetDescription: null },
+            { name: 'Pro', usedPercent: 60, windowMinutes: 60, resetsAt: null, resetDescription: null }
+          ]
+        })
+      }),
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.gemini?.windows).toEqual([
+      { role: 'BURST', windowMinutes: 60, remainingRatio: 0.93, remainingRatioGranularity: 0.01, resetAt: null, resetAtSource: 'unknown', pool: 'Flash' },
+      { role: 'BURST', windowMinutes: 60, remainingRatio: 0.4, remainingRatioGranularity: 0.01, resetAt: null, resetAtSource: 'unknown', pool: 'Pro' }
+    ])
+  })
+
+  it('exposes whatever Antigravity state is present without inventing reset provenance', () => {
+    const evidence = projectResourceEvidence(
+      state({
+        antigravity: provider({
+          provider: 'antigravity',
+          weekly: window({ usedPercent: 1, windowMinutes: 10080, resetsAt: Date.parse('2026-09-16T00:00:00.000Z') })
+        })
+      }),
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.antigravity?.windows[0]?.resetAtSource).toBe('unknown')
+  })
+
+  it('marks an unavailable/error provider unavailable with no windows', () => {
+    const evidence = projectResourceEvidence(
+      state({ codex: provider({ provider: 'codex', status: 'unavailable', error: 'no auth' }) }),
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.codex).toMatchObject({ available: false, status: 'unavailable', windows: [] })
+  })
+
+  it('surfaces a rate-limited provider as booleans, not a raw error payload', () => {
+    const retryAtMs = Date.parse('2026-09-09T13:00:00.000Z')
+    const evidence = projectResourceEvidence(
+      state({
+        codex: provider({
+          provider: 'codex',
+          status: 'error',
+          error: 'HTTP 429 from https://example/usage with token abc',
+          usageMetadata: { failureKind: 'rate-limited', retryAtMs }
+        })
+      }),
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.codex).toMatchObject({
+      rateLimited: true,
+      retryAt: '2026-09-09T13:00:00.000Z'
+    })
+    expect(JSON.stringify(evidence)).not.toContain('429')
+    expect(JSON.stringify(evidence)).not.toContain('token abc')
+  })
+
+  it('omits providers with no state and never fabricates windows', () => {
+    const evidence = projectResourceEvidence(state({}), { queriedAtMs: QUERIED_AT_MS })
+    expect(Object.keys(evidence.providers)).toEqual([])
+  })
+
+  it('handles a missing source update time as null age', () => {
+    const evidence = projectResourceEvidence(
+      state({
+        codex: provider({
+          provider: 'codex',
+          updatedAt: Number.NaN,
+          session: window({ usedPercent: 0, windowMinutes: 300 })
+        })
+      }),
+      { queriedAtMs: QUERIED_AT_MS }
+    )
+    expect(evidence.providers.codex?.sourceUpdatedAt).toBeNull()
+    expect(evidence.providers.codex?.dataAgeMs).toBeNull()
+  })
+
+  it('never emits account identity fields', () => {
+    const serialized = JSON.stringify(
+      projectResourceEvidence(
+        state({
+          claude: provider({ provider: 'claude', session: window({ usedPercent: 10, windowMinutes: 300 }) }),
+          inactiveClaudeAccounts: [
+            { accountId: 'acct-secret', rateLimits: null, updatedAt: 1, isFetching: false }
+          ]
+        }),
+        { queriedAtMs: QUERIED_AT_MS }
+      )
+    )
+    for (const forbidden of ['acct-secret', 'accountId', 'email', '@', 'providerAccountId', 'organizationName']) {
+      expect(serialized).not.toContain(forbidden)
+    }
+  })
+})

--- a/src/main/rate-limits/resource-evidence-projection.ts
+++ b/src/main/rate-limits/resource-evidence-projection.ts
@@ -6,11 +6,13 @@ import type {
 import type {
   ResourceEvidence,
   ResourceEvidenceProvider,
-  ResourceEvidenceWindow
+  ResourceEvidenceWindow,
+  ResourceEvidenceWindowScope
 } from '../../shared/resource-evidence-types'
 
 // Why: the caller's horizon roles come from the window's real duration; an
-// unrecognised duration stays UNKNOWN rather than guessing a horizon.
+// unrecognised duration stays UNKNOWN rather than guessing a horizon. `scope`
+// (not this map) is the stable identity — it comes from the source field name.
 const WINDOW_ROLE_BY_MINUTES: Record<number, 'BURST' | 'BUDGET'> = {
   60: 'BURST', // Gemini hourly per-model bucket
   300: 'BURST', // 5-hour session window
@@ -18,14 +20,25 @@ const WINDOW_ROLE_BY_MINUTES: Record<number, 'BURST' | 'BUDGET'> = {
   43200: 'BUDGET' // 30-day monthly window (OpenCode Go, Grok unified billing)
 }
 
+/** Formats a Unix ms timestamp as ISO 8601, or null when it is missing/NaN. */
 function toIso(ms: number | null | undefined): string | null {
   return typeof ms === 'number' && Number.isFinite(ms) ? new Date(ms).toISOString() : null
 }
 
-function projectWindow(window: RateLimitWindow, pool?: string): ResourceEvidenceWindow {
+/**
+ * Projects one normalized quota window. `scope` is passed by the caller (the
+ * `ProviderRateLimits` field name) so it stays stable regardless of duration,
+ * and `role` is derived from `windowMinutes`.
+ */
+function projectWindow(
+  window: RateLimitWindow,
+  scope: ResourceEvidenceWindowScope,
+  pool?: string
+): ResourceEvidenceWindow {
   const usedPercent = Math.min(100, Math.max(0, window.usedPercent))
   return {
     role: WINDOW_ROLE_BY_MINUTES[window.windowMinutes] ?? 'UNKNOWN',
+    scope,
     windowMinutes: window.windowMinutes,
     remainingRatio: Math.round((1 - usedPercent / 100) * 100) / 100,
     remainingRatioGranularity: 0.01,
@@ -35,16 +48,23 @@ function projectWindow(window: RateLimitWindow, pool?: string): ResourceEvidence
   }
 }
 
+/**
+ * Projects one provider's normalized rate-limit state into identity-free
+ * evidence. Reads only the usage windows, timestamp, status, and two derived
+ * booleans — never `usageMetadata` credential fields or the raw error string.
+ */
 function projectProvider(
   limits: ProviderRateLimits,
   queriedAtMs: number
 ): ResourceEvidenceProvider {
   const windows: ResourceEvidenceWindow[] = []
-  if (limits.session) windows.push(projectWindow(limits.session))
-  if (limits.weekly) windows.push(projectWindow(limits.weekly))
-  if (limits.monthly) windows.push(projectWindow(limits.monthly))
-  if (limits.fableWeekly) windows.push(projectWindow(limits.fableWeekly))
-  for (const bucket of limits.buckets ?? []) windows.push(projectWindow(bucket, bucket.name))
+  if (limits.session) windows.push(projectWindow(limits.session, 'session'))
+  if (limits.weekly) windows.push(projectWindow(limits.weekly, 'weekly'))
+  if (limits.fableWeekly) windows.push(projectWindow(limits.fableWeekly, 'fableWeekly'))
+  if (limits.monthly) windows.push(projectWindow(limits.monthly, 'monthly'))
+  for (const bucket of limits.buckets ?? []) {
+    windows.push(projectWindow(bucket, 'bucket', bucket.name))
+  }
 
   const updatedAtMs =
     typeof limits.updatedAt === 'number' && Number.isFinite(limits.updatedAt)

--- a/src/main/rate-limits/resource-evidence-projection.ts
+++ b/src/main/rate-limits/resource-evidence-projection.ts
@@ -1,0 +1,96 @@
+import type {
+  ProviderRateLimits,
+  RateLimitState,
+  RateLimitWindow
+} from '../../shared/rate-limit-types'
+import type {
+  ResourceEvidence,
+  ResourceEvidenceProvider,
+  ResourceEvidenceWindow
+} from '../../shared/resource-evidence-types'
+
+// Why: the caller's horizon roles come from the window's real duration; an
+// unrecognised duration stays UNKNOWN rather than guessing a horizon.
+const WINDOW_ROLE_BY_MINUTES: Record<number, 'BURST' | 'BUDGET'> = {
+  60: 'BURST', // Gemini hourly per-model bucket
+  300: 'BURST', // 5-hour session window
+  10080: 'BUDGET', // 7-day weekly window
+  43200: 'BUDGET' // 30-day monthly window (OpenCode Go, Grok unified billing)
+}
+
+function toIso(ms: number | null | undefined): string | null {
+  return typeof ms === 'number' && Number.isFinite(ms) ? new Date(ms).toISOString() : null
+}
+
+function projectWindow(window: RateLimitWindow, pool?: string): ResourceEvidenceWindow {
+  const usedPercent = Math.min(100, Math.max(0, window.usedPercent))
+  return {
+    role: WINDOW_ROLE_BY_MINUTES[window.windowMinutes] ?? 'UNKNOWN',
+    windowMinutes: window.windowMinutes,
+    remainingRatio: Math.round((1 - usedPercent / 100) * 100) / 100,
+    remainingRatioGranularity: 0.01,
+    resetAt: toIso(window.resetsAt),
+    resetAtSource: 'unknown',
+    ...(pool ? { pool } : {})
+  }
+}
+
+function projectProvider(
+  limits: ProviderRateLimits,
+  queriedAtMs: number
+): ResourceEvidenceProvider {
+  const windows: ResourceEvidenceWindow[] = []
+  if (limits.session) windows.push(projectWindow(limits.session))
+  if (limits.weekly) windows.push(projectWindow(limits.weekly))
+  if (limits.monthly) windows.push(projectWindow(limits.monthly))
+  if (limits.fableWeekly) windows.push(projectWindow(limits.fableWeekly))
+  for (const bucket of limits.buckets ?? []) windows.push(projectWindow(bucket, bucket.name))
+
+  const updatedAtMs =
+    typeof limits.updatedAt === 'number' && Number.isFinite(limits.updatedAt)
+      ? limits.updatedAt
+      : null
+
+  const extras: NonNullable<ResourceEvidenceProvider['extras']> = {}
+  if (typeof limits.planType === 'string') extras.planType = limits.planType
+  if (limits.rateLimitResetCredits) {
+    extras.resetCreditsAvailable = limits.rateLimitResetCredits.availableCount
+  }
+
+  return {
+    available: limits.status === 'ok' && windows.length > 0,
+    status: limits.status,
+    sourceUpdatedAt: toIso(updatedAtMs),
+    dataAgeMs: updatedAtMs === null ? null : Math.max(0, queriedAtMs - updatedAtMs),
+    rateLimited: limits.usageMetadata?.failureKind === 'rate-limited',
+    retryAt: toIso(limits.usageMetadata?.retryAtMs ?? null),
+    windows,
+    ...(Object.keys(extras).length > 0 ? { extras } : {})
+  }
+}
+
+/**
+ * Projects the identity-free subset of RateLimitState into machine-readable
+ * resource evidence. Pure and deterministic; never reads the account arrays,
+ * emails, credentials, or raw provider payloads that sit alongside it.
+ */
+export function projectResourceEvidence(
+  state: RateLimitState,
+  options: { queriedAtMs: number }
+): ResourceEvidence {
+  const entries: readonly [ProviderRateLimits['provider'], ProviderRateLimits | null][] = [
+    ['claude', state.claude],
+    ['codex', state.codex],
+    ['gemini', state.gemini],
+    ['antigravity', state.antigravity],
+    ['grok', state.grok],
+    ['kimi', state.kimi],
+    ['minimax', state.minimax],
+    ['opencode-go', state.opencodeGo]
+  ]
+  const providers: ResourceEvidence['providers'] = {}
+  for (const [name, limits] of entries) {
+    if (limits) providers[name] = projectProvider(limits, options.queriedAtMs)
+  }
+  return { queriedAt: new Date(options.queriedAtMs).toISOString(), providers }
+}

--- a/src/main/runtime/rpc/methods/index.ts
+++ b/src/main/runtime/rpc/methods/index.ts
@@ -17,6 +17,7 @@ import { NOTIFICATION_METHODS } from './notifications'
 import { STATS_METHODS } from './stats'
 import { DIAGNOSTICS_METHODS } from './diagnostics'
 import { ACCOUNT_METHODS } from './accounts'
+import { RESOURCE_METHODS } from './resource'
 import { PREFLIGHT_METHODS } from './preflight'
 import { COMPUTER_METHODS } from './computer'
 import { SESSION_TAB_METHODS } from './session-tabs'
@@ -73,6 +74,7 @@ export const ALL_RPC_METHODS: readonly RpcAnyMethod[] = [
   ...STATS_METHODS,
   ...DIAGNOSTICS_METHODS,
   ...ACCOUNT_METHODS,
+  ...RESOURCE_METHODS,
   ...PREFLIGHT_METHODS,
   ...COMPUTER_METHODS,
   ...SESSION_TAB_METHODS,

--- a/src/main/runtime/rpc/methods/resource.test.ts
+++ b/src/main/runtime/rpc/methods/resource.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcRequest } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { ResourceEvidence } from '../../../shared/resource-evidence-types'
+import { RESOURCE_METHODS } from './resource'
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+const evidence: ResourceEvidence = {
+  queriedAt: '2026-09-09T12:00:00.000Z',
+  providers: {
+    codex: {
+      available: true,
+      status: 'ok',
+      sourceUpdatedAt: '2026-09-09T11:52:00.000Z',
+      dataAgeMs: 480000,
+      rateLimited: false,
+      retryAt: null,
+      windows: [
+        {
+          role: 'BURST',
+          windowMinutes: 300,
+          remainingRatio: 0.81,
+          remainingRatioGranularity: 0.01,
+          resetAt: '2026-09-09T14:38:00.000Z',
+          resetAtSource: 'unknown'
+        }
+      ]
+    }
+  }
+}
+
+describe('resource RPC methods', () => {
+  it('returns the resource evidence projection and defaults refresh to false', async () => {
+    const getResourceEvidence = vi.fn().mockResolvedValue(evidence)
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getResourceEvidence
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: RESOURCE_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest('resource.status'))
+
+    expect(getResourceEvidence).toHaveBeenCalledWith({ refresh: false })
+    expect(response).toMatchObject({ ok: true, result: evidence })
+  })
+
+  it('passes an explicit refresh through', async () => {
+    const getResourceEvidence = vi.fn().mockResolvedValue(evidence)
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getResourceEvidence
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: RESOURCE_METHODS })
+
+    await dispatcher.dispatch(makeRequest('resource.status', { refresh: true }))
+
+    expect(getResourceEvidence).toHaveBeenCalledWith({ refresh: true })
+  })
+
+  it('carries no account arrays or identity in the response', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getResourceEvidence: vi.fn().mockResolvedValue(evidence)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: RESOURCE_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest('resource.status'))
+    const serialized = JSON.stringify(response)
+
+    for (const forbidden of ['accounts', 'inactiveClaudeAccounts', 'email', 'accountId']) {
+      expect(serialized).not.toContain(forbidden)
+    }
+  })
+})

--- a/src/main/runtime/rpc/methods/resource.test.ts
+++ b/src/main/runtime/rpc/methods/resource.test.ts
@@ -22,6 +22,7 @@ const evidence: ResourceEvidence = {
       windows: [
         {
           role: 'BURST',
+          scope: 'session',
           windowMinutes: 300,
           remainingRatio: 0.81,
           remainingRatioGranularity: 0.01,

--- a/src/main/runtime/rpc/methods/resource.ts
+++ b/src/main/runtime/rpc/methods/resource.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+import { defineMethod, type RpcMethod } from '../core'
+
+const ResourceStatusParams = z.object({
+  // Why: default off — the command returns the cached poll snapshot; refresh
+  // opts into the stale-aware provider fetch (poll throttle and Retry-After still apply).
+  refresh: z.boolean().default(false)
+})
+
+export const RESOURCE_METHODS: RpcMethod[] = [
+  defineMethod({
+    name: 'resource.status',
+    params: ResourceStatusParams,
+    handler: async (params, { runtime }) => runtime.getResourceEvidence({ refresh: params.refresh })
+  })
+]

--- a/src/main/runtime/rpc/methods/resource.ts
+++ b/src/main/runtime/rpc/methods/resource.ts
@@ -7,6 +7,12 @@ const ResourceStatusParams = z.object({
   refresh: z.boolean().default(false)
 })
 
+/**
+ * `resource.status` — read-only, identity-free projection of RateLimitService
+ * state (see `resource-evidence-projection.ts`). Additive method: an older
+ * dispatcher answers `method_not_found`. Never mutates account or credential
+ * state; `refresh` reuses the existing stale-aware fetch.
+ */
 export const RESOURCE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'resource.status',

--- a/src/main/runtime/runtime-account-controller.ts
+++ b/src/main/runtime/runtime-account-controller.ts
@@ -10,6 +10,8 @@ import type {
   CodexRateLimitAccountsState
 } from '../../shared/managed-account-types'
 import type { CodexRateLimitResetOutcome, RateLimitState } from '../../shared/rate-limit-types'
+import type { ResourceEvidence } from '../../shared/resource-evidence-types'
+import { projectResourceEvidence } from '../rate-limits/resource-evidence-projection'
 import type { CodexResetCreditExpectedScope } from '../../shared/codex-reset-credit-scope'
 import type { CommitMessageAgentEnvironmentResolvers } from '../text-generation/commit-message-agent-environment'
 import type { ClaudeAccountSelectionTarget } from '../claude-accounts/runtime-selection'
@@ -65,6 +67,17 @@ export class RuntimeAccountController {
       codex: codexAccounts.listAccounts(),
       rateLimits: rateLimits.getState()
     }
+  }
+
+  async getResourceEvidence(options?: { refresh?: boolean }): Promise<ResourceEvidence> {
+    const { rateLimits } = this.requireServices()
+    // Why: refresh reuses the stale-aware plan (honours the poll throttle and
+    // Retry-After); never the forced fetch or the inactive-account sweeps
+    // refreshForMobile adds — this projection never touches account data.
+    if (options?.refresh) {
+      await rateLimits.refreshIfStale()
+    }
+    return projectResourceEvidence(rateLimits.getState(), { queriedAtMs: Date.now() })
   }
 
   async refreshForMobile(): Promise<void> {

--- a/src/main/runtime/runtime-account-controller.ts
+++ b/src/main/runtime/runtime-account-controller.ts
@@ -69,11 +69,15 @@ export class RuntimeAccountController {
     }
   }
 
+  /**
+   * Identity-free projection of the current rate-limit snapshot for
+   * `resource.status`. With `refresh`, reuses the stale-aware plan (honours the
+   * poll throttle and `Retry-After`) — never the forced fetch or the
+   * inactive-account sweeps `refreshForMobile` adds. Reads only
+   * `RateLimitService` state, never account data.
+   */
   async getResourceEvidence(options?: { refresh?: boolean }): Promise<ResourceEvidence> {
     const { rateLimits } = this.requireServices()
-    // Why: refresh reuses the stale-aware plan (honours the poll throttle and
-    // Retry-After); never the forced fetch or the inactive-account sweeps
-    // refreshForMobile adds — this projection never touches account data.
     if (options?.refresh) {
       await rateLimits.refreshIfStale()
     }

--- a/src/main/runtime/runtime-service-command-surface.ts
+++ b/src/main/runtime/runtime-service-command-surface.ts
@@ -34,6 +34,7 @@ export type RuntimeServiceCommandSurface = {
   setCommitMessageAgentEnvironmentResolvers: RuntimeAccountController['setCommitMessageAgentEnvironment']
   getCommitMessageAgentEnvironmentResolvers: RuntimeAccountController['getCommitMessageAgentEnvironment']
   getAccountsSnapshot: RuntimeAccountController['getSnapshot']
+  getResourceEvidence: RuntimeAccountController['getResourceEvidence']
   refreshAccountsForMobile: RuntimeAccountController['refreshForMobile']
   refreshAccountsForMobileSubscriber: RuntimeAccountController['refreshForMobileSubscriber']
   selectClaudeAccount: RuntimeAccountController['selectClaude']
@@ -116,6 +117,7 @@ export function installRuntimeServiceCommandSurface(
     getCommitMessageAgentEnvironmentResolvers:
       accounts.getCommitMessageAgentEnvironment.bind(accounts),
     getAccountsSnapshot: accounts.getSnapshot.bind(accounts),
+    getResourceEvidence: accounts.getResourceEvidence.bind(accounts),
     refreshAccountsForMobile: accounts.refreshForMobile.bind(accounts),
     refreshAccountsForMobileSubscriber: accounts.refreshForMobileSubscriber.bind(accounts),
     selectClaudeAccount: accounts.selectClaude.bind(accounts),

--- a/src/main/startup/cli-command-names.ts
+++ b/src/main/startup/cli-command-names.ts
@@ -50,6 +50,7 @@ export const CLI_COMMAND_NAMES = [
   'project',
   'reload',
   'repo',
+  'resource',
   'screenshot',
   'scroll',
   'scrollintoview',

--- a/src/shared/cli-argument-boundary.ts
+++ b/src/shared/cli-argument-boundary.ts
@@ -32,6 +32,7 @@ export const CLI_BOOLEAN_FLAGS = new Set([
   'ready',
   'recipe-json',
   'references',
+  'refresh',
   'relations',
   'reinstall',
   'restore-window',

--- a/src/shared/resource-evidence-types.ts
+++ b/src/shared/resource-evidence-types.ts
@@ -1,0 +1,45 @@
+import type { ProviderRateLimits } from './rate-limit-types'
+
+// Identity-free projection of RateLimitService state for machine consumers
+// (`orca resource status --json`). Carries no account identity, credentials, or
+// raw provider payloads — only normalized usage windows and their timestamps.
+
+export type ResourceEvidenceWindowRole = 'BURST' | 'BUDGET' | 'UNKNOWN'
+
+export type ResourceEvidenceWindow = {
+  role: ResourceEvidenceWindowRole
+  windowMinutes: number
+  /** 1 - usedPercent/100. usedPercent is an integer, so this is 0.01-grained. */
+  remainingRatio: number
+  /** The step size of `remainingRatio`; the source is integer percent. */
+  remainingRatioGranularity: 0.01
+  /** ISO 8601, or null when the provider did not report a reset time. */
+  resetAt: string | null
+  /** Orca does not retain whether `resetAt` was provider-absolute or derived. */
+  resetAtSource: 'unknown'
+  /** Gemini per-model bucket name; absent for session/weekly/monthly windows. */
+  pool?: string
+}
+
+export type ResourceEvidenceProvider = {
+  available: boolean
+  status: ProviderRateLimits['status']
+  /** ISO 8601 of the last successful provider data update, or null. */
+  sourceUpdatedAt: string | null
+  /** `queriedAt` minus `sourceUpdatedAt` in ms; null when the source time is unknown. */
+  dataAgeMs: number | null
+  rateLimited: boolean
+  /** ISO 8601 before which refetches should not be attempted, or null. */
+  retryAt: string | null
+  windows: ResourceEvidenceWindow[]
+  extras?: {
+    planType?: string
+    resetCreditsAvailable?: number
+  }
+}
+
+export type ResourceEvidence = {
+  /** ISO 8601 — when this projection was produced. Not a provider observation time. */
+  queriedAt: string
+  providers: Partial<Record<ProviderRateLimits['provider'], ResourceEvidenceProvider>>
+}

--- a/src/shared/resource-evidence-types.ts
+++ b/src/shared/resource-evidence-types.ts
@@ -4,10 +4,31 @@ import type { ProviderRateLimits } from './rate-limit-types'
 // (`orca resource status --json`). Carries no account identity, credentials, or
 // raw provider payloads — only normalized usage windows and their timestamps.
 
+/**
+ * Generic capacity role for routing relevance, derived from the window's
+ * duration: short rolling windows are `BURST`, long-horizon caps are `BUDGET`,
+ * and an unrecognised duration is `UNKNOWN`. It is deliberately not a stable
+ * identity — several distinct quotas can share a role.
+ */
 export type ResourceEvidenceWindowRole = 'BURST' | 'BUDGET' | 'UNKNOWN'
+
+/**
+ * Stable discriminator for the underlying normalized quota window, mirroring the
+ * `ProviderRateLimits` field the window was projected from. Unlike array
+ * position (which is not identity) and `role` (which is not unique), a consumer
+ * can rely on `scope` to tell e.g. `weekly` from `fableWeekly` even though both
+ * are `BUDGET` / 10080-minute windows.
+ */
+export type ResourceEvidenceWindowScope =
+  | 'session'
+  | 'weekly'
+  | 'fableWeekly'
+  | 'monthly'
+  | 'bucket'
 
 export type ResourceEvidenceWindow = {
   role: ResourceEvidenceWindowRole
+  scope: ResourceEvidenceWindowScope
   windowMinutes: number
   /** 1 - usedPercent/100. usedPercent is an integer, so this is 0.01-grained. */
   remainingRatio: number
@@ -17,11 +38,18 @@ export type ResourceEvidenceWindow = {
   resetAt: string | null
   /** Orca does not retain whether `resetAt` was provider-absolute or derived. */
   resetAtSource: 'unknown'
-  /** Gemini per-model bucket name; absent for session/weekly/monthly windows. */
+  /** Model/bucket name for `scope: 'bucket'` windows (Gemini); absent otherwise. */
   pool?: string
 }
 
 export type ResourceEvidenceProvider = {
+  /**
+   * True when the last fetch succeeded (`status === 'ok'`) AND at least one
+   * usage window is present — i.e. a quota number can actually be read. A
+   * provider whose fetch succeeded but reported no windows is `available: false`
+   * with `status: 'ok'`; a consumer that only cares whether the fetch worked
+   * should read `status` directly.
+   */
   available: boolean
   status: ProviderRateLimits['status']
   /** ISO 8601 of the last successful provider data update, or null. */


### PR DESCRIPTION
## ELI5

Orca already normalizes each provider's usage/rate-limit state and shows it in the status bar. The only machine-readable way to get at it today is `orca account list --json`, which is really about **accounts** — it carries emails and org names and isn't a usage contract. This adds `orca resource status --json`: a small, read-only, identity-free view of the same numbers, for scripts and external orchestration.

## What Changed

- **New RPC method `resource.status`** (`src/main/runtime/rpc/methods/resource.ts`, registered in `methods/index.ts`) — additive, read-only. Params `{ refresh?: boolean = false }`; result is `ResourceEvidence`.
- **Pure projection** `projectResourceEvidence(state: RateLimitState, { queriedAtMs })` (`src/main/rate-limits/resource-evidence-projection.ts`). Iterates only the eight provider entries of `RateLimitState`; never the account arrays, `inactive*Accounts`, credentials, `usageMetadata` credential fields, `resetDescription`, or the raw `error` string.
- **Contract types** in `src/shared/resource-evidence-types.ts`:
  - per provider — `status`, `available` (`true` only when the fetch succeeded **and** ≥1 window is present; a fetch that succeeded with no windows is `available: false` / `status: "ok"`), `source_updated_at`, `data_age_ms`, `rate_limited` / `retry_at`, `windows[]`, optional `extras` (`plan_type`, `reset_credits_available`).
  - per window — `scope` (**stable discriminator**: `session | weekly | fableWeekly | monthly | bucket`, mirroring the `ProviderRateLimits` field), `role` (generic horizon: `BURST | BUDGET | UNKNOWN`, from `windowMinutes`), `window_minutes`, `remaining_ratio` + `remaining_ratio_granularity` (`0.01` — the source is integer `usedPercent`), `reset_at`, `reset_at_source` (always `"unknown"` — the state records no provenance), and `pool` (model name) for `bucket` windows.
- **Runtime surface** — `getResourceEvidence()` on `RuntimeAccountController`, exposed via `runtime-service-command-surface.ts`. With `refresh` it reuses `rateLimits.refreshIfStale()` (the stale-aware plan — honours the poll throttle and `Retry-After`), **not** the forced `refresh()` or the inactive-account sweeps `refreshForMobile()` adds.
- **CLI** — `orca resource status [--json] [--refresh]`: handler, spec, `handler-group-manifest.ts` group, `cli-command-names.ts` entry, and `--refresh` added to `CLI_BOOLEAN_FLAGS`. `--json` prints the RPC success envelope; human mode prints one line per provider and per window (each window led by its `scope`).
- **Docs** — a "Machine-readable evidence" section in `usage-tracking.mdx`.

`accounts.list` / `accounts.subscribe` payloads are untouched. No `RUNTIME_PROTOCOL_VERSION` bump.

## Why

Automation and external orchestration need "how close is each provider to a limit?" without pulling account identity in with it, and without depending on array position for semantics. `orca account list --json` fails both: its envelope is account-shaped (emails, org names, active-account ids), and it renders no dedicated usage contract.

Everything is a projection of the existing `RateLimitService` — no new polling, parsers, or state. Orca reports the evidence and its two timestamps (`queried_at` = projection time, `source_updated_at` = last provider refresh) and **no freshness verdict**; the caller decides what "fresh enough" means. The `scope` field exists because `ProviderRateLimits` distinguishes `weekly` and `fableWeekly` but both are 7‑day `BUDGET` / 10080‑minute windows — a machine consumer must be able to tell them apart by a field, not by order.

## Linked Issue

N/A — self-contained additive CLI capability from outside the team; no tracking issue filed.

## Visual Proof

N/A — new CLI command and RPC; no UI or interaction change.

## Testing

Prepared in an environment where `pnpm install` could not complete (npm-registry instability plus the repo's supply-chain policy check on the lockfile), so `pnpm tc` / `oxlint` / `pnpm test` / `pnpm build` were **not** run locally. What was checked locally:

| Check | Result |
| --- | --- |
| `node --experimental-strip-types --check` on all 8 new `.ts` files | pass (syntax / erasable-grammar) |
| `git diff --check` | clean |
| `max-lines` budget (300 `.ts` / 800 test, blank+comment-skipped) | within limits |
| Static review against real exports (`defineMethod`/`RpcMethod`, `printResult`, `CommandSpec`, `RateLimitService.refreshIfStale`/`getState`, flag system, the four registration points, `handler-group-manifest.test.ts` / `registry-parity` / `cli-command-name-parity` expectations) | consistent |

Automated tests added/updated (run by CI): projection unit tests — Codex `session`+`weekly`, Claude, coexisting `weekly`+`fableWeekly` (distinguished by `scope`, not order), standalone `fableWeekly`, `monthly`, unrecognised `windowMinutes` → `role: UNKNOWN`, all five `scope` values, Gemini `bucket` pools, Antigravity, unavailable/error, status-ok-with-no-windows → `available: false`, rate-limited (booleans only, no raw payload), missing state, `NaN` update time, identity-leak scan; `resource.status` RPC tests (projection-only response, default `refresh: false`, explicit refresh); CLI handler tests (stable parseable JSON, `--refresh` mapping, concise human summary).

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not manually runnable here (no built runtime); CI is the verification authority for this branch.

## AI Disclosure

AI-assisted. Implementation, tests, and this description were written with Claude (Anthropic) under human direction; the design was reviewed against the actual repo types and conventions before each file.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

(Not applicable — this touches the rate-limit projection, RPC surface, and CLI; nothing in the skill installer.)

## Notes

- **Security** — read-only; identity firewall verified by tests. No credentials, tokens, auth headers, emails, account ids, or raw provider payloads in the output. Projects from `RateLimitService.getState()`, not from `AccountsSnapshot`.
- **Cross-platform** — no platform-specific code; the CLI path uses the standard registration points.
- **Remote / SSH** — new additive RPC method: `remote-wire-compatibility.md` Rule 1. An older dispatcher answers `method_not_found` (visible at negotiation, not silently dropped). `accounts.list` / `accounts.subscribe` unchanged; no new stream opcode; no protocol-version bump.
- **Mobile** — no mobile surface touched.
- **Backwards compatibility** — additive only.
- **Performance** — pure synchronous projection over ≤8 provider objects; `--refresh` reuses the existing stale-aware fetch (throttled).

### Known first-version limitations

- `reset_at_source` is always `"unknown"` — `RateLimitWindow` records no provenance for `resetsAt`. A follow-up in the per-provider mappers could add it.
- `remaining_ratio` granularity `0.01` (integer `usedPercent`) — surfaced honestly via `remaining_ratio_granularity`.
- No quota-generation metadata (none exists in the underlying state).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — **not run locally (toolchain blocked); relying on CI**
