### PR TITLE
feat(mobile): jump from the bottom of a long reply back to its prompt

### DIFF
--- a/mobile/src/session/MobileNativeChatJumpControl.tsx
+++ b/mobile/src/session/MobileNativeChatJumpControl.tsx
@@ -1,0 +1,43 @@
+import { Pressable } from 'react-native'
+import { ArrowDown, CornerLeftUp } from 'lucide-react-native'
+import { colors } from '../theme/mobile-theme'
+import { styles } from './mobile-native-chat-view-styles'
+
+/** The list's one floating control. Reading history, it returns to the latest
+ *  message; at the bottom of a reply taller than the screen, it goes up to the
+ *  prompt. The two never show together, so they share a slot. */
+export function MobileNativeChatJumpControl({
+  atBottom,
+  showPromptJump,
+  onScrollToLatest,
+  onJumpToPrompt
+}: {
+  atBottom: boolean
+  showPromptJump: boolean
+  onScrollToLatest: () => void
+  onJumpToPrompt: () => void
+}): React.JSX.Element | null {
+  if (!atBottom) {
+    return (
+      <Pressable
+        accessibilityLabel="Scroll to latest"
+        style={[styles.fab, styles.fabBottom]}
+        onPress={onScrollToLatest}
+      >
+        <ArrowDown size={18} color={colors.textPrimary} strokeWidth={2.2} />
+      </Pressable>
+    )
+  }
+  if (!showPromptJump) {
+    return null
+  }
+  return (
+    <Pressable
+      accessibilityLabel="Scroll to prompt"
+      style={[styles.fab, styles.fabBottom]}
+      onPress={onJumpToPrompt}
+    >
+      <CornerLeftUp size={18} color={colors.textPrimary} strokeWidth={2.2} />
+    </Pressable>
+  )
+}

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -34,6 +34,7 @@ vi.mock('lucide-react-native', () => ({
   ArrowDown: 'ArrowDown',
   ChevronsDownUp: 'ChevronsDownUp',
   ChevronsUpDown: 'ChevronsUpDown',
+  CornerLeftUp: 'CornerLeftUp',
   Square: 'Square'
 }))
 
@@ -258,6 +259,82 @@ describe('MobileNativeChatView', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  describe('floating jump control', () => {
+    const prompt: NativeChatMessage = {
+      id: 'u1',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'explain' }],
+      timestamp: 0,
+      source: 'transcript'
+    }
+
+    function list(): ReactTestInstance {
+      return renderer!.root.find((node) => node.type === 'FlatList')
+    }
+
+    function jumpControls(): string[] {
+      return renderer!.root
+        .findAll(
+          (node) =>
+            node.type === 'Pressable' &&
+            ['Scroll to latest', 'Scroll to prompt'].includes(node.props.accessibilityLabel)
+        )
+        .map((node) => node.props.accessibilityLabel as string)
+    }
+
+    async function reportViewable(...keys: string[]): Promise<void> {
+      await act(async () => {
+        list().props.onViewableItemsChanged({
+          viewableItems: keys.map((key) => ({ key, index: null, isViewable: true, item: null })),
+          changed: []
+        })
+      })
+    }
+
+    async function scrollAwayFromBottom(): Promise<void> {
+      await act(async () => {
+        list().props.onScroll({
+          nativeEvent: {
+            contentOffset: { y: 400 },
+            contentSize: { height: 2000 },
+            layoutMeasurement: { height: 600 }
+          }
+        })
+      })
+    }
+
+    it('offers the prompt at the bottom of a reply taller than the screen', async () => {
+      const folded = [prompt, assistantTurn('a1', 'long answer')]
+      await render({ messages: folded, folded })
+      expect(jumpControls()).toEqual([])
+
+      await reportViewable('a1')
+      expect(jumpControls()).toEqual(['Scroll to prompt'])
+
+      await reportViewable('u1', 'a1')
+      expect(jumpControls()).toEqual([])
+    })
+
+    it('swaps to Scroll to latest away from the bottom, never showing both', async () => {
+      const folded = [prompt, assistantTurn('a1', 'long answer')]
+      await render({ messages: folded, folded })
+      await reportViewable('a1')
+
+      await scrollAwayFromBottom()
+
+      expect(jumpControls()).toEqual(['Scroll to latest'])
+    })
+
+    it('stays hidden when the loaded transcript has no prompt', async () => {
+      const folded = [assistantTurn('a1', 'paged in mid-session')]
+      await render({ messages: folded, folded })
+
+      await reportViewable('a1')
+
+      expect(jumpControls()).toEqual([])
+    })
   })
 
   describe('structured turn status wiring', () => {

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler'
-import { ArrowDown, ChevronsDownUp, ChevronsUpDown, Square } from 'lucide-react-native'
+import { ChevronsDownUp, ChevronsUpDown, Square } from 'lucide-react-native'
 import type { AskAnswerSelection, AskPrompt } from '../../../src/shared/native-chat-ask'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import type { NativeChatSettledTurns } from '../../../src/shared/native-chat-turn-status'
@@ -24,6 +24,8 @@ import {
 import { useMobileNativeChatPinchGesture } from './use-mobile-native-chat-pinch-gesture'
 import { useMobileNativeChatTurnDisclosure } from './use-mobile-native-chat-turn-disclosure'
 import { useSettledMobileNativeChatInputLock } from './use-mobile-native-chat-input-lease'
+import { useMobileNativeChatPromptJump } from './use-mobile-native-chat-prompt-jump'
+import { MobileNativeChatJumpControl } from './MobileNativeChatJumpControl'
 import { MobileNativeChatTurnStatus } from './MobileNativeChatTurnStatus'
 import { MobileAgentWorkingIndicator } from './MobileAgentWorkingIndicator'
 import type { PendingNativeChatImage } from './mobile-native-chat-image-attachment'
@@ -258,6 +260,7 @@ export function MobileNativeChatView({
     },
     [hasMore, loadingEarlier, onLoadEarlier]
   )
+  const promptJump = useMobileNativeChatPromptJump(listRef, data, atBottom)
 
   // Per-turn "Thinking / Working for N / Worked for N" rows. The structured lane
   // owns them; the bridge lane keeps its three-dot indicator.
@@ -310,6 +313,8 @@ export function MobileNativeChatView({
               keyboardShouldPersistTaps="handled"
               onScroll={onScroll}
               scrollEventThrottle={32}
+              onViewableItemsChanged={promptJump.onViewableItemsChanged}
+              onScrollToIndexFailed={promptJump.onScrollToIndexFailed}
               onContentSizeChange={() => {
                 if (data.length > 0 && atBottom) {
                   listRef.current?.scrollToEnd({ animated: false })
@@ -349,16 +354,12 @@ export function MobileNativeChatView({
               }
             />
           </GestureDetector>
-          {/* Jump-to-latest control. */}
-          {!atBottom ? (
-            <Pressable
-              accessibilityLabel="Scroll to latest"
-              style={[styles.fab, styles.fabBottom]}
-              onPress={() => listRef.current?.scrollToEnd({ animated: true })}
-            >
-              <ArrowDown size={18} color={colors.textPrimary} strokeWidth={2.2} />
-            </Pressable>
-          ) : null}
+          <MobileNativeChatJumpControl
+            atBottom={atBottom}
+            showPromptJump={promptJump.showPromptJump}
+            onScrollToLatest={() => listRef.current?.scrollToEnd({ animated: true })}
+            onJumpToPrompt={promptJump.onJumpToPrompt}
+          />
         </GestureHandlerRootView>
       )}
       <MobileNativeChatPromptCard

--- a/mobile/src/session/mobile-native-chat-prompt-anchor.test.ts
+++ b/mobile/src/session/mobile-native-chat-prompt-anchor.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage, NativeChatRole } from '../../../src/shared/native-chat-types'
+import { mobileNativeChatLatestPromptIndex } from './mobile-native-chat-prompt-anchor'
+
+function transcript(...roles: NativeChatRole[]): NativeChatMessage[] {
+  return roles.map((role, index) => ({
+    id: `m${index}`,
+    role,
+    blocks: [{ type: 'text', text: role }],
+    timestamp: index,
+    source: 'transcript'
+  }))
+}
+
+describe('mobileNativeChatLatestPromptIndex', () => {
+  it('finds the newest prompt, not an older one', () => {
+    expect(
+      mobileNativeChatLatestPromptIndex(transcript('user', 'assistant', 'user', 'assistant'))
+    ).toBe(2)
+  })
+
+  it('skips tool and reasoning turns after the prompt', () => {
+    expect(
+      mobileNativeChatLatestPromptIndex(transcript('user', 'reasoning', 'tool', 'assistant'))
+    ).toBe(0)
+  })
+
+  it('returns the prompt itself when it is the last row', () => {
+    expect(mobileNativeChatLatestPromptIndex(transcript('assistant', 'user'))).toBe(1)
+  })
+
+  it('returns null when the loaded transcript has no prompt', () => {
+    expect(mobileNativeChatLatestPromptIndex(transcript('assistant', 'assistant'))).toBeNull()
+    expect(mobileNativeChatLatestPromptIndex([])).toBeNull()
+  })
+
+  it('ignores system turns, which are not prompts the user wrote', () => {
+    expect(mobileNativeChatLatestPromptIndex(transcript('system', 'assistant'))).toBeNull()
+  })
+})

--- a/mobile/src/session/mobile-native-chat-prompt-anchor.ts
+++ b/mobile/src/session/mobile-native-chat-prompt-anchor.ts
@@ -1,0 +1,10 @@
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+
+/** Index of the newest `user` message in the rendered list, or `null` when the
+ *  loaded transcript has none (paged in mid-session, or a scrape with no prompts). */
+export function mobileNativeChatLatestPromptIndex(
+  messages: readonly NativeChatMessage[]
+): number | null {
+  const index = messages.findLastIndex((message) => message.role === 'user')
+  return index === -1 ? null : index
+}

--- a/mobile/src/session/use-mobile-native-chat-prompt-jump.test.tsx
+++ b/mobile/src/session/use-mobile-native-chat-prompt-jump.test.tsx
@@ -1,0 +1,117 @@
+import { createElement, type ReactElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { FlatList } from 'react-native'
+import type { NativeChatMessage, NativeChatRole } from '../../../src/shared/native-chat-types'
+import { useMobileNativeChatPromptJump } from './use-mobile-native-chat-prompt-jump'
+
+function transcript(...roles: NativeChatRole[]): NativeChatMessage[] {
+  return roles.map((role, index) => ({
+    id: `m${index}`,
+    role,
+    blocks: [{ type: 'text', text: role }],
+    timestamp: index,
+    source: 'transcript'
+  }))
+}
+
+type Jump = ReturnType<typeof useMobileNativeChatPromptJump>
+
+function harness() {
+  const list = { scrollToIndex: vi.fn(), scrollToOffset: vi.fn() }
+  const listRef = { current: list as unknown as FlatList<NativeChatMessage> }
+  const seen: Jump[] = []
+  function Probe({ data }: { data: NativeChatMessage[] }): ReactElement | null {
+    seen.push(useMobileNativeChatPromptJump(listRef, data, true))
+    return null
+  }
+  const latest = (): Jump => seen.at(-1)!
+  return { list, seen, latest, Probe }
+}
+
+describe('useMobileNativeChatPromptJump', () => {
+  let tree: ReactTestRenderer | null = null
+
+  afterEach(() => {
+    act(() => tree?.unmount())
+    tree = null
+    vi.useRealTimers()
+  })
+
+  it('jumps to the newest prompt after a turn is appended', () => {
+    const { list, latest, Probe } = harness()
+    act(() => {
+      tree = create(createElement(Probe, { data: transcript('user', 'assistant') }))
+    })
+    act(() => {
+      tree!.update(
+        createElement(Probe, { data: transcript('user', 'assistant', 'user', 'assistant') })
+      )
+    })
+
+    latest().onJumpToPrompt()
+
+    expect(list.scrollToIndex).toHaveBeenCalledWith({ index: 2, viewPosition: 0, animated: true })
+  })
+
+  it('does not scroll when the loaded transcript has no prompt', () => {
+    const { list, latest, Probe } = harness()
+    act(() => {
+      tree = create(createElement(Probe, { data: transcript('assistant') }))
+    })
+
+    latest().onJumpToPrompt()
+
+    expect(list.scrollToIndex).not.toHaveBeenCalled()
+  })
+
+  it('keeps one onViewableItemsChanged across renders, which FlatList requires', () => {
+    const { seen, Probe } = harness()
+    act(() => {
+      tree = create(createElement(Probe, { data: transcript('user') }))
+    })
+    act(() => {
+      tree!.update(createElement(Probe, { data: transcript('user', 'assistant') }))
+    })
+
+    expect(new Set(seen.map((jump) => jump.onViewableItemsChanged)).size).toBe(1)
+  })
+
+  it('lands near an unmeasured row, then retries the exact jump', () => {
+    vi.useFakeTimers()
+    const { list, latest, Probe } = harness()
+    act(() => {
+      tree = create(createElement(Probe, { data: transcript('user', 'assistant') }))
+    })
+
+    latest().onScrollToIndexFailed({
+      index: 5,
+      highestMeasuredFrameIndex: 2,
+      averageItemLength: 100
+    })
+    expect(list.scrollToOffset).toHaveBeenCalledWith({ offset: 500, animated: true })
+    expect(list.scrollToIndex).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(120)
+    expect(list.scrollToIndex).toHaveBeenCalledWith({ index: 5, viewPosition: 0, animated: true })
+  })
+
+  it('drops a pending retry when the view unmounts', () => {
+    vi.useFakeTimers()
+    const { list, latest, Probe } = harness()
+    act(() => {
+      tree = create(createElement(Probe, { data: transcript('user', 'assistant') }))
+    })
+
+    latest().onScrollToIndexFailed({
+      index: 5,
+      highestMeasuredFrameIndex: 2,
+      averageItemLength: 100
+    })
+    act(() => tree!.unmount())
+    tree = null
+    vi.advanceTimersByTime(120)
+
+    expect(list.scrollToIndex).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-prompt-jump.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompt-jump.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import type { FlatList, ViewToken } from 'react-native'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { mobileNativeChatLatestPromptIndex } from './mobile-native-chat-prompt-anchor'
+
+const SCROLL_RETRY_MS = 120
+
+type ScrollToIndexFailure = {
+  index: number
+  highestMeasuredFrameIndex: number
+  averageItemLength: number
+}
+
+/** Drives the jump-to-prompt control: shown at the bottom of the list while the
+ *  newest prompt has scrolled out of view, i.e. under a reply taller than the screen. */
+export function useMobileNativeChatPromptJump(
+  listRef: RefObject<FlatList<NativeChatMessage> | null>,
+  data: readonly NativeChatMessage[],
+  atBottom: boolean
+): {
+  showPromptJump: boolean
+  onJumpToPrompt: () => void
+  onViewableItemsChanged: (info: { viewableItems: ViewToken[] }) => void
+  onScrollToIndexFailed: (info: ScrollToIndexFailure) => void
+} {
+  // Null until the list first reports, so the control cannot flash before layout.
+  const [viewableKeys, setViewableKeys] = useState<ReadonlySet<string> | null>(null)
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  useEffect(
+    () => () => {
+      if (retryTimerRef.current) {
+        clearTimeout(retryTimerRef.current)
+      }
+    },
+    []
+  )
+
+  // Why a ref: FlatList throws if onViewableItemsChanged changes identity after mount.
+  const onViewableItemsChanged = useRef((info: { viewableItems: ViewToken[] }) => {
+    setViewableKeys(new Set(info.viewableItems.map((token) => token.key)))
+  }).current
+
+  const promptIndex = mobileNativeChatLatestPromptIndex(data)
+  const promptId = promptIndex === null ? null : data[promptIndex].id
+  const showPromptJump =
+    atBottom && promptId !== null && viewableKeys !== null && !viewableKeys.has(promptId)
+
+  const onJumpToPrompt = useCallback(() => {
+    if (promptIndex !== null) {
+      listRef.current?.scrollToIndex({ index: promptIndex, viewPosition: 0, animated: true })
+    }
+  }, [listRef, promptIndex])
+
+  // An off-screen row may not be measured yet: land near it, then retry once laid out.
+  const onScrollToIndexFailed = useCallback(
+    (info: ScrollToIndexFailure) => {
+      listRef.current?.scrollToOffset({
+        offset: info.averageItemLength * info.index,
+        animated: true
+      })
+      if (retryTimerRef.current) {
+        clearTimeout(retryTimerRef.current)
+      }
+      retryTimerRef.current = setTimeout(() => {
+        retryTimerRef.current = null
+        listRef.current?.scrollToIndex({ index: info.index, viewPosition: 0, animated: true })
+      }, SCROLL_RETRY_MS)
+    },
+    [listRef]
+  )
+
+  return { showPromptJump, onJumpToPrompt, onViewableItemsChanged, onScrollToIndexFailed }
+}


### PR DESCRIPTION
## ELI5

On mobile, when an agent's reply is longer than the screen, the question that produced it scrolls far out of view. Getting back to it means a long manual scroll. Now, when you are at the bottom of such a reply, the round floating button in the corner points up to your prompt. Tap it and you land on the prompt; the same button turns into the existing "Scroll to latest" arrow, so one tap takes you back.

## What Changed

The floating control at the bottom-right of the native chat list now has two faces that never show together:

| Where you are | Floating control |
|---|---|
| Scrolled up from the bottom | **↓ Scroll to latest** (unchanged) |
| At the bottom, newest prompt still on screen | nothing (unchanged) |
| At the bottom, newest prompt scrolled out of view | **↰ Scroll to prompt** (new) |

- **`use-mobile-native-chat-prompt-jump.ts` (new)** — tracks which rows are on screen via `onViewableItemsChanged`, shows the control only when `atBottom` and the newest `user` row is not among them, and jumps with `scrollToIndex`. It stays hidden until the list first reports viewability, so it cannot flash before layout. `onScrollToIndexFailed` lands near an unmeasured row and retries once, with the retry timer cleared on unmount.
- **`MobileNativeChatJumpControl.tsx` (new)** — renders the one slot (`styles.fab` + `styles.fabBottom`, same icon size/colour as the existing arrow). "Scroll to latest" moved here unchanged so the mutual exclusion lives in one place.
- **`mobile-native-chat-prompt-anchor.ts` (new)** — `mobileNativeChatLatestPromptIndex`: the newest `user` row, or `null` when the loaded window has none (paged in mid-session), in which case the control stays hidden rather than jumping somewhere arbitrary.
- **`MobileNativeChatView.tsx`** — wiring only (+2 FlatList props, one hook call, the control). Logic lives outside the view, which is close to its `max-lines` cap.

## Why

#19769 removed the persistent per-message Copy / scroll-to-top row, and with it my earlier take on this feature (#19732, now closed), which added a third button to that row. This version follows the direction #19769 set: no persistent per-message chrome. It reuses the one floating control that survived, adds no new slot, and is only visible in the situation where it helps — at the end of a reply you cannot see the start of.

Only the newest prompt is targeted. Jumping to "the prompt of whatever row is on screen" while scrolled through history would need a second button next to ↓ and could point *down* when you are above the newest prompt, which is exactly the clutter and ambiguity #19769 removed.

## Linked Issue

Fixes #19731

## Visual Proof

iPhone 17 Pro simulator (iOS 26.5), dev-client build of this branch against the repo's mock server (`MOCK_NATIVE_CHAT=1`) serving a short turn followed by a long reply. `BEFORE` is the same session with `MobileNativeChatView.tsx` swapped back to `main` via Fast Refresh, so only that file differs.

**The floating-control corner:**

![before and after, close-up](https://raw.githubusercontent.com/yohangwak/orca/visual-proof-mobile-jump-to-prompt-fab/mobile-jump-to-prompt-fab/compare.png)

**Full screens — before, at the bottom, after tapping ↰, after tapping ↓:**

![full screens side by side](https://raw.githubusercontent.com/yohangwak/orca/visual-proof-mobile-jump-to-prompt-fab/mobile-jump-to-prompt-fab/side-by-side.png)

The captures live on a branch of my fork, so no binaries enter this diff.

## Testing

- [x] I manually tested these changes locally — iOS simulator against the mock server: at the bottom of the long reply ↰ appears; tapping it lands the prompt at the top and the slot becomes ↓; tapping ↓ returns to the bottom and ↰ reappears.
- [x] Automated tests added/updated, or explained why not below

New tests:

- `use-mobile-native-chat-prompt-jump.test.tsx` — jumps to the newest prompt after a turn is appended; no scroll without a prompt; `onViewableItemsChanged` keeps one identity across renders (FlatList throws otherwise); unmeasured-row fallback then exact retry; pending retry dropped on unmount.
- `MobileNativeChatView.test.ts` — ↰ appears only once viewability is reported and the prompt is off screen, hides when the prompt is visible; scrolling away from the bottom swaps it for ↓ and never shows both; stays hidden when the loaded transcript has no prompt.
- `mobile-native-chat-prompt-anchor.test.ts` — newest vs older prompt, tool/reasoning rows after the prompt, prompt as last row, no prompt, `system` rows ignored.

Each guard was ablated against the source to confirm the tests pin it: disabling the visibility condition, dropping the `useRef` around the viewability callback, and removing the retry-timer cleanup each turn exactly the corresponding test red.

Local results on this branch:

| | result |
|---|---|
| `pnpm exec vitest run src/session` (mobile) | 159 files, 1495 tests passed |
| `pnpm exec tsc --noEmit` (mobile) | pass |
| `pnpm typecheck:node` | pass |
| `oxlint` on changed files (incl. `max-lines`, verified to fire on a 450-line probe) | pass |
| pre-commit (`oxlint`, react-doctor, `oxfmt`) | pass |

Not covered: a reply that is still streaming (the mock serves a static transcript). Android was not run; the change is plain React Native with no platform branches.

## AI Disclosure

Written with Claude (Anthropic) — Claude Opus 5 — editing the code, running the checks and driving the simulator. The interaction design (bottom-only, shared slot, newest prompt only) was decided by me; all results above come from local runs.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Mobile only. No RPC, stream or published-content change, so no remote wire compatibility impact; desktop, SSH and folder workspaces are untouched.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — ran the mobile-scoped equivalents above; full-repo runs left to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFZzbnJGvStTqj7nHJrsfT
