### PR TITLE
feat(native-chat): describe slash commands from the provider's own report

### DIFF
--- a/src/main/claude/claude-slash-command-catalog.test.ts
+++ b/src/main/claude/claude-slash-command-catalog.test.ts
@@ -156,6 +156,7 @@ it('bounds the row text a provider can put in the picker', () => {
       { name: 'long', description: 'x'.repeat(201), argumentHint: 'y'.repeat(101) },
       { name: 'wrong-type', description: 42, argumentHint: { text: 'no' } },
       { name: 'blank', description: '   ' },
+      { name: 'long-whitespace', description: `Visible${' '.repeat(201)}` },
       { name: 'wrapped', description: 'first line\n  second   line' }
     ]
   })
@@ -163,11 +164,51 @@ it('bounds the row text a provider can put in the picker', () => {
     { name: 'long', kind: 'command', kindUnspecified: true },
     { name: 'wrong-type', kind: 'command', kindUnspecified: true },
     { name: 'blank', kind: 'command', kindUnspecified: true },
+    { name: 'long-whitespace', kind: 'command', kindUnspecified: true },
     {
       name: 'wrapped',
       kind: 'command',
       kindUnspecified: true,
       description: 'first line second line'
+    }
+  ])
+})
+
+it('does not let malformed descriptor names consume the command detail budget', () => {
+  const catalog = new ClaudeSlashCommandCatalog(undefined, {
+    commands: [
+      ...Array.from({ length: 512 }, (_, index) => ({
+        name: `invalid name ${index}`,
+        description: 'Rejected with its name'
+      })),
+      { name: 'goal', description: 'Set or view the goal', argumentHint: '<goal>' }
+    ]
+  })
+  expect(catalog.commands).toEqual([
+    {
+      name: 'goal',
+      kind: 'command',
+      kindUnspecified: true,
+      description: 'Set or view the goal',
+      argumentHint: '<goal>'
+    }
+  ])
+})
+
+it('combines non-empty fields from duplicate descriptors without discarding earlier text', () => {
+  const catalog = new ClaudeSlashCommandCatalog(undefined, {
+    commands: [
+      { name: 'goal', description: 'Set or view the goal' },
+      { name: 'goal', argumentHint: '<goal>' }
+    ]
+  })
+  expect(catalog.commands).toEqual([
+    {
+      name: 'goal',
+      kind: 'command',
+      kindUnspecified: true,
+      description: 'Set or view the goal',
+      argumentHint: '<goal>'
     }
   ])
 })

--- a/src/main/claude/claude-slash-command-catalog.test.ts
+++ b/src/main/claude/claude-slash-command-catalog.test.ts
@@ -86,8 +86,8 @@ it('accepts descriptor reloads, removing old skills while retaining terminal fil
   }
   expect(catalog.observe(reload)).toBe(true)
   expect(catalog.commands).toEqual([
-    { name: 'clear', kind: 'command' },
-    { name: 'new-skill', kind: 'skill' }
+    { name: 'clear', kind: 'command', description: 'Clear' },
+    { name: 'new-skill', kind: 'skill', description: 'New' }
   ])
   expect(catalog.observe(reload)).toBe(false)
   expect(catalog.observe({ ...reload, commands: [] })).toBe(true)
@@ -129,4 +129,106 @@ it('publishes classification becoming authoritative even when the name and kind 
   const catalog = new ClaudeSlashCommandCatalog(undefined, { commands: [{ name: 'clear' }] })
   expect(catalog.observe(init({ slash_commands: ['clear'], skills: [] }))).toBe(true)
   expect(catalog.commands).toEqual([{ name: 'clear', kind: 'command' }])
+})
+
+it('keeps the description and argument hint a descriptor report authored', () => {
+  const catalog = new ClaudeSlashCommandCatalog(undefined, {
+    commands: [
+      { name: 'goal', description: 'Set or view the goal', argumentHint: '<goal>' },
+      { name: 'quiet', description: '', argumentHint: '' }
+    ]
+  })
+  expect(catalog.commands).toEqual([
+    {
+      name: 'goal',
+      kind: 'command',
+      kindUnspecified: true,
+      description: 'Set or view the goal',
+      argumentHint: '<goal>'
+    },
+    { name: 'quiet', kind: 'command', kindUnspecified: true }
+  ])
+})
+
+it('bounds the row text a provider can put in the picker', () => {
+  const catalog = new ClaudeSlashCommandCatalog(undefined, {
+    commands: [
+      { name: 'long', description: 'x'.repeat(201), argumentHint: 'y'.repeat(101) },
+      { name: 'wrong-type', description: 42, argumentHint: { text: 'no' } },
+      { name: 'blank', description: '   ' },
+      { name: 'wrapped', description: 'first line\n  second   line' }
+    ]
+  })
+  expect(catalog.commands).toEqual([
+    { name: 'long', kind: 'command', kindUnspecified: true },
+    { name: 'wrong-type', kind: 'command', kindUnspecified: true },
+    { name: 'blank', kind: 'command', kindUnspecified: true },
+    {
+      name: 'wrapped',
+      kind: 'command',
+      kindUnspecified: true,
+      description: 'first line second line'
+    }
+  ])
+})
+
+it('carries descriptor text across the name-only stream init that classifies it', () => {
+  const catalog = new ClaudeSlashCommandCatalog(undefined, {
+    commands: [
+      { name: 'clear', description: 'Clear conversation' },
+      { name: 'ref-oss', description: 'A skill' }
+    ]
+  })
+  expect(catalog.observe(init({ slash_commands: ['clear', 'ref-oss'], skills: ['ref-oss'] }))).toBe(
+    true
+  )
+  expect(catalog.commands).toEqual([
+    { name: 'clear', kind: 'command', description: 'Clear conversation' },
+    { name: 'ref-oss', kind: 'skill', description: 'A skill' }
+  ])
+})
+
+it('reports a description-only change and lets a later report drop the text', () => {
+  const catalog = new ClaudeSlashCommandCatalog(init({ slash_commands: ['clear'], skills: [] }))
+  expect(catalog.commands).toEqual([{ name: 'clear', kind: 'command' }])
+  const changed = {
+    type: 'system',
+    subtype: 'commands_changed',
+    commands: [{ name: 'clear', description: 'Clear conversation history' }]
+  }
+  expect(catalog.observe(changed)).toBe(true)
+  expect(catalog.commands).toEqual([
+    { name: 'clear', kind: 'command', description: 'Clear conversation history' }
+  ])
+  expect(catalog.observe(changed)).toBe(false)
+  expect(catalog.observe({ ...changed, commands: [{ name: 'clear' }] })).toBe(true)
+  expect(catalog.commands).toEqual([{ name: 'clear', kind: 'command' }])
+})
+
+it('describes nothing when the session reported names only', () => {
+  expect(readClaudeSlashCommands(init())).toEqual([
+    { name: 'clear', kind: 'command' },
+    { name: 'ref-oss', kind: 'skill' },
+    { name: 'opsx:apply', kind: 'command' }
+  ])
+  expect(new ClaudeSlashCommandCatalog(init()).commands).toEqual([
+    { name: 'clear', kind: 'command' },
+    { name: 'ref-oss', kind: 'skill' },
+    { name: 'opsx:apply', kind: 'command' }
+  ])
+})
+
+it('still hides terminal-only names however well the provider describes them', () => {
+  const catalog = new ClaudeSlashCommandCatalog(init())
+  expect(
+    catalog.observe({
+      type: 'system',
+      subtype: 'commands_changed',
+      commands: [
+        { name: 'doctor', description: 'Diagnose the CLI install' },
+        { name: 'ref-oss', description: 'A skill' }
+      ]
+    })
+  ).toBe(true)
+  expect(catalog.commands).toEqual([{ name: 'ref-oss', kind: 'skill', description: 'A skill' }])
 })

--- a/src/main/claude/claude-slash-command-catalog.ts
+++ b/src/main/claude/claude-slash-command-catalog.ts
@@ -9,6 +9,11 @@ const MAX_ARGUMENT_HINT_LENGTH = 100
 /** The provider's own row text for one command, absent when it reported none. */
 type CommandDetail = Pick<AgentSessionSlashCommand, 'description' | 'argumentHint'>
 
+function commandName(value: unknown): string | undefined {
+  const name = typeof value === 'string' ? value.trim() : ''
+  return name.length > 0 && name.length <= MAX_NAME_LENGTH && !/\s/u.test(name) ? name : undefined
+}
+
 function names(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return []
@@ -18,54 +23,61 @@ function names(value: unknown): string[] {
     if (seen.size >= MAX_COMMANDS) {
       break
     }
-    const name = typeof entry === 'string' ? entry.trim() : ''
-    if (name.length > 0 && name.length <= MAX_NAME_LENGTH && !/\s/u.test(name)) {
+    const name = commandName(entry)
+    if (name !== undefined) {
       seen.add(name)
     }
   }
   return [...seen]
 }
 
-function descriptorNames(value: unknown): string[] {
-  return names(
-    Array.isArray(value)
-      ? value.map((entry) => (entry !== null && typeof entry === 'object' ? entry.name : undefined))
-      : []
-  )
-}
-
 /** A single picker row's worth of provider text: unusable values are dropped, not truncated. */
 function rowText(value: unknown, maxLength: number): string | undefined {
-  if (typeof value !== 'string') {
+  if (typeof value !== 'string' || value.length > maxLength) {
     return undefined
   }
   const collapsed = value.replace(/\s+/gu, ' ').trim()
   return collapsed.length > 0 && collapsed.length <= maxLength ? collapsed : undefined
 }
 
-function descriptorDetails(value: unknown): Map<string, CommandDetail> {
+function descriptorCatalog(value: unknown): {
+  names: string[]
+  details: Map<string, CommandDetail>
+} {
+  const names: string[] = []
+  const seen = new Set<string>()
   const details = new Map<string, CommandDetail>()
   if (!Array.isArray(value)) {
-    return details
+    return { names, details }
   }
   for (const entry of value) {
-    if (details.size >= MAX_COMMANDS) {
+    if (seen.size >= MAX_COMMANDS) {
       break
     }
-    if (entry === null || typeof entry !== 'object' || typeof entry.name !== 'string') {
+    if (entry === null || typeof entry !== 'object') {
       continue
     }
-    const description = rowText(entry.description, MAX_DESCRIPTION_LENGTH)
-    const argumentHint = rowText(entry.argumentHint, MAX_ARGUMENT_HINT_LENGTH)
+    const name = commandName(entry.name)
+    if (name === undefined) {
+      continue
+    }
+    if (!seen.has(name)) {
+      seen.add(name)
+      names.push(name)
+    }
+    const previous = details.get(name)
+    const description = previous?.description ?? rowText(entry.description, MAX_DESCRIPTION_LENGTH)
+    const argumentHint =
+      previous?.argumentHint ?? rowText(entry.argumentHint, MAX_ARGUMENT_HINT_LENGTH)
     if (description === undefined && argumentHint === undefined) {
       continue
     }
-    details.set(entry.name.trim(), {
+    details.set(name, {
       ...(description === undefined ? {} : { description }),
       ...(argumentHint === undefined ? {} : { argumentHint })
     })
   }
-  return details
+  return { names, details }
 }
 
 function carriesCommandCatalog(message: Record<string, unknown>): boolean {
@@ -105,9 +117,10 @@ export class ClaudeSlashCommandCatalog {
       'commands' in initialization &&
       Array.isArray(initialization.commands)
     ) {
-      this.details = descriptorDetails(initialization.commands)
+      const catalog = descriptorCatalog(initialization.commands)
+      this.details = catalog.details
       this.entries = this.describe(
-        descriptorNames(initialization.commands).map((name) => ({
+        catalog.names.map((name) => ({
           name,
           kind: 'command',
           kindUnspecified: true
@@ -143,9 +156,10 @@ export class ClaudeSlashCommandCatalog {
       message.subtype === 'commands_changed' &&
       Array.isArray(message.commands)
     ) {
-      this.details = descriptorDetails(message.commands)
+      const catalog = descriptorCatalog(message.commands)
+      this.details = catalog.details
       next = this.describe(
-        descriptorNames(message.commands)
+        catalog.names
           .filter((name) => !this.hidden.has(name))
           .map((name) =>
             this.hasSkillClassification

--- a/src/main/claude/claude-slash-command-catalog.ts
+++ b/src/main/claude/claude-slash-command-catalog.ts
@@ -3,6 +3,11 @@ import type { AgentSessionSlashCommand } from '../../shared/agent-session-wire'
 // Stream init carries name arrays; control initialization and reloads carry descriptors.
 const MAX_COMMANDS = 512
 const MAX_NAME_LENGTH = 200
+const MAX_DESCRIPTION_LENGTH = 200
+const MAX_ARGUMENT_HINT_LENGTH = 100
+
+/** The provider's own row text for one command, absent when it reported none. */
+type CommandDetail = Pick<AgentSessionSlashCommand, 'description' | 'argumentHint'>
 
 function names(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -27,6 +32,40 @@ function descriptorNames(value: unknown): string[] {
       ? value.map((entry) => (entry !== null && typeof entry === 'object' ? entry.name : undefined))
       : []
   )
+}
+
+/** A single picker row's worth of provider text: unusable values are dropped, not truncated. */
+function rowText(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const collapsed = value.replace(/\s+/gu, ' ').trim()
+  return collapsed.length > 0 && collapsed.length <= maxLength ? collapsed : undefined
+}
+
+function descriptorDetails(value: unknown): Map<string, CommandDetail> {
+  const details = new Map<string, CommandDetail>()
+  if (!Array.isArray(value)) {
+    return details
+  }
+  for (const entry of value) {
+    if (details.size >= MAX_COMMANDS) {
+      break
+    }
+    if (entry === null || typeof entry !== 'object' || typeof entry.name !== 'string') {
+      continue
+    }
+    const description = rowText(entry.description, MAX_DESCRIPTION_LENGTH)
+    const argumentHint = rowText(entry.argumentHint, MAX_ARGUMENT_HINT_LENGTH)
+    if (description === undefined && argumentHint === undefined) {
+      continue
+    }
+    details.set(entry.name.trim(), {
+      ...(description === undefined ? {} : { description }),
+      ...(argumentHint === undefined ? {} : { argumentHint })
+    })
+  }
+  return details
 }
 
 function carriesCommandCatalog(message: Record<string, unknown>): boolean {
@@ -56,6 +95,7 @@ export class ClaudeSlashCommandCatalog {
   private hasSkillClassification = false
   private hidden = new Set<string>()
   private commandNames = new Set<string>()
+  private details = new Map<string, CommandDetail>()
 
   constructor(initMessage?: Record<string, unknown>, initialization?: unknown) {
     // SessionStart can prove acquisition before the first stream init exists.
@@ -65,11 +105,14 @@ export class ClaudeSlashCommandCatalog {
       'commands' in initialization &&
       Array.isArray(initialization.commands)
     ) {
-      this.entries = descriptorNames(initialization.commands).map((name) => ({
-        name,
-        kind: 'command',
-        kindUnspecified: true
-      }))
+      this.details = descriptorDetails(initialization.commands)
+      this.entries = this.describe(
+        descriptorNames(initialization.commands).map((name) => ({
+          name,
+          kind: 'command',
+          kindUnspecified: true
+        }))
+      )
     }
     if (initMessage) {
       this.observe(initMessage)
@@ -80,13 +123,18 @@ export class ClaudeSlashCommandCatalog {
     return this.entries
   }
 
+  /** Provider row text, carried across the name-only frames that never restate it. */
+  private describe(entries: AgentSessionSlashCommand[]): AgentSessionSlashCommand[] {
+    return entries.map((entry) => ({ ...entry, ...this.details.get(entry.name) }))
+  }
+
   /** True when this frame replaced the catalog with a different one. */
   observe(message: Record<string, unknown>): boolean {
     let next: AgentSessionSlashCommand[]
     if (carriesCommandCatalog(message)) {
       this.hasSkillClassification = true
       this.hidden = new Set(names(message.terminal_slash_commands))
-      next = readClaudeSlashCommands(message)
+      next = this.describe(readClaudeSlashCommands(message))
       this.commandNames = new Set(
         next.filter((entry) => entry.kind === 'command').map((entry) => entry.name)
       )
@@ -95,13 +143,16 @@ export class ClaudeSlashCommandCatalog {
       message.subtype === 'commands_changed' &&
       Array.isArray(message.commands)
     ) {
-      next = descriptorNames(message.commands)
-        .filter((name) => !this.hidden.has(name))
-        .map((name) =>
-          this.hasSkillClassification
-            ? { name, kind: this.commandNames.has(name) ? 'command' : 'skill' }
-            : { name, kind: 'command', kindUnspecified: true }
-        )
+      this.details = descriptorDetails(message.commands)
+      next = this.describe(
+        descriptorNames(message.commands)
+          .filter((name) => !this.hidden.has(name))
+          .map((name) =>
+            this.hasSkillClassification
+              ? { name, kind: this.commandNames.has(name) ? 'command' : 'skill' }
+              : { name, kind: 'command', kindUnspecified: true }
+          )
+      )
     } else {
       return false
     }
@@ -112,7 +163,9 @@ export class ClaudeSlashCommandCatalog {
         (entry, index) =>
           entry.name === this.entries?.[index]?.name &&
           entry.kind === this.entries?.[index]?.kind &&
-          entry.kindUnspecified === this.entries?.[index]?.kindUnspecified
+          entry.kindUnspecified === this.entries?.[index]?.kindUnspecified &&
+          entry.description === this.entries?.[index]?.description &&
+          entry.argumentHint === this.entries?.[index]?.argumentHint
       )
     ) {
       return false

--- a/src/main/claude/claude-structured-session-commands.test.ts
+++ b/src/main/claude/claude-structured-session-commands.test.ts
@@ -55,8 +55,14 @@ it.each([
   const adapter = adapterFor(claude)
   try {
     await adapter.acquire({ identity: identityFor(), fence: 7, spawnToken: 'spawn-9' })
+    const described = commands[0]?.description
     expect(adapter.readCommands('session-1')).toEqual(
-      commands.map(({ name }) => ({ name, kind: 'command', kindUnspecified: true }))
+      commands.map(({ name, description }) => ({
+        name,
+        kind: 'command',
+        kindUnspecified: true,
+        ...(description ? { description } : {})
+      }))
     )
     expect(claude.connections[0].sent).toEqual([])
     expect(claude.connections[0].calls.map(({ subtype }) => subtype)).toEqual([
@@ -70,7 +76,10 @@ it.each([
       slash_commands: ['project:check'],
       skills: ['project:check']
     })
-    expect(adapter.readCommands('session-1')).toEqual([{ name: 'project:check', kind: 'skill' }])
+    // The stream init classifies the name; the control seed's text survives it.
+    expect(adapter.readCommands('session-1')).toEqual([
+      { name: 'project:check', kind: 'skill', ...(described ? { description: described } : {}) }
+    ])
   } finally {
     await adapter.closeSession('session-1')
   }

--- a/src/renderer/src/components/native-chat/NativeChatAutocompleteMenus.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatAutocompleteMenus.test.tsx
@@ -3,6 +3,8 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { NativeChatPickerMenu } from './NativeChatAutocompleteMenus'
+import { buildNativeChatPickerItems } from './native-chat-picker-items'
+import { sessionSlashCommandSuggestions } from '../../../../shared/native-chat-slash-commands'
 import type { ComposerAutocomplete } from './native-chat-composer-state'
 
 function autocomplete(
@@ -126,6 +128,45 @@ describe('NativeChatPickerMenu', () => {
       />
     )
     expect(screen.getAllByText('No matching commands')).toHaveLength(2)
+  })
+
+  it('shows the argument hint the provider reported beside the command token', () => {
+    render(
+      <NativeChatPickerMenu
+        autocomplete={autocomplete({
+          items: buildNativeChatPickerItems(
+            sessionSlashCommandSuggestions('claude', [
+              {
+                name: 'goal',
+                kind: 'command',
+                description: 'Set a goal and keep working until it is met',
+                argumentHint: '<objective>'
+              },
+              { name: 'clear', kind: 'command' },
+              { name: 'wordy', kind: 'command', argumentHint: `<${'a'.repeat(200)}>` }
+            ]),
+            [],
+            '',
+            '/'
+          )
+        })}
+        activeIndex={0}
+        listboxId="picker"
+        onChoose={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+    const goal = screen.getByRole('option', { name: /goal/i })
+    expect(goal.textContent).toContain('<objective>')
+    expect(goal.textContent).toContain('Set a goal and keep working until it is met')
+    // A command the report left hintless renders its row unchanged.
+    expect(screen.getByRole('option', { name: /clear/i }).textContent).toBe(
+      '/clearClear conversation history'
+    )
+    // A hint long enough to swamp the row is capped before it reaches the DOM.
+    expect(screen.getByRole('option', { name: /wordy/i }).textContent).toBe(
+      `/wordy<${'a'.repeat(79)}`
+    )
   })
 
   it('announces a successful empty skill result distinctly from loading', () => {

--- a/src/renderer/src/components/native-chat/NativeChatAutocompleteMenus.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatAutocompleteMenus.tsx
@@ -209,7 +209,14 @@ function PickerOption({
         <Package className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
       ) : null}
       <span className="min-w-0 flex-1">
-        <span className="block truncate font-mono font-medium">{item.token}</span>
+        <span className="flex min-w-0 items-baseline gap-1.5">
+          <span className="min-w-0 truncate font-mono font-medium">{item.token}</span>
+          {item.kind === 'command' && item.argumentHint ? (
+            <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+              {item.argumentHint}
+            </span>
+          ) : null}
+        </span>
         {item.description ? (
           <span className="block truncate text-xs text-muted-foreground">{item.description}</span>
         ) : null}

--- a/src/renderer/src/components/native-chat/native-chat-picker-items.ts
+++ b/src/renderer/src/components/native-chat/native-chat-picker-items.ts
@@ -21,6 +21,8 @@ export type NativeChatPickerItem =
       /** Exactly what a pick inserts — the form the agent invokes. */
       token: string
       description?: string
+      /** How the provider says the command is invoked, e.g. `<objective>`. */
+      argumentHint?: string
       skillCollision: boolean
     }
   | {
@@ -80,6 +82,9 @@ export function buildNativeChatPickerItems(
         name: command.name,
         token: `/${command.name}`,
         description: command.description ? sanitizePickerText(command.description, 240) : undefined,
+        argumentHint: command.argumentHint
+          ? sanitizePickerText(command.argumentHint, 80)
+          : undefined,
         skillCollision: sharedSigil && skillNames.has(command.name)
       },
       stableOrder: index

--- a/src/shared/agent-session-wire.ts
+++ b/src/shared/agent-session-wire.ts
@@ -343,6 +343,10 @@ export type AgentSessionSlashCommand = {
   kind: 'command' | 'skill'
   /** Membership is authoritative, but this provider report did not classify the name. */
   kindUnspecified?: true
+  /** Provider-authored row text; absent when the report carried names only. */
+  description?: string
+  /** Provider-authored argument sketch, e.g. `<issue-url>`. */
+  argumentHint?: string
 }
 
 /** The provider's own command surface, read per session. Additive read-only

--- a/src/shared/native-chat-slash-commands.test.ts
+++ b/src/shared/native-chat-slash-commands.test.ts
@@ -104,16 +104,24 @@ describe('a session that reports its own command surface', () => {
     ])
   })
 
-  it('keeps a reported description on a command the curated catalog never claims', () => {
+  it('keeps a reported description and argument hint the curated catalog never claims', () => {
     expect(
       sessionSlashCommandSuggestions('codex', [
         {
           name: 'opsx:apply',
           kind: 'command',
           description: 'Apply the plan',
+          argumentHint: '<plan-id>',
           kindUnspecified: true
         }
       ])
-    ).toEqual([{ name: 'opsx:apply', description: 'Apply the plan', kindUnspecified: true }])
+    ).toEqual([
+      {
+        name: 'opsx:apply',
+        description: 'Apply the plan',
+        argumentHint: '<plan-id>',
+        kindUnspecified: true
+      }
+    ])
   })
 })

--- a/src/shared/native-chat-slash-commands.test.ts
+++ b/src/shared/native-chat-slash-commands.test.ts
@@ -89,4 +89,31 @@ describe('a session that reports its own command surface', () => {
   it('splits skills out for the picker to group on its own', () => {
     expect(sessionReportedSkillNames(reported)).toEqual(['ref-oss'])
   })
+
+  it('prefers the description the session reported over the curated one', () => {
+    expect(
+      sessionSlashCommandSuggestions('claude', [
+        { name: 'clear', kind: 'command', description: 'Wipe the transcript' },
+        { name: 'goal', kind: 'command', description: 'Set or view the goal' },
+        { name: 'compact', kind: 'command' }
+      ])
+    ).toEqual([
+      { name: 'clear', description: 'Wipe the transcript' },
+      { name: 'goal', description: 'Set or view the goal' },
+      { name: 'compact', description: 'Summarize and compact the conversation' }
+    ])
+  })
+
+  it('keeps a reported description on a command the curated catalog never claims', () => {
+    expect(
+      sessionSlashCommandSuggestions('codex', [
+        {
+          name: 'opsx:apply',
+          kind: 'command',
+          description: 'Apply the plan',
+          kindUnspecified: true
+        }
+      ])
+    ).toEqual([{ name: 'opsx:apply', description: 'Apply the plan', kindUnspecified: true }])
+  })
 })

--- a/src/shared/native-chat-slash-commands.ts
+++ b/src/shared/native-chat-slash-commands.ts
@@ -12,6 +12,8 @@ export type SlashCommandSuggestion = {
   name: string
   /** Optional one-line description for the suggestion row. */
   description?: string
+  /** Provider-authored argument sketch, e.g. `<objective>`. */
+  argumentHint?: string
   kindUnspecified?: true
 }
 
@@ -111,6 +113,7 @@ export function sessionSlashCommandSuggestions(
       return {
         name: entry.name,
         ...(description ? { description } : {}),
+        ...(entry.argumentHint ? { argumentHint: entry.argumentHint } : {}),
         ...(entry.kindUnspecified ? { kindUnspecified: true as const } : {})
       }
     })

--- a/src/shared/native-chat-slash-commands.ts
+++ b/src/shared/native-chat-slash-commands.ts
@@ -93,9 +93,10 @@ export function getAgentSlashCommands(agent: AgentType): readonly SlashCommandSu
 }
 
 /** The command rows for a session that reports its own `/` surface. The report
- *  is the authority on WHICH commands exist; the curated catalog above is kept
- *  only as the description source for the names both know about. Skills are
- *  excluded — they render in the picker's own skills group. */
+ *  is the authority on WHICH commands exist and, when it carries one, on how a
+ *  command is described; the curated catalog above only covers the names whose
+ *  report is text-free. Skills are excluded — they render in the picker's own
+ *  skills group. */
 export function sessionSlashCommandSuggestions(
   agent: AgentType,
   reported: readonly AgentSessionSlashCommand[]
@@ -106,7 +107,7 @@ export function sessionSlashCommandSuggestions(
   return reported
     .filter((entry) => entry.kind === 'command')
     .map((entry) => {
-      const description = described.get(entry.name)
+      const description = entry.description ?? described.get(entry.name)
       return {
         name: entry.name,
         ...(description ? { description } : {}),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​232 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 |

<!-- /orca-pr-loc -->

## Before / After

In a Claude native chat, typing `/` lists the commands that session actually loaded — 48 of them on this machine. **Before this PR, 45 of those 48 rows were a bare command name with no explanation**, because Orca described them from a hand-written 5-entry map instead of the text Claude already sends. `/goal`, `/code-review`'s arguments, `/effort`'s options — none of it reached the picker.

**After, the picker shows what the provider reports**: 38 of the 48 commands carry a one-line description — every one of them the provider's own text, including the three the curated map used to answer for — and 19 also show the argument sketch beside the token (`/debug [issue description]`, `/code-review [low|medium|high|xhigh|max] [--fix] [--comment] …`). Nothing else about the row changed, and skill rows are untouched.

| Before (base commit) | After (this branch) |
| --- | --- |
| ![before-slash-all.png](https://github.com/user-attachments/assets/23dc3c96-c9fd-41ee-8119-97bbd36d11bc) | ![after-slash-all.png](https://github.com/user-attachments/assets/985c5349-7418-4fb2-bb91-50dcca206db2) |

The same list, filtered to `/g` — `/goal` goes from a bare token to an explained row:

| Before | After |
| --- | --- |
| ![before-slash-g.png](https://github.com/user-attachments/assets/a8652aeb-fc6b-4090-b912-739c51f3bfb6) | ![after-slash-g.png](https://github.com/user-attachments/assets/265bfcc4-79dd-4a1d-8291-57eb32e0fe8f) |

Counted from the rendered picker in both apps (same Mac, same Claude install, same session report of 67 entries = 48 commands + 19 skills):

| Rows in the `/` picker | Before | After |
| --- | --- | --- |
| Commands listed | 48 | 48 |
| …with a description | **3** | **38** |
| …with an argument hint | **0** | **19** |
| Skills listed / described | 19 / 19 | 19 / 19 (unchanged) |

## Problem

Native chat renders Claude's slash commands from the catalog the session reports, but the *descriptions* came from a hand-written map (`CLAUDE_COMMANDS` in `src/shared/native-chat-slash-commands.ts`) that covers 5 commands. A real session reports far more — 67 entries here — so most rows, `/goal` among them, rendered with a blank description. Only 3 of the 5 curated names were even in what this session reported.

The data was already arriving and being dropped: the provider's descriptors carry `name`, `description` and `argumentHint`, and `descriptorNames()` in `src/main/claude/claude-slash-command-catalog.ts` kept only `.name`.

## Fix

Carry the provider's own text through to the picker:

- `claude-slash-command-catalog.ts` — descriptor-shaped sources (control initialization, `commands_changed` with `commands`) now contribute `description`/`argumentHint`, bounded the same way names already are: non-strings, blanks, and values over 200 (description) / 100 (argument hint) characters are dropped rather than truncated, whitespace is collapsed to one line, and the map is capped at `MAX_COMMANDS`. A descriptor frame replaces the text wholesale, so a later report that omits a description clears it.
- The text is retained by name across the *name-only* frames. The stream `init` message carries `slash_commands` as plain strings, and it is what classifies commands vs skills — without this it would wipe the descriptions the control seed just supplied. Change detection now compares the text too, so a description-only refresh still republishes.
- `agent-session-wire.ts` — `AgentSessionSlashCommand` gains **optional** `description` / `argumentHint`. Nothing is renamed or made required, so old clients and old hosts are unaffected.
- `native-chat-slash-commands.ts` — `sessionSlashCommandSuggestions` prefers the reported description and falls back to the curated map. No entries were added to `CLAUDE_COMMANDS` / `CODEX_COMMANDS`: that map also drives which commands the structured dispatcher claims, so growing it would change dispatch behaviour. Keeping description sourcing separate from it is the point of the change.

The `terminal_slash_commands` hide-list and skill classification are unchanged, and a terminal-only command stays hidden however well the provider describes it (covered by a test).

`argumentHint` is rendered too, beside the command token — `/debug` reads `/debug [issue description]` on the token line, with "Enable debug logging for this session and help diagnose issues" below it. It uses the row's existing 11px muted tier — subordinate to the description, no new tokens or sizes — sits in a `min-w-0` flex row so it truncates instead of pushing the row wide, and the picker caps it at 80 characters before it reaches the DOM. The mobile composer is deliberately untouched (no file under `mobile/` is changed): it builds its rows from the curated catalog, not the session report, so a hint would never be populated there.

## Visual proof

Both screenshots above are the real app, driven over CDP with the window kept off screen:

- **After** — this branch (`5c8dbd0`), Orca dev instance on a fresh profile, real Claude structured native chat in a folder workspace, `/` typed into the composer. No message was sent; the catalog arrives with the session.
- **Before** — an identically-driven second instance built from a worktree at `12f2c6b` (an ancestor of this branch's base `721a269`, i.e. without these commits), same folder workspace, same Claude, same 48-command report.

The row counts in the table above were read out of the rendered DOM of each instance, per picker group.

What the screenshots do **not** show: the hint's 80-character cap and description truncation (asserted in the render test, not reproducible with the text this Claude reports), the Codex lane, and mobile.

## Ablation

**Argument hint rendering** (second commit): reverted the three source files that carry and render the hint, test kept — **1 failed / 6 passed** in `NativeChatAutocompleteMenus.test.tsx`. Restored: **7 passed**. The test drives the real chain — a wire entry through `sessionSlashCommandSuggestions` and `buildNativeChatPickerItems` into the rendered option — and asserts both the hint text and that an over-long hint arrives capped.

**Description sourcing** (first commit): reverted only the three source files, tests kept: **8 failed / 21 passed**. Restored: **29 passed / 0 failed** (`claude-slash-command-catalog.test.ts` + `native-chat-slash-commands.test.ts`). The one new test that passes in both states is the "describes nothing when the session reported names only" case, which asserts the unchanged string-only behaviour.

New coverage: descriptor text preserved; over-long / wrong-type / blank / multi-line text bounded; text carried across the name-only stream init; description-only change detected and later cleared; string-only reports still description-free; hide-list unchanged; reported description beating the curated one; curated fallback intact.

Two pre-existing tests were updated because they now legitimately carry descriptions (`claude-slash-command-catalog.test.ts` descriptor reload, and the `claude-structured-session-commands.test.ts` control-initialization seed, which now proves the text survives the stream init end-to-end through the adapter).

## Gates

- `pnpm test src/main/claude/claude-slash-command-catalog.test.ts src/shared/native-chat-slash-commands.test.ts src/main/claude/claude-structured-session-commands.test.ts` — 3 files, 33 tests passed.
- `pnpm tc` — exit 0.
- `pnpm run check:code-quality:changed` — passed, 0 new findings across 9 changed files (code quality, type-aware, React Doctor).
- `pnpm test src/renderer/src/components/native-chat …` — 130 files, 1355 tests passed.
- `pnpm test src/main/claude src/shared` — 8457 passed. The remaining failures are pre-existing: the same files fail with this change fully reverted at the base commit (`remote-runtime-shared-control-connection`, `feature-interactions`, `claude-tui-resume-real-binary.integration`, `claude-structured-real-cli`), and `claude-agent-sdk-exit-proof` / `claude-stream-json-connection` / `claude-agent-sdk-import-boundary` fail non-deterministically under load in both states (a different test name each run).
