### PR TITLE
fix(editor): open plain details blocks in rich markdown mode

### DIFF
--- a/src/renderer/src/components/editor/details-markdown-html.test.ts
+++ b/src/renderer/src/components/editor/details-markdown-html.test.ts
@@ -3,6 +3,7 @@ import {
   extractDetailsSummaryHtml,
   isEditableDetailsHtmlBlock,
   matchDetailsHtmlBlock,
+  normalizeDetailsOpeningTag,
   parseDetailsAttributes,
   parseToggleHeadingVariant,
   type DetailsHtmlBlock
@@ -26,6 +27,30 @@ afterEach(() => {
 })
 
 describe('details markdown html', () => {
+  it.each([
+    ['<details>', '<details class="orca-details">'],
+    ['<details open="open">', '<details class="orca-details" open>'],
+    [
+      "<details open data-orca-toggle = 'heading-2' class='orca-details'>",
+      '<details class="orca-details" data-orca-toggle="heading-2" open>'
+    ]
+  ])('normalizes supported opening tag %s like the serializer', (input, expected) => {
+    expect(normalizeDetailsOpeningTag(input)).toBe(expected)
+  })
+
+  it.each([
+    '<details id="keep">',
+    '<details class="custom">',
+    '<details data-orca-toggle="heading-6">',
+    '<details open="false">',
+    '<detailsish>',
+    '</details>',
+    '<summary>',
+    '<!-- <details> -->'
+  ])('leaves noncanonical or unrelated fragment %s unchanged', (fragment) => {
+    expect(normalizeDetailsOpeningTag(fragment)).toBe(fragment)
+  })
+
   it('extracts leading summary html without regex capture', () => {
     const matchSpy = vi.spyOn(String.prototype, 'match')
     const inner = `\n<SUMMARY>${'Heading line\n'.repeat(1_000)}</SUMMARY><p>Body</p>`

--- a/src/renderer/src/components/editor/details-markdown-html.test.ts
+++ b/src/renderer/src/components/editor/details-markdown-html.test.ts
@@ -30,6 +30,9 @@ describe('details markdown html', () => {
   it.each([
     ['<details>', '<details class="orca-details">'],
     ['<details open="open">', '<details class="orca-details" open>'],
+    ['<details CLASS="orca-details">', '<details class="orca-details">'],
+    ["<details Class='orca-details'>", '<details class="orca-details">'],
+    ['<details cLaSs=orca-details>', '<details class="orca-details">'],
     [
       "<details open data-orca-toggle = 'heading-2' class='orca-details'>",
       '<details class="orca-details" data-orca-toggle="heading-2" open>'
@@ -41,6 +44,9 @@ describe('details markdown html', () => {
   it.each([
     '<details id="keep">',
     '<details class="custom">',
+    '<details class="ORCA-DETAILS">',
+    "<details CLASS='Orca-Details'>",
+    '<details Class=ORCA-DETAILS>',
     '<details data-orca-toggle="heading-6">',
     '<details open="false">',
     '<detailsish>',
@@ -50,6 +56,15 @@ describe('details markdown html', () => {
   ])('leaves noncanonical or unrelated fragment %s unchanged', (fragment) => {
     expect(normalizeDetailsOpeningTag(fragment)).toBe(fragment)
   })
+
+  it.each(['ORCA-DETAILS', 'Orca-Details'])(
+    'keeps case-sensitive class %s out of editable details nodes',
+    (className) => {
+      expect(
+        isEditableHtml(`<details class="${className}"><summary>Toggle</summary>Body</details>`)
+      ).toBe(false)
+    }
+  )
 
   it('extracts leading summary html without regex capture', () => {
     const matchSpy = vi.spyOn(String.prototype, 'match')

--- a/src/renderer/src/components/editor/details-markdown-html.ts
+++ b/src/renderer/src/components/editor/details-markdown-html.ts
@@ -193,6 +193,15 @@ function hasOnlySupportedDetailsAttributes(rawAttributes: string): boolean {
   )
 }
 
+export function normalizeDetailsOpeningTag(fragment: string): string {
+  const match = fragment.match(/^<details(\s[^<>]*)?>$/i)
+  const attributes = match?.[1] ?? ''
+  if (!match || !hasOnlySupportedDetailsAttributes(attributes)) {
+    return fragment
+  }
+  return `<details ${renderDetailsAttributes(parseDetailsAttributes(attributes))}>`
+}
+
 function hasOnlyPlainParagraphAndBreakTags(content: string): boolean {
   return !/<p\b(?!\s*>)[^>]*>|<br\b(?!\s*\/?>)[^>]*>/iu.test(content)
 }

--- a/src/renderer/src/components/editor/details-markdown-html.ts
+++ b/src/renderer/src/components/editor/details-markdown-html.ts
@@ -184,7 +184,11 @@ function hasOnlySupportedDetailsAttributes(rawAttributes: string): boolean {
   return (
     rawAttributes
       .replace(/\s+open(?:\s*=\s*(?:""|"open"|''|'open'|open))?(?=\s|$)/giu, '')
-      .replace(/\s+class\s*=\s*(?:"orca-details"|'orca-details'|orca-details)(?=\s|$)/giu, '')
+      // HTML attribute names ignore case; class tokens do not.
+      .replace(
+        /\s+[cC][lL][aA][sS][sS]\s*=\s*(?:"orca-details"|'orca-details'|orca-details)(?=\s|$)/gu,
+        ''
+      )
       .replace(
         /\s+data-orca-toggle\s*=\s*(?:"heading-[1-5]"|'heading-[1-5]'|heading-[1-5])(?=\s|$)/giu,
         ''

--- a/src/renderer/src/components/editor/markdown-rich-mode.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as roundTrip from './markdown-round-trip'
 import { RICH_MARKDOWN_MAX_SIZE_BYTES } from '../../../../shared/constants'
 import {
   getMarkdownRichModeEligibility,
@@ -20,6 +21,53 @@ describe('getMarkdownRichModeUnsupportedMessage', () => {
 
   it('allows common raw html in markdown files', () => {
     expect(getMarkdownRichModeUnsupportedMessage('Before <span>hi</span> after\n')).toBeNull()
+  })
+
+  it.each(['', ' open', ' open="open"', " data-orca-toggle='heading-2' open"])(
+    'allows editable details blocks with attributes %s',
+    (attributes) => {
+      const content = `<details${attributes}>\n<summary>Toggle</summary>\n\nBody\n\n</details>\n`
+
+      expect(getMarkdownRichModeUnsupportedMessage(content)).toBeNull()
+    }
+  )
+
+  it('allows nested plain details blocks', () => {
+    const inner = '<details>\n<summary>Inner</summary>\n\nBody\n\n</details>'
+    const content = `<details open>\n<summary>Outer</summary>\n\n${inner}\n\n</details>\n`
+
+    expect(getMarkdownRichModeUnsupportedMessage(content)).toBeNull()
+  })
+
+  it('checks mixed editable and passthrough details blocks in source order', () => {
+    const content = [
+      '<details>\n<summary>Editable</summary>\n\nBody\n\n</details>',
+      '<details>\n<summary><span>Passthrough</span></summary>\n\nBody\n\n</details>',
+      '<details class="orca-details" open>\n<summary>Authored</summary>\n\nBody\n\n</details>'
+    ].join('\n\n')
+
+    expect(getMarkdownRichModeUnsupportedMessage(content)).toBeNull()
+  })
+
+  it.each([' id="keep"', ' class="custom"', ' data-orca-toggle="heading-6"', ' open'])(
+    'rejects a details round trip that loses attributes %s',
+    (attributes) => {
+      const content = `<details${attributes}>\n<summary>Toggle</summary>\n\nBody\n\n</details>`
+      vi.spyOn(roundTrip, 'getRichMarkdownRoundTripOutput').mockReturnValue(
+        '<details class="orca-details">\n<summary>Toggle</summary>\n\nBody\n\n</details>'
+      )
+
+      expect(getMarkdownRichModeUnsupportedMessage(content)).not.toBeNull()
+    }
+  )
+
+  it('still rejects unrelated HTML lost alongside a normalized details tag', () => {
+    const content = '<details>\n<summary>Toggle</summary>\n\nBody\n\n</details>\n<span>Tail</span>'
+    vi.spyOn(roundTrip, 'getRichMarkdownRoundTripOutput').mockReturnValue(
+      '<details class="orca-details">\n<summary>Toggle</summary>\n\nBody\n\n</details>\nTail'
+    )
+
+    expect(getMarkdownRichModeUnsupportedMessage(content)).not.toBeNull()
   })
 
   it('allows markdown autolinks wrapped in angle brackets', () => {

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -1,4 +1,5 @@
 import { defaultSchema } from 'rehype-sanitize'
+import { normalizeDetailsOpeningTag } from './details-markdown-html'
 import { getRichMarkdownRoundTripOutput } from './markdown-round-trip'
 import { extractFrontMatter } from './markdown-frontmatter'
 import { exceedsMarkdownRichModeSizeLimit } from './markdown-rich-size-limit'
@@ -211,11 +212,18 @@ function stripMarkdownCode(content: string): string {
 function preservesEmbeddedHtml(contentWithoutCode: string, roundTripOutput: string): boolean {
   let searchIndex = 0
   return forEachEmbeddedHtmlFragment(contentWithoutCode, (fragment) => {
-    const foundIndex = roundTripOutput.indexOf(fragment, searchIndex)
+    const normalized = normalizeDetailsOpeningTag(fragment)
+    const exactIndex = roundTripOutput.indexOf(fragment, searchIndex)
+    // Details serialization adds Orca's class and canonicalizes supported attributes.
+    const normalizedIndex =
+      normalized === fragment ? -1 : roundTripOutput.indexOf(normalized, searchIndex)
+    const useNormalized =
+      normalizedIndex !== -1 && (exactIndex === -1 || normalizedIndex < exactIndex)
+    const foundIndex = useNormalized ? normalizedIndex : exactIndex
     if (foundIndex === -1) {
       return false
     }
-    searchIndex = foundIndex + fragment.length
+    searchIndex = foundIndex + (useNormalized ? normalized.length : fragment.length)
     return true
   })
 }

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -160,6 +160,15 @@ describe('rich markdown round trip', () => {
     expect(roundTripMarkdown(input)).toBe(input.trimEnd())
   })
 
+  it.each(['class="ORCA-DETAILS"', "CLASS='Orca-Details'", 'Class=ORCA-DETAILS'])(
+    'preserves details with case-sensitive %s as passthrough html',
+    (attributes) => {
+      const input = `<details ${attributes}><summary>Toggle</summary><p>Body</p></details>`
+
+      expect(roundTripMarkdown(input)).toBe(input)
+    }
+  )
+
   it('preserves details blocks with unsupported attributes as passthrough html', () => {
     const input =
       '<details id="x"><summary class="s">Toggle</summary><p data-x="1">Body</p></details>\n'

--- a/tests/e2e/markdown-nested-toggle.spec.ts
+++ b/tests/e2e/markdown-nested-toggle.spec.ts
@@ -26,6 +26,36 @@ test.describe('Markdown nested toggle regression', () => {
     await waitForActiveWorktree(orcaPage)
   })
 
+  test('a plain details block opens as an editable toggle', async ({ orcaPage }, testInfo) => {
+    const context = await getActiveWorktreeContext(orcaPage)
+    let filePath: string | null = null
+
+    try {
+      filePath = await createMarkdownFixture(
+        context,
+        NESTED_TOGGLE_FIXTURE_DIRECTORY,
+        'plain-details',
+        testInfo.workerIndex,
+        '<details>\n<summary>Toggle</summary>\n\nBody\n\n</details>\n'
+      )
+      await openMarkdownFixture(orcaPage, context, filePath)
+      const editor = await waitForRichMarkdownEditor(orcaPage)
+      const toggle = editor.locator('[data-type="details"]')
+
+      await expect(toggle).toHaveCount(1)
+      await expect(toggle.locator('summary')).toHaveText('Toggle')
+      await expect(editor.locator('[data-raw-markdown-html-block]')).toHaveCount(0)
+      const screenshotPath = testInfo.outputPath('plain-details-rich-editor.png')
+      await orcaPage.screenshot({ path: screenshotPath })
+      await testInfo.attach('plain-details-rich-editor', {
+        path: screenshotPath,
+        contentType: 'image/png'
+      })
+    } finally {
+      await cleanupMarkdownFixture(filePath)
+    }
+  })
+
   test('a nested toggle on disk reopens as editable toggles', async ({ orcaPage }, testInfo) => {
     const context = await getActiveWorktreeContext(orcaPage)
     let filePath: string | null = null


### PR DESCRIPTION
## ELI5

A normal Markdown `<details>` block should open as a collapsible toggle, not force the whole file into Source mode. The rich editor already supports it; its safety check was mistaking the automatically added `orca-details` class for lost HTML.

## What Changed

- Normalize only supported `<details>` opening tags with the existing attribute validator, parser, and serializer.
- Accept the earliest exact or normalized match during the HTML-preservation check. This also handles mixed editable and raw-passthrough blocks in order.
- Add tests for plain/open/heading/nested toggles, mixed passthrough content, and rejection when a round trip loses attributes or unrelated HTML.
- Add an Electron regression test for opening the issue's plain-details fixture from disk.

The serializer and the raw-HTML fallback are unchanged.

## Why

The serializer emits `<details class="orca-details">`, but the old check required the literal `<details>` tag to appear in its output. Reusing the existing supported-attribute rules fixes this mismatch without broadly ignoring HTML attributes.

## Linked Issue

Fixes #19781

## Visual Proof

Actual hidden Electron runs on macOS, using the same fixture. The new E2E test fails on unpatched `main` and passes with this change.

| Before: Source mode and HTML warning | After: editable rich toggle |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/ffa2d873-1a02-4f13-8c88-546093b78fae) | ![After](https://github.com/user-attachments/assets/3c2044de-1625-403d-8264-ae5f9b43fa93) |

## Testing

- `pnpm lint` — passed.
- `pnpm tc` — passed (all typecheck projects).
- `pnpm run check:code-quality:changed` — passed.
- Focused Vitest run — **117 tests passed** across eligibility, eligibility caching, details HTML, round-trip serialization, and details keyboard behavior.
- Electron build and CLI build through the E2E setup — passed.
- `markdown-nested-toggle.spec.ts`, `electron-headless`, one worker — **4 tests passed**: plain details opening, nested toggles, editing/save/reopen, and unsupported nested HTML passthrough.
- Before the fix, all **5 new real-round-trip regression cases failed**, and the new Electron test failed because the rich editor never appeared.
- Full repository test suite and production packaging were not run locally; CI remains to be checked.

All agent-launched tests/apps used `ORCA_BACKGROUND_LAUNCH=1`. No visible app windows or OS-focus validation was used.

- [ ] I manually tested these changes locally (validation above is automated against the actual app, not a human walkthrough)
- [x] Automated tests added/updated

## AI Disclosure

AI-assisted implementation, tests, and independent code review using Prime Agent. The verification results above are from executed local commands, including actual Electron before/after runs.

## Review

- Cross-platform: shared renderer string logic; no platform-specific paths or shortcuts added. Executed on macOS; Windows/Linux not directly tested.
- SSH/remote/local and folder workspaces: no host routing, filesystem, workspace identity, or wire-protocol changes. Remote hosts were not directly tested.
- Agents/integrations/providers: no provider-specific changes.
- Performance: only the existing HTML round-trip path changes; the 50,000-character guard remains in place. No new parsing/editor instance is created.
- UI quality: existing toggle UI and styles are reused; before/after screenshots above.
- Security/data preservation: unknown attributes and unrelated HTML still require exact preservation; regression tests cover dropped attributes and markup.

## Agent skill upstream boundary

- [x] Not applicable; no agent-skill implementation or upstream material changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full `pnpm test` and production `pnpm build` verified (focused tests and E2E builds passed; see above)

## Author

X (Twitter): [@SahilSharm42312](https://x.com/SahilSharm42312)
