### PR TITLE
fix(native-chat): never adopt an unlisted model as the launch default

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-launch-default-adoption.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-launch-default-adoption.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearNativeChatSessionOptionCacheForTests,
+  seedNativeChatAppliedSessionOptions
+} from './native-chat-session-option-cache'
+import { createNativeChatPtySessionOptions } from './native-chat-pty-session-options'
+import {
+  resolveNativeChatSessionOptionDefaults,
+  updateNativeChatSessionOptionDefaults
+} from '../../../../shared/native-chat-session-option-defaults'
+import type {
+  PersistedNativeChatSessionOptions,
+  SessionOptionValue
+} from '../../../../shared/native-chat-session-options'
+
+describe('native chat launch-default adoption', () => {
+  beforeEach(() => clearNativeChatSessionOptionCacheForTests())
+
+  // Why: current CLIs list `opus[1m]` and no plain `opus`, so this stands in for a host
+  // catalog that both adds an unseeded id and drops a seeded one.
+  const HOST_CLAUDE_MODELS = [
+    { id: 'opus[1m]', label: 'Opus (1M context)', options: [] },
+    { id: 'sonnet', label: 'Sonnet', options: [] }
+  ]
+
+  /** Folds picker persists onto a durable record the way the settings writer does, so a
+   *  test reads the launch flag a later chat would actually emit rather than the flag. */
+  const claudeLaunchDefaults = (): {
+    read: () => PersistedNativeChatSessionOptions
+    persistSelection: (args: {
+      modelId: string
+      optionId: string
+      value: SessionOptionValue
+      adoptModelAsLaunchDefault: boolean
+    }) => void
+  } => {
+    let persisted: PersistedNativeChatSessionOptions = {}
+    return {
+      read: () => persisted,
+      persistSelection: (args) => {
+        persisted = updateNativeChatSessionOptionDefaults({ persisted, agent: 'claude', ...args })
+      }
+    }
+  }
+
+  it('does not adopt a launch-flag model no list carries as the persisted launch default', async () => {
+    // Regression: `worker-start --model claude-opus-5` seeds that id verbatim, and once
+    // discovery landed the gate waved anything through for a non-authoritative catalog.
+    // Re-picking the row it drew wrote the id into settings, so every later claude chat
+    // for this agent launched `-m claude-opus-5` — an id neither list has ever carried.
+    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'claude-opus-5' })
+    const defaults = claudeLaunchDefaults()
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      initialModels: HOST_CLAUDE_MODELS,
+      mode: 'live',
+      dispatchCommand: vi.fn().mockResolvedValue({ outcome: 'applied' }),
+      persistSelection: defaults.persistSelection
+    })!
+
+    await surface.setOption('model', 'claude-opus-5')
+
+    expect(defaults.read().claude?.model).toBeUndefined()
+    expect(resolveNativeChatSessionOptionDefaults(defaults.read(), 'claude')).toBeUndefined()
+  })
+
+  it('does not adopt an unlisted launch-flag model before discovery either', async () => {
+    // The same raw flag read through the other branch: a tracked model is normally proof
+    // enough, but tracking says the flag was emitted, not that the id names anything.
+    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'claude-opus-5' })
+    const defaults = claudeLaunchDefaults()
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: vi.fn().mockResolvedValue({ outcome: 'applied' }),
+      persistSelection: defaults.persistSelection
+    })!
+
+    await surface.setOption('model', 'claude-opus-5')
+
+    expect(defaults.read().claude?.model).toBeUndefined()
+  })
+
+  it('still adopts a model only the host catalog lists', async () => {
+    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'sonnet' })
+    const defaults = claudeLaunchDefaults()
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      initialModels: HOST_CLAUDE_MODELS,
+      mode: 'live',
+      dispatchCommand: vi.fn().mockResolvedValue({ outcome: 'applied' }),
+      persistSelection: defaults.persistSelection
+    })!
+
+    await surface.setOption('model', 'opus[1m]')
+
+    expect(defaults.read().claude?.model).toBe('opus[1m]')
+  })
+
+  it('still adopts a seeded alias the host catalog has stopped listing', async () => {
+    // `opus` is a real model the seed vouches for, and this catalog is not authoritative,
+    // so a CLI that lists only `opus[1m]` is no evidence against it.
+    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'opus', effort: 'xhigh' })
+    const defaults = claudeLaunchDefaults()
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      initialModels: HOST_CLAUDE_MODELS,
+      mode: 'live',
+      dispatchCommand: vi.fn(),
+      persistSelection: defaults.persistSelection
+    })!
+
+    await surface.setOption('effort', 'high')
+
+    expect(resolveNativeChatSessionOptionDefaults(defaults.read(), 'claude')).toMatchObject({
+      model: 'opus',
+      effort: 'high'
+    })
+  })
+
+  it('still adopts a tracked seed model before any discovery', async () => {
+    seedNativeChatAppliedSessionOptions('pty-1', 'claude', { model: 'opus', effort: 'xhigh' })
+    const defaults = claudeLaunchDefaults()
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: vi.fn(),
+      persistSelection: defaults.persistSelection
+    })!
+
+    await surface.setOption('effort', 'high')
+
+    expect(defaults.read().claude?.model).toBe('opus')
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -143,8 +143,9 @@ export function createNativeChatPtySessionOptions(
    *  the seed's guess, so only an id the session actually tracks is evidence of
    *  anything; after one, an authoritative list that omits the id proves it retired —
    *  adopting either would emit an `-m` that is fatal on an account without it.
-   *  Both branches sit behind one precondition: some real list must carry the id. An id
-   *  only a raw launch flag or a typed `/model` ever named names no known model. */
+   *  Both branches sit behind one precondition: some real list must carry the id.
+   *  A raw launch flag and an agent report both enter the record verbatim, so an id
+   *  neither list knows names nothing, whatever put it there. */
   const modelIsAdoptableAsLaunchDefault = (modelId: string): boolean => {
     const listedIn = (list: readonly CatalogModel[]): boolean =>
       list.some((model) => model.id === modelId)

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -142,11 +142,19 @@ export function createNativeChatPtySessionOptions(
    *  persist time because a probe can settle mid-pick. Before one, `isDefault` is just
    *  the seed's guess, so only an id the session actually tracks is evidence of
    *  anything; after one, an authoritative list that omits the id proves it retired —
-   *  adopting either would emit an `-m` that is fatal on an account without it. */
-  const modelIsAdoptableAsLaunchDefault = (modelId: string): boolean =>
-    modelsAreDiscovered
-      ? !catalog.discoveredModelsAreAuthoritative || models.some((model) => model.id === modelId)
+   *  adopting either would emit an `-m` that is fatal on an account without it.
+   *  Both branches sit behind one precondition: some real list must carry the id. An id
+   *  only a raw launch flag or a typed `/model` ever named names no known model. */
+  const modelIsAdoptableAsLaunchDefault = (modelId: string): boolean => {
+    const listedIn = (list: readonly CatalogModel[]): boolean =>
+      list.some((model) => model.id === modelId)
+    if (!listedIn(models) && !listedIn(catalog.models)) {
+      return false
+    }
+    return modelsAreDiscovered
+      ? !catalog.discoveredModelsAreAuthoritative || listedIn(models)
       : record.model !== undefined
+  }
 
   /** Every persist path — picker applies and typed commands — funnels through here. */
   const persist = (modelId: string | null, optionId: string, value: SessionOptionValue): void => {


### PR DESCRIPTION
## The bug

`modelIsAdoptableAsLaunchDefault` in `native-chat-pty-session-options.ts` is the sole gate on whether a model id may become the **persisted `-m` launch flag** for future native chats with an agent:

```ts
const modelIsAdoptableAsLaunchDefault = (modelId: string): boolean =>
  modelsAreDiscovered
    ? !catalog.discoveredModelsAreAuthoritative || models.some((model) => model.id === modelId)
    : record.model !== undefined
```

Claude and Codex do not set `discoveredModelsAreAuthoritative`, so `!catalog.discoveredModelsAreAuthoritative` is `true` and the discovered branch short-circuits to `true` for **any** id once a host model list has arrived.

## How an unlisted id gets into the record

Two paths write a model id verbatim, with no catalog matching:

- **A raw launch flag.** `worker-start --model claude-opus-5` flows through `seedNativeChatAppliedSessionOptions`, which stores `values.model` as-is.
- **An agent report.** `applyNativeChatReportedSessionOptions` (`native-chat-session-option-state.ts:132-138`) likewise stores `values.model` as-is, so an agent reporting a model name Orca does not carry lands one too.

A typed `/model` is *not* a third path: `matchNativeChatCatalogModelId` only ever returns ids drawn from the list it is handed, so a never-seen id either collapses to a catalog id (claude `/model claude-opus-5` → `opus`) or matches nothing (codex `/model gpt-6-turbo` → no persist). It can only re-assert an id one of the two paths above already tracked.

## User-visible consequence

Once such an id is in the record, the first option write or model re-pick in that chat persists it as the durable default, and **every future native chat with that agent launches `-m claude-opus-5`** — an id that neither the host CLI's list nor the catalog seed carries. The same holds for the pre-discovery branch, where a tracked model is treated as proof enough; tracking only says the id was written, not that it names a real model.

## The fix

Both branches now sit behind one precondition: the active `models` list or the `catalog.models` seed must carry the id. An id no list carries is not evidence of anything and never becomes durable state.

Ids that *are* carried keep every existing behaviour — the change is a pure `&&` narrowing:

- **authoritative catalogs (grok)** are unaffected: that branch already required `models.some(...)`, and the precondition is implied by it.
- **a seeded alias the host CLI has stopped listing** (`opus` when the CLI lists only `opus[1m]`) is still adopted — it is a real model the seed vouches for.
- **a model only the host catalog lists** (`opus[1m]`, unseeded) is still adopted.
- **the `record.model !== undefined` branch** is otherwise untouched.

The gate reads the raw `models` and `catalog.models` lists, never the reconciled `activeModels()`, so it does not depend on the fabricated row and is correct both before and after #19852.

## Tests

New file `native-chat-launch-default-adoption.test.ts` (5 tests). The new tests went in their own file because `native-chat-pty-session-options.test.ts` is already near the 800-line `max-lines` cap and adding to it broke the rule; no suppression was added, and that file is restored to a verified-empty diff.

Ablation — production change reverted by hand, restored by hand, re-proven at the final commit:

| test | ablated |
| --- | --- |
| unlisted launch-flag id not adopted (discovered) | **RED** |
| unlisted launch-flag id not adopted (pre-discovery) | **RED** |
| model only the host catalog lists is still adopted | green (no-regression guard) |
| seeded alias the CLI stopped listing is still adopted | green (no-regression guard) |
| tracked seed model before discovery is still adopted | green (no-regression guard) |

The three no-regression guards cannot go red against this change by construction, so each was also proven load-bearing against an over-reaching variant of the fix: dropping the seed fallback reddens the seeded-alias test; a seed-only precondition reddens the host-catalog test *and* an existing grok test; neutering the pre-discovery branch reddens the tracked-seed test and two existing tests.

## Not in this PR

- The model **name** shown in the chat and the fabricated `{ id, label: id, options: [] }` catalog row — that is #19852, already open.
- The effort picker for an unlisted model, and the empty-dropdown explanatory text — separate follow-ups.
- `worker-start --model` itself behaves exactly as on `main`; nothing under `src/main/runtime/rpc/methods/orchestration/` is touched.
