### PR TITLE
fix(orchestration): deliver omitted-to dispatch mail to coordinator

### DIFF
--- a/src/main/runtime/orchestration/db/messages/message-inbox.ts
+++ b/src/main/runtime/orchestration/db/messages/message-inbox.ts
@@ -228,6 +228,36 @@ export function getInbox(this: OrchestrationDb, limit = 20): MessageRow[] {
   )
 }
 
+// Why: read-only history for multiple handles — returns every message regardless of read/delivered state, never flips the read bit (§3.3).
+export function getAllMessagesForHandles(
+  this: OrchestrationDb,
+  handles: string[],
+  limit = 100,
+  types?: MessageType[]
+): MessageRow[] {
+  if (handles.length === 0) {
+    return []
+  }
+  const handlePlaceholders = handles.map(() => '?').join(',')
+  if (types && types.length > 0) {
+    const typePlaceholders = types.map(() => '?').join(',')
+    return exposeMessageListTimestamps(
+      this.db
+        .prepare(
+          `SELECT * FROM messages WHERE to_handle IN (${handlePlaceholders}) AND type IN (${typePlaceholders}) ORDER BY sequence DESC LIMIT ?`
+        )
+        .all(...handles, ...types, limit) as MessageRow[]
+    )
+  }
+  return exposeMessageListTimestamps(
+    this.db
+      .prepare(
+        `SELECT * FROM messages WHERE to_handle IN (${handlePlaceholders}) ORDER BY sequence DESC LIMIT ?`
+      )
+      .all(...handles, limit) as MessageRow[]
+  )
+}
+
 // Why: read-only history for a handle — returns every message regardless of read/delivered state, never flips the read bit (§3.3).
 export function getAllMessagesForHandle(
   this: OrchestrationDb,
@@ -235,21 +265,7 @@ export function getAllMessagesForHandle(
   limit = 100,
   types?: MessageType[]
 ): MessageRow[] {
-  if (types && types.length > 0) {
-    const placeholders = types.map(() => '?').join(',')
-    return exposeMessageListTimestamps(
-      this.db
-        .prepare(
-          `SELECT * FROM messages WHERE to_handle = ? AND type IN (${placeholders}) ORDER BY sequence DESC LIMIT ?`
-        )
-        .all(toHandle, ...types, limit) as MessageRow[]
-    )
-  }
-  return exposeMessageListTimestamps(
-    this.db
-      .prepare('SELECT * FROM messages WHERE to_handle = ? ORDER BY sequence DESC LIMIT ?')
-      .all(toHandle, limit) as MessageRow[]
-  )
+  return this.getAllMessagesForHandles([toHandle], limit, types)
 }
 
 // Why: ask wait-loop read — to_handle filter shows only replies to the worker; afterSequence resumes past its own outbound ask.
@@ -288,6 +304,7 @@ export type MessageInboxMethods = {
   areUnreadMessages: typeof areUnreadMessages
   markAsReadAndDelivered: typeof markAsReadAndDelivered
   getInbox: typeof getInbox
+  getAllMessagesForHandles: typeof getAllMessagesForHandles
   getAllMessagesForHandle: typeof getAllMessagesForHandle
   getThreadMessagesFor: typeof getThreadMessagesFor
 }
@@ -306,6 +323,7 @@ export function attachMessageInbox(ctor: { prototype: object }): void {
     areUnreadMessages,
     markAsReadAndDelivered,
     getInbox,
+    getAllMessagesForHandles,
     getAllMessagesForHandle,
     getThreadMessagesFor
   })

--- a/src/main/runtime/orchestration/mailbox-delivery-target.ts
+++ b/src/main/runtime/orchestration/mailbox-delivery-target.ts
@@ -31,8 +31,11 @@ export class OrchestrationMailboxDeliveryTarget {
     const remote =
       dispatchId && !dispatch ? db?.getRemoteDispatchAttachment?.(dispatchId) : undefined
     const paneKey = dispatch?.assignee_pane_key ?? remote?.pane_key
+    const run = runId ? db?.getRun?.(runId) : undefined
+    const runPaneKey = run?.coordinator_pane_key
     const ownerHandle = runId
-      ? db?.getRun(runId)?.coordinator_handle
+      ? ((runPaneKey ? this.deps.getTerminalHandleForPaneKey(runPaneKey) : null) ??
+        run?.coordinator_handle)
       : ((paneKey ? this.deps.getTerminalHandleForPaneKey(paneKey) : null) ??
         dispatch?.assignee_handle ??
         remote?.terminal_handle)

--- a/src/main/runtime/orchestration/mailbox-owner.ts
+++ b/src/main/runtime/orchestration/mailbox-owner.ts
@@ -1,5 +1,6 @@
 import type { AgentStatus } from '../../../shared/agent-detection'
 import type { OrchestrationDb } from './db'
+import { isEquivalentPaneKey } from './db/pane-key-match'
 
 export type OrchestrationMailboxLeaf = {
   tabId: string
@@ -57,7 +58,27 @@ export class OrchestrationMailboxOwner {
       return null
     }
     const paneKey = `${leaf.tabId}:${leaf.leafId}`
-    const run = db.getCurrentRunForPane?.(paneKey)
+    let run = db.getCurrentRunForPane?.(paneKey)
+    if (requestedMailbox?.startsWith('run:')) {
+      const requestedRunId = requestedMailbox.slice('run:'.length)
+      if (!run) {
+        const candidateRun = db.getRun?.(requestedRunId)
+        if (
+          candidateRun &&
+          (candidateRun.coordinator_handle === terminalHandle ||
+            (candidateRun.coordinator_pane_key &&
+              isEquivalentPaneKey(candidateRun.coordinator_pane_key, paneKey)) ||
+            (db.getRunMailboxOwnerIdsForHandle?.(terminalHandle) ?? []).includes(requestedRunId))
+        ) {
+          run = candidateRun
+        }
+      }
+    } else if (!requestedMailbox && !run) {
+      const ownerRunIds = db.getRunMailboxOwnerIdsForHandle?.(terminalHandle) ?? []
+      if (ownerRunIds.length === 1) {
+        run = db.getRun?.(ownerRunIds[0])
+      }
+    }
     if (run) {
       return this.resolveRunMailbox(db, leaf, terminalHandle, run.id, requestedMailbox, options)
     }

--- a/src/main/runtime/rpc/methods/orchestration/messaging/check-methods.ts
+++ b/src/main/runtime/rpc/methods/orchestration/messaging/check-methods.ts
@@ -46,7 +46,7 @@ export const ORCHESTRATION_CHECK_METHODS: RpcMethod[] = [
           runtime,
           db,
           handle,
-          paneKey: paneKey ?? boundRun?.coordinator_pane_key ?? undefined,
+          paneKey,
           typeFilter,
           signal,
           legacyCoordinatorRunId,

--- a/src/main/runtime/rpc/methods/orchestration/messaging/check-methods.ts
+++ b/src/main/runtime/rpc/methods/orchestration/messaging/check-methods.ts
@@ -33,14 +33,20 @@ export const ORCHESTRATION_CHECK_METHODS: RpcMethod[] = [
 
       // Why: a live runtime handle is authoritative; pane metadata is only the restart fallback.
       const paneKey = runtime.getTerminalPaneKey(handle) ?? params.terminalPaneKey
-      const boundRun = paneKey ? db.getCurrentRunForPane(paneKey) : undefined
+      let boundRun = paneKey ? db.getCurrentRunForPane(paneKey) : undefined
+      if (!boundRun && !params.run) {
+        const ownerRunIds = db.getRunMailboxOwnerIdsForHandle(handle)
+        if (ownerRunIds.length === 1) {
+          boundRun = db.getRun(ownerRunIds[0])
+        }
+      }
       if (params.run || boundRun) {
         return checkRunMailbox({
           params,
           runtime,
           db,
           handle,
-          paneKey,
+          paneKey: paneKey ?? boundRun?.coordinator_pane_key ?? undefined,
           typeFilter,
           signal,
           legacyCoordinatorRunId,

--- a/src/main/runtime/rpc/methods/orchestration/messaging/check.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/messaging/check.test.ts
@@ -5,10 +5,6 @@ import type { OrchestrationDb } from '../../../../orchestration/db'
 import { reconcileLifecycleMessage } from '../../../../orchestration/lifecycle-reconciliation'
 import type { OrcaRuntimeService } from '../../../../orca-runtime'
 import { createRootDispatch } from '../../../../orchestration/db/root-dispatch-test-fixture'
-import { OrchestrationMailboxDeliveryTarget } from '../../../../orchestration/mailbox-delivery-target'
-import { OrchestrationMailboxOwner } from '../../../../orchestration/mailbox-owner'
-import { OrchestrationMailboxPointerDelivery } from '../../../../orchestration/mailbox-pointer-delivery'
-import { WRITE_ACCEPTED } from '../../../../../../shared/pty-write-settlement'
 
 describe('orchestration RPC methods', () => {
   const h = createOrchestrationRpcHarness()
@@ -56,28 +52,28 @@ describe('orchestration RPC methods', () => {
       filesModified?: string[]
       senderPaneKey?: string
     }): void {
-      const payload: Record<string, unknown> = {}
+      const payload: Record<string, unknown> = { outcome: 'succeeded' }
       if (params.taskId !== undefined) {
         payload.taskId = params.taskId
       }
       if (params.dispatchId !== undefined) {
         payload.dispatchId = params.dispatchId
       }
-      payload.outcome = 'succeeded'
       if (params.filesModified !== undefined) {
         payload.filesModified = params.filesModified
       }
-
-      const message = db.insertMessage({
-        from: params.from ?? 'term_worker',
-        to: params.to ?? `run:${activeRunId}`,
-        subject: 'Done',
-        type: 'worker_done',
-        payload: JSON.stringify(payload),
-        senderPaneKey: params.senderPaneKey,
-        runId: activeRunId
-      })
-      reconcileLifecycleMessage(db, message)
+      reconcileLifecycleMessage(
+        db,
+        db.insertMessage({
+          from: params.from ?? 'term_worker',
+          to: params.to ?? `run:${activeRunId}`,
+          subject: 'Done',
+          type: 'worker_done',
+          payload: JSON.stringify(payload),
+          senderPaneKey: params.senderPaneKey,
+          runId: activeRunId
+        })
+      )
     }
 
     it('returns unread messages for a terminal', async () => {
@@ -796,198 +792,4 @@ describe('orchestration RPC methods', () => {
       expect(db.getUnreadMessages('b')).toHaveLength(1)
     })
   })
-
-  describe('orchestration.inbox', () => {
-    it('returns all messages', async () => {
-      setup()
-      db.insertMessage({ from: 'a', to: 'b', subject: 'one' })
-      db.insertMessage({ from: 'c', to: 'd', subject: 'two' })
-
-      const result = (await call('orchestration.inbox', {})) as { count: number }
-      expect(result.count).toBe(2)
-    })
-
-    it('--terminal <handle> matches check --all output for the same handle', async () => {
-      setup()
-      db.insertMessage({ from: 'a', to: 'b', subject: 'one' })
-      db.insertMessage({ from: 'a', to: 'b', subject: 'two' })
-      db.insertMessage({ from: 'a', to: 'c', subject: 'other' })
-
-      const inbox = (await call('orchestration.inbox', { terminal: 'b' })) as {
-        messages: { id: string; to_handle: string }[]
-        count: number
-      }
-      const check = (await call('orchestration.check', {
-        terminal: 'b',
-        all: true
-      })) as { messages: { id: string; to_handle: string }[]; count: number }
-
-      expect(inbox.count).toBe(2)
-      expect(check.count).toBe(2)
-      // Same rows in the same order — both use sequence DESC
-      expect(inbox.messages.map((m) => m.id)).toEqual(check.messages.map((m) => m.id))
-      expect(inbox.messages.every((m) => m.to_handle === 'b')).toBe(true)
-    })
-
-    it('--terminal <unknown_handle> returns empty list without erroring', async () => {
-      setup()
-      db.insertMessage({ from: 'a', to: 'b', subject: 'one' })
-
-      const result = (await call('orchestration.inbox', {
-        terminal: 'does_not_exist'
-      })) as { count: number }
-      expect(result.count).toBe(0)
-    })
-
-    it('with --terminal <coordinator_handle> returns messages sent to run:<run_id>', async () => {
-      setup(true)
-      db.insertMessage({
-        from: 'term_worker',
-        to: `run:${activeRunId}`,
-        subject: 'Worker finished task',
-        type: 'worker_done',
-        payload: JSON.stringify({ outcome: 'succeeded' }),
-        runId: activeRunId
-      })
-      db.insertMessage({
-        from: 'term_worker',
-        to: `run:${activeRunId}`,
-        subject: 'Worker heartbeat',
-        type: 'heartbeat',
-        payload: JSON.stringify({ progress: 50 }),
-        runId: activeRunId
-      })
-      db.insertMessage({
-        from: 'someone',
-        to: 'term_other',
-        subject: 'Unrelated message'
-      })
-
-      const inbox = (await call('orchestration.inbox', {
-        terminal: 'term_coord'
-      })) as {
-        messages: { id: string; to_handle: string; type: string }[]
-        count: number
-      }
-
-      expect(inbox.count).toBe(2)
-      expect(inbox.messages.every((m) => m.to_handle === `run:${activeRunId}`)).toBe(true)
-      expect(inbox.messages.map((m) => m.type)).toContain('worker_done')
-      expect(inbox.messages.map((m) => m.type)).toContain('heartbeat')
-    })
-
-    it('with --terminal <worker_handle> returns messages sent to dispatch:<dispatch_id>', async () => {
-      setup(true)
-      const task = db.createTask({ spec: 'subtask', runId: activeRunId })
-      const dispatch = createRootDispatch(db, task.id, 'term_worker', 'tab_worker:leaf_worker')
-
-      db.insertMessage({
-        from: 'term_coord',
-        to: `dispatch:${dispatch.id}`,
-        subject: 'Task assigned',
-        type: 'dispatch',
-        runId: activeRunId
-      })
-      db.insertMessage({
-        from: 'someone',
-        to: 'term_other',
-        subject: 'Other'
-      })
-
-      const inbox = (await call('orchestration.inbox', {
-        terminal: 'term_worker'
-      })) as {
-        messages: { id: string; to_handle: string }[]
-        count: number
-      }
-
-      expect(inbox.count).toBe(1)
-      expect(inbox.messages[0]?.to_handle).toBe(`dispatch:${dispatch.id}`)
-    })
-
-    it('push-on-idle pointer delivery resolves the coordinator terminal and delivers run:<run_id> messages when coordinator is live', async () => {
-      vi.useFakeTimers()
-      try {
-        setup(true)
-        const message = db.insertMessage({
-          from: 'term_worker',
-          to: `run:${activeRunId}`,
-          subject: 'Worker done',
-          type: 'worker_done',
-          payload: JSON.stringify({ outcome: 'succeeded' }),
-          runId: activeRunId
-        })
-
-        const [tabId, leafId] = coordinatorPaneKey.split(':')
-        const leaf = {
-          tabId: tabId ?? 'tab_coord',
-          leafId: leafId ?? 'leaf_coord',
-          ptyId: 'pty_coord',
-          writable: true,
-          lastAgentStatus: 'idle' as const,
-          lastAgentStatusObservedLive: true,
-          lastOscTitle: null
-        }
-
-        const deliveryTarget = new OrchestrationMailboxDeliveryTarget({
-          getDb: () => db,
-          getTerminalHandleForPaneKey: (paneKey) =>
-            paneKey === coordinatorPaneKey ? 'term_coord' : null,
-          hasTerminalHandle: (handle) => handle === 'term_coord',
-          isStructuredWorkerHandle: () => false,
-          canProbePtyLiveness: () => true,
-          controllerKnowsPtyIsLive: () => true,
-          isLeafPtyProvenAbsent: async () => false
-        })
-
-        const mailboxOwner = new OrchestrationMailboxOwner({
-          getDb: () => db,
-          getLeaf: () => leaf,
-          getLeafKey: (t, l) => `${t}:${l}`,
-          getTerminalHandleForLeafKey: (leafKey) =>
-            leafKey === coordinatorPaneKey ? 'term_coord' : undefined,
-          getTerminalProcessIncarnation: () => 'inc_1',
-          onRoutedMessageTypes: vi.fn(),
-          onForeignMailboxRouted: vi.fn()
-        })
-
-        expect(deliveryTarget.resolveTerminalHandle(`run:${activeRunId}`)).toBe('term_coord')
-        expect(mailboxOwner.resolve(leaf, `run:${activeRunId}`)).toBe(`run:${activeRunId}`)
-        expect(mailboxOwner.resolve(leaf)).toBe(`run:${activeRunId}`)
-
-        const writes: string[] = []
-        const pointerDelivery = new OrchestrationMailboxPointerDelivery({
-          deliveryTarget,
-          mailboxOwner,
-          getDb: () => db,
-          getLeaf: () => leaf,
-          getLiveLeafForHandle: () => leaf,
-          getLeafKey: (t, l) => `${t}:${l}`,
-          getTerminalHandleForLeafKey: (leafKey) =>
-            leafKey === coordinatorPaneKey ? 'term_coord' : undefined,
-          getMessageWaiters: () => undefined,
-          getTabTitle: () => 'coordinator',
-          getCliCommand: () => 'orca' as const,
-          resolveSubmitTarget: () => ({
-            leaf,
-            terminalHandle: 'term_coord',
-            processIncarnation: 'inc_1'
-          }),
-          isLeafPtyProvenAbsent: async () => false,
-          redriveMailbox: vi.fn(),
-          writePty: (_ptyId, data) => {
-            writes.push(data)
-            return WRITE_ACCEPTED
-          }
-        })
-
-        pointerDelivery.deliverForHandle(`run:${activeRunId}`)
-        await vi.advanceTimersByTimeAsync(1000)
-        const delivered = db.getMessageById(message.id)
-        expect(delivered?.delivered_at).not.toBeNull()
-      } finally {
-        vi.useRealTimers()
-      }
-    })
-})
 })

--- a/src/main/runtime/rpc/methods/orchestration/messaging/check.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/messaging/check.test.ts
@@ -5,6 +5,10 @@ import type { OrchestrationDb } from '../../../../orchestration/db'
 import { reconcileLifecycleMessage } from '../../../../orchestration/lifecycle-reconciliation'
 import type { OrcaRuntimeService } from '../../../../orca-runtime'
 import { createRootDispatch } from '../../../../orchestration/db/root-dispatch-test-fixture'
+import { OrchestrationMailboxDeliveryTarget } from '../../../../orchestration/mailbox-delivery-target'
+import { OrchestrationMailboxOwner } from '../../../../orchestration/mailbox-owner'
+import { OrchestrationMailboxPointerDelivery } from '../../../../orchestration/mailbox-pointer-delivery'
+import { WRITE_ACCEPTED } from '../../../../../../shared/pty-write-settlement'
 
 describe('orchestration RPC methods', () => {
   const h = createOrchestrationRpcHarness()
@@ -834,5 +838,156 @@ describe('orchestration RPC methods', () => {
       })) as { count: number }
       expect(result.count).toBe(0)
     })
-  })
+
+    it('with --terminal <coordinator_handle> returns messages sent to run:<run_id>', async () => {
+      setup(true)
+      db.insertMessage({
+        from: 'term_worker',
+        to: `run:${activeRunId}`,
+        subject: 'Worker finished task',
+        type: 'worker_done',
+        payload: JSON.stringify({ outcome: 'succeeded' }),
+        runId: activeRunId
+      })
+      db.insertMessage({
+        from: 'term_worker',
+        to: `run:${activeRunId}`,
+        subject: 'Worker heartbeat',
+        type: 'heartbeat',
+        payload: JSON.stringify({ progress: 50 }),
+        runId: activeRunId
+      })
+      db.insertMessage({
+        from: 'someone',
+        to: 'term_other',
+        subject: 'Unrelated message'
+      })
+
+      const inbox = (await call('orchestration.inbox', {
+        terminal: 'term_coord'
+      })) as {
+        messages: { id: string; to_handle: string; type: string }[]
+        count: number
+      }
+
+      expect(inbox.count).toBe(2)
+      expect(inbox.messages.every((m) => m.to_handle === `run:${activeRunId}`)).toBe(true)
+      expect(inbox.messages.map((m) => m.type)).toContain('worker_done')
+      expect(inbox.messages.map((m) => m.type)).toContain('heartbeat')
+    })
+
+    it('with --terminal <worker_handle> returns messages sent to dispatch:<dispatch_id>', async () => {
+      setup(true)
+      const task = db.createTask({ spec: 'subtask', runId: activeRunId })
+      const dispatch = createRootDispatch(db, task.id, 'term_worker', 'tab_worker:leaf_worker')
+
+      db.insertMessage({
+        from: 'term_coord',
+        to: `dispatch:${dispatch.id}`,
+        subject: 'Task assigned',
+        type: 'dispatch',
+        runId: activeRunId
+      })
+      db.insertMessage({
+        from: 'someone',
+        to: 'term_other',
+        subject: 'Other'
+      })
+
+      const inbox = (await call('orchestration.inbox', {
+        terminal: 'term_worker'
+      })) as {
+        messages: { id: string; to_handle: string }[]
+        count: number
+      }
+
+      expect(inbox.count).toBe(1)
+      expect(inbox.messages[0]?.to_handle).toBe(`dispatch:${dispatch.id}`)
+    })
+
+    it('push-on-idle pointer delivery resolves the coordinator terminal and delivers run:<run_id> messages when coordinator is live', async () => {
+      vi.useFakeTimers()
+      try {
+        setup(true)
+        const message = db.insertMessage({
+          from: 'term_worker',
+          to: `run:${activeRunId}`,
+          subject: 'Worker done',
+          type: 'worker_done',
+          payload: JSON.stringify({ outcome: 'succeeded' }),
+          runId: activeRunId
+        })
+
+        const [tabId, leafId] = coordinatorPaneKey.split(':')
+        const leaf = {
+          tabId: tabId ?? 'tab_coord',
+          leafId: leafId ?? 'leaf_coord',
+          ptyId: 'pty_coord',
+          writable: true,
+          lastAgentStatus: 'idle' as const,
+          lastAgentStatusObservedLive: true,
+          lastOscTitle: null
+        }
+
+        const deliveryTarget = new OrchestrationMailboxDeliveryTarget({
+          getDb: () => db,
+          getTerminalHandleForPaneKey: (paneKey) =>
+            paneKey === coordinatorPaneKey ? 'term_coord' : null,
+          hasTerminalHandle: (handle) => handle === 'term_coord',
+          isStructuredWorkerHandle: () => false,
+          canProbePtyLiveness: () => true,
+          controllerKnowsPtyIsLive: () => true,
+          isLeafPtyProvenAbsent: async () => false
+        })
+
+        const mailboxOwner = new OrchestrationMailboxOwner({
+          getDb: () => db,
+          getLeaf: () => leaf,
+          getLeafKey: (t, l) => `${t}:${l}`,
+          getTerminalHandleForLeafKey: (leafKey) =>
+            leafKey === coordinatorPaneKey ? 'term_coord' : undefined,
+          getTerminalProcessIncarnation: () => 'inc_1',
+          onRoutedMessageTypes: vi.fn(),
+          onForeignMailboxRouted: vi.fn()
+        })
+
+        expect(deliveryTarget.resolveTerminalHandle(`run:${activeRunId}`)).toBe('term_coord')
+        expect(mailboxOwner.resolve(leaf, `run:${activeRunId}`)).toBe(`run:${activeRunId}`)
+        expect(mailboxOwner.resolve(leaf)).toBe(`run:${activeRunId}`)
+
+        const writes: string[] = []
+        const pointerDelivery = new OrchestrationMailboxPointerDelivery({
+          deliveryTarget,
+          mailboxOwner,
+          getDb: () => db,
+          getLeaf: () => leaf,
+          getLiveLeafForHandle: () => leaf,
+          getLeafKey: (t, l) => `${t}:${l}`,
+          getTerminalHandleForLeafKey: (leafKey) =>
+            leafKey === coordinatorPaneKey ? 'term_coord' : undefined,
+          getMessageWaiters: () => undefined,
+          getTabTitle: () => 'coordinator',
+          getCliCommand: () => 'orca' as const,
+          resolveSubmitTarget: () => ({
+            leaf,
+            terminalHandle: 'term_coord',
+            processIncarnation: 'inc_1'
+          }),
+          isLeafPtyProvenAbsent: async () => false,
+          redriveMailbox: vi.fn(),
+          writePty: (_ptyId, data) => {
+            writes.push(data)
+            return WRITE_ACCEPTED
+          }
+        })
+
+        pointerDelivery.deliverForHandle(`run:${activeRunId}`)
+        await vi.advanceTimersByTimeAsync(1000)
+        const delivered = db.getMessageById(message.id)
+        expect(delivered?.delivered_at).not.toBeNull()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+})
 })

--- a/src/main/runtime/rpc/methods/orchestration/messaging/inbox.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/messaging/inbox.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RpcContext } from '../../../core'
+import { createOrchestrationRpcHarness } from '../rpc-test-harness'
+import type { OrchestrationDb } from '../../../../orchestration/db'
+import { createRootDispatch } from '../../../../orchestration/db/root-dispatch-test-fixture'
+import { OrchestrationMailboxDeliveryTarget } from '../../../../orchestration/mailbox-delivery-target'
+import { OrchestrationMailboxOwner } from '../../../../orchestration/mailbox-owner'
+import { OrchestrationMailboxPointerDelivery } from '../../../../orchestration/mailbox-pointer-delivery'
+import { WRITE_ACCEPTED } from '../../../../../../shared/pty-write-settlement'
+import { formatMessagePointer } from '../../../../orchestration/formatter'
+
+describe('orchestration RPC methods', () => {
+  const h = createOrchestrationRpcHarness()
+  const { coordinatorPaneKey } = h
+  let db: OrchestrationDb
+  let ctx: RpcContext
+  let activeRunId: string | undefined
+
+  function setup(withBoundRun = true): void {
+    ;({ db, ctx, activeRunId } = h.setup(withBoundRun))
+  }
+
+  afterEach(() => {
+    h.cleanup()
+  })
+
+  async function call(name: string, params: Record<string, unknown>) {
+    return h.call(name, params, ctx)
+  }
+
+  describe('orchestration.inbox', () => {
+    it('returns all messages', async () => {
+      setup()
+      db.insertMessage({ from: 'a', to: 'b', subject: 'one' })
+      db.insertMessage({ from: 'c', to: 'd', subject: 'two' })
+
+      const result = (await call('orchestration.inbox', {})) as { count: number }
+      expect(result.count).toBe(2)
+    })
+
+    it('--terminal <handle> matches check --all output for the same handle', async () => {
+      setup()
+      db.insertMessage({ from: 'a', to: 'b', subject: 'one' })
+      db.insertMessage({ from: 'a', to: 'b', subject: 'two' })
+      db.insertMessage({ from: 'a', to: 'c', subject: 'other' })
+
+      const inbox = (await call('orchestration.inbox', { terminal: 'b' })) as {
+        messages: { id: string; to_handle: string }[]
+        count: number
+      }
+      const check = (await call('orchestration.check', {
+        terminal: 'b',
+        all: true
+      })) as { messages: { id: string; to_handle: string }[]; count: number }
+
+      expect(inbox.count).toBe(2)
+      expect(check.count).toBe(2)
+      // Same rows in the same order — both use sequence DESC
+      expect(inbox.messages.map((m) => m.id)).toEqual(check.messages.map((m) => m.id))
+      expect(inbox.messages.every((m) => m.to_handle === 'b')).toBe(true)
+    })
+
+    it('--terminal <unknown_handle> returns empty list without erroring', async () => {
+      setup()
+      db.insertMessage({ from: 'a', to: 'b', subject: 'one' })
+
+      const result = (await call('orchestration.inbox', {
+        terminal: 'does_not_exist'
+      })) as { count: number }
+      expect(result.count).toBe(0)
+    })
+
+    it('with --terminal <coordinator_handle> returns messages sent to run:<run_id>', async () => {
+      setup(true)
+      db.insertMessage({
+        from: 'term_worker',
+        to: `run:${activeRunId}`,
+        subject: 'Worker finished task',
+        type: 'worker_done',
+        payload: JSON.stringify({ outcome: 'succeeded' }),
+        runId: activeRunId
+      })
+      db.insertMessage({
+        from: 'term_worker',
+        to: `run:${activeRunId}`,
+        subject: 'Worker heartbeat',
+        type: 'heartbeat',
+        payload: JSON.stringify({ progress: 50 }),
+        runId: activeRunId
+      })
+      db.insertMessage({ from: 'someone', to: 'term_other', subject: 'Unrelated message' })
+      const inbox = (await call('orchestration.inbox', { terminal: 'term_coord' })) as {
+        messages: { id: string; to_handle: string; type: string }[]
+        count: number
+      }
+      expect(inbox.count).toBe(2)
+      expect(inbox.messages.every((m) => m.to_handle === `run:${activeRunId}`)).toBe(true)
+      expect(inbox.messages.map((m) => m.type)).toContain('worker_done')
+      expect(inbox.messages.map((m) => m.type)).toContain('heartbeat')
+    })
+
+    it('with --terminal <worker_handle> returns messages sent to dispatch:<dispatch_id>', async () => {
+      setup(true)
+      const task = db.createTask({ spec: 'subtask', runId: activeRunId })
+      const dispatch = createRootDispatch(db, task.id, 'term_worker', 'tab_worker:leaf_worker')
+      db.insertMessage({
+        from: 'term_coord',
+        to: `dispatch:${dispatch.id}`,
+        subject: 'Task assigned',
+        type: 'dispatch',
+        runId: activeRunId
+      })
+      db.insertMessage({ from: 'someone', to: 'term_other', subject: 'Other' })
+      const inbox = (await call('orchestration.inbox', { terminal: 'term_worker' })) as {
+        messages: { id: string; to_handle: string }[]
+        count: number
+      }
+      expect(inbox.count).toBe(1)
+      expect(inbox.messages[0]?.to_handle).toBe(`dispatch:${dispatch.id}`)
+    })
+
+    it('push-on-idle pointer delivery resolves the coordinator terminal and delivers run:<run_id> messages when coordinator is live', async () => {
+      vi.useFakeTimers()
+      try {
+        setup(true)
+        const message = db.insertMessage({
+          from: 'term_worker',
+          to: `run:${activeRunId}`,
+          subject: 'Worker done',
+          type: 'worker_done',
+          payload: JSON.stringify({ outcome: 'succeeded' }),
+          runId: activeRunId
+        })
+        const [tabId = 'tab_coord', leafId = 'leaf_coord'] = coordinatorPaneKey.split(':')
+        const leaf = {
+          tabId,
+          leafId,
+          ptyId: 'pty_coord',
+          writable: true,
+          lastAgentStatus: 'idle' as const,
+          lastAgentStatusObservedLive: true,
+          lastOscTitle: null
+        }
+        const deliveryTarget = new OrchestrationMailboxDeliveryTarget({
+          getDb: () => db,
+          getTerminalHandleForPaneKey: (pk) => (pk === coordinatorPaneKey ? 'term_coord' : null),
+          hasTerminalHandle: (h) => h === 'term_coord',
+          isStructuredWorkerHandle: () => false,
+          canProbePtyLiveness: () => true,
+          controllerKnowsPtyIsLive: () => true,
+          isLeafPtyProvenAbsent: async () => false
+        })
+        const mailboxOwner = new OrchestrationMailboxOwner({
+          getDb: () => db,
+          getLeaf: () => leaf,
+          getLeafKey: (t, l) => `${t}:${l}`,
+          getTerminalHandleForLeafKey: (lk) =>
+            lk === coordinatorPaneKey ? 'term_coord' : undefined,
+          getTerminalProcessIncarnation: () => 'inc_1',
+          onRoutedMessageTypes: vi.fn(),
+          onForeignMailboxRouted: vi.fn()
+        })
+        expect(deliveryTarget.resolveTerminalHandle(`run:${activeRunId}`)).toBe('term_coord')
+        expect(mailboxOwner.resolve(leaf, `run:${activeRunId}`)).toBe(`run:${activeRunId}`)
+        expect(mailboxOwner.resolve(leaf)).toBe(`run:${activeRunId}`)
+        const writes: string[] = []
+        const pointerDelivery = new OrchestrationMailboxPointerDelivery({
+          deliveryTarget,
+          mailboxOwner,
+          getDb: () => db,
+          getLeaf: () => leaf,
+          getLiveLeafForHandle: () => leaf,
+          getLeafKey: (t, l) => `${t}:${l}`,
+          getTerminalHandleForLeafKey: (lk) =>
+            lk === coordinatorPaneKey ? 'term_coord' : undefined,
+          getMessageWaiters: () => undefined,
+          getTabTitle: () => 'coordinator',
+          getCliCommand: () => 'orca' as const,
+          resolveSubmitTarget: () => ({
+            leaf,
+            terminalHandle: 'term_coord',
+            processIncarnation: 'inc_1'
+          }),
+          isLeafPtyProvenAbsent: async () => false,
+          redriveMailbox: vi.fn(),
+          writePty: (_ptyId, data) => {
+            writes.push(data)
+            return WRITE_ACCEPTED
+          }
+        })
+        pointerDelivery.deliverForHandle(`run:${activeRunId}`)
+        await vi.advanceTimersByTimeAsync(1000)
+        const delivered = db.getMessageById(message.id)
+        expect(delivered?.delivered_at).not.toBeNull()
+        expect(writes).toEqual([formatMessagePointer(1, `run:${activeRunId}`), '\r'])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration/messaging/message-methods.ts
+++ b/src/main/runtime/rpc/methods/orchestration/messaging/message-methods.ts
@@ -133,10 +133,54 @@ export const ORCHESTRATION_MESSAGE_METHODS: RpcMethod[] = [
     params: InboxParams,
     handler: (params, { runtime }) => {
       const db = runtime.getOrchestrationDb()
-      // Why: stale/unknown handles return empty rather than error — historical rows survive handle deletion (design doc §3.3).
-      const messages = params.terminal
-        ? db.getAllMessagesForHandle(params.terminal, params.limit)
-        : db.getInbox(params.limit)
+      if (!params.terminal) {
+        const messages = db.getInbox(params.limit)
+        return { messages, count: messages.length }
+      }
+
+      if (params.terminal.startsWith('run:') || params.terminal.startsWith('dispatch:')) {
+        const messages = db.getAllMessagesForHandles([params.terminal], params.limit)
+        return { messages, count: messages.length }
+      }
+
+      const handles = new Set<string>([params.terminal])
+      const paneKey = runtime.getTerminalPaneKey(params.terminal) ?? undefined
+
+      const ownerRunIds = db.getRunMailboxOwnerIdsForHandle?.(params.terminal) ?? []
+      for (const runId of ownerRunIds) {
+        handles.add(`run:${runId}`)
+      }
+      const boundRun = paneKey ? db.getCurrentRunForPane?.(paneKey) : undefined
+      if (boundRun?.id) {
+        handles.add(`run:${boundRun.id}`)
+      }
+      type QueryableDb = {
+        db?: { prepare?: (sql: string) => { all: (param: unknown) => { id: string }[] } }
+      }
+      const rawDb = (db as unknown as QueryableDb).db
+      const runsWithCoord = rawDb
+        ?.prepare?.('SELECT id FROM runs WHERE coordinator_handle = ?')
+        ?.all?.(params.terminal)
+      if (runsWithCoord) {
+        for (const row of runsWithCoord) {
+          handles.add(`run:${row.id}`)
+        }
+      }
+
+      const activeDispatches = db.getActiveDispatchMailboxOwners?.(params.terminal, paneKey) ?? []
+      for (const d of activeDispatches) {
+        handles.add(`dispatch:${d.id}`)
+      }
+      const assigneeDispatches = rawDb
+        ?.prepare?.('SELECT id FROM dispatch_contexts WHERE assignee_handle = ?')
+        ?.all?.(params.terminal)
+      if (assigneeDispatches) {
+        for (const row of assigneeDispatches) {
+          handles.add(`dispatch:${row.id}`)
+        }
+      }
+
+      const messages = db.getAllMessagesForHandles(Array.from(handles), params.limit)
       return { messages, count: messages.length }
     }
   }),

--- a/src/main/runtime/rpc/methods/orchestration/messaging/message-methods.ts
+++ b/src/main/runtime/rpc/methods/orchestration/messaging/message-methods.ts
@@ -154,30 +154,9 @@ export const ORCHESTRATION_MESSAGE_METHODS: RpcMethod[] = [
       if (boundRun?.id) {
         handles.add(`run:${boundRun.id}`)
       }
-      type QueryableDb = {
-        db?: { prepare?: (sql: string) => { all: (param: unknown) => { id: string }[] } }
-      }
-      const rawDb = (db as unknown as QueryableDb).db
-      const runsWithCoord = rawDb
-        ?.prepare?.('SELECT id FROM runs WHERE coordinator_handle = ?')
-        ?.all?.(params.terminal)
-      if (runsWithCoord) {
-        for (const row of runsWithCoord) {
-          handles.add(`run:${row.id}`)
-        }
-      }
-
       const activeDispatches = db.getActiveDispatchMailboxOwners?.(params.terminal, paneKey) ?? []
       for (const d of activeDispatches) {
         handles.add(`dispatch:${d.id}`)
-      }
-      const assigneeDispatches = rawDb
-        ?.prepare?.('SELECT id FROM dispatch_contexts WHERE assignee_handle = ?')
-        ?.all?.(params.terminal)
-      if (assigneeDispatches) {
-        for (const row of assigneeDispatches) {
-          handles.add(`dispatch:${row.id}`)
-        }
       }
 
       const messages = db.getAllMessagesForHandles(Array.from(handles), params.limit)


### PR DESCRIPTION
## ELI5

When dispatch mail is sent without an explicit `to` recipient, it now routes directly to the coordinator's mailbox so the coordinator doesn't miss messages.

## What Changed

- Expanded `getAllMessagesForHandles` to query across multiple mailbox handles.
- Resolved `run:` mailbox owner from coordinator live terminal.
- Extracted inbox RPC tests into dedicated `inbox.test.ts`.
- Replaced raw SQL queries with typed `OrchestrationDb` calls and tightened caller scope.
- Added assertion for pointer delivery to coordinator PTY.

## Why

Addresses message routing when dispatches omit the destination mailbox, preventing critical messages from being lost or stranded.

## Linked Issue

Fixes #19844

## Visual Proof

N/A (RPC / backend messaging change with no UI changes)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Commands run locally:
- `pnpm test src/main/runtime/rpc/methods/orchestration/messaging/` (13 files passed, 154 tests passed)
- `pnpm typecheck` (passed)
- `pnpm run check:max-lines-ratchet` (passed)
- `pnpm run check:code-quality:changed` (passed)

## AI Disclosure

Developed with AI assistance.

## Review

Standard RPC and DB method review.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
