### PR TITLE
test(orchestration): execute the skill guide's taught sequence end to end

### DIFF
--- a/config/scripts/orchestration-guide-command-contract.test.mjs
+++ b/config/scripts/orchestration-guide-command-contract.test.mjs
@@ -1,37 +1,25 @@
-import { readFileSync, readdirSync } from 'node:fs'
-import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { ORCHESTRATION_COMMAND_SPECS } from '../../src/cli/specs/orchestration'
+import { readOrchestrationGuideInvocations } from './orchestration-guide-invocations'
 
-const projectDir = resolve(import.meta.dirname, '../..')
-const guideRoot = join(projectDir, 'skill-guides', 'orchestration')
-const guidePaths = [
-  join(projectDir, 'skill-guides', 'orchestration.md'),
-  ...readdirSync(join(guideRoot, 'references')).map((name) => join(guideRoot, 'references', name))
-]
-
-function documentedInvocations() {
-  return guidePaths.flatMap((path) => {
-    const text = readFileSync(path, 'utf8')
-    return [...text.matchAll(/ORCA orchestration ([a-z-]+)([^`\n]*)/gu)].map((match) => ({
-      path,
-      verb: match[1],
-      flags: [...match[2].matchAll(/(?:^|\s)--([a-z][a-z-]*)/gu)].map((flag) => flag[1])
-    }))
-  })
-}
-
+/**
+ * Kept alongside tests/e2e/orchestration-guide-contract.spec.ts rather than replaced by it:
+ * this runs on every PR in seconds with no build, and it is the only gate that covers the
+ * documented commands the E2E spec cannot execute (legacy takeover, remote placement). The
+ * E2E spec owns the other direction — that the documented sequence still WORKS. Both read
+ * the guide through the same parser so the two cannot disagree about what is documented.
+ */
 describe('orchestration guide command contract', () => {
   it('documents only orchestration verbs and flags accepted by the CLI specs', () => {
     const specs = new Map(
       ORCHESTRATION_COMMAND_SPECS.map((spec) => [spec.path[1], new Set(spec.allowedFlags)])
     )
 
-    for (const invocation of documentedInvocations()) {
+    for (const invocation of readOrchestrationGuideInvocations()) {
       const allowed = specs.get(invocation.verb)
-      expect(allowed, `${invocation.path}: ${invocation.verb}`).toBeDefined()
+      expect(allowed, `${invocation.source}: ${invocation.verb}`).toBeDefined()
       for (const flag of invocation.flags) {
-        expect(allowed, `${invocation.path}: ${invocation.verb} --${flag}`).toContain(flag)
+        expect(allowed, `${invocation.source}: ${invocation.verb} --${flag}`).toContain(flag)
       }
     }
   })

--- a/config/scripts/orchestration-guide-invocations.ts
+++ b/config/scripts/orchestration-guide-invocations.ts
@@ -1,0 +1,65 @@
+/**
+ * The orchestration skill guide's own command list, parsed out of its Markdown.
+ *
+ * Two gates read it and must not drift apart: the static contract test here in
+ * config/scripts (every documented verb/flag is accepted by the CLI specs) and
+ * tests/e2e/orchestration-guide-contract.spec.ts (every documented verb/flag is
+ * actually executed against a live runtime, or explicitly excused).
+ *
+ * `projectDir` is a parameter rather than `import.meta.dirname` because
+ * Playwright transpiles specs to CJS, where `import.meta` is a parse error.
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type GuideInvocation = {
+  /** Absolute path of the guide file this invocation was read from. */
+  source: string
+  verb: string
+  flags: string[]
+}
+
+/** `ORCA` is the guide's placeholder for whichever CLI executable the agent selected. */
+const INVOCATION_PATTERN = /ORCA orchestration ([a-z-]+)([^`\n]*)/gu
+const FLAG_PATTERN = /(?:^|\s)--([a-z][a-z-]*)/gu
+
+export function orchestrationGuidePaths(projectDir: string = process.cwd()): string[] {
+  const referencesDir = join(projectDir, 'skill-guides', 'orchestration', 'references')
+  return [
+    join(projectDir, 'skill-guides', 'orchestration.md'),
+    ...readdirSync(referencesDir)
+      .filter((name) => name.endsWith('.md'))
+      .sort()
+      .map((name) => join(referencesDir, name))
+  ]
+}
+
+export function readOrchestrationGuideInvocations(
+  projectDir: string = process.cwd()
+): GuideInvocation[] {
+  return orchestrationGuidePaths(projectDir).flatMap((source) => {
+    const text = readFileSync(source, 'utf8')
+    return [...text.matchAll(INVOCATION_PATTERN)].map((match) => ({
+      source,
+      verb: match[1] ?? '',
+      flags: [...(match[2] ?? '').matchAll(FLAG_PATTERN)].map((flag) => flag[1] ?? '')
+    }))
+  })
+}
+
+/** The unit both gates count: one `verb --flag` string per documented pair. */
+export function commandPair(verb: string, flag: string): string {
+  return `${verb} --${flag}`
+}
+
+export function documentedOrchestrationCommandPairs(
+  projectDir: string = process.cwd()
+): Set<string> {
+  const pairs = new Set<string>()
+  for (const invocation of readOrchestrationGuideInvocations(projectDir)) {
+    for (const flag of invocation.flags) {
+      pairs.add(commandPair(invocation.verb, flag))
+    }
+  }
+  return pairs
+}

--- a/tests/e2e/helpers/orchestration-guide-cli.ts
+++ b/tests/e2e/helpers/orchestration-guide-cli.ts
@@ -1,0 +1,60 @@
+/**
+ * Runs the guide's argv through the COMPILED CLI (`out/cli/index.js`) against a
+ * live runtime, and records what it ran for the drift gate.
+ *
+ * Why the compiled binary and not the handler modules: every existing CLI test
+ * mocks the runtime client, so the runtime's own refusal is never produced.
+ * #19542 broke exactly there — the params were right and the write threw.
+ *
+ * `as` sets ORCA_TERMINAL_HANDLE rather than adding `--from`, because that is
+ * how the guide's commands run: inside an Orca terminal that resolves the
+ * caller. Passing `--from` everywhere would test an argv the guide never prints.
+ */
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { expect } from '@stablyai/playwright-test'
+import type { GuideCommandLedger } from './orchestration-guide-command-ledger'
+
+export type CliRun = { args: string[]; status: number | null; stdout: string; stderr: string }
+export type OrchestrationCli = (as: string | null, args: string[]) => CliRun
+
+export const COMPILED_CLI_ENTRY = path.join(process.cwd(), 'out', 'cli', 'index.js')
+
+export function createOrchestrationCli(
+  userDataDir: string,
+  ledger: GuideCommandLedger
+): OrchestrationCli {
+  return (as, args) => {
+    ledger.record(args)
+    // Strip an inherited handle so identity comes from `as` alone, never from the shell that ran the suite.
+    const { ORCA_TERMINAL_HANDLE: _inherited, ...cleanEnv } = process.env
+    void _inherited
+    const result = spawnSync(process.execPath, [COMPILED_CLI_ENTRY, ...args], {
+      env: {
+        ...cleanEnv,
+        ORCA_USER_DATA_PATH: userDataDir,
+        ORCA_DEV_CLI_INVOCATION: '1',
+        ...(as ? { ORCA_TERMINAL_HANDLE: as } : {})
+      },
+      encoding: 'utf8',
+      timeout: 120_000
+    })
+    return { args, status: result.status, stdout: result.stdout ?? '', stderr: result.stderr ?? '' }
+  }
+}
+
+export function describeRun(run: CliRun): string {
+  return `orca ${run.args.join(' ')}\nexit=${run.status}\nstdout:\n${run.stdout}\nstderr:\n${run.stderr}`
+}
+
+/** The `{ok, result}` envelope, without asserting the exit code. */
+export function payload<T>(run: CliRun): T {
+  const parsed = JSON.parse(run.stdout) as { ok: boolean; result: T }
+  expect(parsed.ok, describeRun(run)).toBe(true)
+  return parsed.result
+}
+
+export function receipt<T>(run: CliRun): T {
+  expect(run.status, describeRun(run)).toBe(0)
+  return payload<T>(run)
+}

--- a/tests/e2e/helpers/orchestration-guide-command-ledger.ts
+++ b/tests/e2e/helpers/orchestration-guide-command-ledger.ts
@@ -1,0 +1,129 @@
+/**
+ * The drift gate for tests/e2e/orchestration-guide-contract.spec.ts.
+ *
+ * The spec records every `orchestration` argv it runs through the compiled CLI;
+ * this compares that record against the commands the skill guide actually
+ * teaches. Both directions fail the test:
+ *
+ *   - a guide command nobody executed is either newly documented and unproven,
+ *     or the spec stopped covering it — unless it is excused below;
+ *   - a flag the spec executed that no guide file documents means the taught
+ *     path and the tested path have diverged.
+ *
+ * Excuses are per (verb, flag) and each carries the reason it cannot be reached
+ * from one local profile. They are still covered by the static contract test in
+ * config/scripts/orchestration-guide-command-contract.test.mjs, which proves the
+ * CLI specs still accept them.
+ */
+import {
+  commandPair,
+  documentedOrchestrationCommandPairs
+} from '../../../config/scripts/orchestration-guide-invocations'
+
+export type GuideCoverageGaps = {
+  /** Documented by the guide, never executed, and not excused. */
+  unexecuted: string[]
+  /** Executed by the spec, documented by no guide file, and not excused. */
+  undocumented: string[]
+}
+
+type Excuse = { pairs: string[]; reason: string }
+
+const NOT_EXECUTED: Excuse[] = [
+  {
+    pairs: ['worker-start --on', 'worker-start --repo', 'worker-start --setup'],
+    reason:
+      'Remote placement needs a second execution host and a repo selector on it; this spec owns one local profile.'
+  },
+  {
+    pairs: ['worker-start --name', 'worker-start --retry-of', 'worker-start --terminal'],
+    reason:
+      'Each needs state this spec deliberately never reaches: a new worktree to name, a positively-proven failed Dispatch to retry, and an idle pre-existing agent terminal to adopt.'
+  },
+  {
+    pairs: ['worker-start --model', 'worker-start --effort'],
+    reason:
+      'Launch preferences are forwarded only when the worker server advertises support, and the fake agent on PATH takes no model argv, so executing them would assert nothing.'
+  },
+  {
+    pairs: ['run-use --takeover-legacy'],
+    reason:
+      'Takeover fences a live legacy coordinator. Reaching it needs a pre-cutover database; src/main/runtime/orchestration/orchestration-adopted-run-binding.test.ts builds that graph directly.'
+  },
+  {
+    pairs: ['worker-abandon --dispatch', 'worker-abandon --json'],
+    reason:
+      'Abandon fences a Dispatch whose resources may still be live; tests/e2e/orchestration-low-level-dispatch-release.spec.ts already drives it against a live runtime.'
+  }
+]
+
+const NOT_DOCUMENTED: Excuse[] = [
+  {
+    pairs: ['ask --json'],
+    reason:
+      'The guide prints `ask` without `--json` because a worker reads the answer as prose; the spec needs the machine-readable receipt to assert the pending question id and the resumed answer.'
+  }
+]
+
+function expandExcuses(excuses: Excuse[]): Map<string, string> {
+  const byPair = new Map<string, string>()
+  for (const excuse of excuses) {
+    for (const pair of excuse.pairs) {
+      byPair.set(pair, excuse.reason)
+    }
+  }
+  return byPair
+}
+
+export type GuideCommandLedger = {
+  /** `args` is the full CLI argv, e.g. ['orchestration', 'send', '--to', ...]. */
+  record: (args: string[]) => void
+  executedPairs: () => Set<string>
+}
+
+export function createGuideCommandLedger(): GuideCommandLedger {
+  const executed = new Set<string>()
+  return {
+    record: (args) => {
+      if (args[0] !== 'orchestration' || !args[1]) {
+        return
+      }
+      const verb = args[1]
+      for (const arg of args.slice(2)) {
+        if (arg.startsWith('--')) {
+          executed.add(commandPair(verb, arg.slice(2)))
+        }
+      }
+    },
+    executedPairs: () => new Set(executed)
+  }
+}
+
+export function findGuideCoverageGaps(
+  executed: Set<string>,
+  projectDir?: string
+): GuideCoverageGaps {
+  const documented = documentedOrchestrationCommandPairs(projectDir)
+  const excusedUnexecuted = expandExcuses(NOT_EXECUTED)
+  const excusedUndocumented = expandExcuses(NOT_DOCUMENTED)
+  return {
+    unexecuted: [...documented]
+      .filter((pair) => !executed.has(pair) && !excusedUnexecuted.has(pair))
+      .sort(),
+    undocumented: [...executed]
+      .filter((pair) => !documented.has(pair) && !excusedUndocumented.has(pair))
+      .sort()
+  }
+}
+
+/**
+ * An excuse that no longer excuses anything is itself drift: a not-executed entry
+ * for a command the guide dropped, or a not-documented entry for one it adopted.
+ */
+export function findStaleExcuses(projectDir?: string): string[] {
+  const documented = documentedOrchestrationCommandPairs(projectDir)
+  return [
+    ...[...expandExcuses(NOT_EXECUTED).keys()].filter((pair) => !documented.has(pair)),
+    ...[...expandExcuses(NOT_DOCUMENTED).keys()].filter((pair) => documented.has(pair))
+  ].sort()
+}

--- a/tests/e2e/helpers/orchestration-guide-command-ledger.unit.test.ts
+++ b/tests/e2e/helpers/orchestration-guide-command-ledger.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { documentedOrchestrationCommandPairs } from '../../../config/scripts/orchestration-guide-invocations'
+import {
+  createGuideCommandLedger,
+  findGuideCoverageGaps,
+  findStaleExcuses
+} from './orchestration-guide-command-ledger'
+
+/**
+ * The drift gate's own gate. It runs in vitest, not Playwright, so an excuse that
+ * outlives the guide line it excuses fails on every PR rather than only on the
+ * ones routed to E2E.
+ */
+describe('orchestration guide command ledger', () => {
+  it('reads a non-trivial command list out of the guide', () => {
+    const documented = documentedOrchestrationCommandPairs()
+    expect(documented.size).toBeGreaterThan(40)
+    expect(documented).toContain('send --to')
+    expect(documented).toContain('worker-start --spec')
+  })
+
+  it('records the verb and flags of an orchestration argv and ignores anything else', () => {
+    const ledger = createGuideCommandLedger()
+    ledger.record(['orchestration', 'send', '--to', 'term_a', '--subject', 'x', '--json'])
+    ledger.record(['status', '--json'])
+    expect([...ledger.executedPairs()].sort()).toEqual([
+      'send --json',
+      'send --subject',
+      'send --to'
+    ])
+  })
+
+  it('reports a documented command nobody executed and an executed command nobody documented', () => {
+    const gaps = findGuideCoverageGaps(new Set(['run-create --objective', 'send --nonsense']))
+    expect(gaps.unexecuted).toContain('send --to')
+    expect(gaps.unexecuted).not.toContain('run-create --objective')
+    expect(gaps.undocumented).toEqual(['send --nonsense'])
+  })
+
+  it('excuses only pairs the guide still documents', () => {
+    expect(findStaleExcuses()).toEqual([])
+  })
+})

--- a/tests/e2e/helpers/orchestration-guide-fake-agent.ts
+++ b/tests/e2e/helpers/orchestration-guide-fake-agent.ts
@@ -1,0 +1,98 @@
+/**
+ * A codex stand-in on PATH for the guide-contract spec.
+ *
+ * It ACKs the injected preamble the way a real TUI does (bracketed paste, then a
+ * submit) and records every stdin chunk under the handle it was launched as.
+ * That recording is what makes the Dispatch capability observable: the spec
+ * reads the capability the worker really received in its preamble rather than
+ * asking an RPC for one, which is the same substitution the worker contract
+ * forbids.
+ */
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { buildFakeAgentCommandOverride } from './fake-agent-command-override'
+import { FAKE_AGENT_PASTE_END_SCANNER_SOURCE } from './fake-agent-paste-end-scanner'
+
+export type GuideContractFakeAgent = {
+  /** Value for `agentCmdOverrides.codex`, and the argv for a low-level `terminal.create`. */
+  command: string
+  /** Every fake agent appends here; the launch env must carry it as ORCA_E2E_GUIDE_STDIN. */
+  stdinLedgerPath: string
+  /** Everything the pane owned by `handle` has been sent, concatenated. */
+  readStdin: (handle: string) => string
+  reset: () => void
+  cleanup: () => void
+}
+
+const AGENT_SOURCE = `
+const { appendFileSync } = require('node:fs')
+if (process.argv.slice(2).includes('app-server')) {
+  process.stderr.write("error: unrecognized subcommand 'app-server'\\n")
+  process.exit(2)
+}
+${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
+process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
+process.stdin.on('data', (chunk) => {
+  const input = chunk.toString()
+  try {
+    appendFileSync(
+      process.env.ORCA_E2E_GUIDE_STDIN,
+      JSON.stringify({ handle: process.env.ORCA_TERMINAL_HANDLE || null, input }) + '\\n'
+    )
+  } catch {}
+  const scan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
+  fakeAgentPasteEndTail = scan.tail
+  if (scan.pasteEndOffset !== null) {
+    process.stdout.write('\\x1b[?25h')
+  }
+  fakeAgentMaybeAck(scan, input, () => {
+    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
+    setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+  })
+})
+process.stdin.setRawMode?.(true)
+process.stdin.resume()
+setInterval(() => {}, 60_000)
+`
+
+export function createGuideContractFakeAgent(): GuideContractFakeAgent {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-guide-contract-'))
+  const stdinLedgerPath = path.join(dir, 'agent-stdin.jsonl')
+  const executable = path.join(dir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+
+  if (process.platform === 'win32') {
+    writeFileSync(path.join(dir, 'fake-codex.js'), AGENT_SOURCE)
+    writeFileSync(executable, '@echo off\r\nnode "%~dp0\\fake-codex.js" %*\r\n')
+  } else {
+    writeFileSync(executable, `#!/usr/bin/env node\n${AGENT_SOURCE}`)
+    chmodSync(executable, 0o755)
+  }
+
+  return {
+    command: buildFakeAgentCommandOverride(executable),
+    stdinLedgerPath,
+    readStdin: (handle) => {
+      if (!existsSync(stdinLedgerPath)) {
+        return ''
+      }
+      return readFileSync(stdinLedgerPath, 'utf8')
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as { handle: string | null; input: string })
+        .filter((entry) => entry.handle === handle)
+        .map((entry) => entry.input)
+        .join('')
+    },
+    reset: () => rmSync(stdinLedgerPath, { force: true }),
+    cleanup: () => rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+/** Prepended to PATH so `worker-start --agent codex` and `terminal.create` both find it. */
+export function fakeAgentLaunchEnv(agent: GuideContractFakeAgent): Record<string, string> {
+  return {
+    PATH: `${path.dirname(agent.stdinLedgerPath)}${path.delimiter}${process.env.PATH ?? ''}`,
+    ORCA_E2E_GUIDE_STDIN: agent.stdinLedgerPath
+  }
+}

--- a/tests/e2e/helpers/orchestration-guide-terminal-topology.ts
+++ b/tests/e2e/helpers/orchestration-guide-terminal-topology.ts
@@ -1,0 +1,100 @@
+/**
+ * The terminals the guide-contract spec addresses, and how to keep addressing
+ * them across a restart.
+ *
+ * The PTY outlives the app but the handle minted for it may not, so anything
+ * that has to survive a relaunch is tracked by `ptyId` and re-resolved. Pane
+ * binding is polled with a long budget on purpose: this suite shares a machine
+ * with other Electron E2E runs, where a bound pane is slow, not absent.
+ */
+import { expect, type Page } from '@stablyai/playwright-test'
+import type { RuntimeClient } from '../../src/cli/runtime-client'
+import type { RuntimeTerminalListResult } from '../../src/shared/runtime-types'
+import { waitForActivePaneHookDescriptor, waitForActivePanePtyId } from './terminal'
+
+const PANE_BINDING_TIMEOUT_MS = 120_000
+
+export async function resolveActivePaneHandle(page: Page, client: RuntimeClient): Promise<string> {
+  await waitForActivePanePtyId(page, PANE_BINDING_TIMEOUT_MS)
+  const { paneKey } = await waitForActivePaneHookDescriptor(page, PANE_BINDING_TIMEOUT_MS)
+  const resolved = await client.call<{ terminal: { handle: string } }>('terminal.resolvePane', {
+    paneKey
+  })
+  return resolved.result.terminal.handle
+}
+
+export async function waitForRegisteredWorktree(
+  client: RuntimeClient,
+  worktreeId: string
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const listed = await client.call<{ worktrees: { id: string }[] }>('worktree.list', {})
+        return listed.result.worktrees.some((worktree) => worktree.id === worktreeId)
+      },
+      { timeout: 90_000, message: 'runtime never registered the worktree' }
+    )
+    .toBe(true)
+}
+
+/** A second plain shell in no Run: the other half of `send --to <handle>`. Returns its PTY id. */
+export async function createPeerTerminalPty(
+  client: RuntimeClient,
+  worktreeId: string
+): Promise<string> {
+  const created = await client.call<{ terminal: { handle: string } }>('terminal.create', {
+    worktree: `id:${worktreeId}`,
+    title: 'guide contract peer'
+  })
+  const handle = created.result.terminal.handle
+  const listed = await client.call<RuntimeTerminalListResult>('terminal.list')
+  const ptyId = listed.result.terminals.find((entry) => entry.handle === handle)?.ptyId
+  if (!ptyId) {
+    throw new Error(`terminal.create returned ${handle} with no PTY`)
+  }
+  return ptyId
+}
+
+/** An operator-created agent terminal, which is what `dispatch --inject` targets. */
+export async function createAgentTerminal(
+  client: RuntimeClient,
+  worktreeId: string,
+  command: string
+): Promise<string> {
+  const created = await client.call<{ terminal: { handle: string } }>('terminal.create', {
+    worktree: `id:${worktreeId}`,
+    command,
+    launchAgent: 'codex',
+    title: 'guide contract inject target'
+  })
+  const handle = created.result.terminal.handle
+  await expect
+    .poll(
+      async () => {
+        const inspected = await client.call<{ process: { foregroundProcess: string | null } }>(
+          'terminal.inspectProcess',
+          { terminal: handle }
+        )
+        return inspected.result.process.foregroundProcess
+      },
+      { timeout: 60_000, message: 'the inject target never started an agent process' }
+    )
+    .toBeTruthy()
+  return handle
+}
+
+export async function handleForPty(client: RuntimeClient, ptyId: string): Promise<string> {
+  let handle: string | null = null
+  await expect
+    .poll(
+      async () => {
+        const listed = await client.call<RuntimeTerminalListResult>('terminal.list')
+        handle = listed.result.terminals.find((entry) => entry.ptyId === ptyId)?.handle ?? null
+        return handle
+      },
+      { timeout: PANE_BINDING_TIMEOUT_MS, message: `no live terminal is attached to pty ${ptyId}` }
+    )
+    .toBeTruthy()
+  return handle as unknown as string
+}

--- a/tests/e2e/helpers/orchestration-mail-store.ts
+++ b/tests/e2e/helpers/orchestration-mail-store.ts
@@ -45,6 +45,38 @@ export function readMailRow(userDataDir: string, id: string): MailRow | undefine
   ) as MailRow | undefined
 }
 
+export type ThreadedMailRow = Pick<MailRow, 'id' | 'run_id' | 'to_handle' | 'read'> & {
+  thread_id: string | null
+}
+
+/** Exact rows, in insertion order, for asserting that a set of ids survived a restart unchanged. */
+export function readMailRowsById(userDataDir: string, ids: string[]): ThreadedMailRow[] {
+  if (ids.length === 0) {
+    return []
+  }
+  return withMailDb(userDataDir, (db) =>
+    db
+      .prepare(
+        `SELECT id, run_id, to_handle, read, thread_id FROM messages
+         WHERE id IN (${ids.map(() => '?').join(',')}) ORDER BY sequence`
+      )
+      .all(...ids)
+  ) as ThreadedMailRow[]
+}
+
+/**
+ * How many Runs this database has adopted from a pre-cutover contract.
+ *
+ * A reopen that gains a row here means the skew probe read current state as
+ * legacy state — the second half of the #19542 class of bug.
+ */
+export function countLegacyAdoptions(userDataDir: string): number {
+  return withMailDb(
+    userDataDir,
+    (db) => (db.prepare('SELECT COUNT(*) AS n FROM legacy_adoptions').get() as { n: number }).n
+  )
+}
+
 export function readMailbox(userDataDir: string, toHandle: string): MailRow[] {
   return withMailDb(userDataDir, (db) =>
     db

--- a/tests/e2e/orchestration-guide-contract.spec.ts
+++ b/tests/e2e/orchestration-guide-contract.spec.ts
@@ -1,0 +1,729 @@
+import { existsSync, readFileSync } from 'node:fs'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { TEST_REPO_PATH_FILE } from './global-setup'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import { RuntimeClient } from '../../src/cli/runtime-client'
+import type { RuntimeTerminalListResult } from '../../src/shared/runtime-types'
+import { FAKE_AGENT_WINDOWS_SHELL } from './helpers/fake-agent-command-override'
+import { countLegacyAdoptions, readMailRowsById } from './helpers/orchestration-mail-store'
+import {
+  createOrchestrationCli,
+  describeRun,
+  payload,
+  receipt,
+  type OrchestrationCli
+} from './helpers/orchestration-guide-cli'
+import {
+  createGuideCommandLedger,
+  findGuideCoverageGaps,
+  findStaleExcuses
+} from './helpers/orchestration-guide-command-ledger'
+import {
+  createGuideContractFakeAgent,
+  fakeAgentLaunchEnv
+} from './helpers/orchestration-guide-fake-agent'
+import {
+  createAgentTerminal,
+  createPeerTerminalPty,
+  handleForPty,
+  resolveActivePaneHandle,
+  waitForRegisteredWorktree
+} from './helpers/orchestration-guide-terminal-topology'
+
+const agent = createGuideContractFakeAgent()
+const ledger = createGuideCommandLedger()
+
+async function applyFakeAgentSettings(page: Page): Promise<void> {
+  await page.evaluate(
+    async ({ agentCommand, terminalWindowsShell }) => {
+      await window.__store?.getState().updateSettings({
+        agentCmdOverrides: { codex: agentCommand },
+        terminalWindowsShell
+      })
+    },
+    { agentCommand: agent.command, terminalWindowsShell: FAKE_AGENT_WINDOWS_SHELL }
+  )
+}
+
+async function readUserDataDir(app: ElectronApplication): Promise<string> {
+  return await app.evaluate(({ app: electronApp }) => electronApp.getPath('userData'))
+}
+
+test.afterAll(() => {
+  agent.cleanup()
+})
+
+test('runs the orchestration guide sequence through the compiled CLI across a restart', async (// oxlint-disable-next-line no-empty-pattern -- this spec owns both Electron launches and opts out of the shared app fixture.
+{}, testInfo) => {
+  test.setTimeout(600_000)
+  const repoPath = existsSync(TEST_REPO_PATH_FILE)
+    ? readFileSync(TEST_REPO_PATH_FILE, 'utf8').trim()
+    : ''
+  test.skip(!repoPath || !existsSync(repoPath), 'Global setup did not produce a seeded test repo')
+
+  agent.reset()
+  const session = createRestartSession(testInfo, fakeAgentLaunchEnv(agent))
+  let firstApp: ElectronApplication | null = null
+  let secondApp: ElectronApplication | null = null
+
+  try {
+    // ── Launch 1: two terminals, neither in a Run ────────────────────────────
+    const first = await session.launch()
+    firstApp = first.app
+    const worktreeId = await attachRepoAndOpenTerminal(first.page, repoPath)
+    const userDataDir = await readUserDataDir(first.app)
+    const orca: OrchestrationCli = createOrchestrationCli(userDataDir, ledger)
+    const firstClient = new RuntimeClient(userDataDir, 30_000, null, null)
+    await waitForRegisteredWorktree(firstClient, worktreeId)
+    await applyFakeAgentSettings(first.page)
+
+    const coordinator = await resolveActivePaneHandle(first.page, firstClient)
+    const peerPtyId = await createPeerTerminalPty(firstClient, worktreeId)
+    const peer = await handleForPty(firstClient, peerPtyId)
+
+    // (a) The #19542 command: a sender in NO Run mailing a bare handle.
+    const sent = receipt<{ message: { id: string; run_id?: string } }>(
+      orca(coordinator, [
+        'orchestration',
+        'send',
+        '--to',
+        peer,
+        '--subject',
+        'Guide contract: plain terminal mail',
+        '--body',
+        'Sent before any Run exists.',
+        '--json'
+      ])
+    )
+    const unboundMessageId = sent.message.id
+    expect(unboundMessageId).toMatch(/^msg_/)
+    expect(readMailRowsById(userDataDir, [unboundMessageId])).toEqual([
+      expect.objectContaining({ run_id: 'run_unbound', to_handle: peer, read: 0 })
+    ])
+
+    // (b) The recipient reads it, replies, and the sender sees the reply on the same thread.
+    const checked = receipt<{ messages: { id: string; subject?: string }[]; count: number }>(
+      orca(peer, ['orchestration', 'check', '--terminal', peer, '--json'])
+    )
+    expect(checked.messages.map((message) => message.id)).toContain(unboundMessageId)
+    const replied = receipt<{ message: { id: string } }>(
+      orca(peer, [
+        'orchestration',
+        'reply',
+        '--id',
+        unboundMessageId,
+        '--body',
+        'Reply from the second plain terminal.',
+        '--json'
+      ])
+    )
+    const replyId = replied.message.id
+    const coordinatorInbox = receipt<{ messages: { id: string }[] }>(
+      orca(coordinator, ['orchestration', 'check', '--terminal', coordinator, '--json'])
+    )
+    expect(coordinatorInbox.messages.map((message) => message.id)).toContain(replyId)
+    const threadRows = readMailRowsById(userDataDir, [unboundMessageId, replyId])
+    expect(threadRows.find((row) => row.id === replyId)?.thread_id).toBe(unboundMessageId)
+
+    // One more that nobody reads, so the restart has an UNREAD row to preserve.
+    const pending = receipt<{ message: { id: string } }>(
+      orca(coordinator, [
+        'orchestration',
+        'send',
+        '--to',
+        peer,
+        '--subject',
+        'Guide contract: survives the restart',
+        '--body',
+        'Never read before the restart.',
+        '--json'
+      ])
+    )
+    const pendingId = pending.message.id
+    const rowsBeforeRestart = readMailRowsById(userDataDir, [unboundMessageId, replyId, pendingId])
+    const adoptionsBeforeRestart = countLegacyAdoptions(userDataDir)
+
+    // ── (c) Restart the runtime against the same profile ─────────────────────
+    await session.close(firstApp)
+    firstApp = null
+    const second = await session.launch()
+    secondApp = second.app
+    const client = new RuntimeClient(session.userDataDir, 30_000, null, null)
+    await applyFakeAgentSettings(second.page)
+
+    expect(readMailRowsById(userDataDir, [unboundMessageId, replyId, pendingId])).toEqual(
+      rowsBeforeRestart
+    )
+    expect(countLegacyAdoptions(userDataDir)).toBe(adoptionsBeforeRestart)
+    const restoredPeer = await handleForPty(client, peerPtyId)
+    const afterRestart = receipt<{ messages: { id: string }[]; formatted?: string }>(
+      orca(restoredPeer, [
+        'orchestration',
+        'check',
+        '--terminal',
+        restoredPeer,
+        '--peek',
+        '--format',
+        '--json'
+      ])
+    )
+    expect(afterRestart.messages.map((message) => message.id)).toContain(pendingId)
+    expect(afterRestart.formatted).toContain('Guide contract: survives the restart')
+    // --peek is read-only: the row it just returned is still unread.
+    expect(readMailRowsById(userDataDir, [pendingId])[0]?.read).toBe(0)
+
+    const restoredCoordinator = await resolveActivePaneHandle(second.page, client)
+    const inbox = receipt<{ messages: { id: string }[] }>(
+      orca(restoredCoordinator, ['orchestration', 'inbox', '--full', '--json'])
+    )
+    expect(inbox.messages.map((message) => message.id)).toEqual(
+      expect.arrayContaining([unboundMessageId, replyId, pendingId])
+    )
+
+    // ── (d) Bind a Run, plan Tasks, start a supervised worker ────────────────
+    const run = receipt<{ run: { id: string; objective: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'run-create',
+        '--objective',
+        'Execute the orchestration guide sequence',
+        '--json'
+      ])
+    )
+    const runId = run.run.id
+    expect(runId).toMatch(/^run_/)
+    expect(run.run.objective).toBe('Execute the orchestration guide sequence')
+
+    const runList = receipt<{ runs: { id: string }[] }>(
+      orca(restoredCoordinator, ['orchestration', 'run-list', '--json'])
+    )
+    expect(runList.runs.map((entry) => entry.id)).toContain(runId)
+    const runShow = receipt<{ run: { id: string } }>(
+      orca(restoredCoordinator, ['orchestration', 'run-show', '--id', runId, '--json'])
+    )
+    expect(runShow.run.id).toBe(runId)
+    const rebound = receipt<{ run: { id: string } }>(
+      orca(restoredCoordinator, ['orchestration', 'run-use', '--id', runId, '--json'])
+    )
+    expect(rebound.run.id).toBe(runId)
+
+    const firstTask = receipt<{ task: { id: string; status: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'task-create',
+        '--spec',
+        'Guide contract: the dependency-free Task',
+        '--json'
+      ])
+    )
+    const dependentTask = receipt<{ task: { id: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'task-create',
+        '--spec',
+        'Guide contract: the dependent Task',
+        '--deps',
+        JSON.stringify([firstTask.task.id]),
+        '--json'
+      ])
+    )
+    const readyTasks = receipt<{ tasks: { id: string }[] }>(
+      orca(restoredCoordinator, ['orchestration', 'task-list', '--ready', '--brief', '--json'])
+    )
+    expect(readyTasks.tasks.map((task) => task.id)).toContain(firstTask.task.id)
+    expect(readyTasks.tasks.map((task) => task.id)).not.toContain(dependentTask.task.id)
+    const runTasks = receipt<{ tasks: { id: string }[] }>(
+      orca(restoredCoordinator, ['orchestration', 'task-list', '--run', runId, '--json'])
+    )
+    expect(runTasks.tasks.map((task) => task.id)).toEqual(
+      expect.arrayContaining([firstTask.task.id, dependentTask.task.id])
+    )
+
+    const started = receipt<{
+      taskId: string
+      dispatchId: string
+      effects: { kind: string; role?: string; id?: string }[]
+    }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'worker-start',
+        '--spec',
+        'Guide contract: the supervised worker',
+        '--worktree',
+        'current',
+        '--agent',
+        'codex',
+        '--json'
+      ])
+    )
+    const worker = started.effects.find(
+      (effect) => effect.kind === 'terminal' && effect.role === 'agent'
+    )?.id
+    expect(worker, JSON.stringify(started)).toBeTruthy()
+    const workerHandle = worker as string
+    const taskId = started.taskId
+    const dispatchId = started.dispatchId
+    expect(taskId).toMatch(/^task_/)
+    expect(dispatchId).toEqual(expect.any(String))
+
+    // The capability the worker must copy comes from the preamble it received.
+    await expect
+      .poll(() => agent.readStdin(workerHandle), {
+        timeout: 60_000,
+        message: 'the worker pane never received a preamble carrying a Dispatch capability'
+      })
+      .toMatch(/--dispatch-capability dcap_/)
+    const capability = agent
+      .readStdin(workerHandle)
+      .match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1] as string
+
+    // ── (e) The worker's own contract ────────────────────────────────────────
+    const workerCheck = receipt<{ count: number }>(
+      orca(workerHandle, ['orchestration', 'check', '--terminal', workerHandle, '--json'])
+    )
+    expect(workerCheck.count).toBeGreaterThanOrEqual(0)
+    const heartbeat = orca(workerHandle, [
+      'orchestration',
+      'send',
+      '--from',
+      workerHandle,
+      '--dispatch-capability',
+      capability,
+      '--type',
+      'heartbeat',
+      '--subject',
+      'alive',
+      '--task-id',
+      taskId,
+      '--dispatch-id',
+      dispatchId,
+      '--phase',
+      'implementing',
+      '--json'
+    ])
+    expect(receipt<{ message?: { id: string }; relay?: unknown }>(heartbeat)).toBeTruthy()
+
+    // ask blocks; a short timeout leaves the question durably pending with a resumable id.
+    const askTimedOut = orca(workerHandle, [
+      'orchestration',
+      'ask',
+      '--from',
+      workerHandle,
+      '--dispatch-capability',
+      capability,
+      '--question',
+      'Guide contract: which option?',
+      '--options',
+      'left,right',
+      '--timeout-ms',
+      '4000',
+      '--json'
+    ])
+    // A timed-out ask exits 1 by contract and still returns the pending question's identity.
+    expect(askTimedOut.status, describeRun(askTimedOut)).toBe(1)
+    const askReceipt = payload<{
+      timedOut: boolean
+      messageId: string | null
+      answer: string | null
+    }>(askTimedOut)
+    expect(askReceipt.timedOut, describeRun(askTimedOut)).toBe(true)
+    expect(askReceipt.messageId).toMatch(/^msg_/)
+    const questionId = askReceipt.messageId as string
+
+    // ── (f) The coordinator's delivery loop ──────────────────────────────────
+    const firstDelivery = receipt<{
+      deliveryId: string | null
+      messages: { id: string; type?: string }[]
+    }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'check',
+        '--wait',
+        '--types',
+        'worker_done,escalation,question',
+        '--timeout-ms',
+        '60000',
+        '--json'
+      ])
+    )
+    expect(firstDelivery.deliveryId).toBeTruthy()
+    expect(firstDelivery.messages.map((message) => message.id)).toContain(questionId)
+    receipt<{ message: { id: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'reply',
+        '--id',
+        questionId,
+        '--body',
+        'left',
+        '--json'
+      ])
+    )
+
+    const resumed = receipt<{ answer: string | null; timedOut: boolean }>(
+      orca(workerHandle, [
+        'orchestration',
+        'ask',
+        '--from',
+        workerHandle,
+        '--dispatch-capability',
+        capability,
+        '--resume',
+        questionId,
+        '--timeout-ms',
+        '60000',
+        '--json'
+      ])
+    )
+    expect(resumed.timedOut).toBe(false)
+    expect(resumed.answer).toBe('left')
+
+    // ── (g) Address forms the guide documents ────────────────────────────────
+    const toRun = receipt<{ message: { id: string; run_id?: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'send',
+        '--to',
+        `run:${runId}`,
+        '--subject',
+        'Guide contract: Run mailbox',
+        '--body',
+        'Addressed to the Run home inbox.',
+        '--json'
+      ])
+    )
+    expect(readMailRowsById(userDataDir, [toRun.message.id])[0]?.run_id).toBe(runId)
+    const toDispatch = receipt<{ message?: { id: string }; relay?: { dispatchId: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'send',
+        '--to',
+        `dispatch:${dispatchId}`,
+        '--subject',
+        'Follow-up',
+        '--body',
+        'Attempt-specific coordinator guidance.',
+        '--json'
+      ])
+    )
+    expect(toDispatch.message?.id ?? toDispatch.relay?.dispatchId).toBeTruthy()
+    const toGroup = receipt<{ messages: { id: string }[]; recipients: number }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'send',
+        '--to',
+        '@all',
+        '--subject',
+        'Guide contract: group fan-out',
+        '--body',
+        'Intentional fan-out status.',
+        '--json'
+      ])
+    )
+    expect(toGroup.recipients).toBeGreaterThan(0)
+    expect(toGroup.messages).toHaveLength(toGroup.recipients)
+    const toWorktreeGroup = receipt<{ recipients: number }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'send',
+        '--to',
+        `@worktree:${worktreeId}`,
+        '--subject',
+        'Guide contract: worktree fan-out',
+        '--body',
+        'Intentional worktree fan-out.',
+        '--json'
+      ])
+    )
+    expect(toWorktreeGroup.recipients).toBeGreaterThan(0)
+
+    // The worker reads coordinator follow-ups before it settles, as the contract requires.
+    const workerFollowUp = receipt<{ messages: { subject?: string }[] }>(
+      orca(workerHandle, ['orchestration', 'check', '--terminal', workerHandle, '--json'])
+    )
+    expect(workerFollowUp.messages.map((message) => message.subject)).toContain('Follow-up')
+
+    const escalation = orca(workerHandle, [
+      'orchestration',
+      'send',
+      '--from',
+      workerHandle,
+      '--dispatch-capability',
+      capability,
+      '--type',
+      'escalation',
+      '--subject',
+      'Blocked: guide contract escalation',
+      '--body',
+      'Escalating before completion.',
+      '--task-id',
+      taskId,
+      '--dispatch-id',
+      dispatchId,
+      '--json'
+    ])
+    expect(escalation.status, describeRun(escalation)).toBe(0)
+
+    const done = receipt<{
+      lifecycle?: { action: string; outcome?: string }
+      mutation?: { requestId: string }
+    }>(
+      orca(workerHandle, [
+        'orchestration',
+        'send',
+        '--from',
+        workerHandle,
+        '--dispatch-capability',
+        capability,
+        '--type',
+        'worker_done',
+        '--subject',
+        'Guide contract complete',
+        '--body',
+        'Ran the guide sequence. Every receipt matched. Nothing remains.',
+        '--task-id',
+        taskId,
+        '--dispatch-id',
+        dispatchId,
+        '--outcome',
+        'succeeded',
+        '--json'
+      ])
+    )
+    expect(done.lifecycle?.action).toMatch(/^(completed|settled)$/)
+
+    const settledDelivery = receipt<{
+      deliveryId: string | null
+      messages: { id: string; type?: string }[]
+    }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'check',
+        '--ack',
+        firstDelivery.deliveryId as string,
+        '--wait',
+        '--types',
+        'worker_done,escalation,question',
+        '--timeout-ms',
+        '60000',
+        '--json'
+      ])
+    )
+    expect(settledDelivery.messages.map((message) => message.type)).toContain('worker_done')
+
+    // ── Inspection and cleanup verbs ─────────────────────────────────────────
+    const workers = receipt<{ workers: { dispatchId: string }[] }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'worker-list',
+        '--run',
+        runId,
+        '--include-remote',
+        '--json'
+      ])
+    )
+    expect(workers.workers.map((entry) => entry.dispatchId)).toContain(dispatchId)
+    const workerShow = receipt<{ dispatchId?: string; dispatch?: { id: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'worker-show',
+        '--dispatch',
+        dispatchId,
+        '--json'
+      ])
+    )
+    expect(workerShow.dispatchId ?? workerShow.dispatch?.id).toBe(dispatchId)
+    const workerRead = orca(restoredCoordinator, [
+      'orchestration',
+      'worker-read',
+      '--dispatch',
+      dispatchId,
+      '--limit',
+      '50',
+      '--json'
+    ])
+    expect(workerRead.status, describeRun(workerRead)).toBe(0)
+
+    const retained = receipt<{ state: string }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'worker-retain',
+        '--dispatch',
+        dispatchId,
+        '--json'
+      ])
+    )
+    expect(retained.state).toBe('retained')
+    const released = receipt<{ state: string }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'worker-release',
+        '--dispatch',
+        dispatchId,
+        '--json'
+      ])
+    )
+    expect(['released', 'retained']).toContain(released.state)
+
+    // ── Low-level topology and mutation recovery ─────────────────────────────
+    const injectTask = receipt<{ task: { id: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'task-create',
+        '--spec',
+        'Guide contract: the low-level dispatch Task',
+        '--json'
+      ])
+    )
+    const injectTarget = await createAgentTerminal(client, worktreeId, agent.command)
+    const injected = receipt<{ dispatchId?: string; dispatch?: { id: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'dispatch',
+        '--task',
+        injectTask.task.id,
+        '--to',
+        injectTarget,
+        '--inject',
+        '--json'
+      ])
+    )
+    const injectedDispatchId = injected.dispatchId ?? injected.dispatch?.id
+    expect(injectedDispatchId).toBeTruthy()
+    await expect
+      .poll(() => agent.readStdin(injectTarget), {
+        timeout: 60_000,
+        message: 'dispatch --inject never reached the target agent'
+      })
+      .toContain(injectTask.task.id)
+
+    const gate = receipt<{ gate: { id: string; status: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'gate-create',
+        '--task',
+        firstTask.task.id,
+        '--question',
+        'Guide contract: which branch?',
+        '--options',
+        JSON.stringify(['merge', 'revert']),
+        '--json'
+      ])
+    )
+    const gates = receipt<{ gates: { id: string }[] }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'gate-list',
+        '--task',
+        firstTask.task.id,
+        '--json'
+      ])
+    )
+    expect(gates.gates.map((entry) => entry.id)).toContain(gate.gate.id)
+    const resolvedGate = receipt<{ gate: { id: string; status: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'gate-resolve',
+        '--id',
+        gate.gate.id,
+        '--resolution',
+        'merge',
+        '--json'
+      ])
+    )
+    expect(resolvedGate.gate.status).toBe('resolved')
+
+    // The recovery question after a lost response, asked about a mutation that really landed.
+    const settledRequestId = done.mutation?.requestId as string
+    expect(settledRequestId, JSON.stringify(done)).toBeTruthy()
+    const requestShow = receipt<{ requestId: string; state: string; interpretation: string }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'request-show',
+        '--request',
+        settledRequestId,
+        '--json'
+      ])
+    )
+    expect(requestShow.requestId).toBe(settledRequestId)
+    expect(requestShow.state).toBe('completed')
+    expect(requestShow.interpretation.length).toBeGreaterThan(0)
+
+    const runScopedCheck = receipt<{ messages: unknown[] }>(
+      orca(restoredCoordinator, ['orchestration', 'check', '--run', runId, '--json'])
+    )
+    expect(Array.isArray(runScopedCheck.messages)).toBe(true)
+
+    // ── Planned fan-out: start a named Task, then stop that exact worker ─────
+    const plannedTask = receipt<{ task: { id: string } }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'task-create',
+        '--spec',
+        'Guide contract: the planned-fan-out Task',
+        '--json'
+      ])
+    )
+    const secondStart = receipt<{
+      taskId: string
+      dispatchId: string
+      effects: { kind: string; role?: string; id?: string }[]
+    }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'worker-start',
+        '--task',
+        plannedTask.task.id,
+        '--worktree',
+        'current',
+        '--agent',
+        'codex',
+        '--json'
+      ])
+    )
+    expect(secondStart.taskId).toBe(plannedTask.task.id)
+    const secondWorker = secondStart.effects.find(
+      (effect) => effect.kind === 'terminal' && effect.role === 'agent'
+    )?.id as string
+    expect(secondWorker, JSON.stringify(secondStart)).toBeTruthy()
+
+    const stopped = receipt<{ state: string; processAction: string }>(
+      orca(restoredCoordinator, [
+        'orchestration',
+        'worker-stop',
+        '--dispatch',
+        secondStart.dispatchId,
+        '--json'
+      ])
+    )
+    expect(stopped.state).not.toBe('stop_unknown')
+    // worker-stop closes the exact supervised terminal it owns, and only that one.
+    await expect
+      .poll(
+        async () => {
+          const listed = await client.call<RuntimeTerminalListResult>('terminal.list')
+          return listed.result.terminals.map((entry) => entry.handle)
+        },
+        { timeout: 60_000, message: 'worker-stop never closed the stopped worker terminal' }
+      )
+      .not.toContain(secondWorker)
+    const survivors = await client.call<RuntimeTerminalListResult>('terminal.list')
+    expect(survivors.result.terminals.map((entry) => entry.handle)).toContain(injectTarget)
+
+    // ── The drift gate ───────────────────────────────────────────────────────
+    expect(findStaleExcuses(process.cwd())).toEqual([])
+    expect(findGuideCoverageGaps(ledger.executedPairs(), process.cwd())).toEqual({
+      unexecuted: [],
+      undocumented: []
+    })
+  } finally {
+    if (firstApp) {
+      await session.close(firstApp)
+    }
+    if (secondApp) {
+      await session.close(secondApp)
+    }
+    await session.dispose()
+  }
+})

--- a/tests/e2e/orchestration-idle-mail-delivery.spec.ts
+++ b/tests/e2e/orchestration-idle-mail-delivery.spec.ts
@@ -350,9 +350,10 @@ test.describe('orchestration push-on-idle mail delivery', () => {
     await expectSubmitted(pane)
   })
 
-  // #19542 deleted the legacy-Run write fallback, so a sender in no Run has
-  // nowhere to file mail to a bare handle: the send is refused outright, which
-  // is what keeps an unsafe pointer out of the pane on the next idle frame.
+  // A sender in no Run files mail to a bare handle under the unbound Run, not the
+  // legacy one (#19542 deleted that fallback, #19696 restored delivery). The row is
+  // durable and unread; what stays out of the pane is the pointer, because an
+  // unbound row has no safe check for the recipient to run.
   test('keeps unbound direct mail durable without pointing to an unsafe check', async ({
     orcaPage,
     electronApp


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1206 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1180 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |

<!-- /orca-pr-loc -->

## What the user notices

**Before:** an orchestration-source PR could delete the unbound-Run write path and
merge green. It did: #19542 broke `orca orchestration send --to <handle>` between two
plain terminals — the first command `skills get orchestration` teaches — and users
reported "orchestration stopped working after updating". Every gate passed because no
gate ran the guide's argv through a real CLI binary against a real runtime: the CLI
tests `vi.mock` the runtime client, the RPC harness uses `:memory:` with a Run already
bound, and the guide-contract check only matched strings against
`ORCHESTRATION_COMMAND_SPECS`.

**After:** a PR that breaks any command the guide teaches fails
`tests/e2e/orchestration-guide-contract.spec.ts`. The spec boots Electron, spawns the
compiled `out/cli/index.js`, and runs the guide's sequence in the order the guide
prints it, asserting each receipt's shape. The same spec fails if the guide starts
teaching a command nobody executes, or if the spec starts executing a flag the guide
never teaches. Nothing about the shipped product changes; the change is entirely in
what can merge.

## The delete question

Nothing was deleted outright, and one candidate was deliberately kept.

`config/scripts/orchestration-guide-command-contract.test.mjs` was the obvious delete:
the new spec executes the taught commands, which strictly dominates matching their
strings. It stays because it covers what the spec cannot and the spec cannot cover it:

- it runs on **every** PR in ~200 ms with no build, while the E2E only runs on PRs
  routed to it and needs a full `electron-vite` + `build:cli`;
- it is the only gate over the eleven documented (verb, flag) pairs one local profile
  cannot reach (remote placement, legacy takeover, abandon). Those are excused from the
  E2E's coverage gate by name; the static test still proves the CLI accepts them.

What was removed is the duplication between them: both now read the guide through one
parser, `config/scripts/orchestration-guide-invocations.ts`, so they cannot disagree
about what "documented" means. The spec's own duplication was also removed — its DB
reads went into the existing `tests/e2e/helpers/orchestration-mail-store.ts` rather
than a second SQLite reader beside it.

The stale comment at `orchestration-idle-mail-delivery.spec.ts:353` ("the send is
refused outright") was deleted; the test under it was already correct.

## Proof

### 1. The regression this exists to catch (mandatory proof)

Local scratch edit re-applying the #19542 deletion in
`src/main/runtime/orchestration/db/messages/message-insert.ts` — the unbound block and
its `INSERT OR IGNORE INTO runs` replaced with:

```ts
const runId = msg.runId
if (!runId) {
  throw new Error('Run is required')
}
```

Rebuilt (no `SKIP_BUILD`, so global setup ran `electron-vite build --mode e2e` and
`pnpm run build:cli`) and ran the spec:

```
ORCA_BACKGROUND_LAUNCH=1 npx playwright test tests/e2e/orchestration-guide-contract.spec.ts \
  --config tests/playwright.config.ts --project electron-headless --workers=1
```

```
  1) [electron-headless] › tests/e2e/orchestration-guide-contract.spec.ts › runs the orchestration guide sequence through the compiled CLI across a restart

    Error: orca orchestration send --to term_65925ab9-28c7-41e6-8513-d06915852cd8 --subject Guide contract: plain terminal mail --body Sent before any Run exists. --json
    exit=1
    stdout:
    {
      "id": "8b56f917-584f-42ec-bb10-544b3dfc2ec3",
      "ok": false,
      "error": {
        "code": "runtime_error",
        "message": "Run is required Orchestration mutation request ID: 206e2156-a37e-4366-bfb9-f278da52229d.",
        "data": {
          "orchestrationRequestId": "206e2156-a37e-4366-bfb9-f278da52229d",
          "originalCommand": ["orca","orchestration","send","--to","term_65925ab9-28c7-41e6-8513-d06915852cd8","--subject","Guide contract: plain terminal mail","--body","Sent before any Run exists.","--json"]
        }
      }
    }
  1 failed
```

Step (a) — the first command in the guide — fails, on the exact string users saw.
Reverted with `git checkout -- src/main/runtime/orchestration/db/messages/message-insert.ts`,
rebuilt, re-ran:

```
  ✓  1 [electron-headless] › tests/e2e/orchestration-guide-contract.spec.ts:220:5 › runs the orchestration guide sequence through the compiled CLI across a restart (20.6s)
  1 passed (30.7s)
```

### 2. The drift gate bites

Scratch edit appending one fenced line to
`skill-guides/orchestration/references/coordinator-loop.md`:

````
```text
ORCA orchestration task-update --id <task_id> --status completed --json
```
````

The static contract test stays green (the CLI accepts that verb and those flags). The
spec goes red:

```
    Error: expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 5

      Object {
        "undocumented": Array [],
    -   "unexecuted": Array [],
    +   "unexecuted": Array [
    +     "task-update --id",
    +     "task-update --json",
    +     "task-update --status",
    +   ],
      }
  1 failed
```

Reverted with `git checkout -- skill-guides/orchestration/references/coordinator-loop.md`.

### 3. What the sequence actually executes

Through the compiled CLI, against a live runtime, across a restart, with
`ORCA_TERMINAL_HANDLE` set instead of an added `--from` (which is how the guide's argv
really runs — inside an Orca terminal that resolves the caller):

- **(a)** `send --to <handleB> --subject --body --json` from a terminal in **no Run** →
  exit 0, `message.id`, and the row asserted directly in SQLite as
  `run_id = 'run_unbound'`, `read = 0`.
- **(b)** `check --terminal <B> --json` returns it; `reply --id --body --json`;
  `check --terminal <A> --json` sees the reply and `thread_id` equals the original id.
- **(c)** restart the runtime on the same profile: the three message rows are
  byte-identical (`toEqual` on the pre-restart rows), `SELECT COUNT(*) FROM legacy_adoptions`
  is unchanged, `check --terminal <B> --peek --format --json` returns the unread row with
  its subject rendered, and the row is still `read = 0` afterwards (peek is non-consuming).
- **(d)** `inbox --full --json`; `run-create --objective --json`; `run-list`; `run-show --id`;
  `run-use --id`; `task-create --spec` and `task-create --spec --deps`;
  `task-list --ready --brief` (asserts the dependent Task is absent) and `task-list --run`;
  `worker-start --spec --worktree current --agent codex --json` with a fake codex on PATH.
- **(e)** the Dispatch capability is read out of the preamble the worker pane actually
  received, then the worker runs `check --terminal <worker>`,
  `send --type heartbeat --phase`, `ask --question --options --timeout-ms` (exits 1 on
  timeout and returns the pending question id), `ask --resume` (returns the coordinator's
  answer), `send --type escalation`, a second `check` before settling, and
  `send --type worker_done --outcome succeeded`.
- **(f)** the coordinator runs `check --wait --types "worker_done,escalation,question"
  --timeout-ms 60000 --json` → the question with a delivery id; `reply --id`;
  `check --ack <delivery_id> --wait --types --timeout-ms --json` → the batch containing
  `worker_done`; `worker-list --run --include-remote`; `worker-show --dispatch`;
  `worker-read --dispatch --limit 50`; `worker-retain` (asserts `state: 'retained'`) then
  `worker-release`.
- **(g)** address forms: `--to <handle>`, `--to run:<id>` (asserted to land in that Run's
  rows), `--to dispatch:<id>` before release (and the worker sees it on its next `check`),
  and the group forms the guide documents in `messaging-and-gates.md`: `--to @all` and
  `--to @worktree:<id>`, each asserted on `recipients` and the returned `messages` array.
- plus `dispatch --task --to --inject --json` into an operator-created agent terminal
  (`low-level-topology.md`), `gate-create/gate-list/gate-resolve`,
  `request-show --request` on the request id the `worker_done` receipt returned (asserted
  `completed`), `check --run <id>`, `worker-start --task`, and `worker-stop --dispatch`
  (asserted to close that exact terminal and leave the inject target alive).

The coverage gate is what keeps that list honest: it fails if the guide documents
something the spec does not run. Eleven pairs are excused by name with a reason, in
`tests/e2e/helpers/orchestration-guide-command-ledger.ts`:
`worker-start --on/--repo/--setup` (needs a second execution host),
`worker-start --name/--retry-of/--terminal` (needs a new worktree / a proven failed
Dispatch / an idle pre-existing agent terminal), `worker-start --model/--effort` (only
forwarded when the worker server advertises support, and the fake agent takes no model
argv), `run-use --takeover-legacy` (needs a pre-cutover database), and
`worker-abandon --dispatch/--json` (already driven by
`orchestration-low-level-dispatch-release.spec.ts`). One flag is excused in the other
direction: `ask --json`, because the guide prints `ask` without it.
An excuse that stops matching the guide is itself a failure (`findStaleExcuses`), and
that check runs in vitest on every PR, not only in E2E.

## Wire / SSH / folder workspace

- **Remote wire:** no wire change. The spec adds no RPC, no stream opcode, and no
  published field; it only calls existing ones. It does not cover the mixed-version case
  — a client and host at different versions is PR 3's scope.
- **SSH:** not covered and not affected. Everything runs on one local execution host;
  `worker-start --on <environment>` is on the coverage gate's excuse list for exactly
  that reason. Nothing here assumes local-only behaviour in product code.
- **Folder workspace:** not covered. The spec uses the seeded git repo the E2E global
  setup produces, because the restart fixture (`attachRepoAndOpenTerminal`) needs one.
  A non-git folder workspace would exercise the same orchestration paths; that gap is
  named in the report.

## Testing

| Gate | Result |
| --- | --- |
| `pnpm tc` | pass (exit 0) |
| `pnpm test tests/e2e/helpers/orchestration-guide-command-ledger.unit.test.ts config/scripts/orchestration-guide-command-contract.test.mjs` | pass — `Test Files 2 passed (2) / Tests 5 passed (5)`, 220 ms |
| same command, second run (flake) | pass — `Test Files 2 passed (2) / Tests 5 passed (5)`, 204 ms |
| `pnpm run check:code-quality:changed` | pass — `code quality: 0 new finding(s) across 10 changed file(s). / type-aware code quality: 0 new finding(s) / React Doctor: 0 new finding(s) / Changed-code quality gate passed since aac38d698ff7.` |
| `pnpm run check:react-doctor:changed` | pass — `orca  no score  0 issues` |
| `git diff --check` | clean |
| `git status` | clean; nothing untracked |
| New spec, full build (no `SKIP_BUILD`) | pass — `✓ 1 ... (21.9s) / 1 passed (32.1s)` |
| New spec, `SKIP_BUILD=1` run 2 | pass — `1 passed (22.8s)` |
| New spec, `SKIP_BUILD=1` run 3 | pass — `1 passed (20.4s)` |
| `tests/e2e/orchestration-idle-mail-delivery.spec.ts` (comment-only edit) | `10 passed, 2 failed`; both failures are the pre-existing 15 s `waitForActivePanePtyId` default timing out under machine load, and both pass on re-run: `2 passed (15.7s)` |

Two additional runs failed for an environment reason worth stating plainly: this
worktree symlinks a `node_modules` shared with four other concurrent agents, and any
`pnpm <script>` in this repo re-verifies dependencies and re-runs `postinstall`. Twice a
sibling agent's `node-pty` rebuild landed mid-run, once removing `spawn-helper`
(`"Daemon's node-pty install is gone (worktree deleted?)"` from `worker-start`) and once
failing `pnpm run build:cli` with a `node-gyp` error. Both name the *primary* worktree's
`node_modules` path in the error. Neither is reachable in CI, where each job installs its
own tree, and both passed on immediate re-run with no code change.

Spec file is 729 lines (cap 800); no lint disables were added.
