### PR TITLE
Fix macOS CLI symlink permissions

### DIFF
--- a/src/main/cli/cli-command-filesystem-transaction.ts
+++ b/src/main/cli/cli-command-filesystem-transaction.ts
@@ -200,7 +200,7 @@ export function buildMacPrivilegedSymlinkTransaction(
     `if [ "$captured" -eq 1 ]; then ${restoreOrPreserve}; else /bin/rmdir ${quoteShell(transactionDirectory)}; fi; exit 73`
   return (
     `${capture}if /bin/mkdir ${quoteShell(publishDirectory)} && ` +
-    `/bin/ln -s ${quoteShell(args.launcherPath)} ${quoteShell(publishPath)} && ` +
+    `(umask 022; /bin/ln -s ${quoteShell(args.launcherPath)} ${quoteShell(publishPath)}) && ` +
     `/bin/ln -P ${quoteShell(publishPath)} ${quoteShell(commandDirectory)}; then ` +
     `/bin/rm ${quoteShell(publishPath)}; /bin/rmdir ${quoteShell(publishDirectory)}; ` +
     `if [ "$captured" -eq 1 ]; then /bin/rm ${quoteShell(heldPath)}; fi; ` +

--- a/src/main/cli/cli-command-privileged-transaction.test.ts
+++ b/src/main/cli/cli-command-privileged-transaction.test.ts
@@ -93,6 +93,7 @@ describe.skipIf(process.platform !== 'darwin' || process.getuid?.() === 0)(
       const installed = await installer.install()
       expect(installed.state).toBe('installed')
       await expect(readlink(fixture.commandPath)).resolves.toBe(installed.launcherPath)
+      expect(Number((await lstat(fixture.commandPath, { bigint: true })).mode & 0o777n)).toBe(0o755)
 
       await chmod(fixture.protectedDirectory, 0o500)
       await expect(installer.remove()).resolves.toMatchObject({ state: 'not_installed' })


### PR DESCRIPTION
## ELI5

Registering the Orca CLI on macOS could create a link that only root could inspect. This keeps the private transaction directories locked down while publishing the final /usr/local/bin/orca symlink with normal executable-link permissions.

## What Changed

- Create the staged launcher symlink under a scoped umask 022.
- Keep the transaction and publication directories under the existing umask 077.
- Assert the published symlink mode in the real macOS transaction test.

## Why

The transaction-wide umask 077 also applied to the symlink itself on macOS, producing mode 0700. Non-root users could then receive EACCES from readlink and the CLI launcher could not resolve the app path.

## Linked Issue

Fixes #19120

## Visual Proof

N/A — no UI or interaction layout changes; this corrects filesystem permissions for CLI registration.

## Testing

- [x] pnpm test src/main/cli/cli-command-privileged-transaction.test.ts (4/4)
- [x] pnpm run check:code-quality:changed
- [x] pnpm tc:node
- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm build on macOS
- [x] I manually verified the installed /usr/local/bin/orca link is readable and orca status --json succeeds
- [x] Automated tests added/updated

The repository-wide Vitest run reports five environment-dependent failures unrelated to this change. All five reproduce on this branch's baseline checkout: one shell recipe cleanup assertion, two installed Claude structured CLI expectations, one Claude trust prompt integration, and one installed Claude path expectation. CI will provide the clean-environment full-suite result.

## AI Disclosure

OpenAI Codex (GPT-5) was used to inspect, implement, test, and review the change.

## Review

- Security: transaction/quarantine directories remain 0700; only the published symlink uses 022, and foreign command replacement guards are unchanged.
- Cross-platform: the changed transaction is macOS-only; Linux and Windows paths are untouched.
- SSH/remote/local: this affects only local macOS CLI registration and does not change remote wire behavior.
- Agents/integrations/mobile: no agent, provider, integration, or mobile behavior changes.
- Performance: one scoped subshell runs only during CLI install/update, with no steady-state cost.
- Backward compatibility: command path, target, transaction, and rollback semantics are unchanged.

## Agent skill upstream boundary

- [x] Not applicable.

## Author

X (Twitter): N/A

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof marked N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and compatibility impact considered
- [ ] pnpm lint, pnpm typecheck, pnpm test, and pnpm build all pass locally (lint/typecheck/build pass; full-suite baseline failures documented above; CI pending)
