### PR TITLE
Add result-focused agent notification mode

### DIFF
--- a/docs/site/content/docs/notifications.mdx
+++ b/docs/site/content/docs/notifications.mdx
@@ -8,6 +8,8 @@ Orca runs agents, not just terminals, so it knows when an agent actually finishe
 
 When an agent transitions from working to idle, Orca fires a notification — system notification, sound, and a chip on the worktree.
 
+Under **Settings → Notifications → Agent notification mode**, choose **Results and action required** to keep intermediate tool activity visible without making it unread or sending an alert. This mode requests attention only for a meaningful assistant result, an explicit input or approval request, or a structured failure. **All completions and attention** preserves the original behavior.
+
 ## Persistent bell
 
 The header bell shows unread notifications across all worktrees. Clicking a notification jumps to the matching worktree and pane.

--- a/src/main/ipc/notifications-delivery-gating.test.ts
+++ b/src/main/ipc/notifications-delivery-gating.test.ts
@@ -133,6 +133,32 @@ describe('registerNotificationHandlers', () => {
     expect(notificationCtorMock).not.toHaveBeenCalled()
   })
 
+  it('filters progress before tray and native delivery in result-focused mode', async () => {
+    getAllWindowsMock.mockReturnValue([
+      { isDestroyed: () => false, isVisible: () => false, isMinimized: () => false } as never
+    ])
+    registerNotificationHandlers({
+      getSettings: () => ({
+        notifications: {
+          enabled: true,
+          agentTaskComplete: true,
+          agentNotificationMode: 'results-and-actions',
+          terminalBell: true,
+          suppressWhenFocused: false
+        }
+      })
+    } as never)
+
+    const result = await getDispatchHandler()(
+      {},
+      { source: 'agent-task-complete', agentNotificationIntent: 'progress' }
+    )
+
+    expect(result).toEqual({ delivered: false, reason: 'filtered-by-policy' })
+    expect(setTrayAttentionMock).not.toHaveBeenCalled()
+    expect(notificationCtorMock).not.toHaveBeenCalled()
+  })
+
   it('suppresses active-worktree notifications while Orca is focused', async () => {
     getAllWindowsMock.mockReturnValue([
       {

--- a/src/main/ipc/notifications-mobile-fanout.test.ts
+++ b/src/main/ipc/notifications-mobile-fanout.test.ts
@@ -129,6 +129,37 @@ describe('registerNotificationHandlers', () => {
     expect(dispatchMobileNotification).not.toHaveBeenCalled()
   })
 
+  it('filters result-focused progress before mobile fanout', async () => {
+    const dispatchMobileNotification = vi.fn()
+    registerNotificationHandlers(
+      {
+        getSettings: () => ({
+          notifications: {
+            enabled: true,
+            agentTaskComplete: true,
+            agentNotificationMode: 'results-and-actions',
+            terminalBell: true,
+            suppressWhenFocused: false
+          }
+        })
+      } as never,
+      { dispatchMobileNotification } as never
+    )
+
+    expect(
+      await getDispatchHandler()(
+        {},
+        {
+          source: 'agent-task-complete',
+          worktreeId: 'repo::wt1',
+          agentNotificationIntent: 'progress'
+        }
+      )
+    ).toEqual({ delivered: false, reason: 'filtered-by-policy' })
+    expect(dispatchMobileNotification).not.toHaveBeenCalled()
+    expect(notificationCtorMock).not.toHaveBeenCalled()
+  })
+
   it('dispatches one mobile notification when the active worktree is focused on desktop', async () => {
     getAllWindowsMock.mockReturnValue([
       {

--- a/src/main/ipc/notifications.ts
+++ b/src/main/ipc/notifications.ts
@@ -24,6 +24,7 @@ import {
   recordNotificationDeliveryOutcome,
   resetNotificationPermissionEvidence
 } from './notification-permission-probe'
+import { shouldSurfaceAgentNotification } from '../../shared/agent-notification-policy'
 
 export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntimeService): void {
   const recentDesktopNotifications = new Map<string, number>()
@@ -110,7 +111,17 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
       _event,
       args: NotificationDispatchRequest
     ): NotificationDispatchResult | Promise<NotificationDispatchResult> => {
-      // Why: light the tray attention dot before the cooldown/focus/enabled gates so they can't hold it back (clears on window show/restore; see index.ts).
+      const settings = store.getSettings().notifications
+      if (
+        args.source === 'agent-task-complete' &&
+        !shouldSurfaceAgentNotification(
+          settings.agentNotificationMode,
+          args.agentNotificationIntent
+        )
+      ) {
+        return { delivered: false, reason: 'filtered-by-policy' }
+      }
+
       if (args.source === 'agent-task-complete' || args.source === 'terminal-bell') {
         const activeWindow = BrowserWindow.getAllWindows().find((win) => !win.isDestroyed()) ?? null
         if (!isMainWindowVisible(activeWindow)) {
@@ -118,7 +129,6 @@ export function registerNotificationHandlers(store: Store, runtime?: OrcaRuntime
         }
       }
 
-      const settings = store.getSettings().notifications
       if (!settings.enabled) {
         return { delivered: false, reason: 'disabled' }
       }

--- a/src/main/persistence/applying-settings/onboarding-normalization.test.ts
+++ b/src/main/persistence/applying-settings/onboarding-normalization.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeNotificationSettings } from './onboarding-normalization'
+
+describe('normalizeNotificationSettings agent notification mode', () => {
+  it('defaults missing and invalid modes to legacy behavior', () => {
+    expect(normalizeNotificationSettings({}).agentNotificationMode).toBe('all')
+    expect(
+      normalizeNotificationSettings({ agentNotificationMode: 'unexpected' }).agentNotificationMode
+    ).toBe('all')
+  })
+
+  it('preserves the result-focused mode', () => {
+    expect(
+      normalizeNotificationSettings({ agentNotificationMode: 'results-and-actions' })
+        .agentNotificationMode
+    ).toBe('results-and-actions')
+  })
+})

--- a/src/main/persistence/applying-settings/onboarding-normalization.ts
+++ b/src/main/persistence/applying-settings/onboarding-normalization.ts
@@ -4,6 +4,7 @@ import type {
   OnboardingState
 } from '../../../shared/onboarding-state-types'
 import type { NotificationSettings } from '../../../shared/notification-settings-types'
+import { isAgentNotificationMode } from '../../../shared/agent-notification-policy'
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import {
   getDefaultNotificationSettings,
@@ -49,6 +50,9 @@ export function normalizeNotificationSettings(value: unknown): NotificationSetti
   return {
     enabled: booleanOr(candidate.enabled, defaults.enabled),
     agentTaskComplete: booleanOr(candidate.agentTaskComplete, defaults.agentTaskComplete),
+    agentNotificationMode: isAgentNotificationMode(candidate.agentNotificationMode)
+      ? candidate.agentNotificationMode
+      : defaults.agentNotificationMode,
     terminalBell: booleanOr(candidate.terminalBell, defaults.terminalBell),
     suppressWhenFocused: booleanOr(candidate.suppressWhenFocused, defaults.suppressWhenFocused),
     customSoundId,

--- a/src/renderer/src/components/activity/activity-event-build-cache.ts
+++ b/src/renderer/src/components/activity/activity-event-build-cache.ts
@@ -13,11 +13,14 @@ import type {
   ActivityLiveAgentState
 } from './activity-thread-types'
 import { buildPaneActivityEvents } from './activity-pane-events'
+import type { AgentNotificationMode } from '../../../../shared/notification-settings-types'
 
 type PaneActivityCacheEntry = {
   source: unknown
   orchestration: AgentStatusOrchestrationContext | undefined
   acknowledgedAt: number
+  manuallyUnreadAt: number
+  agentNotificationMode: AgentNotificationMode | undefined
   clearedAt: number
   worktree: Worktree
   repo: Repo | null
@@ -46,6 +49,8 @@ export type PaneBuildRequest = {
   agentType: AgentType
   agentAlive: boolean
   acknowledgedAt: number
+  manuallyUnreadAt: number
+  agentNotificationMode: AgentNotificationMode | undefined
   clearedAt: number
   migrationUnsupportedPtyId?: string
   liveState: ActivityLiveAgentState | null
@@ -63,6 +68,8 @@ export function resolvePaneBuild(
     cached.source === request.source &&
     cached.orchestration === request.orchestration &&
     cached.acknowledgedAt === request.acknowledgedAt &&
+    cached.manuallyUnreadAt === request.manuallyUnreadAt &&
+    cached.agentNotificationMode === request.agentNotificationMode &&
     cached.clearedAt === request.clearedAt &&
     cached.worktree === request.worktree &&
     cached.repo === request.repo &&
@@ -96,6 +103,8 @@ export function resolvePaneBuild(
     agentType: request.agentType,
     agentAlive: request.agentAlive,
     acknowledgedAt: request.acknowledgedAt,
+    manuallyUnreadAt: request.manuallyUnreadAt,
+    agentNotificationMode: request.agentNotificationMode,
     clearedAt: request.clearedAt,
     liveState: request.liveState,
     migrationUnsupportedPtyId: request.migrationUnsupportedPtyId
@@ -117,6 +126,8 @@ export function resolvePaneBuild(
     source: request.source,
     orchestration: request.orchestration,
     acknowledgedAt: request.acknowledgedAt,
+    manuallyUnreadAt: request.manuallyUnreadAt,
+    agentNotificationMode: request.agentNotificationMode,
     clearedAt: request.clearedAt,
     worktree: request.worktree,
     repo: request.repo,

--- a/src/renderer/src/components/activity/activity-event-builder-sources.ts
+++ b/src/renderer/src/components/activity/activity-event-builder-sources.ts
@@ -57,6 +57,8 @@ export function appendUnsupportedAndRetainedEvents(context: {
         agentType: entry.agentType ?? 'unknown',
         agentAlive: false,
         acknowledgedAt: args.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0,
+        manuallyUnreadAt: args.manuallyUnreadTurnsByPaneKey?.[entry.paneKey] ?? 0,
+        agentNotificationMode: args.agentNotificationMode,
         clearedAt: args.activityClearedAtByPaneKey?.[entry.paneKey] ?? 0,
         migrationUnsupportedPtyId: unsupported.ptyId,
         liveState: 'blocked'
@@ -94,6 +96,8 @@ export function appendUnsupportedAndRetainedEvents(context: {
         agentType: retained.agentType,
         agentAlive: false,
         acknowledgedAt: args.acknowledgedAgentsByPaneKey[paneKey] ?? 0,
+        manuallyUnreadAt: args.manuallyUnreadTurnsByPaneKey?.[paneKey] ?? 0,
+        agentNotificationMode: args.agentNotificationMode,
         clearedAt: args.activityClearedAtByPaneKey?.[paneKey] ?? 0,
         liveState: null
       },

--- a/src/renderer/src/components/activity/activity-event-builder.live-cap.test.ts
+++ b/src/renderer/src/components/activity/activity-event-builder.live-cap.test.ts
@@ -51,4 +51,51 @@ describe('live activity capacity', () => {
     expect(workingThreads).toHaveLength(81)
     expect(workingThreads.every((thread) => thread.unread)).toBe(true)
   })
+
+  it('keeps progress rows visible but quiet in result-focused mode', () => {
+    const repo = makeRepo()
+    const worktree = makeWorktree()
+    const tab = makeTabWithIds('tab-progress', worktree.id)
+    const paneKey = makePaneKey(tab.id, LEAF_ID)
+    const entry: AgentStatusEntry = {
+      paneKey,
+      state: 'working',
+      prompt: 'Run checks',
+      stateStartedAt: 2_000,
+      updatedAt: 3_000,
+      stateHistory: [
+        {
+          state: 'done',
+          prompt: 'Previous result',
+          startedAt: 1_000,
+          notificationIntent: 'result'
+        }
+      ],
+      agentType: 'codex',
+      toolName: 'Bash',
+      toolInput: 'pnpm test'
+    }
+    const build = (manuallyUnreadTurnsByPaneKey?: Record<string, number>) =>
+      buildActivityEvents({
+        agentStatusByPaneKey: { [paneKey]: entry },
+        retainedAgentsByPaneKey: {},
+        tabsByWorktree: { [worktree.id]: [tab] },
+        worktreeMap: new Map([[worktree.id, worktree]]),
+        repoMap: new Map([[repo.id, repo]]),
+        acknowledgedAgentsByPaneKey: {},
+        manuallyUnreadTurnsByPaneKey,
+        agentNotificationMode: 'results-and-actions',
+        now: 3_000
+      }).events
+
+    expect(build()).toEqual([
+      expect.objectContaining({ timestamp: 2_000, state: 'working', unread: false }),
+      expect.objectContaining({ timestamp: 1_000, state: 'done', unread: true })
+    ])
+    expect(build({ [paneKey]: 2_000 })[0]).toMatchObject({
+      timestamp: 2_000,
+      state: 'working',
+      unread: true
+    })
+  })
 })

--- a/src/renderer/src/components/activity/activity-event-builder.ts
+++ b/src/renderer/src/components/activity/activity-event-builder.ts
@@ -11,6 +11,7 @@ import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { Tab } from '../../../../shared/tab-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { Worktree } from '../../../../shared/worktree/types'
+import type { AgentNotificationMode } from '../../../../shared/notification-settings-types'
 import type { ActivityEvent, ActivityLiveAgentSnapshot } from './activity-thread-types'
 import { capActivityEvents } from './activity-event-cap'
 import { newestActivityHistoryEntries } from './activity-pane-events'
@@ -42,6 +43,8 @@ export type BuildActivityEventsArgs = {
   repos?: readonly Repo[]
   resolveWorktree?: (worktreeId: string, executionHostId?: ExecutionHostId) => Worktree | undefined
   acknowledgedAgentsByPaneKey: Record<string, number>
+  manuallyUnreadTurnsByPaneKey?: Record<string, number>
+  agentNotificationMode?: AgentNotificationMode
   /** Per-pane "Clear completed" cutoffs; events stamped at or before the cutoff are hidden. */
   activityClearedAtByPaneKey?: Record<string, number>
   now: number
@@ -107,6 +110,8 @@ export function buildActivityEvents(
         agentType: entry.agentType ?? 'unknown',
         agentAlive: true,
         acknowledgedAt: args.acknowledgedAgentsByPaneKey[paneKey] ?? 0,
+        manuallyUnreadAt: args.manuallyUnreadTurnsByPaneKey?.[paneKey] ?? 0,
+        agentNotificationMode: args.agentNotificationMode,
         clearedAt: args.activityClearedAtByPaneKey?.[paneKey] ?? 0,
         liveState
       },

--- a/src/renderer/src/components/activity/activity-pane-events.ts
+++ b/src/renderer/src/components/activity/activity-pane-events.ts
@@ -12,6 +12,14 @@ import type {
   ActivityLiveAgentState
 } from './activity-thread-types'
 import { EVENTS_PER_PANE_CAP } from './activity-event-cap'
+import {
+  classifyAgentNotificationIntent,
+  shouldSurfaceAgentNotification
+} from '../../../../shared/agent-notification-policy'
+import type {
+  AgentNotificationIntent,
+  AgentNotificationMode
+} from '../../../../shared/notification-settings-types'
 
 function historyEntrySnapshot(
   entry: AgentStatusEntry,
@@ -53,6 +61,8 @@ type PaneEventInputs = {
   agentType: AgentStatusEntry['agentType']
   agentAlive: boolean
   acknowledgedAt: number
+  manuallyUnreadAt: number
+  agentNotificationMode: AgentNotificationMode | undefined
   clearedAt: number
   liveState: ActivityLiveAgentState | null
   migrationUnsupportedPtyId?: string
@@ -62,7 +72,12 @@ type PaneEventInputs = {
 export function buildPaneActivityEvents(args: PaneEventInputs): ActivityEvent[] {
   const events: ActivityEvent[] = []
   const seenIds = new Set<string>()
-  const append = (state: ActivityEventState, timestamp: number, entry: AgentStatusEntry): void => {
+  const append = (
+    state: ActivityEventState,
+    timestamp: number,
+    entry: AgentStatusEntry,
+    notificationIntent: AgentNotificationIntent | undefined
+  ): void => {
     const id = `agent:${entry.paneKey}:${state}:${timestamp}`
     if (seenIds.has(id)) {
       return
@@ -79,7 +94,10 @@ export function buildPaneActivityEvents(args: PaneEventInputs): ActivityEvent[] 
       agentType: args.agentType ?? 'unknown',
       agentAlive: args.agentAlive,
       migrationUnsupportedPtyId: args.migrationUnsupportedPtyId,
-      unread: args.acknowledgedAt < timestamp
+      unread:
+        args.manuallyUnreadAt === timestamp ||
+        (shouldSurfaceAgentNotification(args.agentNotificationMode, notificationIntent) &&
+          args.acknowledgedAt < timestamp)
     })
   }
 
@@ -93,7 +111,8 @@ export function buildPaneActivityEvents(args: PaneEventInputs): ActivityEvent[] 
     append(
       history.state as ActivityEventState,
       history.startedAt,
-      historyEntrySnapshot(args.entry, history)
+      historyEntrySnapshot(args.entry, history),
+      history.notificationIntent
     )
   }
 
@@ -108,6 +127,11 @@ export function buildPaneActivityEvents(args: PaneEventInputs): ActivityEvent[] 
   if (args.entry.stateStartedAt <= args.clearedAt) {
     return events
   }
-  append(currentState, args.entry.stateStartedAt, args.entry)
+  append(
+    currentState,
+    args.entry.stateStartedAt,
+    args.entry,
+    classifyAgentNotificationIntent(args.entry)
+  )
   return events
 }

--- a/src/renderer/src/components/activity/use-agent-pane-threads.ts
+++ b/src/renderer/src/components/activity/use-agent-pane-threads.ts
@@ -7,6 +7,7 @@ import {
   getSettingsFocusedExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
+import type { AgentNotificationMode } from '../../../../shared/notification-settings-types'
 import { buildActivityEvents, createActivityEventBuildCache } from './activity-event-builder'
 import { projectActivityTabs, type ActivityTabProjection } from './activity-tab-projection'
 import { buildAgentPaneThreads, createAgentPaneThreadReuseCache } from './activity-thread-builder'
@@ -39,6 +40,7 @@ export type AgentPaneThreadsStoreData = Pick<
   | 'detectedWorktreesByRepo'
   | 'getKnownWorktreeById'
   | 'acknowledgedAgentsByPaneKey'
+  | 'manuallyUnreadTurnsByPaneKey'
   | 'activityClearedAtByPaneKey'
   | 'acknowledgeAgents'
   | 'unacknowledgeAgents'
@@ -48,6 +50,7 @@ export type AgentPaneThreadsStoreData = Pick<
   worktreeMap: ReturnType<typeof getWorktreeMapFromState>
   repoMap: ReturnType<typeof getRepoMapFromState>
   generatedTitlesEnabled: boolean
+  agentNotificationMode: AgentNotificationMode | undefined
   /** Focused-host fallback for hostless worktrees, shared by the scope filter and the row actions. */
   defaultHostId: ExecutionHostId
 }
@@ -107,10 +110,12 @@ export function useAgentPaneThreads(args: {
       worktreeMap: getWorktreeMapFromState(s),
       repoMap: getRepoMapFromState(s),
       acknowledgedAgentsByPaneKey: s.acknowledgedAgentsByPaneKey,
+      manuallyUnreadTurnsByPaneKey: s.manuallyUnreadTurnsByPaneKey,
       activityClearedAtByPaneKey: s.activityClearedAtByPaneKey,
       acknowledgeAgents: s.acknowledgeAgents,
       unacknowledgeAgents: s.unacknowledgeAgents,
       generatedTitlesEnabled: s.settings?.tabAutoGenerateTitle === true,
+      agentNotificationMode: s.settings?.notifications?.agentNotificationMode,
       defaultHostId: getSettingsFocusedExecutionHostId(s.settings)
     }))
   )
@@ -141,6 +146,8 @@ export function useAgentPaneThreads(args: {
           repos: storeData.repos,
           resolveWorktree: storeData.getKnownWorktreeById,
           acknowledgedAgentsByPaneKey: storeData.acknowledgedAgentsByPaneKey,
+          manuallyUnreadTurnsByPaneKey: storeData.manuallyUnreadTurnsByPaneKey,
+          agentNotificationMode: storeData.agentNotificationMode,
           activityClearedAtByPaneKey: storeData.activityClearedAtByPaneKey,
           // Why: Date.now() is read in the memo body (not a dep) so stale-decay recomputes when agentStatusEpoch ticks, not on wall-clock time.
           now: Date.now()

--- a/src/renderer/src/components/settings/AgentNotificationModeSetting.tsx
+++ b/src/renderer/src/components/settings/AgentNotificationModeSetting.tsx
@@ -1,0 +1,70 @@
+import type { AgentNotificationMode } from '../../../../shared/notification-settings-types'
+import { isAgentNotificationMode } from '../../../../shared/agent-notification-policy'
+import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { translate } from '@/i18n/i18n'
+
+type AgentNotificationModeSettingProps = {
+  value: AgentNotificationMode
+  disabled: boolean
+  onChange: (value: AgentNotificationMode) => void
+}
+
+export function AgentNotificationModeSetting({
+  value,
+  disabled,
+  onChange
+}: AgentNotificationModeSettingProps): React.JSX.Element {
+  return (
+    <div className="space-y-2 py-2 pl-6">
+      <div className="space-y-1">
+        <Label>
+          {translate(
+            'auto.components.settings.AgentNotificationModeSetting.label',
+            'Agent notification mode'
+          )}
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.AgentNotificationModeSetting.description',
+            'Choose whether intermediate agent activity should request your attention.'
+          )}
+        </p>
+      </div>
+      <Select
+        value={value}
+        disabled={disabled}
+        onValueChange={(nextValue) => {
+          if (isAgentNotificationMode(nextValue)) {
+            onChange(nextValue)
+          }
+        }}
+      >
+        <SelectTrigger
+          size="sm"
+          className="w-full max-w-72"
+          aria-label={translate(
+            'auto.components.settings.AgentNotificationModeSetting.label',
+            'Agent notification mode'
+          )}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">
+            {translate(
+              'auto.components.settings.AgentNotificationModeSetting.all',
+              'All completions and attention'
+            )}
+          </SelectItem>
+          <SelectItem value="results-and-actions">
+            {translate(
+              'auto.components.settings.AgentNotificationModeSetting.resultsAndActions',
+              'Results and action required'
+            )}
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/NotificationsPane.test.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.test.tsx
@@ -29,6 +29,7 @@ function createSettings(): GlobalSettings {
     notifications: {
       enabled: true,
       agentTaskComplete: true,
+      agentNotificationMode: 'results-and-actions',
       terminalBell: true,
       suppressWhenFocused: true,
       customSoundId: 'system',
@@ -55,6 +56,10 @@ describe('NotificationsPane', () => {
     )
 
     expect(html).toContain('Notification Sound')
+    expect(html).toContain('Agent notification mode')
+    expect(html).toContain(
+      'Choose whether intermediate agent activity should request your attention.'
+    )
     expect(getNotificationSoundOptions(null).map((option) => option.title)).toEqual(
       expect.arrayContaining(['System Default', 'Two Tone', 'Bong', 'Ding'])
     )

--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -9,6 +9,7 @@ import {
   useMacNotificationPermissionState
 } from '@/components/notifications/mac-notification-permission-card'
 import { NotificationSettingToggle } from './NotificationSettingToggle'
+import { AgentNotificationModeSetting } from './AgentNotificationModeSetting'
 import { NotificationSoundSection } from './NotificationSoundSection'
 import {
   createNotificationVolumeDraftState,
@@ -144,6 +145,14 @@ export function NotificationsPane({
           void updateNotificationSettings({
             agentTaskComplete: !notificationSettings.agentTaskComplete
           })
+        }
+      />
+
+      <AgentNotificationModeSetting
+        value={notificationSettings.agentNotificationMode ?? 'all'}
+        disabled={!notificationSettings.enabled || !notificationSettings.agentTaskComplete}
+        onChange={(agentNotificationMode) =>
+          void updateNotificationSettings({ agentNotificationMode })
         }
       />
 

--- a/src/renderer/src/components/settings/notifications-search.ts
+++ b/src/renderer/src/components/settings/notifications-search.ts
@@ -58,6 +58,27 @@ export const getNotificationsPaneSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate(
+      'auto.components.settings.notifications.search.agentNotificationMode',
+      'Agent notification mode'
+    ),
+    description: translate(
+      'auto.components.settings.notifications.search.agentNotificationModeDescription',
+      'Choose whether intermediate agent activity should request attention.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.notifications.search.results', 'results'),
+      ...translateSearchKeyword(
+        'auto.components.settings.notifications.search.actionRequired',
+        'action required'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.notifications.search.progress',
+        'progress'
+      )
+    ]
+  },
+  {
     title: translate('auto.components.settings.notifications.search.a5edee1d99', 'Terminal Bell'),
     description: translate(
       'auto.components.settings.notifications.search.d3f1c48677',

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -33,6 +33,7 @@ type MockState = {
     notifications?: {
       customSoundPath?: string | null
       customSoundId?: string | null
+      agentNotificationMode?: 'all' | 'results-and-actions'
     }
   }
   markWorktreeUnread: ReturnType<typeof vi.fn>
@@ -188,6 +189,28 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
     expect(mockState.markTerminalTabUnread).toHaveBeenCalledWith('tab-1')
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
+  })
+
+  it('filters progress before unread and delivery side effects in result-focused mode', () => {
+    mockState.settings.notifications = { agentNotificationMode: 'results-and-actions' }
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      toolName: 'Bash'
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: mockState.agentStatusByPaneKey[paneKey]
+    })
+
+    const sideEffects = [
+      window.api.notifications.dispatch,
+      mockState.markWorktreeUnread,
+      playDesktopNotificationSound
+    ]
+    sideEffects.forEach((sideEffect) => expect(sideEffect).not.toHaveBeenCalled())
   })
 
   it('builds the notification id from a completion snapshot, not the pinned working row', () => {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -5,6 +5,10 @@ import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { playDesktopNotificationSound } from '@/lib/desktop-notification-sound'
 import { showBlockedNotificationFallbackToast } from '@/lib/blocked-notification-fallback'
 import { buildAgentNotificationId } from '../../../../shared/agent-notification-id'
+import {
+  classifyAgentNotificationIntent,
+  shouldSurfaceAgentNotification
+} from '../../../../shared/agent-notification-policy'
 import { shareCompatibleTitleIdentityGroup } from '../../../../shared/agent-title-owner'
 import {
   isFreshNonDoneAgentStatus,
@@ -118,6 +122,19 @@ export function dispatchTerminalNotification(
   ) {
     return
   }
+  const agentNotificationIntent =
+    event.source === 'agent-task-complete'
+      ? classifyAgentNotificationIntent(agentStatus)
+      : undefined
+  if (
+    event.source === 'agent-task-complete' &&
+    !shouldSurfaceAgentNotification(
+      state.settings?.notifications?.agentNotificationMode,
+      agentNotificationIntent
+    )
+  ) {
+    return
+  }
   const agentNotificationStateStartedAt =
     eventAgentStatusSnapshot?.stateStartedAt ?? freshStoredAgentStatus?.stateStartedAt
   // Why: main-process hook IPC can update inactive/unmounted worktrees before
@@ -223,6 +240,7 @@ export function dispatchTerminalNotification(
       hasMultipleActiveRepos: countReposNeedingNotificationDisambiguation(state) > 1,
       terminalTitle: event.terminalTitle,
       isActiveWorktree: state.activeWorktreeId === worktreeId,
+      ...(agentNotificationIntent ? { agentNotificationIntent } : {}),
       ...agentSnapshot
     })
     .then((result) => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9952,7 +9952,12 @@
             "72539aede4": "system",
             "51ae2183e1": "desktop",
             "0534c76311": "Master switch for Orca desktop notifications.",
-            "4a210b2f72": "Enable Notifications"
+            "4a210b2f72": "Enable Notifications",
+            "agentNotificationMode": "Agent notification mode",
+            "agentNotificationModeDescription": "Choose whether intermediate agent activity should request attention.",
+            "results": "results",
+            "actionRequired": "action required",
+            "progress": "progress"
           }
         },
         "orchestration": {
@@ -11839,6 +11844,12 @@
           "targetDescription": "Higher values increase contrast where possible. Background colors stay unchanged.",
           "subtle": "Subtle",
           "strong": "Strong"
+        },
+        "AgentNotificationModeSetting": {
+          "label": "Agent notification mode",
+          "description": "Choose whether intermediate agent activity should request your attention.",
+          "all": "All completions and attention",
+          "resultsAndActions": "Results and action required"
         }
       },
       "right": {

--- a/src/renderer/src/store/slices/agent-status-batch.test.ts
+++ b/src/renderer/src/store/slices/agent-status-batch.test.ts
@@ -187,7 +187,7 @@ describe('setAgentStatuses', () => {
     )
     expect(
       batchStore.getState().agentStatusByPaneKey[FIRST_PANE].stateHistory.at(-1)
-    ).toMatchObject({ state: 'done' })
+    ).toMatchObject({ state: 'done', notificationIntent: 'result' })
     // The swallowed `done`'s output survives on the entry, not on the history row.
     expect(
       batchStore.getState().agentStatusByPaneKey[FIRST_PANE].lastCompletedAssistantMessage

--- a/src/renderer/src/store/slices/agent-status-live-entry-builder.ts
+++ b/src/renderer/src/store/slices/agent-status-live-entry-builder.ts
@@ -19,6 +19,7 @@ import {
   shouldSuppressInheritedTerminalStatus
 } from '../../../../shared/agent-status-identity'
 import { isCommandCodeNewTurnWhileWorking } from '../../../../shared/command-code-turn-boundary'
+import { classifyAgentNotificationIntent } from '../../../../shared/agent-notification-policy'
 import type {
   AgentStatusMetadata,
   AgentStatusPayload,
@@ -96,7 +97,8 @@ export function buildAgentStatusLiveEntry(
         state: existing.state,
         prompt: existing.prompt,
         startedAt: existing.stateStartedAt,
-        interrupted: existing.interrupted
+        interrupted: existing.interrupted,
+        notificationIntent: classifyAgentNotificationIntent(existing)
       }
     ]
     if (history.length > AGENT_STATE_HISTORY_MAX) {

--- a/src/shared/agent-notification-policy.test.ts
+++ b/src/shared/agent-notification-policy.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from './agent-status-types'
+import type { OrchestrationFleetAttentionCategory } from './orchestration-fleet-attention'
+import {
+  classifyAgentNotificationIntent,
+  shouldSurfaceAgentNotification
+} from './agent-notification-policy'
+
+type Facts = Pick<
+  AgentStatusEntry,
+  | 'state'
+  | 'interactivePrompt'
+  | 'lastAssistantMessage'
+  | 'lastAssistantMessageIsToolOutput'
+  | 'sessionBoundary'
+  | 'orchestration'
+>
+
+function facts(overrides: Partial<Facts> = {}): Facts {
+  return { state: 'working', ...overrides }
+}
+
+function orchestration(
+  categories: OrchestrationFleetAttentionCategory[],
+  dispatchStatus: NonNullable<AgentStatusEntry['orchestration']>['dispatchStatus'] = 'dispatched'
+): AgentStatusEntry['orchestration'] {
+  return {
+    taskId: 'task-1',
+    dispatchId: 'dispatch-1',
+    dispatchStatus,
+    attention: { categories, requiresAction: categories.length > 0 }
+  }
+}
+
+describe('agent notification policy', () => {
+  it.each([
+    ['working tool use', facts()],
+    [
+      'tool-only completion',
+      facts({
+        state: 'done',
+        lastAssistantMessage: 'tool output',
+        lastAssistantMessageIsToolOutput: true
+      })
+    ],
+    ['generic waiting', facts({ state: 'waiting' })],
+    ['generic blocked', facts({ state: 'blocked' })],
+    [
+      'session boundary',
+      facts({ state: 'done', sessionBoundary: true, lastAssistantMessage: 'restored' })
+    ],
+    ['stale orchestration', facts({ orchestration: orchestration(['stale']) })]
+  ])('classifies %s as progress', (_name, entry) => {
+    expect(classifyAgentNotificationIntent(entry)).toBe('progress')
+  })
+
+  it('classifies assistant prose and root completion as results', () => {
+    expect(
+      classifyAgentNotificationIntent(facts({ state: 'done', lastAssistantMessage: 'Finished.' }))
+    ).toBe('result')
+    expect(
+      classifyAgentNotificationIntent(facts({ orchestration: orchestration(['root_completion']) }))
+    ).toBe('result')
+  })
+
+  it.each(['input', 'approval', 'guidance'] as const)(
+    'classifies %s orchestration as action required',
+    (category) => {
+      expect(
+        classifyAgentNotificationIntent(facts({ orchestration: orchestration([category]) }))
+      ).toBe('action-required')
+    }
+  )
+
+  it('classifies an interactive prompt as action required', () => {
+    expect(
+      classifyAgentNotificationIntent(facts({ interactivePrompt: '{"question":"Pick"}' }))
+    ).toBe('action-required')
+  })
+
+  it.each(['failure', 'interruption', 'unverifiable'] as const)(
+    'classifies %s orchestration as failure',
+    (category) => {
+      expect(
+        classifyAgentNotificationIntent(facts({ orchestration: orchestration([category]) }))
+      ).toBe('failure')
+    }
+  )
+
+  it('classifies failed lifecycle states as failure', () => {
+    expect(
+      classifyAgentNotificationIntent(facts({ orchestration: orchestration([], 'failed') }))
+    ).toBe('failure')
+    expect(
+      classifyAgentNotificationIntent(facts({ orchestration: orchestration([], 'circuit_broken') }))
+    ).toBe('failure')
+  })
+
+  it('preserves legacy mode and filters only progress in result-focused mode', () => {
+    expect(shouldSurfaceAgentNotification('all', 'progress')).toBe(true)
+    expect(shouldSurfaceAgentNotification(undefined, undefined)).toBe(true)
+    expect(shouldSurfaceAgentNotification('results-and-actions', undefined)).toBe(false)
+    expect(shouldSurfaceAgentNotification('results-and-actions', 'progress')).toBe(false)
+    expect(shouldSurfaceAgentNotification('results-and-actions', 'result')).toBe(true)
+    expect(shouldSurfaceAgentNotification('results-and-actions', 'action-required')).toBe(true)
+    expect(shouldSurfaceAgentNotification('results-and-actions', 'failure')).toBe(true)
+  })
+})

--- a/src/shared/agent-notification-policy.ts
+++ b/src/shared/agent-notification-policy.ts
@@ -1,0 +1,71 @@
+import type { AgentStatusEntry } from './agent-status-types'
+import {
+  AGENT_NOTIFICATION_MODES,
+  type AgentNotificationIntent,
+  type AgentNotificationMode
+} from './notification-settings-types'
+import type { OrchestrationFleetAttentionCategory } from './orchestration-fleet-attention'
+
+const FAILURE_CATEGORIES = new Set<OrchestrationFleetAttentionCategory>([
+  'failure',
+  'interruption',
+  'unverifiable'
+])
+const ACTION_CATEGORIES = new Set<OrchestrationFleetAttentionCategory>([
+  'input',
+  'approval',
+  'guidance'
+])
+
+export function isAgentNotificationMode(value: unknown): value is AgentNotificationMode {
+  return AGENT_NOTIFICATION_MODES.some((mode) => mode === value)
+}
+
+export function shouldSurfaceAgentNotification(
+  mode: AgentNotificationMode | undefined,
+  intent: AgentNotificationIntent | undefined
+): boolean {
+  return mode !== 'results-and-actions' || (intent !== undefined && intent !== 'progress')
+}
+
+type AgentNotificationFacts = Pick<
+  AgentStatusEntry,
+  | 'state'
+  | 'interactivePrompt'
+  | 'lastAssistantMessage'
+  | 'lastAssistantMessageIsToolOutput'
+  | 'sessionBoundary'
+  | 'orchestration'
+>
+
+export function classifyAgentNotificationIntent(
+  entry: AgentNotificationFacts | undefined
+): AgentNotificationIntent {
+  if (!entry || entry.sessionBoundary === true) {
+    return 'progress'
+  }
+  const orchestration = entry.orchestration
+  const categories = orchestration?.attention?.categories ?? []
+  if (
+    orchestration?.dispatchStatus === 'failed' ||
+    orchestration?.dispatchStatus === 'circuit_broken' ||
+    categories.some((category) => FAILURE_CATEGORIES.has(category))
+  ) {
+    return 'failure'
+  }
+  if (
+    Boolean(entry.interactivePrompt?.trim()) ||
+    categories.some((category) => ACTION_CATEGORIES.has(category))
+  ) {
+    return 'action-required'
+  }
+  if (
+    categories.includes('root_completion') ||
+    (entry.state === 'done' &&
+      entry.lastAssistantMessageIsToolOutput !== true &&
+      Boolean(entry.lastAssistantMessage?.trim()))
+  ) {
+    return 'result'
+  }
+  return 'progress'
+}

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -5,6 +5,7 @@
 import type { AgentProviderSessionMetadata } from './agent-session-resume'
 import type { OrchestrationFleetAttention } from './orchestration-fleet-attention'
 import type { AgentStatusRowFacets } from './agent-status-observation'
+import type { AgentNotificationIntent } from './notification-settings-types'
 import {
   normalizeInteractivePromptField,
   normalizeOptionalField,
@@ -65,6 +66,8 @@ export type AgentStateHistoryEntry = {
   /** True when this `done` was a cancellation (agent hook like Claude `is_interrupt`,
    *  or Orca's guarded fallback). Always falsy for non-`done` states so retention logic can preserve it. */
   interrupted?: boolean
+  /** Notification meaning captured before live fields are cleared by the next transition. */
+  notificationIntent?: AgentNotificationIntent
 }
 
 /** Maximum number of history entries kept per agent to bound memory. */

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -122,6 +122,7 @@ export function getDefaultNotificationSettings(): NotificationSettings {
   return {
     enabled: true,
     agentTaskComplete: true,
+    agentNotificationMode: 'all',
     terminalBell: false,
     suppressWhenFocused: true,
     customSoundId: 'system',

--- a/src/shared/notification-settings-types.ts
+++ b/src/shared/notification-settings-types.ts
@@ -1,8 +1,21 @@
 import type { AgentStatusState, AgentType } from './agent-status-types'
 
+export const AGENT_NOTIFICATION_MODES = ['all', 'results-and-actions'] as const
+export type AgentNotificationMode = (typeof AGENT_NOTIFICATION_MODES)[number]
+
+export const AGENT_NOTIFICATION_INTENTS = [
+  'progress',
+  'result',
+  'action-required',
+  'failure'
+] as const
+export type AgentNotificationIntent = (typeof AGENT_NOTIFICATION_INTENTS)[number]
+
 export type NotificationSettings = {
   enabled: boolean
   agentTaskComplete: boolean
+  /** Missing values preserve the legacy all-events behavior for mixed-version settings. */
+  agentNotificationMode?: AgentNotificationMode
   terminalBell: boolean
   suppressWhenFocused: boolean
   customSoundId:
@@ -43,6 +56,7 @@ export type NotificationDispatchRequest = {
   agentToolInput?: string
   agentLastAssistantMessage?: string
   agentInterrupted?: boolean
+  agentNotificationIntent?: AgentNotificationIntent
 }
 
 export type NotificationDispatchResult = {
@@ -51,6 +65,7 @@ export type NotificationDispatchResult = {
   reason?:
     | 'disabled'
     | 'source-disabled'
+    | 'filtered-by-policy'
     | 'suppressed-focus'
     | 'cooldown'
     | 'not-supported'

--- a/tests/e2e/notification-settings.spec.ts
+++ b/tests/e2e/notification-settings.spec.ts
@@ -11,8 +11,9 @@ async function getSettings(
 async function openNotificationSettings(
   page: Parameters<typeof waitForSessionReady>[0]
 ): Promise<void> {
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     const state = window.__store!.getState()
+    await state.updateSettings({ uiLanguage: 'en' })
     state.openSettingsTarget({ pane: 'notifications', repoId: null })
     state.openSettingsPage()
   })
@@ -44,6 +45,9 @@ test.describe('Notification settings', () => {
       name: 'Agent Task Complete'
     })
     const terminalBellSwitch = notificationsSection.getByRole('switch', { name: 'Terminal Bell' })
+    const agentNotificationMode = notificationsSection.getByRole('combobox', {
+      name: 'Agent notification mode'
+    })
     const suppressWhileFocusedSwitch = notificationsSection.getByRole('switch', {
       name: 'Suppress While Focused'
     })
@@ -53,9 +57,20 @@ test.describe('Notification settings', () => {
 
     await expect(enableNotificationsSwitch).toHaveAttribute('aria-checked', 'true')
     await expect(agentTaskCompleteSwitch).toBeEnabled()
+    await expect(agentNotificationMode).toBeEnabled()
     await expect(terminalBellSwitch).toBeEnabled()
     await expect(suppressWhileFocusedSwitch).toBeEnabled()
     await expect(sendTestButton).toBeEnabled()
+
+    await agentNotificationMode.click()
+    await orcaPage.getByRole('option', { name: 'Results and action required' }).click()
+    await expect(agentNotificationMode).toContainText('Results and action required')
+    await expect
+      .poll(async () => (await getSettings(orcaPage)).notifications.agentNotificationMode, {
+        timeout: 5_000,
+        message: 'agent notification mode did not persist'
+      })
+      .toBe('results-and-actions')
 
     await agentTaskCompleteSwitch.click()
     await expect(agentTaskCompleteSwitch).toHaveAttribute('aria-checked', 'false')
@@ -65,10 +80,12 @@ test.describe('Notification settings', () => {
         message: 'agent task-complete notification setting did not persist after disabling'
       })
       .toBe(false)
+    await expect(agentNotificationMode).toBeDisabled()
 
     await enableNotificationsSwitch.click()
     await expect(enableNotificationsSwitch).toHaveAttribute('aria-checked', 'false')
     await expect(agentTaskCompleteSwitch).toBeDisabled()
+    await expect(agentNotificationMode).toBeDisabled()
     await expect(terminalBellSwitch).toBeDisabled()
     await expect(suppressWhileFocusedSwitch).toBeDisabled()
     await expect(sendTestButton).toBeDisabled()


### PR DESCRIPTION
## ELI5

Orca can keep showing every agent step in Activity while only asking for attention when there is a useful result, a question or approval request, or a failure.

## What Changed

- Added an Agent notification mode setting with legacy All completions and attention and opt-in Results and action required choices.
- Added one shared structured intent classifier for progress, result, action-required, and failure states.
- Applied the policy before Activity unread state and before renderer, main-process, tray, sound, native desktop, and mobile delivery side effects.
- Preserved terminal bell, test notifications, manual Mark Unread, and legacy behavior when the new setting is absent.
- Stored intent with agent history so old progress rows remain visible without becoming attention events.
- Added documentation, search metadata, localization catalog entries, unit/integration coverage, and settings E2E coverage.

## Why

Intermediate shell commands, searches, test runs, and waiting transitions are useful history, but they should not interrupt users who only want results or situations requiring action. A structured policy keeps those rows visible while consistently suppressing their attention side effects without brittle message-text matching.

## Linked Issue

Fixes #19880

## Visual Proof

The screenshots use synthetic E2E settings state and contain no private task content.

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Before, light theme](https://github.com/user-attachments/assets/99d76618-866d-41b7-a7bb-de149d91d5f3) | ![After, light theme](https://github.com/user-attachments/assets/aff18ca5-2976-46c0-b2f8-bae1b937436d) |
| Dark | ![Before, dark theme](https://github.com/user-attachments/assets/f2c19667-ace4-4f93-b3fb-332fec5c882d) | ![After, dark theme](https://github.com/user-attachments/assets/806b5992-07d5-4b8f-bbb6-e87e5ad68e83) |

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- pnpm lint: pass
- pnpm typecheck: pass
- pnpm build: pass on macOS
- Focused notification suite: 94/94 pass across 8 files
- Notification settings Electron E2E: 1/1 pass
- Full Vitest suite: 77,878 pass, 388 skip, 5 fail. The same five failures reproduce unchanged on the baseline worktree and depend on the local shell / installed Claude CLI: one shell recipe cleanup assertion, two real Claude structured CLI expectations, one Claude trust prompt integration, and one installed Claude path expectation.

## AI Disclosure

Implemented and reviewed with OpenAI Codex (GPT-5).

## Review

- Security: no new external input, credential, or filesystem boundary; persisted setting values are validated during normalization.
- Cross-platform: policy logic is shared TypeScript with no platform-specific API. Production desktop, web, and macOS native builds pass.
- Remote SSH: intent classification operates on existing normalized agent status and orchestration metadata, so local and remote activity use the same path.
- Mobile: main-process fanout applies the same policy before mobile delivery; covered by a regression test.
- Agent/integration compatibility: missing settings preserve legacy behavior, unknown or missing intent fails quiet only in the opt-in result-focused mode, and terminal bell/test notification behavior is unchanged.
- Performance: constant-time classification over the existing bounded attention category list; Activity cache keys include the two new policy inputs.
- UI: the setting follows the existing notification hierarchy, disables with its parent controls, persists across reload, and was checked in light and dark themes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No new security, platform, remote SSH, or backward-compatibility issue found in self-review. The feature is opt-in; existing users retain the current notification behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (full test has five baseline-identical environment failures documented above; CI will provide a clean environment)

## Author

X (Twitter): N/A
