### PR TITLE
ci: fail a PR that rewrites or disables an existing test's expected outcome

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -161,6 +161,16 @@ jobs:
       - name: Enforce React Doctor on changed lines
         run: pnpm run check:react-doctor:changed -- "${{ github.event.pull_request.base.sha }}"
 
+      # Why here and not a job of its own: this job already blocks verify, already runs for
+      # every non-docs PR, and already has the full history the merge-base diff needs.
+      # Why PR_BODY through env: a PR body is attacker-controlled text and `${{ }}` inside a
+      # run: block is substituted before the shell parses it.
+      - name: Check flipped test assertions
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: pnpm run check:flipped-test-assertions -- --require-body "$BASE_SHA"
+
       - name: Check Zustand selector fan-out budget
         run: pnpm run check:zustand-selector-fanout
 

--- a/config/scripts/check-changed-code-quality.mjs
+++ b/config/scripts/check-changed-code-quality.mjs
@@ -3,7 +3,10 @@ import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
-import { resolvePullRequestDiffBase } from './git-pull-request-diff-base.mjs'
+import {
+  resolveExistingDiffBase,
+  resolvePullRequestDiffBase
+} from './git-pull-request-diff-base.mjs'
 import { resolveOxlintInvocation } from './oxlint-cli-invocation.mjs'
 
 const SOURCE_FILE_PATTERN = /\.(?:[cm]?[jt]sx?)$/
@@ -88,29 +91,8 @@ export function isRootCodeQualityPath(file) {
   return !ROOT_CODE_QUALITY_IGNORED_PREFIXES.some((prefix) => file.startsWith(prefix))
 }
 
-function resolveBase(root, requestedBase) {
-  for (const candidate of [
-    requestedBase,
-    process.env.ORCA_CODE_QUALITY_BASE,
-    'origin/main',
-    'main'
-  ]) {
-    if (!candidate) {
-      continue
-    }
-    const result = spawnSync('git', ['rev-parse', '--verify', `${candidate}^{commit}`], {
-      cwd: root,
-      stdio: 'ignore'
-    })
-    if (result.status === 0) {
-      return candidate
-    }
-  }
-  throw new Error('Pass the pull request base SHA or make origin/main available locally.')
-}
-
 export function collectAddedLineRanges(root, requestedBase) {
-  const base = resolveBase(root, requestedBase)
+  const base = resolveExistingDiffBase(root, requestedBase)
   const mergeBase = runGit(root, ['merge-base', base, 'HEAD']).trim()
   const comparisonBase = resolvePullRequestDiffBase(root, mergeBase)
   const changedFiles = splitNullDelimited(

--- a/config/scripts/check-flipped-test-assertions.mjs
+++ b/config/scripts/check-flipped-test-assertions.mjs
@@ -1,0 +1,271 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+import {
+  resolveExistingDiffBase,
+  resolvePullRequestDiffBase
+} from './git-pull-request-diff-base.mjs'
+
+// Flags a diff that changes what an EXISTING test expects, in the two areas where a
+// silently-rewritten expectation shipped a user-visible break (#19542/#19684): the
+// Playwright suite that does not gate PRs, and the orchestration RPC methods.
+//
+// Deliberately hunk-scoped and textual. Known false negative: a test deleted in one
+// hunk and re-added in another reads as an unrelated delete plus add, so a full
+// rewrite is not flagged. Renames are direction-blind, so restoring an old title is
+// flagged too. Both cost one PR-body paragraph, which is the whole price of the gate.
+
+const SCOPED_DIRECTORIES = ['tests/e2e/', 'src/main/runtime/rpc/methods/orchestration/']
+const TEST_FILE_PATTERN = /\.(?:spec\.ts|test\.ts|test\.mjs)$/
+const HUNK_HEADER_PATTERN = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/
+const TEST_TITLE_PATTERN = /\b(?:test|it)(?:\.[\w.]+)*\s*\(\s*(['"`])([^'"`]*)\1/
+// `toBeInstanceOf(Error)` and `toBeInstanceOf(RuntimeRpcFailureError)` both count.
+const FAILURE_EXPECTATION = /toThrow|\.rejects\b|toBeInstanceOf\(\s*\w*Error\b/
+// The removed side of a flip: the line that consumed a successful result.
+const SUCCESS_PATH = /expect\(|await\s/
+const EMPTY_EXPECTATION =
+  /\.toEqual\(\s*[[{]\s*[\]}]\s*\)|\.toHaveLength\(\s*0\s*\)|\.toBeNull\(\s*\)|\.toBeUndefined\(\s*\)/
+const NON_EMPTY_EXPECTATION =
+  /toMatchObject|toContain|\.toHaveLength\(\s*[1-9]|\.toEqual\(\s*[[{](?!\s*[\]}]\s*\))/
+const SECTION_HEADING = /^#{2,6}\s+User-visible change$/
+const ANY_HEADING = /^#{1,6}\s+\S/
+
+const INSTRUCTIONS = [
+  'This change rewrites what an existing test expects. If that is intentional, the product',
+  'behaviour it pins changed too, so say what a user sees. Add this to the PR body:',
+  '',
+  '  ## User-visible change',
+  '  Before: <what the user got with the old expectation>',
+  '  After: <what the user gets now>',
+  '',
+  'If nothing user-visible changed, the test is asserting something the product still does',
+  'not do — restore the old expectation instead of the section.'
+].join('\n')
+
+export function isScopedTestFile(file) {
+  return (
+    SCOPED_DIRECTORIES.some((prefix) => file.startsWith(prefix)) && TEST_FILE_PATTERN.test(file)
+  )
+}
+
+export function parseUnifiedDiffHunks(diff) {
+  const hunks = []
+  let file = null
+  let hunk = null
+  let newLine = 0
+  for (const raw of diff.split(/\r?\n/)) {
+    if (raw.startsWith('+++ ')) {
+      const target = raw.slice(4).trim()
+      file = target === '/dev/null' ? null : target.replace(/^b\//, '')
+      hunk = null
+      continue
+    }
+    if (raw.startsWith('--- ')) {
+      continue
+    }
+    const header = HUNK_HEADER_PATTERN.exec(raw)
+    if (header) {
+      newLine = Number.parseInt(header[1], 10)
+      hunk = file === null ? null : { file, added: [], removed: [] }
+      if (hunk !== null) {
+        hunks.push(hunk)
+      }
+      continue
+    }
+    if (hunk === null) {
+      continue
+    }
+    if (raw.startsWith('+')) {
+      hunk.added.push({ line: newLine, text: raw.slice(1) })
+      newLine += 1
+    } else if (raw.startsWith('-')) {
+      hunk.removed.push({ line: newLine, text: raw.slice(1) })
+    } else if (!raw.startsWith('\\')) {
+      newLine += 1
+    }
+  }
+  return hunks
+}
+
+function codeLines(lines) {
+  return lines.filter(({ text }) => !/^\s*(?:\/\/|\/\*|\*)/.test(text))
+}
+
+export function extractTestTitles(lines) {
+  const titles = []
+  for (const { line, text } of codeLines(lines)) {
+    const match = TEST_TITLE_PATTERN.exec(text)
+    if (match) {
+      titles.push({ line, title: match[2] })
+    }
+  }
+  return titles
+}
+
+export function findRenamedTests(hunk) {
+  const removed = extractTestTitles(hunk.removed)
+  const added = extractTestTitles(hunk.added)
+  const removedTitles = new Set(removed.map((entry) => entry.title))
+  const addedTitles = new Set(added.map((entry) => entry.title))
+  const dropped = removed.filter((entry) => !addedTitles.has(entry.title))
+  const introduced = added.filter((entry) => !removedTitles.has(entry.title))
+  return dropped.slice(0, introduced.length).map((entry, index) => ({
+    file: hunk.file,
+    line: introduced[index].line,
+    kind: 'renamed test',
+    removed: entry.title,
+    added: introduced[index].title
+  }))
+}
+
+export function findFlippedToFailure(hunk) {
+  const removed = codeLines(hunk.removed).find(
+    ({ text }) => SUCCESS_PATH.test(text) && !FAILURE_EXPECTATION.test(text)
+  )
+  const added = codeLines(hunk.added).find(({ text }) => FAILURE_EXPECTATION.test(text))
+  if (!removed || !added) {
+    return []
+  }
+  return [
+    {
+      file: hunk.file,
+      line: added.line,
+      kind: 'flipped to expect-failure',
+      removed: removed.text.trim(),
+      added: added.text.trim()
+    }
+  ]
+}
+
+export function findEmptiedExpectations(hunk) {
+  const removed = codeLines(hunk.removed).find(({ text }) => NON_EMPTY_EXPECTATION.test(text))
+  const added = codeLines(hunk.added).find(({ text }) => EMPTY_EXPECTATION.test(text))
+  if (!removed || !added) {
+    return []
+  }
+  return [
+    {
+      file: hunk.file,
+      line: added.line,
+      kind: 'expectation emptied',
+      removed: removed.text.trim(),
+      added: added.text.trim()
+    }
+  ]
+}
+
+export function collectFindings(diff) {
+  return parseUnifiedDiffHunks(diff)
+    .filter((hunk) => isScopedTestFile(hunk.file))
+    .flatMap((hunk) => [
+      ...findRenamedTests(hunk),
+      ...findFlippedToFailure(hunk),
+      ...findEmptiedExpectations(hunk)
+    ])
+}
+
+// Exact by design: `## User-visible changes` (plural) is not this section, and a
+// pointer to it from some other heading is not the section either.
+export function hasUserVisibleChangeSection(body) {
+  const lines = (body ?? '').split(/\r?\n/)
+  const start = lines.findIndex((line) => SECTION_HEADING.test(line.trim()))
+  if (start === -1) {
+    return false
+  }
+  let before = false
+  let after = false
+  for (const line of lines.slice(start + 1)) {
+    if (ANY_HEADING.test(line.trim())) {
+      break
+    }
+    const text = line.replace(/^[\s>]*(?:[-*+]\s+)?(?:\*\*|__|\*|_)?/, '')
+    before ||= text.startsWith('Before:')
+    after ||= text.startsWith('After:')
+  }
+  return before && after
+}
+
+export function formatFinding(finding) {
+  return `${finding.file}:${finding.line}: ${finding.kind}: ${finding.removed} → ${finding.added}`
+}
+
+function annotationValue(value) {
+  return String(value).replaceAll('%', '%25').replaceAll('\r', '%0D').replaceAll('\n', '%0A')
+}
+
+function collectScopedDiff(root, requestedBase) {
+  const base = resolveExistingDiffBase(root, requestedBase)
+  const mergeBase = execFileSync('git', ['merge-base', base, 'HEAD'], {
+    cwd: root,
+    encoding: 'utf8'
+  }).trim()
+  return execFileSync(
+    'git',
+    [
+      'diff',
+      '--unified=0',
+      '--no-color',
+      resolvePullRequestDiffBase(root, mergeBase),
+      '--',
+      ...SCOPED_DIRECTORIES
+    ],
+    { cwd: root, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+  )
+}
+
+function parseArguments(argv) {
+  const options = { diffFile: null, requireBody: false, requestedBase: undefined }
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === '--require-body') {
+      options.requireBody = true
+    } else if (argument.startsWith('--diff-file=')) {
+      options.diffFile = argument.slice('--diff-file='.length)
+    } else if (argument === '--diff-file') {
+      index += 1
+      options.diffFile = argv[index]
+    } else if (argument !== '--' && !argument.startsWith('--') && !options.requestedBase) {
+      options.requestedBase = argument
+    }
+  }
+  return options
+}
+
+export function main(argv = process.argv.slice(2), root = process.cwd(), env = process.env) {
+  const { diffFile, requireBody, requestedBase } = parseArguments(argv)
+  const diff =
+    diffFile === null
+      ? collectScopedDiff(root, requestedBase)
+      : readFileSync(diffFile === '-' ? 0 : diffFile, 'utf8')
+  const findings = collectFindings(diff)
+  if (findings.length === 0) {
+    console.log('Flipped-assertion gate: no rewritten test expectations in the gated paths.')
+    return 0
+  }
+  for (const finding of findings) {
+    console.error(
+      `::error file=${annotationValue(finding.file)},line=${finding.line},title=${annotationValue(finding.kind)}::${annotationValue(INSTRUCTIONS.split('\n')[0])}`
+    )
+    console.error(formatFinding(finding))
+  }
+  if (hasUserVisibleChangeSection(env.PR_BODY)) {
+    console.log(
+      `Flipped-assertion gate: ${findings.length} rewritten expectation(s), explained by the PR body's "## User-visible change" section.`
+    )
+    return 0
+  }
+  console.error('')
+  console.error(INSTRUCTIONS)
+  if (requireBody) {
+    return 1
+  }
+  console.log(
+    'Reporting only: CI passes --require-body, which turns the findings above into a failure.'
+  )
+  return 0
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(main())
+}

--- a/config/scripts/check-flipped-test-assertions.mjs
+++ b/config/scripts/check-flipped-test-assertions.mjs
@@ -6,34 +6,23 @@ import {
   resolveExistingDiffBase,
   resolvePullRequestDiffBase
 } from './git-pull-request-diff-base.mjs'
+import {
+  collectFindings,
+  formatFinding,
+  SCOPED_DIRECTORIES
+} from './test-expectation-flip-heuristics.mjs'
 
-// Flags a diff that changes what an EXISTING test expects, in the two areas where a
-// silently-rewritten expectation shipped a user-visible break (#19542/#19684): the
-// Playwright suite that does not gate PRs, and the orchestration RPC methods.
-//
-// Deliberately hunk-scoped and textual. Known false negative: a test deleted in one
-// hunk and re-added in another reads as an unrelated delete plus add, so a full
-// rewrite is not flagged. Renames are direction-blind, so restoring an old title is
-// flagged too. Both cost one PR-body paragraph, which is the whole price of the gate.
+// PR gate: a diff that stops an existing test asserting what it used to (see
+// test-expectation-flip-heuristics.mjs for the four shapes) must say what a user sees.
+// The only way out is a `## User-visible change` section in the PR body, which is one
+// paragraph, and which nobody wrote for #19684.
 
-const SCOPED_DIRECTORIES = ['tests/e2e/', 'src/main/runtime/rpc/methods/orchestration/']
-const TEST_FILE_PATTERN = /\.(?:spec\.ts|test\.ts|test\.mjs)$/
-const HUNK_HEADER_PATTERN = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/
-const TEST_TITLE_PATTERN = /\b(?:test|it)(?:\.[\w.]+)*\s*\(\s*(['"`])([^'"`]*)\1/
-// `toBeInstanceOf(Error)` and `toBeInstanceOf(RuntimeRpcFailureError)` both count.
-const FAILURE_EXPECTATION = /toThrow|\.rejects\b|toBeInstanceOf\(\s*\w*Error\b/
-// The removed side of a flip: the line that consumed a successful result.
-const SUCCESS_PATH = /expect\(|await\s/
-const EMPTY_EXPECTATION =
-  /\.toEqual\(\s*[[{]\s*[\]}]\s*\)|\.toHaveLength\(\s*0\s*\)|\.toBeNull\(\s*\)|\.toBeUndefined\(\s*\)/
-const NON_EMPTY_EXPECTATION =
-  /toMatchObject|toContain|\.toHaveLength\(\s*[1-9]|\.toEqual\(\s*[[{](?!\s*[\]}]\s*\))/
 const SECTION_HEADING = /^#{2,6}\s+User-visible change$/
 const ANY_HEADING = /^#{1,6}\s+\S/
 
 const INSTRUCTIONS = [
-  'This change rewrites what an existing test expects. If that is intentional, the product',
-  'behaviour it pins changed too, so say what a user sees. Add this to the PR body:',
+  'This change rewrites or disables what an existing test expects. If that is intentional,',
+  'the product behaviour it pins changed too, so say what a user sees. Add this to the PR body:',
   '',
   '  ## User-visible change',
   '  Before: <what the user got with the old expectation>',
@@ -42,128 +31,6 @@ const INSTRUCTIONS = [
   'If nothing user-visible changed, the test is asserting something the product still does',
   'not do — restore the old expectation instead of the section.'
 ].join('\n')
-
-export function isScopedTestFile(file) {
-  return (
-    SCOPED_DIRECTORIES.some((prefix) => file.startsWith(prefix)) && TEST_FILE_PATTERN.test(file)
-  )
-}
-
-export function parseUnifiedDiffHunks(diff) {
-  const hunks = []
-  let file = null
-  let hunk = null
-  let newLine = 0
-  for (const raw of diff.split(/\r?\n/)) {
-    if (raw.startsWith('+++ ')) {
-      const target = raw.slice(4).trim()
-      file = target === '/dev/null' ? null : target.replace(/^b\//, '')
-      hunk = null
-      continue
-    }
-    if (raw.startsWith('--- ')) {
-      continue
-    }
-    const header = HUNK_HEADER_PATTERN.exec(raw)
-    if (header) {
-      newLine = Number.parseInt(header[1], 10)
-      hunk = file === null ? null : { file, added: [], removed: [] }
-      if (hunk !== null) {
-        hunks.push(hunk)
-      }
-      continue
-    }
-    if (hunk === null) {
-      continue
-    }
-    if (raw.startsWith('+')) {
-      hunk.added.push({ line: newLine, text: raw.slice(1) })
-      newLine += 1
-    } else if (raw.startsWith('-')) {
-      hunk.removed.push({ line: newLine, text: raw.slice(1) })
-    } else if (!raw.startsWith('\\')) {
-      newLine += 1
-    }
-  }
-  return hunks
-}
-
-function codeLines(lines) {
-  return lines.filter(({ text }) => !/^\s*(?:\/\/|\/\*|\*)/.test(text))
-}
-
-export function extractTestTitles(lines) {
-  const titles = []
-  for (const { line, text } of codeLines(lines)) {
-    const match = TEST_TITLE_PATTERN.exec(text)
-    if (match) {
-      titles.push({ line, title: match[2] })
-    }
-  }
-  return titles
-}
-
-export function findRenamedTests(hunk) {
-  const removed = extractTestTitles(hunk.removed)
-  const added = extractTestTitles(hunk.added)
-  const removedTitles = new Set(removed.map((entry) => entry.title))
-  const addedTitles = new Set(added.map((entry) => entry.title))
-  const dropped = removed.filter((entry) => !addedTitles.has(entry.title))
-  const introduced = added.filter((entry) => !removedTitles.has(entry.title))
-  return dropped.slice(0, introduced.length).map((entry, index) => ({
-    file: hunk.file,
-    line: introduced[index].line,
-    kind: 'renamed test',
-    removed: entry.title,
-    added: introduced[index].title
-  }))
-}
-
-export function findFlippedToFailure(hunk) {
-  const removed = codeLines(hunk.removed).find(
-    ({ text }) => SUCCESS_PATH.test(text) && !FAILURE_EXPECTATION.test(text)
-  )
-  const added = codeLines(hunk.added).find(({ text }) => FAILURE_EXPECTATION.test(text))
-  if (!removed || !added) {
-    return []
-  }
-  return [
-    {
-      file: hunk.file,
-      line: added.line,
-      kind: 'flipped to expect-failure',
-      removed: removed.text.trim(),
-      added: added.text.trim()
-    }
-  ]
-}
-
-export function findEmptiedExpectations(hunk) {
-  const removed = codeLines(hunk.removed).find(({ text }) => NON_EMPTY_EXPECTATION.test(text))
-  const added = codeLines(hunk.added).find(({ text }) => EMPTY_EXPECTATION.test(text))
-  if (!removed || !added) {
-    return []
-  }
-  return [
-    {
-      file: hunk.file,
-      line: added.line,
-      kind: 'expectation emptied',
-      removed: removed.text.trim(),
-      added: added.text.trim()
-    }
-  ]
-}
-
-export function collectFindings(diff) {
-  return parseUnifiedDiffHunks(diff)
-    .filter((hunk) => isScopedTestFile(hunk.file))
-    .flatMap((hunk) => [
-      ...findRenamedTests(hunk),
-      ...findFlippedToFailure(hunk),
-      ...findEmptiedExpectations(hunk)
-    ])
-}
 
 // Exact by design: `## User-visible changes` (plural) is not this section, and a
 // pointer to it from some other heading is not the section either.
@@ -184,10 +51,6 @@ export function hasUserVisibleChangeSection(body) {
     after ||= text.startsWith('After:')
   }
   return before && after
-}
-
-export function formatFinding(finding) {
-  return `${finding.file}:${finding.line}: ${finding.kind}: ${finding.removed} → ${finding.added}`
 }
 
 function annotationValue(value) {

--- a/config/scripts/check-flipped-test-assertions.test.mjs
+++ b/config/scripts/check-flipped-test-assertions.test.mjs
@@ -3,17 +3,17 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { parse as parseYaml } from 'yaml'
+import { hasUserVisibleChangeSection, main } from './check-flipped-test-assertions.mjs'
 import {
   collectFindings,
   extractTestTitles,
+  findDisabledTests,
   findEmptiedExpectations,
   findFlippedToFailure,
   findRenamedTests,
-  hasUserVisibleChangeSection,
   isScopedTestFile,
-  main,
   parseUnifiedDiffHunks
-} from './check-flipped-test-assertions.mjs'
+} from './test-expectation-flip-heuristics.mjs'
 
 const projectDir = resolve(import.meta.dirname, '../..')
 const prWorkflow = parseYaml(readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8'))
@@ -229,19 +229,123 @@ describe('renamed test heuristic', () => {
     expect(findRenamedTests(hunk)).toHaveLength(1)
   })
 
-  it('reads it() and test.describe() titles too', () => {
+  it('reads it(), describe() and test.describe() titles, and marks the disabled ones', () => {
     expect(
       extractTestTitles([
         { line: 1, text: "  it('does a thing', () => {" },
         { line: 2, text: "  test.describe('a suite', () => {" },
         { line: 3, text: "  test.skip('skipped', () => {" },
-        { line: 4, text: '  const unrelated = 1' }
+        { line: 4, text: "  describe.skip('a skipped suite', () => {" },
+        { line: 5, text: "  it.only('focused', () => {" },
+        { line: 6, text: '  const unrelated = 1' }
       ])
     ).toEqual([
-      { line: 1, title: 'does a thing' },
-      { line: 2, title: 'a suite' },
-      { line: 3, title: 'skipped' }
+      { line: 1, title: 'does a thing', text: "  it('does a thing', () => {", disabled: false },
+      { line: 2, title: 'a suite', text: "  test.describe('a suite', () => {", disabled: false },
+      { line: 3, title: 'skipped', text: "  test.skip('skipped', () => {", disabled: true },
+      {
+        line: 4,
+        title: 'a skipped suite',
+        text: "  describe.skip('a skipped suite', () => {",
+        disabled: true
+      },
+      // `.only` narrows a run; it does not stop asserting, so it is not a disable.
+      { line: 5, title: 'focused', text: "  it.only('focused', () => {", disabled: false }
     ])
+  })
+})
+
+describe('disabled-test heuristic', () => {
+  it.each([
+    ["+  test.skip('keeps unbound direct mail durable', async () => {", 'test.skip'],
+    ["+  test.fixme('keeps unbound direct mail durable', async () => {", 'test.fixme'],
+    ["+  it.skip('keeps unbound direct mail durable', async () => {", 'it.skip']
+  ])('flags an existing test turned into %s', (added) => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3 +3 @@', [
+        "-  test('keeps unbound direct mail durable', async () => {",
+        added
+      ])
+    )
+
+    expect(findDisabledTests(hunk)).toEqual([
+      {
+        file: 'tests/e2e/a.spec.ts',
+        line: 3,
+        kind: 'test disabled',
+        removed: "test('keeps unbound direct mail durable', async () => {",
+        added: added.slice(1).trim()
+      }
+    ])
+  })
+
+  it('flags a describe turned into describe.skip', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('src/main/runtime/rpc/methods/orchestration/send.test.ts', '@@ -3 +3 @@', [
+        "-describe('unbound send', () => {",
+        "+describe.skip('unbound send', () => {"
+      ])
+    )
+
+    expect(findDisabledTests(hunk)).toHaveLength(1)
+  })
+
+  // The title can sit on its own line when the call is wrapped, so the removed side is
+  // matched on text as well as on an extracted title.
+  it('flags a skip whose predecessor line only mentions the title', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3,2 +3 @@', [
+        '-  test(',
+        "-    'keeps unbound direct mail durable',",
+        "+  test.skip('keeps unbound direct mail durable', async () => {"
+      ])
+    )
+
+    expect(findDisabledTests(hunk)).toHaveLength(1)
+  })
+
+  // Re-enabling a test is the direction that adds coverage back.
+  it('does not flag unskipping', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3 +3 @@', [
+        "-  test.skip('keeps unbound direct mail durable', async () => {",
+        "+  test('keeps unbound direct mail durable', async () => {"
+      ])
+    )
+
+    expect(findDisabledTests(hunk)).toEqual([])
+  })
+
+  it('does not flag a brand new skipped test', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3,0 +4 @@', [
+        "+  test.skip('a case nobody has written yet', async () => {})"
+      ])
+    )
+
+    expect(findDisabledTests(hunk)).toEqual([])
+  })
+
+  it('does not flag dropping .only, which re-widens the run', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3 +3 @@', [
+        "-  test.only('keeps unbound direct mail durable', async () => {",
+        "+  test('keeps unbound direct mail durable', async () => {"
+      ])
+    )
+
+    expect(findDisabledTests(hunk)).toEqual([])
+  })
+
+  it('does not double-report a skip as a rename', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3 +3 @@', [
+        "-  test('keeps unbound direct mail durable', async () => {",
+        "+  test.skip('keeps unbound direct mail durable', async () => {"
+      ])
+    )
+
+    expect(findRenamedTests(hunk)).toEqual([])
   })
 })
 

--- a/config/scripts/check-flipped-test-assertions.test.mjs
+++ b/config/scripts/check-flipped-test-assertions.test.mjs
@@ -1,0 +1,528 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { parse as parseYaml } from 'yaml'
+import {
+  collectFindings,
+  extractTestTitles,
+  findEmptiedExpectations,
+  findFlippedToFailure,
+  findRenamedTests,
+  hasUserVisibleChangeSection,
+  isScopedTestFile,
+  main,
+  parseUnifiedDiffHunks
+} from './check-flipped-test-assertions.mjs'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+const prWorkflow = parseYaml(readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8'))
+const packageScripts = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf8')).scripts
+
+// Verbatim `git diff 750e6ffada^ 750e6ffada --unified=0` (#19684, the test-only PR that rewrote
+// the spec which had already caught #19542 on main). Frozen as text rather than read from git so
+// the gate stays proven against the real regression in a shallow clone.
+const PR_19684_DIFF = `diff --git a/tests/e2e/orchestration-idle-mail-delivery.spec.ts b/tests/e2e/orchestration-idle-mail-delivery.spec.ts
+index f679bdba60..8ca6657ab7 100644
+--- a/tests/e2e/orchestration-idle-mail-delivery.spec.ts
++++ b/tests/e2e/orchestration-idle-mail-delivery.spec.ts
+@@ -37,0 +38 @@ import { RuntimeClient, type RuntimeRpcSuccess } from '../../src/cli/runtime-cli
++import { RuntimeRpcFailureError } from '../../src/cli/runtime/types'
+@@ -353 +354,4 @@ test.describe('orchestration push-on-idle mail delivery', () => {
+-  test('keeps unbound direct mail durable without pointing to an unsafe check', async ({
++  // #19542 deleted the legacy-Run write fallback, so a sender in no Run has
++  // nowhere to file mail to a bare handle: the send is refused outright, which
++  // is what keeps an unsafe pointer out of the pane on the next idle frame.
++  test('refuses unbound direct mail from a sender in no Run instead of pushing it', async ({
+@@ -363 +367,25 @@ test.describe('orchestration push-on-idle mail delivery', () => {
+-    const messageId = await sendMail(client, pane.handle, { subject: 'Unbound direct mail' })
++    const refusal = await sendMail(client, pane.handle, { subject: 'Unbound direct mail' }).then(
++      () => undefined,
++      (error: unknown) => error
++    )
++    // Why runtime_error and not run_required: insertMessage throws a plain
++    // Error, which the dispatcher passes through with its message and no
++    // recovery data — the sibling no-recipient path is the one that adds it.
++    // The request-id suffix and stamp are the client's durable-mutation bookkeeping.
++    expect(refusal).toBeInstanceOf(RuntimeRpcFailureError)
++    expect(refusal).toMatchObject({
++      code: 'runtime_error',
++      message: expect.stringContaining('Run is required')
++    })
++    // Pins that the SERVER attached no orchestrationSkillRecoveryData, without
++    // freezing whatever else the client may stamp alongside its request id.
++    const refusalData = (refusal as RuntimeRpcFailureError).data
++    expect(refusalData).toMatchObject({ orchestrationRequestId: expect.any(String) })
++    expect(refusalData).not.toHaveProperty('effectsApplied')
++    expect(refusalData).not.toHaveProperty('guide')
++    expect(refusalData).not.toHaveProperty('nextCommandArgs')
++    expect(refusalData).not.toHaveProperty('nextSteps')
++    expect(readMailbox(userDataDir, pane.handle)).toEqual([])
++
++    // A busy→idle edge is the push trigger. Walking one proves the refusal left
++    // nothing behind for the scan to point at, not merely that the push was slow.
+@@ -369,5 +397,3 @@ test.describe('orchestration push-on-idle mail delivery', () => {
+-    expect(readMailRow(userDataDir, messageId)).toMatchObject({
+-      to_handle: pane.handle,
+-      read: 0,
+-      delivered_at: null
+-    })
++    // The ledger only proves anything once the push window has fully elapsed.
++    await orcaPage.waitForTimeout(NO_DELIVERY_SETTLE_MS)
++    expect(readMailbox(userDataDir, pane.handle)).toEqual([])
+`
+
+// #19684's real section set, abridged. What matters is that none of its headings is the
+// escape hatch, which is why the gate would have held it.
+const PR_19684_BODY = [
+  '## ELI5',
+  '',
+  'One E2E test still expected the pre-#19542 world where mail to a bare terminal handle',
+  'from a sender in no Run was quietly filed under the legacy Run.',
+  '',
+  '## What Changed',
+  '',
+  '- `tests/e2e/orchestration-idle-mail-delivery.spec.ts`: the test is rewritten to pin the refusal.',
+  '- No product code changed. Neighbouring tests untouched.',
+  '',
+  '## Why',
+  '',
+  '#19542 deleted every `?? LEGACY_RUN_ID` write fallback, so `insertMessage` now throws.',
+  '',
+  '## Testing',
+  '',
+  '| Command | Result |',
+  '| --- | --- |',
+  '| the spec, `-g "unbound direct mail"` | 1 passed |'
+].join('\n')
+
+function diffOf(file, header, lines) {
+  return [
+    `diff --git a/${file} b/${file}`,
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    header,
+    ...lines
+  ].join('\n')
+}
+
+describe('gate scope', () => {
+  it.each([
+    'tests/e2e/orchestration-idle-mail-delivery.spec.ts',
+    'tests/e2e/cross-version-wire/terminal-stream.spec.ts',
+    'src/main/runtime/rpc/methods/orchestration/send-unbound-terminals.test.ts'
+  ])('gates %s', (file) => {
+    expect(isScopedTestFile(file)).toBe(true)
+  })
+
+  it.each([
+    'tests/e2e/fixtures/orchestration-fake-agent.ts',
+    'src/main/runtime/rpc/methods/orchestration/send-methods.ts',
+    'src/main/runtime/orchestration/db/messages/message-insert.test.ts',
+    'src/cli/handlers/orchestration.test.ts'
+  ])('does not gate %s', (file) => {
+    expect(isScopedTestFile(file)).toBe(false)
+  })
+})
+
+describe('unified diff parsing', () => {
+  it('keeps the file header out of the hunk and numbers added lines on the new side', () => {
+    const hunks = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -10,2 +12,3 @@', [
+        '-const before = 1',
+        '-const gone = 2',
+        '+const after = 1',
+        ' context',
+        '+const tail = 3'
+      ])
+    )
+
+    expect(hunks).toEqual([
+      {
+        file: 'tests/e2e/a.spec.ts',
+        removed: [
+          { line: 12, text: 'const before = 1' },
+          { line: 12, text: 'const gone = 2' }
+        ],
+        added: [
+          { line: 12, text: 'const after = 1' },
+          { line: 14, text: 'const tail = 3' }
+        ]
+      }
+    ])
+  })
+
+  it('reads a deleted file as no hunks so its removals cannot pair with another file', () => {
+    const diff = [
+      'diff --git a/tests/e2e/a.spec.ts b/tests/e2e/a.spec.ts',
+      '--- a/tests/e2e/a.spec.ts',
+      '+++ /dev/null',
+      '@@ -1,2 +0,0 @@',
+      "-test('kept', () => {})",
+      '-expect(rows).toMatchObject({ read: 0 })'
+    ].join('\n')
+
+    expect(parseUnifiedDiffHunks(diff)).toEqual([])
+  })
+})
+
+describe('renamed test heuristic', () => {
+  it('flags a title replaced in the same hunk', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3 +3 @@', [
+        "-  test('keeps unbound direct mail durable', async () => {",
+        "+  test('refuses unbound direct mail', async () => {"
+      ])
+    )
+
+    expect(findRenamedTests(hunk)).toEqual([
+      {
+        file: 'tests/e2e/a.spec.ts',
+        line: 3,
+        kind: 'renamed test',
+        removed: 'keeps unbound direct mail durable',
+        added: 'refuses unbound direct mail'
+      }
+    ])
+  })
+
+  it('ignores an edit that keeps the title', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3 +3 @@', [
+        "-  test('keeps unbound direct mail durable', async () => {",
+        "+  test('keeps unbound direct mail durable', async ({ page }) => {"
+      ])
+    )
+
+    expect(findRenamedTests(hunk)).toEqual([])
+  })
+
+  it('ignores a brand new test with nothing removed', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3,0 +4 @@', ["+  test('a new case', async () => {})"])
+    )
+
+    expect(findRenamedTests(hunk)).toEqual([])
+  })
+
+  it('ignores a title quoted inside a comment', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3 +3 @@', [
+        "-  // superseded by test('old name', ...)",
+        "+  // superseded by test('new name', ...)"
+      ])
+    )
+
+    expect(findRenamedTests(hunk)).toEqual([])
+  })
+
+  // Direction-blind on purpose: nothing in a diff says which title carries the older intent,
+  // so restoring a renamed test is flagged too. The cost is the same one paragraph.
+  it('flags the restoring direction as well', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -3 +3 @@', [
+        "-  test('refuses unbound direct mail', async () => {",
+        "+  test('keeps unbound direct mail durable', async () => {"
+      ])
+    )
+
+    expect(findRenamedTests(hunk)).toHaveLength(1)
+  })
+
+  it('reads it() and test.describe() titles too', () => {
+    expect(
+      extractTestTitles([
+        { line: 1, text: "  it('does a thing', () => {" },
+        { line: 2, text: "  test.describe('a suite', () => {" },
+        { line: 3, text: "  test.skip('skipped', () => {" },
+        { line: 4, text: '  const unrelated = 1' }
+      ])
+    ).toEqual([
+      { line: 1, title: 'does a thing' },
+      { line: 2, title: 'a suite' },
+      { line: 3, title: 'skipped' }
+    ])
+  })
+})
+
+describe('flipped-to-expect-failure heuristic', () => {
+  it('flags a consumed result replaced by an error expectation', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -8 +8,2 @@', [
+        '-    const messageId = await sendMail(client, pane.handle)',
+        '+    const refusal = await sendMail(client, pane.handle).catch((error) => error)',
+        '+    expect(refusal).toBeInstanceOf(RuntimeRpcFailureError)'
+      ])
+    )
+
+    expect(findFlippedToFailure(hunk)).toEqual([
+      {
+        file: 'tests/e2e/a.spec.ts',
+        line: 9,
+        kind: 'flipped to expect-failure',
+        removed: 'const messageId = await sendMail(client, pane.handle)',
+        added: 'expect(refusal).toBeInstanceOf(RuntimeRpcFailureError)'
+      }
+    ])
+  })
+
+  it.each([
+    '+    await expect(send()).rejects.toThrow()',
+    '+    expect(send).toThrow()',
+    '+    expect(refusal).toBeInstanceOf(Error)'
+  ])('flags %s', (added) => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -8 +8 @@', ['-    expect(await send()).toBe(1)', added])
+    )
+
+    expect(findFlippedToFailure(hunk)).toHaveLength(1)
+  })
+
+  // A fix that restores working behaviour must not pay the gate's price.
+  it('does not flag the reverse direction', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -8,2 +8,2 @@', [
+        '-    await expect(sendMail(client, pane.handle)).rejects.toThrow()',
+        '-    expect(refusal).toBeInstanceOf(RuntimeRpcFailureError)',
+        '+    const messageId = await sendMail(client, pane.handle)',
+        '+    expect(readMailRow(dir, messageId)).toMatchObject({ read: 0 })'
+      ])
+    )
+
+    expect(findFlippedToFailure(hunk)).toEqual([])
+  })
+
+  it('does not flag a hunk that only adds an error expectation', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -8,0 +9 @@', [
+        '+    await expect(sendMail(client, other)).rejects.toThrow()'
+      ])
+    )
+
+    expect(findFlippedToFailure(hunk)).toEqual([])
+  })
+})
+
+describe('emptied-expectation heuristic', () => {
+  it.each([
+    '+    expect(readMailbox(dir, handle)).toEqual([])',
+    '+    expect(readMailbox(dir, handle)).toHaveLength(0)',
+    '+    expect(readMailRow(dir, id)).toBeNull()',
+    '+    expect(readMailRow(dir, id)).toBeUndefined()',
+    '+    expect(snapshot).toEqual({})'
+  ])('flags %s replacing a populated expectation', (added) => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -8,2 +8 @@', [
+        '-    expect(readMailRow(dir, messageId)).toMatchObject({',
+        '-      read: 0',
+        added
+      ])
+    )
+
+    expect(findEmptiedExpectations(hunk)).toHaveLength(1)
+  })
+
+  it.each([
+    '-    expect(rows).toEqual([{ id: 1 }])',
+    '-    expect(rows).toContain(handle)',
+    '-    expect(rows).toHaveLength(2)'
+  ])('accepts %s as the populated side', (removed) => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -8 +8 @@', [removed, '+    expect(rows).toEqual([])'])
+    )
+
+    expect(findEmptiedExpectations(hunk)).toHaveLength(1)
+  })
+
+  it('does not flag the reverse direction', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -8 +8 @@', [
+        '-    expect(readMailbox(dir, handle)).toEqual([])',
+        '+    expect(readMailRow(dir, messageId)).toMatchObject({ read: 0 })'
+      ])
+    )
+
+    expect(findEmptiedExpectations(hunk)).toEqual([])
+  })
+
+  it('does not flag an emptiness assertion added beside an unrelated removal', () => {
+    const [hunk] = parseUnifiedDiffHunks(
+      diffOf('tests/e2e/a.spec.ts', '@@ -8 +8,2 @@', [
+        '-    const dir = makeUserDataDir()',
+        '+    const dir = makeUserDataDir({ seeded: false })',
+        '+    expect(readMailbox(dir, handle)).toEqual([])'
+      ])
+    )
+
+    expect(findEmptiedExpectations(hunk)).toEqual([])
+  })
+})
+
+describe('the #19684 diff', () => {
+  it('reports all three flips with their file and line', () => {
+    expect(collectFindings(PR_19684_DIFF)).toEqual([
+      {
+        file: 'tests/e2e/orchestration-idle-mail-delivery.spec.ts',
+        line: 357,
+        kind: 'renamed test',
+        removed: 'keeps unbound direct mail durable without pointing to an unsafe check',
+        added: 'refuses unbound direct mail from a sender in no Run instead of pushing it'
+      },
+      {
+        file: 'tests/e2e/orchestration-idle-mail-delivery.spec.ts',
+        line: 375,
+        kind: 'flipped to expect-failure',
+        removed:
+          "const messageId = await sendMail(client, pane.handle, { subject: 'Unbound direct mail' })",
+        added: 'expect(refusal).toBeInstanceOf(RuntimeRpcFailureError)'
+      },
+      {
+        file: 'tests/e2e/orchestration-idle-mail-delivery.spec.ts',
+        line: 399,
+        kind: 'expectation emptied',
+        removed: 'expect(readMailRow(userDataDir, messageId)).toMatchObject({',
+        added: 'expect(readMailbox(userDataDir, pane.handle)).toEqual([])'
+      }
+    ])
+  })
+
+  it('ignores the same flips outside the gated paths', () => {
+    const moved = PR_19684_DIFF.replaceAll(
+      'tests/e2e/orchestration-idle-mail-delivery.spec.ts',
+      'src/main/runtime/orchestration/idle-mail-delivery.test.ts'
+    )
+
+    expect(collectFindings(moved)).toEqual([])
+  })
+})
+
+describe('the escape-hatch section', () => {
+  it('accepts the section with both lines', () => {
+    expect(
+      hasUserVisibleChangeSection(
+        ['## User-visible change', 'Before: mail was stored.', 'After: the send is refused.'].join(
+          '\n'
+        )
+      )
+    ).toBe(true)
+  })
+
+  it('accepts bulleted and bolded lines', () => {
+    expect(
+      hasUserVisibleChangeSection(
+        ['## User-visible change', '- **Before:** stored', '- **After:** refused'].join('\n')
+      )
+    ).toBe(true)
+  })
+
+  it('rejects the #19684 body, whose headings never explain the outcome change', () => {
+    expect(hasUserVisibleChangeSection(PR_19684_BODY)).toBe(false)
+  })
+
+  it('rejects an empty or absent body', () => {
+    expect(hasUserVisibleChangeSection('')).toBe(false)
+    expect(hasUserVisibleChangeSection(undefined)).toBe(false)
+  })
+
+  it.each([
+    ['only Before', ['## User-visible change', 'Before: stored']],
+    ['only After', ['## User-visible change', 'After: refused']],
+    [
+      'both lines after the section ended',
+      ['## User-visible change', '## Testing', 'Before: stored', 'After: refused']
+    ]
+  ])('rejects a section with %s', (_label, lines) => {
+    expect(hasUserVisibleChangeSection(lines.join('\n'))).toBe(false)
+  })
+
+  // Exact on purpose: a near-miss heading must fail loudly rather than silently excuse a flip.
+  it.each(['## User-visible changes', '## User visible change', '## user-visible change'])(
+    'does not accept %s',
+    (heading) => {
+      expect(
+        hasUserVisibleChangeSection([heading, 'Before: stored', 'After: refused'].join('\n'))
+      ).toBe(false)
+    }
+  )
+
+  it('accepts a deeper heading level', () => {
+    expect(
+      hasUserVisibleChangeSection(
+        ['### User-visible change', 'Before: stored', 'After: refused'].join('\n')
+      )
+    ).toBe(true)
+  })
+})
+
+describe('exit codes', () => {
+  let diffFile
+
+  beforeEach(() => {
+    diffFile = join(mkdtempSync(join(tmpdir(), 'flipped-assertion-')), '19684.diff')
+    writeFileSync(diffFile, PR_19684_DIFF)
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fails when CI requires a body that does not explain the flips', () => {
+    expect(
+      main(['--diff-file', diffFile, '--require-body'], projectDir, { PR_BODY: PR_19684_BODY })
+    ).toBe(1)
+  })
+
+  it('passes once the body carries the section', () => {
+    const body = `${PR_19684_BODY}\n\n## User-visible change\n\nBefore: stored\nAfter: refused\n`
+
+    expect(main(['--diff-file', diffFile, '--require-body'], projectDir, { PR_BODY: body })).toBe(0)
+  })
+
+  it('reports without failing when the body is not available', () => {
+    expect(main([`--diff-file=${diffFile}`], projectDir, {})).toBe(0)
+  })
+
+  it('passes a diff with no gated flip', () => {
+    writeFileSync(
+      diffFile,
+      diffOf('tests/e2e/a.spec.ts', '@@ -8,0 +9 @@', ['+    expect(rows).toHaveLength(2)'])
+    )
+
+    expect(main(['--diff-file', diffFile, '--require-body'], projectDir, {})).toBe(0)
+  })
+})
+
+describe('CI wiring', () => {
+  const step = prWorkflow.jobs.static_analysis.steps.find(
+    (candidate) => candidate.name === 'Check flipped test assertions'
+  )
+
+  // static_analysis is the job to extend: it is already in verify.needs, already runs for every
+  // non-docs PR, and already checks out full history for the sibling changed-code gate's diff.
+  it('runs in a job verify blocks on', () => {
+    expect(step).toBeDefined()
+    expect(prWorkflow.jobs.verify.needs).toContain('static_analysis')
+  })
+
+  it('requires the body and passes the PR base SHA', () => {
+    expect(step.run).toContain('pnpm run check:flipped-test-assertions')
+    expect(step.run).toContain('--require-body')
+    expect(step.run).toContain('"$BASE_SHA"')
+  })
+
+  // Why env and not interpolation: a PR body is attacker-controlled text, and `${{ }}` inside a
+  // run: block is substituted before the shell parses it.
+  it('reads the body through env, never interpolated into the shell', () => {
+    expect(step.env.PR_BODY).toBe('${{ github.event.pull_request.body }}')
+    expect(step.env.BASE_SHA).toBe('${{ github.event.pull_request.base.sha }}')
+    expect(step.run).not.toContain('github.event.pull_request.body')
+  })
+
+  it('is a real package script', () => {
+    expect(packageScripts['check:flipped-test-assertions']).toBe(
+      'node config/scripts/check-flipped-test-assertions.mjs'
+    )
+  })
+})

--- a/config/scripts/git-pull-request-diff-base.mjs
+++ b/config/scripts/git-pull-request-diff-base.mjs
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import process from 'node:process'
 
 export function selectPullRequestDiffBase(requestedBase, headParents, eventName) {
@@ -20,4 +20,27 @@ export function resolvePullRequestDiffBase(
     .trim()
     .split(/\s+/)
   return selectPullRequestDiffBase(requestedBase, headParents, eventName)
+}
+
+// Shared by every changed-code gate: the first candidate that names a real commit.
+// ORCA_CODE_QUALITY_BASE stays supported so one override still steers all of them.
+export function resolveExistingDiffBase(root, requestedBase) {
+  for (const candidate of [
+    requestedBase,
+    process.env.ORCA_CODE_QUALITY_BASE,
+    'origin/main',
+    'main'
+  ]) {
+    if (!candidate) {
+      continue
+    }
+    const result = spawnSync('git', ['rev-parse', '--verify', `${candidate}^{commit}`], {
+      cwd: root,
+      stdio: 'ignore'
+    })
+    if (result.status === 0) {
+      return candidate
+    }
+  }
+  throw new Error('Pass the pull request base SHA or make origin/main available locally.')
 }

--- a/config/scripts/test-expectation-flip-heuristics.mjs
+++ b/config/scripts/test-expectation-flip-heuristics.mjs
@@ -1,0 +1,195 @@
+// The four diff shapes that mean an EXISTING test stopped asserting what it used to, in
+// the two areas where a silently-rewritten expectation shipped a user-visible break
+// (#19542/#19684): the Playwright suite that does not gate PRs, and the orchestration RPC
+// methods. A renamed title, a success path turned into an error expectation, a populated
+// expectation emptied, and an enabled test turned into .skip/.fixme.
+//
+// Deliberately hunk-scoped and textual. Known false negatives: a test deleted in one hunk
+// and re-added in another reads as an unrelated delete plus add, and a test DELETED
+// outright has no addition to pair with, so neither is flagged. Renames are
+// direction-blind, so restoring an old title is flagged too. Each costs one PR-body
+// paragraph, which is the whole price of the gate.
+//
+// The CLI, the escape hatch and the exit codes live in check-flipped-test-assertions.mjs.
+
+export const SCOPED_DIRECTORIES = ['tests/e2e/', 'src/main/runtime/rpc/methods/orchestration/']
+const TEST_FILE_PATTERN = /\.(?:spec\.ts|test\.ts|test\.mjs)$/
+const HUNK_HEADER_PATTERN = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/
+const TEST_TITLE_PATTERN = /\b(?:test|it|describe)((?:\.[\w$]+)*)\s*\(\s*(['"`])([^'"`]*)\2/
+// `.only` is not a disable: it narrows a run, it does not stop asserting.
+const DISABLING_MODIFIER = /^(?:skip|fixme)$/
+const DISABLED_CALL = /\.(?:skip|fixme)\s*\(/
+// `toBeInstanceOf(Error)` and `toBeInstanceOf(RuntimeRpcFailureError)` both count.
+const FAILURE_EXPECTATION = /toThrow|\.rejects\b|toBeInstanceOf\(\s*\w*Error\b/
+// The removed side of a flip: the line that consumed a successful result.
+const SUCCESS_PATH = /expect\(|await\s/
+const EMPTY_EXPECTATION =
+  /\.toEqual\(\s*[[{]\s*[\]}]\s*\)|\.toHaveLength\(\s*0\s*\)|\.toBeNull\(\s*\)|\.toBeUndefined\(\s*\)/
+const NON_EMPTY_EXPECTATION =
+  /toMatchObject|toContain|\.toHaveLength\(\s*[1-9]|\.toEqual\(\s*[[{](?!\s*[\]}]\s*\))/
+
+export function isScopedTestFile(file) {
+  return (
+    SCOPED_DIRECTORIES.some((prefix) => file.startsWith(prefix)) && TEST_FILE_PATTERN.test(file)
+  )
+}
+
+export function parseUnifiedDiffHunks(diff) {
+  const hunks = []
+  let file = null
+  let hunk = null
+  let newLine = 0
+  for (const raw of diff.split(/\r?\n/)) {
+    if (raw.startsWith('+++ ')) {
+      const target = raw.slice(4).trim()
+      file = target === '/dev/null' ? null : target.replace(/^b\//, '')
+      hunk = null
+      continue
+    }
+    if (raw.startsWith('--- ')) {
+      continue
+    }
+    const header = HUNK_HEADER_PATTERN.exec(raw)
+    if (header) {
+      newLine = Number.parseInt(header[1], 10)
+      hunk = file === null ? null : { file, added: [], removed: [] }
+      if (hunk !== null) {
+        hunks.push(hunk)
+      }
+      continue
+    }
+    if (hunk === null) {
+      continue
+    }
+    if (raw.startsWith('+')) {
+      hunk.added.push({ line: newLine, text: raw.slice(1) })
+      newLine += 1
+    } else if (raw.startsWith('-')) {
+      hunk.removed.push({ line: newLine, text: raw.slice(1) })
+    } else if (!raw.startsWith('\\')) {
+      newLine += 1
+    }
+  }
+  return hunks
+}
+
+function codeLines(lines) {
+  return lines.filter(({ text }) => !/^\s*(?:\/\/|\/\*|\*)/.test(text))
+}
+
+export function extractTestTitles(lines) {
+  const titles = []
+  for (const { line, text } of codeLines(lines)) {
+    const match = TEST_TITLE_PATTERN.exec(text)
+    if (match) {
+      const modifiers = match[1].split('.').filter(Boolean)
+      titles.push({
+        line,
+        title: match[3],
+        text,
+        disabled: modifiers.some((modifier) => DISABLING_MODIFIER.test(modifier))
+      })
+    }
+  }
+  return titles
+}
+
+export function findRenamedTests(hunk) {
+  const removed = extractTestTitles(hunk.removed)
+  const added = extractTestTitles(hunk.added)
+  const removedTitles = new Set(removed.map((entry) => entry.title))
+  const addedTitles = new Set(added.map((entry) => entry.title))
+  const dropped = removed.filter((entry) => !addedTitles.has(entry.title))
+  const introduced = added.filter((entry) => !removedTitles.has(entry.title))
+  return dropped.slice(0, introduced.length).map((entry, index) => ({
+    file: hunk.file,
+    line: introduced[index].line,
+    kind: 'renamed test',
+    removed: entry.title,
+    added: introduced[index].title
+  }))
+}
+
+// A test turned off still reads as a passing suite, which is how a known-broken
+// expectation survives review. Unskipping is not flagged; a new skipped test is not
+// either, because there is no earlier expectation it stops enforcing.
+export function findDisabledTests(hunk) {
+  const enabledByTitle = new Map(
+    extractTestTitles(hunk.removed)
+      .filter((entry) => !entry.disabled)
+      .map((entry) => [entry.title, entry])
+  )
+  // Fallback for a title that sits on its own line: any removed line that is not itself
+  // a skip and still mentions the title counts as the enabled predecessor.
+  const enabledLines = codeLines(hunk.removed).filter(({ text }) => !DISABLED_CALL.test(text))
+  const findings = []
+  for (const entry of extractTestTitles(hunk.added)) {
+    if (!entry.disabled) {
+      continue
+    }
+    const predecessor =
+      enabledByTitle.get(entry.title) ??
+      enabledLines.find(({ text }) => entry.title !== '' && text.includes(entry.title))
+    if (predecessor) {
+      findings.push({
+        file: hunk.file,
+        line: entry.line,
+        kind: 'test disabled',
+        removed: predecessor.text.trim(),
+        added: entry.text.trim()
+      })
+    }
+  }
+  return findings
+}
+
+export function findFlippedToFailure(hunk) {
+  const removed = codeLines(hunk.removed).find(
+    ({ text }) => SUCCESS_PATH.test(text) && !FAILURE_EXPECTATION.test(text)
+  )
+  const added = codeLines(hunk.added).find(({ text }) => FAILURE_EXPECTATION.test(text))
+  if (!removed || !added) {
+    return []
+  }
+  return [
+    {
+      file: hunk.file,
+      line: added.line,
+      kind: 'flipped to expect-failure',
+      removed: removed.text.trim(),
+      added: added.text.trim()
+    }
+  ]
+}
+
+export function findEmptiedExpectations(hunk) {
+  const removed = codeLines(hunk.removed).find(({ text }) => NON_EMPTY_EXPECTATION.test(text))
+  const added = codeLines(hunk.added).find(({ text }) => EMPTY_EXPECTATION.test(text))
+  if (!removed || !added) {
+    return []
+  }
+  return [
+    {
+      file: hunk.file,
+      line: added.line,
+      kind: 'expectation emptied',
+      removed: removed.text.trim(),
+      added: added.text.trim()
+    }
+  ]
+}
+
+export function collectFindings(diff) {
+  return parseUnifiedDiffHunks(diff)
+    .filter((hunk) => isScopedTestFile(hunk.file))
+    .flatMap((hunk) => [
+      ...findRenamedTests(hunk),
+      ...findDisabledTests(hunk),
+      ...findFlippedToFailure(hunk),
+      ...findEmptiedExpectations(hunk)
+    ])
+}
+
+export function formatFinding(finding) {
+  return `${finding.file}:${finding.line}: ${finding.kind}: ${finding.removed} → ${finding.added}`
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "audit:dead-code": "pnpm dlx knip@5.88.1 --config config/knip.json",
     "check:code-quality:changed": "node config/scripts/check-changed-code-quality.mjs",
     "check:react-doctor:changed": "node config/scripts/check-react-doctor-changed.mjs",
+    "check:flipped-test-assertions": "node config/scripts/check-flipped-test-assertions.mjs",
     "check:zustand-selector-fanout": "node config/scripts/zustand-selector-fanout-benchmark.mjs --check",
     "doctor": "pnpm dlx react-doctor@0.9.1 . --no-telemetry",
     "lint:react-doctor": "oxlint --config config/oxlint-react-doctor.json",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​632 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​632 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​369 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​345 |

<!-- /orca-pr-loc -->

## What the user notices

**Before:** #19542 deleted the four `?? LEGACY_RUN_ID` write fallbacks and `orca orchestration send --to <handle>` between two plain terminals started failing with `Run is required` — the first command the orchestration skill guide teaches. The e2e test that already covered it (`tests/e2e/orchestration-idle-mail-delivery.spec.ts`, "keeps unbound direct mail durable", since #12584) went red on main's scheduled run twice. #19684 then renamed that test to "refuses unbound direct mail", replaced the stored-row assertion with an error assertion and an `expect(readMailbox(...)).toEqual([])`, and merged as a test-only change with green CI. Hours later users reported "orchestration stopped working after updating". No PR-time check had an opinion, because "the test now expects the opposite" is not a lint finding, not a type error, and not a red suite.

**After:** that same PR fails `static analysis` on the PR, with:

```
tests/e2e/orchestration-idle-mail-delivery.spec.ts:357: renamed test: keeps unbound direct mail durable without pointing to an unsafe check → refuses unbound direct mail from a sender in no Run instead of pushing it
tests/e2e/orchestration-idle-mail-delivery.spec.ts:375: flipped to expect-failure: const messageId = await sendMail(client, pane.handle, { subject: 'Unbound direct mail' }) → expect(refusal).toBeInstanceOf(RuntimeRpcFailureError)
tests/e2e/orchestration-idle-mail-delivery.spec.ts:399: expectation emptied: expect(readMailRow(userDataDir, messageId)).toMatchObject({ → expect(readMailbox(userDataDir, pane.handle)).toEqual([])
```

and the instruction to add a `## User-visible change` section with `Before:` / `After:` lines. Writing those two lines for #19684 forces the author to state, in the PR body, that sending between two plain terminals no longer works — which is exactly the sentence nobody wrote. The cheaper way out of a red test — `test.skip` — is flagged the same way, for the same reason.

The gate does not judge whether the flip is right. It requires that someone said out loud what a user will see.

## What it checks

Diff-only, inside `tests/e2e/**` and `src/main/runtime/rpc/methods/orchestration/**`, `*.spec.ts` / `*.test.ts` / `*.test.mjs` only, hunk-scoped (`--unified=0`). Four shapes:

1. **renamed test** — a `test(` / `it(` / `describe(` / `test.describe(` title removed and a different one added in the same hunk.
2. **test disabled** — an added `test.skip(` / `it.skip(` / `test.fixme(` / `it.fixme(` / `describe.skip(` whose title had an enabled predecessor removed in the same hunk (matched on the extracted title, or on any removed non-skip line that still contains the title, which covers a wrapped call with the title on its own line). A test switched off still reads as a green suite, so it is the cheapest way to make a known-broken expectation stop complaining.
3. **flipped to expect-failure** — a line that consumed a successful result (`expect(` or `await `) removed, and a `toThrow` / `.rejects` / `toBeInstanceOf(…Error)` added in the same hunk.
4. **expectation emptied** — `toMatchObject` / `toEqual({…` / `toEqual([…` / `toContain` / `toHaveLength(n>0)` removed, and `.toEqual([])` / `.toEqual({})` / `.toHaveLength(0)` / `.toBeNull()` / `.toBeUndefined()` added in the same hunk.

Directions that restore coverage are deliberately **not** flagged: unskipping a test, replacing an error expectation with a value expectation, and dropping `.only`. `.only` is not treated as a disable at all — it narrows a run, it does not stop asserting. A skip that keeps its title reports once, as a disable, not also as a rename. Proven below.

Escape hatch: a `## User-visible change` heading in the PR body with a `Before:` line and an `After:` line before the next heading. The match is exact — `## User-visible changes` (plural), `## User visible change` and `## user-visible change` do **not** satisfy it, so a near miss fails loudly instead of silently excusing a flip. Bulleted and bolded `- **Before:**` forms are accepted.

**Measured cost, not guessed:** replaying the gate over the last 80 first-parent main commits that touch the gated paths, **11 would have been flagged** — 10 for a renamed title only, and #19684 as the only one hitting three kinds at once. Zero `test disabled` findings in that window, so the fourth heuristic adds no noise on real history. Roughly one PR in seven pays one paragraph.

## The delete question

- `resolveBase` is **deleted** from `check-changed-code-quality.mjs` and moved into the shared `git-pull-request-diff-base.mjs` as `resolveExistingDiffBase`. Both changed-code gates now resolve their base through one function instead of two copies; `check-changed-code-quality.mjs` shrinks from 370 to 352 lines.
- The four diff-shape rules live in `test-expectation-flip-heuristics.mjs`; `check-flipped-test-assertions.mjs` is the CLI and the escape hatch, 134 lines. Neither file needs a `max-lines` bump and neither is named for a role.
- No new job, no new runner, no new `verify.needs` entry: the check is a step in `static_analysis`, which is already in `verify.needs`, already runs for every non-docs PR (it is in `ALWAYS_ON_CODE_JOBS`), and already checks out full history for the merge-base diff the sibling gate needs.
- Nothing else could be removed. The gate covers a class no existing check has any signal for; `check-changed-code-quality.mjs` reads oxlint diagnostics, not diff semantics, so extending it would have meant a second unrelated pass inside a script already near its budget.

## Proof

All commands run in the branch worktree. Scratch state was local only and is deleted.

### 1. The real #19684 diff, with the real #19684 body → red

```
$ git diff 750e6ffada^ 750e6ffada --unified=0 --no-color > /tmp/19684.diff
$ PR_BODY="$(cat pr-19684-original-body.md)" \
    node config/scripts/check-flipped-test-assertions.mjs --diff-file /tmp/19684.diff --require-body
exit=1
tests/e2e/orchestration-idle-mail-delivery.spec.ts:357: renamed test: keeps unbound direct mail durable without pointing to an unsafe check → refuses unbound direct mail from a sender in no Run instead of pushing it
tests/e2e/orchestration-idle-mail-delivery.spec.ts:375: flipped to expect-failure: const messageId = await sendMail(client, pane.handle, { subject: 'Unbound direct mail' }) → expect(refusal).toBeInstanceOf(RuntimeRpcFailureError)
tests/e2e/orchestration-idle-mail-delivery.spec.ts:399: expectation emptied: expect(readMailRow(userDataDir, messageId)).toMatchObject({ → expect(readMailbox(userDataDir, pane.handle)).toEqual([])

This change rewrites or disables what an existing test expects. If that is intentional,
the product behaviour it pins changed too, so say what a user sees. Add this to the PR body:

  ## User-visible change
  Before: <what the user got with the old expectation>
  After: <what the user gets now>

If nothing user-visible changed, the test is asserting something the product still does
not do — restore the old expectation instead of the section.
```

### 2. Same diff, body plus the section → green

```
$ PR_BODY="$(cat body-with-section.md)" \
    node config/scripts/check-flipped-test-assertions.mjs --diff-file /tmp/19684.diff --require-body
exit=0
... (same three findings printed) ...
Flipped-assertion gate: 3 rewritten expectation(s), explained by the PR body's "## User-visible change" section.
```

### 3. The live-git path, through the package script, on a scratch branch

Scratch branch `scratch/flipped-assertion-proof` off this branch replayed the #19684 flip on the current spec (rename the title, swap the `sendMail` result for `rejects.toThrow`, swap the `toMatchObject` row assertion for `toEqual([])`), committed locally:

```
$ pnpm run check:flipped-test-assertions -- --require-body aac38d698f
$ node config/scripts/check-flipped-test-assertions.mjs -- --require-body aac38d698f
exit=1
tests/e2e/orchestration-idle-mail-delivery.spec.ts:356: renamed test: keeps unbound direct mail durable without pointing to an unsafe check → refuses unbound direct mail from a sender in no Run
tests/e2e/orchestration-idle-mail-delivery.spec.ts:368: flipped to expect-failure: const messageId = await sendMail(client, pane.handle, { subject: 'Unbound direct mail' }) → await expect(sendMail(client, pane.handle, { subject: 'Unbound direct mail' })).rejects.toThrow(
tests/e2e/orchestration-idle-mail-delivery.spec.ts:377: expectation emptied: expect(readMailRow(userDataDir, messageId)).toMatchObject({ → expect(readMailbox(userDataDir, pane.handle)).toEqual([])
[ELIFECYCLE] Command failed with exit code 1.
```

With `PR_BODY` carrying the section, same branch, same base: `exit=0`, `Flipped-assertion gate: 3 rewritten expectation(s), explained by the PR body's "## User-visible change" section.`

### 4. The reverse direction is not a flip

Diffing the scratch commit back to this branch (i.e. restoring the working assertions):

```
$ node config/scripts/check-flipped-test-assertions.mjs --diff-file /tmp/reverse.diff --require-body
exit=1
tests/e2e/orchestration-idle-mail-delivery.spec.ts:356: renamed test: refuses unbound direct mail from a sender in no Run → keeps unbound direct mail durable without pointing to an unsafe check
```

Zero `flipped to expect-failure` and zero `expectation emptied` findings — restoring behaviour costs nothing on the assertion heuristics. The rename is still reported, because a diff carries no evidence of which title is the older intent; that is the documented direction-blind case and its cost is the same one paragraph. It is also why the real #19696 revert appears in the noise survey above. Unskipping and dropping `.only` are covered by unit tests rather than a branch replay.

### 5. This PR against its own gate

```
$ pnpm run check:flipped-test-assertions -- --require-body aac38d698f
Flipped-assertion gate: no rewritten test expectations in the gated paths.
exit=0
```

## Wire / SSH / folder workspace

- **Wire:** not affected. Nothing here runs in the app, on a host, or over a relay; it is a CI script over a git diff, and it publishes and reads no wire field.
- **SSH:** not affected. The gate never executes a workspace or contacts an execution host, so no liveness verdict is involved.
- **Folder workspace:** not affected. It only reads the repository's own diff; it makes no assumption about the shape of any user workspace, git worktree or folder.
- **Cross-platform:** pure Node plus `git diff`; no shell, no macOS assumption. It runs on `ubuntu-latest` in the `static_analysis` job.

## Known limits (v1, stated on purpose)

Hunk-scoped and textual, so it does not catch: a test **deleted outright** (no addition to pair with) or deleted in one hunk and re-added in another; changing the fixture instead of the assertion; a brand-new test that asserts the wrong thing with nothing to diff against; and any edit outside the two gated path prefixes. See PR5-REPORT.md for the full adversarial list.

## Testing

| Command | Result |
| --- | --- |
| `pnpm tc` | exit 0 (re-run after the amendment) |
| `pnpm test config/scripts/check-flipped-test-assertions.test.mjs` | 61 passed, exit 0 |
| `pnpm test check-flipped-test-assertions.test.mjs check-changed-code-quality.test.mjs pr-e2e-gate-contract.test.mjs` (run 1) | 3 files, 117 passed, exit 0 |
| same three files (run 2, flake check) | 3 files, 117 passed, 412ms, exit 0 |
| `pnpm test pr-workflow-parallelism.test.mjs pr-code-change-scope.test.mjs pr-workflow-lint-parity.test.mjs` | 3 files, 50 passed, exit 0 (other consumers of `static_analysis`) |
| `pnpm run check:code-quality:changed -- aac38d698f` | 0 new findings across 5 changed files, gate passed |
| `pnpm run check:react-doctor:changed -- aac38d698f` | scanned 5 files, 0 issues, exit 0 |
| `pnpm exec oxlint <the five changed .mjs files>` | exit 0, no findings |
| `pnpm exec oxlint --config config/oxlint-react-doctor.json <same>` | exit 0 |
| `pnpm exec oxfmt --write <same> package.json` | no changes |
| `pnpm run check:max-lines-ratchet` | OK — 7 grandfathered suppressions, no new bypasses |
| `git diff --check` | clean |

No lint disables, no `@ts-ignore`, no `@ts-expect-error`. CLI 134 lines, heuristics 195 lines, test 632 lines.
Playwright was not run: this PR adds no spec and changes no product code. E2E coverage of the orchestration path is PR 1 and PR 2's scope.
