### PR TITLE
Move a registered project in place instead of refusing it

### DIFF
--- a/src/main/ipc/folder-repo-git-upgrade.ts
+++ b/src/main/ipc/folder-repo-git-upgrade.ts
@@ -6,7 +6,7 @@ import type { Repo } from '../../shared/repo-types'
 import type { Store } from '../persistence'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { isFolderRepo } from '../../shared/repo-kind'
-import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree/id'
+import { folderProjectHasExtraWorkspaces } from '../project-kind-transition'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { isWslUncPath } from '../../shared/wsl-paths'
 import { getGitRepoRoot, isGitRepo } from '../git/repo'
@@ -55,20 +55,6 @@ function isUpgradeCandidate(repo: Repo): boolean {
     getRepoExecutionHostId(repo) === LOCAL_EXECUTION_HOST_ID &&
     !isWslUncPath(repo.path)
   )
-}
-
-/**
- * A folder project's extra workspaces are `worktreeMeta` rows keyed
- * `repoId::path::workspace:<uuid>`, and only the folder branch of the worktree listing
- * knows those keys exist. Flipping `kind` moves the repo onto the git branch, which lists
- * `git worktree list` (one path) and prunes every lineage id under the repo that is not in
- * it — so those workspaces vanish from the sidebar and their lineage is deleted. Migrating
- * them belongs to the listing code that owns both shapes, not to this watch, so refuse the
- * upgrade instead of destroying them. Such a project keeps working exactly as it does today.
- */
-function hasExtraFolderWorkspaces(store: Store, repo: Repo): boolean {
-  const prefix = `${repo.id}::${repo.path}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
-  return Object.keys(store.getAllWorktreeMeta()).some((key) => key.startsWith(prefix))
 }
 
 /** Identity of the `.git` entry, or null when there is none. */
@@ -122,7 +108,7 @@ async function upgradeFolderRepo(watch: UpgradeWatch, repoId: string): Promise<U
   if (!current || !isUpgradeCandidate(current)) {
     return 'blocked'
   }
-  if (hasExtraFolderWorkspaces(watch.store, current)) {
+  if (folderProjectHasExtraWorkspaces(watch.store.getAllWorktreeMeta(), current)) {
     return 'blocked'
   }
   const updates = resolveUpgrade(current.path)

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -69,7 +69,7 @@ export function registerRepoHandlers(
   ipcMain.removeHandler('sparsePresets:remove')
 
   registerRepoCatalogHandlers(mainWindow, store)
-  registerProjectHostSetupHandlers(mainWindow, store)
+  registerProjectHostSetupHandlers(mainWindow, store, runtime)
   registerRepoCreationHandlers(mainWindow, store)
   registerProjectGroupHandlers(mainWindow, store)
   registerFolderWorkspaceHandlers(mainWindow, store, runtime)

--- a/src/main/ipc/repos/project-host-setup-handlers.ts
+++ b/src/main/ipc/repos/project-host-setup-handlers.ts
@@ -16,6 +16,7 @@ import { getProjectIdForProviderIdentity } from '../../../shared/project-host-se
 import { getProjectHostSetupForRepo } from '../../../shared/project-host-setup-lookup'
 import { parseExecutionHostId } from '../../../shared/execution-host'
 import { prepareLocalWorktreeRootForRepo } from '../../worktree-root-preparation'
+import type { OrcaRuntimeService } from '../../runtime/orca-runtime'
 import { applyProjectHostSetupPathRelocation } from '../../project-path-relocation'
 import { invalidateAuthorizedRootsCache } from '../registered-worktree-roots-cache'
 import { emitRepoAdded } from './repo-added-telemetry'
@@ -78,7 +79,11 @@ function alignRepoWithRequestedProject(
   return buildProjectHostSetupResult(store, repo)
 }
 
-export function registerProjectHostSetupHandlers(mainWindow: BrowserWindow, store: Store): void {
+export function registerProjectHostSetupHandlers(
+  mainWindow: BrowserWindow,
+  store: Store,
+  runtime: OrcaRuntimeService
+): void {
   ipcMain.handle(
     'projectHostSetups:create',
     (_event, rawArgs: ProjectHostSetupCreateArgs): ProjectHostSetupCreateResult => {
@@ -104,7 +109,14 @@ export function registerProjectHostSetupHandlers(mainWindow: BrowserWindow, stor
         rawArgs,
         'project_host_setup_update_invalid_args'
       )
-      const { updates, relocatedRepo } = applyProjectHostSetupPathRelocation(store, args)
+      // Same delivery as the RPC entry point: a relocation must announce old->new per workspace, or
+      // the renderer's diff reads the vanished id as a deletion and tears the workspace down.
+      const { updates, relocatedRepo } = applyProjectHostSetupPathRelocation(
+        store,
+        args,
+        (repoId, oldWorktreeId, newWorktreeId) =>
+          runtime.notifyWorktreeFolderRenamed(repoId, oldWorktreeId, newWorktreeId)
+      )
       if (relocatedRepo) {
         invalidateAuthorizedRootsCache()
       }

--- a/src/main/ipc/repos/project-host-setup-handlers.ts
+++ b/src/main/ipc/repos/project-host-setup-handlers.ts
@@ -16,6 +16,7 @@ import { getProjectIdForProviderIdentity } from '../../../shared/project-host-se
 import { getProjectHostSetupForRepo } from '../../../shared/project-host-setup-lookup'
 import { parseExecutionHostId } from '../../../shared/execution-host'
 import { prepareLocalWorktreeRootForRepo } from '../../worktree-root-preparation'
+import { applyProjectHostSetupPathRelocation } from '../../project-path-relocation'
 import { invalidateAuthorizedRootsCache } from '../registered-worktree-roots-cache'
 import { emitRepoAdded } from './repo-added-telemetry'
 import { notifyReposChanged } from './repos-changed-notification'
@@ -103,11 +104,15 @@ export function registerProjectHostSetupHandlers(mainWindow: BrowserWindow, stor
         rawArgs,
         'project_host_setup_update_invalid_args'
       )
-      const result = store.updateProjectHostSetup(args)
+      const { updates, relocatedRepo } = applyProjectHostSetupPathRelocation(store, args)
+      if (relocatedRepo) {
+        invalidateAuthorizedRootsCache()
+      }
+      const result = store.updateProjectHostSetup({ ...args, updates })
       if (!result) {
         throw new Error(`Project host setup not found: ${args.setupId}`)
       }
-      if ('worktreeBasePath' in args.updates && result.repo) {
+      if ('worktreeBasePath' in updates && result.repo) {
         void prepareLocalWorktreeRootForRepo(store, result.repo)
         invalidateAuthorizedRootsCache()
       }

--- a/src/main/persistence-update-repo.test.ts
+++ b/src/main/persistence-update-repo.test.ts
@@ -321,16 +321,55 @@ describe('Store', () => {
     })
   })
 
-  it('rejects repo-backed project host setup path changes', async () => {
+  it('rejects a raw repo-backed project host setup path write', async () => {
     const store = await createStore()
     store.addRepo(makeRepo({ id: 'r1', path: '/repo' }))
 
+    // Persistence stays the backstop: a path write that skipped the relocation would strand every
+    // `<repoId>::<path>` workspace id, so it must never land as a plain field update.
     expect(() =>
       store.updateProjectHostSetup({
         setupId: 'r1',
         updates: { path: '/other' }
       })
-    ).toThrow('Repo-backed project host setup paths must be changed by re-importing the project.')
+    ).toThrow('must be moved through a project relocation')
+  })
+
+  it('refuses a folder project git upgrade that would unlist its folder workspaces', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ id: 'r1', path: '/repo', kind: 'folder' }))
+    store.setWorktreeMeta('r1::/repo::workspace:11111111-1111-1111-1111-111111111111', {
+      displayName: 'draft'
+    })
+
+    // Why: the `.git` upgrade watch already refuses this. A second kind writer that allowed it would
+    // do silently what the first one refuses.
+    expect(() => store.updateProjectHostSetup({ setupId: 'r1', updates: { kind: 'git' } })).toThrow(
+      /folder workspaces that a Git project cannot list/
+    )
+    expect(store.getRepo('r1')?.kind).toBe('folder')
+  })
+
+  it('upgrades a folder project with no extra folder workspaces', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ id: 'r1', path: '/repo', kind: 'folder' }))
+    store.setWorktreeMeta('r1::/repo', { displayName: 'repo' })
+
+    store.updateProjectHostSetup({ setupId: 'r1', updates: { kind: 'git' } })
+
+    expect(store.getRepo('r1')?.kind).toBe('git')
+  })
+
+  it('still lets a git project become a folder project', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ id: 'r1', path: '/repo', kind: 'git' }))
+    store.setWorktreeMeta('r1::/repo::workspace:11111111-1111-1111-1111-111111111111', {
+      displayName: 'draft'
+    })
+
+    store.updateProjectHostSetup({ setupId: 'r1', updates: { kind: 'folder' } })
+
+    expect(store.getRepo('r1')?.kind).toBe('folder')
   })
 
   it('deletes independent project host setup records without deleting the project', async () => {

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -18,6 +18,7 @@ import type { PersistedState } from '../../../shared/persisted-state-types'
 import type { Repo } from '../../../shared/repo-types'
 import { getRepoExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
 import { syncProjectHostSetupCompatibilityState } from './repo-lifecycle-operations'
+import { bumpLocalWorktreeScanGeneration } from '../../local-worktree-scan-generation'
 import {
   planRepoPathRelocation,
   type RepoWorkspaceIdentityMove
@@ -144,6 +145,9 @@ export class Store {
     // stale on the setup row until an unrelated catalog mutation happens to rebuild it — and
     // `setup.path` is what an automation resolves its run directory from.
     syncProjectHostSetupCompatibilityState(this)
+    // Every path a scan would report just changed, which is exactly what this generation exists to
+    // signal. `updateRepo` bumps it for far smaller edits; a direct write must not skip it.
+    bumpLocalWorktreeScanGeneration(repoId)
     scheduleSave(this.domains.scheduling)
     return { repo: this.getRepo(repoId) ?? stored, moves }
   }

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -17,6 +17,7 @@ import {
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import type { Repo } from '../../../shared/repo-types'
 import { getRepoExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
+import { syncProjectHostSetupCompatibilityState } from './repo-lifecycle-operations'
 import {
   planRepoPathRelocation,
   type RepoWorkspaceIdentityMove
@@ -133,10 +134,16 @@ export class Store {
     }
     const moves = planRepoPathRelocation(this.state, stored, newPath)
     // Re-key first: a migration reads the old id, so the repo must still spell the old path.
+    // No host argument, matching the folder-rename path: naming a host that disagrees with the row's
+    // own persisted `hostId` makes the migration skip the session it was called to move.
     for (const move of moves) {
-      this.migrateWorktreeIdentity(move.from, move.to, getRepoExecutionHostId(stored))
+      this.migrateWorktreeIdentity(move.from, move.to)
     }
     stored.path = newPath
+    // Project host setups are projected from the repo catalog, so a path written without this stays
+    // stale on the setup row until an unrelated catalog mutation happens to rebuild it — and
+    // `setup.path` is what an automation resolves its run directory from.
+    syncProjectHostSetupCompatibilityState(this)
     scheduleSave(this.domains.scheduling)
     return { repo: this.getRepo(repoId) ?? stored, moves }
   }

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -15,6 +15,9 @@ import {
   type StoreDomains
 } from './store-domain-composition'
 import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { Repo } from '../../../shared/repo-types'
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
+import { planRepoPathRelocation } from '../tracking-repos/repo-path-relocation'
 import { scheduleSave } from './write-scheduling'
 import type { WriteSchedulingOperations } from './write-scheduling'
 import type { PrimaryStateWriteOperations } from './primary-state-writes'
@@ -101,6 +104,33 @@ export class Store {
       clearTimeout(this.runtime.writeTimer)
       this.runtime.writeTimer = null
     }
+  }
+
+  /**
+   * Point a registered project at a directory it has moved to, carrying its workspaces across.
+   *
+   * Lives on the composition root because it is the one repo mutation that also has to re-key
+   * worktree-derived identity: `updateRepo` cannot take `path` precisely because changing it alone
+   * would strand every `<repoId>::<path>` row. Callers own validating that `newPath` exists on the
+   * host that runs the project; this only rewrites persisted identity.
+   */
+  relocateRepoPath(repoId: string, newPath: string): Repo | null {
+    const repo = this.getRepo(repoId)
+    if (!repo) {
+      return null
+    }
+    const moves = planRepoPathRelocation(this.state, repo, newPath)
+    // Re-key first: a migration reads the old id, so the repo must still spell the old path.
+    for (const move of moves) {
+      this.migrateWorktreeIdentity(move.from, move.to, getRepoExecutionHostId(repo))
+    }
+    const stored = this.state.repos.find((candidate) => candidate.id === repoId)
+    if (!stored) {
+      return null
+    }
+    stored.path = newPath
+    scheduleSave(this.domains.scheduling)
+    return this.getRepo(repoId) ?? stored
   }
 }
 

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -16,8 +16,11 @@ import {
 } from './store-domain-composition'
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import type { Repo } from '../../../shared/repo-types'
-import { getRepoExecutionHostId } from '../../../shared/execution-host'
-import { planRepoPathRelocation } from '../tracking-repos/repo-path-relocation'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
+import {
+  planRepoPathRelocation,
+  type RepoWorkspaceIdentityMove
+} from '../tracking-repos/repo-path-relocation'
 import { scheduleSave } from './write-scheduling'
 import type { WriteSchedulingOperations } from './write-scheduling'
 import type { PrimaryStateWriteOperations } from './primary-state-writes'
@@ -114,23 +117,28 @@ export class Store {
    * would strand every `<repoId>::<path>` row. Callers own validating that `newPath` exists on the
    * host that runs the project; this only rewrites persisted identity.
    */
-  relocateRepoPath(repoId: string, newPath: string): Repo | null {
-    const repo = this.getRepo(repoId)
-    if (!repo) {
-      return null
-    }
-    const moves = planRepoPathRelocation(this.state, repo, newPath)
-    // Re-key first: a migration reads the old id, so the repo must still spell the old path.
-    for (const move of moves) {
-      this.migrateWorktreeIdentity(move.from, move.to, getRepoExecutionHostId(repo))
-    }
-    const stored = this.state.repos.find((candidate) => candidate.id === repoId)
+  relocateRepoPath(
+    repoId: string,
+    newPath: string,
+    hostId?: ExecutionHostId
+  ): { repo: Repo; moves: RepoWorkspaceIdentityMove[] } | null {
+    // Host-qualified like `updateRepo`: the same repo id can exist on several execution hosts, and an
+    // id-only lookup would move one host's row using another host's request.
+    const stored = this.state.repos.find(
+      (candidate) =>
+        candidate.id === repoId && (!hostId || getRepoExecutionHostId(candidate) === hostId)
+    )
     if (!stored) {
       return null
     }
+    const moves = planRepoPathRelocation(this.state, stored, newPath)
+    // Re-key first: a migration reads the old id, so the repo must still spell the old path.
+    for (const move of moves) {
+      this.migrateWorktreeIdentity(move.from, move.to, getRepoExecutionHostId(stored))
+    }
     stored.path = newPath
     scheduleSave(this.domains.scheduling)
-    return this.getRepo(repoId) ?? stored
+    return { repo: this.getRepo(repoId) ?? stored, moves }
   }
 }
 

--- a/src/main/persistence/tracking-repos/project-host-setup-update.ts
+++ b/src/main/persistence/tracking-repos/project-host-setup-update.ts
@@ -2,6 +2,7 @@ import type { PersistedState } from '../../../shared/persisted-state-types'
 import type { ProjectHostSetup, ProjectHostSetupUpdateArgs } from '../../../shared/project-types'
 import type { Repo } from '../../../shared/repo-types'
 import type { RepoUpdatePersistenceOperations } from './repo-update-operations'
+import { refuseFolderProjectGitUpgradeReason } from '../../project-kind-transition'
 
 export type ProjectHostSetupUpdateOperations = {
   state: PersistedState
@@ -32,8 +33,11 @@ export class ProjectHostSetupPersistenceOperations {
     updates: ProjectHostSetupUpdateArgs['updates']
   ): { setup: ProjectHostSetup; repo: Repo } | null {
     if (updates.path !== undefined && updates.path !== repo.path) {
+      // Why still a throw: the project's path is baked into every `<repoId>::<path>` workspace id,
+      // so it can only move through `relocateRepoPath`, which re-keys them. Callers reach that via
+      // `applyProjectHostSetupPathRelocation`; anything landing here skipped the migration.
       throw new Error(
-        'Repo-backed project host setup paths must be changed by re-importing the project.'
+        "Repo-backed project host setup paths must be moved through a project relocation, which carries the project's workspaces to the new path."
       )
     }
     if (updates.setupState !== undefined && updates.setupState !== 'ready') {
@@ -47,6 +51,13 @@ export class ProjectHostSetupPersistenceOperations {
       repoUpdates.worktreeBasePath = updates.worktreeBasePath
     }
     if (updates.kind !== undefined) {
+      const refusal =
+        updates.kind === 'git'
+          ? refuseFolderProjectGitUpgradeReason(this.state.worktreeMeta, repo)
+          : null
+      if (refusal) {
+        throw new Error(refusal)
+      }
       repoUpdates.kind = updates.kind
     }
     if (updates.setupMethod === 'provisioned') {

--- a/src/main/persistence/tracking-repos/repo-path-relocation.ts
+++ b/src/main/persistence/tracking-repos/repo-path-relocation.ts
@@ -14,13 +14,38 @@ export type RepoWorkspaceIdentityMove = {
 }
 
 /**
- * Worktree ids are `<repoId>::<path>` with an optional `::workspace:<uuid>` suffix, so a project's
- * registered path is baked into every workspace that sits at its checkout. Moving the project has to
- * re-key them together; this plans the moves so the caller can apply them through the same
- * identity migration a worktree folder rename uses.
+ * The part of `filesystemPath` below the project root, or null when it is not at or inside it.
  *
- * Only ids at the checkout itself move. A git project's extra worktrees live under their own base
- * path, which the project path does not own, so relocating the checkout must not rewrite them.
+ * Splits on the raw spelling but decides on the normalized one: a stored id can spell the root with
+ * a different case or separator than the repo row does, so slicing by the repo path's length would
+ * cut in the wrong place. Walking separator boundaries keeps the tail byte-exact as stored.
+ */
+function relocationTail(filesystemPath: string, rootKey: string): string | null {
+  if (normalizeRuntimePathForComparison(filesystemPath) === rootKey) {
+    return ''
+  }
+  for (let index = 0; index < filesystemPath.length; index += 1) {
+    const character = filesystemPath[index]
+    if (character !== '/' && character !== '\\') {
+      continue
+    }
+    if (normalizeRuntimePathForComparison(filesystemPath.slice(0, index)) === rootKey) {
+      return filesystemPath.slice(index)
+    }
+  }
+  return null
+}
+
+/**
+ * Worktree ids are `<repoId>::<path>` with an optional `::workspace:<uuid>` suffix, so a project's
+ * registered path is baked into every workspace that lives at or inside its checkout. Moving the
+ * project has to re-key them together; this plans the moves so the caller can apply them through the
+ * same identity migration a worktree folder rename uses.
+ *
+ * Descendants move too, not just the checkout itself: `worktreeBasePath` is resolved relative to
+ * `repo.path`, so a project configured with a relative base keeps its worktrees inside the directory
+ * that is moving. A worktree under an absolute base lies outside the moved directory and is left
+ * alone, which is correct — the move did not touch it.
  */
 export function planRepoPathRelocation(
   state: PersistedState,
@@ -45,15 +70,17 @@ export function planRepoPathRelocation(
     if (filesystemPath === undefined) {
       continue
     }
-    if (normalizeRuntimePathForComparison(filesystemPath) !== oldKey) {
+    const tail = relocationTail(filesystemPath, oldKey)
+    if (tail === null) {
       continue
     }
-    // The instance suffix is whatever the filesystem view stripped; carry it across unchanged so
-    // sibling workspaces stay distinct instead of collapsing onto one id.
+    // The instance suffix is identity, not path; carry it across unchanged so sibling workspaces
+    // stay distinct instead of collapsing onto one id.
     const instanceSuffix = parsed.worktreePath.slice(filesystemPath.length)
+    const relocatedPath = `${newPath}${tail}`
     moves.push({
       from: worktreeId,
-      to: `${repo.id}${WORKTREE_ID_SEPARATOR}${newPath}${instanceSuffix}`
+      to: `${repo.id}${WORKTREE_ID_SEPARATOR}${relocatedPath}${instanceSuffix}`
     })
   }
   return moves

--- a/src/main/persistence/tracking-repos/repo-path-relocation.ts
+++ b/src/main/persistence/tracking-repos/repo-path-relocation.ts
@@ -1,0 +1,60 @@
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { Repo } from '../../../shared/repo-types'
+import { normalizeRuntimePathForComparison } from '../../../shared/cross-platform-path'
+import {
+  splitWorktreeId,
+  splitWorktreeIdForFilesystem,
+  WORKTREE_ID_SEPARATOR
+} from '../../../shared/worktree/id'
+
+/** One workspace's path-derived id before and after the project moves. */
+export type RepoWorkspaceIdentityMove = {
+  readonly from: string
+  readonly to: string
+}
+
+/**
+ * Worktree ids are `<repoId>::<path>` with an optional `::workspace:<uuid>` suffix, so a project's
+ * registered path is baked into every workspace that sits at its checkout. Moving the project has to
+ * re-key them together; this plans the moves so the caller can apply them through the same
+ * identity migration a worktree folder rename uses.
+ *
+ * Only ids at the checkout itself move. A git project's extra worktrees live under their own base
+ * path, which the project path does not own, so relocating the checkout must not rewrite them.
+ */
+export function planRepoPathRelocation(
+  state: PersistedState,
+  repo: Pick<Repo, 'id' | 'path'>,
+  newPath: string
+): RepoWorkspaceIdentityMove[] {
+  const oldKey = normalizeRuntimePathForComparison(repo.path)
+  if (normalizeRuntimePathForComparison(newPath) === oldKey) {
+    return []
+  }
+  const candidateIds = new Set([
+    ...Object.keys(state.worktreeMeta ?? {}),
+    ...Object.keys(state.worktreeLineageById ?? {})
+  ])
+  const moves: RepoWorkspaceIdentityMove[] = []
+  for (const worktreeId of candidateIds) {
+    const parsed = splitWorktreeId(worktreeId)
+    if (!parsed || parsed.repoId !== repo.id) {
+      continue
+    }
+    const filesystemPath = splitWorktreeIdForFilesystem(worktreeId)?.worktreePath
+    if (filesystemPath === undefined) {
+      continue
+    }
+    if (normalizeRuntimePathForComparison(filesystemPath) !== oldKey) {
+      continue
+    }
+    // The instance suffix is whatever the filesystem view stripped; carry it across unchanged so
+    // sibling workspaces stay distinct instead of collapsing onto one id.
+    const instanceSuffix = parsed.worktreePath.slice(filesystemPath.length)
+    moves.push({
+      from: worktreeId,
+      to: `${repo.id}${WORKTREE_ID_SEPARATOR}${newPath}${instanceSuffix}`
+    })
+  }
+  return moves
+}

--- a/src/main/project-kind-transition.ts
+++ b/src/main/project-kind-transition.ts
@@ -1,0 +1,37 @@
+import type { Repo } from '../shared/repo-types'
+import type { WorktreeMeta } from '../shared/worktree/meta-types'
+import { isFolderRepo } from '../shared/repo-kind'
+import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../shared/worktree/id'
+
+/**
+ * A folder project's extra workspaces are `worktreeMeta` rows keyed
+ * `<repoId>::<path>::workspace:<uuid>`, and only the folder branch of the worktree listing knows
+ * those keys exist. Flipping `kind` to `git` moves the repo onto the git branch, which lists
+ * `git worktree list` — one path — so those workspaces stop being listed at all.
+ */
+export function folderProjectHasExtraWorkspaces(
+  allWorktreeMeta: Readonly<Record<string, WorktreeMeta>>,
+  repo: Pick<Repo, 'id' | 'path'>
+): boolean {
+  const prefix = `${repo.id}::${repo.path}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
+  return Object.keys(allWorktreeMeta).some((key) => key.startsWith(prefix))
+}
+
+/**
+ * Whether a project may move from `folder` to `git` right now.
+ *
+ * Two writers change a project's kind — the `.git` upgrade watch and a project host setup update —
+ * and both must reach the same verdict, or the setup path silently does what the watch refuses.
+ * Returns null when the transition is allowed, or the reason it is not.
+ */
+export function refuseFolderProjectGitUpgradeReason(
+  allWorktreeMeta: Readonly<Record<string, WorktreeMeta>>,
+  repo: Pick<Repo, 'id' | 'path' | 'kind'>
+): string | null {
+  if (!isFolderRepo(repo)) {
+    return null
+  }
+  return folderProjectHasExtraWorkspaces(allWorktreeMeta, repo)
+    ? 'This project has folder workspaces that a Git project cannot list. Remove them before turning it into a Git project.'
+    : null
+}

--- a/src/main/project-kind-transition.ts
+++ b/src/main/project-kind-transition.ts
@@ -1,7 +1,11 @@
 import type { Repo } from '../shared/repo-types'
 import type { WorktreeMeta } from '../shared/worktree/meta-types'
 import { isFolderRepo } from '../shared/repo-kind'
-import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../shared/worktree/id'
+import {
+  FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
+  splitWorktreeIdForFilesystem
+} from '../shared/worktree/id'
+import { normalizeRuntimePathForComparison } from '../shared/cross-platform-path'
 
 /**
  * A folder project's extra workspaces are `worktreeMeta` rows keyed
@@ -13,8 +17,20 @@ export function folderProjectHasExtraWorkspaces(
   allWorktreeMeta: Readonly<Record<string, WorktreeMeta>>,
   repo: Pick<Repo, 'id' | 'path'>
 ): boolean {
-  const prefix = `${repo.id}::${repo.path}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
-  return Object.keys(allWorktreeMeta).some((key) => key.startsWith(prefix))
+  // Compare the parsed path, not a raw prefix: a stored id can spell the root with a different case
+  // or separator than the repo row does, and a raw `startsWith` would miss those workspaces and
+  // report a project as safe to upgrade when it is not.
+  const repoPathKey = normalizeRuntimePathForComparison(repo.path)
+  return Object.keys(allWorktreeMeta).some((key) => {
+    if (!key.includes(FOLDER_WORKSPACE_INSTANCE_SEPARATOR)) {
+      return false
+    }
+    const parsed = splitWorktreeIdForFilesystem(key)
+    return (
+      parsed?.repoId === repo.id &&
+      normalizeRuntimePathForComparison(parsed.worktreePath) === repoPathKey
+    )
+  })
 }
 
 /**

--- a/src/main/project-path-relocation.test.ts
+++ b/src/main/project-path-relocation.test.ts
@@ -11,6 +11,8 @@ import {
 } from './project-path-relocation'
 import { RuntimeProjectHostSetupController } from './runtime/runtime-project-host-setup-controller'
 import { registerProjectHostSetupHandlers } from './ipc/repos/project-host-setup-handlers'
+import { renameWorktreeFolderOnFirstWork } from './agent-hooks/first-work-folder-rename'
+import { computeWorktreePath } from './ipc/worktree-logic'
 
 const ipcHandlers = new Map<string, (event: unknown, args: unknown) => unknown>()
 
@@ -224,6 +226,68 @@ describe('relocateProjectPath', () => {
   })
 })
 
+describe('pty identity across a re-key', () => {
+  beforeEach(() => makeDirs('pty'))
+  afterEach(cleanupDirs)
+
+  function seedTerminal(store: Store, worktreeId: string): string {
+    const ptyId = `${worktreeId}@@22222222-2222-2222-2222-222222222222`
+    store.setWorktreeMeta(worktreeId, { displayName: 'wt' })
+    store.setWorkspaceSession({
+      tabsByWorktree: {
+        [worktreeId]: [{ id: 'tab-1', worktreeId, type: 'terminal', title: 'zsh', ptyId }]
+      }
+    } as never)
+    return ptyId
+  }
+
+  function ptyIdAt(store: Store, worktreeId: string): string | undefined {
+    const session = store.getWorkspaceSession() as unknown as {
+      tabsByWorktree?: Record<string, { ptyId?: string }[]>
+    }
+    return session.tabsByWorktree?.[worktreeId]?.[0]?.ptyId
+  }
+
+  /**
+   * A minted pty id embeds the worktree id that owned it, and neither re-key path rewrites it. This
+   * pins that the two paths behave the same, so the orphaned terminal is a property of the shared
+   * rename mechanism and not something relocation introduced. Remapping it is its own change.
+   */
+  it('leaves the pty id spelling the old worktree id on the existing folder-rename path', async () => {
+    const store = createStore()
+    store.addRepo(makeRepo({ id: 'r1', path: oldPath, kind: 'git' }))
+    // No directories are created: the move itself is stubbed, only the re-key is under test.
+    const worktreePath = computeWorktreePath('wt-old', oldPath, store.getSettings())
+    const oldId = `r1::${worktreePath}`
+    const ptyId = seedTerminal(store, oldId)
+    let newId = ''
+
+    await renameWorktreeFolderOnFirstWork(oldId, 'wt-new', {
+      getRepo: (id) => store.getRepo(id),
+      getSettings: () => store.getSettings(),
+      migrateWorktreeIdentity: (from, to) => store.migrateWorktreeIdentity(from, to),
+      notifyWorktreeRenamed: (_repoId, _from, to) => {
+        newId = to
+      },
+      pathExists: async () => false,
+      moveWorktree: async () => {}
+    })
+
+    expect(newId).not.toBe('')
+    expect(ptyIdAt(store, newId)).toBe(ptyId)
+  })
+
+  it('leaves the pty id spelling the old worktree id on relocation, identically', () => {
+    const store = createStore()
+    store.addRepo(makeRepo({ id: 'r1', path: oldPath, kind: 'folder' }))
+    const ptyId = seedTerminal(store, `r1::${oldPath}`)
+
+    relocateProjectPath(store, store.getRepo('r1') as never, newPath, recordingNotifier().notify)
+
+    expect(ptyIdAt(store, `r1::${newPath}`)).toBe(ptyId)
+  })
+})
+
 describe('projectHostSetup.update entry points', () => {
   beforeEach(() => makeDirs('entry'))
   afterEach(cleanupDirs)
@@ -319,6 +383,39 @@ describe('projectHostSetup.update entry points', () => {
     ).toThrow(/another host/)
     expect(store.getRepos().find((repo) => !repo.connectionId)?.path).toBe(oldPath)
     expect(notices).toEqual([])
+  })
+
+  it('moves the project host setup row with the repo', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(rootWorkspaceId(), { displayName: 'example-project' })
+    const { controller } = rpcController(store)
+
+    controller.updateSetup({ setupId: 'r1', updates: { path: newPath } })
+
+    // `setup.path` is projected from the repo catalog and is what an automation resolves its run
+    // directory from, so a stale row would run work in the directory the project just left.
+    expect(store.getProjectHostSetups().find((setup) => setup.repoId === 'r1')?.path).toBe(newPath)
+  })
+
+  it('migrates the session even when the workspace row names its own host', () => {
+    const store = storeWithFolderProject()
+    // A row carrying a `hostId` must still migrate: naming a disagreeing host at the call site
+    // makes the identity migration skip the legacy session state entirely.
+    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft', hostId: 'ssh:elsewhere' })
+    store.setWorkspaceSession({
+      tabsByWorktree: {
+        [instanceWorkspaceId()]: [
+          { id: 'tab-1', worktreeId: instanceWorkspaceId(), type: 'terminal', title: 'zsh' }
+        ]
+      }
+    } as never)
+
+    relocateProjectPath(store, store.getRepo('r1') as never, newPath, recordingNotifier().notify)
+
+    const session = store.getWorkspaceSession() as unknown as {
+      tabsByWorktree?: Record<string, { id: string }[]>
+    }
+    expect(session.tabsByWorktree?.[`r1::${newPath}::workspace:${INSTANCE_UUID}`]).toHaveLength(1)
   })
 
   it('does not hand persistence a path it did not apply', () => {

--- a/src/main/project-path-relocation.test.ts
+++ b/src/main/project-path-relocation.test.ts
@@ -13,6 +13,7 @@ import { RuntimeProjectHostSetupController } from './runtime/runtime-project-hos
 import { registerProjectHostSetupHandlers } from './ipc/repos/project-host-setup-handlers'
 import { renameWorktreeFolderOnFirstWork } from './agent-hooks/first-work-folder-rename'
 import { computeWorktreePath } from './ipc/worktree-logic'
+import { getLocalWorktreeScanGeneration } from './local-worktree-scan-generation'
 
 const ipcHandlers = new Map<string, (event: unknown, args: unknown) => unknown>()
 
@@ -383,6 +384,19 @@ describe('projectHostSetup.update entry points', () => {
     ).toThrow(/another host/)
     expect(store.getRepos().find((repo) => !repo.connectionId)?.path).toBe(oldPath)
     expect(notices).toEqual([])
+  })
+
+  it('advances the local worktree scan generation', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(rootWorkspaceId(), { displayName: 'example-project' })
+    const before = getLocalWorktreeScanGeneration('r1')
+    const { controller } = rpcController(store)
+
+    controller.updateSetup({ setupId: 'r1', updates: { path: newPath } })
+
+    // Every path a scan would report just changed; a detected-worktree cache keyed on this
+    // generation would otherwise keep answering for the directory the project left.
+    expect(getLocalWorktreeScanGeneration('r1')).toBeGreaterThan(before)
   })
 
   it('moves the project host setup row with the repo', () => {

--- a/src/main/project-path-relocation.test.ts
+++ b/src/main/project-path-relocation.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { Store } from './persistence'
+import { testState, createStore, makeRepo } from './persistence-test-harness'
+import { applyProjectHostSetupPathRelocation, relocateProjectPath } from './project-path-relocation'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: { isEncryptionAvailable: () => false }
+}))
+
+let root = ''
+let oldPath = ''
+let newPath = ''
+
+/** The real Store, so the relocation is driven through the same state the app persists. */
+function storeWithFolderProject(): Store {
+  const store = createStore()
+  store.addRepo(makeRepo({ id: 'r1', path: oldPath, kind: 'folder' }))
+  return store
+}
+
+const rootWorkspaceId = (): string => `r1::${oldPath}`
+const instanceWorkspaceId = (): string =>
+  `r1::${oldPath}::workspace:11111111-1111-1111-1111-111111111111`
+
+describe('relocateProjectPath', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-relocate-'))
+    root = mkdtempSync(join(tmpdir(), 'orca-projects-'))
+    oldPath = join(root, 'example-project')
+    newPath = join(root, 'renamed-project')
+    mkdirSync(oldPath)
+    mkdirSync(newPath)
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('carries a folder project and every workspace identity to the new path', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(rootWorkspaceId(), { displayName: 'example-project' })
+    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft', isPinned: true })
+
+    const result = relocateProjectPath(store, 'r1', newPath)
+
+    expect(result.outcome).toBe('relocated')
+    expect(store.getRepo('r1')?.path).toBe(newPath)
+    // The instance suffix is identity, so siblings must stay distinct rather than collapse.
+    expect(store.getWorktreeMeta(`r1::${newPath}`)?.displayName).toBe('example-project')
+    const movedInstance = store.getWorktreeMeta(
+      `r1::${newPath}::workspace:11111111-1111-1111-1111-111111111111`
+    )
+    expect(movedInstance?.displayName).toBe('draft')
+    expect(movedInstance?.isPinned).toBe(true)
+    expect(store.getWorktreeMeta(rootWorkspaceId())).toBeUndefined()
+    expect(store.getWorktreeMeta(instanceWorkspaceId())).toBeUndefined()
+  })
+
+  it('keeps the session bound to the relocated workspace', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
+    store.setWorkspaceSession({
+      tabsByWorktree: {
+        [instanceWorkspaceId()]: [
+          { id: 'tab-1', worktreeId: instanceWorkspaceId(), type: 'terminal', title: 'zsh' }
+        ]
+      },
+      activeWorktreeId: instanceWorkspaceId()
+    } as never)
+
+    relocateProjectPath(store, 'r1', newPath)
+
+    const session = store.getWorkspaceSession() as unknown as {
+      tabsByWorktree?: Record<string, { worktreeId: string }[]>
+      activeWorktreeId?: string
+    }
+    const movedId = `r1::${newPath}::workspace:11111111-1111-1111-1111-111111111111`
+    expect(session.tabsByWorktree?.[movedId]?.[0]?.worktreeId).toBe(movedId)
+    expect(session.tabsByWorktree?.[instanceWorkspaceId()]).toBeUndefined()
+    expect(session.activeWorktreeId).toBe(movedId)
+  })
+
+  it('records the prior id so a session minted under it is not reaped', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
+
+    relocateProjectPath(store, 'r1', newPath)
+
+    const moved = store.getWorktreeMeta(
+      `r1::${newPath}::workspace:11111111-1111-1111-1111-111111111111`
+    )
+    expect(moved?.priorWorktreeIds).toContain(instanceWorkspaceId())
+  })
+
+  it('leaves a project untouched when the target directory does not exist', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
+    const missing = join(root, 'not-there')
+
+    const result = relocateProjectPath(store, 'r1', missing)
+
+    expect(result).toMatchObject({ outcome: 'refused' })
+    // A refusal must not half-migrate: the old identity is still the live one.
+    expect(store.getRepo('r1')?.path).toBe(oldPath)
+    expect(store.getWorktreeMeta(instanceWorkspaceId())?.displayName).toBe('draft')
+  })
+
+  it('refuses a path another project already occupies', () => {
+    const store = storeWithFolderProject()
+    store.addRepo(makeRepo({ id: 'r2', path: newPath, displayName: 'Other', kind: 'folder' }))
+
+    const result = relocateProjectPath(store, 'r1', newPath)
+
+    expect(result).toMatchObject({ outcome: 'refused' })
+    expect(store.getRepo('r1')?.path).toBe(oldPath)
+  })
+
+  it('refuses a project whose files live on another execution host', () => {
+    const store = createStore()
+    store.addRepo(
+      makeRepo({ id: 'r1', path: oldPath, kind: 'folder', connectionId: 'ssh-target-1' })
+    )
+
+    const result = relocateProjectPath(store, 'r1', newPath)
+
+    expect(result).toMatchObject({ outcome: 'refused' })
+    expect(store.getRepo('r1')?.path).toBe(oldPath)
+  })
+
+  it('leaves worktrees outside the project directory where they are', () => {
+    const store = createStore()
+    store.addRepo(makeRepo({ id: 'r1', path: oldPath, kind: 'git' }))
+    const siblingWorktreeId = `r1::${join(root, 'worktrees', 'feature')}`
+    store.setWorktreeMeta(`r1::${oldPath}`, { displayName: 'main' })
+    store.setWorktreeMeta(siblingWorktreeId, { displayName: 'feature' })
+
+    relocateProjectPath(store, 'r1', newPath)
+
+    // Only the checkout itself is addressed by the project path; a worktree under the base path is not.
+    expect(store.getWorktreeMeta(siblingWorktreeId)?.displayName).toBe('feature')
+    expect(store.getWorktreeMeta(`r1::${newPath}`)?.displayName).toBe('main')
+  })
+
+  it('reports an unchanged path without rewriting identity', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
+
+    const result = relocateProjectPath(store, 'r1', oldPath)
+
+    expect(result.outcome).toBe('unchanged')
+    expect(store.getWorktreeMeta(instanceWorkspaceId())?.displayName).toBe('draft')
+  })
+})
+
+describe('applyProjectHostSetupPathRelocation', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-relocate-setup-'))
+    root = mkdtempSync(join(tmpdir(), 'orca-projects-setup-'))
+    oldPath = join(root, 'example-project')
+    newPath = join(root, 'renamed-project')
+    mkdirSync(oldPath)
+    mkdirSync(newPath)
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('relocates the project and hands persistence updates without a path', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
+
+    const { updates, relocatedRepo } = applyProjectHostSetupPathRelocation(store, {
+      setupId: 'r1',
+      updates: { path: newPath, displayName: 'Renamed' }
+    })
+
+    expect(relocatedRepo?.path).toBe(newPath)
+    expect(updates).toEqual({ displayName: 'Renamed' })
+    // Persistence still refuses a raw path write, so the stripped update must survive it.
+    expect(() => store.updateProjectHostSetup({ setupId: 'r1', updates })).not.toThrow()
+    expect(store.getRepo('r1')?.displayName).toBe('Renamed')
+  })
+
+  it('passes an update with no path change straight through', () => {
+    const store = storeWithFolderProject()
+
+    const { updates, relocatedRepo } = applyProjectHostSetupPathRelocation(store, {
+      setupId: 'r1',
+      updates: { displayName: 'Renamed' }
+    })
+
+    expect(relocatedRepo).toBeNull()
+    expect(updates).toEqual({ displayName: 'Renamed' })
+  })
+
+  it('surfaces the refusal instead of silently dropping the path', () => {
+    const store = storeWithFolderProject()
+
+    expect(() =>
+      applyProjectHostSetupPathRelocation(store, {
+        setupId: 'r1',
+        updates: { path: join(root, 'not-there') }
+      })
+    ).toThrow(/No directory exists/)
+  })
+})

--- a/src/main/project-path-relocation.test.ts
+++ b/src/main/project-path-relocation.test.ts
@@ -321,6 +321,22 @@ describe('projectHostSetup.update entry points', () => {
     expect(notices).toEqual([])
   })
 
+  it('does not hand persistence a path it did not apply', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(rootWorkspaceId(), { displayName: 'example-project' })
+    const { controller } = rpcController(store)
+
+    // The stored spelling is the trimmed one, so forwarding the raw request would trip the
+    // persistence backstop that refuses any path it did not apply itself.
+    controller.updateSetup({
+      setupId: 'r1',
+      updates: { path: `  ${newPath}  `, displayName: 'Renamed' }
+    })
+
+    expect(store.getRepo('r1')?.path).toBe(newPath)
+    expect(store.getRepo('r1')?.displayName).toBe('Renamed')
+  })
+
   it('passes an update with no path change straight through', () => {
     const store = storeWithFolderProject()
     const { notify, notices } = recordingNotifier()

--- a/src/main/project-path-relocation.test.ts
+++ b/src/main/project-path-relocation.test.ts
@@ -4,18 +4,46 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import type { Store } from './persistence'
 import { testState, createStore, makeRepo } from './persistence-test-harness'
-import { applyProjectHostSetupPathRelocation, relocateProjectPath } from './project-path-relocation'
+import {
+  applyProjectHostSetupPathRelocation,
+  relocateProjectPath,
+  type WorktreeRenameNotifier
+} from './project-path-relocation'
+import { RuntimeProjectHostSetupController } from './runtime/runtime-project-host-setup-controller'
+import { registerProjectHostSetupHandlers } from './ipc/repos/project-host-setup-handlers'
+
+const ipcHandlers = new Map<string, (event: unknown, args: unknown) => unknown>()
 
 vi.mock('electron', () => ({
   app: { getPath: () => testState.dir },
-  safeStorage: { isEncryptionAvailable: () => false }
+  safeStorage: { isEncryptionAvailable: () => false },
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, args: unknown) => unknown) => {
+      ipcHandlers.set(channel, handler)
+    },
+    removeHandler: (channel: string) => {
+      ipcHandlers.delete(channel)
+    }
+  }
 }))
 
 let root = ''
 let oldPath = ''
 let newPath = ''
 
-/** The real Store, so the relocation is driven through the same state the app persists. */
+/** Every old->new pair the change announced, in order. This is the payload the renderer re-keys on. */
+type RenameNotice = { repoId: string; oldWorktreeId: string; newWorktreeId: string }
+
+function recordingNotifier(): { notify: WorktreeRenameNotifier; notices: RenameNotice[] } {
+  const notices: RenameNotice[] = []
+  return {
+    notices,
+    notify: (repoId, oldWorktreeId, newWorktreeId) =>
+      notices.push({ repoId, oldWorktreeId, newWorktreeId })
+  }
+}
+
+/** The real Store, so relocation is driven through the same state the app persists. */
 function storeWithFolderProject(): Store {
   const store = createStore()
   store.addRepo(makeRepo({ id: 'r1', path: oldPath, kind: 'folder' }))
@@ -23,42 +51,78 @@ function storeWithFolderProject(): Store {
 }
 
 const rootWorkspaceId = (): string => `r1::${oldPath}`
-const instanceWorkspaceId = (): string =>
-  `r1::${oldPath}::workspace:11111111-1111-1111-1111-111111111111`
+const INSTANCE_UUID = '11111111-1111-1111-1111-111111111111'
+const instanceWorkspaceId = (): string => `r1::${oldPath}::workspace:${INSTANCE_UUID}`
+
+function makeDirs(prefix: string): void {
+  testState.dir = mkdtempSync(join(tmpdir(), `orca-${prefix}-`))
+  root = mkdtempSync(join(tmpdir(), `orca-projects-${prefix}-`))
+  oldPath = join(root, 'example-project')
+  newPath = join(root, 'renamed-project')
+  mkdirSync(oldPath)
+  mkdirSync(newPath)
+}
+
+function cleanupDirs(): void {
+  ipcHandlers.clear()
+  rmSync(testState.dir, { recursive: true, force: true })
+  rmSync(root, { recursive: true, force: true })
+}
 
 describe('relocateProjectPath', () => {
-  beforeEach(() => {
-    testState.dir = mkdtempSync(join(tmpdir(), 'orca-relocate-'))
-    root = mkdtempSync(join(tmpdir(), 'orca-projects-'))
-    oldPath = join(root, 'example-project')
-    newPath = join(root, 'renamed-project')
-    mkdirSync(oldPath)
-    mkdirSync(newPath)
-  })
-
-  afterEach(() => {
-    rmSync(testState.dir, { recursive: true, force: true })
-    rmSync(root, { recursive: true, force: true })
-  })
+  beforeEach(() => makeDirs('relocate'))
+  afterEach(cleanupDirs)
 
   it('carries a folder project and every workspace identity to the new path', () => {
     const store = storeWithFolderProject()
     store.setWorktreeMeta(rootWorkspaceId(), { displayName: 'example-project' })
     store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft', isPinned: true })
+    const { notify, notices } = recordingNotifier()
 
-    const result = relocateProjectPath(store, 'r1', newPath)
+    const result = relocateProjectPath(store, store.getRepo('r1') as never, newPath, notify)
 
     expect(result.outcome).toBe('relocated')
     expect(store.getRepo('r1')?.path).toBe(newPath)
-    // The instance suffix is identity, so siblings must stay distinct rather than collapse.
-    expect(store.getWorktreeMeta(`r1::${newPath}`)?.displayName).toBe('example-project')
-    const movedInstance = store.getWorktreeMeta(
-      `r1::${newPath}::workspace:11111111-1111-1111-1111-111111111111`
-    )
+    const movedInstance = store.getWorktreeMeta(`r1::${newPath}::workspace:${INSTANCE_UUID}`)
     expect(movedInstance?.displayName).toBe('draft')
     expect(movedInstance?.isPinned).toBe(true)
-    expect(store.getWorktreeMeta(rootWorkspaceId())).toBeUndefined()
     expect(store.getWorktreeMeta(instanceWorkspaceId())).toBeUndefined()
+    // Every re-keyed id must be announced, or the renderer reads it as a deletion.
+    expect(new Set(notices.map((notice) => notice.oldWorktreeId))).toEqual(
+      new Set([rootWorkspaceId(), instanceWorkspaceId()])
+    )
+    expect(notices.every((notice) => notice.repoId === 'r1')).toBe(true)
+  })
+
+  it('moves worktrees inside the project directory, as a relative worktree base puts them', () => {
+    const store = createStore()
+    store.addRepo(
+      makeRepo({ id: 'r1', path: oldPath, kind: 'git', worktreeBasePath: '.worktrees' })
+    )
+    const childId = `r1::${join(oldPath, '.worktrees', 'feature')}`
+    store.setWorktreeMeta(`r1::${oldPath}`, { displayName: 'main' })
+    store.setWorktreeMeta(childId, { displayName: 'feature' })
+    const { notify, notices } = recordingNotifier()
+
+    relocateProjectPath(store, store.getRepo('r1') as never, newPath, notify)
+
+    const movedChildId = `r1::${join(newPath, '.worktrees', 'feature')}`
+    expect(store.getWorktreeMeta(movedChildId)?.displayName).toBe('feature')
+    expect(store.getWorktreeMeta(childId)).toBeUndefined()
+    expect(notices.map((notice) => notice.newWorktreeId)).toContain(movedChildId)
+  })
+
+  it('leaves a worktree outside the project directory where it is', () => {
+    const store = createStore()
+    store.addRepo(makeRepo({ id: 'r1', path: oldPath, kind: 'git' }))
+    const outsideId = `r1::${join(root, 'elsewhere', 'feature')}`
+    store.setWorktreeMeta(outsideId, { displayName: 'feature' })
+    const { notify, notices } = recordingNotifier()
+
+    relocateProjectPath(store, store.getRepo('r1') as never, newPath, notify)
+
+    expect(store.getWorktreeMeta(outsideId)?.displayName).toBe('feature')
+    expect(notices.map((notice) => notice.oldWorktreeId)).not.toContain(outsideId)
   })
 
   it('keeps the session bound to the relocated workspace', () => {
@@ -73,13 +137,13 @@ describe('relocateProjectPath', () => {
       activeWorktreeId: instanceWorkspaceId()
     } as never)
 
-    relocateProjectPath(store, 'r1', newPath)
+    relocateProjectPath(store, store.getRepo('r1') as never, newPath, recordingNotifier().notify)
 
     const session = store.getWorkspaceSession() as unknown as {
       tabsByWorktree?: Record<string, { worktreeId: string }[]>
       activeWorktreeId?: string
     }
-    const movedId = `r1::${newPath}::workspace:11111111-1111-1111-1111-111111111111`
+    const movedId = `r1::${newPath}::workspace:${INSTANCE_UUID}`
     expect(session.tabsByWorktree?.[movedId]?.[0]?.worktreeId).toBe(movedId)
     expect(session.tabsByWorktree?.[instanceWorkspaceId()]).toBeUndefined()
     expect(session.activeWorktreeId).toBe(movedId)
@@ -89,32 +153,42 @@ describe('relocateProjectPath', () => {
     const store = storeWithFolderProject()
     store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
 
-    relocateProjectPath(store, 'r1', newPath)
+    relocateProjectPath(store, store.getRepo('r1') as never, newPath, recordingNotifier().notify)
 
-    const moved = store.getWorktreeMeta(
-      `r1::${newPath}::workspace:11111111-1111-1111-1111-111111111111`
-    )
-    expect(moved?.priorWorktreeIds).toContain(instanceWorkspaceId())
+    expect(
+      store.getWorktreeMeta(`r1::${newPath}::workspace:${INSTANCE_UUID}`)?.priorWorktreeIds
+    ).toContain(instanceWorkspaceId())
   })
 
-  it('leaves a project untouched when the target directory does not exist', () => {
+  it('leaves a project untouched and announces nothing when the target does not exist', () => {
     const store = storeWithFolderProject()
     store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
-    const missing = join(root, 'not-there')
+    const { notify, notices } = recordingNotifier()
 
-    const result = relocateProjectPath(store, 'r1', missing)
+    const result = relocateProjectPath(
+      store,
+      store.getRepo('r1') as never,
+      join(root, 'not-there'),
+      notify
+    )
 
     expect(result).toMatchObject({ outcome: 'refused' })
-    // A refusal must not half-migrate: the old identity is still the live one.
+    // A refusal must not half-migrate, and must not announce a rename that did not happen.
     expect(store.getRepo('r1')?.path).toBe(oldPath)
     expect(store.getWorktreeMeta(instanceWorkspaceId())?.displayName).toBe('draft')
+    expect(notices).toEqual([])
   })
 
   it('refuses a path another project already occupies', () => {
     const store = storeWithFolderProject()
     store.addRepo(makeRepo({ id: 'r2', path: newPath, displayName: 'Other', kind: 'folder' }))
 
-    const result = relocateProjectPath(store, 'r1', newPath)
+    const result = relocateProjectPath(
+      store,
+      store.getRepo('r1') as never,
+      newPath,
+      recordingNotifier().notify
+    )
 
     expect(result).toMatchObject({ outcome: 'refused' })
     expect(store.getRepo('r1')?.path).toBe(oldPath)
@@ -126,88 +200,151 @@ describe('relocateProjectPath', () => {
       makeRepo({ id: 'r1', path: oldPath, kind: 'folder', connectionId: 'ssh-target-1' })
     )
 
-    const result = relocateProjectPath(store, 'r1', newPath)
+    const result = relocateProjectPath(
+      store,
+      store.getRepo('r1') as never,
+      newPath,
+      recordingNotifier().notify
+    )
 
     expect(result).toMatchObject({ outcome: 'refused' })
     expect(store.getRepo('r1')?.path).toBe(oldPath)
   })
 
-  it('leaves worktrees outside the project directory where they are', () => {
-    const store = createStore()
-    store.addRepo(makeRepo({ id: 'r1', path: oldPath, kind: 'git' }))
-    const siblingWorktreeId = `r1::${join(root, 'worktrees', 'feature')}`
-    store.setWorktreeMeta(`r1::${oldPath}`, { displayName: 'main' })
-    store.setWorktreeMeta(siblingWorktreeId, { displayName: 'feature' })
-
-    relocateProjectPath(store, 'r1', newPath)
-
-    // Only the checkout itself is addressed by the project path; a worktree under the base path is not.
-    expect(store.getWorktreeMeta(siblingWorktreeId)?.displayName).toBe('feature')
-    expect(store.getWorktreeMeta(`r1::${newPath}`)?.displayName).toBe('main')
-  })
-
-  it('reports an unchanged path without rewriting identity', () => {
+  it('reports an unchanged path without rewriting identity or announcing a rename', () => {
     const store = storeWithFolderProject()
     store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
+    const { notify, notices } = recordingNotifier()
 
-    const result = relocateProjectPath(store, 'r1', oldPath)
+    const result = relocateProjectPath(store, store.getRepo('r1') as never, oldPath, notify)
 
     expect(result.outcome).toBe('unchanged')
     expect(store.getWorktreeMeta(instanceWorkspaceId())?.displayName).toBe('draft')
+    expect(notices).toEqual([])
   })
 })
 
-describe('applyProjectHostSetupPathRelocation', () => {
-  beforeEach(() => {
-    testState.dir = mkdtempSync(join(tmpdir(), 'orca-relocate-setup-'))
-    root = mkdtempSync(join(tmpdir(), 'orca-projects-setup-'))
-    oldPath = join(root, 'example-project')
-    newPath = join(root, 'renamed-project')
-    mkdirSync(oldPath)
-    mkdirSync(newPath)
-  })
+describe('projectHostSetup.update entry points', () => {
+  beforeEach(() => makeDirs('entry'))
+  afterEach(cleanupDirs)
 
-  afterEach(() => {
-    rmSync(testState.dir, { recursive: true, force: true })
-    rmSync(root, { recursive: true, force: true })
-  })
-
-  it('relocates the project and hands persistence updates without a path', () => {
-    const store = storeWithFolderProject()
-    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
-
-    const { updates, relocatedRepo } = applyProjectHostSetupPathRelocation(store, {
-      setupId: 'r1',
-      updates: { path: newPath, displayName: 'Renamed' }
+  /** The RPC entry point, built the way the runtime builds it. */
+  function rpcController(store: Store): {
+    controller: RuntimeProjectHostSetupController
+    notices: RenameNotice[]
+  } {
+    const { notify, notices } = recordingNotifier()
+    const controller = new RuntimeProjectHostSetupController({
+      getStore: () => store as never,
+      listRepos: () => store.getRepos(),
+      addRepo: vi.fn() as never,
+      addRemoteRepo: vi.fn() as never,
+      cloneRepo: vi.fn() as never,
+      invalidateResolvedWorktrees: vi.fn(),
+      invalidateWorktreeScan: vi.fn(),
+      notifyReposChanged: vi.fn(),
+      notifyWorktreeRenamed: notify
     })
+    return { controller, notices }
+  }
 
-    expect(relocatedRepo?.path).toBe(newPath)
-    expect(updates).toEqual({ displayName: 'Renamed' })
-    // Persistence still refuses a raw path write, so the stripped update must survive it.
-    expect(() => store.updateProjectHostSetup({ setupId: 'r1', updates })).not.toThrow()
+  it('announces every re-keyed workspace through the RPC entry point', () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(rootWorkspaceId(), { displayName: 'example-project' })
+    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
+    const { controller, notices } = rpcController(store)
+
+    controller.updateSetup({ setupId: 'r1', updates: { path: newPath, displayName: 'Renamed' } })
+
+    expect(store.getRepo('r1')?.path).toBe(newPath)
     expect(store.getRepo('r1')?.displayName).toBe('Renamed')
+    expect(new Set(notices.map((notice) => notice.oldWorktreeId))).toEqual(
+      new Set([rootWorkspaceId(), instanceWorkspaceId()])
+    )
+    expect(new Set(notices.map((notice) => notice.newWorktreeId))).toEqual(
+      new Set([`r1::${newPath}`, `r1::${newPath}::workspace:${INSTANCE_UUID}`])
+    )
+  })
+
+  it('announces every re-keyed workspace through the IPC entry point', async () => {
+    const store = storeWithFolderProject()
+    store.setWorktreeMeta(rootWorkspaceId(), { displayName: 'example-project' })
+    store.setWorktreeMeta(instanceWorkspaceId(), { displayName: 'draft' })
+    const notifyWorktreeFolderRenamed = vi.fn()
+    const mainWindow = {
+      isDestroyed: () => false,
+      webContents: { send: vi.fn() }
+    }
+    registerProjectHostSetupHandlers(mainWindow as never, store, {
+      notifyWorktreeFolderRenamed
+    } as never)
+
+    const handler = ipcHandlers.get('projectHostSetups:update')
+    expect(handler).toBeDefined()
+    await handler?.({}, { setupId: 'r1', updates: { path: newPath } })
+
+    expect(store.getRepo('r1')?.path).toBe(newPath)
+    // The desktop surface must deliver the same signal the RPC surface does.
+    expect(new Set(notifyWorktreeFolderRenamed.mock.calls.map((call) => call[1]))).toEqual(
+      new Set([rootWorkspaceId(), instanceWorkspaceId()])
+    )
+  })
+
+  it("resolves the repo on the setup's own host, not a sibling row with the same id", () => {
+    const store = createStore()
+    // The same repo id on two hosts. Persistence documents that an id-only lookup writes one host's
+    // row from another's request; a relocation doing that would move the wrong project's files.
+    store.addRepo(makeRepo({ id: 'r1', path: oldPath, kind: 'folder' }))
+    store.addRepo(
+      makeRepo({ id: 'r1', path: '/srv/example', kind: 'folder', connectionId: 'ssh-target-1' })
+    )
+    const sshSetup = store
+      .getProjectHostSetups()
+      .find((setup) => setup.repoId === 'r1' && setup.hostId !== 'local')
+    expect(sshSetup).toBeDefined()
+    const { notify, notices } = recordingNotifier()
+
+    // Ask on behalf of the SSH setup. Its host owns that filesystem, so this must refuse rather
+    // than fall through to the local checkout and relocate it.
+    expect(() =>
+      applyProjectHostSetupPathRelocation(
+        {
+          getRepos: () => store.getRepos(),
+          relocateRepoPath: (repoId, path, hostId) => store.relocateRepoPath(repoId, path, hostId),
+          getProjectHostSetups: () => [sshSetup as never]
+        },
+        { setupId: sshSetup?.id as string, updates: { path: newPath } },
+        notify
+      )
+    ).toThrow(/another host/)
+    expect(store.getRepos().find((repo) => !repo.connectionId)?.path).toBe(oldPath)
+    expect(notices).toEqual([])
   })
 
   it('passes an update with no path change straight through', () => {
     const store = storeWithFolderProject()
+    const { notify, notices } = recordingNotifier()
 
-    const { updates, relocatedRepo } = applyProjectHostSetupPathRelocation(store, {
-      setupId: 'r1',
-      updates: { displayName: 'Renamed' }
-    })
+    const { updates, relocatedRepo } = applyProjectHostSetupPathRelocation(
+      store,
+      { setupId: 'r1', updates: { displayName: 'Renamed' } },
+      notify
+    )
 
     expect(relocatedRepo).toBeNull()
     expect(updates).toEqual({ displayName: 'Renamed' })
+    expect(notices).toEqual([])
   })
 
   it('surfaces the refusal instead of silently dropping the path', () => {
     const store = storeWithFolderProject()
 
     expect(() =>
-      applyProjectHostSetupPathRelocation(store, {
-        setupId: 'r1',
-        updates: { path: join(root, 'not-there') }
-      })
+      applyProjectHostSetupPathRelocation(
+        store,
+        { setupId: 'r1', updates: { path: join(root, 'not-there') } },
+        recordingNotifier().notify
+      )
     ).toThrow(/No directory exists/)
   })
 })

--- a/src/main/project-path-relocation.ts
+++ b/src/main/project-path-relocation.ts
@@ -2,15 +2,37 @@ import { statSync } from 'node:fs'
 import { isAbsolute } from 'node:path'
 import type { Repo } from '../shared/repo-types'
 import type { ProjectHostSetupUpdateArgs } from '../shared/project-types'
-import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  type ExecutionHostId
+} from '../shared/execution-host'
 import { normalizeRuntimePathForComparison } from '../shared/cross-platform-path'
+import type { RepoWorkspaceIdentityMove } from './persistence/tracking-repos/repo-path-relocation'
 
 /** The store surface a relocation needs; keeps this callable from the IPC and RPC entry points alike. */
 export type ProjectPathRelocationStore = {
-  getRepo: (id: string) => Repo | undefined
   getRepos: () => Repo[]
-  relocateRepoPath: (repoId: string, newPath: string) => Repo | null
+  relocateRepoPath: (
+    repoId: string,
+    newPath: string,
+    hostId?: ExecutionHostId
+  ) => { repo: Repo; moves: RepoWorkspaceIdentityMove[] } | null
 }
+
+/**
+ * Tells the rest of the app an id changed rather than disappeared.
+ *
+ * Required, not optional: every existing re-key site pairs the persistence write with this signal,
+ * because the renderer's worktree diff treats an id that stops appearing as a deletion and tears
+ * down the workspace's tabs and terminals. A relocation that only re-keys storage would lose live
+ * state that the old outright refusal never touched.
+ */
+export type WorktreeRenameNotifier = (
+  repoId: string,
+  oldWorktreeId: string,
+  newWorktreeId: string
+) => void
 
 export type ProjectPathRelocationResult =
   | { readonly outcome: 'relocated'; readonly repo: Repo }
@@ -32,18 +54,18 @@ function isExistingDirectory(pathValue: string): boolean {
  *
  * Refuses rather than guesses. A project on an SSH host is checked by the host that runs it, never
  * from here, so a remote relocation is declined outright instead of validated against local disk.
+ *
+ * Takes the resolved `repo`, not an id: the same id can exist on several execution hosts, and an
+ * id-only lookup would relocate a sibling host's row.
  */
 export function relocateProjectPath(
   store: ProjectPathRelocationStore,
-  repoId: string,
+  repo: Repo,
   rawNewPath: string,
+  notifyWorktreeRenamed: WorktreeRenameNotifier,
   options: { directoryExists?: (path: string) => boolean } = {}
 ): ProjectPathRelocationResult {
   const directoryExists = options.directoryExists ?? isExistingDirectory
-  const repo = store.getRepo(repoId)
-  if (!repo) {
-    return { outcome: 'refused', error: `Project not found: ${repoId}` }
-  }
   const newPath = rawNewPath.trim()
   if (!newPath || !isAbsolute(newPath)) {
     return { outcome: 'refused', error: 'The new project location must be an absolute path.' }
@@ -51,7 +73,8 @@ export function relocateProjectPath(
   if (normalizeRuntimePathForComparison(newPath) === normalizeRuntimePathForComparison(repo.path)) {
     return { outcome: 'unchanged', repo }
   }
-  if (repo.connectionId || getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
+  const hostId = getRepoExecutionHostId(repo)
+  if (repo.connectionId || hostId !== LOCAL_EXECUTION_HOST_ID) {
     return {
       outcome: 'refused',
       error:
@@ -63,7 +86,9 @@ export function relocateProjectPath(
     .getRepos()
     .find(
       (candidate) =>
-        candidate.id !== repo.id && normalizeRuntimePathForComparison(candidate.path) === newPathKey
+        candidate.id !== repo.id &&
+        getRepoExecutionHostId(candidate) === hostId &&
+        normalizeRuntimePathForComparison(candidate.path) === newPathKey
     )
   if (occupant) {
     return {
@@ -74,11 +99,14 @@ export function relocateProjectPath(
   if (!directoryExists(newPath)) {
     return { outcome: 'refused', error: `No directory exists at ${newPath}.` }
   }
-  const relocated = store.relocateRepoPath(repo.id, newPath)
+  const relocated = store.relocateRepoPath(repo.id, newPath, hostId)
   if (!relocated) {
-    return { outcome: 'refused', error: `Project could not be moved: ${repoId}` }
+    return { outcome: 'refused', error: `Project could not be moved: ${repo.id}` }
   }
-  return { outcome: 'relocated', repo: relocated }
+  for (const move of relocated.moves) {
+    notifyWorktreeRenamed(repo.id, move.from, move.to)
+  }
+  return { outcome: 'relocated', repo: relocated.repo }
 }
 
 /**
@@ -91,9 +119,10 @@ export function relocateProjectPath(
  */
 export function applyProjectHostSetupPathRelocation(
   store: ProjectPathRelocationStore & {
-    getProjectHostSetups?: () => readonly { id: string; repoId: string }[]
+    getProjectHostSetups?: () => readonly { id: string; repoId: string; hostId: ExecutionHostId }[]
   },
   args: ProjectHostSetupUpdateArgs,
+  notifyWorktreeRenamed: WorktreeRenameNotifier,
   options: { directoryExists?: (path: string) => boolean } = {}
 ): { updates: ProjectHostSetupUpdateArgs['updates']; relocatedRepo: Repo | null } {
   const requestedPath = args.updates.path
@@ -101,12 +130,21 @@ export function applyProjectHostSetupPathRelocation(
     return { updates: args.updates, relocatedRepo: null }
   }
   const setup = store.getProjectHostSetups?.().find((entry) => entry.id === args.setupId)
-  const repoId = setup?.repoId
+  // Resolve the row this setup actually owns. Matching on repo id alone would answer an SSH setup's
+  // request with the local checkout, which then passes the local-only guard and moves the wrong one.
+  const repo = setup
+    ? store
+        .getRepos()
+        .find(
+          (candidate) =>
+            candidate.id === setup.repoId && getRepoExecutionHostId(candidate) === setup.hostId
+        )
+    : undefined
   // An independent setup owns its own `path` field; only a repo-backed one is a project location.
-  if (!repoId || !store.getRepo(repoId)) {
+  if (!repo) {
     return { updates: args.updates, relocatedRepo: null }
   }
-  const result = relocateProjectPath(store, repoId, requestedPath, options)
+  const result = relocateProjectPath(store, repo, requestedPath, notifyWorktreeRenamed, options)
   if (result.outcome === 'refused') {
     throw new Error(result.error)
   }

--- a/src/main/project-path-relocation.ts
+++ b/src/main/project-path-relocation.ts
@@ -1,0 +1,118 @@
+import { statSync } from 'node:fs'
+import { isAbsolute } from 'node:path'
+import type { Repo } from '../shared/repo-types'
+import type { ProjectHostSetupUpdateArgs } from '../shared/project-types'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
+import { normalizeRuntimePathForComparison } from '../shared/cross-platform-path'
+
+/** The store surface a relocation needs; keeps this callable from the IPC and RPC entry points alike. */
+export type ProjectPathRelocationStore = {
+  getRepo: (id: string) => Repo | undefined
+  getRepos: () => Repo[]
+  relocateRepoPath: (repoId: string, newPath: string) => Repo | null
+}
+
+export type ProjectPathRelocationResult =
+  | { readonly outcome: 'relocated'; readonly repo: Repo }
+  | { readonly outcome: 'unchanged'; readonly repo: Repo }
+  | { readonly outcome: 'refused'; readonly error: string }
+
+function isExistingDirectory(pathValue: string): boolean {
+  try {
+    return statSync(pathValue).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Move a registered project to the directory it now lives in, keeping its id, its workspaces and
+ * their sessions. The single authority for a project path change: `updateRepo` deliberately cannot
+ * take `path`, because every workspace id is derived from it.
+ *
+ * Refuses rather than guesses. A project on an SSH host is checked by the host that runs it, never
+ * from here, so a remote relocation is declined outright instead of validated against local disk.
+ */
+export function relocateProjectPath(
+  store: ProjectPathRelocationStore,
+  repoId: string,
+  rawNewPath: string,
+  options: { directoryExists?: (path: string) => boolean } = {}
+): ProjectPathRelocationResult {
+  const directoryExists = options.directoryExists ?? isExistingDirectory
+  const repo = store.getRepo(repoId)
+  if (!repo) {
+    return { outcome: 'refused', error: `Project not found: ${repoId}` }
+  }
+  const newPath = rawNewPath.trim()
+  if (!newPath || !isAbsolute(newPath)) {
+    return { outcome: 'refused', error: 'The new project location must be an absolute path.' }
+  }
+  if (normalizeRuntimePathForComparison(newPath) === normalizeRuntimePathForComparison(repo.path)) {
+    return { outcome: 'unchanged', repo }
+  }
+  if (repo.connectionId || getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
+    return {
+      outcome: 'refused',
+      error:
+        'Only a project on this machine can be moved from here. Re-import a project that runs on another host from that host.'
+    }
+  }
+  const newPathKey = normalizeRuntimePathForComparison(newPath)
+  const occupant = store
+    .getRepos()
+    .find(
+      (candidate) =>
+        candidate.id !== repo.id && normalizeRuntimePathForComparison(candidate.path) === newPathKey
+    )
+  if (occupant) {
+    return {
+      outcome: 'refused',
+      error: `Another project ("${occupant.displayName}") is already registered at ${newPath}.`
+    }
+  }
+  if (!directoryExists(newPath)) {
+    return { outcome: 'refused', error: `No directory exists at ${newPath}.` }
+  }
+  const relocated = store.relocateRepoPath(repo.id, newPath)
+  if (!relocated) {
+    return { outcome: 'refused', error: `Project could not be moved: ${repoId}` }
+  }
+  return { outcome: 'relocated', repo: relocated }
+}
+
+/**
+ * Resolve the path change a setup update asks for before persistence sees it.
+ *
+ * A repo-backed setup's path is the project's registered path, so changing it is a relocation, not
+ * a field write — persistence refuses it outright for exactly that reason. Both the IPC and RPC
+ * entry points run this first so a caller reaching either one gets the same answer, and hand the
+ * remaining fields on with `path` already applied.
+ */
+export function applyProjectHostSetupPathRelocation(
+  store: ProjectPathRelocationStore & {
+    getProjectHostSetups?: () => readonly { id: string; repoId: string }[]
+  },
+  args: ProjectHostSetupUpdateArgs,
+  options: { directoryExists?: (path: string) => boolean } = {}
+): { updates: ProjectHostSetupUpdateArgs['updates']; relocatedRepo: Repo | null } {
+  const requestedPath = args.updates.path
+  if (requestedPath === undefined) {
+    return { updates: args.updates, relocatedRepo: null }
+  }
+  const setup = store.getProjectHostSetups?.().find((entry) => entry.id === args.setupId)
+  const repoId = setup?.repoId
+  // An independent setup owns its own `path` field; only a repo-backed one is a project location.
+  if (!repoId || !store.getRepo(repoId)) {
+    return { updates: args.updates, relocatedRepo: null }
+  }
+  const result = relocateProjectPath(store, repoId, requestedPath, options)
+  if (result.outcome === 'refused') {
+    throw new Error(result.error)
+  }
+  const { path: _path, ...rest } = args.updates
+  return {
+    updates: rest,
+    relocatedRepo: result.outcome === 'relocated' ? result.repo : null
+  }
+}

--- a/src/main/runtime/orca-runtime-preserved-branch-cleanup.ts
+++ b/src/main/runtime/orca-runtime-preserved-branch-cleanup.ts
@@ -216,7 +216,9 @@ export class OrcaRuntimeWithPreservedBranchCleanup extends OrcaRuntimeWithTermin
       (this as RuntimeCommandSurfaceHost<this>).cloneRepo(url, destination, hostId),
     invalidateResolvedWorktrees: () => this.invalidateResolvedWorktreeCache(),
     invalidateWorktreeScan: (repoId) => this.invalidateWorktreeScanCacheForRepo(repoId),
-    notifyReposChanged: () => this.notifyReposChanged()
+    notifyReposChanged: () => this.notifyReposChanged(),
+    notifyWorktreeRenamed: (repoId, oldWorktreeId, newWorktreeId) =>
+      this.notifyWorktreeFolderRenamed(repoId, oldWorktreeId, newWorktreeId)
   })
 
   protected readonly projectGroups = new RuntimeProjectGroupController({

--- a/src/main/runtime/runtime-project-host-setup-controller.test.ts
+++ b/src/main/runtime/runtime-project-host-setup-controller.test.ts
@@ -43,7 +43,8 @@ function makeController(): {
     cloneRepo,
     invalidateResolvedWorktrees: vi.fn(),
     invalidateWorktreeScan: vi.fn(),
-    notifyReposChanged: vi.fn()
+    notifyReposChanged: vi.fn(),
+    notifyWorktreeRenamed: vi.fn()
   })
   return {
     controller,

--- a/src/main/runtime/runtime-project-host-setup-controller.ts
+++ b/src/main/runtime/runtime-project-host-setup-controller.ts
@@ -22,6 +22,7 @@ import { getProjectIdForProviderIdentity } from '../../shared/project-host-setup
 import { getProjectHostSetupForRepo } from '../../shared/project-host-setup-lookup'
 import { invalidateAuthorizedRootsCache } from '../ipc/filesystem-auth'
 import { prepareLocalWorktreeRootForRepo } from '../worktree-root-preparation'
+import { applyProjectHostSetupPathRelocation } from '../project-path-relocation'
 import type { RuntimeStore } from './runtime-store-contract'
 
 type RuntimeProjectHostSetupDependencies = {
@@ -130,11 +131,32 @@ export class RuntimeProjectHostSetupController {
     if (!store?.updateProjectHostSetup) {
       throw new Error('runtime_unavailable')
     }
-    const result = store.updateProjectHostSetup(args)
+    // A repo-backed setup's path is the project's own location, so settle a move before the field
+    // write; persistence only ever sees updates whose `path` it can apply verbatim.
+    const { updates, relocatedRepo } = store.relocateRepoPath
+      ? applyProjectHostSetupPathRelocation(
+          {
+            getRepo: store.getRepo,
+            getRepos: store.getRepos,
+            relocateRepoPath: store.relocateRepoPath,
+            ...(store.getProjectHostSetups
+              ? { getProjectHostSetups: store.getProjectHostSetups }
+              : {})
+          },
+          args
+        )
+      : { updates: args.updates, relocatedRepo: null }
+    if (relocatedRepo) {
+      this.deps.invalidateResolvedWorktrees()
+      this.deps.invalidateWorktreeScan(relocatedRepo.id)
+      invalidateAuthorizedRootsCache()
+      this.deps.notifyReposChanged()
+    }
+    const result = store.updateProjectHostSetup({ ...args, updates })
     if (!result) {
       throw new Error(`Project host setup not found: ${args.setupId}`)
     }
-    if ('worktreeBasePath' in args.updates && result.repo) {
+    if ('worktreeBasePath' in updates && result.repo) {
       void prepareLocalWorktreeRootForRepo(store, result.repo)
       invalidateAuthorizedRootsCache()
     }

--- a/src/main/runtime/runtime-project-host-setup-controller.ts
+++ b/src/main/runtime/runtime-project-host-setup-controller.ts
@@ -40,6 +40,8 @@ type RuntimeProjectHostSetupDependencies = {
   invalidateResolvedWorktrees: () => void
   invalidateWorktreeScan: (repoId: string) => void
   notifyReposChanged: () => void
+  /** Carry old->new worktree id so the renderer re-keys instead of treating a relocation as a deletion. */
+  notifyWorktreeRenamed: (repoId: string, oldWorktreeId: string, newWorktreeId: string) => void
 }
 
 // Why clone alone still refuses: nothing in this process clones onto an SSH host. `cloneRepo` runs
@@ -133,22 +135,24 @@ export class RuntimeProjectHostSetupController {
     }
     // A repo-backed setup's path is the project's own location, so settle a move before the field
     // write; persistence only ever sees updates whose `path` it can apply verbatim.
-    const { updates, relocatedRepo } = store.relocateRepoPath
+    const relocateRepoPath = store.relocateRepoPath
+    const getProjectHostSetups = store.getProjectHostSetups
+    const { updates, relocatedRepo } = relocateRepoPath
       ? applyProjectHostSetupPathRelocation(
           {
-            getRepo: store.getRepo,
-            getRepos: store.getRepos,
-            relocateRepoPath: store.relocateRepoPath,
-            ...(store.getProjectHostSetups
-              ? { getProjectHostSetups: store.getProjectHostSetups }
+            // Bound: these are Store prototype methods and lose `this` when passed bare.
+            getRepos: () => store.getRepos(),
+            relocateRepoPath: (repoId, path, hostId) =>
+              relocateRepoPath.call(store, repoId, path, hostId),
+            ...(getProjectHostSetups
+              ? { getProjectHostSetups: () => getProjectHostSetups.call(store) }
               : {})
           },
-          args
+          args,
+          this.deps.notifyWorktreeRenamed
         )
       : { updates: args.updates, relocatedRepo: null }
     if (relocatedRepo) {
-      this.deps.invalidateResolvedWorktrees()
-      this.deps.invalidateWorktreeScan(relocatedRepo.id)
       invalidateAuthorizedRootsCache()
       this.deps.notifyReposChanged()
     }

--- a/src/main/runtime/runtime-store-contract.ts
+++ b/src/main/runtime/runtime-store-contract.ts
@@ -16,6 +16,7 @@ export type RuntimeStore = {
   getProjectHostSetups?: Store['getProjectHostSetups']
   createProjectHostSetup?: Store['createProjectHostSetup']
   updateProjectHostSetup?: Store['updateProjectHostSetup']
+  relocateRepoPath?: Store['relocateRepoPath']
   deleteProjectHostSetup?: Store['deleteProjectHostSetup']
   getProjectGroups?: Store['getProjectGroups']
   createProjectGroup?: Store['createProjectGroup']

--- a/src/main/worktree-lineage-pruning.test.ts
+++ b/src/main/worktree-lineage-pruning.test.ts
@@ -133,6 +133,31 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     expect(metaById[parentId].instanceId).toBe(edge.parentWorktreeInstanceId)
   })
 
+  it('keeps a folder workspace whose backing directory git still lists', () => {
+    // Why: `<repoId>::<path>::workspace:<uuid>` is one directory with several workspace identities.
+    // Reading the suffix as part of the path makes each one look like a checkout git dropped.
+    const rootId = 'repo-1::/repo'
+    const instanceId = 'repo-1::/repo::workspace:11111111-1111-1111-1111-111111111111'
+    const edge = lineage(instanceId, rootId)
+    const worktreeLineageById = { [instanceId]: edge }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(instanceId)]: workspaceLineage(instanceId, rootId)
+    }
+    const metaById = {
+      [rootId]: { instanceId: edge.parentWorktreeInstanceId } as WorktreeMeta,
+      [instanceId]: { instanceId: edge.worktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
+
+    pruneLineageForMissingRepoWorktrees(store as never, repo, [
+      { path: '/repo', head: 'a', branch: 'main', isBare: false, isMainWorktree: true }
+    ])
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
+    expect(worktreeLineageById[instanceId]).toBeDefined()
+  })
+
   it('refuses an empty scan when the repo still has registered lineage', () => {
     const parentId = 'repo-1::/repo/parent'
     const childId = 'repo-1::/repo/child'

--- a/src/main/worktree-lineage-pruning.ts
+++ b/src/main/worktree-lineage-pruning.ts
@@ -4,7 +4,7 @@ import type { WorkspaceLineage, WorktreeLineage } from '../shared/worktree/linea
 import type { GitWorktreeInfo } from '../shared/worktree/types'
 import { getRepoExecutionHostId } from '../shared/execution-host'
 import { isWorkspaceKey, parseWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
-import { splitWorktreeId } from '../shared/worktree/id'
+import { splitWorktreeIdForFilesystem } from '../shared/worktree/id'
 import { worktreeRetentionPathComparisonKey } from './worktree-retention-path-comparison'
 import type { Store } from './persistence'
 
@@ -72,7 +72,10 @@ export function pruneLineageForMissingRepoWorktrees(
     if (liveIds.has(worktreeId) || preservedMetadataCandidateIds?.has(worktreeId)) {
       return true
     }
-    const worktreePath = splitWorktreeId(worktreeId)?.worktreePath
+    // Why the filesystem view: a folder workspace's `::workspace:<uuid>` suffix is identity, not
+    // path. Reading it raw makes every folder workspace look like a directory git no longer lists,
+    // and prunes the lineage of workspaces whose directory is right there in `livePathKeys`.
+    const worktreePath = splitWorktreeIdForFilesystem(worktreeId)?.worktreePath
     if (!worktreePath) {
       return false
     }


### PR DESCRIPTION
## What this fixes

A registered project's **path** and **kind** are decided at import and then cannot be corrected in place. Every worktree-derived key is `<repoId>::<path>` with an optional `::workspace:<uuid>` suffix, so changing either one as a plain field write would strand the project's workspaces.

### STA-6870 — renaming a registered non-Git folder left no recovery (CLI recovery restored; no GUI affordance)

`updateRepoBackedProjectHostSetup` (`project-host-setup-update.ts:34`) threw on any path change, so a folder project whose directory was renamed outside Orca kept pointing at the old path forever: new terminals failed with `Working directory "<old-path>" does not exist`, and `project setup-update --path` was rejected with an error naming re-import — which mints a new repo id and orphans the project's workspaces.

The re-keying machinery already existed and was already paired with a delivery signal; only the project-level entry point was missing. `Store.relocateRepoPath` plans every workspace at or inside the checkout and re-keys each through `migrateWorktreeIdentity` (meta, lineage, tabs, browser pages, session state, `priorWorktreeIds`), then `relocateProjectPath` announces each move through `notifyWorktreeFolderRenamed` — the same old→new signal a worktree folder rename emits, so the renderer re-keys instead of reading the id change as a deletion. The notifier is a required argument, not an option, because a relocation that only re-keys storage would tear down the workspace's tabs and terminals. With no workspaces to move the notifier never fires, so neither entry point invalidates anything — correct, since nothing was re-keyed. Both the IPC and RPC entry points pass the same delivery.

`orca project setup-update --setup <id> --path <path>` — the exact command the reporter ran and got refused — now performs the relocation. **There is no GUI affordance**: nothing in the renderer calls `updateProjectHostSetup` with a `path`, and `SetProjectLocationDialog` creates a setup for a project that has none rather than relocating one that moved. A user working only in the app still has no in-place recovery, so **this PR should not auto-close STA-6870**; the affordance is a separate ticket on a different review surface.

Worktrees **inside** the project directory move with it: `worktreeBasePath` is resolved relative to `repo.path` (`configured-worktree-base-path.ts:18-22`), so a project on a relative base keeps its worktrees in the directory that is moving. A worktree under an absolute base lies outside and is correctly left alone. The tail below the root is split on separator boundaries and decided on the normalized form, so a differently spelled root cannot cut in the wrong place.

The repo is resolved on the **setup's own host**. The same repo id can exist on several execution hosts (`project-host-operations.ts:213-216`), and an id-only lookup answered an SSH setup's request with the local checkout, which then passed the local-only guard.

### Partially addresses STA-6710 — two writers disagreed about a project's kind

The `.git` upgrade watch refuses to flip a folder project that has folder workspaces, because the git listing branch would stop listing them. A project host setup update wrote `kind` blind (`project-host-setup-update.ts:48`), doing silently what the watch refuses. Both now share `refuseFolderProjectGitUpgradeReason`. The guard compares the parsed, normalized path rather than a raw string prefix, so a differently spelled id cannot report a project as safe to upgrade when it is not.

Separately, `pruneLineageForMissingRepoWorktrees` resolved a worktree id's path with `splitWorktreeId` instead of `splitWorktreeIdForFilesystem` (`worktree-lineage-pruning.ts:75`), reading a folder workspace's `::workspace:<uuid>` suffix as part of the directory name. Every folder workspace looked like a checkout git no longer lists and had its lineage pruned even though its directory was in `livePathKeys`. This only ever preserves more; nothing new is pruned.

## What this does NOT fix

**STA-6710 is not closed.** A project imported before its folder was a Git repo stays `kind: "folder"` forever once any folder workspace exists, so workspace creation keeps producing directory-alias workspaces — no `git worktree add`, hence the 1 ms `worktree.create` span reported as `Success` (`register-worktree-create-handlers.ts:66,103`). The persisted `kind` is the **selector** for which listing owns a project's workspaces: the folder listing enumerates `worktreeMeta` keys, the git listing enumerates `git worktree list` paths, and the key spaces are incompatible. Clearing the deadlock therefore means teaching the git listing to surface residual `::workspace:` rows across the four listing sites (`register-worktree-catalog-handlers.ts` ×2, `repo-worktree-row-resolution.ts`, `runtime-managed-worktree-queries.ts`), which changes what a paired client sees and needs its own wire review. Separate PR.

**STA-6524 is already fixed on `main`** by b7b6ea3942 (#19138), which added the `isFolderRepo` gate at `first-work-branch-rename.ts:174`. Verified by ablation. No change needed.

**STA-6602 is a different mechanism** — the renderer's `settingsProjectSetupSelection` is never set by the repo-row deep link, and `switchableProjectHostSetups` collapses setups by `hostId`. Repo *selection* in settings state, not project kind or path.

**STA-6681 has no reportable content.**

### Three further defects found in validation

**The project host setup row kept the old path.** Setups are projected from the repo catalog and `updateRepo` re-syncs that projection (`repo-update-operations.ts:186`); the relocation wrote `repo.path` directly and did not, so the setup row stayed stale until an unrelated catalog mutation rebuilt it. `setup.path` is what an automation resolves its run directory from (`automation-run-context.ts:34`) and what the sidebar groups projects by (`project-grouping.ts:57`), so a relocated project's automations would have run in the directory it just left. Now re-synced in the same write.

**The detected-worktree scan generation was not advanced.** `updateRepo` bumps a module-level generation counter for far smaller edits (`repo-lifecycle-operations.ts:71,99`), and the runtime's own invalidation touches different counters than the one `detected-worktree-scan-cache.ts:133` and `runtime-managed-worktree-queries.ts:164` key on, so a cache could keep answering for the directory the project had just left. Fail-soft — a stale detected listing — but every path a scan would report changes in a relocation, which is exactly what the generation exists to signal. Now bumped in the same write.

**The re-key named an execution host the folder-rename path does not.** `Store.migrateWorktreeIdentity` skips the legacy session migration outright when the host it is given disagrees with the row's own persisted `hostId`, so a workspace row carrying a `hostId` would have lost its tabs and session while the identity write appeared to succeed. Now matches the existing call site and passes no host.

## Precedent

In-repo precedent matches on the **persistence half** and was **absent on the delivery half**: `migrateWorktreeIdentity` is the established re-key primitive, and every existing call site bundles the rename notification with it — which this change did not, until review caught it. It now matches on both halves.

**Deviation worth recording:** two identity systems coexist — the path-derived locator and a stable `instanceId` with an alias table (`state.worktreeIdentityAliases`, `worktree-identity-metadata.ts:198-240`). Routing relocation through that alias table would make a move a one-row update instead of re-keying the locator everywhere. This change re-keys the locator, consistent with the existing rename path, and does not adopt the alias indirection.

## Known limitations and follow-ups

**The live terminal does not survive a relocation — inherited, not new, but more exposed.** A minted pty id embeds the worktree id that owned it (`<worktreeId>@@<uuid>`), and `migrateWorktreeIdentity` re-keys the tab but never rewrites that id, so the pane's pty is orphaned and re-activating mints a fresh shell. Evidenced by running both re-key paths over the same fixture: the pre-existing first-work folder-rename path and this relocation **both** leave `ptyId` spelling the old worktree id. Two tests pin that equivalence. Same mechanism does not mean same blast radius, though: the folder rename fires on a just-created worktree that has no live shell yet, while a relocation fires on a project the user has been working in, so a real terminal is far likelier to be lost here. Remapping pty identity is its own change with its own risk and is not attempted here.

**A still-open editor tab keeps its old absolute path** after the project moves and renders "Access denied: path resolves outside allowed directories" until reopened. Known rough edge, not fixed here.

Also disclosed, not fixed:

- Worktree ids present **only** in session state are not migrated — masked by discovery backfill, reachable before the first listing.
- The kind verdict reads legacy `worktreeMeta` and misses canonical-only rows that `getAllWorktreeMetaForHost` exposes.
- **Class sweep:** `local-worktree-runtime-options.ts:31`, `filesystem-source-control-ai-targets.ts:31,50` and `worktree-retention-path-comparison.ts:16` all use raw `splitWorktreeId` output as a filesystem path — the same mistake fixed here at `worktree-lineage-pruning.ts:75`, currently masked by the suffix-free root row.
- A projected project host setup carries the **repo id as its own id on every host**, so `setupId` alone cannot disambiguate hosts. This change resolves the repo from the resolved setup's `hostId`, matching what persistence does with the same lookup, so the two never diverge; the upstream ambiguity is untouched.

## Tests

22 new across `project-path-relocation.test.ts` (18), `worktree-lineage-pruning.test.ts` (1) and `persistence-update-repo.test.ts` (3, plus one message update). Two drive the **real entry points** — `RuntimeProjectHostSetupController.updateSetup` and the registered `projectHostSetups:update` IPC handler — and assert the **announced old→new payload**, not store internals. The rest drive the real `Store` from the shared persistence harness.

### Ablations (all at final head `6d5674d10e`, each restored with `cp` and verified byte-identical)

| # | Lever reverted (single) | Suite | Result |
|---|---|---|---|
| A1 | `worktree-lineage-pruning.ts` at `main` | lineage pruning | 1F / 5P |
| A2 | `project-host-setup-update.ts` at `main` | persistence update repo | 2F / 30P |
| A3 | `isFolderRepo` gate removed (STA-6524 proof) | first-work branch rename | 1F / 38P |
| A4 | identity migration removed from `relocateRepoPath` | relocation | 6F / 14P |
| A5 | planner drops the `::workspace:<uuid>` suffix | relocation | 5F / 15P |
| A6 | planner moves only the checkout, not descendants | relocation | 1F / 19P |
| A7 | preflight leaves `path` in the forwarded updates | relocation | 1F / 19P |
| A8 | **both entry-point wirings severed** | relocation | 2F / 18P |
| A10 | setup projection re-sync removed | relocation | 1F / 19P |
| A11 | execution host named at re-key again | relocation | 1F / 19P |
| A12 | scan-generation bump removed | relocation | 1F / 19P |
| A9 | **all levers that exist on `main`, together** | pruning + persistence | 3F / 35P, suites still load |

A8 is the arm that mattered: before review the same severing left every test green, because they pinned the unit rather than the shipping path. A7 also stayed green on the first pass — the assertion had been dropped in a rewrite and is restored.

**"Did the bad case get worse" arm:** `upgrades a folder project with no extra folder workspaces` and `still lets a git project become a folder project` pass with *and* without the change, so the new refusal did not widen into safe transitions. Refusal arms (missing directory, occupied path, non-local host, unchanged path) assert no half-migrated state **and no rename announced**.

### Gates at `6d5674d10e`

- vitest (persistence, relocation, lineage pruning, folder-repo upgrade, repos IPC, runtime tests, setup controller, CLI project setup): **1170 passed, 1 skipped**, exit 0. Timeout flakes appear on this machine under load (observed at load average 59-74, all failures at a flat ~30 s ceiling); every one passed in isolation and on an identical re-run, and none is in a file this branch touches.
- `tsc --noEmit -p config/tsconfig.node.json` exit 0 · `config/tsconfig.tc.cli.json` exit 0 · `config/tsconfig.tc.web.json` exit 0 (run separately)
- `pnpm exec oxlint --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings` exit 0, proven non-vacuous (planted duplicate import reports `import(no-duplicates)`, exit 1)
- `pnpm run check:code-quality:changed` — 0 findings across 16 files
- `pnpm-lock.yaml` absent from **all five** commits (verified per commit); no NUL bytes in any changed file

## Cross-platform / SSH / WSL / wire

- All path comparison goes through `normalizeRuntimePathForComparison`, which folds Windows drive/UNC and WSL alias spellings. No separator is assumed; the relocation tail is split on both `/` and `\`.
- No git command added or changed, so the Git 2.25 baseline is untouched. No child process spawned.
- SSH: relocation is refused for a repo with a `connectionId` or a non-local execution host, and the repo is now resolved on the setup's own host so a remote setup can never resolve the local row. The host that runs the project owns the filesystem check.
- Wire: no RPC params, stream frames or published payloads change shape. A relocation now emits `worktrees:changed` carrying the existing optional `renamed` field, which the preload bridge and renderer already handle. A path change that used to always throw can now succeed.
- Types: `Repo`, `ProjectHostSetup` and all shared types unchanged. `RuntimeStore` gains one optional `relocateRepoPath?`; `Store` gains one method; `RuntimeProjectHostSetupDependencies` gains one required `notifyWorktreeRenamed`.

## Validation

Run in Electron over four relocations (2 folder, 2 git). Relocation succeeds, persisted `repos[].path` and the `worktreeMeta` keys re-key on disk, and the announcement carries the correct old→new ids. All ten worktree-keyed renderer maps moved old→new, `activeWorktreeId` re-pointed, the sidebar row and an editor tab survived, and no purge warning fired — a trustworthy negative, since the same session observed real purge warnings elsewhere.

The terminal loss described above was isolated during that run: with a folder project the on-disk `mv` alone did **not** kill the shell, and two arms that performed no `mv` at all still lost it, which is what pointed at the shared re-key mechanism rather than the directory moving.
