### PR TITLE
fix(terminal): recover remote pane geometry and replacement mouse state

### DIFF
--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
@@ -56,6 +56,32 @@ describe('createPaneForegroundAgentTracker', () => {
     vi.useRealTimers()
   })
 
+  it('retires a pending predecessor read when an incarnation reuses its PTY ID', async () => {
+    let resolveRead!: (value: string | null) => void
+    readForegroundProcess.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRead = resolve
+        })
+    )
+    const tracker = makeTracker()
+    tracker.onVisiblePtyBound(true)
+    await flushSettleRead(VISIBLE_PTY_SETTLE_MS)
+    tracker.resetForPtyReplacement()
+    expect(tracker.hasReadInFlight()).toBe(false)
+    resolveRead('pi')
+    await flushSettleRead(SECOND_WRAPPER_RETRY_MS)
+    expect(publish).not.toHaveBeenCalled()
+    expect(onConfirmedShellForeground).not.toHaveBeenCalled()
+    expect(onVisibleForegroundSettled).not.toHaveBeenCalled()
+    expect(readForegroundProcess).toHaveBeenCalledOnce()
+    readForegroundProcess.mockResolvedValue('codex')
+    tracker.onCommandStarted()
+    await flushSettleRead(COMMAND_SETTLE_MS)
+    expect(publish).toHaveBeenCalledWith({ agent: 'codex', shellForeground: false })
+    tracker.dispose()
+  })
+
   // Why: detach/remount emits no PTY exit, so the store entry outlives this tracker.
   // A capability retained pending the disposed read would latch there forever.
   it('releases a retained capability when disposed mid-read', async () => {

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
@@ -60,6 +60,7 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
   onCommandStarted: (expectedAgent?: TuiAgent | null) => void
   /** True when pane identity must remain visible until an async shell confirmation. */
   onCommandFinished: () => boolean
+  resetForPtyReplacement: () => void
   dispose: () => void
 } {
   let disposed = false
@@ -259,6 +260,12 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
   }
 
   return {
+    resetForPtyReplacement() {
+      cancelPendingRead()
+      hasForegroundAgentEvidence = false
+      hasKnownAgentEvidence = false
+      hasAgentExpectation = false
+    },
     // Why: onVisiblePtyBound refuses to schedule while a higher-authority
     // command read owns the pane, so "it scheduled nothing" must not be read
     // as "nothing will confirm this pane".

--- a/src/renderer/src/components/terminal-pane/pty-connection-daemon-snapshot-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-daemon-snapshot-replay.test.ts
@@ -7,6 +7,7 @@ import {
   RESET_GRAPHIC_RENDITION
 } from '../../../../shared/terminal-mode-reset-profiles'
 import { Terminal } from '@xterm/headless'
+import { NORMAL_BUFFER_PROLOGUE } from './pty-connection-test-constants'
 import { flushAsyncTicks, createDeferred, writeHeadlessTerminal } from './pty-connection-test-async'
 import { createRect } from './pty-connection-test-dom'
 import {
@@ -768,7 +769,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(8)
     replayCallback.current?.('blocking replay')
     await flushAsyncTicks(12)
-    expect(writes).toEqual(['\x1b[2J\x1b[3J\x1b[H'])
+    expect(writes).toEqual([NORMAL_BUFFER_PROLOGUE])
     reattachResult.resolve({ id: 'tab-pty', snapshot: 'stale authoritative snapshot' })
     await flushAsyncTicks(12)
     const resizeCallsBeforeReplacement = transport.resize.mock.calls.length

--- a/src/renderer/src/components/terminal-pane/pty-connection-remote-snapshot-source-grid.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-remote-snapshot-source-grid.test.ts
@@ -1,11 +1,17 @@
 import type * as React from 'react'
+import { Terminal } from '@xterm/headless'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { flushAsyncTicks, renderHeadlessBuffer } from './pty-connection-test-async'
+import {
+  flushAsyncTicks,
+  renderHeadlessBuffer,
+  writeHeadlessTerminal
+} from './pty-connection-test-async'
 import { createMockTransport, createPane, createManager } from './pty-connection-test-pane-fixtures'
 import type { ConnectCallbacks, MockTransport } from './pty-connection-test-pane-fixtures'
 import { buildPaneConnectionDeps } from './pty-connection-test-deps'
 import {
   createInitialStoreState,
+  buildReattachPaneTitleState,
   buildActiveRuntimeEnvironmentState
 } from './pty-connection-test-store-fixtures'
 import type { StoreState } from './pty-connection-test-store-state'
@@ -62,7 +68,11 @@ vi.mock('@/store', () => ({
 
 vi.mock('@/lib/agent-status', async (importOriginal) => {
   const { buildAgentStatusModuleMock } = await import('./pty-connection-test-environment')
-  return buildAgentStatusModuleMock(await importOriginal<Record<string, unknown>>())
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...buildAgentStatusModuleMock(actual),
+    detectAgentStatusFromTitle: actual.detectAgentStatusFromTitle
+  }
 })
 
 vi.mock('./cache-timer-seeding', () => ({
@@ -133,20 +143,32 @@ function createDeps(overrides: Record<string, unknown> = {}) {
   return buildPaneConnectionDeps(() => mockStoreState, overrides)
 }
 
-async function connectRemotePane(): Promise<{
+async function connectRemotePane(
+  title?: string,
+  incarnationId: string | null = 'inc-old'
+): Promise<{
   operations: { kind: 'resize' | 'write'; value: string }[]
   pane: ReturnType<typeof createPane>
   transport: MockTransport
+  live: (data: string) => void
+  rebind: (incarnationId?: string | null) => void
   replay: (data: string, meta?: Record<string, unknown>) => void
   dispose: () => void
 }> {
   const { connectPanePty } = await import('./pty-connection')
   mockStoreState = buildActiveRuntimeEnvironmentState(mockStoreState, 'env-1')
+  if (title) {
+    mockStoreState = buildReattachPaneTitleState(mockStoreState, title)
+  }
   const transport = createMockTransport('remote:env-1@@terminal-1')
-  const captured: { current: ConnectCallbacks['onReplayData'] | null } = { current: null }
+  const captured: {
+    current: ConnectCallbacks['onReplayData'] | null
+    live: ConnectCallbacks['onData'] | null
+  } = { current: null, live: null }
   transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
     captured.current = callbacks.onReplayData ?? null
-    return { id: 'remote:env-1@@terminal-1', replay: '' }
+    captured.live = callbacks.onData ?? null
+    return { id: 'remote:env-1@@terminal-1', replay: '', incarnationId }
   })
   transportFactoryQueue.push(transport)
 
@@ -177,6 +199,15 @@ async function connectRemotePane(): Promise<{
     operations,
     pane,
     transport,
+    live: (data) => captured.live?.(data),
+    rebind: (nextIncarnation) => {
+      const onRebind = createdTransportOptions.at(-1)?.onPtyRebind as (
+        id: string,
+        replacedId: string,
+        incarnationId?: string | null
+      ) => void
+      onRebind('remote:env-1@@terminal-1', 'remote:env-1@@terminal-1', nextIncarnation)
+    },
     replay: (data, meta) => captured.current?.(data, meta as never),
     dispose: () => disposable.dispose()
   }
@@ -195,6 +226,104 @@ describe('pushed remote snapshot replay grid', () => {
 
   afterEach(async () => {
     await restoreTerminalTestGlobals()
+  })
+
+  it.each([
+    { name: 'replacement with shell ownership', owner: 'shell' as const, expectedMouse: 'none' },
+    {
+      name: 'known replacement without ownership',
+      owner: undefined,
+      expectedMouse: 'none',
+      replacement: true
+    },
+    { name: 'unknown legacy ownership', owner: undefined, expectedMouse: 'any' },
+    {
+      name: 'unknown predecessor',
+      owner: undefined,
+      expectedMouse: 'any',
+      replacement: true,
+      unknownPredecessor: true
+    },
+    { name: 'unknown successor', owner: undefined, expectedMouse: 'any', unknownSuccessor: true },
+    {
+      name: 'same-incarnation rebind',
+      owner: undefined,
+      expectedMouse: 'any',
+      sameIncarnation: true
+    },
+    { name: 'surviving agent', owner: undefined, expectedMouse: 'any', liveAgent: true },
+    {
+      name: 'replacement agent',
+      owner: undefined,
+      expectedMouse: 'any',
+      liveAgent: true,
+      replacement: true
+    }
+  ])('reconciles mouse modes for a $name despite a retained Pi title', async (scenario) => {
+    const session = await connectRemotePane(
+      'π - remote-session',
+      scenario.unknownPredecessor ? null : 'inc-old'
+    )
+    const terminal = new Terminal({ cols: PANE_COLS, rows: PANE_ROWS, allowProposedApi: true })
+    const mouseModes = '\x1b[?1003h\x1b[?1006h'
+    const snapshot = scenario.liveAgent ? `${mouseModes}LIVE_AGENT` : 'REPLACEMENT_SHELL$ '
+    try {
+      await writeHeadlessTerminal(terminal, `OLD_AGENT_FRAME${mouseModes}`)
+      expect(terminal.modes.mouseTrackingMode).toBe('any')
+      if (scenario.replacement) {
+        session.rebind('inc-new')
+      }
+      if (scenario.sameIncarnation) {
+        session.rebind('inc-old')
+      }
+      if (scenario.unknownSuccessor) {
+        session.rebind(null)
+      }
+      session.replay(snapshot, {
+        snapshotCols: PANE_COLS,
+        snapshotRows: PANE_ROWS,
+        ...(scenario.owner ? { terminalOwner: scenario.owner, alternateScreen: false } : {})
+      })
+      await flushAsyncTicks(20)
+      const writes = session.operations.filter((operation) => operation.kind === 'write')
+      expect(writes.some((operation) => operation.value.includes(snapshot))).toBe(true)
+      for (const operation of writes) {
+        await writeHeadlessTerminal(terminal, operation.value)
+      }
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toContain(
+        scenario.liveAgent ? 'LIVE_AGENT' : 'REPLACEMENT_SHELL$'
+      )
+      expect(terminal.modes.mouseTrackingMode).toBe(scenario.expectedMouse)
+    } finally {
+      session.dispose()
+      terminal.dispose()
+    }
+  })
+
+  it('grounds a retained invisible pen before painting a replacement shell snapshot', async () => {
+    const session = await connectRemotePane('π - remote-session')
+    const terminal = new Terminal({ cols: PANE_COLS, rows: PANE_ROWS, allowProposedApi: true })
+    try {
+      await writeHeadlessTerminal(terminal, 'OLD_AGENT_FRAME\x1b[8m')
+      session.replay('REPLACEMENT_SHELL$ ', {
+        snapshotCols: PANE_COLS,
+        snapshotRows: PANE_ROWS,
+        terminalOwner: 'shell',
+        alternateScreen: false
+      })
+      await flushAsyncTicks(20)
+      for (const operation of session.operations) {
+        if (operation.kind === 'write') {
+          await writeHeadlessTerminal(terminal, operation.value)
+        }
+      }
+      const line = terminal.buffer.active.getLine(0)
+      expect(line?.translateToString(true)).toContain('REPLACEMENT_SHELL$')
+      expect(line?.getCell(0)?.isInvisible()).toBe(0)
+    } finally {
+      session.dispose()
+      terminal.dispose()
+    }
   })
 
   it('replays at the host grid and then pushes the pane grid back to the PTY', async () => {
@@ -216,6 +345,67 @@ describe('pushed remote snapshot replay grid', () => {
     expect(session.transport.resize).toHaveBeenCalledWith(PANE_COLS, PANE_ROWS)
     expect(session.transport.resize).not.toHaveBeenCalledWith(HOST_COLS, HOST_ROWS)
     session.dispose()
+  })
+
+  it('fits locally after source replay without claiming an unknown remote owner grid', async () => {
+    const { setFitOverride, getFitOverrideForPty } =
+      await import('@/lib/pane-manager/mobile-fit-overrides')
+    const session = await connectRemotePane()
+    const id = 'remote:env-1@@terminal-1'
+    setFitOverride(id, 'remote-desktop-fit', 0, 0)
+    try {
+      session.replay('SHELL$', { snapshotCols: 2, snapshotRows: 1 })
+      await flushAsyncTicks(20)
+      expect(session.pane.terminal.resize).toHaveBeenCalledWith(2, 1)
+      expect(session.pane.terminal.cols).toBe(PANE_COLS)
+      expect(session.pane.terminal.rows).toBe(PANE_ROWS)
+      expect(session.transport.resize).not.toHaveBeenCalled()
+      expect(getFitOverrideForPty(id)).toEqual({ mode: 'remote-desktop-fit', cols: 0, rows: 0 })
+    } finally {
+      setFitOverride(id, 'desktop-fit', 0, 0)
+      session.dispose()
+    }
+  })
+
+  it('retires an in-flight predecessor replay and keeps successor live output for a reused handle', async () => {
+    const session = await connectRemotePane('π - remote-session')
+    const write = session.pane.terminal.write.getMockImplementation()!
+    let finishOldWrite: (() => void) | undefined
+    session.pane.terminal.write.mockImplementation((data: string, callback?: () => void) => {
+      if (data === 'STALE_FRAME') {
+        write(data)
+        finishOldWrite = callback
+      } else {
+        write(data, callback)
+      }
+    })
+    try {
+      session.replay('STALE_FRAME', {
+        snapshotCols: 2,
+        snapshotRows: 1,
+        pendingEscapeTailAnsi: '\x1b[999;'
+      })
+      await flushAsyncTicks(10)
+      expect(finishOldWrite).toBeTypeOf('function')
+      session.live('STALE_ACK')
+      session.rebind('inc-new')
+      session.replay('SUCCESSOR_FRAME', { snapshotCols: 2, snapshotRows: 1 })
+      session.live('LIVE_ACK')
+      finishOldWrite?.()
+      await flushAsyncTicks(30)
+      const writes = session.operations.filter((op) => op.kind === 'write').map((op) => op.value)
+      expect(writes).not.toContain('\x1b[999;')
+      expect(writes.join('')).not.toContain('STALE_ACK')
+      expect(writes.join('')).toContain('LIVE_ACK')
+      expect(writes.findIndex((data) => data.includes('LIVE_ACK'))).toBeGreaterThan(
+        writes.indexOf('SUCCESSOR_FRAME')
+      )
+      expect(session.pane.terminal.cols).toBe(PANE_COLS)
+      expect(session.transport.resize).not.toHaveBeenCalledWith(2, 1)
+    } finally {
+      finishOldWrite?.()
+      session.dispose()
+    }
   })
 
   it('keeps the pane grid when the host published no snapshot dimensions', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection-replay-payload-handling.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-replay-payload-handling.test.ts
@@ -619,7 +619,7 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).toHaveBeenCalledTimes(1)
     expect(pane.terminal.write).toHaveBeenNthCalledWith(
       1,
-      '\x1b[2J\x1b[3J\x1b[H',
+      NORMAL_BUFFER_PROLOGUE,
       expect.any(Function)
     )
 
@@ -658,7 +658,7 @@ describe('connectPanePty', () => {
 
     callbacksRef.replay?.('authoritative replay')
     await flushAsyncTicks(8)
-    expect(writes).toEqual(['\x1b[2J\x1b[3J\x1b[H'])
+    expect(writes).toEqual([NORMAL_BUFFER_PROLOGUE])
 
     const acknowledgeLiveFrame = vi.fn()
     deliverTerminalDataWithDeferredCredit(acknowledgeLiveFrame, () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection/pane-pty-visibility-bind.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pane-pty-visibility-bind.ts
@@ -1,3 +1,4 @@
+import { retireRemotePtyIncarnation } from './remote-pty-incarnation-replacement'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 // Why: a restored pane's stale-account prompt can only be raised once a PTY is
@@ -204,7 +205,11 @@ export function installPanePtyVisibilityBind(session: ConnectPanePtySession): vo
     if (!session.canAdoptCapturedDirectSshRetryPty(ptyId)) {
       return
     }
+    const replacedIncarnationId = session.remotePtyIncarnationId
     session.remotePtyIncarnationId = incarnationId ?? null
+    if (replacedIncarnationId && incarnationId && replacedIncarnationId !== incarnationId) {
+      retireRemotePtyIncarnation(session, replacedPtyId, ptyId)
+    }
     // Why: provider handle rotation keeps the existing pane/session generation;
     // replace its stale store identity without fresh-spawn exit semantics.
     session.bindActivePanePty(ptyId, { replacePtyId: replacedPtyId })

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-input-forward.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-input-forward.ts
@@ -283,8 +283,10 @@ export function installPtyInputForward(session: ConnectPanePtySession): void {
     attemptGeneration: number,
     reattachPtyId: string
   ): { shouldContinue: () => boolean; continuation: () => void } => {
+    const incarnationId = session.remotePtyIncarnationId
     const isCurrent = (): boolean =>
       !session.disposed &&
+      session.remotePtyIncarnationId === incarnationId &&
       attemptGeneration === session.transportStreamGeneration &&
       session.transport.getPtyId() === reattachPtyId
     return {

--- a/src/renderer/src/components/terminal-pane/pty-connection/remote-pty-incarnation-replacement.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/remote-pty-incarnation-replacement.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ConnectPanePtySession } from './connect-pane-pty-session'
+import { retireRemotePtyIncarnation } from './remote-pty-incarnation-replacement'
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    agentStatusByPaneKey: {} as Record<string, { terminalHandle?: string }>,
+    agentLaunchConfigByPaneKey: {} as Record<string, { identity: { terminalHandle?: string } }>,
+    removeAgentStatus: vi.fn(),
+    clearAgentLaunchConfig: vi.fn(),
+    clearPaneForegroundAgent: vi.fn()
+  }
+}))
+vi.mock('@/store', () => ({ useAppStore: { getState: () => state } }))
+
+function createSession() {
+  return {
+    cacheKey: 'pane',
+    authoritativeReattachGeneration: 1,
+    replayPayloadGeneration: 1,
+    clearHiddenOutputRestoreState: vi.fn(),
+    clearRestoredSnapshotBaseline: vi.fn(),
+    clearPaneMode2031State: vi.fn(),
+    kittyKeyboardModes: { reset: vi.fn() },
+    paneForegroundAgentTracker: { resetForPtyReplacement: vi.fn() },
+    clearCommandInferredPaneAgent: vi.fn(),
+    resetPendingShellCommandLine: vi.fn(),
+    rememberReattachPayloadAgentSignal: vi.fn(),
+    clearStaleAgentTabTitleOnConfirmedShell: vi.fn(),
+    deps: { setCacheTimerStartedAt: vi.fn() },
+    writeReplayData: vi.fn()
+  }
+}
+
+describe('remote PTY incarnation replacement publication ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.agentStatusByPaneKey = {}
+    state.agentLaunchConfigByPaneKey = {}
+  })
+
+  it.each([
+    { name: 'known predecessor', rowHandle: 'old', successorHandle: 'new', clear: true },
+    {
+      name: 'successor published before rebind',
+      rowHandle: 'new',
+      successorHandle: 'new',
+      clear: false
+    },
+    {
+      name: 'same-handle successor publication',
+      rowHandle: 'old',
+      successorHandle: 'old',
+      clear: false
+    },
+    { name: 'unknown row ownership', rowHandle: undefined, successorHandle: 'new', clear: false }
+  ])('only retires a positively owned row: $name', ({ rowHandle, successorHandle, clear }) => {
+    const session = createSession()
+    state.agentStatusByPaneKey.pane = { terminalHandle: rowHandle }
+    state.agentLaunchConfigByPaneKey.pane = { identity: { terminalHandle: rowHandle } }
+    retireRemotePtyIncarnation(
+      session as unknown as ConnectPanePtySession,
+      'remote:env@@old',
+      `remote:env@@${successorHandle}`
+    )
+    expect(state.removeAgentStatus).toHaveBeenCalledTimes(clear ? 1 : 0)
+    expect(state.clearAgentLaunchConfig).toHaveBeenCalledTimes(clear ? 1 : 0)
+    expect(session.deps.setCacheTimerStartedAt).toHaveBeenCalledTimes(clear ? 1 : 0)
+    expect(session.clearStaleAgentTabTitleOnConfirmedShell).not.toHaveBeenCalled()
+    expect(session.paneForegroundAgentTracker.resetForPtyReplacement).toHaveBeenCalledOnce()
+    expect(session.writeReplayData).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection/remote-pty-incarnation-replacement.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/remote-pty-incarnation-replacement.ts
@@ -1,0 +1,52 @@
+import { useAppStore } from '@/store'
+import { parseRemoteRuntimePtyId } from '../../../../../shared/remote-runtime-pty-id'
+import {
+  ABORT_TRUNCATED_CONTROL_STRING,
+  POST_REPLAY_MODE_RESET
+} from '../../../../../shared/terminal-mode-reset-profiles'
+import type { ConnectPanePtySession } from './connect-pane-pty-session'
+
+/** A proved replacement retires predecessor evidence, without spawning or claiming shell ownership. */
+export function retireRemotePtyIncarnation(
+  session: ConnectPanePtySession,
+  replacedPtyId: string,
+  ptyId: string
+): void {
+  session.authoritativeReattachGeneration += 1
+  session.replayPayloadGeneration += 1
+  session.pendingReplayData = null
+  session.pendingReattachFit?.cancel()
+  session.pendingReattachFit = null
+  session.clearHiddenOutputRestoreState()
+  session.clearRestoredSnapshotBaseline()
+  session.deferredReattachLiveData?.discard()
+  session.clearPaneMode2031State()
+  session.kittyKeyboardModes.reset()
+  session.paneForegroundAgentTracker.resetForPtyReplacement()
+  session.visibleForegroundSamplePending = false
+  session.visibleForegroundSampleSettled = false
+  session.deferredCommandFinishedStatusDrop = null
+  session.deferredConfirmedShellReconcile = null
+  session.clearCommandInferredPaneAgent()
+  session.resetPendingShellCommandLine()
+  session.rememberReattachPayloadAgentSignal('', { fullScreenReplay: true })
+  const state = useAppStore.getState()
+  const predecessorHandle = parseRemoteRuntimePtyId(replacedPtyId)?.handle
+  const successorHandle = parseRemoteRuntimePtyId(ptyId)?.handle
+  // Published rows can already belong to the successor; reused handles carry no incarnation fence.
+  if (predecessorHandle && successorHandle && predecessorHandle !== successorHandle) {
+    if (state.agentStatusByPaneKey[session.cacheKey]?.terminalHandle === predecessorHandle) {
+      state.removeAgentStatus(session.cacheKey)
+      session.deps.setCacheTimerStartedAt(session.cacheKey, null)
+    }
+    if (
+      state.agentLaunchConfigByPaneKey[session.cacheKey]?.identity.terminalHandle ===
+      predecessorHandle
+    ) {
+      state.clearAgentLaunchConfig(session.cacheKey)
+    }
+  }
+  state.clearPaneForegroundAgent(session.cacheKey)
+  session.replacementReplayPending = true
+  session.writeReplayData(`${ABORT_TRUNCATED_CONTROL_STRING}${POST_REPLAY_MODE_RESET}`)
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection/replay-data-drain.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/replay-data-drain.ts
@@ -1,3 +1,8 @@
+import {
+  ABORT_TRUNCATED_CONTROL_STRING,
+  buildSnapshotReplayPrologue,
+  POST_REPLAY_LIVE_AGENT_SNAPSHOT_RESET
+} from '../../../../../shared/terminal-mode-reset-profiles'
 import { waitForTerminalOutputParsed } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { safeFit, safeFitAndThen } from '@/lib/pane-manager/pane-tree-ops'
 import { getFitOverrideForPty } from '@/lib/pane-manager/mobile-fit-overrides'
@@ -75,11 +80,13 @@ export function bindReplayDataDrain(session: ConnectPanePtySession): void {
   let replayedAtSourceGrid = false
   const drainReplayDataQueue = async (
     expectedPtyId: string | null,
-    expectedStreamGeneration: number
+    expectedStreamGeneration: number,
+    expectedIncarnationId: string | null | undefined
   ): Promise<boolean> => {
     let appliedCurrentPayload = false
     while (session.pendingReplayData !== null) {
       if (
+        session.remotePtyIncarnationId !== expectedIncarnationId ||
         session.pendingReplayData.ptyId !== expectedPtyId ||
         session.pendingReplayData.streamGeneration !== expectedStreamGeneration
       ) {
@@ -117,8 +124,16 @@ export function bindReplayDataDrain(session: ConnectPanePtySession): void {
       // Why ahead of the source-grid resize: the clear is grid-independent, so
       // dropping the scrollback first spares a reflow of history the very next
       // sequence discards (see use-terminal-container-fit-sync.ts on its cost).
+      const replacementReplay = session.replacementReplayPending === true
       if (clearBeforeReplay) {
-        await session.writeReplayDataAsync('\x1b[2J\x1b[3J\x1b[H')
+        const paneOnAlternateScreen = session.pane.terminal.buffer.active.type === 'alternate'
+        await session.writeReplayDataAsync(
+          ABORT_TRUNCATED_CONTROL_STRING +
+            buildSnapshotReplayPrologue({
+              targetAlternateScreen: alternateScreen ?? paneOnAlternateScreen,
+              paneOnAlternateScreen
+            })
+        )
         if (!isCurrentPayload()) {
           continue
         }
@@ -159,7 +174,9 @@ export function bindReplayDataDrain(session: ConnectPanePtySession): void {
       }
       if (clearBeforeReplay || data.length > 0) {
         await session.writeReplayDataAsync(
-          session.reattachReplayResetSequence(data, false, alternateScreen, terminalOwner)
+          replacementReplay && terminalOwner !== 'shell'
+            ? POST_REPLAY_LIVE_AGENT_SNAPSHOT_RESET
+            : session.reattachReplayResetSequence(data, false, alternateScreen, terminalOwner)
         )
         if (!isCurrentPayload()) {
           continue
@@ -181,6 +198,7 @@ export function bindReplayDataDrain(session: ConnectPanePtySession): void {
       // empty buffer; rebuilding after replay parses seeds the glyph atlas
       // from the now-populated xterm state.
       session.manager.rebuildPaneWebgl(session.pane.id)
+      session.replacementReplayPending = false
       appliedCurrentPayload = true
     }
     return appliedCurrentPayload
@@ -233,6 +251,7 @@ export function bindReplayDataDrain(session: ConnectPanePtySession): void {
       return
     }
     const scheduledPtyId = session.pendingReplayData?.ptyId ?? null
+    const scheduledIncarnationId = session.remotePtyIncarnationId
     replayDrainQueued = true
     // Why reset here: a transaction whose restore was skipped never ran its
     // afterRestore, and a stale flag would fit a later drain that never left
@@ -249,12 +268,17 @@ export function bindReplayDataDrain(session: ConnectPanePtySession): void {
       .then(() =>
         session.structuralReplayCoordinator.run(
           async () => {
-            replayCompleted = await drainReplayDataQueue(scheduledPtyId, scheduledStreamGeneration)
+            replayCompleted = await drainReplayDataQueue(
+              scheduledPtyId,
+              scheduledStreamGeneration,
+              scheduledIncarnationId
+            )
           },
           {
             shouldRestore: () =>
               !session.disposed &&
               session.transport.getPtyId() === scheduledPtyId &&
+              session.remotePtyIncarnationId === scheduledIncarnationId &&
               session.transportStreamGeneration === scheduledStreamGeneration,
             afterRestore: () => fitAfterSourceGridReplay(scheduledPtyId, scheduledStreamGeneration)
           }
@@ -270,7 +294,11 @@ export function bindReplayDataDrain(session: ConnectPanePtySession): void {
           // re-reading it here could retag stale bytes for a replacement PTY.
           session.scheduleReplayDataDrain()
         }
-        session.finishReattachLiveDataDeferral(replayCompleted, scheduledStreamGeneration)
+        // A superseded image must not fail the successor's deferred live-output owner.
+        session.finishReattachLiveDataDeferral(
+          replayCompleted || session.remotePtyIncarnationId !== scheduledIncarnationId,
+          scheduledStreamGeneration
+        )
       })
   }
 }

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-incarnation-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-incarnation-recovery.test.ts
@@ -66,6 +66,46 @@ describe('remote PTY incarnation recovery', () => {
     }
   )
 
+  it.each(['terminal-1', 'terminal-2'])(
+    'uses the persisted session ID for connect reattachment to %s',
+    async (nextHandle) => {
+      resolvedPaneHandle = nextHandle
+      const originalCall = mocks.runtimeCall.getMockImplementation()!
+      mocks.runtimeCall.mockImplementation(async (request: { method: string }) => {
+        const response = await originalCall(request)
+        if (request.method === 'terminal.resolvePane') {
+          response.result.terminal.incarnationId = 'inc-new'
+        }
+        return response
+      })
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const onPtyRebind = vi.fn()
+      const onPtySpawn = vi.fn()
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-tab-1',
+        leafId: 'pane:1',
+        onPtyRebind,
+        onPtySpawn
+      })
+      try {
+        await transport.connect({
+          url: '',
+          sessionId: 'remote:env-1@@terminal-1',
+          callbacks: {}
+        })
+        expect(onPtyRebind).toHaveBeenCalledExactlyOnceWith(
+          `remote:env-1@@${nextHandle}`,
+          'remote:env-1@@terminal-1',
+          'inc-new'
+        )
+        expect(onPtySpawn).not.toHaveBeenCalled()
+      } finally {
+        transport.destroy?.()
+      }
+    }
+  )
+
   it.each(
     [
       { mirror: true, rotate: false, next: null, inventory: false },

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-incarnation-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-incarnation-recovery.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  decodeTerminalStreamFrame,
+  TerminalStreamOpcode
+} from '../../../../shared/terminal-stream-protocol'
+import {
+  createRemoteRuntimeTransportMocks,
+  type MultiplexSubscriptionCallbacks
+} from './remote-runtime-pty-transport-test-harness'
+
+let subscriptionCallbacks: MultiplexSubscriptionCallbacks = null
+let resolvedPaneHandle = 'terminal-1'
+const mocks = createRemoteRuntimeTransportMocks({
+  getCallbacks: () => subscriptionCallbacks,
+  setCallbacks: (callbacks) => {
+    subscriptionCallbacks = callbacks
+  },
+  getResolvedPaneHandle: () => resolvedPaneHandle,
+  setResolvedPaneHandle: (handle) => {
+    resolvedPaneHandle = handle
+  }
+})
+
+describe('remote PTY incarnation recovery', () => {
+  beforeEach(() => mocks.resetRemoteRuntimeTransport())
+
+  it.each([true, false])(
+    'publishes initial attach identity before its replay (mirror=%s)',
+    async (mirror) => {
+      const originalCall = mocks.runtimeCall.getMockImplementation()!
+      mocks.runtimeCall.mockImplementation(async (request: { method: string }) => {
+        const response = await originalCall(request)
+        if (request.method === 'terminal.resolvePane') {
+          response.result.terminal.incarnationId = 'inc-old'
+        }
+        return response
+      })
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const events: string[] = []
+      const onPtySpawn = vi.fn()
+      const onPtyRebind = vi.fn((_id: string, _old: string, incarnationId?: string | null) => {
+        events.push(`identity:${incarnationId}`)
+      })
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: mirror ? 'web-terminal-tab-1' : 'tab-1',
+        leafId: 'pane:1',
+        onPtySpawn,
+        onPtyRebind
+      })
+      try {
+        transport.attach({
+          existingPtyId: 'remote:env-1@@terminal-1',
+          cols: 75,
+          rows: 60,
+          callbacks: { onReplayData: () => events.push('replay') }
+        })
+        await vi.waitFor(() => expect(mocks.subscriptionSendBinary).toHaveBeenCalled())
+        mocks.emitSnapshot(mocks.latestSubscribePayload().streamId, 'FRAME')
+        await vi.waitFor(() => expect(events).toContain('replay'))
+        expect(events).toEqual(['identity:inc-old', 'replay'])
+        expect(onPtySpawn).not.toHaveBeenCalled()
+      } finally {
+        transport.destroy?.()
+      }
+    }
+  )
+
+  it.each(
+    [
+      { mirror: true, rotate: false, next: null, inventory: false },
+      { mirror: false, rotate: false, next: null, inventory: false },
+      { mirror: true, rotate: false, next: 'inc-new', inventory: true },
+      { mirror: true, rotate: true, next: 'inc-new', inventory: true },
+      { mirror: true, rotate: false, next: 'inc-new', inventory: false },
+      { mirror: true, rotate: true, next: 'inc-old', inventory: false },
+      { mirror: false, rotate: false, next: 'inc-new', inventory: false },
+      { mirror: false, rotate: true, next: 'inc-old', inventory: false },
+      { mirror: true, rotate: true, next: null, inventory: false }
+    ].flatMap((scenario) =>
+      (['mobile-fit', 'remote-desktop-fit'] as const).map((holdMode) => ({ ...scenario, holdMode }))
+    )
+  )(
+    'preserves ownership while delivering identity: $mirror/$rotate/$next/$inventory/$holdMode',
+    async (scenario) => {
+      let incarnationId: string | null = 'inc-old'
+      const originalCall = mocks.runtimeCall.getMockImplementation()!
+      mocks.runtimeCall.mockImplementation(async (request: { method: string }) => {
+        const response = await originalCall(request)
+        if (request.method === 'terminal.resolvePane') {
+          response.result.terminal.incarnationId = incarnationId
+        }
+        if (request.method === 'session.tabs.activate' && scenario.inventory) {
+          response.result.tabs[0].incarnationId = incarnationId
+        }
+        return response
+      })
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const { setFitOverride, getFitOverrideForPty, onOverrideChange } =
+        await import('../../lib/pane-manager/mobile-fit-overrides')
+      const { setDriverForPty, getDriverForPty, onDriverChange } =
+        await import('../../lib/pane-manager/mobile-driver-state')
+      const fitChanged = vi.fn()
+      const driverChanged = vi.fn()
+      const unsubscribeFit = onOverrideChange(fitChanged)
+      const unsubscribeDriver = onDriverChange(driverChanged)
+      const onPtyRebind = vi.fn()
+      const onPtySpawn = vi.fn()
+      const onPtyExit = vi.fn()
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: scenario.mirror ? 'web-terminal-tab-1' : 'tab-1',
+        leafId: 'pane:1',
+        onPtyRebind,
+        onPtySpawn,
+        onPtyExit
+      })
+      try {
+        await transport.connect({ url: '', callbacks: {} })
+        await vi.waitFor(() => expect(mocks.subscriptionSendBinary).toHaveBeenCalled())
+        setFitOverride('remote:env-1@@terminal-1', scenario.holdMode, 49, 20)
+        setDriverForPty('remote:env-1@@terminal-1', { kind: 'mobile', clientId: 'phone-1' })
+        fitChanged.mockClear()
+        driverChanged.mockClear()
+        const initialSubscriptions = mocks.subscribedTerminalHandles().length
+        onPtySpawn.mockClear()
+        incarnationId = scenario.next
+        if (scenario.rotate) {
+          resolvedPaneHandle = 'terminal-2'
+        }
+        subscriptionCallbacks?.onClose?.()
+        await vi.waitFor(() =>
+          expect(mocks.subscribedTerminalHandles().length).toBeGreaterThan(initialSubscriptions)
+        )
+        if (scenario.mirror || scenario.rotate || scenario.next) {
+          expect(onPtyRebind).toHaveBeenCalledOnce()
+          expect(onPtyRebind).toHaveBeenCalledWith(
+            `remote:env-1@@${resolvedPaneHandle}`,
+            'remote:env-1@@terminal-1',
+            ...(incarnationId ? [incarnationId] : [])
+          )
+        } else {
+          expect(onPtyRebind).not.toHaveBeenCalled()
+        }
+        const nextPtyId = `remote:env-1@@${resolvedPaneHandle}`
+        expect(getFitOverrideForPty(nextPtyId)).toEqual({
+          mode: scenario.holdMode,
+          cols: 49,
+          rows: 20
+        })
+        expect(getDriverForPty(nextPtyId)).toEqual({ kind: 'mobile', clientId: 'phone-1' })
+        if (!scenario.rotate) {
+          expect(fitChanged).not.toHaveBeenCalled()
+          expect(driverChanged).not.toHaveBeenCalled()
+        }
+        expect(
+          mocks.subscriptionSendBinary.mock.calls.map(
+            ([bytes]) => decodeTerminalStreamFrame(bytes)?.opcode
+          )
+        ).not.toContain(TerminalStreamOpcode.Resize)
+        expect(
+          mocks.subscriptionSendBinary.mock.calls.map(
+            ([bytes]) => decodeTerminalStreamFrame(bytes)?.opcode
+          )
+        ).not.toContain(TerminalStreamOpcode.ClaimViewport)
+        expect(onPtySpawn).not.toHaveBeenCalled()
+        expect(onPtyExit).not.toHaveBeenCalled()
+      } finally {
+        unsubscribeFit()
+        unsubscribeDriver()
+        transport.destroy?.()
+      }
+    }
+  )
+})

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -101,6 +101,7 @@ const TERMINAL_CREATE_RETRY_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 15_00
 type HostHandleReplacementPolicy = 'reuse' | 'prefer-replacement' | 'require-replacement'
 
 type HostSessionHandleWaitResult = {
+  incarnationId?: string | null
   handle: string | null | undefined
   inventoryFailed: boolean
 }
@@ -529,10 +530,10 @@ export function createRemoteRuntimePtyTransport(
     )
   }
 
-  function findReadyHostSessionHandle(
+  function findReadyHostSessionTerminal(
     snapshot: RuntimeMobileSessionTabsResult,
     hostTabId: string
-  ): string | null {
+  ): RuntimeMobileSessionTerminalClientTab | null {
     const terminalTabs = getHostSessionTerminalSurfaces(snapshot, hostTabId, {
       matchRequestedLeaf: false
     })
@@ -544,8 +545,7 @@ export function createRemoteRuntimePtyTransport(
           (tab) => tab.status === 'ready' && tab.parentTabId === hostTabId && tab.isActive
         ) ?? terminalTabs.find((tab) => tab.status === 'ready' && tab.parentTabId === hostTabId))
     if (selected?.status === 'ready') {
-      authoritativePtyIncarnationId = selected.incarnationId ?? null
-      return selected.terminal
+      return selected
     }
     return null
   }
@@ -618,9 +618,10 @@ export function createRemoteRuntimePtyTransport(
       }
       throw error
     }
-    const immediate = findReadyHostSessionHandle(activated, hostTabId)
+    const immediate = findReadyHostSessionTerminal(activated, hostTabId)
     if (immediate) {
-      return immediate
+      adoptExecutionMetadata(immediate)
+      return immediate.terminal
     }
 
     const startedAt = Date.now()
@@ -668,9 +669,10 @@ export function createRemoteRuntimePtyTransport(
         nextRequest = 'list'
         continue
       }
-      const handle = findReadyHostSessionHandle(snapshot, hostTabId)
-      if (handle) {
-        return handle
+      const terminal = findReadyHostSessionTerminal(snapshot, hostTabId)
+      if (terminal) {
+        adoptExecutionMetadata(terminal)
+        return terminal.terminal
       }
       if (request === 'activate') {
         // Why: an activation response can race host publication, so inventory — not this snapshot — decides what exists.
@@ -774,14 +776,18 @@ export function createRemoteRuntimePtyTransport(
     // Why: list-only polling cannot recreate a host PTY lost across desktop generations.
     let nextRequest: 'activate' | 'list' = 'activate'
     let lastRequestError: unknown = null
-    let lastReadyHandle: string | null = null
+    let lastReadyTerminal: RuntimeMobileSessionTerminalClientTab | null = null
     const finishBoundedWait = (): HostSessionHandleWaitResult => {
       const effectivePolicy = stricterReplacementPolicy(
         replacementPolicy,
         getRecoveryReplacementPolicy(previousHandle)
       )
-      if (effectivePolicy === 'prefer-replacement' && lastReadyHandle) {
-        return { handle: lastReadyHandle, inventoryFailed: false }
+      if (effectivePolicy === 'prefer-replacement' && lastReadyTerminal) {
+        return {
+          handle: lastReadyTerminal.terminal,
+          incarnationId: lastReadyTerminal.incarnationId,
+          inventoryFailed: false
+        }
       }
       if (lastRequestError) {
         console.warn(
@@ -822,16 +828,21 @@ export function createRemoteRuntimePtyTransport(
               // must stay slept even though it publishes the same pending status.
               await activateHostSessionSurface(hostTabId, worktree, 'automatic', requestRemainingMs)
         lastRequestError = null
-        const nextHandle = findReadyHostSessionHandle(listed, hostTabId)
-        if (nextHandle) {
-          lastReadyHandle = nextHandle
+        const nextTerminal = findReadyHostSessionTerminal(listed, hostTabId)
+        const nextHandle = nextTerminal?.terminal
+        if (nextTerminal) {
+          lastReadyTerminal = nextTerminal
         }
         const effectivePolicy = stricterReplacementPolicy(
           replacementPolicy,
           getRecoveryReplacementPolicy(previousHandle)
         )
         if (nextHandle && (effectivePolicy === 'reuse' || nextHandle !== previousHandle)) {
-          return { handle: nextHandle, inventoryFailed: false }
+          return {
+            handle: nextHandle,
+            incarnationId: nextTerminal?.incarnationId,
+            inventoryFailed: false
+          }
         }
         if (request === 'list') {
           if (!hasHostSessionTerminalSurface(listed, hostTabId)) {
@@ -918,7 +929,7 @@ export function createRemoteRuntimePtyTransport(
   }
 
   async function attachHostSessionMirror(
-    options: { cols?: number; rows?: number },
+    options: { cols?: number; rows?: number; existingPtyId?: string },
     notifySpawn = true,
     expectedAttachGeneration?: number,
     expectedLifecycleEpoch?: number
@@ -955,26 +966,9 @@ export function createRemoteRuntimePtyTransport(
       return undefined
     }
 
-    if (leafId && worktreeId && !resolvePaneUnavailable) {
-      try {
-        const resolved = await callRuntime<{ terminal: RuntimeTerminalResolvePane }>(
-          'terminal.resolvePane',
-          { paneKey: `${hostTabId}:${leafId}`, worktreeId }
-        )
-        const terminal = resolved.terminal
-        if (
-          terminal.handle === hostHandle &&
-          terminal.tabId === hostTabId &&
-          terminal.leafId === leafId &&
-          (!terminal.worktreeId || terminal.worktreeId === worktreeId)
-        ) {
-          adoptExecutionMetadata(terminal)
-        }
-      } catch (error) {
-        if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
-          resolvePaneUnavailable = true
-        }
-      }
+    const executionMetadata = await resolveHostSessionExecutionMetadata(hostTabId, hostHandle)
+    if (executionMetadata && isCurrent()) {
+      adoptExecutionMetadata(executionMetadata)
     }
 
     if (!isCurrent() || recovery.currentPhase === 'disconnected') {
@@ -990,6 +984,13 @@ export function createRemoteRuntimePtyTransport(
     }
     if (notifySpawn) {
       onPtySpawn?.(remotePtyId)
+    } else if (authoritativePtyIncarnationId) {
+      // attach() has no result consumer; publish its identity before the first image.
+      onPtyRebind?.(
+        remotePtyId,
+        options.existingPtyId ?? remotePtyId,
+        authoritativePtyIncarnationId
+      )
     }
 
     try {
@@ -1009,6 +1010,35 @@ export function createRemoteRuntimePtyTransport(
       isReattach: true,
       ...(authoritativePtyIncarnationId ? { incarnationId: authoritativePtyIncarnationId } : {})
     } satisfies PtyConnectResult
+  }
+
+  // Older inventory projections omit incarnation even when resolvePane can prove it.
+  async function resolveHostSessionExecutionMetadata(
+    hostTabId: string,
+    hostHandle: string
+  ): Promise<RuntimeTerminalResolvePane | null> {
+    if (!leafId || !worktreeId || resolvePaneUnavailable) {
+      return null
+    }
+    try {
+      const { terminal } = await callRuntime<{ terminal: RuntimeTerminalResolvePane }>(
+        'terminal.resolvePane',
+        { paneKey: `${hostTabId}:${leafId}`, worktreeId }
+      )
+      if (
+        terminal.handle === hostHandle &&
+        terminal.tabId === hostTabId &&
+        terminal.leafId === leafId &&
+        (!terminal.worktreeId || terminal.worktreeId === worktreeId)
+      ) {
+        return terminal
+      }
+    } catch (error) {
+      if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
+        resolvePaneUnavailable = true
+      }
+    }
+    return null
   }
 
   async function callRuntimeForEnvironment<TResult>(
@@ -1253,7 +1283,7 @@ export function createRemoteRuntimePtyTransport(
 
   async function adoptResolvedHostPane(
     terminal: RuntimeTerminalResolvePane,
-    options: { cols?: number; rows?: number },
+    options: { cols?: number; rows?: number; existingPtyId?: string },
     notifySpawn = true,
     expectedAttachGeneration?: number
   ): Promise<PtyConnectResult | undefined> {
@@ -1276,6 +1306,12 @@ export function createRemoteRuntimePtyTransport(
     }
     if (notifySpawn) {
       onPtySpawn?.(remotePtyId)
+    } else if (authoritativePtyIncarnationId) {
+      onPtyRebind?.(
+        remotePtyId,
+        options.existingPtyId ?? remotePtyId,
+        authoritativePtyIncarnationId
+      )
     }
     emitRecoveryState()
     try {
@@ -1588,8 +1624,10 @@ export function createRemoteRuntimePtyTransport(
     setAttachmentReady(false)
     // Why: host handle rotation preserves the pane generation; only the store identity changes, not spawn/exit semantics.
     if (replacedPtyId) {
-      replaceFitOverridePtyId(replacedPtyId, remotePtyId)
-      replaceDriverPtyId(replacedPtyId, remotePtyId)
+      if (replacedPtyId !== remotePtyId) {
+        replaceFitOverridePtyId(replacedPtyId, remotePtyId)
+        replaceDriverPtyId(replacedPtyId, remotePtyId)
+      }
       if (nextIncarnationId) {
         onPtyRebind?.(remotePtyId, replacedPtyId, nextIncarnationId)
       } else {
@@ -1610,7 +1648,7 @@ export function createRemoteRuntimePtyTransport(
         hostTabId,
         leafId
       },
-      (update) => {
+      async (update) => {
         if (destroyed || !connected || handle !== previousHandle) {
           clearPublishedHandleWait()
           return
@@ -1624,7 +1662,10 @@ export function createRemoteRuntimePtyTransport(
         if (!update.terminalHandle) {
           return
         }
-        if (update.terminalHandle === previousHandle) {
+        if (
+          update.terminalHandle === previousHandle &&
+          (!update.incarnationId || update.incarnationId === authoritativePtyIncarnationId)
+        ) {
           // Why: once the auto-recovery window is spent, a host still publishing this surface is evidence the fenced handle outlived the stale error.
           if (!autoRecoveryWindowSpent || getCurrentMultiplexedStream(previousHandle)) {
             return
@@ -1645,7 +1686,19 @@ export function createRemoteRuntimePtyTransport(
           // Why: without a live epoch a failed resubscribe is swallowed as already-latched, leaving a pane with no handle and no way back.
           recovery.begin()
         }
-        rebindRemoteTerminalHandle(update.terminalHandle)
+        const expectedSubscriptionGeneration = subscriptionGeneration
+        const metadata = update.incarnationId
+          ? update
+          : await resolveHostSessionExecutionMetadata(hostTabId, update.terminalHandle)
+        if (
+          destroyed ||
+          !connected ||
+          handle !== previousHandle ||
+          subscriptionGeneration !== expectedSubscriptionGeneration
+        ) {
+          return
+        }
+        rebindRemoteTerminalHandle(update.terminalHandle, metadata?.incarnationId ?? null)
         const reboundHandle = handle
         const reboundPtyId = remotePtyId
         void subscribeToHandle().catch((error) => {
@@ -1788,8 +1841,20 @@ export function createRemoteRuntimePtyTransport(
       if (effectivePolicy === 'require-replacement' && nextHandle === previousHandle) {
         return
       }
-      if (nextHandle !== previousHandle) {
-        rebindRemoteTerminalHandle(nextHandle)
+      const executionMetadata = waitResult.incarnationId
+        ? waitResult
+        : await resolveHostSessionExecutionMetadata(hostTabId, nextHandle)
+      if (
+        destroyed ||
+        !connected ||
+        handle !== previousHandle ||
+        !recovery.isCurrent(recoveryEpoch)
+      ) {
+        return
+      }
+      const nextIncarnationId = executionMetadata?.incarnationId ?? null
+      if (nextHandle !== previousHandle || nextIncarnationId !== authoritativePtyIncarnationId) {
+        rebindRemoteTerminalHandle(nextHandle, nextIncarnationId)
       }
       clearPublishedHandleWait()
       await subscribeToHandle(
@@ -1814,10 +1879,13 @@ export function createRemoteRuntimePtyTransport(
         retireRemoteTerminalId(-1)
         return
       }
-      if (resolved.handle !== previousHandle) {
-        adoptExecutionMetadata(resolved)
+      if (
+        resolved.handle !== previousHandle ||
+        (resolved.incarnationId ?? null) !== authoritativePtyIncarnationId
+      ) {
         rebindRemoteTerminalHandle(resolved.handle, resolved.incarnationId ?? null)
       }
+      adoptExecutionMetadata(resolved)
       clearPublishedHandleWait()
       await subscribeToHandle(
         recoveryEpoch,

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -929,7 +929,7 @@ export function createRemoteRuntimePtyTransport(
   }
 
   async function attachHostSessionMirror(
-    options: { cols?: number; rows?: number; existingPtyId?: string },
+    options: { cols?: number; rows?: number; existingPtyId?: string; sessionId?: string },
     notifySpawn = true,
     expectedAttachGeneration?: number,
     expectedLifecycleEpoch?: number
@@ -988,7 +988,7 @@ export function createRemoteRuntimePtyTransport(
       // attach() has no result consumer; publish its identity before the first image.
       onPtyRebind?.(
         remotePtyId,
-        options.existingPtyId ?? remotePtyId,
+        options.existingPtyId ?? options.sessionId ?? remotePtyId,
         authoritativePtyIncarnationId
       )
     }

--- a/src/renderer/src/lib/pane-manager/pane-fit-unknown-owner-size.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-unknown-owner-size.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readProposedPaneFitDimensions, safeFit } from './pane-fit'
+import { getFitOverrideForPty, hydrateOverrides, setFitOverride } from './mobile-fit-overrides'
+import type { ManagedPane } from './pane-manager-types'
+
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({ recordRendererCrashBreadcrumb: vi.fn() }))
+afterEach(() => hydrateOverrides([]))
+
+function createPane(width = 649): ManagedPane {
+  const terminal = {
+    cols: 120,
+    rows: 40,
+    resize: vi.fn((cols: number, rows: number) => {
+      terminal.cols = cols
+      terminal.rows = rows
+    })
+  }
+  return {
+    terminal,
+    container: {
+      dataset: { ptyId: 'held-pty' },
+      getBoundingClientRect: () => ({ width, height: 964 })
+    },
+    fitAddon: {
+      proposeDimensions: vi.fn(() => ({ cols: 75, rows: 60 })),
+      fit: vi.fn(() => terminal.resize(75, 60))
+    }
+  } as unknown as ManagedPane
+}
+
+describe('safeFit with an owner whose geometry is unknown', () => {
+  it.each(['remote-desktop-fit', 'mobile-fit'] as const)(
+    'retains the %s hold while fitting locally',
+    (mode) => {
+      const pane = createPane()
+      setFitOverride('held-pty', mode, 0, 0)
+      expect(readProposedPaneFitDimensions(pane)).toEqual({ cols: 75, rows: 60 })
+      expect(safeFit(pane)).toBe(true)
+      expect(pane.terminal.resize).toHaveBeenCalledWith(75, 60)
+      expect(pane.terminal.resize).not.toHaveBeenCalledWith(0, 0)
+      expect(getFitOverrideForPty('held-pty')).toEqual({ mode, cols: 0, rows: 0 })
+      setFitOverride('held-pty', mode, 2, 1)
+      expect(safeFit(pane)).toBe(true)
+      expect(pane.terminal.resize).toHaveBeenLastCalledWith(2, 1)
+    }
+  )
+
+  it.each([Number.NaN, Infinity, -1])('does not apply invalid owner dimension %s', (cols) => {
+    const pane = createPane()
+    setFitOverride('held-pty', 'remote-desktop-fit', cols, 40)
+    expect(safeFit(pane)).toBe(true)
+    expect(pane.terminal.resize).toHaveBeenCalledWith(75, 60)
+    expect(getFitOverrideForPty('held-pty')?.cols).toBe(cols)
+  })
+
+  it('does not guess a hidden destination grid', () => {
+    const pane = createPane(0)
+    setFitOverride('held-pty', 'remote-desktop-fit', 0, 0)
+    expect(readProposedPaneFitDimensions(pane)).toBeNull()
+    expect(safeFit(pane)).toBe(false)
+    expect(pane.terminal.resize).not.toHaveBeenCalled()
+    expect(getFitOverrideForPty('held-pty')).not.toBeNull()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.ts
@@ -63,7 +63,7 @@ export function readProposedPaneFitDimensions(
   const ptyId = pane.container?.dataset?.ptyId
   const override = ptyId ? getFitOverrideForPty(ptyId) : null
   const measurable = canMeasurePaneForFit(pane)
-  if (!measurable && !override) {
+  if (!measurable && !(override && hasKnownFitOverrideDimensions(override))) {
     return null
   }
   // Re-check after the metric flush: larger cells can push a narrow pane below
@@ -71,10 +71,19 @@ export function readProposedPaneFitDimensions(
   if (measurable && flushDeferredPaneMetricOptions(pane) && !canMeasurePaneForFit(pane)) {
     return null
   }
-  if (override) {
+  if (override && hasKnownFitOverrideDimensions(override)) {
     return { cols: override.cols, rows: override.rows }
   }
   return getProposedPaneDimensions(pane)
+}
+
+function hasKnownFitOverrideDimensions(dimensions: { cols: number; rows: number }): boolean {
+  return (
+    Number.isFinite(dimensions.cols) &&
+    Number.isFinite(dimensions.rows) &&
+    dimensions.cols > 0 &&
+    dimensions.rows > 0
+  )
 }
 
 function canPreserveScrollIntentForFit(pane: ManagedPane): boolean {
@@ -108,10 +117,10 @@ function performSafeFit(pane: ManagedPane): boolean {
     shouldRestoreScroll = true
   }
   try {
-    // Why: a mobile-owned PTY must stay at its phone grid on passive desktop panes.
+    // Why: an unknown host size retains the hold but cannot size the renderer to zero.
     const ptyId = pane.container?.dataset?.ptyId
     const override = ptyId ? getFitOverrideForPty(ptyId) : null
-    if (override) {
+    if (override && hasKnownFitOverrideDimensions(override)) {
       if (pane.terminal.cols !== override.cols || pane.terminal.rows !== override.rows) {
         if (canPreserveScrollIntentForFit(pane)) {
           captureScrollForFit()

--- a/src/renderer/src/runtime/web-session-terminal-handle-events.test.ts
+++ b/src/renderer/src/runtime/web-session-terminal-handle-events.test.ts
@@ -22,41 +22,46 @@ function snapshot(
 }
 
 describe('accepted web-session terminal handle events', () => {
-  it('notifies only the matching runtime/worktree/pane and releases the listener', async () => {
-    const listener = vi.fn()
-    const unsubscribe = subscribeAcceptedWebSessionTerminalHandle(
-      { environmentId: 'env-1', worktreeId: 'wt-1', hostTabId: 'tab-1', leafId: 'leaf-1' },
-      listener
-    )
+  it.each([undefined, 'inc-new'])(
+    'notifies only the matching runtime/worktree/pane with optional identity %s and releases the listener',
+    async (incarnationId) => {
+      const listener = vi.fn()
+      const unsubscribe = subscribeAcceptedWebSessionTerminalHandle(
+        { environmentId: 'env-1', worktreeId: 'wt-1', hostTabId: 'tab-1', leafId: 'leaf-1' },
+        listener
+      )
 
-    queueAcceptedWebSessionTerminalSnapshot(snapshot([]), 'env-2')
-    queueAcceptedWebSessionTerminalSnapshot(snapshot([], 'wt-2'), 'env-1')
-    queueAcceptedWebSessionTerminalSnapshot(
-      snapshot([
-        {
-          type: 'terminal',
-          id: 'tab-1::leaf-1',
-          parentTabId: 'tab-1',
-          leafId: 'leaf-1',
-          title: 'Claude Code',
-          isActive: true,
-          status: 'ready',
-          terminal: 'terminal-replacement'
-        }
-      ]),
-      'env-1'
-    )
-    await Promise.resolve()
+      queueAcceptedWebSessionTerminalSnapshot(snapshot([]), 'env-2')
+      queueAcceptedWebSessionTerminalSnapshot(snapshot([], 'wt-2'), 'env-1')
+      queueAcceptedWebSessionTerminalSnapshot(
+        snapshot([
+          {
+            type: 'terminal',
+            id: 'tab-1::leaf-1',
+            parentTabId: 'tab-1',
+            leafId: 'leaf-1',
+            title: 'Claude Code',
+            isActive: true,
+            status: 'ready',
+            terminal: 'terminal-replacement',
+            incarnationId
+          }
+        ]),
+        'env-1'
+      )
+      await Promise.resolve()
 
-    expect(listener).toHaveBeenCalledOnce()
-    expect(listener).toHaveBeenCalledWith({
-      surfacePresent: true,
-      terminalHandle: 'terminal-replacement'
-    })
-    expect(getWebSessionTerminalHandleSubscriberCountForTests()).toBe(1)
-    unsubscribe()
-    expect(getWebSessionTerminalHandleSubscriberCountForTests()).toBe(0)
-  })
+      expect(listener).toHaveBeenCalledOnce()
+      expect(listener).toHaveBeenCalledWith({
+        surfacePresent: true,
+        terminalHandle: 'terminal-replacement',
+        ...(incarnationId ? { incarnationId } : {})
+      })
+      expect(getWebSessionTerminalHandleSubscriberCountForTests()).toBe(1)
+      unsubscribe()
+      expect(getWebSessionTerminalHandleSubscriberCountForTests()).toBe(0)
+    }
+  )
 
   it('distinguishes a pending handle from an explicitly removed surface', async () => {
     const listener = vi.fn()

--- a/src/renderer/src/runtime/web-session-terminal-handle-events.ts
+++ b/src/renderer/src/runtime/web-session-terminal-handle-events.ts
@@ -6,6 +6,7 @@ import type {
 export type WebSessionTerminalHandleUpdate = {
   surfacePresent: boolean
   terminalHandle: string | null
+  incarnationId?: string | null
 }
 
 type TerminalHandleSubscriber = {
@@ -48,7 +49,8 @@ function resolveSubscriberUpdate(
     mirroredSurfaces.find((surface) => surface.status === 'ready')
   return {
     surfacePresent: true,
-    terminalHandle: readySurface?.terminal ?? null
+    terminalHandle: readySurface?.terminal ?? null,
+    ...(readySurface?.incarnationId ? { incarnationId: readySurface.incarnationId } : {})
   }
 }
 

--- a/tests/e2e/helpers/remote-terminal-geometry-probe.ts
+++ b/tests/e2e/helpers/remote-terminal-geometry-probe.ts
@@ -1,0 +1,51 @@
+import type { Page } from '@stablyai/playwright-test'
+
+/** Records the actual mutation and its renderer metrics without changing terminal input. */
+export async function installRemoteTerminalGeometryProbe(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((id) => {
+    const pane = window.__paneManagers?.get(id)?.getActivePane?.()
+    if (!pane) {
+      throw new Error('No pane for geometry probe')
+    }
+    const events: unknown[] = []
+    Reflect.set(window, '__remoteTerminalGeometryEvents', events)
+    const measure = () => {
+      const parent = pane.terminal.element?.parentElement
+      const core = Reflect.get(pane.terminal, '_core')
+      const style = parent ? getComputedStyle(parent) : null
+      return {
+        grid: { cols: pane.terminal.cols, rows: pane.terminal.rows },
+        parent: { width: style?.width, height: style?.height, display: style?.display },
+        cell: core?._renderService?.dimensions?.css?.cell,
+        ptyId: pane.container.dataset.ptyId,
+        time: performance.now()
+      }
+    }
+    const resize = pane.terminal.resize.bind(pane.terminal)
+    pane.terminal.resize = (cols, rows) => {
+      events.push({
+        kind: 'resize',
+        cols,
+        rows,
+        ...measure(),
+        stack: new Error('terminal resize').stack
+      })
+      resize(cols, rows)
+    }
+    const propose = pane.fitAddon.proposeDimensions.bind(pane.fitAddon)
+    pane.fitAddon.proposeDimensions = () => {
+      const proposal = propose()
+      events.push({
+        kind: 'proposal',
+        proposal,
+        ...measure(),
+        stack: new Error('fit proposal').stack
+      })
+      return proposal
+    }
+  }, tabId)
+}
+
+export async function readRemoteTerminalGeometryProbe(page: Page): Promise<unknown> {
+  return page.evaluate(() => Reflect.get(window, '__remoteTerminalGeometryEvents'))
+}

--- a/tests/e2e/paired-remote-terminal-replacement-state.spec.ts
+++ b/tests/e2e/paired-remote-terminal-replacement-state.spec.ts
@@ -1,0 +1,419 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  expect,
+  test,
+  type ElectronApplication,
+  type Page,
+  type TestInfo
+} from '@stablyai/playwright-test'
+import {
+  installRemoteTerminalGeometryProbe,
+  readRemoteTerminalGeometryProbe
+} from './helpers/remote-terminal-geometry-probe'
+import { toWebTerminalSurfaceTabId } from '../../src/shared/terminal-surface-id'
+import { toRemoteRuntimePtyId } from '../../src/shared/remote-runtime-pty-id'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+import { launchPairedElectronClient } from './helpers/paired-electron-client'
+import { cleanupE2EDaemons } from './helpers/electron-process-shutdown'
+import {
+  createHostCliTerminal,
+  readSink,
+  type RuntimeRpcCall
+} from './helpers/host-created-terminal-retention-oracle'
+
+type TerminalSummary = {
+  handle: string
+  ptyId: string
+  incarnationId: string
+  agentIdentity?: string
+}
+
+async function verifyReleaseBuild(app: ElectronApplication) {
+  const observed = await app.evaluate(({ app }) => ({
+    appVersion: app.getVersion(),
+    electronVersion: process.versions.electron,
+    userDataDir: app.getPath('userData')
+  }))
+  const manifest = JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'))
+  const electronManifest = JSON.parse(
+    readFileSync(path.join(process.cwd(), 'node_modules', 'electron', 'package.json'), 'utf8')
+  )
+  expect(observed.appVersion).toBe(manifest.version)
+  expect(observed.electronVersion).toBe(electronManifest.version)
+  return observed
+}
+
+async function captureHiddenRenderer(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  const cdp = await page.context().newCDPSession(page)
+  try {
+    const { data } = await cdp.send('Page.captureScreenshot', { format: 'png' })
+    const screenshot = testInfo.outputPath(`${name}.png`)
+    writeFileSync(screenshot, Buffer.from(data, 'base64'))
+    await testInfo.attach(name, { path: screenshot, contentType: 'image/png' })
+  } finally {
+    await cdp.detach()
+  }
+}
+
+async function inspectPane(page: Page, tabId: string) {
+  return page.evaluate((id) => {
+    const manager = window.__paneManagers?.get(id)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
+    if (!pane) {
+      return null
+    }
+    const terminal = pane.terminal
+    const buffer = terminal.buffer.active
+    let text = ''
+    let invisibleCharacters = 0
+    for (let y = 0; y < buffer.length; y++) {
+      const line = buffer.getLine(y)
+      text += `${y > 0 && !line?.isWrapped ? '\n' : ''}${line?.translateToString(true) ?? ''}`
+      for (let x = 0; x < terminal.cols; x++) {
+        const cell = line?.getCell(x)
+        if (cell?.getChars().trim() && cell.isInvisible()) {
+          invisibleCharacters++
+        }
+      }
+    }
+    const prior = Reflect.get(window, '__replacementOriginalTerminal')
+    const state = window.__store?.getState()
+    return {
+      sameTerminal: terminal === prior,
+      mouseMode: terminal.modes.mouseTrackingMode,
+      bufferType: buffer.type,
+      viewportY: buffer.viewportY,
+      baseY: buffer.baseY,
+      text,
+      cols: terminal.cols,
+      rows: terminal.rows,
+      proposedGrid: pane.fitAddon.proposeDimensions(),
+      documentVisibility: document.visibilityState,
+      containerSize: {
+        width: pane.container.getBoundingClientRect().width,
+        height: pane.container.getBoundingClientRect().height
+      },
+      agentStates: Object.values(state?.agentStatusByPaneKey ?? {}).map((entry) => ({
+        agentType: entry.agentType,
+        state: entry.state,
+        terminalTitle: entry.terminalTitle
+      })),
+      invisibleCharacters,
+      title: state?.tabsByWorktree[state.activeWorktreeId ?? '']?.find((tab) => tab.id === id)
+        ?.title,
+      ptyId: pane.container.dataset.ptyId,
+      recoveryPhase: pane.container.dataset.ptyRecoveryState
+    }
+  }, tabId)
+}
+
+async function probeMouse(page: Page, tabId: string) {
+  return page.evaluate(async (id) => {
+    const manager = window.__paneManagers?.get(id)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
+    const screen = pane?.terminal.element?.querySelector('.xterm-screen')
+    if (!pane || !screen) {
+      throw new Error('No rendered terminal for mouse probe')
+    }
+    const terminal = pane.terminal
+    const reports: string[] = []
+    const listener = terminal.onData((data) => {
+      if (data.includes('\x1b[<')) {
+        reports.push(data)
+      }
+    })
+    const before = terminal.buffer.active.viewportY
+    try {
+      const rect = screen.getBoundingClientRect()
+      if (rect.width <= 0 || rect.height <= 0) {
+        throw new Error('Terminal has no layout')
+      }
+      for (const fraction of [0.2, 0.4, 0.6, 0.8]) {
+        screen.dispatchEvent(
+          new MouseEvent('mousemove', {
+            bubbles: true,
+            clientX: rect.x + rect.width * fraction,
+            clientY: rect.y + rect.height * 0.5,
+            buttons: 0
+          })
+        )
+      }
+      screen.dispatchEvent(
+        new WheelEvent('wheel', {
+          bubbles: true,
+          cancelable: true,
+          deltaY: -120,
+          clientX: rect.x + rect.width * 0.5,
+          clientY: rect.y + rect.height * 0.5
+        })
+      )
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+      return { reports, before, after: terminal.buffer.active.viewportY }
+    } finally {
+      listener.dispose()
+    }
+  }, tabId)
+}
+
+// oxlint-disable-next-line no-empty-pattern -- Manually owned host/client fixtures; testInfo is the second argument.
+test('retained remote pane reconciles replacement shell and preserves a surviving agent', async ({}, testInfo) => {
+  test.skip(process.platform === 'win32', 'This diagnostic reproduces the POSIX shell replacement')
+  expect(process.env.ORCA_BACKGROUND_LAUNCH).toBe('1')
+  const scratch = mkdtempSync(path.join(os.tmpdir(), 'orca-replacement-state-'))
+  const fixturePath = path.join(scratch, 'agent.mjs')
+  const sinkPath = path.join(scratch, 'agent.log')
+  writeFileSync(
+    fixturePath,
+    [
+      "import { appendFileSync } from 'node:fs'",
+      'const sink = process.argv[2]',
+      'appendFileSync(sink, `READY:${process.pid}\\n`)',
+      'process.stdin.setRawMode?.(true)',
+      "process.stdout.write('\\x1b]0;π - replacement-test\\x07')",
+      'process.stdout.write(\'\\x1b]9999;{"state":"idle","agentType":"pi"}\\x07\')',
+      'for (let i = 0; i < 80; i++) process.stdout.write(`OLD_AGENT_ROW_${i}\\r\\n`)',
+      "process.stdout.write('AGENT_READY\\r\\n\\x1b[?1003h\\x1b[?1006h')",
+      'process.stdin.on(\'data\', data => { appendFileSync(sink, `INPUT:${JSON.stringify(data.toString())}\\n`); if (data.toString().includes(\'WARM_PROBE\')) process.stdout.write(\'WARM_PROBE_ACK\\r\\n\'); if (data.toString().includes(\'ARM_STATUS\')) process.stdout.write(\'\\x1b]9999;{"state":"working","prompt":"fixture","agentType":"pi"}\\x07\') })',
+      'process.stdin.resume()'
+    ].join('\n')
+  )
+  const host = await launchHeadlessPairedRuntimeHost({ pinnedServePort: true })
+  let client: Awaited<ReturnType<typeof launchPairedElectronClient>> | undefined
+  const evidence: Record<string, unknown> = {}
+  const hostCall: RuntimeRpcCall = async (method, params) =>
+    (await host.client.call(method, params)).result as never
+  try {
+    evidence.hostBuild = await verifyReleaseBuild(host.app)
+    const added = await hostCall<{ repo: { id: string } }>('repo.add', {
+      path: scratch,
+      kind: 'folder'
+    })
+    const listed = await hostCall<{ worktrees: { id: string }[] }>('worktree.list', {
+      repo: `id:${added.repo.id}`
+    })
+    const worktreeId = listed.worktrees[0]?.id
+    if (!worktreeId) {
+      throw new Error('Host did not create the disposable folder workspace')
+    }
+    const created = await createHostCliTerminal(hostCall, worktreeId, fixturePath, sinkPath)
+    const before = await hostCall<{ terminal: TerminalSummary }>('terminal.show', {
+      terminal: created.handle
+    })
+    evidence.hostBefore = before.terminal
+    const webTabId = toWebTerminalSurfaceTabId(created.tabId)
+    client = await launchPairedElectronClient(host.offer, testInfo, 'replacement-test')
+    evidence.clientBuild = await verifyReleaseBuild(client.app)
+    const { page } = client
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            (id) =>
+              window.__store
+                ?.getState()
+                .allWorktrees()
+                .some((w) => w.id === id),
+            worktreeId
+          ),
+        { timeout: 60_000 }
+      )
+      .toBe(true)
+    await page.evaluate(
+      ({ worktreeId, environmentId }) => {
+        window.__store?.getState().setActiveView('terminal')
+        window.__store?.getState().setActiveWorktree(worktreeId, `runtime:${environmentId}`)
+      },
+      { worktreeId, environmentId: client.environmentId }
+    )
+    await page
+      .locator(`[data-testid="sortable-tab"][data-tab-id="${webTabId}"]`)
+      .click({ timeout: 60_000 })
+    await expect
+      .poll(async () => (await inspectPane(page, webTabId))?.text, { timeout: 30_000 })
+      .toContain('AGENT_READY')
+    await page.evaluate((id) => {
+      const manager = window.__paneManagers?.get(id)
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
+      Reflect.set(window, '__replacementOriginalTerminal', pane?.terminal)
+    }, webTabId)
+    await expect.poll(async () => (await inspectPane(page, webTabId))?.mouseMode).toBe('any')
+    await hostCall('terminal.send', { terminal: created.handle, text: 'ARM_STATUS' })
+    await expect
+      .poll(
+        async () =>
+          (await inspectPane(page, webTabId))?.agentStates.some(
+            (entry) => entry.agentType === 'pi' && entry.state === 'working'
+          ),
+        { timeout: 15_000 }
+      )
+      .toBe(true)
+    await installRemoteTerminalGeometryProbe(page, webTabId)
+    evidence.before = await inspectPane(page, webTabId)
+    evidence.mouseBefore = await probeMouse(page, webTabId)
+    expect(
+      (evidence.mouseBefore as Awaited<ReturnType<typeof probeMouse>>).reports.length
+    ).toBeGreaterThan(0)
+    await captureHiddenRenderer(page, testInfo, 'before-restart')
+
+    // A process-only serve restart must not be confused with replacing its daemon-backed PTY.
+    await host.restartServeProcess()
+    evidence.warmHostBuild = await verifyReleaseBuild(host.app)
+    await expect
+      .poll(async () => (await inspectPane(page, webTabId))?.text, { timeout: 45_000 })
+      .toContain('AGENT_READY')
+    let warm: TerminalSummary | undefined
+    await expect
+      .poll(
+        async () => {
+          const inventory = await hostCall<{ terminals: TerminalSummary[] }>('terminal.list', {
+            worktree: `id:${worktreeId}`
+          })
+          warm = inventory.terminals.find((t) => t.ptyId === before.terminal.ptyId)
+          return warm?.incarnationId
+        },
+        { timeout: 45_000 }
+      )
+      .toBe(before.terminal.incarnationId)
+    if (!warm) {
+      throw new Error('Host did not re-publish the surviving terminal')
+    }
+    await hostCall('terminal.send', { terminal: warm.handle, text: 'WARM_PROBE' })
+    await expect
+      .poll(async () => (await inspectPane(page, webTabId))?.text, {
+        timeout: 45_000
+      })
+      .toContain('WARM_PROBE_ACK')
+    evidence.warmImmediate = await inspectPane(page, webTabId)
+    await expect
+      .configure({ soft: true })
+      .poll(
+        async () => {
+          const pane = await inspectPane(page, webTabId)
+          return Boolean(
+            pane && pane.cols === pane.proposedGrid?.cols && pane.rows === pane.proposedGrid?.rows
+          )
+        },
+        { timeout: 10_000, message: 'Reconnect geometry did not recover within 10 seconds' }
+      )
+      .toBe(true)
+    evidence.warm = await inspectPane(page, webTabId)
+    await captureHiddenRenderer(page, testInfo, 'after-warm-restart')
+    expect.soft((evidence.warm as Awaited<ReturnType<typeof inspectPane>>)?.sameTerminal).toBe(true)
+    expect.soft((evidence.warm as Awaited<ReturnType<typeof inspectPane>>)?.mouseMode).toBe('any')
+    evidence.mouseWarm = await probeMouse(page, webTabId)
+    expect
+      .soft((evidence.mouseWarm as Awaited<ReturnType<typeof probeMouse>>).reports.length)
+      .toBeGreaterThan(0)
+
+    // Only the daemon owned by this freshly-created temporary profile is retired.
+    await host.restartServeProcess({ betweenProcesses: () => cleanupE2EDaemons(host.userDataDir) })
+    evidence.replacementHostBuild = await verifyReleaseBuild(host.app)
+    let replacement: TerminalSummary | undefined
+    await expect
+      .poll(
+        async () => {
+          const inventory = await hostCall<{ terminals: TerminalSummary[] }>('terminal.list', {
+            worktree: `id:${worktreeId}`
+          })
+          replacement = inventory.terminals.find((t) => t.ptyId === before.terminal.ptyId)
+          return Boolean(
+            replacement?.incarnationId &&
+            replacement.incarnationId !== before.terminal.incarnationId
+          )
+        },
+        { timeout: 60_000 }
+      )
+      .toBe(true)
+    if (!replacement) {
+      throw new Error('Host never published the replacement terminal')
+    }
+    evidence.hostAfter = replacement
+    evidence.hostSessionAfter = await hostCall('session.tabs.list', {
+      worktree: `id:${worktreeId}`
+    })
+    evidence.hostScreen = await hostCall('terminal.read', {
+      terminal: replacement.handle,
+      screen: true
+    })
+    await expect
+      .poll(
+        async () => {
+          const pane = await inspectPane(page, webTabId)
+          return { ptyId: pane?.ptyId, phase: pane?.recoveryPhase }
+        },
+        { timeout: 45_000 }
+      )
+      .toEqual({
+        ptyId: toRemoteRuntimePtyId(replacement.handle, client.environmentId),
+        phase: 'connected'
+      })
+    await expect
+      .configure({ soft: true })
+      .poll(
+        async () => {
+          const pane = await inspectPane(page, webTabId)
+          return Boolean(
+            pane &&
+            pane.mouseMode === 'none' &&
+            pane.cols === pane.proposedGrid?.cols &&
+            pane.rows === pane.proposedGrid?.rows &&
+            !pane.agentStates.some((entry) => entry.agentType === 'pi' && entry.state === 'working')
+          )
+        },
+        { timeout: 10_000, message: 'Replacement retained agent modes/status after settling' }
+      )
+      .toBe(true)
+    evidence.after = await inspectPane(page, webTabId)
+    evidence.mouseAfter = await probeMouse(page, webTabId)
+    evidence.hostScreenAfterMouse = await hostCall('terminal.read', {
+      terminal: replacement.handle,
+      screen: true
+    })
+    await captureHiddenRenderer(page, testInfo, 'after-replacement')
+    const after = evidence.after as Awaited<ReturnType<typeof inspectPane>>
+    expect.soft(after?.sameTerminal).toBe(true)
+    expect.soft(after?.mouseMode).toBe('none')
+    expect.soft(after?.invisibleCharacters).toBe(0)
+    expect
+      .soft((evidence.mouseAfter as Awaited<ReturnType<typeof probeMouse>>).reports)
+      .toHaveLength(0)
+    expect
+      .soft(
+        after?.agentStates.some((entry) => entry.agentType === 'pi' && entry.state === 'working')
+      )
+      .toBe(false)
+    expect.soft(after?.cols).toBe(after?.proposedGrid?.cols)
+    expect.soft(after?.rows).toBe(after?.proposedGrid?.rows)
+    const hostScreen = evidence.hostScreen as { terminal: { tail: string[]; source?: string } }
+    expect(hostScreen.terminal.source).toBe('screen')
+    const prompt = hostScreen.terminal.tail.at(-1)?.trim()
+    expect(prompt).toBeTruthy()
+    expect.soft(after?.text).toContain(prompt)
+    const afterMouse = evidence.hostScreenAfterMouse as { terminal: { tail: string[] } }
+    expect.soft(afterMouse.terminal.tail.join('\n')).not.toMatch(/(?:35|64);\d+;\d+[Mm]/)
+    expect
+      .soft(
+        readSink(sinkPath)
+          .split('\n')
+          .filter((line) => line.startsWith('READY:'))
+      )
+      .toHaveLength(1)
+  } finally {
+    if (client) {
+      evidence.geometryEvents = await readRemoteTerminalGeometryProbe(client.page).catch(() => null)
+    }
+    evidence.fixtureLog = readSink(sinkPath)
+    writeFileSync(
+      testInfo.outputPath('replacement-evidence.json'),
+      JSON.stringify(evidence, null, 2)
+    )
+    try {
+      await client?.dispose()
+    } finally {
+      await host.dispose()
+      rmSync(scratch, { recursive: true, force: true })
+    }
+  }
+})

--- a/tests/playwright.remote-replacement.config.ts
+++ b/tests/playwright.remote-replacement.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@stablyai/playwright-test'
+
+// This diagnostic owns its profiles and builds explicitly; no global CLI installation or SSH setup.
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: 'paired-remote-terminal-replacement-state.spec.ts',
+  timeout: 180_000,
+  workers: 1,
+  retries: 0,
+  reporter: 'list',
+  outputDir: '../test-results/remote-replacement',
+  use: { trace: 'retain-on-failure' }
+})

--- a/tests/playwright.remote-replacement.config.ts
+++ b/tests/playwright.remote-replacement.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from '@stablyai/playwright-test'
 
+process.env.ORCA_BACKGROUND_LAUNCH = '1'
+
 // This diagnostic owns its profiles and builds explicitly; no global CLI installation or SSH setup.
 export default defineConfig({
   testDir: './e2e',
   testMatch: 'paired-remote-terminal-replacement-state.spec.ts',
-  timeout: 180_000,
+  timeout: 420_000,
   workers: 1,
   retries: 0,
   reporter: 'list',


### PR DESCRIPTION
## ELI5

Remote terminals should reconnect without shrinking to a nearly blank grid or sending mouse escape codes into a replacement shell. This fixes those two failures while preserving the terminal modes of an agent that is still running.

## What Changed

- Keep remote/mobile ownership holds when their dimensions are unknown, but do not resize xterm to `0×0`. Measurable panes fit locally without claiming or resizing the host; genuine positive small grids remain authoritative.
- Deliver optional process-incarnation identity on initial attachment and recovery using existing RPCs. Retire predecessor modes, replay work and positively attributed client status only after a known incarnation change.
- Preserve ownership maps for same-handle identity updates and retain same-incarnation/unknown-identity behavior.
- Add causal unit regressions and an isolated paired-host/client Electron test covering warm reconnect, shell replacement, actual mouse reports and host-side echo.

## Why

The release reproduction captured an owner-fit override calling `terminal.resize(0, 0)`, which xterm clamped to `2×1`. A separate replacement path retained the predecessor's mouse modes because the pane did not consistently receive incarnation changes.

## Linked Issue

Refs https://github.com/stablyai/orca/issues/18464

**Stack 1/2.** This PR addresses terminal recovery, not the entire identity issue. A dependent PR will address host-published automatic titles and completed agent metadata. The issue should remain open until that work is complete.

## Visual Proof

Synthetic, disposable Linux fixtures; screenshots captured through CDP without showing or focusing native windows. Before: exact `v1.4.199`. After: this commit rebased onto current upstream `main`, whose package still reports `1.4.197`; both use Electron `43.6.0`. No release-version changes are included.

| Case | Before | After |
| --- | --- | --- |
| Warm reconnect: `2×1` → `75×60`, surviving agent retained | ![Blank after reconnect](https://github.com/user-attachments/assets/1ec27d67-18ff-4641-b2f6-8f36371a5399) | ![Recovered terminal after reconnect](https://github.com/user-attachments/assets/9c6bb56a-cd91-4b51-9c0c-bfe6df8b3032) |
| Replacement shell: mouse-coordinate echo → no reports | ![Mouse coordinates echoed by Bash](https://github.com/user-attachments/assets/c61ba299-4c74-4aca-b9a4-fd307e876310) | ![Replacement shell without coordinate echo](https://github.com/user-attachments/assets/91fda70f-95f6-41c9-a216-278ae5a15d55) |

The old Pi title visible in the replacement screenshot is a known host-publication defect reserved for stack 2, not a claim of complete identity cleanup.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Fresh checks on the rebased commit:
- 1,001 targeted tests across 101 files passed, including connect reattachment with a rotated handle.
- 10 terminal wire-skew tests passed, including older peers without mode metadata.
- Web and node TypeScript checks, changed-file formatting/lint and the changed-code quality check passed.
- Electron E2E build passed; isolated paired-terminal scenario passed (42.7s), including a run without a caller-exported background-launch variable.
- Same retained xterm and surviving-agent mouse mode verified across warm reconnect; replacement fits the measured pane, emits no mouse reports and does not retain a working Pi row.

Rendered validation used Linux/Xvfb, `ORCA_BACKGROUND_LAUNCH=1`, sanitized environment and disposable HOME/profiles. Test entry point: `tests/playwright.remote-replacement.config.ts`. No default global E2E setup, live service or real agent session was used. No native macOS/Windows or real SSH rendered validation; mixed-version coverage is protocol-level. Full repository lint/test/build suites are not claimed.

## AI Disclosure

AI-assisted implementation and separate review using OpenAI coding assistants.

## Review

Independent review covered process-identity races, same-handle ownership preservation, unknown/older-peer metadata, successor state, remote/mobile resize authority, cross-platform behavior and performance/security risks. A same-handle ownership-map regression found during review was reproduced, fixed and re-reviewed. No new host execution, provider-specific behavior, shortcuts, filesystem operations or protocol opcode is introduced. RPC enrichment occurs at attachment/recovery boundaries, not per output chunk. Visual recovery evidence was inspected.

## Agent skill upstream boundary

- [x] Not applicable; no skill-installer material changed.

## Notes

The full original identity diagnostic remains available for the dependent patch. PR 1's test deliberately checks terminal recovery and absence of stale *working* state; it does not claim that host-published Pi titles/completed metadata are cleared. No skipped or expected-failure tests conceal that distinction.

## Checklist

- [x] Scoped to terminal recovery; most additions are regression coverage
- [x] Changes and rationale explained, including ELI5
- [x] Before/after screenshots attached
- [x] Self-reviewed and independently reviewed for correctness, security and performance
- [x] Cross-platform, SSH/remote, mobile ownership and backwards compatibility considered
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` run; targeted checks listed above
