### PR TITLE
fix(orchestration): revalidate an attempted Enter instead of resending it

### DIFF
--- a/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-delivery.ts
@@ -9,6 +9,10 @@ import {
   OrchestrationMailboxPointerState,
   type OrchestrationMailboxDeliveryFlight
 } from './mailbox-pointer-state'
+import {
+  MAILBOX_POINTER_RESERVED,
+  MAILBOX_POINTER_WRITE_ATTEMPTED
+} from './db/messages/mailbox-pointer-enter-state'
 import { resumePendingOrchestrationMailboxPointer } from './mailbox-pointer-resume'
 import { stageOrchestrationMailboxPointer } from './mailbox-pointer-stage'
 
@@ -163,7 +167,19 @@ export class OrchestrationMailboxPointerDelivery<TWaiter extends OrchestrationMe
       clearTimeout(flight.enterTimer)
     }
     if (flight?.stagedMessageIds.length) {
-      this.deps.getDb()?.markAsUndelivered(flight.stagedMessageIds)
+      const db = this.deps.getDb()
+      if (db && flight.processIncarnation) {
+        // Why: the Enter timer was just cleared, so a reserved or merely-written pointer provably
+        // never submitted and is released. An attempted Enter may already have landed, so it stays
+        // at its phase for the resume path to revalidate rather than being sent a second time.
+        db.releaseMailboxPointerEnter(
+          flight.stagedMessageIds,
+          { ptyId, processIncarnation: flight.processIncarnation },
+          [MAILBOX_POINTER_RESERVED, MAILBOX_POINTER_WRITE_ATTEMPTED]
+        )
+      } else {
+        db?.markAsUndelivered(flight.stagedMessageIds)
+      }
     }
     for (const mailboxHandle of releasedMailboxes) {
       this.redrive(mailboxHandle, true)

--- a/src/main/runtime/orchestration/mailbox-pointer-stage.test.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-stage.test.ts
@@ -200,3 +200,72 @@ describe('mailbox pointer staging watermark', () => {
     db.close()
   })
 })
+
+describe('retiring a pty mid-delivery', () => {
+  // Why: an Enter that was already written may have landed. Releasing it would send the same
+  // mail a second time, so only phases that provably never submitted become redeliverable.
+  it('leaves an attempted Enter at its phase instead of making it redeliverable', async () => {
+    vi.useFakeTimers()
+    const db = new OrchestrationDb(':memory:')
+    const settlements: ((settlement: WriteSettlement) => void)[] = []
+    const writePty = vi.fn(
+      () =>
+        new Promise<WriteSettlement>((resolve) => {
+          settlements.push(resolve)
+        }) as unknown as WriteSettlement
+    )
+    try {
+      const message = db.insertMessage({ from: 'a', to: 'run:run-1', subject: 'mail' })
+      const delivery = new OrchestrationMailboxPointerDelivery(pointerDeps(db, writePty) as never)
+      delivery.deliver(LEAF, { mailboxHandle: 'run:run-1' })
+
+      // Settle the pointer write, so the pane reaches WRITE_ATTEMPTED and arms the Enter.
+      settlements[0]?.(WRITE_ACCEPTED)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(db.getMessageById(message.id)?.pointer_enter_pending).toBe(2)
+
+      // Fire the Enter but never settle it: this is the ambiguous state.
+      await vi.advanceTimersByTimeAsync(600)
+      expect(db.getMessageById(message.id)?.pointer_enter_pending).toBe(3)
+
+      delivery.retirePty('pty-1')
+      expect(db.getMessageById(message.id)).toMatchObject({
+        pointer_enter_pending: 3,
+        read: 0
+      })
+    } finally {
+      db.close()
+      vi.useRealTimers()
+    }
+  })
+
+  it('releases a pointer whose Enter never fired', async () => {
+    vi.useFakeTimers()
+    const db = new OrchestrationDb(':memory:')
+    const settlements: ((settlement: WriteSettlement) => void)[] = []
+    const writePty = vi.fn(
+      () =>
+        new Promise<WriteSettlement>((resolve) => {
+          settlements.push(resolve)
+        }) as unknown as WriteSettlement
+    )
+    try {
+      const message = db.insertMessage({ from: 'a', to: 'run:run-1', subject: 'mail' })
+      const delivery = new OrchestrationMailboxPointerDelivery(pointerDeps(db, writePty) as never)
+      delivery.deliver(LEAF, { mailboxHandle: 'run:run-1' })
+      settlements[0]?.(WRITE_ACCEPTED)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(db.getMessageById(message.id)?.pointer_enter_pending).toBe(2)
+
+      delivery.retirePty('pty-1')
+      expect(db.getMessageById(message.id)).toMatchObject({
+        pointer_enter_pending: 0,
+        read: 0,
+        delivered_at: null
+      })
+    } finally {
+      db.close()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/runtime/orchestration/mailbox-pointer-stage.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-stage.ts
@@ -58,6 +58,7 @@ export function stageOrchestrationMailboxPointer<TWaiter extends OrchestrationMe
     return
   }
   const flight = args.state.beginFlight(ptyId)
+  flight.processIncarnation = expectedTarget.processIncarnation
   flight.stagedMessageIds = args.messages.map((message) => message.id)
   try {
     if (

--- a/src/main/runtime/orchestration/mailbox-pointer-state.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-state.ts
@@ -6,6 +6,8 @@ export type OrchestrationMailboxDeliveryFlight = {
   submitEnter: (() => void) | null
   deferredUntilIdle: boolean
   idleObservedWhileDeferred: boolean
+  /** The incarnation that staged this flight, so retirement can name the rows it owns. */
+  processIncarnation?: string
 }
 
 export type ParkedOrchestrationMailboxDelivery = {

--- a/src/main/runtime/terminal-send-stale-leaf-liveness.test.ts
+++ b/src/main/runtime/terminal-send-stale-leaf-liveness.test.ts
@@ -386,6 +386,7 @@ function makeOrchestrationDbStub(toHandle: () => string) {
     runMailbox,
     markAsDelivered,
     markAsUndelivered,
+    releaseMailboxPointerEnter,
     stageMailboxPointerEnter,
     insert(subject: string, type: StoredMessageRow['type'] = 'status'): void {
       rows.push({
@@ -759,7 +760,7 @@ describe('push-on-idle orchestration delivery absence gate', () => {
       await vi.advanceTimersByTimeAsync(500)
       expect(write.mock.calls.filter(([, data]) => data === '\r')).toHaveLength(0)
       expect(stub.stageMailboxPointerEnter).toHaveBeenCalledOnce()
-      expect(stub.markAsUndelivered).toHaveBeenCalledOnce()
+      expect(stub.releaseMailboxPointerEnter).toHaveBeenCalledOnce()
       expect(stub.rows[0].delivered_at).toBeNull()
 
       // The replacement's own delivery starts a fresh flight and completes —
@@ -804,7 +805,7 @@ describe('push-on-idle orchestration delivery absence gate', () => {
       await vi.advanceTimersByTimeAsync(500)
       expect(write.mock.calls.filter(([, data]) => data === '\r')).toHaveLength(0)
       expect(stub.stageMailboxPointerEnter).toHaveBeenCalledOnce()
-      expect(stub.markAsUndelivered).toHaveBeenCalledOnce()
+      expect(stub.releaseMailboxPointerEnter).toHaveBeenCalledOnce()
       // No stray settle flushed the parked trigger into the dead pty.
       expect(write).toHaveBeenCalledTimes(1)
       expect(stub.rows.every((row) => row.delivered_at === null)).toBe(true)
@@ -835,7 +836,7 @@ describe('push-on-idle orchestration delivery absence gate', () => {
       await vi.advanceTimersByTimeAsync(500)
       expect(write.mock.calls.filter(([, data]) => data === '\r')).toHaveLength(0)
       expect(stub.stageMailboxPointerEnter).toHaveBeenCalledOnce()
-      expect(stub.markAsUndelivered).toHaveBeenCalledOnce()
+      expect(stub.releaseMailboxPointerEnter).toHaveBeenCalledOnce()
       expect(stub.rows[0].delivered_at).toBeNull()
     } finally {
       vi.useRealTimers()


### PR DESCRIPTION
> **This is a behavioral correctness fix, not a performance change.**
> Measured perf impact: **−0.10 µs**, inside noise. Nothing here is intended to make anything faster.
> **Scope: asynchronous PTY providers** — including SSH and daemon-backed local PTYs. The window does not exist in the direct in-process `LocalPtyProvider`.

## The bug

When a PTY retires mid-delivery, `retirePty` called `markAsUndelivered` on every staged message, clearing all pointer state and making the whole batch redeliverable.

That is correct for a pointer whose Enter never fired. It is wrong for one already at `ENTER_ATTEMPTED`: that Enter was written to the transport and may well have landed. Redelivering it types the same mail into the pane a second time.

## Why it affects asynchronous providers

The vulnerable window is exactly `mailbox-pointer-submit.ts:114` (the row reaches `ENTER_ATTEMPTED`) to `:118` (`await deps.writePty(ptyId, '\r')` resolves). How wide that is depends entirely on the provider:

| Provider | `writeWithSettlement` | Window |
|---|---|---|
| direct in-process local — `local-pty-provider.ts:83` | `(id, data): WriteSettlement` — **synchronous** | **effectively zero** |
| daemon-backed local — `daemon-pty-router.ts:97` | `(id, data): Promise<WriteSettlement>` — daemon IPC | **one asynchronous settlement** |
| SSH — `ssh-pty-provider.ts:49` | `(id, data): Promise<WriteSettlement>` — remote RPC | **one asynchronous settlement** |

On the direct in-process `LocalPtyProvider`, settlement is not a promise, so the `await` resolves on the next microtask. A PTY exit arrives as a libuv macrotask and cannot interleave with a microtask, so `retirePty` cannot observe the row at `ENTER_ATTEMPTED`.

For daemon-backed local PTYs and SSH PTYs, settlement crosses an asynchronous IPC/RPC boundary, and macrotasks — including the PTY exit event — can run while it is pending.

I did not measure live provider settlement latency, so no timing figure is quoted. The scope claim is structural, from the provider types and delivery path.

## The fix

The Enter timer is cleared at the top of retirement, which is positive evidence about what happened:

| Phase | Meaning | Before | After |
|---|---|---|---|
| `RESERVED` | claimed, nothing typed | redeliverable | redeliverable |
| `WRITE_ATTEMPTED` | pointer typed, Enter never fired | redeliverable | redeliverable |
| `ENTER_ATTEMPTED` | Enter written, settlement unknown | **cleared and resent** | **left at phase for the resume path to revalidate** |

Only the ambiguous case changes. This matches what `mailbox-pointer-submit.ts` already documents for an unverifiable settlement — *"neither settling it as delivered nor rolling it back ... is provable here"* — and the execution-boundary rule that loss of contact is never evidence about what the remote process received. An Enter whose settlement never came back is `unverifiable`, not "never sent".

The flight now carries the process incarnation that staged it, so retirement can name exactly the rows it owns instead of clearing by message id alone. Where no incarnation is recorded, the previous `markAsUndelivered` path is kept.

## Performance

Explicitly none, and measured rather than assumed. Against a copy of a real 368 MB orchestration database (50,866 messages), WAL + `synchronous=NORMAL`, statements prepared once, 500 warmup then 4,000 iterations × 7 reps, median, shared staging cost subtracted:

| Arm | Isolated call cost |
|---|---|
| `markAsUndelivered` (before) | 26.69 µs |
| `releaseMailboxPointerEnter` (after) | 26.59 µs |

**Delta −0.10 µs**, identical WAL growth. Both are a single `UPDATE` inside a `SAVEPOINT`; the added fence predicates ride on a row lookup that already happens.

It also runs rarely: the changed code sits behind `if (flight?.stagedMessageIds.length)`, so a working title frame with no airborne delivery does a `Map` lookup and returns without touching the database.

## Validation

`pnpm tc:node` and `oxlint` clean. Orchestration and stale-leaf suites pass.

Two ablations confirm the new coverage is a real regression guard rather than a pin:

- releasing `ENTER_ATTEMPTED` as well → the new test fails
- reverting to `main`'s blanket `markAsUndelivered` → the new test fails

Worth flagging: the three existing `terminal-send-stale-leaf-liveness` cases pass either way, because they all exercise a `WRITE_ATTEMPTED` flight. **The phase-3 behavior was previously unguarded entirely**, which is why this adds coverage for it directly rather than relying on those.

One pre-existing failure reproduces on `main` and is unrelated: the `orchestration-cli-subprocess` keepalive assertion.

## Context

Supersedes #19644, which bundled this fix into a much larger restructuring of mailbox pointer recovery. Measurement did not support that restructuring: its per-frame change saved 1.84 µs with zero I/O difference, the partial index it claimed to enable was already in use on `main` with an identical query plan, and its incarnation fencing guarded a window `markAsUndelivered` already closes. This is the one demonstrated improvement from that work, in 5 files. Full numbers are recorded on #19644.
