### PR TITLE
Name a native-chat model only when it is available or agent-reported

### DIFF
--- a/src/main/claude/claude-structured-session-adapter.test.ts
+++ b/src/main/claude/claude-structured-session-adapter.test.ts
@@ -592,13 +592,9 @@ describe('ClaudeStructuredSessionAdapter turns and controls', () => {
     const adapter = await acquired(claude)
     const result = await adapter.readOptions({ sessionId: 'session-1', fence: 7 })
 
-    expect(result.models.map((model) => model.id)).toEqual([
-      'fable',
-      'opus',
-      'sonnet',
-      'haiku',
-      'custom-model'
-    ])
+    // Was: a trailing `custom-model` row. The seed is a list of available ids, and the
+    // init frame's unlisted model is reported as current without being offered.
+    expect(result.models.map((model) => model.id)).toEqual(['fable', 'opus', 'sonnet', 'haiku'])
     expect(result.current).toEqual({
       model: 'custom-model',
       effort: 'high',

--- a/src/main/claude/claude-structured-session-options.test.ts
+++ b/src/main/claude/claude-structured-session-options.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { readClaudeStructuredSessionOptions } from './claude-structured-session-options'
+import type { ClaudeSession } from './claude-structured-session-state'
+
+// `list_models` rows as the CLI reports them: the `default` row carries only the
+// resolved id, which is what marks the listed alias that resolves to the same model.
+const LISTED_ROWS = [
+  { value: 'default', resolvedModel: 'claude-opus-5[1m]' },
+  {
+    value: 'opus[1m]',
+    displayName: 'Opus (1M context)',
+    resolvedModel: 'claude-opus-5[1m]',
+    supportsEffort: true,
+    supportedEffortLevels: ['low', 'high']
+  },
+  { value: 'sonnet', displayName: 'Sonnet', resolvedModel: 'claude-sonnet-5' }
+]
+
+function optionsSession(reportedModel: string): ClaudeSession {
+  return {
+    connection: { supportedModels: async () => LISTED_ROWS },
+    options: new Map(),
+    reportedOptions: { model: reportedModel },
+    optionMutationSequence: 0,
+    reportedModelMutation: 0,
+    confirmedOptions: new Set()
+  } as unknown as ClaudeSession
+}
+
+describe('readClaudeStructuredSessionOptions', () => {
+  it('names the listed alias the init frame’s resolved id belongs to', async () => {
+    // The pill shows a picked Opus as `opus[1m]`, not as the resolved id the session
+    // reports — the mapping, not a fabricated row, is what keeps that model nameable.
+    const options = await readClaudeStructuredSessionOptions(
+      optionsSession('claude-opus-5[1m]'),
+      undefined
+    )
+
+    expect(options.current).toEqual({ model: 'opus[1m]', confirmed: ['model'] })
+    expect(options.models).toEqual([
+      {
+        id: 'opus[1m]',
+        label: 'Opus (1M context)',
+        isDefault: true,
+        efforts: [
+          { value: 'low', label: 'Low' },
+          { value: 'high', label: 'High' }
+        ]
+      },
+      { id: 'sonnet', label: 'Sonnet', isDefault: false, efforts: [] }
+    ])
+  })
+
+  it('reports an unlisted current model without listing it', async () => {
+    // Was: a fabricated `{ id: model, label: model, efforts: [] }` row, which offered a
+    // raw launch flag (`worker-start --model claude-opus-5`) as if the CLI listed it.
+    const options = await readClaudeStructuredSessionOptions(
+      optionsSession('claude-opus-5'),
+      undefined
+    )
+
+    expect(options.current.model).toBe('claude-opus-5')
+    expect(options.models.map((model) => model.id)).toEqual(['opus[1m]', 'sonnet'])
+  })
+})

--- a/src/main/claude/claude-structured-session-options.ts
+++ b/src/main/claude/claude-structured-session-options.ts
@@ -157,10 +157,10 @@ export async function readClaudeStructuredSessionOptions(
   const discovered = listedModels(catalog ? { models: catalog } : null)
   const models = discovered.length > 0 ? discovered : seedModels()
   const current = readClaudeCurrentModel(session)
+  // `models` stays the CLI's own list (or the seed): `currentModelId` already maps a
+  // resolved id back onto a listed row, so what survives unmatched is an id the CLI
+  // never offered. It is reported as current — the session runs it — but not listed.
   const model = currentModelId(models, current.id)
-  if (!models.some((entry) => entry.id === model)) {
-    models.push({ id: model, label: model, isDefault: false, efforts: [], resolvedModel: null })
-  }
   const effort = session.options.get('effort') ?? session.reportedOptions.effort
   const confirmed = [
     ...(current.confirmed ? ['model'] : []),

--- a/src/main/codex/codex-structured-session-options.test.ts
+++ b/src/main/codex/codex-structured-session-options.test.ts
@@ -123,6 +123,25 @@ describe('structured Codex session options', () => {
     )
   })
 
+  it('reports an unlisted current model without offering it as a choice', async () => {
+    // Was: a fabricated `{ id, label: id, efforts: [] }` row, which offered a raw launch
+    // id in the picker as though the account were entitled to it.
+    const request = vi.fn(async () => ({
+      data: [{ model: 'gpt-live', displayName: 'GPT Live', isDefault: true }],
+      nextCursor: null
+    }))
+
+    await expect(
+      readCodexStructuredSessionOptions({
+        connection: { request } as never,
+        current: { model: 'gpt-unlisted' }
+      })
+    ).resolves.toEqual({
+      models: [{ id: 'gpt-live', label: 'GPT Live', isDefault: true, efforts: [] }],
+      current: { model: 'gpt-unlisted' }
+    })
+  })
+
   it('hydrates current values from thread start or resume', () => {
     expect(
       reportedCodexThreadOptions({

--- a/src/main/codex/codex-structured-session-options.test.ts
+++ b/src/main/codex/codex-structured-session-options.test.ts
@@ -4,6 +4,7 @@ import { CodexAcquisitionWindow } from './codex-structured-acquisition-window'
 import {
   applyCodexStructuredSessionOption,
   readCodexStructuredSessionOptions,
+  readLiveCodexSessionOptions,
   reportedCodexThreadOptions,
   restoredCodexSessionOptions
 } from './codex-structured-session-options'
@@ -139,6 +140,51 @@ describe('structured Codex session options', () => {
     ).resolves.toEqual({
       models: [{ id: 'gpt-live', label: 'GPT Live', isDefault: true, efforts: [] }],
       current: { model: 'gpt-unlisted' }
+    })
+  })
+
+  it('confirms a model the thread reported, but not a pick we restored', async () => {
+    // The display rule names an unlisted model only when the agent reported it, so the
+    // reader has to say which of the two answered. `session.options` is a restored pick
+    // or an unechoed write of ours; `reportedOptions` is the opened thread's own state.
+    const request = vi.fn(async () => ({
+      data: [{ model: 'gpt-live', displayName: 'GPT Live', isDefault: true }],
+      nextCursor: null
+    }))
+    const session = (
+      options: Map<string, string>,
+      reported: Record<string, string>
+    ): CodexSession =>
+      ({ connection: { request }, options, reportedOptions: reported }) as unknown as CodexSession
+
+    await expect(
+      readLiveCodexSessionOptions(session(new Map(), { model: 'gpt-unlisted' }), undefined)
+    ).resolves.toMatchObject({ current: { model: 'gpt-unlisted', confirmed: ['model'] } })
+
+    const restored = await readLiveCodexSessionOptions(
+      session(new Map([['model', 'gpt-stale']]), {}),
+      undefined
+    )
+    expect(restored.current).toEqual({ model: 'gpt-stale' })
+    expect(restored.current.confirmed).toBeUndefined()
+  })
+
+  it('does not confirm a model it substituted rather than read', async () => {
+    // With nothing current the reader picks the default; that is our choice, not a report.
+    const request = vi.fn(async () => ({
+      data: [{ model: 'gpt-live', displayName: 'GPT Live', isDefault: true }],
+      nextCursor: null
+    }))
+
+    await expect(
+      readCodexStructuredSessionOptions({
+        connection: { request } as never,
+        current: {},
+        confirmed: ['model']
+      })
+    ).resolves.toEqual({
+      models: [{ id: 'gpt-live', label: 'GPT Live', isDefault: true, efforts: [] }],
+      current: { model: 'gpt-live' }
     })
   })
 

--- a/src/main/codex/codex-structured-session-options.test.ts
+++ b/src/main/codex/codex-structured-session-options.test.ts
@@ -1,4 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
+import { CODEX_SESSION_OPTION_CATALOG } from '../../shared/agent-session-option-catalog-claude-codex'
+import {
+  applyStructuredAgentSessionOptions,
+  canSetStructuredAgentSessionOption,
+  createStructuredAgentSessionOptionState,
+  structuredAgentSessionOptionSnapshot
+} from '../../shared/structured-agent-session-options'
 import type { CodexAppServerConnection } from './codex-app-server-connection'
 import { CodexAcquisitionWindow } from './codex-structured-acquisition-window'
 import {
@@ -167,6 +174,43 @@ describe('structured Codex session options', () => {
     )
     expect(restored.current).toEqual({ model: 'gpt-stale' })
     expect(restored.current.confirmed).toBeUndefined()
+
+    const changedModel = await readLiveCodexSessionOptions(
+      session(new Map([['model', 'gpt-stale']]), { model: 'gpt-old', effort: 'high' }),
+      undefined
+    )
+    expect(changedModel.current).toEqual({ model: 'gpt-stale', effort: 'high' })
+    expect(changedModel.current.confirmed).toBeUndefined()
+  })
+
+  it('confirms a restored model when the opened thread reported the same value', async () => {
+    const request = vi.fn(async () => ({
+      data: [{ model: 'gpt-live', displayName: 'GPT Live', isDefault: true }],
+      nextCursor: null
+    }))
+    const restored = {
+      connection: { request },
+      options: new Map([['model', 'gpt-unlisted']]),
+      reportedOptions: { model: 'gpt-unlisted' }
+    } as unknown as CodexSession
+
+    const result = await readLiveCodexSessionOptions(restored, undefined)
+    expect(result).toMatchObject({
+      current: { model: 'gpt-unlisted', confirmed: ['model'] }
+    })
+    const state = applyStructuredAgentSessionOptions(
+      createStructuredAgentSessionOptionState('codex'),
+      CODEX_SESSION_OPTION_CATALOG,
+      result
+    )
+    const model = structuredAgentSessionOptionSnapshot(state)[0]!
+    expect(model).toMatchObject({
+      valueSource: 'reported',
+      kind: { currentValue: 'gpt-unlisted' }
+    })
+    expect(model.kind.type === 'select' ? model.kind.choices : []).not.toContainEqual(
+      expect.objectContaining({ value: 'gpt-unlisted' })
+    )
   })
 
   it('does not confirm a model it substituted rather than read', async () => {
@@ -221,6 +265,31 @@ describe('structured Codex session options', () => {
     await expect(
       applyCodexStructuredSessionOption(session, 'model', 'gpt-fast', undefined)
     ).resolves.toEqual({ model: 'gpt-fast', effort: 'low' })
+  })
+
+  it('applies a catalog-safe effort to a running unlisted model', async () => {
+    const session = optionSession(
+      vi.fn(async () => ({
+        data: [{ model: 'gpt-live', supportedReasoningEfforts: [{ reasoningEffort: 'high' }] }],
+        nextCursor: null
+      }))
+    )
+    session.reportedOptions = { model: 'gpt-unlisted', effort: 'medium' }
+    const result = await readLiveCodexSessionOptions(session, undefined)
+    const state = applyStructuredAgentSessionOptions(
+      createStructuredAgentSessionOptionState('codex'),
+      CODEX_SESSION_OPTION_CATALOG,
+      result
+    )
+    expect(canSetStructuredAgentSessionOption(state, 'effort', 'high')).toBe(true)
+
+    await expect(
+      applyCodexStructuredSessionOption(session, 'effort', 'high', undefined)
+    ).resolves.toEqual({ model: 'gpt-unlisted', effort: 'high' })
+    expect(session.reportedOptions).toEqual({ model: 'gpt-unlisted' })
+    await expect(readLiveCodexSessionOptions(session, undefined)).resolves.toMatchObject({
+      current: { model: 'gpt-unlisted', effort: 'high', confirmed: ['model'] }
+    })
   })
 
   it('rejects values absent from the provider catalog', async () => {

--- a/src/main/codex/codex-structured-session-options.ts
+++ b/src/main/codex/codex-structured-session-options.ts
@@ -102,14 +102,8 @@ export async function readCodexStructuredSessionOptions(input: {
       break
     }
   }
-  if (input.current.model && !models.some((model) => model.id === input.current.model)) {
-    models.push({
-      id: input.current.model,
-      label: input.current.model,
-      isDefault: false,
-      efforts: []
-    })
-  }
+  // `models` stays what `model/list` offered: a current id the account cannot select is
+  // still reported (the thread runs it) but never listed, so no raw id is offerable.
   const model = input.current.model ?? models.find((entry) => entry.isDefault)?.id ?? models[0]?.id
   if (!model) {
     throw new Error('codex app-server returned no available models')

--- a/src/main/codex/codex-structured-session-options.ts
+++ b/src/main/codex/codex-structured-session-options.ts
@@ -78,6 +78,9 @@ function modelOption(value: unknown): AgentSessionModelOption | null {
 export async function readCodexStructuredSessionOptions(input: {
   connection: Pick<CodexAppServerConnection, 'request'>
   current: { model?: string; effort?: string }
+  /** Ids in `current` that came from the thread's own state rather than from a value we
+   *  wrote. Only the caller knows which answered, so it must say. */
+  confirmed?: readonly string[]
   timeoutMs?: number
 }): Promise<AgentSessionOptionsResult> {
   const models: AgentSessionModelOption[] = []
@@ -108,9 +111,15 @@ export async function readCodexStructuredSessionOptions(input: {
   if (!model) {
     throw new Error('codex app-server returned no available models')
   }
+  // Never pass on a confirmation for a model this function substituted rather than read.
+  const confirmed = input.confirmed?.filter((id) => id !== 'model' || model === input.current.model)
   return {
     models,
-    current: { model, ...(input.current.effort ? { effort: input.current.effort } : {}) }
+    current: {
+      model,
+      ...(input.current.effort ? { effort: input.current.effort } : {}),
+      ...(confirmed?.length ? { confirmed } : {})
+    }
   }
 }
 
@@ -127,11 +136,21 @@ export function readLiveCodexSessionOptions(
   session: CodexSession,
   timeoutMs: number | undefined
 ): Promise<AgentSessionOptionsResult> {
-  const model = session.options.get('model') ?? session.reportedOptions.model
-  const effort = session.options.get('effort') ?? session.reportedOptions.effort
+  const pendingModel = session.options.get('model')
+  const pendingEffort = session.options.get('effort')
+  const model = pendingModel ?? session.reportedOptions.model
+  const effort = pendingEffort ?? session.reportedOptions.effort
+  // Why: `session.options` holds a restored pick or a write of ours the thread has not
+  // echoed — neither is the agent speaking. A value that fell through to the opened
+  // thread's own state is, which is what lets an unlisted model still be named.
+  const confirmed = [
+    ...(!pendingModel && model ? ['model'] : []),
+    ...(!pendingEffort && effort ? ['effort'] : [])
+  ]
   return readCodexStructuredSessionOptions({
     connection: session.connection,
     current: { ...(model ? { model } : {}), ...(effort ? { effort } : {}) },
+    ...(confirmed.length > 0 ? { confirmed } : {}),
     timeoutMs
   })
 }

--- a/src/main/codex/codex-structured-session-options.ts
+++ b/src/main/codex/codex-structured-session-options.ts
@@ -3,6 +3,8 @@ import type {
   AgentSessionOptionChoice,
   AgentSessionOptionsResult
 } from '../../shared/agent-session-wire'
+import { resolveCatalogModelOptions } from '../../shared/agent-session-option-catalog'
+import { CODEX_SESSION_OPTION_CATALOG } from '../../shared/agent-session-option-catalog-claude-codex'
 import type { CodexAppServerConnection } from './codex-app-server-connection'
 import type { CodexOpenedThread } from './codex-structured-thread-open'
 import type { CodexSession } from './codex-structured-session-state'
@@ -11,6 +13,19 @@ import { AgentSessionOptionRejectedError } from '../native-chat/agent-session-wi
 
 const MODEL_PAGE_LIMIT = 100
 const MAX_MODEL_PAGES = 20
+
+function supportedEfforts(
+  model: AgentSessionModelOption | undefined,
+  modelId: string
+): readonly AgentSessionOptionChoice[] {
+  if (model) {
+    return model.efforts
+  }
+  const fallback = resolveCatalogModelOptions(CODEX_SESSION_OPTION_CATALOG, [], modelId).find(
+    (option) => option.id === 'effort'
+  )
+  return fallback?.kind.type === 'select' ? fallback.kind.choices : []
+}
 
 export function restoredCodexSessionOptions(
   options: Readonly<Record<string, string>> | undefined
@@ -140,12 +155,12 @@ export function readLiveCodexSessionOptions(
   const pendingEffort = session.options.get('effort')
   const model = pendingModel ?? session.reportedOptions.model
   const effort = pendingEffort ?? session.reportedOptions.effort
-  // Why: `session.options` holds a restored pick or a write of ours the thread has not
-  // echoed — neither is the agent speaking. A value that fell through to the opened
-  // thread's own state is, which is what lets an unlisted model still be named.
+  // A matching restored override still has the opened thread's evidence. Successful
+  // writes clear that evidence below, so equality cannot reuse a stale report.
+  const modelConfirmed = Boolean(model && model === session.reportedOptions.model)
   const confirmed = [
-    ...(!pendingModel && model ? ['model'] : []),
-    ...(!pendingEffort && effort ? ['effort'] : [])
+    ...(modelConfirmed ? ['model'] : []),
+    ...(modelConfirmed && effort && effort === session.reportedOptions.effort ? ['effort'] : [])
   ]
   return readCodexStructuredSessionOptions({
     connection: session.connection,
@@ -193,19 +208,26 @@ async function applyValidatedCodexStructuredSessionOption(
   }
   const modelId = key === 'model' ? value : catalog.current.model
   const model = catalog.models.find((entry) => entry.id === modelId)
+  const efforts = supportedEfforts(model, modelId)
   const requestedEffort = key === 'effort' ? value : priorEffort
   if (
     key === 'effort' &&
-    (!model?.efforts.length || !model.efforts.some((effort) => effort.value === requestedEffort))
+    (!efforts.length || !efforts.some((effort) => effort.value === requestedEffort))
   ) {
     throw new Error(`codex app-server model ${modelId} does not support ${value}`)
   }
   const effort =
-    model?.efforts.length === 0
+    efforts.length === 0
       ? undefined
-      : (model?.efforts.find((entry) => entry.value === requestedEffort)?.value ??
+      : (efforts.find((entry) => entry.value === requestedEffort)?.value ??
         model?.defaultEffort ??
-        model?.efforts[0]?.value)
+        efforts[0]?.value)
+  if (key === 'model') {
+    delete session.reportedOptions.model
+    delete session.reportedOptions.effort
+  } else {
+    delete session.reportedOptions.effort
+  }
   session.options.set('model', modelId)
   if (effort) {
     session.options.set('effort', effort)

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -612,6 +612,31 @@ describe('native chat PTY session options', () => {
     ).not.toContain('future-model')
   })
 
+  it('still lets the terminal adjust a model it cannot name', async () => {
+    // New on this path: `main` fabricated the row with `options: []`, so an unlisted model
+    // was inert here while the structured transport could still adjust it. Both now draw
+    // the launch-safe set, and the model is offered as a choice on neither.
+    // This has to apply for real: a `settable: true` row the apply path cannot resolve
+    // renders a control that throws when clicked, which is worse than no control.
+    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'future-model' })
+    const dispatch = vi.fn()
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: dispatch
+    })!
+    expect(surface.getSnapshot().map(({ id }) => id)).toEqual(['model', 'effort'])
+
+    await surface.setOption('effort', 'high')
+
+    expect(dispatch).toHaveBeenCalledWith('/effort high')
+    expect(surface.getSnapshot().find(({ id }) => id === 'effort')).toMatchObject({
+      settable: true,
+      kind: { currentValue: 'high' }
+    })
+  })
+
   it('keeps a tracked alias selectable when the host catalog omits it', async () => {
     seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
       model: 'opus',

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -628,6 +628,12 @@ describe('native chat PTY session options', () => {
     })!
     expect(surface.getSnapshot().map(({ id }) => id)).toEqual(['model', 'effort'])
 
+    surface.recordOutgoingCommand('/effort low')
+    expect(surface.getSnapshot().find(({ id }) => id === 'effort')).toMatchObject({
+      valueSource: 'dispatched',
+      kind: { currentValue: 'low' }
+    })
+
     await surface.setOption('effort', 'high')
 
     expect(dispatch).toHaveBeenCalledWith('/effort high')

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -593,10 +593,11 @@ describe('native chat PTY session options', () => {
     expect(surface.getSnapshot()[0]).toMatchObject({ valueSource: 'unknown' })
   })
 
-  it('passes an unknown persisted model through as a literal choice', () => {
-    seedNativeChatAppliedSessionOptions('pty-1', 'claude', {
-      model: 'future-model'
-    })
+  it('withholds an unknown persisted model instead of offering it as a choice', () => {
+    // Was: a literal `{ value: id, label: id }` row. A launch flag the CLI never listed
+    // (`worker-start --model claude-opus-5`) names no model we can offer, so the pill
+    // reads `unknown` and the dropdown stays available-models-only.
+    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'future-model' })
     const surface = createNativeChatPtySessionOptions({
       agent: 'claude',
       scopeKey: 'pty-1',
@@ -604,10 +605,11 @@ describe('native chat PTY session options', () => {
       dispatchCommand: vi.fn()
     })!
     const model = surface.getSnapshot()[0]
-    expect(model.kind).toMatchObject({
-      currentValue: 'future-model',
-      choices: expect.arrayContaining([{ value: 'future-model', label: 'future-model' }])
-    })
+    expect(model).toMatchObject({ valueSource: 'unknown', kind: { type: 'select' } })
+    expect(model.kind.type === 'select' ? model.kind.currentValue : 'set').toBeUndefined()
+    expect(
+      model.kind.type === 'select' ? model.kind.choices.map(({ value }) => value) : []
+    ).not.toContain('future-model')
   })
 
   it('keeps a tracked alias selectable when the host catalog omits it', async () => {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -1,6 +1,6 @@
 import {
   findCatalogModel,
-  findCatalogOption,
+  resolveCatalogModelOptions,
   type AgentSessionOptionCatalog,
   type CatalogMidSessionApply,
   type CatalogModel,
@@ -72,8 +72,11 @@ function currentApply(
   if (optionId === 'model') {
     return { apply: ctx.catalog.modelApply, modelId }
   }
-  const model = modelId ? findCatalogModel({ ...ctx.catalog, models }, modelId) : undefined
-  const option = findCatalogOption(model, optionId)
+  // Why: the snapshot draws an unlisted model's rows from the launch-safe set, so
+  // resolving through the model list alone would reject the very rows it rendered.
+  const option = resolveCatalogModelOptions(ctx.catalog, models, modelId).find(
+    (candidate) => candidate.id === optionId
+  )
   return option ? { apply: option.apply, modelId } : null
 }
 

--- a/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
@@ -96,7 +96,9 @@ describe('nativeChatModelPillLabel', () => {
 
   it('falls back to the raw id when the list no longer offers it', () => {
     // A discovered list can drop an id the record still tracks; showing the id beats
-    // showing "Model" while a real model is running.
+    // showing "Model" while a real model is running. Not a hand-fed shape: this is
+    // exactly what the builder emits for a reported-but-unlisted model — the test
+    // above drives the same descriptor through `buildNativeChatSessionOptionSnapshot`.
     expect(nativeChatModelPillLabel(modelDescriptor('reported', 'grok-build'))).toBe('grok-build')
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
@@ -55,7 +55,8 @@ describe('nativeChatModelPillLabel', () => {
     // the seed carries, so the composer's pill must read the neutral category rather
     // than echoing back the string the launch was typed with.
     const record = createNativeChatSessionOptionRecord('claude')
-    record.model = { value: 'claude-opus-5', source: 'reported' }
+    // `applied` is what seedNativeChatAppliedSessionOptions writes for a launch flag.
+    record.model = { value: 'claude-opus-5', source: 'applied' }
     const snapshot = buildNativeChatSessionOptionSnapshot({
       catalog: CLAUDE_SESSION_OPTION_CATALOG,
       models: withTrackedNativeChatModel(
@@ -70,6 +71,27 @@ describe('nativeChatModelPillLabel', () => {
     })
 
     expect(nativeChatModelPillLabel(snapshot[0]!)).toBe('Model')
+  })
+
+  it('names a reported model the list cannot carry, end to end from the builder', () => {
+    // The other half of the rule: Claude's own header named this model, so the pill shows
+    // it even though no catalog carries it and the dropdown cannot offer it.
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.model = { value: 'my-custom-model', source: 'reported' }
+    const snapshot = buildNativeChatSessionOptionSnapshot({
+      catalog: CLAUDE_SESSION_OPTION_CATALOG,
+      models: withTrackedNativeChatModel(
+        CLAUDE_SESSION_OPTION_CATALOG,
+        CLAUDE_SESSION_OPTION_CATALOG.models,
+        record
+      ),
+      record,
+      mode: 'live',
+      modelLabel: 'Model',
+      liveTransport: 'catalog'
+    })
+
+    expect(nativeChatModelPillLabel(snapshot[0]!)).toBe('my-custom-model')
   })
 
   it('falls back to the raw id when the list no longer offers it', () => {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
@@ -5,6 +5,12 @@ import {
   nativeChatSessionChoiceLabel
 } from './native-chat-session-option-labels'
 import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
+import { CLAUDE_SESSION_OPTION_CATALOG } from '../../../../shared/agent-session-option-catalog-claude-codex'
+import {
+  buildNativeChatSessionOptionSnapshot,
+  withTrackedNativeChatModel
+} from '../../../../shared/native-chat-session-option-snapshot'
+import { createNativeChatSessionOptionRecord } from '../../../../shared/native-chat-session-option-state'
 
 vi.mock('@/i18n/i18n', () => ({
   translate: vi.fn((_key: string, fallback: string) => fallback)
@@ -42,6 +48,28 @@ describe('nativeChatModelPillLabel', () => {
   it('withholds a value it has no evidence for', () => {
     expect(nativeChatModelPillLabel(modelDescriptor('unknown', 'grok-4.5'))).toBe('Model')
     expect(nativeChatModelPillLabel(modelDescriptor('default'))).toBe('Model')
+  })
+
+  it('withholds a launch flag no list carried, end to end from the builder', () => {
+    // `worker-start --model claude-opus-5` tracks an id neither the discovered list nor
+    // the seed carries, so the composer's pill must read the neutral category rather
+    // than echoing back the string the launch was typed with.
+    const record = createNativeChatSessionOptionRecord('claude')
+    record.model = { value: 'claude-opus-5', source: 'reported' }
+    const snapshot = buildNativeChatSessionOptionSnapshot({
+      catalog: CLAUDE_SESSION_OPTION_CATALOG,
+      models: withTrackedNativeChatModel(
+        CLAUDE_SESSION_OPTION_CATALOG,
+        CLAUDE_SESSION_OPTION_CATALOG.models,
+        record
+      ),
+      record,
+      mode: 'live',
+      modelLabel: 'Model',
+      liveTransport: 'catalog'
+    })
+
+    expect(nativeChatModelPillLabel(snapshot[0]!)).toBe('Model')
   })
 
   it('falls back to the raw id when the list no longer offers it', () => {

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -54,6 +54,21 @@ export function findCatalogOption(
   return model?.options.find((option) => option.id === optionId)
 }
 
+/** The options an id draws: the listed model's own, or the launch-safe set for an id no
+ *  list carries. Mirrors `resolveAgentSessionOptionLaunch`, so the picker offers exactly
+ *  the options a launch of that id would resolve. Shared because the snapshot that renders
+ *  a row and the apply path that services it must never disagree about which rows exist. */
+export function resolveCatalogModelOptions(
+  catalog: AgentSessionOptionCatalog,
+  models: readonly CatalogModel[],
+  modelId: string | null
+): readonly CatalogOption[] {
+  if (!modelId) {
+    return []
+  }
+  return models.find((model) => model.id === modelId)?.options ?? catalog.unknownModelOptions ?? []
+}
+
 /** Merge live rows over the static seed while retaining cataloged option mappings. */
 export function mergeCatalogModels(
   seed: readonly CatalogModel[],

--- a/src/shared/native-chat-session-option-commands.ts
+++ b/src/shared/native-chat-session-option-commands.ts
@@ -1,8 +1,9 @@
-import type {
-  AgentSessionOptionCatalog,
-  CatalogMidSessionApply,
-  CatalogModel,
-  CatalogOptionApply
+import {
+  resolveCatalogModelOptions,
+  type AgentSessionOptionCatalog,
+  type CatalogMidSessionApply,
+  type CatalogModel,
+  type CatalogOptionApply
 } from './agent-session-option-catalog'
 import type { SessionOptionValue } from './native-chat-session-options'
 import {
@@ -175,8 +176,7 @@ export function recordNativeChatSessionOptionCommand(args: {
   })
   // Re-resolved: the command above may have just tracked a model.
   const modelId = resolveEffectiveNativeChatModelId(catalog, models, record)
-  const model = modelId ? models.find((candidate) => candidate.id === modelId) : undefined
-  for (const option of model?.options ?? []) {
+  for (const option of resolveCatalogModelOptions(catalog, models, modelId)) {
     opensAgentPicker =
       opensAgentPicker || isSessionOptionAgentPickerCommand(option.apply.midSession, command)
     changed =

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -140,7 +140,9 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       modelLabel: 'Model',
       liveTransport: 'agent-session'
     })
-    expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model'])
+    // An empty list takes the choices, not the effort picker: the thread still runs a model.
+    expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model', 'effort'])
+    expect(snapshot[1]).toMatchObject({ settable: true })
     const model = snapshot[0]!
     // No id is offerable, and the raw one never reaches the trigger.
     expect(model.kind.type === 'select' ? model.kind.choices : null).toEqual([])
@@ -236,8 +238,11 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       expect(model).toMatchObject({ valueSource: 'unknown' })
       expect(model.kind.currentValue).toBeUndefined()
       expect(model.kind.choices.some((choice) => choice.value === 'claude-opus-5')).toBe(false)
-      // Restoring this session's effort row from `unknownModelOptions` is a follow-up.
-      expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model'])
+      // The session still runs that model, so its options stay settable off the catalog's
+      // launch-safe set. Unnameable is not unadjustable.
+      expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model', 'effort'])
+      expect(snapshot[1]).toMatchObject({ settable: true })
+      expect(CLAUDE_SESSION_OPTION_CATALOG.unknownModelOptions?.[0]?.id).toBe('effort')
     })
 
     it('names an unlisted model the agent reported, without offering it as a choice', () => {

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -104,9 +104,12 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
     expect(model.kind.choices.map((choice) => choice.value)).toEqual(
       CLAUDE_SESSION_OPTION_CATALOG.models.map((catalogModel) => catalogModel.id)
     )
+    // Nor does it name one it cannot offer: the trigger would show a raw id.
+    expect(model.kind.currentValue).toBeUndefined()
+    expect(model).toMatchObject({ valueSource: 'unknown' })
   })
 
-  it('is empty when the model list is empty', () => {
+  it('is empty when the model list is empty and nothing is tracked', () => {
     expect(
       buildNativeChatSessionOptionSnapshot({
         catalog: CLAUDE_SESSION_OPTION_CATALOG,
@@ -117,6 +120,27 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
         liveTransport: 'catalog'
       })
     ).toEqual([])
+  })
+
+  it('keeps the model row when the provider listed no models at all', () => {
+    // A restored Codex thread whose `model/list` came back empty still runs a model —
+    // `readCodexStructuredSessionOptions` refuses only when nothing resolves at all — so
+    // the row has to survive the blank picker instead of taking the pill with it.
+    const record = createNativeChatSessionOptionRecord('codex')
+    record.model = { value: 'gpt-5.9-secret', source: 'reported' }
+    const snapshot = buildNativeChatSessionOptionSnapshot({
+      catalog: { ...CODEX_SESSION_OPTION_CATALOG, models: [], defaultModelIsCliDefault: true },
+      models: [],
+      record,
+      mode: 'live',
+      modelLabel: 'Model',
+      liveTransport: 'agent-session'
+    })
+    expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model'])
+    const model = snapshot[0]!
+    // No id is offerable, and the raw one never reaches the trigger.
+    expect(model.kind.type === 'select' ? model.kind.choices : null).toEqual([])
+    expect(model).toMatchObject({ valueSource: 'unknown' })
   })
 
   describe('sortNativeChatSessionOptions', () => {
@@ -178,19 +202,37 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       expect(snapshot.length).toBeGreaterThan(1)
     })
 
-    it('labels a wholly unknown tracked model by its id rather than dropping it', () => {
+    it('offers no row for a tracked id neither the discovered list nor the seed carries', () => {
+      // Was: a fabricated `{ id, label: id, options: [] }` row, which put a raw launch
+      // flag (`worker-start --model claude-opus-5`) in the picker and in the pill as
+      // though the CLI had listed it. Only available models may be offered or named.
       const record = claudeRecord()
-      record.model = { value: 'experimental-model', source: 'reported' }
+      record.model = { value: 'claude-opus-5', source: 'reported' }
       const reconciled = withTrackedNativeChatModel(
         CLAUDE_SESSION_OPTION_CATALOG,
         CLAUDE_SESSION_OPTION_CATALOG.models,
         record
       )
-      expect(reconciled.at(-1)).toEqual({
-        id: 'experimental-model',
-        label: 'experimental-model',
-        options: []
+      expect(reconciled).toEqual([...CLAUDE_SESSION_OPTION_CATALOG.models])
+
+      const snapshot = buildNativeChatSessionOptionSnapshot({
+        catalog: CLAUDE_SESSION_OPTION_CATALOG,
+        models: reconciled,
+        record,
+        mode: 'live',
+        modelLabel: 'Model',
+        liveTransport: 'catalog'
       })
+      const model = snapshot[0]!
+      if (model.kind.type !== 'select') {
+        throw new Error('model descriptor must be a select')
+      }
+      // `unknown` is what nativeChatModelPillLabel reads to render the neutral "Model".
+      expect(model).toMatchObject({ valueSource: 'unknown' })
+      expect(model.kind.currentValue).toBeUndefined()
+      expect(model.kind.choices.some((choice) => choice.value === 'claude-opus-5')).toBe(false)
+      // Restoring this session's effort row from `unknownModelOptions` is a follow-up.
+      expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model'])
     })
 
     it('leaves the list alone when the tracked model is already listed', () => {

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -11,6 +11,7 @@ import {
 import { GROK_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-grok'
 import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
 import {
+  applyNativeChatReportedSessionOptions,
   createNativeChatSessionOptionRecord,
   type NativeChatSessionOptionRecord
 } from './native-chat-session-option-state'
@@ -88,7 +89,8 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
     // The builder no longer appends the tracked model itself — reconciling it is
     // the caller's job (withTrackedNativeChatModel), so every row is a real choice.
     const record = claudeRecord()
-    record.model = { value: 'experimental-model', source: 'reported' }
+    // `applied`, not `reported`: an unconfirmed pick is the case that is withheld.
+    record.model = { value: 'experimental-model', source: 'applied' }
     const snapshot = buildNativeChatSessionOptionSnapshot({
       catalog: CLAUDE_SESSION_OPTION_CATALOG,
       models: CLAUDE_SESSION_OPTION_CATALOG.models,
@@ -127,7 +129,9 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
     // `readCodexStructuredSessionOptions` refuses only when nothing resolves at all — so
     // the row has to survive the blank picker instead of taking the pill with it.
     const record = createNativeChatSessionOptionRecord('codex')
-    record.model = { value: 'gpt-5.9-secret', source: 'reported' }
+    // What `applyStructuredAgentSessionOptions` actually writes for Codex, whose reader
+    // emits no `confirmed` ids — so this id is unconfirmed and stays unnamed.
+    record.model = { value: 'gpt-5.9-secret', source: 'dispatched' }
     const snapshot = buildNativeChatSessionOptionSnapshot({
       catalog: { ...CODEX_SESSION_OPTION_CATALOG, models: [], defaultModelIsCliDefault: true },
       models: [],
@@ -207,7 +211,8 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       // flag (`worker-start --model claude-opus-5`) in the picker and in the pill as
       // though the CLI had listed it. Only available models may be offered or named.
       const record = claudeRecord()
-      record.model = { value: 'claude-opus-5', source: 'reported' }
+      // `applied` is what a launch flag lands as; see the reported case below.
+      record.model = { value: 'claude-opus-5', source: 'applied' }
       const reconciled = withTrackedNativeChatModel(
         CLAUDE_SESSION_OPTION_CATALOG,
         CLAUDE_SESSION_OPTION_CATALOG.models,
@@ -233,6 +238,60 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
       expect(model.kind.choices.some((choice) => choice.value === 'claude-opus-5')).toBe(false)
       // Restoring this session's effort row from `unknownModelOptions` is a follow-up.
       expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model'])
+    })
+
+    it('names an unlisted model the agent reported, without offering it as a choice', () => {
+      // Claude prints a custom model in its own header, and the screen parser passes that
+      // raw name through (claude-terminal-session-options: a custom model reports no
+      // effort but keeps its name). That is the model actually running, so it is named —
+      // it just stays unpickable, because the picker only offers available models.
+      const record = claudeRecord()
+      record.model = { value: 'my-custom-model', source: 'reported' }
+      const snapshot = buildNativeChatSessionOptionSnapshot({
+        catalog: CLAUDE_SESSION_OPTION_CATALOG,
+        models: withTrackedNativeChatModel(
+          CLAUDE_SESSION_OPTION_CATALOG,
+          CLAUDE_SESSION_OPTION_CATALOG.models,
+          record
+        ),
+        record,
+        mode: 'live',
+        modelLabel: 'Model',
+        liveTransport: 'catalog'
+      })
+      const model = snapshot[0]!
+      if (model.kind.type !== 'select') {
+        throw new Error('model descriptor must be a select')
+      }
+      expect(model).toMatchObject({ valueSource: 'reported' })
+      expect(model.kind.currentValue).toBe('my-custom-model')
+      expect(model.kind.choices.some((choice) => choice.value === 'my-custom-model')).toBe(false)
+    })
+
+    it('withholds the same id until an agent confirms it', () => {
+      // The transition the rule exists for: `worker-start --model my-custom-model` lands
+      // unconfirmed and is not named, then Claude's header confirms what is running.
+      const record = claudeRecord()
+      const pill = (): SessionOptionDescriptor =>
+        buildNativeChatSessionOptionSnapshot({
+          catalog: CLAUDE_SESSION_OPTION_CATALOG,
+          models: CLAUDE_SESSION_OPTION_CATALOG.models,
+          record,
+          mode: 'live',
+          modelLabel: 'Model',
+          liveTransport: 'catalog'
+        })[0]!
+
+      record.model = { value: 'my-custom-model', source: 'dispatched' }
+      const before = pill()
+      expect(before).toMatchObject({ valueSource: 'unknown' })
+      expect(before.kind.type === 'select' ? before.kind.currentValue : 'set').toBeUndefined()
+
+      applyNativeChatReportedSessionOptions(record, { model: 'my-custom-model' })
+      expect(record.model).toEqual({ value: 'my-custom-model', source: 'reported' })
+      const after = pill()
+      expect(after).toMatchObject({ valueSource: 'reported' })
+      expect(after.kind.type === 'select' ? after.kind.currentValue : null).toBe('my-custom-model')
     })
 
     it('leaves the list alone when the tracked model is already listed', () => {

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -264,7 +264,11 @@ export function buildNativeChatSessionOptionSnapshot(args: {
     return snapshot
   }
   const trackedValues = record.valuesByModel[effectiveModelId] ?? {}
-  for (const option of listedModel?.options ?? []) {
+  // Why: an unlisted model still runs, so its options come from the catalog's launch-safe
+  // set rather than leaving the session unadjustable — the same fallback the launch
+  // resolver already applies (see agent-session-option-launch). Options, not choices: the
+  // model stays absent from `modelChoices` either way.
+  for (const option of listedModel?.options ?? catalog.unknownModelOptions ?? []) {
     const descriptor = optionDescriptor({
       option,
       tracked: trackedValues[option.id],

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -231,8 +231,12 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   const listedModel = models.find((candidate) => candidate.id === effectiveModelId)
   // Why: an id the picker cannot offer is still nameable when the agent itself reported
   // it — a custom model, or one newer than this catalog, is what the session is actually
-  // running. Only an unconfirmed id (a launch flag, a typed value) is withheld, so the
-  // pill never echoes back input no agent has stood behind.
+  // running. Only an unconfirmed id (a launch flag lands `applied`, a typed pick
+  // `dispatched`) is withheld, so the pill never echoes back input no agent stood behind.
+  // `reported` proves only that we read the value off the agent, not that the agent
+  // acknowledged a write of ours: the PTY path omits `confirmed` entirely, which makes
+  // every scraped value `reported`. That is the right reading for a header scrape — the
+  // CLI renders what it is running — but it is not an acknowledgement.
   const nameableModelId =
     listedModel || modelTracked?.source === 'reported' ? effectiveModelId : null
   const modelAction = actionForApply(catalog.modelApply, modelTracked, mode, liveTransport)

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -1,8 +1,9 @@
-import type {
-  AgentSessionOptionCatalog,
-  CatalogMidSessionApply,
-  CatalogModel,
-  CatalogOption
+import {
+  resolveCatalogModelOptions,
+  type AgentSessionOptionCatalog,
+  type CatalogMidSessionApply,
+  type CatalogModel,
+  type CatalogOption
 } from './agent-session-option-catalog'
 import type {
   NativeChatLiveOptionTransport,
@@ -265,10 +266,9 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   }
   const trackedValues = record.valuesByModel[effectiveModelId] ?? {}
   // Why: an unlisted model still runs, so its options come from the catalog's launch-safe
-  // set rather than leaving the session unadjustable — the same fallback the launch
-  // resolver already applies (see agent-session-option-launch). Options, not choices: the
-  // model stays absent from `modelChoices` either way.
-  for (const option of listedModel?.options ?? catalog.unknownModelOptions ?? []) {
+  // set rather than leaving the session unadjustable. Options, not choices: the model
+  // stays absent from `modelChoices` either way.
+  for (const option of resolveCatalogModelOptions(catalog, models, effectiveModelId)) {
     const descriptor = optionDescriptor({
       option,
       tracked: trackedValues[option.id],

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -157,9 +157,10 @@ export function sortNativeChatSessionOptions(
 }
 
 /**
- * Why: the tracked model can sit outside the active list — a persisted default,
- * or an alias this host's CLI no longer lists. Keeping a row for it preserves
- * the labelled selection and the model's own options instead of blanking both.
+ * Why: an alias this host's CLI no longer lists is still a real, seeded model, so its
+ * seed row preserves the labelled selection and the model's own options instead of
+ * blanking both. An id neither list carries names no model we can offer — the picker
+ * lists only available models, so it gets no row at all.
  * Shared so mobile satisfies the same caller contract the desktop surface does.
  */
 export function withTrackedNativeChatModel(
@@ -172,7 +173,7 @@ export function withTrackedNativeChatModel(
     return [...models]
   }
   const seeded = catalog.models.find((model) => model.id === trackedId)
-  return [...models, seeded ?? { id: trackedId, label: trackedId, options: [] }]
+  return seeded ? [...models, seeded] : [...models]
 }
 
 /** Why: no tracked model means no `-m` was ever emitted, so the CLI is running its
@@ -210,21 +211,24 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   liveTransport: NativeChatLiveOptionTransport
 }): SessionOptionDescriptor[] {
   const { catalog, models, record, mode, modelLabel, liveTransport } = args
-  if (models.length === 0) {
+  const modelTracked = record.model
+  const trackedModelId = typeof modelTracked?.value === 'string' ? modelTracked.value : null
+  const defaultModelId = cliDefaultModelId(catalog, models, trackedModelId)
+  const effectiveModelId = trackedModelId ?? defaultModelId
+  // Why: an empty list is a provider that offered nothing, not a session without a model.
+  // A tracked id still names what the session runs, so its row survives the blank picker.
+  if (models.length === 0 && !effectiveModelId) {
     return []
   }
-  const modelTracked = record.model
-  // Why: callers reconcile the tracked model into `models` (see
-  // withTrackedNativeChatModel), so every listed row is a real choice and the
-  // trigger never shows a value without one.
+  // Why: every row is an available model — the catalog's or a probe's. A tracked id
+  // outside both (a raw launch flag, a stale persisted pick) names none of them, so it
+  // is never offered and never shown as the value.
   const modelChoices = models.map(({ id, label, description }) => ({
     value: id,
     label,
     ...(description ? { description } : {})
   }))
-  const trackedModelId = typeof modelTracked?.value === 'string' ? modelTracked.value : null
-  const defaultModelId = cliDefaultModelId(catalog, models, trackedModelId)
-  const effectiveModelId = trackedModelId ?? defaultModelId
+  const listedModel = models.find((candidate) => candidate.id === effectiveModelId)
   const modelAction = actionForApply(catalog.modelApply, modelTracked, mode, liveTransport)
   const snapshot: SessionOptionDescriptor[] = [
     {
@@ -233,10 +237,14 @@ export function buildNativeChatSessionOptionSnapshot(args: {
       category: 'model',
       kind: {
         type: 'select',
-        ...(effectiveModelId ? { currentValue: effectiveModelId } : {}),
+        ...(listedModel ? { currentValue: listedModel.id } : {}),
         choices: modelChoices
       },
-      valueSource: modelTracked?.source ?? (defaultModelId ? 'default' : 'unknown'),
+      // An unlisted id is tracked but unnameable: `unknown` is what the pill reads to
+      // withhold it, keeping the raw string out of the trigger.
+      valueSource: listedModel
+        ? (modelTracked?.source ?? (defaultModelId ? 'default' : 'unknown'))
+        : 'unknown',
       transport: liveTransport,
       ...settableState({ mode, liveTransport, apply: catalog.modelApply }),
       ...(modelAction ? { action: modelAction } : {})
@@ -245,9 +253,8 @@ export function buildNativeChatSessionOptionSnapshot(args: {
   if (!effectiveModelId) {
     return snapshot
   }
-  const model = models.find((candidate) => candidate.id === effectiveModelId)
   const trackedValues = record.valuesByModel[effectiveModelId] ?? {}
-  for (const option of model?.options ?? []) {
+  for (const option of listedModel?.options ?? []) {
     const descriptor = optionDescriptor({
       option,
       tracked: trackedValues[option.id],

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -221,14 +221,20 @@ export function buildNativeChatSessionOptionSnapshot(args: {
     return []
   }
   // Why: every row is an available model — the catalog's or a probe's. A tracked id
-  // outside both (a raw launch flag, a stale persisted pick) names none of them, so it
-  // is never offered and never shown as the value.
+  // outside both is never offered as a choice, whatever its provenance; whether it may
+  // still be *named* is a separate question, answered by `nameableModelId` below.
   const modelChoices = models.map(({ id, label, description }) => ({
     value: id,
     label,
     ...(description ? { description } : {})
   }))
   const listedModel = models.find((candidate) => candidate.id === effectiveModelId)
+  // Why: an id the picker cannot offer is still nameable when the agent itself reported
+  // it — a custom model, or one newer than this catalog, is what the session is actually
+  // running. Only an unconfirmed id (a launch flag, a typed value) is withheld, so the
+  // pill never echoes back input no agent has stood behind.
+  const nameableModelId =
+    listedModel || modelTracked?.source === 'reported' ? effectiveModelId : null
   const modelAction = actionForApply(catalog.modelApply, modelTracked, mode, liveTransport)
   const snapshot: SessionOptionDescriptor[] = [
     {
@@ -237,12 +243,12 @@ export function buildNativeChatSessionOptionSnapshot(args: {
       category: 'model',
       kind: {
         type: 'select',
-        ...(listedModel ? { currentValue: listedModel.id } : {}),
+        ...(nameableModelId ? { currentValue: nameableModelId } : {}),
         choices: modelChoices
       },
-      // An unlisted id is tracked but unnameable: `unknown` is what the pill reads to
-      // withhold it, keeping the raw string out of the trigger.
-      valueSource: listedModel
+      // `unknown` is what the pill reads to withhold a value, keeping an unconfirmed
+      // raw string out of the trigger. A reported one keeps its own provenance.
+      valueSource: nameableModelId
         ? (modelTracked?.source ?? (defaultModelId ? 'default' : 'unknown'))
         : 'unknown',
       transport: liveTransport,

--- a/src/shared/structured-agent-session-options.test.ts
+++ b/src/shared/structured-agent-session-options.test.ts
@@ -97,15 +97,28 @@ describe('structured agent session options', () => {
       { models: [], current: { model: 'gpt-5.9-secret' } }
     )
 
-    // Codex's reader emits no `confirmed` ids, so even a model the thread genuinely runs
-    // records as `dispatched`, not `reported` — which is why the name stays withheld here
-    // while the equivalent Claude case is named. Pinned so that when the reader starts
-    // confirming, this reddens and the name can be turned on deliberately.
+    // Unconfirmed: a pick restored from a previous session, which the thread has not
+    // echoed. An empty list must not promote it to a name it was never owed.
     expect(state.record.model).toEqual({ value: 'gpt-5.9-secret', source: 'dispatched' })
     const snapshot = structuredAgentSessionOptionSnapshot(state)
     expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model'])
     const model = snapshot[0]
     expect(model).toMatchObject({ valueSource: 'unknown' })
+    expect(model.kind.type === 'select' ? model.kind.choices : null).toEqual([])
+  })
+
+  it('names the model an empty-listing provider reported, without offering it', () => {
+    // The regression this rule exists to prevent: a thread whose `model/list` came back
+    // empty still runs a model and says so, so the pill must name it rather than blank.
+    const state = applyStructuredAgentSessionOptions(
+      createStructuredAgentSessionOptionState('codex'),
+      CODEX_SESSION_OPTION_CATALOG,
+      { models: [], current: { model: 'gpt-5.9-secret', confirmed: ['model'] } }
+    )
+
+    const model = structuredAgentSessionOptionSnapshot(state)[0]
+    expect(model).toMatchObject({ valueSource: 'reported' })
+    expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBe('gpt-5.9-secret')
     expect(model.kind.type === 'select' ? model.kind.choices : null).toEqual([])
   })
 

--- a/src/shared/structured-agent-session-options.test.ts
+++ b/src/shared/structured-agent-session-options.test.ts
@@ -4,6 +4,7 @@ import { buildNativeChatSessionOptionSnapshot } from './native-chat-session-opti
 import { createNativeChatSessionOptionRecord } from './native-chat-session-option-state'
 import {
   applyStructuredAgentSessionOptions,
+  commitStructuredAgentSessionOptionValues,
   createStructuredAgentSessionOptionState,
   structuredAgentSessionOptionSnapshot
 } from './structured-agent-session-options'
@@ -127,6 +128,35 @@ describe('structured agent session options', () => {
     expect(model).toMatchObject({ valueSource: 'reported' })
     expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBe('gpt-5.9-secret')
     expect(model.kind.type === 'select' ? model.kind.choices : null).toEqual([])
+  })
+
+  it('keeps an unchanged model reported when committing an effort write', () => {
+    const reported = applyStructuredAgentSessionOptions(
+      createStructuredAgentSessionOptionState('codex'),
+      CODEX_SESSION_OPTION_CATALOG,
+      {
+        models: [],
+        current: {
+          model: 'gpt-5.9-secret',
+          effort: 'medium',
+          confirmed: ['model', 'effort']
+        }
+      }
+    )
+
+    const committed = commitStructuredAgentSessionOptionValues(reported, {
+      model: 'gpt-5.9-secret',
+      effort: 'high'
+    })
+    expect(committed.record.model).toEqual({ value: 'gpt-5.9-secret', source: 'reported' })
+    expect(committed.record.valuesByModel['gpt-5.9-secret']?.effort).toEqual({
+      value: 'high',
+      source: 'dispatched'
+    })
+    expect(structuredAgentSessionOptionSnapshot(committed)[0]).toMatchObject({
+      valueSource: 'reported',
+      kind: { currentValue: 'gpt-5.9-secret' }
+    })
   })
 
   it('projects live options as directly settable descriptors', () => {

--- a/src/shared/structured-agent-session-options.test.ts
+++ b/src/shared/structured-agent-session-options.test.ts
@@ -61,7 +61,7 @@ describe('structured agent session options', () => {
     })
   })
 
-  it('uses provider-scoped models and retains the current unknown id', () => {
+  it('uses provider-scoped models and withholds a current id they do not carry', () => {
     const state = applyStructuredAgentSessionOptions(
       createStructuredAgentSessionOptionState('codex'),
       CODEX_SESSION_OPTION_CATALOG,
@@ -77,11 +77,31 @@ describe('structured agent session options', () => {
         current: { model: 'persisted-unknown' }
       }
     )
+    // Was: a fabricated `persisted-unknown` choice. The provider never listed that id, so
+    // it is tracked as the model the thread runs, but never offered and never named.
     const model = structuredAgentSessionOptionSnapshot(state)[0]
     expect(
       model.kind.type === 'select' ? model.kind.choices.map((choice) => choice.value) : []
-    ).toEqual(['account-model', 'persisted-unknown'])
-    expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBe('persisted-unknown')
+    ).toEqual(['account-model'])
+    expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBeUndefined()
+    expect(model).toMatchObject({ valueSource: 'unknown' })
+  })
+
+  it('keeps the model row when the provider lists no models at all', () => {
+    // `readCodexStructuredSessionOptions` throws only when no model resolves at all, so an
+    // empty `model/list` on a restored thread reaches here with a current model. Fabricating
+    // a row used to hide that; without one the snapshot must not blank the pill.
+    const state = applyStructuredAgentSessionOptions(
+      createStructuredAgentSessionOptionState('codex'),
+      CODEX_SESSION_OPTION_CATALOG,
+      { models: [], current: { model: 'gpt-5.9-secret' } }
+    )
+
+    const snapshot = structuredAgentSessionOptionSnapshot(state)
+    expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model'])
+    const model = snapshot[0]
+    expect(model).toMatchObject({ valueSource: 'unknown' })
+    expect(model.kind.type === 'select' ? model.kind.choices : null).toEqual([])
   })
 
   it('projects live options as directly settable descriptors', () => {

--- a/src/shared/structured-agent-session-options.test.ts
+++ b/src/shared/structured-agent-session-options.test.ts
@@ -79,12 +79,18 @@ describe('structured agent session options', () => {
     )
     // Was: a fabricated `persisted-unknown` choice. The provider never listed that id, so
     // it is tracked as the model the thread runs, but never offered and never named.
-    const model = structuredAgentSessionOptionSnapshot(state)[0]
+    const snapshot = structuredAgentSessionOptionSnapshot(state)
+    const model = snapshot[0]
     expect(
       model.kind.type === 'select' ? model.kind.choices.map((choice) => choice.value) : []
     ).toEqual(['account-model'])
     expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBeUndefined()
     expect(model).toMatchObject({ valueSource: 'unknown' })
+    // Unnameable, but the thread still runs it, so effort stays settable off the catalog.
+    expect(snapshot.find((descriptor) => descriptor.id === 'effort')).toMatchObject({
+      settable: true,
+      kind: { type: 'select' }
+    })
   })
 
   it('keeps the model row when the provider lists no models at all', () => {
@@ -101,7 +107,8 @@ describe('structured agent session options', () => {
     // echoed. An empty list must not promote it to a name it was never owed.
     expect(state.record.model).toEqual({ value: 'gpt-5.9-secret', source: 'dispatched' })
     const snapshot = structuredAgentSessionOptionSnapshot(state)
-    expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model'])
+    expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model', 'effort'])
+    expect(snapshot[1]).toMatchObject({ settable: true })
     const model = snapshot[0]
     expect(model).toMatchObject({ valueSource: 'unknown' })
     expect(model.kind.type === 'select' ? model.kind.choices : null).toEqual([])

--- a/src/shared/structured-agent-session-options.test.ts
+++ b/src/shared/structured-agent-session-options.test.ts
@@ -97,6 +97,11 @@ describe('structured agent session options', () => {
       { models: [], current: { model: 'gpt-5.9-secret' } }
     )
 
+    // Codex's reader emits no `confirmed` ids, so even a model the thread genuinely runs
+    // records as `dispatched`, not `reported` — which is why the name stays withheld here
+    // while the equivalent Claude case is named. Pinned so that when the reader starts
+    // confirming, this reddens and the name can be turned on deliberately.
+    expect(state.record.model).toEqual({ value: 'gpt-5.9-secret', source: 'dispatched' })
     const snapshot = structuredAgentSessionOptionSnapshot(state)
     expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model'])
     const model = snapshot[0]

--- a/src/shared/structured-agent-session-options.ts
+++ b/src/shared/structured-agent-session-options.ts
@@ -49,14 +49,10 @@ export function structuredAgentSessionOptionCatalog(
   seed: AgentSessionOptionCatalog,
   result: AgentSessionOptionsResult
 ): AgentSessionOptionCatalog {
+  // Why: only ids the provider lists may be offered. An unlisted `current.model` still
+  // reaches the snapshot through the record, which draws it as tracked-but-unmatched —
+  // a neutral pill — instead of a raw-id row.
   const models: CatalogModel[] = result.models.map(discoveredModel)
-  if (!models.some((model) => model.id === result.current.model)) {
-    models.push({
-      id: result.current.model,
-      label: result.current.model,
-      options: seed.unknownModelOptions ?? []
-    })
-  }
   return { ...seed, models, defaultModelIsCliDefault: true }
 }
 

--- a/src/shared/structured-agent-session-options.ts
+++ b/src/shared/structured-agent-session-options.ts
@@ -10,6 +10,7 @@ import {
 import {
   applyNativeChatReportedSessionOptions,
   createNativeChatSessionOptionRecord,
+  getTrackedSessionOption,
   setTrackedSessionOption,
   type NativeChatSessionOptionRecord
 } from './native-chat-session-option-state'
@@ -128,7 +129,12 @@ export function commitStructuredAgentSessionOption(
     state.catalog.models,
     state.record
   )
-  setTrackedSessionOption(state.record, id, value, 'dispatched', effectiveModel)
+  const current =
+    id === 'model' ? state.record.model : getTrackedSessionOption(state.record, effectiveModel, id)
+  // A full commit response repeats unchanged values; keep any provider evidence they carry.
+  if (current?.value !== value) {
+    setTrackedSessionOption(state.record, id, value, 'dispatched', effectiveModel)
+  }
   return { ...state, pendingId: null }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​488 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​461 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​133 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​57 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 |

<!-- /orca-pr-loc -->

## What this changes

**The rule in one sentence: the native chat names a model when it is one of the available models, or when the agent itself reported it — and withholds only an unlisted id that no agent has confirmed.**

The native chat's model pill echoed back whatever model string a launch was given. Every layer that builds the picker appended a fabricated row for an id no list carried, so `worker-start --model claude-opus-5` made that raw flag **both** a selectable row in the model dropdown **and** the name on the pill — even though it is only the string the user typed, not evidence of what the agent is running.

The rule now has two halves, and they are separate questions:

**What may be offered as a choice:** only an available model — the catalog's, or one a host probe discovered. An unlisted id is never a pickable row, whatever its provenance.

**What may be shown as the name:** an available model, **or** any id whose record source is `reported` — i.e. one the agent itself confirmed. Only an *unconfirmed* unlisted id is withheld, and the pill then renders the neutral "Model" label.

That second half matters because the agent is the ground truth. Claude prints a custom model in its own header, and the screen parser passes that raw name through deliberately — `claude-terminal-session-options.ts` drops `effort` for a custom model while *keeping* its name, on the reasoning that a model with no catalog options is still a model that is running. Gating purely on the list would have inverted that: the neutral "Model" for a model Claude is displaying by name. A custom model, or one newer than Orca's catalog, is exactly where showing the real name matters most.

Provenance separates the two cases cleanly:

| Source | Written by | Unlisted id is… |
| --- | --- | --- |
| `applied` | `seedNativeChatAppliedSessionOptions` — a launch flag | withheld |
| `dispatched` | a pick sent but not yet confirmed | withheld |
| `reported` | `applyNativeChatReportedSessionOptions` — the agent's own report | **named** |

So `worker-start --model claude-opus-5` shows the neutral pill, and the real name appears the moment the agent reports one. Never the user's unconfirmed input; always the agent's confirmed truth.

Cases that were already correct and are untouched: an alias the host's CLI merely *stopped* listing is still re-added from the **seed** by `withTrackedNativeChatModel`, keeping its row, its name and its options; and a resolved id the CLI reports (`claude-opus-5[1m]`) still maps back onto the listed alias it belongs to (`opus[1m]`) through `currentModelId`, now pinned by a test. Both structured readers still report `current.model` unchanged — only what they *list* changed. In the Claude reader, `const model = currentModelId(...)` is computed before the deleted push, so the reported value is byte-identical.

One honest caveat: `reported` cannot distinguish "the agent told us" from "the agent echoed back what we sent it". For a header scrape that distinction does not matter — the CLI renders what it is actually running — and no code here claims the record can tell them apart.

## The Codex empty-list edge

Dropping the Codex fabrication makes `models: []` reachable alongside a truthy `current.model`: `readCodexStructuredSessionOptions` throws only when *no* model resolves at all, so a restored thread whose `model/list` comes back empty reaches the snapshot with a model in hand. `buildNativeChatSessionOptionSnapshot` short-circuited on `models.length === 0`, which would have blanked the pill entirely.

That is genuinely reachable, so this PR includes the minimal guard: the early return now also requires that nothing is tracked (`models.length === 0 && !effectiveModelId`). The model list is honestly empty and offers nothing, but the row survives. The model list is **not** floored on the seed catalog — that would offer models the account may not have, which is the opposite of the point of this PR.

## The second regression: the structured effort picker

`main`'s fabricated row was pushed by the **shared** catalog builder, and it carried options:

```ts
models.push({ id: result.current.model, label: result.current.model,
              options: seed.unknownModelOptions ?? [] })
```

So on `main` the snapshot's option loop found that row and emitted a settable effort descriptor. Removing the push left the loop reading `listedModel?.options ?? []` — empty for a model no list carries — and the structured path lost its effort picker.

Options now fall back to `catalog.unknownModelOptions`: the same set `main` reached through the fabricated row, and the same fallback `resolveAgentSessionOptionLaunch` already applies on `main` when it cannot resolve a model. Reaching it at the point the snapshot builds options, rather than through a row, keeps the two questions separate — the model is adjustable without ever entering `modelChoices`.

Probed on `origin/main` (prod files reconstructed byte-identically) and on this head, for an unlisted model:

| case | `main` | this PR |
| --- | --- | --- |
| structured, thread-reported | `gpt-unlisted` · `[model, effort]` | `gpt-unlisted` · `[model, effort]` |
| structured, restored pick | `gpt-unlisted` · `[model, effort]` | **`Model`** · `[model, effort]` |
| PTY, header scrape | `my-custom-model` · `[model]` | `my-custom-model` · `[model, **effort**]` |
| PTY, launch flag | `my-custom-model` · `[model]` | **`Model`** · `[model, **effort**]` |

The two bolded `Model` cells are the fix, not a loss: those are unconfirmed values the user supplied, which is exactly what this PR stops echoing. Every agent-confirmed name that worked on `main` still works.

**The PTY effort row is new, not restored.** `main` never had it: `withTrackedNativeChatModel` fabricated its row with `options: []`, so an unlisted model was inert on the terminal surface while the structured transport could still adjust it. The fallback lives in shared code and cannot sensibly be keyed on transport — that would encode the accident as a rule — so this PR removes the asymmetry rather than preserving it. If exact parity is preferred over the fix, this is the piece to object to.

Exposing that row required the apply path to resolve options the same way. `currentApply` resolved them through the model list alone, so for a model no list carries it returned nothing and threw `Unknown session option: effort` — the control rendered, claimed `settable: true`, and failed when clicked. Both sides now read a shared `resolveCatalogModelOptions`, so the set that renders a row and the set that services it cannot drift apart.

**Only the terminal surface needed that.** Structured sessions set options over the `agentSession.setOption` RPC (`use-structured-agent-session.ts:136`) and never reach `applySetOption`, which is why the structured half worked without it — and reverting the apply change reddens the terminal test alone, nothing structured.

**Audited the whole exposure:** `unknownModelOptions` carries exactly one entry, `effort`, and only for claude, codex and grok; gemini and cursor declare none and draw no rows for an unlisted model. Both entry points — `setOption` and the agent-picker `invokeAction` codex uses — go through `currentApply`, so one fix covers all of it.

## Files

| File | Change |
| --- | --- |
| `src/shared/native-chat-session-option-snapshot.ts` | Stop fabricating a row in `withTrackedNativeChatModel` (seed rows still re-added); name the model only when it is listed **or** agent-reported; source an unlisted model's options from `unknownModelOptions`; guard the empty-list early return |
| `src/shared/structured-agent-session-options.ts` | Stop fabricating a row for an unlisted `current.model` |
| `src/main/claude/claude-structured-session-options.ts` | Stop fabricating; `current.model` still reported unchanged |
| `src/main/codex/codex-structured-session-options.ts` | Stop fabricating; `current.model` still reported unchanged; report the thread's own confirmations |
| `src/shared/agent-session-option-catalog.ts` | Add `resolveCatalogModelOptions`, the single answer to "which options does this model draw" |
| `src/renderer/.../native-chat-session-option-apply.ts` | Resolve options through that same helper, so a rendered row can be applied |

Plus tests, including a new `claude-structured-session-options.test.ts`.

## Testing

117 tests across the 7 touched test files pass. Broader sweep over native-chat / session-option / Claude / Codex: 5564 passed, with one unrelated real-binary integration test (`claude-tui-resume-real-binary`) that fails on `ps` under parallel load and passes in isolation. All three typecheck projects exit 0, run sequentially. `oxlint` and `oxfmt --check` clean.

Every behavioural change was ablated by hand at the final head — production change reverted, tests confirmed RED, change restored, restore verified by grep:

| Lever reverted | RED | Proves |
| --- | --- | --- |
| `withTrackedNativeChatModel` fabrication | 4 | an unlisted id gets no seed-fabricated row |
| Whole display gate (name every effective id) | 8 | the gate exists at all |
| Provenance branch removed (name only listed ids) | 3 | a reported id **is** named |
| **Provenance predicate dropped (name any tracked id)** | **8** | the `=== 'reported'` test is load-bearing: the four unconfirmed-unlisted cases go from withheld to named |
| Empty-list early-return guard | 2 | the row survives an empty provider list |
| Shared structured catalog fabrication | 2 | unlisted `current.model` gets no row |
| Claude reader fabrication | 2 | unlisted current model reported, not listed |
| Codex reader fabrication | 1 | unlisted current model reported, not listed |
| Codex thread confirmation dropped | 1 | the reader must distinguish thread state from a restored pick |
| Codex confirms blindly (no substitution filter) | 1 | a substituted default is never passed on as confirmed |
| Unlisted model loses `unknownModelOptions` | 5 | an unlisted model stays adjustable, on both surfaces |
| Apply path resolves options through the model list alone | 1 | the rendered row can actually be applied (terminal only) |

The fourth lever is the one that proves the rule is not vacuous: replacing `source === 'reported'` with a bare truthiness check reddens every withheld case, so the comparison is doing real work rather than decorating a condition that would hold anyway.

## Codex had to report its confirmations, or this PR would have regressed it

Withholding unlisted ids initially broke Codex. On `main` the Codex reader fabricated a row for an unlisted `current.model`, so the pill named it. Removing that fabrication left the name to provenance — and Codex reported none: `readCodexStructuredSessionOptions` emitted no `confirmed` ids, so `result.current.confirmed ?? []` recorded even a model the thread was genuinely running as `dispatched`.

Probed against `origin/main` with its prod files reconstructed byte-identically, running the full producer chain (reader → catalog → record → snapshot → pill) for a resumed thread on `gpt-unlisted`:

| | pill |
| --- | --- |
| `origin/main` | `gpt-unlisted` |
| this PR before the fix | `Model` |
| this PR now | `gpt-unlisted` |

That was the exact bug this branch fixes for Claude, recreated for Codex — a user-visible loss, so it is fixed here rather than deferred.

`input.current` cannot answer the question alone, because it merges two sources: `session.options` holds a pick restored from a previous session or a write of ours the thread has not echoed, while `session.reportedOptions` has exactly one writer — `reportedCodexThreadOptions(opened)`, the opened or resumed thread — and is the agent's own state. Only `readLiveCodexSessionOptions` knows which one answered, so it now says so and the reader passes it on. A restored pick stays unconfirmed and unnamed; a model the reader *substitutes* because nothing was current is never confirmed either, since that id is our choice, not a report.

`confirmed` is an existing optional field on `AgentSessionOptionsResult`, documented so that its absence means "unconfirmed". A host that predates this sends nothing and old clients read exactly what they read today, so this is a host filling in a defined field, not a wire change.

## Deliberately out of scope

- **`modelIsAdoptableAsLaunchDefault`** — an unlisted model still becoming the persisted launch default.
- **Explanatory text for an empty dropdown** in `NativeChatSessionOptionPickers.tsx`, and the `en.json` key it needs.

`worker-start --model` validation is untouched: nothing under `src/main/runtime/rpc/methods/orchestration/` changed, so that flag behaves exactly as on `main`.
