### PR TITLE
feat(keybindings): add bindable shortcut for the activity/notification list

### DIFF
--- a/docs/site/content/docs/settings.mdx
+++ b/docs/site/content/docs/settings.mdx
@@ -133,6 +133,7 @@ Settings are grouped into panes. Everything here is searchable with `Cmd-,` then
 - Full keymap — every binding remappable.
 - Toggle Sleeping Workspaces ships unbound; assign it here if you want a direct shortcut for the sidebar sleeping-worktree filter.
 - **Toggle Workspace Board** ships unbound; assign it here to open or close the Workspace Board with one shortcut. Existing bindings for `workspace.openBoard` continue to work.
+- **Toggle Activity View** ships unbound; assign it here to jump straight to the sidebar's bell/notification list (each session's waiting time) without clicking the bell icon.
 - Close all editor tabs defaults to `Cmd+Option+W` on macOS and `Ctrl+Alt+W` on Windows / Linux.
 - **Tab navigation defaults (new installs):** next/previous tab **across all types** is `Cmd+Shift+]` / `Cmd+Shift+[` (Ctrl on Linux/Windows). Same-type next/previous is `Cmd+Option+]` / `Cmd+Option+[`. Previous recent tab is `Ctrl+Tab`. Existing installs keep customized overrides under `~/.orca/keybindings.json`.
 - **Add Review Note** defaults to `Cmd+Shift+A` (macOS) / `Ctrl+Shift+A` (Windows / Linux); remappable.

--- a/src/renderer/src/app-shell/app-command-handlers-activity-toggle.test.ts
+++ b/src/renderer/src/app-shell/app-command-handlers-activity-toggle.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import type { AppShortcutState, ShortcutDispatchInput } from './app-command-handlers'
+
+const mocks = vi.hoisted(() => ({
+  store: {} as AppState
+}))
+
+vi.mock('../store', () => ({
+  useAppStore: Object.assign(vi.fn(), { getState: () => mocks.store })
+}))
+
+vi.mock('@/lib/floating-workspace-terminal-actions', () => ({
+  isFloatingWorkspacePanelFocused: () => false
+}))
+
+vi.mock('@/lib/terminal-shortcut-capture-notification', () => ({
+  showTerminalShortcutCaptureNotification: vi.fn()
+}))
+
+import { createAppCommandHandlers } from './app-command-handlers'
+
+function shortcutState(overrides: Partial<AppShortcutState> = {}): AppShortcutState {
+  return {
+    activeView: 'terminal',
+    activeWorktreeId: 'repo::/feature',
+    actions: {} as AppShortcutState['actions'],
+    creationLayoutActive: false,
+    floatingTerminalEnabled: false,
+    floatingTerminalOpen: false,
+    floatingVisibleTabCount: 0,
+    keybindings: {},
+    openFloatingWorkspaceMaximized: vi.fn(),
+    pluginCommands: [],
+    setFloatingTerminalOpen: vi.fn(),
+    terminalShortcutPolicy: 'orca-first',
+    workspaceChromeActive: true,
+    ...overrides
+  }
+}
+
+function shortcutInput(): ShortcutDispatchInput {
+  return {
+    target: null,
+    defaultPrevented: false,
+    preventDefault: vi.fn()
+  }
+}
+
+describe('sidebar.activity.toggle app command', () => {
+  let setSidebarBody: ReturnType<typeof vi.fn>
+  let setSidebarOpen: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    setSidebarBody = vi.fn()
+    setSidebarOpen = vi.fn()
+    mocks.store = {
+      sidebarBody: 'workspaces',
+      setSidebarBody,
+      setSidebarOpen
+    } as unknown as AppState
+  })
+
+  it('switches to the activity view and reveals the sidebar', () => {
+    const input = shortcutInput()
+    const handler = createAppCommandHandlers(shortcutState(), input).get('sidebar.activity.toggle')
+
+    expect(handler?.()).toBe(true)
+    expect(setSidebarBody).toHaveBeenCalledWith('agents')
+    expect(setSidebarOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('switches back to workspaces without forcing the sidebar open or closed', () => {
+    mocks.store = {
+      sidebarBody: 'agents',
+      setSidebarBody,
+      setSidebarOpen
+    } as unknown as AppState
+    const handler = createAppCommandHandlers(shortcutState()).get('sidebar.activity.toggle')
+
+    expect(handler?.()).toBe(true)
+    expect(setSidebarBody).toHaveBeenCalledWith('workspaces')
+    expect(setSidebarOpen).not.toHaveBeenCalled()
+  })
+
+  it('does not claim the chord from the Settings view', () => {
+    const handler = createAppCommandHandlers(shortcutState({ activeView: 'settings' })).get(
+      'sidebar.activity.toggle'
+    )
+
+    expect(handler?.()).toBe(false)
+    expect(setSidebarBody).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/app-shell/app-command-handlers.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.ts
@@ -179,6 +179,24 @@ export function createAppCommandHandlers(
         })
     ],
     [
+      'sidebar.activity.toggle',
+      () => {
+        if (activeView === 'settings') {
+          return false
+        }
+        return claim('sidebar.activity.toggle', () => {
+          const store = useAppStore.getState()
+          const nextShowingActivity = store.sidebarBody !== 'agents'
+          store.setSidebarBody(nextShowingActivity ? 'agents' : 'workspaces')
+          // Why: mirror sidebar.sleepingWorkspaces.toggle — reveal only when opening,
+          // never force the sidebar closed while turning the activity view off.
+          if (nextShowingActivity) {
+            store.setSidebarOpen(true)
+          }
+        })
+      }
+    ],
+    [
       'floatingWorkspace.maximize',
       () => {
         if (floatingTerminalOpen || !floatingTerminalEnabled) {

--- a/src/shared/keybindings-unassigned-actions.test.ts
+++ b/src/shared/keybindings-unassigned-actions.test.ts
@@ -215,6 +215,35 @@ describe('keybindings', () => {
     )
   })
 
+  it('keeps the activity view toggle unassigned until users customize it', () => {
+    const binding = {
+      key: 'b',
+      code: 'KeyB',
+      control: true,
+      meta: false,
+      alt: true,
+      shift: false
+    }
+
+    const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
+    for (const platform of platforms) {
+      expect(getEffectiveKeybindingsForAction('sidebar.activity.toggle', platform)).toEqual([])
+    }
+    expect(keybindingMatchesAction('sidebar.activity.toggle', binding, 'linux')).toBe(false)
+    expect(
+      keybindingMatchesAction('sidebar.activity.toggle', binding, 'linux', {
+        'sidebar.activity.toggle': ['Mod+Alt+B']
+      })
+    ).toBe(true)
+
+    const definition = getKeybindingDefinition('sidebar.activity.toggle')
+    expect(definition?.title).toBe('Toggle Activity View')
+    expect(definition?.group).toBe('Global')
+    expect(definition?.searchKeywords).toEqual(
+      expect.arrayContaining(['bell', 'notification', 'attention', 'waiting', 'unread'])
+    )
+  })
+
   it('leaves floating workspace minimize unassigned because floating terminal toggle owns show and hide', () => {
     const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
     const minimizeAction = 'floatingWorkspace.minimize' as KeybindingActionId

--- a/src/shared/keybindings/definitions-core-1.ts
+++ b/src/shared/keybindings/definitions-core-1.ts
@@ -257,6 +257,28 @@ export const KEYBINDING_DEFINITION_CORE_1: readonly KeybindingDefinition[] = [
     defaultBindings: platformBindings([])
   },
   {
+    id: 'sidebar.activity.toggle',
+    title: 'Toggle Activity View',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: [
+      'shortcut',
+      'sidebar',
+      'activity',
+      'agents',
+      'bell',
+      'notification',
+      'notifications',
+      'attention',
+      'needs attention',
+      'waiting',
+      'unread'
+    ],
+    // Why: configurable but unbound by default, matching sidebar.sleepingWorkspaces.toggle —
+    // reaching this view otherwise takes a mouse click on the sidebar's bell button (#19519).
+    defaultBindings: platformBindings([])
+  },
+  {
     id: 'sidebar.focusWorktreeList',
     title: 'Focus worktree list',
     group: 'Global',
@@ -272,29 +294,6 @@ export const KEYBINDING_DEFINITION_CORE_1: readonly KeybindingDefinition[] = [
     scope: 'global',
     searchKeywords: ['shortcut', 'floating terminal', 'terminal'],
     defaultBindings: platformBindings(['Mod+Alt+A']),
-    allowInTerminal: true
-  },
-  {
-    id: 'floatingWorkspace.maximize',
-    title: 'Maximize Floating Workspace Panel',
-    group: 'Global',
-    scope: 'global',
-    searchKeywords: [
-      'shortcut',
-      'floating',
-      'workspace',
-      'panel',
-      'floating workspace',
-      'workspace panel',
-      'maximize',
-      'expand'
-    ],
-    // Why: pairs with floatingTerminal.toggle (Cmd+Opt+A) so maximize stays one-handed; macOS-only, Linux/Windows unbound.
-    defaultBindings: {
-      darwin: ['Mod+Alt+Shift+A'],
-      linux: [],
-      win32: []
-    },
     allowInTerminal: true
   }
 ]

--- a/src/shared/keybindings/definitions-core-2.ts
+++ b/src/shared/keybindings/definitions-core-2.ts
@@ -3,6 +3,29 @@ import { platformBindings } from './definitions-support'
 
 export const KEYBINDING_DEFINITION_CORE_2: readonly KeybindingDefinition[] = [
   {
+    id: 'floatingWorkspace.maximize',
+    title: 'Maximize Floating Workspace Panel',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: [
+      'shortcut',
+      'floating',
+      'workspace',
+      'panel',
+      'floating workspace',
+      'workspace panel',
+      'maximize',
+      'expand'
+    ],
+    // Why: pairs with floatingTerminal.toggle (Cmd+Opt+A) so maximize stays one-handed; macOS-only, Linux/Windows unbound.
+    defaultBindings: {
+      darwin: ['Mod+Alt+Shift+A'],
+      linux: [],
+      win32: []
+    },
+    allowInTerminal: true
+  },
+  {
     id: 'floatingWorkspace.minimize',
     title: 'Minimize Floating Workspace Panel',
     group: 'Global',
@@ -265,18 +288,6 @@ export const KEYBINDING_DEFINITION_CORE_2: readonly KeybindingDefinition[] = [
       darwin: ['Mod+BracketLeft'],
       linux: ['Alt+ArrowLeft'],
       win32: ['Alt+ArrowLeft']
-    }
-  },
-  {
-    id: 'browser.forward',
-    title: 'Go Forward in Browser',
-    group: 'Browser',
-    scope: 'browser',
-    searchKeywords: ['shortcut', 'browser', 'history', 'forward', 'next'],
-    defaultBindings: {
-      darwin: ['Mod+BracketRight'],
-      linux: ['Alt+ArrowRight'],
-      win32: ['Alt+ArrowRight']
     }
   }
 ]

--- a/src/shared/keybindings/definitions-core-3.ts
+++ b/src/shared/keybindings/definitions-core-3.ts
@@ -3,6 +3,18 @@ import { platformBindings } from './definitions-support'
 
 export const KEYBINDING_DEFINITION_CORE_3: readonly KeybindingDefinition[] = [
   {
+    id: 'browser.forward',
+    title: 'Go Forward in Browser',
+    group: 'Browser',
+    scope: 'browser',
+    searchKeywords: ['shortcut', 'browser', 'history', 'forward', 'next'],
+    defaultBindings: {
+      darwin: ['Mod+BracketRight'],
+      linux: ['Alt+ArrowRight'],
+      win32: ['Alt+ArrowRight']
+    }
+  },
+  {
     id: 'browser.reload',
     title: 'Reload Browser Page',
     group: 'Browser',
@@ -280,13 +292,5 @@ export const KEYBINDING_DEFINITION_CORE_3: readonly KeybindingDefinition[] = [
     scope: 'terminal',
     searchKeywords: ['shortcut', 'pane', 'expand', 'collapse'],
     defaultBindings: platformBindings(['Mod+Shift+Enter'])
-  },
-  {
-    id: 'terminal.setTitle',
-    title: 'Set Title…',
-    group: 'Terminal Panes',
-    scope: 'terminal',
-    searchKeywords: ['shortcut', 'terminal', 'pane', 'set title', 'title', 'rename'],
-    defaultBindings: platformBindings([])
   }
 ]

--- a/src/shared/keybindings/definitions-core-4.ts
+++ b/src/shared/keybindings/definitions-core-4.ts
@@ -3,6 +3,14 @@ import { platformBindings } from './definitions-support'
 
 export const KEYBINDING_DEFINITION_CORE_4: readonly KeybindingDefinition[] = [
   {
+    id: 'terminal.setTitle',
+    title: 'Set Title…',
+    group: 'Terminal Panes',
+    scope: 'terminal',
+    searchKeywords: ['shortcut', 'terminal', 'pane', 'set title', 'title', 'rename'],
+    defaultBindings: platformBindings([])
+  },
+  {
     id: 'terminal.clearPaneTitle',
     title: 'Clear Pane Title',
     group: 'Terminal Panes',

--- a/src/shared/keybindings/types.ts
+++ b/src/shared/keybindings/types.ts
@@ -47,6 +47,7 @@ export type KeybindingActionId =
   | 'sidebar.checks.toggle'
   | 'sidebar.ports.toggle'
   | 'sidebar.sleepingWorkspaces.toggle'
+  | 'sidebar.activity.toggle'
   | 'sidebar.focusWorktreeList'
   | 'floatingTerminal.toggle'
   | 'floatingWorkspace.maximize'

--- a/src/shared/plugins/plugin-command-actions.ts
+++ b/src/shared/plugins/plugin-command-actions.ts
@@ -7,6 +7,7 @@ export const PLUGIN_COMMAND_ALIAS_ACTION_IDS = [
   'worktree.history.forward',
   'sidebar.left.toggle',
   'sidebar.sleepingWorkspaces.toggle',
+  'sidebar.activity.toggle',
   'floatingWorkspace.maximize',
   'tab.rename',
   'workspace.rename',


### PR DESCRIPTION
## Summary

Adds a new bindable command, `sidebar.activity.toggle` ("Toggle Activity View"), that jumps straight to the sidebar's bell/notification list — the view showing each session's waiting time (e.g. "5m", "9m") — instead of requiring a mouse click on the bell icon.

Closes #19519.

## Why

The Agent Dashboard already has a bindable command (`dashboard.toggle`), but the sidebar's notification/activity list (opened via the bell icon in the sidebar header) had no command of its own, so it wasn't discoverable in Shortcuts settings when searching for "bell", "notification", "waiting", "needs", or "attention" — exactly what the issue reporter searched for.

## What changed

- New `KeybindingActionId`: `sidebar.activity.toggle`, defined unbound by default (like `dashboard.toggle` and `workspace.openBoard`) so it doesn't claim a cross-platform chord — users assign it themselves in Settings → Shortcuts.
- Search keywords include `bell`, `notification`, `attention`, `waiting`, `unread` so it surfaces for the exact terms from the issue.
- Handler in `app-command-handlers.ts` mirrors the sidebar bell button's own toggle behavior exactly: flips `sidebarBody` between `'agents'` and `'workspaces'`, and reveals the sidebar only when opening (never forces it closed), matching the existing `sidebar.sleepingWorkspaces.toggle` pattern. No-ops in the Settings view.
- Wired into the existing renderer-owned command dispatch path (`PLUGIN_COMMAND_ALIAS_ACTION_IDS` + `createAppCommandHandlers`) used by other pure-UI toggles like `sidebar.left.toggle` — no main-process/global-accelerator plumbing needed since this view lives in the main window only.
- Rebalanced `definitions-core-{1..4}.ts` to stay under the repo's 300-line-per-file cap; these are pure relocations of existing, unmodified definitions to keep the concatenated palette order unchanged (per the file's own "boundaries follow line count, not theme" comment).
- Added tests (new definition, unassigned-by-default behavior, and handler behavior) and a doc bullet in `docs/site/content/docs/settings.mdx`.

## Testing

- `vitest run` on the touched/related test files (keybindings, app-command-handlers, shortcut-groups/visibility) — all green.
- `tsc --noEmit` on the web project — no new errors introduced.
- `oxlint` on all touched files — clean.
- Ran `/code-review medium` on the diff — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GD1x6ysNRB3e9nMxkofttK
