### PR TITLE
fix(agent-hooks): install remote Codex hooks where Codex actually reads them

### DIFF
--- a/src/main/agent-hooks/codex-app-server-home-probe.test.ts
+++ b/src/main/agent-hooks/codex-app-server-home-probe.test.ts
@@ -1,8 +1,11 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { probeCodexHomeViaAppServer } from './codex-app-server-home-probe'
+import {
+  buildCodexProbeEnvironment,
+  probeCodexHomeViaAppServer
+} from './codex-app-server-home-probe'
 
 // The probe speaks to a real child over pipes; `/bin/sh` is the shell it uses
 // on every host that reaches this code (Windows remotes never install hooks).
@@ -120,5 +123,48 @@ sleep 30
 
     await expect(pending).resolves.toBeNull()
     expect(Date.now() - startedAt).toBeLessThan(5_000)
+  })
+})
+
+describe('buildCodexProbeEnvironment', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('drops the CODEX_HOME Orca injected for its own managed accounts', () => {
+    // Orca exports these for its managed Codex accounts. Reading one back would
+    // report Orca's own answer as if it were the host user's configuration.
+    vi.stubEnv('CODEX_HOME', '/orca/codex-accounts/abc/home')
+    vi.stubEnv('ORCA_CODEX_HOME', '/orca/codex-accounts/abc/home')
+
+    const env = buildCodexProbeEnvironment('/home/dev')
+
+    expect(env.CODEX_HOME).toBeUndefined()
+    expect(env.ORCA_CODEX_HOME).toBeUndefined()
+  })
+
+  it('pins HOME to the home the installer resolved', () => {
+    expect(buildCodexProbeEnvironment('/home/dev').HOME).toBe('/home/dev')
+  })
+
+  onPosix('asks Codex under the installer s home, not Orca s injected one', async () => {
+    vi.stubEnv('CODEX_HOME', '/orca/codex-accounts/abc/home')
+    const fake = await withFakeCodex(
+      `#!/bin/sh
+read -r _line
+home="\${CODEX_HOME:-$HOME/.codex}"
+printf '{"id":1,"result":{"codexHome":"%s"}}\\n' "$home"
+sleep 5
+`
+    )
+
+    await expect(
+      probeCodexHomeViaAppServer({
+        loginShell: '/bin/sh',
+        loginShellFlag: '-c',
+        env: { ...buildCodexProbeEnvironment('/home/dev'), PATH: fake.PATH },
+        timeoutMs: 10_000
+      })
+    ).resolves.toBe('/home/dev/.codex')
   })
 })

--- a/src/main/agent-hooks/codex-app-server-home-probe.test.ts
+++ b/src/main/agent-hooks/codex-app-server-home-probe.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { probeCodexHomeViaAppServer } from './codex-app-server-home-probe'
+
+// The probe speaks to a real child over pipes; `/bin/sh` is the shell it uses
+// on every host that reaches this code (Windows remotes never install hooks).
+const onPosix = process.platform === 'win32' ? it.skip : it
+
+const temporaryRoots: string[] = []
+
+async function withFakeCodex(script: string): Promise<NodeJS.ProcessEnv> {
+  const binDir = await mkdtemp(join(tmpdir(), 'orca-codex-probe-'))
+  temporaryRoots.push(binDir)
+  const codexPath = join(binDir, 'codex')
+  await writeFile(codexPath, script, 'utf8')
+  await chmod(codexPath, 0o755)
+  return { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` }
+}
+
+function probe(env: NodeJS.ProcessEnv, timeoutMs = 10_000): Promise<string | null> {
+  return probeCodexHomeViaAppServer({
+    loginShell: '/bin/sh',
+    loginShellFlag: '-c',
+    env,
+    timeoutMs
+  })
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))
+  )
+})
+
+describe('probeCodexHomeViaAppServer', () => {
+  onPosix('reads the codexHome the app-server reports', async () => {
+    const env = await withFakeCodex(
+      `#!/bin/sh
+read -r _line
+printf '%s\\n' '{"id":1,"result":{"codexHome":"/home/dev/.codex-openai","platformFamily":"unix"}}'
+# Hold the pipe open the way a real app-server does.
+sleep 5
+`
+    )
+
+    await expect(probe(env)).resolves.toBe('/home/dev/.codex-openai')
+  })
+
+  onPosix('ignores a login-shell banner printed ahead of the reply', async () => {
+    const env = await withFakeCodex(
+      `#!/bin/sh
+echo 'Welcome to Ubuntu 24.04 LTS'
+echo 'Last login: Tue'
+read -r _line
+printf '%s\\n' '{"id":1,"result":{"codexHome":"/home/dev/.codex-openai"}}'
+sleep 5
+`
+    )
+
+    await expect(probe(env)).resolves.toBe('/home/dev/.codex-openai')
+  })
+
+  onPosix('skips notifications that arrive before the initialize result', async () => {
+    const env = await withFakeCodex(
+      `#!/bin/sh
+read -r _line
+printf '%s\\n' '{"method":"remoteControl/status/changed","params":{"status":"disabled"}}'
+printf '%s\\n' '{"id":1,"result":{"codexHome":"/opt/codex-home"}}'
+sleep 5
+`
+    )
+
+    await expect(probe(env)).resolves.toBe('/opt/codex-home')
+  })
+
+  onPosix('answers null when the CLI exits without a reply', async () => {
+    const env = await withFakeCodex(
+      `#!/bin/sh
+echo 'Error: CODEX_HOME points to a path that does not exist' >&2
+exit 1
+`
+    )
+
+    await expect(probe(env)).resolves.toBeNull()
+  })
+
+  onPosix('answers null when the CLI never replies, without hanging', async () => {
+    const env = await withFakeCodex(
+      `#!/bin/sh
+sleep 30
+`
+    )
+
+    await expect(probe(env, 400)).resolves.toBeNull()
+  })
+
+  onPosix('answers null when codex is not on PATH at all', async () => {
+    await expect(probe({ ...process.env, PATH: '/nonexistent-orca-probe-dir' })).resolves.toBeNull()
+  })
+
+  onPosix('answers null once the install is aborted', async () => {
+    const env = await withFakeCodex(
+      `#!/bin/sh
+sleep 30
+`
+    )
+    const controller = new AbortController()
+    const startedAt = Date.now()
+    // A deadline far past this assertion, so only the abort can settle the probe.
+    const pending = probeCodexHomeViaAppServer({
+      loginShell: '/bin/sh',
+      loginShellFlag: '-c',
+      env,
+      signal: controller.signal,
+      timeoutMs: 60_000
+    })
+    controller.abort()
+
+    await expect(pending).resolves.toBeNull()
+    expect(Date.now() - startedAt).toBeLessThan(5_000)
+  })
+})

--- a/src/main/agent-hooks/codex-app-server-home-probe.ts
+++ b/src/main/agent-hooks/codex-app-server-home-probe.ts
@@ -1,0 +1,143 @@
+/**
+ * Ask the host's own `codex` where its `CODEX_HOME` is.
+ *
+ * A launcher wrapper earlier on `PATH` can `export CODEX_HOME=...` and `exec`
+ * the real binary, so the value exists only inside the Codex process: the
+ * parent PTY's login shell reports nothing, and Orca installed its managed
+ * hooks into `~/.codex` while Codex read `~/.codex-openai` (#19598). The
+ * app-server `initialize` handshake is the wrapper-aware answer, because it
+ * comes from the same process the wrapper configured.
+ *
+ * The probe therefore runs through a login shell — that is what resolves the
+ * wrapper in the first place — and reads stdout a line at a time, so a profile
+ * banner printed ahead of the JSON cannot corrupt the reply.
+ */
+
+import { spawnProcess } from '../../shared/child-process/run-process'
+import { CODEX_READ_ONLY_APP_SERVER_ARGS } from '../codex-cli/codex-read-only-app-server-args'
+
+const PROBE_TIMEOUT_MS = 12_000
+const MAX_STDOUT_BYTES = 64 * 1024
+const INITIALIZE_ID = 1
+
+/**
+ * `codex app-server` exits without answering when stdin reaches EOF, so the
+ * request is written and the pipe is left open until the reply lands.
+ */
+function initializeRequest(): string {
+  return `${JSON.stringify({
+    id: INITIALIZE_ID,
+    method: 'initialize',
+    params: { clientInfo: { name: 'orca', title: 'Orca', version: '1.0.0' } }
+  })}\n`
+}
+
+function readCodexHomeFromLine(line: string): string | null {
+  if (!line.startsWith('{')) {
+    return null
+  }
+  let message: unknown
+  try {
+    message = JSON.parse(line)
+  } catch {
+    return null
+  }
+  const envelope = message as { id?: unknown; result?: { codexHome?: unknown } }
+  if (envelope.id !== INITIALIZE_ID || typeof envelope.result?.codexHome !== 'string') {
+    return null
+  }
+  return envelope.result.codexHome
+}
+
+/**
+ * The raw `codexHome` the host's Codex reports, or `null` when it does not
+ * answer. Callers validate the shape; this only refuses to invent one.
+ */
+export function probeCodexHomeViaAppServer(options: {
+  loginShell: string
+  loginShellFlag: string
+  env?: NodeJS.ProcessEnv
+  signal?: AbortSignal
+  timeoutMs?: number
+}): Promise<string | null> {
+  const command = `exec codex ${CODEX_READ_ONLY_APP_SERVER_ARGS.join(' ')}`
+  return new Promise<string | null>((resolve) => {
+    let child: ReturnType<typeof spawnProcess>
+    try {
+      child = spawnProcess({
+        program: options.loginShell,
+        args: [options.loginShellFlag, command],
+        stdio: ['pipe', 'pipe', 'ignore'],
+        ...(options.env ? { env: options.env } : {})
+      })
+    } catch {
+      resolve(null)
+      return
+    }
+
+    let pending = ''
+    let bytesRead = 0
+    let settled = false
+    const timer = setTimeout(() => settle(null), options.timeoutMs ?? PROBE_TIMEOUT_MS)
+
+    function settle(codexHome: string | null): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      options.signal?.removeEventListener('abort', onAbort)
+      child.stdout.off('data', onData)
+      child.off('error', onFailure)
+      child.off('close', onClose)
+      child.stdin.off('error', onFailure)
+      // Why: the handshake is all we wanted; a long-lived app-server here would
+      // outlive the install and hold the user's Codex state files open.
+      child.kill()
+      resolve(codexHome)
+    }
+
+    function onAbort(): void {
+      settle(null)
+    }
+
+    function onFailure(): void {
+      settle(null)
+    }
+
+    function onClose(): void {
+      settle(null)
+    }
+
+    function onData(chunk: Buffer): void {
+      bytesRead += chunk.length
+      pending += chunk.toString('utf8')
+      let newline = pending.indexOf('\n')
+      while (newline >= 0) {
+        const codexHome = readCodexHomeFromLine(pending.slice(0, newline).trim())
+        pending = pending.slice(newline + 1)
+        if (codexHome !== null) {
+          settle(codexHome)
+          return
+        }
+        newline = pending.indexOf('\n')
+      }
+      if (bytesRead > MAX_STDOUT_BYTES) {
+        settle(null)
+      }
+    }
+
+    child.on('error', onFailure)
+    child.on('close', onClose)
+    child.stdin.on('error', onFailure)
+    child.stdout.on('data', onData)
+    if (options.signal) {
+      if (options.signal.aborted) {
+        settle(null)
+        return
+      }
+      options.signal.addEventListener('abort', onAbort, { once: true })
+    }
+    child.stdin.write(initializeRequest())
+  })
+}

--- a/src/main/agent-hooks/codex-app-server-home-probe.ts
+++ b/src/main/agent-hooks/codex-app-server-home-probe.ts
@@ -21,6 +21,23 @@ const MAX_STDOUT_BYTES = 64 * 1024
 const INITIALIZE_ID = 1
 
 /**
+ * The environment the probe hands the child.
+ *
+ * `HOME` is pinned to the home the installer resolved, so parent and child
+ * agree on which account is being configured. `CODEX_HOME`/`ORCA_CODEX_HOME`
+ * are dropped because Orca injects them for its own managed accounts — reading
+ * one back would report Orca's own answer as if it were the host user's. A
+ * value the user's profile or launcher wrapper sets is unaffected: the login
+ * shell re-exports it, which is the whole point of the probe.
+ */
+export function buildCodexProbeEnvironment(home: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, HOME: home }
+  delete env.CODEX_HOME
+  delete env.ORCA_CODEX_HOME
+  return env
+}
+
+/**
  * `codex app-server` exits without answering when stdin reaches EOF, so the
  * request is written and the pipe is left open until the reply lands.
  */

--- a/src/main/agent-hooks/managed-hook-runtime.test.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.test.ts
@@ -17,7 +17,7 @@ const { execFile } = await import('node:child_process')
 const execFileMock = vi.mocked(execFile)
 const { execFile: actualExecFile } =
   await vi.importActual<typeof NodeChildProcess>('node:child_process')
-const { installManagedHooks, resolveRelayCodexHome, resolveRelayGrokHome } =
+const { installManagedHooks, resolveRelayGrokHome, resolveRelayRedirectedCodexHome } =
   await import('./managed-hook-runtime')
 
 type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void
@@ -160,21 +160,40 @@ describe.runIf(process.platform !== 'win32')('installManagedHooks', () => {
   })
 })
 
-describe.runIf(process.platform !== 'win32')('resolveRelayCodexHome', () => {
+describe.runIf(process.platform !== 'win32')('resolveRelayRedirectedCodexHome', () => {
   const CODEX_ONLY = ['codex'] as const
 
-  it('uses the CODEX_HOME the host s own Codex reports', async () => {
+  it('reports the CODEX_HOME the host s own Codex names', async () => {
     // #19598: a launcher wrapper exports CODEX_HOME inside the script, so only
     // Codex itself knows. The login-shell environment never sees it.
     await expect(
-      resolveRelayCodexHome('/home/orca', CODEX_ONLY, undefined, async () => '/home/orca/.codex-x/')
+      resolveRelayRedirectedCodexHome(
+        '/home/orca',
+        CODEX_ONLY,
+        undefined,
+        async () => '/home/orca/.codex-x/'
+      )
     ).resolves.toBe('/home/orca/.codex-x')
   })
 
-  it('falls back to ~/.codex when Codex does not answer', async () => {
+  // Why null rather than the path: an explicit codexHomeDir switches
+  // installRemote to its redirected-runtime contract (script location, command
+  // wrapper, hook order). An unwrapped host must keep the incumbent layout.
+  it('reports no redirect when Codex names the ordinary home', async () => {
     await expect(
-      resolveRelayCodexHome('/home/orca', CODEX_ONLY, undefined, async () => null)
-    ).resolves.toBe('/home/orca/.codex')
+      resolveRelayRedirectedCodexHome(
+        '/home/orca/',
+        CODEX_ONLY,
+        undefined,
+        async () => '/home/orca/.codex'
+      )
+    ).resolves.toBeNull()
+  })
+
+  it('reports no redirect when Codex does not answer', async () => {
+    await expect(
+      resolveRelayRedirectedCodexHome('/home/orca', CODEX_ONLY, undefined, async () => null)
+    ).resolves.toBeNull()
   })
 
   it.each([
@@ -182,18 +201,18 @@ describe.runIf(process.platform !== 'win32')('resolveRelayCodexHome', () => {
     ['Windows', 'C:\\Users\\bob\\.codex'],
     ['control-character', '/home/orca/.codex\u0007'],
     ['empty', '   ']
-  ])('falls back when the reported home is %s', async (_label, reported) => {
+  ])('reports no redirect when the reported home is %s', async (_label, reported) => {
     await expect(
-      resolveRelayCodexHome('/home/orca', CODEX_ONLY, undefined, async () => reported)
-    ).resolves.toBe('/home/orca/.codex')
+      resolveRelayRedirectedCodexHome('/home/orca', CODEX_ONLY, undefined, async () => reported)
+    ).resolves.toBeNull()
   })
 
   it('does not probe for a host with no detected Codex', async () => {
     const probe = vi.fn()
 
-    await expect(resolveRelayCodexHome('/home/orca', ['claude'], undefined, probe)).resolves.toBe(
-      '/home/orca/.codex'
-    )
+    await expect(
+      resolveRelayRedirectedCodexHome('/home/orca', ['claude'], undefined, probe)
+    ).resolves.toBeNull()
     expect(probe).not.toHaveBeenCalled()
   })
 })
@@ -235,7 +254,9 @@ describe.runIf(process.platform !== 'win32')(
       })
     })
 
-    it('still installs into ~/.codex when Codex reports the default home', async () => {
+    // The redirected-home contract moves the hook script under CODEX_HOME and
+    // rewrites the command; an unwrapped host must keep the incumbent layout.
+    it('leaves an unwrapped host on its incumbent ~/.codex layout', async () => {
       const home = await createTempHome()
       await stubWrappedCodex(home, join(home, '.codex'))
 
@@ -245,8 +266,23 @@ describe.runIf(process.platform !== 'win32')(
       })
 
       await expect(readFile(join(home, '.codex', 'hooks.json'), 'utf8')).resolves.toContain(
-        'codex-hook.sh'
+        join(home, '.orca', 'agent-hooks', 'codex-hook.sh')
       )
+      await expect(
+        readFile(join(home, '.codex', '.orca', 'agent-hooks', 'codex-hook.sh'), 'utf8')
+      ).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+
+    it('moves the hook script under a redirected home, as the runtime installer does', async () => {
+      const home = await createTempHome()
+      const codexHome = join(home, '.codex-openai')
+      await stubWrappedCodex(home, codexHome)
+
+      await installManagedHooks({ agents: ['codex'] })
+
+      await expect(
+        readFile(join(codexHome, '.orca', 'agent-hooks', 'codex-hook.sh'), 'utf8')
+      ).resolves.toContain('#!/bin/sh')
     })
   }
 )

--- a/src/main/agent-hooks/managed-hook-runtime.test.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -17,7 +17,8 @@ const { execFile } = await import('node:child_process')
 const execFileMock = vi.mocked(execFile)
 const { execFile: actualExecFile } =
   await vi.importActual<typeof NodeChildProcess>('node:child_process')
-const { installManagedHooks, resolveRelayGrokHome } = await import('./managed-hook-runtime')
+const { installManagedHooks, resolveRelayCodexHome, resolveRelayGrokHome } =
+  await import('./managed-hook-runtime')
 
 type ExecFileCallback = (error: Error | null, result?: { stdout: string; stderr: string }) => void
 
@@ -158,3 +159,94 @@ describe.runIf(process.platform !== 'win32')('installManagedHooks', () => {
     expect((await readdir(home)).sort()).toEqual(['.claude', '.orca', SHELL_NAME, SHELL_RUNS_NAME])
   })
 })
+
+describe.runIf(process.platform !== 'win32')('resolveRelayCodexHome', () => {
+  const CODEX_ONLY = ['codex'] as const
+
+  it('uses the CODEX_HOME the host s own Codex reports', async () => {
+    // #19598: a launcher wrapper exports CODEX_HOME inside the script, so only
+    // Codex itself knows. The login-shell environment never sees it.
+    await expect(
+      resolveRelayCodexHome('/home/orca', CODEX_ONLY, undefined, async () => '/home/orca/.codex-x/')
+    ).resolves.toBe('/home/orca/.codex-x')
+  })
+
+  it('falls back to ~/.codex when Codex does not answer', async () => {
+    await expect(
+      resolveRelayCodexHome('/home/orca', CODEX_ONLY, undefined, async () => null)
+    ).resolves.toBe('/home/orca/.codex')
+  })
+
+  it.each([
+    ['relative', '../relative'],
+    ['Windows', 'C:\\Users\\bob\\.codex'],
+    ['control-character', '/home/orca/.codex\u0007'],
+    ['empty', '   ']
+  ])('falls back when the reported home is %s', async (_label, reported) => {
+    await expect(
+      resolveRelayCodexHome('/home/orca', CODEX_ONLY, undefined, async () => reported)
+    ).resolves.toBe('/home/orca/.codex')
+  })
+
+  it('does not probe for a host with no detected Codex', async () => {
+    const probe = vi.fn()
+
+    await expect(resolveRelayCodexHome('/home/orca', ['claude'], undefined, probe)).resolves.toBe(
+      '/home/orca/.codex'
+    )
+    expect(probe).not.toHaveBeenCalled()
+  })
+})
+
+describe.runIf(process.platform !== 'win32')(
+  'installManagedHooks with a redirected Codex home',
+  () => {
+    /** A `codex` earlier on PATH that exports its own CODEX_HOME, as in #19598. */
+    async function stubWrappedCodex(home: string, codexHome: string): Promise<void> {
+      const binDir = join(home, 'bin')
+      await mkdir(binDir, { recursive: true })
+      const codexPath = join(binDir, 'codex')
+      await writeFile(
+        codexPath,
+        `#!/bin/sh\nread -r _line\nprintf '%s\\n' '{"id":1,"result":{"codexHome":"${codexHome}"}}'\nsleep 5\n`,
+        'utf8'
+      )
+      await chmod(codexPath, 0o755)
+      vi.stubEnv('HOME', home)
+      vi.stubEnv('SHELL', '/bin/sh')
+      vi.stubEnv('PATH', `${binDir}:${process.env.PATH ?? ''}`)
+    }
+
+    it('installs into the home Codex reports, not ~/.codex', async () => {
+      const home = await createTempHome()
+      const codexHome = join(home, '.codex-openai')
+      await stubWrappedCodex(home, codexHome)
+
+      await expect(installManagedHooks({ agents: ['codex'] })).resolves.toEqual({
+        installers: 1,
+        errors: 0
+      })
+
+      await expect(readFile(join(codexHome, 'hooks.json'), 'utf8')).resolves.toContain(
+        'codex-hook.sh'
+      )
+      await expect(readFile(join(home, '.codex', 'hooks.json'), 'utf8')).rejects.toMatchObject({
+        code: 'ENOENT'
+      })
+    })
+
+    it('still installs into ~/.codex when Codex reports the default home', async () => {
+      const home = await createTempHome()
+      await stubWrappedCodex(home, join(home, '.codex'))
+
+      await expect(installManagedHooks({ agents: ['codex'] })).resolves.toEqual({
+        installers: 1,
+        errors: 0
+      })
+
+      await expect(readFile(join(home, '.codex', 'hooks.json'), 'utf8')).resolves.toContain(
+        'codex-hook.sh'
+      )
+    })
+  }
+)

--- a/src/main/agent-hooks/managed-hook-runtime.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.ts
@@ -3,7 +3,10 @@ import { basename } from 'node:path'
 import { homedir, userInfo } from 'node:os'
 import { promisify } from 'node:util'
 import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers'
-import { probeCodexHomeViaAppServer } from './codex-app-server-home-probe'
+import {
+  buildCodexProbeEnvironment,
+  probeCodexHomeViaAppServer
+} from './codex-app-server-home-probe'
 import type { AgentHookTarget } from '../../shared/agent-hook-types'
 import { createManagedHookLocalFilesystem } from './managed-hook-local-filesystem'
 import { withManagedHookInstallLock } from './managed-hook-install-lock'
@@ -109,6 +112,7 @@ export async function resolveRelayRedirectedCodexHome(
   const reported = await probe({
     loginShell: shell,
     loginShellFlag: flag,
+    env: buildCodexProbeEnvironment(home),
     ...(signal ? { signal } : {})
   })
   const codexHome = reported === null ? null : normalizePosixAgentHome(reported.trim())

--- a/src/main/agent-hooks/managed-hook-runtime.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.ts
@@ -80,26 +80,30 @@ export async function resolveRelayGrokHome(home: string, signal?: AbortSignal): 
 }
 
 /**
- * Where this host's Codex actually keeps its config.
+ * The Codex home this host redirects to, or `null` for the ordinary `~/.codex`.
  *
  * `printenv CODEX_HOME` is not enough: a launcher wrapper exports it inside the
  * script and `exec`s the real binary, so it never reaches the parent shell
  * (#19598). Codex's own app-server handshake reports the value the wrapper set,
- * which is the only authority on the question. Anything else — no Codex on
- * PATH, a CLI too old for the handshake, a timeout, a non-POSIX answer — falls
- * back to `~/.codex`, the incumbent behaviour.
+ * which is the only authority on the question. No Codex on PATH, a CLI too old
+ * for the handshake, a timeout, an abort, or a non-POSIX answer all read as
+ * "not redirected".
+ *
+ * Why `null` rather than the default path: `installRemote` treats an explicit
+ * `codexHomeDir` as a redirected runtime home and moves the hook script under
+ * it, switches the command wrapper and reorders the hook groups. Handing it
+ * `~/.codex` would apply that contract to every unwrapped host as well.
  */
-export async function resolveRelayCodexHome(
+export async function resolveRelayRedirectedCodexHome(
   home: string,
   agents: readonly AgentHookTarget[],
   signal?: AbortSignal,
   probe: typeof probeCodexHomeViaAppServer = probeCodexHomeViaAppServer
-): Promise<string> {
-  const fallback = defaultAgentHome(home, '.codex')
+): Promise<string | null> {
   // Why: only a positively detected Codex pays for the probe; other hosts must
   // not start an app-server for a CLI the user never installed.
   if (!agents.includes('codex')) {
-    return fallback
+    return null
   }
   const { shell, flag } = loginShellInvocation()
   const reported = await probe({
@@ -107,7 +111,8 @@ export async function resolveRelayCodexHome(
     loginShellFlag: flag,
     ...(signal ? { signal } : {})
   })
-  return (reported === null ? null : normalizePosixAgentHome(reported.trim())) ?? fallback
+  const codexHome = reported === null ? null : normalizePosixAgentHome(reported.trim())
+  return !codexHome || codexHome === defaultAgentHome(home, '.codex') ? null : codexHome
 }
 
 export async function installManagedHooks(options?: {
@@ -124,7 +129,7 @@ export async function installManagedHooks(options?: {
   const home = homedir()
   const grokHomeDir = await resolveRelayGrokHome(home, options?.signal)
   options?.signal?.throwIfAborted()
-  const codexHomeDir = await resolveRelayCodexHome(home, agents, options?.signal)
+  const codexHomeDir = await resolveRelayRedirectedCodexHome(home, agents, options?.signal)
   options?.signal?.throwIfAborted()
   const hostIdentity = scopeManagedHookHostIdentity(
     await readManagedHookHostIdentity(),
@@ -138,7 +143,7 @@ export async function installManagedHooks(options?: {
         createManagedHookLocalFilesystem(),
         home,
         {
-          codexHomeDir,
+          ...(codexHomeDir ? { codexHomeDir } : {}),
           grokHomeDir,
           signal: options?.signal,
           agents

--- a/src/main/agent-hooks/managed-hook-runtime.ts
+++ b/src/main/agent-hooks/managed-hook-runtime.ts
@@ -3,6 +3,7 @@ import { basename } from 'node:path'
 import { homedir, userInfo } from 'node:os'
 import { promisify } from 'node:util'
 import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers'
+import { probeCodexHomeViaAppServer } from './codex-app-server-home-probe'
 import type { AgentHookTarget } from '../../shared/agent-hook-types'
 import { createManagedHookLocalFilesystem } from './managed-hook-local-filesystem'
 import { withManagedHookInstallLock } from './managed-hook-install-lock'
@@ -12,7 +13,7 @@ import {
 } from './managed-hook-owner-identity'
 
 const execFileAsync = promisify(execFile)
-const GROK_HOME_MAX_LENGTH = 4096
+const AGENT_HOME_MAX_LENGTH = 4096
 const GROK_HOME_PROBE_TIMEOUT_MS = 8_000
 
 export type ManagedHookInstallSummary = {
@@ -20,8 +21,8 @@ export type ManagedHookInstallSummary = {
   errors: number
 }
 
-function defaultGrokHome(home: string): string {
-  return `${home.replace(/\/+$/, '') || home}/.grok`
+function defaultAgentHome(home: string, directoryName: string): string {
+  return `${home.replace(/\/+$/, '') || home}/${directoryName}`
 }
 
 function hasControlCharacter(value: string): boolean {
@@ -31,10 +32,11 @@ function hasControlCharacter(value: string): boolean {
   })
 }
 
-function normalizeGrokHome(candidate: string): string | null {
+/** Shared by every agent home read off a host: absolute POSIX, no smuggled control bytes. */
+function normalizePosixAgentHome(candidate: string): string | null {
   if (
     candidate.length === 0 ||
-    candidate.length > GROK_HOME_MAX_LENGTH ||
+    candidate.length > AGENT_HOME_MAX_LENGTH ||
     candidate !== candidate.trim() ||
     !candidate.startsWith('/') ||
     candidate.includes('\\') ||
@@ -45,32 +47,67 @@ function normalizeGrokHome(candidate: string): string | null {
   return candidate.replace(/\/+$/, '') || '/'
 }
 
-function resolveLoginShell(): string {
+/**
+ * The shell an agent PTY would start, and the flag that makes it read the
+ * user's profile — which is what puts a launcher wrapper on `PATH`.
+ */
+function loginShellInvocation(): { shell: string; flag: string } {
   const candidate = process.env.SHELL || userInfo().shell || '/bin/sh'
-  if (!candidate.startsWith('/') || candidate.includes('\\') || hasControlCharacter(candidate)) {
-    return '/bin/sh'
-  }
-  return candidate
+  const shell =
+    !candidate.startsWith('/') || candidate.includes('\\') || hasControlCharacter(candidate)
+      ? '/bin/sh'
+      : candidate
+  const shellName = basename(shell)
+  return { shell, flag: shellName === 'sh' || shellName === 'dash' ? '-c' : '-lc' }
 }
 
 export async function resolveRelayGrokHome(home: string, signal?: AbortSignal): Promise<string> {
-  const fallback = defaultGrokHome(home)
+  const fallback = defaultAgentHome(home, '.grok')
   try {
-    const shell = resolveLoginShell()
-    const shellName = basename(shell)
-    const mode = shellName === 'sh' || shellName === 'dash' ? '-c' : '-lc'
+    const { shell, flag } = loginShellInvocation()
     // Why: agent PTYs start login shells, so read the same profile-derived
     // GROK_HOME without opening two additional SSH exec channels.
     const { stdout } = await execFileAsync(
       shell,
-      [mode, `printenv GROK_HOME | head -c ${GROK_HOME_MAX_LENGTH + 1}`],
+      [flag, `printenv GROK_HOME | head -c ${AGENT_HOME_MAX_LENGTH + 1}`],
       { encoding: 'utf8', timeout: GROK_HOME_PROBE_TIMEOUT_MS, signal }
     )
-    return normalizeGrokHome(stdout.split(/\r?\n/, 1)[0] ?? '') ?? fallback
+    return normalizePosixAgentHome(stdout.split(/\r?\n/, 1)[0] ?? '') ?? fallback
   } catch {
     signal?.throwIfAborted()
     return fallback
   }
+}
+
+/**
+ * Where this host's Codex actually keeps its config.
+ *
+ * `printenv CODEX_HOME` is not enough: a launcher wrapper exports it inside the
+ * script and `exec`s the real binary, so it never reaches the parent shell
+ * (#19598). Codex's own app-server handshake reports the value the wrapper set,
+ * which is the only authority on the question. Anything else — no Codex on
+ * PATH, a CLI too old for the handshake, a timeout, a non-POSIX answer — falls
+ * back to `~/.codex`, the incumbent behaviour.
+ */
+export async function resolveRelayCodexHome(
+  home: string,
+  agents: readonly AgentHookTarget[],
+  signal?: AbortSignal,
+  probe: typeof probeCodexHomeViaAppServer = probeCodexHomeViaAppServer
+): Promise<string> {
+  const fallback = defaultAgentHome(home, '.codex')
+  // Why: only a positively detected Codex pays for the probe; other hosts must
+  // not start an app-server for a CLI the user never installed.
+  if (!agents.includes('codex')) {
+    return fallback
+  }
+  const { shell, flag } = loginShellInvocation()
+  const reported = await probe({
+    loginShell: shell,
+    loginShellFlag: flag,
+    ...(signal ? { signal } : {})
+  })
+  return (reported === null ? null : normalizePosixAgentHome(reported.trim())) ?? fallback
 }
 
 export async function installManagedHooks(options?: {
@@ -87,6 +124,8 @@ export async function installManagedHooks(options?: {
   const home = homedir()
   const grokHomeDir = await resolveRelayGrokHome(home, options?.signal)
   options?.signal?.throwIfAborted()
+  const codexHomeDir = await resolveRelayCodexHome(home, agents, options?.signal)
+  options?.signal?.throwIfAborted()
   const hostIdentity = scopeManagedHookHostIdentity(
     await readManagedHookHostIdentity(),
     options?.hostKeyFingerprint
@@ -99,6 +138,7 @@ export async function installManagedHooks(options?: {
         createManagedHookLocalFilesystem(),
         home,
         {
+          codexHomeDir,
           grokHomeDir,
           signal: options?.signal,
           agents


### PR DESCRIPTION
> [!NOTE]
> **Superseded-pending — do not merge unless #19701 stalls.**
>
> #19701 fixes the same issue on a better structure: it reuses the shared
> `runCodexAppServerSession` helper instead of standing up a second probe. Its
> command resolution didn't reach the reporter's wrapper, so I pushed that delta
> to its branch as `98162669648` and verified it on the host. Once #19701 is
> green with that in place, close this one unmerged. Kept open only as a
> fallback if that branch goes quiet.

<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​300 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​298 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​225 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​209 |

<!-- /orca-pr-loc -->

Fixes #19598

## ELI5

Codex keeps its settings in a folder. Normally that's `~/.codex`, but some people
have a little `codex` launcher script that quietly points Codex at a different
folder — say `~/.codex-openai` — and then starts the real Codex.

Orca puts its "tell me when the agent starts and stops" hooks into that folder.
It was always putting them in `~/.codex`, because the launcher only sets the new
location *inside* Codex, where nobody outside can see it. So Codex read one
folder, Orca wrote the other, and Orca never heard a thing: the Codex pane's
status fell back to guessing from terminal output and then vanished after a turn
finished, because no "Stop" hook ever arrived.

Now Orca just asks Codex where its folder is, and puts the hooks there.

## What changed

`codex app-server`'s `initialize` reply carries `codexHome`. That is the
authoritative answer, because it comes from the same process the launcher
configured. The relay-side installer asks for it once, through the same login
shell an agent PTY would use — that's what puts the wrapper on `PATH` in the
first place.

Two things the real host taught this implementation:

- `codex app-server` **exits without answering** once stdin reaches EOF, so the
  request pipe has to stay open until the reply arrives. Writing the request and
  closing (what `runProcess({ input })` does) yields exit 0 and empty stdout.
- A login shell can print a profile banner before the JSON, so stdout is parsed
  a line at a time and non-matching lines are skipped.

`resolveRelayRedirectedCodexHome` answers **`null` for the ordinary `~/.codex`**,
not the path. That matters: `installRemote` treats an explicit `codexHomeDir` as
a redirected runtime home and moves the hook script under it, switches the
command wrapper and reorders the hook groups. Handing it `~/.codex` would apply
that WSL-shaped contract to every unwrapped SSH host too. Unwrapped hosts keep
the exact layout they have today — verified byte-for-byte against `origin/main`
on a real host (below).

Only a positively detected Codex pays for the probe. No Codex on `PATH`, a CLI
too old for the handshake, a timeout, an abort, or a non-POSIX answer all read as
"not redirected".

## Proof, on a real macOS client → Linux SSH host

Host `openclaw` (Ubuntu 24.04, codex-cli 0.153.0), with the issue's exact wrapper
first on `PATH`:

```bash
#!/usr/bin/env bash
set -euo pipefail
export CODEX_HOME="$HOME/.codex-openai"
exec /usr/local/bin/codex "$@"
```

The login shell cannot see it, but Codex can:

```
login-shell CODEX_HOME: unset
initialize: {"id":1,"result":{"codexHome":"/home/neil/.codex-openai",...}}
```

Running the **shipped relay artifact** (`out/relay/linux-x64/managed-hook-runtime.js`)
built from each ref, on that host, against a throwaway `$HOME`:

**Wrapper present**

| build | hooks.json | script it references |
|---|---|---|
| `origin/main` @ 2bf298d | `.codex/hooks.json` | `$HOME/.orca/agent-hooks/codex-hook.sh` |
| this branch | `.codex-openai/hooks.json` | `$HOME/.codex-openai/.orca/agent-hooks/codex-hook.sh` |

**No wrapper — no change, which is the point**

| build | hooks.json | script it references |
|---|---|---|
| `origin/main` @ 2bf298d | `.codex/hooks.json` | `$HOME/.orca/agent-hooks/codex-hook.sh` |
| this branch | `.codex/hooks.json` | `$HOME/.orca/agent-hooks/codex-hook.sh` |

Windows host `awin` over SSH: no `/bin/sh`, so the probe fails instantly and
reports "not redirected" — unchanged from today. Windows SSH remotes never reach
the managed-hook installer anyway (`installManagedHooksOnRemote` returns early
for them).

## Side effect worth knowing

Starting `codex app-server` makes Codex run its own first-run initialisation, so
a host that has never launched Codex gains its usual `~/.codex` state files
(sqlite, bundled system skills) at hook-install time instead of at first launch.
The installer already created that directory to write `hooks.json` and the trust
entries, and the probe only runs for a positively detected Codex, so this is
earlier — not new.

## Tests

`codex-app-server-home-probe.test.ts` drives a real child over pipes with a fake
`codex` on `PATH`: reply, banner-then-reply, notification-then-reply, non-zero
exit, never-replies (deadline), missing binary, abort.
`managed-hook-runtime.test.ts` covers the end-to-end cases — a wrapped `codex`
puts hooks and script under the reported home; an unwrapped one keeps the
incumbent `~/.orca/agent-hooks` layout — plus validation and "don't probe
undetected agents".

### Mutation results (9/9 killed)

| mutation | killed by |
|---|---|
| don't pass `codexHomeDir` to the installer | `installs into the home Codex reports…`, `moves the hook script under a redirected home…` |
| never redirect | + `reports the CODEX_HOME the host's own Codex names` |
| **treat `~/.codex` as a redirect** (the regression this branch's second commit fixes) | `reports no redirect when Codex names the ordinary home`, `leaves an unwrapped host on its incumbent ~/.codex layout` |
| skip POSIX/control-char validation | the 4 invalid-shape cases |
| probe for every host | `does not probe for a host with no detected Codex` |
| never send `initialize` | the 3 reply-reading cases |
| take the first stdout line verbatim | the 3 reply-reading cases |
| remove the probe deadline | `answers null when the CLI never replies, without hanging` |
| ignore the abort signal | `answers null once the install is aborted` |

Two survivors were found and fixed rather than reported away:

- **ignore the abort signal** survived because the test asserted the value but
  not the latency, so the 12s default deadline satisfied it. It now asserts the
  probe settles in under 5s with the deadline pushed to 60s.
- **treat `~/.codex` as a redirect** was a real defect in the first commit, found
  by the readiness checklist and confirmed on the host: every unwrapped SSH user
  would have had their hook script relocated. Second commit fixes it, with the
  host A/B above as proof.

## Gates

`pnpm tc`, `pnpm test src/main/agent-hooks src/main/codex src/shared/child-process/child-process-import-boundary.test.ts`,
`oxlint`, `pnpm run check:code-quality:changed`, `pnpm format`.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts; all 3 commit(s) replayed as-is.

| | SHA |
| --- | --- |
| old head | `f8cde6efe29d430a02bb6cc74948e9e6ad8d4487` |
| new head | `b8bfd89ebbbb90e94d2b9c77f53ed5562c2d2693` |
<!-- /rebase-record -->
