### PR TITLE
fix(sidebar): clarify create tooltip reveals new workspace and add project

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHeader.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.test.tsx
@@ -93,8 +93,10 @@ vi.mock('@/components/ui/popover', () => ({
 let container: HTMLDivElement
 let root: Root
 
+const CREATE_BUTTON_LABEL = 'Create \u2014 new workspace or add project'
+
 function createButton(): HTMLButtonElement {
-  const button = container.querySelector<HTMLButtonElement>('[aria-label="Create"]')
+  const button = container.querySelector<HTMLButtonElement>(`[aria-label="${CREATE_BUTTON_LABEL}"]`)
   if (!button) {
     throw new Error('Create button not rendered')
   }
@@ -194,6 +196,16 @@ describe('SidebarHeader', () => {
     expect(mocks.openWorkspaceCreationComposerWithTourHandoff).not.toHaveBeenCalled()
   })
 
+  it('exposes a create button disclosing that workspaces can be created and projects added', () => {
+    act(() => {
+      root.render(<SidebarHeader onWorkspaceBoardMenuOpenChange={vi.fn()} />)
+    })
+
+    const button = createButton()
+    expect(button.getAttribute('aria-label')).toBe(CREATE_BUTTON_LABEL)
+    expect(container.textContent).toContain(CREATE_BUTTON_LABEL)
+  })
+
   it('omits the shortcut hint when workspace creation is unassigned', async () => {
     mocks.shortcutLabel.current = null
     act(() => {
@@ -282,7 +294,7 @@ describe('SidebarHeader', () => {
     })
 
     expect(container.querySelector('[aria-label="Turn off activity view"]')).toBeTruthy()
-    expect(container.querySelector('[aria-label="Create"]')).toBeTruthy()
+    expect(container.querySelector(`[aria-label="${CREATE_BUTTON_LABEL}"]`)).toBeTruthy()
     expect(container.querySelector('[aria-label="Workspace options"]')).toBeNull()
     expect(container.querySelector('[aria-label="Add Project"]')).toBeNull()
   })
@@ -298,7 +310,7 @@ describe('SidebarHeader', () => {
     expect(headerClasses.has('h-8')).toBe(true)
     expect(container.querySelector('[aria-label="View activity"]')).toBeTruthy()
     expect(container.querySelector('[aria-label="Add Project"]')).toBeNull()
-    expect(container.querySelector('[aria-label="Create"]')).toBeTruthy()
+    expect(container.querySelector(`[aria-label="${CREATE_BUTTON_LABEL}"]`)).toBeTruthy()
   })
 
   it('keeps the same actions on one row at compact width', async () => {
@@ -309,7 +321,7 @@ describe('SidebarHeader', () => {
 
     expect(container.querySelector('[aria-label="Add Project"]')).toBeNull()
     expect(container.querySelector('[aria-label="View activity"]')).toBeTruthy()
-    expect(container.querySelector('[aria-label="Create"]')).toBeTruthy()
+    expect(container.querySelector(`[aria-label="${CREATE_BUTTON_LABEL}"]`)).toBeTruthy()
     expect(container.querySelector('[aria-label="Workspace options"]')).toBeTruthy()
     expect(container.querySelector('[aria-label="More workspace actions"]')).toBeNull()
 
@@ -350,7 +362,7 @@ describe('SidebarHeader', () => {
       })
       expect(container.querySelector('[aria-label="More workspace actions"]')).toBeNull()
       expect(container.querySelector('[aria-label="Add Project"]')).toBeNull()
-      expect(container.querySelector('[aria-label="Create"]')).toBeTruthy()
+      expect(container.querySelector(`[aria-label="${CREATE_BUTTON_LABEL}"]`)).toBeTruthy()
       expect(container.querySelector('[aria-label="Workspace options"]')).toBeTruthy()
     }
   })

--- a/src/renderer/src/components/sidebar/sidebar-header-actions.tsx
+++ b/src/renderer/src/components/sidebar/sidebar-header-actions.tsx
@@ -64,7 +64,10 @@ function SidebarCreateMenu({
               size="icon-xs"
               type="button"
               className="text-muted-foreground"
-              aria-label={translate('auto.components.sidebar.SidebarHeader.createMenu', 'Create')}
+              aria-label={translate(
+                'auto.components.sidebar.SidebarHeader.createMenu',
+                'Create — new workspace or add project'
+              )}
               data-workspace-board-preserve-open={boardAttr}
               data-contextual-tour-target="workspace-create-control"
             >
@@ -73,7 +76,10 @@ function SidebarCreateMenu({
           </DropdownMenuTrigger>
         </TooltipTrigger>
         <TooltipContent side="bottom" sideOffset={6}>
-          {translate('auto.components.sidebar.SidebarHeader.createMenu', 'Create')}
+          {translate(
+            'auto.components.sidebar.SidebarHeader.createMenu',
+            'Create — new workspace or add project'
+          )}
         </TooltipContent>
       </Tooltip>
       <DropdownMenuContent

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5298,7 +5298,7 @@
           "5c9c7c16aa": "Add a project to create workspaces",
           "a30e34eb5c": "Close workspace board",
           "views": "Sidebar view",
-          "createMenu": "Create",
+          "createMenu": "Create — new workspace or add project",
           "addProject": "Add project"
         },
         "SidebarNav": {

--- a/tests/e2e/golden-core-flows.spec.ts
+++ b/tests/e2e/golden-core-flows.spec.ts
@@ -471,7 +471,10 @@ test.describe('New-user golden core flow', () => {
       .locator('[data-contextual-tour-target="workspace-create-control"]')
       .first()
     await expect(createControl).toBeVisible()
-    await expect(createControl).toHaveAttribute('aria-label', 'Create')
+    await expect(createControl).toHaveAttribute(
+      'aria-label',
+      'Create — new workspace or add project'
+    )
     const createControlBox = await createControl.boundingBox()
     expect(createControlBox?.width ?? 0).toBeGreaterThan(0)
     expect(createControlBox?.height ?? 0).toBeGreaterThan(0)

--- a/tests/e2e/helpers/sidebar-project-dialog.ts
+++ b/tests/e2e/helpers/sidebar-project-dialog.ts
@@ -1,13 +1,13 @@
 import { expect, type Page } from '@stablyai/playwright-test'
 
 export async function openSidebarProjectDialog(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await page.getByRole('button', { name: /Create/ }).click()
   await page.getByRole('menuitem', { name: 'Add project', exact: true }).click()
   await expect(page.getByRole('dialog', { name: /Add a project/i })).toBeVisible()
 }
 
 export async function openSidebarWorkspaceComposer(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await page.getByRole('button', { name: /Create/ }).click()
   const newWorkspaceItem = page.getByRole('menuitem', { name: /^New workspace/ })
   await expect(newWorkspaceItem).toBeVisible()
   await newWorkspaceItem.click()

--- a/tests/e2e/helpers/sidebar-project-dialog.ts
+++ b/tests/e2e/helpers/sidebar-project-dialog.ts
@@ -1,13 +1,23 @@
 import { expect, type Page } from '@stablyai/playwright-test'
 
 export async function openSidebarProjectDialog(page: Page): Promise<void> {
-  await page.getByRole('button', { name: /Create/ }).click()
+  await page
+    .getByRole('button', {
+      name: 'Create — new workspace or add project',
+      exact: true
+    })
+    .click()
   await page.getByRole('menuitem', { name: 'Add project', exact: true }).click()
   await expect(page.getByRole('dialog', { name: /Add a project/i })).toBeVisible()
 }
 
 export async function openSidebarWorkspaceComposer(page: Page): Promise<void> {
-  await page.getByRole('button', { name: /Create/ }).click()
+  await page
+    .getByRole('button', {
+      name: 'Create — new workspace or add project',
+      exact: true
+    })
+    .click()
   const newWorkspaceItem = page.getByRole('menuitem', { name: /^New workspace/ })
   await expect(newWorkspaceItem).toBeVisible()
   await newWorkspaceItem.click()


### PR DESCRIPTION
## ELI5

Hovering over the `+` button in the sidebar header previously showed a generic "Create" tooltip (and in earlier releases "New workspace"). This made it look like the button only created workspaces, leaving users unable to tell that "Add project" is also inside that menu. We updated the tooltip and screen-reader label to say **"Create — new workspace or add project"**.

## What Changed

- Updated `aria-label` and `TooltipContent` in [`sidebar-header-actions.tsx`](file:///c:/Users/Kamraam/Desktop/Do%20Not%20Touch/ORCA/orca/src/renderer/src/components/sidebar/sidebar-header-actions.tsx) to `'Create — new workspace or add project'`.
- Updated `auto.components.sidebar.SidebarHeader.createMenu` in [`en.json`](file:///c:/Users/Kamraam/Desktop/Do%20Not%20Touch/ORCA/orca/src/renderer/src/i18n/locales/en.json) to `"Create — new workspace or add project"`.
- Updated [`SidebarHeader.test.tsx`](file:///c:/Users/Kamraam/Desktop/Do%20Not%20Touch/ORCA/orca/src/renderer/src/components/sidebar/SidebarHeader.test.tsx) test selectors and added a dedicated unit test asserting the new accessible name and tooltip text.

## Why

In #19375, the create actions in the sidebar header were unified into a single `+` dropdown menu containing both "New workspace" and "Add project". While this solved reachability, the trigger button's tooltip and accessible name only said "Create". 

Because the sidebar is primarily viewed as a workspace list, users hovering over `+` assume it only creates workspaces, and hunting for "Add project" makes it seem like the feature was removed. Updating the tooltip and `aria-label` immediately clarifies what lives behind the button for both sighted users on hover and screen-reader users.

## Linked Issue

Fixes #19658

## Visual Proof

| State | Tooltip / Accessible Name |
|---|---|
| **Before** | `Create` |
| **After** | `Create — new workspace or add project` |

<img width="1917" height="1021" alt="image" src="https://github.com/user-attachments/assets/4af22caa-9e83-41c4-9350-fd12cf0c2859" />



*(The tooltip is rendered via Radix Tooltip on mouse hover over the `+` icon in the sidebar header).*

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Platform tested**: Windows 11 (local)

**Steps followed**:
1. Ran Vitest on `SidebarHeader.test.tsx` (15/15 tests passing, including new tooltip & `aria-label` test).
2. Ran web typecheck: `npx tsc --noEmit -p config/tsconfig.tc.web.json` (0 errors).
3. Ran `oxlint` and `check-changed-code-quality.mjs` (0 errors, 0 warnings).
4. Ran `verify-localization-catalog.mjs` (passed).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Cross-platform**: Pure React UI / i18n copy update; behaves identically across macOS, Windows, and Linux.
- **Accessibility**: Improves screen reader context by replacing generic `"Create"` with a descriptive accessible name.
- **Performance**: No runtime overhead or extra re-renders.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
