### PR TITLE
feat(speech): let cloud dictation target any OpenAI-compatible endpoint

### DIFF
--- a/src/main/speech/openai-compatible-endpoint.test.ts
+++ b/src/main/speech/openai-compatible-endpoint.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getDefaultVoiceSettings } from '../../shared/constants'
+import type { VoiceSettings } from '../../shared/speech-types'
+import {
+  readOpenAiCompatibleEndpoint,
+  resolveOpenAiCompatibleUrl,
+  setVoiceSettingsReader
+} from './openai-compatible-endpoint'
+
+function voice(overrides: Partial<VoiceSettings>): VoiceSettings {
+  return { ...getDefaultVoiceSettings(), ...overrides }
+}
+
+describe('resolveOpenAiCompatibleUrl', () => {
+  it('appends the transcription path when the URL carries none', () => {
+    expect(resolveOpenAiCompatibleUrl('http://127.0.0.1:8080')).toBe(
+      'http://127.0.0.1:8080/v1/audio/transcriptions'
+    )
+    expect(resolveOpenAiCompatibleUrl('https://api.groq.com/')).toBe(
+      'https://api.groq.com/v1/audio/transcriptions'
+    )
+  })
+
+  it('keeps a URL that already points at an endpoint', () => {
+    expect(resolveOpenAiCompatibleUrl('https://api.groq.com/openai/v1/audio/transcriptions')).toBe(
+      'https://api.groq.com/openai/v1/audio/transcriptions'
+    )
+  })
+
+  it('rejects empty, relative and non-http URLs', () => {
+    expect(resolveOpenAiCompatibleUrl('')).toBeNull()
+    expect(resolveOpenAiCompatibleUrl('   ')).toBeNull()
+    expect(resolveOpenAiCompatibleUrl('api.groq.com')).toBeNull()
+    expect(resolveOpenAiCompatibleUrl('file:///etc/passwd')).toBeNull()
+  })
+})
+
+describe('readOpenAiCompatibleEndpoint', () => {
+  afterEach(() => {
+    setVoiceSettingsReader(null)
+  })
+
+  it('is null without a reader and with the default settings', () => {
+    expect(readOpenAiCompatibleEndpoint()).toBeNull()
+    setVoiceSettingsReader(() => getDefaultVoiceSettings())
+    expect(readOpenAiCompatibleEndpoint()).toBeNull()
+  })
+
+  it('returns URL and model once both are configured', () => {
+    setVoiceSettingsReader(() =>
+      voice({
+        openAiCompatible: {
+          baseUrl: 'https://api.groq.com/openai/v1/audio/transcriptions',
+          model: ' whisper-large-v3-turbo '
+        }
+      })
+    )
+    expect(readOpenAiCompatibleEndpoint()).toEqual({
+      url: 'https://api.groq.com/openai/v1/audio/transcriptions',
+      model: 'whisper-large-v3-turbo'
+    })
+  })
+
+  it('keeps the catalog model when only the URL is set', () => {
+    setVoiceSettingsReader(() =>
+      voice({ openAiCompatible: { baseUrl: 'http://127.0.0.1:8080', model: '' } })
+    )
+    expect(readOpenAiCompatibleEndpoint()).toEqual({
+      url: 'http://127.0.0.1:8080/v1/audio/transcriptions',
+      model: null
+    })
+  })
+
+  it('ignores a model without a URL, so dictation still goes to OpenAI', () => {
+    setVoiceSettingsReader(() =>
+      voice({ openAiCompatible: { baseUrl: '', model: 'whisper-large-v3' } })
+    )
+    expect(readOpenAiCompatibleEndpoint()).toBeNull()
+  })
+})

--- a/src/main/speech/openai-compatible-endpoint.ts
+++ b/src/main/speech/openai-compatible-endpoint.ts
@@ -1,0 +1,59 @@
+/**
+ * Optional OpenAI-compatible transcription endpoint.
+ *
+ * Cloud dictation posts to api.openai.com through a hardcoded constant, so the
+ * only way to use another OpenAI-compatible service (Groq, OpenRouter, a local
+ * Whisper server) was to patch the packaged app. This module holds the reader
+ * for the two voice settings that redirect it, set once by the speech runtime
+ * service — the STT session itself has no store.
+ */
+import type { VoiceSettings } from '../../shared/speech-types'
+
+export type OpenAiCompatibleEndpoint = {
+  /** Full URL to POST the multipart form to. */
+  url: string
+  /** Model name to send, or null to keep the catalog model's OpenAI name. */
+  model: string | null
+}
+
+const TRANSCRIPTION_PATH = '/v1/audio/transcriptions'
+
+let readVoiceSettings: (() => VoiceSettings | null) | null = null
+
+export function setVoiceSettingsReader(reader: (() => VoiceSettings | null) | null): void {
+  readVoiceSettings = reader
+}
+
+/**
+ * Appends the transcription path when the configured base URL has none, so
+ * `http://127.0.0.1:8080` and `https://api.groq.com/openai/v1/audio/transcriptions`
+ * both work. Returns null for anything that is not an absolute http(s) URL.
+ */
+export function resolveOpenAiCompatibleUrl(baseUrl: string): string | null {
+  const trimmed = baseUrl.trim()
+  if (!trimmed) {
+    return null
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return null
+  }
+  const path = parsed.pathname.replace(/\/+$/, '')
+  return path ? `${parsed.origin}${path}${parsed.search}` : `${parsed.origin}${TRANSCRIPTION_PATH}`
+}
+
+/** The configured endpoint, or null when dictation should go to OpenAI. */
+export function readOpenAiCompatibleEndpoint(): OpenAiCompatibleEndpoint | null {
+  const settings = readVoiceSettings?.()?.openAiCompatible ?? null
+  const url = settings ? resolveOpenAiCompatibleUrl(settings.baseUrl) : null
+  if (!url) {
+    return null
+  }
+  const model = settings?.model.trim()
+  return { url, model: model ? model : null }
+}

--- a/src/main/speech/openai-transcription-client.ts
+++ b/src/main/speech/openai-transcription-client.ts
@@ -1,4 +1,5 @@
 import { resampleToRate } from './stt-audio-resample'
+import type { OpenAiCompatibleEndpoint } from './openai-compatible-endpoint'
 
 export const OPENAI_TRANSCRIPTION_MODEL_BY_ID: Record<string, string> = {
   'openai-gpt-4o-mini-transcribe': 'gpt-4o-mini-transcribe',
@@ -83,7 +84,9 @@ export class OpenAiTranscriptionSession {
 
   constructor(
     private readonly modelId: string,
-    private readonly readApiKey: () => string
+    private readonly readApiKey: () => string,
+    /** Optional OpenAI-compatible endpoint; null keeps the OpenAI defaults. */
+    private readonly readEndpoint: () => OpenAiCompatibleEndpoint | null = () => null
   ) {}
 
   feedAudio(samples: Float32Array, sampleRate: number): void {
@@ -108,18 +111,21 @@ export class OpenAiTranscriptionSession {
     const audio = combineChunks(this.chunks)
     this.chunks = []
     const wav = encodePcm16Wav(audio, CLOUD_TRANSCRIPTION_SAMPLE_RATE)
+    // A configured OpenAI-compatible service replaces URL and model. Its key
+    // still travels in the same header, so users of a keyless local server
+    // simply leave the API key empty.
+    const endpoint = this.readEndpoint()
     const form = new FormData()
-    form.append('model', apiModel)
+    form.append('model', endpoint?.model ?? apiModel)
     form.append('response_format', 'json')
     // Why: OpenAI's transcription endpoint expects a multipart file object;
     // a named WAV blob avoids filesystem temp files and works in packaged apps.
     form.append('file', new Blob([new Uint8Array(wav)], { type: 'audio/wav' }), 'dictation.wav')
 
-    const response = await fetch(OPENAI_TRANSCRIPTION_URL, {
+    const apiKey = this.readApiKey()
+    const response = await fetch(endpoint?.url ?? OPENAI_TRANSCRIPTION_URL, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.readApiKey()}`
-      },
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
       body: form
     })
 

--- a/src/main/speech/speech-runtime-service.ts
+++ b/src/main/speech/speech-runtime-service.ts
@@ -1,6 +1,7 @@
 import type { ModelManager } from './model-manager'
 import type { SttService } from './stt-service'
 import type { VoiceSettings } from '../../shared/speech-types'
+import { setVoiceSettingsReader } from './openai-compatible-endpoint'
 
 /**
  * Lazy accessors for the speech services.
@@ -53,6 +54,9 @@ export function getSpeechModelManager(store: SpeechSettingsStore): ModelManager 
 }
 
 export function getSpeechSttService(store: SpeechSettingsStore): SttService {
+  // The STT session has no store of its own; give it a reader for the
+  // OpenAI-compatible endpoint settings before the first dictation starts.
+  setVoiceSettingsReader(() => store.getSettings().voice ?? null)
   if (!sttService) {
     sttService = requireFactories().createSttService(getSpeechModelManager(store))
   }

--- a/src/main/speech/stt-session-start.ts
+++ b/src/main/speech/stt-session-start.ts
@@ -2,6 +2,7 @@ import { Worker } from 'node:worker_threads'
 import { getCatalogModel } from './model-catalog'
 import { OpenAiTranscriptionSession } from './openai-transcription-client'
 import { readOpenAiSpeechApiKey } from './openai-api-key-store'
+import { readOpenAiCompatibleEndpoint } from './openai-compatible-endpoint'
 import type { SttEventSink } from './stt-service'
 import type { SttSessionState } from './stt-session-state'
 import {
@@ -77,7 +78,11 @@ async function startSttSession(
     if (modelState.status !== 'ready') {
       throw new Error(`Model not ready: ${modelState.status}`)
     }
-    state.cloudSession = new OpenAiTranscriptionSession(modelId, readOpenAiSpeechApiKey)
+    state.cloudSession = new OpenAiTranscriptionSession(
+      modelId,
+      readOpenAiSpeechApiKey,
+      readOpenAiCompatibleEndpoint
+    )
     state.activeModelId = modelId
     state.activeHotwordsFilePath = undefined
     state.eventSink = sink

--- a/src/renderer/src/components/settings/OpenAiCompatibleEndpointRow.tsx
+++ b/src/renderer/src/components/settings/OpenAiCompatibleEndpointRow.tsx
@@ -1,0 +1,65 @@
+import { Server } from 'lucide-react'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { translate } from '@/i18n/i18n'
+import type { OpenAiCompatibleSettings } from '../../../../shared/speech-types'
+
+type OpenAiCompatibleEndpointRowProps = {
+  settings: OpenAiCompatibleSettings
+  disabled: boolean
+  onChange: (next: OpenAiCompatibleSettings) => void
+}
+
+/**
+ * Points cloud dictation at any OpenAI-compatible transcription service
+ * (Groq, OpenRouter, a self-hosted Whisper). Empty base URL = OpenAI.
+ */
+export function OpenAiCompatibleEndpointRow({
+  settings,
+  disabled,
+  onChange
+}: OpenAiCompatibleEndpointRowProps): React.JSX.Element {
+  return (
+    <div className="space-y-2 py-2">
+      <div className="flex items-center gap-2">
+        <Server className="size-4 shrink-0 text-muted-foreground" />
+        <Label htmlFor="openai-compatible-base-url">
+          {translate(
+            'auto.components.settings.OpenAiCompatibleEndpointRow.a1b2c3d4e5',
+            'OpenAI-compatible endpoint'
+          )}
+        </Label>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {translate(
+          'auto.components.settings.OpenAiCompatibleEndpointRow.b2c3d4e5f6',
+          'Send cloud dictation to another service that speaks the OpenAI transcription API — Groq, OpenRouter or a local Whisper server. Leave empty to use OpenAI. The API key above is sent as the bearer token; a keyless local server needs none.'
+        )}
+      </p>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Input
+          id="openai-compatible-base-url"
+          value={settings.baseUrl}
+          disabled={disabled}
+          spellCheck={false}
+          placeholder={translate(
+            'auto.components.settings.OpenAiCompatibleEndpointRow.d4e5f6a7b8',
+            'https://api.groq.com/openai/v1/audio/transcriptions'
+          )}
+          onChange={(event) => onChange({ ...settings, baseUrl: event.target.value })}
+        />
+        <Input
+          id="openai-compatible-model"
+          value={settings.model}
+          disabled={disabled}
+          spellCheck={false}
+          placeholder={translate(
+            'auto.components.settings.OpenAiCompatibleEndpointRow.c3d4e5f6a7',
+            'Model name, e.g. whisper-large-v3-turbo'
+          )}
+          onChange={(event) => onChange({ ...settings, model: event.target.value })}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/VoicePane.tsx
+++ b/src/renderer/src/components/settings/VoicePane.tsx
@@ -6,6 +6,7 @@ import { Separator } from '../ui/separator'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { OpenAiTranscriptionKeyDialog } from './OpenAiTranscriptionKeyDialog'
+import { OpenAiCompatibleEndpointRow } from './OpenAiCompatibleEndpointRow'
 import { OpenAiTranscriptionSettingsRow } from './OpenAiTranscriptionSettingsRow'
 import { handleVoiceDictationToggle } from './voice-dictation-toggle'
 import { VoiceDictationSettingsSection } from './VoiceDictationSettingsSection'
@@ -235,6 +236,12 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
             disabled={openAiKeyPending}
             onConfigure={() => openOpenAiDialog(null)}
             onClear={() => void clearOpenAiApiKey()}
+          />
+          <Separator />
+          <OpenAiCompatibleEndpointRow
+            settings={voiceSettings.openAiCompatible}
+            disabled={openAiKeyPending}
+            onChange={(openAiCompatible) => updateVoiceSettings({ openAiCompatible })}
           />
         </>
       )}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11839,6 +11839,12 @@
           "targetDescription": "Higher values increase contrast where possible. Background colors stay unchanged.",
           "subtle": "Subtle",
           "strong": "Strong"
+        },
+        "OpenAiCompatibleEndpointRow": {
+          "a1b2c3d4e5": "OpenAI-compatible endpoint",
+          "b2c3d4e5f6": "Send cloud dictation to another service that speaks the OpenAI transcription API — Groq, OpenRouter or a local Whisper server. Leave empty to use OpenAI. The API key above is sent as the bearer token; a keyless local server needs none.",
+          "c3d4e5f6a7": "Model name, e.g. whisper-large-v3-turbo",
+          "d4e5f6a7b8": "https://api.groq.com/openai/v1/audio/transcriptions"
         }
       },
       "right": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -188,7 +188,8 @@ export function getDefaultVoiceSettings(): VoiceSettings {
     userModels: [],
     openAiApiKeyConfigured: false,
     microphoneDeviceId: null,
-    microphoneDeviceLabel: null
+    microphoneDeviceLabel: null,
+    openAiCompatible: { baseUrl: '', model: '' }
   }
 }
 

--- a/src/shared/speech-types.ts
+++ b/src/shared/speech-types.ts
@@ -79,4 +79,17 @@ export type VoiceSettings = {
   microphoneDeviceId: string | null
   /** Cached label for display when the preferred device is unplugged */
   microphoneDeviceLabel: string | null
+  /** Redirects cloud dictation to any service that speaks the OpenAI transcription API. */
+  openAiCompatible: OpenAiCompatibleSettings
+}
+
+export type OpenAiCompatibleSettings = {
+  /**
+   * Base URL of an OpenAI-compatible transcription service (Groq, OpenRouter,
+   * a local Whisper server, …). Empty string = OpenAI itself. The path
+   * `/v1/audio/transcriptions` is appended when the URL carries none.
+   */
+  baseUrl: string
+  /** Model name sent to that service; empty = the catalog model's OpenAI name. */
+  model: string
 }


### PR DESCRIPTION
Closes #10593.

## Problem

Cloud dictation posts to a hardcoded constant:

```ts
// src/main/speech/openai-transcription-client.ts
const OPENAI_TRANSCRIPTION_URL = 'https://api.openai.com/v1/audio/transcriptions'
```

There is no setting, env var or base-URL override, so pointing dictation at another service that speaks the same API — Groq, OpenRouter, or a self-hosted Whisper — means patching `app.asar`, which breaks on every update. #10593 asks for Groq; the comment there asks for OpenRouter. This adds the one knob both need instead of a client per provider.

## Change

Two voice settings, grouped as `voice.openAiCompatible`:

| Setting | Effect |
|---|---|
| `baseUrl` | Empty = OpenAI, unchanged. A URL without a path gets `/v1/audio/transcriptions` appended, so `http://127.0.0.1:8080` and a full endpoint URL both work. Only `http(s)` is accepted. |
| `model` | Empty = the catalog model's OpenAI name; otherwise sent verbatim (e.g. `whisper-large-v3-turbo`). |

The stored API key still travels as the bearer token and is omitted when empty, which is what a keyless local server needs. Existing profiles are untouched: the default is an empty base URL, so behaviour is identical until someone fills the field in.

The STT session has no settings store of its own, so the reader is installed by `speech-runtime-service`, where the store is already known — the same place that resolves the models directory.

## Tests

`src/main/speech/openai-compatible-endpoint.test.ts` covers URL resolution (path appended, existing path preserved, empty/relative/non-http rejected) and the reader (no reader, defaults, URL only, model only, both).

## Verification

- `pnpm run typecheck` and `pnpm lint` (all gates, including localization) pass
- `pnpm exec vitest run` over `src/main/speech`, `src/renderer/src/components/settings` and `src/shared`: 8848 passed. One unrelated failure, `src/shared/pane-agent-identity-title-corpus.test.ts`, reproduces on a clean checkout of `main` with this branch stashed, so it is pre-existing on this machine.
- Verified manually against a local Whisper server (OpenAI-compatible, `whisper-large-v3-turbo`) and against api.openai.com with the field empty.