### PR TITLE
fix(test): keep the suite from deleting the developer's Claude credentials via CLAUDE_CONFIG_DIR

### DIFF
--- a/config/scripts/vitest-claude-env-isolation.test.ts
+++ b/config/scripts/vitest-claude-env-isolation.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+
+describe('Claude config isolation', () => {
+  it('never lets a test see the host session CLAUDE_CONFIG_DIR', () => {
+    // Launched from a Claude Code session, the variable names the developer's real
+    // account, and the runtime-auth tests would delete and rewrite its credentials —
+    // logging out every session on that account.
+    expect(process.env.CLAUDE_CONFIG_DIR).toBeUndefined()
+  })
+})

--- a/config/scripts/vitest-claude-env-isolation.ts
+++ b/config/scripts/vitest-claude-env-isolation.ts
@@ -1,0 +1,4 @@
+// Why: a host Claude Code session exports CLAUDE_CONFIG_DIR and Orca honours it, so
+// runtime-auth tests that believe they use a temp dir delete and rewrite the
+// developer's real credentials. Tests that need the variable set it themselves.
+delete process.env.CLAUDE_CONFIG_DIR

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     execArgv: ['--no-experimental-webstorage', '--expose-gc'],
     // Why: happy-dom drops MutationObserver callbacks on GC; keep them alive like a browser does.
     setupFiles: [
+      resolve('config/scripts/vitest-claude-env-isolation.ts'),
       resolve('config/scripts/happy-dom-offscreen-canvas.ts'),
       resolve('config/scripts/happy-dom-mutation-observer-retention.ts'),
       resolve('config/scripts/vitest-host-ports-setup.ts')

--- a/tests/e2e/helpers/electron-home-isolation.ts
+++ b/tests/e2e/helpers/electron-home-isolation.ts
@@ -9,6 +9,8 @@ const RESTRICTED_ENV_KEYS = new Set([
   'HOMEPATH',
   'CODEX_HOME',
   'ORCA_CODEX_HOME',
+  // A host Claude Code session's real account; Orca and its agents would write through it.
+  'CLAUDE_CONFIG_DIR',
   'ORCA_E2E_USER_DATA_DIR',
   'ORCA_E2E_HOME_DIR',
   'ZDOTDIR',

--- a/tests/e2e/helpers/electron-home-isolation.unit.test.ts
+++ b/tests/e2e/helpers/electron-home-isolation.unit.test.ts
@@ -31,6 +31,7 @@ describe('createElectronHomeIsolation', () => {
         USERPROFILE: '/real/home',
         CODEX_HOME: '/real/codex',
         ORCA_CODEX_HOME: '/real/orca-codex',
+        CLAUDE_CONFIG_DIR: '/real/claude-account',
         ZDOTDIR: '/real/zdotdir',
         PATH: '/bin'
       },
@@ -54,6 +55,9 @@ describe('createElectronHomeIsolation', () => {
     })
     expect(isolation.env.CODEX_HOME).toBeUndefined()
     expect(isolation.env.ORCA_CODEX_HOME).toBeUndefined()
+    // Inherited from a host Claude Code session, it names the developer's real
+    // account; the app and the agents it spawns would log that account out.
+    expect(isolation.env.CLAUDE_CONFIG_DIR).toBeUndefined()
     expect(isolation.env.ZDOTDIR).toBeUndefined()
     // Codex always routes to the resolved home, so the post-launch guard must
     // accept the boundary this env produces.
@@ -72,6 +76,16 @@ describe('createElectronHomeIsolation', () => {
         realHome: '/real/home'
       })
     ).toThrow(/launchEnv\.CODEX_HOME/)
+
+    expect(() =>
+      createElectronHomeIsolation({
+        inheritedEnv: {},
+        launchEnv: { CLAUDE_CONFIG_DIR: '/real/claude-account' },
+        extraEnv: {},
+        userDataDir: createUserDataDir(),
+        realHome: '/real/home'
+      })
+    ).toThrow(/launchEnv\.CLAUDE_CONFIG_DIR/)
 
     expect(() =>
       createElectronHomeIsolation({


### PR DESCRIPTION
## ELI5

Running Orca's tests from inside a Claude Code session can log you out of Claude Code. The session tells its child processes where your Claude account lives through `CLAUDE_CONFIG_DIR`; the test runner inherits it, Orca's code honours it, and the claude-accounts tests — which believe they are working in a temporary folder — delete and rewrite your real credentials. This PR removes that variable from the test environment.

## What Changed

- `config/scripts/vitest-claude-env-isolation.ts` (new, first in `setupFiles`): deletes `CLAUDE_CONFIG_DIR` before any test module loads. Tests that need the variable already set it themselves.
- `tests/e2e/helpers/electron-home-isolation.ts`: adds `CLAUDE_CONFIG_DIR` to the restricted keys, next to `CODEX_HOME`, so the e2e Electron app — and the agents it spawns — never inherit the host account either.
- Tests: a guard that fails if any test can see the variable, and the e2e isolation test now covers `CLAUDE_CONFIG_DIR` both inherited and passed through `launchEnv`.

## Why

Claude Code sessions (and multi-account launchers) export `CLAUDE_CONFIG_DIR=<account dir>`. `vitest` inherits the parent environment, and `src/main/claude-accounts/runtime-auth-service-*.test.ts` resolve the Claude config dir from it. Run that way, the tests:

- delete `.credentials.json` in the real account directory,
- rewrite it with test tokens,
- remove `oauthAccount` from `.claude.json`,

after which every Claude Code session on that account fails its next request with `Not logged in · Please run /login`. The only trace in the test output is 76 failures reading `Unexpected Claude config dir: <real path>`, which looks like an environment quirk rather than data loss — which is how it went unnoticed while it logged a developer out about twenty times over two days.

A setup file is the smallest change that protects every test at once, including ones added later; fixing individual tests would leave the next claude-accounts test exposed. The e2e launcher already strips `CODEX_HOME` for the same reason.

## Linked Issue

No separate issue — the problem, reproduction and evidence are in this PR.

## Visual Proof

N/A — test-environment change only; no UI or runtime behaviour changes.

## Testing

Reproduction with a decoy config dir, so no real credentials are at risk:

```sh
DECOY=$(mktemp -d)
printf '{"claudeAiOauth":{"accessToken":"decoy","refreshToken":"decoy","expiresAt":4102444800000}}\n' > "$DECOY/.credentials.json"
printf '{"oauthAccount":{"emailAddress":"decoy@example.invalid"}}\n' > "$DECOY/.claude.json"
CLAUDE_CONFIG_DIR="$DECOY" pnpm exec vitest run --config config/vitest.config.ts src/main/claude-accounts
ls -la "$DECOY"
```

- On current `main` (f2d5711b2d), before this change: the decoy's `.credentials.json` is deleted, `.claude.json` is rewritten without `oauthAccount`, and 76 tests fail in 7 files with `Unexpected Claude config dir`.
- With this change: the decoy is untouched (same hashes and mtimes), and all 212 tests in `src/main/claude-accounts`, the new guard and the e2e isolation test pass.

Platforms: tested on Linux. The change is platform-neutral — it deletes an environment variable, and Node's `process.env` is case-insensitive on Windows, so it holds there too.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The failure was found while investigating repeated Claude Code logouts on a developer's machine; the fix and the decoy verification above were run locally.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: stops the test suite from destroying a developer's real credentials. Cross-platform: platform-neutral. SSH/remote, mobile, backwards compatibility and performance: unaffected — test environment only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — ran the affected tests and `oxlint` on the changed files; CI will cover the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4p7iWdvZPkMh7TsuVkEi6
