### PR TITLE
Fix wheel scrolling walking prompt history in full-screen terminal apps

### DIFF
--- a/src/renderer/src/components/settings/TerminalAlternateScreenWheelSetting.tsx
+++ b/src/renderer/src/components/settings/TerminalAlternateScreenWheelSetting.tsx
@@ -1,0 +1,52 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
+
+type TerminalAlternateScreenWheelSettingProps = {
+  settings: Pick<GlobalSettings, 'terminalAlternateScreenWheelSendsArrowKeys'>
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function TerminalAlternateScreenWheelSetting({
+  settings,
+  updateSettings
+}: TerminalAlternateScreenWheelSettingProps): React.JSX.Element {
+  const title = translate(
+    'auto.components.settings.TerminalAlternateScreenWheelSetting.title',
+    'Full-screen apps: wheel sends arrow keys'
+  )
+  const description = translate(
+    'auto.components.settings.TerminalAlternateScreenWheelSetting.description',
+    'Scrolls pagers and editors that do not handle the mouse themselves. Turn off if scrolling a full-screen agent walks its prompt history instead. Apps that state their own preference are unaffected.'
+  )
+
+  return (
+    <SearchableSetting
+      title={title}
+      description={description}
+      keywords={[
+        'terminal',
+        'wheel',
+        'scroll',
+        'arrow keys',
+        'alternate screen',
+        'full screen',
+        'tui',
+        'prompt history'
+      ]}
+    >
+      <SettingsSwitchRow
+        label={title}
+        description={description}
+        checked={settings.terminalAlternateScreenWheelSendsArrowKeys}
+        onChange={() =>
+          updateSettings({
+            terminalAlternateScreenWheelSendsArrowKeys:
+              !settings.terminalAlternateScreenWheelSendsArrowKeys
+          })
+        }
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/TerminalInteractionSection.tsx
+++ b/src/renderer/src/components/settings/TerminalInteractionSection.tsx
@@ -5,6 +5,7 @@ import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
+import { TerminalAlternateScreenWheelSetting } from './TerminalAlternateScreenWheelSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { getTerminalRightClickToPasteSearchEntry } from './terminal-windows-search'
 import { OSC52_CLIPBOARD_SETTING_ID } from '../terminal-pane/osc52-clipboard-setting-anchor'
@@ -268,6 +269,8 @@ export function TerminalInteractionSection({
             />
           </SearchableSetting>
         ) : null}
+
+        <TerminalAlternateScreenWheelSetting settings={settings} updateSettings={updateSettings} />
 
         <SearchableSetting
           title={translate(

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -9,6 +9,7 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalScrollSensitivity: 'Normal Scroll Speed',
   terminalFastScrollSensitivity: 'Fast Scroll Speed',
   terminalTuiScrollSensitivity: 'TUI Scroll Speed',
+  terminalAlternateScreenWheelSendsArrowKeys: 'Full-Screen Wheel Sends Arrow Keys',
   terminalBackgroundOpacity: 'Background Opacity',
   terminalMinimumContrastRatio: 'Color Contrast',
   terminalCursorStyle: 'Cursor Style',

--- a/src/renderer/src/components/terminal-pane/terminal-pane-manager-options.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-manager-options.ts
@@ -158,6 +158,8 @@ export function createTerminalPaneManagerOptions(
     },
     terminalTuiScrollSensitivity: () =>
       normalizeTerminalTuiMouseWheelMultiplier(settingsRef.current?.terminalTuiScrollSensitivity),
+    terminalAlternateScreenWheelSendsArrowKeys: () =>
+      settingsRef.current?.terminalAlternateScreenWheelSendsArrowKeys,
     onLinkClick: (paneId, event, url) => {
       const activePane = managerRef.current?.getPanes().find((candidate) => candidate.id === paneId)
       handleTerminalWebLinkClick(url, event, {

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -117,6 +117,7 @@ export function createPaneDOM(
     xtermContainer,
     linkTooltip,
     terminalTuiScrollSensitivity: options.terminalTuiScrollSensitivity,
+    terminalAlternateScreenWheelSendsArrowKeys: options.terminalAlternateScreenWheelSendsArrowKeys,
     terminalGpuAcceleration: options.terminalGpuAcceleration ?? 'auto',
     gpuRenderingEnabled: ENABLE_WEBGL_RENDERER,
     webglAttachmentDeferred: false,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -8,6 +8,7 @@ import { clearPendingSplitScrollRestore } from './pane-split-scroll'
 import { cancelDeferredScrollRestore } from './pane-scroll'
 import { activateOrcaTerminalUnicodeProvider } from '../../../../shared/terminal-unicode-provider'
 import { attachTerminalMouseWheelMultiplier } from './pane-terminal-mouse-wheel'
+import { attachTerminalAlternateScrollModeTracking } from './terminal-alternate-scroll-mode'
 import { attachTerminalScrollIntentTracking } from './terminal-scroll-intent-dom-tracking'
 import {
   installTerminalLinkifierHoverResetOnMouseLeave,
@@ -35,6 +36,7 @@ export function openTerminal(pane: ManagedPaneInternal, ligaturesEnabled = false
     xtermContainer,
     linkTooltip,
     terminalTuiScrollSensitivity,
+    terminalAlternateScreenWheelSendsArrowKeys,
     fitAddon,
     searchAddon,
     serializeAddon,
@@ -54,8 +56,12 @@ export function openTerminal(pane: ManagedPaneInternal, ligaturesEnabled = false
   terminal.loadAddon(serializeAddon)
   terminal.loadAddon(unicode11Addon)
   terminal.loadAddon(webLinksAddon)
+  const alternateScrollMode = attachTerminalAlternateScrollModeTracking(terminal)
+  pane.alternateScrollModeDisposable = alternateScrollMode
   attachTerminalMouseWheelMultiplier(terminal, {
-    getTuiMouseWheelMultiplier: terminalTuiScrollSensitivity
+    getTuiMouseWheelMultiplier: terminalTuiScrollSensitivity,
+    getAlternateScrollModeAppPreference: alternateScrollMode.appPreference,
+    getAlternateScrollModeDefault: terminalAlternateScreenWheelSendsArrowKeys
   })
   pane.terminalScrollIntentDisposable = attachTerminalScrollIntentTracking(
     terminal,
@@ -194,6 +200,8 @@ export function disposePane(
   pane.focusClassSyncCleanup = null
   pane.terminalScrollIntentDisposable?.dispose()
   pane.terminalScrollIntentDisposable = null
+  pane.alternateScrollModeDisposable?.dispose()
+  pane.alternateScrollModeDisposable = null
   pane.linkifierHoverResetDisposable?.dispose()
   pane.linkifierHoverResetDisposable = null
   pane.linkifierMouseLeaveResetDisposable?.dispose()

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -65,6 +65,7 @@ export type PaneManagerOptions = {
   terminalOptions?: (paneId: number) => Partial<ITerminalOptions>
   terminalLigaturesEnabled?: () => boolean
   terminalTuiScrollSensitivity?: () => number | undefined
+  terminalAlternateScreenWheelSendsArrowKeys?: () => boolean | undefined
   onLinkClick?: (paneId: number, event: MouseEvent | undefined, url: string) => void
   /** Resolved per hover so link-routing setting changes apply without recreating panes. */
   // Why: required so dropping the wiring is a compile error — an optional hint with a
@@ -147,6 +148,7 @@ export type ManagedPaneInternal = {
   xtermContainer: HTMLElement
   linkTooltip: HTMLElement
   terminalTuiScrollSensitivity?: () => number | undefined
+  terminalAlternateScreenWheelSendsArrowKeys?: () => boolean | undefined
   terminalGpuAcceleration: GlobalSettings['terminalGpuAcceleration']
   gpuRenderingEnabled: boolean
   webglAttachmentDeferred: boolean
@@ -189,6 +191,8 @@ export type ManagedPaneInternal = {
   focusClassSyncCleanup?: (() => void) | null
   // Stored so disposePane() can remove user-scroll intent listeners.
   terminalScrollIntentDisposable?: IDisposable | null
+  // Stored so disposePane() can detach DECSET 1007 tracking.
+  alternateScrollModeDisposable?: IDisposable | null
   // Stored so disposePane() can detach the streamed-output hover-cache reset
   // that keeps freshly printed links linkifiable without a scroll.
   linkifierHoverResetDisposable?: IDisposable | null

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.test.ts
@@ -5,7 +5,8 @@ import {
   createTerminalTuiMouseWheelDistanceState,
   normalizeTerminalTuiMouseWheelMultiplier,
   resolveTerminalTuiMouseWheelReportCount,
-  shouldMultiplyTerminalMouseWheel
+  shouldMultiplyTerminalMouseWheel,
+  shouldSynthesizeTerminalWheelCursorKeys
 } from './pane-terminal-mouse-wheel'
 
 const DOM_DELTA_PIXEL = 0
@@ -393,6 +394,7 @@ describe('terminal mouse wheel multiplier', () => {
           handlers.push(handler)
         },
         element: target,
+        buffer: { active: { type: 'normal' as const } },
         modes: { mouseTrackingMode: 'any' },
         rows: 24
       },
@@ -434,6 +436,7 @@ describe('terminal mouse wheel multiplier', () => {
         handlers.push(handler)
       },
       element: target,
+      buffer: { active: { type: 'normal' as const } },
       modes: { mouseTrackingMode: 'none' as const },
       rows: 24
     }
@@ -471,6 +474,7 @@ describe('terminal mouse wheel multiplier', () => {
         handlers.push(handler)
       },
       element: target,
+      buffer: { active: { type: 'normal' as const } },
       modes: { mouseTrackingMode: 'any' as 'any' | 'none' },
       rows: 24
     }
@@ -510,6 +514,7 @@ describe('terminal mouse wheel multiplier', () => {
           handlers.push(handler)
         },
         element: target,
+        buffer: { active: { type: 'normal' as const } },
         modes: { mouseTrackingMode: 'any' },
         rows: 24
       },
@@ -563,6 +568,7 @@ describe('terminal mouse wheel multiplier', () => {
           handlers.push(handler)
         },
         element: target,
+        buffer: { active: { type: 'normal' as const } },
         modes: { mouseTrackingMode: 'any' },
         rows: 24
       },
@@ -598,6 +604,7 @@ describe('terminal mouse wheel multiplier', () => {
           handlers.push(handler)
         },
         element: target,
+        buffer: { active: { type: 'normal' as const } },
         modes: { mouseTrackingMode: 'any' },
         rows: 24
       },
@@ -641,5 +648,106 @@ describe('terminal mouse wheel multiplier', () => {
     expect(handlers[0]?.(secondEvent)).toBe(false)
     await Promise.resolve()
     expect(dispatched).toHaveLength(6)
+  })
+})
+
+type AlternateScrollWheelCase = {
+  bufferType: 'normal' | 'alternate'
+  appPreference?: boolean
+  settingDefault?: boolean
+}
+
+/** Captures the wheel handler for a terminal with no mouse reporting active. */
+function captureUnreportedWheelHandler(
+  testCase: AlternateScrollWheelCase
+): (event: WheelEvent) => boolean {
+  const handlers: ((event: WheelEvent) => boolean)[] = []
+  attachTerminalMouseWheelMultiplier(
+    {
+      attachCustomWheelEventHandler: (handler) => {
+        handlers.push(handler)
+      },
+      element: terminalElement(false),
+      buffer: { active: { type: testCase.bufferType } },
+      modes: { mouseTrackingMode: 'none' },
+      rows: 24
+    },
+    {
+      getAlternateScrollModeAppPreference: () => testCase.appPreference,
+      getAlternateScrollModeDefault: () => testCase.settingDefault
+    }
+  )
+  const handler = handlers[0]
+  if (!handler) {
+    throw new Error('wheel handler was not registered')
+  }
+  return handler
+}
+
+describe('alternate-screen wheel cursor keys', () => {
+  it('defaults to xterm cursor-key synthesis when nothing states a preference', () => {
+    expect(shouldSynthesizeTerminalWheelCursorKeys(undefined, undefined)).toBe(true)
+  })
+
+  it('lets the setting decide when the app never set DECSET 1007', () => {
+    expect(shouldSynthesizeTerminalWheelCursorKeys(undefined, false)).toBe(false)
+    expect(shouldSynthesizeTerminalWheelCursorKeys(undefined, true)).toBe(true)
+  })
+
+  it('lets an explicit DECSET 1007 from the app override the setting', () => {
+    expect(shouldSynthesizeTerminalWheelCursorKeys(true, false)).toBe(true)
+    expect(shouldSynthesizeTerminalWheelCursorKeys(false, true)).toBe(false)
+  })
+
+  it('leaves alternate-screen wheel input to xterm while the setting is on', () => {
+    const handler = captureUnreportedWheelHandler({
+      bufferType: 'alternate',
+      settingDefault: true
+    })
+    expect(handler(wheelEvent({ deltaY: -100 }))).toBe(true)
+  })
+
+  it('suppresses alternate-screen cursor keys once the setting is off', () => {
+    const handler = captureUnreportedWheelHandler({
+      bufferType: 'alternate',
+      settingDefault: false
+    })
+    expect(handler(wheelEvent({ deltaY: -100 }))).toBe(false)
+  })
+
+  it('keeps cursor keys for an app that asked for them with the setting off', () => {
+    const handler = captureUnreportedWheelHandler({
+      bufferType: 'alternate',
+      appPreference: true,
+      settingDefault: false
+    })
+    expect(handler(wheelEvent({ deltaY: -100 }))).toBe(true)
+  })
+
+  it('drops cursor keys for an app that turned DECSET 1007 off with the setting on', () => {
+    const handler = captureUnreportedWheelHandler({
+      bufferType: 'alternate',
+      appPreference: false,
+      settingDefault: true
+    })
+    expect(handler(wheelEvent({ deltaY: -100 }))).toBe(false)
+  })
+
+  it('never touches normal-buffer scrollback wheel input', () => {
+    const handler = captureUnreportedWheelHandler({
+      bufferType: 'normal',
+      appPreference: false,
+      settingDefault: false
+    })
+    expect(handler(wheelEvent({ deltaY: -100 }))).toBe(true)
+  })
+
+  it('leaves shift-wheel and horizontal wheel input to xterm', () => {
+    const handler = captureUnreportedWheelHandler({
+      bufferType: 'alternate',
+      settingDefault: false
+    })
+    expect(handler(wheelEvent({ deltaY: -100, shiftKey: true }))).toBe(true)
+    expect(handler(wheelEvent({ deltaY: 0 }))).toBe(true)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-mouse-wheel.ts
@@ -22,11 +22,16 @@ const REPLAYED_WHEEL_EVENT_PROPERTY = '__orcaReplayedTerminalWheelEvent'
 const DOM_DELTA_LINE = 1
 
 type TerminalWheelTarget = Pick<Terminal, 'attachCustomWheelEventHandler' | 'element' | 'rows'> & {
+  buffer: { active: Pick<Terminal['buffer']['active'], 'type'> }
   modes: Pick<Terminal['modes'], 'mouseTrackingMode'>
 }
 
 type TerminalMouseWheelMultiplierOptions = {
   getTuiMouseWheelMultiplier?: () => number | undefined
+  /** App's DECSET 1007 state, undefined while it has never set the mode. */
+  getAlternateScrollModeAppPreference?: () => boolean | undefined
+  /** User setting applied when the app expressed no DECSET 1007 preference. */
+  getAlternateScrollModeDefault?: () => boolean | undefined
 }
 
 type ReplayedWheelEvent = WheelEvent & {
@@ -101,6 +106,23 @@ function resolveTerminalWheelCellHeight(terminal: TerminalWheelTarget): number |
     return undefined
   }
   return rect.height / terminal.rows
+}
+
+/**
+ * Whether xterm may turn a wheel event into cursor keys for this terminal.
+ *
+ * Why this gate exists: xterm decides purely on "the active buffer has no
+ * scrollback", so every alternate-screen app without mouse reporting gets
+ * Up/Down. That suits a pager, but an agent CLI or a multiplexer maps those to
+ * input history, so the wheel silently rewrites the user's prompt. DECSET 1007
+ * is the mode that distinguishes the two; the setting is the fallback for apps
+ * that never state a preference.
+ */
+export function shouldSynthesizeTerminalWheelCursorKeys(
+  appPreference: boolean | undefined,
+  settingDefault: boolean | undefined
+): boolean {
+  return appPreference ?? settingDefault ?? true
 }
 
 export function shouldMultiplyTerminalMouseWheel(
@@ -189,10 +211,24 @@ export function attachTerminalMouseWheelMultiplier(
 ): void {
   const replayState = createTerminalTuiMouseWheelReplayState()
   terminal.attachCustomWheelEventHandler((event) => {
-    if (
-      terminal.modes.mouseTrackingMode === 'none' ||
-      !shouldMultiplyTerminalMouseWheel(event, terminal.element)
-    ) {
+    if (terminal.modes.mouseTrackingMode === 'none') {
+      // Why only the alternate screen: it is the sole buffer xterm converts the
+      // wheel on, and returning false here is what suppresses that conversion.
+      if (
+        terminal.buffer.active.type === 'alternate' &&
+        event.deltaY !== 0 &&
+        !event.shiftKey &&
+        !shouldSynthesizeTerminalWheelCursorKeys(
+          options.getAlternateScrollModeAppPreference?.(),
+          options.getAlternateScrollModeDefault?.()
+        )
+      ) {
+        return false
+      }
+      return true
+    }
+
+    if (!shouldMultiplyTerminalMouseWheel(event, terminal.element)) {
       return true
     }
 

--- a/src/renderer/src/lib/pane-manager/terminal-alternate-scroll-mode.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-alternate-scroll-mode.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import { attachTerminalAlternateScrollModeTracking } from './terminal-alternate-scroll-mode'
+
+type CsiKey = string
+type Handlers = {
+  csi: Map<CsiKey, (params: (number | number[])[]) => boolean>
+  esc: Map<string, () => boolean>
+  disposed: string[]
+}
+
+// Why enforced here: xterm's EscapeSequenceParser throws on an out-of-range
+// identifier byte, and that throw lands in a React render. A permissive fake
+// would let a misplaced prefix/intermediate reach the app.
+function assertIdentifierBytes(id: {
+  prefix?: string
+  intermediates?: string
+  final: string
+}): void {
+  const inRange = (value: string, low: number, high: number) =>
+    [...value].every((char) => char.charCodeAt(0) >= low && char.charCodeAt(0) <= high)
+  if (id.prefix !== undefined && !inRange(id.prefix, 0x3c, 0x3f)) {
+    throw new Error('prefix must be in range 0x3c .. 0x3f')
+  }
+  if (id.intermediates !== undefined && !inRange(id.intermediates, 0x20, 0x2f)) {
+    throw new Error('intermediate must be in range 0x20 .. 0x2f')
+  }
+  if (!inRange(id.final, 0x40, 0x7e)) {
+    throw new Error('final must be in range 0x40 .. 0x7e')
+  }
+}
+
+function fakeTerminal(): {
+  terminal: Parameters<typeof attachTerminalAlternateScrollModeTracking>[0]
+  handlers: Handlers
+} {
+  const handlers: Handlers = { csi: new Map(), esc: new Map(), disposed: [] }
+  const terminal = {
+    parser: {
+      registerCsiHandler: (
+        id: { prefix?: string; intermediates?: string; final: string },
+        handler: (params: (number | number[])[]) => boolean
+      ) => {
+        assertIdentifierBytes(id)
+        const key = `${id.prefix ?? ''}${id.intermediates ?? ''}${id.final}`
+        handlers.csi.set(key, handler)
+        return { dispose: () => handlers.disposed.push(key) }
+      },
+      registerEscHandler: (id: { final: string }, handler: () => boolean) => {
+        assertIdentifierBytes(id)
+        handlers.esc.set(id.final, handler)
+        return { dispose: () => handlers.disposed.push(`esc:${id.final}`) }
+      }
+    }
+  }
+  return { terminal, handlers }
+}
+
+describe('terminal alternate scroll mode (DECSET 1007)', () => {
+  it('reports no preference until the app sets the mode', () => {
+    const { terminal } = fakeTerminal()
+    expect(attachTerminalAlternateScrollModeTracking(terminal).appPreference()).toBeUndefined()
+  })
+
+  it('tracks the mode being set and reset', () => {
+    const { terminal, handlers } = fakeTerminal()
+    const tracked = attachTerminalAlternateScrollModeTracking(terminal)
+
+    expect(handlers.csi.get('?h')?.([1007])).toBe(false)
+    expect(tracked.appPreference()).toBe(true)
+
+    expect(handlers.csi.get('?l')?.([1007])).toBe(false)
+    expect(tracked.appPreference()).toBe(false)
+  })
+
+  it('reads the mode out of a combined private-mode sequence', () => {
+    const { terminal, handlers } = fakeTerminal()
+    const tracked = attachTerminalAlternateScrollModeTracking(terminal)
+
+    handlers.csi.get('?h')?.([1049, 1007])
+    expect(tracked.appPreference()).toBe(true)
+  })
+
+  it('ignores private modes it does not own', () => {
+    const { terminal, handlers } = fakeTerminal()
+    const tracked = attachTerminalAlternateScrollModeTracking(terminal)
+
+    handlers.csi.get('?h')?.([1049, 1000, 1006])
+    expect(tracked.appPreference()).toBeUndefined()
+  })
+
+  it('clears the preference on a full reset so it cannot outlive the process', () => {
+    const { terminal, handlers } = fakeTerminal()
+    const tracked = attachTerminalAlternateScrollModeTracking(terminal)
+
+    handlers.csi.get('?h')?.([1007])
+    expect(handlers.esc.get('c')?.()).toBe(false)
+    expect(tracked.appPreference()).toBeUndefined()
+  })
+
+  it('clears the preference on a soft reset', () => {
+    const { terminal, handlers } = fakeTerminal()
+    const tracked = attachTerminalAlternateScrollModeTracking(terminal)
+
+    handlers.csi.get('?l')?.([1007])
+    expect(handlers.csi.get('!p')?.([])).toBe(false)
+    expect(tracked.appPreference()).toBeUndefined()
+  })
+
+  it('forgets a preference when the app leaves the alternate screen', () => {
+    const { terminal, handlers } = fakeTerminal()
+    const tracked = attachTerminalAlternateScrollModeTracking(terminal)
+
+    handlers.csi.get('?h')?.([1049])
+    handlers.csi.get('?h')?.([1007])
+    expect(tracked.appPreference()).toBe(true)
+
+    handlers.csi.get('?l')?.([1049])
+    expect(tracked.appPreference()).toBeUndefined()
+  })
+
+  it('forgets a disabled preference so the next app is not retuned by it', () => {
+    const { terminal, handlers } = fakeTerminal()
+    const tracked = attachTerminalAlternateScrollModeTracking(terminal)
+
+    handlers.csi.get('?l')?.([1007])
+    expect(tracked.appPreference()).toBe(false)
+
+    handlers.csi.get('?l')?.([1049])
+    expect(tracked.appPreference()).toBeUndefined()
+
+    handlers.csi.get('?h')?.([1049])
+    expect(tracked.appPreference()).toBeUndefined()
+  })
+
+  it('starts a fresh alternate-screen session even when entry reuses the sequence', () => {
+    const { terminal, handlers } = fakeTerminal()
+    const tracked = attachTerminalAlternateScrollModeTracking(terminal)
+
+    handlers.csi.get('?l')?.([1007])
+    handlers.csi.get('?h')?.([1049, 1007])
+    expect(tracked.appPreference()).toBe(true)
+  })
+
+  it('covers the older alternate-screen modes', () => {
+    for (const mode of [1049, 1047, 47]) {
+      const { terminal, handlers } = fakeTerminal()
+      const tracked = attachTerminalAlternateScrollModeTracking(terminal)
+      handlers.csi.get('?h')?.([1007])
+      handlers.csi.get('?l')?.([mode])
+      expect(tracked.appPreference()).toBeUndefined()
+    }
+  })
+
+  it('removes every registration on dispose', () => {
+    const { terminal, handlers } = fakeTerminal()
+    attachTerminalAlternateScrollModeTracking(terminal).dispose()
+    expect(handlers.disposed.sort()).toEqual(['!p', '?h', '?l', 'esc:c'])
+  })
+
+  it('degrades to no preference on a parser without handler registration', () => {
+    const tracked = attachTerminalAlternateScrollModeTracking({})
+    expect(tracked.appPreference()).toBeUndefined()
+    expect(() => tracked.dispose()).not.toThrow()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-alternate-scroll-mode.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-alternate-scroll-mode.ts
@@ -1,0 +1,109 @@
+import { guardParserHandler } from '@/components/terminal-pane/terminal-parser-handler-guard'
+
+// DECSET 1007. xterm.js parses no mode here, so Orca tracks it itself.
+const ALTERNATE_SCROLL_MODE = 1007
+// Alternate-screen modes, in the order terminals have accumulated them.
+const ALTERNATE_SCREEN_MODES = [1049, 1047, 47]
+const SET_MODE_FINAL = 'h'
+const RESET_MODE_FINAL = 'l'
+const SOFT_RESET_FINAL = 'p'
+const SOFT_RESET_INTERMEDIATE = '!'
+const FULL_RESET_FINAL = 'c'
+
+// Why split: xterm only accepts a prefix in 0x3c..0x3f, so DECSTR's `!` is an
+// intermediate byte, not a prefix.
+type CsiHandlerId = { prefix?: string; intermediates?: string; final: string }
+type ParserHandler = (params: (number | number[])[]) => boolean
+
+export type TerminalAlternateScrollModeTarget = {
+  parser?: {
+    registerCsiHandler?: (id: CsiHandlerId, handler: ParserHandler) => { dispose: () => void }
+    registerEscHandler?: (id: { final: string }, handler: () => boolean) => { dispose: () => void }
+  }
+}
+
+export type TerminalAlternateScrollMode = {
+  /** The app's explicit DECSET 1007 state, or undefined while it has never set it. */
+  appPreference: () => boolean | undefined
+  dispose: () => void
+}
+
+function paramsIncludeMode(params: (number | number[])[], modes: number[]): boolean {
+  return params.some((param) =>
+    Array.isArray(param) ? param.some((value) => modes.includes(value)) : modes.includes(param)
+  )
+}
+
+/**
+ * Tracks DECSET 1007 (alternate scroll mode) so wheel routing can tell an app
+ * that wants wheel-as-cursor-keys from one that has turned it off.
+ *
+ * Why tracked here: xterm.js implements neither the mode nor a way to read it,
+ * and synthesizes cursor keys purely from "the buffer has no scrollback".
+ */
+export function attachTerminalAlternateScrollModeTracking(
+  terminal: TerminalAlternateScrollModeTarget
+): TerminalAlternateScrollMode {
+  let appPreference: boolean | undefined
+
+  // Why scoped to one alternate-screen session: the mode only steers the wheel
+  // on the alternate screen, and a preference left behind by an app that has
+  // already exited would silently retune the wheel for whatever the user runs
+  // in the pane next. Entering and leaving the alternate screen both clear it,
+  // so each fullscreen app starts from the user's setting.
+  const observeSetPrivateMode = (params: (number | number[])[]) => {
+    if (paramsIncludeMode(params, ALTERNATE_SCREEN_MODES)) {
+      appPreference = undefined
+    }
+    if (paramsIncludeMode(params, [ALTERNATE_SCROLL_MODE])) {
+      appPreference = true
+    }
+    // Why false: this observes the mode, it does not implement the sequence.
+    return false
+  }
+
+  const observeResetPrivateMode = (params: (number | number[])[]) => {
+    if (paramsIncludeMode(params, [ALTERNATE_SCROLL_MODE])) {
+      appPreference = false
+    }
+    if (paramsIncludeMode(params, ALTERNATE_SCREEN_MODES)) {
+      appPreference = undefined
+    }
+    return false
+  }
+
+  // Why cleared on reset too: a killed TUI or a dropped SSH session can leave
+  // the pane on the alternate screen with no exit sequence ever arriving.
+  const observeReset = () => {
+    appPreference = undefined
+    return false
+  }
+
+  const registrations = [
+    terminal.parser?.registerCsiHandler?.(
+      { prefix: '?', final: SET_MODE_FINAL },
+      guardParserHandler('csi-alternate-scroll-set', observeSetPrivateMode)
+    ),
+    terminal.parser?.registerCsiHandler?.(
+      { prefix: '?', final: RESET_MODE_FINAL },
+      guardParserHandler('csi-alternate-scroll-reset', observeResetPrivateMode)
+    ),
+    terminal.parser?.registerCsiHandler?.(
+      { intermediates: SOFT_RESET_INTERMEDIATE, final: SOFT_RESET_FINAL },
+      guardParserHandler('csi-alternate-scroll-soft-reset', observeReset)
+    ),
+    terminal.parser?.registerEscHandler?.(
+      { final: FULL_RESET_FINAL },
+      guardParserHandler('esc-alternate-scroll-full-reset', observeReset)
+    )
+  ]
+
+  return {
+    appPreference: () => appPreference,
+    dispose: () => {
+      for (const registration of registrations) {
+        registration?.dispose()
+      }
+    }
+  }
+}

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -68,6 +68,10 @@ export function buildDefaultSettings(args: {
     terminalFastScrollSensitivity: 5,
     terminalTuiScrollSensitivity: 1,
     terminalTuiScrollSensitivityDefaultedToOne: true,
+    // Why true: preserves xterm's existing wheel-as-cursor-keys behaviour, which
+    // pagers and editors rely on. Users whose fullscreen agent maps arrows to
+    // input history turn it off.
+    terminalAlternateScreenWheelSendsArrowKeys: true,
     // Why: "auto" uses WebGL when supported, falling back to DOM on renderer failure or software/unknown GPU.
     terminalGpuAcceleration: 'auto',
     // Why 'auto': enable ligatures only for known ligature fonts, never forced. Resolver in shared/terminal-ligatures.ts.

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -115,6 +115,10 @@ export type GlobalSettings = {
   terminalTuiScrollSensitivity: number
   /** One-shot migration guard for moving inherited TUI wheel reports from 3 to 1. */
   terminalTuiScrollSensitivityDefaultedToOne?: boolean
+  /** Fallback for DECSET 1007 when a fullscreen app never sets the mode: whether
+   *  the wheel sends arrow keys on the alternate screen. Apps that set 1007
+   *  explicitly win over this. */
+  terminalAlternateScreenWheelSendsArrowKeys: boolean
   /** Terminal renderer policy.
    *  - 'auto': try xterm WebGL and fall back to DOM when unsupported or risky.
    *  - 'on': always try xterm WebGL.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​274 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​273 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​229 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​224 |

<!-- /orca-pr-loc -->

## ELI5

Scrolling the wheel over a full-screen terminal app that doesn't handle the mouse itself makes the terminal type Up/Down arrows instead. A pager wants that. An agent CLI or tmux does not — it walks your prompt history backwards. Orca now looks at the standard terminal mode that says which behaviour an app wants, and adds a setting for apps that never say.

## Why this and not the normal buffer

xterm decides whether the wheel becomes cursor keys from a single condition — `!buffer.hasScrollback` (`MouseService.ts:267`). Orca's scrollback floor is 1000 rows (`terminal-scrollback-policy.ts:2`), so on the normal buffer that is never true: the wheel scrolls and no arrows are sent. The symptom is alternate-screen only.

I verified this against real panes with real (CDP-dispatched, trusted) wheel events before writing anything:

| scenario | bytes to PTY | result |
| --- | --- | --- |
| real inline agent pane (normal buffer, mouse off) | focus reports only | viewport scrolled 118 → 105, prompt untouched |
| `tmux` (alt screen, mouse off) | `ESC O A` ×2 | shell prompt walked back through history |

`tmux` is the one-command reproduction: it sends `?1049h` and then explicitly `?1000l ?1002l ?1003l ?1006l`.

## What changed

- Track **DECSET 1007** (alternate scroll mode). xterm implements it neither as a parsed mode nor as readable state, so `terminal-alternate-scroll-mode.ts` observes the private-mode sequences through the parser and reports the app's preference.
- Wheel routing consults it only on the alternate screen with no mouse reporting: app preference wins, otherwise the new setting, otherwise today's behaviour.
- The preference is scoped to one alternate-screen session. Entering or leaving the alternate screen clears it, as do RIS and DECSTR, so a mode left behind by an exited or killed app can't retune the wheel for whatever runs next in the pane.
- New setting **Full-screen apps: wheel sends arrow keys**, default **on** — identical to current behaviour.

## Testing

- `pnpm tc` — passed
- `pnpm run check:code-quality:changed` — 0 findings
- `pnpm exec vitest run` over `lib/pane-manager`, `components/terminal-pane`, `components/settings`, `shared` — 13,956 passed
- 26 new unit tests

### Live verification

Every row below is a real PTY in a running Orca window driven with trusted `Input.dispatchMouseEvent` wheel events, asserting the actual bytes reaching the PTY.

| scenario | setting | arrows | mouse reports | expected |
| --- | --- | --- | --- | --- |
| normal buffer | on | 0 | 0 | scrolls, no arrows |
| normal buffer | off | 0 | 0 | unchanged |
| alt screen, no 1007 | on | 6 | 0 | unchanged from today |
| alt screen, no 1007 | off | 0 | 0 | **fixed** |
| alt screen, `?1007h` | off | 6 | 0 | app overrides setting |
| alt screen, `?1007l` | on | 0 | 0 | app overrides setting |
| `tmux` | on | 2 | 0 | unchanged from today |
| `tmux` | off | 0 | 0 | **fixed** |
| `less` | on | 2 | 0 | **no regression** |
| `less` | off | 0 | 0 | documented trade-off |
| alt screen + mouse reporting | off | 0 | 10 | unchanged |
| alt screen + mouse reporting | on | 0 | 11 | unchanged |

That harness earned its keep: it caught two real defects in my own code that unit tests missed — an out-of-range CSI prefix for DECSTR that crashed the terminal workbench on pane creation, and a `?1007l` preference leaking across apps in the same pane. Both are fixed, and both now have unit coverage (the test fake validates xterm's identifier byte ranges).

## Notes

- Cross-platform: renderer-only, no platform branches. Nothing about the mechanism is Windows-specific — I checked the one Windows-conditional branch in xterm's buffer code (`_isReflowEnabled`, conpty build gate) and it only affects reflow on resize.
- SSH/remote: no execution-host or wire change; wheel routing stays client-side.
- Trade-off: with the setting off, alternate-screen pagers lose wheel-to-arrow scrolling. That's why it defaults to on and why an app's explicit 1007 overrides it.
- Supersedes #17103, which routes normal-buffer wheel input instead. That path is unreachable when the viewport has room to scroll — xterm's scrollable element handles the wheel first and calls `stopPropagation()`, so the custom handler is never invoked — and it leaves the alternate-screen branch, the only one that emits arrows, untouched.
