### PR TITLE
feat(cmd-j): compact palette location layout

### DIFF
--- a/src/renderer/src/components/worktree-jump-palette-browser-simulator-rows.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-browser-simulator-rows.tsx
@@ -161,6 +161,7 @@ export function WorktreeJumpPaletteBrowserRow({
               secondaryText={result.secondaryText}
               secondaryRanges={result.secondaryRanges}
               secondaryMatches={result.secondaryMatches}
+              elideSecondaryPathHead
               sessionAge={browserSessionAge}
               leadingBadges={
                 <>

--- a/src/renderer/src/components/worktree-jump-palette-browser-simulator-rows.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-browser-simulator-rows.tsx
@@ -1,15 +1,14 @@
 import type React from 'react'
 import { Smartphone } from 'lucide-react'
 import { CommandItem } from '@/components/ui/command'
-import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { getPaletteHostBadge } from '@/components/cmd-j/palette-host-badge'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import type { BrowserPaletteItem, SimulatorPaletteItem } from './worktree-jump-palette-model'
 import type { WorktreeJumpPaletteController } from './use-worktree-jump-palette-controller'
 import {
-  HighlightedText,
   PaletteHostBadgeChip,
+  PaletteLocationChip,
   PaletteOpenTabPrimaryLine,
   PaletteRowShortcutBadge
 } from './worktree-jump-palette-primitives'
@@ -67,8 +66,6 @@ export function WorktreeJumpPaletteSimulatorRow({
               secondaryText={result.secondaryText}
               secondaryRanges={result.secondaryRanges}
               secondaryMatches={result.secondaryMatches}
-              worktreeName={result.worktreeName}
-              worktreeRanges={result.worktreeRanges}
               sessionAge={simulatorSessionAge}
               leadingBadges={
                 <>
@@ -94,16 +91,15 @@ export function WorktreeJumpPaletteSimulatorRow({
               </span>
             ) : null}
           </div>
-          <div className="flex shrink-0 items-center gap-1.5">
+          <div className="flex min-w-0 max-w-[40%] items-center justify-end gap-1.5">
             <PaletteHostBadgeChip badge={simulatorHostBadge} />
-            {simulatorRepoName && (
-              <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
-                <RepoBadgeMark color={simulatorRepo?.badgeColor} />
-                <span className="truncate">
-                  <HighlightedText text={simulatorRepoName} matchRanges={result.repoRanges} />
-                </span>
-              </span>
-            )}
+            <PaletteLocationChip
+              repoName={simulatorRepoName}
+              repoRanges={result.repoRanges}
+              repoColor={simulatorRepo?.badgeColor}
+              worktreeName={result.worktreeName}
+              worktreeRanges={result.worktreeRanges}
+            />
             <PaletteRowShortcutBadge
               index={controller.recentTabShortcutIndexByItem.get(entry)}
               modifierKeys={controller.digitShortcutModifiers}
@@ -165,8 +161,6 @@ export function WorktreeJumpPaletteBrowserRow({
               secondaryText={result.secondaryText}
               secondaryRanges={result.secondaryRanges}
               secondaryMatches={result.secondaryMatches}
-              worktreeName={result.worktreeName}
-              worktreeRanges={result.worktreeRanges}
               sessionAge={browserSessionAge}
               leadingBadges={
                 <>
@@ -187,16 +181,15 @@ export function WorktreeJumpPaletteBrowserRow({
               }
             />
           </div>
-          <div className="flex shrink-0 items-center gap-1.5">
+          <div className="flex min-w-0 max-w-[40%] items-center justify-end gap-1.5">
             <PaletteHostBadgeChip badge={browserHostBadge} />
-            {browserRepoName && (
-              <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
-                <RepoBadgeMark color={browserRepo?.badgeColor} />
-                <span className="truncate">
-                  <HighlightedText text={browserRepoName} matchRanges={result.repoRanges} />
-                </span>
-              </span>
-            )}
+            <PaletteLocationChip
+              repoName={browserRepoName}
+              repoRanges={result.repoRanges}
+              repoColor={browserRepo?.badgeColor}
+              worktreeName={result.worktreeName}
+              worktreeRanges={result.worktreeRanges}
+            />
             <PaletteRowShortcutBadge
               index={controller.recentTabShortcutIndexByItem.get(entry)}
               modifierKeys={controller.digitShortcutModifiers}

--- a/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
@@ -448,8 +448,13 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
     const title = row?.querySelector('[data-slot="palette-open-tab-title"]')
     const worktree = row?.querySelector('[data-slot="palette-open-tab-worktree"]')
     expect(title?.textContent).toBe(longTitle)
-    expect(title?.classList.contains('flex-auto')).toBe(true)
+    expect(title?.classList.contains('min-w-0')).toBe(true)
+    expect(title?.classList.contains('shrink-0')).toBe(false)
     expect(worktree?.textContent).toBe('user-support')
+    const locationChip = worktree?.closest('[data-slot="palette-location-chip"]')
+    expect(locationChip).not.toBeNull()
+    expect(locationChip?.parentElement?.classList.contains('max-w-[40%]')).toBe(true)
+    expect(locationChip?.parentElement?.classList.contains('min-w-0')).toBe(true)
     expect(worktree?.compareDocumentPosition(title ?? document.createElement('span'))).toBe(
       Node.DOCUMENT_POSITION_PRECEDING
     )

--- a/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
@@ -460,7 +460,7 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
     )
   })
 
-  it('tags the worktree rail label as a branch when the visible name is the branch', async () => {
+  it('shows the branch in the location chip when the workspace display name is empty', async () => {
     await renderPalette({
       worktreesByRepo: {
         'repo-1': [makeWorktree('wt-tabs', '', { displayName: '' })]

--- a/src/renderer/src/components/worktree-jump-palette-primitives.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-primitives.test.tsx
@@ -3,7 +3,7 @@
 import { cleanup, render, type RenderResult, screen } from '@testing-library/react'
 import { afterEach, expect, it } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
-import { PaletteOpenTabPrimaryLine } from './worktree-jump-palette-primitives'
+import { PaletteLocationChip, PaletteOpenTabPrimaryLine } from './worktree-jump-palette-primitives'
 
 afterEach(() => cleanup())
 
@@ -18,8 +18,6 @@ function renderPrimaryLine(
         secondaryText="src/app.ts"
         secondaryRanges={[]}
         secondaryMatches={secondaryMatches}
-        worktreeName="Workspace"
-        worktreeRanges={[]}
       />
     </TooltipProvider>
   )
@@ -44,4 +42,93 @@ it('renders no badge when every secondary match is already shown', () => {
   renderPrimaryLine([{ text: 'src/app.ts', ranges: [] }])
 
   expect(screen.queryByText(/^\+\d+$/)).toBeNull()
+})
+
+it('elides a deep path from the head so the matched tail stays visible', () => {
+  const path = '/Users/me/projects/orca/new-create-button-design/proposals/create-button.html'
+  const start = path.indexOf('create-butt')
+  const { container } = render(
+    <TooltipProvider>
+      <PaletteOpenTabPrimaryLine
+        title="Design"
+        titleRanges={[]}
+        secondaryText={path}
+        secondaryRanges={[{ start, end: start + 'create-butt'.length }]}
+      />
+    </TooltipProvider>
+  )
+
+  const secondary = container.querySelector('[data-slot="palette-open-tab-secondary"]')
+  expect(secondary?.textContent).toBe(path)
+  const [head, tail] = Array.from(secondary?.children ?? [])
+  expect(head?.textContent).toBe('/Users/me/projects/orca')
+  expect(tail?.textContent).toBe('/new-create-button-design/proposals/create-button.html')
+  expect(tail?.querySelector('.font-semibold')?.textContent).toBe('create-butt')
+})
+
+it('folds the worktree into the repo chip and drops it when it repeats the repo name', () => {
+  const { container, rerender } = render(
+    <TooltipProvider>
+      <PaletteLocationChip
+        repoName="orca"
+        repoRanges={[]}
+        worktreeName="new-create-button-design"
+        worktreeRanges={[]}
+      />
+    </TooltipProvider>
+  )
+  expect(container.querySelector('[data-slot="palette-location-chip"]')?.textContent).toBe(
+    'orca·new-create-button-design'
+  )
+  const chip = container.querySelector('[data-slot="palette-location-chip"]')
+  const repo = container.querySelector('[data-slot="palette-location-repo"]')
+  const worktree = container.querySelector('[data-slot="palette-open-tab-worktree"]')
+  expect(chip?.className).toContain('overflow-hidden')
+  expect(chip?.className).toContain('min-w-0')
+  expect(repo?.className).toContain('max-w-[55%]')
+  expect(repo?.className).toContain('min-w-[3ch]')
+  expect(worktree?.className).toContain('min-w-[3ch]')
+  expect(worktree?.getAttribute('data-state')).toBeNull()
+  expect(worktree?.getAttribute('tabindex')).toBeNull()
+
+  rerender(
+    <TooltipProvider>
+      <PaletteLocationChip
+        repoName="orca"
+        repoRanges={[]}
+        worktreeName="orca"
+        worktreeRanges={[{ start: 0, end: 4 }]}
+      />
+    </TooltipProvider>
+  )
+  expect(container.querySelector('[data-slot="palette-location-chip"]')?.textContent).toBe('orca')
+  expect(
+    container.querySelector('[data-slot="palette-location-repo"] .font-semibold')?.textContent
+  ).toBe('orca')
+})
+
+it('keeps a short title at its natural width so the session age stays beside it', () => {
+  const { container } = render(
+    <TooltipProvider>
+      <PaletteOpenTabPrimaryLine
+        title="Terminal 1"
+        titleRanges={[]}
+        secondaryText=""
+        secondaryRanges={[]}
+        sessionAge="2d"
+      />
+    </TooltipProvider>
+  )
+
+  const title = container.querySelector('[data-slot="palette-open-tab-title"]')
+  expect(title?.className).toContain('min-w-0')
+  expect(title?.className).not.toContain('shrink-0')
+})
+
+it('caps the title only when it shares the line with secondary text', () => {
+  const { container } = renderPrimaryLine([])
+
+  const title = container.querySelector('[data-slot="palette-open-tab-title"]')
+  expect(title?.className).toContain('max-w-[62%]')
+  expect(title?.className).toContain('shrink-0')
 })

--- a/src/renderer/src/components/worktree-jump-palette-primitives.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-primitives.test.tsx
@@ -54,6 +54,7 @@ it('elides a deep path from the head so the matched tail stays visible', () => {
         titleRanges={[]}
         secondaryText={path}
         secondaryRanges={[{ start, end: start + 'create-butt'.length }]}
+        elideSecondaryPathHead
       />
     </TooltipProvider>
   )
@@ -64,6 +65,27 @@ it('elides a deep path from the head so the matched tail stays visible', () => {
   expect(head?.textContent).toBe('/Users/me/projects/orca')
   expect(tail?.textContent).toBe('/new-create-button-design/proposals/create-button.html')
   expect(tail?.querySelector('.font-semibold')?.textContent).toBe('create-butt')
+})
+
+it('keeps slash-separated agent snippets intact', () => {
+  const snippet =
+    'Ran pnpm test src/renderer/src/components/worktree-jump-palette-primitives.test.tsx'
+  const start = snippet.indexOf('worktree-jump')
+  const { container } = render(
+    <TooltipProvider>
+      <PaletteOpenTabPrimaryLine
+        title="Agent session"
+        titleRanges={[]}
+        secondaryText={snippet}
+        secondaryRanges={[{ start, end: start + 'worktree-jump'.length }]}
+      />
+    </TooltipProvider>
+  )
+
+  const secondary = container.querySelector('[data-slot="palette-open-tab-secondary"]')
+  expect(secondary?.textContent).toBe(snippet)
+  expect(secondary?.children).toHaveLength(1)
+  expect(secondary?.querySelector('.font-semibold')?.textContent).toBe('worktree-jump')
 })
 
 it('folds the worktree into the repo chip and drops it when it repeats the repo name', () => {

--- a/src/renderer/src/components/worktree-jump-palette-primitives.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-primitives.tsx
@@ -70,12 +70,14 @@ export function HighlightedText({
 
 function PaletteOpenTabSecondaryText({
   text,
-  ranges
+  ranges,
+  elidePathHead
 }: {
   text: string
   ranges: readonly MatchRange[]
+  elidePathHead: boolean
 }): React.JSX.Element {
-  const split = splitPathHeadForElision(text, ranges)
+  const split = elidePathHead ? splitPathHeadForElision(text, ranges) : null
   const content = split ? (
     <span
       data-slot="palette-open-tab-secondary"
@@ -110,6 +112,7 @@ export function PaletteOpenTabPrimaryLine({
   secondaryText,
   secondaryRanges,
   secondaryMatches = NO_SECONDARY_MATCHES,
+  elideSecondaryPathHead = false,
   sessionAge,
   leadingBadges
 }: {
@@ -118,6 +121,7 @@ export function PaletteOpenTabPrimaryLine({
   secondaryText: string
   secondaryRanges: readonly MatchRange[]
   secondaryMatches?: readonly { text: string; ranges: readonly MatchRange[] }[]
+  elideSecondaryPathHead?: boolean
   sessionAge?: string
   leadingBadges?: React.ReactNode
 }): React.JSX.Element {
@@ -151,7 +155,11 @@ export function PaletteOpenTabPrimaryLine({
       ) : null}
       {leadingBadges}
       {showSecondary ? (
-        <PaletteOpenTabSecondaryText text={secondaryText} ranges={secondaryRanges} />
+        <PaletteOpenTabSecondaryText
+          text={secondaryText}
+          ranges={secondaryRanges}
+          elidePathHead={elideSecondaryPathHead}
+        />
       ) : null}
       {additionalSecondaryMatches.length ? (
         <>

--- a/src/renderer/src/components/worktree-jump-palette-primitives.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-primitives.tsx
@@ -1,11 +1,12 @@
-import React, { useLayoutEffect, useRef, useState } from 'react'
+import React from 'react'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { translate } from '@/i18n/i18n'
 import type { PaletteHostBadge } from '@/components/cmd-j/palette-host-badge'
 import type { MatchRange, PaletteSearchResult } from '@/lib/worktree-palette-search'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import type { Worktree } from '../../../shared/worktree/types'
-import { resolveWorktreeBranchLabel } from '@/lib/worktree-default-display-name'
+import { splitPathHeadForElision } from '@/lib/path-head-elision'
+import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
+import { cn } from '@/lib/utils'
 
 const NO_SECONDARY_MATCHES: readonly { text: string; ranges: readonly MatchRange[] }[] = []
 
@@ -67,14 +68,48 @@ export function HighlightedText({
   return <>{parts}</>
 }
 
+function PaletteOpenTabSecondaryText({
+  text,
+  ranges
+}: {
+  text: string
+  ranges: readonly MatchRange[]
+}): React.JSX.Element {
+  const split = splitPathHeadForElision(text, ranges)
+  const content = split ? (
+    <span
+      data-slot="palette-open-tab-secondary"
+      className="flex min-w-0 items-baseline overflow-hidden font-mono text-[11px] text-muted-foreground/80"
+    >
+      <span className="min-w-0 shrink-[999] truncate">{split.head}</span>
+      <span className="min-w-0 shrink truncate">
+        <HighlightedText text={split.tail} matchRanges={split.tailRanges} />
+      </span>
+    </span>
+  ) : (
+    <span
+      data-slot="palette-open-tab-secondary"
+      className="min-w-0 truncate font-mono text-[11px] text-muted-foreground/80"
+    >
+      <HighlightedText text={text} matchRanges={ranges} />
+    </span>
+  )
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{content}</TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4} className="max-w-96 break-all">
+        {text}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
 export function PaletteOpenTabPrimaryLine({
   title,
   titleRanges,
   secondaryText,
   secondaryRanges,
   secondaryMatches = NO_SECONDARY_MATCHES,
-  worktreeName,
-  worktreeRanges,
   sessionAge,
   leadingBadges
 }: {
@@ -83,13 +118,10 @@ export function PaletteOpenTabPrimaryLine({
   secondaryText: string
   secondaryRanges: readonly MatchRange[]
   secondaryMatches?: readonly { text: string; ranges: readonly MatchRange[] }[]
-  worktreeName: string
-  worktreeRanges: readonly MatchRange[]
   sessionAge?: string
   leadingBadges?: React.ReactNode
 }): React.JSX.Element {
   const showSecondary = secondaryText.trim().length > 0
-  const showWorktree = worktreeName.trim().length > 0
   const additionalSecondaryMatches = secondaryMatches.filter(
     (match) => match.text && match.text !== secondaryText
   )
@@ -98,7 +130,10 @@ export function PaletteOpenTabPrimaryLine({
     <div className="flex min-w-0 items-center gap-2 overflow-hidden">
       <span
         data-slot="palette-open-tab-title"
-        className="min-w-0 flex-auto truncate text-[14px] font-semibold tracking-[-0.01em] text-foreground"
+        className={cn(
+          'truncate text-[14px] font-semibold tracking-[-0.01em] text-foreground',
+          showSecondary ? 'max-w-[62%] shrink-0' : 'min-w-0'
+        )}
       >
         <HighlightedText text={title} matchRanges={titleRanges} />
       </span>
@@ -116,12 +151,7 @@ export function PaletteOpenTabPrimaryLine({
       ) : null}
       {leadingBadges}
       {showSecondary ? (
-        <>
-          <span className="shrink-0 text-muted-foreground/45">·</span>
-          <span className="min-w-0 truncate text-[12px] font-medium text-muted-foreground/92">
-            <HighlightedText text={secondaryText} matchRanges={secondaryRanges} />
-          </span>
-        </>
+        <PaletteOpenTabSecondaryText text={secondaryText} ranges={secondaryRanges} />
       ) : null}
       {additionalSecondaryMatches.length ? (
         <>
@@ -154,85 +184,76 @@ export function PaletteOpenTabPrimaryLine({
           </Tooltip>
         </>
       ) : null}
-      {showWorktree ? (
-        <>
-          <span className="shrink-0 text-muted-foreground/45">·</span>
-          <span
-            data-slot="palette-open-tab-worktree"
-            className="min-w-0 truncate text-[12px] font-medium text-muted-foreground/92"
-          >
-            <HighlightedText text={worktreeName} matchRanges={worktreeRanges} />
-          </span>
-        </>
-      ) : null}
     </div>
   )
 }
 
-function resolveOpenTabWorktreeRailTooltip({
-  isBranch,
-  truncated,
-  name
+export function PaletteLocationChip({
+  repoName,
+  repoRanges,
+  repoColor,
+  worktreeName,
+  worktreeRanges,
+  className
 }: {
-  isBranch: boolean
-  truncated: boolean
-  name: string
-}): string {
-  if (truncated) {
-    return name
-  }
-  return isBranch
-    ? translate('auto.components.WorktreeJumpPalette.paletteOpenTabBranch', 'Branch name')
-    : translate('auto.components.WorktreeJumpPalette.paletteOpenTabWorkspace', 'Workspace name')
-}
-
-export function PaletteOpenTabWorktreeRailLabel({
-  name,
-  matchRanges,
-  worktree,
-  className,
-  slot = 'palette-open-tab-worktree'
-}: {
-  name: string
-  matchRanges: readonly MatchRange[]
-  worktree?: Pick<Worktree, 'branch'> | null
+  repoName: string
+  repoRanges: readonly MatchRange[]
+  repoColor?: string
+  worktreeName: string
+  worktreeRanges: readonly MatchRange[]
   className?: string
-  slot?: string
 }): React.JSX.Element | null {
-  const [truncated, setTruncated] = useState(false)
-  const labelRef = useRef<HTMLSpanElement | null>(null)
-  useLayoutEffect(() => {
-    const node = labelRef.current
-    if (!node) {
-      setTruncated(false)
-      return
-    }
-    const updateTruncated = (): void => {
-      const next = node.scrollWidth > node.clientWidth
-      setTruncated((current) => (current === next ? current : next))
-    }
-    updateTruncated()
-    if (typeof ResizeObserver === 'undefined') {
-      return
-    }
-    const observer = new ResizeObserver(updateTruncated)
-    observer.observe(node)
-    return () => observer.disconnect()
-  }, [name])
-  if (name.trim().length === 0) {
+  const showRepo = repoName.trim().length > 0
+  const repeatedName = showRepo && worktreeName === repoName
+  const showWorktree = worktreeName.trim().length > 0 && !repeatedName
+  if (!showRepo && !showWorktree) {
     return null
   }
-  const isBranch = worktree != null && name === resolveWorktreeBranchLabel(worktree)
-  const tooltip = resolveOpenTabWorktreeRailTooltip({ isBranch, truncated, name })
+  const repoMatchRanges = repeatedName
+    ? [...repoRanges, ...worktreeRanges].sort((left, right) => left.start - right.start)
+    : repoRanges
+  const label = [showRepo ? repoName : '', showWorktree ? worktreeName : '']
+    .filter(Boolean)
+    .join(' · ')
+  const chip = (
+    <span
+      data-slot="palette-location-chip"
+      className={cn(
+        'inline-flex min-w-0 max-w-[260px] items-center gap-1.5 overflow-hidden rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground',
+        className
+      )}
+    >
+      {showRepo ? (
+        <>
+          <RepoBadgeMark color={repoColor} />
+          <span
+            className={cn('min-w-0 truncate', showWorktree && 'min-w-[3ch] max-w-[55%]')}
+            data-slot="palette-location-repo"
+          >
+            <HighlightedText text={repoName} matchRanges={repoMatchRanges} />
+          </span>
+        </>
+      ) : null}
+      {showRepo && showWorktree ? (
+        <span aria-hidden className="shrink-0 text-muted-foreground/50">
+          ·
+        </span>
+      ) : null}
+      {showWorktree ? (
+        <span
+          data-slot="palette-open-tab-worktree"
+          className="min-w-[3ch] truncate font-medium text-muted-foreground"
+        >
+          <HighlightedText text={worktreeName} matchRanges={worktreeRanges} />
+        </span>
+      ) : null}
+    </span>
+  )
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <span ref={labelRef} data-slot={slot} tabIndex={-1} className={className}>
-          <HighlightedText text={name} matchRanges={matchRanges} />
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" sideOffset={6} className="max-w-80 break-all">
-        {tooltip}
+      <TooltipTrigger asChild>{chip}</TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4} className="max-w-96 break-all">
+        {label}
       </TooltipContent>
     </Tooltip>
   )

--- a/src/renderer/src/components/worktree-jump-palette-workspace-tab-row.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-workspace-tab-row.tsx
@@ -3,15 +3,14 @@ import { FileText, SquareTerminal } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { CommandItem } from '@/components/ui/command'
 import { PaletteRecentTabStatusDot } from '@/components/cmd-j/palette-live-status'
-import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { getPaletteHostBadge } from '@/components/cmd-j/palette-host-badge'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import type { WorkspaceTabPaletteItem } from './worktree-jump-palette-model'
 import type { WorktreeJumpPaletteController } from './use-worktree-jump-palette-controller'
 import {
-  HighlightedText,
   PaletteHostBadgeChip,
+  PaletteLocationChip,
   PaletteOpenTabPrimaryLine,
   PaletteRowShortcutBadge
 } from './worktree-jump-palette-primitives'
@@ -76,8 +75,6 @@ export function WorktreeJumpPaletteWorkspaceTabRow({
               secondaryText={result.secondaryText}
               secondaryRanges={result.secondaryRanges}
               secondaryMatches={result.secondaryMatches}
-              worktreeName={result.worktreeName}
-              worktreeRanges={result.worktreeRanges}
               sessionAge={sessionAge}
               leadingBadges={
                 <>
@@ -103,16 +100,15 @@ export function WorktreeJumpPaletteWorkspaceTabRow({
               </span>
             ) : null}
           </div>
-          <div className="flex shrink-0 items-center gap-1.5">
+          <div className="flex min-w-0 max-w-[40%] items-center justify-end gap-1.5">
             <PaletteHostBadgeChip badge={workspaceTabHostBadge} />
-            {workspaceTabRepoName && (
-              <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
-                <RepoBadgeMark color={workspaceTabRepo?.badgeColor} />
-                <span className="truncate">
-                  <HighlightedText text={workspaceTabRepoName} matchRanges={result.repoRanges} />
-                </span>
-              </span>
-            )}
+            <PaletteLocationChip
+              repoName={workspaceTabRepoName}
+              repoRanges={result.repoRanges}
+              repoColor={workspaceTabRepo?.badgeColor}
+              worktreeName={result.worktreeName}
+              worktreeRanges={result.worktreeRanges}
+            />
             <PaletteRowShortcutBadge
               index={controller.recentTabShortcutIndexByItem.get(entry)}
               modifierKeys={controller.digitShortcutModifiers}

--- a/src/renderer/src/components/worktree-jump-palette-workspace-tab-row.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-workspace-tab-row.tsx
@@ -16,6 +16,7 @@ import {
 } from './worktree-jump-palette-primitives'
 import { formatPaletteSessionAge } from '@/components/cmd-j/palette-session-age'
 import { resolvePaletteRepoForWorktree } from '@/lib/palette-repo-resolution'
+import { isEditorTabContentType } from '@/store/slices/editor/tabs/editor-tab-content-type'
 
 export function WorktreeJumpPaletteWorkspaceTabRow({
   entry,
@@ -75,7 +76,7 @@ export function WorktreeJumpPaletteWorkspaceTabRow({
               secondaryText={result.secondaryText}
               secondaryRanges={result.secondaryRanges}
               secondaryMatches={result.secondaryMatches}
-              elideSecondaryPathHead={result.contentType === 'editor'}
+              elideSecondaryPathHead={isEditorTabContentType(result.contentType)}
               sessionAge={sessionAge}
               leadingBadges={
                 <>

--- a/src/renderer/src/components/worktree-jump-palette-workspace-tab-row.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-workspace-tab-row.tsx
@@ -75,6 +75,7 @@ export function WorktreeJumpPaletteWorkspaceTabRow({
               secondaryText={result.secondaryText}
               secondaryRanges={result.secondaryRanges}
               secondaryMatches={result.secondaryMatches}
+              elideSecondaryPathHead={result.contentType === 'editor'}
               sessionAge={sessionAge}
               leadingBadges={
                 <>

--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -189,7 +189,9 @@
       },
       "WorktreeJumpPalette": {
         "c4afa68159": "Try a worktree, setting, action, tab title, agent prompt, URL, PR, or port.",
-        "dabd819ca1": "Type to see all {{value0}} worktrees"
+        "dabd819ca1": "Type to see all {{value0}} worktrees",
+        "paletteOpenTabBranch": "Branch name",
+        "paletteOpenTabWorkspace": "Workspace name"
       },
       "activity": {
         "ActivityPrototypePage": {

--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -189,9 +189,7 @@
       },
       "WorktreeJumpPalette": {
         "c4afa68159": "Try a worktree, setting, action, tab title, agent prompt, URL, PR, or port.",
-        "dabd819ca1": "Type to see all {{value0}} worktrees",
-        "paletteOpenTabBranch": "Branch name",
-        "paletteOpenTabWorkspace": "Workspace name"
+        "dabd819ca1": "Type to see all {{value0}} worktrees"
       },
       "activity": {
         "ActivityPrototypePage": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2378,8 +2378,6 @@
         "recentChatsTerminalsHeader": "Recent Chats & Terminals",
         "27f10cca63": "Search chats, terminals, worktrees, settings, and actions...",
         "2770f02910": "Search chats, terminals, worktrees, settings, and actions",
-        "paletteOpenTabBranch": "Branch name",
-        "paletteOpenTabWorkspace": "Workspace name",
         "lastActiveTime": "Last active {{value0}} ago"
       },
       "github": {

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -2201,8 +2201,6 @@
         "recentChatsTerminalsHeader": "Chats et terminaux récents",
         "27f10cca63": "Rechercher chats, terminaux, worktrees, paramètres et actions...",
         "2770f02910": "Rechercher chats, terminaux, worktrees, paramètres et actions",
-        "paletteOpenTabBranch": "Nom de branche",
-        "paletteOpenTabWorkspace": "Nom de l'espace de travail",
         "lastActiveTime": "Dernière activité il y a {{value0}}"
       },
       "github": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​124 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |

<!-- /orca-pr-loc -->

## ELI5

Give Cmd+J results more room for the useful text by grouping repository and worktree location into one compact chip.

## What Changed

- Combined repository and worktree labels into a bounded location chip for terminal, browser, and simulator rows.
- Kept the existing host badge behavior intact.
- Elided long secondary paths from the head so filenames and matched tail segments remain visible.
- Adjusted title sizing so short titles stay natural while title-plus-path rows share space predictably.
- Added coverage for repeated repo/worktree names, truncation boundaries, highlight preservation, and row layout.

## Why

The previous row repeated location information across the center and right rail, leaving too little room for titles and paths. The compact chip keeps the same context while reducing visual competition.

## Linked Issue

N/A — no linked issue was provided.

## Visual Proof

| Before | After |
| --- | --- |
| ![Cmd+J before](https://github.com/user-attachments/assets/d26e9ce4-1010-4033-b865-6a5a0129448e) | ![Cmd+J after](https://github.com/user-attachments/assets/54932f9c-a27c-4a59-ad37-7045751d38e9) |

Both screenshots show the real Orca renderer with Cmd+J filtered to `terminal`.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated with:

- 69 focused tests across five Cmd+J and path-elision suites
- `pnpm tc:web`
- commit hooks
- `pnpm run check:code-quality:changed` (0 new findings)
- Hidden Electron/CDP validation on macOS with `ORCA_BACKGROUND_LAUNCH=1`: opened Cmd+J, searched `terminal`, and verified the rendered location chip and surrounding row layout

Not manually exercised on Linux, Windows, or SSH. This is renderer-only presentation logic; Windows path behavior is covered by automated tests, and execution/remote boundaries are unchanged.

## AI Disclosure

## Review

This PR is stacked on #19938. Review this PR against `palette-path-head-elision`; after #19938 lands, retarget/rebase it onto `main` before merging.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The unrelated host-filter behavior from the original oversized branch was intentionally omitted. Existing host badges remain unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted tests, `pnpm tc:web`, commit hooks, and changed-code quality passed; full suite/build left to CI)
