### PR TITLE
Fix automation completion session matching

### DIFF
--- a/src/renderer/src/hooks/automation-dispatch-agent-status-match.ts
+++ b/src/renderer/src/hooks/automation-dispatch-agent-status-match.ts
@@ -1,0 +1,89 @@
+import type { AgentStateHistoryEntry, AgentStatusEntry } from '../../../shared/agent-status-types'
+import {
+  agentProviderSessionsEqual,
+  type AgentProviderSessionMetadata
+} from '../../../shared/agent-session-resume'
+import { normalizePromptField } from '../../../shared/agent-status-field-normalization'
+
+type AgentStatusRunCandidate = Pick<AgentStateHistoryEntry, 'state' | 'prompt' | 'providerSession'>
+
+export function createAutomationAgentStatusMatcher(prompt: string) {
+  let targetProviderSession: AgentProviderSessionMetadata | undefined
+  const runPrompt = normalizePromptField(prompt)
+  const promptMatchesRun = (candidatePrompt: string | undefined): boolean => {
+    if (!runPrompt) {
+      return true
+    }
+    const trimmed = candidatePrompt?.trim() ?? ''
+    return trimmed.length > 0 && trimmed === runPrompt
+  }
+  const maybeCaptureTargetProviderSession = (
+    candidate: Pick<AgentStatusEntry, 'state' | 'prompt' | 'providerSession'>
+  ): void => {
+    if (targetProviderSession || candidate.state === 'done' || !candidate.providerSession) {
+      return
+    }
+    if (promptMatchesRun(candidate.prompt)) {
+      targetProviderSession = candidate.providerSession
+    }
+  }
+  const candidateBelongsToRun = (
+    agentType: string | undefined,
+    candidate: AgentStatusRunCandidate
+  ): boolean => {
+    if (targetProviderSession) {
+      return (
+        candidate.providerSession !== undefined &&
+        agentProviderSessionsEqual(agentType, candidate.providerSession, targetProviderSession)
+      )
+    }
+    if (candidate.state !== 'done' && candidate.providerSession?.transcriptPath) {
+      return true
+    }
+    return promptMatchesRun(candidate.prompt)
+  }
+
+  return {
+    candidateBelongsToRun,
+    maybeCaptureTargetProviderSession,
+    promptMatchesRun
+  }
+}
+
+export function automationAgentStateHistoryEntriesEqual(
+  agentType: string | undefined,
+  left: AgentStateHistoryEntry,
+  right: AgentStateHistoryEntry
+): boolean {
+  return (
+    left.state === right.state &&
+    left.prompt === right.prompt &&
+    left.startedAt === right.startedAt &&
+    left.interrupted === right.interrupted &&
+    agentProviderSessionsEqual(agentType, left.providerSession, right.providerSession)
+  )
+}
+
+export function getAutomationAgentStateHistoryOverlap(
+  agentType: string | undefined,
+  previous: AgentStateHistoryEntry[],
+  current: AgentStateHistoryEntry[]
+): number {
+  for (let overlap = Math.min(previous.length, current.length); overlap > 0; overlap -= 1) {
+    const previousOffset = previous.length - overlap
+    if (
+      current
+        .slice(0, overlap)
+        .every((entry, index) =>
+          automationAgentStateHistoryEntriesEqual(
+            agentType,
+            entry,
+            previous[previousOffset + index]
+          )
+        )
+    ) {
+      return overlap
+    }
+  }
+  return 0
+}

--- a/src/renderer/src/hooks/automation-dispatch-agent-status-match.ts
+++ b/src/renderer/src/hooks/automation-dispatch-agent-status-match.ts
@@ -37,9 +37,6 @@ export function createAutomationAgentStatusMatcher(prompt: string) {
         agentProviderSessionsEqual(agentType, candidate.providerSession, targetProviderSession)
       )
     }
-    if (candidate.state !== 'done' && candidate.providerSession?.transcriptPath) {
-      return true
-    }
     return promptMatchesRun(candidate.prompt)
   }
 

--- a/src/renderer/src/hooks/automation-dispatch-completion.ts
+++ b/src/renderer/src/hooks/automation-dispatch-completion.ts
@@ -8,11 +8,19 @@ import type {
   AutomationPrecheckResult,
   AutomationRun
 } from '../../../shared/automations-types'
-import type { AgentStateHistoryEntry, AgentStatusEntry } from '../../../shared/agent-status-types'
+import type {
+  AgentStateHistoryEntry,
+  AgentStatusEntry,
+  ParsedAgentStatusPayload
+} from '../../../shared/agent-status-types'
 import {
   selectAutomationAgentStatusEntryChange,
   UNCHANGED_AUTOMATION_AGENT_STATUS_ENTRY
 } from './automation-agent-status-entry-change'
+import {
+  createAutomationAgentStatusMatcher,
+  getAutomationAgentStateHistoryOverlap
+} from './automation-dispatch-agent-status-match'
 import type { Worktree } from '../../../shared/worktree/types'
 import { isProvenProcessExit } from '../../../shared/terminal-exit-cause'
 
@@ -20,6 +28,7 @@ type MarkDispatchResult = (result: AutomationDispatchResult) => Promise<void>
 
 export function createAutomationDispatchCompletion(args: {
   run: AutomationRun
+  prompt: string
   worktree: Worktree
   precheckResult: AutomationPrecheckResult | null
   markDispatchResult: MarkDispatchResult
@@ -35,9 +44,12 @@ export function createAutomationDispatchCompletion(args: {
   let pendingDone = false
   let completionMarked = false
   let contactLost = false
+  let directSawWorkingAfterStart = false
   let unsubscribeAgentStatus = (): void => {}
   let unsubscribeSessionObserver = (): void => {}
   let releaseReuseDispatchTab = (): void => {}
+  const { candidateBelongsToRun, maybeCaptureTargetProviderSession, promptMatchesRun } =
+    createAutomationAgentStatusMatcher(args.prompt)
   const cleanupRunObservers = (): void => {
     unsubscribeAgentStatus()
     unsubscribeSessionObserver()
@@ -158,6 +170,25 @@ export function createAutomationDispatchCompletion(args: {
     }
     settleLateResult(markCompletionResult())
   }
+  const handleAgentStatusPayload = (
+    payload: ParsedAgentStatusPayload,
+    options?: { requireWorkingAfterStart?: boolean }
+  ): void => {
+    if (payload.state === 'working' && promptMatchesRun(payload.prompt)) {
+      directSawWorkingAfterStart = true
+      return
+    }
+    if (
+      payload.state !== 'done' ||
+      payload.sessionBoundary === true ||
+      (options?.requireWorkingAfterStart && !directSawWorkingAfterStart) ||
+      !promptMatchesRun(payload.prompt)
+    ) {
+      return
+    }
+    latestAssistantMessage = payload.lastAssistantMessage?.trim() || latestAssistantMessage
+    handleAgentDone()
+  }
   const handleExit = (code: number): void => {
     if (completionMarked) {
       return
@@ -190,7 +221,12 @@ export function createAutomationDispatchCompletion(args: {
       if (!entry || entry.updatedAt < startedAfter) {
         return
       }
-      const historyOverlap = getAgentStateHistoryOverlap(observedStateHistory, entry.stateHistory)
+      maybeCaptureTargetProviderSession(entry)
+      const historyOverlap = getAutomationAgentStateHistoryOverlap(
+        entry.agentType,
+        observedStateHistory,
+        entry.stateHistory
+      )
       // Why: sawWorkingAfterStart stays monotonic — a recreated entry
       // (transport loss, PTY exit, cap eviction) arrives with an empty
       // stateHistory, so clearing it here would strand reuseSession runs
@@ -199,11 +235,14 @@ export function createAutomationDispatchCompletion(args: {
         if (historicalState.startedAt < startedAfter) {
           continue
         }
-        if (historicalState.state === 'working') {
+        maybeCaptureTargetProviderSession(historicalState)
+        const historicalStateBelongsToRun = candidateBelongsToRun(entry.agentType, historicalState)
+        if (historicalState.state === 'working' && historicalStateBelongsToRun) {
           sawWorkingAfterStart = true
         }
         if (
           historicalState.state === 'done' &&
+          historicalStateBelongsToRun &&
           (!options?.requireWorkingAfterStart || sawWorkingAfterStart)
         ) {
           // Why: this `done` already rolled out of the live entry, so its output
@@ -215,11 +254,13 @@ export function createAutomationDispatchCompletion(args: {
         }
       }
       observedStateHistory = [...entry.stateHistory]
-      if (entry.state === 'working') {
+      const entryBelongsToRun = candidateBelongsToRun(entry.agentType, entry)
+      if (entry.state === 'working' && entryBelongsToRun) {
         sawWorkingAfterStart = true
       }
       if (
         entry.state === 'done' &&
+        entryBelongsToRun &&
         // Why: a session-boundary done is the agent CONNECTING (Claude SessionStart
         // fires at launch, before the argv prompt submits) — completing here would
         // close the tab and record an empty run result.
@@ -238,11 +279,9 @@ export function createAutomationDispatchCompletion(args: {
 
   return {
     appendOutput: (chunk: string) => outputSnapshotBuffer.append(chunk),
-    captureAssistantMessage: (message: string | null | undefined) => {
-      latestAssistantMessage = message?.trim() || latestAssistantMessage
-    },
     cleanupRunObservers,
     handleAgentDone,
+    handleAgentStatusPayload,
     handleExit,
     observeAgentStatus,
     setReuseDispatchTabRelease: (release: () => void) => {
@@ -260,35 +299,4 @@ export function createAutomationDispatchCompletion(args: {
       }
     }
   }
-}
-
-function agentStateHistoryEntriesEqual(
-  left: AgentStateHistoryEntry,
-  right: AgentStateHistoryEntry
-): boolean {
-  return (
-    left.state === right.state &&
-    left.prompt === right.prompt &&
-    left.startedAt === right.startedAt &&
-    left.interrupted === right.interrupted
-  )
-}
-
-function getAgentStateHistoryOverlap(
-  previous: AgentStateHistoryEntry[],
-  current: AgentStateHistoryEntry[]
-): number {
-  for (let overlap = Math.min(previous.length, current.length); overlap > 0; overlap -= 1) {
-    const previousOffset = previous.length - overlap
-    if (
-      current
-        .slice(0, overlap)
-        .every((entry, index) =>
-          agentStateHistoryEntriesEqual(entry, previous[previousOffset + index])
-        )
-    ) {
-      return overlap
-    }
-  }
-  return 0
 }

--- a/src/renderer/src/hooks/automation-dispatch-handler.ts
+++ b/src/renderer/src/hooks/automation-dispatch-handler.ts
@@ -85,6 +85,7 @@ export async function handleAutomationDispatchRequest({
     }
     const completion = createAutomationDispatchCompletion({
       run,
+      prompt: automation.prompt,
       worktree,
       precheckResult: resolved.context.precheckResult,
       markDispatchResult,
@@ -116,16 +117,6 @@ export async function handleAutomationDispatchRequest({
             if (!submitted) {
               completion.cleanupRunObservers()
             } else {
-              let reuseSawWorking = false
-              const handleReusableAgentStatus = (payload: { state: string }): void => {
-                if (payload.state === 'working') {
-                  reuseSawWorking = true
-                  return
-                }
-                if (payload.state === 'done' && reuseSawWorking) {
-                  completion.handleAgentDone()
-                }
-              }
               const reuseCompletionStartedAt = Date.now()
               completion.setSessionObserver(
                 await observeExistingAutomationSession({
@@ -134,8 +125,9 @@ export async function handleAutomationDispatchRequest({
                   runId: run.id,
                   onData: completion.appendOutput,
                   onAgentStatus: (payload) => {
-                    completion.captureAssistantMessage(payload.lastAssistantMessage)
-                    handleReusableAgentStatus(payload)
+                    completion.handleAgentStatusPayload(payload, {
+                      requireWorkingAfterStart: true
+                    })
                   },
                   onExit: completion.handleExit
                 })
@@ -172,12 +164,9 @@ export async function handleAutomationDispatchRequest({
       title: run.title,
       onData: completion.appendOutput,
       onAgentStatus: (payload) => {
-        completion.captureAssistantMessage(payload.lastAssistantMessage)
-        // Why: session-boundary done = launch connect, not run completion (see observeAgentStatus).
-        if (payload.state !== 'done' || payload.sessionBoundary === true) {
-          return
-        }
-        completion.handleAgentDone()
+        completion.handleAgentStatusPayload(payload, {
+          requireWorkingAfterStart: true
+        })
       },
       onExit: (_ptyId, code) => {
         completion.handleExit(code)
@@ -193,7 +182,9 @@ export async function handleAutomationDispatchRequest({
       releaseTerminalOwnership()
     }
     const launchedTabId = result.tabId
-    completion.observeAgentStatus(result.paneKey, dispatchStartedAt)
+    completion.observeAgentStatus(result.paneKey, dispatchStartedAt, {
+      requireWorkingAfterStart: true
+    })
     try {
       await markDispatchResult({
         runId: run.id,

--- a/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
+++ b/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
@@ -245,6 +245,46 @@ describe('automation dispatch completion on an unverifiable loss', () => {
     )
   })
 
+  it('does not count a mismatched transcript-backed working status for the run gate', async () => {
+    const completion = await createCompletion()
+    completion.observeAgentStatus('pane-1', 1000, { requireWorkingAfterStart: true })
+
+    publishAgentStatus(
+      agentStatusEntry('working', 'title-session', {
+        prompt: 'Generate a concise, single-line task title',
+        updatedAt: 1001
+      })
+    )
+    publishAgentStatus(
+      agentStatusEntry('done', 'sessionless', {
+        providerSession: undefined,
+        lastAssistantMessage: 'sessionless done',
+        updatedAt: 1002
+      })
+    )
+    await Promise.resolve()
+
+    expect(markDispatchResult).not.toHaveBeenCalled()
+
+    publishAgentStatus(agentStatusEntry('working', 'main-session', { updatedAt: 1003 }))
+    publishAgentStatus(
+      agentStatusEntry('done', 'main-session', {
+        lastAssistantMessage: 'Run completed',
+        updatedAt: 1004
+      })
+    )
+
+    await vi.waitFor(() =>
+      expect(markDispatchResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: 'run-1',
+          status: 'completed',
+          outputSnapshot: expect.objectContaining({ content: 'Run completed' })
+        })
+      )
+    )
+  })
+
   it('rejects sessionless store done statuses after the run session is known', async () => {
     const completion = await createCompletion()
     completion.observeAgentStatus('pane-1', 1000)

--- a/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
+++ b/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
@@ -1,10 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AutomationDispatchResult } from '../../../shared/automations-types'
+import type { AgentStateHistoryEntry, AgentStatusEntry } from '../../../shared/agent-status-types'
+
+let mockAgentStatusByPaneKey: Record<string, AgentStatusEntry> = {}
+const storeSubscribers = new Set<() => void>()
 
 vi.mock('@/store', () => ({
   useAppStore: {
-    getState: () => ({ agentStatusByPaneKey: {} }),
-    subscribe: vi.fn(() => () => {})
+    getState: () => ({ agentStatusByPaneKey: mockAgentStatusByPaneKey }),
+    subscribe: vi.fn((subscriber: () => void) => {
+      storeSubscribers.add(subscriber)
+      return () => storeSubscribers.delete(subscriber)
+    })
   }
 }))
 
@@ -12,20 +19,71 @@ const markDispatchResult = vi.fn<(result: AutomationDispatchResult) => Promise<v
 const releaseTerminalOwnership = vi.fn()
 const finalizeTerminalOwnership = vi.fn(() => false)
 
-async function createCompletion() {
+async function createCompletion(options: { settleDispatch?: boolean } = {}) {
   const { createAutomationDispatchCompletion } = await import('./automation-dispatch-completion')
   const completion = createAutomationDispatchCompletion({
     run: { id: 'run-1' } as never,
+    prompt: 'Run the slow automation task',
     worktree: { id: 'wt-1', displayName: 'Automation worktree' } as never,
     precheckResult: null,
     markDispatchResult,
     releaseTerminalOwnership,
     finalizeTerminalOwnership
   })
-  // The dispatch itself is already recorded before any exit can settle it.
-  await completion.settlePendingAfterDispatch()
+  if (options.settleDispatch !== false) {
+    // The dispatch itself is already recorded before any exit can settle it.
+    await completion.settlePendingAfterDispatch()
+  }
   markDispatchResult.mockClear()
   return completion
+}
+
+function publishAgentStatus(entry: AgentStatusEntry): void {
+  mockAgentStatusByPaneKey = { [entry.paneKey]: entry }
+  for (const subscriber of storeSubscribers) {
+    subscriber()
+  }
+}
+
+function agentStatusEntry(
+  state: AgentStatusEntry['state'],
+  providerSessionId: string,
+  overrides: Partial<AgentStatusEntry> = {}
+): AgentStatusEntry {
+  const updatedAt = overrides.updatedAt ?? Date.now()
+  return {
+    state,
+    prompt: 'Run the slow automation task',
+    updatedAt,
+    stateStartedAt: overrides.stateStartedAt ?? updatedAt,
+    agentType: 'codex',
+    paneKey: 'pane-1',
+    stateHistory: overrides.stateHistory ?? [],
+    providerSession: {
+      key: 'session_id',
+      id: providerSessionId,
+      transcriptPath: `/tmp/${providerSessionId}.jsonl`
+    },
+    ...overrides
+  }
+}
+
+function agentStateHistoryEntry(
+  state: AgentStateHistoryEntry['state'],
+  providerSessionId: string,
+  overrides: Partial<AgentStateHistoryEntry> = {}
+): AgentStateHistoryEntry {
+  return {
+    state,
+    prompt: 'Run the slow automation task',
+    startedAt: overrides.startedAt ?? Date.now(),
+    providerSession: {
+      key: 'session_id',
+      id: providerSessionId,
+      transcriptPath: `/tmp/${providerSessionId}.jsonl`
+    },
+    ...overrides
+  }
 }
 
 /**
@@ -36,6 +94,8 @@ async function createCompletion() {
 describe('automation dispatch completion on an unverifiable loss', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAgentStatusByPaneKey = {}
+    storeSubscribers.clear()
     markDispatchResult.mockResolvedValue(undefined)
     finalizeTerminalOwnership.mockReturnValue(false)
   })
@@ -101,5 +161,256 @@ describe('automation dispatch completion on an unverifiable loss', () => {
       )
     )
     warnSpy.mockRestore()
+  })
+
+  it('ignores a done status from another provider session in the same pane', async () => {
+    const completion = await createCompletion()
+    completion.observeAgentStatus('pane-1', 1000)
+
+    publishAgentStatus(agentStatusEntry('working', 'main-session', { updatedAt: 1001 }))
+    publishAgentStatus(
+      agentStatusEntry('working', 'title-session', {
+        prompt: 'Generate a concise, single-line task title',
+        providerSession: { key: 'session_id', id: 'title-session' },
+        updatedAt: 1002
+      })
+    )
+    publishAgentStatus(
+      agentStatusEntry('done', 'title-session', {
+        prompt: 'Generate a concise, single-line task title',
+        lastAssistantMessage: '{"title":"Run slow task"}',
+        providerSession: { key: 'session_id', id: 'title-session' },
+        updatedAt: 1003
+      })
+    )
+    await Promise.resolve()
+
+    expect(markDispatchResult).not.toHaveBeenCalled()
+
+    publishAgentStatus(
+      agentStatusEntry('done', 'main-session', {
+        lastAssistantMessage: 'Run completed',
+        updatedAt: 1004
+      })
+    )
+
+    await vi.waitFor(() =>
+      expect(markDispatchResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: 'run-1',
+          status: 'completed',
+          outputSnapshot: expect.objectContaining({ content: 'Run completed' })
+        })
+      )
+    )
+  })
+
+  it('does not bind the run to a mismatched transcript-backed working status', async () => {
+    const completion = await createCompletion()
+    completion.observeAgentStatus('pane-1', 1000)
+
+    publishAgentStatus(
+      agentStatusEntry('working', 'title-session', {
+        prompt: 'Generate a concise, single-line task title',
+        updatedAt: 1001
+      })
+    )
+    publishAgentStatus(
+      agentStatusEntry('done', 'title-session', {
+        prompt: 'Generate a concise, single-line task title',
+        lastAssistantMessage: '{"title":"Run slow task"}',
+        updatedAt: 1002
+      })
+    )
+    await Promise.resolve()
+
+    expect(markDispatchResult).not.toHaveBeenCalled()
+
+    publishAgentStatus(agentStatusEntry('working', 'main-session', { updatedAt: 1003 }))
+    publishAgentStatus(
+      agentStatusEntry('done', 'main-session', {
+        lastAssistantMessage: 'Run completed',
+        updatedAt: 1004
+      })
+    )
+
+    await vi.waitFor(() =>
+      expect(markDispatchResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: 'run-1',
+          status: 'completed',
+          outputSnapshot: expect.objectContaining({ content: 'Run completed' })
+        })
+      )
+    )
+  })
+
+  it('rejects sessionless store done statuses after the run session is known', async () => {
+    const completion = await createCompletion()
+    completion.observeAgentStatus('pane-1', 1000)
+
+    publishAgentStatus(agentStatusEntry('working', 'main-session', { updatedAt: 1001 }))
+    publishAgentStatus(
+      agentStatusEntry('done', 'sessionless', {
+        lastAssistantMessage: 'sessionless done',
+        providerSession: undefined,
+        updatedAt: 1002
+      })
+    )
+    await Promise.resolve()
+
+    expect(markDispatchResult).not.toHaveBeenCalled()
+
+    publishAgentStatus(
+      agentStatusEntry('done', 'main-session', {
+        lastAssistantMessage: 'Run completed',
+        updatedAt: 1003
+      })
+    )
+
+    await vi.waitFor(() =>
+      expect(markDispatchResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: 'run-1',
+          status: 'completed',
+          outputSnapshot: expect.objectContaining({ content: 'Run completed' })
+        })
+      )
+    )
+  })
+
+  it('recovers the target session from state history when observing after the turn completed', async () => {
+    const completion = await createCompletion()
+
+    publishAgentStatus(
+      agentStatusEntry('done', 'sessionless', {
+        lastCompletedAssistantMessage: 'Run completed from history',
+        providerSession: undefined,
+        updatedAt: 1004,
+        stateHistory: [
+          agentStateHistoryEntry('working', 'main-session', { startedAt: 1001 }),
+          agentStateHistoryEntry('done', 'main-session', { startedAt: 1003 })
+        ]
+      })
+    )
+    completion.observeAgentStatus('pane-1', 1000, { requireWorkingAfterStart: true })
+
+    await vi.waitFor(() =>
+      expect(markDispatchResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: 'run-1',
+          status: 'completed',
+          outputSnapshot: expect.objectContaining({ content: 'Run completed from history' })
+        })
+      )
+    )
+  })
+
+  it('does not overlap pi history rows that share an id but have different transcript files', async () => {
+    const { getAutomationAgentStateHistoryOverlap } =
+      await import('./automation-dispatch-agent-status-match')
+    const previous = [
+      agentStateHistoryEntry('working', 'shared-id', {
+        providerSession: { key: 'session_id', id: 'shared-id', transcriptPath: '/tmp/first.jsonl' },
+        startedAt: 1001
+      })
+    ]
+    const current = [
+      agentStateHistoryEntry('working', 'shared-id', {
+        providerSession: {
+          key: 'session_id',
+          id: 'shared-id',
+          transcriptPath: '/tmp/second.jsonl'
+        },
+        startedAt: 1001
+      })
+    ]
+
+    expect(getAutomationAgentStateHistoryOverlap('pi', previous, current)).toBe(0)
+    expect(getAutomationAgentStateHistoryOverlap('codex', previous, current)).toBe(1)
+  })
+
+  it('does not settle an early direct done before this run starts working', async () => {
+    const completion = await createCompletion({ settleDispatch: false })
+
+    completion.handleAgentStatusPayload(
+      {
+        state: 'done',
+        prompt: 'Run the slow automation task',
+        lastAssistantMessage: 'early done'
+      } as never,
+      { requireWorkingAfterStart: true }
+    )
+    await completion.settlePendingAfterDispatch()
+    await Promise.resolve()
+
+    expect(markDispatchResult).not.toHaveBeenCalled()
+
+    completion.handleAgentStatusPayload(
+      { state: 'working', prompt: 'Run the slow automation task' } as never,
+      { requireWorkingAfterStart: true }
+    )
+    completion.handleAgentStatusPayload(
+      {
+        state: 'done',
+        prompt: 'Run the slow automation task',
+        lastAssistantMessage: 'Run completed'
+      } as never,
+      { requireWorkingAfterStart: true }
+    )
+
+    await vi.waitFor(() =>
+      expect(markDispatchResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: 'run-1',
+          status: 'completed',
+          outputSnapshot: expect.objectContaining({ content: 'Run completed' })
+        })
+      )
+    )
+  })
+
+  it('ignores direct title-generation status even when it embeds the run prompt', async () => {
+    const completion = await createCompletion()
+    const titlePrompt =
+      'Generate a concise, single-line task title for: Run the slow automation task'
+
+    completion.handleAgentStatusPayload(
+      { state: 'working', prompt: 'Run the slow automation task' } as never,
+      { requireWorkingAfterStart: true }
+    )
+    completion.handleAgentStatusPayload({ state: 'working', prompt: titlePrompt } as never, {
+      requireWorkingAfterStart: true
+    })
+    completion.handleAgentStatusPayload(
+      {
+        state: 'done',
+        prompt: titlePrompt,
+        lastAssistantMessage: '{"title":"Run slow task"}'
+      } as never,
+      { requireWorkingAfterStart: true }
+    )
+    await Promise.resolve()
+
+    expect(markDispatchResult).not.toHaveBeenCalled()
+
+    completion.handleAgentStatusPayload(
+      {
+        state: 'done',
+        prompt: 'Run the slow automation task',
+        lastAssistantMessage: 'Run completed'
+      } as never,
+      { requireWorkingAfterStart: true }
+    )
+
+    await vi.waitFor(() =>
+      expect(markDispatchResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: 'run-1',
+          status: 'completed',
+          outputSnapshot: expect.objectContaining({ content: 'Run completed' })
+        })
+      )
+    )
   })
 })

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -29,6 +29,10 @@ const setupLaunch = {
   runnerScriptPath: '/tmp/setup.sh',
   envVars: { ORCA_WORKTREE_PATH: '/repo/worktree' }
 }
+const AUTOMATION_PROMPT = 'run this'
+const AGENT_TAB_ID = 'agent-tab'
+const AGENT_PANE_KEY = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
+const AGENT_PTY_ID = 'agent-pty'
 
 const createdWorktree = {
   id: 'wt-created',
@@ -78,7 +82,7 @@ function makeAutomation(overrides: Record<string, unknown> = {}) {
   return {
     id: 'automation-1',
     projectId: 'repo-1',
-    prompt: 'run this',
+    prompt: AUTOMATION_PROMPT,
     precheck: null,
     agentId: 'claude',
     workspaceMode: 'new_per_run',
@@ -99,6 +103,19 @@ function makeRun() {
     trigger: 'scheduled',
     workspaceId: null,
     workspaceDisplayName: null
+  }
+}
+
+function makeLaunchResult() {
+  return {
+    tabId: AGENT_TAB_ID,
+    paneKey: AGENT_PANE_KEY,
+    ptyId: AGENT_PTY_ID,
+    startupPlan: {},
+    terminalOwnership: {
+      finalize: mockFinalizeTerminalOwnership,
+      release: mockReleaseTerminalOwnership
+    }
   }
 }
 
@@ -204,16 +221,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     state.getKnownWorktreeById.mockReturnValue(undefined)
     mockCreateWorktree.mockResolvedValue({ worktree: createdWorktree, setup: setupLaunch })
     mockLaunchWorktreeBackgroundTerminals.mockResolvedValue(undefined)
-    mockLaunchAgentBackgroundSession.mockResolvedValue({
-      tabId: 'agent-tab',
-      paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-      ptyId: 'agent-pty',
-      startupPlan: {},
-      terminalOwnership: {
-        finalize: mockFinalizeTerminalOwnership,
-        release: mockReleaseTerminalOwnership
-      }
-    })
+    mockLaunchAgentBackgroundSession.mockResolvedValue(makeLaunchResult())
     mockOnDispatchRequested.mockReturnValue(() => {})
     mockSshNeedsPassphrasePrompt.mockResolvedValue(false)
     mockSshGetState.mockResolvedValue({ status: 'connected' })
@@ -540,7 +548,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
 
   it('finalizes a fresh non-reuse terminal only after completed result persistence', async () => {
     const order: string[] = []
-    let launchArgs: { onAgentStatus?: (payload: { state: string }) => void } = {}
+    let launchArgs: { onAgentStatus?: (payload: { state: string; prompt?: string }) => void } = {}
     mockMarkDispatchResult.mockImplementation(
       async (result: { status: string; terminalPaneKey?: string | null }) => {
         // The retirement clear reuses status 'completed' but nulls the terminal
@@ -558,20 +566,12 @@ describe('useAutomationDispatchEvents setup launch', () => {
     })
     mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
       launchArgs = args
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
+      return makeLaunchResult()
     })
 
     await registerAndDispatch()
-    launchArgs.onAgentStatus?.({ state: 'done' })
+    launchArgs.onAgentStatus?.({ state: 'working', prompt: AUTOMATION_PROMPT })
+    launchArgs.onAgentStatus?.({ state: 'done', prompt: AUTOMATION_PROMPT })
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
 
     expect(order).toEqual([
@@ -594,39 +594,39 @@ describe('useAutomationDispatchEvents setup launch', () => {
 
   it('ignores a session-boundary done so a connecting agent cannot complete the run (STA-3386)', async () => {
     let launchArgs: {
-      onAgentStatus?: (payload: { state: string; sessionBoundary?: boolean }) => void
+      onAgentStatus?: (payload: {
+        state: string
+        prompt?: string
+        sessionBoundary?: boolean
+      }) => void
     } = {}
     mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
       launchArgs = args
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
+      return makeLaunchResult()
     })
 
     await registerAndDispatch()
     // Why: Claude fires SessionStart (a sessionBoundary done) at launch, before the argv
     // prompt submits — treating it as run completion would close the tab on an empty run.
-    launchArgs.onAgentStatus?.({ state: 'done', sessionBoundary: true })
+    launchArgs.onAgentStatus?.({
+      state: 'done',
+      prompt: AUTOMATION_PROMPT,
+      sessionBoundary: true
+    })
     await Promise.resolve()
     expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
 
-    launchArgs.onAgentStatus?.({ state: 'done' })
+    launchArgs.onAgentStatus?.({ state: 'working', prompt: AUTOMATION_PROMPT })
+    launchArgs.onAgentStatus?.({ state: 'done', prompt: AUTOMATION_PROMPT })
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
   })
 
   it('skips unchanged status and persists batched working→done→working output', async () => {
     const paneKey = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
 
-    await registerAndDispatch()
+    await registerAndDispatch(makeAutomation({ prompt: 'first turn' }))
     expect(countUnchangedObserverHistoryReads(state, latestStoreSubscriber)).toBe(0)
-    const transitionStartedAt = Date.now() + 1
+    const transitionStartedAt = Date.now() + 60_000
     state.agentStatusByPaneKey = {
       [paneKey]: {
         paneKey,
@@ -672,7 +672,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     mockObserveExistingAutomationSession.mockResolvedValue(() => {})
 
     await registerAndDispatch(makeAutomation({ reuseSession: true }))
-    const transitionStartedAt = Date.now() + 1
+    const transitionStartedAt = Date.now() + 60_000
     state.agentStatusByPaneKey = {
       [paneKey]: {
         paneKey,
@@ -709,8 +709,8 @@ describe('useAutomationDispatchEvents setup launch', () => {
     })
     mockObserveExistingAutomationSession.mockResolvedValue(() => {})
 
-    await registerAndDispatch(makeAutomation({ reuseSession: true }))
-    const workingStartedAt = Date.now() + 1
+    await registerAndDispatch(makeAutomation({ prompt: 'turn', reuseSession: true }))
+    const workingStartedAt = Date.now() + 60_000
     state.agentStatusByPaneKey = {
       [paneKey]: {
         paneKey,
@@ -750,27 +750,19 @@ describe('useAutomationDispatchEvents setup launch', () => {
 
   it('consumes duplicate done and zero-exit completion through one finalizer', async () => {
     let launchArgs: {
-      onAgentStatus?: (payload: { state: string }) => void
+      onAgentStatus?: (payload: { state: string; prompt?: string }) => void
       onExit?: (ptyId: string, code: number) => void
     } = {}
     mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
       launchArgs = args
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
+      return makeLaunchResult()
     })
 
     await registerAndDispatch()
-    launchArgs.onAgentStatus?.({ state: 'done' })
+    launchArgs.onAgentStatus?.({ state: 'working', prompt: AUTOMATION_PROMPT })
+    launchArgs.onAgentStatus?.({ state: 'done', prompt: AUTOMATION_PROMPT })
     launchArgs.onExit?.('agent-pty', 0)
-    launchArgs.onAgentStatus?.({ state: 'done' })
+    launchArgs.onAgentStatus?.({ state: 'done', prompt: AUTOMATION_PROMPT })
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
 
     expect(
@@ -785,16 +777,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     let onExit: ((ptyId: string, code: number) => void) | undefined
     mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
       onExit = args.onExit
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
+      return makeLaunchResult()
     })
 
     await registerAndDispatch()
@@ -825,17 +808,9 @@ describe('useAutomationDispatchEvents setup launch', () => {
       .mockRejectedValueOnce(new Error('completion persistence unavailable'))
       .mockResolvedValueOnce(undefined)
     mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
-      args.onAgentStatus?.({ state: 'done' })
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
+      args.onAgentStatus?.({ state: 'working', prompt: AUTOMATION_PROMPT })
+      args.onAgentStatus?.({ state: 'done', prompt: AUTOMATION_PROMPT })
+      return makeLaunchResult()
     })
 
     await registerAndDispatch()
@@ -848,27 +823,19 @@ describe('useAutomationDispatchEvents setup launch', () => {
   })
 
   it('diagnoses a late completed-persistence rejection once without terminal cleanup', async () => {
-    let onAgentStatus: ((payload: { state: string }) => void) | undefined
+    let onAgentStatus: ((payload: { state: string; prompt?: string }) => void) | undefined
     const persistenceError = new Error('late completion persistence unavailable')
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     mockMarkDispatchResult.mockResolvedValueOnce(undefined).mockRejectedValueOnce(persistenceError)
     mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
       onAgentStatus = args.onAgentStatus
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
+      return makeLaunchResult()
     })
 
     await registerAndDispatch()
-    onAgentStatus?.({ state: 'done' })
-    onAgentStatus?.({ state: 'done' })
+    onAgentStatus?.({ state: 'working', prompt: AUTOMATION_PROMPT })
+    onAgentStatus?.({ state: 'done', prompt: AUTOMATION_PROMPT })
+    onAgentStatus?.({ state: 'done', prompt: AUTOMATION_PROMPT })
     await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledOnce())
 
     expect(errorSpy).toHaveBeenCalledWith(

--- a/src/renderer/src/store/slices/agent-status-live-entry-builder.ts
+++ b/src/renderer/src/store/slices/agent-status-live-entry-builder.ts
@@ -96,7 +96,8 @@ export function buildAgentStatusLiveEntry(
         state: existing.state,
         prompt: existing.prompt,
         startedAt: existing.stateStartedAt,
-        interrupted: existing.interrupted
+        interrupted: existing.interrupted,
+        providerSession: existing.providerSession
       }
     ]
     if (history.length > AGENT_STATE_HISTORY_MAX) {

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -65,6 +65,8 @@ export type AgentStateHistoryEntry = {
   /** True when this `done` was a cancellation (agent hook like Claude `is_interrupt`,
    *  or Orca's guarded fallback). Always falsy for non-`done` states so retention logic can preserve it. */
   interrupted?: boolean
+  /** Provider-owned conversation/session id for this historical state, when reported. */
+  providerSession?: AgentProviderSessionMetadata
 }
 
 /** Maximum number of history entries kept per agent to bound memory. */


### PR DESCRIPTION
## ELI5

Automation runs were sometimes watching the terminal instead of the exact Codex turn they launched. A hidden Codex title-generation turn could say "done" first, so Orca thought the scheduled job finished and closed the terminal while the real job was still running.

## What Changed

- Bind automation completion to the provider session that first proves ownership of the scheduled prompt.
- Preserve `providerSession` on `AgentStateHistoryEntry` so late observers can still identify the correct run from history.
- Require a matching `working` edge before accepting direct OSC `done` payloads in dispatch paths.
- Ignore same-pane `done` events from title-generation or other auxiliary sessions.
- Tighten state-history overlap comparison to use the current agent type, so `pi` / `prime-agent` transcript-backed sessions do not collapse by id alone.
- Add regression coverage for cross-session `done`, early direct `done`, title-generation prompts, state-history-only completion recovery, transcript-aware history overlap, and the higher-level automation dispatch event flow.

## Why

Codex can emit status for auxiliary sessions in the same terminal pane, especially with Orca's shared/default `CODEX_HOME`. A pane-level `state === "done"` is therefore not enough evidence that the automation prompt finished. The completion path now treats prompt matching as a bootstrap step to learn the target provider session, then uses provider-session identity as the authoritative completion guard.

## Linked Issue

Fixes #19979

## Visual Proof

No visual change - this is automation completion logic, not UI rendering. The behavioral proof is a source-dev scheduled Codex automation run with Orca's default shared `CODEX_HOME`: a 45s marker wrote both `started` and `after_sleep` before the run completed and the terminal was cleaned up.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed locally on macOS:

- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run build`
- `corepack pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts src/renderer/src/hooks/useAutomationDispatchEvents.test.ts` (33 tests)
- `git diff --check`

Full test attempt:

- `corepack pnpm test` was run twice. The first run exposed six PR-related failures in `src/renderer/src/hooks/useAutomationDispatchEvents.test.ts`; those were fixed and the focused file now passes.
- The second full run progressed past the automation tests, then reported failures outside this PR diff in `tests/e2e/cross-version-wire/release-checkout.unit.test.ts`, `src/main/codex/codex-tui-resume-real-binary.integration.test.ts`, and `config/scripts/skill-recipe-shell.test.mjs`, then stalled with an updater import timeout warning. I interrupted it after it stopped producing output.

Manual source-dev validation:

- Used Orca default/shared Codex home, not real `~/.codex`.
- Ran a scheduled automation with a 45s marker and did not focus/touch the terminal.
- Confirmed `after_sleep` was written before automation completed and terminal cleanup ran.

## AI Disclosure

OpenAI Codex was used to investigate, implement, test, and update this PR.

## Author

X: N/A - not provided.

## Review

Self-review notes:

- Correctness: completion is no longer driven by same-pane `done` alone; provider session identity is required once known.
- Security: no new external input execution path or credential handling change.
- Performance: added matching is constant-time per observed current/history entry and history remains bounded.
- Cross-platform: logic is renderer/store-side and platform-neutral; no path separator, shell, or OS-specific behavior added.
- SSH/remote: unverifiable process loss still does not finalize/clean up live work; provider-session matching applies equally to local and remote status observations.
- Compatibility: direct OSC fallback remains for status producers that do not include provider session, guarded by exact prompt match and working-after-start.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No schema migration is required. `providerSession` is optional on historical status entries, so older records remain readable; they simply cannot satisfy the stricter store-backed session-bound completion path once a target session is known.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `No visual change` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (lint/typecheck/build passed locally; full test was attempted twice but still has non-PR-diff failures/hang as documented above)
