### PR TITLE
fix(relay): one malformed pre-auth handshake frame closes its connection, not the daemon

### DIFF
--- a/src/main/ssh/relay-protocol-backpressure.test.ts
+++ b/src/main/ssh/relay-protocol-backpressure.test.ts
@@ -200,6 +200,40 @@ describe('FrameDecoder bounded turns', () => {
     expect(seen).toEqual([1, 4])
   })
 
+  // feed() runs straight from a transport data handler. A frame owner that threw on the first
+  // turn used to escape feed() and reach uncaughtException. The continuation path was already
+  // contained; the synchronous path must match it.
+  it('contains a frame owner that throws on the synchronous turn and reports one typed error', () => {
+    const seen: number[] = []
+    const onError = vi.fn()
+    const pause = vi.fn()
+    const resume = vi.fn()
+    const decoder = new FrameDecoder(
+      (decoded) => {
+        if (decoded.id === 2) {
+          throw new Error('frame owner failed')
+        }
+        seen.push(decoded.id)
+      },
+      onError,
+      { pause, resume }
+    )
+
+    expect(() => decoder.feed(Buffer.concat([frame(1), frame(2), frame(3)]))).not.toThrow()
+
+    expect(seen).toEqual([1])
+    expect(onError).toHaveBeenCalledExactlyOnceWith(expect.any(FrameDecoderContinuationError))
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      cause: expect.objectContaining({ message: 'frame owner failed' })
+    })
+    expect(decoder.drain()).toHaveLength(0)
+    expect(pause).not.toHaveBeenCalled()
+    expect(resume).not.toHaveBeenCalled()
+
+    decoder.feed(frame(4))
+    expect(seen).toEqual([1, 4])
+  })
+
   it('keeps reads active for partial frames and incrementally discards oversized payloads', () => {
     const errors: Error[] = []
     const seen: DecodedFrame[] = []

--- a/src/relay/protocol-backpressure.test.ts
+++ b/src/relay/protocol-backpressure.test.ts
@@ -200,6 +200,41 @@ describe('relay FrameDecoder bounded turns', () => {
     expect(seen).toEqual([1, 4])
   })
 
+  // feed() runs straight from a socket 'data' handler. A frame owner that threw on the first
+  // turn used to escape feed() and reach uncaughtException, which in the relay daemon means every
+  // PTY and agent session it holds dies with it. The continuation path was already contained.
+  it('contains a frame owner that throws on the synchronous turn and reports one typed error', () => {
+    const seen: number[] = []
+    const onError = vi.fn()
+    const pause = vi.fn()
+    const resume = vi.fn()
+    const decoder = new FrameDecoder(
+      (decoded) => {
+        if (decoded.id === 2) {
+          throw new Error('frame owner failed')
+        }
+        seen.push(decoded.id)
+      },
+      onError,
+      { pause, resume }
+    )
+
+    expect(() => decoder.feed(Buffer.concat([frame(1), frame(2), frame(3)]))).not.toThrow()
+
+    expect(seen).toEqual([1])
+    expect(onError).toHaveBeenCalledExactlyOnceWith(expect.any(FrameDecoderContinuationError))
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      cause: expect.objectContaining({ message: 'frame owner failed' })
+    })
+    // Residue after the bad frame is dropped rather than replayed, and no pause epoch is leaked.
+    expect(decoder.drain()).toHaveLength(0)
+    expect(pause).not.toHaveBeenCalled()
+    expect(resume).not.toHaveBeenCalled()
+
+    decoder.feed(frame(4))
+    expect(seen).toEqual([1, 4])
+  })
+
   it('keeps reads active for partial frames and incrementally discards oversized payloads', () => {
     const errors: Error[] = []
     const seen: DecodedFrame[] = []

--- a/src/relay/protocol-handshake.test.ts
+++ b/src/relay/protocol-handshake.test.ts
@@ -61,6 +61,47 @@ describe('handshake framing', () => {
     expect(() => parseHandshakeMessage(bogus)).toThrow(/Unknown handshake type/)
   })
 
+  // The daemon logs the peer's version before any credential check, and `JSON.parse` can hand
+  // back a value a template literal throws on. The parser is the one place every reader shares.
+  it('rejects a version that is not a string on both arms that carry one', () => {
+    for (const type of ['orca-relay-handshake', 'orca-relay-handshake-ok']) {
+      for (const version of [{ toString: 1 }, 7, null, undefined, ['0.1.0']]) {
+        const payload = Buffer.from(JSON.stringify({ type, version }))
+        expect(
+          () => parseHandshakeMessage(payload),
+          `${type} version=${JSON.stringify(version)}`
+        ).toThrow(/Handshake field version is not a string/)
+      }
+    }
+  })
+
+  it('rejects a mismatch reply whose expected or got is not a string', () => {
+    const type = 'orca-relay-handshake-mismatch'
+    expect(() =>
+      parseHandshakeMessage(Buffer.from(JSON.stringify({ type, expected: {}, got: 'b' })))
+    ).toThrow(/Handshake field expected is not a string/)
+    expect(() =>
+      parseHandshakeMessage(Buffer.from(JSON.stringify({ type, expected: 'a', got: 1 })))
+    ).toThrow(/Handshake field got is not a string/)
+  })
+
+  it('rejects payloads that are not objects', () => {
+    for (const payload of ['null', '"orca-relay-handshake"', '42']) {
+      expect(() => parseHandshakeMessage(Buffer.from(payload)), payload).toThrow(
+        /Handshake payload is not an object/
+      )
+    }
+  })
+
+  it('still accepts a credential-mismatch reply, which carries no fields', () => {
+    const payload = Buffer.from(
+      JSON.stringify({ type: 'orca-relay-handshake-credential-mismatch' })
+    )
+    expect(parseHandshakeMessage(payload)).toEqual({
+      type: 'orca-relay-handshake-credential-mismatch'
+    })
+  })
+
   it('handshake frames use a distinct MessageType from Regular and KeepAlive', () => {
     expect(MessageType.Handshake).not.toBe(MessageType.Regular)
     expect(MessageType.Handshake).not.toBe(MessageType.KeepAlive)

--- a/src/relay/protocol-handshake.test.ts
+++ b/src/relay/protocol-handshake.test.ts
@@ -61,6 +61,13 @@ describe('handshake framing', () => {
     expect(() => parseHandshakeMessage(bogus)).toThrow(/Unknown handshake type/)
   })
 
+  // `type` is peer-supplied, so it can be an object whose String() conversion throws — which
+  // replaced the one diagnostic this refusal exists to produce with a primitive-conversion error.
+  it('still names the refusal when the peer type cannot be stringified', () => {
+    const hostile = Buffer.from(JSON.stringify({ type: { toString: 1 } }))
+    expect(() => parseHandshakeMessage(hostile)).toThrow(/Unknown handshake type: object/)
+  })
+
   // The daemon logs the peer's version before any credential check, and `JSON.parse` can hand
   // back a value a template literal throws on. The parser is the one place every reader shares.
   it('rejects a version that is not a string on both arms that carry one', () => {

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -72,7 +72,10 @@ export function parseHandshakeMessage(payload: Buffer): HandshakeMessage {
       ? HANDSHAKE_STRING_FIELDS[t as HandshakeMessage['type']]
       : null
   if (required === null) {
-    throw new Error(`Unknown handshake type: ${String(t)}`)
+    // Why typeof and not String(t): a peer-supplied `{ "type": { "toString": 1 } }` makes String()
+    // itself throw "Cannot convert object to primitive value", replacing the one diagnostic this
+    // line exists to produce.
+    throw new Error(`Unknown handshake type: ${typeof t === 'string' ? t : typeof t}`)
   }
   for (const field of required) {
     if (typeof msg[field] !== 'string') {

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -50,18 +50,36 @@ export function encodeHandshakeFrame(msg: HandshakeMessage): Buffer {
   return encodeFrame(MessageType.Handshake, 0, 0, payload)
 }
 
+// Why the fields are checked and not just the type: this frame arrives before any credential, and
+// both sides interpolate its version fields into log lines. `JSON.parse` can produce values a
+// template literal throws on, so anything that reaches a reader must already be a string.
+const HANDSHAKE_STRING_FIELDS: Readonly<Record<HandshakeMessage['type'], readonly string[]>> = {
+  'orca-relay-handshake': ['version'],
+  'orca-relay-handshake-ok': ['version'],
+  'orca-relay-handshake-mismatch': ['expected', 'got'],
+  'orca-relay-handshake-credential-mismatch': []
+}
+
 export function parseHandshakeMessage(payload: Buffer): HandshakeMessage {
-  const msg = JSON.parse(payload.toString('utf-8')) as HandshakeMessage
-  const t = (msg as { type?: string }).type
-  if (
-    t !== 'orca-relay-handshake' &&
-    t !== 'orca-relay-handshake-ok' &&
-    t !== 'orca-relay-handshake-mismatch' &&
-    t !== 'orca-relay-handshake-credential-mismatch'
-  ) {
-    throw new Error(`Unknown handshake type: ${t}`)
+  const parsed: unknown = JSON.parse(payload.toString('utf-8'))
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('Handshake payload is not an object')
   }
-  return msg
+  const msg = parsed as Record<string, unknown>
+  const t = msg.type
+  const required =
+    typeof t === 'string' && Object.hasOwn(HANDSHAKE_STRING_FIELDS, t)
+      ? HANDSHAKE_STRING_FIELDS[t as HandshakeMessage['type']]
+      : null
+  if (required === null) {
+    throw new Error(`Unknown handshake type: ${String(t)}`)
+  }
+  for (const field of required) {
+    if (typeof msg[field] !== 'string') {
+      throw new Error(`Handshake field ${field} is not a string`)
+    }
+  }
+  return msg as unknown as HandshakeMessage
 }
 
 export const KEEPALIVE_SEND_MS = 5_000

--- a/src/relay/relay-handshake-roundtrip.test.ts
+++ b/src/relay/relay-handshake-roundtrip.test.ts
@@ -14,6 +14,7 @@ import {
   encodeJsonRpcFrame,
   FrameDecoder,
   type DecodedFrame,
+  type HandshakeMessage,
   MessageType
 } from './protocol'
 import { relayTestSocketPath } from './relay-test-socket-path'
@@ -245,5 +246,69 @@ describe('handshake round-trip over a real Socket pair', () => {
     expect(acceptedCb).not.toHaveBeenCalled()
 
     bridgeSock.destroy()
+  })
+
+  // The daemon reads one handshake frame before any credential check, so every field on it is
+  // untrusted input. `JSON.parse` hands back objects a template literal cannot stringify, and the
+  // frame callback runs inside the decoder: a throw there used to escape the socket's data
+  // handler and take the daemon — and every PTY and agent session it held — down with it.
+  it('closes a connection whose handshake version is not a string and keeps serving', async () => {
+    const { accepted } = await startDaemon('0.1.0+server-version')
+
+    const hostile = connect(sockPath)
+    await new Promise<void>((r) => hostile.once('connect', () => r()))
+    const hostileClosed = new Promise<void>((r) => hostile.once('close', () => r()))
+    hostile.write(
+      encodeHandshakeFrame(
+        JSON.parse('{"type":"orca-relay-handshake","version":{"toString":1}}') as HandshakeMessage
+      )
+    )
+    await hostileClosed
+
+    const good = connect(sockPath)
+    await new Promise<void>((r) => good.once('connect', () => r()))
+    const acceptedCb = vi.fn<(leftover: Buffer) => void>()
+    runConnectHandshake(good, '0.1.0+server-version', { onAccepted: acceptedCb })
+    await accepted
+    await vi.waitFor(() => expect(acceptedCb).toHaveBeenCalledTimes(1))
+
+    good.destroy()
+  })
+
+  // Same class, different instance: `onAccepted` runs inside the frame callback too, so a throw
+  // from the accept path must cost that one connection and nothing else.
+  it('closes only the connection whose accept path throws', async () => {
+    let connections = 0
+    const acceptedSockets: Socket[] = []
+    server = createServer((sock) => {
+      trackServerSocket(sock)
+      connections += 1
+      const failThisOne = connections === 1
+      setupDaemonHandshake(sock, {
+        launchVersion: '0.1.0+server-version',
+        onAccepted: (s) => {
+          if (failThisOne) {
+            throw new Error('accept path failed')
+          }
+          acceptedSockets.push(s)
+        }
+      })
+    })
+    await new Promise<void>((r) => server.listen(sockPath, () => r()))
+
+    const first = connect(sockPath)
+    await new Promise<void>((r) => first.once('connect', () => r()))
+    const firstClosed = new Promise<void>((r) => first.once('close', () => r()))
+    runConnectHandshake(first, '0.1.0+server-version', { onAccepted: vi.fn() })
+    await firstClosed
+
+    const second = connect(sockPath)
+    await new Promise<void>((r) => second.once('connect', () => r()))
+    const acceptedCb = vi.fn<(leftover: Buffer) => void>()
+    runConnectHandshake(second, '0.1.0+server-version', { onAccepted: acceptedCb })
+    await vi.waitFor(() => expect(acceptedCb).toHaveBeenCalledTimes(1))
+    expect(acceptedSockets).toHaveLength(1)
+
+    second.destroy()
   })
 })

--- a/src/relay/relay-orca-cli-channel.ts
+++ b/src/relay/relay-orca-cli-channel.ts
@@ -151,6 +151,13 @@ export async function runRelayOrcaCliChannel(
     }
   }
 
+  // Why an explicit error path: the decoder contains a throwing frame owner instead of letting
+  // it escape, so a malformed relay reply must still end this one-shot command, not park it.
+  const onDecodeError = (error: Error): void => {
+    process.stderr.write(`[orca-cli] Relay protocol error: ${error.message}\n`)
+    sock.destroy()
+    process.exit(1)
+  }
   const decoder = new FrameDecoder((frame: DecodedFrame) => {
     if (frame.id > highestReceivedSeq) {
       highestReceivedSeq = frame.id
@@ -194,7 +201,7 @@ export async function runRelayOrcaCliChannel(
       }
       sendPostOutput(result.postOutput)
     })
-  })
+  }, onDecodeError)
 
   const connectTimeout = setTimeout(() => {
     process.stderr.write(`[orca-cli] Relay connection timed out after ${CONNECT_TIMEOUT_MS}ms\n`)

--- a/src/relay/relay-orca-cli-channel.ts
+++ b/src/relay/relay-orca-cli-channel.ts
@@ -154,9 +154,13 @@ export async function runRelayOrcaCliChannel(
   // Why an explicit error path: the decoder contains a throwing frame owner instead of letting
   // it escape, so a malformed relay reply must still end this one-shot command, not park it.
   const onDecodeError = (error: Error): void => {
-    process.stderr.write(`[orca-cli] Relay protocol error: ${error.message}\n`)
-    sock.destroy()
-    process.exit(1)
+    // Why exit inside the write callback: stderr is async on pipe transports, so exiting early
+    // drops the only evidence this failure ever produces — the same reason relay-handshake.ts
+    // writes its mismatch line this way.
+    process.stderr.write(`[orca-cli] Relay protocol error: ${error.message}\n`, () => {
+      sock.destroy()
+      process.exit(1)
+    })
   }
   const decoder = new FrameDecoder((frame: DecodedFrame) => {
     if (frame.id > highestReceivedSeq) {

--- a/src/shared/relay-frame-decoder.ts
+++ b/src/shared/relay-frame-decoder.ts
@@ -143,12 +143,22 @@ export class FrameDecoder {
         const framed = this.buffer.take(totalLength)
         frames += 1
         bytes += totalLength
-        this.onFrame({
-          type: framed[0],
-          id: framed.readUInt32BE(1),
-          ack: framed.readUInt32BE(5),
-          payload: framed.subarray(HEADER_LENGTH, totalLength)
-        })
+        // Why contain here and not in the caller: feed() runs straight from a socket 'data'
+        // handler, so a frame owner that throws on the first turn would escape as an
+        // uncaughtException and take the whole process — and every connection it serves — down.
+        // The continuation path already contains this; the synchronous path must match it, so
+        // one bad frame costs one connection (the owner's onError closes it), never the process.
+        try {
+          this.onFrame({
+            type: framed[0],
+            id: framed.readUInt32BE(1),
+            ack: framed.readUInt32BE(5),
+            payload: framed.subarray(HEADER_LENGTH, totalLength)
+          })
+        } catch (error) {
+          // reset() bumps the generation, which ends this turn and drops the residue.
+          containFrameDecoderContinuation(() => this.reset(), this.onError, error)
+        }
       }
     } finally {
       this.draining = false


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |

<!-- /orca-pr-loc -->

## ELI5

The relay daemon that runs on your SSH host reads one small "hello" message from every new connection before it checks any credential. It also writes a log line quoting the version that message claims. If the claimed version is not text but a particular kind of object, quoting it throws — and that throw happened in a place with no safety net, so the **whole daemon exited**, taking every terminal and every agent session it was holding down with it.

This is present on `main` today. It is fixed at two layers because only the second one closes the class.

## The defect

`parseHandshakeMessage` returned whatever `JSON.parse` produced after checking only `type`. The daemon then interpolates `msg.version` into a log line on the mismatch path (`relay-handshake.ts:126`) — and, with #19861, on the accept path too. A `version` that is not a string can make that interpolation throw.

That throw happens inside the `FrameDecoder` frame callback. `FrameDecoder.drainTurn` wrapped its synchronous dispatch loop in `try` / `finally` with no `catch`, so the throw escaped `feed()`, escaped the socket `data` handler, and reached `uncaughtException`, whose handler in `relay-daemon.ts` force-kills every PTY and exits. The continuation (scheduled) turn already contained a throwing frame owner; the synchronous first turn did not.

The version check runs before the credential check, so no credential is needed. The Unix socket is `0600`, so this is same-uid rather than a privilege-boundary crossing — but anything running under that account, including a process the relay itself spawned, can reach it. Details on the Windows transport are below.

## The fix

**Instance — `src/relay/protocol.ts`.** `parseHandshakeMessage` now requires the string fields each arm carries (`version` on `-handshake` and `-ok`; `expected` and `got` on `-mismatch`) and rejects a payload that is not an object. Both the daemon and the `--connect` bridge share this parser, so neither side can interpolate a non-string again. The rejection lands in the existing `Could not parse handshake` path, which already closes only that socket.

**Class — `src/shared/relay-frame-decoder.ts`.** The synchronous dispatch turn now contains a throwing frame owner the same way the continuation turn already did: reset the residue, report one `FrameDecoderContinuationError` to `onError`. Every existing owner's `onError` already closes its own connection (`sock.destroy()` in the handshake, `closeClient` in the dispatcher, `dispose` in the SSH multiplexer). So any future throw of this shape — a new field, a new log line, a throwing `onAccepted` — costs one connection instead of the process. Leak, never kill.

The relay CLI channel (`relay-orca-cli-channel.ts`) was the one `FrameDecoder` owner with no `onError`; it gains one so a malformed reply still ends that one-shot command rather than parking it.

## Why this is closing an inconsistency, not adding a policy

Every `FrameDecoder` owner already answers `onError` by ending its own connection: `sock.destroy()` in both handshake arms (`relay-handshake.ts`), `closeClient(client, error, …)` in the dispatcher (`dispatcher-client-lifecycle.ts:146`), `dispose('connection_lost')` in the SSH multiplexer (`ssh-channel-multiplexer.ts:628-631`). The decoder's continuation turn already routed a throwing owner to that `onError`. The synchronous first turn was the one path that skipped it. This change applies the existing policy there.

Hot path: the dispatcher's `handleFrame` already wraps `parseJsonRpcMessage` + dispatch in its own `try`/`catch` (`dispatcher-frame-codec.ts:29-38`), so on the PTY data path the new `catch` is never entered; it only costs a `try` frame per decoded frame.

Runtime floor: the parser uses `Object.hasOwn` (Node 16.9+). The relay bundle targets `node18` (`config/scripts/build-relay.mjs`) and the remote preflight refuses hosts below `MIN_NODE_MAJOR = 18` (`ssh-remote-node-toolchain-probe.ts:5`), so this is inside what the user's host is already required to run.

## Not changed

- No wire change. Every valid frame that parsed before parses now; the handshake envelope is untouched.
- `scheduleContinuation()` still throws if the scheduler itself throws (`releases its pause epoch when continuation scheduling throws`). That is the decoder's own contract with its caller, not a peer-driven path.

## Tests

- `relay-handshake-roundtrip.test.ts`: a daemon fed a non-string `version` closes that connection and admits the next well-formed bridge; a daemon whose `onAccepted` throws for one connection closes only that one and serves the next.
- `protocol-handshake.test.ts`: the parser rejects a non-string `version` on both arms that carry one, non-string `expected`/`got`, and non-object payloads; still accepts the field-less credential-mismatch reply.
- `protocol-backpressure.test.ts` and its `src/main/ssh` mirror: a frame owner that throws on the synchronous turn is contained, residue dropped, one typed error reported, no pause epoch leaked, decoder usable afterwards.

`pnpm tc` clean · `oxlint` clean · changed-code quality gate 0 new findings · 4 suites / 36 tests passed on macOS, and **36/36 on `awin` (Windows, Node 24) over real named pipes**.

### Mutations — 8 applied, 8 killed

| mutation | killed by |
|---|---|
| remove the synchronous-turn `catch` | both *contains a frame owner that throws on the synchronous turn…*; and the roundtrip **worker dies** on *closes only the connection whose accept path throws* (a JSON reporter scores that test `pending`, not failed — it is a kill) |
| `catch` reports but does not reset | *…synchronous turn…* and the existing continuation test in both decoder suites |
| `catch` resets but reports nothing | the same two, plus *closes only the connection whose accept path throws* |
| parser drops the string check | *rejects a version that is not a string on both arms…* and *rejects a mismatch reply…* |
| parser accepts non-object payloads | *rejects payloads that are not objects* |
| parser forgets the `-mismatch` arm's fields | *rejects a mismatch reply whose expected or got is not a string* |
| parser forgets the `-ok` arm's `version` | *rejects a version that is not a string on both arms…* |
| both layers removed (main's state) | roundtrip **worker dies** with `Cannot convert object to primitive value` — the original crash, reproduced |

With only the `catch` removed, the non-string-version test still passes because the parser now rejects the frame first; with only the parser check removed, the daemon still survives because the decoder contains the throw. Each layer covers the other's gap, which is the point of shipping both.

## Windows

The relay skips `umask(0o177)` for named pipes (`shouldSetUmask = !isRelayNamedPipePath(...)`), so the pipe's DACL is whatever the runtime gives a pipe bound with no security options. Measured on `awin` (Windows, Node 24) on a pipe bound the same way the relay binds its own:

```
D:(A;;FR;;;WD)(A;;FR;;;AN)(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;<owner>)
```

`Everyone` and `ANONYMOUS LOGON` hold `Read, Synchronize`; only the owner, `SYSTEM`, and `Administrators` hold full access. Read access lets any local account **connect** to the pipe and read whatever the daemon writes, but not write a frame to it — so the malformed-frame path is same-account on that host too, matching the Unix `0600` posture for this defect. The broader read grant to every local account is the runtime default, not something the relay chose, and is worth its own look separately.

`win-lowspec` was unreachable for the whole session (`runtime_timeout`), so this is **one host, unverified elsewhere**. The relay's own pipe was not live on `awin` at the time; the measurement is of a probe pipe created the same way.


---

## Follow-up folded in: `0b59a2044c2`

Two error paths in this PR's own territory that **destroy the evidence they exist to produce**. Both were found after review and were sitting on an un-PR'd integration branch (`nwparker/adv3-failure-fixes`); folding them here means a reviewer taking this PR takes its fixes too, rather than merging it and silently missing them.

**1. The unknown-type refusal could not name what it refused.** This PR hardens the parser against a non-string `version`. The sibling hole one line away was missed: the unknown-`type` arm interpolated `String(t)` on a peer-supplied value, and `{"type":{"toString":1}}` makes `String()` itself throw *"Cannot convert object to primitive value"*. So the refusal arrives as a primitive-conversion error instead of naming the type — the one diagnostic that line exists to produce. `describeRelayProtocolVersion` guards this exact hazard two files away.

Now `typeof t === 'string' ? t : typeof t`, with a test asserting `/Unknown handshake type: object/` against the hostile payload.

**2. `onDecodeError` — added by this PR — exited before stderr flushed.** It wrote the failure line and then called `process.exit(1)` synchronously. **stderr is async on a pipe transport**, so the one line recording why the command died could be dropped entirely. `relay-handshake.ts` already exits inside its write callback for exactly this reason; this new site did not.

The exit moved inside the write callback, matching the existing precedent.

Both are containment, not behaviour change: the refusal still refuses and the command still dies. They only stop it happening silently.

Verification on the updated head: `tsc --noEmit -p config/tsconfig.node.json` clean · full `src/relay` — **172 files / 1702 tests passed, 1 file / 4 tests skipped**, 0 failures.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts; all 2 commit(s) replayed as-is.

| | SHA |
| --- | --- |
| old head | `0b59a2044c2ca15f25d4a72bf0125d0c22aa20ea` |
| new head | `336c09910ba71012a520c9c302474f946df092ea` |
<!-- /rebase-record -->

## Known gap: `relay-orca-cli-channel.ts` has no test coverage

Stated plainly rather than left to be found.

This branch adds an `onDecodeError` to the `FrameDecoder` in `src/relay/relay-orca-cli-channel.ts` that writes to stderr and then calls `process.exit(1)`. **No test exercises it** — no test file in the repo references that module at all.

The change is still the right one: before it, the subclass's default `onError` only logged, so a decode fault left the one-shot CLI command parked waiting for a reply that could never arrive. Every error that reaches this observer is already fatal to the command — a frame the decoder discarded as oversized, a retained-input reset, or a contained frame-owner throw — so there is no case where a previously-succeeding command now fails.

It is untested because the honest options are both poor: driving it in-process means stubbing `process.exit` around a function that opens real sockets and reads stdin, and a subprocess harness would need a built bundle. A brittle test here would be worse than a named gap.

## Optional-field validation

`2887a40bfe6` closes the invariant this PR left half-applied. The parser refused a non-string `version`, `expected` and `got`, then returned the object with `endpointCredential` — the most pre-auth field on the frame — unproved. It was safe only by accident: its single reader compares it, and a non-string loses that comparison. Nothing held that shape in place, and the next reader to interpolate it into a log line would have reinstated exactly the template-literal throw this function exists to stop.

Present-but-not-a-string is now refused at the parser; absent stays accepted, since a bridge presenting no credential is the common case.

**One deliberate wire-visible delta:** a peer sending a non-string credential used to receive `orca-relay-handshake-credential-mismatch` (exit 43) and now gets a bare close. No first-party client can reach it — `runConnectHandshake` types the parameter `string` and omits it when falsy — and a bare close is the right answer to a frame that was malformed before any credential was checked.
