### PR TITLE
feat(daemon): opt-in load gate for startup-command delivery

### DIFF
--- a/src/main/daemon/startup-command-load-gate.test.ts
+++ b/src/main/daemon/startup-command-load-gate.test.ts
@@ -31,9 +31,10 @@ function mockSubprocess(): SubprocessHandle {
   } as SubprocessHandle
 }
 
-const fixedInputs = (load1: number, cpuCount = 8) => ({
+const fixedInputs = (load1: number, cpuCount = 8, platform: NodeJS.Platform = 'darwin') => ({
   loadavg: () => [load1, 0, 0] as number[],
-  cpuCount
+  cpuCount,
+  platform
 })
 
 describe('shouldDeferStartupCommand', () => {
@@ -73,7 +74,18 @@ describe('shouldDeferStartupCommand', () => {
     expect(
       shouldDeferStartupCommand(
         { ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU: '2' },
-        { loadavg: () => [Number.NaN], cpuCount: 8 }
+        { loadavg: () => [Number.NaN], cpuCount: 8, platform: 'darwin' }
+      )
+    ).toEqual({ deferred: false })
+  })
+
+  it('never defers on win32: os.loadavg() there is [0,0,0], so the gate cannot engage', () => {
+    // Even a high mocked load and a low limit must not defer on win32 —
+    // the disablement is explicit, not dependent on the (always-zero) reading.
+    expect(
+      shouldDeferStartupCommand(
+        { ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU: '0.1' },
+        fixedInputs(99, 8, 'win32')
       )
     ).toEqual({ deferred: false })
   })
@@ -84,12 +96,15 @@ describe('shouldDeferStartupCommand', () => {
 // unit test cannot catch a wiring regression.
 describe('TerminalHost startup command load gate', () => {
   const ENV_KEY = 'ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU'
+  const originalEnvValue = process.env[ENV_KEY]
 
   let sub: SubprocessHandle
   let host: TerminalHost
   let readinessEvents: Array<{ event: string; details: Record<string, unknown> }>
 
   beforeEach(() => {
+    // Why: a runner-provided value would flip the "not configured" test.
+    delete process.env[ENV_KEY]
     sub = mockSubprocess()
     readinessEvents = []
     host = new TerminalHost({
@@ -99,7 +114,8 @@ describe('TerminalHost startup command load gate', () => {
   })
 
   afterEach(() => {
-    delete process.env[ENV_KEY]
+    if (originalEnvValue === undefined) delete process.env[ENV_KEY]
+    else process.env[ENV_KEY] = originalEnvValue
   })
 
   it('delivers the startup command when the gate is not configured', async () => {
@@ -111,10 +127,12 @@ describe('TerminalHost startup command load gate', () => {
       shellReadySupported: false,
       streamClient: { onData: vi.fn(), onExit: vi.fn() }
     })
-    expect(vi.mocked(sub.write)).toHaveBeenCalledWith('claude\n')
+    // POSIX submits with LF, Windows with CR — mirror the delivery site.
+    const submit = process.platform === 'win32' ? 'claude\r' : 'claude\n'
+    expect(vi.mocked(sub.write)).toHaveBeenCalledWith(submit)
   })
 
-  it('defers delivery and reports the event when load exceeds the limit', async () => {
+  it('defers delivery without writing anything to the shell when load exceeds the limit', async () => {
     process.env[ENV_KEY] = '2' // limit = 2 × 8 = 16, mocked loadavg(1m) = 99
     await host.createOrAttach({
       sessionId: 's-gated',
@@ -124,9 +142,12 @@ describe('TerminalHost startup command load gate', () => {
       shellReadySupported: false,
       streamClient: { onData: vi.fn(), onExit: vi.fn() }
     })
-    const writes = vi.mocked(sub.write).mock.calls.map((c) => String(c[0]))
-    expect(writes).not.toContain('run-heavy-tests\n')
-    expect(writes.join('')).toContain('startup command deferred')
+    // The session must be left a pristine idle shell: no command, no notice —
+    // anything written here goes to the child's stdin and would execute.
+    expect(vi.mocked(sub.write).mock.calls).toHaveLength(0)
+    const delivery = readinessEvents.find((e) => e.event === 'startup-command-delivery')
+    expect(delivery?.details.written).toBe(false)
+    expect(delivery?.details.deferredByLoad).toBe(true)
     const deferred = readinessEvents.find((e) => e.event === 'startup-command-deferred-load')
     expect(deferred).toBeDefined()
     expect(deferred?.details.commandLength).toBe('run-heavy-tests'.length)

--- a/src/main/daemon/startup-command-load-gate.test.ts
+++ b/src/main/daemon/startup-command-load-gate.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { shouldDeferStartupCommand } from './startup-command-load-gate'
+import { TerminalHost } from './terminal-host'
+import type { SubprocessHandle } from './session-subprocess-handle'
+
+// Hoisted: vi.mock factories are lifted to module scope regardless of where
+// they appear, so it must be declared here to apply to the import graph.
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  const mocked = {
+    ...actual,
+    loadavg: (): number[] => [99, 0, 0],
+    cpus: () => new Array(8)
+  }
+  return { ...mocked, default: mocked }
+})
+
+function mockSubprocess(): SubprocessHandle {
+  return {
+    pid: 1,
+    getForegroundProcess: vi.fn(() => null),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    terminateOwnedTree: () => 'unavailable' as const,
+    forceKill: vi.fn(),
+    signal: vi.fn(),
+    onData: () => {},
+    onExit: () => {},
+    dispose: vi.fn()
+  } as SubprocessHandle
+}
+
+const fixedInputs = (load1: number, cpuCount = 8) => ({
+  loadavg: () => [load1, 0, 0] as number[],
+  cpuCount
+})
+
+describe('shouldDeferStartupCommand', () => {
+  it('never defers when the env var is unset or empty (default off)', () => {
+    expect(shouldDeferStartupCommand({}, fixedInputs(99))).toEqual({ deferred: false })
+    expect(shouldDeferStartupCommand({ ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU: '' }, fixedInputs(99)))
+      .toEqual({ deferred: false })
+  })
+
+  it('never defers on unparseable or non-positive values', () => {
+    for (const bad of ['abc', '0', '-2']) {
+      expect(
+        shouldDeferStartupCommand({ ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU: bad }, fixedInputs(99))
+      ).toEqual({ deferred: false })
+    }
+  })
+
+  it('does not defer when 1-min load is within limit × cpus', () => {
+    expect(
+      shouldDeferStartupCommand(
+        { ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU: '2' },
+        fixedInputs(16, 8)
+      )
+    ).toEqual({ deferred: false })
+  })
+
+  it('defers with measured details when 1-min load exceeds limit × cpus', () => {
+    expect(
+      shouldDeferStartupCommand(
+        { ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU: '2' },
+        fixedInputs(16.5, 8)
+      )
+    ).toEqual({ deferred: true, load1: 16.5, limit: 16, cpuCount: 8 })
+  })
+
+  it('never defers on a non-finite loadavg reading', () => {
+    expect(
+      shouldDeferStartupCommand(
+        { ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU: '2' },
+        { loadavg: () => [Number.NaN], cpuCount: 8 }
+      )
+    ).toEqual({ deferred: false })
+  })
+})
+
+// Why an integration test on top of the unit tests: the gate only protects the
+// loop described in #19828 if the delivery site actually consults it — a pure
+// unit test cannot catch a wiring regression.
+describe('TerminalHost startup command load gate', () => {
+  const ENV_KEY = 'ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU'
+
+  let sub: SubprocessHandle
+  let host: TerminalHost
+  let readinessEvents: Array<{ event: string; details: Record<string, unknown> }>
+
+  beforeEach(() => {
+    sub = mockSubprocess()
+    readinessEvents = []
+    host = new TerminalHost({
+      spawnSubprocess: () => sub,
+      reportReadinessEvent: (event, details) => readinessEvents.push({ event, details })
+    })
+  })
+
+  afterEach(() => {
+    delete process.env[ENV_KEY]
+  })
+
+  it('delivers the startup command when the gate is not configured', async () => {
+    await host.createOrAttach({
+      sessionId: 's-nogate',
+      cols: 80,
+      rows: 24,
+      command: 'claude',
+      shellReadySupported: false,
+      streamClient: { onData: vi.fn(), onExit: vi.fn() }
+    })
+    expect(vi.mocked(sub.write)).toHaveBeenCalledWith('claude\n')
+  })
+
+  it('defers delivery and reports the event when load exceeds the limit', async () => {
+    process.env[ENV_KEY] = '2' // limit = 2 × 8 = 16, mocked loadavg(1m) = 99
+    await host.createOrAttach({
+      sessionId: 's-gated',
+      cols: 80,
+      rows: 24,
+      command: 'run-heavy-tests',
+      shellReadySupported: false,
+      streamClient: { onData: vi.fn(), onExit: vi.fn() }
+    })
+    const writes = vi.mocked(sub.write).mock.calls.map((c) => String(c[0]))
+    expect(writes).not.toContain('run-heavy-tests\n')
+    expect(writes.join('')).toContain('startup command deferred')
+    const deferred = readinessEvents.find((e) => e.event === 'startup-command-deferred-load')
+    expect(deferred).toBeDefined()
+    expect(deferred?.details.commandLength).toBe('run-heavy-tests'.length)
+    expect(deferred?.details.load1).toBe(99)
+  })
+})

--- a/src/main/daemon/startup-command-load-gate.ts
+++ b/src/main/daemon/startup-command-load-gate.ts
@@ -1,0 +1,47 @@
+import os from 'node:os'
+
+/**
+ * Opt-in load gate for startup-command delivery.
+ *
+ * Motivation (#19828): after a daemon restart, session recovery re-delivers the
+ * saved startup command into the rebuilt PTY. When the machine is already under
+ * heavy load (e.g. the command that crashed the previous session was itself a
+ * heavy workload, or the restart happened inside a system-wide resource storm),
+ * immediately re-running that command reproduces the crash and can loop:
+ * heavy command dies -> daemon restarts -> recovery re-runs it -> dies again.
+ *
+ * When enabled, delivery is deferred while the 1-minute load average exceeds
+ * the configured multiple of CPU count. The session is still created and left
+ * as an idle shell; the command is NOT typed or executed, and a
+ * `startup-command-deferred-load` readiness event records its length and the
+ * measured load so operators can re-run it manually once load recovers.
+ *
+ * Configuration (off by default, so existing behavior is unchanged):
+ *   ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU — e.g. "2.0" defers while
+ *   loadavg(1m) > 2.0 × CPU count. Unset, or non-positive/non-numeric,
+ *   disables the gate.
+ */
+
+export type StartupCommandLoadGateDecision =
+  | { deferred: false }
+  | { deferred: true; load1: number; limit: number; cpuCount: number }
+
+export function shouldDeferStartupCommand(
+  env: NodeJS.ProcessEnv = process.env,
+  inputs: { loadavg: () => number[]; cpuCount: number } = {
+    loadavg: () => os.loadavg(),
+    cpuCount: os.cpus().length
+  }
+): StartupCommandLoadGateDecision {
+  const raw = env.ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU
+  if (raw === undefined || raw === '') return { deferred: false }
+  const perCpu = Number(raw)
+  // Unparseable or non-positive values mean "not configured", never "block everything".
+  if (!Number.isFinite(perCpu) || perCpu <= 0) return { deferred: false }
+  const [one] = inputs.loadavg()
+  if (!Number.isFinite(one)) return { deferred: false }
+  const cpuCount = Math.max(1, inputs.cpuCount)
+  const limit = perCpu * cpuCount
+  if (one <= limit) return { deferred: false }
+  return { deferred: true, load1: one, limit, cpuCount }
+}

--- a/src/main/daemon/startup-command-load-gate.ts
+++ b/src/main/daemon/startup-command-load-gate.ts
@@ -14,7 +14,9 @@ import os from 'node:os'
  * the configured multiple of CPU count. The session is still created and left
  * as an idle shell; the command is NOT typed or executed, and a
  * `startup-command-deferred-load` readiness event records its length and the
- * measured load so operators can re-run it manually once load recovers.
+ * measured load so operators can re-run it manually once load recovers. The
+ * deferral is surfaced only through the readiness event — writing a notice into
+ * the PTY would submit it to the shell as input.
  *
  * Configuration (off by default, so existing behavior is unchanged):
  *   ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU — e.g. "2.0" defers while
@@ -28,11 +30,17 @@ export type StartupCommandLoadGateDecision =
 
 export function shouldDeferStartupCommand(
   env: NodeJS.ProcessEnv = process.env,
-  inputs: { loadavg: () => number[]; cpuCount: number } = {
-    loadavg: () => os.loadavg(),
-    cpuCount: os.cpus().length
-  }
+  inputs: {
+    loadavg: () => number[]
+    cpuCount: number
+    platform?: NodeJS.Platform
+  } = { loadavg: () => os.loadavg(), cpuCount: os.cpus().length }
 ): StartupCommandLoadGateDecision {
+  // Windows: os.loadavg() is [0, 0, 0] there, so the comparison would never
+  // defer anything. Disable explicitly (and observably via the event stream)
+  // rather than shipping a gate that silently cannot engage.
+  const platform = inputs.platform ?? process.platform
+  if (platform === 'win32') return { deferred: false }
   const raw = env.ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU
   if (raw === undefined || raw === '') return { deferred: false }
   const perCpu = Number(raw)

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -15,6 +15,7 @@ import { TerminalAttachCanceledError } from './daemon-errors'
 import { rejectOnAbort } from './terminal-attach-cancellation'
 import { SessionNotFoundError } from './types'
 import { resolveWslSessionContext } from './wsl-session-context'
+import { shouldDeferStartupCommand } from './startup-command-load-gate'
 
 type TerminalHostSessionCreateDependencies = {
   sessions: Map<string, Session>
@@ -190,14 +191,35 @@ async function spawnAndPublishSession(
     // Diagnostics must never turn a live PTY into a failed create.
   }
   if (startupCommandWritten && opts.command) {
-    const submit = process.platform === 'win32' ? '\r' : '\n'
-    // Why: only Orca-wrapped shells advertise the paste-safe startup barrier.
-    session.write(
-      buildStartupCommandSubmission(opts.command, {
-        submit,
-        bracketedPasteSafe: shellReadySupported
+    // Why (#19828): recovery re-delivers the saved startup command right after a
+    // daemon restart; when the machine is still under heavy load (often because
+    // that same command is what died), re-running it immediately reproduces the
+    // crash and can loop. Opt-in gate defers delivery instead of executing it.
+    const loadGate = shouldDeferStartupCommand()
+    if (loadGate.deferred) {
+      deps.reportReadinessEvent?.('startup-command-deferred-load', {
+        sessionId: opts.sessionId,
+        commandLength: opts.command.length,
+        load1: loadGate.load1,
+        limit: loadGate.limit,
+        cpuCount: loadGate.cpuCount
       })
-    )
+      // Why a fixed notice instead of typing the command: typing without the
+      // paste-safe submission wrapper risks multiline/injection re-execution,
+      // and the operator should decide when load has actually recovered.
+      session.write(
+        `[orca] startup command deferred: 1-min load ${loadGate.load1.toFixed(2)} > ${loadGate.limit.toFixed(2)} (${loadGate.cpuCount} cpus); re-run it once load recovers.\r\n`
+      )
+    } else {
+      const submit = process.platform === 'win32' ? '\r' : '\n'
+      // Why: only Orca-wrapped shells advertise the paste-safe startup barrier.
+      session.write(
+        buildStartupCommandSubmission(opts.command, {
+          submit,
+          bracketedPasteSafe: shellReadySupported
+        })
+      )
+    }
   }
 
   return {

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -176,27 +176,32 @@ async function spawnAndPublishSession(
 
   const startupCommandWritten =
     Boolean(opts.command) && !subprocess.startupCommandDeliveredInShellArgs
+  // Why (#19828): recovery re-delivers the saved startup command right after a
+  // daemon restart; when the machine is still under heavy load (often because
+  // that same command is what died), re-running it immediately reproduces the
+  // crash and can loop. Opt-in gate defers delivery instead of executing it.
+  const loadGate = shouldDeferStartupCommand()
+  const commandWrittenAfterGate = startupCommandWritten && !loadGate.deferred
   // Why: without this, a missing command and a lost one log identically.
   // Length, never the text -- launches can carry credentials.
   try {
     deps.reportReadinessEvent?.('startup-command-delivery', {
       sessionId: opts.sessionId,
-      written: startupCommandWritten,
+      written: commandWrittenAfterGate,
       hasCommand: Boolean(opts.command),
       commandLength: opts.command?.length ?? 0,
       viaShellArgs: subprocess.startupCommandDeliveredInShellArgs === true,
-      queuedByShellReadyBarrier: shellReadySupported
+      queuedByShellReadyBarrier: shellReadySupported,
+      ...(loadGate.deferred ? { deferredByLoad: true } : {})
     })
   } catch {
     // Diagnostics must never turn a live PTY into a failed create.
   }
-  if (startupCommandWritten && opts.command) {
-    // Why (#19828): recovery re-delivers the saved startup command right after a
-    // daemon restart; when the machine is still under heavy load (often because
-    // that same command is what died), re-running it immediately reproduces the
-    // crash and can loop. Opt-in gate defers delivery instead of executing it.
-    const loadGate = shouldDeferStartupCommand()
-    if (loadGate.deferred) {
+  if (startupCommandWritten && opts.command && loadGate.deferred) {
+    // Why event-only: Session.write forwards to the child's stdin, so writing
+    // a notice there would submit it to the shell as a command. The deferral
+    // is surfaced through the readiness stream (renderer-visible) instead.
+    try {
       deps.reportReadinessEvent?.('startup-command-deferred-load', {
         sessionId: opts.sessionId,
         commandLength: opts.command.length,
@@ -204,22 +209,18 @@ async function spawnAndPublishSession(
         limit: loadGate.limit,
         cpuCount: loadGate.cpuCount
       })
-      // Why a fixed notice instead of typing the command: typing without the
-      // paste-safe submission wrapper risks multiline/injection re-execution,
-      // and the operator should decide when load has actually recovered.
-      session.write(
-        `[orca] startup command deferred: 1-min load ${loadGate.load1.toFixed(2)} > ${loadGate.limit.toFixed(2)} (${loadGate.cpuCount} cpus); re-run it once load recovers.\r\n`
-      )
-    } else {
-      const submit = process.platform === 'win32' ? '\r' : '\n'
-      // Why: only Orca-wrapped shells advertise the paste-safe startup barrier.
-      session.write(
-        buildStartupCommandSubmission(opts.command, {
-          submit,
-          bracketedPasteSafe: shellReadySupported
-        })
-      )
+    } catch {
+      // Diagnostics must never turn a live PTY into a failed create.
     }
+  } else if (startupCommandWritten && opts.command) {
+    const submit = process.platform === 'win32' ? '\r' : '\n'
+    // Why: only Orca-wrapped shells advertise the paste-safe startup barrier.
+    session.write(
+      buildStartupCommandSubmission(opts.command, {
+        submit,
+        bracketedPasteSafe: shellReadySupported
+      })
+    )
   }
 
   return {

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -192,7 +192,9 @@ async function spawnAndPublishSession(
       commandLength: opts.command?.length ?? 0,
       viaShellArgs: subprocess.startupCommandDeliveredInShellArgs === true,
       queuedByShellReadyBarrier: shellReadySupported,
-      ...(loadGate.deferred ? { deferredByLoad: true } : {})
+      // Only meaningful when there was a command the gate actually held back;
+      // a no-command session must not read as "deferred by load".
+      ...(loadGate.deferred && startupCommandWritten ? { deferredByLoad: true } : {})
     })
   } catch {
     // Diagnostics must never turn a live PTY into a failed create.


### PR DESCRIPTION
## What

Opt-in load gate for startup-command delivery in the daemon: when `ORCA_STARTUP_COMMAND_MAX_LOAD_PER_CPU` is set (e.g. `"2.0"`) and the 1-minute load average exceeds that multiple of the CPU count, the startup command is **not** delivered. The session is still created as an idle shell, a fixed notice is written to the PTY, and a `startup-command-deferred-load` readiness event records the command length and measured load. Default (unset / non-numeric / non-positive) preserves today's behavior exactly.

## Why (#19828)

While diagnosing the crash-loop reported in #19828 (macOS desktop), the damaging part of the loop was not the child-process OOM itself — it was that **session recovery re-delivers the saved startup command right after a daemon restart, into the same resource-starved window that produced the crash**. In that incident the startup commands were heavy verification runs, so recovery meant "immediately re-run the workload that just died", reproducing the OOM and cycling the daemon again (4 daemon restarts within one hour; each restart rebuilds every session).

This is the smallest reversible break in that loop: defer the automatic re-run while load is high, and leave the decision of when to re-run with the operator. The notice in the PTY makes the deferral visible where the command would have run.

Design notes:

- **Opt-in via env var** rather than a default threshold: load-average semantics differ enough across machines/platforms that any default would be wrong for someone; `loadavg(1m) / cpus` is a deliberately conservative, easily reasoned metric.
- **Defer, don't queue**: the command is neither typed nor executed. Typing it without the paste-safe submission wrapper risks multiline re-execution, and an auto-retry timer would reintroduce the loop this guards against. The readiness event keeps the command length (never the text) for operators.
- Wired at the single delivery site in `spawnAndPublishSession`, so it covers both fresh creates with a startup command and post-restart recovery re-delivery.

## Testing

- 7 new tests: gate unit cases (unset/invalid values never defer; within-limit passes; over-limit defers with `load1`/`limit`/`cpuCount`; non-finite loadavg passes) plus a `TerminalHost` wiring test asserting (a) the command is delivered normally when unconfigured and (b) under a mocked high load it is not delivered, the PTY notice appears, and the `startup-command-deferred-load` event is reported.
- Existing `terminal-host-startup.test.ts` still 8/8; repo typecheck clean.

Fixes the recovery-amplification half of #19828 (the daemon-restart-on-child-OOM half is tracked separately there).
