### PR TITLE
ci: run and block on orchestration e2e for orchestration-source PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,14 @@ on:
         description: '"true" when the PR touches SSH execution source; gates the Docker-SSH lane'
         required: false
         type: string
+      artifact_suffix:
+        description: >-
+          Appended to every artifact name this workflow uploads or downloads. A caller that
+          invokes this workflow twice in one run must give the second call a distinct value:
+          upload-artifact fails outright when two jobs in the same run upload one name.
+        required: false
+        default: ''
+        type: string
   workflow_dispatch:
     inputs:
       ref:
@@ -70,7 +78,7 @@ jobs:
       - name: Upload E2E build output
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-build-out
+          name: e2e-build-out${{ inputs.artifact_suffix }}
           path: out/
           # Why: build-relay.mjs writes each relay's marker as `out/relay/<platform>/.version`,
           # and upload-artifact drops dotfiles by default — consumers then fail SSH specs with
@@ -159,7 +167,7 @@ jobs:
       - name: Download E2E build output
         uses: actions/download-artifact@v8
         with:
-          name: e2e-build-out
+          name: e2e-build-out${{ inputs.artifact_suffix }}
           path: out/
 
       # Why: the Electron suite is wall-clock constrained on OSS runners, but
@@ -180,7 +188,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-traces-${{ matrix.shard_name }}
+          name: playwright-traces-${{ matrix.shard_name }}${{ inputs.artifact_suffix }}
           path: test-results/
           retention-days: 7
           if-no-files-found: ignore
@@ -214,7 +222,7 @@ jobs:
       - name: Download E2E build output
         uses: actions/download-artifact@v8
         with:
-          name: e2e-build-out
+          name: e2e-build-out${{ inputs.artifact_suffix }}
           path: out/
 
       - name: Run changed E2E specs
@@ -258,7 +266,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-traces-changed
+          name: playwright-traces-changed${{ inputs.artifact_suffix }}
           path: test-results/
           retention-days: 7
           if-no-files-found: ignore
@@ -301,7 +309,7 @@ jobs:
       - name: Download E2E build output
         uses: actions/download-artifact@v8
         with:
-          name: e2e-build-out
+          name: e2e-build-out${{ inputs.artifact_suffix }}
           path: out/
 
       # Why: this is the release-path proof that the deployed Linux relay keeps
@@ -354,7 +362,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-traces-ssh-docker-watcher-isolation
+          name: playwright-traces-ssh-docker-watcher-isolation${{ inputs.artifact_suffix }}
           path: e2e-traces/
           retention-days: 7
           if-no-files-found: ignore
@@ -396,7 +404,7 @@ jobs:
           native-runtime: electron
       - uses: actions/download-artifact@v8
         with:
-          name: e2e-build-out
+          name: e2e-build-out${{ inputs.artifact_suffix }}
           path: out/
       - name: Start isolated localhost SSH server
         shell: bash
@@ -438,7 +446,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: localhost-ssh-traces
+          name: localhost-ssh-traces${{ inputs.artifact_suffix }}
           path: test-results/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -962,6 +962,11 @@ jobs:
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       test_files: ${{ needs.code_paths.outputs.orchestration_test_files }}
+      # Why: a PR touching orchestration source AND another routed source runs both callers of
+      # e2e.yml in one workflow run, and upload-artifact fails when two jobs upload one name.
+      # Without this the second `build` to finish dies on e2e-build-out and takes a required
+      # check red for a reason unrelated to the PR.
+      artifact_suffix: -orchestration
 
   # Why this is not in verify's needs: it is the first PR-gate run of a harness whose reliability
   # is only known from nightly main runs (20/20 green, 2026-08-09..2026-08-29, p50 3m25s). It

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,6 +43,10 @@ jobs:
       package_windows: ${{ steps.filter.outputs.package_windows }}
       e2e_should_run: ${{ steps.e2e_filter.outputs.should_run }}
       test_files: ${{ steps.e2e_filter.outputs.test_files }}
+      # Named for the job, not `_should_run`, because verify's strict loop derives every
+      # SHOULD_RUN from `code_paths.outputs.<job>`.
+      orchestration_e2e: ${{ steps.e2e_filter.outputs.orchestration_e2e }}
+      orchestration_test_files: ${{ steps.e2e_filter.outputs.orchestration_test_files }}
       ssh_source_changed: ${{ steps.e2e_filter.outputs.ssh_source_changed }}
       native_ime_source_changed: ${{ steps.e2e_filter.outputs.native_ime_source_changed }}
       wsl_source_changed: ${{ steps.e2e_filter.outputs.wsl_source_changed }}
@@ -82,8 +86,16 @@ jobs:
           CHANGED="$(git diff --name-only --diff-filter=AMCR --merge-base "$BASE" "$HEAD")"
           # Source routes are executable contracts so a test can prove exact
           # authorities, exclusions, and sentinels without evaluating workflow shell.
-          TEST_FILES_JSON="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs)"
+          # Why --advisory-specs rather than the full selection: the orchestration specs are
+          # owned by the blocking `orchestration_e2e` job below, and running them in both lanes
+          # would pay for the same 10 specs twice on one PR.
+          TEST_FILES_JSON="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --advisory-specs)"
           echo "test_files=$TEST_FILES_JSON" >> "$GITHUB_OUTPUT"
+          ORCHESTRATION_TEST_FILES_JSON="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --orchestration-specs)"
+          echo "orchestration_test_files=$ORCHESTRATION_TEST_FILES_JSON" >> "$GITHUB_OUTPUT"
+          ORCHESTRATION_E2E="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --orchestration-source)"
+          echo "orchestration_e2e=$ORCHESTRATION_E2E" >> "$GITHUB_OUTPUT"
+          echo "Orchestration E2E specs: $ORCHESTRATION_TEST_FILES_JSON"
           # Why a separate signal: the Docker-SSH lane must trigger on SSH source, not on a
           # spec name surviving in a route's list. Same routes, so the two cannot drift.
           SSH_SOURCE_CHANGED="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --ssh-source)"
@@ -933,6 +945,24 @@ jobs:
       test_files: ${{ needs.code_paths.outputs.test_files }}
       ssh_source_changed: ${{ needs.code_paths.outputs.ssh_source_changed }}
 
+  # Why this one blocks while `e2e` above does not: `e2e` is the whole suite, which is red on
+  # main from specs unrelated to any given PR. This job runs only the 10 orchestration/worker
+  # specs, and those are green on main's scheduled runs. PR #19542 changed orchestration source
+  # only, so it matched no route, ran zero specs, and shipped a "Run is required" failure on
+  # `orca orchestration send` — the first command the orchestration skill guide teaches. The
+  # spec that catches it had existed since #12584 and simply never ran on the PR.
+  orchestration_e2e:
+    name: orchestration e2e (blocking)
+    needs: code_paths
+    if: needs.code_paths.outputs.orchestration_e2e == 'true'
+    # Why: reusable e2e.yml only checkouts, builds, and uploads artifacts.
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha }}
+      test_files: ${{ needs.code_paths.outputs.orchestration_test_files }}
+
   # Why this is not in verify's needs: it is the first PR-gate run of a harness whose reliability
   # is only known from nightly main runs (20/20 green, 2026-08-09..2026-08-29, p50 3m25s). It
   # reports a red X on the PR without blocking, exactly like `e2e` above. Deliberately no
@@ -971,6 +1001,7 @@ jobs:
       - shell_contracts
       - test
       - orcad_browser
+      - orchestration_e2e
       - cross-version-wire
       - managed_hook_node18
       - package
@@ -986,6 +1017,11 @@ jobs:
       # `"$E2E" = success || skipped` after the loop — skipped is the normal
       # result for a path-filtered job and must keep passing, so it has to be
       # checked outside the loop or it would excuse the jobs above.
+      # orchestration_e2e IS in needs, and that is not a contradiction: it runs a
+      # named subset of 10 specs that is green on main's scheduled runs, so it
+      # cannot inherit the whole suite's redness. It fits the strict loop because
+      # its SHOULD_RUN comes from code_paths.outputs.orchestration_e2e, which is
+      # 'true' exactly when the routed orchestration spec list is non-empty.
       - name: Require successful checks
         env:
           CODE_PATHS: ${{ needs.code_paths.result }}
@@ -1007,6 +1043,8 @@ jobs:
           TEST_SHOULD_RUN: ${{ needs.code_paths.outputs.test }}
           ORCAD_BROWSER: ${{ needs.orcad_browser.result }}
           ORCAD_BROWSER_SHOULD_RUN: ${{ needs.code_paths.outputs.orcad_browser }}
+          ORCHESTRATION_E2E: ${{ needs.orchestration_e2e.result }}
+          ORCHESTRATION_E2E_SHOULD_RUN: ${{ needs.code_paths.outputs.orchestration_e2e }}
           CROSS_VERSION_WIRE: ${{ needs.cross-version-wire.result }}
           CROSS_VERSION_WIRE_SHOULD_RUN: ${{ needs.code_paths.outputs.cross-version-wire }}
           MANAGED_HOOK_NODE18: ${{ needs.managed_hook_node18.result }}
@@ -1049,6 +1087,7 @@ jobs:
           check_job shell_contracts "$SHELL_CONTRACTS" "$SHELL_CONTRACTS_SHOULD_RUN"
           check_job test "$TEST" "$TEST_SHOULD_RUN"
           check_job orcad_browser "$ORCAD_BROWSER" "$ORCAD_BROWSER_SHOULD_RUN"
+          check_job orchestration_e2e "$ORCHESTRATION_E2E" "$ORCHESTRATION_E2E_SHOULD_RUN"
           check_job cross-version-wire "$CROSS_VERSION_WIRE" "$CROSS_VERSION_WIRE_SHOULD_RUN"
           check_job managed_hook_node18 "$MANAGED_HOOK_NODE18" "$MANAGED_HOOK_NODE18_SHOULD_RUN"
           check_job package "$PACKAGE" "$PACKAGE_SHOULD_RUN"

--- a/config/scripts/pr-e2e-orchestration-routing.test.mjs
+++ b/config/scripts/pr-e2e-orchestration-routing.test.mjs
@@ -246,4 +246,49 @@ describe('orchestration PR E2E routing', () => {
     }
     expect(e2eWorkflow.jobs['changed-e2e'].if).toBe("inputs.test_files != ''")
   })
+
+  it('gives each caller of e2e.yml its own artifact namespace', () => {
+    // Why: pr.yml now calls e2e.yml twice in one run. upload-artifact fails outright when two
+    // jobs in a run upload one name, so without distinct suffixes a PR touching orchestration
+    // source AND another routed source kills whichever `build` uploads e2e-build-out second --
+    // taking a required check red for a reason that has nothing to do with the PR.
+    const callers = Object.entries(prWorkflow.jobs).filter(
+      ([, job]) => job.uses === './.github/workflows/e2e.yml'
+    )
+    expect(callers.length).toBeGreaterThan(1)
+    const suffixes = callers.map(([, job]) => String(job.with?.artifact_suffix ?? ''))
+    expect(new Set(suffixes).size, `duplicate artifact_suffix among ${suffixes.join(', ')}`).toBe(
+      callers.length
+    )
+    expect(prWorkflow.jobs.orchestration_e2e.with.artifact_suffix).toBe('-orchestration')
+    // The advisory caller keeps the empty default so schedule and dispatch runs, which pass no
+    // inputs at all, land on the same artifact names they always have.
+    expect(prWorkflow.jobs.e2e.with.artifact_suffix).toBeUndefined()
+    expect(e2eWorkflow.on.workflow_call.inputs.artifact_suffix).toMatchObject({
+      required: false,
+      default: '',
+      type: 'string'
+    })
+  })
+
+  it('suffixes every artifact e2e.yml uploads or downloads', () => {
+    // Why every one, not just e2e-build-out: a trace upload that kept a bare name would fail the
+    // job only when a spec fails in both lanes -- a red that appears exactly when the suite is
+    // already telling you something, and hides it.
+    const artifactSteps = Object.values(e2eWorkflow.jobs)
+      .flatMap((job) => job.steps ?? [])
+      .filter((step) => /^actions\/(?:upload|download)-artifact@/.test(step.uses ?? ''))
+    expect(artifactSteps.length).toBeGreaterThan(0)
+    for (const step of artifactSteps) {
+      expect(step.with?.name, JSON.stringify(step.with)).toMatch(
+        /\$\{\{ inputs\.artifact_suffix \}\}$/
+      )
+    }
+    // A concurrency group would serialize or cancel one call against the other; e2e.yml has none
+    // and must not grow one without keying it the same way.
+    expect(e2eWorkflow.concurrency).toBeUndefined()
+    for (const job of Object.values(e2eWorkflow.jobs)) {
+      expect(job.concurrency).toBeUndefined()
+    }
+  })
 })

--- a/config/scripts/pr-e2e-orchestration-routing.test.mjs
+++ b/config/scripts/pr-e2e-orchestration-routing.test.mjs
@@ -1,0 +1,249 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+import {
+  hasOrchestrationE2eChange,
+  ORCHESTRATION_E2E_ROUTE_ID,
+  PR_E2E_SOURCE_ROUTES,
+  selectAdvisoryPrE2eSpecs,
+  selectOrchestrationPrE2eSpecs,
+  selectPrE2eSpecs
+} from './pr-e2e-source-routing.mjs'
+
+const prWorkflow = parse(readFileSync('.github/workflows/pr.yml', 'utf8'))
+const e2eWorkflow = parse(readFileSync('.github/workflows/e2e.yml', 'utf8'))
+const filterStep = prWorkflow.jobs.code_paths.steps.find((step) => step.id === 'e2e_filter')
+const verifyStep = prWorkflow.jobs.verify.steps.find(
+  (step) => step.name === 'Require successful checks'
+)
+const route = PR_E2E_SOURCE_ROUTES.find((candidate) => candidate.id === ORCHESTRATION_E2E_ROUTE_ID)
+
+/** One product-source file per prefix the route claims authority over. */
+const ROUTED_SOURCES = [
+  'src/main/runtime/orchestration/db/messages/message-insert.ts',
+  'src/main/runtime/orchestration-fleet-agent-status-snapshot.ts',
+  'src/main/runtime/rpc/methods/orchestration/messaging/send.ts',
+  'src/main/runtime/rpc/orchestration-legacy-mail.ts',
+  'src/cli/handlers/orchestration.ts',
+  'src/cli/handlers/orchestration/send.ts',
+  'src/cli/handlers/orchestration-worker-settlement.ts',
+  'src/cli/specs/orchestration.ts',
+  'src/cli/specs/orchestration-worker-specs.ts',
+  'src/shared/orchestration-check-output.ts',
+  'skill-guides/orchestration.md',
+  'skill-guides/orchestration/references/worker-contract.md'
+]
+
+// The full `git show 98fdbc4adee --name-only` of PR #19542, the change that shipped
+// "Run is required" on `orca orchestration send` between two plain terminals. Frozen on
+// purpose: the whole point of the case is that this exact diff selected zero specs.
+const PR_19542_CHANGED_FILES = [
+  'config/reliability-gates.jsonc',
+  'config/scripts/orchestration-skill-guidance.test.mjs',
+  'skill-guides/orchestration.md',
+  'src/cli/bundled-skill-guides.ts',
+  'src/main/runtime/orca-runtime-subscribe-to-terminal-resize.ts',
+  'src/main/runtime/orca-runtime-tests/lineage-and-scan-cache-part-05.spec.ts',
+  'src/main/runtime/orca-runtime-tests/mobile-creation-and-orchestration-part-02.spec.ts',
+  'src/main/runtime/orca-runtime-tests/terminal-output-and-worker-recovery-part-04.spec.ts',
+  'src/main/runtime/orchestration-messages-fake-parity.test.ts',
+  'src/main/runtime/orchestration/coordinator-decision-gates.test.ts',
+  'src/main/runtime/orchestration/coordinator-dispatch-unobserved-prompt.test.ts',
+  'src/main/runtime/orchestration/coordinator-drift-probe-coalescing.test.ts',
+  'src/main/runtime/orchestration/coordinator-escalation-triage.test.ts',
+  'src/main/runtime/orchestration/coordinator-stale-base-flag.test.ts',
+  'src/main/runtime/orchestration/coordinator.test.ts',
+  'src/main/runtime/orchestration/db-empty-dispatch-shortcircuit.benchmark.test.ts',
+  'src/main/runtime/orchestration/db-heartbeat-straggler-guard.test.ts',
+  'src/main/runtime/orchestration/db-message-timestamp.test.ts',
+  'src/main/runtime/orchestration/db-messages.test.ts',
+  'src/main/runtime/orchestration/db-task-create-readiness.test.ts',
+  'src/main/runtime/orchestration/db-task-dispatch-invariant.test.ts',
+  'src/main/runtime/orchestration/db-task-dispatch-lifecycle-guards.test.ts',
+  'src/main/runtime/orchestration/db-task-dispatch-races.test.ts',
+  'src/main/runtime/orchestration/db-undelivered-mailboxes.test.ts',
+  'src/main/runtime/orchestration/db.test.ts',
+  'src/main/runtime/orchestration/db/attempt-outcome-projection.test.ts',
+  'src/main/runtime/orchestration/db/contract-constants.ts',
+  'src/main/runtime/orchestration/db/decision-gate-lifecycle.test.ts',
+  'src/main/runtime/orchestration/db/decision-gates/decision-gate-store.ts',
+  'src/main/runtime/orchestration/db/dispatch-depth.test.ts',
+  'src/main/runtime/orchestration/db/dispatch-mailbox-consumer-fencing.test.ts',
+  'src/main/runtime/orchestration/db/dispatch-row-writer.ts',
+  'src/main/runtime/orchestration/db/federation/federated-dispatch-observation-fence.test.ts',
+  'src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-create.ts',
+  'src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-release.test.ts',
+  'src/main/runtime/orchestration/db/lifecycle-transition.test.ts',
+  'src/main/runtime/orchestration/db/messages/message-insert.ts',
+  'src/main/runtime/orchestration/db/schema/create-graph-tables-sql.ts',
+  'src/main/runtime/orchestration/db/schema/federated-home-run-migration.test.ts',
+  'src/main/runtime/orchestration/db/schema/migrate-v40.ts',
+  'src/main/runtime/orchestration/db/schema/migrate.ts',
+  'src/main/runtime/orchestration/db/tasks/task-store.ts',
+  'src/main/runtime/orchestration/db/writer-run-required.test.ts',
+  'src/main/runtime/orchestration/dispatch-failure-idempotency.test.ts',
+  'src/main/runtime/orchestration/failed-start-terminal-adoption.test.ts',
+  'src/main/runtime/orchestration/federation-acknowledgment-integrity.test.ts',
+  'src/main/runtime/orchestration/federation-control-message.ts',
+  'src/main/runtime/orchestration/lifecycle-caller-edges.test.ts',
+  'src/main/runtime/orchestration/lifecycle-reconciliation.test.ts',
+  'src/main/runtime/orchestration/lightweight-run-worker-exit-escalation.test.ts',
+  'src/main/runtime/orchestration/mailbox-pointer-eligibility.test.ts',
+  'src/main/runtime/orchestration/mailbox-pointer-stage.test.ts',
+  'src/main/runtime/orchestration/mailbox-pointer-submit.test.ts',
+  'src/main/runtime/orchestration/message-batch-atomicity.test.ts',
+  'src/main/runtime/orchestration/nested-worker-depth-migration.test.ts',
+  'src/main/runtime/orchestration/orchestration-adopted-run-binding.test.ts',
+  'src/main/runtime/orchestration/orchestration-all-start-versions-migration.test.ts',
+  'src/main/runtime/orchestration/orchestration-db-retention-pagination.test.ts',
+  'src/main/runtime/orchestration/orchestration-federated-legacy-probe.test.ts',
+  'src/main/runtime/orchestration/orchestration-legacy-storage-test-fixture.ts',
+  'src/main/runtime/orchestration/orchestration-mutation-question-db.test.ts',
+  'src/main/runtime/orchestration/orchestration-schema-version-skew.ts',
+  'src/main/runtime/orchestration/orchestration-settled-worker-resume-fence-db.test.ts',
+  'src/main/runtime/orchestration/orchestration-version-skew-migration.test.ts',
+  'src/main/runtime/orchestration/orchestration-worker-dispatch-db.test.ts',
+  'src/main/runtime/orchestration/r1-identity-migration.test.ts',
+  'src/main/runtime/orchestration/types.ts',
+  'src/main/runtime/orchestration/worker-start-unobserved-prompt-settlement.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federated-message-targeting.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federated-release-safety.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federation-agent-launch.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federation-control-mail.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federation-folder-placement.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federation-lifecycle-settlement.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federation-liveness-verdict.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federation-setup.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federation-start-prompt-budget.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federation-start-schema.ts',
+  'src/main/runtime/rpc/methods/orchestration/federation/federation.ts',
+  'src/main/runtime/rpc/methods/orchestration/messaging/check-worker-federated-attachment.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/messaging/check-worker.ts',
+  'src/main/runtime/rpc/methods/orchestration/runs/migration-behavior.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/worker/failed-start-residual-terminal.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/worker/legacy-dispatch-projection.test.ts',
+  'src/main/runtime/rpc/methods/orchestration/worker/manual-dispatch-observation.test.ts',
+  'src/main/runtime/rpc/methods/structured-worker-stop-receipt.test.ts',
+  'src/main/runtime/rpc/orchestration-11745-regression-verification.test.ts',
+  'src/main/runtime/rpc/orchestration-legacy-compatibility-dispatcher-test-fixture.ts',
+  'src/main/runtime/rpc/orchestration-legacy-coordinator-race.test.ts',
+  'src/main/runtime/rpc/orchestration-legacy-question-takeover.test.ts',
+  'src/main/runtime/rpc/orchestration-legacy-takeover-delivery.test.ts',
+  'src/main/runtime/rpc/orchestration-legacy-takeover-dispatcher.test.ts',
+  'src/main/runtime/rpc/orchestration-mutation-ledger.test.ts',
+  'src/main/runtime/rpc/orchestration-mutation-request-show.test.ts',
+  'src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts',
+  'src/main/runtime/runtime-legacy-worker-terminal-resume-fence.test.ts',
+  'src/main/runtime/runtime-rpc-request-authorization.test.ts',
+  'src/shared/orchestration-fleet-projection.test.ts',
+  'src/shared/orchestration-fleet-worker-projection.ts'
+]
+
+describe('orchestration PR E2E routing', () => {
+  it('routes every orchestration source prefix at the full spec list', () => {
+    for (const source of ROUTED_SOURCES) {
+      expect(selectPrE2eSpecs([source]), source).toEqual(route.specs)
+    }
+  })
+
+  it('leaves orchestration unit tests off the lane they cannot regress', () => {
+    // Why: those files are the bulk of an orchestration PR's diff. Routing them would put a
+    // 10-spec Playwright gate on every test-only edit, the cost the filter exists to avoid --
+    // and #19542 proved the unit layer is not what catches this class anyway.
+    for (const source of ROUTED_SOURCES.filter((file) => file.endsWith('.ts'))) {
+      expect(selectPrE2eSpecs([source.replace(/\.ts$/, '.test.ts')]), source).toEqual([])
+    }
+    expect(
+      selectOrchestrationPrE2eSpecs(['src/main/runtime/orchestration/rpc-test-harness.ts'])
+    ).toEqual([])
+    // Named surfaces deliberately NOT made authorities: routing them would run this gate on most
+    // PRs. orca-runtime.ts is the honest gap -- see the PR body.
+    for (const source of [
+      'src/main/runtime/orca-runtime.ts',
+      'src/shared/agents-orchestration-steps.ts'
+    ]) {
+      expect(selectOrchestrationPrE2eSpecs([source]), source).toEqual([])
+    }
+  })
+
+  it('claims every orchestration and worker spec that exists', () => {
+    // Why derived from the directory: a new orchestration spec nobody adds to the route is a
+    // spec the blocking gate never runs, which is the #19542 shape again.
+    const onDisk = readdirSync('tests/e2e')
+      .filter((file) => file.endsWith('.spec.ts') && /orchestration|worker/i.test(file))
+      .map((file) => `tests/e2e/${file}`)
+      .sort()
+    expect(onDisk.length).toBeGreaterThan(0)
+    expect([...route.specs].sort()).toEqual(onDisk)
+  })
+
+  it('selects the orchestration specs from the #19542 diff that selected none', () => {
+    expect(selectOrchestrationPrE2eSpecs(PR_19542_CHANGED_FILES)).toEqual(route.specs)
+    expect(hasOrchestrationE2eChange(PR_19542_CHANGED_FILES)).toBe(true)
+    // The single file whose deletion caused the user-visible break, on its own.
+    expect(
+      hasOrchestrationE2eChange(['src/main/runtime/orchestration/db/messages/message-insert.ts'])
+    ).toBe(true)
+    expect(hasOrchestrationE2eChange(['src/main/git/git-status.ts'])).toBe(false)
+  })
+
+  it('runs each selected spec in exactly one of the two lanes', () => {
+    // Why partition rather than "advisory minus source-matched": editing an orchestration spec
+    // alone selects it with no source match, and keying the split on source would drop it from
+    // the advisory list without ever adding it to the blocking one.
+    const specEdit = ['tests/e2e/orchestration-idle-mail-delivery.spec.ts']
+    expect(selectOrchestrationPrE2eSpecs(specEdit)).toEqual(specEdit)
+    expect(selectAdvisoryPrE2eSpecs(specEdit)).toEqual([])
+    const mixed = [...specEdit, 'tests/e2e/active-view-restart-restore.spec.ts']
+    expect(selectAdvisoryPrE2eSpecs(mixed)).toEqual([
+      'tests/e2e/active-view-restart-restore.spec.ts'
+    ])
+    for (const changed of [PR_19542_CHANGED_FILES, specEdit, mixed]) {
+      expect(
+        [...selectAdvisoryPrE2eSpecs(changed), ...selectOrchestrationPrE2eSpecs(changed)].sort()
+      ).toEqual(selectPrE2eSpecs(changed))
+    }
+  })
+
+  it('blocks verify on the orchestration lane while the whole suite stays advisory', () => {
+    expect(prWorkflow.jobs.verify.needs).toContain('orchestration_e2e')
+    expect(prWorkflow.jobs.verify.needs).not.toContain('e2e')
+    expect(verifyStep.env.ORCHESTRATION_E2E).toBe('${{ needs.orchestration_e2e.result }}')
+    expect(verifyStep.env.ORCHESTRATION_E2E_SHOULD_RUN).toBe(
+      '${{ needs.code_paths.outputs.orchestration_e2e }}'
+    )
+    expect(verifyStep.run).toContain(
+      'check_job orchestration_e2e "$ORCHESTRATION_E2E" "$ORCHESTRATION_E2E_SHOULD_RUN"'
+    )
+  })
+
+  it('feeds the blocking job only the orchestration specs', () => {
+    const job = prWorkflow.jobs.orchestration_e2e
+    expect(job.uses).toBe('./.github/workflows/e2e.yml')
+    expect(job.if).toBe("needs.code_paths.outputs.orchestration_e2e == 'true'")
+    expect(job.with.test_files).toBe('${{ needs.code_paths.outputs.orchestration_test_files }}')
+    expect(job.with.ref).toBe('${{ github.event.pull_request.head.sha }}')
+    expect(prWorkflow.jobs.code_paths.outputs.orchestration_e2e).toBe(
+      '${{ steps.e2e_filter.outputs.orchestration_e2e }}'
+    )
+    expect(prWorkflow.jobs.code_paths.outputs.orchestration_test_files).toBe(
+      '${{ steps.e2e_filter.outputs.orchestration_test_files }}'
+    )
+    expect(filterStep.run).toContain('pr-e2e-source-routing.mjs --orchestration-specs')
+    expect(filterStep.run).toContain('pr-e2e-source-routing.mjs --orchestration-source')
+    expect(filterStep.run).toContain('pr-e2e-source-routing.mjs --advisory-specs')
+  })
+
+  it('keeps the orchestration specs out of the lane exclusions that would skip them', () => {
+    // Why: changed-e2e drops specs owned by dedicated lanes. An orchestration spec landing in
+    // that jq filter would make the blocking job green without running anything.
+    const changedRun = e2eWorkflow.jobs['changed-e2e'].steps.find(
+      (step) => step.name === 'Run changed E2E specs'
+    )
+    for (const spec of route.specs) {
+      expect(changedRun.run, spec).not.toContain(`!= "${spec}"`)
+    }
+    expect(e2eWorkflow.jobs['changed-e2e'].if).toBe("inputs.test_files != ''")
+  })
+})

--- a/config/scripts/pr-e2e-source-routing.mjs
+++ b/config/scripts/pr-e2e-source-routing.mjs
@@ -12,7 +12,34 @@ const NATIVE_IME_PRODUCT_SOURCE =
 const NATIVE_IME_HARNESS =
   /^(?:config\/scripts\/focus-nested-wayland-terminal\.sh$|config\/scripts\/(?:run-terminal-ibus-hangul-e2e|terminal-ime-engagement-receipt)\.mjs$|tests\/e2e\/terminal-ime-(?:boundary-probe|byte-reader|engagement-receipt)\.ts$|tests\/e2e\/terminal-(?:ibus-hangul|hangul-terminating-digit|macos-2set-korean)-native\.spec\.ts$)/
 
+// Why the skill guides are authorities: the guide is the taught command surface, and #19542
+// changed it in the same commit that broke `orca orchestration send` between plain terminals.
+const ORCHESTRATION_PRODUCT_SOURCE =
+  /^(?:src\/main\/runtime\/(?:orchestration[/-]|rpc\/(?:methods\/orchestration\/|orchestration-))|src\/cli\/(?:handlers\/orchestration[./-]|specs\/orchestration)|src\/shared\/orchestration-|skill-guides\/orchestration(?:\.md$|\/))/
+
 export const PR_E2E_SOURCE_ROUTES = [
+  {
+    // Why this route exists: #19542 changed only orchestration source, matched no route, ran
+    // zero specs, and shipped a "Run is required" failure on the first command the
+    // orchestration skill guide teaches. The spec that catches it had existed since #12584.
+    id: 'orchestration.runtime-and-cli',
+    specs: [
+      'tests/e2e/completed-worker-retirement-resume.spec.ts',
+      'tests/e2e/orchestration-idle-mail-delivery.spec.ts',
+      'tests/e2e/orchestration-idle-mail-restore.spec.ts',
+      'tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts',
+      'tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts',
+      'tests/e2e/orchestration-low-level-dispatch-release.spec.ts',
+      'tests/e2e/orchestration-worker-settlement-release-cli.spec.ts',
+      'tests/e2e/orchestration-worker-terminal-visibility.spec.ts',
+      'tests/e2e/orchestration-worker-transcript-providers.spec.ts',
+      'tests/e2e/settled-worker-tab-survives-restart.spec.ts'
+    ],
+    matches: (file) =>
+      isProductSource(file) &&
+      !file.endsWith('-test-harness.ts') &&
+      ORCHESTRATION_PRODUCT_SOURCE.test(file)
+  },
   {
     id: 'ssh.localhost-agent-hooks',
     specs: ['tests/e2e/ssh-localhost.spec.ts'],
@@ -228,6 +255,32 @@ export function selectPrE2eSpecs(changedPaths, reportRoute = () => undefined) {
   return [...specs].sort((left, right) => left.localeCompare(right))
 }
 
+export const ORCHESTRATION_E2E_ROUTE_ID = 'orchestration.runtime-and-cli'
+
+const orchestrationOwnedSpecs = () =>
+  new Set(
+    PR_E2E_SOURCE_ROUTES.find((route) => route.id === ORCHESTRATION_E2E_ROUTE_ID)?.specs ?? []
+  )
+
+// Why partitioned by spec rather than by "did orchestration source change", the way
+// hasSshSourceChange is: editing one of these specs alone selects it through the changed-spec
+// rule, with no source match. Keying the blocking lane on source would drop that spec from the
+// advisory lane's list while never adding it to the blocking one, so it would run nowhere.
+export function selectOrchestrationPrE2eSpecs(changedPaths) {
+  const owned = orchestrationOwnedSpecs()
+  return selectPrE2eSpecs(changedPaths).filter((spec) => owned.has(spec))
+}
+
+/** Everything the advisory `e2e` job still owns: the full selection minus the blocking lane's. */
+export function selectAdvisoryPrE2eSpecs(changedPaths) {
+  const owned = orchestrationOwnedSpecs()
+  return selectPrE2eSpecs(changedPaths).filter((spec) => !owned.has(spec))
+}
+
+export function hasOrchestrationE2eChange(changedPaths) {
+  return selectOrchestrationPrE2eSpecs(changedPaths).length > 0
+}
+
 /** Routes whose authorities are SSH execution source, and so require the Docker-SSH lane. */
 export const SSH_SOURCE_ROUTE_IDS = ['ssh-terminal-source', 'ssh-workspace-session-restore']
 
@@ -252,10 +305,12 @@ export function hasNativeImeSourceChange(changedPaths) {
 }
 
 export function shouldRunReusablePrE2e(changedPaths) {
-  // Native IME has its own workflow; SSH still runs inside the reusable workflow.
+  // Native IME has its own workflow; SSH still runs inside the reusable workflow. The
+  // orchestration specs have their own blocking call of the same workflow, so an
+  // orchestration-only PR must not also start the advisory one with an empty list.
   return (
     hasSshSourceChange(changedPaths) ||
-    selectPrE2eSpecs(changedPaths).some(
+    selectAdvisoryPrE2eSpecs(changedPaths).some(
       (spec) => spec !== 'tests/e2e/terminal-ibus-hangul-native.spec.ts'
     )
   )
@@ -277,6 +332,12 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   const changedPaths = input.split(/\r?\n/).filter(Boolean)
   if (process.argv.includes('--ssh-source')) {
     process.stdout.write(`${hasSshSourceChange(changedPaths)}\n`)
+  } else if (process.argv.includes('--orchestration-source')) {
+    process.stdout.write(`${hasOrchestrationE2eChange(changedPaths)}\n`)
+  } else if (process.argv.includes('--orchestration-specs')) {
+    process.stdout.write(`${JSON.stringify(selectOrchestrationPrE2eSpecs(changedPaths))}\n`)
+  } else if (process.argv.includes('--advisory-specs')) {
+    process.stdout.write(`${JSON.stringify(selectAdvisoryPrE2eSpecs(changedPaths))}\n`)
   } else if (process.argv.includes('--reusable-workflow')) {
     process.stdout.write(`${shouldRunReusablePrE2e(changedPaths)}\n`)
   } else if (process.argv.includes('--wsl-source')) {

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -464,6 +464,7 @@ describe('PR workflow parallelism', () => {
       'shell_contracts',
       'test',
       'orcad_browser',
+      'orchestration_e2e',
       'cross-version-wire',
       'managed_hook_node18',
       'package',

--- a/config/scripts/release-e2e-dispatch-contract.test.mjs
+++ b/config/scripts/release-e2e-dispatch-contract.test.mjs
@@ -82,7 +82,11 @@ describe('release E2E dispatch contract', () => {
       (step) => step.name === 'Upload E2E build output'
     )
 
-    expect(uploadStep.with.name).toBe('e2e-build-out')
+    // Compared against the upload rather than a literal: the name carries a per-caller suffix so
+    // two calls of this workflow in one run cannot collide, and what has to hold is that every
+    // download still asks for the artifact this job produced.
+    const buildArtifactName = uploadStep.with.name
+    expect(buildArtifactName).toContain('e2e-build-out')
     expect(uploadStep.with.path).toBe('out/')
 
     for (const [jobName, runStepName] of [
@@ -94,7 +98,7 @@ describe('release E2E dispatch contract', () => {
       const runStep = job.steps.find((step) => step.name === runStepName)
 
       expect(job.needs).toEqual(['build', 'prepare-native-cache'])
-      expect(downloadStep.with.name).toBe('e2e-build-out')
+      expect(downloadStep.with.name).toBe(buildArtifactName)
       expect(downloadStep.with.path).toBe('out/')
       expect(runStep.run).toContain('ORCA_RELAY_PATH="$GITHUB_WORKSPACE/out/relay"')
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​301 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​299 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 |

<!-- /orca-pr-loc -->

## What the user notices

**Before:** A PR that changes only orchestration source merges with zero e2e specs run.
That is what happened to #19542 on 2026-09-08: its e2e job reported `skipping`, it merged, and
`orca orchestration send --to <handle>` between two plain terminals — the first command the
orchestration skill guide teaches — started failing with `Run is required`. Users reported
"orchestration stopped working after updating". The spec that catches it,
`tests/e2e/orchestration-idle-mail-delivery.spec.ts` "keeps unbound direct mail durable", had
existed since #12584 in August. It went red on main's scheduled e2e for two runs, which blocks
nothing, and #19684 then renamed it to "refuses unbound direct mail" and asserted the error —
merged as a test-only change hours before the first user report.

**After:** The same PR selects the 10 orchestration/worker specs, runs them in a new
`orchestration e2e (blocking)` check, and `verify` — the required aggregate — fails if any of
them fails. The author sees a red required check on the PR instead of a user seeing the error
after updating.

## The delete question

Net add. What was deliberately *not* added is where the work went.

- **No new path list.** `hasOrchestrationE2eChange` is derived from the route's own spec list,
  not from a second copy of the prefixes. That is the mistake `hasSshSourceChange`'s comment
  already documents ("two lists that must agree is how that drifted").
- **No special case in `pr-code-change-scope.mjs`.** Naming the `code_paths` output
  `orchestration_e2e` rather than `orchestration_e2e_should_run` means verify's existing strict
  loop — which derives every `<JOB>_SHOULD_RUN` from `code_paths.outputs.<job>` — enforces the
  job with zero new mechanism. The only line added to `verify`'s script is one `check_job` call.
- **No duplicate run.** The advisory `e2e` job's `test_files` is now the selection *minus* this
  lane's specs, so no PR pays for the same 10 specs twice. `selectPrE2eSpecs` is unchanged and
  still the single authority; the two lanes are a partition of its output, and a contract test
  asserts advisory ∪ blocking == the full selection for every case it exercises.
- **One assertion deleted, not added.** `release-e2e-dispatch-contract.test.mjs` pinned the
  literal `e2e-build-out` on the upload *and* on both downloads. Three literals became one
  comparison against the upload's own name, which is what the test was really guarding: upload
  and download must agree. Strictly stronger — a mutant that renames one download still fails it.
- **No `config/reliability-gates.jsonc` entry.** The existing "keeps source-routed sentinels
  registered to their reliability gates" test names five specific gate ids and does not demand
  one per route. Every gate in that manifest is a per-invariant record with an oracle,
  assertion refs, and evidence runs; this change adds no invariant and no spec, so an entry
  would be fabricated provenance. `pnpm run check:reliability-gates` passes unchanged.

## Proof

The gate cannot be executed locally — GitHub Actions is not runnable here — so the proof is in
two halves: the routing output that decides which specs the job runs, and the spec itself going
red on the reintroduced regression. Both were run on a local scratch state that re-applies the
#19542 deletion in `src/main/runtime/orchestration/db/messages/message-insert.ts` (the unbound-Run
`INSERT OR IGNORE` block replaced by `const runId = msg.runId; if (!runId) throw new Error('Run is
required')`), never committed and reverted afterwards with
`git checkout -- src/main/runtime/orchestration/db/messages/message-insert.ts`.

### 1. Routing: the file #19542 broke now selects the orchestration specs

```
$ printf 'src/main/runtime/orchestration/db/messages/message-insert.ts\n' | node config/scripts/pr-e2e-source-routing.mjs
[pr-e2e] orchestration.runtime-and-cli: tests/e2e/completed-worker-retirement-resume.spec.ts, tests/e2e/orchestration-idle-mail-delivery.spec.ts, tests/e2e/orchestration-idle-mail-restore.spec.ts, tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts, tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts, tests/e2e/orchestration-low-level-dispatch-release.spec.ts, tests/e2e/orchestration-worker-settlement-release-cli.spec.ts, tests/e2e/orchestration-worker-terminal-visibility.spec.ts, tests/e2e/orchestration-worker-transcript-providers.spec.ts, tests/e2e/settled-worker-tab-survives-restart.spec.ts
["tests/e2e/completed-worker-retirement-resume.spec.ts","tests/e2e/orchestration-idle-mail-delivery.spec.ts","tests/e2e/orchestration-idle-mail-restore.spec.ts","tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts","tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts","tests/e2e/orchestration-low-level-dispatch-release.spec.ts","tests/e2e/orchestration-worker-settlement-release-cli.spec.ts","tests/e2e/orchestration-worker-terminal-visibility.spec.ts","tests/e2e/orchestration-worker-transcript-providers.spec.ts","tests/e2e/settled-worker-tab-survives-restart.spec.ts"]

$ ... --orchestration-source
true
$ ... --orchestration-specs
["tests/e2e/completed-worker-retirement-resume.spec.ts", ... same 10 ...]
$ ... --advisory-specs
[]
```

`--orchestration-source true` is what turns `code_paths.outputs.orchestration_e2e` into `'true'`,
which is what makes the job run and what verify's strict loop requires to be `success`.
`--advisory-specs []` is the no-duplicate-run half: the advisory `e2e` job does not start.

On `origin/main` today the same input prints `[]` and selects nothing.

### 2. The routed spec is red on the regression

```
$ ORCA_BACKGROUND_LAUNCH=1 npx playwright test tests/e2e/orchestration-idle-mail-delivery.spec.ts \
    --config tests/playwright.config.ts --project electron-headless --workers=1 -g "unbound direct mail"
[e2e] Building Electron app with electron-vite build --mode e2e...
  ✘  1 [electron-headless] › tests/e2e/orchestration-idle-mail-delivery.spec.ts:356:7 › orchestration push-on-idle mail delivery › keeps unbound direct mail durable without pointing to an unsafe check (4.5s)

  1) ... keeps unbound direct mail durable without pointing to an unsafe check

    Error: Run is required Orchestration mutation request ID: c4545dac-d3ad-4d9b-871e-820ac540cc46.

        at RuntimeClient.call (src/cli/runtime/client.ts:172:13)
        at sendMail (tests/e2e/orchestration-idle-mail-delivery.spec.ts:190:16)
        at tests/e2e/orchestration-idle-mail-delivery.spec.ts:368:23

  1 failed
EXIT=1
```

That is the user's error string, produced by the real runtime through the real RPC path — not a
mocked client. (`src/cli/handlers/orchestration.test.ts` and `src/cli/index-orchestration.test.ts`
`vi.mock` the runtime client, which is why the unit layer stayed green through #19542.)

### 3. Same command, same rebuild, after reverting the scratch edit

```
$ git checkout -- src/main/runtime/orchestration/db/messages/message-insert.ts
$ ORCA_BACKGROUND_LAUNCH=1 npx playwright test tests/e2e/orchestration-idle-mail-delivery.spec.ts \
    --config tests/playwright.config.ts --project electron-headless --workers=1 -g "unbound direct mail"
[e2e] Building Electron app with electron-vite build --mode e2e...
  ✓  1 [electron-headless] › tests/e2e/orchestration-idle-mail-delivery.spec.ts:356:7 › ... keeps unbound direct mail durable without pointing to an unsafe check (9.7s)
  1 passed (26.7s)
EXIT=0
```

Both runs rebuilt `out/` (no `SKIP_BUILD`), so neither read a stale bundle.

## Two callers, one run

`pr.yml` now invokes the reusable `e2e.yml` twice. Both invocations start its `build` job, and
`actions/upload-artifact` v4+ **fails** when two jobs in one workflow run upload the same name.
Without a fix, a PR touching orchestration source *and* any other routed source would kill
whichever `build` uploaded `e2e-build-out` second — taking the new required check red for a
reason unrelated to the PR. `playwright-traces-changed` had the same collision when a spec failed
in both lanes.

`e2e.yml` gains an optional `artifact_suffix` `workflow_call` input (default `''`), appended to
every artifact name it uploads or downloads — all nine steps, not only the two that can collide
today. A bare name left behind would fail only when a spec fails in both lanes, i.e. exactly when
the suite is already telling you something, and would hide it.

| Job | Artifact | Suffixed |
|---|---|---|
| `build` | `e2e-build-out` (upload) | yes |
| `e2e` shards, `changed-e2e`, `ssh-docker-watcher-isolation`, `ssh-localhost` | `e2e-build-out` (download ×4) | yes |
| `e2e` shards | `playwright-traces-${{ matrix.shard_name }}` | yes |
| `changed-e2e` | `playwright-traces-changed` | yes |
| `ssh-docker-watcher-isolation` | `playwright-traces-ssh-docker-watcher-isolation` | yes |
| `ssh-localhost` | `localhost-ssh-traces` | yes |

The advisory `e2e` caller passes nothing; `orchestration_e2e` passes `-orchestration`. Schedule
and dispatch runs pass no inputs at all, so they keep the artifact names they have always used.
`e2e.yml` has no `concurrency:` at workflow or job level (confirmed — a group would serialize or
cancel one call against the other), and a contract test now asserts it stays that way. `pr.yml`
holds the only two callers of `e2e.yml` in the repo.

Two new contract tests plus the reworked one, each mutation-checked:

```
$ # mutant: orchestration_e2e drops artifact_suffix
  × gives each caller of e2e.yml its own artifact namespace
    AssertionError: duplicate artifact_suffix among , : expected 1 to be 2

$ # mutant: one trace name loses the suffix
  × suffixes every artifact e2e.yml uploads or downloads
    AssertionError: {"name":"playwright-traces-changed",...}: expected 'playwright-traces-changed' to match /\$\{\{ inputs\.artifact_suffix \}\}$/

$ # mutant: one download drifts from the upload name
  × hands the built relay artifact to every E2E run command
    AssertionError: expected 'e2e-build-out-typo${{ inputs.artifact...' to be 'e2e-build-out${{ inputs.artifact_suff...'
```

`actionlint` resolves the caller/callee input contract, so a typo in the input name is a hard
error rather than a silently ignored `with:` key:

```
$ actionlint .github/workflows/pr.yml     # with `artifact_suffixx:` deliberately typo'd
.github/workflows/pr.yml:969:7: input "artifact_suffixx" is not defined in "./.github/workflows/e2e.yml" reusable workflow. defined inputs are "artifact_suffix", "ref", "ssh_source_changed", "test_files" [workflow-call]
```

## Wire / SSH / folder workspace

- **Remote wire:** not affected. Nothing here changes an RPC param, a stream frame, or what a
  host publishes. It is CI routing plus one workflow job.
- **SSH:** not affected, and deliberately not covered. None of the 10 routed specs runs against an
  SSH host; the Docker-SSH lane is selected by `hasSshSourceChange`, which this change does not
  touch (the new call to `selectAdvisoryPrE2eSpecs` inside `shouldRunReusablePrE2e` sits behind an
  unchanged `hasSshSourceChange(...) ||` short-circuit, so an SSH-source PR still starts the
  reusable workflow even when the advisory list is empty). An orchestration change that only
  breaks on a remote execution host still merges green — see the report.
- **Folder (non-git) workspaces:** not affected. The routed specs use whatever workspace their
  own fixtures build; no new assumption about git worktrees is introduced here.
- **Cross-platform:** the new job runs on `ubuntu-latest` through the existing `e2e.yml`
  `changed-e2e` lane. Nothing added assumes macOS. `orchestration_e2e` is a plain reusable-workflow
  call with no new shell.

## Testing

| Gate | Result |
|---|---|
| `pnpm tc` | `tc EXIT=0` |
| `pnpm test` on the 6 affected test files | run 1: `Test Files 6 passed (6) / Tests 109 passed (109)` |
| same command, second run (flake) | run 2: `Test Files 6 passed (6) / Tests 109 passed (109)` |
| `pnpm test config/scripts` (whole directory) | run 1: `Test Files 184 passed \| 2 skipped (186) / Tests 1539 passed \| 10 skipped (1549)` |
| same, second run (flake) | run 2: `Test Files 184 passed \| 2 skipped (186) / Tests 1539 passed \| 10 skipped (1549)` |
| `pnpm run check:code-quality:changed` | `code quality: 0 new finding(s) across 4 changed file(s). / type-aware code quality: 0 new finding(s) / React Doctor: 0 new finding(s) / Changed-code quality gate passed since aac38d698ff7.` |
| `pnpm run check:react-doctor:changed` | `orca  no score  0 issues` |
| `actionlint .github/workflows/pr.yml .github/workflows/e2e.yml` | `actionlint EXIT=0`, no output (v1.7.12 from Homebrew — **not** present in `node_modules/.bin`) |
| `npx oxlint <changed files>` | `oxlint-exit=0` |
| `npx oxfmt --check <changed files>` | `All matched files use the correct format.` |
| `pnpm run check:max-lines-ratchet` | `max-lines ratchet OK — 7 grandfathered suppression(s), no new bypasses.` |
| `pnpm run check:reliability-gates` | `Reliability gate manifest check passed for 118 gate(s).` |
| `git diff --check` / `git diff --cached --check` | both exit 0 |
| `git status` | clean, nothing untracked |

The changed-code gate caught one real finding on the first pass of the follow-up commit —
`typescript(restrict-template-expressions)` on an array interpolated into an assertion message —
fixed with an explicit `String(...)` + `.join(', ')`; the output above is the re-run.

### The blocking subset, run end to end twice

Both runs: `--project electron-headless --workers=1`, all 10 specs. Run 1 built `out/`; run 2
used `SKIP_BUILD=1` against that build.

| Run | Result |
|---|---|
| 1 (with build) | `1 failed / 23 passed (4.8m)` — `orchestration-idle-mail-delivery.spec.ts:356` |
| 2 (`SKIP_BUILD=1`) | `1 failed / 23 passed (4.6m)` — `completed-worker-retirement-resume.spec.ts:39` |

Both failures are the same shared fixture predicate, not an orchestration assertion:

```
Error: Active terminal pane did not receive a PTY binding
expect(received).not.toBeNull()
Received: null
Call Log:
- Timeout 15000ms exceeded while waiting on the predicate
```

That is `waitForActivePanePtyId` in `tests/e2e/helpers/terminal.ts:87`, a 15s budget on the app's
*first* pane binding, used by 355 call sites across the suite. Follow-up isolation runs:

```
$ ... orchestration-idle-mail-delivery.spec.ts -g "unbound direct mail" --repeat-each=5
  5 passed (42.4s)      EXIT=0

$ ... completed-worker-retirement-resume.spec.ts --repeat-each=3
  4 passed, 1 failed (1.0m)   EXIT=1   (same PTY-binding predicate)
```

The run-1 failure was self-inflicted: `pnpm test config/scripts` (1547 tests) was running
concurrently. The run-2 and repeat failures were not — but this host was at load average 6.5–7.4
on 18 cores with 146 competing Electron/node processes from other agent worktrees, and 261% CPU
already consumed by other work. So: `orchestration-idle-mail-delivery` is 6/6 green here;
`completed-worker-retirement-resume` is 6/8 green here, failing only in the first-pane-binding
wait.

I did **not** quarantine either spec and did **not** widen the shared 15s budget. Quarantining a
spec that is green on CI would delete exactly the coverage this PR exists to add, and raising the
default in `tests/e2e/helpers/terminal.ts` touches 355 call sites whose behaviour I cannot measure
from this change (it would add 15s to every genuinely-failing test in the suite). The evidence
that matters for a gate that runs on `ubuntu-latest` is main's scheduled e2e: across the last four
runs (34380808516, 34284171625, 34255148958, 34165484966) the only orchestration/worker spec that
failed was `orchestration-idle-mail-delivery.spec.ts`, on the two runs before #19696 landed — a
real regression, not flake — and the latest run has zero orchestration failures.
`completed-worker-retirement-resume.spec.ts` has not failed on CI in that window. This is the top
open risk in the report; confirming it against a real CI runner is the user's call. If it does
flake on CI, the fix is at the fixture-budget layer, not here.
