### PR TITLE
test(runtime): pin sleeping-agent resume on a failed SSH target

### DIFF
--- a/src/renderer/src/lib/ssh-failed-target-sleeping-agent-resume.test.ts
+++ b/src/renderer/src/lib/ssh-failed-target-sleeping-agent-resume.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The resume half of the terminal-state floor.
+ *
+ * `workspace-terminal-host-authority.ts` says an SSH target whose sync terminated in
+ * `offline`/`error` without ever hydrating answers `none`, so this client may act. The seeding
+ * consumer is covered end to end (worktree-agent-activation-seam.test.ts); the sleeping-agent
+ * consumer (resume-sleeping-agent-session.ts) was only covered at the predicate. Without this,
+ * a failed target's agents stay unresumable for the rest of the app session and nothing fails.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import { useAppStore } from '@/store'
+import { makeWorktree } from '@/store/slices/store-test-helpers'
+import { resolveWorkspaceTerminalHostAuthority } from './workspace-terminal-host-authority'
+import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+
+const initialAppStoreState = useAppStore.getState()
+const TARGET_ID = 'ssh-target-1'
+const WORKTREE_ID = 'repoSsh::/srv/proj/feature'
+
+afterEach(() => {
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function seedFailedSshTarget(phase?: 'offline' | 'error' | 'pulling'): void {
+  const tab: TerminalTab = {
+    id: 'tab-1',
+    ptyId: null,
+    worktreeId: WORKTREE_ID,
+    title: 'shell',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+  const record: SleepingAgentSessionRecord = {
+    paneKey: 'tab-1:leaf-1',
+    tabId: 'tab-1',
+    worktreeId: WORKTREE_ID,
+    agent: 'pi',
+    providerSession: { key: 'session_id', id: 'pi-session-1', transcriptPath: '/tmp/pi-1.jsonl' },
+    prompt: '',
+    state: 'working',
+    capturedAt: 1,
+    updatedAt: 1,
+    origin: 'worktree-sleep'
+  }
+  useAppStore.setState({
+    repos: [
+      {
+        id: 'repoSsh',
+        path: '/srv/proj',
+        displayName: 'repoSsh',
+        badgeColor: '#000',
+        addedAt: 0,
+        connectionId: TARGET_ID
+      }
+    ] as never,
+    worktreesByRepo: {
+      repoSsh: [
+        makeWorktree({
+          id: WORKTREE_ID,
+          repoId: 'repoSsh',
+          path: '/srv/proj/feature',
+          hostId: `ssh:${TARGET_ID}`
+        } as never)
+      ]
+    },
+    remoteWorkspaceHydratedTargetIds: new Set<string>(),
+    remoteWorkspaceSyncStatusByTargetId:
+      phase === undefined ? {} : { [TARGET_ID]: { phase, direction: 'pull' as const } },
+    tabsByWorktree: { [WORKTREE_ID]: [tab] },
+    sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+  })
+}
+
+describe('sleeping-agent resume on a failed SSH target', () => {
+  it.each(['offline', 'error'] as const)(
+    'resumes a sleeping agent once a sync terminates in %s without ever hydrating',
+    (phase) => {
+      seedFailedSshTarget(phase)
+
+      expect(resolveWorkspaceTerminalHostAuthority(useAppStore.getState(), WORKTREE_ID)).toBe(
+        'none'
+      )
+      // The gate this exists for: a target that failed must not stay unresumable for the session.
+      expect(resumeSleepingAgentSessionsForWorktree(WORKTREE_ID)).toBe(1)
+      expect(useAppStore.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toBeUndefined()
+    }
+  )
+
+  it('still declines to resume while the host has not answered', () => {
+    // Control: an in-flight sync is `unverifiable`, and resuming there forks a session the host
+    // may still be running. The floor must not widen into "resume whenever we are unsure".
+    seedFailedSshTarget('pulling')
+
+    expect(resolveWorkspaceTerminalHostAuthority(useAppStore.getState(), WORKTREE_ID)).toBe(
+      'unverifiable'
+    )
+    expect(resumeSleepingAgentSessionsForWorktree(WORKTREE_ID)).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toBeDefined()
+  })
+
+  it('still declines to resume when no sync status exists at all', () => {
+    seedFailedSshTarget(undefined)
+
+    expect(resolveWorkspaceTerminalHostAuthority(useAppStore.getState(), WORKTREE_ID)).toBe(
+      'unverifiable'
+    )
+    expect(resumeSleepingAgentSessionsForWorktree(WORKTREE_ID)).toBe(0)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Test-only. Closes a coverage gap on a **pre-existing** safety mechanism — no behaviour change, nothing here is new code under test.

## The mechanism

`workspace-terminal-host-authority.ts` carries a deliberate floor:

```ts
const TERMINATED_WITHOUT_ANSWER_PHASES = new Set(['offline', 'error'])
```

An SSH target whose sync terminated in `offline`/`error` **without ever hydrating** resolves to `none`, so this client may act. Its own comment says what removing it costs:

> The bounded floor. Without it a single failed sync leaves every git worktree on this target terminal-less and its sleeping agents unresumable for the rest of the app session — strictly worse than the pre-gate behaviour, and only escapable by creating a tab by hand.

## The gap

The floor has three consumers:

| consumer | coverage before this PR |
|---|---|
| initial-terminal seeding (`worktree-initial-terminal-seeding.ts`) | end to end, via `worktree-agent-activation-seam.test.ts` |
| startup terminal watcher (`use-terminal-watcher-effects.ts`) | — |
| **sleeping-agent resume** (`resume-sleeping-agent-session.ts`) | **predicate only** |

**The floor is already load-bearing, and that is measured, not assumed.** Emptying `TERMINATED_WITHOUT_ANSWER_PHASES` on `main` fails exactly three assertions: the two unit assertions in `workspace-terminal-host-authority.test.ts` and the end-to-end seam assertion *"still seeds a pane when the selected SSH relay is detached"*. So the **seeding** consumer is genuinely protected.

The **resume** consumer is not. Nothing failed if the floor stopped reaching it — which is the half of that comment about *unresumable agents*, and the more expensive half, since the user's escape hatch (create a tab by hand) recovers a terminal but not a sleeping agent's session.

## What this adds

An SSH git worktree on a target at phase `offline`/`error` with an empty hydrated set resumes its sleeping agent (returns 1, record cleared). Two controls keep the floor from widening into *"resume whenever we are unsure"*: an in-flight `pulling` sync and no sync status at all both stay `unverifiable` and resume nothing — resuming there would fork a session the host may still be running.

**Verified by mutation on this branch**: emptying the phase set fails exactly the two floor assertions and leaves both controls passing.

## Provenance

Found while adversarially testing the SSH-remote integration stack. The floor predates that stack (#16750, amended by #16956), so this belongs to none of the stacked PRs and is deliberately split out rather than folded into one of them.

Two things I noticed and did **not** change here:

- Phase `conflict` gets no floor. An unplaceable host snapshot both clears hydration and sets `conflict`, so authority stays `unverifiable` with nothing bounding it. That exclusion is deliberate and documented (a conflicted target's tabs *do* exist on the host, so seeding would duplicate), but it is the one case that reaches the outcome the floor exists to prevent.
- `workspace-terminal-host-authority.test.ts` still asserts in prose that `clearRemoteWorkspaceHydrated` has no production caller. It now has three.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts; all 1 commit(s) replayed as-is.

| | SHA |
| --- | --- |
| old head | `ae1b50920646af705a31e5ad3a01f7273955b3ca` |
| new head | `e47e0778f5cd481850ff631aff96d9b8af7cf286` |
<!-- /rebase-record -->
