### PR TITLE
Navigate worktree diff files from diff controls

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.diff-file-navigation.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.diff-file-navigation.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { OpenFile } from '@/store/slices/editor'
+import type { GitStatusEntry } from '../../../../shared/git-status-types'
+import type { WorktreeDiffNavigationDirection } from './worktree-diff-file-navigation'
+
+type ProviderProps = {
+  children: React.ReactNode
+  canNavigateFile?: boolean
+  onNavigateFile?: (direction: WorktreeDiffNavigationDirection) => boolean
+}
+
+const panelProbe = vi.hoisted(() => ({
+  providerProps: null as ProviderProps | null,
+  shellProps: null as { model: { isDiffSurface: boolean; isChangesMode: boolean } } | null,
+  contentState: {
+    fileContents: {},
+    diffContents: {},
+    reloadContent: () => {}
+  }
+}))
+
+vi.mock('./diff-navigation-context', () => ({
+  DiffNavigationProvider: (props: ProviderProps) => {
+    panelProbe.providerProps = props
+    return <div data-diff-navigation-provider>{props.children}</div>
+  }
+}))
+
+vi.mock('./EditorPanelShell', () => ({
+  EditorPanelShell: (props: { model: { isDiffSurface: boolean; isChangesMode: boolean } }) => {
+    panelProbe.shellProps = props
+    return <div data-editor-panel-shell />
+  }
+}))
+
+vi.mock('./useEditorPanelContentState', () => ({
+  useEditorPanelContentState: () => panelProbe.contentState
+}))
+
+import EditorPanel from './EditorPanel'
+
+const WORKTREE_ID = 'wt-1'
+const WORKTREE_ROOT = '/repo'
+const GROUP_ID = 'group-1'
+const initialAppState = useAppStore.getInitialState()
+let container: HTMLDivElement
+let root: Root
+
+const unstaged = (path: string): GitStatusEntry => ({ path, status: 'modified', area: 'unstaged' })
+const untracked = (path: string): GitStatusEntry => ({
+  path,
+  status: 'untracked',
+  area: 'untracked'
+})
+const deleted = (path: string): GitStatusEntry => ({ path, status: 'deleted', area: 'unstaged' })
+
+function makeOpenFile(relativePath = 'src/a.ts', overrides: Partial<OpenFile> = {}): OpenFile {
+  const filePath = `${WORKTREE_ROOT}/${relativePath}`
+  return {
+    id: filePath,
+    filePath,
+    relativePath,
+    worktreeId: WORKTREE_ID,
+    language: 'typescript',
+    mode: 'edit',
+    isDirty: false,
+    ...overrides
+  }
+}
+
+function seedState(
+  activeFile: OpenFile,
+  entries: GitStatusEntry[],
+  extra: Partial<ReturnType<typeof useAppStore.getState>> = {}
+): void {
+  const { openFiles: extraOpenFiles, editorViewMode: extraEditorViewMode, ...restExtra } = extra
+  const editorViewMode = extraEditorViewMode
+    ? { [activeFile.id]: 'changes', ...extraEditorViewMode }
+    : { [activeFile.id]: 'changes' }
+  useAppStore.setState(initialAppState, true)
+  useAppStore.setState({
+    openFiles: extraOpenFiles ? [activeFile, ...extraOpenFiles] : [activeFile],
+    activeFileId: activeFile.id,
+    activeFileIdByWorktree: { [WORKTREE_ID]: activeFile.id },
+    activeTabType: 'editor',
+    activeTabTypeByWorktree: { [WORKTREE_ID]: 'editor' },
+    editorViewMode,
+    gitStatusByWorktree: { [WORKTREE_ID]: entries },
+    groupsByWorktree: {
+      [WORKTREE_ID]: [{ id: GROUP_ID, worktreeId: WORKTREE_ID, activeTabId: null, tabOrder: [] }]
+    },
+    activeGroupIdByWorktree: { [WORKTREE_ID]: GROUP_ID },
+    worktreesByRepo: {
+      repo: [
+        {
+          id: WORKTREE_ID,
+          repoId: 'repo',
+          path: WORKTREE_ROOT,
+          displayName: 'repo'
+        }
+      ]
+    },
+    ...restExtra
+  } as Partial<ReturnType<typeof useAppStore.getState>>)
+}
+
+async function renderPanel(): Promise<void> {
+  await act(async () => root.render(<EditorPanel />))
+}
+
+describe('EditorPanel worktree diff file navigation', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    panelProbe.providerProps = null
+    panelProbe.shellProps = null
+    panelProbe.contentState = { fileContents: {}, diffContents: {}, reloadContent: () => {} }
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+    panelProbe.providerProps = null
+    panelProbe.shellProps = null
+  })
+
+  it('opens an unopened unstaged candidate in Changes mode in the active group', async () => {
+    const activeFile = makeOpenFile('src/a.ts')
+    seedState(activeFile, [unstaged('src/a.ts'), unstaged('src/b.ts')])
+    await renderPanel()
+
+    const navigated = panelProbe.providerProps?.onNavigateFile?.('next')
+
+    expect(navigated).toBe(true)
+    const opened = useAppStore.getState().openFiles.find((file) => file.relativePath === 'src/b.ts')
+    expect(opened).toEqual(
+      expect.objectContaining({
+        id: '/repo/src/b.ts',
+        filePath: '/repo/src/b.ts',
+        relativePath: 'src/b.ts',
+        worktreeId: WORKTREE_ID,
+        language: 'typescript',
+        mode: 'edit'
+      })
+    )
+    expect(useAppStore.getState().editorViewMode['/repo/src/b.ts']).toBe('changes')
+    expect(useAppStore.getState().activeGroupIdByWorktree[WORKTREE_ID]).toBe(GROUP_ID)
+  })
+
+  it('reuses an existing edit tab and selects Changes mode', async () => {
+    const activeFile = makeOpenFile('src/a.ts')
+    const existing = makeOpenFile('src/b.ts')
+    seedState(activeFile, [unstaged('src/a.ts'), unstaged('src/b.ts')], {
+      openFiles: [existing],
+      editorViewMode: { [existing.id]: 'edit' }
+    })
+    await renderPanel()
+
+    expect(panelProbe.providerProps?.onNavigateFile?.('next')).toBe(true)
+
+    const state = useAppStore.getState()
+    expect(state.openFiles.filter((file) => file.relativePath === 'src/b.ts')).toHaveLength(1)
+    expect(state.activeFileId).toBe(existing.id)
+    expect(state.editorViewMode[existing.id]).toBe('changes')
+  })
+
+  it('skips staged-only paths', async () => {
+    const activeFile = makeOpenFile('src/a.ts')
+    seedState(activeFile, [
+      unstaged('src/a.ts'),
+      { path: 'src/staged-only.ts', status: 'modified', area: 'staged' },
+      unstaged('src/z.ts')
+    ])
+    await renderPanel()
+
+    expect(panelProbe.providerProps?.onNavigateFile?.('next')).toBe(true)
+
+    expect(useAppStore.getState().activeFileId).toBe('/repo/src/z.ts')
+  })
+
+  it('opens an untracked target in Changes mode', async () => {
+    const activeFile = makeOpenFile('src/a.ts')
+    seedState(activeFile, [unstaged('src/a.ts'), untracked('src/new.ts')])
+    await renderPanel()
+
+    expect(panelProbe.providerProps?.onNavigateFile?.('next')).toBe(true)
+
+    expect(useAppStore.getState().openFiles.find((file) => file.relativePath === 'src/new.ts')).toEqual(
+      expect.objectContaining({ mode: 'edit', language: 'typescript' })
+    )
+    expect(useAppStore.getState().editorViewMode['/repo/src/new.ts']).toBe('changes')
+  })
+
+  it('opens deleted unstaged targets as unstaged single-file diffs', async () => {
+    const activeFile = makeOpenFile('src/a.ts')
+    seedState(activeFile, [unstaged('src/a.ts'), deleted('src/deleted.ts')])
+    await renderPanel()
+
+    expect(panelProbe.providerProps?.onNavigateFile?.('next')).toBe(true)
+
+    expect(useAppStore.getState().activeFileId).toBe(
+      `${WORKTREE_ID}::diff::unstaged::src/deleted.ts`
+    )
+    expect(useAppStore.getState().openFiles.find((file) => file.relativePath === 'src/deleted.ts')).toEqual(
+      expect.objectContaining({ mode: 'diff', diffSource: 'unstaged' })
+    )
+  })
+
+  it('returns false when there is no second candidate', async () => {
+    const activeFile = makeOpenFile('src/a.ts')
+    seedState(activeFile, [unstaged('src/a.ts')])
+    await renderPanel()
+
+    expect(panelProbe.providerProps?.canNavigateFile).toBe(false)
+    expect(panelProbe.providerProps?.onNavigateFile?.('next')).toBe(false)
+  })
+
+  it('uses the resolver insertion fallback when an unstaged diff path disappeared', async () => {
+    const activeFile = makeOpenFile('src/b.ts', {
+      id: `${WORKTREE_ID}::diff::unstaged::src/b.ts`,
+      mode: 'diff',
+      diffSource: 'unstaged'
+    })
+    seedState(activeFile, [unstaged('src/a.ts'), unstaged('src/c.ts'), unstaged('src/d.ts')], {
+      editorViewMode: {}
+    })
+    await renderPanel()
+
+    expect(panelProbe.providerProps?.onNavigateFile?.('next')).toBe(true)
+
+    expect(useAppStore.getState().activeFileId).toBe('/repo/src/c.ts')
+  })
+
+  it('does not enable file-boundary navigation for staged-only Changes-mode edit tabs', async () => {
+    const activeFile = makeOpenFile('src/staged-only.ts')
+    seedState(activeFile, [
+      { path: 'src/staged-only.ts', status: 'modified', area: 'staged' },
+      unstaged('src/z.ts')
+    ])
+    await renderPanel()
+
+    expect(panelProbe.providerProps?.canNavigateFile).toBe(false)
+    expect(panelProbe.providerProps?.onNavigateFile).toBeUndefined()
+  })
+
+  it('keeps file-boundary controls available for binary eligible Changes-mode edit tabs', async () => {
+    const activeFile = makeOpenFile('src/image.bin', { language: 'plaintext' })
+    panelProbe.contentState = {
+      fileContents: { [activeFile.id]: { content: '', isBinary: true } },
+      diffContents: {},
+      reloadContent: () => {}
+    }
+    seedState(activeFile, [unstaged('src/image.bin'), unstaged('src/next.ts')])
+    await renderPanel()
+
+    expect(panelProbe.providerProps?.canNavigateFile).toBe(true)
+    expect(panelProbe.providerProps?.onNavigateFile?.('next')).toBe(true)
+    expect(panelProbe.shellProps?.model.isDiffSurface).toBe(true)
+    expect(panelProbe.shellProps?.model.isChangesMode).toBe(false)
+    expect(useAppStore.getState().activeFileId).toBe('/repo/src/next.ts')
+  })
+
+  it('does not enable file-boundary navigation for staged diff tabs', async () => {
+    const activeFile = makeOpenFile('src/a.ts', {
+      id: `${WORKTREE_ID}::diff::staged::src/a.ts`,
+      mode: 'diff',
+      diffSource: 'staged'
+    })
+    seedState(activeFile, [unstaged('src/a.ts'), unstaged('src/b.ts')], {
+      editorViewMode: {}
+    })
+    await renderPanel()
+
+    expect(panelProbe.providerProps?.canNavigateFile).toBe(false)
+    expect(panelProbe.providerProps?.onNavigateFile).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -26,6 +26,8 @@ import {
 import { createEditorPanelDraftSelector } from './editor-panel-draft-selector'
 import { createCurrentMarkdownArtifactRequest } from './markdown-artifact-upload'
 import { useEditorPanelSave } from './useEditorPanelSave'
+import { useWorktreeDiffFileNavigation } from './useWorktreeDiffFileNavigation'
+import { useDiffSideBySideDefault } from './useDiffSideBySideDefault'
 
 function EditorPanelInner({
   activeFileId: activeFileIdProp,
@@ -106,15 +108,7 @@ function EditorPanelInner({
     },
     [clearCopiedPathToastResetTimer]
   )
-  const [sideBySide, setSideBySide] = useState(settings?.diffDefaultView === 'side-by-side')
-  const [prevDiffView, setPrevDiffView] = useState(settings?.diffDefaultView)
-
-  if (settings?.diffDefaultView !== prevDiffView) {
-    setPrevDiffView(settings?.diffDefaultView)
-    if (settings?.diffDefaultView !== undefined) {
-      setSideBySide(settings.diffDefaultView === 'side-by-side')
-    }
-  }
+  const [sideBySide, setSideBySide] = useDiffSideBySideDefault(settings?.diffDefaultView)
 
   const requestedChangesMode =
     !!activeFile &&
@@ -168,6 +162,11 @@ function EditorPanelInner({
     openFiles,
     requestRenameForFile
   })
+  const {
+    canNavigateWorktreeFile,
+    handleNavigateWorktreeFile,
+    isWorktreeFileNavigationSurface
+  } = useWorktreeDiffFileNavigation({ activeFile, gitStatusEntries, requestedChangesMode })
   useEditorCmdSaveRequest({
     activeFile,
     openFiles,
@@ -217,6 +216,7 @@ function EditorPanelInner({
     markdownViewMode,
     markdownRichModeSizeOverridden,
     isChangesMode,
+    hasWorktreeDiffNavigation: canNavigateWorktreeFile,
     canOpenWorkspaceFileBrowser
   })
 
@@ -334,7 +334,12 @@ function EditorPanelInner({
 
   return (
     // Why: each split pane needs an isolated bridge between its diff editor and header controls.
-    <DiffNavigationProvider>
+    <DiffNavigationProvider
+      canNavigateFile={canNavigateWorktreeFile}
+      onNavigateFile={
+        isWorktreeFileNavigationSurface ? handleNavigateWorktreeFile : undefined
+      }
+    >
       <EditorPanelShell
         panelRef={setPanelRef}
         activeFile={activeFile}

--- a/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
@@ -46,12 +46,17 @@ vi.mock('@/components/artifacts/ArtifactPublishButton', () => ({
   ArtifactPublishButton: () => <button data-artifact-publish />
 }))
 
-vi.mock('./diff-navigation-context', () => ({
-  useDiffNavigation: () => ({
+const diffNavigationMock = vi.hoisted(() => ({
+  value: {
     changeCount: 2,
+    canNavigate: true,
     goToPreviousDiff: vi.fn(),
     goToNextDiff: vi.fn()
-  })
+  }
+}))
+
+vi.mock('./diff-navigation-context', () => ({
+  useDiffNavigation: () => diffNavigationMock.value
 }))
 
 const activeFile: OpenFile = {
@@ -103,6 +108,19 @@ function renderHeader(overrides: Partial<ComponentProps<typeof EditorPanelHeader
 }
 
 describe('EditorPanelHeader', () => {
+  it('enables diff arrows when file-boundary navigation is available', () => {
+    diffNavigationMock.value = {
+      changeCount: 0,
+      canNavigate: true,
+      goToPreviousDiff: vi.fn(),
+      goToNextDiff: vi.fn()
+    }
+    expect(renderHeader()).not.toContain('disabled=""')
+
+    diffNavigationMock.value = { ...diffNavigationMock.value, canNavigate: false }
+    expect(renderHeader()).toContain('disabled=""')
+  })
+
   it('shares one tooltip provider across the diff header controls', () => {
     const html = renderHeader()
 

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -103,7 +103,7 @@ export function EditorPanelHeader({
     () => diffComments.filter((comment) => comment.filePath === activeFile.relativePath),
     [activeFile.relativePath, diffComments]
   )
-  const { changeCount, goToPreviousDiff, goToNextDiff } = useDiffNavigation()
+  const { canNavigate, goToPreviousDiff, goToNextDiff } = useDiffNavigation()
   const previousChangeShortcut = useShortcutKeyDetails('editor.previousChange')
   const nextChangeShortcut = useShortcutKeyDetails('editor.nextChange')
 
@@ -227,7 +227,7 @@ export function EditorPanelHeader({
                   'auto.components.editor.EditorPanelHeader.2076ecfc9c',
                   'Previous change'
                 )}
-                disabled={changeCount === 0}
+                disabled={!canNavigate}
               >
                 <ArrowUp size={14} />
               </button>
@@ -253,7 +253,7 @@ export function EditorPanelHeader({
                   'auto.components.editor.EditorPanelHeader.631dab0df3',
                   'Next change'
                 )}
-                disabled={changeCount === 0}
+                disabled={!canNavigate}
               >
                 <ArrowDown size={14} />
               </button>

--- a/src/renderer/src/components/editor/EditorPanelShell.diff-navigation-shortcut.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.diff-navigation-shortcut.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import { EditorPanelShell } from './EditorPanelShell'
+
+const navigationMock = vi.hoisted(() => ({
+  goToNextDiff: vi.fn(),
+  goToPreviousDiff: vi.fn()
+}))
+
+vi.mock('./diff-navigation-context', () => ({
+  useDiffNavigation: () => navigationMock
+}))
+
+vi.mock('./EditorPanelHeader', () => ({
+  EditorPanelHeader: () => <button type="button">header</button>
+}))
+
+vi.mock('./EditorContent', () => ({
+  EditorContent: () => <div data-editor-content tabIndex={0} />
+}))
+
+vi.mock('./UntitledFileRenameDialog', () => ({
+  UntitledFileRenameDialog: () => null
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: Record<string, unknown>) => unknown) => selector({ worktreesByRepo: {}, keybindings: {} }),
+    { getState: () => ({ worktreesByRepo: {}, keybindings: {} }) }
+  )
+}))
+
+function openFile(): OpenFile {
+  return {
+    id: '/repo/src/image.bin',
+    filePath: '/repo/src/image.bin',
+    relativePath: 'src/image.bin',
+    worktreeId: 'wt-1',
+    language: 'plaintext',
+    mode: 'edit'
+  } as OpenFile
+}
+
+function model(overrides: Partial<Record<string, unknown>> = {}): never {
+  return {
+    isCombinedDiff: false,
+    isSingleDiff: false,
+    isDiffSurface: true,
+    isChangesMode: false,
+    hasWorktreeDiffNavigation: true,
+    isMarkdown: false,
+    isMermaid: false,
+    isCsv: false,
+    isNotebook: false,
+    hasEditorToggle: false,
+    availableEditorToggleModes: [],
+    effectiveToggleValue: 'edit',
+    canOpenPreviewToSide: false,
+    canShowMarkdownPreview: false,
+    canShowMarkdownTableOfContents: false,
+    isMarkdownTableOfContentsDisabled: false,
+    shouldShowMarkdownExportAction: false,
+    canExportMarkdownToPdf: false,
+    openFileState: { canOpen: false },
+    worktreeEntries: [],
+    resolvedLanguage: 'plaintext',
+    mdViewMode: 'rich',
+    ...overrides
+  } as never
+}
+
+function renderShell(shellModel = model()): { root: Root; container: HTMLDivElement } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  const file = openFile()
+  const noop = (): void => {}
+  act(() => {
+    root.render(
+      <EditorPanelShell
+        panelRef={null}
+        activeFile={file}
+        activeViewStateId={file.id}
+        model={shellModel}
+        copiedPathVisible={false}
+        showMarkdownTableOfContents={false}
+        canShowMarkdownFrontmatterToggle={false}
+        markdownFrontmatterVisible={false}
+        sideBySide={false}
+        openFiles={[file]}
+        fileContents={{}}
+        diffContents={{}}
+        editorDrafts={{}}
+        pendingEditorReveal={null}
+        renameDialogFile={null}
+        renameError={null}
+        disableRenameBrowse={false}
+        onCopyPath={noop}
+        onOpenDiffTargetFile={noop}
+        onOpenPreviewToSide={noop}
+        onOpenMarkdownPreview={noop}
+        onOpenContainingFolder={noop}
+        onToggleSideBySide={noop}
+        onEditorToggleChange={noop}
+        onToggleMarkdownTableOfContents={noop}
+        onToggleMarkdownFrontmatter={noop}
+        onExportMarkdownToPdf={noop}
+        onContentChange={noop}
+        onContentChangeForFile={noop}
+        onDirtyStateHint={noop}
+        onSave={async () => true}
+        onSaveForFile={async () => true}
+        onReloadContent={noop}
+        onCloseMarkdownTableOfContents={noop}
+        onCloseRenameDialog={noop}
+        onRenameConfirm={async () => {}}
+        markdownAnnotationsEnabled={false}
+      />
+    )
+  })
+  return { root, container }
+}
+
+describe('EditorPanelShell worktree diff navigation shortcut fallback', () => {
+  let mounted: { root: Root; container: HTMLDivElement } | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    navigationMock.goToNextDiff.mockReset()
+    navigationMock.goToPreviousDiff.mockReset()
+  })
+
+  afterEach(() => {
+    if (mounted) {
+      act(() => mounted?.root.unmount())
+      mounted.container.remove()
+    }
+    mounted = null
+  })
+
+  it('routes F7 and Shift+F7 through diff navigation when no Monaco diff editor is mounted', () => {
+    mounted = renderShell()
+    const target = mounted.container.firstElementChild as HTMLElement
+
+    const nextEvent = new KeyboardEvent('keydown', { key: 'F7', bubbles: true, cancelable: true })
+    target.dispatchEvent(nextEvent)
+    expect(nextEvent.defaultPrevented).toBe(true)
+    expect(navigationMock.goToNextDiff).toHaveBeenCalledOnce()
+
+    const previousEvent = new KeyboardEvent('keydown', {
+      key: 'F7',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    target.dispatchEvent(previousEvent)
+    expect(previousEvent.defaultPrevented).toBe(true)
+    expect(navigationMock.goToPreviousDiff).toHaveBeenCalledOnce()
+  })
+
+  it('does not install the fallback shortcut while a Monaco changes diff is mounted', () => {
+    mounted = renderShell(model({ isChangesMode: true }))
+    const target = mounted.container.firstElementChild as HTMLElement
+
+    const event = new KeyboardEvent('keydown', { key: 'F7', bubbles: true, cancelable: true })
+    target.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(navigationMock.goToNextDiff).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -1,4 +1,4 @@
-import { Suspense, type JSX, type Ref } from 'react'
+import { Suspense, useCallback, useEffect, useState, type JSX, type Ref } from 'react'
 import { useAppStore } from '@/store'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import type { OpenFile } from '@/store/slices/editor'
@@ -12,8 +12,20 @@ import { shouldShowEditorPanelHeader } from './editor-header'
 import { getUntitledFileRoot } from './untitled-file-rename-path'
 import { translate } from '@/i18n/i18n'
 import type { ArtifactWriteRequest } from '../../../../shared/artifacts'
+import { installMonacoDiffChangeNavigationShortcut } from './editor-shortcuts'
+import { useDiffNavigation } from './diff-navigation-context'
 
 type EditorPanelRenderModel = ReturnType<typeof getEditorPanelRenderModel>
+
+function assignPanelRef(ref: Ref<HTMLDivElement>, node: HTMLDivElement | null): void {
+  if (typeof ref === 'function') {
+    ref(node)
+    return
+  }
+  if (ref) {
+    ref.current = node
+  }
+}
 
 type EditorPanelShellProps = {
   panelRef: Ref<HTMLDivElement>
@@ -96,8 +108,34 @@ export function EditorPanelShell({
   onRenameConfirm,
   markdownAnnotationsEnabled
 }: EditorPanelShellProps): JSX.Element {
+  const [rootNode, setRootNode] = useState<HTMLDivElement | null>(null)
+  const { goToNextDiff, goToPreviousDiff } = useDiffNavigation()
+  const setRootRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      assignPanelRef(panelRef, node)
+      setRootNode(node)
+    },
+    [panelRef]
+  )
+
+  useEffect(() => {
+    if (!rootNode || !model.hasWorktreeDiffNavigation || model.isChangesMode) {
+      return
+    }
+    return installMonacoDiffChangeNavigationShortcut({
+      getContainerDomNode: () => rootNode,
+      navigate: (direction) => {
+        if (direction === 'next') {
+          goToNextDiff()
+        } else {
+          goToPreviousDiff()
+        }
+      }
+    })
+  }, [goToNextDiff, goToPreviousDiff, model.hasWorktreeDiffNavigation, model.isChangesMode, rootNode])
+
   return (
-    <div ref={panelRef} className="flex flex-col flex-1 min-w-0 min-h-0">
+    <div ref={setRootRef} className="flex flex-col flex-1 min-w-0 min-h-0">
       {shouldShowEditorPanelHeader(activeFile, model.isCombinedDiff) && (
         <EditorPanelHeader
           activeFile={activeFile}
@@ -150,7 +188,7 @@ export function EditorPanelShell({
           isNotebook={model.isNotebook}
           mdViewMode={model.mdViewMode}
           inlineMarkdownRenderState={model.inlineMarkdownRenderState}
-          isChangesMode={model.isDiffSurface && !model.isSingleDiff}
+          isChangesMode={model.isChangesMode}
           sideBySide={sideBySide}
           pendingEditorReveal={pendingEditorReveal}
           handleContentChange={onContentChange}

--- a/src/renderer/src/components/editor/diff-navigation-context.test.tsx
+++ b/src/renderer/src/components/editor/diff-navigation-context.test.tsx
@@ -10,25 +10,41 @@ import {
   type DiffEditorRegistrationContextValue,
   type DiffNavigationContextValue
 } from './diff-navigation-context'
+import type { WorktreeDiffNavigationDirection } from './worktree-diff-file-navigation'
+
+type FakeLineChange = {
+  modifiedStartLineNumber: number
+  modifiedEndLineNumber: number
+}
 
 type FakeDiffEditor = editor.IStandaloneDiffEditor & {
-  setLineChanges: (count: number) => void
+  setLineChanges: (changes: number | FakeLineChange[]) => void
+  setPosition: (position: { lineNumber: number; column: number } | null) => void
   fireUpdate: () => void
   goToDiff: ReturnType<typeof vi.fn>
   disposeUpdate: ReturnType<typeof vi.fn>
   containerNode: HTMLElement
 }
 
-function createFakeEditor(initialCount: number): FakeDiffEditor {
-  let count = initialCount
+function makeLineChanges(count: number): FakeLineChange[] {
+  return Array.from({ length: count }, (_, index) => ({
+    modifiedStartLineNumber: 10 + index * 10,
+    modifiedEndLineNumber: 10 + index * 10
+  }))
+}
+
+function createFakeEditor(initialChanges: number | FakeLineChange[]): FakeDiffEditor {
+  let changes = Array.isArray(initialChanges) ? initialChanges : makeLineChanges(initialChanges)
+  let position: { lineNumber: number; column: number } | null = { lineNumber: 1, column: 1 }
   let updateCallback: (() => void) | null = null
   const disposeUpdate = vi.fn(() => {
     updateCallback = null
   })
   const containerNode = document.createElement('div')
-  const editor = {
-    getLineChanges: () => (count > 0 ? Array.from({ length: count }, () => ({})) : []),
+  const diffEditor = {
+    getLineChanges: () => changes,
     goToDiff: vi.fn(),
+    getModifiedEditor: () => ({ getPosition: () => position }),
     getContainerDomNode: () => containerNode,
     onDidUpdateDiff: (cb: () => void) => {
       updateCallback = cb
@@ -36,14 +52,17 @@ function createFakeEditor(initialCount: number): FakeDiffEditor {
         dispose: disposeUpdate
       }
     },
-    setLineChanges: (next: number) => {
-      count = next
+    setLineChanges: (next: number | FakeLineChange[]) => {
+      changes = Array.isArray(next) ? next : makeLineChanges(next)
+    },
+    setPosition: (next: { lineNumber: number; column: number } | null) => {
+      position = next
     },
     fireUpdate: () => updateCallback?.(),
     disposeUpdate,
     containerNode
   } as unknown as FakeDiffEditor
-  return editor
+  return diffEditor
 }
 
 let captured: DiffNavigationContextValue | null = null
@@ -65,13 +84,16 @@ describe('DiffNavigationProvider', () => {
   let container: HTMLDivElement | null = null
   let root: Root | null = null
 
-  function mount(): void {
+  function mount(props: {
+    canNavigateFile?: boolean
+    onNavigateFile?: (direction: WorktreeDiffNavigationDirection) => boolean
+  } = {}): void {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
     act(() => {
       root?.render(
-        <DiffNavigationProvider>
+        <DiffNavigationProvider {...props}>
           <Probe />
           <RegistrationProbe />
         </DiffNavigationProvider>
@@ -97,12 +119,144 @@ describe('DiffNavigationProvider', () => {
     act(() => registration?.registerDiffEditor(editor))
 
     expect(captured?.changeCount).toBe(3)
+    expect(captured?.canNavigate).toBe(true)
 
     act(() => captured?.goToNextDiff())
     expect(editor.goToDiff).toHaveBeenCalledWith('next')
 
+    editor.setPosition({ lineNumber: 99, column: 1 })
     act(() => captured?.goToPreviousDiff())
     expect(editor.goToDiff).toHaveBeenCalledWith('previous')
+  })
+
+  it('hands next navigation to a file callback after the last hunk', () => {
+    const onNavigateFile = vi.fn(() => true)
+    mount({ canNavigateFile: true, onNavigateFile })
+    const editor = createFakeEditor([
+      { modifiedStartLineNumber: 10, modifiedEndLineNumber: 10 },
+      { modifiedStartLineNumber: 20, modifiedEndLineNumber: 20 }
+    ])
+    act(() => registration?.registerDiffEditor(editor))
+
+    act(() => captured?.goToNextDiff())
+    expect(editor.goToDiff).toHaveBeenCalledWith('next')
+    expect(onNavigateFile).not.toHaveBeenCalled()
+
+    editor.setPosition({ lineNumber: 99, column: 1 })
+    act(() => captured?.goToNextDiff())
+    expect(onNavigateFile).toHaveBeenCalledWith('next')
+  })
+
+  it('hands previous navigation to a file callback before the first hunk', () => {
+    const onNavigateFile = vi.fn(() => true)
+    mount({ canNavigateFile: true, onNavigateFile })
+    const editor = createFakeEditor([{ modifiedStartLineNumber: 10, modifiedEndLineNumber: 10 }])
+    act(() => registration?.registerDiffEditor(editor))
+
+    act(() => captured?.goToPreviousDiff())
+
+    expect(onNavigateFile).toHaveBeenCalledWith('previous')
+    expect(editor.goToDiff).not.toHaveBeenCalled()
+  })
+
+  it('hands off immediately when the registered diff has no text hunks', () => {
+    const onNavigateFile = vi.fn(() => true)
+    mount({ canNavigateFile: true, onNavigateFile })
+    const editor = createFakeEditor(0)
+    act(() => registration?.registerDiffEditor(editor))
+
+    expect(captured?.changeCount).toBe(0)
+    expect(captured?.canNavigate).toBe(true)
+    act(() => captured?.goToNextDiff())
+
+    expect(onNavigateFile).toHaveBeenCalledWith('next')
+    expect(editor.goToDiff).not.toHaveBeenCalled()
+  })
+
+  it('does not move the current editor when the file callback cannot navigate', () => {
+    const onNavigateFile = vi.fn(() => false)
+    mount({ canNavigateFile: true, onNavigateFile })
+    const editor = createFakeEditor([{ modifiedStartLineNumber: 10, modifiedEndLineNumber: 10 }])
+    editor.setPosition({ lineNumber: 99, column: 1 })
+    act(() => registration?.registerDiffEditor(editor))
+
+    act(() => captured?.goToNextDiff())
+
+    expect(onNavigateFile).toHaveBeenCalledWith('next')
+    expect(editor.goToDiff).not.toHaveBeenCalled()
+  })
+
+  it('reveals pending next navigation after the replacement editor updates', () => {
+    const onNavigateFile = vi.fn(() => true)
+    mount({ canNavigateFile: true, onNavigateFile })
+    const oldEditor = createFakeEditor([{ modifiedStartLineNumber: 10, modifiedEndLineNumber: 10 }])
+    oldEditor.setPosition({ lineNumber: 99, column: 1 })
+    act(() => registration?.registerDiffEditor(oldEditor))
+    act(() => captured?.goToNextDiff())
+
+    const newEditor = createFakeEditor(0)
+    act(() => registration?.registerDiffEditor(newEditor))
+    expect(newEditor.goToDiff).not.toHaveBeenCalled()
+
+    act(() => {
+      newEditor.setLineChanges(2)
+      newEditor.fireUpdate()
+    })
+
+    expect(newEditor.goToDiff).toHaveBeenCalledOnce()
+    expect(newEditor.goToDiff).toHaveBeenCalledWith('next')
+    act(() => newEditor.fireUpdate())
+    expect(newEditor.goToDiff).toHaveBeenCalledOnce()
+  })
+
+  it('reveals pending previous navigation after the replacement editor updates', () => {
+    const onNavigateFile = vi.fn(() => true)
+    mount({ canNavigateFile: true, onNavigateFile })
+    const oldEditor = createFakeEditor([{ modifiedStartLineNumber: 10, modifiedEndLineNumber: 10 }])
+    act(() => registration?.registerDiffEditor(oldEditor))
+    act(() => captured?.goToPreviousDiff())
+
+    const newEditor = createFakeEditor(0)
+    act(() => registration?.registerDiffEditor(newEditor))
+    act(() => {
+      newEditor.setLineChanges(2)
+      newEditor.fireUpdate()
+    })
+
+    expect(newEditor.goToDiff).toHaveBeenCalledWith('previous')
+  })
+
+  it('reveals pending navigation when the replacement editor is already computed at registration', () => {
+    const onNavigateFile = vi.fn(() => true)
+    mount({ canNavigateFile: true, onNavigateFile })
+    const oldEditor = createFakeEditor([{ modifiedStartLineNumber: 10, modifiedEndLineNumber: 10 }])
+    oldEditor.setPosition({ lineNumber: 99, column: 1 })
+    act(() => registration?.registerDiffEditor(oldEditor))
+    act(() => captured?.goToNextDiff())
+
+    const newEditor = createFakeEditor(2)
+    act(() => registration?.registerDiffEditor(newEditor))
+
+    expect(newEditor.goToDiff).toHaveBeenCalledOnce()
+    expect(newEditor.goToDiff).toHaveBeenCalledWith('next')
+  })
+
+  it('clears pending reveal for a computed empty diff', () => {
+    const onNavigateFile = vi.fn(() => true)
+    mount({ canNavigateFile: true, onNavigateFile })
+    const oldEditor = createFakeEditor(0)
+    act(() => registration?.registerDiffEditor(oldEditor))
+    act(() => captured?.goToNextDiff())
+
+    const newEditor = createFakeEditor(0)
+    act(() => registration?.registerDiffEditor(newEditor))
+    act(() => newEditor.fireUpdate())
+    act(() => {
+      newEditor.setLineChanges(1)
+      newEditor.fireUpdate()
+    })
+
+    expect(newEditor.goToDiff).not.toHaveBeenCalled()
   })
 
   it('re-renders when onDidUpdateDiff flips the count 0 -> N (count is state)', () => {
@@ -110,12 +264,14 @@ describe('DiffNavigationProvider', () => {
     const editor = createFakeEditor(0)
     act(() => registration?.registerDiffEditor(editor))
     expect(captured?.changeCount).toBe(0)
+    expect(captured?.canNavigate).toBe(false)
 
     act(() => {
       editor.setLineChanges(2)
       editor.fireUpdate()
     })
     expect(captured?.changeCount).toBe(2)
+    expect(captured?.canNavigate).toBe(true)
     expect(registrationRenderCount).toBe(1)
   })
 

--- a/src/renderer/src/components/editor/diff-navigation-context.tsx
+++ b/src/renderer/src/components/editor/diff-navigation-context.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import type { editor } from 'monaco-editor'
 import { installMonacoDiffChangeNavigationShortcut } from './editor-shortcuts'
+import type { WorktreeDiffNavigationDirection } from './worktree-diff-file-navigation'
 
 export type DiffEditorRegistrationContextValue = {
   registerDiffEditor: (editor: editor.IStandaloneDiffEditor) => void
@@ -11,6 +12,20 @@ export type DiffNavigationContextValue = {
   goToPreviousDiff: () => void
   goToNextDiff: () => void
   changeCount: number
+  canNavigate: boolean
+}
+
+type DiffNavigationProviderProps = {
+  children: React.ReactNode
+  canNavigateFile?: boolean
+  onNavigateFile?: (direction: WorktreeDiffNavigationDirection) => boolean
+}
+
+type DiffLineChange = NonNullable<ReturnType<editor.IStandaloneDiffEditor['getLineChanges']>>[number]
+type LastInFileNavigation = {
+  editor: editor.IStandaloneDiffEditor
+  direction: WorktreeDiffNavigationDirection
+  lineNumber: number
 }
 
 const noop = (): void => {}
@@ -25,20 +40,95 @@ const DiffEditorRegistrationContext = createContext<DiffEditorRegistrationContex
 const DiffNavigationContext = createContext<DiffNavigationContextValue>({
   goToPreviousDiff: noop,
   goToNextDiff: noop,
-  changeCount: 0
+  changeCount: 0,
+  canNavigate: false
 })
 
 function countChanges(diffEditor: editor.IStandaloneDiffEditor): number {
   return diffEditor.getLineChanges()?.length ?? 0
 }
 
+function getModifiedStartLine(change: DiffLineChange): number {
+  return change.modifiedStartLineNumber || change.modifiedEndLineNumber
+}
+
+function getModifiedEndLine(change: DiffLineChange): number {
+  return change.modifiedEndLineNumber || change.modifiedStartLineNumber
+}
+
+function getRemainingChangeLine(
+  diffEditor: editor.IStandaloneDiffEditor,
+  direction: WorktreeDiffNavigationDirection,
+  lastNavigation: LastInFileNavigation | null
+): number | null {
+  const changes = diffEditor.getLineChanges() ?? []
+  if (changes.length === 0) {
+    return null
+  }
+  const positionLineNumber = diffEditor.getModifiedEditor().getPosition()?.lineNumber ?? null
+  const lineNumber = getEffectiveLineNumber(
+    diffEditor,
+    direction,
+    positionLineNumber,
+    lastNavigation
+  )
+  if (lineNumber === null) {
+    const edgeChange = direction === 'next' ? changes[0] : changes.at(-1)
+    return edgeChange ? getChangeLine(edgeChange, direction) : null
+  }
+  if (direction === 'next') {
+    return changes
+      .map((change) => getModifiedStartLine(change))
+      .find((changeLine) => changeLine > lineNumber) ?? null
+  }
+  for (let index = changes.length - 1; index >= 0; index -= 1) {
+    const changeLine = getModifiedEndLine(changes[index])
+    if (changeLine < lineNumber) {
+      return changeLine
+    }
+  }
+  return null
+}
+
+function getEffectiveLineNumber(
+  diffEditor: editor.IStandaloneDiffEditor,
+  direction: WorktreeDiffNavigationDirection,
+  positionLineNumber: number | null,
+  lastNavigation: LastInFileNavigation | null
+): number | null {
+  if (lastNavigation?.editor !== diffEditor || lastNavigation.direction !== direction) {
+    return positionLineNumber
+  }
+  if (positionLineNumber === null) {
+    return lastNavigation.lineNumber
+  }
+  if (direction === 'next' && positionLineNumber <= lastNavigation.lineNumber) {
+    return lastNavigation.lineNumber
+  }
+  if (direction === 'previous' && positionLineNumber >= lastNavigation.lineNumber) {
+    return lastNavigation.lineNumber
+  }
+  return positionLineNumber
+}
+
+function getChangeLine(
+  change: DiffLineChange,
+  direction: WorktreeDiffNavigationDirection
+): number {
+  return direction === 'next' ? getModifiedStartLine(change) : getModifiedEndLine(change)
+}
+
 export function DiffNavigationProvider({
-  children
-}: {
-  children: React.ReactNode
-}): React.JSX.Element {
+  children,
+  canNavigateFile = false,
+  onNavigateFile
+}: DiffNavigationProviderProps): React.JSX.Element {
   const editorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
   const updateSubRef = useRef<{ dispose: () => void } | null>(null)
+  const canNavigateFileRef = useRef(canNavigateFile)
+  const onNavigateFileRef = useRef<typeof onNavigateFile>(onNavigateFile)
+  const pendingRevealDirectionRef = useRef<WorktreeDiffNavigationDirection | null>(null)
+  const lastInFileNavigationRef = useRef<LastInFileNavigation | null>(null)
   // Why: F7/Shift+F7 change navigation shares the registered editor with the
   // header buttons, so the keyboard listener lives here rather than in DiffViewer.
   const shortcutCleanupRef = useRef<(() => void) | null>(null)
@@ -47,22 +137,69 @@ export function DiffNavigationProvider({
   // changes on the 0 -> N flip once the diff computation lands.
   const [changeCount, setChangeCount] = useState(0)
 
-  const registerDiffEditor = useCallback((diffEditor: editor.IStandaloneDiffEditor) => {
-    editorRef.current = diffEditor
-    // Hold at most one update subscription; replace any prior editor's.
-    updateSubRef.current?.dispose()
-    updateSubRef.current = diffEditor.onDidUpdateDiff(() => {
-      // Why: ignore updates from an editor that is no longer current so a stale
-      // subscription in the fast-swap case can't write a wrong count.
-      if (editorRef.current === diffEditor) {
-        setChangeCount(countChanges(diffEditor))
-      }
-    })
-    // Hold at most one keyboard listener; replace any prior editor's.
-    shortcutCleanupRef.current?.()
-    shortcutCleanupRef.current = installMonacoDiffChangeNavigationShortcut(diffEditor)
-    setChangeCount(countChanges(diffEditor))
+  canNavigateFileRef.current = canNavigateFile
+  onNavigateFileRef.current = onNavigateFile
+
+  const revealPendingDiff = useCallback((diffEditor: editor.IStandaloneDiffEditor) => {
+    const direction = pendingRevealDirectionRef.current
+    if (!direction) {
+      return
+    }
+    pendingRevealDirectionRef.current = null
+    if (countChanges(diffEditor) > 0) {
+      diffEditor.goToDiff(direction)
+    }
   }, [])
+
+  const navigate = useCallback((direction: WorktreeDiffNavigationDirection): void => {
+    const diffEditor = editorRef.current
+    if (diffEditor) {
+      const lineNumber = getRemainingChangeLine(
+        diffEditor,
+        direction,
+        lastInFileNavigationRef.current
+      )
+      if (lineNumber !== null) {
+        lastInFileNavigationRef.current = { editor: diffEditor, direction, lineNumber }
+        diffEditor.goToDiff(direction)
+        return
+      }
+    }
+    lastInFileNavigationRef.current = null
+    if (!canNavigateFileRef.current || !onNavigateFileRef.current?.(direction)) {
+      return
+    }
+    pendingRevealDirectionRef.current = direction
+  }, [])
+
+  const registerDiffEditor = useCallback(
+    (diffEditor: editor.IStandaloneDiffEditor) => {
+      editorRef.current = diffEditor
+      lastInFileNavigationRef.current = null
+      // Hold at most one update subscription; replace any prior editor's.
+      updateSubRef.current?.dispose()
+      updateSubRef.current = diffEditor.onDidUpdateDiff(() => {
+        // Why: ignore updates from an editor that is no longer current so a stale
+        // subscription in the fast-swap case can't write a wrong count.
+        if (editorRef.current === diffEditor) {
+          setChangeCount(countChanges(diffEditor))
+          revealPendingDiff(diffEditor)
+        }
+      })
+      // Hold at most one keyboard listener; replace any prior editor's.
+      shortcutCleanupRef.current?.()
+      shortcutCleanupRef.current = installMonacoDiffChangeNavigationShortcut({
+        getContainerDomNode: () => diffEditor.getContainerDomNode(),
+        navigate
+      })
+      const initialChangeCount = countChanges(diffEditor)
+      setChangeCount(initialChangeCount)
+      if (initialChangeCount > 0) {
+        revealPendingDiff(diffEditor)
+      }
+    },
+    [navigate, revealPendingDiff]
+  )
 
   const unregisterDiffEditor = useCallback((diffEditor: editor.IStandaloneDiffEditor) => {
     // Why: identity guard for the fast-swap race — a stale dispose carrying the
@@ -79,12 +216,12 @@ export function DiffNavigationProvider({
   }, [])
 
   const goToPreviousDiff = useCallback(() => {
-    editorRef.current?.goToDiff('previous')
-  }, [])
+    navigate('previous')
+  }, [navigate])
 
   const goToNextDiff = useCallback(() => {
-    editorRef.current?.goToDiff('next')
-  }, [])
+    navigate('next')
+  }, [navigate])
 
   useEffect(() => {
     return () => {
@@ -92,6 +229,8 @@ export function DiffNavigationProvider({
       updateSubRef.current = null
       shortcutCleanupRef.current?.()
       shortcutCleanupRef.current = null
+      pendingRevealDirectionRef.current = null
+      lastInFileNavigationRef.current = null
     }
   }, [])
 
@@ -99,13 +238,15 @@ export function DiffNavigationProvider({
     () => ({ registerDiffEditor, unregisterDiffEditor }),
     [registerDiffEditor, unregisterDiffEditor]
   )
+  const canNavigate = changeCount > 0 || canNavigateFile
   const navigationValue = useMemo(
     () => ({
       goToPreviousDiff,
       goToNextDiff,
-      changeCount
+      changeCount,
+      canNavigate
     }),
-    [goToPreviousDiff, goToNextDiff, changeCount]
+    [goToPreviousDiff, goToNextDiff, changeCount, canNavigate]
   )
 
   return (

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -26,6 +26,7 @@ type EditorPanelRenderModelParams = {
   markdownViewMode: StoreState['markdownViewMode']
   markdownRichModeSizeOverridden: boolean
   isChangesMode: boolean
+  hasWorktreeDiffNavigation?: boolean
   canOpenWorkspaceFileBrowser: boolean
 }
 
@@ -38,6 +39,7 @@ export function getEditorPanelRenderModel({
   markdownViewMode,
   markdownRichModeSizeOverridden,
   isChangesMode,
+  hasWorktreeDiffNavigation = false,
   canOpenWorkspaceFileBrowser
 }: EditorPanelRenderModelParams) {
   const isSingleDiff =
@@ -174,7 +176,9 @@ export function getEditorPanelRenderModel({
         activeFile.conflict?.conflictStatus !== 'unresolved'))
   return {
     isSingleDiff,
-    isDiffSurface: isSingleDiff || isChangesMode,
+    isChangesMode,
+    isDiffSurface: isSingleDiff || isChangesMode || hasWorktreeDiffNavigation,
+    hasWorktreeDiffNavigation,
     isCombinedDiff,
     worktreeEntries,
     resolvedLanguage,

--- a/src/renderer/src/components/editor/editor-shortcuts.test.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.test.ts
@@ -320,12 +320,12 @@ describe('installMonacoDiffChangeNavigationShortcut', () => {
     container: HTMLDivElement
     dispose: () => void
     input: HTMLTextAreaElement
-    goToDiff: ReturnType<typeof vi.fn>
+    navigate: ReturnType<typeof vi.fn>
     onDownstreamKeyDown: ReturnType<typeof vi.fn>
   } {
     const container = document.createElement('div')
     const input = document.createElement('textarea')
-    const goToDiff = vi.fn()
+    const navigate = vi.fn()
     const onDownstreamKeyDown = vi.fn()
     container.appendChild(input)
     document.body.appendChild(container)
@@ -335,10 +335,10 @@ describe('installMonacoDiffChangeNavigationShortcut', () => {
       container,
       dispose: installMonacoDiffChangeNavigationShortcut({
         getContainerDomNode: () => container,
-        goToDiff
+        navigate
       }),
       input,
-      goToDiff,
+      navigate,
       onDownstreamKeyDown
     }
   }
@@ -352,7 +352,7 @@ describe('installMonacoDiffChangeNavigationShortcut', () => {
     const event = dispatchKeyDown(fixture.input, { key, code: key, shiftKey })
 
     expect(event.defaultPrevented).toBe(true)
-    expect(fixture.goToDiff).toHaveBeenCalledWith(direction)
+    expect(fixture.navigate).toHaveBeenCalledWith(direction)
     expect(fixture.onDownstreamKeyDown).not.toHaveBeenCalled()
     fixture.dispose()
   })
@@ -367,7 +367,7 @@ describe('installMonacoDiffChangeNavigationShortcut', () => {
     })
 
     expect(event.defaultPrevented).toBe(true)
-    expect(fixture.goToDiff).not.toHaveBeenCalled()
+    expect(fixture.navigate).not.toHaveBeenCalled()
     expect(fixture.onDownstreamKeyDown).not.toHaveBeenCalled()
     fixture.dispose()
   })
@@ -392,7 +392,7 @@ describe('installMonacoDiffChangeNavigationShortcut', () => {
     expect(defaultEvent.defaultPrevented).toBe(false)
     expect(customEvent.defaultPrevented).toBe(true)
     expect(disposedEvent.defaultPrevented).toBe(false)
-    expect(fixture.goToDiff).toHaveBeenCalledTimes(1)
-    expect(fixture.goToDiff).toHaveBeenCalledWith('next')
+    expect(fixture.navigate).toHaveBeenCalledTimes(1)
+    expect(fixture.navigate).toHaveBeenCalledWith('next')
   })
 })

--- a/src/renderer/src/components/editor/editor-shortcuts.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.ts
@@ -48,7 +48,7 @@ export function installEditorFindShortcut(target: HTMLElement, onFind: () => voi
 
 type MonacoDiffNavigationEditor = {
   getContainerDomNode: () => HTMLElement
-  goToDiff: (target: 'next' | 'previous') => void
+  navigate: (target: 'next' | 'previous') => void
 }
 
 export function installMonacoDiffChangeNavigationShortcut(
@@ -70,7 +70,7 @@ export function installMonacoDiffChangeNavigationShortcut(
     event.stopPropagation()
     // Consume matched repeats but navigate once per press (matches find shortcut).
     if (!event.repeat) {
-      editor.goToDiff(direction)
+      editor.navigate(direction)
     }
   }
 

--- a/src/renderer/src/components/editor/useDiffSideBySideDefault.ts
+++ b/src/renderer/src/components/editor/useDiffSideBySideDefault.ts
@@ -1,0 +1,17 @@
+import { useState, type Dispatch, type SetStateAction } from 'react'
+
+export function useDiffSideBySideDefault(
+  diffDefaultView: 'side-by-side' | 'inline' | undefined
+): [boolean, Dispatch<SetStateAction<boolean>>] {
+  const [sideBySide, setSideBySide] = useState(diffDefaultView === 'side-by-side')
+  const [prevDiffView, setPrevDiffView] = useState(diffDefaultView)
+
+  if (diffDefaultView !== prevDiffView) {
+    setPrevDiffView(diffDefaultView)
+    if (diffDefaultView !== undefined) {
+      setSideBySide(diffDefaultView === 'side-by-side')
+    }
+  }
+
+  return [sideBySide, setSideBySide]
+}

--- a/src/renderer/src/components/editor/useWorktreeDiffFileNavigation.ts
+++ b/src/renderer/src/components/editor/useWorktreeDiffFileNavigation.ts
@@ -1,0 +1,124 @@
+import { useCallback, useMemo } from 'react'
+import { useAppStore } from '@/store'
+import { getWorktreeMapFromState } from '@/store/selectors'
+import type { OpenFile } from '@/store/slices/editor'
+import { detectLanguage } from '@/lib/language-detect'
+import { joinPath } from '@/lib/path'
+import type { GitStatusEntry } from '../../../../shared/git-status-types'
+import { resolveSourceControlGroupOrder } from '../right-sidebar/source-control/listing/section-order'
+import {
+  getAdjacentWorktreeDiffCandidate,
+  getWorktreeDiffNavigationCandidates,
+  type WorktreeDiffNavigationDirection
+} from './worktree-diff-file-navigation'
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function inferWorktreeRoot(filePath: string, relativePath: string): string | null {
+  const normalizedRelativePath = relativePath.replace(/[\\/]+/g, '/')
+  if (!normalizedRelativePath) {
+    return null
+  }
+  const relativePathPattern = normalizedRelativePath.split('/').map(escapeRegex).join('[\\\\/]')
+  const match = new RegExp(`[\\\\/]${relativePathPattern}$`).exec(filePath)
+  return match?.index === undefined ? null : filePath.slice(0, match.index)
+}
+
+export function useWorktreeDiffFileNavigation({
+  activeFile,
+  gitStatusEntries,
+  requestedChangesMode
+}: {
+  activeFile: OpenFile | null
+  gitStatusEntries: readonly GitStatusEntry[] | undefined
+  requestedChangesMode: boolean
+}): {
+  canNavigateWorktreeFile: boolean
+  handleNavigateWorktreeFile: (direction: WorktreeDiffNavigationDirection) => boolean
+  isWorktreeFileNavigationSurface: boolean
+} {
+  const activeWorktreeId = activeFile?.worktreeId
+  const activeWorktreeRoot = useAppStore((s) =>
+    activeWorktreeId ? (getWorktreeMapFromState(s).get(activeWorktreeId)?.path ?? null) : null
+  )
+  const activeEditorTargetGroupId = useAppStore((s) =>
+    activeWorktreeId
+      ? (s.activeGroupIdByWorktree[activeWorktreeId] ?? s.groupsByWorktree[activeWorktreeId]?.[0]?.id)
+      : undefined
+  )
+  const sourceControlGroupOrderSetting = useAppStore((s) => s.settings?.sourceControlGroupOrder)
+  const setEditorViewMode = useAppStore((s) => s.setEditorViewMode)
+  const openFile = useAppStore((s) => s.openFile)
+  const openDiff = useAppStore((s) => s.openDiff)
+  const sourceControlGroupOrder = useMemo(
+    () => resolveSourceControlGroupOrder(sourceControlGroupOrderSetting),
+    [sourceControlGroupOrderSetting]
+  )
+  const candidates = useMemo(
+    () => getWorktreeDiffNavigationCandidates(gitStatusEntries, sourceControlGroupOrder),
+    [gitStatusEntries, sourceControlGroupOrder]
+  )
+  const activeCandidate = activeFile
+    ? (candidates.find((candidate) => candidate.path === activeFile.relativePath) ?? null)
+    : null
+  const isUnstagedDiffSurface = Boolean(
+    activeFile?.mode === 'diff' && activeFile.diffSource === 'unstaged'
+  )
+  const isEligibleChangesSurface = Boolean(requestedChangesMode && activeCandidate)
+  const isWorktreeFileNavigationSurface = isUnstagedDiffSurface || isEligibleChangesSurface
+  const canNavigateWorktreeFile = isWorktreeFileNavigationSurface && candidates.length > 1
+  const handleNavigateWorktreeFile = useCallback(
+    (direction: WorktreeDiffNavigationDirection): boolean => {
+      if (!activeFile || !canNavigateWorktreeFile) {
+        return false
+      }
+      const candidate = getAdjacentWorktreeDiffCandidate({
+        candidates,
+        currentPath: activeFile.relativePath,
+        currentArea: activeCandidate?.area ?? 'unstaged',
+        direction
+      })
+      const worktreeRoot = activeWorktreeRoot ?? inferWorktreeRoot(activeFile.filePath, activeFile.relativePath)
+      if (!candidate || !worktreeRoot) {
+        return false
+      }
+      const filePath = joinPath(worktreeRoot, candidate.path)
+      const language = detectLanguage(candidate.path)
+      if (candidate.status === 'deleted') {
+        openDiff(activeFile.worktreeId, filePath, candidate.path, language, false, {
+          targetGroupId: activeEditorTargetGroupId,
+          runtimeEnvironmentId: activeFile.runtimeEnvironmentId
+        })
+        return true
+      }
+      const openedFileId = openFile(
+        {
+          filePath,
+          relativePath: candidate.path,
+          worktreeId: activeFile.worktreeId,
+          runtimeEnvironmentId: activeFile.runtimeEnvironmentId,
+          language,
+          mode: 'edit'
+        },
+        { targetGroupId: activeEditorTargetGroupId }
+      )
+      setEditorViewMode(openedFileId, 'changes')
+      return true
+    },
+    [
+      activeCandidate,
+      activeEditorTargetGroupId,
+      activeFile,
+      activeWorktreeRoot,
+      canNavigateWorktreeFile,
+      candidates,
+      openDiff,
+      openFile,
+      setEditorViewMode
+    ]
+  )
+
+  return { canNavigateWorktreeFile, handleNavigateWorktreeFile, isWorktreeFileNavigationSurface }
+}

--- a/src/renderer/src/components/editor/worktree-diff-file-navigation.test.ts
+++ b/src/renderer/src/components/editor/worktree-diff-file-navigation.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import type { GitStatusEntry } from '../../../../shared/git-status-types'
+import {
+  getAdjacentWorktreeDiffCandidate,
+  getWorktreeDiffNavigationCandidates
+} from './worktree-diff-file-navigation'
+
+const unstaged = (path: string): GitStatusEntry => ({
+  path,
+  status: 'modified',
+  area: 'unstaged'
+})
+const untracked = (path: string): GitStatusEntry => ({
+  path,
+  status: 'untracked',
+  area: 'untracked'
+})
+
+const deleted = (path: string): GitStatusEntry => ({ path, status: 'deleted', area: 'unstaged' })
+
+describe('worktree diff file navigation', () => {
+  it('keeps unstaged/untracked paths once, in Source Control order', () => {
+    const candidates = getWorktreeDiffNavigationCandidates([
+      { path: 'src/10.ts', status: 'modified', area: 'staged' },
+      unstaged('src/2.ts'),
+      unstaged('src/10.ts'),
+      untracked('src/new.ts')
+    ])
+
+    expect(candidates.map((candidate) => candidate.path)).toEqual([
+      'src/2.ts',
+      'src/10.ts',
+      'src/new.ts'
+    ])
+  })
+
+  it('excludes staged-only and unresolved-conflict entries', () => {
+    const candidates = getWorktreeDiffNavigationCandidates([
+      { path: 'src/staged.ts', status: 'modified', area: 'staged' },
+      { path: 'src/conflict.ts', status: 'modified', area: 'unstaged', conflictStatus: 'unresolved' },
+      unstaged('src/eligible.ts')
+    ])
+
+    expect(candidates.map((candidate) => candidate.path)).toEqual(['src/eligible.ts'])
+  })
+
+  it('retains untracked and deleted unstaged candidates in displayed section order', () => {
+    const candidates = getWorktreeDiffNavigationCandidates([
+      untracked('src/new.ts'),
+      deleted('src/removed.ts')
+    ])
+
+    expect(candidates).toEqual([
+      expect.objectContaining({ path: 'src/removed.ts', status: 'deleted', area: 'unstaged' }),
+      expect.objectContaining({ path: 'src/new.ts', status: 'untracked', area: 'untracked' })
+    ])
+  })
+
+  it('keeps all Changes entries before untracked entries when Source Control is changes-first', () => {
+    const candidates = getWorktreeDiffNavigationCandidates([
+      untracked('src/a-new.ts'),
+      unstaged('src/z-changed.ts'),
+      unstaged('src/b-changed.ts')
+    ])
+
+    expect(candidates.map((candidate) => candidate.path)).toEqual([
+      'src/b-changed.ts',
+      'src/z-changed.ts',
+      'src/a-new.ts'
+    ])
+  })
+
+  it('respects Source Control untracked-first section order', () => {
+    const candidates = getWorktreeDiffNavigationCandidates(
+      [unstaged('src/a-changed.ts'), untracked('src/z-new.ts'), untracked('src/b-new.ts')],
+      ['untracked', 'unstaged', 'staged']
+    )
+
+    expect(candidates.map((candidate) => candidate.path)).toEqual([
+      'src/b-new.ts',
+      'src/z-new.ts',
+      'src/a-changed.ts'
+    ])
+  })
+
+  it.each([
+    ['next', 'src/a.ts', 'src/b.ts'],
+    ['previous', 'src/a.ts', 'src/c.ts']
+  ] as const)('wraps %s from %s to %s', (direction, currentPath, expectedPath) => {
+    const candidates = getWorktreeDiffNavigationCandidates([
+      unstaged('src/a.ts'),
+      unstaged('src/b.ts'),
+      unstaged('src/c.ts')
+    ])
+
+    expect(getAdjacentWorktreeDiffCandidate({ candidates, currentPath, direction })?.path).toBe(
+      expectedPath
+    )
+  })
+
+  it('returns null when no candidate or no second candidate exists', () => {
+    expect(
+      getAdjacentWorktreeDiffCandidate({ candidates: [], currentPath: 'src/a.ts', direction: 'next' })
+    ).toBeNull()
+    expect(
+      getAdjacentWorktreeDiffCandidate({
+        candidates: getWorktreeDiffNavigationCandidates([unstaged('src/a.ts')]),
+        currentPath: 'src/a.ts',
+        direction: 'previous'
+      })
+    ).toBeNull()
+  })
+
+  it('selects next relative to the sorted insertion point when current path disappeared', () => {
+    const candidates = getWorktreeDiffNavigationCandidates([
+      unstaged('src/a.ts'),
+      unstaged('src/c.ts'),
+      unstaged('src/d.ts')
+    ])
+
+    expect(
+      getAdjacentWorktreeDiffCandidate({
+        candidates,
+        currentPath: 'src/b.ts',
+        direction: 'next'
+      })?.path
+    ).toBe('src/c.ts')
+  })
+
+  it('selects previous relative to the sorted insertion point when current path disappeared', () => {
+    const candidates = getWorktreeDiffNavigationCandidates([
+      unstaged('src/a.ts'),
+      unstaged('src/c.ts'),
+      unstaged('src/d.ts')
+    ])
+
+    expect(
+      getAdjacentWorktreeDiffCandidate({
+        candidates,
+        currentPath: 'src/b.ts',
+        direction: 'previous'
+      })?.path
+    ).toBe('src/a.ts')
+  })
+
+  it('uses the current area insertion point when a disappeared untracked path was active', () => {
+    const candidates = getWorktreeDiffNavigationCandidates(
+      [unstaged('src/a.ts'), untracked('src/c.ts'), untracked('src/e.ts')],
+      ['untracked', 'unstaged', 'staged']
+    )
+
+    expect(
+      getAdjacentWorktreeDiffCandidate({
+        candidates,
+        currentPath: 'src/d.ts',
+        currentArea: 'untracked',
+        direction: 'next'
+      })?.path
+    ).toBe('src/e.ts')
+  })
+})

--- a/src/renderer/src/components/editor/worktree-diff-file-navigation.ts
+++ b/src/renderer/src/components/editor/worktree-diff-file-navigation.ts
@@ -1,0 +1,118 @@
+import type { GitStatusEntry } from '../../../../shared/git-status-types'
+import { compareGitStatusEntries } from '../right-sidebar/source-control-status-sort'
+import {
+  SOURCE_CONTROL_AREAS,
+  type SourceControlSectionArea
+} from '../right-sidebar/source-control/listing/section-order'
+
+export type WorktreeDiffNavigationDirection = 'next' | 'previous'
+
+export type WorktreeDiffNavigationCandidate = Pick<
+  GitStatusEntry,
+  'path' | 'status' | 'oldPath' | 'conflictStatus'
+> & {
+  area: 'unstaged' | 'untracked'
+}
+
+type AdjacentCandidateArgs = {
+  candidates: readonly WorktreeDiffNavigationCandidate[]
+  currentPath: string
+  currentArea?: 'unstaged' | 'untracked'
+  direction: WorktreeDiffNavigationDirection
+}
+
+export function getWorktreeDiffNavigationCandidates(
+  entries: readonly GitStatusEntry[] | undefined,
+  sourceControlGroupOrder: readonly SourceControlSectionArea[] = SOURCE_CONTROL_AREAS
+): WorktreeDiffNavigationCandidate[] {
+  const groups: Record<'unstaged' | 'untracked', WorktreeDiffNavigationCandidate[]> = {
+    unstaged: [],
+    untracked: []
+  }
+  const seenPaths = new Set<string>()
+  for (const entry of entries ?? []) {
+    if (
+      (entry.area !== 'unstaged' && entry.area !== 'untracked') ||
+      entry.conflictStatus === 'unresolved' ||
+      seenPaths.has(entry.path)
+    ) {
+      continue
+    }
+    seenPaths.add(entry.path)
+    groups[entry.area].push({
+      path: entry.path,
+      status: entry.status,
+      area: entry.area,
+      oldPath: entry.oldPath,
+      conflictStatus: entry.conflictStatus
+    })
+  }
+  groups.unstaged.sort(compareGitStatusEntries)
+  groups.untracked.sort(compareGitStatusEntries)
+  return sourceControlGroupOrder.flatMap((area) =>
+    area === 'unstaged' || area === 'untracked' ? groups[area] : []
+  )
+}
+
+export function getAdjacentWorktreeDiffCandidate({
+  candidates,
+  currentPath,
+  currentArea = 'unstaged',
+  direction
+}: AdjacentCandidateArgs): WorktreeDiffNavigationCandidate | null {
+  if (candidates.length <= 1) {
+    return null
+  }
+
+  const currentIndex = candidates.findIndex((candidate) => candidate.path === currentPath)
+  if (currentIndex !== -1) {
+    return candidates[wrapIndex(currentIndex + (direction === 'next' ? 1 : -1), candidates.length)]
+  }
+
+  const insertionIndex = findInsertionIndex(candidates, currentPath, currentArea)
+  const targetIndex =
+    direction === 'next'
+      ? wrapIndex(insertionIndex, candidates.length)
+      : wrapIndex(insertionIndex - 1, candidates.length)
+  return candidates[targetIndex]
+}
+
+function findInsertionIndex(
+  candidates: readonly WorktreeDiffNavigationCandidate[],
+  currentPath: string,
+  currentArea: 'unstaged' | 'untracked'
+): number {
+  const currentEntry: GitStatusEntry = { path: currentPath, status: 'modified', area: currentArea }
+  const areaStart = candidates.findIndex((candidate) => candidate.area === currentArea)
+  if (areaStart === -1) {
+    return 0
+  }
+  let areaEnd = areaStart
+  while (areaEnd < candidates.length && candidates[areaEnd]?.area === currentArea) {
+    areaEnd += 1
+  }
+  return findAreaInsertionIndex(candidates, areaStart, areaEnd, currentEntry)
+}
+
+function findAreaInsertionIndex(
+  candidates: readonly WorktreeDiffNavigationCandidate[],
+  start: number,
+  end: number,
+  currentEntry: GitStatusEntry
+): number {
+  let low = start
+  let high = end
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2)
+    if (compareGitStatusEntries(candidates[mid], currentEntry) < 0) {
+      low = mid + 1
+    } else {
+      high = mid
+    }
+  }
+  return low
+}
+
+function wrapIndex(index: number, length: number): number {
+  return ((index % length) + length) % length
+}

--- a/tests/e2e/golden-source-control-open-diff.spec.ts
+++ b/tests/e2e/golden-source-control-open-diff.spec.ts
@@ -1,5 +1,7 @@
-import { realpathSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { realpathSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import {
   cleanupGoldenWorktree,
@@ -50,3 +52,118 @@ test('@golden opens an unstaged file diff from Source Control', async ({
   await probe.focus()
   await expect(probe).toBeFocused()
 })
+
+test('@golden navigates unstaged and untracked files from diff controls', async ({
+  orcaPage,
+  testRepoPath,
+  registerPostElectronShutdownCleanup
+}) => {
+  const fixture = createGoldenWorktree(testRepoPath, 'diff-file-navigation')
+  registerPostElectronShutdownCleanup(async () => cleanupGoldenWorktree(testRepoPath, fixture))
+  seedMultiFileNavigationFixture(fixture.worktreePath)
+
+  await waitForSessionReady(orcaPage)
+  await openGoldenSourceControl(orcaPage, testRepoPath, fixture)
+
+  const initialFile = orcaPage
+    .locator('[data-testid="source-control-entry"]')
+    .filter({ hasText: 'unstaged.ts' })
+  await expect(initialFile).toBeVisible({ timeout: 15_000 })
+  await initialFile.click()
+  await expect(orcaPage.locator('.monaco-diff-editor')).toBeVisible({ timeout: 20_000 })
+  await expectActiveEditorPath(orcaPage, fixture.worktreePath, 'unstaged.ts', true)
+
+  await navigateWithHeaderUntil(orcaPage, 'Next change', 'untracked.ts')
+  await expectActiveEditorPath(orcaPage, fixture.worktreePath, 'untracked.ts')
+  await navigateWithHeaderUntil(orcaPage, 'Next change', 'deleted.ts')
+  await expectActiveEditorPath(orcaPage, fixture.worktreePath, 'deleted.ts', true)
+  await navigateWithHeaderUntil(orcaPage, 'Next change', 'unstaged.ts')
+  await expectActiveEditorPath(orcaPage, fixture.worktreePath, 'unstaged.ts')
+
+  await navigateWithHeaderUntil(orcaPage, 'Previous change', 'deleted.ts')
+  await expectActiveEditorPath(orcaPage, fixture.worktreePath, 'deleted.ts', true)
+  await pressDiffShortcutUntil(orcaPage, 'F7', 'unstaged.ts')
+  await expectActiveEditorPath(orcaPage, fixture.worktreePath, 'unstaged.ts')
+  await pressDiffShortcutUntil(orcaPage, 'Shift+F7', 'deleted.ts')
+  await expectActiveEditorPath(orcaPage, fixture.worktreePath, 'deleted.ts', true)
+
+  const openedPaths = await orcaPage.evaluate(() =>
+    window.__store?.getState().openFiles.map((file) => file.relativePath) ?? []
+  )
+  expect(openedPaths).not.toContain('staged-only.ts')
+})
+
+function seedMultiFileNavigationFixture(worktreePath: string): void {
+  writeFileSync(path.join(worktreePath, 'unstaged.ts'), 'one\n')
+  writeFileSync(path.join(worktreePath, 'staged-only.ts'), 'one\n')
+  writeFileSync(path.join(worktreePath, 'deleted.ts'), 'one\n')
+  execFileSync('git', ['add', 'unstaged.ts', 'staged-only.ts', 'deleted.ts'], {
+    cwd: worktreePath,
+    stdio: 'pipe'
+  })
+  execFileSync('git', ['commit', '-m', 'diff navigation fixture'], {
+    cwd: worktreePath,
+    stdio: 'pipe'
+  })
+  writeFileSync(path.join(worktreePath, 'unstaged.ts'), 'one\ntwo\n')
+  writeFileSync(path.join(worktreePath, 'staged-only.ts'), 'one\ntwo\n')
+  execFileSync('git', ['add', 'staged-only.ts'], { cwd: worktreePath, stdio: 'pipe' })
+  rmSync(path.join(worktreePath, 'deleted.ts'))
+  writeFileSync(path.join(worktreePath, 'untracked.ts'), 'new\n')
+}
+
+async function getActiveEditorRelativePath(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    return state?.openFiles.find((file) => file.id === state.activeFileId)?.relativePath ?? null
+  })
+}
+
+async function expectActiveEditorPath(
+  page: Page,
+  worktreePath: string,
+  relativePath: string,
+  isDiff = false
+): Promise<void> {
+  await expect.poll(() => getActiveEditorRelativePath(page), { timeout: 10_000 }).toBe(relativePath)
+  const title = `${path.join(realpathSync(worktreePath), relativePath).replaceAll('\\', '/')}${
+    isDiff ? ' (diff)' : ''
+  }`
+  await expect(page.locator('.editor-header-path').first()).toHaveAttribute('title', title)
+}
+
+async function navigateWithHeaderUntil(
+  page: Page,
+  buttonName: 'Next change' | 'Previous change',
+  expectedRelativePath: string
+): Promise<void> {
+  const button = page.getByRole('button', { name: buttonName })
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    await button.click()
+    try {
+      await expect.poll(() => getActiveEditorRelativePath(page), { timeout: 2_000 }).toBe(expectedRelativePath)
+      return
+    } catch {
+      // Keep stepping through any remaining hunks in the current file.
+    }
+  }
+  await expect.poll(() => getActiveEditorRelativePath(page), { timeout: 1 }).toBe(expectedRelativePath)
+}
+
+async function pressDiffShortcutUntil(
+  page: Page,
+  shortcut: 'F7' | 'Shift+F7',
+  expectedRelativePath: string
+): Promise<void> {
+  await page.locator('.monaco-diff-editor textarea').first().focus()
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    await page.keyboard.press(shortcut)
+    try {
+      await expect.poll(() => getActiveEditorRelativePath(page), { timeout: 2_000 }).toBe(expectedRelativePath)
+      return
+    } catch {
+      // Keep stepping through any remaining hunks in the current file.
+    }
+  }
+  await expect.poll(() => getActiveEditorRelativePath(page), { timeout: 1 }).toBe(expectedRelativePath)
+}


### PR DESCRIPTION
## ELI5

The next/previous diff controls can now keep walking through the changed files shown in Source Control instead of getting stuck inside one already-open file. Reviewers can use the existing arrow buttons or F7 / Shift+F7 to move through eligible worktree files in the same order Source Control displays them.

## What Changed

- Added a Source Control ordered worktree diff navigation candidate resolver for unstaged and untracked entries.
- Extended the diff navigation provider so it moves within the current diff while hunks remain, then crosses to the next/previous eligible file at the boundary.
- Opens existing files in Changes mode and deleted files as unstaged single-file diff tabs.
- Preserves staged-only, branch, commit, combined diff, and unresolved conflict behavior.
- Keeps binary/no-text files as review stops, including F7 / Shift+F7 fallback navigation when no Monaco diff editor mounts.
- Updated header button availability to use provider-level navigation availability.
- Added renderer and Electron headless coverage for file-boundary traversal.

## Why

Multi-file worktree review currently requires repeatedly returning to Source Control to pick the next file. This keeps the existing controls and shortcut model, but lets review flow across the Source Control file list without introducing a new UI surface.

## Linked Issue

Fixes #10353

## Visual Proof


https://github.com/user-attachments/assets/c8475744-7f15-46be-8bfb-92e04073fb3b


## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed locally:

- `npm exec --yes pnpm@12.0.0 -- test src/renderer/src/components/editor/worktree-diff-file-navigation.test.ts src/renderer/src/components/editor/diff-navigation-context.test.tsx src/renderer/src/components/editor/editor-shortcuts.test.ts src/renderer/src/components/editor/EditorPanel.diff-file-navigation.test.tsx src/renderer/src/components/editor/EditorPanelHeader.test.tsx src/renderer/src/components/editor/EditorPanelShell.diff-navigation-shortcut.test.tsx`
- `ORCA_BACKGROUND_LAUNCH=1 npm exec --yes pnpm@12.0.0 -- exec playwright test tests/e2e/golden-source-control-open-diff.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1`
- `npm exec --yes pnpm@12.0.0 -- typecheck`
- `npm exec --yes pnpm@12.0.0 -- lint`
- `npm exec --yes pnpm@12.0.0 -- build`
- `git diff --check`

Full `npm exec --yes pnpm@12.0.0 -- test` ran locally with 74,542 passing tests and 380 skipped, but failed on three environment/baseline cases outside this change area:

- `config/scripts/workflow-ref-reachability.test.mjs`: local Git does not support `git init --ref-format=reftable`.
- `config/scripts/macos-computer-helper-owner-loss-processes.test.mjs`: temp child pid file was not created.
- `src/main/daemon/shell-ready-bash-wrapper.test.ts`: local interactive bash/preexec behavior mismatch.

Platform tested: macOS local/headless Electron. SSH/remote compatibility was considered by preserving existing worktree IDs, runtime environment IDs, and path helpers; not manually exercised over SSH.

## AI Disclosure

Implemented with assistance from Pi using OpenAI/Codex-backed models and subagent review.

## Review

Agent review summary:

- Cross-platform: uses existing keybinding matching and shortcut label infrastructure; no hardcoded `metaKey` or platform-specific shortcut behavior added.
- Paths: uses existing path helpers for worktree file resolution.
- SSH/remote/local: carries existing worktree and runtime environment IDs through `openFile` / `openDiff`; no new direct process or filesystem assumptions added beyond existing editor open flows.
- Git providers/integrations: provider-neutral; no GitHub-specific product behavior added.
- Performance: candidate computation is memoized from the active worktree status snapshot, grouped/sorted like Source Control, and only used for boundary navigation.
- UI quality: reuses existing header controls, labels, tooltips, and shortcuts; no new colors, layout, or visual primitives.
- Security: no new network calls, shell execution, or credential handling.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No release/version changes. `pnpm` was not installed directly on this machine, so local validation used `npm exec --yes pnpm@12.0.0 -- ...`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
