### PR TITLE
perf(native-chat): bound retained items on the structured session path

### DIFF
--- a/src/shared/structured-agent-session-item-retention.test.ts
+++ b/src/shared/structured-agent-session-item-retention.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentJournalRenderItem } from './agent-session-journal-types'
+import type { AgentSessionHistoryPage } from './agent-session-wire'
+import {
+  EMPTY_STRUCTURED_AGENT_SESSION,
+  oldestStructuredAgentSessionCursor,
+  reduceStructuredAgentSession,
+  type StructuredAgentSessionState
+} from './structured-agent-session-reducer'
+
+const CAP = 1024
+
+function item(sequence: number): AgentJournalRenderItem {
+  return {
+    itemId: `item-${sequence}`,
+    revision: 1,
+    sequence,
+    observedAt: sequence,
+    body: { kind: 'message', role: 'assistant', blocks: [{ type: 'text', text: `t-${sequence}` }] }
+  }
+}
+
+function page(items: AgentJournalRenderItem[], hasOlder: boolean): AgentSessionHistoryPage {
+  const oldest = items[0]?.sequence ?? 0
+  const newest = items.at(-1)?.sequence ?? 0
+  return {
+    sessionId: 'session-a',
+    epoch: 'epoch-a',
+    direction: 'tail',
+    items,
+    removedItemIds: [],
+    submissions: [],
+    window: {
+      oldest: { epoch: 'epoch-a', sequence: oldest },
+      newest: { epoch: 'epoch-a', sequence: newest },
+      nextCursor: { epoch: 'epoch-a', sequence: oldest }
+    },
+    liveCursor: { epoch: 'epoch-a', sequence: newest },
+    hasOlder,
+    hasNewer: false
+  }
+}
+
+function hydrate(items: AgentJournalRenderItem[], hasOlder = false): StructuredAgentSessionState {
+  return reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
+    type: 'event',
+    event: { type: 'snapshot', sessionId: 'session-a', fence: 1, page: page(items, hasOlder) }
+  })
+}
+
+function streamItems(
+  state: StructuredAgentSessionState,
+  sequences: number[]
+): StructuredAgentSessionState {
+  return sequences.reduce(
+    (current, sequence) =>
+      reduceStructuredAgentSession(current, {
+        type: 'event',
+        event: {
+          type: 'batch',
+          sessionId: 'session-a',
+          batch: {
+            cursor: { epoch: 'epoch-a', sequence },
+            items: [item(sequence)],
+            removedItemIds: [],
+            submissions: []
+          }
+        }
+      }),
+    state
+  )
+}
+
+describe('structured agent session item retention', () => {
+  it('bounds retained items on a long live session', () => {
+    const streamed = streamItems(
+      hydrate([item(0)]),
+      Array.from({ length: CAP + 500 }, (_, index) => index + 1)
+    )
+
+    expect(streamed.items).toHaveLength(CAP)
+    expect(streamed.items.at(-1)?.sequence).toBe(CAP + 500)
+    expect(streamed.items[0]?.sequence).toBe(501)
+  })
+
+  it('offers paging for items the cap dropped', () => {
+    const streamed = streamItems(
+      hydrate([item(0)]),
+      Array.from({ length: CAP + 10 }, (_, index) => index + 1)
+    )
+
+    expect(streamed.hasOlder).toBe(true)
+    expect(oldestStructuredAgentSessionCursor(streamed)).toEqual({
+      epoch: 'epoch-a',
+      sequence: streamed.items[0]?.sequence
+    })
+  })
+
+  it('leaves a session under the cap untouched', () => {
+    const hydrated = hydrate([item(0)])
+    const streamed = streamItems(
+      hydrated,
+      Array.from({ length: 200 }, (_, index) => index + 1)
+    )
+
+    expect(streamed.items).toHaveLength(201)
+    expect(streamed.hasOlder).toBe(false)
+  })
+
+  it('widens the retained window when older items are paged in', () => {
+    const streamed = streamItems(
+      hydrate([item(1_000)], true),
+      Array.from({ length: CAP + 10 }, (_, index) => index + 1_001)
+    )
+    const older = reduceStructuredAgentSession(streamed, {
+      type: 'older-page',
+      requestedEpoch: 'epoch-a',
+      page: page(
+        Array.from({ length: 300 }, (_, index) => item(index + 700)),
+        true
+      )
+    })
+    expect(older.items).toHaveLength(CAP + 300)
+
+    // A live batch slides the widened window by one instead of collapsing it back to the cap.
+    const afterLive = streamItems(older, [3_000])
+
+    expect(afterLive.items).toHaveLength(CAP + 300)
+    expect(afterLive.items[0]?.sequence).toBe(701)
+    expect(afterLive.items.some((entry) => entry.sequence === 800)).toBe(true)
+  })
+
+  it('keeps item identity stable when a batch carries no journal change', () => {
+    const hydrated = hydrate([item(0)])
+    const unchanged = reduceStructuredAgentSession(hydrated, {
+      type: 'event',
+      event: {
+        type: 'batch',
+        sessionId: 'session-a',
+        fence: 2,
+        batch: {
+          cursor: { epoch: 'epoch-a', sequence: 0 },
+          items: [],
+          removedItemIds: [],
+          submissions: []
+        }
+      }
+    })
+
+    expect(unchanged.items).toBe(hydrated.items)
+  })
+})

--- a/src/shared/structured-agent-session-reducer.ts
+++ b/src/shared/structured-agent-session-reducer.ts
@@ -18,6 +18,8 @@ export type StructuredAgentSessionState = {
   fence: number | null
   items: AgentJournalRenderItem[]
   submissions: AgentJournalSubmission[]
+  /** Head-trim floor for `items`; paging back raises it so a live batch cannot undo the page. */
+  retainedItemLimit: number
   hasOlder: boolean
   status: 'idle' | 'loading' | 'ready' | 'error'
   error?: string
@@ -35,18 +37,22 @@ export type StructuredAgentSessionAction =
   | { type: 'tail-page'; page: AgentSessionHistoryPage }
   | { type: 'older-page'; requestedEpoch: string; page: AgentSessionHistoryPage }
 
+const MAX_RETAINED_SUBMISSIONS = 256
+// Well above the renderer's initial read window (300) plus a page, so only genuinely
+// long live sessions trim; anything trimmed is still reachable by paging older.
+const MAX_RETAINED_ITEMS = 1024
+
 export const EMPTY_STRUCTURED_AGENT_SESSION: StructuredAgentSessionState = {
   epoch: null,
   cursor: null,
   fence: null,
   items: [],
   submissions: [],
+  retainedItemLimit: MAX_RETAINED_ITEMS,
   hasOlder: false,
   status: 'idle',
   handoff: null
 }
-
-const MAX_RETAINED_SUBMISSIONS = 256
 
 function backgroundTaskStatesEqual(
   left: AgentSessionBackgroundTaskState | null | undefined,
@@ -91,6 +97,7 @@ function replacePage(
     fence,
     items: [...page.items].sort((left, right) => left.sequence - right.sequence),
     submissions: page.submissions,
+    retainedItemLimit: Math.max(MAX_RETAINED_ITEMS, page.items.length),
     hasOlder: page.hasOlder,
     status: 'ready',
     handoff: handoff ?? null,
@@ -119,6 +126,13 @@ function mergeItems(
     }
   }
   return [...byId.values()].sort((left, right) => left.sequence - right.sequence)
+}
+
+function trimRetainedItems(
+  items: AgentJournalRenderItem[],
+  limit: number
+): AgentJournalRenderItem[] {
+  return items.length <= limit ? items : items.slice(items.length - limit)
 }
 
 function mergeSubmissions(
@@ -186,6 +200,7 @@ export function reduceStructuredAgentSession(
       submissions: sameEpoch
         ? mergeSubmissions(state.submissions, action.page.submissions)
         : action.page.submissions,
+      retainedItemLimit: Math.max(MAX_RETAINED_ITEMS, action.page.items.length),
       hasOlder: action.page.hasOlder,
       status: 'ready',
       handoff: state.handoff,
@@ -202,9 +217,11 @@ export function reduceStructuredAgentSession(
     if (state.epoch !== action.requestedEpoch || action.page.epoch !== action.requestedEpoch) {
       return state
     }
+    const paged = mergeItems(state.items, action.page.items, action.page.removedItemIds)
     return {
       ...state,
-      items: mergeItems(state.items, action.page.items, action.page.removedItemIds),
+      items: paged,
+      retainedItemLimit: Math.max(state.retainedItemLimit, paged.length),
       submissions: mergeSubmissions(state.submissions, action.page.submissions),
       hasOlder: action.page.hasOlder
     }
@@ -246,13 +263,17 @@ export function reduceStructuredAgentSession(
   ) {
     return state
   }
+  const merged = journalUnchanged
+    ? state.items
+    : mergeItems(state.items, event.batch.items, event.batch.removedItemIds)
+  const items = trimRetainedItems(merged, state.retainedItemLimit)
   return {
     ...state,
     cursor: event.batch.cursor,
     fence: event.fence ?? state.fence,
-    items: journalUnchanged
-      ? state.items
-      : mergeItems(state.items, event.batch.items, event.batch.removedItemIds),
+    items,
+    // A trim leaves older items behind the cursor, so paging must stay offered.
+    hasOlder: items.length < merged.length ? true : state.hasOlder,
     submissions: journalUnchanged
       ? state.submissions
       : mergeSubmissions(state.submissions, event.batch.submissions),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |

<!-- /orca-pr-loc -->

## ELI5

Chat history in a long agent session was a bucket with no lid. Every new message got added and nothing ever came out, so a session you left running all day kept piling up messages in memory even though you could only see the last screenful.

The message *list* already had a lid (256). The message *bubbles* did not. This puts a lid on the bubbles too: keep the newest 1024, and if we drop older ones, mark the session as "has older" so scrolling up fetches them straight back from the server. Nothing is lost — it just isn't held in memory until you ask for it.

If you *do* scroll up, the lid gets raised to whatever you paged in, so a new incoming message can't yank the history you just loaded back out from under you.

## What changed

`src/shared/structured-agent-session-reducer.ts`:

- New `MAX_RETAINED_ITEMS = 1024` and a `retainedItemLimit` field on the reducer state.
- The live-batch merge head-trims `items` to that limit, and sets `hasOlder: true` whenever it trims, so trimmed items stay reachable through the existing `oldestStructuredAgentSessionCursor` → `agentSession.history direction: 'before'` path that both the renderer (`structured-agent-session-read-owner.ts`) and mobile (`use-mobile-structured-agent-state.ts`) already use.
- `older-page` raises `retainedItemLimit` to the merged length, so paging back widens the retained window rather than being undone by the next live batch. This mirrors the live path's growing `limitRef` (`use-native-chat-live-session.ts`, `NATIVE_CHAT_INITIAL_LIMIT` 300 + `NATIVE_CHAT_PAGE` 200).
- Snapshot/reset/tail-page reset the limit to `max(MAX_RETAINED_ITEMS, page.items.length)`.

The cap sits well above the renderer's 300-item initial read window plus a page, so ordinary sessions never trim.

## Why 1024 and not a smaller number

The renderer restores up to `NATIVE_CHAT_INITIAL_LIMIT` (300) items on hydration and pages 200 at a time. Any cap at or below that would fight the restore loop on every session. 1024 leaves headroom for several pages before the first trim.

## Trade-offs (negative, user-facing)

- **A very long live session that is then scrolled all the way up re-fetches trimmed items over the wire** instead of finding them in memory. That is one `agentSession.history` round trip per page, on a path that already exists and is already exercised (`hasOlder` was already true for any session longer than one page). Over SSH/relay this is a real request, not a local read.
- **Identity churn**: once past the cap, every live batch produces a new `items` array (it did before too, since `mergeItems` already rebuilt it) *and* a new head element, so a consumer memoizing on `items[0]` sees it change more often. No such consumer exists today.

## Testing

- New `src/shared/structured-agent-session-item-retention.test.ts` (5 tests): the cap binds on a long live session; `hasOlder` + the older-page cursor stay correct after a trim; a session under the cap is untouched; paging older widens the window and a following live batch slides it instead of collapsing it; no-journal-change batches still preserve `items` reference identity.
- Verified the three cap-specific tests **fail against `origin/main`'s reducer** and pass against this one.
- `pnpm test src/shared/structured-agent-session src/renderer/src/components/native-chat mobile/src/session` — 134 files, 1336 tests, all pass.
- `pnpm tc` clean; `pnpm run check:code-quality:changed` — 0 new findings.

## Wire compatibility

None. `retainedItemLimit` is client-side reducer state; no RPC params, stream frames, or published content change.