### PR TITLE
fix(keybindings): match Option chords by layout character, not physical key

### DIFF
--- a/src/renderer/src/app-shell/global-keybindings-layout-prefetch.test.tsx
+++ b/src/renderer/src/app-shell/global-keybindings-layout-prefetch.test.tsx
@@ -1,0 +1,70 @@
+// The global dispatcher resolves Option chords through the active layout, so the layout
+// cache must be warm at renderer startup rather than when a terminal pane first mounts.
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { keybindingMatchesAction } from '../../../shared/keybindings'
+import type * as LayoutBaseCharacter from '@/lib/keyboard-layout/layout-base-character'
+
+const prefetchLayoutCharacters = vi.fn()
+
+vi.mock('@/lib/keyboard-layout/layout-base-character', async (importOriginal) => {
+  const actual = await importOriginal<typeof LayoutBaseCharacter>()
+  return { ...actual, prefetchLayoutCharacters }
+})
+
+describe('renderer startup warms the keyboard layout cache', () => {
+  beforeEach(() => {
+    prefetchLayoutCharacters.mockClear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('prefetches the layout characters on macOS without a terminal pane', async () => {
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' })
+    const { warmKeyboardLayoutCache } = await import('./global-keybindings-layout-prefetch')
+    warmKeyboardLayoutCache('darwin')
+    expect(prefetchLayoutCharacters).toHaveBeenCalledOnce()
+  })
+
+  it('does not prefetch on Windows or Linux, where Option does not compose', async () => {
+    const { warmKeyboardLayoutCache } = await import('./global-keybindings-layout-prefetch')
+    warmKeyboardLayoutCache('win32')
+    warmKeyboardLayoutCache('linux')
+    expect(prefetchLayoutCharacters).not.toHaveBeenCalled()
+  })
+})
+
+describe('the global dispatcher resolves a Dvorak Option chord before any terminal exists', () => {
+  it('matches Alt+Z on the key that types z, not the physical Z key', () => {
+    // Dvorak: physical Semicolon types 'z'; physical KeyZ types ';'.
+    const dvorak = (code: string): string | undefined =>
+      code === 'Semicolon' ? 'z' : code === 'KeyZ' ? ';' : undefined
+    const optionChord = (code: string) => ({
+      key: 'Ω',
+      code,
+      alt: true,
+      control: false,
+      meta: false,
+      shift: false
+    })
+
+    expect(
+      keybindingMatchesAction(
+        'editor.toggleWordWrap',
+        optionChord('Semicolon'),
+        'darwin',
+        undefined,
+        {
+          layoutCharacterForCode: dvorak
+        }
+      )
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction('editor.toggleWordWrap', optionChord('KeyZ'), 'darwin', undefined, {
+        layoutCharacterForCode: dvorak
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/app-shell/global-keybindings-layout-prefetch.ts
+++ b/src/renderer/src/app-shell/global-keybindings-layout-prefetch.ts
@@ -1,0 +1,15 @@
+import { prefetchLayoutCharacters } from '@/lib/keyboard-layout/layout-base-character'
+
+/**
+ * Warms the active layout's character cache for the window-level shortcut dispatchers.
+ *
+ * Why: the cache resolves asynchronously, and Option chords fall back to US-QWERTY
+ * physical codes while it is empty. Only macOS composes Option into a character with
+ * no Latin logical key, so other platforms never consult the cache.
+ */
+export function warmKeyboardLayoutCache(platform: NodeJS.Platform): void {
+  if (platform !== 'darwin') {
+    return
+  }
+  prefetchLayoutCharacters()
+}

--- a/src/renderer/src/app-shell/use-global-keybindings.ts
+++ b/src/renderer/src/app-shell/use-global-keybindings.ts
@@ -166,7 +166,8 @@ export function useGlobalKeybindings(args: {
       // An empty floating workspace has no tab to close, so Cmd/Ctrl+W hides the overlay before other surfaces act.
       if (
         keybindingMatchesAction('tab.close', input, shortcutPlatform, keybindings, {
-          context: 'app'
+          context: 'app',
+          layoutCharacterForCode: getLayoutBaseCharacterForCode
         }) &&
         shouldMinimizeFloatingWorkspacePanelOnCloseShortcut({
           floatingTerminalOpen,

--- a/src/renderer/src/app-shell/use-global-keybindings.ts
+++ b/src/renderer/src/app-shell/use-global-keybindings.ts
@@ -20,6 +20,7 @@ import {
 } from '../components/right-sidebar/file-search-include-pattern'
 import { usePluginCommands } from '@/store/plugin-panels'
 import { useAppStore } from '../store'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 import {
   keybindingMatchesAction,
   type KeybindingActionId,
@@ -122,7 +123,8 @@ export function useGlobalKeybindings(args: {
       const matchShortcut = (actionId: KeybindingActionId): boolean =>
         keybindingMatchesAction(actionId, input, shortcutPlatform, keybindings, {
           context,
-          terminalShortcutPolicy
+          terminalShortcutPolicy,
+          layoutCharacterForCode: getLayoutBaseCharacterForCode
         })
       const notifyTerminalCapture = (actionId: KeybindingActionId): void => {
         if (context !== 'terminal' || (terminalShortcutPolicy ?? 'orca-first') !== 'orca-first') {
@@ -199,7 +201,11 @@ export function useGlobalKeybindings(args: {
 
       // Only short-circuit chords the floating panel itself claims; suppressing others here would silently no-op them when focus is in the panel.
       if (isFloatingWorkspacePanelFocused()) {
-        const floatingMatchOptions: KeybindingMatchOptions = { context, terminalShortcutPolicy }
+        const floatingMatchOptions: KeybindingMatchOptions = {
+          context,
+          terminalShortcutPolicy,
+          layoutCharacterForCode: getLayoutBaseCharacterForCode
+        }
         if (
           matchFloatingWorkspacePanelChord(
             input,

--- a/src/renderer/src/app-shell/use-global-keybindings.ts
+++ b/src/renderer/src/app-shell/use-global-keybindings.ts
@@ -21,6 +21,7 @@ import {
 import { usePluginCommands } from '@/store/plugin-panels'
 import { useAppStore } from '../store'
 import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
+import { warmKeyboardLayoutCache } from './global-keybindings-layout-prefetch'
 import {
   keybindingMatchesAction,
   type KeybindingActionId,
@@ -82,6 +83,7 @@ export function useGlobalKeybindings(args: {
   })
 
   useEffect(() => {
+    warmKeyboardLayoutCache(shortcutPlatform)
     const doubleTapDetector = new ModifierDoubleTapDetector()
 
     const unregisterAppCommandDispatcher = registerAppCommandDispatcher((actionId) =>

--- a/src/renderer/src/components/editor/editor-shortcuts.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.ts
@@ -1,4 +1,5 @@
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { useAppStore } from '@/store'
 import { keybindingMatchesAction, type KeybindingActionId } from '../../../../shared/keybindings'
@@ -11,7 +12,8 @@ export function editorShortcutMatches(
     actionId,
     event,
     getShortcutPlatform(),
-    useAppStore.getState().keybindings
+    useAppStore.getState().keybindings,
+    { layoutCharacterForCode: getLayoutBaseCharacterForCode }
   )
 }
 

--- a/src/renderer/src/components/editor/markdown-preview-search.ts
+++ b/src/renderer/src/components/editor/markdown-preview-search.ts
@@ -1,4 +1,8 @@
-import { keybindingMatchesAction, type KeybindingOverrides } from '../../../../shared/keybindings'
+import {
+  keybindingMatchesAction,
+  type KeybindingOverrides,
+  type LayoutCharacterLookup
+} from '../../../../shared/keybindings'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
 
 export const MARKDOWN_PREVIEW_SEARCH_QUERY_MAX_BYTES = 2 * 1024
@@ -13,17 +17,23 @@ export function isMarkdownPreviewSearchQueryTooLarge(
 export function isMarkdownPreviewFindShortcut(
   event: Pick<KeyboardEvent, 'key' | 'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
   platform: NodeJS.Platform,
-  keybindings?: KeybindingOverrides
+  keybindings?: KeybindingOverrides,
+  layoutCharacterForCode?: LayoutCharacterLookup
 ): boolean {
-  return keybindingMatchesAction('editor.find', event, platform, keybindings)
+  return keybindingMatchesAction('editor.find', event, platform, keybindings, {
+    layoutCharacterForCode
+  })
 }
 
 export function isMarkdownPreviewReplaceShortcut(
   event: Pick<KeyboardEvent, 'key' | 'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
   platform: NodeJS.Platform,
-  keybindings?: KeybindingOverrides
+  keybindings?: KeybindingOverrides,
+  layoutCharacterForCode?: LayoutCharacterLookup
 ): boolean {
-  return keybindingMatchesAction('editor.replace', event, platform, keybindings)
+  return keybindingMatchesAction('editor.replace', event, platform, keybindings, {
+    layoutCharacterForCode
+  })
 }
 
 export type TextMatchOptions = {

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.ts
@@ -34,6 +34,7 @@ import type { RichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-htm
 import { handleRichMarkdownLinkShortcut } from './rich-markdown-link-shortcut'
 import { handleRichMarkdownSaveShortcut } from './rich-markdown-save-shortcut'
 import { flushPendingProseMirrorSelection } from './rich-markdown-selection-flush'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 
 export type KeyHandlerContext = {
   isMac: boolean
@@ -96,7 +97,8 @@ export function createRichMarkdownKeyHandler(
       isMarkdownPreviewFindShortcut(
         event,
         getShortcutPlatform(),
-        useAppStore.getState().keybindings
+        useAppStore.getState().keybindings,
+        getLayoutBaseCharacterForCode
       )
     ) {
       event.preventDefault()

--- a/src/renderer/src/components/editor/use-markdown-preview-viewport.ts
+++ b/src/renderer/src/components/editor/use-markdown-preview-viewport.ts
@@ -14,6 +14,7 @@ import {
 } from './markdown-preview-search'
 import type { MarkdownPreviewFoundation } from './use-markdown-preview-foundation'
 import { useMarkdownPreviewScrollViewport } from './use-markdown-preview-scroll-viewport'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 
 function clearMarkdownPreviewTimeout(timeoutRef: MutableRefObject<number | null>): void {
   if (timeoutRef.current === null) {
@@ -244,7 +245,12 @@ export function useMarkdownPreviewViewport({
       const targetInsidePreview = target instanceof Node && root.contains(target)
 
       if (
-        isMarkdownPreviewFindShortcut(event, getShortcutPlatform(), keybindings) &&
+        isMarkdownPreviewFindShortcut(
+          event,
+          getShortcutPlatform(),
+          keybindings,
+          getLayoutBaseCharacterForCode
+        ) &&
         targetInsidePreview
       ) {
         event.preventDefault()

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -14,6 +14,7 @@ import {
   richMarkdownSearchPluginKey
 } from './rich-markdown-search'
 import { createRichMarkdownSearchMatchesCache } from './rich-markdown-search-matches-cache'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 
 export function useRichMarkdownSearch({
   editor,
@@ -315,20 +316,19 @@ export function useRichMarkdownSearch({
 
       const target = event.target
       const targetInsideEditor = target instanceof Node && root.contains(target)
-      if (
-        isMarkdownPreviewFindShortcut(event, getShortcutPlatform(), keybindings) &&
-        targetInsideEditor
-      ) {
+      const shortcutArgs = [
+        getShortcutPlatform(),
+        keybindings,
+        getLayoutBaseCharacterForCode
+      ] as const
+      if (isMarkdownPreviewFindShortcut(event, ...shortcutArgs) && targetInsideEditor) {
         event.preventDefault()
         event.stopPropagation()
         openSearch()
         return
       }
 
-      if (
-        isMarkdownPreviewReplaceShortcut(event, getShortcutPlatform(), keybindings) &&
-        targetInsideEditor
-      ) {
+      if (isMarkdownPreviewReplaceShortcut(event, ...shortcutArgs) && targetInsideEditor) {
         event.preventDefault()
         event.stopPropagation()
         openReplace()

--- a/src/renderer/src/components/floating-terminal/use-floating-terminal-global-shortcut-listeners.ts
+++ b/src/renderer/src/components/floating-terminal/use-floating-terminal-global-shortcut-listeners.ts
@@ -4,6 +4,7 @@ import {
   isFloatingWorkspaceTerminalInputTarget,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { useAppStore } from '@/store'
 import {
@@ -68,7 +69,8 @@ export function useFloatingTerminalGlobalShortcutListeners({
       const matches = (actionId: KeybindingActionId): boolean =>
         keybindingMatchesAction(actionId, event, getShortcutPlatform(), state.keybindings, {
           context,
-          terminalShortcutPolicy: state.settings?.terminalShortcutPolicy
+          terminalShortcutPolicy: state.settings?.terminalShortcutPolicy,
+          layoutCharacterForCode: getLayoutBaseCharacterForCode
         })
       const consume = (): void => {
         event.preventDefault()

--- a/src/renderer/src/components/floating-terminal/use-floating-terminal-panel-shortcuts.ts
+++ b/src/renderer/src/components/floating-terminal/use-floating-terminal-panel-shortcuts.ts
@@ -6,6 +6,7 @@ import {
   matchFloatingWorkspacePanelShortcut
 } from '@/lib/floating-workspace-shortcut-policy'
 import { isFloatingWorkspaceTerminalInputTarget } from '@/lib/floating-workspace-terminal-actions'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { requestTerminalTabRename } from '@/components/tab-bar/terminal-tab-rename-request'
 import { useAppStore } from '@/store'
@@ -75,10 +76,18 @@ export function useFloatingTerminalPanelShortcuts({
         : isFloatingTerminalInput
           ? 'terminal'
           : 'app'
-      const matchOptions: KeybindingMatchOptions = { context, terminalShortcutPolicy }
+      const matchOptions: KeybindingMatchOptions = {
+        context,
+        terminalShortcutPolicy,
+        layoutCharacterForCode: getLayoutBaseCharacterForCode
+      }
       const floatingChromeMatchOptions: KeybindingMatchOptions =
         isFloatingTerminalInput && terminalShortcutPolicy === 'terminal-first'
-          ? { context: 'app', terminalShortcutPolicy }
+          ? {
+              context: 'app',
+              terminalShortcutPolicy,
+              layoutCharacterForCode: getLayoutBaseCharacterForCode
+            }
           : matchOptions
       const ownedAction = matchFloatingWorkspacePanelOwnedAction(
         input,

--- a/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
@@ -20,6 +20,7 @@ import {
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { translate } from '@/i18n/i18n'
 import { isEditableTarget } from '@/lib/editable-target'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 
 export function shouldIgnoreFileExplorerKeyTarget(target: EventTarget | null): boolean {
   return (
@@ -250,13 +251,17 @@ export function useFileExplorerKeys(opts: {
         'fileExplorer.copyRelativePath',
         e,
         platform,
-        keybindings
+        keybindings,
+        { layoutCharacterForCode: getLayoutBaseCharacterForCode }
       )
       const wantsCopyPath = keybindingMatchesAction(
         'fileExplorer.copyPath',
         e,
         platform,
-        keybindings
+        keybindings,
+        {
+          layoutCharacterForCode: getLayoutBaseCharacterForCode
+        }
       )
       if (!wantsCopyRelativePath && !wantsCopyPath) {
         return

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-layout.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-layout.test.ts
@@ -1,0 +1,74 @@
+// Terminal shortcut resolution must consult the active layout for Option chords, which
+// macOS reports as composed characters with no Latin logical key.
+import { describe, expect, it } from 'vitest'
+import {
+  resolveTerminalShortcutAction,
+  type TerminalShortcutEvent
+} from './terminal-shortcut-policy'
+
+function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent {
+  return {
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    repeat: false,
+    ...overrides
+  }
+}
+
+describe('resolveTerminalShortcutAction layout-aware Option chords', () => {
+  // Dvorak: physical Z types ';' and physical Semicolon types 'z'.
+  const dvorakLayoutCharacter = (code: string, shifted: boolean): string | undefined => {
+    if (shifted) {
+      return undefined
+    }
+    if (code === 'KeyZ') {
+      return ';'
+    }
+    if (code === 'Semicolon') {
+      return 'z'
+    }
+    return undefined
+  }
+
+  const optionChord = (code: string): TerminalShortcutEvent =>
+    event({ key: 'Ω', code, altKey: true })
+
+  const remappedSearch = { 'terminal.search': ['Alt+Z'] }
+
+  function resolveWithLayout(
+    input: TerminalShortcutEvent,
+    layout?: (code: string, shifted: boolean) => string | undefined
+  ): ReturnType<typeof resolveTerminalShortcutAction> {
+    return resolveTerminalShortcutAction(
+      input,
+      true,
+      'false',
+      0,
+      false,
+      remappedSearch,
+      undefined,
+      undefined,
+      layout
+    )
+  }
+
+  it('matches an Option chord by physical code when no layout lookup is supplied', () => {
+    expect(resolveWithLayout(optionChord('KeyZ'))).toEqual({ type: 'toggleSearch' })
+  })
+
+  it('does not match physical Z on Dvorak, where that key types a semicolon', () => {
+    expect(resolveWithLayout(optionChord('KeyZ'), dvorakLayoutCharacter)).not.toEqual({
+      type: 'toggleSearch'
+    })
+  })
+
+  it('matches the key that actually types z on Dvorak', () => {
+    expect(resolveWithLayout(optionChord('Semicolon'), dvorakLayoutCharacter)).toEqual({
+      type: 'toggleSearch'
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -3,6 +3,7 @@ import {
   type KeybindingInput,
   type KeybindingMatchOptions,
   type KeybindingOverrides,
+  type LayoutCharacterLookup,
   type TerminalShortcutPolicy
 } from '../../../../shared/keybindings'
 import type { WindowsShiftEnterEncoding } from './terminal-windows-shift-enter'
@@ -94,71 +95,86 @@ export function resolveTerminalShortcutAction(
   hasCtrlEnterCsiUAuthority?: () => boolean
 ): TerminalShortcutAction | null {
   const platform: NodeJS.Platform = isMac ? 'darwin' : isWindows ? 'win32' : 'linux'
+  // Why: an Option chord composes from the unshifted layer, so shortcut matching asks for the base character.
+  const baseLayoutCharacterForCode: LayoutCharacterLookup | undefined = layoutCharacterForCode
+    ? (code) => layoutCharacterForCode(code, false)
+    : undefined
+  const matchesAction = (actionId: Parameters<typeof keybindingMatchesAction>[0]): boolean =>
+    keybindingMatchesAction(actionId, event, platform, keybindings, {
+      layoutCharacterForCode: baseLayoutCharacterForCode
+    })
 
   // Why: capture this chord even on repeat without blocking the OS default input-source switch.
-  if (keybindingMatchesAction('terminal.switchInputSource', event, platform, keybindings)) {
+  if (matchesAction('terminal.switchInputSource')) {
     return { type: 'switchInputSource' }
   }
 
   // Why: held select-all keydowns must remain claimed until keyup so Kitty
   // event reporting cannot encode their repeat or release into the PTY.
-  if (keybindingMatchesAction('terminal.selectAll', event, platform, keybindings)) {
+  if (matchesAction('terminal.selectAll')) {
     return { type: 'selectAll' }
   }
 
   if (!event.repeat) {
-    if (keybindingMatchesAction('terminal.copySelection', event, platform, keybindings)) {
+    if (matchesAction('terminal.copySelection')) {
       return { type: 'copySelection' }
     }
 
-    if (keybindingMatchesAction('terminal.search', event, platform, keybindings)) {
+    if (matchesAction('terminal.search')) {
       return { type: 'toggleSearch' }
     }
 
-    if (keybindingMatchesAction('terminal.clear', event, platform, keybindings)) {
+    if (matchesAction('terminal.clear')) {
       return { type: 'clearActivePane' }
     }
 
-    if (keybindingMatchesAction('terminal.focusPreviousPane', event, platform, keybindings)) {
+    if (matchesAction('terminal.focusPreviousPane')) {
       return { type: 'focusPane', direction: 'previous' }
     }
 
-    if (keybindingMatchesAction('terminal.focusNextPane', event, platform, keybindings)) {
+    if (matchesAction('terminal.focusNextPane')) {
       return { type: 'focusPane', direction: 'next' }
     }
 
-    if (keybindingMatchesAction('terminal.equalizePaneSizes', event, platform, keybindings)) {
+    if (matchesAction('terminal.equalizePaneSizes')) {
       return { type: 'equalizePaneSizes' }
     }
 
-    if (keybindingMatchesAction('terminal.expandPane', event, platform, keybindings)) {
+    if (matchesAction('terminal.expandPane')) {
       return { type: 'toggleExpandActivePane' }
     }
 
-    if (keybindingMatchesAction('terminal.setTitle', event, platform, keybindings)) {
+    if (matchesAction('terminal.setTitle')) {
       return { type: 'setTitle' }
     }
 
-    if (keybindingMatchesAction('terminal.clearPaneTitle', event, platform, keybindings)) {
+    if (matchesAction('terminal.clearPaneTitle')) {
       return { type: 'clearPaneTitle' }
     }
 
     // Why: recognize the active tab.close binding as a pane-close alias too, so a user who remaps
     // tab.close alone still closes the focused split pane (never the whole tab); L2 always defers to us.
     if (
-      isTerminalPaneCloseChord(event, platform, keybindings, undefined, {
-        context: 'terminal',
-        terminalShortcutPolicy
-      })
+      isTerminalPaneCloseChord(
+        event,
+        platform,
+        keybindings,
+        { layoutCharacterForCode: baseLayoutCharacterForCode },
+        {
+          context: 'terminal',
+          terminalShortcutPolicy,
+          layoutCharacterForCode: baseLayoutCharacterForCode
+        }
+      )
     ) {
       return { type: 'closeActivePane' }
     }
 
-    if (keybindingMatchesAction('terminal.splitRight', event, platform, keybindings)) {
+    if (matchesAction('terminal.splitRight')) {
       return { type: 'splitActivePane', direction: 'vertical' }
     }
 
-    if (keybindingMatchesAction('terminal.splitDown', event, platform, keybindings)) {
+    if (matchesAction('terminal.splitDown')) {
       return { type: 'splitActivePane', direction: 'horizontal' }
     }
   }

--- a/src/renderer/src/components/terminal-workspace-keydown.ts
+++ b/src/renderer/src/components/terminal-workspace-keydown.ts
@@ -4,6 +4,7 @@ import type { KeybindingActionId } from '../../../shared/keybindings'
 import { keybindingMatchesAction } from '../../../shared/keybindings'
 import { matchesRecentTabSwitcherChord } from '../../../shared/window-shortcut-policy'
 import { useAppStore } from '../store'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 import {
   createFloatingWorkspaceBrowserTab,
   createFloatingWorkspaceMarkdownTab,
@@ -49,7 +50,8 @@ export function handleTerminalWorkspaceKeyDown(
   const matchShortcut = (actionId: KeybindingActionId): boolean =>
     keybindingMatchesAction(actionId, event, shortcutPlatform, keybindings, {
       context,
-      terminalShortcutPolicy
+      terminalShortcutPolicy,
+      layoutCharacterForCode: getLayoutBaseCharacterForCode
     })
   const notifyTerminalCapture = (actionId: KeybindingActionId): void => {
     if (context !== 'terminal' || terminalShortcutPolicy !== 'orca-first') {

--- a/src/renderer/src/lib/keybinding-dispatcher-layout.test.ts
+++ b/src/renderer/src/lib/keybinding-dispatcher-layout.test.ts
@@ -1,0 +1,155 @@
+// Option chords must resolve against the active layout's character in every dispatcher
+// that owns a shortcut, not just the ones traced when the shared matcher gained the lookup.
+import { describe, expect, it } from 'vitest'
+import {
+  keybindingMatchesAction,
+  keybindingMatchesInput,
+  type KeybindingInput,
+  type LayoutCharacterLookup
+} from '../../../shared/keybindings'
+import {
+  matchFloatingWorkspacePanelOwnedAction,
+  matchFloatingWorkspacePanelShortcut
+} from './floating-workspace-shortcut-policy'
+
+// Dvorak: the key engraved Z on a QWERTY board types ';', and ';' types 'z'.
+const dvorakLookup: LayoutCharacterLookup = (code) => {
+  if (code === 'KeyZ') {
+    return ';'
+  }
+  if (code === 'Semicolon') {
+    return 'z'
+  }
+  if (code === 'KeyA') {
+    return 'a'
+  }
+  return undefined
+}
+
+// macOS reports the composed character for Option chords, leaving no Latin logical key.
+function optionChord(overrides: Partial<KeybindingInput>): KeybindingInput {
+  return {
+    key: 'Ω',
+    code: 'KeyZ',
+    alt: true,
+    control: false,
+    meta: false,
+    shift: false,
+    ...overrides
+  } as KeybindingInput
+}
+
+describe('editor.toggleWordWrap (Alt+Z) through the shared matcher', () => {
+  it('matches the physical Z key when no layout lookup is supplied', () => {
+    expect(keybindingMatchesAction('editor.toggleWordWrap', optionChord({}), 'darwin')).toBe(true)
+  })
+
+  it('does not match physical Z on Dvorak, where that key types a semicolon', () => {
+    expect(
+      keybindingMatchesAction('editor.toggleWordWrap', optionChord({}), 'darwin', undefined, {
+        layoutCharacterForCode: dvorakLookup
+      })
+    ).toBe(false)
+  })
+
+  it('matches the key that actually types z on Dvorak', () => {
+    expect(
+      keybindingMatchesAction(
+        'editor.toggleWordWrap',
+        optionChord({ code: 'Semicolon' }),
+        'darwin',
+        undefined,
+        { layoutCharacterForCode: dvorakLookup }
+      )
+    ).toBe(true)
+  })
+})
+
+describe('floating workspace panel dispatcher', () => {
+  const maximizeChord = (code: string): KeybindingInput =>
+    optionChord({ key: 'Å', code, meta: true, shift: true })
+
+  it('still claims Mod+Alt+Shift+A on QWERTY with the lookup wired in', () => {
+    expect(
+      matchFloatingWorkspacePanelShortcut(
+        { ...maximizeChord('KeyA'), target: null } as never,
+        'darwin',
+        undefined,
+        { context: 'app', layoutCharacterForCode: dvorakLookup }
+      )
+    ).toEqual({ kind: 'action', action: 'floatingWorkspace.maximize' })
+  })
+
+  it('does not claim maximize from a physical A that types another character', () => {
+    const swappedLookup: LayoutCharacterLookup = (code) => (code === 'KeyA' ? 'q' : undefined)
+    expect(
+      matchFloatingWorkspacePanelShortcut(
+        { ...maximizeChord('KeyA'), target: null } as never,
+        'darwin',
+        undefined,
+        { context: 'app', layoutCharacterForCode: swappedLookup }
+      )
+    ).toBeNull()
+  })
+
+  it('resolves owned creation chords against the layout character', () => {
+    // tab.closeAll is Mod+Alt+W; tab.close (owned) stays Mod+W, so an Option chord
+    // on a remapped layout must not resolve through the physical code.
+    const remapped = { 'tab.close': ['Alt+Z'] }
+    expect(
+      matchFloatingWorkspacePanelOwnedAction(
+        { ...optionChord({}), target: null } as never,
+        'darwin',
+        remapped,
+        { context: 'app', layoutCharacterForCode: dvorakLookup }
+      )
+    ).toBeNull()
+    expect(
+      matchFloatingWorkspacePanelOwnedAction(
+        { ...optionChord({ code: 'Semicolon' }), target: null } as never,
+        'darwin',
+        remapped,
+        { context: 'app', layoutCharacterForCode: dvorakLookup }
+      )
+    ).toBe('tab.close')
+  })
+})
+
+describe('file explorer copy-path chords', () => {
+  // fileExplorer.copyPath is Mod+Alt+C on darwin.
+  const copyPathLookup: LayoutCharacterLookup = (code) =>
+    code === 'KeyC' ? 'j' : code === 'KeyJ' ? 'c' : undefined
+
+  it('does not match physical C when that key types j', () => {
+    expect(
+      keybindingMatchesAction(
+        'fileExplorer.copyPath',
+        optionChord({ key: 'ç', code: 'KeyC', meta: true }),
+        'darwin',
+        undefined,
+        { layoutCharacterForCode: copyPathLookup }
+      )
+    ).toBe(false)
+  })
+
+  it('matches the key that types c on that layout', () => {
+    expect(
+      keybindingMatchesAction(
+        'fileExplorer.copyPath',
+        optionChord({ key: 'ç', code: 'KeyJ', meta: true }),
+        'darwin',
+        undefined,
+        { layoutCharacterForCode: copyPathLookup }
+      )
+    ).toBe(true)
+  })
+})
+
+describe('plugin command bindings', () => {
+  it('resolves a plugin-declared Alt+letter binding through the layout lookup', () => {
+    expect(keybindingMatchesInput('Alt+Z', optionChord({}), 'darwin', dvorakLookup)).toBe(false)
+    expect(
+      keybindingMatchesInput('Alt+Z', optionChord({ code: 'Semicolon' }), 'darwin', dvorakLookup)
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/plugin-command-keybindings.ts
+++ b/src/renderer/src/lib/plugin-command-keybindings.ts
@@ -8,6 +8,7 @@ import {
   type PluginKeybindingActionId
 } from '../../../shared/keybindings'
 import { translate } from '@/i18n/i18n'
+import { getLayoutBaseCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 import { pluginCommandKeybindingActionId as sharedPluginCommandKeybindingActionId } from '../../../shared/plugins/plugin-command-actions'
 
 export function pluginCommandKeybindingActionId(
@@ -65,7 +66,7 @@ export function findPluginCommandForKeybinding(
       continue
     }
     const matches = getEffectivePluginCommandKeybindings(command, platform, overrides).some(
-      (binding) => keybindingMatchesInput(binding, input, platform)
+      (binding) => keybindingMatchesInput(binding, input, platform, getLayoutBaseCharacterForCode)
     )
     if (matches) {
       return command

--- a/src/shared/keybindings-keyboard-layout.test.ts
+++ b/src/shared/keybindings-keyboard-layout.test.ts
@@ -341,4 +341,143 @@ describe('keybindings', () => {
       false
     )
   })
+
+  describe('Option-chord matching resolves the layout character on macOS (#2858 regression on the Alt path)', () => {
+    // Dvorak's ';' key sits at physical KeyZ; Option+that key composes '…' with no logical Latin key.
+    const dvorakOptionOnZPosition = {
+      key: '…',
+      code: 'KeyZ',
+      control: false,
+      meta: false,
+      alt: true,
+      shift: false
+    }
+    // Dvorak's 'z' key sits at physical Semicolon; Option+that key composes 'Ω'.
+    const dvorakOptionOnSemicolonPosition = {
+      key: 'Ω',
+      code: 'Semicolon',
+      control: false,
+      meta: false,
+      alt: true,
+      shift: false
+    }
+    const dvorakLayoutCharacterForCode = (code: string): string | undefined =>
+      ({ KeyZ: ';', Semicolon: 'z' })[code]
+
+    it("does not match Alt+Z for Dvorak Option on the key that types ';' (KeyZ)", () => {
+      expect(
+        keybindingMatchesAction(
+          'editor.toggleWordWrap',
+          dvorakOptionOnZPosition,
+          'darwin',
+          undefined,
+          {
+            layoutCharacterForCode: dvorakLayoutCharacterForCode
+          }
+        )
+      ).toBe(false)
+    })
+
+    it("matches Alt+Z for Dvorak Option on the key that types 'z' (Semicolon)", () => {
+      expect(
+        keybindingMatchesAction(
+          'editor.toggleWordWrap',
+          dvorakOptionOnSemicolonPosition,
+          'darwin',
+          undefined,
+          { layoutCharacterForCode: dvorakLayoutCharacterForCode }
+        )
+      ).toBe(true)
+    })
+
+    it('still matches Cmd+Alt+A (#2920) on QWERTY with a layout map present', () => {
+      const qwertyLayoutCharacterForCode = (code: string): string | undefined =>
+        code === 'KeyA' ? 'a' : undefined
+      expect(
+        keybindingMatchesAction(
+          'floatingTerminal.toggle',
+          { key: 'å', code: 'KeyA', control: false, meta: true, alt: true, shift: false },
+          'darwin',
+          undefined,
+          { layoutCharacterForCode: qwertyLayoutCharacterForCode }
+        )
+      ).toBe(true)
+    })
+
+    it('still matches Cmd+Alt+A (#2920) on QWERTY with no layout map (fallback to physical code)', () => {
+      expect(
+        keybindingMatchesAction(
+          'floatingTerminal.toggle',
+          { key: 'å', code: 'KeyA', control: false, meta: true, alt: true, shift: false },
+          'darwin'
+        )
+      ).toBe(true)
+    })
+
+    it('resolves an AZERTY Option chord by the layout character rather than the physical code', () => {
+      // AZERTY's 'a' key sits at physical KeyQ; Option+that key composes 'æ' on macOS AZERTY.
+      const azertyLayoutCharacterForCode = (code: string): string | undefined =>
+        code === 'KeyQ' ? 'a' : undefined
+      expect(
+        keybindingMatchesAction(
+          'floatingTerminal.toggle',
+          { key: 'æ', code: 'KeyQ', control: false, meta: true, alt: true, shift: false },
+          'darwin',
+          undefined,
+          { layoutCharacterForCode: azertyLayoutCharacterForCode }
+        )
+      ).toBe(true)
+    })
+
+    it('does not misfire a Latin Alt shortcut on a non-Latin layout character', () => {
+      // A Cyrillic layout's key at physical KeyZ types 'я'; no Latin letter binding should match through the layout lookup.
+      const cyrillicLayoutCharacterForCode = (code: string): string | undefined =>
+        code === 'KeyZ' ? 'я' : undefined
+      expect(
+        keybindingMatchesAction(
+          'editor.toggleWordWrap',
+          { key: '…', code: 'KeyZ', control: false, meta: false, alt: true, shift: false },
+          'darwin',
+          undefined,
+          { layoutCharacterForCode: cyrillicLayoutCharacterForCode }
+        )
+      ).toBe(false)
+    })
+
+    it('leaves a Windows/Linux Alt chord unaffected by the layout lookup', () => {
+      // Alt does not compose on Windows/Linux, so the logical key is a real letter and the layout lookup is never consulted.
+      const layoutCharacterForCode = (code: string): string | undefined =>
+        code === 'KeyZ' ? ';' : undefined
+      expect(
+        keybindingMatchesAction(
+          'editor.toggleWordWrap',
+          { key: 'z', code: 'KeyZ', control: false, meta: false, alt: true, shift: false },
+          'linux',
+          undefined,
+          { layoutCharacterForCode }
+        )
+      ).toBe(true)
+    })
+
+    it('resolves the bracket case from #4451 through the layout lookup and preserves it with no map', () => {
+      const macOptionLeftBracket = {
+        key: '“',
+        code: 'BracketLeft',
+        control: false,
+        meta: true,
+        alt: true,
+        shift: false
+      }
+      // Layout map agrees with the physical code: BracketLeft types '[' on this (QWERTY) layout.
+      expect(
+        keybindingMatchesAction('tab.previousSameType', macOptionLeftBracket, 'darwin', undefined, {
+          layoutCharacterForCode: (code) => (code === 'BracketLeft' ? '[' : undefined)
+        })
+      ).toBe(true)
+      // No layout map available: falls back to physical code, matching pre-existing behavior.
+      expect(keybindingMatchesAction('tab.previousSameType', macOptionLeftBracket, 'darwin')).toBe(
+        true
+      )
+    })
+  })
 })

--- a/src/shared/keybindings-keyboard-layout.test.ts
+++ b/src/shared/keybindings-keyboard-layout.test.ts
@@ -459,6 +459,41 @@ describe('keybindings', () => {
       ).toBe(true)
     })
 
+    it('does not fall back to the physical bracket when the layout maps that key to a letter', () => {
+      // A layout where BracketLeft types 'q': the Option chord is a definitive non-match for
+      // a bracket binding, so the physical '[' token must not resolve it.
+      expect(
+        keybindingMatchesAction(
+          'tab.previousSameType',
+          {
+            key: '\u201c',
+            code: 'BracketLeft',
+            control: false,
+            meta: true,
+            alt: true,
+            shift: false
+          },
+          'darwin',
+          undefined,
+          { layoutCharacterForCode: (code) => (code === 'BracketLeft' ? 'q' : undefined) }
+        )
+      ).toBe(false)
+    })
+
+    it('does not fall back to the physical letter when the layout maps that key to punctuation', () => {
+      // Dvorak KeyZ types ';': already covered for the letter branch, asserted here as the
+      // symmetric partner of the bracket case above.
+      expect(
+        keybindingMatchesAction(
+          'editor.toggleWordWrap',
+          { key: '\u2026', code: 'KeyZ', control: false, meta: false, alt: true, shift: false },
+          'darwin',
+          undefined,
+          { layoutCharacterForCode: (code) => (code === 'KeyZ' ? ';' : undefined) }
+        )
+      ).toBe(false)
+    })
+
     it('resolves the bracket case from #4451 through the layout lookup and preserves it with no map', () => {
       const macOptionLeftBracket = {
         key: '“',

--- a/src/shared/keybindings-keyboard-layout.test.ts
+++ b/src/shared/keybindings-keyboard-layout.test.ts
@@ -481,8 +481,7 @@ describe('keybindings', () => {
     })
 
     it('does not fall back to the physical letter when the layout maps that key to punctuation', () => {
-      // Dvorak KeyZ types ';': already covered for the letter branch, asserted here as the
-      // symmetric partner of the bracket case above.
+      // Dvorak KeyZ types ';', so a letter binding must not resolve through the physical code.
       expect(
         keybindingMatchesAction(
           'editor.toggleWordWrap',

--- a/src/shared/keybindings/matching-key.ts
+++ b/src/shared/keybindings/matching-key.ts
@@ -89,7 +89,8 @@ export function letterKeyMatches(
   // Why: the mac-Option composed-character path has no logical key; the physical
   // code resolves through the active layout so non-QWERTY layouts match by character (#2858).
   const layoutCharacter = layoutCharacterForCode?.(input.code ?? '')
-  if (layoutCharacter) {
+  if (layoutCharacter !== undefined) {
+    // Why: a layout that assigns this key another character is a definitive non-match; the physical code would misfire the chord.
     return layoutCharacter.toUpperCase() === letter.toUpperCase()
   }
   return input.code === `Key${letter.toUpperCase()}`
@@ -176,9 +177,10 @@ export function keyMatches(
     // Why: the mac-Option composed-character path has no logical key; the physical
     // code resolves through the active layout so non-QWERTY layouts match by character (#2858).
     const layoutCharacter = layoutCharacterForCode?.(input.code ?? '')
-    const layoutToken = layoutCharacter ? normalizeKeyToken(layoutCharacter) : null
-    if (layoutToken && isPunctuationKeyToken(layoutToken)) {
-      return layoutToken === parsedKey
+    if (layoutCharacter !== undefined) {
+      // Why: a layout that assigns this key another character is a definitive non-match; the physical token would misfire the chord.
+      const layoutToken = normalizeKeyToken(layoutCharacter)
+      return layoutToken !== null && isPunctuationKeyToken(layoutToken) && layoutToken === parsedKey
     }
     return physicalPunctuationKey(input) === parsedKey
   }

--- a/src/shared/keybindings/matching-key.ts
+++ b/src/shared/keybindings/matching-key.ts
@@ -86,8 +86,8 @@ export function letterKeyMatches(
   if (!shouldUseMacOptionLetterPhysicalFallback(parsed, input, platform)) {
     return false
   }
-  // Why: the mac-Option composed-character path has no logical key, so resolve the
-  // physical code through the active layout rather than assuming US QWERTY (#2858).
+  // Why: the mac-Option composed-character path has no logical key; the physical
+  // code resolves through the active layout so non-QWERTY layouts match by character (#2858).
   const layoutCharacter = layoutCharacterForCode?.(input.code ?? '')
   if (layoutCharacter) {
     return layoutCharacter.toUpperCase() === letter.toUpperCase()
@@ -173,8 +173,8 @@ export function keyMatches(
     if (!shouldUseMacOptionPunctuationPhysicalFallback(parsed, input, platform)) {
       return false
     }
-    // Why: the mac-Option composed-character path has no logical key, so resolve the
-    // physical code through the active layout rather than assuming US QWERTY (#2858).
+    // Why: the mac-Option composed-character path has no logical key; the physical
+    // code resolves through the active layout so non-QWERTY layouts match by character (#2858).
     const layoutCharacter = layoutCharacterForCode?.(input.code ?? '')
     const layoutToken = layoutCharacter ? normalizeKeyToken(layoutCharacter) : null
     if (layoutToken && isPunctuationKeyToken(layoutToken)) {

--- a/src/shared/keybindings/matching-key.ts
+++ b/src/shared/keybindings/matching-key.ts
@@ -1,6 +1,11 @@
-import type { KeybindingInput, ModifierToken, ParsedKeybinding } from './types'
+import type {
+  KeybindingInput,
+  LayoutCharacterLookup,
+  ModifierToken,
+  ParsedKeybinding
+} from './types'
 import { getKeybindingPlatform } from './definitions'
-import { hasModifier } from './parser'
+import { hasModifier, normalizeKeyToken } from './parser'
 import {
   canFallBackToPhysicalCode,
   logicalKeyTokenFromInput,
@@ -68,17 +73,26 @@ export function letterKeyMatches(
   input: KeybindingInput,
   letter: string,
   parsed: ParsedKeybinding,
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  layoutCharacterForCode?: LayoutCharacterLookup
 ): boolean {
   const logicalKey = logicalKeyTokenFromInput(input)
   if (logicalKey && logicalKey.length === 1 && logicalKey >= 'A' && logicalKey <= 'Z') {
     return logicalKey === letter.toUpperCase()
   }
-  return (
-    (canFallBackToPhysicalCode(input, platform) ||
-      shouldUseMacOptionLetterPhysicalFallback(parsed, input, platform)) &&
-    input.code === `Key${letter.toUpperCase()}`
-  )
+  if (canFallBackToPhysicalCode(input, platform)) {
+    return input.code === `Key${letter.toUpperCase()}`
+  }
+  if (!shouldUseMacOptionLetterPhysicalFallback(parsed, input, platform)) {
+    return false
+  }
+  // Why: the mac-Option composed-character path has no logical key, so resolve the
+  // physical code through the active layout rather than assuming US QWERTY (#2858).
+  const layoutCharacter = layoutCharacterForCode?.(input.code ?? '')
+  if (layoutCharacter) {
+    return layoutCharacter.toUpperCase() === letter.toUpperCase()
+  }
+  return input.code === `Key${letter.toUpperCase()}`
 }
 
 export function digitKeyMatches(
@@ -127,10 +141,11 @@ export function keyMatches(
   parsedKey: string,
   input: KeybindingInput,
   parsed: ParsedKeybinding,
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  layoutCharacterForCode?: LayoutCharacterLookup
 ): boolean {
   if (parsedKey.length === 1 && parsedKey >= 'A' && parsedKey <= 'Z') {
-    return letterKeyMatches(input, parsedKey, parsed, platform)
+    return letterKeyMatches(input, parsedKey, parsed, platform, layoutCharacterForCode)
   }
   if (parsedKey.length === 1 && parsedKey >= '0' && parsedKey <= '9') {
     return digitKeyMatches(input, parsedKey, platform)
@@ -152,11 +167,20 @@ export function keyMatches(
       }
       return semanticKey === parsedKey
     }
-    return (
-      (canFallBackToPhysicalCode(input, platform) ||
-        shouldUseMacOptionPunctuationPhysicalFallback(parsed, input, platform)) &&
-      physicalPunctuationKey(input) === parsedKey
-    )
+    if (canFallBackToPhysicalCode(input, platform)) {
+      return physicalPunctuationKey(input) === parsedKey
+    }
+    if (!shouldUseMacOptionPunctuationPhysicalFallback(parsed, input, platform)) {
+      return false
+    }
+    // Why: the mac-Option composed-character path has no logical key, so resolve the
+    // physical code through the active layout rather than assuming US QWERTY (#2858).
+    const layoutCharacter = layoutCharacterForCode?.(input.code ?? '')
+    const layoutToken = layoutCharacter ? normalizeKeyToken(layoutCharacter) : null
+    if (layoutToken && isPunctuationKeyToken(layoutToken)) {
+      return layoutToken === parsedKey
+    }
+    return physicalPunctuationKey(input) === parsedKey
   }
 
   const logicalKey = logicalKeyTokenFromInput(input)

--- a/src/shared/keybindings/matching.ts
+++ b/src/shared/keybindings/matching.ts
@@ -3,6 +3,7 @@ import type {
   KeybindingInput,
   KeybindingOverrides,
   KeybindingMatchOptions,
+  LayoutCharacterLookup,
   ParsedKeybinding
 } from './types'
 import { DEFINITIONS_BY_ID, DIGIT_INDEX_KEY_PATTERN, isDigitIndexActionId } from './definitions'
@@ -19,7 +20,8 @@ import { getEffectiveKeybindingsForAction, keybindingIsActiveInContext } from '.
 export function keybindingMatchesInput(
   binding: string,
   input: KeybindingInput,
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  layoutCharacterForCode?: LayoutCharacterLookup
 ): boolean {
   const parsed = parseKeybinding(binding)
   if (!parsed) {
@@ -37,7 +39,8 @@ export function keybindingMatchesInput(
     return false
   }
   return (
-    modifierStateMatches(parsed, input, platform) && keyMatches(parsed.key, input, parsed, platform)
+    modifierStateMatches(parsed, input, platform) &&
+    keyMatches(parsed.key, input, parsed, platform, layoutCharacterForCode)
   )
 }
 
@@ -96,7 +99,7 @@ export function keybindingMatchesAction(
     return false
   }
   return getEffectiveKeybindingsForAction(actionId, platform, overrides).some((binding) =>
-    keybindingMatchesInput(binding, input, platform)
+    keybindingMatchesInput(binding, input, platform, options.layoutCharacterForCode)
   )
 }
 

--- a/src/shared/keybindings/types.ts
+++ b/src/shared/keybindings/types.ts
@@ -16,9 +16,13 @@ export type KeybindingPlatform = 'darwin' | 'linux' | 'win32'
 
 export type TerminalShortcutPolicy = 'orca-first' | 'terminal-first'
 
+/** Active layout's unmodified character for a physical code, or undefined when unknown. */
+export type LayoutCharacterLookup = (code: string) => string | undefined
+
 export type KeybindingMatchOptions = {
   context?: KeybindingContext
   terminalShortcutPolicy?: TerminalShortcutPolicy
+  layoutCharacterForCode?: LayoutCharacterLookup
 }
 
 export type AgentTabActionId = `tab.newAgent.${TuiAgent}`

--- a/src/shared/window-shortcut-policy-layout.test.ts
+++ b/src/shared/window-shortcut-policy-layout.test.ts
@@ -1,0 +1,124 @@
+// Window shortcuts must resolve letters through the active keyboard layout, including the
+// macOS Option-composed path where the event carries no Latin logical key.
+import { describe, expect, it } from 'vitest'
+import {
+  resolveWindowShortcutAction,
+  type WindowShortcutAction,
+  type WindowShortcutInput
+} from './window-shortcut-policy'
+
+describe('resolveWindowShortcutAction layout resolution', () => {
+  it('resolves the floating terminal chord when macOS Option composes the letter', () => {
+    expect(
+      resolveWindowShortcutAction(
+        {
+          code: 'KeyA',
+          key: 'å',
+          meta: true,
+          control: false,
+          alt: true,
+          shift: false
+        },
+        'darwin'
+      )
+    ).toEqual({ type: 'toggleFloatingTerminal' })
+  })
+
+  it('resolves the floating terminal chord through the layout map, not the physical code', () => {
+    // AZERTY types 'a' on physical KeyQ, so only the layout lookup can resolve this chord.
+    expect(
+      resolveWindowShortcutAction(
+        {
+          code: 'KeyQ',
+          key: 'æ',
+          meta: true,
+          control: false,
+          alt: true,
+          shift: false
+        },
+        'darwin',
+        undefined,
+        { layoutCharacterForCode: (code) => (code === 'KeyQ' ? 'a' : undefined) }
+      )
+    ).toEqual({ type: 'toggleFloatingTerminal' })
+  })
+
+  it('does not resolve the floating terminal chord from physical KeyA when the layout types another letter', () => {
+    expect(
+      resolveWindowShortcutAction(
+        {
+          code: 'KeyA',
+          key: 'å',
+          meta: true,
+          control: false,
+          alt: true,
+          shift: false
+        },
+        'darwin',
+        undefined,
+        { layoutCharacterForCode: (code) => (code === 'KeyA' ? 'q' : undefined) }
+      )
+    ).toBeNull()
+  })
+
+  it('resolves letter shortcuts by layout-aware key, with code as fallback', () => {
+    // Why: non-QWERTY layouts (Dvorak, Colemak, AZERTY, …) move letters to
+    // other physical keys. Matching only on `input.code` (always QWERTY)
+    // breaks the shortcut for those users. Prefer `input.key` when it is a
+    // letter; fall back to `input.code` only when `key` is empty or a
+    // non-letter marker (dead keys, IME edge cases).
+
+    // Dvorak layout: the letters the user presses sit on different codes
+    // ('b'→KeyN, 'l'→KeyP, 'p'→KeyR, 'n'→KeyL, 'j'→KeyC). All must resolve
+    // to the layout-matched shortcut.
+    const dvorak: [WindowShortcutInput, WindowShortcutAction][] = [
+      [
+        { code: 'KeyN', key: 'b', meta: true, alt: false, shift: false },
+        { type: 'toggleLeftSidebar' }
+      ],
+      [
+        { code: 'KeyP', key: 'l', meta: true, alt: false, shift: false },
+        { type: 'toggleRightSidebar' }
+      ],
+      [{ code: 'KeyR', key: 'p', meta: true, alt: false, shift: false }, { type: 'openQuickOpen' }],
+      [
+        { code: 'KeyL', key: 'n', meta: true, alt: false, shift: false },
+        { type: 'openNewWorkspace' }
+      ],
+      [
+        { code: 'KeyC', key: 'j', meta: true, alt: false, shift: false },
+        { type: 'toggleWorktreePalette' }
+      ]
+    ]
+    for (const [input, expected] of dvorak) {
+      expect(resolveWindowShortcutAction(input, 'darwin')).toEqual(expected)
+    }
+
+    // Inverse guard: physical QWERTY-B on Dvorak types 'x' — that is the
+    // platform Cut shortcut, not the sidebar. The layout-aware match must
+    // reject it.
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyB', key: 'x', meta: true, alt: false, shift: false },
+        'darwin'
+      )
+    ).toBeNull()
+
+    // Fallback: drivers/IME states that leave `key` empty or non-letter
+    // (dead keys, modifier names) must still reach the shortcut on QWERTY.
+    const fallbacks: [WindowShortcutInput, WindowShortcutAction][] = [
+      [
+        { code: 'KeyB', key: '', meta: true, alt: false, shift: false },
+        { type: 'toggleLeftSidebar' }
+      ],
+      [
+        { code: 'KeyN', key: 'Dead', meta: true, alt: false, shift: false },
+        { type: 'openNewWorkspace' }
+      ],
+      [{ code: 'KeyP', meta: true, alt: false, shift: false }, { type: 'openQuickOpen' }]
+    ]
+    for (const [input, expected] of fallbacks) {
+      expect(resolveWindowShortcutAction(input, 'darwin')).toEqual(expected)
+    }
+  })
+})

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -4,7 +4,6 @@ import {
   isWindowShortcutModifierChord,
   matchesRecentTabSwitcherChord,
   resolveWindowShortcutAction,
-  type WindowShortcutAction,
   type WindowShortcutInput
 } from './window-shortcut-policy'
 import type { KeybindingOverrides } from './keybindings'
@@ -605,40 +604,6 @@ describe('resolveWindowShortcutAction', () => {
     ).toEqual({ type: 'toggleFloatingTerminal' })
   })
 
-  it('resolves the floating terminal chord when macOS Option composes the letter', () => {
-    expect(
-      resolveWindowShortcutAction(
-        {
-          code: 'KeyA',
-          key: 'å',
-          meta: true,
-          control: false,
-          alt: true,
-          shift: false
-        },
-        'darwin'
-      )
-    ).toEqual({ type: 'toggleFloatingTerminal' })
-  })
-
-  it('resolves the floating terminal chord on QWERTY with a layout map present (#2920 preserved on the layout path)', () => {
-    expect(
-      resolveWindowShortcutAction(
-        {
-          code: 'KeyA',
-          key: 'å',
-          meta: true,
-          control: false,
-          alt: true,
-          shift: false
-        },
-        'darwin',
-        undefined,
-        { layoutCharacterForCode: (code) => (code === 'KeyA' ? 'a' : undefined) }
-      )
-    ).toEqual({ type: 'toggleFloatingTerminal' })
-  })
-
   it('rejects floating terminal chord variants with Shift or opposite primary modifier', () => {
     expect(
       resolveWindowShortcutAction(
@@ -812,67 +777,6 @@ describe('resolveWindowShortcutAction', () => {
         'darwin'
       )
     ).toBeNull()
-  })
-
-  it('resolves letter shortcuts by layout-aware key, with code as fallback', () => {
-    // Why: non-QWERTY layouts (Dvorak, Colemak, AZERTY, …) move letters to
-    // other physical keys. Matching only on `input.code` (always QWERTY)
-    // breaks the shortcut for those users. Prefer `input.key` when it is a
-    // letter; fall back to `input.code` only when `key` is empty or a
-    // non-letter marker (dead keys, IME edge cases).
-
-    // Dvorak layout: the letters the user presses sit on different codes
-    // ('b'→KeyN, 'l'→KeyP, 'p'→KeyR, 'n'→KeyL, 'j'→KeyC). All must resolve
-    // to the layout-matched shortcut.
-    const dvorak: [WindowShortcutInput, WindowShortcutAction][] = [
-      [
-        { code: 'KeyN', key: 'b', meta: true, alt: false, shift: false },
-        { type: 'toggleLeftSidebar' }
-      ],
-      [
-        { code: 'KeyP', key: 'l', meta: true, alt: false, shift: false },
-        { type: 'toggleRightSidebar' }
-      ],
-      [{ code: 'KeyR', key: 'p', meta: true, alt: false, shift: false }, { type: 'openQuickOpen' }],
-      [
-        { code: 'KeyL', key: 'n', meta: true, alt: false, shift: false },
-        { type: 'openNewWorkspace' }
-      ],
-      [
-        { code: 'KeyC', key: 'j', meta: true, alt: false, shift: false },
-        { type: 'toggleWorktreePalette' }
-      ]
-    ]
-    for (const [input, expected] of dvorak) {
-      expect(resolveWindowShortcutAction(input, 'darwin')).toEqual(expected)
-    }
-
-    // Inverse guard: physical QWERTY-B on Dvorak types 'x' — that is the
-    // platform Cut shortcut, not the sidebar. The layout-aware match must
-    // reject it.
-    expect(
-      resolveWindowShortcutAction(
-        { code: 'KeyB', key: 'x', meta: true, alt: false, shift: false },
-        'darwin'
-      )
-    ).toBeNull()
-
-    // Fallback: drivers/IME states that leave `key` empty or non-letter
-    // (dead keys, modifier names) must still reach the shortcut on QWERTY.
-    const fallbacks: [WindowShortcutInput, WindowShortcutAction][] = [
-      [
-        { code: 'KeyB', key: '', meta: true, alt: false, shift: false },
-        { type: 'toggleLeftSidebar' }
-      ],
-      [
-        { code: 'KeyN', key: 'Dead', meta: true, alt: false, shift: false },
-        { type: 'openNewWorkspace' }
-      ],
-      [{ code: 'KeyP', meta: true, alt: false, shift: false }, { type: 'openQuickOpen' }]
-    ]
-    for (const [input, expected] of fallbacks) {
-      expect(resolveWindowShortcutAction(input, 'darwin')).toEqual(expected)
-    }
   })
 
   it('exposes the shared platform modifier gate used by browser guests', () => {

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -621,6 +621,24 @@ describe('resolveWindowShortcutAction', () => {
     ).toEqual({ type: 'toggleFloatingTerminal' })
   })
 
+  it('resolves the floating terminal chord on QWERTY with a layout map present (#2920 preserved on the layout path)', () => {
+    expect(
+      resolveWindowShortcutAction(
+        {
+          code: 'KeyA',
+          key: 'å',
+          meta: true,
+          control: false,
+          alt: true,
+          shift: false
+        },
+        'darwin',
+        undefined,
+        { layoutCharacterForCode: (code) => (code === 'KeyA' ? 'a' : undefined) }
+      )
+    ).toEqual({ type: 'toggleFloatingTerminal' })
+  })
+
   it('rejects floating terminal chord variants with Shift or opposite primary modifier', () => {
     expect(
       resolveWindowShortcutAction(


### PR DESCRIPTION
## ELI5

Keyboard shortcuts that use the Option key on macOS now match the letter your keyboard layout actually produces, instead of always assuming a US QWERTY layout.

## What Changed

`letterKeyMatches` and the punctuation branch of `keyMatches` (`src/shared/keybindings/matching-key.ts`) now resolve the physical key code through the active keyboard layout map when macOS's Option-composed-character fallback is the only path available, instead of assuming the physical code corresponds to its US QWERTY letter. When no layout map is available, behavior is unchanged — it falls back to the physical code exactly as before.

The lookup is injected as an optional parameter (`layoutCharacterForCode` on `KeybindingMatchOptions`), following the same pattern the terminal keyboard handlers already use for kitty-protocol encoding. It's wired at every renderer dispatcher that reaches an Alt-letter or Alt-punctuation binding: the terminal workspace and global keydown handlers, the floating-terminal panel shortcuts, the terminal shortcut policy, the editor and markdown-preview shortcut helpers, the file explorer's copy-path chords, and plugin command keybindings. Main-process call sites are untouched, since the layout accessor is renderer-only.

## Why

On Dvorak, the `;` key sits at the physical position QWERTY calls `KeyZ`. Option plus that key composes a character with no logical Latin key, so the matcher fell back to physical `code` and matched `Alt+Z` — the word-wrap toggle — even though the user never typed anything near a `Z`.

This is the same bug class issue #2858 fixed for Cmd chords via PR #2867, which established that shortcuts should match by the layout's produced character, not physical position. That fix landed the same day as PR #19753's Option-letter fallback and PR for the bracket fallback, both of which reached for physical `code` as their escape hatch without knowing about the Cmd-path fix. This restores the same rule on the Option path rather than changing it.

## Linked Issue

Fixes #19777

## Visual Proof

N/A — this is matcher logic with no visual surface. Covered by the unit tests listed below.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Ran `pnpm test src/shared/keybindings src/shared/window-shortcut-policy.test.ts` (122 tests passing, including 9 new cases), `pnpm tc` (clean), and `oxlint`/`oxfmt` on changed files (no warnings).

New cases cover: Dvorak Option on the key that types `;` no longer matches `Alt+Z`; Dvorak Option on the key that types `z` does match `Alt+Z`; `Cmd+Option+A` (#2920) still matches on QWERTY both with and without a layout map; an AZERTY Option chord resolves by layout character; a non-Latin (Cyrillic) layout character never misfires a Latin Alt shortcut; a Windows/Linux Alt chord is unaffected since Alt doesn't compose there; and the bracket case from #4451 still passes both with a layout map and with none.

## AI Disclosure

Authored with Claude Code (Claude Fable 5.1 and Sonnet teammates) under my review.

## Review

Cross-platform: main-process call sites (Windows/Linux menu accelerators, window shortcut policy) pass no layout lookup and keep today's physical-code behavior unchanged, since the layout accessor is renderer-only and reaches for `window`. Alt does not compose on Windows/Linux, so the logical key is always a real letter there and this code path is never reached on those platforms regardless.

SSH: no interaction — this is local keyboard-input matching, not affected by remote execution state.

Agent/integration: no IPC, schema, or settings surface added. The lookup is a plain function parameter threaded through existing call sites.

Performance: the lookup is a single map/cache read per keystroke, only on the already-rare Option-composed-character path, with no new allocation on the hot logical-key path.

Security: no new external input surface; the layout map itself already ships and is trusted by existing terminal-side consumers.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: [@fbartho](https://x.com/fbartho). I prefer Mastodon: [@fbartho@mastodon.social](https://mastodon.social/@fbartho).

