### PR TITLE
fix(browser): strip app/Electron UA tokens on WhatsApp Web

### DIFF
--- a/src/main/browser/browser-manager-navigation.ts
+++ b/src/main/browser/browser-manager-navigation.ts
@@ -1,6 +1,7 @@
 import { openPopupWithOriginBar, type PopupChildWindowOptions } from './popup-origin-bar-window'
 import { getBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
 import { googleAuthUserAgent, isGoogleAuthUrl } from './browser-google-auth-ua'
+import { isWhatsAppWebUrl, whatsAppCompatUserAgent } from './browser-whatsapp-ua'
 import { buildViewportUserAgentOverride } from './browser-viewport-user-agent'
 import {
   safeOrigin,
@@ -42,13 +43,16 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
         ? latestPendingOverride
         : confirmedOverride
     const currentUa = currentOverride?.userAgent ?? guest.getUserAgent()
-    const nextUa = isGoogleAuthUrl(url)
-      ? firefoxUa
-      : // Only restore when the auth-host override is actually in place, so normal
-        // navigation never touches the session UA.
-        currentUa === firefoxUa
-        ? guest.session.getUserAgent()
-        : null
+    const sessionUa = guest.session.getUserAgent()
+    // Why: WhatsApp Web is the second host-scoped identity exception — its UA sniffing rejects
+    // the Electron/app tokens, so that host gets the session identity minus those tokens.
+    const whatsAppUa = whatsAppCompatUserAgent(sessionUa)
+    const hostScopedUa = isGoogleAuthUrl(url) ? firefoxUa : isWhatsAppWebUrl(url) ? whatsAppUa : null
+    // Only restore when a host-scoped override is actually in place, so normal
+    // navigation never touches the session UA.
+    const hostScopedOverrideActive =
+      currentUa === firefoxUa || (whatsAppUa !== sessionUa && currentUa === whatsAppUa)
+    const nextUa = hostScopedUa ?? (hostScopedOverrideActive ? sessionUa : null)
     let authOverrideIssuedOverCdp = false
     if (nextUa !== null && nextUa !== currentUa) {
       // Why: WebContents.setUserAgent() during a redirect makes Chromium cancel the in-flight

--- a/src/main/browser/browser-session-ua.ts
+++ b/src/main/browser/browser-session-ua.ts
@@ -7,24 +7,31 @@ import {
   setUserAgentHeader,
   stripClientHints
 } from './browser-google-auth-ua'
+import { isWhatsAppWebUrl, whatsAppCompatUserAgent } from './browser-whatsapp-ua'
 
 // Why: the session keeps Electron's stock UA. Stripping the Electron/app tokens to look like
 // plain Chrome is what Cloudflare Turnstile rejects (error 600010): a Chrome UA that ships no
 // client hints reads as a spoof, while a declared Electron client clears the same challenge.
-// This handler only owns the Google auth-host Firefox switch, which is a proven, host-scoped
-// exception that must stay consistent across the header and every cross-host subresource.
+// This handler only owns the proven, host-scoped exceptions — the Google auth-host Firefox
+// switch and the WhatsApp Web token strip — which must stay consistent across the header and
+// every cross-host subresource.
 export function setupGoogleAuthUserAgentOverride(sess: Session): void {
   const firefoxUa = googleAuthUserAgent()
 
   sess.webRequest.onBeforeSendHeaders({ urls: ['https://*/*'] }, (details, callback) => {
     const headers = details.requestHeaders
+    const requestUa = currentUserAgent(headers)
     if (isGoogleAuthUrl(details.url)) {
       // Why: present a Firefox identity on Google's sign-in hosts so the user logs
       // in inside the app and Google issues self-refreshing bound cookies. Strip
       // sec-ch-ua* because real Firefox sends none.
       setUserAgentHeader(headers, firefoxUa)
       stripClientHints(headers)
-    } else if (currentUserAgent(headers) === firefoxUa) {
+    } else if (isWhatsAppWebUrl(details.url) && requestUa !== undefined) {
+      // Why: WhatsApp Web's "update Chrome" gate trips on the Electron/app UA tokens; keep the
+      // wire identity in step with the navigator.userAgent switch in applyGoogleAuthUserAgent.
+      setUserAgentHeader(headers, whatsAppCompatUserAgent(requestUa))
+    } else if (requestUa === firefoxUa) {
       // Why: while the auth document is on screen the WebContents UA is Firefox, so its
       // cross-host subresource/XHR requests carry the Firefox UA yet still bear Chromium
       // client hints — a sharper cross-host identity tell than either alone.

--- a/src/main/browser/browser-viewport-user-agent.test.ts
+++ b/src/main/browser/browser-viewport-user-agent.test.ts
@@ -30,6 +30,20 @@ describe('buildViewportUserAgentOverride', () => {
     expect(override.userAgentMetadata).toBeUndefined()
   })
 
+  it('strips the app and Electron tokens on WhatsApp Web, keeping the Chrome identity', () => {
+    const electronUa =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Orca/1.4.198 Chrome/150.0.7871.224 Electron/43.4.1 Safari/537.36'
+    const override = buildViewportUserAgentOverride({
+      url: 'https://web.whatsapp.com/',
+      mobile: false,
+      baseUserAgent: electronUa
+    })
+    expect(override.userAgent).toBe(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.7871.224 Safari/537.36'
+    )
+    expect(override.userAgentMetadata).toBeUndefined()
+  })
+
   it('splices the real Chrome major into the mobile UA and its client hints', () => {
     const override = buildViewportUserAgentOverride({
       url: 'https://example.com/',

--- a/src/main/browser/browser-viewport-user-agent.ts
+++ b/src/main/browser/browser-viewport-user-agent.ts
@@ -5,6 +5,7 @@
 // the exact UA mismatch this scope exists to remove.
 
 import { googleAuthUserAgent, isGoogleAuthUrl } from './browser-google-auth-ua'
+import { isWhatsAppWebUrl, whatsAppCompatUserAgent } from './browser-whatsapp-ua'
 
 type UserAgentBrand = { brand: string; version: string }
 
@@ -44,8 +45,13 @@ export function buildViewportUserAgentOverride(args: {
     return { userAgent: googleAuthUserAgent() }
   }
   if (!args.mobile) {
-    // Why: desktop presets republish the session's own identity unchanged.
-    return { userAgent: args.baseUserAgent }
+    // Why: desktop presets republish the session's own identity unchanged — except on WhatsApp
+    // Web, whose UA sniffing rejects the Electron/app tokens (see browser-whatsapp-ua.ts).
+    return {
+      userAgent: isWhatsAppWebUrl(args.url)
+        ? whatsAppCompatUserAgent(args.baseUserAgent)
+        : args.baseUserAgent
+    }
   }
   const chromeMajor = extractChromeMajor(args.baseUserAgent)
   // Why: userAgentMetadata must accompany the mobile UA so client hints match, or bot-detection flags the desktop-hint leak.

--- a/src/main/browser/browser-whatsapp-ua.test.ts
+++ b/src/main/browser/browser-whatsapp-ua.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { isWhatsAppWebUrl, whatsAppCompatUserAgent } from './browser-whatsapp-ua'
+
+const ELECTRON_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Orca/1.4.198 Chrome/150.0.7871.224 Electron/43.4.1 Safari/537.36'
+const STRIPPED_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.7871.224 Safari/537.36'
+
+describe('isWhatsAppWebUrl', () => {
+  it('matches the WhatsApp Web host exactly', () => {
+    expect(isWhatsAppWebUrl('https://web.whatsapp.com/')).toBe(true)
+    expect(isWhatsAppWebUrl('https://WEB.WHATSAPP.COM/qr')).toBe(true)
+  })
+
+  it('does not match other WhatsApp surfaces or lookalikes', () => {
+    expect(isWhatsAppWebUrl('https://www.whatsapp.com/')).toBe(false)
+    expect(isWhatsAppWebUrl('https://faq.whatsapp.com/')).toBe(false)
+    expect(isWhatsAppWebUrl('https://web.whatsapp.com.evil.test/')).toBe(false)
+    expect(isWhatsAppWebUrl('https://whatsapp.com/')).toBe(false)
+    expect(isWhatsAppWebUrl('not a url')).toBe(false)
+  })
+})
+
+describe('whatsAppCompatUserAgent', () => {
+  it('drops only the app and Electron tokens, keeping the Chrome identity byte-identical', () => {
+    expect(whatsAppCompatUserAgent(ELECTRON_UA)).toBe(STRIPPED_UA)
+  })
+
+  it('handles the lowercase app token dev builds emit', () => {
+    expect(
+      whatsAppCompatUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) orca/1.0.0 Chrome/134.0.0.0 Electron/30.0.0 Safari/537.36'
+      )
+    ).toBe(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36'
+    )
+  })
+
+  it('returns a UA without those tokens unchanged', () => {
+    expect(whatsAppCompatUserAgent(STRIPPED_UA)).toBe(STRIPPED_UA)
+    const firefoxUa = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0'
+    expect(whatsAppCompatUserAgent(firefoxUa)).toBe(firefoxUa)
+  })
+
+  it('is idempotent', () => {
+    expect(whatsAppCompatUserAgent(whatsAppCompatUserAgent(ELECTRON_UA))).toBe(STRIPPED_UA)
+  })
+})

--- a/src/main/browser/browser-whatsapp-ua.ts
+++ b/src/main/browser/browser-whatsapp-ua.ts
@@ -1,0 +1,26 @@
+// Why: web.whatsapp.com UA-sniffs and shows its "update Chrome" wall whenever the Electron/app
+// tokens are present, even alongside a current Chrome token. The fix is host-scoped, mirroring
+// the Google auth-host Firefox switch: the session-wide UA deliberately keeps the Electron
+// tokens (see browser-session-ua.ts — a Chrome-shaped app-wide identity is what Cloudflare
+// Turnstile rejects), so only WhatsApp Web sees the session identity minus those tokens.
+// Client hints stay untouched: Chromium's real sec-ch-ua brands carry no Electron entry, so
+// they agree with the stripped Chrome-format UA.
+
+// Why: exact hostname match — www/faq.whatsapp.com are ordinary sites that accept the stock UA,
+// and only the web client gates on it.
+const WHATSAPP_WEB_HOST = 'web.whatsapp.com'
+
+export function isWhatsAppWebUrl(rawUrl: string): boolean {
+  try {
+    return new URL(rawUrl).hostname.toLowerCase() === WHATSAPP_WEB_HOST
+  } catch {
+    return false
+  }
+}
+
+// Why: drop ONLY the app and Electron product tokens (case-insensitive — dev builds emit a
+// lowercase app token); platform, Chrome build, and WebKit/Safari tokens must stay byte-identical
+// to the engine's own identity or the UA stops matching the real Chromium underneath.
+export function whatsAppCompatUserAgent(userAgent: string): string {
+  return userAgent.replace(/\s?\bOrca\/\S+/i, '').replace(/\s?\bElectron\/\S+/i, '')
+}


### PR DESCRIPTION
### Problem

Opening https://web.whatsapp.com in Orca's embedded browser shows WhatsApp's browser gate — "WhatsApp works with Google Chrome 100+ / To use WhatsApp, update Chrome" — even though the runtime is current.

Reproduced on Orca 1.4.198 (macOS): the embedded tabs send

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Orca/1.4.198 Chrome/150.0.7871.224 Electron/43.4.1 Safari/537.36
```

WhatsApp's UA sniffing trips on the `Electron/…` (and app) product tokens and refuses the session despite `Chrome/150`.

### Fix

Host-scoped UA exception for `web.whatsapp.com` only, mirroring the existing Google auth-host Firefox switch: that host sees the session identity minus the `Orca/…` and `Electron/…` tokens (platform, Chrome and WebKit/Safari tokens stay byte-identical to the real engine). Applied consistently in the three places a UA is decided:

- `browser-session-ua.ts` — the wire header via `webRequest.onBeforeSendHeaders`
- `browser-manager-navigation.ts` — the navigation-time `navigator.userAgent` override (with restore when leaving the host)
- `browser-viewport-user-agent.ts` — the desktop viewport UA builder

The session-wide UA deliberately keeps the Electron tokens: per the existing comment in `browser-session-ua.ts`, a Chrome-shaped app-wide identity is exactly what Cloudflare Turnstile rejects (error 600010). Only the one host that gates on those tokens gets the stripped identity. Client hints are untouched — Chromium's real `sec-ch-ua` brands carry no Electron entry, so they agree with the stripped UA.

Scope guard: exact-hostname match (`web.whatsapp.com` only — `www`/`faq.whatsapp.com` accept the stock UA), lookalike hosts rejected.

### Verification

- Unit tests added: `browser-whatsapp-ua.test.ts` (host matching incl. lookalikes, token stripping incl. lowercase dev token, idempotence) and a WhatsApp case in `browser-viewport-user-agent.test.ts`.
- Tests were **not run locally** (fresh clone without the native runtime/deps; the install is long-running) — relying on CI.
- Manual repro of the bug itself was done against the released 1.4.198 build; the fixed build was not manually exercised.
