### PR TITLE
perf(terminal): resume OSC terminator search past the carried frame

### DIFF
--- a/src/shared/agent-status-osc-split-frame-scan-budget.test.ts
+++ b/src/shared/agent-status-osc-split-frame-scan-budget.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createAgentStatusOscProcessor } from './agent-status-osc'
+
+/** Total characters swept by terminator/prefix searches across every chunk of a feed. */
+function feedWithScanBudget(chunks: string[]) {
+  let searchedChars = 0
+  const indexOf = String.prototype.indexOf
+  const spy = vi.spyOn(String.prototype, 'indexOf').mockImplementation(function (
+    this: string,
+    search,
+    from = 0
+  ) {
+    const found = indexOf.call(this, search, from)
+    searchedChars += (found === -1 ? this.length : found + String(search).length) - Number(from)
+    return found
+  })
+  try {
+    const process = createAgentStatusOscProcessor()
+    const results = chunks.map((chunk) => process(chunk))
+    return { results, searchedChars }
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+describe('OSC 9999 split-frame scan budget', () => {
+  it('keeps per-chunk work flat as the split frame accumulates', () => {
+    // One unterminated marker whose payload arrives one character at a time.
+    const feedOf = (chunkCount: number): string[] => [
+      '\x1b]9999;{"state":"working","prompt":"',
+      ...Array<string>(chunkCount).fill('x')
+    ]
+
+    const small = feedWithScanBudget(feedOf(2000))
+    const large = feedWithScanBudget(feedOf(4000))
+
+    expect(small.results.every((result) => result.payloads.length === 0)).toBe(true)
+    // Re-scanning the accumulation would quadruple the budget when the feed doubles.
+    expect(large.searchedChars).toBeLessThan(small.searchedChars * 3)
+  })
+
+  it.each(['\x07', '\x1b\\'])(
+    'matches whole-string parsing when split at every offset with terminator %j',
+    (terminator) => {
+      const stream = `head\x1b]9999;{"state":"working","prompt":"p"}${terminator}tail`
+      const whole = createAgentStatusOscProcessor()(stream)
+
+      for (let split = 1; split < stream.length; split += 1) {
+        const process = createAgentStatusOscProcessor()
+        const first = process(stream.slice(0, split))
+        const second = process(stream.slice(split))
+        expect({
+          cleanData: first.cleanData + second.cleanData,
+          payloads: [...first.payloads, ...second.payloads]
+        }).toEqual({ cleanData: whole.cleanData, payloads: whole.payloads })
+      }
+    }
+  )
+
+  it('finds a string terminator straddling the resume boundary', () => {
+    const process = createAgentStatusOscProcessor()
+    // The ESC lands as the last character of the carried frame; the backslash arrives next.
+    expect(process('\x1b]9999;{"state":"working"}\x1b').payloads).toEqual([])
+    expect(process('\\rest').payloads).toMatchObject([{ state: 'working' }])
+  })
+
+  it('still parses a payload that completes many chunks later', () => {
+    const process = createAgentStatusOscProcessor()
+    process('\x1b]9999;{"state":"wor')
+    for (const chunk of ['k', 'i', 'n', 'g']) {
+      expect(process(chunk).payloads).toEqual([])
+    }
+    expect(process('"}\x07done').payloads).toMatchObject([{ state: 'working' }])
+  })
+})

--- a/src/shared/agent-status-osc.ts
+++ b/src/shared/agent-status-osc.ts
@@ -57,6 +57,9 @@ function findAgentStatusTerminator(
 export function createAgentStatusOscProcessor(): (data: string) => ProcessedAgentStatusChunk {
   const MAX_PENDING = 64 * 1024
   let pending = ''
+  // How much of `pending` already failed a terminator search, so a frame split across
+  // many chunks re-scans only the new bytes instead of the whole accumulation.
+  let pendingSearched = 0
 
   return (data: string): ProcessedAgentStatusChunk => {
     // Ordinary terminal output is by far the common case. Keep it on the
@@ -76,7 +79,9 @@ export function createAgentStatusOscProcessor(): (data: string) => ProcessedAgen
     }
 
     const combined = pending + data
+    const resumeFrom = pendingSearched
     pending = ''
+    pendingSearched = 0
 
     const payloads: ParsedAgentStatusPayload[] = []
     let lastPayloadCleanOffset: number | null = null
@@ -100,12 +105,16 @@ export function createAgentStatusOscProcessor(): (data: string) => ProcessedAgen
 
       cleanData += combined.slice(cursor, start)
       const payloadStart = start + OSC_AGENT_STATUS_PREFIX.length
-      const terminator = findAgentStatusTerminator(combined, payloadStart, nextTerminator)
+      // Minus one so a `\x1b\\` straddling the previous chunk boundary is still found.
+      const searchFrom =
+        start === 0 && resumeFrom > 0 ? Math.max(payloadStart, resumeFrom - 1) : payloadStart
+      const terminator = findAgentStatusTerminator(combined, searchFrom, nextTerminator)
 
       if (terminator === null) {
         const candidate = combined.slice(start)
         // Own the frame so it stops pinning the consumed chunk it was sliced from.
         pending = candidate.length > MAX_PENDING ? '' : ownRetainedString(candidate)
+        pendingSearched = pending.length
         break
       }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## ELI5

Agents announce their status by printing an invisible marker into the terminal: a start tag, some JSON, and an end tag. That marker can be split across many PTY chunks, so Orca keeps the incomplete piece in a `pending` buffer and looks for the end tag again when the next chunk arrives.

The bug: it looked for the end tag *from the beginning of the whole buffer* every time. If a marker arrives one character at a time, chunk 1000 re-reads the 999 characters it already read. Work grows with the **square** of the frame length.

Now it remembers how far it already searched and resumes from there. Same result, one pass.

## The change

`pendingSearched` records how much of `pending` already failed a terminator search. The next chunk resumes at `pendingSearched - 1`.

The `- 1` matters: the string terminator is two characters (`ESC` `\`). If the `ESC` was the last character of the carried frame and the `\` opens the next chunk, resuming exactly at `pendingSearched` would step over the match. Resuming one character earlier re-checks that boundary. There is a dedicated test for exactly this split.

`pendingSearched` is reset to `0` on the short prefix-carry paths, which stash at most 6 characters and were never searched.

## Why it is safe

The parser is a pure function of the byte stream, so a split can only be wrong if it produces a different answer than the unsplit stream. The test asserts that directly: for both terminator forms, the stream is split at **every** offset and the concatenated result must equal whole-string parsing.

## Testing

- New: `agent-status-osc-split-frame-scan-budget.test.ts` (5 tests).
  - **Growth-rate invariant**, not a magic threshold: the same feed is run at 2000 and 4000 chunks and the search budget must less than triple. Re-scanning the accumulation quadruples it. This test **fails on `main`** and passes here — verified by reverting the production file and re-running.
  - Split at every offset, both terminators, vs whole-string parsing.
  - String terminator straddling the resume boundary.
  - A payload that completes many chunks later still parses.
- Existing `agent-status-osc.test.ts`, `agent-status-osc-scan-budget.test.ts`, `agent-status-osc-pending-retention.test.ts` all pass (26 tests total).
- `pnpm tc:node` clean; oxlint and oxfmt clean via commit hooks.

## Trade-offs

None user-facing. No wire change, no platform branches, no change to what is parsed or emitted — only to how far the scan rewinds. The `MAX_PENDING` 64 KiB bound is untouched.
