### PR TITLE
test(ci): replace fixed teardown waits with bounded polls

### DIFF
--- a/src/main/native-chat/agent-session-wire/structured-agent-session-claude-options-round-trip.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-claude-options-round-trip.test.ts
@@ -167,12 +167,14 @@ describe('Claude structured session handoff options', () => {
     ).toMatchObject({ ok: true, value: { options: { model: PICKED_MODEL } } })
 
     expect(await host.requestHandoff(CALLER, handoff('to-tui'))).toMatchObject({ ok: true })
-    await vi.waitFor(async () =>
-      expect(await host.handoffStatus(SESSION)).toMatchObject({ owner: 'tui' })
+    await vi.waitFor(
+      async () => expect(await host.handoffStatus(SESSION)).toMatchObject({ owner: 'tui' }),
+      { timeout: 10_000 }
     )
     expect(await host.requestHandoff(CALLER, handoff('to-native'))).toMatchObject({ ok: true })
-    await vi.waitFor(async () =>
-      expect(await host.handoffStatus(SESSION)).toMatchObject({ owner: 'native' })
+    await vi.waitFor(
+      async () => expect(await host.handoffStatus(SESSION)).toMatchObject({ owner: 'native' }),
+      { timeout: 10_000 }
     )
 
     expect(acquire.mock.calls[1]?.[0].options).toEqual({ model: PICKED_MODEL })

--- a/src/main/windows/windows-pty-job.win32.test.ts
+++ b/src/main/windows/windows-pty-job.win32.test.ts
@@ -34,6 +34,14 @@ function isAlive(pid: number): boolean {
   }
 }
 
+// Teardown is asynchronous; poll instead of guessing how long the job takes.
+async function waitUntilDead(pid: number, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (isAlive(pid) && Date.now() < deadline) {
+    await sleep(50)
+  }
+}
+
 describeOnWindows('ConPTY job ownership', () => {
   const spawned: IPty[] = []
 
@@ -108,7 +116,8 @@ describeOnWindows('ConPTY job ownership', () => {
     expect(isAlive(grandchildPid)).toBe(true)
 
     expect(terminatePtyJob(proc)).toBe('terminated')
-    await sleep(1_500)
+    await waitUntilDead(proc.pid)
+    await waitUntilDead(grandchildPid)
 
     expect(isAlive(proc.pid)).toBe(false)
     expect(isAlive(grandchildPid)).toBe(false)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Two tests on `main` were waiting by *stopwatch* instead of by *result*. One said "wait 1.5 seconds, the process should be dead by now"; the other said "wait 1 second, the handoff should have happened by now". On a busy CI machine, "by now" arrives late, and the test fails even though the code is fine. This changes both to wait *for the thing to happen*, with a generous ceiling.

## What broke

| Test | Old wait | Symptom |
|---|---|---|
| `windows-pty-job.win32.test.ts:113` | `await sleep(1_500)` after `terminatePtyJob` | intermittent failure in `package (windows)` — hit #19446, #19495, #19498 |
| `structured-agent-session-claude-options-round-trip.test.ts:170,174` | `vi.waitFor` 1s default, two-hop handoff | intermittent failure under parallel shard load — hit #19494 |

Evidence the second one is load-dependent, not a real defect: it reproduced 4 of 16 times under parallel load, and 5/5 + 6/6 clean when run unloaded.

## Why this is safe

Both changes **strictly widen an existing wait**. The assertions are untouched:

- `waitUntilDead` polls `isAlive` every 50 ms up to 30 s, then the original `expect(isAlive(pid)).toBe(false)` runs. A process that genuinely leaks still fails the test — it just fails 30 s later instead of 1.5 s later.
- `vi.waitFor(..., { timeout: 10_000 })` still fails if the handoff never lands.

Neither can turn a red test green. They can only stop a green test from being called red.

## Not changed

The `await sleep(2_000)` in *"leaves a backgrounded process alone when the shell exits cleanly"* is deliberately left alone — it proves an **absence** (the process must *still be alive* after the wait), so polling would defeat its purpose.

## Trade-offs

None user-facing. Test-only; no `src` behavior change. Worst case a genuinely-broken teardown now takes 30 s to report instead of 1.5 s.
