### PR TITLE
fix(editor): preserve Markdown preview when following wiki links

### DIFF
--- a/src/renderer/src/components/editor/useMarkdownDocuments.navigation.test.ts
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.navigation.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MarkdownViewMode, OpenFile } from '@/store/slices/editor'
+import { useMarkdownDocuments } from './useMarkdownDocuments'
+
+const runtime = vi.hoisted(() => ({
+  connectionId: null as string | null,
+  stat: vi.fn(),
+  list: vi.fn()
+}))
+const target = {
+  filePath: '/repo/target.md',
+  relativePath: 'target.md',
+  basename: 'target.md',
+  name: 'target'
+}
+const state = {
+  settings: {},
+  worktreesByRepo: { repo: [{ id: 'wt', path: '/repo' }] },
+  openFile: vi.fn(),
+  openMarkdownPreview: vi.fn()
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign((selector: (store: typeof state) => unknown) => selector(state), {
+    getState: () => state
+  })
+}))
+vi.mock('@/lib/connection-context', () => ({ getConnectionId: () => runtime.connectionId }))
+vi.mock('@/runtime/runtime-file-client', () => ({ statRuntimePath: runtime.stat }))
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  settingsForRuntimeOwner: (_settings: unknown, owner: string | null | undefined) => ({ owner })
+}))
+vi.mock('./markdown-document-list-request', () => ({
+  requestSharedMarkdownDocumentList: runtime.list
+}))
+
+let root: Root
+let container: HTMLDivElement
+let controller: ReturnType<typeof useMarkdownDocuments>
+const save = vi.fn(async () => true)
+
+function Harness({ file, viewMode }: { file: OpenFile; viewMode: MarkdownViewMode }): null {
+  controller = useMarkdownDocuments(file, true, viewMode, save)
+  return null
+}
+
+function sourceFile(mode: OpenFile['mode'], runtimeEnvironmentId: string | null = null): OpenFile {
+  return {
+    id: 'source',
+    filePath: '/repo/source.md',
+    relativePath: 'source.md',
+    worktreeId: 'wt',
+    language: 'markdown',
+    isDirty: false,
+    mode,
+    runtimeEnvironmentId
+  }
+}
+
+async function render(file: OpenFile, viewMode: MarkdownViewMode): Promise<void> {
+  await act(async () => {
+    root.render(createElement(Harness, { file, viewMode }))
+  })
+}
+
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  vi.clearAllMocks()
+  runtime.connectionId = null
+  runtime.stat.mockResolvedValue({ isDirectory: false })
+  runtime.list.mockResolvedValue([target])
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.unstubAllGlobals()
+})
+
+describe('Markdown document navigation', () => {
+  it.each([
+    ['markdown-preview', 'source'],
+    ['edit', 'preview'],
+    ['diff', 'preview']
+  ] as const)('preserves preview from %s / %s without a fragment', async (mode, viewMode) => {
+    await render(sourceFile(mode), viewMode)
+    await act(async () => {
+      await controller.previewProps.onOpenDocument(target)
+    })
+
+    expect(state.openMarkdownPreview).toHaveBeenCalledWith(
+      {
+        filePath: target.filePath,
+        relativePath: target.relativePath,
+        worktreeId: 'wt',
+        language: 'markdown',
+        runtimeEnvironmentId: null
+      },
+      { anchor: undefined }
+    )
+    expect(state.openFile).not.toHaveBeenCalled()
+  })
+
+  it.each(['source', 'rich'] as const)(
+    'keeps plain links from %s editing in edit mode',
+    async (viewMode) => {
+      await render(sourceFile('edit'), viewMode)
+      await act(async () => {
+        await controller.openMarkdownDocument(target)
+      })
+
+      expect(state.openFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filePath: target.filePath,
+          mode: 'edit',
+          worktreeId: 'wt',
+          runtimeEnvironmentId: null
+        })
+      )
+      expect(state.openMarkdownPreview).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['source', 'rich', 'preview'] as const)(
+    'keeps anchored links from %s in preview',
+    async (viewMode) => {
+      await render(sourceFile('edit'), viewMode)
+      await act(async () => {
+        await controller.openMarkdownDocument(target, { anchor: 'target' })
+      })
+
+      expect(state.openMarkdownPreview).toHaveBeenCalledWith(
+        expect.objectContaining({ filePath: target.filePath }),
+        { anchor: 'target' }
+      )
+      expect(state.openFile).not.toHaveBeenCalled()
+    }
+  )
+
+  it('uses the new source mode after a rerender', async () => {
+    await render(sourceFile('markdown-preview'), 'source')
+    await render(sourceFile('edit'), 'source')
+    await act(async () => {
+      await controller.openMarkdownDocument(target)
+    })
+    expect(state.openFile).toHaveBeenCalledOnce()
+    expect(state.openMarkdownPreview).not.toHaveBeenCalled()
+
+    state.openFile.mockClear()
+    await render(sourceFile('edit'), 'preview')
+    await act(async () => {
+      await controller.openMarkdownDocument(target)
+    })
+    expect(state.openMarkdownPreview).toHaveBeenCalledOnce()
+    expect(state.openFile).not.toHaveBeenCalled()
+  })
+
+  it('retains SSH and runtime ownership for an indexed wiki link', async () => {
+    runtime.connectionId = 'ssh-owner'
+    await render(sourceFile('markdown-preview', 'runtime-owner'), 'source')
+    await act(async () => {
+      controller.onOpenDocLink('target')
+    })
+
+    expect(runtime.stat).toHaveBeenCalledWith(
+      {
+        settings: { owner: 'runtime-owner' },
+        worktreeId: 'wt',
+        worktreePath: '/repo',
+        connectionId: 'ssh-owner'
+      },
+      target.filePath
+    )
+    expect(state.openMarkdownPreview).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: 'wt', runtimeEnvironmentId: 'runtime-owner' }),
+      { anchor: null }
+    )
+    expect(state.openFile).not.toHaveBeenCalled()
+  })
+
+  it.each(['directory', 'missing'])('does not navigate to a %s destination', async (kind) => {
+    await render(sourceFile('markdown-preview'), 'source')
+    if (kind === 'directory') {
+      runtime.stat.mockResolvedValue({ isDirectory: true })
+    } else {
+      runtime.stat.mockRejectedValue(new Error('missing'))
+    }
+    await act(async () => {
+      await controller.previewProps.onOpenDocument(target)
+    })
+
+    expect(runtime.list).toHaveBeenLastCalledWith(expect.anything(), '/repo', {
+      requireFresh: true
+    })
+    expect(state.openFile).not.toHaveBeenCalled()
+    expect(state.openMarkdownPreview).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate when the source workspace cannot be resolved', async () => {
+    await render({ ...sourceFile('markdown-preview'), worktreeId: 'unknown' }, 'source')
+    await act(async () => {
+      await controller.previewProps.onOpenDocument(target)
+    })
+
+    expect(runtime.stat).not.toHaveBeenCalled()
+    expect(state.openFile).not.toHaveBeenCalled()
+    expect(state.openMarkdownPreview).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/useMarkdownDocuments.ts
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.ts
@@ -138,9 +138,8 @@ export function useMarkdownDocuments(
         return
       }
 
-      if (options.anchor) {
-        // Why: heading fragments are preview anchors, not filesystem paths.
-        // Opening preview preserves Obsidian-style [[note#Heading]] navigation.
+      if (options.anchor || activeFile.mode === 'markdown-preview' || viewMode === 'preview') {
+        // Preserve the reading surface; fragments only choose a heading within it.
         openMarkdownPreview(
           {
             filePath: document.filePath,
@@ -164,11 +163,13 @@ export function useMarkdownDocuments(
       })
     },
     [
+      activeFile.mode,
       activeFile.runtimeEnvironmentId,
       connectionId,
       openFile,
       openMarkdownPreview,
       refreshMarkdownDocuments,
+      viewMode,
       worktreeId,
       worktreePath
     ]

--- a/tests/e2e/markdown-preview-document-navigation.spec.ts
+++ b/tests/e2e/markdown-preview-document-navigation.spec.ts
@@ -1,0 +1,98 @@
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import {
+  cleanupMarkdownFixture,
+  createMarkdownFixture,
+  getActiveWorktreeContext
+} from './helpers/markdown-editor-fixture'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const FIXTURE_DIRECTORY = 'orca-e2e-preview-document-navigation'
+
+for (const kind of ['relative', 'wiki'] as const) {
+  for (const anchored of [false, true]) {
+    test(`${kind} ${anchored ? 'anchored' : 'plain'} links stay in Markdown preview`, async ({
+      orcaPage
+    }, testInfo) => {
+      await waitForSessionReady(orcaPage)
+      await waitForActiveWorktree(orcaPage)
+      const context = await getActiveWorktreeContext(orcaPage)
+      let sourcePath: string | null = null
+      let targetPath: string | null = null
+
+      try {
+        targetPath = await createMarkdownFixture(
+          context,
+          FIXTURE_DIRECTORY,
+          'target',
+          testInfo.workerIndex,
+          '# Target\n\nDestination content.\n'
+        )
+        const fragment = anchored ? '#target' : ''
+        const relativeTarget = path.relative(context.rootPath, targetPath).split(path.sep).join('/')
+        const link =
+          kind === 'wiki'
+            ? `[[${relativeTarget}${fragment}|Open target]]`
+            : `[Open target](${path.basename(targetPath)}${fragment})`
+        sourcePath = await createMarkdownFixture(
+          context,
+          FIXTURE_DIRECTORY,
+          'source',
+          testInfo.workerIndex,
+          `# Source\n\n${link}\n`
+        )
+        await orcaPage.evaluate(
+          ({ filePath, relativePath, worktreeId }) => {
+            window.__store!.getState().openMarkdownPreview({
+              filePath,
+              relativePath,
+              worktreeId,
+              language: 'markdown'
+            })
+          },
+          {
+            filePath: sourcePath,
+            relativePath: path.relative(context.rootPath, sourcePath),
+            worktreeId: context.worktreeId
+          }
+        )
+        const linkElement = orcaPage.getByRole('link', { name: 'Open target', exact: true })
+        await expect(linkElement).toBeVisible()
+        if (kind === 'wiki') {
+          await expect(linkElement).not.toHaveClass(/markdown-doc-link-broken/)
+        }
+        await linkElement.click()
+
+        await expect
+          .poll(() =>
+            orcaPage.evaluate(() => {
+              const state = window.__store!.getState()
+              const file = state.openFiles.find((entry) => entry.id === state.activeFileId)
+              return file
+                ? {
+                    filePath: file.filePath,
+                    mode: file.mode,
+                    anchor: file.markdownPreviewAnchor ?? null
+                  }
+                : null
+            })
+          )
+          .toEqual({
+            filePath: targetPath,
+            mode: 'markdown-preview',
+            anchor: anchored ? 'target' : null
+          })
+        await expect(orcaPage.getByRole('heading', { name: 'Target', exact: true })).toBeVisible()
+        const screenshotPath = testInfo.outputPath('destination-preview.png')
+        await orcaPage.screenshot({ path: screenshotPath })
+        await testInfo.attach('destination-preview', {
+          path: screenshotPath,
+          contentType: 'image/png'
+        })
+      } finally {
+        await cleanupMarkdownFixture(sourcePath)
+        await cleanupMarkdownFixture(targetPath)
+      }
+    })
+  }
+}


### PR DESCRIPTION
## ELI5

While reading a Markdown preview, following `[[target]]` should keep you in preview, just like `[[target#heading]]`. It currently opens the target in edit mode unless the link has a heading fragment. This PR preserves the reading surface without changing how plain document links behave when used from an editor.

## What Changed

- Treat dedicated `markdown-preview` tabs and inline/diff `preview` views as preview navigation, independent of an optional heading fragment.
- Include both source mode values in the callback dependencies so switching view modes does not leave stale navigation behavior.
- Add 13 hook regressions and four hidden Electron cases for ordinary and wiki-style links, with and without heading fragments.

The production change is confined to `useMarkdownDocuments.ts`. Existing path validation, document lookup, runtime routing, and editor/preview actions are reused.

## Why

The `options.anchor` branch chose preview only for anchored wiki links. A dedicated preview tab can have a Markdown view-mode value of `source`, so checking `viewMode` alone would miss the real reproduction; `activeFile.mode` must also be considered.

## Linked Issue

Related to #17879.

**Scope clarification:** on current `main` (`aac38d6`), the issue's ordinary `[Target](target.md)` and `[Target](target.md#heading)` examples already preserve preview through the separate standard-link handler. Both passed the unpatched Electron test. The remaining inconsistency is the indexed/wiki-document route through `useMarkdownDocuments`: `[[target]]` opens edit mode while `[[target#heading]]` opens preview. This PR fixes that remaining route, rather than claiming the ordinary-link reproduction still fails or automatically closing the issue.

## Visual Proof

Actual hidden Electron runs of the plain wiki-link case. Before: target is an editable tab with the formatting toolbar. After: target is a preview tab with its eye icon and read-only preview surface.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/bc67bbf7-ca3e-44f3-b8e3-efae45b114f8) | ![After](https://github.com/user-attachments/assets/e38a2018-485f-4362-9c00-74b337132bb0) |

## Testing

- `pnpm lint` — passed.
- `pnpm tc` — all typecheck projects passed.
- `pnpm run check:code-quality:changed` — passed.
- `oxfmt --check` on the three changed files — passed.
- Focused Vitest run — **40 tests passed** across six suites: navigation hook, save helper, document-link parsing, preview link interaction, preview store action, and document-worktree selector.
- Before the fix, **five new hook cases failed**. The unpatched app's plain wiki-link test failed specifically with `mode: "edit"` instead of `"markdown-preview"`; its anchored wiki-link test passed.
- Rebuilt Electron app: **all four navigation E2E cases passed**, covering ordinary/wiki links with/without anchors.
- Electron and CLI builds through the E2E setup passed.
- Full repository tests and production packaging were not run locally.

All app/test launches used `ORCA_BACKGROUND_LAUNCH=1`; Electron validation used the isolated headless fixture without showing windows or taking OS focus.

- [ ] I manually tested these changes locally (the local app validation above is automated, not a human walkthrough)
- [x] Automated tests added/updated

## AI Disclosure

AI-assisted implementation, regression tests, and independent call-site review using Prime Agent. Test/build results above are from executed commands and actual Electron runs.

## Review

- Cross-platform: no new path parsing, platform checks, or keyboard shortcuts. E2E fixture uses Node path utilities. Actual app tested on macOS only.
- SSH/remote/local: runtime and connection ownership forwarding is unchanged and covered with mocked hook inputs. No live SSH host was tested.
- Folder workspaces: this does not change document-root discovery. Existing unresolvable-workspace behavior remains a no-op; no claim of expanded folder-workspace support.
- Agent/integration/provider compatibility: no provider-specific behavior changes.
- Performance: adds only two mode comparisons to an existing click-time branch; no new filesystem or network calls.
- UI: reuses the existing preview and editor surfaces; screenshots above.
- Security/data preservation: destination stat checks and missing/directory rejection remain intact. No file writes or protocol changes were added.

## Agent skill upstream boundary

- [x] Not applicable; no agent-skill implementation or upstream material changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full repository tests and production packaging verified (focused tests and E2E builds passed; see above)

## Author

X (Twitter): [@SahilSharm42312](https://x.com/SahilSharm42312)
