### PR TITLE
feat(editor): offer the markdown preview when rich mode falls back

### DIFF
--- a/src/renderer/src/components/editor/EditorContent.markdown-classification.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.markdown-classification.test.tsx
@@ -98,12 +98,14 @@ function renderEditPath({
   language = 'markdown',
   viewMode = 'rich',
   mode = 'edit',
+  markdownRichModeFaultedContent = {},
   onOpenMarkdownPreview
 }: {
   content: string
   language?: 'markdown' | 'typescript'
   viewMode?: 'source' | 'rich' | 'preview'
   mode?: 'edit' | 'markdown-preview'
+  markdownRichModeFaultedContent?: Record<string, string>
   onOpenMarkdownPreview?: () => void
 }) {
   const activeFile = openFile(language, mode)
@@ -119,6 +121,7 @@ function renderEditPath({
     gitBranchEntries: undefined,
     markdownViewMode: { [activeFile.id]: viewMode },
     markdownRichModeSizeOverridden: false,
+    markdownRichModeFaultedContent,
     isChangesMode: false,
     canOpenWorkspaceFileBrowser: true
   })
@@ -174,6 +177,7 @@ function getGuardedRenderModel({
     gitBranchEntries: undefined,
     markdownViewMode: { [activeFile.id]: 'rich' },
     markdownRichModeSizeOverridden: false,
+    markdownRichModeFaultedContent: {},
     isChangesMode,
     canOpenWorkspaceFileBrowser: true
   })
@@ -225,6 +229,12 @@ describe('inline Markdown render classification', () => {
       args: { content: 'const value = 1', language: 'typescript' as const },
       expectedView: 'source',
       canExport: false
+    },
+    {
+      name: 'Source-view Markdown edit tabs',
+      args: { content: '# Source', viewMode: 'source' as const },
+      expectedView: 'source',
+      canExport: false
     }
   ])('skips rich eligibility scans for $name', ({ args, expectedView, canExport }) => {
     const result = renderEditPath(args)
@@ -233,15 +243,6 @@ describe('inline Markdown render classification', () => {
     expect(result.model.canExportMarkdownToPdf).toBe(canExport)
     expect(classifiers.getUnsupportedMessage).not.toHaveBeenCalled()
     expect(classifiers.exceedsSizeLimit).not.toHaveBeenCalled()
-  })
-
-  it('scans source Markdown edit tabs too, so the toggle knows whether rich mode would fall back', () => {
-    const result = renderEditPath({ content: '# Source', viewMode: 'source' as const })
-
-    expect(result.view.container.innerHTML).toContain('data-editor-view="source"')
-    expect(result.model.canExportMarkdownToPdf).toBe(false)
-    expect(classifiers.getUnsupportedMessage).toHaveBeenCalledTimes(1)
-    expect(classifiers.exceedsSizeLimit).toHaveBeenCalledTimes(1)
   })
 
   it.each([
@@ -319,6 +320,36 @@ describe('inline Markdown render classification', () => {
 
     const normal = renderEditPath({ content: '# Ordinary content' })
     expect(normal.model.availableEditorToggleModes).toEqual(['source', 'rich', 'changes'])
+  })
+
+  it('keeps the Preview toggle in Source view from a stored fault, without re-scanning', () => {
+    const content = '[reference]: https://example.com'
+    const result = renderEditPath({
+      content,
+      viewMode: 'source',
+      markdownRichModeFaultedContent: { [openFile().id]: content }
+    })
+
+    expect(result.model.availableEditorToggleModes).toEqual([
+      'source',
+      'rich',
+      'preview',
+      'changes'
+    ])
+    expect(classifiers.getUnsupportedMessage).not.toHaveBeenCalled()
+    expect(classifiers.exceedsSizeLimit).not.toHaveBeenCalled()
+  })
+
+  it('drops the Preview toggle once content no longer matches the stored fault', () => {
+    const result = renderEditPath({
+      content: '# Edited since the fault',
+      viewMode: 'source',
+      markdownRichModeFaultedContent: {
+        [openFile().id]: '[reference]: https://example.com'
+      }
+    })
+
+    expect(result.model.availableEditorToggleModes).toEqual(['source', 'rich', 'changes'])
   })
 
   it('opens the preview tab from the fallback banner action', () => {

--- a/src/renderer/src/components/editor/EditorContent.markdown-classification.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.markdown-classification.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { OpenFile } from '@/store/slices/editor'
 import type { FileContent } from './editor-panel-content-types'
@@ -97,12 +97,14 @@ function renderEditPath({
   content,
   language = 'markdown',
   viewMode = 'rich',
-  mode = 'edit'
+  mode = 'edit',
+  onOpenMarkdownPreview
 }: {
   content: string
   language?: 'markdown' | 'typescript'
   viewMode?: 'source' | 'rich' | 'preview'
   mode?: 'edit' | 'markdown-preview'
+  onOpenMarkdownPreview?: () => void
 }) {
   const activeFile = openFile(language, mode)
   const fileContents = {
@@ -145,6 +147,7 @@ function renderEditPath({
       handleSave={vi.fn()}
       handleSaveForFile={vi.fn()}
       reloadContent={vi.fn()}
+      onOpenMarkdownPreview={onOpenMarkdownPreview}
     />
   )
 
@@ -212,12 +215,6 @@ describe('inline Markdown render classification', () => {
 
   it.each([
     {
-      name: 'source Markdown',
-      args: { content: '# Source', viewMode: 'source' as const },
-      expectedView: 'source',
-      canExport: false
-    },
-    {
       name: 'Markdown preview',
       args: { content: '# Preview', mode: 'markdown-preview' as const },
       expectedView: 'preview',
@@ -236,6 +233,15 @@ describe('inline Markdown render classification', () => {
     expect(result.model.canExportMarkdownToPdf).toBe(canExport)
     expect(classifiers.getUnsupportedMessage).not.toHaveBeenCalled()
     expect(classifiers.exceedsSizeLimit).not.toHaveBeenCalled()
+  })
+
+  it('scans source Markdown edit tabs too, so the toggle knows whether rich mode would fall back', () => {
+    const result = renderEditPath({ content: '# Source', viewMode: 'source' as const })
+
+    expect(result.view.container.innerHTML).toContain('data-editor-view="source"')
+    expect(result.model.canExportMarkdownToPdf).toBe(false)
+    expect(classifiers.getUnsupportedMessage).toHaveBeenCalledTimes(1)
+    expect(classifiers.exceedsSizeLimit).toHaveBeenCalledTimes(1)
   })
 
   it.each([
@@ -300,5 +306,36 @@ describe('inline Markdown render classification', () => {
     expect(oversized.model.canExportMarkdownToPdf).toBe(false)
     expect(oversized.view.getByText(/File is larger than the .* rich editing limit/)).toBeTruthy()
     expect(oversized.view.getByText('Open anyway')).toBeTruthy()
+  })
+
+  it('offers the Preview toggle once rich mode falls back to source for this content', () => {
+    const fallback = renderEditPath({ content: '[reference]: https://example.com' })
+    expect(fallback.model.availableEditorToggleModes).toEqual([
+      'source',
+      'rich',
+      'preview',
+      'changes'
+    ])
+
+    const normal = renderEditPath({ content: '# Ordinary content' })
+    expect(normal.model.availableEditorToggleModes).toEqual(['source', 'rich', 'changes'])
+  })
+
+  it('opens the preview tab from the fallback banner action', () => {
+    const onOpenMarkdownPreview = vi.fn()
+    const { view } = renderEditPath({
+      content: '[reference]: https://example.com',
+      onOpenMarkdownPreview
+    })
+
+    fireEvent.click(view.getByText('Open preview'))
+
+    expect(onOpenMarkdownPreview).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the fallback banner preview action when no handler is provided', () => {
+    const { view } = renderEditPath({ content: '[reference]: https://example.com' })
+
+    expect(view.queryByText('Open preview')).toBeNull()
   })
 })

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -61,7 +61,8 @@ export function EditorContent({
   handleDirtyStateHint,
   handleSave,
   handleSaveForFile,
-  reloadContent
+  reloadContent,
+  onOpenMarkdownPreview
 }: {
   activeFile: OpenFile
   viewStateScopeId: string
@@ -90,6 +91,7 @@ export function EditorContent({
   handleSave: (content: string) => Promise<boolean>
   handleSaveForFile: (file: OpenFile, content: string) => Promise<boolean>
   reloadContent: (file: OpenFile) => void
+  onOpenMarkdownPreview?: () => void
 }): React.JSX.Element {
   const editorViewStateKey =
     viewStateScopeId === activeFile.id
@@ -252,6 +254,7 @@ export function EditorContent({
         markdownDocuments={markdownDocuments}
         getConflictNavigation={getConflictNavigation}
         getMarkdownSourceLineOffset={getMarkdownSourceLineOffset}
+        onOpenMarkdownPreview={onOpenMarkdownPreview}
         handleContentChange={handleContentChange}
         handleDirtyStateHint={handleDirtyStateHint}
         handleSave={handleSave}

--- a/src/renderer/src/components/editor/EditorEditFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorEditFileSurface.tsx
@@ -51,6 +51,7 @@ export function EditorEditFileSurface({
   markdownDocuments,
   getConflictNavigation,
   getMarkdownSourceLineOffset,
+  onOpenMarkdownPreview,
   handleContentChange,
   handleDirtyStateHint,
   handleSave,
@@ -82,6 +83,7 @@ export function EditorEditFileSurface({
   markdownDocuments: MarkdownDocumentsController
   getConflictNavigation: (file: OpenFile, content: string) => EditorConflictNavigation | undefined
   getMarkdownSourceLineOffset: (frontMatterRaw: string) => number
+  onOpenMarkdownPreview?: () => void
   handleContentChange: (content: string) => void
   handleDirtyStateHint: (dirty: boolean) => void
   handleSave: (content: string) => Promise<boolean>
@@ -220,6 +222,7 @@ export function EditorEditFileSurface({
       markdownAnnotationsEnabled={markdownAnnotationsEnabled}
       markdownDocuments={markdownDocuments}
       getMarkdownSourceLineOffset={getMarkdownSourceLineOffset}
+      onOpenMarkdownPreview={onOpenMarkdownPreview}
       handleContentChange={handleContentChange}
       handleDirtyStateHint={handleDirtyStateHint}
       monacoEditor={monacoEditor}

--- a/src/renderer/src/components/editor/EditorMarkdownFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorMarkdownFileSurface.tsx
@@ -25,6 +25,7 @@ export function EditorMarkdownFileSurface({
   markdownAnnotationsEnabled,
   markdownDocuments,
   getMarkdownSourceLineOffset,
+  onOpenMarkdownPreview,
   handleContentChange,
   handleDirtyStateHint,
   monacoEditor
@@ -41,6 +42,7 @@ export function EditorMarkdownFileSurface({
   markdownAnnotationsEnabled: boolean
   markdownDocuments: MarkdownDocumentsController
   getMarkdownSourceLineOffset: (frontMatterRaw: string) => number
+  onOpenMarkdownPreview?: () => void
   handleContentChange: (content: string) => void
   handleDirtyStateHint: (dirty: boolean) => void
   monacoEditor: React.JSX.Element
@@ -68,6 +70,17 @@ export function EditorMarkdownFileSurface({
       <div className="flex h-full min-h-0 flex-col">
         <div className="flex items-center gap-3 border-b border-border/60 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
           <span className="min-w-0 flex-1">{richFallbackMessage}</span>
+          {onOpenMarkdownPreview ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              className="shrink-0"
+              onClick={onOpenMarkdownPreview}
+            >
+              {translate('editor.richMarkdown.openPreview', 'Open preview')}
+            </Button>
+          ) : null}
           {isSizeFallback ? (
             <Button
               type="button"

--- a/src/renderer/src/components/editor/EditorPanel.markdown-classification-memoization.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.markdown-classification-memoization.test.tsx
@@ -278,6 +278,28 @@ describe('EditorPanel markdown classification memoization', () => {
     expect(probe.eligibility).toHaveBeenCalledTimes(1)
   })
 
+  it('records a rich-mode fault in the store once Rich view falls back, and clears it on recovery', async () => {
+    contentState.fileContents = {
+      [FILE_PATH]: { content: MARKDOWN_WITH_REFERENCE_LINKS, isBinary: false }
+    }
+    useAppStore.setState({
+      editorDrafts: { [FILE_PATH]: MARKDOWN_WITH_REFERENCE_LINKS }
+    })
+    await act(async () => root.render(<EditorPanel />))
+    await flushEffects()
+
+    expect(useAppStore.getState().markdownRichModeFaultedContent[FILE_PATH]).toBe(
+      MARKDOWN_WITH_REFERENCE_LINKS
+    )
+
+    await act(async () => {
+      useAppStore.getState().setEditorDraft(FILE_PATH, MARKDOWN_WITH_HTML)
+    })
+    await flushEffects()
+
+    expect(useAppStore.getState().markdownRichModeFaultedContent[FILE_PATH]).toBeUndefined()
+  })
+
   it('keeps the content-change callback identity stable across content loads', async () => {
     await act(async () => root.render(<EditorPanel />))
     await flushEffects()

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -251,21 +251,6 @@ function EditorPanelInner({
       setMarkdownViewMode(activeFile.filePath, preferredMarkdownViewMode)
     }
   }
-  const handleEditorToggleChange = (next: EditorToggleValue): void => {
-    const fileId = activeFile.id
-    if (activeFile.mode === 'diff' && model.isMarkdown && next === 'rich') {
-      handleOpenDiffTargetFile('rich')
-      return
-    }
-    if (next === 'changes') {
-      setEditorViewMode(fileId, 'changes')
-      return
-    }
-    setEditorViewMode(fileId, 'edit')
-    if (next !== 'edit') {
-      setMarkdownViewMode(fileId, next)
-    }
-  }
   const handleOpenMarkdownPreview = (): void => {
     openMarkdownPreview(
       {
@@ -277,6 +262,29 @@ function EditorPanelInner({
       },
       { sourceFileId: activeFile.id }
     )
+  }
+  const handleEditorToggleChange = (next: EditorToggleValue): void => {
+    const fileId = activeFile.id
+    if (activeFile.mode === 'diff' && model.isMarkdown && next === 'rich') {
+      handleOpenDiffTargetFile('rich')
+      return
+    }
+    if (next === 'changes') {
+      setEditorViewMode(fileId, 'changes')
+      return
+    }
+    // Why: the toggle only offers 'preview' as a fallback affordance (rich mode
+    // couldn't render this content); it opens the existing dedicated preview
+    // tab rather than a real edit-tab render mode, since 'edit' tabs never
+    // render read-only preview inline (see getMarkdownRenderMode).
+    if (next === 'preview') {
+      handleOpenMarkdownPreview()
+      return
+    }
+    setEditorViewMode(fileId, 'edit')
+    if (next !== 'edit') {
+      setMarkdownViewMode(fileId, next)
+    }
   }
   const handleOpenContainingFolder = (): void => {
     // Why: virtual editor tabs use synthetic ids instead of on-disk paths.

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -16,6 +16,7 @@ import { useClosedEditorTabCleanup } from './useClosedEditorTabCleanup'
 import { useEditorCmdSaveRequest } from './useEditorCmdSaveRequest'
 import { useEditorPanelContentState } from './useEditorPanelContentState'
 import { useMarkdownPreviewShortcut } from './useMarkdownPreviewShortcut'
+import { useMarkdownRichModeFaultTracking } from './useMarkdownRichModeFaultTracking'
 import { useUntitledFileRename } from './useUntitledFileRename'
 import { extractFrontMatter } from './markdown-frontmatter'
 import { useEditorContentChangeHandler } from './use-editor-content-change-handler'
@@ -66,6 +67,8 @@ function EditorPanelInner({
   const markdownRichModeSizeOverridden = useAppStore(
     (s) => activeFileId !== null && s.markdownRichModeSizeOverride[activeFileId] === true
   )
+  const markdownRichModeFaultedContent = useAppStore((s) => s.markdownRichModeFaultedContent)
+  const setMarkdownRichModeFaultedContent = useAppStore((s) => s.setMarkdownRichModeFaultedContent)
   const editorViewMode = useAppStore((s) => s.editorViewMode)
   const setEditorViewMode = useAppStore((s) => s.setEditorViewMode)
   const openFile = useAppStore((s) => s.openFile)
@@ -205,20 +208,31 @@ function EditorPanelInner({
     }
   }, [activeFile, clearCopiedPathToastResetTimer])
 
-  if (!activeFile) {
+  const model = activeFile
+    ? getEditorPanelRenderModel({
+        activeFile,
+        fileContents,
+        editorDrafts,
+        gitStatusEntries,
+        gitBranchEntries,
+        markdownViewMode,
+        markdownRichModeSizeOverridden,
+        markdownRichModeFaultedContent,
+        isChangesMode,
+        canOpenWorkspaceFileBrowser
+      })
+    : null
+  useMarkdownRichModeFaultTracking({
+    fileId: activeFile?.id ?? null,
+    mdViewMode: model?.mdViewMode ?? 'source',
+    inlineMarkdownRenderState: model?.inlineMarkdownRenderState ?? null,
+    inlineMarkdownContent: model?.inlineMarkdownContent ?? null,
+    setMarkdownRichModeFaultedContent
+  })
+
+  if (!activeFile || !model) {
     return null
   }
-  const model = getEditorPanelRenderModel({
-    activeFile,
-    fileContents,
-    editorDrafts,
-    gitStatusEntries,
-    gitBranchEntries,
-    markdownViewMode,
-    markdownRichModeSizeOverridden,
-    isChangesMode,
-    canOpenWorkspaceFileBrowser
-  })
 
   const handleOpenPreviewToSide = (): void => {
     const state = useAppStore.getState()

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -163,6 +163,7 @@ export function EditorPanelShell({
           showMarkdownFrontmatter={markdownFrontmatterVisible}
           onCloseMarkdownTableOfContents={onCloseMarkdownTableOfContents}
           markdownAnnotationsEnabled={markdownAnnotationsEnabled}
+          onOpenMarkdownPreview={onOpenMarkdownPreview}
         />
       </Suspense>
       <UntitledFileRenameDialog

--- a/src/renderer/src/components/editor/editor-panel-render-model.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.test.ts
@@ -62,6 +62,22 @@ function htmlFile(overrides: Partial<OpenFile> = {}): OpenFile {
   }
 }
 
+describe('getEditorPanelRenderModel rich-mode fallback toggle', () => {
+  it('offers Preview once rich mode falls back for this content', () => {
+    const model = renderModel({
+      editorDrafts: { '/repo/README.md': '[reference]: https://example.com' }
+    })
+
+    expect(model.availableEditorToggleModes).toEqual(['source', 'rich', 'preview', 'changes'])
+  })
+
+  it('omits Preview for ordinary markdown content', () => {
+    const model = renderModel({})
+
+    expect(model.availableEditorToggleModes).toEqual(['source', 'rich', 'changes'])
+  })
+})
+
 describe('getEditorPanelRenderModel HTML preview affordance', () => {
   it('enables preview for HTML edit tabs', () => {
     expect(renderModel({ activeFile: htmlFile(), fileContents: {} }).canOpenPreviewToSide).toBe(

--- a/src/renderer/src/components/editor/editor-panel-render-model.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.test.ts
@@ -32,6 +32,7 @@ function renderModel(args: {
   editorDrafts?: Record<string, string>
   markdownViewMode?: Record<string, 'source' | 'rich' | 'preview'>
   markdownRichModeSizeOverridden?: boolean
+  markdownRichModeFaultedContent?: Record<string, string>
   isChangesMode?: boolean
   gitStatusByWorktree?: Record<string, GitStatusEntry[]>
 }) {
@@ -44,6 +45,7 @@ function renderModel(args: {
     gitBranchEntries: undefined,
     markdownViewMode: args.markdownViewMode ?? {},
     markdownRichModeSizeOverridden: args.markdownRichModeSizeOverridden ?? false,
+    markdownRichModeFaultedContent: args.markdownRichModeFaultedContent ?? {},
     isChangesMode: args.isChangesMode ?? false,
     canOpenWorkspaceFileBrowser: true
   })
@@ -63,7 +65,40 @@ function htmlFile(overrides: Partial<OpenFile> = {}): OpenFile {
 }
 
 describe('getEditorPanelRenderModel rich-mode fallback toggle', () => {
-  it('offers Preview once rich mode falls back for this content', () => {
+  it('omits Preview in Source view until a fault is recorded for this content, even though it would fault', () => {
+    const model = renderModel({
+      markdownViewMode: { '/repo/README.md': 'source' },
+      editorDrafts: { '/repo/README.md': '[reference]: https://example.com' }
+    })
+
+    expect(model.availableEditorToggleModes).toEqual(['source', 'rich', 'changes'])
+  })
+
+  it('offers Preview in Source view once a stored fault matches the current content', () => {
+    const model = renderModel({
+      markdownViewMode: { '/repo/README.md': 'source' },
+      editorDrafts: { '/repo/README.md': '[reference]: https://example.com' },
+      markdownRichModeFaultedContent: {
+        '/repo/README.md': '[reference]: https://example.com'
+      }
+    })
+
+    expect(model.availableEditorToggleModes).toEqual(['source', 'rich', 'preview', 'changes'])
+  })
+
+  it('omits Preview when the stored fault is for different, stale content', () => {
+    const model = renderModel({
+      markdownViewMode: { '/repo/README.md': 'source' },
+      editorDrafts: { '/repo/README.md': '# Edited since the fault' },
+      markdownRichModeFaultedContent: {
+        '/repo/README.md': '[reference]: https://example.com'
+      }
+    })
+
+    expect(model.availableEditorToggleModes).toEqual(['source', 'rich', 'changes'])
+  })
+
+  it('offers Preview when Rich view classifies live and this content falls back', () => {
     const model = renderModel({
       editorDrafts: { '/repo/README.md': '[reference]: https://example.com' }
     })
@@ -95,6 +130,7 @@ describe('getEditorPanelRenderModel HTML preview affordance', () => {
       gitBranchEntries: undefined,
       markdownViewMode: {},
       markdownRichModeSizeOverridden: false,
+      markdownRichModeFaultedContent: {},
       isChangesMode: false,
       canOpenWorkspaceFileBrowser: false
     })

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -25,6 +25,7 @@ type EditorPanelRenderModelParams = {
   gitBranchEntries: StoreState['gitBranchChangesByWorktree'][string] | undefined
   markdownViewMode: StoreState['markdownViewMode']
   markdownRichModeSizeOverridden: boolean
+  markdownRichModeFaultedContent: StoreState['markdownRichModeFaultedContent']
   isChangesMode: boolean
   canOpenWorkspaceFileBrowser: boolean
 }
@@ -37,6 +38,7 @@ export function getEditorPanelRenderModel({
   gitBranchEntries,
   markdownViewMode,
   markdownRichModeSizeOverridden,
+  markdownRichModeFaultedContent,
   isChangesMode,
   canOpenWorkspaceFileBrowser
 }: EditorPanelRenderModelParams) {
@@ -125,21 +127,24 @@ export function getEditorPanelRenderModel({
     !inlineFileContent.loadError &&
     activeFile.conflict?.kind !== 'conflict-placeholder' &&
     activeFile.conflict?.conflictStatus !== 'unresolved'
-  // Why: classified once per content change (cached) so both the toggle's
-  // fallback-preview affordance and the inline banner below agree on whether
-  // rich mode would fall back, without duplicating the eligibility scan. Gated
-  // on the same guards as the inline renderer so unrenderable content (binary,
-  // load error, unresolved conflict, Changes mode) is never scanned.
-  const richModeEligibility = canRenderInlineMarkdown
-    ? getCachedMarkdownRichModeEligibility({
-        content: inlineMarkdownContent,
-        sizeOverridden: markdownRichModeSizeOverridden
-      })
-    : null
+  // Why: classifying scans the whole document, so it only runs while the user
+  // is looking at Rich mode. Source-view tabs read the stored fault instead
+  // (see useMarkdownRichModeFaultTracking) rather than re-scanning.
+  const richModeEligibility =
+    canRenderInlineMarkdown && mdViewMode === 'rich'
+      ? getCachedMarkdownRichModeEligibility({
+          content: inlineMarkdownContent,
+          sizeOverridden: markdownRichModeSizeOverridden
+        })
+      : null
   const richModeUnsupportedMessage = richModeEligibility?.unsupportedMessage ?? null
+  const richModeFaultedForCurrentContent =
+    canRenderInlineMarkdown &&
+    markdownRichModeFaultedContent[activeFile.id] === inlineMarkdownContent
   const richModeFallsBackToSource =
-    richModeEligibility !== null &&
-    (richModeEligibility.exceedsSizeLimit || richModeUnsupportedMessage !== null)
+    richModeEligibility !== null
+      ? richModeEligibility.exceedsSizeLimit || richModeUnsupportedMessage !== null
+      : richModeFaultedForCurrentContent
   const editorToggleModes = getEditorToggleModes({
     language: viewerLanguage,
     mode: activeFile.mode,
@@ -207,6 +212,7 @@ export function getEditorPanelRenderModel({
     shouldShowMarkdownExportAction,
     canExportMarkdownToPdf,
     inlineMarkdownRenderState,
+    inlineMarkdownContent,
     canShowMarkdownTableOfContents:
       viewerLanguage === 'markdown' &&
       (hasViewModeToggle || activeFile.mode === 'markdown-preview'),

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -127,9 +127,8 @@ export function getEditorPanelRenderModel({
     !inlineFileContent.loadError &&
     activeFile.conflict?.kind !== 'conflict-placeholder' &&
     activeFile.conflict?.conflictStatus !== 'unresolved'
-  // Why: classifying scans the whole document, so it only runs while the user
-  // is looking at Rich mode. Source-view tabs read the stored fault instead
-  // (see useMarkdownRichModeFaultTracking) rather than re-scanning.
+  // Why: classification scans the whole document, so it runs only in Rich
+  // mode; Source-view tabs read the stored fault (useMarkdownRichModeFaultTracking).
   const richModeEligibility =
     canRenderInlineMarkdown && mdViewMode === 'rich'
       ? getCachedMarkdownRichModeEligibility({

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -105,26 +105,12 @@ export function getEditorPanelRenderModel({
     markdownViewModes.includes(storedMarkdownViewMode)
       ? storedMarkdownViewMode
       : defaultMarkdownViewMode
-  const editorToggleModes = getEditorToggleModes({
-    language: viewerLanguage,
-    mode: activeFile.mode,
-    diffSource: activeFile.diffSource
-  })
-  const isBinaryEditSurface =
-    activeFile.mode === 'edit' && fileContents[activeFile.id]?.isBinary === true
-  const availableEditorToggleModes =
-    isBinaryEditSurface || !canUseChangesModeForFile(activeFile)
-      ? editorToggleModes.filter((mode) => mode !== 'changes')
-      : editorToggleModes
-  const effectiveToggleValue: EditorToggleValue = isChangesMode
-    ? 'changes'
-    : hasViewModeToggle
-      ? mdViewMode
-      : 'edit'
   const inlineMarkdownContent =
     activeFile.mode === 'edit'
       ? (editorDrafts[activeFile.id] ?? fileContents[activeFile.id]?.content ?? null)
       : null
+  const isBinaryEditSurface =
+    activeFile.mode === 'edit' && fileContents[activeFile.id]?.isBinary === true
   const shouldShowMarkdownExportAction =
     viewerLanguage === 'markdown' &&
     (activeFile.mode === 'edit' || activeFile.mode === 'markdown-preview')
@@ -139,16 +125,38 @@ export function getEditorPanelRenderModel({
     !inlineFileContent.loadError &&
     activeFile.conflict?.kind !== 'conflict-placeholder' &&
     activeFile.conflict?.conflictStatus !== 'unresolved'
+  // Why: classified once per content change (cached) so both the toggle's
+  // fallback-preview affordance and the inline banner below agree on whether
+  // rich mode would fall back, without duplicating the eligibility scan. Gated
+  // on the same guards as the inline renderer so unrenderable content (binary,
+  // load error, unresolved conflict, Changes mode) is never scanned.
+  const richModeEligibility = canRenderInlineMarkdown
+    ? getCachedMarkdownRichModeEligibility({
+        content: inlineMarkdownContent,
+        sizeOverridden: markdownRichModeSizeOverridden
+      })
+    : null
+  const richModeUnsupportedMessage = richModeEligibility?.unsupportedMessage ?? null
+  const richModeFallsBackToSource =
+    richModeEligibility !== null &&
+    (richModeEligibility.exceedsSizeLimit || richModeUnsupportedMessage !== null)
+  const editorToggleModes = getEditorToggleModes({
+    language: viewerLanguage,
+    mode: activeFile.mode,
+    diffSource: activeFile.diffSource,
+    richModeFallsBackToSource
+  })
+  const availableEditorToggleModes =
+    isBinaryEditSurface || !canUseChangesModeForFile(activeFile)
+      ? editorToggleModes.filter((mode) => mode !== 'changes')
+      : editorToggleModes
+  const effectiveToggleValue: EditorToggleValue = isChangesMode
+    ? 'changes'
+    : hasViewModeToggle
+      ? mdViewMode
+      : 'edit'
   let inlineMarkdownRenderState: MarkdownRenderState | null = null
   if (canRenderInlineMarkdown) {
-    const shouldClassifyRichMode = mdViewMode === 'rich'
-    const richModeEligibility = shouldClassifyRichMode
-      ? getCachedMarkdownRichModeEligibility({
-          content: inlineMarkdownContent,
-          sizeOverridden: markdownRichModeSizeOverridden
-        })
-      : null
-    const richModeUnsupportedMessage = richModeEligibility?.unsupportedMessage ?? null
     inlineMarkdownRenderState = {
       renderMode: getMarkdownRenderMode({
         exceedsRichModeSizeLimit: richModeEligibility?.exceedsSizeLimit ?? false,

--- a/src/renderer/src/components/editor/markdown-preview-controls.test.ts
+++ b/src/renderer/src/components/editor/markdown-preview-controls.test.ts
@@ -46,6 +46,38 @@ describe('getMarkdownViewModes', () => {
   })
 })
 
+describe('getEditorToggleModes rich-mode fallback', () => {
+  it('offers Preview alongside Source and Rich when rich mode falls back for this content', () => {
+    expect(
+      getEditorToggleModes({
+        language: 'markdown',
+        mode: 'edit',
+        richModeFallsBackToSource: true
+      })
+    ).toEqual(['source', 'rich', 'preview', 'changes'])
+  })
+
+  it('omits Preview when rich mode renders normally', () => {
+    expect(
+      getEditorToggleModes({
+        language: 'markdown',
+        mode: 'edit',
+        richModeFallsBackToSource: false
+      })
+    ).toEqual(['source', 'rich', 'changes'])
+  })
+
+  it('does not add Preview for non-markdown languages even when the flag is set', () => {
+    expect(
+      getEditorToggleModes({
+        language: 'mermaid',
+        mode: 'edit',
+        richModeFallsBackToSource: true
+      })
+    ).toEqual(['source', 'rich', 'changes'])
+  })
+})
+
 describe('markdown preview helpers', () => {
   it('defaults markdown edit tabs to rich mode', () => {
     expect(

--- a/src/renderer/src/components/editor/markdown-preview-controls.ts
+++ b/src/renderer/src/components/editor/markdown-preview-controls.ts
@@ -6,7 +6,18 @@ type MarkdownPreviewTarget = Pick<OpenFile, 'mode' | 'diffSource'> & {
   language: string
 }
 
+type EditorToggleTarget = MarkdownPreviewTarget & {
+  // Why: only markdown edit tabs have a dedicated read-only preview tab to
+  // route to, so this only affects the markdown edit toggle set.
+  richModeFallsBackToSource?: boolean
+}
+
 const MARKDOWN_EDIT_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
+const MARKDOWN_EDIT_TOGGLE_MODES_WITH_PREVIEW_FALLBACK = [
+  'source',
+  'rich',
+  'preview'
+] as const satisfies readonly EditorToggleValue[]
 const MARKDOWN_DIFF_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
 const MERMAID_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
 const CSV_VIEW_MODES = ['source', 'rich'] as const satisfies readonly MarkdownViewMode[]
@@ -21,7 +32,7 @@ const NO_VIEW_MODES = [] as const satisfies readonly MarkdownViewMode[]
 // Edit | Changes.
 const CODE_EDIT_TOGGLE_MODES = ['edit', 'changes'] as const satisfies readonly EditorToggleValue[]
 
-export function getEditorToggleModes(target: MarkdownPreviewTarget): readonly EditorToggleValue[] {
+export function getEditorToggleModes(target: EditorToggleTarget): readonly EditorToggleValue[] {
   if (target.mode !== 'edit') {
     return getMarkdownViewModes(target)
   }
@@ -29,6 +40,12 @@ export function getEditorToggleModes(target: MarkdownPreviewTarget): readonly Ed
     // Why: notebook source mode is raw JSON and Changes would diff that JSON,
     // which is noisy and currently invalid for restored external notebooks.
     return NOTEBOOK_VIEW_MODES
+  }
+  // Why: when rich mode would fall back to Source for this content, the
+  // toggle offers the dedicated read-only preview tab instead of leaving
+  // Preview undiscoverable behind a menu item and a shortcut.
+  if (target.language === 'markdown' && target.richModeFallsBackToSource) {
+    return [...MARKDOWN_EDIT_TOGGLE_MODES_WITH_PREVIEW_FALLBACK, 'changes']
   }
   const languageModes = getMarkdownViewModes(target)
   if (languageModes.length > 0) {

--- a/src/renderer/src/components/editor/useMarkdownRichModeFaultTracking.ts
+++ b/src/renderer/src/components/editor/useMarkdownRichModeFaultTracking.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+import type { MarkdownViewMode } from '@/store/slices/editor'
+import type { MarkdownRenderState } from './markdown-render-mode'
+
+type UseMarkdownRichModeFaultTrackingParams = {
+  fileId: string | null
+  mdViewMode: MarkdownViewMode
+  inlineMarkdownRenderState: MarkdownRenderState | null
+  inlineMarkdownContent: string | null
+  setMarkdownRichModeFaultedContent: (fileId: string, content: string | null) => void
+}
+
+// Why: getMarkdownRenderMode only decides source-vs-rich-vs-preview for the
+// content it's given; recording that a Rich attempt fell back (or recovered)
+// as durable per-tab state is a side effect, so it belongs in an effect keyed
+// off the render model's output rather than during render itself.
+export function useMarkdownRichModeFaultTracking({
+  fileId,
+  mdViewMode,
+  inlineMarkdownRenderState,
+  inlineMarkdownContent,
+  setMarkdownRichModeFaultedContent
+}: UseMarkdownRichModeFaultTrackingParams): void {
+  useEffect(() => {
+    if (!fileId || mdViewMode !== 'rich' || inlineMarkdownRenderState === null) {
+      return
+    }
+    if (inlineMarkdownRenderState.renderMode === 'source') {
+      setMarkdownRichModeFaultedContent(fileId, inlineMarkdownContent)
+      return
+    }
+    // Why: a successful Rich attempt for this content means it's no longer a
+    // fault, whatever content is currently stored for this tab.
+    setMarkdownRichModeFaultedContent(fileId, null)
+  }, [
+    fileId,
+    mdViewMode,
+    inlineMarkdownRenderState,
+    inlineMarkdownContent,
+    setMarkdownRichModeFaultedContent
+  ])
+}

--- a/src/renderer/src/components/editor/useMarkdownRichModeFaultTracking.ts
+++ b/src/renderer/src/components/editor/useMarkdownRichModeFaultTracking.ts
@@ -10,10 +10,9 @@ type UseMarkdownRichModeFaultTrackingParams = {
   setMarkdownRichModeFaultedContent: (fileId: string, content: string | null) => void
 }
 
-// Why: getMarkdownRenderMode only decides source-vs-rich-vs-preview for the
-// content it's given; recording that a Rich attempt fell back (or recovered)
-// as durable per-tab state is a side effect, so it belongs in an effect keyed
-// off the render model's output rather than during render itself.
+// Why: recording that a Rich attempt fell back or recovered is durable per-tab
+// state, a side effect, so it lives in an effect keyed off the render model's
+// output, never inside render.
 export function useMarkdownRichModeFaultTracking({
   fileId,
   mdViewMode,
@@ -29,8 +28,8 @@ export function useMarkdownRichModeFaultTracking({
       setMarkdownRichModeFaultedContent(fileId, inlineMarkdownContent)
       return
     }
-    // Why: a successful Rich attempt for this content means it's no longer a
-    // fault, whatever content is currently stored for this tab.
+    // Why: a successful Rich attempt for this content clears the fault,
+    // whatever content is currently stored for this tab.
     setMarkdownRichModeFaultedContent(fileId, null)
   }, [
     fileId,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -111,7 +111,8 @@
   "editor": {
     "richMarkdown": {
       "tooLarge": "File is larger than the {{limit}} rich editing limit. Showing source mode instead.",
-      "openAnyway": "Open anyway"
+      "openAnyway": "Open anyway",
+      "openPreview": "Open preview"
     }
   },
   "githubChecks": {

--- a/src/renderer/src/store/slices/editor/actions/close-file-action.ts
+++ b/src/renderer/src/store/slices/editor/actions/close-file-action.ts
@@ -34,6 +34,8 @@ export function createCloseFileAction(
         delete newMarkdownViewMode[fileId]
         const newMarkdownRichModeSizeOverride = { ...s.markdownRichModeSizeOverride }
         delete newMarkdownRichModeSizeOverride[fileId]
+        const newMarkdownRichModeFaultedContent = { ...s.markdownRichModeFaultedContent }
+        delete newMarkdownRichModeFaultedContent[fileId]
         const newEditorViewMode = { ...s.editorViewMode }
         delete newEditorViewMode[fileId]
         const markdownVisibilityKeys = new Set([fileId])
@@ -182,6 +184,7 @@ export function createCloseFileAction(
           activeTabTypeByWorktree: newActiveTabTypeByWorktree,
           markdownViewMode: newMarkdownViewMode,
           markdownRichModeSizeOverride: newMarkdownRichModeSizeOverride,
+          markdownRichModeFaultedContent: newMarkdownRichModeFaultedContent,
           editorViewMode: newEditorViewMode,
           markdownFrontmatterVisible: newMarkdownFrontmatterVisible,
           markdownTableOfContentsVisible: newMarkdownTableOfContentsVisible,

--- a/src/renderer/src/store/slices/editor/actions/editor-draft-state.ts
+++ b/src/renderer/src/store/slices/editor/actions/editor-draft-state.ts
@@ -17,9 +17,9 @@ export type EditorDraftState = {
   // Why: per-file opt-in to open an oversized markdown file in the rich editor despite the size limit.
   markdownRichModeSizeOverride: Record<string, boolean>
   setMarkdownRichModeSizeOverride: (fileId: string, enabled: boolean) => void
-  // Why: the content string that made rich mode fall back to Source for this
-  // tab, so the toggle can offer Preview without re-scanning. A stale entry
-  // (content no longer matches) reads as "not faulted for this content".
+  // Why: the content that made rich mode fall back to Source for this tab, so
+  // the toggle can offer Preview without re-scanning; a stale entry (content
+  // differs) reads as not faulted.
   markdownRichModeFaultedContent: Record<string, string>
   setMarkdownRichModeFaultedContent: (fileId: string, content: string | null) => void
   editorViewMode: Record<string, EditorViewMode>

--- a/src/renderer/src/store/slices/editor/actions/editor-draft-state.ts
+++ b/src/renderer/src/store/slices/editor/actions/editor-draft-state.ts
@@ -17,6 +17,11 @@ export type EditorDraftState = {
   // Why: per-file opt-in to open an oversized markdown file in the rich editor despite the size limit.
   markdownRichModeSizeOverride: Record<string, boolean>
   setMarkdownRichModeSizeOverride: (fileId: string, enabled: boolean) => void
+  // Why: the content string that made rich mode fall back to Source for this
+  // tab, so the toggle can offer Preview without re-scanning. A stale entry
+  // (content no longer matches) reads as "not faulted for this content".
+  markdownRichModeFaultedContent: Record<string, string>
+  setMarkdownRichModeFaultedContent: (fileId: string, content: string | null) => void
   editorViewMode: Record<string, EditorViewMode>
   setEditorViewMode: (fileId: string, mode: EditorViewMode) => void
   markdownFrontmatterVisible: Record<string, boolean>
@@ -88,6 +93,26 @@ export function createEditorDraftState(set: EditorSet, _get: EditorGet): EditorD
         }
         return {
           markdownRichModeSizeOverride: { ...s.markdownRichModeSizeOverride, [fileId]: true }
+        }
+      }),
+
+    // Rich-mode fallback fault, per tab
+    markdownRichModeFaultedContent: {},
+    setMarkdownRichModeFaultedContent: (fileId, content) =>
+      set((s) => {
+        if (content === null) {
+          if (!(fileId in s.markdownRichModeFaultedContent)) {
+            return s
+          }
+          const next = { ...s.markdownRichModeFaultedContent }
+          delete next[fileId]
+          return { markdownRichModeFaultedContent: next }
+        }
+        if (s.markdownRichModeFaultedContent[fileId] === content) {
+          return s
+        }
+        return {
+          markdownRichModeFaultedContent: { ...s.markdownRichModeFaultedContent, [fileId]: content }
         }
       }),
 

--- a/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
@@ -175,6 +175,7 @@ export function applyOpenFileToState(
         editorCursorLine: nextEditorCursorLine,
         markdownViewMode: nextMarkdownViewMode,
         markdownRichModeSizeOverride: nextMarkdownRichModeSizeOverride,
+        markdownRichModeFaultedContent: nextMarkdownRichModeFaultedContent,
         editorViewMode: nextEditorViewMode,
         markdownFrontmatterVisible: nextMarkdownFrontmatterVisible,
         markdownTableOfContentsVisible: nextMarkdownTableOfContentsVisible
@@ -237,6 +238,7 @@ export function applyOpenFileToState(
         editorCursorLine: nextEditorCursorLine,
         markdownViewMode: nextMarkdownViewMode,
         markdownRichModeSizeOverride: nextMarkdownRichModeSizeOverride,
+        markdownRichModeFaultedContent: nextMarkdownRichModeFaultedContent,
         editorViewMode: nextEditorViewMode,
         markdownFrontmatterVisible: nextMarkdownFrontmatterVisible,
         markdownTableOfContentsVisible: nextMarkdownTableOfContentsVisible,

--- a/src/renderer/src/store/slices/editor/actions/recently-closed-editor-tabs.ts
+++ b/src/renderer/src/store/slices/editor/actions/recently-closed-editor-tabs.ts
@@ -78,6 +78,7 @@ export function createRecentlyClosedEditorTabs(
             activeTabType: 'terminal',
             markdownViewMode: {},
             markdownRichModeSizeOverride: {},
+            markdownRichModeFaultedContent: {},
             editorViewMode: {},
             markdownFrontmatterVisible: {},
             markdownTableOfContentsVisible: {},
@@ -96,6 +97,11 @@ export function createRecentlyClosedEditorTabs(
         )
         const newMarkdownRichModeSizeOverride = Object.fromEntries(
           Object.entries(s.markdownRichModeSizeOverride).filter(([fileId]) =>
+            remainingFileIds.has(fileId)
+          )
+        )
+        const newMarkdownRichModeFaultedContent = Object.fromEntries(
+          Object.entries(s.markdownRichModeFaultedContent).filter(([fileId]) =>
             remainingFileIds.has(fileId)
           )
         )
@@ -182,6 +188,7 @@ export function createRecentlyClosedEditorTabs(
           activeTabType: browserTabsForWorktree.length > 0 ? 'browser' : 'terminal',
           markdownViewMode: newMarkdownViewMode,
           markdownRichModeSizeOverride: newMarkdownRichModeSizeOverride,
+          markdownRichModeFaultedContent: newMarkdownRichModeFaultedContent,
           editorViewMode: newEditorViewMode,
           markdownFrontmatterVisible: newMarkdownFrontmatterVisible,
           markdownTableOfContentsVisible: newMarkdownTableOfContentsVisible,

--- a/src/renderer/src/store/slices/editor/actions/rekey-open-files-action.ts
+++ b/src/renderer/src/store/slices/editor/actions/rekey-open-files-action.ts
@@ -121,6 +121,10 @@ export function createRekeyOpenFilesAction(
             s.markdownRichModeSizeOverride,
             migrations
           ),
+          markdownRichModeFaultedContent: rekeyFileIdRecord(
+            s.markdownRichModeFaultedContent,
+            migrations
+          ),
           editorViewMode: rekeyFileIdRecord(s.editorViewMode, migrations),
           markdownFrontmatterVisible: rekeyFileIdRecord(s.markdownFrontmatterVisible, migrations),
           markdownTableOfContentsVisible: rekeyFileIdRecord(

--- a/src/renderer/src/store/slices/editor/actions/restored-editor-owner-transition.ts
+++ b/src/renderer/src/store/slices/editor/actions/restored-editor-owner-transition.ts
@@ -206,6 +206,10 @@ export function buildRestoredEditorOwnerTransition(
         editorCursorLine: rekeyFileIdRecord(s.editorCursorLine, migrations),
         markdownViewMode: rekeyFileIdRecord(s.markdownViewMode, migrations),
         markdownRichModeSizeOverride: rekeyFileIdRecord(s.markdownRichModeSizeOverride, migrations),
+        markdownRichModeFaultedContent: rekeyFileIdRecord(
+          s.markdownRichModeFaultedContent,
+          migrations
+        ),
         editorViewMode: rekeyFileIdRecord(s.editorViewMode, migrations),
         markdownFrontmatterVisible: rekeyFileIdRecord(s.markdownFrontmatterVisible, migrations),
         markdownTableOfContentsVisible: rekeyFileIdRecord(

--- a/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
+++ b/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
@@ -78,6 +78,7 @@ export function removeEditorStateForReplacedPreview(
     | 'editorCursorLine'
     | 'markdownViewMode'
     | 'markdownRichModeSizeOverride'
+    | 'markdownRichModeFaultedContent'
     | 'editorViewMode'
     | 'markdownFrontmatterVisible'
     | 'markdownTableOfContentsVisible'
@@ -91,6 +92,7 @@ export function removeEditorStateForReplacedPreview(
   | 'editorCursorLine'
   | 'markdownViewMode'
   | 'markdownRichModeSizeOverride'
+  | 'markdownRichModeFaultedContent'
   | 'editorViewMode'
   | 'markdownFrontmatterVisible'
   | 'markdownTableOfContentsVisible'
@@ -113,6 +115,7 @@ export function removeEditorStateForReplacedPreview(
       editorCursorLine: state.editorCursorLine,
       markdownViewMode: state.markdownViewMode,
       markdownRichModeSizeOverride: state.markdownRichModeSizeOverride,
+      markdownRichModeFaultedContent: state.markdownRichModeFaultedContent,
       editorViewMode: state.editorViewMode,
       markdownFrontmatterVisible: state.markdownFrontmatterVisible,
       markdownTableOfContentsVisible: state.markdownTableOfContentsVisible
@@ -130,6 +133,11 @@ export function removeEditorStateForReplacedPreview(
     ),
     markdownRichModeSizeOverride: Object.fromEntries(
       Object.entries(state.markdownRichModeSizeOverride).filter(
+        ([fileId]) => fileId !== replacedFile.id
+      )
+    ),
+    markdownRichModeFaultedContent: Object.fromEntries(
+      Object.entries(state.markdownRichModeFaultedContent).filter(
         ([fileId]) => fileId !== replacedFile.id
       )
     ),

--- a/src/renderer/src/store/slices/worktrees-slice-test-harness.ts
+++ b/src/renderer/src/store/slices/worktrees-slice-test-harness.ts
@@ -167,6 +167,7 @@ export function createTestStore() {
         editorDrafts: {},
         markdownViewMode: {},
         markdownRichModeSizeOverride: {},
+        markdownRichModeFaultedContent: {},
         editorViewMode: {},
         showDotfilesByWorktree: {},
         expandedDirs: {},

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
@@ -105,6 +105,7 @@ export function applyRemoveWorktreeSuccessState(
       editorDrafts: omitByFileId(s.editorDrafts),
       markdownViewMode: omitByFileId(s.markdownViewMode),
       markdownRichModeSizeOverride: omitByFileId(s.markdownRichModeSizeOverride),
+      markdownRichModeFaultedContent: omitByFileId(s.markdownRichModeFaultedContent),
       editorViewMode: omitByFileId(s.editorViewMode),
       markdownFrontmatterVisible: omitByFileId(s.markdownFrontmatterVisible),
       // Why: editorCursorLine is keyed by fileId; clear it with the other per-file state so it doesn't leak.

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
@@ -175,6 +175,7 @@ export function buildWorktreePurgeState(
     editorDrafts: omitByFileId(s.editorDrafts),
     markdownViewMode: omitByFileId(s.markdownViewMode),
     markdownRichModeSizeOverride: omitByFileId(s.markdownRichModeSizeOverride),
+    markdownRichModeFaultedContent: omitByFileId(s.markdownRichModeFaultedContent),
     markdownFrontmatterVisible: omitByFileId(s.markdownFrontmatterVisible),
     // Why: keyed by fileId; the bulk reconcile path previously kept these, leaking a cursor-line / view-mode entry per removed file.
     editorCursorLine: omitByFileId(s.editorCursorLine),


### PR DESCRIPTION
## ELI5

When a markdown file has something rich mode can't handle — like an HTML block or a reference-style link — the editor falls back to a plain code view and shows a banner explaining why, but the nicely-formatted read-only preview was hidden behind a menu. This adds a Preview button right where you'd look for it: in the view toggle, and on the banner itself. The toggle only offers it once rich mode has actually hit that content and failed, not on a guess.

## What Changed

- The Source / Rich Editor toggle gains a third Preview option, but only for markdown edit tabs whose rich mode has actually fallen back to Source for the current content.
- The fallback banner gains an "Open preview" button next to the existing "Open anyway" button.
- Both open the same existing dedicated preview tab that the filename dropdown's "Open Markdown Preview" item and the `editor.markdownPreview` shortcut already use — no new preview surface.
- The fallback is tracked per tab in the store rather than classified speculatively: a Source-view markdown tab never scans its content on the chance rich mode might fail there. The toggle only offers Preview once a real Rich-mode attempt for that content has actually faulted, and drops it again once the content changes or a later Rich attempt succeeds.

## Why

The dedicated preview tab already existed but was undiscoverable exactly when someone needed it most: right after landing on the fallback banner with no idea rich mode wasn't going to work here. Reusing the existing preview action keeps this a discoverability fix rather than a new rendering path, and driving the affordance off an actual fault rather than a speculative scan keeps Source-view tabs from paying a classification cost nobody asked for.

## Linked Issue

Fixes #19796

## Visual Proof

A markdown file with a bare `<details>` block, opened in Rich view so rich mode faults.

**Before** (toggle offers Source and Rich Editor only; the banner has no action):
<img width="850" height="776" alt="before" src="https://github.com/user-attachments/assets/ecdbeb73-49e1-413b-b558-eb9123b3f95c" />
[before.webm](https://github.com/user-attachments/assets/3fa96d07-457c-448d-991b-b035216baee4)

**After** (toggle gains Preview and the banner gains "Open preview"; either lands on the read-only preview tab):
<img width="850" height="776" alt="after" src="https://github.com/user-attachments/assets/5ff2af2d-a347-4165-9d1f-2fa6dc00fe18" />
[after.webm](https://github.com/user-attachments/assets/f3a85a34-0d17-4274-a818-3ea3037c4b1c)

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`editor-panel-render-model.test.ts` covers the fault-driven toggle behavior directly, including the stale-content case where an edit since the last fault drops the flag without reclassifying. `EditorContent.markdown-classification.test.tsx` covers the banner's click-through to the preview tab, confirms the button is absent when no handler is supplied, and confirms Source-view markdown tabs skip the classification scan entirely. `EditorPanel.markdown-classification-memoization.test.tsx` mounts the full panel end to end and asserts the store records the fault after a live Rich-mode failure and clears it once the content is edited to succeed. `pnpm test src/renderer/src/components/editor` passes in full (1424 tests) and `pnpm test src/renderer/src/store/slices` passes in full (3133 tests).

## AI Disclosure

Authored with Claude Code (Claude Fable 5.1 and Sonnet teammates) under my review.

## Review

Implements the toggle-and-banner design described above, with the Preview affordance driven by a stored per-tab fault rather than speculative classification. Rich-mode eligibility classification only runs while a tab is actually in Rich view, matching the codebase's classification gate before this feature; Source-view and Preview-view tabs read the stored fault instead of re-scanning.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security, cross-platform, remote SSH, or mobile surface touched — this is a renderer-only UI affordance reusing existing store actions and an existing tab type. The new `markdownRichModeFaultedContent` store field follows the same per-tab-state lifecycle (close, rekey, worktree teardown, preview eviction) as the existing `markdownRichModeSizeOverride` and `markdownViewMode` fields it sits beside.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: [@fbartho](https://x.com/fbartho). I prefer Mastodon: [@fbartho@mastodon.social](https://mastodon.social/@fbartho).
