### PR TITLE
feat(editor): add "Reload from Disk" to the editor tab context menu

### DIFF
--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -16,6 +16,7 @@ export const ORCA_EDITOR_SAVE_AND_CLOSE_EVENT = 'orca:save-and-close'
 export const ORCA_EDITOR_FILE_SAVED_EVENT = 'orca:editor-file-saved'
 export const ORCA_EDITOR_REQUEST_CMD_SAVE_EVENT = 'orca:editor-request-cmd-save'
 export const ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT = 'orca:editor-request-file-close'
+export const ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT = 'orca:editor-request-file-reload'
 
 export type EditorPathMutationTarget = {
   worktreeId: string
@@ -52,6 +53,10 @@ export type EditorFileSavedDetail = {
 }
 
 export type EditorRequestFileCloseDetail = {
+  fileId: string
+}
+
+export type EditorRequestFileReloadDetail = {
   fileId: string
 }
 
@@ -215,6 +220,17 @@ export async function requestEditorFileSave(target: EditorSaveFileTarget): Promi
 export function requestEditorFileClose(fileId: string): void {
   window.dispatchEvent(
     new CustomEvent<EditorRequestFileCloseDetail>(ORCA_EDITOR_REQUEST_FILE_CLOSE_EVENT, {
+      detail: { fileId }
+    })
+  )
+}
+
+// CONTRACT: dispatched only after any unsaved draft has been discarded (see
+// requestEditorTabDiskReload) — consumers reload without a dirty skip, because
+// their openFiles snapshot can still say dirty before that store write renders.
+export function requestEditorFileReload(fileId: string): void {
+  window.dispatchEvent(
+    new CustomEvent<EditorRequestFileReloadDetail>(ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT, {
       detail: { fileId }
     })
   )

--- a/src/renderer/src/components/editor/editor-tab-disk-reload.test.ts
+++ b/src/renderer/src/components/editor/editor-tab-disk-reload.test.ts
@@ -69,14 +69,23 @@ describe('requestEditorTabDiskReload', () => {
     window.removeEventListener(ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT, listener)
   })
 
-  it('dispatches a reload request for a clean tab without touching the draft state', () => {
+  it('dispatches a reload request for a clean tab without an undo toast', () => {
     mockStore([makeFile()])
 
     requestEditorTabDiskReload('file-1')
 
     expect(dispatchedFileIds).toEqual(['file-1'])
-    expect(clearEditorDraft).not.toHaveBeenCalled()
-    expect(markFileDirty).not.toHaveBeenCalled()
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  it('discards a not-yet-dirty draft (isDirty lags behind the debounced draft sync)', () => {
+    mockStore([makeFile()], { 'file-1': 'draft before isDirty flushes' })
+
+    requestEditorTabDiskReload('file-1')
+
+    expect(dispatchedFileIds).toEqual(['file-1'])
+    expect(clearEditorDraft).toHaveBeenCalledWith('file-1')
+    expect(toastMock).toHaveBeenCalledTimes(1)
   })
 
   it('discards a dirty tab draft (with the undo toast) before dispatching', () => {

--- a/src/renderer/src/components/editor/editor-tab-disk-reload.test.ts
+++ b/src/renderer/src/components/editor/editor-tab-disk-reload.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+
+const toastMock = vi.hoisted(() => vi.fn())
+vi.mock('sonner', () => ({ toast: toastMock }))
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: vi.fn()
+  }
+}))
+vi.mock('@/runtime/runtime-file-client', () => ({
+  readRuntimeFileContent: vi.fn()
+}))
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  settingsForRuntimeOwner: () => null
+}))
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionIdForFile: () => undefined
+}))
+
+import { useAppStore } from '@/store'
+import {
+  ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT,
+  type EditorRequestFileReloadDetail
+} from './editor-autosave'
+import { requestEditorTabDiskReload } from './editor-tab-disk-reload'
+
+function makeFile(overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id: 'file-1',
+    filePath: '/repo/notes.md',
+    relativePath: 'notes.md',
+    worktreeId: 'wt-1',
+    language: 'markdown',
+    mode: 'edit',
+    isDirty: false,
+    ...overrides
+  } as OpenFile
+}
+
+describe('requestEditorTabDiskReload', () => {
+  const clearEditorDraft = vi.fn()
+  const markFileDirty = vi.fn()
+  const setExternalMutation = vi.fn()
+  const dispatchedFileIds: string[] = []
+  const listener = (event: Event): void => {
+    dispatchedFileIds.push((event as CustomEvent<EditorRequestFileReloadDetail>).detail.fileId)
+  }
+
+  function mockStore(openFiles: OpenFile[], editorDrafts: Record<string, string> = {}): void {
+    vi.mocked(useAppStore.getState).mockReturnValue({
+      clearEditorDraft,
+      markFileDirty,
+      setExternalMutation,
+      editorDrafts,
+      openFiles
+    } as never)
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    dispatchedFileIds.length = 0
+    window.addEventListener(ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT, listener)
+  })
+
+  afterEach(() => {
+    window.removeEventListener(ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT, listener)
+  })
+
+  it('dispatches a reload request for a clean tab without touching the draft state', () => {
+    mockStore([makeFile()])
+
+    requestEditorTabDiskReload('file-1')
+
+    expect(dispatchedFileIds).toEqual(['file-1'])
+    expect(clearEditorDraft).not.toHaveBeenCalled()
+    expect(markFileDirty).not.toHaveBeenCalled()
+  })
+
+  it('discards a dirty tab draft (with the undo toast) before dispatching', () => {
+    const order: string[] = []
+    clearEditorDraft.mockImplementation(() => order.push('clearEditorDraft'))
+    mockStore([makeFile({ id: 'dirty-file', isDirty: true })], { 'dirty-file': 'unsaved text' })
+    const trackDispatch = (): void => {
+      order.push('dispatch')
+    }
+    window.addEventListener(ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT, trackDispatch)
+
+    requestEditorTabDiskReload('dirty-file')
+    window.removeEventListener(ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT, trackDispatch)
+
+    expect(dispatchedFileIds).toEqual(['dirty-file'])
+    expect(clearEditorDraft).toHaveBeenCalledWith('dirty-file')
+    expect(markFileDirty).toHaveBeenCalledWith('dirty-file', false)
+    expect(setExternalMutation).toHaveBeenCalledWith('dirty-file', null)
+    expect(toastMock).toHaveBeenCalledTimes(1)
+    // Why: the draft shadows loaded content, so the discard must land before
+    // the owning panel refetches or the stale unsaved text stays visible.
+    expect(order).toEqual(['clearEditorDraft', 'dispatch'])
+  })
+
+  it('ignores tabs that have no single reloadable disk source', () => {
+    mockStore([makeFile({ mode: 'diff', diffSource: 'combined-uncommitted' })])
+
+    requestEditorTabDiskReload('file-1')
+
+    expect(dispatchedFileIds).toEqual([])
+    expect(clearEditorDraft).not.toHaveBeenCalled()
+  })
+
+  it('ignores unknown file ids', () => {
+    mockStore([makeFile()])
+
+    requestEditorTabDiskReload('missing')
+
+    expect(dispatchedFileIds).toEqual([])
+  })
+})

--- a/src/renderer/src/components/editor/editor-tab-disk-reload.ts
+++ b/src/renderer/src/components/editor/editor-tab-disk-reload.ts
@@ -1,0 +1,19 @@
+import { useAppStore } from '@/store'
+import { isExternalReloadableEditorTab, requestEditorFileReload } from './editor-autosave'
+import { reloadTabContentFromDisk } from './ExternalFileChangeBanner'
+
+/** User-requested "Reload from Disk" (editor tab context menu). Dirty tabs go
+ *  through reloadTabContentFromDisk so the discarded draft gets the same Undo
+ *  toast as the conflict banner; the refetch itself is delegated to the owning
+ *  EditorPanel via the reload-request event. */
+export function requestEditorTabDiskReload(fileId: string): void {
+  const file = useAppStore.getState().openFiles.find((openFile) => openFile.id === fileId)
+  if (!file || !isExternalReloadableEditorTab(file)) {
+    return
+  }
+  if (file.isDirty) {
+    reloadTabContentFromDisk(file, (target) => requestEditorFileReload(target.id))
+    return
+  }
+  requestEditorFileReload(file.id)
+}

--- a/src/renderer/src/components/editor/editor-tab-disk-reload.ts
+++ b/src/renderer/src/components/editor/editor-tab-disk-reload.ts
@@ -2,18 +2,16 @@ import { useAppStore } from '@/store'
 import { isExternalReloadableEditorTab, requestEditorFileReload } from './editor-autosave'
 import { reloadTabContentFromDisk } from './ExternalFileChangeBanner'
 
-/** User-requested "Reload from Disk" (editor tab context menu). Dirty tabs go
- *  through reloadTabContentFromDisk so the discarded draft gets the same Undo
- *  toast as the conflict banner; the refetch itself is delegated to the owning
- *  EditorPanel via the reload-request event. */
+/** User-requested "Reload from Disk" (editor tab context menu). Always routes
+ *  through reloadTabContentFromDisk — isDirty lags editorDrafts (debounced), so
+ *  gating on it could leave a not-yet-dirty draft shadowing the reloaded
+ *  content. For clean tabs its mutations are no-ops and the Undo toast fires
+ *  only when a draft was actually discarded; the refetch itself is delegated
+ *  to the owning EditorPanel via the reload-request event. */
 export function requestEditorTabDiskReload(fileId: string): void {
   const file = useAppStore.getState().openFiles.find((openFile) => openFile.id === fileId)
   if (!file || !isExternalReloadableEditorTab(file)) {
     return
   }
-  if (file.isDirty) {
-    reloadTabContentFromDisk(file, (target) => requestEditorFileReload(target.id))
-    return
-  }
-  requestEditorFileReload(file.id)
+  reloadTabContentFromDisk(file, (target) => requestEditorFileReload(target.id))
 }

--- a/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.test.tsx
@@ -4,7 +4,10 @@ import { act, useLayoutEffect, useRef, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { OpenFile } from '@/store/slices/editor'
-import { ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT } from './editor-autosave'
+import {
+  ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
+  ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT
+} from './editor-autosave'
 import type { DiffContent, FileContent } from './editor-panel-content-types'
 import { useEditorPanelExternalContentEvents } from './useEditorPanelExternalContentEvents'
 
@@ -83,6 +86,14 @@ function dispatchExternalChange(relativePath: string): void {
           relativePath
         }
       })
+    )
+  })
+}
+
+function dispatchReloadRequest(fileId: string): void {
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent(ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT, { detail: { fileId } })
     )
   })
 }
@@ -238,5 +249,88 @@ describe('useEditorPanelExternalContentEvents', () => {
     const previewOptions = previewCalls.loadFile.mock.calls[0]?.[4]
     expect(sourceOptions?.externalEventGeneration).toBeTypeOf('number')
     expect(previewOptions?.externalEventGeneration).toBe(sourceOptions?.externalEventGeneration)
+  })
+
+  describe('reload requests', () => {
+    it('force-reloads the visible owner', () => {
+      const file = makeFile('reloaded')
+      const calls = makeCalls()
+
+      act(() => {
+        root.render(
+          <ExternalContentProbe activeFileId={file.id} calls={calls} isVisible openFiles={[file]} />
+        )
+      })
+      dispatchReloadRequest(file.id)
+
+      expect(calls.loadFile).toHaveBeenCalledOnce()
+      expect(calls.loadFile.mock.calls[0]?.[4]?.force).toBe(true)
+      expect(calls.invalidateDiff).toHaveBeenCalledExactlyOnceWith([file.id])
+    })
+
+    it('invalidates a hidden panel without reloading until reveal', () => {
+      const file = makeFile('reloaded')
+      const calls = makeCalls()
+
+      act(() => {
+        root.render(
+          <ExternalContentProbe
+            activeFileId={file.id}
+            calls={calls}
+            isVisible={false}
+            openFiles={[file]}
+          />
+        )
+      })
+      dispatchReloadRequest(file.id)
+
+      expect(calls.loadFile).not.toHaveBeenCalled()
+      expect(calls.invalidate).toHaveBeenCalledExactlyOnceWith([file.id])
+    })
+
+    it('reloads a still-dirty snapshot — the dispatcher already discarded the draft', () => {
+      const file = makeFile('reloaded', { isDirty: true })
+      const calls = makeCalls()
+
+      act(() => {
+        root.render(
+          <ExternalContentProbe activeFileId={file.id} calls={calls} isVisible openFiles={[file]} />
+        )
+      })
+      dispatchReloadRequest(file.id)
+
+      expect(calls.loadFile).toHaveBeenCalledOnce()
+    })
+
+    it('reloads the diff body for an unstaged diff tab', () => {
+      const file = makeFile('reloaded', { mode: 'diff', diffSource: 'unstaged' })
+      const calls = makeCalls()
+
+      act(() => {
+        root.render(
+          <ExternalContentProbe activeFileId={file.id} calls={calls} isVisible openFiles={[file]} />
+        )
+      })
+      dispatchReloadRequest(file.id)
+
+      expect(calls.loadFile).not.toHaveBeenCalled()
+      expect(calls.loadDiff).toHaveBeenCalledOnce()
+      expect(calls.loadDiff.mock.calls[0]?.[1]?.force).toBe(true)
+    })
+
+    it('ignores requests for files this panel does not hold', () => {
+      const file = makeFile('reloaded')
+      const calls = makeCalls()
+
+      act(() => {
+        root.render(
+          <ExternalContentProbe activeFileId={file.id} calls={calls} isVisible openFiles={[file]} />
+        )
+      })
+      dispatchReloadRequest('unknown-file')
+
+      expect(calls.loadFile).not.toHaveBeenCalled()
+      expect(calls.invalidate).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
+++ b/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
@@ -5,8 +5,10 @@ import {
   getOpenFilesForExternalFileChange,
   ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
   ORCA_EDITOR_FILE_SAVED_EVENT,
+  ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT,
   type EditorFileSavedDetail,
-  type EditorPathMutationTarget
+  type EditorPathMutationTarget,
+  type EditorRequestFileReloadDetail
 } from './editor-autosave'
 import type { DiffContent, FileContent } from './editor-panel-content-types'
 import { isReloadableSingleFileDiffTab } from './editor-panel-diff-reload'
@@ -50,6 +52,44 @@ function getExternalEventGeneration(event: Event): number {
   return generation
 }
 
+type OwnedFileReloadDeps = Pick<
+  UseEditorPanelExternalContentEventsParams,
+  'editorViewModeRef' | 'loadDiffContent' | 'loadFileContent'
+>
+
+// Shared by the external-change and explicit reload-request handlers so the
+// per-mode refetch (file body vs diff body, Changes-view diff) cannot drift.
+function forceReloadOwnedFile(
+  file: OpenFile,
+  eventGeneration: number,
+  { editorViewModeRef, loadDiffContent, loadFileContent }: OwnedFileReloadDeps,
+  onDiffInvalidate: (fileId: string) => void
+): void {
+  if (file.mode === 'edit' || file.mode === 'markdown-preview') {
+    // Why force: the reload must replace any in-flight pre-change read so the
+    // tab shows the new on-disk content, not a stale dedupe result.
+    void loadFileContent(file.filePath, file.id, file.worktreeId, file.relativePath, {
+      force: true,
+      externalEventGeneration: eventGeneration
+    })
+    if (editorViewModeRef.current[file.id] === 'changes') {
+      void loadDiffContent(file, {
+        force: true,
+        externalEventGeneration: eventGeneration
+      })
+    } else {
+      onDiffInvalidate(file.id)
+    }
+    return
+  }
+  if (isReloadableSingleFileDiffTab(file)) {
+    void loadDiffContent(file, {
+      force: true,
+      externalEventGeneration: eventGeneration
+    })
+  }
+}
+
 export function useEditorPanelExternalContentEvents({
   activeContentFileIdRef,
   invalidateContent,
@@ -82,27 +122,12 @@ export function useEditorPanelExternalContentEvents({
           invalidatedFileIds.push(file.id)
           continue
         }
-        if (file.mode === 'edit' || file.mode === 'markdown-preview') {
-          // Why: external writes must replace any in-flight pre-change read so
-          // the tab shows the new on-disk content, not a stale dedupe result.
-          void loadFileContent(file.filePath, file.id, file.worktreeId, file.relativePath, {
-            force: true,
-            externalEventGeneration: eventGeneration
-          })
-          if (editorViewModeRef.current[file.id] === 'changes') {
-            void loadDiffContent(file, {
-              force: true,
-              externalEventGeneration: eventGeneration
-            })
-          } else {
-            invalidatedDiffFileIds.push(file.id)
-          }
-        } else if (isReloadableSingleFileDiffTab(file)) {
-          void loadDiffContent(file, {
-            force: true,
-            externalEventGeneration: eventGeneration
-          })
-        }
+        forceReloadOwnedFile(
+          file,
+          eventGeneration,
+          { editorViewModeRef, loadDiffContent, loadFileContent },
+          (fileId) => invalidatedDiffFileIds.push(fileId)
+        )
       }
       if (invalidatedFileIds.length > 0) {
         invalidateContent(invalidatedFileIds)
@@ -114,6 +139,44 @@ export function useEditorPanelExternalContentEvents({
     window.addEventListener(ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT, handler as EventListener)
     return () =>
       window.removeEventListener(ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT, handler as EventListener)
+  }, [
+    activeContentFileIdRef,
+    editorViewModeRef,
+    invalidateContent,
+    invalidateDiffContent,
+    isVisibleRef,
+    loadDiffContent,
+    loadFileContent,
+    openFilesRef
+  ])
+
+  useEffect(() => {
+    const handler = (event: Event): void => {
+      const detail = (event as CustomEvent<EditorRequestFileReloadDetail>).detail
+      if (!detail) {
+        return
+      }
+      const file = openFilesRef.current.find((openFile) => openFile.id === detail.fileId)
+      if (!file) {
+        return
+      }
+      // Why no dirty skip: per the requestEditorFileReload contract the draft is
+      // already discarded — this snapshot can still say dirty because that store
+      // write hasn't rendered yet, and skipping would drop an explicit reload.
+      if (!isVisibleRef.current || file.id !== activeContentFileIdRef.current) {
+        invalidateContent([file.id])
+        return
+      }
+      forceReloadOwnedFile(
+        file,
+        getExternalEventGeneration(event),
+        { editorViewModeRef, loadDiffContent, loadFileContent },
+        (fileId) => invalidateDiffContent([fileId])
+      )
+    }
+    window.addEventListener(ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT, handler as EventListener)
+    return () =>
+      window.removeEventListener(ORCA_EDITOR_REQUEST_FILE_RELOAD_EVENT, handler as EventListener)
   }, [
     activeContentFileIdRef,
     editorViewModeRef,

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -9,6 +9,7 @@ import {
   Pencil,
   Pin,
   PinOff,
+  RefreshCw,
   X
 } from 'lucide-react'
 import {
@@ -20,6 +21,8 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { useAppStore } from '@/store'
+import { isExternalReloadableEditorTab } from '@/components/editor/editor-autosave'
+import { requestEditorTabDiskReload } from '@/components/editor/editor-tab-disk-reload'
 import { showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import type { OpenFile } from '../../store/slices/editor'
@@ -105,6 +108,7 @@ export function EditorFileTabContextMenu({
   const renameShortcut = useOptionalShortcutLabel('tab.rename')
   const closeShortcut = useOptionalShortcutLabel('tab.close')
   const closeAllShortcut = useOptionalShortcutLabel('tab.closeAll')
+  const canReloadFromDisk = isExternalReloadableEditorTab(file)
 
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange} modal={false}>
@@ -189,32 +193,46 @@ export function EditorFileTabContextMenu({
           )}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        {canShowMarkdownPreview ? (
-          <>
-            <DropdownMenuItem
-              onSelect={() => {
-                onActivate()
-                onOpenMarkdownPreview(
-                  {
-                    filePath: file.filePath,
-                    relativePath: file.relativePath,
-                    worktreeId: file.worktreeId,
-                    runtimeEnvironmentId: file.runtimeEnvironmentId,
-                    language: resolvedLanguage
-                  },
-                  { sourceFileId: file.id }
-                )
-              }}
-            >
-              <Eye className="size-3.5" />
-              {translate(
-                'auto.components.tab.bar.EditorFileTabContextMenu.bfd5797ef4',
-                'Open Markdown Preview'
-              )}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
+        {canReloadFromDisk ? (
+          <DropdownMenuItem
+            onSelect={() => {
+              // Why activate first: a background tab's reload lands lazily on
+              // reveal — activating makes the fresh content visible immediately.
+              onActivate()
+              requestEditorTabDiskReload(file.id)
+            }}
+          >
+            <RefreshCw className="size-3.5" />
+            {translate(
+              'components.tab.bar.EditorFileTabContextMenu.reloadFromDisk',
+              'Reload from Disk'
+            )}
+          </DropdownMenuItem>
         ) : null}
+        {canShowMarkdownPreview ? (
+          <DropdownMenuItem
+            onSelect={() => {
+              onActivate()
+              onOpenMarkdownPreview(
+                {
+                  filePath: file.filePath,
+                  relativePath: file.relativePath,
+                  worktreeId: file.worktreeId,
+                  runtimeEnvironmentId: file.runtimeEnvironmentId,
+                  language: resolvedLanguage
+                },
+                { sourceFileId: file.id }
+              )
+            }}
+          >
+            <Eye className="size-3.5" />
+            {translate(
+              'auto.components.tab.bar.EditorFileTabContextMenu.bfd5797ef4',
+              'Open Markdown Preview'
+            )}
+          </DropdownMenuItem>
+        ) : null}
+        {canReloadFromDisk || canShowMarkdownPreview ? <DropdownMenuSeparator /> : null}
         <DropdownMenuItem
           onSelect={() => {
             void window.api.ui.writeClipboardText(file.filePath)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17292,7 +17292,8 @@
         },
         "EditorFileTabContextMenu": {
           "closeOthers": "Close Others",
-          "closeTabsToLeft": "Close Tabs To The Left"
+          "closeTabsToLeft": "Close Tabs To The Left",
+          "reloadFromDisk": "Reload from Disk"
         }
       }
     },


### PR DESCRIPTION
## ELI5

When a file open in the editor goes stale (e.g. an agent rewrote it while the fs watcher missed it), you can now right-click its tab and pick **Reload from Disk** instead of closing and reopening the tab.

## What Changed

- Add a `Reload from Disk` item to the editor tab context menu, shown for edit, markdown-preview, and single-file unstaged/staged diff tabs (gated on the existing `isExternalReloadableEditorTab`)
- New `requestEditorTabDiskReload` entry point: dirty tabs route through the conflict banner's `reloadTabContentFromDisk`, so the discarded draft keeps the same "Reloaded from disk" Undo toast; clean tabs skip straight to the refetch
- New `orca:editor-request-file-reload` window event (`requestEditorFileReload`) that delegates the refetch to the owning EditorPanel — the tab strip has no access to the panel's content loaders, mirroring the existing `orca:editor-request-file-close` pattern
- Extract `forceReloadOwnedFile` so the external-change handler and the new reload-request handler share the per-mode refetch branching (file body vs diff body vs Changes-view diff); hidden/inactive panels invalidate and reload lazily on reveal, exactly like external changes
- Tests: reload-request handler cases in `useEditorPanelExternalContentEvents.test.tsx`, new `editor-tab-disk-reload.test.ts` (dirty-discard ordering, non-reloadable tabs, unknown ids)
- `en.json`: one new catalog entry (`components.tab.bar.EditorFileTabContextMenu.reloadFromDisk`)

## Why

Reload-from-disk already ships, but its only entry point is the changed-on-disk conflict banner, which requires a dirty buffer *and* a watcher hit. When the watcher misses (#14801, files outside every worktree root #15612, ignored dirs), the only recovery is closing and reopening the tab. This adds the missing manual lever on the surface where staleness is noticed: the tab itself.

## Linked Issue

Part of #11085 — complementary to #11086, which adds the `…` actions-menu item and the unbound `editor.reloadFromDisk` keybinding. This PR adds the tab-context-menu surface; both reuse the banner's `reloadTabContentFromDisk` so behavior stays identical.

## Visual Proof

New `Reload from Disk` item (refresh icon) in the editor tab context menu, between the close group and `Copy Path`. Screenshot to follow in a PR comment — not attached yet.

## Testing

- `pnpm test src/renderer/src/components/editor/editor-tab-disk-reload.test.ts src/renderer/src/components/editor/useEditorPanelExternalContentEvents.test.tsx src/renderer/src/components/editor/ExternalFileChangeBanner.test.tsx` — 24 passed (macOS)
- `pnpm tc`, `pnpm run check:code-quality:changed` (0 new findings), `sync:localization-catalog` / `verify:localization-*` all pass

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Claude Fable 5), reviewed by the PR author.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Renderer-only; no IPC/wire, path, or shortcut changes, so SSH/remote and cross-platform behavior ride the same panel content loaders the watcher pipeline already uses. Diff-surface reloads match what the banner already does on unstaged diff tabs.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
