### PR TITLE
test(wsl): the banner suite could not fail where it will normally run

### DIFF
--- a/config/scripts/win32-test-lane-registration.test.mjs
+++ b/config/scripts/win32-test-lane-registration.test.mjs
@@ -59,9 +59,22 @@ import { classifyPrJobs } from './pr-code-change-scope.mjs'
  *   - whether a registered suite EXECUTES. Registration is what is asserted. A
  *     suite gated on win32 plus an env var stays skipped on the CI runner even
  *     when registered -- see MANUAL_OPT_IN -- and a path registered but gated
- *     for another platform is not caught either.
+ *     for another platform is not caught either. Measured 2026-09: nothing in
+ *     `.github/` or `config/` sets any `ORCA_REAL_WSL_*` variable, so all four
+ *     `*.wsl.test.ts` suites ran on no machine until someone exported them by
+ *     hand. They pass; that was not knowable from the board.
+ *   - that an env-var gate can be OPENED. These are compared with `===`, and
+ *     `set VAR=1 && cmd` in cmd.exe stores `"1 "` -- trailing space, gate shut,
+ *     suite reports "skipped" exactly as it does when you never set it. Prefer
+ *     `set "VAR=1"`, and prefer a gate whose closed state is distinguishable
+ *     from its unset state. A gate nobody can open is a gate nobody is running.
  *   - whether the `package_windows` job is triggered for a given diff, or
- *     whether the registered test asserts anything worth running.
+ *     whether the registered test asserts anything worth running. The second
+ *     half is not hypothetical: `local-worktree-filesystem-wsl-banner.wsl.test.ts`
+ *     was registered, opt-in, green -- and could not fail, because its contrast
+ *     row used `endsWith` and the banner it contrasts against is conditional on
+ *     distro user state. Registered, triggered and unable to fail are three
+ *     separate ways to be invisible.
  *
  * Growth of the two grandfathered lists is capped by literals, but only review
  * stops someone raising a cap. The caps make that an explicit, visible edit.

--- a/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
+++ b/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
@@ -57,9 +57,19 @@ describe.skipIf(!runRealWsl)('WSL worktree reads carry no shell chatter', () => 
     const { readPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })
     const raw = await readThroughRawLoginShell(`${fixtureRoot}/file.txt`)
 
-    // Contrast: routed through a login shell the read carries whatever the rc
-    // files printed (stock Ubuntu ships a sudo hint). These reads use a plain
-    // `sh -c`, which runs no rc at all, so they are exactly the file.
+    // Precondition, not decoration. This row is the suite's only contrast, and
+    // `endsWith` alone holds whether or not the rc files printed anything -- so
+    // without this line the contrast is satisfied by a machine that produces no
+    // banner at all, and the suite reports success having exercised nothing.
+    //
+    // The banner is conditional on distro user state this suite does not own:
+    // Ubuntu's sudo hint is gated on `~/.sudo_as_admin_successful` and the MOTD
+    // on `~/.motd_shown` (once per day per HOME). On any machine where the user
+    // has sudo'd and today's MOTD already fired -- every developer box after day
+    // one -- `raw` is exactly the file. Fail loudly there instead: "the hazard is
+    // not reproducible on this machine" is a real answer, and a green run that
+    // never met the banner is not.
+    expect(raw).not.toBe(FILE_CONTENTS)
     expect(raw.endsWith(FILE_CONTENTS)).toBe(true)
     expect(await readPath(unc(`${fixtureRoot}/file.txt`))).toBe(FILE_CONTENTS)
   }, 60_000)

--- a/src/main/wsl/wsl-runner.wsl.test.ts
+++ b/src/main/wsl/wsl-runner.wsl.test.ts
@@ -11,6 +11,18 @@ import { resolveWslExecutablePath } from './wsl-executable-path'
  * Gated behind an env var and win32 because it mutates the distro's `~/.profile`
  * to reproduce #14288. Run with:
  *   ORCA_REAL_WSL_RUNNER_TEST=1 pnpm vitest run src/main/wsl/wsl-runner.wsl.test.ts
+ *
+ * DO NOT run this against a distro you share. The teardown below works, but it
+ * has no margin, and all three of its failure modes land on a real user:
+ *   - the appended `sleep 60` is in `$HOME/.profile` for the duration, so any
+ *     login shell started in that window stalls a minute;
+ *   - an aborted run (crash, timeout, Ctrl-C) never reaches `afterAll`, and the
+ *     stall becomes permanent;
+ *   - the backup is `cp … || true` to a FIXED path, so if it fails, or a stale
+ *     copy from an earlier abort is present, teardown's `|| rm -f "$HOME/.profile"`
+ *     deletes or reverts the user's profile.
+ * Verified by hashing `$HOME/.profile` either side of a run, which is the check
+ * to repeat if you must run it somewhere shared -- do not assume the restore.
  */
 const DISTRO = process.env.ORCA_WSL_TEST_DISTRO ?? 'Ubuntu-24.04'
 const enabled = process.platform === 'win32' && process.env.ORCA_REAL_WSL_RUNNER_TEST === '1'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

A test that guards the WSL login-shell banner could not fail on the machines where it will normally be run. Found by running it — for the first time — against a real Ubuntu-24.04 distro under WSL2.

## The problem

`local-worktree-filesystem-wsl-banner.wsl.test.ts` exists to prove a WSL worktree read carries no login-shell chatter. Its only contrast row asserted:

```ts
expect(raw.endsWith(FILE_CONTENTS)).toBe(true)
```

That holds whether or not the rc files printed anything. On a machine that emits no banner, the row is satisfied by a shell that printed nothing, and the suite reports success having exercised nothing.

## Measured

Against a live Ubuntu-24.04 distro, with production mutated to route the read through a login shell — `['sh','-c',cmd]` → `['sh','-lc', buildWslLoginShellCommand(cmd)]`, exactly the regression this suite guards, and exactly what the production file's own header says not to do:

| production read | banner | result |
| --- | --- | --- |
| real | absent | pass |
| real | forced | pass — the no-login-shell design genuinely defeats a real 881-byte banner |
| **mutated** | **absent** | **PASS — survivor** |
| mutated | forced | fail (4/5), `expected 'To run a command as administrator (us…' to be 'line one\nline two\n'` |

**Row 3 is the finding.** The only test guarding this would have shipped the regression green.

The banner is conditional on distro user state the suite does not own: Ubuntu's sudo hint is gated on `~/.sudo_as_admin_successful`, and the MOTD on `~/.motd_shown`, once per day per HOME. The old comment said *"stock Ubuntu ships a sudo hint"* — true only until the user first runs `sudo`. So the condition is silently false on every developer box after day one, which is precisely where an opt-in suite gets run.

## The change

`expect(raw).not.toBe(FILE_CONTENTS)` turns the contrast into a precondition. "The hazard is not reproducible on this machine" is a real answer; a green run that never met the banner is not.

Verified both directions on the same distro:

- banner absent → the row now **fails** (1/5) instead of passing vacuously
- banner forced → **5/5 pass**
- banner forced, production mutated → still **fails 4/5**, so the teeth are unchanged

## Second commit: two things worth writing down

Comments only, no assertion or behaviour changes; both lane ratchets stay green.

**Lane ratchet header**, beside the existing "does a registered suite EXECUTE" prose:

- Nothing in `.github/` or `config/` sets any `ORCA_REAL_WSL_*` variable. All four `*.wsl.test.ts` suites ran on **no machine** until exported by hand. They pass (16/16) — that was not knowable from a green board.
- These gates are compared with `===`, and `set VAR=1 && cmd` in cmd.exe stores `"1 "`. Trailing space, gate shut, and the suite reports "skipped" **identically to never having set it**. I had this filed as a repo defect for several minutes before checking my own shell.
- Registered, triggered, and unable to fail are three separate ways to be invisible. This suite was all three at once.

**Runner suite header** (`wsl-runner.wsl.test.ts`): it appends `sleep 60` to the shared distro user's `~/.profile`, backs up to a **fixed path** with `|| true`, and teardown's fallback is `rm -f "$HOME/.profile"`. The teardown works — it has no margin. An aborted run leaves every new login stalling a minute, or deletes the profile outright. The note says not to run it against a shared distro and gives the check to repeat if you must: hash `$HOME/.profile` either side, never assume the restore. (That is how this run was made safe; the hash matched.)

## Scope

Outside the SSH-remote integration stack; based on `main`. Two commits, three files, no production code touched.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts.

| | SHA |
| --- | --- |
| old head | `469289e5a6d037d154f38a50bb5abba64626696e` |
| new head | `065b3fab2433dfd552c8808ff719128709585da6` |

#20050 stacks on this branch and was replayed onto the new head.
<!-- /rebase-record -->
