### PR TITLE
fix(computer): check macOS permissions in the execution process

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -211,6 +211,12 @@ final class Provider {
 
     func handle(method: String, params: [String: JSONValue]) throws -> Any {
         switch method {
+        case "permissionsStatus":
+            let status = permissionStatusSnapshotSettled()
+            return [
+                "accessibility": status.accessibilityGranted ? "granted" : "not-granted",
+                "screenshots": status.screenshotsGranted ? "granted" : "not-granted",
+            ]
         case "handshake":
             return providerHandshake()
         case "listApps":
@@ -495,6 +501,7 @@ final class Provider {
                     "moveResize": false,
                 ],
                 "observation": [
+                    "permissionStatus": true,
                     "screenshot": true,
                     "annotatedScreenshot": false,
                     "elementFrames": true,
@@ -606,7 +613,7 @@ final class Provider {
             // should open macOS privacy prompts/settings; runtime calls stay quiet.
             throw ProviderError.coded(
                 "permission_denied",
-                "Accessibility permission is required for Orca Computer Use. Run `orca computer permissions` or open Settings > Computer Use, grant Accessibility to Orca Computer Use, then retry."
+                "Accessibility permission is denied for the computer-use execution process. Run `orca computer permissions`. If Orca Computer Use is already allowed, check Accessibility for the app that runs computer use (usually Orca), then retry."
             )
         }
         let appElement = AXUIElementCreateApplication(app.pid)

--- a/src/main/computer/macos-computer-use-permission-status.test.ts
+++ b/src/main/computer/macos-computer-use-permission-status.test.ts
@@ -1,221 +1,84 @@
-import { execFileSync, spawn, spawnSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
-import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getComputerUsePermissionStatus } from './macos-computer-use-permission-status'
 
-const resolveHelperAppPathMock = vi.hoisted(() => vi.fn())
-const resolveHelperExecutablePathMock = vi.hoisted(() => vi.fn())
-const permissionStatusTempDir = '/tmp/orca-computer-use-permissions-test'
-const permissionStatusPath = join(permissionStatusTempDir, 'status.json')
-
-vi.mock('child_process', () => ({
-  execFileSync: vi.fn(),
-  spawn: vi.fn(() => {
-    const child = {
-      stdout: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
-      stderr: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
-      on: vi.fn((event: string, callback: (status: number) => void) => {
-        if (event === 'close') {
-          queueMicrotask(() => callback(0))
-        }
-        return child
-      }),
-      off: vi.fn(() => child),
-      unref: vi.fn()
-    }
-    return child
-  }),
-  spawnSync: vi.fn()
+const { statusMock, appPathMock, executablePathMock } = vi.hoisted(() => ({
+  statusMock: vi.fn(),
+  appPathMock: vi.fn(),
+  executablePathMock: vi.fn()
 }))
 
-vi.mock('fs/promises', () => ({
-  mkdtemp: vi.fn(),
-  readFile: vi.fn(),
-  rm: vi.fn(),
-  stat: vi.fn()
-}))
-
+vi.mock('./sidecar-client', () => ({ callComputerSidecarPermissionStatus: statusMock }))
 vi.mock('./macos-native-provider-paths', () => ({
-  resolveMacOSComputerUseAppPath: resolveHelperAppPathMock,
-  resolveMacOSComputerUseExecutablePath: resolveHelperExecutablePathMock
+  resolveMacOSComputerUseAppPath: appPathMock,
+  resolveMacOSComputerUseExecutablePath: executablePathMock
 }))
 
-describe('getComputerUsePermissionStatus', () => {
-  const originalPlatform = process.platform
-
-  beforeEach(() => {
-    vi.mocked(spawn).mockClear()
-    vi.mocked(spawnSync).mockClear()
-    vi.mocked(execFileSync).mockReset()
-    vi.mocked(mkdtemp).mockReset()
-    vi.mocked(readFile).mockReset()
-    vi.mocked(rm).mockReset()
-    vi.mocked(stat).mockReset()
-    resolveHelperAppPathMock.mockReset()
-    resolveHelperExecutablePathMock.mockReset()
-    resolveHelperAppPathMock.mockReturnValue('/Applications/Orca Computer Use.app')
-    resolveHelperExecutablePathMock.mockReturnValue(
-      '/Applications/Orca Computer Use.app/Contents/MacOS/orca-computer-use-macos'
-    )
-    vi.mocked(mkdtemp).mockResolvedValue(permissionStatusTempDir)
-    vi.mocked(stat).mockResolvedValue({} as Awaited<ReturnType<typeof stat>>)
-    mockPermissionStatus('{"accessibility":"granted","screenshots":"granted"}')
-    setPlatform('darwin')
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-    setPlatform(originalPlatform)
-  })
-
-  it('wraps permission status helper launch failures', async () => {
-    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
-    const child = {
-      stdout: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
-      stderr: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
-      on: vi.fn((event: string, callback: (error: Error) => void) => {
-        if (event === 'error') {
-          queueMicrotask(() => callback(new Error('spawn ENOENT /private/path')))
-        }
-        return child
-      }),
-      off: vi.fn(() => child),
-      unref: vi.fn()
-    }
-    vi.mocked(spawn).mockImplementationOnce(() => child as unknown as ReturnType<typeof spawn>)
-
-    await expect(getComputerUsePermissionStatus()).rejects.toMatchObject({
-      name: 'RuntimeClientError',
-      code: 'accessibility_error',
-      message: 'Could not check permissions: failed to launch helper'
-    })
-    expect(rm).toHaveBeenCalledWith(permissionStatusTempDir, {
-      recursive: true,
-      force: true
-    })
-  })
-
-  it('removes permission status helper listeners after close', async () => {
-    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
-    const child = {
-      stdout: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
-      stderr: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
-      on: vi.fn((event: string, callback: (status: number) => void) => {
-        if (event === 'close') {
-          queueMicrotask(() => callback(0))
-        }
-        return child
-      }),
-      off: vi.fn(() => child),
-      unref: vi.fn()
-    }
-    vi.mocked(spawn).mockImplementationOnce(() => child as unknown as ReturnType<typeof spawn>)
-
-    await expect(getComputerUsePermissionStatus()).resolves.toMatchObject({
-      helperUnavailableReason: null
-    })
-
-    expect(child.stdout.off).toHaveBeenCalledWith('data', expect.any(Function))
-    expect(child.stderr.off).toHaveBeenCalledWith('data', expect.any(Function))
-    expect(child.off).toHaveBeenCalledWith('error', expect.any(Function))
-    expect(child.off).toHaveBeenCalledWith('close', expect.any(Function))
-  })
-
-  it('times out when the permission status helper launch never closes', async () => {
-    vi.useFakeTimers()
-    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
-    const child = {
-      stdout: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
-      stderr: { off: vi.fn(), on: vi.fn(), setEncoding: vi.fn() },
-      on: vi.fn(() => child),
-      off: vi.fn(() => child),
-      kill: vi.fn(),
-      unref: vi.fn()
-    }
-    vi.mocked(spawn).mockImplementationOnce(() => child as unknown as ReturnType<typeof spawn>)
-
-    let settled = false
-    const statusPromise = getComputerUsePermissionStatus().then(
-      (status) => {
-        settled = true
-        return status
-      },
-      (error: unknown) => {
-        settled = true
-        throw error
-      }
-    )
-    const rejection = expect(statusPromise).rejects.toMatchObject({
-      name: 'RuntimeClientError',
-      code: 'accessibility_error',
-      message: 'Timed out launching permission helper'
-    })
-
-    await vi.advanceTimersByTimeAsync(5000)
-
-    expect(settled).toBe(true)
-    await rejection
-    expect(child.kill).toHaveBeenCalled()
-    expect(rm).toHaveBeenCalledWith(permissionStatusTempDir, {
-      recursive: true,
-      force: true
-    })
-  })
-
-  it('reads permission status through the helper app identity', async () => {
-    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
-    mockPermissionStatus('{"accessibility":"granted","screenshots":"not-granted"}')
-
-    await expect(getComputerUsePermissionStatus()).resolves.toEqual({
-      platform: 'darwin',
-      helperAppPath: '/Applications/Orca Computer Use.app',
-      helperUnavailableReason: null,
-      permissions: [
-        { id: 'accessibility', status: 'granted' },
-        { id: 'screenshots', status: 'not-granted' }
-      ]
-    })
-    expect(spawn).toHaveBeenCalledWith(
-      '/usr/bin/open',
-      [
-        '-n',
-        '/Applications/Orca Computer Use.app',
-        '--args',
-        '--permission-status-file',
-        permissionStatusPath
-      ],
-      { stdio: ['ignore', 'pipe', 'pipe'] }
-    )
-    expect(spawnSync).not.toHaveBeenCalled()
-    expect(readFile).toHaveBeenCalledWith(permissionStatusPath, 'utf8')
-    expect(rm).toHaveBeenCalledWith(permissionStatusTempDir, {
-      recursive: true,
-      force: true
-    })
-  })
-
-  it('returns unavailable permission status when the helper app is missing on macOS', async () => {
-    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
-    resolveHelperAppPathMock.mockReturnValue(null)
-
-    await expect(getComputerUsePermissionStatus()).resolves.toEqual({
-      platform: 'darwin',
-      helperAppPath: null,
-      helperUnavailableReason: 'Orca Computer Use.app was not found',
-      permissions: [
-        { id: 'accessibility', status: 'not-granted' },
-        { id: 'screenshots', status: 'not-granted' }
-      ]
-    })
-    expect(execFileSync).not.toHaveBeenCalled()
-  })
+const originalPlatform = process.platform
+beforeEach(() => {
+  vi.resetAllMocks()
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+  appPathMock.mockReturnValue('/Applications/Orca Computer Use.app')
+  executablePathMock.mockReturnValue(
+    '/Applications/Orca Computer Use.app/Contents/MacOS/orca-computer-use-macos'
+  )
+})
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
 })
 
-function mockPermissionStatus(json: string): void {
-  vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>)
-  vi.mocked(readFile).mockResolvedValue(json)
-}
+describe('execution-process permission status', () => {
+  it('reports execution denial even when a separately launched helper could be authorized', async () => {
+    statusMock.mockResolvedValue({ accessibility: 'not-granted', screenshots: 'granted' })
+    await expect(getComputerUsePermissionStatus()).resolves.toMatchObject({
+      helperUnavailableReason: null,
+      permissions: [
+        { id: 'accessibility', status: 'not-granted' },
+        { id: 'screenshots', status: 'granted' }
+      ]
+    })
+    expect(statusMock).toHaveBeenCalledOnce()
+  })
 
-function setPlatform(platform: NodeJS.Platform): void {
-  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
-}
+  it('refreshes execution status after a permission change', async () => {
+    statusMock
+      .mockResolvedValueOnce({ accessibility: 'not-granted', screenshots: 'not-granted' })
+      .mockResolvedValueOnce({ accessibility: 'granted', screenshots: 'granted' })
+    await getComputerUsePermissionStatus()
+    expect(
+      (await getComputerUsePermissionStatus()).permissions.every((p) => p.status === 'granted')
+    ).toBe(true)
+    expect(statusMock).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(['unsupported_capability', 'accessibility_error', 'action_timeout'])(
+    'preserves %s instead of probing another process',
+    async (code) => {
+      const error = Object.assign(new Error('execution probe failed'), { code })
+      statusMock.mockRejectedValue(error)
+      await expect(getComputerUsePermissionStatus()).rejects.toBe(error)
+    }
+  )
+
+  it.each(['app', 'executable'])(
+    'does not start the sidecar when the %s is missing',
+    async (missing) => {
+      if (missing === 'app') {
+        appPathMock.mockReturnValue(null)
+      } else {
+        executablePathMock.mockReturnValue(null)
+      }
+      expect((await getComputerUsePermissionStatus()).helperUnavailableReason).toContain(
+        'was not found'
+      )
+      expect(statusMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['linux', 'win32'])('does not start a macOS provider on %s', async (platform) => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+    expect(
+      (await getComputerUsePermissionStatus()).permissions.every((p) => p.status === 'unsupported')
+    ).toBe(true)
+    expect(statusMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/computer/macos-computer-use-permission-status.ts
+++ b/src/main/computer/macos-computer-use-permission-status.ts
@@ -1,20 +1,9 @@
-import { spawn } from 'node:child_process'
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { setTimeout as delay } from 'node:timers/promises'
-import type {
-  ComputerUsePermissionId,
-  ComputerUsePermissionStatus,
-  ComputerUsePermissionStatusResult
-} from '../../shared/computer-use-permissions-types'
+import type { ComputerUsePermissionStatusResult } from '../../shared/computer-use-permissions-types'
 import {
   resolveMacOSComputerUseAppPath,
   resolveMacOSComputerUseExecutablePath
 } from './macos-native-provider-paths'
-import { RuntimeClientError } from './runtime-client-error'
-
-const PERMISSION_STATUS_HELPER_LAUNCH_TIMEOUT_MS = 5_000
+import { callComputerSidecarPermissionStatus } from './sidecar-client'
 
 export function getComputerUsePermissionStatus(): Promise<ComputerUsePermissionStatusResult> {
   return getComputerUsePermissionStatusAsync()
@@ -46,15 +35,15 @@ async function getComputerUsePermissionStatusAsync(): Promise<ComputerUsePermiss
     )
   }
 
-  const raw = await readPermissionStatusFromHelperApp(helperAppPath)
+  const raw = await callComputerSidecarPermissionStatus()
 
   return {
     platform: process.platform,
     helperAppPath,
     helperUnavailableReason: null,
     permissions: [
-      { id: 'accessibility', status: raw.accessibility ?? 'not-granted' },
-      { id: 'screenshots', status: raw.screenshots ?? 'not-granted' }
+      { id: 'accessibility', status: raw.accessibility },
+      { id: 'screenshots', status: raw.screenshots }
     ]
   }
 }
@@ -71,124 +60,5 @@ function createUnavailablePermissionStatus(
       { id: 'accessibility', status: 'not-granted' },
       { id: 'screenshots', status: 'not-granted' }
     ]
-  }
-}
-
-async function readPermissionStatusFromHelperApp(
-  helperAppPath: string
-): Promise<Partial<Record<ComputerUsePermissionId, ComputerUsePermissionStatus>>> {
-  const tempDir = await mkdtemp(join(tmpdir(), 'orca-computer-use-permissions-'))
-  const statusPath = join(tempDir, 'status.json')
-  try {
-    // Why: TCC status must be checked through the helper app identity. Directly
-    // execing the binary can inherit the parent app's already-granted context.
-    await launchPermissionStatusHelper(helperAppPath, statusPath)
-
-    for (let attempt = 0; attempt < 50; attempt++) {
-      if (await fileExists(statusPath)) {
-        const output = await readFile(statusPath, 'utf8')
-        return JSON.parse(output) as Partial<
-          Record<ComputerUsePermissionId, ComputerUsePermissionStatus>
-        >
-      }
-      await delay(100)
-    }
-    throw new RuntimeClientError('accessibility_error', 'Timed out checking permissions')
-  } finally {
-    await rm(tempDir, { recursive: true, force: true })
-  }
-}
-
-function launchPermissionStatusHelper(helperAppPath: string, statusPath: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const launch = spawn(
-      '/usr/bin/open',
-      ['-n', helperAppPath, '--args', '--permission-status-file', statusPath],
-      {
-        stdio: ['ignore', 'pipe', 'pipe']
-      }
-    )
-    let stdout = ''
-    let stderr = ''
-
-    launch.stdout?.setEncoding('utf8')
-    launch.stderr?.setEncoding('utf8')
-    const onStdoutData = (chunk: string): void => {
-      stdout += chunk
-    }
-    const onStderrData = (chunk: string): void => {
-      stderr += chunk
-    }
-    let settled = false
-    let launchTimeout: ReturnType<typeof setTimeout> | null = null
-    const removeListeners = (): void => {
-      launch.stdout?.off('data', onStdoutData)
-      launch.stderr?.off('data', onStderrData)
-      launch.off('error', onError)
-      launch.off('close', onClose)
-      if (launchTimeout) {
-        clearTimeout(launchTimeout)
-        launchTimeout = null
-      }
-    }
-    const settleResolve = (): void => {
-      if (settled) {
-        return
-      }
-      settled = true
-      removeListeners()
-      resolve()
-    }
-    const settleReject = (error: Error): void => {
-      if (settled) {
-        return
-      }
-      settled = true
-      removeListeners()
-      reject(error)
-    }
-    const onError = (): void => {
-      settleReject(
-        new RuntimeClientError(
-          'accessibility_error',
-          'Could not check permissions: failed to launch helper'
-        )
-      )
-    }
-    const onClose = (status: number | null): void => {
-      if (status === 0) {
-        settleResolve()
-        return
-      }
-      const detail = stderr.trim() || stdout.trim() || `exit ${status ?? 'unknown'}`
-      settleReject(
-        new RuntimeClientError('accessibility_error', `Could not check permissions: ${detail}`)
-      )
-    }
-    const onTimeout = (): void => {
-      launch.kill()
-      settleReject(
-        new RuntimeClientError('accessibility_error', 'Timed out launching permission helper')
-      )
-    }
-    // Why: the status-file polling timeout only starts after `open` exits; if
-    // `open` wedges first, permission checks would otherwise stay pending.
-    launchTimeout = setTimeout(onTimeout, PERMISSION_STATUS_HELPER_LAUNCH_TIMEOUT_MS)
-    if (typeof launchTimeout.unref === 'function') {
-      launchTimeout.unref()
-    }
-    launch.stdout?.on('data', onStdoutData)
-    launch.stderr?.on('data', onStderrData)
-    launch.on('error', onError)
-    launch.on('close', onClose)
-  })
-}
-
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await stat(path)
-    return true
-  } catch {
-    return false
   }
 }

--- a/src/main/computer/macos-computer-use-permissions.test.ts
+++ b/src/main/computer/macos-computer-use-permissions.test.ts
@@ -1,5 +1,4 @@
 import { execFileSync, spawn, spawnSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -9,7 +8,7 @@ import {
 
 const resolveHelperAppPathMock = vi.hoisted(() => vi.fn())
 const resolveHelperExecutablePathMock = vi.hoisted(() => vi.fn())
-const permissionStatusTempDir = '/tmp/orca-computer-use-permissions-test'
+const permissionStatusMock = vi.hoisted(() => vi.fn())
 const helperAppPath = '/Applications/Orca Computer Use.app'
 const helperInfoPlistPath = join(helperAppPath, 'Contents', 'Info.plist')
 
@@ -33,11 +32,8 @@ vi.mock('child_process', () => ({
   spawnSync: vi.fn()
 }))
 
-vi.mock('fs/promises', () => ({
-  mkdtemp: vi.fn(),
-  readFile: vi.fn(),
-  rm: vi.fn(),
-  stat: vi.fn()
+vi.mock('./sidecar-client', () => ({
+  callComputerSidecarPermissionStatus: permissionStatusMock
 }))
 
 vi.mock('./macos-native-provider-paths', () => ({
@@ -52,17 +48,12 @@ describe('openComputerUsePermissions', () => {
     vi.mocked(spawn).mockClear()
     vi.mocked(spawnSync).mockClear()
     vi.mocked(execFileSync).mockReset()
-    vi.mocked(mkdtemp).mockReset()
-    vi.mocked(readFile).mockReset()
-    vi.mocked(rm).mockReset()
-    vi.mocked(stat).mockReset()
+    permissionStatusMock.mockReset()
     resolveHelperAppPathMock.mockReset()
     resolveHelperExecutablePathMock.mockReset()
     resolveHelperExecutablePathMock.mockReturnValue(
       '/Applications/Orca Computer Use.app/Contents/MacOS/orca-computer-use-macos'
     )
-    vi.mocked(mkdtemp).mockResolvedValue(permissionStatusTempDir)
-    vi.mocked(stat).mockResolvedValue({} as Awaited<ReturnType<typeof stat>>)
     mockPermissionStatus('{"accessibility":"granted","screenshots":"granted"}')
     setPlatform('darwin')
   })
@@ -108,7 +99,8 @@ describe('openComputerUsePermissions', () => {
         { id: 'accessibility', status: 'granted' },
         { id: 'screenshots', status: 'not-granted' }
       ],
-      nextStep: 'Grant Screen Recording to Orca Computer Use, then retry get-app-state.'
+      nextStep:
+        'Grant Screen Recording to Orca Computer Use. If it is already allowed, check the app that runs computer use (usually Orca), then retry get-app-state.'
     })
     expect(spawnSync).toHaveBeenCalledWith(
       '/usr/bin/pkill',
@@ -141,7 +133,8 @@ describe('openComputerUsePermissions', () => {
         { id: 'accessibility', status: 'not-granted' },
         { id: 'screenshots', status: 'not-granted' }
       ],
-      nextStep: 'Grant Accessibility to Orca Computer Use, then retry get-app-state.'
+      nextStep:
+        'Grant Accessibility to Orca Computer Use. If it is already allowed, check the app that runs computer use (usually Orca), then retry get-app-state.'
     })
     expect(spawn).toHaveBeenCalledWith(
       '/usr/bin/open',
@@ -164,7 +157,8 @@ describe('openComputerUsePermissions', () => {
         { id: 'accessibility', status: 'granted' },
         { id: 'screenshots', status: 'not-granted' }
       ],
-      nextStep: 'Grant Screen Recording to Orca Computer Use, then retry get-app-state.'
+      nextStep:
+        'Grant Screen Recording to Orca Computer Use. If it is already allowed, check the app that runs computer use (usually Orca), then retry get-app-state.'
     })
     expect(spawn).toHaveBeenCalledWith(
       '/usr/bin/open',
@@ -210,9 +204,9 @@ describe('openComputerUsePermissions', () => {
 
   it('resets stale macOS TCC grants for the helper bundle id', async () => {
     resolveHelperAppPathMock.mockReturnValue('/Applications/Orca Computer Use.app')
-    vi.mocked(readFile)
-      .mockResolvedValueOnce('{"accessibility":"granted","screenshots":"granted"}')
-      .mockResolvedValueOnce('{"accessibility":"not-granted","screenshots":"not-granted"}')
+    permissionStatusMock
+      .mockResolvedValueOnce({ accessibility: 'granted', screenshots: 'granted' })
+      .mockResolvedValueOnce({ accessibility: 'not-granted', screenshots: 'not-granted' })
     vi.mocked(execFileSync).mockReturnValueOnce('com.example.orca.computer-use\n')
     vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>)
 
@@ -246,7 +240,7 @@ describe('openComputerUsePermissions', () => {
 
 function mockPermissionStatus(json: string): void {
   vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>)
-  vi.mocked(readFile).mockResolvedValue(json)
+  permissionStatusMock.mockResolvedValue(JSON.parse(json))
 }
 
 function setPlatform(platform: NodeJS.Platform): void {

--- a/src/main/computer/macos-computer-use-permissions.ts
+++ b/src/main/computer/macos-computer-use-permissions.ts
@@ -171,5 +171,5 @@ function nextPermissionStep(
   if (!missing) {
     return null
   }
-  return `Grant ${missing.id === 'accessibility' ? 'Accessibility' : 'Screen Recording'} to Orca Computer Use, then retry get-app-state.`
+  return `Grant ${missing.id === 'accessibility' ? 'Accessibility' : 'Screen Recording'} to Orca Computer Use. If it is already allowed, check the app that runs computer use (usually Orca), then retry get-app-state.`
 }

--- a/src/main/computer/macos-native-provider-client.ts
+++ b/src/main/computer/macos-native-provider-client.ts
@@ -1,3 +1,4 @@
+import type { ComputerUsePermissionStatusSnapshot } from '../../shared/computer-use-permissions-types'
 import { rmSync } from 'node:fs'
 import type net from 'node:net'
 import type {
@@ -41,6 +42,10 @@ export class MacOSNativeProviderClient {
   private providerCapabilities: ComputerProviderCapabilities | null = null
   private socketListenerCleanup: (() => void) | null = null
   private socketStartGeneration = 0
+  async permissionsStatus(): Promise<ComputerUsePermissionStatusSnapshot> {
+    await this.ensureCapability('observation', 'permissionStatus')
+    return (await this.call('permissionsStatus', {})) as ComputerUsePermissionStatusSnapshot
+  }
   async listApps(): Promise<ComputerListAppsResult> {
     return (await this.call('listApps', {})) as ComputerListAppsResult
   }
@@ -77,13 +82,9 @@ export class MacOSNativeProviderClient {
       socket.write(`${JSON.stringify({ id, method: 'terminate', params: {}, token })}\n`)
       socket.end()
     }
-    for (const [id, pending] of this.pending) {
-      clearTimeout(pending.timer)
-      pending.reject(
-        new RuntimeClientError('accessibility_error', 'native macOS provider shut down')
-      )
-      this.pending.delete(id)
-    }
+    this.rejectPending(
+      new RuntimeClientError('accessibility_error', 'native macOS provider shut down')
+    )
     this.cleanupSocketDirectory()
   }
   private async call(method: NativeMethod, params: unknown): Promise<unknown> {

--- a/src/main/computer/macos-native-provider-contract.ts
+++ b/src/main/computer/macos-native-provider-contract.ts
@@ -2,6 +2,7 @@ import type net from 'node:net'
 import type { ComputerProviderCapabilities } from '../../shared/runtime-types'
 
 export type NativeMethod =
+  | 'permissionsStatus'
   | 'handshake'
   | 'listApps'
   | 'listWindows'
@@ -19,7 +20,7 @@ export type NativeMethod =
 
 export type NativeActionMethod = Exclude<
   NativeMethod,
-  'handshake' | 'listApps' | 'listWindows' | 'getAppState' | 'terminate'
+  'permissionsStatus' | 'handshake' | 'listApps' | 'listWindows' | 'getAppState' | 'terminate'
 >
 
 export type NativeResponse =

--- a/src/main/computer/macos-native-provider-permissions.test.ts
+++ b/src/main/computer/macos-native-provider-permissions.test.ts
@@ -1,0 +1,88 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MacOSNativeProviderClient } from './macos-native-provider-client'
+
+const { connectMock, spawnMock } = vi.hoisted(() => ({ connectMock: vi.fn(), spawnMock: vi.fn() }))
+vi.mock('child_process', () => ({ spawn: spawnMock }))
+vi.mock('fs', () => ({
+  chmodSync: vi.fn(),
+  mkdtempSync: vi.fn(() => '/tmp/orca-permission-test'),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn()
+}))
+vi.mock('./macos-native-provider-paths', () => ({
+  resolveMacOSComputerUseExecutablePath: () =>
+    '/Applications/Orca Computer Use.app/Contents/MacOS/orca-computer-use-macos'
+}))
+vi.mock('./macos-native-provider-socket', () => ({ connectMacOSProviderSocket: connectMock }))
+
+class PermissionSocket extends EventEmitter {
+  destroyed = false
+  permissionStatus: boolean | undefined = true
+  requests: string[] = []
+  status = { accessibility: 'not-granted', screenshots: 'granted' }
+  setEncoding(): void {}
+  end(): void {
+    this.destroyed = true
+  }
+  write(line: string, callback?: (error?: Error) => void): boolean {
+    const request = JSON.parse(line)
+    this.requests.push(request.method)
+    const result =
+      request.method === 'handshake'
+        ? {
+            protocolVersion: 1,
+            supports: { observation: { permissionStatus: this.permissionStatus } }
+          }
+        : this.status
+    queueMicrotask(() =>
+      this.emit('data', `${JSON.stringify({ id: request.id, ok: true, result })}\n`)
+    )
+    callback?.()
+    return true
+  }
+}
+
+let client: MacOSNativeProviderClient
+let socket: PermissionSocket
+beforeEach(() => {
+  socket = new PermissionSocket()
+  connectMock.mockResolvedValue(socket)
+  spawnMock.mockImplementation(() =>
+    Object.assign(new EventEmitter(), { unref: vi.fn(), kill: vi.fn() })
+  )
+  client = new MacOSNativeProviderClient()
+})
+afterEach(() => {
+  client.shutdown()
+  vi.clearAllMocks()
+})
+
+describe('native execution permission status', () => {
+  it('checks and refreshes permissions on the same socket used for observation', async () => {
+    await client.snapshot({ app: 'com.apple.finder' })
+    await expect(client.permissionsStatus()).resolves.toEqual(socket.status)
+    socket.status = { accessibility: 'granted', screenshots: 'granted' }
+    await expect(client.permissionsStatus()).resolves.toEqual(socket.status)
+    expect(socket.requests).toEqual([
+      'handshake',
+      'getAppState',
+      'permissionsStatus',
+      'permissionsStatus'
+    ])
+    expect(connectMock).toHaveBeenCalledOnce()
+    expect(spawnMock).toHaveBeenCalledOnce()
+  })
+
+  it.each([false, undefined])(
+    'rejects helpers without permissionStatus support (%s)',
+    async (supported) => {
+      socket.permissionStatus = supported
+      await expect(client.permissionsStatus()).rejects.toMatchObject({
+        code: 'unsupported_capability'
+      })
+      expect(socket.requests).toEqual(['handshake'])
+      expect(spawnMock).toHaveBeenCalledOnce()
+    }
+  )
+})

--- a/src/main/computer/macos-native-provider-transport.ts
+++ b/src/main/computer/macos-native-provider-transport.ts
@@ -76,8 +76,7 @@ export async function startMacOSNativeProviderSocket({
   const socketToken = randomUUID()
   const socketTokenPath = join(socketDirectory, 'provider.token')
   writeFileSync(socketTokenPath, socketToken, { encoding: 'utf8', mode: 0o600 })
-  // Why: launching the nested helper via LaunchServices can make TCC evaluate
-  // Orca.app as responsible; the signed helper executable owns this grant.
+  // TCC can attribute this child to its launcher; permission probes must use this process.
   const provider = spawnProvider(helperExecutablePath, socketPath, socketTokenPath)
   const providerFailure = waitForProviderLaunchFailure(provider)
   const connectAbort = new AbortController()

--- a/src/main/computer/sidecar-client.test.ts
+++ b/src/main/computer/sidecar-client.test.ts
@@ -7,6 +7,8 @@ import {
 } from '../../shared/clipboard-text'
 import {
   callComputerSidecarAction,
+  callComputerSidecarPermissionStatus,
+  callComputerSidecarSnapshot,
   callComputerSidecarCapabilities,
   resetComputerSidecarForTest
 } from './sidecar-client'
@@ -73,6 +75,20 @@ describe('computer sidecar client', () => {
     resetComputerSidecarForTest()
     forkMock.mockReset()
     vi.useRealTimers()
+  })
+
+  it('uses the observation sidecar for permission checks and preserves denial', async () => {
+    const snapshot = callComputerSidecarSnapshot({ app: 'com.apple.finder' })
+    const child = children[0]!
+    child.emit('message', { id: child.sent[0]!.id, ok: true, result: {} })
+    await snapshot
+    const status = callComputerSidecarPermissionStatus()
+    await vi.waitFor(() => expect(child.sent).toHaveLength(2))
+    expect(child.sent[1]!.method).toBe('permissionsStatus')
+    const denied = { accessibility: 'not-granted', screenshots: 'granted' }
+    child.emit('message', { id: child.sent[1]!.id, ok: true, result: denied })
+    await expect(status).resolves.toEqual(denied)
+    expect(forkMock).toHaveBeenCalledOnce()
   })
 
   it('ignores stale child exit and error after a replacement sidecar starts', async () => {

--- a/src/main/computer/sidecar-client.ts
+++ b/src/main/computer/sidecar-client.ts
@@ -1,3 +1,4 @@
+import type { ComputerUsePermissionStatusSnapshot } from '../../shared/computer-use-permissions-types'
 import { fork, type ChildProcess } from 'node:child_process'
 import { getAppEnvironment, hasAppEnvironment } from '../../shared/app-environment'
 import { join } from 'node:path'
@@ -14,6 +15,7 @@ import { validateComputerSidecarPasteText } from './computer-sidecar-paste-valid
 import { RuntimeClientError } from './runtime-client-error'
 
 type ComputerSidecarMethod =
+  | 'permissionsStatus'
   | 'capabilities'
   | 'listApps'
   | 'listWindows'
@@ -51,6 +53,13 @@ let sidecar: ComputerSidecarProcess | null = null
 // stale children keep a no-op listener that does not retain the sidecar owner.
 function ignoreStaleChildError(): void {}
 
+export async function callComputerSidecarPermissionStatus(): Promise<ComputerUsePermissionStatusSnapshot> {
+  return (await getComputerSidecar().call(
+    'permissionsStatus',
+    {}
+  )) as ComputerUsePermissionStatusSnapshot
+}
+
 export async function callComputerSidecarListApps(): Promise<ComputerListAppsResult> {
   return (await getComputerSidecar().call('listApps', {})) as ComputerListAppsResult
 }
@@ -74,7 +83,7 @@ export async function callComputerSidecarSnapshot(
 export async function callComputerSidecarAction(
   method: Exclude<
     ComputerSidecarMethod,
-    'capabilities' | 'listApps' | 'listWindows' | 'getAppState'
+    'permissionsStatus' | 'capabilities' | 'listApps' | 'listWindows' | 'getAppState'
   >,
   params: unknown
 ): Promise<ComputerActionResult> {

--- a/src/main/computer/sidecar-entry.ts
+++ b/src/main/computer/sidecar-entry.ts
@@ -52,6 +52,15 @@ async function dispatch(method: string, params: Record<string, unknown>): Promis
   }
 
   switch (method) {
+    case 'permissionsStatus': {
+      if ('permissionsStatus' in provider) {
+        return await provider.permissionsStatus()
+      }
+      throw new RuntimeClientError(
+        'unsupported_capability',
+        'This computer provider does not support permission status checks'
+      )
+    }
     case 'capabilities': {
       return await provider.capabilities()
     }

--- a/src/shared/computer-use-permissions-types.ts
+++ b/src/shared/computer-use-permissions-types.ts
@@ -2,6 +2,11 @@ export type ComputerUsePermissionId = 'accessibility' | 'screenshots'
 
 export type ComputerUsePermissionStatus = 'granted' | 'not-granted' | 'unsupported'
 
+export type ComputerUsePermissionStatusSnapshot = Record<
+  ComputerUsePermissionId,
+  ComputerUsePermissionStatus
+>
+
 export type ComputerUsePermissionState = {
   id: ComputerUsePermissionId
   status: ComputerUsePermissionStatus

--- a/src/shared/computer-use-runtime-types.ts
+++ b/src/shared/computer-use-runtime-types.ts
@@ -144,6 +144,7 @@ export type ComputerProviderCapabilities = {
       moveResize: boolean
     }
     observation: {
+      permissionStatus?: boolean
       screenshot: boolean
       annotatedScreenshot: boolean
       elementFrames: boolean


### PR DESCRIPTION
## ELI5

The permission check and the computer-use operation must ask macOS about the same process. Previously, the check launched a separate helper app. That helper could report “granted” while the process that reads windows received `permission_denied`.

## What Changed

- Route permission status through the existing computer sidecar and its native provider socket, so checks and observations use the same execution process.
- Reuse the existing bounded Accessibility and Screen Recording probes. Remove the separate status-file helper launch and polling.
- Advertise an optional `observation.permissionStatus` capability. Older custom helpers return `unsupported_capability`; there is no separate-process fallback.
- Update denial guidance to include the app that runs computer use when the helper is already allowed.

## Why

On a local macOS build, the CLI reported both permissions granted while Finder observation repeatedly failed with `permission_denied`. Granting Accessibility to Orca itself made the same observation succeed. The old check used LaunchServices, while execution spawned the helper binary through the sidecar. Those launch contexts need not have the same effective TCC permissions.

This fixes the diagnostic boundary. It does not claim to identify the responsible TCC identity in every launch environment or to fix every AX denial. No permission is granted or reset automatically.

## Linked Issue

Related to #9458 and #10372 (permission status and execution disagree). This PR does not claim that all causes in those reports are resolved.

## Visual Proof

No layout changes. The relevant evidence is the diagnostic result:

- Before, observed on macOS: permission status reported Accessibility `granted`; Finder `get-app-state` returned `permission_denied`.
- After, automated regression: permission checks and observations use one native socket and one sidecar process. A denied execution probe remains `not-granted`; a later grant is read again without restarting the process.

A manual before/after run of the patched installed app with only the helper authorized is still pending. This PR is a draft for that validation.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

On macOS arm64:

- `node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/main/computer`: 100 tests passed in 18 files.
- `node config/scripts/verify-computer-native.mjs`: native helper compiled; 92 XCTest cases, 4 Swift Testing cases, 8 Linux renderer tests, and native argument guardrails passed. Windows checks were skipped on this machine.
- Oxlint, type-aware Oxlint, oxfmt, and `git diff --check` passed for the changed files.
- `node node_modules/typescript/bin/tsc --noEmit -p config/tsconfig.node.json` is blocked by the workspace's missing `@anthropic-ai/claude-agent-sdk` dependency and consequent errors in Claude modules. No computer-use type errors were reported.

Regression coverage includes execution denial, permission changes, shared-process reuse, missing helper files, unsupported legacy helpers, propagated errors, and non-macOS no-op behavior. The installed application and the user's TCC grants were not changed during this patch's validation. Full packaged-app and SSH validation remain for CI/manual testing.

## AI Disclosure

Implemented and checked with OpenAI Codex.

## Review

The permission RPC still runs on the host that executes computer use. The public permission result shape is unchanged; the native capability is optional, and no remote stream opcode changes. Linux and Windows permission-status behavior remains unsupported. Workspace type and git provider do not affect this path.

## Agent skill upstream boundary

- [x] Not applicable; no agent skill source or content is changed.

## Notes

The standalone setup window continues to show its own helper permission state. This change makes the runtime status authoritative and adds guidance for the launcher, but does not redesign that setup window or alter the native launch identity.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full lint, typecheck, test, and build pass (limitations above)
