### PR TITLE
docs(terminal): correct the reveal-repaint premise for hidden tabs

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -125,10 +125,9 @@ export function resumeTerminalVisibility({
       resetAndRefreshAllTerminalWebglAtlases('visibility-resume-dpr')
       manager.scheduleRevealRepaint()
     } else {
-      // Why: a hidden pane's parsed output updated the cell model without
-      // presenting, so the reveal diff reports those cells unchanged. Force one
-      // present now; the settled rebuild is two frames out and would otherwise
-      // leave pre-hide pixels composited until then.
+      // Why: this path just re-attached WebGL and its canvas starts empty, so
+      // present now rather than leave the pane blank until the settled rebuild
+      // two frames later.
       for (const pane of manager.getPanes()) {
         presentPaneViewportPreservingSynchronizedOutput(pane)
       }

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
@@ -67,13 +67,15 @@ function flushPaneRevealRepaints(): void {
 /**
  * Repaints a revealed tab's panes from their xterm buffers.
  *
- * Why: while a pane is hidden, parsed output can update the WebGL renderer's
- * per-cell model without ever presenting a frame. At reveal the model diff
- * reports those cells unchanged, so plain refreshes skip them and the canvas
- * keeps compositing pre-hide pixels until a selection or resize rebuilds the
- * model. Once layout settles, reattach every revealed renderer before one
- * registry-wide atlas reset so no delayed pane-local clear can invalidate a
- * sibling terminal's rebuilt model.
+ * Why: the heavy reveal recreates renderers, so once layout settles, reattach
+ * every revealed renderer before one registry-wide atlas reset — a delayed
+ * pane-local clear would otherwise invalidate a sibling's rebuilt model.
+ *
+ * NOT why: an ordinary display:none tab does not strand a stale cell model.
+ * With no box the render service is paused, so refreshRows returns before
+ * _updateModel and only latches _needsFullRefresh, which the observer pays back
+ * with a full refresh on reveal. Staleness needs that latch cleared while the
+ * pane is still hidden — see the display guard in pane-viewport-present.ts.
  */
 export function schedulePaneRevealRepaint(getPanes: () => Iterable<ManagedPaneInternal>): void {
   pendingRevealRepaints.add(getPanes)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## What this changes

A docstring correction only. No behaviour change, no tests, no types, no wire surface.

`pane-reveal-repaint.ts` claimed:

> while a pane is hidden, parsed output can update the WebGL renderer's per-cell model without ever presenting a frame. At reveal the model diff reports those cells unchanged, so plain refreshes skip them...

That is **false for an ordinary `display:none` tab**, and `terminal-visibility-resume.ts` repeated it. Both are replaced with what the reveal repaint is actually for, plus the condition a stale model would really need.

## Why it matters

The claim is load-bearing-looking and wrong, and it sent an investigation of STA-6990 down a dead end that ended in a designed-but-unshipped atlas-clear-on-every-tab-switch. Left in place it will do that again.

## Evidence the old claim is false

From the pinned xterm core (`@xterm/xterm` 6.1.0-beta.303):

- A hidden terminal tab is `display: none` — `RetainedPaneHost.tsx:157`.
- `display:none` pauses the render service via xterm's IntersectionObserver.
- While paused, `_updateModel` is never reached: `refreshRows(e,i,r=!1,s=!1){if(this._isPaused){this._needsFullRefresh=!0;return}` — so the per-cell model does **not** advance while hidden.
- The same observer pays the latch back on reveal: `!this._isPaused&&this._needsFullRefresh&&(this._pausedResizeTask.flush(),this.refreshRows(0,this._rowCount-1),this._needsFullRefresh=!1)`.

A stale model needs `_needsFullRefresh` cleared *while the pane is still hidden*. `releaseRenderPause` (`terminal-render-pause-release.ts:58-60`) does clear it, which is why `pane-viewport-present.ts` guards on `isManagedPaneDisplayNone`; the only other caller is gated on the pane already being visible (`fresh-spawn-follow-reset.ts:115,130`).

## STA-6990 / STA-6991: investigated, NOT closed

This PR closes neither. Both remain open with the investigation recorded.

**Ruled out with evidence**
1. Cell-width / multi-byte width calculation. Independently of the earlier width work: the reported cure is a resize, and a wrong cell width survives a resize — the buffer just re-lays out at the same wrong widths. Only a renderer-state fault is cured by one.
2. Stale per-cell model on tab reveal — falsified above.
3. Skipped fit on the light tab reveal. The light path does skip its own fit (`terminal-visibility-resume.ts:104` is inside `if (flushedDeferredMetrics)`), but the fit is supplied anyway: the fit ResizeObserver is attached at pane creation (`pane-lifecycle.ts:111`) and detached only at `disposePane` (`:182`), so it stays live across hide/show and fires `requestStablePaneFit` on the 0×0 → WxH transition.

**Remaining candidates, ranked**
1. *(6991, and possibly 6990)* Glyph-atlas page pressure. Over-budget texture pages render fully transparent — literally missing characters — and CJK inflates distinct-glyph count, which fits the reported Chinese correlation. Unproven: I could not show `_pages.length` exceeding the budget, and `_createNewPage` caps it at `Math.max(4, maxAtlasPages)` with `maxAtlasPages = min(32, gl.MAX_TEXTURE_IMAGE_UNITS)` (≥16 on WebGL2), so the overflow may be unreachable on macOS.
2. *(6991)* Atlas page merge/eviction. Two real bugs have already been fixed here, so the area still bites.
3. *(6990)* `requestFullViewportPresent` returns false when neither paused nor holding DEC 2026 (`terminal-render-pause-release.ts:120`), so the settled reveal often degrades to a plain `terminal.refresh()` two frames late — a window under load rather than a deterministic chain.

**Probes that would settle these**, from the devtools console on a reproducing pane — no code change needed:
- `t._core._renderService._isPaused` / `._needsFullRefresh` while hidden and immediately after reveal. To keep a `false` reading unambiguous between "latch cleared" and "nothing was owed", compare `_renderer.value._model.cells` against the buffer for the same viewport row in the same sample: model ≠ buffer with `_needsFullRefresh === false` is the smoking gun; model == buffer means nothing was owed.
- Candidate 1: `addon._renderer._charAtlas.pages.length` against `maxAtlasPages` on a CJK-heavy pane, and watch for xterm's own `Atlas page count (N) exceeds the renderer's texture capacity (M)` warning.

## Validation

- `tsc --noEmit` run separately per project — `config/tsconfig.node.json`, `config/tsconfig.tc.web.json`, `config/tsconfig.tc.cli.json` — exit 0 each.
- `oxlint` exit 0; `oxlint --config config/oxlint-code-quality-native-plugins.json src config tests mobile --deny-warnings` exit 0; `oxlint --config config/oxlint-code-quality-type-aware.json src --deny-warnings` exit 0.
- `vitest run --config config/vitest.config.ts` over `pane-reveal-repaint.test.ts`, `terminal-visibility-resume.test.ts`, `use-terminal-pane-global-effects-visibility-resume.test.ts` — 3 files, 44 tests, all passing.

No ablation is reported because there is no behaviour change to ablate: a comment edit cannot fail a test, and claiming an ablation arm here would be meaningless.
