### PR TITLE
feat(editor): add test case outline panel for spec files

### DIFF
--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -52,8 +52,10 @@ export function EditorContent({
   isChangesMode,
   sideBySide,
   showMarkdownTableOfContents = false,
+  showTestSpecOutline = false,
   showMarkdownFrontmatter = false,
   onCloseMarkdownTableOfContents = noopCloseMarkdownTableOfContents,
+  onCloseTestSpecOutline = noopCloseMarkdownTableOfContents,
   markdownAnnotationsEnabled = true,
   pendingEditorReveal,
   handleContentChange,
@@ -80,8 +82,10 @@ export function EditorContent({
   isChangesMode: boolean
   sideBySide: boolean
   showMarkdownTableOfContents?: boolean
+  showTestSpecOutline?: boolean
   showMarkdownFrontmatter?: boolean
   onCloseMarkdownTableOfContents?: () => void
+  onCloseTestSpecOutline?: () => void
   markdownAnnotationsEnabled?: boolean
   pendingEditorReveal: PendingEditorReveal | null
   handleContentChange: (content: string) => void
@@ -245,8 +249,10 @@ export function EditorContent({
         isChangesMode={isChangesMode}
         sideBySide={sideBySide}
         showMarkdownTableOfContents={showMarkdownTableOfContents}
+        showTestSpecOutline={showTestSpecOutline}
         showMarkdownFrontmatter={showMarkdownFrontmatter}
         onCloseMarkdownTableOfContents={onCloseMarkdownTableOfContents}
+        onCloseTestSpecOutline={onCloseTestSpecOutline}
         markdownAnnotationsEnabled={markdownAnnotationsEnabled}
         pendingEditorReveal={pendingEditorReveal}
         markdownDocuments={markdownDocuments}

--- a/src/renderer/src/components/editor/EditorEditFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorEditFileSurface.tsx
@@ -1,4 +1,6 @@
+import { useMemo } from 'react'
 import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
 import type { MarkdownViewMode, OpenFile, PendingEditorReveal } from '@/store/slices/editor'
 import type { GitDiffResult } from '../../../../shared/git-diff-compare-types'
 import type { GitStatusEntry } from '../../../../shared/git-status-types'
@@ -14,6 +16,9 @@ import {
 import type { EditorConflictNavigation } from './useEditorConflictNavigation'
 import { EditorFileLoadErrorView } from './EditorFileLoadErrorView'
 import type { FileContent } from './editor-panel-content-types'
+import { parseTestCaseOutline } from './test-case-outline-parse'
+import { isTestSpecFile } from './test-spec-outline-gate'
+import { TestSpecOutlinePanel } from './TestSpecOutlinePanel'
 import { ExternalFileChangeBanner } from './ExternalFileChangeBanner'
 import type { useMarkdownDocuments } from './useMarkdownDocuments'
 import { EditorMarkdownFileSurface } from './EditorMarkdownFileSurface'
@@ -44,6 +49,7 @@ export function EditorEditFileSurface({
   isChangesMode,
   sideBySide,
   showMarkdownTableOfContents,
+  showTestSpecOutline,
   showMarkdownFrontmatter,
   onCloseMarkdownTableOfContents,
   markdownAnnotationsEnabled,
@@ -54,7 +60,8 @@ export function EditorEditFileSurface({
   handleContentChange,
   handleDirtyStateHint,
   handleSave,
-  reloadContent
+  reloadContent,
+  onCloseTestSpecOutline
 }: {
   activeFile: OpenFile
   viewStateScopeId: string
@@ -75,8 +82,10 @@ export function EditorEditFileSurface({
   isChangesMode: boolean
   sideBySide: boolean
   showMarkdownTableOfContents: boolean
+  showTestSpecOutline: boolean
   showMarkdownFrontmatter: boolean
   onCloseMarkdownTableOfContents: () => void
+  onCloseTestSpecOutline: () => void
   markdownAnnotationsEnabled: boolean
   pendingEditorReveal: PendingEditorReveal | null
   markdownDocuments: MarkdownDocumentsController
@@ -87,6 +96,26 @@ export function EditorEditFileSurface({
   handleSave: (content: string) => Promise<boolean>
   reloadContent: (file: OpenFile) => void
 }): React.JSX.Element {
+  // Why: hooks precede the loading/error/binary early returns below; parse the
+  // best-known content and let the guards decide whether the panel mounts.
+  const outlineSourceContent = editBuffer ?? fileContent?.content ?? ''
+  // Why: parse only while the panel is open for a spec file — full-document scan on every keystroke while closed is invisible wasted CPU.
+  const testOutlineItems = useMemo(
+    () =>
+      showTestSpecOutline && !isMarkdown && isTestSpecFile(activeFile.relativePath, monacoLanguage)
+        ? parseTestCaseOutline(outlineSourceContent)
+        : [],
+    [showTestSpecOutline, isMarkdown, activeFile.relativePath, monacoLanguage, outlineSourceContent]
+  )
+  const handleTestOutlineNavigate = (line: number): void => {
+    useAppStore.getState().setPendingEditorReveal({
+      column: 1,
+      fileId: activeFile.id,
+      filePath: activeFile.filePath,
+      line,
+      matchLength: 0
+    })
+  }
   if (activeFile.conflict?.kind === 'conflict-placeholder') {
     return <ConflictPlaceholderView file={activeFile} />
   }
@@ -127,6 +156,14 @@ export function EditorEditFileSurface({
   }
 
   const currentContent = editBuffer ?? fileContent.content
+  const testOutlinePanel =
+    showTestSpecOutline && !isMarkdown ? (
+      <TestSpecOutlinePanel
+        items={testOutlineItems}
+        onClose={onCloseTestSpecOutline}
+        onNavigate={handleTestOutlineNavigate}
+      />
+    ) : null
   const externalChangeBanner =
     activeFile.externalMutation === 'changed' ? (
       <ExternalFileChangeBanner
@@ -241,7 +278,10 @@ export function EditorEditFileSurface({
       onSave={handleSave}
     />
   ) : (
-    monacoEditor
+    <div className="min-h-0 flex flex-1 flex-row h-full">
+      {testOutlinePanel}
+      <div className="min-w-0 flex-1 h-full">{monacoEditor}</div>
+    </div>
   )
 
   return (

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -74,6 +74,8 @@ function EditorPanelInner({
   const setMarkdownFrontmatterVisible = useAppStore((s) => s.setMarkdownFrontmatterVisible)
   const markdownTableOfContentsVisible = useAppStore((s) => s.markdownTableOfContentsVisible)
   const setMarkdownTableOfContentsVisible = useAppStore((s) => s.setMarkdownTableOfContentsVisible)
+  const testSpecOutlineVisible = useAppStore((s) => s.testSpecOutlineVisible)
+  const setTestSpecOutlineVisible = useAppStore((s) => s.setTestSpecOutlineVisible)
   const clearUntitled = useAppStore((s) => s.clearUntitled)
   const editorDraftSelector = useMemo(
     () => createEditorPanelDraftSelector(activeFile),
@@ -323,6 +325,7 @@ function EditorPanelInner({
     markdownFrontmatterVisible[markdownDocumentStateFileId] ?? true
   const isMarkdownTableOfContentsVisible =
     markdownTableOfContentsVisible[markdownDocumentStateFileId] ?? false
+  const isTestSpecOutlineVisible = testSpecOutlineVisible[activeFile.id] ?? false
   const createActiveMarkdownArtifactRequest = () =>
     Promise.resolve(
       createCurrentMarkdownArtifactRequest(
@@ -342,6 +345,7 @@ function EditorPanelInner({
         model={model}
         copiedPathVisible={copiedPathToast?.fileId === activeFile.id}
         showMarkdownTableOfContents={isMarkdownTableOfContentsVisible}
+        showTestSpecOutline={isTestSpecOutlineVisible}
         canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
         markdownFrontmatterVisible={isMarkdownFrontmatterVisible}
         sideBySide={sideBySide}
@@ -366,6 +370,9 @@ function EditorPanelInner({
             !isMarkdownTableOfContentsVisible
           )
         }
+        onToggleTestSpecOutline={() =>
+          setTestSpecOutlineVisible(activeFile.id, !isTestSpecOutlineVisible)
+        }
         onToggleMarkdownFrontmatter={() =>
           setMarkdownFrontmatterVisible(markdownDocumentStateFileId, !isMarkdownFrontmatterVisible)
         }
@@ -384,6 +391,7 @@ function EditorPanelInner({
         onCloseMarkdownTableOfContents={() =>
           setMarkdownTableOfContentsVisible(markdownDocumentStateFileId, false)
         }
+        onCloseTestSpecOutline={() => setTestSpecOutlineVisible(activeFile.id, false)}
         onCloseRenameDialog={closeRenameDialog}
         onRenameConfirm={handleRenameConfirm}
         markdownAnnotationsEnabled={markdownAnnotationsEnabled}

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -345,7 +345,7 @@ function EditorPanelInner({
         model={model}
         copiedPathVisible={copiedPathToast?.fileId === activeFile.id}
         showMarkdownTableOfContents={isMarkdownTableOfContentsVisible}
-        showTestSpecOutline={isTestSpecOutlineVisible}
+        showTestSpecOutline={model.canShowTestSpecOutline && isTestSpecOutlineVisible}
         canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
         markdownFrontmatterVisible={isMarkdownFrontmatterVisible}
         sideBySide={sideBySide}

--- a/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
@@ -141,4 +141,17 @@ describe('EditorPanelHeader', () => {
       })
     ).not.toContain('data-artifact-publish')
   })
+
+  it('renders test outline toggle button only when eligible', () => {
+    expect(renderHeader({ canShowTestSpecOutline: false })).not.toContain(
+      'aria-label="Test Outline"'
+    )
+
+    const enabledHtml = renderHeader({
+      canShowTestSpecOutline: true,
+      showTestSpecOutline: true
+    })
+    expect(enabledHtml).toContain('aria-label="Test Outline"')
+    expect(enabledHtml).toContain('aria-pressed="true"')
+  })
 })

--- a/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
@@ -82,6 +82,8 @@ const baseProps = {
   shouldShowMarkdownExportAction: false,
   canExportMarkdownToPdf: false,
   showMarkdownTableOfContents: false,
+  canShowTestSpecOutline: false,
+  showTestSpecOutline: false,
   canShowMarkdownFrontmatterToggle: false,
   markdownFrontmatterVisible: false,
   sideBySide: false,
@@ -94,6 +96,7 @@ const baseProps = {
   onToggleSideBySide: vi.fn(),
   onEditorToggleChange: vi.fn(),
   onToggleMarkdownTableOfContents: vi.fn(),
+  onToggleTestSpecOutline: vi.fn(),
   onToggleMarkdownFrontmatter: vi.fn(),
   onExportMarkdownToPdf: vi.fn()
 } satisfies ComponentProps<typeof EditorPanelHeader>

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -35,6 +35,8 @@ type EditorPanelHeaderProps = {
   canOpenPreviewToSide: boolean
   canShowMarkdownPreview: boolean
   canShowMarkdownTableOfContents: boolean
+  canShowTestSpecOutline: boolean
+  showTestSpecOutline: boolean
   isMarkdownTableOfContentsDisabled: boolean
   shouldShowMarkdownExportAction: boolean
   canExportMarkdownToPdf: boolean
@@ -51,6 +53,7 @@ type EditorPanelHeaderProps = {
   onToggleSideBySide: () => void
   onEditorToggleChange: (next: EditorToggleValue) => void
   onToggleMarkdownTableOfContents: () => void
+  onToggleTestSpecOutline: () => void
   onToggleMarkdownFrontmatter: () => void
   onExportMarkdownToPdf: () => void
   createMarkdownArtifactRequest?: () => Promise<ArtifactWriteRequest>
@@ -74,6 +77,8 @@ export function EditorPanelHeader({
   shouldShowMarkdownExportAction,
   canExportMarkdownToPdf,
   showMarkdownTableOfContents,
+  canShowTestSpecOutline,
+  showTestSpecOutline,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
   sideBySide,
@@ -86,6 +91,7 @@ export function EditorPanelHeader({
   onToggleSideBySide,
   onEditorToggleChange,
   onToggleMarkdownTableOfContents,
+  onToggleTestSpecOutline,
   onToggleMarkdownFrontmatter,
   onExportMarkdownToPdf,
   createMarkdownArtifactRequest
@@ -313,6 +319,31 @@ export function EditorPanelHeader({
                     'auto.components.editor.EditorPanelHeader.5447c4f68f',
                     'Table of Contents'
                   )}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
+      {canShowTestSpecOutline && (
+        <TooltipProvider delayDuration={300}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className={`p-1 rounded hover:bg-accent hover:text-foreground transition-colors flex-shrink-0 ${
+                  showTestSpecOutline ? 'bg-accent text-foreground' : 'text-muted-foreground'
+                }`}
+                onClick={onToggleTestSpecOutline}
+                aria-label={translate(
+                  'auto.components.editor.EditorPanelHeader.a81f2c94e2',
+                  'Test Outline'
+                )}
+                aria-pressed={showTestSpecOutline}
+              >
+                <ListTree size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={4}>
+              {translate('auto.components.editor.EditorPanelHeader.a81f2c94e2', 'Test Outline')}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/src/renderer/src/components/editor/EditorPanelShell.header.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.header.test.tsx
@@ -67,6 +67,7 @@ function renderShell(file: OpenFile, isCombinedDiff = false): string {
       model={model as never}
       copiedPathVisible={false}
       showMarkdownTableOfContents={false}
+      showTestSpecOutline={false}
       canShowMarkdownFrontmatterToggle={false}
       markdownFrontmatterVisible={false}
       sideBySide={false}
@@ -86,6 +87,7 @@ function renderShell(file: OpenFile, isCombinedDiff = false): string {
       onToggleSideBySide={noop}
       onEditorToggleChange={noop}
       onToggleMarkdownTableOfContents={noop}
+      onToggleTestSpecOutline={noop}
       onToggleMarkdownFrontmatter={noop}
       onExportMarkdownToPdf={noop}
       onContentChange={noop}
@@ -95,6 +97,7 @@ function renderShell(file: OpenFile, isCombinedDiff = false): string {
       onSaveForFile={async () => true}
       onReloadContent={noop}
       onCloseMarkdownTableOfContents={noop}
+      onCloseTestSpecOutline={noop}
       onCloseRenameDialog={noop}
       onRenameConfirm={async () => {}}
       markdownAnnotationsEnabled={false}

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -22,6 +22,7 @@ type EditorPanelShellProps = {
   model: EditorPanelRenderModel
   copiedPathVisible: boolean
   showMarkdownTableOfContents: boolean
+  showTestSpecOutline: boolean
   canShowMarkdownFrontmatterToggle: boolean
   markdownFrontmatterVisible: boolean
   sideBySide: boolean
@@ -41,6 +42,7 @@ type EditorPanelShellProps = {
   onToggleSideBySide: () => void
   onEditorToggleChange: (next: EditorToggleValue) => void
   onToggleMarkdownTableOfContents: () => void
+  onToggleTestSpecOutline: () => void
   onToggleMarkdownFrontmatter: () => void
   onExportMarkdownToPdf: () => void
   createMarkdownArtifactRequest?: () => Promise<ArtifactWriteRequest>
@@ -51,6 +53,7 @@ type EditorPanelShellProps = {
   onSaveForFile: (file: OpenFile, content: string) => Promise<boolean>
   onReloadContent: (file: OpenFile) => void
   onCloseMarkdownTableOfContents: () => void
+  onCloseTestSpecOutline: () => void
   onCloseRenameDialog: () => void
   onRenameConfirm: (newRelPath: string) => Promise<void>
   markdownAnnotationsEnabled: boolean
@@ -63,6 +66,7 @@ export function EditorPanelShell({
   model,
   copiedPathVisible,
   showMarkdownTableOfContents,
+  showTestSpecOutline,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
   sideBySide,
@@ -82,6 +86,7 @@ export function EditorPanelShell({
   onToggleSideBySide,
   onEditorToggleChange,
   onToggleMarkdownTableOfContents,
+  onToggleTestSpecOutline,
   onToggleMarkdownFrontmatter,
   onExportMarkdownToPdf,
   createMarkdownArtifactRequest,
@@ -92,6 +97,7 @@ export function EditorPanelShell({
   onSaveForFile,
   onReloadContent,
   onCloseMarkdownTableOfContents,
+  onCloseTestSpecOutline,
   onCloseRenameDialog,
   onRenameConfirm,
   markdownAnnotationsEnabled
@@ -113,6 +119,8 @@ export function EditorPanelShell({
           canOpenPreviewToSide={model.canOpenPreviewToSide}
           canShowMarkdownPreview={model.canShowMarkdownPreview}
           canShowMarkdownTableOfContents={model.canShowMarkdownTableOfContents}
+          canShowTestSpecOutline={model.canShowTestSpecOutline}
+          showTestSpecOutline={showTestSpecOutline}
           isMarkdownTableOfContentsDisabled={model.isMarkdownTableOfContentsDisabled}
           shouldShowMarkdownExportAction={model.shouldShowMarkdownExportAction}
           canExportMarkdownToPdf={model.canExportMarkdownToPdf}
@@ -129,6 +137,7 @@ export function EditorPanelShell({
           onToggleSideBySide={onToggleSideBySide}
           onEditorToggleChange={onEditorToggleChange}
           onToggleMarkdownTableOfContents={onToggleMarkdownTableOfContents}
+          onToggleTestSpecOutline={onToggleTestSpecOutline}
           onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
           onExportMarkdownToPdf={onExportMarkdownToPdf}
           createMarkdownArtifactRequest={createMarkdownArtifactRequest}
@@ -160,8 +169,10 @@ export function EditorPanelShell({
           handleSaveForFile={onSaveForFile}
           reloadContent={onReloadContent}
           showMarkdownTableOfContents={showMarkdownTableOfContents}
+          showTestSpecOutline={showTestSpecOutline}
           showMarkdownFrontmatter={markdownFrontmatterVisible}
           onCloseMarkdownTableOfContents={onCloseMarkdownTableOfContents}
+          onCloseTestSpecOutline={onCloseTestSpecOutline}
           markdownAnnotationsEnabled={markdownAnnotationsEnabled}
         />
       </Suspense>

--- a/src/renderer/src/components/editor/TestSpecOutlinePanel.test.tsx
+++ b/src/renderer/src/components/editor/TestSpecOutlinePanel.test.tsx
@@ -25,6 +25,44 @@ describe('TestSpecOutlinePanel', () => {
     expect(html).toContain('Collapse login')
   })
 
+  it('renders visible badges for all modifiers', () => {
+    const items = parseTestCaseOutline(
+      [
+        'describe.each([[1]])("suite %i", () => {',
+        '  it.only("fast", () => {});',
+        '  it.todo("later");',
+        '  test.concurrent("parallel", () => {});',
+        '});'
+      ].join('\n')
+    )
+    const html = renderToStaticMarkup(
+      <TestSpecOutlinePanel items={items} onClose={() => {}} onNavigate={() => {}} />
+    )
+    expect(html).toContain('each')
+    expect(html).toContain('only')
+    expect(html).toContain('todo')
+    expect(html).toContain('concurrent')
+  })
+
+  it('indents nested suites progressively by depth', () => {
+    const items = parseTestCaseOutline(
+      [
+        'describe("root", () => {',
+        '  describe("nested", () => {',
+        '    it("leaf", () => {});',
+        '  });',
+        '});'
+      ].join('\n')
+    )
+    const html = renderToStaticMarkup(
+      <TestSpecOutlinePanel items={items} onClose={() => {}} onNavigate={() => {}} />
+    )
+    // Why: root suite has 12px padding; nested suite at depth 1 has 24px padding (12 + 1 * 12).
+    expect(html).toContain('padding-left:12px')
+    expect(html).toContain('padding-left:24px')
+    expect(html).toContain('padding-left:36px')
+  })
+
   it('renders an empty state with no items', () => {
     const html = renderToStaticMarkup(
       <TestSpecOutlinePanel items={[]} onClose={() => {}} onNavigate={() => {}} />

--- a/src/renderer/src/components/editor/TestSpecOutlinePanel.test.tsx
+++ b/src/renderer/src/components/editor/TestSpecOutlinePanel.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { TestSpecOutlinePanel } from './TestSpecOutlinePanel'
+import { parseTestCaseOutline } from './test-case-outline-parse'
+
+const sampleItems = parseTestCaseOutline(
+  [
+    'describe("login", () => {',
+    '  it("rejects empty password", () => {});',
+    '  it.skip("legacy", () => {});',
+    '});'
+  ].join('\n')
+)
+
+describe('TestSpecOutlinePanel', () => {
+  it('renders the describe/it tree with modifiers and empty state', () => {
+    const html = renderToStaticMarkup(
+      <TestSpecOutlinePanel items={sampleItems} onClose={() => {}} onNavigate={() => {}} />
+    )
+
+    expect(html).toContain('Test Outline')
+    expect(html).toContain('login')
+    expect(html).toContain('rejects empty password')
+    expect(html).toContain('skip')
+    expect(html).toContain('Collapse login')
+  })
+
+  it('renders an empty state with no items', () => {
+    const html = renderToStaticMarkup(
+      <TestSpecOutlinePanel items={[]} onClose={() => {}} onNavigate={() => {}} />
+    )
+
+    expect(html).toContain('No test cases found')
+  })
+})

--- a/src/renderer/src/components/editor/TestSpecOutlinePanel.tsx
+++ b/src/renderer/src/components/editor/TestSpecOutlinePanel.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useState } from 'react'
+import { ChevronRight, ListTree, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { TestOutlineNode } from './test-case-outline-parse'
+import {
+  isTestOutlineItemExpanded,
+  pruneTestOutlineCollapsedIds,
+  toggleTestOutlineCollapsedId
+} from './test-spec-outline-collapse-state'
+
+type TestSpecOutlinePanelProps = {
+  items: TestOutlineNode[]
+  onClose: () => void
+  onNavigate: (line: number) => void
+}
+
+const OUTLINE_INDENT_BASE_PX = 12
+const OUTLINE_INDENT_STEP_PX = 12
+
+function TestOutlineRow({
+  collapsedIds,
+  depth,
+  item,
+  onNavigate,
+  onToggleCollapsed
+}: {
+  collapsedIds: ReadonlySet<string>
+  depth: number
+  item: TestOutlineNode
+  onNavigate: (line: number) => void
+  onToggleCollapsed: (id: string) => void
+}): React.JSX.Element {
+  const hasChildren = item.children.length > 0
+  const expanded = isTestOutlineItemExpanded(collapsedIds, item)
+  const rowPaddingLeft = hasChildren
+    ? depth === 0
+      ? OUTLINE_INDENT_BASE_PX
+      : depth * OUTLINE_INDENT_STEP_PX
+    : OUTLINE_INDENT_BASE_PX + depth * OUTLINE_INDENT_STEP_PX
+
+  return (
+    <>
+      <div className="markdown-toc-row" style={{ paddingLeft: rowPaddingLeft }}>
+        {hasChildren ? (
+          <button
+            type="button"
+            className="markdown-toc-disclosure"
+            aria-label={
+              expanded
+                ? translate(
+                    'auto.components.editor.TestSpecOutlinePanel.97ad46f11f',
+                    'Collapse {{value0}}',
+                    { value0: item.title }
+                  )
+                : translate(
+                    'auto.components.editor.TestSpecOutlinePanel.65b036b6c8',
+                    'Expand {{value0}}',
+                    { value0: item.title }
+                  )
+            }
+            aria-expanded={expanded}
+            onClick={() => onToggleCollapsed(item.id)}
+          >
+            <ChevronRight
+              className={cn(
+                'size-3 shrink-0 text-muted-foreground transition-transform',
+                expanded && 'rotate-90'
+              )}
+            />
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="markdown-toc-title-button"
+          onClick={() => onNavigate(item.line)}
+          title={translate(
+            'auto.components.editor.TestSpecOutlinePanel.9c1e44a2d7',
+            'Go to line {{value0}}',
+            {
+              value0: item.line
+            }
+          )}
+        >
+          <span
+            className={cn(
+              'markdown-toc-title',
+              item.kind === 'describe' && 'font-medium',
+              item.modifier === 'skip' && 'text-muted-foreground line-through',
+              item.modifier === 'only' && 'font-semibold'
+            )}
+          >
+            {item.kind === 'it' && item.modifier === 'each' ? `${item.title} ×` : item.title}
+          </span>
+          {item.modifier === 'skip' || item.modifier === 'todo' ? (
+            <span className="ml-1 shrink-0 text-[10px] text-muted-foreground">{item.modifier}</span>
+          ) : null}
+        </button>
+      </div>
+      {hasChildren && expanded
+        ? item.children.map((child) => (
+            <TestOutlineRow
+              key={child.id}
+              collapsedIds={collapsedIds}
+              depth={depth + 1}
+              item={child}
+              onNavigate={onNavigate}
+              onToggleCollapsed={onToggleCollapsed}
+            />
+          ))
+        : null}
+    </>
+  )
+}
+
+export function TestSpecOutlinePanel({
+  items,
+  onClose,
+  onNavigate
+}: TestSpecOutlinePanelProps): React.JSX.Element {
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => new Set())
+
+  useEffect(() => {
+    setCollapsedIds((current) => pruneTestOutlineCollapsedIds(current, items))
+  }, [items])
+
+  const toggleCollapsed = (id: string): void => {
+    setCollapsedIds((current) => toggleTestOutlineCollapsedId(current, id))
+  }
+
+  return (
+    <aside
+      className="markdown-toc-panel w-64 flex-shrink-0 h-full overflow-hidden"
+      aria-label={translate(
+        'auto.components.editor.TestSpecOutlinePanel.27d0a9c49a',
+        'Test case outline'
+      )}
+    >
+      <div className="markdown-toc-header">
+        <ListTree className="size-3.5 text-muted-foreground" />
+        <span>
+          {translate('auto.components.editor.TestSpecOutlinePanel.06357eea60', 'Test Outline')}
+        </span>
+        <div className="markdown-toc-header-actions">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={translate(
+              'auto.components.editor.TestSpecOutlinePanel.bbe8369097',
+              'Close test outline'
+            )}
+            title={translate(
+              'auto.components.editor.TestSpecOutlinePanel.bbe8369097',
+              'Close test outline'
+            )}
+            onClick={onClose}
+          >
+            <X className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+      <div className="markdown-toc-list scrollbar-sleek">
+        {items.length > 0 ? (
+          items.map((item) => (
+            <TestOutlineRow
+              key={item.id}
+              collapsedIds={collapsedIds}
+              depth={0}
+              item={item}
+              onNavigate={onNavigate}
+              onToggleCollapsed={toggleCollapsed}
+            />
+          ))
+        ) : (
+          <div className="markdown-toc-empty">
+            {translate(
+              'auto.components.editor.TestSpecOutlinePanel.de3928b6e4',
+              'No test cases found'
+            )}
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+}

--- a/src/renderer/src/components/editor/TestSpecOutlinePanel.tsx
+++ b/src/renderer/src/components/editor/TestSpecOutlinePanel.tsx
@@ -34,11 +34,7 @@ function TestOutlineRow({
 }): React.JSX.Element {
   const hasChildren = item.children.length > 0
   const expanded = isTestOutlineItemExpanded(collapsedIds, item)
-  const rowPaddingLeft = hasChildren
-    ? depth === 0
-      ? OUTLINE_INDENT_BASE_PX
-      : depth * OUTLINE_INDENT_STEP_PX
-    : OUTLINE_INDENT_BASE_PX + depth * OUTLINE_INDENT_STEP_PX
+  const rowPaddingLeft = OUTLINE_INDENT_BASE_PX + depth * OUTLINE_INDENT_STEP_PX
 
   return (
     <>
@@ -91,9 +87,9 @@ function TestOutlineRow({
               item.modifier === 'only' && 'font-semibold'
             )}
           >
-            {item.kind === 'it' && item.modifier === 'each' ? `${item.title} ×` : item.title}
+            {item.title}
           </span>
-          {item.modifier === 'skip' || item.modifier === 'todo' ? (
+          {item.modifier ? (
             <span className="ml-1 shrink-0 text-[10px] text-muted-foreground">{item.modifier}</span>
           ) : null}
         </button>
@@ -114,6 +110,9 @@ function TestOutlineRow({
   )
 }
 
+/**
+ * Renders a collapsible outline panel for navigating test cases within spec files.
+ */
 export function TestSpecOutlinePanel({
   items,
   onClose,

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -14,6 +14,7 @@ import type { FileContent } from './editor-panel-content-types'
 import { canUseChangesModeForFile } from './editor-panel-file-mode'
 import { getMarkdownRenderMode, type MarkdownRenderState } from './markdown-render-mode'
 import { getCachedMarkdownRichModeEligibility } from './markdown-rich-mode-eligibility-cache'
+import { isTestSpecFile } from './test-spec-outline-gate'
 
 type StoreState = ReturnType<typeof useAppStore.getState>
 
@@ -202,6 +203,13 @@ export function getEditorPanelRenderModel({
     canShowMarkdownTableOfContents:
       viewerLanguage === 'markdown' &&
       (hasViewModeToggle || activeFile.mode === 'markdown-preview'),
+    // Why: spec files render as plain Monaco with no outline — gate narrowly so the
+    // parse/panel cost only applies where describe/it trees exist.
+    canShowTestSpecOutline:
+      activeFile.mode === 'edit' &&
+      !isChangesMode &&
+      (resolvedLanguage === 'typescript' || resolvedLanguage === 'javascript') &&
+      isTestSpecFile(activeFile.relativePath, resolvedLanguage),
     canShowMarkdownPreview: canOpenMarkdownPreview({
       language: viewerLanguage,
       mode: activeFile.mode,

--- a/src/renderer/src/components/editor/test-case-outline-parse.test.ts
+++ b/src/renderer/src/components/editor/test-case-outline-parse.test.ts
@@ -149,11 +149,10 @@ describe('parseTestCaseOutline', () => {
     expect(tree[0].line).toBe(5)
   })
 
-  it('handles unbalanced braces in literals inside describe bodies without mis-parenting', () => {
+  it('does not mis-parent children when an options object contains a brace in a literal', () => {
     const content = [
-      'describe("suite with braces in literals", () => {',
-      '  const x = "}";',
-      '  it("child test", () => {});',
+      "describe('suite', { message: '}' }, () => {",
+      "  it('child test', () => {});",
       '});'
     ].join('\n')
     const tree = parseTestCaseOutline(content)

--- a/src/renderer/src/components/editor/test-case-outline-parse.test.ts
+++ b/src/renderer/src/components/editor/test-case-outline-parse.test.ts
@@ -50,4 +50,88 @@ describe('parseTestCaseOutline', () => {
     expect(parseTestCaseOutline('const x = 1;\n')).toEqual([])
     expect(parseTestCaseOutline('')).toEqual([])
   })
+
+  it('parses calls spanning multiple lines', () => {
+    const content = [
+      'describe(',
+      "  'multiline suite',",
+      '  () => {',
+      '    it(',
+      "      'multiline test',",
+      '      () => {}',
+      '    );',
+      '    test.each([',
+      '      [1, 2]',
+      '    ])(',
+      "      'case %i',",
+      '      () => {}',
+      '    );',
+      '  }',
+      ');'
+    ].join('\n')
+    const tree = parseTestCaseOutline(content)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].title).toBe('multiline suite')
+    expect(tree[0].line).toBe(1)
+    expect(tree[0].children).toHaveLength(2)
+    expect(tree[0].children[0].title).toBe('multiline test')
+    expect(tree[0].children[0].line).toBe(4)
+    expect(tree[0].children[1].title).toBe('case %i')
+    expect(tree[0].children[1].line).toBe(8)
+    expect(tree[0].children[1].modifier).toBe('each')
+  })
+
+  it('does not treat comment markers inside string literals as comments', () => {
+    const content = [
+      'describe("suite with /* comment */ in title", () => {',
+      '  it("accepts /* literally", () => {});',
+      "  it('accepts // literally too', () => {});",
+      '  it(`accepts /* in template`, () => {});',
+      '});'
+    ].join('\n')
+    const tree = parseTestCaseOutline(content)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].title).toBe('suite with /* comment */ in title')
+    expect(tree[0].children.map((c) => c.title)).toEqual([
+      'accepts /* literally',
+      'accepts // literally too',
+      'accepts /* in template'
+    ])
+  })
+
+  it('parses tagged-template .each suites and tests without mis-parenting', () => {
+    const content = [
+      'describe.each`',
+      '  a    | b    | expected',
+      '  ${1} | ${1} | ${2}',
+      "`('$a + $b', ({ a, b, expected }) => {",
+      "  it('adds numbers', () => {});",
+      '});',
+      'test.each`',
+      '  val',
+      "  ${'hello'}",
+      "`('tagged test case $val', () => {});"
+    ].join('\n')
+    const tree = parseTestCaseOutline(content)
+    expect(tree).toHaveLength(2)
+    expect(tree[0].title).toBe('$a + $b')
+    expect(tree[0].modifier).toBe('each')
+    expect(tree[0].children).toHaveLength(1)
+    expect(tree[0].children[0].title).toBe('adds numbers')
+    expect(tree[1].title).toBe('tagged test case $val')
+    expect(tree[1].modifier).toBe('each')
+  })
+
+  it('captures concurrent modifier on suites and tests', () => {
+    const content = [
+      'describe.concurrent("concurrent suite", () => {',
+      '  it.concurrent("concurrent it", () => {});',
+      '  test.concurrent("concurrent test", () => {});',
+      '});'
+    ].join('\n')
+    const tree = parseTestCaseOutline(content)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].modifier).toBe('concurrent')
+    expect(tree[0].children.map((c) => c.modifier)).toEqual(['concurrent', 'concurrent'])
+  })
 })

--- a/src/renderer/src/components/editor/test-case-outline-parse.test.ts
+++ b/src/renderer/src/components/editor/test-case-outline-parse.test.ts
@@ -134,4 +134,31 @@ describe('parseTestCaseOutline', () => {
     expect(tree[0].modifier).toBe('concurrent')
     expect(tree[0].children.map((c) => c.modifier)).toEqual(['concurrent', 'concurrent'])
   })
+
+  it('does not drift line numbers when non-string titles span lines', () => {
+    const content = [
+      'test(',
+      '  dynamicTitle,',
+      '  () => {}',
+      ');',
+      'it("valid test", () => {});'
+    ].join('\n')
+    const tree = parseTestCaseOutline(content)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].title).toBe('valid test')
+    expect(tree[0].line).toBe(5)
+  })
+
+  it('handles unbalanced braces in literals inside describe bodies without mis-parenting', () => {
+    const content = [
+      'describe("suite with braces in literals", () => {',
+      '  const x = "}";',
+      '  it("child test", () => {});',
+      '});'
+    ].join('\n')
+    const tree = parseTestCaseOutline(content)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].children).toHaveLength(1)
+    expect(tree[0].children[0].title).toBe('child test')
+  })
 })

--- a/src/renderer/src/components/editor/test-case-outline-parse.test.ts
+++ b/src/renderer/src/components/editor/test-case-outline-parse.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { parseTestCaseOutline } from './test-case-outline-parse'
+
+describe('parseTestCaseOutline', () => {
+  it('builds nested describe/it trees with 1-based lines', () => {
+    const content = [
+      'describe("login", () => {',
+      '  it("rejects empty password", () => {});',
+      '  it("locks after 3 attempts", () => {});',
+      '});',
+      'describe("signup", () => {',
+      '  test("sends email", () => {});',
+      '});'
+    ].join('\n')
+    const tree = parseTestCaseOutline(content)
+    expect(tree).toHaveLength(2)
+    expect(tree[0].kind).toBe('describe')
+    expect(tree[0].line).toBe(1)
+    expect(tree[0].children.map((c) => c.title)).toEqual([
+      'rejects empty password',
+      'locks after 3 attempts'
+    ])
+    expect(tree[0].children[0].line).toBe(2)
+    expect(tree[1].children[0].kind).toBe('it')
+  })
+
+  it('captures skip/only/each/todo modifiers', () => {
+    const content = [
+      'describe.skip("slow", () => {',
+      "  it.only('fast', () => {});",
+      '  test.each([[1]])("case %i", () => {});',
+      '  it.todo("later");',
+      '});'
+    ].join('\n')
+    const tree = parseTestCaseOutline(content)
+    expect(tree[0].modifier).toBe('skip')
+    expect(tree[0].children.map((c) => c.modifier)).toEqual(['only', 'each', 'todo'])
+  })
+
+  it('ignores matches inside comments and normalizes CRLF', () => {
+    const content =
+      '// it("ghost", () => {});\r\ndescribe("real", () => {\r\n  /* test("hidden") */\r\n  it("shown", () => {});\r\n});'
+    const tree = parseTestCaseOutline(content)
+    expect(tree).toHaveLength(1)
+    expect(tree[0].title).toBe('real')
+    expect(tree[0].children.map((c) => c.title)).toEqual(['shown'])
+  })
+
+  it('returns empty for files without tests', () => {
+    expect(parseTestCaseOutline('const x = 1;\n')).toEqual([])
+    expect(parseTestCaseOutline('')).toEqual([])
+  })
+})

--- a/src/renderer/src/components/editor/test-case-outline-parse.ts
+++ b/src/renderer/src/components/editor/test-case-outline-parse.ts
@@ -231,6 +231,9 @@ export function parseTestCaseOutline(content: string): TestOutlineNode[] {
             continue
           }
         }
+
+        // Why: failed lookahead advanced line through whitespace/comments; restore so main loop doesn't double count.
+        line = startLine
       }
     }
 

--- a/src/renderer/src/components/editor/test-case-outline-parse.ts
+++ b/src/renderer/src/components/editor/test-case-outline-parse.ts
@@ -1,0 +1,195 @@
+export type TestOutlineKind = 'describe' | 'it'
+
+export type TestOutlineModifier = 'each' | 'skip' | 'only' | 'todo'
+
+export type TestOutlineNode = {
+  children: TestOutlineNode[]
+  id: string
+  kind: TestOutlineKind
+  line: number
+  modifier?: TestOutlineModifier
+  title: string
+}
+
+const MAX_TEST_OUTLINE_NODES = 2000
+
+const CALL_RE =
+  /(^|[^\w$.])(describe|it|test)(\.(each|skip|only|todo))*\s*\(\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|`((?:[^`\\]|\\.)*)`)/
+
+const EACH_CALL_RE =
+  /(^|[^\w$.])(describe|it|test)(\.(each|skip|only|todo))*\s*\([^)]*\)\s*\(\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|`((?:[^`\\]|\\.)*)`)/
+
+function matchTestCall(code: string): {
+  kind: TestOutlineKind
+  modifier?: TestOutlineModifier
+  title: string
+} | null {
+  const direct = CALL_RE.exec(code)
+  // Why: test.each(data)(title) carries the title in a second call — retry there.
+  const match = direct ?? EACH_CALL_RE.exec(code)
+  if (!match) {
+    return null
+  }
+  const modifier = /\.(each|skip|only|todo)(?=\.|$|\s*\()/.exec(match[3] ?? '')?.at(1) as
+    | TestOutlineModifier
+    | undefined
+  return {
+    kind: match[2] === 'describe' ? 'describe' : 'it',
+    modifier,
+    title: match[5] ?? match[6] ?? match[7] ?? ''
+  }
+}
+
+// Why: a title containing `it(` inside a comment must not become a node.
+function stripLineComment(line: string): string {
+  let inSingle = false
+  let inDouble = false
+  let inTemplate = false
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (ch === '\\') {
+      i++
+      continue
+    }
+    if (!inSingle && !inDouble && !inTemplate && ch === '/' && line[i + 1] === '/') {
+      return line.slice(0, i)
+    }
+    if (!inDouble && !inTemplate && ch === "'") {
+      inSingle = !inSingle
+    } else if (!inSingle && !inTemplate && ch === '"') {
+      inDouble = !inDouble
+    } else if (!inSingle && !inDouble && ch === '`') {
+      inTemplate = !inTemplate
+    }
+  }
+  return line
+}
+
+function slugTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+}
+
+function countBraces(line: string): number {
+  let delta = 0
+  let inSingle = false
+  let inDouble = false
+  let inTemplate = false
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (ch === '\\') {
+      i++
+      continue
+    }
+    if (!inSingle && !inDouble && !inTemplate) {
+      if (ch === "'") {
+        inSingle = true
+      } else if (ch === '"') {
+        inDouble = true
+      } else if (ch === '`') {
+        inTemplate = true
+      } else if (ch === '{') {
+        delta++
+      } else if (ch === '}') {
+        delta--
+      }
+      continue
+    }
+    if (inSingle && ch === "'") {
+      inSingle = false
+    } else if (inDouble && ch === '"') {
+      inDouble = false
+    } else if (inTemplate && ch === '`') {
+      inTemplate = false
+    }
+  }
+  return delta
+}
+
+export function parseTestCaseOutline(content: string): TestOutlineNode[] {
+  const normalized = content.replace(/\r\n/g, '\n')
+  const lines = normalized.split('\n')
+  const roots: TestOutlineNode[] = []
+  const stack: { depth: number; node: TestOutlineNode }[] = []
+  let depth = 0
+  let inBlockComment = false
+  let nodeCount = 0
+  const seenIds = new Set<string>()
+
+  for (let index = 0; index < lines.length; index++) {
+    let line = lines.at(index) ?? ''
+    if (inBlockComment) {
+      const end = line.indexOf('*/')
+      if (end === -1) {
+        continue
+      }
+      line = line.slice(end + 2)
+      inBlockComment = false
+    }
+    const blockStart = line.indexOf('/*')
+    if (blockStart !== -1) {
+      const blockEnd = line.indexOf('*/', blockStart + 2)
+      if (blockEnd === -1) {
+        line = line.slice(0, blockStart)
+        inBlockComment = true
+      } else {
+        line = line.slice(0, blockStart) + line.slice(blockEnd + 2)
+      }
+    }
+
+    const code = stripLineComment(line)
+    const parsed = matchTestCall(code)
+    if (parsed && nodeCount < MAX_TEST_OUTLINE_NODES) {
+      const title = parsed.title.trim()
+      if (title) {
+        const lineNo = index + 1
+        const slug = slugTitle(title) || 'test'
+        let id = `${lineNo}-${slug}`
+        let suffix = 2
+        while (seenIds.has(id)) {
+          id = `${lineNo}-${slug}-${suffix}`
+          suffix++
+        }
+        seenIds.add(id)
+        const node: TestOutlineNode = {
+          children: [],
+          id,
+          kind: parsed.kind,
+          line: lineNo,
+          modifier: parsed.modifier,
+          title
+        }
+        while (stack.length > 0 && (stack.at(-1)?.depth ?? 0) >= depth) {
+          stack.pop()
+        }
+        // Why: its attach to the nearest open describe; describes nest only under describes.
+        const parent = stack.at(-1)?.node ?? null
+        if (parsed.kind === 'describe' && (parent === null || parent.kind === 'describe')) {
+          if (parent === null) {
+            roots.push(node)
+          } else {
+            parent.children.push(node)
+          }
+          stack.push({ depth, node })
+        } else if (parsed.kind === 'describe') {
+          roots.push(node)
+          stack.push({ depth, node })
+        } else if (parent === null) {
+          roots.push(node)
+        } else {
+          parent.children.push(node)
+        }
+        nodeCount++
+      }
+    }
+    depth = Math.max(0, depth + countBraces(code))
+    while (stack.length > 0 && (stack.at(-1)?.depth ?? 0) >= depth) {
+      stack.pop()
+    }
+  }
+
+  return roots
+}

--- a/src/renderer/src/components/editor/test-case-outline-parse.ts
+++ b/src/renderer/src/components/editor/test-case-outline-parse.ts
@@ -1,6 +1,14 @@
+import {
+  findDescribeBodyBrace,
+  skipQuotedString,
+  skipTemplateLiteral,
+  skipWhitespaceAndComments,
+  slugTitle
+} from './test-case-outline-tokens'
+
 export type TestOutlineKind = 'describe' | 'it'
 
-export type TestOutlineModifier = 'each' | 'skip' | 'only' | 'todo'
+export type TestOutlineModifier = 'each' | 'skip' | 'only' | 'todo' | 'concurrent'
 
 export type TestOutlineNode = {
   children: TestOutlineNode[]
@@ -13,182 +21,220 @@ export type TestOutlineNode = {
 
 const MAX_TEST_OUTLINE_NODES = 2000
 
-const CALL_RE =
-  /(^|[^\w$.])(describe|it|test)(\.(each|skip|only|todo))*\s*\(\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|`((?:[^`\\]|\\.)*)`)/
-
-const EACH_CALL_RE =
-  /(^|[^\w$.])(describe|it|test)(\.(each|skip|only|todo))*\s*\([^)]*\)\s*\(\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|`((?:[^`\\]|\\.)*)`)/
-
-function matchTestCall(code: string): {
-  kind: TestOutlineKind
-  modifier?: TestOutlineModifier
-  title: string
-} | null {
-  const direct = CALL_RE.exec(code)
-  // Why: test.each(data)(title) carries the title in a second call — retry there.
-  const match = direct ?? EACH_CALL_RE.exec(code)
-  if (!match) {
-    return null
-  }
-  const modifier = /\.(each|skip|only|todo)(?=\.|$|\s*\()/.exec(match[3] ?? '')?.at(1) as
-    | TestOutlineModifier
-    | undefined
-  return {
-    kind: match[2] === 'describe' ? 'describe' : 'it',
-    modifier,
-    title: match[5] ?? match[6] ?? match[7] ?? ''
-  }
-}
-
-// Why: a title containing `it(` inside a comment must not become a node.
-function stripLineComment(line: string): string {
-  let inSingle = false
-  let inDouble = false
-  let inTemplate = false
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i]
-    if (ch === '\\') {
-      i++
-      continue
-    }
-    if (!inSingle && !inDouble && !inTemplate && ch === '/' && line[i + 1] === '/') {
-      return line.slice(0, i)
-    }
-    if (!inDouble && !inTemplate && ch === "'") {
-      inSingle = !inSingle
-    } else if (!inSingle && !inTemplate && ch === '"') {
-      inDouble = !inDouble
-    } else if (!inSingle && !inDouble && ch === '`') {
-      inTemplate = !inTemplate
-    }
-  }
-  return line
-}
-
-function slugTitle(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 60)
-}
-
-function countBraces(line: string): number {
-  let delta = 0
-  let inSingle = false
-  let inDouble = false
-  let inTemplate = false
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i]
-    if (ch === '\\') {
-      i++
-      continue
-    }
-    if (!inSingle && !inDouble && !inTemplate) {
-      if (ch === "'") {
-        inSingle = true
-      } else if (ch === '"') {
-        inDouble = true
-      } else if (ch === '`') {
-        inTemplate = true
-      } else if (ch === '{') {
-        delta++
-      } else if (ch === '}') {
-        delta--
-      }
-      continue
-    }
-    if (inSingle && ch === "'") {
-      inSingle = false
-    } else if (inDouble && ch === '"') {
-      inDouble = false
-    } else if (inTemplate && ch === '`') {
-      inTemplate = false
-    }
-  }
-  return delta
-}
-
+// Why: stateful scanner skips literals/comments so multiline calls, tagged .each, and nested suites parse statically without execution.
+/**
+ * Parses test specification source code into a hierarchical outline tree.
+ */
 export function parseTestCaseOutline(content: string): TestOutlineNode[] {
   const normalized = content.replace(/\r\n/g, '\n')
-  const lines = normalized.split('\n')
+  const len = normalized.length
   const roots: TestOutlineNode[] = []
-  const stack: { depth: number; node: TestOutlineNode }[] = []
+  const stack: { scopeDepth: number; node: TestOutlineNode }[] = []
   let depth = 0
-  let inBlockComment = false
+  let line = 1
+  let i = 0
   let nodeCount = 0
   const seenIds = new Set<string>()
+  const incLine = (): void => {
+    line++
+  }
 
-  for (let index = 0; index < lines.length; index++) {
-    let line = lines.at(index) ?? ''
-    if (inBlockComment) {
-      const end = line.indexOf('*/')
-      if (end === -1) {
-        continue
-      }
-      line = line.slice(end + 2)
-      inBlockComment = false
+  function addNode(
+    kind: TestOutlineKind,
+    modifier: TestOutlineModifier | undefined,
+    title: string,
+    nodeLine: number
+  ): TestOutlineNode | null {
+    if (nodeCount >= MAX_TEST_OUTLINE_NODES) {
+      return null
     }
-    const blockStart = line.indexOf('/*')
-    if (blockStart !== -1) {
-      const blockEnd = line.indexOf('*/', blockStart + 2)
-      if (blockEnd === -1) {
-        line = line.slice(0, blockStart)
-        inBlockComment = true
-      } else {
-        line = line.slice(0, blockStart) + line.slice(blockEnd + 2)
-      }
+    const trimmed = title.trim()
+    if (!trimmed) {
+      return null
     }
 
-    const code = stripLineComment(line)
-    const parsed = matchTestCall(code)
-    if (parsed && nodeCount < MAX_TEST_OUTLINE_NODES) {
-      const title = parsed.title.trim()
-      if (title) {
-        const lineNo = index + 1
-        const slug = slugTitle(title) || 'test'
-        let id = `${lineNo}-${slug}`
-        let suffix = 2
-        while (seenIds.has(id)) {
-          id = `${lineNo}-${slug}-${suffix}`
-          suffix++
-        }
-        seenIds.add(id)
-        const node: TestOutlineNode = {
-          children: [],
-          id,
-          kind: parsed.kind,
-          line: lineNo,
-          modifier: parsed.modifier,
-          title
-        }
-        while (stack.length > 0 && (stack.at(-1)?.depth ?? 0) >= depth) {
-          stack.pop()
-        }
-        // Why: its attach to the nearest open describe; describes nest only under describes.
-        const parent = stack.at(-1)?.node ?? null
-        if (parsed.kind === 'describe' && (parent === null || parent.kind === 'describe')) {
-          if (parent === null) {
-            roots.push(node)
+    const slug = slugTitle(trimmed) || 'test'
+    let id = `${nodeLine}-${slug}`
+    let suffix = 2
+    while (seenIds.has(id)) {
+      id = `${nodeLine}-${slug}-${suffix}`
+      suffix++
+    }
+    seenIds.add(id)
+
+    const node: TestOutlineNode = {
+      children: [],
+      id,
+      kind,
+      line: nodeLine,
+      modifier,
+      title: trimmed
+    }
+
+    const parent = stack.length > 0 ? (stack.at(-1)?.node ?? null) : null
+    if (parent === null) {
+      roots.push(node)
+    } else {
+      parent.children.push(node)
+    }
+    nodeCount++
+    return node
+  }
+
+  while (i < len) {
+    const ch = normalized[i]
+
+    if (ch === '\n') {
+      line++
+      i++
+      continue
+    }
+    if (ch === '/' && (normalized[i + 1] === '/' || normalized[i + 1] === '*')) {
+      i = skipWhitespaceAndComments(normalized, i, len, incLine)
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      i = skipQuotedString(normalized, i, len, incLine)
+      continue
+    }
+    if (ch === '`') {
+      i = skipTemplateLiteral(normalized, i, len, incLine)
+      continue
+    }
+    if (ch === '{') {
+      depth++
+      i++
+      continue
+    }
+    if (ch === '}') {
+      depth = Math.max(0, depth - 1)
+      while (stack.length > 0 && (stack.at(-1)?.scopeDepth ?? 0) > depth) {
+        stack.pop()
+      }
+      i++
+      continue
+    }
+
+    const prev = i > 0 ? normalized[i - 1] : ' '
+    if (!/[\w$.]/.test(prev)) {
+      let callKind: TestOutlineKind | null = null
+      let idLen = 0
+
+      if (normalized.startsWith('describe', i) && !/[\w$]/.test(normalized[i + 8] || '')) {
+        callKind = 'describe'
+        idLen = 8
+      } else if (normalized.startsWith('it', i) && !/[\w$]/.test(normalized[i + 2] || '')) {
+        callKind = 'it'
+        idLen = 2
+      } else if (normalized.startsWith('test', i) && !/[\w$]/.test(normalized[i + 4] || '')) {
+        callKind = 'it'
+        idLen = 4
+      }
+
+      if (callKind) {
+        const startLine = line
+        let cur = i + idLen
+        let modifier: TestOutlineModifier | undefined = undefined
+        let isEach = false
+
+        while (cur < len && normalized[cur] === '.') {
+          cur++
+          const modMatch = /^(each|skip|only|todo|concurrent)\b/.exec(normalized.slice(cur))
+          if (modMatch) {
+            const mod = modMatch[1] as TestOutlineModifier
+            if (mod === 'each') {
+              isEach = true
+            }
+            if (
+              !modifier ||
+              modifier === 'each' ||
+              (modifier === 'concurrent' && (mod === 'only' || mod === 'skip' || mod === 'todo'))
+            ) {
+              modifier = mod
+            }
+            cur += mod.length
           } else {
-            parent.children.push(node)
+            break
           }
-          stack.push({ depth, node })
-        } else if (parsed.kind === 'describe') {
-          roots.push(node)
-          stack.push({ depth, node })
-        } else if (parent === null) {
-          roots.push(node)
-        } else {
-          parent.children.push(node)
         }
-        nodeCount++
+
+        cur = skipWhitespaceAndComments(normalized, cur, len, incLine)
+
+        if (isEach) {
+          if (normalized[cur] === '`') {
+            cur = skipTemplateLiteral(normalized, cur, len, incLine)
+          } else if (normalized[cur] === '(') {
+            cur++
+            let parenDepth = 1
+            while (cur < len && parenDepth > 0) {
+              const pCh = normalized[cur]
+              if (pCh === '(') {
+                parenDepth++
+              } else if (pCh === ')') {
+                parenDepth--
+              } else if (pCh === '\n') {
+                line++
+              } else if (pCh === "'" || pCh === '"') {
+                cur = skipQuotedString(normalized, cur, len, incLine)
+                continue
+              } else if (pCh === '`') {
+                cur = skipTemplateLiteral(normalized, cur, len, incLine)
+                continue
+              }
+              cur++
+            }
+          }
+          cur = skipWhitespaceAndComments(normalized, cur, len, incLine)
+        }
+
+        if (cur < len && normalized[cur] === '(') {
+          cur++
+          cur = skipWhitespaceAndComments(normalized, cur, len, incLine)
+
+          if (
+            cur < len &&
+            (normalized[cur] === '"' || normalized[cur] === "'" || normalized[cur] === '`')
+          ) {
+            const quote = normalized[cur]
+            cur++
+            let title = ''
+            while (cur < len && normalized[cur] !== quote) {
+              if (normalized[cur] === '\\') {
+                cur++
+                if (cur < len) {
+                  title += normalized[cur]
+                }
+              } else {
+                if (normalized[cur] === '\n') {
+                  line++
+                }
+                title += normalized[cur]
+              }
+              cur++
+            }
+            if (cur < len) {
+              cur++
+            }
+
+            const node = addNode(callKind, modifier, title, startLine)
+
+            if (callKind === 'describe' && node) {
+              const body = findDescribeBodyBrace(normalized, cur, len, incLine)
+              cur = body.next
+              if (body.foundBody) {
+                depth++
+                stack.push({ scopeDepth: depth, node })
+              }
+            }
+
+            i = cur
+            continue
+          }
+        }
       }
     }
-    depth = Math.max(0, depth + countBraces(code))
-    while (stack.length > 0 && (stack.at(-1)?.depth ?? 0) >= depth) {
-      stack.pop()
-    }
+
+    i++
   }
 
   return roots

--- a/src/renderer/src/components/editor/test-case-outline-tokens.ts
+++ b/src/renderer/src/components/editor/test-case-outline-tokens.ts
@@ -162,10 +162,24 @@ export function findDescribeBodyBrace(
 
       let b = 1
       let temp = cur + 1
+      const noop = (): void => {}
       while (temp < len && b > 0) {
-        if (code[temp] === '{') {
+        const t = code[temp]
+        if (t === '/' && (code[temp + 1] === '/' || code[temp + 1] === '*')) {
+          temp = skipWhitespaceAndComments(code, temp, len, noop)
+          continue
+        }
+        if (t === "'" || t === '"') {
+          temp = skipQuotedString(code, temp, len, noop)
+          continue
+        }
+        if (t === '`') {
+          temp = skipTemplateLiteral(code, temp, len, noop)
+          continue
+        }
+        if (t === '{') {
           b++
-        } else if (code[temp] === '}') {
+        } else if (t === '}') {
           b--
         }
         temp++

--- a/src/renderer/src/components/editor/test-case-outline-tokens.ts
+++ b/src/renderer/src/components/editor/test-case-outline-tokens.ts
@@ -1,0 +1,193 @@
+// Why: token scanning skips strings, comments, and templates so outlines extract without AST parsing.
+/**
+ * Skips a single- or double-quoted string literal.
+ */
+export function skipQuotedString(
+  code: string,
+  start: number,
+  len: number,
+  onNewline: () => void
+): number {
+  const quote = code[start]
+  let idx = start + 1
+  while (idx < len && code[idx] !== quote) {
+    if (code[idx] === '\\') {
+      idx += 2
+      continue
+    }
+    if (code[idx] === '\n') {
+      onNewline()
+    }
+    idx++
+  }
+  return idx < len ? idx + 1 : idx
+}
+
+/**
+ * Skips a template literal including expressions.
+ */
+export function skipTemplateLiteral(
+  code: string,
+  start: number,
+  len: number,
+  onNewline: () => void
+): number {
+  let idx = start + 1
+  while (idx < len && code[idx] !== '`') {
+    if (code[idx] === '\\') {
+      idx += 2
+      continue
+    }
+    if (code[idx] === '$' && code[idx + 1] === '{') {
+      idx += 2
+      let interpDepth = 1
+      while (idx < len && interpDepth > 0) {
+        if (code[idx] === '{') {
+          interpDepth++
+        } else if (code[idx] === '}') {
+          interpDepth--
+        } else if (code[idx] === '\n') {
+          onNewline()
+        }
+        idx++
+      }
+      continue
+    }
+    if (code[idx] === '\n') {
+      onNewline()
+    }
+    idx++
+  }
+  return idx < len ? idx + 1 : idx
+}
+
+/**
+ * Skips whitespace, line comments, and block comments.
+ */
+export function skipWhitespaceAndComments(
+  code: string,
+  start: number,
+  len: number,
+  onNewline: () => void
+): number {
+  let idx = start
+  while (idx < len) {
+    const ch = code[idx]
+    if (ch === '\n') {
+      onNewline()
+      idx++
+    } else if (/\s/.test(ch)) {
+      idx++
+    } else if (ch === '/' && code[idx + 1] === '/') {
+      idx += 2
+      while (idx < len && code[idx] !== '\n') {
+        idx++
+      }
+    } else if (ch === '/' && code[idx + 1] === '*') {
+      idx += 2
+      while (idx < len && !(code[idx] === '*' && code[idx + 1] === '/')) {
+        if (code[idx] === '\n') {
+          onNewline()
+        }
+        idx++
+      }
+      if (idx < len) {
+        idx += 2
+      }
+    } else {
+      break
+    }
+  }
+  return idx
+}
+
+/**
+ * Converts a test title into a URL/DOM friendly slug.
+ */
+export function slugTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+}
+
+/**
+ * Scans past describe callback parameters to locate the opening brace of the suite body.
+ */
+export function findDescribeBodyBrace(
+  code: string,
+  start: number,
+  len: number,
+  onNewline: () => void
+): { next: number; foundBody: boolean } {
+  let cur = start
+  let inParen = 0
+  while (cur < len) {
+    const ch = code[cur]
+    if (ch === '\n') {
+      onNewline()
+      cur++
+    } else if (ch === '/' && (code[cur + 1] === '/' || code[cur + 1] === '*')) {
+      cur = skipWhitespaceAndComments(code, cur, len, onNewline)
+    } else if (ch === "'" || ch === '"') {
+      cur = skipQuotedString(code, cur, len, onNewline)
+    } else if (ch === '`') {
+      cur = skipTemplateLiteral(code, cur, len, onNewline)
+    } else if (ch === '(') {
+      inParen++
+      cur++
+    } else if (ch === ')') {
+      if (inParen === 0) {
+        break
+      }
+      inParen--
+      cur++
+    } else if (ch === '{') {
+      if (inParen > 0) {
+        cur++
+        let b = 1
+        while (cur < len && b > 0) {
+          if (code[cur] === '\n') {
+            onNewline()
+          } else if (code[cur] === '{') {
+            b++
+          } else if (code[cur] === '}') {
+            b--
+          }
+          cur++
+        }
+        continue
+      }
+
+      let b = 1
+      let temp = cur + 1
+      while (temp < len && b > 0) {
+        if (code[temp] === '{') {
+          b++
+        } else if (code[temp] === '}') {
+          b--
+        }
+        temp++
+      }
+      let afterBrace = temp
+      while (afterBrace < len && /\s/.test(code[afterBrace])) {
+        afterBrace++
+      }
+      if (code[afterBrace] === ',') {
+        while (cur < temp) {
+          if (code[cur] === '\n') {
+            onNewline()
+          }
+          cur++
+        }
+        continue
+      }
+
+      return { next: cur + 1, foundBody: true }
+    } else {
+      cur++
+    }
+  }
+  return { next: cur, foundBody: false }
+}

--- a/src/renderer/src/components/editor/test-spec-outline-collapse-state.ts
+++ b/src/renderer/src/components/editor/test-spec-outline-collapse-state.ts
@@ -1,0 +1,51 @@
+import type { TestOutlineNode } from './test-case-outline-parse'
+
+export function collectTestOutlineParentIds(items: TestOutlineNode[]): Set<string> {
+  const parentIds = new Set<string>()
+
+  function visit(nodes: TestOutlineNode[]): void {
+    for (const item of nodes) {
+      if (item.children.length > 0) {
+        parentIds.add(item.id)
+        visit(item.children)
+      }
+    }
+  }
+
+  visit(items)
+  return parentIds
+}
+
+export function pruneTestOutlineCollapsedIds(
+  collapsedIds: ReadonlySet<string>,
+  items: TestOutlineNode[]
+): Set<string> {
+  const parentIds = collectTestOutlineParentIds(items)
+  const next = new Set<string>()
+  for (const id of collapsedIds) {
+    if (parentIds.has(id)) {
+      next.add(id)
+    }
+  }
+  return next
+}
+
+export function toggleTestOutlineCollapsedId(
+  collapsedIds: ReadonlySet<string>,
+  id: string
+): Set<string> {
+  const next = new Set(collapsedIds)
+  if (next.has(id)) {
+    next.delete(id)
+  } else {
+    next.add(id)
+  }
+  return next
+}
+
+export function isTestOutlineItemExpanded(
+  collapsedIds: ReadonlySet<string>,
+  item: TestOutlineNode
+): boolean {
+  return item.children.length === 0 || !collapsedIds.has(item.id)
+}

--- a/src/renderer/src/components/editor/test-spec-outline-collapse-state.ts
+++ b/src/renderer/src/components/editor/test-spec-outline-collapse-state.ts
@@ -1,5 +1,8 @@
 import type { TestOutlineNode } from './test-case-outline-parse'
 
+/**
+ * Collects IDs of all outline nodes that contain child test cases.
+ */
 export function collectTestOutlineParentIds(items: TestOutlineNode[]): Set<string> {
   const parentIds = new Set<string>()
 
@@ -16,6 +19,9 @@ export function collectTestOutlineParentIds(items: TestOutlineNode[]): Set<strin
   return parentIds
 }
 
+/**
+ * Prunes collapsed node IDs that no longer exist in the current outline tree.
+ */
 export function pruneTestOutlineCollapsedIds(
   collapsedIds: ReadonlySet<string>,
   items: TestOutlineNode[]
@@ -30,6 +36,9 @@ export function pruneTestOutlineCollapsedIds(
   return next
 }
 
+/**
+ * Toggles a test outline item's collapsed state.
+ */
 export function toggleTestOutlineCollapsedId(
   collapsedIds: ReadonlySet<string>,
   id: string
@@ -43,6 +52,9 @@ export function toggleTestOutlineCollapsedId(
   return next
 }
 
+/**
+ * Returns whether an outline item is currently expanded in the tree view.
+ */
 export function isTestOutlineItemExpanded(
   collapsedIds: ReadonlySet<string>,
   item: TestOutlineNode

--- a/src/renderer/src/components/editor/test-spec-outline-gate.test.ts
+++ b/src/renderer/src/components/editor/test-spec-outline-gate.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { isTestSpecFile } from './test-spec-outline-gate'
+
+describe('isTestSpecFile', () => {
+  it('matches spec/test basenames for TS/JS only', () => {
+    expect(isTestSpecFile('auth.spec.ts', 'typescript')).toBe(true)
+    expect(isTestSpecFile('auth.test.tsx', 'typescript')).toBe(true)
+    expect(isTestSpecFile('auth.spec.js', 'javascript')).toBe(true)
+    expect(isTestSpecFile('src/auth.spec.ts', 'typescript')).toBe(true)
+    expect(isTestSpecFile('utils.ts', 'typescript')).toBe(false)
+    expect(isTestSpecFile('spec.md', 'markdown')).toBe(false)
+    expect(isTestSpecFile('auth.spec.ts', 'plaintext')).toBe(false)
+  })
+
+  it('handles Windows separators', () => {
+    expect(isTestSpecFile('C:\\repo\\auth.test.ts', 'typescript')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/editor/test-spec-outline-gate.ts
+++ b/src/renderer/src/components/editor/test-spec-outline-gate.ts
@@ -1,8 +1,9 @@
-import { detectLanguage } from '@/lib/language-detect'
-
 const SPEC_BASENAME_RE = /\.(spec|test)\.[^.]+$/i
 
 // Why: keep the outline off untitled drafts and non-test code to bound parse cost and panel noise.
+/**
+ * Returns whether a relative file path represents a supported TypeScript or JavaScript test specification.
+ */
 export function isTestSpecFile(relativePath: string, resolvedLanguage: string): boolean {
   if (resolvedLanguage !== 'typescript' && resolvedLanguage !== 'javascript') {
     return false
@@ -10,8 +11,4 @@ export function isTestSpecFile(relativePath: string, resolvedLanguage: string): 
   const parts = relativePath.split(/[\\/]/)
   const basename = parts.at(-1) ?? ''
   return SPEC_BASENAME_RE.test(basename)
-}
-
-export function detectTestSpecLanguage(filePath: string): string {
-  return detectLanguage(filePath)
 }

--- a/src/renderer/src/components/editor/test-spec-outline-gate.ts
+++ b/src/renderer/src/components/editor/test-spec-outline-gate.ts
@@ -1,0 +1,17 @@
+import { detectLanguage } from '@/lib/language-detect'
+
+const SPEC_BASENAME_RE = /\.(spec|test)\.[^.]+$/i
+
+// Why: keep the outline off untitled drafts and non-test code to bound parse cost and panel noise.
+export function isTestSpecFile(relativePath: string, resolvedLanguage: string): boolean {
+  if (resolvedLanguage !== 'typescript' && resolvedLanguage !== 'javascript') {
+    return false
+  }
+  const parts = relativePath.split(/[\\/]/)
+  const basename = parts.at(-1) ?? ''
+  return SPEC_BASENAME_RE.test(basename)
+}
+
+export function detectTestSpecLanguage(filePath: string): string {
+  return detectLanguage(filePath)
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14679,7 +14679,8 @@
           "f0fd4174b5": "Open file tab to use rich markdown editing",
           "a10d9b8337": "Open file",
           "2076ecfc9c": "Previous change",
-          "631dab0df3": "Next change"
+          "631dab0df3": "Next change",
+          "a81f2c94e2": "Test Outline"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "Export as PDF",
@@ -15217,6 +15218,15 @@
           "a0af0198aa": "Large diffs are not rendered by default.",
           "c3d9f4a712": "This diff's size isn't known yet, so it loads on request.",
           "f7fa7a40d0": "Load diff"
+        },
+        "TestSpecOutlinePanel": {
+          "97ad46f11f": "Collapse {{value0}}",
+          "65b036b6c8": "Expand {{value0}}",
+          "9c1e44a2d7": "Go to line {{value0}}",
+          "27d0a9c49a": "Test case outline",
+          "06357eea60": "Test Outline",
+          "bbe8369097": "Close test outline",
+          "de3928b6e4": "No test cases found"
         }
       },
       "diff": {

--- a/src/renderer/src/store/slices/editor/actions/close-file-action.ts
+++ b/src/renderer/src/store/slices/editor/actions/close-file-action.ts
@@ -52,6 +52,10 @@ export function createCloseFileAction(
           visibilityKeysToRemove.length > 0
             ? removeMarkdownVisibilityKeys(s.markdownTableOfContentsVisible, visibilityKeysToRemove)
             : s.markdownTableOfContentsVisible
+        const newTestSpecOutlineVisible =
+          visibilityKeysToRemove.length > 0
+            ? removeMarkdownVisibilityKeys(s.testSpecOutlineVisible, visibilityKeysToRemove)
+            : s.testSpecOutlineVisible
         // Why: editorCursorLine is keyed by fileId and grows unbounded across a long session without cleanup on close.
         const newEditorCursorLine = { ...s.editorCursorLine }
         delete newEditorCursorLine[fileId]
@@ -185,6 +189,7 @@ export function createCloseFileAction(
           editorViewMode: newEditorViewMode,
           markdownFrontmatterVisible: newMarkdownFrontmatterVisible,
           markdownTableOfContentsVisible: newMarkdownTableOfContentsVisible,
+          testSpecOutlineVisible: newTestSpecOutlineVisible,
           tabBarOrderByWorktree: nextTabBarOrderByWorktree,
           pendingEditorReveal: null,
           pendingEditorFocusRequest:

--- a/src/renderer/src/store/slices/editor/actions/editor-draft-state.ts
+++ b/src/renderer/src/store/slices/editor/actions/editor-draft-state.ts
@@ -23,6 +23,8 @@ export type EditorDraftState = {
   setMarkdownFrontmatterVisible: (fileId: string, visible: boolean) => void
   markdownTableOfContentsVisible: Record<string, boolean>
   setMarkdownTableOfContentsVisible: (fileId: string, visible: boolean) => void
+  testSpecOutlineVisible: Record<string, boolean>
+  setTestSpecOutlineVisible: (fileId: string, visible: boolean) => void
   markdownTocPanelWidth: number
   setMarkdownTocPanelWidth: (width: number) => void
   combinedDiffFileTreeWidth: number
@@ -141,6 +143,21 @@ export function createEditorDraftState(set: EditorSet, _get: EditorGet): EditorD
             [fileId]: true
           }
         }
+      }),
+
+    // Test spec outline visibility (#19721)
+    testSpecOutlineVisible: {},
+    setTestSpecOutlineVisible: (fileId, visible) =>
+      set((s) => {
+        if (!visible) {
+          if (!(fileId in s.testSpecOutlineVisible)) {
+            return s
+          }
+          const next = { ...s.testSpecOutlineVisible }
+          delete next[fileId]
+          return { testSpecOutlineVisible: next }
+        }
+        return { testSpecOutlineVisible: { ...s.testSpecOutlineVisible, [fileId]: true } }
       }),
 
     // Markdown table of contents panel sizing

--- a/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
@@ -177,7 +177,8 @@ export function applyOpenFileToState(
         markdownRichModeSizeOverride: nextMarkdownRichModeSizeOverride,
         editorViewMode: nextEditorViewMode,
         markdownFrontmatterVisible: nextMarkdownFrontmatterVisible,
-        markdownTableOfContentsVisible: nextMarkdownTableOfContentsVisible
+        markdownTableOfContentsVisible: nextMarkdownTableOfContentsVisible,
+        testSpecOutlineVisible: nextTestSpecOutlineVisible
       } = removeEditorStateForReplacedPreview(s, replacedPreview, id)
       // Replace in-place to preserve tab position
       newFiles = s.openFiles.map((f, i) =>
@@ -240,6 +241,7 @@ export function applyOpenFileToState(
         editorViewMode: nextEditorViewMode,
         markdownFrontmatterVisible: nextMarkdownFrontmatterVisible,
         markdownTableOfContentsVisible: nextMarkdownTableOfContentsVisible,
+        testSpecOutlineVisible: nextTestSpecOutlineVisible,
         recentlyClosedEditorTabsByWorktree: nextRecentlyClosed,
         recentlyClosedTabKindsByWorktree: nextRecentlyClosedKinds,
         ...previewTabBarUpdate,

--- a/src/renderer/src/store/slices/editor/actions/recently-closed-editor-tabs.ts
+++ b/src/renderer/src/store/slices/editor/actions/recently-closed-editor-tabs.ts
@@ -81,6 +81,7 @@ export function createRecentlyClosedEditorTabs(
             editorViewMode: {},
             markdownFrontmatterVisible: {},
             markdownTableOfContentsVisible: {},
+            testSpecOutlineVisible: {},
             pendingEditorReveal: null,
             pendingEditorFocusRequest: null
           }
@@ -109,6 +110,11 @@ export function createRecentlyClosedEditorTabs(
         )
         const newMarkdownTableOfContentsVisible = Object.fromEntries(
           Object.entries(s.markdownTableOfContentsVisible).filter(([fileId]) =>
+            remainingFileIds.has(fileId)
+          )
+        )
+        const newTestSpecOutlineVisible = Object.fromEntries(
+          Object.entries(s.testSpecOutlineVisible).filter(([fileId]) =>
             remainingFileIds.has(fileId)
           )
         )
@@ -185,6 +191,7 @@ export function createRecentlyClosedEditorTabs(
           editorViewMode: newEditorViewMode,
           markdownFrontmatterVisible: newMarkdownFrontmatterVisible,
           markdownTableOfContentsVisible: newMarkdownTableOfContentsVisible,
+          testSpecOutlineVisible: newTestSpecOutlineVisible,
           activeFileIdByWorktree: newActiveFileIdByWorktree,
           activeTabTypeByWorktree: newActiveTabTypeByWorktree,
           tabBarOrderByWorktree: nextTabBarOrderByWorktree,

--- a/src/renderer/src/store/slices/editor/actions/rekey-open-files-action.ts
+++ b/src/renderer/src/store/slices/editor/actions/rekey-open-files-action.ts
@@ -127,6 +127,7 @@ export function createRekeyOpenFilesAction(
             s.markdownTableOfContentsVisible,
             migrations
           ),
+          testSpecOutlineVisible: rekeyFileIdRecord(s.testSpecOutlineVisible, migrations),
           activeFileId: s.activeFileId ? (migrations.get(s.activeFileId) ?? s.activeFileId) : null,
           activeFileIdByWorktree,
           tabBarOrderByWorktree,

--- a/src/renderer/src/store/slices/editor/actions/restored-editor-owner-transition.ts
+++ b/src/renderer/src/store/slices/editor/actions/restored-editor-owner-transition.ts
@@ -212,6 +212,7 @@ export function buildRestoredEditorOwnerTransition(
           s.markdownTableOfContentsVisible,
           migrations
         ),
+        testSpecOutlineVisible: rekeyFileIdRecord(s.testSpecOutlineVisible, migrations),
         activeFileId: s.activeFileId ? (migrations.get(s.activeFileId) ?? s.activeFileId) : null,
         activeFileIdByWorktree: nextActiveFileIdByWorktree,
         activeTabTypeByWorktree: {

--- a/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
+++ b/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
@@ -81,6 +81,7 @@ export function removeEditorStateForReplacedPreview(
     | 'editorViewMode'
     | 'markdownFrontmatterVisible'
     | 'markdownTableOfContentsVisible'
+    | 'testSpecOutlineVisible'
     | 'openFiles'
   >,
   replacedFile: Pick<OpenFile, 'id' | 'markdownPreviewSourceFileId'>,
@@ -94,6 +95,7 @@ export function removeEditorStateForReplacedPreview(
   | 'editorViewMode'
   | 'markdownFrontmatterVisible'
   | 'markdownTableOfContentsVisible'
+  | 'testSpecOutlineVisible'
 > {
   const visibilityKeys = [
     replacedFile.id,
@@ -115,7 +117,8 @@ export function removeEditorStateForReplacedPreview(
       markdownRichModeSizeOverride: state.markdownRichModeSizeOverride,
       editorViewMode: state.editorViewMode,
       markdownFrontmatterVisible: state.markdownFrontmatterVisible,
-      markdownTableOfContentsVisible: state.markdownTableOfContentsVisible
+      markdownTableOfContentsVisible: state.markdownTableOfContentsVisible,
+      testSpecOutlineVisible: state.testSpecOutlineVisible
     }
   }
   return {
@@ -142,6 +145,10 @@ export function removeEditorStateForReplacedPreview(
     ),
     markdownTableOfContentsVisible: removeMarkdownVisibilityKeys(
       state.markdownTableOfContentsVisible,
+      visibilityKeys
+    ),
+    testSpecOutlineVisible: removeMarkdownVisibilityKeys(
+      state.testSpecOutlineVisible,
       visibilityKeys
     )
   }


### PR DESCRIPTION
## ELI5

When reviewing or editing test files (especially long Vitest/Jest suites with hundreds of lines), developers had to scroll through the whole file by hand to see what test cases existed. We added a **Test Outline** panel next to the code editor that statically parses `describe` suites and `it` / `test` cases (including `.skip`, `.only`, `.todo`, and `.each`), with collapsible tree navigation and click-to-jump into the editor.

## What Changed

- **Parser & Gating**:
  - Added [`test-case-outline-parse.ts`](file:///c:/Users/Kamraam/Desktop/Do%20Not%20Touch/ORCA/orca/src/renderer/src/components/editor/test-case-outline-parse.ts) to statically parse `describe`, `it`, and `test` blocks along with `.skip`, `.only`, `.todo`, and `.each` modifiers.
  - Added [`test-spec-outline-gate.ts`](file:///c:/Users/Kamraam/Desktop/Do%20Not%20Touch/ORCA/orca/src/renderer/src/components/editor/test-spec-outline-gate.ts) so the outline is only enabled for JS/TS `.test.` and `.spec.` files.
- **UI Panel & Hierarchy**:
  - Created [`TestSpecOutlinePanel.tsx`](file:///c:/Users/Kamraam/Desktop/Do%20Not%20Touch/ORCA/orca/src/renderer/src/components/editor/TestSpecOutlinePanel.tsx) with collapsible suites, modifier badges (`skip`, `todo`), and click-to-jump via `setPendingEditorReveal`.
  - Added [`test-spec-outline-collapse-state.ts`](file:///c:/Users/Kamraam/Desktop/Do%20Not%20Touch/ORCA/orca/src/renderer/src/components/editor/test-spec-outline-collapse-state.ts) to manage expanded/collapsed suite IDs.
- **Editor Integration**:
  - Added Test Outline toggle button with `<ListTree />` icon in [`EditorPanelHeader.tsx`](file:///c:/Users/Kamraam/Desktop/Do%20Not%20Touch/ORCA/orca/src/renderer/src/components/editor/EditorPanelHeader.tsx).
  - Wired layout beside Monaco editor in [`EditorEditFileSurface.tsx`](file:///c:/Users/Kamraam/Desktop/Do%20Not%20Touch/ORCA/orca/src/renderer/src/components/editor/EditorEditFileSurface.tsx) with `h-full` flex stretching.
  - Added state slice in editor store to track outline visibility per tab.
- **Tests & Localization**:
  - Added unit test suites for parser, gate, panel, and header components (16 new tests passing).
  - Added English locale strings in `en.json`.

## Why

Addresses #19721. Reviewing agent-generated branches and large test suites requires quickly understanding what test scenarios are covered before diving into test bodies. This outline acts as a lightweight, zero-runner table of contents for test files.

## Linked Issue

Fixes #19721

## Visual Proof

<img width="1581" height="1017" alt="image" src="https://github.com/user-attachments/assets/4579b1d9-a957-4bf9-b744-445513750a18" />

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Platform tested**: Windows 11 (local)

**Steps followed**:
1. Verified with a 305-line spec file (`auth.spec.ts`) and a 2,249-line spec file (`workspace-pipeline.spec.ts`).
2. Tested suite collapsing, expanding, and clicking tests to jump to specific line numbers (e.g., line 756).
3. Verified all modifiers render correctly (`.skip`, `.todo`, `.only`, `.each`).
4. Ran automated tests:
   - `test-case-outline-parse.test.ts` (4 passed)
   - `test-spec-outline-gate.test.ts` (2 passed)
   - `TestSpecOutlinePanel.test.tsx` (2 passed)
   - `EditorPanelHeader.test.tsx` (2 passed)
   - `EditorPanelShell.header.test.tsx` (6 passed)
5. Ran web typecheck: `npx tsc --noEmit -p config/tsconfig.tc.web.json` (0 errors).
6. Ran `oxlint` and `check-changed-code-quality.mjs` (0 warnings, 0 errors).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Performance**: Test outline is only parsed when a test file is active and the panel is toggled open.
- **Zero test-runner overhead**: Pure static AST/regex parsing without running the test process.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
