### PR TITLE
fix(editor): stop treating prose after [label]: as a link definition

### DIFF
--- a/src/renderer/src/components/editor/markdown-rich-mode.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.test.ts
@@ -166,6 +166,26 @@ describe('getMarkdownRichModeUnsupportedMessage', () => {
       ).not.toBeNull()
     })
 
+    it('blocks a link reference definition nested inside a blockquote inside a list item', () => {
+      expect(
+        getMarkdownRichModeUnsupportedMessage('- > [id]: https://example.com\n  > uses [id] here\n')
+      ).not.toBeNull()
+    })
+
+    it('blocks a link reference definition nested inside a list item inside a blockquote', () => {
+      expect(
+        getMarkdownRichModeUnsupportedMessage('> - [id]: https://example.com\n>   uses [id] here\n')
+      ).not.toBeNull()
+    })
+
+    it('blocks a link reference definition nested three levels deep', () => {
+      expect(
+        getMarkdownRichModeUnsupportedMessage(
+          '> - > [id]: https://example.com\n>   > uses [id] here\n'
+        )
+      ).not.toBeNull()
+    })
+
     it('allows a bracketed label followed by prose, not a link destination', () => {
       expect(getMarkdownRichModeUnsupportedMessage('[Bug]: text with spaces\n')).toBeNull()
     })

--- a/src/renderer/src/components/editor/markdown-rich-mode.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.test.ts
@@ -221,5 +221,15 @@ describe('getMarkdownRichModeUnsupportedMessage', () => {
 
       expect(getMarkdownRichModeUnsupportedMessage(content)).toBeNull()
     })
+
+    it('scans a long non-matching indented line without catastrophic backtracking', () => {
+      const content = `${' '.repeat(200)}x\n`
+
+      const start = performance.now()
+      getMarkdownRichModeUnsupportedMessage(content)
+      const elapsed = performance.now() - start
+
+      expect(elapsed).toBeLessThan(50)
+    })
   })
 })

--- a/src/renderer/src/components/editor/markdown-rich-mode.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.test.ts
@@ -132,4 +132,62 @@ describe('getMarkdownRichModeUnsupportedMessage', () => {
       unsupportedMessage: expect.any(String)
     })
   })
+
+  describe('reference-style link definitions', () => {
+    it('blocks a real link reference definition', () => {
+      expect(getMarkdownRichModeUnsupportedMessage('[id]: https://example.com\n')).not.toBeNull()
+    })
+
+    it('blocks a link reference definition with an angle-bracket destination and title', () => {
+      expect(
+        getMarkdownRichModeUnsupportedMessage('[id]: <https://example.com> "Title"\n')
+      ).not.toBeNull()
+    })
+
+    it('blocks a link reference definition with a relative destination and single-quoted title', () => {
+      expect(
+        getMarkdownRichModeUnsupportedMessage("[id]: ./relative/path 'title'\n")
+      ).not.toBeNull()
+    })
+
+    it('blocks a link reference definition indented up to three spaces', () => {
+      expect(getMarkdownRichModeUnsupportedMessage('   [id]: https://example.com\n')).not.toBeNull()
+    })
+
+    it('blocks a link reference definition nested inside a blockquote', () => {
+      expect(
+        getMarkdownRichModeUnsupportedMessage('> [id]: https://example.com\n> uses [id] here\n')
+      ).not.toBeNull()
+    })
+
+    it('blocks a link reference definition nested inside a list item', () => {
+      expect(
+        getMarkdownRichModeUnsupportedMessage('- [id]: https://example.com\n  uses [id] here\n')
+      ).not.toBeNull()
+    })
+
+    it('allows a bracketed label followed by prose, not a link destination', () => {
+      expect(getMarkdownRichModeUnsupportedMessage('[Bug]: text with spaces\n')).toBeNull()
+    })
+
+    it('allows a real GFM task list item', () => {
+      // A task-list checkbox is `[ ]`/`[x]` followed directly by whitespace
+      // and text, with no colon — `- [x]: done` is CommonMark's link
+      // reference definition syntax (label `x`, destination `done`), not a
+      // task item.
+      expect(getMarkdownRichModeUnsupportedMessage('- [x] done\n')).toBeNull()
+    })
+
+    it('allows a bracketed label followed by prose starting with "this is"', () => {
+      expect(getMarkdownRichModeUnsupportedMessage('[note]: this is prose\n')).toBeNull()
+    })
+
+    it('allows the reported issue title line', () => {
+      expect(
+        getMarkdownRichModeUnsupportedMessage(
+          "[Bug]: Backspace at the start of the first line under a heading merges that line's text into the heading\n"
+        )
+      ).toBeNull()
+    })
+  })
 })

--- a/src/renderer/src/components/editor/markdown-rich-mode.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.test.ts
@@ -209,5 +209,17 @@ describe('getMarkdownRichModeUnsupportedMessage', () => {
         )
       ).toBeNull()
     })
+
+    it('conservatively blocks a pre-filter match in a document past the parse-size guard', () => {
+      const content = `${'a'.repeat(50_001)}\n[Bug]: text with spaces\n`
+
+      expect(getMarkdownRichModeUnsupportedMessage(content)).not.toBeNull()
+    })
+
+    it('still parses to confirm a pre-filter match at or under the parse-size guard', () => {
+      const content = `${'a'.repeat(49_970)}\n[Bug]: text with spaces\n`
+
+      expect(getMarkdownRichModeUnsupportedMessage(content)).toBeNull()
+    })
   })
 })

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -171,8 +171,13 @@ const linkReferenceDefinitionProcessor = unified().use(remarkParse).use(remarkGf
 
 // Why: only an mdast `definition` node proves a `[label]:` line is a link
 // reference definition and not prose. Definitions can sit inside blockquotes
-// and list items, so the whole tree is walked.
+// and list items, so the whole tree is walked. Above the same size cap as the
+// HTML round-trip check, parsing is skipped and the pre-filter match is
+// trusted as a definition, since blocking rich mode is the safe default.
 function hasLinkReferenceDefinition(content: string): boolean {
+  if (content.length > 50_000) {
+    return true
+  }
   const tree = linkReferenceDefinitionProcessor.parse(content)
   return containsDefinitionNode(tree)
 }

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -1,3 +1,6 @@
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
 import { defaultSchema } from 'rehype-sanitize'
 import { getRichMarkdownRoundTripOutput } from './markdown-round-trip'
 import { extractFrontMatter } from './markdown-frontmatter'
@@ -58,7 +61,14 @@ const UNSUPPORTED_PATTERNS: UnsupportedMatch[] = [
         'Editable only in code mode because this file contains reference-style links.'
       )
     },
-    pattern: /^\[[^\]]+\]:\s+\S+/m
+    // Why: this is a cheap pre-filter only, loose enough to admit definitions
+    // nested inside blockquotes or list items (`> [id]: url`, `- [id]: url`).
+    // `[label]: ` also opens an ordinary paragraph (e.g. `[Bug]: steps to
+    // reproduce…`). Confirming an actual reference-style link definition is
+    // delegated to `hasLinkReferenceDefinition`, which parses the CommonMark
+    // grammar via `remark-parse` instead of guessing the definition shape
+    // with regex.
+    pattern: /^[ >]*(?:[-*+]\s+|\d+[.)]\s+)?\[[^\]]+\]:/m
   },
   {
     reason: 'footnotes',
@@ -113,9 +123,13 @@ export function getMarkdownRichModeUnsupportedReason(
     if (matcher.reason === 'html-or-jsx') {
       continue
     }
-    if (matcher.pattern.test(contentWithoutCode)) {
-      return matcher.reason
+    if (!matcher.pattern.test(contentWithoutCode)) {
+      continue
     }
+    if (matcher.reason === 'reference-links' && !hasLinkReferenceDefinition(contentWithoutCode)) {
+      continue
+    }
+    return matcher.reason
   }
 
   if (hasHtml) {
@@ -154,6 +168,31 @@ export function getMarkdownRichModeEligibility(params: {
     exceedsSizeLimit: decision.exceedsSizeLimit,
     unsupportedMessage: resolveMarkdownRichModeUnsupportedMessage(decision.unsupportedReason)
   }
+}
+
+const linkReferenceDefinitionProcessor = unified().use(remarkParse).use(remarkGfm)
+
+// Why: `[label]: ` also opens an ordinary paragraph, so only an mdast
+// `definition` node — parsed per CommonMark's link reference definition
+// grammar — confirms the line is actually a reference-style link, not prose
+// that starts the same way. Definitions can nest inside container blocks
+// (blockquotes, list items), so the whole tree is walked rather than only
+// its top-level children.
+function hasLinkReferenceDefinition(content: string): boolean {
+  const tree = linkReferenceDefinitionProcessor.parse(content)
+  return containsDefinitionNode(tree)
+}
+
+function containsDefinitionNode(node: { type: string; children?: unknown[] }): boolean {
+  if (node.type === 'definition') {
+    return true
+  }
+  if (!Array.isArray(node.children)) {
+    return false
+  }
+  return node.children.some((child) =>
+    containsDefinitionNode(child as { type: string; children?: unknown[] })
+  )
 }
 
 function hasHtmlOrJsx(content: string, pattern: RegExp): boolean {

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -61,13 +61,9 @@ const UNSUPPORTED_PATTERNS: UnsupportedMatch[] = [
         'Editable only in code mode because this file contains reference-style links.'
       )
     },
-    // Why: this is a cheap pre-filter only, loose enough to admit definitions
-    // nested inside blockquotes or list items (`> [id]: url`, `- [id]: url`).
-    // `[label]: ` also opens an ordinary paragraph (e.g. `[Bug]: steps to
-    // reproduce…`). Confirming an actual reference-style link definition is
-    // delegated to `hasLinkReferenceDefinition`, which parses the CommonMark
-    // grammar via `remark-parse` instead of guessing the definition shape
-    // with regex.
+    // Why: a cheap pre-filter that admits definitions nested in blockquotes or
+    // list items; `[label]: ` also opens ordinary prose, so
+    // `hasLinkReferenceDefinition` confirms a real definition per CommonMark.
     pattern: /^[ >]*(?:[-*+]\s+|\d+[.)]\s+)?\[[^\]]+\]:/m
   },
   {
@@ -172,12 +168,9 @@ export function getMarkdownRichModeEligibility(params: {
 
 const linkReferenceDefinitionProcessor = unified().use(remarkParse).use(remarkGfm)
 
-// Why: `[label]: ` also opens an ordinary paragraph, so only an mdast
-// `definition` node — parsed per CommonMark's link reference definition
-// grammar — confirms the line is actually a reference-style link, not prose
-// that starts the same way. Definitions can nest inside container blocks
-// (blockquotes, list items), so the whole tree is walked rather than only
-// its top-level children.
+// Why: only an mdast `definition` node proves a `[label]:` line is a link
+// reference definition and not prose. Definitions can sit inside blockquotes
+// and list items, so the whole tree is walked.
 function hasLinkReferenceDefinition(content: string): boolean {
   const tree = linkReferenceDefinitionProcessor.parse(content)
   return containsDefinitionNode(tree)

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -61,10 +61,11 @@ const UNSUPPORTED_PATTERNS: UnsupportedMatch[] = [
         'Editable only in code mode because this file contains reference-style links.'
       )
     },
-    // Why: a cheap pre-filter that admits definitions nested in blockquotes or
-    // list items; `[label]: ` also opens ordinary prose, so
-    // `hasLinkReferenceDefinition` confirms a real definition per CommonMark.
-    pattern: /^[ >]*(?:[-*+]\s+|\d+[.)]\s+)?\[[^\]]+\]:/m
+    // Why: a cheap pre-filter that admits definitions nested under any depth
+    // of blockquote/list container markers in any order; `[label]: ` also
+    // opens ordinary prose, so `hasLinkReferenceDefinition` confirms a real
+    // definition per CommonMark.
+    pattern: /^(?:[ >]*(?:[-*+]\s+|\d+[.)]\s+)?)*\[[^\]]+\]:/m
   },
   {
     reason: 'footnotes',

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -61,11 +61,12 @@ const UNSUPPORTED_PATTERNS: UnsupportedMatch[] = [
         'Editable only in code mode because this file contains reference-style links.'
       )
     },
-    // Why: a cheap pre-filter that admits definitions nested under any depth
-    // of blockquote/list container markers in any order; `[label]: ` also
-    // opens ordinary prose, so `hasLinkReferenceDefinition` confirms a real
+    // Why: a cheap, linear-time pre-filter — a single non-nested character
+    // class, so it can't backtrack. It deliberately over-admits shapes no
+    // container nesting produces (e.g. `1) [x]:`); `[label]: ` also opens
+    // ordinary prose, so `hasLinkReferenceDefinition` confirms a real
     // definition per CommonMark.
-    pattern: /^(?:[ >]*(?:[-*+]\s+|\d+[.)]\s+)?)*\[[^\]]+\]:/m
+    pattern: /^[ \t>*+\-\d.)]*\[[^\]]+\]:/m
   },
   {
     reason: 'footnotes',


### PR DESCRIPTION
## ELI5

The rich editor used to think any line starting with `[something]:` was a link definition and would kick the whole file into read-only Source mode. Now it actually checks whether the rest of the line looks like a link before doing that, so a line like `[Bug]: steps to reproduce…` stays editable.

## What Changed

`getMarkdownRichModeUnsupportedReason` now confirms a real CommonMark link reference definition before reporting the `reference-links` unsupported reason, instead of matching any line that starts with `[label]:` followed by non-whitespace. The existing regex is kept as a cheap pre-filter (loosened to also admit definitions nested in blockquotes and list items), and a new `hasLinkReferenceDefinition` helper parses the content with `remark-parse` + `remark-gfm` — dependencies already used the same way in `markdown-table-of-contents.ts` — and walks the resulting mdast tree for an actual `definition` node.

## Why

A markdown line such as `[Bug]: Backspace at the start of the first line under a heading merges that line's text into the heading` was tripping the old regex (`/^\[[^\]]+\]:\s+\S+/m`), which only required one non-whitespace character after the colon and whitespace. Under CommonMark, `[label]:` only opens a link reference definition when the entire remainder of the line is a destination plus optional title — prose after the label makes it a paragraph. Reusing the CommonMark-compliant parser already in the dependency tree was more reliable than hand-rolling the full definition grammar (angle-bracket vs. bare destinations, three title-quote styles, balanced-parenthesis rules) a second time in regex.

## Linked Issue

Fixes #19795

## Visual Proof

**Before**: opening a markdown file containing `[Bug]: Backspace at the start of the first line under a heading merges that line's text into the heading` shows the Source-mode-only banner ("Editable only in code mode because this file contains reference-style links"), and the rich editor is unavailable.
<img width="569" height="260" alt="before" src="https://github.com/user-attachments/assets/f8fb1cda-c370-4bdc-a173-4ad282c196cc" />
[before.webm](https://github.com/user-attachments/assets/51bf2205-f56d-487c-bc3d-79717ab88bdb)

**After**: the same file opens normally in the rich editor, with no banner. A file containing an actual reference-style link definition (for example `[id]: https://example.com`) still falls back to Source mode as before.
<img width="569" height="283" alt="after" src="https://github.com/user-attachments/assets/328e7ff0-cc33-4324-ae81-7d6595de388d" />
[after.webm](https://github.com/user-attachments/assets/937ddfd9-a9ad-4229-baf7-36e7a3faeeea)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added 12 tests to `markdown-rich-mode.test.ts` covering: real link reference definitions (bare destination, angle-bracket destination with title, relative path with single-quoted title, 3-space indent, nested inside a blockquote, nested inside a list item) and non-definitions that share the `[label]:` prefix (prose after the label, prose starting "this is", a real GFM task-list item, and the exact reported line). Ran `pnpm test src/renderer/src/components/editor` (1420 passed, 2 skipped, no regressions), `pnpm tc`, and `oxlint` on the changed files — all clean.

## AI Disclosure

Authored with Claude Code (Claude Fable 5.1 and Sonnet teammates) under my review.

## Review

Fixed a false-positive in the rich-mode "reference-style links" detector: any line starting with `[label]:` was blocking rich mode even when it was ordinary prose, not a link definition. Replaced the plain-regex check with a CommonMark-grammar check via the already-present `remark-parse`/`remark-gfm` dependencies, keeping the regex only as a cheap pre-filter. Verified against CommonMark's actual link-reference-definition rules, including definitions nested inside blockquotes and list items, and against GFM's task-list-item syntax to make sure real task items and real definitions are still told apart correctly.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: [@fbartho](https://x.com/fbartho). I prefer Mastodon: [@fbartho@mastodon.social](https://mastodon.social/@fbartho).
```

## Follow-up commit

7111f2be63c3de2d7c636b0ea64dff0c3053b9ab
