### PR TITLE
fix(daemon): pin owner-only modes on persisted terminal history

### DIFF
--- a/src/main/daemon/daemon-launch-paths.ts
+++ b/src/main/daemon/daemon-launch-paths.ts
@@ -1,7 +1,9 @@
-import { existsSync, mkdirSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { connect } from 'node:net'
 import { join } from 'node:path'
 import { getAppEnvironment } from '../../shared/app-environment'
+import { ensurePrivateDir } from './daemon-private-file-modes'
+import { scheduleTerminalHistoryPermissionRepair } from './terminal-history-permission-repair'
 import { getDaemonLogFilePath } from '../observability/logs-directory'
 import { DaemonClient } from './client'
 import { daemonRecoveryProbeTimeoutMs } from './daemon-recovery-budget'
@@ -10,13 +12,16 @@ import { PROTOCOL_VERSION, type ListSessionsResult } from './types'
 
 export function getDaemonRuntimeDir(): string {
   const dir = join(getAppEnvironment().getPath('userData'), 'daemon')
-  mkdirSync(dir, { recursive: true })
+  ensurePrivateDir(dir)
   return dir
 }
 
 export function getDaemonHistoryDir(): string {
   const dir = join(getAppEnvironment().getPath('userData'), 'terminal-history')
-  mkdirSync(dir, { recursive: true })
+  ensurePrivateDir(dir)
+  // Why here: the one accessor every history producer goes through, so the backlog sweep is hooked
+  // once per host that owns the files — native, WSL, or a remote SSH server's own main process.
+  scheduleTerminalHistoryPermissionRepair(dir)
   return dir
 }
 

--- a/src/main/daemon/daemon-launch-paths.ts
+++ b/src/main/daemon/daemon-launch-paths.ts
@@ -21,7 +21,8 @@ export function getDaemonHistoryDir(): string {
   ensurePrivateDir(dir)
   // Why here: the one accessor every history producer goes through, so the backlog sweep is hooked
   // once per host that owns the files — native, WSL, or a remote SSH server's own main process.
-  scheduleTerminalHistoryPermissionRepair(dir)
+  // The scheduler defers and de-duplicates, so the several startup calls cost one late sweep.
+  void scheduleTerminalHistoryPermissionRepair(dir)
   return dir
 }
 

--- a/src/main/daemon/daemon-private-file-modes.ts
+++ b/src/main/daemon/daemon-private-file-modes.ts
@@ -1,0 +1,33 @@
+// Mode primitives for daemon-owned on-disk state. Terminal history persists verbatim screen and
+// scrollback (checkpoint.json holds snapshotAnsi + scrollbackAnsi) and the runtime dir holds the
+// daemon's auth token, so neither may be left at whatever umask applies to other local users.
+
+import { chmodSync, existsSync, mkdirSync } from 'node:fs'
+
+export const PRIVATE_DIR_MODE = 0o700
+export const PRIVATE_FILE_MODE = 0o600
+
+/** Windows ignores POSIX mode bits and can reject chmod outright; hardening must never break a write. */
+export function supportsPosixFileModes(): boolean {
+  return process.platform !== 'win32'
+}
+
+/** Best-effort repair for a path created before modes were pinned (or by an older daemon). */
+export function tightenPathMode(path: string, mode: number): void {
+  if (!supportsPosixFileModes()) {
+    return
+  }
+  try {
+    if (existsSync(path)) {
+      chmodSync(path, mode)
+    }
+  } catch {
+    // Read-only volumes, foreign ownership, exotic filesystems: leave the mode as found.
+  }
+}
+
+/** mkdir with the private mode, plus a chmod repair for a directory that already existed. */
+export function ensurePrivateDir(dir: string): void {
+  mkdirSync(dir, { recursive: true, mode: PRIVATE_DIR_MODE })
+  tightenPathMode(dir, PRIVATE_DIR_MODE)
+}

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -11,6 +11,7 @@ import {
   type ActiveHistoryRecoveryFreeze,
   type HistoryRecoveryFreeze
 } from './terminal-history-recovery-quarantine'
+import { TerminalHistoryRecoveryFreezes } from './terminal-history-recovery-freezes'
 import {
   removeTerminalHistorySessionTrees,
   schedulePendingSessionTreeRemovals
@@ -39,7 +40,7 @@ export class HistoryManager {
   private writers = new Map<string, TerminalHistorySessionWriter>()
   private disabledSessions = new Set<string>()
   private mutations = new TerminalHistoryMutationTracker()
-  private recoveryFreezes = new Map<string, ActiveHistoryRecoveryFreeze>()
+  private readonly recoveryFreezes: TerminalHistoryRecoveryFreezes
   private onWriteError?: (sessionId: string, error: Error) => void
   private checkpointMaxBytes: number
 
@@ -49,6 +50,7 @@ export class HistoryManager {
   ) {
     this.onWriteError = opts?.onWriteError
     this.checkpointMaxBytes = opts?.checkpointMaxBytes ?? TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES
+    this.recoveryFreezes = new TerminalHistoryRecoveryFreezes(basePath)
     // Why: a quit between tombstone and reclaim leaves the tree on disk; nothing else rescans the queue.
     schedulePendingSessionTreeRemovals(this.basePath)
   }
@@ -57,7 +59,7 @@ export class HistoryManager {
     let recoveryFreeze = opts.recoveryFreeze
     try {
       this.disabledSessions.delete(sessionId)
-      const dir = join(this.basePath, getHistorySessionDirName(sessionId))
+      const dir = this.sessionDir(sessionId)
       recoveryFreeze ??= await this.freezeForRecovery(sessionId)
       const activeFreeze = this.requireRecoveryFreeze(sessionId, recoveryFreeze)
 
@@ -70,7 +72,7 @@ export class HistoryManager {
       ) {
         throw new Error('terminal_history_recovery_generation_changed')
       }
-      this.recoveryFreezes.delete(sessionId)
+      this.recoveryFreezes.release(sessionId)
       ensurePrivateDir(dir)
 
       const meta: SessionMeta = {
@@ -110,14 +112,14 @@ export class HistoryManager {
       token: randomUUID()
     }
     const activeFreeze: ActiveHistoryRecoveryFreeze = { handle }
-    this.recoveryFreezes.set(sessionId, activeFreeze)
+    this.recoveryFreezes.hold(sessionId, activeFreeze)
     try {
       await this.mutations.wait(sessionId)
       activeFreeze.fingerprint = fingerprintTerminalHistorySession(this.basePath, sessionId)
       return handle
     } catch (err) {
       if (this.recoveryFreezes.get(sessionId) === activeFreeze) {
-        this.recoveryFreezes.delete(sessionId)
+        this.recoveryFreezes.release(sessionId)
       }
       throw err
     }
@@ -126,7 +128,7 @@ export class HistoryManager {
   abandonRecoveryFreeze(freeze?: HistoryRecoveryFreeze): void {
     const activeFreeze = freeze ? this.recoveryFreezes.get(freeze.sessionId) : undefined
     if (activeFreeze && activeFreeze.handle === freeze) {
-      this.recoveryFreezes.delete(activeFreeze.handle.sessionId)
+      this.recoveryFreezes.release(activeFreeze.handle.sessionId)
     }
   }
 
@@ -147,7 +149,7 @@ export class HistoryManager {
         ) {
           throw new Error('terminal_history_recovery_generation_changed')
         }
-        this.recoveryFreezes.delete(sessionId)
+        this.recoveryFreezes.release(sessionId)
       } catch (err) {
         this.abandonRecoveryFreeze(recoveryFreeze)
         this.handleWriteError(sessionId, err)
@@ -156,7 +158,7 @@ export class HistoryManager {
     } else if (this.recoveryFreezes.has(sessionId)) {
       return
     }
-    const dir = join(this.basePath, getHistorySessionDirName(sessionId))
+    const dir = this.sessionDir(sessionId)
     this.writers.set(
       sessionId,
       new TerminalHistorySessionWriter(dir, false, this.checkpointMaxBytes)
@@ -272,7 +274,7 @@ export class HistoryManager {
   async removeSession(sessionId: string): Promise<void> {
     this.writers.delete(sessionId)
     this.disabledSessions.delete(sessionId)
-    this.recoveryFreezes.delete(sessionId)
+    this.recoveryFreezes.release(sessionId)
     await this.mutations.wait(sessionId)
     // Why tombstoned: writer handles are closed by here, so the trees only have to become unreachable —
     // they reach hundreds of MB and every terminal a worktree delete tears down awaits this.
@@ -292,12 +294,11 @@ export class HistoryManager {
   }
 
   hasHistory(sessionId: string): boolean {
-    return existsSync(join(this.basePath, getHistorySessionDirName(sessionId), 'meta.json'))
+    return existsSync(join(this.sessionDir(sessionId), 'meta.json'))
   }
 
   readMeta(sessionId: string): SessionMeta | null {
-    const dir = join(this.basePath, getHistorySessionDirName(sessionId))
-    return readTerminalHistoryMetaFromDir(dir)
+    return readTerminalHistoryMetaFromDir(this.sessionDir(sessionId))
   }
 
   async dispose(): Promise<void> {
@@ -313,12 +314,17 @@ export class HistoryManager {
       }
     }
     this.writers.clear()
+    this.recoveryFreezes.releaseAll()
   }
 
   // Why: history is best-effort; callers fire-and-forget so a throw would be an unhandled rejection — disable instead.
   private handleWriteError(sessionId: string, err: unknown): void {
     this.disabledSessions.add(sessionId)
     this.onWriteError?.(sessionId, err as Error)
+  }
+
+  private sessionDir(sessionId: string): string {
+    return join(this.basePath, getHistorySessionDirName(sessionId))
   }
 
   private requireRecoveryFreeze(

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -1,7 +1,9 @@
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
-import { mkdirSync, writeFileSync, existsSync, unlinkSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { getHistorySessionDirName } from './history-paths'
+import { ensurePrivateDir } from './daemon-private-file-modes'
+import { clearReplayableTerminalHistorySessionFiles } from './terminal-history-session-files'
 import {
   fingerprintTerminalHistorySession,
   hasTerminalHistoryRecoveryProtection,
@@ -17,6 +19,7 @@ import { TerminalHistorySessionWriter } from './terminal-history-session-writer'
 import {
   readTerminalHistoryMetaFromDir,
   updateTerminalHistoryMeta,
+  writeTerminalHistoryMeta,
   type SessionMeta
 } from './terminal-history-metadata'
 import type { PendingOutputRecord, TerminalSnapshot } from './types'
@@ -68,7 +71,7 @@ export class HistoryManager {
         throw new Error('terminal_history_recovery_generation_changed')
       }
       this.recoveryFreezes.delete(sessionId)
-      mkdirSync(dir, { recursive: true })
+      ensurePrivateDir(dir)
 
       const meta: SessionMeta = {
         cwd: opts.cwd,
@@ -78,21 +81,10 @@ export class HistoryManager {
         endedAt: null,
         exitCode: null
       }
-      writeFileSync(join(dir, 'meta.json'), JSON.stringify(meta, null, 2))
+      writeTerminalHistoryMeta(dir, meta)
 
       if (!opts.quarantineUnreadableRecovery) {
-        // Why: a crash before the first checkpoint must not replay a cleanly ended prior session.
-        for (const staleFile of [
-          join(dir, 'checkpoint.json'),
-          join(dir, 'scrollback.bin'),
-          join(dir, 'output.log')
-        ]) {
-          try {
-            unlinkSync(staleFile)
-          } catch {
-            // ENOENT is expected for new sessions
-          }
-        }
+        clearReplayableTerminalHistorySessionFiles(dir)
       }
 
       this.writers.set(

--- a/src/main/daemon/terminal-history-metadata.ts
+++ b/src/main/daemon/terminal-history-metadata.ts
@@ -4,6 +4,7 @@ import { getHistorySessionDirName } from './history-paths'
 import { isValidTerminalHistorySize } from './terminal-history-dimensions'
 import { readTerminalHistoryJson } from './terminal-history-file-reader'
 import { TERMINAL_HISTORY_META_MAX_BYTES } from './terminal-history-file-limits'
+import { PRIVATE_FILE_MODE, tightenPathMode } from './daemon-private-file-modes'
 
 export type SessionMeta = {
   cwd: string
@@ -44,13 +45,21 @@ export function readTerminalHistoryMetaFromDir(dir: string): SessionMeta | null 
   }
 }
 
+/** meta.json records the session's cwd, so it is private like the rest of the tree. */
+export function writeTerminalHistoryMeta(dir: string, meta: SessionMeta): void {
+  const metaPath = join(dir, 'meta.json')
+  writeFileSync(metaPath, JSON.stringify(meta, null, 2), { mode: PRIVATE_FILE_MODE })
+  // `mode` applies only at creation, so a rewrite of an older daemon's file needs the chmod.
+  tightenPathMode(metaPath, PRIVATE_FILE_MODE)
+}
+
 export function updateTerminalHistoryMeta(dir: string, updates: Partial<SessionMeta>): void {
   const meta = readTerminalHistoryMetaFromDir(dir)
   if (!meta) {
     return
   }
   Object.assign(meta, updates)
-  writeFileSync(join(dir, 'meta.json'), JSON.stringify(meta, null, 2))
+  writeTerminalHistoryMeta(dir, meta)
 }
 
 function isSessionMeta(value: unknown): value is SessionMeta {

--- a/src/main/daemon/terminal-history-permission-repair.ts
+++ b/src/main/daemon/terminal-history-permission-repair.ts
@@ -7,18 +7,27 @@
 
 import { existsSync, type Dirent } from 'node:fs'
 import { chmod, readdir, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import {
   PRIVATE_DIR_MODE,
   PRIVATE_FILE_MODE,
   supportsPosixFileModes
 } from './daemon-private-file-modes'
+import { isTerminalHistorySessionDirRecoveryProtected } from './terminal-history-recovery-quarantine'
 
 const REPAIR_MARKER_NAME = '.permissions-repaired-v1'
 // Bounds the one-time walk: retention keeps 10k session trees, each a handful of files.
 const MAX_REPAIR_ENTRIES = 200_000
 // base → session/quarantine owner → quarantined generation → files.
 const MAX_REPAIR_DEPTH = 3
+// Same 10s the sibling history GC waits before walking this very tree, and for the same reason:
+// stay off startup-critical I/O (see scheduleHistoryGc in src/main/terminal-history-gc.ts).
+const REPAIR_START_DELAY_MS = 10_000
+
+// Per-process, keyed by base path: getDaemonHistoryDir() is the accessor every history producer
+// goes through, and a single startup calls it more than once. Never cleared, so a sweep that throws
+// cannot wedge a retry loop — the on-disk marker is what carries the decision across launches.
+const scheduledBasePaths = new Set<string>()
 
 async function chmodQuietly(path: string, mode: number): Promise<void> {
   try {
@@ -35,6 +44,12 @@ async function tightenTree(root: string): Promise<void> {
     const current = queue.shift()
     if (!current) {
       return
+    }
+    // Why skip: chmod moves the mode/ctime that the recovery fingerprint hashes, so sweeping a tree
+    // mid-freeze fails the re-check and silently stops that pane persisting for the rest of the run.
+    // Nothing is left loose — the session's own writer tightens its tree when it attaches.
+    if (current.depth > 0 && isTerminalHistorySessionDirRecoveryProtected(current.dir)) {
+      continue
     }
     await chmodQuietly(current.dir, PRIVATE_DIR_MODE)
     let entries: Dirent[]
@@ -55,6 +70,10 @@ async function tightenTree(root: string): Promise<void> {
           queue.push({ dir: child, depth: current.depth + 1 })
         }
       } else if (entry.isFile()) {
+        // Re-checked per file: a freeze can open while this directory is being walked.
+        if (current.depth > 0 && isTerminalHistorySessionDirRecoveryProtected(current.dir)) {
+          break
+        }
         await chmodQuietly(child, PRIVATE_FILE_MODE)
       }
     }
@@ -80,9 +99,20 @@ export async function repairTerminalHistoryPermissions(basePath: string): Promis
   return true
 }
 
-/** Fire-and-forget so the daemon's startup path never waits on, or fails from, permission hardening. */
-export function scheduleTerminalHistoryPermissionRepair(basePath: string): void {
-  void repairTerminalHistoryPermissions(basePath).catch(() => {
-    // Best-effort by construction.
-  })
+/** Deferred and once per base path per process, so daemon init neither waits on permission hardening
+ *  nor runs two sweeps over one tree. Resolves with the sweep's outcome, or `null` when already
+ *  scheduled; callers on the startup path ignore it. */
+export function scheduleTerminalHistoryPermissionRepair(basePath: string): Promise<boolean> | null {
+  const key = resolve(basePath)
+  if (scheduledBasePaths.has(key)) {
+    return null
+  }
+  scheduledBasePaths.add(key)
+  const { promise, resolve: settle } = Promise.withResolvers<boolean>()
+  const timer = setTimeout(() => {
+    repairTerminalHistoryPermissions(key).then(settle, () => settle(false))
+  }, REPAIR_START_DELAY_MS)
+  // Why: a pending sweep must never be the reason the process (or a test worker) stays alive.
+  timer.unref()
+  return promise
 }

--- a/src/main/daemon/terminal-history-permission-repair.ts
+++ b/src/main/daemon/terminal-history-permission-repair.ts
@@ -1,0 +1,88 @@
+// History trees written before owner-only modes were pinned landed at whatever umask applied, which on
+// a default umask leaves every checkpoint.json world-readable. This is the backlog repair: one bounded
+// sweep of the base dir, marker-guarded so every later launch costs one existsSync rather than a walk
+// over 10k session trees. Live trees are tightened per-session in terminal-history-session-files.
+//
+// The marker is a regular file, so `history-reader`'s directory-only session scan already skips it.
+
+import { existsSync, type Dirent } from 'node:fs'
+import { chmod, readdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  PRIVATE_DIR_MODE,
+  PRIVATE_FILE_MODE,
+  supportsPosixFileModes
+} from './daemon-private-file-modes'
+
+const REPAIR_MARKER_NAME = '.permissions-repaired-v1'
+// Bounds the one-time walk: retention keeps 10k session trees, each a handful of files.
+const MAX_REPAIR_ENTRIES = 200_000
+// base → session/quarantine owner → quarantined generation → files.
+const MAX_REPAIR_DEPTH = 3
+
+async function chmodQuietly(path: string, mode: number): Promise<void> {
+  try {
+    await chmod(path, mode)
+  } catch {
+    // A path that cannot be tightened must not abort the rest of the sweep.
+  }
+}
+
+async function tightenTree(root: string): Promise<void> {
+  const queue: { dir: string; depth: number }[] = [{ dir: root, depth: 0 }]
+  let budget = MAX_REPAIR_ENTRIES
+  while (queue.length > 0 && budget > 0) {
+    const current = queue.shift()
+    if (!current) {
+      return
+    }
+    await chmodQuietly(current.dir, PRIVATE_DIR_MODE)
+    let entries: Dirent[]
+    try {
+      entries = await readdir(current.dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      budget -= 1
+      if (budget <= 0) {
+        return
+      }
+      // Dirent types come from lstat, so symlinks match neither branch and are never chased.
+      const child = join(current.dir, entry.name)
+      if (entry.isDirectory()) {
+        if (current.depth < MAX_REPAIR_DEPTH) {
+          queue.push({ dir: child, depth: current.depth + 1 })
+        }
+      } else if (entry.isFile()) {
+        await chmodQuietly(child, PRIVATE_FILE_MODE)
+      }
+    }
+  }
+}
+
+/** Resolves `true` when the sweep ran. The marker is written even if some paths resisted chmod, so a
+ *  permanently unfixable file cannot make every launch re-walk the tree. */
+export async function repairTerminalHistoryPermissions(basePath: string): Promise<boolean> {
+  if (!supportsPosixFileModes() || !existsSync(basePath)) {
+    return false
+  }
+  const markerPath = join(basePath, REPAIR_MARKER_NAME)
+  if (existsSync(markerPath)) {
+    return false
+  }
+  await tightenTree(basePath)
+  try {
+    await writeFile(markerPath, '', { mode: PRIVATE_FILE_MODE })
+  } catch {
+    // Marker write failed: the next launch repeats a bounded, idempotent sweep.
+  }
+  return true
+}
+
+/** Fire-and-forget so the daemon's startup path never waits on, or fails from, permission hardening. */
+export function scheduleTerminalHistoryPermissionRepair(basePath: string): void {
+  void repairTerminalHistoryPermissions(basePath).catch(() => {
+    // Best-effort by construction.
+  })
+}

--- a/src/main/daemon/terminal-history-permissions.test.ts
+++ b/src/main/daemon/terminal-history-permissions.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { HistoryManager } from './history-manager'
+import { HistoryReader } from './history-reader'
+import { getHistorySessionDirName } from './history-paths'
+import { flushPendingSessionTreeRemovals } from './terminal-history-session-tombstone'
+import { repairTerminalHistoryPermissions } from './terminal-history-permission-repair'
+import { tightenTerminalHistorySessionDirMode } from './terminal-history-session-files'
+import type { TerminalModes, TerminalSnapshot } from './types'
+
+const onPosix = it.skipIf(process.platform === 'win32')
+const REPAIR_MARKER_NAME = '.permissions-repaired-v1'
+
+const defaultModes: TerminalModes = {
+  bracketedPaste: false,
+  mouseTracking: false,
+  applicationCursor: false,
+  alternateScreen: false
+}
+
+function makeSnapshot(overrides: Partial<TerminalSnapshot> = {}): TerminalSnapshot {
+  return {
+    snapshotAnsi: 'secret scrollback\r\n',
+    scrollbackAnsi: '',
+    rehydrateSequences: '',
+    cwd: '/tmp',
+    modes: defaultModes,
+    cols: 80,
+    rows: 24,
+    scrollbackLines: 0,
+    ...overrides
+  }
+}
+
+function modeOf(path: string): number {
+  return statSync(path).mode & 0o777
+}
+
+function sessionPath(baseDir: string, sessionId: string, file: string): string {
+  return join(baseDir, getHistorySessionDirName(sessionId), file)
+}
+
+/** `process.platform` is read at call time, so the Windows branch is reachable from a POSIX runner. */
+function stubPlatform(platform: NodeJS.Platform): () => void {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+  return () => {
+    if (original) {
+      Object.defineProperty(process, 'platform', original)
+    }
+  }
+}
+
+describe('terminal history file permissions', () => {
+  const createdDirs: string[] = []
+
+  /** Repair tests need a base dir with no HistoryManager racing its own startup sweep against them. */
+  function isolatedDir(): string {
+    const created = mkdtempSync(join(tmpdir(), 'history-perms-test-'))
+    createdDirs.push(created)
+    return created
+  }
+
+  afterEach(async () => {
+    await flushPendingSessionTreeRemovals()
+    for (const created of createdDirs.splice(0)) {
+      rmSync(created, { recursive: true, force: true })
+    }
+  })
+
+  describe('newly written history', () => {
+    let dir: string
+    let mgr: HistoryManager
+
+    beforeEach(() => {
+      dir = isolatedDir()
+      mgr = new HistoryManager(dir)
+    })
+
+    afterEach(async () => {
+      await mgr.dispose()
+    })
+
+    onPosix('pins 0o700 on the session directory and 0o600 on meta.json', async () => {
+      await mgr.openSession('sess-1', { cwd: '/home/user', cols: 80, rows: 24 })
+
+      expect(modeOf(join(dir, getHistorySessionDirName('sess-1')))).toBe(0o700)
+      expect(modeOf(sessionPath(dir, 'sess-1', 'meta.json'))).toBe(0o600)
+    })
+
+    onPosix('pins 0o600 on checkpoint.json, which holds verbatim scrollback', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
+      await mgr.checkpoint('sess-1', makeSnapshot())
+
+      const checkpointPath = sessionPath(dir, 'sess-1', 'checkpoint.json')
+      expect(readFileSync(checkpointPath, 'utf-8')).toContain('secret scrollback')
+      expect(modeOf(checkpointPath)).toBe(0o600)
+    })
+
+    onPosix('pins 0o600 on output.log', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
+      await mgr.appendIncrements('sess-1', 1, [{ kind: 'output', data: 'secret increment' }])
+
+      expect(modeOf(sessionPath(dir, 'sess-1', 'output.log'))).toBe(0o600)
+    })
+
+    onPosix(
+      'tightens a checkpoint tmp left behind by an older daemon before renaming it',
+      async () => {
+        await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
+        const tmpPath = `${sessionPath(dir, 'sess-1', 'checkpoint.json')}.tmp`
+        writeFileSync(tmpPath, 'stale', { mode: 0o644 })
+
+        await mgr.checkpoint('sess-1', makeSnapshot())
+
+        expect(modeOf(sessionPath(dir, 'sess-1', 'checkpoint.json'))).toBe(0o600)
+      }
+    )
+
+    onPosix('keeps the sweep marker out of the restorable-session listing', async () => {
+      await mgr.openSession('sess-1', { cwd: '/tmp', cols: 80, rows: 24 })
+      await repairTerminalHistoryPermissions(dir)
+
+      expect(existsSync(join(dir, REPAIR_MARKER_NAME))).toBe(true)
+      expect(new HistoryReader(dir).listRestorable()).toEqual(['sess-1'])
+    })
+  })
+
+  describe('repairing history written before modes were pinned', () => {
+    /** A base dir shaped like one written under a default umask: world-readable throughout. */
+    function seedLegacyTree(): { base: string; sessionDir: string; checkpointPath: string } {
+      const base = isolatedDir()
+      const sessionDir = join(base, getHistorySessionDirName('legacy'))
+      mkdirSync(sessionDir, { recursive: true })
+      chmodSync(base, 0o755)
+      chmodSync(sessionDir, 0o755)
+      const checkpointPath = join(sessionDir, 'checkpoint.json')
+      writeFileSync(checkpointPath, '{"scrollbackAnsi":"secret"}')
+      chmodSync(checkpointPath, 0o644)
+      return { base, sessionDir, checkpointPath }
+    }
+
+    onPosix('tightens a pre-existing 0o644 session tree when its writer attaches', () => {
+      const { sessionDir, checkpointPath } = seedLegacyTree()
+
+      tightenTerminalHistorySessionDirMode(sessionDir)
+
+      expect(modeOf(sessionDir)).toBe(0o700)
+      expect(modeOf(checkpointPath)).toBe(0o600)
+    })
+
+    onPosix('sweeps the whole base dir once and then short-circuits', async () => {
+      const { base, sessionDir, checkpointPath } = seedLegacyTree()
+
+      await expect(repairTerminalHistoryPermissions(base)).resolves.toBe(true)
+      expect(modeOf(base)).toBe(0o700)
+      expect(modeOf(sessionDir)).toBe(0o700)
+      expect(modeOf(checkpointPath)).toBe(0o600)
+
+      // Marker-guarded: a later launch must not re-walk 10k session trees.
+      chmodSync(checkpointPath, 0o644)
+      await expect(repairTerminalHistoryPermissions(base)).resolves.toBe(false)
+      expect(modeOf(checkpointPath)).toBe(0o644)
+    })
+
+    onPosix('finishes and marks the sweep done even when every chmod is rejected', async () => {
+      const { base } = seedLegacyTree()
+      vi.resetModules()
+      vi.doMock('node:fs/promises', async () => {
+        const actual = await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+        return {
+          ...actual,
+          default: actual,
+          chmod: () => Promise.reject(Object.assign(new Error('EPERM'), { code: 'EPERM' }))
+        }
+      })
+      try {
+        const { repairTerminalHistoryPermissions: patchedRepair } =
+          await import('./terminal-history-permission-repair')
+        await expect(patchedRepair(base)).resolves.toBe(true)
+      } finally {
+        vi.doUnmock('node:fs/promises')
+        vi.resetModules()
+      }
+
+      expect(existsSync(join(base, REPAIR_MARKER_NAME))).toBe(true)
+    })
+  })
+
+  describe('hosts where POSIX modes do not apply', () => {
+    it('skips the repair sweep on win32 rather than touching the tree', async () => {
+      const base = isolatedDir()
+      const restore = stubPlatform('win32')
+      try {
+        await expect(repairTerminalHistoryPermissions(base)).resolves.toBe(false)
+      } finally {
+        restore()
+      }
+      expect(existsSync(join(base, REPAIR_MARKER_NAME))).toBe(false)
+    })
+
+    it('still writes history when the platform reports win32', async () => {
+      const base = isolatedDir()
+      const restore = stubPlatform('win32')
+      const mgr = new HistoryManager(base)
+      try {
+        await mgr.openSession('win-sess', { cwd: 'C:\\tmp', cols: 80, rows: 24 })
+        await mgr.checkpoint('win-sess', makeSnapshot())
+      } finally {
+        await mgr.dispose()
+        restore()
+      }
+
+      expect(readFileSync(sessionPath(base, 'win-sess', 'checkpoint.json'), 'utf-8')).toContain(
+        'secret scrollback'
+      )
+    })
+
+    onPosix('still writes history when chmod itself throws', async () => {
+      const base = isolatedDir()
+      vi.resetModules()
+      vi.doMock('node:fs', async () => {
+        const actual = await vi.importActual<typeof NodeFs>('node:fs')
+        const chmodSyncThrows = (): never => {
+          throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' })
+        }
+        return { ...actual, default: actual, chmodSync: chmodSyncThrows }
+      })
+      try {
+        const { HistoryManager: PatchedHistoryManager } = await import('./history-manager')
+        const mgr = new PatchedHistoryManager(base)
+        await mgr.openSession('chmodless', { cwd: '/tmp', cols: 80, rows: 24 })
+        await mgr.checkpoint('chmodless', makeSnapshot())
+        await mgr.dispose()
+      } finally {
+        vi.doUnmock('node:fs')
+        vi.resetModules()
+      }
+
+      expect(readFileSync(sessionPath(base, 'chmodless', 'checkpoint.json'), 'utf-8')).toContain(
+        'secret scrollback'
+      )
+    })
+  })
+})

--- a/src/main/daemon/terminal-history-permissions.test.ts
+++ b/src/main/daemon/terminal-history-permissions.test.ts
@@ -17,7 +17,10 @@ import { HistoryManager } from './history-manager'
 import { HistoryReader } from './history-reader'
 import { getHistorySessionDirName } from './history-paths'
 import { flushPendingSessionTreeRemovals } from './terminal-history-session-tombstone'
-import { repairTerminalHistoryPermissions } from './terminal-history-permission-repair'
+import {
+  repairTerminalHistoryPermissions,
+  scheduleTerminalHistoryPermissionRepair
+} from './terminal-history-permission-repair'
 import { tightenTerminalHistorySessionDirMode } from './terminal-history-session-files'
 import type { TerminalModes, TerminalSnapshot } from './types'
 
@@ -174,6 +177,79 @@ describe('terminal history file permissions', () => {
       chmodSync(checkpointPath, 0o644)
       await expect(repairTerminalHistoryPermissions(base)).resolves.toBe(false)
       expect(modeOf(checkpointPath)).toBe(0o644)
+    })
+
+    onPosix('leaves a session under an open recovery freeze alone', async () => {
+      const { base, sessionDir: legacyDir, checkpointPath } = seedLegacyTree()
+      const writeErrors: Error[] = []
+      const mgr = new HistoryManager(base, {
+        onWriteError: (_sessionId, error) => writeErrors.push(error)
+      })
+      try {
+        await mgr.openSession('frozen', { cwd: '/tmp', cols: 80, rows: 24 })
+        await mgr.checkpoint('frozen', makeSnapshot())
+
+        // The production ordering: freeze fingerprints, the sweep runs, then the writer re-registers.
+        const freeze = await mgr.freezeForRecovery('frozen')
+        await expect(repairTerminalHistoryPermissions(base)).resolves.toBe(true)
+        mgr.registerWriter('frozen', freeze)
+
+        expect(writeErrors.map((error) => error.message)).toEqual([])
+        expect(mgr.isSessionDisabled('frozen')).toBe(false)
+        // Persistence, not just the absence of an error: the pane must still reach disk.
+        await mgr.checkpoint('frozen', makeSnapshot({ snapshotAnsi: 'after the sweep\r\n' }))
+        expect(readFileSync(sessionPath(base, 'frozen', 'checkpoint.json'), 'utf-8')).toContain(
+          'after the sweep'
+        )
+      } finally {
+        await mgr.dispose()
+      }
+
+      // Narrow skip: every session that is not frozen is still tightened by the same sweep.
+      expect(modeOf(legacyDir)).toBe(0o700)
+      expect(modeOf(checkpointPath)).toBe(0o600)
+    })
+
+    onPosix('sweeps a session tree once its recovery freeze is released', async () => {
+      const base = isolatedDir()
+      const mgr = new HistoryManager(base)
+      try {
+        await mgr.openSession('thawed', { cwd: '/tmp', cols: 80, rows: 24 })
+        const freeze = await mgr.freezeForRecovery('thawed')
+        mgr.abandonRecoveryFreeze(freeze)
+      } finally {
+        await mgr.dispose()
+      }
+      const sessionDir = join(base, getHistorySessionDirName('thawed'))
+      chmodSync(sessionDir, 0o755)
+
+      await expect(repairTerminalHistoryPermissions(base)).resolves.toBe(true)
+
+      expect(modeOf(sessionDir)).toBe(0o700)
+    })
+
+    onPosix('defers the sweep off the daemon-init critical path and runs it once', async () => {
+      const { base, checkpointPath } = seedLegacyTree()
+      vi.useFakeTimers()
+      try {
+        const first = scheduleTerminalHistoryPermissionRepair(base)
+        // Both startup accessors ask for the same tree; only the first arms a sweep.
+        expect(scheduleTerminalHistoryPermissionRepair(base)).toBeNull()
+        expect(vi.getTimerCount()).toBe(1)
+
+        // Still armed, and the tree still untouched, well past daemon init — the sibling
+        // history GC waits the same 10s over this directory for the same reason.
+        await vi.advanceTimersByTimeAsync(9_999)
+        expect(vi.getTimerCount()).toBe(1)
+        expect(existsSync(join(base, REPAIR_MARKER_NAME))).toBe(false)
+        expect(modeOf(checkpointPath)).toBe(0o644)
+
+        await vi.advanceTimersByTimeAsync(1)
+        await expect(first).resolves.toBe(true)
+      } finally {
+        vi.useRealTimers()
+      }
+      expect(modeOf(checkpointPath)).toBe(0o600)
     })
 
     onPosix('finishes and marks the sweep done even when every chmod is rejected', async () => {

--- a/src/main/daemon/terminal-history-recovery-freezes.ts
+++ b/src/main/daemon/terminal-history-recovery-freezes.ts
@@ -1,0 +1,48 @@
+import { join } from 'node:path'
+import { getHistorySessionDirName } from './history-paths'
+import {
+  markTerminalHistorySessionRecoveryFrozen,
+  unmarkTerminalHistorySessionRecoveryFrozen,
+  type ActiveHistoryRecoveryFreeze
+} from './terminal-history-recovery-quarantine'
+
+/** The recovery freezes one HistoryManager holds, each paired with the process-wide hold that keeps
+ *  the backlog permission sweep off a tree whose fingerprint has already been taken. Paired here so
+ *  the in-memory freeze and that hold cannot drift apart across the manager's many release paths. */
+export class TerminalHistoryRecoveryFreezes {
+  private readonly bySessionId = new Map<string, ActiveHistoryRecoveryFreeze>()
+
+  constructor(private readonly basePath: string) {}
+
+  get(sessionId: string): ActiveHistoryRecoveryFreeze | undefined {
+    return this.bySessionId.get(sessionId)
+  }
+
+  has(sessionId: string): boolean {
+    return this.bySessionId.has(sessionId)
+  }
+
+  hold(sessionId: string, freeze: ActiveHistoryRecoveryFreeze): void {
+    this.bySessionId.set(sessionId, freeze)
+    // Why before the caller's first await: the sweep must see the hold before the freeze reads the
+    // fingerprint it later re-checks, or a chmod in between silently disables the session's writer.
+    markTerminalHistorySessionRecoveryFrozen(this.sessionDir(sessionId))
+  }
+
+  release(sessionId: string): void {
+    if (this.bySessionId.delete(sessionId)) {
+      unmarkTerminalHistorySessionRecoveryFrozen(this.sessionDir(sessionId))
+    }
+  }
+
+  /** Why: an outstanding hold would keep the sweep off that tree for the rest of the process. */
+  releaseAll(): void {
+    for (const sessionId of this.bySessionId.keys()) {
+      this.release(sessionId)
+    }
+  }
+
+  private sessionDir(sessionId: string): string {
+    return join(this.basePath, getHistorySessionDirName(sessionId))
+  }
+}

--- a/src/main/daemon/terminal-history-recovery-quarantine.ts
+++ b/src/main/daemon/terminal-history-recovery-quarantine.ts
@@ -1,6 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { existsSync, lstatSync, readdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { ensurePrivateDir, PRIVATE_FILE_MODE } from './daemon-private-file-modes'
 import { getHistorySessionDirName } from './history-paths'
 
@@ -26,6 +26,39 @@ export function isTerminalHistoryQuarantineEntry(name: string): boolean {
 export function getTerminalHistoryQuarantineOwnerDir(basePath: string, sessionId: string): string {
   const sessionHash = createHash('sha256').update(sessionId).digest('hex')
   return join(basePath, QUARANTINE_DIR_NAME, sessionHash)
+}
+
+// Why process-wide and not a HistoryManager field: the freeze lives in this process's memory while
+// the backlog permission sweep walks the same tree from an unrelated module, and its chmod moves the
+// `mode`/`ctimeMs` that fingerprintTerminalHistorySession hashes. Refcounted because the legacy and
+// current daemon adapters each hold their own HistoryManager over one base path.
+const recoveryFrozenSessionDirs = new Map<string, number>()
+
+export function markTerminalHistorySessionRecoveryFrozen(sessionDir: string): void {
+  const key = resolve(sessionDir)
+  recoveryFrozenSessionDirs.set(key, (recoveryFrozenSessionDirs.get(key) ?? 0) + 1)
+}
+
+export function unmarkTerminalHistorySessionRecoveryFrozen(sessionDir: string): void {
+  const key = resolve(sessionDir)
+  const held = recoveryFrozenSessionDirs.get(key)
+  if (held === undefined) {
+    return
+  }
+  if (held > 1) {
+    recoveryFrozenSessionDirs.set(key, held - 1)
+  } else {
+    recoveryFrozenSessionDirs.delete(key)
+  }
+}
+
+/** True while a session tree must not be touched by anything outside its own recovery handshake:
+ *  an open freeze holds a fingerprint of it, or a failed quarantine left it fail-closed on disk. */
+export function isTerminalHistorySessionDirRecoveryProtected(sessionDir: string): boolean {
+  return (
+    recoveryFrozenSessionDirs.has(resolve(sessionDir)) ||
+    existsSync(join(sessionDir, RECOVERY_PROTECTION_MARKER))
+  )
 }
 
 export function hasTerminalHistoryRecoveryProtection(basePath: string, sessionId: string): boolean {

--- a/src/main/daemon/terminal-history-recovery-quarantine.ts
+++ b/src/main/daemon/terminal-history-recovery-quarantine.ts
@@ -1,14 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
-import {
-  existsSync,
-  lstatSync,
-  mkdirSync,
-  readdirSync,
-  renameSync,
-  unlinkSync,
-  writeFileSync
-} from 'node:fs'
+import { existsSync, lstatSync, readdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { ensurePrivateDir, PRIVATE_FILE_MODE } from './daemon-private-file-modes'
 import { getHistorySessionDirName } from './history-paths'
 
 const QUARANTINE_DIR_NAME = '.recovery-quarantine'
@@ -83,8 +76,8 @@ export function quarantineTerminalHistorySession(
   const sessionDir = join(basePath, getHistorySessionDirName(sessionId))
   const ownerDir = getTerminalHistoryQuarantineOwnerDir(basePath, sessionId)
   // Why: if rename is blocked, a later adapter must not attach a writer to the unreadable generation.
-  writeFileSync(join(sessionDir, RECOVERY_PROTECTION_MARKER), '')
-  mkdirSync(ownerDir, { recursive: true })
+  writeFileSync(join(sessionDir, RECOVERY_PROTECTION_MARKER), '', { mode: PRIVATE_FILE_MODE })
+  ensurePrivateDir(ownerDir)
   const quarantineDir = join(ownerDir, randomUUID())
   renameSync(sessionDir, quarantineDir)
   return quarantineDir

--- a/src/main/daemon/terminal-history-session-files.ts
+++ b/src/main/daemon/terminal-history-session-files.ts
@@ -1,0 +1,36 @@
+// The files one terminal-history session tree owns, and the whole-tree operations over them.
+// Single list so the stale-file reset and the permission tightening cannot drift apart.
+
+import { unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, tightenPathMode } from './daemon-private-file-modes'
+
+export const TERMINAL_HISTORY_SESSION_FILE_NAMES = [
+  'checkpoint.json',
+  'output.log',
+  'meta.json',
+  'scrollback.bin'
+] as const
+
+// meta.json survives: a reset re-anchors replayable state, not the session's identity.
+const REPLAYABLE_SESSION_FILE_NAMES = ['checkpoint.json', 'scrollback.bin', 'output.log'] as const
+
+/** Why: a crash before the first checkpoint must not replay a cleanly ended prior session. */
+export function clearReplayableTerminalHistorySessionFiles(dir: string): void {
+  for (const name of REPLAYABLE_SESSION_FILE_NAMES) {
+    try {
+      unlinkSync(join(dir, name))
+    } catch {
+      // ENOENT is expected for new sessions.
+    }
+  }
+}
+
+/** Idempotent and ~5 syscalls: tighten one session tree as it is opened for writing. Needed because
+ *  `mode` on writeFile only applies at creation, so files an older daemon left at umask stay open. */
+export function tightenTerminalHistorySessionDirMode(dir: string): void {
+  tightenPathMode(dir, PRIVATE_DIR_MODE)
+  for (const name of TERMINAL_HISTORY_SESSION_FILE_NAMES) {
+    tightenPathMode(join(dir, name), PRIVATE_FILE_MODE)
+  }
+}

--- a/src/main/daemon/terminal-history-session-tombstone.ts
+++ b/src/main/daemon/terminal-history-session-tombstone.ts
@@ -3,9 +3,10 @@
 // so the stop-and-wait path is metadata-only, and drain the queue off the critical path.
 
 import { randomUUID } from 'node:crypto'
-import { existsSync, mkdirSync, readdirSync, renameSync } from 'node:fs'
+import { existsSync, readdirSync, renameSync } from 'node:fs'
 import { join } from 'node:path'
 import { removeHostTree } from '../host-tree-removal'
+import { ensurePrivateDir } from './daemon-private-file-modes'
 import { getHistorySessionDirName } from './history-paths'
 import { getTerminalHistoryQuarantineOwnerDir } from './terminal-history-recovery-quarantine'
 
@@ -29,7 +30,7 @@ function getPendingDeleteRoot(basePath: string): string {
 function tombstoneSessionTree(basePath: string, dir: string): string | null {
   const pendingRoot = getPendingDeleteRoot(basePath)
   try {
-    mkdirSync(pendingRoot, { recursive: true })
+    ensurePrivateDir(pendingRoot)
     const tombstone = join(pendingRoot, randomUUID())
     renameSync(dir, tombstone)
     return tombstone

--- a/src/main/daemon/terminal-history-session-writer.ts
+++ b/src/main/daemon/terminal-history-session-writer.ts
@@ -18,6 +18,8 @@ import { clearTerminalHistoryRecoveryProtection } from './terminal-history-recov
 import type { PendingOutputRecord, TerminalSnapshot } from './types'
 import { TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES } from './terminal-history-file-limits'
 import { serializeTerminalCheckpointWithinLimit } from './terminal-checkpoint-serializer'
+import { PRIVATE_FILE_MODE, tightenPathMode } from './daemon-private-file-modes'
+import { tightenTerminalHistorySessionDirMode } from './terminal-history-session-files'
 
 // Why 5MB: bounds cold-restore replay time and per-session disk; hitting the cap triggers one checkpoint that resets the log.
 const LOG_MAX_BYTES = 5 * 1024 * 1024
@@ -37,6 +39,8 @@ export class TerminalHistorySessionWriter {
     this.logPath = join(dir, 'output.log')
     this.logGeneration = fresh ? 0 : null
     this.logBytes = fresh ? 0 : null
+    // Why here: a warm attach reuses files an older daemon created at umask, which `mode` cannot fix.
+    tightenTerminalHistorySessionDirMode(dir)
   }
 
   async appendIncrements(
@@ -50,10 +54,12 @@ export class TerminalHistorySessionWriter {
       return 'needs-checkpoint'
     }
     if (this.logBytes === 0) {
-      await fsPromises.writeFile(this.logPath, encodeLogHeader(this.logGeneration ?? 0))
+      await fsPromises.writeFile(this.logPath, encodeLogHeader(this.logGeneration ?? 0), {
+        mode: PRIVATE_FILE_MODE
+      })
       this.logBytes = LOG_HEADER_BYTES
     }
-    await fsPromises.appendFile(this.logPath, batch)
+    await fsPromises.appendFile(this.logPath, batch, { mode: PRIVATE_FILE_MODE })
     this.logBytes = (this.logBytes ?? LOG_HEADER_BYTES) + batch.length
     return 'ok'
   }
@@ -87,9 +93,14 @@ export class TerminalHistorySessionWriter {
       }
     }
     const tmpPath = `${this.checkpointPath}.tmp`
-    await fsPromises.writeFile(tmpPath, data)
+    // Mode on the tmp file, not after the rename: the checkpoint is never briefly world-readable.
+    await fsPromises.writeFile(tmpPath, data, { mode: PRIVATE_FILE_MODE })
+    // A tmp left behind by a pre-fix crash is reused in place, where `mode` no longer applies.
+    tightenPathMode(tmpPath, PRIVATE_FILE_MODE)
     await fsPromises.rename(tmpPath, this.checkpointPath)
-    await fsPromises.writeFile(this.logPath, encodeLogHeader(generation))
+    await fsPromises.writeFile(this.logPath, encodeLogHeader(generation), {
+      mode: PRIVATE_FILE_MODE
+    })
     this.logGeneration = generation
     this.logBytes = LOG_HEADER_BYTES
     clearTerminalHistoryRecoveryProtection(this.dir)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​334 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​334 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​335 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​49 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​286 |

<!-- /orca-pr-loc -->

## Impact

Orca's daemon terminal history persists **verbatim terminal scrollback** to disk with no file mode pinned, so every directory and file lands at whatever umask applies. Under a default umask (022) that means world-readable.

This is **local information disclosure on a shared machine** — any other local user (or any process running as another local account) can read full terminal scrollback for up to 10,000 retained sessions. It is not remotely exploitable and requires local read access to the user's data directory.

Real-world count on one developer machine right now:

```
$ find "~/Library/Application Support/orca-dev/terminal-history" -name checkpoint.json -perm -o+r | wc -l
713
```

713 world-readable `checkpoint.json` files (`-rw-r--r--`), under directories at `drwxr-xr-x`. The production `orca` data dir on the same machine happens to be `0700` — that is luck of the umask, not intent.

**This is pre-existing and is not introduced by any recent PR.** The unpinned `mkdirSync`/`writeFile` calls predate current work; nothing in flight touches these paths.

## ELI5

Orca keeps a copy of everything your terminals print — the whole scrollback — on disk, for up to 10,000 past sessions, so you can scroll back after a restart. Those files were written with whatever permissions the system happened to default to, which on a normal macOS/Linux box means **any other user account on that machine can open and read them**: commands, output, whatever a tool happened to echo. On one developer's machine right now that's 713 world-readable files.

Everything else in Orca that stores sensitive material — shell history, the agent-hooks store, the daemon's auth token — is already deliberately locked to its owner. This corner was just missed.

Now the folders and files are created owner-only, and a one-time sweep tightens the ones already sitting on disk. That first-launch repair happens quietly in the background a few seconds after the app is up, rather than during startup, so nothing you do feels slower because of it — and it deliberately steps around any terminal that is in the middle of restoring its scrollback. Windows doesn't honour these permission bits at all, so there it changes nothing and the code doesn't pretend otherwise.

## Evidence

Missing modes:

- `src/main/daemon/history-manager.ts:71` — `mkdirSync(dir, { recursive: true })`, no mode (session dir)
- `src/main/daemon/daemon-launch-paths.ts:13,19` — same, no mode (daemon runtime dir, history base dir)
- `src/main/daemon/terminal-history-session-writer.ts:53,56,90,92` — `writeFile`/`appendFile`/checkpoint tmp write, no mode
- `src/main/daemon/terminal-history-metadata.ts:53` — `meta.json` rewrite, no mode
- `src/main/daemon/terminal-history-session-tombstone.ts:32`, `src/main/daemon/terminal-history-recovery-quarantine.ts:86,87` — pending-delete root, quarantine owner dir, protection marker

What is exposed:

- `src/main/daemon/terminal-checkpoint-serializer.ts:16-17` — `checkpoint.json` carries `snapshotAnsi` + `scrollbackAnsi`, i.e. the verbatim screen and scrollback
- `src/main/daemon/terminal-history-restorable-retention.ts:1` — `MAX_RESTORABLE_TERMINAL_HISTORY_SESSIONS = 10_000`

Every sibling that writes comparable data already pins modes deliberately, which is why this reads as an omission rather than a decision:

- `src/main/agent-hooks/server/server-persistence.ts:115-123` — `mkdirSync(..., { mode: 0o700 })` + a `chmodSync` repair guarded by `process.platform !== 'win32'`, then `writeFileSync(..., { mode: 0o600 })`
- `src/main/terminal-history.ts:74,112` — shell history at `0o700`/`0o600`
- `src/main/daemon/daemon-file-log.ts:20`, `src/main/observability/local-file-sink.ts:26-27`, `src/main/ai-vault/session-parse-cache-persistence.ts:24` — `PRIVATE_FILE_MODE = 0o600`

## The fix

New `src/main/daemon/daemon-private-file-modes.ts` holds the primitives (`PRIVATE_DIR_MODE = 0o700`, `PRIVATE_FILE_MODE = 0o600`, `ensurePrivateDir`, `tightenPathMode`). The existing `PRIVATE_FILE_MODE` constants are module-private and scoped to other concerns (the daemon NDJSON log's rotation family, the trace sink), so this reuses the established *name and value* rather than exporting one of those across concerns.

Modes are now pinned on the history base dir, the daemon runtime dir (which holds the auth token), session dirs, the pending-delete root, quarantine owner dirs, `checkpoint.json`, `output.log`, `meta.json`, the recovery-protection marker, and the checkpoint tmp file. The tmp file gets its mode *before* the rename, so the checkpoint is never briefly world-readable.

## Repairing the existing exposure

`mode` on `writeFile`/`mkdir` only applies at creation, so pinning alone leaves the 713 existing files untouched. Two repairs:

1. **Backlog sweep** (`terminal-history-permission-repair.ts`) — one bounded async walk of the base dir, hooked into `getDaemonHistoryDir()`, the single accessor every history producer resolves through. Guarded by a `.permissions-repaired-v1` marker file, so every later launch costs one `existsSync`, never a walk over 10k session trees. Depth-capped at 3 and entry-budgeted at 200k. Symlinks are skipped (`Dirent` types come from `lstat`, so a symlink matches neither the directory nor the file branch and is never chased). Fire-and-forget and fully non-throwing — it cannot fail or delay daemon startup. The marker is written even when some paths resist `chmod`, so one permanently unfixable file can't make every launch re-walk. It is deferred, de-duplicated, and steers around sessions under recovery protection — see [Scheduling the sweep](#scheduling-the-sweep) below.
2. **Per-session tighten** — `TerminalHistorySessionWriter`'s constructor tightens its own tree (~5 syscalls, idempotent). This covers a warm attach to files an older daemon left at umask.

The marker is a regular file, so `history-reader`'s directory-only session scan already skips it; a test pins that.

## Scheduling the sweep

Review of the first revision found three issues, all of them consequences of running the backlog sweep inline on the daemon-init critical path. None of them touch the security objective; all three are about *when* and *over what* the sweep runs.

### It must not run inside a recovery-freeze window

`fingerprintTerminalHistorySession` hashes `stats.mode` and `stats.ctimeMs` of a session directory and each of its entries. `chmod` moves both. The recovery-freeze protocol takes that fingerprint in `freezeForRecovery` and re-checks it later in `registerWriter` / `openSession`, so a sweep landing between the two failed the re-check with `terminal_history_recovery_generation_changed`. That falls into `handleWriteError` → `disabledSessions.add(sessionId)`, and because `onWriteError` has no production caller (`daemon-pty-runtime-state.ts` constructs `new HistoryManager(opts.historyPath)` with no options), the failure was **silent**: that pane persisted no scrollback for the remainder of the app run. One launch only, no on-disk history lost, self-healing next launch — but a real regression, and invisible.

The window was not theoretical. `freezeHistory()` fingerprints, then `detectColdRestoreState` replays checkpoint + log serialized behind a 1-wide semaphore, then a daemon RPC, and only then `registerWriter`. Pane restore starts moments after `initDaemonPtyProvider` scheduled the sweep, and the sweep took ~1.6 s.

**Why `hasTerminalHistoryRecoveryProtection` alone was not enough.** This is the non-obvious part, and the obvious reading is wrong. That predicate tests for the on-disk `.unreadable-recovery` marker, which is written only by `quarantineTerminalHistorySession` when a quarantine rename is blocked. It is not written during a freeze. The freeze itself lives purely in memory, in `HistoryManager.recoveryFreezes`, in a different module from the sweep — so the marker check would have skipped a handful of already-broken trees and sailed straight through every tree that was actually at risk.

So the fix adds the missing half: a refcounted, process-wide hold keyed by session *directory*, in `terminal-history-recovery-quarantine.ts`. It is taken synchronously in `hold()` before the freeze's first `await` — the sweep must see the hold before the freeze reads the fingerprint it will later re-check — and released on every path that drops a freeze, plus `dispose()`. Refcounted because the legacy and current daemon adapters each hold their own `HistoryManager` over one base path. `isTerminalHistorySessionDirRecoveryProtected(dir)` is the union of that hold and the on-disk marker, and the sweep consults it immediately before each directory `chmod` and again before each file `chmod` (a session directory's own files are chmodded contiguously within one loop iteration, so the subtree is covered by those two checks).

Skipping loses nothing. A live session's own `TerminalHistorySessionWriter` constructor already tightens its tree on attach, and it does so *after* the fingerprint re-check, by design — so a tree the sweep steps over is tightened by the session that owns it.

The freeze bookkeeping moved out of `HistoryManager` into `TerminalHistoryRecoveryFreezes` (`terminal-history-recovery-freezes.ts`), so the in-memory freeze and its sweep hold cannot drift apart across the manager's six release paths — and so `history-manager.ts` stays under its 300-line cap without a `max-lines` disable.

**The fingerprint was not touched.** Dropping `mode`/`ctimeMs` from it is the shorter diff and someone will propose it, so to be explicit: that would weaken a corruption check in order to paper over a scheduling problem. The fingerprint's job is to prove a session tree has not changed under a recovery handshake, and a mode or ctime change is a real change to that tree — the right answer is for the sweep to stop being an unannounced third-party mutator, which is what it now does.

### It must not run twice

`getDaemonHistoryDir()` runs more than once per startup — directly at `daemon-provider-init.ts:91`, and again via the `historyPath = getHistoryDir()` default parameter in `createLegacyDaemonAdapters` — and the scheduler had no guard. Because the marker is only written after the first sweep completes, the second call started a full second concurrent sweep over the same tree: double the one-time `chmod` I/O and double the exposure window above.

The scheduler now arms at most one sweep per base path per process, keyed on the resolved path. The set is never cleared, so a sweep that throws cannot wedge a retry loop; the on-disk marker remains the thing that carries the decision across launches.

`scheduleTerminalHistoryPermissionRepair` now returns `Promise<boolean> | null` — the sweep's outcome, or `null` when a sweep was already scheduled for that path. That return value is what makes the guard observable to a test without adding a test-only export or a module-reset hook; the startup caller simply `void`s it.

### It must not run during daemon init

The sweep fired synchronously from the history-dir accessor with no deferral, measured at **1,581 ms over 8,769 files** on a tree matching a real developer machine (2,923 session dirs). The sibling history GC walks the *same* directory and deliberately waits 10 s for exactly this reason — "Why 10s: avoids competing with startup-critical I/O".

The sweep now takes the same 10 s, on an `unref`'d timer so a pending sweep never holds the process (or a test worker) open. Daemon-init inline cost drops from **1,581 ms to 0.071 ms** — the accessor now does nothing but arm a timer.

Rather than extracting a shared constant, the delay carries a comment pointing at `scheduleHistoryGc`'s rationale. Sharing the constant would mean editing `src/main/terminal-history-gc.ts`, which is outside this PR's diff; a queued security fix is the wrong place to add churn to an unrelated file.

Deferral does **not** carry the freeze fix. A recovery freeze can still be open at the 10 s mark, so the skip predicate stands entirely on its own and does not depend on timing.

### Residual: the in-flight chmod window

The hold closes every practically reachable window, but not a theoretical one, and this PR should not be read as eliminating the race outright.

If a `chmod` on exactly that session's directory is *already in flight* at the instant the freeze registers its hold, that `chmod` can still land after the fingerprint's `lstat` and cause the same mismatch. No new `chmod` can start once the hold is visible — the predicate is checked synchronously immediately before each one — so at most a single already-issued syscall is in play.

Closing it fully would mean having `freezeForRecovery` await the sweep's in-flight `chmod` before fingerprinting. That was deliberately rejected: it introduces a strictly worse failure mode, where a `chmod` hung on a network filesystem blocks terminal pane restore. Trading a silent one-launch loss of scrollback persistence for a hang on the restore path is not a good trade.

The ordering is favourable regardless. `hold()` → `await mutations.wait(sessionId)` → fingerprint puts a full event-loop turn between the hold and the `lstat`, and the offending `chmod` was issued before the hold, so it has almost always settled — and therefore been *included* in the fingerprint — by the time the fingerprint is taken. What was a seconds-wide, reliably reproducible race is now a sub-millisecond one that requires a freeze to begin during one specific directory's `chmod` syscall.

## Windows

`fs` mode bits are largely a no-op on Windows and `chmod` there can throw or silently do nothing, so:

- every mode-tightening path short-circuits on `process.platform === 'win32'` before touching the filesystem;
- the repair sweep returns early on win32 and writes no marker, so it stays available if the tree is later read on a POSIX host;
- every `chmod` that does run is wrapped and swallowed — read-only volumes, foreign ownership, and exotic filesystems degrade to "leave the mode as found";
- `mkdirSync(..., { mode })` is harmless on Windows (ignored), so the mkdir calls stay unconditional.

History writing and daemon startup never depend on a chmod succeeding. Tests cover both: a forced-`win32` platform and a `chmodSync` that throws `EPERM` — history is still written correctly in both.

WSL and remote SSH Linux hosts run the same code path on the host that owns the files, and there the modes do apply — `getDaemonHistoryDir()` resolves per-host, so a remote Orca server sweeps its own tree.

## Tests

New `src/main/daemon/terminal-history-permissions.test.ts` (14 tests), following `history-manager.test.ts`'s idioms (`mkdtemp` fixtures, `chmodSync`, `it.skipIf(process.platform === 'win32')` for assertions that are meaningless on Windows):

- new files: session dir `0o700`; `meta.json` / `checkpoint.json` / `output.log` at `0o600`
- a stale `checkpoint.json.tmp` at `0o644` does not leak through the rename
- repair: a pre-existing `0o644` tree is tightened when its writer attaches
- sweep: repairs a world-readable base dir, then short-circuits on the second call
- sweep finishes and marks itself done even when every `chmod` is rejected
- win32: sweep is skipped and no marker written; history still written
- `chmodSync` throwing `EPERM`: swallowed, history still written
- the sweep marker stays out of `listRestorable()`
- **the freeze race**: freeze → full sweep → `registerWriter`, the reviewer's reproduction ordering, asserting no `onWriteError`, the session not disabled, and — the point of the test — that a subsequent checkpoint still reaches disk. The same case asserts a second, unfrozen session in the same tree *is* tightened, so the skip is narrow rather than a blanket opt-out
- a session tree is swept normally once its recovery freeze is released
- the sweep is deferred past daemon init and armed only once for two accessor calls

Mutation-checked — reverting each production change fails a test. Every mode-asserting case goes through `it.skipIf(process.platform === 'win32')` (12 of the 14), so they are skipped rather than vacuously passing where modes are meaningless; the two that must run everywhere stub `process.platform` instead. On the macOS runner all 14 ran, none skipped.

| Mutation | Failing test |
| --- | --- |
| `0o700`/`0o600` → `0o755`/`0o644` | 6 tests fail |
| drop the `win32` guard | 1 test fails |
| async `chmod` no longer swallowed | 1 test fails |
| sync `chmod` no longer swallowed | 1 test fails |
| skip predicate disabled in the sweep | `leaves a session under an open recovery freeze alone` — fails with exactly `terminal_history_recovery_generation_changed`, the reviewer's error |
| once-guard removed from the scheduler | `defers the sweep off the daemon-init critical path and runs it once` |
| deferral removed (`10_000` → `0`) | same test |
| deferral shortened (`10_000` → `5_000`) | same test |
| freeze hold never released | `sweeps a session tree once its recovery freeze is released` |

## Drive-by

The session-file name list was duplicated between `history-manager`'s stale-file reset and the new tightening, so both now share `terminal-history-session-files.ts`. That also brings `history-manager.ts` back under the 300-line cap it was sitting exactly on — as does moving the recovery-freeze bookkeeping into `terminal-history-recovery-freezes.ts`. No `max-lines` disable was added.

## Verification

- `pnpm test src/main/daemon/` — 165 files passed, 3 skipped; 1858 tests passed, 13 skipped
- `pnpm tc` — clean
- `oxlint` — clean
- `pnpm run check:code-quality:changed` — 0 new findings across 11 changed files
- `pnpm test src/main/terminal-history-gc.test.ts src/relay/terminal-history` — 28 passed (the sweep shares its tree with the shell-history GC)

Re-measured after the scheduling changes, on a synthetic tree matching a real machine (2,923 session dirs / 8,769 files):

- daemon-init inline cost: **1,581 ms → 0.071 ms**
- second sweep: 0 ms (marker short-circuit), unchanged
- the added recovery-protection check costs one `existsSync` per directory — **~10 ms across 2,923 dirs**, and it is now off the critical path entirely
- bounds re-verified empirically: depth-3 directory tightened, depth-4 directory and its file untouched; symlink targets outside the tree left at `0644`/`0755`; no `unlink`/`rm`/`rename`/`truncate` anywhere in the repair module


