### PR TITLE
fix(orchestration): submit Cursor CLI mail pointers instead of leaving them in the composer

### DIFF
--- a/src/main/runtime/orca-runtime-core.ts
+++ b/src/main/runtime/orca-runtime-core.ts
@@ -2,8 +2,6 @@
 import type { RuntimeWorktreeScanResult } from './repo-worktree-resolution-scan'
 import type { TerminalWorkspaceLaunchScope } from './runtime-legacy-worker-terminal-recovery-types'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
-import type { RuntimeLeafRecord } from './runtime-terminal-state-records'
-import { isCursorAgentTitle } from '../../shared/agent-detection'
 import { isAbsolute, relative, resolve } from 'node:path'
 import type {
   RuntimeTerminalDriverState,
@@ -49,13 +47,6 @@ export type RuntimeWorktreeScanRefresh = {
 export type ResolvedTerminalWorkspaceLaunchTarget = {
   scope: TerminalWorkspaceLaunchScope
   managedWorktree: ResolvedWorktree | null
-}
-
-export function isCursorAgentOrchestrationTarget(
-  leaf: RuntimeLeafRecord,
-  tabTitle: string | null | undefined
-): boolean {
-  return [leaf.lastOscTitle, leaf.paneTitle, tabTitle].some(isCursorAgentTitle)
 }
 
 export const AGENT_SESSION_OPERATION_PER_CLIENT_LIMIT = 512

--- a/src/main/runtime/orca-runtime-deliver-pending-messages.ts
+++ b/src/main/runtime/orca-runtime-deliver-pending-messages.ts
@@ -2,7 +2,6 @@
 import { OrcaRuntimeWithResolveExitWaiters } from './orca-runtime-resolve-exit-waiters'
 import type { RuntimeLeafRecord } from './runtime-terminal-state-records'
 import { formatMessagePointer } from './orchestration/formatter'
-import { isCursorAgentOrchestrationTarget } from './orca-runtime-core'
 
 export class OrcaRuntimeWithDeliverPendingMessages extends OrcaRuntimeWithResolveExitWaiters {
   // Why: normal delivery stays event-driven; the bounded mailbox retry only repairs missed liveness edges.
@@ -130,9 +129,9 @@ export class OrcaRuntimeWithDeliverPendingMessages extends OrcaRuntimeWithResolv
     const deliveryPtyId = leaf.ptyId
     const flight: { enterTimer: ReturnType<typeof setTimeout> | null } = { enterTimer: null }
     this.messageDeliveryFlightsByPtyId.set(deliveryPtyId, flight)
-    // Why: every sync outcome — failed write, Cursor branch, or a throw —
-    // must end the flight here, or a leaked flag parks this pty's deliveries
-    // forever. Only an armed Enter hands settling to its own callback.
+    // Why: every sync outcome — failed write or a throw — must end the flight
+    // here, or a leaked flag parks this pty's deliveries forever. Only an armed
+    // Enter hands settling to its own callback.
     let settlesInEnterCallback = false
     try {
       const payload = formatMessagePointer(unread.length, mailboxHandle)
@@ -150,12 +149,6 @@ export class OrcaRuntimeWithDeliverPendingMessages extends OrcaRuntimeWithResolv
         pointedIdsAfterWrite.add(message.id)
       }
       this.pointedMessageIdsByHandle.set(mailboxHandle, pointedIdsAfterWrite)
-
-      const tabTitle = this.tabs.get(leaf.tabId)?.title
-      if (isCursorAgentOrchestrationTarget(leaf, tabTitle)) {
-        // Why: Cursor Agent treats injected PTY text as editable prompt input, so submitting must stay under user control.
-        return
-      }
 
       // Why: agent TUIs can swallow a \r in the same PTY write; submit separately after a delay.
       flight.enterTimer = setTimeout(() => {

--- a/src/main/runtime/orchestration/mailbox-pointer-stage-cursor-submit.test.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-stage-cursor-submit.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrchestrationDb } from './db'
+import { OrchestrationMailboxPointerState } from './mailbox-pointer-state'
+import { stageOrchestrationMailboxPointer } from './mailbox-pointer-stage'
+import { WRITE_ACCEPTED } from '../../../shared/pty-write-settlement'
+import type { OrchestrationMailboxLeaf } from './mailbox-owner'
+
+function idleLeaf(lastOscTitle: string | null): OrchestrationMailboxLeaf {
+  return {
+    tabId: 'tab-1',
+    leafId: 'leaf-1',
+    ptyId: 'pty-1',
+    writable: true,
+    lastAgentStatus: 'idle',
+    lastAgentStatusObservedLive: true,
+    lastOscTitle,
+    paneTitle: null
+  }
+}
+
+async function collectPointerWrites(
+  leaf: OrchestrationMailboxLeaf,
+  tabTitle: string | null = null
+): Promise<string[]> {
+  const db = new OrchestrationDb(':memory:')
+  const message = db.insertMessage({
+    runId: 'run_legacy_local',
+    from: 'a',
+    to: 'run:run-1',
+    subject: 's'
+  })
+  const state = new OrchestrationMailboxPointerState()
+  const writePty = vi.fn((_ptyId: string, _data: string) => WRITE_ACCEPTED)
+  stageOrchestrationMailboxPointer({
+    deps: {
+      mailboxOwner: { resolve: () => 'run:run-1' },
+      deliveryTarget: { resolveTerminalHandle: () => 'term-1', deferForAbsenceProbe: () => false },
+      getDb: () => db,
+      getLeaf: () => leaf,
+      getLeafKey: () => 'tab-1:leaf-1',
+      getLiveLeafForHandle: () => leaf,
+      getMessageWaiters: () => undefined,
+      getTabTitle: () => tabTitle,
+      getCliCommand: () => 'orca' as const,
+      getTerminalHandleForLeafKey: () => 'term-1',
+      resolveSubmitTarget: () => ({
+        leaf,
+        terminalHandle: 'term-1',
+        processIncarnation: 'inc-1'
+      }),
+      isLeafPtyProvenAbsent: async () => false,
+      redriveMailbox: vi.fn(),
+      writePty
+    },
+    state,
+    leaf,
+    mailboxHandle: 'run:run-1',
+    messages: [{ id: message.id, type: 'status', sequence: 1 }],
+    newestSequence: 1,
+    enterDelayMs: 5,
+    leafKey: 'tab-1:leaf-1',
+    settle: (ptyId: string, flight: never) => state.settleFlight(ptyId, flight),
+    redrive: vi.fn()
+  } as never)
+  await vi.waitFor(() => expect(writePty).toHaveBeenCalledWith(leaf.ptyId, '\r'))
+  const payloads = writePty.mock.calls.map(([, data]) => data)
+  db.close()
+  return payloads
+}
+
+describe('mailbox pointer submit across agent titles', () => {
+  it.each([['Cursor Ready'], ['Cursor Agent'], ['Codex done'], ['Claude Code'], ['Kimi']] as const)(
+    'writes the pointer then Enter for %s',
+    async (title) => {
+      const payloads = await collectPointerWrites(idleLeaf(title))
+      expect(payloads[0]).toContain('You have 1 orchestration message')
+      expect(payloads[0]).not.toContain('\r')
+      expect(payloads.at(-1)).toBe('\r')
+    }
+  )
+
+  it('still submits when Cursor identity is only on the tab title', async () => {
+    const payloads = await collectPointerWrites(idleLeaf(null), 'Cursor Ready')
+    expect(payloads[0]).toContain('You have 1 orchestration message')
+    expect(payloads.at(-1)).toBe('\r')
+  })
+})

--- a/src/main/runtime/orchestration/mailbox-pointer-stage.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-stage.ts
@@ -1,4 +1,3 @@
-import { isCursorAgentTitle } from '../../../shared/agent-detection'
 import { formatMessagePointer } from './formatter'
 import type {
   OrchestrationMailboxPointerMessage,
@@ -144,16 +143,6 @@ function finishPointerWriteAndStageEnter<TWaiter extends OrchestrationMessageWai
       if (args.state.clearWatermark(args.mailboxHandle, args.newestSequence, ptyId)) {
         args.redrive(args.mailboxHandle)
       }
-      return
-    }
-    if (
-      [args.leaf.lastOscTitle, args.leaf.paneTitle, args.deps.getTabTitle(args.leaf.tabId)].some(
-        isCursorAgentTitle
-      )
-    ) {
-      db.markAsDelivered(flight.stagedMessageIds)
-      args.state.clearWatermark(args.mailboxHandle, args.newestSequence, ptyId)
-      args.redrive(args.mailboxHandle)
       return
     }
     const submitEnter = (): void =>

--- a/tests/e2e/helpers/orchestration-mail-pane-agent.ts
+++ b/tests/e2e/helpers/orchestration-mail-pane-agent.ts
@@ -28,7 +28,7 @@ import path from 'node:path'
 /** `detectAgentStatusFromTitle` reads these as agent-name + strong keyword. */
 export const CODEX_IDLE_TITLE = 'Codex done'
 export const CODEX_WORKING_TITLE = 'Codex working'
-/** Also satisfies `isCursorAgentTitle`, which suppresses the synthesized Enter. */
+/** Cursor Agent idle title (`isCursorAgentTitle`). */
 export const CURSOR_IDLE_TITLE = 'Cursor Ready'
 
 export type AgentLedgerEntry = {

--- a/tests/e2e/orchestration-idle-mail-delivery.spec.ts
+++ b/tests/e2e/orchestration-idle-mail-delivery.spec.ts
@@ -627,25 +627,22 @@ test.describe('orchestration push-on-idle mail delivery', () => {
     await expectSubmitted(pane)
   })
 
-  test('writes the pointer but never Enter for a Cursor agent pane', async ({
+  test('writes and submits the pointer for a Cursor agent pane', async ({
     orcaPage,
     electronApp
   }) => {
     test.setTimeout(180_000)
     const { client, openAgentPane } = await setUpMailFixture(orcaPage, electronApp)
     const pane = await openAgentPane()
-    // Cursor treats injected PTY text as editable prompt content, so submitting
-    // has to stay under user control there too.
     pane.agent.setTitle(CURSOR_IDLE_TITLE)
     await waitForObservedTitle(client, pane.handle, CURSOR_IDLE_TITLE)
-    const mailbox = await createRunMailbox(client, pane, 'Cursor no-submit')
+    const mailbox = await createRunMailbox(client, pane, 'Cursor pointer submit')
 
-    const subject = 'Cursor no-submit'
+    const subject = 'Cursor pointer submit'
     await sendMail(client, mailbox, { subject })
 
     await expectPointed(pane)
-    await orcaPage.waitForTimeout(2_000)
-    expectNotSubmitted(pane)
+    await expectSubmitted(pane)
   })
 })
 


### PR DESCRIPTION
## ELI5

When Cursor CLI is the coordinator, Orca types "you have N orchestration messages" into the input box and then stops. Other agents get a follow-up Enter so they actually run the check. This change sends that same Enter for Cursor, so the nudge is submitted instead of piling up in the composer.

## What Changed

- Idle mailbox pointer delivery no longer special-cases Cursor titles to skip the delayed Enter. Cursor uses the same write-then-`\r` path as Claude / Codex / Kimi / Grok.
- Removed the matching skip on the leftover `deliverPendingMessages` mixin (live run/dispatch mail already goes through `mailbox-pointer-stage.ts`).
- Unit tests assert Cursor titles emit `\r` after the pointer, and that Codex / Claude / Kimi still do too.
- Updated the orchestration idle-mail E2E Cursor case to expect submit rather than "never Enter".

## Why

`#3156` skipped Enter for Cursor because older Cursor Agent treated injected PTY text as a user-owned draft. Current `cursor-agent` (2026.09.08) does **not** auto-submit that text, so the pointer sits in the composer. A later user Enter then sends the stacked pointer lines plus whatever they typed.

Dispatch inject is a different path (`writeTerminalAgentPrompt`: bracketed paste, settle delay, separate `\r`) and already submits. This bug is only the idle mail pointer.

## Linked Issue

Fixes #19760

Related: #3034 / #3156 (original skip), #14832 (submit-while-typing, separate), #16822 (disable the pointer, separate).

## Visual Proof

N/A — no UI chrome change. Behavior is a PTY write of `\r` after the existing pointer text. I did not attach a live Cursor terminal recording.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Automated:

- `vitest` `mailbox-pointer-stage-cursor-submit.test.ts` (6), `mailbox-pointer-stage.test.ts` (5), `mailbox-pointer-submit.test.ts` (11), plus formatter and eligibility tests — all passed
- `oxfmt` on the changed files
- `oxlint` and `check-changed-code-quality.mjs` — 0 findings
- `tsc --noEmit -p config/tsconfig.node.json` — passed
- `check-max-lines-ratchet` — passed

Not run here (CI should cover):

- Full `pnpm lint` / `pnpm test` / `pnpm build` (Electron postinstall was still downloading a binary in this environment)
- Playwright E2E `orchestration-idle-mail-delivery.spec.ts` (needs a packaged Electron app)
- Live `cursor-agent` end-to-end against a running Orca desktop — **not done**. Reason: this patch is against upstream source, not the installed 1.4.198 app, and standing up `pnpm dev` plus a real Cursor coordinator was not cost-justified in this run.

Platforms actually exercised: Linux unit tests only. The Enter byte is still `\r` after the existing 500ms delay on every OS; no platform-specific branch was added.

## AI Disclosure

Patch drafted with Grok 4.6 (xAI) in an Orca-dispatched coding session, then reviewed against the current `mailbox-pointer-stage` / `writeTerminalAgentPrompt` split.

## Review

- **Cross-platform:** Pointer submit remains `writePty(ptyId, '\r')` after `enterDelayMs` (default 500, overridable in E2E). No new OS check. Windows ConPTY ingest delay lives on the dispatch-inject path, not this pointer path; that is unchanged.
- **SSH / remote / local:** Pointer bytes still go through `writeOrchestrationPointerPty` and the session write gate. No remote wire change.
- **Agents:** Cursor now matches Claude/Codex/Kimi/Grok for this pointer. Dispatch inject is untouched. Structured-session pointer delivery is a sibling and was not changed.
- **Performance:** One extra `\r` write on Cursor idle delivery; no new timers beyond the existing delay.
- **UI:** No renderer change.
- **Security:** Still only writes the existing pointer string plus Enter into a PTY the runtime already owns. No new trust-dialog handling; idle+live-status gating is unchanged.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

`#3156` made Cursor skip Enter on purpose. This PR treats that skip as obsolete for coordinator Cursor CLI. If a human-driven Cursor pane still prefers inject-without-submit, that should be an explicit setting (see #16822) rather than a silent title match.

Trust-dialog / `agent_prompt_stalled` on first Claude/Kimi launch is a different inject path and is not addressed here.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Local: targeted oxlint + node typecheck + focused vitest. Full lint/test/build left to CI.