### PR TITLE
Show the model a native-chat session is actually running, and stop offering raw launch flags

### DIFF
--- a/mobile/src/session/MobileNativeChatSessionOptionPickers.test.ts
+++ b/mobile/src/session/MobileNativeChatSessionOptionPickers.test.ts
@@ -280,6 +280,33 @@ describe('MobileNativeChatSessionOptionPickers', () => {
     }
   )
 
+  // A running model with an empty `model/list` must not open onto a blank sheet.
+  it('captions an empty choice list instead of rendering an empty sheet', async () => {
+    const captionCount = (): number =>
+      renderer!.root
+        .findAll((node) => node.type === 'Text')
+        .filter(
+          (node) =>
+            (node.props as { children?: unknown }).children === 'No choices reported by the agent'
+        ).length
+
+    mount([
+      {
+        ...MODEL_DESCRIPTOR,
+        kind: { type: 'select', currentValue: 'gpt-5.2-codex', choices: [] }
+      },
+      EFFORT_DESCRIPTOR
+    ])
+    await act(async () => pill('Model').props.onPress())
+    expect(captionCount()).toBeGreaterThan(0)
+
+    renderer?.unmount()
+    mount([MODEL_DESCRIPTOR, EFFORT_DESCRIPTOR])
+    await act(async () => pill('Model').props.onPress())
+    expect(captionCount()).toBe(0)
+    expect(rowByText('Sonnet 5').props.accessibilityRole).toBe('radio')
+  })
+
   it('locks the pills while the agent is working', () => {
     mount([MODEL_DESCRIPTOR, EFFORT_DESCRIPTOR], true)
     expect(pill('Model').props).toMatchObject({ disabled: true })

--- a/mobile/src/session/MobileNativeChatSessionOptionRows.tsx
+++ b/mobile/src/session/MobileNativeChatSessionOptionRows.tsx
@@ -219,6 +219,10 @@ export function DescriptorRows({
     )
   }
   const { currentValue, choices } = descriptor.kind
+  // Why: a running value with nothing listable behind it would render an empty card.
+  if (choices.length === 0) {
+    return <SessionOptionCaption>No choices reported by the agent</SessionOptionCaption>
+  }
   return (
     <>
       {choices.map((choice, index) => (

--- a/mobile/src/session/use-mobile-native-chat-session-options.ts
+++ b/mobile/src/session/use-mobile-native-chat-session-options.ts
@@ -2,9 +2,8 @@ import type { AgentSessionConversationCommand } from '../../../src/shared/agent-
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import {
   getAgentSessionOptionCatalog,
-  type AgentSessionOptionCatalog,
-  type CatalogCommandDelivery,
-  type CatalogModel
+  resolveCatalogModelOptions,
+  type CatalogCommandDelivery
 } from '../../../src/shared/agent-session-option-catalog'
 import type {
   SessionOptionDescriptor,
@@ -15,10 +14,7 @@ import {
   buildNativeChatSessionOptionCommand,
   recordNativeChatSessionOptionCommand
 } from '../../../src/shared/native-chat-session-option-commands'
-import {
-  buildNativeChatSessionOptionSnapshot,
-  withTrackedNativeChatModel
-} from '../../../src/shared/native-chat-session-option-snapshot'
+import { buildNativeChatSessionOptionSnapshot } from '../../../src/shared/native-chat-session-option-snapshot'
 import {
   applyNativeChatReportedSessionOptions,
   clearNativeChatSessionModel,
@@ -83,15 +79,6 @@ export function clearMobileSessionOptionRecordsForTests(): void {
 }
 
 const EMPTY_SNAPSHOT: SessionOptionDescriptor[] = []
-
-/** The model list every consumer must see: the catalog's, plus the tracked model
- *  when the catalog no longer lists it. Desktop reconciles identically. */
-function activeModels(
-  catalog: AgentSessionOptionCatalog,
-  record: NativeChatSessionOptionRecord
-): CatalogModel[] {
-  return withTrackedNativeChatModel(catalog, catalog.models, record)
-}
 
 export function useMobileNativeChatSessionOptions(args: {
   agent: string | null
@@ -166,9 +153,9 @@ export function useMobileNativeChatSessionOptions(args: {
     const record = getScopedRecord(scopeKey, agent)
     return buildNativeChatSessionOptionSnapshot({
       catalog,
-      // The snapshot no longer self-heals an unlisted tracked model; every caller
-      // reconciles it in, so a value the seed dropped keeps its row and options.
-      models: activeModels(catalog, record),
+      // The seed is the whole list here: mobile runs no model probe, so there is
+      // nothing for desktop's `withTrackedNativeChatModel` to reconcile back in.
+      models: catalog.models,
       record,
       mode: 'live',
       modelLabel: 'Model',
@@ -222,9 +209,9 @@ export function useMobileNativeChatSessionOptions(args: {
         const apply =
           id === 'model'
             ? catalog.modelApply
-            : activeModels(catalog, record)
-                .find((model) => model.id === previousModelId)
-                ?.options.find((option) => option.id === id)?.apply
+            : resolveCatalogModelOptions(catalog, catalog.models, previousModelId).find(
+                (option) => option.id === id
+              )?.apply
         if (!apply || apply.midSession?.kind === 'agent-picker') {
           return false
         }
@@ -246,7 +233,7 @@ export function useMobileNativeChatSessionOptions(args: {
           apply,
           modelId: previousModelId,
           catalog,
-          models: activeModels(catalog, record),
+          models: catalog.models,
           record
         })
         if (!command) {
@@ -300,9 +287,9 @@ export function useMobileNativeChatSessionOptions(args: {
         const apply =
           id === 'model'
             ? catalog.modelApply
-            : activeModels(catalog, record)
-                .find((model) => model.id === modelId)
-                ?.options.find((option) => option.id === id)?.apply
+            : resolveCatalogModelOptions(catalog, catalog.models, modelId).find(
+                (option) => option.id === id
+              )?.apply
         const midSession = apply?.midSession
         if (midSession?.kind === 'agent-picker') {
           const outcome = midSession.delivery
@@ -334,7 +321,7 @@ export function useMobileNativeChatSessionOptions(args: {
       const record = getScopedRecord(scopeKey, agent)
       const result = recordNativeChatSessionOptionCommand({
         catalog,
-        models: activeModels(catalog, record),
+        models: catalog.models,
         record,
         command
       })

--- a/src/main/claude/claude-structured-session-adapter.test.ts
+++ b/src/main/claude/claude-structured-session-adapter.test.ts
@@ -592,13 +592,9 @@ describe('ClaudeStructuredSessionAdapter turns and controls', () => {
     const adapter = await acquired(claude)
     const result = await adapter.readOptions({ sessionId: 'session-1', fence: 7 })
 
-    expect(result.models.map((model) => model.id)).toEqual([
-      'fable',
-      'opus',
-      'sonnet',
-      'haiku',
-      'custom-model'
-    ])
+    // The seed is the whole list: `custom-model` is not one of its ids, so it is reported
+    // as what the session runs without being fabricated into the picker beside them.
+    expect(result.models.map((model) => model.id)).toEqual(['fable', 'opus', 'sonnet', 'haiku'])
     expect(result.current).toEqual({
       model: 'custom-model',
       effort: 'high',

--- a/src/main/claude/claude-structured-session-options.test.ts
+++ b/src/main/claude/claude-structured-session-options.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { readClaudeStructuredSessionOptions } from './claude-structured-session-options'
+import type { ClaudeSession } from './claude-structured-session-state'
+
+// `list_models` rows as the CLI reports them: the `default` row carries only the
+// resolved id, which is what marks the listed alias resolving to the same model.
+const LISTED_ROWS = [
+  { value: 'default', resolvedModel: 'claude-opus-5[1m]' },
+  {
+    value: 'opus[1m]',
+    displayName: 'Opus (1M context)',
+    resolvedModel: 'claude-opus-5[1m]',
+    supportsEffort: true,
+    supportedEffortLevels: ['low', 'high']
+  },
+  { value: 'sonnet', displayName: 'Sonnet', resolvedModel: 'claude-sonnet-5' }
+]
+
+function optionsSession(reportedModel: string): ClaudeSession {
+  return {
+    connection: { supportedModels: async () => LISTED_ROWS },
+    options: new Map(),
+    reportedOptions: { model: reportedModel },
+    optionMutationSequence: 0,
+    reportedModelMutation: 0,
+    confirmedOptions: new Set()
+  } as unknown as ClaudeSession
+}
+
+describe('readClaudeStructuredSessionOptions', () => {
+  it('names the listed alias the init frame’s resolved id belongs to', async () => {
+    // A legitimately picked Opus is unaffected: the resolved id maps back onto the
+    // listed `opus[1m]` row, so it stays a real choice with its own efforts.
+    const options = await readClaudeStructuredSessionOptions(
+      optionsSession('claude-opus-5[1m]'),
+      undefined
+    )
+
+    expect(options.current).toEqual({ model: 'opus[1m]', confirmed: ['model'] })
+    expect(options.models).toEqual([
+      {
+        id: 'opus[1m]',
+        label: 'Opus (1M context)',
+        isDefault: true,
+        efforts: [
+          { value: 'low', label: 'Low' },
+          { value: 'high', label: 'High' }
+        ]
+      },
+      { id: 'sonnet', label: 'Sonnet', isDefault: false, efforts: [] }
+    ])
+  })
+
+  it('reports an unlisted current model without listing it', async () => {
+    // Was: a fabricated `{ id: model, label: model, efforts: [] }` row, which offered a
+    // raw launch flag (`worker-start --model claude-opus-5`) as if the CLI listed it.
+    const options = await readClaudeStructuredSessionOptions(
+      optionsSession('claude-opus-5'),
+      undefined
+    )
+
+    expect(options.current.model).toBe('claude-opus-5')
+    expect(options.models.map((model) => model.id)).toEqual(['opus[1m]', 'sonnet'])
+  })
+})

--- a/src/main/claude/claude-structured-session-options.ts
+++ b/src/main/claude/claude-structured-session-options.ts
@@ -157,10 +157,10 @@ export async function readClaudeStructuredSessionOptions(
   const discovered = listedModels(catalog ? { models: catalog } : null)
   const models = discovered.length > 0 ? discovered : seedModels()
   const current = readClaudeCurrentModel(session)
+  // `models` stays the CLI's own list (or the seed): `currentModelId` already maps a
+  // resolved id back onto a listed row, so what survives unmatched is an id the CLI
+  // never offered. It is reported as current — the session runs it — but not listed.
   const model = currentModelId(models, current.id)
-  if (!models.some((entry) => entry.id === model)) {
-    models.push({ id: model, label: model, isDefault: false, efforts: [], resolvedModel: null })
-  }
   const effort = session.options.get('effort') ?? session.reportedOptions.effort
   const confirmed = [
     ...(current.confirmed ? ['model'] : []),

--- a/src/main/codex/codex-structured-session-options.test.ts
+++ b/src/main/codex/codex-structured-session-options.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
+import { CODEX_SESSION_OPTION_CATALOG } from '../../shared/agent-session-option-catalog-claude-codex'
+import {
+  applyStructuredAgentSessionOptions,
+  createStructuredAgentSessionOptionState,
+  structuredAgentSessionOptionSnapshot
+} from '../../shared/structured-agent-session-options'
 import type { CodexAppServerConnection } from './codex-app-server-connection'
 import { CodexAcquisitionWindow } from './codex-structured-acquisition-window'
 import {
@@ -121,6 +127,66 @@ describe('structured Codex session options', () => {
       { limit: 100, includeHidden: false, cursor: 'page-2' },
       { timeoutMs: undefined }
     )
+  })
+
+  it('reports an unlisted current model without offering it as a choice', async () => {
+    // Was: a fabricated `{ id, label: id, efforts: [] }` row, which offered a raw launch
+    // id in the picker as though the account were entitled to it.
+    const request = vi.fn(async () => ({
+      data: [{ model: 'gpt-live', displayName: 'GPT Live', isDefault: true }],
+      nextCursor: null
+    }))
+
+    await expect(
+      readCodexStructuredSessionOptions({
+        connection: { request } as never,
+        current: { model: 'gpt-unlisted' }
+      })
+    ).resolves.toEqual({
+      models: [{ id: 'gpt-live', label: 'GPT Live', isDefault: true, efforts: [] }],
+      current: { model: 'gpt-unlisted' }
+    })
+  })
+
+  it('falls back to the seed when model/list answers nothing for a running thread', async () => {
+    // The thread still runs a model, and an empty list carries no options — the snapshot
+    // returns nothing at all for one, taking the effort pill with the model pill.
+    const request = vi.fn(async () => ({ data: [], nextCursor: null }))
+
+    const result = await readCodexStructuredSessionOptions({
+      connection: { request } as never,
+      current: { model: 'gpt-5.9-secret' }
+    })
+
+    expect(result.current.model).toBe('gpt-5.9-secret')
+    expect(result.models.map((model) => model.id)).toEqual(
+      CODEX_SESSION_OPTION_CATALOG.models.map((model) => model.id)
+    )
+    expect(result.models.some((model) => model.id === 'gpt-5.9-secret')).toBe(false)
+
+    // What the floor is for: both pills survive, and the pill still names what runs.
+    const snapshot = structuredAgentSessionOptionSnapshot(
+      applyStructuredAgentSessionOptions(
+        createStructuredAgentSessionOptionState('codex'),
+        CODEX_SESSION_OPTION_CATALOG,
+        result
+      )
+    )
+    expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model', 'effort'])
+    // Any source but `unknown` makes the pill name the value it carries.
+    expect(snapshot[0]).toMatchObject({
+      valueSource: 'dispatched',
+      kind: { type: 'select', currentValue: 'gpt-5.9-secret' }
+    })
+    expect(snapshot[1]).toMatchObject({ settable: true })
+  })
+
+  it('still refuses a thread with neither a listed model nor a current one', async () => {
+    const request = vi.fn(async () => ({ data: [], nextCursor: null }))
+
+    await expect(
+      readCodexStructuredSessionOptions({ connection: { request } as never, current: {} })
+    ).rejects.toThrow('codex app-server returned no available models')
   })
 
   it('hydrates current values from thread start or resume', () => {

--- a/src/main/codex/codex-structured-session-options.test.ts
+++ b/src/main/codex/codex-structured-session-options.test.ts
@@ -177,13 +177,11 @@ describe('structured Codex session options', () => {
     expect(snapshot[1]).toMatchObject({ settable: true })
   })
 
-  it('refuses a seeded model the account is not entitled to', async () => {
-    // The seed is a short list of ids Codex *may* offer, gated on auth. Treating it as
-    // the catalog would let this pick through and defer the failure to `turn/start`.
-    const request = vi.fn(async () => ({
-      data: [{ model: 'gpt-live', displayName: 'GPT Live', isDefault: true }],
-      nextCursor: null
-    }))
+  it('refuses a seeded model the account is not entitled to when nothing is listed', async () => {
+    // The seed is a short list of ids Codex *may* offer, gated on auth. An empty
+    // `model/list` is the one state where a seed floor would become `catalog.models`,
+    // letting this pick pass the host guard and deferring the failure to `turn/start`.
+    const request = vi.fn(async () => ({ data: [], nextCursor: null }))
 
     await expect(
       applyCodexStructuredSessionOption(optionSession(request), 'model', 'gpt-5.6-sol', undefined)

--- a/src/main/codex/codex-structured-session-options.test.ts
+++ b/src/main/codex/codex-structured-session-options.test.ts
@@ -148,9 +148,10 @@ describe('structured Codex session options', () => {
     })
   })
 
-  it('falls back to the seed when model/list answers nothing for a running thread', async () => {
-    // The thread still runs a model, and an empty list carries no options — the snapshot
-    // returns nothing at all for one, taking the effort pill with the model pill.
+  it('keeps both pills for a running thread when model/list answers nothing', async () => {
+    // An empty list is no evidence about what this account may pick, so nothing is
+    // offered. The snapshot still names what runs and draws effort from the catalog's
+    // launch-safe set, rather than blanking both pills or inventing five seeded ids.
     const request = vi.fn(async () => ({ data: [], nextCursor: null }))
 
     const result = await readCodexStructuredSessionOptions({
@@ -158,13 +159,8 @@ describe('structured Codex session options', () => {
       current: { model: 'gpt-5.9-secret' }
     })
 
-    expect(result.current.model).toBe('gpt-5.9-secret')
-    expect(result.models.map((model) => model.id)).toEqual(
-      CODEX_SESSION_OPTION_CATALOG.models.map((model) => model.id)
-    )
-    expect(result.models.some((model) => model.id === 'gpt-5.9-secret')).toBe(false)
+    expect(result).toEqual({ models: [], current: { model: 'gpt-5.9-secret' } })
 
-    // What the floor is for: both pills survive, and the pill still names what runs.
     const snapshot = structuredAgentSessionOptionSnapshot(
       applyStructuredAgentSessionOptions(
         createStructuredAgentSessionOptionState('codex'),
@@ -176,9 +172,22 @@ describe('structured Codex session options', () => {
     // Any source but `unknown` makes the pill name the value it carries.
     expect(snapshot[0]).toMatchObject({
       valueSource: 'dispatched',
-      kind: { type: 'select', currentValue: 'gpt-5.9-secret' }
+      kind: { type: 'select', currentValue: 'gpt-5.9-secret', choices: [] }
     })
     expect(snapshot[1]).toMatchObject({ settable: true })
+  })
+
+  it('refuses a seeded model the account is not entitled to', async () => {
+    // The seed is a short list of ids Codex *may* offer, gated on auth. Treating it as
+    // the catalog would let this pick through and defer the failure to `turn/start`.
+    const request = vi.fn(async () => ({
+      data: [{ model: 'gpt-live', displayName: 'GPT Live', isDefault: true }],
+      nextCursor: null
+    }))
+
+    await expect(
+      applyCodexStructuredSessionOption(optionSession(request), 'model', 'gpt-5.6-sol', undefined)
+    ).rejects.toThrow('codex app-server does not offer model gpt-5.6-sol')
   })
 
   it('still refuses a thread with neither a listed model nor a current one', async () => {

--- a/src/main/codex/codex-structured-session-options.ts
+++ b/src/main/codex/codex-structured-session-options.ts
@@ -1,4 +1,3 @@
-import { CODEX_SESSION_OPTION_CATALOG } from '../../shared/agent-session-option-catalog-claude-codex'
 import type {
   AgentSessionModelOption,
   AgentSessionOptionChoice,
@@ -76,21 +75,6 @@ function modelOption(value: unknown): AgentSessionModelOption | null {
   }
 }
 
-function seedCodexModels(): AgentSessionModelOption[] {
-  return CODEX_SESSION_OPTION_CATALOG.models.map((model) => {
-    const effort = model.options.find((option) => option.id === 'effort')
-    const select = effort?.kind.type === 'select' ? effort.kind : null
-    return {
-      id: model.id,
-      label: model.label,
-      ...(model.description ? { description: model.description } : {}),
-      isDefault: model.isDefault === true,
-      ...(select ? { defaultEffort: String(select.defaultValue) } : {}),
-      efforts: select ? select.choices : []
-    }
-  })
-}
-
 export async function readCodexStructuredSessionOptions(input: {
   connection: Pick<CodexAppServerConnection, 'request'>
   current: { model?: string; effort?: string }
@@ -124,11 +108,8 @@ export async function readCodexStructuredSessionOptions(input: {
   if (!model) {
     throw new Error('codex app-server returned no available models')
   }
-  // Why: a restored thread still runs a model when `model/list` comes back empty, and the
-  // snapshot returns nothing at all for an empty list — blanking the effort pill too. Same
-  // seed floor the Claude reader applies; after the guard, so a thread with no model raises.
   return {
-    models: models.length > 0 ? models : seedCodexModels(),
+    models,
     current: { model, ...(input.current.effort ? { effort: input.current.effort } : {}) }
   }
 }

--- a/src/main/codex/codex-structured-session-options.ts
+++ b/src/main/codex/codex-structured-session-options.ts
@@ -1,3 +1,4 @@
+import { CODEX_SESSION_OPTION_CATALOG } from '../../shared/agent-session-option-catalog-claude-codex'
 import type {
   AgentSessionModelOption,
   AgentSessionOptionChoice,
@@ -75,6 +76,21 @@ function modelOption(value: unknown): AgentSessionModelOption | null {
   }
 }
 
+function seedCodexModels(): AgentSessionModelOption[] {
+  return CODEX_SESSION_OPTION_CATALOG.models.map((model) => {
+    const effort = model.options.find((option) => option.id === 'effort')
+    const select = effort?.kind.type === 'select' ? effort.kind : null
+    return {
+      id: model.id,
+      label: model.label,
+      ...(model.description ? { description: model.description } : {}),
+      isDefault: model.isDefault === true,
+      ...(select ? { defaultEffort: String(select.defaultValue) } : {}),
+      efforts: select ? select.choices : []
+    }
+  })
+}
+
 export async function readCodexStructuredSessionOptions(input: {
   connection: Pick<CodexAppServerConnection, 'request'>
   current: { model?: string; effort?: string }
@@ -102,20 +118,17 @@ export async function readCodexStructuredSessionOptions(input: {
       break
     }
   }
-  if (input.current.model && !models.some((model) => model.id === input.current.model)) {
-    models.push({
-      id: input.current.model,
-      label: input.current.model,
-      isDefault: false,
-      efforts: []
-    })
-  }
+  // `models` stays what `model/list` offered: a current id the account cannot select is
+  // still reported (the thread runs it) but never listed, so no raw id becomes a choice.
   const model = input.current.model ?? models.find((entry) => entry.isDefault)?.id ?? models[0]?.id
   if (!model) {
     throw new Error('codex app-server returned no available models')
   }
+  // Why: a restored thread still runs a model when `model/list` comes back empty, and the
+  // snapshot returns nothing at all for an empty list — blanking the effort pill too. Same
+  // seed floor the Claude reader applies; after the guard, so a thread with no model raises.
   return {
-    models,
+    models: models.length > 0 ? models : seedCodexModels(),
     current: { model, ...(input.current.effort ? { effort: input.current.effort } : {}) }
   }
 }

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-launch-preferences.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-launch-preferences.ts
@@ -1,8 +1,7 @@
 import type { AgentLaunchPreferences } from '../../../../../../shared/agent-session-host-authority'
 import {
-  findCatalogModel,
-  findCatalogOption,
-  getAgentSessionOptionCatalog
+  getAgentSessionOptionCatalog,
+  resolveCatalogModelOptions
 } from '../../../../../../shared/agent-session-option-catalog'
 import { resolveAgentSessionOptionLaunch } from '../../../../../../shared/agent-session-option-launch'
 import { ORCHESTRATION_WORKER_LAUNCH_PREFERENCES_RUNTIME_CAPABILITY } from '../../../../../../shared/protocol-version'
@@ -75,12 +74,9 @@ export function resolveWorkerLaunchPreferences(args: {
   }
 
   if (args.effort) {
-    const model = findCatalogModel(catalog, args.model)
-    const option =
-      findCatalogOption(model, 'effort') ??
-      (!model
-        ? catalog.unknownModelOptions?.find((candidate) => candidate.id === 'effort')
-        : undefined)
+    const option = resolveCatalogModelOptions(catalog, catalog.models, args.model).find(
+      (candidate) => candidate.id === 'effort'
+    )
     if (
       option?.kind.type !== 'select' ||
       !option.kind.choices.some((choice) => choice.value === args.effort)

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.test.tsx
@@ -530,4 +530,31 @@ describe('NativeChatSessionOptionPickers', () => {
     expect(screen.getAllByText('Thinking').length).toBeGreaterThan(0)
     expect(screen.getAllByText('Sent to the agent — not confirmed').length).toBeGreaterThan(0)
   })
+
+  // A running model with an empty `model/list` must not open onto a blank panel.
+  it('explains an empty choice list instead of rendering an empty menu', () => {
+    const { rerender } = render(
+      <NativeChatSessionOptionPickers
+        surface={surface}
+        snapshot={[
+          model({
+            kind: { type: 'select', currentValue: 'gpt-5.2-codex', choices: [] },
+            valueSource: 'reported'
+          })
+        ]}
+        isWorking={false}
+      />
+    )
+    expect(screen.getByText('No choices reported by the agent')).not.toBeNull()
+    // The pill still names the model that is running; only the list is empty.
+    expect(screen.getByRole('button', { name: 'Model gpt-5.2-codex' }).textContent).toContain(
+      'gpt-5.2-codex'
+    )
+
+    rerender(
+      <NativeChatSessionOptionPickers surface={surface} snapshot={[model()]} isWorking={false} />
+    )
+    expect(screen.queryByText('No choices reported by the agent')).toBeNull()
+    expect(screen.getByRole('radio', { name: 'Opus 4.8' })).not.toBeNull()
+  })
 })

--- a/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSessionOptionPickers.tsx
@@ -170,6 +170,15 @@ function DescriptorMenuRows(props: {
       </>
     )
   }
+  // Why: the agent can report a running value with nothing listable behind it;
+  // an empty radio group renders as a blank panel that looks broken.
+  if (descriptor.kind.choices.length === 0) {
+    return (
+      <DropdownMenuLabel className="font-normal text-muted-foreground">
+        {translate('components.native-chat.composer.noChoices', 'No choices reported by the agent')}
+      </DropdownMenuLabel>
+    )
+  }
   return (
     <DropdownMenuRadioGroup
       value={descriptor.kind.currentValue}

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -6,6 +6,7 @@ import {
 } from './native-chat-session-option-cache'
 import { createNativeChatPtySessionOptions } from './native-chat-pty-session-options'
 import { mergeDiscoveredAuthoritativeModels } from '../../../../shared/agent-session-option-catalog'
+import { CLAUDE_SESSION_OPTION_CATALOG } from '../../../../shared/agent-session-option-catalog-claude-codex'
 import { GROK_SESSION_OPTION_CATALOG } from '../../../../shared/agent-session-option-catalog-grok'
 import {
   resolveNativeChatSessionOptionDefaults,
@@ -843,6 +844,51 @@ describe('native chat PTY session options', () => {
       expect.objectContaining({ adoptModelAsLaunchDefault: true })
     )
   })
+
+  it.each([true, false])(
+    'never adopts a model no list carries as the launch default (discovered: %s)',
+    async (discovered) => {
+      // Regression: `worker-start --model claude-opus-5` tracks an id neither the probe
+      // nor the seed carries. Its effort row is drawn from the launch-safe set, so
+      // setting effort persisted `model: claude-opus-5` and every later Claude native
+      // chat launched with a flag the account may not have. Claude never marks its
+      // discovered list authoritative, so neither branch of the guard caught it.
+      let persisted: PersistedNativeChatSessionOptions = {}
+      seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'claude-opus-5' })
+      const surface = createNativeChatPtySessionOptions({
+        agent: 'claude',
+        scopeKey: 'pty-1',
+        mode: 'live',
+        ...(discovered ? { initialModels: CLAUDE_SESSION_OPTION_CATALOG.models } : {}),
+        dispatchCommand: vi.fn().mockResolvedValue({ outcome: 'applied' }),
+        persistSelection: ({ modelId, optionId, value, adoptModelAsLaunchDefault }) => {
+          persisted = updateNativeChatSessionOptionDefaults({
+            persisted,
+            agent: 'claude',
+            modelId,
+            optionId,
+            value,
+            adoptModelAsLaunchDefault
+          })
+        }
+      })!
+
+      // The pill still names what the session runs — this fix withholds the flag, not the truth.
+      expect(surface.getSnapshot().find(({ id }) => id === 'model')).toMatchObject({
+        kind: { currentValue: 'claude-opus-5' }
+      })
+
+      await surface.setOption('effort', 'max')
+
+      expect(persisted.claude?.model).toBeUndefined()
+      // Still scoped to that id, so an explicit reselect gets its value back.
+      expect(persisted.claude?.valuesByModel?.['claude-opus-5']?.effort).toBe('max')
+
+      // A seeded alias is unaffected: picking it still becomes the launch default.
+      await surface.setOption('model', 'opus')
+      expect(persisted.claude?.model).toBe('opus')
+    }
+  )
 
   it('carries an effort set under a probe-confirmed default into later launches', async () => {
     // Regression: the value persisted under the model id while `model` stayed unset, so

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -593,21 +593,32 @@ describe('native chat PTY session options', () => {
     expect(surface.getSnapshot()[0]).toMatchObject({ valueSource: 'unknown' })
   })
 
-  it('passes an unknown persisted model through as a literal choice', () => {
+  it('names a raw launch model without offering it, and keeps its effort picker', async () => {
+    // `worker-start --model claude-opus-5` persists a launch flag no list carries. It used
+    // to be fabricated into the dropdown as a pickable model, with `options: []` behind it.
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
-      model: 'future-model'
+      model: 'claude-opus-5'
     })
+    const dispatch = vi.fn()
     const surface = createNativeChatPtySessionOptions({
       agent: 'claude',
       scopeKey: 'pty-1',
       mode: 'live',
-      dispatchCommand: vi.fn()
+      dispatchCommand: dispatch
     })!
+
     const model = surface.getSnapshot()[0]
-    expect(model.kind).toMatchObject({
-      currentValue: 'future-model',
-      choices: expect.arrayContaining([{ value: 'future-model', label: 'future-model' }])
-    })
+    expect(model.kind.type === 'select' ? model.kind.choices : []).not.toContainEqual(
+      expect.objectContaining({ value: 'claude-opus-5' })
+    )
+    // The session is running it, so the pill still names it.
+    expect(model.kind).toMatchObject({ currentValue: 'claude-opus-5' })
+    expect(model.valueSource).toBe('applied')
+
+    const effort = surface.getSnapshot().find(({ id }) => id === 'effort')
+    expect(effort).toMatchObject({ settable: true })
+    await surface.setOption('effort', 'high')
+    expect(dispatch).toHaveBeenCalledWith('/effort high')
   })
 
   it('keeps a tracked alias selectable when the host catalog omits it', async () => {

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -1,4 +1,5 @@
 import {
+  findCatalogModel,
   getAgentSessionOptionCatalog,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
@@ -142,11 +143,17 @@ export function createNativeChatPtySessionOptions(
    *  persist time because a probe can settle mid-pick. Before one, `isDefault` is just
    *  the seed's guess, so only an id the session actually tracks is evidence of
    *  anything; after one, an authoritative list that omits the id proves it retired —
-   *  adopting either would emit an `-m` that is fatal on an account without it. */
-  const modelIsAdoptableAsLaunchDefault = (modelId: string): boolean =>
-    modelsAreDiscovered
+   *  adopting either would emit an `-m` that is fatal on an account without it. An id
+   *  neither list carries has no such evidence at all: it reached us as a raw launch
+   *  flag or a typed `/model`, and every option row it draws would otherwise persist it. */
+  const modelIsAdoptableAsLaunchDefault = (modelId: string): boolean => {
+    if (!models.some((model) => model.id === modelId) && !findCatalogModel(catalog, modelId)) {
+      return false
+    }
+    return modelsAreDiscovered
       ? !catalog.discoveredModelsAreAuthoritative || models.some((model) => model.id === modelId)
       : record.model !== undefined
+  }
 
   /** Every persist path — picker applies and typed commands — funnels through here. */
   const persist = (modelId: string | null, optionId: string, value: SessionOptionValue): void => {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -1,6 +1,6 @@
 import {
   findCatalogModel,
-  findCatalogOption,
+  resolveCatalogModelOptions,
   type AgentSessionOptionCatalog,
   type CatalogMidSessionApply,
   type CatalogModel,
@@ -72,8 +72,11 @@ function currentApply(
   if (optionId === 'model') {
     return { apply: ctx.catalog.modelApply, modelId }
   }
-  const model = modelId ? findCatalogModel({ ...ctx.catalog, models }, modelId) : undefined
-  const option = findCatalogOption(model, optionId)
+  // Why: the snapshot draws an unlisted model's rows from the launch-safe set, so
+  // resolving through the model list alone would reject the very rows it rendered.
+  const option = resolveCatalogModelOptions(ctx.catalog, models, modelId).find(
+    (candidate) => candidate.id === optionId
+  )
   return option ? { apply: option.apply, modelId } : null
 }
 

--- a/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
@@ -5,6 +5,9 @@ import {
   nativeChatSessionChoiceLabel
 } from './native-chat-session-option-labels'
 import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
+import { CLAUDE_SESSION_OPTION_CATALOG } from '../../../../shared/agent-session-option-catalog-claude-codex'
+import { buildNativeChatSessionOptionSnapshot } from '../../../../shared/native-chat-session-option-snapshot'
+import { createNativeChatSessionOptionRecord } from '../../../../shared/native-chat-session-option-state'
 
 vi.mock('@/i18n/i18n', () => ({
   translate: vi.fn((_key: string, fallback: string) => fallback)
@@ -48,6 +51,24 @@ describe('nativeChatModelPillLabel', () => {
     // A discovered list can drop an id the record still tracks; showing the id beats
     // showing "Model" while a real model is running.
     expect(nativeChatModelPillLabel(modelDescriptor('reported', 'grok-build'))).toBe('grok-build')
+  })
+
+  it('names the unlisted model a real snapshot reports, end to end', () => {
+    // The producer half of the contract above: the snapshot must keep handing the pill a
+    // `currentValue` and a non-`unknown` source for a model that is running but unlisted,
+    // or the composer goes back to reading a neutral "Model" over a live session.
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.model = { value: 'claude-opus-5', source: 'reported' }
+    const snapshot = buildNativeChatSessionOptionSnapshot({
+      catalog: CLAUDE_SESSION_OPTION_CATALOG,
+      models: CLAUDE_SESSION_OPTION_CATALOG.models,
+      record,
+      mode: 'live',
+      modelLabel: 'Model',
+      liveTransport: 'catalog'
+    })
+
+    expect(nativeChatModelPillLabel(snapshot[0]!)).toBe('claude-opus-5')
   })
 })
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17070,6 +17070,7 @@
         "toggleOption": "Toggle {{value0}}",
         "pillAccessibleName": "{{value0}} {{value1}}",
         "valueUnknown": "Current value unknown — pick On or Off",
+        "noChoices": "No choices reported by the agent",
         "sentNotConfirmed": "Sent to the agent — not confirmed",
         "setWhenSessionStarts": "Set when the session starts.",
         "availableAfterSessionStarts": "Available after the session starts.",

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -54,6 +54,21 @@ export function findCatalogOption(
   return model?.options.find((option) => option.id === optionId)
 }
 
+/** The options an id draws: the listed model's own, or the catalog's launch-safe set for
+ *  an id no list carries. Mirrors `resolveAgentSessionOptionLaunch`, so the picker offers
+ *  exactly the options a launch of that id would resolve — including for a model that is
+ *  running but absent from the choices, which the snapshot deliberately does not invent. */
+export function resolveCatalogModelOptions(
+  catalog: AgentSessionOptionCatalog,
+  models: readonly CatalogModel[],
+  modelId: string | null
+): readonly CatalogOption[] {
+  if (!modelId) {
+    return []
+  }
+  return models.find((model) => model.id === modelId)?.options ?? catalog.unknownModelOptions ?? []
+}
+
 /** Merge live rows over the static seed while retaining cataloged option mappings. */
 export function mergeCatalogModels(
   seed: readonly CatalogModel[],

--- a/src/shared/agent-session-option-launch.ts
+++ b/src/shared/agent-session-option-launch.ts
@@ -1,5 +1,9 @@
 import type { AgentType } from './agent-status-types'
-import { findCatalogModel, getAgentSessionOptionCatalog } from './agent-session-option-catalog'
+import {
+  findCatalogModel,
+  getAgentSessionOptionCatalog,
+  resolveCatalogModelOptions
+} from './agent-session-option-catalog'
 import type { SessionOptionValue } from './native-chat-session-options'
 
 export type ResolvedSessionOptionLaunch = {
@@ -18,8 +22,7 @@ export function removeOverriddenAgentSessionArgs(
     return [...tokens]
   }
   let result = catalog.modelApply.removeAgentArgs?.(tokens) ?? [...tokens]
-  const model = findCatalogModel(catalog, modelId)
-  const modelOptions = model?.options ?? catalog.unknownModelOptions ?? []
+  const modelOptions = resolveCatalogModelOptions(catalog, catalog.models, modelId)
   for (const option of modelOptions) {
     if (values[option.id] !== undefined && option.apply.removeAgentArgs) {
       result = option.apply.removeAgentArgs(result)
@@ -43,7 +46,7 @@ export function resolveAgentSessionOptionLaunch(
   const model = findCatalogModel(catalog, modelId)
   const appliedValues: Record<string, SessionOptionValue> = {}
   const args: string[] = []
-  const modelOptions = model?.options ?? catalog.unknownModelOptions ?? []
+  const modelOptions = resolveCatalogModelOptions(catalog, catalog.models, modelId)
   const modelValues = Object.fromEntries(
     modelOptions.flatMap((option) => {
       const explicitValue = values[option.id]

--- a/src/shared/native-chat-session-option-commands.test.ts
+++ b/src/shared/native-chat-session-option-commands.test.ts
@@ -3,7 +3,9 @@ import {
   CLAUDE_SESSION_OPTION_CATALOG,
   CODEX_SESSION_OPTION_CATALOG
 } from './agent-session-option-catalog-claude-codex'
+import { CURSOR_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-gemini-cursor'
 import { GROK_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-grok'
+import type { AgentSessionOptionCatalog } from './agent-session-option-catalog'
 import {
   buildNativeChatSessionOptionCommand,
   parseBuiltSessionOptionCommand,
@@ -85,6 +87,41 @@ describe('buildNativeChatSessionOptionCommand', () => {
       command: '/model',
       delivery: 'type'
     })
+  })
+
+  it('composes an unlisted model from the launch-safe options, not from nothing', () => {
+    // No shipped catalog both composes options into the model value and defines
+    // `unknownModelOptions`, so this pins the rule at the emit site: the composed
+    // string must carry the same defaults a launch of that id would resolve.
+    const composing: AgentSessionOptionCatalog = {
+      ...CURSOR_SESSION_OPTION_CATALOG,
+      unknownModelOptions: [
+        {
+          id: 'effort',
+          label: 'Effort',
+          kind: {
+            type: 'select',
+            choices: [{ value: 'high', label: 'High' }],
+            defaultValue: 'high'
+          },
+          apply: { composedIntoModel: true }
+        }
+      ]
+    }
+    const record = createNativeChatSessionOptionRecord('cursor')
+    record.model = { value: 'gpt-unlisted', source: 'dispatched' }
+
+    expect(
+      buildNativeChatSessionOptionCommand({
+        optionId: 'fastMode',
+        value: true,
+        apply: { composedIntoModel: true },
+        modelId: 'gpt-unlisted',
+        catalog: composing,
+        models: CURSOR_SESSION_OPTION_CATALOG.models,
+        record
+      })
+    ).toBe('/model gpt-unlisted-high-fast')
   })
 })
 
@@ -388,5 +425,28 @@ describe('recordNativeChatSessionOptionCommand for grok', () => {
       command: '/model grok-4.5'
     })
     expect(record.model).toEqual({ value: 'grok-4.5', source: 'dispatched' })
+  })
+
+  it('records and persists a typed option under a model no list carries', () => {
+    // `worker-start --model claude-opus-5` leaves an id neither the probe nor the seed
+    // carries. Its rows come off the launch-safe set, so a typed `/effort` under it is
+    // real state — resolving through the model list alone dropped it silently.
+    const record = claudeRecord('claude-opus-5')
+    const persist = vi.fn()
+
+    expect(
+      recordNativeChatSessionOptionCommand({
+        catalog: CLAUDE_SESSION_OPTION_CATALOG,
+        models: CLAUDE_SESSION_OPTION_CATALOG.models,
+        record,
+        command: '/effort max',
+        persist
+      })
+    ).toEqual({ changed: true, opensAgentPicker: false })
+    expect(record.valuesByModel['claude-opus-5']?.effort).toEqual({
+      value: 'max',
+      source: 'dispatched'
+    })
+    expect(persist).toHaveBeenCalledWith('claude-opus-5', 'effort', 'max')
   })
 })

--- a/src/shared/native-chat-session-option-commands.ts
+++ b/src/shared/native-chat-session-option-commands.ts
@@ -165,9 +165,8 @@ export function recordNativeChatSessionOptionCommand(args: {
     canonicalize: (value) =>
       /\s/.test(value)
         ? null
-        : // Fall back to the seed: an alias this host's CLI no longer lists is
-          // still a legitimate thing to type, and callers reconcile it back into
-          // the list (withTrackedNativeChatModel) rather than blanking the row.
+        : // Fall back to the seed: an alias this host's CLI no longer lists is still a
+          // legitimate thing to type, and is named as the current value even unlisted.
           (matchNativeChatCatalogModelId({ ...catalog, models: [...models] }, value) ??
           matchNativeChatCatalogModelId(catalog, value)),
     effectiveModelId: resolveEffectiveNativeChatModelId(catalog, models, record),

--- a/src/shared/native-chat-session-option-commands.ts
+++ b/src/shared/native-chat-session-option-commands.ts
@@ -1,8 +1,9 @@
-import type {
-  AgentSessionOptionCatalog,
-  CatalogMidSessionApply,
-  CatalogModel,
-  CatalogOptionApply
+import {
+  resolveCatalogModelOptions,
+  type AgentSessionOptionCatalog,
+  type CatalogMidSessionApply,
+  type CatalogModel,
+  type CatalogOptionApply
 } from './agent-session-option-catalog'
 import type { SessionOptionValue } from './native-chat-session-options'
 import {
@@ -63,9 +64,8 @@ export function buildNativeChatSessionOptionCommand(args: {
   if (!args.apply.composedIntoModel || !args.modelId || !args.catalog.composeModelValue) {
     return null
   }
-  const model = args.models.find((candidate) => candidate.id === args.modelId)
   const values = flattenNativeChatSessionOptionRecord(args.record, args.modelId)
-  for (const option of model?.options ?? []) {
+  for (const option of resolveCatalogModelOptions(args.catalog, args.models, args.modelId)) {
     values[option.id] ??= option.kind.defaultValue
   }
   values[args.optionId] = args.value
@@ -175,8 +175,7 @@ export function recordNativeChatSessionOptionCommand(args: {
   })
   // Re-resolved: the command above may have just tracked a model.
   const modelId = resolveEffectiveNativeChatModelId(catalog, models, record)
-  const model = modelId ? models.find((candidate) => candidate.id === modelId) : undefined
-  for (const option of model?.options ?? []) {
+  for (const option of resolveCatalogModelOptions(catalog, models, modelId)) {
     opensAgentPicker =
       opensAgentPicker || isSessionOptionAgentPickerCommand(option.apply.midSession, command)
     changed =

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -178,19 +178,72 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       expect(snapshot.length).toBeGreaterThan(1)
     })
 
-    it('labels a wholly unknown tracked model by its id rather than dropping it', () => {
+    it('never invents a row for an id no list carries', () => {
+      // `worker-start --model claude-opus-5` is a raw launch flag, not a model anyone
+      // can pick: fabricating a row put it in the dropdown as a selectable model.
       const record = claudeRecord()
-      record.model = { value: 'experimental-model', source: 'reported' }
-      const reconciled = withTrackedNativeChatModel(
-        CLAUDE_SESSION_OPTION_CATALOG,
-        CLAUDE_SESSION_OPTION_CATALOG.models,
-        record
-      )
-      expect(reconciled.at(-1)).toEqual({
-        id: 'experimental-model',
-        label: 'experimental-model',
-        options: []
+      record.model = { value: 'claude-opus-5', source: 'reported' }
+      expect(
+        withTrackedNativeChatModel(
+          CLAUDE_SESSION_OPTION_CATALOG,
+          CLAUDE_SESSION_OPTION_CATALOG.models,
+          record
+        )
+      ).toEqual([...CLAUDE_SESSION_OPTION_CATALOG.models])
+    })
+
+    it('names the unlisted model that is running without offering it as a choice', () => {
+      const record = claudeRecord()
+      record.model = { value: 'claude-opus-5', source: 'reported' }
+      const snapshot = buildNativeChatSessionOptionSnapshot({
+        catalog: CLAUDE_SESSION_OPTION_CATALOG,
+        models: withTrackedNativeChatModel(
+          CLAUDE_SESSION_OPTION_CATALOG,
+          CLAUDE_SESSION_OPTION_CATALOG.models,
+          record
+        ),
+        record,
+        mode: 'live',
+        modelLabel: 'Model',
+        liveTransport: 'catalog'
       })
+      const model = snapshot[0]!
+      if (model.kind.type !== 'select') {
+        throw new Error('model descriptor must be a select')
+      }
+      expect(model.kind.choices.some((choice) => choice.value === 'claude-opus-5')).toBe(false)
+      // The session runs it, so the pill still names it: `currentValue` plus a source the
+      // pill does not withhold is what `nativeChatModelPillLabel` renders as the raw id.
+      expect(model.kind.currentValue).toBe('claude-opus-5')
+      expect(model.valueSource).toBe('reported')
+      // The fabricated row carried `options: []`, which took the effort picker with it.
+      const effort = snapshot.find((descriptor) => descriptor.id === 'effort')
+      expect(effort).toMatchObject({ settable: true, kind: { type: 'select' } })
+      expect(effort?.kind.type === 'select' ? effort.kind.choices.length : 0).toBeGreaterThan(1)
+    })
+
+    it('keeps a legitimately picked model unaffected', () => {
+      const record = claudeRecord()
+      record.model = { value: 'sonnet', source: 'reported' }
+      const snapshot = buildNativeChatSessionOptionSnapshot({
+        catalog: CLAUDE_SESSION_OPTION_CATALOG,
+        models: withTrackedNativeChatModel(
+          CLAUDE_SESSION_OPTION_CATALOG,
+          CLAUDE_SESSION_OPTION_CATALOG.models,
+          record
+        ),
+        record,
+        mode: 'live',
+        modelLabel: 'Model',
+        liveTransport: 'catalog'
+      })
+      const model = snapshot[0]!
+      expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBe('sonnet')
+      expect(
+        model.kind.type === 'select' &&
+          model.kind.choices.some((choice) => choice.value === 'sonnet')
+      ).toBe(true)
+      expect(snapshot.find((descriptor) => descriptor.id === 'effort')).toBeDefined()
     })
 
     it('leaves the list alone when the tracked model is already listed', () => {

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -106,7 +106,7 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
     )
   })
 
-  it('is empty when the model list is empty', () => {
+  it('is empty when the model list is empty and no model resolves', () => {
     expect(
       buildNativeChatSessionOptionSnapshot({
         catalog: CLAUDE_SESSION_OPTION_CATALOG,
@@ -117,6 +117,31 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
         liveTransport: 'catalog'
       })
     ).toEqual([])
+  })
+
+  it('names a running model an empty list cannot offer, and keeps its effort row', () => {
+    // A provider that lists nothing has said nothing about what this account may pick,
+    // so there is nothing to offer — but the thread demonstrably runs a model, and
+    // blanking both pills over an empty list hides a fact we hold.
+    const record = createNativeChatSessionOptionRecord('codex')
+    record.model = { value: 'gpt-5.9-secret', source: 'reported' }
+
+    const snapshot = buildNativeChatSessionOptionSnapshot({
+      catalog: CODEX_SESSION_OPTION_CATALOG,
+      models: [],
+      record,
+      mode: 'live',
+      modelLabel: 'Model',
+      liveTransport: 'agent-session'
+    })
+
+    expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model', 'effort'])
+    expect(snapshot[0]!.kind).toEqual({
+      type: 'select',
+      currentValue: 'gpt-5.9-secret',
+      choices: []
+    })
+    expect(snapshot[0]!.valueSource).toBe('reported')
   })
 
   describe('sortNativeChatSessionOptions', () => {

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -212,10 +212,15 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   liveTransport: NativeChatLiveOptionTransport
 }): SessionOptionDescriptor[] {
   const { catalog, models, record, mode, modelLabel, liveTransport } = args
-  if (models.length === 0) {
+  const modelTracked = record.model
+  const trackedModelId = typeof modelTracked?.value === 'string' ? modelTracked.value : null
+  const defaultModelId = cliDefaultModelId(catalog, models, trackedModelId)
+  const effectiveModelId = trackedModelId ?? defaultModelId
+  // Why: an empty list only means "nothing to show" when no id resolves either. A session
+  // that demonstrably runs a model still names it, with no choices to offer beside it.
+  if (models.length === 0 && !effectiveModelId) {
     return []
   }
-  const modelTracked = record.model
   // Why: every row is an official model — the catalog's or a probe's. An id outside
   // both is never offered as a choice, but it stays the current value below: the
   // session is running it, and naming it beats showing a model that it is not.
@@ -224,9 +229,6 @@ export function buildNativeChatSessionOptionSnapshot(args: {
     label,
     ...(description ? { description } : {})
   }))
-  const trackedModelId = typeof modelTracked?.value === 'string' ? modelTracked.value : null
-  const defaultModelId = cliDefaultModelId(catalog, models, trackedModelId)
-  const effectiveModelId = trackedModelId ?? defaultModelId
   const modelAction = actionForApply(catalog.modelApply, modelTracked, mode, liveTransport)
   const snapshot: SessionOptionDescriptor[] = [
     {

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -1,8 +1,9 @@
-import type {
-  AgentSessionOptionCatalog,
-  CatalogMidSessionApply,
-  CatalogModel,
-  CatalogOption
+import {
+  resolveCatalogModelOptions,
+  type AgentSessionOptionCatalog,
+  type CatalogMidSessionApply,
+  type CatalogModel,
+  type CatalogOption
 } from './agent-session-option-catalog'
 import type {
   NativeChatLiveOptionTransport,
@@ -157,9 +158,10 @@ export function sortNativeChatSessionOptions(
 }
 
 /**
- * Why: the tracked model can sit outside the active list — a persisted default,
- * or an alias this host's CLI no longer lists. Keeping a row for it preserves
- * the labelled selection and the model's own options instead of blanking both.
+ * Why: an alias this host's CLI no longer lists is still a real, seeded model, so its
+ * seed row preserves the labelled selection and the model's own options instead of
+ * blanking both. An id neither list carries names no model anyone can pick — a raw
+ * launch flag, a typo'd `/model` — so it gets no row and never becomes a choice.
  * Shared so mobile satisfies the same caller contract the desktop surface does.
  */
 export function withTrackedNativeChatModel(
@@ -172,7 +174,7 @@ export function withTrackedNativeChatModel(
     return [...models]
   }
   const seeded = catalog.models.find((model) => model.id === trackedId)
-  return [...models, seeded ?? { id: trackedId, label: trackedId, options: [] }]
+  return seeded ? [...models, seeded] : [...models]
 }
 
 /** Why: no tracked model means no `-m` was ever emitted, so the CLI is running its
@@ -214,9 +216,9 @@ export function buildNativeChatSessionOptionSnapshot(args: {
     return []
   }
   const modelTracked = record.model
-  // Why: callers reconcile the tracked model into `models` (see
-  // withTrackedNativeChatModel), so every listed row is a real choice and the
-  // trigger never shows a value without one.
+  // Why: every row is an official model — the catalog's or a probe's. An id outside
+  // both is never offered as a choice, but it stays the current value below: the
+  // session is running it, and naming it beats showing a model that it is not.
   const modelChoices = models.map(({ id, label, description }) => ({
     value: id,
     label,
@@ -245,9 +247,10 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   if (!effectiveModelId) {
     return snapshot
   }
-  const model = models.find((candidate) => candidate.id === effectiveModelId)
+  // Why: an unlisted model still runs, so its options come off the launch-safe set
+  // rather than leaving that session with no effort picker at all.
   const trackedValues = record.valuesByModel[effectiveModelId] ?? {}
-  for (const option of model?.options ?? []) {
+  for (const option of resolveCatalogModelOptions(catalog, models, effectiveModelId)) {
     const descriptor = optionDescriptor({
       option,
       tracked: trackedValues[option.id],

--- a/src/shared/structured-agent-session-composer.test.ts
+++ b/src/shared/structured-agent-session-composer.test.ts
@@ -4,6 +4,7 @@ import {
   isStructuredAgentSessionComposerCommand,
   structuredSlashCommands
 } from './structured-agent-session-composer'
+import type { SessionOptionDescriptor } from './native-chat-session-options'
 
 describe('structuredSlashCommands', () => {
   // The composer menu and the dispatcher read this one list. When they disagreed,
@@ -83,6 +84,45 @@ describe('dispatchStructuredAgentSessionComposerCommand', () => {
       }
     }
   )
+  it('accepts the running model as a no-op even though it is never offered', async () => {
+    // The pill names an unlisted model the session actually runs; typing that same id
+    // used to be refused as "not an available model", contradicting the pill.
+    const setOption = vi.fn(async () => true)
+    const running = {
+      ...controller,
+      setOption,
+      snapshot: [
+        {
+          id: 'model',
+          label: 'Model',
+          category: 'model',
+          kind: {
+            type: 'select',
+            currentValue: 'claude-opus-5',
+            choices: [{ value: 'gpt-live', label: 'GPT Live' }]
+          },
+          valueSource: 'reported',
+          transport: 'agent-session',
+          settable: true
+        }
+      ] satisfies SessionOptionDescriptor[]
+    }
+
+    expect(
+      await dispatchStructuredAgentSessionComposerCommand('/model Claude-Opus-5', running)
+    ).toEqual({ handled: true, accepted: true, error: null })
+    expect(setOption).not.toHaveBeenCalled()
+
+    // A genuinely unavailable id is still refused.
+    expect(
+      await dispatchStructuredAgentSessionComposerCommand('/model gpt-retired', running)
+    ).toEqual({
+      handled: true,
+      accepted: false,
+      error: 'gpt-retired is not an available model for this chat session.'
+    })
+  })
+
   it('retains a draft on unsupported hosts and rejects arguments before dispatch', async () => {
     expect(await dispatchStructuredAgentSessionComposerCommand('/clear', controller)).toMatchObject(
       { handled: true, accepted: false, error: '/clear is not supported by this chat host.' }

--- a/src/shared/structured-agent-session-composer.ts
+++ b/src/shared/structured-agent-session-composer.ts
@@ -140,6 +140,11 @@ export async function dispatchStructuredAgentSessionComposerCommand(
     (entry) => entry.value.toLowerCase() === normalized || entry.label.toLowerCase() === normalized
   )
   if (!choice) {
+    // Why: the running value is named but never offered, so rejecting it would
+    // contradict the pill; re-stating what is already set is a no-op.
+    if (descriptor.kind.currentValue?.toLowerCase() === normalized) {
+      return { handled: true, accepted: true, error: null }
+    }
     return {
       handled: true,
       accepted: false,

--- a/src/shared/structured-agent-session-options.test.ts
+++ b/src/shared/structured-agent-session-options.test.ts
@@ -61,7 +61,7 @@ describe('structured agent session options', () => {
     })
   })
 
-  it('uses provider-scoped models and retains the current unknown id', () => {
+  it('offers only provider-listed ids while still reporting the current unknown one', () => {
     const state = applyStructuredAgentSessionOptions(
       createStructuredAgentSessionOptionState('codex'),
       CODEX_SESSION_OPTION_CATALOG,
@@ -77,11 +77,18 @@ describe('structured agent session options', () => {
         current: { model: 'persisted-unknown' }
       }
     )
-    const model = structuredAgentSessionOptionSnapshot(state)[0]
+    const snapshot = structuredAgentSessionOptionSnapshot(state)
+    const model = snapshot[0]!
+    // The provider never listed it, so it is not offerable — but the thread runs it.
     expect(
       model.kind.type === 'select' ? model.kind.choices.map((choice) => choice.value) : []
-    ).toEqual(['account-model', 'persisted-unknown'])
+    ).toEqual(['account-model'])
     expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBe('persisted-unknown')
+    // The fabricated row was where `unknownModelOptions` used to hang; the resolver keeps it.
+    expect(snapshot.find((descriptor) => descriptor.id === 'effort')).toMatchObject({
+      settable: true,
+      kind: { type: 'select' }
+    })
   })
 
   it('projects live options as directly settable descriptors', () => {

--- a/src/shared/structured-agent-session-options.ts
+++ b/src/shared/structured-agent-session-options.ts
@@ -49,14 +49,10 @@ export function structuredAgentSessionOptionCatalog(
   seed: AgentSessionOptionCatalog,
   result: AgentSessionOptionsResult
 ): AgentSessionOptionCatalog {
+  // Why: only ids the provider lists may be OFFERED. An unlisted `current.model` still
+  // reaches the snapshot through the record, which reports it as the running model and
+  // draws its effort row from `unknownModelOptions` — without making it a choice.
   const models: CatalogModel[] = result.models.map(discoveredModel)
-  if (!models.some((model) => model.id === result.current.model)) {
-    models.push({
-      id: result.current.model,
-      label: result.current.model,
-      options: seed.unknownModelOptions ?? []
-    })
-  }
   return { ...seed, models, defaultModelIsCliDefault: true }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​480 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​451 |
| Prod | 15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​95 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## The bug

Four layers fabricated a catalog row — `{ id: trackedId, label: trackedId, options: [] }` — whenever the tracked model id was one neither the CLI-discovered list nor the static seed carried:

- `withTrackedNativeChatModel` (`src/shared/native-chat-session-option-snapshot.ts`)
- `structuredAgentSessionOptionCatalog` (`src/shared/structured-agent-session-options.ts`)
- `readClaudeStructuredSessionOptions` (`src/main/claude/claude-structured-session-options.ts`)
- `readCodexStructuredSessionOptions` (`src/main/codex/codex-structured-session-options.ts`)

Two consequences:

1. **A raw launch flag appeared in the model dropdown as a selectable model.** A worker started with `worker-start --model claude-opus-5` rendered `claude-opus-5` as a pickable option beside `Opus`, `Sonnet` and the rest.
2. **The effort picker vanished for that session.** The fabricated desktop row carried `options: []`, so the snapshot found no options under the effective model and dropped the effort row entirely.

## The fix

No layer fabricates a row any more. An id neither list carries never becomes a choice — but it is still **named** as the pill's current value, because the session is demonstrably running it.

The options for such an id come from `resolveCatalogModelOptions`, a shared resolver: the listed model's own options, falling back to the catalog's `unknownModelOptions`. Seven call sites read it — the snapshot, the command recorder and emitter, the desktop applier, the mobile hook, and `worker-launch-preferences` — so the effort row is present **and settable** for an unlisted model rather than merely rendered.

### Two claims from an earlier revision of this description were wrong

**A retired seeded alias getting its seed row back is PTY-only.** `withTrackedNativeChatModel` reconciles a seeded alias the host's CLI has retired back into the list, and that is real on the PTY path. On the structured path it cannot happen: `structuredAgentSessionOptionCatalog` sets `catalog.models` to the discovered list, so the seed lookup scans the same array and can never find anything, and `structuredAgentSessionOptionSnapshot` never calls it. Structured Codex with `current.model = 'gpt-5.6-sol'` (seeded, 7 effort levels) and a list without it yields `choices: ['gpt-live']`, no seed row, and 5 effort levels from `unknownModelOptions` rather than the seed's 7. `main` also gives 5, so this is not a defect — just an inaccurate claim.

**"The picker offers exactly the options a launch would resolve" does not hold when `listModels` succeeds.** The launch path resolves against `catalog.models` while the snapshot resolves against the discovered list, so a probe-discovered id absent from the seed draws different options in each. The two agree only for an id absent from *both*.

### An unlisted id must never become the persisted launch default

`modelIsAdoptableAsLaunchDefault` decides whether a picker write may also persist `model` as the `-m` launch flag for every future session of that agent. Its docstring already said an id with no evidence behind it must not be adopted, but the code only enforced that for catalogs marking their discovered list authoritative — which Claude does not.

On `main` that hole was reachable through the **model row**, whose fabricated entry was selectable. This PR closes that door and, by restoring the effort row for an unlisted model, opens an equivalent route through **effort**: `worker-start --model claude-opus-5` → open native chat → change effort → every later Claude native chat launches with that flag. Same hazard, new route.

The guard now refuses any id carried by neither the discovered list nor the catalog seed, in both the discovered and not-yet-discovered branches. Retirement semantics for ids that *are* seeded or listed are unchanged, and the value stays scoped under that model id so an explicit reselect gets it back.

### `/model <the model you are running>` no longer errors

`dispatchStructuredAgentSessionComposerCommand` resolved its argument against `descriptor.kind.choices` only, so typing the very id the pill names returned *"… is not an available model for this chat session."* It now accepts an argument matching the descriptor's `currentValue` as a no-op success. Genuinely unavailable ids are still refused.

### Codex: narrow the snapshot guard, do not floor on the seed

Removing the Codex fabrication makes an empty `model/list` reachable alongside a truthy `current.model`. `buildNativeChatSessionOptionSnapshot` returned `[]` for an empty list, which would blank the model pill *and* the effort pill on a restored thread.

The guard was the defect, so the guard is what changed: it bails only when the list is empty **and** no model id resolves either. With an empty list and a running model it emits the model row — naming what runs, with an empty `choices` array — plus the effort row from `unknownModelOptions`. Both pill helpers already fall back to `{ value: currentValue, label: currentValue }`, so neither surface blanks.

An earlier revision instead floored `readCodexStructuredSessionOptions` on the Codex seed. That is removed. It contributed nothing it claimed to protect (any single row restores both pills, and the effort row comes from `unknownModelOptions`); it defeated a host-side guard, since `applyValidatedCodexStructuredSessionOption` validates a model pick against `catalog.models`, so an entitlement-gated id like `gpt-5.6-sol` would have passed and been stored, deferring the failure to `turn/start`; and it contradicted the catalog's own note that Codex model access depends on auth and the seed is deliberately short. `models: []` also arises when `modelOption` rejects every row, so the floor would have masked a Codex wire-format change behind five hardcoded ids.

The `codex app-server returned no available models` guard and its test are untouched.

## Accepted consequences

- **An empty model picker when `model/list` returns no usable rows.** Newly reachable because the guard was narrowed. Every alternative is worse: blanking both pills hides the model that is actually running, and flooring on the seed offers five entitlement-gated ids and defeats host-side validation. An empty picker that correctly names the running model is the honest degradation, and it is a degenerate state that requires `model/list` to succeed and return nothing usable.
- **No checked radio** in the model dropdown while the pill names an unlisted running model — the intended consequence of not offering the id. An explicit "unavailable" marker is a new UI affordance and belongs in a follow-up, together with the point above.
- **Mixed-version skew:** a new client against an old host still sees the raw id offered with no effort row, because the old host's fabricated `efforts: []` becomes `options: []` and `[] ?? x` is `[]`. This is `main`'s behaviour, and it cannot be closed by treating an empty `options` as absent — cursor and gemini have legitimate models with `options: []` and neither defines `unknownModelOptions`.
- Claude's `unknownModelOptions` exposes the extended effort ladder for an unlisted model and the host does not enforce a narrower one (`readClaudeModelEffortLevels` returns `null`). Inherent to restoring the effort picker at all.
- Stricter `worker-start --model` validation is tracked separately in #19682; `worker-start --model` behaves exactly as on `main`.

## Tests

Every ablation below was re-proven at the final head. Each was bracketed: the removed symbol was grepped before and after the run to prove the ablation actually landed, then restored and re-run.

| Lever ablated | Test | Ablated | Restored |
| --- | --- | --- | --- |
| Launch-default guard | `never adopts a model no list carries as the launch default` (both branches) | 2 failed / 32 | 32 passed |
| Narrowed snapshot guard | `names a running model an empty list cannot offer, and keeps its effort row` | 1 failed / 24 | 24 passed |
| Codex seed floor re-added | `keeps both pills…`, `refuses a seeded model the account is not entitled to when nothing is listed` | 2 failed / 9 | 9 passed |
| Options resolver in the command recorder + emitter | `records and persists a typed option under a model no list carries`, `composes an unlisted model from the launch-safe options` | 2 failed / 27 | 27 passed |
| Composer `currentValue` acceptance | `accepts the running model as a no-op even though it is never offered` | 1 failed / 14 | 14 passed |

Two honesty notes on this table:

- An earlier revision claimed every behavioural change had a failing-without-it test. That was **false** for `src/shared/native-chat-session-option-commands.ts` — reverting it to `main` left the suite fully green. Both call sites are covered now: ablated to `main`, the emitter produces `/model gpt-unlisted-fast` instead of `…-high-fast` and the recorder returns `changed: false`.
- The Codex entitlement test as first written listed one live model, so the floor never engaged and the assertion held with or without it. It was corrected to use an empty `model/list`, the only state where the floor becomes `catalog.models`; it is ablation-sensitive now.

No shipped catalog both composes options into the model value *and* defines `unknownModelOptions`, so the emitter test pins the shared rule against a catalog shaped that way rather than a live one. The recorder test uses the real Claude catalog, where the widening is observable today.

`worker-launch-preferences` was converted to the shared resolver as a pure dedup — behaviour-identical by inspection of both branches, with its existing 22 tests unchanged and green.

## Verification

- `pnpm tc` exit 0; mobile `tsc --noEmit` exit 0.
- `pnpm run check:code-quality:changed`: 0 new findings across 21 changed files, including the type-aware and React Doctor passes.
- `oxlint` clean on all 21 changed files.
- Mobile: `src/session` 156 files / 1476 tests passed.
- Root suite: 28 files / 76 tests failed. All were re-run in isolation; 20 files passed, and the remaining 5 files / 6 tests fail identically at the PR base with none of these changes applied, so they are pre-existing and unrelated (real-binary integration, relay/subprocess timing, CLI selector messaging, release-checkout).
