### PR TITLE
fix(linear): make evictStaleEntries actually evict by age

### DIFF
--- a/src/renderer/src/store/slices/linear/linear-cache-eviction-adversarial.test.ts
+++ b/src/renderer/src/store/slices/linear/linear-cache-eviction-adversarial.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CacheEntry } from '../../github/cache-model'
+import {
+  CACHE_EVICTION_MAX_AGE,
+  MAX_CACHE_ENTRIES,
+  TEAM_CACHE_TTL,
+  evictStaleEntries,
+  isFresh
+} from './linear-cache'
+
+const NOW = new Date('2026-01-01T00:00:00Z').getTime()
+const entry = (ageMs: number): CacheEntry<string> => ({ data: 'x', fetchedAt: NOW - ageMs })
+
+describe('evictStaleEntries adversarial', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+  afterEach(() => vi.useRealTimers())
+
+  it('evicts exactly at the horizon and keeps one ms under it', () => {
+    const out = evictStaleEntries({
+      at: entry(CACHE_EVICTION_MAX_AGE),
+      under: entry(CACHE_EVICTION_MAX_AGE - 1)
+    })
+    expect(Object.keys(out).sort()).toEqual(['under'])
+  })
+
+  it('never evicts anything a TEAM_CACHE_TTL read would still call fresh', () => {
+    for (const age of [0, 1, TEAM_CACHE_TTL - 2, TEAM_CACHE_TTL - 1]) {
+      const cache = { k: entry(age) }
+      expect(isFresh(cache.k, TEAM_CACHE_TTL)).toBe(true)
+      expect(evictStaleEntries(cache)).toHaveProperty('k')
+    }
+  })
+
+  it('drops malformed fetchedAt (undefined / NaN / null)', () => {
+    const cache = {
+      undef: { data: 'x' } as unknown as CacheEntry<string>,
+      nan: { data: 'x', fetchedAt: Number.NaN } as CacheEntry<string>,
+      nul: { data: 'x', fetchedAt: null } as unknown as CacheEntry<string>,
+      ok: entry(0)
+    }
+    expect(Object.keys(evictStaleEntries(cache))).toEqual(['ok'])
+  })
+
+  it('keeps entries stamped in the future (clock stepped backwards)', () => {
+    expect(evictStaleEntries({ future: entry(-60 * 60_000) })).toHaveProperty('future')
+  })
+
+  it('returns a NEW object (not identity) when everything is age-evicted', () => {
+    const cache = { old: entry(CACHE_EVICTION_MAX_AGE + 1) }
+    const out = evictStaleEntries(cache)
+    expect(Object.is(out, cache)).toBe(false)
+    expect(out).toEqual({})
+  })
+
+  it('preserves identity at exactly MAX_CACHE_ENTRIES with all entries live', () => {
+    const cache: Record<string, CacheEntry<string>> = {}
+    for (let i = 0; i < MAX_CACHE_ENTRIES; i += 1) {
+      cache[`k${i}`] = entry(i)
+    }
+    expect(Object.is(evictStaleEntries(cache), cache)).toBe(true)
+  })
+
+  it('preserves identity on the empty cache', () => {
+    const cache: Record<string, CacheEntry<string>> = {}
+    expect(Object.is(evictStaleEntries(cache), cache)).toBe(true)
+  })
+
+  it('age pass never loses a newer entry the count-cap-only policy would have kept', () => {
+    const cache: Record<string, CacheEntry<string>> = {}
+    for (let i = 0; i < MAX_CACHE_ENTRIES + 50; i += 1) {
+      cache[`k${i}`] = entry(i * 1000) // k0 newest
+    }
+    const countCapOnly = Object.keys(cache)
+      .sort((a, b) => cache[b].fetchedAt - cache[a].fetchedAt)
+      .slice(0, MAX_CACHE_ENTRIES)
+    const pruned = evictStaleEntries(cache)
+    for (const key of Object.keys(pruned)) {
+      expect(countCapOnly).toContain(key)
+    }
+    expect(Object.keys(pruned)).toHaveLength(MAX_CACHE_ENTRIES)
+  })
+
+  it('does not mutate the input cache', () => {
+    const cache = { a: entry(0), b: entry(CACHE_EVICTION_MAX_AGE + 1) }
+    const before = { ...cache }
+    evictStaleEntries(cache)
+    expect(cache).toEqual(before)
+  })
+
+  it('honours an explicit maxAgeMs override', () => {
+    const out = evictStaleEntries({ a: entry(0), b: entry(5_000) }, MAX_CACHE_ENTRIES, 1_000)
+    expect(Object.keys(out)).toEqual(['a'])
+  })
+
+  it('count cap still keeps the newest when all entries are within the horizon', () => {
+    const cache: Record<string, CacheEntry<string>> = {}
+    for (let i = 0; i < MAX_CACHE_ENTRIES + 1; i += 1) {
+      cache[`k${i}`] = entry(i)
+    }
+    const pruned = evictStaleEntries(cache)
+    expect(Object.keys(pruned)).toHaveLength(MAX_CACHE_ENTRIES)
+    expect(pruned).toHaveProperty('k0')
+    expect(pruned).not.toHaveProperty(`k${MAX_CACHE_ENTRIES}`)
+  })
+})

--- a/src/renderer/src/store/slices/linear/linear-cache-eviction.test.ts
+++ b/src/renderer/src/store/slices/linear/linear-cache-eviction.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CacheEntry } from '../../github/cache-model'
+import {
+  CACHE_EVICTION_MAX_AGE,
+  CACHE_TTL,
+  MAX_CACHE_ENTRIES,
+  TEAM_CACHE_TTL,
+  evictStaleEntries,
+  isFresh
+} from './linear-cache'
+
+const NOW = new Date('2026-01-01T00:00:00Z').getTime()
+
+function entry(ageMs: number): CacheEntry<string> {
+  return { data: 'payload', fetchedAt: NOW - ageMs }
+}
+
+describe('evictStaleEntries', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('drops entries older than the eviction horizon and keeps newer ones', () => {
+    const pruned = evictStaleEntries({
+      recent: entry(1_000),
+      ancient: entry(CACHE_EVICTION_MAX_AGE + 1_000)
+    })
+    expect(Object.keys(pruned)).toEqual(['recent'])
+  })
+
+  it('keeps entries a team read would still accept as fresh', () => {
+    const midAge = entry(TEAM_CACHE_TTL - 60_000)
+    expect(isFresh(midAge, TEAM_CACHE_TTL)).toBe(true)
+    expect(isFresh(midAge)).toBe(false) // stale for the default read TTL, still worth retaining
+    expect(evictStaleEntries({ midAge })).toHaveProperty('midAge')
+  })
+
+  it('still enforces the count cap after age eviction, dropping oldest first', () => {
+    const cache: Record<string, CacheEntry<string>> = {}
+    for (let i = 0; i < MAX_CACHE_ENTRIES + 10; i += 1) {
+      cache[`key-${i}`] = entry(i) // key-0 newest, higher index older
+    }
+    cache.ancient = entry(CACHE_EVICTION_MAX_AGE + 1_000)
+
+    const pruned = evictStaleEntries(cache)
+
+    expect(Object.keys(pruned)).toHaveLength(MAX_CACHE_ENTRIES)
+    expect(pruned).not.toHaveProperty('ancient')
+    expect(pruned).toHaveProperty('key-0')
+    expect(pruned).not.toHaveProperty(`key-${MAX_CACHE_ENTRIES + 9}`)
+  })
+
+  it('returns the same reference when nothing is evicted', () => {
+    const cache = { recent: entry(CACHE_TTL + 1_000) }
+    expect(evictStaleEntries(cache)).toBe(cache)
+  })
+})

--- a/src/renderer/src/store/slices/linear/linear-cache.ts
+++ b/src/renderer/src/store/slices/linear/linear-cache.ts
@@ -32,7 +32,7 @@ export function evictStaleEntries<T>(
   const keys = Object.keys(cache)
   const live = keys.filter((key) => now - (cache[key]?.fetchedAt ?? 0) < maxAgeMs)
   if (live.length === keys.length && keys.length <= maxEntries) {
-    return cache // identity preserved so a no-op eviction does not re-render subscribers
+    return cache // no allocation when nothing ages out; callers already pass a fresh object
   }
   const sorted = live.sort((a, b) => (cache[a]?.fetchedAt ?? 0) - (cache[b]?.fetchedAt ?? 0))
   const pruned: Record<string, CacheEntry<T>> = {}

--- a/src/renderer/src/store/slices/linear/linear-cache.ts
+++ b/src/renderer/src/store/slices/linear/linear-cache.ts
@@ -13,6 +13,8 @@ import { linearIssueAttributeFilterSignature } from '../../../../../shared/linea
 export const CACHE_TTL = 60_000 // 60s — same as GitHub work-items revalidation TTL
 export const TEAM_CACHE_TTL = 10 * 60_000 // Teams change rarely and block visible Linear rows.
 export const MAX_CACHE_ENTRIES = 500
+/** Longer than every read TTL (incl. TEAM_CACHE_TTL) so eviction never drops what a reader would still accept, while bounding stale-fallback retention. */
+export const CACHE_EVICTION_MAX_AGE = 15 * 60_000
 
 export function isFresh<T>(
   entry: CacheEntry<T> | undefined,
@@ -23,15 +25,18 @@ export function isFresh<T>(
 
 export function evictStaleEntries<T>(
   cache: Record<string, CacheEntry<T>>,
-  maxEntries = MAX_CACHE_ENTRIES
+  maxEntries = MAX_CACHE_ENTRIES,
+  maxAgeMs = CACHE_EVICTION_MAX_AGE
 ): Record<string, CacheEntry<T>> {
+  const now = Date.now()
   const keys = Object.keys(cache)
-  if (keys.length <= maxEntries) {
-    return cache
+  const live = keys.filter((key) => now - (cache[key]?.fetchedAt ?? 0) < maxAgeMs)
+  if (live.length === keys.length && keys.length <= maxEntries) {
+    return cache // identity preserved so a no-op eviction does not re-render subscribers
   }
-  const sorted = keys.sort((a, b) => (cache[a]?.fetchedAt ?? 0) - (cache[b]?.fetchedAt ?? 0))
+  const sorted = live.sort((a, b) => (cache[a]?.fetchedAt ?? 0) - (cache[b]?.fetchedAt ?? 0))
   const pruned: Record<string, CacheEntry<T>> = {}
-  for (const key of sorted.slice(sorted.length - maxEntries)) {
+  for (const key of sorted.slice(Math.max(0, sorted.length - maxEntries))) {
     pruned[key] = cache[key]
   }
   return pruned


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​169 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​169 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## What

`evictStaleEntries` in the Linear store did not evict anything stale. Despite the name, it dropped entries **oldest-first only when the count exceeded `MAX_CACHE_ENTRIES = 500`**. The `CACHE_TTL = 60_000` constant next to it was read only by `isFresh` on the *read* path — never for eviction. So up to 500 entries of arbitrarily old Linear data stayed resident in the renderer heap indefinitely.

This adds an age pass (`CACHE_EVICTION_MAX_AGE = 15 * 60_000`) that runs before the existing count cap, across all **11** call sites that share this evictor (search, issue list, issue detail, project list/detail/issues, custom-view list/detail/issues/projects, teams).

## Fix evidence

Failing-first, on the committed test:

```
BEFORE  × drops entries older than the eviction horizon and keeps newer ones
        × still enforces the count cap after age eviction, dropping oldest first
        AssertionError: expected { 'key-498': …(499) } to not have property "ancient"
        Tests  2 failed | 2 passed (4)

AFTER   Tests  4 passed (4)
```

Suite: `pnpm test src/renderer/src/store/slices/linear` → **8 files / 64 tests pass** (7 files / 53 tests baseline, unchanged, + new coverage). `pnpm tc:web` clean, `oxlint` clean.

## ELI5

Orca keeps a shortcut box of recently-fetched Linear issues so screens paint instantly. The box had a rule: "if it holds more than 500 things, throw out the oldest." It had no rule for "throw out things that got old." So a stale item could sit there forever as long as the box never filled up. This adds the missing rule — anything older than 15 minutes gets thrown out on the next write — while keeping the 500-item limit as a backstop.

## Why 15 minutes and not the 60s TTL

Eviction must outlive *freshness*, because several readers deliberately serve any-age data:
- `linear-team-actions.ts:48` reads with `TEAM_CACHE_TTL` = **10 minutes** and shares this same evictor.
- The 11 `.catch()` fallbacks serve last-known rows when a fetch fails.
- `largestCachedCollectionBelowLimit` paints a smaller cached page instantly while a larger one loads.

15 min sits strictly above the longest read TTL (10 min), so **no read that would have hit is turned into a refetch**.

## Trade-offs / limits (honest scope)

- **This does not reduce the persisted footprint.** The crash payloads that prompted the investigation show `storeKB.linearSearchCache` pinned at a 1000 KB persisted budget — but the Linear caches are **never hydrated from disk** (`linear.ts:32-42` initialises all 11 to `{}`; there is no counterpart to `github.ts:91-101`). This bounds *in-memory* retention during a session only. Do not read this PR as fixing the persisted cap.
- **Eviction is write-triggered only.** Linear has no periodic sweep (GitHub has `refreshAllGitHub`). If fetches into a given cache map stop, aged entries survive until the next successful fetch into that same map. Bounds growth during active use; does not bound idle retention.
- **No user-visible regression identified.** Eviction runs only inside the success `.then()`, so an offline user never triggers it.
- **Known sibling defect, deliberately not touched:** `store/github/cache-policy.ts:17-27` carries the identical "age alone does not evict" bug behind `CACHE_TTL = 300_000`, feeding 5 caches *plus* disk hydration. That is the higher-leverage follow-up.

## Provenance

Found while triaging crash reports `fb476b1c` and `d4d32680` (fpadilla-fadua, v1.4.198, Linux). **Those two crashes were environmental** — an external `oom_score`-driven kill — and this cache was a contributor to a bloated renderer, **not the cause**. Shipping it on its own merits, not as a crash fix.

## Adversarial review

**1 loop → CLEAN on correctness.** The reviewer independently verified the horizon choice (grepped every `isFresh` call site and every any-age reader; no read TTL exceeds 15 min), confirmed 11 call sites exactly, and wrote 11 adversarial cases covering exact-horizon boundary, `undefined`/`NaN`/`null` `fetchedAt`, NTP-step-backwards future stamps, input non-mutation, and the 501→500 count-cap interaction. It confirmed age-evicted keys are a strict subset of what the count cap would have dropped, so no newer entry is lost.

It also caught two accuracy problems, both fixed here: an in-code comment claimed reference identity avoided subscriber re-renders, which is **inert** for Linear because all 11 call sites pass a freshly-spread object (comment corrected); and the original framing wrongly implied this reduced the persisted footprint (corrected above).
