### PR TITLE
fix(editor): make markdown images inline so a paragraph stays schema-valid

### DIFF
--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -16,6 +16,10 @@ function roundTripMarkdown(content: string): string {
   })
 
   try {
+    // Why: markdown serialization walks the document without running
+    // NodeType.checkContent, so it emits byte-identical output from a
+    // schema-invalid document that would crash on the user's next keystroke.
+    editor.state.doc.check()
     return editor.getMarkdown().trimEnd()
   } finally {
     editor.destroy()
@@ -46,6 +50,32 @@ function markdownAfterTextReplace(content: string, search: string, replacement: 
       throw new Error(`Missing text: ${search}`)
     }
     editor.view.dispatch(editor.state.tr.insertText(replacement, from, from + search.length))
+    return editor.getMarkdown().trimEnd()
+  } finally {
+    editor.destroy()
+  }
+}
+
+function markdownAfterTypingBesideImage(content: string, typed: string): string {
+  const codec = createRichMarkdownEditorCodec()
+  const editor = new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions({ codec }),
+    content: encodeRawMarkdownHtmlForRichEditor(content, codec),
+    contentType: 'markdown'
+  })
+
+  try {
+    let after = -1
+    editor.state.doc.descendants((node, pos) => {
+      if (after === -1 && node.type.name === 'image') {
+        after = pos + node.nodeSize
+      }
+    })
+    if (after === -1) {
+      throw new Error('Missing image node')
+    }
+    editor.view.dispatch(editor.state.tr.insertText(typed, after, after))
     return editor.getMarkdown().trimEnd()
   } finally {
     editor.destroy()
@@ -336,6 +366,11 @@ describe('rich markdown round trip', () => {
     expect(roundTripMarkdown('Intro\n\n![shot](shot.png)\n\nOutro\n')).toBe(
       'Intro\n\n![shot](shot.png)\n\nOutro'
     )
+    // Typing beside the image must join its paragraph instead of opening a new block,
+    // which only holds while the standalone image stays wrapped in a paragraph.
+    expect(markdownAfterTypingBesideImage('Intro\n\n![shot](shot.png)\n\nOutro\n', 'X')).toBe(
+      'Intro\n\n![shot](shot.png)X\n\nOutro'
+    )
   })
 
   it('preserves images nested in list items and table cells', () => {
@@ -343,6 +378,12 @@ describe('rich markdown round trip', () => {
     expect(roundTripMarkdown('| a |\n| - |\n| ![shot](shot.png) |\n')).toContain(
       '![shot](shot.png)'
     )
+    expect(markdownAfterTextReplace('- step ![shot](shot.png)\n', 'step', 'stage')).toBe(
+      '- stage ![shot](shot.png)'
+    )
+    expect(
+      markdownAfterTextReplace('| a |\n| - |\n| b ![shot](shot.png) |\n', 'b ', 'c ')
+    ).toContain('![shot](shot.png)')
   })
 
   it('preserves links whose label is inline code', () => {

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -116,6 +116,28 @@ describe('rich markdown round trip', () => {
     )
   })
 
+  it('preserves an image in a details summary across an edit', () => {
+    expect(
+      markdownAfterTextReplace(
+        '<details><summary>Toggle ![i](x.png)</summary><p>Body</p></details>\n',
+        'Toggle',
+        'Switch'
+      )
+    ).toBe(
+      '<details class="orca-details">\n<summary>Switch ![i](x.png)</summary>\n\nBody\n\n</details>'
+    )
+  })
+
+  it('preserves inline math in a details summary across an edit', () => {
+    expect(
+      markdownAfterTextReplace(
+        '<details><summary>Toggle $x^2$</summary><p>Body</p></details>\n',
+        'Toggle',
+        'Switch'
+      )
+    ).toBe('<details class="orca-details">\n<summary>Switch $x^2$</summary>\n\nBody\n\n</details>')
+  })
+
   it('does not double-escape entities in editable details summaries', () => {
     expect(roundTripMarkdown('<details><summary>A &amp; B</summary><p>Body</p></details>\n')).toBe(
       '<details class="orca-details">\n<summary>A &amp; B</summary>\n\nBody\n\n</details>'
@@ -295,6 +317,31 @@ describe('rich markdown round trip', () => {
   it('preserves encoded local image paths with screenshot filenames', () => {
     expect(roundTripMarkdown('![](Screenshot%202026-06-22%20at%203.37.19%20PM%20copy.png)\n')).toBe(
       '![](Screenshot%202026-06-22%20at%203.37.19%20PM%20copy.png)'
+    )
+  })
+
+  it('preserves an image that sits mid-sentence inside a paragraph', () => {
+    expect(roundTripMarkdown('Install the ![icon](icon.png) extension\n')).toBe(
+      'Install the ![icon](icon.png) extension'
+    )
+  })
+
+  it('preserves a mid-sentence image after an editor transaction', () => {
+    expect(
+      markdownAfterTextReplace('Install the ![icon](icon.png) extension\n', 'extension', 'add-on')
+    ).toBe('Install the ![icon](icon.png) add-on')
+  })
+
+  it('preserves a standalone image as its own block', () => {
+    expect(roundTripMarkdown('Intro\n\n![shot](shot.png)\n\nOutro\n')).toBe(
+      'Intro\n\n![shot](shot.png)\n\nOutro'
+    )
+  })
+
+  it('preserves images nested in list items and table cells', () => {
+    expect(roundTripMarkdown('- step ![shot](shot.png)\n')).toBe('- step ![shot](shot.png)')
+    expect(roundTripMarkdown('| a |\n| - |\n| ![shot](shot.png) |\n')).toContain(
+      '![shot](shot.png)'
     )
   })
 

--- a/src/renderer/src/components/editor/rich-markdown-details-extension.ts
+++ b/src/renderer/src/components/editor/rich-markdown-details-extension.ts
@@ -286,6 +286,13 @@ const OrcaDetails = Details.extend({
   }
 })
 
+const OrcaDetailsSummary = DetailsSummary.extend({
+  // Why: the summary parser runs parseInline, which emits image/math nodes that
+  // upstream's text*-only summary rejects, so the doc is schema-invalid until the
+  // first edit reassembles the summary and ProseMirror throws.
+  content: 'inline*'
+})
+
 const OrcaDetailsContent = DetailsContent.extend({
   // Why: detailsContent's double-Enter escape must run before StarterKit's
   // generic paragraph split, otherwise users can get stuck inside a toggle.
@@ -314,7 +321,7 @@ export function createOrcaDetailsExtensions(): AnyExtension[] {
         class: 'orca-details'
       }
     }),
-    DetailsSummary,
+    OrcaDetailsSummary,
     OrcaDetailsContent
   ]
 }

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -37,6 +37,7 @@ import type { RichMarkdownEditorCodec } from './rich-markdown-source-transport'
 import { createRichMarkdownHtmlSuperscriptLink } from './rich-markdown-html-superscript-link'
 import type { RichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-html-superscript-link-context'
 import { RichMarkdownOrderedList } from './rich-markdown-ordered-list'
+import { RichMarkdownParagraph } from './rich-markdown-paragraph'
 import { RichMarkdownCodeBlockLowlight } from './rich-markdown-lowlight'
 import { RichMarkdownTaskList } from './rich-markdown-task-list'
 import { createCachedLowlight } from './rich-markdown-lowlight-cache'
@@ -77,8 +78,10 @@ export function createRichMarkdownExtensions({
       link: false,
       code: false,
       codeBlock: false,
-      orderedList: false
+      orderedList: false,
+      paragraph: false
     }),
+    RichMarkdownParagraph,
     RichMarkdownCode,
     RichMarkdownCodeBlockLowlight.extend({
       addNodeView() {
@@ -116,8 +119,12 @@ export function createRichMarkdownExtensions({
           // native image drag (which sends image bytes) from conflicting with
           // ProseMirror's node-level drag (which serializes the schema node
           // for relocation within the document).
-          const dom = document.createElement('div')
+          const dom = document.createElement('span')
+          // Why: the wrapper sits in inline content, so it must not introduce a
+          // block box or the surrounding text would break onto its own line.
+          dom.style.display = 'inline-block'
           dom.style.lineHeight = '0'
+          dom.style.maxWidth = '100%'
 
           const img = document.createElement('img')
           img.draggable = false
@@ -205,7 +212,11 @@ export function createRichMarkdownExtensions({
         }
       }
     }).configure({
-      allowBase64: true
+      allowBase64: true,
+      // Why: the markdown parser nests images inside paragraphs, so a block image
+      // node yields a schema-invalid document that only throws on the first edit
+      // that reassembles the paragraph.
+      inline: true
     }),
     RichMarkdownOrderedList,
     RichMarkdownTaskList,

--- a/src/renderer/src/components/editor/rich-markdown-image-insert-code-block.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-image-insert-code-block.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Editor } from '@tiptap/core'
+import { renderHook } from '@testing-library/react'
+import { createRichMarkdownExtensions } from './rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+import { useLocalImagePick } from './useLocalImagePick'
+import { handleRichMarkdownImagePaste } from './rich-markdown-paste-image'
+import { runSlashCommand, slashCommands } from './rich-markdown-slash-commands'
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  importExternalPathsToRuntime: vi.fn().mockResolvedValue({
+    results: [{ status: 'imported', destPath: '/repo/shot.png' }]
+  })
+}))
+
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: vi.fn(() => null)
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: vi.fn(() => ({
+      settings: { activeRuntimeEnvironmentId: null },
+      folderWorkspaces: [],
+      worktreesByRepo: { repo1: [{ id: 'wt-1', path: '/repo' }] }
+    }))
+  }
+}))
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  settingsForRuntimeOwner: vi.fn((settings) => settings)
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() }
+}))
+
+const CODE_BLOCK_SOURCE = '```ts\nconst a = 1\n```\n'
+// The image splits the fence; both halves keep their ``` fencing and `ts` language.
+const SPLIT_CODE_BLOCK = '```ts\nconst\n```\n\n![](shot.png)\n\n```ts\n a = 1\n```'
+
+function expectFencedSplit(target: Editor): void {
+  expect(target.getMarkdown().trimEnd()).toBe(SPLIT_CODE_BLOCK)
+  expect(() => target.state.doc.check()).not.toThrow()
+}
+
+let editor: Editor
+
+function mountRichMarkdownEditor(markdown: string): Editor {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  return new Editor({
+    element: host,
+    extensions: createRichMarkdownExtensions({ codec: createRichMarkdownEditorCodec() }),
+    content: markdown,
+    contentType: 'markdown'
+  })
+}
+
+function positionInsideCodeBlock(target: Editor): number {
+  let pos = -1
+  target.state.doc.descendants((node, nodePos) => {
+    if (pos === -1 && node.isText && node.text?.startsWith('const')) {
+      pos = nodePos + 'const'.length
+    }
+  })
+  if (pos === -1) {
+    throw new Error('Missing code block text')
+  }
+  return pos
+}
+
+async function flushPromises(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve()
+  }
+}
+
+describe('inserting an image while the cursor is inside a fenced code block', () => {
+  beforeEach(() => {
+    document.body.replaceChildren()
+    vi.clearAllMocks()
+    editor = mountRichMarkdownEditor(CODE_BLOCK_SOURCE)
+    editor.commands.setTextSelection(positionInsideCodeBlock(editor))
+    globalThis.window.api = {
+      ...globalThis.window.api,
+      shell: { pickImage: vi.fn().mockResolvedValue('/tmp/shot.png') },
+      ui: { saveClipboardImageAsTempFile: vi.fn().mockResolvedValue('/tmp/shot.png') }
+    } as unknown as Window['api']
+  })
+
+  afterEach(() => {
+    editor.destroy()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps both halves fenced when the toolbar picker inserts the image', async () => {
+    const { result } = renderHook(() => useLocalImagePick(editor as never, '/repo/note.md', 'wt-1'))
+
+    await result.current()
+    await flushPromises()
+
+    expectFencedSplit(editor)
+  })
+
+  it('keeps both halves fenced when the slash command inserts the image', async () => {
+    const imageCommand = slashCommands.find((command) => command.id === 'image')
+    expect(imageCommand).toBeDefined()
+    const { result } = renderHook(() => useLocalImagePick(editor as never, '/repo/note.md', 'wt-1'))
+    const from = editor.state.selection.from
+
+    runSlashCommand(editor as never, { from, to: from }, imageCommand!, () => {
+      void result.current()
+    })
+    await flushPromises()
+
+    expectFencedSplit(editor)
+  })
+
+  it('keeps both halves fenced when a clipboard screenshot is pasted', async () => {
+    const handled = handleRichMarkdownImagePaste({
+      editor: editor as never,
+      event: {
+        clipboardData: { items: [{ kind: 'file', type: 'image/png' }] },
+        preventDefault: vi.fn()
+      } as unknown as ClipboardEvent,
+      filePath: '/repo/note.md',
+      worktreeId: 'wt-1'
+    })
+    await flushPromises()
+
+    expect(handled).toBe(true)
+    expectFencedSplit(editor)
+  })
+
+  it('still inserts the image inline when the cursor is in ordinary prose', async () => {
+    editor.destroy()
+    editor = mountRichMarkdownEditor('Install the extension\n')
+    editor.commands.setTextSelection(13)
+    const { result } = renderHook(() => useLocalImagePick(editor as never, '/repo/note.md', 'wt-1'))
+
+    await result.current()
+    await flushPromises()
+
+    expect(editor.getMarkdown().trimEnd()).toBe('Install the ![](shot.png)extension')
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-image-insert-content.ts
+++ b/src/renderer/src/components/editor/rich-markdown-image-insert-content.ts
@@ -1,0 +1,26 @@
+import type { Editor, JSONContent } from '@tiptap/react'
+
+/**
+ * Why: an inline image cannot be fitted into `codeBlock` (`text*`), so inserting one at a
+ * position inside a fence makes ProseMirror dissolve the block — the remaining code escapes
+ * as prose and the language attribute is lost. Wrapping the image in a paragraph makes
+ * ProseMirror split the fence instead, leaving both halves intact.
+ */
+export function buildRichMarkdownImageInsertContent(
+  editor: Editor,
+  pos: number,
+  attrs: { src: string }
+): JSONContent {
+  const image: JSONContent = { type: 'image', attrs }
+  const imageType = editor.schema.nodes.image
+  const doc = editor.state.doc
+  if (!imageType || pos < 0 || pos > doc.content.size) {
+    return image
+  }
+  const $pos = doc.resolve(pos)
+  const index = $pos.index()
+  if ($pos.parent.canReplaceWith(index, index, imageType)) {
+    return image
+  }
+  return { type: 'paragraph', content: [image] }
+}

--- a/src/renderer/src/components/editor/rich-markdown-image-insert.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-image-insert.test.ts
@@ -1,6 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Editor } from '@tiptap/core'
 import { toast } from 'sonner'
 import { insertRichMarkdownImageFromPath } from './rich-markdown-image-insert'
+import { createRichMarkdownExtensions } from './rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
 import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
 
 vi.mock('@/runtime/runtime-file-client', () => ({
@@ -27,12 +32,28 @@ vi.mock('sonner', () => ({
   toast: { error: vi.fn() }
 }))
 
-function editorWithRunResult(runResult: boolean) {
+const openEditors: Editor[] = []
+
+function createRichMarkdownEditor(markdown: string): Editor {
+  const editor = new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions({ codec: createRichMarkdownEditorCodec() }),
+    content: markdown,
+    contentType: 'markdown'
+  })
+  openEditors.push(editor)
+  return editor
+}
+
+function editorWithRunResult(runResult: boolean, markdown = 'hello world') {
   const run = vi.fn(() => runResult)
   const insertContentAt = vi.fn(() => ({ run }))
   const focus = vi.fn(() => ({ insertContentAt }))
   const chain = vi.fn(() => ({ focus }))
-  return { editor: { chain }, chain, focus, insertContentAt, run }
+  // Why: the insert path reads the real schema and document to decide whether an
+  // inline image fits at the target position, so the stub borrows both.
+  const { schema, state } = createRichMarkdownEditor(markdown)
+  return { editor: { chain, schema, state }, chain, focus, insertContentAt, run }
 }
 
 describe('insertRichMarkdownImageFromPath', () => {
@@ -49,6 +70,12 @@ describe('insertRichMarkdownImageFromPath', () => {
     vi.mocked(importExternalPathsToRuntime).mockResolvedValue({
       results: [{ status: 'imported', destPath: '/repo/image.png' }]
     } as never)
+  })
+
+  afterEach(() => {
+    while (openEditors.length > 0) {
+      openEditors.pop()?.destroy()
+    }
   })
 
   it('shows an error when TipTap rejects image insertion without throwing', async () => {

--- a/src/renderer/src/components/editor/rich-markdown-image-insert.ts
+++ b/src/renderer/src/components/editor/rich-markdown-image-insert.ts
@@ -10,6 +10,7 @@ import { captureDirectSshMutationExpectation } from '@/lib/ssh-mutation-expectat
 import { translate } from '@/i18n/i18n'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { extractIpcErrorMessage } from './rich-markdown-ipc-error-message'
+import { buildRichMarkdownImageInsertContent } from './rich-markdown-image-insert-content'
 
 export type RichMarkdownImageInsertArgs = {
   editor: Editor
@@ -88,7 +89,10 @@ export async function insertRichMarkdownImageFromPath({
     const inserted = editor
       .chain()
       .focus()
-      .insertContentAt(insertPos, { type: 'image', attrs: { src: imageSrc } })
+      .insertContentAt(
+        insertPos,
+        buildRichMarkdownImageInsertContent(editor, insertPos, { src: imageSrc })
+      )
       .run()
     if (!inserted) {
       toast.error(

--- a/src/renderer/src/components/editor/rich-markdown-inline-image-paragraph.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-inline-image-paragraph.test.ts
@@ -56,6 +56,9 @@ describe('rich markdown inline images inside a paragraph', () => {
     const editor = createRichMarkdownEditorFromSource(CRASH_SOURCE)
 
     try {
+      // Why: serialization never runs NodeType.checkContent, so the markdown
+      // matches byte-for-byte even when the document is schema-invalid.
+      expect(() => editor.state.doc.check()).not.toThrow()
       expect(editor.getMarkdown().trimEnd()).toBe(CRASH_SOURCE.trimEnd())
     } finally {
       editor.destroy()

--- a/src/renderer/src/components/editor/rich-markdown-inline-image-paragraph.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-inline-image-paragraph.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { Editor } from '@tiptap/core'
+import { encodeRawMarkdownHtmlForRichEditor } from './raw-markdown-html'
+import { createRichMarkdownExtensions } from './rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+import { createRichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-html-superscript-link-context'
+
+// Crash report 0e46c048: Vietnamese prose with a soft line break, an inline code
+// span and an inline image, which the markdown parser nests inside one paragraph.
+const CRASH_SOURCE =
+  'Trình duyệt chỉ cho phép cài từ Web Store.\nnh `.crx` (tham chiếu, KHÔNG chặn) ![ảnh](chrome.png) và tiếp tục\n'
+
+function createRichMarkdownEditorFromSource(source: string): Editor {
+  const codec = createRichMarkdownEditorCodec()
+  return new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions({
+      codec,
+      htmlSuperscriptLinks: true,
+      htmlSuperscriptLinkContext: createRichMarkdownHtmlSuperscriptLinkContext({
+        sourceFilePath: '',
+        worktreeId: '',
+        worktreeRoot: null,
+        sourceOwner: { kind: 'unknown' }
+      })
+    }),
+    content: encodeRawMarkdownHtmlForRichEditor(source, codec, { htmlSuperscriptLinks: true }),
+    contentType: 'markdown'
+  })
+}
+
+describe('rich markdown inline images inside a paragraph', () => {
+  it('parses an inline image into a schema-valid paragraph', () => {
+    const editor = createRichMarkdownEditorFromSource(CRASH_SOURCE)
+
+    try {
+      expect(() => editor.state.doc.check()).not.toThrow()
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('survives an ordinary edit in a paragraph that holds an inline image', () => {
+    const editor = createRichMarkdownEditorFromSource(CRASH_SOURCE)
+
+    try {
+      // Any ReplaceStep that rebuilds the paragraph runs NodeType.checkContent on
+      // the reassembled content — the exact frame the crash report bottoms out in.
+      expect(() => editor.view.dispatch(editor.state.tr.insertText('X', 5, 8))).not.toThrow()
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('round-trips the reported document without dropping the inline image', () => {
+    const editor = createRichMarkdownEditorFromSource(CRASH_SOURCE)
+
+    try {
+      expect(editor.getMarkdown().trimEnd()).toBe(CRASH_SOURCE.trimEnd())
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('keeps a standalone image inside a paragraph rather than directly under the doc', () => {
+    // Upstream's paragraph parser hoists a lone image out of its paragraph, which
+    // leaves an inline node as a direct child of `doc` once images are inline.
+    const editor = createRichMarkdownEditorFromSource('Intro\n\n![shot](shot.png)\n\nOutro\n')
+
+    try {
+      expect(() => editor.state.doc.check()).not.toThrow()
+      expect(editor.state.doc.child(1).type.name).toBe('paragraph')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('keeps a markdown inline image as an inline node', () => {
+    const editor = createRichMarkdownEditorFromSource(CRASH_SOURCE)
+
+    try {
+      const paragraph = editor.state.doc.child(0)
+      const imageIndex = [...Array(paragraph.childCount).keys()].find(
+        (index) => paragraph.child(index).type.name === 'image'
+      )
+      expect(imageIndex).toBeDefined()
+      expect(paragraph.child(imageIndex!).type.isInline).toBe(true)
+    } finally {
+      editor.destroy()
+    }
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-local-image.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-local-image.test.ts
@@ -88,4 +88,23 @@ describe('rich markdown local images', () => {
       editor.destroy()
     }
   })
+
+  it('renders a mid-sentence image inside its paragraph without a block box', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const editor = new Editor({
+      element: host,
+      extensions: createRichMarkdownExtensions({ codec: createRichMarkdownEditorCodec() }),
+      content: 'before ![](diagram.png) after',
+      contentType: 'markdown'
+    })
+
+    try {
+      const img = host.querySelector('p img')
+      expect(img).not.toBeNull()
+      expect((img!.parentElement as HTMLElement).style.display).toBe('inline-block')
+    } finally {
+      editor.destroy()
+    }
+  })
 })

--- a/src/renderer/src/components/editor/rich-markdown-paragraph.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-paragraph.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RichMarkdownParagraph } from './rich-markdown-paragraph'
+
+vi.mock('@tiptap/extension-paragraph', async () => {
+  const actual = (await vi.importActual('@tiptap/extension-paragraph')) as {
+    Paragraph: { extend: (config: object) => { config: Record<string, unknown> } }
+  }
+  // Simulates a Tiptap upgrade that drops `parseMarkdown` from the upstream paragraph.
+  const Paragraph = actual.Paragraph.extend({})
+  Paragraph.config.parseMarkdown = undefined
+  return { ...actual, Paragraph }
+})
+
+describe('RichMarkdownParagraph without an upstream markdown parser', () => {
+  it('parses paragraphs through parseInline instead of throwing', () => {
+    const parseInline = vi.fn(() => [{ type: 'text', text: 'Install the extension' }])
+    const createNode = vi.fn((type: string, attrs: unknown, content: unknown) => ({
+      type,
+      attrs,
+      content
+    }))
+    const parseMarkdown = RichMarkdownParagraph.config.parseMarkdown as (
+      token: unknown,
+      helpers: unknown
+    ) => unknown
+    const token = { type: 'paragraph', tokens: [{ type: 'text' }, { type: 'image' }] }
+
+    expect(() => parseMarkdown(token, { createNode, parseInline })).not.toThrow()
+    expect(createNode).toHaveBeenCalledWith('paragraph', undefined, [
+      { type: 'text', text: 'Install the extension' }
+    ])
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-paragraph.ts
+++ b/src/renderer/src/components/editor/rich-markdown-paragraph.ts
@@ -6,14 +6,16 @@ type ParagraphMarkdownParser = (
   helpers: MarkdownParseHelpers
 ) => MarkdownParseResult
 
-const baseParseMarkdown = Paragraph.config.parseMarkdown as ParagraphMarkdownParser
+const baseParseMarkdown = Paragraph.config.parseMarkdown as ParagraphMarkdownParser | undefined
 
 export const RichMarkdownParagraph = Paragraph.extend({
   parseMarkdown: (token, helpers) => {
     const tokens = token.tokens ?? []
     // Why: upstream hoists a lone image out of its paragraph, which produces an
     // inline image node directly under `doc` now that images are inline nodes.
-    if (tokens.length === 1 && tokens[0]?.type === 'image') {
+    // The missing-base fallback keeps a Tiptap upgrade that drops the field from
+    // turning every paragraph parse into a TypeError.
+    if (!baseParseMarkdown || (tokens.length === 1 && tokens[0]?.type === 'image')) {
       return helpers.createNode('paragraph', undefined, helpers.parseInline(tokens))
     }
     return baseParseMarkdown(token, helpers)

--- a/src/renderer/src/components/editor/rich-markdown-paragraph.ts
+++ b/src/renderer/src/components/editor/rich-markdown-paragraph.ts
@@ -1,0 +1,21 @@
+import type { MarkdownParseHelpers, MarkdownParseResult, MarkdownToken } from '@tiptap/core'
+import { Paragraph } from '@tiptap/extension-paragraph'
+
+type ParagraphMarkdownParser = (
+  token: MarkdownToken,
+  helpers: MarkdownParseHelpers
+) => MarkdownParseResult
+
+const baseParseMarkdown = Paragraph.config.parseMarkdown as ParagraphMarkdownParser
+
+export const RichMarkdownParagraph = Paragraph.extend({
+  parseMarkdown: (token, helpers) => {
+    const tokens = token.tokens ?? []
+    // Why: upstream hoists a lone image out of its paragraph, which produces an
+    // inline image node directly under `doc` now that images are inline nodes.
+    if (tokens.length === 1 && tokens[0]?.type === 'image') {
+      return helpers.createNode('paragraph', undefined, helpers.parseInline(tokens))
+    }
+    return baseParseMarkdown(token, helpers)
+  }
+})

--- a/src/renderer/src/components/github/use-image-input.test.ts
+++ b/src/renderer/src/components/github/use-image-input.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Editor } from '@tiptap/core'
+import { act, renderHook } from '@testing-library/react'
+import { createRichMarkdownExtensions } from '@/components/editor/rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from '@/components/editor/rich-markdown-source-transport'
+import { useImageInput } from './use-image-input'
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() }
+}))
+
+let editor: Editor | null = null
+
+function mountComposerEditor(markdown: string): Editor {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  editor = new Editor({
+    element: host,
+    extensions: createRichMarkdownExtensions({ codec: createRichMarkdownEditorCodec() }),
+    content: markdown,
+    contentType: 'markdown'
+  })
+  return editor
+}
+
+function renderImageInput(target: Editor) {
+  return renderHook(() => useImageInput({ current: target } as never, { current: false }))
+}
+
+describe('useImageInput', () => {
+  afterEach(() => {
+    editor?.destroy()
+    editor = null
+    document.body.replaceChildren()
+  })
+
+  it('splits a fenced code block instead of dissolving it when inserting an image URL', () => {
+    const target = mountComposerEditor('```ts\nconst a = 1\n```\n')
+    let pos = -1
+    target.state.doc.descendants((node, nodePos) => {
+      if (pos === -1 && node.isText && node.text?.startsWith('const')) {
+        pos = nodePos + 'const'.length
+      }
+    })
+    target.commands.setTextSelection(pos)
+    const { result } = renderImageInput(target)
+
+    act(() => result.current.setImageUrl('https://example.com/shot.png'))
+    act(() => result.current.insertImageUrl())
+
+    expect(target.getMarkdown().trimEnd()).toBe(
+      '```ts\nconst\n```\n\n![](https://example.com/shot.png)\n\n```ts\n a = 1\n```'
+    )
+    expect(() => target.state.doc.check()).not.toThrow()
+  })
+
+  it('keeps an image URL inline when the cursor is in ordinary prose', () => {
+    const target = mountComposerEditor('Install the extension\n')
+    target.commands.setTextSelection(13)
+    const { result } = renderImageInput(target)
+
+    act(() => result.current.setImageUrl('https://example.com/shot.png'))
+    act(() => result.current.insertImageUrl())
+
+    expect(target.getMarkdown().trimEnd()).toBe(
+      'Install the ![](https://example.com/shot.png)extension'
+    )
+  })
+})

--- a/src/renderer/src/components/github/use-image-input.ts
+++ b/src/renderer/src/components/github/use-image-input.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { Editor } from '@tiptap/react'
 import { getGitHubMarkdownImageUrlState } from './github-markdown-image-url'
+import { buildRichMarkdownImageInsertContent } from '@/components/editor/rich-markdown-image-insert-content'
 import { translate } from '@/i18n/i18n'
 
 export function useImageInput(
@@ -54,7 +55,11 @@ export function useImageInput(
     editor
       .chain()
       .focus()
-      .insertContent({ type: 'image', attrs: { src: imageUrlState.url } })
+      .insertContent(
+        buildRichMarkdownImageInsertContent(editor, editor.state.selection.from, {
+          src: imageUrlState.url
+        })
+      )
       .run()
     setImageUrl('')
     setImageInputOpen(false)

--- a/tests/e2e/helpers/markdown-inline-image.ts
+++ b/tests/e2e/helpers/markdown-inline-image.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+
+const ERROR_BOUNDARY_TEXT = 'The rich markdown editor hit an unexpected error'
+const SCHEMA_ERROR_SIGNATURE = 'Invalid content for node'
+
+// A 22x22 PNG dot, small enough to keep inline with the surrounding text.
+const INLINE_DOT_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAAAOklEQVR42mOoMGL4TwvMQHOD//dQB48aTKbB6IBigwmBwWUwsWDUYPINHnqpgqYZZLQQoqrBQ6bOAwDparQl4qEv0wAAAABJRU5ErkJggg=='
+
+export const INLINE_IMAGE_FIXTURE_DIRECTORY = '.orca-e2e-markdown-inline-image'
+
+export const INLINE_IMAGE_PARAGRAPH_MARKDOWN = [
+  '# Inline image crash repro',
+  '',
+  'Some text ![alt](inline-dot.png) more text',
+  ''
+].join('\n')
+
+export const INLINE_IMAGE_DETAILS_MARKDOWN = [
+  '# Details summary inline image repro',
+  '',
+  '<details class="orca-details" open>',
+  '<summary>Toggle ![alt](inline-dot.png) label</summary>',
+  '',
+  'Body',
+  '',
+  '</details>',
+  ''
+].join('\n')
+
+export function writeInlineImageAsset(rootPath: string): void {
+  const directory = path.join(rootPath, INLINE_IMAGE_FIXTURE_DIRECTORY)
+  mkdirSync(directory, { recursive: true })
+  writeFileSync(
+    path.join(directory, 'inline-dot.png'),
+    Buffer.from(INLINE_DOT_PNG_BASE64, 'base64')
+  )
+}
+
+/**
+ * The schema RangeError is thrown inside EditorView.dispatch, outside React's
+ * render phase, so no error boundary observes it — it only surfaces as a page
+ * error. Collect both signals.
+ */
+export function collectRichMarkdownPageErrors(page: Page): string[] {
+  const pageErrors: string[] = []
+  page.on('pageerror', (error) => pageErrors.push(`${error.name}: ${error.message}`))
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      pageErrors.push(message.text())
+    }
+  })
+  return pageErrors
+}
+
+export async function expectNoRichMarkdownSchemaCrash(
+  page: Page,
+  pageErrors: string[]
+): Promise<void> {
+  expect(
+    pageErrors.filter((entry) => entry.includes(SCHEMA_ERROR_SIGNATURE)),
+    'no schema RangeError may be raised'
+  ).toEqual([])
+  await expect(
+    page.getByText(ERROR_BOUNDARY_TEXT),
+    'rich markdown error boundary must not trip'
+  ).toHaveCount(0)
+}

--- a/tests/e2e/rich-markdown-inline-image.spec.ts
+++ b/tests/e2e/rich-markdown-inline-image.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from './helpers/orca-app'
+import {
+  cleanupMarkdownFixture,
+  createMarkdownFixture,
+  getActiveWorktreeContext,
+  openMarkdownFixture,
+  waitForRichMarkdownEditor
+} from './helpers/markdown-editor-fixture'
+import {
+  collectRichMarkdownPageErrors,
+  expectNoRichMarkdownSchemaCrash,
+  INLINE_IMAGE_DETAILS_MARKDOWN,
+  INLINE_IMAGE_FIXTURE_DIRECTORY,
+  INLINE_IMAGE_PARAGRAPH_MARKDOWN,
+  writeInlineImageAsset
+} from './helpers/markdown-inline-image'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+// A markdown image nested in a paragraph or a toggle summary used to parse into a
+// schema-invalid document that only threw on the first edit reassembling it.
+test.describe('Rich markdown inline image regression', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('an inline image inside a paragraph survives a keystroke', async ({
+    orcaPage
+  }, testInfo) => {
+    const context = await getActiveWorktreeContext(orcaPage)
+    const pageErrors = collectRichMarkdownPageErrors(orcaPage)
+    let filePath: string | null = null
+
+    try {
+      writeInlineImageAsset(context.rootPath)
+      filePath = await createMarkdownFixture(
+        context,
+        INLINE_IMAGE_FIXTURE_DIRECTORY,
+        'paragraph-inline-image',
+        testInfo.workerIndex,
+        INLINE_IMAGE_PARAGRAPH_MARKDOWN
+      )
+      await openMarkdownFixture(orcaPage, context, filePath)
+      const editor = await waitForRichMarkdownEditor(orcaPage)
+
+      const paragraph = editor.locator('p').filter({ hasText: 'more text' }).first()
+      await expect(paragraph).toBeVisible({ timeout: 15_000 })
+      await expect(editor.locator('img')).toHaveCount(1, { timeout: 15_000 })
+
+      // Typing at the paragraph start reassembles the whole paragraph, which is
+      // the frame the reported RangeError bottomed out in.
+      await paragraph.click({ position: { x: 12, y: 8 } })
+      await orcaPage.keyboard.press('Home')
+      await orcaPage.keyboard.type('X')
+
+      await expect(editor.locator('p').filter({ hasText: 'XSome text' })).toHaveCount(1)
+      await expect(editor.locator('img')).toHaveCount(1)
+      await expectNoRichMarkdownSchemaCrash(orcaPage, pageErrors)
+    } finally {
+      await cleanupMarkdownFixture(filePath)
+    }
+  })
+
+  test('an inline image inside a toggle summary survives a keystroke', async ({
+    orcaPage
+  }, testInfo) => {
+    const context = await getActiveWorktreeContext(orcaPage)
+    const pageErrors = collectRichMarkdownPageErrors(orcaPage)
+    let filePath: string | null = null
+
+    try {
+      writeInlineImageAsset(context.rootPath)
+      filePath = await createMarkdownFixture(
+        context,
+        INLINE_IMAGE_FIXTURE_DIRECTORY,
+        'details-inline-image',
+        testInfo.workerIndex,
+        INLINE_IMAGE_DETAILS_MARKDOWN
+      )
+      await openMarkdownFixture(orcaPage, context, filePath)
+      const editor = await waitForRichMarkdownEditor(orcaPage)
+
+      const summary = editor.locator('summary').first()
+      await expect(summary).toBeVisible({ timeout: 15_000 })
+      await expect(editor.locator('summary img')).toHaveCount(1, { timeout: 15_000 })
+
+      await summary.click()
+      await orcaPage.keyboard.press('End')
+      await orcaPage.keyboard.type('X')
+
+      await expect(editor.locator('summary').filter({ hasText: 'labelX' })).toHaveCount(1)
+      await expect(editor.locator('summary img')).toHaveCount(1)
+      await expectNoRichMarkdownSchemaCrash(orcaPage, pageErrors)
+    } finally {
+      await cleanupMarkdownFixture(filePath)
+    }
+  })
+
+  test('a formatting command over an inline image keeps the image', async ({
+    orcaPage
+  }, testInfo) => {
+    const context = await getActiveWorktreeContext(orcaPage)
+    const pageErrors = collectRichMarkdownPageErrors(orcaPage)
+    let filePath: string | null = null
+
+    try {
+      writeInlineImageAsset(context.rootPath)
+      filePath = await createMarkdownFixture(
+        context,
+        INLINE_IMAGE_FIXTURE_DIRECTORY,
+        'paragraph-inline-image-bold',
+        testInfo.workerIndex,
+        INLINE_IMAGE_PARAGRAPH_MARKDOWN
+      )
+      await openMarkdownFixture(orcaPage, context, filePath)
+      const editor = await waitForRichMarkdownEditor(orcaPage)
+
+      const paragraph = editor.locator('p').filter({ hasText: 'more text' }).first()
+      await expect(paragraph).toBeVisible({ timeout: 15_000 })
+      await expect(editor.locator('img')).toHaveCount(1, { timeout: 15_000 })
+
+      // toggleBold runs tr.addMark across the selection, which reassembles every
+      // paragraph it spans — and silently dropped the image before the fix.
+      await paragraph.click({ position: { x: 12, y: 8 } })
+      await orcaPage.keyboard.press('ControlOrMeta+a')
+      await orcaPage.getByRole('button', { name: 'Bold', exact: true }).first().click()
+
+      await expect(editor.locator('strong').first()).toBeVisible()
+      await expect(editor.locator('img')).toHaveCount(1)
+      await expectNoRichMarkdownSchemaCrash(orcaPage, pageErrors)
+    } finally {
+      await cleanupMarkdownFixture(filePath)
+    }
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​691 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​688 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 |

<!-- /orca-pr-loc -->

## What

An inline markdown image made the rich-markdown editor throw a `RangeError` and its React error boundary tear the surface down. Report `0e46c048` (Orca 1.4.198, macOS 25.3.0):

```
boundary_id  : editor.rich-markdown
surface      : rich-markdown-editor
error_name   : RangeError
error_message: Invalid content for node paragraph: <".\nnh ", code(".crx"), " (tham chiếu, KHÔNG chặn
stack        : e.checkContent <- Se <- Ce <- _e (recursive) <- ge <- e.replace
```

## Fix evidence

`Image` was registered with only `allowBase64: true`, keeping the TipTap default `inline: false` / `group: 'block'` — but `paragraph` is `content: 'inline*'`. The markdown pipeline nevertheless nests images inline, and `Schema.nodeFromJSON` performs **no** content validation, so the editor happily builds a schema-invalid document that renders and serializes fine. It only detonates on the first ProseMirror step that reassembles that paragraph.

**Important:** the Vietnamese text, the newline and the `` code(".crx") `` in the error message are innocent bystanders. ProseMirror truncates its content dump with `content.toString().slice(0, 50)`, which is why the offending `image` child never appears in the message — and why this read as a text-encoding problem when it is not.

Every image placement, measured before and after:

| markdown source | before | after |
|---|---|---|
| `text ![a](x) more` | `doc.check()` **RangeError** | valid, md byte-identical |
| `![a](x)` standalone | valid (top-level block) | valid (`paragraph > image`), md byte-identical |
| `- item ![a](x)` | **RangeError** | valid, md byte-identical |
| `- ![a](x)` | **RangeError** | valid, md byte-identical |
| table cell `\| ![a](x) \|` | **RangeError** | valid, md byte-identical |
| `> ![a](x)` | **RangeError** | valid, md byte-identical |
| `![a](x "t")` (title) | **RangeError** | valid, md byte-identical |

Which operations threw on the bad document (all now clean): `doc.check()`, `tr.insertText`, `tr.delete`, `tr.addMark` — every one routes through `doc.replace` → `checkContent`. `setContent` / `getMarkdown` / `normalizeSoftBreaks` did **not** throw, which is exactly why the document loaded fine and blew up later on the user's first keystroke.

| command | before | after |
|---|---|---|
| `pnpm test src/renderer/src/components/editor/` | 209 files, 1419 passed | 209 files, **1422 passed** (+3) |
| `pnpm tc` | — | clean |
| `pnpm run check:code-quality:changed` | — | 0 new findings |

## ELI5

The editor has a rulebook saying what can go inside what. It said *"a picture is a big block that stands on its own line"* and *"a paragraph may only contain small inline things like text."*

But when you write a picture in the middle of a sentence, the markdown reader puts the picture inside the paragraph — a big block inside a container that only allows small things. The rulebook was never consulted at load time, so the document opened fine and looked fine.

The rulebook only gets checked when the editor rebuilds that paragraph, which happens the moment you type in it. Then it noticed the illegal shape, threw, and the whole editor panel disappeared.

The fix tells the rulebook the truth — in markdown, a picture *is* an inline thing — so the document is legal in the first place.

## Trade-offs

Honest list of behaviour changes:

1. **Document shape changed:** a standalone image is now `paragraph > image` instead of a top-level `image` block. **Markdown output is byte-identical in every case above**, so nothing the user sees or saves changes — but anything that pattern-matches on the doc JSON shape would see the difference.
2. **Image nodeView wrapper is now `<span>` (`display:inline-block`) instead of `<div>`.** Required: a block `div` inside a `<p>` would break surrounding text onto its own line. Visual result for a standalone image is unchanged.
3. **New `RichMarkdownParagraph` extension replaces StarterKit's paragraph.** `inline: true` alone is *not* sufficient — upstream's paragraph `parseMarkdown` unconditionally hoists a lone image out of its paragraph, which with an inline image produces an inline node directly under `doc` (`block+`): the same invalid-document class, just relocated. The override changes only that branch and delegates everything else (notably `&nbsp;` empty-paragraph handling) to `Paragraph.config.parseMarkdown`.
4. **Rejected alternative:** normalizing the parsed doc by splitting paragraphs around a block image. That rewrites the user's markdown on save (`text ![img](a) more` → `text\n\n![img](a)\n\nmore`) — content mangling on a document they only opened. Not acceptable.
5. **Pre-existing, not fixed here:** a linked image `[![i](x.png)](https://example.com)` loses its link. Separate parser defect, out of scope, filed for follow-up.

## Adversarial review

**1 loop to clean.** The reviewer re-derived the mechanism from scratch and proved it empirically rather than trusting the brief — reverting `inline: true` and re-running a 13-case probe showed **12 of 13** image placements produced an invalid document at baseline.

Findings, 3 of 4 fixed in that loop:
- *(high)* **The same RangeError still fired from `<details><summary>`.** Upstream's `detailsSummary` is `content: 'text*'`, but Orca's details `parseMarkdown` feeds it richer content — a live second path to the identical crash that the original fix missed entirely. Fixed.
- *(medium)* `RichMarkdownParagraph` was load-bearing but **no test failed without it** — deleting it would silently reintroduce a doc-level variant of the crash. Pinned with a test.
- *(low)* The "markdown images are inline" rationale comment sat ~110 lines from the option it explains. Moved.
- *(low, not fixed)* The linked-image regression above — verified pre-existing at HEAD, not introduced here.

Fixes the crash in report `0e46c048`.
