### PR TITLE
fix(mobile): restore iOS back swipes over the terminal

### DIFF
--- a/mobile/src/terminal/terminal-webview-html/surface-touch-gestures.ts
+++ b/mobile/src/terminal/terminal-webview-html/surface-touch-gestures.ts
@@ -42,6 +42,7 @@ export const TERMINAL_HTML_SURFACE_TOUCH_GESTURES = `  ${TERMINAL_TAP_DISPATCH_J
   });
 
   var ts = {
+    startX: 0, startY: 0, backSwipe: null,
     lastX: 0, lastY: 0, lastTime: 0, velY: 0,
     accumDelta: 0, momentumId: null, isPinching: false,
     pinchDist: 0, pinchScale: 0, pinchSurfX: 0, pinchSurfY: 0
@@ -78,6 +79,7 @@ export const TERMINAL_HTML_SURFACE_TOUCH_GESTURES = `  ${TERMINAL_TAP_DISPATCH_J
         cancelAnimationFrame(ts.momentumId);
         ts.momentumId = null;
       }
+      ts.backSwipe = null;
       if (e.touches.length === 2) {
         ts.isPinching = true;
         smoothScrollOffsetY = 0;
@@ -90,8 +92,9 @@ export const TERMINAL_HTML_SURFACE_TOUCH_GESTURES = `  ${TERMINAL_TAP_DISPATCH_J
         ts.pinchSurfY = (my - panY) / total;
       } else if (e.touches.length === 1) {
         ts.isPinching = false;
-        ts.lastX = e.touches[0].clientX;
-        ts.lastY = e.touches[0].clientY;
+        ts.startX = ts.lastX = e.touches[0].clientX;
+        ts.startY = ts.lastY = e.touches[0].clientY;
+        ts.backSwipe = isIOSWebView() && ts.startX <= 24 ? 'pending' : null;
         ts.lastTime = Date.now();
         ts.velY = 0;
         ts.accumDelta = 0;
@@ -101,8 +104,23 @@ export const TERMINAL_HTML_SURFACE_TOUCH_GESTURES = `  ${TERMINAL_TAP_DISPATCH_J
     targetSurface.addEventListener('touchmove', function(e) {
       if (dispatcherShouldBlockSurface()) return;
       if (!term) return;
-      e.preventDefault();
       e.stopPropagation();
+
+      // Let UIKit own edge-back without xterm cancelling the native gesture.
+      if (ts.backSwipe && e.touches.length === 1) {
+        if (ts.backSwipe === 'pending') {
+          var dx = e.touches[0].clientX - ts.startX;
+          var dy = e.touches[0].clientY - ts.startY;
+          if (Math.max(Math.abs(dx), Math.abs(dy)) < 8) return;
+          ts.backSwipe = dx > Math.abs(dy) ? 'active' : null;
+          if (ts.backSwipe === 'active') {
+            clearLongPress();
+            tapCandidate = null;
+          }
+        }
+        if (ts.backSwipe === 'active') return;
+      }
+      e.preventDefault();
 
       if (e.touches.length === 2) {
         ts.isPinching = true;
@@ -165,7 +183,7 @@ export const TERMINAL_HTML_SURFACE_TOUCH_GESTURES = `  ${TERMINAL_TAP_DISPATCH_J
 
     targetSurface.addEventListener('touchend', function(e) {
       if (dispatcherShouldBlockSurface()) return;
-      if (!term) return;
+      if (!term || ts.backSwipe === 'active') return;
 
       if (ts.isPinching && e.touches.length < 2) {
         ts.isPinching = false;

--- a/mobile/src/terminal/terminal-webview-html/surface-touch-gestures.ts
+++ b/mobile/src/terminal/terminal-webview-html/surface-touch-gestures.ts
@@ -183,7 +183,11 @@ export const TERMINAL_HTML_SURFACE_TOUCH_GESTURES = `  ${TERMINAL_TAP_DISPATCH_J
 
     targetSurface.addEventListener('touchend', function(e) {
       if (dispatcherShouldBlockSurface()) return;
-      if (!term || ts.backSwipe === 'active') return;
+      if (!term) return;
+      if (ts.backSwipe === 'active') {
+        e.stopPropagation();
+        return;
+      }
 
       if (ts.isPinching && e.touches.length < 2) {
         ts.isPinching = false;

--- a/mobile/src/terminal/terminal-webview-html/surface-touch-gestures.ts
+++ b/mobile/src/terminal/terminal-webview-html/surface-touch-gestures.ts
@@ -47,6 +47,8 @@ export const TERMINAL_HTML_SURFACE_TOUCH_GESTURES = `  ${TERMINAL_TAP_DISPATCH_J
     accumDelta: 0, momentumId: null, isPinching: false,
     pinchDist: 0, pinchScale: 0, pinchSurfX: 0, pinchSurfY: 0
   };
+  var EDGE_BACK_START_X = 24;
+  var EDGE_BACK_SLOP = 8;
 
   function updateTouchVelocity(deltaY, dt) {
     if (dt <= 0) return;
@@ -94,7 +96,7 @@ export const TERMINAL_HTML_SURFACE_TOUCH_GESTURES = `  ${TERMINAL_TAP_DISPATCH_J
         ts.isPinching = false;
         ts.startX = ts.lastX = e.touches[0].clientX;
         ts.startY = ts.lastY = e.touches[0].clientY;
-        ts.backSwipe = isIOSWebView() && ts.startX <= 24 ? 'pending' : null;
+        ts.backSwipe = isIOSWebView() && ts.startX <= EDGE_BACK_START_X ? 'pending' : null;
         ts.lastTime = Date.now();
         ts.velY = 0;
         ts.accumDelta = 0;
@@ -111,7 +113,7 @@ export const TERMINAL_HTML_SURFACE_TOUCH_GESTURES = `  ${TERMINAL_TAP_DISPATCH_J
         if (ts.backSwipe === 'pending') {
           var dx = e.touches[0].clientX - ts.startX;
           var dy = e.touches[0].clientY - ts.startY;
-          if (Math.max(Math.abs(dx), Math.abs(dy)) < 8) return;
+          if (Math.max(Math.abs(dx), Math.abs(dy)) < EDGE_BACK_SLOP) return;
           ts.backSwipe = dx > Math.abs(dy) ? 'active' : null;
           if (ts.backSwipe === 'active') {
             clearLongPress();

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -36,7 +36,7 @@ describe('TerminalWebView scroll routing', () => {
   })
 
   it('yields an iOS left-edge back swipe without panning, scrolling, tapping, or momentum', () => {
-    const { touch, context, descendantTouchMove } = createTerminalTouchHarness()
+    const { touch, context, descendantTouchMove, descendantTouchEnd } = createTerminalTouchHarness()
     context.shouldRouteScrollToTerminalInput = () => true
     touch('touchstart', [[4, 200]])
     const move = touch('touchmove', [[84, 204]])
@@ -47,7 +47,11 @@ describe('TerminalWebView scroll routing', () => {
     expect(context.tapCandidate).toBeNull()
     expect(context.longPressTimer).toBeNull()
     expect(touch('touchmove', [[2, 200]]).preventDefault).not.toHaveBeenCalled()
-    touch('touchend', [])
+    const end = touch('touchend', [])
+    expect(end.defaultPrevented).toBe(false)
+    expect(end.preventDefault).not.toHaveBeenCalled()
+    expect(descendantTouchEnd).not.toHaveBeenCalled()
+    expect(end.stopPropagation).toHaveBeenCalled()
     vi.advanceTimersByTime(600)
     expect(context.notifyTerminalSurfaceTap).not.toHaveBeenCalled()
     expect(context.enterSelect).not.toHaveBeenCalled()
@@ -70,10 +74,12 @@ describe('TerminalWebView scroll routing', () => {
     ['iOS edge scroll', true, 4, 6, 280],
     ['iOS leftward pan', true, 20, 2, 204]
   ] as const)('preserves terminal handling for %s', (_name, ios, startX, endX, endY) => {
-    const { touch, context } = createTerminalTouchHarness(ios)
+    const { touch, context, descendantTouchEnd } = createTerminalTouchHarness(ios)
     touch('touchstart', [[startX, 200]])
     expect(touch('touchmove', [[endX, endY]]).preventDefault).toHaveBeenCalled()
     expect(context.enqueueNormalBufferScrollDelta).toHaveBeenCalled()
+    touch('touchend', [])
+    expect(descendantTouchEnd).toHaveBeenCalledOnce()
   })
 
   it('keeps an edge-origin vertical scroll in the terminal after a horizontal turn', () => {

--- a/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
+++ b/mobile/src/terminal/terminal-webview-scroll-routing.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { readTerminalWebViewHtmlSource } from './terminal-webview-html-source.test-support'
+import { createTerminalTouchHarness } from './terminal-webview-touch-test-harness'
 
 // The in-WebView JS lives in terminal-webview-html.ts; the RN wrapper in
 // TerminalWebView.tsx. Concatenate both so assertions resolve regardless of file.
@@ -28,6 +29,131 @@ function sliceBetween(startPattern: string, endPattern: string): string {
 }
 
 describe('TerminalWebView scroll routing', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('yields an iOS left-edge back swipe without panning, scrolling, tapping, or momentum', () => {
+    const { touch, context, descendantTouchMove } = createTerminalTouchHarness()
+    context.shouldRouteScrollToTerminalInput = () => true
+    touch('touchstart', [[4, 200]])
+    const move = touch('touchmove', [[84, 204]])
+    expect(move.defaultPrevented).toBe(false)
+    expect(move.preventDefault).not.toHaveBeenCalled()
+    expect(move.stopPropagation).toHaveBeenCalled()
+    expect(descendantTouchMove).not.toHaveBeenCalled()
+    expect(context.tapCandidate).toBeNull()
+    expect(context.longPressTimer).toBeNull()
+    expect(touch('touchmove', [[2, 200]]).preventDefault).not.toHaveBeenCalled()
+    touch('touchend', [])
+    vi.advanceTimersByTime(600)
+    expect(context.notifyTerminalSurfaceTap).not.toHaveBeenCalled()
+    expect(context.enterSelect).not.toHaveBeenCalled()
+    expect(context.enqueueNormalBufferScrollDelta).not.toHaveBeenCalled()
+    expect(context.routeScrollLines).not.toHaveBeenCalled()
+    expect(context.updateTransform).not.toHaveBeenCalled()
+    expect(context.requestAnimationFrame).not.toHaveBeenCalled()
+  })
+
+  it('waits through initial finger jitter before handing a back swipe to iOS', () => {
+    const { touch } = createTerminalTouchHarness()
+    touch('touchstart', [[4, 200]])
+    expect(touch('touchmove', [[3, 203]]).preventDefault).not.toHaveBeenCalled()
+    expect(touch('touchmove', [[84, 200]]).preventDefault).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['Android edge swipe', false, 4, 84, 204],
+    ['iOS interior swipe', true, 25, 105, 204],
+    ['iOS edge scroll', true, 4, 6, 280],
+    ['iOS leftward pan', true, 20, 2, 204]
+  ] as const)('preserves terminal handling for %s', (_name, ios, startX, endX, endY) => {
+    const { touch, context } = createTerminalTouchHarness(ios)
+    touch('touchstart', [[startX, 200]])
+    expect(touch('touchmove', [[endX, endY]]).preventDefault).toHaveBeenCalled()
+    expect(context.enqueueNormalBufferScrollDelta).toHaveBeenCalled()
+  })
+
+  it('keeps an edge-origin vertical scroll in the terminal after a horizontal turn', () => {
+    const { touch } = createTerminalTouchHarness()
+    touch('touchstart', [[4, 200]])
+    touch('touchmove', [[4, 230]])
+    expect(touch('touchmove', [[84, 230]]).preventDefault).toHaveBeenCalled()
+  })
+
+  it('dispatches edge taps and clears their pending long press', () => {
+    const { touch, context } = createTerminalTouchHarness()
+    touch('touchstart', [[4, 200]])
+    touch('touchmove', [[6, 202]])
+    touch('touchend', [])
+    expect(context.notifyTerminalSurfaceTap).toHaveBeenCalledExactlyOnceWith(4, 200, true)
+    expect(context.tapCandidate).toBeNull()
+    expect(context.longPressTimer).toBeNull()
+    vi.advanceTimersByTime(600)
+    expect(context.enterSelect).not.toHaveBeenCalled()
+  })
+
+  it('enters selection after a long press at the edge without dispatching a tap', () => {
+    const { touch, context } = createTerminalTouchHarness()
+    touch('touchstart', [[4, 200]])
+    touch('touchmove', [[6, 202]])
+    vi.advanceTimersByTime(500)
+    expect(context.enterSelect).toHaveBeenCalledExactlyOnceWith(0, 0)
+    touch('touchend', [])
+    expect(context.notifyTerminalSurfaceTap).not.toHaveBeenCalled()
+    expect(context.longPressOrigin).toBeNull()
+  })
+
+  it('clears the tap and long press as soon as a back swipe crosses its threshold', () => {
+    const { touch, context } = createTerminalTouchHarness()
+    touch('touchstart', [[4, 200]])
+    touch('touchmove', [[12, 200]])
+    vi.advanceTimersByTime(500)
+    touch('touchend', [])
+    expect(context.enterSelect).not.toHaveBeenCalled()
+    expect(context.notifyTerminalSurfaceTap).not.toHaveBeenCalled()
+  })
+
+  it('leaves selection-handle drags to the document dispatcher', () => {
+    const { touch, context, handleStart } = createTerminalTouchHarness()
+    touch('touchstart', [[4, 200]])
+    vi.advanceTimersByTime(500)
+    touch('touchend', [])
+    touch('touchstart', [[4, 200]], handleStart)
+    expect(touch('touchmove', [[84, 200]], handleStart).defaultPrevented).toBe(true)
+    expect(context.handleDragMove).toHaveBeenCalledWith('start', 84, 200)
+    touch('touchcancel', [], handleStart)
+    expect(context.sel?.activeHandle).toBeNull()
+  })
+
+  it('preserves pinch zoom when a second finger joins an edge touch', () => {
+    const { touch, context } = createTerminalTouchHarness()
+    touch('touchstart', [[4, 200]])
+    touch('touchstart', [[4, 200], [100, 200]])
+    expect(touch('touchmove', [[4, 200], [150, 200]]).preventDefault).toHaveBeenCalled()
+    expect(context.updateTransform).toHaveBeenCalled()
+  })
+
+  it.each([false, true])('cleans up a cancelled edge touch (back swipe active: %s)', (active) => {
+    const { touch, context } = createTerminalTouchHarness()
+    touch('touchstart', [[4, 200]])
+    if (active) {
+      touch('touchmove', [[84, 200]])
+    }
+    touch('touchcancel', [])
+    expect(context.tapCandidate).toBeNull()
+    expect(context.longPressTimer).toBeNull()
+    expect(context.longPressOrigin).toBeNull()
+    expect(context.stopEdgeScroll).toHaveBeenCalled()
+    vi.advanceTimersByTime(600)
+    expect(context.enterSelect).not.toHaveBeenCalled()
+    expect(context.notifyTerminalSurfaceTap).not.toHaveBeenCalled()
+    touch('touchstart', [[100, 200]])
+    expect(touch('touchmove', [[100, 250]]).preventDefault).toHaveBeenCalled()
+  })
+
   it('keeps Android touch drags inside the terminal WebView', () => {
     expect(source).toContain('nestedScrollEnabled')
   })

--- a/mobile/src/terminal/terminal-webview-touch-test-harness.ts
+++ b/mobile/src/terminal/terminal-webview-touch-test-harness.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from 'node:fs'
+import { Script } from 'node:vm'
+import { vi } from 'vitest'
+import { TERMINAL_TAP_DISPATCH_JS } from './terminal-webview-tap-dispatch-injected'
+import { TERMINAL_HTML_SELECTION_STATE_AND_EVICTION } from './terminal-webview-html/selection-state-and-eviction'
+
+type TouchEvent = {
+  target: object
+  touches: Array<{ identifier: number; clientX: number; clientY: number }>
+  preventDefault: ReturnType<typeof vi.fn>
+  stopPropagation: ReturnType<typeof vi.fn>
+}
+type TouchListener = {
+  handler: (event: TouchEvent) => void
+  capture: boolean
+  passive: boolean
+}
+
+function createTouchTarget() {
+  const listeners = new Map<string, TouchListener>()
+  return {
+    listeners,
+    addEventListener(
+      type: string,
+      handler: TouchListener['handler'],
+      options: boolean | AddEventListenerOptions = false
+    ) {
+      listeners.set(type, {
+        handler,
+        capture: typeof options === 'boolean' ? options : (options.capture ?? false),
+        passive: typeof options === 'boolean' ? false : (options.passive ?? false)
+      })
+    }
+  }
+}
+
+export function createTerminalTouchHarness(ios = true) {
+  const source = readFileSync(
+    new URL('./terminal-webview-html/surface-touch-gestures.ts', import.meta.url),
+    'utf8'
+  )
+  const cell = {}
+  const handleStart = {}
+  const handleEnd = {}
+  const context = {
+    document: {
+      ...createTouchTarget(),
+      getElementById(id: string) {
+        if (id === 'sel-handle-start') {
+          return handleStart
+        }
+        if (id === 'sel-handle-end') {
+          return handleEnd
+        }
+        return { contains: (target: object) => target === handleStart || target === handleEnd }
+      }
+    },
+    surface: { ...createTouchTarget(), contains: (target: object) => target === cell },
+    attachSurfaceWheelHandler: vi.fn(),
+    attachSurfaceMouseClickDragHandler: vi.fn(),
+    isIOSWebView: () => ios,
+    term: { element: { scrollWidth: 800 } },
+    window: { innerWidth: 400 },
+    getTotalScale: () => 1,
+    getCellHeight: () => 15,
+    shouldRouteScrollToTerminalInput: () => false,
+    enqueueNormalBufferScrollDelta: vi.fn(() => true),
+    applyNormalBufferScrollDelta: vi.fn(() => true),
+    resetSmoothScrollOffset: vi.fn(),
+    routeScrollLines: vi.fn(),
+    clampPan: vi.fn(),
+    updateTransform: vi.fn(),
+    requestAnimationFrame: vi.fn(() => 1),
+    cancelAnimationFrame: vi.fn(),
+    viewportToCell: () => ({ col: 0, row: 0 }),
+    enterSelect: vi.fn(),
+    cancelSelect: vi.fn(),
+    handleDragMove: vi.fn(),
+    stopEdgeScroll: vi.fn(),
+    notify: vi.fn(),
+    notifyTerminalSurfaceTap: vi.fn(),
+    tapCandidate: null as object | null,
+    longPressTimer: null as ReturnType<typeof setTimeout> | null,
+    longPressOrigin: null as object | null,
+    selMode: 'navigate',
+    sel: null as { activeHandle: string | null } | null,
+    panX: 0,
+    panY: 0,
+    userScale: 1,
+    currentTextScale: 1,
+    MIN_TEXT_SCALE: 0.5,
+    MAX_TEXT_SCALE: 2,
+    setTimeout,
+    clearTimeout,
+    Date,
+    Math
+  }
+  context.enterSelect.mockImplementation(() => {
+    context.selMode = 'select'
+    context.sel = { activeHandle: null }
+  })
+  context.cancelSelect.mockImplementation(() => {
+    context.selMode = 'navigate'
+    context.sel = null
+  })
+  const start = source.indexOf('  var ts =')
+  if (start === -1) {
+    throw new Error('Terminal touch handlers not found')
+  }
+  new Script(
+    TERMINAL_HTML_SELECTION_STATE_AND_EVICTION +
+      TERMINAL_TAP_DISPATCH_JS +
+      source.slice(start, source.lastIndexOf('`'))
+  ).runInNewContext(context)
+  const descendantTouchMove = vi.fn((event: TouchEvent) => event.preventDefault())
+
+  function touch(type: string, points: Array<[number, number]>, target = cell) {
+    let stopped = false
+    let passive = false
+    let defaultPrevented = false
+    const event: TouchEvent = {
+      target,
+      touches: points.map(([clientX, clientY], identifier) => ({ identifier, clientX, clientY })),
+      preventDefault: vi.fn(() => {
+        if (!passive) {
+          defaultPrevented = true
+        }
+      }),
+      stopPropagation: vi.fn(() => {
+        stopped = true
+      })
+    }
+    const ancestors = target === cell ? [context.document, context.surface] : [context.document]
+    function dispatchListener(listener: TouchListener | undefined, capture: boolean) {
+      if (stopped || !listener || listener.capture !== capture) {
+        return
+      }
+      passive = listener.passive
+      listener.handler(event)
+    }
+    for (const ancestor of ancestors) {
+      dispatchListener(ancestor.listeners.get(type), true)
+    }
+    if (!stopped && type === 'touchmove' && target === cell) {
+      passive = false
+      descendantTouchMove(event)
+    }
+    for (const ancestor of ancestors.toReversed()) {
+      dispatchListener(ancestor.listeners.get(type), false)
+    }
+    return { ...event, defaultPrevented }
+  }
+
+  return { touch, context, descendantTouchMove, handleStart }
+}

--- a/mobile/src/terminal/terminal-webview-touch-test-harness.ts
+++ b/mobile/src/terminal/terminal-webview-touch-test-harness.ts
@@ -113,6 +113,7 @@ export function createTerminalTouchHarness(ios = true) {
       source.slice(start, source.lastIndexOf('`'))
   ).runInNewContext(context)
   const descendantTouchMove = vi.fn((event: TouchEvent) => event.preventDefault())
+  const descendantTouchEnd = vi.fn()
 
   function touch(type: string, points: Array<[number, number]>, target = cell) {
     let stopped = false
@@ -141,9 +142,13 @@ export function createTerminalTouchHarness(ios = true) {
     for (const ancestor of ancestors) {
       dispatchListener(ancestor.listeners.get(type), true)
     }
-    if (!stopped && type === 'touchmove' && target === cell) {
+    if (!stopped && target === cell) {
       passive = false
-      descendantTouchMove(event)
+      if (type === 'touchmove') {
+        descendantTouchMove(event)
+      } else if (type === 'touchend') {
+        descendantTouchEnd(event)
+      }
     }
     for (const ancestor of ancestors.toReversed()) {
       dispatchListener(ancestor.listeners.get(type), false)
@@ -151,5 +156,5 @@ export function createTerminalTouchHarness(ios = true) {
     return { ...event, defaultPrevented }
   }
 
-  return { touch, context, descendantTouchMove, handleStart }
+  return { touch, context, descendantTouchMove, descendantTouchEnd, handleStart }
 }


### PR DESCRIPTION
## ELI5

**Paused: the reported bug is real, but this patch still fails native verification.** On iOS, swiping from the left edge over terminal content stays on the terminal. The same swipe over the native command dock goes back. Both the original code and this PR behave that way in the simulator.

## What Changed

The candidate patch stops cancelling predominantly rightward iOS touches that start in the leftmost 24 CSS pixels. It adds a small movement threshold and suppresses terminal scrolling/taps during a recognized back swipe.

## Why

The hypothesis was that cancelling every WebView touch move prevents native back navigation. Actual UIKit/WKWebView testing shows this JavaScript routing change alone is insufficient. Further work must identify the native gesture ownership boundary before changing this approach; no additional symptom patches were made.

## Linked Issue

Reported directly by the user; no issue reference supplied.

## Visual Proof

Native iPhone 17 Pro / iOS 26.1 screenshot after the terminal-edge swipe on this PR head. The session remains open; this is failure evidence, not a successful after image.

![PR head remains on terminal after edge swipe](https://github.com/user-attachments/assets/968d084a-6c4d-4968-9c23-f30c6e2496e9)

A local native recording also captured the failed terminal swipe followed by the working dock control. It was not uploaded because the destination workspace list includes unrelated workspace titles. There is no successful after proof.

## Testing

- [x] I manually tested these changes locally — native verification failed as described below.
- [x] Automated tests added/updated.

2026-09-17 native A/B check:

- Base: `e74c22a0e77`; head: `88b1dba7ab59c3ce09f9424133360b34fdb0e02d`.
- Headless iPhone 17 Pro simulator, iOS 26.1; installed Expo development binary version 0.0.36; Metro loaded each pinned JavaScript revision. No simulator desktop window was revealed or activated.
- Confirmed the running head module exported the new `EDGE_BACK_SLOP` implementation through the React Native debugger. This PR changes JavaScript only; the same native binary was used for both sides.
- Open the host workspace list, then the isolated `shaharmor-ios-review` shell terminal. Send 32 native begin/move/end touch points, x=0.005 to 0.855, y=0.5, approximately 16 ms apart. Both revisions remain on the terminal.
- The same native gesture at y=0.93 over the command dock returns to the host workspace list on both revisions. Repeated the head failure and successful dock control in a recording.
- The PR's `terminal-webview-scroll-routing.test.ts` suite passed all 28 tests. These tests prove JavaScript event routing, not native navigation.

Full readiness/elegance/final acceptance is paused at the failed native/root-cause gate. No successful full-build, typecheck, or device pass is claimed.

## AI Disclosure

Original implementation: Pi using `gpt-6-astra` via GitHub Copilot. Follow-up review and native exercise: Codex.

## Review

Do not merge as a verified fix. The original symptom is reproduced, but the proposed mechanism did not fix it in native exercise. No release-blocking severity or regression verdict is assigned here. The next step is a captured native gesture investigation, followed by a new approach and repeated native A/B proof.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill source was copied.

## Notes

The changed runtime path is client-side touch routing: no persisted state, RPC, execution-host, SSH, authentication, or provider contract changes. The candidate deliberately reserves rightward gestures starting in the leftmost 24 pixels; the impact on horizontal terminal panning and vertical gesture arbitration remains unaccepted until native navigation works.

## Author

X: [@shaharmor1](https://x.com/shaharmor1)

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why, including ELI5.
- [ ] Successful before/after visual proof.
- [ ] Full readiness review and final behavior accepted.
- [x] Cross-platform, SSH/remote, and path/shortcut scope considered.
- [ ] Full lint, typecheck, tests, and build pass.
