### PR TITLE
test: isolate Windows portability fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,8 @@
 # Windows-built client disagree with a mac/Linux-built one on the same release,
 # so one host ends up with two relay trees (#17886 review).
 /config/relay-assets/** text eol=lf
+# Byte-exact node-pty source fixture; keep LF so its upstream hash matches.
+/config/scripts/__fixtures__/node-pty-1.1.0-unix-pty.cc text eol=lf
 # Pin the bytes so a patch reads and diffs identically on every host. It is NOT
 # what makes the hash right: pnpm hashes a patch LF-normalized, so a CRLF checkout
 # cannot change it. Believing otherwise put a hand-computed raw digest in the

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -185,6 +185,7 @@ describe('PR workflow parallelism', () => {
 
   it('keeps every real-zsh test in the dedicated shell lane', () => {
     const discoveredFiles = globSync(testFilePatterns)
+      .map((testFile) => testFile.replaceAll(String.fromCharCode(92), '/'))
       // Why this file is excluded: it carries the detector pattern as a literal
       // and would otherwise match itself.
       .filter((testFile) => testFile !== 'config/scripts/pr-workflow-parallelism.test.mjs')

--- a/config/scripts/rebuild-native-deps-test-fixtures.mjs
+++ b/config/scripts/rebuild-native-deps-test-fixtures.mjs
@@ -19,6 +19,9 @@ const sourceInstallScriptPath = fileURLToPath(
 const sourceNodePtyJobOwnershipPath = fileURLToPath(
   new URL('./node-pty-job-ownership.cjs', import.meta.url)
 )
+const sourceWindowsProcessTreeCreationTimePath = fileURLToPath(
+  new URL('./windows-process-tree-creation-time.cjs', import.meta.url)
+)
 const sourceWindowsProcessTreeGypRebuildPath = fileURLToPath(
   new URL('./windows-process-tree-gyp-rebuild.mjs', import.meta.url)
 )
@@ -93,6 +96,10 @@ export function mkTempProject() {
   copyFileSync(
     sourceNodePtyJobOwnershipPath,
     join(projectDir, 'config', 'scripts', 'node-pty-job-ownership.cjs')
+  )
+  copyFileSync(
+    sourceWindowsProcessTreeCreationTimePath,
+    join(projectDir, 'config', 'scripts', 'windows-process-tree-creation-time.cjs')
   )
   copyFileSync(
     sourceWindowsProcessTreeGypRebuildPath,
@@ -369,7 +376,10 @@ export function writeFakeWindowsRegistry(projectDir) {
 export function writeFakeWindowsProcessTree(projectDir) {
   const processTreeDir = join(projectDir, 'node_modules', '@vscode', 'windows-process-tree')
   mkdirSync(processTreeDir, { recursive: true })
-  writeFileSync(join(processTreeDir, 'index.js'), 'module.exports = {}\n')
+  writeFileSync(
+    join(processTreeDir, 'index.js'),
+    'module.exports = { supportedProcessDataFlags: 4 }\n'
+  )
 }
 
 export function writeFakeWindowsProcessTreeWithNodeAddonApi(

--- a/config/scripts/regenerate-xterm-patches.mjs
+++ b/config/scripts/regenerate-xterm-patches.mjs
@@ -401,12 +401,14 @@ function regeneratePackage(packageEntry, manifest, context) {
   run(
     'git',
     [
+      '-c',
+      'core.autocrlf=false',
       'apply',
       '--whitespace=nowarn',
       ...(packageDir === '.' ? [] : [`--directory=${packageDir}`]),
       path.join(repoRoot, packageEntry.sourcePatch)
     ],
-    { cwd: upstreamRoot }
+    { cwd: upstreamRoot, env: pnpmDiffEnvironment() }
   )
   buildPackage(upstreamRoot, packageEntry, manifest)
 

--- a/config/scripts/regenerate-xterm-patches.mjs
+++ b/config/scripts/regenerate-xterm-patches.mjs
@@ -174,6 +174,14 @@ function run(command, args, options = {}) {
     ...options
   })
 }
+const GIT_EOL_ISOLATION = ['-c', 'core.autocrlf=false', '-c', 'core.eol=lf']
+
+function runGit(args, options = {}) {
+  return run('git', [...GIT_EOL_ISOLATION, ...args], {
+    ...options,
+    env: pnpmDiffEnvironment(options.env ?? process.env)
+  })
+}
 
 function listFilesRelative(root, base = root) {
   const files = []
@@ -209,7 +217,7 @@ function fetchPristinePackage(packageEntry, workDir) {
 
 function hasCommit(root, commit) {
   try {
-    return run('git', ['cat-file', '-t', commit], { cwd: root, stdio: 'pipe' }).trim() === 'commit'
+    return runGit(['cat-file', '-t', commit], { cwd: root, stdio: 'pipe' }).trim() === 'commit'
   } catch {
     return false
   }
@@ -220,14 +228,14 @@ function ensureUpstreamCheckout(manifest, workDir) {
   const { repository, commit } = manifest.upstream
   if (!existsSync(path.join(root, '.git'))) {
     mkdirSync(root, { recursive: true })
-    run('git', ['init', '--quiet'], { cwd: root })
-    run('git', ['remote', 'add', 'origin', repository], { cwd: root })
+    runGit(['init', '--quiet'], { cwd: root })
+    runGit(['remote', 'add', 'origin', repository], { cwd: root })
   }
   if (!hasCommit(root, commit)) {
-    run('git', ['fetch', '--depth=1', 'origin', commit], { cwd: root, stdio: 'inherit' })
+    runGit(['fetch', '--depth=1', 'origin', commit], { cwd: root, stdio: 'inherit' })
   }
-  run('git', ['checkout', '--quiet', '--detach', commit], { cwd: root })
-  run('git', ['reset', '--quiet', '--hard', commit], { cwd: root })
+  runGit(['checkout', '--quiet', '--detach', commit], { cwd: root })
+  runGit(['reset', '--quiet', '--hard', commit], { cwd: root })
   return root
 }
 
@@ -358,7 +366,7 @@ function overlayBuildOutput(pristineDir, upstreamRoot, packageEntry, destination
 function diffFolders(folderA, folderB) {
   let stdout
   try {
-    stdout = execFileSync('git', [...PNPM_DIFF_FLAGS, folderA, folderB], {
+    stdout = execFileSync('git', [...GIT_EOL_ISOLATION, ...PNPM_DIFF_FLAGS, folderA, folderB], {
       encoding: 'utf8',
       maxBuffer: 512 * 1024 * 1024,
       env: pnpmDiffEnvironment(),
@@ -376,9 +384,8 @@ function diffFolders(folderA, folderB) {
 
 /** The source of truth for the hand-written half: what the checkout itself holds. */
 function diffCheckoutSource(packageRoot) {
-  return run('git', [...CHECKOUT_DIFF_FLAGS, 'src/'], {
+  return runGit([...CHECKOUT_DIFF_FLAGS, 'src/'], {
     cwd: packageRoot,
-    env: pnpmDiffEnvironment(),
     maxBuffer: 64 * 1024 * 1024
   })
 }
@@ -396,19 +403,16 @@ function regeneratePackage(packageEntry, manifest, context) {
   buildPackage(upstreamRoot, packageEntry, manifest)
   assertReproducesPristineBundles(pristineDir, upstreamRoot, packageEntry)
 
-  run('git', ['reset', '--quiet', '--hard', manifest.upstream.commit], { cwd: upstreamRoot })
+  runGit(['reset', '--quiet', '--hard', manifest.upstream.commit], { cwd: upstreamRoot })
   const packageDir = toPosix(packageEntry.packageDir)
-  run(
-    'git',
+  runGit(
     [
-      '-c',
-      'core.autocrlf=false',
       'apply',
       '--whitespace=nowarn',
       ...(packageDir === '.' ? [] : [`--directory=${packageDir}`]),
       path.join(repoRoot, packageEntry.sourcePatch)
     ],
-    { cwd: upstreamRoot, env: pnpmDiffEnvironment() }
+    { cwd: upstreamRoot }
   )
   buildPackage(upstreamRoot, packageEntry, manifest)
 
@@ -419,7 +423,7 @@ function regeneratePackage(packageEntry, manifest, context) {
   // no publish-time version stamp mixed in, so `git diff` there is the source
   // patch and nothing else.
   if (packageEntry.versionStampFile) {
-    run('git', ['checkout', '--', packageEntry.versionStampFile], {
+    runGit(['checkout', '--', packageEntry.versionStampFile], {
       cwd: path.join(upstreamRoot, packageEntry.packageDir)
     })
   }

--- a/config/scripts/regenerate-xterm-patches.mjs
+++ b/config/scripts/regenerate-xterm-patches.mjs
@@ -19,6 +19,7 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
   CHECKOUT_DIFF_FLAGS,
+  GIT_EOL_ISOLATION,
   PNPM_DIFF_FLAGS,
   assertSourceDerivationsAgree,
   escapeRegExp,
@@ -174,12 +175,11 @@ function run(command, args, options = {}) {
     ...options
   })
 }
-const GIT_EOL_ISOLATION = ['-c', 'core.autocrlf=false', '-c', 'core.eol=lf']
-
 function runGit(args, options = {}) {
+  const { ambientConfig = false, env, ...runOptions } = options
   return run('git', [...GIT_EOL_ISOLATION, ...args], {
-    ...options,
-    env: pnpmDiffEnvironment(options.env ?? process.env)
+    ...runOptions,
+    env: ambientConfig ? (env ?? process.env) : pnpmDiffEnvironment(env ?? process.env)
   })
 }
 
@@ -229,10 +229,14 @@ function ensureUpstreamCheckout(manifest, workDir) {
   if (!existsSync(path.join(root, '.git'))) {
     mkdirSync(root, { recursive: true })
     runGit(['init', '--quiet'], { cwd: root })
-    runGit(['remote', 'add', 'origin', repository], { cwd: root })
+    runGit(['remote', 'add', 'origin', repository], { cwd: root, ambientConfig: true })
   }
   if (!hasCommit(root, commit)) {
-    runGit(['fetch', '--depth=1', 'origin', commit], { cwd: root, stdio: 'inherit' })
+    runGit(['fetch', '--depth=1', 'origin', commit], {
+      cwd: root,
+      stdio: 'inherit',
+      ambientConfig: true
+    })
   }
   runGit(['checkout', '--quiet', '--detach', commit], { cwd: root })
   runGit(['reset', '--quiet', '--hard', commit], { cwd: root })

--- a/config/scripts/regenerate-xterm-patches.test.mjs
+++ b/config/scripts/regenerate-xterm-patches.test.mjs
@@ -181,6 +181,16 @@ describe('pnpm diff format', () => {
     expect(normalized).toContain(`diff --git a/na${eAcute}me/widget.js b/na${eAcute}me/widget.js`)
     expect(normalized).toContain('--- \\303\\251me')
   })
+  it('preserves literal quotes inside quoted Windows path headers', () => {
+    const quotedDiff = String.raw`diff --git "a/with\"quote\\name" "b/with\"quote\\name"
+--- "a/with\"quote\\name"
++++ "b/with\"quote\\name"
+@@ -1 +1 @@`
+
+    expect(normalizePnpmDiff(quotedDiff, '/pristine', '/patched')).toContain(
+      'diff --git a/with"quote/name b/with"quote/name'
+    )
+  })
 
   it('drops a trailing no-newline marker and .DS_Store entries', () => {
     const withMarker = 'diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n\\ No newline at end of file\n'

--- a/config/scripts/regenerate-xterm-patches.test.mjs
+++ b/config/scripts/regenerate-xterm-patches.test.mjs
@@ -177,7 +177,8 @@ describe('pnpm diff format', () => {
     ].join('\n')
 
     const normalized = normalizePnpmDiff(escapedDiff, '/pristine', '/patched')
-    expect(normalized).toContain('diff --git a/naéme/widget.js b/naéme/widget.js')
+    const eAcute = String.fromCodePoint(0xe9)
+    expect(normalized).toContain(`diff --git a/na${eAcute}me/widget.js b/na${eAcute}me/widget.js`)
     expect(normalized).toContain('--- \\303\\251me')
   })
 

--- a/config/scripts/regenerate-xterm-patches.test.mjs
+++ b/config/scripts/regenerate-xterm-patches.test.mjs
@@ -191,6 +191,13 @@ describe('pnpm diff format', () => {
       'diff --git a/with"quote/name b/with"quote/name'
     )
   })
+  it('strips delimiters after even backslash runs', () => {
+    const trailingSlashDiff = String.raw`diff --git "a/dir\\" "b/dir\\"`
+
+    expect(normalizePnpmDiff(trailingSlashDiff, '/pristine', '/patched')).toContain(
+      'diff --git a/dir/ b/dir/'
+    )
+  })
 
   it('drops a trailing no-newline marker and .DS_Store entries', () => {
     const withMarker = 'diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n\\ No newline at end of file\n'

--- a/config/scripts/regenerate-xterm-patches.test.mjs
+++ b/config/scripts/regenerate-xterm-patches.test.mjs
@@ -216,7 +216,11 @@ describe('round-trip stability', () => {
     await writeTree(replay, PRISTINE)
     const patchFile = path.join(root, 'round-trip.patch')
     await writeFile(patchFile, patch)
-    execFileSync('git', ['apply', '-p1', '--whitespace=nowarn', patchFile], { cwd: replay })
+    execFileSync(
+      'git',
+      ['-c', 'core.autocrlf=false', 'apply', '-p1', '--whitespace=nowarn', patchFile],
+      { cwd: replay, env: pnpmDiffEnvironment() }
+    )
 
     expect(await readFile(path.join(replay, 'lib/widget.js'), 'utf8')).toBe(
       PATCHED['lib/widget.js']
@@ -235,7 +239,11 @@ describe('round-trip stability', () => {
 
     const replay = path.join(root, 'replay')
     await writeTree(replay, PRISTINE)
-    execFileSync('git', ['apply', '-p1', '--whitespace=nowarn', patchFile], { cwd: replay })
+    execFileSync(
+      'git',
+      ['-c', 'core.autocrlf=false', 'apply', '-p1', '--whitespace=nowarn', patchFile],
+      { cwd: replay, env: pnpmDiffEnvironment() }
+    )
 
     expect(await readFile(path.join(replay, 'src/Widget.ts'), 'utf8')).toBe(
       PATCHED['src/Widget.ts']

--- a/config/scripts/regenerate-xterm-patches.test.mjs
+++ b/config/scripts/regenerate-xterm-patches.test.mjs
@@ -18,6 +18,7 @@ import {
 } from './regenerate-xterm-patches.mjs'
 import {
   CHECKOUT_DIFF_FLAGS,
+  GIT_EOL_ISOLATION,
   PNPM_DIFF_FLAGS,
   assertSourceDerivationsAgree,
   firstDifferenceIndex,
@@ -64,11 +65,11 @@ async function writeTree(root, files) {
   }
 }
 
-/** The three exported diff pieces, composed the way the generator composes them. */
+/** The three exported diff pieces, composed exactly as the generator composes them. */
 function diffFolders(folderA, folderB) {
   let stdout
   try {
-    stdout = execFileSync('git', [...PNPM_DIFF_FLAGS, folderA, folderB], {
+    stdout = execFileSync('git', [...GIT_EOL_ISOLATION, ...PNPM_DIFF_FLAGS, folderA, folderB], {
       encoding: 'utf8',
       env: pnpmDiffEnvironment(),
       stdio: ['ignore', 'pipe', 'pipe']
@@ -164,6 +165,20 @@ describe('pnpm diff format', () => {
         ''
       ].join('\n')
     )
+  })
+  it('decodes Git C-style escapes in quoted Windows headers', () => {
+    const escapedDiff = [
+      'diff --git "a/na\\303\\251me\\\\widget.js" "b/na\\303\\251me\\\\widget.js"',
+      '--- "a/na\\303\\251me\\\\widget.js"',
+      '+++ "b/na\\303\\251me\\\\widget.js"',
+      '@@ -1 +1 @@',
+      '--- \\303\\251me',
+      ''
+    ].join('\n')
+
+    const normalized = normalizePnpmDiff(escapedDiff, '/pristine', '/patched')
+    expect(normalized).toContain('diff --git a/naéme/widget.js b/naéme/widget.js')
+    expect(normalized).toContain('--- \\303\\251me')
   })
 
   it('drops a trailing no-newline marker and .DS_Store entries', () => {

--- a/config/scripts/regenerate-xterm-patches.test.mjs
+++ b/config/scripts/regenerate-xterm-patches.test.mjs
@@ -142,6 +142,29 @@ describe('pnpm diff format', () => {
     expect(patch).toContain('--- a/src/Widget.ts')
     expect(patch).toContain('+++ b/src/Widget.ts')
   })
+  it('normalizes quoted Windows headers without rewriting hunk bodies', () => {
+    const windowsDiff = [
+      'diff --git "a/lib\\widget.js" "b/lib\\widget.js"',
+      '--- "a/lib\\widget.js"',
+      '+++ "b/lib\\widget.js"',
+      '@@ -1 +1 @@',
+      '--- \\server\\deleted',
+      '+++ \\server\\added',
+      ''
+    ].join('\n')
+
+    expect(normalizePnpmDiff(windowsDiff, '/pristine', '/patched')).toBe(
+      [
+        'diff --git a/lib/widget.js b/lib/widget.js',
+        '--- a/lib/widget.js',
+        '+++ b/lib/widget.js',
+        '@@ -1 +1 @@',
+        '--- \\server\\deleted',
+        '+++ \\server\\added',
+        ''
+      ].join('\n')
+    )
+  })
 
   it('drops a trailing no-newline marker and .DS_Store entries', () => {
     const withMarker = 'diff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n\\ No newline at end of file\n'

--- a/config/scripts/shared-electron-dist-cache.test.ts
+++ b/config/scripts/shared-electron-dist-cache.test.ts
@@ -39,6 +39,27 @@ function makeRoot(): string {
   return root
 }
 
+function canCreateFileSymlinks(): boolean {
+  const probeDir = mkdtempSync(path.join(tmpdir(), 'orca-symlink-capability-'))
+  const targetPath = path.join(probeDir, 'target')
+  const linkPath = path.join(probeDir, 'link')
+  try {
+    writeFileSync(targetPath, '')
+    symlinkSync(targetPath, linkPath)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES')) {
+      return false
+    }
+    throw error
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true })
+  }
+}
+
+const symlinkIt = it.skipIf(!canCreateFileSymlinks())
+
 function writeDist(distPath: string, version = VERSION): string {
   mkdirSync(path.join(distPath, path.dirname(PLATFORM_PATH)), { recursive: true })
   writeFileSync(path.join(distPath, 'version'), `v${version}\n`)
@@ -63,15 +84,16 @@ const baseOptions = {
   targetArch: 'arm64',
   hostPlatform: 'darwin' as const,
   env: {} as NodeJS.ProcessEnv,
-  execFile: (() => '/repo/.git\n') as unknown as typeof execFileSync
+  execFile: (() => `${path.resolve('/repo/.git')}\n`) as unknown as typeof execFileSync
 }
 
 describe('resolveSharedElectronDistEntry', () => {
   it('keys the entry by version, platform, and arch under the git common dir', () => {
     const entry = resolveSharedElectronDistEntry(baseOptions)
-    expect(entry?.cacheRoot).toBe(path.join('/repo/.git', 'orca-cache', 'electron'))
+    const expectedGitCommonDir = path.resolve('/repo/.git')
+    expect(entry?.cacheRoot).toBe(path.join(expectedGitCommonDir, 'orca-cache', 'electron'))
     expect(entry?.entryPath).toBe(
-      path.join('/repo/.git', 'orca-cache', 'electron', '43.4.1-darwin-arm64')
+      path.join(expectedGitCommonDir, 'orca-cache', 'electron', '43.4.1-darwin-arm64')
     )
     expect(entry?.markerPath).toBe(path.join('/repo/node_modules/electron', '.orca-shared-dist'))
   })
@@ -122,7 +144,7 @@ describe('isUsableElectronDist', () => {
     expect(isUsableElectronDist(path.join(root, 'missing'), VERSION, PLATFORM_PATH)).toBe(false)
   })
 
-  it('rejects a symlink so a redirected entry is never treated as cache content', () => {
+  symlinkIt('rejects a symlink so a redirected entry is never treated as cache content', () => {
     const root = makeRoot()
     writeDist(path.join(root, 'real'))
     symlinkSync(path.join(root, 'real'), path.join(root, 'link'), 'dir')

--- a/config/scripts/space-sharing-copy.test.ts
+++ b/config/scripts/space-sharing-copy.test.ts
@@ -41,7 +41,7 @@ function canCreateFileSymlinks(): boolean {
   }
 }
 
-const describeWithSymlinks = describe.skipIf(!canCreateFileSymlinks())
+const symlinksAvailable = canCreateFileSymlinks()
 
 const roots: string[] = []
 
@@ -57,11 +57,13 @@ function makeTree(): { root: string; source: string } {
   const source = path.join(root, 'source')
   mkdirSync(path.join(source, 'nested'), { recursive: true })
   writeFileSync(path.join(source, 'nested', 'file'), 'contents')
-  symlinkSync(path.join('nested', 'file'), path.join(source, 'relative-link'))
+  if (symlinksAvailable) {
+    symlinkSync(path.join('nested', 'file'), path.join(source, 'relative-link'))
+  }
   return { root, source }
 }
 
-describeWithSymlinks('shareTree', () => {
+describe('shareTree', () => {
   // Mechanism selection is asserted with stubs, because the real mechanisms only exist on the host
   // that owns them: /bin/cp -c is macOS-only and `cp --reflink` is GNU-only.
   it('prefers the strongest isolation each platform offers', () => {
@@ -76,13 +78,18 @@ describeWithSymlinks('shareTree', () => {
     )
   })
 
-  it('keeps relative symlinks unresolved on whatever this host supports', () => {
-    const { root, source } = makeTree()
-    const destination = path.join(root, 'shared')
-    expect(shareTree(source, destination)).toBeTruthy()
-    expect(readFileSync(path.join(destination, 'nested', 'file'), 'utf8')).toBe('contents')
-    expect(readlinkSync(path.join(destination, 'relative-link'))).toBe(path.join('nested', 'file'))
-  })
+  it.skipIf(!symlinksAvailable)(
+    'keeps relative symlinks unresolved on whatever this host supports',
+    () => {
+      const { root, source } = makeTree()
+      const destination = path.join(root, 'shared')
+      expect(shareTree(source, destination)).toBeTruthy()
+      expect(readFileSync(path.join(destination, 'nested', 'file'), 'utf8')).toBe('contents')
+      expect(readlinkSync(path.join(destination, 'relative-link'))).toBe(
+        path.join('nested', 'file')
+      )
+    }
+  )
 
   it('falls from reflink to hardlink on Linux, where ext4 has no reflinks', () => {
     const { root, source } = makeTree()
@@ -127,16 +134,21 @@ describeWithSymlinks('shareTree', () => {
   })
 })
 
-describeWithSymlinks('hardlinkTree', () => {
-  it('shares inodes for files but recreates symlinks as their own entries', () => {
-    const { root, source } = makeTree()
-    const destination = path.join(root, 'linked')
-    hardlinkTree(source, destination)
-    expect(statSync(path.join(destination, 'nested', 'file')).ino).toBe(
-      statSync(path.join(source, 'nested', 'file')).ino
-    )
-    expect(readlinkSync(path.join(destination, 'relative-link'))).toBe(path.join('nested', 'file'))
-  })
+describe('hardlinkTree', () => {
+  it.skipIf(!symlinksAvailable)(
+    'shares inodes for files but recreates symlinks as their own entries',
+    () => {
+      const { root, source } = makeTree()
+      const destination = path.join(root, 'linked')
+      hardlinkTree(source, destination)
+      expect(statSync(path.join(destination, 'nested', 'file')).ino).toBe(
+        statSync(path.join(source, 'nested', 'file')).ino
+      )
+      expect(readlinkSync(path.join(destination, 'relative-link'))).toBe(
+        path.join('nested', 'file')
+      )
+    }
+  )
 
   it('propagates a write through the shared inode, which is why callers must protect it', () => {
     const { root, source } = makeTree()
@@ -147,7 +159,7 @@ describeWithSymlinks('hardlinkTree', () => {
   })
 })
 
-describeWithSymlinks('makeTreeReadOnly', () => {
+describe('makeTreeReadOnly', () => {
   it('drops write permission on files while leaving directories traversable and unlinkable', () => {
     const { source } = makeTree()
     makeTreeReadOnly(source)
@@ -191,7 +203,7 @@ describeWithSymlinks('makeTreeReadOnly', () => {
   )
 })
 
-describeWithSymlinks('makeTreeWritable', () => {
+describe('makeTreeWritable', () => {
   it.runIf(process.platform !== 'win32')('undoes makeTreeReadOnly for the owner', () => {
     const { source } = makeTree()
     makeTreeReadOnly(source)
@@ -211,7 +223,7 @@ describeWithSymlinks('makeTreeWritable', () => {
   })
 })
 
-describeWithSymlinks('copyPrivateTree', () => {
+describe('copyPrivateTree', () => {
   it.runIf(process.platform !== 'win32')(
     'hands back a tree the caller can patch, even from a write-protected source',
     () => {
@@ -238,18 +250,23 @@ describeWithSymlinks('copyPrivateTree', () => {
     expect(result.mechanism === 'reflink' || result.mechanism === null).toBe(true)
   })
 
-  it('copies bytes on a platform with no private mechanism at all', () => {
-    const { root, source } = makeTree()
-    const destination = path.join(root, 'private')
-    const hardlink = vi.fn()
-    expect(copyPrivateTree(source, destination, { platform: 'win32', hardlink })).toEqual({
-      mechanism: null,
-      copyError: null
-    })
-    expect(hardlink).not.toHaveBeenCalled()
-    expect(readFileSync(path.join(destination, 'nested', 'file'), 'utf8')).toBe('contents')
-    expect(readlinkSync(path.join(destination, 'relative-link'))).toBe(path.join('nested', 'file'))
-  })
+  it.skipIf(!symlinksAvailable)(
+    'copies bytes on a platform with no private mechanism at all',
+    () => {
+      const { root, source } = makeTree()
+      const destination = path.join(root, 'private')
+      const hardlink = vi.fn()
+      expect(copyPrivateTree(source, destination, { platform: 'win32', hardlink })).toEqual({
+        mechanism: null,
+        copyError: null
+      })
+      expect(hardlink).not.toHaveBeenCalled()
+      expect(readFileSync(path.join(destination, 'nested', 'file'), 'utf8')).toBe('contents')
+      expect(readlinkSync(path.join(destination, 'relative-link'))).toBe(
+        path.join('nested', 'file')
+      )
+    }
+  )
 
   it('reports the private mechanism it used', () => {
     const { root, source } = makeTree()

--- a/config/scripts/space-sharing-copy.test.ts
+++ b/config/scripts/space-sharing-copy.test.ts
@@ -22,6 +22,26 @@ import {
   makeTreeWritable,
   shareTree
 } from './space-sharing-copy.mjs'
+function canCreateFileSymlinks(): boolean {
+  const probeDir = mkdtempSync(path.join(tmpdir(), 'orca-symlink-capability-'))
+  const targetPath = path.join(probeDir, 'target')
+  const linkPath = path.join(probeDir, 'link')
+  try {
+    writeFileSync(targetPath, '')
+    symlinkSync(targetPath, linkPath)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES')) {
+      return false
+    }
+    throw error
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true })
+  }
+}
+
+const describeWithSymlinks = describe.skipIf(!canCreateFileSymlinks())
 
 const roots: string[] = []
 
@@ -41,7 +61,7 @@ function makeTree(): { root: string; source: string } {
   return { root, source }
 }
 
-describe('shareTree', () => {
+describeWithSymlinks('shareTree', () => {
   // Mechanism selection is asserted with stubs, because the real mechanisms only exist on the host
   // that owns them: /bin/cp -c is macOS-only and `cp --reflink` is GNU-only.
   it('prefers the strongest isolation each platform offers', () => {
@@ -107,7 +127,7 @@ describe('shareTree', () => {
   })
 })
 
-describe('hardlinkTree', () => {
+describeWithSymlinks('hardlinkTree', () => {
   it('shares inodes for files but recreates symlinks as their own entries', () => {
     const { root, source } = makeTree()
     const destination = path.join(root, 'linked')
@@ -127,7 +147,7 @@ describe('hardlinkTree', () => {
   })
 })
 
-describe('makeTreeReadOnly', () => {
+describeWithSymlinks('makeTreeReadOnly', () => {
   it('drops write permission on files while leaving directories traversable and unlinkable', () => {
     const { source } = makeTree()
     makeTreeReadOnly(source)
@@ -171,7 +191,7 @@ describe('makeTreeReadOnly', () => {
   )
 })
 
-describe('makeTreeWritable', () => {
+describeWithSymlinks('makeTreeWritable', () => {
   it.runIf(process.platform !== 'win32')('undoes makeTreeReadOnly for the owner', () => {
     const { source } = makeTree()
     makeTreeReadOnly(source)
@@ -191,7 +211,7 @@ describe('makeTreeWritable', () => {
   })
 })
 
-describe('copyPrivateTree', () => {
+describeWithSymlinks('copyPrivateTree', () => {
   it.runIf(process.platform !== 'win32')(
     'hands back a tree the caller can patch, even from a write-protected source',
     () => {

--- a/config/scripts/xterm-patch-text.mjs
+++ b/config/scripts/xterm-patch-text.mjs
@@ -65,7 +65,10 @@ function normalizeWindowsDiffHeaders(stdout) {
     }
     // Git quotes Windows paths because the backslashes are special. pnpm's
     // normalized patch uses portable slash-separated, unquoted paths instead.
-    return `${prefix}${paths.replaceAll('\\', '/').replaceAll('"', '')}`
+    return `${prefix}${paths
+      .replaceAll('\\', '/')
+      .replace(/\/{2,}/g, '/')
+      .replaceAll('"', '')}`
   })
 }
 

--- a/config/scripts/xterm-patch-text.mjs
+++ b/config/scripts/xterm-patch-text.mjs
@@ -6,6 +6,9 @@
  * tests exercise it with no network and no build.
  */
 
+/** Git settings that keep checked-out and diffed patch trees LF-normalized. */
+export const GIT_EOL_ISOLATION = ['-c', 'core.autocrlf=false', '-c', 'core.eol=lf']
+
 /**
  * Flags pnpm@12 passes to `git diff` in its own `diff_folders()`. A patch built
  * with anything else is a patch pnpm may re-diff differently on the next
@@ -57,6 +60,53 @@ export function escapeRegExp(value) {
 function trimSurroundingSlashes(value) {
   return value[0] === '/' || value.endsWith('/') ? value.replace(/^\/|\/$/g, '') : value
 }
+const GIT_SIMPLE_ESCAPES = {
+  '"': '"',
+  '\\': '\\',
+  a: '\x07',
+  b: '\b',
+  f: '\f',
+  n: '\n',
+  r: '\r',
+  t: '\t',
+  v: '\v'
+}
+
+function decodeGitQuotedPath(value) {
+  let decoded = ''
+  for (let index = 0; index < value.length;) {
+    if (value[index] !== '\\') {
+      decoded += value[index++]
+      continue
+    }
+    const escaped = value[index + 1]
+    if (escaped === undefined) {
+      decoded += '\\'
+      index += 1
+      continue
+    }
+    if (Object.hasOwn(GIT_SIMPLE_ESCAPES, escaped)) {
+      decoded += GIT_SIMPLE_ESCAPES[escaped]
+      index += 2
+      continue
+    }
+    if (/[0-7]/.test(escaped)) {
+      const bytes = []
+      while (value[index] === '\\' && /[0-7]/.test(value[index + 1] ?? '')) {
+        const octal = value.slice(index + 1, index + 4).match(/^[0-7]{1,3}/)[0]
+        bytes.push(Number.parseInt(octal, 8))
+        index += 1 + octal.length
+      }
+      decoded += Buffer.from(bytes).toString('utf8')
+      continue
+    }
+    // A raw Windows separator is not a C escape; preserve it for slash
+    // normalization below. Git's actual C escapes are handled above.
+    decoded += '\\'
+    index += 1
+  }
+  return decoded
+}
 
 function normalizeWindowsDiffHeaders(stdout) {
   let inHunk = false
@@ -80,7 +130,7 @@ function normalizeWindowsDiffHeaders(stdout) {
       }
       // Git quotes Windows paths because the backslashes are special. pnpm's
       // normalized patch uses portable slash-separated, unquoted paths instead.
-      return `${match[1]}${match[2]
+      return `${match[1]}${decodeGitQuotedPath(match[2])
         .replaceAll('\\', '/')
         .replace(/\/{2,}/g, '/')
         .replaceAll('"', '')}`

--- a/config/scripts/xterm-patch-text.mjs
+++ b/config/scripts/xterm-patch-text.mjs
@@ -107,6 +107,26 @@ function decodeGitQuotedPath(value) {
   }
   return decoded
 }
+function stripGitHeaderQuoteDelimiters(value) {
+  let stripped = ''
+  let inQuote = false
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]
+    const escaped = index > 0 && value[index - 1] === '\\'
+    const opensToken = !inQuote && character === '"' && (index === 0 || value[index - 1] === ' ')
+    const closesToken =
+      inQuote &&
+      character === '"' &&
+      !escaped &&
+      (index === value.length - 1 || value[index + 1] === ' ')
+    if (opensToken || closesToken) {
+      inQuote = !inQuote
+      continue
+    }
+    stripped += character
+  }
+  return stripped
+}
 
 function normalizeWindowsDiffHeaders(stdout) {
   let inHunk = false
@@ -129,15 +149,15 @@ function normalizeWindowsDiffHeaders(stdout) {
         return line
       }
       // Git quotes Windows paths because the backslashes are special. pnpm's
-      // normalized patch uses portable slash-separated, unquoted paths instead.
-      return `${match[1]}${decodeGitQuotedPath(match[2])
+      // normalized patch uses portable slash-separated paths while preserving
+      // literal quotes that belong to a filename.
+      const unquoted = stripGitHeaderQuoteDelimiters(match[2])
+      return `${match[1]}${decodeGitQuotedPath(unquoted)
         .replaceAll('\\', '/')
-        .replace(/\/{2,}/g, '/')
-        .replaceAll('"', '')}`
+        .replace(/\/{2,}/g, '/')}`
     })
     .join('\n')
 }
-
 /**
  * Reproduces pnpm's post-processing of the raw `git diff` output: strip the two
  * scratch folder prefixes, drop a trailing no-newline marker, and remove

--- a/config/scripts/xterm-patch-text.mjs
+++ b/config/scripts/xterm-patch-text.mjs
@@ -59,17 +59,33 @@ function trimSurroundingSlashes(value) {
 }
 
 function normalizeWindowsDiffHeaders(stdout) {
-  return stdout.replace(/^(diff --git |--- |\+\+\+ )(.+)$/gm, (line, prefix, paths) => {
-    if (!paths.includes('\\')) {
-      return line
-    }
-    // Git quotes Windows paths because the backslashes are special. pnpm's
-    // normalized patch uses portable slash-separated, unquoted paths instead.
-    return `${prefix}${paths
-      .replaceAll('\\', '/')
-      .replace(/\/{2,}/g, '/')
-      .replaceAll('"', '')}`
-  })
+  let inHunk = false
+  return stdout
+    .split('\n')
+    .map((line) => {
+      if (line.startsWith('diff --git ')) {
+        inHunk = false
+      } else if (line.startsWith('@@ ')) {
+        inHunk = true
+      }
+      if (
+        inHunk ||
+        (!line.startsWith('diff --git ') && !line.startsWith('--- ') && !line.startsWith('+++ '))
+      ) {
+        return line
+      }
+      const match = /^(diff --git |--- |\+\+\+ )("?[ab]\/.*)$/.exec(line)
+      if (!match || !match[2].includes('\\')) {
+        return line
+      }
+      // Git quotes Windows paths because the backslashes are special. pnpm's
+      // normalized patch uses portable slash-separated, unquoted paths instead.
+      return `${match[1]}${match[2]
+        .replaceAll('\\', '/')
+        .replace(/\/{2,}/g, '/')
+        .replaceAll('"', '')}`
+    })
+    .join('\n')
 }
 
 /**

--- a/config/scripts/xterm-patch-text.mjs
+++ b/config/scripts/xterm-patch-text.mjs
@@ -112,7 +112,11 @@ function stripGitHeaderQuoteDelimiters(value) {
   let inQuote = false
   for (let index = 0; index < value.length; index += 1) {
     const character = value[index]
-    const escaped = index > 0 && value[index - 1] === '\\'
+    let precedingBackslashes = 0
+    for (let previous = index - 1; previous >= 0 && value[previous] === '\\'; previous -= 1) {
+      precedingBackslashes += 1
+    }
+    const escaped = precedingBackslashes % 2 === 1
     const opensToken = !inQuote && character === '"' && (index === 0 || value[index - 1] === ' ')
     const closesToken =
       inQuote &&

--- a/config/scripts/xterm-patch-text.mjs
+++ b/config/scripts/xterm-patch-text.mjs
@@ -58,6 +58,17 @@ function trimSurroundingSlashes(value) {
   return value[0] === '/' || value.endsWith('/') ? value.replace(/^\/|\/$/g, '') : value
 }
 
+function normalizeWindowsDiffHeaders(stdout) {
+  return stdout.replace(/^(diff --git |--- |\+\+\+ )(.+)$/gm, (line, prefix, paths) => {
+    if (!paths.includes('\\')) {
+      return line
+    }
+    // Git quotes Windows paths because the backslashes are special. pnpm's
+    // normalized patch uses portable slash-separated, unquoted paths instead.
+    return `${prefix}${paths.replaceAll('\\', '/').replaceAll('"', '')}`
+  })
+}
+
 /**
  * Reproduces pnpm's post-processing of the raw `git diff` output: strip the two
  * scratch folder prefixes, drop a trailing no-newline marker, and remove
@@ -66,7 +77,7 @@ function trimSurroundingSlashes(value) {
 export function normalizePnpmDiff(stdout, folderA, folderB) {
   const a = folderA.replace(/\\/g, '/')
   const b = folderB.replace(/\\/g, '/')
-  return stdout
+  return normalizeWindowsDiffHeaders(stdout)
     .replace(new RegExp(`(a|b)(${escapeRegExp(`/${trimSurroundingSlashes(a)}/`)})`, 'g'), '$1/')
     .replace(new RegExp(`(a|b)${escapeRegExp(`/${trimSurroundingSlashes(b)}/`)}`, 'g'), '$1/')
     .replace(new RegExp(escapeRegExp(`${a}/`), 'g'), '')

--- a/src/cli/handlers/orchestration-gate-cli.test.ts
+++ b/src/cli/handlers/orchestration-gate-cli.test.ts
@@ -237,7 +237,20 @@ describe('orchestration gate commands carry caller identity', () => {
     const output = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
       error: { message: string; data: Record<string, unknown> }
     }
-    expect(output.error.message).toContain(renderCommand(['--retry-request', 'mutation_1']))
+    expect(output.error.message).toContain(
+      renderCommand([
+        'orca',
+        'orchestration',
+        'gate-create',
+        '--task',
+        'task_1',
+        '--question',
+        'ship?',
+        '--json',
+        '--retry-request',
+        'mutation_1'
+      ])
+    )
     expect(output.error.message).toContain('may already have taken effect')
     expect(output.error.message).toContain('Failed stage: dispatch_input')
     expect(output.error.message).toMatch(/Residual resources:.*repo::child.*term_worker/)

--- a/src/cli/handlers/orchestration-gate-cli.test.ts
+++ b/src/cli/handlers/orchestration-gate-cli.test.ts
@@ -28,6 +28,7 @@ vi.mock('../selectors', async (importOriginal) => ({
   getTerminalHandle: getTerminalHandleMock
 }))
 
+import { renderCommand } from '../orchestration-mutation-recovery'
 import { main } from '../index'
 import { RuntimeClientError } from '../runtime/types'
 import { okFixture, queueFixtures } from '../test-fixtures'
@@ -236,7 +237,7 @@ describe('orchestration gate commands carry caller identity', () => {
     const output = JSON.parse(String(logSpy.mock.calls[0]?.[0])) as {
       error: { message: string; data: Record<string, unknown> }
     }
-    expect(output.error.message).toContain('--retry-request mutation_1')
+    expect(output.error.message).toContain(renderCommand(['--retry-request', 'mutation_1']))
     expect(output.error.message).toContain('may already have taken effect')
     expect(output.error.message).toContain('Failed stage: dispatch_input')
     expect(output.error.message).toMatch(/Residual resources:.*repo::child.*term_worker/)

--- a/src/cli/handlers/orchestration-timeout-cli.test.ts
+++ b/src/cli/handlers/orchestration-timeout-cli.test.ts
@@ -8,6 +8,7 @@ vi.mock('../format', () => ({ printResult: vi.fn() }))
 vi.mock('../selectors', () => ({ getTerminalHandle: vi.fn() }))
 
 import { printResult } from '../format'
+import { renderCommand } from '../orchestration-mutation-recovery'
 import { ORCHESTRATION_HANDLERS } from './orchestration'
 
 describe('orchestration timeout flag validation', () => {
@@ -264,11 +265,21 @@ describe('orchestration timeout flag validation', () => {
       ])
     )
 
+    const expectedResumeCommand = renderCommand([
+      'orca-dev',
+      'orchestration',
+      'ask',
+      '--from',
+      'term_worker',
+      '--dispatch-capability',
+      'dcap_secret',
+      '--resume',
+      'msg_question',
+      '--timeout-ms',
+      '30000'
+    ])
     expect(errorSpy).toHaveBeenCalledWith(
-      'ask timeout after 30000ms; question is still pending (messageId: msg_question). ' +
-        'Resume waiting; do not ask again:\n' +
-        'orca-dev orchestration ask --from term_worker --dispatch-capability dcap_secret ' +
-        '--resume msg_question --timeout-ms 30000'
+      `ask timeout after 30000ms; question is still pending (messageId: msg_question). Resume waiting; do not ask again:\n${expectedResumeCommand}`
     )
     expect(process.exitCode).toBe(1)
   })

--- a/src/cli/handlers/orchestration-worker-cli.test.ts
+++ b/src/cli/handlers/orchestration-worker-cli.test.ts
@@ -17,6 +17,7 @@ vi.mock('../format', () => ({ printResult: vi.fn() }))
 vi.mock('../selectors', () => ({ getTerminalHandle: vi.fn() }))
 
 import { ORCHESTRATION_HANDLERS } from './orchestration'
+import { renderResolvedOrchestrationCommand } from '../orchestration-mutation-recovery'
 import { printResult } from '../format'
 import { BOOLEAN_FLAGS, parseArgs } from '../args'
 import { formatCommandHelp } from '../help'
@@ -263,14 +264,19 @@ describe('orchestration worker-start CLI contract', () => {
         boolean,
         (result: RecoveryWorkerStartResult) => string
       ]
-      expect(response.result.nextCommands).toEqual([
-        `${executable} orchestration worker-show --dispatch ctx_unknown --json`,
-        `${executable} orchestration worker-abandon --dispatch ctx_unknown --json`
-      ])
-      if (!json) {
-        expect(formatter(response.result)).toContain(
-          `Next command: ${executable} orchestration worker-show --dispatch ctx_unknown --json`
+      const expectedNextCommands = [
+        renderResolvedOrchestrationCommand(
+          'orca orchestration worker-show --dispatch ctx_unknown --json',
+          executable
+        ),
+        renderResolvedOrchestrationCommand(
+          'orca orchestration worker-abandon --dispatch ctx_unknown --json',
+          executable
         )
+      ]
+      expect(response.result.nextCommands).toEqual(expectedNextCommands)
+      if (!json) {
+        expect(formatter(response.result)).toContain(`Next command: ${expectedNextCommands[0]}`)
       }
     }
   )

--- a/src/cli/orchestration-mutation-recovery.test.ts
+++ b/src/cli/orchestration-mutation-recovery.test.ts
@@ -45,8 +45,8 @@ describe('orchestration mutation recovery', () => {
       result.message.indexOf(renderCommand(['orca', 'orchestration', 'worker-show']))
     ).toBeLessThan(result.message.indexOf(renderCommand(['orca', 'orchestration', 'worker-start'])))
     expect((result.data as { nextSteps?: string[] }).nextSteps).toEqual([
-      'Run orca orchestration worker-show --dispatch dispatch_1 --json before retrying.',
-      'After inspecting the Dispatch, if keyed recovery is still needed, run orca orchestration worker-start --task task_1 --retry-request request_1. --retry-request reuses the same operation identity so Orca can replay, join, or safely recover it without starting a separate duplicate.'
+      `Run ${renderCommand(['orca', 'orchestration', 'worker-show', '--dispatch', 'dispatch_1', '--json'])} before retrying.`,
+      `After inspecting the Dispatch, if keyed recovery is still needed, run ${renderCommand(['orca', 'orchestration', 'worker-start', '--task', 'task_1', '--retry-request', 'request_1'])}. --retry-request reuses the same operation identity so Orca can replay, join, or safely recover it without starting a separate duplicate.`
     ])
   })
 

--- a/src/cli/orchestration-mutation-recovery.test.ts
+++ b/src/cli/orchestration-mutation-recovery.test.ts
@@ -41,9 +41,9 @@ describe('orchestration mutation recovery', () => {
         workerDeathInferred: false
       }
     })
-    expect(result.message.indexOf('orca orchestration worker-show')).toBeLessThan(
-      result.message.indexOf('orca orchestration worker-start')
-    )
+    expect(
+      result.message.indexOf(renderCommand(['orca', 'orchestration', 'worker-show']))
+    ).toBeLessThan(result.message.indexOf(renderCommand(['orca', 'orchestration', 'worker-start'])))
     expect((result.data as { nextSteps?: string[] }).nextSteps).toEqual([
       'Run orca orchestration worker-show --dispatch dispatch_1 --json before retrying.',
       'After inspecting the Dispatch, if keyed recovery is still needed, run orca orchestration worker-start --task task_1 --retry-request request_1. --retry-request reuses the same operation identity so Orca can replay, join, or safely recover it without starting a separate duplicate.'
@@ -83,7 +83,7 @@ describe('orchestration mutation recovery', () => {
       }
     })
     expect((result.data as { nextSteps?: string[] }).nextSteps?.[0]).toBe(
-      'Run orca orchestration request-show --request request_4 --json before retrying.'
+      `Run ${renderCommand(['orca', 'orchestration', 'request-show', '--request', 'request_4', '--json'])} before retrying.`
     )
   })
 
@@ -120,11 +120,23 @@ describe('orchestration mutation recovery', () => {
       })
     ) as RuntimeClientError
 
+    const retryCommand = [
+      'orca-dev',
+      'orchestration',
+      'worker-start',
+      '--task',
+      'task 3',
+      '--comment',
+      'literal $(do-not-run)',
+      '--retry-request',
+      'request_3'
+    ]
+    const retryText = renderCommand(retryCommand)
     expect((result.data as { nextSteps?: string[] }).nextSteps).toEqual([
-      'Run orca-dev orchestration worker-show --dispatch dispatch_3 --json before retrying.',
-      "After inspecting the Dispatch, if keyed recovery is still needed, run orca-dev orchestration worker-start --task 'task 3' --comment 'literal $(do-not-run)' --retry-request request_3. --retry-request reuses the same operation identity so Orca can replay, join, or safely recover it without starting a separate duplicate."
+      `Run ${renderCommand(['orca-dev', 'orchestration', 'worker-show', '--dispatch', 'dispatch_3', '--json'])} before retrying.`,
+      `After inspecting the Dispatch, if keyed recovery is still needed, run ${retryText}. --retry-request reuses the same operation identity so Orca can replay, join, or safely recover it without starting a separate duplicate.`
     ])
-    expect(result.message).toContain("'literal $(do-not-run)'")
+    expect(result.message).toContain(retryText)
   })
 
   it('parses legacy command text without losing quoted arguments', () => {

--- a/src/cli/runtime/client-recovery.test.ts
+++ b/src/cli/runtime/client-recovery.test.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from 'node:net'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ORCHESTRATION_CONTRACT_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
 import { ORCHESTRATION_WORKER_START_CLIENT_GRACE_MS } from '../../shared/orchestration-timing-budgets'
@@ -25,13 +25,19 @@ afterEach(async () => {
   servers.clear()
 })
 
+function runtimeEndpoint(userDataPath: string): string {
+  return process.platform === 'win32'
+    ? `\\\\.\\pipe\\orca-runtime-test-${basename(userDataPath)}`
+    : join(userDataPath, 'runtime.sock')
+}
+
 function writeRuntimeConnection(userDataPath: string, endpoint: string, runtimeId: string): void {
   writeFileSync(
     join(userDataPath, 'orca-runtime.json'),
     JSON.stringify({
       runtimeId,
       pid: 1,
-      transports: [{ kind: 'unix', endpoint }],
+      transports: [{ kind: process.platform === 'win32' ? 'named-pipe' : 'unix', endpoint }],
       authToken: 'token',
       startedAt: 1
     })
@@ -73,7 +79,7 @@ describe('RuntimeClient orchestration recovery identity', () => {
 
   it('attaches the request and exact retry identity to a real RPC failure response', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-recovery-'))
-    const endpoint = join(userDataPath, 'runtime.sock')
+    const endpoint = runtimeEndpoint(userDataPath)
     const server = createServer((socket) => {
       let buffer = ''
       socket.setEncoding('utf8')
@@ -154,7 +160,7 @@ describe('RuntimeClient orchestration recovery identity', () => {
 
   it('keeps durable prompt retry when failure metadata proves the preflight runtime', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-current-prompt-'))
-    const endpoint = join(userDataPath, 'runtime.sock')
+    const endpoint = runtimeEndpoint(userDataPath)
     const server = createServer((socket) => {
       socket.once('data', (data) => {
         const request = JSON.parse(String(data).trim()) as { id: string }
@@ -201,7 +207,7 @@ describe('RuntimeClient orchestration recovery identity', () => {
 
   it('keeps the prompt retry ID when the attested runtime times out in transport', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-rt-timeout-'))
-    const endpoint = join(userDataPath, 'runtime.sock')
+    const endpoint = runtimeEndpoint(userDataPath)
     let receivedRequest: Record<string, unknown> | undefined
     const server = createServer((socket) => {
       socket.once('data', (data) => {
@@ -245,7 +251,7 @@ describe('RuntimeClient orchestration recovery identity', () => {
 
   it('blocks retry when a downgraded runtime rejects after capability preflight', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-downgraded-prompt-'))
-    const endpoint = join(userDataPath, 'runtime.sock')
+    const endpoint = runtimeEndpoint(userDataPath)
     let receivedRequest: Record<string, unknown> | undefined
     const server = createServer((socket) => {
       socket.once('data', (data) => {
@@ -292,7 +298,7 @@ describe('RuntimeClient orchestration recovery identity', () => {
 
   it('blocks retry when a downgraded runtime loses the prompt reply', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-lost-prompt-reply-'))
-    const endpoint = join(userDataPath, 'runtime.sock')
+    const endpoint = runtimeEndpoint(userDataPath)
     let receivedRequest: Record<string, unknown> | undefined
     const server = createServer((socket) => {
       socket.once('data', (data) => {
@@ -334,7 +340,7 @@ describe('RuntimeClient orchestration recovery identity', () => {
 
   it('reports an unknown legacy prompt outcome without advertising an unsafe retry', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-legacy-prompt-'))
-    const endpoint = join(userDataPath, 'runtime.sock')
+    const endpoint = runtimeEndpoint(userDataPath)
     let receivedRequest: Record<string, unknown> | undefined
     const server = createServer((socket) => {
       socket.once('data', (data) => {

--- a/src/main/agent-hooks/hook-script-outside-orca.test.ts
+++ b/src/main/agent-hooks/hook-script-outside-orca.test.ts
@@ -26,7 +26,7 @@ function runHook(dir: string, extraEnv: NodeJS.ProcessEnv = {}) {
   })
 }
 
-describe('managed hook outside an Orca terminal', () => {
+describe.skipIf(process.platform === 'win32')('managed hook outside an Orca terminal', () => {
   it('no Orca env at all: silent, exit 0, writes nothing', () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-outside-'))
     const res = runHook(dir)

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -40,6 +40,27 @@ import { wrapRuntimeHomeHookCommand } from './runtime-home-hook-command'
 let tmpDir: string
 let configPath: string
 
+function canCreateFileSymlinks(): boolean {
+  const probeDir = mkdtempSync(join(tmpdir(), 'orca-symlink-capability-'))
+  const targetPath = join(probeDir, 'target')
+  const linkPath = join(probeDir, 'link')
+  try {
+    writeFileSync(targetPath, '')
+    symlinkSync(targetPath, linkPath)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES')) {
+      return false
+    }
+    throw error
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true })
+  }
+}
+
+const symlinkIt = it.skipIf(!canCreateFileSymlinks())
+
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'orca-installer-utils-test-'))
   configPath = join(tmpDir, 'settings.json')
@@ -97,7 +118,7 @@ describe('readHooksJsonWithRaw', () => {
 })
 
 describe('writeHooksJson', () => {
-  it('updates a symlink target without replacing the hook config link', () => {
+  symlinkIt('updates a symlink target without replacing the hook config link', () => {
     const targetPath = join(tmpDir, 'dotfiles-hooks.json')
     writeFileSync(targetPath, '{"hooks":{}}\n')
     symlinkSync(targetPath, configPath)
@@ -110,7 +131,7 @@ describe('writeHooksJson', () => {
     })
   })
 
-  it('does not replace a dangling hook config symlink', () => {
+  symlinkIt('does not replace a dangling hook config symlink', () => {
     const targetPath = join(tmpDir, 'missing-dotfiles-hooks.json')
     symlinkSync(targetPath, configPath)
 
@@ -150,7 +171,7 @@ describe('writeHooksJson', () => {
     expect(bak).toEqual(original)
   })
 
-  it('does not follow an existing .bak symlink', () => {
+  symlinkIt('does not follow an existing .bak symlink', () => {
     const original = '{"hooks":{}}\n'
     const backupTarget = join(tmpDir, 'dotfiles-backup.json')
     writeFileSync(configPath, original, 'utf-8')

--- a/src/main/agent-hooks/spool.test.ts
+++ b/src/main/agent-hooks/spool.test.ts
@@ -219,35 +219,38 @@ describe('agent hook spool', () => {
     }
   })
 
-  it('spools when the endpoint is present but the receiver is unavailable', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'orca-spool-failure-'))
-    const endpointDir = join(dir, 'agent-hooks')
-    mkdirSync(endpointDir, { recursive: true })
-    const endpoint = join(endpointDir, 'endpoint.env')
-    writeFileSync(
-      endpoint,
-      'ORCA_AGENT_HOOK_PORT=9\nORCA_AGENT_HOOK_TOKEN=stale\nORCA_AGENT_HOOK_ENV=production\nORCA_AGENT_HOOK_VERSION=1\n'
-    )
-    const script = join(dir, 'codex-hook.sh')
-    writeFileSync(script, codexInternals.getManagedScript('posix'))
-    chmodSync(script, 0o755)
-    execFileSync('/bin/sh', [script], {
-      input: '{"hook_event_name":"SubagentStop","agent_id":"child"}\n',
-      env: {
-        ...process.env,
-        ORCA_AGENT_HOOK_ENDPOINT: endpoint,
-        ORCA_PANE_KEY: 'tab-failure:0',
-        ORCA_TAB_ID: 'tab-failure',
-        ORCA_AGENT_LAUNCH_TOKEN: 'generation-token'
-      },
-      timeout: 5000
-    })
-    const spoolFiles = readdirSync(join(endpointDir, 'spool'))
-    expect(spoolFiles).toHaveLength(1)
-    expect(readFileSync(join(endpointDir, 'spool', spoolFiles[0]!), 'utf8')).toContain(
-      'SubagentStop'
-    )
-  })
+  it.skipIf(process.platform === 'win32')(
+    'spools when the endpoint is present but the receiver is unavailable',
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), 'orca-spool-failure-'))
+      const endpointDir = join(dir, 'agent-hooks')
+      mkdirSync(endpointDir, { recursive: true })
+      const endpoint = join(endpointDir, 'endpoint.env')
+      writeFileSync(
+        endpoint,
+        'ORCA_AGENT_HOOK_PORT=9\nORCA_AGENT_HOOK_TOKEN=stale\nORCA_AGENT_HOOK_ENV=production\nORCA_AGENT_HOOK_VERSION=1\n'
+      )
+      const script = join(dir, 'codex-hook.sh')
+      writeFileSync(script, codexInternals.getManagedScript('posix'))
+      chmodSync(script, 0o755)
+      execFileSync('/bin/sh', [script], {
+        input: '{"hook_event_name":"SubagentStop","agent_id":"child"}\n',
+        env: {
+          ...process.env,
+          ORCA_AGENT_HOOK_ENDPOINT: endpoint,
+          ORCA_PANE_KEY: 'tab-failure:0',
+          ORCA_TAB_ID: 'tab-failure',
+          ORCA_AGENT_LAUNCH_TOKEN: 'generation-token'
+        },
+        timeout: 5000
+      })
+      const spoolFiles = readdirSync(join(endpointDir, 'spool'))
+      expect(spoolFiles).toHaveLength(1)
+      expect(readFileSync(join(endpointDir, 'spool', spoolFiles[0]!), 'utf8')).toContain(
+        'SubagentStop'
+      )
+    }
+  )
 
   it('does not mark a non-terminal downtime replay as runtime-observed', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-spool-observed-'))

--- a/src/main/agent-hooks/spool.test.ts
+++ b/src/main/agent-hooks/spool.test.ts
@@ -219,6 +219,8 @@ describe('agent hook spool', () => {
     }
   })
 
+  // Windows hook execution is covered by text assertions; this POSIX shell replay remains
+  // intentionally POSIX-only until a Windows .cmd spool smoke test exists.
   it.skipIf(process.platform === 'win32')(
     'spools when the endpoint is present but the receiver is unavailable',
     () => {

--- a/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
+++ b/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, readFileSync, readdirSync } from 'node:fs'
 import { rm as rmAsync } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type * as osModule from 'node:os'
 

--- a/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
+++ b/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
@@ -93,11 +93,11 @@ describe('Windows managed hook post interpreter', () => {
     rmSync(isolatedUserDataDir, {
       recursive: true,
       force: true,
-      maxRetries: 5,
-      retryDelay: 100
+      maxRetries: 20,
+      retryDelay: 250
     })
     homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
-    rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    rmSync(home, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 })
     home = ''
   })
 

--- a/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
+++ b/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
@@ -3,8 +3,8 @@
 // at once: a managed Windows .cmd hook posts through curl.exe and spawns no interpreter.
 // Generated under a mocked win32 platform, not executed, so the POSIX CI legs guard it too.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { mkdtempSync, readFileSync, readdirSync } from 'node:fs'
+import { rm as rmAsync } from 'node:fs/promises'
 import { join } from 'node:path'
 import type * as osModule from 'node:os'
 
@@ -84,20 +84,20 @@ describe('Windows managed hook post interpreter', () => {
     homedirMock.mockReturnValue(home)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     if (previousUserDataPath === undefined) {
       delete process.env.ORCA_USER_DATA_PATH
     } else {
       process.env.ORCA_USER_DATA_PATH = previousUserDataPath
     }
-    rmSync(isolatedUserDataDir, {
+    await rmAsync(isolatedUserDataDir, {
       recursive: true,
       force: true,
       maxRetries: 20,
       retryDelay: 250
     })
     homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
-    rmSync(home, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 })
+    await rmAsync(home, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 })
     home = ''
   })
 

--- a/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
+++ b/src/main/agent-hooks/windows-hook-post-interpreter.test.ts
@@ -90,9 +90,14 @@ describe('Windows managed hook post interpreter', () => {
     } else {
       process.env.ORCA_USER_DATA_PATH = previousUserDataPath
     }
-    rmSync(isolatedUserDataDir, { recursive: true, force: true })
+    rmSync(isolatedUserDataDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100
+    })
     homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
-    rmSync(home, { recursive: true, force: true })
+    rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
     home = ''
   })
 

--- a/src/main/codex-accounts/runtime-home-service-per-account-migration.test.ts
+++ b/src/main/codex-accounts/runtime-home-service-per-account-migration.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import type { GlobalSettings } from '../../shared/global-settings-types'
 import type { CodexManagedAccount } from '../../shared/managed-account-types'
 import type * as NodeOs from 'node:os'
+import type * as ShellStartupEnv from '../pty/shell-startup-env'
 import { readHookTrustEntries } from '../codex/config-toml-trust'
 
 const testState = { userData: '', home: '' }
@@ -18,6 +19,10 @@ vi.mock('node:os', async () => {
 
 beforeEach(() => {
   vi.resetModules()
+  vi.doMock('../pty/shell-startup-env', async () => ({
+    ...(await vi.importActual<typeof ShellStartupEnv>('../pty/shell-startup-env')),
+    isShellStartupEnvProbeSupported: () => true
+  }))
   testState.userData = mkdtempSync(join(tmpdir(), 'orca-codex-e-migration-'))
   testState.home = mkdtempSync(join(tmpdir(), 'orca-codex-e-home-'))
   for (const key of [
@@ -36,6 +41,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.doUnmock('../pty/shell-startup-env')
   rmSync(testState.userData, { recursive: true, force: true })
   rmSync(testState.home, { recursive: true, force: true })
   for (const [key, value] of Object.entries(previousEnv)) {

--- a/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
+++ b/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
@@ -57,6 +57,7 @@ describe('CodexRuntimeHomeService', () => {
   })
 
   afterEach(() => {
+    vi.doUnmock('../../shared/wsl-paths')
     teardownRuntimeHomeTest()
   })
 

--- a/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
+++ b/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
@@ -5,6 +5,7 @@ import type * as CodexConfigMirror from '../codex/codex-config-mirror'
 import type * as CodexHomePaths from '../codex/codex-home-paths'
 import type * as CodexPaneAccountRegistry from '../codex/codex-pane-account-registry'
 import type * as LegacyWslRuntimeAuthDrain from './legacy-wsl-runtime-auth-drain'
+import type * as WslCodexAuthBatchReader from './wsl-codex-auth-batch-reader'
 import type * as WslPaths from '../../shared/wsl-paths'
 import { createSettings } from './runtime-home-settings-test-fixtures'
 import {

--- a/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
+++ b/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
@@ -5,7 +5,7 @@ import type * as CodexConfigMirror from '../codex/codex-config-mirror'
 import type * as CodexHomePaths from '../codex/codex-home-paths'
 import type * as CodexPaneAccountRegistry from '../codex/codex-pane-account-registry'
 import type * as LegacyWslRuntimeAuthDrain from './legacy-wsl-runtime-auth-drain'
-import type * as WslCodexAuthBatchReader from './wsl-codex-auth-batch-reader'
+import type * as WslPaths from '../../shared/wsl-paths'
 import { createSettings } from './runtime-home-settings-test-fixtures'
 import {
   createCodexAuthJson,
@@ -31,6 +31,26 @@ vi.mock('node:os', async () => {
   }
 })
 
+function mockLocalWslPathBridge(wslHome: string): void {
+  vi.doMock('../../shared/wsl-paths', async (importOriginal) => {
+    const actual = await importOriginal<typeof WslPaths>()
+    return {
+      ...actual,
+      toWindowsWslUncPath: (linuxPath: string) => {
+        const normalized = linuxPath.replaceAll('\\', '/')
+        const accountMatch = normalized.match(/\/codex-accounts\/([^/]+)\/home$/)
+        if (accountMatch) {
+          return join(testState.userDataDir, 'codex-accounts', accountMatch[1], 'home')
+        }
+        if (normalized.endsWith('/.codex')) {
+          return join(wslHome, '.codex')
+        }
+        return join(wslHome, ...normalized.split('/').filter(Boolean))
+      }
+    }
+  })
+}
+
 describe('CodexRuntimeHomeService', () => {
   beforeEach(() => {
     setupRuntimeHomeTest()
@@ -48,6 +68,7 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
+    mockLocalWslPathBridge(wslHome)
     const runtimeAuthPath = join(testState.fakeHomeDir, '.codex', 'auth.json')
     writeFileSync(runtimeAuthPath, '{"account":"host-system"}\n', 'utf-8')
     const wslManagedHomePath = createManagedAuth(
@@ -118,6 +139,7 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
+    mockLocalWslPathBridge(wslHome)
     const systemAuth = createCodexAuthJson('system@example.com', 'acct-system', 'system-token')
     const managedHomePath = createManagedAuth(
       testState.userDataDir,
@@ -184,6 +206,7 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
+    mockLocalWslPathBridge(wslHome)
     const systemCodexHomePath = join(wslHome, '.codex')
     mkdirSync(systemCodexHomePath, { recursive: true })
     writeFileSync(
@@ -242,6 +265,7 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
+    mockLocalWslPathBridge(wslHome)
     const firstAuth = createCodexAuthJson('first@example.com', 'acct-first', 'first-token')
     const secondAuth = createCodexAuthJson('second@example.com', 'acct-second', 'second-token')
     const firstManagedHomePath = createManagedAuth(testState.userDataDir, 'account-1', firstAuth)
@@ -322,6 +346,7 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
+    mockLocalWslPathBridge(wslHome)
     let finishDrain: (() => void) | undefined
     const startLegacyWslRuntimeAuthDrain = vi.fn(
       (_options: unknown, _startOptions?: { throwOnFailure?: boolean }) =>
@@ -440,6 +465,7 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
+    mockLocalWslPathBridge(wslHome)
     const wslManagedAuth = createCodexAuthJson(
       'wsl@example.com',
       'acct-wsl',

--- a/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
+++ b/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
@@ -49,6 +49,12 @@ function mockLocalWslPathBridge(wslHome: string): void {
       }
     }
   })
+  vi.doMock('../codex/wsl-codex-session-bridge', () => ({
+    startWslCodexSessionBridgeInBackground: vi.fn(() => Promise.resolve())
+  }))
+  vi.doMock('./legacy-wsl-runtime-auth-drain', () => ({
+    startLegacyWslRuntimeAuthDrain: vi.fn(() => Promise.resolve())
+  }))
 }
 
 describe('CodexRuntimeHomeService', () => {

--- a/src/main/codex-accounts/service-wsl-accounts.test.ts
+++ b/src/main/codex-accounts/service-wsl-accounts.test.ts
@@ -75,6 +75,10 @@ describe('CodexAccountService config sync', () => {
         return null
       }
     }))
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(() => `${wslLinuxHomePath}\n`),
+      spawn: vi.fn()
+    }))
     vi.doMock('../wsl', () => ({
       toWindowsWslPath: (linuxPath: string) =>
         linuxPath === wslLinuxCanonicalHomePath ||

--- a/src/main/codex/codex-app-server-connection.test.ts
+++ b/src/main/codex/codex-app-server-connection.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { PassThrough } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type * as CodexAppServerProcessTeardownModule from './codex-app-server-process-teardown'
+import type { spawnProcess } from '../../shared/child-process/run-process'
 import {
   isCodexAppServerRequestError,
   openCodexAppServerConnection,

--- a/src/main/codex/codex-app-server-connection.test.ts
+++ b/src/main/codex/codex-app-server-connection.test.ts
@@ -3,7 +3,7 @@ import { realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { PassThrough } from 'node:stream'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { spawnProcess } from '../../shared/child-process/run-process'
+import type * as CodexAppServerProcessTeardownModule from './codex-app-server-process-teardown'
 import {
   isCodexAppServerRequestError,
   openCodexAppServerConnection,
@@ -11,6 +11,24 @@ import {
   type CodexAppServerConnectionHandlers
 } from './codex-app-server-connection'
 import { isCodexAppServerUnsupportedError } from './codex-app-server-session'
+
+// The connection tests use synthetic children; do not invoke the real Windows taskkill command
+// for their fake PID. The process-tree implementation has its own platform-specific tests.
+vi.mock('./codex-app-server-process-teardown', async (importOriginal) => {
+  const actual = await importOriginal<typeof CodexAppServerProcessTeardownModule>()
+  if (process.platform !== 'win32') {
+    return actual
+  }
+  return {
+    ...actual,
+    terminateCodexAppServerProcessTree: async (
+      child: Parameters<typeof actual.terminateCodexAppServerProcessTree>[0]
+    ) => {
+      child.kill('SIGKILL')
+      return true
+    }
+  }
+})
 
 const originalCodexHome = process.env.CODEX_HOME
 
@@ -428,7 +446,9 @@ describe('openCodexAppServerConnection', () => {
     await vi.advanceTimersByTimeAsync(4_100)
 
     await expect(Promise.all([first, second])).resolves.toEqual([true, true])
-    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual(['SIGSTOP', 'SIGKILL'])
+    expect(child.kill.mock.calls.map(([signal]) => signal)).toEqual(
+      process.platform === 'win32' ? ['SIGKILL'] : ['SIGSTOP', 'SIGKILL']
+    )
   })
 
   it('allows a later close to observe exit after an unproven attempt', async () => {

--- a/src/main/daemon/daemon-endpoint-reachability-test-harness.ts
+++ b/src/main/daemon/daemon-endpoint-reachability-test-harness.ts
@@ -4,12 +4,25 @@
 import { probeSocketConnect } from './daemon-endpoint-probe'
 
 const ENDPOINT_UNREACHABLE_TIMEOUT_MS = 2_000
+const ENDPOINT_REACHABLE_TIMEOUT_MS = 2_000
 const ENDPOINT_POLL_MS = 20
 
 /**
  * Why reuse the production probe: it is the same classifier the daemon publishes against, so a
  * test cannot drift from what the daemon itself treats as a reachable endpoint.
  */
+export async function waitForEndpointReachable(socketPath: string): Promise<void> {
+  const deadline = Date.now() + ENDPOINT_REACHABLE_TIMEOUT_MS
+  while ((await probeSocketConnect(socketPath)) !== 'connected') {
+    if (Date.now() >= deadline) {
+      throw new Error(`Endpoint did not become reachable: ${socketPath}`)
+    }
+    const delay = Promise.withResolvers<void>()
+    setTimeout(delay.resolve, ENDPOINT_POLL_MS)
+    await delay.promise
+  }
+}
+
 export async function waitForEndpointUnreachable(socketPath: string): Promise<boolean> {
   const deadline = Date.now() + ENDPOINT_UNREACHABLE_TIMEOUT_MS
   while ((await probeSocketConnect(socketPath)) === 'connected') {

--- a/src/main/daemon/daemon-pty-adapter-daemon-recovery.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-daemon-recovery.test.ts
@@ -7,6 +7,7 @@ import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { DaemonServer } from './daemon-server'
 import type { DaemonFileLog } from './daemon-file-log'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
+import { waitForEndpointReachable } from './daemon-endpoint-reachability-test-harness'
 import {
   createMockSubprocess,
   startDaemonAdapterHarness,
@@ -89,7 +90,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
   })
 
   describe('dead-endpoint write respawn (STA-2373)', () => {
-    function restartServerOnRespawn(): void {
+    async function restartServerOnRespawn(): Promise<void> {
       server = new DaemonServer({
         socketPath,
         tokenPath,
@@ -99,6 +100,10 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           return lastSubprocess
         }
       })
+      await server.start()
+      if (process.platform === 'win32') {
+        await waitForEndpointReachable(socketPath)
+      }
     }
 
     it('rejects stale input until createOrAttach remounts the pane onto the new daemon', async () => {
@@ -237,8 +242,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         await new Promise<void>((resolve) => {
           releaseRespawn = resolve
         })
-        restartServerOnRespawn()
-        await server.start()
+        await restartServerOnRespawn()
       })
       const healingAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
       try {
@@ -265,8 +269,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
     it('does not respawn when a dropped write targets no active session', async () => {
       const respawn = vi.fn(async () => {
-        restartServerOnRespawn()
-        await server.start()
+        await restartServerOnRespawn()
       })
       const idleAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
       try {
@@ -336,8 +339,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
     it('re-arms recovery for a second daemon death when a background session never rebinds', async () => {
       const respawn = vi.fn(async () => {
-        restartServerOnRespawn()
-        await server.start()
+        await restartServerOnRespawn()
       })
       const healingAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn })
       const recovered: string[] = []

--- a/src/main/git/repo-detection.test.ts
+++ b/src/main/git/repo-detection.test.ts
@@ -80,7 +80,7 @@ describe('isGitRepo', () => {
     git(realRepo, ['init', '--quiet'])
 
     withGitUnavailable(() => {
-      expect(getGitRepoRoot(nestedDir)).toBe(realRepo)
+      expect(getGitRepoRoot(nestedDir)).toBe(realRepo.replace(/\\/g, '/'))
     })
   })
 
@@ -330,7 +330,7 @@ describe('isGitRepo', () => {
     const bareRepo = path.join(tmpDir, 'bare.git')
     git(tmpDir, ['init', '--bare', '--quiet', bareRepo])
 
-    expect(getGitRepoRoot(bareRepo)).toBe(bareRepo)
+    expect(getGitRepoRoot(bareRepo)).toBe(bareRepo.replace(/\\/g, '/'))
   })
 })
 

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -50,7 +50,7 @@ function createMockChildProcess(pid: number): MockChildProcess {
  * Spawn stand-in for the gh/glab deadline tests: the CLI hangs, while the `ps`
  * quiescence probe the tree termination runs answers immediately.
  */
-function mockWedgedCliSpawn(child: MockChildProcess): void {
+function mockWedgedCliSpawn(child: MockChildProcess) {
   spawnMock.mockImplementation((program: string) => {
     if (program !== 'ps') {
       return child
@@ -59,6 +59,7 @@ function mockWedgedCliSpawn(child: MockChildProcess): void {
     queueMicrotask(() => probe.emit('close', 0, null))
     return probe
   })
+  return mockProcessGroupSignals()
 }
 
 /** Signals succeed; the existence probe reports the group already gone. */
@@ -303,7 +304,7 @@ describe('runner execFile timeout handling', () => {
     'signals the whole gh process group when gh never calls back',
     async () => {
       const child = createMockChildProcess(1234)
-      mockWedgedCliSpawn(child)
+      const processKill = mockWedgedCliSpawn(child)
       try {
         const promise = ghExecFileAsync(['api', 'repos/stablyai/orca/issues/5388'], {
           cwd: '/repo'
@@ -325,7 +326,7 @@ describe('runner execFile timeout handling', () => {
     'signals the whole glab process group when glab never calls back',
     async () => {
       const child = createMockChildProcess(1234)
-      mockWedgedCliSpawn(child)
+      const processKill = mockWedgedCliSpawn(child)
       try {
         const promise = glabExecFileAsync(['api', 'projects/stablyai%2Forca/issues'], {
           cwd: '/repo'
@@ -373,8 +374,7 @@ describe('runner execFile timeout handling', () => {
     'kills an active gh execution when its caller aborts',
     async () => {
       const child = createMockChildProcess(1234)
-      mockWedgedCliSpawn(child)
-      const processKill = mockProcessGroupSignals()
+      const processKill = mockWedgedCliSpawn(child)
       try {
         const controller = new AbortController()
         const promise = ghExecFileAsync(['api', 'repos/stablyai/orca/issues/5388'], {
@@ -396,9 +396,7 @@ describe('runner execFile timeout handling', () => {
   )
 
   it.skipIf(process.platform === 'win32')('honors explicit gh timeouts', async () => {
-    const child = createMockChildProcess(1234)
-    mockWedgedCliSpawn(child)
-    const processKill = mockProcessGroupSignals()
+    const processKill = mockWedgedCliSpawn(createMockChildProcess(1234))
     try {
       const promise = ghExecFileAsync(['api', 'repos/stablyai/orca/issues/5388'], {
         cwd: '/repo',

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -299,44 +299,48 @@ describe('runner execFile timeout handling', () => {
   // Why the group and not the child (#18234): `gh` and `glab` on PATH are often
   // shims, so the deadline has a chain to reap. Signalling only the direct child
   // leaves the rest of it running under init long after the deadline passed.
-  it('signals the whole gh process group when gh never calls back', async () => {
-    const child = createMockChildProcess(1234)
-    mockWedgedCliSpawn(child)
-    const processKill = mockProcessGroupSignals()
-    try {
-      const promise = ghExecFileAsync(['api', 'repos/stablyai/orca/issues/5388'], {
-        cwd: '/repo'
-      })
-      const rejection = expect(promise).rejects.toThrow('gh timed out.')
-      await vi.advanceTimersByTimeAsync(30_000)
-      expect(spawnMock.mock.calls[0][2].detached).toBe(true)
-      await vi.advanceTimersByTimeAsync(2_000)
+  it.skipIf(process.platform === 'win32')(
+    'signals the whole gh process group when gh never calls back',
+    async () => {
+      const child = createMockChildProcess(1234)
+      mockWedgedCliSpawn(child)
+      try {
+        const promise = ghExecFileAsync(['api', 'repos/stablyai/orca/issues/5388'], {
+          cwd: '/repo'
+        })
+        const rejection = expect(promise).rejects.toThrow('gh timed out.')
+        await vi.advanceTimersByTimeAsync(30_000)
+        expect(spawnMock.mock.calls[0][2].detached).toBe(true)
+        await vi.advanceTimersByTimeAsync(2_000)
 
-      await rejection
-      expect(processKill).toHaveBeenCalledWith(-1234, undefined)
-    } finally {
-      processKill.mockRestore()
+        await rejection
+        expect(processKill).toHaveBeenCalledWith(-1234, undefined)
+      } finally {
+        processKill.mockRestore()
+      }
     }
-  })
+  )
 
-  it('signals the whole glab process group when glab never calls back', async () => {
-    const child = createMockChildProcess(1234)
-    mockWedgedCliSpawn(child)
-    const processKill = mockProcessGroupSignals()
-    try {
-      const promise = glabExecFileAsync(['api', 'projects/stablyai%2Forca/issues'], {
-        cwd: '/repo'
-      })
-      const rejection = expect(promise).rejects.toThrow('glab timed out.')
-      await vi.advanceTimersByTimeAsync(30_000)
-      await vi.advanceTimersByTimeAsync(2_000)
+  it.skipIf(process.platform === 'win32')(
+    'signals the whole glab process group when glab never calls back',
+    async () => {
+      const child = createMockChildProcess(1234)
+      mockWedgedCliSpawn(child)
+      try {
+        const promise = glabExecFileAsync(['api', 'projects/stablyai%2Forca/issues'], {
+          cwd: '/repo'
+        })
+        const rejection = expect(promise).rejects.toThrow('glab timed out.')
+        await vi.advanceTimersByTimeAsync(30_000)
+        await vi.advanceTimersByTimeAsync(2_000)
 
-      await rejection
-      expect(processKill).toHaveBeenCalledWith(-1234, undefined)
-    } finally {
-      processKill.mockRestore()
+        await rejection
+        expect(processKill).toHaveBeenCalledWith(-1234, undefined)
+      } finally {
+        processKill.mockRestore()
+      }
     }
-  })
+  )
 
   it('aborts glab retry backoff instead of starting another attempt', async () => {
     const controller = new AbortController()

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -369,30 +369,33 @@ describe('runner execFile timeout handling', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1)
   })
 
-  it('kills an active gh execution when its caller aborts', async () => {
-    const child = createMockChildProcess(1234)
-    mockWedgedCliSpawn(child)
-    const processKill = mockProcessGroupSignals()
-    try {
-      const controller = new AbortController()
-      const promise = ghExecFileAsync(['api', 'repos/stablyai/orca/issues/5388'], {
-        cwd: '/repo',
-        signal: controller.signal
-      })
-      const rejection = expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+  it.skipIf(process.platform === 'win32')(
+    'kills an active gh execution when its caller aborts',
+    async () => {
+      const child = createMockChildProcess(1234)
+      mockWedgedCliSpawn(child)
+      const processKill = mockProcessGroupSignals()
+      try {
+        const controller = new AbortController()
+        const promise = ghExecFileAsync(['api', 'repos/stablyai/orca/issues/5388'], {
+          cwd: '/repo',
+          signal: controller.signal
+        })
+        const rejection = expect(promise).rejects.toMatchObject({ name: 'AbortError' })
 
-      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
-      controller.abort()
-      await vi.advanceTimersByTimeAsync(2_000)
+        await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+        controller.abort()
+        await vi.advanceTimersByTimeAsync(2_000)
 
-      await rejection
-      expect(processKill).toHaveBeenCalledWith(-1234, undefined)
-    } finally {
-      processKill.mockRestore()
+        await rejection
+        expect(processKill).toHaveBeenCalledWith(-1234, undefined)
+      } finally {
+        processKill.mockRestore()
+      }
     }
-  })
+  )
 
-  it('honors explicit gh timeouts', async () => {
+  it.skipIf(process.platform === 'win32')('honors explicit gh timeouts', async () => {
     const child = createMockChildProcess(1234)
     mockWedgedCliSpawn(child)
     const processKill = mockProcessGroupSignals()

--- a/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as path from 'node:path'
 import type * as ParcelWatcherProcess from './parcel-watcher-process'
 
 const { handleMock } = vi.hoisted(() => ({
@@ -601,8 +602,14 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     replacementCallback(null, [{ type: 'update', path: '/tmp/repo/retry.txt' }] as never)
     await vi.waitFor(() =>
       expect(replacementSender.send).toHaveBeenCalledWith('fs:changed', {
-        worktreePath: '/tmp/repo',
-        events: [{ kind: 'update', absolutePath: '/tmp/repo/retry.txt', isDirectory: true }]
+        worktreePath: path.resolve('/tmp/repo'),
+        events: [
+          {
+            kind: 'update',
+            absolutePath: path.resolve('/tmp/repo/retry.txt'),
+            isDirectory: true
+          }
+        ]
       })
     )
   })

--- a/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
@@ -2,9 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as path from 'node:path'
 import type * as ParcelWatcherProcess from './parcel-watcher-process'
 
-const { handleMock } = vi.hoisted(() => ({
-  handleMock: vi.fn()
-}))
+const { handleMock, subscribeParcelWatcherMock, subscribeViaWatcherProcessMock } = vi.hoisted(
+  () => ({
+    handleMock: vi.fn(),
+    subscribeParcelWatcherMock: vi.fn(),
+    subscribeViaWatcherProcessMock: vi.fn()
+  })
+)
 
 vi.mock('electron', () => ({
   ipcMain: {
@@ -17,7 +21,7 @@ vi.mock('fs/promises', () => ({
 }))
 
 vi.mock('@parcel/watcher', () => ({
-  subscribe: vi.fn()
+  subscribe: subscribeParcelWatcherMock
 }))
 
 vi.mock('./filesystem-watcher-wsl', () => ({
@@ -28,7 +32,7 @@ vi.mock('./parcel-watcher-process', async (importOriginal) => {
   const actual = await importOriginal<typeof ParcelWatcherProcess>()
   return {
     ...actual,
-    subscribeViaWatcherProcess: vi.fn(actual.subscribeViaWatcherProcess)
+    subscribeViaWatcherProcess: subscribeViaWatcherProcessMock
   }
 })
 
@@ -47,6 +51,8 @@ import { stat } from 'node:fs/promises'
 import { subscribe as subscribeParcelWatcher } from '@parcel/watcher'
 import { subscribeViaWatcherProcess } from './parcel-watcher-process'
 import { WatcherProcessFailure } from './parcel-watcher-process-failure'
+const WORKTREE_PATH = path.resolve('/tmp', 'repo')
+const OTHER_WORKTREE_PATH = path.resolve('/tmp', 'other')
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => unknown>
 
@@ -57,7 +63,11 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     handleMock.mockReset()
     vi.mocked(stat).mockReset()
     vi.mocked(subscribeParcelWatcher).mockReset()
-    vi.mocked(subscribeViaWatcherProcess).mockClear()
+    vi.mocked(subscribeViaWatcherProcess).mockReset()
+    vi.mocked(subscribeViaWatcherProcess).mockImplementation(
+      (dir, callback, opts) =>
+        vi.mocked(subscribeParcelWatcher)(dir, callback as never, opts as never) as never
+    )
     for (const key of Object.keys(handlers)) {
       delete handlers[key]
     }
@@ -94,7 +104,7 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       id: 1
     }
 
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
     destroyedCallbacks[0]()
 
     let shutdownResolved = false
@@ -127,7 +137,7 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     })
     const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
 
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
     watcherCallback(new Error('root disappeared'), [])
 
     let shutdownResolved = false
@@ -168,7 +178,7 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
 
     const watchPromise = handlers['fs:watchWorktree'](
       { sender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
     await vi.waitFor(() => {
       expect(subscribeParcelWatcher).toHaveBeenCalled()
@@ -213,14 +223,14 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
 
     const watchOne = handlers['fs:watchWorktree'](
       { sender: senderOne },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
     await vi.waitFor(() => {
       expect(statResolvers).toHaveLength(1)
     })
     const watchTwo = handlers['fs:watchWorktree'](
       { sender: senderTwo },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
 
     try {
@@ -256,12 +266,12 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       id: 1
     }
 
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
 
     vi.useFakeTimers()
     try {
-      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: '/tmp/repo' })
-      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: '/tmp/repo' })
+      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: WORKTREE_PATH })
+      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: WORKTREE_PATH })
 
       expect(vi.getTimerCount()).toBe(1)
       await vi.advanceTimersByTimeAsync(30_000)
@@ -282,8 +292,8 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       id: 1
     }
 
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
-    await closeLocalWatcherForWorktreePath('/tmp/repo')
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
+    await closeLocalWatcherForWorktreePath(WORKTREE_PATH)
 
     expect(unsubscribeMock).toHaveBeenCalledTimes(1)
   })
@@ -352,9 +362,9 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     vi.mocked(subscribeParcelWatcher).mockResolvedValue({ unsubscribe: unsubscribeMock } as never)
     const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
 
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
 
-    await expect(closeLocalWatcherForWorktreePath('/tmp/repo')).rejects.toBe(terminationError)
+    await expect(closeLocalWatcherForWorktreePath(WORKTREE_PATH)).rejects.toBe(terminationError)
     expect(unsubscribeMock).toHaveBeenCalledTimes(1)
   })
 
@@ -380,13 +390,13 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       }),
       id: 1
     }
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
     destroyedCallbacks[0]()
     await vi.waitFor(() => expect(unsubscribeMock).toHaveBeenCalledTimes(1))
 
     let settled = false
     const closeFailure = expect(
-      closeLocalWatcherForWorktreePath('/tmp/repo').finally(() => {
+      closeLocalWatcherForWorktreePath(WORKTREE_PATH).finally(() => {
         settled = true
       })
     ).rejects.toBe(terminationError)
@@ -421,14 +431,14 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       }),
       id: 1
     }
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
     destroyedCallbacks[0]()
     await vi.waitFor(() => expect(unsubscribeMock).toHaveBeenCalledTimes(1))
 
-    await expect(closeLocalWatcherForWorktreePath('/tmp/repo')).rejects.toBe(terminationError)
+    await expect(closeLocalWatcherForWorktreePath(WORKTREE_PATH)).rejects.toBe(terminationError)
     signalPhysicalExit()
     await Promise.resolve()
-    await expect(closeLocalWatcherForWorktreePath('/tmp/repo')).resolves.toBeUndefined()
+    await expect(closeLocalWatcherForWorktreePath(WORKTREE_PATH)).resolves.toBeUndefined()
   })
 
   it('retains callback terminal failure when the cleared subscription later unsubscribes cleanly', async () => {
@@ -450,15 +460,15 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       return { unsubscribe }
     })
     const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
 
     watcherCallback(terminationError, [])
     await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledTimes(1))
 
-    await expect(closeLocalWatcherForWorktreePath('/tmp/repo')).rejects.toBe(terminationError)
+    await expect(closeLocalWatcherForWorktreePath(WORKTREE_PATH)).rejects.toBe(terminationError)
     signalPhysicalExit()
     await physicalExit
-    await expect(closeLocalWatcherForWorktreePath('/tmp/repo')).resolves.toBeUndefined()
+    await expect(closeLocalWatcherForWorktreePath(WORKTREE_PATH)).resolves.toBeUndefined()
   })
 
   it('propagates terminal child failure while deletion cancels an active crawl', async () => {
@@ -482,18 +492,18 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
     const watchPromise = handlers['fs:watchWorktree'](
       { sender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
     const watchFailure = expect(watchPromise).rejects.toBe(terminationError)
     await vi.waitFor(() => expect(subscribeViaWatcherProcess).toHaveBeenCalledTimes(1))
 
-    await expect(closeLocalWatcherForWorktreePath('/tmp/repo')).rejects.toBe(terminationError)
+    await expect(closeLocalWatcherForWorktreePath(WORKTREE_PATH)).rejects.toBe(terminationError)
     await watchFailure
-    await expect(closeLocalWatcherForWorktreePath('/tmp/repo')).rejects.toBe(terminationError)
+    await expect(closeLocalWatcherForWorktreePath(WORKTREE_PATH)).rejects.toBe(terminationError)
 
     signalPhysicalExit()
     await physicalExit
-    await expect(closeLocalWatcherForWorktreePath('/tmp/repo')).resolves.toBeUndefined()
+    await expect(closeLocalWatcherForWorktreePath(WORKTREE_PATH)).resolves.toBeUndefined()
   })
 
   it('closes a pending grace-teardown watcher immediately for worktree deletion', async () => {
@@ -507,14 +517,14 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       id: 1
     }
 
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
 
     vi.useFakeTimers()
     try {
-      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: '/tmp/repo' })
+      handlers['fs:unwatchWorktree']({ sender: { id: 1 } }, { worktreePath: WORKTREE_PATH })
 
       expect(vi.getTimerCount()).toBe(1)
-      await closeLocalWatcherForWorktreePath('/tmp/repo')
+      await closeLocalWatcherForWorktreePath(WORKTREE_PATH)
 
       expect(unsubscribeMock).toHaveBeenCalledTimes(1)
       expect(vi.getTimerCount()).toBe(0)
@@ -542,7 +552,7 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
 
     const watchPromise = handlers['fs:watchWorktree'](
       { sender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
     await vi.waitFor(() => {
       expect(subscribeParcelWatcher).toHaveBeenCalled()
@@ -550,7 +560,7 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
 
     const unwatchPromise = handlers['fs:unwatchWorktree'](
       { sender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
     // Why: unwatch must abort the in-flight install so watchWorktree settles
     // without waiting for the native subscribe crawl to finish.
@@ -587,26 +597,28 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
 
     const firstWatch = handlers['fs:watchWorktree'](
       { sender: firstSender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
     await vi.waitFor(() => expect(subscribeViaWatcherProcess).toHaveBeenCalledTimes(1))
 
-    handlers['fs:unwatchWorktree']({ sender: firstSender }, { worktreePath: '/tmp/repo' })
+    handlers['fs:unwatchWorktree']({ sender: firstSender }, { worktreePath: WORKTREE_PATH })
     const replacementWatch = handlers['fs:watchWorktree'](
       { sender: replacementSender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
 
     await Promise.all([firstWatch, replacementWatch])
     expect(subscribeViaWatcherProcess).toHaveBeenCalledTimes(2)
-    replacementCallback(null, [{ type: 'update', path: '/tmp/repo/retry.txt' }] as never)
+    replacementCallback(null, [
+      { type: 'update', path: path.join(WORKTREE_PATH, 'retry.txt') }
+    ] as never)
     await vi.waitFor(() =>
       expect(replacementSender.send).toHaveBeenCalledWith('fs:changed', {
-        worktreePath: path.resolve('/tmp/repo'),
+        worktreePath: path.resolve(WORKTREE_PATH),
         events: [
           {
             kind: 'update',
-            absolutePath: path.resolve('/tmp/repo/retry.txt'),
+            absolutePath: path.resolve(path.join(WORKTREE_PATH, 'retry.txt')),
             isDirectory: true
           }
         ]
@@ -641,33 +653,33 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     const reopenSender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 3 }
     const first = handlers['fs:watchWorktree'](
       { sender: firstSender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
 
     await vi.waitFor(() => expect(subscribeViaWatcherProcess).toHaveBeenCalledTimes(1))
-    handlers['fs:unwatchWorktree']({ sender: firstSender }, { worktreePath: '/tmp/repo' })
-    expect(installs.get('/tmp/repo')?.signal?.aborted).toBe(true)
+    handlers['fs:unwatchWorktree']({ sender: firstSender }, { worktreePath: WORKTREE_PATH })
+    expect(installs.get(WORKTREE_PATH)?.signal?.aborted).toBe(true)
 
     const joiner = handlers['fs:watchWorktree'](
       { sender: joinerSender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
     await closeAllWatchers()
     const reopen = handlers['fs:watchWorktree'](
       { sender: reopenSender },
-      { worktreePath: '/tmp/other' }
+      { worktreePath: OTHER_WORKTREE_PATH }
     ) as Promise<unknown>
     await vi.waitFor(() => expect(subscribeViaWatcherProcess).toHaveBeenCalledTimes(2))
 
-    installs.get('/tmp/repo')?.resolve({ unsubscribe: lateUnsubscribe })
-    installs.get('/tmp/other')?.resolve({ unsubscribe: vi.fn() })
+    installs.get(WORKTREE_PATH)?.resolve({ unsubscribe: lateUnsubscribe })
+    installs.get(OTHER_WORKTREE_PATH)?.resolve({ unsubscribe: vi.fn() })
     await Promise.all([first, joiner, reopen])
 
     expect(subscribeViaWatcherProcess).toHaveBeenCalledTimes(2)
     expect(
       vi
         .mocked(subscribeViaWatcherProcess)
-        .mock.calls.filter(([rootPath]) => rootPath.endsWith('/tmp/repo'))
+        .mock.calls.filter(([rootPath]) => rootPath.endsWith(WORKTREE_PATH))
     ).toHaveLength(1)
     await vi.waitFor(() => expect(lateUnsubscribe).toHaveBeenCalledTimes(1))
   })
@@ -691,12 +703,12 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
 
     const watchPromise = handlers['fs:watchWorktree'](
       { sender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
     await vi.waitFor(() => {
       expect(subscribeParcelWatcher).toHaveBeenCalled()
     })
-    const closePromise = closeLocalWatcherForWorktreePath('/tmp/repo')
+    const closePromise = closeLocalWatcherForWorktreePath(WORKTREE_PATH)
     const closedBeforeNativeSubscribe = await Promise.race([
       closePromise.then(() => true),
       new Promise<false>((resolve) => setTimeout(() => resolve(false), 0))
@@ -722,15 +734,15 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       id: 1
     }
 
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
-    await closeLocalWatcherForWorktreePath('/tmp/repo')
-    await restoreLocalWatcherAfterFailedRemoval('/tmp/repo')
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
+    await closeLocalWatcherForWorktreePath(WORKTREE_PATH)
+    await restoreLocalWatcherAfterFailedRemoval(WORKTREE_PATH)
 
     expect(firstUnsubscribe).toHaveBeenCalledTimes(1)
     expect(subscribeParcelWatcher).toHaveBeenCalledTimes(2)
     expect(sender.send).toHaveBeenCalledWith('fs:changed', {
-      worktreePath: '/tmp/repo',
-      events: [{ kind: 'overflow', absolutePath: '/tmp/repo' }]
+      worktreePath: WORKTREE_PATH,
+      events: [{ kind: 'overflow', absolutePath: WORKTREE_PATH }]
     })
   })
 
@@ -740,10 +752,10 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     vi.mocked(subscribeParcelWatcher).mockResolvedValue({ unsubscribe: firstUnsubscribe } as never)
     const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
 
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
-    await closeLocalWatcherForWorktreePath('/tmp/repo')
-    handlers['fs:unwatchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
-    await restoreLocalWatcherAfterFailedRemoval('/tmp/repo')
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
+    await closeLocalWatcherForWorktreePath(WORKTREE_PATH)
+    handlers['fs:unwatchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
+    await restoreLocalWatcherAfterFailedRemoval(WORKTREE_PATH)
 
     expect(firstUnsubscribe).toHaveBeenCalledTimes(1)
     expect(subscribeParcelWatcher).toHaveBeenCalledTimes(1)
@@ -766,10 +778,10 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
       id: 1
     }
 
-    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/tmp/repo' })
-    await closeLocalWatcherForWorktreePath('/tmp/repo')
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: WORKTREE_PATH })
+    await closeLocalWatcherForWorktreePath(WORKTREE_PATH)
     destroyedCallbacks[0]?.()
-    await restoreLocalWatcherAfterFailedRemoval('/tmp/repo')
+    await restoreLocalWatcherAfterFailedRemoval(WORKTREE_PATH)
 
     expect(firstUnsubscribe).toHaveBeenCalledTimes(1)
     expect(subscribeParcelWatcher).toHaveBeenCalledTimes(1)
@@ -795,7 +807,7 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
 
     const watchPromise = handlers['fs:watchWorktree'](
       { sender },
-      { worktreePath: '/tmp/repo' }
+      { worktreePath: WORKTREE_PATH }
     ) as Promise<unknown>
     await vi.waitFor(() => {
       expect(subscribeParcelWatcher).toHaveBeenCalled()

--- a/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
@@ -65,8 +65,33 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     vi.mocked(subscribeParcelWatcher).mockReset()
     vi.mocked(subscribeViaWatcherProcess).mockReset()
     vi.mocked(subscribeViaWatcherProcess).mockImplementation(
-      (dir, callback, opts) =>
-        vi.mocked(subscribeParcelWatcher)(dir, callback as never, opts as never) as never
+      (dir, callback, opts, hooks) =>
+        new Promise((resolve, reject) => {
+          let aborted = false
+          const onAbort = () => {
+            aborted = true
+            reject(new Error('subscribe aborted'))
+          }
+          hooks?.signal?.addEventListener('abort', onAbort, { once: true })
+          Promise.resolve(
+            vi.mocked(subscribeParcelWatcher)(dir, callback as never, opts as never)
+          ).then(
+            (subscription) => {
+              hooks?.signal?.removeEventListener('abort', onAbort)
+              if (aborted) {
+                void subscription?.unsubscribe?.()
+                return
+              }
+              resolve(subscription as never)
+            },
+            (error) => {
+              hooks?.signal?.removeEventListener('abort', onAbort)
+              if (!aborted) {
+                reject(error)
+              }
+            }
+          )
+        }) as never
     )
     for (const key of Object.keys(handlers)) {
       delete handlers[key]

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { join, sep } from 'node:path'
+import { join, posix as pathPosix } from 'node:path'
 import type { GlobalSettings } from '../../shared/global-settings-types'
 import type { Repo } from '../../shared/repo-types'
 import type {
@@ -63,7 +63,7 @@ type PollerCallback = (events: WorktreeBasePollEvent[]) => void
 const watcherCallbacks = new Map<string, PollerCallback>()
 const unsubscribeMocks = new Map<string, ReturnType<typeof vi.fn>>()
 const pollerOptions = new Map<string, WorktreeBasePollerOptions>()
-const absolutePath = (...parts: string[]): string => join(sep, ...parts)
+const absolutePath = (...parts: string[]): string => pathPosix.join('/', ...parts)
 const WORKTREE_ROOT = absolutePath('workspace', 'worktrees')
 const PROJECT_ROOT = absolutePath('workspace', 'projects', 'project')
 const PROJECT_GIT_COMMON_DIR = join(PROJECT_ROOT, '.git')

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { join, posix as pathPosix } from 'node:path'
+import { posix as pathPosix } from 'node:path'
 import type { GlobalSettings } from '../../shared/global-settings-types'
 import type { Repo } from '../../shared/repo-types'
 import type {
@@ -63,6 +63,7 @@ type PollerCallback = (events: WorktreeBasePollEvent[]) => void
 const watcherCallbacks = new Map<string, PollerCallback>()
 const unsubscribeMocks = new Map<string, ReturnType<typeof vi.fn>>()
 const pollerOptions = new Map<string, WorktreeBasePollerOptions>()
+const join = pathPosix.join
 const absolutePath = (...parts: string[]): string => pathPosix.join('/', ...parts)
 const WORKTREE_ROOT = absolutePath('workspace', 'worktrees')
 const PROJECT_ROOT = absolutePath('workspace', 'projects', 'project')

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -276,6 +276,9 @@ describe('fetchCodexRateLimits', () => {
 
   it('kills the RPC child and skips PTY fallback when the fetch signal aborts', async () => {
     const rpcChild = makeRpcChild()
+    // Why: keep the fake alive through graceful stdin shutdown so this test
+    // exercises the platform-specific force-termination path on every host.
+    rpcChild.stdin.end.mockImplementation(() => {})
     childSpawnMock.mockReturnValue(rpcChild)
     const controller = new AbortController()
 
@@ -283,6 +286,7 @@ describe('fetchCodexRateLimits', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     controller.abort()
+    await vi.advanceTimersByTimeAsync(5_000)
 
     await expect(resultPromise).resolves.toMatchObject({
       provider: 'codex',

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -381,11 +381,15 @@ describe('fetchCodexRateLimits', () => {
 
   it('removes RPC listeners when the app-server timeout settles', async () => {
     const rpcChild = makeRpcChild()
+    // Why: keep the fake alive through graceful stdin shutdown so timeout
+    // cleanup exercises force termination on Windows as well as POSIX hosts.
+    rpcChild.stdin.end.mockImplementation(() => {})
     childSpawnMock.mockReturnValue(rpcChild)
 
     const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
     // Why: without an initialize response only the 30s boot deadline fires.
     await vi.advanceTimersByTimeAsync(30_000)
+    await vi.advanceTimersByTimeAsync(5_000)
 
     await expect(resultPromise).resolves.toMatchObject({
       provider: 'codex',

--- a/src/main/repo-icon-autodetect.test.ts
+++ b/src/main/repo-icon-autodetect.test.ts
@@ -26,7 +26,7 @@ const registeredHosts: string[] = []
 /** A remote host whose only readable file is a package.json naming a host-specific homepage. */
 function registerHomepageHost(connectionId: string, homepage: string) {
   const stat = vi.fn(async (filePath: string) => {
-    if (!filePath.endsWith('/package.json')) {
+    if (!filePath.replaceAll('\\', '/').endsWith('/package.json')) {
       throw new Error('ENOENT')
     }
     return { type: 'file', size: 64, mtime: 0 }

--- a/src/main/runtime/structured-agent-session-integration.test.ts
+++ b/src/main/runtime/structured-agent-session-integration.test.ts
@@ -38,6 +38,12 @@ import {
 } from './structured-agent-session-runtime'
 
 const journals = createTrackedJournalOpener()
+// The fake app-server has no child process. Keep this integration test focused
+// on the agentSession wire instead of host-specific descendant enumeration.
+vi.mock('../codex/codex-structured-turn-processes', () => ({
+  captureCodexTurnProcesses: async () => null,
+  terminateCodexTurnProcesses: async () => true
+}))
 
 const SESSION = 'session-integration-1'
 const THREAD = 'thread-integration'

--- a/src/main/ssh/ssh-system-fallback.test.ts
+++ b/src/main/ssh/ssh-system-fallback.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, win32 } from 'node:path'
 import { EventEmitter } from 'node:events'
 import { PassThrough } from 'node:stream'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
@@ -38,7 +38,14 @@ import type { SshTarget } from '../../shared/ssh-types'
 import type { SystemSshResolvedConfig } from './ssh-control-socket'
 
 const SYSTEM_SSH_PATH =
-  process.platform === 'win32' ? 'C:\\Windows\\System32\\OpenSSH\\ssh.exe' : '/usr/bin/ssh'
+  process.platform === 'win32'
+    ? win32.join(
+        process.env.SystemRoot ?? process.env.WINDIR ?? 'C:\\Windows',
+        'System32',
+        'OpenSSH',
+        'ssh.exe'
+      )
+    : '/usr/bin/ssh'
 
 function decodePowerShellCommand(command: string): string {
   const encoded = command.match(/-EncodedCommand\s+(\S+)/)?.[1]

--- a/src/relay/fs-handler.test.ts
+++ b/src/relay/fs-handler.test.ts
@@ -5,7 +5,7 @@ import { RelayContext } from './context'
 import type { RelayDispatcher } from './dispatcher'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { subscribeWithInProcessWatcher } from '../main/ipc/parcel-watcher-in-process-fallback'
 import { createMockDispatcher } from './relay-fs-test-dispatcher'
@@ -27,6 +27,27 @@ function statIdentity(stats: {
 }) {
   return `${stats.dev}:${stats.ino}:${stats.nlink ?? 'unknown'}:${stats.size}:${stats.mtimeMs}`
 }
+
+function canCreateFileSymlinks(): boolean {
+  const probeDir = mkdtempSync(path.join(tmpdir(), 'orca-symlink-capability-'))
+  const targetPath = path.join(probeDir, 'target')
+  const linkPath = path.join(probeDir, 'link')
+  try {
+    writeFileSync(targetPath, '')
+    symlinkSync(targetPath, linkPath)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES')) {
+      return false
+    }
+    throw error
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true })
+  }
+}
+
+const symlinkIt = it.skipIf(!canCreateFileSymlinks())
 
 describe('FsHandler', () => {
   let dispatcher: ReturnType<typeof createMockDispatcher>
@@ -300,27 +321,30 @@ describe('FsHandler', () => {
     await expect(fs.readFile(filePath, 'utf-8')).resolves.toBe('abcdef')
   })
 
-  it('writeTerminalArtifact rejects a retargeted symlink before writing outside temp', async () => {
-    const filePath = path.join(tmpDir, 'artifact-link.json')
-    const outsidePath = path.join(tmpDir, 'outside.json')
-    writeFileSync(filePath, '{"ok":true}')
-    writeFileSync(outsidePath, '{"secret":true}')
-    const stats = await fs.stat(filePath)
-    const expectedRealPath = await fs.realpath(filePath)
-    await fs.rm(filePath)
-    symlinkSync(outsidePath, filePath)
+  symlinkIt(
+    'writeTerminalArtifact rejects a retargeted symlink before writing outside temp',
+    async () => {
+      const filePath = path.join(tmpDir, 'artifact-link.json')
+      const outsidePath = path.join(tmpDir, 'outside.json')
+      writeFileSync(filePath, '{"ok":true}')
+      writeFileSync(outsidePath, '{"secret":true}')
+      const stats = await fs.stat(filePath)
+      const expectedRealPath = await fs.realpath(filePath)
+      await fs.rm(filePath)
+      symlinkSync(outsidePath, filePath)
 
-    await expect(
-      dispatcher.callRequest('fs.writeTerminalArtifact', {
-        filePath,
-        content: '{"ok":false}',
-        expectedRealPath,
-        expectedStatIdentity: statIdentity(stats),
-        maxBytes: 512 * 1024
-      })
-    ).rejects.toThrow('terminal_file_grant_stale')
-    await expect(fs.readFile(outsidePath, 'utf-8')).resolves.toBe('{"secret":true}')
-  })
+      await expect(
+        dispatcher.callRequest('fs.writeTerminalArtifact', {
+          filePath,
+          content: '{"ok":false}',
+          expectedRealPath,
+          expectedStatIdentity: statIdentity(stats),
+          maxBytes: 512 * 1024
+        })
+      ).rejects.toThrow('terminal_file_grant_stale')
+      await expect(fs.readFile(outsidePath, 'utf-8')).resolves.toBe('{"secret":true}')
+    }
+  )
 
   it('writeTerminalArtifact rejects hard-linked files before writing', async () => {
     const outsidePath = path.join(tmpDir, 'outside-hardlink.json')
@@ -375,7 +399,7 @@ describe('FsHandler', () => {
     expect(result.type).toBe('directory')
   })
 
-  it('lstat returns symlink type without following links', async () => {
+  symlinkIt('lstat returns symlink type without following links', async () => {
     const targetFile = path.join(tmpDir, 'target.txt')
     const linkPath = path.join(tmpDir, 'link.txt')
     writeFileSync(targetFile, 'target')
@@ -534,7 +558,7 @@ describe('FsHandler', () => {
     expect(content).toBe('existing')
   })
 
-  it('realpath resolves symlinks', async () => {
+  symlinkIt('realpath resolves symlinks', async () => {
     const realFile = path.join(tmpDir, 'real.txt')
     const linkPath = path.join(tmpDir, 'link.txt')
     writeFileSync(realFile, 'real')

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -6,6 +6,8 @@ import {
   mkdtempSync,
   readFileSync,
   statSync,
+  rmSync,
+  symlinkSync,
   unlinkSync,
   writeFileSync
 } from 'node:fs'
@@ -79,6 +81,27 @@ function spawnRelayEntry(
 function spawn(args: string[] = [], env?: NodeJS.ProcessEnv): RelayProcess {
   return spawnRelayEntry(relayEntry, args, env)
 }
+
+function canCreateFileSymlinks(): boolean {
+  const probeDir = mkdtempSync(path.join(tmpdir(), 'orca-symlink-capability-'))
+  const targetPath = path.join(probeDir, 'target')
+  const linkPath = path.join(probeDir, 'link')
+  try {
+    writeFileSync(targetPath, '')
+    symlinkSync(targetPath, linkPath)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES')) {
+      return false
+    }
+    throw error
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true })
+  }
+}
+
+const symlinkIt = it.skipIf(!canCreateFileSymlinks())
 
 function waitForChildExit(
   proc: ReturnType<typeof spawnChild>,
@@ -894,29 +917,32 @@ describe('Subprocess: Relay entry point', () => {
     await rm(outsideDir, { recursive: true, force: true }).catch(() => {})
   }, 10_000)
 
-  it('reads files via symlinks resolving outside the workspace', async () => {
-    // Regression test for issue #1661: a symlink under the workspace pointing
-    // to a directory outside it must resolve transparently. The pre-removal
-    // relay rejected this with "Path outside authorized workspace".
-    tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
-    const outsideDir = mkdtempSync(path.join(tmpdir(), 'relay-outside-'))
-    writeFileSync(path.join(outsideDir, 'data.txt'), 'symlinked-target')
-    const { symlinkSync } = require('node:fs')
-    symlinkSync(outsideDir, path.join(tmpDir, 'link'))
+  symlinkIt(
+    'reads files via symlinks resolving outside the workspace',
+    async () => {
+      // Regression test for issue #1661: a symlink under the workspace pointing
+      // to a directory outside it must resolve transparently. The pre-removal
+      // relay rejected this with "Path outside authorized workspace".
+      tmpDir = mkdtempSync(path.join(tmpdir(), 'relay-sub-'))
+      const outsideDir = mkdtempSync(path.join(tmpdir(), 'relay-outside-'))
+      writeFileSync(path.join(outsideDir, 'data.txt'), 'symlinked-target')
+      symlinkSync(outsideDir, path.join(tmpDir, 'link'))
 
-    relay = spawn()
-    await relay.sentinelReceived
+      relay = spawn()
+      await relay.sentinelReceived
 
-    const id = relay.send('fs.readFile', {
-      filePath: path.join(tmpDir, 'link', 'data.txt')
-    })
-    const resp = await relay.waitForResponse(id)
+      const id = relay.send('fs.readFile', {
+        filePath: path.join(tmpDir, 'link', 'data.txt')
+      })
+      const resp = await relay.waitForResponse(id)
 
-    expect(resp.error).toBeUndefined()
-    expect((resp.result as { content: string }).content).toBe('symlinked-target')
+      expect(resp.error).toBeUndefined()
+      expect((resp.result as { content: string }).content).toBe('symlinked-target')
 
-    await rm(outsideDir, { recursive: true, force: true }).catch(() => {})
-  }, 10_000)
+      await rm(outsideDir, { recursive: true, force: true }).catch(() => {})
+    },
+    10_000
+  )
 
   it('resolves ~ to home directory via session.resolveHome', async () => {
     relay = spawn()

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -583,8 +583,8 @@ describe('renderer startup runtime routing', () => {
     expect(checkpointBlock).toContain(
       'const shutdownCheckpointPersist = createShutdownCheckpointPersist({'
     )
-    expect(checkpointBlock).toContain(
-      'buildWorkspaceSessionHostSnapshots(\n          buildWorkspaceSessionPayload(freshState),\n          freshState\n        )'
+    expect(checkpointBlock.replace(/\s+/g, ' ')).toContain(
+      'buildWorkspaceSessionHostSnapshots( buildWorkspaceSessionPayload(freshState), freshState )'
     )
     expect(checkpointBlock).toContain('buildUiPatch: () => buildActiveViewUnloadPatch(')
     // Why pin the exact gate: the degrade tiers must arm only for intentional

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -603,8 +603,8 @@ describe('renderer startup runtime routing', () => {
     expect(source).toContain(
       'window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.abandonAttempt)'
     )
-    expect(source).toContain(
-      'ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,\n      shutdownCheckpoint.abortAfterCheckpointFailure'
+    expect(source.replace(/\s+/g, ' ')).toContain(
+      'ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT, shutdownCheckpoint.abortAfterCheckpointFailure'
     )
     expect(source).toContain(
       'window.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, shutdownCheckpoint.abandonAttempt)'

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -580,6 +580,7 @@ describe('cross-version structured agent sessions', () => {
   describe('an old client against a structured-owned AI Vault row', () => {
     let root: string
     let store: AgentSessionRecordStore
+    let host: StructuredAgentSessionHost
     let runtime: Record<string, unknown>
     let createMobileSessionTerminal: ReturnType<typeof vi.fn>
 
@@ -589,7 +590,7 @@ describe('cross-version structured agent sessions', () => {
         directory: join(root, 'store'),
         hostId: 'local'
       })
-      const host = new StructuredAgentSessionHost({
+      host = new StructuredAgentSessionHost({
         store,
         adapter: {
           acquire: async ({ fence }) => ({
@@ -658,6 +659,7 @@ describe('cross-version structured agent sessions', () => {
 
     afterEach(async () => {
       setStructuredAgentSessionHost(null)
+      await host.flushAllStreamedEvents()
       await rm(root, { recursive: true, force: true })
     })
 

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -39,7 +39,7 @@ import {
 } from './versioned-agent-session-wire'
 
 // Why: a cold CI run extracts the baseline checkout before the first pairing.
-const SUITE_TIMEOUT_MS = 180_000
+const SUITE_TIMEOUT_MS = 300_000
 
 const SESSION = 'session-alpha'
 const WORKSPACE = 'workspace-1'
@@ -148,12 +148,13 @@ const STRUCTURED_CALLS: {
 let baselineRef: string
 let current: AgentSessionWireBuild
 let baseline: AgentSessionWireBuild
-let operations = 0
+let releasedCurrent: AgentSessionWireBuild
 
 beforeAll(async () => {
   baselineRef = resolveBaselineReleaseRef()
   current = await loadAgentSessionWireBuild(WORKING_TREE)
   baseline = await loadAgentSessionWireBuild(baselineRef)
+  releasedCurrent = await loadAgentSessionWireBuild('HEAD')
 }, SUITE_TIMEOUT_MS)
 
 /** `<13-digit ms>-<32 hex>`, the only shape the durable ledger accepts. */
@@ -508,7 +509,6 @@ describe('cross-version structured agent sessions', () => {
         // runner's module graph. It is the only place the "registered means
         // usable" claim is executable today, because the baseline registers none
         // of these methods — so it has to carry the whole manifest, not a sample.
-        const releasedCurrent = await loadAgentSessionWireBuild('HEAD')
         expect(releasedCurrent.capabilities).toContain(STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)
         expect(
           releasedCurrent.methodNames.filter((name) => name.startsWith('agentSession.'))

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -149,6 +149,7 @@ let baselineRef: string
 let current: AgentSessionWireBuild
 let baseline: AgentSessionWireBuild
 let releasedCurrent: AgentSessionWireBuild
+let operations = 0
 
 beforeAll(async () => {
   baselineRef = resolveBaselineReleaseRef()

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -888,7 +888,7 @@ describe('cross-version structured agent sessions', () => {
       for (const host of hosts.splice(0)) {
         await host.flushAllStreamedEvents()
       }
-      await rm(root, { recursive: true, force: true })
+      await rm(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 50 })
     })
 
     it('resumes from the cursor the client held, with no snapshot and no replay', async () => {

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -885,7 +885,9 @@ describe('cross-version structured agent sessions', () => {
 
     afterEach(async () => {
       setStructuredAgentSessionHost(null)
-      await Promise.all(hosts.splice(0).map((host) => host.flushAllStreamedEvents()))
+      for (const host of hosts.splice(0)) {
+        await host.flushAllStreamedEvents()
+      }
       await rm(root, { recursive: true, force: true })
     })
 

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -771,6 +771,7 @@ describe('cross-version structured agent sessions', () => {
     let root: string
     let store: AgentSessionRecordStore
     let runtime: unknown
+    const hosts: StructuredAgentSessionHost[] = []
 
     /** Phase 2 owns provider processes; the adapter is the only stub here. */
     function adapter(): StructuredAgentSessionAdapter {
@@ -824,6 +825,7 @@ describe('cross-version structured agent sessions', () => {
         probeOwner: async () => ({ outcome: 'pid-absent' }),
         now: () => NOW
       })
+      hosts.push(host)
       setStructuredAgentSessionHost(host)
       return host
     }
@@ -883,6 +885,7 @@ describe('cross-version structured agent sessions', () => {
 
     afterEach(async () => {
       setStructuredAgentSessionHost(null)
+      await Promise.all(hosts.splice(0).map((host) => host.flushAllStreamedEvents()))
       await rm(root, { recursive: true, force: true })
     })
 


### PR DESCRIPTION
## Summary

Split the Windows portability work out of #18563 so the SSH archive-hook fix can stay focused.

This PR contains test and fixture changes for Windows path handling, symlink privilege detection, WSL/daemon/relay lifecycle behavior, process cleanup, and xterm patch portability. It does not contain the SSH archive-hook implementation.

## Relationship to #18563

- #18563 contains only the SSH archive-hook removal fix and its focused regression tests.
- This PR contains the independent Windows portability work.

## Validation

Validated on the `win32` hpv2 worktree at this PR head:

- `pnpm tc` — passed.
- `pnpm run check:code-quality:changed -- f2d5711b2d32e9f11277cd63805c76b0b5f9ddf7` — passed with 0 new findings across 34 changed source files.
- The changed test files passed in focused groups: 30 files, 615 tests passed, 49 skipped.
  - `pr-workflow-parallelism.test.mjs`: 18 passed.
  - The other 28 changed test files: 584 passed, 49 skipped.
  - `cross-version-agent-session-wire.unit.test.ts`: 13 passed.
- Generated cross-version cache data was removed after validation; the hpv2 worktree retains only its pre-existing `NUL` untracked entry.

The broad hpv2 `pnpm test` run remains non-green because of unrelated baseline/platform failures and is not used as a completion claim for this test-only PR. `pnpm typecheck:e2e` is explicitly non-enforced by the repository config and still reports its existing baseline errors; it is not part of the required `pnpm tc` result.