### PR TITLE
fix(browser): restore the Chrome-shaped browser identity (STA-7147)

### DIFF
--- a/docs/site/content/docs/browser/profiles.mdx
+++ b/docs/site/content/docs/browser/profiles.mdx
@@ -9,7 +9,9 @@ Browser-use profiles let you run the Orca browser with a specific identity — a
 1. Open [Settings → Browser → Profiles](/docs/settings).
 1. Click **Add profile**, give it a name.
 1. Optionally seed it with cookies, a user-agent, and a viewport size.
-1. Every profile presents Electron's own user agent. Orca no longer rewrites it to look like Chrome, because Cloudflare Turnstile rejects a Chrome-shaped UA that sends no client hints and accepts a declared Electron client. The only exception is Google's sign-in hosts, where Orca presents a Firefox identity so Google issues cookies bound to the embedded browser. A **native user agent** profile (`orca tab profile create --no-ua-spoof`) also skips that Google exception.
+1. For sites that reject Orca's default Chrome-shaped UA (some Google sign-in flows), create a profile that keeps the **native Electron user agent** instead of spoofing. Default profiles still use the cleaned Chrome UA for broader Cloudflare compatibility.
+
+You can also create a no-spoof profile from the CLI with `orca tab profile create --no-ua-spoof` when you script browser setup.
 
 ## Cookie import and Google sign-in
 

--- a/docs/site/content/docs/browser/profiles.mdx
+++ b/docs/site/content/docs/browser/profiles.mdx
@@ -9,7 +9,7 @@ Browser-use profiles let you run the Orca browser with a specific identity — a
 1. Open [Settings → Browser → Profiles](/docs/settings).
 1. Click **Add profile**, give it a name.
 1. Optionally seed it with cookies, a user-agent, and a viewport size.
-1. For sites that reject Orca's default Chrome-shaped UA (some Google sign-in flows), create a profile that keeps the **native Electron user agent** instead of spoofing. Default profiles still use the cleaned Chrome UA for broader Cloudflare compatibility.
+1. Default profiles remove Orca and Electron tokens from the browser engine's user agent, preserving the Chrome-shaped identity expected by imported sessions. This focused compatibility measure does not make the embedded browser identical to Chrome. Google sign-in hosts use a scoped Firefox identity. If a site rejects the cleaned identity, including some Cloudflare-protected sites, create a profile that keeps the **native Electron user agent** instead.
 
 You can also create a no-spoof profile from the CLI with `orca tab profile create --no-ua-spoof` when you script browser setup.
 

--- a/src/main/browser/browser-google-auth-ua.ts
+++ b/src/main/browser/browser-google-auth-ua.ts
@@ -1,12 +1,12 @@
 // Why: Google binds a signed-in session to the browser identity that created it.
-// Cookies copied in from another browser (or sent under an Electron/Chrome-shaped
-// UA that doesn't match a real first-party browser) get flagged by anti-fraud on
-// accounts.google.com and expire within ~1h. Presenting a Firefox identity scoped
+// Cookies copied in from another browser (or sent under a UA that doesn't match a
+// real first-party browser) get flagged by anti-fraud on accounts.google.com and
+// expire within ~1h. Presenting a Firefox identity scoped
 // to Google's auth hosts lets the user sign in *inside* the embedded browser, so
 // Google issues cookies bound to THIS browser that self-refresh — instead of us
 // transplanting cookies that go stale. Scope is deliberately the auth hosts only:
 // post-auth app surfaces (mail.google.com, myaccount.google.com, drive, etc.) keep
-// the profile's real Chrome-shaped identity so nothing else about the session shifts.
+// the profile's real identity so nothing else about the session shifts.
 
 // Why: exact hostname match — subdomains such as myaccount.google.com are post-auth
 // app surfaces, not the sign-in flow, and must retain the profile's real identity.

--- a/src/main/browser/browser-google-auth-ua.ts
+++ b/src/main/browser/browser-google-auth-ua.ts
@@ -1,12 +1,12 @@
 // Why: Google binds a signed-in session to the browser identity that created it.
-// Cookies copied in from another browser (or sent under a UA that doesn't match a
-// real first-party browser) get flagged by anti-fraud on accounts.google.com and
-// expire within ~1h. Presenting a Firefox identity scoped
+// Cookies copied in from another browser (or sent under an Electron/Chrome-shaped
+// UA that doesn't match a real first-party browser) get flagged by anti-fraud on
+// accounts.google.com and expire within ~1h. Presenting a Firefox identity scoped
 // to Google's auth hosts lets the user sign in *inside* the embedded browser, so
 // Google issues cookies bound to THIS browser that self-refresh — instead of us
 // transplanting cookies that go stale. Scope is deliberately the auth hosts only:
 // post-auth app surfaces (mail.google.com, myaccount.google.com, drive, etc.) keep
-// the profile's real identity so nothing else about the session shifts.
+// the profile's real Chrome-shaped identity so nothing else about the session shifts.
 
 // Why: exact hostname match — subdomains such as myaccount.google.com are post-auth
 // app surfaces, not the sign-in flow, and must retain the profile's real identity.

--- a/src/main/browser/browser-manager-auth-user-agent.test.ts
+++ b/src/main/browser/browser-manager-auth-user-agent.test.ts
@@ -197,7 +197,7 @@ describe('browserManager', () => {
 
   // Why: popup child windows get attachGuestPolicies but are never entered into tabIdByWebContentsId,
   // so a direct lookup of the UA mode misses the native opt-out. That is worse than doing nothing —
-  // native sessions skip setupClientHintsOverride, so the popup would send the raw Electron UA on the
+  // native sessions skip setupGoogleAuthUserAgentOverride, so the popup would send the raw Electron UA on the
   // wire while navigator.userAgent claimed Firefox. Google sign-in popups are a first-class surface.
   it('leaves the UA untouched on auth hosts for a popup owned by a native-UA profile', () => {
     const ownerGuest = {

--- a/src/main/browser/browser-manager-auth-user-agent.test.ts
+++ b/src/main/browser/browser-manager-auth-user-agent.test.ts
@@ -51,7 +51,7 @@ import {
 import {
   createViewportGuestFactory,
   flushViewportOps,
-  GUEST_ELECTRON_UA
+  GUEST_CLEAN_UA
 } from './browser-manager-viewport-test-fixtures'
 
 const {
@@ -197,9 +197,8 @@ describe('browserManager', () => {
 
   // Why: popup child windows get attachGuestPolicies but are never entered into tabIdByWebContentsId,
   // so a direct lookup of the UA mode misses the native opt-out. That is worse than doing nothing —
-  // native sessions never install the header-level Firefox switch, so the popup would send the
-  // Electron UA on the wire while navigator.userAgent claimed Firefox. Google sign-in popups are a
-  // first-class surface.
+  // native sessions skip setupClientHintsOverride, so the popup would send the raw Electron UA on the
+  // wire while navigator.userAgent claimed Firefox. Google sign-in popups are a first-class surface.
   it('leaves the UA untouched on auth hosts for a popup owned by a native-UA profile', () => {
     const ownerGuest = {
       id: 415,
@@ -544,7 +543,7 @@ describe('browserManager', () => {
     )
     expect(uaWrites.length).toBeGreaterThan(0)
     for (const [, params] of uaWrites) {
-      expect((params as { userAgent: string }).userAgent).toBe(GUEST_ELECTRON_UA)
+      expect((params as { userAgent: string }).userAgent).toBe(GUEST_CLEAN_UA)
     }
   })
 })

--- a/src/main/browser/browser-manager-navigation.ts
+++ b/src/main/browser/browser-manager-navigation.ts
@@ -12,7 +12,7 @@ import { BrowserManagerVisibility } from './browser-manager-visibility'
 
 export abstract class BrowserManagerNavigation extends BrowserManagerVisibility {
   // Why: navigator.userAgent (read by Google's auth JS) reflects the WebContents UA,
-  // not the request header, so the header-level Firefox switch in setupClientHintsOverride
+  // not the request header, so the header-level Firefox switch in setupGoogleAuthUserAgentOverride
   // must be matched here per navigation or the two layers disagree — itself a bot tell.
   // Restores the session's base identity off the auth hosts. Native-UA profiles opt out
   // of the whole clean-UA path, so they keep their untouched identity everywhere.
@@ -24,7 +24,7 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
     const browserPageId = this.tabIdByWebContentsId.get(guest.id)
     // Why: popup child windows get these policies but are never in tabIdByWebContentsId, so a direct
     // lookup misses the native-UA opt-out and would hand a native profile's popup the Firefox UA.
-    // That is worse than doing nothing: native sessions skip setupClientHintsOverride entirely, so
+    // That is worse than doing nothing: native sessions skip setupGoogleAuthUserAgentOverride, so
     // the popup would send the raw Electron UA on the wire while navigator.userAgent claims Firefox.
     const ownerTabId = this.resolveBrowserTabIdForGuestWebContentsId(guest.id)
     // Session state is authoritative before renderer registration and after a native profile imports a source UA.
@@ -56,8 +56,8 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
       // navigation (ERR_ABORTED) and replay the original request, which a POST-started OAuth chain
       // cannot survive — the sign-in lands on a blank tab. CDP retargets navigator.userAgent without
       // touching the navigation, and it outranks the WebContents UA from then on, so a guest that
-      // switches to it stays on it. The wire UA never depended on this write: setupClientHintsOverride
-      // rewrites User-Agent per request for auth-host URLs on its own.
+      // switches to it stays on it. The wire UA never depended on this write:
+      // setupGoogleAuthUserAgentOverride rewrites User-Agent per request for auth-host URLs on its own.
       if (options.duringRedirect === true || overrideState !== undefined) {
         if (this.canOverrideUserAgentOverCdp(guest)) {
           authOverrideIssuedOverCdp = true

--- a/src/main/browser/browser-manager-navigation.ts
+++ b/src/main/browser/browser-manager-navigation.ts
@@ -1,4 +1,5 @@
 import { openPopupWithOriginBar, type PopupChildWindowOptions } from './popup-origin-bar-window'
+import { cleanElectronUserAgent } from './browser-session-ua'
 import { getBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
 import { googleAuthUserAgent, isGoogleAuthUrl } from './browser-google-auth-ua'
 import { buildViewportUserAgentOverride } from './browser-viewport-user-agent'
@@ -11,10 +12,10 @@ import { BrowserManagerVisibility } from './browser-manager-visibility'
 
 export abstract class BrowserManagerNavigation extends BrowserManagerVisibility {
   // Why: navigator.userAgent (read by Google's auth JS) reflects the WebContents UA,
-  // not the request header, so the header-level Firefox switch in setupGoogleAuthUserAgentOverride
+  // not the request header, so the header-level Firefox switch in setupClientHintsOverride
   // must be matched here per navigation or the two layers disagree — itself a bot tell.
   // Restores the session's base identity off the auth hosts. Native-UA profiles opt out
-  // of the Firefox switch, so they keep their untouched identity everywhere.
+  // of the whole clean-UA path, so they keep their untouched identity everywhere.
   protected applyGoogleAuthUserAgent(
     guest: Electron.WebContents,
     url: string,
@@ -23,8 +24,8 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
     const browserPageId = this.tabIdByWebContentsId.get(guest.id)
     // Why: popup child windows get these policies but are never in tabIdByWebContentsId, so a direct
     // lookup misses the native-UA opt-out and would hand a native profile's popup the Firefox UA.
-    // That is worse than doing nothing: native sessions never install the header-level Firefox
-    // switch, so the popup would send the Electron UA on the wire while navigator.userAgent claims Firefox.
+    // That is worse than doing nothing: native sessions skip setupClientHintsOverride entirely, so
+    // the popup would send the raw Electron UA on the wire while navigator.userAgent claims Firefox.
     const ownerTabId = this.resolveBrowserTabIdForGuestWebContentsId(guest.id)
     // Session state is authoritative before renderer registration and after a native profile imports a source UA.
     const mode =
@@ -55,14 +56,15 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
       // navigation (ERR_ABORTED) and replay the original request, which a POST-started OAuth chain
       // cannot survive — the sign-in lands on a blank tab. CDP retargets navigator.userAgent without
       // touching the navigation, and it outranks the WebContents UA from then on, so a guest that
-      // switches to it stays on it. The wire UA never depended on this write:
-      // setupGoogleAuthUserAgentOverride rewrites User-Agent per request for auth-host URLs on its own.
+      // switches to it stays on it. The wire UA never depended on this write: setupClientHintsOverride
+      // rewrites User-Agent per request for auth-host URLs on its own.
       if (options.duringRedirect === true || overrideState !== undefined) {
         if (this.canOverrideUserAgentOverCdp(guest)) {
           authOverrideIssuedOverCdp = true
           // Why: go through the viewport builder rather than writing nextUa raw, so both CDP writers
-          // resolve one identity for this URL — Firefox on auth hosts, the session's base identity
-          // off them, any mobile preset preserved.
+          // resolve one identity for this URL — Firefox on auth hosts, the profile's clean base off
+          // them, any mobile preset preserved. Writing the session UA directly would put the
+          // unlaundered Electron token back on the wire.
           void this.applyAuthUserAgentOverrideOverCdp(
             guest,
             (browserPageId ? this.viewportUaOverrideMobileByTabId.get(browserPageId) : undefined) ??
@@ -186,7 +188,7 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
 
   // Why: Emulation.setUserAgentOverride is set once and stands across every later navigation,
   // outranking setUserAgent for navigator.userAgent. A viewport preset applied before reaching an
-  // auth host would otherwise pin navigator.userAgent to the session's preset UA while the
+  // auth host would otherwise pin navigator.userAgent to the Chrome-shaped preset UA while the
   // request header says Firefox — the two-layer disagreement this scope exists to remove.
   protected reapplyViewportUserAgentOverride(
     guest: Electron.WebContents,
@@ -220,7 +222,7 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
         // Why: the session UA is the profile's stable base identity. guest.getUserAgent() is not:
         // applyGoogleAuthUserAgent leaves it pinned to the Firefox auth UA once a guest switches to
         // the CDP override, so reading it back here would republish that identity on ordinary hosts.
-        baseUserAgent: baseUserAgent ?? guest.session.getUserAgent()
+        baseUserAgent: cleanElectronUserAgent(baseUserAgent ?? guest.session.getUserAgent())
       })
     )
   }

--- a/src/main/browser/browser-manager-viewport-override.test.ts
+++ b/src/main/browser/browser-manager-viewport-override.test.ts
@@ -49,6 +49,7 @@ import {
 import {
   createViewportGuestFactory,
   flushViewportOps,
+  GUEST_CLEAN_UA,
   GUEST_ELECTRON_UA
 } from './browser-manager-viewport-test-fixtures'
 
@@ -206,7 +207,7 @@ describe('browserManager', () => {
         mobile: false
       })
       expect(debuggerSendCommand).toHaveBeenLastCalledWith('Emulation.setUserAgentOverride', {
-        userAgent: GUEST_ELECTRON_UA
+        userAgent: GUEST_CLEAN_UA
       })
 
       // Navigating to the auth host must move the standing override to the Firefox identity.
@@ -217,11 +218,11 @@ describe('browserManager', () => {
         userAgent: googleAuthUserAgent()
       })
 
-      // Leaving the auth host restores the session's own preset UA.
+      // Leaving the auth host restores the clean Chrome-shaped preset UA.
       debuggerSendCommand.mockClear()
       willRedirect({ preventDefault: vi.fn() }, 'https://example.com/', false, true)
       await flushViewportOps()
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
     })
 
     // Why: not an ordering race — debugger.sendCommand dispatches in call order over one channel, so
@@ -240,9 +241,9 @@ describe('browserManager', () => {
     }
 
     // Why mobile: on the desktop branch the break is masked by coincidence — applyGoogleAuthUserAgent
-    // has already switched the WebContents UA to Firefox, so the stale-URL desktop path happens to
-    // emit Firefox anyway. The mobile branch derives a Chrome-shaped iPhone UA from the session base
-    // and exposes the real defect.
+    // has already switched the WebContents UA to Firefox, and cleanElectronUserAgent passes a Firefox
+    // UA through untouched, so the stale-URL desktop path happens to emit Firefox anyway. The mobile
+    // branch derives a Chrome-shaped iPhone UA from that same base and exposes the real defect.
     it('does not leave the Chrome preset UA standing when a mobile preset lands mid-navigation onto an auth host', async () => {
       const { guest, debuggerSendCommand } = makeGuest(4251, 'https://example.com/')
       // Hold the preset's first CDP command open so the navigation lands inside its await window.
@@ -331,7 +332,7 @@ describe('browserManager', () => {
 
       // Without the fix the resuming preset re-reads getURL() as the auth host and clobbers the
       // navigation's correct write, stranding the Firefox UA on a non-auth page.
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
     })
 
     it('falls back to the committed URL once a navigation commits or fails', async () => {
@@ -377,7 +378,7 @@ describe('browserManager', () => {
       await flushViewportOps()
 
       expect(guest.setUserAgent).toHaveBeenLastCalledWith(GUEST_ELECTRON_UA)
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
 
       // A later preset must also resolve the committed, non-auth URL.
       debuggerSendCommand.mockClear()
@@ -456,7 +457,7 @@ describe('browserManager', () => {
       expect(guest.setUserAgent).not.toHaveBeenCalled()
       expect(debuggerSendCommand).not.toHaveBeenCalledWith(
         'Emulation.setUserAgentOverride',
-        expect.objectContaining({ userAgent: GUEST_ELECTRON_UA })
+        expect.objectContaining({ userAgent: GUEST_CLEAN_UA })
       )
     })
 
@@ -516,7 +517,7 @@ describe('browserManager', () => {
       didFailLoad(null, -3, 'Aborted', 'https://accounts.google.com/redirected', true)
       await flushViewportOps()
       expect(guest.setUserAgent).not.toHaveBeenCalled()
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
     })
 
     it('preserves the auth identity when a viewport preset is cleared after a redirect', async () => {
@@ -591,7 +592,7 @@ describe('browserManager', () => {
       didStartNavigation(null, 'https://example.com/', false, true)
       await flushViewportOps()
 
-      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_ELECTRON_UA })
+      expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
     })
 
     it('reapplies a preset when navigation starts during its final UA write', async () => {
@@ -848,7 +849,8 @@ describe('browserManager', () => {
 
       expect(debuggerAttach).toHaveBeenCalledWith('1.3')
       expect(debuggerSendCommand).toHaveBeenCalled()
-      // Why: detaching would clear every standing CDP override (viewport, auth UA). Guard regression.
+      // Why: detaching would clear Page.addScriptToEvaluateOnNewDocument
+      // (anti-detection). Guard regression.
       expect((guest.debugger as { detach?: unknown }).detach ?? undefined).toBeUndefined()
     })
 

--- a/src/main/browser/browser-manager-viewport-override.test.ts
+++ b/src/main/browser/browser-manager-viewport-override.test.ts
@@ -849,8 +849,7 @@ describe('browserManager', () => {
 
       expect(debuggerAttach).toHaveBeenCalledWith('1.3')
       expect(debuggerSendCommand).toHaveBeenCalled()
-      // Why: detaching would clear Page.addScriptToEvaluateOnNewDocument
-      // (anti-detection). Guard regression.
+      // Why: detaching would clear every standing CDP override (viewport, auth UA). Guard regression.
       expect((guest.debugger as { detach?: unknown }).detach ?? undefined).toBeUndefined()
     })
 

--- a/src/main/browser/browser-manager-viewport-test-fixtures.ts
+++ b/src/main/browser/browser-manager-viewport-test-fixtures.ts
@@ -53,7 +53,9 @@ export function createViewportGuestFactory(
       debugger: {
         isAttached: debuggerIsAttached,
         attach: debuggerAttach,
-        sendCommand: debuggerSendCommand
+        sendCommand: debuggerSendCommand,
+        on: vi.fn(),
+        off: vi.fn()
       }
     }
     return {

--- a/src/main/browser/browser-manager-viewport-test-fixtures.ts
+++ b/src/main/browser/browser-manager-viewport-test-fixtures.ts
@@ -3,6 +3,8 @@ import type { BrowserManagerMocks } from './browser-manager-test-harness'
 
 export const GUEST_ELECTRON_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) orca/1.0.0 Chrome/134.0.0.0 Electron/30.0.0 Safari/537.36'
+export const GUEST_CLEAN_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36'
 
 // Why: viewport UA writes are queued on the per-tab chain, so draining it takes more than one
 // microtask hop; loop until the chain is empty rather than guessing a tick count.
@@ -51,9 +53,7 @@ export function createViewportGuestFactory(
       debugger: {
         isAttached: debuggerIsAttached,
         attach: debuggerAttach,
-        sendCommand: debuggerSendCommand,
-        on: vi.fn(),
-        off: vi.fn()
+        sendCommand: debuggerSendCommand
       }
     }
     return {

--- a/src/main/browser/browser-session-partition-policies.test.ts
+++ b/src/main/browser/browser-session-partition-policies.test.ts
@@ -82,7 +82,8 @@ vi.mock('./browser-media-access', () => ({
   requestSystemMediaAccess: async () => false
 }))
 vi.mock('./browser-session-ua', () => ({
-  setupGoogleAuthUserAgentOverride: vi.fn()
+  cleanElectronUserAgent: (userAgent: string) => userAgent,
+  setupClientHintsOverride: vi.fn()
 }))
 vi.mock('./browser-session-user-agent-mode', () => ({
   setBrowserSessionUserAgentMode: vi.fn()

--- a/src/main/browser/browser-session-partition-policies.test.ts
+++ b/src/main/browser/browser-session-partition-policies.test.ts
@@ -83,7 +83,7 @@ vi.mock('./browser-media-access', () => ({
 }))
 vi.mock('./browser-session-ua', () => ({
   cleanElectronUserAgent: (userAgent: string) => userAgent,
-  setupClientHintsOverride: vi.fn()
+  setupGoogleAuthUserAgentOverride: vi.fn()
 }))
 vi.mock('./browser-session-user-agent-mode', () => ({
   setBrowserSessionUserAgentMode: vi.fn()

--- a/src/main/browser/browser-session-partition-policies.ts
+++ b/src/main/browser/browser-session-partition-policies.ts
@@ -9,7 +9,7 @@ import {
 } from './browser-session-proxy'
 import { hasSystemMediaAccess, requestSystemMediaAccess } from './browser-media-access'
 import { isAutoGrantedBrowserSessionPermission } from './browser-session-permission-policy'
-import { cleanElectronUserAgent, setupClientHintsOverride } from './browser-session-ua'
+import { cleanElectronUserAgent, setupGoogleAuthUserAgentOverride } from './browser-session-ua'
 import { setBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
 import {
   allowsBrowserWebAuthnPermission,
@@ -95,7 +95,7 @@ export function installBrowserSessionPartitionPolicies(
   if (profile.userAgentMode !== 'native' && typeof sess.getUserAgent === 'function') {
     const cleanUA = cleanElectronUserAgent(sess.getUserAgent())
     sess.setUserAgent(cleanUA)
-    setupClientHintsOverride(sess, cleanUA)
+    setupGoogleAuthUserAgentOverride(sess)
   }
   if (options?.permissions === 'deny') {
     sess.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false))
@@ -192,10 +192,10 @@ export function applyBrowserSessionUserAgentModes(profiles: BrowserSessionProfil
         continue
       }
 
-      // Why: the default Electron UA leaks "Electron/X.X.X" + app name, which trips Cloudflare Turnstile.
+      // Why: imported sessions need the same Chrome-shaped identity after app restart.
       const cleanUA = cleanElectronUserAgent(sess.getUserAgent())
       sess.setUserAgent(cleanUA)
-      setupClientHintsOverride(sess, cleanUA)
+      setupGoogleAuthUserAgentOverride(sess)
     } catch {
       /* session not available yet (e.g. unit tests or pre-ready) */
     }

--- a/src/main/browser/browser-session-partition-policies.ts
+++ b/src/main/browser/browser-session-partition-policies.ts
@@ -9,7 +9,7 @@ import {
 } from './browser-session-proxy'
 import { hasSystemMediaAccess, requestSystemMediaAccess } from './browser-media-access'
 import { isAutoGrantedBrowserSessionPermission } from './browser-session-permission-policy'
-import { setupGoogleAuthUserAgentOverride } from './browser-session-ua'
+import { cleanElectronUserAgent, setupClientHintsOverride } from './browser-session-ua'
 import { setBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
 import {
   allowsBrowserWebAuthnPermission,
@@ -92,8 +92,10 @@ export function installBrowserSessionPartitionPolicies(
   }
 
   browserManager.installCertificateRequestGuard(sess)
-  if (profile.userAgentMode !== 'native') {
-    setupGoogleAuthUserAgentOverride(sess)
+  if (profile.userAgentMode !== 'native' && typeof sess.getUserAgent === 'function') {
+    const cleanUA = cleanElectronUserAgent(sess.getUserAgent())
+    sess.setUserAgent(cleanUA)
+    setupClientHintsOverride(sess, cleanUA)
   }
   if (options?.permissions === 'deny') {
     sess.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false))
@@ -189,7 +191,11 @@ export function applyBrowserSessionUserAgentModes(profiles: BrowserSessionProfil
       if (profile.userAgentMode === 'native') {
         continue
       }
-      setupGoogleAuthUserAgentOverride(sess)
+
+      // Why: the default Electron UA leaks "Electron/X.X.X" + app name, which trips Cloudflare Turnstile.
+      const cleanUA = cleanElectronUserAgent(sess.getUserAgent())
+      sess.setUserAgent(cleanUA)
+      setupClientHintsOverride(sess, cleanUA)
     } catch {
       /* session not available yet (e.g. unit tests or pre-ready) */
     }

--- a/src/main/browser/browser-session-partition-proxy-install.test.ts
+++ b/src/main/browser/browser-session-partition-proxy-install.test.ts
@@ -45,7 +45,7 @@ vi.mock('./browser-media-access', () => ({
 }))
 vi.mock('./browser-session-ua', () => ({
   cleanElectronUserAgent: vi.fn((ua: string) => ua),
-  setupClientHintsOverride: vi.fn()
+  setupGoogleAuthUserAgentOverride: vi.fn()
 }))
 vi.mock('./browser-session-user-agent-mode', () => ({
   setBrowserSessionUserAgentMode: vi.fn(),

--- a/src/main/browser/browser-session-partition-proxy-install.test.ts
+++ b/src/main/browser/browser-session-partition-proxy-install.test.ts
@@ -44,7 +44,8 @@ vi.mock('./browser-media-access', () => ({
   requestSystemMediaAccess: vi.fn(async () => false)
 }))
 vi.mock('./browser-session-ua', () => ({
-  setupGoogleAuthUserAgentOverride: vi.fn()
+  cleanElectronUserAgent: vi.fn((ua: string) => ua),
+  setupClientHintsOverride: vi.fn()
 }))
 vi.mock('./browser-session-user-agent-mode', () => ({
   setBrowserSessionUserAgentMode: vi.fn(),

--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const USER_DATA = '/user-data'
 const META_PATH = `${USER_DATA}/browser-session-meta.json`
+const RAW_ELECTRON_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Orca/1.4.198 Chrome/150.0.7871.224 Electron/43.4.1 Safari/537.36'
+const CLEAN_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.7871.224 Safari/537.36'
 
 type FsState = {
   files: Map<string, string>
@@ -27,7 +31,8 @@ function installModuleMocks(
   copyFailures = new Set<string>()
 ): {
   sessionFromPartitionMock: ReturnType<typeof vi.fn>
-  setupClientHintsOverrideMock: ReturnType<typeof vi.fn>
+  cleanElectronUserAgentMock: ReturnType<typeof vi.fn>
+  setupGoogleAuthUserAgentOverrideMock: ReturnType<typeof vi.fn>
   browserManagerHandleGuestWillDownloadMock: ReturnType<typeof vi.fn>
   browserManagerNotifyPermissionDeniedMock: ReturnType<typeof vi.fn>
   requestSystemMediaAccessMock: ReturnType<typeof vi.fn>
@@ -35,7 +40,7 @@ function installModuleMocks(
   const sessionFromPartitionMock = vi.fn((partition: string) => ({
     partition,
     setUserAgent: vi.fn(),
-    getUserAgent: vi.fn(() => 'Mozilla/5.0 Electron/31 Orca'),
+    getUserAgent: vi.fn(() => RAW_ELECTRON_USER_AGENT),
     setPermissionRequestHandler: vi.fn(),
     setPermissionCheckHandler: vi.fn(),
     setDevicePermissionHandler: vi.fn(),
@@ -45,7 +50,8 @@ function installModuleMocks(
     clearStorageData: vi.fn().mockResolvedValue(undefined),
     clearCache: vi.fn().mockResolvedValue(undefined)
   }))
-  const setupClientHintsOverrideMock = vi.fn()
+  const cleanElectronUserAgentMock = vi.fn(() => CLEAN_USER_AGENT)
+  const setupGoogleAuthUserAgentOverrideMock = vi.fn()
   const browserManagerHandleGuestWillDownloadMock = vi.fn()
   const browserManagerNotifyPermissionDeniedMock = vi.fn()
   const requestSystemMediaAccessMock = vi.fn().mockResolvedValue(true)
@@ -119,8 +125,8 @@ function installModuleMocks(
     requestSystemMediaAccess: requestSystemMediaAccessMock
   }))
   vi.doMock('./browser-session-ua', () => ({
-    cleanElectronUserAgent: vi.fn((ua: string) => ua.replace(/\s*Electron\/\S+/, '')),
-    setupClientHintsOverride: setupClientHintsOverrideMock
+    cleanElectronUserAgent: cleanElectronUserAgentMock,
+    setupGoogleAuthUserAgentOverride: setupGoogleAuthUserAgentOverrideMock
   }))
   // This suite models replay with an in-memory filesystem. The real file-backed SQLite merge has
   // dedicated coverage; these fixtures are legacy unmarked images and keep the copy path.
@@ -149,7 +155,8 @@ function installModuleMocks(
 
   return {
     sessionFromPartitionMock,
-    setupClientHintsOverrideMock,
+    cleanElectronUserAgentMock,
+    setupGoogleAuthUserAgentOverrideMock,
     browserManagerHandleGuestWillDownloadMock,
     browserManagerNotifyPermissionDeniedMock,
     requestSystemMediaAccessMock
@@ -236,19 +243,28 @@ describe('BrowserSessionRegistry persistence', () => {
 
   it('keeps UA cleaning as the fallback for profiles without an override', async () => {
     const fsState = createFsState()
-    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
+    const {
+      sessionFromPartitionMock,
+      cleanElectronUserAgentMock,
+      setupGoogleAuthUserAgentOverrideMock
+    } = installModuleMocks(fsState)
     const { browserSessionRegistry } = await import('./browser-session-registry')
 
     await browserSessionRegistry.createProfile('isolated', 'Default identity')
 
     const profileSession = sessionFromPartitionMock.mock.results.at(-1)?.value
-    expect(profileSession.setUserAgent).toHaveBeenCalledWith('Mozilla/5.0 Orca')
-    expect(setupClientHintsOverrideMock).toHaveBeenCalledWith(profileSession, 'Mozilla/5.0 Orca')
+    expect(cleanElectronUserAgentMock).toHaveBeenCalledWith(RAW_ELECTRON_USER_AGENT)
+    expect(profileSession.setUserAgent).toHaveBeenCalledWith(CLEAN_USER_AGENT)
+    expect(setupGoogleAuthUserAgentOverrideMock).toHaveBeenCalledWith(profileSession)
   })
 
   it('leaves UA and client hints untouched for native-mode profiles', async () => {
     const fsState = createFsState()
-    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
+    const {
+      sessionFromPartitionMock,
+      cleanElectronUserAgentMock,
+      setupGoogleAuthUserAgentOverrideMock
+    } = installModuleMocks(fsState)
     const { browserSessionRegistry } = await import('./browser-session-registry')
 
     await browserSessionRegistry.createProfile('isolated', 'Google', { userAgentMode: 'native' })
@@ -256,7 +272,8 @@ describe('BrowserSessionRegistry persistence', () => {
     const profileSession = sessionFromPartitionMock.mock.results.at(-1)?.value
     const { getBrowserSessionUserAgentMode } = await import('./browser-session-user-agent-mode')
     expect(profileSession.setUserAgent).not.toHaveBeenCalled()
-    expect(setupClientHintsOverrideMock).not.toHaveBeenCalled()
+    expect(cleanElectronUserAgentMock).not.toHaveBeenCalled()
+    expect(setupGoogleAuthUserAgentOverrideMock).not.toHaveBeenCalled()
     expect(getBrowserSessionUserAgentMode(profileSession as never)).toBe('native')
   })
 
@@ -405,7 +422,11 @@ describe('BrowserSessionRegistry persistence', () => {
       ]
     })
 
-    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
+    const {
+      sessionFromPartitionMock,
+      cleanElectronUserAgentMock,
+      setupGoogleAuthUserAgentOverrideMock
+    } = installModuleMocks(fsState)
     const { browserSessionRegistry } = await import('./browser-session-registry')
 
     browserSessionRegistry.initializeBrowserSessionsFromPersistedState()
@@ -417,12 +438,12 @@ describe('BrowserSessionRegistry persistence', () => {
     expect(appliedUas).not.toContain(validUa)
     // Why: every non-native profile falls to Orca's own cleaned engine UA.
     expect(appliedUas.length).toBeGreaterThan(0)
-    expect(appliedUas.every((ua) => ua === 'Mozilla/5.0 Orca')).toBe(true)
+    expect(appliedUas.every((ua) => ua === CLEAN_USER_AGENT)).toBe(true)
+    expect(cleanElectronUserAgentMock).toHaveBeenCalled()
     expect(
-      setupClientHintsOverrideMock.mock.calls.every(
-        (c: unknown[]) => c[1] !== brokenUa && c[1] !== validUa
-      )
+      cleanElectronUserAgentMock.mock.calls.every(([ua]) => ua === RAW_ELECTRON_USER_AGENT)
     ).toBe(true)
+    expect(setupGoogleAuthUserAgentOverrideMock).toHaveBeenCalled()
   })
 
   it('never applies a legacy persisted UA to a native-mode profile', async () => {
@@ -487,7 +508,8 @@ describe('BrowserSessionRegistry persistence', () => {
       ]
     })
 
-    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
+    const { sessionFromPartitionMock, setupGoogleAuthUserAgentOverrideMock } =
+      installModuleMocks(fsState)
     const { browserSessionRegistry } = await import('./browser-session-registry')
 
     browserSessionRegistry.initializeBrowserSessionsFromPersistedState()
@@ -498,7 +520,7 @@ describe('BrowserSessionRegistry persistence', () => {
     expect(importedSessions.length).toBeGreaterThan(0)
     expect(importedSessions.every((sess) => sess.setUserAgent.mock.calls.length === 0)).toBe(true)
     expect(
-      setupClientHintsOverrideMock.mock.calls.some(
+      setupGoogleAuthUserAgentOverrideMock.mock.calls.some(
         ([sess]) => (sess as { partition?: string }).partition === importedPartition
       )
     ).toBe(false)

--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -27,7 +27,7 @@ function installModuleMocks(
   copyFailures = new Set<string>()
 ): {
   sessionFromPartitionMock: ReturnType<typeof vi.fn>
-  setupGoogleAuthUserAgentOverrideMock: ReturnType<typeof vi.fn>
+  setupClientHintsOverrideMock: ReturnType<typeof vi.fn>
   browserManagerHandleGuestWillDownloadMock: ReturnType<typeof vi.fn>
   browserManagerNotifyPermissionDeniedMock: ReturnType<typeof vi.fn>
   requestSystemMediaAccessMock: ReturnType<typeof vi.fn>
@@ -36,7 +36,6 @@ function installModuleMocks(
     partition,
     setUserAgent: vi.fn(),
     getUserAgent: vi.fn(() => 'Mozilla/5.0 Electron/31 Orca'),
-    webRequest: { onBeforeSendHeaders: vi.fn() },
     setPermissionRequestHandler: vi.fn(),
     setPermissionCheckHandler: vi.fn(),
     setDevicePermissionHandler: vi.fn(),
@@ -46,7 +45,7 @@ function installModuleMocks(
     clearStorageData: vi.fn().mockResolvedValue(undefined),
     clearCache: vi.fn().mockResolvedValue(undefined)
   }))
-  const setupGoogleAuthUserAgentOverrideMock = vi.fn()
+  const setupClientHintsOverrideMock = vi.fn()
   const browserManagerHandleGuestWillDownloadMock = vi.fn()
   const browserManagerNotifyPermissionDeniedMock = vi.fn()
   const requestSystemMediaAccessMock = vi.fn().mockResolvedValue(true)
@@ -120,7 +119,8 @@ function installModuleMocks(
     requestSystemMediaAccess: requestSystemMediaAccessMock
   }))
   vi.doMock('./browser-session-ua', () => ({
-    setupGoogleAuthUserAgentOverride: setupGoogleAuthUserAgentOverrideMock
+    cleanElectronUserAgent: vi.fn((ua: string) => ua.replace(/\s*Electron\/\S+/, '')),
+    setupClientHintsOverride: setupClientHintsOverrideMock
   }))
   // This suite models replay with an in-memory filesystem. The real file-backed SQLite merge has
   // dedicated coverage; these fixtures are legacy unmarked images and keep the copy path.
@@ -149,7 +149,7 @@ function installModuleMocks(
 
   return {
     sessionFromPartitionMock,
-    setupGoogleAuthUserAgentOverrideMock,
+    setupClientHintsOverrideMock,
     browserManagerHandleGuestWillDownloadMock,
     browserManagerNotifyPermissionDeniedMock,
     requestSystemMediaAccessMock
@@ -234,24 +234,21 @@ describe('BrowserSessionRegistry persistence', () => {
     })
   })
 
-  // Why: the stock Electron UA is what clears Cloudflare; only the Google auth switch installs.
-  it('keeps the stock UA and installs the Google auth switch for profiles without an override', async () => {
+  it('keeps UA cleaning as the fallback for profiles without an override', async () => {
     const fsState = createFsState()
-    const { sessionFromPartitionMock, setupGoogleAuthUserAgentOverrideMock } =
-      installModuleMocks(fsState)
+    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
     const { browserSessionRegistry } = await import('./browser-session-registry')
 
     await browserSessionRegistry.createProfile('isolated', 'Default identity')
 
     const profileSession = sessionFromPartitionMock.mock.results.at(-1)?.value
-    expect(profileSession.setUserAgent).not.toHaveBeenCalled()
-    expect(setupGoogleAuthUserAgentOverrideMock).toHaveBeenCalledWith(profileSession)
+    expect(profileSession.setUserAgent).toHaveBeenCalledWith('Mozilla/5.0 Orca')
+    expect(setupClientHintsOverrideMock).toHaveBeenCalledWith(profileSession, 'Mozilla/5.0 Orca')
   })
 
   it('leaves UA and client hints untouched for native-mode profiles', async () => {
     const fsState = createFsState()
-    const { sessionFromPartitionMock, setupGoogleAuthUserAgentOverrideMock } =
-      installModuleMocks(fsState)
+    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
     const { browserSessionRegistry } = await import('./browser-session-registry')
 
     await browserSessionRegistry.createProfile('isolated', 'Google', { userAgentMode: 'native' })
@@ -259,7 +256,7 @@ describe('BrowserSessionRegistry persistence', () => {
     const profileSession = sessionFromPartitionMock.mock.results.at(-1)?.value
     const { getBrowserSessionUserAgentMode } = await import('./browser-session-user-agent-mode')
     expect(profileSession.setUserAgent).not.toHaveBeenCalled()
-    expect(setupGoogleAuthUserAgentOverrideMock).not.toHaveBeenCalled()
+    expect(setupClientHintsOverrideMock).not.toHaveBeenCalled()
     expect(getBrowserSessionUserAgentMode(profileSession as never)).toBe('native')
   })
 
@@ -382,7 +379,7 @@ describe('BrowserSessionRegistry persistence', () => {
   // Why: imports before Aug 2026 persisted a synthesized source-browser UA
   // (fork imports as a broken Chrome/1.x, Chrome imports as a valid version).
   // Neither may ever be applied again — the engine-derived UA is the only one.
-  it('ignores legacy persisted UAs, valid or broken, and keeps the engine UA', async () => {
+  it('ignores legacy persisted UAs, valid or broken, and applies the engine UA', async () => {
     const importedPartition = 'persist:orca-browser-session-11111111-1111-4111-8111-111111111111'
     const brokenUa =
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/1.158.1 Safari/537.36'
@@ -408,8 +405,7 @@ describe('BrowserSessionRegistry persistence', () => {
       ]
     })
 
-    const { sessionFromPartitionMock, setupGoogleAuthUserAgentOverrideMock } =
-      installModuleMocks(fsState)
+    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
     const { browserSessionRegistry } = await import('./browser-session-registry')
 
     browserSessionRegistry.initializeBrowserSessionsFromPersistedState()
@@ -417,9 +413,16 @@ describe('BrowserSessionRegistry persistence', () => {
     const appliedUas = sessionFromPartitionMock.mock.results.flatMap((r) =>
       r.value.setUserAgent.mock.calls.map((c: unknown[]) => c[0])
     )
-    // Why: no persisted UA is ever written back; every profile keeps the engine's stock UA.
-    expect(appliedUas).toEqual([])
-    expect(setupGoogleAuthUserAgentOverrideMock).toHaveBeenCalled()
+    expect(appliedUas).not.toContain(brokenUa)
+    expect(appliedUas).not.toContain(validUa)
+    // Why: every non-native profile falls to Orca's own cleaned engine UA.
+    expect(appliedUas.length).toBeGreaterThan(0)
+    expect(appliedUas.every((ua) => ua === 'Mozilla/5.0 Orca')).toBe(true)
+    expect(
+      setupClientHintsOverrideMock.mock.calls.every(
+        (c: unknown[]) => c[1] !== brokenUa && c[1] !== validUa
+      )
+    ).toBe(true)
   })
 
   it('never applies a legacy persisted UA to a native-mode profile', async () => {
@@ -484,8 +487,7 @@ describe('BrowserSessionRegistry persistence', () => {
       ]
     })
 
-    const { sessionFromPartitionMock, setupGoogleAuthUserAgentOverrideMock } =
-      installModuleMocks(fsState)
+    const { sessionFromPartitionMock, setupClientHintsOverrideMock } = installModuleMocks(fsState)
     const { browserSessionRegistry } = await import('./browser-session-registry')
 
     browserSessionRegistry.initializeBrowserSessionsFromPersistedState()
@@ -496,7 +498,7 @@ describe('BrowserSessionRegistry persistence', () => {
     expect(importedSessions.length).toBeGreaterThan(0)
     expect(importedSessions.every((sess) => sess.setUserAgent.mock.calls.length === 0)).toBe(true)
     expect(
-      setupGoogleAuthUserAgentOverrideMock.mock.calls.some(
+      setupClientHintsOverrideMock.mock.calls.some(
         ([sess]) => (sess as { partition?: string }).partition === importedPartition
       )
     ).toBe(false)

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -33,7 +33,7 @@ vi.mock('./browser-manager', () => ({
 
 import { browserSessionRegistry } from './browser-session-registry'
 import { googleAuthUserAgent } from './browser-google-auth-ua'
-import { setupClientHintsOverride } from './browser-session-ua'
+import { setupGoogleAuthUserAgentOverride } from './browser-session-ua'
 import { setBrowserNetworkProxySettingsResolver } from './browser-session-proxy'
 import { handleElectronProxyLogin } from '../network/electron-proxy-credentials'
 import { applyProxySettingsToSession } from '../network/proxy-settings'
@@ -528,83 +528,49 @@ describe('BrowserSessionRegistry', () => {
     })
   })
 
-  describe('setupClientHintsOverride', () => {
-    it('overrides sec-ch-ua headers for Edge UA', () => {
+  describe('setupGoogleAuthUserAgentOverride', () => {
+    function install(): (details: unknown, callback: ReturnType<typeof vi.fn>) => void {
       const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-      const edgeUa =
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36 Edg/147.0.3210.5'
-
-      setupClientHintsOverride(mockSess, edgeUa)
-
+      setupGoogleAuthUserAgentOverride({ webRequest: { onBeforeSendHeaders } } as never)
       expect(onBeforeSendHeaders).toHaveBeenCalledWith(
         { urls: ['https://*/*'] },
         expect.any(Function)
       )
+      return onBeforeSendHeaders.mock.calls[0][1]
+    }
 
+    it('leaves ordinary-host identity headers untouched', () => {
       const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      listener(
-        { requestHeaders: { 'sec-ch-ua': 'old', 'sec-ch-ua-full-version-list': 'old' } },
+      install()(
+        {
+          url: 'https://example.com/',
+          requestHeaders: {
+            'User-Agent': 'Mozilla/5.0 Chrome/150.0.0.0 Safari/537.36',
+            'sec-ch-ua': 'browser-owned',
+            Cookie: 'abc=123'
+          }
+        },
         callback
       )
-      const modified = callback.mock.calls[0][0].requestHeaders
-      expect(modified['sec-ch-ua']).toContain('Microsoft Edge')
-      expect(modified['sec-ch-ua']).toContain('"147"')
-      expect(modified['sec-ch-ua-full-version-list']).toContain('147.0.3210.5')
-    })
 
-    it('overrides sec-ch-ua headers for Chrome UA', () => {
-      const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-      const chromeUa =
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
-
-      setupClientHintsOverride(mockSess, chromeUa)
-
-      const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      listener({ requestHeaders: { 'sec-ch-ua': 'old' } }, callback)
-      const modified = callback.mock.calls[0][0].requestHeaders
-      expect(modified['sec-ch-ua']).toContain('Google Chrome')
-      expect(modified['sec-ch-ua']).not.toContain('Microsoft Edge')
-    })
-
-    it('registers handler even for non-Chrome UA but leaves sec-ch-ua untouched off auth hosts', () => {
-      const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-
-      // Why: the Google-auth Firefox switch must install regardless of the base UA.
-      setupClientHintsOverride(mockSess, 'Mozilla/5.0 (compatible; MSIE 10.0)')
-
-      expect(onBeforeSendHeaders).toHaveBeenCalledWith(
-        { urls: ['https://*/*'] },
-        expect.any(Function)
-      )
-      const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      listener({ url: 'https://example.com/', requestHeaders: { 'sec-ch-ua': 'old' } }, callback)
-      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toBe('old')
+      expect(callback.mock.calls[0][0].requestHeaders).toEqual({
+        'User-Agent': 'Mozilla/5.0 Chrome/150.0.0.0 Safari/537.36',
+        'sec-ch-ua': 'browser-owned',
+        Cookie: 'abc=123'
+      })
     })
 
     it('presents a Firefox UA and strips client hints on Google auth hosts', () => {
-      const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-      setupClientHintsOverride(
-        mockSess,
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
-      )
-
       const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      listener(
+      install()(
         {
           url: 'https://accounts.google.com/v3/signin/identifier',
           requestHeaders: {
             'User-Agent': 'Chrome/147',
             'sec-ch-ua': 'old',
-            'sec-ch-ua-full-version-list': 'old',
-            'sec-ch-ua-platform': '"macOS"'
+            'SEC-CH-UA-Full-Version-List': 'old',
+            'sec-ch-ua-platform': '"macOS"',
+            Accept: 'text/html'
           }
         },
         callback
@@ -612,24 +578,15 @@ describe('BrowserSessionRegistry', () => {
       const modified = callback.mock.calls[0][0].requestHeaders
       expect(modified['User-Agent']).toMatch(/Firefox\/\d/)
       expect(modified['User-Agent']).not.toContain('Chrome')
-      expect(modified['sec-ch-ua']).toBeUndefined()
-      expect(modified['sec-ch-ua-full-version-list']).toBeUndefined()
-      expect(modified['sec-ch-ua-platform']).toBeUndefined()
+      expect(Object.keys(modified).some((key) => key.toLowerCase().startsWith('sec-ch-ua'))).toBe(
+        false
+      )
+      expect(modified.Accept).toBe('text/html')
     })
 
     it('strips client hints on a cross-host request that carries the Firefox auth UA', () => {
-      const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-      setupClientHintsOverride(
-        mockSess,
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
-      )
-
       const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      // Subresource/XHR to a non-auth Google host while the auth document is on
-      // screen: the WebContents Firefox UA leaks onto the request header.
-      listener(
+      install()(
         {
           url: 'https://play.google.com/log',
           requestHeaders: {
@@ -651,99 +608,19 @@ describe('BrowserSessionRegistry', () => {
       expect(modified['sec-ch-ua-mobile']).toBeUndefined()
     })
 
-    it('keeps the clean Chrome identity on cross-host requests that carry the Chrome UA', () => {
-      const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-      const chromeUa =
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
-      setupClientHintsOverride(mockSess, chromeUa)
-
+    it('keeps the session identity on Google app subdomains', () => {
       const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      // Regression guard: non-Google sites (Cloudflare) must keep Chrome hints.
-      listener(
+      install()(
         {
-          url: 'https://example.com/api',
-          requestHeaders: { 'User-Agent': chromeUa, 'sec-ch-ua': 'old' }
+          url: 'https://myaccount.google.com/',
+          requestHeaders: { 'User-Agent': 'Chrome/150', 'sec-ch-ua': 'browser-owned' }
         },
         callback
       )
-      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toContain('Google Chrome')
-    })
-
-    it('does not strip hints for the Firefox UA when googleAuthOverride is disabled', () => {
-      const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-      const chromeUa =
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
-      setupClientHintsOverride(mockSess, chromeUa, { googleAuthOverride: false })
-
-      const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      listener(
-        {
-          url: 'https://play.google.com/log',
-          requestHeaders: { 'User-Agent': googleAuthUserAgent(), 'sec-ch-ua': 'old' }
-        },
-        callback
-      )
-      // Imported-native profiles never install the Firefox switch, so the strip
-      // branch stays inert and hints are aligned to Chrome instead.
-      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toContain('Google Chrome')
-    })
-
-    it('keeps Chrome client hints on Google app subdomains (not auth hosts)', () => {
-      const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-      setupClientHintsOverride(
-        mockSess,
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
-      )
-
-      const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      listener(
-        { url: 'https://myaccount.google.com/', requestHeaders: { 'sec-ch-ua': 'old' } },
-        callback
-      )
-      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toContain('Google Chrome')
-    })
-
-    it('keeps an imported native UA on auth hosts while aligning its Chrome hints', () => {
-      const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-      const importedUa =
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
-      setupClientHintsOverride(mockSess, importedUa, { googleAuthOverride: false })
-
-      const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      listener(
-        {
-          url: 'https://accounts.google.com/v3/signin/identifier',
-          requestHeaders: { 'User-Agent': importedUa, 'sec-ch-ua': 'old' }
-        },
-        callback
-      )
-      const modified = callback.mock.calls[0][0].requestHeaders
-      expect(modified['User-Agent']).toBe(importedUa)
-      expect(modified['sec-ch-ua']).toContain('Google Chrome')
-    })
-
-    it('leaves non-Client-Hints headers unchanged', () => {
-      const onBeforeSendHeaders = vi.fn()
-      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
-      setupClientHintsOverride(mockSess, 'Mozilla/5.0 Chrome/147.0.0.0 Safari/537.36')
-
-      const callback = vi.fn()
-      const listener = onBeforeSendHeaders.mock.calls[0][1]
-      listener(
-        { requestHeaders: { Cookie: 'abc=123', 'sec-ch-ua': 'old', Accept: 'text/html' } },
-        callback
-      )
-      const modified = callback.mock.calls[0][0].requestHeaders
-      expect(modified.Cookie).toBe('abc=123')
-      expect(modified.Accept).toBe('text/html')
+      expect(callback.mock.calls[0][0].requestHeaders).toEqual({
+        'User-Agent': 'Chrome/150',
+        'sec-ch-ua': 'browser-owned'
+      })
     })
   })
 })

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -33,7 +33,7 @@ vi.mock('./browser-manager', () => ({
 
 import { browserSessionRegistry } from './browser-session-registry'
 import { googleAuthUserAgent } from './browser-google-auth-ua'
-import { setupGoogleAuthUserAgentOverride } from './browser-session-ua'
+import { setupClientHintsOverride } from './browser-session-ua'
 import { setBrowserNetworkProxySettingsResolver } from './browser-session-proxy'
 import { handleElectronProxyLogin } from '../network/electron-proxy-credentials'
 import { applyProxySettingsToSession } from '../network/proxy-settings'
@@ -54,7 +54,6 @@ describe('BrowserSessionRegistry', () => {
     askForMediaAccessMock.mockResolvedValue(true)
     getMediaAccessStatusMock.mockReturnValue('granted')
     sessionFromPartitionMock.mockReturnValue({
-      webRequest: { onBeforeSendHeaders: vi.fn() },
       setPermissionRequestHandler: vi.fn(),
       setPermissionCheckHandler: vi.fn(),
       setDevicePermissionHandler: vi.fn(),
@@ -529,46 +528,80 @@ describe('BrowserSessionRegistry', () => {
     })
   })
 
-  describe('setupGoogleAuthUserAgentOverride', () => {
-    const STOCK_UA =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) orca/1.0.0 Chrome/147.0.6890.3 Electron/43.0.0 Safari/537.36'
-
-    function install(): (details: unknown, callback: ReturnType<typeof vi.fn>) => void {
+  describe('setupClientHintsOverride', () => {
+    it('overrides sec-ch-ua headers for Edge UA', () => {
       const onBeforeSendHeaders = vi.fn()
-      setupGoogleAuthUserAgentOverride({ webRequest: { onBeforeSendHeaders } } as never)
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      const edgeUa =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36 Edg/147.0.3210.5'
+
+      setupClientHintsOverride(mockSess, edgeUa)
+
       expect(onBeforeSendHeaders).toHaveBeenCalledWith(
         { urls: ['https://*/*'] },
         expect.any(Function)
       )
-      return onBeforeSendHeaders.mock.calls[0][1]
-    }
 
-    // Why: the Electron token is what clears Cloudflare Turnstile; a Chrome-shaped UA with no
-    // client hints is what it rejects, so ordinary hosts must see the session's UA untouched.
-    it('leaves the stock Electron UA and its client hints alone off the auth hosts', () => {
-      const listener = install()
       const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
       listener(
-        {
-          url: 'https://example.com/api',
-          requestHeaders: { 'User-Agent': STOCK_UA, 'sec-ch-ua': 'old', Cookie: 'abc=123' }
-        },
+        { requestHeaders: { 'sec-ch-ua': 'old', 'sec-ch-ua-full-version-list': 'old' } },
         callback
       )
       const modified = callback.mock.calls[0][0].requestHeaders
-      expect(modified['User-Agent']).toBe(STOCK_UA)
-      expect(modified['sec-ch-ua']).toBe('old')
-      expect(modified.Cookie).toBe('abc=123')
+      expect(modified['sec-ch-ua']).toContain('Microsoft Edge')
+      expect(modified['sec-ch-ua']).toContain('"147"')
+      expect(modified['sec-ch-ua-full-version-list']).toContain('147.0.3210.5')
+    })
+
+    it('overrides sec-ch-ua headers for Chrome UA', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      const chromeUa =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+
+      setupClientHintsOverride(mockSess, chromeUa)
+
+      const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      listener({ requestHeaders: { 'sec-ch-ua': 'old' } }, callback)
+      const modified = callback.mock.calls[0][0].requestHeaders
+      expect(modified['sec-ch-ua']).toContain('Google Chrome')
+      expect(modified['sec-ch-ua']).not.toContain('Microsoft Edge')
+    })
+
+    it('registers handler even for non-Chrome UA but leaves sec-ch-ua untouched off auth hosts', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+
+      // Why: the Google-auth Firefox switch must install regardless of the base UA.
+      setupClientHintsOverride(mockSess, 'Mozilla/5.0 (compatible; MSIE 10.0)')
+
+      expect(onBeforeSendHeaders).toHaveBeenCalledWith(
+        { urls: ['https://*/*'] },
+        expect.any(Function)
+      )
+      const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      listener({ url: 'https://example.com/', requestHeaders: { 'sec-ch-ua': 'old' } }, callback)
+      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toBe('old')
     })
 
     it('presents a Firefox UA and strips client hints on Google auth hosts', () => {
-      const listener = install()
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      setupClientHintsOverride(
+        mockSess,
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+      )
+
       const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
       listener(
         {
           url: 'https://accounts.google.com/v3/signin/identifier',
           requestHeaders: {
-            'User-Agent': STOCK_UA,
+            'User-Agent': 'Chrome/147',
             'sec-ch-ua': 'old',
             'sec-ch-ua-full-version-list': 'old',
             'sec-ch-ua-platform': '"macOS"'
@@ -577,7 +610,7 @@ describe('BrowserSessionRegistry', () => {
         callback
       )
       const modified = callback.mock.calls[0][0].requestHeaders
-      expect(modified['User-Agent']).toBe(googleAuthUserAgent())
+      expect(modified['User-Agent']).toMatch(/Firefox\/\d/)
       expect(modified['User-Agent']).not.toContain('Chrome')
       expect(modified['sec-ch-ua']).toBeUndefined()
       expect(modified['sec-ch-ua-full-version-list']).toBeUndefined()
@@ -585,8 +618,15 @@ describe('BrowserSessionRegistry', () => {
     })
 
     it('strips client hints on a cross-host request that carries the Firefox auth UA', () => {
-      const listener = install()
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      setupClientHintsOverride(
+        mockSess,
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+      )
+
       const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
       // Subresource/XHR to a non-auth Google host while the auth document is on
       // screen: the WebContents Firefox UA leaks onto the request header.
       listener(
@@ -611,19 +651,99 @@ describe('BrowserSessionRegistry', () => {
       expect(modified['sec-ch-ua-mobile']).toBeUndefined()
     })
 
-    it('keeps the session identity on Google app subdomains (not auth hosts)', () => {
-      const listener = install()
+    it('keeps the clean Chrome identity on cross-host requests that carry the Chrome UA', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      const chromeUa =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+      setupClientHintsOverride(mockSess, chromeUa)
+
       const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      // Regression guard: non-Google sites (Cloudflare) must keep Chrome hints.
       listener(
         {
-          url: 'https://myaccount.google.com/',
-          requestHeaders: { 'User-Agent': STOCK_UA, 'sec-ch-ua': 'old' }
+          url: 'https://example.com/api',
+          requestHeaders: { 'User-Agent': chromeUa, 'sec-ch-ua': 'old' }
+        },
+        callback
+      )
+      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toContain('Google Chrome')
+    })
+
+    it('does not strip hints for the Firefox UA when googleAuthOverride is disabled', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      const chromeUa =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+      setupClientHintsOverride(mockSess, chromeUa, { googleAuthOverride: false })
+
+      const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      listener(
+        {
+          url: 'https://play.google.com/log',
+          requestHeaders: { 'User-Agent': googleAuthUserAgent(), 'sec-ch-ua': 'old' }
+        },
+        callback
+      )
+      // Imported-native profiles never install the Firefox switch, so the strip
+      // branch stays inert and hints are aligned to Chrome instead.
+      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toContain('Google Chrome')
+    })
+
+    it('keeps Chrome client hints on Google app subdomains (not auth hosts)', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      setupClientHintsOverride(
+        mockSess,
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+      )
+
+      const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      listener(
+        { url: 'https://myaccount.google.com/', requestHeaders: { 'sec-ch-ua': 'old' } },
+        callback
+      )
+      expect(callback.mock.calls[0][0].requestHeaders['sec-ch-ua']).toContain('Google Chrome')
+    })
+
+    it('keeps an imported native UA on auth hosts while aligning its Chrome hints', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      const importedUa =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.6890.3 Safari/537.36'
+      setupClientHintsOverride(mockSess, importedUa, { googleAuthOverride: false })
+
+      const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      listener(
+        {
+          url: 'https://accounts.google.com/v3/signin/identifier',
+          requestHeaders: { 'User-Agent': importedUa, 'sec-ch-ua': 'old' }
         },
         callback
       )
       const modified = callback.mock.calls[0][0].requestHeaders
-      expect(modified['User-Agent']).toBe(STOCK_UA)
-      expect(modified['sec-ch-ua']).toBe('old')
+      expect(modified['User-Agent']).toBe(importedUa)
+      expect(modified['sec-ch-ua']).toContain('Google Chrome')
+    })
+
+    it('leaves non-Client-Hints headers unchanged', () => {
+      const onBeforeSendHeaders = vi.fn()
+      const mockSess = { webRequest: { onBeforeSendHeaders } } as never
+      setupClientHintsOverride(mockSess, 'Mozilla/5.0 Chrome/147.0.0.0 Safari/537.36')
+
+      const callback = vi.fn()
+      const listener = onBeforeSendHeaders.mock.calls[0][1]
+      listener(
+        { requestHeaders: { Cookie: 'abc=123', 'sec-ch-ua': 'old', Accept: 'text/html' } },
+        callback
+      )
+      const modified = callback.mock.calls[0][0].requestHeaders
+      expect(modified.Cookie).toBe('abc=123')
+      expect(modified.Accept).toBe('text/html')
     })
   })
 })

--- a/src/main/browser/browser-session-ua-wire-identity.electron.test.ts
+++ b/src/main/browser/browser-session-ua-wire-identity.electron.test.ts
@@ -5,13 +5,19 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import { build as buildVite } from 'vite'
+import {
+  LOCAL_HTTPS_TEST_CERTIFICATE,
+  LOCAL_HTTPS_TEST_PRIVATE_KEY
+} from './browser-local-https-test-certificate'
 
 // Why this runs a real Electron: sites that hold a transplanted session re-check the browser
 // identity that minted it, and an `Orca/x.y.z … Electron/x.y.z` UA is not one any browser sends —
 // LinkedIn and x.com revoked live sessions over it (STA-7147). The header layer is the only place
 // that identity can be proven, and the vm-based unit tests cannot see Chromium's header emission
-// at all. Every partition must therefore strip the Electron and app tokens on the wire for
-// ordinary hosts and present the Firefox identity on Google's sign-in hosts only.
+// at all. Every clean-mode partition must therefore strip the Electron and app tokens on the
+// wire for ordinary hosts and present the Firefox identity on Google's sign-in hosts only. This
+// focused revocation fix does not claim full Chrome fingerprint parity; native mode remains the
+// fallback for sites that reject the cleaned identity, including some Turnstile deployments.
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
 const fixtureRoots: string[] = []
@@ -28,13 +34,24 @@ const FIXTURE_LAUNCH_ATTEMPTS = 2
 type CapturedRequest = {
   url: string
   userAgent: string | null
-  clientHints: string[]
+  clientHints: Record<string, string>
+}
+
+type UserAgentBrand = {
+  brand: string
+  version: string
+}
+
+type NavigatorUserAgentData = {
+  brands: UserAgentBrand[]
+  highEntropy: { fullVersionList?: UserAgentBrand[] }
 }
 
 type FixtureResult = {
   rawUserAgent: string
   sessionUserAgent: string
   navigatorUserAgent: string
+  navigatorUserAgentData: NavigatorUserAgentData | null
   requests: CapturedRequest[]
 }
 
@@ -49,8 +66,9 @@ function neverReachedElectronReady(fixtureResult: string): boolean {
 function buildFixtureMain(modulePath: string, resultPath: string): string {
   return `
 const { app, BrowserWindow, session } = require('electron')
+const { createServer } = require('node:https')
 const { writeFileSync } = require('node:fs')
-const { cleanElectronUserAgent, setupClientHintsOverride } = require(${JSON.stringify(modulePath)})
+const { cleanElectronUserAgent, setupGoogleAuthUserAgentOverride } = require(${JSON.stringify(modulePath)})
 const resultPath = ${JSON.stringify(resultPath)}
 // Why: production's UA carries an app token ("Orca/1.4.198") between the engine comment and
 // Chrome/, and an unnamed fixture emits none — which would leave half of cleanElectronUserAgent
@@ -75,39 +93,69 @@ async function run() {
   const rawUserAgent = sess.getUserAgent()
   const cleanUa = cleanElectronUserAgent(rawUserAgent)
   sess.setUserAgent(cleanUa)
-  setupClientHintsOverride(sess, cleanUa)
+  setupGoogleAuthUserAgentOverride(sess)
   mark('clean identity installed')
 
-  // Why: onSendHeaders reports the headers exactly as they leave the network stack, after the
-  // product's onBeforeSendHeaders listener has rewritten them. The requests must actually be
-  // dispatched for it to fire, so the session is pointed at a proxy that refuses every
-  // connection: nothing reaches the real hosts and every load fails fast.
-  await sess.setProxy({ proxyRules: 'http://127.0.0.1:9', proxyBypassRules: '<-loopback>' })
+  sess.setCertificateVerifyProc((_request, callback) => callback(0))
   const requests = []
   sess.webRequest.onSendHeaders({ urls: ['https://*/*'] }, (details) => {
     const headers = details.requestHeaders || {}
     const uaKey = Object.keys(headers).find((key) => key.toLowerCase() === 'user-agent')
+    const clientHints = {}
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase().startsWith('sec-ch-ua')) {
+        clientHints[key.toLowerCase()] = value
+      }
+    }
     requests.push({
       url: details.url,
       userAgent: uaKey ? headers[uaKey] : null,
-      clientHints: Object.keys(headers)
-        .filter((key) => key.toLowerCase().startsWith('sec-ch-ua'))
-        .sort()
+      clientHints
     })
   })
 
+  const server = createServer(
+    {
+      cert: ${JSON.stringify(LOCAL_HTTPS_TEST_CERTIFICATE)},
+      key: ${JSON.stringify(LOCAL_HTTPS_TEST_PRIVATE_KEY)}
+    },
+    (_request, response) => {
+      response.setHeader('Accept-CH', 'Sec-CH-UA-Full-Version-List')
+      response.end('<!doctype html><title>identity</title>')
+    }
+  )
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const origin = 'https://127.0.0.1:' + server.address().port
   const window = new BrowserWindow({ show: false, webPreferences: { partition } })
   mark('window created')
-  for (const url of ['https://example.com/', 'https://accounts.google.com/v3/signin/identifier']) {
-    await window.loadURL(url).catch(() => {})
+  let navigatorUserAgent
+  let navigatorUserAgentData
+  try {
+    await window.loadURL(origin + '/')
+    navigatorUserAgent = await window.webContents.executeJavaScript('navigator.userAgent')
+    navigatorUserAgentData = await window.webContents.executeJavaScript(
+      "(async () => { const data = navigator.userAgentData; return data ? { brands: data.brands, highEntropy: await data.getHighEntropyValues(['fullVersionList']) } : null })()"
+    )
+    await window.webContents.executeJavaScript(
+      'fetch("/hints").then((response) => response.text())'
+    )
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
   }
+
+  // Dispatch a real auth-host request without allowing it to reach the Internet.
+  await sess.setProxy({ proxyRules: 'http://127.0.0.1:9', proxyBypassRules: '<-loopback>' })
+  await window.loadURL('https://accounts.google.com/v3/signin/identifier').catch(() => {})
   mark('navigations attempted')
-  const navigatorUserAgent = await window.webContents.executeJavaScript('navigator.userAgent')
   clearTimeout(timeout)
   writeFileSync(resultPath, JSON.stringify({
     rawUserAgent,
     sessionUserAgent: sess.getUserAgent(),
     navigatorUserAgent,
+    navigatorUserAgentData,
     requests
   }))
   window.destroy()
@@ -167,6 +215,13 @@ async function runFixture(): Promise<FixtureResult> {
   }
 }
 
+function parseClientHintBrands(value: string): UserAgentBrand[] {
+  return [...value.matchAll(/"([^"]+)";v="([^"]+)"/g)].map((match) => ({
+    brand: match[1],
+    version: match[2]
+  }))
+}
+
 describe('browser session wire identity under Electron', () => {
   it('strips the Electron and app tokens for ordinary hosts and sends Firefox to Google auth hosts', async () => {
     const result = await runFixture()
@@ -181,10 +236,26 @@ describe('browser session wire identity under Electron', () => {
     expect(result.sessionUserAgent).not.toContain('Electron/')
     expect(result.sessionUserAgent).toMatch(/\(KHTML, like Gecko\) Chrome\/[\d.]+ Safari\/537\.36$/)
 
-    const ordinary = result.requests.find((request) => request.url === 'https://example.com/')
+    const ordinary = result.requests.find((request) => request.url.endsWith('/hints'))
     expect(ordinary, JSON.stringify(result.requests)).toBeDefined()
     expect(ordinary?.userAgent).toBe(result.sessionUserAgent)
     expect(result.navigatorUserAgent).toBe(result.sessionUserAgent)
+    expect(result.navigatorUserAgentData).not.toBeNull()
+
+    // Chromium owns both client-hint surfaces. Rewriting only the request headers would make this
+    // comparison fail while leaving the legacy UA assertions above green.
+    const wireBrands = parseClientHintBrands(ordinary?.clientHints['sec-ch-ua'] ?? '')
+    expect(wireBrands).toEqual(result.navigatorUserAgentData?.brands)
+    expect(wireBrands.some(({ brand }) => /Electron|Orca/i.test(brand))).toBe(false)
+    const chromeMajor = result.sessionUserAgent.match(/Chrome\/(\d+)/)?.[1]
+    expect(wireBrands.find(({ brand }) => brand === 'Chromium')?.version).toBe(chromeMajor)
+
+    const fullVersionList = ordinary?.clientHints['sec-ch-ua-full-version-list']
+    if (fullVersionList) {
+      expect(parseClientHintBrands(fullVersionList)).toEqual(
+        result.navigatorUserAgentData?.highEntropy.fullVersionList
+      )
+    }
 
     const auth = result.requests.find((request) =>
       request.url.startsWith('https://accounts.google.com/')
@@ -192,6 +263,6 @@ describe('browser session wire identity under Electron', () => {
     expect(auth, JSON.stringify(result.requests)).toBeDefined()
     expect(auth?.userAgent).toMatch(/Firefox\/\d/)
     expect(auth?.userAgent).not.toContain('Chrome')
-    expect(auth?.clientHints).toEqual([])
+    expect(auth?.clientHints).toEqual({})
   })
 })

--- a/src/main/browser/browser-session-ua-wire-identity.electron.test.ts
+++ b/src/main/browser/browser-session-ua-wire-identity.electron.test.ts
@@ -6,11 +6,12 @@ import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import { build as buildVite } from 'vite'
 
-// Why this runs a real Electron: Cloudflare Turnstile rejects a Chrome-shaped UA that ships no
-// client hints (error 600010) and clears a declared Electron client. The header layer is the
-// only place that identity can be proven, and the vm-based unit tests cannot see Chromium's
-// header emission at all. Every partition must therefore keep the stock Electron UA on the wire
-// for ordinary hosts and present the Firefox identity on Google's sign-in hosts only.
+// Why this runs a real Electron: sites that hold a transplanted session re-check the browser
+// identity that minted it, and an `Orca/x.y.z … Electron/x.y.z` UA is not one any browser sends —
+// LinkedIn and x.com revoked live sessions over it (STA-7147). The header layer is the only place
+// that identity can be proven, and the vm-based unit tests cannot see Chromium's header emission
+// at all. Every partition must therefore strip the Electron and app tokens on the wire for
+// ordinary hosts and present the Firefox identity on Google's sign-in hosts only.
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
 const fixtureRoots: string[] = []
@@ -31,6 +32,7 @@ type CapturedRequest = {
 }
 
 type FixtureResult = {
+  rawUserAgent: string
   sessionUserAgent: string
   navigatorUserAgent: string
   requests: CapturedRequest[]
@@ -48,8 +50,12 @@ function buildFixtureMain(modulePath: string, resultPath: string): string {
   return `
 const { app, BrowserWindow, session } = require('electron')
 const { writeFileSync } = require('node:fs')
-const { setupGoogleAuthUserAgentOverride } = require(${JSON.stringify(modulePath)})
+const { cleanElectronUserAgent, setupClientHintsOverride } = require(${JSON.stringify(modulePath)})
 const resultPath = ${JSON.stringify(resultPath)}
+// Why: production's UA carries an app token ("Orca/1.4.198") between the engine comment and
+// Chrome/, and an unnamed fixture emits none — which would leave half of cleanElectronUserAgent
+// unexercised while the test still passed.
+app.setName('OrcaWireIdentityFixture')
 let currentStep = 'starting'
 const mark = (step) => {
   currentStep = step
@@ -65,8 +71,12 @@ async function run() {
   mark('ready')
   const partition = 'persist:wire-identity-test'
   const sess = session.fromPartition(partition)
-  setupGoogleAuthUserAgentOverride(sess)
-  mark('auth switch installed')
+  // Mirrors installBrowserSessionPartitionPolicies for a non-native profile.
+  const rawUserAgent = sess.getUserAgent()
+  const cleanUa = cleanElectronUserAgent(rawUserAgent)
+  sess.setUserAgent(cleanUa)
+  setupClientHintsOverride(sess, cleanUa)
+  mark('clean identity installed')
 
   // Why: onSendHeaders reports the headers exactly as they leave the network stack, after the
   // product's onBeforeSendHeaders listener has rewritten them. The requests must actually be
@@ -95,6 +105,7 @@ async function run() {
   const navigatorUserAgent = await window.webContents.executeJavaScript('navigator.userAgent')
   clearTimeout(timeout)
   writeFileSync(resultPath, JSON.stringify({
+    rawUserAgent,
     sessionUserAgent: sess.getUserAgent(),
     navigatorUserAgent,
     requests
@@ -157,12 +168,18 @@ async function runFixture(): Promise<FixtureResult> {
 }
 
 describe('browser session wire identity under Electron', () => {
-  it('sends the stock Electron UA to ordinary hosts and Firefox to Google auth hosts', async () => {
+  it('strips the Electron and app tokens for ordinary hosts and sends Firefox to Google auth hosts', async () => {
     const result = await runFixture()
 
-    // Presence precondition: the stock identity still carries the Electron token that the old
-    // Chrome-shaped rewrite stripped, so an identity check below cannot pass on an empty UA.
-    expect(result.sessionUserAgent).toMatch(/ Electron\/\d/)
+    // Presence precondition: the raw identity really does carry the tokens, so the absence
+    // assertions below cannot pass vacuously on an empty or already-clean UA.
+    expect(result.rawUserAgent).toMatch(/ Electron\/\d/)
+    expect(result.rawUserAgent).toMatch(/\(KHTML, like Gecko\) \S+ Chrome\//)
+
+    // The whole point of STA-7147: nothing between the engine comment and Chrome/, and no
+    // Electron token anywhere — the shape a real Chrome sends.
+    expect(result.sessionUserAgent).not.toContain('Electron/')
+    expect(result.sessionUserAgent).toMatch(/\(KHTML, like Gecko\) Chrome\/[\d.]+ Safari\/537\.36$/)
 
     const ordinary = result.requests.find((request) => request.url === 'https://example.com/')
     expect(ordinary, JSON.stringify(result.requests)).toBeDefined()

--- a/src/main/browser/browser-session-ua.ts
+++ b/src/main/browser/browser-session-ua.ts
@@ -8,28 +8,93 @@ import {
   stripClientHints
 } from './browser-google-auth-ua'
 
-// Why: the session keeps Electron's stock UA. Stripping the Electron/app tokens to look like
-// plain Chrome is what Cloudflare Turnstile rejects (error 600010): a Chrome UA that ships no
-// client hints reads as a spoof, while a declared Electron client clears the same challenge.
-// This handler only owns the Google auth-host Firefox switch, which is a proven, host-scoped
-// exception that must stay consistent across the header and every cross-host subresource.
-export function setupGoogleAuthUserAgentOverride(sess: Session): void {
+// Why: Electron's default UA includes "Electron/X.X.X" and the app name
+// (e.g. "orca/1.2.3"), which Cloudflare Turnstile and other bot detectors
+// flag as non-human traffic. Strip those tokens so the webview's UA and
+// sec-ch-ua Client Hints look like standard Chrome.
+export function cleanElectronUserAgent(ua: string): string {
+  return (
+    ua
+      .replace(/\s+Electron\/\S+/, '')
+      // Why: \S+ matches any non-whitespace token (e.g. "orca/1.3.8-rc.0")
+      // including pre-release semver strings that [\d.]+ would miss.
+      .replace(/(\)\s+)\S+\s+(Chrome\/)/, '$1$2')
+  )
+}
+
+// Why: Electron emits sec-ch-ua brands like "Not A(Brand" without a
+// "Google Chrome" entry, which disagrees with the Chrome-shaped UA the session
+// presents. Rewrite the hint headers to the brand set Chrome ships for the same
+// engine version so the two surfaces tell one story. Also owns the Google
+// auth-host Firefox switch, which must install even for a non-Chrome-shaped UA.
+export function setupClientHintsOverride(
+  sess: Session,
+  ua: string,
+  options: { googleAuthOverride?: boolean } = {}
+): void {
+  // Why: only Chrome-shaped base UAs carry sec-ch-ua hints to rewrite, but the
+  // Google-auth Firefox switch below must install regardless, so keep the hints
+  // optional rather than bailing out of the whole handler.
+  const chromeHints = buildChromeClientHints(ua)
   const firefoxUa = googleAuthUserAgent()
 
   sess.webRequest.onBeforeSendHeaders({ urls: ['https://*/*'] }, (details, callback) => {
     const headers = details.requestHeaders
-    if (isGoogleAuthUrl(details.url)) {
+    if (options.googleAuthOverride !== false && isGoogleAuthUrl(details.url)) {
       // Why: present a Firefox identity on Google's sign-in hosts so the user logs
       // in inside the app and Google issues self-refreshing bound cookies. Strip
       // sec-ch-ua* because real Firefox sends none.
       setUserAgentHeader(headers, firefoxUa)
       stripClientHints(headers)
-    } else if (currentUserAgent(headers) === firefoxUa) {
-      // Why: while the auth document is on screen the WebContents UA is Firefox, so its
-      // cross-host subresource/XHR requests carry the Firefox UA yet still bear Chromium
-      // client hints — a sharper cross-host identity tell than either alone.
+      callback({ requestHeaders: headers })
+      return
+    }
+    if (options.googleAuthOverride !== false && currentUserAgent(headers) === firefoxUa) {
+      // Why: while the auth document is on screen the WebContents UA is Firefox,
+      // so its cross-host subresource/XHR requests (gstatic, play.google.com, the
+      // sign-in challenge endpoints) reach here carrying the Firefox UA yet still
+      // bearing Chromium client hints. Rewriting those to Chrome pairs a Firefox
+      // UA with Chrome hints — a sharper cross-host identity tell than either
+      // alone, which can stall Google's password-submit challenge. Real Firefox
+      // sends no client hints, so strip them to keep one identity for the flow.
       stripClientHints(headers)
+      callback({ requestHeaders: headers })
+      return
+    }
+    if (chromeHints) {
+      for (const key of Object.keys(headers)) {
+        const lower = key.toLowerCase()
+        if (lower === 'sec-ch-ua') {
+          headers[key] = chromeHints.secChUa
+        } else if (lower === 'sec-ch-ua-full-version-list') {
+          headers[key] = chromeHints.secChUaFull
+        }
+      }
     }
     callback({ requestHeaders: headers })
   })
+}
+
+function buildChromeClientHints(ua: string): { secChUa: string; secChUaFull: string } | null {
+  const chromeMatch = ua.match(/Chrome\/([\d.]+)/)
+  if (!chromeMatch) {
+    return null
+  }
+  const fullChromeVersion = chromeMatch[1]
+  const majorVersion = fullChromeVersion.split('.')[0]
+
+  let brand = 'Google Chrome'
+  let brandFullVersion = fullChromeVersion
+
+  const edgeMatch = ua.match(/Edg\/([\d.]+)/)
+  if (edgeMatch) {
+    brand = 'Microsoft Edge'
+    brandFullVersion = edgeMatch[1]
+  }
+  const brandMajor = brandFullVersion.split('.')[0]
+
+  return {
+    secChUa: `"${brand}";v="${brandMajor}", "Chromium";v="${majorVersion}", "Not/A)Brand";v="24"`,
+    secChUaFull: `"${brand}";v="${brandFullVersion}", "Chromium";v="${fullChromeVersion}", "Not/A)Brand";v="24.0.0.0"`
+  }
 }

--- a/src/main/browser/browser-session-ua.ts
+++ b/src/main/browser/browser-session-ua.ts
@@ -9,9 +9,9 @@ import {
 } from './browser-google-auth-ua'
 
 // Why: Electron's default UA includes "Electron/X.X.X" and the app name
-// (e.g. "orca/1.2.3"), which Cloudflare Turnstile and other bot detectors
-// flag as non-human traffic. Strip those tokens so the webview's UA and
-// sec-ch-ua Client Hints look like standard Chrome.
+// (e.g. "orca/1.2.3"), an impossible identity for sessions imported from Chrome.
+// This focused revocation fix strips only those tokens; it does not attempt full Chrome
+// impersonation, and Chromium's client-hint identity remains browser-owned.
 export function cleanElectronUserAgent(ua: string): string {
   return (
     ua
@@ -22,25 +22,15 @@ export function cleanElectronUserAgent(ua: string): string {
   )
 }
 
-// Why: Electron emits sec-ch-ua brands like "Not A(Brand" without a
-// "Google Chrome" entry, which disagrees with the Chrome-shaped UA the session
-// presents. Rewrite the hint headers to the brand set Chrome ships for the same
-// engine version so the two surfaces tell one story. Also owns the Google
-// auth-host Firefox switch, which must install even for a non-Chrome-shaped UA.
-export function setupClientHintsOverride(
-  sess: Session,
-  ua: string,
-  options: { googleAuthOverride?: boolean } = {}
-): void {
-  // Why: only Chrome-shaped base UAs carry sec-ch-ua hints to rewrite, but the
-  // Google-auth Firefox switch below must install regardless, so keep the hints
-  // optional rather than bailing out of the whole handler.
-  const chromeHints = buildChromeClientHints(ua)
+// Why: Chromium already publishes one internally consistent client-hint identity through both
+// request headers and navigator.userAgentData. This handler only owns the host-scoped Firefox
+// exception; synthesizing Chrome brands here would make those two browser-owned surfaces disagree.
+export function setupGoogleAuthUserAgentOverride(sess: Session): void {
   const firefoxUa = googleAuthUserAgent()
 
   sess.webRequest.onBeforeSendHeaders({ urls: ['https://*/*'] }, (details, callback) => {
     const headers = details.requestHeaders
-    if (options.googleAuthOverride !== false && isGoogleAuthUrl(details.url)) {
+    if (isGoogleAuthUrl(details.url)) {
       // Why: present a Firefox identity on Google's sign-in hosts so the user logs
       // in inside the app and Google issues self-refreshing bound cookies. Strip
       // sec-ch-ua* because real Firefox sends none.
@@ -49,7 +39,7 @@ export function setupClientHintsOverride(
       callback({ requestHeaders: headers })
       return
     }
-    if (options.googleAuthOverride !== false && currentUserAgent(headers) === firefoxUa) {
+    if (currentUserAgent(headers) === firefoxUa) {
       // Why: while the auth document is on screen the WebContents UA is Firefox,
       // so its cross-host subresource/XHR requests (gstatic, play.google.com, the
       // sign-in challenge endpoints) reach here carrying the Firefox UA yet still
@@ -61,40 +51,6 @@ export function setupClientHintsOverride(
       callback({ requestHeaders: headers })
       return
     }
-    if (chromeHints) {
-      for (const key of Object.keys(headers)) {
-        const lower = key.toLowerCase()
-        if (lower === 'sec-ch-ua') {
-          headers[key] = chromeHints.secChUa
-        } else if (lower === 'sec-ch-ua-full-version-list') {
-          headers[key] = chromeHints.secChUaFull
-        }
-      }
-    }
     callback({ requestHeaders: headers })
   })
-}
-
-function buildChromeClientHints(ua: string): { secChUa: string; secChUaFull: string } | null {
-  const chromeMatch = ua.match(/Chrome\/([\d.]+)/)
-  if (!chromeMatch) {
-    return null
-  }
-  const fullChromeVersion = chromeMatch[1]
-  const majorVersion = fullChromeVersion.split('.')[0]
-
-  let brand = 'Google Chrome'
-  let brandFullVersion = fullChromeVersion
-
-  const edgeMatch = ua.match(/Edg\/([\d.]+)/)
-  if (edgeMatch) {
-    brand = 'Microsoft Edge'
-    brandFullVersion = edgeMatch[1]
-  }
-  const brandMajor = brandFullVersion.split('.')[0]
-
-  return {
-    secChUa: `"${brand}";v="${brandMajor}", "Chromium";v="${majorVersion}", "Not/A)Brand";v="24"`,
-    secChUaFull: `"${brand}";v="${brandFullVersion}", "Chromium";v="${fullChromeVersion}", "Not/A)Brand";v="24.0.0.0"`
-  }
 }

--- a/src/main/browser/browser-viewport-user-agent.ts
+++ b/src/main/browser/browser-viewport-user-agent.ts
@@ -23,7 +23,7 @@ export type ViewportUserAgentOverride = {
 }
 
 // Why: responsive sites UA-sniff; this is Chrome DevTools' default iPhone UA template with the real
-// Chrome major spliced in to keep sec-ch-ua consistent (see setupClientHintsOverride).
+// Chrome major spliced in so the userAgentMetadata brands below agree with it.
 function buildMobileUserAgent(chromeMajor: string): string {
   return `Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/${chromeMajor}.0.0.0 Mobile/15E148 Safari/604.1`
 }

--- a/src/main/browser/browser-viewport-user-agent.ts
+++ b/src/main/browser/browser-viewport-user-agent.ts
@@ -23,7 +23,7 @@ export type ViewportUserAgentOverride = {
 }
 
 // Why: responsive sites UA-sniff; this is Chrome DevTools' default iPhone UA template with the real
-// Chrome major spliced in so the userAgentMetadata brands below agree with it.
+// Chrome major spliced in to keep sec-ch-ua consistent (see setupClientHintsOverride).
 function buildMobileUserAgent(chromeMajor: string): string {
   return `Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/${chromeMajor}.0.0.0 Mobile/15E148 Safari/604.1`
 }
@@ -44,7 +44,8 @@ export function buildViewportUserAgentOverride(args: {
     return { userAgent: googleAuthUserAgent() }
   }
   if (!args.mobile) {
-    // Why: desktop presets republish the session's own identity unchanged.
+    // Why: desktop presets republish the session's clean identity, or a preset would put the
+    // Electron/app tokens back on the wire and a transplanted session gets revoked (STA-7147).
     return { userAgent: args.baseUserAgent }
   }
   const chromeMajor = extractChromeMajor(args.baseUserAgent)

--- a/tests/tools/google-signin-ua-probe.cjs
+++ b/tests/tools/google-signin-ua-probe.cjs
@@ -10,10 +10,9 @@ const MODES = new Set([
   'electron-fixed',
   'firefox-auth',
   'firefox-fixed',
-  // Replicates the SHIPPED app exactly (setupClientHintsOverride +
-  // applyGoogleAuthUserAgent): Firefox UA is written to the WebContents on auth
-  // navs and to the request header only for auth-host URLs; every other request
-  // keeps whatever UA the WebContents carries. Logs incoming vs outgoing
+  // Replicates the app before and after the cross-host fix. Firefox UA is written
+  // to the WebContents on auth navs and to the request header only for auth-host
+  // URLs; every other request keeps whatever UA the WebContents carries. Logs incoming vs outgoing
   // identity for ALL requests to expose cross-host mismatches during the flow.
   'app-current',
   // Same, but with the STA-3811 fix: the header layer strips client hints on any
@@ -171,7 +170,7 @@ app.whenReady().then(async () => {
     const incoming = relevantHeaders(headers)
 
     if (isAppMode) {
-      // Mirror setupClientHintsOverride: only auth-host URLs get the Firefox UA
+      // Mirror setupGoogleAuthUserAgentOverride: only auth-host URLs get the Firefox UA
       // header + hint strip; every other request keeps its incoming UA (which is
       // the WebContents UA — Firefox while the auth document is on screen).
       if (isGoogleAuthUrl(details.url)) {
@@ -184,10 +183,6 @@ app.whenReady().then(async () => {
         // instead of rewriting to Chrome — keeping UA and hints one story.
         if (mode === 'app-fixed' && currentUa === identities.firefox) {
           removeClientHints(headers)
-        } else {
-          // Real setupClientHintsOverride builds Chrome hints once from the
-          // session's cleaned UA (a closure), never from the per-request UA.
-          applyChromeClientHints(headers, identities.cleaned)
         }
       }
       const outgoing = relevantHeaders(headers)

--- a/tests/tools/google-signin-ua-probe.cjs
+++ b/tests/tools/google-signin-ua-probe.cjs
@@ -10,8 +10,8 @@ const MODES = new Set([
   'electron-fixed',
   'firefox-auth',
   'firefox-fixed',
-  // Replicates the app as it shipped before the UA rewrite was removed
-  // (cleaned Chrome-shaped session UA + the Google auth Firefox switch): Firefox UA is written to the WebContents on auth
+  // Replicates the SHIPPED app exactly (setupClientHintsOverride +
+  // applyGoogleAuthUserAgent): Firefox UA is written to the WebContents on auth
   // navs and to the request header only for auth-host URLs; every other request
   // keeps whatever UA the WebContents carries. Logs incoming vs outgoing
   // identity for ALL requests to expose cross-host mismatches during the flow.
@@ -185,7 +185,7 @@ app.whenReady().then(async () => {
         if (mode === 'app-fixed' && currentUa === identities.firefox) {
           removeClientHints(headers)
         } else {
-          // The retired client-hints rewrite built Chrome hints once from the
+          // Real setupClientHintsOverride builds Chrome hints once from the
           // session's cleaned UA (a closure), never from the per-request UA.
           applyChromeClientHints(headers, identities.cleaned)
         }


### PR DESCRIPTION
## Problem

Since **v1.4.198** the embedded browser announces itself on every non-Google host as:

```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Orca/1.4.198 Chrome/150.0.7871.224 Electron/43.4.1 Safari/537.36
```

No browser sends that. Sites that re-check the identity holding a session reject it — reports of being signed out of x.com, LinkedIn and "most websites."

**This escapes our app.** One reporter was signed out of LinkedIn in their own Chrome and met LinkedIn's *"Quick security check … suspicious activity"* SMS flow. Orca's cookie jar cannot touch Chrome's, so that is server-side session revocation.

`436ef827dd` (#18749, merged Sep 4) is the cause. `v1.4.197` does not contain it; `v1.4.198` (Sep 8) is the first build that does; first report Sep 9. It is the only identity-touching commit in `src/main/browser` in that window.

The repo already documented the mechanism, in a comment #18749 edited without acting on (`browser-google-auth-ua.ts`): copied-in cookies *"sent under a UA that doesn't match a real first-party browser get flagged by anti-fraud."* That is why the Google auth-host switch exists. #18749 kept it for `accounts.google.com` and gave every other host an Electron identity.

**Not a cookie-import bug.** No cookie-import file changed on main since Aug 31, and the import attaches its own debugger (`browser-cookie-clear-store.ts:142-177`), independent of the attach #18749 removed. Cookies were always written correctly; servers were refusing them.

## Fix

Strip the `Electron/x.y.z` and `Orca/x.y.z` tokens from the session UA. That is the whole change.

This is deliberately **not** Chrome impersonation. Chromium's client-hint identity (`sec-ch-ua*` and `navigator.userAgentData`) stays browser-owned and internally consistent — the pre-#18749 code also injected synthetic "Google Chrome" brands into two headers, and that is **not** restored, because it made the header and JS surfaces disagree while buying nothing (see the measurement below).

**Kept from #18749**, all independent of the UA:
- `anti-detection.ts` stays deleted — its premises were measured false on Electron 43 and its overrides are themselves published bot signatures
- no `Runtime.enable` into cross-origin iframes
- no unconditional CDP debugger attach on every browsing guest

Removes the need for #19740 (per-host Electron-token stripping for WhatsApp Web).

## Measured tradeoff: this re-opens #13822, and there is no design that avoids it

Ablation on a standalone Electron 43.6.0 / Chromium 150 harness against `dash.cloudflare.com/login`, 5 reps per arm, fresh profile per run. Controls re-run after the matrix with no drift.

| Arm | Configuration | Pass |
|---|---|---|
| A1 | Stock Electron UA, no debugger (today's shipped behaviour) | **5/5** |
| A2 | Stock UA + debugger attached | **5/5** |
| A3 | Cleaned Chrome UA + the old two-header hint rewrite (pre-#18749) | 0/5 |
| A4 | CDP `Emulation.setUserAgentOverride` + complete `userAgentMetadata` | 0/5 |
| A4b | A4 + matching header hints — navigation, subresource, OOPIF and `userAgentData` all agree | 0/5 |
| A8 | A4b claiming current Chrome 152 | 0/5 |
| A7 | **Identical CDP mechanism, publishing Electron's own identity** | **5/5** |
| A9/A10 | Stock UA + `Runtime.enable`, including into the cross-origin iframe | **5/5** |

**Every arm claiming Google Chrome failed 25/25. Every arm publishing the Electron identity passed 25/25.**

A7 is the isolating control: same override, same complete metadata, differing only in which identity it publishes. So the trigger is not the debugger attach, not the Emulation override, and not client-hint shape or coherence. A "coherent Chrome identity" fix was the obvious candidate and it is **measured dead** — three ways (A4, A4b, A8).

Scoping that claim precisely: this rig measured **Turnstile outcomes only**. It shows a Chrome-claiming
identity cannot clear Turnstile. It does *not* measure cookie acceptance — that the Electron identity
gets sessions revoked comes from user reports and documented UA-binding, not from this matrix. So
"irreconcilable" rests on measured-Turnstile plus reported-sessions, and this is a forced choice. Taking it knowingly: a Turnstile failure is bounded and confined to our browser; session revocation damages users' real accounts and demands SMS re-verification.

The permanent fix therefore has to scope the identity rather than find a better global disguise, and the
same rig measured why that is hard. `Emulation.setUserAgentOverride` is **target-wide and forward-only**:
it reaches only frames created *after* it is set, a pre-existing cross-origin iframe keeps the old identity
indefinitely, and a cross-host top-level navigation does *not* clear it. So switching identity on a live
page produces a split-identity page — top frame claiming Chrome while an embedded third-party frame still
says Electron — which is a sharper contradiction than either identity alone. Header-only scoping is arm A3,
which fails, and there is no per-partition or per-session seam either: CDP offers no partition-scoped
identity, and Electron's per-partition primitive (`session.setUserAgent`) sets only the UA string, which
*is* A3. The only seam that is both coherent and enforceable is **per-WebContents, set before the first
navigation and immutable for that WebContents' lifetime** — identity decided at guest creation, not at
navigation time, with navigation off the host forced into a fresh WebContents carrying the default
identity. That is follow-up work, not this PR, and whether it rescues cookie acceptance at all is
unmeasured.

Incidentally, A9/A10 bear on #18749's premise that OOPIF `Runtime.enable` is the Cloudflare tell. With
`Runtime.enable` plus a `Runtime.evaluate` landed **inside the challenge frame itself** (verified by
reading `location.href` in the child session), the challenge still passed 3/3. That refutes the
*necessity* claim — removing it was not required for Turnstile to clear here — but not the weaker
claim that Cloudflare can observe it: detection is not the same as challenge failure, and it could
be weighted differently on higher-risk paths. That change is harmless and is left in place.

## Tests

- Real-Electron wire-identity test asserts the stripped identity on ordinary hosts and Firefox on Google auth hosts. **Ablation-verified**: neutering `cleanElectronUserAgent` turns it red on the Electron-token assertion.
- Its fixture gained an app name — without one the raw UA carried **no app token**, so the `Orca/x.y.z` half of the cleaner was never exercised and the test passed while half-testing.
- Full CI green.

## Caveats, stated rather than buried

- **Scope of what reverting costs.** It costs the embedded-widget class, measured: 25/25 pass on the Electron
  identity versus 0/25 on every Chrome-claiming configuration, on `dash.cloudflare.com`. For the full-page
  interstitial class, no configuration cleared it in this rig — including the shipped one, 0/44 across three
  sites — but that positive control did not reproduce, and the non-reproduction is unattributed (hidden
  never-focused window, fresh profile per run, or Cloudflare tightening since Sep 4 are all live). **It should
  not be cited as evidence that the shipped build fails interstitials for users.** Earning the stronger claim
  needs a visible focused window on an isolated display or CI, which the environment rules prohibit here.
  So the mechanism is well-supported for the embedded-widget class and unverified for the interstitial class.
- No live LinkedIn/X run was performed. The session-revocation mechanism is inferred from user reports plus documented UA-binding behaviour, not measured here.
- Not restoring the synthetic Chrome hints is a deviation from the exact v1.4.197 state. It is justified by reasoning and by A3's failure, not by a measurement that sites accept sessions without them.
- There is no identity epoch, so sessions minted under the Electron UA since Sep 8 may see one further round of logouts on the way back.
