### PR TITLE
fix(i18n): localize the CLI reveal button label

### DIFF
--- a/src/renderer/src/components/settings/CliSection.reveal-label.test.tsx
+++ b/src/renderer/src/components/settings/CliSection.reveal-label.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as I18nModule from '@/i18n/i18n'
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import { CliSection } from './CliSection'
+
+const REVEAL_KEYS = new Set([
+  'auto.components.settings.CliSection.6f894ef9c2',
+  'auto.components.settings.CliSection.cbe55e4d48',
+  'auto.components.settings.CliSection.9fd4023db0'
+])
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+vi.mock('@/hooks/useInstalledAgentSkills', () => ({
+  GLOBAL_AGENT_SKILL_SOURCE_KINDS: ['global'],
+  useInstalledAgentSkill: () => ({
+    installed: false,
+    loading: false,
+    error: null,
+    refresh: vi.fn()
+  })
+}))
+
+vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
+  useActiveProjectSkillRuntime: () => ({ canUseLocalSkillFreshness: true })
+}))
+
+vi.mock('./AgentSkillSetupPanel', () => ({
+  AgentSkillSetupPanel: () => <div data-testid="agent-skill-setup-panel" />
+}))
+
+vi.mock('./CliRegistrationDialog', () => ({
+  CliRegistrationDialog: () => null
+}))
+
+vi.mock('./WslCliRegistration', () => ({ WslCliRegistration: () => null }))
+
+// Why: only the reveal keys are intercepted so the test proves they route
+// through translate without disturbing the rest of the section's copy.
+vi.mock('@/i18n/i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof I18nModule>()
+  return {
+    ...actual,
+    translate: (...args: Parameters<typeof actual.translate>) => {
+      const [key, fallback] = args
+      return REVEAL_KEYS.has(key) ? `T:${fallback}` : actual.translate(...args)
+    }
+  }
+})
+
+function installedStatus(commandPath: string): CliInstallStatus {
+  return {
+    platform: 'darwin',
+    commandName: 'orca',
+    commandPath,
+    pathDirectory: '/usr/local/bin',
+    pathConfigured: true,
+    launcherPath: '/Applications/Orca.app/Contents/Resources/bin/orca',
+    installMethod: 'symlink',
+    supported: true,
+    state: 'installed',
+    currentTarget: commandPath,
+    unsupportedReason: null,
+    detail: ''
+  }
+}
+
+function stubCliApi(status: CliInstallStatus): void {
+  Object.assign(window, {
+    api: {
+      cli: {
+        getInstallStatus: vi.fn().mockResolvedValue(status),
+        getWslInstallStatus: vi.fn().mockResolvedValue(status),
+        install: vi.fn(),
+        remove: vi.fn()
+      },
+      shell: { openPath: vi.fn() }
+    }
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('CliSection reveal label localization', () => {
+  it.each([
+    ['darwin', 'T:Show in Finder'],
+    ['win32', 'T:Show in Explorer'],
+    ['linux', 'T:Show in File Manager']
+  ])('localizes the reveal button on %s', async (platform, expected) => {
+    stubCliApi(installedStatus('/usr/local/bin/orca'))
+    render(<CliSection currentPlatform={platform} settings={getDefaultSettings('/tmp')} />)
+    expect(await screen.findByText(expected)).toBeDefined()
+  })
+})

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -47,12 +47,12 @@ type CliSectionProps = {
 
 function getRevealLabel(platform: string): string {
   if (platform === 'darwin') {
-    return 'Show in Finder'
+    return translate('auto.components.settings.CliSection.6f894ef9c2', 'Show in Finder')
   }
   if (platform === 'win32') {
-    return 'Show in Explorer'
+    return translate('auto.components.settings.CliSection.cbe55e4d48', 'Show in Explorer')
   }
-  return 'Show in File Manager'
+  return translate('auto.components.settings.CliSection.9fd4023db0', 'Show in File Manager')
 }
 
 function getInstallDescription(platform: string): string {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6844,7 +6844,10 @@
           "cliSkillTerminalTitle": "CLI skill setup",
           "cliSkillTerminalAria": "CLI skill install terminal",
           "installFailureUnknownReason": "Orca could not finish CLI registration and reported no reason.",
-          "installFailureConflictRemedy": "Remove {{value0}} and register again if it is no longer needed."
+          "installFailureConflictRemedy": "Remove {{value0}} and register again if it is no longer needed.",
+          "6f894ef9c2": "Show in Finder",
+          "cbe55e4d48": "Show in Explorer",
+          "9fd4023db0": "Show in File Manager"
         },
         "CliSkillRuntimeSetup": {
           "04325573f8": "WSL",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5815,7 +5815,10 @@
           "14444243ba": "¿Eliminar `{{value0}}` de PATH?",
           "5d432fe44d": "instalado",
           "8a9b784c60": "desactualizado",
-          "d363e5929b": "Comprobando registro de CLI..."
+          "d363e5929b": "Comprobando registro de CLI...",
+          "6f894ef9c2": "Mostrar en Finder",
+          "cbe55e4d48": "Mostrar en el Explorador de archivos",
+          "9fd4023db0": "Mostrar en el gestor de archivos"
         },
         "CliSkillRuntimeSetup": {
           "04325573f8": "WSL",


### PR DESCRIPTION
## ELI5

In Settings → Orca CLI there is a button that reveals the CLI's install folder. Its label was written directly in code as plain English and never asked the translation system for the active language, so in Spanish (and every other UI language) it stayed English. This change makes the label ask the translation system, and adds the Spanish text.

## What Changed

- `src/renderer/src/components/settings/CliSection.tsx`: `getRevealLabel()` now returns `translate(key, fallback)` for the three platform variants instead of hardcoded literals.
- `src/renderer/src/i18n/locales/en.json`: adds the three new keys (`6f894ef9c2`, `cbe55e4d48`, `9fd4023db0`).
- `src/renderer/src/i18n/locales/es.json`: adds the Spanish values (`Mostrar en Finder`, `Mostrar en el Explorador de archivos`, `Mostrar en el gestor de archivos`).
- `src/renderer/src/components/settings/CliSection.reveal-label.test.tsx`: new regression test proving the label routes through `translate()` on darwin / win32 / linux.

## Why

This is the same class of bug as #19290 (the file-explorer context-menu reveal labels): a user-facing label that never went through the i18n catalog. The CLI settings button was a fourth, still-hardcoded occurrence. Wrapping it in `translate()` is the minimal fix; the other target locales keep falling back to English until translated, which is the intended behavior.

## Linked Issue

Fixes #19895

## Visual Proof

Text-only change; no layout change.

**Before** (es-ES, Settings → Orca CLI): `Show in Finder` / `Show in Explorer` / `Show in File Manager`

**After** (es-ES): `Mostrar en Finder` / `Mostrar en el Explorador de archivos` / `Mostrar en el gestor de archivos`

I did not capture a screenshot from a running app for this PR; happy to add one if it is required for review.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platform tested: Linux (renderer unit test via happy-dom). The change is platform-conditional strings only, so behavior on macOS/Windows is the same code path with a different key.

Commands run:

- `pnpm run verify:localization-catalog` ✅
- `pnpm run verify:localization-runtime-catalog` ✅
- `pnpm run verify:localization-extraction` ✅
- `pnpm run verify:localization-coverage` ✅
- `pnpm tc` ✅
- `pnpm test src/renderer/src/components/settings/CliSection.reveal-label.test.tsx` ✅
- `pnpm run check:code-quality:changed` ✅

## AI Disclosure

Written with opencode (model deepseek-v4-flash) as an assistant. I reviewed the change and ran the checks above.

## Review

- Cross-platform: label selection logic is unchanged; only the source of the string changed. Verified for darwin / win32 / linux in the new test.
- SSH/remote/local: N/A, label text only.
- Agent/integration compatibility: N/A.
- Performance: none (a single translate lookup in render).
- UI quality: string-only change, no layout impact; long Spanish labels wrap the same way as the sibling copy.
- Security: none.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensured no issues in: Security, cross-platform support, remote SSH, mobile, backwards compatibility, performance. The other locales (fr/ja/ko/zh) intentionally fall back to English for these keys until a localization PR supplies them.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after provided as text (no screenshot); N/A for layout
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

GitHub: @galiprandi
