### PR TITLE
fix(editor): scroll wide code blocks horizontally instead of wrapping

### DIFF
--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -143,7 +143,10 @@ export function RichMarkdownCodeBlock({
           <Copy size={14} />
         )}
       </button>
-      <NodeViewContent<'pre'> as="pre" />
+      {/* Tiptap's NodeViewContent defaults to white-space: pre-wrap inline,
+          which wraps at whitespace and defeats the wrapper's overflow-x
+          scroller; override it so wide lines scroll instead of wrapping. */}
+      <NodeViewContent<'pre'> as="pre" style={{ whiteSpace: 'pre' }} />
       {/* Why: mermaid diagrams render as a live SVG preview below the editable
           source so users can see the result while editing. The code block stays
           editable — the diagram is read-only output. This preview also goes

--- a/tests/e2e/markdown-code-block-horizontal-scroll.spec.ts
+++ b/tests/e2e/markdown-code-block-horizontal-scroll.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  cleanupMarkdownFixture,
+  createMarkdownFixture,
+  getActiveWorktreeContext,
+  openMarkdownFixture,
+  waitForRichMarkdownEditor
+} from './helpers/markdown-ordered-list-exit'
+
+const WIDE_LINE =
+  'const veryLongLineOfCodeThatShouldNotWrapAtAllUnderAnyCircumstances = ' + `"${'a'.repeat(160)}"`
+const WIDE_CODE_BLOCK_MARKDOWN = `# Wide code block\n\n\`\`\`ts\n${WIDE_LINE}\n\`\`\`\n`
+
+test.describe('Wide code blocks scroll horizontally', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await orcaPage.setViewportSize({ width: 900, height: 700 })
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('a code block wider than the editor scrolls instead of wrapping', async ({
+    orcaPage
+  }, testInfo) => {
+    let filePath: string | null = null
+
+    try {
+      const context = await getActiveWorktreeContext(orcaPage)
+      filePath = await createMarkdownFixture(
+        context,
+        'code-block-horizontal-scroll',
+        testInfo.workerIndex,
+        WIDE_CODE_BLOCK_MARKDOWN
+      )
+      await openMarkdownFixture(orcaPage, context, filePath)
+      await waitForRichMarkdownEditor(orcaPage)
+
+      const metrics = await orcaPage.evaluate(() => {
+        const pre = document.querySelector('.rich-markdown-editor pre')
+        if (!pre) {
+          throw new Error('Code block was not rendered')
+        }
+        return {
+          whiteSpace: window.getComputedStyle(pre).whiteSpace,
+          scrollWidth: pre.scrollWidth,
+          clientWidth: pre.clientWidth
+        }
+      })
+
+      expect(metrics.whiteSpace).toBe('pre')
+      expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth)
+    } finally {
+      await cleanupMarkdownFixture(filePath)
+    }
+  })
+})

--- a/tests/e2e/markdown-code-block-horizontal-scroll.spec.ts
+++ b/tests/e2e/markdown-code-block-horizontal-scroll.spec.ts
@@ -47,13 +47,9 @@ test.describe('Wide code blocks scroll horizontally', () => {
         }
       })
 
-      // The wide viewport keeps the editor pane wider than WIDE_LINE's
-      // unbroken run needs to fit on one line, so pre-wrap wraps it at
-      // ordinary word boundaries with no overflow — scrollWidth only
-      // exceeds clientWidth once white-space: pre removes those wrap
-      // points, which is what pins this assertion to the fix. A narrower
-      // pane lets the browser's overflow-wrap: break-word fallback wrap
-      // the run mid-word even under pre-wrap, which would pass either way.
+      // The wide viewport fits WIDE_LINE's unbroken run on one wrapped
+      // line under pre-wrap with no overflow, so scrollWidth exceeds
+      // clientWidth only once white-space: pre removes that wrap point.
       expect(metrics.whiteSpace).toBe('pre')
       expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth)
     } finally {

--- a/tests/e2e/markdown-code-block-horizontal-scroll.spec.ts
+++ b/tests/e2e/markdown-code-block-horizontal-scroll.spec.ts
@@ -14,7 +14,7 @@ const WIDE_CODE_BLOCK_MARKDOWN = `# Wide code block\n\n\`\`\`ts\n${WIDE_LINE}\n\
 
 test.describe('Wide code blocks scroll horizontally', () => {
   test.beforeEach(async ({ orcaPage }) => {
-    await orcaPage.setViewportSize({ width: 900, height: 700 })
+    await orcaPage.setViewportSize({ width: 1440, height: 900 })
     await waitForSessionReady(orcaPage)
     await waitForActiveWorktree(orcaPage)
   })
@@ -47,6 +47,13 @@ test.describe('Wide code blocks scroll horizontally', () => {
         }
       })
 
+      // The wide viewport keeps the editor pane wider than WIDE_LINE's
+      // unbroken run needs to fit on one line, so pre-wrap wraps it at
+      // ordinary word boundaries with no overflow — scrollWidth only
+      // exceeds clientWidth once white-space: pre removes those wrap
+      // points, which is what pins this assertion to the fix. A narrower
+      // pane lets the browser's overflow-wrap: break-word fallback wrap
+      // the run mid-word even under pre-wrap, which would pass either way.
       expect(metrics.whiteSpace).toBe('pre')
       expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth)
     } finally {


### PR DESCRIPTION
## ELI5

Wide lines in a code block used to wrap onto a second line inside the editor. They now stay on one line and the code block scrolls sideways, like a normal code editor.

## What Changed

`RichMarkdownCodeBlock.tsx` passes `style={{ whiteSpace: 'pre' }}` to Tiptap's `NodeViewContent` for the code block's `<pre>` element.

## Why

Tiptap's `NodeViewContent` sets an inline `white-space: pre-wrap` style on every element it renders unless the caller overrides it. Inline styles beat stylesheet rules, so the existing `overflow-x: auto` on `.rich-markdown-editor pre` never took effect: the block wrapped before the browser needed to scroll it. Overriding the `style` prop directly is the only place this can be fixed.

## Linked Issue

Fixes #19772

## Visual Proof

A paragraph of prose above a fenced code block with one very long line.

**Before** (the long line wraps across three rows):
<img width="569" height="454" alt="before" src="https://github.com/user-attachments/assets/fcee5331-b5f4-436e-8819-a6959064835c" />
[before.webm](https://github.com/user-attachments/assets/c4951ef9-390c-4d8d-ba0f-5625edc0060a)

**After** (one row, scrolling horizontally):
<img width="569" height="345" alt="after" src="https://github.com/user-attachments/assets/9b438dda-c0f9-470b-895b-e9448c0645fc" />
[after.webm](https://github.com/user-attachments/assets/3d53101f-6969-43b3-8b7f-df918a5adcbd)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added `tests/e2e/markdown-code-block-horizontal-scroll.spec.ts`, a Playwright test against the hidden Electron renderer. It asserts the code block's computed `white-space` is `pre` and that `scrollWidth` exceeds `clientWidth` for a line wider than the viewport. It fails on the pre-fix source and passes on the fix. A unit test is not feasible here: the component's `NodeViewContent`/`NodeViewWrapper` children require a live Tiptap editor context. `pnpm tc`, `oxlint`, and `oxfmt` are clean. Tested on macOS.

The read-only markdown preview (`.markdown-body pre` in `markdown-preview.css`) renders through `react-markdown`, carries no inline style override, and already scrolls correctly; no change there.

## AI Disclosure

Authored with Claude Code (Claude Fable 5.1 and Sonnet teammates) under my review.

## Review

Agent review summary: one inline style on a renderer component; no IPC, remote-wire, platform-specific, agent-integration, or mobile surface; no performance impact; no new input parsing or security surface.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Editor-only change; nothing platform-, remote-, mobile-, or compatibility-sensitive.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: [@fbartho](https://x.com/fbartho). I prefer Mastodon: [@fbartho@mastodon.social](https://mastodon.social/@fbartho).
