### PR TITLE
docs(reference): how to deliver a real agent-status hook in a repro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ docs/**
 !docs/mobile-terminal-shortcut-bar.md
 !docs/reference/
 !docs/reference/agent-pty-transcript-capture.md
+!docs/reference/agent-status-repro-harness.md
 !docs/reference/agent-status-store.md
 !docs/reference/antigravity-readiness-evidence.md
 !docs/reference/git-compatibility.md

--- a/docs/reference/agent-status-repro-harness.md
+++ b/docs/reference/agent-status-repro-harness.md
@@ -1,0 +1,51 @@
+# Reproducing agent-status bugs
+
+Agent status is the input to tab reveal, sleeping-session capture, and resume. Reproducing any of
+those means producing a *real* status transition, and the obvious way to do it silently produces
+nothing at all. This page is the delivery contract for a repro harness.
+
+## Post the hook where the pane lives, never to the client's own port
+
+Orca's hook endpoint (`<userData>/agent-hooks/**/endpoint.env`: `ORCA_AGENT_HOOK_PORT`,
+`ORCA_AGENT_HOOK_TOKEN`, `ORCA_AGENT_HOOK_ENV`, `ORCA_AGENT_HOOK_VERSION`) answers `204` to any
+correctly-signed POST, including one that will never reach the renderer.
+
+- **POST from the client machine to the client's own port** for a pane whose PTY is remote: main
+  accepts it and stores it with `connectionId: null`. `agentStatus.getSnapshot()` shows it. The
+  renderer drops it, and `agentStatusByPaneKey` stays empty. `204` is not delivery.
+- **POST from inside the pane's own PTY**, using the endpoint variables in that PTY's environment:
+  main tags the event with the owning connection, and the status lands.
+
+On an SSH host the pane's env carries a relay-forwarded port and `ORCA_AGENT_HOOK_ENV=remote`; read
+it from the agent process (`tr '\0' '\n' < /proc/<pid>/environ`) or from the process's own
+`process.env`. On a paired runtime the pane's env points at the *host's* endpoint, so the post must
+run on the host and the status reaches the client through the session mirror.
+
+The payload is the agent's own hook shape. For `claude`, `{ hook_event_name: 'UserPromptSubmit',
+session_id }` starts a turn and `{ hook_event_name: 'Stop', session_id }` completes one; the
+`session_id` is what becomes the resumable provider session
+(`extractAgentProviderSession` in `src/shared/agent-session-resume.ts`).
+
+## The pane has to be a real agent pane
+
+A status for a pane Orca has no agent evidence for is dropped, whatever the hook says. Launch the
+agent through the normal surface (New tab → the agent) so a launch config is registered and the
+pane key is baked into the PTY env. `tests/e2e/fixtures/golden-stub-agent/golden-stub-agent.js`
+works as the agent binary — put it on the execution host's `PATH` under the agent's name. It has to
+be on the *execution host*: agent detection probes there, not on the client.
+
+## Topology decides what the client is even allowed to hold
+
+The same scenario exercises different code depending on where the pane lives, so state the topology
+before quoting a result.
+
+| | direct SSH target | paired runtime |
+| --- | --- | --- |
+| tab row | ordinary local row | `web-terminal-*` mirror surface |
+| PTY handle | client-side | published by the host, one round trip after the rows |
+| sleeping-session record | captured by the client | captured by the **host**; the client's `sleepingAgentSessionsByPaneKey` stays empty for host-owned panes |
+
+A resume-duplication scenario cannot fire on a topology where the client holds no record, and a
+pane-ownership check that refuses `web-terminal-*` ids
+(`paneWillConnectOnActivation` in `src/renderer/src/lib/sleeping-agent-pane-ownership.ts`) cannot
+fire on direct SSH. A zero-hit run is only evidence about the topology it ran on.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |

<!-- /orca-pr-loc -->

## ELI5

If you want to test anything about agent status — a tab that reveals itself, a session that resumes, a "working" spinner — you have to make Orca believe an agent really started or finished a turn. The obvious way to do that is to send Orca's hook a message. It answers `204 OK`. Nothing happens. You conclude the bug is not real.

It *did* accept the message. It just threw it away, because you sent it from the wrong machine. This page says where to send it from, and what else has to be true before a status can land at all.

## What it documents

- **`204` is not delivery.** A hook posted from the client machine to the client's own port, for a pane whose PTY is remote, is stored with `connectionId: null` and dropped by the renderer. It shows up in `agentStatus.getSnapshot()` and never in `agentStatusByPaneKey`. Posting from inside the pane's own PTY — using the endpoint variables in that PTY's environment — lands.
- **The pane has to be a real agent pane.** A status for a pane Orca has no agent evidence for is dropped whatever the hook says. Launch through the normal surface so a launch config is registered, and put the stub agent on the *execution host's* `PATH`, because detection probes there and not on the client.
- **Topology decides what the client is even allowed to hold** — a table for direct SSH vs paired runtime covering the tab row, the PTY handle, and which side captures the sleeping-session record. A zero-hit run is only evidence about the topology it ran on.

## Why it is worth a page

Each of these produced a false negative for me while investigating #19735 and #19697, and none is visible from the code you are debugging — the hook answers `204`, the pane looks like an agent, and the store stays empty. The topology table also explains why the same scenario is structurally immune on two different configurations for two different reasons, which is the kind of thing that reads as "not reproducible" if you have not written it down.

## Proof

Every claim was measured against a live rig: a dockerized SSH host and a paired headless runtime, both driven end to end from a real client, with hooks delivered through the relay and through the host's own endpoint. The `connectionId: null` drop, the relay-delivered success, the agent-detection requirement, and the empty client-side record on a paired runtime were all observed directly rather than read off the source.

Docs-only. `docs/**` is gitignored, so the page needed an allow-list line in `.gitignore` next to the other tracked reference docs.

<!-- rebase-record -->
## Rebase record (2026-09-11)

| | SHA |
| --- | --- |
| old head | `774d14ee3dad95f93214db743a381ece2f5db777` |
| intermediate (on pinned `main` `5fa62feda7c`) | `931a407ebcf7a75ded3a4561f24c996edd33f3aa` |
| **new head** | `dadf371a123f5179a281b61aabf38fb91d4e3154` |

Rebased twice. The first pass targeted the pinned `main` `5fa62feda7c264c6eda99ba4788ffebab9aae26c`; `main` then advanced to `20c56249d51d4a58392e04b0de7d52fa4c24060f` and #19983 added two more entries at the **same** `.gitignore` insertion point, which put this PR straight back into `CONFLICTING`. It was the only PR in the batch that regressed, so it alone was re-pinned to `20c56249d51d4a58392e04b0de7d52fa4c24060f`.

Both conflicts were the same shape and resolved the same way: the `docs/` allowlist in `.gitignore` is a union, alphabetically ordered. `agent-pty-transcript-capture.md`, `agent-status-repro-harness.md`, `agent-status-store.md` and `antigravity-readiness-evidence.md` are all present, and `git check-ignore` confirms none of them is ignored.

This file is a standing collision point: any PR adding a `docs/reference/` doc will conflict here with any other. Worth merging promptly rather than re-resolving.
<!-- /rebase-record -->
