### PR TITLE
fix(crash-reporting): stop the byte cap starving the daemon log out of crash bundles

### DIFF
--- a/src/main/observability/bundle-daemon-log-budget-starvation.test.ts
+++ b/src/main/observability/bundle-daemon-log-budget-starvation.test.ts
@@ -1,0 +1,227 @@
+// Regression: the daemon lifecycle log used to be appended after the trace family under one
+// shared budget, so a trace family that filled the 4 MiB cap starved it to zero lines.
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { _internalsForTests, collectBundle } from './bundle'
+
+let dir: string
+let traceFile: string
+let daemonFile: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'orca-bundle-daemon-'))
+  traceFile = join(dir, 'main.trace.ndjson')
+  daemonFile = join(dir, 'daemon.log')
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function makeSpan(name: string, padBytes: number): Record<string, unknown> {
+  const now = BigInt(Date.now()) * 1_000_000n
+  return {
+    type: 'effect-span',
+    name,
+    traceId: 'a'.repeat(32),
+    spanId: 'b'.repeat(16),
+    kind: 'internal',
+    startTimeUnixNano: String(now - 1_000_000_000n),
+    endTimeUnixNano: String(now),
+    durationMs: 1,
+    attributes: { message: 'x'.repeat(padBytes) },
+    events: [],
+    exit: { _tag: 'Success' }
+  }
+}
+
+/** Lines are read from EOF backwards, so the newest-first list is written reversed. */
+function writeNewestFirst(file: string, newestFirst: string[]): void {
+  writeFileSync(file, `${newestFirst.toReversed().join('\n')}\n`)
+}
+
+function daemonRecord(event: string, totalBytes: number): string {
+  const base = JSON.stringify({
+    src: 'daemon',
+    ts: new Date().toISOString(),
+    pid: 1,
+    event,
+    detail: ''
+  })
+  return JSON.stringify({
+    src: 'daemon',
+    ts: new Date().toISOString(),
+    pid: 1,
+    event,
+    detail: 'z'.repeat(Math.max(0, totalBytes - base.length))
+  })
+}
+
+/** A span whose serialized length is exactly `totalBytes`. */
+function exactSpan(name: string, totalBytes: number): string {
+  const empty = JSON.stringify(makeSpan(name, 0))
+  return JSON.stringify(makeSpan(name, Math.max(0, totalBytes - empty.length)))
+}
+
+function collectWith(traceFile: string, daemonFile: string): ReturnType<typeof collectBundle> {
+  return collectBundle({
+    traceFilePath: traceFile,
+    maxFiles: 10,
+    daemonLogFilePath: daemonFile,
+    daemonLogMaxFiles: 3,
+    lookbackMinutes: 30,
+    appVersion: '1',
+    platform: 'darwin',
+    arch: 'arm64',
+    osRelease: '24',
+    orcaChannel: 'dev'
+  })
+}
+
+describe('bundle — daemon log under byte-cap pressure', () => {
+  it('still merges a recent daemon lifecycle line when the trace family fills the cap', () => {
+    // Six 1 MiB spans (~6 MiB) guarantee the cap is exhausted inside the trace file.
+    const oneMiB = 1024 * 1024
+    const spans = Array.from({ length: 6 }, (_, i) => makeSpan(`trace-span-${String(i)}`, oneMiB))
+    writeFileSync(traceFile, `${spans.map((s) => JSON.stringify(s)).join('\n')}\n`)
+    writeFileSync(
+      daemonFile,
+      `${JSON.stringify({
+        src: 'daemon',
+        ts: new Date().toISOString(),
+        pid: 1,
+        event: 'session-exited',
+        reason: 'the evidence a crash triage actually needs'
+      })}\n`
+    )
+
+    const bundle = collectBundle({
+      traceFilePath: traceFile,
+      maxFiles: 10,
+      daemonLogFilePath: daemonFile,
+      daemonLogMaxFiles: 3,
+      lookbackMinutes: 30,
+      appVersion: '1',
+      platform: 'darwin',
+      arch: 'arm64',
+      osRelease: '24',
+      orcaChannel: 'dev'
+    })
+
+    const lines = bundle.payload.split('\n').filter((l) => l.length > 0)
+    const traceNames = lines.flatMap((l) => /"name":"(trace-span-\d+)"/.exec(l)?.[1] ?? [])
+    const daemonEvents = lines.flatMap((l) => /"event":"([^"]+)"/.exec(l)?.[1] ?? [])
+
+    // Precondition: the cap really was exhausted by the trace family.
+    expect(bundle.bytes).toBeGreaterThan(_internalsForTests.MAX_BUNDLE_BYTES - 2 * oneMiB)
+    expect(bundle.bytes).toBeLessThanOrEqual(_internalsForTests.MAX_BUNDLE_BYTES)
+    expect(traceNames).toContain('trace-span-5')
+
+    // The daemon line is newer than every trace span it was starved by.
+    expect(daemonEvents).toEqual(['session-exited'])
+  })
+
+  it('stays under the upload cap when both families overflow their budgets', () => {
+    const oneMiB = 1024 * 1024
+    const spans = Array.from({ length: 6 }, (_, i) => makeSpan(`trace-span-${String(i)}`, oneMiB))
+    writeFileSync(traceFile, `${spans.map((s) => JSON.stringify(s)).join('\n')}\n`)
+    // 40 x 32 KiB of daemon lines far exceeds the 256 KiB reserve.
+    const daemonLines = Array.from({ length: 40 }, (_, i) =>
+      JSON.stringify({
+        src: 'daemon',
+        ts: new Date().toISOString(),
+        pid: 1,
+        event: `daemon-event-${String(i)}`,
+        detail: 'y'.repeat(32 * 1024)
+      })
+    )
+    writeFileSync(daemonFile, `${daemonLines.join('\n')}\n`)
+
+    const bundle = collectBundle({
+      traceFilePath: traceFile,
+      maxFiles: 10,
+      daemonLogFilePath: daemonFile,
+      daemonLogMaxFiles: 3,
+      lookbackMinutes: 30,
+      appVersion: '1',
+      platform: 'darwin',
+      arch: 'arm64',
+      osRelease: '24',
+      orcaChannel: 'dev'
+    })
+
+    expect(bundle.bytes).toBeLessThanOrEqual(_internalsForTests.MAX_BUNDLE_BYTES)
+    // The daemon family is bounded by its reserve, and the newest daemon line survives.
+    expect(bundle.payload).toContain('"event":"daemon-event-39"')
+    expect(bundle.payload).not.toContain('"event":"daemon-event-0"')
+    // The trace family still gets the overwhelming majority of the cap.
+    expect(bundle.payload).toContain('"name":"trace-span-5"')
+  })
+
+  it('spends the whole cap on a heavy daemon log when the trace family is light', () => {
+    // The reserve is a floor, not a ceiling: a quiet trace family must not leave the cap unspent
+    // while a daemon in a restart loop is cut off at 256 KiB.
+    writeFileSync(traceFile, `${JSON.stringify(makeSpan('trace-span-0', 1024))}\n`)
+    const daemonLines = Array.from({ length: 32 }, (_, i) =>
+      JSON.stringify({
+        src: 'daemon',
+        ts: new Date().toISOString(),
+        pid: 1,
+        event: `daemon-event-${String(i)}`,
+        detail: 'y'.repeat(64 * 1024)
+      })
+    )
+    writeFileSync(daemonFile, `${daemonLines.join('\n')}\n`)
+
+    const bundle = collectBundle({
+      traceFilePath: traceFile,
+      maxFiles: 10,
+      daemonLogFilePath: daemonFile,
+      daemonLogMaxFiles: 3,
+      lookbackMinutes: 30,
+      appVersion: '1',
+      platform: 'darwin',
+      arch: 'arm64',
+      osRelease: '24',
+      orcaChannel: 'dev'
+    })
+
+    expect(bundle.bytes).toBeLessThanOrEqual(_internalsForTests.MAX_BUNDLE_BYTES)
+    // ~2 MiB of daemon lines must survive, not the 256 KiB the reserve alone would have allowed.
+    expect(bundle.bytes).toBeGreaterThan(4 * _internalsForTests.DAEMON_LOG_RESERVE_BYTES)
+    expect(bundle.payload).toContain('"event":"daemon-event-31"')
+    expect(bundle.payload).toContain('"event":"daemon-event-0"')
+  })
+
+  it('never loses daemon lines the reserve pass had already collected', () => {
+    // Collection is not monotonic in budget: a record the 256 KiB reserve pass skipped as
+    // oversized can be admitted by the larger second-pass budget and then fill it, cutting off
+    // every older line behind it. The larger pass must only be taken when it is actually better.
+    const emptyTrace = join(dir, 'empty.trace.ndjson')
+    writeFileSync(emptyTrace, '')
+    writeFileSync(daemonFile, '')
+    const available =
+      _internalsForTests.MAX_BUNDLE_BYTES - collectWith(emptyTrace, daemonFile).bytes
+
+    const secondPassBudget = 319_488
+    writeNewestFirst(daemonFile, [
+      daemonRecord('newest-lifecycle', 200),
+      // Bigger than the 256 KiB reserve (so pass 1 skips it) but small enough for pass 2 to
+      // admit it and then have no room left for the mediums behind it.
+      daemonRecord('oversized-detail', secondPassBudget - 400),
+      ...Array.from({ length: 6 }, (_, i) => daemonRecord(`m-${String(i)}`, 65_536))
+    ])
+    // One trace line sized so the second-pass daemon budget lands exactly on secondPassBudget.
+    writeFileSync(traceFile, `${exactSpan('t-0', available - secondPassBudget - 1)}\n`)
+
+    const bundle = collectWith(traceFile, daemonFile)
+    const events = bundle.payload.split('\n').flatMap((l) => /"event":"([^"]+)"/.exec(l)?.[1] ?? [])
+
+    expect(bundle.bytes).toBeLessThanOrEqual(_internalsForTests.MAX_BUNDLE_BYTES)
+    // The reserve pass had already banked these; the second pass must not drop them.
+    expect(events).toContain('newest-lifecycle')
+    expect(events).toContain('m-0')
+  })
+})

--- a/src/main/observability/bundle.ts
+++ b/src/main/observability/bundle.ts
@@ -8,7 +8,7 @@
 
 import { randomBytes } from 'node:crypto'
 import { readFileSync, statSync } from 'node:fs'
-import { MAX_BUNDLE_BYTES } from './diagnostic-bundle-limits'
+import { DAEMON_LOG_RESERVE_BYTES, MAX_BUNDLE_BYTES } from './diagnostic-bundle-limits'
 import { listRotatedFiles } from './local-file-sink'
 import { redactValue } from './redactor'
 
@@ -66,40 +66,33 @@ function* readLinesNewestFirst(text: string): Iterable<string> {
   }
 }
 
-/**
- * Read the last N minutes of NDJSON across the rotated family into a redacted bundle payload.
- * Main keeps the uploadable payload so a compromised renderer can't substitute bytes after preview.
- */
-export function collectBundle(opts: CollectBundleOptions): CollectedBundle {
-  const lookbackMs = (opts.lookbackMinutes ?? DEFAULT_LOOKBACK_MINUTES) * 60 * 1000
-  const cutoffMs = Date.now() - lookbackMs
-  const cutoffNanos = BigInt(cutoffMs) * 1_000_000n
-  const bundleSubmissionId = generateBundleSubmissionId()
-  const header: BundleHeader = {
-    bundle_submission_id: bundleSubmissionId,
-    app_version: opts.appVersion,
-    platform: opts.platform,
-    arch: opts.arch,
-    os_release: opts.osRelease,
-    orca_channel: opts.orcaChannel,
-    collected_at: new Date().toISOString(),
-    schema_version: 1
+type FamilyLines = {
+  readonly lines: string[]
+  readonly bytes: number
+  readonly spanCount: number
+}
+
+/** More lifecycle lines wins; equal lines fall back to more bytes. */
+function isRicherFamily(candidate: FamilyLines, incumbent: FamilyLines): boolean {
+  return candidate.lines.length === incumbent.lines.length
+    ? candidate.bytes >= incumbent.bytes
+    : candidate.lines.length > incumbent.lines.length
+}
+
+/** Collect one rotated family newest → oldest, adding at most `budget` bytes. */
+function collectFamilyLines(
+  files: readonly string[],
+  budget: number,
+  cutoffMs: number,
+  cutoffNanos: bigint
+): FamilyLines {
+  const lines: string[] = []
+  let bytes = 0
+  let spanCount = 0
+  if (budget <= 0) {
+    return { lines, bytes, spanCount }
   }
 
-  const headerLine = JSON.stringify({ type: 'bundle-header', ...header })
-  const lines: string[] = [headerLine]
-  let spanCount = 0
-  // Track bytes incrementally to avoid an O(N²) `lines.join('\n').length` per span.
-  let currentBytes = Buffer.byteLength(`${headerLine}\n`)
-  const maxRecordBytes = MAX_BUNDLE_BYTES - currentBytes
-
-  // Trace files then daemon log, each newest → oldest so the byte cap keeps the most recent spans.
-  const files = [
-    ...listRotatedFiles(opts.traceFilePath, opts.maxFiles),
-    ...(opts.daemonLogFilePath
-      ? listRotatedFiles(opts.daemonLogFilePath, opts.daemonLogMaxFiles ?? opts.maxFiles)
-      : [])
-  ]
   outer: for (const file of files) {
     let text: string
     try {
@@ -149,26 +142,82 @@ export function collectBundle(opts: CollectBundleOptions): CollectedBundle {
       // Second redaction pass (server mode) catches nested auth fields and strips identity keys before preview.
       const redacted = JSON.stringify(redactValue(parsed, 'server'))
       const redactedBytes = Buffer.byteLength(redacted) + 1
-      if (redactedBytes > maxRecordBytes) {
+      if (redactedBytes > budget) {
         // Skip a single oversized record so it can't suppress every smaller span behind it.
         continue
       }
-      if (currentBytes + redactedBytes > MAX_BUNDLE_BYTES) {
-        // Hard ceiling matches the upload endpoint's 4 MiB; check before appending so the preview uploads as-is.
+      if (bytes + redactedBytes > budget) {
+        // This family is full; the caller's remaining budget still covers the other family.
         break outer
       }
       lines.push(redacted)
       spanCount += 1
-      currentBytes += redactedBytes
+      bytes += redactedBytes
     }
   }
 
-  const payload = `${lines.join('\n')}\n`
+  return { lines, bytes, spanCount }
+}
+
+/**
+ * Read the last N minutes of NDJSON across the rotated family into a redacted bundle payload.
+ * Main keeps the uploadable payload so a compromised renderer can't substitute bytes after preview.
+ */
+export function collectBundle(opts: CollectBundleOptions): CollectedBundle {
+  const lookbackMs = (opts.lookbackMinutes ?? DEFAULT_LOOKBACK_MINUTES) * 60 * 1000
+  const cutoffMs = Date.now() - lookbackMs
+  const cutoffNanos = BigInt(cutoffMs) * 1_000_000n
+  const bundleSubmissionId = generateBundleSubmissionId()
+  const header: BundleHeader = {
+    bundle_submission_id: bundleSubmissionId,
+    app_version: opts.appVersion,
+    platform: opts.platform,
+    arch: opts.arch,
+    os_release: opts.osRelease,
+    orca_channel: opts.orcaChannel,
+    collected_at: new Date().toISOString(),
+    schema_version: 1
+  }
+
+  const headerLine = JSON.stringify({ type: 'bundle-header', ...header })
+  const available = MAX_BUNDLE_BYTES - Buffer.byteLength(`${headerLine}\n`)
+
+  const daemonFiles = opts.daemonLogFilePath
+    ? listRotatedFiles(opts.daemonLogFilePath, opts.daemonLogMaxFiles ?? opts.maxFiles)
+    : []
+
+  // Daemon family first, under a small reserve: it is tiny and high-value, and a trace family
+  // that fills the whole cap would otherwise starve it to zero lines.
+  const reserve = Math.min(DAEMON_LOG_RESERVE_BYTES, available)
+  const reserved = collectFamilyLines(daemonFiles, reserve, cutoffMs, cutoffNanos)
+  // Trace gets every reserved byte the daemon log did not use.
+  const trace = collectFamilyLines(
+    listRotatedFiles(opts.traceFilePath, opts.maxFiles),
+    available - reserved.bytes,
+    cutoffMs,
+    cutoffNanos
+  )
+  // Why a second daemon pass: the reserve is a floor, not a ceiling. A light trace family would
+  // otherwise leave megabytes of cap unspent while a busy daemon log was cut off at the reserve.
+  const daemonBudget = available - trace.bytes
+  const rerun =
+    daemonBudget > reserved.bytes
+      ? collectFamilyLines(daemonFiles, daemonBudget, cutoffMs, cutoffNanos)
+      : reserved
+  // Why keep the better pass: collection is not monotonic in budget. A record the reserve pass
+  // skipped as oversized can be admitted by the larger budget and then fill it, cutting off
+  // everything behind it — and a daemon rotation between the two reads has the same effect.
+  // Lines rank above bytes: the daemon log's value is the sequence of lifecycle events, so four
+  // events beat one blob that happens to weigh more.
+  const daemon = isRicherFamily(rerun, reserved) ? rerun : reserved
+
+  // Emitted trace-then-daemon, each family newest → oldest within itself.
+  const payload = `${[headerLine, ...trace.lines, ...daemon.lines].join('\n')}\n`
   return {
     bundleSubmissionId,
     payload,
     bytes: Buffer.byteLength(payload),
-    spanCount
+    spanCount: trace.spanCount + daemon.spanCount
   }
 }
 
@@ -186,5 +235,6 @@ export function generateBundleSubmissionId(): string {
 
 // Test-only export.
 export const _internalsForTests = {
+  DAEMON_LOG_RESERVE_BYTES,
   MAX_BUNDLE_BYTES
 }

--- a/src/main/observability/diagnostic-bundle-limits.ts
+++ b/src/main/observability/diagnostic-bundle-limits.ts
@@ -1,1 +1,5 @@
 export const MAX_BUNDLE_BYTES = 4 * 1024 * 1024 // 4 MiB cap enforced before upload
+// Why: the trace family alone routinely fills the whole cap on a busy session, which
+// would otherwise leave zero bytes for the daemon lifecycle log. Only the bytes the
+// daemon family actually uses are taken from the trace family's budget.
+export const DAEMON_LOG_RESERVE_BYTES = 256 * 1024


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​227 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​227 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |

<!-- /orca-pr-loc -->

## What

The crash diagnostic bundle is capped at 4 MiB. The collector built **one flat file list** — `[...traceFiles, ...daemonFiles]` — and did `break outer` when the cap was hit, abandoning the **entire remaining list**. Because the daemon family was appended *after* the trace family, any session busy enough to fill 4 MiB with trace spans left the daemon lifecycle log with **zero lines**.

That silently broke the contract documented at `bundle.ts:20`:

> *"Detached-daemon lifecycle log; its rotated family is merged in so daemon failures are diagnosable from a field report."*

## Fix evidence — measured on four real field bundles

Every crash bundle in the v1.4.199 triage window is pinned within 1 KB of the 4 MiB cap and contains **exactly zero daemon lines**:

| Bundle | Total records | Trace spans | **Daemon lines** | Bytes (cap 4194304) |
|---|---|---|---|---|
| `593e20ea` pedroguimaraes | 7142 | 7141 | **0** | 4194126 |
| `fb476b1c` fpadilla-fadua | 6889 | 6888 | **0** | 4193990 |
| `d4d32680` fpadilla-fadua | 6863 | 6862 | **0** | 4193296 |
| `8eea1671` hector-ae03 | 5319 | 5318 | **0** | 4193760 |

This is not a case of the daemon log being unrequested: the crash path passes it unconditionally (`observability/index.ts:245`, `daemonLogFilePath: getDaemonLogFilePath()`).

Failing-first, on the committed tests:

```
WITHOUT FIX
  × still merges a recent daemon lifecycle line when the trace family fills the cap
    AssertionError: expected [] to deeply equal [ 'session-exited' ]
  × stays under the upload cap when both families overflow their budgets
  × spends the whole cap on a heavy daemon log when the trace family is light
    AssertionError: expected 198442 to be greater than 1048576
  × never loses daemon lines the reserve pass had already collected
    AssertionError: expected [ 'newest-lifecycle', …(1) ] to include 'm-0'

WITH FIX
  Test Files 10 passed (10)
  Tests     151 passed (151)
```

`pnpm tc:node` clean, `oxlint` clean.

## ELI5

Crash reports carry a 4 MB evidence bundle. The packer filled it from two piles — app traces first, daemon logs second — and stopped the instant the box was full. On any busy session the trace pile filled the box by itself, so **the daemon pile never got in at all**, even though the code's own comment promised it would. Now each pile gets its own budget: the daemon log is guaranteed a small slice, the traces get everything the daemon log didn't use, and if the traces finish early the daemon log gets the leftovers too.

## How the budget works

1. Daemon family collected first under a **256 KiB reserve**.
2. Trace family gets `available - reserved.bytes` — every reserved byte the daemon log did not use is handed back.
3. Daemon family re-collected with `available - trace.bytes` — the reserve is a **floor, not a ceiling**, so a light trace family does not leave the cap unspent.
4. The richer of the two daemon passes is kept (more lifecycle lines wins; equal lines falls back to more bytes).

Step 4 exists because collection is **not monotonic in budget**: a record the reserve pass skipped as oversized can be admitted by the larger budget, fill it, and cut off everything behind it. A daemon rotation between the two reads has the same effect.

## Trade-offs

- **The daemon family is read twice.** Measured at **1.63 ms** for a full 5.24 MB daemon log (whole heavy collect 19.4 ms; trace-only 0.2 ms). This is a user-initiated path. Optional future tightening: return a `truncated` flag from `collectFamilyLines` and skip the rerun when the reserve pass drained the family.
- **The oversized-single-record threshold narrowed** for the daemon family from ~4 MiB to the family budget. Judged near-theoretical: daemon lines are terse `{src, ts, pid, event, …scalars}` (`daemon-file-log.ts:103`, ~33 call sites, no stacks or output capture). Triggering the worst case needs ~15 daemon records each over 256 KiB.
- **Trace loses at most 256 KiB** (6% of the cap) and only when the daemon log actually uses it.
- **No user-visible behaviour change.** Bundle line order is unchanged in effect — no consumer parses it (payload goes to the upload body, the preview `writeFileSync`, and crash-feedback `content`).

## Provenance

Found while triaging v1.4.199 crash reports. **None of those four crashes were caused by Orca** — all were host memory/commit exhaustion. This is a diagnostics defect that made them *harder to diagnose*, shipped on its own merits.

## Adversarial review — 3 loops to clean

- **Loop 1 — CONFIRMED:** the 256 KiB reserve acted as a hard **ceiling**. Light trace + heavy daemon truncated the daemon log at 256 KiB while ~3.8 MiB of cap went unused (measured: old 2,100,032 B / 32 spans vs new 197,091 B / 3). Fixed by the third phase above. Loop 1 also cleared the cap invariant algebraically, showing each `+1` per line is exactly the join separator it pays for.
- **Loop 2 — CONFIRMED:** data loss. `collectFamilyLines` is not monotonic in budget; measured the reserve pass banking 196,808 B / 4 daemon lines and the second pass returning 200 B / 1 line, which the code took blindly. Fixed by keeping the richer pass. (Loop 2 proposed comparing bytes; that was **rejected** — a constructed case showed bytes alone still drops 3 lifecycle lines to gain one 319 KB blob.)
- **Loop 3 — CLEAN.** Independently re-verified rather than trusting loop 2. Built the worst case for the more-lines rule (4×975 KiB blobs ahead of 5000 terse lines: more-lines keeps 2166 lines / 262,825 B where bytes-alone keeps ~3.9 MiB) and showed it **unreachable** given how the daemon log is actually written. Confirmed more-lines makes the guarantee *provable* — the reserve pass cannot admit zero, so `daemon.lines >= reserved.lines >= 1` — and noted the field defect was itself measured in daemon **line count**. Cap proven exact to the byte in both comparator branches (4,194,304, delta 0); `spanCount` asserted correct across ~215 generated bundles; rotation race driven by mutating the file between reads; 200-bundle fuzz seeded with oversized daemon records, no invariant broken.
