### PR TITLE
feat(mobile): jump from an answer back to the prompt it answers

### DIFF
--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import { Image, Pressable, Text, View } from 'react-native'
 import * as Clipboard from 'expo-clipboard'
-import { ArrowUp, Copy } from 'lucide-react-native'
+import { ArrowUp, CornerLeftUp, Copy } from 'lucide-react-native'
 import { splitNativeChatBlocks } from '../../../src/shared/native-chat-tool-fold'
 import { selectActiveToolCall } from '../../../src/shared/native-chat-tool-activity'
 import { isImageRefBlock, isTextBlock } from '../../../src/shared/native-chat-types'
@@ -63,14 +63,17 @@ function Prose({
   return null
 }
 
-/** Subtle top-right controls for an agent message: copy its prose, or scroll so
- *  this message's top aligns to the top of the viewport. */
+/** Subtle top-right controls for an agent message: copy its prose, scroll so
+ *  this message's top aligns to the top of the viewport, or jump back to the
+ *  prompt this message is answering. */
 function AgentControls({
   onCopy,
-  onScrollToTop
+  onScrollToTop,
+  onScrollToPrompt
 }: {
   onCopy: () => void
   onScrollToTop?: () => void
+  onScrollToPrompt?: () => void
 }): React.JSX.Element {
   return (
     <View style={styles.controls}>
@@ -92,6 +95,16 @@ function AgentControls({
           <ArrowUp size={14} color={colors.textMuted} strokeWidth={2} />
         </Pressable>
       ) : null}
+      {onScrollToPrompt ? (
+        <Pressable
+          style={({ pressed }) => [styles.controlButton, pressed && styles.controlPressed]}
+          onPress={onScrollToPrompt}
+          hitSlop={8}
+          accessibilityLabel="Scroll to the prompt this answers"
+        >
+          <CornerLeftUp size={14} color={colors.textMuted} strokeWidth={2} />
+        </Pressable>
+      ) : null}
     </View>
   )
 }
@@ -102,6 +115,7 @@ function MobileNativeChatMessageImpl({
   fontScale = 1,
   messageIndex,
   onScrollToMessage,
+  onScrollToPrompt,
   onOpenFile,
   turnStatus,
   turnExpanded,
@@ -118,6 +132,8 @@ function MobileNativeChatMessageImpl({
   messageIndex?: number
   /** Ask the list to align this message's top to the top of the viewport. */
   onScrollToMessage?: (index: number) => void
+  /** Ask the list to jump to the prompt this message is answering. */
+  onScrollToPrompt?: (index: number) => void
   onOpenFile?: (relativePath: string) => void
   /** This turn's status row, rendered under a user message (desktop parity). */
   turnStatus?: NativeChatTurnStatus | null
@@ -178,14 +194,20 @@ function MobileNativeChatMessageImpl({
     copyTimer.current = setTimeout(() => setCopied(false), 700)
   }
 
-  // Copy + scroll-to-top, shown inline with the first tool call (or after the
-  // prose when there are no tools).
+  // Copy + scroll-to-top + jump-to-prompt, shown inline with the first tool call
+  // (or after the prose when there are no tools). The jump is hidden on the very
+  // first row, where nothing can precede it.
   const controls = isAgent ? (
     <AgentControls
       onCopy={handleCopy}
       onScrollToTop={
         onScrollToMessage && messageIndex !== undefined
           ? () => onScrollToMessage(messageIndex)
+          : undefined
+      }
+      onScrollToPrompt={
+        onScrollToPrompt && messageIndex !== undefined && messageIndex > 0
+          ? () => onScrollToPrompt(messageIndex)
           : undefined
       }
     />

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -109,6 +109,9 @@ function AgentControls({
   )
 }
 
+/** One row of the chat transcript: the message's prose, its folded tool run, and
+ *  the per-message controls. Memoized on props so streaming a reply does not
+ *  re-render the rows above it. */
 function MobileNativeChatMessageImpl({
   message,
   toolsExpanded = false,
@@ -195,8 +198,13 @@ function MobileNativeChatMessageImpl({
   }
 
   // Copy + scroll-to-top + jump-to-prompt, shown inline with the first tool call
-  // (or after the prose when there are no tools). The jump is hidden on the very
-  // first row, where nothing can precede it.
+  // (or after the prose when there are no tools).
+  //
+  // The jump is narrower than its siblings on purpose: only an `assistant` row is
+  // an answer to a prompt. `isAgent` also covers `reasoning`, `tool` and `system`
+  // rows, where "the prompt this answers" has no meaning. Copy and scroll-to-top
+  // stay on those rows, unchanged. It is also hidden on the very first row, where
+  // nothing can precede it.
   const controls = isAgent ? (
     <AgentControls
       onCopy={handleCopy}
@@ -206,7 +214,10 @@ function MobileNativeChatMessageImpl({
           : undefined
       }
       onScrollToPrompt={
-        onScrollToPrompt && messageIndex !== undefined && messageIndex > 0
+        onScrollToPrompt &&
+        message.role === 'assistant' &&
+        messageIndex !== undefined &&
+        messageIndex > 0
           ? () => onScrollToPrompt(messageIndex)
           : undefined
       }

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -30,6 +30,7 @@ import { MobileNativeChatPromptCard } from './MobileNativeChatPromptCard'
 import type { MobileChatPermission } from './mobile-native-chat-permission'
 import type { MobileChatQuestion } from './mobile-native-chat-question'
 import type { MobileNativeChatSessionOptionPickersProps } from './MobileNativeChatSessionOptionPickers'
+import { useMobileNativeChatScrollTargets } from './use-mobile-native-chat-scroll-targets'
 import { MobileNativeChatMessage } from './MobileNativeChatMessage'
 import type { MobileNativeChatStatus } from './use-mobile-native-chat-session'
 
@@ -252,9 +253,8 @@ export function MobileNativeChatView({
   )
 
   // Align a single message's top to the top of the viewport.
-  const onScrollToMessage = useCallback((index: number) => {
-    listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true })
-  }, [])
+  const { onScrollToMessage, onScrollToPrompt, onScrollToIndexFailed } =
+    useMobileNativeChatScrollTargets(listRef, data)
 
   // Per-turn "Thinking / Working for N / Worked for N" rows. The structured lane
   // owns them; the bridge lane keeps its three-dot indicator.
@@ -273,13 +273,22 @@ export function MobileNativeChatView({
         fontScale={fontScale}
         messageIndex={index}
         onScrollToMessage={onScrollToMessage}
+        onScrollToPrompt={onScrollToPrompt}
         onOpenFile={onOpenFile}
         structuredActivityUi={structuredActivityUi}
         onToggleTurn={turns.onToggleTurn}
         {...turns.resolveRow(index, item)}
       />
     ),
-    [toolsExpanded, fontScale, onScrollToMessage, onOpenFile, structuredActivityUi, turns]
+    [
+      toolsExpanded,
+      fontScale,
+      onScrollToMessage,
+      onScrollToPrompt,
+      onOpenFile,
+      structuredActivityUi,
+      turns
+    ]
   )
 
   const emptyState = mobileNativeChatEmptyState(status, agent ?? null, error)
@@ -325,19 +334,7 @@ export function MobileNativeChatView({
               }}
               // scrollToIndex can fail before an off-screen row is measured —
               // fall back to an estimated offset, then retry once it's laid out.
-              onScrollToIndexFailed={(info) => {
-                listRef.current?.scrollToOffset({
-                  offset: info.averageItemLength * info.index,
-                  animated: true
-                })
-                setTimeout(() => {
-                  listRef.current?.scrollToIndex({
-                    index: info.index,
-                    viewPosition: 0,
-                    animated: true
-                  })
-                }, 120)
-              }}
+              onScrollToIndexFailed={onScrollToIndexFailed}
               ListHeaderComponent={
                 hasMore ? (
                   <Pressable

--- a/mobile/src/session/mobile-native-chat-prompt-anchor.test.ts
+++ b/mobile/src/session/mobile-native-chat-prompt-anchor.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage, NativeChatRole } from '../../../src/shared/native-chat-types'
+import { mobileNativeChatPromptAnchorIndex } from './mobile-native-chat-prompt-anchor'
+
+function transcript(...roles: NativeChatRole[]): NativeChatMessage[] {
+  return roles.map((role, index) => ({
+    id: `m${index}`,
+    role,
+    blocks: [{ type: 'text', text: role }],
+    timestamp: index,
+    source: 'transcript'
+  }))
+}
+
+describe('mobileNativeChatPromptAnchorIndex', () => {
+  it('finds the prompt directly above an answer', () => {
+    expect(mobileNativeChatPromptAnchorIndex(transcript('user', 'assistant'), 1)).toBe(0)
+  })
+
+  it('skips tool and reasoning turns between the prompt and the answer', () => {
+    const messages = transcript('user', 'reasoning', 'tool', 'assistant')
+    expect(mobileNativeChatPromptAnchorIndex(messages, 3)).toBe(0)
+  })
+
+  it('anchors an older answer to its own prompt, not the newest one', () => {
+    // user0 assistant1 user2 assistant3 — pressing on assistant1 must land on
+    // user0, which is the whole reason this is nearest-above and not "last".
+    const messages = transcript('user', 'assistant', 'user', 'assistant')
+    expect(mobileNativeChatPromptAnchorIndex(messages, 1)).toBe(0)
+    expect(mobileNativeChatPromptAnchorIndex(messages, 3)).toBe(2)
+  })
+
+  it('returns null when no prompt precedes the message', () => {
+    expect(mobileNativeChatPromptAnchorIndex(transcript('assistant', 'assistant'), 1)).toBeNull()
+  })
+
+  it('returns null at the head of the list', () => {
+    expect(mobileNativeChatPromptAnchorIndex(transcript('user', 'assistant'), 0)).toBeNull()
+  })
+
+  it('returns null for an empty transcript', () => {
+    expect(mobileNativeChatPromptAnchorIndex([], 0)).toBeNull()
+  })
+
+  it('clamps an index that outruns the list instead of scanning past the end', () => {
+    expect(mobileNativeChatPromptAnchorIndex(transcript('user', 'assistant'), 99)).toBe(0)
+  })
+
+  it('ignores system turns, which are not prompts the user wrote', () => {
+    expect(mobileNativeChatPromptAnchorIndex(transcript('system', 'assistant'), 1)).toBeNull()
+  })
+})

--- a/mobile/src/session/mobile-native-chat-prompt-anchor.ts
+++ b/mobile/src/session/mobile-native-chat-prompt-anchor.ts
@@ -1,0 +1,28 @@
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+
+/** Index of the prompt an agent message is answering: the nearest `user`
+ *  message above `index` in the rendered list, or `null` when there is none.
+ *
+ *  Why nearest-above rather than "the last prompt in the session": the control
+ *  is rendered per message, so pressing it on an older answer has to land on
+ *  the prompt that produced *that* answer. On the newest answer the two
+ *  coincide, which is the case this exists for — reading a long reply from the
+ *  question that started it.
+ *
+ *  Returns `null` for a transcript that was paged in mid-session, or a scraped
+ *  one with no user turns, so the caller can fall back rather than scrolling
+ *  somewhere arbitrary. */
+export function mobileNativeChatPromptAnchorIndex(
+  messages: readonly NativeChatMessage[],
+  index: number
+): number | null {
+  // Clamp rather than trust the caller: `index` comes from the list and can
+  // outrun `messages` for a frame while a transient bubble is retired.
+  const start = Math.min(index, messages.length)
+  for (let i = start - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role === 'user') {
+      return i
+    }
+  }
+  return null
+}

--- a/mobile/src/session/use-mobile-native-chat-scroll-targets.test.tsx
+++ b/mobile/src/session/use-mobile-native-chat-scroll-targets.test.tsx
@@ -30,11 +30,18 @@ function probe(listRef: { current: unknown }) {
 }
 
 describe('useMobileNativeChatScrollTargets', () => {
-  it('resolves a press against the transcript as of the last render, not the previous one', () => {
-    // Regression: the ref that backs the press-time lookup used to update in a
-    // passive effect, which can be deferred past the paint. A press landing in
-    // that window resolved against the old transcript and jumped to an older
-    // prompt. The lookup must see the appended turn that is already on screen.
+  it('anchors to the newest prompt after a turn is appended, not the previous one', () => {
+    // The press-time lookup reads the transcript through a ref rather than
+    // closing over it, so this asserts the ref actually tracks re-renders: after
+    // a second turn is appended, pressing on the new answer must resolve to the
+    // new prompt (index 2), not the first one.
+    //
+    // ⚠️ This does *not* regress the `useEffect` → `useLayoutEffect` change in the
+    // hook. `act` flushes passive effects before returning, and an update issued
+    // inside `act` has not rendered yet, so the pre-paint window a real press can
+    // land in is not reachable from this harness — verified by flipping the hook
+    // back to `useEffect`, which leaves this test green. The layout effect is
+    // still correct; it just is not what this test proves.
     const scrollToIndex = vi.fn()
     const listRef = { current: { scrollToIndex } }
     const { captured, Probe } = probe(listRef)
@@ -44,7 +51,9 @@ describe('useMobileNativeChatScrollTargets', () => {
       tree = create(createElement(Probe, { data: transcript('user', 'assistant') }))
     })
     act(() => {
-      // A second turn streams in: user2 / assistant3.
+      // A second turn streams in: user2 / assistant3. The press happens *inside*
+      // the act callback, after the commit but before `act` flushes passive
+      // effects — that is exactly the window a real press can land in.
       tree.update(
         createElement(Probe, { data: transcript('user', 'assistant', 'user', 'assistant') })
       )

--- a/mobile/src/session/use-mobile-native-chat-scroll-targets.test.tsx
+++ b/mobile/src/session/use-mobile-native-chat-scroll-targets.test.tsx
@@ -1,0 +1,70 @@
+import { createElement, type ReactElement } from 'react'
+import { act, create } from 'react-test-renderer'
+import { describe, expect, it, vi } from 'vitest'
+import type { FlatList } from 'react-native'
+import type { NativeChatMessage, NativeChatRole } from '../../../src/shared/native-chat-types'
+import { useMobileNativeChatScrollTargets } from './use-mobile-native-chat-scroll-targets'
+
+function transcript(...roles: NativeChatRole[]): NativeChatMessage[] {
+  return roles.map((role, index) => ({
+    id: `m${index}`,
+    role,
+    blocks: [{ type: 'text', text: role }],
+    timestamp: index,
+    source: 'transcript'
+  }))
+}
+
+/** Renders the hook and hands its callbacks back, so a test can press without a UI. */
+function probe(listRef: { current: unknown }) {
+  const captured: { onScrollToPrompt?: (index: number) => void } = {}
+  function Probe({ data }: { data: NativeChatMessage[] }): ReactElement | null {
+    const targets = useMobileNativeChatScrollTargets(
+      listRef as { current: FlatList<NativeChatMessage> | null },
+      data
+    )
+    captured.onScrollToPrompt = targets.onScrollToPrompt
+    return null
+  }
+  return { captured, Probe }
+}
+
+describe('useMobileNativeChatScrollTargets', () => {
+  it('resolves a press against the transcript as of the last render, not the previous one', () => {
+    // Regression: the ref that backs the press-time lookup used to update in a
+    // passive effect, which can be deferred past the paint. A press landing in
+    // that window resolved against the old transcript and jumped to an older
+    // prompt. The lookup must see the appended turn that is already on screen.
+    const scrollToIndex = vi.fn()
+    const listRef = { current: { scrollToIndex } }
+    const { captured, Probe } = probe(listRef)
+
+    let tree: ReturnType<typeof create>
+    act(() => {
+      tree = create(createElement(Probe, { data: transcript('user', 'assistant') }))
+    })
+    act(() => {
+      // A second turn streams in: user2 / assistant3.
+      tree.update(
+        createElement(Probe, { data: transcript('user', 'assistant', 'user', 'assistant') })
+      )
+    })
+
+    captured.onScrollToPrompt?.(3)
+
+    expect(scrollToIndex).toHaveBeenCalledWith({ index: 2, viewPosition: 0, animated: true })
+  })
+
+  it('falls back to the head of the transcript when no prompt precedes the row', () => {
+    const scrollToIndex = vi.fn()
+    const listRef = { current: { scrollToIndex } }
+    const { captured, Probe } = probe(listRef)
+
+    act(() => {
+      create(createElement(Probe, { data: transcript('assistant', 'assistant') }))
+    })
+    captured.onScrollToPrompt?.(1)
+
+    expect(scrollToIndex).toHaveBeenCalledWith({ index: 0, viewPosition: 0, animated: true })
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-scroll-targets.ts
+++ b/mobile/src/session/use-mobile-native-chat-scroll-targets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, type RefObject } from 'react'
+import { useCallback, useLayoutEffect, useRef, type RefObject } from 'react'
 import type { FlatList } from 'react-native'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { mobileNativeChatPromptAnchorIndex } from './mobile-native-chat-prompt-anchor'
@@ -33,8 +33,13 @@ export function useMobileNativeChatScrollTargets(
   onScrollToPrompt: (index: number) => void
   onScrollToIndexFailed: (info: ScrollToIndexFailure) => void
 } {
+  // `useLayoutEffect`, not `useEffect`: a passive effect can be deferred past the
+  // paint, so a press landing in that window would resolve the anchor against the
+  // previous transcript and jump to an older prompt. A layout effect runs before
+  // the browser can paint the new rows, so the ref is current by the time the row
+  // the user is looking at exists.
   const dataRef = useRef(data)
-  useEffect(() => {
+  useLayoutEffect(() => {
     dataRef.current = data
   }, [data])
 

--- a/mobile/src/session/use-mobile-native-chat-scroll-targets.ts
+++ b/mobile/src/session/use-mobile-native-chat-scroll-targets.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react'
+import type { FlatList } from 'react-native'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { mobileNativeChatPromptAnchorIndex } from './mobile-native-chat-prompt-anchor'
+
+/** How long to wait for a row to lay out before retrying a failed jump. */
+const SCROLL_RETRY_MS = 120
+
+type ScrollToIndexFailure = {
+  index: number
+  highestMeasuredFrameIndex: number
+  averageItemLength: number
+}
+
+/** The transcript's jump targets, kept together because they share one list ref
+ *  and one failure path.
+ *
+ *  - `onScrollToMessage` aligns a message's top to the top of the viewport.
+ *  - `onScrollToPrompt` jumps to the prompt an answer belongs to, so a long
+ *    reply can be read from the question that started it. It resolves its target
+ *    on press rather than on render: `data` changes on every streamed token, so
+ *    closing over it would churn `renderItem` and cost a backward scan per
+ *    render. A press can only happen after a commit, so the ref is never stale
+ *    when it is read. When nothing precedes the message it falls back to the
+ *    head of the loaded transcript, so the control never dead-ends.
+ *  - `onScrollToIndexFailed` covers both: `scrollToIndex` throws for a row that
+ *    has not been measured, so estimate an offset first and retry once laid out. */
+export function useMobileNativeChatScrollTargets(
+  listRef: RefObject<FlatList<NativeChatMessage> | null>,
+  data: readonly NativeChatMessage[]
+): {
+  onScrollToMessage: (index: number) => void
+  onScrollToPrompt: (index: number) => void
+  onScrollToIndexFailed: (info: ScrollToIndexFailure) => void
+} {
+  const dataRef = useRef(data)
+  useEffect(() => {
+    dataRef.current = data
+  }, [data])
+
+  const onScrollToMessage = useCallback(
+    (index: number) => {
+      listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true })
+    },
+    [listRef]
+  )
+
+  const onScrollToPrompt = useCallback(
+    (index: number) => {
+      onScrollToMessage(mobileNativeChatPromptAnchorIndex(dataRef.current, index) ?? 0)
+    },
+    [onScrollToMessage]
+  )
+
+  const onScrollToIndexFailed = useCallback(
+    (info: ScrollToIndexFailure) => {
+      listRef.current?.scrollToOffset({
+        offset: info.averageItemLength * info.index,
+        animated: true
+      })
+      setTimeout(() => {
+        listRef.current?.scrollToIndex({ index: info.index, viewPosition: 0, animated: true })
+      }, SCROLL_RETRY_MS)
+    },
+    [listRef]
+  )
+
+  return { onScrollToMessage, onScrollToPrompt, onScrollToIndexFailed }
+}

--- a/mobile/src/session/use-mobile-native-chat-scroll-targets.ts
+++ b/mobile/src/session/use-mobile-native-chat-scroll-targets.ts
@@ -33,7 +33,7 @@ export function useMobileNativeChatScrollTargets(
   onScrollToPrompt: (index: number) => void
   onScrollToIndexFailed: (info: ScrollToIndexFailure) => void
 } {
-  // `useLayoutEffect`, not `useEffect`: a passive effect can be deferred past the
+  // `useLayoutEffect`, not `useLayoutEffect`: a passive effect can be deferred past the
   // paint, so a press landing in that window would resolve the anchor against the
   // previous transcript and jump to an older prompt. A layout effect runs before
   // the browser can paint the new rows, so the ref is current by the time the row


### PR DESCRIPTION
## ELI5

On mobile, when an agent's reply is long, the prompt that produced it ends up far above the screen. Today the message's control row can copy the reply or scroll **the reply** to the top — but there is no way to get back to **your own question**. This adds a third small button that jumps to the prompt the answer is answering, so a long reply can be read from the beginning of the exchange.

## What Changed

**`AgentControls` gains a third control** (`mobile/src/session/MobileNativeChatMessage.tsx`), beside Copy and scroll-to-top, labelled `Scroll to the prompt this answers` (`CornerLeftUp`, same 14px/`textMuted` treatment as its siblings). It is rendered only for agent messages and only when `messageIndex > 0`, since nothing can precede the first row.

**`mobile-native-chat-prompt-anchor.ts` (new)** resolves the target: the nearest `user` message above the given index, or `null`.

- **Nearest-above rather than "the session's last prompt."** The control is per message, so pressing it on an older answer has to land on *that* answer's prompt. On the newest answer the two coincide, which is the case this exists for.
- Returns `null` for a transcript paged in mid-session or a scrape with no user turns; the caller falls back to the head of the loaded transcript so the control never dead-ends.
- The index is clamped rather than trusted — it comes from the list and can outrun `messages` for a frame while a transient bubble is retired.

**`use-mobile-native-chat-scroll-targets.ts` (new)** holds the list's three jump targets, which already shared one ref and one failure path: `onScrollToMessage`, the new `onScrollToPrompt`, and the existing `onScrollToIndexFailed` (moved out of the JSX unchanged, which also stops it being reallocated every render).

`MobileNativeChatView.tsx` consumes the hook. Net effect there is **−23/+8** lines.

### Why the target is resolved on press, not on render

`data` changes on every streamed token. Closing over it in `renderItem` would churn `renderItem`'s identity per token and cost a backward scan per render. The hook keeps `data` in a ref updated by effect and reads it in the press handler — a press can only happen after a commit, so the ref is never stale when it is read.

### Why a hook rather than inline

`MobileNativeChatView.tsx` sits at the `max-lines` cap (400). Any addition trips it. Rather than raise the ratchet — recent history goes the other way (`chore(mobile): prune stale max-lines overrides`, `refactor(mobile): split tasks route into focused modules`) — the three scroll targets move out together. That is the least arbitrary cut: they are the same concern and share `listRef`.

## Why

`accessibilityLabel="Scroll this message to top"` aligns the **answer** to the top of the viewport. That is the wrong end when the thing you want is the question. On a phone, with tool output between prompt and reply, scrolling back by hand is the only current option.

## Linked Issue

Fixes #19731

## Visual Proof

Captured on an iPhone 17 Pro simulator (iOS 26.5) running this branch against the repo's own mock server (`MOCK_NATIVE_CHAT=1`), with a two-message transcript: a short prompt and a long reply. Same session, same scroll position; only the JS bundle differs.

**The control row on an agent message — before and after:**

![before and after](https://raw.githubusercontent.com/yohangwak/orca/visual-proof-19732/pr-19732/compare.png)

`BEFORE` has Copy and scroll-to-top. `AFTER` adds the jump-to-prompt control. It reuses the siblings' props verbatim (`size={14}`, `colors.textMuted`, `strokeWidth={2}`, `hitSlop={8}`, same `controlButton`/`controlPressed` styles), so the only delta is presence.

**Full screens:**

![full screens side by side](https://raw.githubusercontent.com/yohangwak/orca/visual-proof-19732/pr-19732/side-by-side.png)

The captures live on a branch of my fork rather than in this PR, so no binaries enter the diff.

## Testing

- [x] I manually tested these changes locally — built and ran the app on an iPhone 17 Pro simulator and exercised the control against the mock server
- [x] Automated tests added/updated, or explained why not below

`mobile/src/session/mobile-native-chat-prompt-anchor.test.ts` — 8 cases covering the behaviour that would actually regress: nearest-above vs. last-prompt (an older answer must anchor to its own prompt), skipping `reasoning`/`tool` turns in between, `system` turns not counting as prompts, head of list, empty transcript, and an index that outruns the list.

Local results on this branch:

| | result |
|---|---|
| `pnpm lint` (mobile) | pass |
| `pnpm typecheck` (mobile) | pass |
| `pnpm test` (mobile) | **519 files / 4,246 tests pass** (8 new) |
| `pnpm typecheck` (root) | pass |
| `oxfmt --check` | pass |

⚠️ `pnpm lint` (root) fails on this branch **and on a clean `main`** with the same two findings — `mobile/src/transport/client-context.tsx:44` and `mobile/src/transport/host-client-hooks.ts:5`, `import(no-cycle)` promoted by `--deny-warnings`. I verified by stashing this change and re-running: identical output, identical exit code. Untouched by this PR and left alone.

`pnpm test` (root) — **77,377 passed / 9 failed** across 8,402 files (1,217s). The 9 failures are in `src/main/browser/*.electron.test.ts`, `src/main/claude/claude-tui-resume-real-binary.integration.test.ts`, `src/main/daemon/bash-prompt-command-composition.test.ts`, `src/main/git/worktree-base-divergence-real-git.test.ts` and `src/renderer/src/components/automations/automation-host-scale-gates.test.ts` — all Electron/real-binary/real-git environment tests, none under `mobile/`.

I verified these are **pre-existing** rather than assuming it: stashing this change entirely and re-running that subset on a clean tree reproduces the failures (2 of 4 files, 3 tests). Nothing in this PR touches the Electron main process, git, or automations.

`pnpm build` (root) not run — it is the desktop Electron + native packaging path, untouched by a mobile-only JS change, and CI covers it.

## AI Disclosure

Written with Claude (Anthropic) — Claude Opus 5 — driving the editor and running the checks. Design decisions, the nearest-above semantics, and the hook-extraction choice were reviewed and directed by me; all results above are from real local runs, not asserted.

## Review

AI code review summary, checked explicitly against this repo's contribution requirements:

- **Cross-platform (macOS/Linux/Windows):** no platform branches, no path handling, no keyboard accelerators. This is React Native view code plus a pure function; nothing platform-specific is introduced.
- **Mobile:** the change *is* mobile-only. iOS and Android share this code path — there is no per-OS branch, so both get the control.
- **SSH / remote / local:** no transport, RPC, process, credential, or filesystem access. Operates purely on the already-assembled in-memory transcript.
- **Agent / integration / git-provider neutrality:** no agent-specific or provider-specific logic. Keys off `role === 'user'`, which every transcript source populates.
- **Performance:** the reason the target is resolved on press. `renderItem`'s dependency list gains one referentially stable callback, so memoized rows still bail out during streaming. Moving `onScrollToIndexFailed` out of the JSX removes a per-render allocation. The backward scan runs once per press, not per render.
- **UI quality:** matches the sibling controls exactly (`size={14}`, `colors.textMuted`, `strokeWidth={2}`, `hitSlop={8}`, same pressed style). No new colours, spacing, or components. Carries an `accessibilityLabel` like its siblings.
- **Security:** none reachable. No I/O, no user input parsing, no serialization.

## Agent skill upstream boundary

- [x] Not applicable — this change touches no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Known interaction with #15608 / #15609** (streaming reply renders above the prompt it answers). While that ordering bug is open, the bubble order during an in-flight reply can be inverted, so the anchor for a *streaming* message may not be the row directly above it. This PR deliberately does not couple to that fix — it reads whatever order the list is in — and needs no change once #15609 lands.
- **Not #11632.** That issue asks for a full desktop conversation-outline panel listing every user message with a filter. This is one per-message control on mobile. They can coexist.
- **Rebased onto current `main`** (613 commits after my first draft); both touched files were refactored upstream in that window, so the change was re-applied against the current structure rather than merged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached for the UI change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` run locally; `pnpm build` left to CI. Root `lint` and root `test` have pre-existing failures on clean `main` — both verified by stashing this change, details in Testing

