### PR TITLE
fix(agent-sleep): preserve native chat view mode across hibernation resume

### DIFF
--- a/src/renderer/src/lib/sleeping-agent-session-launch-view-mode.test.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch-view-mode.test.ts
@@ -1,0 +1,88 @@
+// Agent Sleep's restart opens a fresh tab for a hibernated session (#19668):
+// a record captured from a tab in native chat view must resume into a tab
+// with viewMode: 'chat', or mobile clients render it as a plain terminal.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+
+const mockCreateTab = vi.fn()
+
+const store = {
+  settings: {
+    agentCmdOverrides: {},
+    agentDefaultArgs: {} as Record<string, string>,
+    agentDefaultEnv: {} as Record<string, Record<string, string>>,
+    activeRuntimeEnvironmentId: null as string | null
+  },
+  repos: [{ id: 'repo-1', connectionId: null as string | null, path: '/repo' }],
+  worktreesByRepo: {
+    'repo-1': [{ id: 'wt-1', repoId: 'repo-1', path: '/repo/feature', displayName: 'feature' }]
+  } as Record<string, { id: string; repoId: string; path: string; displayName: string }[]>,
+  getKnownWorktreeById: (id: string) =>
+    Object.values(store.worktreesByRepo)
+      .flat()
+      .find((worktree) => worktree.id === id),
+  tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+  openFiles: [] as { id: string; worktreeId: string }[],
+  browserTabsByWorktree: {} as Record<string, { id: string }[]>,
+  tabBarOrderByWorktree: {} as Record<string, string[]>,
+  createTab: mockCreateTab,
+  claimAutomaticAgentResume: vi.fn(),
+  clearSleepingAgentSession: vi.fn(),
+  setActiveTabType: vi.fn(),
+  setTabBarOrder: vi.fn()
+}
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => store } }))
+vi.mock('@/lib/new-workspace', () => ({ CLIENT_PLATFORM: 'darwin' }))
+vi.mock('sonner', () => ({ toast: { message: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/telemetry', () => ({
+  track: vi.fn(),
+  tuiAgentToAgentKind: (agent: string) => agent
+}))
+vi.mock('@/components/tab-bar/reconcile-order', () => ({
+  reconcileTabOrder: vi.fn((_stored, termIds: string[]) => [...termIds])
+}))
+
+const SESSION_ID = '0199f7a1-0000-7000-8000-000000000002'
+
+function record(overrides: Partial<SleepingAgentSessionRecord> = {}): SleepingAgentSessionRecord {
+  return {
+    paneKey: 'tab-1::leaf-1',
+    tabId: 'tab-1',
+    worktreeId: 'wt-1',
+    agent: 'codex',
+    providerSession: { key: 'session_id', id: SESSION_ID },
+    prompt: 'finish the task',
+    state: 'done',
+    origin: 'worktree-sleep',
+    capturedAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+async function launchAndGetCreateTabOptions(
+  input: SleepingAgentSessionRecord
+): Promise<{ viewMode?: 'terminal' | 'chat' } | undefined> {
+  const { launchSleepingAgentSession } = await import('./sleeping-agent-session-launch')
+  launchSleepingAgentSession(input)
+  return mockCreateTab.mock.calls.at(-1)?.[3] as { viewMode?: 'terminal' | 'chat' } | undefined
+}
+
+describe('launchSleepingAgentSession viewMode passthrough', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCreateTab.mockReturnValue({ id: 'tab-1' })
+  })
+
+  it('resumes a chat-viewMode record into a chat-viewMode tab', async () => {
+    const options = await launchAndGetCreateTabOptions(record({ viewMode: 'chat' }))
+    expect(options?.viewMode).toBe('chat')
+  })
+
+  it('does not set viewMode for a plain terminal record', async () => {
+    const options = await launchAndGetCreateTabOptions(record())
+    expect(options?.viewMode).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/sleeping-agent-session-launch.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch.ts
@@ -122,6 +122,7 @@ export function launchSleepingAgentSession(
       launchAgent: record.agent,
       providerSession: record.providerSession
     },
+    ...(record.viewMode ? { viewMode: record.viewMode } : {}),
     ...(options?.suppressNavigation ? { activate: false, recordInteraction: false } : {})
   })
   state.clearSleepingAgentSession(record.paneKey)

--- a/src/renderer/src/store/slices/agent-status-sleeping-records-view-mode.test.ts
+++ b/src/renderer/src/store/slices/agent-status-sleeping-records-view-mode.test.ts
@@ -1,0 +1,95 @@
+// A tab showing the native chat view (viewMode: 'chat') must keep that fact in
+// its hibernation resume record, or Agent Sleep's restart re-opens it as a
+// plain terminal — including for mobile clients, which only render the chat
+// overlay when the tab's viewMode says so (#19668).
+
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '../types'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { Tab } from '../../../../shared/tab-types'
+import { sleepingRecordFromEntry } from './agent-status-sleeping-records'
+
+const LEAF = '11111111-1111-4111-8111-111111111111'
+const WORKTREE_ID = 'wt-1'
+const TAB_ID = 'tab-1'
+
+function terminalTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: TAB_ID,
+    ptyId: 'pty-1',
+    worktreeId: WORKTREE_ID,
+    title: 'Agent',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ...overrides
+  }
+}
+
+function unifiedTab(overrides: Partial<Tab> = {}): Tab {
+  return {
+    id: TAB_ID,
+    entityId: TAB_ID,
+    groupId: 'group-1',
+    worktreeId: WORKTREE_ID,
+    contentType: 'terminal',
+    label: 'Agent',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ...overrides
+  }
+}
+
+function entry(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
+  const paneKey = overrides.paneKey ?? `${TAB_ID}:${LEAF}`
+  return {
+    state: 'done',
+    prompt: 'ship it',
+    updatedAt: 1,
+    stateStartedAt: 1,
+    paneKey,
+    tabId: TAB_ID,
+    worktreeId: WORKTREE_ID,
+    agentType: 'claude',
+    providerSession: { key: 'session_id', id: 'session-1' },
+    stateHistory: [],
+    ...overrides
+  }
+}
+
+function stateWithTabs(termTab: TerminalTab, unified: Tab): AppState {
+  return {
+    tabsByWorktree: { [WORKTREE_ID]: [termTab] },
+    unifiedTabsByWorktree: { [WORKTREE_ID]: [unified] }
+  } as unknown as AppState
+}
+
+describe('sleepingRecordFromEntry viewMode capture', () => {
+  it('carries the source tab chat viewMode into the record', () => {
+    const state = stateWithTabs(terminalTab(), unifiedTab({ viewMode: 'chat' }))
+    const record = sleepingRecordFromEntry({
+      state,
+      entry: entry(),
+      worktreeId: WORKTREE_ID,
+      capturedAt: 2
+    })
+
+    expect(record?.viewMode).toBe('chat')
+  })
+
+  it('omits viewMode for a plain terminal tab', () => {
+    const state = stateWithTabs(terminalTab(), unifiedTab())
+    const record = sleepingRecordFromEntry({
+      state,
+      entry: entry(),
+      worktreeId: WORKTREE_ID,
+      capturedAt: 2
+    })
+
+    expect(record?.viewMode).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/agent-status-sleeping-records.ts
+++ b/src/renderer/src/store/slices/agent-status-sleeping-records.ts
@@ -7,6 +7,7 @@ import {
   type SleepingAgentSessionRecord
 } from '../../../../shared/agent-session-resume'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import { findTabAndWorktree } from './tab-group-state'
 import { findTabForAgentEntry } from './agent-status-pane-key-tab-binding'
 
 export function copyLaunchConfig(config: SleepingAgentLaunchConfig): SleepingAgentLaunchConfig {
@@ -39,6 +40,10 @@ export function sleepingRecordFromEntry(args: {
     return null
   }
   const tab = args.tab ?? findTabForAgentEntry(args.state, args.worktreeId, args.entry)
+  // Why: viewMode lives on the unified tab, not the legacy TerminalTab captured above.
+  const unifiedViewMode = tab
+    ? findTabAndWorktree(args.state.unifiedTabsByWorktree, tab.id)?.tab.viewMode
+    : undefined
   return {
     paneKey: args.entry.paneKey,
     ...(tab ? { tabId: tab.id } : {}),
@@ -57,6 +62,7 @@ export function sleepingRecordFromEntry(args: {
       ? { lastAssistantMessage: args.entry.lastAssistantMessage }
       : {}),
     ...(args.launchConfig ? { launchConfig: copyLaunchConfig(args.launchConfig) } : {}),
+    ...(unifiedViewMode === 'chat' ? { viewMode: 'chat' } : {}),
     ...(args.entry.interrupted ? { interrupted: true } : {}),
     ...(args.origin ? { origin: args.origin } : {})
   }

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -57,6 +57,11 @@ export type SleepingAgentSessionRecord = {
   interrupted?: boolean
   connectionId?: string | null
   launchConfig?: SleepingAgentLaunchConfig
+  /** The source tab's unified-tab view mode at capture time. When the pane's
+   *  tab is gone at resume (worktree-sleep/quit), the fresh resume tab is
+   *  minted from this record alone, so 'chat' must be carried here or the
+   *  resumed tab silently falls back to the raw terminal view (#19668). */
+  viewMode?: 'terminal' | 'chat'
   /** How the record was captured. Worktree-sleep records (legacy records have
    *  no origin) are consumed by worktree activation, which opens a fresh tab.
    *  Quit/live records describe panes that still exist in the restored session,

--- a/src/shared/workspace-session-schema.sleeping-agent.test.ts
+++ b/src/shared/workspace-session-schema.sleeping-agent.test.ts
@@ -457,6 +457,38 @@ describe('parseWorkspaceSession sleeping agents', () => {
     }
   })
 
+  it('preserves the chat viewMode across hydration (#19668)', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      sleepingAgentSessionsByPaneKey: {
+        'tab1:pane-1': {
+          paneKey: 'tab1:pane-1',
+          tabId: 'tab1',
+          worktreeId: 'wt',
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'codex-session' },
+          prompt: 'continue',
+          state: 'done',
+          capturedAt: 10,
+          updatedAt: 9,
+          origin: 'worktree-sleep',
+          viewMode: 'chat'
+        }
+      }
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      // Why: dropped on hydration means a real app restart re-opens the resumed
+      // tab as a raw terminal even though the fix threads viewMode in memory.
+      expect(result.value.sleepingAgentSessionsByPaneKey?.['tab1:pane-1']?.viewMode).toBe('chat')
+    }
+  })
+
   it('preserves legacy live sleeping agent origins across hydration', () => {
     const result = parseWorkspaceSession({
       activeRepoId: null,

--- a/src/shared/workspace-session-sleeping-agents.ts
+++ b/src/shared/workspace-session-sleeping-agents.ts
@@ -98,6 +98,7 @@ const sleepingAgentSessionRecordSchema = z
     interrupted: z.boolean().optional(),
     connectionId: z.string().nullable().optional(),
     launchConfig: sleepingAgentLaunchConfigSchema.optional(),
+    viewMode: z.enum(['terminal', 'chat']).catch('terminal').optional(),
     origin: z.enum(['worktree-sleep', 'quit', 'live']).optional(),
     restoreOnTabOpenOnly: z.boolean().optional()
   })


### PR DESCRIPTION
## Summary
- Fixes #19668: when Agent Sleep (hibernation) restarts a session, the resumed tab always opened as a raw terminal, even if the tab had been in native chat view — which is what mobile clients render as the "native view."
- Root cause: `SleepingAgentSessionRecord` (the hibernation resume record) never captured the source tab's `viewMode`. When the original tab is gone at resume time (`worktree-sleep`/`quit` origin), `launchSleepingAgentSession` mints a brand-new tab via `createTab(...)`, which defaults to `viewMode: 'terminal'` unless told otherwise — so the chat overlay was silently dropped, and mobile's projection (which only forwards `viewMode` when present) fell back to rendering a plain terminal.
- Fix: capture the source tab's unified `viewMode` in `sleepingRecordFromEntry` (reading `unifiedTabsByWorktree`, since `viewMode` lives there rather than on the legacy `TerminalTab`), add `viewMode` to `SleepingAgentSessionRecord`, and thread it through `launchSleepingAgentSession`'s `createTab(...)` call.

## Test plan
- [x] Added `agent-status-sleeping-records-view-mode.test.ts`: `sleepingRecordFromEntry` captures `viewMode: 'chat'` from the unified tab, and omits it for a plain terminal tab.
- [x] Added `sleeping-agent-session-launch-view-mode.test.ts`: `launchSleepingAgentSession` passes `viewMode` through to `createTab` when the record has it, and omits it otherwise.
- [x] `pnpm vitest run` across touched hibernation/resume/agent-status test suites (208+ tests) — all pass.
- [x] `pnpm tc:web` / `pnpm tc:node` — no type errors.
- [x] `pnpm run check:code-quality:changed` — 0 new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpG1TUFp6wwDYUeBVMAXA4