### PR TITLE
fix(skills): prove an SSH skill-install destination on the host, not from the request

### DIFF
--- a/src/main/skills/skill-install-destinations.test.ts
+++ b/src/main/skills/skill-install-destinations.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, parse } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { SkillInstallRequest } from '../../shared/skill-install-contract'
 import { resolveSkillInstallDestination } from './skill-install-destinations'
@@ -93,5 +93,101 @@ describe('resolveSkillInstallDestination', () => {
         authority
       )
     ).rejects.toThrow('skill-install-ssh-dispatch-required')
+  })
+})
+
+describe('workspace destinations must be workspaces', () => {
+  /** The incumbent check was `requireContained(dir, dir)`, so any directory the
+   *  request named became the install root on the execution host (#18273). */
+  async function authorityFor(workspacePath: string) {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-destination-guard-'))
+    roots.push(root)
+    const home = join(root, 'home')
+    await mkdir(home)
+    return {
+      environmentId: 'environment_1',
+      homeDirectory: await realpath(home),
+      home: await realpath(home),
+      resolveWorktree: async (id: string) =>
+        id === 'worktree_1' ? { id, path: workspacePath } : null,
+      resolveFolderWorkspace: async (id: string) =>
+        id === 'folder_1' ? { id, path: workspacePath } : null
+    }
+  }
+
+  it('rejects the execution host home directory as a workspace', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-destination-guard-'))
+    roots.push(root)
+    const home = await realpath(root)
+    const authority = {
+      environmentId: 'environment_1',
+      homeDirectory: home,
+      resolveWorktree: async (id: string) => (id === 'worktree_1' ? { id, path: home } : null),
+      resolveFolderWorkspace: async () => null
+    }
+
+    await expect(
+      resolveSkillInstallDestination(
+        { scope: 'workspace', worktreeId: 'worktree_1' } as SkillInstallRequest['destination'],
+        authority
+      )
+    ).rejects.toThrow('skill-install-destination-escape')
+  })
+
+  it('rejects a directory that contains the execution host home', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-destination-guard-'))
+    roots.push(root)
+    const home = join(root, 'home')
+    await mkdir(home)
+    const authority = {
+      environmentId: 'environment_1',
+      homeDirectory: await realpath(home),
+      resolveWorktree: async (id: string) =>
+        id === 'worktree_1' ? { id, path: await realpath(root) } : null,
+      resolveFolderWorkspace: async () => null
+    }
+
+    await expect(
+      resolveSkillInstallDestination(
+        { scope: 'workspace', worktreeId: 'worktree_1' } as SkillInstallRequest['destination'],
+        authority
+      )
+    ).rejects.toThrow('skill-install-destination-escape')
+  })
+
+  it('rejects a filesystem root', async () => {
+    const authority = await authorityFor(parse(process.cwd()).root)
+
+    await expect(
+      resolveSkillInstallDestination(
+        { scope: 'workspace', folderWorkspaceId: 'folder_1' } as SkillInstallRequest['destination'],
+        authority
+      )
+    ).rejects.toThrow('skill-install-destination-escape')
+  })
+
+  it('still accepts a real workspace directory that sits under the home tree', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-destination-guard-'))
+    roots.push(root)
+    const home = join(root, 'home')
+    const workspace = join(home, 'workspaces', 'feature')
+    await mkdir(workspace, { recursive: true })
+    const authority = {
+      environmentId: 'environment_1',
+      homeDirectory: await realpath(home),
+      resolveWorktree: async (id: string) =>
+        id === 'worktree_1' ? { id, path: await realpath(workspace) } : null,
+      resolveFolderWorkspace: async () => null
+    }
+
+    await expect(
+      resolveSkillInstallDestination(
+        { scope: 'workspace', worktreeId: 'worktree_1' } as SkillInstallRequest['destination'],
+        authority
+      )
+    ).resolves.toMatchObject({
+      scope: 'workspace',
+      workspaceDirectory: await realpath(workspace)
+    })
   })
 })

--- a/src/main/skills/skill-install-destinations.ts
+++ b/src/main/skills/skill-install-destinations.ts
@@ -1,5 +1,5 @@
 import { lstat, realpath } from 'node:fs/promises'
-import { isAbsolute, relative, resolve } from 'node:path'
+import { isAbsolute, parse, relative, resolve, sep } from 'node:path'
 import type { SkillInstallRequest } from '../../shared/skill-install-contract'
 
 type WorkspaceIdentity = {
@@ -32,13 +32,31 @@ async function requireDirectory(path: string, category: string): Promise<string>
   return realpath(path)
 }
 
-function requireContained(root: string, path: string): void {
+/** Whether `path` is `root` or lies inside it. `sep` is this machine's, and
+ *  this module only ever runs on the machine that owns the filesystem. */
+function isContained(root: string, path: string): boolean {
   const child = relative(resolve(root), resolve(path))
-  if (
-    child === '..' ||
-    child.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) ||
-    isAbsolute(child)
-  ) {
+  return child !== '..' && !child.startsWith(`..${sep}`) && !isAbsolute(child)
+}
+
+/**
+ * A workspace destination has to be a workspace, not just any directory the
+ * caller named.
+ *
+ * The incumbent check was `requireContained(workspaceDirectory,
+ * workspaceDirectory)`, which is true by construction and so asserted nothing:
+ * whatever `path` the request carried became the install root on the execution
+ * host (#18273, threat model TM-04/TM-11). These rules are the ones that hold
+ * for every host without a workspace catalog to consult; the SSH relay adds a
+ * Git proof on top for worktrees.
+ */
+function requireWorkspaceDirectory(homeDirectory: string, workspaceDirectory: string): void {
+  const home = resolve(homeDirectory)
+  const workspace = resolve(workspaceDirectory)
+  // A filesystem root, the home tree itself, or anything containing the home
+  // tree is not a workspace — installing there scatters `.agents` across the
+  // user's whole account instead of one checkout.
+  if (workspace === parse(workspace).root || workspace === home || isContained(workspace, home)) {
     throw new Error('skill-install-destination-escape')
   }
 }
@@ -91,7 +109,7 @@ export async function resolveSkillInstallDestination(
     workspace.path,
     'skill-install-workspace-unavailable'
   )
-  requireContained(workspaceDirectory, workspaceDirectory)
+  requireWorkspaceDirectory(homeDirectory, workspaceDirectory)
   return {
     scope: 'workspace',
     homeDirectory,

--- a/src/relay/skill-install-handler.ts
+++ b/src/relay/skill-install-handler.ts
@@ -61,6 +61,7 @@ import {
 } from '../main/skills/skill-install-operation-error'
 import { recoverPendingSkillTransactions } from '../main/skills/skill-transaction-startup-recovery'
 import { resolveEnvironmentSkillProviderRoots } from '../main/skills/skill-provider-runtime-roots'
+import { isHostGitWorktreeRoot } from './skill-install-workspace-proof'
 
 const SSH_SKILL_ENVIRONMENT_ID = 'ssh-host'
 
@@ -198,12 +199,25 @@ export class SkillInstallHandler {
     })
   }
 
+  /**
+   * The destination authority for one relay request.
+   *
+   * Mixed-version note: old clients still send `workspace.path` and the schema
+   * still accepts it, but it is a hint, not authority — a worktree destination
+   * is only honoured once Git on this host confirms the directory is a checkout
+   * root (#18273). `resolveSkillInstallDestination` applies the structural
+   * rules (never the home tree, never a filesystem root) to both kinds.
+   */
   private authority(workspace?: SkillSshWorkspaceAuthority): SkillInstallDestinationAuthority {
     return {
       environmentId: SSH_SKILL_ENVIRONMENT_ID,
       homeDirectory: this.homeDirectory,
-      resolveWorktree: async (id) =>
-        workspace?.kind === 'worktree' && workspace.id === id ? workspace : null,
+      resolveWorktree: async (id) => {
+        if (workspace?.kind !== 'worktree' || workspace.id !== id) {
+          return null
+        }
+        return (await isHostGitWorktreeRoot(workspace.path)) ? workspace : null
+      },
       resolveFolderWorkspace: async (id) =>
         workspace?.kind === 'folder' && workspace.id === id ? workspace : null
     }

--- a/src/relay/skill-install-workspace-authority.test.ts
+++ b/src/relay/skill-install-workspace-authority.test.ts
@@ -1,0 +1,138 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { MethodHandler, RelayDispatcher } from './dispatcher'
+import { createSkillPackageArchive } from '../main/skills/skill-package-creation'
+import {
+  SKILL_SSH_RELAY_BEGIN_UPLOAD_METHOD,
+  SKILL_SSH_RELAY_COMMIT_UPLOAD_METHOD,
+  SKILL_SSH_RELAY_INSTALL_METHOD,
+  SKILL_SSH_RELAY_UPLOAD_CHUNK_METHOD
+} from '../shared/skill-ssh-relay-contract'
+import { runProcess } from '../shared/child-process/run-process'
+import { SkillInstallHandler } from './skill-install-handler'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function gitInit(directory: string): Promise<boolean> {
+  const result = await runProcess({
+    program: 'git',
+    args: ['-C', directory, 'init', '--quiet'],
+    timeoutMs: 20_000
+  }).catch(() => null)
+  return result?.code === 0
+}
+
+/**
+ * A relay handler plus a staged package, ready to install into whatever
+ * `workspace` the caller claims. `checkout` is a real Git working tree on this
+ * host; `plain` is an ordinary directory, standing in for `~/.ssh` or `/etc`.
+ */
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'orca-relay-skill-authority-'))
+  roots.push(root)
+  const home = join(root, 'home')
+  const state = join(root, 'state')
+  const source = join(root, 'source')
+  const checkout = join(home, 'workspaces', 'feature')
+  const plain = join(home, '.ssh')
+  await Promise.all([
+    mkdir(home),
+    mkdir(source),
+    mkdir(checkout, { recursive: true }),
+    mkdir(plain, { recursive: true })
+  ])
+  await writeFile(
+    join(source, 'SKILL.md'),
+    '---\nname: relay-skill\ndescription: Relay test\n---\n\n# Relay\n'
+  )
+  const archive = await createSkillPackageArchive({
+    sourceDirectory: source,
+    archivePath: join(root, 'package.tar.gz'),
+    packageId: 'package_1',
+    versionId: 'version_1'
+  })
+  const bytes = await readFile(archive.archivePath)
+  const handlers = new Map<string, MethodHandler>()
+  const dispatcher = {
+    onRequest: vi.fn((method: string, handler: MethodHandler) => handlers.set(method, handler))
+  } as unknown as RelayDispatcher
+  new SkillInstallHandler(dispatcher, {
+    homeDirectory: home,
+    stateDirectory: state,
+    detectProviders: async () => [],
+    recovery: Promise.resolve()
+  })
+  const call = (method: string, params: Record<string, unknown>) =>
+    handlers.get(method)!(params, {
+      clientId: 1,
+      isStale: () => false,
+      signal: new AbortController().signal
+    })
+
+  const packageIdentity = {
+    packageId: archive.manifest.packageId,
+    versionId: archive.manifest.versionId,
+    packageDigest: archive.manifest.packageDigest,
+    archiveSha256: archive.archiveSha256,
+    compressedBytes: bytes.length
+  }
+
+  async function install(workspacePath: string): Promise<{ status: string }> {
+    const begun = (await call(SKILL_SSH_RELAY_BEGIN_UPLOAD_METHOD, {
+      package: packageIdentity
+    })) as { uploadId: string }
+    await call(SKILL_SSH_RELAY_UPLOAD_CHUNK_METHOD, {
+      uploadId: begun.uploadId,
+      offset: 0,
+      bytesBase64: bytes.toString('base64')
+    })
+    await call(SKILL_SSH_RELAY_COMMIT_UPLOAD_METHOD, { uploadId: begun.uploadId })
+    return (await call(SKILL_SSH_RELAY_INSTALL_METHOD, {
+      request: {
+        operationId: `operation_${Math.random().toString(36).slice(2)}`,
+        package: packageIdentity,
+        ingress: { kind: 'staged-upload', uploadId: begun.uploadId },
+        destination: { scope: 'workspace', worktreeId: 'worktree_1' }
+      },
+      workspace: { kind: 'worktree', id: 'worktree_1', path: workspacePath }
+    })) as { status: string }
+  }
+
+  return { checkout, home, install, plain }
+}
+
+describe('SSH relay worktree install destinations', () => {
+  it('refuses a client path that is not a checkout on this host', async () => {
+    // #18273: `~/.ssh` matched the requested worktree id and was accepted as
+    // the install root, because the relay handed the caller's path straight
+    // back as authority.
+    const { install, plain } = await fixture()
+
+    await expect(install(plain)).rejects.toThrow(/skill-install-workspace-not-found/)
+  })
+
+  it('installs into a directory Git confirms is a checkout root', async () => {
+    const { checkout, install } = await fixture()
+    expect(await gitInit(checkout)).toBe(true)
+
+    await expect(install(checkout)).resolves.toMatchObject({ status: 'installed' })
+    await expect(
+      readFile(join(checkout, '.agents', 'skills', 'relay-skill', 'SKILL.md'), 'utf8')
+    ).resolves.toContain('# Relay')
+  })
+
+  it('refuses a path merely inside a checkout rather than its root', async () => {
+    const { checkout, install } = await fixture()
+    expect(await gitInit(checkout)).toBe(true)
+    const nested = join(checkout, 'packages', 'app')
+    await mkdir(nested, { recursive: true })
+
+    await expect(install(nested)).rejects.toThrow(/skill-install-workspace-not-found/)
+  })
+})

--- a/src/relay/skill-install-workspace-proof.ts
+++ b/src/relay/skill-install-workspace-proof.ts
@@ -1,0 +1,45 @@
+/**
+ * Proving, on the execution host, that a skill-install destination really is a
+ * workspace checkout.
+ *
+ * The SSH relay's `authority()` used to hand the caller's own `workspace.path`
+ * straight back as the destination root, so a request could name any directory
+ * on the host and have a packaged skill tree written there (#18273, threat
+ * model TM-04/TM-11). The relay has no worktree catalog to look the id up in —
+ * an Orca worktree id is client metadata — so the host's own answer has to come
+ * from Git: `rev-parse --show-toplevel` inside the candidate names the working
+ * tree that directory belongs to, and only a real checkout root answers with
+ * itself. `~/.ssh`, `~/.gnupg` and `/etc` do not.
+ */
+
+import { realpath } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { runProcess } from '../shared/child-process/run-process'
+
+const GIT_PROOF_TIMEOUT_MS = 10_000
+
+/**
+ * Whether `candidatePath` is the root of a Git working tree on this host.
+ *
+ * `--show-toplevel` is Git 1.7-era, so no capability probe is needed. A missing
+ * Git, a non-repository, or a path merely *inside* a checkout all answer false;
+ * the caller then reports the workspace as not found.
+ */
+export async function isHostGitWorktreeRoot(candidatePath: string): Promise<boolean> {
+  const result = await runProcess({
+    program: 'git',
+    args: ['-C', candidatePath, 'rev-parse', '--show-toplevel'],
+    timeoutMs: GIT_PROOF_TIMEOUT_MS
+  }).catch(() => null)
+  const reported = result?.code === 0 ? result.stdout.trim() : ''
+  if (!reported) {
+    return false
+  }
+  // Why realpath both sides: Git reports the resolved tree, while the request
+  // may name a symlinked or `/private`-prefixed spelling of the same directory.
+  const [candidate, toplevel] = await Promise.all([
+    realpath(candidatePath).catch(() => resolve(candidatePath)),
+    realpath(reported).catch(() => resolve(reported))
+  ])
+  return candidate === toplevel
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​235 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​234 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 |

<!-- /orca-pr-loc -->

Refs #18273

## ELI5

When you install a skill onto an SSH host, the request says "put it in worktree
`worktree_1`, which lives at `<path>`". The relay took that path at face value
and used it as the install root. The one containment check it ran was:

```ts
requireContained(workspaceDirectory, workspaceDirectory)
```

— a directory is always inside itself, so that assertion could never fail. Any
directory the request named became the destination on the host.

Now the host decides. It refuses places that obviously aren't a workspace, and
for a worktree it asks Git whether the directory is really a checkout.

## What changed

**1. Structural rules, in `resolveSkillInstallDestination` (both kinds).**
The workspace directory may not be a filesystem root, may not be the host's home
directory, and may not *contain* the home directory. A checkout under the home
tree — the normal case — still installs. This replaces the vacuous call; the
plan's Step 1 "contain under home" was deliberately **not** used, because the
plan's own STOP condition rules it out: "any subdirectory of home" still permits
`~/.ssh` and `~/.gnupg`.

**2. A Git proof, for worktree destinations, on the relay.**
`git -C <candidate> rev-parse --show-toplevel` must name the candidate itself.
Only a checkout root answers with itself, so `~/.ssh`, `~/.gnupg`, `/etc` and a
path merely *inside* a checkout are all rejected as
`skill-install-workspace-not-found`. `--show-toplevel` is Git 1.7-era, so no
capability probe or fallback is needed.

The relay has no worktree catalog to look an id up in — an Orca worktree id is
client metadata, and `splitWorktreeIdForFilesystem` derives the path *from the
id*, so it is exactly as caller-controlled as `workspace.path`. Verification
against the host's own filesystem is the only authority available here.

**Mixed-version:** `path` stays required on the schema and old clients keep
sending it. It is now a hint the host verifies rather than authority it grants —
no new required field, no new stream opcode
(`docs/reference/remote-wire-compatibility.md` Rules 1–2).

## Tests

- `src/main/skills/skill-install-destinations.test.ts` — home directory, a
  directory containing home, and a filesystem root all throw
  `skill-install-destination-escape`; a real workspace under the home tree still
  resolves.
- `src/relay/skill-install-workspace-authority.test.ts` — a full staged-upload
  install through the relay handler against three claimed paths: `~/.ssh`
  (refused), a real `git init` checkout (installed, `SKILL.md` written under
  `.agents/skills/`), and a subdirectory of that checkout (refused).

### Mutation results (5/5 killed)

| mutation | killed by |
|---|---|
| return the caller's `workspace` with no host check (the bug) | `refuses a client path that is not a checkout on this host`, `refuses a path merely inside a checkout rather than its root` |
| accept any path inside a repo, not just the root | `refuses a path merely inside a checkout rather than its root` |
| restore the vacuous containment call | the 3 structural cases |
| drop only the home-directory rejection | `rejects the execution host home directory as a workspace`, `rejects a directory that contains the execution host home` |
| flip containment so real workspaces are refused | `still accepts a real workspace directory that sits under the home tree` + 1 |

## Known residual — folder workspaces

A **folder** workspace is not necessarily a Git repository, so the Git proof
cannot apply to it without breaking legitimate plain-folder workspaces, and the
relay has no other host-side registry to check it against. Folder destinations
therefore get the structural rules only. Blast radius is bounded — the install
root always has `.agents/skills/<validated-name>` appended, so this creates a
directory rather than overwriting a named file — but a caller can still place
one in any writable directory on the host. Closing it properly needs a host-side
workspace registry (the relay learning which folder roots a session actually
opened), which is larger than this change and worth its own issue. Flagging
rather than shipping a guess.

## Gates

`pnpm tc`, `pnpm test src/relay src/main/skills …` (2327 passed), `oxlint`,
`pnpm run check:code-quality:changed`, `pnpm run check:max-lines-ratchet`,
`pnpm format`.
