### PR TITLE
feat(native-chat): focus the message box when a chat appears

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatResolvedView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatResolvedView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNativeChatComposerRevealFocus } from './use-native-chat-composer-reveal-focus'
 import { useAppStore } from '../../store'
 import { useNativeChatLaunchDraftSignal } from './use-native-chat-launch-draft-adoption'
 import { useNativeChatRetainedSession } from './use-native-chat-retained-session'
@@ -63,6 +64,7 @@ export function NativeChatResolvedView({
   sessionId,
   transcriptPath,
   isVisible,
+  isFocusedGroup,
   targetPtyId,
   terminalTabId,
   ownsTabWideLaunchDraft,
@@ -130,6 +132,13 @@ export function NativeChatResolvedView({
     rootRef,
     composerRef,
     questionAnswerInputRef
+  })
+  useNativeChatComposerRevealFocus({
+    rootRef,
+    composerRef,
+    isVisible,
+    isFocusedGroup,
+    composerReady: !questionActive && targetPtyId !== null && canSend
   })
   const contextMenu = useNativeChatContextMenu({
     rootRef,

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import React, { forwardRef, useImperativeHandle } from 'react'
+import React, { forwardRef, useImperativeHandle, useRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentJournalRenderItem } from '../../../../shared/agent-session-journal-types'
 import type { AgentSessionBackgroundTask } from '../../../../shared/agent-session-wire'
@@ -144,13 +144,18 @@ vi.mock('./NativeChatMessageList', () => ({
 vi.mock('./NativeChatComposer', () => ({
   NativeChatComposer: forwardRef((props: typeof mocks.composerProps, ref) => {
     mocks.composerProps = props
+    const fieldRef = useRef<HTMLTextAreaElement>(null)
     useImperativeHandle(ref, () => ({
-      focus: () => true,
+      // Real DOM focus: the reveal-focus loop retries until focus lands in the pane.
+      focus: () => {
+        fieldRef.current?.focus()
+        return true
+      },
       insertTypedText: () => true,
       handlePasteEvent: mocks.handlePasteEvent,
       pasteFromClipboard: mocks.pasteFromClipboard
     }))
-    return <textarea data-testid="structured-composer" />
+    return <textarea ref={fieldRef} data-testid="structured-composer" />
   })
 }))
 vi.mock('./NativeChatEmptyState', () => ({ NativeChatEmptyState: () => null }))
@@ -192,6 +197,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-paste"
         sessionId="session-paste"
         target={{ kind: 'local' }}
@@ -210,6 +216,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-1"
         sessionId="session-1"
         target={{ kind: 'environment', environmentId: 'env-1' }}
@@ -231,6 +238,7 @@ describe('NativeChatStructuredSession', () => {
       render(
         <NativeChatStructuredSession
           isVisible
+          isFocusedGroup
           tabId="structured-tab-parity"
           sessionId="session-parity"
           target={{ kind: 'local' }}
@@ -247,6 +255,7 @@ describe('NativeChatStructuredSession', () => {
   const claudeSessionView = (tabId: string, sessionId: string) => (
     <NativeChatStructuredSession
       isVisible
+      isFocusedGroup
       tabId={tabId}
       sessionId={sessionId}
       target={{ kind: 'local' }}
@@ -406,6 +415,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-1"
         sessionId="session-1"
         target={{ kind: 'local' }}
@@ -441,6 +451,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-1"
         sessionId="session-1"
         target={{ kind: 'local' }}
@@ -472,6 +483,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-wedge"
         sessionId="session-wedge"
         target={{ kind: 'local' }}
@@ -503,6 +515,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-probe-flag"
         sessionId="session-probe-flag"
         target={{ kind: 'local' }}
@@ -535,6 +548,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-parked"
         sessionId="session-parked"
         target={{ kind: 'local' }}
@@ -584,6 +598,7 @@ describe('NativeChatStructuredSession', () => {
     const makeView = (): React.ReactElement => (
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-churn"
         sessionId="session-churn"
         target={{ kind: 'local' }}
@@ -637,6 +652,7 @@ describe('NativeChatStructuredSession', () => {
     ) => (
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-target-switch"
         sessionId="session-target-switch"
         target={target}
@@ -671,6 +687,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-forced"
         sessionId="session-forced"
         target={{ kind: 'local' }}
@@ -709,6 +726,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-pending"
         sessionId="session-pending"
         target={{ kind: 'local' }}
@@ -738,6 +756,7 @@ describe('NativeChatStructuredSession', () => {
       render(
         <NativeChatStructuredSession
           isVisible
+          isFocusedGroup
           tabId="structured-tab-budget"
           sessionId="session-budget"
           target={{ kind: 'local' }}
@@ -808,6 +827,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-questions"
         sessionId="session-questions"
         target={{ kind: 'local' }}
@@ -866,6 +886,7 @@ describe('NativeChatStructuredSession', () => {
     render(
       <NativeChatStructuredSession
         isVisible
+        isFocusedGroup
         tabId="structured-tab-legacy-question"
         sessionId="session-legacy-question"
         target={{ kind: 'local' }}

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -11,6 +11,7 @@ import { NativeChatEmptyState } from './NativeChatEmptyState'
 import { NativeChatMessageList } from './NativeChatMessageList'
 import { NativeChatQuestionCard } from './NativeChatQuestionCard'
 import { selectNativeChatViewState } from './native-chat-view-state'
+import { useNativeChatComposerRevealFocus } from './use-native-chat-composer-reveal-focus'
 import { useNativeChatFontScale } from './use-native-chat-font-scale'
 import { LinkActionPopover } from '@/components/link-actions/LinkActionPopover'
 import { useNativeChatLinkActions } from './use-native-chat-link-actions'
@@ -99,6 +100,13 @@ export function NativeChatStructuredSession(
   const activeStoppingBackgroundTasks =
     stoppingBackgroundTasks?.sessionId === props.sessionId ? stoppingBackgroundTasks : null
   const prompt = controller.prompts[0] ?? null
+  useNativeChatComposerRevealFocus({
+    rootRef,
+    composerRef,
+    isVisible: props.isVisible,
+    isFocusedGroup: props.isFocusedGroup,
+    composerReady: prompt === null
+  })
   const questionBody = prompt?.body.kind === 'question' ? prompt.body : null
   const questions =
     questionBody?.questions ??

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -17,6 +17,7 @@ export default function NativeChatView(props: NativeChatViewProps): React.JSX.El
 function NativeChatBridgeView({
   terminalTabId,
   isVisible,
+  isFocusedGroup,
   paneKey: preferredPaneKey,
   targetPtyId = null,
   launchAgent,
@@ -45,6 +46,7 @@ function NativeChatBridgeView({
           sessionId={resolution.sessionId}
           transcriptPath={resolution.transcriptPath}
           isVisible={isVisible}
+          isFocusedGroup={isFocusedGroup}
           targetPtyId={targetPtyId}
           terminalTabId={terminalTabId}
           ownsTabWideLaunchDraft={ownsTabWideLaunchDraft}

--- a/src/renderer/src/components/native-chat/StructuredAgentSessionPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionPaneOverlayLayer.test.tsx
@@ -7,6 +7,7 @@ import type { Tab, TabGroup } from '../../../../shared/tab-types'
 type MockAppState = {
   unifiedTabsByWorktree: Record<string, readonly Tab[]>
   groupsByWorktree: Record<string, readonly TabGroup[]>
+  activeGroupIdByWorktree: Record<string, string>
   runtimeEnvironmentId: string | null
   focusGroup: (worktreeId: string, groupId: string) => void
 }
@@ -24,6 +25,7 @@ vi.mock('@/store', async () => {
   const useAppStore = create<MockAppState>(() => ({
     unifiedTabsByWorktree: {},
     groupsByWorktree: {},
+    activeGroupIdByWorktree: {},
     runtimeEnvironmentId: null,
     focusGroup: mocks.focusGroup
   }))
@@ -52,11 +54,13 @@ vi.mock('./NativeChatView', async () => {
     default: function MockNativeChatView({
       tabId,
       groupId,
-      isVisible
+      isVisible,
+      isFocusedGroup
     }: {
       tabId: string
       groupId?: string
       isVisible: boolean
+      isFocusedGroup: boolean
     }) {
       mocks.groupIdByTabId.set(tabId, groupId)
       useEffect(() => {
@@ -69,6 +73,7 @@ vi.mock('./NativeChatView', async () => {
         <span
           data-chat-tab-id={tabId}
           data-chat-visible={String(isVisible)}
+          data-chat-focused-group={String(isFocusedGroup)}
           data-native-chat-working="true"
         />
       )
@@ -80,6 +85,7 @@ import StructuredAgentSessionPaneOverlayLayer from './StructuredAgentSessionPane
 
 const WORKTREE_ID = 'wt-1'
 const GROUP_ID = 'group-1'
+const SECOND_GROUP_ID = 'group-2'
 const FIRST_TAB_ID = 'structured-agent-session-session-1'
 const SECOND_TAB_ID = 'structured-agent-session-session-2'
 
@@ -164,6 +170,52 @@ describe('StructuredAgentSessionPaneOverlayLayer', () => {
     expect(slot?.style.zIndex).toBe('')
     expect(slot?.querySelector('[data-native-chat-working="true"]')).not.toBeNull()
   })
+
+  it('marks only the focused split column as the focused group', () => {
+    act(() => {
+      mocks.store?.setState({
+        unifiedTabsByWorktree: {
+          [WORKTREE_ID]: [
+            structuredTab(FIRST_TAB_ID, 'session-1', 0),
+            { ...structuredTab(SECOND_TAB_ID, 'session-2', 1), groupId: SECOND_GROUP_ID }
+          ]
+        },
+        groupsByWorktree: {
+          [WORKTREE_ID]: [
+            createGroup(FIRST_TAB_ID),
+            {
+              id: SECOND_GROUP_ID,
+              worktreeId: WORKTREE_ID,
+              activeTabId: SECOND_TAB_ID,
+              tabOrder: [SECOND_TAB_ID]
+            }
+          ]
+        },
+        activeGroupIdByWorktree: { [WORKTREE_ID]: SECOND_GROUP_ID }
+      })
+    })
+    const view = render(
+      <StructuredAgentSessionPaneOverlayLayer worktreeId={WORKTREE_ID} isWorktreeActive />
+    )
+
+    // Both columns are revealed at once; only the focused one may take the caret.
+    expect(chatSurface(view.container, FIRST_TAB_ID).dataset.chatVisible).toBe('true')
+    expect(chatSurface(view.container, SECOND_TAB_ID).dataset.chatVisible).toBe('true')
+    expect(chatSurface(view.container, FIRST_TAB_ID).dataset.chatFocusedGroup).toBe('false')
+    expect(chatSurface(view.container, SECOND_TAB_ID).dataset.chatFocusedGroup).toBe('true')
+  })
+
+  it('marks no column as focused when the focused group id names nothing', () => {
+    act(() => {
+      mocks.store?.setState({ activeGroupIdByWorktree: { [WORKTREE_ID]: 'group-removed' } })
+    })
+    const view = render(
+      <StructuredAgentSessionPaneOverlayLayer worktreeId={WORKTREE_ID} isWorktreeActive />
+    )
+
+    expect(chatSurface(view.container, FIRST_TAB_ID).dataset.chatVisible).toBe('true')
+    expect(chatSurface(view.container, FIRST_TAB_ID).dataset.chatFocusedGroup).toBe('false')
+  })
 })
 
 function createState(activeTabId: string): MockAppState {
@@ -175,6 +227,7 @@ function createState(activeTabId: string): MockAppState {
       ]
     },
     groupsByWorktree: { [WORKTREE_ID]: [createGroup(activeTabId)] },
+    activeGroupIdByWorktree: { [WORKTREE_ID]: GROUP_ID },
     runtimeEnvironmentId: null,
     focusGroup: mocks.focusGroup
   }

--- a/src/renderer/src/components/native-chat/StructuredAgentSessionPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionPaneOverlayLayer.tsx
@@ -20,12 +20,14 @@ const StructuredAgentSessionOverlaySlot = memo(function StructuredAgentSessionOv
   tab,
   groupId,
   isActive,
+  isFocusedGroup,
   target,
   onFocusOwningGroup
 }: {
   tab: StructuredAgentSessionTab
   groupId: string | undefined
   isActive: boolean
+  isFocusedGroup: boolean
   target: RuntimeClientTarget
   onFocusOwningGroup: ((groupId: string) => void) | undefined
 }): React.JSX.Element {
@@ -43,6 +45,7 @@ const StructuredAgentSessionOverlaySlot = memo(function StructuredAgentSessionOv
         sessionId={tab.entityId}
         agent={tab.agentSessionAgent}
         isVisible={isActive}
+        isFocusedGroup={isFocusedGroup}
         target={target}
       />
     </RetainedPaneHost>
@@ -57,11 +60,12 @@ const StructuredAgentSessionPaneOverlayLayer = memo(
     worktreeId: string
     isWorktreeActive: boolean
   }): React.JSX.Element {
-    const { unifiedTabs, groups, runtimeEnvironmentId } = useAppStore(
+    const { unifiedTabs, groups, runtimeEnvironmentId, activeGroupId } = useAppStore(
       useShallow((state) => ({
         unifiedTabs: state.unifiedTabsByWorktree[worktreeId] ?? EMPTY_UNIFIED_TABS,
         groups: state.groupsByWorktree[worktreeId] ?? EMPTY_GROUPS,
-        runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+        runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId),
+        activeGroupId: state.activeGroupIdByWorktree[worktreeId]
       }))
     )
     const focusGroup = useAppStore((state) => state.focusGroup)
@@ -95,6 +99,11 @@ const StructuredAgentSessionPaneOverlayLayer = memo(
             tab={tab}
             groupId={tab.groupId}
             isActive={Boolean(isWorktreeActive && groupActiveTabById.get(tab.groupId) === tab.id)}
+            isFocusedGroup={Boolean(
+              isWorktreeActive &&
+              groupActiveTabById.get(tab.groupId) === tab.id &&
+              tab.groupId === activeGroupId
+            )}
             target={target}
             onFocusOwningGroup={focusOwningGroup}
           />

--- a/src/renderer/src/components/native-chat/native-chat-composer-reveal-focus.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-composer-reveal-focus.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { act, createElement, useRef } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { useNativeChatComposerRevealFocus } from './use-native-chat-composer-reveal-focus'
+import type { NativeChatComposerHandle } from './NativeChatComposer'
+
+type HarnessProps = {
+  isVisible: boolean
+  isFocusedGroup: boolean
+  composerReady?: boolean
+  /** Composer handle is unavailable until this many focus attempts have run. */
+  readyAfterAttempts?: number
+  onFocus?: () => void
+  /** Rerender-only churn, to prove the latch holds. */
+  nonce?: number
+}
+
+let container: HTMLDivElement
+let root: Root
+let frames: (() => void)[] = []
+let focusCalls = 0
+
+/** Drain queued frames; each drained frame may queue the next. */
+function drainFrames(max = 20): void {
+  for (let i = 0; i < max && frames.length > 0; i += 1) {
+    const queued = frames
+    frames = []
+    act(() => {
+      for (const frame of queued) {
+        frame()
+      }
+    })
+  }
+}
+
+function Harness(props: HarnessProps): React.JSX.Element {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const fieldRef = useRef<HTMLTextAreaElement>(null)
+  const attemptsRef = useRef(0)
+  const composerRef = useRef<NativeChatComposerHandle>(null)
+  composerRef.current = {
+    focus: () => {
+      attemptsRef.current += 1
+      focusCalls += 1
+      props.onFocus?.()
+      if (attemptsRef.current <= (props.readyAfterAttempts ?? 0)) {
+        return false
+      }
+      fieldRef.current?.focus()
+      return true
+    },
+    insertTypedText: () => true,
+    handlePasteEvent: () => {},
+    pasteFromClipboard: () => {}
+  } as NativeChatComposerHandle
+  useNativeChatComposerRevealFocus({
+    rootRef,
+    composerRef,
+    isVisible: props.isVisible,
+    isFocusedGroup: props.isFocusedGroup,
+    composerReady: props.composerReady ?? true,
+    scheduleFrame: (callback) => {
+      frames.push(callback)
+    }
+  })
+  return createElement(
+    'div',
+    { ref: rootRef },
+    createElement('textarea', { ref: fieldRef, 'data-testid': 'composer' }),
+    createElement('button', { type: 'button', 'data-testid': 'in-pane-button' })
+  )
+}
+
+function render(props: HarnessProps): void {
+  act(() => {
+    root.render(createElement(Harness, props))
+  })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  frames = []
+  focusCalls = 0
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+describe('useNativeChatComposerRevealFocus', () => {
+  it('focuses when it mounts already revealed', () => {
+    render({ isVisible: true, isFocusedGroup: true })
+    expect(focusCalls).toBe(0)
+    drainFrames()
+    expect(focusCalls).toBe(1)
+    expect(container.querySelector('textarea')).toBe(document.activeElement)
+  })
+
+  it('focuses on the isVisible edge', () => {
+    render({ isVisible: false, isFocusedGroup: true })
+    drainFrames()
+    expect(focusCalls).toBe(0)
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+  })
+
+  it('focuses on the isFocusedGroup edge alone', () => {
+    render({ isVisible: true, isFocusedGroup: false })
+    drainFrames()
+    expect(focusCalls).toBe(0)
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+  })
+
+  it('lets only the focused group claim when two panes are revealed together', () => {
+    const other = document.createElement('div')
+    document.body.appendChild(other)
+    const otherRoot = createRoot(other)
+    act(() => {
+      root.render(createElement(Harness, { isVisible: true, isFocusedGroup: true }))
+      otherRoot.render(createElement(Harness, { isVisible: true, isFocusedGroup: false }))
+    })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+    act(() => {
+      otherRoot.unmount()
+    })
+    other.remove()
+  })
+
+  it('holds the latch across unrelated rerenders', () => {
+    render({ isVisible: true, isFocusedGroup: true, nonce: 1 })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+    render({ isVisible: true, isFocusedGroup: true, nonce: 2 })
+    render({ isVisible: true, isFocusedGroup: true, nonce: 3 })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+  })
+
+  // A button is neither inside-pane-focus nor an editable field, so only the latch can stop this.
+  it('does not chase focus the user moved to a control outside the pane', () => {
+    render({ isVisible: true, isFocusedGroup: true, nonce: 1 })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    act(() => {
+      outside.focus()
+    })
+    render({ isVisible: true, isFocusedGroup: true, nonce: 2 })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+    expect(document.activeElement).toBe(outside)
+    outside.remove()
+  })
+
+  // Non-editable, so only the inside-the-pane check can stop this one.
+  it('leaves focus on a non-editable control inside the pane', () => {
+    render({ isVisible: false, isFocusedGroup: true })
+    const button = container.querySelector('button')
+    act(() => {
+      button?.focus()
+    })
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames()
+    expect(focusCalls).toBe(0)
+    expect(document.activeElement).toBe(button)
+  })
+
+  it('re-arms after the pane is hidden and revealed again', () => {
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames()
+    render({ isVisible: false, isFocusedGroup: true })
+    drainFrames()
+    act(() => {
+      ;(document.activeElement as HTMLElement | null)?.blur()
+    })
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames()
+    expect(focusCalls).toBe(2)
+  })
+
+  it('retries across frames until the composer takes focus', () => {
+    render({ isVisible: true, isFocusedGroup: true, readyAfterAttempts: 2 })
+    drainFrames()
+    expect(focusCalls).toBe(3)
+    expect(container.querySelector('textarea')).toBe(document.activeElement)
+  })
+
+  it('gives up after a bounded number of attempts', () => {
+    render({ isVisible: true, isFocusedGroup: true, readyAfterAttempts: 99 })
+    drainFrames()
+    expect(focusCalls).toBe(6)
+  })
+
+  it('waits for a composer that is not ready yet, then focuses', () => {
+    render({ isVisible: true, isFocusedGroup: true, composerReady: false })
+    drainFrames()
+    expect(focusCalls).toBe(0)
+    render({ isVisible: true, isFocusedGroup: true, composerReady: true })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+  })
+
+  it('leaves focus alone when it is already inside the pane', () => {
+    render({ isVisible: false, isFocusedGroup: true })
+    const field = container.querySelector('textarea')
+    act(() => {
+      field?.focus()
+    })
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames()
+    expect(focusCalls).toBe(0)
+  })
+
+  it('leaves a live text field outside the pane alone', () => {
+    const outside = document.createElement('input')
+    document.body.appendChild(outside)
+    outside.focus()
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames()
+    expect(focusCalls).toBe(0)
+    expect(document.activeElement).toBe(outside)
+    outside.remove()
+  })
+
+  it('still claims focus from the covered xterm helper textarea', () => {
+    const helper = document.createElement('textarea')
+    helper.className = 'xterm-helper-textarea'
+    document.body.appendChild(helper)
+    helper.focus()
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+    expect(container.querySelector('textarea')).toBe(document.activeElement)
+    helper.remove()
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-composer-reveal-focus.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-composer-reveal-focus.test.tsx
@@ -147,17 +147,59 @@ describe('useNativeChatComposerRevealFocus', () => {
     expect(focusCalls).toBe(1)
   })
 
-  // A button is neither inside-pane-focus nor an editable field, so only the latch can stop this.
-  it('does not chase focus the user moved to a control outside the pane', () => {
+  it('reclaims focus after delayed programmatic restoration', () => {
     render({ isVisible: true, isFocusedGroup: true, nonce: 1 })
-    drainFrames()
+    drainFrames(1)
     expect(focusCalls).toBe(1)
     const outside = document.createElement('button')
     document.body.appendChild(outside)
     act(() => {
       outside.focus()
     })
-    render({ isVisible: true, isFocusedGroup: true, nonce: 2 })
+    drainFrames()
+    expect(focusCalls).toBe(2)
+    expect(container.querySelector('textarea')).toBe(document.activeElement)
+    outside.remove()
+  })
+
+  it('does not chase focus after the user moves to a control outside the pane', () => {
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames(1)
+    expect(focusCalls).toBe(1)
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    act(() => {
+      outside.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+      outside.focus()
+    })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+    expect(document.activeElement).toBe(outside)
+    outside.remove()
+  })
+
+  it('does not cancel a scheduled claim when the user types immediately', () => {
+    render({ isVisible: true, isFocusedGroup: true })
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }))
+    })
+    drainFrames()
+    expect(focusCalls).toBe(1)
+    expect(container.querySelector('textarea')).toBe(document.activeElement)
+  })
+
+  it('does not chase focus after the user tabs away', () => {
+    render({ isVisible: true, isFocusedGroup: true })
+    drainFrames(1)
+    expect(focusCalls).toBe(1)
+    const outside = document.createElement('button')
+    document.body.appendChild(outside)
+    act(() => {
+      document.activeElement?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true })
+      )
+      outside.focus()
+    })
     drainFrames()
     expect(focusCalls).toBe(1)
     expect(document.activeElement).toBe(outside)

--- a/src/renderer/src/components/native-chat/native-chat-view-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-view-types.ts
@@ -10,6 +10,8 @@ export type NativeChatBridgeViewProps = {
   terminalTabId: string
   /** Whether the hosted terminal surface is currently visible. */
   isVisible: boolean
+  /** This pane's split group holds focus; a revealed sibling column must not take the caret. */
+  isFocusedGroup: boolean
   /** Specific split leaf this chat surface replaces. */
   paneKey?: string
   /** PTY bound to `paneKey`, used for composer and interactive-card sends. */
@@ -35,6 +37,8 @@ export type NativeChatStructuredViewProps = {
   target: RuntimeClientTarget
   agent: AgentType
   isVisible: boolean
+  /** This pane's split group holds focus; a revealed sibling column must not take the caret. */
+  isFocusedGroup: boolean
   contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>
 }
 
@@ -44,6 +48,8 @@ export type NativeChatResolvedViewProps = {
   sessionId: string | null
   transcriptPath: string | null
   isVisible: boolean
+  /** This pane's split group holds focus; a revealed sibling column must not take the caret. */
+  isFocusedGroup: boolean
   targetPtyId: string | null
   terminalTabId: string
   ownsTabWideLaunchDraft: boolean

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-reveal-focus.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-reveal-focus.ts
@@ -4,7 +4,7 @@ import { shouldPreserveEditableFocus } from '@/components/terminal-pane/pane-hel
 import { scheduleNextFrame } from '@/components/terminal-pane/terminal-ime-input-context-refresh'
 import type { NativeChatComposerHandle } from './NativeChatComposer'
 
-/** Frames a reveal keeps re-taking the composer before it gives up (~100ms). */
+/** Focus attempts per reveal, including recovery from delayed programmatic restoration. */
 const REVEAL_FOCUS_FRAMES = 6
 
 type NativeChatComposerRevealFocusArgs = {
@@ -44,21 +44,45 @@ export function useNativeChatComposerRevealFocus({
       return
     }
     let cancelled = false
+    let userInteracted = false
     let attempts = 0
+    const ownerDocument = rootRef.current?.ownerDocument
+    const cancelForPointer = (): void => {
+      userInteracted = true
+    }
+    const cancelForFocusNavigation = (event: KeyboardEvent): void => {
+      if (event.key === 'Tab') {
+        userInteracted = true
+      }
+    }
+    const stopWatchingUserIntent = (): void => {
+      ownerDocument?.removeEventListener('pointerdown', cancelForPointer, true)
+      ownerDocument?.removeEventListener('keydown', cancelForFocusNavigation, true)
+    }
+    const finish = (): void => {
+      claimedRef.current = true
+      stopWatchingUserIntent()
+    }
+    ownerDocument?.addEventListener('pointerdown', cancelForPointer, true)
+    ownerDocument?.addEventListener('keydown', cancelForFocusNavigation, true)
     const claim = (): void => {
       if (cancelled) {
+        return
+      }
+      if (userInteracted) {
+        finish()
         return
       }
       const active = rootRef.current?.ownerDocument.activeElement ?? null
       // Focus already inside this pane is our own take landing or the user's click; either ends it.
       if (rootRef.current?.contains(active) === true) {
-        claimedRef.current = true
+        finish()
         return
       }
       // Why: a live text field elsewhere is a user edit — a batch worktree-create keeps its
       // next name field open behind the pane we just revealed.
       if (shouldPreserveEditableFocus(active)) {
-        claimedRef.current = true
+        finish()
         return
       }
       composerRef.current?.focus()
@@ -67,13 +91,14 @@ export function useNativeChatComposerRevealFocus({
         scheduleFrame(claim)
         return
       }
-      claimedRef.current = true
+      finish()
     }
     // Why: Radix restores the dialog trigger in a setTimeout(0) on close, which beats a
     // same-tick take; a frame lands after it.
     scheduleFrame(claim)
     return () => {
       cancelled = true
+      stopWatchingUserIntent()
     }
   }, [composerReady, composerRef, revealed, rootRef, scheduleFrame])
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-reveal-focus.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-reveal-focus.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
+import { shouldPreserveEditableFocus } from '@/components/terminal-pane/pane-helpers'
+import { scheduleNextFrame } from '@/components/terminal-pane/terminal-ime-input-context-refresh'
+import type { NativeChatComposerHandle } from './NativeChatComposer'
+
+/** Frames a reveal keeps re-taking the composer before it gives up (~100ms). */
+const REVEAL_FOCUS_FRAMES = 6
+
+type NativeChatComposerRevealFocusArgs = {
+  rootRef: RefObject<HTMLElement | null>
+  composerRef: RefObject<NativeChatComposerHandle | null>
+  isVisible: boolean
+  /** This pane's split group is the focused one; false keeps a revealed sibling from fighting. */
+  isFocusedGroup: boolean
+  /** A composer is mounted and enabled — false while a prompt/question card owns the region. */
+  composerReady: boolean
+  /** Override the frame scheduler (tests). */
+  scheduleFrame?: (callback: () => void) => void
+}
+
+/**
+ * Focus the composer whenever this pane reveals it, so a chat you just opened —
+ * or switched back to — is ready to type into. Retained panes never unmount, so
+ * the reveal edge, not mount, is the signal.
+ */
+export function useNativeChatComposerRevealFocus({
+  rootRef,
+  composerRef,
+  isVisible,
+  isFocusedGroup,
+  composerReady,
+  scheduleFrame = scheduleNextFrame
+}: NativeChatComposerRevealFocusArgs): void {
+  const revealed = isVisible && isFocusedGroup
+  const claimedRef = useRef(false)
+
+  useEffect(() => {
+    if (!revealed) {
+      claimedRef.current = false
+      return
+    }
+    if (claimedRef.current || !composerReady) {
+      return
+    }
+    let cancelled = false
+    let attempts = 0
+    const claim = (): void => {
+      if (cancelled) {
+        return
+      }
+      const active = rootRef.current?.ownerDocument.activeElement ?? null
+      // Focus already inside this pane is our own take landing or the user's click; either ends it.
+      if (rootRef.current?.contains(active) === true) {
+        claimedRef.current = true
+        return
+      }
+      // Why: a live text field elsewhere is a user edit — a batch worktree-create keeps its
+      // next name field open behind the pane we just revealed.
+      if (shouldPreserveEditableFocus(active)) {
+        claimedRef.current = true
+        return
+      }
+      composerRef.current?.focus()
+      attempts += 1
+      if (attempts < REVEAL_FOCUS_FRAMES) {
+        scheduleFrame(claim)
+        return
+      }
+      claimedRef.current = true
+    }
+    // Why: Radix restores the dialog trigger in a setTimeout(0) on close, which beats a
+    // same-tick take; a frame lands after it.
+    scheduleFrame(claim)
+    return () => {
+      cancelled = true
+    }
+  }, [composerReady, composerRef, revealed, rootRef, scheduleFrame])
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPaneNativeChatPortal.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneNativeChatPortal.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalPaneController } from './use-terminal-pane-controller'
+
+const mocks = vi.hoisted(() => ({
+  nativeChatViewProps: null as null | { isFocusedGroup: boolean }
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (
+    selector: (state: {
+      agentStatusByPaneKey: Record<string, never>
+      sleepingAgentSessionsByPaneKey: Record<string, never>
+      paneForegroundAgentByPaneKey: Record<string, never>
+    }) => unknown
+  ) =>
+    selector({
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {},
+      paneForegroundAgentByPaneKey: {}
+    })
+}))
+
+vi.mock('../native-chat/NativeChatView', () => ({
+  default: (props: { isFocusedGroup: boolean }) => {
+    mocks.nativeChatViewProps = props
+    return <span data-focused-group={String(props.isFocusedGroup)} />
+  }
+}))
+
+import { TerminalPaneNativeChatPortal } from './TerminalPaneNativeChatPortal'
+
+afterEach(() => {
+  cleanup()
+  mocks.nativeChatViewProps = null
+})
+
+describe('TerminalPaneNativeChatPortal', () => {
+  it.each([
+    ['pty-backed', false],
+    ['structured', true]
+  ] as const)(
+    'only gives the %s composer focus ownership to the active split leaf',
+    (_, structured) => {
+      const portalContainer = document.createElement('div')
+      document.body.appendChild(portalContainer)
+      const view = render(
+        <TerminalPaneNativeChatPortal
+          controller={makeController(portalContainer, {
+            activePaneIsChatLeaf: false,
+            structured
+          })}
+        />
+      )
+
+      expect(mocks.nativeChatViewProps?.isFocusedGroup).toBe(false)
+
+      view.rerender(
+        <TerminalPaneNativeChatPortal
+          controller={makeController(portalContainer, { activePaneIsChatLeaf: true, structured })}
+        />
+      )
+      expect(mocks.nativeChatViewProps?.isFocusedGroup).toBe(true)
+
+      portalContainer.remove()
+    }
+  )
+})
+
+function makeController(
+  portalContainer: HTMLElement,
+  overrides: { activePaneIsChatLeaf: boolean; structured: boolean }
+): TerminalPaneController {
+  const chatPane = {
+    id: 1,
+    leafId: '11111111-1111-4111-8111-111111111111',
+    container: portalContainer
+  }
+  return {
+    chatPane,
+    chatPaneLaunchAgent: null,
+    chatPaneOwnsTabWideLaunchDraft: false,
+    chatPanePtyId: null,
+    chatPaneResolvedAgent: null,
+    contextMenu: {
+      runForPane: vi.fn()
+    },
+    effectiveChatViewMode: true,
+    expandedPaneId: null,
+    activePaneIsChatLeaf: overrides.activePaneIsChatLeaf,
+    isActive: true,
+    isRendererVisible: true,
+    managedPanes: [chatPane, { id: 2, leafId: '22222222-2222-4222-8222-222222222222' }],
+    readNativeChatTerminalScreen: vi.fn(),
+    resolveAgentForLeaf: vi.fn(() => null),
+    structuredChatAgent: overrides.structured ? 'codex' : null,
+    structuredChatTarget: { kind: 'local' },
+    structuredSessionId: overrides.structured ? 'session-1' : null,
+    switchNativeChatToTerminal: vi.fn(),
+    tabId: 'tab-1',
+    unifiedTabId: null
+  } as unknown as TerminalPaneController
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPaneNativeChatPortal.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneNativeChatPortal.tsx
@@ -20,6 +20,7 @@ export function TerminalPaneNativeChatPortal({
     contextMenu,
     effectiveChatViewMode,
     expandedPaneId,
+    activePaneIsChatLeaf,
     isActive,
     isRendererVisible,
     managedPanes,
@@ -75,7 +76,7 @@ export function TerminalPaneNativeChatPortal({
           sessionId={structuredSessionId}
           agent={structuredChatAgent}
           isVisible={isRendererVisible}
-          isFocusedGroup={isActive}
+          isFocusedGroup={isActive && activePaneIsChatLeaf}
           target={structuredChatTarget}
           contextMenuActions={contextMenuActions}
         />
@@ -83,7 +84,7 @@ export function TerminalPaneNativeChatPortal({
         <NativeChatView
           terminalTabId={tabId}
           isVisible={isRendererVisible}
-          isFocusedGroup={isActive}
+          isFocusedGroup={isActive && activePaneIsChatLeaf}
           paneKey={makePaneKey(tabId, chatPane.leafId)}
           targetPtyId={chatPanePtyId}
           launchAgent={chatPaneLaunchAgent}

--- a/src/renderer/src/components/terminal-pane/TerminalPaneNativeChatPortal.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneNativeChatPortal.tsx
@@ -20,6 +20,7 @@ export function TerminalPaneNativeChatPortal({
     contextMenu,
     effectiveChatViewMode,
     expandedPaneId,
+    isActive,
     isRendererVisible,
     managedPanes,
     readNativeChatTerminalScreen,
@@ -74,6 +75,7 @@ export function TerminalPaneNativeChatPortal({
           sessionId={structuredSessionId}
           agent={structuredChatAgent}
           isVisible={isRendererVisible}
+          isFocusedGroup={isActive}
           target={structuredChatTarget}
           contextMenuActions={contextMenuActions}
         />
@@ -81,6 +83,7 @@ export function TerminalPaneNativeChatPortal({
         <NativeChatView
           terminalTabId={tabId}
           isVisible={isRendererVisible}
+          isFocusedGroup={isActive}
           paneKey={makePaneKey(tabId, chatPane.leafId)}
           targetPtyId={chatPanePtyId}
           launchAgent={chatPaneLaunchAgent}

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -45,7 +45,7 @@ export function isLinuxUserAgent(
   return !isMacUserAgent(userAgent) && !isWindowsUserAgent(userAgent) && userAgent.includes('Linux')
 }
 
-function shouldPreserveEditableFocus(element: Element | null): boolean {
+export function shouldPreserveEditableFocus(element: Element | null): boolean {
   if (!(element instanceof HTMLElement)) {
     return false
   }

--- a/src/renderer/src/lib/workspace-activation-terminal-focus.test.ts
+++ b/src/renderer/src/lib/workspace-activation-terminal-focus.test.ts
@@ -1,3 +1,4 @@
+import type * as SyncRuntimeGraphModule from '@/runtime/sync-runtime-graph'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const focusTerminalTabSurfaceMock = vi.hoisted(() => vi.fn())
@@ -19,6 +20,8 @@ vi.mock('@/store', () => ({
 }))
 
 import { queueWorkspaceActivationTerminalFocus } from './workspace-activation-terminal-focus'
+
+const CHAT_VIEW_LEAF_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
 
 type FocusState = {
   activeWorktreeId: string | null
@@ -96,6 +99,57 @@ describe('queueWorkspaceActivationTerminalFocus', () => {
 
     expect(focusRuntimeTerminalSurfaceMock).toHaveBeenCalledWith('tab-1', null, 'wt-1')
     expect(focusTerminalTabSurfaceMock).not.toHaveBeenCalled()
+  })
+
+  // Why: a legacy native chat is a terminal tab whose xterm stays mounted under the chat portal.
+  // Activation must leave the caret in the composer, so neither the runtime path's xterm focus
+  // nor the DOM fallback may fire. Runs the real runtime surface, not the module mock.
+  it('leaves a chat-view terminal tab unfocused on both the runtime and DOM paths', async () => {
+    const runtime = await vi.importActual<typeof SyncRuntimeGraphModule>(
+      '@/runtime/sync-runtime-graph'
+    )
+    focusRuntimeTerminalSurfaceMock.mockImplementation(runtime.focusRuntimeTerminalSurface)
+    const focus = vi.fn()
+    const pane = {
+      id: 1,
+      leafId: CHAT_VIEW_LEAF_ID,
+      container: {
+        querySelector: (selector: string) =>
+          selector === '.native-chat-pane-shell' ? ({} as Element) : null
+      },
+      terminal: { focus }
+    }
+    const manager = {
+      getPanes: () => [pane],
+      getActivePane: () => pane,
+      getLeafId: () => CHAT_VIEW_LEAF_ID,
+      getNumericIdForLeaf: () => pane.id,
+      setActivePane: vi.fn()
+    }
+    const unregister = runtime.registerRuntimeTerminalTab({
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      getManager: () => manager as never,
+      getContainer: () => null,
+      getPtyIdForPane: () => null,
+      getTabWideAgentHintLeafId: () => null
+    })
+    try {
+      setFocusState({
+        activeWorktreeId: 'wt-1',
+        activeView: 'terminal',
+        activeTabType: 'terminal',
+        activeTabId: 'tab-1'
+      })
+
+      queueWorkspaceActivationTerminalFocus('wt-1', { primaryTabId: 'tab-1' })
+      flushFrame()
+
+      expect(focus).not.toHaveBeenCalled()
+      expect(focusTerminalTabSurfaceMock).not.toHaveBeenCalled()
+    } finally {
+      unregister()
+    }
   })
 
   // Why: #9939 — the return value is what stops the palette from running its whole-document

--- a/src/renderer/src/runtime/focus-runtime-terminal-surface-chat-view.test.ts
+++ b/src/renderer/src/runtime/focus-runtime-terminal-surface-chat-view.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { focusRuntimeTerminalSurface, registerRuntimeTerminalTab } from './sync-runtime-graph'
+
+const TAB_ID = 'chat-view-tab'
+const WORKTREE_ID = 'chat-view-worktree'
+const LEAF_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const PANE_ID = 1
+
+const unregisterCallbacks: (() => void)[] = []
+
+/** The cover class TerminalPaneNativeChatPortal renders over the still-mounted xterm. */
+function makePaneContainer(covered: boolean): HTMLElement {
+  const container = document.createElement('div')
+  container.setAttribute('data-leaf-id', LEAF_ID)
+  if (covered) {
+    const shell = document.createElement('div')
+    shell.className = 'native-chat-pane-shell absolute inset-0 z-10 flex'
+    container.append(shell)
+  }
+  return container
+}
+
+function registerChatViewTab(covered: boolean): {
+  focus: ReturnType<typeof vi.fn>
+  setActivePane: ReturnType<typeof vi.fn>
+} {
+  const focus = vi.fn()
+  const setActivePane = vi.fn()
+  const pane = {
+    id: PANE_ID,
+    leafId: LEAF_ID,
+    container: makePaneContainer(covered),
+    terminal: { focus }
+  }
+  const manager = {
+    getPanes: () => [pane],
+    getActivePane: () => pane,
+    getLeafId: (paneId: number) => (paneId === pane.id ? pane.leafId : null),
+    getNumericIdForLeaf: (candidateLeafId: string) =>
+      candidateLeafId === pane.leafId ? pane.id : null,
+    setActivePane
+  }
+  unregisterCallbacks.push(
+    registerRuntimeTerminalTab({
+      tabId: TAB_ID,
+      worktreeId: WORKTREE_ID,
+      getManager: () => manager as never,
+      getContainer: () => null,
+      getPtyIdForPane: () => null,
+      getTabWideAgentHintLeafId: () => null
+    })
+  )
+  return { focus, setActivePane }
+}
+
+// Why: a legacy native chat is a terminal tab with viewMode 'chat' — the xterm stays mounted
+// under the chat portal, so focusing it drags the caret out of the composer (#9939 twin).
+describe('focusRuntimeTerminalSurface on a chat-view pane', () => {
+  afterEach(() => {
+    while (unregisterCallbacks.length > 0) {
+      unregisterCallbacks.pop()?.()
+    }
+  })
+
+  it('claims focus without touching the covered xterm', () => {
+    const { focus } = registerChatViewTab(true)
+
+    // Why true, not false: false routes the caller to the DOM fallback, which for a structured
+    // tab id finds no [data-terminal-tab-id] element and focuses an unrelated tab's xterm.
+    expect(focusRuntimeTerminalSurface(TAB_ID, null, WORKTREE_ID)).toBe(true)
+    expect(focus).not.toHaveBeenCalled()
+  })
+
+  it('focuses the active xterm when no chat portal covers it', () => {
+    const { focus } = registerChatViewTab(false)
+
+    expect(focusRuntimeTerminalSurface(TAB_ID, null, WORKTREE_ID)).toBe(true)
+    expect(focus).toHaveBeenCalledOnce()
+  })
+
+  it('does not activate the requested leaf with focus while the chat portal covers it', () => {
+    const { setActivePane } = registerChatViewTab(true)
+
+    expect(focusRuntimeTerminalSurface(TAB_ID, LEAF_ID, WORKTREE_ID)).toBe(true)
+    expect(setActivePane).not.toHaveBeenCalled()
+  })
+
+  it('activates the requested leaf with focus when no chat portal covers it', () => {
+    const { setActivePane } = registerChatViewTab(false)
+
+    expect(focusRuntimeTerminalSurface(TAB_ID, LEAF_ID, WORKTREE_ID)).toBe(true)
+    expect(setActivePane).toHaveBeenCalledWith(PANE_ID, { focus: true })
+  })
+})

--- a/src/renderer/src/runtime/focus-runtime-terminal-surface-chat-view.test.ts
+++ b/src/renderer/src/runtime/focus-runtime-terminal-surface-chat-view.test.ts
@@ -5,20 +5,61 @@ import { focusRuntimeTerminalSurface, registerRuntimeTerminalTab } from './sync-
 const TAB_ID = 'chat-view-tab'
 const WORKTREE_ID = 'chat-view-worktree'
 const LEAF_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const SECOND_LEAF_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
 const PANE_ID = 1
+const SECOND_PANE_ID = 2
 
 const unregisterCallbacks: (() => void)[] = []
 
 /** The cover class TerminalPaneNativeChatPortal renders over the still-mounted xterm. */
-function makePaneContainer(covered: boolean): HTMLElement {
+function makePaneContainer(covered: boolean, leafId = LEAF_ID): HTMLElement {
   const container = document.createElement('div')
-  container.setAttribute('data-leaf-id', LEAF_ID)
+  container.setAttribute('data-leaf-id', leafId)
   if (covered) {
     const shell = document.createElement('div')
     shell.className = 'native-chat-pane-shell absolute inset-0 z-10 flex'
     container.append(shell)
   }
   return container
+}
+
+function registerSplitChatViewTab(options: { activeCovered: boolean; requestedCovered: boolean }): {
+  setActivePane: ReturnType<typeof vi.fn>
+} {
+  const panes = [
+    {
+      id: PANE_ID,
+      leafId: LEAF_ID,
+      container: makePaneContainer(options.activeCovered),
+      terminal: { focus: vi.fn() }
+    },
+    {
+      id: SECOND_PANE_ID,
+      leafId: SECOND_LEAF_ID,
+      container: makePaneContainer(options.requestedCovered, SECOND_LEAF_ID),
+      terminal: { focus: vi.fn() }
+    }
+  ]
+  const setActivePane = vi.fn()
+  const manager = {
+    getPanes: () => panes,
+    getActivePane: () => panes[0],
+    getLeafId: (paneId: number) => panes.find((pane) => pane.id === paneId)?.leafId ?? null,
+    getNumericIdForLeaf: (leafId: string) =>
+      panes.find((pane) => pane.leafId === leafId)?.id ?? null,
+    setActivePane
+  }
+  unregisterCallbacks.push(
+    registerRuntimeTerminalTab({
+      tabId: TAB_ID,
+      worktreeId: WORKTREE_ID,
+      getManager: () => manager as never,
+      getContainer: () => null,
+      getPtyIdForPane: () => null,
+      getTabWideAgentHintLeafId: () => null
+    })
+  )
+  return { setActivePane }
 }
 
 function registerChatViewTab(covered: boolean): {
@@ -79,11 +120,11 @@ describe('focusRuntimeTerminalSurface on a chat-view pane', () => {
     expect(focus).toHaveBeenCalledOnce()
   })
 
-  it('does not activate the requested leaf with focus while the chat portal covers it', () => {
+  it('activates the requested chat leaf without focusing its covered xterm', () => {
     const { setActivePane } = registerChatViewTab(true)
 
     expect(focusRuntimeTerminalSurface(TAB_ID, LEAF_ID, WORKTREE_ID)).toBe(true)
-    expect(setActivePane).not.toHaveBeenCalled()
+    expect(setActivePane).toHaveBeenCalledWith(PANE_ID, { focus: false })
   })
 
   it('activates the requested leaf with focus when no chat portal covers it', () => {
@@ -91,5 +132,25 @@ describe('focusRuntimeTerminalSurface on a chat-view pane', () => {
 
     expect(focusRuntimeTerminalSurface(TAB_ID, LEAF_ID, WORKTREE_ID)).toBe(true)
     expect(setActivePane).toHaveBeenCalledWith(PANE_ID, { focus: true })
+  })
+
+  it('focuses a requested uncovered leaf when the active leaf is covered', () => {
+    const { setActivePane } = registerSplitChatViewTab({
+      activeCovered: true,
+      requestedCovered: false
+    })
+
+    expect(focusRuntimeTerminalSurface(TAB_ID, SECOND_LEAF_ID, WORKTREE_ID)).toBe(true)
+    expect(setActivePane).toHaveBeenCalledWith(SECOND_PANE_ID, { focus: true })
+  })
+
+  it('activates a requested covered leaf without focusing its xterm', () => {
+    const { setActivePane } = registerSplitChatViewTab({
+      activeCovered: false,
+      requestedCovered: true
+    })
+
+    expect(focusRuntimeTerminalSurface(TAB_ID, SECOND_LEAF_ID, WORKTREE_ID)).toBe(true)
+    expect(setActivePane).toHaveBeenCalledWith(SECOND_PANE_ID, { focus: false })
   })
 })

--- a/src/renderer/src/runtime/sync-runtime-graph-terminal-registration-ownership.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-terminal-registration-ownership.test.ts
@@ -15,7 +15,7 @@ const LEAF_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const LEAF_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
 function registerSurface(worktreeId: string, leafId: string, ptyId: string): () => void {
-  const pane = { id: 1, leafId }
+  const pane = { id: 1, leafId, container: { querySelector: () => null } }
   const manager = {
     getPanes: () => [pane],
     getActivePane: () => pane,
@@ -79,8 +79,9 @@ describe('runtime terminal registration ownership', () => {
   it('focuses the requested worktree when tab ids collide', () => {
     const focusA = vi.fn()
     const focusB = vi.fn()
-    const paneA = { id: 1, leafId: LEAF_A, terminal: { focus: focusA } }
-    const paneB = { id: 1, leafId: LEAF_B, terminal: { focus: focusB } }
+    const container = { querySelector: () => null }
+    const paneA = { id: 1, leafId: LEAF_A, container, terminal: { focus: focusA } }
+    const paneB = { id: 1, leafId: LEAF_B, container, terminal: { focus: focusB } }
     const managerA = {
       getPanes: () => [paneA],
       getActivePane: () => paneA,

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -1,4 +1,5 @@
 import type { AppState } from '@/store/types'
+import { activePaneIsCoveredByNativeChat } from '@/components/terminal-pane/native-chat-covered-pane'
 import { resolveLeafIdForManager } from '@/lib/pane-manager/pane-key-resolution'
 import {
   syncRuntimeGraph,
@@ -70,6 +71,13 @@ export function focusRuntimeTerminalSurface(
   const manager = registered?.getManager()
   if (!manager) {
     return false
+  }
+  // Why: mirrors focus-terminal-tab-surface.ts's chat-view bail — the xterm is covered by the
+  // chat portal, so focusing it pulls the caret out of the composer. `true` = handled, because
+  // `false` sends the caller to the DOM fallback, which for a structured tab id focuses an
+  // unrelated tab's xterm.
+  if (activePaneIsCoveredByNativeChat(manager)) {
+    return true
   }
   if (!leafId) {
     manager.getActivePane()?.terminal.focus()

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -1,5 +1,8 @@
 import type { AppState } from '@/store/types'
-import { activePaneIsCoveredByNativeChat } from '@/components/terminal-pane/native-chat-covered-pane'
+import {
+  activePaneIsCoveredByNativeChat,
+  paneIsCoveredByNativeChat
+} from '@/components/terminal-pane/native-chat-covered-pane'
 import { resolveLeafIdForManager } from '@/lib/pane-manager/pane-key-resolution'
 import {
   syncRuntimeGraph,
@@ -72,14 +75,13 @@ export function focusRuntimeTerminalSurface(
   if (!manager) {
     return false
   }
-  // Why: mirrors focus-terminal-tab-surface.ts's chat-view bail — the xterm is covered by the
-  // chat portal, so focusing it pulls the caret out of the composer. `true` = handled, because
-  // `false` sends the caller to the DOM fallback, which for a structured tab id focuses an
-  // unrelated tab's xterm.
-  if (activePaneIsCoveredByNativeChat(manager)) {
-    return true
-  }
   if (!leafId) {
+    // Why: mirrors focus-terminal-tab-surface.ts's chat-view bail — the xterm is covered by the
+    // chat portal, so focusing it pulls the caret out of the composer. `true` = handled because
+    // `false` sends the caller to the DOM fallback.
+    if (activePaneIsCoveredByNativeChat(manager)) {
+      return true
+    }
     manager.getActivePane()?.terminal.focus()
     return true
   }
@@ -87,7 +89,14 @@ export function focusRuntimeTerminalSurface(
   if (resolution.status !== 'resolved') {
     return false
   }
-  manager.setActivePane(resolution.numericPaneId, { focus: true })
+  const requestedPane = manager
+    .getPanes()
+    .find((candidate) => candidate.id === resolution.numericPaneId)
+  // Activating a covered leaf lets its chat surface claim the composer without focusing the
+  // xterm underneath it. Explicit leaf requests must still change the manager's active pane.
+  manager.setActivePane(resolution.numericPaneId, {
+    focus: !paneIsCoveredByNativeChat(requestedPane)
+  })
   scheduleRuntimeGraphSync()
   return true
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​687 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​680 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​159 |

<!-- /orca-pr-loc -->

## ELI5

You open a chat and the cursor isn't in the message box, so you have to click before you can type. Now it's already there.

## What Changed

A new hook, `useNativeChatComposerRevealFocus`, focuses the chat composer whenever a chat pane reveals it. It's called from both chat views, which already held a `composerRef`, so nothing new had to be plumbed.

It fires on the reveal edge, not on mount. Structured panes are retained — hidden with `display:none` + `inert` and never unmounted on a tab switch (`RetainedPaneHost.tsx:145-157`) — so a mount-only effect would miss every switch-back. Covered events: a new chat tab, a worktree-create that lands in chat, the Cmd/Ctrl+Shift+J view toggle, and re-selecting an existing chat tab.

It reuses the existing `NativeChatComposerHandle.focus()` seam and the existing `shouldPreserveEditableFocus` predicate (`pane-helpers.ts`, now exported) rather than adding a parallel mechanism. No Tiptap `autofocus` — that would be a second, competing path.

The first attempt is deferred one frame and retried over a bounded run of frames, because two things can beat a same-tick take: Tiptap publishes its imperative adapter only after `EditorContent` attaches, and Radix's `FocusScope` restores a closing dialog's trigger in a `setTimeout(0)`. The verification stops once focus remains in the pane, so the happy path is two frames. If a closing dialog restores focus afterward, the next frame reclaims the composer. Pointer input or Tab/Shift+Tab navigation cancels the remaining attempts so user intent wins; printable keys do not cancel the initial claim.

Two supporting changes:

**`isFocusedGroup`**, derived from `activeGroupIdByWorktree`. On worktree activation `isWorktreeActive` flips once for the whole layer, so in a 2-column split both chat panes go visible in the same commit and would fight over the caret. The bridge route already had this bit as `controller.isActive` (`TerminalPaneOverlayLayer.tsx:142`); only the structured overlay needed it added.

**A focus-steal fix in `focusRuntimeTerminalSurface`.** Legacy chat is a `terminal` tab with `viewMode: 'chat'` whose xterm stays mounted underneath. The DOM-path twin already declines chat view via `data-terminal-chat-view` (`focus-terminal-tab-surface.ts:74-77`), but the runtime path — which `queueWorkspaceActivationTerminalFocus` tries *first* — focused the covered xterm unconditionally and pulled the caret back out of the composer. The runtime path now resolves any explicit leaf before applying that policy. It activates an uncovered requested leaf with `{ focus: true }`, and a covered requested chat leaf with `{ focus: false }`; that preserves leaf selection without focusing the hidden xterm. Returning `true` still prevents the DOM fallback from targeting an unrelated xterm.

## Why

Nothing in the chat surface focused the composer on open. The only existing focus calls were reactive — typing on the bridge pane background, accepting a picker item, resolving an attachment, starting dictation — and the structured pane had none of them. The view-mode toggle ended at `toggleTabViewMode` and focused nothing.

A pane-local reveal effect was chosen over a store flag like the browser's `pendingAddressBarFocusByTabId`. That flag carries a one-shot creation intent across a mount gap and is consumed so revisits *don't* refocus — the opposite of what's wanted here. It would need re-arming at eight sites, each a silent bug if missed, all re-deriving what the pane layer already knows.

## Linked Issue

No existing open issue covers this; it came from a direct request. Happy to file one and link it if that's preferred.


## Visual Proof

Same flow both times: open a chat from the tab-bar "+" → Claude, then type `typing` **without clicking anything**.

**BEFORE** — `document.activeElement` is `BODY`, the six keystrokes go nowhere, composer still shows its placeholder:

![orca-pr-BEFORE.png](https://github.com/user-attachments/assets/eb6077f5-e897-4b40-86e9-0a3c578b2fd9)

**AFTER** — focus is the composer's ProseMirror contenteditable and the text lands in it:

![orca-pr-AFTER.png](https://github.com/user-attachments/assets/0e9fbdc9-4c19-4078-86ff-767824e6e934)

Captured on macOS against this branch, in one app session, with only the hook toggled between the two shots — so the difference is attributable to this change and not to setup drift.

## Testing

Ran in the real app (macOS) on isolated CDP ports and throwaway profiles, driving the actual tab controls. The [final current-source Electron evidence](https://github.com/stablyai/orca/pull/19868#issuecomment-5623644449) covers the settled source:

- New chat tab focuses the composer, and typing lands there with no click — verified on **both** routes: the portal/bridge chat, and a structured `agent-session` chat.
- Switching away to another tab and back re-focuses the composer.
- **Ablation:** with the hook disabled via HMR, the identical flow leaves `document.activeElement` on `BODY`. Re-enabled, it focuses again.

Automated:

- `native-chat-composer-reveal-focus.test.tsx` — 17 tests: reveal/focused-group edges, split ownership, latch/re-arm behavior, bounded delayed-restoration recovery, preserving editable focus, pointer and Tab cancellation, immediate printable-key behavior, and covered-xterm handoff.
- `focus-runtime-terminal-surface-chat-view.test.ts` — explicit covered and uncovered leaf activation, including mixed splits.
- `TerminalPaneNativeChatPortal.test.tsx` — active-leaf focus ownership on both PTY-backed and structured routes.
- Extended `workspace-activation-terminal-focus.test.ts`, `StructuredAgentSessionPaneOverlayLayer.test.tsx`, and fixed container-less fake panes in `sync-runtime-graph-terminal-registration-ownership.test.ts`.

Each guard was ablated individually and confirmed to turn its test red. Worth calling out: the first version of the hook test passed for the wrong reason — the four guards masked each other pairwise, so removing the latch or the in-pane check changed nothing. Two tests were added that isolate them.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Gates on the final review source: `pnpm tc` clean, 7 focused files / 61 tests green (including 17 hook and 2 portal cases), `check:code-quality:changed` reports 0 new findings, oxlint clean, and `git diff --check` clean. Post-push CI is green: 20 successful checks, 14 intentionally skipped, and no failures or pending checks.

**Not covered:** Linux and Windows were not exercised (no platform-specific code in this change — no keyboard modifiers, no paths). SSH/remote was not exercised live; the runtime-path guard is the piece that matters there and it is unit-tested. The batch worktree-create case — several worktrees in sequence, where the composer must not steal the modal's next name field — is covered by unit test but was not exercised live.

## AI Disclosure

Claude Opus 4.5 via Claude Code and Codex.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Cross-platform:** no platform-dependent code. No `metaKey` hardcoding, no path handling, no shell.
- **Remote SSH:** the runtime focus path is the SSH-relevant surface; the guard makes it decline a chat-covered pane, which is strictly less focus-stealing than before. No execution-host semantics touched.
- **Remote wire:** no RPC params, stream frames, or published content changed.
- **Mobile:** untouched. The composer's `canSend` still reflects the mobile presence-lock; a locked composer is non-editable, so `focus()` returns false and the bounded retry simply expires.
- **Performance:** one effect per chat pane, running only on a reveal edge, latched to at most one claim per visibility episode; at most 6 frames and normally 2. Temporary document listeners are removed on success, cancellation, exhaustion, dependency changes, and unmount.
- **Backwards compatibility:** `isFocusedGroup` is a required prop deliberately — an omitted prop would silently disable the feature for a route, so the typecheck is the forcing function.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


