### PR TITLE
fix(github): honour forced refreshes on the queried work-item list

### DIFF
--- a/src/main/github/client-work-items-query-paging.test.ts
+++ b/src/main/github/client-work-items-query-paging.test.ts
@@ -237,6 +237,47 @@ describe('listWorkItems query paging', () => {
     )
   })
 
+  // Why: the recent and queried lists are built by the same request builder, so pin both paths. The
+  // recent path already dropped the cache pair but had no coverage to stop it regressing (#19632).
+  it('drops the gh response cache on the recent list when a refresh is forced', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    // The recent list fetches both sides, so every gh call in this test returns an empty page.
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: '[]' })
+
+    await listWorkItems('/repo-root', 10, undefined, 2, undefined, undefined, true)
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        'api',
+        `search/issues?q=${encodeURIComponent('repo:acme/widgets is:issue is:open')}&sort=created&order=desc&per_page=10&page=2`,
+        '--jq',
+        '.items'
+      ],
+      { cwd: '/repo-root' }
+    )
+  })
+
+  // Why: the Tasks refresh button forces a fetch with noCache. Without dropping the cache arg the
+  // queried list re-serves the same 120s-cached response, so "Refresh GitHub work" looks inert (#19632).
+  it('drops the gh response cache when a queried refresh is forced', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+    await listWorkItems('/repo-root', 10, 'is:issue is:open', 2, undefined, undefined, true)
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        'api',
+        `search/issues?q=${encodeURIComponent('repo:acme/widgets is:issue is:open')}&sort=created&order=desc&per_page=10&page=2`,
+        '--jq',
+        '.items'
+      ],
+      { cwd: '/repo-root' }
+    )
+  })
+
   it('fetches and slices stable PR results for the requested numbered page', async () => {
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })

--- a/src/main/github/client/list/list-work-items.ts
+++ b/src/main/github/client/list/list-work-items.ts
@@ -58,6 +58,7 @@ export async function listWorkItems(
           limit,
           requestedPage,
           connectionId,
+          noCache,
           localGitOptions
         )
 

--- a/src/main/github/client/list/work-item-list-request.ts
+++ b/src/main/github/client/list/work-item-list-request.ts
@@ -24,8 +24,9 @@ export function buildWorkItemListRequest(args: {
   limit: number
   query: ParsedTaskQuery
   page: number
+  noCache?: boolean
 }): WorkItemListRequest {
-  const { kind, ownerRepo, limit, query, page } = args
+  const { kind, ownerRepo, limit, query, page, noCache } = args
   const searchParts: string[] = []
 
   if (kind === 'issue') {
@@ -73,8 +74,10 @@ export function buildWorkItemListRequest(args: {
     return {
       args: [
         'api',
-        '--cache',
-        '120s',
+        // Why: gh serves this request from its own 120s response cache. A user-forced refresh must not
+        // replay it, so the cache pair is omitted here instead of being spliced out by index at each
+        // call site, where it was coupled to this array's layout (#19632).
+        ...(noCache ? [] : ['--cache', '120s']),
         `search/issues?q=${encodeURIComponent(searchParts.join(' '))}&sort=created&order=desc&per_page=${limit}&page=${page}`,
         '--jq',
         '.items'

--- a/src/main/github/client/list/work-item-pages.ts
+++ b/src/main/github/client/list/work-item-pages.ts
@@ -40,7 +40,8 @@ export async function listRecentWorkItems(
         ownerRepo: issueOwnerRepo,
         limit,
         query: recentQuery,
-        page
+        page,
+        noCache
       })
     : null
   const prRequest = prOwnerRepo
@@ -52,9 +53,6 @@ export async function listRecentWorkItems(
         page
       })
     : null
-  if (noCache && issueRequest) {
-    issueRequest.args.splice(1, 2)
-  }
   // Why: unresolved sources must stay empty — an unscoped Search API would return other public repos' issues (#9660).
   // Why: allSettled so a 403 on the issue side doesn't zero the PR half (partial results + banner).
   const [issuesSettled, prsSettled] = await Promise.allSettled([
@@ -130,6 +128,7 @@ export async function listQueriedWorkItems(
   limit: number,
   page?: number,
   connectionId?: string | null,
+  noCache?: boolean,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<PartialWorkItemsResult> {
   const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
@@ -159,7 +158,8 @@ export async function listQueriedWorkItems(
       ownerRepo: issueOwnerRepo,
       limit,
       query,
-      page: page ?? 1
+      page: page ?? 1,
+      noCache
     })
     try {
       const { stdout } = await ghExecFileAsync(request.args, {


### PR DESCRIPTION
## ELI5

The Tasks page has a refresh button. It was quietly reloading a cached copy of the data instead of asking GitHub for fresh data, so pressing it often looked like nothing happened. This change makes the refresh button actually bypass the cache.

## What Changed

- `buildWorkItemListRequest` now takes an optional `noCache`, and omits gh's `--cache 120s` pair from the issue request when it is set. The request builder is the only place that knows this request's argument layout.
- `listRecentWorkItems` passes `noCache` to the builder instead of stripping the cache pair afterwards with `args.splice(1, 2)`.
- `listQueriedWorkItems` gains the same optional `noCache` parameter and passes it through. `listWorkItems` now forwards its existing `noCache` to it.
- Tests: adds coverage for both paths. The recent path already dropped the cache pair but had none; the queried path did not drop it at all.

## Why

`listWorkItems` already receives `noCache`, and the renderer already sets it for exactly this case — `deriveTaskPageGitHubWorkItemsFetchOptions` resolves `noCache: forcedFetch`, i.e. only for a user-forced refresh (covered by `task-page-cache-selectors.test.ts`).

But it only reached one of the two lists. `listRecentWorkItems` honoured it; `listQueriedWorkItems` had no such parameter, so `gh api --cache 120s search/issues?...` kept replaying the same cached response. The Tasks page always applies a query (`getTaskPresetQuery` resolves to `is:issue is:open`), so the cached path was the default one — which is why Refresh appeared inert and returned instantly with no spinner.

The old `args.splice(1, 2)` reached into the request builder's array from another module, coupling a caller to an argument layout it does not own. Rather than duplicate that in the queried path, the decision moved next to the args themselves. Normal polling still passes `noCache: false` and keeps the 120s cache and its Search API rate-limit protection; only a forced refresh bypasses it.

Fixes #19632

## Visual Proof

N/A — no UI or interaction change. The visible symptom (Refresh appearing to do nothing) is fixed by the data fetch, not by any rendering change.

## Testing

- `pnpm test src/main/github/client-work-items-query-paging.test.ts` — 9 passed. The queried-path test fails on the previous commit (`--cache 120s` present in the actual call) and passes after the change.
- `pnpm test src/main/github` — 67 files, 715 tests, all pass.
- `pnpm tc` — clean (exit 0).
- `pnpm run check:code-quality:changed` — 0 new findings across the 4 changed files; `oxlint` clean.

Platform testing: this is platform-neutral argument shaping with no runtime platform branch, so it behaves identically on macOS, Linux, and Windows. I verified on Linux only. I did not run `pnpm lint`, `pnpm build`, or the full `pnpm test` suite locally; CI will cover those.

## AI Disclosure

Written with an AI coding agent (deepseek-flash via opencode-go), working from a code-verified root cause and a failing test written first. All commands in the Testing section were run by the agent on Linux.

## Review

AI-assisted code review summary, per CONTRIBUTING:

- **Cross-platform**: no platform branches, path handling, or shortcut changes. Arguments are built as an array, never a shell string. Identical behaviour on macOS/Linux/Windows.
- **SSH/remote/local**: `noCache` is now honoured on both lists for every host. The request is still built the same way and executed via `ghRepoExecOptions`/`githubHostExecOptions`, so SSH and remote-server paths are unaffected apart from the intended cache bypass. No host-specific assumptions added.
- **Agents and integrations**: untouched. No agent-, provider-, or integration-specific code; this is GitHub work-item listing only, and the PR side of the builder is unchanged.
- **Performance**: reduces work on a forced refresh (one fewer cache hit, no extra requests). No new work in a hot path, and normal polling keeps its existing caching, so GitHub rate-limit exposure is unchanged.
- **UI quality**: no UI change.
- **Security**: no new user input, no new interpolation into a command line, no credential or token handling touched.

Known risk, stated plainly: a maintainer could decide the queried path should keep its cache even on a forced refresh. I think the asymmetry is the bug — `noCache` exists, the renderer sets it for forced refreshes, and the recent path already honours it — but this is the one judgement call in the change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

No backwards-compatibility concern: `noCache` is optional, the only caller was updated, and the `listWorkItems` result shape is unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
