### PR TITLE
test(terminal): pin the ESC dispatch through both scanners, drop a wrong claim

### DIFF
--- a/src/main/runtime/terminal-ansi-normalization.ts
+++ b/src/main/runtime/terminal-ansi-normalization.ts
@@ -12,7 +12,6 @@ export function parseAnsiControlSequence(
       endIndex: number
     }
   | null {
-  // charCodeAt, not value[i]: indexing mints a one-char string on every escape.
   const introducer = classifyTerminalEscapeIntroducer(value.charCodeAt(escapeIndex + 1))
   if (introducer === 'csi') {
     for (let index = escapeIndex + 2; index < value.length; index += 1) {

--- a/src/main/runtime/terminal-escape-dispatch.test.ts
+++ b/src/main/runtime/terminal-escape-dispatch.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import { extractPartialEscapeTail } from '../../shared/terminal-partial-escape-tail'
+import { parseAnsiControlSequence } from './terminal-ansi-normalization'
+
+// Why this file: `terminal-escape-introducer.test.ts` checks the table against a restatement
+// of its own ranges, and the partial-tail fuzz nets check the ESC gate and the fold property
+// against an oracle that shares the same table -- so neither catches a wrong dispatch entry.
+// These assert the observable consequence of each class instead, through both consumers.
+
+const ESC = '\x1b'
+const BEL = '\x07'
+
+/** The dispatch as it stood before the table was shared (34790ce0843^), as an oracle. */
+function expectedClass(
+  code: number
+): 'csi' | 'osc' | 'string' | 'intermediate' | 'execute' | 'final' {
+  if (code === 0x5b) {
+    return 'csi'
+  }
+  if (code === 0x5d) {
+    return 'osc'
+  }
+  if (code === 0x50 || code === 0x58 || code === 0x5e || code === 0x5f) {
+    return 'string'
+  }
+  if (code >= 0x20 && code <= 0x2f) {
+    return 'intermediate'
+  }
+  if (code < 0x20 || code === 0x7f) {
+    return 'execute'
+  }
+  return 'final'
+}
+
+describe('terminal escape dispatch, observed through both scanners', () => {
+  it('gives each introducer class its own terminator across the whole BMP', () => {
+    for (let code = 0; code <= 0xffff; code += 1) {
+      if (code === 0x1b || code === 0x18 || code === 0x1a) {
+        continue // ESC/CAN/SUB are intercepted before the dispatch; the fuzz nets cover them.
+      }
+      const opener = ESC + String.fromCharCode(code)
+      switch (expectedClass(code)) {
+        case 'csi':
+          expect([code, extractPartialEscapeTail(`${opener}m`)]).toEqual([code, ''])
+          expect([code, extractPartialEscapeTail(`${opener};1`)]).toEqual([code, `${opener};1`])
+          break
+        case 'osc':
+          // BEL terminates an OSC...
+          expect([code, extractPartialEscapeTail(`${opener}title${BEL}`)]).toEqual([code, ''])
+          expect([code, extractPartialEscapeTail(`${opener}title${ESC}\\`)]).toEqual([code, ''])
+          break
+        case 'string':
+          // ...but must NOT terminate a DCS/SOS/PM/APC string; only ST does.
+          expect([code, extractPartialEscapeTail(`${opener}x${BEL}`)]).toEqual([
+            code,
+            `${opener}x${BEL}`
+          ])
+          expect([code, extractPartialEscapeTail(`${opener}x${ESC}\\`)]).toEqual([code, ''])
+          break
+        case 'intermediate':
+          expect([code, extractPartialEscapeTail(`${opener}0`)]).toEqual([code, ''])
+          expect([code, extractPartialEscapeTail(`${opener} `)]).toEqual([code, `${opener} `])
+          break
+        case 'execute':
+          // The ESC stays pending: a C0 executes and DEL is ignored mid-sequence.
+          expect([code, extractPartialEscapeTail(opener)]).toEqual([code, opener])
+          break
+        case 'final':
+          expect([code, extractPartialEscapeTail(opener)]).toEqual([code, ''])
+          break
+      }
+    }
+  })
+
+  it('routes the normalizer to the matching sequence scanner across the whole BMP', () => {
+    for (let code = 0; code <= 0xffff; code += 1) {
+      const opener = ESC + String.fromCharCode(code)
+      const introducer = expectedClass(code)
+      if (introducer === 'csi') {
+        expect([code, parseAnsiControlSequence(`${opener}1A`, 0)]).toEqual([
+          code,
+          { kind: 'csi', final: 'A', params: '1', firstParam: 1, endIndex: 3 }
+        ])
+      } else if (introducer === 'osc') {
+        expect([code, parseAnsiControlSequence(`${opener}0;t${BEL}`, 0)]).toEqual([
+          code,
+          { kind: 'other', endIndex: 5 }
+        ])
+        // An unterminated OSC is incomplete, not a two-byte sequence.
+        expect([code, parseAnsiControlSequence(`${opener}0;t`, 0)]).toEqual([code, null])
+      } else if (introducer === 'string') {
+        expect([code, parseAnsiControlSequence(`${opener}x${ESC}\\`, 0)]).toEqual([
+          code,
+          { kind: 'other', endIndex: 4 }
+        ])
+        // BEL does not close it, so the sequence is still incomplete.
+        expect([code, parseAnsiControlSequence(`${opener}x${BEL}`, 0)]).toEqual([code, null])
+      } else {
+        // Intermediates, C0/DEL and final bytes are all consumed as two-byte sequences here.
+        expect([code, parseAnsiControlSequence(`${opener}zz`, 0)]).toEqual([
+          code,
+          { kind: 'other', endIndex: 1 }
+        ])
+      }
+    }
+  })
+
+  it('reads a missing introducer as a two-byte sequence, at any index', () => {
+    // `charCodeAt` past the end is NaN; it must not fall into csi/osc/string and start scanning.
+    for (const value of ['', ESC, `x${ESC}`, 'abc']) {
+      for (let index = -3; index <= value.length + 3; index += 1) {
+        const parsed = parseAnsiControlSequence(value, index)
+        expect([value, index, parsed]).toEqual([
+          value,
+          index,
+          { kind: 'other', endIndex: index + 1 }
+        ])
+      }
+    }
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​121 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​121 |
| Prod | 1 | 0 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

Follow-up to #19842 from an adversarial `/readiness-checklist` pass over it. Two P2s, no correctness defect found.

## ELI5

Two fixes to my own previous PR.

**One:** I claimed that change made things faster because it stopped creating a tiny throwaway string on every escape code. I measured it. That was wrong — the engine hands out those one-character strings from a cache, so nothing was being created and nothing got faster. The comment saying otherwise is now gone. Sharing the lookup table was always the real reason for that PR; the speed claim was decoration, and wrong decoration is worse than none.

**Two:** the test I wrote checked the lookup table by itself. But the table has to be *used* correctly too, and nothing checked that. If someone sent window-title codes down the wrong parsing branch, every test still passed. Now one doesn't.

## P2-1: the perf claim in #19842 was false

`src/main/runtime/terminal-ansi-normalization.ts` carried:

```
// charCodeAt, not value[i]: indexing mints a one-char string on every escape.
```

That is not true for ASCII introducers. V8 serves single-character one-byte strings from `single_character_string_table`, so `value[i]` returns an interned string rather than allocating.

Measured, both ways:

- **Allocation:** 11,400,000 `value[i]` reads over an ASCII string grow the heap by **28 KB**. `charCodeAt` over the same reads: 15 KB. A 16-byte allocation per read would be ~180 MB. There is no allocation to remove.
- **End-to-end:** the shipped `parseAnsiControlSequence` vs a verbatim copy of its pre-#19842 form, median of 7 runs × 20,000 iterations, three workloads:

  | workload | old | new | delta |
  |---|---|---|---|
  | spinner CSI redraw | 51.8 ms | 51.5 ms | +0.5% |
  | OSC title | 26.7 ms | 26.7 ms | −0.3% |
  | mixed + two-byte | 46.4 ms | 46.2 ms | +0.4% |

  Within noise. #19842 is behavior- and cost-neutral; its value is the deduplicated table, which is real.

The comment is removed. No code change — `charCodeAt` is still the right read now that the shared table is numeric, it just isn't faster.

## P2-2: nothing pinned the dispatch, only the table

`src/shared/terminal-escape-introducer.test.ts` checks `classifyTerminalEscapeIntroducer` against a restatement of its ranges. That is a real net for the *table* — I mutation-checked it and it catches a narrowed intermediate range, a dropped `X`/SOS, and a misfiled DEL. But nothing checked that each class is then *routed* to the matching scanner.

New `src/main/runtime/terminal-escape-dispatch.test.ts` (3 tests) asserts the observable consequence of every class, across all of `0x0000`–`0xffff`, through both consumers:

- via `extractPartialEscapeTail`: BEL terminates an OSC but must **not** terminate a DCS/SOS/PM/APC string; a CSI final byte closes the sequence while a parameter does not; an intermediate needs a final; `execute` leaves the ESC pending; `final` returns to ground.
- via `parseAnsiControlSequence`: each class reaches its own scanner, and an unterminated OSC/string yields `null` rather than being mistaken for a two-byte sequence.
- a missing introducer (`NaN` from `charCodeAt` past the end, at negative and out-of-range indices) is read as a two-byte sequence rather than opening a scan.

**Mutation results** — routing OSC through the ST-only scanner (`if (introducer === 'osc')` → `'string'`, a plausible wrong-branch edit that breaks every terminal title sequence, with the table left correct):

| test | verdict |
|---|---|
| `terminal-escape-introducer.test.ts` | missed |
| `terminal-partial-escape-tail.fuzz.test.ts` | missed |
| `terminal-partial-escape-tail.test.ts` | missed |
| `terminal-escape-dispatch.test.ts` (new) | **caught** |

The fuzz nets also miss a narrowed intermediate range and a misfiled DEL, because `/` and DEL never appear as introducers in their alphabet. Worth knowing about that net's reach, but not worth widening it here.

The file lives in `src/main/runtime/` rather than next to the table because `src/shared` is a separate tsconfig project that cannot import `src/main` (TS6307); the test needs both sides.

## Review result for #19842 itself: no correctness defect

The zero-behavior-change claim holds. Differentially checked against verbatim copies of both pre-refactor implementations:

- `parseAnsiControlSequence` vs old, every 2-byte sequence after ESC across the **whole BMP** (65,536 cases); every 3-byte sequence over `0x000`–`0x1ff` (262,144 cases); negative, at-end and past-end `escapeIndex` on six inputs; 30,000 random streams built from astral pairs, lone high and low surrogates, C1 CSI and the control alphabet, checked at every ESC offset.
- `stateAfterEscByte` ground/non-ground verdict vs old across the whole BMP, plus the per-class terminator distinction above.

Zero divergences. Those throwaway harnesses are not committed; the committed dispatch test is the durable part.

## Trade-offs (negative, user-facing)

None. Test-only plus one deleted comment.

## Testing

`pnpm test src/shared/terminal-escape-introducer src/shared/terminal-partial-escape-tail src/main/runtime/terminal-ansi src/main/runtime/terminal-tail src/main/runtime/terminal-escape-dispatch` — all pass. `pnpm tc` clean. `pnpm run check:code-quality:changed` — 0 findings.