### PR TITLE
fix(codex): one resolved Codex home, and a mirror that merges instead of overwriting

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -84,6 +84,7 @@
     "../src/main/codex/config-toml-key-path.ts",
     "../src/main/codex/config-toml-line-scan.ts",
     "../src/main/codex/config-toml-project-trust.ts",
+    "../src/main/codex/config-toml-runtime-added-sections.ts",
     "../src/main/codex/config-toml-runtime-owned-sections.ts",
     "../src/main/codex/config-toml-syntax.ts",
     "../src/main/codex/config-toml-trust.ts",

--- a/src/main/agent-hooks/execution-host-agent-homes.ts
+++ b/src/main/agent-hooks/execution-host-agent-homes.ts
@@ -1,0 +1,129 @@
+import { execFile } from 'node:child_process'
+import { basename } from 'node:path'
+import { userInfo } from 'node:os'
+import { promisify } from 'node:util'
+import { initializeCodexAppServerConnection } from '../codex/codex-app-server-handshake'
+import { runCodexAppServerSession } from '../codex/codex-app-server-session'
+
+// Why: this module runs on the execution host, so every home it returns is a
+// path on that host. Agent config homes are resolved here rather than by each
+// installer, which otherwise assumes `~/.<agent>` and writes where the agent
+// will never read.
+
+const execFileAsync = promisify(execFile)
+const AGENT_HOME_MAX_LENGTH = 4096
+const HOME_PROBE_TIMEOUT_MS = 8_000
+
+export function hasControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const code = character.charCodeAt(0)
+    return code <= 0x1f || code === 0x7f
+  })
+}
+
+/** Rejects anything that is not a plain absolute POSIX directory path. The
+ *  execution host for these installers is POSIX; a Windows-shaped or
+ *  control-character path is a probe that went wrong, not a home. */
+export function normalizePosixAgentHome(candidate: string): string | null {
+  if (
+    candidate.length === 0 ||
+    candidate.length > AGENT_HOME_MAX_LENGTH ||
+    candidate !== candidate.trim() ||
+    !candidate.startsWith('/') ||
+    candidate.includes('\\') ||
+    hasControlCharacter(candidate)
+  ) {
+    return null
+  }
+  return candidate.replace(/\/+$/, '') || '/'
+}
+
+export function resolveLoginShell(): string {
+  const candidate = process.env.SHELL || userInfo().shell || '/bin/sh'
+  if (!candidate.startsWith('/') || candidate.includes('\\') || hasControlCharacter(candidate)) {
+    return '/bin/sh'
+  }
+  return candidate
+}
+
+function loginShellFlag(shell: string): string {
+  const shellName = basename(shell)
+  return shellName === 'sh' || shellName === 'dash' ? '-c' : '-lc'
+}
+
+function defaultAgentHome(home: string, directoryName: string): string {
+  return `${home.replace(/\/+$/, '') || home}/${directoryName}`
+}
+
+export async function resolveExecutionHostGrokHome(
+  home: string,
+  signal?: AbortSignal
+): Promise<string> {
+  const fallback = defaultAgentHome(home, '.grok')
+  try {
+    const shell = resolveLoginShell()
+    // Why: agent PTYs start login shells, so read the same profile-derived
+    // GROK_HOME without opening two additional SSH exec channels.
+    const { stdout } = await execFileAsync(
+      shell,
+      [loginShellFlag(shell), `printenv GROK_HOME | head -c ${AGENT_HOME_MAX_LENGTH + 1}`],
+      { encoding: 'utf8', timeout: HOME_PROBE_TIMEOUT_MS, signal }
+    )
+    return normalizePosixAgentHome(stdout.split(/\r?\n/, 1)[0] ?? '') ?? fallback
+  } catch {
+    signal?.throwIfAborted()
+    return fallback
+  }
+}
+
+/**
+ * Asks the host's own Codex where its CODEX_HOME is.
+ *
+ * Reading the environment the way the Grok probe does is not enough here: a
+ * `codex` launcher commonly exports CODEX_HOME inside the wrapper script, so it
+ * exists only for the Codex process and a login shell reports nothing. The
+ * app-server handshake returns the home the server actually resolved, which
+ * costs no wrapper parsing and stays correct for any launcher shape.
+ */
+export async function resolveExecutionHostCodexHome(
+  home: string,
+  signal?: AbortSignal
+): Promise<string> {
+  const fallback = defaultAgentHome(home, '.codex')
+  try {
+    const shell = resolveLoginShell()
+    const initializeResult = await runCodexAppServerSession(
+      {
+        // Why: launch through the login shell so the probe resolves `codex` the
+        // same way the PTY does, wrapper included. That leaves no host CLI path
+        // to pair a node runtime against, which is what `cliPath: null` means.
+        command: shell,
+        args: [loginShellFlag(shell), 'exec codex app-server'],
+        cliPath: null,
+        timeoutMs: HOME_PROBE_TIMEOUT_MS
+      },
+      async (rpc) => await initializeCodexAppServerConnection(rpc)
+    )
+    const reported = (initializeResult as { codexHome?: unknown } | null)?.codexHome
+    return (typeof reported === 'string' ? normalizePosixAgentHome(reported) : null) ?? fallback
+  } catch {
+    // Why: an absent, old, or hung Codex must not fail hook installation. The
+    // default home is still right for every launcher that does not redirect.
+    signal?.throwIfAborted()
+    return fallback
+  }
+}
+
+/**
+ * The Codex home only when the host redirects it away from `~/.codex`.
+ *
+ * `undefined` means "the default home", which every installer already assumes,
+ * so a host with no redirection stays on exactly the path it uses today.
+ */
+export async function resolveRedirectedExecutionHostCodexHome(
+  home: string,
+  signal?: AbortSignal
+): Promise<string | undefined> {
+  const resolved = await resolveExecutionHostCodexHome(home, signal)
+  return resolved === defaultAgentHome(home, '.codex') ? undefined : resolved
+}

--- a/src/main/agent-hooks/execution-host-agent-homes.ts
+++ b/src/main/agent-hooks/execution-host-agent-homes.ts
@@ -1,7 +1,6 @@
-import { execFile } from 'node:child_process'
 import { basename } from 'node:path'
 import { userInfo } from 'node:os'
-import { promisify } from 'node:util'
+import { runProcess } from '../../shared/child-process/run-process'
 import { initializeCodexAppServerConnection } from '../codex/codex-app-server-handshake'
 import { runCodexAppServerSession } from '../codex/codex-app-server-session'
 
@@ -10,7 +9,6 @@ import { runCodexAppServerSession } from '../codex/codex-app-server-session'
 // installer, which otherwise assumes `~/.<agent>` and writes where the agent
 // will never read.
 
-const execFileAsync = promisify(execFile)
 const AGENT_HOME_MAX_LENGTH = 4096
 const HOME_PROBE_TIMEOUT_MS = 8_000
 
@@ -64,11 +62,14 @@ export async function resolveExecutionHostGrokHome(
     const shell = resolveLoginShell()
     // Why: agent PTYs start login shells, so read the same profile-derived
     // GROK_HOME without opening two additional SSH exec channels.
-    const { stdout } = await execFileAsync(
-      shell,
-      [loginShellFlag(shell), `printenv GROK_HOME | head -c ${AGENT_HOME_MAX_LENGTH + 1}`],
-      { encoding: 'utf8', timeout: HOME_PROBE_TIMEOUT_MS, signal }
-    )
+    // Why: a non-zero exit needs no special case — it yields no stdout, and an
+    // unparseable home already falls back.
+    const { stdout } = await runProcess({
+      program: shell,
+      args: [loginShellFlag(shell), `printenv GROK_HOME | head -c ${AGENT_HOME_MAX_LENGTH + 1}`],
+      timeoutMs: HOME_PROBE_TIMEOUT_MS,
+      signal
+    })
     return normalizePosixAgentHome(stdout.split(/\r?\n/, 1)[0] ?? '') ?? fallback
   } catch {
     signal?.throwIfAborted()

--- a/src/main/agent-hooks/execution-host-codex-home.test.ts
+++ b/src/main/agent-hooks/execution-host-codex-home.test.ts
@@ -1,0 +1,172 @@
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  resolveExecutionHostCodexHome,
+  resolveRedirectedExecutionHostCodexHome
+} from './execution-host-agent-homes'
+import { installManagedHooks } from './managed-hook-runtime'
+
+const tempHomes: string[] = []
+const tempRoot = process.platform === 'win32' ? tmpdir() : '/tmp'
+
+async function createTempHome(): Promise<string> {
+  const home = await mkdtemp(join(tempRoot, 'orca-execution-host-codex-'))
+  tempHomes.push(home)
+  return home
+}
+
+/**
+ * A login shell whose `codex` resolves to a stub app-server, standing in for the
+ * host wrapper in the report: CODEX_HOME exists only for the Codex process, so
+ * the handshake is the only place the real home is observable.
+ */
+async function stubLoginShellWithCodex(
+  home: string,
+  { reportedHome }: { reportedHome: string | null }
+): Promise<void> {
+  const server = [
+    "const readline = require('node:readline')",
+    "readline.createInterface({ input: process.stdin }).on('line', (line) => {",
+    '  const message = JSON.parse(line)',
+    "  if (typeof message.id !== 'number') return",
+    `  const result = ${reportedHome === null ? '{}' : `{ codexHome: ${JSON.stringify(reportedHome)} }`}`,
+    "  process.stdout.write(JSON.stringify({ id: message.id, result }) + '\\n')",
+    '})',
+    ''
+  ].join('\n')
+  const serverPath = join(home, 'codex-app-server.js')
+  await writeFile(serverPath, server, 'utf8')
+  const shell = join(home, 'login-shell')
+  await writeFile(
+    shell,
+    [
+      '#!/bin/sh',
+      'case "$2" in',
+      `  *"codex app-server"*) exec ${JSON.stringify(process.execPath)} ${JSON.stringify(serverPath)} ;;`,
+      '  *) exit 0 ;;',
+      'esac',
+      ''
+    ].join('\n'),
+    'utf8'
+  )
+  await chmod(shell, 0o755)
+  vi.stubEnv('HOME', home)
+  vi.stubEnv('SHELL', shell)
+}
+
+/** A login shell with no `codex` at all: the probe must degrade, not throw. */
+async function stubLoginShellWithoutCodex(home: string): Promise<void> {
+  const shell = join(home, 'login-shell')
+  await writeFile(shell, '#!/bin/sh\nexit 127\n', 'utf8')
+  await chmod(shell, 0o755)
+  vi.stubEnv('HOME', home)
+  vi.stubEnv('SHELL', shell)
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await Promise.all(tempHomes.splice(0).map((home) => rm(home, { recursive: true, force: true })))
+})
+
+describe.runIf(process.platform !== 'win32')('resolveExecutionHostCodexHome', () => {
+  it('reports the home the host Codex resolved, not the default', async () => {
+    const home = await createTempHome()
+    await stubLoginShellWithCodex(home, { reportedHome: `${home}/.codex-openai` })
+
+    await expect(resolveExecutionHostCodexHome(home)).resolves.toBe(`${home}/.codex-openai`)
+  })
+
+  it('normalizes a trailing separator on the reported home', async () => {
+    const home = await createTempHome()
+    await stubLoginShellWithCodex(home, { reportedHome: `${home}/.codex-openai///` })
+
+    await expect(resolveExecutionHostCodexHome(home)).resolves.toBe(`${home}/.codex-openai`)
+  })
+
+  it('falls back when the reported home is not an absolute POSIX path', async () => {
+    const home = await createTempHome()
+    await stubLoginShellWithCodex(home, { reportedHome: '../relative' })
+
+    await expect(resolveExecutionHostCodexHome(home)).resolves.toBe(`${home}/.codex`)
+  })
+
+  it('falls back when the handshake reports no home at all', async () => {
+    const home = await createTempHome()
+    await stubLoginShellWithCodex(home, { reportedHome: null })
+
+    await expect(resolveExecutionHostCodexHome(home)).resolves.toBe(`${home}/.codex`)
+  })
+
+  it('falls back when the host has no usable codex', async () => {
+    const home = await createTempHome()
+    await stubLoginShellWithoutCodex(home)
+
+    await expect(resolveExecutionHostCodexHome(home)).resolves.toBe(`${home}/.codex`)
+  })
+})
+
+describe.runIf(process.platform !== 'win32')('resolveRedirectedExecutionHostCodexHome', () => {
+  it('returns nothing when the host uses the default home', async () => {
+    const home = await createTempHome()
+    await stubLoginShellWithCodex(home, { reportedHome: `${home}/.codex` })
+
+    await expect(resolveRedirectedExecutionHostCodexHome(home)).resolves.toBeUndefined()
+  })
+
+  it('returns the home only when it is genuinely redirected', async () => {
+    const home = await createTempHome()
+    await stubLoginShellWithCodex(home, { reportedHome: `${home}/.codex-openai` })
+
+    await expect(resolveRedirectedExecutionHostCodexHome(home)).resolves.toBe(
+      `${home}/.codex-openai`
+    )
+  })
+})
+
+describe.runIf(process.platform !== 'win32')('installManagedHooks on a redirecting host', () => {
+  it('installs Codex hooks into the home Codex actually reads', async () => {
+    const home = await createTempHome()
+    const redirected = join(home, '.codex-openai')
+    await mkdir(redirected, { recursive: true })
+    await stubLoginShellWithCodex(home, { reportedHome: redirected })
+
+    await expect(installManagedHooks({ agents: ['codex'] })).resolves.toEqual({
+      installers: 1,
+      errors: 0
+    })
+
+    const installed = JSON.parse(await readFile(join(redirected, 'hooks.json'), 'utf8')) as {
+      hooks: Record<string, unknown>
+    }
+    expect(Object.keys(installed.hooks).length).toBeGreaterThan(0)
+    expect(JSON.stringify(installed)).toContain('codex-hook.sh')
+    // Why: the whole defect is hooks landing in a home Codex never reads.
+    expect(existsSync(join(home, '.codex', 'hooks.json'))).toBe(false)
+    // Why: only the config location moves. A redirected home on an SSH host is
+    // the user's own, with no Orca runtime installer writing it, so it keeps the
+    // guest-home script contract rather than the runtime-installer one.
+    expect(existsSync(join(home, '.orca', 'agent-hooks', 'codex-hook.sh'))).toBe(true)
+    expect(existsSync(join(redirected, '.orca', 'agent-hooks', 'codex-hook.sh'))).toBe(false)
+  })
+
+  it('leaves a host that does not redirect on its existing install contract', async () => {
+    const home = await createTempHome()
+    await stubLoginShellWithCodex(home, { reportedHome: `${home}/.codex` })
+
+    await expect(installManagedHooks({ agents: ['codex'] })).resolves.toEqual({
+      installers: 1,
+      errors: 0
+    })
+
+    expect(existsSync(join(home, '.codex', 'hooks.json'))).toBe(true)
+    // Why: the guest-home script location is the unchanged plain-SSH contract.
+    // Passing the default home through as a redirect would move it and silently
+    // reorder every user's hooks, so pin where it lands.
+    expect(existsSync(join(home, '.orca', 'agent-hooks', 'codex-hook.sh'))).toBe(true)
+    expect(await readdir(join(home, '.codex'))).not.toContain('.orca')
+  })
+})

--- a/src/main/agent-hooks/managed-hook-runtime.test.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.test.ts
@@ -1,54 +1,9 @@
-import { chmod, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as NodeChildProcess from 'node:child_process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// Why: the probe spawns a real login shell, and `resolveRelayGrokHome` swallows every
-// spawn failure into its fallback. Left unmocked this asserts the runner's scheduling
-// latency, not the parser: on a loaded sharded CI box the 8s timeout expires and the
-// first case silently flips to the fallback path.
-vi.mock('node:child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof NodeChildProcess>()
-  return { ...actual, execFile: vi.fn() }
-})
-
-const { execFile } = await import('node:child_process')
-const execFileMock = vi.mocked(execFile)
-const { execFile: actualExecFile } =
-  await vi.importActual<typeof NodeChildProcess>('node:child_process')
 const { installManagedHooks, resolveRelayGrokHome } = await import('./managed-hook-runtime')
-
-type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void
-
-function stubProbeOutput(stdout: string): void {
-  execFileMock.mockImplementation(((...args: unknown[]) => {
-    ;(args.at(-1) as ExecFileCallback)(null, { stdout, stderr: '' })
-    return undefined
-  }) as unknown as typeof execFile)
-}
-
-function stubProbeFailure(error: Error): void {
-  execFileMock.mockImplementation(((...args: unknown[]) => {
-    ;(args.at(-1) as ExecFileCallback)(error)
-    return undefined
-  }) as unknown as typeof execFile)
-}
-
-beforeEach(() => {
-  execFileMock.mockReset()
-  // Why: `installManagedHooks` proves a skipped probe through the login-shell run log, so the
-  // probe must really spawn unless a case above stubs it. The mock loses `promisify.custom`,
-  // so the real `(error, stdout, stderr)` callback is reshaped into the `{ stdout, stderr }`
-  // that `promisify(execFile)` resolves in production.
-  execFileMock.mockImplementation(((...args: unknown[]) => {
-    const callback = args.at(-1) as ExecFileCallback
-    return (actualExecFile as (...callArgs: unknown[]) => unknown)(
-      ...args.slice(0, -1),
-      (error: Error | null, stdout: string, stderr: string) => callback(error, { stdout, stderr })
-    )
-  }) as unknown as typeof execFile)
-})
 
 const tempHomes: string[] = []
 const tempRoot = process.platform === 'win32' ? tmpdir() : '/tmp'
@@ -79,42 +34,59 @@ afterEach(async () => {
   await Promise.all(tempHomes.splice(0).map((home) => rm(home, { recursive: true, force: true })))
 })
 
+/** A probe shell named after a real shell, so the `-c` / `-lc` choice this
+ *  module derives from the basename is exercised rather than asserted on a mock.
+ *  Why a stub and not the user's shell: the probe swallows every failure into
+ *  its fallback, so a slow real login shell would silently assert nothing. */
+async function stubGrokShell(
+  home: string,
+  { shellName, printed }: { shellName: string; printed: string | null }
+): Promise<void> {
+  const shell = join(home, shellName)
+  // Why `printf '%s\\n'`: sh's `%s` does not interpret an escape, so a newline
+  // has to come from the format string for the first-line read to be exercised.
+  const body = printed === null ? 'exit 1' : `printf '%s\\n' ${JSON.stringify(printed)}`
+  await writeFile(shell, `#!/bin/sh\necho "$1" >> "${join(home, 'probe-flag')}"\n${body}\n`, 'utf8')
+  await chmod(shell, 0o755)
+  vi.stubEnv('SHELL', shell)
+}
+
+async function readProbeFlag(home: string): Promise<string> {
+  return (await readFile(join(home, 'probe-flag'), 'utf8')).trim()
+}
+
 describe.runIf(process.platform !== 'win32')('resolveRelayGrokHome', () => {
   it('uses the login-shell GROK_HOME and normalizes trailing separators', async () => {
-    vi.stubEnv('SHELL', '/bin/sh')
-    stubProbeOutput('/srv/grok///\n')
+    const home = await createTempHome()
+    await stubGrokShell(home, { shellName: 'sh', printed: '/srv/grok///' })
 
     await expect(resolveRelayGrokHome('/home/orca')).resolves.toBe('/srv/grok')
 
-    const [shell, args] = execFileMock.mock.calls[0] ?? []
-    expect(shell).toBe('/bin/sh')
     // `sh`/`dash` reject `-lc`, so the mode choice is part of the contract under test.
-    expect(args?.[0]).toBe('-c')
+    expect(await readProbeFlag(home)).toBe('-c')
   })
 
   it('passes -lc to a login shell that supports it', async () => {
-    vi.stubEnv('SHELL', '/bin/zsh')
-    stubProbeOutput('/srv/grok\n')
+    const home = await createTempHome()
+    await stubGrokShell(home, { shellName: 'zsh', printed: '/srv/grok' })
 
     await expect(resolveRelayGrokHome('/home/orca')).resolves.toBe('/srv/grok')
 
-    const [shell, args] = execFileMock.mock.calls[0] ?? []
-    expect(shell).toBe('/bin/zsh')
-    expect(args?.[0]).toBe('-lc')
+    expect(await readProbeFlag(home)).toBe('-lc')
   })
 
   it('falls back when the login-shell GROK_HOME is not an absolute POSIX path', async () => {
-    vi.stubEnv('SHELL', '/bin/sh')
-    stubProbeOutput('../relative\n')
+    const home = await createTempHome()
+    await stubGrokShell(home, { shellName: 'sh', printed: '../relative' })
 
     await expect(resolveRelayGrokHome('/home/orca')).resolves.toBe('/home/orca/.grok')
   })
 
-  // Why: this is the branch that made the old test flaky — pin it so a probe failure is
-  // an asserted fallback rather than an invisible substitution for a real answer.
-  it('falls back when the probe fails or times out', async () => {
-    vi.stubEnv('SHELL', '/bin/sh')
-    stubProbeFailure(Object.assign(new Error('spawn timed out'), { killed: true }))
+  // Why: pin the failure branch, so a probe failure is an asserted fallback
+  // rather than an invisible substitution for a real answer.
+  it('falls back when the probe exits non-zero', async () => {
+    const home = await createTempHome()
+    await stubGrokShell(home, { shellName: 'sh', printed: null })
 
     await expect(resolveRelayGrokHome('/home/orca')).resolves.toBe('/home/orca/.grok')
   })

--- a/src/main/agent-hooks/managed-hook-runtime.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.ts
@@ -1,7 +1,4 @@
-import { execFile } from 'node:child_process'
-import { basename } from 'node:path'
-import { homedir, userInfo } from 'node:os'
-import { promisify } from 'node:util'
+import { homedir } from 'node:os'
 import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers'
 import type { AgentHookTarget } from '../../shared/agent-hook-types'
 import { createManagedHookLocalFilesystem } from './managed-hook-local-filesystem'
@@ -10,68 +7,19 @@ import {
   readManagedHookHostIdentity,
   scopeManagedHookHostIdentity
 } from './managed-hook-owner-identity'
-
-const execFileAsync = promisify(execFile)
-const GROK_HOME_MAX_LENGTH = 4096
-const GROK_HOME_PROBE_TIMEOUT_MS = 8_000
+import {
+  resolveExecutionHostGrokHome,
+  resolveRedirectedExecutionHostCodexHome
+} from './execution-host-agent-homes'
 
 export type ManagedHookInstallSummary = {
   installers: number
   errors: number
 }
 
-function defaultGrokHome(home: string): string {
-  return `${home.replace(/\/+$/, '') || home}/.grok`
-}
-
-function hasControlCharacter(value: string): boolean {
-  return Array.from(value).some((character) => {
-    const code = character.charCodeAt(0)
-    return code <= 0x1f || code === 0x7f
-  })
-}
-
-function normalizeGrokHome(candidate: string): string | null {
-  if (
-    candidate.length === 0 ||
-    candidate.length > GROK_HOME_MAX_LENGTH ||
-    candidate !== candidate.trim() ||
-    !candidate.startsWith('/') ||
-    candidate.includes('\\') ||
-    hasControlCharacter(candidate)
-  ) {
-    return null
-  }
-  return candidate.replace(/\/+$/, '') || '/'
-}
-
-function resolveLoginShell(): string {
-  const candidate = process.env.SHELL || userInfo().shell || '/bin/sh'
-  if (!candidate.startsWith('/') || candidate.includes('\\') || hasControlCharacter(candidate)) {
-    return '/bin/sh'
-  }
-  return candidate
-}
-
-export async function resolveRelayGrokHome(home: string, signal?: AbortSignal): Promise<string> {
-  const fallback = defaultGrokHome(home)
-  try {
-    const shell = resolveLoginShell()
-    const shellName = basename(shell)
-    const mode = shellName === 'sh' || shellName === 'dash' ? '-c' : '-lc'
-    // Why: agent PTYs start login shells, so read the same profile-derived
-    // GROK_HOME without opening two additional SSH exec channels.
-    const { stdout } = await execFileAsync(
-      shell,
-      [mode, `printenv GROK_HOME | head -c ${GROK_HOME_MAX_LENGTH + 1}`],
-      { encoding: 'utf8', timeout: GROK_HOME_PROBE_TIMEOUT_MS, signal }
-    )
-    return normalizeGrokHome(stdout.split(/\r?\n/, 1)[0] ?? '') ?? fallback
-  } catch {
-    signal?.throwIfAborted()
-    return fallback
-  }
-}
+/** Kept as the relay-facing name for the Grok probe; the resolution itself now
+ *  lives with every other execution-host home. */
+export const resolveRelayGrokHome = resolveExecutionHostGrokHome
 
 export async function installManagedHooks(options?: {
   signal?: AbortSignal
@@ -85,7 +33,16 @@ export async function installManagedHooks(options?: {
     return { installers: 0, errors: 0 }
   }
   const home = homedir()
-  const grokHomeDir = await resolveRelayGrokHome(home, options?.signal)
+  const grokHomeDir = await resolveExecutionHostGrokHome(home, options?.signal)
+  options?.signal?.throwIfAborted()
+  // Why: gated on Codex being present so a host without it never pays for an
+  // app-server handshake, and only a home that is actually redirected is passed
+  // on — handing the installer the default `~/.codex` would change nothing about
+  // where hooks land while flipping every ordinary SSH host onto the
+  // redirected-runtime contract.
+  const codexHomeDir = agents.includes('codex')
+    ? await resolveRedirectedExecutionHostCodexHome(home, options?.signal)
+    : undefined
   options?.signal?.throwIfAborted()
   const hostIdentity = scopeManagedHookHostIdentity(
     await readManagedHookHostIdentity(),
@@ -99,6 +56,7 @@ export async function installManagedHooks(options?: {
         createManagedHookLocalFilesystem(),
         home,
         {
+          ...(codexHomeDir ? { codexHomeDir, useRuntimeInstallerHookContract: false } : {}),
           grokHomeDir,
           signal: options?.signal,
           agents

--- a/src/main/agent-hooks/remote-managed-hook-installers.ts
+++ b/src/main/agent-hooks/remote-managed-hook-installers.ts
@@ -20,6 +20,8 @@ export type RemoteManagedHookInstallOptions = {
   codexHomeDir?: string
   /** Skip the trust write when a redirected runtime config is seeded by the launch path. */
   deferTrustUntilConfigToml?: boolean
+  /** Whether `codexHomeDir` is a home Orca's own runtime installer also writes. */
+  useRuntimeInstallerHookContract?: boolean
   /** Explicit GROK_HOME for remote runtimes that redirect Grok's config. */
   grokHomeDir?: string
   /** Stops before starting the next installer when the owning relay request
@@ -47,7 +49,8 @@ const REMOTE_MANAGED_HOOK_INSTALLERS: readonly RemoteManagedHookInstaller[] = [
     (sftp, remoteHome, options) =>
       codexHookService.installRemote(sftp, remoteHome, {
         codexHomeDir: options?.codexHomeDir,
-        deferTrustUntilConfigToml: options?.deferTrustUntilConfigToml
+        deferTrustUntilConfigToml: options?.deferTrustUntilConfigToml,
+        useRuntimeInstallerHookContract: options?.useRuntimeInstallerHookContract
       })
   ],
   ['gemini', (sftp, remoteHome) => geminiHookService.installRemote(sftp, remoteHome)],

--- a/src/main/codex/codex-app-server-handshake.ts
+++ b/src/main/codex/codex-app-server-handshake.ts
@@ -2,10 +2,12 @@ import type { CodexAppServerConnection } from './codex-app-server-connection-typ
 
 const HANDSHAKE_TIMEOUT_MS = 15_000
 
+/** Returns the `initialize` result, which carries the CODEX_HOME the server
+ *  itself resolved — the only wrapper-aware answer available to a caller. */
 export async function initializeCodexAppServerConnection(
-  connection: CodexAppServerConnection
-): Promise<void> {
-  await connection.request(
+  connection: Pick<CodexAppServerConnection, 'request' | 'notify'>
+): Promise<unknown> {
+  const result = await connection.request(
     'initialize',
     {
       clientInfo: { name: 'orca_desktop', title: 'Orca', version: '0.0.0' },
@@ -19,4 +21,5 @@ export async function initializeCodexAppServerConnection(
     { timeoutMs: HANDSHAKE_TIMEOUT_MS }
   )
   connection.notify('initialized')
+  return result
 }

--- a/src/main/codex/codex-config-mirror-runtime-added-sections.test.ts
+++ b/src/main/codex/codex-config-mirror-runtime-added-sections.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { appendFileSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  appendFileSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import type * as NodeOs from 'node:os'
 import { join } from 'node:path'
@@ -218,12 +225,7 @@ describe('ownership between the source config and the managed home', () => {
   })
 
   it('keeps an added server through the same pass that honours a deletion', () => {
-    writeSystemConfig(
-      'model = "system-model"',
-      '',
-      '[mcp_servers.retired]',
-      'command = "retired"'
-    )
+    writeSystemConfig('model = "system-model"', '', '[mcp_servers.retired]', 'command = "retired"')
     syncSystemConfigIntoManagedCodexHome()
     addServerInsideManagedHome('[mcp_servers.added-in-orca]', 'command = "added"')
 

--- a/src/main/codex/codex-config-mirror-runtime-added-sections.test.ts
+++ b/src/main/codex/codex-config-mirror-runtime-added-sections.test.ts
@@ -357,3 +357,76 @@ describe('one table, however the two sides spell it', () => {
     expect(readRuntimeConfig()).not.toContain('[mcp_servers.foo.env]')
   })
 })
+
+describe('a table the source declares without a [header]', () => {
+  // Why a second describe: the spelling cases above are all header-vs-header.
+  // These are the other declaration sites — a dotted key, an inline table, and
+  // a plain value — each of which binds a name a runtime header would then
+  // redefine. Same unparseable-config outcome, reached a different way, so
+  // each site is pinned rather than trusted to a representative.
+  it('claims a table a dotted key declares inside a body', () => {
+    writeSystemConfig('[mcp_servers]', 'serena.command = "serena"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.serena]', 'command = "runtime"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('[mcp_servers.serena]')
+  })
+
+  it('claims a table an inline value declares inside a body', () => {
+    writeSystemConfig('[mcp_servers]', 'serena = { command = "serena" }')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.serena]', 'command = "runtime"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('[mcp_servers.serena]')
+  })
+
+  it('claims a name a plain scalar already binds', () => {
+    // Why a scalar counts: `model = "x"` leaves no table for `[model]` to add
+    // to, so emitting the header is a redefinition, not a merge.
+    writeSystemConfig('model = "system-model"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[model]', 'nested = true')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('[model]')
+    expect(readRuntimeConfig()).toContain('model = "system-model"')
+  })
+
+  it('claims a name an array value already binds', () => {
+    writeSystemConfig('model = "system-model"', 'items = [1, 2]')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[items]', 'nested = true')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('[items]')
+  })
+
+  it('claims a nested name a scalar inside a body binds', () => {
+    writeSystemConfig('[mcp_servers]', 'serena = "shorthand"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.serena]', 'command = "runtime"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('[mcp_servers.serena]')
+  })
+
+  it('still keeps a table the source only mentions as a bare header', () => {
+    // Why paired here: every rule above deletes, so one case has to prove the
+    // scan did not simply start dropping whatever it is shown.
+    writeSystemConfig('[mcp_servers]')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.added-in-orca]', 'command = "added"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).toContain('[mcp_servers.added-in-orca]')
+  })
+})
+

--- a/src/main/codex/codex-config-mirror-runtime-added-sections.test.ts
+++ b/src/main/codex/codex-config-mirror-runtime-added-sections.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { appendFileSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import type * as NodeOs from 'node:os'
+import { join } from 'node:path'
+
+const { getPathMock, homedirMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn<(name: string) => string>(),
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: getPathMock
+  }
+}))
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return {
+    ...actual,
+    homedir: homedirMock
+  }
+})
+
+import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+
+let fakeHomeDir: string
+let userDataDir: string
+let previousUserDataPath: string | undefined
+
+function getSystemConfigPath(): string {
+  return join(fakeHomeDir, '.codex', 'config.toml')
+}
+
+function getRuntimeHomePath(): string {
+  return join(userDataDir, 'codex-runtime-home', 'home')
+}
+
+function getRuntimeConfigPath(): string {
+  return join(getRuntimeHomePath(), 'config.toml')
+}
+
+function readRuntimeConfig(): string {
+  return readFileSync(getRuntimeConfigPath(), 'utf-8')
+}
+
+function readBaselineSections(runtimeHomePath = getRuntimeHomePath()): unknown {
+  const raw = readFileSync(join(runtimeHomePath, '.orca-config-settings-baseline.json'), 'utf-8')
+  return (JSON.parse(raw) as { mirroredSections?: unknown }).mirroredSections
+}
+
+function writeSystemConfig(...lines: string[]): void {
+  writeFileSync(getSystemConfigPath(), `${lines.join('\n')}\n`, 'utf-8')
+}
+
+/** Stands in for `codex mcp add` run inside an Orca-launched Codex: the table
+ *  exists only in the managed home, never in the user's ~/.codex. */
+function addServerInsideManagedHome(...lines: string[]): void {
+  appendFileSync(getRuntimeConfigPath(), `\n${lines.join('\n')}\n`, 'utf-8')
+}
+
+beforeEach(() => {
+  fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-added-home-'))
+  userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-added-user-data-'))
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataDir
+  homedirMock.mockReturnValue(fakeHomeDir)
+  getPathMock.mockImplementation((name: string) => {
+    if (name === 'userData') {
+      return userDataDir
+    }
+    throw new Error(`unexpected app.getPath(${name})`)
+  })
+  mkdirSync(join(fakeHomeDir, '.codex'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(fakeHomeDir, { recursive: true, force: true })
+  rmSync(userDataDir, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  vi.clearAllMocks()
+})
+
+describe('a config section added inside the managed Codex home', () => {
+  it('survives the next remirror', () => {
+    writeSystemConfig('model = "system-model"', '', '[mcp_servers.serena]', 'command = "serena"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.added-in-orca]', 'command = "added"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readRuntimeConfig()
+    expect(runtimeConfig).toContain('[mcp_servers.added-in-orca]')
+    expect(runtimeConfig).toContain('command = "added"')
+    // Why: the source's own server must still arrive; preservation is additive.
+    expect(runtimeConfig).toContain('[mcp_servers.serena]')
+  })
+
+  it('survives repeated remirrors rather than only the first', () => {
+    writeSystemConfig('model = "system-model"', '', '[mcp_servers.serena]', 'command = "serena"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.added-in-orca]', 'command = "added"')
+
+    syncSystemConfigIntoManagedCodexHome()
+    syncSystemConfigIntoManagedCodexHome()
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).toContain('[mcp_servers.added-in-orca]')
+  })
+
+  it('is byte-identical across repeated remirrors', () => {
+    writeSystemConfig('model = "system-model"', '', '[mcp_servers.serena]', 'command = "serena"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.added-in-orca]', 'command = "added"')
+
+    syncSystemConfigIntoManagedCodexHome()
+    const afterFirst = readRuntimeConfig()
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).toBe(afterFirst)
+  })
+
+  it('keeps its nested env and http_headers tables with the server they belong to', () => {
+    writeSystemConfig('model = "system-model"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome(
+      '[mcp_servers.added-in-orca]',
+      'command = "added"',
+      '',
+      '[mcp_servers.added-in-orca.env]',
+      'TOKEN = "value"',
+      '',
+      '[mcp_servers.added-in-orca.http_headers]',
+      'Authorization = "Bearer token"'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readRuntimeConfig()
+    expect(runtimeConfig).toContain('TOKEN = "value"')
+    expect(runtimeConfig).toContain('Authorization = "Bearer token"')
+    // Why: a nested table is only attached to its parent while it still follows
+    // it, so preserving the blocks out of order would silently reparent them.
+    expect(runtimeConfig.indexOf('[mcp_servers.added-in-orca]')).toBeLessThan(
+      runtimeConfig.indexOf('[mcp_servers.added-in-orca.env]')
+    )
+    expect(runtimeConfig.indexOf('[mcp_servers.added-in-orca.env]')).toBeLessThan(
+      runtimeConfig.indexOf('[mcp_servers.added-in-orca.http_headers]')
+    )
+  })
+
+  it('keeps more than one added server', () => {
+    writeSystemConfig('model = "system-model"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome(
+      '[mcp_servers.first-added]',
+      'command = "first"',
+      '',
+      '[mcp_servers.second-added]',
+      'command = "second"'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).toContain('[mcp_servers.first-added]')
+    expect(readRuntimeConfig()).toContain('[mcp_servers.second-added]')
+  })
+
+  it('records what the source contributed so a later pass can tell the two apart', () => {
+    writeSystemConfig('model = "system-model"', '', '[mcp_servers.serena]', 'command = "serena"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readBaselineSections()).toEqual(['[mcp_servers.serena]'])
+  })
+})
+
+describe('ownership between the source config and the managed home', () => {
+  it('lets the source win for a server name defined on both sides', () => {
+    writeSystemConfig('model = "system-model"', '', '[mcp_servers.shared]', 'command = "system"')
+    syncSystemConfigIntoManagedCodexHome()
+    writeFileSync(
+      getRuntimeConfigPath(),
+      ['model = "system-model"', '', '[mcp_servers.shared]', 'command = "runtime"', ''].join('\n'),
+      'utf-8'
+    )
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    const runtimeConfig = readRuntimeConfig()
+    expect(runtimeConfig).toContain('command = "system"')
+    expect(runtimeConfig).not.toContain('command = "runtime"')
+  })
+
+  it('does not resurrect a server the user deleted from the source config', () => {
+    writeSystemConfig(
+      'model = "system-model"',
+      '',
+      '[mcp_servers.serena]',
+      'command = "serena"',
+      '',
+      '[mcp_servers.retired]',
+      'command = "retired"'
+    )
+    syncSystemConfigIntoManagedCodexHome()
+    expect(readRuntimeConfig()).toContain('[mcp_servers.retired]')
+
+    writeSystemConfig('model = "system-model"', '', '[mcp_servers.serena]', 'command = "serena"')
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('[mcp_servers.retired]')
+    expect(readRuntimeConfig()).toContain('[mcp_servers.serena]')
+  })
+
+  it('keeps an added server through the same pass that honours a deletion', () => {
+    writeSystemConfig(
+      'model = "system-model"',
+      '',
+      '[mcp_servers.retired]',
+      'command = "retired"'
+    )
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.added-in-orca]', 'command = "added"')
+
+    writeSystemConfig('model = "system-model"')
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('[mcp_servers.retired]')
+    expect(readRuntimeConfig()).toContain('[mcp_servers.added-in-orca]')
+  })
+
+  it('keeps an unrecognised runtime section when no record of the source exists', () => {
+    // Why: a home mirrored by an older Orca has no recorded section set. The
+    // managed home is the only copy of anything added inside it, so an
+    // unanswered question must not authorize a deletion.
+    writeSystemConfig('model = "system-model"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.added-in-orca]', 'command = "added"')
+    rmSync(join(getRuntimeHomePath(), '.orca-config-settings-baseline.json'), { force: true })
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).toContain('[mcp_servers.added-in-orca]')
+  })
+
+  it('lets an inline table in the source out-rank the same table in the managed home', () => {
+    // Why: TOML spells one table two ways. `tui = { .. }` in the source claims
+    // `[tui]`, or the runtime's header form would look runtime-added and stick.
+    writeSystemConfig('model = "system-model"', 'tui = { animations = false }')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[tui]', 'theme = "runtime-only"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('theme = "runtime-only"')
+  })
+})
+
+describe('a per-account managed home passed explicitly', () => {
+  it('follows the same ownership rules as the default host home', () => {
+    // Why: WSL and per-account homes reach the mirror through these explicit
+    // paths rather than the host defaults, and must not diverge from them.
+    const accountHome = join(userDataDir, 'codex-accounts', 'account-1', 'home')
+    mkdirSync(accountHome, { recursive: true })
+    const homes = {
+      runtimeHomePath: accountHome,
+      systemHomePath: join(fakeHomeDir, '.codex')
+    }
+    writeSystemConfig('model = "system-model"', '', '[mcp_servers.retired]', 'command = "retired"')
+    syncSystemConfigIntoManagedCodexHome(homes)
+    appendFileSync(
+      join(accountHome, 'config.toml'),
+      '\n[mcp_servers.added-in-orca]\ncommand = "added"\n',
+      'utf-8'
+    )
+
+    writeSystemConfig('model = "system-model"')
+    syncSystemConfigIntoManagedCodexHome(homes)
+
+    const accountConfig = readFileSync(join(accountHome, 'config.toml'), 'utf-8')
+    expect(accountConfig).toContain('[mcp_servers.added-in-orca]')
+    expect(accountConfig).not.toContain('[mcp_servers.retired]')
+    expect(readBaselineSections(accountHome)).toEqual([])
+  })
+})

--- a/src/main/codex/codex-config-mirror-runtime-added-sections.test.ts
+++ b/src/main/codex/codex-config-mirror-runtime-added-sections.test.ts
@@ -183,7 +183,7 @@ describe('a config section added inside the managed Codex home', () => {
 
     syncSystemConfigIntoManagedCodexHome()
 
-    expect(readBaselineSections()).toEqual(['[mcp_servers.serena]'])
+    expect(readBaselineSections()).toEqual(['["mcp_servers","serena"]'])
   })
 })
 
@@ -288,5 +288,72 @@ describe('a per-account managed home passed explicitly', () => {
     expect(accountConfig).toContain('[mcp_servers.added-in-orca]')
     expect(accountConfig).not.toContain('[mcp_servers.retired]')
     expect(readBaselineSections(accountHome)).toEqual([])
+  })
+})
+
+describe('one table, however the two sides spell it', () => {
+  // Why these are their own describe: before canonical keys a spelling
+  // difference read as "the source does not declare this", so the mirror
+  // emitted BOTH spellings. A duplicate table is an unparseable config.toml —
+  // a worse outcome than the setting loss this change exists to fix, so each
+  // spelling is pinned separately rather than trusted to one representative.
+  function expectSingleServerTable(runtimeConfig: string): void {
+    const declarations = runtimeConfig.match(/^\s*\[\[?[^\]]*serena[^\]]*\]\]?/gm) ?? []
+    expect(declarations).toHaveLength(1)
+  }
+
+  it('treats a whitespace-padded source header as the same table', () => {
+    writeSystemConfig('[ mcp_servers.serena ]', 'command = "serena"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.serena]', 'command = "runtime"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expectSingleServerTable(readRuntimeConfig())
+    expect(readRuntimeConfig()).toContain('command = "serena"')
+  })
+
+  it('treats a quoted source key as the same table as a bare one', () => {
+    writeSystemConfig('[mcp_servers."serena"]', 'command = "serena"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.serena]', 'command = "runtime"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expectSingleServerTable(readRuntimeConfig())
+  })
+
+  it('treats an array-of-tables name as claimed by a plain source table', () => {
+    // Why: a table and an array of tables cannot share a name, so emitting both
+    // is the same fatal shape as a duplicate.
+    writeSystemConfig('[profiles]', 'x = 1')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[[profiles]]', 'x = 2')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig().match(/^\s*\[\[?profiles\]\]?/gm) ?? []).toHaveLength(1)
+  })
+
+  it('lets a dotted source key claim the whole table path it declares', () => {
+    writeSystemConfig('mcp_servers.foo.command = "x"')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.foo]', 'command = "runtime"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('[mcp_servers.foo]')
+  })
+
+  it('does not extend a source inline table with a runtime sub-table', () => {
+    // Why: TOML forbids it outright, so emitting the sub-table would produce a
+    // config Codex refuses rather than a merge the user wanted.
+    writeSystemConfig('mcp_servers = { foo = { command = "x" } }')
+    syncSystemConfigIntoManagedCodexHome()
+    addServerInsideManagedHome('[mcp_servers.foo.env]', 'TOKEN = "value"')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).not.toContain('[mcp_servers.foo.env]')
   })
 })

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -16,6 +16,11 @@ import {
   type CodexSettingsPromotionPlan
 } from './config-settings-promotion'
 import { readCodexSettingsBaseline } from './config-settings-baseline'
+import {
+  createRuntimeAddedSectionFilter,
+  getCodexConfigSectionKeys,
+  type MirroredCodexSectionKeys
+} from './config-toml-runtime-added-sections'
 import { getCodexConfigSyncStatus, reportCodexConfigSyncOutcome } from './config-sync-stall'
 import { preserveRuntimeConflictValues } from './codex-config-settings-preservation'
 import {
@@ -97,7 +102,8 @@ export function syncSystemConfigIntoManagedCodexHome(
     homes.runtimeHomePath,
     new Map(
       [...promotionPlan.conflicts].filter(([key]) => mirrorResult.preservedConflictKeys.has(key))
-    )
+    ),
+    mirrorResult.mirroredSectionKeys
   )
 }
 
@@ -138,7 +144,11 @@ export function syncSystemConfigIntoLegacySharedCodexHome(
     runtimeConfigBeforeMirror !== null
       ? mergeSystemCodexConfigIntoRuntime(
           runtimeConfigBeforeMirror,
-          prepareSystemConfigForRuntimeMirror(rawSystemConfig, sourceConfigDir)
+          prepareSystemConfigForRuntimeMirror(rawSystemConfig, sourceConfigDir),
+          // Why: this lane refreshes the same home the managed lane records for,
+          // so it reads that record but never advances it — a one-way refresh
+          // for retained PTYs must not claim authority over what was mirrored.
+          readCodexSettingsBaseline(homes.runtimeHomePath)?.mirroredSectionKeys ?? null
         )
       : prepareSystemConfigForFreshRuntimeMirror(rawSystemConfig, sourceConfigDir)
   if (runtimeConfigBeforeMirror === nextRuntimeConfig) {
@@ -152,7 +162,13 @@ export function syncSystemConfigIntoLegacySharedCodexHome(
 type CodexConfigMirrorResult =
   | { status: 'skipped-missing-source' }
   | { status: 'refused-indeterminate'; error: unknown }
-  | { status: 'mirrored'; preservedConflictKeys: ReadonlySet<string> }
+  | {
+      status: 'mirrored'
+      preservedConflictKeys: ReadonlySet<string>
+      /** What the source contributed on this pass, so the next one can tell a
+       *  section deleted at the source from one added inside the managed home. */
+      mirroredSectionKeys: ReadonlySet<string>
+    }
 
 function syncSystemConfigIntoManagedCodexHomeUnsafe(
   { runtimeHomePath, systemHomePath, systemConfigDir }: CodexSettingsPromotionHomes,
@@ -181,30 +197,35 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(
   if (rawSystemConfig.trim() === '') {
     return runtimeConfigExists
       ? { status: 'skipped-missing-source' }
-      : { status: 'mirrored', preservedConflictKeys: new Set() }
+      : { status: 'mirrored', preservedConflictKeys: new Set(), mirroredSectionKeys: new Set() }
   }
 
   const sourceConfigDir = resolveCodexConfigMirrorSourceDirectory(systemHomePath, systemConfigDir)
+  const systemConfig = prepareSystemConfigForRuntimeMirror(rawSystemConfig, sourceConfigDir)
+  const mirroredSectionKeys = getCodexConfigSectionKeys(systemConfig)
   if (!runtimeConfigExists) {
     writeFileAtomically(
       runtimeConfigPath,
       prepareSystemConfigForFreshRuntimeMirror(rawSystemConfig, sourceConfigDir)
     )
-    return { status: 'mirrored', preservedConflictKeys: new Set() }
+    return { status: 'mirrored', preservedConflictKeys: new Set(), mirroredSectionKeys }
   }
 
-  const systemConfig = prepareSystemConfigForRuntimeMirror(rawSystemConfig, sourceConfigDir)
   // Why: reuse the bytes already observed above rather than re-reading. A second
   // read could succeed where the first failed and re-open the gap this closes.
   const runtimeConfig = runtimeConfigObservation.value
   const preserved = preserveRuntimeConflictValues(
-    mergeSystemCodexConfigIntoRuntime(runtimeConfig, systemConfig),
+    mergeSystemCodexConfigIntoRuntime(
+      runtimeConfig,
+      systemConfig,
+      readCodexSettingsBaseline(runtimeHomePath)?.mirroredSectionKeys ?? null
+    ),
     promotionPlan.runtimeValuesToPreserve
   )
   if (preserved.content !== runtimeConfig) {
     writeFileAtomically(runtimeConfigPath, preserved.content)
   }
-  return { status: 'mirrored', preservedConflictKeys: preserved.keys }
+  return { status: 'mirrored', preservedConflictKeys: preserved.keys, mirroredSectionKeys }
 }
 
 export function resolveCodexConfigMirrorSourceDirectory(
@@ -236,7 +257,11 @@ export function prepareSystemConfigForFreshRuntimeMirror(
   return stripRuntimeOwnedTomlSections(prepareSystemConfigForRuntimeMirror(config, systemConfigDir))
 }
 
-function mergeSystemCodexConfigIntoRuntime(runtimeConfig: string, systemConfig: string): string {
+function mergeSystemCodexConfigIntoRuntime(
+  runtimeConfig: string,
+  systemConfig: string,
+  mirroredSectionKeys: MirroredCodexSectionKeys
+): string {
   const runtimeSections = deduplicateProjectTomlSections(getTomlSections(runtimeConfig))
   const runtimeProjectHeaders = new Set(
     runtimeSections
@@ -259,20 +284,28 @@ function mergeSystemCodexConfigIntoRuntime(runtimeConfig: string, systemConfig: 
       .filter((section) => getProjectTrustLevel(section.block) === 'trusted')
       .map((section) => getTomlSectionHeaderKey(section.header))
   )
-  // Why: ordinary Codex settings should mirror ~/.codex exactly; runtime hook
-  // trust and project trust are written under Orca's managed CODEX_HOME and
-  // must survive the copy unless the user explicitly revoked project trust in
-  // the system config.
+  // Why: runtime hook trust and project trust are written under Orca's managed
+  // CODEX_HOME and must survive the copy unless the user explicitly revoked
+  // project trust in the system config. Every other runtime section is kept or
+  // dropped by what the source contributed last time, so a table written
+  // through an Orca-launched Codex is not rebuilt away on the next pass.
+  const keepRuntimeAddedSection = createRuntimeAddedSectionFilter({
+    systemConfig,
+    mirroredSectionKeys
+  })
   return joinTomlBlocks([
     stripRuntimeOwnedTomlSections(systemConfig, runtimeProjectHeaders),
     ...runtimeSections
-      .filter((section) => isRuntimePreservedTomlSection(section.header))
-      .filter(
-        (section) =>
+      .filter((section) => {
+        if (!isRuntimePreservedTomlSection(section.header)) {
+          return keepRuntimeAddedSection(section)
+        }
+        return (
           !isRuntimeProjectTomlSection(section.header) ||
           !systemUntrustedProjectHeaders.has(getRevocationTomlSectionHeaderKey(section.header)) ||
           systemTrustedProjectHeaders.has(getTomlSectionHeaderKey(section.header))
-      )
+        )
+      })
       .map((section) => section.block)
   ])
 }

--- a/src/main/codex/codex-hook-remote-install.ts
+++ b/src/main/codex/codex-hook-remote-install.ts
@@ -26,7 +26,14 @@ import { getManagedScript } from './codex-hook-script'
 export async function installCodexHooksRemote(
   sftp: SFTPWrapper,
   remoteHome: string,
-  options?: { codexHomeDir?: string; deferTrustUntilConfigToml?: boolean }
+  options?: {
+    codexHomeDir?: string
+    deferTrustUntilConfigToml?: boolean
+    /** Whether this home is also written by Orca's own runtime installer.
+     *  Defaults to the historical coupling with `codexHomeDir`; an SSH host
+     *  whose Codex merely points elsewhere keeps the guest-home contract. */
+    useRuntimeInstallerHookContract?: boolean
+  }
 ): Promise<AgentHookInstallStatus> {
   const codexHomeBase =
     options?.codexHomeDir?.replace(/\/$/, '') ?? `${remoteHome.replace(/\/$/, '')}/.codex`
@@ -35,7 +42,10 @@ export async function installCodexHooksRemote(
   // Redirected WSL homes must use the same script location and command shape
   // as the runtime installer; two representations of one hooks.json race
   // into stale trust keys. Plain SSH keeps its guest-home script contract.
-  const redirectedCodexHome = options?.codexHomeDir?.replace(/\/$/, '')
+  const redirectedCodexHome =
+    (options?.useRuntimeInstallerHookContract ?? options?.codexHomeDir !== undefined)
+      ? options?.codexHomeDir?.replace(/\/$/, '')
+      : undefined
   const remoteScriptPath = redirectedCodexHome
     ? `${redirectedCodexHome}/.orca/agent-hooks/codex-hook.sh`
     : `${remoteHome.replace(/\/$/, '')}/.orca/agent-hooks/codex-hook.sh`

--- a/src/main/codex/codex-hook-service-implementation.ts
+++ b/src/main/codex/codex-hook-service-implementation.ts
@@ -240,7 +240,11 @@ export class CodexHookService {
   installRemote(
     sftp: SFTPWrapper,
     remoteHome: string,
-    options?: { codexHomeDir?: string; deferTrustUntilConfigToml?: boolean }
+    options?: {
+      codexHomeDir?: string
+      deferTrustUntilConfigToml?: boolean
+      useRuntimeInstallerHookContract?: boolean
+    }
   ): Promise<AgentHookInstallStatus> {
     return installCodexHooksRemote(sftp, remoteHome, options)
   }

--- a/src/main/codex/config-settings-baseline.ts
+++ b/src/main/codex/config-settings-baseline.ts
@@ -4,6 +4,7 @@ import { JsonTextStructureCapacityError } from '../../shared/json-text-structure
 import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 import { join } from 'node:path'
 import { readAgentStateFileSync, readAgentStateJsonFileSync } from '../agent-state-file-reader'
+import type { MirroredCodexSectionKeys } from './config-toml-runtime-added-sections'
 
 const SETTINGS_BASELINE_FILE = '.orca-config-settings-baseline.json'
 
@@ -15,12 +16,18 @@ export type CodexSettingsConflict = {
 export type CodexSettingsBaseline = {
   settings: ReadonlyMap<string, string | null>
   conflicts: ReadonlyMap<string, CodexSettingsConflict>
+  /** Section keys the last mirror copied in; `null` when none was recorded. */
+  mirroredSectionKeys: MirroredCodexSectionKeys
 }
 
+// Why: the section set is an added optional field at version 2 on purpose. A
+// version bump would make an older Orca reject the whole baseline as invalid
+// and rebuild it, stranding a runtime setting change it had not yet promoted.
 type StoredSettingsBaseline = {
   version: 1 | 2
   settings: Record<string, string | null>
   conflicts?: Record<string, CodexSettingsConflict>
+  mirroredSections?: string[]
 }
 
 /**
@@ -74,7 +81,12 @@ function readParsedCodexSettingsBaseline(
         conflicts.set(key, conflict)
       }
     }
-    return { settings, conflicts }
+    // Why: absent stays `null` rather than collapsing to an empty set, which
+    // would claim the source contributed nothing and authorize deletions.
+    const mirroredSectionKeys = Array.isArray(parsed.mirroredSections)
+      ? new Set(parsed.mirroredSections.filter((key): key is string => typeof key === 'string'))
+      : null
+    return { settings, conflicts, mirroredSectionKeys }
   } catch (error) {
     // Why: invalid baseline state is still `null` — resetting it is the intent,
     // and only a read that FAILED must be preserved.
@@ -101,6 +113,11 @@ export function writeCodexSettingsBaseline(
   }
   if (baseline.conflicts.size > 0) {
     file.conflicts = Object.fromEntries(baseline.conflicts)
+  }
+  if (baseline.mirroredSectionKeys !== null) {
+    // Why: sorted so a re-mirror that changed nothing serializes identically
+    // and the unchanged-bytes short-circuit below still skips the write.
+    file.mirroredSections = [...baseline.mirroredSectionKeys].sort()
   }
   const baselinePath = getCodexSettingsBaselinePath(runtimeHomePath)
   const serialized = `${JSON.stringify(file, null, 2)}\n`

--- a/src/main/codex/config-settings-promotion.ts
+++ b/src/main/codex/config-settings-promotion.ts
@@ -15,12 +15,14 @@ import { parseTomlKeyPath, parseTomlTableHeaderPath } from './config-toml-key-pa
 import { tuiStructuredKey, upsertPromotedSettingsInContent } from './codex-config-settings-upsert'
 import {
   observeCodexSettingsBaseline,
+  readCodexSettingsBaseline,
   writeCodexSettingsBaseline,
   type CodexSettingsBaseline,
   type CodexSettingsConflict
 } from './config-settings-baseline'
 import { resolveUntrackedCodexSetting } from './config-settings-conflict-resolution'
 import { extractOrdinaryCodexSettings } from './config-toml-runtime-owned-sections'
+import type { MirroredCodexSectionKeys } from './config-toml-runtime-added-sections'
 
 // Why: the mirror reverts in-Codex config changes each launch; promotion salvages them by diffing the last baseline.
 
@@ -161,7 +163,10 @@ function readPromotedSettingValues(configPath: string): Map<string, TopLevelSett
  */
 export function snapshotCodexRuntimeSettingsBaseline(
   runtimeHomePath = getOrcaManagedCodexHomePath(),
-  conflicts: ReadonlyMap<string, CodexSettingsConflict> = new Map()
+  conflicts: ReadonlyMap<string, CodexSettingsConflict> = new Map(),
+  /** Omit on a pass that did not mirror, to carry the recorded set forward
+   *  instead of erasing the only record of what the source last contributed. */
+  mirroredSectionKeys?: MirroredCodexSectionKeys
 ): void {
   try {
     const runtimeTomlPath = join(runtimeHomePath, 'config.toml')
@@ -175,7 +180,14 @@ export function snapshotCodexRuntimeSettingsBaseline(
         settings.set(key, value?.raw ?? null)
       }
     }
-    writeCodexSettingsBaseline(runtimeHomePath, { settings, conflicts })
+    writeCodexSettingsBaseline(runtimeHomePath, {
+      settings,
+      conflicts,
+      mirroredSectionKeys:
+        mirroredSectionKeys === undefined
+          ? (readCodexSettingsBaseline(runtimeHomePath)?.mirroredSectionKeys ?? null)
+          : mirroredSectionKeys
+    })
   } catch (error) {
     console.warn('[codex-settings-promotion] failed to snapshot settings baseline', error)
   }

--- a/src/main/codex/config-toml-runtime-added-sections.ts
+++ b/src/main/codex/config-toml-runtime-added-sections.ts
@@ -1,0 +1,92 @@
+import {
+  createTomlLineScanState,
+  isTomlStructuralLine,
+  updateTomlLineScanState
+} from './config-toml-line-scan'
+import { parseTomlKeyPath } from './config-toml-key-path'
+import {
+  getTomlSectionHeaderKey,
+  getTomlSections,
+  type TomlSection
+} from './config-toml-runtime-owned-sections'
+
+/**
+ * The section keys the last mirror copied in from the system config.
+ *
+ * `null` is not an empty set. An empty set claims the source contributed no
+ * sections; `null` says no mirror has recorded an answer yet, and no runtime
+ * section may be deleted on its authority.
+ */
+export type MirroredCodexSectionKeys = ReadonlySet<string> | null
+
+export function getCodexConfigSectionKeys(config: string): ReadonlySet<string> {
+  return new Set([
+    ...getTomlSections(config).map((section) => getTomlSectionHeaderKey(section.header)),
+    ...getPreambleTableKeys(config)
+  ])
+}
+
+/**
+ * Table names a top-level assignment claims before the first `[table]` header.
+ *
+ * TOML spells the same table two ways, so `tui = { animations = false }` claims
+ * `[tui]` just as a header would. Without this the source's inline shape would
+ * not out-rank a `[tui]` table in the runtime home, and a setting the promotion
+ * pass deliberately reverted would come back looking runtime-added.
+ */
+function getPreambleTableKeys(config: string): string[] {
+  const lines = config.split('\n')
+  const preambleEnd = getTomlSections(config)[0]?.start ?? lines.length
+  const keys: string[] = []
+  let scanState = createTomlLineScanState()
+  for (let index = 0; index < preambleEnd; index += 1) {
+    const line = lines[index] ?? ''
+    const parsed = isTomlStructuralLine(scanState) ? parseTomlKeyPath(line) : null
+    // Why: only an assignment claims a name; a bare word on its own does not.
+    const assigned = parsed ? line.slice(parsed.end).trimStart() : ''
+    if (parsed && assigned.startsWith('=')) {
+      // Why: a scalar names no table, so `model = "x"` must not claim `[model]`
+      // and leave a phantom key in the record of what the source contributed.
+      // A dotted key and an inline table both do define one.
+      const definesTable =
+        parsed.segments.length > 1 || assigned.slice(1).trimStart().startsWith('{')
+      if (definesTable) {
+        keys.push(`[${parsed.segments[0]}]`)
+      }
+    }
+    scanState = updateTomlLineScanState(scanState, line)
+  }
+  return keys
+}
+
+/**
+ * Separates a runtime section the user added inside Orca's managed CODEX_HOME
+ * from one the mirror copied in and the user has since deleted at the source.
+ *
+ * Without this the mirror rebuilds every ordinary section from the system config
+ * and keeps only a fixed allowlist of runtime-owned tables, so anything written
+ * through an Orca-launched Codex — `[mcp_servers.*]` above all — is dropped on
+ * the next pass.
+ */
+export function createRuntimeAddedSectionFilter({
+  systemConfig,
+  mirroredSectionKeys
+}: {
+  systemConfig: string
+  mirroredSectionKeys: MirroredCodexSectionKeys
+}): (section: TomlSection) => boolean {
+  const systemSectionKeys = getCodexConfigSectionKeys(systemConfig)
+  return (section) => {
+    const key = getTomlSectionHeaderKey(section.header)
+    // Why: the system half of the merge already carries every section it
+    // defines, so the source wins for a name present on both sides.
+    if (systemSectionKeys.has(key)) {
+      return false
+    }
+    // Why: recorded as mirrored in and now absent at the source means the user
+    // deleted it there, and re-appending it would undo that deletion. With no
+    // recorded set the section is kept instead: the managed home is the only
+    // copy of anything added inside it, so deleting on a guess is unrecoverable.
+    return mirroredSectionKeys === null || !mirroredSectionKeys.has(key)
+  }
+}

--- a/src/main/codex/config-toml-runtime-added-sections.ts
+++ b/src/main/codex/config-toml-runtime-added-sections.ts
@@ -1,5 +1,6 @@
 import {
   createTomlLineScanState,
+  getTomlTableHeader,
   isTomlStructuralLine,
   updateTomlLineScanState
 } from './config-toml-line-scan'
@@ -45,46 +46,57 @@ export function getCodexConfigSectionKeys(config: string): ReadonlySet<string> {
   return keys
 }
 
-type PreambleTableClaims = {
-  /** Tables the preamble declares, including every ancestor it closes. */
-  tables: ReadonlySet<string>
-  /** Tables assigned as an inline table, which no sub-table may extend. */
-  inlineTables: readonly (readonly string[])[]
+type DeclaredTableClaims = {
+  /** Every table path an assignment closes, including its prefixes. */
+  closed: ReadonlySet<string>
+  /** Full key paths an assignment binds. Nothing may be declared at or below
+   *  one: a scalar or array leaves no table to extend, and TOML forbids
+   *  extending an inline table with a sub-table. */
+  bindings: readonly (readonly string[])[]
 }
 
 /**
- * Tables a top-level assignment declares before the first `[table]` header.
+ * Table paths the config closes by assigning to them, wherever that happens.
  *
- * TOML spells one table several ways: `tui = { animations = false }` and
- * `tui.theme = "x"` both declare `tui` just as `[tui]` would, and once declared
- * that way a later `[tui]` header is invalid rather than additive. Ancestors
- * count for the same reason — `a.b.c = 1` closes `a` and `a.b` as well.
+ * A table is declared by more than a `[header]`. `tui = { animations = false }`
+ * declares `tui`, `a.b.c = 1` declares `a` and `a.b`, and even `model = "x"`
+ * binds `model` so that a later `[model]` is a redefinition rather than an
+ * addition. All of it applies inside a table body too, relative to the
+ * enclosing header — `[a]` followed by `b.c = 1` closes `a.b`.
+ *
+ * This scan has to see every such site. A missed one lets the mirror emit a
+ * runtime table beside a source name that already owns it, and two declarations
+ * of one name is a config.toml Codex refuses to parse.
  */
-function readPreambleTableClaims(config: string): PreambleTableClaims {
-  const lines = config.split('\n')
-  const preambleEnd = getTomlSections(config)[0]?.start ?? lines.length
-  const tables = new Set<string>()
-  const inlineTables: string[][] = []
+function readDeclaredTableClaims(config: string): DeclaredTableClaims {
+  const closed = new Set<string>()
+  const bindings: string[][] = []
   let scanState = createTomlLineScanState()
-  for (let index = 0; index < preambleEnd; index += 1) {
-    const line = lines[index] ?? ''
-    const parsed = isTomlStructuralLine(scanState) ? parseTomlKeyPath(line) : null
-    const assigned = parsed ? line.slice(parsed.end).trimStart() : ''
-    if (parsed && assigned.startsWith('=')) {
-      const isInlineTable = assigned.slice(1).trimStart().startsWith('{')
-      // Why: `a.b.c = 1` declares table `a.b`; `a = { .. }` declares `a`. A
-      // plain scalar declares none, so `model = "x"` claims no `[model]`.
-      const tablePath = isInlineTable ? parsed.segments : parsed.segments.slice(0, -1)
-      for (let depth = 1; depth <= tablePath.length; depth += 1) {
-        tables.add(canonicalTablePath(tablePath.slice(0, depth)))
+  // `null` while inside a header this module could not parse: claiming at the
+  // wrong depth is worse than claiming nothing, and nothing matches main.
+  let enclosing: string[] | null = []
+  for (const line of config.split('\n')) {
+    if (!isTomlStructuralLine(scanState)) {
+      scanState = updateTomlLineScanState(scanState, line)
+      continue
+    }
+    const header = getTomlTableHeader(line)
+    if (header !== null) {
+      enclosing = parseTomlTableHeaderPath(header)?.segments.slice() ?? null
+      scanState = updateTomlLineScanState(scanState, line)
+      continue
+    }
+    const parsed = enclosing === null ? null : parseTomlKeyPath(line)
+    if (enclosing !== null && parsed && line.slice(parsed.end).trimStart().startsWith('=')) {
+      const path = [...enclosing, ...parsed.segments]
+      for (let depth = 1; depth <= path.length; depth += 1) {
+        closed.add(canonicalTablePath(path.slice(0, depth)))
       }
-      if (isInlineTable && tablePath.length > 0) {
-        inlineTables.push([...tablePath])
-      }
+      bindings.push(path)
     }
     scanState = updateTomlLineScanState(scanState, line)
   }
-  return { tables, inlineTables }
+  return { closed, bindings }
 }
 
 /**
@@ -104,7 +116,7 @@ export function createRuntimeAddedSectionFilter({
   mirroredSectionKeys: MirroredCodexSectionKeys
 }): (section: TomlSection) => boolean {
   const sourceSectionKeys = getCodexConfigSectionKeys(systemConfig)
-  const preamble = readPreambleTableClaims(systemConfig)
+  const declared = readDeclaredTableClaims(systemConfig)
   return (section) => {
     const parsed = parseTomlTableHeaderPath(section.header)
     // Why: a header that does not parse cannot be compared against the source,
@@ -117,12 +129,12 @@ export function createRuntimeAddedSectionFilter({
     const key = canonicalTablePath(parsed.segments)
     // Why: the system half of the merge already carries every table it
     // declares, so the source wins for a name present on both sides.
-    if (sourceSectionKeys.has(key) || preamble.tables.has(key)) {
+    if (sourceSectionKeys.has(key) || declared.closed.has(key)) {
       return false
     }
-    // Why: TOML forbids extending an inline table with a sub-table, so a
-    // runtime `[a.b.env]` under a source `a = { b = .. }` cannot be emitted.
-    if (preamble.inlineTables.some((path) => isPrefixOf(path, parsed.segments))) {
+    // Why: a bound name owns everything beneath it. `[a.b.env]` cannot extend a
+    // source `a = { b = .. }`, and nothing at all can nest under `a = "x"`.
+    if (declared.bindings.some((path) => isPrefixOf(path, parsed.segments))) {
       return false
     }
     // Why: recorded as mirrored in and now absent at the source means the user

--- a/src/main/codex/config-toml-runtime-added-sections.ts
+++ b/src/main/codex/config-toml-runtime-added-sections.ts
@@ -3,12 +3,8 @@ import {
   isTomlStructuralLine,
   updateTomlLineScanState
 } from './config-toml-line-scan'
-import { parseTomlKeyPath } from './config-toml-key-path'
-import {
-  getTomlSectionHeaderKey,
-  getTomlSections,
-  type TomlSection
-} from './config-toml-runtime-owned-sections'
+import { parseTomlKeyPath, parseTomlTableHeaderPath } from './config-toml-key-path'
+import { getTomlSections, type TomlSection } from './config-toml-runtime-owned-sections'
 
 /**
  * The section keys the last mirror copied in from the system config.
@@ -19,54 +15,86 @@ import {
  */
 export type MirroredCodexSectionKeys = ReadonlySet<string> | null
 
+/**
+ * One key per table, whatever spelling declared it.
+ *
+ * `[a.b]`, `[ a.b ]`, `[a."b"]` and `[[a.b]]` are all one table to Codex, so
+ * they must be one key here. Comparing raw header text instead lets a spelling
+ * difference read as "the source does not declare this", and the mirror then
+ * emits both — a duplicate table, and a config.toml Codex cannot parse. The
+ * array-of-tables marker is dropped deliberately: a table and an array of
+ * tables cannot share a name either.
+ */
+function canonicalTablePath(segments: readonly string[]): string {
+  return JSON.stringify(segments)
+}
+
+function isPrefixOf(prefix: readonly string[], segments: readonly string[]): boolean {
+  return prefix.length <= segments.length && prefix.every((part, index) => segments[index] === part)
+}
+
+/** Canonical keys for the tables a config declares with a `[header]`. */
 export function getCodexConfigSectionKeys(config: string): ReadonlySet<string> {
-  return new Set([
-    ...getTomlSections(config).map((section) => getTomlSectionHeaderKey(section.header)),
-    ...getPreambleTableKeys(config)
-  ])
+  const keys = new Set<string>()
+  for (const section of getTomlSections(config)) {
+    const parsed = parseTomlTableHeaderPath(section.header)
+    if (parsed) {
+      keys.add(canonicalTablePath(parsed.segments))
+    }
+  }
+  return keys
+}
+
+type PreambleTableClaims = {
+  /** Tables the preamble declares, including every ancestor it closes. */
+  tables: ReadonlySet<string>
+  /** Tables assigned as an inline table, which no sub-table may extend. */
+  inlineTables: readonly (readonly string[])[]
 }
 
 /**
- * Table names a top-level assignment claims before the first `[table]` header.
+ * Tables a top-level assignment declares before the first `[table]` header.
  *
- * TOML spells the same table two ways, so `tui = { animations = false }` claims
- * `[tui]` just as a header would. Without this the source's inline shape would
- * not out-rank a `[tui]` table in the runtime home, and a setting the promotion
- * pass deliberately reverted would come back looking runtime-added.
+ * TOML spells one table several ways: `tui = { animations = false }` and
+ * `tui.theme = "x"` both declare `tui` just as `[tui]` would, and once declared
+ * that way a later `[tui]` header is invalid rather than additive. Ancestors
+ * count for the same reason — `a.b.c = 1` closes `a` and `a.b` as well.
  */
-function getPreambleTableKeys(config: string): string[] {
+function readPreambleTableClaims(config: string): PreambleTableClaims {
   const lines = config.split('\n')
   const preambleEnd = getTomlSections(config)[0]?.start ?? lines.length
-  const keys: string[] = []
+  const tables = new Set<string>()
+  const inlineTables: string[][] = []
   let scanState = createTomlLineScanState()
   for (let index = 0; index < preambleEnd; index += 1) {
     const line = lines[index] ?? ''
     const parsed = isTomlStructuralLine(scanState) ? parseTomlKeyPath(line) : null
-    // Why: only an assignment claims a name; a bare word on its own does not.
     const assigned = parsed ? line.slice(parsed.end).trimStart() : ''
     if (parsed && assigned.startsWith('=')) {
-      // Why: a scalar names no table, so `model = "x"` must not claim `[model]`
-      // and leave a phantom key in the record of what the source contributed.
-      // A dotted key and an inline table both do define one.
-      const definesTable =
-        parsed.segments.length > 1 || assigned.slice(1).trimStart().startsWith('{')
-      if (definesTable) {
-        keys.push(`[${parsed.segments[0]}]`)
+      const isInlineTable = assigned.slice(1).trimStart().startsWith('{')
+      // Why: `a.b.c = 1` declares table `a.b`; `a = { .. }` declares `a`. A
+      // plain scalar declares none, so `model = "x"` claims no `[model]`.
+      const tablePath = isInlineTable ? parsed.segments : parsed.segments.slice(0, -1)
+      for (let depth = 1; depth <= tablePath.length; depth += 1) {
+        tables.add(canonicalTablePath(tablePath.slice(0, depth)))
+      }
+      if (isInlineTable && tablePath.length > 0) {
+        inlineTables.push([...tablePath])
       }
     }
     scanState = updateTomlLineScanState(scanState, line)
   }
-  return keys
+  return { tables, inlineTables }
 }
 
 /**
  * Separates a runtime section the user added inside Orca's managed CODEX_HOME
  * from one the mirror copied in and the user has since deleted at the source.
  *
- * Without this the mirror rebuilds every ordinary section from the system config
- * and keeps only a fixed allowlist of runtime-owned tables, so anything written
- * through an Orca-launched Codex — `[mcp_servers.*]` above all — is dropped on
- * the next pass.
+ * Without this the mirror rebuilds every ordinary section from the system
+ * config and keeps only a fixed allowlist of runtime-owned tables, so anything
+ * written through an Orca-launched Codex — `[mcp_servers.*]` above all — is
+ * dropped on the next pass.
  */
 export function createRuntimeAddedSectionFilter({
   systemConfig,
@@ -75,12 +103,26 @@ export function createRuntimeAddedSectionFilter({
   systemConfig: string
   mirroredSectionKeys: MirroredCodexSectionKeys
 }): (section: TomlSection) => boolean {
-  const systemSectionKeys = getCodexConfigSectionKeys(systemConfig)
+  const sourceSectionKeys = getCodexConfigSectionKeys(systemConfig)
+  const preamble = readPreambleTableClaims(systemConfig)
   return (section) => {
-    const key = getTomlSectionHeaderKey(section.header)
-    // Why: the system half of the merge already carries every section it
-    // defines, so the source wins for a name present on both sides.
-    if (systemSectionKeys.has(key)) {
+    const parsed = parseTomlTableHeaderPath(section.header)
+    // Why: a header that does not parse cannot be compared against the source,
+    // and emitting it beside a source table of the same name is what produces
+    // an unparseable config. Dropping is also what the mirror did with every
+    // ordinary runtime section before this filter existed, so it is no worse.
+    if (!parsed) {
+      return false
+    }
+    const key = canonicalTablePath(parsed.segments)
+    // Why: the system half of the merge already carries every table it
+    // declares, so the source wins for a name present on both sides.
+    if (sourceSectionKeys.has(key) || preamble.tables.has(key)) {
+      return false
+    }
+    // Why: TOML forbids extending an inline table with a sub-table, so a
+    // runtime `[a.b.env]` under a source `a = { b = .. }` cannot be emitted.
+    if (preamble.inlineTables.some((path) => isPrefixOf(path, parsed.segments))) {
       return false
     }
     // Why: recorded as mirrored in and now absent at the source means the user

--- a/src/shared/child-process/__fixtures__/child-process-import-allowlist.txt
+++ b/src/shared/child-process/__fixtures__/child-process-import-allowlist.txt
@@ -35,7 +35,6 @@ src/cli/handlers/skills.ts
 src/cli/runtime/launch.ts
 src/cli/runtime/serve-update-supervisor.ts
 src/main/agent-hooks/managed-hook-owner-identity.ts
-src/main/agent-hooks/managed-hook-runtime.ts
 src/main/agent-hooks/wsl-hook-relay-launch.ts
 src/main/agent-hooks/wsl-hook-relay-link.ts
 src/main/agent-hooks/wsl-hook-relay-manager.ts

--- a/src/shared/child-process/__fixtures__/windows-console-visibility-allowlist.txt
+++ b/src/shared/child-process/__fixtures__/windows-console-visibility-allowlist.txt
@@ -6,7 +6,6 @@ cli/handlers/core.ts
 cli/handlers/skills.ts
 cli/runtime/launch.ts
 main/agent-hooks/managed-hook-owner-identity.ts
-main/agent-hooks/managed-hook-runtime.ts
 main/app-icon.ts
 main/automations/precheck-runner.ts
 main/claude-accounts/keychain.ts

--- a/src/shared/child-process/child-process-import-boundary.test.ts
+++ b/src/shared/child-process/child-process-import-boundary.test.ts
@@ -29,7 +29,7 @@ const CHILD_PROCESS_IMPORT_ALLOWLIST: readonly string[] = readFileSync(
  * May only ever be DECREASED, and only by migrating a file off
  * `node:child_process`. Raising it is never the fix.
  */
-const DIRECT_IMPORTER_PIN = 155
+const DIRECT_IMPORTER_PIN = 154
 
 const IMPORT_PATTERN =
   /(?:from\s+['"]node:child_process['"]|from\s+['"]child_process['"]|require\(\s*['"]node:child_process['"]|require\(\s*['"]child_process['"])/

--- a/src/shared/child-process/windows-console-visibility.test.ts
+++ b/src/shared/child-process/windows-console-visibility.test.ts
@@ -34,7 +34,7 @@ const ALLOWLIST: readonly string[] = readAllowlist(
  * the allowlist does not bound this: a swap (one file fixed and delisted, one
  * new file added with its entry) satisfies both membership assertions.
  */
-const UNHIDDEN_SPAWNER_PIN = 65
+const UNHIDDEN_SPAWNER_PIN = 64
 
 const CHILD_PROCESS_IMPORT =
   /from\s+['"](?:node:)?child_process['"]|require\(\s*['"](?:node:)?child_process['"]/


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​642 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​68 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​574 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​405 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​88 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​317 |

<!-- /orca-pr-loc -->

Fixes STA-6986. Fixes STA-7009.

**Two independent fixes under one principle** — the managed Codex home is
resolved once and merged into, never guessed at and never overwritten. They
share no file, function or data, and are batched thematically rather than
because one mechanism connects them.

## 1. The mirror deleted config the user added inside the managed home (STA-6986)

`mergeSystemCodexConfigIntoRuntime` rebuilt the runtime `config.toml` from the
system config and re-appended only what `isRuntimePreservedTomlSection` allows —
`[hooks.state.*]` and `[projects.*]`. That is a **closed allowlist of survivors**,
so every other runtime-only table was dropped. `codex mcp add` run inside an
Orca-launched Codex writes `[mcp_servers.<name>]` into the managed home only, so
the next launch removed it. `codex-config-mirror.ts:266-277` at `main`.

The allowlist is the bug class, not a missing entry: adding `mcp_servers` to it
would resurrect a server the user deleted from `~/.codex`, because the merge has
no way to tell "added here" from "deleted there". That distinction needs a base.

Each mirror now records the table identities the source contributed, in the
settings baseline that already exists for exactly this purpose. A runtime
section the source does not declare is then classified:

| in the recorded set? | verdict |
|---|---|
| no | added inside the managed home — **keep** |
| yes | mirrored in, since deleted at the source — **drop** |
| no record at all | **keep** |

The last row is deliberate. The managed home is the only copy of anything added
inside it, so an unanswered question must not authorize a deletion. An empty
recorded set and a missing one are therefore distinct values, not both "empty".
A corrupt baseline collapses to the same keep-never-delete direction.

Conflict rule: for a name declared on both sides the source wins, since the
mirror is one-way for ordinary settings and promotion handles the scalar
write-back separately.

### Tables are compared by identity, wherever the source declares them

Codex spells one table many ways, so the comparison canonicalizes rather than
matching raw header text. Getting this wrong is worse than the bug being fixed:
where `main` merely dropped a section on a key mismatch, comparing text would
emit **both** spellings — a duplicate table, and a `config.toml` Codex cannot
parse. Losing a setting is recoverable; a corrupt config is not.

So `[a.b]`, `[ a.b ]`, `[a."b"]` and `[[a.b]]` are one key. A header that does
not parse is dropped — exactly what `main` did with every ordinary runtime
section, so never worse.

A `[header]` is not the only way to declare a table, and the scan has to see
every site. An assignment closes every prefix of its key path and binds the
path itself, and nothing may be declared at or below a binding — which covers
a dotted key (`a.b.c = 1` closes `a` and `a.b`), an inline table (which no
sub-table may extend), and a plain scalar or array (`model = "x"` leaves no
table for a later `[model]` to add to). All of it applies inside a table body
as well as the preamble, relative to the enclosing header: `[a]` followed by
`b.c = 1` closes `a.b`. A bare header still claims nothing beneath it, so a
table added inside the managed home survives.

The baseline file stays at version 2 with an added optional field. A version
bump would make an older Orca reject the whole baseline and rebuild it,
stranding a runtime change it had not yet promoted.

## 2. Remote hook install ignored a redirected CODEX_HOME (STA-7009)

`managed-hook-runtime.ts` runs on the execution host and resolved `GROK_HOME`
there, but never resolved `CODEX_HOME` — it passed `grokHomeDir` and no
`codexHomeDir`, so `installCodexHooksRemote` fell back to
`${remoteHome}/.codex` (`codex-hook-remote-install.ts:31-32`). A host whose
`codex` launcher exports `CODEX_HOME` inside the wrapper script reads hooks from
somewhere else, so no `Stop` hook ever arrives and workspace status decays to
terminal heuristics.

Reading the environment the way the Grok probe does cannot work here: the
wrapper exports the variable only for the Codex process, so a login shell
reports nothing. The host's own Codex is asked instead — a short `app-server`
session whose `initialize` result reports the home the server resolved. That
needs no wrapper parsing and is correct for any launcher shape. It runs only
when Codex is in the host's detected-agent allowlist, and any failure, timeout,
or old CLI falls back to `~/.codex`.

Both agent homes now come from one execution-host module, and that module
spawns through `runProcess` rather than `node:child_process`. The Grok probe
was previously a direct spawner; moving it without migrating it would have
carried the violation into a new file. Both spawn ratchets therefore tighten:
the direct-importer pin drops **155 → 154** and the unhidden-spawner pin
**65 → 64**, with both now-stale allowlist entries deleted.

**One deliberate restraint.** `codexHomeDir` also silently selected a different
install contract — script location, hook ordering, and command wrapper — meant
for WSL runtime homes that Orca's own installer also writes. Passing a resolved
home for SSH would have flipped every Codex host onto that contract. The
argument is split, so the resolved home is passed only when it actually differs
from `~/.codex`, and only the config location moves. **A host that does not
redirect is byte-identical to today**, pinned by a test. Two existing test
callers pin the historical coupling and still pass.

## Evidence

Seven ablation arms, all re-run at the final head `af706b8e7b`. No test in
either file passes in every arm.

**STA-6986** — 23 tests, driven through `syncSystemConfigIntoManagedCodexHome`
(the real writer) against `mkdtemp` homes.

| arm | result |
|---|---|
| all production levers at `main` (3 files reverted, new module removed) | **9 of 23 fail** |
| preservation made unconditional (over-reach guard) | **16 of 23 fail** |
| raw header text instead of canonical identity | **11 of 23 fail** |
| **claim scan limited to the preamble** | **3 of 23 fail** — exactly the in-body sites |
| recording lever alone at `main` | **4 of 23 fail** |

The third and fourth arms are the ones that matter most: between them they
redden all eleven duplicate-declaration cases, and each fails only the cases its
own lever governs, so the corruption is closed by those changes specifically and
not by something incidental. The second exists because the arm-1 survivors are
guards against over-reach — a one-direction ablation would have left them
unproven.

**STA-7009** — 9 tests. The probe is a real `codex app-server` stub reached
through a real login shell, and the install tests call `installManagedHooks`.

| arm | result |
|---|---|
| production wiring severed (resolver kept, home no longer passed) | redirected-host install test **fails**; all 8 resolver tests still pass |
| contract split reverted (home and contract re-coupled) | same test **fails**, on script location |
| Grok probe reverted to `node:child_process` | both spawn-ratchet tests **fail** |

The first is the shipping-path property: the unit tests alone would have stayed
green, so a green suite without this arm would not have proven the wiring.

Restores verified by `cmp` plus an empty `git diff` after every arm.

Full suite over `src/main/agent-hooks`, `src/main/codex`,
`src/shared/child-process`, `src/relay`: **4380 passed, 71 skipped, 0 failed**.
Typecheck run as three separate projects: **node 0, cli 0, web 0**.
`check:code-quality:changed` clean (0 findings across 15 files); the
native-plugins oxlint run exits 0.

## Relationship to #19270

**Conflicts textually in `src/main/codex/codex-config-mirror.ts`; composes
semantically.** Verified against that PR's head `82effd4cd8`, not assumed.

It is the only shared file. #19270 adds file-mode enforcement and home-local
path rewriting; this adds a section-baseline argument. They touch adjacent
lines at the same call sites for unrelated reasons, and neither changes the
other's behaviour. Whichever lands second resolves by keeping both argument
additions.

**Merge-ordering note.** This PR retains runtime-only `[mcp_servers.*.env]`
tables that `main` used to delete, and those can hold bearer tokens. The
exposure is pre-existing and unchanged in kind — same bytes, same file mode —
but its lifetime is extended until #19270 lands the owner-only mode. **#19270
should land first or together.** File modes are deliberately not touched here;
duplicating that fix would conflict with it.

## Known follow-ups, not fixed here

- `snapshotCodexRuntimeSettingsBaseline` swallows write failures, so the runtime
  `config.toml` can advance while the record does not. The next pass then reads
  a stale record; the failure direction is keep-never-delete.
- `syncSystemConfigIntoLegacySharedCodexHome` writes the runtime config but
  never advances the record, so a table arriving only through that retired lane
  is permanently classified user-added.
- The per-connect `codex app-server` probe is not memoized; one handshake runs
  per SSH connect that reports Codex.
- The Grok probe's failure arm now asserts a non-zero exit rather than a killed
  spawn, so the `timeoutMs` branch is no longer directly covered. Exercising it
  would mean an 8s sleep against a module constant that is not injectable.

## What this does not close

- **STA-1806** — partially. Its remote-install gap is what STA-7009 became, and
  that half is fixed. Its other half is a different mechanism: `agent hooks
  status` inspects the local managed home and reports `installed` for an SSH
  worktree whose agent runs elsewhere. That is a reporting surface, untouched.
- **STA-6756** (`hooks.json` → `config.toml`) is a hook *representation*
  migration with its own installer guarantees — trust hashes, permissions,
  rollback, user hook positions.
- **STA-2755** needs a durable user-facing scope setting and its diagnostics,
  which is a product contract rather than a resolution bug.
- **STA-6643** is a path-length and filesystem-migration problem: a shorter
  ownership root, an atomic rename, and a compatibility symlink.

## Risk

Types change (three option types, one baseline type, one handshake return); all
three tsconfig projects typecheck clean, run separately.

No wire, RPC, or stream-frame change. The remote hook runtime is a versioned
relay artifact, and its behaviour changes only for a host that redirects
CODEX_HOME — a host that is fully broken today. WSL is unaffected because its
callers still pass the coupled contract, which now defaults to the historical
behaviour. The Windows remote path is unchanged (the relay returns before hook
install for Windows hosts). Nothing here loosens permissions or logs
credential-bearing content.

**Not validated live:** no SSH host and no redirected-CODEX_HOME host was
exercised. Both remote lanes are covered only by the stubbed-shell tests above.

