### PR TITLE
feat(plugins): add workspace-located plugin panels

### DIFF
--- a/examples/plugins/hello-orca/orca-plugin.json
+++ b/examples/plugins/hello-orca/orca-plugin.json
@@ -9,7 +9,16 @@
   "pluginApi": 1,
   "main": "main.mjs",
   "contributes": {
-    "panels": [{ "id": "hello", "title": "Hello Orca", "icon": "plug", "entry": "panel.html" }],
+    "panels": [
+      { "id": "hello", "title": "Hello Orca", "icon": "plug", "entry": "panel.html" },
+      {
+        "id": "hello-workspace",
+        "title": "Hello Orca Workspace",
+        "icon": "layout-dashboard",
+        "location": "workspace",
+        "entry": "workspace.html"
+      }
+    ],
     "commands": [{ "id": "hello-ping", "title": "Hello: Ping" }],
     "events": [{ "on": "worktree.created" }, { "on": "agent.status.changed" }]
   },

--- a/examples/plugins/hello-orca/panel.html
+++ b/examples/plugins/hello-orca/panel.html
@@ -47,6 +47,7 @@
     <select id="terms" hidden></select>
     <button id="send" hidden>Type "echo hi from plugin" into selected terminal</button>
     <button id="notify">Show a notification</button>
+    <button id="open-workspace">Open the workspace view</button>
     <p class="status" id="status"></p>
     <script>
       'use strict'
@@ -110,6 +111,16 @@
           statusEl.textContent = result.ok
             ? 'typed (accepted=' + result.value.accepted + ')'
             : 'send failed: ' + (result.error || result.errorCode)
+        })
+      })
+
+      document.getElementById('open-workspace').addEventListener('click', function () {
+        // Renderer-local action: the host opens a workspace panel this same
+        // plugin declares. It never reaches the main process.
+        call('workspace.openView', { viewId: 'hello-workspace' }).then(function (result) {
+          statusEl.textContent = result.ok
+            ? 'workspace view opened'
+            : 'open failed: ' + (result.error || result.errorCode)
         })
       })
 

--- a/examples/plugins/hello-orca/workspace.html
+++ b/examples/plugins/hello-orca/workspace.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 24px;
+        font-family: system-ui, sans-serif;
+        font-size: 13px;
+        color: var(--foreground, #ddd);
+        background: var(--background, transparent);
+      }
+      h1 {
+        font-size: 18px;
+        margin: 0 0 4px;
+      }
+      p {
+        margin: 0 0 16px;
+        color: var(--muted-foreground, #999);
+      }
+      .card {
+        max-width: 640px;
+        padding: 16px;
+        border: 1px solid var(--border, #555);
+        border-radius: 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Hello Orca Workspace 🗺️</h1>
+    <p>
+      This panel declares <code>"location": "workspace"</code>, so it renders across the workspace
+      area instead of the right sidebar. It has no activity-bar entry — the sidebar panel opens it.
+    </p>
+    <div class="card">
+      Same sandbox, same bridge, more room: use this surface for content a 320px sidebar cannot
+      hold, such as a board, a diff, or a dashboard.
+    </div>
+  </body>
+</html>

--- a/src/main/plugins/plugin-list-projection.ts
+++ b/src/main/plugins/plugin-list-projection.ts
@@ -29,6 +29,7 @@ export type PluginListPanelEntry = {
   id: string
   title: string
   icon?: string
+  location?: 'right-sidebar' | 'workspace'
   tabKey: `plugin:${string}`
 }
 
@@ -175,6 +176,7 @@ export async function buildPluginList(
           id: panel.id,
           title: panel.title,
           ...(panel.icon ? { icon: panel.icon } : {}),
+          ...(panel.location ? { location: panel.location } : {}),
           tabKey: pluginPanelTabKey(plugin.pluginKey, panel.id)
         })),
         commands: service.contentPacks.commands.preview(plugin.pluginKey).map((command) => ({

--- a/src/preload/api/plugin-host-api.ts
+++ b/src/preload/api/plugin-host-api.ts
@@ -14,6 +14,8 @@ export type PluginHostPanel = {
   title: string
   /** Lucide icon name declared in the plugin manifest. */
   icon?: string
+  /** Omitted by older hosts and interpreted as right-sidebar. */
+  location?: 'right-sidebar' | 'workspace'
   tabKey: `plugin:${string}`
 }
 

--- a/src/renderer/src/app-shell/AppWorkspaceShell.tsx
+++ b/src/renderer/src/app-shell/AppWorkspaceShell.tsx
@@ -11,6 +11,7 @@ import { TitlebarLeftControls } from './TitlebarLeftControls'
 import { RightSidebarToggle, TitlebarMainStrip } from './TitlebarMainStrip'
 import type { AppChromeLayout } from './use-app-chrome-layout'
 import type { FloatingWorkspacePanelState } from './use-floating-workspace-panel'
+import { PluginWorkspacePanel } from '../components/plugin-workspace/PluginWorkspacePanel'
 
 const Landing = lazy(() => import('../components/Landing'))
 const WorktreeCreationPanel = lazy(
@@ -162,6 +163,7 @@ export function AppWorkspaceShell(props: {
                 <div className="titlebar">{titlebarMainStrip}</div>
               ) : null}
               <div className="relative flex flex-1 min-w-0 min-h-0 overflow-hidden">
+                <PluginWorkspacePanel />
                 {/* Why: match the RightSidebar header's 36px/top-0 so the toggle's vertical center is identical open vs closed — else the icon jitters. */}
                 {layout.workspaceChromeActive && !layout.rightSidebarOpen && (
                   <div

--- a/src/renderer/src/components/plugin-workspace/PluginWorkspacePanel.tsx
+++ b/src/renderer/src/components/plugin-workspace/PluginWorkspacePanel.tsx
@@ -1,0 +1,31 @@
+import { X } from 'lucide-react'
+import PluginPanel from '../right-sidebar/PluginPanel'
+import { usePluginPanels, usePluginPanelsStore } from '@/store/plugin-panels'
+import { Button } from '@/components/ui/button'
+
+export function PluginWorkspacePanel(): React.JSX.Element | null {
+  const tabKey = usePluginPanelsStore((state) => state.activeWorkspacePanel)
+  const close = usePluginPanelsStore((state) => state.closeWorkspacePanel)
+  const panels = usePluginPanels()
+  const panel = panels.find(
+    (candidate) => candidate.tabKey === tabKey && candidate.location === 'workspace'
+  )
+
+  if (!tabKey || !panel) {
+    return null
+  }
+
+  return (
+    <section className="absolute inset-0 z-20 flex min-h-0 flex-col bg-background">
+      <header className="titlebar flex shrink-0 items-center border-b border-border px-3">
+        <div className="min-w-0 flex-1 truncate text-sm font-medium">{panel.title}</div>
+        <Button variant="ghost" size="icon" onClick={close} aria-label="Close workspace view">
+          <X className="size-4" />
+        </Button>
+      </header>
+      <div className="flex min-h-0 flex-1">
+        <PluginPanel tabKey={tabKey} expectedLocation="workspace" />
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/plugin-workspace/PluginWorkspacePanel.tsx
+++ b/src/renderer/src/components/plugin-workspace/PluginWorkspacePanel.tsx
@@ -24,7 +24,10 @@ export function PluginWorkspacePanel(): React.JSX.Element | null {
         </Button>
       </header>
       <div className="flex min-h-0 flex-1">
-        <PluginPanel tabKey={tabKey} expectedLocation="workspace" />
+        {/* Why key: same rule as the sidebar — switching views must remount the
+            sandboxed iframe so a reused frame cannot keep posting messages while
+            the bridge rebinds under the next panel's session. */}
+        <PluginPanel key={tabKey} tabKey={tabKey} expectedLocation="workspace" />
       </div>
     </section>
   )

--- a/src/renderer/src/components/right-sidebar/PluginPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/PluginPanel.test.tsx
@@ -9,9 +9,10 @@ vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
 }))
 
-const { usePluginPanelsMock, setPanelHealthMock } = vi.hoisted(() => ({
-  usePluginPanelsMock: vi.fn<() => ActivePluginPanel[]>(() => []),
-  setPanelHealthMock: vi.fn()
+const { panelListMock, setPanelHealthMock, openWorkspacePanelMock } = vi.hoisted(() => ({
+  panelListMock: vi.fn<() => ActivePluginPanel[]>(() => []),
+  setPanelHealthMock: vi.fn(),
+  openWorkspacePanelMock: vi.fn()
 }))
 
 const { watchdogStartMock, watchdogStopMock, watchdogCallbacks } = vi.hoisted(() => ({
@@ -21,10 +22,13 @@ const { watchdogStartMock, watchdogStopMock, watchdogCallbacks } = vi.hoisted(()
 }))
 
 vi.mock('@/store/plugin-panels', () => ({
-  usePluginPanels: usePluginPanelsMock,
-  usePluginPanelsStore: (
-    selector: (state: { setPanelHealth: typeof setPanelHealthMock }) => unknown
-  ) => selector({ setPanelHealth: setPanelHealthMock })
+  usePluginPanels: panelListMock,
+  collectActivePluginPanels: () => panelListMock(),
+  usePluginPanelsStore: Object.assign(
+    (selector: (state: { setPanelHealth: typeof setPanelHealthMock }) => unknown) =>
+      selector({ setPanelHealth: setPanelHealthMock }),
+    { getState: () => ({ plugins: [], openWorkspacePanel: openWorkspacePanelMock }) }
+  )
 }))
 
 vi.mock('./plugin-panel-watchdog', () => ({
@@ -80,7 +84,7 @@ beforeEach(() => {
   setPanelHealthMock.mockReset()
   document.documentElement.classList.remove('dark')
   pluginChangedListener = null
-  usePluginPanelsMock.mockReturnValue([dashboardPanel])
+  panelListMock.mockReturnValue([dashboardPanel])
   globalThis.window.api = {
     plugins: {
       readPanelEntry: readPanelEntryMock,
@@ -102,9 +106,12 @@ afterEach(async () => {
   vi.restoreAllMocks()
 })
 
-async function renderPanel(tabKey: string): Promise<void> {
+async function renderPanel(
+  tabKey: string,
+  expectedLocation?: 'right-sidebar' | 'workspace'
+): Promise<void> {
   await act(async () => {
-    root.render(<PluginPanel tabKey={tabKey} />)
+    root.render(<PluginPanel tabKey={tabKey} expectedLocation={expectedLocation} />)
   })
 }
 
@@ -340,10 +347,67 @@ describe('PluginPanel', () => {
   })
 
   it('shows an unavailable state for a tab whose plugin is gone', async () => {
-    usePluginPanelsMock.mockReturnValue([])
+    panelListMock.mockReturnValue([])
 
     await renderPanel('plugin:orca-samples.removed-plugin/dashboard')
 
+    expect(readPanelEntryMock).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('This plugin panel is no longer available.')
+  })
+
+  it('still delivers an in-flight action reply after the plugin list refreshes', async () => {
+    readPanelEntryMock.mockResolvedValue({
+      html: '<h1>Hello plugin</h1>',
+      sessionToken: SESSION_TOKEN
+    })
+    await renderPanel(dashboardPanel.tabKey)
+    const iframe = container.querySelector('iframe')
+
+    let resolveAction!: (outcome: { ok: true; value: unknown }) => void
+    panelActionMock.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveAction = resolve))
+    )
+    const postMessage = vi.fn()
+    Object.defineProperty(iframe?.contentWindow ?? {}, 'postMessage', {
+      value: postMessage,
+      configurable: true
+    })
+
+    const event = new MessageEvent('message', {
+      data: {
+        type: 'orca-panel-action',
+        requestId: 'in-flight',
+        action: 'notifications.show',
+        params: { title: 'Hello' }
+      }
+    })
+    Object.defineProperty(event, 'source', { value: iframe?.contentWindow })
+    await act(async () => {
+      window.dispatchEvent(event)
+      await waitForHappyDomTasks()
+    })
+
+    // A plugin-list refresh (install, enable, dev reload) hands the component a
+    // new array identity. It must not orphan the reply the panel is awaiting.
+    panelListMock.mockReturnValue([{ ...dashboardPanel }])
+    await renderPanel(dashboardPanel.tabKey)
+    await act(async () => {
+      resolveAction({ ok: true, value: { delivered: true } })
+      await waitForHappyDomTasks()
+    })
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'in-flight', ok: true }),
+      '*'
+    )
+  })
+
+  it('refuses to render a panel on a surface it did not declare', async () => {
+    panelListMock.mockReturnValue([{ ...dashboardPanel, location: 'workspace' }])
+
+    await renderPanel(dashboardPanel.tabKey, 'right-sidebar')
+
+    // A workspace panel reached through a sidebar tab must not load its entry.
     expect(readPanelEntryMock).not.toHaveBeenCalled()
     expect(container.textContent).toContain('This plugin panel is no longer available.')
   })

--- a/src/renderer/src/components/right-sidebar/PluginPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PluginPanel.tsx
@@ -15,11 +15,16 @@ import {
 import { createPanelWatchdog } from './plugin-panel-watchdog'
 import { buildPanelDesignTokenCss, currentPanelColorScheme } from './plugin-panel-design-token-css'
 import { usePluginPanelThemeRevision } from './use-plugin-panel-theme-revision'
-import { usePluginPanels, usePluginPanelsStore } from '@/store/plugin-panels'
+import {
+  collectActivePluginPanels,
+  usePluginPanels,
+  usePluginPanelsStore
+} from '@/store/plugin-panels'
 import { translate } from '@/i18n/i18n'
 
 type PluginPanelProps = {
   tabKey: string
+  expectedLocation?: 'right-sidebar' | 'workspace'
 }
 
 type PluginPanelEntryState =
@@ -45,11 +50,15 @@ function fillPanelShell(html: string): string {
     .replace(PANEL_SHELL_TOKENS_PLACEHOLDER, buildPanelDesignTokenCss())
 }
 
-function PluginPanel({ tabKey }: PluginPanelProps): React.JSX.Element {
+function PluginPanel({ tabKey, expectedLocation }: PluginPanelProps): React.JSX.Element {
   const panels = usePluginPanels()
   const setPanelHealth = usePluginPanelsStore((state) => state.setPanelHealth)
   const panel = isPluginPanelTabKey(tabKey)
-    ? (panels.find((entry) => entry.tabKey === tabKey) ?? null)
+    ? (panels.find(
+        (entry) =>
+          entry.tabKey === tabKey &&
+          (!expectedLocation || (entry.location ?? 'right-sidebar') === expectedLocation)
+      ) ?? null)
     : null
   const [entryState, setEntryState] = useState<PluginPanelEntryState>({ status: 'loading' })
   const [sessionToken, setSessionToken] = useState<string | null>(null)
@@ -89,6 +98,19 @@ function PluginPanel({ tabKey }: PluginPanelProps): React.JSX.Element {
       sessionToken,
       getPanelWindow: () => iframeRef.current?.contentWindow ?? null,
       callPanelAction: callPanelActionViaPreload,
+      openWorkspaceView: (viewId) => {
+        // Read the list at call time: capturing it would rebind this handler on
+        // every plugin-list refresh, and the rebind drops in-flight replies.
+        const target = collectActivePluginPanels(usePluginPanelsStore.getState().plugins).find(
+          (entry) =>
+            entry.pluginKey === pluginKey && entry.id === viewId && entry.location === 'workspace'
+        )
+        if (!target) {
+          return false
+        }
+        usePluginPanelsStore.getState().openWorkspacePanel(target.tabKey)
+        return true
+      },
       isActive: () => active,
       onPong: (pingId) => watchdog.handlePong(pingId)
     })
@@ -97,7 +119,7 @@ function PluginPanel({ tabKey }: PluginPanelProps): React.JSX.Element {
       active = false
       window.removeEventListener('message', handler)
     }
-  }, [panelDocument, sessionToken, watchdog])
+  }, [panelDocument, pluginKey, sessionToken, watchdog])
 
   useEffect(() => {
     if (!panelFrameKey || loadedFrameKey !== panelFrameKey) {

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
@@ -65,6 +65,98 @@ describe('createPanelBridgeMessageHandler', () => {
     )
   })
 
+  it('opens an owned workspace view without relaying the renderer-only action to main', () => {
+    const panelWindow = createFakePanelWindow()
+    const callPanelAction = vi.fn()
+    const openWorkspaceView = vi.fn().mockReturnValue(true)
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction,
+      openWorkspaceView
+    })
+
+    handler(
+      messageEvent(
+        {
+          type: 'orca-panel-action',
+          requestId: 'open-1',
+          action: 'workspace.openView',
+          params: { viewId: 'board' }
+        },
+        panelWindow
+      )
+    )
+
+    expect(openWorkspaceView).toHaveBeenCalledWith('board')
+    expect(callPanelAction).not.toHaveBeenCalled()
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      { type: 'orca-panel-action-result', requestId: 'open-1', ok: true, value: null },
+      '*'
+    )
+  })
+
+  it('refuses a workspace view the panel does not own without reaching main', () => {
+    const panelWindow = createFakePanelWindow()
+    const callPanelAction = vi.fn()
+    // The renderer scopes lookups to the requesting plugin, so a foreign or
+    // unknown viewId arrives here as a plain false.
+    const openWorkspaceView = vi.fn().mockReturnValue(false)
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction,
+      openWorkspaceView
+    })
+
+    handler(
+      messageEvent(
+        {
+          type: 'orca-panel-action',
+          requestId: 'open-2',
+          action: 'workspace.openView',
+          params: { viewId: 'someone-elses-board' }
+        },
+        panelWindow
+      )
+    )
+
+    expect(callPanelAction).not.toHaveBeenCalled()
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'open-2', ok: false, errorCode: 'invalid_request' }),
+      '*'
+    )
+  })
+
+  it('rejects a workspace view request with no usable viewId', () => {
+    const panelWindow = createFakePanelWindow()
+    const openWorkspaceView = vi.fn()
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction: vi.fn(),
+      openWorkspaceView
+    })
+
+    handler(
+      messageEvent(
+        {
+          type: 'orca-panel-action',
+          requestId: 'open-3',
+          action: 'workspace.openView',
+          params: { viewId: 42 }
+        },
+        panelWindow
+      )
+    )
+
+    expect(openWorkspaceView).not.toHaveBeenCalled()
+    expect(panelWindow.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'open-3', ok: false }),
+      '*'
+    )
+  })
+
   it('ignores messages whose source is not the panel iframe window', async () => {
     const panelWindow = createFakePanelWindow()
     const { handler, callPanelAction } = createHandler(panelWindow)

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
@@ -1,6 +1,7 @@
 import {
   PANEL_ACTION_RESULT_TYPE,
   PANEL_CONTROL_MESSAGE_MAX_BYTES,
+  PANEL_OPEN_WORKSPACE_VIEW_ACTION,
   looksLikePanelActionRequest,
   parsePanelActionRequest,
   readPanelPongId,
@@ -36,6 +37,7 @@ export type PanelBridgeHostOptions = {
   /** The mounted panel iframe's contentWindow, or null when unmounted. */
   getPanelWindow: () => Window | null
   callPanelAction: (call: PanelActionCall) => Promise<PluginPanelActionOutcome>
+  openWorkspaceView?: (viewId: string) => boolean
   /** False once the requesting panel document/session has been replaced. */
   isActive?: () => boolean
   onPong?: (pingId: number) => void
@@ -155,6 +157,27 @@ export function createPanelBridgeMessageHandler(
       return
     }
     const { requestId, action, params } = parsed.request
+    if (action === PANEL_OPEN_WORKSPACE_VIEW_ACTION) {
+      const viewId =
+        typeof params === 'object' &&
+        params !== null &&
+        typeof (params as { viewId?: unknown }).viewId === 'string'
+          ? (params as { viewId: string }).viewId
+          : null
+      const opened = viewId ? options.openWorkspaceView?.(viewId) === true : false
+      respond(
+        opened
+          ? { type: PANEL_ACTION_RESULT_TYPE, requestId, ok: true, value: null }
+          : {
+              type: PANEL_ACTION_RESULT_TYPE,
+              requestId,
+              ok: false,
+              errorCode: 'invalid_request',
+              error: 'Workspace view is unavailable.'
+            }
+      )
+      return
+    }
     options
       .callPanelAction({ sessionToken: options.sessionToken, action, params })
       .then((outcome) => {

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -46,7 +46,7 @@ export function RightSidebarPanelContent({
             a reused frame could keep posting messages while the bridge is
             rebound under the next plugin's identity. */}
         {isPluginPanelTabKey(effectiveTab) && (
-          <PluginPanel key={effectiveTab} tabKey={effectiveTab} />
+          <PluginPanel key={effectiveTab} tabKey={effectiveTab} expectedLocation="right-sidebar" />
         )}
       </Suspense>
     </div>

--- a/src/renderer/src/components/right-sidebar/use-right-sidebar-activity-items.ts
+++ b/src/renderer/src/components/right-sidebar/use-right-sidebar-activity-items.ts
@@ -8,7 +8,7 @@ import { getVisibleRightSidebarActivityItems } from './right-sidebar-activity-vi
 import { getPluginPanelActivityItems } from './plugin-panel-activity-items'
 import {
   collectInstalledPluginTabKeys,
-  usePluginPanels,
+  usePluginPanelsAt,
   usePluginPanelsStore,
   type PluginPanelsFetchStatus
 } from '@/store/plugin-panels'
@@ -46,7 +46,7 @@ export function useRightSidebarActivityItems({
   const isFolder = isFolderWorkspace || (activeRepo ? isFolderRepo(activeRepo) : false)
   const isSshRepo = Boolean(activeRepo?.connectionId)
   const pluginSystemEnabled = useAppStore((s) => s.settings?.pluginSystemEnabled === true)
-  const pluginPanels = usePluginPanels()
+  const pluginPanels = usePluginPanelsAt('right-sidebar')
   const visiblePluginPanels = useMemo(
     () => (pluginSystemEnabled ? pluginPanels : []),
     [pluginPanels, pluginSystemEnabled]

--- a/src/renderer/src/store/plugin-panels.test.ts
+++ b/src/renderer/src/store/plugin-panels.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { PluginHostListEntry } from '../../../preload/api-types'
 import {
   collectActivePluginCommands,
+  collectActivePluginPanelsAt,
   collectEditablePluginCommands,
   usePluginPanelsStore
 } from './plugin-panels'
@@ -65,6 +66,39 @@ describe('plugin panel list loading', () => {
         { ...enabled, status: 'disabled' }
       ])
     ).toEqual([expect.objectContaining({ pluginKey: enabled.pluginKey, id: 'tasks' })])
+  })
+
+  it('routes panels to their declared surface and keeps legacy panels in the sidebar', () => {
+    const entry = {
+      ...plugin('orca-samples.current'),
+      panels: [
+        {
+          id: 'legacy',
+          title: 'Legacy',
+          tabKey: 'plugin:orca-samples.current/legacy' as const
+        },
+        {
+          id: 'sidebar',
+          title: 'Sidebar',
+          location: 'right-sidebar' as const,
+          tabKey: 'plugin:orca-samples.current/sidebar' as const
+        },
+        {
+          id: 'board',
+          title: 'Board',
+          location: 'workspace' as const,
+          tabKey: 'plugin:orca-samples.current/board' as const
+        }
+      ]
+    }
+
+    // A manifest written before `location` existed must keep its sidebar tab.
+    expect(collectActivePluginPanelsAt([entry], 'right-sidebar').map((p) => p.id)).toEqual([
+      'legacy',
+      'sidebar'
+    ])
+    expect(collectActivePluginPanelsAt([entry], 'workspace').map((p) => p.id)).toEqual(['board'])
+    expect(collectActivePluginPanelsAt([{ ...entry, status: 'disabled' }], 'workspace')).toEqual([])
   })
 
   it('bounds watchdog errors to installed panels and clears them on recovery', () => {

--- a/src/renderer/src/store/plugin-panels.test.ts
+++ b/src/renderer/src/store/plugin-panels.test.ts
@@ -6,6 +6,7 @@ import {
   collectActivePluginCommands,
   collectActivePluginPanelsAt,
   collectEditablePluginCommands,
+  collectInstalledPluginTabKeys,
   usePluginPanelsStore
 } from './plugin-panels'
 
@@ -99,6 +100,27 @@ describe('plugin panel list loading', () => {
     ])
     expect(collectActivePluginPanelsAt([entry], 'workspace').map((p) => p.id)).toEqual(['board'])
     expect(collectActivePluginPanelsAt([{ ...entry, status: 'disabled' }], 'workspace')).toEqual([])
+  })
+
+  it('keeps workspace panels out of the sidebar route key set', () => {
+    const entry = {
+      ...plugin('orca-samples.current'),
+      panels: [
+        { id: 'legacy', title: 'Legacy', tabKey: 'plugin:orca-samples.current/legacy' as const },
+        {
+          id: 'board',
+          title: 'Board',
+          location: 'workspace' as const,
+          tabKey: 'plugin:orca-samples.current/board' as const
+        }
+      ]
+    }
+
+    // A panel that moved to the workspace surface must not keep a persisted
+    // sidebar route alive — the normalizer drops what this set omits.
+    expect(collectInstalledPluginTabKeys([entry])).toEqual(
+      new Set(['plugin:orca-samples.current/legacy'])
+    )
   })
 
   it('bounds watchdog errors to installed panels and clears them on recovery', () => {

--- a/src/renderer/src/store/plugin-panels.ts
+++ b/src/renderer/src/store/plugin-panels.ts
@@ -168,13 +168,21 @@ export function collectActivePluginPanelsAt(
   )
 }
 
-/** Tab keys of every installed plugin panel (any status) — used by the
+/** Tab keys of every installed sidebar panel (any status) — used by the
  *  persisted-route normalizer to drop keys of uninstalled plugins while
- *  keeping keys that are merely disabled. */
+ *  keeping keys that are merely disabled. Workspace panels are excluded: they
+ *  are not sidebar-routable, so a panel that moved surface must drop its stale
+ *  sidebar route rather than survive normalization. */
 export function collectInstalledPluginTabKeys(
   plugins: readonly PluginHostListEntry[]
 ): Set<string> {
-  return new Set(plugins.flatMap((plugin) => plugin.panels.map((panel) => panel.tabKey)))
+  return new Set(
+    plugins.flatMap((plugin) =>
+      plugin.panels
+        .filter((panel) => (panel.location ?? 'right-sidebar') === 'right-sidebar')
+        .map((panel) => panel.tabKey)
+    )
+  )
 }
 
 export function collectActivePluginCommands(

--- a/src/renderer/src/store/plugin-panels.ts
+++ b/src/renderer/src/store/plugin-panels.ts
@@ -19,10 +19,13 @@ export type PluginPanelHealth = 'healthy' | 'error'
 type PluginPanelsState = {
   plugins: PluginHostListEntry[]
   panelErrors: Record<string, true>
+  activeWorkspacePanel: string | null
   fetchStatus: PluginPanelsFetchStatus
   fetchPlugins: () => Promise<void>
   setPlugins: (plugins: PluginHostListEntry[]) => void
   setPanelHealth: (tabKey: string, health: PluginPanelHealth) => void
+  openWorkspacePanel: (tabKey: string) => void
+  closeWorkspacePanel: () => void
 }
 
 let pluginListGeneration = 0
@@ -49,6 +52,7 @@ function schedulePluginListRetry(generation: number): void {
 export const usePluginPanelsStore = create<PluginPanelsState>()((set) => ({
   plugins: [],
   panelErrors: {},
+  activeWorkspacePanel: null,
   fetchStatus: 'idle',
   fetchPlugins: async () => {
     const generation = ++pluginListGeneration
@@ -106,7 +110,9 @@ export const usePluginPanelsStore = create<PluginPanelsState>()((set) => ({
       }
       return { panelErrors }
     })
-  }
+  },
+  openWorkspacePanel: (tabKey) => set({ activeWorkspacePanel: tabKey }),
+  closeWorkspacePanel: () => set({ activeWorkspacePanel: null })
 }))
 
 function retainInstalledPanelErrors(
@@ -151,6 +157,15 @@ export function collectActivePluginPanels(plugins: PluginHostListEntry[]): Activ
         pluginName: plugin.name
       }))
     )
+}
+
+export function collectActivePluginPanelsAt(
+  plugins: PluginHostListEntry[],
+  location: NonNullable<PluginHostPanel['location']>
+): ActivePluginPanel[] {
+  return collectActivePluginPanels(plugins).filter(
+    (panel) => (panel.location ?? 'right-sidebar') === location
+  )
 }
 
 /** Tab keys of every installed plugin panel (any status) — used by the
@@ -202,6 +217,16 @@ export function usePluginPanels(): ActivePluginPanel[] {
   // Why: derive in useMemo (not the selector) so the store snapshot stays
   // referentially stable and doesn't retrigger useSyncExternalStore loops.
   return useMemo(() => collectActivePluginPanels(plugins), [plugins])
+}
+
+export function usePluginPanelsAt(
+  location: NonNullable<PluginHostPanel['location']>
+): ActivePluginPanel[] {
+  const plugins = usePluginPanelsStore((s) => s.plugins)
+  useEffect(() => {
+    ensurePluginPanelsLoaded()
+  }, [])
+  return useMemo(() => collectActivePluginPanelsAt(plugins, location), [location, plugins])
 }
 
 /** Commands of enabled plugins, sharing the authoritative plugin-list refresh. */

--- a/src/shared/plugins/plugin-manifest.ts
+++ b/src/shared/plugins/plugin-manifest.ts
@@ -46,6 +46,8 @@ const panelContributionSchema = z.object({
   title: z.string().min(1).max(256),
   /** Lucide icon name rendered in the right-sidebar activity bar. */
   icon: z.string().min(1).max(64).optional(),
+  /** Defaults to the legacy right-sidebar surface for compatibility. */
+  location: z.enum(['right-sidebar', 'workspace']).optional(),
   /** HTML entry rendered inside a sandboxed panel frame. */
   entry: pluginRelativePathSchema
 })

--- a/src/shared/plugins/plugin-panel-bridge.ts
+++ b/src/shared/plugins/plugin-panel-bridge.ts
@@ -17,6 +17,7 @@ export const PANEL_ACTION_RESULT_TYPE = 'orca-panel-action-result'
 export const PANEL_PING_TYPE = 'orca-panel-ping'
 export const PANEL_PONG_TYPE = 'orca-panel-pong'
 export const PLUGIN_PANEL_FRAME_NAME_PREFIX = 'orca-plugin-panel:'
+export const PANEL_OPEN_WORKSPACE_VIEW_ACTION = 'workspace.openView'
 
 /** Per-plugin bridge budgets, enforced host-side. */
 export const PANEL_MESSAGE_MAX_BYTES = 64 * 1024
@@ -39,7 +40,13 @@ export const panelActionRequestSchema = z.object({
   type: z.literal(PANEL_ACTION_REQUEST_TYPE),
   /** Plugin-chosen correlation id echoed back on the result message. */
   requestId: z.string().min(1).max(128),
-  action: z.string().min(1).refine(isPluginPanelAction, 'not a panel-callable action'),
+  action: z
+    .string()
+    .min(1)
+    .refine(
+      (action) => action === PANEL_OPEN_WORKSPACE_VIEW_ACTION || isPluginPanelAction(action),
+      'not a panel-callable action'
+    ),
   params: z.unknown().optional()
 })
 


### PR DESCRIPTION
Panels may declare `location: "workspace"` in their manifest and render as a full workspace surface instead of a right-sidebar tab. Sidebar panels open one via the renderer-local `workspace.openView` bridge action, which never reaches main.

## ELI5

Today a plugin can only draw inside the narrow strip on the right. Some plugins need real room — a board, a diff, a dashboard — and 320px is not enough. This adds a second place a plugin panel can live: the big middle area. A plugin says where each of its panels belongs in its manifest, and a panel in the sidebar can ask Orca to open its own big view. Nothing else about plugins changes: same sandbox, same permissions, same bridge.

## What Changed

- `panels[].location` (`"right-sidebar" | "workspace"`) added to the plugin manifest schema. Optional — omitting it means `right-sidebar`, exactly as before.
- The field is carried through the plugin list projection (`src/main/plugins/plugin-list-projection.ts`) and the preload type, so both desktop IPC and the runtime RPC report it.
- `PluginWorkspacePanel` renders the active workspace panel over the workspace area with a titled header and a close button. Rendered by `AppWorkspaceShell`; `null` when nothing is open.
- `usePluginPanelsAt(location)` / `collectActivePluginPanelsAt` split panels by surface. The right-sidebar activity bar now asks for `'right-sidebar'`, so a workspace panel gets no activity-bar entry.
- `PluginPanel` takes an optional `expectedLocation` and refuses to render a panel on a surface it did not declare.
- New bridge action `workspace.openView` (`{ viewId }`). It is handled entirely in the renderer and returns before `callPanelAction` — it never reaches the main process. The lookup is scoped to the requesting plugin, so a panel can only open a workspace view its own manifest declares; anything else is rejected as `invalid_request`.
- `examples/plugins/hello-orca` gained a workspace panel and a button that opens it, as the reference for plugin authors and the reproduction path for this PR.

## Why

This started from writing a plugin for my own workflow and running out of room. A panel is the only surface a plugin gets, and on my machine that iframe is 349px wide — enough for a few buttons and a status line, not for the thing I actually wanted to look at.

What made it feel like a gap rather than a constraint I should design around was Orca's own workspace board. It is a Kanban that opens across the center pane — 1294px, four 308px lanes side by side. A plugin panel is roughly *one* of those lanes. Orca clearly already treats the workspace area as the place for content you scan rather than click through; plugins just have no way to reach it.

So the cap is not really about pixels, it is about what a plugin is allowed to be. Anything board-, table-, or diff-shaped either does not fit or gets rebuilt as a cramped list. Since the workspace area is where Orca already puts its own wide content, it is the natural second surface to open to plugins.

Two choices worth calling out:

**`location` is declarative and optional.** A workspace surface could have been a new contribution kind (`contributes.views`), but panels already carry the entry-HTML, sandbox, session, watchdog, and theme-token plumbing — a second kind would duplicate all of it for one differing property. Declaring the surface keeps every existing manifest valid and every existing panel on its current surface with no migration.

**`workspace.openView` never reaches main.** Which surface is showing is renderer state; main owns nothing here and has nothing to authorize. Routing it through the capability gate would mean a new host method, a new capability, and an IPC round trip to move a piece of local UI state. Handling it in the bridge host keeps the host API surface unchanged — and the reachability check stays strict, because the renderer resolves `viewId` only among panels the requesting plugin declared.

## Linked Issue

Fixes #19826

## Visual Proof

Reproduced with the in-repo sample plugin, so a reviewer sees the same thing:

```bash
pnpm dev
# Settings → Plugins → enable the plugin system, install from local path:
#   examples/plugins/hello-orca
# Open the "Hello Orca" panel in the right sidebar
```

**Before** — the sample plugin's only surface is the right sidebar; the workspace area belongs to the terminal.

<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/4f0e1f48-961e-45bb-8906-051dc60ba3ac" />

**After** — "Open the workspace view" opens `hello-workspace` across the workspace area. The sidebar panel stays mounted and usable next to it, and the workspace panel has no activity-bar icon of its own.

<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/d8f1d48e-e33c-4bf5-a0eb-7f1809ceb9e8" />

## Testing

Manual, on macOS 15 (arm64), against `pnpm dev` with the plugin system enabled:

1. Installed `examples/plugins/hello-orca` from a local path and approved consent.
2. Confirmed the activity bar shows only "Hello Orca" — the workspace panel contributes no icon.
3. Clicked "Open the workspace view": the workspace surface opens and the panel reports `workspace view opened`.
4. Closed it with the header close button and reopened it; state is a single active view, not a stack.
5. Confirmed a manifest with no `location` (the pre-existing `hello` panel, and the two bundled launch plugins) still renders in the sidebar and nowhere else.

Automated:

- `collectActivePluginPanelsAt` routes by declared surface, keeps `location`-less panels in the sidebar, and still drops non-enabled plugins (`src/renderer/src/store/plugin-panels.test.ts`).
- `PluginPanel` refuses to load an entry when the panel's surface does not match `expectedLocation` (`PluginPanel.test.tsx`).
- The bridge host opens an owned view without relaying to main, refuses a view the panel does not own, and rejects a non-string `viewId` (`plugin-panel-bridge-host.test.ts`).

Not tested by me: Linux, Windows, SSH/remote hosts, mobile. See Notes for why I believe the risk there is structural rather than untested — but I cannot claim to have run it.

Full-suite status on my machine: `pnpm lint`, `pnpm typecheck` and `pnpm build` pass; `pnpm test` is 77,376 passed / 7 failed. All 7 failures are environmental on my box and touch no plugin code — `workflow-ref-reachability` needs `git init --ref-format=reftable` (my git is 2.39.5, Apple), and the `codex-fetcher-pty-settle`, `claude-structured-real-cli` and `skill-recipe-shell` cases drive the real locally installed CLIs (codex 0.146.0 vs the 0.145 panel the test pins). I expect CI's pinned versions to pass them, but I have not verified that myself.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with AI assistance: OpenAI Codex for the initial implementation, Anthropic Claude Opus 5 (via Claude Code) for the workspace-mount fix, the tests, the sample-plugin reference, and this description. All changes were reviewed and manually verified by me.

## Review

Agent review summary (Claude Opus 5), against the areas CONTRIBUTING asks for:

- **Cross-platform**: no new paths, shell invocations, child processes, or keyboard shortcuts. The change is a React component, a Zustand selector, a Zod field, and a message-handler branch. No `metaKey`/`ctrlKey` handling is introduced.
- **SSH / remote**: `workspace.openView` is renderer-local, so no execution-host round trip is added and nothing about it depends on locality. The only wire change is the new optional `location` field on the plugin list, which travels the same projection for desktop IPC and runtime RPC.
- **Backwards / wire compatibility**: per `docs/reference/remote-wire-compatibility.md`, a new optional field is safe in both directions. New client + old host: `location` is absent, every panel stays in the sidebar — today's behavior. Old client + new host: the field is ignored, so a workspace panel appears as a sidebar tab, which is a graceful degradation rather than a break. No new stream opcode.
- **Agent / integration / git provider**: untouched — nothing in this change is provider- or agent-aware.
- **Performance**: `PluginWorkspacePanel` returns `null` until a view is opened, so the idle cost is one store read. `collectActivePluginPanelsAt` filters an already-memoized list. The `panels` dependency added to the bridge-handler effect rebinds one `message` listener when the plugin list changes; the listener is removed in the same cleanup, so there is no accumulation.
- **UI quality**: uses `bg-background` / `border-border` and the existing `titlebar` height per `docs/STYLEGUIDE.md`; no new color values, font sizes, or shadow tiers. Verified in light mode. The close control is a standard `Button` primitive with an `aria-label`.
- **Security**: the workspace panel is the same sandboxed, opaque-origin iframe with the same CSP shell and session token as a sidebar panel — no new privilege. The new action widens the panel-callable set by exactly one renderer-local verb, and its `viewId` resolves only among panels the requesting plugin declared, so it cannot open another plugin's view or probe for one. Everything that reaches main still goes through the unchanged capability gate. `expectedLocation` closes the inverse hole: a persisted sidebar tab key cannot be used to mount a workspace panel.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Deliberate scope limits, flagged for reviewers rather than hidden:

- **One workspace view at a time.** `activeWorkspacePanel` is a single tab key, not a stack or a tab strip. Opening a second view replaces the first. Multiple concurrent workspace views can be added later without changing the manifest contract.
- **The workspace view overlays the tab strip while open.** It is a full surface by design, so tab switching requires closing it. If maintainers would rather it live *inside* the tab strip as a real tab, that is a larger change to routing and persistence and I would rather do it in a follow-up than smuggle it in here.
- **Not persisted across restarts.** The open view is in-memory only, so a restart returns to the terminal. Persisting it would mean touching the route normalizer, which felt out of scope for the first surface.
- **No plugin-authoring docs updated** because the repo has none for `orca-plugin.json`; `examples/plugins/hello-orca` is the de facto reference, so that is where the new field is demonstrated.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — see Testing: 7 local `pnpm test` failures are environmental (local git/CLI versions) and unrelated to this change
