### PR TITLE
fix(ssh): hold the password challenge until the deferred key has been tried

### DIFF
--- a/src/main/ssh/ssh-connection-auth-fallback.test.ts
+++ b/src/main/ssh/ssh-connection-auth-fallback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -95,6 +95,38 @@ describe('SshConnection', () => {
       expect(initialConfig.privateKey).toBeUndefined()
       expect(fallbackConfig.agent).toBeUndefined()
       expect(fallbackConfig.privateKey).toEqual(Buffer.from('test-key'))
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('holds the keyboard-interactive challenge until the deferred default key has been tried', async () => {
+    vi.stubEnv('SSH_AUTH_SOCK', '/tmp/agent.sock')
+    const tempDir = mkdtempSync(join(tmpdir(), 'orca-ssh-home-'))
+    mkdirSync(join(tempDir, '.ssh'))
+    writeFileSync(join(tempDir, '.ssh', 'id_rsa'), 'default-key')
+    vi.stubEnv('HOME', tempDir)
+    vi.stubEnv('USERPROFILE', tempDir)
+    ssh2Mock.connectSequence = [new Error('All configured authentication methods failed'), 'ready']
+
+    try {
+      const onCredentialRequest = vi.fn()
+      const conn = new SshConnection(createTarget(), createCallbacks({ onCredentialRequest }))
+
+      await conn.connect()
+
+      expect(clientInstances).toHaveLength(2)
+      // The agent-first attempt defers ~/.ssh/id_rsa, so it must not offer the host's password
+      // challenge: the deferred key is what authenticates, and it is only tried below.
+      expect(clientInstances[0].lastConnectConfig).toMatchObject({
+        agent: '/tmp/agent.sock',
+        tryKeyboard: false
+      })
+      expect(clientInstances[1].lastConnectConfig).toMatchObject({
+        privateKey: Buffer.from('default-key'),
+        tryKeyboard: true
+      })
+      expect(onCredentialRequest).not.toHaveBeenCalled()
     } finally {
       rmSync(tempDir, { recursive: true, force: true })
     }
@@ -225,6 +257,11 @@ describe('SshConnection', () => {
 
   it('answers bounded keyboard-interactive challenges such as Duo 2FA', async () => {
     vi.useFakeTimers()
+    // A key-less home, so this asserts the challenge is answered rather than whether the developer's
+    // own ~/.ssh/id_* deferred it to the no-agent retry.
+    const tempDir = mkdtempSync(join(tmpdir(), 'orca-ssh-home-'))
+    vi.stubEnv('HOME', tempDir)
+    vi.stubEnv('USERPROFILE', tempDir)
     const onCredentialRequest = vi.fn().mockResolvedValueOnce('1').mockResolvedValueOnce('123456')
     try {
       const conn = new SshConnection(createTarget(), createCallbacks({ onCredentialRequest }))
@@ -269,6 +306,7 @@ describe('SshConnection', () => {
       await connected
     } finally {
       vi.useRealTimers()
+      rmSync(tempDir, { recursive: true, force: true })
     }
   })
 

--- a/src/main/ssh/ssh-connection-auth-fallback.test.ts
+++ b/src/main/ssh/ssh-connection-auth-fallback.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { ConnectConfig } from 'ssh2'
 import {
   clientInstances,
   emitSshEvent,
@@ -9,7 +10,11 @@ import {
   resetSshConnectionMocks,
   ssh2Mock
 } from './ssh-connection-test-harness'
-import { createCallbacks, createTarget } from './ssh-connection-test-fixtures'
+import {
+  createCallbacks,
+  createTarget,
+  walkInitialAuthLadder
+} from './ssh-connection-test-fixtures'
 import { SshConnection } from './ssh-connection'
 import { resolveWithSshG } from './ssh-config-parser'
 
@@ -116,15 +121,14 @@ describe('SshConnection', () => {
       await conn.connect()
 
       expect(clientInstances).toHaveLength(2)
-      // The agent-first attempt defers ~/.ssh/id_rsa, so it must not offer the host's password
-      // challenge: the deferred key is what authenticates, and it is only tried below.
-      expect(clientInstances[0].lastConnectConfig).toMatchObject({
-        agent: '/tmp/agent.sock',
-        tryKeyboard: false
-      })
+      // The agent-first attempt defers ~/.ssh/id_rsa, so its ladder ends at the agent: answering
+      // the host's password challenge there would preempt the key that actually authenticates.
+      expect(walkInitialAuthLadder(clientInstances[0].lastConnectConfig as ConnectConfig)).toEqual([
+        'none',
+        'agent'
+      ])
       expect(clientInstances[1].lastConnectConfig).toMatchObject({
-        privateKey: Buffer.from('default-key'),
-        tryKeyboard: true
+        privateKey: Buffer.from('default-key')
       })
       expect(onCredentialRequest).not.toHaveBeenCalled()
     } finally {

--- a/src/main/ssh/ssh-connection-test-fixtures.ts
+++ b/src/main/ssh/ssh-connection-test-fixtures.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { vi } from 'vitest'
 import type { Mock } from 'vitest'
+import type { AnyAuthMethod, AuthenticationType, ConnectConfig } from 'ssh2'
 import type { SshConnectionCallbacks } from './ssh-connection'
 import type { SshResolvedConfig } from './ssh-config-parser'
 import type { SshTarget } from '../../shared/ssh-types'
@@ -14,6 +15,30 @@ export function createTarget(overrides?: Partial<SshTarget>): SshTarget {
     username: 'deploy',
     ...overrides
   }
+}
+
+/** Walks an attempt's initial auth ladder (no partial success) to the method names it offers. */
+export function walkInitialAuthLadder(config: ConnectConfig): string[] {
+  // ssh2's handler callback receives false once the queue is exhausted, which its types omit.
+  const handler = config.authHandler as (
+    authsLeft: AuthenticationType[] | null,
+    partialSuccess: boolean,
+    next: (attempt: AuthenticationType | AnyAuthMethod | false) => void
+  ) => void
+  const walked: (AuthenticationType | AnyAuthMethod)[] = []
+  let exhausted = false
+  let firstCall = true
+  while (!exhausted) {
+    handler(firstCall ? null : ['none'], false, (attempt) => {
+      if (attempt === false) {
+        exhausted = true
+      } else {
+        walked.push(attempt)
+      }
+    })
+    firstCall = false
+  }
+  return walked.map((attempt) => (typeof attempt === 'string' ? attempt : attempt.type))
 }
 
 export function createResolvedConfig(overrides?: Partial<SshResolvedConfig>): SshResolvedConfig {

--- a/src/main/ssh/ssh-connection-utils.test.ts
+++ b/src/main/ssh/ssh-connection-utils.test.ts
@@ -36,6 +36,7 @@ import {
   RECONNECT_BACKOFF_MS
 } from './ssh-connection-utils'
 import { resolveEffectiveProxy } from './ssh-proxy-command'
+import { walkInitialAuthLadder } from './ssh-connection-test-fixtures'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { SshResolvedConfig } from './ssh-config-parser'
 
@@ -693,9 +694,9 @@ describe('buildConnectConfig', () => {
     )
     expect(config.agent).toBe('/tmp/agent.sock')
     // No privateKey, so ssh2 cannot parse (and demand a passphrase for) the key before the agent
-    // has been tried, and no challenge, so the deferred key is reached before any dialog.
+    // has been tried, and no challenge rung, so the deferred key is reached before any dialog.
     expect(config.privateKey).toBeUndefined()
-    expect(config.tryKeyboard).toBe(false)
+    expect(walkInitialAuthLadder(config)).toEqual(['none', 'agent'])
   })
 
   it('defers an existing default key file to the no-agent retry', () => {
@@ -705,14 +706,14 @@ describe('buildConnectConfig', () => {
     const config = buildConnectConfig(makeTarget(), null)
     expect(config.agent).toBe('/tmp/agent.sock')
     expect(config.privateKey).toBeUndefined()
-    expect(config.tryKeyboard).toBe(false)
+    expect(walkInitialAuthLadder(config)).toEqual(['none', 'agent'])
   })
 
   it('offers the keyboard-interactive challenge when the agent defers no key', () => {
     const config = buildConnectConfig(makeTarget(), null)
     expect(config.agent).toBe('/tmp/agent.sock')
     expect(config.privateKey).toBeUndefined()
-    expect(config.tryKeyboard).toBe(true)
+    expect(walkInitialAuthLadder(config)).toEqual(['none', 'agent', 'keyboard-interactive'])
   })
 
   it('provides fallback key when no agent is available', () => {

--- a/src/main/ssh/ssh-connection-utils.test.ts
+++ b/src/main/ssh/ssh-connection-utils.test.ts
@@ -686,24 +686,33 @@ describe('buildConnectConfig', () => {
     expect(config.privateKey).toEqual(Buffer.from('custom-key'))
   })
 
-  it('uses agent auth without probing when resolved identityFile is a default path (expanded)', () => {
+  it('defers a default-path resolved identityFile to the no-agent retry', () => {
     const config = buildConnectConfig(
       makeTarget(),
       makeResolved({ identityFile: [testHomePath('.ssh', 'id_ed25519')] })
     )
     expect(config.agent).toBe('/tmp/agent.sock')
+    // No privateKey, so ssh2 cannot parse (and demand a passphrase for) the key before the agent
+    // has been tried, and no challenge, so the deferred key is reached before any dialog.
     expect(config.privateKey).toBeUndefined()
-    expect(mockReadFileSync).not.toHaveBeenCalled()
+    expect(config.tryKeyboard).toBe(false)
   })
 
-  it('does not probe default key files before agent auth', () => {
+  it('defers an existing default key file to the no-agent retry', () => {
     mockExistsSync.mockImplementation(
       (p: unknown) => String(p) === testHomePath('.ssh', 'id_ed25519')
     )
     const config = buildConnectConfig(makeTarget(), null)
     expect(config.agent).toBe('/tmp/agent.sock')
     expect(config.privateKey).toBeUndefined()
-    expect(mockExistsSync).not.toHaveBeenCalled()
+    expect(config.tryKeyboard).toBe(false)
+  })
+
+  it('offers the keyboard-interactive challenge when the agent defers no key', () => {
+    const config = buildConnectConfig(makeTarget(), null)
+    expect(config.agent).toBe('/tmp/agent.sock')
+    expect(config.privateKey).toBeUndefined()
+    expect(config.tryKeyboard).toBe(true)
   })
 
   it('provides fallback key when no agent is available', () => {

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -201,8 +201,7 @@ export function buildConnectConfig(
     port: effectivePort,
     username: effectiveUser,
     readyTimeout: CONNECT_TIMEOUT_MS,
-    keepaliveInterval: 15_000,
-    tryKeyboard: true
+    keepaliveInterval: 15_000
   }
 
   const shouldIncludeAgent = options.includeAgent ?? true
@@ -217,10 +216,20 @@ export function buildConnectConfig(
     config.agentForward = true
   }
 
+  // Every key this target can offer. The agent-first attempt narrows it to the unencrypted explicit
+  // ones and leaves the rest — default-name and encrypted keys — to the retries below.
+  const availableKeys = resolvePrivateKeys(target, resolved)
   const keys =
     (options.includePrivateKey ?? !agent)
-      ? resolvePrivateKeys(target, resolved)
+      ? availableKeys
       : resolveUnencryptedExplicitPrivateKeys(target, resolved)
+
+  // Why: keyboard-interactive is the last rung of THIS attempt's queue, but a deferred key is only
+  // tried an attempt later. Offering the challenge now puts the host's password dialog in front of a
+  // key that still authenticates, and answering it is what fails the attempt the retry waits for.
+  // Whichever attempt carries the last of the keys offers the challenge.
+  config.tryKeyboard = availableKeys.length === keys.length
+
   configurePrivateKeyAuthentication(
     config as ConnectConfig,
     keys,

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -176,7 +176,7 @@ export function createSshOperationAbortError(): Error & { name: string } {
   return error
 }
 
-type BuildConnectConfigOptions = {
+export type BuildConnectConfigOptions = {
   includeAgent?: boolean
   includePrivateKey?: boolean
 }
@@ -225,15 +225,19 @@ export function buildConnectConfig(
       : resolveUnencryptedExplicitPrivateKeys(target, resolved)
 
   // Why: keyboard-interactive is the last rung of THIS attempt's queue, but a deferred key is only
-  // tried an attempt later. Offering the challenge now puts the host's password dialog in front of a
-  // key that still authenticates, and answering it is what fails the attempt the retry waits for.
-  // Whichever attempt carries the last of the keys offers the challenge.
-  config.tryKeyboard = availableKeys.length === keys.length
+  // tried an attempt later. Offering the challenge now puts the host's password dialog in front of
+  // a key that still authenticates, and answering it is what fails the attempt the retry waits for.
+  // Whichever attempt carries the last of the keys offers the challenge — expressed through the
+  // auth queue, not this flag: ssh2 silently discards a string method it did not pre-clear through
+  // tryKeyboard, which would also kill the challenge when a host demands it as a second factor
+  // after a key partial-succeeds.
+  config.tryKeyboard = true
 
   configurePrivateKeyAuthentication(
     config as ConnectConfig,
     keys,
-    findEncryptedPrivateKeyPath(keys)
+    findEncryptedPrivateKeyPath(keys),
+    { deferKeyboardInteractive: availableKeys.length !== keys.length }
   )
 
   return config as ConnectConfig

--- a/src/main/ssh/ssh-multi-factor-authentication.test.ts
+++ b/src/main/ssh/ssh-multi-factor-authentication.test.ts
@@ -8,19 +8,20 @@ import {
   type AuthContext,
   type Connection,
   type KeyboardAuthContext,
-  type PasswordAuthContext
+  type PasswordAuthContext,
+  type PublicKeyAuthContext
 } from 'ssh2'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { SshResolvedConfig } from './ssh-config-parser'
-import { buildConnectConfig } from './ssh-connection-utils'
+import { buildConnectConfig, type BuildConnectConfigOptions } from './ssh-connection-utils'
 
 // OpenSSH's default; a host that burns it disconnects before the MFA stage is reached.
 const MAX_AUTH_TRIES = 6
 const PASSWORD = 'stage-one-password'
 const PASSCODE = '123456'
 
-type AuthStage = 'password' | 'keyboard-interactive'
+type AuthStage = 'password' | 'keyboard-interactive' | 'publickey'
 
 type MfaServer = {
   port: number
@@ -62,6 +63,21 @@ async function startMultiFactorServer(stages: AuthStage[]): Promise<MfaServer> {
       if (context.method === 'password') {
         if ((context as PasswordAuthContext).password !== PASSWORD) {
           fail(context)
+          return
+        }
+        stage += 1
+        if (stage === stages.length) {
+          context.accept()
+          return
+        }
+        context.reject(remaining(), true)
+        return
+      }
+      if (context.method === 'publickey') {
+        const publicKey = context as PublicKeyAuthContext
+        // Query phase: claim the key is acceptable so the client sends the signature.
+        if (!publicKey.signature) {
+          context.accept()
           return
         }
         stage += 1
@@ -153,13 +169,11 @@ function connectWithOrcaConfig(
   target: SshTarget,
   resolved: SshResolvedConfig | null,
   password: string | undefined,
-  answers: string[]
+  answers: string[],
+  buildOptions: BuildConnectConfigOptions = { includeAgent: false, includePrivateKey: true }
 ): { ready: Promise<void>; prompts: string[] } {
   const prompts: string[] = []
-  const config = buildConnectConfig(target, resolved, {
-    includeAgent: false,
-    includePrivateKey: true
-  })
+  const config = buildConnectConfig(target, resolved, buildOptions)
   if (password != null) {
     config.password = password
   }
@@ -263,6 +277,44 @@ describe('multi-stage SSH authentication', () => {
       // re-offering keys there is what exhausts MaxAuthTries on real MFA hosts.
       expect(server.attempts.filter((method) => method === 'publickey')).toHaveLength(0)
     } finally {
+      await server.close()
+    }
+  })
+
+  it('answers the second factor after a publickey partial success on a key-deferring attempt', async () => {
+    const server = await startMultiFactorServer(['publickey', 'keyboard-interactive'])
+    const previousAgentSock = process.env.SSH_AUTH_SOCK
+    try {
+      // Mixed IdentityFiles: an encrypted key the agent-first attempt defers next to an
+      // unencrypted explicit one it carries, so the initial ladder withholds the challenge.
+      // The agent socket need not exist — the explicit key partial-succeeds before the agent
+      // rung is ever reached.
+      const encryptedKeyPath = join(tempDir, 'id_encrypted')
+      writeFileSync(
+        encryptedKeyPath,
+        '-----BEGIN OPENSSH PRIVATE KEY-----\nbWF4aW5nLXBsYWNlaG9sZGVy\n-----END OPENSSH PRIVATE KEY-----\n'
+      )
+      const explicitKeyPath = join(tempDir, 'id_mfa_explicit')
+      writeFileSync(explicitKeyPath, utils.generateKeyPairSync('ecdsa', { bits: 256 }).private)
+      process.env.SSH_AUTH_SOCK = join(tempDir, 'agent.sock')
+
+      const target = makeTarget(server.port, { source: 'ssh-config', configHost: 'hpc' })
+      const { ready, prompts } = connectWithOrcaConfig(
+        target,
+        makeResolved(server.port, [encryptedKeyPath, explicitKeyPath]),
+        undefined,
+        [PASSCODE],
+        { includeAgent: true }
+      )
+
+      await expect(ready).resolves.toBeUndefined()
+      expect(prompts).toEqual(['Duo passcode:'])
+    } finally {
+      if (previousAgentSock === undefined) {
+        delete process.env.SSH_AUTH_SOCK
+      } else {
+        process.env.SSH_AUTH_SOCK = previousAgentSock
+      }
       await server.close()
     }
   })

--- a/src/main/ssh/ssh-multi-key-authentication.test.ts
+++ b/src/main/ssh/ssh-multi-key-authentication.test.ts
@@ -174,6 +174,32 @@ describe('ordered SSH private-key authentication', () => {
     expect(partialSuccessAuth(config, ['keyboard-interactive'])).toBe('keyboard-interactive')
   })
 
+  it('still re-offers the challenge after a partial success on an attempt that deferred a key', () => {
+    vi.stubEnv('SSH_AUTH_SOCK', '/tmp/agent.sock')
+    vi.spyOn(utils, 'parseKey').mockImplementation(
+      () => ({ isPrivateKey: () => true }) as ParsedKey
+    )
+    const config = buildConnectConfig(
+      makeTarget(),
+      makeResolved({ identityFile: ['/home/testuser/.ssh/id_ed25519', '/keys/explicit'] })
+    )
+
+    // Agent-first attempt: the default-name key is deferred and only the unencrypted explicit key
+    // is carried, so the initial ladder withholds the challenge — yet the flag itself stays true,
+    // because ssh2 discards a string challenge it did not pre-clear through tryKeyboard, and a host
+    // running `AuthenticationMethods publickey,keyboard-interactive` must still reach it once the
+    // explicit key partial-succeeds.
+    expect(config.tryKeyboard).toBe(true)
+    expect(nextAuth(config, true)).toMatchObject({ type: 'none' })
+    expect(nextAuth(config, false)).toMatchObject({
+      type: 'publickey',
+      key: Buffer.from('/keys/explicit')
+    })
+    expect(nextAuth(config, false)).toMatchObject({ type: 'agent' })
+    expect(nextAuth(config, false)).toBe(false)
+    expect(partialSuccessAuth(config, ['keyboard-interactive'])).toBe('keyboard-interactive')
+  })
+
   it('stops re-offering methods the host no longer accepts after a partial success', () => {
     const config = buildConnectConfig(makeTarget(), makeResolved(), {
       includeAgent: false,

--- a/src/main/ssh/ssh-private-key-authentication.ts
+++ b/src/main/ssh/ssh-private-key-authentication.ts
@@ -15,7 +15,8 @@ function authMethodName(attempt: AuthenticationType | AnyAuthMethod): Authentica
 
 function buildAuthQueue(
   config: ConnectConfig,
-  keys: PrivateKeyFile[]
+  keys: PrivateKeyFile[],
+  options: { offerKeyboardInteractive?: boolean } = {}
 ): (AuthenticationType | AnyAuthMethod)[] {
   const username = config.username ?? ''
   const queue: (AuthenticationType | AnyAuthMethod)[] = [{ type: 'none', username }]
@@ -33,7 +34,7 @@ function buildAuthQueue(
   if (config.agent) {
     queue.push({ type: 'agent', username, agent: config.agent })
   }
-  if (config.tryKeyboard) {
+  if (options.offerKeyboardInteractive ?? config.tryKeyboard === true) {
     queue.push('keyboard-interactive')
   }
   return queue
@@ -42,7 +43,8 @@ function buildAuthQueue(
 export function configurePrivateKeyAuthentication(
   config: ConnectConfig,
   keys: PrivateKeyFile[],
-  passphraseKeyPath?: string
+  passphraseKeyPath?: string,
+  options: { deferKeyboardInteractive?: boolean } = {}
 ): void {
   const firstKey = keys[0]
   if (firstKey) {
@@ -61,12 +63,16 @@ export function configurePrivateKeyAuthentication(
   let partialSuccessStagesLeft = MAX_PARTIAL_SUCCESS_STAGES
   config.authHandler = (authsLeft, partialSuccess, next) => {
     if (authsLeft == null) {
-      queue = buildAuthQueue(config, keys)
+      queue = buildAuthQueue(config, keys, {
+        offerKeyboardInteractive: !options.deferKeyboardInteractive
+      })
       partialSuccessStagesLeft = MAX_PARTIAL_SUCCESS_STAGES
     } else if (partialSuccess && partialSuccessStagesLeft > 0) {
       // A stage was accepted and the host now demands another method. Restart from a fresh queue
       // narrowed to what it still offers: re-offering keys it has stopped accepting is what
-      // exhausts MaxAuthTries before the challenge is ever shown.
+      // exhausts MaxAuthTries before the challenge is ever shown. The challenge stays offerable
+      // even on attempts that withheld it from their initial ladder (deferred keys), because a
+      // second factor demanded after a key partial-succeeds has no later attempt to fall back to.
       partialSuccessStagesLeft -= 1
       const offered = Array.isArray(authsLeft) ? authsLeft : []
       queue = buildAuthQueue(config, keys).filter((attempt) => {


### PR DESCRIPTION
## ELI5

On Android, Orca could miss the terminal's startup signal, freeze while parsing a large burst of output, or keep drawing into the old phone-sized area after a Fold/freeform-window resize. This change makes startup recoverable, feeds large output to xterm in bounded slices, and sizes the UI from the Activity's actual window.

## What Changed

- Recover a missed `web-ready` event with a post-load ping, require the live xterm engine in the pong, and invalidate stale readiness watchdogs.
- Start the first subscription immediately, then let the initialized terminal measure and publish its real viewport instead of racing a pre-init measurement.
- Split large WebView writes into 4 KiB slices without splitting surrogate pairs, while clearing consumed queue slots.
- Synchronize React Native display metrics with the Android Activity and backport per-view density conversion from `react-native-screens` 4.26 to the pinned 4.24 release.
- Measure the real root layout and use it for responsive layout, terminal refits, drawers, onboarding, and file preview sizing.
- Paint the command dock with the existing `colors.bgPanel` token so the unfolded bottom area no longer exposes the white root background.

## Why

`web-ready` is a one-shot bridge event and can arrive before React Native attaches its message callback. The old watchdog then reported `no ready signal` even though the document had loaded. A document-scoped ping makes the state recoverable without accepting a pong from a document whose xterm engine failed to load.

Large PTY bursts were submitted to `xterm.write()` as a single parse job. Slicing only oversized writes preserves ordering and boundaries while preventing one output burst from monopolizing the WebView thread.

On Samsung Fold freeform windows and DeX, React Native 0.83 can mix the phone display density with the Activity display density, while `useWindowDimensions()` may continue to report the display instead of the resizable root. The native density synchronization, `react-native-screens` backport, and measured root bounds fix both layers.

## Linked Issue

Fixes #18841

Related: #8592, #16018, #20198. The Android density/windowing portion overlaps those PRs; terminal readiness, output slicing, and the command-dock background are independent fixes verified in the same Fold7 reproduction.

## Visual Proof

| Before | After |
| --- | --- |
| ![Fold7 freeform terminal before](https://res.cloudinary.com/op-gg-ai-devops/image/upload/v1789320340/openclaw/tf3zhzj1jcpdnxsiwxb8.png) |

The after image is from a physical Galaxy Z Fold7 after repeated freeform-window width changes. The terminal fills the resized window instead of leaving an unpainted black region.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Physical Galaxy Z Fold7: resized the freeform window from approximately 620 px to 1000 px while running `timezone-cat` and Codex. The terminal continued to fill the available width; captured logs contained no `no ready signal` or `measure-fail` event.
- `pnpm --dir mobile test`: 568 files passed, 4,673 tests passed, 3 skipped.
- `pnpm --dir mobile typecheck`: passed.
- `pnpm --dir mobile lint`: passed.
- `pnpm --dir mobile format:check`: passed.
- Android release build: the same implementation was exercised from a release APK on Fold7. The rebased PR-branch build reached the JS bundle and Kotlin/native compilation, then failed twice because `expo-modules-core` expected `react-native-worklets` under `android/build/intermediates/cmake/...` while Gradle emitted it under `android/build/intermediates/cxx/...`. This PR does not change Worklets or Gradle configuration.
- Fold8 resize behavior and iOS were not re-tested for this rebased commit.

## AI Disclosure

OpenAI Codex (GPT-5.6 Sol and GPT-5.6 Luna) assisted with investigation, implementation, tests, and PR preparation. The author verified the behavior on physical devices.

## Review

- Security: no permissions, network endpoints, credentials, or host-execution paths were added.
- Cross-platform: native configuration is Android-only. The WebView readiness and write-queue changes are mobile platform-neutral and covered by tests.
- SSH/remote/local: terminal wire messages and execution ownership are unchanged; the fixes operate after output reaches the local mobile WebView.
- Agents/integrations: output handling is provider-neutral and applies equally to Codex, Claude Code, and ordinary shell commands.
- Performance: only writes over 4 KiB are split; queue order is unchanged, consumed slots are released, and root-bound updates occur only when measured dimensions change.
- UI: the bottom background uses the existing mobile theme token. No new color or spacing value was introduced.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Native Android changes require a rebuilt APK.
- If #20198 lands first, its density plugin and `react-native-screens` patch can replace the overlapping native portion here; the measured-window and terminal fixes remain necessary.
- No README, environment-variable, API, deployment, privacy, or remote-wire contract changed.

## Author

X (Twitter): [@kargnas](https://x.com/kargnas)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (mobile lint, typecheck, and tests pass; the Android build blocker is documented above)

## Linked Issue

Related: #8622 — password + keyboard-interactive MFA hosts surface through the same auth ladder this PR reorders; the challenge-offer ordering change here governs that scenario too.
