### PR TITLE
fix(windows): clear stale CHROME_CRASHPAD_PIPE_NAME in packaged CLI launcher

### DIFF
--- a/native/windows-cli-launcher/OrcaCliLauncher.cs
+++ b/native/windows-cli-launcher/OrcaCliLauncher.cs
@@ -53,6 +53,9 @@ internal static class OrcaCliLauncher
                 "ORCA_CLI_COMMAND",
                 requestedCliCommand == "orca-ide" ? "orca-ide" : "orca"
             );
+            // Why: a stale pipe inherited from the Orca parent makes Electron log Crashpad
+            // registration errors on stderr even when the CLI succeeds (stablyai/orca#19792).
+            Environment.SetEnvironmentVariable("CHROME_CRASHPAD_PIPE_NAME", null);
 
             using (Process child = Process.Start(startInfo))
             {

--- a/src/main/cli/windows-launcher-asset.test.ts
+++ b/src/main/cli/windows-launcher-asset.test.ts
@@ -28,4 +28,14 @@ describe('packaged Windows CLI launcher asset', () => {
     expect(source).toContain('child.WaitForExit();')
     expect(source).toContain('return child.ExitCode;')
   })
+
+  it('clears inherited CHROME_CRASHPAD_PIPE_NAME before launching Electron-as-Node', () => {
+    const sourcePath = join(process.cwd(), 'native', 'windows-cli-launcher', 'OrcaCliLauncher.cs')
+    const source = readFileSync(sourcePath, 'utf8')
+
+    // Why: the packaged CLI is often spawned from an Orca terminal that already set this pipe.
+    expect(source).toContain(
+      'Environment.SetEnvironmentVariable("CHROME_CRASHPAD_PIPE_NAME", null);'
+    )
+  })
 })

--- a/src/main/cli/windows-launcher-asset.test.ts
+++ b/src/main/cli/windows-launcher-asset.test.ts
@@ -33,9 +33,13 @@ describe('packaged Windows CLI launcher asset', () => {
     const sourcePath = join(process.cwd(), 'native', 'windows-cli-launcher', 'OrcaCliLauncher.cs')
     const source = readFileSync(sourcePath, 'utf8')
 
-    // Why: the packaged CLI is often spawned from an Orca terminal that already set this pipe.
-    expect(source).toContain(
+    const cleanupIndex = source.indexOf(
       'Environment.SetEnvironmentVariable("CHROME_CRASHPAD_PIPE_NAME", null);'
     )
+    const processStartIndex = source.indexOf('using (Process child = Process.Start(startInfo))')
+
+    // Why: cleanup must run on the launcher process before the child inherits its env block.
+    expect(cleanupIndex).toBeGreaterThanOrEqual(0)
+    expect(processStartIndex).toBeGreaterThan(cleanupIndex)
   })
 })


### PR DESCRIPTION
## ELI5

When Orca runs the Windows `orca` CLI from inside the app, the child Electron process inherited a Crashpad pipe name that no longer works, so every command printed a scary stderr line even when it succeeded. The launcher now drops that variable before starting the CLI.

## What Changed

- Clear `CHROME_CRASHPAD_PIPE_NAME` on the launcher process before `Process.Start`, so the Electron-as-Node child does not try to register with a stale pipe inherited from an Orca parent.
- Regression test asserts the launcher source keeps this clear in `windows-launcher-asset.test.ts`.

## Why

Packaged Windows CLI invocations spawned from Orca-managed terminals inherit `CHROME_CRASHPAD_PIPE_NAME`. When that pipe is stale, Chromium logs Crashpad registration errors on stderr (`CreateFile` / `registration_protocol_win`) on every run, which pollutes multi-agent orchestration logs despite exit 0 and valid JSON on stdout. Clearing only that variable in the calling process removes the noise; mutating the launcher's own environment block (not `ProcessStartInfo.Environment`) matches the existing packaged CLI env contract (#12046).

## Linked Issue

Fixes #19792

## Visual Proof

N/A — stderr noise removal for the packaged CLI; no UI change.

## Testing

- [x] `pnpm test src/main/cli/windows-launcher-asset.test.ts` (Linux CI host; source contract assertion)
- [ ] Full Windows launcher integration not run on this host (existing `itWindows` suite covers compile/launch on Windows CI)

## AI Disclosure

Cursor Cloud Agent (Composer)

## Notes

Preserves existing launcher env moves: `NODE_OPTIONS` / `NODE_REPL_EXTERNAL_MODULE` → `ORCA_*`, `ELECTRON_RUN_AS_NODE`, `ORCA_WINDOWS_PACKAGED_CLI_LAUNCHER`, `ORCA_CLI_COMMAND.