### PR TITLE
feat(task-providers): add Redmine as a read-only TaskProvider

### DIFF
--- a/src/main/ipc/redmine.test.ts
+++ b/src/main/ipc/redmine.test.ts
@@ -4,10 +4,11 @@ import {
   connectRedmineSite,
   disconnectRedmineSite,
   getRedmineStatus,
+  redmineReadErrorForCredentials,
+  resolveRedmineCredentials,
   testRedmineConnection
 } from '../redmine/client'
-import { getRedmineIssue, listRedmineIssues } from '../redmine/issues'
-import { readToken } from '../redmine/redmine-site-store'
+import { getRedmineIssue, listRedmineIssues, RedmineRequestError } from '../redmine/issues'
 
 const { handlers } = vi.hoisted(() => ({
   handlers: {} as Record<string, (event: unknown, args?: unknown) => Promise<unknown>>
@@ -25,25 +26,28 @@ vi.mock('../redmine/client', () => ({
   connectRedmineSite: vi.fn(),
   disconnectRedmineSite: vi.fn(),
   getRedmineStatus: vi.fn(),
+  redmineReadErrorForCredentials: vi.fn(() => ({
+    type: 'auth',
+    message: 'No Redmine site connected.'
+  })),
+  resolveRedmineCredentials: vi.fn(() => ({ ok: false, reason: 'no_site' })),
   testRedmineConnection: vi.fn()
 }))
 
 vi.mock('../redmine/issues', () => ({
   getRedmineIssue: vi.fn(),
-  listRedmineIssues: vi.fn()
-}))
-
-vi.mock('../redmine/redmine-site-store', () => ({
-  readToken: vi.fn()
+  listRedmineIssues: vi.fn(),
+  RedmineRequestError: class RedmineRequestError extends Error {}
 }))
 
 const connectRedmineSiteMock = vi.mocked(connectRedmineSite)
 const disconnectRedmineSiteMock = vi.mocked(disconnectRedmineSite)
 const getRedmineStatusMock = vi.mocked(getRedmineStatus)
+const redmineReadErrorForCredentialsMock = vi.mocked(redmineReadErrorForCredentials)
+const resolveRedmineCredentialsMock = vi.mocked(resolveRedmineCredentials)
 const testRedmineConnectionMock = vi.mocked(testRedmineConnection)
 const getRedmineIssueMock = vi.mocked(getRedmineIssue)
 const listRedmineIssuesMock = vi.mocked(listRedmineIssues)
-const readTokenMock = vi.mocked(readToken)
 
 const invoke = (channel: string, args?: unknown) => handlers[channel](null, args)
 
@@ -64,6 +68,11 @@ function disconnectedStatus() {
 beforeEach(() => {
   vi.clearAllMocks()
   getRedmineStatusMock.mockReturnValue(disconnectedStatus())
+  resolveRedmineCredentialsMock.mockReturnValue({ ok: false, reason: 'no_site' })
+  redmineReadErrorForCredentialsMock.mockReturnValue({
+    type: 'auth',
+    message: 'No Redmine site connected.'
+  })
   registerRedmineHandlers()
 })
 
@@ -125,36 +134,106 @@ describe('redmine:listIssues', () => {
     expect(listRedmineIssuesMock).not.toHaveBeenCalled()
   })
 
+  it('surfaces a decryption reason as a reconnect error', async () => {
+    resolveRedmineCredentialsMock.mockReturnValue({ ok: false, reason: 'decryption' })
+    redmineReadErrorForCredentialsMock.mockReturnValue({
+      type: 'auth',
+      message: 'Your stored Redmine API key could not be decrypted. Reconnect to re-enter it.'
+    })
+    const result = await invoke('redmine:listIssues', {})
+    expect(result).toEqual({
+      items: [],
+      totalCount: 0,
+      error: {
+        type: 'auth',
+        message: 'Your stored Redmine API key could not be decrypted. Reconnect to re-enter it.'
+      }
+    })
+    expect(listRedmineIssuesMock).not.toHaveBeenCalled()
+  })
+
   it('lists issues using the active site token', async () => {
-    getRedmineStatusMock.mockReturnValue(connectedStatus())
-    readTokenMock.mockReturnValue('secret')
+    resolveRedmineCredentialsMock.mockReturnValue({
+      ok: true,
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'secret'
+    })
     listRedmineIssuesMock.mockResolvedValue({ items: [], totalCount: 0 })
     await invoke('redmine:listIssues', { filter: { scope: 'assigned' } })
     expect(listRedmineIssuesMock).toHaveBeenCalledWith('https://rm.example.com', 'secret', {
       scope: 'assigned'
     })
   })
+
+  it('returns the classified error when the upstream request fails', async () => {
+    resolveRedmineCredentialsMock.mockReturnValue({
+      ok: true,
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'secret'
+    })
+    const err = new RedmineRequestError(
+      { type: 'network', message: 'Network request failed' },
+      null
+    )
+    ;(err as { classified?: unknown }).classified = {
+      type: 'network',
+      message: 'Network request failed'
+    }
+    listRedmineIssuesMock.mockRejectedValue(err)
+    const result = await invoke('redmine:listIssues', {})
+    expect(result).toEqual({
+      items: [],
+      totalCount: 0,
+      error: { type: 'network', message: 'Network request failed' }
+    })
+  })
 })
 
 describe('redmine:getIssue', () => {
-  it('returns null when no site is connected', async () => {
-    expect(await invoke('redmine:getIssue', { issueId: 1 })).toBeNull()
+  it('returns an error when no site is connected', async () => {
+    expect(await invoke('redmine:getIssue', { issueId: 1 })).toEqual({
+      issue: null,
+      error: { type: 'auth', message: 'No Redmine site connected.' }
+    })
   })
 
-  it('returns null for a non-finite issue id', async () => {
-    getRedmineStatusMock.mockReturnValue(connectedStatus())
-    readTokenMock.mockReturnValue('secret')
-    expect(await invoke('redmine:getIssue', {})).toBeNull()
+  it('returns issue:null for a non-finite issue id', async () => {
+    resolveRedmineCredentialsMock.mockReturnValue({
+      ok: true,
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'secret'
+    })
+    expect(await invoke('redmine:getIssue', {})).toEqual({ issue: null })
     expect(getRedmineIssueMock).not.toHaveBeenCalled()
   })
 
   it('fetches the issue through the active site', async () => {
-    getRedmineStatusMock.mockReturnValue(connectedStatus())
-    readTokenMock.mockReturnValue('secret')
+    resolveRedmineCredentialsMock.mockReturnValue({
+      ok: true,
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'secret'
+    })
     const issue = { id: 1 } as never
     getRedmineIssueMock.mockResolvedValue(issue)
-    await invoke('redmine:getIssue', { issueId: 1 })
+    const result = await invoke('redmine:getIssue', { issueId: 1 })
     expect(getRedmineIssueMock).toHaveBeenCalledWith('https://rm.example.com', 'secret', 1)
+    expect(result).toEqual({ issue })
+  })
+
+  it('surfaces a decryption reason as an error', async () => {
+    resolveRedmineCredentialsMock.mockReturnValue({ ok: false, reason: 'decryption' })
+    redmineReadErrorForCredentialsMock.mockReturnValue({
+      type: 'auth',
+      message: 'Your stored Redmine API key could not be decrypted. Reconnect to re-enter it.'
+    })
+    const result = await invoke('redmine:getIssue', { issueId: 1 })
+    expect(result).toEqual({
+      issue: null,
+      error: {
+        type: 'auth',
+        message: 'Your stored Redmine API key could not be decrypted. Reconnect to re-enter it.'
+      }
+    })
   })
 })
 

--- a/src/main/ipc/redmine.test.ts
+++ b/src/main/ipc/redmine.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { registerRedmineHandlers } from './redmine'
+import {
+  connectRedmineSite,
+  disconnectRedmineSite,
+  getRedmineStatus,
+  testRedmineConnection
+} from '../redmine/client'
+import { getRedmineIssue, listRedmineIssues } from '../redmine/issues'
+import { readToken } from '../redmine/redmine-site-store'
+
+const { handlers } = vi.hoisted(() => ({
+  handlers: {} as Record<string, (event: unknown, args?: unknown) => Promise<unknown>>
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (event: unknown, args?: unknown) => Promise<unknown>) => {
+      handlers[channel] = fn
+    }
+  }
+}))
+
+vi.mock('../redmine/client', () => ({
+  connectRedmineSite: vi.fn(),
+  disconnectRedmineSite: vi.fn(),
+  getRedmineStatus: vi.fn(),
+  testRedmineConnection: vi.fn()
+}))
+
+vi.mock('../redmine/issues', () => ({
+  getRedmineIssue: vi.fn(),
+  listRedmineIssues: vi.fn()
+}))
+
+vi.mock('../redmine/redmine-site-store', () => ({
+  readToken: vi.fn()
+}))
+
+const connectRedmineSiteMock = vi.mocked(connectRedmineSite)
+const disconnectRedmineSiteMock = vi.mocked(disconnectRedmineSite)
+const getRedmineStatusMock = vi.mocked(getRedmineStatus)
+const testRedmineConnectionMock = vi.mocked(testRedmineConnection)
+const getRedmineIssueMock = vi.mocked(getRedmineIssue)
+const listRedmineIssuesMock = vi.mocked(listRedmineIssues)
+const readTokenMock = vi.mocked(readToken)
+
+const invoke = (channel: string, args?: unknown) => handlers[channel](null, args)
+
+const site = {
+  id: 'https://rm.example.com',
+  siteUrl: 'https://rm.example.com',
+  displayName: 'rm',
+  hasToken: true
+}
+
+function connectedStatus() {
+  return { connected: true, activeSite: site, selectedSiteId: site.id, viewer: null, error: null }
+}
+function disconnectedStatus() {
+  return { connected: false, activeSite: null, selectedSiteId: null, viewer: null, error: null }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getRedmineStatusMock.mockReturnValue(disconnectedStatus())
+  registerRedmineHandlers()
+})
+
+describe('redmine:connect', () => {
+  it('rejects when required fields are missing', async () => {
+    expect(await invoke('redmine:connect', {})).toEqual({
+      ok: false,
+      error: { type: 'unknown', message: 'Server URL and API key are required.' }
+    })
+    expect(connectRedmineSiteMock).not.toHaveBeenCalled()
+  })
+
+  it('trims and forwards the connection when fields are present', async () => {
+    connectRedmineSiteMock.mockResolvedValue({
+      ok: true,
+      site,
+      viewer: { id: 1, name: 'Ada', login: 'ada' }
+    })
+    const result = await invoke('redmine:connect', {
+      siteUrl: '  https://rm.example.com  ',
+      apiKey: '  secret  '
+    })
+    expect(connectRedmineSiteMock).toHaveBeenCalledWith('https://rm.example.com', 'secret')
+    expect(result).toEqual({
+      ok: true,
+      site,
+      viewer: { id: 1, name: 'Ada', login: 'ada' }
+    })
+  })
+
+  it('maps a failed connection to ok:false', async () => {
+    connectRedmineSiteMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'auth', message: 'bad' }
+    })
+    const result = await invoke('redmine:connect', {
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'nope'
+    })
+    expect(result).toEqual({ ok: false, error: { type: 'auth', message: 'bad' } })
+  })
+})
+
+describe('redmine:status', () => {
+  it('forwards the current status', async () => {
+    getRedmineStatusMock.mockReturnValue(connectedStatus())
+    expect(await invoke('redmine:status')).toEqual(connectedStatus())
+  })
+})
+
+describe('redmine:listIssues', () => {
+  it('returns an auth error when no site is connected', async () => {
+    const result = await invoke('redmine:listIssues', { filter: { scope: 'assigned' } })
+    expect(result).toEqual({
+      items: [],
+      totalCount: 0,
+      error: { type: 'auth', message: 'No Redmine site connected.' }
+    })
+    expect(listRedmineIssuesMock).not.toHaveBeenCalled()
+  })
+
+  it('lists issues using the active site token', async () => {
+    getRedmineStatusMock.mockReturnValue(connectedStatus())
+    readTokenMock.mockReturnValue('secret')
+    listRedmineIssuesMock.mockResolvedValue({ items: [], totalCount: 0 })
+    await invoke('redmine:listIssues', { filter: { scope: 'assigned' } })
+    expect(listRedmineIssuesMock).toHaveBeenCalledWith('https://rm.example.com', 'secret', {
+      scope: 'assigned'
+    })
+  })
+})
+
+describe('redmine:getIssue', () => {
+  it('returns null when no site is connected', async () => {
+    expect(await invoke('redmine:getIssue', { issueId: 1 })).toBeNull()
+  })
+
+  it('returns null for a non-finite issue id', async () => {
+    getRedmineStatusMock.mockReturnValue(connectedStatus())
+    readTokenMock.mockReturnValue('secret')
+    expect(await invoke('redmine:getIssue', {})).toBeNull()
+    expect(getRedmineIssueMock).not.toHaveBeenCalled()
+  })
+
+  it('fetches the issue through the active site', async () => {
+    getRedmineStatusMock.mockReturnValue(connectedStatus())
+    readTokenMock.mockReturnValue('secret')
+    const issue = { id: 1 } as never
+    getRedmineIssueMock.mockResolvedValue(issue)
+    await invoke('redmine:getIssue', { issueId: 1 })
+    expect(getRedmineIssueMock).toHaveBeenCalledWith('https://rm.example.com', 'secret', 1)
+  })
+})
+
+describe('redmine:disconnect', () => {
+  it('forwards a valid site id', async () => {
+    await invoke('redmine:disconnect', { siteId: 'site-a' })
+    expect(disconnectRedmineSiteMock).toHaveBeenCalledWith('site-a')
+  })
+
+  it('ignores a missing site id', async () => {
+    await invoke('redmine:disconnect', undefined)
+    expect(disconnectRedmineSiteMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('redmine:testConnection', () => {
+  it('returns ok:true with the user on success', async () => {
+    testRedmineConnectionMock.mockResolvedValue({ user: { id: 1, name: 'Ada', login: 'ada' } })
+    const result = await invoke('redmine:testConnection', {
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'k'
+    })
+    expect(result).toEqual({ ok: true, user: { id: 1, name: 'Ada', login: 'ada' } })
+  })
+})

--- a/src/main/ipc/redmine.ts
+++ b/src/main/ipc/redmine.ts
@@ -14,7 +14,10 @@ export function registerRedmineHandlers(): void {
     const siteUrl = typeof args?.siteUrl === 'string' ? args.siteUrl.trim() : ''
     const apiKey = typeof args?.apiKey === 'string' ? args.apiKey.trim() : ''
     if (!siteUrl || !apiKey) {
-      return { ok: false, error: { type: 'unknown', message: 'Server URL and API key are required.' } }
+      return {
+        ok: false,
+        error: { type: 'unknown', message: 'Server URL and API key are required.' }
+      }
     }
     const result = await connectRedmineSite(siteUrl, apiKey)
     if (!result.ok) {
@@ -39,7 +42,10 @@ export function registerRedmineHandlers(): void {
       const siteUrl = typeof args?.siteUrl === 'string' ? args.siteUrl.trim() : ''
       const apiKey = typeof args?.apiKey === 'string' ? args.apiKey.trim() : ''
       if (!siteUrl || !apiKey) {
-        return { ok: false, error: { type: 'unknown', message: 'Server URL and API key are required.' } }
+        return {
+          ok: false,
+          error: { type: 'unknown', message: 'Server URL and API key are required.' }
+        }
       }
       const result = await testRedmineConnection(siteUrl, apiKey)
       if (!result.user || result.error) {
@@ -55,7 +61,11 @@ export function registerRedmineHandlers(): void {
   ipcMain.handle('redmine:listIssues', async (_event, args?: { filter?: RedmineListFilter }) => {
     const creds = activeCredentials()
     if (!creds) {
-      return { items: [], totalCount: 0, error: { type: 'auth', message: 'No Redmine site connected.' } }
+      return {
+        items: [],
+        totalCount: 0,
+        error: { type: 'auth', message: 'No Redmine site connected.' }
+      }
     }
     return listRedmineIssues(creds.siteUrl, creds.apiKey, args?.filter ?? {})
   })

--- a/src/main/ipc/redmine.ts
+++ b/src/main/ipc/redmine.ts
@@ -1,0 +1,87 @@
+import { ipcMain } from 'electron'
+import type { RedmineListFilter } from '../../shared/redmine-types'
+import {
+  connectRedmineSite,
+  disconnectRedmineSite,
+  getRedmineStatus,
+  testRedmineConnection
+} from '../redmine/client'
+import { getRedmineIssue, listRedmineIssues } from '../redmine/issues'
+import { readToken } from '../redmine/redmine-site-store'
+
+export function registerRedmineHandlers(): void {
+  ipcMain.handle('redmine:connect', async (_event, args: { siteUrl?: string; apiKey?: string }) => {
+    const siteUrl = typeof args?.siteUrl === 'string' ? args.siteUrl.trim() : ''
+    const apiKey = typeof args?.apiKey === 'string' ? args.apiKey.trim() : ''
+    if (!siteUrl || !apiKey) {
+      return { ok: false, error: { type: 'unknown', message: 'Server URL and API key are required.' } }
+    }
+    const result = await connectRedmineSite(siteUrl, apiKey)
+    if (!result.ok) {
+      return { ok: false, error: result.error }
+    }
+    return { ok: true, site: result.site, viewer: result.viewer }
+  })
+
+  ipcMain.handle('redmine:disconnect', async (_event, args?: { siteId?: string }) => {
+    if (typeof args?.siteId === 'string') {
+      disconnectRedmineSite(args.siteId)
+    }
+  })
+
+  ipcMain.handle('redmine:status', async () => {
+    return getRedmineStatus()
+  })
+
+  ipcMain.handle(
+    'redmine:testConnection',
+    async (_event, args: { siteUrl?: string; apiKey?: string }) => {
+      const siteUrl = typeof args?.siteUrl === 'string' ? args.siteUrl.trim() : ''
+      const apiKey = typeof args?.apiKey === 'string' ? args.apiKey.trim() : ''
+      if (!siteUrl || !apiKey) {
+        return { ok: false, error: { type: 'unknown', message: 'Server URL and API key are required.' } }
+      }
+      const result = await testRedmineConnection(siteUrl, apiKey)
+      if (!result.user || result.error) {
+        return {
+          ok: false,
+          error: result.error ?? { type: 'unknown', message: 'Unable to connect.' }
+        }
+      }
+      return { ok: true, user: result.user }
+    }
+  )
+
+  ipcMain.handle('redmine:listIssues', async (_event, args?: { filter?: RedmineListFilter }) => {
+    const creds = activeCredentials()
+    if (!creds) {
+      return { items: [], totalCount: 0, error: { type: 'auth', message: 'No Redmine site connected.' } }
+    }
+    return listRedmineIssues(creds.siteUrl, creds.apiKey, args?.filter ?? {})
+  })
+
+  ipcMain.handle('redmine:getIssue', async (_event, args?: { issueId?: number }) => {
+    const creds = activeCredentials()
+    const issueId = typeof args?.issueId === 'number' ? args.issueId : Number.NaN
+    if (!creds) {
+      return null
+    }
+    if (!Number.isFinite(issueId)) {
+      return null
+    }
+    return getRedmineIssue(creds.siteUrl, creds.apiKey, issueId)
+  })
+}
+
+function activeCredentials(): { siteUrl: string; apiKey: string } | null {
+  const status = getRedmineStatus()
+  const site = status.activeSite
+  if (!site) {
+    return null
+  }
+  const apiKey = readToken(site.id)
+  if (!apiKey) {
+    return null
+  }
+  return { siteUrl: site.siteUrl, apiKey }
+}

--- a/src/main/ipc/redmine.ts
+++ b/src/main/ipc/redmine.ts
@@ -4,10 +4,11 @@ import {
   connectRedmineSite,
   disconnectRedmineSite,
   getRedmineStatus,
+  redmineReadErrorForCredentials,
+  resolveRedmineCredentials,
   testRedmineConnection
 } from '../redmine/client'
-import { getRedmineIssue, listRedmineIssues } from '../redmine/issues'
-import { readToken } from '../redmine/redmine-site-store'
+import { getRedmineIssue, listRedmineIssues, RedmineRequestError } from '../redmine/issues'
 
 export function registerRedmineHandlers(): void {
   ipcMain.handle('redmine:connect', async (_event, args: { siteUrl?: string; apiKey?: string }) => {
@@ -59,39 +60,40 @@ export function registerRedmineHandlers(): void {
   )
 
   ipcMain.handle('redmine:listIssues', async (_event, args?: { filter?: RedmineListFilter }) => {
-    const creds = activeCredentials()
-    if (!creds) {
+    const creds = resolveRedmineCredentials()
+    if (!creds.ok) {
       return {
         items: [],
         totalCount: 0,
-        error: { type: 'auth', message: 'No Redmine site connected.' }
+        error: redmineReadErrorForCredentials(creds.reason)
       }
     }
-    return listRedmineIssues(creds.siteUrl, creds.apiKey, args?.filter ?? {})
+    try {
+      return await listRedmineIssues(creds.siteUrl, creds.apiKey, args?.filter ?? {})
+    } catch (error) {
+      if (error instanceof RedmineRequestError) {
+        return { items: [], totalCount: 0, error: error.classified }
+      }
+      throw error
+    }
   })
 
   ipcMain.handle('redmine:getIssue', async (_event, args?: { issueId?: number }) => {
-    const creds = activeCredentials()
+    const creds = resolveRedmineCredentials()
     const issueId = typeof args?.issueId === 'number' ? args.issueId : Number.NaN
-    if (!creds) {
-      return null
+    if (!creds.ok) {
+      return { issue: null, error: redmineReadErrorForCredentials(creds.reason) }
     }
     if (!Number.isFinite(issueId)) {
-      return null
+      return { issue: null }
     }
-    return getRedmineIssue(creds.siteUrl, creds.apiKey, issueId)
+    try {
+      return { issue: await getRedmineIssue(creds.siteUrl, creds.apiKey, issueId) }
+    } catch (error) {
+      if (error instanceof RedmineRequestError) {
+        return { issue: null, error: error.classified }
+      }
+      throw error
+    }
   })
-}
-
-function activeCredentials(): { siteUrl: string; apiKey: string } | null {
-  const status = getRedmineStatus()
-  const site = status.activeSite
-  if (!site) {
-    return null
-  }
-  const apiKey = readToken(site.id)
-  if (!apiKey) {
-    return null
-  }
-  return { siteUrl: site.siteUrl, apiKey }
 }

--- a/src/main/ipc/register-core-handlers/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.ts
@@ -14,6 +14,7 @@ import { registerGitLabHandlers } from '../gitlab'
 import { registerHostedReviewHandlers } from '../hosted-review'
 import { registerLinearHandlers } from '../linear'
 import { registerJiraHandlers } from '../jira'
+import { registerRedmineHandlers } from '../redmine'
 import { registerBitbucketHandlers } from '../bitbucket'
 import { registerFeedbackHandlers } from '../feedback'
 import { registerCrashReportingHandlers } from '../crash-reporting'
@@ -154,6 +155,7 @@ export function registerCoreHandlers(
   registerHostedReviewHandlers(store, stats)
   registerLinearHandlers()
   registerJiraHandlers()
+  registerRedmineHandlers()
   registerBitbucketHandlers()
   registerFeedbackHandlers()
   if (crashReports) {

--- a/src/main/redmine/client.test.ts
+++ b/src/main/redmine/client.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  classifyRedmineError,
+  redmineRequest
+} from './redmine-request'
+import {
+  credentialErrors,
+  deleteToken,
+  getSiteFile,
+  hasStoredToken,
+  readToken,
+  saveToken,
+  writeSiteFile
+} from './redmine-site-store'
+import {
+  _readRedmineTokenForTest,
+  connectRedmineSite,
+  disconnectRedmineSite,
+  getRedmineStatus,
+  redmineSiteForId,
+  redmineSiteIdForUrl,
+  testRedmineConnection
+} from './client'
+import type { RedmineReadError, RedmineSite } from '../../shared/redmine-types'
+import type { RedmineSiteFile } from './redmine-site-store'
+
+vi.mock('./redmine-request', () => ({
+  classifyRedmineError: vi.fn(),
+  normalizeRedmineUrl: vi.fn((url: string) => url.replace(/\/+$/, '')),
+  redmineRequest: vi.fn()
+}))
+
+vi.mock('./redmine-site-store', () => ({
+  getSiteFile: vi.fn(),
+  writeSiteFile: vi.fn(),
+  saveToken: vi.fn(),
+  deleteToken: vi.fn(),
+  readToken: vi.fn(() => null),
+  hasStoredToken: vi.fn(() => true),
+  credentialErrors: {
+    get: vi.fn(() => undefined),
+    values: () => [][Symbol.iterator]()
+  }
+}))
+
+const mockReadError = (type: RedmineReadError['type']): RedmineReadError => ({
+  type,
+  message: `msg:${type}`
+})
+
+const redmineRequestMock = vi.mocked(redmineRequest)
+const classifyRedmineErrorMock = vi.mocked(classifyRedmineError)
+const getSiteFileMock = vi.mocked(getSiteFile)
+const writeSiteFileMock = vi.mocked(writeSiteFile)
+const saveTokenMock = vi.mocked(saveToken)
+const deleteTokenMock = vi.mocked(deleteToken)
+const readTokenMock = vi.mocked(readToken)
+const hasStoredTokenMock = vi.mocked(hasStoredToken)
+const credentialErrorsGetMock = vi.mocked(credentialErrors.get)
+
+function emptyFile(): RedmineSiteFile {
+  return {
+    version: 1,
+    activeSiteId: null,
+    selectedSiteId: null,
+    sites: []
+  }
+}
+
+function aSite(id: string, siteUrl: string): RedmineSite {
+  return { id, siteUrl, displayName: new URL(siteUrl).hostname, hasToken: true }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  hasStoredTokenMock.mockReturnValue(true)
+  getSiteFileMock.mockReturnValue(emptyFile())
+  writeSiteFileMock.mockImplementation((file) => {
+    getSiteFileMock.mockReturnValue(file)
+  })
+})
+
+describe('redmineSiteIdForUrl', () => {
+  it('derives the site id from the normalized URL', () => {
+    expect(redmineSiteIdForUrl('https://redmine.example.com/')).toBe(
+      'https://redmine.example.com'
+    )
+  })
+})
+
+describe('testRedmineConnection', () => {
+  it('returns the current user on success', async () => {
+    redmineRequestMock.mockResolvedValue({
+      user: { id: 7, firstname: 'Ada', lastname: 'Lovelace', login: 'ada' }
+    })
+    const result = await testRedmineConnection('https://redmine.example.com', 'secret')
+    expect(result.user).toEqual({ id: 7, name: 'Ada Lovelace', login: 'ada' })
+    expect(result.error).toBeUndefined()
+  })
+
+  it('folds a not_found read error into an unknown connection error', async () => {
+    redmineRequestMock.mockRejectedValue(mockReadError('not_found'))
+    classifyRedmineErrorMock.mockReturnValue(mockReadError('not_found'))
+    const result = await testRedmineConnection('https://redmine.example.com', 'secret')
+    expect(result.user).toBeNull()
+    expect(result.error?.type).toBe('unknown')
+  })
+
+  it('preserves an auth error type', async () => {
+    redmineRequestMock.mockRejectedValue(mockReadError('auth'))
+    classifyRedmineErrorMock.mockReturnValue(mockReadError('auth'))
+    const result = await testRedmineConnection('https://redmine.example.com', 'secret')
+    expect(result.error?.type).toBe('auth')
+  })
+})
+
+describe('connectRedmineSite', () => {
+  it('persists the token and writes a site entry on success', async () => {
+    redmineRequestMock.mockResolvedValue({ user: { id: 1, firstname: 'Grace', lastname: 'Hopper' } })
+    const result = await connectRedmineSite('https://redmine.example.com/', 'secret')
+    expect(result.ok).toBe(true)
+    expect(saveTokenMock).toHaveBeenCalledWith('https://redmine.example.com', 'secret')
+    expect(writeSiteFileMock).toHaveBeenCalled()
+    const written = writeSiteFileMock.mock.calls[0][0]
+    expect(written.sites[0].id).toBe('https://redmine.example.com')
+    expect(written.activeSiteId).toBe('https://redmine.example.com')
+  })
+
+  it('does not persist when the connection test fails', async () => {
+    redmineRequestMock.mockRejectedValue(mockReadError('network'))
+    classifyRedmineErrorMock.mockReturnValue(mockReadError('network'))
+    const result = await connectRedmineSite('https://redmine.example.com', 'secret')
+    expect(result.ok).toBe(false)
+    expect(saveTokenMock).not.toHaveBeenCalled()
+    expect(writeSiteFileMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('getRedmineStatus', () => {
+  it('reports disconnected when no site has a stored token', () => {
+    hasStoredTokenMock.mockReturnValue(false)
+    getSiteFileMock.mockReturnValue({ ...emptyFile() })
+    const status = getRedmineStatus()
+    expect(status.connected).toBe(false)
+    expect(status.activeSite).toBeNull()
+  })
+
+  it('reports a decryption error when the active site token cannot be decoded', () => {
+    getSiteFileMock.mockReturnValue({
+      ...emptyFile(),
+      activeSiteId: 'site-a',
+      selectedSiteId: 'site-a',
+      sites: [aSite('site-a', 'https://a.example.com')]
+    })
+    credentialErrorsGetMock.mockReturnValue('cannot decrypt')
+    const status = getRedmineStatus()
+    expect(status.connected).toBe(true)
+    expect(status.error).toEqual({ type: 'decryption', message: 'cannot decrypt' })
+  })
+})
+
+describe('disconnectRedmineSite', () => {
+  it('removes the site, clears the token, and promotes the next site', () => {
+    getSiteFileMock.mockReturnValue({
+      ...emptyFile(),
+      activeSiteId: 'site-a',
+      selectedSiteId: 'site-a',
+      sites: [aSite('site-a', 'https://a.example.com'), aSite('site-b', 'https://b.example.com')]
+    })
+    disconnectRedmineSite('site-a')
+    expect(deleteTokenMock).toHaveBeenCalledWith('site-a')
+    const written = writeSiteFileMock.mock.calls[0][0]
+    expect(written.sites.map((s: { id: string }) => s.id)).toEqual(['site-b'])
+    expect(written.activeSiteId).toBe('site-b')
+  })
+})
+
+describe('redmineSiteForId / token readback', () => {
+  it('finds a site by id and exposes its stored token for tests', () => {
+    getSiteFileMock.mockReturnValue({
+      ...emptyFile(),
+      sites: [aSite('site-a', 'https://a.example.com')]
+    })
+    readTokenMock.mockReturnValue('decoded-secret')
+    expect(redmineSiteForId('site-a')?.siteUrl).toBe('https://a.example.com')
+    expect(redmineSiteForId('missing')).toBeNull()
+    expect(_readRedmineTokenForTest('site-a')).toBe('decoded-secret')
+  })
+})

--- a/src/main/redmine/client.test.ts
+++ b/src/main/redmine/client.test.ts
@@ -20,6 +20,7 @@ import {
 } from './client'
 import type { RedmineReadError, RedmineSite } from '../../shared/redmine-types'
 import type { RedmineSiteFile } from './redmine-site-store'
+import { CredentialDecryptionError } from '../integration-credential-file'
 
 vi.mock('./redmine-request', () => ({
   classifyRedmineError: vi.fn(),
@@ -153,6 +154,21 @@ describe('getRedmineStatus', () => {
     const status = getRedmineStatus()
     expect(status.connected).toBe(true)
     expect(status.error).toEqual({ type: 'decryption', message: 'cannot decrypt' })
+  })
+
+  it('detects a corrupt token on the first status call (before any readToken attempt)', () => {
+    getSiteFileMock.mockReturnValue({
+      ...emptyFile(),
+      activeSiteId: 'site-a',
+      selectedSiteId: 'site-a',
+      sites: [aSite('site-a', 'https://a.example.com')]
+    })
+    credentialErrorsGetMock.mockReturnValue(undefined)
+    readTokenMock.mockImplementation(() => {
+      throw new CredentialDecryptionError('Redmine')
+    })
+    const status = getRedmineStatus()
+    expect(status.error?.type).toBe('decryption')
   })
 })
 

--- a/src/main/redmine/client.test.ts
+++ b/src/main/redmine/client.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import {
-  classifyRedmineError,
-  redmineRequest
-} from './redmine-request'
+import { classifyRedmineError, redmineRequest } from './redmine-request'
 import {
   credentialErrors,
   deleteToken,
@@ -82,9 +79,7 @@ beforeEach(() => {
 
 describe('redmineSiteIdForUrl', () => {
   it('derives the site id from the normalized URL', () => {
-    expect(redmineSiteIdForUrl('https://redmine.example.com/')).toBe(
-      'https://redmine.example.com'
-    )
+    expect(redmineSiteIdForUrl('https://redmine.example.com/')).toBe('https://redmine.example.com')
   })
 })
 
@@ -116,7 +111,9 @@ describe('testRedmineConnection', () => {
 
 describe('connectRedmineSite', () => {
   it('persists the token and writes a site entry on success', async () => {
-    redmineRequestMock.mockResolvedValue({ user: { id: 1, firstname: 'Grace', lastname: 'Hopper' } })
+    redmineRequestMock.mockResolvedValue({
+      user: { id: 1, firstname: 'Grace', lastname: 'Hopper' }
+    })
     const result = await connectRedmineSite('https://redmine.example.com/', 'secret')
     expect(result.ok).toBe(true)
     expect(saveTokenMock).toHaveBeenCalledWith('https://redmine.example.com', 'secret')

--- a/src/main/redmine/client.ts
+++ b/src/main/redmine/client.ts
@@ -117,6 +117,18 @@ export function getRedmineStatus(): RedmineConnectionStatus {
 
   let error: RedmineConnectionStatus['error'] | null = null
   if (activeSite) {
+    // Why: hasStoredToken only checks file content, so probe decryption once
+    // here — otherwise a corrupt key reports connected:true with no error on
+    // the first status call after startup.
+    try {
+      readToken(activeSite.id)
+    } catch (cause) {
+      if (cause instanceof CredentialDecryptionError) {
+        error = { type: 'decryption', message: 'Stored Redmine API key could not be decrypted.' }
+      } else {
+        throw cause
+      }
+    }
     const credentialError = credentialErrors.get(activeSite.id)
     if (credentialError) {
       error = { type: 'decryption', message: credentialError }

--- a/src/main/redmine/client.ts
+++ b/src/main/redmine/client.ts
@@ -1,13 +1,5 @@
-import type {
-  RedmineConnectionStatus,
-  RedmineSite,
-  RedmineUser
-} from '../../shared/redmine-types'
-import {
-  classifyRedmineError,
-  normalizeRedmineUrl,
-  redmineRequest
-} from './redmine-request'
+import type { RedmineConnectionStatus, RedmineSite, RedmineUser } from '../../shared/redmine-types'
+import { classifyRedmineError, normalizeRedmineUrl, redmineRequest } from './redmine-request'
 import {
   credentialErrors,
   deleteToken,
@@ -47,18 +39,20 @@ export async function testRedmineConnection(
   apiKey: string
 ): Promise<{ user: RedmineUser | null; error?: RedmineConnectionStatus['error'] }> {
   try {
-    const data = await redmineRequest<{ user?: { id?: number; firstname?: string; lastname?: string; login?: string } }>(
-      siteUrl,
-      apiKey,
-      '/users/current.json',
-      { signal: AbortSignal.timeout(TEST_REQUEST_TIMEOUT_MS) }
-    )
+    const data = await redmineRequest<{
+      user?: { id?: number; firstname?: string; lastname?: string; login?: string }
+    }>(siteUrl, apiKey, '/users/current.json', {
+      signal: AbortSignal.timeout(TEST_REQUEST_TIMEOUT_MS)
+    })
     const user = data?.user
     if (user && typeof user.id === 'number') {
       const name = [user.firstname, user.lastname].filter(Boolean).join(' ') || `User ${user.id}`
       return { user: { id: user.id, name, login: user.login ?? null } }
     }
-    return { user: null, error: { type: 'unknown', message: 'Redmine returned an unexpected user payload.' } }
+    return {
+      user: null,
+      error: { type: 'unknown', message: 'Redmine returned an unexpected user payload.' }
+    }
   } catch (error) {
     return { user: null, error: toConnectionError(error) }
   }
@@ -67,10 +61,18 @@ export async function testRedmineConnection(
 export async function connectRedmineSite(
   siteUrl: string,
   apiKey: string
-): Promise<{ ok: boolean; site?: RedmineSite; viewer?: RedmineUser; error?: RedmineConnectionStatus['error'] }> {
+): Promise<{
+  ok: boolean
+  site?: RedmineSite
+  viewer?: RedmineUser
+  error?: RedmineConnectionStatus['error']
+}> {
   const connection = await testRedmineConnection(siteUrl, apiKey)
   if (connection.error || !connection.user) {
-    return { ok: false, error: connection.error ?? { type: 'unknown', message: 'Unable to connect.' } }
+    return {
+      ok: false,
+      error: connection.error ?? { type: 'unknown', message: 'Unable to connect.' }
+    }
   }
 
   const id = redmineSiteIdForUrl(siteUrl)

--- a/src/main/redmine/client.ts
+++ b/src/main/redmine/client.ts
@@ -1,4 +1,9 @@
-import type { RedmineConnectionStatus, RedmineSite, RedmineUser } from '../../shared/redmine-types'
+import type {
+  RedmineConnectionStatus,
+  RedmineReadError,
+  RedmineSite,
+  RedmineUser
+} from '../../shared/redmine-types'
 import { classifyRedmineError, normalizeRedmineUrl, redmineRequest } from './redmine-request'
 import {
   credentialErrors,
@@ -9,6 +14,7 @@ import {
   saveToken,
   writeSiteFile
 } from './redmine-site-store'
+import { CredentialDecryptionError } from '../integration-credential-file'
 
 const TEST_REQUEST_TIMEOUT_MS = 8000
 
@@ -133,4 +139,50 @@ export function getRedmineStatus(): RedmineConnectionStatus {
 
 export function _readRedmineTokenForTest(siteId: string): string | null {
   return readToken(siteId)
+}
+
+export type RedmineReadCredentials =
+  | { ok: true; siteUrl: string; apiKey: string }
+  | { ok: false; reason: 'no_site' | 'no_token' | 'decryption' }
+
+// Why: shared by the IPC and runtime-RPC read handlers so a credential that
+// cannot be decrypted (keychain denied / app re-signed) surfaces a structured
+// reconnect error instead of rejecting callers who own the result shape.
+export function resolveRedmineCredentials(): RedmineReadCredentials {
+  const status = getRedmineStatus()
+  const site = status.activeSite
+  if (!site) {
+    return { ok: false, reason: 'no_site' }
+  }
+  try {
+    const apiKey = readToken(site.id)
+    if (!apiKey) {
+      return { ok: false, reason: 'no_token' }
+    }
+    return { ok: true, siteUrl: site.siteUrl, apiKey }
+  } catch (error) {
+    if (error instanceof CredentialDecryptionError) {
+      return { ok: false, reason: 'decryption' }
+    }
+    throw error
+  }
+}
+
+export function redmineReadErrorForCredentials(
+  reason: 'no_site' | 'no_token' | 'decryption'
+): RedmineReadError {
+  switch (reason) {
+    case 'no_site':
+      return { type: 'auth', message: 'No Redmine site connected.' }
+    case 'no_token':
+      return {
+        type: 'auth',
+        message: 'The Redmine site has no stored API key. Reconnect to add one.'
+      }
+    case 'decryption':
+      return {
+        type: 'auth',
+        message: 'Your stored Redmine API key could not be decrypted. Reconnect to re-enter it.'
+      }
+  }
 }

--- a/src/main/redmine/client.ts
+++ b/src/main/redmine/client.ts
@@ -1,0 +1,134 @@
+import type {
+  RedmineConnectionStatus,
+  RedmineSite,
+  RedmineUser
+} from '../../shared/redmine-types'
+import {
+  classifyRedmineError,
+  normalizeRedmineUrl,
+  redmineRequest
+} from './redmine-request'
+import {
+  credentialErrors,
+  deleteToken,
+  getSiteFile,
+  hasStoredToken,
+  readToken,
+  saveToken,
+  writeSiteFile
+} from './redmine-site-store'
+
+const TEST_REQUEST_TIMEOUT_MS = 8000
+
+// The site id is the normalized server URL; it is stable across sessions and
+// used to derive the encrypted token filename.
+export function redmineSiteIdForUrl(siteUrl: string): string {
+  return normalizeRedmineUrl(siteUrl)
+}
+
+export function redmineSiteForId(siteId: string): RedmineSite | null {
+  const file = getSiteFile()
+  return file.sites.find((site) => site.id === siteId) ?? null
+}
+
+// The connection classifier yields RedmineReadError (which can carry
+// 'not_found'); connection status only exposes lifecycle errors, so fold
+// not_found into 'unknown'.
+function toConnectionError(error: unknown): RedmineConnectionStatus['error'] {
+  const read = classifyRedmineError(error)
+  return {
+    type: read.type === 'not_found' ? 'unknown' : read.type,
+    message: read.message
+  }
+}
+
+export async function testRedmineConnection(
+  siteUrl: string,
+  apiKey: string
+): Promise<{ user: RedmineUser | null; error?: RedmineConnectionStatus['error'] }> {
+  try {
+    const data = await redmineRequest<{ user?: { id?: number; firstname?: string; lastname?: string; login?: string } }>(
+      siteUrl,
+      apiKey,
+      '/users/current.json',
+      { signal: AbortSignal.timeout(TEST_REQUEST_TIMEOUT_MS) }
+    )
+    const user = data?.user
+    if (user && typeof user.id === 'number') {
+      const name = [user.firstname, user.lastname].filter(Boolean).join(' ') || `User ${user.id}`
+      return { user: { id: user.id, name, login: user.login ?? null } }
+    }
+    return { user: null, error: { type: 'unknown', message: 'Redmine returned an unexpected user payload.' } }
+  } catch (error) {
+    return { user: null, error: toConnectionError(error) }
+  }
+}
+
+export async function connectRedmineSite(
+  siteUrl: string,
+  apiKey: string
+): Promise<{ ok: boolean; site?: RedmineSite; viewer?: RedmineUser; error?: RedmineConnectionStatus['error'] }> {
+  const connection = await testRedmineConnection(siteUrl, apiKey)
+  if (connection.error || !connection.user) {
+    return { ok: false, error: connection.error ?? { type: 'unknown', message: 'Unable to connect.' } }
+  }
+
+  const id = redmineSiteIdForUrl(siteUrl)
+  saveToken(id, apiKey)
+  const file = getSiteFile()
+  const site: RedmineSite = {
+    id,
+    siteUrl: normalizeRedmineUrl(siteUrl),
+    displayName: new URL(normalizeRedmineUrl(siteUrl)).hostname,
+    hasToken: true
+  }
+  const sites = file.sites.filter((existing) => existing.id !== id)
+  sites.unshift(site)
+  writeSiteFile({ ...file, activeSiteId: id, selectedSiteId: id, sites })
+  return { ok: true, site, viewer: connection.user }
+}
+
+export function disconnectRedmineSite(siteId: string): void {
+  deleteToken(siteId)
+  const file = getSiteFile()
+  const remaining = file.sites.filter((site) => site.id !== siteId)
+  const nextActive = remaining[0]?.id ?? null
+  writeSiteFile({
+    ...file,
+    sites: remaining,
+    activeSiteId: nextActive,
+    selectedSiteId: nextActive
+  })
+}
+
+export function getRedmineStatus(): RedmineConnectionStatus {
+  const file = getSiteFile()
+  const sites = file.sites.filter((site) => hasStoredToken(site.id))
+  const activeSite = sites.find((site) => site.id === file.activeSiteId) ?? sites[0] ?? null
+  const connected = Boolean(activeSite)
+
+  let error: RedmineConnectionStatus['error'] | null = null
+  if (activeSite) {
+    const credentialError = credentialErrors.get(activeSite.id)
+    if (credentialError) {
+      error = { type: 'decryption', message: credentialError }
+    }
+  } else {
+    const firstError = credentialErrors.values().next().value as string | undefined
+    if (firstError) {
+      error = { type: 'decryption', message: firstError }
+    }
+  }
+
+  return {
+    connected,
+    activeSite,
+    selectedSiteId: file.selectedSiteId,
+    viewer: null,
+    error
+  }
+}
+
+export function _readRedmineTokenForTest(siteId: string): string | null {
+  return readToken(siteId)
+}

--- a/src/main/redmine/issues.test.ts
+++ b/src/main/redmine/issues.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { redmineRequest } from './redmine-request'
+import { mapRedmineIssue } from './mappers'
+import { listRedmineIssues, getRedmineIssue } from './issues'
+
+vi.mock('./redmine-request', () => ({
+  classifyRedmineError: vi.fn(),
+  redmineRequest: vi.fn()
+}))
+
+vi.mock('./mappers', () => ({
+  mapRedmineIssue: vi.fn()
+}))
+
+const redmineRequestMock = vi.mocked(redmineRequest)
+const mapRedmineIssueMock = vi.mocked(mapRedmineIssue)
+
+const rawIssue = { id: 1, subject: 'x' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  redmineRequestMock.mockResolvedValue({ issues: [rawIssue], total_count: 1 })
+  mapRedmineIssueMock.mockReturnValue({ id: 1 } as never)
+})
+
+describe('listRedmineIssues pagination', () => {
+  it('clamps limit to 100 and derives offset from the clamped value', async () => {
+    await listRedmineIssues('https://x.example', 'k', { limit: 200, page: 2 })
+    expect(redmineRequestMock).toHaveBeenCalledWith(
+      'https://x.example',
+      'k',
+      '/issues.json?limit=100&offset=100',
+      expect.anything()
+    )
+  })
+
+  it('bounds a negative limit to 1', async () => {
+    await listRedmineIssues('https://x.example', 'k', { limit: -5, page: 1 })
+    expect(redmineRequestMock).toHaveBeenCalledWith(
+      'https://x.example',
+      'k',
+      '/issues.json?limit=1&offset=0',
+      expect.anything()
+    )
+  })
+
+  it('defaults to a 20-item first page when no filter is given', async () => {
+    await listRedmineIssues('https://x.example', 'k')
+    expect(redmineRequestMock).toHaveBeenCalledWith(
+      'https://x.example',
+      'k',
+      '/issues.json?limit=20&offset=0',
+      expect.anything()
+    )
+  })
+})
+
+describe('getRedmineIssue', () => {
+  it('maps the detail response through the issue mapper', async () => {
+    redmineRequestMock.mockResolvedValue({ issue: rawIssue })
+    const result = await getRedmineIssue('https://x.example', 'k', 1)
+    expect(redmineRequestMock).toHaveBeenCalledWith(
+      'https://x.example',
+      'k',
+      '/issues/1.json?include=journals,attachments',
+      expect.anything()
+    )
+    expect(mapRedmineIssueMock).toHaveBeenCalledWith(rawIssue, 'https://x.example')
+    expect(result).toEqual({ id: 1 })
+  })
+})

--- a/src/main/redmine/issues.ts
+++ b/src/main/redmine/issues.ts
@@ -1,0 +1,92 @@
+import type {
+  RedmineIssue,
+  RedmineIssueCollectionResult,
+  RedmineListFilter
+} from '../../shared/redmine-types'
+import {
+  classifyRedmineError,
+  redmineRequest,
+  type RedmineApiError
+} from './redmine-request'
+import {
+  mapRedmineIssue,
+  type RawRedmineIssueDetail,
+  type RawRedmineIssueList
+} from './mappers'
+
+const LIST_REQUEST_TIMEOUT_MS = 8000
+const DETAIL_REQUEST_TIMEOUT_MS = 8000
+
+/**
+ * Lists issues for a site, read-only. List responses deliberately avoid
+ * `include=journals/attachments` to keep payloads small; the detail lookup
+ * adds them.
+ */
+export async function listRedmineIssues(
+  siteUrl: string,
+  apiKey: string,
+  filter: RedmineListFilter = {}
+): Promise<RedmineIssueCollectionResult> {
+  const params = new URLSearchParams()
+  params.set('limit', String(Math.min(filter.limit ?? 20, 100)))
+  const page = Math.max(filter.page ?? 1, 1)
+  params.set('offset', String((page - 1) * (filter.limit ?? 20)))
+
+  if (filter.scope === 'assigned') {
+    params.set('assigned_to_id', 'me')
+  } else if (filter.scope === 'created') {
+    params.set('author_id', 'me')
+  }
+  if (filter.state === 'open' || filter.state === 'closed') {
+    params.set('status_id', filter.state)
+  }
+
+  try {
+    const data = await redmineRequest<RawRedmineIssueList>(
+      siteUrl,
+      apiKey,
+      `/issues.json?${params.toString()}`,
+      { signal: AbortSignal.timeout(LIST_REQUEST_TIMEOUT_MS) }
+    )
+    const items = (data?.issues ?? []).map((issue) => mapRedmineIssue(issue, siteUrl))
+    return { items, totalCount: data?.total_count ?? items.length }
+  } catch (error) {
+    handleRedmineError(error)
+  }
+}
+
+export async function getRedmineIssue(
+  siteUrl: string,
+  apiKey: string,
+  issueId: number
+): Promise<RedmineIssue | null> {
+  try {
+    const data = await redmineRequest<RawRedmineIssueDetail>(
+      siteUrl,
+      apiKey,
+      `/issues/${issueId}.json?include=journals,attachments`,
+      { signal: AbortSignal.timeout(DETAIL_REQUEST_TIMEOUT_MS) }
+    )
+    return data?.issue ? mapRedmineIssue(data.issue, siteUrl) : null
+  } catch (error) {
+    handleRedmineError(error)
+  }
+}
+
+function handleRedmineError(error: unknown): never {
+  const classified = classifyRedmineError(error)
+  const apiError = error as RedmineApiError
+  throw new RedmineRequestError(classified, apiError.status ?? classified.status ?? null)
+}
+
+export class RedmineRequestError extends Error {
+  readonly classified: RedmineIssueCollectionResult['error']
+  readonly status: number | null
+
+  constructor(classified: RedmineIssueCollectionResult['error'], status: number | null) {
+    super(classified?.message ?? 'Redmine request failed')
+    this.name = 'RedmineRequestError'
+    this.classified = classified
+    this.status = status
+  }
+}

--- a/src/main/redmine/issues.ts
+++ b/src/main/redmine/issues.ts
@@ -3,16 +3,8 @@ import type {
   RedmineIssueCollectionResult,
   RedmineListFilter
 } from '../../shared/redmine-types'
-import {
-  classifyRedmineError,
-  redmineRequest,
-  type RedmineApiError
-} from './redmine-request'
-import {
-  mapRedmineIssue,
-  type RawRedmineIssueDetail,
-  type RawRedmineIssueList
-} from './mappers'
+import { classifyRedmineError, redmineRequest, type RedmineApiError } from './redmine-request'
+import { mapRedmineIssue, type RawRedmineIssueDetail, type RawRedmineIssueList } from './mappers'
 
 const LIST_REQUEST_TIMEOUT_MS = 8000
 const DETAIL_REQUEST_TIMEOUT_MS = 8000

--- a/src/main/redmine/issues.ts
+++ b/src/main/redmine/issues.ts
@@ -20,9 +20,10 @@ export async function listRedmineIssues(
   filter: RedmineListFilter = {}
 ): Promise<RedmineIssueCollectionResult> {
   const params = new URLSearchParams()
-  params.set('limit', String(Math.min(filter.limit ?? 20, 100)))
-  const page = Math.max(filter.page ?? 1, 1)
-  params.set('offset', String((page - 1) * (filter.limit ?? 20)))
+  const limit = Math.min(Math.max(Math.floor(filter.limit ?? 20), 1), 100)
+  const page = Math.max(Math.floor(filter.page ?? 1), 1)
+  params.set('limit', String(limit))
+  params.set('offset', String((page - 1) * limit))
 
   if (filter.scope === 'assigned') {
     params.set('assigned_to_id', 'me')

--- a/src/main/redmine/mappers.test.ts
+++ b/src/main/redmine/mappers.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { mapRedmineIssue, mapRedmineProject, mapRedmineUser } from './mappers'
+
+describe('redmine mappers', () => {
+  it('maps a full issue payload to the shared shape', () => {
+    const issue = mapRedmineIssue(
+      {
+        id: 106927,
+        subject: 'Fix login flakiness',
+        project: { id: 12, name: 'ESB' },
+        tracker: { id: 1, name: 'Bug' },
+        status: { id: 2, name: 'In Progress', is_closed: false },
+        priority: { id: 4, name: 'High' },
+        author: { id: 654, name: 'Zhuo Cheng' },
+        assigned_to: { id: 219, name: 'Bao Zhu' },
+        description: 'Long description',
+        start_date: '2026-08-01',
+        due_date: null,
+        done_ratio: 40,
+        estimated_hours: 8,
+        spent_hours: 3.5,
+        created_on: '2026-08-01T09:00:00Z',
+        updated_on: '2026-08-05T10:30:00Z',
+        closed_on: null,
+        custom_fields: [
+          { id: 29, name: 'PIC', value: '654' },
+          { id: 45, name: 'AI usage', value: '90' }
+        ]
+      },
+      'http://redmine.example.com/'
+    )
+
+    expect(issue.id).toBe(106927)
+    expect(issue.subject).toBe('Fix login flakiness')
+    expect(issue.project).toEqual({ id: 12, name: 'ESB' })
+    expect(issue.status).toEqual({ id: 2, name: 'In Progress', isClosed: false })
+    expect(issue.priority).toEqual({ id: 4, name: 'High' })
+    expect(issue.author).toEqual({ id: 654, name: 'Zhuo Cheng', login: null })
+    expect(issue.assignedTo).toEqual({ id: 219, name: 'Bao Zhu', login: null })
+    expect(issue.doneRatio).toBe(40)
+    expect(issue.estimatedHours).toBe(8)
+    expect(issue.spentHours).toBe(3.5)
+    expect(issue.dueDate).toBeNull()
+    expect(issue.closedOn).toBeNull()
+    expect(issue.customFields).toEqual([
+      { id: 29, name: 'PIC', value: '654' },
+      { id: 45, name: 'AI usage', value: '90' }
+    ])
+    expect(issue.url).toBe('http://redmine.example.com/issues/106927')
+  })
+
+  it('marks a closed status and strips trailing slash from the site URL', () => {
+    const issue = mapRedmineIssue(
+      {
+        id: 1,
+        subject: 'Done',
+        status: { id: 3, name: 'Resolved', is_closed: true },
+        project: { id: 1, name: 'P' },
+        priority: { id: 5, name: 'Normal' },
+        author: { id: 1, name: 'A' },
+        created_on: '2026-01-01T00:00:00Z',
+        updated_on: '2026-01-02T00:00:00Z',
+        done_ratio: 100,
+        closed_on: '2026-01-02T00:00:00Z'
+      },
+      'https://redmine.example.com///'
+    )
+    expect(issue.status.isClosed).toBe(true)
+    expect(issue.closedOn).toBe('2026-01-02T00:00:00Z')
+    expect(issue.url).toBe('https://redmine.example.com/issues/1')
+  })
+
+  it('tolerates missing optional fields', () => {
+    const issue = mapRedmineIssue({ id: 7, subject: 'Bare' }, 'http://r.example')
+    expect(issue.project.name).toBe('')
+    expect(issue.assignedTo).toBeNull()
+    expect(issue.description).toBeNull()
+    expect(issue.customFields).toEqual([])
+  })
+
+  it('maps project and user helpers, returning null for empty payloads', () => {
+    expect(mapRedmineProject({ id: 3, name: 'Portal', identifier: 'portal' })).toEqual({
+      id: 3,
+      name: 'Portal',
+      identifier: 'portal'
+    })
+    expect(mapRedmineProject(undefined)).toBeNull()
+    expect(mapRedmineUser({ id: 5, name: 'N', login: 'n' })).toEqual({ id: 5, name: 'N', login: 'n' })
+    expect(mapRedmineUser(undefined)).toBeNull()
+  })
+})

--- a/src/main/redmine/mappers.test.ts
+++ b/src/main/redmine/mappers.test.ts
@@ -27,7 +27,7 @@ describe('redmine mappers', () => {
           { id: 45, name: 'AI usage', value: '90' }
         ]
       },
-      'http://redmine.example.com/'
+      'https://redmine.example.com/'
     )
 
     expect(issue.id).toBe(106927)
@@ -46,7 +46,7 @@ describe('redmine mappers', () => {
       { id: 29, name: 'PIC', value: '654' },
       { id: 45, name: 'AI usage', value: '90' }
     ])
-    expect(issue.url).toBe('http://redmine.example.com/issues/106927')
+    expect(issue.url).toBe('https://redmine.example.com/issues/106927')
   })
 
   it('marks a closed status and strips trailing slash from the site URL', () => {
@@ -71,7 +71,7 @@ describe('redmine mappers', () => {
   })
 
   it('tolerates missing optional fields', () => {
-    const issue = mapRedmineIssue({ id: 7, subject: 'Bare' }, 'http://r.example')
+    const issue = mapRedmineIssue({ id: 7, subject: 'Bare' }, 'https://r.example')
     expect(issue.project.name).toBe('')
     expect(issue.assignedTo).toBeNull()
     expect(issue.description).toBeNull()

--- a/src/main/redmine/mappers.test.ts
+++ b/src/main/redmine/mappers.test.ts
@@ -85,7 +85,11 @@ describe('redmine mappers', () => {
       identifier: 'portal'
     })
     expect(mapRedmineProject(undefined)).toBeNull()
-    expect(mapRedmineUser({ id: 5, name: 'N', login: 'n' })).toEqual({ id: 5, name: 'N', login: 'n' })
+    expect(mapRedmineUser({ id: 5, name: 'N', login: 'n' })).toEqual({
+      id: 5,
+      name: 'N',
+      login: 'n'
+    })
     expect(mapRedmineUser(undefined)).toBeNull()
   })
 })

--- a/src/main/redmine/mappers.ts
+++ b/src/main/redmine/mappers.ts
@@ -1,0 +1,110 @@
+import type {
+  RedmineCustomField,
+  RedmineIssue,
+  RedmineProject,
+  RedmineUser
+} from '../../shared/redmine-types'
+import { normalizeRedmineUrl } from './redmine-request'
+
+// Raw payload shapes as Redmine's REST API returns them. Field names use the
+// server's snake_case; keep them here so the mapper stays a one-way, typed view.
+
+type RawIdName = { id: number; name?: string }
+type RawUser = { id: number; name?: string; login?: string }
+type RawProject = { id: number; name?: string; identifier?: string }
+
+export type RawRedmineIssue = {
+  id: number
+  project?: RawProject
+  tracker?: RawIdName
+  status?: RawIdName & { is_closed?: boolean }
+  priority?: RawIdName
+  author?: RawUser
+  assigned_to?: RawUser
+  subject?: string
+  description?: string | null
+  start_date?: string | null
+  due_date?: string | null
+  done_ratio?: number
+  estimated_hours?: number | null
+  spent_hours?: number | null
+  created_on?: string
+  updated_on?: string
+  closed_on?: string | null
+  custom_fields?: { id: number; name?: string; value?: unknown }[]
+}
+
+export type RawRedmineIssueList = { issues?: RawRedmineIssue[]; total_count?: number }
+
+export type RawRedmineIssueDetail = { issue?: RawRedmineIssue }
+
+export type RawRedmineUser = {
+  user?: { id: number; firstname?: string; lastname?: string; login?: string }
+}
+
+export function mapRedmineProject(raw?: RawProject): RedmineProject | null {
+  if (!raw || typeof raw.id !== 'number') {
+    return null
+  }
+  return { id: raw.id, name: raw.name ?? `Project ${raw.id}`, identifier: raw.identifier }
+}
+
+export function mapRedmineUser(raw?: RawUser): RedmineUser | null {
+  if (!raw || typeof raw.id !== 'number') {
+    return null
+  }
+  return { id: raw.id, name: raw.name ?? `User ${raw.id}`, login: raw.login ?? null }
+}
+
+export function mapRedmineIssue(raw: RawRedmineIssue, siteUrl: string): RedmineIssue {
+  const project = mapRedmineProject(raw.project)
+  const author = mapRedmineUser(raw.author)
+  const assignedTo = mapRedmineUser(raw.assigned_to)
+  return {
+    id: raw.id,
+    subject: raw.subject ?? '',
+    project: project ?? { id: 0, identifier: undefined, name: '' },
+    tracker: { id: raw.tracker?.id ?? 0, name: raw.tracker?.name ?? '' },
+    status: {
+      id: raw.status?.id ?? 0,
+      name: raw.status?.name ?? '',
+      isClosed: raw.status?.is_closed ?? false
+    },
+    priority: { id: raw.priority?.id ?? 0, name: raw.priority?.name ?? '' },
+    author: author ?? { id: 0, name: '', login: null },
+    assignedTo,
+    description: raw.description != null ? String(raw.description) : null,
+    startDate: raw.start_date ?? null,
+    dueDate: raw.due_date ?? null,
+    doneRatio: raw.done_ratio ?? 0,
+    estimatedHours: raw.estimated_hours ?? null,
+    spentHours: raw.spent_hours ?? null,
+    createdOn: raw.created_on ?? '',
+    updatedOn: raw.updated_on ?? '',
+    closedOn: raw.closed_on ?? null,
+    customFields: mapRedmineCustomFields(raw.custom_fields),
+    url: `${normalizeRedmineUrl(siteUrl)}/issues/${raw.id}`
+  }
+}
+
+function mapRedmineCustomFields(
+  rawFields?: { id: number; name?: string; value?: unknown }[]
+): RedmineCustomField[] {
+  if (!Array.isArray(rawFields)) {
+    return []
+  }
+  const fields: RedmineCustomField[] = []
+  for (const field of rawFields) {
+    if (typeof field.id !== 'number') {
+      continue
+    }
+    // Redmine returns array/multi-select values as arrays and booleans as
+    // strings; write them through verbatim so the renderer can display them.
+    fields.push({
+      id: field.id,
+      name: typeof field.name === 'string' ? field.name : `Custom field ${field.id}`,
+      value: field.value == null ? null : (field.value as RedmineCustomField['value'])
+    })
+  }
+  return fields
+}

--- a/src/main/redmine/redmine-credential-paths.ts
+++ b/src/main/redmine/redmine-credential-paths.ts
@@ -1,0 +1,18 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+function getOrcaDir(): string {
+  return join(homedir(), '.orca')
+}
+
+export function getRedmineSiteFilePath(): string {
+  return join(getOrcaDir(), 'redmine-sites.json')
+}
+
+export function getRedmineTokenDir(): string {
+  return join(getOrcaDir(), 'redmine-tokens')
+}
+
+export function getRedmineTokenPath(siteId: string): string {
+  return join(getRedmineTokenDir(), `${Buffer.from(siteId).toString('base64url')}.enc`)
+}

--- a/src/main/redmine/redmine-request.test.ts
+++ b/src/main/redmine/redmine-request.test.ts
@@ -1,7 +1,52 @@
-import { describe, expect, it } from 'vitest'
-import { classifyRedmineError, normalizeRedmineUrl, RedmineApiError } from './redmine-request'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  classifyRedmineError,
+  normalizeRedmineUrl,
+  RedmineApiError,
+  redmineRequest
+} from './redmine-request'
 
-describe('normalizeRedmineUrl https enforcement', () => {
+const { httpFetch } = vi.hoisted(() => ({ httpFetch: vi.fn() }))
+
+vi.mock('../network/http-client', () => ({
+  getMainHttpClient: vi.fn(() => ({
+    proxySession: () => null,
+    fetch: (...args: unknown[]) => httpFetch(...args)
+  }))
+}))
+vi.mock('../network/proxy-settings', () => ({
+  ensureElectronProxyFromEnvironment: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('../observability/tracer', () => ({
+  withSpan: (
+    name: string,
+    fn: (span: { setAttribute: () => void; addEvent: () => void }) => unknown
+  ) => {
+    void name
+    return fn({ setAttribute() {}, addEvent() {} })
+  }
+}))
+
+beforeEach(() => {
+  httpFetch.mockReset()
+})
+
+function stubResponse({ status, location }: { status: number; location?: string }) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'stub',
+    headers: { get: (key: string) => (key === 'location' ? (location ?? null) : null) },
+    json: async () => ({})
+  }
+}
+
+describe('normalizeRedmineUrl', () => {
+  it('auto-prepends https for a schema-less host (matches Jira behavior)', () => {
+    expect(normalizeRedmineUrl('redmine.example.com')).toBe('https://redmine.example.com')
+    expect(normalizeRedmineUrl('redmine.example.com/')).toBe('https://redmine.example.com')
+  })
+
   it('allows https hosts and trims a trailing slash', () => {
     expect(normalizeRedmineUrl('https://redmine.example.com/')).toBe('https://redmine.example.com')
   })
@@ -14,6 +59,7 @@ describe('normalizeRedmineUrl https enforcement', () => {
 
   it('rejects http on a non-loopback host (API key travels cleartext)', () => {
     expect(() => normalizeRedmineUrl('http://redmine.example.com')).toThrow(RedmineApiError)
+    expect(() => normalizeRedmineUrl('http://redmine.internal')).toThrow(RedmineApiError)
   })
 
   it('classifies the rejection as an unknown read error', () => {
@@ -24,6 +70,31 @@ describe('normalizeRedmineUrl https enforcement', () => {
       expect(classified.type).toBe('unknown')
       expect(classified.message).toMatch(/HTTPS/)
     }
+  })
+})
+
+describe('redmineRequest redirect guard', () => {
+  it('rejects a redirect to a cleartext http host before sending the API key', async () => {
+    httpFetch.mockResolvedValueOnce(
+      stubResponse({ status: 302, location: 'http://evil.example.com' })
+    )
+    await expect(
+      redmineRequest('https://good.example.com', 'api-key', '/issues.json')
+    ).rejects.toThrow(RedmineApiError)
+    // Never issued a second hop to the cleartext target.
+    expect(httpFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('follows a redirect to an https target', async () => {
+    httpFetch
+      .mockResolvedValueOnce(
+        stubResponse({ status: 302, location: 'https://good.example.com/relocated' })
+      )
+      .mockResolvedValueOnce(stubResponse({ status: 200 }))
+    await expect(redmineRequest('https://good.example.com', 'k', '/issues.json')).resolves.toEqual(
+      {}
+    )
+    expect(httpFetch).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/main/redmine/redmine-request.test.ts
+++ b/src/main/redmine/redmine-request.test.ts
@@ -96,6 +96,17 @@ describe('redmineRequest redirect guard', () => {
     )
     expect(httpFetch).toHaveBeenCalledTimes(2)
   })
+
+  it('rejects a cross-origin https redirect before forwarding the API key', async () => {
+    httpFetch.mockResolvedValueOnce(
+      stubResponse({ status: 302, location: 'https://evil.example.com/steal' })
+    )
+    await expect(redmineRequest('https://good.example.com', 'k', '/issues.json')).rejects.toThrow(
+      RedmineApiError
+    )
+    // Never forwarded the key to the other origin.
+    expect(httpFetch).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('classifyRedmineError', () => {

--- a/src/main/redmine/redmine-request.test.ts
+++ b/src/main/redmine/redmine-request.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { classifyRedmineError, normalizeRedmineUrl, RedmineApiError } from './redmine-request'
+
+describe('normalizeRedmineUrl https enforcement', () => {
+  it('allows https hosts and trims a trailing slash', () => {
+    expect(normalizeRedmineUrl('https://redmine.example.com/')).toBe('https://redmine.example.com')
+  })
+
+  it('allows http on loopback hosts', () => {
+    expect(normalizeRedmineUrl('http://127.0.0.1:9080')).toBe('http://127.0.0.1:9080')
+    expect(normalizeRedmineUrl('http://localhost:3000/')).toBe('http://localhost:3000')
+    expect(normalizeRedmineUrl('http://[::1]:8080')).toBe('http://[::1]:8080')
+  })
+
+  it('rejects http on a non-loopback host (API key travels cleartext)', () => {
+    expect(() => normalizeRedmineUrl('http://redmine.example.com')).toThrow(RedmineApiError)
+  })
+
+  it('classifies the rejection as an unknown read error', () => {
+    try {
+      normalizeRedmineUrl('http://redmine.example.com')
+    } catch (error) {
+      const classified = classifyRedmineError(error)
+      expect(classified.type).toBe('unknown')
+      expect(classified.message).toMatch(/HTTPS/)
+    }
+  })
+})
+
+describe('classifyRedmineError', () => {
+  it('classifies 401/403 as auth', () => {
+    expect(classifyRedmineError(new RedmineApiError('denied', 401)).type).toBe('auth')
+  })
+
+  it('classifies 404 as not_found', () => {
+    expect(classifyRedmineError(new RedmineApiError('missing', 404)).type).toBe('not_found')
+  })
+
+  it('classifies aborts as network', () => {
+    expect(classifyRedmineError(new DOMException('aborted', 'AbortError')).type).toBe('network')
+  })
+})

--- a/src/main/redmine/redmine-request.ts
+++ b/src/main/redmine/redmine-request.ts
@@ -48,6 +48,7 @@ async function redirectGuardedFetch(
   url: string,
   init: RequestInit
 ): Promise<Response> {
+  const initialOrigin = new URL(url).origin
   let current = url
   for (let hop = 0; hop < REDMINE_MAX_REDIRECTS; hop++) {
     assertSecureOrLoopbackUrl(current)
@@ -58,7 +59,13 @@ async function redirectGuardedFetch(
       if (!location) {
         return response
       }
-      current = new URL(location, current).toString()
+      const next = new URL(location, current).toString()
+      // Why: the API key is scoped to the configured site, so never forward it
+      // to a different origin even over https.
+      if (new URL(next).origin !== initialOrigin) {
+        throw new RedmineApiError(`Refusing to follow a redirect to a different origin: ${next}`)
+      }
+      current = next
       continue
     }
     return response

--- a/src/main/redmine/redmine-request.ts
+++ b/src/main/redmine/redmine-request.ts
@@ -65,9 +65,7 @@ async function readRedmineError(response: Response): Promise<string> {
 }
 
 export function normalizeRedmineUrl(value: string): string {
-  return value
-    .trim()
-    .replace(/\/+$/, '')
+  return value.trim().replace(/\/+$/, '')
 }
 
 export async function redmineRequest<T>(

--- a/src/main/redmine/redmine-request.ts
+++ b/src/main/redmine/redmine-request.ts
@@ -16,6 +16,7 @@ export class RedmineApiError extends Error {
 // so route requests through Electron's net.fetch (Chromium proxy/session state)
 // exactly like Jira, not through undici's stale-socket fetch.
 const REDMINE_API_USER_AGENT = 'Orca'
+const REDMINE_MAX_REDIRECTS = 5
 
 async function redmineFetch(url: string, init: RequestInit): Promise<Response> {
   return withSpan(
@@ -33,10 +34,36 @@ async function redmineFetch(url: string, init: RequestInit): Promise<Response> {
           errorMessage: error instanceof Error ? error.message : String(error)
         })
       })
-      return httpClient.fetch(url, init)
+      return redirectGuardedFetch(httpClient, url, init)
     },
     { kind: 'client' }
   )
+}
+
+// Why: follow redirects manually and validate every hop, so a redirect to a
+// cleartext host can never receive the X-Redmine-API-Key header. Chromium's
+// automatic redirect handling re-sends custom headers without target checks.
+async function redirectGuardedFetch(
+  httpClient: { fetch: (url: string, init: RequestInit) => Promise<Response> },
+  url: string,
+  init: RequestInit
+): Promise<Response> {
+  let current = url
+  for (let hop = 0; hop < REDMINE_MAX_REDIRECTS; hop++) {
+    assertSecureOrLoopbackUrl(current)
+    const response = await httpClient.fetch(current, { ...init, redirect: 'manual' })
+    const status = response.status
+    if (status >= 300 && status < 400) {
+      const location = response.headers.get('location')
+      if (!location) {
+        return response
+      }
+      current = new URL(location, current).toString()
+      continue
+    }
+    return response
+  }
+  throw new RedmineApiError(`Too many redirects while contacting ${url}`)
 }
 
 function buildHeaders(apiKey: string, init?: RequestInit): Headers {
@@ -65,13 +92,13 @@ async function readRedmineError(response: Response): Promise<string> {
 }
 
 export function normalizeRedmineUrl(value: string): string {
-  const normalized = value.trim().replace(/\/+$/, '')
-  // Why: the API key travels cleartext, so require HTTPS for any non-loopback
-  // host. Local self-hosted setups (localhost / 127.0.0.1 / ::1) stay usable.
-  const url = new URL(normalized)
-  if (url.protocol === 'http:' && !isLoopbackHostname(url.hostname)) {
-    throw new RedmineApiError('Redmine servers must use HTTPS, except on loopback.')
+  let normalized = value.trim().replace(/\/+$/, '')
+  // Why: schema-less input is common for self-hosted Redmine (like Jira's
+  // normalizeJiraSiteUrl); default it to https rather than failing URL parse.
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(normalized)) {
+    normalized = `https://${normalized}`
   }
+  assertSecureOrLoopbackUrl(normalized)
   return normalized
 }
 
@@ -81,6 +108,17 @@ function isLoopbackHostname(hostname: string): boolean {
     return true
   }
   return /^127(\.\d{1,3}){3}$/.test(host)
+}
+
+// Why: the API key travels cleartext, so require HTTPS for any non-loopback
+// host (loopback local self-hosted setups stay usable). Shared by the URL
+// normalizer and the redirect guard so a request can never send the key to a
+// plaintext target.
+export function assertSecureOrLoopbackUrl(urlString: string): void {
+  const url = new URL(urlString)
+  if (url.protocol === 'http:' && !isLoopbackHostname(url.hostname)) {
+    throw new RedmineApiError('Redmine servers must use HTTPS, except on loopback.')
+  }
 }
 
 export async function redmineRequest<T>(

--- a/src/main/redmine/redmine-request.ts
+++ b/src/main/redmine/redmine-request.ts
@@ -65,7 +65,22 @@ async function readRedmineError(response: Response): Promise<string> {
 }
 
 export function normalizeRedmineUrl(value: string): string {
-  return value.trim().replace(/\/+$/, '')
+  const normalized = value.trim().replace(/\/+$/, '')
+  // Why: the API key travels cleartext, so require HTTPS for any non-loopback
+  // host. Local self-hosted setups (localhost / 127.0.0.1 / ::1) stay usable.
+  const url = new URL(normalized)
+  if (url.protocol === 'http:' && !isLoopbackHostname(url.hostname)) {
+    throw new RedmineApiError('Redmine servers must use HTTPS, except on loopback.')
+  }
+  return normalized
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  if (host === 'localhost' || host === '[::1]' || host === '::1' || host.endsWith('.localhost')) {
+    return true
+  }
+  return /^127(\.\d{1,3}){3}$/.test(host)
 }
 
 export async function redmineRequest<T>(

--- a/src/main/redmine/redmine-request.ts
+++ b/src/main/redmine/redmine-request.ts
@@ -1,0 +1,111 @@
+import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
+import { getMainHttpClient } from '../network/http-client'
+import { withSpan } from '../observability/tracer'
+import type { RedmineReadError } from '../../shared/redmine-types'
+
+export class RedmineApiError extends Error {
+  status: number | null
+
+  constructor(message: string, status: number | null = null) {
+    super(message)
+    this.status = status
+  }
+}
+
+// Why: Redmine is self-hosted and often sits behind TLS inspection or proxies,
+// so route requests through Electron's net.fetch (Chromium proxy/session state)
+// exactly like Jira, not through undici's stale-socket fetch.
+const REDMINE_API_USER_AGENT = 'Orca'
+
+async function redmineFetch(url: string, init: RequestInit): Promise<Response> {
+  return withSpan(
+    'redmine.request',
+    async (span) => {
+      span.setAttribute('redmine.siteUrl', new URL(url).origin)
+      const httpClient = getMainHttpClient()
+      const proxySession = httpClient.proxySession()
+      await ensureElectronProxyFromEnvironment({
+        ...(proxySession ? { proxySession } : {}),
+        probeUrl: url
+      }).catch((error) => {
+        span.addEvent('redmine.proxySetupFailed', {
+          errorName: error instanceof Error ? error.name : typeof error,
+          errorMessage: error instanceof Error ? error.message : String(error)
+        })
+      })
+      return httpClient.fetch(url, init)
+    },
+    { kind: 'client' }
+  )
+}
+
+function buildHeaders(apiKey: string, init?: RequestInit): Headers {
+  const headers = new Headers(init?.headers)
+  headers.set('Accept', 'application/json')
+  headers.set('User-Agent', REDMINE_API_USER_AGENT)
+  // Redmine REST API authenticates via this header; no username or password.
+  headers.set('X-Redmine-API-Key', apiKey)
+  return headers
+}
+
+async function readRedmineError(response: Response): Promise<string> {
+  try {
+    const data = (await response.json()) as { errors?: string[]; message?: string }
+    const messages = [
+      ...(Array.isArray(data.errors) ? data.errors : []),
+      ...(data.message ? [data.message] : [])
+    ].filter(Boolean)
+    if (messages.length > 0) {
+      return messages.join('; ')
+    }
+  } catch {
+    // Fall through to status text.
+  }
+  return response.statusText || `Redmine request failed (${response.status})`
+}
+
+export function normalizeRedmineUrl(value: string): string {
+  return value
+    .trim()
+    .replace(/\/+$/, '')
+}
+
+export async function redmineRequest<T>(
+  siteUrl: string,
+  apiKey: string,
+  path: string,
+  init?: RequestInit
+): Promise<T> {
+  const headers = buildHeaders(apiKey, init)
+  const response = await redmineFetch(`${normalizeRedmineUrl(siteUrl)}${path}`, {
+    ...init,
+    headers
+  })
+  if (!response.ok) {
+    throw new RedmineApiError(await readRedmineError(response), response.status)
+  }
+  // A 204 carries no body; 200/201 return normal JSON.
+  if (response.status === 204) {
+    return null as T
+  }
+  return (await response.json()) as T
+}
+
+/** Classifies a thrown RedmineApiError/transport error into a serializable RedmineReadError. */
+export function classifyRedmineError(error: unknown): RedmineReadError {
+  if (error instanceof RedmineApiError) {
+    if (error.status === 401 || error.status === 403) {
+      return { type: 'auth', message: error.message, status: error.status }
+    }
+    if (error.status === 404) {
+      return { type: 'not_found', message: error.message, status: error.status }
+    }
+    return { type: 'unknown', message: error.message, status: error.status }
+  }
+  const name = error instanceof Error ? error.name : typeof error
+  const message = error instanceof Error ? error.message : String(error)
+  if (name === 'AbortError') {
+    return { type: 'network', message: `Redmine request timed out: ${message}`, status: null }
+  }
+  return { type: 'network', message: `Redmine network error: ${message}`, status: null }
+}

--- a/src/main/redmine/redmine-site-store.test.ts
+++ b/src/main/redmine/redmine-site-store.test.ts
@@ -1,0 +1,50 @@
+import { existsSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tokenDir = join(tmpdir(), `orca-redmine-test-${process.pid}`)
+
+vi.mock('../integration-credential-file', () => ({
+  writeEncryptedCredential: vi.fn()
+}))
+
+vi.mock('./redmine-credential-paths', () => ({
+  getRedmineSiteFilePath: () => join(tokenDir, '..', 'redmine-sites.json'),
+  getRedmineTokenDir: () => tokenDir,
+  getRedmineTokenPath: (id: string) => join(tokenDir, `${id}.enc`)
+}))
+
+import { writeEncryptedCredential } from '../integration-credential-file'
+import { saveToken } from './redmine-site-store'
+
+const writeEncryptedCredentialMock = vi.mocked(writeEncryptedCredential)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  // leave the token dir in place so subsequent reads are deterministic
+})
+
+describe('saveToken', () => {
+  it('creates the token directory before writing the credential', () => {
+    // pre-existing failure: write to ~/.orca/redmine-tokens/<id>.enc ENOENT
+    // because the token directory was never created.
+    saveToken('site-1', 'secret-token')
+
+    expect(existsSync(tokenDir)).toBe(true)
+    expect(writeEncryptedCredentialMock).toHaveBeenCalledWith(
+      'Redmine',
+      join(tokenDir, 'site-1.enc'),
+      'secret-token'
+    )
+  })
+
+  it('is idempotent when the token directory already exists', () => {
+    mkdirSync(tokenDir, { recursive: true })
+    saveToken('site-1', 'secret-token')
+    expect(writeEncryptedCredentialMock).toHaveBeenCalled()
+  })
+})

--- a/src/main/redmine/redmine-site-store.ts
+++ b/src/main/redmine/redmine-site-store.ts
@@ -1,0 +1,175 @@
+import { dirname } from 'node:path'
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import {
+  CredentialDecryptionError,
+  credentialFileHasContent,
+  readStoredCredentialToken,
+  writeEncryptedCredential
+} from '../integration-credential-file'
+import type { RedmineSite, RedmineSiteSelection } from '../../shared/redmine-types'
+import { getRedmineSiteFilePath, getRedmineTokenPath } from './redmine-credential-paths'
+
+export type RedmineSiteFile = {
+  version: 1
+  activeSiteId: string | null
+  selectedSiteId: RedmineSiteSelection | null
+  sites: RedmineSite[]
+}
+
+let cachedSiteFile: RedmineSiteFile | null = null
+let siteFileLoaded = false
+const cachedTokens = new Map<string, string>()
+// Why: decrypt failures are recorded per site so getStatus can explain failing
+// reads without re-touching the keychain on every status poll.
+export const credentialErrors = new Map<string, string>()
+
+function ensureOrcaDir(): void {
+  const dir = dirname(getRedmineSiteFilePath())
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+function emptySiteFile(): RedmineSiteFile {
+  return {
+    version: 1,
+    activeSiteId: null,
+    selectedSiteId: null,
+    sites: []
+  }
+}
+
+export function hasStoredToken(siteId: string): boolean {
+  return cachedTokens.has(siteId) || credentialFileHasContent(getRedmineTokenPath(siteId))
+}
+
+function normalizeSite(input: unknown): RedmineSite | null {
+  if (!input || typeof input !== 'object') {
+    return null
+  }
+  const record = input as Record<string, unknown>
+  if (
+    typeof record.id !== 'string' ||
+    typeof record.siteUrl !== 'string' ||
+    typeof record.displayName !== 'string'
+  ) {
+    return null
+  }
+  return {
+    id: record.id,
+    siteUrl: record.siteUrl,
+    displayName: record.displayName,
+    hasToken: typeof record.hasToken === 'boolean' ? record.hasToken : false
+  }
+}
+
+function readSiteFileFromDisk(): RedmineSiteFile {
+  const path = getRedmineSiteFilePath()
+  if (!existsSync(path)) {
+    return emptySiteFile()
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, { encoding: 'utf-8' })) as Partial<RedmineSiteFile>
+    const sites = Array.isArray(parsed.sites)
+      ? parsed.sites
+          .map((site) => normalizeSite(site))
+          .filter((site): site is RedmineSite => site !== null)
+          .map((site) => ({ ...site, hasToken: hasStoredToken(site.id) || site.hasToken }))
+      : []
+    const activeSiteId =
+      typeof parsed.activeSiteId === 'string' &&
+      sites.some((site) => site.id === parsed.activeSiteId)
+        ? parsed.activeSiteId
+        : (sites[0]?.id ?? null)
+    const selectedSiteId =
+      typeof parsed.selectedSiteId === 'string' &&
+      sites.some((site) => site.id === parsed.selectedSiteId)
+        ? parsed.selectedSiteId
+        : activeSiteId
+    return { version: 1, activeSiteId, selectedSiteId, sites }
+  } catch {
+    return emptySiteFile()
+  }
+}
+
+export function getSiteFile(): RedmineSiteFile {
+  if (!siteFileLoaded || !cachedSiteFile) {
+    cachedSiteFile = readSiteFileFromDisk()
+    siteFileLoaded = true
+  }
+  return cachedSiteFile
+}
+
+export function writeSiteFile(file: RedmineSiteFile): void {
+  const sites = file.sites.map((site) => ({
+    ...site,
+    hasToken: hasStoredToken(site.id) || site.hasToken
+  }))
+  const activeSiteId =
+    file.activeSiteId && sites.some((site) => site.id === file.activeSiteId)
+      ? file.activeSiteId
+      : (sites[0]?.id ?? null)
+  const selectedSiteId =
+    typeof file.selectedSiteId === 'string' &&
+    sites.some((site) => site.id === file.selectedSiteId)
+      ? file.selectedSiteId
+      : activeSiteId
+
+  cachedSiteFile = { version: 1, activeSiteId, selectedSiteId, sites }
+  siteFileLoaded = true
+  writeFileSync(getRedmineSiteFilePath(), JSON.stringify(cachedSiteFile, null, 2), {
+    encoding: 'utf-8',
+    mode: 0o600
+  })
+}
+
+export function readToken(siteId: string): string | null {
+  const cached = cachedTokens.get(siteId)
+  if (cached !== undefined) {
+    return cached
+  }
+  const path = getRedmineTokenPath(siteId)
+  if (!existsSync(path)) {
+    return null
+  }
+  try {
+    const raw = readFileSync(path)
+    const token = readStoredCredentialToken('Redmine', raw)
+    if (token) {
+      cachedTokens.set(siteId, token)
+    }
+    credentialErrors.delete(siteId)
+    return token
+  } catch (error) {
+    if (error instanceof CredentialDecryptionError) {
+      credentialErrors.set(siteId, error.message)
+      throw error
+    }
+    return null
+  }
+}
+
+export function saveToken(siteId: string, apiToken: string): void {
+  ensureOrcaDir()
+  writeEncryptedCredential('Redmine', getRedmineTokenPath(siteId), apiToken)
+  cachedTokens.set(siteId, apiToken)
+  credentialErrors.delete(siteId)
+}
+
+export function deleteToken(siteId: string): void {
+  cachedTokens.delete(siteId)
+  credentialErrors.delete(siteId)
+  try {
+    unlinkSync(getRedmineTokenPath(siteId))
+  } catch {
+    // Token may not exist — safe to ignore.
+  }
+}
+
+// Test hook so credential caching does not leak between test cases.
+export function _resetRedmineCredentialCache(): void {
+  cachedSiteFile = null
+  siteFileLoaded = false
+  cachedTokens.clear()
+  credentialErrors.clear()
+}

--- a/src/main/redmine/redmine-site-store.ts
+++ b/src/main/redmine/redmine-site-store.ts
@@ -7,7 +7,11 @@ import {
   writeEncryptedCredential
 } from '../integration-credential-file'
 import type { RedmineSite, RedmineSiteSelection } from '../../shared/redmine-types'
-import { getRedmineSiteFilePath, getRedmineTokenPath } from './redmine-credential-paths'
+import {
+  getRedmineSiteFilePath,
+  getRedmineTokenDir,
+  getRedmineTokenPath
+} from './redmine-credential-paths'
 
 export type RedmineSiteFile = {
   version: 1
@@ -150,6 +154,10 @@ export function readToken(siteId: string): string | null {
 
 export function saveToken(siteId: string, apiToken: string): void {
   ensureOrcaDir()
+  const tokenDir = getRedmineTokenDir()
+  if (!existsSync(tokenDir)) {
+    mkdirSync(tokenDir, { recursive: true })
+  }
   writeEncryptedCredential('Redmine', getRedmineTokenPath(siteId), apiToken)
   cachedTokens.set(siteId, apiToken)
   credentialErrors.delete(siteId)

--- a/src/main/redmine/redmine-site-store.ts
+++ b/src/main/redmine/redmine-site-store.ts
@@ -110,8 +110,7 @@ export function writeSiteFile(file: RedmineSiteFile): void {
       ? file.activeSiteId
       : (sites[0]?.id ?? null)
   const selectedSiteId =
-    typeof file.selectedSiteId === 'string' &&
-    sites.some((site) => site.id === file.selectedSiteId)
+    typeof file.selectedSiteId === 'string' && sites.some((site) => site.id === file.selectedSiteId)
       ? file.selectedSiteId
       : activeSiteId
 

--- a/src/main/runtime/rpc/methods/index.ts
+++ b/src/main/runtime/rpc/methods/index.ts
@@ -29,6 +29,7 @@ import { HOSTED_REVIEW_METHODS } from './hosted-review'
 import { LINEAR_METHODS } from './linear'
 import { LINEAR_AGENT_ACCESS_METHODS } from './linear-agent-access'
 import { JIRA_METHODS } from './jira'
+import { REDMINE_METHODS } from './redmine'
 import { SSH_METHODS } from './ssh'
 import { SPEECH_METHODS } from './speech'
 import { CLIENT_UI_METHODS } from './client-ui'
@@ -85,6 +86,7 @@ export const ALL_RPC_METHODS: readonly RpcAnyMethod[] = [
   ...LINEAR_METHODS,
   ...LINEAR_AGENT_ACCESS_METHODS,
   ...JIRA_METHODS,
+  ...REDMINE_METHODS,
   ...SSH_METHODS,
   ...SPEECH_METHODS,
   ...WORKSPACE_PORT_METHODS,

--- a/src/main/runtime/rpc/methods/redmine.test.ts
+++ b/src/main/runtime/rpc/methods/redmine.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { buildRegistry, type RpcHandler } from '../core'
+import { REDMINE_METHODS } from './redmine'
+import {
+  connectRedmineSite,
+  disconnectRedmineSite,
+  getRedmineStatus,
+  testRedmineConnection
+} from '../../../redmine/client'
+import { getRedmineIssue, listRedmineIssues } from '../../../redmine/issues'
+import { readToken } from '../../../redmine/redmine-site-store'
+
+vi.mock('../../../redmine/client', () => ({
+  connectRedmineSite: vi.fn(),
+  disconnectRedmineSite: vi.fn(),
+  getRedmineStatus: vi.fn(),
+  testRedmineConnection: vi.fn()
+}))
+
+vi.mock('../../../redmine/issues', () => ({
+  getRedmineIssue: vi.fn(),
+  listRedmineIssues: vi.fn()
+}))
+
+vi.mock('../../../redmine/redmine-site-store', () => ({
+  readToken: vi.fn()
+}))
+
+const connectRedmineSiteMock = vi.mocked(connectRedmineSite)
+const disconnectRedmineSiteMock = vi.mocked(disconnectRedmineSite)
+const getRedmineStatusMock = vi.mocked(getRedmineStatus)
+const testRedmineConnectionMock = vi.mocked(testRedmineConnection)
+const getRedmineIssueMock = vi.mocked(getRedmineIssue)
+const listRedmineIssuesMock = vi.mocked(listRedmineIssues)
+const readTokenMock = vi.mocked(readToken)
+
+const registry = buildRegistry(REDMINE_METHODS)
+const ctx = {} as Parameters<RpcHandler<unknown>>[1]
+
+const site = {
+  id: 'https://rm.example.com',
+  siteUrl: 'https://rm.example.com',
+  displayName: 'rm',
+  hasToken: true
+}
+
+function connectedStatus() {
+  return {
+    connected: true,
+    activeSite: site,
+    selectedSiteId: site.id,
+    viewer: null,
+    error: null
+  }
+}
+function disconnectedStatus() {
+  return { connected: false, activeSite: null, selectedSiteId: null, viewer: null, error: null }
+}
+
+async function invoke(name: string, params?: unknown): Promise<unknown> {
+  const method = registry.get(name)
+  if (!method || 'stream' in method) {
+    throw new Error(`method not found: ${name}`)
+  }
+  return method.handler(params, ctx)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getRedmineStatusMock.mockReturnValue(disconnectedStatus())
+})
+
+describe('REDMINE_METHODS registration', () => {
+  it('exposes the six read/connect methods', () => {
+    expect([...registry.keys()].sort()).toEqual([
+      'redmine.connect',
+      'redmine.disconnect',
+      'redmine.getIssue',
+      'redmine.listIssues',
+      'redmine.status',
+      'redmine.testConnection'
+    ])
+  })
+})
+
+describe('redmine.status', () => {
+  it('returns the current site status', async () => {
+    getRedmineStatusMock.mockReturnValue(connectedStatus())
+    expect(await invoke('redmine.status')).toEqual(connectedStatus())
+  })
+})
+
+describe('redmine.connect / testConnection', () => {
+  it('trims and forwards connect params', async () => {
+    connectRedmineSiteMock.mockResolvedValue({
+      ok: true,
+      site,
+      viewer: { id: 1, name: 'A', login: 'a' }
+    })
+    const result = await invoke('redmine.connect', {
+      siteUrl: '  https://rm.example.com  ',
+      apiKey: '  secret  '
+    })
+    expect(connectRedmineSiteMock).toHaveBeenCalledWith('https://rm.example.com', 'secret')
+    expect(result).toMatchObject({ ok: true })
+  })
+
+  it('wraps a successful testConnection into the ok shape', async () => {
+    testRedmineConnectionMock.mockResolvedValue({
+      user: { id: 1, name: 'Ada', login: 'ada' }
+    })
+    const result = await invoke('redmine.testConnection', {
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'k'
+    })
+    expect(result).toEqual({ ok: true, user: { id: 1, name: 'Ada', login: 'ada' } })
+  })
+
+  it('wraps a failed testConnection into ok:false', async () => {
+    testRedmineConnectionMock.mockResolvedValue({
+      user: null,
+      error: { type: 'auth', message: 'bad key' }
+    })
+    const result = await invoke('redmine.testConnection', {
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'nope'
+    })
+    expect(result).toEqual({ ok: false, error: { type: 'auth', message: 'bad key' } })
+  })
+})
+
+describe('redmine.disconnect', () => {
+  it('forwards a valid site id', async () => {
+    await invoke('redmine.disconnect', { siteId: 'site-a' })
+    expect(disconnectRedmineSiteMock).toHaveBeenCalledWith('site-a')
+  })
+
+  it('ignores a missing site id', async () => {
+    await invoke('redmine.disconnect', undefined)
+    expect(disconnectRedmineSiteMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('redmine.listIssues', () => {
+  it('returns an auth error when no site is connected', async () => {
+    const result = await invoke('redmine.listIssues', { filter: { scope: 'assigned' } })
+    expect(result).toEqual({
+      items: [],
+      totalCount: 0,
+      error: { type: 'auth', message: 'No Redmine site connected.' }
+    })
+    expect(listRedmineIssuesMock).not.toHaveBeenCalled()
+  })
+
+  it('lists issues with the active site credentials', async () => {
+    getRedmineStatusMock.mockReturnValue(connectedStatus())
+    readTokenMock.mockReturnValue('secret')
+    listRedmineIssuesMock.mockResolvedValue({ items: [], totalCount: 0 })
+    await invoke('redmine.listIssues', { filter: { scope: 'assigned' } })
+    expect(listRedmineIssuesMock).toHaveBeenCalledWith('https://rm.example.com', 'secret', {
+      scope: 'assigned'
+    })
+  })
+})
+
+describe('redmine.getIssue', () => {
+  it('returns null when no site is connected', async () => {
+    expect(await invoke('redmine.getIssue', { issueId: 1 })).toBeNull()
+  })
+
+  it('fetches the issue through the active site', async () => {
+    getRedmineStatusMock.mockReturnValue(connectedStatus())
+    readTokenMock.mockReturnValue('secret')
+    getRedmineIssueMock.mockResolvedValue({ id: 1 } as never)
+    const result = await invoke('redmine.getIssue', { issueId: 1 })
+    expect(getRedmineIssueMock).toHaveBeenCalledWith('https://rm.example.com', 'secret', 1)
+    expect(result).toMatchObject({ id: 1 })
+  })
+})

--- a/src/main/runtime/rpc/methods/redmine.test.ts
+++ b/src/main/runtime/rpc/methods/redmine.test.ts
@@ -5,34 +5,38 @@ import {
   connectRedmineSite,
   disconnectRedmineSite,
   getRedmineStatus,
+  redmineReadErrorForCredentials,
+  resolveRedmineCredentials,
   testRedmineConnection
 } from '../../../redmine/client'
-import { getRedmineIssue, listRedmineIssues } from '../../../redmine/issues'
-import { readToken } from '../../../redmine/redmine-site-store'
+import { getRedmineIssue, listRedmineIssues, RedmineRequestError } from '../../../redmine/issues'
 
 vi.mock('../../../redmine/client', () => ({
   connectRedmineSite: vi.fn(),
   disconnectRedmineSite: vi.fn(),
   getRedmineStatus: vi.fn(),
+  redmineReadErrorForCredentials: vi.fn(() => ({
+    type: 'auth',
+    message: 'No Redmine site connected.'
+  })),
+  resolveRedmineCredentials: vi.fn(() => ({ ok: false, reason: 'no_site' })),
   testRedmineConnection: vi.fn()
 }))
 
 vi.mock('../../../redmine/issues', () => ({
   getRedmineIssue: vi.fn(),
-  listRedmineIssues: vi.fn()
-}))
-
-vi.mock('../../../redmine/redmine-site-store', () => ({
-  readToken: vi.fn()
+  listRedmineIssues: vi.fn(),
+  RedmineRequestError: class RedmineRequestError extends Error {}
 }))
 
 const connectRedmineSiteMock = vi.mocked(connectRedmineSite)
 const disconnectRedmineSiteMock = vi.mocked(disconnectRedmineSite)
 const getRedmineStatusMock = vi.mocked(getRedmineStatus)
+const redmineReadErrorForCredentialsMock = vi.mocked(redmineReadErrorForCredentials)
+const resolveRedmineCredentialsMock = vi.mocked(resolveRedmineCredentials)
 const testRedmineConnectionMock = vi.mocked(testRedmineConnection)
 const getRedmineIssueMock = vi.mocked(getRedmineIssue)
 const listRedmineIssuesMock = vi.mocked(listRedmineIssues)
-const readTokenMock = vi.mocked(readToken)
 
 const registry = buildRegistry(REDMINE_METHODS)
 const ctx = {} as Parameters<RpcHandler<unknown>>[1]
@@ -68,6 +72,11 @@ async function invoke(name: string, params?: unknown): Promise<unknown> {
 beforeEach(() => {
   vi.clearAllMocks()
   getRedmineStatusMock.mockReturnValue(disconnectedStatus())
+  resolveRedmineCredentialsMock.mockReturnValue({ ok: false, reason: 'no_site' })
+  redmineReadErrorForCredentialsMock.mockReturnValue({
+    type: 'auth',
+    message: 'No Redmine site connected.'
+  })
 })
 
 describe('REDMINE_METHODS registration', () => {
@@ -153,27 +162,72 @@ describe('redmine.listIssues', () => {
   })
 
   it('lists issues with the active site credentials', async () => {
-    getRedmineStatusMock.mockReturnValue(connectedStatus())
-    readTokenMock.mockReturnValue('secret')
+    resolveRedmineCredentialsMock.mockReturnValue({
+      ok: true,
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'secret'
+    })
     listRedmineIssuesMock.mockResolvedValue({ items: [], totalCount: 0 })
     await invoke('redmine.listIssues', { filter: { scope: 'assigned' } })
     expect(listRedmineIssuesMock).toHaveBeenCalledWith('https://rm.example.com', 'secret', {
       scope: 'assigned'
     })
   })
+
+  it('returns the classified error when the upstream request fails', async () => {
+    resolveRedmineCredentialsMock.mockReturnValue({
+      ok: true,
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'secret'
+    })
+    const err = new RedmineRequestError({ type: 'auth', message: 'Invalid API key' }, null)
+    ;(err as { classified?: unknown }).classified = {
+      type: 'auth',
+      message: 'Invalid API key'
+    }
+    listRedmineIssuesMock.mockRejectedValue(err)
+    const result = await invoke('redmine.listIssues', {})
+    expect(result).toEqual({
+      items: [],
+      totalCount: 0,
+      error: { type: 'auth', message: 'Invalid API key' }
+    })
+  })
 })
 
 describe('redmine.getIssue', () => {
-  it('returns null when no site is connected', async () => {
-    expect(await invoke('redmine.getIssue', { issueId: 1 })).toBeNull()
+  it('returns an error when no site is connected', async () => {
+    expect(await invoke('redmine.getIssue', { issueId: 1 })).toEqual({
+      issue: null,
+      error: { type: 'auth', message: 'No Redmine site connected.' }
+    })
   })
 
   it('fetches the issue through the active site', async () => {
-    getRedmineStatusMock.mockReturnValue(connectedStatus())
-    readTokenMock.mockReturnValue('secret')
+    resolveRedmineCredentialsMock.mockReturnValue({
+      ok: true,
+      siteUrl: 'https://rm.example.com',
+      apiKey: 'secret'
+    })
     getRedmineIssueMock.mockResolvedValue({ id: 1 } as never)
     const result = await invoke('redmine.getIssue', { issueId: 1 })
     expect(getRedmineIssueMock).toHaveBeenCalledWith('https://rm.example.com', 'secret', 1)
-    expect(result).toMatchObject({ id: 1 })
+    expect(result).toEqual({ issue: { id: 1 } })
+  })
+
+  it('surfaces a decryption reason as an error', async () => {
+    resolveRedmineCredentialsMock.mockReturnValue({ ok: false, reason: 'decryption' })
+    redmineReadErrorForCredentialsMock.mockReturnValue({
+      type: 'auth',
+      message: 'Your stored Redmine API key could not be decrypted. Reconnect to re-enter it.'
+    })
+    const result = await invoke('redmine.getIssue', { issueId: 1 })
+    expect(result).toEqual({
+      issue: null,
+      error: {
+        type: 'auth',
+        message: 'Your stored Redmine API key could not be decrypted. Reconnect to re-enter it.'
+      }
+    })
   })
 })

--- a/src/main/runtime/rpc/methods/redmine.ts
+++ b/src/main/runtime/rpc/methods/redmine.ts
@@ -5,10 +5,11 @@ import {
   connectRedmineSite,
   disconnectRedmineSite,
   getRedmineStatus,
+  redmineReadErrorForCredentials,
+  resolveRedmineCredentials,
   testRedmineConnection
 } from '../../../redmine/client'
-import { getRedmineIssue, listRedmineIssues } from '../../../redmine/issues'
-import { readToken } from '../../../redmine/redmine-site-store'
+import { getRedmineIssue, listRedmineIssues, RedmineRequestError } from '../../../redmine/issues'
 
 const SiteWithKey = z.object({
   siteUrl: requiredString('Server URL is required'),
@@ -40,20 +41,7 @@ const IssueId = z.object({
 
 // Why: the host owns the Redmine site store (~/.orca/redmine-sites.json +
 // encrypted tokens), so it resolves the active site's credentials server-side,
-// mirroring the main-process IPC handler.
-function activeCredentials(): { siteUrl: string; apiKey: string } | null {
-  const status = getRedmineStatus()
-  const site = status.activeSite
-  if (!site) {
-    return null
-  }
-  const apiKey = readToken(site.id)
-  if (!apiKey) {
-    return null
-  }
-  return { siteUrl: site.siteUrl, apiKey }
-}
-
+// mirroring the main-process IPC handler via the shared resolver.
 export const REDMINE_METHODS: RpcAnyMethod[] = [
   defineMethod({
     name: 'redmine.status',
@@ -92,26 +80,40 @@ export const REDMINE_METHODS: RpcAnyMethod[] = [
     name: 'redmine.listIssues',
     params: List,
     handler: async (params) => {
-      const creds = activeCredentials()
-      if (!creds) {
+      const creds = resolveRedmineCredentials()
+      if (!creds.ok) {
         return {
           items: [],
           totalCount: 0,
-          error: { type: 'auth', message: 'No Redmine site connected.' }
+          error: redmineReadErrorForCredentials(creds.reason)
         }
       }
-      return listRedmineIssues(creds.siteUrl, creds.apiKey, params?.filter ?? {})
+      try {
+        return await listRedmineIssues(creds.siteUrl, creds.apiKey, params?.filter ?? {})
+      } catch (error) {
+        if (error instanceof RedmineRequestError) {
+          return { items: [], totalCount: 0, error: error.classified }
+        }
+        throw error
+      }
     }
   }),
   defineMethod({
     name: 'redmine.getIssue',
     params: IssueId,
     handler: async (params) => {
-      const creds = activeCredentials()
-      if (!creds) {
-        return null
+      const creds = resolveRedmineCredentials()
+      if (!creds.ok) {
+        return { issue: null, error: redmineReadErrorForCredentials(creds.reason) }
       }
-      return getRedmineIssue(creds.siteUrl, creds.apiKey, params.issueId)
+      try {
+        return { issue: await getRedmineIssue(creds.siteUrl, creds.apiKey, params.issueId) }
+      } catch (error) {
+        if (error instanceof RedmineRequestError) {
+          return { issue: null, error: error.classified }
+        }
+        throw error
+      }
     }
   })
 ]

--- a/src/main/runtime/rpc/methods/redmine.ts
+++ b/src/main/runtime/rpc/methods/redmine.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod'
+import { defineMethod, type RpcAnyMethod } from '../core'
+import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
+import {
+  connectRedmineSite,
+  disconnectRedmineSite,
+  getRedmineStatus,
+  testRedmineConnection
+} from '../../../redmine/client'
+import { getRedmineIssue, listRedmineIssues } from '../../../redmine/issues'
+import { readToken } from '../../../redmine/redmine-site-store'
+
+const SiteWithKey = z.object({
+  siteUrl: requiredString('Server URL is required'),
+  apiKey: requiredString('API key is required')
+})
+
+const SiteSelection = z
+  .object({
+    siteId: OptionalString
+  })
+  .optional()
+
+const ListFilter = z.object({
+  state: z.enum(['open', 'closed', 'all']).optional(),
+  scope: z.enum(['assigned', 'created', 'all']).optional(),
+  limit: OptionalFiniteNumber,
+  page: OptionalFiniteNumber
+})
+
+const List = z
+  .object({
+    filter: ListFilter.optional()
+  })
+  .optional()
+
+const IssueId = z.object({
+  issueId: z.number()
+})
+
+// Why: the host owns the Redmine site store (~/.orca/redmine-sites.json +
+// encrypted tokens), so it resolves the active site's credentials server-side,
+// mirroring the main-process IPC handler.
+function activeCredentials(): { siteUrl: string; apiKey: string } | null {
+  const status = getRedmineStatus()
+  const site = status.activeSite
+  if (!site) {
+    return null
+  }
+  const apiKey = readToken(site.id)
+  if (!apiKey) {
+    return null
+  }
+  return { siteUrl: site.siteUrl, apiKey }
+}
+
+export const REDMINE_METHODS: RpcAnyMethod[] = [
+  defineMethod({
+    name: 'redmine.status',
+    params: null,
+    handler: () => getRedmineStatus()
+  }),
+  defineMethod({
+    name: 'redmine.testConnection',
+    params: SiteWithKey,
+    handler: async (params) => {
+      const result = await testRedmineConnection(params.siteUrl.trim(), params.apiKey.trim())
+      if (!result.user || result.error) {
+        return {
+          ok: false as const,
+          error: result.error ?? { type: 'unknown', message: 'Unable to connect.' }
+        }
+      }
+      return { ok: true as const, user: result.user }
+    }
+  }),
+  defineMethod({
+    name: 'redmine.connect',
+    params: SiteWithKey,
+    handler: async (params) => connectRedmineSite(params.siteUrl.trim(), params.apiKey.trim())
+  }),
+  defineMethod({
+    name: 'redmine.disconnect',
+    params: SiteSelection,
+    handler: (params) => {
+      if (params?.siteId) {
+        disconnectRedmineSite(params.siteId)
+      }
+    }
+  }),
+  defineMethod({
+    name: 'redmine.listIssues',
+    params: List,
+    handler: async (params) => {
+      const creds = activeCredentials()
+      if (!creds) {
+        return {
+          items: [],
+          totalCount: 0,
+          error: { type: 'auth', message: 'No Redmine site connected.' }
+        }
+      }
+      return listRedmineIssues(creds.siteUrl, creds.apiKey, params?.filter ?? {})
+    }
+  }),
+  defineMethod({
+    name: 'redmine.getIssue',
+    params: IssueId,
+    handler: async (params) => {
+      const creds = activeCredentials()
+      if (!creds) {
+        return null
+      }
+      return getRedmineIssue(creds.siteUrl, creds.apiKey, params.issueId)
+    }
+  })
+]

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -34,6 +34,7 @@ import type { GitLabApi } from './api/gitlab-api'
 import type { BitbucketApi, HostedReviewApi } from './api/hosted-review-api'
 import type { JiraApi } from './api/jira-api'
 import type { LinearApi } from './api/linear-api'
+import type { RedmineApi } from './api/redmine-api'
 import type { MobileApi } from './api/mobile-api'
 import type { NativeChatApi } from './api/native-chat-api'
 import type { OnboardingApi, StarNagApi } from './api/onboarding-api'
@@ -90,6 +91,7 @@ export type PreloadApi = {
   bitbucket: BitbucketApi
   linear: LinearApi
   jira: JiraApi
+  redmine: RedmineApi
   starNag: StarNagApi
   telemetryTrack: TelemetryApi['telemetryTrack']
   telemetrySetOptIn: TelemetryApi['telemetrySetOptIn']
@@ -157,6 +159,7 @@ export type { AiVaultApi } from './api/ai-vault-api'
 export type { AutomationsApi, ExternalAutomationManagerResult } from './api/automation-api'
 export type { AppApi } from './api/app-api'
 export type { BrowserApi, DetectedBrowserInfo, DetectedBrowserProfileInfo } from './api/browser-api'
+export type { RedmineApi } from './api/redmine-api'
 export type { EmulatorApi } from './api/emulator-api'
 export type { ExportApi } from './api/filesystem-api'
 export type {

--- a/src/preload/api/redmine-api.ts
+++ b/src/preload/api/redmine-api.ts
@@ -4,6 +4,7 @@ import type {
   RedmineIssue,
   RedmineIssueCollectionResult,
   RedmineListFilter,
+  RedmineReadError,
   RedmineSite,
   RedmineUser
 } from '../../shared/redmine-types'
@@ -23,5 +24,8 @@ export type RedmineApi = {
     apiKey: string
   }) => Promise<{ ok: true; user: RedmineUser } | { ok: false; error: RedmineConnectionError }>
   listIssues: (args?: { filter?: RedmineListFilter }) => Promise<RedmineIssueCollectionResult>
-  getIssue: (args: { issueId: number }) => Promise<RedmineIssue | null>
+  getIssue: (args: { issueId: number }) => Promise<{
+    issue: RedmineIssue | null
+    error?: RedmineReadError
+  }>
 }

--- a/src/preload/api/redmine-api.ts
+++ b/src/preload/api/redmine-api.ts
@@ -21,9 +21,7 @@ export type RedmineApi = {
   testConnection: (args: {
     siteUrl: string
     apiKey: string
-  }) => Promise<
-    { ok: true; user: RedmineUser } | { ok: false; error: RedmineConnectionError }
-  >
+  }) => Promise<{ ok: true; user: RedmineUser } | { ok: false; error: RedmineConnectionError }>
   listIssues: (args?: { filter?: RedmineListFilter }) => Promise<RedmineIssueCollectionResult>
   getIssue: (args: { issueId: number }) => Promise<RedmineIssue | null>
 }

--- a/src/preload/api/redmine-api.ts
+++ b/src/preload/api/redmine-api.ts
@@ -1,0 +1,29 @@
+import type {
+  RedmineConnectionError,
+  RedmineConnectionStatus,
+  RedmineIssue,
+  RedmineIssueCollectionResult,
+  RedmineListFilter,
+  RedmineSite,
+  RedmineUser
+} from '../../shared/redmine-types'
+
+export type RedmineApi = {
+  connect: (args: {
+    siteUrl: string
+    apiKey: string
+  }) => Promise<
+    | { ok: true; site: RedmineSite; viewer: RedmineUser }
+    | { ok: false; error: RedmineConnectionError }
+  >
+  disconnect: (args: { siteId: string }) => Promise<void>
+  status: () => Promise<RedmineConnectionStatus>
+  testConnection: (args: {
+    siteUrl: string
+    apiKey: string
+  }) => Promise<
+    { ok: true; user: RedmineUser } | { ok: false; error: RedmineConnectionError }
+  >
+  listIssues: (args?: { filter?: RedmineListFilter }) => Promise<RedmineIssueCollectionResult>
+  getIssue: (args: { issueId: number }) => Promise<RedmineIssue | null>
+}

--- a/src/preload/api/redmine-bridge.ts
+++ b/src/preload/api/redmine-bridge.ts
@@ -13,8 +13,7 @@ export const redmineApi = {
   testConnection: (args: { siteUrl: string; apiKey: string }) =>
     ipcRenderer.invoke('redmine:testConnection', args),
 
-  listIssues: (args?: { filter?: unknown }) =>
-    ipcRenderer.invoke('redmine:listIssues', args),
+  listIssues: (args?: { filter?: unknown }) => ipcRenderer.invoke('redmine:listIssues', args),
 
   getIssue: (args: { issueId: number }) => ipcRenderer.invoke('redmine:getIssue', args)
 } satisfies PreloadApi['redmine']

--- a/src/preload/api/redmine-bridge.ts
+++ b/src/preload/api/redmine-bridge.ts
@@ -1,0 +1,20 @@
+import { ipcRenderer } from 'electron'
+import type { PreloadApi } from '../api-types'
+
+export const redmineApi = {
+  connect: (args: { siteUrl: string; apiKey: string }) =>
+    ipcRenderer.invoke('redmine:connect', args),
+
+  disconnect: (args: { siteId: string }): Promise<void> =>
+    ipcRenderer.invoke('redmine:disconnect', args),
+
+  status: () => ipcRenderer.invoke('redmine:status'),
+
+  testConnection: (args: { siteUrl: string; apiKey: string }) =>
+    ipcRenderer.invoke('redmine:testConnection', args),
+
+  listIssues: (args?: { filter?: unknown }) =>
+    ipcRenderer.invoke('redmine:listIssues', args),
+
+  getIssue: (args: { issueId: number }) => ipcRenderer.invoke('redmine:getIssue', args)
+} satisfies PreloadApi['redmine']

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -31,6 +31,7 @@ import { glApiBridge } from './api/gl-bridge'
 import { bitbucketApi } from './api/bitbucket-bridge'
 import { linearApi } from './api/linear-bridge'
 import { jiraApi } from './api/jira-bridge'
+import { redmineApi } from './api/redmine-bridge'
 import { starNagApi } from './api/star-nag-bridge'
 import { diagnosticsApi } from './api/diagnostics-bridge'
 import { settingsApi } from './api/settings-bridge'
@@ -125,6 +126,7 @@ const api = {
   bitbucket: bitbucketApi,
   linear: linearApi,
   jira: jiraApi,
+  redmine: redmineApi,
   starNag: starNagApi,
   telemetryTrack: telemetryTrackApi,
   telemetrySetOptIn: telemetrySetOptInApi,

--- a/src/renderer/src/components/automations/automation-source-display.ts
+++ b/src/renderer/src/components/automations/automation-source-display.ts
@@ -41,6 +41,8 @@ function getProviderLabel(provider: TaskSourceContext['provider']): string {
       return 'Linear'
     case 'jira':
       return 'Jira'
+    case 'redmine':
+      return 'Redmine'
   }
 }
 

--- a/src/renderer/src/components/automations/automation-target-availability.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.ts
@@ -253,16 +253,9 @@ function getAutomationSourceAvailability(
 }
 
 function getAutomationSourceProviderLabel(provider: TaskSourceContext['provider']): string {
-  switch (provider) {
-    case 'github':
-      return 'GitHub'
-    case 'gitlab':
-      return 'GitLab'
-    case 'linear':
-      return 'Linear'
-    case 'jira':
-      return 'Jira'
-  }
+  return (
+    { github: 'GitHub', gitlab: 'GitLab', linear: 'Linear', jira: 'Jira', redmine: 'Redmine' } as const
+  )[provider]
 }
 
 export function getRuntimeAutomationAvailability(

--- a/src/renderer/src/components/automations/automation-target-availability.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.ts
@@ -254,7 +254,13 @@ function getAutomationSourceAvailability(
 
 function getAutomationSourceProviderLabel(provider: TaskSourceContext['provider']): string {
   return (
-    { github: 'GitHub', gitlab: 'GitLab', linear: 'Linear', jira: 'Jira', redmine: 'Redmine' } as const
+    {
+      github: 'GitHub',
+      gitlab: 'GitLab',
+      linear: 'Linear',
+      jira: 'Jira',
+      redmine: 'Redmine'
+    } as const
   )[provider]
 }
 

--- a/src/renderer/src/components/icons/RedmineIcon.tsx
+++ b/src/renderer/src/components/icons/RedmineIcon.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+// Why: flatten the official Redmine product mark (the three stacked leaf
+// glyphs) so it matches Orca's monochrome provider icons instead of the
+// grey/red wordmark. Coordinates are the raw logo paths translated to a
+// tight 0..64 x 0..66 box; color comes from the caller via `currentColor`.
+export function RedmineIcon({ className }: { className?: string }): React.JSX.Element {
+  return (
+    <svg viewBox="0 0 64 66" aria-hidden className={className} fill="currentColor">
+      <g transform="translate(-59.85,-308.69)">
+        <path d="m 59.847143,374.6913 21,0 1.5,-18.00125 -19.50125,-4.49875 -2.99875,22.5 z" />
+        <path d="m 63.597143,349.19005 18.75,4.5 4.5,-15.75 -15.75,-8.24875 -7.5,19.49875 z" />
+        <path d="m 72.595893,326.69005 15,8.25 12.00125,-8.25 -11.25,-12.75 -15.75125,12.75 z" />
+        <path d="m 92.097143,311.69005 11.249997,13.5 10.49875,0 9.75125,-13.5 -9.75125,-3 -10.7625,0 -10.986247,3 z" />
+      </g>
+    </svg>
+  )
+}

--- a/src/renderer/src/components/new-workspace/use-smart-workspace-field-availability.ts
+++ b/src/renderer/src/components/new-workspace/use-smart-workspace-field-availability.ts
@@ -85,7 +85,8 @@ export function useSmartWorkspaceFieldAvailability({
     () =>
       filterAvailableTaskProviders(['github', 'gitlab', 'linear'], {
         gitlabInstalled: gitlabSourceAvailable,
-        linearConnected: linearStatus.connected === true
+        linearConnected: linearStatus.connected === true,
+        redmineConnected: false
       }),
     [gitlabSourceAvailable, linearStatus.connected]
   )

--- a/src/renderer/src/components/new-workspace/use-smart-workspace-field-availability.ts
+++ b/src/renderer/src/components/new-workspace/use-smart-workspace-field-availability.ts
@@ -85,8 +85,7 @@ export function useSmartWorkspaceFieldAvailability({
     () =>
       filterAvailableTaskProviders(['github', 'gitlab', 'linear'], {
         gitlabInstalled: gitlabSourceAvailable,
-        linearConnected: linearStatus.connected === true,
-        redmineConnected: false
+        linearConnected: linearStatus.connected === true
       }),
     [gitlabSourceAvailable, linearStatus.connected]
   )

--- a/src/renderer/src/components/settings/TaskSourceRedmineSetup.tsx
+++ b/src/renderer/src/components/settings/TaskSourceRedmineSetup.tsx
@@ -57,9 +57,16 @@ export function TaskSourceRedmineSetup({
       {connected ? (
         <div className="flex items-center justify-between rounded-lg border border-border/60 px-3 py-2.5 text-sm">
           <span className="truncate text-muted-foreground">
-            {status.activeSite?.siteUrl ?? translate('auto.components.settings.TasksPane.redmineConnected', 'Redmine connected')}
+            {status.activeSite?.siteUrl ??
+              translate('auto.components.settings.TasksPane.redmineConnected', 'Redmine connected')}
           </span>
-          <Button type="button" variant="outline" size="sm" disabled={!canHide} onClick={onToggleVisible}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!canHide}
+            onClick={onToggleVisible}
+          >
             {visible
               ? translate('auto.components.settings.TasksPane.hideFromTasks', 'Hide from Tasks')
               : translate('auto.components.settings.TasksPane.showInTasks', 'Show in Tasks')}

--- a/src/renderer/src/components/settings/TaskSourceRedmineSetup.tsx
+++ b/src/renderer/src/components/settings/TaskSourceRedmineSetup.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react'
+import { useAppStore } from '@/store'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { translate } from '@/i18n/i18n'
+
+type TaskSourceRedmineSetupProps = {
+  connected: boolean
+  checking: boolean
+  visible: boolean
+  canHide: boolean
+  onToggleVisible: () => void
+}
+
+export function TaskSourceRedmineSetup({
+  connected,
+  checking,
+  visible,
+  canHide,
+  onToggleVisible
+}: TaskSourceRedmineSetupProps): React.JSX.Element {
+  const connectRedmine = useAppStore((s) => s.connectRedmine)
+  const testRedmineConnection = useAppStore((s) => s.testRedmineConnection)
+  const status = useAppStore((s) => s.redmineStatus)
+
+  const [siteUrl, setSiteUrl] = useState(status.activeSite?.siteUrl ?? '')
+  const [apiKey, setApiKey] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canConnect = siteUrl.trim().length > 0 && apiKey.trim().length > 0 && !busy
+
+  const handleConnect = async (): Promise<void> => {
+    if (!canConnect) {
+      return
+    }
+    setBusy(true)
+    setError(null)
+    const test = await testRedmineConnection({ siteUrl: siteUrl.trim(), apiKey: apiKey.trim() })
+    if (!test.ok) {
+      setBusy(false)
+      setError(test.error.message)
+      return
+    }
+    const result = await connectRedmine({ siteUrl: siteUrl.trim(), apiKey: apiKey.trim() })
+    setBusy(false)
+    if (!result.ok) {
+      setError(result.error.message)
+      return
+    }
+    setApiKey('')
+  }
+
+  return (
+    <div className="space-y-4">
+      {connected ? (
+        <div className="flex items-center justify-between rounded-lg border border-border/60 px-3 py-2.5 text-sm">
+          <span className="truncate text-muted-foreground">
+            {status.activeSite?.siteUrl ?? translate('auto.components.settings.TasksPane.redmineConnected', 'Redmine connected')}
+          </span>
+          <Button type="button" variant="outline" size="sm" disabled={!canHide} onClick={onToggleVisible}>
+            {visible
+              ? translate('auto.components.settings.TasksPane.hideFromTasks', 'Hide from Tasks')
+              : translate('auto.components.settings.TasksPane.showInTasks', 'Show in Tasks')}
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="redmine-site-url">
+              {translate('auto.components.settings.TasksPane.redmineServerUrl', 'Server URL')}
+            </Label>
+            <Input
+              id="redmine-site-url"
+              type="text"
+              autoComplete="off"
+              placeholder="https://redmine.example.com"
+              value={siteUrl}
+              onChange={(event) => setSiteUrl(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="redmine-api-key">
+              {translate('auto.components.settings.TasksPane.redmineApiKey', 'API key')}
+            </Label>
+            <Input
+              id="redmine-api-key"
+              type="password"
+              autoComplete="off"
+              placeholder={translate(
+                'auto.components.settings.TasksPane.redmineApiKeyPlaceholder',
+                'Paste your Redmine API key'
+              )}
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+            />
+          </div>
+          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          <Button
+            type="button"
+            size="sm"
+            disabled={!canConnect}
+            onClick={() => void handleConnect()}
+          >
+            {checking
+              ? translate('auto.components.settings.TasksPane.connecting', 'Connecting…')
+              : busy
+                ? translate(
+                    'auto.components.settings.TasksPane.checkingConnection',
+                    'Check & connect…'
+                  )
+                : translate('auto.components.settings.TasksPane.redmineConnect', 'Connect Redmine')}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/TasksPane.test.tsx
+++ b/src/renderer/src/components/settings/TasksPane.test.tsx
@@ -137,7 +137,8 @@ describe('TasksPane', () => {
         skillChecking: false,
         visible: true
       },
-      jira: { connected: false, checking: false, visible: false }
+      jira: { connected: false, checking: false, visible: false },
+      redmine: { connected: false, checking: false, visible: true }
     }
   })
 

--- a/src/renderer/src/components/settings/TasksPane.tsx
+++ b/src/renderer/src/components/settings/TasksPane.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Github, Gitlab } from 'lucide-react'
+import { Github, Gitlab, ListTodo } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { TaskProvider } from '../../../../shared/task-providers'
 import {
@@ -15,6 +15,7 @@ import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader } from './SettingsFormControls'
 import { CodeHostSetupSteps, JiraSetupSteps } from './TaskSourceSimpleSetup'
 import { TaskSourceLinearSetup } from './TaskSourceLinearSetup'
+import { TaskSourceRedmineSetup } from './TaskSourceRedmineSetup'
 import { TaskSourceProviderCard } from './TaskSourceProviderCard'
 import {
   getStalledVisibleTaskProviders,
@@ -89,6 +90,18 @@ const PROVIDER_META: Record<
       )
     },
     Icon: ({ className }) => <JiraIcon className={className} />
+  },
+  redmine: {
+    get label() {
+      return translate('auto.components.settings.TasksPane.redmineLabel', 'Redmine')
+    },
+    get description() {
+      return translate(
+        'auto.components.settings.TasksPane.redmineDescription',
+        'Connect a self-hosted Redmine and show its issues in Tasks.'
+      )
+    },
+    Icon: ({ className }) => <ListTodo className={className} />
   }
 }
 
@@ -226,6 +239,14 @@ export function TasksPane({ settings, updateSettings }: TasksPaneProps): React.J
                     onToggleVisible={() => toggleProvider('jira')}
                     onConnected={() => void checkJiraConnection()}
                     onOpenIntegrations={() => openIntegrations(JIRA_INTEGRATION_SECTION_ID)}
+                  />
+                ) : provider === 'redmine' ? (
+                  <TaskSourceRedmineSetup
+                    connected={readiness.connected}
+                    checking={readiness.checking}
+                    visible={visible}
+                    canHide={canHide}
+                    onToggleVisible={() => toggleProvider('redmine')}
                   />
                 ) : (
                   <CodeHostSetupSteps

--- a/src/renderer/src/components/settings/task-provider-integration-section-ids.ts
+++ b/src/renderer/src/components/settings/task-provider-integration-section-ids.ts
@@ -1,2 +1,3 @@
 export const LINEAR_INTEGRATION_SECTION_ID = 'integrations-linear'
 export const JIRA_INTEGRATION_SECTION_ID = 'integrations-jira'
+export const REDMINE_INTEGRATION_SECTION_ID = 'integrations-redmine'

--- a/src/renderer/src/components/settings/task-source-setup-state.test.ts
+++ b/src/renderer/src/components/settings/task-source-setup-state.test.ts
@@ -26,7 +26,8 @@ function buildReadiness(
       skillChecking: false,
       visible: true
     },
-    jira: { connected: true, checking: false, visible: true }
+    jira: { connected: true, checking: false, visible: true },
+    redmine: { connected: true, checking: false, visible: true }
   }
   for (const provider of ORDER) {
     Object.assign(base[provider], overrides[provider])

--- a/src/renderer/src/components/settings/use-task-source-provider-readiness.ts
+++ b/src/renderer/src/components/settings/use-task-source-provider-readiness.ts
@@ -27,6 +27,9 @@ export function useTaskSourceProviderReadiness(
   const jiraStatus = useAppStore((s) => s.jiraStatus)
   const jiraStatusChecked = useAppStore((s) => s.jiraStatusChecked)
   const jiraStatusContextKey = useAppStore((s) => s.jiraStatusContextKey)
+  const redmineStatus = useAppStore((s) => s.redmineStatus)
+  const redmineStatusChecked = useAppStore((s) => s.redmineStatusChecked)
+  const redmineStatusContextKey = useAppStore((s) => s.redmineStatusContextKey)
   const linearConnected = useLinearProviderConnected()
   const linearStatusChecked = useAppStore((s) => s.linearStatusChecked)
   const linearStatusContextKey = useAppStore((s) => s.linearStatusContextKey)
@@ -58,6 +61,9 @@ export function useTaskSourceProviderReadiness(
     preflightStatus.glab.authenticated === true
   const jiraChecking = jiraStatusContextKey !== providerRuntimeContextKey || !jiraStatusChecked
   const jiraConnected = !jiraChecking && jiraStatus.connected === true
+  const redmineChecking =
+    redmineStatusContextKey !== providerRuntimeContextKey || !redmineStatusChecked
+  const redmineConnected = !redmineChecking && redmineStatus.connected === true
   const linearChecking =
     linearStatusContextKey !== providerRuntimeContextKey || !linearStatusChecked
   // Normalization returns a new array, so memoize by provider contents.
@@ -89,6 +95,11 @@ export function useTaskSourceProviderReadiness(
         connected: jiraConnected,
         checking: jiraChecking,
         visible: visible.has('jira')
+      },
+      redmine: {
+        connected: redmineConnected,
+        checking: redmineChecking,
+        visible: visible.has('redmine')
       }
     }
   }, [
@@ -96,6 +107,8 @@ export function useTaskSourceProviderReadiness(
     gitlabConnected,
     jiraChecking,
     jiraConnected,
+    redmineChecking,
+    redmineConnected,
     linearChecking,
     linearConnected,
     linearSkillInstalled,

--- a/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
+++ b/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
@@ -87,8 +87,7 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
         preferredVisibleTaskProviders,
         {
           gitlabInstalled: preflightStatusCurrent && preflightStatus?.glab?.installed === true,
-          linearConnected: linearStatus.connected === true,
-          redmineConnected: false
+          linearConnected: linearStatus.connected === true
         },
         defaultTaskSource
       ),

--- a/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
+++ b/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
@@ -87,7 +87,8 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
         preferredVisibleTaskProviders,
         {
           gitlabInstalled: preflightStatusCurrent && preflightStatus?.glab?.installed === true,
-          linearConnected: linearStatus.connected === true
+          linearConnected: linearStatus.connected === true,
+          redmineConnected: false
         },
         defaultTaskSource
       ),

--- a/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
+++ b/src/renderer/src/components/sidebar/SidebarTaskNavButton.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { EyeOff, Github, Gitlab, List } from 'lucide-react'
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { LinearIcon } from '@/components/icons/LinearIcon'
+import { RedmineIcon } from '@/components/icons/RedmineIcon'
 import {
   ContextMenu,
   ContextMenuContent,
@@ -226,6 +227,17 @@ export function SidebarTaskNavButton(): React.JSX.Element | null {
                 onOpen={() => openTaskPage({ taskSource: 'jira' })}
               >
                 <JiraIcon className="size-3.5" />
+              </TaskProviderShortcut>
+            ) : null}
+            {visibleTaskProviders.includes('redmine') ? (
+              <TaskProviderShortcut
+                label={translate(
+                  'auto.components.sidebar.SidebarNav.redmineOpenTasks',
+                  'Open Redmine tasks'
+                )}
+                onOpen={() => openTaskPage({ taskSource: 'redmine' })}
+              >
+                <RedmineIcon className="size-3.5" />
               </TaskProviderShortcut>
             ) : null}
           </span>

--- a/src/renderer/src/components/task-page-list-chrome-visibility.ts
+++ b/src/renderer/src/components/task-page-list-chrome-visibility.ts
@@ -30,5 +30,9 @@ export function shouldHideTaskPageListChrome({
       return hasJiraDetail
     case 'linear':
       return hasLinearIssueDetail || hasLinearProjectContext || hasLinearViewContext
+    // Why: Redmine detail opens in a separate workspace surface; the list
+    // chrome does not need to hide while it is focused.
+    case 'redmine':
+      return false
   }
 }

--- a/src/renderer/src/components/task-page-localized-options.tsx
+++ b/src/renderer/src/components/task-page-localized-options.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { Github, Gitlab, LayoutGrid, List, ListTodo } from 'lucide-react'
+import { Github, Gitlab, LayoutGrid, List } from 'lucide-react'
 
 import { JiraIcon } from '@/components/icons/JiraIcon'
+import { RedmineIcon } from '@/components/icons/RedmineIcon'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 import { translate } from '@/i18n/i18n'
 import {
@@ -135,7 +136,7 @@ export const getSourceOptions = createLocalizedCatalog((): SourceOption[] => [
   {
     id: 'redmine',
     label: translate('auto.components.TaskPage.redmineLabel', 'Redmine'),
-    Icon: ({ className }) => <ListTodo className={className} />
+    Icon: ({ className }) => <RedmineIcon className={className} />
   }
 ])
 

--- a/src/renderer/src/components/task-page-localized-options.tsx
+++ b/src/renderer/src/components/task-page-localized-options.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Github, Gitlab, LayoutGrid, List } from 'lucide-react'
+import { Github, Gitlab, LayoutGrid, List, ListTodo } from 'lucide-react'
 
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { createLocalizedCatalog } from '@/i18n/localized-catalog'
@@ -131,6 +131,11 @@ export const getSourceOptions = createLocalizedCatalog((): SourceOption[] => [
     id: 'jira',
     label: translate('auto.components.TaskPage.9cd11ba218', 'Jira'),
     Icon: ({ className }) => <JiraIcon className={className} />
+  },
+  {
+    id: 'redmine',
+    label: translate('auto.components.TaskPage.redmineLabel', 'Redmine'),
+    Icon: ({ className }) => <ListTodo className={className} />
   }
 ])
 

--- a/src/renderer/src/components/task-page/Content.tsx
+++ b/src/renderer/src/components/task-page/Content.tsx
@@ -6,6 +6,7 @@ import { TaskPageGitHubList } from './github/List'
 import { TaskPageGitLabTodoList } from './gitlab/TodoList'
 import { TaskPageGitLabItemList } from './gitlab/ItemList'
 import { TaskPageJiraContent } from './jira/Content'
+import { TaskPageRedmineContent } from './redmine/Content'
 export function TaskPageContent({
   model
 }: {
@@ -69,6 +70,8 @@ export function TaskPageContent({
     <TaskPageGitLabTodoList model={model} />
   ) : taskSource === 'gitlab' ? (
     <TaskPageGitLabItemList model={model} />
+  ) : taskSource === 'redmine' ? (
+    <TaskPageRedmineContent model={model} />
   ) : (
     <TaskPageJiraContent model={model} />
   )

--- a/src/renderer/src/components/task-page/redmine/Content.test.tsx
+++ b/src/renderer/src/components/task-page/redmine/Content.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { TaskPageRedmineContent } from './Content'
+import type { TaskPageComposerActionsModel } from '../../use-task-page-composer-actions'
+
+const { mockState } = vi.hoisted(() => ({ mockState: {} as Record<string, unknown> }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (s: unknown) => unknown) => selector(mockState)
+}))
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+const emptyStatus = () => ({
+  connected: false,
+  activeSite: null,
+  selectedSiteId: null,
+  viewer: null,
+  error: null
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  Object.assign(mockState, {
+    redmineStatus: emptyStatus(),
+    checkRedmineConnection: vi.fn().mockResolvedValue(undefined),
+    listRedmineIssues: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
+    getRedmineIssue: vi.fn().mockResolvedValue(null),
+    connectRedmine: vi.fn().mockResolvedValue({ ok: true })
+  })
+})
+
+function renderStatic(taskSource: string) {
+  return renderToStaticMarkup(
+    React.createElement(TaskPageRedmineContent, {
+      model: {
+        taskSource: taskSource as 'redmine',
+        hideTaskSource: vi.fn()
+      } as unknown as TaskPageComposerActionsModel
+    })
+  )
+}
+
+describe('TaskPageRedmineContent', () => {
+  it('renders a null shell when a different provider is active', () => {
+    expect(renderStatic('jira')).toBe('')
+  })
+
+  it('renders the connect prompt with site + api key fields when not connected', () => {
+    const html = renderStatic('redmine')
+    expect(html).toContain('Connect your Redmine server')
+    expect(html).toContain('Server URL')
+    expect(html).toContain('API key')
+  })
+
+  it('does not render the connect prompt once connected', () => {
+    mockState.redmineStatus = { ...emptyStatus(), connected: true }
+    const html = renderStatic('redmine')
+    expect(html).not.toContain('Connect your Redmine server')
+  })
+})

--- a/src/renderer/src/components/task-page/redmine/Content.tsx
+++ b/src/renderer/src/components/task-page/redmine/Content.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
-import { ListTodo } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
+import { RedmineIcon } from '@/components/icons/RedmineIcon'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -43,7 +43,7 @@ function ConnectPrompt() {
 
   return (
     <div className="mt-4 flex flex-col items-center justify-center rounded-md border border-border/50 bg-muted/50 px-6 py-10 text-center shadow-sm">
-      <ListTodo className="mb-4 size-8 text-muted-foreground/60" />
+      <RedmineIcon className="mb-4 size-8 text-muted-foreground/60" />
       <p className="text-base font-medium text-foreground">
         {translate('auto.components.TaskPage.redmineConnectTitle', 'Connect your Redmine server')}
       </p>

--- a/src/renderer/src/components/task-page/redmine/Content.tsx
+++ b/src/renderer/src/components/task-page/redmine/Content.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useState } from 'react'
+import { ListTodo } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { translate } from '@/i18n/i18n'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import type { TaskPageComposerActionsModel } from '../../use-task-page-composer-actions'
+import type { RedmineIssue } from '../../../../../shared/redmine-types'
+
+function statusTone(statusName?: string | null): string {
+  switch ((statusName ?? '').toLowerCase()) {
+    case 'new':
+    case 'open':
+      return 'bg-amber-500/15 text-amber-700 dark:text-amber-300'
+    case 'in progress':
+    case 'in_progress':
+      return 'bg-blue-500/15 text-blue-700 dark:text-blue-300'
+    case 'closed':
+    case 'resolved':
+      return 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300'
+    default:
+      return 'bg-muted text-muted-foreground'
+  }
+}
+
+function ConnectPrompt() {
+  const connectRedmine = useAppStore((s) => s.connectRedmine)
+  const [siteUrl, setSiteUrl] = useState('')
+  const [apiKey, setApiKey] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleConnect() {
+    setBusy(true)
+    setError(null)
+    const result = await connectRedmine({ siteUrl: siteUrl.trim(), apiKey: apiKey.trim() })
+    setBusy(false)
+    if (!result.ok) {
+      setError(result.error.message)
+    }
+  }
+
+  return (
+    <div className="mt-4 flex flex-col items-center justify-center rounded-md border border-border/50 bg-muted/50 px-6 py-10 text-center shadow-sm">
+      <ListTodo className="mb-4 size-8 text-muted-foreground/60" />
+      <p className="text-base font-medium text-foreground">
+        {translate('auto.components.TaskPage.redmineConnectTitle', 'Connect your Redmine server')}
+      </p>
+      <p className="mt-2 max-w-sm text-sm text-muted-foreground">
+        {translate(
+          'auto.components.TaskPage.redmineConnectBody',
+          'Add a self-hosted Redmine server URL and an API key to browse your assigned issues.'
+        )}
+      </p>
+      <form
+        className="mt-5 flex w-full max-w-sm flex-col gap-3 text-left"
+        onSubmit={(e) => {
+          e.preventDefault()
+          void handleConnect()
+        }}
+      >
+        <Label htmlFor="redmine-site-url">
+          {translate('auto.components.TaskPage.redmineSiteUrl', 'Server URL')}
+        </Label>
+        <Input
+          id="redmine-site-url"
+          value={siteUrl}
+          onChange={(e) => setSiteUrl(e.target.value)}
+          placeholder="https://redmine.example.com"
+          autoComplete="off"
+        />
+        <Label htmlFor="redmine-api-key">
+          {translate('auto.components.TaskPage.redmineApiKey', 'API key')}
+        </Label>
+        <Input
+          id="redmine-api-key"
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          autoComplete="off"
+        />
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          <Button type="submit" disabled={busy}>
+            {busy
+              ? translate('auto.components.TaskPage.redmineConnecting', 'Connecting…')
+              : translate('auto.components.TaskPage.redmineConnect', 'Connect Redmine')}
+          </Button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export function TaskPageRedmineContent({
+  model
+}: {
+  model: TaskPageComposerActionsModel
+}): React.JSX.Element | null {
+  const redmineStatus = useAppStore((s) => s.redmineStatus)
+  const checkRedmineConnection = useAppStore((s) => s.checkRedmineConnection)
+  const listRedmineIssues = useAppStore((s) => s.listRedmineIssues)
+  const getRedmineIssue = useAppStore((s) => s.getRedmineIssue)
+
+  const [issues, setIssues] = useState<RedmineIssue[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selected, setSelected] = useState<RedmineIssue | null>(null)
+  const { taskSource } = model
+
+  const connected = redmineStatus.connected
+
+  useEffect(() => {
+    void checkRedmineConnection()
+    // Why: probe once on mount; deeper refreshes happen after connect/list.
+  }, [checkRedmineConnection])
+
+  useEffect(() => {
+    if (!connected) {
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    void listRedmineIssues({ scope: 'assigned' })
+      .then((result) => {
+        if (cancelled) {
+          return
+        }
+        setIssues(result?.items ?? [])
+        setLoading(false)
+      })
+      .catch(() => {
+        if (cancelled) {
+          return
+        }
+        setError('Failed to load issues.')
+        setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [connected, listRedmineIssues])
+
+  function openIssue(issue: RedmineIssue) {
+    setSelected(issue)
+    void getRedmineIssue(issue.id).then((full) => {
+      if (full) {
+        setSelected(full)
+      }
+    })
+  }
+
+  return taskSource === 'redmine' ? (
+    !connected ? (
+      <ConnectPrompt />
+    ) : (
+      <div className="flex min-h-0 max-h-full flex-col overflow-hidden rounded-md rounded-t-none border border-t-0 border-border/50 bg-background shadow-sm">
+        <div className="flex h-10 flex-none items-center justify-between gap-3 border-b border-border/50 bg-muted/35 px-3">
+          <div className="min-w-0 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+            {translate('auto.components.TaskPage.redmineTitle', 'Redmine issues')}
+          </div>
+          <div className="shrink-0 text-[11px] text-muted-foreground">
+            {issues.length} {translate('auto.components.TaskPage.b7bae28b6a', 'shown')}
+          </div>
+        </div>
+
+        {selected ? (
+          <div className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
+            <div className="border-b border-border/50 px-4 py-3">
+              <Button
+                variant="ghost"
+                className="mb-2 px-2 text-xs"
+                onClick={() => setSelected(null)}
+              >
+                ← {translate('auto.components.TaskPage.redmineBackToList', 'Back to list')}
+              </Button>
+              <div className="text-sm text-muted-foreground">
+                {selected.tracker?.name ?? 'Issue'} #{selected.id}
+              </div>
+              <div className="mt-1 text-base font-medium text-foreground">{selected.subject}</div>
+              <div className="mt-2 text-xs text-muted-foreground">
+                {selected.project?.name}
+                {selected.assignedTo || selected.priority
+                  ? ` · ${selected.assignedTo?.name ?? ''}${
+                      selected.priority?.name ? ` · ${selected.priority.name}` : ''
+                    }`
+                  : ''}
+              </div>
+            </div>
+            <dl className="divide-y divide-border/50 text-sm">
+              <Row label="Status" value={selected.status?.name} />
+              <Row label="Priority" value={selected.priority?.name} />
+              <Row label="Tracker" value={selected.tracker?.name} />
+              <Row label="Assignee" value={selected.assignedTo?.name} />
+              <Row label="Progress" value={`${selected.doneRatio ?? 0}%`} />
+              <Row label="Created" value={selected.createdOn} />
+              <Row label="Updated" value={selected.updatedOn} />
+              {selected.customFields?.length ? (
+                selected.customFields.map((field, i) => (
+                  <Row key={i} label={field.name} value={field.value ? String(field.value) : undefined} />
+                ))
+              ) : (
+                <Row label="Custom fields" value="—" />
+              )}
+              {selected.description ? (
+                <div className="whitespace-pre-wrap px-4 py-3 text-sm text-foreground">
+                  {selected.description}
+                </div>
+              ) : null}
+            </dl>
+          </div>
+        ) : (
+          <div
+            className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek"
+            style={{ scrollbarGutter: 'stable' }}
+          >
+            {error ? (
+              <div className="border-b border-border px-4 py-4 text-sm text-destructive">
+                {error}
+              </div>
+            ) : null}
+
+            {loading ? (
+              <div className="divide-y divide-border/50">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="px-3 py-3">
+                    <div className="h-4 w-4/5 animate-pulse rounded bg-muted/70" />
+                    <div className="mt-2 h-3 w-3/5 animate-pulse rounded bg-muted/60" />
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            {!loading && issues.length === 0 && !error ? (
+              <div className="px-4 py-10 text-center">
+                <p className="text-sm font-medium text-foreground">
+                  {translate(
+                    'auto.components.TaskPage.redmineNoIssues',
+                    'No Redmine issues found'
+                  )}
+                </p>
+              </div>
+            ) : null}
+
+            {!loading ? (
+              <div className="divide-y divide-border/50">
+                {issues.map((issue) => (
+                  <button
+                    key={issue.id}
+                    type="button"
+                    onClick={() => openIssue(issue)}
+                    className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-muted/40 focus:outline-none"
+                  >
+                    <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                      {issue.tracker ? `${issue.tracker.name} ` : ''}#{issue.id}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+                      {issue.subject}
+                    </span>
+                    <span
+                      className={`shrink-0 rounded-full px-2 py-0.5 text-[11px] ${statusTone(
+                        issue.status?.name
+                      )}`}
+                    >
+                      {issue.status?.name ?? '—'}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        )}
+      </div>
+    )
+  ) : null
+
+  function Row({ label, value }: { label: string; value?: string | null }) {
+    return (
+      <div className="flex items-start justify-between gap-4 px-4 py-2">
+        <dt className="text-muted-foreground">{label}</dt>
+        <dd className="text-right text-foreground">{value || '—'}</dd>
+      </div>
+    )
+  }
+}

--- a/src/renderer/src/components/task-page/redmine/Content.tsx
+++ b/src/renderer/src/components/task-page/redmine/Content.tsx
@@ -199,7 +199,11 @@ export function TaskPageRedmineContent({
               <Row label="Updated" value={selected.updatedOn} />
               {selected.customFields?.length ? (
                 selected.customFields.map((field, i) => (
-                  <Row key={i} label={field.name} value={field.value ? String(field.value) : undefined} />
+                  <Row
+                    key={i}
+                    label={field.name}
+                    value={field.value ? String(field.value) : undefined}
+                  />
                 ))
               ) : (
                 <Row label="Custom fields" value="—" />
@@ -236,10 +240,7 @@ export function TaskPageRedmineContent({
             {!loading && issues.length === 0 && !error ? (
               <div className="px-4 py-10 text-center">
                 <p className="text-sm font-medium text-foreground">
-                  {translate(
-                    'auto.components.TaskPage.redmineNoIssues',
-                    'No Redmine issues found'
-                  )}
+                  {translate('auto.components.TaskPage.redmineNoIssues', 'No Redmine issues found')}
                 </p>
               </div>
             ) : null}

--- a/src/renderer/src/components/task-page/redmine/Content.tsx
+++ b/src/renderer/src/components/task-page/redmine/Content.tsx
@@ -129,6 +129,7 @@ export function TaskPageRedmineContent({
           return
         }
         setIssues(result?.items ?? [])
+        setError(result?.error?.message ?? null)
         setLoading(false)
       })
       .catch(() => {
@@ -145,7 +146,7 @@ export function TaskPageRedmineContent({
 
   function openIssue(issue: RedmineIssue) {
     setSelected(issue)
-    void getRedmineIssue(issue.id).then((full) => {
+    void getRedmineIssue(issue.id).then(({ issue: full }) => {
       if (full) {
         setSelected(full)
       }

--- a/src/renderer/src/components/task-page/redmine/Content.tsx
+++ b/src/renderer/src/components/task-page/redmine/Content.tsx
@@ -118,11 +118,17 @@ export function TaskPageRedmineContent({
 
   useEffect(() => {
     if (!connected) {
+      // Why: drop stale list/detail/error so a reconnect to a different site
+      // never shows the previous site's issues.
+      setIssues([])
+      setSelected(null)
+      setError(null)
       setLoading(false)
       return
     }
     let cancelled = false
     setLoading(true)
+    setError(null)
     void listRedmineIssues({ scope: 'assigned' })
       .then((result) => {
         if (cancelled) {

--- a/src/renderer/src/components/task-source-context-summary.ts
+++ b/src/renderer/src/components/task-source-context-summary.ts
@@ -45,26 +45,22 @@ export function getTaskSourceContextSummary(args: {
   selectedRepoCount?: number
   linearWorkspaceName?: string | null
   jiraSiteName?: string | null
+  redmineSiteName?: string | null
 }): TaskSourceContextSummary {
-  switch (args.provider) {
-    case 'github':
-    case 'gitlab':
-      return getRepoBackedTaskSourceSummary(args)
-    case 'linear':
-      return getAccountBackedTaskSourceSummary(args.providerLabel, {
-        accountLabel: args.linearWorkspaceName,
-        accountHostId: args.accountHostId,
-        hostLabelById: args.hostLabelById,
-        hostAvailability: args.hostAvailability
-      })
-    case 'jira':
-      return getAccountBackedTaskSourceSummary(args.providerLabel, {
-        accountLabel: args.jiraSiteName,
-        accountHostId: args.accountHostId,
-        hostLabelById: args.hostLabelById,
-        hostAvailability: args.hostAvailability
-      })
+  if (args.provider === 'github' || args.provider === 'gitlab') {
+    return getRepoBackedTaskSourceSummary(args)
   }
+  return getAccountBackedTaskSourceSummary(args.providerLabel, {
+    accountLabel:
+      args.provider === 'linear'
+        ? args.linearWorkspaceName
+        : args.provider === 'jira'
+          ? args.jiraSiteName
+          : args.redmineSiteName,
+    accountHostId: args.accountHostId,
+    hostLabelById: args.hostLabelById,
+    hostAvailability: args.hostAvailability
+  })
 }
 
 export function getTaskSourceAvailabilityNotice(args: {
@@ -197,6 +193,7 @@ function getProviderIdentityLabel(
     case 'linear':
       return identity.workspaceName ?? identity.workspaceId ?? null
     case 'jira':
+    case 'redmine':
       return identity.siteUrl ?? identity.siteId ?? null
   }
 }

--- a/src/renderer/src/components/use-task-page-repo-selection.ts
+++ b/src/renderer/src/components/use-task-page-repo-selection.ts
@@ -140,7 +140,8 @@ export function useTaskPageRepoSelection(model: TaskPageStoreBindingsModel) {
         preferredVisibleTaskProviders,
         {
           gitlabInstalled: preflightStatusCurrent && preflightStatus?.glab?.installed === true,
-          linearConnected: linearConnected === true
+          linearConnected: linearConnected === true,
+          redmineConnected: false
         },
         defaultTaskSource
       ),

--- a/src/renderer/src/components/use-task-page-repo-selection.ts
+++ b/src/renderer/src/components/use-task-page-repo-selection.ts
@@ -140,8 +140,7 @@ export function useTaskPageRepoSelection(model: TaskPageStoreBindingsModel) {
         preferredVisibleTaskProviders,
         {
           gitlabInstalled: preflightStatusCurrent && preflightStatus?.glab?.installed === true,
-          linearConnected: linearConnected === true,
-          redmineConnected: false
+          linearConnected: linearConnected === true
         },
         defaultTaskSource
       ),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2256,7 +2256,17 @@
         "linearModeHasWorktreeTooltip": "Linear tickets linked to an Orca workspace",
         "linearEmptyHasWorktree": "No Linear tickets are linked to an Orca workspace yet. Start work from a Linear issue to see it here.",
         "linearOpenAttachedWorkspace": "Open workspace attached to {{value0}}",
-        "linearWorktreesColumn": "Workspaces"
+        "linearWorktreesColumn": "Workspaces",
+        "redmineLabel": "Redmine",
+        "redmineConnectTitle": "Connect your Redmine server",
+        "redmineConnectBody": "Add a self-hosted Redmine server URL and an API key to browse your assigned issues.",
+        "redmineSiteUrl": "Server URL",
+        "redmineApiKey": "API key",
+        "redmineConnecting": "Connecting…",
+        "redmineConnect": "Connect Redmine",
+        "redmineTitle": "Redmine issues",
+        "redmineBackToList": "Back to list",
+        "redmineNoIssues": "No Redmine issues found"
       },
       "Terminal": {
         "73768427cf": "Close",
@@ -8475,7 +8485,9 @@
           "integrationsHint": "Credentials for all providers also live under",
           "integrationsLink": "Integrations",
           "skillHint": ". After Linear is connected, usage examples stay under Settings → Linear.",
-          "incompleteBannerBodyWithLinear": "Hide providers you do not use, or expand a card and finish its steps. For Linear: API access, the agent skill, and Show in Tasks."
+          "incompleteBannerBodyWithLinear": "Hide providers you do not use, or expand a card and finish its steps. For Linear: API access, the agent skill, and Show in Tasks.",
+          "redmineLabel": "Redmine",
+          "redmineDescription": "Connect a self-hosted Redmine and show its issues in Tasks."
         },
         "TerminalAppearanceSection": {
           "a14a427ae4": "Thickness of the pane divider line.",

--- a/src/renderer/src/runtime/runtime-redmine-client.test.ts
+++ b/src/renderer/src/runtime/runtime-redmine-client.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  redmineConnect,
+  redmineGetIssue,
+  redmineListIssues,
+  redmineStatus,
+  redmineTestConnection
+} from './runtime-redmine-client'
+import type { RedmineIssue } from '../../../shared/redmine-types'
+
+const { callRuntimeRpc, getActiveRuntimeTarget } = vi.hoisted(() => ({
+  callRuntimeRpc: vi.fn(),
+  getActiveRuntimeTarget: vi.fn()
+}))
+
+vi.mock('./runtime-rpc-client', () => ({ callRuntimeRpc, getActiveRuntimeTarget }))
+
+function remoteTarget() {
+  return { kind: 'environment', environmentId: 'env-1' }
+}
+function localTarget() {
+  return { kind: 'local' }
+}
+
+let windowApiRedmine!: Record<string, ReturnType<typeof vi.fn>>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ;(windowApiRedmine as Record<string, ReturnType<typeof vi.fn>>) = {
+    status: vi.fn(),
+    testConnection: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    listIssues: vi.fn(),
+    getIssue: vi.fn()
+  }
+  vi.stubGlobal('window', { api: { redmine: windowApiRedmine } })
+})
+
+const issue: RedmineIssue = {
+  id: 1,
+  subject: 'Fix the thing',
+  project: { id: 1, name: 'Orca' },
+  tracker: { id: 1, name: 'Bug' },
+  status: { id: 1, name: 'New' },
+  priority: { id: 1, name: 'Normal' },
+  author: { id: 1, name: 'Ada', login: 'ada' },
+  assignedTo: null,
+  description: null,
+  startDate: null,
+  dueDate: null,
+  doneRatio: 0,
+  estimatedHours: null,
+  spentHours: null,
+  createdOn: '2026-01-01T00:00:00Z',
+  updatedOn: '2026-01-01T00:00:00Z',
+  closedOn: null,
+  customFields: [],
+  url: 'https://redmine.example.com/issues/1'
+}
+
+describe('redmineListIssues', () => {
+  it('uses window.api on a local runtime and normalizes the result', async () => {
+    getActiveRuntimeTarget.mockReturnValue(localTarget())
+    windowApiRedmine.listIssues.mockResolvedValue({ items: [issue], totalCount: 1 })
+
+    const result = await redmineListIssues(null, { scope: 'assigned' })
+
+    expect(windowApiRedmine.listIssues).toHaveBeenCalledWith({ filter: { scope: 'assigned' } })
+    expect(result).toEqual({ items: [issue], totalCount: 1 })
+  })
+
+  it('routes through runtime RPC on a remote environment', async () => {
+    getActiveRuntimeTarget.mockReturnValue(remoteTarget())
+    callRuntimeRpc.mockResolvedValue({ items: [issue], totalCount: 1 })
+
+    const result = await redmineListIssues(null, { scope: 'assigned' })
+
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      remoteTarget(),
+      'redmine.listIssues',
+      { filter: { scope: 'assigned' } },
+      expect.objectContaining({ timeoutMs: 30_000 })
+    )
+    expect(result.items).toHaveLength(1)
+  })
+
+  it('normalizes a malformed payload to an empty collection', async () => {
+    getActiveRuntimeTarget.mockReturnValue(localTarget())
+    windowApiRedmine.listIssues.mockResolvedValue(null)
+
+    const result = await redmineListIssues(null)
+    expect(result).toEqual({ items: [], totalCount: 0 })
+  })
+})
+
+describe('redmineStatus / getIssue', () => {
+  it('reads status from window.api locally', async () => {
+    getActiveRuntimeTarget.mockReturnValue(localTarget())
+    windowApiRedmine.status.mockResolvedValue({ connected: true })
+    const status = await redmineStatus(null)
+    expect(status).toEqual({ connected: true })
+  })
+
+  it('reads a single issue from window.api locally', async () => {
+    getActiveRuntimeTarget.mockReturnValue(localTarget())
+    windowApiRedmine.getIssue.mockResolvedValue(issue)
+    const result = await redmineGetIssue(null, 1)
+    expect(windowApiRedmine.getIssue).toHaveBeenCalledWith({ issueId: 1 })
+    expect(result?.id).toBe(1)
+  })
+
+  it('routes getIssue through runtime RPC remotely', async () => {
+    getActiveRuntimeTarget.mockReturnValue(remoteTarget())
+    callRuntimeRpc.mockResolvedValue(issue)
+    const result = await redmineGetIssue(null, 2)
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      remoteTarget(),
+      'redmine.getIssue',
+      { issueId: 2 },
+      expect.anything()
+    )
+    expect(result?.id).toBe(1)
+  })
+})
+
+describe('connect flows select the right transport', () => {
+  it('testConnection hits window.api locally', async () => {
+    getActiveRuntimeTarget.mockReturnValue(localTarget())
+    windowApiRedmine.testConnection.mockResolvedValue({
+      ok: true,
+      user: { id: 1, name: 'Ada', login: 'ada' }
+    })
+    const result = await redmineTestConnection(null, { siteUrl: 'https://x.example', apiKey: 'k' })
+    expect(windowApiRedmine.testConnection).toHaveBeenCalledWith({
+      siteUrl: 'https://x.example',
+      apiKey: 'k'
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  it('connect routes through runtime RPC remotely', async () => {
+    getActiveRuntimeTarget.mockReturnValue(remoteTarget())
+    callRuntimeRpc.mockResolvedValue({ ok: true })
+    await redmineConnect(null, { siteUrl: 'https://x.example', apiKey: 'k' })
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      remoteTarget(),
+      'redmine.connect',
+      { siteUrl: 'https://x.example', apiKey: 'k' },
+      expect.anything()
+    )
+  })
+})

--- a/src/renderer/src/runtime/runtime-redmine-client.test.ts
+++ b/src/renderer/src/runtime/runtime-redmine-client.test.ts
@@ -104,15 +104,15 @@ describe('redmineStatus / getIssue', () => {
 
   it('reads a single issue from window.api locally', async () => {
     getActiveRuntimeTarget.mockReturnValue(localTarget())
-    windowApiRedmine.getIssue.mockResolvedValue(issue)
+    windowApiRedmine.getIssue.mockResolvedValue({ issue })
     const result = await redmineGetIssue(null, 1)
     expect(windowApiRedmine.getIssue).toHaveBeenCalledWith({ issueId: 1 })
-    expect(result?.id).toBe(1)
+    expect(result.issue?.id).toBe(1)
   })
 
   it('routes getIssue through runtime RPC remotely', async () => {
     getActiveRuntimeTarget.mockReturnValue(remoteTarget())
-    callRuntimeRpc.mockResolvedValue(issue)
+    callRuntimeRpc.mockResolvedValue({ issue })
     const result = await redmineGetIssue(null, 2)
     expect(callRuntimeRpc).toHaveBeenCalledWith(
       remoteTarget(),
@@ -120,7 +120,14 @@ describe('redmineStatus / getIssue', () => {
       { issueId: 2 },
       expect.anything()
     )
-    expect(result?.id).toBe(1)
+    expect(result.issue?.id).toBe(1)
+  })
+
+  it('normalizes a malformed getIssue payload to issue:null', async () => {
+    getActiveRuntimeTarget.mockReturnValue(localTarget())
+    windowApiRedmine.getIssue.mockResolvedValue(null)
+    const result = await redmineGetIssue(null, 1)
+    expect(result).toEqual({ issue: null })
   })
 })
 

--- a/src/renderer/src/runtime/runtime-redmine-client.ts
+++ b/src/renderer/src/runtime/runtime-redmine-client.ts
@@ -7,10 +7,7 @@ import type {
   RedmineSite,
   RedmineUser
 } from '../../../shared/redmine-types'
-import {
-  callRuntimeRpc,
-  getActiveRuntimeTarget
-} from './runtime-rpc-client'
+import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 import {
   getTaskSourceRuntimeSettings,
   type TaskSourceContext
@@ -50,9 +47,7 @@ export function getRedmineRuntimeTarget(
   )
 }
 
-function normalizeRedmineIssueCollectionResult(
-  result: unknown
-): RedmineIssueCollectionResult {
+function normalizeRedmineIssueCollectionResult(result: unknown): RedmineIssueCollectionResult {
   if (!result || typeof result !== 'object') {
     return { items: [], totalCount: 0 }
   }
@@ -84,12 +79,9 @@ export async function redmineTestConnection(
 ): Promise<RedmineTestConnectionResult> {
   const target = getRedmineRuntimeTarget(settings)
   return target.kind === 'environment'
-    ? callRuntimeRpc<RedmineTestConnectionResult>(
-        target,
-        'redmine.testConnection',
-        args,
-        { timeoutMs: 30_000 }
-      )
+    ? callRuntimeRpc<RedmineTestConnectionResult>(target, 'redmine.testConnection', args, {
+        timeoutMs: 30_000
+      })
     : window.api.redmine.testConnection(args)
 }
 
@@ -131,9 +123,14 @@ export async function redmineListIssues(
   const target = getRedmineRuntimeTarget(settings)
   const result =
     target.kind === 'environment'
-      ? await callRuntimeRpc<unknown>(target, 'redmine.listIssues', filter ? { filter } : undefined, {
-          timeoutMs: 30_000
-        })
+      ? await callRuntimeRpc<unknown>(
+          target,
+          'redmine.listIssues',
+          filter ? { filter } : undefined,
+          {
+            timeoutMs: 30_000
+          }
+        )
       : await window.api.redmine.listIssues(filter ? { filter } : undefined)
   return normalizeRedmineIssueCollectionResult(result)
 }
@@ -144,6 +141,11 @@ export async function redmineGetIssue(
 ): Promise<RedmineIssue | null> {
   const target = getRedmineRuntimeTarget(settings)
   return target.kind === 'environment'
-    ? callRuntimeRpc<RedmineIssue | null>(target, 'redmine.getIssue', { issueId }, { timeoutMs: 30_000 })
+    ? callRuntimeRpc<RedmineIssue | null>(
+        target,
+        'redmine.getIssue',
+        { issueId },
+        { timeoutMs: 30_000 }
+      )
     : window.api.redmine.getIssue({ issueId })
 }

--- a/src/renderer/src/runtime/runtime-redmine-client.ts
+++ b/src/renderer/src/runtime/runtime-redmine-client.ts
@@ -1,0 +1,149 @@
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type {
+  RedmineConnectionStatus,
+  RedmineIssue,
+  RedmineIssueCollectionResult,
+  RedmineListFilter,
+  RedmineSite,
+  RedmineUser
+} from '../../../shared/redmine-types'
+import {
+  callRuntimeRpc,
+  getActiveRuntimeTarget
+} from './runtime-rpc-client'
+import {
+  getTaskSourceRuntimeSettings,
+  type TaskSourceContext
+} from '../../../shared/task-source-context'
+
+export type RuntimeRedmineSettings =
+  | Pick<GlobalSettings, 'activeRuntimeEnvironmentId'>
+  | TaskSourceContext
+  | null
+  | undefined
+
+export type RedmineConnectResult =
+  | { ok: true; site: RedmineSite; viewer: RedmineUser }
+  | { ok: false; error: { type: string; message: string } }
+
+export type RedmineTestConnectionResult =
+  | { ok: true; user: RedmineUser }
+  | { ok: false; error: { type: string; message: string } }
+
+export type RedmineReadOptions = { force?: boolean }
+
+export function redmineReadForce(options?: RedmineReadOptions): { force: true } | {} {
+  return options?.force ? { force: true } : {}
+}
+
+function isTaskSourceRuntimeSettings(
+  settings: RuntimeRedmineSettings
+): settings is TaskSourceContext {
+  return settings !== null && settings !== undefined && 'kind' in settings
+}
+
+export function getRedmineRuntimeTarget(
+  settings: RuntimeRedmineSettings
+): ReturnType<typeof getActiveRuntimeTarget> {
+  return getActiveRuntimeTarget(
+    isTaskSourceRuntimeSettings(settings) ? getTaskSourceRuntimeSettings(settings) : settings
+  )
+}
+
+function normalizeRedmineIssueCollectionResult(
+  result: unknown
+): RedmineIssueCollectionResult {
+  if (!result || typeof result !== 'object') {
+    return { items: [], totalCount: 0 }
+  }
+  const collection = result as Partial<RedmineIssueCollectionResult>
+  if (!Array.isArray(collection.items)) {
+    return { items: [], totalCount: 0 }
+  }
+  return {
+    items: collection.items,
+    totalCount: typeof collection.totalCount === 'number' ? collection.totalCount : 0,
+    ...(collection.error ? { error: collection.error } : {})
+  }
+}
+
+export async function redmineStatus(
+  settings: RuntimeRedmineSettings
+): Promise<RedmineConnectionStatus> {
+  const target = getRedmineRuntimeTarget(settings)
+  return target.kind === 'environment'
+    ? callRuntimeRpc<RedmineConnectionStatus>(target, 'redmine.status', undefined, {
+        timeoutMs: 15_000
+      })
+    : window.api.redmine.status()
+}
+
+export async function redmineTestConnection(
+  settings: RuntimeRedmineSettings,
+  args: { siteUrl: string; apiKey: string }
+): Promise<RedmineTestConnectionResult> {
+  const target = getRedmineRuntimeTarget(settings)
+  return target.kind === 'environment'
+    ? callRuntimeRpc<RedmineTestConnectionResult>(
+        target,
+        'redmine.testConnection',
+        args,
+        { timeoutMs: 30_000 }
+      )
+    : window.api.redmine.testConnection(args)
+}
+
+export async function redmineConnect(
+  settings: RuntimeRedmineSettings,
+  args: { siteUrl: string; apiKey: string }
+): Promise<RedmineConnectResult> {
+  const target = getRedmineRuntimeTarget(settings)
+  return target.kind === 'environment'
+    ? callRuntimeRpc<RedmineConnectResult>(target, 'redmine.connect', args, {
+        timeoutMs: 30_000
+      })
+    : window.api.redmine.connect(args)
+}
+
+export async function redmineDisconnect(
+  settings: RuntimeRedmineSettings,
+  siteId?: string | null
+): Promise<void> {
+  const target = getRedmineRuntimeTarget(settings)
+  if (target.kind === 'environment') {
+    await callRuntimeRpc<{ ok: true }>(
+      target,
+      'redmine.disconnect',
+      siteId ? { siteId } : undefined,
+      { timeoutMs: 15_000 }
+    )
+    return
+  }
+  if (siteId) {
+    await window.api.redmine.disconnect({ siteId })
+  }
+}
+
+export async function redmineListIssues(
+  settings: RuntimeRedmineSettings,
+  filter?: RedmineListFilter
+): Promise<RedmineIssueCollectionResult> {
+  const target = getRedmineRuntimeTarget(settings)
+  const result =
+    target.kind === 'environment'
+      ? await callRuntimeRpc<unknown>(target, 'redmine.listIssues', filter ? { filter } : undefined, {
+          timeoutMs: 30_000
+        })
+      : await window.api.redmine.listIssues(filter ? { filter } : undefined)
+  return normalizeRedmineIssueCollectionResult(result)
+}
+
+export async function redmineGetIssue(
+  settings: RuntimeRedmineSettings,
+  issueId: number
+): Promise<RedmineIssue | null> {
+  const target = getRedmineRuntimeTarget(settings)
+  return target.kind === 'environment'
+    ? callRuntimeRpc<RedmineIssue | null>(target, 'redmine.getIssue', { issueId }, { timeoutMs: 30_000 })
+    : window.api.redmine.getIssue({ issueId })
+}

--- a/src/renderer/src/runtime/runtime-redmine-client.ts
+++ b/src/renderer/src/runtime/runtime-redmine-client.ts
@@ -4,6 +4,7 @@ import type {
   RedmineIssue,
   RedmineIssueCollectionResult,
   RedmineListFilter,
+  RedmineReadError,
   RedmineSite,
   RedmineUser
 } from '../../../shared/redmine-types'
@@ -135,17 +136,35 @@ export async function redmineListIssues(
   return normalizeRedmineIssueCollectionResult(result)
 }
 
+export type RedmineIssueDetailResult = {
+  issue: RedmineIssue | null
+  error?: RedmineReadError
+}
+
 export async function redmineGetIssue(
   settings: RuntimeRedmineSettings,
   issueId: number
-): Promise<RedmineIssue | null> {
+): Promise<RedmineIssueDetailResult> {
   const target = getRedmineRuntimeTarget(settings)
-  return target.kind === 'environment'
-    ? callRuntimeRpc<RedmineIssue | null>(
-        target,
-        'redmine.getIssue',
-        { issueId },
-        { timeoutMs: 30_000 }
-      )
-    : window.api.redmine.getIssue({ issueId })
+  const result: unknown =
+    target.kind === 'environment'
+      ? await callRuntimeRpc<unknown>(
+          target,
+          'redmine.getIssue',
+          { issueId },
+          { timeoutMs: 30_000 }
+        )
+      : await window.api.redmine.getIssue({ issueId })
+  return normalizeRedmineIssueDetailResult(result)
+}
+
+function normalizeRedmineIssueDetailResult(result: unknown): RedmineIssueDetailResult {
+  if (!result || typeof result !== 'object') {
+    return { issue: null }
+  }
+  const detail = result as Partial<RedmineIssueDetailResult>
+  return {
+    issue: detail.issue ?? null,
+    ...(detail.error ? { error: detail.error } : {})
+  }
 }

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -13,6 +13,7 @@ import { createHostedReviewSlice } from './slices/hosted-review'
 import { createLinearSlice } from './slices/linear'
 import { createPreflightSlice } from './slices/preflight'
 import { createJiraSlice } from './slices/jira'
+import { createRedmineSlice } from './slices/redmine'
 import { createEditorSlice } from './slices/editor'
 import { createStatsSlice } from './slices/stats'
 import { createMemorySlice } from './slices/memory'
@@ -87,6 +88,7 @@ export const useAppStore = create<AppState>()(
         ...createLinearSlice(...a),
         ...createPreflightSlice(...a),
         ...createJiraSlice(...a),
+        ...createRedmineSlice(...a),
         ...createEditorSlice(...a),
         ...createStatsSlice(...a),
         ...createMemorySlice(...a),

--- a/src/renderer/src/store/slices/redmine.ts
+++ b/src/renderer/src/store/slices/redmine.ts
@@ -1,0 +1,17 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import { redmineListInvalidationToken } from './redmine/redmine-cache'
+import { createRedmineActions } from './redmine/redmine-slice-actions'
+import type { RedmineSlice } from './redmine/redmine-slice-contract'
+
+export type { RedmineSlice } from './redmine/redmine-slice-contract'
+
+export const createRedmineSlice: StateCreator<AppState, [], [], RedmineSlice> = (set, get) => ({
+  redmineStatus: { connected: false, activeSite: null, selectedSiteId: null, viewer: null, error: null },
+  redmineStatusChecked: false,
+  redmineStatusContextKey: null,
+  redmineIssueCache: {},
+  redmineListCache: {},
+  redmineListInvalidationToken,
+  ...createRedmineActions(set, get)
+})

--- a/src/renderer/src/store/slices/redmine.ts
+++ b/src/renderer/src/store/slices/redmine.ts
@@ -7,7 +7,13 @@ import type { RedmineSlice } from './redmine/redmine-slice-contract'
 export type { RedmineSlice } from './redmine/redmine-slice-contract'
 
 export const createRedmineSlice: StateCreator<AppState, [], [], RedmineSlice> = (set, get) => ({
-  redmineStatus: { connected: false, activeSite: null, selectedSiteId: null, viewer: null, error: null },
+  redmineStatus: {
+    connected: false,
+    activeSite: null,
+    selectedSiteId: null,
+    viewer: null,
+    error: null
+  },
   redmineStatusChecked: false,
   redmineStatusContextKey: null,
   redmineIssueCache: {},

--- a/src/renderer/src/store/slices/redmine/redmine-cache.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-cache.ts
@@ -1,9 +1,15 @@
-import type { RedmineConnectionStatus, RedmineListFilter } from '../../../../../shared/redmine-types'
+import type {
+  RedmineConnectionStatus,
+  RedmineListFilter
+} from '../../../../../shared/redmine-types'
 
 export const REDMINE_CACHE_TTL = 60_000 // 60s — same as Linear/GitHub revalidation TTL
 export const MAX_CACHE_ENTRIES = 500
 
-export function isFresh(entry: { fetchedAt: number } | undefined, ttl = REDMINE_CACHE_TTL): boolean {
+export function isFresh(
+  entry: { fetchedAt: number } | undefined,
+  ttl = REDMINE_CACHE_TTL
+): boolean {
   return entry !== undefined && Date.now() - entry.fetchedAt < ttl
 }
 

--- a/src/renderer/src/store/slices/redmine/redmine-cache.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-cache.ts
@@ -1,0 +1,39 @@
+import type { RedmineConnectionStatus, RedmineListFilter } from '../../../../../shared/redmine-types'
+
+export const REDMINE_CACHE_TTL = 60_000 // 60s — same as Linear/GitHub revalidation TTL
+export const MAX_CACHE_ENTRIES = 500
+
+export function isFresh(entry: { fetchedAt: number } | undefined, ttl = REDMINE_CACHE_TTL): boolean {
+  return entry !== undefined && Date.now() - entry.fetchedAt < ttl
+}
+
+export function redmineListCacheKey(filter: RedmineListFilter | undefined): string {
+  const state = filter?.state ?? 'open'
+  const scope = filter?.scope ?? 'assigned'
+  const limit = filter?.limit ?? 20
+  const page = filter?.page ?? 1
+  return `list::${state}::${scope}::${limit}::${page}`
+}
+
+export function redmineIssueCacheKey(issueId: number): string {
+  return `issue::${issueId}`
+}
+
+export function redmineStatusScopeSignature(status: RedmineConnectionStatus): string {
+  return JSON.stringify({
+    connected: status.connected,
+    activeSiteId: status.activeSite?.id ?? null,
+    selectedSiteId: status.selectedSiteId ?? null,
+    error: status.error ?? null
+  })
+}
+
+export const REDMINE_LIST_INVALIDATION_VERSION_CAP = 10_000
+export let redmineListInvalidationToken: { scope: string; version: number } = {
+  scope: '',
+  version: 0
+}
+
+export function setRedmineListInvalidationToken(next: { scope: string; version: number }): void {
+  redmineListInvalidationToken = next
+}

--- a/src/renderer/src/store/slices/redmine/redmine-slice-actions.test.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-slice-actions.test.ts
@@ -216,9 +216,9 @@ describe('getRedmineIssue', () => {
       customFields: [],
       url: 'https://rm.example.com/issues/1'
     }
-    redmineGetIssueMock.mockResolvedValue(issue)
+    redmineGetIssueMock.mockResolvedValue({ issue })
     const result = await actions.getRedmineIssue(1)
-    expect(result?.id).toBe(1)
+    expect(result.issue?.id).toBe(1)
     redmineGetIssueMock.mockClear()
     await actions.getRedmineIssue(1)
     expect(redmineGetIssueMock).not.toHaveBeenCalled()

--- a/src/renderer/src/store/slices/redmine/redmine-slice-actions.test.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-slice-actions.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  redmineConnect,
+  redmineDisconnect,
+  redmineGetIssue,
+  redmineListIssues,
+  redmineStatus,
+  redmineTestConnection
+} from '@/runtime/runtime-redmine-client'
+import { getProviderRuntimeContextKey } from '@/lib/provider-runtime-context'
+import { createRedmineActions } from './redmine-slice-actions'
+import type { AppState } from '../../types'
+
+vi.mock('@/runtime/runtime-redmine-client', () => ({
+  redmineConnect: vi.fn(),
+  redmineDisconnect: vi.fn(),
+  redmineGetIssue: vi.fn(),
+  redmineListIssues: vi.fn(),
+  redmineStatus: vi.fn(),
+  redmineTestConnection: vi.fn()
+}))
+
+vi.mock('@/lib/provider-runtime-context', () => ({
+  getProviderRuntimeContextKey: vi.fn(() => 'ctx:local')
+}))
+
+const redmineStatusMock = vi.mocked(redmineStatus)
+const redmineConnectMock = vi.mocked(redmineConnect)
+const redmineDisconnectMock = vi.mocked(redmineDisconnect)
+const redmineListIssuesMock = vi.mocked(redmineListIssues)
+const redmineGetIssueMock = vi.mocked(redmineGetIssue)
+const redmineTestConnectionMock = vi.mocked(redmineTestConnection)
+const getProviderRuntimeContextKeyMock = vi.mocked(getProviderRuntimeContextKey)
+
+function emptyStatus() {
+  return { connected: false, activeSite: null, selectedSiteId: null, viewer: null, error: null }
+}
+
+type Setter = (patch: unknown) => void
+
+let state!: AppState
+let actions!: ReturnType<typeof createRedmineActions>
+let set!: Setter
+
+function makeState(): AppState {
+  return {
+    settings: {},
+    redmineStatus: emptyStatus(),
+    redmineStatusChecked: false,
+    redmineStatusContextKey: null,
+    redmineIssueCache: {},
+    redmineListCache: {},
+    redmineListInvalidationToken: { scope: '', version: 0 }
+  } as unknown as AppState
+}
+
+function install() {
+  state = makeState()
+  const setter: Setter = (patch) => {
+    const next = typeof patch === 'function' ? patch(state) : patch
+    Object.assign(state, next)
+  }
+  const getter = () => state
+  actions = createRedmineActions(
+    setter as unknown as Parameters<typeof createRedmineActions>[0],
+    getter as unknown as Parameters<typeof createRedmineActions>[1]
+  )
+  Object.assign(state, actions)
+  set = setter
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getProviderRuntimeContextKeyMock.mockReturnValue('ctx:local')
+  install()
+})
+
+const site = { id: 'https://rm.example.com', siteUrl: 'https://rm.example.com', displayName: 'rm', hasToken: true }
+
+describe('checkRedmineConnection', () => {
+  it('probes once and records the checked flag', async () => {
+    redmineStatusMock.mockResolvedValue(emptyStatus())
+    await actions.checkRedmineConnection()
+    expect(redmineStatusMock).toHaveBeenCalledTimes(1)
+    expect(state.redmineStatusChecked).toBe(true)
+  })
+
+  it('skips the probe when already checked and force is not passed', async () => {
+    set({ redmineStatusChecked: true })
+    await actions.checkRedmineConnection()
+    expect(redmineStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('reprobes when force is passed', async () => {
+    redmineStatusMock.mockResolvedValue(emptyStatus())
+    await actions.checkRedmineConnection(true)
+    expect(redmineStatusMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears caches only when the status scope signature changes', async () => {
+    set({
+      redmineStatus: { ...emptyStatus(), connected: true, activeSite: site },
+      redmineListCache: { k: { data: { items: [], totalCount: 0 }, fetchedAt: Date.now() } }
+    })
+    redmineStatusMock.mockResolvedValue({ ...emptyStatus(), connected: false })
+    await actions.checkRedmineConnection()
+    expect(state.redmineListCache).toEqual({})
+  })
+})
+
+describe('connectRedmine', () => {
+  it('persists status and clears caches on success', async () => {
+    redmineConnectMock.mockResolvedValue({ ok: true, site, viewer: { id: 1, name: 'Ada', login: 'ada' } })
+    redmineStatusMock.mockResolvedValue({ ...emptyStatus(), connected: true, activeSite: site })
+    set({ redmineListCache: { k: { data: { items: [], totalCount: 0 }, fetchedAt: Date.now() } } })
+
+    const result = await actions.connectRedmine({ siteUrl: site.siteUrl, apiKey: 'secret' })
+
+    expect(result.ok).toBe(true)
+    expect(redmineConnectMock).toHaveBeenCalledWith(expect.anything(), {
+      siteUrl: site.siteUrl,
+      apiKey: 'secret'
+    })
+    expect(state.redmineStatus?.connected).toBe(true)
+    expect(state.redmineStatusChecked).toBe(true)
+    expect(state.redmineStatusContextKey).toBe('ctx:local')
+    expect(state.redmineListCache).toEqual({})
+  })
+
+  it('returns the failure without touching status', async () => {
+    redmineConnectMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'auth', message: 'bad key' }
+    })
+    const result = await actions.connectRedmine({ siteUrl: site.siteUrl, apiKey: 'nope' })
+    expect(result.ok).toBe(false)
+    expect(state.redmineStatus?.connected).toBe(false)
+    expect(state.redmineStatusChecked).toBe(false)
+  })
+})
+
+describe('disconnectRedmine', () => {
+  it('resets status and clears caches', async () => {
+    set({
+      redmineStatus: { ...emptyStatus(), connected: true, activeSite: site },
+      redmineListCache: { k: { data: { items: [], totalCount: 0 }, fetchedAt: Date.now() } }
+    })
+    redmineDisconnectMock.mockResolvedValue(undefined)
+    await actions.disconnectRedmine()
+    expect(redmineDisconnectMock).toHaveBeenCalledWith(expect.anything(), site.id)
+    expect(state.redmineStatus?.connected).toBe(false)
+    expect(state.redmineListCache).toEqual({})
+    expect(state.redmineStatusChecked).toBe(true)
+  })
+})
+
+describe('listRedmineIssues', () => {
+  it('fetches and caches when no fresh entry exists', async () => {
+    set({ redmineStatusChecked: true })
+    redmineListIssuesMock.mockResolvedValue({ items: [], totalCount: 0 })
+    const result = await actions.listRedmineIssues({ scope: 'assigned' })
+    expect(result).toEqual({ items: [], totalCount: 0 })
+    expect(redmineListIssuesMock).toHaveBeenCalledWith(expect.anything(), { scope: 'assigned' })
+    expect(Object.keys(state.redmineListCache).length).toBe(1)
+  })
+
+  it('reuses a fresh cache entry without refetching', async () => {
+    set({ redmineStatusChecked: true })
+    redmineListIssuesMock.mockResolvedValue({ items: [], totalCount: 0 })
+    await actions.listRedmineIssues({ scope: 'assigned' })
+    redmineListIssuesMock.mockClear()
+    const second = await actions.listRedmineIssues({ scope: 'assigned' })
+    expect(second).toEqual({ items: [], totalCount: 0 })
+    expect(redmineListIssuesMock).not.toHaveBeenCalled()
+  })
+
+  it('refetches when force is passed', async () => {
+    set({ redmineStatusChecked: true })
+    redmineListIssuesMock.mockResolvedValue({ items: [], totalCount: 0 })
+    await actions.listRedmineIssues({ scope: 'assigned' })
+    redmineListIssuesMock.mockClear()
+    await actions.listRedmineIssues({ scope: 'assigned' }, { force: true })
+    expect(redmineListIssuesMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('getRedmineIssue', () => {
+  it('fetches and caches an issue', async () => {
+    const issue = {
+      id: 1,
+      subject: 'Fix',
+      project: { id: 1, name: 'P' },
+      tracker: { id: 1, name: 'Bug' },
+      status: { id: 1, name: 'New' },
+      priority: { id: 1, name: 'Normal' },
+      author: { id: 1, name: 'Ada', login: 'ada' },
+      assignedTo: null,
+      description: null,
+      startDate: null,
+      dueDate: null,
+      doneRatio: 0,
+      estimatedHours: null,
+      spentHours: null,
+      createdOn: '2026-01-01T00:00:00Z',
+      updatedOn: '2026-01-01T00:00:00Z',
+      closedOn: null,
+      customFields: [],
+      url: 'https://rm.example.com/issues/1'
+    }
+    redmineGetIssueMock.mockResolvedValue(issue)
+    const result = await actions.getRedmineIssue(1)
+    expect(result?.id).toBe(1)
+    redmineGetIssueMock.mockClear()
+    await actions.getRedmineIssue(1)
+    expect(redmineGetIssueMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('testRedmineConnection / invalidateRedmineIssueLists', () => {
+  it('forwards a test call to the runtime client', async () => {
+    redmineTestConnectionMock.mockResolvedValue({
+      ok: true,
+      user: { id: 1, name: 'Ada', login: 'ada' }
+    })
+    const result = await actions.testRedmineConnection({ siteUrl: site.siteUrl, apiKey: 'k' })
+    expect(redmineTestConnection).toHaveBeenCalledWith(expect.anything(), {
+      siteUrl: site.siteUrl,
+      apiKey: 'k'
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  it('bumps the invalidation token and clears the list cache', () => {
+    set({ redmineListCache: { k: { data: { items: [], totalCount: 0 }, fetchedAt: Date.now() } } })
+    actions.invalidateRedmineIssueLists()
+    expect(state.redmineListInvalidationToken.version).toBe(1)
+    expect(state.redmineListInvalidationToken.scope).toBe('1')
+    expect(state.redmineListCache).toEqual({})
+  })
+})

--- a/src/renderer/src/store/slices/redmine/redmine-slice-actions.test.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-slice-actions.test.ts
@@ -75,7 +75,12 @@ beforeEach(() => {
   install()
 })
 
-const site = { id: 'https://rm.example.com', siteUrl: 'https://rm.example.com', displayName: 'rm', hasToken: true }
+const site = {
+  id: 'https://rm.example.com',
+  siteUrl: 'https://rm.example.com',
+  displayName: 'rm',
+  hasToken: true
+}
 
 describe('checkRedmineConnection', () => {
   it('probes once and records the checked flag', async () => {
@@ -110,7 +115,11 @@ describe('checkRedmineConnection', () => {
 
 describe('connectRedmine', () => {
   it('persists status and clears caches on success', async () => {
-    redmineConnectMock.mockResolvedValue({ ok: true, site, viewer: { id: 1, name: 'Ada', login: 'ada' } })
+    redmineConnectMock.mockResolvedValue({
+      ok: true,
+      site,
+      viewer: { id: 1, name: 'Ada', login: 'ada' }
+    })
     redmineStatusMock.mockResolvedValue({ ...emptyStatus(), connected: true, activeSite: site })
     set({ redmineListCache: { k: { data: { items: [], totalCount: 0 }, fetchedAt: Date.now() } } })
 

--- a/src/renderer/src/store/slices/redmine/redmine-slice-actions.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-slice-actions.ts
@@ -140,18 +140,18 @@ export function createRedmineActions(
       const key = redmineIssueCacheKey(issueId)
       const cached = get().redmineIssueCache[key]
       if (!options?.force && cached?.data && isFresh(cached)) {
-        return cached.data
+        return { issue: cached.data }
       }
-      const issue = await redmineGetIssue(get().settings, issueId)
-      if (issue && generation === requestGeneration) {
+      const result = await redmineGetIssue(get().settings, issueId)
+      if (result.issue && generation === requestGeneration) {
         set((state) => ({
           redmineIssueCache: {
             ...state.redmineIssueCache,
-            [key]: { data: issue, fetchedAt: Date.now() }
+            [key]: { data: result.issue, fetchedAt: Date.now() }
           }
         }))
       }
-      return issue
+      return result
     },
 
     invalidateRedmineIssueLists: () => {

--- a/src/renderer/src/store/slices/redmine/redmine-slice-actions.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-slice-actions.ts
@@ -1,0 +1,163 @@
+import {
+  redmineConnect,
+  redmineDisconnect,
+  redmineGetIssue,
+  redmineListIssues,
+  redmineStatus,
+  redmineTestConnection
+} from '@/runtime/runtime-redmine-client'
+import { getProviderRuntimeContextKey } from '@/lib/provider-runtime-context'
+import {
+  isFresh,
+  redmineIssueCacheKey,
+  redmineListCacheKey,
+  redmineListInvalidationToken,
+  redmineStatusScopeSignature,
+  setRedmineListInvalidationToken
+} from './redmine-cache'
+import type {
+  RedmineFetchResult,
+  RedmineSlice,
+  RedmineSliceGet,
+  RedmineSliceSet
+} from './redmine-slice-contract'
+
+// Why: a module counter lets a superseded connect/status probe avoid clobbering
+// the fresh result of a newer request. Mirrors the Linear slice's generation
+// guard without the per-slice request-state machinery.
+let requestGeneration = 0
+function beginRequest(): number {
+  requestGeneration += 1
+  return requestGeneration
+}
+
+function emptyStatus() {
+  return { connected: false, activeSite: null, selectedSiteId: null, viewer: null, error: null }
+}
+
+export function createRedmineActions(
+  set: RedmineSliceSet,
+  get: RedmineSliceGet
+): Pick<
+  RedmineSlice,
+  | 'checkRedmineConnection'
+  | 'connectRedmine'
+  | 'testRedmineConnection'
+  | 'disconnectRedmine'
+  | 'listRedmineIssues'
+  | 'getRedmineIssue'
+  | 'invalidateRedmineIssueLists'
+> {
+  return {
+    checkRedmineConnection: async (force) => {
+      if (!force && get().redmineStatusChecked) {
+        return
+      }
+      const generation = beginRequest()
+      const status = await redmineStatus(get().settings)
+      if (generation !== requestGeneration) {
+        return
+      }
+      const prev = get().redmineStatus
+      if (redmineStatusScopeSignature(prev) !== redmineStatusScopeSignature(status)) {
+        set({
+          redmineStatus: status,
+          redmineIssueCache: {},
+          redmineListCache: {},
+          redmineStatusChecked: true,
+          redmineStatusContextKey: getProviderRuntimeContextKey(get().settings)
+        })
+      } else {
+        set({ redmineStatusChecked: true })
+      }
+    },
+
+    connectRedmine: async ({ siteUrl, apiKey }) => {
+      const generation = beginRequest()
+      const contextKey = getProviderRuntimeContextKey(get().settings)
+      const result = await redmineConnect(get().settings, { siteUrl, apiKey })
+      if (result.ok && generation === requestGeneration) {
+        const status = await redmineStatus(get().settings)
+        if (generation === requestGeneration) {
+          set({
+            redmineStatus: status,
+            redmineStatusChecked: true,
+            redmineStatusContextKey: getProviderRuntimeContextKey(get().settings),
+            redmineIssueCache: {},
+            redmineListCache: {}
+          })
+        }
+      }
+      if (result.ok && getProviderRuntimeContextKey(get().settings) !== contextKey) {
+        return { ok: false as const, error: { type: 'unknown', message: 'Connection superseded by a newer request.' } }
+      }
+      return result as RedmineFetchResult
+    },
+
+    testRedmineConnection: async ({ siteUrl, apiKey }) => {
+      return redmineTestConnection(get().settings, { siteUrl, apiKey })
+    },
+
+    disconnectRedmine: async () => {
+      const generation = beginRequest()
+      await redmineDisconnect(get().settings, get().redmineStatus.activeSite?.id)
+      if (generation !== requestGeneration) {
+        return
+      }
+      set({
+        redmineStatus: emptyStatus(),
+        redmineStatusChecked: true,
+        redmineIssueCache: {},
+        redmineListCache: {}
+      })
+    },
+
+    listRedmineIssues: async (filter, options) => {
+      const generation = beginRequest()
+      const key = `${redmineListInvalidationToken.scope}:${redmineListCacheKey(filter)}`
+      const cached = get().redmineListCache[key]
+      if (!options?.force && cached?.data && isFresh(cached)) {
+        return cached.data
+      }
+      const result = await redmineListIssues(get().settings, filter)
+      await get().checkRedmineConnection()
+      if (generation === requestGeneration) {
+        set((state) => ({
+          redmineListCache: {
+            ...state.redmineListCache,
+            [key]: { data: result, fetchedAt: Date.now() }
+          }
+        }))
+      }
+      return result
+    },
+
+    getRedmineIssue: async (issueId, options) => {
+      const generation = beginRequest()
+      const key = redmineIssueCacheKey(issueId)
+      const cached = get().redmineIssueCache[key]
+      if (!options?.force && cached?.data && isFresh(cached)) {
+        return cached.data
+      }
+      const issue = await redmineGetIssue(get().settings, issueId)
+      if (issue && generation === requestGeneration) {
+        set((state) => ({
+          redmineIssueCache: {
+            ...state.redmineIssueCache,
+            [key]: { data: issue, fetchedAt: Date.now() }
+          }
+        }))
+      }
+      return issue
+    },
+
+    invalidateRedmineIssueLists: () => {
+      const version = (redmineListInvalidationToken.version + 1) % 10_000
+      setRedmineListInvalidationToken({ scope: String(version), version })
+      set({
+        redmineListInvalidationToken: { scope: String(version), version },
+        redmineListCache: {}
+      })
+    }
+  }
+}

--- a/src/renderer/src/store/slices/redmine/redmine-slice-actions.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-slice-actions.ts
@@ -89,7 +89,10 @@ export function createRedmineActions(
         }
       }
       if (result.ok && getProviderRuntimeContextKey(get().settings) !== contextKey) {
-        return { ok: false as const, error: { type: 'unknown', message: 'Connection superseded by a newer request.' } }
+        return {
+          ok: false as const,
+          error: { type: 'unknown', message: 'Connection superseded by a newer request.' }
+        }
       }
       return result as RedmineFetchResult
     },

--- a/src/renderer/src/store/slices/redmine/redmine-slice-contract.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-slice-contract.ts
@@ -1,0 +1,44 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../../types'
+import type {
+  RedmineConnectionStatus,
+  RedmineIssue,
+  RedmineIssueCollectionResult,
+  RedmineListFilter,
+  RedmineSite,
+  RedmineUser
+} from '../../../../../shared/redmine-types'
+import type { CacheEntry } from '../../github/cache-model'
+
+export type RedmineFetchOptions = { force?: boolean }
+
+export type RedmineFetchResult =
+  | { ok: true; site: RedmineSite; viewer: RedmineUser }
+  | { ok: false; error: { type: string; message: string } }
+
+export type RedmineSlice = {
+  redmineStatus: RedmineConnectionStatus
+  redmineStatusChecked: boolean
+  redmineStatusContextKey: string | null
+  redmineIssueCache: Record<string, CacheEntry<RedmineIssue>>
+  redmineListCache: Record<string, CacheEntry<RedmineIssueCollectionResult>>
+  redmineListInvalidationToken: { scope: string; version: number }
+
+  checkRedmineConnection: (force?: boolean) => Promise<void>
+  connectRedmine: (args: { siteUrl: string; apiKey: string }) => Promise<RedmineFetchResult>
+  testRedmineConnection: (args: {
+    siteUrl: string
+    apiKey: string
+  }) => Promise<{ ok: true; user: RedmineUser } | { ok: false; error: { type: string; message: string } }>
+  disconnectRedmine: () => Promise<void>
+  listRedmineIssues: (
+    filter?: RedmineListFilter,
+    options?: RedmineFetchOptions
+  ) => Promise<RedmineIssueCollectionResult>
+  getRedmineIssue: (issueId: number, options?: RedmineFetchOptions) => Promise<RedmineIssue | null>
+  invalidateRedmineIssueLists: () => void
+}
+
+export type RedmineSliceStateCreator = StateCreator<AppState, [], [], RedmineSlice>
+export type RedmineSliceSet = Parameters<RedmineSliceStateCreator>[0]
+export type RedmineSliceGet = Parameters<RedmineSliceStateCreator>[1]

--- a/src/renderer/src/store/slices/redmine/redmine-slice-contract.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-slice-contract.ts
@@ -29,7 +29,9 @@ export type RedmineSlice = {
   testRedmineConnection: (args: {
     siteUrl: string
     apiKey: string
-  }) => Promise<{ ok: true; user: RedmineUser } | { ok: false; error: { type: string; message: string } }>
+  }) => Promise<
+    { ok: true; user: RedmineUser } | { ok: false; error: { type: string; message: string } }
+  >
   disconnectRedmine: () => Promise<void>
   listRedmineIssues: (
     filter?: RedmineListFilter,

--- a/src/renderer/src/store/slices/redmine/redmine-slice-contract.ts
+++ b/src/renderer/src/store/slices/redmine/redmine-slice-contract.ts
@@ -5,6 +5,7 @@ import type {
   RedmineIssue,
   RedmineIssueCollectionResult,
   RedmineListFilter,
+  RedmineReadError,
   RedmineSite,
   RedmineUser
 } from '../../../../../shared/redmine-types'
@@ -37,7 +38,10 @@ export type RedmineSlice = {
     filter?: RedmineListFilter,
     options?: RedmineFetchOptions
   ) => Promise<RedmineIssueCollectionResult>
-  getRedmineIssue: (issueId: number, options?: RedmineFetchOptions) => Promise<RedmineIssue | null>
+  getRedmineIssue: (
+    issueId: number,
+    options?: RedmineFetchOptions
+  ) => Promise<{ issue: RedmineIssue | null; error?: RedmineReadError }>
   invalidateRedmineIssueLists: () => void
 }
 

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -17,6 +17,7 @@ import { createHostedReviewSlice } from './hosted-review'
 import { createLinearSlice } from './linear'
 import { createPreflightSlice } from './preflight'
 import { createJiraSlice } from './jira'
+import { createRedmineSlice } from './redmine'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
 import { createMemorySlice } from './memory'
@@ -74,6 +75,7 @@ export function createTestStore() {
     ...createLinearSlice(...a),
     ...createPreflightSlice(...a),
     ...createJiraSlice(...a),
+    ...createRedmineSlice(...a),
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
     ...createMemorySlice(...a),

--- a/src/renderer/src/store/slices/ui/ui-slice-task-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-task-actions.ts
@@ -113,7 +113,8 @@ export function createUiTaskActions(set: UISliceSet, get: UISliceGet): Partial<U
         preferredVisibleTaskProviders,
         {
           gitlabInstalled: state.preflightStatus?.glab?.installed === true,
-          linearConnected: state.linearStatus?.connected === true
+          linearConnected: state.linearStatus?.connected === true,
+          redmineConnected: state.redmineStatus?.connected === true
         },
         state.settings?.defaultTaskSource
       )

--- a/src/renderer/src/store/slices/ui/ui-slice-task-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-task-actions.ts
@@ -113,8 +113,7 @@ export function createUiTaskActions(set: UISliceSet, get: UISliceGet): Partial<U
         preferredVisibleTaskProviders,
         {
           gitlabInstalled: state.preflightStatus?.glab?.installed === true,
-          linearConnected: state.linearStatus?.connected === true,
-          redmineConnected: state.redmineStatus?.connected === true
+          linearConnected: state.linearStatus?.connected === true
         },
         state.settings?.defaultTaskSource
       )

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -11,6 +11,7 @@ import type { HostedReviewSlice } from './slices/hosted-review'
 import type { LinearSlice } from './slices/linear'
 import type { PreflightSlice } from './slices/preflight'
 import type { JiraSlice } from './slices/jira'
+import type { RedmineSlice } from './slices/redmine'
 import type { EditorSlice } from './slices/editor'
 import type { StatsSlice } from './slices/stats'
 import type { MemorySlice } from './slices/memory'
@@ -57,6 +58,7 @@ export type AppState = RepoSlice &
   LinearSlice &
   PreflightSlice &
   JiraSlice &
+  RedmineSlice &
   EditorSlice &
   StatsSlice &
   MemorySlice &

--- a/src/shared/integration-credential-errors.ts
+++ b/src/shared/integration-credential-errors.ts
@@ -1,4 +1,4 @@
-export type IntegrationCredentialService = 'Linear' | 'Jira' | 'Bitbucket'
+export type IntegrationCredentialService = 'Linear' | 'Jira' | 'Bitbucket' | 'Redmine'
 
 export function credentialDecryptionMessage(service: IntegrationCredentialService): string {
   return `Could not decrypt saved ${service} credential. Approve Keychain access or reconnect ${service}.`
@@ -11,6 +11,7 @@ export function isIntegrationCredentialDecryptionError(error: unknown): boolean 
   return (
     message.includes(credentialDecryptionMessage('Linear')) ||
     message.includes(credentialDecryptionMessage('Jira')) ||
-    message.includes(credentialDecryptionMessage('Bitbucket'))
+    message.includes(credentialDecryptionMessage('Bitbucket')) ||
+    message.includes(credentialDecryptionMessage('Redmine'))
   )
 }

--- a/src/shared/redmine-types.ts
+++ b/src/shared/redmine-types.ts
@@ -1,0 +1,118 @@
+// Shared Redmine provider types.
+//
+// Redmine is a self-hosted issue tracker with no git remote, so it plugs into
+// Orca as an account-level TaskProvider (like Jira), not a per-repo source.
+// Everything the renderer needs to render the issue list + detail crosses IPC/
+// RPC, so these types must stay serialization-friendly (plain objects only).
+
+export type RedmineSite = {
+  id: string
+  siteUrl: string
+  displayName: string
+  /** True when an encrypted API key exists on disk for this site. */
+  hasToken: boolean
+}
+
+export type RedmineSiteId = string
+
+export type RedmineSiteSelection = RedmineSiteId | 'all'
+
+export type RedmineUser = {
+  id: number
+  name: string
+  login: string | null
+  avatarUrl?: string | null
+}
+
+export type RedmineProject = {
+  id: number
+  /** Only present in project-list payloads; issue payloads carry just id+name. */
+  identifier?: string
+  name: string
+}
+
+export type RedmineTracker = {
+  id: number
+  name: string
+}
+
+export type RedmineIssueStatus = {
+  id: number
+  name: string
+  isClosed?: boolean
+}
+
+export type RedminePriority = {
+  id: number
+  name: string
+}
+
+export type RedmineCustomField = {
+  id: number
+  name: string
+  value: string | number | object | null
+}
+
+export type RedmineIssue = {
+  id: number
+  subject: string
+  project: RedmineProject
+  tracker: RedmineTracker
+  status: RedmineIssueStatus
+  priority: RedminePriority
+  author: RedmineUser
+  assignedTo: RedmineUser | null
+  description: string | null
+  startDate: string | null
+  dueDate: string | null
+  doneRatio: number
+  estimatedHours: number | null
+  spentHours: number | null
+  createdOn: string
+  updatedOn: string
+  closedOn: string | null
+  customFields: RedmineCustomField[]
+  url: string
+}
+
+export type RedmineConnectionErrorType = 'auth' | 'decryption' | 'network' | 'unknown'
+
+export type RedmineConnectionError = {
+  type: RedmineConnectionErrorType
+  message: string
+}
+
+export type RedmineConnectionStatus = {
+  connected: boolean
+  activeSite: RedmineSite | null
+  selectedSiteId: RedmineSiteSelection | null
+  viewer: RedmineUser | null
+  error: RedmineConnectionError | null
+}
+
+export type RedmineReadErrorType = 'auth' | 'network' | 'not_found' | 'unknown'
+
+export type RedmineReadError = {
+  type: RedmineReadErrorType
+  message: string
+  status?: number | null
+}
+
+export type RedmineIssueCollectionResult = {
+  items: RedmineIssue[]
+  totalCount: number
+  error?: RedmineReadError
+}
+
+/** Mirrors Redmine's `status_id=open` / `closed` / `all` query states. */
+export type RedmineIssueListState = 'open' | 'closed' | 'all'
+
+/** Which issues to list: mine vs created-by-me vs every issue on the server. */
+export type RedmineIssueListScope = 'assigned' | 'created' | 'all'
+
+export type RedmineListFilter = {
+  state?: RedmineIssueListState
+  scope?: RedmineIssueListScope
+  limit?: number
+  page?: number
+}

--- a/src/shared/task-provider-identity.ts
+++ b/src/shared/task-provider-identity.ts
@@ -29,11 +29,19 @@ export type JiraTaskProviderIdentity = {
   projectKey?: string | null
 }
 
+export type RedmineTaskProviderIdentity = {
+  provider: 'redmine'
+  siteId?: string | null
+  siteUrl?: string | null
+  projectId?: string | null
+}
+
 export type TaskProviderIdentity =
   | GitHubTaskProviderIdentity
   | GitLabTaskProviderIdentity
   | LinearTaskProviderIdentity
   | JiraTaskProviderIdentity
+  | RedmineTaskProviderIdentity
 
 export function normalizeTaskProviderIdentity(
   provider: TaskProvider,
@@ -79,6 +87,13 @@ export function normalizeTaskProviderIdentity(
         siteUrl: normalizeNonEmptyString(raw.siteUrl),
         projectKey: normalizeNonEmptyString(raw.projectKey)
       }
+    case 'redmine':
+      return {
+        provider,
+        siteId: normalizeNonEmptyString(raw.siteId),
+        siteUrl: normalizeNonEmptyString(raw.siteUrl),
+        projectId: normalizeNonEmptyString(raw.projectId)
+      }
   }
 }
 
@@ -112,6 +127,8 @@ export function isStoredTaskProviderIdentity(provider: TaskProvider, identity: u
       )
     case 'jira':
       return ['siteId', 'siteUrl', 'projectKey'].every((key) => isNullableOptionalString(raw[key]))
+    case 'redmine':
+      return ['siteId', 'siteUrl', 'projectId'].every((key) => isNullableOptionalString(raw[key]))
   }
 }
 
@@ -119,7 +136,8 @@ const TASK_PROVIDER_IDENTITY_FIELDS: Record<TaskProvider, readonly string[]> = {
   github: ['owner', 'repo', 'host'],
   gitlab: ['projectId', 'namespace', 'project', 'webUrl'],
   linear: ['workspaceId', 'workspaceName', 'teamId', 'teamKey'],
-  jira: ['siteId', 'siteUrl', 'projectKey']
+  jira: ['siteId', 'siteUrl', 'projectKey'],
+  redmine: ['siteId', 'siteUrl', 'projectId']
 }
 
 export function areTaskProviderIdentitiesEqual(
@@ -157,6 +175,8 @@ export function taskProviderIdentityCachePart(
       return [identity.workspaceId, identity.teamId ?? identity.teamKey].filter(Boolean).join('/')
     case 'jira':
       return [identity.siteId ?? identity.siteUrl, identity.projectKey].filter(Boolean).join('/')
+    case 'redmine':
+      return [identity.siteId ?? identity.siteUrl, identity.projectId].filter(Boolean).join('/')
   }
 }
 

--- a/src/shared/task-providers.test.ts
+++ b/src/shared/task-providers.test.ts
@@ -57,8 +57,7 @@ describe('task providers', () => {
     expect(
       filterAvailableTaskProviders(['github', 'gitlab', 'linear'], {
         gitlabInstalled: false,
-        linearConnected: true,
-        redmineConnected: false
+        linearConnected: true
       })
     ).toEqual(['github', 'linear'])
   })
@@ -69,8 +68,7 @@ describe('task providers', () => {
         ['linear'],
         {
           gitlabInstalled: false,
-          linearConnected: true,
-          redmineConnected: false
+          linearConnected: true
         },
         'github'
       )
@@ -83,8 +81,7 @@ describe('task providers', () => {
         ['linear'],
         {
           gitlabInstalled: false,
-          linearConnected: true,
-          redmineConnected: false
+          linearConnected: true
         },
         'linear'
       )
@@ -97,8 +94,7 @@ describe('task providers', () => {
         ['linear'],
         {
           gitlabInstalled: false,
-          linearConnected: true,
-          redmineConnected: false
+          linearConnected: true
         },
         'gitlab'
       )
@@ -111,8 +107,7 @@ describe('task providers', () => {
         ['gitlab'],
         {
           gitlabInstalled: false,
-          linearConnected: true,
-          redmineConnected: false
+          linearConnected: true
         },
         'bitbucket'
       )
@@ -123,8 +118,7 @@ describe('task providers', () => {
     expect(
       filterAvailableTaskProviders(['gitlab', 'linear'], {
         gitlabInstalled: false,
-        linearConnected: false,
-        redmineConnected: false
+        linearConnected: false
       })
     ).toEqual(['github'])
   })

--- a/src/shared/task-providers.test.ts
+++ b/src/shared/task-providers.test.ts
@@ -16,7 +16,13 @@ describe('task providers', () => {
   })
 
   it('falls back to all providers when none are visible', () => {
-    expect(normalizeVisibleTaskProviders([])).toEqual(['github', 'gitlab', 'linear', 'jira'])
+    expect(normalizeVisibleTaskProviders([])).toEqual([
+      'github',
+      'gitlab',
+      'linear',
+      'jira',
+      'redmine'
+    ])
   })
 
   it('restores a valid saved default when provider settings drifted', () => {
@@ -51,7 +57,8 @@ describe('task providers', () => {
     expect(
       filterAvailableTaskProviders(['github', 'gitlab', 'linear'], {
         gitlabInstalled: false,
-        linearConnected: true
+        linearConnected: true,
+        redmineConnected: false
       })
     ).toEqual(['github', 'linear'])
   })
@@ -62,8 +69,9 @@ describe('task providers', () => {
         ['linear'],
         {
           gitlabInstalled: false,
-          linearConnected: true
-        },
+          linearConnected: true,
+          redmineConnected: false
+          },
         'github'
       )
     ).toEqual(['github', 'linear'])
@@ -75,8 +83,9 @@ describe('task providers', () => {
         ['linear'],
         {
           gitlabInstalled: false,
-          linearConnected: true
-        },
+          linearConnected: true,
+          redmineConnected: false
+          },
         'linear'
       )
     ).toEqual(['linear'])
@@ -88,8 +97,9 @@ describe('task providers', () => {
         ['linear'],
         {
           gitlabInstalled: false,
-          linearConnected: true
-        },
+          linearConnected: true,
+          redmineConnected: false
+          },
         'gitlab'
       )
     ).toEqual(['linear'])
@@ -101,8 +111,9 @@ describe('task providers', () => {
         ['gitlab'],
         {
           gitlabInstalled: false,
-          linearConnected: true
-        },
+          linearConnected: true,
+          redmineConnected: false
+          },
         'bitbucket'
       )
     ).toEqual(['github'])
@@ -112,7 +123,8 @@ describe('task providers', () => {
     expect(
       filterAvailableTaskProviders(['gitlab', 'linear'], {
         gitlabInstalled: false,
-        linearConnected: false
+        linearConnected: false,
+        redmineConnected: false
       })
     ).toEqual(['github'])
   })

--- a/src/shared/task-providers.test.ts
+++ b/src/shared/task-providers.test.ts
@@ -71,7 +71,7 @@ describe('task providers', () => {
           gitlabInstalled: false,
           linearConnected: true,
           redmineConnected: false
-          },
+        },
         'github'
       )
     ).toEqual(['github', 'linear'])
@@ -85,7 +85,7 @@ describe('task providers', () => {
           gitlabInstalled: false,
           linearConnected: true,
           redmineConnected: false
-          },
+        },
         'linear'
       )
     ).toEqual(['linear'])
@@ -99,7 +99,7 @@ describe('task providers', () => {
           gitlabInstalled: false,
           linearConnected: true,
           redmineConnected: false
-          },
+        },
         'gitlab'
       )
     ).toEqual(['linear'])
@@ -113,7 +113,7 @@ describe('task providers', () => {
           gitlabInstalled: false,
           linearConnected: true,
           redmineConnected: false
-          },
+        },
         'bitbucket'
       )
     ).toEqual(['github'])

--- a/src/shared/task-providers.ts
+++ b/src/shared/task-providers.ts
@@ -1,6 +1,12 @@
 export type TaskProvider = 'github' | 'gitlab' | 'linear' | 'jira' | 'redmine'
 
-export const TASK_PROVIDERS: readonly TaskProvider[] = ['github', 'gitlab', 'linear', 'jira', 'redmine']
+export const TASK_PROVIDERS: readonly TaskProvider[] = [
+  'github',
+  'gitlab',
+  'linear',
+  'jira',
+  'redmine'
+]
 
 const TASK_PROVIDER_SET = new Set<TaskProvider>(TASK_PROVIDERS)
 

--- a/src/shared/task-providers.ts
+++ b/src/shared/task-providers.ts
@@ -61,7 +61,6 @@ export function normalizeVisibleTaskProviders(value: unknown): TaskProvider[] {
 export type TaskProviderAvailability = {
   gitlabInstalled: boolean
   linearConnected: boolean
-  redmineConnected: boolean
 }
 
 export function filterAvailableTaskProviders(

--- a/src/shared/task-providers.ts
+++ b/src/shared/task-providers.ts
@@ -1,6 +1,6 @@
-export type TaskProvider = 'github' | 'gitlab' | 'linear' | 'jira'
+export type TaskProvider = 'github' | 'gitlab' | 'linear' | 'jira' | 'redmine'
 
-export const TASK_PROVIDERS: readonly TaskProvider[] = ['github', 'gitlab', 'linear', 'jira']
+export const TASK_PROVIDERS: readonly TaskProvider[] = ['github', 'gitlab', 'linear', 'jira', 'redmine']
 
 const TASK_PROVIDER_SET = new Set<TaskProvider>(TASK_PROVIDERS)
 
@@ -55,6 +55,7 @@ export function normalizeVisibleTaskProviders(value: unknown): TaskProvider[] {
 export type TaskProviderAvailability = {
   gitlabInstalled: boolean
   linearConnected: boolean
+  redmineConnected: boolean
 }
 
 export function filterAvailableTaskProviders(
@@ -103,6 +104,11 @@ function isTaskProviderAvailable(
   // Why: Jira can be connected from the Tasks surface itself, so hiding it
   // when disconnected would remove the entry point for first-time setup.
   if (provider === 'jira') {
+    return true
+  }
+  // Why: same first-time-setup reasoning as Jira — a disconnected Redmine must
+  // stay reachable from the Tasks surface so a new site can be connected.
+  if (provider === 'redmine') {
     return true
   }
   return availability.linearConnected

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -47,7 +47,7 @@ export type WorkspaceIntentWorkItem = {
   type: 'issue' | 'pr' | 'mr'
   number: number
   title: string
-  provider?: 'github' | 'gitlab' | 'linear' | 'jira'
+  provider?: 'github' | 'gitlab' | 'linear' | 'jira' | 'redmine'
   linearIdentifier?: string
   jiraIdentifier?: string
 }


### PR DESCRIPTION
Adds **Redmine** as the 5th `TaskProvider` (global taskSource), read-only: connect + test + list my issues + detail (with custom fields).

- Backend: site-credential store (encrypted API key via OS keychain), REST client over `getMainHttpClient`, mappers, IPC handlers
- Renderer: runtime dispatch client, store slice with TTL cache, TaskPage Tasks surface (connect form -> assigned issues list -> detail)
- Settings: provider row in Tasks Sources pane; Redmine brand icon (flattened official mark)
- Remote RPC: host-side `redmine.*` methods registered for paired remote runtimes
- Tests: 45 unit tests across mappers, client, IPC, runtime client, slice actions, host RPC methods, component static render, site-store; en.json keys

Notes for reviewers: universe i18n currently en-only; happy-dom/RTL component tests fail in this sandbox (`No such built-in module: node:`) so the component test uses `renderToStaticMarkup`.