### PR TITLE
fix(native-chat): show Claude working from the send, not the provider echo

### DIFF
--- a/mobile/src/session/MobileNativeChatOverlay.tsx
+++ b/mobile/src/session/MobileNativeChatOverlay.tsx
@@ -71,6 +71,7 @@ export function MobileNativeChatOverlay({
         error={session.error}
         agent={controller.nativeChatAgent}
         agentWorking={controller.nativeChatAgentWorking}
+        canStop={controller.nativeChatCanStop}
         structuredActivityUi={controller.nativeChatStructured}
         streaming={streaming}
         onStop={controller.handleNativeChatStop}

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -74,6 +74,7 @@ type Overrides = {
   pending?: Parameters<typeof MobileNativeChatView>[0]['pending']
   structuredActivityUi?: boolean
   agentWorking?: boolean
+  canStop?: boolean
   sendSurfaceId?: string
 }
 
@@ -118,6 +119,18 @@ describe('MobileNativeChatView', () => {
   }
 
   /** Ids of the rows the list is currently rendering. */
+  it('keeps Stop hidden during a structured dispatch until a provider turn can be cancelled', async () => {
+    const props = { structuredActivityUi: true, agentWorking: true, canStop: false }
+    await render(props)
+    const stops = () =>
+      renderer!.root.findAll((node) => node.props.accessibilityLabel === 'Stop the agent')
+    expect(stops()).toHaveLength(0)
+    await update({ ...props, canStop: true })
+    expect(stops()).toHaveLength(1)
+    await update({ agentWorking: true })
+    expect(stops()).toHaveLength(1)
+  })
+
   function listIds(): string[] {
     const list = renderer!.root.find((node) => node.type === 'FlatList')
     return (list.props.data as { id: string }[]).map((row) => row.id)

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -49,10 +49,11 @@ type Props = {
   /** Resolved agent for this chat; names the empty-state copy (desktop parity). */
   agent?: string | null
   agentWorking?: boolean
+  canStop?: boolean
   /** Structured lane: per-turn "Working for N" status plus live tool progress,
    *  replacing the bridge lane's static three-dot working row (desktop parity). */
   structuredActivityUi?: boolean
-  /** Interrupt the agent mid-turn (shown as a Stop button on the working bar). */
+  /** Interrupt a provider turn. */
   onStop?: () => void
   /** Live partial assistant text to show as an in-progress bubble, already gated
    *  by the overlay against the transcript catching up. */
@@ -129,6 +130,7 @@ export function MobileNativeChatView({
   error,
   agent,
   agentWorking,
+  canStop = agentWorking,
   structuredActivityUi = false,
   onStop,
   streaming,
@@ -396,8 +398,6 @@ export function MobileNativeChatView({
         question={question}
         onAnswerQuestion={onAnswerQuestion}
       />
-      {/* Chrome row above the composer: the working indicator and the global
-          tool-calls expand/collapse toggle on the left, Stop in the far corner. */}
       <View style={styles.chromeRow}>
         <View style={styles.chromeLeft}>
           {agentWorking && !structuredActivityUi ? <MobileAgentWorkingIndicator /> : null}
@@ -414,7 +414,7 @@ export function MobileNativeChatView({
             <Text style={styles.chromeToggleLabel}>{toolsExpanded ? 'Collapse' : 'Tools'}</Text>
           </Pressable>
         </View>
-        {agentWorking ? (
+        {canStop ? (
           <Pressable
             style={({ pressed }) => [styles.stopButton, pressed && styles.pressed]}
             onPress={onStop}

--- a/mobile/src/session/mobile-native-chat-controller-contract.ts
+++ b/mobile/src/session/mobile-native-chat-controller-contract.ts
@@ -28,6 +28,7 @@ export type MobileNativeChatController = {
   /** Structured lane: drives the per-turn status row and live tool progress. */
   nativeChatStructured: boolean
   nativeChatAgentWorking: boolean
+  nativeChatCanStop: boolean
   nativeChatStreamingText?: string
   /** Agent mid-turn, regardless of whether chat is the visible view. */
   nativeChatStreamLive: boolean

--- a/mobile/src/session/use-mobile-native-chat-controller.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.test.ts
@@ -55,6 +55,7 @@ const structuredQuestion = {
   allowOther: true,
   optionTokens: ['choice-a', 'choice-b']
 }
+const structuredActivity = { isWorking: false, turnId: null as string | null }
 const structuredSessionState = {
   messages: [] as unknown[],
   status: 'ready',
@@ -86,8 +87,7 @@ vi.mock('./use-mobile-native-chat-session', () => ({
 vi.mock('./use-mobile-structured-agent-session', () => ({
   useMobileStructuredAgentSession: () => ({
     session: structuredSessionState,
-    isWorking: false,
-    turnId: null,
+    ...structuredActivity,
     sendWithOutcome: structuredSendWithOutcome,
     cancel: structuredCancel,
     permission: structuredPermission,
@@ -339,6 +339,37 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
     expect(structuredSendWithOutcome).toHaveBeenCalledWith('look')
     expect(sendWithOutcome).not.toHaveBeenCalled()
     expect(clientStub.sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('separates structured working status from provider cancellation availability', async () => {
+    const props = {
+      tab: {
+        type: 'agent-session',
+        id: 'agent-tab-1',
+        title: 'Chat',
+        sessionId: 'session-structured',
+        agent: 'codex',
+        isActive: true
+      },
+      activeHandle: null,
+      inputLeaseReady: false
+    }
+    structuredActivity.isWorking = true
+    try {
+      await act(async () => {
+        renderer?.update(createElement(Harness, props))
+      })
+      expect(controller?.nativeChatAgentWorking).toBe(true)
+      expect(controller?.nativeChatCanStop).toBe(false)
+      structuredActivity.turnId = 'provider-turn'
+      await act(async () => {
+        renderer?.update(createElement(Harness, props))
+      })
+      expect(controller?.nativeChatCanStop).toBe(true)
+    } finally {
+      structuredActivity.isWorking = false
+      structuredActivity.turnId = null
+    }
   })
 
   it('exposes structured prompt cards and session options on structured tabs', async () => {

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -299,6 +299,9 @@ export function useMobileNativeChatController(args: {
     /** Structured lane: drives the per-turn status row and live tool progress. */
     nativeChatStructured: activeChatStructured,
     nativeChatAgentWorking,
+    nativeChatCanStop: activeChatStructured
+      ? structuredNativeChat.turnId !== null
+      : nativeChatAgentWorking,
     nativeChatStreamingText,
     nativeChatStreamLive,
     nativeChatStreamScopeKey: streamScopeKey,

--- a/mobile/src/session/use-mobile-structured-agent-session.ts
+++ b/mobile/src/session/use-mobile-structured-agent-session.ts
@@ -297,7 +297,7 @@ export function useMobileStructuredAgentSession(args: {
     // A dispatch the provider has not answered yet is already work — see the desktop hook.
     isWorking:
       activeStructuredAgentSessionTurnId(state.items) !== null ||
-      hasUnansweredStructuredAgentSessionDispatch(state.submissions),
+      hasUnansweredStructuredAgentSessionDispatch(state.submissions, state.fence),
     turnId: activeStructuredAgentSessionTurnId(state.items),
     sendWithOutcome,
     cancel,

--- a/mobile/src/session/use-mobile-structured-agent-session.ts
+++ b/mobile/src/session/use-mobile-structured-agent-session.ts
@@ -11,7 +11,10 @@ import {
 import { encodeNativeChatTranscriptIdentity } from '../../../src/shared/native-chat-transcript-retention'
 import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
 import { projectStructuredAgentSessionMessages } from '../../../src/shared/structured-agent-session-message-projection'
-import { activeStructuredAgentSessionTurnId } from '../../../src/shared/structured-agent-session-projection'
+import {
+  activeStructuredAgentSessionTurnId,
+  hasUnansweredStructuredAgentSessionDispatch
+} from '../../../src/shared/structured-agent-session-projection'
 import {
   pendingStructuredApproval,
   pendingStructuredQuestion,
@@ -291,7 +294,10 @@ export function useMobileStructuredAgentSession(args: {
       loadingEarlier: loadingOlder,
       loadEarlier
     },
-    isWorking: activeStructuredAgentSessionTurnId(state.items) !== null,
+    // A dispatch the provider has not answered yet is already work — see the desktop hook.
+    isWorking:
+      activeStructuredAgentSessionTurnId(state.items) !== null ||
+      hasUnansweredStructuredAgentSessionDispatch(state.submissions),
     turnId: activeStructuredAgentSessionTurnId(state.items),
     sendWithOutcome,
     cancel,

--- a/src/main/native-chat/agent-session-journal/journal-crash-boundary.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-crash-boundary.test.ts
@@ -15,6 +15,7 @@ import type {
   AgentJournalMessageItem,
   AgentSessionJournalIdentity
 } from '../../../shared/agent-session-journal-types'
+import { hasUnansweredStructuredAgentSessionDispatch } from '../../../shared/structured-agent-session-projection'
 import { digestPayload } from './journal-payload-bounds'
 import {
   reconcileSubmissions,
@@ -139,6 +140,30 @@ describe('crash between provider accept and journal commit', () => {
     expect(items).toHaveLength(1)
     expect(items[0]?.itemId).toBe(agentJournalSubmissionKey('cm_1'))
     expect(restarted.receiptFor('cm_1')?.providerItemId).toBe(agentJournalItemKey(outcome.identity))
+  })
+
+  it('retires an ack timeout on restart without changing its delivery verdict', async () => {
+    const journal = await open()
+    await journal.appendSubmission({
+      clientMessageId: 'cm_timeout',
+      payloadFingerprint: digestPayload('slow'),
+      body: userMessage('slow'),
+      fence: 1
+    })
+    await journal.resolveDispatch({
+      clientMessageId: 'cm_timeout',
+      state: 'unknown',
+      reason: 'ack timeout',
+      fence: 1
+    })
+    expect(hasUnansweredStructuredAgentSessionDispatch(journal.submissions())).toBe(true)
+    const restarted = await open()
+    await restarted.markPendingSubmissionsUnknown(2)
+    expect(restarted.submissions()[0]?.dispatchState).toBe('unknown')
+    expect(hasUnansweredStructuredAgentSessionDispatch(restarted.submissions())).toBe(false)
+    const cursor = restarted.cursor()
+    await restarted.markPendingSubmissionsUnknown(2)
+    expect(restarted.cursor()).toEqual(cursor)
   })
 
   it('reports a rejected submission as never delivered, and never re-sends it', async () => {

--- a/src/main/native-chat/agent-session-journal/journal-crash-boundary.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-crash-boundary.test.ts
@@ -110,6 +110,8 @@ describe('crash between provider accept and journal commit', () => {
     expect(restarted.pendingSubmissions().map((entry) => entry.clientMessageId)).toEqual(['cm_1'])
     await restarted.markPendingSubmissionsUnknown(2)
     expect(restarted.submissions()[0]?.dispatchState).toBe('unknown')
+    // Marks the send as outlived by its writer, so no reader reports it as still working.
+    expect(restarted.submissions()[0]?.recovered).toBe(true)
 
     const [outcome] = reconcileSubmissions({
       submissions: restarted.submissions(),

--- a/src/main/native-chat/agent-session-journal/journal-pending-submission-recovery.ts
+++ b/src/main/native-chat/agent-session-journal/journal-pending-submission-recovery.ts
@@ -2,14 +2,22 @@ import type { AgentSessionJournal } from './journal-store'
 
 export async function markJournalPendingSubmissionsUnknown(
   journal: AgentSessionJournal,
-  fence: number
+  fence: number,
+  reason = 'host_restarted_before_acknowledgement'
 ): Promise<string[]> {
-  const pending = journal.pendingSubmissions().map((entry) => entry.clientMessageId)
+  const pending = journal
+    .submissions()
+    .filter(
+      (entry) =>
+        entry.dispatchState === 'pending' ||
+        (entry.dispatchState === 'unknown' && entry.recovered !== true)
+    )
+    .map((entry) => entry.clientMessageId)
   for (const clientMessageId of pending) {
     await journal.resolveDispatch({
       clientMessageId,
       state: 'unknown',
-      reason: 'host_restarted_before_acknowledgement',
+      reason,
       fence,
       recovered: true
     })

--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -256,12 +256,15 @@ function applyDispatch(
   if (submission.dispatchState === 'rejected' || submission.dispatchState === 'accepted') {
     return
   }
+  submission.fence = row.fence
   submission.dispatchState = row.state
   submission.providerItemId = row.providerItemId
   submission.reason = row.reason
   submission.resolvedAt = row.ts
   if (row.recovered) {
     submission.recovered = row.recovered
+  } else {
+    delete submission.recovered
   }
   if (row.state !== 'accepted' || !row.providerItemId) {
     return

--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -260,6 +260,9 @@ function applyDispatch(
   submission.providerItemId = row.providerItemId
   submission.reason = row.reason
   submission.resolvedAt = row.ts
+  if (row.recovered) {
+    submission.recovered = row.recovered
+  }
   if (row.state !== 'accepted' || !row.providerItemId) {
     return
   }

--- a/src/main/native-chat/agent-session-journal/journal-store.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.ts
@@ -245,10 +245,9 @@ export class AgentSessionJournal {
     }))
   }
 
-  /** On restart every `pending` submission becomes `unknown` before the session
-   *  accepts a writer. Orca never re-sends on the user's behalf. */
-  async markPendingSubmissionsUnknown(fence: number): Promise<string[]> {
-    return markJournalPendingSubmissionsUnknown(this, fence)
+  /** Retire unanswered sends after their execution owner ended, without assuming delivery. */
+  async markPendingSubmissionsUnknown(fence: number, reason?: string): Promise<string[]> {
+    return markJournalPendingSubmissionsUnknown(this, fence, reason)
   }
 
   /** The escape hatch for corruption, an unreconcilable prefix, a forked handle,

--- a/src/main/native-chat/agent-session-wire/provider-frame-activity.test.ts
+++ b/src/main/native-chat/agent-session-wire/provider-frame-activity.test.ts
@@ -38,36 +38,24 @@ describe('provider frame activity', () => {
     }
   })
 
-  it('uses Claude descriptions and safe semantic status without exposing tool labels', () => {
-    expect(
-      claudeProviderFrameActivity('message:system:task_started', {
-        description: 'Trace the activity channel'
-      })
-    ).toBe('Working on: Trace the activity channel')
-    expect(
-      claudeProviderFrameActivity('message:system:task_progress', {
-        description: 'Reading tests',
-        summary: 'Checking remote compatibility'
-      })
-    ).toBe('Checking remote compatibility')
-    expect(
-      claudeProviderFrameActivity('message:system:task_updated', {
-        patch: { description: 'Validating the renderer' }
-      })
-    ).toBe('Validating the renderer')
+  it('leaves the Claude line on the generic fallback, since Claude never narrates its turn', () => {
+    // Prose on these frames belongs to a spawned task, not to this turn.
+    for (const [kind, payload] of [
+      ['message:system:task_started', { description: 'Trace the activity channel' }],
+      ['message:system:task_progress', { summary: 'Checking remote compatibility' }],
+      ['message:system:task_updated', { patch: { description: 'Validating the renderer' } }],
+      ['message:system:control_request_progress', { status: 'api_retry' }],
+      ['message:tool_progress', { tool_name: 'ReadSecretFile' }]
+    ] as const) {
+      expect(claudeProviderFrameActivity(kind, payload)).toBeNull()
+    }
+    // `requesting` holds for nearly the whole turn and says no more than the fallback.
+    expect(claudeProviderFrameActivity('message:system:status', { status: 'requesting' })).toBeNull()
     expect(claudeProviderFrameActivity('message:system:status', { status: 'compacting' })).toBe(
       'Compacting the conversation'
     )
-    expect(
-      claudeProviderFrameActivity('message:system:control_request_progress', {
-        status: 'api_retry'
-      })
-    ).toBe('Retrying a side question')
-    expect(
-      claudeProviderFrameActivity('message:tool_progress', {
-        tool_name: 'ReadSecretFile'
-      })
-    ).toBeNull()
+    // An unmodeled frame still declines to answer, so it cannot clear live copy.
+    expect(claudeProviderFrameActivity('message:system:unknown_frame', {})).toBeUndefined()
   })
 
   it('falls through on protocol noise and bounds long copy', () => {

--- a/src/main/native-chat/agent-session-wire/provider-frame-activity.ts
+++ b/src/main/native-chat/agent-session-wire/provider-frame-activity.ts
@@ -100,40 +100,29 @@ export function codexProviderFrameActivity(
   return itemType ? (CODEX_ITEM_ACTIVITY[itemType] ?? null) : null
 }
 
+/**
+ * Claude does not narrate its own turn, so the activity line stays the generic fallback.
+ *
+ * Codex names each item it starts, which is what makes its line worth reading. Claude's only
+ * turn-wide frame is `system/status`, whose payload is a bare token — every sentence Orca ever
+ * put on this line for it was Orca's own wording for `requesting`, which is true for nearly the
+ * whole turn and says no more than the fallback does. Its `task_*` frames do carry prose, but
+ * they are keyed by task id and subagent type: they describe a spawned task, not this turn, and
+ * the background-tasks strip already owns that. Compaction is the one exception kept — a real,
+ * rare state that explains an otherwise unexplained wait, and the Codex map reports it too.
+ */
 export function claudeProviderFrameActivity(kind: string, payload: unknown): ActivityText {
   const source = record(payload)
-  if (kind === 'message:system:task_started') {
-    if (source?.ambient === true || source?.skip_transcript === true) {
-      return null
-    }
-    const description = providerActivityText(stringField(source, 'description'))
-    return description ? providerActivityText(`Working on: ${description}`) : null
-  }
-  if (kind === 'message:system:task_progress') {
-    return providerActivityText(
-      stringField(source, 'summary') ?? stringField(source, 'description')
-    )
-  }
-  if (kind === 'message:system:task_updated') {
-    return providerActivityText(stringField(record(source?.patch), 'description'))
-  }
   if (kind === 'message:system:status') {
-    const status = stringField(source, 'status')
-    return status === 'compacting'
-      ? 'Compacting the conversation'
-      : status === 'requesting'
-        ? 'Requesting a response'
-        : null
+    return stringField(source, 'status') === 'compacting' ? 'Compacting the conversation' : null
   }
-  if (kind === 'message:system:control_request_progress') {
-    const status = stringField(source, 'status')
-    return status === 'started'
-      ? 'Exploring a side question'
-      : status === 'api_retry'
-        ? 'Retrying a side question'
-        : null
-  }
-  if (kind === 'message:tool_progress') {
+  if (
+    kind === 'message:system:task_started' ||
+    kind === 'message:system:task_progress' ||
+    kind === 'message:system:task_updated' ||
+    kind === 'message:system:control_request_progress' ||
+    kind === 'message:tool_progress'
+  ) {
     return null
   }
   return undefined

--- a/src/main/native-chat/agent-session-wire/provider-turn-activity-routing.test.ts
+++ b/src/main/native-chat/agent-session-wire/provider-turn-activity-routing.test.ts
@@ -248,10 +248,11 @@ describe('provider turn activity routing', () => {
       })
     )
     expect(state.rows).toHaveLength(turnRows)
+    // Only compaction reaches the line; task and side-question prose is not this turn's work.
     expect(state.activities.slice(-3)).toEqual([
-      { turnId: TURN_ID, text: 'Checking the renderer state' },
+      null,
       { turnId: TURN_ID, text: 'Compacting the conversation' },
-      { turnId: TURN_ID, text: 'Exploring a side question' }
+      null
     ])
 
     translator.handle(claudeMessage({ type: 'tool_progress', tool_name: 'SecretReader' }))

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host-handoff.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host-handoff.ts
@@ -86,6 +86,13 @@ export function createStructuredAgentSessionHostHandoff(
       host.publishStatus?.(sessionId)
       try {
         await host.flush(sessionId)
+        const session = host.session(sessionId)
+        await session.journal.markPendingSubmissionsUnknown(
+          session.fence,
+          'provider_exited_before_acknowledgement'
+        )
+        host.subscribers.publish(sessionId, session.journal)
+        host.publishStatus?.(sessionId)
         host.eventSink(sessionId).unbind()
         return { state: 'stopped' }
       } catch (error) {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-send-idempotency.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-send-idempotency.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AgentJournalMessageItem } from '../../../shared/agent-session-journal-types'
+import { hasUnansweredStructuredAgentSessionDispatch } from '../../../shared/structured-agent-session-projection'
 import { structuredAgentSessionPayloadFingerprint } from '../../../shared/structured-agent-session-mutation'
 import { createTrackedJournalOpener } from '../agent-session-journal/journal-store-test-open'
 import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
@@ -34,6 +35,39 @@ afterEach(async () => {
 })
 
 describe('structured send idempotency', () => {
+  it('publishes a recovered retry as working before waiting for its provider', async () => {
+    const body: AgentJournalMessageItem = {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'retry' }]
+    }
+    const input = { clientMessageId: 'retry-id', payloadFingerprint: 'fingerprint', body }
+    await journal.appendSubmission({ ...input, fence: 1 })
+    await journal.markPendingSubmissionsUnknown(2)
+    const originalItem = journal.snapshot().items[0]
+    const publish = vi.fn()
+    const dispatch = vi.fn(async () => {
+      expect(publish).toHaveBeenCalledOnce()
+      expect(hasUnansweredStructuredAgentSessionDispatch(journal.submissions(), 2)).toBe(true)
+      return { state: 'unknown' as const, reason: 'ack timeout' }
+    })
+    await performSend(
+      {
+        sessionId: 'session-1',
+        journal,
+        fence: 2,
+        adapter: { dispatch } as unknown as StructuredAgentSessionAdapter,
+        persistOptions: async () => undefined,
+        resolvedBy: 'caller',
+        publish,
+        now: () => 1
+      },
+      { ...input, retryUnknown: true }
+    )
+    expect(hasUnansweredStructuredAgentSessionDispatch(journal.submissions(), 2)).toBe(true)
+    expect(journal.snapshot().items).toEqual([originalItem])
+  })
+
   it('does not redispatch one send id reused across caller ledgers', async () => {
     const body: AgentJournalMessageItem = {
       kind: 'message',

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.test.ts
@@ -56,9 +56,11 @@ async function openJournal(sessionId = SESSION, now?: () => number) {
 function indexed(session: {
   journal: Awaited<ReturnType<typeof openJournal>>
   hasProviderChild?: boolean
+  fence?: number
 }) {
   return {
     journal: session.journal,
+    fence: session.fence ?? 1,
     ...(session.hasProviderChild !== undefined
       ? { hasProviderChild: session.hasProviderChild }
       : {}),
@@ -69,7 +71,7 @@ function indexed(session: {
 function feedFor(
   sessions: Map<
     string,
-    { journal: Awaited<ReturnType<typeof openJournal>>; hasProviderChild?: boolean }
+    { journal: Awaited<ReturnType<typeof openJournal>>; hasProviderChild?: boolean; fence?: number }
   >,
   record: Partial<AgentSessionRecord> | null = null,
   onStatusChanged?: StructuredAgentSessionStatusFeedDeps['onStatusChanged']
@@ -151,6 +153,29 @@ describe('StructuredAgentSessionStatusFeed', () => {
         ]
       }
     ])
+  })
+
+  it('stops projecting an old-host unknown submission after the owner fence advances', async () => {
+    const journal = await openJournal()
+    const session = { journal, fence: 1 }
+    const { feed, events } = feedFor(new Map([[SESSION, session]]))
+    await journal.appendSubmission({
+      clientMessageId: 'old-host',
+      payloadFingerprint: 'fp',
+      body: { kind: 'message', role: 'user', blocks: [{ type: 'text', text: 'slow' }] },
+      fence: 1
+    })
+    await journal.resolveDispatch({
+      clientMessageId: 'old-host',
+      state: 'unknown',
+      reason: 'ack timeout',
+      fence: 1
+    })
+    feed.publish(SESSION)
+    expect(events.at(-1)).toMatchObject({ session: { status: 'working' } })
+    session.fence = 2
+    feed.publish(SESSION)
+    expect(events.at(-1)).toMatchObject({ session: { status: 'idle' } })
   })
 
   it('publishes working from the pending submission, before the provider replays the turn', async () => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.test.ts
@@ -153,6 +153,36 @@ describe('StructuredAgentSessionStatusFeed', () => {
     ])
   })
 
+  it('publishes working from the pending submission, before the provider replays the turn', async () => {
+    const journal = await openJournal()
+    const { feed, events } = feedFor(new Map([[SESSION, { journal }]]))
+    events.length = 0
+    await journal.appendSubmission({
+      clientMessageId: 'client-1',
+      payloadFingerprint: 'fingerprint-1',
+      body: { kind: 'message', role: 'user', blocks: [{ type: 'text', text: 'write a poem' }] },
+      fence: 1
+    })
+
+    feed.publish(SESSION)
+    expect(events.at(-1)).toEqual({
+      type: 'status',
+      session: expect.objectContaining({ status: 'working' })
+    })
+
+    await journal.resolveDispatch({
+      clientMessageId: 'client-1',
+      state: 'accepted',
+      providerIdentity: USER_IDENTITY,
+      fence: 1
+    })
+    feed.publish(SESSION)
+    expect(events.at(-1)).toEqual({
+      type: 'status',
+      session: expect.objectContaining({ status: 'idle' })
+    })
+  })
+
   it('publishes working, then idle once the running marker is tombstoned, and never a repeat', async () => {
     const journal = await openJournal()
     const { feed, events } = feedFor(new Map([[SESSION, { journal }]]))

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.ts
@@ -31,6 +31,7 @@ type StatusFeedSession = {
   journal: AgentSessionJournal
   params: { location: { workspaceId: string }; provider: AgentSessionRecord['provider'] }
   hasProviderChild?: boolean
+  fence?: number
 }
 
 export type StructuredAgentSessionStatusFeedDeps = {
@@ -166,7 +167,7 @@ export class StructuredAgentSessionStatusFeed {
       workspaceId: session.params.location.workspaceId,
       agent: session.params.provider,
       ...(session.hasProviderChild ? { hostExecutionOwned: true as const } : {}),
-      ...projectStructuredAgentSessionStatusSummary(items, submissions),
+      ...projectStructuredAgentSessionStatusSummary(items, submissions, session.fence),
       ...(record?.rewind?.phase === 'prepared' || record?.rewind?.phase === 'provider-succeeded'
         ? { rewindBlockedReason: 'outcome-unknown' as const }
         : {}),

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.ts
@@ -153,7 +153,9 @@ export class StructuredAgentSessionStatusFeed {
     journal: AgentSessionJournal
   ): AgentSessionStatusSummary {
     // An unreadable journal projects as "no turn": the chat itself shows the reset.
-    const items = journal.isReadOnly ? [] : journal.snapshot().items
+    const snapshot = journal.isReadOnly ? null : journal.snapshot()
+    const items = snapshot?.items ?? []
+    const submissions = snapshot?.submissions ?? []
     const record = this.deps.getRecord(sessionId)
     const providerSession = structuredAgentSessionProviderSessionMetadata(record)
     // The journal has no model: the record's acknowledged options are where an owner
@@ -164,7 +166,7 @@ export class StructuredAgentSessionStatusFeed {
       workspaceId: session.params.location.workspaceId,
       agent: session.params.provider,
       ...(session.hasProviderChild ? { hostExecutionOwned: true as const } : {}),
-      ...projectStructuredAgentSessionStatusSummary(items),
+      ...projectStructuredAgentSessionStatusSummary(items, submissions),
       ...(record?.rewind?.phase === 'prepared' || record?.rewind?.phase === 'provider-succeeded'
         ? { rewindBlockedReason: 'outcome-unknown' as const }
         : {}),

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-surface-lifetime.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-surface-lifetime.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 import type { AgentSessionOwnerProbe } from '../../../shared/agent-session-lease-adjudication'
+import { hasUnansweredStructuredAgentSessionDispatch } from '../../../shared/structured-agent-session-projection'
 import { computeAgentSessionPayloadFingerprint } from '../../../shared/agent-session-mutation-envelope'
 import type {
   AgentSessionMutationEnvelope,
@@ -334,6 +335,11 @@ describe('an unexpected provider exit', () => {
       acquisitionGeneration: 'generation-1'
     })
 
+    const recoveredHistory = host.history({ sessionId: SESSION, direction: 'tail' })
+    expect(
+      recoveredHistory.ok &&
+        hasUnansweredStructuredAgentSessionDispatch(recoveredHistory.page.submissions)
+    ).toBe(false)
     expect(acquire).toHaveBeenCalledTimes(2)
     expect(dispatch).toHaveBeenCalledOnce()
     expect(store.getRecord(SESSION)?.lease).toMatchObject({

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
@@ -97,6 +97,15 @@ export async function performSend(
   if (!(input.retryUnknown && existing?.dispatchState === 'unknown')) {
     await ctx.journal.appendSubmission({ ...input, fence: ctx.fence })
     ctx.publish()
+  } else {
+    // Retry resumes work without moving or duplicating the original message.
+    await ctx.journal.resolveDispatch({
+      clientMessageId: input.clientMessageId,
+      state: 'unknown',
+      reason: 'dispatch_retry_in_progress',
+      fence: ctx.fence
+    })
+    ctx.publish()
   }
 
   const outcome = await dispatchSafely(ctx, input.clientMessageId, input.body)
@@ -124,8 +133,7 @@ export async function performSend(
         clientMessageId: input.clientMessageId,
         state: 'unknown',
         reason: 'dispatch_result_persistence_failed',
-        fence: ctx.fence,
-        recovered: true
+        fence: ctx.fence
       })
     } catch {
       // Nothing further to record; the pending row is settled on the next attach.

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-unexpected-exit.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-unexpected-exit.test.ts
@@ -49,7 +49,11 @@ describe('provider-exit recovery tickets', () => {
       hasProviderChild: true,
       fence: 7,
       acquisitionGeneration: GENERATION,
-      journal: { snapshot: () => ({ items: [] }), appendLifecycleBatch }
+      journal: {
+        snapshot: () => ({ items: [] }),
+        appendLifecycleBatch,
+        markPendingSubmissionsUnknown: vi.fn(async () => [])
+      }
     } as unknown as StructuredAgentSessionHostSession
     const store = {
       getRecord: () => ({
@@ -89,6 +93,10 @@ describe('provider-exit recovery tickets', () => {
 
     expect(result).toMatchObject({ settlementRetryRequired: false, releasedFence: 8 })
     expect(appendLifecycleBatch).toHaveBeenCalledOnce()
+    expect(session.journal.markPendingSubmissionsUnknown).toHaveBeenCalledWith(
+      7,
+      'provider_exited_before_acknowledgement'
+    )
     expect(session.hasProviderChild).toBe(false)
   })
 
@@ -98,6 +106,7 @@ describe('provider-exit recovery tickets', () => {
       fence: 7,
       acquisitionGeneration: GENERATION,
       journal: {
+        markPendingSubmissionsUnknown: vi.fn(async () => []),
         snapshot: () => ({ items: [] }),
         appendLifecycleBatch: vi.fn(async () => {
           throw new Error('journal still unavailable')

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-unexpected-exit.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-unexpected-exit.ts
@@ -81,6 +81,15 @@ export async function settleUnexpectedStructuredAgentSessionExit(
         settlementRetryRequired = true
         context.onBarrierError?.(unexpectedEvent.sessionId, error)
       }
+      try {
+        await session.journal.markPendingSubmissionsUnknown(
+          session.fence,
+          'provider_exited_before_acknowledgement'
+        )
+      } catch (error) {
+        settlementRetryRequired = true
+        context.onBarrierError?.(unexpectedEvent.sessionId, error)
+      }
       if (unexpectedEvent.settlementRetryRequired || settlementRetryRequired) {
         const retried = await retryUnexpectedExitSettlement({
           context,
@@ -170,6 +179,10 @@ export async function retryUnexpectedExitSettlement(input: {
   stableSettlementId: string
 }): Promise<boolean> {
   try {
+    await input.session.journal.markPendingSubmissionsUnknown(
+      input.session.fence,
+      'provider_exited_before_acknowledgement'
+    )
     const mutations = unexpectedExitFallbackMutations(
       input.event,
       input.session,

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -352,7 +352,9 @@ export function NativeChatStructuredSession(
           targetPtyId={null}
           agent={props.agent}
           canSend={!prompt}
-          isWorking={controller.isWorking}
+          // Stop, not status: only a provider-minted turn can be interrupted, so the button
+          // must not flip while a dispatch is still unanswered.
+          isWorking={controller.turnId !== null}
           onStop={() => {
             if (controller.turnId) {
               void controller.cancel(controller.turnId)

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
 }))
 let fence = 3
 let sessionCommands: { name: string; kind: 'command' | 'skill' }[] | undefined
+let submissions: AgentJournalSubmission[] = []
 
 vi.mock('@/runtime/structured-agent-session-client', () => ({
   callStructuredAgentSession: mocks.call
@@ -25,7 +26,7 @@ vi.mock('./use-structured-agent-session-read', () => ({
       fence,
       commands: sessionCommands,
       items: [],
-      submissions: [],
+      submissions,
       status: 'ready',
       error: null,
       hasOlder: false,
@@ -47,6 +48,7 @@ vi.mock('./use-structured-agent-session-outbox', () => ({
   })
 }))
 
+import type { AgentJournalSubmission } from '../../../../shared/agent-session-journal-types'
 import {
   applyNativeChatSessionOptionSettingsMutation,
   resolveStructuredLaunchSeedOptions
@@ -95,10 +97,72 @@ const OPTIONS = {
   current: { model: 'gpt-live', effort: 'medium' }
 }
 
+describe('useStructuredAgentSession working state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fence = 3
+    submissions = []
+    mocks.call.mockResolvedValue(null)
+  })
+
+  it('reports work from an unanswered dispatch, and keeps the turn id provider-minted', () => {
+    submissions = [
+      {
+        clientMessageId: 'client-1',
+        fence: 3,
+        payloadFingerprint: 'fingerprint-1',
+        dispatchState: 'pending',
+        providerItemId: null,
+        reason: null,
+        submittedAt: 1,
+        resolvedAt: null
+      }
+    ]
+    const { result } = renderHook(() =>
+      useStructuredAgentSession({
+        sessionId: 'session-1',
+        agent: 'codex',
+        target: LOCAL_TARGET,
+        isVisible: true
+      })
+    )
+
+    expect(result.current.isWorking).toBe(true)
+    // Only the provider can mint a cancellable turn, so Stop stays unavailable here.
+    expect(result.current.turnId).toBeNull()
+  })
+
+  it('reports no work once the dispatch resolves and no turn is running', () => {
+    submissions = [
+      {
+        clientMessageId: 'client-1',
+        fence: 3,
+        payloadFingerprint: 'fingerprint-1',
+        dispatchState: 'accepted',
+        providerItemId: 'codex:thread-1:turn-1',
+        reason: null,
+        submittedAt: 1,
+        resolvedAt: 2
+      }
+    ]
+    const { result } = renderHook(() =>
+      useStructuredAgentSession({
+        sessionId: 'session-1',
+        agent: 'codex',
+        target: LOCAL_TARGET,
+        isVisible: true
+      })
+    )
+
+    expect(result.current.isWorking).toBe(false)
+  })
+})
+
 describe('useStructuredAgentSession options', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     fence = 3
+    submissions = []
     mocks.operationId
       .mockReset()
       .mockReturnValueOnce('operation-1')

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.ts
@@ -86,8 +86,7 @@ export function useStructuredAgentSession(args: {
   // A dispatch the provider has not answered is already work; Claude's running row trails the
   // send by seconds, and only a provider-minted turn is cancellable, so the two stay separate.
   const isWorking =
-    turnId !== null ||
-    hasUnansweredStructuredAgentSessionDispatch(state.submissions)
+    turnId !== null || hasUnansweredStructuredAgentSessionDispatch(state.submissions, state.fence)
   const turnActivity = useMemo(
     () => selectStructuredAgentTurnActivity(state.items, turnId, state.activity),
     [state.activity, state.items, turnId]

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.ts
@@ -22,7 +22,10 @@ import {
   structuredAgentSessionOptionPicks,
   structuredAgentSessionOptionSnapshot
 } from '../../../../shared/structured-agent-session-options'
-import { activeStructuredAgentSessionTurnId } from '../../../../shared/structured-agent-session-projection'
+import {
+  activeStructuredAgentSessionTurnId,
+  hasUnansweredStructuredAgentSessionDispatch
+} from '../../../../shared/structured-agent-session-projection'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import { callStructuredAgentSession } from '@/runtime/structured-agent-session-client'
 import { useStructuredAgentSessionHold } from './use-structured-agent-session-hold'
@@ -80,6 +83,11 @@ export function useStructuredAgentSession(args: {
 
   // Refresh options each turn to confirm which model the provider actually selected.
   const turnId = activeStructuredAgentSessionTurnId(state.items)
+  // A dispatch the provider has not answered is already work; Claude's running row trails the
+  // send by seconds, and only a provider-minted turn is cancellable, so the two stay separate.
+  const isWorking =
+    turnId !== null ||
+    hasUnansweredStructuredAgentSessionDispatch(state.submissions)
   const turnActivity = useMemo(
     () => selectStructuredAgentTurnActivity(state.items, turnId, state.activity),
     [state.activity, state.items, turnId]
@@ -210,7 +218,7 @@ export function useStructuredAgentSession(args: {
     send: (...input: Parameters<typeof outboxController.send>) =>
       !commandPending.current && outboxController.send(...input),
     retry: outboxController.retry,
-    isWorking: turnId !== null,
+    isWorking,
     turnActivity,
     ...backgroundTasksView,
     turnId,

--- a/src/shared/agent-session-journal-schemas.ts
+++ b/src/shared/agent-session-journal-schemas.ts
@@ -186,7 +186,8 @@ export const AgentJournalSubmissionSchema = z.object({
   providerItemId: z.string().nullable(),
   reason: z.string().nullable(),
   submittedAt: z.number(),
-  resolvedAt: z.number().nullable()
+  resolvedAt: z.number().nullable(),
+  recovered: z.literal(true).optional()
 })
 
 export function isAdmissibleAgentJournalItemBody(value: unknown): value is AgentJournalItemBody {

--- a/src/shared/agent-session-journal-types.ts
+++ b/src/shared/agent-session-journal-types.ts
@@ -193,6 +193,7 @@ export type AgentJournalDispatchState = (typeof AGENT_JOURNAL_DISPATCH_STATES)[n
  *  the turn reads as delivery unconfirmed, never as sent and never as failed. */
 export type AgentJournalSubmission = {
   clientMessageId: string
+  /** Execution fence of the latest dispatch attempt or recovery. */
   fence: number
   payloadFingerprint: string
   dispatchState: AgentJournalDispatchState

--- a/src/shared/agent-session-journal-types.ts
+++ b/src/shared/agent-session-journal-types.ts
@@ -202,6 +202,9 @@ export type AgentJournalSubmission = {
   reason: string | null
   submittedAt: number
   resolvedAt: number | null
+  /** Set when crash reconciliation resolved the dispatch, not the provider. A live
+   *  `unknown` is a send still outstanding; a recovered one outlived its writer. */
+  recovered?: true
 }
 
 /** Durable answer to "did my send land?", keyed by client message id. Only an

--- a/src/shared/structured-agent-session-projection.test.ts
+++ b/src/shared/structured-agent-session-projection.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { AGENT_STATUS_MAX_FIELD_LENGTH } from './agent-status-field-normalization'
-import type {
-  AgentJournalRenderItem,
-  AgentJournalSubmission
-} from './agent-session-journal-types'
+import type { AgentJournalRenderItem, AgentJournalSubmission } from './agent-session-journal-types'
 import { parsePaneKey } from './stable-pane-id'
 import {
   activeStructuredAgentSessionTurnId,
@@ -180,6 +177,20 @@ describe('structured agent session status projection', () => {
     })
   })
 
+  it('does not resurrect old-host unknown work after its execution fence advances', () => {
+    const oldHostSubmission = { ...submission('m1', 'unknown'), fence: 2 }
+    expect(hasUnansweredStructuredAgentSessionDispatch([oldHostSubmission], 2)).toBe(true)
+    expect(hasUnansweredStructuredAgentSessionDispatch([oldHostSubmission], 3)).toBe(false)
+  })
+
+  it('recognizes recovery from an older host without the optional marker', () => {
+    expect(
+      hasUnansweredStructuredAgentSessionDispatch([
+        { ...submission('m1', 'unknown'), reason: 'host_restarted_before_acknowledgement' }
+      ])
+    ).toBe(false)
+  })
+
   it('stops reading a resolved dispatch as work, and lets a pending prompt outrank it', () => {
     const asked = item('asked', 1, {
       kind: 'message',
@@ -205,9 +216,9 @@ describe('structured agent session status projection', () => {
         { ...submission('m1', 'unknown'), recovered: true }
       ])
     ).toBe(false)
-    expect(projectStructuredAgentSessionStatus([asked, prompt], [submission('m1', 'pending')])).toBe(
-      'attention'
-    )
+    expect(
+      projectStructuredAgentSessionStatus([asked, prompt], [submission('m1', 'pending')])
+    ).toBe('attention')
     expect(projectStructuredAgentSessionStatusSummary([], [])).toEqual({
       status: null,
       latestPrompt: ''

--- a/src/shared/structured-agent-session-projection.test.ts
+++ b/src/shared/structured-agent-session-projection.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { AGENT_STATUS_MAX_FIELD_LENGTH } from './agent-status-field-normalization'
-import type { AgentJournalRenderItem } from './agent-session-journal-types'
+import type {
+  AgentJournalRenderItem,
+  AgentJournalSubmission
+} from './agent-session-journal-types'
 import { parsePaneKey } from './stable-pane-id'
 import {
   activeStructuredAgentSessionTurnId,
   hasPersistedStructuredAgentSessionTurn,
+  hasUnansweredStructuredAgentSessionDispatch,
   projectStructuredItemToNativeChat,
   projectStructuredAgentSessionStatus,
   projectStructuredAgentSessionStatusSummary,
@@ -17,6 +21,22 @@ function item(
   body: AgentJournalRenderItem['body']
 ): AgentJournalRenderItem {
   return { itemId, sequence, revision: 1, observedAt: sequence, body }
+}
+
+function submission(
+  clientMessageId: string,
+  dispatchState: AgentJournalSubmission['dispatchState']
+): AgentJournalSubmission {
+  return {
+    clientMessageId,
+    fence: 1,
+    payloadFingerprint: clientMessageId,
+    dispatchState,
+    providerItemId: null,
+    reason: null,
+    submittedAt: 1,
+    resolvedAt: dispatchState === 'pending' ? null : 2
+  }
 }
 
 describe('structured agent session status projection', () => {
@@ -136,6 +156,61 @@ describe('structured agent session status projection', () => {
     expect(projectStructuredAgentSessionStatusSummary([first, second])).toEqual({
       status: 'idle',
       latestPrompt: 'second line'
+    })
+  })
+
+  it('reads a session as working while a dispatch is unanswered, before any lifecycle row', () => {
+    const asked = item('asked', 1, {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'go' }]
+    })
+    const pending = [submission('m1', 'pending')]
+
+    expect(hasUnansweredStructuredAgentSessionDispatch(pending)).toBe(true)
+    expect(projectStructuredAgentSessionStatus([asked], pending)).toBe('working')
+    // The first send has no journalled message until the provider replays it.
+    expect(projectStructuredAgentSessionStatusSummary([], pending)).toEqual({
+      status: 'working',
+      latestPrompt: ''
+    })
+    expect(projectStructuredAgentSessionStatusSummary([asked], pending)).toEqual({
+      status: 'working',
+      latestPrompt: 'go'
+    })
+  })
+
+  it('stops reading a resolved dispatch as work, and lets a pending prompt outrank it', () => {
+    const asked = item('asked', 1, {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'go' }]
+    })
+    const prompt = item('prompt', 2, {
+      kind: 'approval',
+      title: 'Run command?',
+      detail: null,
+      options: [{ id: 'yes', label: 'Allow' }],
+      resolution: { state: 'pending', selectedOptionId: null, resolvedBy: null, resolvedAt: null }
+    })
+
+    for (const state of ['accepted', 'rejected'] as const) {
+      expect(hasUnansweredStructuredAgentSessionDispatch([submission('m1', state)])).toBe(false)
+      expect(projectStructuredAgentSessionStatus([asked], [submission('m1', state)])).toBe('idle')
+    }
+    // The ack budget elapsing is a delivery answer, not an answer about the turn.
+    expect(hasUnansweredStructuredAgentSessionDispatch([submission('m1', 'unknown')])).toBe(true)
+    expect(
+      hasUnansweredStructuredAgentSessionDispatch([
+        { ...submission('m1', 'unknown'), recovered: true }
+      ])
+    ).toBe(false)
+    expect(projectStructuredAgentSessionStatus([asked, prompt], [submission('m1', 'pending')])).toBe(
+      'attention'
+    )
+    expect(projectStructuredAgentSessionStatusSummary([], [])).toEqual({
+      status: null,
+      latestPrompt: ''
     })
   })
 

--- a/src/shared/structured-agent-session-projection.ts
+++ b/src/shared/structured-agent-session-projection.ts
@@ -190,12 +190,17 @@ export function hasPersistedStructuredAgentSessionTurn(
  * that sent it, so there is nothing still running to report.
  */
 export function hasUnansweredStructuredAgentSessionDispatch(
-  submissions: readonly AgentJournalSubmission[]
+  submissions: readonly AgentJournalSubmission[],
+  currentFence?: number | null
 ): boolean {
   return submissions.some(
     (submission) =>
-      submission.dispatchState === 'pending' ||
-      (submission.dispatchState === 'unknown' && submission.recovered !== true)
+      (currentFence == null || submission.fence >= currentFence) &&
+      (submission.dispatchState === 'pending' ||
+        (submission.dispatchState === 'unknown' &&
+          submission.recovered !== true &&
+          // Older hosts publish the recovery reason but omit the optional marker.
+          submission.reason !== 'host_restarted_before_acknowledgement'))
   )
 }
 
@@ -207,7 +212,8 @@ export function structuredAgentSessionTabId(sessionId: string): string {
 
 export function projectStructuredAgentSessionStatus(
   items: readonly AgentJournalRenderItem[],
-  submissions: readonly AgentJournalSubmission[] = []
+  submissions: readonly AgentJournalSubmission[] = [],
+  currentFence?: number | null
 ): StructuredAgentSessionProjectedStatus {
   if (
     items.some(
@@ -219,7 +225,7 @@ export function projectStructuredAgentSessionStatus(
     return 'attention'
   }
   return activeStructuredAgentSessionTurnId(items) ||
-    hasUnansweredStructuredAgentSessionDispatch(submissions)
+    hasUnansweredStructuredAgentSessionDispatch(submissions, currentFence)
     ? 'working'
     : 'idle'
 }
@@ -299,17 +305,18 @@ export type StructuredAgentSessionStatusProjection = {
  *  has to stay small even though the row only ever renders one line of it. */
 export function projectStructuredAgentSessionStatusSummary(
   items: readonly AgentJournalRenderItem[],
-  submissions: readonly AgentJournalSubmission[] = []
+  submissions: readonly AgentJournalSubmission[] = [],
+  currentFence?: number | null
 ): StructuredAgentSessionStatusProjection {
   // A first send has no journalled message until the provider replays it, so the pending
   // dispatch is also what makes a brand-new session listable at all.
   if (
     !hasPersistedStructuredAgentSessionTurn(items) &&
-    !hasUnansweredStructuredAgentSessionDispatch(submissions)
+    !hasUnansweredStructuredAgentSessionDispatch(submissions, currentFence)
   ) {
     return { status: null, latestPrompt: '' }
   }
-  const status = projectStructuredAgentSessionStatus(items, submissions)
+  const status = projectStructuredAgentSessionStatus(items, submissions, currentFence)
   const activeToolCall = status === 'working' ? activeStructuredAgentSessionToolCall(items) : null
   const toolName = activeToolCall
     ? normalizeOptionalField(activeToolCall.name, AGENT_STATUS_TOOL_NAME_MAX_LENGTH)

--- a/src/shared/structured-agent-session-projection.ts
+++ b/src/shared/structured-agent-session-projection.ts
@@ -5,6 +5,7 @@ import {
 } from './agent-status-field-normalization'
 import type {
   AgentJournalRenderItem,
+  AgentJournalSubmission,
   AgentJournalToolCallItem
 } from './agent-session-journal-types'
 import {
@@ -175,6 +176,29 @@ export function hasPersistedStructuredAgentSessionTurn(
   )
 }
 
+/**
+ * A send the host has journaled that the provider has neither opened a turn for nor refused.
+ *
+ * Codex declares `turn/started` within ~150ms, but Claude's running row can only be written once
+ * the SDK echoes the user message back — a 3.4s median and 18s at p90 on real journals. Waiting
+ * on that echo to call a session working leaves the whole gap reading idle in the chat and in
+ * every session list, so the send itself is the evidence.
+ *
+ * `unknown` still counts: it only means the ack budget elapsed, which happens on 30% of Claude
+ * sends whose turn then arrives anyway, and delivery confidence is a separate question from
+ * whether work is owed. A recovered `unknown` does not — that one outlived the host generation
+ * that sent it, so there is nothing still running to report.
+ */
+export function hasUnansweredStructuredAgentSessionDispatch(
+  submissions: readonly AgentJournalSubmission[]
+): boolean {
+  return submissions.some(
+    (submission) =>
+      submission.dispatchState === 'pending' ||
+      (submission.dispatchState === 'unknown' && submission.recovered !== true)
+  )
+}
+
 export type StructuredAgentSessionProjectedStatus = 'working' | 'attention' | 'idle'
 
 export function structuredAgentSessionTabId(sessionId: string): string {
@@ -182,7 +206,8 @@ export function structuredAgentSessionTabId(sessionId: string): string {
 }
 
 export function projectStructuredAgentSessionStatus(
-  items: readonly AgentJournalRenderItem[]
+  items: readonly AgentJournalRenderItem[],
+  submissions: readonly AgentJournalSubmission[] = []
 ): StructuredAgentSessionProjectedStatus {
   if (
     items.some(
@@ -193,7 +218,10 @@ export function projectStructuredAgentSessionStatus(
   ) {
     return 'attention'
   }
-  return activeStructuredAgentSessionTurnId(items) ? 'working' : 'idle'
+  return activeStructuredAgentSessionTurnId(items) ||
+    hasUnansweredStructuredAgentSessionDispatch(submissions)
+    ? 'working'
+    : 'idle'
 }
 
 function messageProse(blocks: readonly NativeChatBlock[]): string {
@@ -270,12 +298,18 @@ export type StructuredAgentSessionStatusProjection = {
  *  the 8 KB body): a streamed reply re-projects on every journal checkpoint, so the frame
  *  has to stay small even though the row only ever renders one line of it. */
 export function projectStructuredAgentSessionStatusSummary(
-  items: readonly AgentJournalRenderItem[]
+  items: readonly AgentJournalRenderItem[],
+  submissions: readonly AgentJournalSubmission[] = []
 ): StructuredAgentSessionStatusProjection {
-  if (!hasPersistedStructuredAgentSessionTurn(items)) {
+  // A first send has no journalled message until the provider replays it, so the pending
+  // dispatch is also what makes a brand-new session listable at all.
+  if (
+    !hasPersistedStructuredAgentSessionTurn(items) &&
+    !hasUnansweredStructuredAgentSessionDispatch(submissions)
+  ) {
     return { status: null, latestPrompt: '' }
   }
-  const status = projectStructuredAgentSessionStatus(items)
+  const status = projectStructuredAgentSessionStatus(items, submissions)
   const activeToolCall = status === 'working' ? activeStructuredAgentSessionToolCall(items) : null
   const toolName = activeToolCall
     ? normalizeOptionalField(activeToolCall.name, AGENT_STATUS_TOOL_NAME_MAX_LENGTH)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​349 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​314 |
| Prod | 18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​56 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​99 |

<!-- /orca-pr-loc -->

## ELI5

You send a message to Claude in native chat and nothing happens on screen for a few seconds — no spinner, no "Working", and the worktree sidebar still looks idle. Claude *is* working; Orca just wasn't willing to say so until Claude echoed your message back. This makes Orca say it as soon as it sends the message.

## What Changed

**1. A session reads as working from the send, not from the provider echo.**

`isWorking` keyed solely on a running `turnLifecycle` row. Codex writes that row ~150ms after a send. Claude cannot write it until the SDK echoes the user message back, so the chat, the sidebar, `worktree ps` and mobile all read idle for the whole wait.

The journalled submission row is the host's own evidence that a turn is owed, so the shared projection now reads it too — one predicate, so every surface still agrees.

- `unknown` counts as work owed. The ack budget elapsing (`DISPATCH_ACK_TIMEOUT_MS`, 10s) answers *delivery*, not whether work is owed, and it fires on 30% of Claude sends whose turn then arrives anyway.
- A **recovered** `unknown` does not count — that send outlived the host generation that issued it. This needed the existing row-level `recovered` flag carried onto the projected submission (one line in the reducer, one optional wire field).
- Turn identity is untouched: only a provider-minted turn is cancellable, so the composer's Stop button stays keyed to `turnId` and behaves exactly as before.

**2. Claude's activity line stays the generic `⟳ Working…`.**

Claude's only turn-wide frame carries a bare status token; every sentence Orca put on that line was Orca's own wording for it. Its `task_*` frames do carry prose, but they are keyed by task id and subagent type — they describe a spawned task, not this turn, and the background-tasks strip already owns that surface. Compaction is kept, because it explains an otherwise silent long wait and the Codex map reports it too. **Codex's activity line is unchanged.**

## Why

Measured across 34 real Claude sessions and ~280 Codex sessions in the local journal store, submission row → running lifecycle row:

| provider | median | p90 | max | >10s |
|---|---|---|---|---|
| Codex | 0.14s | 0.44s | 1.93s | 0/316 |
| Claude | **3.39s** | **18.1s** | **43.3s** | **30%** |

The asymmetry is structural, not a bug in the Claude adapter: Codex declares turn start, Claude does not, so Orca infers it from a dispatch↔replay join. Every failure or delay of that join silently reads as idle.

## Linked Issue

No existing issue — found while investigating the reported "Claude native chat doesn't show Working" behaviour. Happy to file one if preferred.

## Visual Proof

Isolated background dev instance, real Claude session, driven through the actual composer. Both frames are the same prompt at the same moment: immediately after Enter on a fresh session's first send.

**Before** — message sent, composer cleared, nothing below it:

![proof-before.png](https://github.com/user-attachments/assets/f990a760-2527-4eaf-812c-4bab4a09c715)

**After** — `⟳ Working…` with the spinner:

![proof-after.png](https://github.com/user-attachments/assets/66d05277-1ad2-4b25-814f-f35fe2496ad9)

Same rig, same session, A/B by reverting only the `isWorking` line:

| | send → `⟳ Working…` |
|---|---|
| with the fix | **0 ms** (same 25ms sample as the composer clearing) |
| reverted | **~20.6 s** |

The journal for that reverted turn corroborates independently: `lifecycle running +18.85s` after the submission row. Across the QA turns the lifecycle row landed at +3.34s, +1.95s and +18.85s.

Sidebar was sampled through the same run and transitions `Done → Working → Done`. Across every sample of every turn the indicator text was only ever `Working…` — never a provider-derived sentence.

## Testing

- `pnpm vitest` — 9,917 tests green across `src/shared`, `src/main/native-chat`, `src/renderer/src/components/native-chat`; full `src/main/claude` + `src/main/codex` + `src/main/runtime` also green.
- Three new/changed tests, each **ablated** — the projection, status-feed and reducer tests were confirmed to go red with their change reverted.
- `tsc --noEmit` clean on `tsconfig.node`, `tsconfig.tc.cli`, `tsconfig.tc.web`.
- `pnpm run check:code-quality:changed` — 0 findings across 15 files (incl. React Doctor).
- Manual Electron QA on macOS as above.

**Not covered:** mobile's own suite and typecheck (deps not installed in this worktree); Windows and Linux; SSH/remote hosts.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

**Deviation worth a reviewer's attention:** if a send genuinely never reaches the provider and the host never restarts, the indicator stays on. This is bounded in practice — a late replay upgrades the submission to `accepted` via `settleLateDispatch`, a restart marks it `recovered`, and an observed provider exit settles the turn — but there is no timer that ends it. I chose not to add one: a timeout is what caused the original bug class, and re-introducing one here would recreate it.

Second judgement call: **compaction is the one provider string kept** on Claude's activity line. If you'd rather Claude be unconditionally `Working…`, it is a one-line change.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Cross-platform:** no platform-dependent code paths touched; the change is in shared projection, main-side status feed, and renderer/mobile hooks.
- **Remote wire:** `AgentJournalSubmission.recovered` is a **new optional field**, which older clients strip — safe under `docs/reference/remote-wire-compatibility.md`. No new stream opcodes. Note it does change what the host *publishes* for status, so an old client paired with a new host sees the earlier `working` transition; that is the intended behaviour and is not a decode break.
- **SSH / folder workspaces:** status is projected by the execution host that owns the journal, so remote and folder-workspace sessions get the same behaviour without a client change.
- **Performance:** the predicate is a `.some()` over the submission list, evaluated where the journal was already being projected.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Lint, typecheck and tests pass locally
