### PR TITLE
fix(relay): negotiate a semantic protocol version so an updated client can reach a stranded relay (Release N of 2)

### DIFF
--- a/src/main/ssh/ssh-relay-handshake-mismatch.test.ts
+++ b/src/main/ssh/ssh-relay-handshake-mismatch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { buildRelayHandshakeRefusalError } from './ssh-relay-handshake-mismatch'
+import {
+  RelayVersionMismatchError,
+  RELAY_EXIT_CODE_VERSION_MISMATCH
+} from './ssh-relay-version-mismatch-error'
+import {
+  RelayCredentialMismatchError,
+  RELAY_EXIT_CODE_CREDENTIAL_MISMATCH
+} from './ssh-relay-credential-mismatch-error'
+
+describe('buildRelayHandshakeRefusalError', () => {
+  // The bridge's mismatch line now carries `daemonProtocol=` and `ours=` after the version, so a
+  // `daemon=` capture that merely stops at `;` swallows the separating comma into the version.
+  it('names the daemon version without the comma that follows it', () => {
+    const error = buildRelayHandshakeRefusalError(
+      RELAY_EXIT_CODE_VERSION_MISMATCH,
+      '[relay-connect] Handshake mismatch: expected=0.1.0+aaa, daemon=0.1.0+bbb, ' +
+        'daemonProtocol=6, ours=1; exiting 42\n'
+    )
+    expect(error).toBeInstanceOf(RelayVersionMismatchError)
+    expect(error).toMatchObject({ expected: '0.1.0+aaa', got: '0.1.0+bbb' })
+  })
+
+  // A relay from before the protocol fields still emits the short form.
+  it('still reads the pre-negotiation form of the line', () => {
+    const error = buildRelayHandshakeRefusalError(
+      RELAY_EXIT_CODE_VERSION_MISMATCH,
+      '[relay-connect] Handshake mismatch: expected=0.1.0+aaa, daemon=0.1.0+bbb; exiting 42\n'
+    )
+    expect(error).toMatchObject({ expected: '0.1.0+aaa', got: '0.1.0+bbb' })
+  })
+
+  it('reports an unparseable mismatch line without inventing versions', () => {
+    const error = buildRelayHandshakeRefusalError(RELAY_EXIT_CODE_VERSION_MISMATCH, 'nothing here')
+    expect(error).toMatchObject({ expected: undefined, got: undefined })
+  })
+
+  it('keeps a refused credential distinct from a version skew', () => {
+    expect(
+      buildRelayHandshakeRefusalError(RELAY_EXIT_CODE_CREDENTIAL_MISMATCH, 'refused')
+    ).toBeInstanceOf(RelayCredentialMismatchError)
+  })
+
+  it('returns nothing for an exit code that encodes no refusal', () => {
+    expect(buildRelayHandshakeRefusalError(1, 'crashed')).toBeNull()
+  })
+})

--- a/src/main/ssh/ssh-relay-handshake-mismatch.ts
+++ b/src/main/ssh/ssh-relay-handshake-mismatch.ts
@@ -24,11 +24,13 @@ export function buildRelayHandshakeRefusalError(
 
 // Why: extract the expected/got version pair from --connect's stderr line
 // "Handshake mismatch: expected=<x>, daemon=<y>" so diagnostics name both versions.
+// Why a comma is excluded from `daemon`: the line grew trailing `daemonProtocol=`/`ours=`
+// fields, so the version is no longer the last thing before the `;`.
 function parseHandshakeMismatchStderr(stderr: string): {
   expected: string | undefined
   got: string | undefined
 } {
-  const match = /expected=([^,\s]+),\s*daemon=([^\s;]+)/.exec(stderr)
+  const match = /expected=([^,\s]+),\s*daemon=([^\s;,]+)/.exec(stderr)
   if (!match) {
     return { expected: undefined, got: undefined }
   }

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -27,6 +27,7 @@ export type { DecodedFrame, FrameDecoderOptions } from './relay-frame-decoder'
 import {
   MIN_RELAY_PROTOCOL_VERSION,
   RELAY_PROTOCOL_VERSION,
+  describeRelayProtocolVersion,
   relayProtocolOffer,
   relayProtocolOfferAdmits,
   type RelayHandshakeCapabilities,
@@ -36,6 +37,7 @@ import {
 export {
   MIN_RELAY_PROTOCOL_VERSION,
   RELAY_PROTOCOL_VERSION,
+  describeRelayProtocolVersion,
   relayProtocolOffer,
   relayProtocolOfferAdmits
 }

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -24,6 +24,25 @@ export {
 }
 export type { DecodedFrame, FrameDecoderOptions } from './relay-frame-decoder'
 
+import {
+  MIN_RELAY_PROTOCOL_VERSION,
+  RELAY_PROTOCOL_VERSION,
+  relayProtocolOffer,
+  relayProtocolOfferAdmits,
+  type RelayHandshakeCapabilities,
+  type RelayProtocolOffer
+} from '../shared/relay-protocol-version'
+
+export {
+  MIN_RELAY_PROTOCOL_VERSION,
+  RELAY_PROTOCOL_VERSION,
+  relayProtocolOffer,
+  relayProtocolOfferAdmits
+}
+export type { RelayHandshakeCapabilities, RelayProtocolOffer }
+
+// Why frozen at 0.1.0: the deploy path carries a content hash of the bundle instead, so nothing
+// ever needed this to move. `RELAY_PROTOCOL_VERSION` is the number that describes the wire.
 export const RELAY_VERSION = '0.1.0'
 export const RELAY_SENTINEL = `ORCA-RELAY v${RELAY_VERSION} READY\n`
 
@@ -37,10 +56,24 @@ export const MessageType = {
 // reads exactly one Handshake frame before attaching the JSON-RPC dispatcher,
 // to refuse mismatched-version --connect bridges that would otherwise drive a
 // stale daemon.
+// Why optional on every arm: `parseHandshakeMessage` throws on an unknown `type` and the throw
+// closes the socket, so this envelope can only ever grow by optional fields on the arms that
+// already ship. `endpointCredential` is the precedent. See
+// docs/reference/remote-wire-compatibility.md Rule 1.
 export type HandshakeMessage =
-  | { type: 'orca-relay-handshake'; version: string; endpointCredential?: string }
-  | { type: 'orca-relay-handshake-ok'; version: string }
-  | { type: 'orca-relay-handshake-mismatch'; expected: string; got: string }
+  | ({
+      type: 'orca-relay-handshake'
+      version: string
+      endpointCredential?: string
+    } & RelayProtocolOffer)
+  | ({
+      type: 'orca-relay-handshake-ok'
+      version: string
+      capabilities?: RelayHandshakeCapabilities
+    } & RelayProtocolOffer)
+  // `protocolVersion` here tells a client whose offered range missed *what* it missed, which a
+  // content hash cannot: the two builds may be wire-compatible and merely differ in bytes.
+  | ({ type: 'orca-relay-handshake-mismatch'; expected: string; got: string } & RelayProtocolOffer)
   // Why a distinct reply: the bridge exits with its own code so the client can tell a refused
   // credential from a crashed relay. Old bridges reject the unknown type and exit 1 pre-sentinel.
   | { type: 'orca-relay-handshake-credential-mismatch' }

--- a/src/relay/relay-handshake-roundtrip.test.ts
+++ b/src/relay/relay-handshake-roundtrip.test.ts
@@ -13,9 +13,14 @@ import {
   encodeHandshakeFrame,
   encodeJsonRpcFrame,
   FrameDecoder,
+  parseHandshakeMessage,
+  MIN_RELAY_PROTOCOL_VERSION,
+  RELAY_PROTOCOL_VERSION,
   type DecodedFrame,
+  type HandshakeMessage,
   MessageType
 } from './protocol'
+import { PTY_CONSUMER_SESSION_PROTOCOL_VERSION } from '../shared/pty-consumer-session-contract'
 import { relayTestSocketPath } from './relay-test-socket-path'
 
 // Why: --connect normally calls process.exit on mismatch / fatal handshake
@@ -210,8 +215,85 @@ describe('handshake round-trip over a real Socket pair', () => {
     bridgeSock.destroy()
   })
 
-  it('exits with EXIT_CODE_VERSION_MISMATCH when the daemon reports a mismatch', async () => {
+  // Reads the daemon's single handshake reply off a raw socket, so a test can assert what the
+  // envelope carries rather than only whether the bridge accepted it.
+  function readDaemonReply(sock: Socket): Promise<HandshakeMessage> {
+    return new Promise((resolve) => {
+      const decoder = new FrameDecoder((frame) => {
+        if (frame.type === MessageType.Handshake) {
+          resolve(parseHandshakeMessage(frame.payload))
+        }
+      })
+      sock.on('data', (chunk: Buffer) => decoder.feed(chunk))
+    })
+  }
+
+  it('refuses a cross-build bridge that offers no protocol range at all', async () => {
+    // Why raw bytes: runConnectHandshake now always offers a range. Every relay already deployed
+    // sends none, and for those the build hash stays the only gate — this is that fallback.
     await startDaemon('0.1.0+server-version')
+
+    const bridgeSock = connect(sockPath)
+    await new Promise<void>((r) => bridgeSock.once('connect', () => r()))
+    const reply = readDaemonReply(bridgeSock)
+
+    bridgeSock.write(
+      encodeHandshakeFrame({ type: 'orca-relay-handshake', version: '0.1.0+different' })
+    )
+
+    // The refusal now names the daemon's protocol version, which a content hash cannot express.
+    await expect(reply).resolves.toMatchObject({
+      type: 'orca-relay-handshake-mismatch',
+      expected: '0.1.0+server-version',
+      got: '0.1.0+different',
+      protocolVersion: RELAY_PROTOCOL_VERSION,
+      minProtocolVersion: MIN_RELAY_PROTOCOL_VERSION
+    })
+
+    bridgeSock.destroy()
+  })
+
+  it('refuses a cross-build bridge whose offered range excludes this daemon', async () => {
+    await startDaemon('0.1.0+server-version')
+
+    const bridgeSock = connect(sockPath)
+    await new Promise<void>((r) => bridgeSock.once('connect', () => r()))
+    const reply = readDaemonReply(bridgeSock)
+
+    bridgeSock.write(
+      encodeHandshakeFrame({
+        type: 'orca-relay-handshake',
+        version: '0.1.0+different',
+        protocolVersion: RELAY_PROTOCOL_VERSION + 5,
+        minProtocolVersion: RELAY_PROTOCOL_VERSION + 5
+      })
+    )
+
+    await expect(reply).resolves.toMatchObject({ type: 'orca-relay-handshake-mismatch' })
+
+    bridgeSock.destroy()
+  })
+
+  it('exits with EXIT_CODE_VERSION_MISMATCH when the daemon reports a mismatch', async () => {
+    server = createServer((sock) => {
+      trackServerSocket(sock)
+      const decoder = new FrameDecoder((frame) => {
+        if (frame.type !== MessageType.Handshake) {
+          return
+        }
+        sock.write(
+          encodeHandshakeFrame({
+            type: 'orca-relay-handshake-mismatch',
+            expected: '0.1.0+server-version',
+            got: '0.1.0+different',
+            protocolVersion: RELAY_PROTOCOL_VERSION + 5,
+            minProtocolVersion: RELAY_PROTOCOL_VERSION + 5
+          })
+        )
+      })
+      sock.on('data', (chunk: Buffer) => decoder.feed(chunk))
+    })
+    await new Promise<void>((r) => server.listen(sockPath, () => r()))
 
     const bridgeSock = connect(sockPath)
     await new Promise<void>((r) => bridgeSock.once('connect', () => r()))
@@ -224,6 +306,77 @@ describe('handshake round-trip over a real Socket pair', () => {
     expect(acceptedCb).not.toHaveBeenCalled()
 
     bridgeSock.destroy()
+  })
+
+  // #13852: after an app update the client's bundle hashes differently, so the incumbent relay
+  // holding every live PTY refused it and that work became permanently unreachable.
+  it('admits a bridge from a different build once it offers a range this daemon falls in', async () => {
+    const { accepted } = await startDaemon('0.1.0+incumbent-holding-live-ptys')
+
+    const bridgeSock = connect(sockPath)
+    await new Promise<void>((r) => bridgeSock.once('connect', () => r()))
+
+    const acceptedCb = vi.fn<(leftover: Buffer) => void>()
+    runConnectHandshake(bridgeSock, '0.1.0+freshly-updated-client', { onAccepted: acceptedCb })
+
+    await accepted
+    await vi.waitFor(() => expect(acceptedCb).toHaveBeenCalledTimes(1))
+    expect(exitSpy).not.toHaveBeenCalled()
+
+    bridgeSock.destroy()
+  })
+
+  it('answers a cross-build bridge with the protocol version and capabilities it must speak', async () => {
+    await startDaemon('0.1.0+incumbent-holding-live-ptys')
+
+    const bridgeSock = connect(sockPath)
+    await new Promise<void>((r) => bridgeSock.once('connect', () => r()))
+    const reply = readDaemonReply(bridgeSock)
+
+    bridgeSock.write(
+      encodeHandshakeFrame({
+        type: 'orca-relay-handshake',
+        version: '0.1.0+freshly-updated-client',
+        protocolVersion: RELAY_PROTOCOL_VERSION + 3,
+        minProtocolVersion: MIN_RELAY_PROTOCOL_VERSION
+      })
+    )
+
+    await expect(reply).resolves.toMatchObject({
+      type: 'orca-relay-handshake-ok',
+      // The build the client actually reached, which is no longer its own.
+      version: '0.1.0+incumbent-holding-live-ptys',
+      protocolVersion: RELAY_PROTOCOL_VERSION,
+      minProtocolVersion: MIN_RELAY_PROTOCOL_VERSION,
+      capabilities: { ptyConsumerSession: PTY_CONSUMER_SESSION_PROTOCOL_VERSION }
+    })
+
+    bridgeSock.destroy()
+  })
+
+  // Tolerance replaces a compatibility gate, never the auth gate: the credential file lives inside
+  // the incumbent's own install dir, so presenting it is what proves the caller may reach it.
+  it('still refuses a cross-build bridge that cannot present the endpoint credential', async () => {
+    const { accepted } = await startDaemon('0.1.0+incumbent', 'secret-credential')
+
+    const bridgeSock = connect(sockPath)
+    await new Promise<void>((r) => bridgeSock.once('connect', () => r()))
+    const closed = new Promise<void>((r) => bridgeSock.once('close', () => r()))
+
+    runConnectHandshake(
+      bridgeSock,
+      '0.1.0+freshly-updated-client',
+      { onAccepted: vi.fn() },
+      'wrong-credential'
+    )
+
+    await closed
+    await expect(
+      Promise.race([
+        accepted.then(() => 'accepted'),
+        new Promise<string>((r) => setTimeout(() => r('closed'), 20))
+      ])
+    ).resolves.toBe('closed')
   })
 
   it('does not call onAccepted before any handshake-ok frame arrives', async () => {

--- a/src/relay/relay-handshake-roundtrip.test.ts
+++ b/src/relay/relay-handshake-roundtrip.test.ts
@@ -354,6 +354,36 @@ describe('handshake round-trip over a real Socket pair', () => {
     bridgeSock.destroy()
   })
 
+  // The refusal path logs the peer's claim, and `JSON.parse` yields objects a template literal
+  // cannot stringify. A throw there is inside the frame-decoder callback, so it would kill the
+  // daemon — and every PTY it still holds — on an unauthenticated frame.
+  it('refuses a hostile protocolVersion claim without taking the daemon down', async () => {
+    const { accepted } = await startDaemon('0.1.0+server-version')
+
+    const bridgeSock = connect(sockPath)
+    await new Promise<void>((r) => bridgeSock.once('connect', () => r()))
+    const reply = readDaemonReply(bridgeSock)
+
+    bridgeSock.write(
+      encodeHandshakeFrame(
+        JSON.parse(
+          '{"type":"orca-relay-handshake","version":"0.1.0+different","protocolVersion":{"toString":1}}'
+        ) as HandshakeMessage
+      )
+    )
+
+    await expect(reply).resolves.toMatchObject({ type: 'orca-relay-handshake-mismatch' })
+
+    // Still serving: a second, well-formed client is admitted after the hostile one.
+    const good = connect(sockPath)
+    await new Promise<void>((r) => good.once('connect', () => r()))
+    runConnectHandshake(good, '0.1.0+server-version', { onAccepted: vi.fn() })
+    await accepted
+
+    bridgeSock.destroy()
+    good.destroy()
+  })
+
   // Tolerance replaces a compatibility gate, never the auth gate: the credential file lives inside
   // the incumbent's own install dir, so presenting it is what proves the caller may reach it.
   it('still refuses a cross-build bridge that cannot present the endpoint credential', async () => {

--- a/src/relay/relay-handshake.ts
+++ b/src/relay/relay-handshake.ts
@@ -5,13 +5,24 @@ import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import type { Socket } from 'node:net'
 import {
   RELAY_VERSION,
+  RELAY_PROTOCOL_VERSION,
   MessageType,
   FrameDecoder,
   encodeHandshakeFrame,
   parseHandshakeMessage,
-  type DecodedFrame
+  relayProtocolOffer,
+  relayProtocolOfferAdmits,
+  type DecodedFrame,
+  type RelayHandshakeCapabilities
 } from './protocol'
+import { PTY_CONSUMER_SESSION_PROTOCOL_VERSION } from '../shared/pty-consumer-session-contract'
 import { relayLogLine } from './relay-diagnostic-log'
+
+// Contracts that turn over independently of the handshake integer, so a client cannot infer them
+// from `protocolVersion` and must not have to infer them from the build hash either.
+function relayHandshakeCapabilities(): RelayHandshakeCapabilities {
+  return { ptyConsumerSession: PTY_CONSUMER_SESSION_PROTOCOL_VERSION }
+}
 
 // Why: clients treat this exit code as non-retryable; other non-zero exits are transient.
 export const EXIT_CODE_VERSION_MISMATCH = 42
@@ -121,16 +132,23 @@ function handleDaemonHandshakeFrame(
     sock.destroy()
     return false
   }
-  if (msg.version !== launchVersion) {
+  // Why the build hash is still first: it is the only gate every already-deployed relay has, and
+  // it stays the fallback for peers that offer no protocol range at all. Negotiation is what lets
+  // a relay stranded by an app update keep serving the PTYs it already owns (#13852) — the hash
+  // differs by construction there, while the wire is unchanged.
+  const negotiated = msg.version === launchVersion || relayProtocolOfferAdmits(msg)
+  if (!negotiated) {
     relayLogLine(
-      `[relay] Handshake mismatch: own=${launchVersion}, client=${msg.version}; closing socket`
+      `[relay] Handshake mismatch: own=${launchVersion}/p${RELAY_PROTOCOL_VERSION}, ` +
+        `client=${msg.version}/p${msg.protocolVersion ?? 'none'}; closing socket`
     )
     try {
       sock.write(
         encodeHandshakeFrame({
           type: 'orca-relay-handshake-mismatch',
           expected: launchVersion,
-          got: msg.version
+          got: msg.version,
+          ...relayProtocolOffer()
         })
       )
     } catch {
@@ -150,8 +168,17 @@ function handleDaemonHandshakeFrame(
     sock.end()
     return false
   }
-  process.stderr.write(`[relay] Handshake OK from version=${msg.version}\n`)
-  sock.write(encodeHandshakeFrame({ type: 'orca-relay-handshake-ok', version: launchVersion }))
+  process.stderr.write(
+    `[relay] Handshake OK from version=${msg.version} (${msg.version === launchVersion ? 'same build' : `cross-build, protocol ${RELAY_PROTOCOL_VERSION}`})\n`
+  )
+  sock.write(
+    encodeHandshakeFrame({
+      type: 'orca-relay-handshake-ok',
+      version: launchVersion,
+      ...relayProtocolOffer(),
+      capabilities: relayHandshakeCapabilities()
+    })
+  )
   return true
 }
 
@@ -194,7 +221,11 @@ export function runConnectHandshake(
         process.exit(1)
       }
       if (msg.type === 'orca-relay-handshake-ok') {
-        process.stderr.write(`[relay-connect] Handshake OK at version=${msg.version}\n`)
+        // Why both numbers: with negotiation the daemon's build can legitimately differ from this
+        // bridge's, so the version alone no longer says which relay answered.
+        process.stderr.write(
+          `[relay-connect] Handshake OK at version=${msg.version} protocol=${msg.protocolVersion ?? 'none'}\n`
+        )
         handshakeDone = true
         const leftover = decoder.drain()
         sock.removeAllListeners('data')
@@ -204,7 +235,9 @@ export function runConnectHandshake(
       if (msg.type === 'orca-relay-handshake-mismatch') {
         // Why: exit inside the write callback; stderr is async on pipe transports, so exiting early drops the version detail.
         process.stderr.write(
-          `[relay-connect] Handshake mismatch: expected=${msg.expected}, daemon=${msg.got}; exiting ${EXIT_CODE_VERSION_MISMATCH}\n`,
+          `[relay-connect] Handshake mismatch: expected=${msg.expected}, daemon=${msg.got}, ` +
+            `daemonProtocol=${msg.protocolVersion ?? 'none'}, ours=${RELAY_PROTOCOL_VERSION}; ` +
+            `exiting ${EXIT_CODE_VERSION_MISMATCH}\n`,
           () => {
             sock.destroy()
             process.exit(EXIT_CODE_VERSION_MISMATCH)
@@ -243,7 +276,9 @@ export function runConnectHandshake(
     encodeHandshakeFrame({
       type: 'orca-relay-handshake',
       version: myVersion,
-      ...(endpointCredential ? { endpointCredential } : {})
+      ...(endpointCredential ? { endpointCredential } : {}),
+      // A relay that predates the offer ignores these keys and compares the hash as before.
+      ...relayProtocolOffer()
     })
   )
 }

--- a/src/relay/relay-handshake.ts
+++ b/src/relay/relay-handshake.ts
@@ -10,6 +10,7 @@ import {
   FrameDecoder,
   encodeHandshakeFrame,
   parseHandshakeMessage,
+  describeRelayProtocolVersion,
   relayProtocolOffer,
   relayProtocolOfferAdmits,
   type DecodedFrame,
@@ -140,7 +141,7 @@ function handleDaemonHandshakeFrame(
   if (!negotiated) {
     relayLogLine(
       `[relay] Handshake mismatch: own=${launchVersion}/p${RELAY_PROTOCOL_VERSION}, ` +
-        `client=${msg.version}/p${msg.protocolVersion ?? 'none'}; closing socket`
+        `client=${msg.version}/p${describeRelayProtocolVersion(msg.protocolVersion)}; closing socket`
     )
     try {
       sock.write(
@@ -224,7 +225,7 @@ export function runConnectHandshake(
         // Why both numbers: with negotiation the daemon's build can legitimately differ from this
         // bridge's, so the version alone no longer says which relay answered.
         process.stderr.write(
-          `[relay-connect] Handshake OK at version=${msg.version} protocol=${msg.protocolVersion ?? 'none'}\n`
+          `[relay-connect] Handshake OK at version=${msg.version} protocol=${describeRelayProtocolVersion(msg.protocolVersion)}\n`
         )
         handshakeDone = true
         const leftover = decoder.drain()
@@ -236,7 +237,7 @@ export function runConnectHandshake(
         // Why: exit inside the write callback; stderr is async on pipe transports, so exiting early drops the version detail.
         process.stderr.write(
           `[relay-connect] Handshake mismatch: expected=${msg.expected}, daemon=${msg.got}, ` +
-            `daemonProtocol=${msg.protocolVersion ?? 'none'}, ours=${RELAY_PROTOCOL_VERSION}; ` +
+            `daemonProtocol=${describeRelayProtocolVersion(msg.protocolVersion)}, ours=${RELAY_PROTOCOL_VERSION}; ` +
             `exiting ${EXIT_CODE_VERSION_MISMATCH}\n`,
           () => {
             sock.destroy()

--- a/src/shared/relay-protocol-version.test.ts
+++ b/src/shared/relay-protocol-version.test.ts
@@ -43,6 +43,12 @@ describe('relay protocol version', () => {
     expect(relayProtocolOfferAdmits({ minProtocolVersion: 1 }, 1)).toBe(false)
   })
 
+  // Zero is the one bad value the band check cannot catch on its own: a peer claiming protocol 0
+  // would be admitted by a relay whose own version was also read as 0.
+  it('rejects a zero protocol version rather than treating it as a real version', () => {
+    expect(relayProtocolOfferAdmits({ protocolVersion: 0, minProtocolVersion: 0 }, 0)).toBe(false)
+  })
+
   it('rejects offers that are not plausible integers', () => {
     for (const bad of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2_000_000]) {
       expect(

--- a/src/shared/relay-protocol-version.test.ts
+++ b/src/shared/relay-protocol-version.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MIN_RELAY_PROTOCOL_VERSION,
+  RELAY_PROTOCOL_VERSION,
+  relayProtocolOffer,
+  relayProtocolOfferAdmits
+} from './relay-protocol-version'
+
+describe('relay protocol version', () => {
+  it('is a whole number at or above its own floor', () => {
+    expect(Number.isSafeInteger(RELAY_PROTOCOL_VERSION)).toBe(true)
+    expect(Number.isSafeInteger(MIN_RELAY_PROTOCOL_VERSION)).toBe(true)
+    expect(RELAY_PROTOCOL_VERSION).toBeGreaterThanOrEqual(MIN_RELAY_PROTOCOL_VERSION)
+  })
+
+  it('offers its own range, so a same-build peer is admitted by negotiation as well as by hash', () => {
+    expect(relayProtocolOfferAdmits(relayProtocolOffer())).toBe(true)
+  })
+
+  // The whole point of Release N: the stranded relay is always the OLDER side, and it must be
+  // able to say yes on the first frame with no earlier round trip to downgrade in.
+  it('admits a newer client whose range reaches back to this relay', () => {
+    expect(relayProtocolOfferAdmits({ protocolVersion: 9, minProtocolVersion: 1 }, 1)).toBe(true)
+    expect(relayProtocolOfferAdmits({ protocolVersion: 9, minProtocolVersion: 5 }, 1)).toBe(false)
+  })
+
+  it('admits a client older than this relay when the relay still falls in its range', () => {
+    expect(relayProtocolOfferAdmits({ protocolVersion: 4, minProtocolVersion: 2 }, 3)).toBe(true)
+    expect(relayProtocolOfferAdmits({ protocolVersion: 2, minProtocolVersion: 1 }, 3)).toBe(false)
+  })
+
+  it('treats a lone protocolVersion as a range of exactly one', () => {
+    expect(relayProtocolOfferAdmits({ protocolVersion: 3 }, 3)).toBe(true)
+    expect(relayProtocolOfferAdmits({ protocolVersion: 3 }, 2)).toBe(false)
+    expect(relayProtocolOfferAdmits({ protocolVersion: 3 }, 4)).toBe(false)
+  })
+
+  // A peer that sends no offer predates negotiation; admitting it would hand every unversioned
+  // caller the cross-build path that the build hash is supposed to gate.
+  it('never admits an absent or empty offer', () => {
+    expect(relayProtocolOfferAdmits(undefined, 1)).toBe(false)
+    expect(relayProtocolOfferAdmits({}, 1)).toBe(false)
+    expect(relayProtocolOfferAdmits({ minProtocolVersion: 1 }, 1)).toBe(false)
+  })
+
+  it('rejects offers that are not plausible integers', () => {
+    for (const bad of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2_000_000]) {
+      expect(
+        relayProtocolOfferAdmits({ protocolVersion: bad, minProtocolVersion: 1 }, 1),
+        `protocolVersion=${bad}`
+      ).toBe(false)
+    }
+    for (const bad of ['1', null, {}, []]) {
+      expect(
+        relayProtocolOfferAdmits(
+          { protocolVersion: 1, minProtocolVersion: bad as unknown as number },
+          1
+        ),
+        `minProtocolVersion=${JSON.stringify(bad)}`
+      ).toBe(false)
+    }
+  })
+
+  it('rejects an inverted range instead of silently reordering it', () => {
+    expect(relayProtocolOfferAdmits({ protocolVersion: 1, minProtocolVersion: 5 }, 1)).toBe(false)
+    expect(relayProtocolOfferAdmits({ protocolVersion: 1, minProtocolVersion: 5 }, 5)).toBe(false)
+  })
+})

--- a/src/shared/relay-protocol-version.test.ts
+++ b/src/shared/relay-protocol-version.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   MIN_RELAY_PROTOCOL_VERSION,
   RELAY_PROTOCOL_VERSION,
+  describeRelayProtocolVersion,
   relayProtocolOffer,
   relayProtocolOfferAdmits
 } from './relay-protocol-version'
@@ -70,5 +71,21 @@ describe('relay protocol version', () => {
   it('rejects an inverted range instead of silently reordering it', () => {
     expect(relayProtocolOfferAdmits({ protocolVersion: 1, minProtocolVersion: 5 }, 1)).toBe(false)
     expect(relayProtocolOfferAdmits({ protocolVersion: 1, minProtocolVersion: 5 }, 5)).toBe(false)
+  })
+
+  // A relay daemon logs the peer's claim on the refusal path, and `JSON.parse` can produce an
+  // object a template literal cannot stringify. Throwing there is inside the frame-decoder
+  // callback, which would take the daemon and every PTY it still holds down with it.
+  it('renders a peer version claim that a template literal would throw on', () => {
+    const hostile = JSON.parse('{"protocolVersion": {"toString": 1}}').protocolVersion
+    expect(() => `${hostile}`).toThrow()
+    expect(describeRelayProtocolVersion(hostile)).toBe('none')
+  })
+
+  it('renders real numbers and refuses every other shape', () => {
+    expect(describeRelayProtocolVersion(7)).toBe('7')
+    for (const bad of [undefined, null, '3', {}, [], Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(describeRelayProtocolVersion(bad), JSON.stringify(bad ?? null)).toBe('none')
+    }
   })
 })

--- a/src/shared/relay-protocol-version.ts
+++ b/src/shared/relay-protocol-version.ts
@@ -14,8 +14,39 @@
 export const RELAY_PROTOCOL_VERSION = 1
 
 /**
+ * ## This negotiation is not reachable yet. Do not read it as fixing #13852.
+ *
+ * Measured, not inferred: the deploy path namespaces the relay directory by the CLIENT'S OWN build
+ * hash — `remoteInstallDirName` is `relay-<fullVersion>` — and the daemon socket lives inside that
+ * directory (`ssh-relay-deploy.ts`, `--connect --sock-path ~/.orca-remote/relay-<ownVersion>/…`;
+ * the short-socket fallback derives its segment from the same version dir). Every
+ * `runConnectHandshake` caller takes its path from that one deploy result. So a bridge can only
+ * ever meet a daemon of its own build, `msg.version === launchVersion` short-circuits first, and
+ * `relayProtocolOfferAdmits` never decides anything on any live path. The stranded incumbent this
+ * exists for sits in `relay-<otherVersion>/`, which nothing dials.
+ *
+ * What ships today is therefore three log lines: `describeRelayProtocolVersion` in
+ * `relay-handshake.ts`. `MIN_RELAY_PROTOCOL_VERSION` and the `minProtocolVersion` wire field have
+ * no live reader at all.
+ *
+ * Keep it — the mechanism is correct and hostile-input-safe, and it is the part that has to exist
+ * first. Making it live needs two more changes, both of which must land together:
+ *   1. route the bridge to the incumbent's socket rather than to its own version directory;
+ *   2. stop `validateGrant` (`ssh-pty-consumer-session.ts`) refusing on `serverBuildId`. Its
+ *      premise, "client and relay ship in one build", is still TRUE today and becomes false the
+ *      moment (1) lands — it is a second gate that would refuse what the handshake just admitted.
+ *
+ * Until both land, a change here cannot be validated by any end-to-end test, only by the
+ * handshake's own unit suite.
+ */
+
+/**
  * Oldest peer protocol this build can still speak. Raising it strands every relay below the new
  * floor for good, so it moves only when serving a version is actually impossible.
+ *
+ * No live reader — see the note above. It is serialized onto every handshake and reply so that the
+ * field exists on the wire before any peer needs it (Rule 1, docs/reference/remote-wire-
+ * compatibility.md); an older peer ignoring it today is the point.
  */
 export const MIN_RELAY_PROTOCOL_VERSION = 1
 

--- a/src/shared/relay-protocol-version.ts
+++ b/src/shared/relay-protocol-version.ts
@@ -78,8 +78,10 @@ export function relayProtocolOfferAdmits(
   }
   // Why default to `max`: a peer that names one version speaks exactly that one.
   const min = offer?.minProtocolVersion === undefined ? max : readVersion(offer.minProtocolVersion)
-  if (min === null || min > max) {
+  if (min === null) {
     return false
   }
+  // An inverted range admits nothing rather than being reordered into something the peer never
+  // offered: `min > max` simply fails this band.
   return ownVersion >= min && ownVersion <= max
 }

--- a/src/shared/relay-protocol-version.ts
+++ b/src/shared/relay-protocol-version.ts
@@ -30,13 +30,27 @@ export const RELAY_PROTOCOL_VERSION = 1
  * no live reader at all.
  *
  * Keep it — the mechanism is correct and hostile-input-safe, and it is the part that has to exist
- * first. Making it live needs two more changes, both of which must land together:
+ * first. Making it live needs THREE more changes, all of which must land together. Landing only
+ * the first two ships a negotiation that still refuses, later and less legibly:
  *   1. route the bridge to the incumbent's socket rather than to its own version directory;
  *   2. stop `validateGrant` (`ssh-pty-consumer-session.ts`) refusing on `serverBuildId`. Its
  *      premise, "client and relay ship in one build", is still TRUE today and becomes false the
  *      moment (1) lands — it is a second gate that would refuse what the handshake just admitted.
+ *   3. give that same refusal a way to survive a protocol-version difference. It is ONE `if` with
+ *      two disjuncts, and deleting the `serverBuildId` clause leaves the other one standing:
+ *      `grant.protocolVersion !== PTY_CONSUMER_SESSION_PROTOCOL_VERSION` — a DIFFERENT constant
+ *      from this file's `RELAY_PROTOCOL_VERSION`, compared for exact equality, with no range, no
+ *      floor and no fallback. Two peers that just negotiated a compatible relay protocol are still
+ *      refused if their PTY-session constants differ by one. And there is nothing to negotiate it
+ *      with: `capabilities` on `orca-relay-handshake-ok` is written at exactly one site
+ *      (`relay-handshake.ts`) and read by nothing outside tests, so (3) means giving that field a
+ *      reader before it can carry the peer's PTY-session protocol.
  *
- * Until both land, a change here cannot be validated by any end-to-end test, only by the
+ * Budget a debugging session for the error text too: the refusal interpolates only the build ids,
+ * so a pure protocol-version mismatch reports as "expected build X, got X" with two IDENTICAL ids,
+ * which points at the gate that is not the problem.
+ *
+ * Until all three land, a change here cannot be validated by any end-to-end test, only by the
  * handshake's own unit suite.
  */
 

--- a/src/shared/relay-protocol-version.ts
+++ b/src/shared/relay-protocol-version.ts
@@ -1,0 +1,85 @@
+/**
+ * Semantic wire version for the relay handshake.
+ *
+ * `RELAY_VERSION` ('0.1.0') has never moved, so the deploy path is namespaced by a content hash
+ * of the bundle instead (`config/scripts/build-relay.mjs`). That hash changes on nearly every
+ * release, which makes every install directory — and the socket inside it — unreachable to the
+ * next build, stranding the PTYs and agents the incumbent still owns (#13852).
+ *
+ * This integer is the escape: it names what the *wire* can do, independent of what the bytes
+ * hash to, exactly as `PROTOCOL_VERSION` does for the local terminal daemon
+ * (`src/main/daemon/daemon-protocol-version.ts`). Bump it only when a client and a relay of
+ * adjacent versions genuinely cannot drive each other; a rebuild is not a reason.
+ */
+export const RELAY_PROTOCOL_VERSION = 1
+
+/**
+ * Oldest peer protocol this build can still speak. Raising it strands every relay below the new
+ * floor for good, so it moves only when serving a version is actually impossible.
+ */
+export const MIN_RELAY_PROTOCOL_VERSION = 1
+
+/** Rejects a peer's absurd or non-integer claim before it reaches a comparison. */
+const MAX_PLAUSIBLE_RELAY_PROTOCOL_VERSION = 1_000_000
+
+/**
+ * Contract versions a peer cannot derive from `protocolVersion` alone, because they turn over
+ * independently of the handshake.
+ */
+export type RelayHandshakeCapabilities = {
+  /** `pty.openClient` grant contract this relay mints (`PTY_CONSUMER_SESSION_PROTOCOL_VERSION`). */
+  readonly ptyConsumerSession?: number
+}
+
+/**
+ * The protocol range a peer says it can speak. Both fields are optional on the wire: a relay or
+ * bridge that predates this negotiation sends neither, which is the signal to fall back to
+ * comparing build hashes.
+ */
+export type RelayProtocolOffer = {
+  readonly protocolVersion?: number
+  readonly minProtocolVersion?: number
+}
+
+function readVersion(value: unknown): number | null {
+  return typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= 1 &&
+    value <= MAX_PLAUSIBLE_RELAY_PROTOCOL_VERSION
+    ? value
+    : null
+}
+
+/** This build's own offer, sent on every handshake and reply. */
+export function relayProtocolOffer(): Required<RelayProtocolOffer> {
+  return {
+    protocolVersion: RELAY_PROTOCOL_VERSION,
+    minProtocolVersion: MIN_RELAY_PROTOCOL_VERSION
+  }
+}
+
+/**
+ * Whether a peer offering `offer` can be served by a relay speaking `ownVersion`.
+ *
+ * The peer states a range rather than a single number so an *older* relay can admit a *newer*
+ * client on the first frame — there is no earlier round trip in which the client could learn
+ * what to downgrade to, and the stranded relay is by construction the older side.
+ *
+ * An offer with no `protocolVersion` is not a negotiation at all and never admits: that is a
+ * pre-negotiation peer, and the build-hash comparison stays its only gate.
+ */
+export function relayProtocolOfferAdmits(
+  offer: RelayProtocolOffer | undefined,
+  ownVersion: number = RELAY_PROTOCOL_VERSION
+): boolean {
+  const max = readVersion(offer?.protocolVersion)
+  if (max === null) {
+    return false
+  }
+  // Why default to `max`: a peer that names one version speaks exactly that one.
+  const min = offer?.minProtocolVersion === undefined ? max : readVersion(offer.minProtocolVersion)
+  if (min === null || min > max) {
+    return false
+  }
+  return ownVersion >= min && ownVersion <= max
+}

--- a/src/shared/relay-protocol-version.ts
+++ b/src/shared/relay-protocol-version.ts
@@ -50,6 +50,17 @@ function readVersion(value: unknown): number | null {
     : null
 }
 
+/**
+ * Renders a peer's claimed version for a log line without interpolating it.
+ *
+ * `JSON.parse` can hand back `{ "toString": 1 }`, and a template literal on that throws
+ * `Cannot convert object to primitive value` — inside the frame-decoder callback, which would
+ * take the daemon and every PTY it holds down with it.
+ */
+export function describeRelayProtocolVersion(value: unknown): string {
+  return typeof value === 'number' && Number.isFinite(value) ? String(value) : 'none'
+}
+
 /** This build's own offer, sent on every handshake and reply. */
 export function relayProtocolOffer(): Required<RelayProtocolOffer> {
   return {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​323 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​322 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​229 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​216 |

<!-- /orca-pr-loc -->

## ELI5

Every time you update Orca, the relay that runs on your SSH host gets installed into a **new folder whose name is a hash of the app's bytes**. The relay listens on a socket *inside* that folder. So after an update, the new Orca looks in a new folder, finds no socket, and starts a **second** relay — while the old one keeps running forever, still holding every terminal and every agent you had open. They are not dead. They are unreachable. One field host had 11 folders, 11 sockets, and 19 orphans.

The reason it works this way is that `RELAY_VERSION` is the frozen string `'0.1.0'` and has never moved, so the content hash was added to tell builds apart. But a hash answers "are these the same bytes?", and the question that actually matters is "**can these two talk to each other?**" — which is almost always yes, because a rebuild changes bytes without changing the wire.

This PR gives the relay a real answer to the second question: an integer `RELAY_PROTOCOL_VERSION = 1`, offered as a range in the handshake. A relay now accepts a bridge from a *different build* as long as that bridge says it can speak a protocol the relay speaks. The byte-hash comparison stays as the fallback for every peer that offers no range.

This is the same mechanism the local terminal daemon has always used (`src/main/daemon/daemon-protocol-version.ts`), where 35 earlier protocol versions stay attachable across an update.

## One value doing three jobs

The build hash is a legitimate **artifact** identity — "are these the same bytes?" — that has been pressed into service as two other identities it was never fit for:

| identity | question it answers | what should carry it |
|---|---|---|
| **artifact** | are these the same bytes? | the content hash — correct today |
| **endpoint** | which socket do I dial? | the install path — still the hash (Release N+1) |
| **protocol** | can these two drive each other? | `RELAY_PROTOCOL_VERSION` — **this PR** |

Splitting the three is the fix. Release N introduces the protocol one and leaves the other two exactly as they are.

## This is Release N of two

The relay already deployed on a user's host **never updates itself**. So tolerance has to ship one release *before* any client can use it.

- **This release (N):** the relay learns to *accept* a cross-build peer. No client behaviour changes at all — nothing in this build ever points a bridge at another version's socket, so the new code path is dormant until N+1.
- **Release N+1:** the client learns to *find* a stranded relay and route to it, and the hash-equality gates can start to retire.

**The update *to* this release still strands once, unavoidably.** The relay that gets orphaned by installing this build is the *old* one, which does not have this code. Nothing shipped now can reach back and fix that. From N+1 onward, it stops.

## What changed

- `src/shared/relay-protocol-version.ts` (new) — `RELAY_PROTOCOL_VERSION = 1`, `MIN_RELAY_PROTOCOL_VERSION = 1`, and `relayProtocolOfferAdmits()`.
- `src/relay/protocol.ts` — three existing handshake arms gain optional fields: `protocolVersion` / `minProtocolVersion` on all three, and `capabilities` on `orca-relay-handshake-ok`.
- `src/relay/relay-handshake.ts` — the daemon admits a peer when *either* the build hash matches (unchanged) *or* the peer's offered range contains this relay's protocol version (new). Replies now carry the relay's own range and capabilities.

### Why a range and not a version number

Reviewers reach for a single integer first, and it does not work here. **The stranded relay is by construction the *older* side**, and the handshake's first frame is the first thing on the wire — there is no earlier round trip in which a newer client could learn what to downgrade to. So the *client* states a range and the *relay* checks whether it falls inside it. That lets an old relay say yes immediately, which is the whole point: the relay that needs to accept is the one that can never be updated.

### Deliberately not changed

- **Exit 42, `RelayVersionMismatchError`, the PTY grant `serverBuildId` check, and owner-claim recovery all stay.** They are Release N+1's to retire.
- **The socket stays inside the version directory.** GC reads liveness from in there (`remote-install-gc.ts`), so moving it would break reclamation.
- **No client-side relay router.** Out of scope for this release.

## Wire compatibility

`docs/reference/remote-wire-compatibility.md` Rule 1 — new optional fields on frames that already ship. `parseHandshakeMessage` throws on an unknown `type` and the throw closes the socket, so a new message *type* was never an option; `endpointCredential?` is the existing precedent for growing an arm.

**What an old relay does with the new optional fields:** ignores them. Its `parseHandshakeMessage` validates only `type` and returns the object; unknown keys are never read. It then compares build hashes exactly as before and refuses on mismatch, exit 42. Verified on a real host — see scenario A below.

**What a new relay sends to an old client:** an `orca-relay-handshake-ok` carrying two extra numbers and a `capabilities` object. The old bridge parses it, reads only `type` and `version`, and connects normally. Verified on a real host below: exit 0, and its log line simply lacks the `protocol=` field it cannot read.

**No new opcode** (Rule 2 does not apply — `MessageType` is untouched). **Nothing the relay already published changed meaning** (Rule 3): the fields are purely additive and every reader treats them as optional.

## SSH execution boundary

`docs/reference/ssh-execution-boundary.md` already documents this bug by name and points at the daemon model as the fix. Nothing here kills anything or infers a verdict: this change only ever *admits* a connection that would previously have been refused. A stranded relay holding live PTYs stays `live` — the direction is leak, never kill.

## Proof — real hosts, real bundles

Two relay bundles built from two different commits (`origin/main` at 2bf298d1dc1, and this branch), installed into version directories named exactly like production, sockets bound inside them. Not simulated.

**Linux (`openclaw`, Ubuntu, node v26):**

```
A. BASELINE — pre-Release-N daemon, later-build bridge, hashes differ
   exit=42
   [relay-connect] Handshake mismatch: expected=0.1.0+aaaa…, daemon=0.1.0+cccc…, daemonProtocol=none, ours=1; exiting 42
   daemon still listening after refusal: yes          <-- this is #13852, and why updating TO N strands once

B. THE FIX — Release-N daemon, later-build bridge, hashes differ
   exit=0
   [relay] Handshake OK from version=0.1.0+cccc… (cross-build, protocol 1)

C. UNCHANGED PATH — Release-N daemon, same-build bridge
   exit=0
```

**Wire compat, both skew directions, same host:**

```
NEW RELAY -> OLD CLIENT   exit=0   [relay-connect] Handshake OK at version=0.1.0+shared
NEW RELAY -> NEW CLIENT   exit=0   [relay-connect] Handshake OK at version=0.1.0+shared protocol=1
```

**Windows (`awin`, node v24):** the handshake suites run there against real Windows **named pipes** (`relayTestSocketPath` returns `\\.\pipe\…` on win32) — 25/25 pass, including the cross-build acceptance. Windows matters here because its pipe name hashes the version folder and the superseded sweep is a no-op there, so Windows orphans are not even logged today; this change is transport-agnostic and behaves identically.

`win-lowspec` was unreachable (`runtime_timeout`) for the whole session, so Windows evidence is from `awin` only.

## Tests

`pnpm tc` clean · full `src/relay` suite **1711 passed / 4 skipped** · `oxlint` clean · changed-code quality gate: 0 new findings · Windows 25/25.

Every new assertion was mutation-tested against the specific regression it claims to catch — **12 mutations, 12 killed**, each by the assertion that names it. Eleven are on the negotiation itself (below); the twelfth is on the stderr parser fix, described above.

| mutation | killed by |
|---|---|
| drop the tolerance clause | *admits a bridge from a different build…* |
| admit an absent offer | *never admits an absent or empty offer* |
| drop the offer from `-ok` | *answers a cross-build bridge with the protocol version…* |
| drop `capabilities` from `-ok` | same |
| drop the offer from `-mismatch` | *refuses a cross-build bridge that offers no protocol range at all* |
| skip the credential check when cross-build | *still refuses a cross-build bridge that cannot present the endpoint credential* |
| drop the range's upper bound | *admits a client older than this relay…* |
| default `min` to the floor instead of `max` | *treats a lone protocolVersion as a range of exactly one* |
| reorder an inverted range | *rejects an inverted range instead of silently reordering it* |
| allow a zero version | *rejects a zero protocol version…* |
| interpolate the peer's claim raw | *refuses a hostile protocolVersion claim without taking the daemon down* |

**Note for anyone re-running this matrix.** The last row kills the vitest **worker**, not an assertion — the mutated code crashes the process. A reporter reading only `assertionResults` therefore sees zero failures and scores it a **phantom survivor**; my own harness did exactly that on the first pass. Read the run's exit code and run-level errors, not just assertion status, or that row will make the whole table look untrustworthy. It is a genuine kill.

An earlier draft had a twelfth mutation (an inverted-range guard) that was **inert**: `min > max` can never pass the band check anyway. The redundant branch was deleted rather than left standing behind a vacuous test.

## Incidental find: a peer can crash a relay and take its terminals with it

Not part of the protocol work — found while reviewing it, and worth reading on its own terms.

`parseHandshakeMessage` returns whatever `JSON.parse` produced. `JSON.parse('{"version":{"toString":1}}')` yields an object whose `toString` is not callable, so interpolating it throws `TypeError: Cannot convert object to primitive value`. That interpolation happens in the mismatch log line, inside the `FrameDecoder` frame callback — and `relay-frame-decoder.ts` wraps the dispatch loop in `try`/**`finally`**, with no `catch`. The throw escapes `decoder.feed()`, escapes the socket `data` handler, and becomes an unhandled exception: **the relay daemon dies, and every PTY and agent session it owns dies with it.**

**Malicious, not malformed.** No legitimate sender emits a non-string `version`, so this is not something a buggy peer trips into — it has to be constructed. And it is reachable **before authentication**: the version gate is `relay-handshake.ts:140`, the endpoint-credential gate is `:161`, so a peer that never presents a credential reaches the crash. The reachable set is any process that can `connect()` to the relay's endpoint — which on an SSH host includes anything running as that user, such as an agent CLI inside one of the relay's own PTYs. A hostile process in one terminal can therefore kill every sibling terminal on the host.

This PR routes **its own new fields** through `describeRelayProtocolVersion()` so the protocol work does not widen the vector, and pins that with a test asserting the daemon answers and keeps serving. **The pre-existing `msg.version` case is left alone deliberately** — it predates this change, it is a different bug from #13852, and folding an unrelated pre-auth availability fix into a wire-compatibility PR would make both harder to review. It needs its own change and its own tests. Flagging rather than fixing is the deliberate call, not an oversight.

## A consumer this broke, and the fix

`parseHandshakeMismatchStderr` (`src/main/ssh/ssh-relay-handshake-mismatch.ts`) scrapes the bridge's stderr to name both versions in `RelayVersionMismatchError`. Its `daemon=([^\s;]+)` capture stopped at the `;` — which worked only because the version used to be the *last* field on the line. Adding `daemonProtocol=` and `ours=` after it made the capture swallow the separating comma, so the reported daemon version became `0.1.0+bbb,`.

Narrowed to `[^\s;,]+`, with tests covering both the new form and the pre-negotiation short form (a relay from before this change still emits the old line). Mutating the character class back reddens only the new-form test, not the old-form one.

## The four hash gates, verified on current main

1. **Path** — `ssh-relay-versioned-install.ts` `computeRemoteRelayDir` → `relay-${fullVersion}`; socket bound inside it at `ssh-relay-deploy.ts:1697`. This is the gate that actually bites. **Unchanged here.**
2. **Handshake exit 42** — `relay-handshake.ts`. Both sides read `.version` from beside their own `relay.js`, so today it only fires when that file is unreadable. **This is the gate this PR relaxes**, and only when the peer offers a compatible range.
3. **PTY grant `serverBuildId`** — `ssh-pty-consumer-session.ts:56-65`. **Unchanged.**
4. **Owner-claim recovery** — `ssh-relay-session.ts:1212-1222`. **Unchanged.**

Cross-version *install* isolation stays test-enforced (`ssh-relay-cross-version-isolation.test.ts`); this PR touches no deploy path, so that suite is untouched and still green.

Refs #13852. Also refs #19194, which is a field measurement of the same mechanism rather than a separate bug — five relays across two socket hashes on one host, the oldest 16 days.

This does **not** close #18173 (partition ownership, #12721, covered by #19572) or #18191 (orphan inventory, owned elsewhere). Neither is version stranding.

## Review pass (main merged at e74c22a0e77)

- Merged `main` in to refresh CI after the runner backlog; the new head's `PR Checks` run completed with **20 success / 12 skipped / 0 failure** read from job steps (skips are path-gated lanes this diff does not touch; `cross-version wire compatibility` is gated on `src/shared/protocol-version*` and the terminal/agent wire paths, not the relay handshake, so it skipping here is expected rather than a miss).
- The pre-auth daemon crash class this PR's `describeRelayProtocolVersion` guards against for `protocolVersion` is fixed for `version` — and for every future field — in **#19879**, kept separate so this wire change stays reviewable. The two branches merge cleanly and the combined relay suites pass (60/60).
- On the accept-path log line that now also prints `msg.version`: it sits **after** the credential check, so a peer that pairs a malformed `version` with a valid protocol offer must first present the credential to reach it. The pre-auth surface narrows slightly rather than widening; #19879 validates the field at the parser so neither site can interpolate a non-string at all.


---

## Release N+1 needs **three** conditions, not two

Shipping with only the first two produces a negotiation that still refuses — at a later, worse point, with a message that names the wrong thing.

**Now recorded in the source as well, in two commits added to this branch:**

- `ab445d71682` `docs(relay)`: say plainly that the protocol negotiation is not reachable yet. Carried from a dead-code/unread-field sweep that was stranded on the un-PR'd branch `nwparker/adv2-map-reconciled` (`94ba0b9f052`). It puts the reachability statement in `relay-protocol-version.ts`, where someone editing this feature will actually see it rather than only in a PR body.
- `d0aca79806a` `docs(relay)`: the negotiation needs three conditions, not two. **The carried note listed two.** Correcting it is the point of the commit — a reader implementing N+1 from the two-item list ships a broken negotiation and then debugs it at the wrong gate.

(The `lingerMs` half of that same sweep is a coordinator concern and went to #20061 instead of riding along here.)

**1. Route the bridge to the incumbent's socket.** Today `computeRemoteRelayDir` namespaces the remote install by a content hash of the bundle, so a bridge only ever meets its own build. `relayProtocolOfferAdmits` is called on the live accept path, but `msg.version === launchVersion` short-circuits the offer away before it is consulted — the band is **reachable code whose input never varies**. Until the deploy path can point a bridge at another version's socket, nothing this PR adds is ever exercised.

**2. Drop the build-id half of the grant refusal.** `validateGrant` in `src/main/ssh/ssh-pty-consumer-session.ts` refuses on `grant.serverBuildId !== options.expectedServerBuildId`. A cross-build peer admitted at the handshake still dies here, at `pty.openClient`.

**3. The same condition independently refuses on a protocol-version mismatch — and there is nothing to negotiate it with.** This is the one that gets missed. The refusal is a single `if` with two disjuncts:

```ts
if (
  grant.protocolVersion !== PTY_CONSUMER_SESSION_PROTOCOL_VERSION ||
  grant.serverBuildId !== options.expectedServerBuildId
) {
```

Deleting only the `serverBuildId` clause leaves an **exact-equality** check on `PTY_CONSUMER_SESSION_PROTOCOL_VERSION` — a *different* constant from the `RELAY_PROTOCOL_VERSION` this PR introduces, with no range, no floor, and no fallback. Two peers that just negotiated a compatible relay protocol are still refused if their PTY-session protocol constants differ by one.

And there is no channel to resolve it with: the `capabilities` field this PR adds to `orca-relay-handshake-ok` is **written at exactly one site** (`relay-handshake.ts:180`) and **read by nothing** outside tests. It is a published field with no consumer — so N+1 cannot learn the peer's PTY-session protocol from the handshake without first giving that field a reader.

The error message compounds it: it interpolates only the build ids, so a pure protocol-version mismatch reports as `Remote relay session contract mismatch — expected build X, got X` with two identical ids. Anyone debugging N+1 will chase the wrong gate.

**Anyone wiring this up with conditions 1 and 2 ships a broken negotiation.**

## The reversible removal option — prepared, not recommended

If the band is judged not worth carrying until N+1, the revert is prepared and green on `nwparker/j4-remove-unreachable-relay-protocol-band` @ `068852777c1` — *"revert(relay): remove the unreachable protocol-version negotiation"*.

**It is deliberately not opened as a PR, and should not be merged.** The tradeoff was weighed and declined:

- The band is **not dead code** — the admit check runs on the live accept path. Removing it deletes a real gate, not an unreachable branch.
- Removing it is wire-safe (`minProtocolVersion` is absent from `main` and from every release tag, so no deployed peer reads it, and Rule 3 does not apply). That is what makes it *reversible*, not what makes it *right*.
- What it costs: if the deploy path ever routes a bridge to an incumbent's socket, the band would have admitted a wire-compatible cross-build peer. Without it that peer is refused at the handshake with a clean **exit 42, which has a documented redeploy recovery** — arguably better than the untyped error `validateGrant` throws at `pty.openClient`, which has none. That comparison is a maintainer call, and the call made was to keep the band.

The commit's own message opens *"Prepared as the reversible option, not a recommendation to merge."* Treat it as an escape hatch with a known cost, not a cleanup.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts; all 7 commit(s) replayed as-is.

| | SHA |
| --- | --- |
| old head | `d0aca79806a546a09c627bb7fa19f77ba9175106` |
| new head | `bedc94c5ecbece4e594a1ff23defd0d4fbeeb193` |
<!-- /rebase-record -->
