### PR TITLE
fix(crash-reporting): re-census a heavy renderer so the memory profile is not 21h stale

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -72,7 +72,9 @@ export function recordCrashBreadcrumb(
   }
   const retainedKey = retainedBreadcrumbKey(breadcrumb)
   if (retainedKey) {
-    retainedBreadcrumbs.delete(retainedKey)
+    // Why no delete-then-set: re-inserting moves the key to the back, so a slot that refreshes
+    // outranks one that froze at its peak — and the frozen peak census is exactly the evidence
+    // worth keeping. Plain set preserves insertion order, keeping eviction FIFO by first crossing.
     retainedBreadcrumbs.set(retainedKey, breadcrumb)
     while (retainedBreadcrumbs.size > MAX_RETAINED_BREADCRUMBS) {
       const oldestKey = retainedBreadcrumbs.keys().next()

--- a/src/renderer/src/lib/renderer-memory-sampling.test.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.test.ts
@@ -190,6 +190,28 @@ describe('renderer memory highwater census re-arming', () => {
     expect(censuses().at(-1)).toMatchObject({ thresholdPrivateMB: 600, aboveMarkMinutes: 120 })
   })
 
+  // Sawtooth (build, GC, build) is the ordinary shape of renderer memory. Two spikes hours apart
+  // must not read as sustained pressure, or triage starts a leak hunt that has no leak.
+  it('re-anchors minutes-above-mark after a long spell below the band', async () => {
+    stubFootprint(658)
+    await tick()
+    await tick()
+    expect(censuses().at(-1)).toMatchObject({ aboveMarkMinutes: 0 })
+
+    // 10 hours far below the band, then back up.
+    stubFootprint(100)
+    for (let minute = 0; minute < 600; minute += 1) {
+      await tick()
+    }
+    stubFootprint(700)
+    await tick()
+    await tick()
+
+    // Not 602: the renderer spent those 600 minutes at 100MB.
+    expect(censuses().at(-1)).toMatchObject({ thresholdPrivateMB: 600 })
+    expect(censuses().at(-1)?.aboveMarkMinutes).toBeLessThanOrEqual(2)
+  })
+
   it('emits at most one census per mark while a renderer oscillates around it', async () => {
     stubFootprint(601)
     await tick()

--- a/src/renderer/src/lib/renderer-memory-sampling.test.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.test.ts
@@ -174,11 +174,11 @@ describe('renderer memory highwater census re-arming', () => {
 
   // A refresh replaces the retained crumb's own createdAt, so the census must carry how long the
   // renderer has been over the mark — that is the axis that identified the 21h-stale census.
-  it('reports minutes above the mark across refreshes', async () => {
+  it('reports minutes near the mark across refreshes', async () => {
     stubFootprint(658)
     await tick()
     await tick()
-    expect(censuses().at(-1)).toMatchObject({ thresholdPrivateMB: 600, aboveMarkMinutes: 0 })
+    expect(censuses().at(-1)).toMatchObject({ thresholdPrivateMB: 600, nearMarkMinutes: 0 })
 
     stubFootprint(577)
     for (let minute = 0; minute < 120; minute += 1) {
@@ -187,16 +187,16 @@ describe('renderer memory highwater census re-arming', () => {
 
     // Still over the band, so it refreshed — and it says how long it has been up there.
     expect(censuses().length).toBeGreaterThan(1)
-    expect(censuses().at(-1)).toMatchObject({ thresholdPrivateMB: 600, aboveMarkMinutes: 120 })
+    expect(censuses().at(-1)).toMatchObject({ thresholdPrivateMB: 600, nearMarkMinutes: 120 })
   })
 
   // Sawtooth (build, GC, build) is the ordinary shape of renderer memory. Two spikes hours apart
   // must not read as sustained pressure, or triage starts a leak hunt that has no leak.
-  it('re-anchors minutes-above-mark after a long spell below the band', async () => {
+  it('re-anchors minutes-near-mark after a long observed spell below the band', async () => {
     stubFootprint(658)
     await tick()
     await tick()
-    expect(censuses().at(-1)).toMatchObject({ aboveMarkMinutes: 0 })
+    expect(censuses().at(-1)).toMatchObject({ nearMarkMinutes: 0 })
 
     // 10 hours far below the band, then back up.
     stubFootprint(100)
@@ -209,7 +209,27 @@ describe('renderer memory highwater census re-arming', () => {
 
     // Not 602: the renderer spent those 600 minutes at 100MB.
     expect(censuses().at(-1)).toMatchObject({ thresholdPrivateMB: 600 })
-    expect(censuses().at(-1)?.aboveMarkMinutes).toBeLessThanOrEqual(2)
+    expect(censuses().at(-1)?.nearMarkMinutes).toBeLessThanOrEqual(2)
+  })
+
+  // A wedged main thread or a suspend stops the 60s sampler. That is not the renderer leaving the
+  // band — and it is exactly when the renderer is sickest, so the clock must not reset.
+  it('does not reset the clock when sampling itself stalls', async () => {
+    stubFootprint(658)
+    await tick()
+    await tick()
+    for (let minute = 0; minute < 30; minute += 1) {
+      await tick()
+    }
+    const beforeGap = censuses().at(-1)?.nearMarkMinutes as number
+    expect(beforeGap).toBeGreaterThanOrEqual(30)
+
+    // Sampler stalls for 8 hours, then resumes with the renderer still heavy.
+    nowMs += 8 * 60 * 60_000
+    await tick()
+    await tick()
+
+    expect(censuses().at(-1)?.nearMarkMinutes as number).toBeGreaterThan(beforeGap + 400)
   })
 
   it('emits at most one census per mark while a renderer oscillates around it', async () => {

--- a/src/renderer/src/lib/renderer-memory-sampling.test.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.test.ts
@@ -192,7 +192,7 @@ describe('renderer memory highwater census re-arming', () => {
 
   // Sawtooth (build, GC, build) is the ordinary shape of renderer memory. Two spikes hours apart
   // must not read as sustained pressure, or triage starts a leak hunt that has no leak.
-  it('re-anchors minutes-near-mark after a long observed spell below the band', async () => {
+  it('discounts a long observed spell below the band', async () => {
     stubFootprint(658)
     await tick()
     await tick()

--- a/src/renderer/src/lib/renderer-memory-sampling.test.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.test.ts
@@ -172,6 +172,24 @@ describe('renderer memory highwater census re-arming', () => {
     expect(censuses().map((c) => c.privateMB)).toEqual([1200, 1200])
   })
 
+  // A refresh replaces the retained crumb's own createdAt, so the census must carry how long the
+  // renderer has been over the mark — that is the axis that identified the 21h-stale census.
+  it('reports minutes above the mark across refreshes', async () => {
+    stubFootprint(658)
+    await tick()
+    await tick()
+    expect(censuses().at(-1)).toMatchObject({ thresholdPrivateMB: 600, aboveMarkMinutes: 0 })
+
+    stubFootprint(577)
+    for (let minute = 0; minute < 120; minute += 1) {
+      await tick()
+    }
+
+    // Still over the band, so it refreshed — and it says how long it has been up there.
+    expect(censuses().length).toBeGreaterThan(1)
+    expect(censuses().at(-1)).toMatchObject({ thresholdPrivateMB: 600, aboveMarkMinutes: 120 })
+  })
+
   it('emits at most one census per mark while a renderer oscillates around it', async () => {
     stubFootprint(601)
     await tick()

--- a/src/renderer/src/lib/renderer-memory-sampling.test.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.test.ts
@@ -232,6 +232,27 @@ describe('renderer memory highwater census re-arming', () => {
     expect(censuses().at(-1)?.nearMarkMinutes as number).toBeGreaterThan(beforeGap + 400)
   })
 
+  // A short trough is still a trough. 40 one-minute spikes separated by 14 minutes at 100MB is
+  // not 10 hours of sustained pressure, and reporting it as such sends triage on a leak hunt.
+  it('counts only samples actually seen near the mark, not elapsed time', async () => {
+    stubFootprint(658)
+    await tick()
+    await tick()
+
+    for (let cycle = 0; cycle < 40; cycle += 1) {
+      stubFootprint(100)
+      for (let minute = 0; minute < 14; minute += 1) {
+        await tick()
+      }
+      stubFootprint(620)
+      await tick()
+    }
+
+    // ~40 in-band samples out of ~602 minutes elapsed.
+    const reported = censuses().at(-1)?.nearMarkMinutes as number
+    expect(reported).toBeLessThanOrEqual(60)
+  })
+
   it('emits at most one census per mark while a renderer oscillates around it', async () => {
     stubFootprint(601)
     await tick()

--- a/src/renderer/src/lib/renderer-memory-sampling.test.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RendererMemorySampling from './renderer-memory-sampling'
+
+type SamplingModule = typeof RendererMemorySampling
+
+const KB = 1024
+const SAMPLE_INTERVAL_MS = 60_000
+const WEBVIEW_REGISTRY = '../components/browser-pane/host-guest/webview-registry'
+
+describe('renderer memory highwater census re-arming', () => {
+  let sampling: SamplingModule
+  let recordBreadcrumbMock: ReturnType<typeof vi.fn>
+  let readProcessMemory: ReturnType<typeof vi.fn>
+  let heapStats: Record<string, number>
+  let webviewProfile: { browserWebviewCount: number; registeredBrowserGuestCount: number }
+  let nowMs: number
+
+  const stubFootprint = (privateMB: number): void => {
+    readProcessMemory.mockResolvedValue({ privateKB: privateMB * KB })
+  }
+
+  /** One 60s sampling tick; the async footprint read settles before the next. */
+  const tick = async (): Promise<void> => {
+    nowMs += SAMPLE_INTERVAL_MS
+    sampling.recordRendererMemorySample('interval')
+    await Promise.resolve()
+    await Promise.resolve()
+  }
+
+  const censuses = (): Record<string, unknown>[] =>
+    recordBreadcrumbMock.mock.calls
+      .filter((call) => (call[0] as { name: string }).name === 'renderer_memory_highwater')
+      .map((call) => (call[0] as { data: Record<string, unknown> }).data)
+
+  beforeEach(async () => {
+    vi.resetModules()
+    nowMs = 0
+    recordBreadcrumbMock = vi.fn()
+    readProcessMemory = vi.fn().mockResolvedValue(null)
+    // Why 150MB of a 4192MB limit: 3.6% of the ratio ladder, so only the
+    // private-footprint marks can arm and the ratio marks stay out of the way.
+    heapStats = {
+      usedHeapKB: 150 * KB,
+      totalHeapKB: 305 * KB,
+      heapLimitKB: 4192 * KB,
+      mallocedKB: 1 * KB,
+      blinkAllocatedKB: 215 * KB
+    }
+    webviewProfile = { browserWebviewCount: 0, registeredBrowserGuestCount: 0 }
+    vi.stubGlobal('performance', { now: () => nowMs })
+    vi.stubGlobal('window', {
+      performance: {},
+      api: {
+        crashReports: {
+          recordBreadcrumb: recordBreadcrumbMock,
+          readProcessMemory,
+          readHeapStatistics: () => heapStats
+        }
+      }
+    })
+    vi.stubGlobal('document', {
+      getElementsByTagName: () => ({ length: 2376 }),
+      querySelectorAll: () => ({ length: 12 })
+    })
+    vi.doMock(WEBVIEW_REGISTRY, () => ({
+      getBrowserWebviewMemoryProfile: () => webviewProfile
+    }))
+    sampling = (await import('./renderer-memory-sampling')) as SamplingModule
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.doUnmock(WEBVIEW_REGISTRY)
+  })
+
+  it('emits nothing until a mark is crossed, then exactly one census', async () => {
+    stubFootprint(420)
+    await tick()
+    await tick()
+    expect(censuses()).toHaveLength(0)
+
+    stubFootprint(658)
+    await tick()
+    await tick()
+    expect(censuses()).toHaveLength(1)
+    expect(censuses()[0]).toMatchObject({ thresholdPrivateMB: 600, privateMB: 658 })
+  })
+
+  it('re-emits the census while a renderer plateaus above a mark for 21 hours', async () => {
+    // Field: crashes fb476b1c / d4d32680 crossed 600MB, emitted one census,
+    // then ran 21 more hours and died at 577MB without re-crossing — so both
+    // reports carried a byte-identical census describing a 21h-old workload.
+    stubFootprint(658)
+    await tick()
+    await tick()
+    expect(censuses()).toHaveLength(1)
+    expect(censuses()[0]).toMatchObject({
+      thresholdPrivateMB: 600,
+      privateMB: 658,
+      blinkAllocatedMB: 215,
+      browserWebviews: 0
+    })
+
+    // The workload the stale census could not describe: a browser guest opened,
+    // Blink's own allocation collapsed, and the growth moved outside the heap.
+    webviewProfile.browserWebviewCount = 1
+    heapStats.blinkAllocatedKB = 21 * KB
+    stubFootprint(640)
+    for (let minute = 0; minute < 21 * 60; minute += 1) {
+      await tick()
+    }
+
+    expect(censuses().length).toBeGreaterThan(1)
+    expect(censuses().at(-1)).toMatchObject({
+      thresholdPrivateMB: 600,
+      privateMB: 640,
+      blinkAllocatedMB: 21,
+      browserWebviews: 1
+    })
+    // Anti-spam: 1260 samples must not become 1260 censuses.
+    expect(censuses().length).toBeLessThanOrEqual(90)
+  })
+
+  it('emits at most one census per mark while a renderer oscillates around it', async () => {
+    stubFootprint(601)
+    await tick()
+    await tick()
+    expect(censuses()).toHaveLength(1)
+
+    for (let minute = 0; minute < 14; minute += 1) {
+      stubFootprint(minute % 2 === 0 ? 599 : 601)
+      await tick()
+    }
+
+    expect(censuses()).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/lib/renderer-memory-sampling.test.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.test.ts
@@ -121,6 +121,57 @@ describe('renderer memory highwater census re-arming', () => {
     expect(censuses().length).toBeLessThanOrEqual(90)
   })
 
+  // The literal fb476b1c ending: crossed 600MB, then spent 21h BELOW the mark and died at 577MB.
+  // A re-census gated on the current value never fires here, which was the whole defect.
+  it('re-censuses a renderer that crossed a mark and then settled back below it', async () => {
+    stubFootprint(658)
+    await tick()
+    await tick()
+    expect(censuses()).toHaveLength(1)
+    const firstCensus = censuses()[0]
+
+    // New workload, permanently below the mark, for 21 hours.
+    stubFootprint(577)
+    heapStats.blinkAllocatedKB = 21 * KB
+    webviewProfile = { browserWebviewCount: 1, registeredBrowserGuestCount: 1 }
+    for (let minute = 0; minute < 1260; minute += 1) {
+      await tick()
+    }
+
+    expect(censuses().length).toBeGreaterThan(1)
+    expect(censuses().at(-1)).not.toBe(firstCensus)
+    expect(censuses().at(-1)).toMatchObject({
+      thresholdPrivateMB: 600,
+      privateMB: 577,
+      blinkAllocatedMB: 21,
+      browserWebviews: 1
+    })
+    expect(censuses().length).toBeLessThanOrEqual(90)
+  })
+
+  // The retained crumb is one slot per mark, so a refresh overwrites the peak census. A renderer
+  // that released its memory must keep the peak evidence rather than ship privateMB:50 under a
+  // thresholdPrivateMB:600 label.
+  it('keeps the peak census when a renderer releases its memory', async () => {
+    stubFootprint(1200)
+    heapStats.blinkAllocatedKB = 900 * KB
+    await tick()
+    await tick()
+    // 1200MB crosses both private marks, so both slots are censused at the peak.
+    expect(censuses()).toHaveLength(2)
+
+    // Leak released: 6 hours far below the mark.
+    stubFootprint(50)
+    heapStats.blinkAllocatedKB = 1 * KB
+    for (let minute = 0; minute < 360; minute += 1) {
+      await tick()
+    }
+
+    // No refresh fired, so the retained censuses still describe the peak.
+    expect(censuses()).toHaveLength(2)
+    expect(censuses().map((c) => c.privateMB)).toEqual([1200, 1200])
+  })
+
   it('emits at most one census per mark while a renderer oscillates around it', async () => {
     stubFootprint(601)
     await tick()

--- a/src/renderer/src/lib/renderer-memory-sampling.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.ts
@@ -57,6 +57,8 @@ type HighwaterMarkState = {
   firstCrossedAtMs: number
   lastEmittedAtMs: number
   lastWithinBandAtMs: number
+  /** When the renderer was first observed below the band; null while it is in band. */
+  belowBandSinceMs: number | null
 }
 const emittedHighwaterRatios = new Map<number, HighwaterMarkState>()
 const emittedPrivateHighwaterMarks = new Map<number, HighwaterMarkState>()
@@ -228,11 +230,11 @@ function recordRendererMemoryHighwater(
       if (!isHighwaterCensusDue(emittedHighwaterRatios, threshold, nowMs, ratio)) {
         continue
       }
-      const aboveMarkMinutes = stampHighwaterMark(emittedHighwaterRatios, threshold, nowMs)
+      const nearMarkMinutes = stampHighwaterMark(emittedHighwaterRatios, threshold, nowMs)
       recordRendererCrashBreadcrumb('renderer_memory_highwater', {
         ...profile,
         thresholdPct: Math.round(threshold * 100),
-        aboveMarkMinutes
+        nearMarkMinutes
       })
     }
   }
@@ -241,11 +243,11 @@ function recordRendererMemoryHighwater(
       if (!isHighwaterCensusDue(emittedPrivateHighwaterMarks, mark, nowMs, privateMB)) {
         continue
       }
-      const aboveMarkMinutes = stampHighwaterMark(emittedPrivateHighwaterMarks, mark, nowMs)
+      const nearMarkMinutes = stampHighwaterMark(emittedPrivateHighwaterMarks, mark, nowMs)
       recordRendererCrashBreadcrumb('renderer_memory_highwater', {
         ...profile,
         thresholdPrivateMB: mark,
-        aboveMarkMinutes
+        nearMarkMinutes
       })
     }
   }
@@ -272,21 +274,33 @@ function noteHighwaterBandResidency(
   value: number
 ): void {
   const state = emitted.get(mark)
-  if (state === undefined || value < mark * RENDERER_HIGHWATER_RECENSUS_BAND) {
+  if (state === undefined) {
     return
   }
-  const lapsed = nowMs - state.lastWithinBandAtMs > RENDERER_HIGHWATER_RECENSUS_MS
+  if (value < mark * RENDERER_HIGHWATER_RECENSUS_BAND) {
+    // Why stamp rather than re-anchor here: the spell has to be measured from observed samples.
+    emitted.set(mark, { ...state, belowBandSinceMs: state.belowBandSinceMs ?? nowMs })
+    return
+  }
+  // Why an observed spell and not elapsed time: a renderer that is simply not being sampled — a
+  // main thread wedged past the sample interval, or a suspend — has not left the band, and must
+  // not have its clock reset. Only samples we actually saw below the band count.
+  const lapsed =
+    state.belowBandSinceMs !== null &&
+    nowMs - state.belowBandSinceMs > RENDERER_HIGHWATER_RECENSUS_MS
   emitted.set(mark, {
     firstCrossedAtMs: lapsed ? nowMs : state.firstCrossedAtMs,
     lastEmittedAtMs: state.lastEmittedAtMs,
-    lastWithinBandAtMs: nowMs
+    lastWithinBandAtMs: nowMs,
+    belowBandSinceMs: null
   })
 }
 
 /**
- * Records this emission and returns minutes since the mark was first crossed. Why carry it in the
- * payload: a refresh replaces the retained crumb's `createdAt`, so without this "how long has the
- * renderer been over the mark" — the axis that identified the stale census — becomes unrecoverable.
+ * Records this emission and returns minutes the renderer has been *within the refresh band* of the
+ * mark (>=90% of it), not strictly above it — a renderer sitting at 577MB under a 600MB mark is
+ * the sustained-pressure signal worth reporting. Why carry it in the payload: a refresh replaces
+ * the retained crumb's `createdAt`, so without this the duration axis becomes unrecoverable.
  */
 function stampHighwaterMark(
   emitted: Map<number, HighwaterMarkState>,
@@ -294,7 +308,12 @@ function stampHighwaterMark(
   nowMs: number
 ): number {
   const firstCrossedAtMs = emitted.get(mark)?.firstCrossedAtMs ?? nowMs
-  emitted.set(mark, { firstCrossedAtMs, lastEmittedAtMs: nowMs, lastWithinBandAtMs: nowMs })
+  emitted.set(mark, {
+    firstCrossedAtMs,
+    lastEmittedAtMs: nowMs,
+    lastWithinBandAtMs: nowMs,
+    belowBandSinceMs: null
+  })
   return Math.round((nowMs - firstCrossedAtMs) / 60_000)
 }
 

--- a/src/renderer/src/lib/renderer-memory-sampling.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.ts
@@ -52,8 +52,10 @@ type HeapMetrics = BrowserPerformanceMemory & {
 }
 
 /** Mark -> monotonic time it last emitted a census. */
-const emittedHighwaterRatios = new Map<number, number>()
-const emittedPrivateHighwaterMarks = new Map<number, number>()
+/** First crossing is kept separately: a refresh replaces the crumb's own `createdAt`. */
+type HighwaterMarkState = { firstCrossedAtMs: number; lastEmittedAtMs: number }
+const emittedHighwaterRatios = new Map<number, HighwaterMarkState>()
+const emittedPrivateHighwaterMarks = new Map<number, HighwaterMarkState>()
 let lastProcessFootprint: RendererProcessMemory | null = null
 let processFootprintReadGeneration = 0
 let processFootprintReadInFlight = false
@@ -212,10 +214,11 @@ function recordRendererMemoryHighwater(
       if (!isHighwaterCensusDue(emittedHighwaterRatios, threshold, nowMs, ratio)) {
         continue
       }
-      emittedHighwaterRatios.set(threshold, nowMs)
+      const aboveMarkMinutes = stampHighwaterMark(emittedHighwaterRatios, threshold, nowMs)
       recordRendererCrashBreadcrumb('renderer_memory_highwater', {
         ...profile,
-        thresholdPct: Math.round(threshold * 100)
+        thresholdPct: Math.round(threshold * 100),
+        aboveMarkMinutes
       })
     }
   }
@@ -224,10 +227,11 @@ function recordRendererMemoryHighwater(
       if (!isHighwaterCensusDue(emittedPrivateHighwaterMarks, mark, nowMs, privateMB)) {
         continue
       }
-      emittedPrivateHighwaterMarks.set(mark, nowMs)
+      const aboveMarkMinutes = stampHighwaterMark(emittedPrivateHighwaterMarks, mark, nowMs)
       recordRendererCrashBreadcrumb('renderer_memory_highwater', {
         ...profile,
-        thresholdPrivateMB: mark
+        thresholdPrivateMB: mark,
+        aboveMarkMinutes
       })
     }
   }
@@ -242,13 +246,28 @@ function recordRendererMemoryHighwater(
  * would lose the census taken at its peak. Why monotonic: a wall-clock correction must not
  * stretch or collapse the window.
  */
+/**
+ * Records this emission and returns minutes since the mark was first crossed. Why carry it in the
+ * payload: a refresh replaces the retained crumb's `createdAt`, so without this "how long has the
+ * renderer been over the mark" — the axis that identified the stale census — becomes unrecoverable.
+ */
+function stampHighwaterMark(
+  emitted: Map<number, HighwaterMarkState>,
+  mark: number,
+  nowMs: number
+): number {
+  const firstCrossedAtMs = emitted.get(mark)?.firstCrossedAtMs ?? nowMs
+  emitted.set(mark, { firstCrossedAtMs, lastEmittedAtMs: nowMs })
+  return Math.round((nowMs - firstCrossedAtMs) / 60_000)
+}
+
 function isHighwaterCensusDue(
-  emitted: Map<number, number>,
+  emitted: Map<number, HighwaterMarkState>,
   mark: number,
   nowMs: number,
   value: number
 ): boolean {
-  const lastEmittedAtMs = emitted.get(mark)
+  const lastEmittedAtMs = emitted.get(mark)?.lastEmittedAtMs
   if (lastEmittedAtMs === undefined) {
     return value >= mark
   }

--- a/src/renderer/src/lib/renderer-memory-sampling.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.ts
@@ -51,8 +51,7 @@ type HeapMetrics = BrowserPerformanceMemory & {
   exact: boolean
 }
 
-/** Mark -> monotonic time it last emitted a census. */
-/** First crossing is kept separately: a refresh replaces the crumb's own `createdAt`. */
+/** Per-mark census bookkeeping. Monotonic times throughout; see `isHighwaterCensusDue`. */
 type HighwaterMarkState = {
   /** Accumulated, not derived from a start time: only samples actually seen in band count. */
   nearMarkMs: number
@@ -252,20 +251,7 @@ function recordRendererMemoryHighwater(
   }
 }
 
-/**
- * A mark is due on its first crossing, and thereafter every `RENDERER_HIGHWATER_RECENSUS_MS`
- * while the renderer stays within `RENDERER_HIGHWATER_RECENSUS_BAND` of it. Why not a strict
- * `value >= mark`: report fb476b1c crossed 600MB then died 21h later at 577MB, and a re-census
- * gated on the mark never fires again — that is the stale-census bug. Why not value-independent
- * either: the refresh overwrites the one retained slot, so a renderer that released its memory
- * would lose the census taken at its peak. Why monotonic: a wall-clock correction must not
- * stretch or collapse the window.
- */
-/**
- * Tracks whether the mark is still occupied. Why re-anchor after a gap: the census reports how
- * long the renderer has been heavy, and two spikes hours apart are not sustained pressure —
- * sawtooth (build, GC, build) is the ordinary shape of renderer memory.
- */
+/** Accrues in-band residency for one mark. Emits nothing; see the body for why it accumulates. */
 function noteHighwaterBandResidency(
   emitted: Map<number, HighwaterMarkState>,
   mark: number,
@@ -305,6 +291,15 @@ function stampHighwaterMark(
   return Math.round(nearMarkMs / 60_000)
 }
 
+/**
+ * A mark is due on its first crossing, and thereafter every `RENDERER_HIGHWATER_RECENSUS_MS`
+ * while the renderer stays within `RENDERER_HIGHWATER_RECENSUS_BAND` of it. Why not a strict
+ * `value >= mark`: report fb476b1c crossed 600MB then died 21h later at 577MB, and a re-census
+ * gated on the mark never fires again — that is the stale-census bug. Why not value-independent
+ * either: the refresh overwrites the one retained slot, so a renderer that released its memory
+ * would lose the census taken at its peak. Why monotonic: a wall-clock correction must not
+ * stretch or collapse the window.
+ */
 function isHighwaterCensusDue(
   emitted: Map<number, HighwaterMarkState>,
   mark: number,

--- a/src/renderer/src/lib/renderer-memory-sampling.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.ts
@@ -31,6 +31,10 @@ const RENDERER_PRIVATE_HIGHWATER_MB = [600, 1000] as const
 // stale census. 15min = 1 census per 15 samples, and the store keys retained
 // highwater crumbs by mark, so a refresh replaces the stale one.
 const RENDERER_HIGHWATER_RECENSUS_MS = 15 * 60_000
+// Why 0.9 and not 0: the retained crumb is one slot per mark, so a refresh overwrites the census
+// taken at the peak. Refreshing only while the renderer is still near the mark keeps the peak
+// evidence for a renderer that released its memory, and still re-censuses one that stays large.
+const RENDERER_HIGHWATER_RECENSUS_BAND = 0.9
 
 export type RendererSurface = 'main' | 'dashboard-popout'
 
@@ -170,7 +174,7 @@ function recordRendererMemoryHighwater(
   let crossedThreshold = false
   if (ratio !== null) {
     for (const threshold of RENDERER_MEMORY_HIGHWATER_RATIOS) {
-      if (ratio >= threshold && isHighwaterMarkArmed(emittedHighwaterRatios, threshold, nowMs)) {
+      if (isHighwaterCensusDue(emittedHighwaterRatios, threshold, nowMs, ratio)) {
         crossedThreshold = true
         break
       }
@@ -178,7 +182,7 @@ function recordRendererMemoryHighwater(
   }
   if (privateMB !== null) {
     for (const mark of RENDERER_PRIVATE_HIGHWATER_MB) {
-      if (privateMB >= mark && isHighwaterMarkArmed(emittedPrivateHighwaterMarks, mark, nowMs)) {
+      if (isHighwaterCensusDue(emittedPrivateHighwaterMarks, mark, nowMs, privateMB)) {
         crossedThreshold = true
         break
       }
@@ -205,7 +209,7 @@ function recordRendererMemoryHighwater(
   })
   if (ratio !== null) {
     for (const threshold of RENDERER_MEMORY_HIGHWATER_RATIOS) {
-      if (ratio < threshold || !isHighwaterMarkArmed(emittedHighwaterRatios, threshold, nowMs)) {
+      if (!isHighwaterCensusDue(emittedHighwaterRatios, threshold, nowMs, ratio)) {
         continue
       }
       emittedHighwaterRatios.set(threshold, nowMs)
@@ -217,7 +221,7 @@ function recordRendererMemoryHighwater(
   }
   if (privateMB !== null) {
     for (const mark of RENDERER_PRIVATE_HIGHWATER_MB) {
-      if (privateMB < mark || !isHighwaterMarkArmed(emittedPrivateHighwaterMarks, mark, nowMs)) {
+      if (!isHighwaterCensusDue(emittedPrivateHighwaterMarks, mark, nowMs, privateMB)) {
         continue
       }
       emittedPrivateHighwaterMarks.set(mark, nowMs)
@@ -229,10 +233,29 @@ function recordRendererMemoryHighwater(
   }
 }
 
-/** Why monotonic: a wall-clock correction must not stretch or collapse the window. */
-function isHighwaterMarkArmed(emitted: Map<number, number>, mark: number, nowMs: number): boolean {
+/**
+ * A mark is due on its first crossing, and thereafter every `RENDERER_HIGHWATER_RECENSUS_MS`
+ * while the renderer stays within `RENDERER_HIGHWATER_RECENSUS_BAND` of it. Why not a strict
+ * `value >= mark`: report fb476b1c crossed 600MB then died 21h later at 577MB, and a re-census
+ * gated on the mark never fires again — that is the stale-census bug. Why not value-independent
+ * either: the refresh overwrites the one retained slot, so a renderer that released its memory
+ * would lose the census taken at its peak. Why monotonic: a wall-clock correction must not
+ * stretch or collapse the window.
+ */
+function isHighwaterCensusDue(
+  emitted: Map<number, number>,
+  mark: number,
+  nowMs: number,
+  value: number
+): boolean {
   const lastEmittedAtMs = emitted.get(mark)
-  return lastEmittedAtMs === undefined || nowMs - lastEmittedAtMs >= RENDERER_HIGHWATER_RECENSUS_MS
+  if (lastEmittedAtMs === undefined) {
+    return value >= mark
+  }
+  return (
+    nowMs - lastEmittedAtMs >= RENDERER_HIGHWATER_RECENSUS_MS &&
+    value >= mark * RENDERER_HIGHWATER_RECENSUS_BAND
+  )
 }
 
 function isFiniteHeapBytes(value: number | undefined): value is number {

--- a/src/renderer/src/lib/renderer-memory-sampling.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.ts
@@ -54,11 +54,10 @@ type HeapMetrics = BrowserPerformanceMemory & {
 /** Mark -> monotonic time it last emitted a census. */
 /** First crossing is kept separately: a refresh replaces the crumb's own `createdAt`. */
 type HighwaterMarkState = {
-  firstCrossedAtMs: number
+  /** Accumulated, not derived from a start time: only samples actually seen in band count. */
+  nearMarkMs: number
+  lastSampleAtMs: number
   lastEmittedAtMs: number
-  lastWithinBandAtMs: number
-  /** When the renderer was first observed below the band; null while it is in band. */
-  belowBandSinceMs: number | null
 }
 const emittedHighwaterRatios = new Map<number, HighwaterMarkState>()
 const emittedPrivateHighwaterMarks = new Map<number, HighwaterMarkState>()
@@ -277,22 +276,16 @@ function noteHighwaterBandResidency(
   if (state === undefined) {
     return
   }
-  if (value < mark * RENDERER_HIGHWATER_RECENSUS_BAND) {
-    // Why stamp rather than re-anchor here: the spell has to be measured from observed samples.
-    emitted.set(mark, { ...state, belowBandSinceMs: state.belowBandSinceMs ?? nowMs })
-    return
-  }
-  // Why an observed spell and not elapsed time: a renderer that is simply not being sampled — a
-  // main thread wedged past the sample interval, or a suspend — has not left the band, and must
-  // not have its clock reset. Only samples we actually saw below the band count.
-  const lapsed =
-    state.belowBandSinceMs !== null &&
-    nowMs - state.belowBandSinceMs > RENDERER_HIGHWATER_RECENSUS_MS
+  // Credit each in-band sample with the time since the previous sample. Why accumulate rather than
+  // measure from the first crossing: sawtooth (build, GC, build) is the ordinary shape of renderer
+  // memory, and elapsed time would report a renderer that spent 94% of 10h at 100MB as sustained
+  // pressure. A gap in sampling is still credited, because a wedged renderer has not left the band.
+  const elapsedMs = Math.max(0, nowMs - state.lastSampleAtMs)
+  const inBand = value >= mark * RENDERER_HIGHWATER_RECENSUS_BAND
   emitted.set(mark, {
-    firstCrossedAtMs: lapsed ? nowMs : state.firstCrossedAtMs,
-    lastEmittedAtMs: state.lastEmittedAtMs,
-    lastWithinBandAtMs: nowMs,
-    belowBandSinceMs: null
+    nearMarkMs: inBand ? state.nearMarkMs + elapsedMs : state.nearMarkMs,
+    lastSampleAtMs: nowMs,
+    lastEmittedAtMs: state.lastEmittedAtMs
   })
 }
 
@@ -307,14 +300,9 @@ function stampHighwaterMark(
   mark: number,
   nowMs: number
 ): number {
-  const firstCrossedAtMs = emitted.get(mark)?.firstCrossedAtMs ?? nowMs
-  emitted.set(mark, {
-    firstCrossedAtMs,
-    lastEmittedAtMs: nowMs,
-    lastWithinBandAtMs: nowMs,
-    belowBandSinceMs: null
-  })
-  return Math.round((nowMs - firstCrossedAtMs) / 60_000)
+  const nearMarkMs = emitted.get(mark)?.nearMarkMs ?? 0
+  emitted.set(mark, { nearMarkMs, lastSampleAtMs: nowMs, lastEmittedAtMs: nowMs })
+  return Math.round(nearMarkMs / 60_000)
 }
 
 function isHighwaterCensusDue(

--- a/src/renderer/src/lib/renderer-memory-sampling.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.ts
@@ -1,7 +1,8 @@
 /**
  * Renderer memory sampling for crash reports: the periodic `renderer_memory`
- * crumb, and the one-shot `renderer_memory_highwater` crumbs that carry the
- * subsystem census naming whatever grew.
+ * crumb, and the periodically re-armed
+ * `renderer_memory_highwater` crumbs that carry the subsystem census naming
+ * whatever grew.
  */
 import type { CrashReportDetailValue } from '../../../shared/crash-reporting'
 import type { RendererProcessMemory } from '../../../shared/renderer-process-memory'
@@ -25,6 +26,11 @@ const RENDERER_MEMORY_HIGHWATER_RATIOS = [0.6, 0.8] as const
  * outside every heap counter, so footprint is the only mark that sees them.
  */
 const RENDERER_PRIVATE_HIGHWATER_MB = [600, 1000] as const
+// Why re-arm on a timer, not on a dip below the mark: fb476b1c crossed 600MB
+// once, plateaued 21h and died at 577MB, so a dip-armed rearm ships that same
+// stale census. 15min = 1 census per 15 samples, and the store keys retained
+// highwater crumbs by mark, so a refresh replaces the stale one.
+const RENDERER_HIGHWATER_RECENSUS_MS = 15 * 60_000
 
 export type RendererSurface = 'main' | 'dashboard-popout'
 
@@ -41,8 +47,9 @@ type HeapMetrics = BrowserPerformanceMemory & {
   exact: boolean
 }
 
-const emittedHighwaterRatios = new Set<number>()
-const emittedPrivateHighwaterMarks = new Set<number>()
+/** Mark -> monotonic time it last emitted a census. */
+const emittedHighwaterRatios = new Map<number, number>()
+const emittedPrivateHighwaterMarks = new Map<number, number>()
 let lastProcessFootprint: RendererProcessMemory | null = null
 let processFootprintReadGeneration = 0
 let processFootprintReadInFlight = false
@@ -154,15 +161,16 @@ function recordRendererMemoryHighwater(
   const used = memory.usedJSHeapSize
   const limit = memory.jsHeapSizeLimit
   // Why: NaN would satisfy `ratio < threshold` for nothing, emitting both
-  // levels spuriously and disarming the one-shot for the session.
+  // levels spuriously and disarming both marks.
   const ratio =
     isFiniteHeapBytes(used) && isFiniteHeapBytes(limit) && limit > 0 ? used / limit : null
   const privateMB =
     footprint === null ? null : (toMegabytes(footprint.privateKB * BYTES_PER_KILOBYTE) ?? null)
+  const nowMs = performance.now()
   let crossedThreshold = false
   if (ratio !== null) {
     for (const threshold of RENDERER_MEMORY_HIGHWATER_RATIOS) {
-      if (ratio >= threshold && !emittedHighwaterRatios.has(threshold)) {
+      if (ratio >= threshold && isHighwaterMarkArmed(emittedHighwaterRatios, threshold, nowMs)) {
         crossedThreshold = true
         break
       }
@@ -170,7 +178,7 @@ function recordRendererMemoryHighwater(
   }
   if (privateMB !== null) {
     for (const mark of RENDERER_PRIVATE_HIGHWATER_MB) {
-      if (privateMB >= mark && !emittedPrivateHighwaterMarks.has(mark)) {
+      if (privateMB >= mark && isHighwaterMarkArmed(emittedPrivateHighwaterMarks, mark, nowMs)) {
         crossedThreshold = true
         break
       }
@@ -197,10 +205,10 @@ function recordRendererMemoryHighwater(
   })
   if (ratio !== null) {
     for (const threshold of RENDERER_MEMORY_HIGHWATER_RATIOS) {
-      if (ratio < threshold || emittedHighwaterRatios.has(threshold)) {
+      if (ratio < threshold || !isHighwaterMarkArmed(emittedHighwaterRatios, threshold, nowMs)) {
         continue
       }
-      emittedHighwaterRatios.add(threshold)
+      emittedHighwaterRatios.set(threshold, nowMs)
       recordRendererCrashBreadcrumb('renderer_memory_highwater', {
         ...profile,
         thresholdPct: Math.round(threshold * 100)
@@ -209,16 +217,22 @@ function recordRendererMemoryHighwater(
   }
   if (privateMB !== null) {
     for (const mark of RENDERER_PRIVATE_HIGHWATER_MB) {
-      if (privateMB < mark || emittedPrivateHighwaterMarks.has(mark)) {
+      if (privateMB < mark || !isHighwaterMarkArmed(emittedPrivateHighwaterMarks, mark, nowMs)) {
         continue
       }
-      emittedPrivateHighwaterMarks.add(mark)
+      emittedPrivateHighwaterMarks.set(mark, nowMs)
       recordRendererCrashBreadcrumb('renderer_memory_highwater', {
         ...profile,
         thresholdPrivateMB: mark
       })
     }
   }
+}
+
+/** Why monotonic: a wall-clock correction must not stretch or collapse the window. */
+function isHighwaterMarkArmed(emitted: Map<number, number>, mark: number, nowMs: number): boolean {
+  const lastEmittedAtMs = emitted.get(mark)
+  return lastEmittedAtMs === undefined || nowMs - lastEmittedAtMs >= RENDERER_HIGHWATER_RECENSUS_MS
 }
 
 function isFiniteHeapBytes(value: number | undefined): value is number {

--- a/src/renderer/src/lib/renderer-memory-sampling.ts
+++ b/src/renderer/src/lib/renderer-memory-sampling.ts
@@ -53,7 +53,11 @@ type HeapMetrics = BrowserPerformanceMemory & {
 
 /** Mark -> monotonic time it last emitted a census. */
 /** First crossing is kept separately: a refresh replaces the crumb's own `createdAt`. */
-type HighwaterMarkState = { firstCrossedAtMs: number; lastEmittedAtMs: number }
+type HighwaterMarkState = {
+  firstCrossedAtMs: number
+  lastEmittedAtMs: number
+  lastWithinBandAtMs: number
+}
 const emittedHighwaterRatios = new Map<number, HighwaterMarkState>()
 const emittedPrivateHighwaterMarks = new Map<number, HighwaterMarkState>()
 let lastProcessFootprint: RendererProcessMemory | null = null
@@ -173,6 +177,16 @@ function recordRendererMemoryHighwater(
   const privateMB =
     footprint === null ? null : (toMegabytes(footprint.privateKB * BYTES_PER_KILOBYTE) ?? null)
   const nowMs = performance.now()
+  if (ratio !== null) {
+    for (const threshold of RENDERER_MEMORY_HIGHWATER_RATIOS) {
+      noteHighwaterBandResidency(emittedHighwaterRatios, threshold, nowMs, ratio)
+    }
+  }
+  if (privateMB !== null) {
+    for (const mark of RENDERER_PRIVATE_HIGHWATER_MB) {
+      noteHighwaterBandResidency(emittedPrivateHighwaterMarks, mark, nowMs, privateMB)
+    }
+  }
   let crossedThreshold = false
   if (ratio !== null) {
     for (const threshold of RENDERER_MEMORY_HIGHWATER_RATIOS) {
@@ -247,6 +261,29 @@ function recordRendererMemoryHighwater(
  * stretch or collapse the window.
  */
 /**
+ * Tracks whether the mark is still occupied. Why re-anchor after a gap: the census reports how
+ * long the renderer has been heavy, and two spikes hours apart are not sustained pressure —
+ * sawtooth (build, GC, build) is the ordinary shape of renderer memory.
+ */
+function noteHighwaterBandResidency(
+  emitted: Map<number, HighwaterMarkState>,
+  mark: number,
+  nowMs: number,
+  value: number
+): void {
+  const state = emitted.get(mark)
+  if (state === undefined || value < mark * RENDERER_HIGHWATER_RECENSUS_BAND) {
+    return
+  }
+  const lapsed = nowMs - state.lastWithinBandAtMs > RENDERER_HIGHWATER_RECENSUS_MS
+  emitted.set(mark, {
+    firstCrossedAtMs: lapsed ? nowMs : state.firstCrossedAtMs,
+    lastEmittedAtMs: state.lastEmittedAtMs,
+    lastWithinBandAtMs: nowMs
+  })
+}
+
+/**
  * Records this emission and returns minutes since the mark was first crossed. Why carry it in the
  * payload: a refresh replaces the retained crumb's `createdAt`, so without this "how long has the
  * renderer been over the mark" — the axis that identified the stale census — becomes unrecoverable.
@@ -257,7 +294,7 @@ function stampHighwaterMark(
   nowMs: number
 ): number {
   const firstCrossedAtMs = emitted.get(mark)?.firstCrossedAtMs ?? nowMs
-  emitted.set(mark, { firstCrossedAtMs, lastEmittedAtMs: nowMs })
+  emitted.set(mark, { firstCrossedAtMs, lastEmittedAtMs: nowMs, lastWithinBandAtMs: nowMs })
   return Math.round((nowMs - firstCrossedAtMs) / 60_000)
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​269 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​269 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​111 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​97 |

<!-- /orca-pr-loc -->

## What

The renderer memory **highwater census** — the only breadcrumb carrying `domNodes`, `terminalElements` and `collectRendererMemoryProfileCounts()` (the leak-naming fields) — was emitted **at most once per threshold mark for the entire lifetime of the renderer process**. Module-level `Set`s recorded which marks had fired; only `resetRendererMemorySampling` cleared them.

So the census fired exactly once, early, on the way up — i.e. when it is least useful.

## Field evidence

Crash reports `fb476b1c` and `d4d32680` (fpadilla-fadua, v1.4.198, Linux): a renderer crossed the 600 MB mark at **2026-09-08T21:15:32**, emitted its one census, then ran **21 more hours** and died at 577 MB — never re-crossing 600, so no further census could ever fire.

Both reports therefore carry a byte-identical census describing a workload 21 hours older than the crash:

| | census (21h stale) | at crash |
|---|---|---|
| `browserWebviews` | 0 | 1 |
| `blinkAllocatedMB` | 215 | 21 |
| `domNodes` | 2376 | *unknown — never re-censused* |

This is **why those two crashes could not be diagnosed**. The periodic 60 s `renderer_memory` crumb already carries `privateMB`/`outsideHeapMB`/`blinkAllocatedMB`; the census's unique contribution is exactly the part that stayed 21 h stale.

## Fix evidence

Failing-first on the committed tests:

```
BEFORE
  × re-censuses a renderer that crossed a mark and then settled back below it
    AssertionError: expected 1 to be greater than 1
  × keeps the peak census when a renderer releases its memory
    AssertionError: expected [ …(50) ] to have a length of 2 but got 50
  × discounts a long observed spell below the band
    AssertionError: expected 602 to be less than or equal to 2
  × does not reset the clock when sampling itself stalls
    AssertionError: expected 0 to be greater than 430
  × counts only samples actually seen near the mark, not elapsed time

AFTER
  Test Files 1 passed · Tests 9 passed (9)
```

Suites: `src/renderer/src/lib/` **539 files / 5177 passed**, 1 skipped. `src/main/crash-reporting/` **27 files / 282 passed**. `pnpm tc` clean, `oxlint` clean.

Measured accumulator behaviour (instrumented harness): first crossing **0**; 21 h at 577 MB → **1260** with censuses stepping 0,15,30,…,1260 and zero drift; 120 min → **120**; sawtooth 40×(14 min@100 MB + 1 min@620 MB) → **40** of 602 elapsed; 10 h trough → **2**; 8 h sampler stall while in band → **511**.

## ELI5

When a renderer gets fat, Orca takes one detailed "photo" of what is in memory. It took that photo the first time the renderer crossed 600 MB — and then **never again**, for the rest of that renderer's life. One user's renderer crossed the line, kept running for 21 more hours, and crashed; the only photo in the crash report was 21 hours old and showed a completely different workload. Now Orca retakes the photo every 15 minutes while the renderer is still heavy, and each photo says how long it has been heavy.

## Design decisions

- **Refresh is banded at 90% of the mark, not value-independent.** The retained crumb is one slot per `name:surface:threshold:origin` and is *replaced* on write, so an unconditional refresh destroys the census taken at the peak. Banding keeps the peak evidence for a renderer that released its memory, while still refreshing one that stays heavy. The field renderer at 577 MB under a 600 MB mark refreshes (577 ≥ 540).
- **Banded on the mark, not on the renderer's own peak.** Peak-banding was simulated and **re-breaks the field case** (577 < 658×0.9 = 592.2), shipping the original stale census.
- **`nearMarkMinutes` is accumulated, not derived from a start time.** It credits each in-band *sample* with the time since the previous sample. Deriving it from a first-crossing timestamp reported a sawtooth that spent 94% of 10 h at 100 MB as 586 minutes of sustained pressure.
- **`crash-breadcrumb-store.ts` now uses plain `set` instead of delete-then-set.** Re-inserting moved the key to the back, making eviction LRU-by-write — and the frozen peak slot is the only one that never refreshes, so it became oldest and was evicted first, silently defeating the band fix.

## Trade-offs and known limits

- **Partial fix, stated plainly.** A renderer that crosses 600 MB then settles **more than 10% below** it (say 500 MB) still never refreshes and ships the original stale census. It is **never worse than today**. This is not an oversight: the same rule cannot both refresh a collapsed renderer and preserve its peak.
- **A sampling gap is credited to in-band residency.** A 3-day suspend resuming in band reports ~4341 minutes. This is deliberate and judged **not cappable**: from inside the renderer a suspend is indistinguishable from a wedged main thread, and capping would break the guarantee that a wedged (i.e. sickest) renderer keeps its clock. The renderer genuinely held the memory throughout.
- **Cost:** the census walks the document (`getElementsByTagName('*')`, `querySelectorAll('.xterm')`). Measured in real Blink at **1.07 ms @ 120k nodes, 4.55 ms @ 512k nodes**, built once per sample regardless of how many marks are due — worst case ~4 builds / 15 min ≈ 0.002% duty cycle.
- **Retained slots:** refresh overwrites in place and never grows the map, so no eviction in the normal 8-slot case.
- **Pre-existing, deliberately not fixed:** `MAX_RETAINED_BREADCRUMBS = 8`'s comment ("two ladders, two marks, both surfaces") ignores that the key includes `origin` (`renderer:<webContentsId>`), so dock re-activation and popouts mint new keys and can over-subscribe the cap. Separate change.

## Provenance

**Neither crash was caused by Orca** — both were an external `oom_score`-driven kill under host memory pressure. This is the diagnostics defect that made them undiagnosable, shipped on its own merits.

## Adversarial review — 7 loops

Every loop found something real; six found functional defects, including three consecutive ones in my own corrections.

| Loop | Finding |
|---|---|
| 1 | The first fix kept the gate `value >= mark`, so a renderer dying *below* the mark (577 < 600) never re-emitted — **it did not fix its own bug**. |
| 2 | Making the refresh value-independent **destroyed the peak census**: a peak-then-release renderer shipped `privateMB: 50` under a `thresholdPrivateMB: 600` label, peak evidence unrecoverable. |
| 3 | Confirmed band-on-mark correct and peak-banding wrong; found the refresh **replaced the crumb's `createdAt`**, losing the duration axis entirely. |
| 4 | (a) the duration field never re-anchored — spike → 10 h@100 MB → spike reported **602 minutes** "above the mark"; (b) delete-then-set made retained eviction **LRU-by-write**, evicting the frozen peak census first and defeating the loop-2 fix. |
| 5 | The field measured *band* residency while being named `aboveMarkMinutes` (field case reported 1260 for 1 real minute above the mark) → renamed; a **sampling gap reset the clock** on a continuously heavy renderer. |
| 6 | Re-anchoring only caught troughs **longer** than 15 min; a 14-min trough still over-counted **14.7×** (586 of 602 min). Replaced the whole anchor+re-anchor scheme with incremental accumulation. Also found dead state (`lastWithinBandAtMs` written twice, read nowhere). |
| 7 | **No functional defect.** Doc blocks left behind by the loop-6 rewrite, one asserting the opposite of the code 15 lines below it. Fixed. |

Loop 5 also cleared the riskiest part — `retainedBreadcrumbKey` returns non-null only for `renderer_memory_highwater`, so the store change has nil blast radius. Loop 7 verified end-to-end that `nearMarkMinutes` (including the value `0`) survives both sanitizers and reaches the rendered crash report text.
