### PR TITLE
fix(relay): keep failed rehome polls out of the durable failure budget

### DIFF
--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -5958,6 +5958,10 @@ export class RelayAssignmentStore {
   async recordRegionalRehomeDispatchFailure(attemptId: string): Promise<void> {
     const now = this.now()
     const disableLog = await this.database.transaction(async (transaction) => {
+      // Match claim and enable ordering before a spent budget updates the control.
+      await transaction.queryLocked(
+        `SELECT * FROM relay_region_rehome_control WHERE control_id = 'global'`
+      )
       const worker = (
         await transaction.queryLocked(
           `SELECT * FROM relay_region_rehome_worker_state WHERE worker_id = 'global'`

--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -362,6 +362,9 @@ export const REGIONAL_REHOME_QUARANTINE_FAILURES = 3
 export const REGIONAL_REHOME_QUARANTINE_MS = 15 * 60_000
 const REGIONAL_REHOME_QUARANTINE_EXCLUSION_LIMIT = 50
 const REGIONAL_REHOME_QUARANTINE_MEMORY_LIMIT = 1_000
+// Consecutive drain-dispatch failures that latch the durable control off. Any
+// drain receipt and any enable reset it, so it reads "dispatch is broken now".
+const REGIONAL_REHOME_FAILURE_BUDGET = 3
 const REGIONAL_REHOME_OBSERVATION_MS = 24 * 60 * 60_000
 const ASSIGNMENT_LOCK_RETRY_MAX_DELAY_MS = 50
 type AssignmentInventoryScope = 'none' | 'general' | 'all'
@@ -4992,6 +4995,20 @@ export class RelayAssignmentStore {
           now
         ]
       )
+      if (input.enabled) {
+        // A budget spent under a previous enable is not evidence about this one.
+        // Without this an old counter latches the fresh enable straight back off
+        // on its first transient failure.
+        await transaction.query(
+          `INSERT INTO relay_region_rehome_worker_state
+           (worker_id, next_dispatch_at, paused_until, consecutive_failures, updated_at)
+           VALUES ('global', 0, 0, 0, ?)
+           ON CONFLICT (worker_id) DO UPDATE
+             SET paused_until = 0, consecutive_failures = 0,
+                 updated_at = excluded.updated_at`,
+          [now]
+        )
+      }
       const updated = (
         await transaction.query(
           `SELECT * FROM relay_region_rehome_control WHERE control_id = 'global'`
@@ -5940,7 +5957,7 @@ export class RelayAssignmentStore {
 
   async recordRegionalRehomeDispatchFailure(attemptId: string): Promise<void> {
     const now = this.now()
-    await this.database.transaction(async (transaction) => {
+    const disableLog = await this.database.transaction(async (transaction) => {
       const worker = (
         await transaction.queryLocked(
           `SELECT * FROM relay_region_rehome_worker_state WHERE worker_id = 'global'`
@@ -5952,49 +5969,44 @@ export class RelayAssignmentStore {
           [attemptId]
         )
       )[0]
-      if (!worker || !attempt) return
-      await this.incrementRegionalRehomeWorkerFailure(transaction, worker, now)
+      if (!worker || !attempt) return null
+      return await this.incrementRegionalRehomeWorkerFailure(transaction, worker, now)
     })
+    // Logged after the commit so a rollback cannot fabricate the record.
+    if (disableLog) console.warn(JSON.stringify(disableLog))
   }
 
-  async recordRegionalRehomeWorkerFailure(): Promise<void> {
-    const now = this.now()
-    await this.database.transaction(async (transaction) => {
-      await transaction.query(
-        `INSERT INTO relay_region_rehome_worker_state
-         (worker_id, next_dispatch_at, paused_until, consecutive_failures, updated_at)
-         VALUES ('global', 0, 0, 0, ?)
-         ON CONFLICT (worker_id) DO NOTHING`,
-        [now]
-      )
-      const worker = (
-        await transaction.queryLocked(
-          `SELECT * FROM relay_region_rehome_worker_state WHERE worker_id = 'global'`
-        )
-      )[0]!
-      await this.incrementRegionalRehomeWorkerFailure(transaction, worker, now)
-    })
-  }
-
+  // Returns the durable disable this failure caused, for the caller to log once
+  // its transaction commits; null when the budget survives or was already spent.
   private async incrementRegionalRehomeWorkerFailure(
     transaction: RelayDatabase,
     worker: SqlRow,
     now: number
-  ): Promise<void> {
+  ): Promise<Record<string, string | number> | null> {
     const failures = integer(worker, 'consecutive_failures') + 1
+    const spent = failures >= REGIONAL_REHOME_FAILURE_BUDGET
     await transaction.query(
       `UPDATE relay_region_rehome_worker_state
        SET consecutive_failures = ?, paused_until = ?, updated_at = ?
        WHERE worker_id = 'global'`,
-      [failures, failures >= 3 ? now + 5 * 60_000 : 0, now]
+      [failures, spent ? now + 5 * 60_000 : 0, now]
     )
-    if (failures >= 3) {
-      await transaction.query(
-        `UPDATE relay_region_rehome_control
-         SET generation = generation + 1, enabled = 0, updated_at = ?
-         WHERE control_id = 'global' AND enabled = 1`,
-        [now]
-      )
+    if (!spent) return null
+    const disabled = await transaction.query(
+      `UPDATE relay_region_rehome_control
+       SET generation = generation + 1, enabled = 0, updated_at = ?
+       WHERE control_id = 'global' AND enabled = 1
+       RETURNING generation`,
+      [now]
+    )
+    // The disable is otherwise invisible: inspection only shows enabled=false and
+    // nothing records that the failure budget, not an operator, turned it off.
+    if (disabled.length === 0) return null
+    return {
+      event: 'orca_relay_regional_rehome_failure_budget_disabled',
+      controlGeneration: integer(disabled[0]!, 'generation'),
+      consecutiveFailures: failures,
+      now
     }
   }
 

--- a/cloud/apps/relay/src/regional-rehome-postgres.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-postgres.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RelayAssignmentStore } from './assignment-store.js'
 import { openRelayDatabase, type RelayDatabase } from './database.js'
 import {
@@ -265,6 +265,91 @@ describePostgres('PostgreSQL regional rehoming', () => {
        WHERE user_id = ? AND completed_at IS NULL AND aborted_at IS NULL`,
       [context.identity.userId]
     )).toEqual([{ count: '1' }])
+  })
+
+  it('serializes an enable with a budget-exhausting failure without retries', async () => {
+    const context = await fixture()
+    const attempt = await context.store.claimRegionalRehome()
+    await context.store.recordRegionalRehomeDispatchFailure(attempt!.attemptId)
+    await context.store.recordRegionalRehomeDispatchFailure(attempt!.attemptId)
+    const locked = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    const primaryTransaction = primary.transaction.bind(primary)
+    const secondaryTransaction = secondary.transaction.bind(secondary)
+    let enableTransactions = 0
+    let failureTransactions = 0
+    let enablePid = 0
+    let failurePid = 0
+    const enableSpy = vi.spyOn(primary, 'transaction').mockImplementation((operation, options) =>
+      primaryTransaction(async (transaction) => {
+        enableTransactions++
+        enablePid = Number((await transaction.query('SELECT pg_backend_pid() AS pid'))[0]!.pid)
+        return await operation({
+          dialect: 'postgres',
+          query: transaction.query.bind(transaction),
+          queryLocked: async (sql, params, lockOptions) => {
+            const rows = await transaction.queryLocked(sql, params, lockOptions)
+            if (sql.includes('FROM relay_region_rehome_control')) {
+              locked.resolve()
+              await release.promise
+            }
+            return rows
+          },
+          transaction: transaction.transaction.bind(transaction),
+          close: transaction.close.bind(transaction)
+        })
+      }, options)
+    )
+    const failureSpy = vi.spyOn(secondary, 'transaction').mockImplementation((operation, options) =>
+      secondaryTransaction(async (transaction) => {
+        failureTransactions++
+        failurePid = Number((await transaction.query('SELECT pg_backend_pid() AS pid'))[0]!.pid)
+        return await operation(transaction)
+      }, options)
+    )
+    const enable = context.store.applyRegionalRehomeControl({
+      expectedGeneration: 1,
+      enabled: true,
+      notBefore: context.now(),
+      ratePerMinute: 10,
+      preferenceMaxAgeMs: 24 * 60 * 60_000,
+      hostCooldownMs: 7 * 24 * 60 * 60_000,
+      drainGraceMs: 60_000
+    })
+    let failure: Promise<void> | undefined
+    let outcomes: PromiseSettledResult<unknown>[] = []
+    try {
+      await Promise.race([
+        locked.promise,
+        enable.then(() => {
+          throw new Error('enable completed before the control lock')
+        })
+      ])
+      failure = context.competingStore.recordRegionalRehomeDispatchFailure(attempt!.attemptId)
+      // Observe the actual PostgreSQL wait before letting enable acquire the worker row.
+      await vi.waitFor(async () => {
+        expect(failurePid).not.toBe(0)
+        const rows = await primary.query('SELECT pg_blocking_pids(?) AS blockers', [failurePid])
+        expect(rows[0]!.blockers).toContain(enablePid)
+      }, { interval: 10, timeout: 800 })
+    } finally {
+      release.resolve()
+      outcomes = await Promise.allSettled([enable, ...(failure ? [failure] : [])])
+      enableSpy.mockRestore()
+      failureSpy.mockRestore()
+    }
+    expect(outcomes.map((outcome) => outcome.status)).toEqual(['fulfilled', 'fulfilled'])
+    expect({ enableTransactions, failureTransactions }).toEqual({
+      enableTransactions: 1,
+      failureTransactions: 1
+    })
+    expect(await context.store.inspectRegionalRehomeControl()).toMatchObject({
+      generation: 2,
+      enabled: true
+    })
+    expect(await primary.query(
+      `SELECT consecutive_failures, paused_until FROM relay_region_rehome_worker_state`
+    )).toEqual([{ consecutive_failures: '1', paused_until: '0' }])
   })
 
   it('increments the disable generation once across competing directors', async () => {

--- a/cloud/apps/relay/src/regional-rehome-store.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-store.test.ts
@@ -1709,6 +1709,77 @@ describe('regional rehome assignment state', () => {
     expect(await context.store.claimRegionalRehome()).toBeNull()
     await context.database.close()
   })
+
+  it('clears a stale failure budget when the control is enabled again', async () => {
+    const context = await setup()
+    await activatePreferredSource(context, {
+      userId: 'user-1',
+      relayHostId: 'abcdefghijklmnop'
+    })
+    const attempt = await context.store.claimRegionalRehome()
+    for (let index = 0; index < 3; index++) {
+      await context.store.recordRegionalRehomeDispatchFailure(attempt!.attemptId)
+    }
+    expect(await workerState(context)).toMatchObject({ consecutiveFailures: 3 })
+    const latched = await context.store.inspectRegionalRehomeControl()
+    expect(latched).toMatchObject({ generation: 2, enabled: false })
+
+    await context.store.applyRegionalRehomeControl({
+      expectedGeneration: latched.generation,
+      enabled: true,
+      notBefore: context.now(),
+      ratePerMinute: 10,
+      preferenceMaxAgeMs: 24 * 60 * 60_000,
+      hostCooldownMs: 7 * 24 * 60 * 60_000,
+      drainGraceMs: 60 * 60_000
+    })
+
+    // A budget spent under the previous enable is not evidence about this one.
+    expect(await workerState(context)).toMatchObject({
+      consecutiveFailures: 0,
+      pausedUntil: 0
+    })
+    // One transient failure must not latch the fresh enable straight back off.
+    await context.store.recordRegionalRehomeDispatchFailure(attempt!.attemptId)
+    expect(await context.store.inspectRegionalRehomeControl()).toMatchObject({
+      generation: 3,
+      enabled: true
+    })
+    await context.database.close()
+  })
+
+  it('reports the durable disable when the failure budget latches the control off', async () => {
+    const context = await setup()
+    await activatePreferredSource(context, {
+      userId: 'user-1',
+      relayHostId: 'abcdefghijklmnop'
+    })
+    const attempt = await context.store.claimRegionalRehome()
+    const warnings = collectEventWarnings(
+      'orca_relay_regional_rehome_failure_budget_disabled'
+    )
+    try {
+      for (let index = 0; index < 5; index++) {
+        await context.store.recordRegionalRehomeDispatchFailure(attempt!.attemptId)
+      }
+    } finally {
+      warnings.restore()
+    }
+
+    // Only the transition is reported; later failures find the control already off.
+    expect(warnings.entries).toEqual([
+      expect.objectContaining({
+        event: 'orca_relay_regional_rehome_failure_budget_disabled',
+        controlGeneration: 2,
+        consecutiveFailures: 3
+      })
+    ])
+    expect(await context.store.inspectRegionalRehomeControl()).toMatchObject({
+      generation: 2,
+      enabled: false
+    })
+    await context.database.close()
+  })
 })
 
 class TransactionCountingDatabase implements RelayDatabase {
@@ -2064,5 +2135,20 @@ class CellInventoryLockProbe {
       close: async () => undefined
     })
     return decorate(database)
+  }
+}
+
+async function workerState(
+  context: Context
+): Promise<{ consecutiveFailures: number; pausedUntil: number }> {
+  const row = (
+    await context.database.query(
+      `SELECT consecutive_failures, paused_until
+       FROM relay_region_rehome_worker_state WHERE worker_id = 'global'`
+    )
+  )[0]!
+  return {
+    consecutiveFailures: Number(row.consecutive_failures),
+    pausedUntil: Number(row.paused_until)
   }
 }

--- a/cloud/apps/relay/src/regional-rehome-worker.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-worker.test.ts
@@ -30,11 +30,9 @@ describe('regional rehome worker', () => {
     }
     const claimRegionalRehome = vi.fn().mockResolvedValueOnce(null).mockResolvedValue(attempt)
     const recordRegionalRehomeDrainReceipt = vi.fn().mockResolvedValue(true)
-    const recordRegionalRehomeWorkerFailure = vi.fn().mockResolvedValue(undefined)
     const assignments = {
       claimRegionalRehome,
-      recordRegionalRehomeDrainReceipt,
-      recordRegionalRehomeWorkerFailure
+      recordRegionalRehomeDrainReceipt
     } as unknown as RelayAssignmentStore
     const requests: Array<{ url: string; init?: RequestInit }> = []
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -99,8 +97,7 @@ describe('regional rehome worker', () => {
     const claimRegionalRehome = vi.fn().mockResolvedValueOnce(null).mockResolvedValue(attempt)
     const assignments = {
       claimRegionalRehome,
-      recordRegionalRehomeDispatchFailure: vi.fn().mockResolvedValue(undefined),
-      recordRegionalRehomeWorkerFailure: vi.fn().mockResolvedValue(undefined)
+      recordRegionalRehomeDispatchFailure: vi.fn().mockResolvedValue(undefined)
     } as unknown as RelayAssignmentStore
     const worker = startRegionalRehomeWorker(config(), assignments, {
       now: () => now,
@@ -118,7 +115,36 @@ describe('regional rehome worker', () => {
     expect(assignments.recordRegionalRehomeDispatchFailure).toHaveBeenCalledWith(
       '11111111-1111-4111-8111-111111111111'
     )
-    expect(assignments.recordRegionalRehomeWorkerFailure).not.toHaveBeenCalled()
+  })
+
+  it('keeps a failed poll out of the durable dispatch-failure budget', async () => {
+    let now = 0
+    const claimRegionalRehome = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockRejectedValue(new Error('Connection terminated due to connection timeout'))
+    const recordRegionalRehomeDispatchFailure = vi.fn().mockResolvedValue(undefined)
+    const assignments = {
+      claimRegionalRehome,
+      recordRegionalRehomeDispatchFailure
+    } as unknown as RelayAssignmentStore
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const worker = startRegionalRehomeWorker(config(), assignments, {
+      now: () => now,
+      safetySnapshot: () => safety(now),
+      intervalMs: 60_000
+    })!
+    await settleWorker()
+    now = 1_000
+    await expect(worker.run()).resolves.toBeUndefined()
+    worker.stop()
+
+    // The poll never claimed an attempt, so nothing was drained and nothing may
+    // be charged to the budget that latches the durable control off.
+    expect(recordRegionalRehomeDispatchFailure).not.toHaveBeenCalled()
+    expect(warn.mock.calls.map((call) => JSON.parse(String(call[0])).event)).toEqual([
+      'orca_relay_regional_rehome_poll_failed'
+    ])
   })
 
   it('passes unsafe process telemetry to the durable claim gate', async () => {

--- a/cloud/apps/relay/src/regional-rehome-worker.ts
+++ b/cloud/apps/relay/src/regional-rehome-worker.ts
@@ -97,13 +97,19 @@ export function startRegionalRehomeWorker(
         })
       )
     } catch (error) {
-      await (attemptId
-        ? assignments.recordRegionalRehomeDispatchFailure(attemptId)
-        : assignments.recordRegionalRehomeWorkerFailure()
-      ).catch(() => undefined)
+      // Only a claimed attempt was drained. A poll that failed before the claim
+      // - a pool timeout on the once-a-second control read - dispatched nothing,
+      // so it must not spend the budget that latches the durable control off.
+      if (attemptId) {
+        await assignments
+          .recordRegionalRehomeDispatchFailure(attemptId)
+          .catch(() => undefined)
+      }
       console.warn(
         JSON.stringify({
-          event: 'orca_relay_regional_rehome_dispatch_failed',
+          event: attemptId
+            ? 'orca_relay_regional_rehome_dispatch_failed'
+            : 'orca_relay_regional_rehome_poll_failed',
           reason: error instanceof Error ? error.message : 'unknown'
         })
       )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​204 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​197 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​36 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |

<!-- /orca-pr-loc -->

## The bug

The regional rehome worker polls `claimRegionalRehome` roughly once a second. Its `catch` routed **any** error thrown before an attempt was claimed into `assignments.recordRegionalRehomeWorkerFailure()`, which increments the durable `relay_region_rehome_worker_state.consecutive_failures` budget and disables the control at three.

In practice the thing throwing there is not a rehome failure at all: it is a node-postgres pool timeout on the pre-claim control read (`RELAY_DIRECTOR_DATABASE_POOL_MAX = 3`, `POSTGRES_CONNECTION_TIMEOUT_MS = 2_000`), 52-74 a day out of ~86,400 polls.

That counter resets in exactly one place — `recordRegionalRehomeDrainReceipt`, when a source cell answers a drain. While the control is disabled no drains happen, so it never resets. Production has been sitting at **1068 and still climbing** since 2026-08-28. Enabling the control did not clear it, so the next pool timeout took it to 1069, saw `>= 3`, and silently disabled the control again. That is the ten-minute lifetime of the 2026-08-28 21:06 UTC enable.

The auto-disable also wrote no log event, which is why nobody noticed for two weeks.

## The fix

**1. A poll that never claimed an attempt no longer spends the budget** (`regional-rehome-worker.ts`).

The boundary is the worker, not the store. `claimRegionalRehome` is already correct: it throws infrastructure errors and lets the caller decide. The defect is the caller's classification — `attemptId ? dispatch : worker` treats "we never dispatched" as a dispatch-budget event. The budget's own reset condition ("the source cell answered") proves it measures the drain-dispatch path, so only post-claim errors belong in it.

Making the store swallow connection errors instead would be wrong twice over: it would hide infrastructure failure from the safety telemetry that already tracks `sqlFailures` and pool pressure, and the store's one existing swallow is a deliberately narrow `isDatabaseLockUnavailable` predicate, not a blanket catch.

A pre-claim failure now logs `orca_relay_regional_rehome_poll_failed` rather than `..._dispatch_failed` — those pool timeouts were being reported as failed drains, which is precisely the misreading that hid this. `recordRegionalRehomeWorkerFailure` had no other caller and is removed rather than left as a live trap.

**2. Enabling the control clears the stale budget** (`applyRegionalRehomeControl`).

A budget spent under a previous enable is not evidence about this one. The enable path updated only `relay_region_rehome_control` and never touched the worker row. It now resets `consecutive_failures` and `paused_until` in the same transaction, in the same control-then-worker lock order `claimRegionalRehome` uses. `next_dispatch_at` is deliberately left alone so rate limiting survives the enable.

**3. The durable auto-disable now emits a structured event.**

`orca_relay_regional_rehome_failure_budget_disabled`, carrying `controlGeneration` and `consecutiveFailures`, following the existing `orca_relay_regional_rehome_safety_disabled` precedent and logged after the transaction commits so a rollback cannot fabricate it. Only the `enabled=1 -> 0` transition logs; later failures find the control already off.

## On the recency window (deliberately not done)

The brief asked whether the budget needs a time component. I argue no, and want the reviewer to push back if they disagree.

After fix 1 the only writers to the budget are post-claim dispatch failures and safety pauses, both of which can only happen while the control is enabled and claims are flowing. The staleness hazard needs increments to stop without either a reset or an enable. While the rehome is idle the counter cannot advance at all (`recordRegionalRehomeDispatchFailure` requires an attempt row, so a claim must have happened); while it is dispatching, receipts reset it. Fix 2 zeroes it at every enable.

The one residual case — two failures, then candidates run out permanently, then one more failure days later — latches off a control that has nothing left to do, and the next enable clears it. Buying that costs a `last_failure_at` column and a schema migration on a hot table. Not worth it. If ops wants a rolling window later it is an additive follow-up, not a prerequisite for re-enabling.

## Scope

No change to region selection, the candidate query, or which hosts are eligible. Failure accounting and the enable path only.

## Testing

Each behaviour change has a test that fails on `origin/main`:

| Test | Red on main |
|---|---|
| `keeps a failed poll out of the durable dispatch-failure budget` | `TypeError: assignments.recordRegionalRehomeWorkerFailure is not a function` — the worker demonstrably reaches for the durable budget on a pre-claim error |
| `clears a stale failure budget when the control is enabled again` | `consecutiveFailures: 3, pausedUntil: 87700000` survive the enable (expected `0, 0`) |
| `reports the durable disable when the failure budget latches the control off` | `expected [] to deeply equal [ObjectContaining{...}]` — no event emitted |

Gates, all from `cloud/`:

- `pnpm --filter @orca-cloud/relay test` with `ORCA_RELAY_TEST_POSTGRES_URL` on port 55440 — **72 files, 635 tests passed**. Postgres-backed suites confirmed executing, not skipped (`regional-rehome-postgres.test.ts`: 20 passed against a real PostgreSQL 16).
- `pnpm typecheck` — clean across all 4 projects.
- `pnpm lint` — clean across all 4 projects.

## Note on the brief

The method described as `setRegionalRehomeControl` is actually named `applyRegionalRehomeControl`. Everything else in the description matched the code.
