### PR TITLE
Close the agent terminal dialog on the pane-close chord (Cmd/Ctrl+W)

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -78,6 +78,7 @@ function AgentTerminalFrame({
           ptyId={card.ptyId}
           terminalInput={card.terminalInput ?? null}
           className={previewClassName}
+          onRequestClose={() => onOpenChange(false)}
         />
       ) : (
         <div className="min-h-0 flex-1 px-2.5 pb-2 text-[11px] text-muted-foreground">
@@ -98,8 +99,8 @@ function AgentTerminalFrame({
  * The near-fullscreen live-terminal dialog for one agent. Hosted by the BOARD,
  * not the card: sending a message flips the agent's bucket, which remounts its
  * card in another column — a card-owned dialog would close mid-conversation.
- * Only an explicit close (button, click-outside, Esc outside the terminal)
- * dismisses it.
+ * Only an explicit close (button, click-outside, Esc outside the terminal, or
+ * the pane-close chord from inside it) dismisses it.
  */
 export function AgentTerminalDialog({
   card,

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -53,12 +53,15 @@ function clamp(value: number, min: number, max: number): number {
 export function AgentTerminalPreview({
   ptyId,
   terminalInput = null,
-  className
+  className,
+  onRequestClose
 }: {
   ptyId: string
   /** Host-input facts relayed with the card; null routes bytes by client OS. */
   terminalInput?: DashboardCardTerminalInput | null
   className?: string
+  /** Dismiss the hosting surface; fired by the pane-close chord (Cmd+W). */
+  onRequestClose?: () => void
 }): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
   const terminalRef = useRef<Terminal | null>(null)
@@ -70,6 +73,7 @@ export function AgentTerminalPreview({
   const settingsRef = useRef(settings)
   const macOptionAsAltRef = useRef(macOptionAsAlt)
   const terminalInputRef = useRef(terminalInput)
+  const onRequestCloseRef = useRef(onRequestClose)
   const { terminalTheme, terminalMode } = useMemo(() => {
     if (!settings) {
       return { terminalTheme: null, terminalMode: 'dark' as const }
@@ -93,7 +97,8 @@ export function AgentTerminalPreview({
     settingsRef.current = settings
     macOptionAsAltRef.current = macOptionAsAlt
     terminalInputRef.current = terminalInput
-  }, [settings, macOptionAsAlt, terminalInput])
+    onRequestCloseRef.current = onRequestClose
+  }, [settings, macOptionAsAlt, terminalInput, onRequestClose])
 
   useEffect(() => {
     setPtyGone(false)
@@ -204,6 +209,7 @@ export function AgentTerminalPreview({
           void pasteClipboardText(activeElement, source),
         // Why: route through terminal.input so the chord's bytes carry core's user-input signal, like typed keys.
         sendInput: (data) => terminal?.input(data),
+        requestClose: () => onRequestCloseRef.current?.(),
         getShortcutContext: () => ({
           clientPlatform: getShortcutPlatform(),
           macOptionAsAlt: macOptionAsAltRef.current,

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.close-chord.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.close-chord.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
+
+const platformState = vi.hoisted(() => ({ value: 'darwin' as NodeJS.Platform }))
+const storeState = vi.hoisted(() => ({ keybindings: {} as Record<string, string[]> }))
+
+vi.mock('@/lib/shortcut-platform', () => ({
+  getShortcutPlatform: () => platformState.value
+}))
+vi.mock('@/store', () => {
+  const useAppStore = (selector: (s: typeof storeState) => unknown): unknown => selector(storeState)
+  useAppStore.getState = (): typeof storeState => storeState
+  return { useAppStore }
+})
+
+import { installPreviewTerminalKeyHandler } from './preview-terminal-key-handler'
+
+function installHandler(requestClose: () => void): {
+  handler: (event: KeyboardEvent) => boolean
+  sendInput: ReturnType<typeof vi.fn>
+  dispose: () => void
+} {
+  let handler: ((event: KeyboardEvent) => boolean) | null = null
+  const terminal = {
+    attachCustomKeyEventHandler: (fn: (event: KeyboardEvent) => boolean) => {
+      handler = fn
+    },
+    getSelection: () => '',
+    scrollToTop: vi.fn(),
+    scrollToBottom: vi.fn(),
+    selectAll: vi.fn()
+  } as unknown as Terminal
+  const sendInput = vi.fn()
+  const dispose = installPreviewTerminalKeyHandler({
+    terminal,
+    claimImeKeyEvent: () => false,
+    pasteClipboardText: () => {},
+    sendInput,
+    requestClose,
+    getShortcutContext: () => ({
+      clientPlatform: platformState.value,
+      macOptionAsAlt: 'false',
+      keybindings: storeState.keybindings,
+      terminalInput: null,
+      getKittyKeyboardFlags: () => 0,
+      terminalShortcutPolicy: 'orca-first'
+    })
+  })
+  return { handler: handler!, sendInput, dispose }
+}
+
+let disposeHandler: (() => void) | null = null
+
+beforeEach(() => {
+  platformState.value = 'darwin'
+  storeState.keybindings = {}
+})
+
+afterEach(() => {
+  disposeHandler?.()
+  disposeHandler = null
+})
+
+// Why: the preview auto-focuses its terminal, and xterm swallows Escape and Tab,
+// so the pane-close chord is the only keyboard exit from the dialog.
+describe('preview terminal close chord', () => {
+  it('closes the hosting surface on the tab-close chord instead of swallowing it', () => {
+    const requestClose = vi.fn()
+    const { handler, dispose } = installHandler(requestClose)
+    disposeHandler = dispose
+
+    const event = new KeyboardEvent('keydown', { key: 'w', metaKey: true, cancelable: true })
+    expect(handler(event)).toBe(false)
+
+    expect(requestClose).toHaveBeenCalledTimes(1)
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('leaves ordinary typing to the terminal', () => {
+    const requestClose = vi.fn()
+    const { handler, dispose } = installHandler(requestClose)
+    disposeHandler = dispose
+
+    expect(handler(new KeyboardEvent('keydown', { key: 'w' }))).toBe(true)
+    expect(requestClose).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -29,6 +29,8 @@ export function installPreviewTerminalKeyHandler(args: {
   claimImeKeyEvent: (event: KeyboardEvent) => boolean
   pasteClipboardText: (activeElement: Element | null, source: 'keyboard') => void
   sendInput: (data: string) => void
+  /** Dismiss the surface hosting this preview; the pane-close chord's only target here. */
+  requestClose: () => void
   /** Everything but optionKeyLocations, which this installer tracks itself. */
   getShortcutContext: () => Omit<PreviewShortcutContext, 'optionKeyLocations'>
 }): () => void {
@@ -193,14 +195,19 @@ export function installPreviewTerminalKeyHandler(args: {
         nativeOnlyShortcutTracker.armKeyDown(event)
         event.stopImmediatePropagation()
         return false
-      // Why: pane-scoped chords have no target in a preview dialog. Swallow them
-      // — a pane never sends these bytes to the shell, and xterm would encode
-      // e.g. Ctrl+Shift+D as a bare Ctrl+D. Listed one by one rather than under a
-      // `default` so a newly added action has to be classified here, not
-      // silently swallowed.
+      // Why: the preview's closable unit is the surface itself, so the pane-close
+      // chord (Cmd+W and terminal.closePane) dismisses it — the terminal owns
+      // focus, leaving no other keyboard way out.
+      case 'closeActivePane':
+        args.requestClose()
+        return consumeEvent(event)
+      // Why: the remaining pane-scoped chords have no target in a preview dialog.
+      // Swallow them — a pane never sends these bytes to the shell, and xterm
+      // would encode e.g. Ctrl+Shift+D as a bare Ctrl+D. Listed one by one rather
+      // than under a `default` so a newly added action has to be classified here,
+      // not silently swallowed.
       case 'clearActivePane':
       case 'clearPaneTitle':
-      case 'closeActivePane':
       case 'copySelection':
       case 'equalizePaneSizes':
       case 'focusPane':


### PR DESCRIPTION
## ELI5

When you open an agent from the agent dashboard, you get a big terminal window. Your cursor lands in the terminal straight away, and the terminal eats every key you would normally use to get out: Escape goes to the agent as an interrupt, Tab types a tab. So the only way to close the window was to reach for the mouse. This makes Cmd+W close it, the same key that closes a tab.

## What Changed

`Cmd/Ctrl+W` inside the agent terminal preview now closes the dialog hosting it.

- `preview-terminal-key-handler.ts` takes a `requestClose` callback and gives the `closeActivePane` verdict a real target instead of swallowing it. The other pane-scoped chords stay swallowed, still listed one by one so a newly added action has to be classified rather than silently falling through.
- `AgentTerminalPreview.tsx` grows an optional `onRequestClose` prop, held in a ref next to the other live values so a changing callback identity cannot remount the terminal and reconnect the PTY.
- `AgentTerminalDialog.tsx` wires it in `AgentTerminalFrame`, so the modal and the adjacent-panel variant both get it.

No new keybinding, no new setting, no change to the shortcut registry.

## Why

The dialog auto-focuses its terminal, and every ordinary exit key is already claimed:

- Escape is deliberately blocked from closing while focus is in `.xterm`, so it reaches the agent as an interrupt. Correct, and untouched here.
- Tab falls through to xterm and is sent to the agent.
- `Cmd/Ctrl+W` already resolved to `closeActivePane` via the shared `tab.close` alias in `terminal-shortcut-policy.ts`, and was then swallowed on the grounds that a preview has no pane to close.

That last one is the seam. The chord was already captured and safe: it did not leak to the shell, and it did not close the workspace tab behind the modal. It simply had no target. The preview's closable unit is the surface itself, so pointing the existing verdict at it is a smaller change than inventing a chord, and it inherits the user's own binding rather than hardcoding one.

Riding the existing alias means `terminal.closePane` and any remapped `tab.close` work too, and under the `terminal-first` policy a remapped `tab.close` still yields to the shell, matching how a real pane behaves.

## Linked Issue

Fixes #19757

## Visual Proof

`N/A` — no pixels change. The change is purely which keystroke dismisses an existing dialog; the dialog, its layout, and its close button are untouched.

## Testing

New test: `preview-terminal-key-handler.close-chord.test.ts`, driving the installed `attachCustomKeyEventHandler` directly. It asserts the chord fires `requestClose` exactly once and consumes the event, and that a bare `w` still returns `true` so ordinary typing reaches the terminal. That second case is the regression that would actually bite.

Steps for a reviewer:

1. Enable the experimental agent dashboard.
2. Open an agent's terminal dialog and type, without clicking anywhere.
3. `Cmd+W` (macOS) or `Ctrl+W` (Linux/Windows) closes the dialog.
4. Confirm Escape still interrupts the agent instead of closing, and that the workspace tab behind the dialog is still open.

Verified locally: the new test passes, and the full `src/renderer/src/components/dashboard-popout/` suite passes (45 files, 361 tests). `oxlint` is clean on all four touched files.

Not verified locally, flagging honestly: I could not get a full `pnpm test` / `pnpm typecheck` / `pnpm build` run green in my environment. `pnpm typecheck` fails on pre-existing unresolved module types (`@tiptap/core`, `tinyglobby`, `@testing-library/dom`) and one unrelated error in `rich-markdown-review-rail-blocks.ts`, all untouched by this branch and none in `dashboard-popout/`. The native `node-pty` rebuild also fails on my machine. Leaving those to CI.

Platform notes: no platform-specific code added. The chord resolves through the existing platform-aware keybinding matcher, so it is Cmd on macOS and Ctrl elsewhere with no hardcoded `metaKey`. Tested on macOS only; Linux and Windows go through the same matcher.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Opus 4.5 via Claude Code.

## Review

Agent review against the areas the template calls out:

- **Cross-platform**: no `metaKey` hardcoded, no new accelerator, no path handling. Resolution goes through `keybindingMatchesAction`, which already handles the Cmd/Ctrl split.
- **SSH / remote**: nothing touching execution, process reporting, or liveness. Closing the dialog does not stop, kill, or reinterpret the agent; the PTY connection is torn down by the existing unmount path exactly as the X button already does. No new claim about whether a remote process is alive.
- **Remote wire compatibility**: no RPC params, stream frames, or published content changed. Renderer-local only.
- **Agents / integrations / git providers**: none referenced. The change is agent-agnostic and provider-agnostic.
- **Performance**: one callback ref assignment in an existing `useLayoutEffect`, and one extra `switch` arm on a path that only runs for an already-matched chord. Nothing added to the keystroke hot path or to render.
- **Resource cleanup**: no new listener or timer. The callback rides the existing handler's lifetime and disposer.
- **UI quality**: no visual change, no new tokens, no new component.
- **Security**: no new IPC surface, no new input parsing, nothing reaching the main process.
- **Backwards compatibility**: `onRequestClose` is optional, so the preview behaves exactly as before without it. The only behavior change for an existing user is that a chord which was a silent no-op now closes the dialog.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

One judgment call worth a maintainer's eye: this treats the preview's "closable unit" as the hosting surface rather than a pane. If you would rather Cmd+W stay inert in the preview and have a dedicated bindable action instead, say so and I will rework it that way.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted tests and lint pass; see Testing for what I could not run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
