### PR TITLE
test(native-chat): split structured question fixtures

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -7,6 +7,10 @@ import type { AgentJournalRenderItem } from '../../../../shared/agent-session-jo
 import type { AgentSessionBackgroundTask } from '../../../../shared/agent-session-wire'
 import { decodeAgentSessionQuestionAnswers } from '../../../../shared/agent-session-question-answer'
 import type { NativeChatQuestionCardProps } from './NativeChatQuestionCard'
+import {
+  claudeGroupedQuestionPromptItems,
+  legacySingleQuestionPromptItems
+} from './native-chat-structured-question-test-fixtures'
 
 const mocks = vi.hoisted(() => ({
   call: vi.fn(),
@@ -800,46 +804,7 @@ describe('NativeChatStructuredSession', () => {
   }, 30000)
 
   it('passes Claude grouped questions and one shared answer through the card', () => {
-    mocks.promptItems = [
-      {
-        itemId: 'question-item',
-        revision: 1,
-        sequence: 1,
-        observedAt: 1,
-        body: {
-          kind: 'question',
-          question: '2 grouped questions from Claude',
-          options: [],
-          questions: [
-            {
-              id: 'q1',
-              header: 'Targets',
-              question: 'Which targets?',
-              multiSelect: true,
-              options: [
-                { id: 'target-web', label: 'Web' },
-                { id: 'target-mobile', label: 'Mobile' }
-              ],
-              freeTextQuestionId: 'q1'
-            },
-            {
-              id: 'q2',
-              header: 'Host',
-              question: 'Where should it run?',
-              multiSelect: false,
-              options: [],
-              freeTextQuestionId: 'q2'
-            }
-          ],
-          resolution: {
-            state: 'pending',
-            selectedOptionId: null,
-            resolvedBy: null,
-            resolvedAt: null
-          }
-        }
-      }
-    ]
+    mocks.promptItems = claudeGroupedQuestionPromptItems
 
     render(
       <NativeChatStructuredSession
@@ -876,29 +841,7 @@ describe('NativeChatStructuredSession', () => {
   })
 
   it('keeps legacy single-question option ids and free text behavior', () => {
-    mocks.promptItems = [
-      {
-        itemId: 'legacy-question-item',
-        revision: 1,
-        sequence: 1,
-        observedAt: 1,
-        body: {
-          kind: 'question',
-          question: 'Pick a library',
-          options: [
-            { id: 'q1:choice-1', label: 'React' },
-            { id: 'q1:choice-2', label: 'Vue' }
-          ],
-          freeTextQuestionId: 'q1',
-          resolution: {
-            state: 'pending',
-            selectedOptionId: null,
-            resolvedBy: null,
-            resolvedAt: null
-          }
-        }
-      }
-    ]
+    mocks.promptItems = legacySingleQuestionPromptItems
 
     render(
       <NativeChatStructuredSession

--- a/src/renderer/src/components/native-chat/native-chat-structured-question-test-fixtures.ts
+++ b/src/renderer/src/components/native-chat/native-chat-structured-question-test-fixtures.ts
@@ -1,0 +1,66 @@
+import type { AgentJournalRenderItem } from '../../../../shared/agent-session-journal-types'
+
+export const claudeGroupedQuestionPromptItems: AgentJournalRenderItem[] = [
+  {
+    itemId: 'question-item',
+    revision: 1,
+    sequence: 1,
+    observedAt: 1,
+    body: {
+      kind: 'question',
+      question: '2 grouped questions from Claude',
+      options: [],
+      questions: [
+        {
+          id: 'q1',
+          header: 'Targets',
+          question: 'Which targets?',
+          multiSelect: true,
+          options: [
+            { id: 'target-web', label: 'Web' },
+            { id: 'target-mobile', label: 'Mobile' }
+          ],
+          freeTextQuestionId: 'q1'
+        },
+        {
+          id: 'q2',
+          header: 'Host',
+          question: 'Where should it run?',
+          multiSelect: false,
+          options: [],
+          freeTextQuestionId: 'q2'
+        }
+      ],
+      resolution: {
+        state: 'pending',
+        selectedOptionId: null,
+        resolvedBy: null,
+        resolvedAt: null
+      }
+    }
+  }
+]
+
+export const legacySingleQuestionPromptItems: AgentJournalRenderItem[] = [
+  {
+    itemId: 'legacy-question-item',
+    revision: 1,
+    sequence: 1,
+    observedAt: 1,
+    body: {
+      kind: 'question',
+      question: 'Pick a library',
+      options: [
+        { id: 'q1:choice-1', label: 'React' },
+        { id: 'q1:choice-2', label: 'Vue' }
+      ],
+      freeTextQuestionId: 'q1',
+      resolution: {
+        state: 'pending',
+        selectedOptionId: null,
+        resolvedBy: null,
+        resolvedAt: null
+      }
+    }
+  }
+]


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​63 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​57 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |

<!-- /orca-pr-loc -->

## Summary

- move structured question prompt data into a focused test-fixtures module
- bring `NativeChatStructuredSession.test.tsx` back below the 800-line static-analysis cap
- preserve the existing grouped and legacy question coverage without disabling lint rules

## Testing

- `pnpm test src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx`
- `pnpm run check:code-quality:changed`
- `pnpm tc:web`