### PR TITLE
fix(worktrees): close an idle structured chat on delete instead of refusing

### DIFF
--- a/src/main/ipc/worktrees/removal/worktree-removal-ownership.ts
+++ b/src/main/ipc/worktrees/removal/worktree-removal-ownership.ts
@@ -40,11 +40,17 @@ export async function stopPtysForDestructiveWorktreeRemoval(
     ...(allowUnverifiedStop ? { allowUnverifiedStop: true } : {}),
     ...(connectionId ? { includeLocalRegistry: false } : {})
   })
+  // Structured sessions are counted here too: closing a user's chat is now an ordinary outcome
+  // of this verb, and a removal that closed one but no PTY would otherwise log nothing at all.
+  const structuredStopped = teardownResult.structuredStopped ?? 0
   const total =
-    teardownResult.runtimeStopped + teardownResult.providerStopped + teardownResult.registryStopped
+    teardownResult.runtimeStopped +
+    teardownResult.providerStopped +
+    teardownResult.registryStopped +
+    structuredStopped
   if (total > 0) {
     console.info(
-      `[worktree-teardown] ${worktreeId} killed runtime=${teardownResult.runtimeStopped} provider=${teardownResult.providerStopped} registry=${teardownResult.registryStopped}`
+      `[worktree-teardown] ${worktreeId} killed runtime=${teardownResult.runtimeStopped} provider=${teardownResult.providerStopped} registry=${teardownResult.registryStopped} structured=${structuredStopped}`
     )
   }
 }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-admission.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-admission.ts
@@ -13,6 +13,7 @@ import type {
   AgentSessionMutationResult,
   AgentSessionWireRefusal
 } from '../../../shared/agent-session-wire'
+import { AGENT_SESSION_UNATTACHED_REFUSAL_CODE } from '../../../shared/structured-agent-session-read-refusal'
 import type { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
 import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
 import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
@@ -21,8 +22,10 @@ import { runSettledAgentSessionMutation } from './structured-agent-session-opera
 import { resolveAgentSessionReplayOutcome } from './structured-agent-session-replay-outcome'
 import type { AgentSessionTurnContext } from './structured-agent-session-turns'
 
+// The code is shared with the client so a read that refuses this way can be told apart from a
+// transcript that failed to load; the two must never drift apart.
 export const AGENT_SESSION_NOT_ATTACHED: AgentSessionWireRefusal = {
-  code: 'agent_session_ownership_unknown',
+  code: AGENT_SESSION_UNATTACHED_REFUSAL_CODE,
   message: 'This host holds no attached session by that id.'
 }
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-surface-lifetime.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-surface-lifetime.test.ts
@@ -13,6 +13,7 @@ import type {
   AgentSessionMutationEnvelope,
   AgentSessionSubscribeEvent
 } from '../../../shared/agent-session-wire'
+import { AGENT_SESSION_UNATTACHED_REFUSAL_CODE } from '../../../shared/structured-agent-session-read-refusal'
 import { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
 import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
 import type { StructuredAgentSessionEventSink } from './structured-agent-session-event-sink'
@@ -177,6 +178,25 @@ describe('a chat that closes', () => {
 
     expect(closeSession).not.toHaveBeenCalled()
     expect(host.hasSession(SESSION)).toBe(true)
+  })
+
+  // The pane outlives the close by a few frames — a workspace delete closes the chats inside it
+  // while their panes are still mounted — so whatever a read raises in that window is what the user
+  // sees. This is the code the client narrows on to keep that window off the pane; a host that
+  // starts raising a different one there puts the red error back.
+  it('answers a read from the pane that outlived it with the code the client treats as transitional', async () => {
+    await attach()
+    await host.hold(SESSION, SURFACE)
+
+    await host.close(SESSION)
+
+    expect(host.hasSession(SESSION)).toBe(false)
+    expect(() => host.history({ sessionId: SESSION, direction: 'tail' })).toThrow(
+      AGENT_SESSION_UNATTACHED_REFUSAL_CODE
+    )
+    expect(() =>
+      host.subscribe({ id: 'sub-1', sessionId: SESSION, emit: () => undefined })
+    ).toThrow(AGENT_SESSION_UNATTACHED_REFUSAL_CODE)
   })
 
   it('does not lose the session to a release the client sent twice', async () => {

--- a/src/main/runtime/orca-runtime-pty-foreground-process-reads.ts
+++ b/src/main/runtime/orca-runtime-pty-foreground-process-reads.ts
@@ -149,13 +149,17 @@ export class OrcaRuntimeWithPtyForegroundProcessReads extends OrcaRuntimeWithSta
       ...(allowUnverifiedStop ? { allowUnverifiedStop: true } : {}),
       ...(connectionId ? { includeLocalRegistry: false } : {})
     })
+    // Structured sessions are counted here too, mirroring the IPC path: closing a user's chat is
+    // now an ordinary outcome of this verb, and a removal that closed one but no PTY logged nothing.
+    const structuredStopped = teardownResult.structuredStopped ?? 0
     const total =
       teardownResult.runtimeStopped +
       teardownResult.providerStopped +
-      teardownResult.registryStopped
+      teardownResult.registryStopped +
+      structuredStopped
     if (total > 0) {
       console.info(
-        `[worktree-teardown] ${worktreeId} killed runtime=${teardownResult.runtimeStopped} provider=${teardownResult.providerStopped} registry=${teardownResult.registryStopped}`
+        `[worktree-teardown] ${worktreeId} killed runtime=${teardownResult.runtimeStopped} provider=${teardownResult.providerStopped} registry=${teardownResult.registryStopped} structured=${structuredStopped}`
       )
     }
   }

--- a/src/main/runtime/structured-agent-session-close.test.ts
+++ b/src/main/runtime/structured-agent-session-close.test.ts
@@ -163,6 +163,21 @@ describe('closeStructuredAgentSessionChild tab-visibility rollback', () => {
     expect(host.setSessionTabVisibility.mock.calls).toEqual([[SESSION, false]])
   })
 
+  it('does not put the tab back when the caller is discarding the workspace anyway', async () => {
+    // Worktree teardown passes this off for a removal that cannot refuse — force, and the
+    // folder-workspace paths. A tab put back there is a durable reference to a workspace that is
+    // about to be gone, so it republishes the chat at the next launch pointing at it.
+    const host = installHost({ stuck: true })
+
+    const outcome = await closeStructuredAgentSessionChild(SESSION, {
+      restoreTabOnUnprovenClose: false
+    })
+
+    expect(outcome.stopped).toBe(false)
+    expect(host.visible.has(SESSION)).toBe(false)
+    expect(host.setSessionTabVisibility.mock.calls).toEqual([[SESSION, false]])
+  })
+
   it('does not publish a tab for a session that was already hidden', async () => {
     const host = installHost({ closeThrows: new Error('provider round trip failed'), visible: [] })
 

--- a/src/main/runtime/structured-agent-session-close.test.ts
+++ b/src/main/runtime/structured-agent-session-close.test.ts
@@ -1,0 +1,222 @@
+/**
+ * The chat tab must survive a close that did not land.
+ *
+ * `closeStructuredAgentSessionChild` hides the tab BEFORE it issues the close, so every failure
+ * shape past that point used to leave the user's chat tab pulled out of the durable restore index
+ * for a session that is still running — a destructive operation that refused, and still took
+ * something away.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentSessionRecord } from '../../shared/agent-session-record'
+
+const hostRef: { current: unknown } = { current: null }
+
+vi.mock('../native-chat/agent-session-wire/structured-agent-session-registry', () => ({
+  getStructuredAgentSessionHost: () => hostRef.current
+}))
+
+const { closeStructuredAgentSessionChild } = await import('./structured-agent-session-close')
+
+const SESSION = 'session-1'
+
+function record(sessionId: string): AgentSessionRecord {
+  return {
+    sessionId,
+    provider: 'claude',
+    location: {
+      executionHostId: 'local',
+      wslDistro: null,
+      workspaceId: 'repo_1::/tmp/wt-a',
+      workspaceKind: 'folder'
+    },
+    lease: {
+      sessionId,
+      runtimeKind: 'native',
+      claimStatus: 'live',
+      handoffStage: null,
+      runtimeFence: 1,
+      deathEvidence: null
+    }
+  } as unknown as AgentSessionRecord
+}
+
+type HostOptions = {
+  /** Sessions the host keeps holding through a close, so the post-close observation is `live`. */
+  stuck?: boolean
+  /** Rejects the close, without the child going. */
+  closeThrows?: Error
+  /** The child dies and is recorded dead, but the close then fails past that proof. */
+  settledThenThrows?: boolean
+  /** Rejects the visibility write itself, so the hide never lands. */
+  visibilityThrows?: Error
+  /** Sessions already in the persisted visible-tab index. */
+  visible?: string[]
+  /** Blows up the index read, so the rollback cannot prove the tab was ever visible. */
+  indexThrows?: boolean
+}
+
+function installHost(options: HostOptions = {}) {
+  const entry = record(SESSION)
+  const held = new Set([SESSION])
+  const visible = new Set(options.visible ?? [SESSION])
+  const setSessionTabVisibility = vi.fn(async (sessionId: string, isVisible: boolean) => {
+    if (options.visibilityThrows) {
+      throw options.visibilityThrows
+    }
+    if (isVisible) {
+      visible.add(sessionId)
+    } else {
+      visible.delete(sessionId)
+    }
+  })
+  const close = vi.fn(async (sessionId: string) => {
+    if (options.closeThrows) {
+      throw options.closeThrows
+    }
+    if (options.stuck) {
+      return
+    }
+    held.delete(sessionId)
+    entry.lease.claimStatus = 'released'
+    entry.lease.deathEvidence = { kind: 'exit-observed', detail: 'closed', observedAt: 1 }
+    if (options.settledThenThrows) {
+      throw new Error('the event sink could not be flushed')
+    }
+  })
+  hostRef.current = {
+    deps: { store: { getRecord: (id: string) => (id === SESSION ? entry : null) } },
+    hasSession: (sessionId: string) => held.has(sessionId),
+    getPersistedVisibleSessionTabIndex: () => {
+      if (options.indexThrows) {
+        throw new Error('visible tab index unreadable')
+      }
+      return { present: true, sessionIds: [...visible] }
+    },
+    setSessionTabVisibility,
+    close
+  }
+  return { close, setSessionTabVisibility, visible }
+}
+
+describe('closeStructuredAgentSessionChild tab-visibility rollback', () => {
+  beforeEach(() => {
+    hostRef.current = null
+    vi.restoreAllMocks()
+  })
+
+  it('retires the tab and reports the close on the success path', async () => {
+    const host = installHost()
+    const retire = vi.fn(() => true)
+
+    const outcome = await closeStructuredAgentSessionChild(SESSION, {
+      runtime: {
+        retireStructuredAgentSessionTabFromSnapshot: retire
+      } as never
+    })
+
+    expect(outcome).toEqual({ stopped: true, closeAttempted: true })
+    expect(host.visible.has(SESSION)).toBe(false)
+    expect(retire).toHaveBeenCalledWith(SESSION)
+    // The hide is the only visibility write a settled close performs.
+    expect(host.setSessionTabVisibility.mock.calls).toEqual([[SESSION, false]])
+  })
+
+  it('restores the tab when the close throws and the child is still there', async () => {
+    const host = installHost({ closeThrows: new Error('provider round trip failed') })
+
+    const outcome = await closeStructuredAgentSessionChild(SESSION)
+
+    expect(outcome.stopped).toBe(false)
+    expect(outcome.closeAttempted).toBe(true)
+    expect(outcome.reason).toBe('provider round trip failed')
+    expect(host.visible.has(SESSION)).toBe(true)
+    expect(host.setSessionTabVisibility.mock.calls).toEqual([
+      [SESSION, false],
+      [SESSION, true]
+    ])
+  })
+
+  it('restores the tab when the post-close observation is not `exited`', async () => {
+    const host = installHost({ stuck: true })
+
+    const outcome = await closeStructuredAgentSessionChild(SESSION)
+
+    expect(outcome.stopped).toBe(false)
+    expect(outcome.closeAttempted).toBe(true)
+    expect(host.visible.has(SESSION)).toBe(true)
+    expect(host.setSessionTabVisibility.mock.calls).toEqual([
+      [SESSION, false],
+      [SESSION, true]
+    ])
+  })
+
+  it('leaves the tab retired when a close throws PAST a proven exit', async () => {
+    // `closeStructuredSessionsForWorktree` re-observes and counts this session closed; republishing
+    // the tab here would resurrect it at the next launch for a workspace that is gone.
+    const host = installHost({ settledThenThrows: true })
+
+    const outcome = await closeStructuredAgentSessionChild(SESSION)
+
+    expect(outcome.stopped).toBe(false)
+    expect(host.visible.has(SESSION)).toBe(false)
+    expect(host.setSessionTabVisibility.mock.calls).toEqual([[SESSION, false]])
+  })
+
+  it('does not publish a tab for a session that was already hidden', async () => {
+    const host = installHost({ closeThrows: new Error('provider round trip failed'), visible: [] })
+
+    await closeStructuredAgentSessionChild(SESSION)
+
+    expect(host.visible.has(SESSION)).toBe(false)
+    expect(host.setSessionTabVisibility.mock.calls).toEqual([[SESSION, false]])
+  })
+
+  it('does not roll back a visibility write that never landed', async () => {
+    const host = installHost({ visibilityThrows: new Error('visibility write failed') })
+
+    const outcome = await closeStructuredAgentSessionChild(SESSION)
+
+    expect(outcome).toEqual({
+      stopped: false,
+      closeAttempted: false,
+      reason: 'visibility write failed'
+    })
+    expect(host.close).not.toHaveBeenCalled()
+    expect(host.setSessionTabVisibility.mock.calls).toEqual([[SESSION, false]])
+  })
+
+  it('keeps the original failure when the restore itself throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const host = installHost({ stuck: true })
+    host.setSessionTabVisibility.mockImplementation(async (_sessionId, isVisible) => {
+      if (isVisible) {
+        throw new Error('agent_session_identity_required')
+      }
+    })
+
+    const outcome = await closeStructuredAgentSessionChild(SESSION)
+
+    expect(outcome.stopped).toBe(false)
+    expect(outcome.closeAttempted).toBe(true)
+    expect(outcome.reason).not.toContain('agent_session_identity_required')
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('claims nothing when the visible-tab index cannot be read', async () => {
+    const host = installHost({ indexThrows: true, closeThrows: new Error('boom') })
+
+    await closeStructuredAgentSessionChild(SESSION)
+
+    expect(host.setSessionTabVisibility.mock.calls).toEqual([[SESSION, false]])
+  })
+
+  it('reports no close attempt when no host is installed', async () => {
+    hostRef.current = null
+
+    const outcome = await closeStructuredAgentSessionChild(SESSION)
+
+    expect(outcome.stopped).toBe(false)
+    expect(outcome.closeAttempted).toBe(false)
+  })
+})

--- a/src/main/runtime/structured-agent-session-close.ts
+++ b/src/main/runtime/structured-agent-session-close.ts
@@ -36,6 +36,15 @@ export type StructuredAgentSessionCloseOptions = {
    * keep the child un-evictable for the life of the app. Every settlement has to reach it.
    */
   afterClose?: () => void
+  /**
+   * Whether an unproven close may put the chat tab back in the durable restore index.
+   *
+   * On by default, which is the retryable case: a stop that refused and still took the user's tab
+   * away is the loss the rollback exists to undo. A caller that will discard the WORKSPACE
+   * whatever this close reports passes false — a tab put back there is a durable reference to a
+   * workspace about to be gone, and it republishes the chat at the next launch pointing at it.
+   */
+  restoreTabOnUnprovenClose?: boolean
 }
 
 export async function closeStructuredAgentSessionChild(
@@ -54,7 +63,8 @@ export async function closeStructuredAgentSessionChild(
   // Read BEFORE the hide, so a rollback puts the tab back exactly as it was. Restoring
   // unconditionally would publish a tab for a session that was already hidden — a worker started
   // without a chat tab, or one the user had closed — which is a new side effect, not an undo.
-  const tabWasVisible = readPersistedTabVisibility(host, sessionId)
+  const restoreTabIfCloseFails =
+    options.restoreTabOnUnprovenClose !== false && readPersistedTabVisibility(host, sessionId)
   // Set only once the close is actually issued: `setSessionTabVisibility` throwing first leaves a
   // running child, and a receipt that still said `closed_agent_terminal` for it would be the
   // close-that-never-happened this flag exists to rule out.
@@ -67,7 +77,7 @@ export async function closeStructuredAgentSessionChild(
     // Only `closeAttempted` proves the hide landed: the store transaction restores its own state on
     // failure, so a `setSessionTabVisibility` that threw hid nothing and has nothing to undo.
     if (closeAttempted) {
-      await restorePersistedTabVisibility(host, sessionId, tabWasVisible)
+      await restorePersistedTabVisibility(host, sessionId, restoreTabIfCloseFails)
     }
     return {
       stopped: false,
@@ -78,7 +88,7 @@ export async function closeStructuredAgentSessionChild(
   options.afterClose?.()
   const observation = observeStructuredWorker({ sessionId })
   if (observation.status !== 'exited') {
-    await restorePersistedTabVisibility(host, sessionId, tabWasVisible)
+    await restorePersistedTabVisibility(host, sessionId, restoreTabIfCloseFails)
     return {
       stopped: false,
       closeAttempted: true,
@@ -113,6 +123,11 @@ function readPersistedTabVisibility(host: StructuredAgentSessionHost, sessionId:
  * counting such a session closed and retiring its tab. Republishing there would resurrect a tab for
  * a session that is demonstrably gone, at the next launch, pointing at a deleted workspace.
  *
+ * That observation NARROWS the window; it does not close it. This one and the sweep's are taken a
+ * store write apart, so a child that dies in between is unverifiable here and exited there — which
+ * is why the sweep re-drops the tab reference when it takes that proof. Do not delete either half
+ * on the strength of the other.
+ *
  * Never throws: the caller's `reason` is what the user is asked to act on, and a rollback failure
  * must not replace it. `agent_session_identity_required` is the expected one — the record can be
  * gone by now, which is itself the exit this restore is declining to undo.
@@ -120,9 +135,9 @@ function readPersistedTabVisibility(host: StructuredAgentSessionHost, sessionId:
 async function restorePersistedTabVisibility(
   host: StructuredAgentSessionHost,
   sessionId: string,
-  tabWasVisible: boolean
+  restoreTab: boolean
 ): Promise<void> {
-  if (!tabWasVisible || observeStructuredWorker({ sessionId }).status === 'exited') {
+  if (!restoreTab || observeStructuredWorker({ sessionId }).status === 'exited') {
     return
   }
   try {

--- a/src/main/runtime/structured-agent-session-close.ts
+++ b/src/main/runtime/structured-agent-session-close.ts
@@ -11,6 +11,7 @@
  * longer live is proven gone. Anything else is retained rather than settled.
  */
 
+import type { StructuredAgentSessionHost } from '../native-chat/agent-session-wire/structured-agent-session-host'
 import { getStructuredAgentSessionHost } from '../native-chat/agent-session-wire/structured-agent-session-registry'
 import type { OrcaRuntimeService } from './orca-runtime'
 import { retireSettledStructuredWorkerTab } from './structured-agent-session-tab-retirement'
@@ -50,6 +51,10 @@ export async function closeStructuredAgentSessionChild(
       reason: 'The structured agent-session host is not installed; no session was closed.'
     }
   }
+  // Read BEFORE the hide, so a rollback puts the tab back exactly as it was. Restoring
+  // unconditionally would publish a tab for a session that was already hidden — a worker started
+  // without a chat tab, or one the user had closed — which is a new side effect, not an undo.
+  const tabWasVisible = readPersistedTabVisibility(host, sessionId)
   // Set only once the close is actually issued: `setSessionTabVisibility` throwing first leaves a
   // running child, and a receipt that still said `closed_agent_terminal` for it would be the
   // close-that-never-happened this flag exists to rule out.
@@ -59,6 +64,11 @@ export async function closeStructuredAgentSessionChild(
     closeAttempted = true
     await host.close(sessionId)
   } catch (error) {
+    // Only `closeAttempted` proves the hide landed: the store transaction restores its own state on
+    // failure, so a `setSessionTabVisibility` that threw hid nothing and has nothing to undo.
+    if (closeAttempted) {
+      await restorePersistedTabVisibility(host, sessionId, tabWasVisible)
+    }
     return {
       stopped: false,
       closeAttempted,
@@ -68,6 +78,7 @@ export async function closeStructuredAgentSessionChild(
   options.afterClose?.()
   const observation = observeStructuredWorker({ sessionId })
   if (observation.status !== 'exited') {
+    await restorePersistedTabVisibility(host, sessionId, tabWasVisible)
     return {
       stopped: false,
       closeAttempted: true,
@@ -78,4 +89,48 @@ export async function closeStructuredAgentSessionChild(
   // the live snapshot, which `setSessionTabVisibility(false)` above does not do.
   retireSettledStructuredWorkerTab(sessionId, options.runtime)
   return { stopped: true, closeAttempted: true }
+}
+
+function readPersistedTabVisibility(host: StructuredAgentSessionHost, sessionId: string): boolean {
+  try {
+    return host.getPersistedVisibleSessionTabIndex?.().sessionIds.includes(sessionId) ?? false
+  } catch {
+    // Unreadable index: claim nothing. A rollback that cannot prove the tab was visible must not
+    // publish one, for the same reason the read exists at all.
+    return false
+  }
+}
+
+/**
+ * Puts the chat tab back after a close that did not settle.
+ *
+ * The hide is the one visible side effect this function performs before the destructive step, so a
+ * failed close that kept it left the user's chat tab gone from the durable restore index — the
+ * conversation survived under `userData`, but nothing brought the tab back at the next launch.
+ *
+ * Re-observed first rather than restored outright: a close can throw PAST its own proof and still
+ * have taken the child with it, and `closeStructuredSessionsForWorktree` reads exactly that,
+ * counting such a session closed and retiring its tab. Republishing there would resurrect a tab for
+ * a session that is demonstrably gone, at the next launch, pointing at a deleted workspace.
+ *
+ * Never throws: the caller's `reason` is what the user is asked to act on, and a rollback failure
+ * must not replace it. `agent_session_identity_required` is the expected one — the record can be
+ * gone by now, which is itself the exit this restore is declining to undo.
+ */
+async function restorePersistedTabVisibility(
+  host: StructuredAgentSessionHost,
+  sessionId: string,
+  tabWasVisible: boolean
+): Promise<void> {
+  if (!tabWasVisible || observeStructuredWorker({ sessionId }).status === 'exited') {
+    return
+  }
+  try {
+    await host.setSessionTabVisibility?.(sessionId, true)
+  } catch (error) {
+    console.warn(
+      `[structured-session-close] could not restore the chat tab for ${sessionId} after a failed close`,
+      error
+    )
+  }
 }

--- a/src/main/runtime/structured-session-worktree-teardown.test.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.test.ts
@@ -8,18 +8,31 @@ vi.mock('../native-chat/agent-session-wire/structured-agent-session-registry', (
 }))
 
 const { killAllProcessesForWorktree } = await import('./worktree-teardown')
-const { classifyWorktreeForceDeleteReason } = await import('../../shared/worktree/removal')
+const {
+  classifyWorktreeForceDeleteReason,
+  isProvenLiveStructuredSessionRemovalError,
+  isUnstoppedPtyRemovalError
+} = await import('../../shared/worktree/removal')
 const { listLiveStructuredSessionsForWorktree } =
   await import('./structured-session-worktree-teardown')
 
 const WORKTREE = 'repo_1::/tmp/wt-a'
 const OTHER_WORKTREE = 'repo_1::/tmp/wt-b'
 
-function record(sessionId: string, workspaceId: string): AgentSessionRecord {
+function record(
+  sessionId: string,
+  workspaceId: string,
+  options: { provider?: 'claude' | 'codex'; executionHostId?: string } = {}
+): AgentSessionRecord {
   return {
     sessionId,
-    provider: 'claude',
-    location: { executionHostId: 'local', wslDistro: null, workspaceId, workspaceKind: 'folder' },
+    provider: options.provider ?? 'claude',
+    location: {
+      executionHostId: options.executionHostId ?? 'local',
+      wslDistro: null,
+      workspaceId,
+      workspaceKind: 'folder'
+    },
     lease: {
       sessionId,
       runtimeKind: 'native',
@@ -33,8 +46,12 @@ function record(sessionId: string, workspaceId: string): AgentSessionRecord {
 
 function installHost(options: {
   records: AgentSessionRecord[]
-  /** Sessions the host still holds; a close removes one unless it is listed as stuck. */
+  /** Sessions the host keeps holding through a close, so the post-close observation is `live`. */
   stuck?: Set<string>
+  /** Sessions the host drops without death evidence, so the observation is `unverifiable`. */
+  unverifiable?: Set<string>
+  /** Blocks every close, to exercise the shared sweep budget without fake timers. */
+  closeGate?: Promise<void>
 }): { closed: string[] } {
   const held = new Set(options.records.map((entry) => entry.sessionId))
   const closed: string[] = []
@@ -44,13 +61,18 @@ function installHost(options: {
     setSessionTabVisibility: async () => {},
     close: async (sessionId: string) => {
       closed.push(sessionId)
-      if (!options.stuck?.has(sessionId)) {
-        held.delete(sessionId)
-        const record = options.records.find((entry) => entry.sessionId === sessionId)
-        if (record) {
-          record.lease.claimStatus = 'released'
-          record.lease.deathEvidence = { kind: 'exit-observed', detail: 'closed', observedAt: 1 }
-        }
+      await options.closeGate
+      if (options.stuck?.has(sessionId)) {
+        return
+      }
+      held.delete(sessionId)
+      if (options.unverifiable?.has(sessionId)) {
+        return
+      }
+      const record = options.records.find((entry) => entry.sessionId === sessionId)
+      if (record) {
+        record.lease.claimStatus = 'released'
+        record.lease.deathEvidence = { kind: 'exit-observed', detail: 'closed', observedAt: 1 }
       }
     }
   }
@@ -67,7 +89,7 @@ const localProvider = {
   shutdown: async () => {}
 } as never
 
-function destructiveDeps(extra: { allowUnverifiedStop?: boolean } = {}) {
+function destructiveDeps(extra: { allowUnverifiedStop?: boolean; timeoutMs?: number } = {}) {
   return {
     localProvider,
     requirePhysicalStop: true,
@@ -84,7 +106,7 @@ describe('worktree teardown and structured agent sessions', () => {
 
   it('finds sessions by workspace, and ignores a sibling worktree', () => {
     installHost({ records: [record('s1', WORKTREE), record('s2', OTHER_WORKTREE)] })
-    expect(listLiveStructuredSessionsForWorktree(WORKTREE)).toEqual([
+    expect(listLiveStructuredSessionsForWorktree(WORKTREE, {})).toEqual([
       { sessionId: 's1', agent: 'claude' }
     ])
   })
@@ -105,7 +127,7 @@ describe('worktree teardown and structured agent sessions', () => {
   it('refuses only when the close does not settle', async () => {
     installHost({ records: [record('s1', WORKTREE)], stuck: new Set(['s1']) })
     await expect(killAllProcessesForWorktree(WORKTREE, destructiveDeps())).rejects.toThrow(
-      /1 running agent session/
+      /still live: 1 agent session \(claude\)/
     )
   })
 
@@ -137,7 +159,7 @@ describe('worktree teardown and structured agent sessions', () => {
       (thrown: Error) => thrown.message
     )
     expect(error).not.toContain('s1')
-    expect(error).toContain('1 running agent session')
+    expect(error).toContain('1 agent session (claude)')
   })
 
   it('closes best-effort for a folder-workspace removal, which requires no stop proof', async () => {
@@ -189,6 +211,116 @@ describe('worktree teardown and structured agent sessions', () => {
         includeLocalRegistry: false
       })
     ).resolves.toMatchObject({ runtimeStopped: 0 })
+  })
+
+  it('leaves a same-id workspace on another execution host alone', async () => {
+    // A workspace id is `repoId::path` with no host component, so the local, SSH and paired-runtime
+    // copies of one id are DIFFERENT workspaces. Unfenced, deleting the local one closed a chat
+    // running on somebody else's machine — a destructive cross-host act, not a spurious refusal.
+    const host = installHost({
+      records: [record('s1', WORKTREE, { executionHostId: 'ssh:host-a' })]
+    })
+    await expect(killAllProcessesForWorktree(WORKTREE, destructiveDeps())).resolves.toMatchObject({
+      runtimeStopped: 0
+    })
+    expect(host.closed).toEqual([])
+  })
+
+  it('closes only the session on the host the removal resolved to', async () => {
+    const host = installHost({
+      records: [record('s1', WORKTREE, { executionHostId: 'ssh:host-a' }), record('s2', WORKTREE)]
+    })
+    await expect(
+      killAllProcessesForWorktree(WORKTREE, {
+        ...destructiveDeps(),
+        resolvedConnectionId: 'host-a'
+      })
+    ).resolves.toMatchObject({ structuredStopped: 1 })
+    expect(host.closed).toEqual(['s1'])
+  })
+
+  it('names only the sessions that stayed, and every provider still there', async () => {
+    installHost({
+      records: [
+        record('s1', WORKTREE),
+        record('s2', WORKTREE, { provider: 'codex' }),
+        record('s3', WORKTREE)
+      ],
+      stuck: new Set(['s2', 's3'])
+    })
+    const error = await killAllProcessesForWorktree(WORKTREE, destructiveDeps()).catch(
+      (thrown: Error) => thrown.message
+    )
+    expect(error).toContain('still live: 2 agent sessions (claude, codex)')
+  })
+
+  it('separates a close it could not confirm from one it watched stay attached', async () => {
+    // `src/shared/worktree/removal.ts` keeps these two apart on purpose: a user waiving "we could
+    // not confirm" is making a different decision than one discarding a conversation Orca just saw
+    // running. The toast branches on this marker, so flattening them makes one of the two a lie.
+    installHost({ records: [record('s1', WORKTREE)], unverifiable: new Set(['s1']) })
+    const unconfirmed = await killAllProcessesForWorktree(WORKTREE, destructiveDeps()).catch(
+      (thrown: Error) => thrown.message
+    )
+    expect(unconfirmed).toContain('could not confirm these closed: 1 agent session (claude)')
+    expect(isProvenLiveStructuredSessionRemovalError(unconfirmed as string)).toBe(false)
+
+    installHost({ records: [record('s1', WORKTREE)], stuck: new Set(['s1']) })
+    const live = await killAllProcessesForWorktree(WORKTREE, destructiveDeps()).catch(
+      (thrown: Error) => thrown.message
+    )
+    expect(isProvenLiveStructuredSessionRemovalError(live as string)).toBe(true)
+  })
+
+  it('refuses in agent-session wording when the close outlives the sweep budget', async () => {
+    // A structured close that runs out of time used to reject with the PTY timeout sentinel, which
+    // the classifier reads FIRST — so the toast blamed terminals, and the Force Delete meant to
+    // clear the wedge hit the same rejection again (#11960).
+    installHost({ records: [record('s1', WORKTREE)], closeGate: new Promise<void>(() => {}) })
+    const error = await killAllProcessesForWorktree(
+      WORKTREE,
+      destructiveDeps({ timeoutMs: 5 })
+    ).catch((thrown: Error) => thrown.message)
+    expect(error).toContain('could not confirm these closed: 1 agent session (claude)')
+    expect(isUnstoppedPtyRemovalError(error as string)).toBe(false)
+    expect(classifyWorktreeForceDeleteReason(error as string, true)).toBe('running-agent-session')
+  })
+
+  it('never wedges Force Delete on a close that will not settle', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    installHost({ records: [record('s1', WORKTREE)], closeGate: new Promise<void>(() => {}) })
+    await expect(
+      killAllProcessesForWorktree(
+        WORKTREE,
+        destructiveDeps({ allowUnverifiedStop: true, timeoutMs: 5 })
+      )
+    ).resolves.toMatchObject({ runtimeStopped: 0 })
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('still attached'))
+    warn.mockRestore()
+  })
+
+  it('starts the terminal sweeps while the structured close is still in flight', async () => {
+    // The close is serial and each one waits on a provider round trip. Awaiting it before the
+    // sweeps exist spends the shared budget head-first, and the sweeps then report a timeout for
+    // a stop they never attempted.
+    let releaseClose: () => void = () => {}
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve
+    })
+    installHost({ records: [record('s1', WORKTREE)], closeGate })
+    let terminalSweepStarted = false
+    const runtime = {
+      stopTerminalsForWorktree: async () => {
+        terminalSweepStarted = true
+        return { stopped: 0 }
+      }
+    } as never
+    const removal = killAllProcessesForWorktree(WORKTREE, { ...destructiveDeps(), runtime })
+    await vi.waitFor(() => {
+      expect(terminalSweepStarted).toBe(true)
+    })
+    releaseClose()
+    await expect(removal).resolves.toMatchObject({ structuredStopped: 1 })
   })
 
   it('does not block removal when no structured host is installed', async () => {

--- a/src/main/runtime/structured-session-worktree-teardown.test.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.test.ts
@@ -104,6 +104,15 @@ function destructiveDeps(extra: { allowUnverifiedStop?: boolean; timeoutMs?: num
   }
 }
 
+/** The structured sweep's own warn — a forced removal can emit a PTY-sweep one onto the same spy. */
+function structuredSessionWarning(warn: { mock: { calls: unknown[][] } }): string {
+  return (
+    warn.mock.calls
+      .map((call) => String(call[0]))
+      .find((message) => message.includes('agent session')) ?? ''
+  )
+}
+
 describe('worktree teardown and structured agent sessions', () => {
   beforeEach(() => {
     hostRef.current = null
@@ -202,7 +211,8 @@ describe('worktree teardown and structured agent sessions', () => {
       destructiveDeps({ allowUnverifiedStop: true })
     )
     expect(result.structuredStopped).toBeUndefined()
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('still attached'))
+    // The live arm of that record, carrying the verdict the refusal would have shown.
+    expect(structuredSessionWarning(warn)).toContain('still live: 1 agent session (claude)')
     warn.mockRestore()
   })
 
@@ -361,7 +371,12 @@ describe('worktree teardown and structured agent sessions', () => {
         destructiveDeps({ allowUnverifiedStop: true, timeoutMs: 5 })
       )
     ).resolves.toMatchObject({ runtimeStopped: 0 })
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('still attached'))
+    const message = structuredSessionWarning(warn)
+    expect(message).toContain('could not confirm these closed: 1 agent session (claude)')
+    // The pin: a close that ran out of time was never watched stay attached. This warn is the only
+    // record a forced removal leaves, and the removal.ts split exists precisely so "we could not
+    // confirm" is never reported as "we saw it running" — including here.
+    expect(message).not.toContain('still attached')
     warn.mockRestore()
   })
 

--- a/src/main/runtime/structured-session-worktree-teardown.test.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.test.ts
@@ -281,6 +281,45 @@ describe('worktree teardown and structured agent sessions', () => {
     expect(error).toContain('still live: 2 agent sessions (claude, codex)')
   })
 
+  it('names the unconfirmed sessions too, instead of counting only the live ones', async () => {
+    // The PTY sibling may drop everything outside its live list because a fresh inventory PROVED
+    // those exited. Nothing proves that here: an `unverifiable` session is unclosed as well, so
+    // naming only the live subset told the user "1 agent session" while two were about to go.
+    installHost({
+      records: [record('s1', WORKTREE), record('s2', WORKTREE, { provider: 'codex' })],
+      stuck: new Set(['s1']),
+      unverifiable: new Set(['s2'])
+    })
+    const error = await killAllProcessesForWorktree(WORKTREE, destructiveDeps()).catch(
+      (thrown: Error) => thrown.message
+    )
+    expect(error).toContain(
+      'still live: 1 agent session (claude); could not confirm these closed: 1 agent session (codex)'
+    )
+    // The marker still leads, so the toast keeps showing the stronger of the two warnings.
+    expect(isProvenLiveStructuredSessionRemovalError(error as string)).toBe(true)
+  })
+
+  it('still reports what it closed when a forced removal skips the PTY verdict', async () => {
+    // A sweep that fails outright short-circuits the per-PTY verdict — but not the structured
+    // close that already ran, so the count has to survive that return or the removal log claims
+    // `structured=0` for chats it just ended.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const runtime = {
+      stopTerminalsForWorktree: async () => {
+        throw new Error('the terminal sweep died')
+      }
+    } as never
+    const host = installHost({ records: [record('s1', WORKTREE)] })
+    const result = await killAllProcessesForWorktree(WORKTREE, {
+      ...destructiveDeps({ allowUnverifiedStop: true }),
+      runtime
+    })
+    expect(host.closed).toEqual(['s1'])
+    expect(result.structuredStopped).toBe(1)
+    warn.mockRestore()
+  })
+
   it('separates a close it could not confirm from one it watched stay attached', async () => {
     // `src/shared/worktree/removal.ts` keeps these two apart on purpose: a user waiving "we could
     // not confirm" is making a different decision than one discarding a conversation Orca just saw

--- a/src/main/runtime/structured-session-worktree-teardown.test.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.test.ts
@@ -56,13 +56,40 @@ function installHost(options: {
   closeGate?: Promise<void>
   /** Blocks ONE session's close, so the serial loop can be caught part-way through. */
   closeGates?: Record<string, Promise<void>>
-}): { closed: string[] } {
+  /** Sessions in the persisted visible-tab index, so a rollback has something to put back. */
+  visible?: string[]
+  /**
+   * Sessions whose death evidence lands DURING the close's tab-restore write.
+   *
+   * `setSessionTabVisibility` is a store transaction — a real disk write — so the close's own
+   * observation and the sweep's re-read straddle it and can disagree about the same session.
+   */
+  exitsDuringTabRestore?: Set<string>
+}): { closed: string[]; visible: Set<string> } {
   const held = new Set(options.records.map((entry) => entry.sessionId))
   const closed: string[] = []
+  const visible = new Set(options.visible ?? [])
+  const recordExit = (sessionId: string): void => {
+    const entry = options.records.find((candidate) => candidate.sessionId === sessionId)
+    if (entry) {
+      entry.lease.claimStatus = 'released'
+      entry.lease.deathEvidence = { kind: 'exit-observed', detail: 'closed', observedAt: 1 }
+    }
+  }
   hostRef.current = {
     deps: { store: { listRecords: () => options.records, getRecord: () => null } },
     hasSession: (sessionId: string) => held.has(sessionId),
-    setSessionTabVisibility: async () => {},
+    getPersistedVisibleSessionTabIndex: () => ({ present: true, sessionIds: [...visible] }),
+    setSessionTabVisibility: async (sessionId: string, isVisible: boolean) => {
+      if (!isVisible) {
+        visible.delete(sessionId)
+        return
+      }
+      if (options.exitsDuringTabRestore?.has(sessionId)) {
+        recordExit(sessionId)
+      }
+      visible.add(sessionId)
+    },
     close: async (sessionId: string) => {
       closed.push(sessionId)
       await options.closeGate
@@ -74,10 +101,8 @@ function installHost(options: {
       if (options.unverifiable?.has(sessionId)) {
         return
       }
-      const record = options.records.find((entry) => entry.sessionId === sessionId)
-      if (record) {
-        record.lease.claimStatus = 'released'
-        record.lease.deathEvidence = { kind: 'exit-observed', detail: 'closed', observedAt: 1 }
+      if (!options.exitsDuringTabRestore?.has(sessionId)) {
+        recordExit(sessionId)
       }
       if (options.settledThenThrows?.has(sessionId)) {
         throw new Error('the event sink could not be flushed')
@@ -89,7 +114,7 @@ function installHost(options: {
     hostRef.current as { deps: { store: { getRecord: (id: string) => unknown } } }
   ).deps.store.getRecord = (sessionId: string) =>
     options.records.find((entry) => entry.sessionId === sessionId) ?? null
-  return { closed }
+  return { closed, visible }
 }
 
 const localProvider = {
@@ -146,6 +171,71 @@ describe('worktree teardown and structured agent sessions', () => {
     await expect(killAllProcessesForWorktree(WORKTREE, destructiveDeps())).rejects.toThrow(
       /still live: 1 agent session \(claude\)/
     )
+  })
+
+  it('puts the chat tab back when the removal refuses over the session', async () => {
+    // The workspace survives a refusal, so the tab has to survive it too: a destructive operation
+    // that refused and still took the user's chat tab away is the loss the rollback exists to undo.
+    const host = installHost({
+      records: [record('s1', WORKTREE)],
+      stuck: new Set(['s1']),
+      visible: ['s1']
+    })
+    await expect(killAllProcessesForWorktree(WORKTREE, destructiveDeps())).rejects.toThrow(
+      /still live: 1 agent session \(claude\)/
+    )
+    expect([...host.visible]).toEqual(['s1'])
+  })
+
+  it('leaves the chat tab dropped when a forced removal deletes the workspace anyway', async () => {
+    // The other half of the same rollback. Force does not refuse — it warns and goes on to delete
+    // the checkout — so putting the tab back leaves a DURABLE reference to a workspace that is
+    // about to be gone, which republishes the chat at the next launch pointing at a deleted
+    // worktree: the exact outcome this whole sweep exists to remove.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const host = installHost({
+      records: [record('s1', WORKTREE)],
+      stuck: new Set(['s1']),
+      visible: ['s1']
+    })
+    await killAllProcessesForWorktree(WORKTREE, destructiveDeps({ allowUnverifiedStop: true }))
+    expect([...host.visible]).toEqual([])
+    warn.mockRestore()
+  })
+
+  it('leaves the chat tab dropped for a folder-workspace removal, which never refuses', async () => {
+    // Same reasoning without the force waiver: this caller cannot refuse at all, so the workspace
+    // is forgotten whatever the close reports.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const host = installHost({
+      records: [record('s1', WORKTREE)],
+      stuck: new Set(['s1']),
+      visible: ['s1']
+    })
+    await killAllProcessesForWorktree(WORKTREE, {
+      localProvider,
+      includeProviderInventory: false as const,
+      includeLocalRegistry: false as const,
+      closeStructuredSessions: true
+    })
+    expect([...host.visible]).toEqual([])
+    warn.mockRestore()
+  })
+
+  it('drops the chat tab for a session the sweep proves exited after the close gave up', async () => {
+    // `host.close` can return BEFORE the child's exit is recorded, so the close's own observation
+    // reads unverifiable and puts the tab back — and the sweep's re-read, one store write later,
+    // proves the exit and counts the session closed. The two observations straddle that write and
+    // can disagree; the tab must not survive the disagreement, because this removal proceeds.
+    const host = installHost({
+      records: [record('s1', WORKTREE)],
+      visible: ['s1'],
+      exitsDuringTabRestore: new Set(['s1'])
+    })
+    await expect(killAllProcessesForWorktree(WORKTREE, destructiveDeps())).resolves.toMatchObject({
+      structuredStopped: 1
+    })
+    expect([...host.visible]).toEqual([])
   })
 
   it('names the force escape hatch in the refusal, like the unstopped-PTY gate', async () => {

--- a/src/main/runtime/structured-session-worktree-teardown.test.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.test.ts
@@ -89,19 +89,28 @@ describe('worktree teardown and structured agent sessions', () => {
     ])
   })
 
-  it('refuses a destructive removal rather than deleting the checkout under a live child', async () => {
-    // The defect this pins: all three PTY sweeps enumerate leaves, provider sessions and the local
-    // registry, and a structured session is on NONE of them. Every sweep answered zero, nothing
-    // errored, and removal proceeded — leaving the provider child running with its `cwd` deleted
-    // and the dispatch still reporting the worker live and exact.
-    installHost({ records: [record('s1', WORKTREE)] })
+  it('closes a live session on an ordinary removal instead of refusing it', async () => {
+    // The defect this pins, and the reason the guard is not simply deleted: all three PTY sweeps
+    // enumerate leaves, provider sessions and the local registry, and a structured session is on
+    // NONE of them, so removal used to proceed leaving the provider child running with its `cwd`
+    // deleted. The stop belongs on the ordinary path — the same one that kills a terminal running
+    // the same agent — so an idle chat is no harder to delete than that terminal.
+    const host = installHost({ records: [record('s1', WORKTREE)] })
+    await expect(killAllProcessesForWorktree(WORKTREE, destructiveDeps())).resolves.toMatchObject({
+      structuredStopped: 1
+    })
+    expect(host.closed).toEqual(['s1'])
+  })
+
+  it('refuses only when the close does not settle', async () => {
+    installHost({ records: [record('s1', WORKTREE)], stuck: new Set(['s1']) })
     await expect(killAllProcessesForWorktree(WORKTREE, destructiveDeps())).rejects.toThrow(
       /1 running agent session/
     )
   })
 
   it('names the force escape hatch in the refusal, like the unstopped-PTY gate', async () => {
-    installHost({ records: [record('s1', WORKTREE)] })
+    installHost({ records: [record('s1', WORKTREE)], stuck: new Set(['s1']) })
     await expect(killAllProcessesForWorktree(WORKTREE, destructiveDeps())).rejects.toThrow(/force/i)
   })
 
@@ -109,7 +118,7 @@ describe('worktree teardown and structured agent sessions', () => {
     // The #11960 dead end, and the shape this file's own comments warn about: the desktop
     // affordance comes ONLY from the classifier, and an ordinary delete already passes force:true
     // for the dirty-file skip — so a refusal with no matcher shows raw CLI wording with no button.
-    installHost({ records: [record('s1', WORKTREE)] })
+    installHost({ records: [record('s1', WORKTREE)], stuck: new Set(['s1']) })
     const error = await killAllProcessesForWorktree(WORKTREE, destructiveDeps()).catch(
       (thrown: Error) => thrown.message
     )
@@ -123,7 +132,7 @@ describe('worktree teardown and structured agent sessions', () => {
     // A session id is one tab-id hop from the random pane key that gates a worker's mailbox, and
     // this string reaches CLI output and a desktop toast. A count and the providers are what a
     // user deciding whether to force actually needs.
-    installHost({ records: [record('s1', WORKTREE)] })
+    installHost({ records: [record('s1', WORKTREE)], stuck: new Set(['s1']) })
     const error = await killAllProcessesForWorktree(WORKTREE, destructiveDeps()).catch(
       (thrown: Error) => thrown.message
     )

--- a/src/main/runtime/structured-session-worktree-teardown.test.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.test.ts
@@ -50,6 +50,8 @@ function installHost(options: {
   stuck?: Set<string>
   /** Sessions the host drops without death evidence, so the observation is `unverifiable`. */
   unverifiable?: Set<string>
+  /** Sessions whose child dies and is recorded dead, but whose close then fails past that point. */
+  settledThenThrows?: Set<string>
   /** Blocks every close, to exercise the shared sweep budget without fake timers. */
   closeGate?: Promise<void>
 }): { closed: string[] } {
@@ -73,6 +75,9 @@ function installHost(options: {
       if (record) {
         record.lease.claimStatus = 'released'
         record.lease.deathEvidence = { kind: 'exit-observed', detail: 'closed', observedAt: 1 }
+      }
+      if (options.settledThenThrows?.has(sessionId)) {
+        throw new Error('the event sink could not be flushed')
       }
     }
   }
@@ -199,6 +204,28 @@ describe('worktree teardown and structured agent sessions', () => {
     expect(result.structuredStopped).toBeUndefined()
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('still attached'))
     warn.mockRestore()
+  })
+
+  it('takes the proof when a failed close is re-observed as exited', async () => {
+    // `closeStructuredAgentSessionChild` reports `stopped: false` for anything that throws past its
+    // own observation, and for a record whose death evidence lands after it read. The re-read here
+    // can still PROVE the exit — refusing a delete over a child that is demonstrably gone is the
+    // defect this whole sweep exists to remove, so the proof has to win over the close's verdict.
+    const retired: string[] = []
+    const runtime = {
+      stopTerminalsForWorktree: async () => ({ stopped: 0 }),
+      retireStructuredAgentSessionTabFromSnapshot: (sessionId: string) => {
+        retired.push(sessionId)
+        return true
+      }
+    } as never
+    installHost({ records: [record('s1', WORKTREE)], settledThenThrows: new Set(['s1']) })
+    await expect(
+      killAllProcessesForWorktree(WORKTREE, { ...destructiveDeps(), runtime })
+    ).resolves.toMatchObject({ structuredStopped: 1 })
+    // Retired here because the close gave up before its own retirement step, and a chat tab left
+    // behind re-attaches a released session pointing at a workspace that is about to be deleted.
+    expect(retired).toEqual(['s1'])
   })
 
   it('leaves the best-effort reconciliation paths alone', async () => {

--- a/src/main/runtime/structured-session-worktree-teardown.test.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.test.ts
@@ -54,6 +54,8 @@ function installHost(options: {
   settledThenThrows?: Set<string>
   /** Blocks every close, to exercise the shared sweep budget without fake timers. */
   closeGate?: Promise<void>
+  /** Blocks ONE session's close, so the serial loop can be caught part-way through. */
+  closeGates?: Record<string, Promise<void>>
 }): { closed: string[] } {
   const held = new Set(options.records.map((entry) => entry.sessionId))
   const closed: string[] = []
@@ -64,6 +66,7 @@ function installHost(options: {
     close: async (sessionId: string) => {
       closed.push(sessionId)
       await options.closeGate
+      await options.closeGates?.[sessionId]
       if (options.stuck?.has(sessionId)) {
         return
       }
@@ -263,6 +266,22 @@ describe('worktree teardown and structured agent sessions', () => {
     expect(host.closed).toEqual([])
   })
 
+  it('reads an explicit local fence the way the PTY sweeps do', () => {
+    // This helper reuses the PTY fence's own type, so the two cannot answer `null` differently:
+    // there it means this machine, and it has to mean this machine here. ABSENT is the one
+    // deliberate difference — no fence at all for the PTY sweeps, narrowed to local here, because
+    // a single-host-id comparison cannot express match-all and closing every host's chats is
+    // destructive. Latent today only because `WorktreeTeardownDeps` cannot yet carry the `null`.
+    installHost({
+      records: [record('s1', WORKTREE, { executionHostId: 'ssh:host-a' }), record('s2', WORKTREE)]
+    })
+    const local = [{ sessionId: 's2', agent: 'claude' }]
+    expect(listLiveStructuredSessionsForWorktree(WORKTREE, { resolvedConnectionId: null })).toEqual(
+      local
+    )
+    expect(listLiveStructuredSessionsForWorktree(WORKTREE, {})).toEqual(local)
+  })
+
   it('closes only the session on the host the removal resolved to', async () => {
     const host = installHost({
       records: [record('s1', WORKTREE, { executionHostId: 'ssh:host-a' }), record('s2', WORKTREE)]
@@ -378,6 +397,92 @@ describe('worktree teardown and structured agent sessions', () => {
     // confirm" is never reported as "we saw it running" — including here.
     expect(message).not.toContain('still attached')
     warn.mockRestore()
+  })
+
+  it('names only the sessions still open when the budget expires mid-close', async () => {
+    // The close loop is serial, so a deadline can land part-way through it. A fallback assembled
+    // at the deadline could only name the whole list — so a removal that had already closed the
+    // first chat still told the user both were still there, which is the exact thing this sweep
+    // exists to stop doing: never report state nobody observed.
+    installHost({
+      records: [record('s1', WORKTREE), record('s2', WORKTREE, { provider: 'codex' })],
+      closeGates: { s2: new Promise<void>(() => {}) }
+    })
+    const error = await killAllProcessesForWorktree(
+      WORKTREE,
+      destructiveDeps({ timeoutMs: 40 })
+    ).catch((thrown: Error) => thrown.message)
+    expect(error).toContain('could not confirm these closed: 1 agent session (codex)')
+    expect(error).not.toContain('claude')
+  })
+
+  it('counts the closes that landed before the budget expired', async () => {
+    // The other half of the same fallback: it reported zero closes, so the removal log said
+    // `structured=0` for a chat it had just ended.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const slowClose = new Promise<void>((resolve) => {
+      setTimeout(resolve, 300)
+    })
+    installHost({
+      records: [record('s1', WORKTREE), record('s2', WORKTREE, { provider: 'codex' })],
+      closeGates: { s2: slowClose }
+    })
+    const result = await killAllProcessesForWorktree(
+      WORKTREE,
+      destructiveDeps({ allowUnverifiedStop: true, timeoutMs: 40 })
+    )
+    expect(result.structuredStopped).toBe(1)
+    expect(structuredSessionWarning(warn)).toContain(
+      'could not confirm these closed: 1 agent session (codex)'
+    )
+    warn.mockRestore()
+  })
+
+  it('stops issuing new closes once the budget is spent', async () => {
+    // One slow provider round trip used to starve every session behind it: the outer race had
+    // already given up on the loop, and it went on issuing closes whose outcome nobody would read.
+    // The in-flight one is NOT cancelled — nothing here can cancel a provider round trip — so it
+    // still has to be reported, which is why both sessions are named below.
+    let releaseFirstClose: () => void = () => {}
+    const firstClose = new Promise<void>((resolve) => {
+      releaseFirstClose = resolve
+    })
+    const host = installHost({
+      records: [record('s1', WORKTREE), record('s2', WORKTREE)],
+      closeGates: { s1: firstClose }
+    })
+    const error = await killAllProcessesForWorktree(
+      WORKTREE,
+      destructiveDeps({ timeoutMs: 5 })
+    ).catch((thrown: Error) => thrown.message)
+    expect(error).toContain('could not confirm these closed: 2 agent sessions (claude)')
+    releaseFirstClose()
+    await new Promise((resolve) => {
+      setTimeout(resolve, 25)
+    })
+    expect(host.closed).toEqual(['s1'])
+  })
+
+  it('leaves the terminals already stopped when it refuses over a stuck session', async () => {
+    // Pins a tradeoff that was accepted, not an outcome that is wanted. The PTY sweeps now run
+    // concurrently with the structured close, so a removal that refuses over a session that will
+    // not close has ALREADY killed that workspace's terminals — the head-first serial order spared
+    // them. Serialising it back is worse: it spends the whole shared budget before a single PTY is
+    // asked, and the alternative — refusing before the PTY sweeps — leaves force-delete removing
+    // files while PTY handles are open. The PTY gate itself already kills first and refuses only
+    // on what it could not verify stopped. A later change must not flip this back silently.
+    let terminalSweeps = 0
+    const runtime = {
+      stopTerminalsForWorktree: async () => {
+        terminalSweeps += 1
+        return { stopped: 2 }
+      }
+    } as never
+    installHost({ records: [record('s1', WORKTREE)], stuck: new Set(['s1']) })
+    await expect(
+      killAllProcessesForWorktree(WORKTREE, { ...destructiveDeps(), runtime })
+    ).rejects.toThrow(/still live: 1 agent session \(claude\)/)
+    expect(terminalSweeps).toBe(1)
   })
 
   it('starts the terminal sweeps while the structured close is still in flight', async () => {

--- a/src/main/runtime/structured-session-worktree-teardown.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.ts
@@ -8,10 +8,10 @@
  * kept running with its `cwd` gone, the durable record and chat tab survived to republish at the
  * next launch pointing at a deleted worktree, and `worker-show` still reported the worker live.
  *
- * Membership is `location.workspaceId`, which every structured session carries — so this covers a
- * plain chat session in the worktree as well as a dispatched worker. Liveness is
- * `observeStructuredWorker`, the same `live` / `unverifiable` / `exited` vocabulary the rest of the
- * structured surface uses.
+ * Membership is `location.workspaceId` PLUS the host fence below, and every structured session
+ * carries both — so this covers a plain chat session in the worktree as well as a dispatched
+ * worker. Liveness is `observeStructuredWorker`, the same `live` / `unverifiable` / `exited`
+ * vocabulary the rest of the structured surface uses.
  *
  * `live` here is lease state — a provider child is attached — not work in flight, so it says
  * nothing about whether the user would lose anything. It selects what to CLOSE, never what to
@@ -19,6 +19,13 @@
  * refuses only on a stop it could not verify.
  */
 
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  toRuntimeExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from '../../shared/execution-host'
+import { STILL_LIVE_DETAIL_PREFIX } from '../../shared/worktree/removal'
 import { getStructuredAgentSessionHost } from '../native-chat/agent-session-wire/structured-agent-session-registry'
 import { observeStructuredWorker } from './structured-worker-authority'
 import { closeStructuredAgentSessionChild } from './structured-agent-session-close'
@@ -29,13 +36,45 @@ export type LiveStructuredSessionInWorkspace = {
   agent: 'claude' | 'codex'
 }
 
+export type UnclosedStructuredSession = LiveStructuredSessionInWorkspace & {
+  /** Read AFTER the close: `live` is a child watched stay attached, not merely one left unproven. */
+  status: 'live' | 'unverifiable'
+}
+
 export type StructuredWorktreeSweepRuntime = Pick<
   OrcaRuntimeService,
   'forgetStructuredSessionMail' | 'retireStructuredAgentSessionTabFromSnapshot'
 >
 
+/** The two fields every teardown caller already resolves to fence its PTY sweeps to one host. */
+export type StructuredSessionHostFence = {
+  resolvedConnectionId?: string
+  resolvedRuntimeEnvironmentId?: string
+}
+
 /**
- * Structured sessions with a proven-live child in this worktree.
+ * The one execution host this teardown may touch.
+ *
+ * A workspace id is `repoId::path` with no host component, so the local machine, an SSH host and a
+ * paired runtime can all publish the SAME id and each names a DIFFERENT workspace (STA-4343). The
+ * PTY sweeps fence on exactly these two fields; a structured session records its host directly, so
+ * the comparison is on `location.executionHostId` instead of on a pty-id shape — but the
+ * precedence is the same. Neither field set means the removal targets this machine, which is also
+ * the safe default: a caller that resolved no host closes nothing on anyone else's.
+ */
+export function structuredSessionTeardownHostId(
+  fence: StructuredSessionHostFence
+): ExecutionHostId {
+  if (fence.resolvedRuntimeEnvironmentId !== undefined) {
+    return toRuntimeExecutionHostId(fence.resolvedRuntimeEnvironmentId)
+  }
+  return fence.resolvedConnectionId === undefined
+    ? LOCAL_EXECUTION_HOST_ID
+    : toSshExecutionHostId(fence.resolvedConnectionId)
+}
+
+/**
+ * Structured sessions with a proven-live child in this worktree, on the fenced host only.
  *
  * An uninstalled host answers empty rather than throwing: no host in this generation means no
  * provider child was started by this process, and the three PTY sweeps fall through the same way
@@ -43,7 +82,8 @@ export type StructuredWorktreeSweepRuntime = Pick<
  * directly — that would force-install the host, which is itself a side effect on a teardown path.
  */
 export function listLiveStructuredSessionsForWorktree(
-  worktreeId: string
+  worktreeId: string,
+  fence: StructuredSessionHostFence
 ): LiveStructuredSessionInWorkspace[] {
   const host = getStructuredAgentSessionHost()
   if (!host) {
@@ -55,48 +95,63 @@ export function listLiveStructuredSessionsForWorktree(
   } catch {
     return []
   }
+  const hostId = structuredSessionTeardownHostId(fence)
   return records
     .filter(
       (record) =>
         record.location.workspaceId === worktreeId &&
+        record.location.executionHostId === hostId &&
         observeStructuredWorker({ sessionId: record.sessionId }).status === 'live'
     )
     .map((record) => ({ sessionId: record.sessionId, agent: record.provider }))
 }
 
 /**
- * Counts and providers, never session ids.
+ * Counts, providers and the post-close verdict — never session ids.
  *
  * A session id is one tab-id hop from the random pane key that gates a worker's mailbox, and this
  * string reaches agent-readable CLI output and a desktop toast. The count and the providers are
  * what a user deciding whether to force actually needs; the ids identify nothing they can act on.
+ *
+ * The verdict is here for the reason `describeUnstoppedPtys` carries one: "we watched it stay
+ * attached" and "we could not confirm it went" are different decisions to waive, and the delete
+ * toast branches on this marker. Any proven-live session makes the whole refusal a live one, as it
+ * does for PTYs — that is the stronger warning, and the one whose work is about to be discarded.
  */
-export function describeLiveStructuredSessions(
-  sessions: readonly LiveStructuredSessionInWorkspace[]
+export function describeUnclosedStructuredSessions(
+  sessions: readonly UnclosedStructuredSession[]
 ): string {
-  const noun = sessions.length === 1 ? 'agent session' : 'agent sessions'
-  const providers = [...new Set(sessions.map((session) => session.agent))].sort().join(', ')
-  return `${sessions.length} running ${noun} (${providers})`
+  const stillLive = sessions.filter((session) => session.status === 'live')
+  const named = stillLive.length > 0 ? stillLive : sessions
+  const noun = named.length === 1 ? 'agent session' : 'agent sessions'
+  const providers = [...new Set(named.map((session) => session.agent))].sort().join(', ')
+  const summary = `${named.length} ${noun} (${providers})`
+  return stillLive.length > 0
+    ? `${STILL_LIVE_DETAIL_PREFIX} ${summary}`
+    : `could not confirm these closed: ${summary}`
 }
 
 /**
- * Closes every live structured session in the worktree, and reports what stayed.
+ * Closes the given structured sessions, and reports what stayed.
  *
  * Runs on the ordinary removal too, not just force: a child left running against a deleted `cwd` is
  * the outcome this whole sweep exists to prevent, and closing is how you prevent it. What stayed is
  * the only thing worth refusing over.
+ *
+ * Takes the list rather than re-deriving it, so the sessions reported as unclosed are exactly the
+ * ones a close was attempted on — re-enumerating would run every liveness observation twice and
+ * let the refusal name a session this call never touched.
  */
 export async function closeStructuredSessionsForWorktree(
-  worktreeId: string,
+  sessions: readonly LiveStructuredSessionInWorkspace[],
   runtime?: StructuredWorktreeSweepRuntime
-): Promise<{ closed: number; unstopped: LiveStructuredSessionInWorkspace[] }> {
+): Promise<{ closed: number; unstopped: UnclosedStructuredSession[] }> {
   // No `afterClose` for a dispatched worker: `host.close` drops the holds, so nothing keeps a
   // provider child un-evictable, but the dispatch's redrive subscription and registry entry do
   // survive until it settles by another verb. That is a bounded leak, not a hazard — and passing
   // one here would mean resolving a dispatch id per session on a teardown path that must stay
   // inside the sweep deadline.
-  const sessions = listLiveStructuredSessionsForWorktree(worktreeId)
-  const unstopped: LiveStructuredSessionInWorkspace[] = []
+  const unstopped: UnclosedStructuredSession[] = []
   let closed = 0
   for (const session of sessions) {
     const outcome = await closeStructuredAgentSessionChild(
@@ -105,9 +160,12 @@ export async function closeStructuredSessionsForWorktree(
     )
     if (outcome.stopped) {
       closed += 1
-    } else {
-      unstopped.push(session)
+      continue
     }
+    // Re-observed rather than reusing the close's own reason string: what the user is asked to
+    // waive is the state AFTER the attempt, and a close that threw never reached an observation.
+    const status = observeStructuredWorker({ sessionId: session.sessionId }).status
+    unstopped.push({ ...session, status: status === 'live' ? 'live' : 'unverifiable' })
   }
   return { closed, unstopped }
 }

--- a/src/main/runtime/structured-session-worktree-teardown.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.ts
@@ -209,15 +209,28 @@ export function unclosedStructuredSessions(
  * the outcome this whole sweep exists to prevent, and closing is how you prevent it. What stayed is
  * the only thing worth refusing over.
  *
- * Takes the list rather than re-deriving it, so the sessions reported as unclosed are exactly the
- * ones a close was attempted on — re-enumerating would run every liveness observation twice and
- * let the refusal name a session this call never touched.
+ * Takes the list rather than re-deriving it, so the refusal can only ever name a session out of
+ * the set this sweep was handed — re-enumerating would run every liveness observation twice and
+ * let it name one this call never touched. Not every one of them is a session a close was
+ * attempted on: the deadline check below can leave the tail of the list unasked, and
+ * `unclosedStructuredSessions` reports those as `unverifiable` precisely because nobody looked.
  */
 export async function closeStructuredSessionsForWorktree(
   progress: StructuredSweepProgress,
   deadline: number,
-  runtime?: StructuredWorktreeSweepRuntime
+  options: {
+    runtime?: StructuredWorktreeSweepRuntime
+    /**
+     * Whether this removal can still refuse over an unclosed session.
+     *
+     * It is the only case where the workspace — and therefore its chat tabs — survives, so it is
+     * the only case where an unproven close may put a tab back. Force and the folder-workspace
+     * paths discard the workspace whatever the sweep reports.
+     */
+    mayRefuse?: boolean
+  } = {}
 ): Promise<void> {
+  const { runtime, mayRefuse } = options
   // No `afterClose` for a dispatched worker: `host.close` drops the holds, so nothing keeps a
   // provider child un-evictable, but the dispatch's redrive subscription and registry entry do
   // survive until it settles by another verb. That is a bounded leak, not a hazard — and passing
@@ -231,10 +244,10 @@ export async function closeStructuredSessionsForWorktree(
     if (Date.now() >= deadline) {
       return
     }
-    const outcome = await closeStructuredAgentSessionChild(
-      session.sessionId,
-      runtime ? { runtime } : {}
-    )
+    const outcome = await closeStructuredAgentSessionChild(session.sessionId, {
+      ...(runtime ? { runtime } : {}),
+      restoreTabOnUnprovenClose: mayRefuse === true
+    })
     if (outcome.stopped) {
       progress.closed += 1
     } else {
@@ -246,6 +259,11 @@ export async function closeStructuredSessionsForWorktree(
         // observation, or the record's death evidence landed after it read. Refusing on a child
         // that is demonstrably gone is the defect this sweep exists to remove, so take the proof
         // and run the retirement `closeStructuredAgentSessionChild` skipped when it gave up.
+        //
+        // Including the hide it UNDID: its rollback ran against an observation taken one store
+        // write before this one, so a child that died in between left the tab republished for a
+        // session this sweep is about to count closed. Taking the proof has to take that back.
+        await dropDurableChatTabReference(session.sessionId)
         retireSettledStructuredWorkerTab(session.sessionId, runtime)
         progress.closed += 1
       } else {
@@ -255,5 +273,22 @@ export async function closeStructuredSessionsForWorktree(
     // Advanced only once an outcome is recorded, so a close still in flight when the deadline
     // lands stays reported as unclosed instead of falling out of both counts.
     progress.settled += 1
+  }
+}
+
+/**
+ * Drops a settled session's durable chat-tab reference, and cannot fail the settlement.
+ *
+ * The close's own hide is the ordinary path; this is only for the session whose exit this sweep
+ * proved after that close had already rolled the hide back.
+ */
+async function dropDurableChatTabReference(sessionId: string): Promise<void> {
+  try {
+    await getStructuredAgentSessionHost()?.setSessionTabVisibility?.(sessionId, false)
+  } catch (error) {
+    console.warn(
+      `[worktree-teardown] could not drop the chat tab reference for ${sessionId}`,
+      error
+    )
   }
 }

--- a/src/main/runtime/structured-session-worktree-teardown.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.ts
@@ -30,6 +30,7 @@ import { getStructuredAgentSessionHost } from '../native-chat/agent-session-wire
 import { observeStructuredWorker } from './structured-worker-authority'
 import { closeStructuredAgentSessionChild } from './structured-agent-session-close'
 import { retireSettledStructuredWorkerTab } from './structured-agent-session-tab-retirement'
+import type { WorktreePtyHostFence } from './worktree-pty-host-fence'
 import type { OrcaRuntimeService } from './orca-runtime'
 
 export type LiveStructuredSessionInWorkspace = {
@@ -47,11 +48,19 @@ export type StructuredWorktreeSweepRuntime = Pick<
   'forgetStructuredSessionMail' | 'retireStructuredAgentSessionTabFromSnapshot'
 >
 
-/** The two fields every teardown caller already resolves to fence its PTY sweeps to one host. */
-export type StructuredSessionHostFence = {
-  resolvedConnectionId?: string
-  resolvedRuntimeEnvironmentId?: string
-}
+/**
+ * The two fields every teardown caller already resolves to fence its PTY sweeps to one host.
+ *
+ * Deliberately the PTY fence's own type rather than a look-alike: these two helpers are written
+ * against each other, so a widening on one side must not become a silent disagreement on the
+ * other. `resolvedConnectionId: null` means this machine on both.
+ *
+ * They differ in exactly one reading, and only that one: ABSENT. The PTY fence takes it as no
+ * fence at all and matches every host, which a single-host-id comparison cannot express — and
+ * closing every host's chats is destructive, not merely noisy. So this side reads absent as local
+ * too, the narrower half of that pair. Pinned by test, not left to the next reader to rediscover.
+ */
+export type StructuredSessionHostFence = WorktreePtyHostFence
 
 /**
  * The one execution host this teardown may touch.
@@ -59,9 +68,7 @@ export type StructuredSessionHostFence = {
  * A workspace id is `repoId::path` with no host component, so the local machine, an SSH host and a
  * paired runtime can all publish the SAME id and each names a DIFFERENT workspace (STA-4343). The
  * PTY sweeps fence on exactly these two fields; a structured session records its host directly, so
- * the comparison is on `location.executionHostId` instead of on a pty-id shape — but the
- * precedence is the same. Neither field set means the removal targets this machine, which is also
- * the safe default: a caller that resolved no host closes nothing on anyone else's.
+ * the comparison is on `location.executionHostId` instead of on a pty-id shape.
  */
 export function structuredSessionTeardownHostId(
   fence: StructuredSessionHostFence
@@ -69,9 +76,10 @@ export function structuredSessionTeardownHostId(
   if (fence.resolvedRuntimeEnvironmentId !== undefined) {
     return toRuntimeExecutionHostId(fence.resolvedRuntimeEnvironmentId)
   }
-  return fence.resolvedConnectionId === undefined
-    ? LOCAL_EXECUTION_HOST_ID
-    : toSshExecutionHostId(fence.resolvedConnectionId)
+  // Both no-connection readings collapse here on purpose — see the fence type. A caller that
+  // resolved no host, and one that resolved this machine, each close nothing on anyone else's.
+  const connectionId = fence.resolvedConnectionId ?? null
+  return connectionId === null ? LOCAL_EXECUTION_HOST_ID : toSshExecutionHostId(connectionId)
 }
 
 /**
@@ -148,7 +156,54 @@ export function describeUnclosedStructuredSessions(
 }
 
 /**
- * Closes the given structured sessions, and reports what stayed.
+ * What the close loop has done so far, readable while it is still running.
+ *
+ * The loop is serial and every close waits on a provider round trip, so the shared sweep budget can
+ * expire part-way through it. This is written as it goes rather than returned at the end, because
+ * the caller's timeout path reads THIS: a fabricated whole-list fallback reported sessions the
+ * sweep had already closed as unclosed, named them in the refusal the user reads, and logged
+ * `structured=0` for closes that landed. Saying only what was observed is the point of the sweep.
+ */
+export type StructuredSweepProgress = {
+  /** The sessions this sweep closes, in the order the loop reaches them. */
+  readonly sessions: readonly LiveStructuredSessionInWorkspace[]
+  /** Sessions no longer attached after their close — the count this sweep reports. */
+  closed: number
+  /** Attempted closes that did not settle, each carrying the verdict re-read after the attempt. */
+  unstopped: UnclosedStructuredSession[]
+  /** How many of `sessions`, from the front, have an outcome recorded. */
+  settled: number
+}
+
+export function createStructuredSweepProgress(
+  sessions: readonly LiveStructuredSessionInWorkspace[]
+): StructuredSweepProgress {
+  return { sessions, closed: 0, unstopped: [], settled: 0 }
+}
+
+/**
+ * Everything this sweep did not prove closed.
+ *
+ * A session with no recorded outcome — never started, or still in flight — reports `unverifiable`,
+ * the same verdict as an attempted close that stayed unproven. Chosen, not conflated: the vocabulary is `live` / `unverifiable` / `exited` with no
+ * synonyms, and "we never asked" and "we asked and could not confirm" are both exactly "not
+ * observed exited". A fourth bucket would need its own refusal wording and its own toast
+ * classification for a distinction the user cannot act on any differently — and `live` is the only
+ * verdict either could be mistaken for, which is the one thing neither is allowed to claim.
+ */
+export function unclosedStructuredSessions(
+  progress: StructuredSweepProgress
+): UnclosedStructuredSession[] {
+  return [
+    ...progress.unstopped,
+    ...progress.sessions
+      .slice(progress.settled)
+      .map((session) => ({ ...session, status: 'unverifiable' as const }))
+  ]
+}
+
+/**
+ * Closes the structured sessions in `progress`, recording what stayed as it goes.
  *
  * Runs on the ordinary removal too, not just force: a child left running against a deleted `cwd` is
  * the outcome this whole sweep exists to prevent, and closing is how you prevent it. What stayed is
@@ -159,38 +214,46 @@ export function describeUnclosedStructuredSessions(
  * let the refusal name a session this call never touched.
  */
 export async function closeStructuredSessionsForWorktree(
-  sessions: readonly LiveStructuredSessionInWorkspace[],
+  progress: StructuredSweepProgress,
+  deadline: number,
   runtime?: StructuredWorktreeSweepRuntime
-): Promise<{ closed: number; unstopped: UnclosedStructuredSession[] }> {
+): Promise<void> {
   // No `afterClose` for a dispatched worker: `host.close` drops the holds, so nothing keeps a
   // provider child un-evictable, but the dispatch's redrive subscription and registry entry do
   // survive until it settles by another verb. That is a bounded leak, not a hazard — and passing
   // one here would mean resolving a dispatch id per session on a teardown path that must stay
   // inside the sweep deadline.
-  const unstopped: UnclosedStructuredSession[] = []
-  let closed = 0
-  for (const session of sessions) {
+  for (const session of progress.sessions) {
+    // Stops ISSUING new closes once the budget is spent; an in-flight one is left to finish, since
+    // nothing here can cancel a provider round trip. Without this, one slow round trip starved
+    // every session behind it: the caller's race had already given up, and the loop went on
+    // closing sessions whose outcome nobody would read.
+    if (Date.now() >= deadline) {
+      return
+    }
     const outcome = await closeStructuredAgentSessionChild(
       session.sessionId,
       runtime ? { runtime } : {}
     )
     if (outcome.stopped) {
-      closed += 1
-      continue
+      progress.closed += 1
+    } else {
+      // Re-observed rather than reusing the close's own reason string: what the user is asked to
+      // waive is the state AFTER the attempt, and a close that threw never reached an observation.
+      const status = observeStructuredWorker({ sessionId: session.sessionId }).status
+      if (status === 'exited') {
+        // The re-read can PROVE the exit a failed close could not — it threw past its own
+        // observation, or the record's death evidence landed after it read. Refusing on a child
+        // that is demonstrably gone is the defect this sweep exists to remove, so take the proof
+        // and run the retirement `closeStructuredAgentSessionChild` skipped when it gave up.
+        retireSettledStructuredWorkerTab(session.sessionId, runtime)
+        progress.closed += 1
+      } else {
+        progress.unstopped.push({ ...session, status })
+      }
     }
-    // Re-observed rather than reusing the close's own reason string: what the user is asked to
-    // waive is the state AFTER the attempt, and a close that threw never reached an observation.
-    const status = observeStructuredWorker({ sessionId: session.sessionId }).status
-    if (status === 'exited') {
-      // The re-read can PROVE the exit a failed close could not — it threw past its own
-      // observation, or the record's death evidence landed after it read. Refusing on a child
-      // that is demonstrably gone is the defect this sweep exists to remove, so take the proof
-      // and run the retirement `closeStructuredAgentSessionChild` skipped when it gave up.
-      retireSettledStructuredWorkerTab(session.sessionId, runtime)
-      closed += 1
-      continue
-    }
-    unstopped.push({ ...session, status })
+    // Advanced only once an outcome is recorded, so a close still in flight when the deadline
+    // lands stays reported as unclosed instead of falling out of both counts.
+    progress.settled += 1
   }
-  return { closed, unstopped }
 }

--- a/src/main/runtime/structured-session-worktree-teardown.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.ts
@@ -29,6 +29,7 @@ import { STILL_LIVE_DETAIL_PREFIX } from '../../shared/worktree/removal'
 import { getStructuredAgentSessionHost } from '../native-chat/agent-session-wire/structured-agent-session-registry'
 import { observeStructuredWorker } from './structured-worker-authority'
 import { closeStructuredAgentSessionChild } from './structured-agent-session-close'
+import { retireSettledStructuredWorkerTab } from './structured-agent-session-tab-retirement'
 import type { OrcaRuntimeService } from './orca-runtime'
 
 export type LiveStructuredSessionInWorkspace = {
@@ -165,7 +166,16 @@ export async function closeStructuredSessionsForWorktree(
     // Re-observed rather than reusing the close's own reason string: what the user is asked to
     // waive is the state AFTER the attempt, and a close that threw never reached an observation.
     const status = observeStructuredWorker({ sessionId: session.sessionId }).status
-    unstopped.push({ ...session, status: status === 'live' ? 'live' : 'unverifiable' })
+    if (status === 'exited') {
+      // The re-read can PROVE the exit a failed close could not — it threw past its own
+      // observation, or the record's death evidence landed after it read. Refusing on a child
+      // that is demonstrably gone is the defect this sweep exists to remove, so take the proof
+      // and run the retirement `closeStructuredAgentSessionChild` skipped when it gave up.
+      retireSettledStructuredWorkerTab(session.sessionId, runtime)
+      closed += 1
+      continue
+    }
+    unstopped.push({ ...session, status })
   }
   return { closed, unstopped }
 }

--- a/src/main/runtime/structured-session-worktree-teardown.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.ts
@@ -11,7 +11,12 @@
  * Membership is `location.workspaceId`, which every structured session carries — so this covers a
  * plain chat session in the worktree as well as a dispatched worker. Liveness is
  * `observeStructuredWorker`, the same `live` / `unverifiable` / `exited` vocabulary the rest of the
- * structured surface uses; only a PROVEN live child is worth refusing a removal over.
+ * structured surface uses.
+ *
+ * `live` here is lease state — a provider child is attached — not work in flight, so it says
+ * nothing about whether the user would lose anything. It selects what to CLOSE, never what to
+ * refuse over: a removal refuses only on a close that did not settle, exactly as the PTY sweep
+ * refuses only on a stop it could not verify.
  */
 
 import { getStructuredAgentSessionHost } from '../native-chat/agent-session-wire/structured-agent-session-registry'
@@ -77,8 +82,9 @@ export function describeLiveStructuredSessions(
 /**
  * Closes every live structured session in the worktree, and reports what stayed.
  *
- * Force is the documented escape hatch, so it closes rather than orphaning: a child left running
- * against a deleted `cwd` is the exact outcome this whole sweep exists to prevent.
+ * Runs on the ordinary removal too, not just force: a child left running against a deleted `cwd` is
+ * the outcome this whole sweep exists to prevent, and closing is how you prevent it. What stayed is
+ * the only thing worth refusing over.
  */
 export async function closeStructuredSessionsForWorktree(
   worktreeId: string,

--- a/src/main/runtime/structured-session-worktree-teardown.ts
+++ b/src/main/runtime/structured-session-worktree-teardown.ts
@@ -108,28 +108,43 @@ export function listLiveStructuredSessionsForWorktree(
 }
 
 /**
- * Counts, providers and the post-close verdict — never session ids.
+ * A count and its providers — never session ids.
  *
  * A session id is one tab-id hop from the random pane key that gates a worker's mailbox, and this
  * string reaches agent-readable CLI output and a desktop toast. The count and the providers are
  * what a user deciding whether to force actually needs; the ids identify nothing they can act on.
+ */
+function countStructuredSessions(sessions: readonly UnclosedStructuredSession[]): string {
+  const noun = sessions.length === 1 ? 'agent session' : 'agent sessions'
+  const providers = [...new Set(sessions.map((session) => session.agent))].sort().join(', ')
+  return `${sessions.length} ${noun} (${providers})`
+}
+
+/**
+ * The two post-close verdicts, each with its own count.
  *
- * The verdict is here for the reason `describeUnstoppedPtys` carries one: "we watched it stay
+ * The split is here for the reason `describeUnstoppedPtys` carries one: "we watched it stay
  * attached" and "we could not confirm it went" are different decisions to waive, and the delete
- * toast branches on this marker. Any proven-live session makes the whole refusal a live one, as it
- * does for PTYs — that is the stronger warning, and the one whose work is about to be discarded.
+ * toast branches on the marker a proven-live session leads with.
+ *
+ * Both groups are named, though, which is where this differs from the PTY sibling: there, the
+ * verdict is a fresh inventory, so anything absent from the live list is PROVEN exited and
+ * rightly dropped. Here an `unverifiable` session is unclosed too — folding it into the live
+ * count would overstate what Orca watched, and dropping it said "1 agent session" while three
+ * were about to be discarded.
  */
 export function describeUnclosedStructuredSessions(
   sessions: readonly UnclosedStructuredSession[]
 ): string {
   const stillLive = sessions.filter((session) => session.status === 'live')
-  const named = stillLive.length > 0 ? stillLive : sessions
-  const noun = named.length === 1 ? 'agent session' : 'agent sessions'
-  const providers = [...new Set(named.map((session) => session.agent))].sort().join(', ')
-  const summary = `${named.length} ${noun} (${providers})`
-  return stillLive.length > 0
-    ? `${STILL_LIVE_DETAIL_PREFIX} ${summary}`
-    : `could not confirm these closed: ${summary}`
+  const unconfirmed = sessions.filter((session) => session.status !== 'live')
+  if (stillLive.length === 0) {
+    return `could not confirm these closed: ${countStructuredSessions(unconfirmed)}`
+  }
+  const live = `${STILL_LIVE_DETAIL_PREFIX} ${countStructuredSessions(stillLive)}`
+  return unconfirmed.length === 0
+    ? live
+    : `${live}; could not confirm these closed: ${countStructuredSessions(unconfirmed)}`
 }
 
 /**

--- a/src/main/runtime/unstopped-pty-verification.ts
+++ b/src/main/runtime/unstopped-pty-verification.ts
@@ -2,7 +2,7 @@ import type { IPtyProvider } from '../providers/types'
 import type { OrcaRuntimeService } from './orca-runtime'
 import {
   UNSTOPPED_PTY_DETAIL_SEPARATOR,
-  UNSTOPPED_PTY_LIVE_DETAIL_PREFIX,
+  STILL_LIVE_DETAIL_PREFIX,
   UNSTOPPED_PTY_REMOVAL_PREFIX
 } from '../../shared/worktree/removal'
 import {
@@ -105,7 +105,7 @@ export function describeUnstoppedPtys(
 ): string {
   const detail =
     verdict.status === 'live'
-      ? `${UNSTOPPED_PTY_LIVE_DETAIL_PREFIX} ${verdict.ptyIds.join(', ')}`
+      ? `${STILL_LIVE_DETAIL_PREFIX} ${verdict.ptyIds.join(', ')}`
       : `could not verify these exited: ${failedPtyIds.join(', ')} (${verdict.reason})`
   return `${UNSTOPPED_PTY_REMOVAL_PREFIX} ${worktreeId}${UNSTOPPED_PTY_DETAIL_SEPARATOR}${detail}`
 }

--- a/src/main/runtime/worktree-pty-host-fence.ts
+++ b/src/main/runtime/worktree-pty-host-fence.ts
@@ -1,8 +1,14 @@
 export type WorktreePtyHostFence = {
+  /** `null` is this machine; ABSENT is no fence at all, so every host matches. */
   resolvedConnectionId?: string | null
   resolvedRuntimeEnvironmentId?: string
 }
 
+/**
+ * Also fences the structured sweep, through `structuredSessionTeardownHostId`, which reuses this
+ * exact type so the two cannot drift. That helper narrows ABSENT to local — the one deliberate
+ * difference, documented where it is made.
+ */
 export function worktreePtyBelongsToHost(
   ptyId: string,
   connectionId: string | null | undefined,

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -101,8 +101,8 @@ export async function killAllProcessesForWorktree(
   )
   // FIRST, and before a single PTY sweep starts: a structured agent session is registered on none
   // of the three surfaces below, so all three answered zero and removal deleted the checkout out
-  // from under a running provider child. Refusing costs nothing when there are none, and the check
-  // is synchronous, so a destructive removal fails fast instead of after the whole sweep budget.
+  // from under a running provider child. It returns immediately when there are none, and its own
+  // close is bounded by the same deadline the PTY sweeps share.
   const structuredStopped = await sweepStructuredSessions(worktreeId, deps, deadline, deadlineError)
   const sweeps = createWorktreeSweepTracker()
   const stopAttempts = new Map<string, Promise<boolean>>()
@@ -279,17 +279,18 @@ export async function killAllProcessesForWorktree(
 /**
  * The fourth sweep: structured agent sessions bound to this worktree.
  *
- * Refuses rather than auto-closing on the ordinary destructive path. `worktree rm` is the verb
- * that deletes a user's work, and a running agent session is exactly the thing they would want to
- * be told about before it goes — the same bargain the unstopped-PTY gate already strikes, using
- * the same `--force` escape hatch. Force closes them properly instead of orphaning a child against
- * a `cwd` that is about to disappear.
+ * Stops first and refuses only on unproven stops, which is the bargain the unstopped-PTY gate
+ * actually strikes: that gate kills every PTY — a terminal running an agent included — and refuses
+ * only for the ones whose exit it could not then verify. Refusing merely because a session is
+ * attached made an idle chat, which the user is done with, harder to delete than a terminal running
+ * the same agent. Attachment is lease state, not work in flight, so it was never the right proxy.
  *
- * Two callers participate, for different reasons. A proof-requiring removal (`requirePhysicalStop`)
- * refuses, then closes under force. A folder-workspace removal (`closeStructuredSessions`) closes
- * best-effort without refusing: it shares its root so no checkout vanishes under the child, and one
- * of those paths is a never-throw forget that a refusal would wedge. Reconciliation sweeps set
- * neither — they repair state, delete nothing, and must never close a session.
+ * Two callers participate. A proof-requiring removal (`requirePhysicalStop`) refuses when a close
+ * does not settle, so nothing deletes a checkout out from under a child that is still there. A
+ * folder-workspace removal (`closeStructuredSessions`) never refuses: it shares its root so no
+ * checkout vanishes under the child, and one of those paths is a never-throw forget that a refusal
+ * would wedge. Reconciliation sweeps set neither — they repair state, delete nothing, and must
+ * never close a session.
  */
 async function sweepStructuredSessions(
   worktreeId: string,
@@ -304,6 +305,19 @@ async function sweepStructuredSessions(
   if (live.length === 0) {
     return 0
   }
+  // Raced against the same sweep budget every PTY surface is bounded by: `host.close` awaits a
+  // provider round trip, and a wedged one would otherwise hang `worktree rm` forever with no
+  // timeout error at all. On expiry the sweep reports the timeout exactly as the PTY sweeps do
+  // rather than proceeding as if the sessions had closed.
+  const { closed, unstopped } = await settleBeforeDeadline(
+    () => closeStructuredSessionsForWorktree(worktreeId, deps.runtime),
+    { closed: 0, unstopped: live },
+    deadline,
+    deadlineError
+  )
+  if (unstopped.length === 0) {
+    return closed
+  }
   // Only a proof-requiring removal may refuse. A folder-workspace removal shares its root, so no
   // checkout disappears under the child — the harm is a session left pointing at a workspace Orca
   // has forgotten — and one of those paths is a never-throw forget, which a refusal would wedge.
@@ -311,25 +325,13 @@ async function sweepStructuredSessions(
     // The prefix is what the desktop classifier matches on; without it the toast shows raw CLI
     // wording and hides the Force Delete button — the #11960 dead end this file already documents.
     throw new Error(
-      `${RUNNING_AGENT_SESSION_REMOVAL_PREFIX} ${worktreeId}${UNSTOPPED_PTY_DETAIL_SEPARATOR}${describeLiveStructuredSessions(live)}. ${WORKTREE_TEARDOWN_FORCE_HINT}`
+      `${RUNNING_AGENT_SESSION_REMOVAL_PREFIX} ${worktreeId}${UNSTOPPED_PTY_DETAIL_SEPARATOR}${describeLiveStructuredSessions(unstopped)}. ${WORKTREE_TEARDOWN_FORCE_HINT}`
     )
   }
-  // Raced against the same sweep budget every PTY surface is bounded by: `host.close` awaits a
-  // provider round trip, and a wedged one would otherwise hang `worktree rm --force` forever with
-  // no timeout error at all. On expiry the force path reports the timeout exactly as the PTY
-  // sweeps do rather than proceeding as if the sessions had closed.
-  const { closed, unstopped } = await settleBeforeDeadline(
-    () => closeStructuredSessionsForWorktree(worktreeId, deps.runtime),
-    { closed: 0, unstopped: live },
-    deadline,
-    deadlineError
+  // Force is the documented escape hatch, so removal continues — but say so, because the child
+  // outliving its `cwd` is the failure this sweep exists to make visible.
+  console.warn(
+    `[worktree-teardown] forcing removal of ${worktreeId} with ${describeLiveStructuredSessions(unstopped)} still attached`
   )
-  if (unstopped.length > 0) {
-    // Force is the documented escape hatch, so removal continues — but say so, because the child
-    // outliving its `cwd` is the failure this sweep exists to make visible.
-    console.warn(
-      `[worktree-teardown] forcing removal of ${worktreeId} with ${describeLiveStructuredSessions(unstopped)} still attached`
-    )
-  }
   return closed
 }

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -15,8 +15,10 @@ import {
 } from './worktree-pty-surface-sweeps'
 import {
   closeStructuredSessionsForWorktree,
+  createStructuredSweepProgress,
   describeUnclosedStructuredSessions,
-  listLiveStructuredSessionsForWorktree
+  listLiveStructuredSessionsForWorktree,
+  unclosedStructuredSessions
 } from './structured-session-worktree-teardown'
 import {
   createWorktreeSweepTracker,
@@ -331,14 +333,18 @@ async function sweepStructuredSessions(
   // that is meant to clear it (#11960). A close that ran out of time is a session this removal
   // could not confirm closed, which is exactly what the branch below already words. Tracked so a
   // forced removal still waits out the abandoned-sweep grace before it deletes files.
-  const { closed, unstopped } = await settleBeforeDeadline(
-    sweeps.track(() => closeStructuredSessionsForWorktree(live, deps.runtime)),
-    {
-      closed: 0,
-      unstopped: live.map((session) => ({ ...session, status: 'unverifiable' as const }))
-    },
+  //
+  // The verdict is read off `progress`, which the serial loop fills as it goes, rather than off
+  // this call's result: the deadline can land mid-loop, and a fallback assembled here could only
+  // guess — it named every session, including the ones already closed, and reported zero closes.
+  const progress = createStructuredSweepProgress(live)
+  await settleBeforeDeadline(
+    sweeps.track(() => closeStructuredSessionsForWorktree(progress, deadline, deps.runtime)),
+    undefined,
     deadline
   )
+  const closed = progress.closed
+  const unstopped = unclosedStructuredSessions(progress)
   if (unstopped.length === 0) {
     return closed
   }

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -15,10 +15,14 @@ import {
 } from './worktree-pty-surface-sweeps'
 import {
   closeStructuredSessionsForWorktree,
-  describeLiveStructuredSessions,
+  describeUnclosedStructuredSessions,
   listLiveStructuredSessionsForWorktree
 } from './structured-session-worktree-teardown'
-import { createWorktreeSweepTracker, settleSweepsForForcedRemoval } from './forced-sweep-settlement'
+import {
+  createWorktreeSweepTracker,
+  settleSweepsForForcedRemoval,
+  type WorktreeSweepTracker
+} from './forced-sweep-settlement'
 import {
   describeError,
   describeFailedPtySweep,
@@ -57,7 +61,7 @@ export type WorktreeTeardownResult = {
   runtimeStopped: number
   providerStopped: number
   registryStopped: number
-  /** Structured agent sessions closed by the force path; absent when none were found. */
+  /** Structured agent sessions this teardown closed; absent when it closed none. */
   structuredStopped?: number
 }
 
@@ -99,12 +103,18 @@ export async function killAllProcessesForWorktree(
   const deadlineError = new Error(
     `${WORKTREE_TEARDOWN_TIMEOUT_PREFIX} ${worktreeId}. ${WORKTREE_TEARDOWN_FORCE_HINT}`
   )
-  // FIRST, and before a single PTY sweep starts: a structured agent session is registered on none
-  // of the three surfaces below, so all three answered zero and removal deleted the checkout out
-  // from under a running provider child. It returns immediately when there are none, and its own
-  // close is bounded by the same deadline the PTY sweeps share.
-  const structuredStopped = await sweepStructuredSessions(worktreeId, deps, deadline, deadlineError)
   const sweeps = createWorktreeSweepTracker()
+  // ISSUED first, before a single PTY is touched: a structured agent session is registered on none
+  // of the three surfaces below, so all three answered zero and removal deleted the checkout out
+  // from under a running provider child. Asking the agent plane ahead of the terminal plane also
+  // keeps an intentional stop from reading as a failed process exit.
+  //
+  // Not AWAITED first, though. Its close is serial and each one waits on a provider round trip, so
+  // awaiting here would spend the shared budget before a single PTY was asked — and the sweeps
+  // would then report a timeout for a stop they never attempted. It is joined below, ahead of the
+  // PTY verdict, so a structured refusal still outranks one.
+  const structuredSweep = sweepStructuredSessions(worktreeId, deps, deadline, sweeps)
+  void structuredSweep.catch(() => undefined)
   const stopAttempts = new Map<string, Promise<boolean>>()
   const stopPty = (
     ptyId: string,
@@ -196,6 +206,7 @@ export async function killAllProcessesForWorktree(
   for (const sweep of [runtimeSweep, providerSweep, registrySweep]) {
     void sweep.catch(() => undefined)
   }
+  const structuredStopped = await structuredSweep
   let runtimeResult: { stopped: number }
   let providerStopped: number
   let registryStopped: number
@@ -277,7 +288,7 @@ export async function killAllProcessesForWorktree(
 }
 
 /**
- * The fourth sweep: structured agent sessions bound to this worktree.
+ * The fourth sweep: structured agent sessions bound to this worktree, on this host.
  *
  * Stops first and refuses only on unproven stops, which is the bargain the unstopped-PTY gate
  * actually strikes: that gate kills every PTY — a terminal running an agent included — and refuses
@@ -288,50 +299,60 @@ export async function killAllProcessesForWorktree(
  * Two callers participate. A proof-requiring removal (`requirePhysicalStop`) refuses when a close
  * does not settle, so nothing deletes a checkout out from under a child that is still there. A
  * folder-workspace removal (`closeStructuredSessions`) never refuses: it shares its root so no
- * checkout vanishes under the child, and one of those paths is a never-throw forget that a refusal
- * would wedge. Reconciliation sweeps set neither — they repair state, delete nothing, and must
- * never close a session.
+ * checkout vanishes under the child, and every one of those call sites discards a rejection, so a
+ * refusal there would be words nobody reads. Reconciliation sweeps set neither — they repair state,
+ * delete nothing, and must never close a session.
  */
 async function sweepStructuredSessions(
   worktreeId: string,
   deps: WorktreeTeardownDeps,
   deadline: number,
-  deadlineError: Error
+  sweeps: WorktreeSweepTracker
 ): Promise<number> {
   if (!deps.requirePhysicalStop && !deps.closeStructuredSessions) {
     return 0
   }
-  const live = listLiveStructuredSessionsForWorktree(worktreeId)
+  // `deps` carries the same two host fields the PTY sweeps fence on, and a `repoId::path` id names
+  // a different workspace on every host — so an unfenced list would close a live chat belonging to
+  // an SSH or paired-runtime copy of the id being removed here.
+  const live = listLiveStructuredSessionsForWorktree(worktreeId, deps)
   if (live.length === 0) {
     return 0
   }
-  // Raced against the same sweep budget every PTY surface is bounded by: `host.close` awaits a
-  // provider round trip, and a wedged one would otherwise hang `worktree rm` forever with no
-  // timeout error at all. On expiry the sweep reports the timeout exactly as the PTY sweeps do
-  // rather than proceeding as if the sessions had closed.
+  // Raced against the same sweep budget every PTY surface is bounded by, because `host.close`
+  // awaits a provider round trip whose own eviction steps are each bounded well past this budget.
+  //
+  // Deliberately NOT fail-closed, unlike the PTY sweeps: their timeout sentinel carries the PTY
+  // timeout prefix, which the desktop classifier reads as a TERMINAL failure — so a wedged session
+  // close would refuse in terminal wording, and refuse identically again under the Force Delete
+  // that is meant to clear it (#11960). A close that ran out of time is a session this removal
+  // could not confirm closed, which is exactly what the branch below already words. Tracked so a
+  // forced removal still waits out the abandoned-sweep grace before it deletes files.
   const { closed, unstopped } = await settleBeforeDeadline(
-    () => closeStructuredSessionsForWorktree(worktreeId, deps.runtime),
-    { closed: 0, unstopped: live },
-    deadline,
-    deadlineError
+    sweeps.track(() => closeStructuredSessionsForWorktree(live, deps.runtime)),
+    {
+      closed: 0,
+      unstopped: live.map((session) => ({ ...session, status: 'unverifiable' as const }))
+    },
+    deadline
   )
   if (unstopped.length === 0) {
     return closed
   }
   // Only a proof-requiring removal may refuse. A folder-workspace removal shares its root, so no
   // checkout disappears under the child — the harm is a session left pointing at a workspace Orca
-  // has forgotten — and one of those paths is a never-throw forget, which a refusal would wedge.
+  // has forgotten — and every one of those callers discards a rejection anyway.
   if (deps.requirePhysicalStop && !deps.allowUnverifiedStop) {
     // The prefix is what the desktop classifier matches on; without it the toast shows raw CLI
     // wording and hides the Force Delete button — the #11960 dead end this file already documents.
     throw new Error(
-      `${RUNNING_AGENT_SESSION_REMOVAL_PREFIX} ${worktreeId}${UNSTOPPED_PTY_DETAIL_SEPARATOR}${describeLiveStructuredSessions(unstopped)}. ${WORKTREE_TEARDOWN_FORCE_HINT}`
+      `${RUNNING_AGENT_SESSION_REMOVAL_PREFIX} ${worktreeId}${UNSTOPPED_PTY_DETAIL_SEPARATOR}${describeUnclosedStructuredSessions(unstopped)}. ${WORKTREE_TEARDOWN_FORCE_HINT}`
     )
   }
   // Force is the documented escape hatch, so removal continues — but say so, because the child
   // outliving its `cwd` is the failure this sweep exists to make visible.
   console.warn(
-    `[worktree-teardown] forcing removal of ${worktreeId} with ${describeLiveStructuredSessions(unstopped)} still attached`
+    `[worktree-teardown] forcing removal of ${worktreeId} with ${describeUnclosedStructuredSessions(unstopped)} still attached`
   )
   return closed
 }

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -339,7 +339,13 @@ async function sweepStructuredSessions(
   // guess — it named every session, including the ones already closed, and reported zero closes.
   const progress = createStructuredSweepProgress(live)
   await settleBeforeDeadline(
-    sweeps.track(() => closeStructuredSessionsForWorktree(progress, deadline, deps.runtime)),
+    sweeps.track(() =>
+      closeStructuredSessionsForWorktree(progress, deadline, {
+        ...(deps.runtime ? { runtime: deps.runtime } : {}),
+        // The only shape of removal that can leave this workspace — and its chat tabs — in place.
+        mayRefuse: Boolean(deps.requirePhysicalStop) && !deps.allowUnverifiedStop
+      })
+    ),
     undefined,
     deadline
   )

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -353,9 +353,12 @@ async function sweepStructuredSessions(
     )
   }
   // Force is the documented escape hatch, so removal continues — but say so, because the child
-  // outliving its `cwd` is the failure this sweep exists to make visible.
+  // outliving its `cwd` is the failure this sweep exists to make visible. Carries the verdict
+  // verbatim, like the unstopped-PTY warn above: this line is the only record a forced removal
+  // leaves, and appending "still attached" asserted the live verdict over sessions the sweep had
+  // just said it could not confirm either way.
   console.warn(
-    `[worktree-teardown] forcing removal of ${worktreeId} with ${describeUnclosedStructuredSessions(unstopped)} still attached`
+    `[worktree-teardown] forcing removal of ${worktreeId}${UNSTOPPED_PTY_DETAIL_SEPARATOR}${describeUnclosedStructuredSessions(unstopped)}`
   )
   return closed
 }

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -218,7 +218,10 @@ export async function killAllProcessesForWorktree(
       deadlineError
     )
     if (forced.incomplete) {
-      return forced.stopped
+      // Carries the structured count out too: this early return skips the PTY verdict, not the
+      // sweep that already closed a user's chats, and dropping it makes the log say `structured=0`
+      // for a removal that closed some.
+      return { ...forced.stopped, ...(structuredStopped > 0 ? { structuredStopped } : {}) }
     }
     runtimeResult = { stopped: forced.stopped.runtimeStopped }
     providerStopped = forced.stopped.providerStopped

--- a/src/renderer/src/components/native-chat/structured-agent-session-read-owner.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-read-owner.ts
@@ -5,6 +5,7 @@ import {
   AGENT_SESSION_HISTORY_MAX_LIMIT,
   type AgentSessionHistoryResult
 } from '../../../../shared/agent-session-wire'
+import { isUnattachedAgentSessionReadRefusal } from '../../../../shared/structured-agent-session-read-refusal'
 import {
   EMPTY_STRUCTURED_AGENT_SESSION,
   oldestStructuredAgentSessionCursor,
@@ -230,7 +231,10 @@ function createReadOwner(
           apply({ type: 'older-page', requestedEpoch: cursor.epoch, page: result.page })
         }
       } catch (error) {
-        if (!shouldStop()) {
+        // An unattached session is the live transport's subject, not this page's: it re-asks and
+        // decides. A page that refused that way must not put the pane in an error state the
+        // transport is about to clear.
+        if (!shouldStop() && !isUnattachedAgentSessionReadRefusal(error)) {
           apply({ type: 'error', message: String(error) })
         }
       } finally {

--- a/src/renderer/src/components/native-chat/structured-agent-session-read-transport.test.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-read-transport.test.ts
@@ -133,3 +133,154 @@ describe('structured agent-session read transport generations', () => {
     }
   })
 })
+
+// The refusal a host raises for a session it holds no object for — after a chat close, or before
+// the surface's hold attaches one. Deleting a workspace closes its chats while the pane is still
+// mounted, so this landed on screen as `Could not load conversation` for the frames before the tab
+// retired.
+const UNATTACHED = 'agent_session_ownership_unknown'
+
+describe('structured agent-session read transport unattached refusals', () => {
+  const attempts: SubscribeAttempt[] = []
+
+  beforeEach(() => {
+    attempts.length = 0
+    vi.clearAllMocks()
+    mocks.subscribe.mockImplementation((_target, _params, onEvent, onError, onClose) => {
+      const attempt: SubscribeAttempt = {
+        closed: Promise.withResolvers<{ unsubscribe: () => void }>(),
+        onClose,
+        onError,
+        onEvent,
+        unsubscribe: vi.fn<() => void>()
+      }
+      attempts.push(attempt)
+      return attempt.closed.promise
+    })
+  })
+
+  function startWithTail(
+    refreshTail: () => Promise<void>,
+    applyError: (message: string) => void,
+    applyEvent = vi.fn()
+  ) {
+    return startStructuredAgentSessionReadTransport({
+      applyEvent,
+      applyError,
+      getCursor: () => null,
+      onHistoryReadInvalidated: () => undefined,
+      refreshTail,
+      sessionId: 'session-a',
+      target
+    })
+  }
+
+  function rpcRefusal(code: string): Error & { code: string } {
+    const error = new Error(code) as Error & { code: string }
+    error.name = 'RuntimeRpcCallError'
+    error.code = code
+    return error
+  }
+
+  it('keeps an unattached history refusal off the pane and retries instead', async () => {
+    vi.useFakeTimers()
+    try {
+      const applyError = vi.fn()
+      const transport = startWithTail(async () => {
+        throw rpcRefusal(UNATTACHED)
+      }, applyError)
+      await flushPromises()
+      expect(applyError).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(750)
+      expect(attempts).toHaveLength(1)
+      transport.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('surfaces an unattached refusal that outlives the grace window', async () => {
+    vi.useFakeTimers()
+    try {
+      const applyError = vi.fn()
+      const transport = startWithTail(async () => {
+        throw rpcRefusal(UNATTACHED)
+      }, applyError)
+      await flushPromises()
+      expect(applyError).not.toHaveBeenCalled()
+
+      // Every reconnect re-asks and refuses the same way. Nothing reaches the pane inside the
+      // window a teardown or a pending hold could explain...
+      for (let elapsed = 0; elapsed < 4_500; elapsed += 750) {
+        await vi.advanceTimersByTimeAsync(750)
+        attempts.at(-1)?.onError(rpcRefusal(UNATTACHED))
+      }
+      expect(applyError).not.toHaveBeenCalled()
+
+      // ...and the failure is owed once it has passed.
+      await vi.advanceTimersByTimeAsync(750)
+      attempts.at(-1)?.onError(rpcRefusal(UNATTACHED))
+      expect(applyError).toHaveBeenCalledWith(`RuntimeRpcCallError: ${UNATTACHED}`)
+      transport.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reports an unrelated read failure immediately', async () => {
+    vi.useFakeTimers()
+    try {
+      const applyError = vi.fn()
+      const transport = startWithTail(async () => {
+        throw new Error('journal read failed')
+      }, applyError)
+      await flushPromises()
+      expect(applyError).toHaveBeenCalledExactlyOnceWith('Error: journal read failed')
+      transport.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('classifies the raw refusal payload a stream delivers to its error callback', async () => {
+    vi.useFakeTimers()
+    try {
+      const applyError = vi.fn()
+      const transport = startWithTail(async () => undefined, applyError)
+      await flushPromises()
+      expect(attempts).toHaveLength(1)
+
+      attempts[0].onError({ code: UNATTACHED, message: UNATTACHED })
+      expect(applyError).not.toHaveBeenCalled()
+
+      attempts[0].onError({ code: 'runtime_error', message: 'transport died' })
+      expect(applyError).toHaveBeenCalledOnce()
+      transport.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('restarts the grace once a read lands, so a later refusal is transitional again', async () => {
+    vi.useFakeTimers()
+    try {
+      const applyError = vi.fn()
+      const applyEvent = vi.fn()
+      const transport = startWithTail(async () => undefined, applyError, applyEvent)
+      await flushPromises()
+      expect(attempts).toHaveLength(1)
+
+      attempts[0].onError({ code: UNATTACHED, message: UNATTACHED })
+      await vi.advanceTimersByTimeAsync(6_000)
+      attempts.at(-1)?.onEvent(snapshot(1))
+      expect(applyEvent).toHaveBeenCalled()
+
+      attempts.at(-1)?.onError({ code: UNATTACHED, message: UNATTACHED })
+      expect(applyError).not.toHaveBeenCalled()
+      transport.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/src/components/native-chat/structured-agent-session-read-transport.ts
+++ b/src/renderer/src/components/native-chat/structured-agent-session-read-transport.ts
@@ -1,6 +1,10 @@
 import type { AgentJournalCursor } from '../../../../shared/agent-session-journal-types'
 import type { AgentSessionSubscribeEvent } from '../../../../shared/agent-session-wire'
 import { createStructuredAgentSessionEventCoalescer } from '../../../../shared/structured-agent-session-coalescer'
+import {
+  AGENT_SESSION_UNATTACHED_READ_GRACE_MS,
+  isUnattachedAgentSessionReadRefusal
+} from '../../../../shared/structured-agent-session-read-refusal'
 import { shouldAdvanceStructuredResumeCursor } from '../../../../shared/structured-agent-session-reducer'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import { subscribeStructuredAgentSession } from '@/runtime/structured-agent-session-client'
@@ -43,6 +47,7 @@ export function startStructuredAgentSessionReadTransport(args: {
 } {
   let stopped = false
   let connected = false
+  let unattachedSince: number | null = null
   let opening = false
   let openGeneration = 0
   let stateGeneration = 0
@@ -60,6 +65,32 @@ export function startStructuredAgentSessionReadTransport(args: {
   })
   const isCurrentOpenGeneration = (candidate: number): boolean =>
     !stopped && candidate === openGeneration
+  const clearUnattachedReadGrace = (): void => {
+    unattachedSince = null
+  }
+  /**
+   * A read failure, reported to the pane only once it is one.
+   *
+   * A refusal saying this host holds no attached session is the retry loop's own subject, not a
+   * verdict: the reconnect below re-asks, and either the hold that attaches the session or the tab
+   * retirement that ends the pane resolves it. Painting the pane red inside that window turned an
+   * ordinary chat close into a `Could not load conversation` the user could do nothing about.
+   *
+   * A window, not a mute. An unattached read still refusing past the grace is no longer
+   * transitional, so the pane is owed the failure rather than a spinner that never resolves.
+   */
+  const reportReadFailure = (error: unknown): void => {
+    if (!isUnattachedAgentSessionReadRefusal(error)) {
+      clearUnattachedReadGrace()
+      args.applyError(String(error))
+      return
+    }
+    const now = Date.now()
+    unattachedSince ??= now
+    if (now - unattachedSince >= AGENT_SESSION_UNATTACHED_READ_GRACE_MS) {
+      args.applyError(String(error))
+    }
+  }
   const captureHistoryReadGuard = (): (() => boolean) => {
     const readOpenGeneration = openGeneration
     const readStateGeneration = stateGeneration
@@ -70,6 +101,7 @@ export function startStructuredAgentSessionReadTransport(args: {
     if (!isCurrentOpenGeneration(eventOpenGeneration)) {
       return
     }
+    clearUnattachedReadGrace()
     if (event.type === 'snapshot' || event.type === 'reset') {
       coalescer.flush()
       if (!isCurrentOpenGeneration(eventOpenGeneration)) {
@@ -126,7 +158,7 @@ export function startStructuredAgentSessionReadTransport(args: {
           }
           closedDuringOpen = true
           connected = false
-          args.applyError(String(error))
+          reportReadFailure(error)
           reconnectScheduler.schedule()
         },
         () => {
@@ -152,7 +184,7 @@ export function startStructuredAgentSessionReadTransport(args: {
         return
       }
       connected = false
-      args.applyError(String(error))
+      reportReadFailure(error)
       reconnectScheduler.schedule()
     } finally {
       if (currentOpenGeneration === openGeneration) {
@@ -168,6 +200,7 @@ export function startStructuredAgentSessionReadTransport(args: {
         if (shouldStop()) {
           return
         }
+        clearUnattachedReadGrace()
         resumeCursor = args.getCursor()
         if (!connected) {
           reconnectScheduler.schedule(0)
@@ -175,7 +208,7 @@ export function startStructuredAgentSessionReadTransport(args: {
       })
       .catch((error) => {
         if (!shouldStop()) {
-          args.applyError(String(error))
+          reportReadFailure(error)
         }
       })
   }
@@ -186,12 +219,13 @@ export function startStructuredAgentSessionReadTransport(args: {
       if (shouldStopInitialRead()) {
         return
       }
+      clearUnattachedReadGrace()
       resumeCursor = args.getCursor()
       return open()
     })
     .catch((error) => {
       if (!shouldStopInitialRead()) {
-        args.applyError(String(error))
+        reportReadFailure(error)
         reconnectScheduler.schedule()
       }
     })

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-read.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-read.test.tsx
@@ -399,3 +399,52 @@ describe('useStructuredAgentSessionRead history window', () => {
     expect(unsubscribe).toHaveBeenCalledTimes(2)
   })
 })
+
+// A workspace delete closes its structured chats while the pane is still mounted, so every read
+// against that session refuses `agent_session_ownership_unknown` until the tab retires. A page that
+// lost that race must not leave the pane holding an error the live transport is about to clear.
+describe('useStructuredAgentSessionRead unattached page refusals', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetStructuredAgentSessionReadOwnersForTests()
+    mocks.subscribe.mockResolvedValue({ unsubscribe: vi.fn() })
+  })
+
+  function refusal(code: string): Error & { code: string } {
+    const error = new Error(code) as Error & { code: string }
+    error.name = 'RuntimeRpcCallError'
+    error.code = code
+    return error
+  }
+
+  async function loadedTailThatRefusesOlder(error: Error) {
+    const tailItems = Array.from({ length: 300 }, (_, index) =>
+      message(`tail-${index}`, 301 + index, 'assistant')
+    )
+    mocks.call
+      .mockResolvedValueOnce({ ok: true, page: page('tail', tailItems, true) })
+      .mockRejectedValueOnce(error)
+    const { result } = renderHook(() =>
+      useStructuredAgentSessionRead({ sessionId: 'session-a', target: LOCAL_TARGET })
+    )
+    await waitFor(() => expect(result.current.state.hasOlder).toBe(true))
+    await act(async () => result.current.loadOlder())
+    return result
+  }
+
+  it('leaves the transcript alone when an older page hits a closed session', async () => {
+    const result = await loadedTailThatRefusesOlder(refusal('agent_session_ownership_unknown'))
+    expect(result.current.state.status).not.toBe('error')
+    expect(result.current.state.error).toBeUndefined()
+    expect(result.current.state.items).toHaveLength(300)
+    expect(result.current.loadingOlder).toBe(false)
+  })
+
+  it('still reports an older page that failed for any other reason', async () => {
+    const result = await loadedTailThatRefusesOlder(new Error('journal read failed'))
+    expect(result.current.state.status).toBe('error')
+    expect(result.current.state.error).toBe('Error: journal read failed')
+  })
+})

--- a/src/renderer/src/components/sidebar/delete-worktree-toast.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-toast.test.ts
@@ -50,6 +50,39 @@ describe('getDeleteWorktreeToastCopy', () => {
     })
   })
 
+  // Why: the structured sweep now CLOSES an attached session on the ordinary delete, so reaching
+  // this toast means the close was attempted and did not settle — not that Orca declined to try.
+  it('offers force delete when an agent session could not be confirmed closed', () => {
+    expect(
+      toastCopyForRemovalError(
+        'feature/foo',
+        'Refusing to remove worktree with running agent sessions: repo-1::/w — could not confirm these closed: 1 agent session (claude). Retry with force delete (--force) to remove it anyway.'
+      )
+    ).toEqual({
+      title: 'Failed to delete workspace feature/foo',
+      description:
+        'Orca could not confirm every agent session in this workspace has closed, so it stopped before deleting any files. Use Force Delete to remove it anyway.',
+      isDestructive: false
+    })
+  })
+
+  // Why: the same split the PTY pair above draws. Force Delete proceeds either way, and telling a
+  // user "could not confirm" about a conversation Orca watched stay attached asks them to waive a
+  // doubt that does not exist — the work in that conversation goes with the delete.
+  it('names the running agent sessions when the close left them attached', () => {
+    expect(
+      toastCopyForRemovalError(
+        'feature/foo',
+        'Refusing to remove worktree with running agent sessions: repo-1::/w — still live: 2 agent sessions (claude, codex). Retry with force delete (--force) to remove it anyway.'
+      )
+    ).toEqual({
+      title: 'Failed to delete workspace feature/foo',
+      description:
+        'This workspace still has running agent sessions that Orca could not close, so it stopped before deleting any files. Force Delete will discard any work they hold.',
+      isDestructive: false
+    })
+  })
+
   // Why: a sweep that never answered wedges removal the same way, and the waiver clears
   // both — so it must reach the same force affordance instead of a dead end.
   it('offers force delete when the teardown sweep itself timed out', () => {

--- a/src/renderer/src/components/sidebar/delete-worktree-toast.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-toast.ts
@@ -81,12 +81,12 @@ export function getDeleteWorktreeToastCopy(
           'Failed to delete workspace {{value0}}',
           { value0: worktreeName }
         ),
-        // Why this is not the "could not confirm" wording: Orca watched these sessions stay
-        // attached, so there is no doubt to waive — Force Delete ends a conversation that is
-        // running right now, and any work it holds goes with it.
+        // Why this is the "could not confirm" wording: an ordinary delete already closed these
+        // sessions, so reaching here means the close did not settle — the same doubt the
+        // unverified-PTY case asks the user to waive, not a session Orca declined to close.
         description: translate(
           'auto.components.sidebar.delete.worktree.toast.runningAgentSession',
-          'This workspace still has running agent sessions, so Orca stopped before deleting any files. Force Delete will close them and discard any work they hold.'
+          'Orca could not confirm every agent session in this workspace has closed, so it stopped before deleting any files. Use Force Delete to remove it anyway.'
         ),
         isDestructive: false
       }

--- a/src/renderer/src/components/sidebar/delete-worktree-toast.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-toast.ts
@@ -2,6 +2,7 @@ import { translate } from '@/i18n/i18n'
 import {
   isLockedWorktreeRemovalError,
   isProvenLivePtyRemovalError,
+  isProvenLiveStructuredSessionRemovalError,
   type WorktreeForceDeleteReason
 } from '../../../../shared/worktree/removal'
 export type DeleteWorktreeToastCopy = {
@@ -81,13 +82,19 @@ export function getDeleteWorktreeToastCopy(
           'Failed to delete workspace {{value0}}',
           { value0: worktreeName }
         ),
-        // Why this is the "could not confirm" wording: an ordinary delete already closed these
-        // sessions, so reaching here means the close did not settle — the same doubt the
-        // unverified-PTY case asks the user to waive, not a session Orca declined to close.
-        description: translate(
-          'auto.components.sidebar.delete.worktree.toast.runningAgentSession',
-          'Orca could not confirm every agent session in this workspace has closed, so it stopped before deleting any files. Use Force Delete to remove it anyway.'
-        ),
+        // Why two branches, like the PTY pair above: an ordinary delete already tried to close
+        // these sessions, and only the observation AFTER that attempt separates one Orca watched
+        // stay attached from one it simply could not reach. Telling the first user "could not
+        // confirm" asks them to waive a doubt that does not exist, and a conversation dies with it.
+        description: isProvenLiveStructuredSessionRemovalError(error)
+          ? translate(
+              'auto.components.sidebar.delete.worktree.toast.runningAgentSessionLive',
+              'This workspace still has running agent sessions that Orca could not close, so it stopped before deleting any files. Force Delete will discard any work they hold.'
+            )
+          : translate(
+              'auto.components.sidebar.delete.worktree.toast.runningAgentSession',
+              'Orca could not confirm every agent session in this workspace has closed, so it stopped before deleting any files. Use Force Delete to remove it anyway.'
+            ),
         isDestructive: false
       }
     }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5786,7 +5786,8 @@
               "lockedReason": "This workspace is locked by Git. Git reported: {{value0}}. Run git worktree unlock <worktree-path> from its repository, then retry deletion.",
               "unstoppedPty": "Orca could not confirm every terminal in this workspace has exited, so it stopped before deleting any files. Use Force Delete to remove it anyway.",
               "unstoppedPtyLive": "This workspace still has running terminals, so Orca stopped before deleting any files. Force Delete will kill them and discard any uncommitted work they hold.",
-              "runningAgentSession": "Orca could not confirm every agent session in this workspace has closed, so it stopped before deleting any files. Use Force Delete to remove it anyway."
+              "runningAgentSession": "Orca could not confirm every agent session in this workspace has closed, so it stopped before deleting any files. Use Force Delete to remove it anyway.",
+              "runningAgentSessionLive": "This workspace still has running agent sessions that Orca could not close, so it stopped before deleting any files. Force Delete will discard any work they hold."
             }
           }
         },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5786,7 +5786,7 @@
               "lockedReason": "This workspace is locked by Git. Git reported: {{value0}}. Run git worktree unlock <worktree-path> from its repository, then retry deletion.",
               "unstoppedPty": "Orca could not confirm every terminal in this workspace has exited, so it stopped before deleting any files. Use Force Delete to remove it anyway.",
               "unstoppedPtyLive": "This workspace still has running terminals, so Orca stopped before deleting any files. Force Delete will kill them and discard any uncommitted work they hold.",
-              "runningAgentSession": "This workspace still has running agent sessions, so Orca stopped before deleting any files. Force Delete will close them and discard any work they hold."
+              "runningAgentSession": "Orca could not confirm every agent session in this workspace has closed, so it stopped before deleting any files. Use Force Delete to remove it anyway."
             }
           }
         },

--- a/src/shared/structured-agent-session-read-refusal.ts
+++ b/src/shared/structured-agent-session-read-refusal.ts
@@ -1,0 +1,45 @@
+/**
+ * The one refusal a structured-session READ can raise that is not a failure to read.
+ *
+ * `agentSession.history` and `agentSession.subscribe` both resolve the session through the host's
+ * `requireSession`, which raises this code when the host holds no session object by that id. That
+ * is never a transcript Orca could not read — it is a session this host has not attached YET (the
+ * surface's hold is what attaches one) or one it has just closed. Both windows end on their own:
+ * the first when the hold lands, the second when the chat tab retires.
+ *
+ * The genuinely latched lease — "Orca cannot prove the previous owner exited" — reaches the client
+ * through the ACQUISITION path instead, so narrowing on the code costs a read no real diagnosis.
+ * See `agent-session-lease-adjudication`.
+ */
+
+/** Raised by a host that holds no attached session by that id. */
+export const AGENT_SESSION_UNATTACHED_REFUSAL_CODE = 'agent_session_ownership_unknown'
+
+/**
+ * How long a read may keep refusing this way before the pane is allowed to call it a failure.
+ *
+ * Both windows this code covers are sub-second in practice, so an unattached read that outlives
+ * this one is no longer transitional and the user is owed the error rather than a spinner that
+ * never resolves.
+ */
+export const AGENT_SESSION_UNATTACHED_READ_GRACE_MS = 5_000
+
+/**
+ * Whether a read failure is that refusal.
+ *
+ * Takes both shapes the client sees: the thrown RPC error, whose `code` and `message` are each the
+ * bare refusal code, and the raw failure payload a stream delivers to its error callback.
+ */
+export function isUnattachedAgentSessionReadRefusal(error: unknown): boolean {
+  if (typeof error === 'string') {
+    return error === AGENT_SESSION_UNATTACHED_REFUSAL_CODE
+  }
+  if (typeof error !== 'object' || error === null) {
+    return false
+  }
+  const { code, message } = error as { code?: unknown; message?: unknown }
+  return (
+    code === AGENT_SESSION_UNATTACHED_REFUSAL_CODE ||
+    message === AGENT_SESSION_UNATTACHED_REFUSAL_CODE
+  )
+}

--- a/src/shared/worktree/removal.ts
+++ b/src/shared/worktree/removal.ts
@@ -22,11 +22,12 @@ export type WorktreeForceDeleteReason =
 // rather than scanning the whole message and letting a path spell out a verdict.
 export const UNSTOPPED_PTY_DETAIL_SEPARATOR = ' — '
 
-// Why: verification distinguishes a PTY it watched stay alive from one it could not reach,
+// Why: verification distinguishes a process it watched stay alive from one it could not reach,
 // and the delete toast must not flatten the two — a user waiving "we could not confirm" is
-// making a different decision than one killing a terminal Orca just saw running. The marker
-// and its matcher stay together for the same reason the force hint does.
-export const UNSTOPPED_PTY_LIVE_DETAIL_PREFIX = 'still live:'
+// making a different decision than one killing something Orca just saw running. The marker
+// and its matcher stay together for the same reason the force hint does. Shared by the PTY
+// sweep and the structured-session sweep, which both re-observe after their stop.
+export const STILL_LIVE_DETAIL_PREFIX = 'still live:'
 
 // Why (#11960): a sweep that never answers wedges removal exactly like a stop that could not
 // be proven, and the waiver clears both — but this error carries different words, so without
@@ -54,7 +55,15 @@ export function isUnstoppedPtyRemovalError(error: string): boolean {
 export function isProvenLivePtyRemovalError(error: string): boolean {
   return (
     isUnstoppedPtyRemovalError(error) &&
-    error.includes(`${UNSTOPPED_PTY_DETAIL_SEPARATOR}${UNSTOPPED_PTY_LIVE_DETAIL_PREFIX}`)
+    error.includes(`${UNSTOPPED_PTY_DETAIL_SEPARATOR}${STILL_LIVE_DETAIL_PREFIX}`)
+  )
+}
+
+/** True only when the observation AFTER the close found the session still attached. */
+export function isProvenLiveStructuredSessionRemovalError(error: string): boolean {
+  return (
+    isRunningAgentSessionRemovalError(error) &&
+    error.includes(`${UNSTOPPED_PTY_DETAIL_SEPARATOR}${STILL_LIVE_DETAIL_PREFIX}`)
   )
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​936 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​907 |
| Prod | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​511 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​94 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​417 |

<!-- /orca-pr-loc -->

**Status: ready to merge.** Reviewed over eight adversarial passes with live Electron validation at the final head. CI green. Follow-up in #19970.

## The bug

You open a Codex or Claude chat in a workspace, it answers, you're done with it. You try to delete the workspace and Orca refuses: *"This workspace still has running agent sessions."*

Meanwhile, a workspace whose **terminal** is actively running the same agent deletes without a word — because that path kills the terminal for you.

That's backwards. The thing you were done with blocked you; the thing still working didn't.

## How deleting a workspace used to work

Deleting a workspace sweeps every process Orca can attribute to it. There are three places a terminal can be registered — the renderer's view of the app, the terminal provider's own session list, and a local registry — and the delete sweeps all three, killing what it finds. If it kills something and then can't confirm it actually died, it stops and refuses, because deleting the files out from under a live process is how you get a program running against a directory that no longer exists.

Native chat sessions (Codex Chat, Claude Chat) appear on **none** of those three lists. They have no terminal. So all three sweeps found nothing, reported success, and the delete proceeded — leaving a chat's underlying process running with its working directory deleted.

A guard was added for that: a fourth check that looked for chats in the workspace and **refused the delete if it found any attached**. It never tried to close them. Closing only happened under `--force`.

## Why that guard was wrong

It refused based on whether a chat was *attached*, not whether it was *busy*.

"Attached" just means a process is currently backing the chat. An idle chat that answered a greeting an hour ago is attached in exactly the same way as one mid-answer. So the guard couldn't tell "you're about to lose work" from "this panel is open" — and it chose to block on both.

The other three sweeps never worked that way. Each one issues a real stop, then checks what actually stopped, and refuses only for what it couldn't confirm. Refusing there means *we tried and couldn't prove it worked* — never *something is attached*.

## How it works now

The fourth sweep behaves like the other three: **it closes the chats, then checks each one actually closed.**

- Chats in the workspace get closed as part of the normal delete, the same way terminals get killed.
- Each close is verified. A chat proven gone is done.
- The delete refuses **only** for a chat whose close couldn't be confirmed — the same bargain the terminal sweeps already strike.
- Force delete still overrides everything, as before.

No new capability was needed. The code to close a chat and verify it stopped already existed; it was just locked behind `--force`.

The practical result: an idle chat is no harder to delete than a terminal running the same agent. Which was the point.

## What else the review found

Reworking the sweep surfaced several problems, fixed in the same PR:

- **It could close a chat on the wrong machine.** A workspace ID is a repo and a path with no machine attached, so the same ID can exist on your laptop and on a remote host. Deleting the local one could have closed a live chat on the remote. Now the sweep only touches chats on the machine whose workspace is being deleted — matching how the terminal sweeps already fence themselves.
- **Force Delete could get stuck.** If a chat's close hung, the resulting error was worded as a *terminal* failure, and clicking Force Delete hit the identical error again. The button meant to break the deadlock was itself deadlocked. Now a stuck chat is reported as a chat, and Force Delete clears it.
- **A chat that was already gone could still block the delete.** If a close killed the chat but then failed a later step, Orca treated "proven dead" the same as "unknown" and refused. It now takes the proof.
- **Chats could starve the terminal sweeps of time.** The chat close ran first and alone against a shared time budget, so a slow one left no time for the terminals, which then reported a timeout for a stop they were never asked to make. The sweeps now run alongside each other.
- **The refusal message didn't say which problem it was.** "We watched this stay running" and "we couldn't confirm this closed" are different things to ask someone to override. They're now worded differently, and the delete dialog says the right one.
- **A failed delete left the chat tab gone.** The tab was hidden before the close was attempted and never restored when the close failed — so a delete that *didn't happen* still took your tab away, permanently, from the next launch onward. It's now put back.
- **A red error flashed during deletion.** Closing a chat while its panel was still open made the panel briefly render *"Could not load conversation"* before the tab disappeared. The panel now treats a chat that has gone away as a normal closing state rather than a loading failure. A genuine failure to load still shows an error.

## Behaviour changes worth knowing

- **`orca worktree rm` and desktop Delete now close an attached chat instead of refusing.** This is the point of the PR, but it is a new outcome on a destructive command.
- **If the delete does refuse over a stuck chat, that workspace's terminals have already been killed.** Running the sweeps together is what fixed the starvation above, and the terminal sweeps kill as they go. The terminal path already behaved this way. Pinned by a test so it can't change silently.
- **This partially reverses a guard added a few days earlier.** That guard was the "refuse if attached" check described above.

Existing "you might lose work" protection is unchanged: the uncommitted-changes confirmation still runs before any of this.

## Testing

- Eight adversarial review passes; the last found nothing.
- Live validation in the real app at the final commit: a real Codex chat exchanged a message, the workspace deleted with no refusal and no error toast, and the chat stayed gone after restart. Screenshots in the comments.
- The error flash was checked by sampling 14 distinct UI states across the delete rather than a single screenshot — neither error string appeared anywhere, with zero toasts.
- Full suites, both typecheck projects, and the changed-code quality gates all green.

## Known, not fixed here

A chat with **no** process backing it — because you'd switched away from it, or restarted the app — isn't seen by this sweep, so its tab can reappear after deletion pointing at a workspace that's gone. This behaves identically on `main` and is not caused by this PR. Fixed separately in #19970.
