### PR TITLE
fix(agents): keep a pane working while its agent's descendants are live

### DIFF
--- a/src/main/grok/grok-hook-config.ts
+++ b/src/main/grok/grok-hook-config.ts
@@ -28,7 +28,13 @@ export const GROK_EVENTS = [
     eventName: 'PostToolUseFailure',
     definition: { matcher: GROK_TOOL_EVENT_MATCHER, hooks: [{ type: 'command', command: '' }] }
   },
-  { eventName: 'Notification', definition: { hooks: [{ type: 'command', command: '' }] } }
+  { eventName: 'Notification', definition: { hooks: [{ type: 'command', command: '' }] } },
+  // Why: nested subagents inherit the parent pane's ORCA_PANE_KEY, so without these the pane only
+  // ever hears a child through events that look like the session's own. These name the child, which
+  // is what lets Orca show its row and keep the pane working while a background child outlives the
+  // parent turn. Older grok builds ignore unregistered event names (the StopFailure precedent).
+  { eventName: 'SubagentStart', definition: { hooks: [{ type: 'command', command: '' }] } },
+  { eventName: 'SubagentStop', definition: { hooks: [{ type: 'command', command: '' }] } }
 ] as const
 
 export function buildInstalledGrokConfig(

--- a/src/main/grok/grok-hook-config.ts
+++ b/src/main/grok/grok-hook-config.ts
@@ -34,7 +34,11 @@ export const GROK_EVENTS = [
   // is what lets Orca show its row and keep the pane working while a background child outlives the
   // parent turn. Older grok builds ignore unregistered event names (the StopFailure precedent).
   { eventName: 'SubagentStart', definition: { hooks: [{ type: 'command', command: '' }] } },
-  { eventName: 'SubagentStop', definition: { hooks: [{ type: 'command', command: '' }] } }
+  { eventName: 'SubagentStop', definition: { hooks: [{ type: 'command', command: '' }] } },
+  // Why: an interrupted turn skips the stop gate entirely and reports StopCancelled instead, so a
+  // child spawned by that turn never sends its finish. Without this event the pane keeps a child
+  // nothing can retract and stays working until the process is replaced.
+  { eventName: 'StopCancelled', definition: { hooks: [{ type: 'command', command: '' }] } }
 ] as const
 
 export function buildInstalledGrokConfig(

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -252,6 +252,8 @@ describe('GrokHookService', () => {
         'SessionStart',
         'Stop',
         'StopFailure',
+        'SubagentStart',
+        'SubagentStop',
         'UserPromptSubmit'
       ].sort()
     )

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -252,6 +252,7 @@ describe('GrokHookService', () => {
         'SessionStart',
         'Stop',
         'StopFailure',
+        'StopCancelled',
         'SubagentStart',
         'SubagentStop',
         'UserPromptSubmit'

--- a/src/main/pi/agent-status-async-subagent-source.ts
+++ b/src/main/pi/agent-status-async-subagent-source.ts
@@ -2,8 +2,16 @@ import type { PiAgentKind } from '../../shared/pi-agent-kind'
 
 /** Async child runs delegated through pi's subagent extension outlive the parent turn: the parent
  *  settles and goes interactive while the children keep working. Their lifecycle rides pi's process
- *  event bus rather than the extension API, so it is forwarded here as its own hook event and folded
- *  into the pane's descendant roster receiver-side — the parent's own `agent_end` stays the parent's. */
+ *  event bus rather than the extension API, so it is forwarded here and folded into the pane's
+ *  descendant roster receiver-side — the parent's own `agent_end` stays the parent's.
+ *
+ *  Posts the FULL live set rather than a start/complete delta. `post` in the extension transport is
+ *  a latest-only single slot: while a delivery is in flight, a newer post overwrites the pending one
+ *  and the overwritten message is never sent. Every other caller posts a complete snapshot, so a
+ *  dropped one is harmless. A dropped delta is not — a lost completion would strand a finished child
+ *  in the roster and pin the pane 'working' with nothing left to clear it. Sending the whole set
+ *  keeps this caller idempotent like the rest: the newest message is complete, so it repairs
+ *  whatever the coalescer dropped before it. */
 export function getPiAgentStatusAsyncSubagentSourceLines(kind: PiAgentKind): string[] {
   if (kind !== 'pi') {
     return []
@@ -18,16 +26,7 @@ export function getPiAgentStatusAsyncSubagentSourceLines(kind: PiAgentKind): str
     '  if (!piAsyncSubagentBusBound) {',
     '  try {',
     '    const bus = process as unknown as { on?: (event: string, listener: (payload: unknown) => void) => void }',
-    '    const readRunId = (payload: unknown): string => {',
-    "      if (!payload || typeof payload !== 'object') return ''",
-    '      const record = payload as Record<string, unknown>',
-    "      for (const key of ['runId', 'run_id', 'subagentId', 'subagent_id', 'id']) {",
-    '        const value = record[key]',
-    "        if (typeof value === 'string' && value) return value",
-    '      }',
-    "      return ''",
-    '    }',
-    '    const readText = (payload: unknown, keys: string[]): string | undefined => {',
+    '    const readBusField = (payload: unknown, keys: string[]): string | undefined => {',
     "      if (!payload || typeof payload !== 'object') return undefined",
     '      const record = payload as Record<string, unknown>',
     '      for (const key of keys) {',
@@ -36,18 +35,32 @@ export function getPiAgentStatusAsyncSubagentSourceLines(kind: PiAgentKind): str
     '      }',
     '      return undefined',
     '    }',
-    '    const postAsyncSubagent = (hookEventName: string, payload: unknown): void => {',
+    '    const readRunId = (payload: unknown): string | undefined =>',
+    "      readBusField(payload, ['runId', 'run_id', 'subagentId', 'subagent_id', 'id'])",
+    '    const postAsyncSubagentState = (): void => {',
     '      if (isOmpRuntime()) return',
-    '      const runId = readRunId(payload)',
-    '      if (!runId) return',
-    '      post(hookEventName, {',
-    '        subagent_id: runId,',
-    "        agent_type: readText(payload, ['agentType', 'agent_type', 'subagentType']),",
-    "        description: readText(payload, ['description', 'task', 'prompt']),",
+    '      // Why: the receiver REPLACES its child list with this array, so a post that loses the',
+    '      // race with a newer one costs nothing — the newer one already carries the whole truth.',
+    "      post('subagent_async_state', {",
+    '        subagent_runs: Array.from(piAsyncSubagentRuns.values()),',
     '      })',
     '    }',
-    "    bus.on?.('subagent:async-started', (payload) => postAsyncSubagent('subagent_async_started', payload))",
-    "    bus.on?.('subagent:async-complete', (payload) => postAsyncSubagent('subagent_async_complete', payload))",
+    "    bus.on?.('subagent:async-started', (payload) => {",
+    '      const runId = readRunId(payload)',
+    '      // Why: an unnamed child could never be removed again, so it must not be added.',
+    '      if (!runId) return',
+    '      piAsyncSubagentRuns.set(runId, {',
+    '        id: runId,',
+    "        agent_type: readBusField(payload, ['agentType', 'agent_type', 'subagentType']),",
+    "        description: readBusField(payload, ['description', 'task', 'prompt']),",
+    '      })',
+    '      postAsyncSubagentState()',
+    '    })',
+    "    bus.on?.('subagent:async-complete', (payload) => {",
+    '      const runId = readRunId(payload)',
+    '      if (!runId || !piAsyncSubagentRuns.delete(runId)) return',
+    '      postAsyncSubagentState()',
+    '    })',
     '    piAsyncSubagentBusBound = true',
     '  } catch {',
     '    // Why: status reporting must never fail the pi run; an unavailable bus just means no children.',

--- a/src/main/pi/agent-status-async-subagent-source.ts
+++ b/src/main/pi/agent-status-async-subagent-source.ts
@@ -12,6 +12,10 @@ export function getPiAgentStatusAsyncSubagentSourceLines(kind: PiAgentKind): str
   return [
     '  // Why: a bus this pi build does not emit on simply never fires; registering costs nothing',
     '  // and keeps the parent-only path unchanged for installs without the subagent extension.',
+    '  // pi reloads extensions in-process and re-runs this factory: pi.on handlers are replaced,',
+    '  // but process-bus listeners accumulate, so bind at most once. Deliberately a BLOCK and not',
+    '  // an early return — returning here would skip every handler registered after this point.',
+    '  if (!piAsyncSubagentBusBound) {',
     '  try {',
     '    const bus = process as unknown as { on?: (event: string, listener: (payload: unknown) => void) => void }',
     '    const readRunId = (payload: unknown): string => {',
@@ -44,8 +48,10 @@ export function getPiAgentStatusAsyncSubagentSourceLines(kind: PiAgentKind): str
     '    }',
     "    bus.on?.('subagent:async-started', (payload) => postAsyncSubagent('subagent_async_started', payload))",
     "    bus.on?.('subagent:async-complete', (payload) => postAsyncSubagent('subagent_async_complete', payload))",
+    '    piAsyncSubagentBusBound = true',
     '  } catch {',
     '    // Why: status reporting must never fail the pi run; an unavailable bus just means no children.',
+    '  }',
     '  }',
     ''
   ]

--- a/src/main/pi/agent-status-async-subagent-source.ts
+++ b/src/main/pi/agent-status-async-subagent-source.ts
@@ -1,0 +1,52 @@
+import type { PiAgentKind } from '../../shared/pi-agent-kind'
+
+/** Async child runs delegated through pi's subagent extension outlive the parent turn: the parent
+ *  settles and goes interactive while the children keep working. Their lifecycle rides pi's process
+ *  event bus rather than the extension API, so it is forwarded here as its own hook event and folded
+ *  into the pane's descendant roster receiver-side — the parent's own `agent_end` stays the parent's. */
+export function getPiAgentStatusAsyncSubagentSourceLines(kind: PiAgentKind): string[] {
+  if (kind !== 'pi') {
+    return []
+  }
+
+  return [
+    '  // Why: a bus this pi build does not emit on simply never fires; registering costs nothing',
+    '  // and keeps the parent-only path unchanged for installs without the subagent extension.',
+    '  try {',
+    '    const bus = process as unknown as { on?: (event: string, listener: (payload: unknown) => void) => void }',
+    '    const readRunId = (payload: unknown): string => {',
+    "      if (!payload || typeof payload !== 'object') return ''",
+    '      const record = payload as Record<string, unknown>',
+    "      for (const key of ['runId', 'run_id', 'subagentId', 'subagent_id', 'id']) {",
+    '        const value = record[key]',
+    "        if (typeof value === 'string' && value) return value",
+    '      }',
+    "      return ''",
+    '    }',
+    '    const readText = (payload: unknown, keys: string[]): string | undefined => {',
+    "      if (!payload || typeof payload !== 'object') return undefined",
+    '      const record = payload as Record<string, unknown>',
+    '      for (const key of keys) {',
+    '        const value = record[key]',
+    "        if (typeof value === 'string' && value) return value",
+    '      }',
+    '      return undefined',
+    '    }',
+    '    const postAsyncSubagent = (hookEventName: string, payload: unknown): void => {',
+    '      if (isOmpRuntime()) return',
+    '      const runId = readRunId(payload)',
+    '      if (!runId) return',
+    '      post(hookEventName, {',
+    '        subagent_id: runId,',
+    "        agent_type: readText(payload, ['agentType', 'agent_type', 'subagentType']),",
+    "        description: readText(payload, ['description', 'task', 'prompt']),",
+    '      })',
+    '    }',
+    "    bus.on?.('subagent:async-started', (payload) => postAsyncSubagent('subagent_async_started', payload))",
+    "    bus.on?.('subagent:async-complete', (payload) => postAsyncSubagent('subagent_async_complete', payload))",
+    '  } catch {',
+    '    // Why: status reporting must never fail the pi run; an unavailable bus just means no children.',
+    '  }',
+    ''
+  ]
+}

--- a/src/main/pi/agent-status-async-subagent.test.ts
+++ b/src/main/pi/agent-status-async-subagent.test.ts
@@ -116,11 +116,12 @@ describe('pi async subagent runs reach the pane as descendants (STA-6378)', () =
     const harness = createHarness()
     await drive(harness, 'before_agent_start', { prompt: 'fan out wide' })
     await drive(harness, 'agent_start')
-    await emitWithoutFlush(harness, [
-      { name: 'subagent:async-started', payload: { runId: 'run-1' } },
-      { name: 'subagent:async-started', payload: { runId: 'run-2' } },
-      { name: 'subagent:async-started', payload: { runId: 'run-3' } }
-    ])
+    // Why: the starts are delivered one at a time on purpose. Coalescing them too would drop
+    // the start that pairs with a dropped completion, and the two losses would cancel out —
+    // the pane would settle for the wrong reason and the test would prove nothing.
+    await emit(harness, 'subagent:async-started', { runId: 'run-1' })
+    await emit(harness, 'subagent:async-started', { runId: 'run-2' })
+    await emit(harness, 'subagent:async-started', { runId: 'run-3' })
     await drive(harness, 'agent_end', {})
     expect(harness.states.at(-1)).toBe('working')
 
@@ -139,10 +140,8 @@ describe('pi async subagent runs reach the pane as descendants (STA-6378)', () =
     const harness = createHarness()
     await drive(harness, 'before_agent_start', { prompt: 'partial' })
     await drive(harness, 'agent_start')
-    await emitWithoutFlush(harness, [
-      { name: 'subagent:async-started', payload: { runId: 'run-1' } },
-      { name: 'subagent:async-started', payload: { runId: 'run-2' } }
-    ])
+    await emit(harness, 'subagent:async-started', { runId: 'run-1' })
+    await emit(harness, 'subagent:async-started', { runId: 'run-2' })
     await drive(harness, 'agent_end', {})
 
     await emitWithoutFlush(harness, [

--- a/src/main/pi/agent-status-async-subagent.test.ts
+++ b/src/main/pi/agent-status-async-subagent.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeHookPayload } from '../../shared/agent-hook-listener'
+import { PANE_KEY } from '../../shared/agent-hook-listener-test-harness'
+import { createHookListenerState } from '../../shared/agent-hook-listener/listener-state'
+import {
+  createAgentStatusExtensionHarness,
+  type HookContext
+} from './agent-status-extension-test-harness'
+
+const HOOK_ENV = { ORCA_PANE_KEY: PANE_KEY, ORCA_AGENT_HOOK_ENV: 'production' }
+
+/** Drives the REAL generated extension source into the REAL listener entry, so the pane state
+ *  asserted here is the one a pi pane would actually show. */
+function createHarness(kind: 'pi' | 'omp' | 'prime-agent' = 'pi') {
+  const state = createHookListenerState()
+  const states: (string | undefined)[] = []
+  const harness = createAgentStatusExtensionHarness({
+    kind,
+    env: HOOK_ENV,
+    fetchImpl: async (_url, init) => {
+      const event = normalizeHookPayload(
+        state,
+        kind === 'prime-agent' ? 'prime-agent' : kind,
+        JSON.parse(String(init?.body)),
+        'production'
+      )
+      if (event) {
+        state.lastStatusByPaneKey.set(PANE_KEY, event)
+      }
+      states.push(event?.payload.state)
+      return { ok: true }
+    }
+  })
+  return { ...harness, states }
+}
+
+async function flushPosts(): Promise<void> {
+  // Why: `agent_end` defers its post through a 0ms idle recheck, so microtask flushes alone
+  // would read the pane before the parent's own completion was ever delivered.
+  for (let i = 0; i < 8; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+async function drive(
+  harness: ReturnType<typeof createHarness>,
+  name: string,
+  event: unknown = {},
+  context: HookContext = { isIdle: () => true }
+): Promise<void> {
+  await harness.callHook(name, event, context)
+  await flushPosts()
+}
+
+async function emit(
+  harness: ReturnType<typeof createHarness>,
+  name: string,
+  payload: unknown
+): Promise<void> {
+  harness.emitProcessBus(name, payload)
+  await flushPosts()
+}
+
+describe('pi async subagent runs reach the pane as descendants (STA-6378)', () => {
+  it('holds the pane working while an async child run outlives the parent turn', async () => {
+    const harness = createHarness()
+    await drive(harness, 'before_agent_start', { prompt: 'delegate the sweep' })
+    await drive(harness, 'agent_start')
+    await emit(harness, 'subagent:async-started', { runId: 'run-1', agentType: 'researcher' })
+
+    await drive(harness, 'agent_end', {})
+    expect(harness.states.at(-1)).toBe('working')
+
+    await emit(harness, 'subagent:async-complete', { runId: 'run-1' })
+    expect(harness.states.at(-1)).toBe('done')
+  })
+
+  it('settles only after the last child, then only once for the turn it wakes', async () => {
+    const harness = createHarness()
+    await drive(harness, 'before_agent_start', { prompt: 'fan out' })
+    await drive(harness, 'agent_start')
+    await emit(harness, 'subagent:async-started', { runId: 'run-1' })
+    await emit(harness, 'subagent:async-started', { runId: 'run-2' })
+
+    await drive(harness, 'agent_end', {})
+    await emit(harness, 'subagent:async-complete', { runId: 'run-1' })
+    expect(harness.states.at(-1)).toBe('working')
+
+    await emit(harness, 'subagent:async-complete', { runId: 'run-2' })
+    expect(harness.states.at(-1)).toBe('done')
+
+    // The final child woke the parent for another turn; the pane must not stay settled.
+    await drive(harness, 'agent_start')
+    expect(harness.states.at(-1)).toBe('working')
+    await drive(harness, 'agent_end', {})
+    expect(harness.states.at(-1)).toBe('done')
+
+    expect(harness.states.filter((value) => value === 'done')).toHaveLength(2)
+  })
+
+  it('ignores a bus payload with no run id rather than inventing a child', async () => {
+    const harness = createHarness()
+    await drive(harness, 'before_agent_start', { prompt: 'go' })
+    await drive(harness, 'agent_start')
+    const before = harness.states.length
+
+    await emit(harness, 'subagent:async-started', { note: 'no id here' })
+    expect(harness.states).toHaveLength(before)
+
+    await drive(harness, 'agent_end', {})
+    expect(harness.states.at(-1)).toBe('done')
+  })
+
+  it('binds the process bus once across an in-process extension reload', () => {
+    const harness = createHarness()
+    expect(harness.processBusListenerCount('subagent:async-started')).toBe(1)
+    harness.reload()
+    // Why: pi replaces pi.on handlers on reload but not process-bus listeners; a second
+    // registration would post every async child event twice.
+    expect(harness.processBusListenerCount('subagent:async-started')).toBe(1)
+  })
+
+  it('does not register the pi subagent bus for omp or prime-agent', () => {
+    expect(createHarness('omp').processBusListenerCount('subagent:async-started')).toBe(0)
+    expect(createHarness('prime-agent').processBusListenerCount('subagent:async-started')).toBe(0)
+  })
+})

--- a/src/main/pi/agent-status-async-subagent.test.ts
+++ b/src/main/pi/agent-status-async-subagent.test.ts
@@ -61,6 +61,20 @@ async function emit(
   await flushPosts()
 }
 
+/** Emit several bus events with NO flush between them, so every one after the first lands
+ *  while a delivery is already in flight — the window where the transport's latest-only slot
+ *  discards the pending message. Awaiting between emits would flush that window every time
+ *  and the race would never be exercised. */
+async function emitWithoutFlush(
+  harness: ReturnType<typeof createHarness>,
+  events: readonly { name: string; payload: unknown }[]
+): Promise<void> {
+  for (const event of events) {
+    harness.emitProcessBus(event.name, event.payload)
+  }
+  await flushPosts()
+}
+
 describe('pi async subagent runs reach the pane as descendants (STA-6378)', () => {
   it('holds the pane working while an async child run outlives the parent turn', async () => {
     const harness = createHarness()
@@ -96,6 +110,64 @@ describe('pi async subagent runs reach the pane as descendants (STA-6378)', () =
     expect(harness.states.at(-1)).toBe('done')
 
     expect(harness.states.filter((value) => value === 'done')).toHaveLength(2)
+  })
+
+  it('settles when several children finish inside one in-flight delivery window', async () => {
+    const harness = createHarness()
+    await drive(harness, 'before_agent_start', { prompt: 'fan out wide' })
+    await drive(harness, 'agent_start')
+    await emitWithoutFlush(harness, [
+      { name: 'subagent:async-started', payload: { runId: 'run-1' } },
+      { name: 'subagent:async-started', payload: { runId: 'run-2' } },
+      { name: 'subagent:async-started', payload: { runId: 'run-3' } }
+    ])
+    await drive(harness, 'agent_end', {})
+    expect(harness.states.at(-1)).toBe('working')
+
+    // Why: the transport coalesces to a latest-only slot, so of these three only the last
+    // is ever delivered. It carries the whole live set, so the pane still settles; a
+    // start/complete delta would strand run-1 and run-2 and pin the pane working forever.
+    await emitWithoutFlush(harness, [
+      { name: 'subagent:async-complete', payload: { runId: 'run-1' } },
+      { name: 'subagent:async-complete', payload: { runId: 'run-2' } },
+      { name: 'subagent:async-complete', payload: { runId: 'run-3' } }
+    ])
+    expect(harness.states.at(-1)).toBe('done')
+  })
+
+  it('keeps the pane working when only some of a coalesced burst finish', async () => {
+    const harness = createHarness()
+    await drive(harness, 'before_agent_start', { prompt: 'partial' })
+    await drive(harness, 'agent_start')
+    await emitWithoutFlush(harness, [
+      { name: 'subagent:async-started', payload: { runId: 'run-1' } },
+      { name: 'subagent:async-started', payload: { runId: 'run-2' } }
+    ])
+    await drive(harness, 'agent_end', {})
+
+    await emitWithoutFlush(harness, [
+      { name: 'subagent:async-complete', payload: { runId: 'run-1' } }
+    ])
+    expect(harness.states.at(-1)).toBe('working')
+
+    await emit(harness, 'subagent:async-complete', { runId: 'run-2' })
+    expect(harness.states.at(-1)).toBe('done')
+  })
+
+  it('survives an in-process reload without forgetting live children', async () => {
+    const harness = createHarness()
+    await drive(harness, 'before_agent_start', { prompt: 'reload me' })
+    await drive(harness, 'agent_start')
+    await emit(harness, 'subagent:async-started', { runId: 'run-1' })
+
+    // Why: the posted set is authoritative, so a reload that rebuilt it empty would tell the
+    // receiver the child had finished. The set lives at module scope for exactly this reason.
+    harness.reload()
+    await drive(harness, 'agent_end', {})
+    expect(harness.states.at(-1)).toBe('working')
+
+    await emit(harness, 'subagent:async-complete', { runId: 'run-1' })
+    expect(harness.states.at(-1)).toBe('done')
   })
 
   it('ignores a bus payload with no run id rather than inventing a child', async () => {

--- a/src/main/pi/agent-status-extension-source.ts
+++ b/src/main/pi/agent-status-extension-source.ts
@@ -101,7 +101,16 @@ export function getPiAgentStatusExtensionSource(kind: PiAgentKind = 'pi'): strin
     '// Orca receiver from building an unbounded queue of obsolete snapshots.',
     'const HOOK_POST_TIMEOUT_MS = 1000',
     'let activePost = false',
-    ...(kind === 'pi' ? ['let piUiPromptDepth = 0', 'let piTurnInFlight = false'] : []),
+    ...(kind === 'pi'
+      ? [
+          'let piUiPromptDepth = 0',
+          'let piTurnInFlight = false',
+          // Why: pi reloads extensions in-process, which re-runs the factory. Process-bus
+          // listeners are not replaced on reload the way pi.on handlers are, so a second
+          // registration would post every async child event twice.
+          'let piAsyncSubagentBusBound = false'
+        ]
+      : []),
     'let pendingPost: { hookEventName: string; extra: Record<string, unknown>; metadata: Record<string, unknown>; ompRuntime: boolean } | null = null',
     ...sessionMetadataSourceLines,
     '',

--- a/src/main/pi/agent-status-extension-source.ts
+++ b/src/main/pi/agent-status-extension-source.ts
@@ -108,7 +108,11 @@ export function getPiAgentStatusExtensionSource(kind: PiAgentKind = 'pi'): strin
           // Why: pi reloads extensions in-process, which re-runs the factory. Process-bus
           // listeners are not replaced on reload the way pi.on handlers are, so a second
           // registration would post every async child event twice.
-          'let piAsyncSubagentBusBound = false'
+          'let piAsyncSubagentBusBound = false',
+          // Why: the live child set lives at module scope so it survives an in-process
+          // extension reload — the roster it feeds is authoritative, and rebuilding it
+          // empty would tell the receiver every running child had finished.
+          'const piAsyncSubagentRuns = new Map<string, { id: string; agent_type?: string; description?: string }>()'
         ]
       : []),
     'let pendingPost: { hookEventName: string; extra: Record<string, unknown>; metadata: Record<string, unknown>; ompRuntime: boolean } | null = null',

--- a/src/main/pi/agent-status-extension-test-harness.ts
+++ b/src/main/pi/agent-status-extension-test-harness.ts
@@ -35,6 +35,9 @@ export type AgentStatusExtensionHarness = {
   handlers: Record<string, HookHandler>
   processEnv: Record<string, string | undefined>
   callHook: (name: string, event?: unknown, context?: HookContext) => Promise<void>
+  /** Emit on the process event bus pi's subagent extension publishes async child runs on. */
+  emitProcessBus: (name: string, payload?: unknown) => void
+  processBusListenerCount: (name: string) => number
   // Re-invoke the extension factory in the same process (as Pi does on an
   // in-process extension reload), swapping in the freshly registered handlers.
   reload: () => void
@@ -115,7 +118,11 @@ export function createAgentStatusExtensionHarness(args: {
     throw new Error(`unexpected require(${specifier})`)
   })
 
+  const processBusListeners: Record<string, ((payload: unknown) => void)[]> = {}
   const processMock = {
+    on(name: string, listener: (payload: unknown) => void) {
+      ;(processBusListeners[name] ??= []).push(listener)
+    },
     env: {
       ...BASE_ENV,
       ...(args.kind === 'prime-agent' ? { PRIME_AGENT_INTERNAL_DAEMON_WORKER: '1' } : {}),
@@ -180,6 +187,12 @@ export function createAgentStatusExtensionHarness(args: {
     callHook: async (name, event, hookContext) => {
       await handlers[name]?.(event, hookContext)
     },
+    emitProcessBus: (name, payload) => {
+      for (const listener of processBusListeners[name] ?? []) {
+        listener(payload)
+      }
+    },
+    processBusListenerCount: (name) => (processBusListeners[name] ?? []).length,
     reload: () => {
       for (const key of Object.keys(handlers)) {
         delete handlers[key]

--- a/src/main/pi/agent-status-handler-source.ts
+++ b/src/main/pi/agent-status-handler-source.ts
@@ -1,4 +1,5 @@
 import type { PiAgentKind } from '../../shared/pi-agent-kind'
+import { getPiAgentStatusAsyncSubagentSourceLines } from './agent-status-async-subagent-source'
 import { getPiAgentStatusUiPromptHandlerSourceLines } from './agent-status-ui-prompt-source'
 
 // Why: keep the generated handler registrations separate from hook transport;
@@ -136,6 +137,7 @@ export function getPiAgentStatusHandlerSourceLines(kind: PiAgentKind): string[] 
     '  })',
     '',
     ...approvalHandlers,
+    ...getPiAgentStatusAsyncSubagentSourceLines(kind),
     ...getPiAgentStatusUiPromptHandlerSourceLines(kind),
     "  // Why: capture the assistant's final text on each completed message",
     '  // so the dashboard preview reflects the most recent reply even before',

--- a/src/shared/agent-descendant-roster.test.ts
+++ b/src/shared/agent-descendant-roster.test.ts
@@ -5,18 +5,18 @@ import {
   AGENT_TYPE_MAX_LENGTH
 } from './agent-status-types'
 import {
-  codexRosterToSnapshots,
-  finishCodexSubagent,
-  setCodexSubagentModel,
-  upsertCodexSubagent,
-  type CodexSubagentRoster
-} from './codex-subagent-roster'
+  agentDescendantRosterToSnapshots,
+  finishAgentDescendant,
+  setAgentDescendantModel,
+  upsertAgentDescendant,
+  type AgentDescendantRoster
+} from './agent-descendant-roster'
 
 describe('Codex subagent roster', () => {
   it('normalizes retained identity fields before storing them', () => {
-    const roster: CodexSubagentRoster = new Map()
+    const roster: AgentDescendantRoster = new Map()
 
-    upsertCodexSubagent(
+    upsertAgentDescendant(
       roster,
       ' child-1 ',
       {
@@ -28,49 +28,49 @@ describe('Codex subagent roster', () => {
       10
     )
 
-    const snapshot = codexRosterToSnapshots(roster)?.[0]
+    const snapshot = agentDescendantRosterToSnapshots(roster)?.[0]
     expect([...roster.keys()]).toEqual(['child-1'])
     expect(snapshot?.agentType).toHaveLength(AGENT_TYPE_MAX_LENGTH)
     expect(snapshot?.agentType).not.toContain('\n')
     expect(snapshot?.description).toBe('Review the sidebar lifecycle')
     expect(snapshot?.model).toHaveLength(AGENT_MODEL_MAX_LENGTH)
 
-    finishCodexSubagent(roster, ' child-1 ')
+    finishAgentDescendant(roster, ' child-1 ')
     expect(roster.size).toBe(0)
   })
 
   it('rejects an id that would normalize to an invisible child', () => {
-    const roster: CodexSubagentRoster = new Map()
+    const roster: AgentDescendantRoster = new Map()
 
-    upsertCodexSubagent(roster, '   ', { state: 'waiting' }, 10)
+    upsertAgentDescendant(roster, '   ', { state: 'waiting' }, 10)
 
     expect(roster.size).toBe(0)
   })
 
   it('bounds live storage while admitting a replacement after one child stops', () => {
-    const roster: CodexSubagentRoster = new Map()
+    const roster: AgentDescendantRoster = new Map()
     for (let index = 0; index <= AGENT_STATUS_MAX_SUBAGENTS; index += 1) {
-      upsertCodexSubagent(roster, `child-${index}`, { state: 'working' }, index)
+      upsertAgentDescendant(roster, `child-${index}`, { state: 'working' }, index)
     }
 
     expect(roster.size).toBe(AGENT_STATUS_MAX_SUBAGENTS)
     expect(roster.has(`child-${AGENT_STATUS_MAX_SUBAGENTS}`)).toBe(false)
 
-    finishCodexSubagent(roster, 'child-0')
-    upsertCodexSubagent(roster, 'replacement', { state: 'working' }, 100)
+    finishAgentDescendant(roster, 'child-0')
+    upsertAgentDescendant(roster, 'replacement', { state: 'working' }, 100)
 
     expect(roster.size).toBe(AGENT_STATUS_MAX_SUBAGENTS)
     expect(roster.has('replacement')).toBe(true)
   })
 
-  describe('setCodexSubagentModel', () => {
+  describe('setAgentDescendantModel', () => {
     it('records the model without disturbing the child lifecycle or label', () => {
-      const roster: CodexSubagentRoster = new Map()
-      upsertCodexSubagent(roster, 'child-1', { description: '/root/audit', state: 'waiting' }, 10)
+      const roster: AgentDescendantRoster = new Map()
+      upsertAgentDescendant(roster, 'child-1', { description: '/root/audit', state: 'waiting' }, 10)
 
-      setCodexSubagentModel(roster, 'child-1', ' gpt-5.6-terra ')
+      setAgentDescendantModel(roster, 'child-1', ' gpt-5.6-terra ')
 
-      expect(codexRosterToSnapshots(roster)).toEqual([
+      expect(agentDescendantRosterToSnapshots(roster)).toEqual([
         {
           id: 'child-1',
           agentType: undefined,
@@ -83,31 +83,31 @@ describe('Codex subagent roster', () => {
     })
 
     it('never creates a row for a child that is no longer tracked', () => {
-      const roster: CodexSubagentRoster = new Map()
-      upsertCodexSubagent(roster, 'child-1', { state: 'working' }, 10)
-      finishCodexSubagent(roster, 'child-1')
+      const roster: AgentDescendantRoster = new Map()
+      upsertAgentDescendant(roster, 'child-1', { state: 'working' }, 10)
+      finishAgentDescendant(roster, 'child-1')
 
       // A model read racing a completed child must not resurrect its row.
-      setCodexSubagentModel(roster, 'child-1', 'gpt-5.6-terra')
+      setAgentDescendantModel(roster, 'child-1', 'gpt-5.6-terra')
 
       expect(roster.size).toBe(0)
     })
 
     it('keeps a known model when the new value is empty', () => {
-      const roster: CodexSubagentRoster = new Map()
-      upsertCodexSubagent(roster, 'child-1', { model: 'gpt-5.6-sol', state: 'working' }, 10)
+      const roster: AgentDescendantRoster = new Map()
+      upsertAgentDescendant(roster, 'child-1', { model: 'gpt-5.6-sol', state: 'working' }, 10)
 
-      setCodexSubagentModel(roster, 'child-1', '   ')
-      setCodexSubagentModel(roster, 'child-1', undefined)
+      setAgentDescendantModel(roster, 'child-1', '   ')
+      setAgentDescendantModel(roster, 'child-1', undefined)
 
       expect(roster.get('child-1')?.model).toBe('gpt-5.6-sol')
     })
 
     it('bounds an oversized model to the shared cap', () => {
-      const roster: CodexSubagentRoster = new Map()
-      upsertCodexSubagent(roster, 'child-1', { state: 'working' }, 10)
+      const roster: AgentDescendantRoster = new Map()
+      upsertAgentDescendant(roster, 'child-1', { state: 'working' }, 10)
 
-      setCodexSubagentModel(roster, 'child-1', 'x'.repeat(AGENT_MODEL_MAX_LENGTH + 50))
+      setAgentDescendantModel(roster, 'child-1', 'x'.repeat(AGENT_MODEL_MAX_LENGTH + 50))
 
       expect(roster.get('child-1')?.model).toHaveLength(AGENT_MODEL_MAX_LENGTH)
     })

--- a/src/shared/agent-descendant-roster.ts
+++ b/src/shared/agent-descendant-roster.ts
@@ -3,15 +3,28 @@ import {
   AGENT_STATUS_MAX_SUBAGENTS,
   AGENT_STATUS_TOOL_INPUT_MAX_LENGTH,
   AGENT_TYPE_MAX_LENGTH,
+  type AgentStatusState,
   type AgentSubagentSnapshot
 } from './agent-status-types'
 import { normalizeOptionalField } from './agent-status-field-normalization'
 
-const CODEX_SUBAGENT_ID_MAX_LENGTH = 64
+/** Live descendants (subagents, spawned threads, async child runs) of one pane's
+ *  lead agent session, keyed by the provider-assigned child id.
+ *
+ *  Provider-agnostic on purpose: the pane rule "idle only when the lead is idle
+ *  AND no descendant is live" is one concept, so it has one implementation. A
+ *  provider contributes only how to READ a child out of its hook events
+ *  (`agent-hook-listener/descendant-events.ts`). Claude keeps its own roster
+ *  because its children carry provider-specific reconciliation (teammate
+ *  parking, `background_tasks` folding, restored-snapshot provenance) that no
+ *  other provider has; it implements the same pane rule in
+ *  `providers/claude-roster-state.ts`. */
 
-export type CodexSubagentRoster = Map<string, TrackedCodexSubagent>
+const AGENT_DESCENDANT_ID_MAX_LENGTH = 64
 
-type TrackedCodexSubagent = {
+export type AgentDescendantRoster = Map<string, TrackedAgentDescendant>
+
+type TrackedAgentDescendant = {
   agentType?: string
   description?: string
   model?: string
@@ -19,8 +32,8 @@ type TrackedCodexSubagent = {
   startedAt: number
 }
 
-export function upsertCodexSubagent(
-  roster: CodexSubagentRoster,
+export function upsertAgentDescendant(
+  roster: AgentDescendantRoster,
   id: string,
   fields: {
     agentType?: string
@@ -31,7 +44,7 @@ export function upsertCodexSubagent(
   now: number
 ): void {
   const normalizedId = id.trim()
-  if (normalizedId.length === 0 || normalizedId.length > CODEX_SUBAGENT_ID_MAX_LENGTH) {
+  if (normalizedId.length === 0 || normalizedId.length > AGENT_DESCENDANT_ID_MAX_LENGTH) {
     return
   }
   const agentType = normalizeOptionalField(fields.agentType, AGENT_TYPE_MAX_LENGTH)
@@ -57,18 +70,18 @@ export function upsertCodexSubagent(
   })
 }
 
-export function finishCodexSubagent(roster: CodexSubagentRoster, id: string): void {
+export function finishAgentDescendant(roster: AgentDescendantRoster, id: string): void {
   roster.delete(id.trim())
 }
 
 /**
  * Record the model a already-tracked child is running. Deliberately narrower
- * than `upsertCodexSubagent`: it never creates a roster entry and never touches
+ * than `upsertAgentDescendant`: it never creates a roster entry and never touches
  * `state`, so late model discovery from a child rollout cannot resurrect a
  * finished child nor move any child's lifecycle.
  */
-export function setCodexSubagentModel(
-  roster: CodexSubagentRoster,
+export function setAgentDescendantModel(
+  roster: AgentDescendantRoster,
   id: string,
   model: string | undefined
 ): void {
@@ -83,15 +96,15 @@ export function setCodexSubagentModel(
   existing.model = normalizedModel
 }
 
-export function seedCodexSubagentRoster(
-  roster: CodexSubagentRoster,
+export function seedAgentDescendantRoster(
+  roster: AgentDescendantRoster,
   snapshots: readonly AgentSubagentSnapshot[]
 ): void {
   for (const snapshot of snapshots) {
     if (snapshot.state !== 'working' && snapshot.state !== 'waiting') {
       continue
     }
-    upsertCodexSubagent(
+    upsertAgentDescendant(
       roster,
       snapshot.id,
       {
@@ -105,8 +118,8 @@ export function seedCodexSubagentRoster(
   }
 }
 
-export function codexRosterToSnapshots(
-  roster: CodexSubagentRoster | undefined
+export function agentDescendantRosterToSnapshots(
+  roster: AgentDescendantRoster | undefined
 ): AgentSubagentSnapshot[] | undefined {
   if (!roster || roster.size === 0) {
     return undefined
@@ -123,10 +136,14 @@ export function codexRosterToSnapshots(
   return snapshots
 }
 
-export function codexRosterEffectiveState(
-  roster: CodexSubagentRoster | undefined,
-  leadState: 'working' | 'waiting' | 'done'
-): 'working' | 'waiting' | 'done' {
+/** The pane's state once its live descendants are taken into account: a lead
+ *  `done` is only the pane's `done` when nothing is still running under it. A
+ *  descendant blocked on a human answer outranks the lead's own working state,
+ *  since that wait is the actionable one. */
+export function agentDescendantEffectiveState(
+  roster: AgentDescendantRoster | undefined,
+  leadState: AgentStatusState
+): AgentStatusState {
   if (!roster || roster.size === 0) {
     return leadState
   }

--- a/src/shared/agent-descendant-roster.ts
+++ b/src/shared/agent-descendant-roster.ts
@@ -30,7 +30,21 @@ type TrackedAgentDescendant = {
   model?: string
   state: 'working' | 'waiting'
   startedAt: number
+  /** When this child was last named by one of its provider's events. The reaper's clock:
+   *  a roster entry can only ever hold a pane 'working', so a claim nothing can retract
+   *  is strictly worse than settling late. */
+  lastEventAt: number
 }
+
+/** How long a descendant may go unmentioned before the pane stops believing in it.
+ *
+ *  Every provider loses a child's finish sometimes — the hook was disabled, untrusted or
+ *  timed out, the process was killed, the turn was interrupted before its stop gate ran.
+ *  Without a ceiling that pane is pinned 'working' for the life of the process, and only
+ *  closing it recovers. Deliberately generous: a wrongly reaped child merely settles the
+ *  pane early, which the lead's next event corrects, while too short a window would
+ *  reintroduce the very bug this roster exists to fix. */
+export const AGENT_DESCENDANT_QUIET_REAP_MS = 30 * 60_000
 
 export function upsertAgentDescendant(
   roster: AgentDescendantRoster,
@@ -56,6 +70,7 @@ export function upsertAgentDescendant(
     existing.description = description ?? existing.description
     existing.model = model ?? existing.model
     existing.state = fields.state
+    existing.lastEventAt = now
     return
   }
   if (roster.size >= AGENT_STATUS_MAX_SUBAGENTS) {
@@ -66,8 +81,51 @@ export function upsertAgentDescendant(
     description,
     model,
     state: fields.state,
-    startedAt: now
+    startedAt: now,
+    lastEventAt: now
   })
+}
+
+/** Replace the roster with the provider's authoritative live set. For a provider whose
+ *  transport can drop an intermediate message this is the only safe shape: the newest
+ *  message is complete, so it repairs every add and removal lost before it. */
+export function replaceAgentDescendants(
+  roster: AgentDescendantRoster,
+  children: readonly {
+    id: string
+    agentType?: string
+    description?: string
+    model?: string
+  }[],
+  now: number
+): void {
+  const live = new Set<string>()
+  for (const child of children) {
+    const normalizedId = child.id.trim()
+    if (normalizedId.length === 0 || normalizedId.length > AGENT_DESCENDANT_ID_MAX_LENGTH) {
+      continue
+    }
+    live.add(normalizedId)
+    upsertAgentDescendant(roster, normalizedId, { ...child, state: 'working' }, now)
+  }
+  for (const id of Array.from(roster.keys())) {
+    if (!live.has(id)) {
+      roster.delete(id)
+    }
+  }
+}
+
+/** Drop descendants no event has named for {@link AGENT_DESCENDANT_QUIET_REAP_MS}.
+ *  Runs on read rather than on a timer so the roster stays passive. */
+export function pruneStaleAgentDescendants(roster: AgentDescendantRoster, now: number): boolean {
+  let changed = false
+  for (const [id, tracked] of Array.from(roster.entries())) {
+    if (now - tracked.lastEventAt > AGENT_DESCENDANT_QUIET_REAP_MS) {
+      roster.delete(id)
+      changed = true
+    }
+  }
+  return changed
 }
 
 export function finishAgentDescendant(roster: AgentDescendantRoster, id: string): void {
@@ -115,6 +173,12 @@ export function seedAgentDescendantRoster(
       },
       snapshot.startedAt
     )
+    // Why: a restored child's quiet clock starts at its own start time, so a seed whose
+    // finish was lost while Orca was down cannot outlive the reap window a live one gets.
+    const restored = roster.get(snapshot.id.trim())
+    if (restored) {
+      restored.lastEventAt = snapshot.startedAt
+    }
   }
 }
 

--- a/src/shared/agent-hook-listener-descendant-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-descendant-lifecycle.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  clearPaneCacheState,
   createHookListenerState,
+  movePaneCacheState,
+  paneHasStateClaims,
   type HookListenerState
 } from './agent-hook-listener/listener-state'
 import { normalizeAndAccept, PANE_KEY } from './agent-hook-listener-test-harness'
 import type { AgentHookSource } from './agent-hook-relay'
+import { AGENT_DESCENDANT_QUIET_REAP_MS } from './agent-descendant-roster'
 
 /** Every case drives `normalizeHookPayload`, the entry both the main process and the relay
  *  call, so a fix that never reaches production wiring cannot pass here. */
@@ -124,6 +128,64 @@ describe('descendant lifecycle never settles the pane', () => {
       expect(childTool?.hasExplicitPrompt).toBeUndefined()
     })
 
+    it('clears children when the lead turn is interrupted before its stop gate runs', () => {
+      startTurn()
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
+      expect(publishedState('grok', { hookEventName: 'Stop', reason: 'end_turn' })).toBe('working')
+
+      // Why: an interrupted turn skips the stop gate, so the child never reports a finish and
+      // this cancel is the only proof it is gone. Without it the pane never settles again.
+      publish('grok', {
+        hookEventName: 'StopCancelled',
+        reason: 'user_interrupt',
+        cancelledBy: 'user'
+      })
+      expect(state.descendantRosterByPaneKey.has(PANE_KEY)).toBe(false)
+      expect(
+        publishedState('grok', {
+          hookEventName: 'Notification',
+          notificationType: 'idle_prompt',
+          message: 'Type your message'
+        })
+      ).toBe('done')
+    })
+
+    it('keeps siblings alive when one child cancels itself', () => {
+      startTurn()
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-2', subagentType: 'x' })
+      publish('grok', {
+        hookEventName: 'StopCancelled',
+        reason: 'max_turns',
+        cancelledBy: 'runtime',
+        subagentType: 'x',
+        subagentId: 'sub-1'
+      })
+      expect(state.descendantRosterByPaneKey.get(PANE_KEY)?.size).toBe(1)
+      expect(publishedState('grok', { hookEventName: 'Stop', reason: 'end_turn' })).toBe('working')
+    })
+
+    it('reaps a child whose finish never arrived instead of pinning the pane forever', () => {
+      startTurn()
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
+      expect(publishedState('grok', { hookEventName: 'Stop', reason: 'end_turn' })).toBe('working')
+
+      const tracked = state.descendantRosterByPaneKey.get(PANE_KEY)?.get('sub-1')
+      expect(tracked).toBeDefined()
+      // Why: every provider loses a stop hook sometimes (disabled, untrusted, timed out, killed).
+      // A claim nothing can retract must not outlive the quiet window.
+      tracked!.lastEventAt = Date.now() - AGENT_DESCENDANT_QUIET_REAP_MS - 1
+
+      expect(
+        publishedState('grok', {
+          hookEventName: 'Notification',
+          notificationType: 'idle_prompt',
+          message: 'Type your message'
+        })
+      ).toBe('done')
+      expect(state.descendantRosterByPaneKey.has(PANE_KEY)).toBe(false)
+    })
+
     it('drops a stale child roster when the pane starts a new agent process', () => {
       startTurn()
       publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
@@ -155,9 +217,8 @@ describe('descendant lifecycle never settles the pane', () => {
     it('stays working when the parent settles while an async child run continues', () => {
       startTurn()
       const started = publish('pi', {
-        hook_event_name: 'subagent_async_started',
-        subagent_id: 'run-1',
-        agent_type: 'researcher'
+        hook_event_name: 'subagent_async_state',
+        subagent_runs: [{ id: 'run-1', agent_type: 'researcher' }]
       })
       expect(started?.payload.state).toBe('working')
       expect(started?.payload.subagents).toEqual([
@@ -167,8 +228,8 @@ describe('descendant lifecycle never settles the pane', () => {
       expect(publishedState('pi', { hook_event_name: 'agent_end' })).toBe('working')
 
       const finished = publish('pi', {
-        hook_event_name: 'subagent_async_complete',
-        subagent_id: 'run-1'
+        hook_event_name: 'subagent_async_state',
+        subagent_runs: []
       })
       expect(finished?.payload.state).toBe('done')
       expect(finished?.payload.subagents).toBeUndefined()
@@ -176,25 +237,46 @@ describe('descendant lifecycle never settles the pane', () => {
 
     it('completes once when the final child wakes the parent for another turn', () => {
       startTurn()
-      publish('pi', { hook_event_name: 'subagent_async_started', subagent_id: 'run-1' })
-      publish('pi', { hook_event_name: 'subagent_async_started', subagent_id: 'run-2' })
+      publish('pi', {
+        hook_event_name: 'subagent_async_state',
+        subagent_runs: [{ id: 'run-1' }, { id: 'run-2' }]
+      })
 
       const states = [
         publishedState('pi', { hook_event_name: 'agent_end' }),
-        publishedState('pi', { hook_event_name: 'subagent_async_complete', subagent_id: 'run-1' }),
+        publishedState('pi', {
+          hook_event_name: 'subagent_async_state',
+          subagent_runs: [{ id: 'run-2' }]
+        }),
         // The last child wakes the parent, which runs another turn before the pane is idle.
-        publishedState('pi', { hook_event_name: 'subagent_async_complete', subagent_id: 'run-2' }),
+        publishedState('pi', { hook_event_name: 'subagent_async_state', subagent_runs: [] }),
         publishedState('pi', { hook_event_name: 'agent_start' }),
         publishedState('pi', { hook_event_name: 'agent_end' })
       ]
       expect(states).toEqual(['working', 'working', 'done', 'working', 'done'])
     })
 
+    it('repairs a dropped intermediate set from the next one', () => {
+      startTurn()
+      publish('pi', {
+        hook_event_name: 'subagent_async_state',
+        subagent_runs: [{ id: 'run-1' }, { id: 'run-2' }, { id: 'run-3' }]
+      })
+      expect(publishedState('pi', { hook_event_name: 'agent_end' })).toBe('working')
+
+      // Why: the extension transport coalesces, so the sets naming run-2 and run-3 as still
+      // live can be dropped entirely. The surviving newest message alone must settle the pane.
+      expect(
+        publishedState('pi', { hook_event_name: 'subagent_async_state', subagent_runs: [] })
+      ).toBe('done')
+      expect(state.descendantRosterByPaneKey.has(PANE_KEY)).toBe(false)
+    })
+
     it('keeps the parent prompt while an async child reports', () => {
       startTurn()
       const started = publish('pi', {
-        hook_event_name: 'subagent_async_started',
-        subagent_id: 'run-1',
+        hook_event_name: 'subagent_async_state',
+        subagent_runs: [{ id: 'run-1' }],
         prompt: 'child task text'
       })
       expect(started?.payload.prompt).toBe('delegate')
@@ -203,9 +285,7 @@ describe('descendant lifecycle never settles the pane', () => {
   })
 
   describe('pane-scoped state bookkeeping', () => {
-    it('reports a descendant-only pane as holding a state claim', async () => {
-      const { paneHasStateClaims, clearPaneCacheState } =
-        await import('./agent-hook-listener/listener-state')
+    it('reports a descendant-only pane as holding a state claim', () => {
       publish('grok', { hookEventName: 'UserPromptSubmit', prompt: 'go' })
       publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
       expect(paneHasStateClaims(state, PANE_KEY)).toBe(true)
@@ -215,8 +295,20 @@ describe('descendant lifecycle never settles the pane', () => {
       expect(state.descendantLeadStateByPaneKey.has(PANE_KEY)).toBe(false)
     })
 
-    it('moves descendant state with the pane when its key is remapped', async () => {
-      const { movePaneCacheState } = await import('./agent-hook-listener/listener-state')
+    it('does not claim a state for a pane that only cached a lead verdict', () => {
+      publish('grok', { hookEventName: 'UserPromptSubmit', prompt: 'go' })
+      publish('grok', { hookEventName: 'Stop', reason: 'end_turn' })
+      expect(state.descendantLeadStateByPaneKey.has(PANE_KEY)).toBe(true)
+      expect(state.descendantRosterByPaneKey.has(PANE_KEY)).toBe(false)
+
+      // Why: the lead cache only refines a republish an incoming child event already
+      // triggered; it never creates a row. With the pane's stored row gone it is the
+      // only descendant state left, and it must not read as a live claim on its own.
+      state.lastStatusByPaneKey.delete(PANE_KEY)
+      expect(paneHasStateClaims(state, PANE_KEY)).toBe(false)
+    })
+
+    it('moves descendant state with the pane when its key is remapped', () => {
       publish('grok', { hookEventName: 'UserPromptSubmit', prompt: 'go' })
       publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
 

--- a/src/shared/agent-hook-listener-descendant-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-descendant-lifecycle.test.ts
@@ -135,19 +135,52 @@ describe('descendant lifecycle never settles the pane', () => {
 
       // Why: an interrupted turn skips the stop gate, so the child never reports a finish and
       // this cancel is the only proof it is gone. Without it the pane never settles again.
-      publish('grok', {
+      const cancelled = publish('grok', {
         hookEventName: 'StopCancelled',
         reason: 'user_interrupt',
         cancelledBy: 'user'
       })
+      // Why: assert what the PANE shows, not what the roster holds. Clearing the roster while
+      // publishing nothing leaves the renderer on the pre-cancel row — spinner still running,
+      // child still listed — which is exactly the shape a roster-only assertion cannot see.
+      expect(cancelled).not.toBeNull()
+      expect(cancelled?.payload.state).toBe('done')
+      expect(cancelled?.payload.subagents).toBeUndefined()
+      // Why: a cancelled turn did not finish; the flag is what makes the row read 'Interrupted'
+      // and any notification say 'stopped' rather than 'finished'.
+      expect(cancelled?.payload.interrupted).toBe(true)
       expect(state.descendantRosterByPaneKey.has(PANE_KEY)).toBe(false)
-      expect(
-        publishedState('grok', {
-          hookEventName: 'Notification',
-          notificationType: 'idle_prompt',
-          message: 'Type your message'
-        })
-      ).toBe('done')
+    })
+
+    it('settles a runtime-cancelled turn without waiting for an idle ping', () => {
+      startTurn()
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
+      const cancelled = publish('grok', {
+        hookEventName: 'StopCancelled',
+        reason: 'max_turns',
+        cancelledBy: 'runtime'
+      })
+      expect(cancelled?.payload.state).toBe('done')
+      expect(cancelled?.payload.interrupted).toBe(true)
+      expect(cancelled?.payload.subagents).toBeUndefined()
+    })
+
+    it('surfaces a child blocked on a human answer', () => {
+      startTurn()
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
+      // Why: grok auto-allows ask_user_question, so the child announces its wait as a PreToolUse.
+      // Routing child events away from the lead normalizer must not swallow it.
+      const asked = publish('grok', {
+        hookEventName: 'PreToolUse',
+        subagentType: 'x',
+        subagentId: 'sub-1',
+        toolName: 'ask_user_question',
+        toolInput: { question: 'which one?' }
+      })
+      expect(asked?.payload.state).toBe('waiting')
+
+      // The pane keeps waiting while the lead's own turn ends underneath it.
+      expect(publishedState('grok', { hookEventName: 'Stop', reason: 'end_turn' })).toBe('waiting')
     })
 
     it('keeps siblings alive when one child cancels itself', () => {

--- a/src/shared/agent-hook-listener-descendant-lifecycle.test.ts
+++ b/src/shared/agent-hook-listener-descendant-lifecycle.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  createHookListenerState,
+  type HookListenerState
+} from './agent-hook-listener/listener-state'
+import { normalizeAndAccept, PANE_KEY } from './agent-hook-listener-test-harness'
+import type { AgentHookSource } from './agent-hook-relay'
+
+/** Every case drives `normalizeHookPayload`, the entry both the main process and the relay
+ *  call, so a fix that never reaches production wiring cannot pass here. */
+describe('descendant lifecycle never settles the pane', () => {
+  let state: HookListenerState
+
+  beforeEach(() => {
+    state = createHookListenerState()
+  })
+
+  const publish = (
+    source: AgentHookSource,
+    payload: Record<string, unknown>
+  ): ReturnType<typeof normalizeAndAccept> => normalizeAndAccept(state, source, payload)
+
+  const publishedState = (
+    source: AgentHookSource,
+    payload: Record<string, unknown>
+  ): string | undefined => publish(source, payload)?.payload.state
+
+  describe('grok nested subagents (STA-6982)', () => {
+    const startTurn = (): void => {
+      expect(publishedState('grok', { hookEventName: 'UserPromptSubmit', prompt: 'ship it' })).toBe(
+        'working'
+      )
+    }
+
+    it('keeps the pane working when a nested child session ends', () => {
+      startTurn()
+      // Why: grok remaps a child's turn gate to SubagentStop, so the child's own SessionEnd is what
+      // reaches the parent's pane. It carries subagentType; the session's own SessionEnd never does.
+      expect(
+        publishedState('grok', {
+          hookEventName: 'SessionEnd',
+          reason: 'clear',
+          subagentType: 'explore'
+        })
+      ).toBe('working')
+    })
+
+    it('keeps the pane working when a nested child turn fails', () => {
+      startTurn()
+      expect(
+        publishedState('grok', {
+          hookEventName: 'StopFailure',
+          error: 'rate_limit',
+          subagentType: 'explore'
+        })
+      ).toBe('working')
+    })
+
+    it('still settles the pane on the lead session own stop', () => {
+      startTurn()
+      expect(publishedState('grok', { hookEventName: 'Stop', reason: 'end_turn' })).toBe('done')
+    })
+
+    it('holds the pane working while a tracked child outlives the lead turn', () => {
+      startTurn()
+      const spawned = publish('grok', {
+        hookEventName: 'SubagentStart',
+        subagentId: 'sub-1',
+        subagentType: 'explore',
+        description: 'review the diff'
+      })
+      expect(spawned?.payload.state).toBe('working')
+      expect(spawned?.payload.subagents).toEqual([
+        expect.objectContaining({ id: 'sub-1', state: 'working', agentType: 'explore' })
+      ])
+
+      // The lead's own Stop is real, but a live child means the pane is not idle yet.
+      expect(publishedState('grok', { hookEventName: 'Stop', reason: 'end_turn' })).toBe('working')
+
+      const drained = publish('grok', {
+        hookEventName: 'SubagentStop',
+        subagentId: 'sub-1',
+        subagentType: 'explore'
+      })
+      expect(drained?.payload.state).toBe('done')
+      expect(drained?.payload.subagents).toBeUndefined()
+    })
+
+    it('publishes exactly one done across a child-then-lead completion', () => {
+      startTurn()
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
+      const states = [
+        publishedState('grok', { hookEventName: 'SessionEnd', reason: 'clear', subagentType: 'x' }),
+        publishedState('grok', { hookEventName: 'Stop', reason: 'end_turn' }),
+        publishedState('grok', {
+          hookEventName: 'SubagentStop',
+          subagentId: 'sub-1',
+          subagentType: 'x'
+        })
+      ]
+      expect(states).toEqual(['working', 'working', 'done'])
+      expect(states.filter((value) => value === 'done')).toHaveLength(1)
+    })
+
+    it('does not relabel the pane with a child tool call', () => {
+      startTurn()
+      const parentTool = publish('grok', {
+        hookEventName: 'PreToolUse',
+        toolName: 'edit_file',
+        toolInput: { path: 'src/app.ts' }
+      })
+      expect(parentTool?.payload.toolName).toBe('edit_file')
+
+      const childTool = publish('grok', {
+        hookEventName: 'PreToolUse',
+        subagentType: 'explore',
+        subagentId: 'sub-1',
+        toolName: 'run_terminal_cmd',
+        toolInput: { command: 'rg TODO' }
+      })
+      expect(childTool?.payload.state).toBe('working')
+      expect(childTool?.payload.toolName).toBe('edit_file')
+      expect(childTool?.payload.prompt).toBe('ship it')
+      expect(childTool?.hasExplicitPrompt).toBeUndefined()
+    })
+
+    it('drops a stale child roster when the pane starts a new agent process', () => {
+      startTurn()
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
+      expect(publishedState('grok', { hookEventName: 'Stop', reason: 'end_turn' })).toBe('working')
+
+      // Why: a child whose stop hook was lost must not pin the pane forever; a replaced agent
+      // process cannot still have the old process's children.
+      publish('grok', { hookEventName: 'SessionStart', source: 'startup' })
+      expect(publishedState('grok', { hookEventName: 'UserPromptSubmit', prompt: 'again' })).toBe(
+        'working'
+      )
+      expect(publishedState('grok', { hookEventName: 'Stop', reason: 'end_turn' })).toBe('done')
+    })
+  })
+
+  describe('pi async subagent runs (STA-6378)', () => {
+    const startTurn = (): void => {
+      expect(
+        publishedState('pi', { hook_event_name: 'before_agent_start', prompt: 'delegate' })
+      ).toBe('working')
+      expect(publishedState('pi', { hook_event_name: 'agent_start' })).toBe('working')
+    }
+
+    it('settles the pane when the parent ends with no async children', () => {
+      startTurn()
+      expect(publishedState('pi', { hook_event_name: 'agent_end' })).toBe('done')
+    })
+
+    it('stays working when the parent settles while an async child run continues', () => {
+      startTurn()
+      const started = publish('pi', {
+        hook_event_name: 'subagent_async_started',
+        subagent_id: 'run-1',
+        agent_type: 'researcher'
+      })
+      expect(started?.payload.state).toBe('working')
+      expect(started?.payload.subagents).toEqual([
+        expect.objectContaining({ id: 'run-1', state: 'working', agentType: 'researcher' })
+      ])
+
+      expect(publishedState('pi', { hook_event_name: 'agent_end' })).toBe('working')
+
+      const finished = publish('pi', {
+        hook_event_name: 'subagent_async_complete',
+        subagent_id: 'run-1'
+      })
+      expect(finished?.payload.state).toBe('done')
+      expect(finished?.payload.subagents).toBeUndefined()
+    })
+
+    it('completes once when the final child wakes the parent for another turn', () => {
+      startTurn()
+      publish('pi', { hook_event_name: 'subagent_async_started', subagent_id: 'run-1' })
+      publish('pi', { hook_event_name: 'subagent_async_started', subagent_id: 'run-2' })
+
+      const states = [
+        publishedState('pi', { hook_event_name: 'agent_end' }),
+        publishedState('pi', { hook_event_name: 'subagent_async_complete', subagent_id: 'run-1' }),
+        // The last child wakes the parent, which runs another turn before the pane is idle.
+        publishedState('pi', { hook_event_name: 'subagent_async_complete', subagent_id: 'run-2' }),
+        publishedState('pi', { hook_event_name: 'agent_start' }),
+        publishedState('pi', { hook_event_name: 'agent_end' })
+      ]
+      expect(states).toEqual(['working', 'working', 'done', 'working', 'done'])
+    })
+
+    it('keeps the parent prompt while an async child reports', () => {
+      startTurn()
+      const started = publish('pi', {
+        hook_event_name: 'subagent_async_started',
+        subagent_id: 'run-1',
+        prompt: 'child task text'
+      })
+      expect(started?.payload.prompt).toBe('delegate')
+      expect(started?.hasExplicitPrompt).toBeUndefined()
+    })
+  })
+
+  describe('pane-scoped state bookkeeping', () => {
+    it('reports a descendant-only pane as holding a state claim', async () => {
+      const { paneHasStateClaims, clearPaneCacheState } =
+        await import('./agent-hook-listener/listener-state')
+      publish('grok', { hookEventName: 'UserPromptSubmit', prompt: 'go' })
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
+      expect(paneHasStateClaims(state, PANE_KEY)).toBe(true)
+
+      clearPaneCacheState(state, PANE_KEY)
+      expect(state.descendantRosterByPaneKey.has(PANE_KEY)).toBe(false)
+      expect(state.descendantLeadStateByPaneKey.has(PANE_KEY)).toBe(false)
+    })
+
+    it('moves descendant state with the pane when its key is remapped', async () => {
+      const { movePaneCacheState } = await import('./agent-hook-listener/listener-state')
+      publish('grok', { hookEventName: 'UserPromptSubmit', prompt: 'go' })
+      publish('grok', { hookEventName: 'SubagentStart', subagentId: 'sub-1', subagentType: 'x' })
+
+      movePaneCacheState(state, PANE_KEY, 'tab-2:22222222-2222-4222-8222-222222222222')
+      expect(state.descendantRosterByPaneKey.has(PANE_KEY)).toBe(false)
+      expect(
+        state.descendantRosterByPaneKey.get('tab-2:22222222-2222-4222-8222-222222222222')?.size
+      ).toBe(1)
+    })
+  })
+})

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -136,8 +136,12 @@ export function normalizeHookPayload(
     // Normalization is transport-agnostic; only ingestRemote knows the mux identity to stamp.
     connectionId: null,
     ...(restoredUnconfirmed ? { restoredUnconfirmed: true } : {}),
-    hasExplicitPrompt:
-      source === 'amp'
+    // Why: nothing on a descendant's event describes the pane's own turn — counting a child's
+    // prompt as a user submit would move turn-scoped state (telemetry, permission stickiness)
+    // on the parent.
+    hasExplicitPrompt: dispatched.descendantScoped
+      ? undefined
+      : source === 'amp'
         ? hasExplicitAmpPrompt(eventName, promptText, hookPayloadRecord)
           ? true
           : undefined

--- a/src/shared/agent-hook-listener/descendant-events.ts
+++ b/src/shared/agent-hook-listener/descendant-events.ts
@@ -1,137 +1,168 @@
 import type { AgentHookSource } from '../agent-hook-relay'
 import { readFirstString } from './interactive-tool'
 import { isGrokEvent, normalizeHookEventName } from './provider-event-names'
+import { readString } from './tool-input-preview'
 
-/** What one hook event says about a DESCENDANT of the pane's lead session.
- *
- *  A descendant's lifecycle is not the pane's: it may add or remove a child row,
- *  and it may never settle the pane or fire completion. `id` is optional because
- *  some providers only mark an event as "this fired inside a child" without
- *  naming which one — that is still enough to refuse the settle. */
-export type DescendantEventFacts = {
-  id?: string
+/** One live descendant as its provider names it. */
+export type DescendantEntry = {
+  id: string
   agentType?: string
   description?: string
   model?: string
-  /** The descendant's own turn or session ended. */
-  ended: boolean
 }
 
-/** Providers whose normalizer already tracks its own descendants and derives the
- *  pane state from them. Claude's roster carries teammate parking, background-task
- *  folding and restored-snapshot provenance; Codex's carries per-child models and
- *  rollout reconciliation. Both already implement the pane rule, so the generic
- *  path must not run a second, blinder copy over the same events. */
-export function providerOwnsDescendantLifecycle(source: AgentHookSource): boolean {
-  return source === 'claude' || source === 'codex'
+/** What one hook event says about the DESCENDANTS of the pane's lead session.
+ *
+ *  A descendant's lifecycle is not the pane's: it may change the child list, and it
+ *  may never settle the pane or fire completion.
+ *
+ *  `child` is a delta from a provider whose child events each arrive as their own HTTP
+ *  post, so none can be lost in transit. Its `id` is optional because some providers
+ *  only mark an event as "this fired inside a child" without naming which one — still
+ *  enough to refuse the settle.
+ *
+ *  `live-set` is the authoritative full set, for a provider whose transport can drop an
+ *  intermediate message. Applying a delta over a lossy transport is unrecoverable — a
+ *  lost removal strands a finished child and pins the pane 'working' with nothing left
+ *  to clear it — whereas replacing the set makes every message self-sufficient, so the
+ *  newest one repairs whatever was dropped before it. */
+export type DescendantEventFacts =
+  | ({ kind: 'child'; ended: boolean } & Partial<DescendantEntry>)
+  | { kind: 'live-set'; children: readonly DescendantEntry[] }
+
+/** How one provider reports its descendants. Both questions live together on purpose: a
+ *  provider that opts into descendants MUST also answer how the pane recovers when a
+ *  child's finish never arrives, or it silently inherits "no recovery". */
+type DescendantProviderAdapter = {
+  readEvent: (
+    eventName: unknown,
+    hookPayload: Record<string, unknown>
+  ) => DescendantEventFacts | null
+  /** An event proving the descendants tracked so far can no longer be alive — the pane's
+   *  agent process was replaced, or the turn that owns them was torn down. */
+  isScopeReset: (eventName: unknown, hookPayload: Record<string, unknown>) => boolean
 }
 
-/** Provider-assigned child id under the names hook payloads actually use. */
-function readDescendantId(hookPayload: Record<string, unknown>): string | undefined {
-  return readFirstString(hookPayload, [
-    'subagentId',
-    'subagent_id',
-    'agentId',
-    'agent_id',
-    'runId',
-    'run_id'
-  ])
-}
-
-function readGrokDescendantFacts(
+function readGrokDescendantEvent(
   eventName: unknown,
   hookPayload: Record<string, unknown>
 ): DescendantEventFacts | null {
   const isLifecycleEvent = isGrokEvent(eventName, 'subagent_start', 'subagent_stop', 'subagent_end')
   const subagentType = readFirstString(hookPayload, ['subagentType', 'subagent_type'])
-  // Why: grok stamps `subagentType` on every event that can fire inside a child and omits it in
-  // the main session, so its presence — not the event name — is what tells a child apart. A
-  // background child outlives the parent turn and inherits the pane key, so without this its
-  // SessionEnd/StopFailure lands on the parent as a completion.
+  // Why: grok stamps `subagentType` on the payload of every event that can fire inside a child and
+  // omits it in the main session, so its presence — not the event name — is what tells a child
+  // apart. A child's own turn gate is remapped to SubagentStop, so the events that reach the
+  // parent's pane are the child's SessionEnd/StopFailure, which inherit its ORCA_PANE_KEY.
   if (!isLifecycleEvent && subagentType === undefined) {
     return null
   }
   return {
+    kind: 'child',
     id: readFirstString(hookPayload, ['subagentId', 'subagent_id']),
     agentType: subagentType,
     description: readFirstString(hookPayload, ['description']),
     ended:
       isGrokEvent(eventName, 'subagent_stop', 'subagent_end') ||
-      (subagentType !== undefined &&
-        isGrokEvent(eventName, 'stop', 'session_end', 'stop_failure', 'stop_cancelled'))
+      isGrokEvent(eventName, 'stop', 'session_end', 'stop_failure', 'stop_cancelled')
   }
 }
 
-function readPiDescendantFacts(
+function readPiDescendantEvent(
   eventName: unknown,
   hookPayload: Record<string, unknown>
 ): DescendantEventFacts | null {
-  const normalized = normalizeHookEventName(eventName)
-  if (normalized !== 'subagent_async_started' && normalized !== 'subagent_async_complete') {
+  if (normalizeHookEventName(eventName) !== 'subagent_async_state') {
     return null
   }
-  return {
-    id: readDescendantId(hookPayload),
-    agentType: readFirstString(hookPayload, ['agentType', 'agent_type', 'subagentType']),
-    description: readFirstString(hookPayload, ['description', 'task', 'prompt']),
-    model: readFirstString(hookPayload, ['model']),
-    ended: normalized === 'subagent_async_complete'
+  const runs = hookPayload['subagent_runs']
+  if (!Array.isArray(runs)) {
+    return null
   }
+  const children: DescendantEntry[] = []
+  for (const run of runs) {
+    if (typeof run !== 'object' || run === null) {
+      continue
+    }
+    const record = run as Record<string, unknown>
+    const id = readFirstString(record, ['id', 'run_id', 'runId', 'subagent_id'])
+    if (id) {
+      children.push({
+        id,
+        agentType: readFirstString(record, ['agent_type', 'agentType']),
+        description: readString(record, 'description'),
+        model: readString(record, 'model')
+      })
+    }
+  }
+  return { kind: 'live-set', children }
 }
 
-/** Read a descendant out of one provider's hook event, or null when the event
- *  belongs to the pane's lead session.
+/** Grok's own turn cancel. An interrupted turn skips the stop gate entirely, so a child
+ *  spawned by that turn never reports a finish and the cancel is the only proof it is gone.
+ *  A cancel carrying `subagentType` is one CHILD giving up (its own turn limit, or a declined
+ *  permission) and must not tear down its siblings — `readEvent` ends just that child. */
+function isGrokLeadTurnCancel(eventName: unknown, hookPayload: Record<string, unknown>): boolean {
+  return (
+    isGrokEvent(eventName, 'stop_cancelled') &&
+    readFirstString(hookPayload, ['subagentType', 'subagent_type']) === undefined
+  )
+}
+
+/** Every provider answers, or is explicitly `null` for "reports no child sessions on the
+ *  parent's pane". A `Record` over the source union makes a new provider a compile error
+ *  here, so descendant support and its recovery are decided together, in one place.
  *
- *  Exhaustive on purpose: a new provider has to answer "does this CLI report
- *  child sessions on the parent's pane?" here rather than inherit a guess. The
- *  answer is one line, and `readDescendantId` covers the field names in use. */
+ *  Claude and Codex are `null` because they own richer rosters of their own — Claude's
+ *  carries teammate parking, `background_tasks` folding and restored-snapshot provenance;
+ *  Codex's carries rollout reconciliation — and both already derive the pane from them. */
+const DESCENDANT_PROVIDERS: Record<AgentHookSource, DescendantProviderAdapter | null> = {
+  claude: null,
+  codex: null,
+  grok: {
+    readEvent: readGrokDescendantEvent,
+    isScopeReset: (eventName, hookPayload) =>
+      isGrokEvent(eventName, 'session_start') || isGrokLeadTurnCancel(eventName, hookPayload)
+  },
+  pi: {
+    readEvent: readPiDescendantEvent,
+    isScopeReset: (eventName) => eventName === 'session_start'
+  },
+  // Why: omp and prime-agent share pi's normalizer but not its subagent extension, so they
+  // report no children today; give one a reader here if that changes.
+  omp: null,
+  'prime-agent': null,
+  gemini: null,
+  antigravity: null,
+  amp: null,
+  opencode: null,
+  'mimo-code': null,
+  cursor: null,
+  droid: null,
+  'command-code': null,
+  copilot: null,
+  hermes: null,
+  devin: null,
+  kimi: null
+}
+
+/** Providers whose normalizer already tracks its own descendants and derives the pane state
+ *  from them, so the generic path must not run a second, blinder copy over the same events. */
+export function providerOwnsDescendantLifecycle(source: AgentHookSource): boolean {
+  return source === 'claude' || source === 'codex'
+}
+
 export function readDescendantEventFacts(
   source: AgentHookSource,
   eventName: unknown,
   hookPayload: Record<string, unknown>
 ): DescendantEventFacts | null {
-  switch (source) {
-    // Why: both own their rosters; `providerOwnsDescendantLifecycle` already routes around this,
-    // and answering here too would let a future caller run the generic path over their events.
-    case 'claude':
-    case 'codex':
-      return null
-    case 'grok':
-      return readGrokDescendantFacts(eventName, hookPayload)
-    case 'pi':
-    case 'omp':
-    case 'prime-agent':
-      return readPiDescendantFacts(eventName, hookPayload)
-    case 'gemini':
-    case 'antigravity':
-    case 'amp':
-    case 'opencode':
-    case 'mimo-code':
-    case 'cursor':
-    case 'droid':
-    case 'command-code':
-    case 'copilot':
-    case 'hermes':
-    case 'devin':
-    case 'kimi':
-      // No child-session hook surface reaches Orca for these today. When one gains
-      // one, read it here — the roster and the pane rule already exist.
-      return null
-  }
+  return DESCENDANT_PROVIDERS[source]?.readEvent(eventName, hookPayload) ?? null
 }
 
-/** An event that replaces the pane's agent process, so descendants of the process
- *  it replaced can no longer be alive. The roster's recovery from a lost child
- *  stop: without it a dropped stop hook would pin the pane 'working' forever. */
-export function isDescendantScopeResetEvent(source: AgentHookSource, eventName: unknown): boolean {
-  switch (source) {
-    case 'grok':
-      return isGrokEvent(eventName, 'session_start')
-    case 'pi':
-    case 'omp':
-    case 'prime-agent':
-      return eventName === 'session_start'
-    default:
-      return false
-  }
+export function isDescendantScopeResetEvent(
+  source: AgentHookSource,
+  eventName: unknown,
+  hookPayload: Record<string, unknown>
+): boolean {
+  return DESCENDANT_PROVIDERS[source]?.isScopeReset(eventName, hookPayload) === true
 }

--- a/src/shared/agent-hook-listener/descendant-events.ts
+++ b/src/shared/agent-hook-listener/descendant-events.ts
@@ -1,4 +1,5 @@
 import type { AgentHookSource } from '../agent-hook-relay'
+import { isAskUserQuestionTool } from '../agent-question-answered-intent'
 import { readFirstString } from './interactive-tool'
 import { isGrokEvent, normalizeHookEventName } from './provider-event-names'
 import { readString } from './tool-input-preview'
@@ -27,7 +28,13 @@ export type DescendantEntry = {
  *  to clear it — whereas replacing the set makes every message self-sufficient, so the
  *  newest one repairs whatever was dropped before it. */
 export type DescendantEventFacts =
-  | ({ kind: 'child'; ended: boolean } & Partial<DescendantEntry>)
+  | ({
+      kind: 'child'
+      ended: boolean
+      /** The child is blocked on a human answer. A descendant's wait is the pane's actionable
+       *  state, so it surfaces even when the provider never names which child is waiting. */
+      waiting?: boolean
+    } & Partial<DescendantEntry>)
   | { kind: 'live-set'; children: readonly DescendantEntry[] }
 
 /** How one provider reports its descendants. Both questions live together on purpose: a
@@ -56,11 +63,18 @@ function readGrokDescendantEvent(
   if (!isLifecycleEvent && subagentType === undefined) {
     return null
   }
+  // Why: grok auto-allows ask_user_question, so a child blocked on a human answer announces it as
+  // a PreToolUse. Routing child events away from the lead normalizer would otherwise drop that
+  // wait entirely, and a pane silently waiting on an answer is the worst state to hide.
+  const isChildAsking =
+    isGrokEvent(eventName, 'pre_tool_use') &&
+    isAskUserQuestionTool(readFirstString(hookPayload, ['toolName', 'tool_name', 'name']))
   return {
     kind: 'child',
     id: readFirstString(hookPayload, ['subagentId', 'subagent_id']),
     agentType: subagentType,
     description: readFirstString(hookPayload, ['description']),
+    ...(isChildAsking ? { waiting: true } : {}),
     ended:
       isGrokEvent(eventName, 'subagent_stop', 'subagent_end') ||
       isGrokEvent(eventName, 'stop', 'session_end', 'stop_failure', 'stop_cancelled')

--- a/src/shared/agent-hook-listener/descendant-events.ts
+++ b/src/shared/agent-hook-listener/descendant-events.ts
@@ -1,0 +1,137 @@
+import type { AgentHookSource } from '../agent-hook-relay'
+import { readFirstString } from './interactive-tool'
+import { isGrokEvent, normalizeHookEventName } from './provider-event-names'
+
+/** What one hook event says about a DESCENDANT of the pane's lead session.
+ *
+ *  A descendant's lifecycle is not the pane's: it may add or remove a child row,
+ *  and it may never settle the pane or fire completion. `id` is optional because
+ *  some providers only mark an event as "this fired inside a child" without
+ *  naming which one — that is still enough to refuse the settle. */
+export type DescendantEventFacts = {
+  id?: string
+  agentType?: string
+  description?: string
+  model?: string
+  /** The descendant's own turn or session ended. */
+  ended: boolean
+}
+
+/** Providers whose normalizer already tracks its own descendants and derives the
+ *  pane state from them. Claude's roster carries teammate parking, background-task
+ *  folding and restored-snapshot provenance; Codex's carries per-child models and
+ *  rollout reconciliation. Both already implement the pane rule, so the generic
+ *  path must not run a second, blinder copy over the same events. */
+export function providerOwnsDescendantLifecycle(source: AgentHookSource): boolean {
+  return source === 'claude' || source === 'codex'
+}
+
+/** Provider-assigned child id under the names hook payloads actually use. */
+function readDescendantId(hookPayload: Record<string, unknown>): string | undefined {
+  return readFirstString(hookPayload, [
+    'subagentId',
+    'subagent_id',
+    'agentId',
+    'agent_id',
+    'runId',
+    'run_id'
+  ])
+}
+
+function readGrokDescendantFacts(
+  eventName: unknown,
+  hookPayload: Record<string, unknown>
+): DescendantEventFacts | null {
+  const isLifecycleEvent = isGrokEvent(eventName, 'subagent_start', 'subagent_stop', 'subagent_end')
+  const subagentType = readFirstString(hookPayload, ['subagentType', 'subagent_type'])
+  // Why: grok stamps `subagentType` on every event that can fire inside a child and omits it in
+  // the main session, so its presence — not the event name — is what tells a child apart. A
+  // background child outlives the parent turn and inherits the pane key, so without this its
+  // SessionEnd/StopFailure lands on the parent as a completion.
+  if (!isLifecycleEvent && subagentType === undefined) {
+    return null
+  }
+  return {
+    id: readFirstString(hookPayload, ['subagentId', 'subagent_id']),
+    agentType: subagentType,
+    description: readFirstString(hookPayload, ['description']),
+    ended:
+      isGrokEvent(eventName, 'subagent_stop', 'subagent_end') ||
+      (subagentType !== undefined &&
+        isGrokEvent(eventName, 'stop', 'session_end', 'stop_failure', 'stop_cancelled'))
+  }
+}
+
+function readPiDescendantFacts(
+  eventName: unknown,
+  hookPayload: Record<string, unknown>
+): DescendantEventFacts | null {
+  const normalized = normalizeHookEventName(eventName)
+  if (normalized !== 'subagent_async_started' && normalized !== 'subagent_async_complete') {
+    return null
+  }
+  return {
+    id: readDescendantId(hookPayload),
+    agentType: readFirstString(hookPayload, ['agentType', 'agent_type', 'subagentType']),
+    description: readFirstString(hookPayload, ['description', 'task', 'prompt']),
+    model: readFirstString(hookPayload, ['model']),
+    ended: normalized === 'subagent_async_complete'
+  }
+}
+
+/** Read a descendant out of one provider's hook event, or null when the event
+ *  belongs to the pane's lead session.
+ *
+ *  Exhaustive on purpose: a new provider has to answer "does this CLI report
+ *  child sessions on the parent's pane?" here rather than inherit a guess. The
+ *  answer is one line, and `readDescendantId` covers the field names in use. */
+export function readDescendantEventFacts(
+  source: AgentHookSource,
+  eventName: unknown,
+  hookPayload: Record<string, unknown>
+): DescendantEventFacts | null {
+  switch (source) {
+    // Why: both own their rosters; `providerOwnsDescendantLifecycle` already routes around this,
+    // and answering here too would let a future caller run the generic path over their events.
+    case 'claude':
+    case 'codex':
+      return null
+    case 'grok':
+      return readGrokDescendantFacts(eventName, hookPayload)
+    case 'pi':
+    case 'omp':
+    case 'prime-agent':
+      return readPiDescendantFacts(eventName, hookPayload)
+    case 'gemini':
+    case 'antigravity':
+    case 'amp':
+    case 'opencode':
+    case 'mimo-code':
+    case 'cursor':
+    case 'droid':
+    case 'command-code':
+    case 'copilot':
+    case 'hermes':
+    case 'devin':
+    case 'kimi':
+      // No child-session hook surface reaches Orca for these today. When one gains
+      // one, read it here — the roster and the pane rule already exist.
+      return null
+  }
+}
+
+/** An event that replaces the pane's agent process, so descendants of the process
+ *  it replaced can no longer be alive. The roster's recovery from a lost child
+ *  stop: without it a dropped stop hook would pin the pane 'working' forever. */
+export function isDescendantScopeResetEvent(source: AgentHookSource, eventName: unknown): boolean {
+  switch (source) {
+    case 'grok':
+      return isGrokEvent(eventName, 'session_start')
+    case 'pi':
+    case 'omp':
+    case 'prime-agent':
+      return eventName === 'session_start'
+    default:
+      return false
+  }
+}

--- a/src/shared/agent-hook-listener/descendant-pane-state.ts
+++ b/src/shared/agent-hook-listener/descendant-pane-state.ts
@@ -1,0 +1,102 @@
+import type { AgentHookSource } from '../agent-hook-relay'
+import {
+  agentDescendantEffectiveState,
+  agentDescendantRosterToSnapshots,
+  finishAgentDescendant,
+  upsertAgentDescendant,
+  type AgentDescendantRoster
+} from '../agent-descendant-roster'
+import { normalizeAgentStatusPayload, type ParsedAgentStatusPayload } from '../agent-status-types'
+import type { DescendantEventFacts } from './descendant-events'
+import type { HookListenerState } from './listener-state'
+
+function getOrCreateDescendantRoster(
+  state: HookListenerState,
+  paneKey: string
+): AgentDescendantRoster {
+  let roster = state.descendantRosterByPaneKey.get(paneKey)
+  if (!roster) {
+    roster = new Map()
+    state.descendantRosterByPaneKey.set(paneKey, roster)
+  }
+  return roster
+}
+
+/** Apply a descendant's lifecycle event: it updates the child list and republishes
+ *  the pane from the LEAD's last known state, so a child finishing can never be the
+ *  pane's completion. The lead's own tool/prompt caches are left untouched — a
+ *  child's tool call is not the pane's, and overwriting them would relabel the row
+ *  with the child's work. */
+export function applyDescendantEventToPane(
+  state: HookListenerState,
+  source: AgentHookSource,
+  paneKey: string,
+  facts: DescendantEventFacts
+): ParsedAgentStatusPayload | null {
+  if (facts.id) {
+    if (facts.ended) {
+      const roster = state.descendantRosterByPaneKey.get(paneKey)
+      if (roster) {
+        finishAgentDescendant(roster, facts.id)
+        if (roster.size === 0) {
+          state.descendantRosterByPaneKey.delete(paneKey)
+        }
+      }
+    } else {
+      upsertAgentDescendant(
+        getOrCreateDescendantRoster(state, paneKey),
+        facts.id,
+        {
+          agentType: facts.agentType,
+          description: facts.description,
+          model: facts.model,
+          state: 'working'
+        },
+        Date.now()
+      )
+    }
+  }
+
+  // Why: a child event before any lead event still proves the pane is working — the lead spawned it.
+  const leadState = state.descendantLeadStateByPaneKey.get(paneKey) ?? 'working'
+  const cachedTool = state.lastToolByPaneKey.get(paneKey) ?? {}
+  return normalizeAgentStatusPayload({
+    state: agentDescendantEffectiveState(state.descendantRosterByPaneKey.get(paneKey), leadState),
+    prompt: state.lastPromptByPaneKey.get(paneKey) ?? '',
+    agentType: source,
+    toolName: cachedTool.toolName,
+    toolInput: cachedTool.toolInput,
+    interactivePrompt: cachedTool.interactivePrompt,
+    lastAssistantMessage: cachedTool.lastAssistantMessage,
+    lastAssistantMessageIsToolOutput: cachedTool.lastAssistantMessageIsToolOutput,
+    subagents: agentDescendantRosterToSnapshots(state.descendantRosterByPaneKey.get(paneKey))
+  })
+}
+
+/** The pane is idle only when its lead session is idle AND no descendant is live.
+ *  Records the lead's own verdict first, so draining the last descendant later
+ *  republishes what the lead actually said instead of the gated value. */
+export function gatePaneStateOnDescendants(
+  state: HookListenerState,
+  paneKey: string,
+  payload: ParsedAgentStatusPayload | null
+): ParsedAgentStatusPayload | null {
+  if (!payload) {
+    return payload
+  }
+  state.descendantLeadStateByPaneKey.set(paneKey, payload.state)
+  const roster = state.descendantRosterByPaneKey.get(paneKey)
+  if (!roster || roster.size === 0) {
+    return payload
+  }
+  return {
+    ...payload,
+    state: agentDescendantEffectiveState(roster, payload.state),
+    subagents: agentDescendantRosterToSnapshots(roster)
+  }
+}
+
+export function clearDescendantScope(state: HookListenerState, paneKey: string): void {
+  state.descendantRosterByPaneKey.delete(paneKey)
+  state.descendantLeadStateByPaneKey.delete(paneKey)
+}

--- a/src/shared/agent-hook-listener/descendant-pane-state.ts
+++ b/src/shared/agent-hook-listener/descendant-pane-state.ts
@@ -3,6 +3,8 @@ import {
   agentDescendantEffectiveState,
   agentDescendantRosterToSnapshots,
   finishAgentDescendant,
+  pruneStaleAgentDescendants,
+  replaceAgentDescendants,
   upsertAgentDescendant,
   type AgentDescendantRoster
 } from '../agent-descendant-roster'
@@ -33,15 +35,13 @@ export function applyDescendantEventToPane(
   paneKey: string,
   facts: DescendantEventFacts
 ): ParsedAgentStatusPayload | null {
-  if (facts.id) {
+  const now = Date.now()
+  if (facts.kind === 'live-set') {
+    const roster = getOrCreateDescendantRoster(state, paneKey)
+    replaceAgentDescendants(roster, facts.children, now)
+  } else if (facts.id) {
     if (facts.ended) {
-      const roster = state.descendantRosterByPaneKey.get(paneKey)
-      if (roster) {
-        finishAgentDescendant(roster, facts.id)
-        if (roster.size === 0) {
-          state.descendantRosterByPaneKey.delete(paneKey)
-        }
-      }
+      finishAgentDescendant(state.descendantRosterByPaneKey.get(paneKey) ?? new Map(), facts.id)
     } else {
       upsertAgentDescendant(
         getOrCreateDescendantRoster(state, paneKey),
@@ -52,10 +52,11 @@ export function applyDescendantEventToPane(
           model: facts.model,
           state: 'working'
         },
-        Date.now()
+        now
       )
     }
   }
+  dropEmptyDescendantRoster(state, paneKey, now)
 
   // Why: a child event before any lead event still proves the pane is working — the lead spawned it.
   const leadState = state.descendantLeadStateByPaneKey.get(paneKey) ?? 'working'
@@ -85,14 +86,28 @@ export function gatePaneStateOnDescendants(
     return payload
   }
   state.descendantLeadStateByPaneKey.set(paneKey, payload.state)
+  dropEmptyDescendantRoster(state, paneKey, Date.now())
   const roster = state.descendantRosterByPaneKey.get(paneKey)
-  if (!roster || roster.size === 0) {
+  if (!roster) {
     return payload
   }
   return {
     ...payload,
     state: agentDescendantEffectiveState(roster, payload.state),
     subagents: agentDescendantRosterToSnapshots(roster)
+  }
+}
+
+/** Reap children nothing has mentioned for the quiet window, then forget a roster with
+ *  nothing left in it — the pane must not keep a claim it can no longer justify. */
+function dropEmptyDescendantRoster(state: HookListenerState, paneKey: string, now: number): void {
+  const roster = state.descendantRosterByPaneKey.get(paneKey)
+  if (!roster) {
+    return
+  }
+  pruneStaleAgentDescendants(roster, now)
+  if (roster.size === 0) {
+    state.descendantRosterByPaneKey.delete(paneKey)
   }
 }
 

--- a/src/shared/agent-hook-listener/descendant-pane-state.ts
+++ b/src/shared/agent-hook-listener/descendant-pane-state.ts
@@ -50,7 +50,7 @@ export function applyDescendantEventToPane(
           agentType: facts.agentType,
           description: facts.description,
           model: facts.model,
-          state: 'working'
+          state: facts.waiting === true ? 'waiting' : 'working'
         },
         now
       )
@@ -61,8 +61,14 @@ export function applyDescendantEventToPane(
   // Why: a child event before any lead event still proves the pane is working — the lead spawned it.
   const leadState = state.descendantLeadStateByPaneKey.get(paneKey) ?? 'working'
   const cachedTool = state.lastToolByPaneKey.get(paneKey) ?? {}
+  // Why: a child's wait must surface even when its provider never named which child is waiting,
+  // so there is no roster row to carry the state.
+  const effectiveState =
+    facts.kind === 'child' && facts.waiting === true
+      ? 'waiting'
+      : agentDescendantEffectiveState(state.descendantRosterByPaneKey.get(paneKey), leadState)
   return normalizeAgentStatusPayload({
-    state: agentDescendantEffectiveState(state.descendantRosterByPaneKey.get(paneKey), leadState),
+    state: effectiveState,
     prompt: state.lastPromptByPaneKey.get(paneKey) ?? '',
     agentType: source,
     toolName: cachedTool.toolName,

--- a/src/shared/agent-hook-listener/listener-state.ts
+++ b/src/shared/agent-hook-listener/listener-state.ts
@@ -38,7 +38,9 @@ export type HookListenerState = {
   /** Live descendants for every provider that does not own a roster of its own. */
   descendantRosterByPaneKey: Map<string, AgentDescendantRoster>
   /** What the LEAD session last said, before descendants gated it — so draining the
-   *  last child republishes the lead's verdict instead of the gated one. */
+   *  last child republishes the lead's verdict instead of the gated one. Deliberately
+   *  NOT a state claim (see `paneHasStateClaims`): it only refines a republish that an
+   *  incoming descendant event already triggered, and never creates a row on its own. */
   descendantLeadStateByPaneKey: Map<string, AgentStatusState>
 }
 
@@ -121,8 +123,7 @@ export function paneHasStateClaims(state: HookListenerState, paneKey: string): b
     state.claudeSessionOwnerByPaneKey.has(paneKey) ||
     state.codexSubagentRosterByPaneKey.has(paneKey) ||
     state.codexLeadStateByPaneKey.has(paneKey) ||
-    state.descendantRosterByPaneKey.has(paneKey) ||
-    state.descendantLeadStateByPaneKey.has(paneKey)
+    state.descendantRosterByPaneKey.has(paneKey)
   )
 }
 

--- a/src/shared/agent-hook-listener/listener-state.ts
+++ b/src/shared/agent-hook-listener/listener-state.ts
@@ -1,6 +1,6 @@
 import type { AgentStatusState } from '../agent-status-types'
 import type { ClaudeSubagentRoster } from '../claude-subagent-roster'
-import type { CodexSubagentRoster } from '../codex-subagent-roster'
+import type { AgentDescendantRoster } from '../agent-descendant-roster'
 import type { CodexSubagentTranscriptState } from '../codex-subagent-transcript'
 import type { AgentHookEventPayload, ToolSnapshot } from './listener-event'
 
@@ -30,11 +30,16 @@ export type HookListenerState = {
    *  even when no SessionStart arrives — the backstop for the exits that emit no terminating hook. */
   claudeSessionOwnerByPaneKey: Map<string, string>
   /** Live thread-spawn children per Codex pane. */
-  codexSubagentRosterByPaneKey: Map<string, CodexSubagentRoster>
+  codexSubagentRosterByPaneKey: Map<string, AgentDescendantRoster>
   /** Incremental parent/child rollout cursors for Codex collaboration v2. */
   codexSubagentTranscriptByPaneKey: Map<string, CodexSubagentTranscriptState>
   /** Root Codex state/model, kept separate from child hook traffic. */
   codexLeadStateByPaneKey: Map<string, CodexLeadTurnState>
+  /** Live descendants for every provider that does not own a roster of its own. */
+  descendantRosterByPaneKey: Map<string, AgentDescendantRoster>
+  /** What the LEAD session last said, before descendants gated it — so draining the
+   *  last child republishes the lead's verdict instead of the gated one. */
+  descendantLeadStateByPaneKey: Map<string, AgentStatusState>
 }
 
 export type ClaudeLeadTurnState = {
@@ -73,7 +78,9 @@ export function createHookListenerState(): HookListenerState {
     claudeSessionOwnerByPaneKey: new Map(),
     codexSubagentRosterByPaneKey: new Map(),
     codexSubagentTranscriptByPaneKey: new Map(),
-    codexLeadStateByPaneKey: new Map()
+    codexLeadStateByPaneKey: new Map(),
+    descendantRosterByPaneKey: new Map(),
+    descendantLeadStateByPaneKey: new Map()
   }
 }
 
@@ -93,6 +100,8 @@ export function clearPaneCacheState(state: HookListenerState, paneKey: string): 
   state.codexSubagentRosterByPaneKey.delete(paneKey)
   state.codexSubagentTranscriptByPaneKey.delete(paneKey)
   state.codexLeadStateByPaneKey.delete(paneKey)
+  state.descendantRosterByPaneKey.delete(paneKey)
+  state.descendantLeadStateByPaneKey.delete(paneKey)
 }
 
 /** Does this pane still hold anything that can ASSERT a state — a stored row, or a Claude latch that
@@ -111,7 +120,9 @@ export function paneHasStateClaims(state: HookListenerState, paneKey: string): b
     state.claudeActiveSessionCronPaneKeys.has(paneKey) ||
     state.claudeSessionOwnerByPaneKey.has(paneKey) ||
     state.codexSubagentRosterByPaneKey.has(paneKey) ||
-    state.codexLeadStateByPaneKey.has(paneKey)
+    state.codexLeadStateByPaneKey.has(paneKey) ||
+    state.descendantRosterByPaneKey.has(paneKey) ||
+    state.descendantLeadStateByPaneKey.has(paneKey)
   )
 }
 
@@ -166,6 +177,8 @@ export function movePaneCacheState(
   movePaneScopedMapEntries(state.codexSubagentRosterByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexSubagentTranscriptByPaneKey, fromPaneKey, toPaneKey)
   movePaneScopedMapEntries(state.codexLeadStateByPaneKey, fromPaneKey, toPaneKey)
+  movePaneScopedMapEntries(state.descendantRosterByPaneKey, fromPaneKey, toPaneKey)
+  movePaneScopedMapEntries(state.descendantLeadStateByPaneKey, fromPaneKey, toPaneKey)
 }
 
 export function clearPaneTurnCacheState(state: HookListenerState, paneKey: string): void {
@@ -213,4 +226,6 @@ export function clearAllListenerCaches(state: HookListenerState): void {
   state.codexSubagentRosterByPaneKey.clear()
   state.codexSubagentTranscriptByPaneKey.clear()
   state.codexLeadStateByPaneKey.clear()
+  state.descendantRosterByPaneKey.clear()
+  state.descendantLeadStateByPaneKey.clear()
 }

--- a/src/shared/agent-hook-listener/provider-dispatch.ts
+++ b/src/shared/agent-hook-listener/provider-dispatch.ts
@@ -65,7 +65,7 @@ export function normalizeProviderEvent(input: {
   // reaches the provider normalizer, so it cannot settle the pane or relabel the row.
   const ownsDescendants = providerOwnsDescendantLifecycle(source)
   if (!ownsDescendants) {
-    if (isDescendantScopeResetEvent(source, eventName)) {
+    if (isDescendantScopeResetEvent(source, eventName, hookPayload)) {
       clearDescendantScope(state, paneKey)
     }
     const descendant = readDescendantEventFacts(source, eventName, hookPayload)

--- a/src/shared/agent-hook-listener/provider-dispatch.ts
+++ b/src/shared/agent-hook-listener/provider-dispatch.ts
@@ -3,6 +3,16 @@ import type { AgentHookSource } from '../agent-hook-relay'
 import { readLastCommandCodeUserPromptEntryFromTranscript } from './command-code-transcript'
 import { readGrokHomeEnvelope } from './grok-result-discovery'
 import { readFirstString } from './interactive-tool'
+import {
+  isDescendantScopeResetEvent,
+  providerOwnsDescendantLifecycle,
+  readDescendantEventFacts
+} from './descendant-events'
+import {
+  applyDescendantEventToPane,
+  clearDescendantScope,
+  gatePaneStateOnDescendants
+} from './descendant-pane-state'
 import type { HookListenerState } from './listener-state'
 import type { ExtractedPromptText } from './prompt-fields'
 import { isNewTurnEvent } from './provider-event-routing'
@@ -28,6 +38,8 @@ export type ProviderDispatchResult = {
   resolvedPromptText: string
   promptInteractionKey?: string
   hasTranscriptPromptEvidence: boolean
+  /** The event fired inside a descendant, so nothing on it describes the pane's own turn. */
+  descendantScoped?: true
 }
 
 /** Exhaustive provider routing with provider-specific transcript locality and attribution. */
@@ -47,6 +59,26 @@ export function normalizeProviderEvent(input: {
   let promptInteractionKey: string | undefined
   let hasTranscriptPromptEvidence = false
   let payload: ParsedAgentStatusPayload | null
+
+  // Why: the pane rule — idle only when the lead is idle AND no descendant is live — is applied
+  // here, once, for every provider that does not own a roster. A child's lifecycle event never
+  // reaches the provider normalizer, so it cannot settle the pane or relabel the row.
+  const ownsDescendants = providerOwnsDescendantLifecycle(source)
+  if (!ownsDescendants) {
+    if (isDescendantScopeResetEvent(source, eventName)) {
+      clearDescendantScope(state, paneKey)
+    }
+    const descendant = readDescendantEventFacts(source, eventName, hookPayload)
+    if (descendant) {
+      return {
+        payload: applyDescendantEventToPane(state, source, paneKey, descendant),
+        // Why: a child's prompt is not the pane's turn label, and its tool events are not a user submit.
+        resolvedPromptText: '',
+        hasTranscriptPromptEvidence: false,
+        descendantScoped: true
+      }
+    }
+  }
 
   switch (source) {
     case 'claude':
@@ -150,5 +182,10 @@ export function normalizeProviderEvent(input: {
       break
   }
 
-  return { payload, resolvedPromptText, promptInteractionKey, hasTranscriptPromptEvidence }
+  return {
+    payload: ownsDescendants ? payload : gatePaneStateOnDescendants(state, paneKey, payload),
+    resolvedPromptText,
+    promptInteractionKey,
+    hasTranscriptPromptEvidence
+  }
 }

--- a/src/shared/agent-hook-listener/providers/codex-events.ts
+++ b/src/shared/agent-hook-listener/providers/codex-events.ts
@@ -1,16 +1,17 @@
 import {
   AGENT_MODEL_MAX_LENGTH,
   normalizeAgentStatusPayload,
+  type AgentStatusState,
   type ParsedAgentStatusPayload
 } from '../../agent-status-types'
 import { normalizeOptionalField } from '../../agent-status-field-normalization'
 import { isAskUserQuestionTool } from '../../agent-question-answered-intent'
 import {
-  codexRosterEffectiveState,
-  codexRosterToSnapshots,
-  finishCodexSubagent,
-  upsertCodexSubagent
-} from '../../codex-subagent-roster'
+  agentDescendantEffectiveState,
+  agentDescendantRosterToSnapshots,
+  finishAgentDescendant,
+  upsertAgentDescendant
+} from '../../agent-descendant-roster'
 import { reconcileCodexSubagentTranscript } from '../../codex-subagent-transcript'
 import { readFirstString } from '../interactive-tool'
 import type { HookListenerState } from '../listener-state'
@@ -18,7 +19,7 @@ import { resolvePrompt, resolveToolState } from '../prompt-fields'
 import { extractToolFields, isNewTurnEvent } from '../provider-event-routing'
 import { readString } from '../tool-input-preview'
 import {
-  getOrCreateCodexSubagentRoster,
+  getOrCreateAgentDescendantRoster,
   getOrCreateCodexSubagentTranscriptState,
   hasCodexTranscriptSubagents
 } from './codex-state'
@@ -29,7 +30,7 @@ export function buildCodexStatusPayload(
   promptText: string,
   paneKey: string,
   hookPayload: Record<string, unknown>,
-  options: { stateName: 'working' | 'waiting' | 'done'; updateLead: boolean }
+  options: { stateName: AgentStatusState; updateLead: boolean }
 ): ParsedAgentStatusPayload | null {
   const snapshot = options.updateLead
     ? resolveToolState(state, paneKey, extractToolFields('codex', eventName, hookPayload), {
@@ -50,7 +51,7 @@ export function buildCodexStatusPayload(
     interactivePrompt: snapshot.interactivePrompt,
     lastAssistantMessage: snapshot.lastAssistantMessage,
     lastAssistantMessageIsToolOutput: snapshot.lastAssistantMessageIsToolOutput,
-    subagents: codexRosterToSnapshots(state.codexSubagentRosterByPaneKey.get(paneKey))
+    subagents: agentDescendantRosterToSnapshots(state.codexSubagentRosterByPaneKey.get(paneKey))
   })
 }
 
@@ -61,7 +62,7 @@ export function buildCodexChildDrivenStatusPayload(
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
   const leadState = state.codexLeadStateByPaneKey.get(paneKey)?.state ?? 'working'
-  const stateName = codexRosterEffectiveState(
+  const stateName = agentDescendantEffectiveState(
     state.codexSubagentRosterByPaneKey.get(paneKey),
     leadState
   )
@@ -81,9 +82,9 @@ export function normalizeCodexSubagentLifecycleEvent(
   if (!agentId) {
     return null
   }
-  const roster = getOrCreateCodexSubagentRoster(state, paneKey)
+  const roster = getOrCreateAgentDescendantRoster(state, paneKey)
   if (eventName === 'SubagentStart') {
-    upsertCodexSubagent(
+    upsertAgentDescendant(
       roster,
       agentId,
       {
@@ -94,7 +95,7 @@ export function normalizeCodexSubagentLifecycleEvent(
       Date.now()
     )
   } else {
-    finishCodexSubagent(roster, agentId)
+    finishAgentDescendant(roster, agentId)
   }
   return buildCodexChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
 }
@@ -131,8 +132,8 @@ export function normalizeCodexEvent(
 
   const agentId = readString(hookPayload, 'agent_id')
   if (agentId) {
-    upsertCodexSubagent(
-      getOrCreateCodexSubagentRoster(state, paneKey),
+    upsertAgentDescendant(
+      getOrCreateAgentDescendantRoster(state, paneKey),
       agentId,
       {
         agentType: readString(hookPayload, 'agent_type'),
@@ -153,7 +154,7 @@ export function normalizeCodexEvent(
   if (transcriptPath) {
     reconcileCodexSubagentTranscript(
       getOrCreateCodexSubagentTranscriptState(state, paneKey),
-      getOrCreateCodexSubagentRoster(state, paneKey),
+      getOrCreateAgentDescendantRoster(state, paneKey),
       transcriptPath
     )
   }
@@ -168,7 +169,7 @@ export function normalizeCodexEvent(
       normalizeOptionalField(hookPayload['model'], AGENT_MODEL_MAX_LENGTH) ??
       (eventName === 'SessionStart' ? undefined : previousLead?.model)
   })
-  const effectiveState = codexRosterEffectiveState(
+  const effectiveState = agentDescendantEffectiveState(
     state.codexSubagentRosterByPaneKey.get(paneKey),
     stateName
   )

--- a/src/shared/agent-hook-listener/providers/codex-state.ts
+++ b/src/shared/agent-hook-listener/providers/codex-state.ts
@@ -1,11 +1,11 @@
 import type { ParsedAgentStatusPayload } from '../../agent-status-types'
 import {
-  codexRosterEffectiveState,
-  codexRosterToSnapshots,
-  finishCodexSubagent,
-  seedCodexSubagentRoster,
-  type CodexSubagentRoster
-} from '../../codex-subagent-roster'
+  agentDescendantEffectiveState,
+  agentDescendantRosterToSnapshots,
+  finishAgentDescendant,
+  seedAgentDescendantRoster,
+  type AgentDescendantRoster
+} from '../../agent-descendant-roster'
 import {
   createCodexSubagentTranscriptState,
   hasTrackedCodexTranscriptSubagents,
@@ -13,10 +13,10 @@ import {
 } from '../../codex-subagent-transcript'
 import type { CodexLeadTurnState, HookListenerState } from '../listener-state'
 
-export function getOrCreateCodexSubagentRoster(
+export function getOrCreateAgentDescendantRoster(
   state: HookListenerState,
   paneKey: string
-): CodexSubagentRoster {
+): AgentDescendantRoster {
   let roster = state.codexSubagentRosterByPaneKey.get(paneKey)
   if (!roster) {
     roster = new Map()
@@ -48,7 +48,7 @@ export function seedCodexStateFromSnapshot(
 ): void {
   const snapshots = payload.subagents ?? []
   if (snapshots.length > 0 && !state.codexSubagentRosterByPaneKey.has(paneKey)) {
-    seedCodexSubagentRoster(getOrCreateCodexSubagentRoster(state, paneKey), snapshots)
+    seedAgentDescendantRoster(getOrCreateAgentDescendantRoster(state, paneKey), snapshots)
   }
   if (!state.codexLeadStateByPaneKey.has(paneKey)) {
     // Why: child hooks after restart omit the root model; seed it from durable status before they can overwrite the cache.
@@ -111,13 +111,13 @@ export function reconcileRemoteCodexState(
   if (agentId && !payload.subagents && !state.codexSubagentRosterByPaneKey.has(paneKey)) {
     return payload
   }
-  const roster = getOrCreateCodexSubagentRoster(state, paneKey)
+  const roster = getOrCreateAgentDescendantRoster(state, paneKey)
   if (payload.subagents) {
-    seedCodexSubagentRoster(roster, payload.subagents)
+    seedAgentDescendantRoster(roster, payload.subagents)
   }
   if (agentId) {
     if (eventName === 'SubagentStop') {
-      finishCodexSubagent(roster, agentId)
+      finishAgentDescendant(roster, agentId)
     }
   } else {
     const leadState = codexLeadStateForHookEvent(eventName)
@@ -146,8 +146,8 @@ export function reconcileRemoteCodexState(
   return {
     ...payload,
     prompt,
-    state: codexRosterEffectiveState(roster, lead.state),
+    state: agentDescendantEffectiveState(roster, lead.state),
     model: lead.model ?? payload.model,
-    subagents: codexRosterToSnapshots(roster)
+    subagents: agentDescendantRosterToSnapshots(roster)
   }
 }

--- a/src/shared/agent-hook-listener/providers/grok-events.ts
+++ b/src/shared/agent-hook-listener/providers/grok-events.ts
@@ -43,6 +43,11 @@ export function normalizeGrokEvent(
   const isUserInputPreTool =
     isGrokEvent(eventName, 'pre_tool_use') && isAskUserQuestionTool(preToolName)
 
+  // Why: an interrupted turn skips the stop gate and reports StopCancelled instead. A child-scoped
+  // one never reaches here (dispatch routes it to the roster), so this is always the lead's own
+  // turn ending without finishing. It must publish: the pane would otherwise keep the pre-cancel
+  // row — spinner still running, children still listed — until some later turn happened to end.
+  const isLeadTurnCancel = isGrokEvent(eventName, 'stop_cancelled')
   let stateName: 'working' | 'waiting' | 'done' | null = null
   if (
     isGrokEvent(eventName, 'user_prompt_submit', 'post_tool_use', 'post_tool_use_failure') ||
@@ -51,7 +56,7 @@ export function normalizeGrokEvent(
     stateName = 'working'
   } else if (isUserInputPreTool) {
     stateName = 'waiting'
-  } else if (isGrokEvent(eventName, 'stop', 'session_end', 'stop_failure')) {
+  } else if (isGrokEvent(eventName, 'stop', 'session_end', 'stop_failure') || isLeadTurnCancel) {
     stateName = 'done'
   } else if (
     isGrokEvent(eventName, 'notification') &&
@@ -91,6 +96,10 @@ export function normalizeGrokEvent(
 
   return normalizeAgentStatusPayload({
     state: stateName,
+    // Why: a cancelled turn did not finish. The flag is what makes the row read 'Interrupted' and
+    // any notification say 'stopped' rather than 'finished' — the same shape claude's interrupt
+    // path publishes. Covers a runtime cancel (turn limit, no progress) too: neither completed.
+    ...(isLeadTurnCancel ? { interrupted: true } : {}),
     prompt: resolvePrompt(state, paneKey, effectivePrompt, {
       resetOnNewTurn: isNewTurnEvent('grok', eventName)
     }),

--- a/src/shared/codex-subagent-transcript.test.ts
+++ b/src/shared/codex-subagent-transcript.test.ts
@@ -23,7 +23,10 @@ import {
   hasTrackedCodexTranscriptSubagents,
   reconcileCodexSubagentTranscript
 } from './codex-subagent-transcript'
-import { codexRosterToSnapshots, type CodexSubagentRoster } from './codex-subagent-roster'
+import {
+  agentDescendantRosterToSnapshots,
+  type AgentDescendantRoster
+} from './agent-descendant-roster'
 
 const CHILD_ID = '019fa65f-3144-7151-9c02-cff7a28f316f'
 
@@ -69,12 +72,12 @@ describe('Codex subagent transcript reconciliation', () => {
     writeFileSync(parentPath, jsonl([activity('started')]))
     writeFileSync(childPath, jsonl([{ type: 'event_msg', payload: { type: 'task_started' } }]))
     const state = createCodexSubagentTranscriptState()
-    const roster: CodexSubagentRoster = new Map()
+    const roster: AgentDescendantRoster = new Map()
 
     reconcileCodexSubagentTranscript(state, roster, parentPath)
 
     expect(hasTrackedCodexTranscriptSubagents(state)).toBe(true)
-    expect(codexRosterToSnapshots(roster)).toEqual([
+    expect(agentDescendantRosterToSnapshots(roster)).toEqual([
       {
         id: CHILD_ID,
         description: '/root/sidebar_repro',
@@ -95,7 +98,7 @@ describe('Codex subagent transcript reconciliation', () => {
     reconcileCodexSubagentTranscript(state, roster, parentPath)
 
     expect(hasTrackedCodexTranscriptSubagents(state)).toBe(false)
-    expect(codexRosterToSnapshots(roster)).toBeUndefined()
+    expect(agentDescendantRosterToSnapshots(roster)).toBeUndefined()
   })
 
   it('resolves a child rollout filed under a later session day than the parent', () => {
@@ -111,7 +114,7 @@ describe('Codex subagent transcript reconciliation', () => {
     writeFileSync(parentPath, jsonl([activity('started', childStartedAt)]))
     writeFileSync(childPath, jsonl([{ type: 'event_msg', payload: { type: 'task_started' } }]))
     const state = createCodexSubagentTranscriptState()
-    const roster: CodexSubagentRoster = new Map()
+    const roster: AgentDescendantRoster = new Map()
 
     reconcileCodexSubagentTranscript(state, roster, parentPath)
     writeFileSync(
@@ -136,7 +139,7 @@ describe('Codex subagent transcript reconciliation', () => {
       const parentPath = join(dir, 'rollout-parent.jsonl')
       writeFileSync(parentPath, jsonl([activity('started')]))
       const state = createCodexSubagentTranscriptState()
-      const roster: CodexSubagentRoster = new Map()
+      const roster: AgentDescendantRoster = new Map()
 
       reconcileCodexSubagentTranscript(state, roster, parentPath)
       expect(roster.size).toBe(1)
@@ -161,7 +164,7 @@ describe('Codex subagent transcript reconciliation', () => {
     const parentPath = join(dir, 'rollout-parent.jsonl')
     writeFileSync(parentPath, jsonl([activity('started')]))
     const state = createCodexSubagentTranscriptState()
-    const roster: CodexSubagentRoster = new Map()
+    const roster: AgentDescendantRoster = new Map()
     reconcileCodexSubagentTranscript(state, roster, parentPath)
 
     writeFileSync(parentPath, jsonl([activity('started'), activity('interrupted')]))
@@ -197,18 +200,18 @@ describe('Codex subagent transcript reconciliation', () => {
     it('reports the model from the child rollout, not the parent model', () => {
       const { parentPath } = seedPair([started(), turnContext('gpt-5.6-terra')])
       const state = createCodexSubagentTranscriptState()
-      const roster: CodexSubagentRoster = new Map()
+      const roster: AgentDescendantRoster = new Map()
 
       reconcileCodexSubagentTranscript(state, roster, parentPath)
 
       // The parent runs sol; only the child's own turn_context may set its model.
-      expect(codexRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
+      expect(agentDescendantRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
     })
 
     it('keeps the discovered model when a later poll carries no turn_context', () => {
       const { parentPath, childPath } = seedPair([started(), turnContext('gpt-5.6-terra')])
       const state = createCodexSubagentTranscriptState()
-      const roster: CodexSubagentRoster = new Map()
+      const roster: AgentDescendantRoster = new Map()
       reconcileCodexSubagentTranscript(state, roster, parentPath)
 
       // The cursor is incremental: this appended line is all the next read sees.
@@ -222,7 +225,7 @@ describe('Codex subagent transcript reconciliation', () => {
       )
       reconcileCodexSubagentTranscript(state, roster, parentPath)
 
-      expect(codexRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
+      expect(agentDescendantRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
     })
 
     it('tracks the newest model when the child switches mid-session', () => {
@@ -232,22 +235,22 @@ describe('Codex subagent transcript reconciliation', () => {
         turnContext('gpt-5.6-sol')
       ])
       const state = createCodexSubagentTranscriptState()
-      const roster: CodexSubagentRoster = new Map()
+      const roster: AgentDescendantRoster = new Map()
 
       reconcileCodexSubagentTranscript(state, roster, parentPath)
 
-      expect(codexRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-sol')
+      expect(agentDescendantRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-sol')
     })
 
     it('leaves the child working and keeps its identity while reading the model', () => {
       const { parentPath } = seedPair([started(), turnContext('gpt-5.6-terra')])
       const state = createCodexSubagentTranscriptState()
-      const roster: CodexSubagentRoster = new Map()
+      const roster: AgentDescendantRoster = new Map()
 
       reconcileCodexSubagentTranscript(state, roster, parentPath)
 
       // Model discovery must not move lifecycle or overwrite the child's label.
-      expect(codexRosterToSnapshots(roster)).toEqual([
+      expect(agentDescendantRosterToSnapshots(roster)).toEqual([
         {
           id: CHILD_ID,
           description: '/root/sidebar_repro',
@@ -266,7 +269,7 @@ describe('Codex subagent transcript reconciliation', () => {
         { type: 'event_msg', payload: { type: 'task_complete' } }
       ])
       const state = createCodexSubagentTranscriptState()
-      const roster: CodexSubagentRoster = new Map()
+      const roster: AgentDescendantRoster = new Map()
 
       reconcileCodexSubagentTranscript(state, roster, parentPath)
 
@@ -277,7 +280,7 @@ describe('Codex subagent transcript reconciliation', () => {
     it('reads the model without opening any file beyond the parent and child rollouts', () => {
       const { parentPath } = seedPair([started(), turnContext('gpt-5.6-terra')])
       const state = createCodexSubagentTranscriptState()
-      const roster: CodexSubagentRoster = new Map()
+      const roster: AgentDescendantRoster = new Map()
       openSyncCalls.mockClear()
 
       reconcileCodexSubagentTranscript(state, roster, parentPath)
@@ -285,7 +288,7 @@ describe('Codex subagent transcript reconciliation', () => {
       // Why: model extraction reuses the records already read for completion
       // detection, so it must add no file I/O of its own.
       expect(openSyncCalls).toHaveBeenCalledTimes(2)
-      expect(codexRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
+      expect(agentDescendantRosterToSnapshots(roster)?.[0]?.model).toBe('gpt-5.6-terra')
     })
   })
 })

--- a/src/shared/codex-subagent-transcript.ts
+++ b/src/shared/codex-subagent-transcript.ts
@@ -2,11 +2,11 @@ import { closeSync, openSync, readSync, readdirSync, statSync, type Stats } from
 import { basename, dirname, extname, isAbsolute, join } from 'node:path'
 
 import {
-  finishCodexSubagent,
-  setCodexSubagentModel,
-  upsertCodexSubagent,
-  type CodexSubagentRoster
-} from './codex-subagent-roster'
+  finishAgentDescendant,
+  setAgentDescendantModel,
+  upsertAgentDescendant,
+  type AgentDescendantRoster
+} from './agent-descendant-roster'
 
 const TRANSCRIPT_READ_MAX_BYTES = 1024 * 1024
 const TRANSCRIPT_LINE_MAX_BYTES = 256 * 1024
@@ -253,7 +253,7 @@ export function hasTrackedCodexTranscriptSubagents(
 
 export function reconcileCodexSubagentTranscript(
   state: CodexSubagentTranscriptState,
-  roster: CodexSubagentRoster,
+  roster: AgentDescendantRoster,
   transcriptPath: string | undefined
 ): void {
   const normalizedPath = transcriptPath?.trim()
@@ -262,7 +262,7 @@ export function reconcileCodexSubagentTranscript(
   }
   if (state.parent.filePath !== normalizedPath) {
     for (const id of state.subagents.keys()) {
-      finishCodexSubagent(roster, id)
+      finishAgentDescendant(roster, id)
     }
     state.parent = { filePath: normalizedPath, offset: 0, carry: '' }
     state.subagents.clear()
@@ -273,7 +273,7 @@ export function reconcileCodexSubagentTranscript(
       continue
     }
     if (activity.kind === 'interrupted') {
-      finishCodexSubagent(roster, activity.id)
+      finishAgentDescendant(roster, activity.id)
       state.subagents.delete(activity.id)
       continue
     }
@@ -284,7 +284,7 @@ export function reconcileCodexSubagentTranscript(
     }
     tracked.description = activity.description ?? tracked.description
     state.subagents.set(activity.id, tracked)
-    upsertCodexSubagent(
+    upsertAgentDescendant(
       roster,
       activity.id,
       { description: tracked.description, state: 'working' },
@@ -316,12 +316,12 @@ export function reconcileCodexSubagentTranscript(
       // Why: re-applied every reconcile, not just on discovery — the parent's
       // own activity upsert can rebuild this child's roster entry, which would
       // otherwise drop a model found on an earlier poll.
-      setCodexSubagentModel(roster, id, tracked.model)
+      setAgentDescendantModel(roster, id, tracked.model)
       if (!childIsComplete(records)) {
         continue
       }
     }
-    finishCodexSubagent(roster, id)
+    finishAgentDescendant(roster, id)
     state.subagents.delete(id)
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​609 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​50 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​559 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​752 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​190 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​562 |

<!-- /orca-pr-loc -->

## The rule

A pane is idle only when its lead agent session is idle **and** no descendant is still running. A descendant's lifecycle event may add or remove a child row; it may never settle the pane or fire completion.

That rule existed twice in the codebase — Claude's roster and Codex's — and was missing entirely for every other provider. Grok and Pi are two reports of that one gap.

## Root cause per issue

**STA-6982 (Grok, urgent).** `src/shared/agent-hook-listener/providers/grok-events.ts:54` mapped `stop` / `session_end` / `stop_failure` to pane `done` with no notion of a child. Grok stamps `subagentType` on the payload of every event that can fire inside a subagent and omits it in the main session; nested children inherit the parent pane's `ORCA_PANE_KEY`. One correction to the report: a child's turn gate is remapped to `SubagentStop`, and Grok's `Stop` payload carries no `subagentType` — so the events that actually reached the pane are the child's own `SessionEnd` and `StopFailure`, both of which Orca installs and both of which carry the field. Each one settled the parent and drove the Agent Task Complete notification.

**STA-6378 (Pi, high).** `src/shared/agent-hook-listener/providers/pi-family-events.ts` mapped `agent_end` straight to `done`. Async child runs delegated through pi's subagent extension outlive the parent turn, and nothing in Orca knew they existed: the parent settled, the spinner stopped, and completion could fire while children ran.

## The fix

`src/shared/codex-subagent-roster.ts` was already provider-neutral in substance, so it becomes `src/shared/agent-descendant-roster.ts` — one descendant roster and one `agentDescendantEffectiveState` derivation, reused rather than re-implemented. Codex's behaviour is unchanged (rename plus a widened state type).

The rule is then applied **once**, at `provider-dispatch.ts` — the boundary every provider funnels through:

- a hook event that describes a descendant never reaches the provider normalizer. It updates the roster and republishes the **lead's** last state, so it cannot settle the pane, cannot relabel the row with the child's tool or prompt, and does not count as a user submit (`hasExplicitPrompt`);
- every other event's result is gated: a lead `done` publishes as `working` while a descendant is live.

`descendant-events.ts` holds the only per-provider part as a single table keyed by provider. Each entry answers both halves together — how to read a child out of that CLI's events, and which event proves its children can no longer be alive — because a provider that opts into descendants without answering recovery silently inherits "no recovery". A `Record` over the source union makes a new provider a compile error there, so the question cannot be skipped.

Claude keeps its own roster. Its children carry teammate parking, `background_tasks` folding and restored-snapshot provenance that no other provider has, and it already implements this same pane rule in `providers/claude-roster-state.ts`. Folding it into the generic path would mean either losing that reconciliation or pushing Claude-only fields into every provider.

Supporting changes: Grok's `SubagentStart` / `SubagentStop` are now installed (older builds ignore unregistered event names, the `StopFailure` precedent) so a child can be **named** rather than only inferred; and the managed pi status extension forwards the async child-run lifecycle from pi's process event bus.

### Losing a child's finish must not wedge the pane

A roster entry's only power is to hold a pane `working`, so a claim nothing can retract is worse than settling late. Three things guarantee one can always be retracted:

- **The pi extension posts the full live child set, not a start/complete delta.** Its transport (`agent-status-extension-source.ts`) is a latest-only single slot: while a delivery is in flight, a newer post overwrites the pending one and the overwritten message is never sent. Every other caller posts a complete snapshot, so a dropped one is harmless — a dropped delta would strand a finished child forever. Sending the whole set restores the invariant the transport was built on: the newest message is complete, so it repairs whatever was dropped before it. This is why the payload is a set rather than deltas with their own queue; a second delivery path would add ordering between two queues and a new failure mode instead of removing one.
- **An interrupted grok turn clears its children.** An interrupt skips the stop gate entirely and reports `StopCancelled`, so a child of that turn never sends a finish — the cancel is the only proof it is gone. That event is now installed and a lead-scoped one resets the pane's descendants; a child-scoped one (a child's own turn limit or declined permission) ends just that child. `SessionStart` cannot do this job: it does not fire for a subagent's own session and fires once per session, so it never reaches a mid-session orphan.
- **A quiet-window reaper backstops both.** Every provider loses a stop hook sometimes — disabled, untrusted, timed out, process killed. A descendant unmentioned for 30 minutes is dropped, pruned lazily on the pane's next event so the roster stays passive. Deliberately generous: a wrongly reaped child merely settles the pane early, which the lead's next event corrects, whereas too short a window would reintroduce the bug this roster exists to fix.
- **A cancelled turn publishes an interrupted settle.** Clearing the roster is not enough on its own: grok's normalizer had no `stop_cancelled` case, so it returned nothing and the pane kept its pre-cancel row — spinner running, children listed — while the roster was already empty. A lead-scoped cancel now publishes `done` with `interrupted`, the same shape claude's interrupt path publishes, so the row reads Interrupted and a notification says "stopped" rather than "finished".

**Behaviour change to be explicit about:** a completion notification can now fire on cancel where it could not before. The notification is dispatched off terminal-title transitions and process exit, with hook status acting only as a veto (`isFreshNonDoneAgentStatus`); a pane stuck on `working` was incidentally holding that veto shut. Publishing `done` lifts it. That is the deliberate trade — the alternative leaves the pane wrong until some later turn happens to end, and the idle-prompt ping cannot be relied on to settle it, because grok cancels that ping as soon as the user sends the next message, which is exactly what interrupting to redirect does. Any notification on this path is the "stopped" variant, not "finished".

## STA-6677 (Claude): investigated, not closed, and not this bug

STA-6677 was originally grouped with these two. It does not belong here, and the fix it asks for should not be made.

1. **The harm this cluster is about is already absent on Claude's path.** The drain's `done` repeats the gated lead Stop's `turnCompletedAt`, and `src/renderer/src/components/terminal-pane/agent-completion-hook-observer.ts:164-172` early-returns on a `turnCompletedAt` already handled. The completion notification therefore fires exactly once, at the lead Stop — there is no early or duplicate "Agent Task Complete" here.
2. **What remains is sidebar colour** for the window between the child's stop and the parent's next hook.
3. **Flipping it would reverse a deliberate design.** I implemented the reporter's fix; it broke six tests in `src/shared/agent-hook-listener-claude-subagents.test.ts` (lines 45, 221, 453 among them) that assert the opposite with stated reasons, e.g. *"the lead already stopped before the wait; draining the child must resolve to done, not pin the pane on an invented 'working'."* Those comments name the stuck-spinner class the current behaviour guards against. I reverted the change and left the tests intact.
4. **It is a different root cause.** Unlike Grok and Pi, Orca is not settling on a descendant event here: the lead's own `Stop` genuinely fired and Orca cached it faithfully. The reporter saw the parent still generating *after* that Stop, which points upstream — at why the lead Stop lands while the parent is still working — rather than at pane-state derivation. That needs its own root-causing.

## Also considered, left out

- **STA-6881** (Pi extension prompts should read Blocked, not Working) — already fixed on `main`, after the reported 1.4.197. `src/main/pi/agent-status-ui-prompt-source.ts` forwards `ui_prompt_start` / `ui_prompt_end` and `pi-family-events.ts:37` normalizes them to `waiting`. Both reported symptoms are covered: `waiting` and `blocked` both map to `permission` (`runtime-worktree-status-projection.ts:179-181`), which is exactly what populates `agentWait` (`orca-runtime-get-terminal-interactive-wait.ts:46`), so the `agentWait: null` in the report no longer reproduces. No mechanism left to build, and none of it rides along on the descendant work.
- **STA-6495** (missed OMP completion leaves the spinner stuck) — a delivery failure, not a descendant. It needs run-generation ids, POST retry and receiver-side reconciliation. Different mechanism; not folded in.

## Tests

New: `src/shared/agent-hook-listener-descendant-lifecycle.test.ts` (20) drives `normalizeHookPayload`, the entry both the main process and the relay call. `src/main/pi/agent-status-async-subagent.test.ts` (8) executes the real generated extension source and feeds its POST body through that same entry.

Ablation, every arm re-run at the final head — 20/20 and 8/8 pass there:

| Arm (single lever unless noted) | Result |
|---|---|
| `provider-dispatch.ts` at `main`, new modules kept (shipping path severed) | 21/28 fail |
| lead cancel maps to no state (the reported interrupt defect) | both cancel cases fail |
| `interrupted` flag dropped from the cancel settle | both cancel cases fail |
| child `ask_user_question` wait dropped | the child-wait case fails |
| pi extension posts start/complete deltas instead of the live set | the coalescer-race case fails |
| grok lead-turn cancel dropped from the scope reset | both cancel cases fail |
| quiet-window reaper removed | the lost-finish case fails |
| `StopCancelled` dropped from the installed grok events | the hook-config case fails |
| all production files at `main` (full revert) | the descendant suite cannot load at all; 7/27 fail in the suites that still do |

Three defects were caught by testing rather than review. The Pi harness found that the process-bus bind guard aborted the extension factory on an in-process reload. The coalescer-race arm initially **passed** against the delta payload it was meant to pin — bursting the starts as well as the completions meant a dropped start cancelled out a dropped completion, so the pane settled for the wrong reason; the starts are now delivered one at a time. And the interrupt regression test asserts the **published payload**, not the roster: the earlier roster-only assertion was exactly why a cleared roster with a stale renderer passed review and CI.

Regression at the final head: 16282 tests across `src/main/pi`, `src/main/grok`, `src/main/agent-hooks`, `src/main/codex`, `src/shared`, `src/relay` and `src/renderer/.../terminal-pane`. Two runs each surfaced one different timeout under the parallel load (`spool.test.ts`, `pty-handler-retired-pane-surface.test.ts`); both pass twice in isolation and neither touches this change. All three tsconfig projects typecheck clean, `pnpm run build:cli` succeeds, and `check:code-quality:changed`, `oxlint` and the native-plugins config all exit 0.

### Known limits

- The reaper is lazy — it prunes on the pane's next event, so a pane that goes completely silent keeps its last published row until something arrives. That is the pre-existing shape of any lost terminal transition rather than something the roster introduces, but it means the reaper bounds the damage rather than eliminating it.
- Whether the completion notification is actually suppressed on the descendant path is **not** proven end to end. The link is code reading: keeping the status `working` is what `isFreshNonDoneAgentStatus` tests, and the status staying `working` is measured. An attempt to instrument the dispatch directly did not install, and its "zero notifications" reading is not being claimed as evidence.

## Cross-cutting

**Remote wire (Rule 3 — content, not shape).** No new field, no new opcode. `subagents` is an existing optional field every client already normalizes for Claude and Codex; Grok and Pi panes now populate it, and an old client renders those child rows the same way. The `state` change is `done` → `working`, both long-standing members of `AGENT_STATUS_STATES` with unchanged meaning — the pane simply settles later. Both skew directions were reasoned through and behave: a new hook event reaching an **old** listener normalizes to nothing and is dropped (old hosts keep the old bug, they gain no new one), and a **new** listener paired with an old, un-reinstalled Grok hook config still fixes STA-6982, because the `subagentType` guard needs no `SubagentStart`. `cross-version-agent-session-wire` and `cross-version-terminal-wire` pass (23).

**SSH / execution boundary.** Hooks fire on the execution host and the roster lives in that host's listener state; the main process and the relay each hold their own, as they already did for Claude and Codex. Nothing here reads local process state or treats loss of contact as evidence.

**Cross-platform.** Pure event normalization plus a generated extension string — no paths, no shells, no platform branches.

**Folder workspaces.** Pane-keyed throughout; no worktree or git assumption.

## Types

`HookListenerState` gains two maps; `agentDescendantEffectiveState` and `buildCodexStatusPayload`'s `stateName` widen from the three-value union to `AgentStatusState`; `ProviderDispatchResult` gains an optional `descendantScoped`; `DescendantEventFacts` is a discriminated union of a per-child delta and an authoritative live set. All three tsconfig projects were typechecked separately and are clean.

Closes STA-6982
Closes STA-6378


