### PR TITLE
fix(terminal): deliver Windows Alt+Q to Pi queued-message dequeue

### DIFF
--- a/src/main/window/createMainWindow-terminal-alt-menu-bar.test.ts
+++ b/src/main/window/createMainWindow-terminal-alt-menu-bar.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', async () =>
+  (await import('./createMainWindow-test-harness')).electronModuleMock()
+)
+vi.mock('@electron-toolkit/utils', async () =>
+  (await import('./createMainWindow-test-harness')).electronToolkitUtilsMock()
+)
+vi.mock('./macos-tahoe-release', async () =>
+  (await import('./createMainWindow-test-harness')).macosTahoeReleaseMock()
+)
+vi.mock('../app-icon', async () => (await import('./createMainWindow-test-harness')).appIconMock())
+vi.mock('../browser/browser-manager', async () =>
+  (await import('./createMainWindow-test-harness')).browserManagerMock()
+)
+
+import { createMainWindow } from './createMainWindow'
+import { ipcMain } from 'electron'
+import { resetExpectedTeardownStateForTest } from '../crash-reporting/expected-teardown-state'
+import {
+  browserWindowMock,
+  resetMainWindowMocks,
+  withPlatform
+} from './createMainWindow-test-harness'
+
+function mountWindow(): {
+  beforeInput: (event: { preventDefault: () => void }, input: Record<string, unknown>) => void
+  setTerminalFocused: (focused: boolean) => void
+  webContents: { send: ReturnType<typeof vi.fn> }
+} {
+  const windowHandlers: Record<string, (...args: never[]) => void> = {}
+  const webContents = {
+    on: vi.fn((event: string, handler: (...args: never[]) => void) => {
+      windowHandlers[event] = handler
+    }),
+    setZoomLevel: vi.fn(),
+    setBackgroundThrottling: vi.fn(),
+    invalidate: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+    send: vi.fn(),
+    isDevToolsOpened: vi.fn(),
+    openDevTools: vi.fn(),
+    closeDevTools: vi.fn()
+  }
+  browserWindowMock.mockImplementation(function () {
+    return {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(() => Promise.resolve()),
+      loadURL: vi.fn(() => Promise.resolve())
+    }
+  })
+  createMainWindow({
+    getUI: () => ({}),
+    getSettings: () => ({})
+  } as never)
+  const setFocusedListener = vi
+    .mocked(ipcMain.on)
+    .mock.calls.find(([channel]) => channel === 'ui:setTerminalInputFocused')?.[1]
+  return {
+    beforeInput: windowHandlers['before-input-event'] as never,
+    setTerminalFocused: (focused) => {
+      setFocusedListener?.({ sender: webContents } as never, focused)
+    },
+    webContents
+  }
+}
+
+const bareAlt = {
+  type: 'keyDown',
+  key: 'Alt',
+  code: 'AltLeft',
+  alt: true,
+  control: false,
+  meta: false,
+  shift: false
+}
+
+describe('terminal Alt menu-bar toggle', () => {
+  beforeEach(() => {
+    resetMainWindowMocks()
+    resetExpectedTeardownStateForTest()
+  })
+
+  it('prevents Windows Alt from revealing the menu while the terminal is focused', () => {
+    withPlatform('win32', () => {
+      const { beforeInput, setTerminalFocused, webContents } = mountWindow()
+      setTerminalFocused(true)
+      const preventDefault = vi.fn()
+      beforeInput({ preventDefault }, bareAlt)
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+      expect(webContents.send).not.toHaveBeenCalled()
+    })
+  })
+
+  it('lets Alt+Q reach the renderer so Pi can dequeue', () => {
+    withPlatform('win32', () => {
+      const { beforeInput, setTerminalFocused, webContents } = mountWindow()
+      setTerminalFocused(true)
+      const preventDefault = vi.fn()
+      beforeInput({ preventDefault }, { ...bareAlt, key: 'q', code: 'KeyQ' })
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(webContents.send).not.toHaveBeenCalled()
+    })
+  })
+
+  it('still reveals the menu on Alt when the terminal is not focused', () => {
+    withPlatform('win32', () => {
+      const { beforeInput, webContents } = mountWindow()
+      const preventDefault = vi.fn()
+      beforeInput({ preventDefault }, bareAlt)
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(webContents.send).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/main/window/main-window-shortcut-routing.ts
+++ b/src/main/window/main-window-shortcut-routing.ts
@@ -22,6 +22,15 @@ import type { MainWindowFocusLifecycle } from './main-window-focus-lifecycle'
 import { sendResolvedWindowShortcutAction } from './main-window-shortcut-actions'
 import { isMacAppPasteInput } from './main-window-visual-lifecycle'
 
+function isBareAltMenuBarToggle(input: Electron.Input): boolean {
+  return (
+    !input.control &&
+    !input.meta &&
+    !input.shift &&
+    (input.key === 'Alt' || input.code === 'AltLeft' || input.code === 'AltRight')
+  )
+}
+
 export function installMainWindowShortcutRouting(args: {
   focus: MainWindowFocusLifecycle
   mainWindow: BrowserWindow
@@ -182,6 +191,17 @@ export function installMainWindowShortcutRouting(args: {
         }
         // No allowlisted action: let the keydown reach the renderer, whose detector completes and dispatches inline.
       }
+    }
+
+    // Why: Windows/Linux autoHideMenuBar uses Alt to reveal the native menu, which
+    // swallows Alt+letter/arrow before xterm. Pi's Windows dequeue chord is Alt+Q.
+    if (
+      process.platform !== 'darwin' &&
+      (focus.isTerminalInputFocused() || focus.isFloatingTerminalInputFocused()) &&
+      isBareAltMenuBarToggle(input)
+    ) {
+      event.preventDefault()
+      return
     }
 
     if (

--- a/src/renderer/src/components/terminal-pane/terminal-option-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-option-shortcut-policy.ts
@@ -83,12 +83,46 @@ function kittyEncodesModifiedTextKeys(flags: number): boolean {
   )
 }
 
+function isPhysicalLetterOrDigitCode(code: string | undefined): boolean {
+  return (
+    (code?.startsWith('Key') === true && code.length === 4) ||
+    (code?.startsWith('Digit') === true && code.length === 6)
+  )
+}
+
+// Why: Mac Option encoding is layout-aware; Windows/Linux Alt+letter must still
+// report CSI-u when kitty is on so Pi's Windows dequeue (alt+q) matches.
+function resolveNonMacAltKittyLetterAction(
+  event: TerminalOptionShortcutEvent,
+  context: TerminalOptionShortcutContext
+): TerminalOptionShortcutAction | null {
+  if (event.shiftKey || isImeOwnedKey(event) || !isPhysicalLetterOrDigitCode(event.code)) {
+    return null
+  }
+  const flags = context.getKittyKeyboardFlags()
+  if (!kittyEncodesModifiedTextKeys(flags)) {
+    return null
+  }
+  const data = encodeTerminalOptionKittyEvent(event, {
+    flags,
+    type: event.repeat === true ? 'repeat' : 'press',
+    layoutCharacterForCode: context.layoutCharacterForCode,
+    primaryCharacterFallback: optionKittyPrimaryCharacterFallback(event)
+  })
+  return data === null
+    ? null
+    : { type: 'sendInput', data, optionKittyRelease: createRelease(flags) }
+}
+
 export function resolveTerminalOptionShortcutAction(
   event: TerminalOptionShortcutEvent,
   context: TerminalOptionShortcutContext
 ): TerminalOptionShortcutAction | null {
-  if (!context.isMac || event.metaKey || event.ctrlKey || !event.altKey) {
+  if (event.metaKey || event.ctrlKey || !event.altKey) {
     return null
+  }
+  if (!context.isMac) {
+    return resolveNonMacAltKittyLetterAction(event, context)
   }
   const isLeftOption = (context.optionKeyLocations & 1) !== 0
   const isRightOption = (context.optionKeyLocations & 2) !== 0

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-windows-alt-letter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-windows-alt-letter.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveTerminalShortcutAction,
+  type TerminalShortcutEvent
+} from './terminal-shortcut-policy'
+
+function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent {
+  return {
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    repeat: false,
+    ...overrides
+  }
+}
+
+function resolveWindowsKitty(
+  input: TerminalShortcutEvent,
+  kittyKeyboardFlags = 1
+): ReturnType<typeof resolveTerminalShortcutAction> {
+  return resolveTerminalShortcutAction(
+    input,
+    false,
+    'false',
+    0,
+    true,
+    undefined,
+    undefined,
+    () => kittyKeyboardFlags
+  )
+}
+
+describe('Windows/Linux Alt+letter in kitty panes', () => {
+  it('reports alt+q as CSI-u so Pi dequeue reaches the TUI', () => {
+    expect(resolveWindowsKitty(event({ key: 'q', code: 'KeyQ', altKey: true }))).toEqual({
+      type: 'sendInput',
+      data: '\x1b[113;3u'
+    })
+  })
+
+  it('leaves alt+q to xterm when kitty is inactive', () => {
+    expect(resolveWindowsKitty(event({ key: 'q', code: 'KeyQ', altKey: true }), 0)).toBeNull()
+  })
+
+  it('does not rewrite alt+arrow (xterm already encodes CSI 1;3A/B)', () => {
+    expect(resolveWindowsKitty(event({ key: 'ArrowUp', code: 'ArrowUp', altKey: true }))).toBeNull()
+    expect(
+      resolveWindowsKitty(event({ key: 'ArrowDown', code: 'ArrowDown', altKey: true }))
+    ).toBeNull()
+  })
+
+  it('does not steal AltGr text (ctrl+alt)', () => {
+    expect(
+      resolveWindowsKitty(event({ key: 'q', code: 'KeyQ', altKey: true, ctrlKey: true }))
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
## ELI5

On Windows, Pi shows “Alt+Q to edit queued messages,” but Orca was eating that key. Native Pi works; Orca did not. This lets Alt+Q reach Pi.

## What Changed

- While a terminal is focused on Windows/Linux, do not let `autoHideMenuBar` steal the Alt key for the native menu.
- When Kitty keyboard protocol is active, encode Windows/Linux Alt+letter as CSI-u (same as macOS Option chords), so Pi matches `alt+q`.

## Why

Pi’s Windows dequeue binding is `Alt+Q`. Two Orca layers dropped it:

1. Electron `autoHideMenuBar` reveals the menu on Alt.
2. Kitty CSI-u encoding for Alt+letter was macOS-only, so with Kitty on, Pi ignored legacy `Esc+q`.

Confirmed outside Orca: native Pi Alt+Q restores the queue.

## Linked Issue

Fixes #19733

## Visual Proof

N/A — no rendered UI change. Keyboard routing only. Verify by queuing a Pi steer on Windows and pressing Alt+Q; the composer should refill.

## Testing

- [x] Automated tests added/updated, or explained why not below
- [ ] I manually tested these changes locally

Tests:

- `src/renderer/src/components/terminal-pane/terminal-shortcut-windows-alt-letter.test.ts`
- `src/main/window/createMainWindow-terminal-alt-menu-bar.test.ts`
- existing Option-compose / shortcut-policy suites still pass

Platform: unit tests on Windows. No live Orca UI session in this change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Cross-platform: macOS Option encoding unchanged. Linux gets the same Alt menu-bar + CSI-u treatment. AltGr (Ctrl+Alt) is not rewritten. SSH: encoding follows the client keyboard; kitty flags still come from the PTY.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)