### PR TITLE
feat(review-notes) Show terminal title when sending Notes to Agents

### DIFF
--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
@@ -476,7 +476,12 @@ describe('ReviewNotesSendMenuContent', () => {
     const tree = render()
     const item = findByType(tree, 'DropdownMenuItem')
 
-    expect(collectText(item)).toContain('Payments')
+        const labels = findAllByType(item, 'span').filter(
+          (span) => typeof span.props.className === 'string' && span.props.className.includes('truncate')
+        )
+        expect(collectText(labels[0])).toBe('Payments')
+        expect(collectText(labels[1])).toContain('Claude')
+        expect(collectText(labels[1])).not.toContain('Payments')
     // Why: the agent type moves to the secondary line instead of duplicating the name.
     expect(collectText(item)).toContain('Claude')
   })

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
@@ -477,14 +477,13 @@ describe('ReviewNotesSendMenuContent', () => {
     const tree = render()
     const item = findByType(tree, 'DropdownMenuItem')
 
-        const labels = findAllByType(item, 'span').filter(
-          (span) => typeof span.props.className === 'string' && span.props.className.includes('truncate')
-        )
-        expect(collectText(labels[0])).toBe('Payments')
-        expect(collectText(labels[1])).toContain('Claude')
-        expect(collectText(labels[1])).not.toContain('Payments')
+    const labels = findAllByType(item, 'span').filter(
+      (span) => typeof span.props.className === 'string' && span.props.className.includes('truncate')
+    )
+    expect(collectText(labels[0])).toBe('Payments')
     // Why: the agent type moves to the secondary line instead of duplicating the name.
-    expect(collectText(item)).toContain('Claude')
+    expect(collectText(labels[1])).toContain('Claude')
+    expect(collectText(labels[1])).not.toContain('Payments')
   })
 
   it('does not target title-detected rows skipped by target derivation', async () => {

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
@@ -450,6 +450,32 @@ describe('ReviewNotesSendMenuContent', () => {
     expect(collectText(items[1])).toContain('Claude')
   })
 
+  it('headlines the tab custom title instead of the agent type label', () => {
+    const statusPaneKey = makePaneKey(TAB_A, LEAF_A)
+    setStore({
+      tabsByWorktree: { 'wt-1': [tab(TAB_A, { title: 'Terminal 1', customTitle: 'Payments' })] },
+      terminalLayoutsByTabId: { [TAB_A]: leafLayout(LEAF_A, 'pty-a') }
+    })
+    harness.noteTargets = [
+      {
+        paneKey: statusPaneKey,
+        tabId: TAB_A,
+        leafId: LEAF_A,
+        agentType: 'claude',
+        tabTitle: 'Payments',
+        customTitle: 'Payments',
+        status: 'eligible'
+      }
+    ]
+
+    const tree = render()
+    const item = findByType(tree, 'DropdownMenuItem')
+
+    expect(collectText(item)).toContain('Payments')
+    // Why: the agent type moves to the secondary line instead of duplicating the name.
+    expect(collectText(item)).toContain('Claude')
+  })
+
   it('does not target title-detected rows skipped by target derivation', async () => {
     const paneKey = makePaneKey(TAB_B, LEAF_B)
     harness.worktreeAgentRows = [

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
@@ -34,6 +34,7 @@ const harness = vi.hoisted(() => ({
     leafId: string
     agentType: TuiAgent
     tabTitle: string
+    customTitle: string | null
     status: 'eligible' | 'disabled'
     disabledReason?: string
   }[],
@@ -371,6 +372,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'eligible'
       },
       {
@@ -379,6 +381,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_B,
         agentType: 'codex',
         tabTitle: 'Codex',
+        customTitle: null,
         status: 'eligible'
       }
     ]
@@ -427,6 +430,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'First session',
+        customTitle: null,
         status: 'eligible'
       },
       {
@@ -435,6 +439,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_B,
         agentType: 'codex',
         tabTitle: 'Second session',
+        customTitle: null,
         status: 'eligible'
       }
     ]
@@ -525,6 +530,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_B,
         agentType: 'codex',
         tabTitle: 'Codex',
+        customTitle: null,
         status: 'disabled',
         disabledReason: 'Agent needs permission'
       }
@@ -582,6 +588,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'eligible'
       }
     ]
@@ -608,6 +615,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'codex',
         tabTitle: 'Codex',
+        customTitle: null,
         status: 'disabled',
         disabledReason: 'Agent status is stale'
       }
@@ -635,6 +643,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'eligible'
       }
     ]
@@ -671,6 +680,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'eligible'
       }
     ]
@@ -699,6 +709,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'eligible'
       }
     ]
@@ -725,6 +736,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'eligible'
       }
     ]
@@ -737,6 +749,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'disabled',
         disabledReason: 'Agent status is stale'
       }
@@ -761,6 +774,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'eligible'
       }
     ]
@@ -787,6 +801,7 @@ describe('ReviewNotesSendMenuContent', () => {
         leafId: LEAF_A,
         agentType: 'claude',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'eligible'
       }
     ]

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
@@ -455,6 +455,7 @@ describe('ReviewNotesSendMenuContent', () => {
     expect(collectText(items[1])).toContain('Claude')
   })
 
+  /** The primary label shows the user's rename; the agent type moves to the secondary line. */
   it('headlines the tab custom title instead of the agent type label', () => {
     const statusPaneKey = makePaneKey(TAB_A, LEAF_A)
     setStore({

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -249,10 +249,15 @@ function AgentTargetMenuItem({
   const state = agentRowDotState(agent?.state ?? 'idle', agent?.entry.workingMode)
   const timeAgo = agent ? formatAgentRelativeTime(agent, now) : null
   const disabledReason = target.status === 'disabled' ? target.disabledReason : undefined
+  const agentTypeLabel = formatAgentTypeLabel(target.agentType ?? agent?.agentType)
+  // Why: headline the user's own rename, same as the tab bar and dashboard rows —
+  // it tells apart multiple running agents of the same type better than the type name.
+  const primaryLabel = target.customTitle || agentTypeLabel
   const secondaryParts = [
+    ...(target.customTitle ? [agentTypeLabel] : []),
     agentStateLabel(state),
     ...(timeAgo ? [timeAgo] : []),
-    ...(tabTitle ? [tabTitle] : [])
+    ...(!target.customTitle && tabTitle ? [tabTitle] : [])
   ]
   return (
     <DropdownMenuItem
@@ -273,9 +278,7 @@ function AgentTargetMenuItem({
       />
       <AgentIcon agent={agentTypeToIconAgent(target.agentType ?? agent?.agentType)} size={14} />
       <span className="grid min-w-0 flex-1 text-left">
-        <span className="truncate">
-          {formatAgentTypeLabel(target.agentType ?? agent?.agentType)}
-        </span>
+        <span className="truncate">{primaryLabel}</span>
         <span className="truncate text-[11px] font-normal text-muted-foreground">
           {secondaryParts.join(' · ')}
         </span>

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -232,6 +232,7 @@ function resolveCurrentSendTargetEligibility(
   return { status: 'disabled', disabledReason: 'Terminal is no longer available' }
 }
 
+/** Renders one send-target row, headlining the tab's custom title over its agent type when the user renamed it. */
 function AgentTargetMenuItem({
   target,
   agent,

--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -134,6 +134,34 @@ describe('notes send agent targets', () => {
     ])
   })
 
+  it('prefers the tab custom title over the live title when the user renamed the tab', () => {
+    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
+        tabsByWorktree: {
+          [WORKTREE_ID]: [
+            tab(STATUS_TAB_ID, { title: 'Terminal 1', customTitle: 'Payments' })
+          ]
+        },
+        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toEqual([
+      {
+        paneKey,
+        tabId: STATUS_TAB_ID,
+        leafId: LEAF_A,
+        agentType: 'codex',
+        tabTitle: 'Payments',
+        status: 'eligible'
+      }
+    ])
+  })
+
   it('keeps permission status-backed targets visible but disabled', () => {
     const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
     const targets = deriveNotesSendAgentTargets(
@@ -467,6 +495,41 @@ describe('notes send agent targets', () => {
         leafId: LEAF_B,
         agentType: 'codex',
         tabTitle: 'Previous Codex session',
+        status: 'eligible'
+      }
+    ])
+  })
+
+  it('prefers the tab custom title over the live title for a title-hint-promoted launch-agent pane', () => {
+    const paneKey = makePaneKey(LAUNCH_TAB_ID, LEAF_B)
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        agentStatusByPaneKey: {
+          [paneKey]: entry(paneKey, 'done', OLD_STATUS_UPDATED_AT)
+        },
+        tabsByWorktree: {
+          [WORKTREE_ID]: [
+            tab(LAUNCH_TAB_ID, {
+              title: 'Previous Codex session',
+              customTitle: 'Refactor',
+              launchAgent: 'codex'
+            })
+          ]
+        },
+        terminalLayoutsByTabId: { [LAUNCH_TAB_ID]: leafLayout(LEAF_B, 'pty-b') },
+        runtimePaneTitlesByTabId: { [LAUNCH_TAB_ID]: { 1: 'Codex ready' } }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets).toEqual([
+      {
+        paneKey,
+        tabId: LAUNCH_TAB_ID,
+        leafId: LEAF_B,
+        agentType: 'codex',
+        tabTitle: 'Refactor',
         status: 'eligible'
       }
     ])

--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -129,6 +129,7 @@ describe('notes send agent targets', () => {
         leafId: LEAF_A,
         agentType: 'codex',
         tabTitle: 'Terminal 1',
+        customTitle: null,
         status: 'eligible'
       }
     ])
@@ -157,6 +158,7 @@ describe('notes send agent targets', () => {
         leafId: LEAF_A,
         agentType: 'codex',
         tabTitle: 'Payments',
+        customTitle: 'Payments',
         status: 'eligible'
       }
     ])
@@ -225,6 +227,7 @@ describe('notes send agent targets', () => {
         leafId: LEAF_B,
         agentType: 'codex',
         tabTitle: 'Terminal 2',
+        customTitle: null,
         status: 'eligible'
       }
     ])
@@ -250,6 +253,7 @@ describe('notes send agent targets', () => {
         leafId: LEAF_B,
         agentType: 'codex',
         tabTitle: 'Terminal 2',
+        customTitle: null,
         status: 'eligible'
       }
     ])
@@ -495,6 +499,7 @@ describe('notes send agent targets', () => {
         leafId: LEAF_B,
         agentType: 'codex',
         tabTitle: 'Previous Codex session',
+        customTitle: null,
         status: 'eligible'
       }
     ])
@@ -530,6 +535,7 @@ describe('notes send agent targets', () => {
         leafId: LEAF_B,
         agentType: 'codex',
         tabTitle: 'Refactor',
+        customTitle: 'Refactor',
         status: 'eligible'
       }
     ])
@@ -737,6 +743,7 @@ describe('notes send agent targets', () => {
         leafId: LEAF_B,
         agentType: 'opencode',
         tabTitle: 'Terminal 2',
+        customTitle: null,
         status: 'eligible'
       }
     ])

--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -135,6 +135,7 @@ describe('notes send agent targets', () => {
     ])
   })
 
+  /** A status-backed target headlines the tab's rename over the live pane title. */
   it('prefers the tab custom title over the live title when the user renamed the tab', () => {
     const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
     const targets = deriveNotesSendAgentTargets(
@@ -505,6 +506,7 @@ describe('notes send agent targets', () => {
     ])
   })
 
+  /** A title-hint-promoted launch-agent target also headlines the tab's rename. */
   it('prefers the tab custom title over the live title for a title-hint-promoted launch-agent pane', () => {
     const paneKey = makePaneKey(LAUNCH_TAB_ID, LEAF_B)
     const targets = deriveNotesSendAgentTargets(

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -114,6 +114,7 @@ function resolveNotesTargetAgentType(
   return launchAgent ?? entryAgentType
 }
 
+/** Builds a pre-hook target candidate for a tab from its live pane title, or null if there's no such evidence. */
 function deriveTitleHintAgentTarget(
   state: NotesSendAgentTargetState,
   tab: TerminalTab
@@ -164,6 +165,7 @@ function mergeManualAgentTitleTarget(
   targets.push(target)
 }
 
+/** Merges a title-hint target for a launch-agent tab, promoting a stale status row on the same pane when the hint is fresher. */
 function mergeLaunchAgentTitleTarget(
   targets: NotesSendAgentTarget[],
   target: NotesSendAgentTarget

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -22,6 +22,9 @@ export type NotesSendAgentTarget = {
   leafId: string
   agentType: AgentType | null | undefined
   tabTitle: string
+  // Why: the user's own rename, exposed separately from tabTitle so callers can
+  // headline it instead of the agent type label — a live status title is not a name.
+  customTitle: string | null
   status: 'eligible' | 'disabled'
   disabledReason?: string
 }
@@ -76,6 +79,7 @@ export function deriveNotesSendAgentTargets(
       // Why: prefer the user's own rename (same precedence as the tab bar) over
       // the live status text agents constantly overwrite the title with.
       tabTitle: target.tab.customTitle ?? target.tab.title,
+      customTitle: target.tab.customTitle?.trim() || null,
       status: target.status,
       ...(target.disabledReason ? { disabledReason: target.disabledReason } : {})
     })
@@ -142,6 +146,7 @@ function deriveTitleHintAgentTarget(
     leafId,
     agentType: tab.launchAgent ?? resolveTerminalTitleAgentType(titleEvidence.title),
     tabTitle: tab.customTitle ?? tab.title,
+    customTitle: tab.customTitle?.trim() || null,
     status: disabledReason ? 'disabled' : 'eligible',
     ...(disabledReason ? { disabledReason } : {})
   }
@@ -179,7 +184,8 @@ function mergeLaunchAgentTitleTarget(
         existing.agentType && existing.agentType !== 'unknown'
           ? existing.agentType
           : target.agentType,
-      tabTitle: existing.tabTitle || target.tabTitle
+      tabTitle: existing.tabTitle || target.tabTitle,
+      customTitle: existing.customTitle || target.customTitle
     }
     return
   }

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -73,7 +73,9 @@ export function deriveNotesSendAgentTargets(
       tabId: target.tabId,
       leafId: target.leafId,
       agentType: resolveNotesTargetAgentType(target.entry.agentType, target.tab.launchAgent),
-      tabTitle: target.tab.title,
+      // Why: prefer the user's own rename (same precedence as the tab bar) over
+      // the live status text agents constantly overwrite the title with.
+      tabTitle: target.tab.customTitle ?? target.tab.title,
       status: target.status,
       ...(target.disabledReason ? { disabledReason: target.disabledReason } : {})
     })
@@ -139,7 +141,7 @@ function deriveTitleHintAgentTarget(
     tabId: tab.id,
     leafId,
     agentType: tab.launchAgent ?? resolveTerminalTitleAgentType(titleEvidence.title),
-    tabTitle: tab.title,
+    tabTitle: tab.customTitle ?? tab.title,
     status: disabledReason ? 'disabled' : 'eligible',
     ...(disabledReason ? { disabledReason } : {})
   }


### PR DESCRIPTION
## ELI5

When you send review notes to a running agent, the picker used to just say "Claude" or "Codex" for every row.
Now it shows the name you gave that tab (like "Payments"), so you can tell two Claude tabs apart.

## What Changed

 - notes-send-agent-targets.ts: expose the tab's customTitle separately from tabTitle on each NotesSendAgentTarget,
   preferring the user's rename over the live status text everywhere targets are derived/merged.
  - ReviewNotesSendMenuContent.tsx: headline customTitle (when set) as the primary label in the send-notes picker instead of the agent type label, moving the agent type down to the secondary line so it isn't lost.

## Why

Multiple running agents of the same type were indistinguishable in the send-notes picker (all just labeled "Claude" or "Codex"). Surfacing the user's own tab rename - the same signal already used by the tab bar and dashboard rows

## Linked Issue

Fixes #19913

## Visual Proof

<!-- REQUIRED for UI / behavior changes. Please attach a BEFORE and AFTER that can easily tabbed/switched. Use videos for when appropriate over screenshots -->
<!-- If there is truly no visual or interaction change, write exactly: `N/A` and briefly say why. -->
<!-- For attachments NEVER add directly to the PR files (do not commit to files), use `gh image` extension or drag + drop (works for any attachment) -->

### Before:
<img width="1919" height="1032" alt="before" src="https://github.com/user-attachments/assets/881d762a-3f53-4121-b2a3-dc35d0749919" />

### After:
<img width="1919" height="1032" alt="after" src="https://github.com/user-attachments/assets/afeb8e82-d670-41b9-917a-06016ba30162" />

### If no terminal-title is set for this agent, everything remains unchanged
<img width="1919" height="1032" alt="image" src="https://github.com/user-attachments/assets/1b708a3e-7611-48a8-9a5f-71701efaa69c" />


## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added/updated unit tests in notes-send-agent-targets.test.ts (customTitle derivation and merge precedence) and
ReviewNotesSendMenuContent.test.tsx (headline rendering).

## AI Disclosure

implemented with Claude Opus/Sonnet 5

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security, cross-platform, remote/SSH, or mobile surface touched - pure renderer UI label logic.

This is my first contribution to an open-source project, so I'd appreciate any feedback on things I might've missed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
