### PR TITLE
fix(sidebar): let an agent row show the provider's own session title

### DIFF
--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.rows-cache.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.rows-cache.test.ts
@@ -3,6 +3,7 @@ import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { Worktree } from '../../../../shared/worktree/types'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { buildDashboardSnapshot, type DashboardSnapshotState } from './build-dashboard-snapshot'
 import { createWorktreeAgentRowsCache } from './worktree-agent-rows-cache'
 
@@ -138,5 +139,53 @@ describe('buildDashboardSnapshot rows cache', () => {
     buildDashboardSnapshot(state, NOW, { rowsCache: cache, rowsGeneration: 1 })
     buildDashboardSnapshot(state, NOW + 60_000, { rowsCache: cache, rowsGeneration: 2 })
     expect(cache.lastComputedWorktreeIds.sort()).toEqual(['w1', 'w2'])
+  })
+
+  it('refreshes a retained row from a provider title published to its current tab', () => {
+    const cache = createWorktreeAgentRowsCache()
+    const retainedTab = { ...tab('tab1', 'w1'), title: 'Claude ready' }
+    const retained: RetainedAgentEntry = {
+      entry: {
+        ...entry(PANE_1, 'tab1', 'w1'),
+        providerSession: { key: 'session_id', id: 'session-a' }
+      },
+      worktreeId: 'w1',
+      tab: retainedTab,
+      agentType: 'claude',
+      startedAt: NOW - 10_000
+    }
+    const initial: DashboardSnapshotState = {
+      ...baseState(),
+      tabsByWorktree: { w1: [retainedTab], w2: [tab('tab2', 'w2')] },
+      agentStatusByPaneKey: { [PANE_2]: entry(PANE_2, 'tab2', 'w2') },
+      retainedAgentsByPaneKey: { [PANE_1]: retained }
+    }
+    expect(
+      buildDashboardSnapshot(initial, NOW, { rowsCache: cache, rowsGeneration: 1 }).cards.find(
+        (card) => card.paneKey === PANE_1
+      )?.conversationName
+    ).toBeUndefined()
+
+    const titled: DashboardSnapshotState = {
+      ...initial,
+      tabsByWorktree: {
+        ...initial.tabsByWorktree,
+        w1: [
+          {
+            ...retainedTab,
+            aiVaultTitle: { agent: 'claude', sessionId: 'session-a', title: 'Provider title' }
+          }
+        ]
+      }
+    }
+    const refreshed = buildDashboardSnapshot(titled, NOW, {
+      rowsCache: cache,
+      rowsGeneration: 1
+    })
+
+    expect(cache.lastComputedWorktreeIds).toEqual(['w1'])
+    expect(refreshed.cards.find((card) => card.paneKey === PANE_1)?.conversationName).toBe(
+      'Provider title'
+    )
   })
 })

--- a/src/renderer/src/components/dashboard/dashboard-card-labels.test.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-labels.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
+import { rowConversationName } from './dashboard-card-labels'
+import type { DashboardAgentRow } from './useDashboardData'
+
+const LEAF_A = '11111111-1111-4111-8111-111111111111'
+const LEAF_B = '22222222-2222-4222-8222-222222222222'
+const TAB_ID = 'tab-1'
+const TAB: TerminalTab = {
+  id: TAB_ID,
+  ptyId: 'pty-1',
+  worktreeId: 'wt-1',
+  title: '\u2733 Linear work log',
+  customTitle: null,
+  aiVaultTitle: { agent: 'claude', sessionId: 'session-a', title: 'Provider title' },
+  color: null,
+  sortOrder: 0,
+  createdAt: 0
+}
+const LAYOUT: TerminalLayoutSnapshot = {
+  root: {
+    type: 'split',
+    direction: 'horizontal',
+    first: { type: 'leaf', leafId: LEAF_A },
+    second: { type: 'leaf', leafId: LEAF_B }
+  },
+  activeLeafId: LEAF_A,
+  expandedLeafId: null
+}
+
+function row(leafId: string, sessionId: string): DashboardAgentRow {
+  const paneKey = makePaneKey(TAB_ID, leafId)
+  const entry: AgentStatusEntry = {
+    state: 'working',
+    prompt: '',
+    updatedAt: 0,
+    stateStartedAt: 0,
+    stateHistory: [],
+    agentType: 'claude',
+    paneKey,
+    providerSession: { key: 'session_id', id: sessionId }
+  }
+  return { paneKey, entry, tab: TAB, agentType: 'claude', state: 'working', startedAt: 0 }
+}
+
+describe('rowConversationName', () => {
+  it('publishes a provider title only for the split-pane session that owns it', () => {
+    const paneTitles = { 1: '\u2733 Linear work log', 2: '\u2733 Redis cache strategy' }
+
+    expect(rowConversationName(row(LEAF_A, 'session-a'), false, LAYOUT, paneTitles)).toBe(
+      'Provider title'
+    )
+    expect(rowConversationName(row(LEAF_B, 'session-b'), false, LAYOUT, paneTitles)).toBe(
+      'Redis cache strategy'
+    )
+  })
+})

--- a/src/renderer/src/components/dashboard/dashboard-card-labels.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-labels.ts
@@ -49,7 +49,12 @@ export function rowConversationName(
     parsePaneKey(row.paneKey)?.leafId
   )
   return (
-    getAgentRowConversationName(row.tab, row.agentType, generatedTitlesEnabled, paneLiveTitle) ??
-    undefined
+    getAgentRowConversationName(
+      row.tab,
+      row.agentType,
+      generatedTitlesEnabled,
+      paneLiveTitle,
+      row.entry.providerSession?.id
+    ) ?? undefined
   )
 }

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
@@ -197,6 +197,24 @@ describe('useAgentRowConversationName', () => {
       )
     })
 
+    it('gives a provider session title only to the pane that owns that session', () => {
+      setSplitStore('\u2733 Linear work log')
+      storeState.current.tabsByWorktree['wt-1'][0] = {
+        id: 'tab-1',
+        worktreeId: 'wt-1',
+        customTitle: null,
+        title: '\u2733 Linear work log',
+        aiVaultTitle: { agent: 'claude', sessionId: 'session-a', title: 'Provider title' }
+      }
+      const sessionA = splitRow(LEAF_A, '\u2733 Linear work log')
+      sessionA.entry.providerSession = { key: 'session_id', id: 'session-a' }
+      const sessionB = splitRow(LEAF_B, '\u2733 Linear work log')
+      sessionB.entry.providerSession = { key: 'session_id', id: 'session-b' }
+
+      expect(useAgentRowConversationName(sessionA)).toBe('Provider title')
+      expect(useAgentRowConversationName(sessionB)).toBe('Redis cache strategy')
+    })
+
     it('does not rename the sibling row when the other pane is clicked', () => {
       // Clicking pane B re-syncs the tab title to B's; both rows must be unmoved.
       setSplitStore('\u2733 Redis cache strategy')

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
@@ -64,6 +64,7 @@ export function useAgentRowConversationName(agent: DashboardAgentRow): string | 
     liveTab ?? agent.tab,
     agent.agentType,
     generatedTitlesEnabled,
-    paneLiveTitle
+    paneLiveTitle,
+    agent.entry.providerSession?.id
   )
 }

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -91,17 +91,19 @@ function makeSplitPaneLayout(firstLeafId: string, secondLeafId: string): Termina
 
 describe('buildWorktreeAgentRows', () => {
   it('includes retained rows even when their original tab is no longer current', () => {
+    const retained = makeRetained(ORPHAN_PANE_KEY, 'wt-1', 1000)
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1')],
       entries: [],
       // Why: useWorktreeAgentRows filters retained snapshots by worktreeId, not
       // current tab membership. This is the sidebar behavior that sleep cleanup
       // must counter by dropping worktree-scoped retained rows.
-      retained: [makeRetained(ORPHAN_PANE_KEY, 'wt-1', 1000)],
+      retained: [retained],
       now: 2000
     })
 
     expect(rows.map((row) => row.paneKey)).toEqual([ORPHAN_PANE_KEY])
+    expect(rows[0].tab).toBe(retained.tab)
     expect(rows[0].state).toBe('done')
   })
 

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -78,7 +78,7 @@ function isRetainedLegacyAliasOfSeenStablePane(args: {
 
 function markSeenPaneKeyForCurrentTab(args: {
   paneKey: string | undefined
-  currentTabIds: Set<string>
+  currentTabsById: ReadonlyMap<string, TerminalTab>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   seenPaneKeys: Set<string>
 }): void {
@@ -87,14 +87,14 @@ function markSeenPaneKeyForCurrentTab(args: {
   }
   const parsed = parsePaneKey(args.paneKey)
   if (parsed) {
-    if (args.currentTabIds.has(parsed.tabId)) {
+    if (args.currentTabsById.has(parsed.tabId)) {
       args.seenPaneKeys.add(args.paneKey)
     }
     return
   }
 
   const legacy = parseLegacyNumericPaneKey(args.paneKey)
-  if (!legacy || !args.currentTabIds.has(legacy.tabId)) {
+  if (!legacy || !args.currentTabsById.has(legacy.tabId)) {
     return
   }
   args.seenPaneKeys.add(args.paneKey)
@@ -112,7 +112,7 @@ function markCompletedWorkerParentPaneKeysSeen(args: {
   retained: RetainedAgentEntry[]
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
-  currentTabIds: Set<string>
+  currentTabsById: ReadonlyMap<string, TerminalTab>
   seenPaneKeys: Set<string>
 }): void {
   const markEntry = (entry: AgentStatusEntry): void => {
@@ -124,7 +124,7 @@ function markCompletedWorkerParentPaneKeysSeen(args: {
     // visible parent pane still has a stale spinner title.
     markSeenPaneKeyForCurrentTab({
       paneKey: rowEntry.orchestration?.parentPaneKey,
-      currentTabIds: args.currentTabIds,
+      currentTabsById: args.currentTabsById,
       terminalLayoutsByTabId: args.terminalLayoutsByTabId,
       seenPaneKeys: args.seenPaneKeys
     })
@@ -150,7 +150,7 @@ export function buildWorktreeAgentRows(args: {
 }): DashboardAgentRow[] {
   const rows: DashboardAgentRow[] = []
   const seenPaneKeys = new Set<string>()
-  const currentTabIds = new Set(args.tabs.map((tab) => tab.id))
+  const currentTabsById = new Map(args.tabs.map((tab) => [tab.id, tab] as const))
 
   const entriesByTabId = new Map<string, AgentStatusEntry[]>()
   for (const entry of args.entries) {
@@ -199,7 +199,7 @@ export function buildWorktreeAgentRows(args: {
     retained: args.retained,
     runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey,
     terminalLayoutsByTabId: args.terminalLayoutsByTabId,
-    currentTabIds,
+    currentTabsById,
     seenPaneKeys
   })
 
@@ -256,11 +256,12 @@ export function buildWorktreeAgentRows(args: {
       ra.entry,
       args.runtimeAgentOrchestrationByPaneKey
     )
+    const tab = currentTabsById.get(ra.tab.id) ?? ra.tab
     rows.push({
       paneKey: rowEntry.paneKey,
       entry: rowEntry,
-      tab: ra.tab,
-      agentType: resolveRowAgentType(rowEntry, ra.tab),
+      tab,
+      agentType: resolveRowAgentType(rowEntry, tab),
       rowSource: 'retained',
       state: 'done',
       startedAt: ra.startedAt

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -31,6 +31,43 @@ describe('getAgentRowConversationName', () => {
     )
   })
 
+  it('shows the provider session title from the transcript, so the row matches its tab', () => {
+    const tab = makeTab({
+      aiVaultTitle: { agent: 'claude', sessionId: 's1', title: 'Fix the lease probe' },
+      generatedTitle: 'Fix intake flow',
+      title: '\u2733 Investigate replay bug'
+    })
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Fix the lease probe')
+  })
+
+  it('lets a manual rename and a quick command still outrank the provider title', () => {
+    const vault = { agent: 'claude' as const, sessionId: 's1', title: 'Fix the lease probe' }
+    expect(
+      getAgentRowConversationName(
+        makeTab({ aiVaultTitle: vault, customTitle: 'Mine' }),
+        'claude',
+        true
+      )
+    ).toBe('Mine')
+    expect(
+      getAgentRowConversationName(
+        makeTab({ aiVaultTitle: vault, quickCommandLabel: 'Run tests' }),
+        'claude',
+        true
+      )
+    ).toBe('Run tests')
+  })
+
+  it('keeps a cwd-shaped provider title that the live-title sanitizer would discard', () => {
+    // `auth/login` is a real session name; as a scraped live title it would be read as a cwd.
+    const tab = makeTab({
+      aiVaultTitle: { agent: 'claude', sessionId: 's1', title: 'auth/login' },
+      title: '\u2733 Investigate replay bug'
+    })
+    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('auth/login')
+    expect(getAgentRowConversationName(makeTab({ title: 'auth/login' }), 'claude', true)).toBeNull()
+  })
+
   it('uses the generated title only when generated titles are enabled', () => {
     const tab = makeTab({ generatedTitle: 'Fix intake flow', title: '✳ Investigate replay bug' })
     expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Fix intake flow')

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -31,13 +31,15 @@ describe('getAgentRowConversationName', () => {
     )
   })
 
-  it('shows the provider session title from the transcript, so the row matches its tab', () => {
+  it("shows the title owned by the row's provider session", () => {
     const tab = makeTab({
       aiVaultTitle: { agent: 'claude', sessionId: 's1', title: 'Fix the lease probe' },
       generatedTitle: 'Fix intake flow',
       title: '\u2733 Investigate replay bug'
     })
-    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Fix the lease probe')
+    expect(getAgentRowConversationName(tab, 'claude', true, undefined, 's1')).toBe(
+      'Fix the lease probe'
+    )
   })
 
   it('lets a manual rename and a quick command still outrank the provider title', () => {
@@ -46,14 +48,18 @@ describe('getAgentRowConversationName', () => {
       getAgentRowConversationName(
         makeTab({ aiVaultTitle: vault, customTitle: 'Mine' }),
         'claude',
-        true
+        true,
+        undefined,
+        's1'
       )
     ).toBe('Mine')
     expect(
       getAgentRowConversationName(
         makeTab({ aiVaultTitle: vault, quickCommandLabel: 'Run tests' }),
         'claude',
-        true
+        true,
+        undefined,
+        's1'
       )
     ).toBe('Run tests')
   })
@@ -64,7 +70,7 @@ describe('getAgentRowConversationName', () => {
       aiVaultTitle: { agent: 'claude', sessionId: 's1', title: 'auth/login' },
       title: '\u2733 Investigate replay bug'
     })
-    expect(getAgentRowConversationName(tab, 'claude', true)).toBe('auth/login')
+    expect(getAgentRowConversationName(tab, 'claude', true, undefined, 's1')).toBe('auth/login')
     expect(getAgentRowConversationName(makeTab({ title: 'auth/login' }), 'claude', true)).toBeNull()
   })
 

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -1,7 +1,8 @@
 // Resolves the stable "conversation name" an agent row can show instead of the
 // live last-message preview. Sources, in the same precedence the tab bar uses
 // (tab-title-resolution.ts): manual rename → quick-command label → OpenCode's
-// semantic session title → Orca's generated title → the agent-set live title.
+// semantic session title → provider session title → Orca's generated title →
+// the agent-set live title.
 // Live titles are accepted only when they carry a real name — pure status,
 // identity-echo, and spinner/cwd titles yield null so callers keep the
 // last-message label.
@@ -119,7 +120,8 @@ export function getAgentRowConversationName(
   // this row's own pane title, or `null` when none resolves; `undefined` (a
   // single-pane tab) keeps the tab title. Tab-owned names above are unaffected:
   // the user gave those to the whole tab and they do not flip on focus.
-  paneLiveTitle?: string | null
+  paneLiveTitle?: string | null,
+  providerSessionId?: string
 ): string | null {
   const customTitle = tab.customTitle?.trim()
   if (customTitle) {
@@ -134,11 +136,16 @@ export function getAgentRowConversationName(
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle
   }
-  // The provider's own name for this session, read off its transcript. Placed exactly where the tab
-  // strip places it (`resolveUnifiedTabLabel`), so a row and its tab cannot disagree.
-  const aiVaultTitle = tab.aiVaultTitle?.title.trim()
-  if (aiVaultTitle) {
-    return aiVaultTitle
+  // Provider titles belong to their session, not every pane in the tab.
+  const aiVaultTitle = tab.aiVaultTitle
+  const providerTitle = aiVaultTitle?.title.trim()
+  if (
+    aiVaultTitle &&
+    providerTitle &&
+    aiVaultTitle.agent === agentType &&
+    aiVaultTitle.sessionId === providerSessionId
+  ) {
+    return providerTitle
   }
   const generatedTitle = generatedTitlesEnabled ? tab.generatedTitle?.trim() : ''
   if (generatedTitle) {

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -15,7 +15,7 @@ import type { TerminalTab } from './terminal-tab-types'
 
 export type ConversationNameTab = Pick<
   TerminalTab,
-  'customTitle' | 'quickCommandLabel' | 'generatedTitle' | 'title' | 'defaultTitle'
+  'customTitle' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedTitle' | 'title' | 'defaultTitle'
 >
 
 // Why: synthetic status titles ("Codex ready", "Cursor - action required") are
@@ -133,6 +133,12 @@ export function getAgentRowConversationName(
     paneLiveTitle === undefined ? (tab.title?.trim() ?? '') : (paneLiveTitle?.trim() ?? '')
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle
+  }
+  // The provider's own name for this session, read off its transcript. Placed exactly where the tab
+  // strip places it (`resolveUnifiedTabLabel`), so a row and its tab cannot disagree.
+  const aiVaultTitle = tab.aiVaultTitle?.title.trim()
+  if (aiVaultTitle) {
+    return aiVaultTitle
   }
   const generatedTitle = generatedTitlesEnabled ? tab.generatedTitle?.trim() : ''
   if (generatedTitle) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​171 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

## ELI5

Open a Claude or Codex agent in a terminal and look at two places: the tab, and the agent row in the left worktree sidebar. **They show different names for the same session.**

The tab shows the name the provider itself recorded for that conversation. The sidebar row shows whatever text the terminal happened to be printing, cleaned up by a heuristic. This makes the row read the same name the tab does.

## What Changed

One tier, added to the sidebar row's resolver at exactly the rank the tab strip already uses:

```
customTitle → quickCommandLabel → OpenCode live → [aiVaultTitle] → generatedTitle → sanitized live title
```

`getAgentRowConversationName` had **zero** references to `aiVaultTitle`, while `resolveUnifiedTabLabel` has had that tier all along. That is the whole divergence. The data was already on the tab — the row resolver simply never looked at it.

Nine production lines: the tier, and `aiVaultTitle` added to the `ConversationNameTab` pick.

## Why

Two resolvers grew up separately and were never reconciled, so today a terminal Claude agent's tab reads its title out of the transcript while its row reads the scraped OSC title. Same agent, same instant, two strings.

The row's existing fallback also actively discards good names. `conversationNameFromLiveTitle` runs `isCwdLikeTitle`, which nulls any single token containing a slash — correct for a spinner-plus-cwd title scraped off a pty, wrong for a real session name like `auth/login`. Reading the provider's recorded title never reaches that guard, because it is not a scraped title. The sanitizer keeps full authority over live titles, where it belongs.

## Linked Issue

N/A — falls out of the structured-chat naming work; this is the terminal-agent half of making one name serve every surface.

## Visual Proof

Behaviour change is real but text-only and requires a Claude or Codex session whose transcript carries a title. To see it: open a terminal Claude agent, let it run a turn, compare the tab label with that agent's row in the left sidebar. Before: the row shows the spinner-stripped live title (or nothing, if it looks cwd-shaped). After: both read the transcript title.

I have not attached a screenshot because reproducing it needs a real provider session with a recorded title; the behaviour is pinned by tests instead, including the `auth/login` case that is nulled today.

## Testing

- **Typecheck:** `tc:node`, `tc:cli`, `tc:web` all clean, run sequentially.
- **Tests:** 3 new cases in `agent-row-conversation-name.test.ts` (15 total in that file). Full affected suites: **10,729 passed / 0 failed** across `src/shared`, sidebar and dashboard.
- **Ablation:** removing the tier reddens 2 of the 3 new tests; restored, all 15 pass. Guard symbol grepped back after restore.
- **Platforms:** pure string resolution — no paths, shells, processes or platform branches.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

### Precedence is unchanged above this tier

A manual rename and a quick-command label still outrank the provider title, exactly as on the tab strip. Both are pinned by a test.

### Which agents this actually affects

The vault title path is gated to Claude and Codex (`isAiVaultTitleAgent`) and additionally requires a proven provider session id. So rows for Cursor, Gemini, Kimi, Cline and the rest are unchanged — they have no `aiVaultTitle` to read and fall through to today's behaviour. This PR does not widen that gate.

### Rows with no live tab are unchanged

A row whose tab is not present in this renderer resolves against a synthesised tab that carries no `aiVaultTitle`, so it falls through exactly as it does today. Not a regression; simply out of reach until that row has a real tab.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Security / cross-platform / SSH / mobile:** no new I/O, no paths, no processes. The title is resolved by the execution host that owns the session, unchanged by this PR.
- **Performance:** one optional-chain read and a `trim()` on a path that already performed several.
- **Backwards compatibility:** additive tier; no field, wire shape or stored value changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally
