### PR TITLE
feat: load user-defined TextMate language grammars

### DIFF
--- a/docs/site/content/docs/editing/monaco.mdx
+++ b/docs/site/content/docs/editing/monaco.mdx
@@ -33,3 +33,73 @@ By default the editor and diff views use the same font as the terminal. Leave **
 ## Language support
 
 Syntax highlighting ships for the languages Monaco supports out of the box. Orca is intentionally editor-first, not IDE-first — run type-checkers and linters in a terminal pane.
+
+## User-defined syntax highlighting
+
+Orca desktop reads `~/.orca/languages.json` on startup. It accepts JSON with
+comments and trailing commas. Restart Orca after changing this file or a grammar.
+
+You can reuse the syntax definitions in an installed VS Code or Cursor extension:
+
+```jsonc
+{
+  "extensions": ["~/.cursor/extensions/your-publisher.your-language-1.0.0"]
+}
+```
+
+Each entry points to an unpacked extension directory containing `package.json`.
+Orca reads its `contributes.languages`, `contributes.grammars`, and basic language
+configuration. Extension JavaScript is never loaded. VSIX archives must be
+unpacked first; point at the directory containing the extension's `package.json`.
+
+Alternatively, register a language directly:
+
+```jsonc
+{
+  "languages": [
+    {
+      "id": "my-language",
+      "aliases": ["My Language"],
+      "extensions": [".mylang", ".template.mylang"],
+      "filenames": ["MyLanguagefile"],
+      "grammar": "./grammars/my-language.tmLanguage.json",
+      "configuration": "./grammars/language-configuration.json"
+    }
+  ],
+  "grammars": ["./grammars/dependency.tmLanguage.json"]
+}
+```
+
+`scopeName` is read from the grammar. An optional `scopeName` in a direct
+registration checks that the file declares the expected scope. `configuration`
+is optional. Supported configuration fields are comments, brackets, auto-closing
+pairs, and surrounding pairs; VS Code tuple pairs and JSONC are accepted.
+
+Paths can be absolute, home-relative (`~/`), or relative to `languages.json`.
+Paths declared inside extension manifests are relative to the extension and
+must stay within that directory, including through symlinks.
+
+### Behavior and limits
+
+- Custom filename associations take precedence over custom suffixes, which take
+  precedence over Orca's built-in associations. Filenames are case-sensitive;
+  suffixes are case-insensitive and the longest matching suffix wins. The first
+  entry wins ties. Extensions are processed before direct registrations.
+- Existing Monaco language IDs keep their built-in tokenizer. To replace the
+  highlighting of an existing language, use a distinct ID in a direct
+  registration and associate the desired extensions with it. Imported grammars
+  for built-in languages remain available as dependencies.
+- Highlighting applies to editors and diff views. Grammar files are loaded from
+  the desktop client, including for SSH workspaces, remote servers, and folder
+  workspaces. Browser-only clients retain their built-in highlighting.
+- A stalled configuration read times out after three seconds so the app can finish starting. Fix the configuration path and restart to try again.
+- Invalid entries produce diagnostics while valid neighboring entries continue
+  to load. Missing dependency scopes or invalid grammar expressions produce an
+  error notification when that language is opened, with a plain-text fallback.
+  Diagnostics are also logged with the `[custom-languages]` prefix.
+- Only JSON TextMate grammars are supported. Each file is limited to 5 MiB and
+  loaded grammars to 16 MiB total. Duplicate scopes are rejected; the first
+  definition is retained.
+- Extension activation, LSP features, grammar injection contributions, semantic
+  highlighting, and advanced language-configuration regex rules are outside
+  this loader's scope. Embedded grammars referenced by `include` are supported.

--- a/docs/site/content/docs/editing/monaco.mdx
+++ b/docs/site/content/docs/editing/monaco.mdx
@@ -72,7 +72,8 @@ Alternatively, register a language directly:
 
 `scopeName` is read from the grammar. An optional `scopeName` in a direct
 registration checks that the file declares the expected scope. `configuration`
-is optional. Supported configuration fields are comments, brackets, auto-closing
+is optional. Missing or invalid configuration produces a diagnostic while the language
+continues to highlight without those editor settings. Supported configuration fields are comments, brackets, auto-closing
 pairs, and surrounding pairs; VS Code tuple pairs and JSONC are accepted.
 
 Paths can be absolute, home-relative (`~/`), or relative to `languages.json`.
@@ -96,7 +97,9 @@ must stay within that directory, including through symlinks.
 - Invalid entries produce diagnostics while valid neighboring entries continue
   to load. Missing dependency scopes or invalid grammar expressions produce an
   error notification when that language is opened, with a plain-text fallback.
-  Diagnostics are also logged with the `[custom-languages]` prefix.
+  Missing language-to-grammar mappings also produce diagnostics. Notifications reuse
+  one toast to avoid stacking startup errors; all diagnostics are logged with the
+  `[custom-languages]` prefix.
 - Only JSON TextMate grammars are supported. Each file is limited to 5 MiB and
   loaded grammars to 16 MiB total. Duplicate scopes are rejected; the first
   definition is retained.

--- a/src/main/custom-languages/language-files.ts
+++ b/src/main/custom-languages/language-files.ts
@@ -1,0 +1,93 @@
+import { open, realpath } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { parse, type ParseError } from 'jsonc-parser'
+import { z } from 'zod'
+
+const MAX_FILE_BYTES = 5 * 1024 * 1024
+
+export function resolveLanguagePath(path: string, base: string): string {
+  if (path === '~') {
+    return homedir()
+  }
+  if (path.startsWith('~/') || path.startsWith('~\\')) {
+    return resolve(homedir(), path.slice(2))
+  }
+  return resolve(base, path)
+}
+
+export async function extensionResourcePath(base: string, path: string): Promise<string> {
+  const root = await realpath(base)
+  const target = await realpath(resolve(base, path))
+  const offset = relative(root, target)
+  if (isAbsolute(offset) || offset === '..' || offset.startsWith(`..${sep}`)) {
+    throw new Error(`Extension resource escapes its directory: ${path}`)
+  }
+  return target
+}
+
+export async function readLanguageJson(path: string): Promise<unknown> {
+  const file = await open(path, 'r')
+  try {
+    const stat = await file.stat()
+    if (!stat.isFile() || stat.size > MAX_FILE_BYTES) {
+      throw new Error(`Expected a regular JSON file smaller than 5 MiB: ${path}`)
+    }
+    const buffer = Buffer.alloc(MAX_FILE_BYTES + 1)
+    let bytesRead = 0
+    while (bytesRead < buffer.length) {
+      const chunk = await file.read(buffer, bytesRead, buffer.length - bytesRead, bytesRead)
+      if (chunk.bytesRead === 0) {
+        break
+      }
+      bytesRead += chunk.bytesRead
+    }
+    if (bytesRead > MAX_FILE_BYTES) {
+      throw new Error(`Language file exceeds 5 MiB: ${path}`)
+    }
+    const errors: ParseError[] = []
+    const value: unknown = parse(buffer.toString('utf8', 0, bytesRead), errors, {
+      allowTrailingComma: true
+    })
+    if (errors.length) {
+      throw new Error(`Invalid JSON in ${path} at offset ${errors[0].offset}`)
+    }
+    return value
+  } finally {
+    await file.close()
+  }
+}
+
+const pair = z.tuple([z.string(), z.string()])
+const closingPair = z.union([
+  pair.transform(([open, close]) => ({ open, close })),
+  z.object({ open: z.string(), close: z.string(), notIn: z.array(z.string()).optional() })
+])
+
+export const languageConfigurationSchema = z.object({
+  comments: z
+    .object({
+      lineComment: z
+        .union([z.string(), z.object({ comment: z.string() }).transform((value) => value.comment)])
+        .optional(),
+      blockComment: pair.optional()
+    })
+    .optional(),
+  brackets: z.array(pair).optional(),
+  autoClosingPairs: z.array(closingPair).optional(),
+  surroundingPairs: z.array(closingPair).optional()
+})
+
+export const languageMetadataSchema = z.object({
+  id: z.string().regex(/^[a-zA-Z][a-zA-Z0-9_.-]{0,127}$/),
+  aliases: z.array(z.string()).max(32).optional(),
+  extensions: z
+    .array(z.string().regex(/^\.[^/\\]+$/))
+    .max(128)
+    .optional(),
+  filenames: z
+    .array(z.string().regex(/^[^/\\]+$/))
+    .max(128)
+    .optional(),
+  configuration: z.string().optional()
+})

--- a/src/main/custom-languages/read-custom-languages.test.ts
+++ b/src/main/custom-languages/read-custom-languages.test.ts
@@ -1,0 +1,132 @@
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readCustomLanguages } from './read-custom-languages'
+
+let dir: string
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'orca-languages-'))
+})
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+const grammar = (scopeName: string) => ({
+  scopeName,
+  patterns: [{ name: 'keyword.control', match: '\\blet\\b' }]
+})
+async function json(path: string, value: unknown): Promise<void> {
+  await writeFile(join(dir, path), JSON.stringify(value))
+}
+async function extension(): Promise<void> {
+  await mkdir(join(dir, 'extension'))
+  await json('extension/package.json', {
+    main: './must-not-run.js',
+    contributes: {
+      languages: [
+        { id: 'ExampleLang', extensions: ['.examplelang'], configuration: './configuration.json' }
+      ],
+      grammars: [
+        { language: 'ExampleLang', scopeName: 'source.examplelang', path: './examplelang.json' }
+      ]
+    }
+  })
+  await json('extension/examplelang.json', grammar('source.examplelang'))
+  await writeFile(
+    join(dir, 'extension/configuration.json'),
+    `{
+    // VS Code configuration supports comments and tuple pairs.
+    "comments": { "lineComment": { "comment": "//" } },
+    "autoClosingPairs": [["{", "}"]],
+  }`
+  )
+  await writeFile(
+    join(dir, 'extension/must-not-run.js'),
+    'throw new Error("Extension code executed")'
+  )
+}
+
+describe('readCustomLanguages', () => {
+  it('returns an empty configuration when no file exists', async () => {
+    expect(await readCustomLanguages(join(dir, 'languages.json'))).toEqual({
+      languages: [],
+      grammars: {},
+      diagnostics: []
+    })
+  })
+
+  it('imports extension metadata, JSONC configuration, and dependency grammars without executing code', async () => {
+    await extension()
+    await json('typescript.json', grammar('source.ts'))
+    await json('languages.json', { extensions: ['./extension'], grammars: ['./typescript.json'] })
+    const result = await readCustomLanguages(join(dir, 'languages.json'))
+    expect(result.diagnostics).toEqual([])
+    expect(Object.keys(result.grammars)).toEqual(['source.examplelang', 'source.ts'])
+    expect(result.languages).toEqual([
+      {
+        id: 'ExampleLang',
+        extensions: ['.examplelang'],
+        scopeName: 'source.examplelang',
+        configuration: {
+          comments: { lineComment: '//' },
+          autoClosingPairs: [{ open: '{', close: '}' }]
+        }
+      }
+    ])
+  })
+
+  it('keeps valid direct registrations when neighboring entries are invalid', async () => {
+    await json('valid.json', grammar('source.valid'))
+    await json('languages.json', {
+      languages: [
+        { id: 'bad', grammar: './missing.json' },
+        { id: 'valid', grammar: './valid.json', filenames: ['Specialfile'], extensions: ['.valid'] }
+      ]
+    })
+    const result = await readCustomLanguages(join(dir, 'languages.json'))
+    expect(result.languages.map((language) => language.id)).toEqual(['valid'])
+    expect(result.diagnostics).toHaveLength(1)
+  })
+
+  it('reports malformed JSON and scope mismatches without throwing', async () => {
+    await writeFile(join(dir, 'languages.json'), '{ nope')
+    expect((await readCustomLanguages(join(dir, 'languages.json'))).diagnostics[0]).toContain(
+      'Invalid JSON'
+    )
+    await json('valid.json', grammar('source.actual'))
+    await json('languages.json', {
+      languages: [{ id: 'bad', grammar: './valid.json', scopeName: 'source.expected' }]
+    })
+    const result = await readCustomLanguages(join(dir, 'languages.json'))
+    expect(result.languages).toEqual([])
+    expect(result.diagnostics[0]).toContain('Expected scope source.expected, found source.actual')
+  })
+
+  it('rejects extension resources that escape through symlinks', async () => {
+    await extension()
+    await rm(join(dir, 'extension/examplelang.json'))
+    await json('outside.json', grammar('source.examplelang'))
+    await symlink(join(dir, 'outside.json'), join(dir, 'extension/examplelang.json'))
+    await json('languages.json', { extensions: ['./extension'] })
+    const result = await readCustomLanguages(join(dir, 'languages.json'))
+    expect(result.languages).toEqual([])
+    expect(result.diagnostics[0]).toContain('escapes its directory')
+  })
+
+  it('reports duplicate scopes and preserves the first grammar', async () => {
+    await json('first.json', grammar('source.same'))
+    await json('second.json', { scopeName: 'source.same', patterns: [] })
+    await json('languages.json', { grammars: ['./first.json', './second.json'] })
+    const result = await readCustomLanguages(join(dir, 'languages.json'))
+    expect(result.diagnostics[0]).toContain('Duplicate grammar scope source.same')
+    expect(result.grammars['source.same'].patterns).toHaveLength(1)
+  })
+
+  it('rejects oversized grammar files', async () => {
+    await writeFile(join(dir, 'large.json'), ' '.repeat(5 * 1024 * 1024 + 1))
+    await json('languages.json', { grammars: ['./large.json'] })
+    expect((await readCustomLanguages(join(dir, 'languages.json'))).diagnostics[0]).toContain(
+      'smaller than 5 MiB'
+    )
+  })
+})

--- a/src/main/custom-languages/read-custom-languages.test.ts
+++ b/src/main/custom-languages/read-custom-languages.test.ts
@@ -88,40 +88,87 @@ describe('readCustomLanguages', () => {
     expect(result.diagnostics).toHaveLength(1)
   })
 
-  it('releases the scope and byte budget when direct configuration fails', async () => {
+  it('releases the scope and byte budget when direct registration is rejected', async () => {
     await json('retry.json', { ...grammar('source.retry'), padding: ' '.repeat(4 * 1024 * 1024) })
-    await writeFile(join(dir, 'invalid-config.json'), '{ invalid')
+    await extension()
     await json('languages.json', {
+      extensions: ['./extension'],
       languages: [
         ...Array.from({ length: 4 }, () => ({
-          id: 'retry',
-          grammar: './retry.json',
-          configuration: './invalid-config.json'
+          id: 'ExampleLang',
+          grammar: './retry.json'
         })),
         { id: 'retry', grammar: './retry.json', extensions: ['.retry'] }
       ]
     })
     const result = await readCustomLanguages(join(dir, 'languages.json'))
     expect(result.diagnostics).toHaveLength(4)
-    expect(result.diagnostics.every((message) => message.includes('Invalid JSON'))).toBe(true)
-    expect(result.languages.map((language) => language.id)).toEqual(['retry'])
-    expect(Object.keys(result.grammars)).toEqual(['source.retry'])
-  })
-
-  it('releases a rejected duplicate language grammar without changing the existing language', async () => {
-    await extension()
-    await json('retry.json', grammar('source.retry'))
-    await json('languages.json', {
-      extensions: ['./extension'],
-      languages: [
-        { id: 'ExampleLang', grammar: './retry.json' },
-        { id: 'retry', grammar: './retry.json', extensions: ['.retry'] }
-      ]
-    })
-    const result = await readCustomLanguages(join(dir, 'languages.json'))
-    expect(result.diagnostics).toEqual(['Custom language: Duplicate language id ExampleLang'])
+    expect(
+      result.diagnostics.every((message) => message.includes('Duplicate language id ExampleLang'))
+    ).toBe(true)
     expect(result.languages.map((language) => language.id)).toEqual(['ExampleLang', 'retry'])
     expect(Object.keys(result.grammars)).toEqual(['source.examplelang', 'source.retry'])
+  })
+
+  describe.each(['extension', 'direct'])('%s optional configuration', (source) => {
+    it.each(['missing', 'malformed JSON', 'invalid schema'])(
+      'preserves highlighting when configuration has %s',
+      async (failure) => {
+        await extension()
+        if (failure === 'missing') {
+          await rm(join(dir, 'extension/configuration.json'))
+        } else if (failure === 'malformed JSON') {
+          await writeFile(join(dir, 'extension/configuration.json'), '{ invalid')
+        } else {
+          await json('extension/configuration.json', { brackets: 42 })
+        }
+        await json(
+          'languages.json',
+          source === 'extension'
+            ? { extensions: ['./extension'] }
+            : {
+                languages: [
+                  {
+                    id: 'ExampleLang',
+                    extensions: ['.examplelang'],
+                    grammar: './extension/examplelang.json',
+                    configuration: './extension/configuration.json'
+                  }
+                ]
+              }
+        )
+        const result = await readCustomLanguages(join(dir, 'languages.json'))
+        expect(result.diagnostics).toHaveLength(1)
+        expect(result.diagnostics[0]).toContain('ExampleLang configuration:')
+        expect(result.languages).toEqual([
+          {
+            id: 'ExampleLang',
+            extensions: ['.examplelang'],
+            scopeName: 'source.examplelang',
+            configuration: undefined
+          }
+        ])
+        expect(Object.keys(result.grammars)).toEqual(['source.examplelang'])
+      }
+    )
+  })
+
+  it('reports extension languages without associated grammars', async () => {
+    await mkdir(join(dir, 'extension'))
+    await json('extension/dependency.json', grammar('source.dependency'))
+    await json('extension/package.json', {
+      contributes: {
+        languages: [{ id: 'ExampleLang', extensions: ['.examplelang'] }],
+        grammars: [{ scopeName: 'source.dependency', path: './dependency.json' }]
+      }
+    })
+    await json('languages.json', { extensions: ['./extension'] })
+    const result = await readCustomLanguages(join(dir, 'languages.json'))
+    expect(result.languages).toEqual([])
+    expect(Object.keys(result.grammars)).toEqual(['source.dependency'])
+    expect(result.diagnostics).toEqual([
+      './extension language: No TextMate grammar associated with language ExampleLang'
+    ])
   })
 
   it('rejects extension grammar paths outside the extension directory', async () => {

--- a/src/main/custom-languages/read-custom-languages.test.ts
+++ b/src/main/custom-languages/read-custom-languages.test.ts
@@ -88,6 +88,59 @@ describe('readCustomLanguages', () => {
     expect(result.diagnostics).toHaveLength(1)
   })
 
+  it('releases the scope and byte budget when direct configuration fails', async () => {
+    await json('retry.json', { ...grammar('source.retry'), padding: ' '.repeat(4 * 1024 * 1024) })
+    await writeFile(join(dir, 'invalid-config.json'), '{ invalid')
+    await json('languages.json', {
+      languages: [
+        ...Array.from({ length: 4 }, () => ({
+          id: 'retry',
+          grammar: './retry.json',
+          configuration: './invalid-config.json'
+        })),
+        { id: 'retry', grammar: './retry.json', extensions: ['.retry'] }
+      ]
+    })
+    const result = await readCustomLanguages(join(dir, 'languages.json'))
+    expect(result.diagnostics).toHaveLength(4)
+    expect(result.diagnostics.every((message) => message.includes('Invalid JSON'))).toBe(true)
+    expect(result.languages.map((language) => language.id)).toEqual(['retry'])
+    expect(Object.keys(result.grammars)).toEqual(['source.retry'])
+  })
+
+  it('releases a rejected duplicate language grammar without changing the existing language', async () => {
+    await extension()
+    await json('retry.json', grammar('source.retry'))
+    await json('languages.json', {
+      extensions: ['./extension'],
+      languages: [
+        { id: 'ExampleLang', grammar: './retry.json' },
+        { id: 'retry', grammar: './retry.json', extensions: ['.retry'] }
+      ]
+    })
+    const result = await readCustomLanguages(join(dir, 'languages.json'))
+    expect(result.diagnostics).toEqual(['Custom language: Duplicate language id ExampleLang'])
+    expect(result.languages.map((language) => language.id)).toEqual(['ExampleLang', 'retry'])
+    expect(Object.keys(result.grammars)).toEqual(['source.examplelang', 'source.retry'])
+  })
+
+  it('rejects extension grammar paths outside the extension directory', async () => {
+    await extension()
+    await json('outside.json', grammar('source.examplelang'))
+    await json('extension/package.json', {
+      contributes: {
+        languages: [{ id: 'ExampleLang', extensions: ['.examplelang'] }],
+        grammars: [
+          { language: 'ExampleLang', scopeName: 'source.examplelang', path: '../outside.json' }
+        ]
+      }
+    })
+    await json('languages.json', { extensions: ['./extension'] })
+    const result = await readCustomLanguages(join(dir, 'languages.json'))
+    expect(result.languages).toEqual([])
+    expect(result.diagnostics[0]).toContain('escapes its directory')
+  })
+
   it('reports malformed JSON and scope mismatches without throwing', async () => {
     await writeFile(join(dir, 'languages.json'), '{ nope')
     expect((await readCustomLanguages(join(dir, 'languages.json'))).diagnostics[0]).toContain(
@@ -102,16 +155,19 @@ describe('readCustomLanguages', () => {
     expect(result.diagnostics[0]).toContain('Expected scope source.expected, found source.actual')
   })
 
-  it('rejects extension resources that escape through symlinks', async () => {
-    await extension()
-    await rm(join(dir, 'extension/examplelang.json'))
-    await json('outside.json', grammar('source.examplelang'))
-    await symlink(join(dir, 'outside.json'), join(dir, 'extension/examplelang.json'))
-    await json('languages.json', { extensions: ['./extension'] })
-    const result = await readCustomLanguages(join(dir, 'languages.json'))
-    expect(result.languages).toEqual([])
-    expect(result.diagnostics[0]).toContain('escapes its directory')
-  })
+  it.skipIf(process.platform === 'win32')(
+    'rejects extension resources that escape through symlinks',
+    async () => {
+      await extension()
+      await rm(join(dir, 'extension/examplelang.json'))
+      await json('outside.json', grammar('source.examplelang'))
+      await symlink(join(dir, 'outside.json'), join(dir, 'extension/examplelang.json'))
+      await json('languages.json', { extensions: ['./extension'] })
+      const result = await readCustomLanguages(join(dir, 'languages.json'))
+      expect(result.languages).toEqual([])
+      expect(result.diagnostics[0]).toContain('escapes its directory')
+    }
+  )
 
   it('reports duplicate scopes and preserves the first grammar', async () => {
     await json('first.json', grammar('source.same'))

--- a/src/main/custom-languages/read-custom-languages.ts
+++ b/src/main/custom-languages/read-custom-languages.ts
@@ -137,8 +137,15 @@ export async function readCustomLanguages(
     for (const raw of config.languages) {
       await attempt('Custom language', async () => {
         const entry = directLanguageSchema.parse(raw)
+        const previousBytes = totalBytes
         const scopeName = await addGrammar(await resolveResource(entry.grammar), entry.scopeName)
-        await addLanguage(entry, scopeName, resolveResource)
+        try {
+          await addLanguage(entry, scopeName, resolveResource)
+        } catch (error) {
+          grammars.delete(scopeName)
+          totalBytes = previousBytes
+          throw error
+        }
       })
     }
   })

--- a/src/main/custom-languages/read-custom-languages.ts
+++ b/src/main/custom-languages/read-custom-languages.ts
@@ -1,0 +1,147 @@
+import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+import { z } from 'zod'
+import type { IRawGrammar } from 'vscode-textmate'
+import type { CustomLanguageSnapshot } from '../../shared/custom-languages'
+import {
+  extensionResourcePath,
+  languageConfigurationSchema,
+  languageMetadataSchema,
+  readLanguageJson,
+  resolveLanguagePath
+} from './language-files'
+
+const configSchema = z.object({
+  extensions: z.array(z.string()).max(64).default([]),
+  grammars: z.array(z.string()).max(128).default([]),
+  languages: z.array(z.unknown()).max(128).default([])
+})
+const directLanguageSchema = languageMetadataSchema.extend({
+  grammar: z.string(),
+  scopeName: z.string().optional()
+})
+const extensionSchema = z.object({
+  contributes: z.object({
+    languages: z.array(z.unknown()).max(128).default([]),
+    grammars: z.array(z.unknown()).max(128).default([])
+  })
+})
+const grammarContributionSchema = z.object({
+  language: z.string().optional(),
+  scopeName: z.string(),
+  path: z.string()
+})
+const grammarSchema = z
+  .object({
+    scopeName: z.string().min(1).max(256),
+    patterns: z.array(z.unknown())
+  })
+  .passthrough()
+
+export async function readCustomLanguages(
+  configPath = join(homedir(), '.orca', 'languages.json')
+): Promise<CustomLanguageSnapshot> {
+  const snapshot: CustomLanguageSnapshot = { languages: [], grammars: {}, diagnostics: [] }
+  const grammars = new Map<string, IRawGrammar>()
+  const languageIds = new Set<string>()
+  let totalBytes = 0
+  const attempt = async (label: string, action: () => Promise<void>): Promise<void> => {
+    try {
+      await action()
+    } catch (error) {
+      snapshot.diagnostics.push(
+        `${label}: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+  const addGrammar = async (path: string, expectedScope?: string): Promise<string> => {
+    const grammar = grammarSchema.parse(await readLanguageJson(path))
+    if (expectedScope && expectedScope !== grammar.scopeName) {
+      throw new Error(`Expected scope ${expectedScope}, found ${grammar.scopeName}`)
+    }
+    if (grammars.has(grammar.scopeName)) {
+      throw new Error(`Duplicate grammar scope ${grammar.scopeName}`)
+    }
+    const bytes = Buffer.byteLength(JSON.stringify(grammar))
+    if (totalBytes + bytes > 16 * 1024 * 1024) {
+      throw new Error('Custom grammars exceed 16 MiB total')
+    }
+    totalBytes += bytes
+    grammars.set(grammar.scopeName, grammar as unknown as IRawGrammar)
+    return grammar.scopeName
+  }
+  const addLanguage = async (
+    raw: unknown,
+    scopeName: string,
+    resolveResource: (path: string) => Promise<string>
+  ): Promise<void> => {
+    const { configuration: configurationPath, ...metadata } = languageMetadataSchema.parse(raw)
+    if (languageIds.has(metadata.id)) {
+      throw new Error(`Duplicate language id ${metadata.id}`)
+    }
+    if (!grammars.has(scopeName)) {
+      throw new Error(`Missing grammar ${scopeName}`)
+    }
+    const configuration = configurationPath
+      ? languageConfigurationSchema.parse(
+          await readLanguageJson(await resolveResource(configurationPath))
+        )
+      : undefined
+    snapshot.languages.push({ ...metadata, scopeName, configuration })
+    languageIds.add(metadata.id)
+  }
+
+  let document: unknown
+  try {
+    document = await readLanguageJson(configPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      snapshot.diagnostics.push(`${configPath}: ${String(error)}`)
+    }
+    return snapshot
+  }
+  await attempt(configPath, async () => {
+    const config = configSchema.parse(document)
+    const resolveResource = async (path: string): Promise<string> =>
+      resolveLanguagePath(path, dirname(configPath))
+    for (const extensionPath of config.extensions) {
+      await attempt(extensionPath, async () => {
+        const root = await resolveResource(extensionPath)
+        const extension = extensionSchema.parse(await readLanguageJson(join(root, 'package.json')))
+        const languageScopes = new Map<string, string>()
+        for (const raw of extension.contributes.grammars) {
+          await attempt(`${extensionPath} grammar`, async () => {
+            const entry = grammarContributionSchema.parse(raw)
+            await addGrammar(await extensionResourcePath(root, entry.path), entry.scopeName)
+            if (entry.language) {
+              languageScopes.set(entry.language, entry.scopeName)
+            }
+          })
+        }
+        for (const raw of extension.contributes.languages) {
+          await attempt(`${extensionPath} language`, async () => {
+            const metadata = languageMetadataSchema.parse(raw)
+            const scopeName = languageScopes.get(metadata.id)
+            if (scopeName) {
+              await addLanguage(raw, scopeName, (path) => extensionResourcePath(root, path))
+            }
+          })
+        }
+      })
+    }
+    for (const path of config.grammars) {
+      await attempt(path, async () => {
+        await addGrammar(await resolveResource(path))
+      })
+    }
+    for (const raw of config.languages) {
+      await attempt('Custom language', async () => {
+        const entry = directLanguageSchema.parse(raw)
+        const scopeName = await addGrammar(await resolveResource(entry.grammar), entry.scopeName)
+        await addLanguage(entry, scopeName, resolveResource)
+      })
+    }
+  })
+  snapshot.grammars = Object.fromEntries(grammars)
+  return snapshot
+}

--- a/src/main/custom-languages/read-custom-languages.ts
+++ b/src/main/custom-languages/read-custom-languages.ts
@@ -82,11 +82,14 @@ export async function readCustomLanguages(
     if (!grammars.has(scopeName)) {
       throw new Error(`Missing grammar ${scopeName}`)
     }
-    const configuration = configurationPath
-      ? languageConfigurationSchema.parse(
+    let configuration: z.infer<typeof languageConfigurationSchema> | undefined
+    if (configurationPath) {
+      await attempt(`${metadata.id} configuration`, async () => {
+        configuration = languageConfigurationSchema.parse(
           await readLanguageJson(await resolveResource(configurationPath))
         )
-      : undefined
+      })
+    }
     snapshot.languages.push({ ...metadata, scopeName, configuration })
     languageIds.add(metadata.id)
   }
@@ -122,9 +125,10 @@ export async function readCustomLanguages(
           await attempt(`${extensionPath} language`, async () => {
             const metadata = languageMetadataSchema.parse(raw)
             const scopeName = languageScopes.get(metadata.id)
-            if (scopeName) {
-              await addLanguage(raw, scopeName, (path) => extensionResourcePath(root, path))
+            if (!scopeName) {
+              throw new Error(`No TextMate grammar associated with language ${metadata.id}`)
             }
+            await addLanguage(raw, scopeName, (path) => extensionResourcePath(root, path))
           })
         }
       })

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,3 +1,4 @@
+import { readCustomLanguages } from '../custom-languages/read-custom-languages'
 import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import type { Store } from '../persistence'
 import type { GlobalSettings } from '../../shared/global-settings-types'
@@ -92,6 +93,12 @@ export function registerSettingsHandlers(
         window.webContents.send('settings:changed', updates)
       }
     }
+  })
+
+  let customLanguages: ReturnType<typeof readCustomLanguages> | undefined
+  ipcMain.handle('settings:getCustomLanguages', () => {
+    customLanguages ??= readCustomLanguages()
+    return customLanguages
   })
 
   ipcMain.handle('settings:get', () => {

--- a/src/preload/api/settings-api.ts
+++ b/src/preload/api/settings-api.ts
@@ -1,3 +1,4 @@
+import type { CustomLanguageSnapshot } from '../../shared/custom-languages'
 import type { KeybindingActionId, KeybindingFileSnapshot } from '../../shared/keybindings'
 import type {
   WarpThemeImportPreview,
@@ -6,6 +7,7 @@ import type {
 import type { GhosttyImportPreview, GlobalSettings } from '../../shared/global-settings-types'
 
 export type SettingsApi = {
+  getCustomLanguages?: () => Promise<CustomLanguageSnapshot>
   get: () => Promise<GlobalSettings>
   /** Synchronous persisted-settings read for startup decisions that can't wait for async hydration. Blocking IPC — call sparingly. */
   getSync: () => GlobalSettings | null

--- a/src/preload/api/settings-bridge.ts
+++ b/src/preload/api/settings-bridge.ts
@@ -7,6 +7,7 @@ import type {
 import type { PreloadApi } from '../api-types'
 
 export const settingsApi = {
+  getCustomLanguages: () => ipcRenderer.invoke('settings:getCustomLanguages'),
   get: () => ipcRenderer.invoke('settings:get'),
 
   // Why: blocking read for the few startup decisions (terminal side-effect authority) that can't wait for async hydration. Call sparingly.

--- a/src/renderer/src/lib/custom-language-associations.test.ts
+++ b/src/renderer/src/lib/custom-language-associations.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { setCustomLanguageAssociations } from './custom-language-associations'
+import { detectLanguage } from './language-detect'
+
+afterEach(() => setCustomLanguageAssociations([]))
+describe('custom language associations', () => {
+  it('matches exact names before compound suffixes on Windows and Unix paths', () => {
+    setCustomLanguageAssociations([
+      { id: 'examplelang', scopeName: 'source.examplelang', extensions: ['.examplelang'] },
+      { id: 'template', scopeName: 'source.template', extensions: ['.test.examplelang'] },
+      { id: 'special', scopeName: 'source.special', filenames: ['exact.test.examplelang'] }
+    ])
+    expect(detectLanguage('/repo/code.EXAMPLELANG')).toBe('examplelang')
+    expect(detectLanguage('C:\\repo\\code.test.examplelang')).toBe('template')
+    expect(detectLanguage('/repo/exact.test.examplelang')).toBe('special')
+    expect(detectLanguage('/repo/exact.TEST.EXAMPLELANG')).toBe('template')
+    expect(detectLanguage('/repo/code.ts')).toBe('typescript')
+  })
+
+  it('allows custom associations to override built-in associations, with first entry winning', () => {
+    setCustomLanguageAssociations([
+      { id: 'custom', scopeName: 'source.custom', extensions: ['.ts'], filenames: ['Dockerfile'] },
+      { id: 'later', scopeName: 'source.later', extensions: ['.ts'] }
+    ])
+    expect(detectLanguage('code.ts')).toBe('custom')
+    expect(detectLanguage('Dockerfile')).toBe('custom')
+    setCustomLanguageAssociations([])
+    expect(detectLanguage('code.ts')).toBe('typescript')
+    expect(detectLanguage('Dockerfile')).toBe('dockerfile')
+  })
+})

--- a/src/renderer/src/lib/custom-language-associations.ts
+++ b/src/renderer/src/lib/custom-language-associations.ts
@@ -1,0 +1,33 @@
+import type { CustomLanguage } from '../../../shared/custom-languages'
+
+let filenames = new Map<string, string>()
+let extensions: [string, string][] = []
+
+export function setCustomLanguageAssociations(languages: CustomLanguage[]): void {
+  filenames = new Map()
+  const extensionMap = new Map<string, string>()
+  for (const language of languages) {
+    for (const filename of language.filenames ?? []) {
+      if (!filenames.has(filename)) {
+        filenames.set(filename, language.id)
+      }
+    }
+    for (const extension of language.extensions ?? []) {
+      const normalized = extension.toLowerCase()
+      if (!extensionMap.has(normalized)) {
+        extensionMap.set(normalized, language.id)
+      }
+    }
+  }
+  extensions = [...extensionMap].sort(([left], [right]) => right.length - left.length)
+}
+
+export function detectCustomLanguage(filePath: string): string | undefined {
+  const filename = filePath.split(/[\\/]/).at(-1) ?? ''
+  const exact = filenames.get(filename)
+  if (exact) {
+    return exact
+  }
+  const lower = filename.toLowerCase()
+  return extensions.find(([extension]) => lower.endsWith(extension))?.[1]
+}

--- a/src/renderer/src/lib/custom-language-snapshot.test.ts
+++ b/src/renderer/src/lib/custom-language-snapshot.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+describe('custom language snapshot startup', () => {
+  it('shares one request and installs associations before startup resolves', async () => {
+    const getCustomLanguages = vi.fn(async () => ({
+      languages: [
+        { id: 'ExampleLang', scopeName: 'source.examplelang', extensions: ['.examplelang'] }
+      ],
+      grammars: {},
+      diagnostics: []
+    }))
+    vi.stubGlobal('window', { api: { settings: { getCustomLanguages } } })
+    const { loadCustomLanguageSnapshot } = await import('./custom-language-snapshot')
+    const { detectLanguage } = await import('./language-detect')
+    expect(loadCustomLanguageSnapshot()).toBe(loadCustomLanguageSnapshot())
+    await loadCustomLanguageSnapshot()
+    expect(getCustomLanguages).toHaveBeenCalledTimes(1)
+    expect(detectLanguage('/remote/repo/file.examplelang')).toBe('ExampleLang')
+  })
+
+  it('uses built-in highlighting on web clients without local grammar access', async () => {
+    vi.stubGlobal('window', { api: { settings: {} } })
+    const { loadCustomLanguageSnapshot } = await import('./custom-language-snapshot')
+    expect(await loadCustomLanguageSnapshot()).toEqual({
+      languages: [],
+      grammars: {},
+      diagnostics: []
+    })
+  })
+
+  it('does not block startup when the local bridge fails', async () => {
+    vi.stubGlobal('window', {
+      api: {
+        settings: {
+          getCustomLanguages: async () => {
+            throw new Error('unavailable')
+          }
+        }
+      }
+    })
+    const { loadCustomLanguageSnapshot } = await import('./custom-language-snapshot')
+    const snapshot = await loadCustomLanguageSnapshot()
+    expect(snapshot.languages).toEqual([])
+    expect(snapshot.diagnostics[0]).toContain('unavailable')
+  })
+  it('unblocks startup after a stalled read without installing late associations', async () => {
+    vi.useFakeTimers()
+    let finish!: (value: unknown) => void
+    const request = new Promise((resolve) => {
+      finish = resolve
+    })
+    vi.stubGlobal('window', { api: { settings: { getCustomLanguages: () => request } } })
+    const { loadCustomLanguageSnapshot } = await import('./custom-language-snapshot')
+    const { detectLanguage } = await import('./language-detect')
+    const pending = loadCustomLanguageSnapshot()
+    await vi.advanceTimersByTimeAsync(3000)
+    const snapshot = await pending
+    expect(snapshot.languages).toEqual([])
+    expect(snapshot.diagnostics[0]).toContain('timed out')
+    finish({
+      languages: [{ id: 'example', scopeName: 'source.example', extensions: ['.example'] }],
+      grammars: {},
+      diagnostics: []
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(detectLanguage('file.example')).toBe('plaintext')
+  })
+})

--- a/src/renderer/src/lib/custom-language-snapshot.ts
+++ b/src/renderer/src/lib/custom-language-snapshot.ts
@@ -1,0 +1,36 @@
+import type { CustomLanguageSnapshot } from '../../../shared/custom-languages'
+import { withTimeout } from '../../../shared/promise-timeout-fallback'
+import { setCustomLanguageAssociations } from './custom-language-associations'
+
+let snapshotPromise: Promise<CustomLanguageSnapshot> | undefined
+
+export function loadCustomLanguageSnapshot(): Promise<CustomLanguageSnapshot> {
+  snapshotPromise ??= (async () => {
+    let snapshot: CustomLanguageSnapshot = { languages: [], grammars: {}, diagnostics: [] }
+    try {
+      // Grammars belong to this desktop client, including when its workspace is remote.
+      if (window.api?.settings?.getCustomLanguages) {
+        snapshot = await withTimeout(
+          window.api.settings.getCustomLanguages().catch((error) => ({
+            languages: [],
+            grammars: {},
+            diagnostics: [`Could not load custom languages: ${String(error)}`]
+          })),
+          3000,
+          {
+            languages: [],
+            grammars: {},
+            diagnostics: [
+              'Custom language loading timed out. Check languages.json and restart Orca.'
+            ]
+          }
+        )
+      }
+    } catch (error) {
+      snapshot.diagnostics.push(`Could not load custom languages: ${String(error)}`)
+    }
+    setCustomLanguageAssociations(snapshot.languages)
+    return snapshot
+  })()
+  return snapshotPromise
+}

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -1,3 +1,5 @@
+import { detectCustomLanguage } from './custom-language-associations'
+
 function extname(filePath: string): string {
   const lastDot = filePath.lastIndexOf('.')
   const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
@@ -119,6 +121,11 @@ const FILENAME_TO_LANGUAGE: Record<string, string> = {
 }
 
 export function detectLanguage(filePath: string): string {
+  const customLanguage = detectCustomLanguage(filePath)
+  if (customLanguage) {
+    return customLanguage
+  }
+
   // Check exact filename first
   const parts = filePath.split(/[\\/]/)
   const filename = parts.at(-1)!

--- a/src/renderer/src/lib/monaco-languages/register-custom-languages.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-custom-languages.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { registerCustomLanguages } from './register-custom-languages'
+import { registerTextMateLanguage } from './textmate-language-registration'
+
+vi.mock('./textmate-language-registration', () => ({ registerTextMateLanguage: vi.fn() }))
+describe('registerCustomLanguages', () => {
+  it('shares dependency grammars and reports missing dependencies clearly', async () => {
+    const grammar = { scopeName: 'source.ts', patterns: [], repository: { $self: {}, $base: {} } }
+    const reportError = vi.fn()
+    registerCustomLanguages(
+      {} as never,
+      {
+        languages: [
+          { id: 'ExampleLang', scopeName: 'source.examplelang', extensions: ['.examplelang'] }
+        ],
+        grammars: { 'source.ts': grammar },
+        diagnostics: ['Bad neighboring entry']
+      },
+      reportError
+    )
+    const registration = vi.mocked(registerTextMateLanguage).mock.lastCall![1]
+    expect(registration.language).toEqual({ id: 'ExampleLang', extensions: ['.examplelang'] })
+    expect(await registration.loadGrammar('source.ts')).toBe(grammar)
+    await expect(registration.loadGrammar('source.missing')).rejects.toThrow(
+      'Missing TextMate grammar source.missing'
+    )
+    registration.onError!(new Error('Invalid regex'))
+    expect(reportError).toHaveBeenCalledWith('Bad neighboring entry')
+    expect(reportError).toHaveBeenCalledWith('ExampleLang: Error: Invalid regex')
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-custom-languages.ts
+++ b/src/renderer/src/lib/monaco-languages/register-custom-languages.ts
@@ -1,0 +1,29 @@
+import type * as Monaco from 'monaco-editor'
+import type { CustomLanguageSnapshot } from '../../../../shared/custom-languages'
+import { registerTextMateLanguage } from './textmate-language-registration'
+
+export function registerCustomLanguages(
+  monaco: typeof Monaco,
+  snapshot: CustomLanguageSnapshot,
+  reportError: (message: string) => void
+): void {
+  for (const message of snapshot.diagnostics) {
+    reportError(message)
+  }
+  for (const { scopeName, configuration, ...language } of snapshot.languages) {
+    registerTextMateLanguage(monaco, {
+      language,
+      scopeName,
+      configuration,
+      loadGrammar: async (scope) => {
+        if (!Object.hasOwn(snapshot.grammars, scope)) {
+          throw new Error(
+            `Missing TextMate grammar ${scope}; add its extension or grammar file to languages.json`
+          )
+        }
+        return snapshot.grammars[scope]
+      },
+      onError: (error) => reportError(`${language.id}: ${String(error)}`)
+    })
+  }
+}

--- a/src/renderer/src/lib/monaco-languages/textmate-language-registration.test.ts
+++ b/src/renderer/src/lib/monaco-languages/textmate-language-registration.test.ts
@@ -88,4 +88,23 @@ describe('registerTextMateLanguage', () => {
     expect(monaco.languages.register).not.toHaveBeenCalled()
     expect(monaco.languages.registerTokensProviderFactory).not.toHaveBeenCalled()
   })
+  it('falls back without an unhandled rejection when a custom grammar fails', async () => {
+    const { monaco, createTokensProvider } = createMonacoMock()
+    const onError = vi.fn()
+    registerTextMateLanguage(monaco as never, {
+      language: { id: 'custom' },
+      scopeName: 'source.custom',
+      loadGrammar: vi.fn(),
+      onError,
+      loadProviderModule: async () => ({
+        createTextMateTokensProvider: async () => {
+          throw new Error('Invalid regex')
+        }
+      })
+    })
+    await expect(createTokensProvider()).resolves.toBeNull()
+    await expect(createTokensProvider()).resolves.toBeNull()
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0].message).toBe('Invalid regex')
+  })
 })

--- a/src/renderer/src/lib/monaco-languages/textmate-language-registration.ts
+++ b/src/renderer/src/lib/monaco-languages/textmate-language-registration.ts
@@ -15,6 +15,7 @@ export type TextMateLanguageRegistration = {
   configuration?: Monaco.languages.LanguageConfiguration
   scopeName: string
   loadGrammar: TextMateGrammarLoader
+  onError?: (error: unknown) => void
   loadProviderModule?: () => Promise<TextMateTokenProviderModule>
 }
 
@@ -38,7 +39,7 @@ export function registerTextMateLanguage(
     monaco.languages.setLanguageConfiguration(registration.language.id, registration.configuration)
   }
 
-  let tokensProviderPromise: Promise<TextMateTokensProvider> | undefined
+  let tokensProviderPromise: Promise<TextMateTokensProvider | null> | undefined
   monaco.languages.registerTokensProviderFactory(registration.language.id, {
     create: () => {
       // Why: plain Monaco tokenization requests basic language features; onLanguage
@@ -48,9 +49,16 @@ export function registerTextMateLanguage(
       )().then(({ createTextMateTokensProvider }) =>
         createTextMateTokensProvider({
           scopeName: registration.scopeName,
-          loadGrammar: registration.loadGrammar
+          loadGrammar: registration.loadGrammar,
+          ...(registration.onError ? { onError: registration.onError } : {})
         })
       )
+      if (registration.onError) {
+        tokensProviderPromise = tokensProviderPromise.catch((error) => {
+          registration.onError?.(error)
+          return null
+        })
+      }
       return tokensProviderPromise
     }
   })

--- a/src/renderer/src/lib/monaco-languages/textmate-token-provider.test.ts
+++ b/src/renderer/src/lib/monaco-languages/textmate-token-provider.test.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module'
 import { readFile } from 'node:fs/promises'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createOnigScanner, createOnigString, loadWASM } from 'vscode-oniguruma'
 import type { IOnigLib, IRawGrammar } from 'vscode-textmate'
 import nimGrammar from './textmate-grammars/nim.tmLanguage.json'
@@ -54,5 +54,36 @@ describe('createTextMateTokensProvider', () => {
         loadOniguruma: loadNodeOniguruma
       })
     ).rejects.toThrow('No TextMate grammar registered for scope source.unknown')
+  })
+  it('reports a lazy regex failure once and keeps later lines usable as plain text', async () => {
+    const onError = vi.fn()
+    const provider = await createTextMateTokensProvider({
+      scopeName: 'source.invalid',
+      loadGrammar: async () => ({
+        scopeName: 'source.invalid',
+        repository: { $self: {}, $base: {} },
+        patterns: [{ name: 'keyword', match: '[' }]
+      }),
+      loadOniguruma: loadNodeOniguruma,
+      onError
+    })
+    const first = provider.tokenize('hello', provider.getInitialState())
+    expect(first.tokens).toEqual([{ startIndex: 0, scopes: '' }])
+    expect(provider.tokenize('next line', first.endState).tokens).toEqual(first.tokens)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error)
+
+    const valid = await createTextMateTokensProvider({
+      scopeName: 'source.valid',
+      loadGrammar: async () => ({
+        scopeName: 'source.valid',
+        repository: { $self: {}, $base: {} },
+        patterns: [{ name: 'keyword', match: 'hello' }]
+      }),
+      loadOniguruma: loadNodeOniguruma,
+      onError
+    })
+    expect(valid.tokenize('hello', valid.getInitialState()).tokens[0].scopes).toBe('keyword')
+    expect(onError).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/lib/monaco-languages/textmate-token-provider.ts
+++ b/src/renderer/src/lib/monaco-languages/textmate-token-provider.ts
@@ -11,6 +11,7 @@ export type TextMateTokensProviderOptions = {
   scopeName: string
   loadGrammar: TextMateGrammarLoader
   loadOniguruma?: () => Promise<IOnigLib>
+  onError?: (error: unknown) => void
 }
 
 let browserOnigurumaPromise: Promise<IOnigLib> | undefined
@@ -47,8 +48,10 @@ class TextMateTokenizerState implements Monaco.languages.IState {
 
 function createTokensProvider(
   grammar: IGrammar,
-  fallbackScopeName: string
+  fallbackScopeName: string,
+  onError?: (error: unknown) => void
 ): TextMateTokensProvider {
+  let failed = false
   return {
     getInitialState() {
       return new TextMateTokenizerState(INITIAL)
@@ -56,17 +59,27 @@ function createTokensProvider(
     tokenize(line, state) {
       const textMateState =
         state instanceof TextMateTokenizerState ? state : new TextMateTokenizerState(INITIAL)
-      const result = grammar.tokenizeLine(line, textMateState.ruleStack)
-
-      return {
-        endState: new TextMateTokenizerState(result.ruleStack),
-        tokens: result.tokens.map((token) => ({
-          startIndex: token.startIndex,
-          // Why: Monaco themes match a single token scope; TextMate returns a
-          // scope stack, and the final entry is the most specific reusable one.
-          scopes: token.scopes.at(-1) ?? fallbackScopeName
-        }))
+      if (!failed) {
+        try {
+          const result = grammar.tokenizeLine(line, textMateState.ruleStack)
+          return {
+            endState: new TextMateTokenizerState(result.ruleStack),
+            tokens: result.tokens.map((token) => ({
+              startIndex: token.startIndex,
+              // Monaco themes match the most specific scope in the TextMate stack.
+              scopes: token.scopes.at(-1) ?? fallbackScopeName
+            }))
+          }
+        } catch (error) {
+          if (!onError) {
+            throw error
+          }
+          // Regex scanners can fail lazily, after the grammar has loaded.
+          failed = true
+          onError(error)
+        }
       }
+      return { endState: textMateState, tokens: [{ startIndex: 0, scopes: '' }] }
     }
   }
 }
@@ -94,5 +107,5 @@ export async function createTextMateTokensProvider(
     throw new Error(`No TextMate grammar registered for scope ${options.scopeName}`)
   }
 
-  return createTokensProvider(grammar, options.scopeName)
+  return createTokensProvider(grammar, options.scopeName, options.onError)
 }

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -85,7 +85,7 @@ registerJsonlLanguage(monaco)
 void loadCustomLanguageSnapshot().then((snapshot) => {
   registerCustomLanguages(monaco, snapshot, (message) => {
     console.warn('[custom-languages]', message)
-    toast.error(message)
+    toast.error(message, { id: 'custom-languages' })
   })
 })
 installMonacoDelayerCancellationGuard()

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -1,3 +1,6 @@
+import { toast } from 'sonner'
+import { loadCustomLanguageSnapshot } from './custom-language-snapshot'
+import { registerCustomLanguages } from './monaco-languages/register-custom-languages'
 import { loader } from '@monaco-editor/react'
 import * as monaco from 'monaco-editor'
 import { typescript as monacoTS } from 'monaco-editor'
@@ -79,6 +82,12 @@ registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
 registerNimLanguage(monaco)
 registerJsonlLanguage(monaco)
+void loadCustomLanguageSnapshot().then((snapshot) => {
+  registerCustomLanguages(monaco, snapshot, (message) => {
+    console.warn('[custom-languages]', message)
+    toast.error(message)
+  })
+})
 installMonacoDelayerCancellationGuard()
 installMonacoDiffEditorDisposalGuard(monaco)
 installMonacoPeekReferencesPreviewOptions()

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -9,6 +9,7 @@ import './assets/main.css'
 import { StrictMode } from 'react'
 import { useTranslation } from 'react-i18next'
 import App from './App'
+import { loadCustomLanguageSnapshot } from './lib/custom-language-snapshot'
 import { RecoverableRenderErrorBoundary } from './components/error-boundaries/RecoverableRenderErrorBoundary'
 import {
   installRendererCrashDiagnostics,
@@ -69,14 +70,17 @@ function RendererRoot(): React.JSX.Element {
   )
 }
 
-getOrCreateRendererRoot(rootElement, import.meta.hot?.data).render(
-  <StrictMode>
-    <I18nProvider>
-      <RendererRoot />
-    </I18nProvider>
-  </StrictMode>
-)
-recordRendererCrashBreadcrumb('renderer_bootstrap_rendered')
+// Resolve file associations before restored editors compute their language.
+void loadCustomLanguageSnapshot().then(() => {
+  getOrCreateRendererRoot(rootElement, import.meta.hot?.data).render(
+    <StrictMode>
+      <I18nProvider>
+        <RendererRoot />
+      </I18nProvider>
+    </StrictMode>
+  )
+  recordRendererCrashBreadcrumb('renderer_bootstrap_rendered')
+})
 
 // Why here: the xterm WebGL addon is 243 KB, is only ever constructed once a
 // terminal attaches (many frames away), and is needed by nothing during boot.

--- a/src/shared/custom-languages.ts
+++ b/src/shared/custom-languages.ts
@@ -1,0 +1,17 @@
+import type { languages } from 'monaco-editor'
+import type { IRawGrammar } from 'vscode-textmate'
+
+export type CustomLanguage = {
+  id: string
+  aliases?: string[]
+  extensions?: string[]
+  filenames?: string[]
+  scopeName: string
+  configuration?: languages.LanguageConfiguration
+}
+
+export type CustomLanguageSnapshot = {
+  languages: CustomLanguage[]
+  grammars: Record<string, IRawGrammar>
+  diagnostics: string[]
+}


### PR DESCRIPTION
## ELI5

Orca can read the syntax definitions from an installed VS Code or Cursor extension, so files in custom languages get colors in the editor and diff viewer. Users opt in through `~/.orca/languages.json`; Orca reads the grammar data without running the extension.

## What Changed

- Load unpacked extension manifests or direct JSON TextMate registrations from a client-local JSONC configuration.
- Resolve custom filenames and suffixes before opening restored editors, and reuse Orca’s existing lazy TextMate tokenizer.
- Support shared dependency scopes and basic comments/bracket configuration. Isolate invalid entries, limit input sizes, reject extension resource escapes, and fall back when loading fails.
- Document configuration, precedence, supported formats, and limitations in the editor guide.

## Why

Custom languages can provide reusable TextMate syntax grammars. This PR uses ExampleLang, a synthetic demonstration language. Letting users reuse those definitions avoids adding each language to Orca’s bundled list or maintaining a language-specific fork. This adds highlighting only; extension activation and LSP integration remain separate work.

## Linked Issue

Fixes #8093

## Visual Proof

The same synthetic ExampleLang (`.examplelang`) program, with custom configuration absent (before) and enabled (after), on the same feature build. The demonstration grammar was authored specifically for this example; no installed third-party language extension is required.

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![ExampleLang before, dark](https://github.com/user-attachments/assets/db8c04db-8fff-457f-a923-01943d8b8535) | ![ExampleLang after, dark](https://github.com/user-attachments/assets/d9530530-805d-46e5-ad17-74930c52b8f4) |
| Light | ![ExampleLang before, light](https://github.com/user-attachments/assets/fd76c45d-b54b-419a-bd6a-e8d45a1071b1) | ![ExampleLang after, light](https://github.com/user-attachments/assets/14382067-97f6-419f-aef9-cab1e88541f1) |

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

macOS validation:

- `pnpm lint`: passed, including reliability and localization checks.
- `pnpm typecheck`: passed for all projects; repeated after both review follow-ups.
- `pnpm build`: desktop/web bundles and macOS native helpers passed before the review follow-up. The Electron main/preload/renderer bundles and built-entry smoke checks were repeated after the follow-ups in an isolated E2E build. Native helpers and the complete build command were not rerun.
- Final focused language/settings suite: 98 tests passed across 13 files after the review fixes. New regression cases cover scope and byte-budget rollback, duplicate-ID recovery, extension path traversal, missing grammar mappings, and missing/malformed optional configuration for both extension and direct registrations. Scoped lint also passes. The file-symlink test is skipped on Windows, where creating symlinks may require elevated permissions; the direct path-escape test runs on every platform.
- The contributor manually confirmed custom-language syntax highlighting in the running macOS desktop build.
- `pnpm test --maxWorkers=4`: completed in 20 minutes: **77,423 passed, 13 failed, 395 skipped**, with 2 additional suite-setup failures and 1 unhandled error from missing history. Of 8,406 files, 8,338 passed, 7 failed, and 61 skipped. This broad run started before the final localized lazy-tokenization fix; the final language/settings suite and build were repeated afterward. See the targeted follow-ups below; the full suite is not claimed green.
- Hidden Electron desktop check: passed in light and dark themes. Real startup IPC loaded a synthetic ExampleLang extension; opening the synthetic `.examplelang` file through Explorer selected `ExampleLang` and rendered comments, keywords, and strings with distinct colors. The valid configuration produced no grammar diagnostics. A follow-up run also verified that three configuration diagnostics remain logged while one error toast is shown and the valid language still highlights. All test windows stayed hidden and unfocused. Uses the repository’s isolated profile helpers and Playwright CDP with `ORCA_BACKGROUND_LAUNCH=1`.

Regression tests cover absent/malformed configuration, valid entries beside invalid ones, size limits, symlink escapes, duplicate scopes, filename/suffix precedence, shared grammar dependencies, optional/missing API support, rejected and stalled startup IPC, and failed tokenizer fallback. A real invalid Oniguruma regex verifies failures during lazy tokenization are reported once, later lines remain readable, and another language still highlights.

Follow-up checks:

- All 10 release-checkout tests pass after completing the checkout history and fetching the required release tag. This also removes the reported missing-ref unhandled error.
- The 13 agent-session wire tests and 3 browser-placement wire tests pass after fetching their release prerequisites (including pinned `v1.4.184` for browser placement).
- All 40 structured-adapter tests pass with the ambient `ANTHROPIC_API_KEY` omitted from that test process. The initial assertion failure was reproduced on unchanged base `7dd183d8`.
- Three live Claude handshake tests and one live Claude TUI-resume test fail because the selected account is not signed in. All four failures were reproduced on unchanged base `7dd183d8`; no unrelated authentication code was changed.
- The shell-recipe cleanup test also fails on unchanged base `7dd183d8`: macOS Bash 3.2 treats its empty `vercel_args` array as unbound under `set -u`. This unrelated recipe was not changed.

The five unresolved test failures are the four live Claude sign-in tests and the Bash 3.2 recipe test; each was reproduced on the unchanged base. The complete suite was not rerun after environment repairs.

Linux, Windows, remote/SSH execution, and mobile were not run locally and need CI or maintainer verification. To reproduce highlighting, configure an unpacked grammar extension, restart Orca, and open a matching file from Explorer; compare light/dark editor and Changes view behavior.

## AI Disclosure

Codex (GPT-6) assisted with implementation, tests, documentation, and the self-review below.

## Review

- Cross-platform: filesystem operations use Node path utilities; renderer filename matching accepts both separator styles. No OS-specific shortcuts or native APIs were added. Only macOS was executed locally.
- SSH/remote/local: grammar definitions belong to the desktop client and can highlight local, folder, and remote-workspace files. No remote execution or RPC wire contract changes were added. Browser-only clients retain existing highlighting when the optional API is absent; mixed-host-version and SSH behavior still need runtime verification.
- Agents/integrations/providers: grammar registration is independent of CLI agents, LSP servers, and Git providers. Imported extension JavaScript is never activated.
- Performance: configuration is cached per process and tokenizer construction is lazy. Reads have per-file/aggregate limits. Startup intentionally waits for associations before restoring editors so their first language choice is correct. This adds an IPC round trip before first paint and can leave a blank window for up to three seconds on a stalled read; that timeout and trade-off are explicit. Applying associations reactively after first paint is not implemented. User-supplied grammar complexity can still affect tokenization performance.
- UI quality: existing Monaco theme and tokenizer infrastructure is reused. Captured and visually reviewed light/dark desktop before/after images; no new controls or design tokens were introduced.
- Security: the renderer cannot choose the config path through IPC. Extension resources must remain inside their real directory, including symlinks; malformed entries are isolated. User-selected grammar files are trusted data, not a sandbox for arbitrary grammar complexity.
- Backwards compatibility/mobile: no config preserves built-in detection; built-in Monaco IDs keep their tokenizer. Browser clients tolerate the missing optional API. No mobile-specific behavior was modified.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Restart is required after configuration or grammar changes. Only JSON TextMate grammars and basic language configuration are supported. Extension activation, LSP features, injection contributions, semantic tokens, and advanced configuration regex rules are not included. No package dependency, release version, or generated artifact changes are part of this contribution.

## Author

X: [@abarrett879](https://x.com/abarrett879)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
