### PR TITLE
perf(terminal): share one ESC dispatch table between the two scanners

### DIFF
--- a/src/main/runtime/terminal-ansi-normalization.ts
+++ b/src/main/runtime/terminal-ansi-normalization.ts
@@ -1,4 +1,5 @@
 import { MAX_TAIL_PENDING_ANSI_CHARS } from './terminal-tail-limits'
+import { classifyTerminalEscapeIntroducer } from '../../shared/terminal-escape-introducer'
 import { ownRetainedString } from '../../shared/own-retained-string'
 
 export function parseAnsiControlSequence(
@@ -11,8 +12,9 @@ export function parseAnsiControlSequence(
       endIndex: number
     }
   | null {
-  const introducer = value[escapeIndex + 1]
-  if (introducer === '[') {
+  // charCodeAt, not value[i]: indexing mints a one-char string on every escape.
+  const introducer = classifyTerminalEscapeIntroducer(value.charCodeAt(escapeIndex + 1))
+  if (introducer === 'csi') {
     for (let index = escapeIndex + 2; index < value.length; index += 1) {
       const code = value.charCodeAt(index)
       if (code < 0x40 || code > 0x7e) {
@@ -30,7 +32,7 @@ export function parseAnsiControlSequence(
     }
     return null
   }
-  if (introducer === ']') {
+  if (introducer === 'osc') {
     for (let index = escapeIndex + 2; index < value.length; index += 1) {
       if (value[index] === '\u0007') {
         return { kind: 'other', endIndex: index }
@@ -41,7 +43,7 @@ export function parseAnsiControlSequence(
     }
     return null
   }
-  if (isStTerminatedStringControlIntroducer(introducer)) {
+  if (introducer === 'string') {
     for (let index = escapeIndex + 2; index < value.length; index += 1) {
       if (value[index] === '\u001b' && value[index + 1] === '\\') {
         return { kind: 'other', endIndex: index + 1 }
@@ -50,10 +52,6 @@ export function parseAnsiControlSequence(
     return null
   }
   return { kind: 'other', endIndex: escapeIndex + 1 }
-}
-
-function isStTerminatedStringControlIntroducer(introducer: string | undefined): boolean {
-  return introducer === 'P' || introducer === 'X' || introducer === '^' || introducer === '_'
 }
 
 export function hasCanonicalNumericCsiParams(params: string): boolean {

--- a/src/shared/terminal-escape-introducer.test.ts
+++ b/src/shared/terminal-escape-introducer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyTerminalEscapeIntroducer,
+  type TerminalEscapeIntroducer
+} from './terminal-escape-introducer'
+
+/** Independent restatement of the VT500 dispatch table, written from the ranges rather
+ *  than the implementation, so a reordered branch in the real one shows up here. */
+function expected(code: number): TerminalEscapeIntroducer {
+  if ('[' === String.fromCharCode(code)) {
+    return 'csi'
+  }
+  if (']' === String.fromCharCode(code)) {
+    return 'osc'
+  }
+  if ('PX^_'.includes(String.fromCharCode(code))) {
+    return 'string'
+  }
+  if (String.fromCharCode(code) >= ' ' && String.fromCharCode(code) <= '/') {
+    return 'intermediate'
+  }
+  if (code < 0x20 || code === 0x7f) {
+    return 'execute'
+  }
+  return 'final'
+}
+
+describe('terminal escape introducer', () => {
+  it('classifies every single-byte introducer the way the VT500 table does', () => {
+    for (let code = 0; code <= 0xff; code += 1) {
+      expect([code, classifyTerminalEscapeIntroducer(code)]).toEqual([code, expected(code)])
+    }
+  })
+
+  it('opens ST-terminated strings for DCS, SOS, PM and APC only', () => {
+    const strings = Array.from({ length: 0x100 }, (_, code) => code).filter(
+      (code) => classifyTerminalEscapeIntroducer(code) === 'string'
+    )
+    expect(strings.map((code) => String.fromCharCode(code))).toEqual(['P', 'X', '^', '_'])
+  })
+
+  it('reads a missing byte (ESC at end of input) as a completed two-byte sequence', () => {
+    // `charCodeAt` past the end is NaN; callers rely on that not becoming csi/osc/string.
+    expect(classifyTerminalEscapeIntroducer(''.charCodeAt(0))).toBe('final')
+  })
+})

--- a/src/shared/terminal-escape-introducer.ts
+++ b/src/shared/terminal-escape-introducer.ts
@@ -1,0 +1,32 @@
+// The byte after ESC decides which VT500 sequence just opened. Two scanners need that
+// decision -- the partial-tail state machine (`terminal-partial-escape-tail.ts`) and the
+// preview normalizer's per-sequence parser (`terminal-ansi-normalization.ts`) -- and they
+// must agree on the DCS/SOS/PM/APC set, so the table lives here rather than in each.
+
+export type TerminalEscapeIntroducer =
+  | 'csi' // [
+  | 'osc' // ]
+  | 'string' // P / X / ^ / _ open DCS / SOS / PM / APC -- ST-terminated
+  | 'intermediate' // 0x20-0x2f, more bytes to come before the final
+  | 'execute' // C0 executes / DEL is ignored; the ESC is still pending
+  | 'final' // completes a two-byte sequence (ESC 7, ESC 8, ESC c, ...)
+
+/** Classifies the code unit after ESC. `NaN` (ESC at end of input) reads as `final`. */
+export function classifyTerminalEscapeIntroducer(code: number): TerminalEscapeIntroducer {
+  if (code === 0x5b) {
+    return 'csi'
+  }
+  if (code === 0x5d) {
+    return 'osc'
+  }
+  if (code === 0x50 || code === 0x58 || code === 0x5e || code === 0x5f) {
+    return 'string'
+  }
+  if (code >= 0x20 && code <= 0x2f) {
+    return 'intermediate'
+  }
+  if (code < 0x20 || code === 0x7f) {
+    return 'execute'
+  }
+  return 'final'
+}

--- a/src/shared/terminal-partial-escape-tail.ts
+++ b/src/shared/terminal-partial-escape-tail.ts
@@ -6,6 +6,8 @@
 // partial sequence at the ingest boundary lets snapshot producers append it
 // after the serialized screen so the continuation completes exactly as live.
 
+import { classifyTerminalEscapeIntroducer } from './terminal-escape-introducer'
+
 // Mirrors the VT500 parser states that can span a chunk boundary. C0 controls
 // (except ESC/CAN/SUB) execute mid-sequence without aborting it, matching
 // xterm's state machine.
@@ -32,23 +34,20 @@ export const MAX_PARTIAL_ESCAPE_TAIL_LENGTH = 4096
 
 /** ESC-state transition shared by the fresh-ESC and abort-reprocess paths. */
 function stateAfterEscByte(code: number): ScanState {
-  if (code === 0x5b) {
-    return 'csi' // [
+  switch (classifyTerminalEscapeIntroducer(code)) {
+    case 'csi':
+      return 'csi'
+    case 'osc':
+      return 'osc'
+    case 'string':
+      return 'string'
+    case 'intermediate':
+      return 'escIntermediate'
+    case 'execute':
+      return 'esc' // the ESC is still pending; a further ESC arrives via the callers
+    case 'final':
+      return 'ground'
   }
-  if (code === 0x5d) {
-    return 'osc' // ]
-  }
-  // P / X / ^ / _ open DCS / SOS / PM / APC — ST-terminated strings.
-  if (code === 0x50 || code === 0x58 || code === 0x5e || code === 0x5f) {
-    return 'string'
-  }
-  if (code >= 0x20 && code <= 0x2f) {
-    return 'escIntermediate'
-  }
-  if (code < 0x20 || code === 0x7f) {
-    return 'esc' // C0 executes / DEL is ignored mid-sequence; ESC via callers
-  }
-  return 'ground' // final byte — two-byte sequence (ESC 7, ESC 8, ESC c, …)
 }
 
 /** Returns the trailing incomplete escape sequence of `stream` ('' when the


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

## ELI5

Terminals speak in little escape codes that all start with the same "here comes a command" byte (ESC). The very next byte says *which kind* of command it is — cursor movement, window title, and so on.

Two different parts of Orca each had their own private copy of that lookup list. Two copies of the same list means one day someone updates one and forgets the other, and the two parts start disagreeing about what a byte means.

This makes it one list that both read. Same answers, one place to change it.

Small bonus: the second parser used to create a throwaway one-character string every single time it looked at a byte. It now reads the byte's number directly, so that garbage goes away on a hot terminal-output path.

## What changed

New `src/shared/terminal-escape-introducer.ts` — `classifyTerminalEscapeIntroducer(code)` returning `csi | osc | string | intermediate | execute | final`, the VT500 byte-after-ESC table.

- `src/shared/terminal-partial-escape-tail.ts`: `stateAfterEscByte` becomes a switch over the shared classification. Mapping is unchanged (`intermediate` → `escIntermediate`, `execute` → `esc`, `final` → `ground`).
- `src/main/runtime/terminal-ansi-normalization.ts`: `parseAnsiControlSequence` dispatches on the shared classification instead of comparing `value[escapeIndex + 1]` against character literals, and `isStTerminatedStringControlIntroducer` is deleted. The `P` / `X` / `^` / `_` set is now stated once for the whole codebase.

`parseAnsiControlSequence` has three callers (`terminal-ansi-normalization.ts`, `terminal-tail-line-controls.ts`, `terminal-tail-redraw-buffer.ts`); none change.

## Perf

The only runtime difference is that `parseAnsiControlSequence` no longer does `value[escapeIndex + 1]`, which minted a one-character string per escape parsed. `charCodeAt` returns a number. This is the same allocation the ground scan in `extractPartialEscapeTail` and #19400's CSI-A scan already avoid; this closes the last one on that path. It is a small constant-factor win on control-dense streams (spinner redraws from Claude Code / Codex), not an algorithmic one — the honest framing is that the shared table is the point and the allocation is a bonus.

## Trade-offs (negative, user-facing)

- **None found.** No behavior change, no wire change, no new allocation, no new module boundary crossed (`src/main/runtime/` already imports from `src/shared/`).
- The one real cost is indirection: reading `parseAnsiControlSequence` now requires one hop to see that `'string'` means DCS/SOS/PM/APC. The named union members and the per-member comments are there to pay that back.

## Testing

- New `src/shared/terminal-escape-introducer.test.ts` (3 tests): the classification matches an independently-written restatement of the VT500 ranges across all of `0x00`–`0xff`; the ST-terminated-string set is exactly `P X ^ _`; and a missing byte (`NaN`, i.e. ESC at end of input) reads as `final` rather than opening a sequence, which is what the ESC-at-end callers depend on.
- **Differential equivalence check (run locally, not committed):** the new `parseAnsiControlSequence` returns deep-equal results to a verbatim copy of the pre-refactor implementation for *every* 2- and 3-byte sequence after ESC (all 65,792 cases) and for 20,000 random 12-char streams drawn from a control-dense alphabet (`ESC [ ] P X ^ _ \ BEL ; 0 1 2 9 A m z SP`), checked at every ESC offset. Zero divergences.
- `pnpm test src/shared/terminal-escape-introducer.test.ts src/shared/terminal-partial-escape-tail src/main/runtime/terminal-ansi src/main/runtime/terminal-tail src/renderer/src/components/terminal-pane/hidden-reveal-reconciliation.fuzz.test.ts` — 10 files, 83 tests, all pass. This includes the two existing fold fuzzers, which are the real regression net for the partial-tail state machine.
- `pnpm tc` clean; `pnpm run check:code-quality:changed` — 0 new findings.

## Scope note

A full unified VT parser was considered and rejected: xterm already parses these same bytes downstream, and each scanner's cheap `includes('\x1b')` gate lets it skip most chunks wholesale, so a shared parser would cost more than it saves. Only the dispatch table is shared.