### PR TITLE
fix(chat): honor ordered-list start numbers in transcript markdown

### DIFF
--- a/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
@@ -253,6 +253,32 @@ describe('CommentMarkdown', () => {
     expect(markup).toContain('Problem to solve')
   })
 
+  it('honors a document ordered list that starts past 1', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown variant="document" content={'3. Third\n4. Fourth'} />
+    )
+
+    expect(markup).toContain('<ol start="3"')
+  })
+
+  it('honors a compact ordered list that starts past 1', () => {
+    const markup = renderToStaticMarkup(<CommentMarkdown content={'3. Third\n4. Fourth'} />)
+
+    expect(markup).toContain('<ol start="3"')
+  })
+
+  it('numbers a document ordered list sequentially from repeated markers, per CommonMark', () => {
+    // CommonMark takes the list's start from the first item's typed number and
+    // increments from there, ignoring the numbers typed on later items.
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown variant="document" content={'1. First\n1. Second\n1. Third'} />
+    )
+
+    expect(markup).not.toContain('<ol start=')
+    expect(markup.indexOf('First')).toBeLessThan(markup.indexOf('Second'))
+    expect(markup.indexOf('Second')).toBeLessThan(markup.indexOf('Third'))
+  })
+
   it('contains long PR body markdown inside its available width', () => {
     const markup = renderToStaticMarkup(
       <CommentMarkdown

--- a/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
@@ -107,7 +107,11 @@ export function createCompactCommentMarkdownComponents(
     ),
     // Compact lists
     ul: ({ children }) => <ul className="my-0.5 ml-3 list-disc space-y-0">{children}</ul>,
-    ol: ({ children }) => <ol className="my-0.5 ml-3 list-decimal space-y-0">{children}</ol>,
+    ol: ({ children, start }) => (
+      <ol start={start} className="my-0.5 ml-3 list-decimal space-y-0">
+        {children}
+      </ol>
+    ),
     // Why: GFM task list checkboxes are non-functional in a read-only comment
     // card (clicking them would just open the edit modal via the parent's
     // onClick). Rendering them disabled avoids a misleading interactive
@@ -265,7 +269,11 @@ export function createDocumentCommentMarkdownComponents(
         </pre>
       ),
     ul: ({ children }) => <ul className="my-2 ml-5 list-disc space-y-1">{children}</ul>,
-    ol: ({ children }) => <ol className="my-2 ml-5 list-decimal space-y-1">{children}</ol>,
+    ol: ({ children, start }) => (
+      <ol start={start} className="my-2 ml-5 list-decimal space-y-1">
+        {children}
+      </ol>
+    ),
     li: ({ children }) => (
       <li className="leading-relaxed [&>input]:pointer-events-none">{children}</li>
     ),


### PR DESCRIPTION
## ELI5

Numbered lists in the chat transcript always started counting from 1, even when I typed a list that started at a different number, like 3.

## What Changed

The two custom `ol` renderers in `comment-markdown-element-renderers.tsx` (the compact and document chat markdown variants) now forward the `start` prop that `react-markdown` passes down.

## Why

Both renderers destructured only `children` from their props, silently discarding `start`. `mdast-util-to-hast` sets `start` on the list node whenever the author's first list item is not numbered 1, so the value was already available; it never reached the DOM.

## Linked Issue

Fixes #19764

## Visual Proof

Sending `3. Third` / `4. Fourth` in chat.

**Before** (renders `1.` / `2.`):
<img width="3396" height="1410" alt="before" src="https://github.com/user-attachments/assets/f64b34ca-5684-4302-9d21-c0cbf979523e" />
[before.webm](https://github.com/user-attachments/assets/cd0063dd-87ea-4821-b9d2-fea70aecd158)

**After** (renders `3.` / `4.`, matching the full-file markdown editor):
<img width="3396" height="1410" alt="after" src="https://github.com/user-attachments/assets/4ac72254-63cb-471a-9be2-f1e198f2cc50" />
[after.webm](https://github.com/user-attachments/assets/27446071-f357-45d1-88dd-767660971d64)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added three cases to `CommentMarkdown.test.tsx`: a document-variant list starting at 3, a compact-variant list starting at 3, and a list where the author typed `1.` repeatedly, confirming CommonMark's sequential numbering from the first item is preserved. `pnpm test` for that file, `pnpm tc:web`, and `oxlint`/`oxfmt` on the changed files are clean. Tested on macOS.

## AI Disclosure

Authored with Claude Code (Claude Fable 5.1 and Sonnet teammates) under my review.

## Review

Agent review summary: renderer-only change in one file; no platform-specific code paths, no SSH/remote or wire-format surface, no agent or integration coupling, no performance impact (one attribute forwarded), no new input handling or security surface.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Single-file rendering fix; nothing platform-, remote-, mobile-, or compatibility-sensitive.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: [@fbartho](https://x.com/fbartho). I prefer Mastodon: [@fbartho@mastodon.social](https://mastodon.social/@fbartho).
