### PR TITLE
fix(release): port three release-gate fixes to main so cuts stop re-inheriting them

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -279,16 +279,6 @@ module.exports = {
     }
   },
   afterPack: async (context) => {
-    // Why: a Linux runner-image glibc bump silently shipped a node-pty pty.node
-    // requiring GLIBC_2.34, crashing the app on startup on Ubuntu 20.04 (#9902).
-    // Fail packaging if any bundled native binary exceeds the supported floor.
-    if (context.electronPlatformName === 'linux') {
-      // Why the arch is passed: symbol-version checks pass happily on a wrong-architecture binary,
-      // so a cross-built slice could ship the host's pty.node and only fail at runtime.
-      verifyLinuxGlibcFloor(context.appOutDir, {
-        targetArch: { 1: 'x64', 3: 'arm64' }[context.arch]
-      })
-    }
     const resourcesDir =
       context.electronPlatformName === 'darwin'
         ? join(
@@ -326,6 +316,19 @@ module.exports = {
     }
     stampPackagedCliVersion(resourcesDir, context.packager.appInfo.version)
     prunePackagedRuntimeNodeModules(resourcesDir, context.electronPlatformName, context.arch)
+    // Why: a Linux runner-image glibc bump silently shipped a node-pty pty.node
+    // requiring GLIBC_2.34, crashing the app on startup on Ubuntu 20.04 (#9902).
+    // Fail packaging if any bundled native binary exceeds the supported floor.
+    // Why after the prune: cross-builds intentionally install every optional
+    // native variant, so an arm64 slice still carries the x64 @parcel/watcher
+    // until prunePackagedRuntimeNodeModules drops it.
+    if (context.electronPlatformName === 'linux') {
+      // Why the arch is passed: symbol-version checks pass happily on a wrong-architecture binary,
+      // so a cross-built slice could ship the host's pty.node and only fail at runtime.
+      verifyLinuxGlibcFloor(context.appOutDir, {
+        targetArch: { 1: 'x64', 3: 'arm64' }[context.arch]
+      })
+    }
     verifyPackagedMainRuntimeDeps(resourcesDir)
     // Why: boot the packaged daemon-entry under plain Node, but only for the
     // slice matching the packaging host's arch — daemon-entry.js is JS, yet it

--- a/config/scripts/electron-builder-runtime-resources.test.mjs
+++ b/config/scripts/electron-builder-runtime-resources.test.mjs
@@ -2,7 +2,7 @@ import { readFileSync, readdirSync } from 'node:fs'
 import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
-import { dirname, join, relative, resolve } from 'node:path'
+import { delimiter, dirname, join, relative, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const require = createRequire(import.meta.url)
@@ -386,6 +386,72 @@ describe('packaged runtime resources', () => {
       await rm(root, { recursive: true, force: true })
     }
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'prunes non-target native packages before the Linux glibc gate',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-after-pack-prune-order-'))
+      const previousPath = process.env.PATH
+      try {
+        const appOutDir = join(root, 'linux-unpacked')
+        const resourcesDir = join(appOutDir, 'resources')
+        await cp(
+          join(process.cwd(), 'resources', 'plugins', 'launch'),
+          join(resourcesDir, 'plugins', 'launch'),
+          { recursive: true }
+        )
+
+        const unpackedMainDir = join(resourcesDir, 'app.asar.unpacked', 'out', 'main')
+        await mkdir(unpackedMainDir, { recursive: true })
+        await writeFile(join(unpackedMainDir, 'daemon-entry.js'), '', 'utf8')
+        await writeFile(
+          join(resourcesDir, 'app.asar.unpacked', 'out', 'package.json'),
+          `${JSON.stringify({ name: 'orca-compiled-output', type: 'commonjs', private: true })}\n`,
+          'utf8'
+        )
+
+        const unpackedCliDir = join(resourcesDir, 'app.asar.unpacked', 'out', 'cli')
+        await mkdir(join(unpackedCliDir, 'handlers'), { recursive: true })
+        await writeFile(join(unpackedCliDir, 'handlers', 'skills.js'), '', 'utf8')
+        await writeFile(join(unpackedCliDir, 'index.js'), '', 'utf8')
+
+        const target =
+          process.arch === 'x64'
+            ? { electronArch: 3, machine: 0xb7, nonTarget: 'x64' }
+            : { electronArch: 1, machine: 0x3e, nonTarget: 'arm64' }
+        const wrongArchPackage = join(
+          resourcesDir,
+          'node_modules',
+          '@parcel',
+          `watcher-linux-${target.nonTarget}-glibc`
+        )
+        await mkdir(wrongArchPackage, { recursive: true })
+        const wrongArchElf = Buffer.alloc(20)
+        wrongArchElf.set([0x7f, 0x45, 0x4c, 0x46])
+        wrongArchElf[5] = 1
+        wrongArchElf.writeUInt16LE(target.machine, 18)
+        await writeFile(join(wrongArchPackage, 'watcher.node'), wrongArchElf)
+
+        const stubBinDir = join(root, 'bin')
+        await mkdir(stubBinDir)
+        await writeFile(join(stubBinDir, 'objdump'), '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+        process.env.PATH = `${stubBinDir}${delimiter}${previousPath ?? ''}`
+
+        await expect(
+          electronBuilderConfig.afterPack({
+            appOutDir,
+            electronPlatformName: 'linux',
+            arch: target.electronArch,
+            packager: { appInfo: { version: '9.9.9' } }
+          })
+        ).resolves.toBeUndefined()
+        await expect(stat(wrongArchPackage)).rejects.toMatchObject({ code: 'ENOENT' })
+      } finally {
+        process.env.PATH = previousPath
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
 
   it.skipIf(process.platform === 'win32')(
     'marks packaged Unix CLI launchers executable',

--- a/config/scripts/telemetry-bundle-constant-patterns.mjs
+++ b/config/scripts/telemetry-bundle-constant-patterns.mjs
@@ -1,2 +1,6 @@
-export const BUILD_IDENTITY_RE = /\b(?:const|let|var)\s+BUILD_IDENTITY\s*=\s*"(rc|stable)"/
-export const WRITE_KEY_RE = /\b(?:const|let|var)\s+WRITE_KEY\s*=\s*"(phc_[A-Za-z0-9_-]+)"/
+// The unminified bundle keeps these names. Production minification may rename
+// them, but the injected identity and key remain adjacent in the declaration.
+export const BUILD_IDENTITY_RE = /\b(?:const|let|var)\s+BUILD_IDENTITY\s*=\s*["`](rc|stable)["`]/
+export const WRITE_KEY_RE = /\b(?:const|let|var)\s+WRITE_KEY\s*=\s*["`](phc_[A-Za-z0-9_-]+)["`]/
+export const MINIFIED_TELEMETRY_RE =
+  /\b(?:const|let|var)\s+[$\w]+\s*=\s*["'`](rc|stable)["'`][\s\S]{0,200}?[,$]\s*[$\w]+\s*=\s*["'`](phc_[A-Za-z0-9_-]+)["'`]/

--- a/config/scripts/telemetry-bundle-constant-patterns.test.mjs
+++ b/config/scripts/telemetry-bundle-constant-patterns.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { BUILD_IDENTITY_RE, WRITE_KEY_RE } from './telemetry-bundle-constant-patterns.mjs'
+import {
+  BUILD_IDENTITY_RE,
+  MINIFIED_TELEMETRY_RE,
+  WRITE_KEY_RE
+} from './telemetry-bundle-constant-patterns.mjs'
 
 describe('telemetry bundle constant patterns', () => {
   it.each(['const', 'let', 'var'])('accepts %s declarations', (declaration) => {
@@ -12,5 +16,10 @@ describe('telemetry bundle constant patterns', () => {
     expect('const BUILD_IDENTITY = "dev"').not.toMatch(BUILD_IDENTITY_RE)
     expect('const WRITE_KEY = null').not.toMatch(WRITE_KEY_RE)
     expect('const WRITE_KEY = "example-key"').not.toMatch(WRITE_KEY_RE)
+  })
+
+  it('accepts minified adjacent declarations', () => {
+    const bundle = 'var dde=`stable`,fde=`phc_example-key_123`,pde=(dde===`stable`)'
+    expect(bundle).toMatch(MINIFIED_TELEMETRY_RE)
   })
 })

--- a/config/scripts/verify-telemetry-constants.mjs
+++ b/config/scripts/verify-telemetry-constants.mjs
@@ -38,7 +38,11 @@ import { join, resolve } from 'node:path'
 // `node_modules`). If electron-builder ever drops it, promote this to a
 // direct devDependency in package.json.
 import { extractFile, listPackage } from '@electron/asar'
-import { BUILD_IDENTITY_RE, WRITE_KEY_RE } from './telemetry-bundle-constant-patterns.mjs'
+import {
+  BUILD_IDENTITY_RE,
+  MINIFIED_TELEMETRY_RE,
+  WRITE_KEY_RE
+} from './telemetry-bundle-constant-patterns.mjs'
 
 // Why resolve from import.meta.url instead of cwd: a release runner (or a
 // developer debugging locally) may invoke this script from a non-root cwd.
@@ -156,8 +160,14 @@ function verifyAsar(asarPath) {
 
   const buildIdentityMatch = BUILD_IDENTITY_RE.exec(indexJs)
   const writeKeyMatch = WRITE_KEY_RE.exec(indexJs)
+  const minifiedTelemetryMatch = MINIFIED_TELEMETRY_RE.exec(indexJs)
 
-  if (!buildIdentityMatch) {
+  // Rolldown renames module-local constants in production output. In that
+  // form, verify the adjacent injected identity/key declaration instead.
+  const verifiedIdentity = buildIdentityMatch?.[1] ?? minifiedTelemetryMatch?.[1]
+  const verifiedWriteKey = writeKeyMatch?.[1] ?? minifiedTelemetryMatch?.[2]
+
+  if (!verifiedIdentity) {
     console.error(`::error::BUILD_IDENTITY constant missing or unexpected value in ${asarPath}`)
     const sample = indexJs.match(/.{0,80}BUILD_IDENTITY.{0,80}/g)?.slice(0, 5) ?? []
     for (const line of sample) {
@@ -165,7 +175,7 @@ function verifyAsar(asarPath) {
     }
     return null
   }
-  if (!writeKeyMatch) {
+  if (!verifiedWriteKey) {
     console.error(`::error::PostHog WRITE_KEY missing from ${asarPath}`)
     const sample = indexJs.match(/.{0,80}WRITE_KEY.{0,80}/g)?.slice(0, 5) ?? []
     for (const line of sample) {
@@ -174,7 +184,7 @@ function verifyAsar(asarPath) {
     return null
   }
 
-  return { asarPath, buildIdentity: buildIdentityMatch[1], writeKey: writeKeyMatch[1] }
+  return { asarPath, buildIdentity: verifiedIdentity, writeKey: verifiedWriteKey }
 }
 
 // Why verify every match (not just the first): macOS dual-arch produces one

--- a/src/main/skills/skill-root-file-walk.test.ts
+++ b/src/main/skills/skill-root-file-walk.test.ts
@@ -73,9 +73,7 @@ describe('findSkillFiles', () => {
     // visited set collapses them to a single entry beside the real file.
     const withinDepth = await findSkillFiles(root, 5)
     expect(withinDepth).toContain(join(edge, 'SKILL.md'))
-    expect(withinDepth.filter((path) => /[\\/]link\d{2}[\\/]SKILL\.md$/.test(path))).toHaveLength(
-      1
-    )
+    expect(withinDepth.filter((path) => /[\\/]link\d{2}[\\/]SKILL\.md$/.test(path))).toHaveLength(1)
     expect(withinDepth).toHaveLength(2)
     expect(statPaths).toHaveLength(32)
   })

--- a/src/main/skills/skill-root-file-walk.test.ts
+++ b/src/main/skills/skill-root-file-walk.test.ts
@@ -66,10 +66,17 @@ describe('findSkillFiles', () => {
 
     expect(await findSkillFiles(root, 4)).toEqual([join(edge, 'SKILL.md')])
     expect(statPaths).toEqual([])
-    expect(await findSkillFiles(root, 5)).toEqual([
-      join(edge, 'SKILL.md'),
-      join(edge, 'link00', 'SKILL.md')
-    ])
+    // Why not a fixed array: `readdir` order is filesystem-dependent, and both
+    // the result order and which link survives dedup follow it. NTFS enumerates
+    // its name index alphabetically, so `link00` precedes `SKILL.md` on Windows
+    // and follows it on APFS/ext4. All 32 links share one realpath, so the
+    // visited set collapses them to a single entry beside the real file.
+    const withinDepth = await findSkillFiles(root, 5)
+    expect(withinDepth).toContain(join(edge, 'SKILL.md'))
+    expect(withinDepth.filter((path) => /[\\/]link\d{2}[\\/]SKILL\.md$/.test(path))).toHaveLength(
+      1
+    )
+    expect(withinDepth).toHaveLength(2)
     expect(statPaths).toHaveLength(32)
   })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |

<!-- /orca-pr-loc -->

## Problem

Three release-gate fixes have been written on release branches and **never merged back to `main`**, so
every new cut re-inherits all three failures. This is the **third** recurrence:

| When | Commit | Reached `main`? |
|---|---|---|
| v1.4.197 branch, Sep 3 | `35f1b0ebb9` "validate minified telemetry and prune target natives first" | **No** |
| v1.4.199 branch, Sep 8 | `a883e17116` + `d0bbe4475d` (also duplicated as `6400598212`) | **No** |
| 1.4.200 (today) | re-picked again onto `release/adhoc-1.4.200-daily-202609091829-cherrypicks` | — |

The automated Daily Release Readiness Scan files it fresh every cut:
[STA-7114](https://linear.app/stably/issue/STA-7114) (v1.4.199) and
[STA-7186](https://linear.app/stably/issue/STA-7186) (09-10 daily) are the same bug, filed twice.

Release lineage is a side branch that never merges back, so a fix landed only there is lost by
construction. This PR lands all three on `main` once.

## What's here

Three cherry-picks, `-x` so provenance is preserved. All authored by Neil; I only ported them.

1. **`prune optional natives before the linux arch floor check`** (`config/electron-builder.config.cjs`)
   `verifyLinuxGlibcFloor` ran at line 288, but `prunePackagedRuntimeNodeModules` — which deletes the
   wrong-arch optional natives — runs at line 328. A cross-build still carries
   `@parcel/watcher-linux-x64-glibc/watcher.node` in the arm64 slice at check time, so the check throws
   on a file that was about to be deleted and was never going to ship. **Linux arm64 packaging fails.**
   Pure code motion: the check moves after the prune, with a comment recording the ordering constraint.

2. **`restore the minified telemetry constant fallback`** (`config/scripts/verify-telemetry-constants.mjs`,
   `telemetry-bundle-constant-patterns.mjs`)
   Both regexes key off the literal `BUILD_IDENTITY` / `WRITE_KEY` identifiers, which `oxc` renames —
   `minify: 'oxc'` is pinned at `electron.vite.config.ts:200,312`. The identifier does not occur in the
   shipped bundle, so the verifier reports it missing with no fallback. **Fails macOS, Windows and both
   Linux builds.** Note this class is invisible to PR CI, which packages Linux and Windows only and
   never runs the asar verifier.

3. **`stop asserting readdir order in the skill root walk test`** (`src/main/skills/skill-root-file-walk.test.ts`)
   The test asserted an exact array order. `findSkillFiles` emits in `readdir` order, and NTFS
   enumerates its filename index on the uppercased name, where `LINK00` sorts before `SKILL.MD`. Windows
   returns the same two paths reversed. Asserts the contract instead of the order.

## Verification

- All three cherry-pick **cleanly** onto current `main`.
- Each is already **proven in production** — this exact content shipped in v1.4.199.
- Diff is 4 files, +44 / −20. No lockfile change, no dependency change.
- **Not run locally:** the scratch worktree had no `node_modules` and I did not want a package-script
  run installing into a shared tree. CI covers `skill-root-file-walk.test.ts`; the other two files are
  packaging scripts exercised only by a real cut.

## Why it matters

Until this lands, every future cut starts broken in the same three ways and someone re-discovers them
under release pressure. Landing it is what closes STA-7114 / STA-7186 for good rather than for one release.
