### PR TITLE
fix(editor): exit heading style on Enter

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-heading-continuation.ts
+++ b/src/renderer/src/components/editor/rich-markdown-heading-continuation.ts
@@ -2,9 +2,10 @@ import type { Editor } from '@tiptap/core'
 import { TextSelection } from '@tiptap/pm/state'
 
 /**
- * Why: TipTap's stock Heading node has no Enter override, so the default
- * ProseMirror keymap's splitBlock carries the heading type into the new
- * block. This handler exits heading style on Enter to match Notion/Obsidian.
+ * Why: ProseMirror's default splitBlock keeps the heading type when Enter
+ * lands inside heading text; only at the block edges does it fall back to
+ * a paragraph. This handler makes every position exit to a paragraph,
+ * matching Notion/Obsidian.
  */
 export function exitHeadingOnEnter(editor: Editor): boolean {
   const { selection, schema } = editor.state

--- a/src/renderer/src/components/editor/rich-markdown-heading-continuation.ts
+++ b/src/renderer/src/components/editor/rich-markdown-heading-continuation.ts
@@ -29,6 +29,15 @@ export function exitHeadingOnEnter(editor: Editor): boolean {
   const headingEnd = $from.after($from.depth)
   const offset = $from.parentOffset
 
+  // Why: an empty heading satisfies both edge branches, and the start branch
+  // would leave the caret in a heading with nothing to push down.
+  if (heading.content.size === 0) {
+    const tr = state.tr.setBlockType(headingStart + 1, headingStart + 1, paragraphType)
+    tr.setSelection(TextSelection.create(tr.doc, headingStart + 1))
+    view.dispatch(tr.scrollIntoView())
+    return true
+  }
+
   if (offset === 0) {
     const paragraph = paragraphType.create()
     const tr = state.tr.insert(headingStart, paragraph)

--- a/src/renderer/src/components/editor/rich-markdown-heading-continuation.ts
+++ b/src/renderer/src/components/editor/rich-markdown-heading-continuation.ts
@@ -1,0 +1,61 @@
+import type { Editor } from '@tiptap/core'
+import { TextSelection } from '@tiptap/pm/state'
+
+/**
+ * Why: TipTap's stock Heading node has no Enter override, so the default
+ * ProseMirror keymap's splitBlock carries the heading type into the new
+ * block. This handler exits heading style on Enter to match Notion/Obsidian.
+ */
+export function exitHeadingOnEnter(editor: Editor): boolean {
+  const { selection, schema } = editor.state
+  if (!(selection instanceof TextSelection) || !selection.empty) {
+    return false
+  }
+
+  const { $from } = selection
+  const heading = $from.parent
+  if (heading.type.name !== 'heading') {
+    return false
+  }
+
+  const paragraphType = schema.nodes.paragraph
+  if (!paragraphType) {
+    return false
+  }
+
+  const { state, view } = editor
+  const headingStart = $from.before($from.depth)
+  const headingEnd = $from.after($from.depth)
+  const offset = $from.parentOffset
+
+  if (offset === 0) {
+    const paragraph = paragraphType.create()
+    const tr = state.tr.insert(headingStart, paragraph)
+    // Why: keep the cursor in the heading being pushed down, matching
+    // Notion/Obsidian — the new blank paragraph lands above, unfocused.
+    tr.setSelection(TextSelection.create(tr.doc, tr.mapping.map($from.pos)))
+    view.dispatch(tr.scrollIntoView())
+    return true
+  }
+
+  if (offset === heading.content.size) {
+    const paragraph = paragraphType.create()
+    const tr = state.tr.insert(headingEnd, paragraph)
+    tr.setSelection(TextSelection.create(tr.doc, headingEnd + 1))
+    view.dispatch(tr.scrollIntoView())
+    return true
+  }
+
+  const before = heading.content.cut(0, offset)
+  const after = heading.content.cut(offset)
+  if (!heading.type.validContent(before) || !paragraphType.validContent(after)) {
+    return false
+  }
+
+  const remainingHeading = heading.type.create(heading.attrs, before, heading.marks)
+  const newParagraph = paragraphType.create(null, after)
+  const tr = state.tr.replaceWith(headingStart, headingEnd, [remainingHeading, newParagraph])
+  tr.setSelection(TextSelection.create(tr.doc, headingStart + remainingHeading.nodeSize + 1))
+  view.dispatch(tr.scrollIntoView())
+  return true
+}

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
@@ -594,6 +594,58 @@ describe('rich markdown key handler', () => {
     }
   })
 
+  it('leaves the heading intact when Enter commits a slash-menu row', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Section/' }] }
+      ]
+    })
+
+    try {
+      editor.commands.setTextSelection(9)
+      const ctx = createContext(editor, false)
+      const run = vi.fn()
+      ctx.slashMenuRef.current = { query: '', from: 8, to: 9, left: 0, top: 0 }
+      ctx.filteredSlashCommandsRef.current = [{ id: 'heading-1', run } as never]
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(ctx)(null, event)).toBe(true)
+      expect(run).toHaveBeenCalledWith(editor)
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [{ type: 'heading', attrs: { level: 2 } }]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('leaves the heading intact when Enter commits a doc-link row', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'See [[no' }] }
+      ]
+    })
+
+    try {
+      editor.commands.setTextSelection(9)
+      const ctx = createContext(editor, false)
+      const run = vi.fn()
+      ctx.docLinkMenuRef.current = { query: 'no', from: 5, to: 9, left: 0, top: 0 } as never
+      ctx.filteredDocLinkRowsRef.current = [
+        { kind: 'action', id: 'create-no', label: 'Create no', run } as never
+      ]
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(ctx)(null, event)).toBe(true)
+      expect(run).toHaveBeenCalledWith(editor)
+      expect(editor.state.doc.firstChild?.type.name).toBe('heading')
+    } finally {
+      editor.destroy()
+    }
+  })
+
   it('does not intercept Shift+Enter inside a heading', () => {
     const editor = createEditor({
       type: 'doc',

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
@@ -483,6 +483,117 @@ describe('rich markdown key handler', () => {
     }
   })
 
+  it('converts an empty heading to a paragraph on Enter', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [{ type: 'heading', attrs: { level: 2 } }]
+    })
+
+    try {
+      editor.commands.setTextSelection(1)
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(createContext(editor, false))(null, event)).toBe(true)
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [{ type: 'paragraph' }]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('does not stack blank paragraphs on repeated Enter in an empty heading', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [{ type: 'heading', attrs: { level: 2 } }]
+    })
+
+    try {
+      const handler = createRichMarkdownKeyHandler(createContext(editor, false))
+      handler(null, keyEvent('Enter'))
+      handler(null, keyEvent('Enter'))
+
+      expect(editor.state.doc.childCount).toBe(1)
+      expect(editor.state.doc.firstChild?.type.name).toBe('paragraph')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('converts an empty heading inside a list item to a paragraph on Enter', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [{ type: 'listItem', content: [{ type: 'heading', attrs: { level: 2 } }] }]
+        }
+      ]
+    })
+
+    try {
+      editor.commands.setTextSelection(3)
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(createContext(editor, false))(null, event)).toBe(true)
+      expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [
+          {
+            type: 'bulletList',
+            content: [{ type: 'listItem', content: [{ type: 'paragraph' }] }]
+          }
+        ]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('converts an empty heading inside a blockquote to a paragraph on Enter', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [{ type: 'blockquote', content: [{ type: 'heading', attrs: { level: 2 } }] }]
+    })
+
+    try {
+      editor.commands.setTextSelection(2)
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(createContext(editor, false))(null, event)).toBe(true)
+      expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [{ type: 'blockquote', content: [{ type: 'paragraph' }] }]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('splits a whitespace-only heading rather than converting it', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [{ type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: '  ' }] }]
+    })
+
+    try {
+      editor.commands.setTextSelection(2)
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(createContext(editor, false))(null, event)).toBe(true)
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [
+          { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: ' ' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: ' ' }] }
+        ]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
   it('does not intercept Shift+Enter inside a heading', () => {
     const editor = createEditor({
       type: 'doc',

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
@@ -32,7 +32,9 @@ const TABLE_MARKDOWN = `| A | B |
 function createTableEditor(): Editor {
   return new Editor({
     element: null,
-    extensions: createRichMarkdownExtensions({ codec: createRichMarkdownEditorCodec() }),
+    extensions: createRichMarkdownExtensions({
+      codec: createRichMarkdownEditorCodec()
+    }),
     content: TABLE_MARKDOWN,
     contentType: 'markdown'
   })
@@ -152,7 +154,11 @@ describe('rich markdown key handler', () => {
 
     try {
       const ctx = createContext(editor, false)
-      const event = keyEvent('a', { metaKey: true, shiftKey: true, code: 'KeyA' })
+      const event = keyEvent('a', {
+        metaKey: true,
+        shiftKey: true,
+        code: 'KeyA'
+      })
 
       expect(createRichMarkdownKeyHandler(ctx)(null, event)).toBe(true)
       expect(event.preventDefault).toHaveBeenCalled()
@@ -168,7 +174,11 @@ describe('rich markdown key handler', () => {
     try {
       const ctx = createContext(editor, false)
       ctx.openAnnotationPopoverRef.current = vi.fn(() => false)
-      const event = keyEvent('a', { metaKey: true, shiftKey: true, code: 'KeyA' })
+      const event = keyEvent('a', {
+        metaKey: true,
+        shiftKey: true,
+        code: 'KeyA'
+      })
 
       expect(createRichMarkdownKeyHandler(ctx)(null, event)).toBe(false)
       expect(event.preventDefault).not.toHaveBeenCalled()
@@ -183,7 +193,12 @@ describe('rich markdown key handler', () => {
 
     try {
       const ctx = createContext(editor, false)
-      const event = keyEvent('a', { metaKey: true, shiftKey: true, code: 'KeyA', repeat: true })
+      const event = keyEvent('a', {
+        metaKey: true,
+        shiftKey: true,
+        code: 'KeyA',
+        repeat: true
+      })
 
       // Why: leave the repeat unconsumed here; open drafts are consumed by the
       // mounted composer guard (product B) instead of this editor key path.
@@ -204,7 +219,11 @@ describe('rich markdown key handler', () => {
       // (which reads the selection), so the handler now only delegates the open
       // with requireLiveSelection and consumes the chord when it succeeds.
       ctx.openAnnotationPopoverRef.current = vi.fn(() => true)
-      const event = keyEvent('a', { metaKey: true, shiftKey: true, code: 'KeyA' })
+      const event = keyEvent('a', {
+        metaKey: true,
+        shiftKey: true,
+        code: 'KeyA'
+      })
 
       expect(createRichMarkdownKeyHandler(ctx)(null, event)).toBe(true)
       expect(event.preventDefault).toHaveBeenCalled()
@@ -257,16 +276,30 @@ describe('rich markdown key handler', () => {
           content: [
             {
               type: 'listItem',
-              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Item 1' }] }]
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Item 1' }]
+                }
+              ]
             },
             {
               type: 'listItem',
-              content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Item 2' }] }]
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [{ type: 'text', text: 'Item 2' }]
+                }
+              ]
             },
             { type: 'listItem', content: [{ type: 'paragraph' }] }
           ]
         },
-        { type: 'heading', attrs: { level: 2 }, content: [{ type: 'text', text: 'Next section' }] }
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Next section' }]
+        }
       ]
     })
 
@@ -355,6 +388,147 @@ describe('rich markdown key handler', () => {
     }
   })
 
+  it('exits heading style on Enter at the end of a heading', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Section' }]
+        }
+      ]
+    })
+
+    try {
+      editor.commands.setTextSelection(editor.state.doc.content.size - 1)
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(createContext(editor, false))(null, event)).toBe(true)
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(editor.state.selection.$from.parent.type.name).toBe('paragraph')
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [{ type: 'heading', attrs: { level: 2 } }, { type: 'paragraph' }]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('splits the trailing text into a paragraph on Enter in the middle of a heading', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'SectionTwo' }]
+        }
+      ]
+    })
+
+    try {
+      // Position after "Section", before "Two".
+      editor.commands.setTextSelection(1 + 'Section'.length)
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(createContext(editor, false))(null, event)).toBe(true)
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [
+          {
+            type: 'heading',
+            attrs: { level: 2 },
+            content: [{ type: 'text', text: 'Section' }]
+          },
+          { type: 'paragraph', content: [{ type: 'text', text: 'Two' }] }
+        ]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('inserts an empty paragraph above and keeps the heading on Enter at its start', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Section' }]
+        }
+      ]
+    })
+
+    try {
+      editor.commands.setTextSelection(1)
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(createContext(editor, false))(null, event)).toBe(true)
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(editor.state.selection.$from.parent.type.name).toBe('heading')
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [
+          { type: 'paragraph' },
+          {
+            type: 'heading',
+            attrs: { level: 2 },
+            content: [{ type: 'text', text: 'Section' }]
+          }
+        ]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('does not intercept Shift+Enter inside a heading', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [
+        {
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: 'Section' }]
+        }
+      ]
+    })
+
+    try {
+      editor.commands.setTextSelection(editor.state.doc.content.size - 1)
+      const event = keyEvent('Enter', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor, false))(null, event)).toBe(false)
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [{ type: 'heading', attrs: { level: 2 } }]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('leaves paragraph Enter behavior unaffected by the heading handler', () => {
+    const editor = createEditor({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Body text' }] }]
+    })
+
+    try {
+      editor.commands.setTextSelection(editor.state.doc.content.size - 1)
+      const event = keyEvent('Enter')
+
+      expect(createRichMarkdownKeyHandler(createContext(editor, false))(null, event)).toBe(false)
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(editor.state.doc.toJSON()).toMatchObject({
+        content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Body text' }] }]
+      })
+    } finally {
+      editor.destroy()
+    }
+  })
+
   it('dismisses the slash menu on Escape even when search has no matches', () => {
     const editor = createEditor({
       type: 'doc',
@@ -364,7 +538,13 @@ describe('rich markdown key handler', () => {
     try {
       editor.commands.setTextSelection(5)
       const ctx = createContext(editor, false)
-      ctx.slashMenuRef.current = { query: 'zzz', from: 1, to: 5, left: 0, top: 0 }
+      ctx.slashMenuRef.current = {
+        query: 'zzz',
+        from: 1,
+        to: 5,
+        left: 0,
+        top: 0
+      }
       ctx.filteredSlashCommandsRef.current = []
       ctx.setSlashMenu = vi.fn()
       const event = keyEvent('Escape')

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.ts
@@ -177,17 +177,20 @@ export function createRichMarkdownKeyHandler(
         event.preventDefault()
         return true
       }
-      if (ed && !event.shiftKey && !isComposingMarkdownInput(event, ed) && exitHeadingOnEnter(ed)) {
+      // Why: the slash/doc-link menus own Enter while open, and their blocks
+      // run later in this handler.
+      const noMenuOpen = !ctx.slashMenuRef.current && !ctx.docLinkMenuRef.current
+      const headingEnterEligible =
+        ed && !event.shiftKey && noMenuOpen && !isComposingMarkdownInput(event, ed)
+      if (headingEnterEligible && exitHeadingOnEnter(ed)) {
         event.preventDefault()
         return true
       }
       // Why: table Enter (cell below / add row) must run before ProseMirror
-      // inserts an in-cell paragraph that GFM serialization cannot keep — but
-      // the slash/doc-link menus own Enter while open (their blocks run later).
+      // inserts an in-cell paragraph that GFM serialization cannot keep.
       if (
         ed &&
-        !ctx.slashMenuRef.current &&
-        !ctx.docLinkMenuRef.current &&
+        noMenuOpen &&
         !isComposingMarkdownInput(event, ed) &&
         handleRichMarkdownTableEnter(ed)
       ) {

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.ts
@@ -18,6 +18,7 @@ import {
   exitTrailingEmptyOrderedListItem
 } from './rich-markdown-list-continuation'
 import { deleteAdjacentEmptyParagraph } from './rich-markdown-empty-paragraph-delete'
+import { exitHeadingOnEnter } from './rich-markdown-heading-continuation'
 import { handleRichMarkdownTableBackspace } from './rich-markdown-table-row-delete'
 import { handleRichMarkdownTableEnter } from './rich-markdown-table-enter'
 import { handleRichMarkdownTableTab } from './rich-markdown-table-tab'
@@ -173,6 +174,10 @@ export function createRichMarkdownKeyHandler(
         return true
       }
       if (ed && !isComposingMarkdownInput(event, ed) && exitTrailingEmptyOrderedListItem(ed)) {
+        event.preventDefault()
+        return true
+      }
+      if (ed && !event.shiftKey && !isComposingMarkdownInput(event, ed) && exitHeadingOnEnter(ed)) {
         event.preventDefault()
         return true
       }


### PR DESCRIPTION
## ELI5

Pressing Enter inside a heading now starts a normal paragraph instead of another heading, matching Notion, Obsidian, and Google Docs.

## What Changed

Added a heading-aware Enter case to the rich markdown editor's key handler:

- Enter at the end of a heading inserts an empty paragraph after it and moves the cursor there.
- Enter in the middle of a heading splits it: text after the cursor becomes a new paragraph, text before stays the heading.
- Enter at the start of a heading inserts an empty paragraph above it and keeps the cursor in the heading.
- Shift+Enter inside a heading is unaffected (still inserts a hard break).

The end and start cases already behaved this way by default; the handler makes them explicit alongside the mid-heading split, which is the case that was broken.

## Why

TipTap's stock Heading extension has no Enter override, so the keystroke fell through to ProseMirror's default `splitBlock`, which keeps the heading's node type when Enter lands inside heading text and only falls back to a paragraph at the block edges. Every other editor in common use exits heading style on Enter; this brings the rich markdown editor in line with that expectation.

## Linked Issue

Fixes #19766

## Visual Proof

Enter between `Section` and `Two` in an H2 heading.

**Before** (`Two` stays a second heading):
<img width="649" height="246" alt="before" src="https://github.com/user-attachments/assets/c0823baf-9b6d-4331-8d84-0d8d98637092" />
[before.webm](https://github.com/user-attachments/assets/383a5924-554f-4a8c-8c89-b9c0f2524b2d)

**After** (`Two` becomes a paragraph):
<img width="649" height="225" alt="after" src="https://github.com/user-attachments/assets/53eb3f94-f160-450b-be25-029ddeb77a42" />
[after.webm](https://github.com/user-attachments/assets/dd3a759e-edcc-4a9c-8a2f-b5605b55ad64)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`rich-markdown-key-handler.test.ts` gains cases for end-of-heading, mid-heading, start-of-heading, Shift+Enter (unaffected), and a paragraph control case. `pnpm test src/renderer/src/components/editor` (208 files, 1,415 tests), `pnpm tc`, and `oxlint` on the changed files are clean. Tested on macOS.

## AI Disclosure

Authored with Claude Code (Claude Fable 5.1 and Sonnet teammates) under my review.

## Review

Agent review summary: pure editor keymap logic in the renderer; no IPC, remote-wire, platform-specific, agent-integration, or mobile surface; no performance impact (one selection check per Enter inside a heading); no new input parsing or security surface.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Editor-only change; nothing platform-, remote-, mobile-, or compatibility-sensitive.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: [@fbartho](https://x.com/fbartho). I prefer Mastodon: [@fbartho@mastodon.social](https://mastodon.social/@fbartho).

