### PR TITLE
fix(native-chat): keep worktree active during chat creation

### DIFF
--- a/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
+++ b/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
@@ -17,7 +17,7 @@ const SURFACE_PROVIDING_CALLERS = [
   'src/renderer/src/hooks/composer-state/full-creation-execution.ts',
   'src/renderer/src/lib/fix-checks-agent-launch.ts',
   'src/renderer/src/lib/launch-work-item-direct.ts',
-  'src/renderer/src/lib/worktree-creation-flow-execute.ts',
+  'src/renderer/src/lib/worktree-creation-structured-session.ts',
   'src/renderer/src/lib/workspace-port-actions.ts',
   'src/renderer/src/store/repos/repo-add-actions.ts'
 ]

--- a/src/renderer/src/lib/worktree-creation-flow-execute.ts
+++ b/src/renderer/src/lib/worktree-creation-flow-execute.ts
@@ -173,21 +173,18 @@ export async function executeWorktreeCreation(
 
   let activation: ActivateAndRevealResult | false = false
   let primaryTabId: string | null
-  if (shouldActivateOnCompletion) {
+  if (shouldActivateOnCompletion && !structuredLaunch) {
     activation = activateAndRevealWorktree(worktree.id, {
       sidebarRevealBehavior: 'auto',
       ...(result.setup ? { setup: result.setup } : {}),
       ...(result.defaultTabs ? { defaultTabs: result.defaultTabs } : {}),
       ...(startupOpt ? { startup: startupOpt } : {}),
       ...(preparedRequest.issueCommand ? { issueCommand: preparedRequest.issueCommand } : {}),
-      ...(backendSpawned ? { backendStartupTerminalSpawned: true } : {}),
-      ...(structuredLaunch ? { providesInitialSurface: true } : {})
+      ...(backendSpawned ? { backendStartupTerminalSpawned: true } : {})
     })
     primaryTabId = activation === false ? null : activation.primaryTabId
   } else {
-    // The user moved on. Seed the worktree's terminal + setup in the background
-    // (setActiveTab only writes global focus for the active worktree, so this is
-    // safe) without yanking them back to it.
+    // Keep chat creation on its pending surface until the session is ready.
     const hasExplicitTerminalWork = Boolean(
       startupOpt || result.setup || preparedRequest.issueCommand || result.defaultTabs
     )

--- a/src/renderer/src/lib/worktree-creation-structured-session.test.ts
+++ b/src/renderer/src/lib/worktree-creation-structured-session.test.ts
@@ -10,7 +10,8 @@ const mocks = vi.hoisted(() => ({
   cancelStructuredAgentLaunch: vi.fn(),
   closeStructuredAgentSession: vi.fn(),
   callRuntimeRpc: vi.fn(),
-  activateStructuredAgentSessionById: vi.fn()
+  activateStructuredAgentSessionById: vi.fn(),
+  activateAndRevealWorktree: vi.fn()
 }))
 
 vi.mock('@/store', () => ({
@@ -51,7 +52,7 @@ vi.mock('@/lib/worktree-initial-terminal-seeding', () => ({
 }))
 
 vi.mock('@/lib/worktree-activation', () => ({
-  activateAndRevealWorktree: vi.fn()
+  activateAndRevealWorktree: mocks.activateAndRevealWorktree
 }))
 
 vi.mock('@/lib/agent-trust-preflight', () => ({
@@ -169,5 +170,42 @@ describe('launchStructuredWorktreeSession', () => {
     expect(mocks.activateStructuredAgentSessionById).not.toHaveBeenCalled()
     expect(releaseCallerAfterUnknownOutcome).toHaveBeenCalledOnce()
     expect(mocks.unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it('activates the workspace before selecting a chat when creation deferred activation', async () => {
+    mocks.startStructuredAgentLaunch.mockReturnValue({
+      sessionId: 'session-1',
+      launchResult: Promise.resolve({ sessionId: 'session-1', fence: 1 }),
+      claimDefinitiveRefusalFallback: vi.fn(() => Promise.resolve(false))
+    })
+    mocks.activateAndRevealWorktree.mockReturnValue({ primaryTabId: null })
+
+    const result = await launchStructuredWorktreeSession({
+      creationId: 'creation-1',
+      request: {
+        repoId: 'repo-1',
+        name: 'routing-recovery',
+        setupDecision: 'run',
+        agent: 'codex',
+        pendingFirstAgentMessageRename: false,
+        note: '',
+        startupPlan: null,
+        quickPrompt: 'Fix the route',
+        quickTelemetry: null
+      },
+      worktreeId: 'worktree-1',
+      shouldActivateOnCompletion: true,
+      fallbackStartupOpt: undefined,
+      activation: false,
+      primaryTabId: null
+    })
+
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('worktree-1', {
+      providesInitialSurface: true
+    })
+    expect(mocks.activateAndRevealWorktree.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.activateStructuredAgentSessionById.mock.invocationCallOrder[0]
+    )
+    expect(result.activation).toEqual({ primaryTabId: null })
   })
 })

--- a/src/renderer/src/lib/worktree-creation-structured-session.ts
+++ b/src/renderer/src/lib/worktree-creation-structured-session.ts
@@ -139,6 +139,11 @@ export async function launchStructuredWorktreeSession(args: {
       return { accepted, cancelled, visibilityUnknown, activation, primaryTabId }
     }
     if (args.shouldActivateOnCompletion) {
+      // Chat selection requires its workspace to be active.
+      if (!activation) {
+        activation = activateAndRevealWorktree(args.worktreeId, { providesInitialSurface: true })
+        primaryTabId = activation === false ? null : activation.primaryTabId
+      }
       activateStructuredAgentSessionById({
         worktreeId: args.worktreeId,
         sessionId: receipt.sessionId


### PR DESCRIPTION
## Problem
Creating a worktree with the native Chat UI could leave the app on the landing screen while the Chat session was still being created.

## Fix
Defer activation for structured Chat launches and activate the worktree immediately before selecting the ready Chat session. This prevents the transient setup surface from clearing the newly created workspace selection.

## Validation
- `ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/worktree-creation-structured-session.test.ts src/renderer/src/lib/worktree-creation-chat-setup.test.ts src/renderer/src/lib/worktree-creation-flow.test.ts`
- `pnpm tc:node`
