### PR TITLE
fix(runtime): keep a live host verdict when a status probe can't reach it (#19647, #16516)

### DIFF
--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -710,7 +710,10 @@ describe('runtime-status slice', () => {
     clearRuntimeCompatibilityCacheForTests()
   })
 
-  it('records null and returns false when a runtime refresh fails', async () => {
+  // #19647: a failed status.get dials its own fresh socket, so a refresh must not overwrite a
+  // recorded live verdict with null — that retires the host's session-tabs mirror and dims its
+  // still-live rows on a fault the client could not even ask through.
+  it('preserves a recorded live verdict when a refresh probe fails', async () => {
     const getStatus = vi.fn().mockRejectedValue(new Error('closed'))
     stubRuntimeEnvironmentApi({ getStatus })
     const store = createSliceStore()
@@ -720,6 +723,14 @@ describe('runtime-status slice', () => {
     const reachable = await store.getState().refreshRuntimeEnvironmentStatus('env-a')
 
     expect(reachable).toBe(false)
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status).toBe(cached)
+  })
+
+  it('records null on a first-contact refresh failure, so host coverage completes', async () => {
+    stubRuntimeEnvironmentApi({ getStatus: vi.fn().mockRejectedValue(new Error('closed')) })
+    const store = createSliceStore()
+
+    expect(await store.getState().refreshRuntimeEnvironmentStatus('env-a')).toBe(false)
     expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status).toBe(null)
   })
 

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -292,6 +292,15 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
         get().applyRuntimeHostStatusSnapshot(entry.snapshot)
         return
       }
+      // A null entry here only ever comes from a failed status.get, which dials its own fresh
+      // socket — an unverifiable transport failure, never a host-answered "gone". Overwriting a
+      // recorded live verdict with it retires the host's session-tabs mirror and dims its sidebar
+      // rows for a host whose established flows are still delivering. Keep the live verdict; the
+      // status recheck ladder keeps probing and settles it on a real answer. A first-contact
+      // failure (no prior live status) still records null so host coverage completes. #19647
+      if (entry.status === null && get().runtimeStatusByEnvironmentId.get(environmentId)?.status) {
+        return
+      }
       // Why: setRuntimeEnvironmentStatus drops any stale compat failure on a non-null
       // (reachable) status, so a recovered host's reuse-flagged refetches re-probe.
       get().setRuntimeEnvironmentStatus(environmentId, entry)

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -292,12 +292,12 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
         get().applyRuntimeHostStatusSnapshot(entry.snapshot)
         return
       }
-      // A null entry here only ever comes from a failed status.get, which dials its own fresh
-      // socket — an unverifiable transport failure, never a host-answered "gone". Overwriting a
-      // recorded live verdict with it retires the host's session-tabs mirror and dims its sidebar
-      // rows for a host whose established flows are still delivering. Keep the live verdict; the
-      // status recheck ladder keeps probing and settles it on a real answer. A first-contact
-      // failure (no prior live status) still records null so host coverage completes. #19647
+      // A null entry with no snapshot only ever comes from a status.get that threw — an
+      // unverifiable transport failure, never a host-answered "gone". Publishing it would fire
+      // the disconnect toast and retire the host's session-tabs mirror while its established
+      // flows are still delivering. Keep the live verdict; the connection's status owner (#20003)
+      // holds the last verdict and retries until a real answer. A first-contact failure (no prior
+      // live status) still records null so host coverage completes. #19647
       if (entry.status === null && get().runtimeStatusByEnvironmentId.get(environmentId)?.status) {
         return
       }

--- a/tests/e2e/helpers/runtime-endpoint-link-fault.ts
+++ b/tests/e2e/helpers/runtime-endpoint-link-fault.ts
@@ -1,0 +1,110 @@
+import net from 'node:net'
+import { decodePairingOffer, encodePairingOffer } from '../../../src/shared/pairing'
+
+/**
+ * A TCP hop in front of a paired runtime's WebSocket endpoint whose fault mode can
+ * change mid-test.
+ *
+ * `stall-new` is the Tailscale-shaped fault this exists for: already-established
+ * flows keep delivering while a freshly dialed connection hangs unanswered. That
+ * asymmetry is what separates "the control plane could not ask" from "the runtime
+ * is gone", and neither killing the runtime nor `runtimeEnvironments.disconnect`
+ * can produce it — both take the two halves down together.
+ */
+export type RuntimeLinkFaultMode = 'pass' | 'stall-new'
+
+export type RuntimeEndpointLinkFault = {
+  /** ws:// endpoint that routes through this hop. */
+  endpoint: string
+  setMode: (mode: RuntimeLinkFaultMode) => void
+  /** Connections accepted since the last reset — proves a dial actually reached the hop. */
+  acceptedConnectionCount: () => number
+  stalledConnectionCount: () => number
+  resetCounters: () => void
+  close: () => Promise<void>
+}
+
+function parseWsEndpoint(endpoint: string): { host: string; port: number } {
+  const url = new URL(endpoint)
+  return { host: url.hostname, port: Number(url.port) }
+}
+
+export async function startRuntimeEndpointLinkFault(
+  upstreamEndpoint: string
+): Promise<RuntimeEndpointLinkFault> {
+  const upstream = parseWsEndpoint(upstreamEndpoint)
+  let mode: RuntimeLinkFaultMode = 'pass'
+  let accepted = 0
+  let stalledTotal = 0
+  const stalled = new Set<net.Socket>()
+  const live = new Set<net.Socket>()
+
+  const server = net.createServer((client) => {
+    accepted += 1
+    live.add(client)
+    client.on('close', () => live.delete(client))
+    client.on('error', () => client.destroy())
+    if (mode === 'stall-new') {
+      // Accept the TCP handshake and answer nothing: the dialer waits out its own
+      // timeout, as it does on a half-open path, instead of failing fast on reset.
+      stalledTotal += 1
+      stalled.add(client)
+      client.on('close', () => stalled.delete(client))
+      return
+    }
+    const upstreamSocket = net.connect(upstream.port, upstream.host)
+    live.add(upstreamSocket)
+    upstreamSocket.on('close', () => live.delete(upstreamSocket))
+    upstreamSocket.on('error', () => client.destroy())
+    client.pipe(upstreamSocket)
+    upstreamSocket.pipe(client)
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject)
+      resolve()
+    })
+  })
+  const address = server.address()
+  if (address === null || typeof address === 'string') {
+    throw new Error('runtime endpoint link fault did not bind a TCP port')
+  }
+
+  return {
+    endpoint: `ws://127.0.0.1:${address.port}`,
+    setMode: (next) => {
+      mode = next
+      if (next === 'pass') {
+        for (const socket of stalled) {
+          socket.destroy()
+        }
+        stalled.clear()
+      }
+    },
+    acceptedConnectionCount: () => accepted,
+    stalledConnectionCount: () => stalledTotal,
+    resetCounters: () => {
+      accepted = 0
+      stalledTotal = 0
+    },
+    close: async () => {
+      for (const socket of live) {
+        socket.destroy()
+      }
+      live.clear()
+      stalled.clear()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  }
+}
+
+/** Re-points a pairing offer at `endpoint` without touching its keys or device token. */
+export function repointPairingUrl(pairingUrl: string, endpoint: string): string {
+  return encodePairingOffer({ ...decodePairingOffer(pairingUrl), endpoint })
+}
+
+export function readPairingEndpoint(pairingUrl: string): string {
+  return decodePairingOffer(pairingUrl).endpoint
+}

--- a/tests/e2e/helpers/runtime-endpoint-link-fault.ts
+++ b/tests/e2e/helpers/runtime-endpoint-link-fault.ts
@@ -17,6 +17,12 @@ export type RuntimeEndpointLinkFault = {
   /** ws:// endpoint that routes through this hop. */
   endpoint: string
   setMode: (mode: RuntimeLinkFaultMode) => void
+  /**
+   * Severs every established flow once, leaving `mode` in force for what dials next.
+   * With `stall-new` this is the link flap that puts the shared-control socket into
+   * `reconnecting` while its replacement dial hangs.
+   */
+  dropEstablished: () => number
   /** Connections accepted since the last reset — proves a dial actually reached the hop. */
   acceptedConnectionCount: () => number
   stalledConnectionCount: () => number
@@ -82,6 +88,16 @@ export async function startRuntimeEndpointLinkFault(
         }
         stalled.clear()
       }
+    },
+    dropEstablished: () => {
+      let dropped = 0
+      for (const socket of live) {
+        if (!stalled.has(socket)) {
+          socket.destroy()
+          dropped += 1
+        }
+      }
+      return dropped
     },
     acceptedConnectionCount: () => accepted,
     stalledConnectionCount: () => stalledTotal,

--- a/tests/e2e/paired-remote-terminal-tab-switch-reconnect.spec.ts
+++ b/tests/e2e/paired-remote-terminal-tab-switch-reconnect.spec.ts
@@ -498,20 +498,22 @@ test('paired client tab switch does not reconnect the remote runtime', async ({
       `[tab-switch-repro] connection generation across the flap: ${String(generationBeforeFlap)} -> ${String(generationAfterRecovery)}`
     )
 
-    // Writer contract (#19647), the fix under test: a status.get that could not reach the host is
-    // unverifiable, so the recorded live verdict survives the transport fault (no null published)
-    // and recovery is not a second connection (the connection generation never advances). These
-    // are the hard gate; both fail on the unfixed writer.
-    expect(
-      flapped.sawNullStatus,
-      'a failed status.get over a stalled link published status: null over a live verdict (#19647)'
-    ).toBe(false)
+    // Writer contract (#19647), the fix under test: recovery is not a second connection, so the
+    // connection generation never advances. This fails on the unfixed writer.
     expect(
       generationAfterRecovery,
       'recovery advanced the connection generation, so the session-tabs mirror was rebuilt (#19647)'
     ).toBe(generationBeforeFlap)
-    // The fix keeps the environment revivable rather than retiring it: the pane is never disposed
-    // and its host is never dropped from the mirror targets, so a later trigger can bring it back.
+    // `sawNullStatus` is DIAGNOSTIC here, not a gate. #20003 split the vocabulary: the store entry's
+    // `status` now means "verified on the current socket" and the owner's `snapshot.status` holds the
+    // last verdict, so `entry.status === null` during an outage no longer means the client declared
+    // the host gone. It also drives the mirror's own rebuild after the socket returns, so asserting
+    // it stays non-null would contradict the recovery this arm measures.
+    console.log(
+      `[tab-switch-repro] entry.status nulled during the flap (expected post-#20003): ${String(flapped.sawNullStatus)}`
+    )
+    // The fix keeps the environment revivable rather than retiring it: the pane is never disposed,
+    // so a later trigger can bring it back.
     const finalObservation = await observePane(
       client.page,
       target.webTabId,

--- a/tests/e2e/paired-remote-terminal-tab-switch-reconnect.spec.ts
+++ b/tests/e2e/paired-remote-terminal-tab-switch-reconnect.spec.ts
@@ -1,0 +1,543 @@
+/**
+ * #19647 "Orca has to reconnect every time I switch tabs".
+ *
+ * TOPOLOGY: real Orca desktop app as the remote server + a separate real Orca
+ * desktop client paired to it, with every client->host byte routed through a TCP
+ * hop whose fault mode this test controls. That hop is the reporter's Tailscale
+ * link; `stall-new` reproduces its characteristic failure, where established
+ * flows keep delivering (their agent kept working) while a freshly dialed
+ * connection hangs.
+ *
+ * Exploratory-first: the `[tab-switch-repro]` census and timeline lines are the
+ * diagnosis. The hard gate is the #19647 writer contract — a status.get the client
+ * could not push through must not null a recorded live verdict, and recovery must not
+ * advance the connection generation. Whether the pane repaints within budget is logged,
+ * NOT asserted: that is gated on the un-park latch (#19872) and the multiplexer
+ * cold-handshake (#19871), both filed separately. A green run is NOT a clean bill of health.
+ *
+ * Run:
+ *   pnpm exec playwright test \
+ *     tests/e2e/paired-remote-terminal-tab-switch-reconnect.spec.ts \
+ *     --config tests/playwright.config.ts --project electron-headless --workers=1
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import os from 'node:os'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import {
+  HOST_TERMINAL_SURFACE_SEPARATOR,
+  toWebTerminalSurfaceTabId
+} from '../../src/shared/terminal-surface-id'
+import { expect, test } from './helpers/orca-app'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedElectronClient
+} from './helpers/paired-electron-client'
+import {
+  readPairingEndpoint,
+  repointPairingUrl,
+  startRuntimeEndpointLinkFault
+} from './helpers/runtime-endpoint-link-fault'
+import { waitForTabParked } from './helpers/terminal-hidden-parking'
+
+const PARK_DELAY_MS = 2_000
+const scratch = mkdtempSync(path.join(os.tmpdir(), 'orca-tab-switch-reconnect-'))
+const fixturePath = path.join(scratch, 'tab-switch-terminal.mjs')
+writeFileSync(
+  fixturePath,
+  [
+    "import { appendFileSync } from 'node:fs'",
+    'const sink = process.argv[2]',
+    'const record = (line) => appendFileSync(sink, `${line}\\n`)',
+    "record('READY')",
+    "process.stdout.write('READY\\r\\n')",
+    "process.stdin.setEncoding('utf8')",
+    "let pending = ''",
+    "process.stdin.on('data', (data) => {",
+    '  pending += data',
+    '  const lines = pending.split(/\\r\\n|\\r|\\n/)',
+    "  pending = lines.pop() ?? ''",
+    '  for (const line of lines) {',
+    '    record(`LINE:${line}`)',
+    '    process.stdout.write(`LINE:${line}\\r\\n`)',
+    '  }',
+    '})',
+    'process.stdin.resume()'
+  ].join('\n')
+)
+
+test.afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true })
+})
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function fixtureCommand(sinkPath: string): string {
+  const command = [process.execPath, fixturePath, sinkPath]
+  return process.platform === 'win32'
+    ? command.map((value) => `"${value.replaceAll('"', '""')}"`).join(' ')
+    : command.map(shellQuote).join(' ')
+}
+
+function readSink(sinkPath: string): string {
+  try {
+    return readFileSync(sinkPath, 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+async function callEnvironment<TResult>(
+  page: Page,
+  environmentId: string,
+  method: string,
+  params: unknown
+): Promise<TResult> {
+  return page.evaluate(
+    async ({ environmentId, method, params }) => {
+      const response = await window.api.runtimeEnvironments.call({
+        selector: environmentId,
+        method,
+        params
+      })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return response.result
+    },
+    { environmentId, method, params }
+  ) as Promise<TResult>
+}
+
+type HostTerminal = {
+  hostTabId: string
+  sinkPath: string
+  terminal: string
+  webTabId: string
+}
+
+async function createHostTerminal(
+  page: Page,
+  environmentId: string,
+  worktreeId: string
+): Promise<HostTerminal> {
+  const sinkPath = path.join(scratch, `sink-${randomUUID()}.log`)
+  const result = await callEnvironment<{
+    tab: { id: string; terminal: string | null }
+  }>(page, environmentId, 'session.tabs.createTerminal', {
+    worktree: `id:${worktreeId}`,
+    command: fixtureCommand(sinkPath),
+    activate: false,
+    select: false,
+    navigation: 'caller'
+  })
+  if (!result.tab.terminal) {
+    throw new Error('host session terminal was not created')
+  }
+  const hostTabId = result.tab.id.split(HOST_TERMINAL_SURFACE_SEPARATOR)[0]
+  return {
+    hostTabId,
+    sinkPath,
+    terminal: result.tab.terminal,
+    webTabId: toWebTerminalSurfaceTabId(hostTabId)
+  }
+}
+
+async function waitForMirroredTab(page: Page, worktreeId: string, webTabId: string): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          (id) => (window.__store?.getState().tabsByWorktree[id] ?? []).map((tab) => tab.id),
+          worktreeId
+        ),
+      {
+        timeout: 60_000,
+        message: `client never mirrored host tab ${webTabId}`
+      }
+    )
+    .toContain(webTabId)
+}
+
+async function selectClientTab(page: Page, worktreeId: string, webTabId: string): Promise<void> {
+  await page.evaluate(
+    ({ webTabId, worktreeId }) => {
+      const state = window.__store?.getState()
+      state?.setActiveView('terminal')
+      state?.setActiveWorktree(worktreeId)
+      state?.setActiveTab(webTabId)
+      state?.setActiveTabType('terminal')
+    },
+    { webTabId, worktreeId }
+  )
+}
+
+async function openClientTab(page: Page, worktreeId: string, webTabId: string): Promise<void> {
+  await waitForMirroredTab(page, worktreeId, webTabId)
+  await selectClientTab(page, worktreeId, webTabId)
+  await expect
+    .poll(() => page.evaluate((id) => window.__paneManagers?.has(id) ?? false, webTabId), {
+      timeout: 60_000,
+      message: `client pane for ${webTabId} did not mount`
+    })
+    .toBe(true)
+}
+
+type MultiplexCensus = {
+  activeStreamCount: number
+  transportSubscribeCount: number
+  transportUnsubscribeCount: number
+  streamSubscribeCount: number
+  streamUnsubscribeCount: number
+}
+
+async function readMultiplexCensus(page: Page): Promise<MultiplexCensus> {
+  return page.evaluate(() => {
+    const snapshot = (
+      window as Window & {
+        __remoteTerminalMultiplexAckGate?: {
+          snapshot: () => {
+            activeStreams: unknown[]
+            transportSubscribeCount: number
+            transportUnsubscribeCount: number
+            streamSubscribeCount: number
+            streamUnsubscribeCount: number
+          }
+        }
+      }
+    ).__remoteTerminalMultiplexAckGate?.snapshot()
+    return {
+      activeStreamCount: snapshot?.activeStreams.length ?? -1,
+      transportSubscribeCount: snapshot?.transportSubscribeCount ?? -1,
+      transportUnsubscribeCount: snapshot?.transportUnsubscribeCount ?? -1,
+      streamSubscribeCount: snapshot?.streamSubscribeCount ?? -1,
+      streamUnsubscribeCount: snapshot?.streamUnsubscribeCount ?? -1
+    }
+  })
+}
+
+type PaneObservation = {
+  atMs: number
+  banner: string | null
+  recoveryState: string | null
+  mounted: boolean
+  nullStatusEnvironments: number
+  connectionGeneration: number | null
+  remoteControlState: string | null
+}
+
+async function observePane(
+  page: Page,
+  webTabId: string,
+  environmentId: string,
+  startedAt: number
+): Promise<PaneObservation> {
+  const observation = await page.evaluate(
+    ({ id, environmentId }) => {
+      const manager = window.__paneManagers?.get(id)
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      const banner = document.querySelector('[data-terminal-remote-runtime-reconnect-banner]')
+      const statuses = window.__store?.getState().runtimeStatusByEnvironmentId
+      let nullStatusEnvironments = 0
+      for (const entry of statuses?.values() ?? []) {
+        if (entry.status === null) {
+          nullStatusEnvironments += 1
+        }
+      }
+      return {
+        banner: banner?.getAttribute('data-terminal-remote-runtime-reconnect-banner') ?? null,
+        recoveryState: pane?.container?.dataset?.ptyRecoveryState ?? null,
+        mounted: Boolean(manager),
+        nullStatusEnvironments,
+        connectionGeneration: statuses?.get(environmentId)?.connectionGeneration ?? null,
+        remoteControlState:
+          statuses?.get(environmentId)?.status?.remoteControl?.state ??
+          statuses?.get(environmentId)?.remoteControl?.state ??
+          null
+      }
+    },
+    { id: webTabId, environmentId }
+  )
+  return { atMs: Date.now() - startedAt, ...observation }
+}
+
+async function readPaneContent(page: Page, webTabId: string): Promise<string> {
+  return page.evaluate((id) => {
+    const manager = window.__paneManagers?.get(id)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    return pane?.serializeAddon?.serialize?.() ?? ''
+  }, webTabId)
+}
+
+type RevealRecord = {
+  timeline: PaneObservation[]
+  paintedAtMs: number | null
+  sawBanner: boolean
+  sawNullStatus: boolean
+}
+
+/** Samples the revealed pane for `budgetMs`, stopping early once `marker` paints. */
+async function recordRevealTimeline(
+  page: Page,
+  webTabId: string,
+  environmentId: string,
+  marker: string,
+  budgetMs: number
+): Promise<RevealRecord> {
+  const startedAt = Date.now()
+  const timeline: PaneObservation[] = []
+  let paintedAtMs: number | null = null
+  let sawBanner = false
+  let sawNullStatus = false
+  let previous = ''
+  while (Date.now() - startedAt < budgetMs) {
+    const observation = await observePane(page, webTabId, environmentId, startedAt)
+    sawBanner ||= observation.banner !== null
+    sawNullStatus ||= observation.nullStatusEnvironments > 0
+    const key = `${observation.banner}|${observation.recoveryState}|${observation.mounted}|${observation.nullStatusEnvironments}|${observation.connectionGeneration}|${observation.remoteControlState}`
+    if (key !== previous) {
+      timeline.push(observation)
+      previous = key
+    }
+    if ((await readPaneContent(page, webTabId)).includes(marker)) {
+      paintedAtMs = Date.now() - startedAt
+      timeline.push(await observePane(page, webTabId, environmentId, startedAt))
+      break
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+  return { timeline, paintedAtMs, sawBanner, sawNullStatus }
+}
+
+test('paired client tab switch does not reconnect the remote runtime', async ({
+  orcaPage
+}, testInfo) => {
+  test.setTimeout(900_000)
+  const rawOffer = await createRuntimeDesktopPairingOffer(orcaPage)
+  const link = await startRuntimeEndpointLinkFault(readPairingEndpoint(rawOffer.pairingUrl))
+  const offer = {
+    ...rawOffer,
+    pairingUrl: repointPairingUrl(rawOffer.pairingUrl, link.endpoint)
+  }
+
+  const client = await launchPairedElectronClient(offer, testInfo, 'tab-switch-reconnect', {
+    extraEnv: { ORCA_E2E_TERMINAL_PARKING_DELAY_MS: String(PARK_DELAY_MS) }
+  })
+  const createdTerminals: string[] = []
+  try {
+    const worktreeId = await orcaPage.evaluate(() => {
+      const id = window.__store?.getState().activeWorktreeId
+      if (!id) {
+        throw new Error('headed host has no active worktree')
+      }
+      return id
+    })
+    await expect
+      .poll(
+        () =>
+          client.page.evaluate(
+            (id) =>
+              window.__store
+                ?.getState()
+                .allWorktrees()
+                .some((worktree) => worktree.id === id) ?? false,
+            worktreeId
+          ),
+        {
+          timeout: 60_000,
+          message: 'paired client never saw the host worktree'
+        }
+      )
+      .toBe(true)
+
+    const target = await createHostTerminal(client.page, client.environmentId, worktreeId)
+    const decoys = [
+      await createHostTerminal(client.page, client.environmentId, worktreeId),
+      await createHostTerminal(client.page, client.environmentId, worktreeId)
+    ]
+    createdTerminals.push(target.terminal, ...decoys.map((decoy) => decoy.terminal))
+
+    await openClientTab(client.page, worktreeId, target.webTabId)
+    await expect
+      .poll(() => readPaneContent(client.page, target.webTabId), {
+        timeout: 60_000,
+        message: 'target terminal never painted READY'
+      })
+      .toContain('READY')
+
+    const censusAfterFirstOpen = await readMultiplexCensus(client.page)
+    console.log(
+      `[tab-switch-repro] census after first open: ${JSON.stringify(censusAfterFirstOpen)}`
+    )
+
+    // ---- Arm A: plain tab switching on a healthy link. No fault involved: if the
+    // transport subscribe count climbs here, tab switching alone tears down and
+    // re-establishes the environment's control channel.
+    for (let round = 0; round < 3; round += 1) {
+      await openClientTab(client.page, worktreeId, decoys[0].webTabId)
+      await openClientTab(client.page, worktreeId, decoys[1].webTabId)
+      await waitForTabParked(client.page, target.webTabId, {
+        parkDelayMs: PARK_DELAY_MS
+      })
+      await openClientTab(client.page, worktreeId, target.webTabId)
+    }
+    const censusAfterHealthySwitching = await readMultiplexCensus(client.page)
+    console.log(
+      `[tab-switch-repro] census after healthy switching: ${JSON.stringify(censusAfterHealthySwitching)}`
+    )
+    console.log(
+      `[tab-switch-repro] ARM A transportSubscribeCount delta over 3 healthy park/reveal rounds: ${censusAfterHealthySwitching.transportSubscribeCount - censusAfterFirstOpen.transportSubscribeCount} (unsubscribe delta ${censusAfterHealthySwitching.transportUnsubscribeCount - censusAfterFirstOpen.transportUnsubscribeCount})`
+    )
+
+    // ---- Arm B: park every terminal pane for this environment, so nothing holds
+    // the multiplexed control channel open, then reveal one under a link whose
+    // established flows are fine but whose new dials hang.
+    // Why not a plain view switch: cold-park exempts the single most-recently-hidden
+    // tab, so one pane (and its stream) keeps the multiplexer alive, and the exemption
+    // migrates to a parked tab the moment the exempt one closes. So: make a decoy the
+    // exempt one, park the rest, put the link into stall-new, and only then close that
+    // decoy on the host (over the established control flow). The multiplexer idles out
+    // and nothing can re-dial it on a healthy path before the reveal.
+    await openClientTab(client.page, worktreeId, decoys[1].webTabId)
+    await client.page.evaluate(() => {
+      window.__store?.getState().setActiveView('changes')
+    })
+    await waitForTabParked(client.page, target.webTabId, { parkDelayMs: PARK_DELAY_MS })
+    await waitForTabParked(client.page, decoys[0].webTabId, { parkDelayMs: PARK_DELAY_MS })
+    const censusBeforeRelease = await readMultiplexCensus(client.page)
+    console.log(
+      `[tab-switch-repro] census with only the exempt decoy mounted: ${JSON.stringify(censusBeforeRelease)}`
+    )
+    link.resetCounters()
+    link.setMode('stall-new')
+    await callEnvironment(client.page, client.environmentId, 'terminal.closeTab', {
+      terminal: decoys[1].terminal
+    })
+    createdTerminals.splice(createdTerminals.indexOf(decoys[1].terminal), 1)
+    await expect
+      .poll(async () => (await readMultiplexCensus(client.page)).transportUnsubscribeCount, {
+        timeout: 30_000,
+        message: 'the terminal multiplexer was never released after its last stream closed'
+      })
+      .toBeGreaterThan(censusBeforeRelease.transportUnsubscribeCount)
+    const censusAfterFullPark = await readMultiplexCensus(client.page)
+    console.log(
+      `[tab-switch-repro] census after every pane parked and the multiplexer released: ${JSON.stringify(censusAfterFullPark)}`
+    )
+    // Setup invariant, not a claim about the bug: the reveal below has to pay a fresh
+    // dial, or Arm B degrades into "reveal a tab whose transport is still up".
+    expect(
+      censusAfterFullPark.transportUnsubscribeCount,
+      'Arm B precondition: the terminal multiplexer must have been released before the stalled reveal'
+    ).toBeGreaterThan(censusBeforeRelease.transportUnsubscribeCount)
+
+    await selectClientTab(client.page, worktreeId, target.webTabId)
+    const stalled = await recordRevealTimeline(
+      client.page,
+      target.webTabId,
+      client.environmentId,
+      'READY',
+      40_000
+    )
+    console.log(
+      `[tab-switch-repro] stalled reveal: painted=${String(stalled.paintedAtMs)} banner=${stalled.sawBanner} nullStatus=${stalled.sawNullStatus} timeline=${JSON.stringify(stalled.timeline)}`
+    )
+    console.log(
+      `[tab-switch-repro] dials at the hop: accepted=${link.acceptedConnectionCount()} stalled=${link.stalledConnectionCount()}`
+    )
+
+    // ---- Arm B2: the reporter's "reconnecting" state. Sever the established flows
+    // once while new dials still hang, so the shared-control socket enters
+    // `reconnecting` and the status recheck ladder arms. What the store does with
+    // the resulting failed status.get is the writer under test: a live verdict must
+    // not become `status: null` because the client could not ask.
+    const generationBeforeFlap = (
+      await observePane(client.page, target.webTabId, client.environmentId, 0)
+    ).connectionGeneration
+    const dropped = link.dropEstablished()
+    const flapped = await recordRevealTimeline(
+      client.page,
+      target.webTabId,
+      client.environmentId,
+      'READY',
+      45_000
+    )
+    console.log(
+      `[tab-switch-repro] link flap under stall-new: dropped=${dropped} banner=${flapped.sawBanner} nullStatus=${flapped.sawNullStatus} timeline=${JSON.stringify(flapped.timeline)}`
+    )
+
+    // ---- Arm C: restore the link and measure time-to-recovery.
+    link.setMode('pass')
+    // Drive the documented recovery path. A pane whose attach timed out parks a retry that
+    // arms no timer (#19872): it waits for online/resume/manual Reconnect, so within a bounded
+    // budget the pane only comes back when one of those fires. Dispatching 'online' is exactly
+    // that trigger — the same one a real network-return raises — so this arm exercises genuine
+    // recovery, not the ~180s latch.
+    await client.page.evaluate(() => window.dispatchEvent(new Event('online')))
+    const recovered = await recordRevealTimeline(
+      client.page,
+      target.webTabId,
+      client.environmentId,
+      'READY',
+      30_000
+    )
+    console.log(
+      `[tab-switch-repro] recovery after link restored: painted=${String(recovered.paintedAtMs)} timeline=${JSON.stringify(recovered.timeline)}`
+    )
+    console.log(
+      `[tab-switch-repro] census after recovery: ${JSON.stringify(await readMultiplexCensus(client.page))}`
+    )
+    console.log(`[tab-switch-repro] target sink: ${readSink(target.sinkPath).slice(0, 200)}`)
+    const generationAfterRecovery = (
+      await observePane(client.page, target.webTabId, client.environmentId, 0)
+    ).connectionGeneration
+    console.log(
+      `[tab-switch-repro] connection generation across the flap: ${String(generationBeforeFlap)} -> ${String(generationAfterRecovery)}`
+    )
+
+    // Writer contract (#19647), the fix under test: a status.get that could not reach the host is
+    // unverifiable, so the recorded live verdict survives the transport fault (no null published)
+    // and recovery is not a second connection (the connection generation never advances). These
+    // are the hard gate; both fail on the unfixed writer.
+    expect(
+      flapped.sawNullStatus,
+      'a failed status.get over a stalled link published status: null over a live verdict (#19647)'
+    ).toBe(false)
+    expect(
+      generationAfterRecovery,
+      'recovery advanced the connection generation, so the session-tabs mirror was rebuilt (#19647)'
+    ).toBe(generationBeforeFlap)
+    // The fix keeps the environment revivable rather than retiring it: the pane is never disposed
+    // and its host is never dropped from the mirror targets, so a later trigger can bring it back.
+    const finalObservation = await observePane(
+      client.page,
+      target.webTabId,
+      client.environmentId,
+      0
+    )
+    expect(
+      finalObservation.mounted,
+      'the revealed pane was disposed instead of kept revivable'
+    ).toBe(true)
+    // Recovery TIMELINE is diagnostic, NOT a pass/fail gate: whether the pane actually repaints
+    // within budget depends on the un-park latch (#19872) and the multiplexer cold-handshake
+    // (#19871), both filed separately and out of scope here. A green run is not a clean bill of
+    // health — read the [tab-switch-repro] timeline above. This value is unchanged by this PR
+    // (the unfixed writer left it null too), so it is logged, not asserted.
+    console.log(
+      `[tab-switch-repro] recovery-contract observation (gated on #19872/#19871): painted=${String(recovered.paintedAtMs)}`
+    )
+  } finally {
+    link.setMode('pass')
+    for (const terminal of createdTerminals) {
+      await callEnvironment(client.page, client.environmentId, 'terminal.closeTab', {
+        terminal
+      }).catch(() => undefined)
+    }
+    await client.dispose()
+    await link.close()
+  }
+})

--- a/tests/e2e/sidebar-runtime-host-disconnected-glyph.spec.ts
+++ b/tests/e2e/sidebar-runtime-host-disconnected-glyph.spec.ts
@@ -1,0 +1,124 @@
+import type { Locator, Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const ENVIRONMENT_ID = 'e2e-remote-host'
+const HOST_LABEL = 'Remote Mac'
+
+type RecordedState = 'no-entry' | 'probed-unreachable' | 'probed-reachable'
+
+/** Put the seeded worktree's repo on a runtime host and record one status verdict for it. */
+async function seedRuntimeHost(page: Page, recorded: RecordedState): Promise<string> {
+  return page.evaluate(
+    ({ environmentId, hostLabel, recorded }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      const state = store.getState()
+      const worktree = Object.values(state.worktreesByRepo).flat()[0]
+      if (!worktree) {
+        throw new Error('no seeded worktree to place on a runtime host')
+      }
+      state.setRuntimeEnvironments([
+        {
+          id: environmentId,
+          name: hostLabel,
+          createdAt: 1,
+          updatedAt: 1,
+          lastUsedAt: null,
+          runtimeId: 'e2e-runtime',
+          endpoints: [
+            { id: 'ws', kind: 'websocket', label: 'WebSocket', endpoint: 'ws://127.0.0.1:1' }
+          ],
+          preferredEndpointId: 'ws'
+        }
+      ])
+      store.setState({
+        repos: state.repos.map((repo) =>
+          repo.id === worktree.repoId
+            ? { ...repo, connectionId: undefined, executionHostId: `runtime:${environmentId}` }
+            : repo
+        )
+      })
+      if (recorded === 'probed-unreachable') {
+        state.setRuntimeEnvironmentStatus(environmentId, { status: null, checkedAt: Date.now() })
+      }
+      if (recorded === 'probed-reachable') {
+        state.setRuntimeEnvironmentStatus(environmentId, {
+          status: {
+            runtimeId: 'e2e-runtime',
+            rendererGraphEpoch: 1,
+            graphStatus: 'ready',
+            authoritativeWindowId: 1,
+            desktopWindowStatus: 'available',
+            liveTabCount: 0,
+            liveLeafCount: 0
+          },
+          checkedAt: Date.now()
+        })
+      }
+      return worktree.id
+    },
+    { environmentId: ENVIRONMENT_ID, hostLabel: HOST_LABEL, recorded }
+  )
+}
+
+async function captureCard(card: Locator, testInfo: TestInfo, name: string): Promise<void> {
+  const shot = testInfo.outputPath(name)
+  await card.screenshot({ path: shot, animations: 'disabled' })
+  await testInfo.attach(name, { path: shot, contentType: 'image/png' })
+}
+
+test.describe('sidebar runtime host glyph', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  // Why: an absent entry means "not probed yet". Painting it destructive made every
+  // remote card red and dimmed between launch and the first probe answering.
+  test('does not call a runtime host disconnected before its first probe answers', async ({
+    orcaPage
+  }, testInfo) => {
+    await seedRuntimeHost(orcaPage, 'no-entry')
+    const card = orcaPage.locator(`[data-worktree-card-surface="true"]`).first()
+    await expect(card).toBeVisible()
+
+    // Captured before the assertions so a regression run still yields the evidence image.
+    await captureCard(card, testInfo, 'runtime-host-glyph-before-probe.png')
+
+    await expect(card.locator('svg.lucide-server')).toBeVisible()
+    await expect(card.locator('svg.lucide-server-off')).toHaveCount(0)
+    await expect(card).not.toHaveClass(/opacity-60/)
+  })
+
+  // The deliberate no-change case: a probe actually reported this host unreachable.
+  test('still marks a runtime host disconnected once a probe finds it unreachable', async ({
+    orcaPage
+  }, testInfo) => {
+    await seedRuntimeHost(orcaPage, 'probed-unreachable')
+    const card = orcaPage.locator(`[data-worktree-card-surface="true"]`).first()
+    await expect(card).toBeVisible()
+
+    await captureCard(card, testInfo, 'runtime-host-glyph-disconnected.png')
+
+    await expect(card.locator('svg.lucide-server-off')).toBeVisible()
+    await expect(card).toHaveClass(/opacity-60/)
+  })
+
+  test('clears the disconnected glyph when a later probe reaches the host', async ({
+    orcaPage
+  }, testInfo) => {
+    await seedRuntimeHost(orcaPage, 'probed-unreachable')
+    const card = orcaPage.locator(`[data-worktree-card-surface="true"]`).first()
+    await expect(card.locator('svg.lucide-server-off')).toBeVisible()
+
+    await seedRuntimeHost(orcaPage, 'probed-reachable')
+    await captureCard(card, testInfo, 'runtime-host-glyph-recovered.png')
+
+    await expect(card.locator('svg.lucide-server')).toBeVisible()
+    await expect(card.locator('svg.lucide-server-off')).toHaveCount(0)
+    await expect(card).not.toHaveClass(/opacity-60/)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​807 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​806 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

<!-- rebase-record -->
> [!NOTE]
> ## Rebase decision: resolved. No reviewer adjudication needed.
>
> Both questions this section previously asked a reviewer to decide were answered by reading and testing `main`. The answers are below with their evidence. One open defect is recorded at the end — it is **not** this PR's and is not blocking it.

**Rebased 2026-09-11** onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. Old head `1751433b2118fd15aaa1afc0e3b40fc0fb276674` → rebased head `200a98c19eafcb0c7f059fb0d139619e0a08c4d1` → current head `6ad1e48e4d61f36c73678bf5c0171987266685d5`.

`main` landed **#20003, `fix(runtime): let connections own host status recovery` (`3b82d8de642`)**, which **deleted `src/renderer/src/store/slices/runtime-status-recheck.ts`** and moved failed-status retries into a connection-owned `RuntimeHostStatusOwner`. The rebase accepted that deletion.

### Q1 — does #20003's connection-owned retry cover the deleted recheck ladder? **Yes, all three arms.**

| ladder behaviour this PR added | covered on `main` | where |
| --- | --- | --- |
| re-ask a `status: null` host on the backoff ladder (#16516) | **yes, and more broadly.** `RuntimeHostStatusOwner.complete()` calls `scheduleRetry()` on *every* failure, on the same `[3s, 6s, 12s, 30s, 60s]` ladder. The old `shouldRecheck` predicate required `SHARED_CONTROL` + `remoteControl.state !== 'ready'`, which is precisely why a `status: null` host was never re-asked. There is no predicate now. | `src/shared/runtime-host-status-owner.ts` (`RETRY_DELAYS_MS`, `complete`, `scheduleRetry`); pinned by `runtime-host-status-owner.test.ts` → *"retries a failed status operation while retaining healthy transport and last good metadata"* and by `runtime-environment-status-recovery.test.ts` → *"recovers a saved host after its first status check fails, without another UI request"* |
| cancel the ladder on `runtime_manually_disconnected` | **yes, at the source rather than by reacting to an error code.** `runtimeEnvironments:disconnect` marks the environment and invalidates the transport → `closeRemoteRuntimeRequestConnection` → `owner.dispose()`, which aborts the in-flight request, clears the retry timer and sets `verification: 'blocked'`. `startRequest` and `scheduleRetry` both bail on `blocked`, and a re-created owner is disposed immediately while the environment is still manually disconnected. `getRuntimeEnvironmentStatus` also short-circuits before the owner is touched. | `runtime-environment-connectivity-handlers.ts`, `runtime-environment-request-connections.ts`, owner `dispose`/`startRequest`/`scheduleRetry`; pinned by *"disconnect settles readers and prevents late results and retry resurrection"* |
| `runtime_unavailable` must not null a live verdict *inside the ladder* | **yes, structurally.** The owner's `complete()` on a failure patches only `checkedAt` and `verification`; it never touches `snapshot.status`. A failed probe therefore cannot overwrite a verified verdict at all, rather than being talked out of it by a conditional. `setRuntimeEnvironmentStatus` then reads `previous?.snapshot?.status ?? previous?.status`, so recovery finds the same `runtimeId` and does **not** advance the connection generation. | `runtime-host-status-owner.ts` `complete()`; `runtime-status.ts` `previousVerifiedStatus`; pinned by `runtime-status-snapshot.test.ts` → *"represents failed verification honestly without manufacturing a session restart or toast"* |

**Nothing was lost. The deletion was correct and the ladder must not be re-landed.** #20003's mechanism is a strict improvement: one retry slot per connection shared by all readers, instead of a renderer-side timer keyed on a capability predicate.

### Q2 — is the flipped assertion in `runtime-status.test.ts` correct, or was `main` right? **The flip is correct; `main`'s assertion pinned a defect.**

`main`'s `records null and returns false when a runtime refresh fails` stubs an API with **no `getStatusSnapshots`** and a `getStatus` that *rejects*, so it exercises `refreshRuntimeEnvironmentStatus`'s `catch` branch — the one place with no snapshot and no owner behind it. Measured on `main` at `94c2f96ea46`, that path over a recorded live verdict produces:

```
{ reachable: false, status: null, disconnectToastCalls: 1 }
```

So it does not merely record `null`: it fires `showRuntimeDisconnectedToast` and drops the environment out of `getReachableRuntimeSessionMirrorTargets`. That is a user-facing "host disconnected" claim and a mirror retirement, both derived from a call that threw. `docs/reference/ssh-execution-boundary.md`: *"Absence from a client-side set, a lookup that threw, a socket that closed, a command that timed out — none of these observe the process. They are `unverifiable` by construction."* `main`'s own snapshot reader already refuses the same inference in the same file — `applyRuntimeHostStatusSnapshot` routes a non-verified snapshot around `setRuntimeEnvironmentStatus` with the comment *"Lost contact or a failed method observes no runtime session ending."* The `catch` branch was simply never revisited when that landed.

**Mutation-proven both ways**, on `200a98c19ea`, `vitest run --config config/vitest.config.ts src/renderer/src/store/slices/runtime-status.test.ts` (43 tests):

| mutation | result |
| --- | --- |
| guard disabled (`if (false && …)`) | **1 failed / 42 passed** — exactly `preserves a recorded live verdict when a refresh probe fails`, `AssertionError: expected null to be { runtimeId: 'rt', … }` |
| guard widened to `if (entry.status === null) return` (drop the live-verdict condition) | **2 failed / 41 passed** — `records null on a first-contact refresh failure, so host coverage completes` and `shares one full catalog and status sweep across overlapping hydrations` |

The guard is therefore pinned from both sides: it cannot be removed and it cannot be widened.

### What this PR actually delivers on `main` — narrower than the body below claims

The `catch` branch is the *only* writer the guard now covers. On `main` a transport fault no longer throws: `getRuntimeEnvironmentStatus` resolves `ok: false` through the owner, and the renderer takes the snapshot path. Both production shells (`src/preload/api/runtime-environments-bridge.ts`, `src/renderer/src/web/preload-api/web-runtime-environments-api.ts`) expose `getStatusSnapshots`, so the guard fires only when `getStatus` itself rejects — an unknown selector, an IPC failure, or an unexpected throw. **The #19647 invariant on the main path is now enforced by #20003's owner; this guard backstops the exception path.** That is a real and correctly-pinned narrowing, not a no-op, but the "Proof of fix" measurements further down were taken against the pre-#20003 tree and describe a writer that no longer exists.

### Follow-up commit `6ad1e48e4d6`

- `runtime-status.ts`: the guard's comment described a recheck ladder that no longer exists. Restated in #20003's vocabulary. **The guard itself is byte-for-byte unchanged.**
- `paired-remote-terminal-tab-switch-reconnect.spec.ts`: the flap arm's `expect(flapped.sawNullStatus).toBe(false)` gate **cannot hold on `main` and would fail.** #20003 split the vocabulary — the store entry's `status` means "verified on the current socket" and the owner's `snapshot.status` holds the last verdict — so a dropped socket publishes `verification: 'unavailable'` and the renderer derives `entry.status = null` *by design*. That null is also what drives the session-tabs mirror's own rebuild once the socket returns (the mirror-target key changes, which reinstalls the subscriptions), so asserting it stays non-null would contradict the recovery the same arm measures. Demoted to a logged diagnostic with that reason recorded inline. The connection-generation and pane-mounted assertions — the actual #19647 contract — are unchanged.

### Open defect found while answering this, NOT introduced here and NOT blocking

`main` retires a live host's session-tabs mirror on an **unverifiable** probe over a **ready** transport. Reproduced against `94c2f96ea46` by driving the store's own publication path:

```
verified snapshot            -> mirror targets: [{ environmentId: 'env-a', runtimeId: 'rt-1', … }]
snapshot(verification:'unavailable', transport:'ready')
  entry: { status: null, snapshot.status: { runtimeId: 'rt-1' }, verification: 'unavailable', transport: 'ready' }
  mirror targets: []
```

`applyRuntimeHostStatusSnapshot` nulls `entry.status` for any non-verified snapshot; `getReachableRuntimeSessionMirrorTargets` skips on `!status?.status`; that key feeds a `useEffect` in `use-web-session-tabs-sync.ts` whose cleanup unsubscribes `session.tabs.subscribeAll` and calls `clearWebSessionTabsTrackingForEnvironment`. So a status probe that goes unanswered while the shared-control socket is still `ready` cold-reloads the host's tab mirror — while `main`'s own `runtimeHostConnectionStateForEntry` calls that same entry `runtime-unavailable`, which `isConnectedRuntimeHostState` counts as **connected**. Two derivations, opposite verdicts, and the destructive one wins.

This is #20003's reader, not this PR's writer, and it is **deliberately not fixed here**: holding the target through an outage without a resubscribe-on-stream-death path would strand the mirror, because today's teardown is what restores it (`installWindowVisibilitySubscriptionParking` retries *subscribe* failures only; a mid-stream `{ type: 'end' }` triggers no resubscribe). That needs its own change.

### Conflict ledger

| file | resolution |
| --- | --- |
| `runtime-host-connection-state.ts` / `.test.ts` | Took `main`. Its copy is a strict superset — same derivation plus a `snapshot` branch in `runtimeHostConnectionStateForEntry`, plus one extra test. |
| `runtime-status-recheck.ts` / `.test.ts` | Accepted `main`'s deletion. **Confirmed correct — see Q1.** |
| `runtime-status.ts` | Took `main` for the removed `reconcileRuntimeStatusRecheck` call. The #19647 guard survives and is mutation-proven. |
| `runtime-status.test.ts` | The assertion flip. **Confirmed correct — see Q2.** |

### Gates on `6ad1e48e4d6`

- `node config/scripts/run-typecheck-projects-in-parallel.mjs` — exit 0, empty log. Proven failable first by injecting `const __gateProof: number = "not a number"` → `TS2322`, exit 1.
- `vitest run --config config/vitest.config.ts src/renderer/src/store/slices/runtime-status.test.ts` — 43 passed, exit 0. Proven failable by the two mutations above.
- `oxlint` and `oxfmt --check` on both changed files — clean.
- The one `tsc -p config/tsconfig.e2e.json` error in the spec (`TS2345` at line 406, `setActiveView('changes')`) is pre-existing on `200a98c19ea` and untouched; that project is red repo-wide and is not a gate.

### #20059 carries the same commits

**#20059** carries these commits and hit the identical conflict. Both verdicts apply there unchanged, and `6ad1e48e4d6` was cherry-picked onto it as `51ebc047ce1` — the two contested files are byte-identical across both branches (blobs `1dd012cb317` and `1b798747a27` before, identical trees after).
<!-- /rebase-record -->
## ELI5

When you switch tabs against a remote Orca server over a flaky link (Tailscale, VPN), the client would suddenly decide the server was gone and rebuild everything — tearing down its live session-tab mirror and demanding a reconnect — even while your agent kept happily running on that server. It also dimmed the sidebar and showed a red "disconnected" glyph for a server it had never actually failed to reach.

The reason: a background status probe (`status.get`) dials its **own brand-new socket**. On a half-open link, that fresh dial hangs and fails while your established terminal/agent flows keep delivering. The client treated that "I couldn't even ask" failure as "the host is gone" and wrote `status: null` over a perfectly live verdict. That one write dropped the environment out of the session-tabs mirror targets (teardown #1), and when the next probe succeeded it advanced the connection generation and rebuilt the mirror again (teardown #2). One transient probe failure, two full mirror teardowns.

This makes the writer honest: **loss of contact is unverifiable, never "exited"** (per `docs/reference/ssh-execution-boundary.md`). A `status.get` that fails with `runtime_unavailable` — the code the client's own main process mints for a transport failure it never got an answer to — no longer overwrites a recorded live verdict. The live status stays, the mirror is never retired, the connection generation never bumps, and the status recheck ladder keeps probing until it gets a real answer. First-contact failures (no prior live verdict) still record `null` so host coverage completes.

It also carries forward the reader-side fixes from #19163 (against #16516): the recheck ladder now re-asks a `status: null` host on its backoff, and the sidebar/glyph use the shared `runtimeHostConnectionState` derivation so a host that was **never probed** is no longer painted the same destructive red as one a probe found unreachable.

## Root cause

`fireRuntimeStatusRecheck` (`src/renderer/src/store/slices/runtime-status-recheck.ts`) and the `refreshRuntimeEnvironmentStatus` wrapper (`src/renderer/src/store/slices/runtime-status.ts`) caught a failed `status.get` and published `{ status: null }` unconditionally — while the sibling caller `runtime-client-ipc-bridge.ts:200` already documented that a failed probe here is unverifiable and must publish nothing. `status.get` is exactly the call that dials a fresh socket (`sendRemoteRuntimeRequest`), so a flaky path kills it while established flows keep delivering.

`null` was carrying three meanings — "never asked", "asked and the socket failed", "host is gone, retire its mirror". The mirror read meaning two as three (#19647); the sidebar read meaning one as three (#16516).

## The discriminator (verified)

Main synthesizes `code: 'runtime_unavailable'` for a transport failure in `getRuntimeEnvironmentStatus` (`src/main/ipc/runtime-environment-transport-routing.ts`). I verified the host `status.get` handler (`src/main/runtime/orca-runtime-get-status.ts`, `rpc/methods/status.ts`) never mints that code — it is minted only by the client's own main process and never crosses the wire. So keying on it is safe under `docs/reference/remote-wire-compatibility.md` Rules 1 and 3 (no wire field changes; nothing new is published to old peers). Verdict on the discriminator: **sound and confirmed.**

## Proof of fix (measured, not inspected)

New e2e rig `tests/e2e/paired-remote-terminal-tab-switch-reconnect.spec.ts` runs a real paired desktop client through a TCP hop whose `stall-new` mode lets established flows deliver while fresh dials hang (the reporter's Tailscale shape).

- **Baseline (unfixed):** on a link flap under `stall-new`, `nullStatusEnvironments` went `0 -> 1` (status nulled) and the connection generation advanced `0 -> 1` (mirror rebuilt) — the double teardown, reproduced.
- **Fixed:** `nullStatus=false` throughout the flap and connection generation stays `0 -> 0`. The live verdict survives; recovery is not a second connection.

**Arm A** (healthy tab switching) showed `transportSubscribeCount` delta `0` across 3 park/reveal rounds — plain tab switching does not by itself churn the control channel; the churn is the writer nulling a live verdict on a transport fault.

## Out of scope — filed as issues

- #19871 — the `terminal.multiplex` socket is dropped on last-stream close, so every cold-park reveal pays a fresh WebSocket + E2EE handshake.
- #19872 — the un-park recovery banner says "retrying automatically" while `parkRetry` arms no timer (false UI; ~180s stall until online/resume/manual). The spec's recovery arm dispatches `online` to drive the documented recovery path rather than sit on this latch.

## Tests

- `runtime-status-recheck.test.ts`: preserves a live verdict on an unverifiable probe; no connection-generation bump on recovery; plus the #19163 ladder/manual-disconnect cases.
- `runtime-status.test.ts`: default refresh preserves a recorded live verdict; first-contact failures still record `null`.
- `runtime-host-connection-state.test.ts`, `NoticeHostGlyph.test.tsx`, `WorktreeCard.ssh-reconnect-prompt.test.tsx`: #19163 reader-side coverage.
- Every new assertion mutation-tested: disabling the recheck preserve fails exactly the two #19647 recheck assertions (9 others pass); disabling the refresh preserve fails exactly the refresh preservation test (43 others pass).

Co-authored-by: Omar Shahine <10343873+omarshahine@users.noreply.github.com>
Co-authored-by: ASDFGHoney <86656987+ASDFGHoney@users.noreply.github.com>



