### PR TITLE
fix(runtime): a host frame's active tab is a report, not this client's focus

### DIFF
--- a/src/renderer/src/runtime/web-session-tabs-sync/apply-preparation-groups.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/apply-preparation-groups.ts
@@ -141,7 +141,8 @@ export function prepareWebSessionTabsSnapshotGroups(
         validUnifiedTabIds,
         environmentId,
         worktreeId,
-        clientGroupIdByLocalTabId
+        clientGroupIdByLocalTabId,
+        honorSnapshotActiveFocus
       })
     }
     const strippedGroups = retainClientPlacedMirroredTabs({

--- a/src/renderer/src/runtime/web-session-tabs-sync/layout-groups.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/layout-groups.ts
@@ -128,7 +128,8 @@ export function buildMirroredHostGroups({
   validUnifiedTabIds,
   environmentId,
   worktreeId,
-  clientGroupIdByLocalTabId
+  clientGroupIdByLocalTabId,
+  honorSnapshotActiveFocus
 }: {
   currentGroups: readonly TabGroup[]
   hostGroups: readonly RuntimeMobileSessionTabGroup[]
@@ -140,6 +141,9 @@ export function buildMirroredHostGroups({
   environmentId: string
   worktreeId: string
   clientGroupIdByLocalTabId: ReadonlyMap<string, string>
+  /** True only when this frame carries navigation intent — a client focus request, or a host
+   *  `navigationIntent: 'follow'`. Unsolicited frames never move a client's focus (#5435). */
+  honorSnapshotActiveFocus: boolean
 }): TabGroup[] | null {
   const strippedGroups = retainClientPlacedMirroredTabs({
     groups: currentGroups,
@@ -149,6 +153,12 @@ export function buildMirroredHostGroups({
     nextActiveUnifiedTabId
   })
   const groupsById = new Map(strippedGroups.map((group) => [group.id, group]))
+  // Why pre-strip: stripping drops every mirrored tab this client did not place itself, so a group
+  // whose tabs are all mirrored comes back with `activeTabId: null` and its focus looks unheld.
+  // What the client was showing is only legible before that.
+  const clientActiveTabIdByGroupId = new Map(
+    currentGroups.map((group) => [group.id, group.activeTabId])
+  )
   const orderedGroups: TabGroup[] = []
   const seen = new Set<string>()
 
@@ -180,14 +190,26 @@ export function buildMirroredHostGroups({
     }
     const activeFromHost =
       hostGroup.activeTabId !== null ? (hostToLocalTabId.get(hostGroup.activeTabId) ?? null) : null
+    // Why this order: `activeFromHost` reports which tab the HOST has focused, which on a host
+    // running an agent follows the working session. It answers "where is the host looking", not
+    // "where should this client look", so it outranks the tab this client is showing only when the
+    // frame carries intent. Without that, every republication repointed each group the client was
+    // not currently visiting.
+    const heldTabId = existing?.activeTabId ?? clientActiveTabIdByGroupId.get(hostGroup.id) ?? null
+    const clientActiveTabId = heldTabId && tabOrder.includes(heldTabId) ? heldTabId : null
+    const hostActiveTabId =
+      activeFromHost && tabOrder.includes(activeFromHost) ? activeFromHost : null
     const activeTabId =
-      nextActiveUnifiedTabId && tabOrder.includes(nextActiveUnifiedTabId)
+      (nextActiveUnifiedTabId && tabOrder.includes(nextActiveUnifiedTabId)
         ? nextActiveUnifiedTabId
-        : activeFromHost && tabOrder.includes(activeFromHost)
-          ? activeFromHost
-          : existing?.activeTabId && tabOrder.includes(existing.activeTabId)
-            ? existing.activeTabId
-            : (tabOrder[0] ?? null)
+        : null) ??
+      (honorSnapshotActiveFocus ? hostActiveTabId : null) ??
+      // A group this client has never shown has no focus to preserve, so the host's is the only
+      // answer available — that is adoption, not an override.
+      clientActiveTabId ??
+      hostActiveTabId ??
+      tabOrder[0] ??
+      null
     orderedGroups.push({
       id: hostGroup.id,
       worktreeId,

--- a/src/renderer/src/runtime/web-session-tabs-sync/mirrored-group-active-tab-ranking.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/mirrored-group-active-tab-ranking.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { TabGroup } from '../../../../shared/tab-types'
+import { buildMirroredHostGroups } from './layout-groups'
+
+// Why: #5435's rule, applied one level down. A host group's `activeTabId` is a report of what the
+// host has focused — on an agent-running host it follows the working session — so it must not
+// outrank the tab this client is showing in that group. Only a client-owned intent may.
+
+const WT = 'repo::/worktree'
+const ENV = 'web-env-1'
+const NOW = 1_700_000_000_000
+
+const GROUP_A = 'host-group-a'
+const GROUP_B = 'host-group-b'
+const VISIBLE_TAB = 'web-terminal-visible'
+const CLIENT_TAB_IN_B = 'web-terminal-client-choice'
+const HOST_ACTIVE_TAB_IN_B = 'web-terminal-host-choice'
+
+function group(id: string, activeTabId: string | null, tabOrder: string[]): TabGroup {
+  return { id, worktreeId: WT, activeTabId, tabOrder, recentTabIds: [...tabOrder] }
+}
+
+/** Two groups, as a split workspace has: the client is looking at group A, and group B shows a tab
+ *  of its own while the host reports a different one as active. */
+function buildSplit(options: { honorSnapshotActiveFocus: boolean }): TabGroup[] | null {
+  return buildMirroredHostGroups({
+    currentGroups: [
+      group(GROUP_A, VISIBLE_TAB, [VISIBLE_TAB]),
+      group(GROUP_B, CLIENT_TAB_IN_B, [CLIENT_TAB_IN_B, HOST_ACTIVE_TAB_IN_B])
+    ],
+    hostGroups: [
+      { id: GROUP_A, activeTabId: 'host-visible', tabOrder: ['host-visible'] },
+      {
+        id: GROUP_B,
+        activeTabId: 'host-choice',
+        tabOrder: ['host-client-choice', 'host-choice']
+      }
+    ],
+    hostToLocalTabId: new Map([
+      ['host-visible', VISIBLE_TAB],
+      ['host-client-choice', CLIENT_TAB_IN_B],
+      ['host-choice', HOST_ACTIVE_TAB_IN_B]
+    ]),
+    mirroredUnifiedIds: new Set([VISIBLE_TAB, CLIENT_TAB_IN_B, HOST_ACTIVE_TAB_IN_B]),
+    // The client is looking at group A, so nothing selects a tab inside group B.
+    nextActiveUnifiedTabId: VISIBLE_TAB,
+    now: NOW,
+    validUnifiedTabIds: new Set([VISIBLE_TAB, CLIENT_TAB_IN_B, HOST_ACTIVE_TAB_IN_B]),
+    environmentId: ENV,
+    worktreeId: WT,
+    clientGroupIdByLocalTabId: new Map(),
+    honorSnapshotActiveFocus: options.honorSnapshotActiveFocus
+  })
+}
+
+describe('buildMirroredHostGroups — active tab ranking', () => {
+  it('keeps the tab the client is showing in a group the host reports differently', () => {
+    const groups = buildSplit({ honorSnapshotActiveFocus: false })
+
+    expect(groups?.find((entry) => entry.id === GROUP_A)?.activeTabId).toBe(VISIBLE_TAB)
+    expect(groups?.find((entry) => entry.id === GROUP_B)?.activeTabId).toBe(CLIENT_TAB_IN_B)
+  })
+
+  it('follows the host active tab when the frame carries navigation intent', () => {
+    const groups = buildSplit({ honorSnapshotActiveFocus: true })
+
+    expect(groups?.find((entry) => entry.id === GROUP_B)?.activeTabId).toBe(HOST_ACTIVE_TAB_IN_B)
+  })
+
+  it('adopts the host active tab for a group this client has never shown', () => {
+    const groups = buildMirroredHostGroups({
+      currentGroups: [group(GROUP_A, VISIBLE_TAB, [VISIBLE_TAB])],
+      hostGroups: [
+        { id: GROUP_A, activeTabId: 'host-visible', tabOrder: ['host-visible'] },
+        { id: GROUP_B, activeTabId: 'host-choice', tabOrder: ['host-choice'] }
+      ],
+      hostToLocalTabId: new Map([
+        ['host-visible', VISIBLE_TAB],
+        ['host-choice', HOST_ACTIVE_TAB_IN_B]
+      ]),
+      mirroredUnifiedIds: new Set([VISIBLE_TAB, HOST_ACTIVE_TAB_IN_B]),
+      nextActiveUnifiedTabId: VISIBLE_TAB,
+      now: NOW,
+      validUnifiedTabIds: new Set([VISIBLE_TAB, HOST_ACTIVE_TAB_IN_B]),
+      environmentId: ENV,
+      worktreeId: WT,
+      clientGroupIdByLocalTabId: new Map(),
+      honorSnapshotActiveFocus: false
+    })
+
+    expect(groups?.find((entry) => entry.id === GROUP_B)?.activeTabId).toBe(HOST_ACTIVE_TAB_IN_B)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## ELI5

You have a remote workspace split into two panes. You're typing in the left one. The right one is showing a shell you picked. On the host machine, an agent is running in a *different* tab, and the host keeps saying "my active tab is the agent."

Every time the host republishes its tabs — which is every few seconds while an agent works — the right pane switches to the agent's tab. You didn't ask for that. The host was describing itself, and we read it as an instruction.

## The defect

`buildMirroredHostGroups` ranked a group's active tab like this:

```
nextActiveUnifiedTabId  >  activeFromHost  >  existing.activeTabId  >  tabOrder[0]
```

`activeFromHost` is the host's `tabGroup.activeTabId` — a *report* of where the host is looking, which on a host running an agent follows the working session. It sat **above** `existing.activeTabId`, the tab this client is showing in that group, and nothing in the chain consulted `honorSnapshotActiveFocus`.

That is the same overload this subsystem keeps producing: one value answering a question it has no standing to answer. "The host's active tab" is not "what this client should be looking at". #5435 already fixed that rule one level up, for the snapshot's top-level active tab; this is the per-group copy of it that was missed.

Reachability is the part worth noting: branch one only wins for the group holding the client's visible tab, so **every other group falls straight to `activeFromHost` on every frame**. A single-group workspace never shows it. A split does, on every republication.

## The fix

Rank client focus above the host's report unless the frame carries intent:

```
nextActiveUnifiedTabId
  → honorSnapshotActiveFocus ? activeFromHost : —
  → the tab this client is showing
  → activeFromHost        (a group this client has never shown — adoption, not override)
  → tabOrder[0]
```

Two behaviours are deliberately preserved: a frame carrying navigation intent (a client focus request, or the host's `navigationIntent: 'follow'`) still moves focus, and a group the client has no focus in still adopts the host's active tab, because there is nothing to preserve.

One subtlety in the implementation. `retainClientPlacedMirroredTabs` runs first and drops every mirrored tab the client did not place itself, so a group whose tabs are all mirrored comes back with `activeTabId: null` — its focus *looks* unheld exactly when we need to know what it was. The held tab is therefore read from `currentGroups` before stripping, and still validated against the rebuilt `tabOrder`.

## Proof

`mirrored-group-active-tab-ranking.test.ts` pins the three-way discrimination, using a two-group split with the client's visible tab in group A and a host-reported active tab in group B:

- unsolicited frame → group B keeps the client's tab (**fails before this change**: `expected 'web-terminal-host-choice' to be 'web-terminal-client-choice'`)
- frame with `honorSnapshotActiveFocus` → group B follows the host
- group the client has never shown → adopts the host's active tab

**Mutation:** swapping only the two branches back (`hostActiveTabId ?? clientActiveTabId`) fails **1 test — the first one — out of 1518** across the 179-file renderer runtime suite. Nothing else in the suite depends on the old ranking.

Gates: `pnpm tc`, `pnpm test src/renderer/src/runtime` (179 files / 1518 tests green), `oxlint`, `pnpm run check:code-quality:changed` (0 new findings), `pnpm format`.

## Scope

This is a correctness fix on the focus path, found while investigating #19697. It is **not** claimed as that issue's cause — the frame shape I reproduced for #19697 at the reducer seam is a different route, and I could not produce it from a real host. Deliberately no closing keyword.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts; all 1 commit(s) replayed as-is.

| | SHA |
| --- | --- |
| old head | `c7f399f9faea2a3f877862ca5ad0c405154b5754` |
| new head | `021748b7ae4d23440ddd5e6dc5fc3d02adee1632` |
<!-- /rebase-record -->
