### PR TITLE
feat(chat): use tabular numerals in message bodies

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatMessageRow.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageRow.test.tsx
@@ -74,4 +74,13 @@ describe('MessageRow control visibility', () => {
     expect(screen.queryByRole('time')).toBeNull()
     expect(screen.queryByRole('button')).toBeNull()
   })
+
+  it.each(['assistant', 'user'] as const)(
+    'renders the %s message body with tabular numerals',
+    (role) => {
+      renderMessage(role)
+      const bodyRoot = screen.getByText('Message text').closest('p')!.parentElement!
+      expect(bodyRoot).toHaveClass('tabular-nums')
+    }
+  )
 })

--- a/src/renderer/src/components/native-chat/NativeChatMessageRow.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageRow.tsx
@@ -148,7 +148,7 @@ export const MessageRow = memo(function MessageRow({
               <CommentMarkdown
                 content={markdown}
                 variant="document"
-                className="text-sm"
+                className="text-sm tabular-nums [&_code]:[font-variant-numeric:normal]"
                 onLinkClick={onLinkClick}
                 allowFileUriLinks={allowFileUriLinks}
               />
@@ -201,7 +201,7 @@ export const MessageRow = memo(function MessageRow({
         <CommentMarkdown
           content={markdown}
           variant="document"
-          className="text-sm"
+          className="text-sm tabular-nums [&_code]:[font-variant-numeric:normal]"
           onLinkClick={onLinkClick}
           allowFileUriLinks={allowFileUriLinks}
           linkifyFilePaths={onLinkClick !== undefined}

--- a/src/renderer/src/components/native-chat/NativeChatNoticeRow.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatNoticeRow.test.tsx
@@ -49,6 +49,7 @@ describe('notice rows', () => {
       'text-sm',
       'text-foreground'
     )
+    expect(screen.getByRole('heading', { name: 'Steps' }).parentElement).toHaveClass('tabular-nums')
   })
   it('shows provider notice text once while retaining its diagnostic disclosure', () => {
     renderStatus({

--- a/src/renderer/src/components/native-chat/NativeChatNoticeRow.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatNoticeRow.tsx
@@ -43,7 +43,7 @@ export function NativeChatNoticeRow({
           <CommentMarkdown
             content={block.text}
             variant="document"
-            className="text-sm"
+            className="text-sm tabular-nums [&_code]:[font-variant-numeric:normal]"
             onLinkClick={onLinkClick}
             allowFileUriLinks={allowFileUriLinks}
             linkifyFilePaths={onLinkClick !== undefined}


### PR DESCRIPTION
## ELI5

Numbers in chat messages now line up evenly and the letter O is easier to tell apart from the digit 0, because digits in a message now use fixed-width versions of themselves instead of each digit taking up a slightly different amount of space.

## What Changed

Added the tabular-nums utility class to the three places a chat message body renders text: the user message bubble, the assistant message body, and the plan-document notice card, all in `src/renderer/src/components/native-chat/`. Code blocks inside messages are explicitly excluded so they keep rendering in monospace as before.

## Why

Orca already applies tabular-nums in roughly ninety other places — timestamps, diff counts, task counters, the sidebar, the status bar — but not to the chat transcript's own message text, where numbers most often appear in prose and short lists.

## Linked Issue

Fixes #19805

## Visual Proof

**Before**: proportional digits in the message body — a short numeric table and the line `O0O0 1111 8888` render with each digit at its natural width.
<img width="580" height="260" alt="before" src="https://github.com/user-attachments/assets/c3176a55-d991-427f-b973-c318b73f0edf" />
[before.webm](https://github.com/user-attachments/assets/850fba4e-edb8-4a52-b481-07608770e0d3)

**After**: the same content with tabular-nums applied — digits render at a uniform fixed width, matching the treatment already used for timestamps and counters elsewhere in the app.
<img width="580" height="260" alt="after" src="https://github.com/user-attachments/assets/4e3a85c5-cef9-4b2e-8423-7dd4c72973e8" />
[after.webm](https://github.com/user-attachments/assets/758f0eff-63ca-4e52-abb9-5ea55231ee1c)


## Testing

- [x] Automated tests added/updated, or explained why not below

Extended the existing render tests for both affected components (`NativeChatMessageRow.test.tsx`, `NativeChatNoticeRow.test.tsx`) to assert the tabular-nums class on the message body root. Verified the bundled Geist font actually implements the OpenType tnum feature by decompressing the shipped woff2 and reading its GSUB table directly — all ten digit glyphs substitute to tabular-figure variants under this feature.

## AI Disclosure

Authored with Claude Code (Claude Fable 5.1 and Sonnet teammates) under my review.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: [@fbartho](https://x.com/fbartho). I prefer Mastodon: [@fbartho@mastodon.social](https://mastodon.social/@fbartho).
