### PR TITLE
fix(terminal): prevent duplicate resumes of completed live agents

### DIFF
--- a/src/renderer/src/lib/host-mirrored-pane-resume-replay.test.ts
+++ b/src/renderer/src/lib/host-mirrored-pane-resume-replay.test.ts
@@ -5,6 +5,10 @@ import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-
 import { makeCreatedAgentWorktree } from '@/lib/worktree-activation-created-agent-test-state'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import {
+  RESUMABLE_TUI_AGENTS,
+  type AgentProviderSessionMetadata
+} from '../../../shared/agent-session-resume'
+import {
   hasHostSessionMirrorHydrated,
   markHostSessionMirrorHydrated,
   resetHostSessionMirrorHydrationForTests
@@ -193,6 +197,72 @@ describe('parked mirrored-pane resume replay', () => {
     expect(after.sleepingAgentSessionsByPaneKey[paneKey]).toBeDefined()
     expect(Object.keys(after.automaticAgentResumeClaimsByTabId)).toHaveLength(0)
   })
+
+  it.each(
+    RESUMABLE_TUI_AGENTS.flatMap((agent) =>
+      (['working', 'done'] as const).flatMap((checkpointState) =>
+        [
+          { livePtyIds: ['pty-host-old-1'], expectedLaunches: 0 },
+          { livePtyIds: [], expectedLaunches: 1 },
+          { livePtyIds: ['other-pane-pty'], expectedLaunches: 1 }
+        ].map((scenario) => ({ agent, checkpointState, ...scenario }))
+      )
+    )
+  )(
+    'checks exact live ownership before resuming $agent $checkpointState with $livePtyIds',
+    ({ agent, checkpointState, livePtyIds, expectedLaunches }) => {
+      const worktree = makeRuntimeOwnedWorktree()
+      seedState(worktree)
+      const paneKey = seedSleepingRecord(worktree.id, 'completed-session')
+      const providerSession: AgentProviderSessionMetadata = {
+        key: agent === 'antigravity' ? 'conversation_id' : 'session_id',
+        id: 'completed-session',
+        ...(agent === 'pi' || agent === 'prime-agent'
+          ? { transcriptPath: `/remote/${agent}/session.jsonl` }
+          : {})
+      }
+      const record = {
+        ...useAppStore.getState().sleepingAgentSessionsByPaneKey[paneKey]!,
+        agent,
+        providerSession
+      }
+      const stalePaneKey = makePaneKey('old-tab', LEAF_ID)
+      useAppStore.setState({
+        ptyIdsByTabId: { [WEB_TAB_ID]: [...livePtyIds] },
+        sleepingAgentSessionsByPaneKey: {
+          [stalePaneKey]: {
+            ...record,
+            paneKey: stalePaneKey,
+            tabId: 'old-tab',
+            state: checkpointState,
+            origin: 'quit'
+          }
+        },
+        agentStatusByPaneKey: {
+          [paneKey]: {
+            paneKey,
+            tabId: WEB_TAB_ID,
+            worktreeId: worktree.id,
+            agentType: record.agent,
+            providerSession: record.providerSession,
+            state: 'done',
+            prompt: '',
+            updatedAt: 2000,
+            stateStartedAt: 2000,
+            stateHistory: []
+          }
+        }
+      })
+      markHostSessionMirrorHydrated(RUNTIME_ENV_ID)
+
+      expect(resumeSleepingAgentSessionsForWorktree(worktree.id)).toBe(expectedLaunches)
+      const after = useAppStore.getState()
+      expect(after.tabsByWorktree[worktree.id]).toHaveLength(1 + expectedLaunches)
+      expect(after.tabsByWorktree[worktree.id]?.[0]?.id).toBe(WEB_TAB_ID)
+      expect(after.sleepingAgentSessionsByPaneKey[stalePaneKey]).toBeUndefined()
+      expect(Object.keys(after.pendingStartupByTabId)).toHaveLength(expectedLaunches)
+    }
+  )
 
   it('drops the hydrated verdict when the host reconnects under a new runtime id', () => {
     connectRuntime('runtime-a')

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -4,10 +4,12 @@ import {
   type SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../shared/stable-pane-id'
 import {
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,
-  recordPaneIsOwnedByPreservedPane
+  recordPaneIsOwnedByPreservedPane,
+  stablePaneHasLivePty
 } from './sleeping-agent-pane-ownership'
 import {
   launchSleepingAgentSession,
@@ -96,11 +98,25 @@ function activeOrQueuedResumeClaimsProviderSession(
     if (samePaneOwnsRecovery && entry.paneKey === record.paneKey) {
       continue
     }
+    const tabId = getAgentStatusTabId(entry)
+    const pane = parsePaneKey(entry.paneKey)
+    // A completed turn still owns its transcript while its exact PTY is live.
+    const completedPaneIsLive = Boolean(
+      entry.state === 'done' &&
+      pane &&
+      tabId === pane.tabId &&
+      stablePaneHasLivePty(
+        pane.tabId,
+        pane.leafId,
+        state.ptyIdsByTabId,
+        state.terminalLayoutsByTabId[pane.tabId]
+      )
+    )
     if (
-      worktreeTabIds.has(getAgentStatusTabId(entry) ?? '') &&
+      worktreeTabIds.has(tabId ?? '') &&
       entry.worktreeId === record.worktreeId &&
       entry.agentType === record.agent &&
-      entry.state !== 'done' &&
+      (entry.state !== 'done' || completedPaneIsLive) &&
       agentProviderSessionsEqual(record.agent, entry.providerSession, record.providerSession)
     ) {
       return true

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -94,7 +94,7 @@ function hasRestorableStablePanePty(
 // the pane that reconnects on activation. Liveness comes from the runtime
 // live-PTY map (ptyIdsByTabId), not the layout's ptyIdsByLeafId snapshot, which
 // persists stale across sleep/restart.
-function stablePaneHasLivePty(
+export function stablePaneHasLivePty(
   tabId: string,
   leafId: string,
   ptyIdsByTabId: Record<string, string[]>,


### PR DESCRIPTION
## ELI5

An agent can finish answering while its terminal is still running. Opening that workspace should show the existing conversation, not start a second copy. This change prevents a stale recovery record from reopening a completed session that already has a live terminal.

## What Changed

- Include completed agent statuses in automatic-resume deduplication only when their exact pane has a live PTY.
- Reuse the existing stable-pane liveness check rather than trusting persisted PTY hints or introducing another liveness implementation.
- Preserve workspace, agent, and provider-session identity checks and the existing in-place recovery path.
- Add 84 regression scenarios generated from the canonical list of all 14 resumable agents: working/done checkpoints crossed with matching, absent, and different live PTYs. Use Antigravity conversation IDs and Pi/Prime Agent transcript paths where required.

## Why

The automatic recovery sweep previously excluded every `done` status. A stale checkpoint pointing at an old tab could therefore launch a second terminal beside the same provider session in a completed but still-live pane. The original regression tests failed by launching one extra tab before the fix.

## Linked Issue

Fixes #19735

## Visual Proof

No visual change to layout, styling, or components. The intentional interaction change is that workspace selection no longer creates an unsolicited restored-session tab for this case.

The reporter's macOS recording shows `Terminal 2` displaying `session restored` beside the original Pi tab, then disappearing. It contains unrelated workspace content and is not uploaded. No rendered after-recording or desktop end-to-end verification has been performed; this PR provides store-level regression evidence, not a claim of visual validation.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

On Linux, with `ORCA_BACKGROUND_LAUNCH=1`:

- 135 tests passed across five targeted suites: `host-mirrored-pane-resume-replay`, `resume-sleeping-agent-session`, `pi-live-session-no-duplicate-tab`, `pi-session-resume-wake`, and `host-session-mirror-hydration-frame-ordering`.
- `pnpm tc:web` passed.
- Changed-file oxlint, React Doctor lint, oxfmt, and `git diff --check` passed.
- Full-repository lint/typecheck/test/build and platform integration validation are left to CI. No macOS/Windows app launch or live SSH/paired-host test was performed.

## AI Disclosure

Implemented and tested with an OpenAI coding assistant.

## Review

- **Cross-platform:** pure renderer state logic; no OS-specific commands, shortcuts, or filesystem operations added. Test transcript paths describe the simulated remote host.
- **Remote/SSH/local:** uses existing exact live-PTY ownership evidence and leaves host-authority/hydration guards intact. A completed status alone cannot claim live ownership. No wire or host-published content changes.
- **Agents/integrations:** all 14 resumable agents covered using the canonical registry and their provider-session identity formats; no Git-provider-specific changes.
- **Performance:** constant-time pane/layout lookups inside the existing status scan; no new RPC, timer, subscription, or process probe.
- **UI quality:** preserves the existing surface instead of opening a duplicate; visual/manual validation remains pending as documented above.
- **Security:** no new execution or credential access; reduces the risk of concurrent writers on the same provider transcript.

## Agent skill upstream boundary

- [x] Not applicable: no agent skill-sharing or installer code changed.

## Notes

**Draft — ongoing investigation and validation.** Keep adding follow-up commits to this PR. Do not mark ready, merge, or close #19735 until full testing is complete. The `Fixes #19735` link will close the issue on merge, not while this PR remains open. Full validation is a release gate, not waived by the targeted tests below.

Both folder workspaces and git worktrees use the same workspace/provider-session checks. The tests simulate paired-host state; they are not live remote integration tests. The report's intermittent disappearing-versus-persistent behavior is not claimed to be fully reproduced end-to-end.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (CI to cover)

