### PR TITLE
fix(relay): stop the relay reopening a broker after quit

### DIFF
--- a/src/main/runtime/relay/desktop-relay-service.ts
+++ b/src/main/runtime/relay/desktop-relay-service.ts
@@ -117,8 +117,10 @@ export class DesktopRelayService {
     this.refreshDemand()
   }
 
-  // The re-armable fence: sign-out and relaunch, which want the next auth
-  // mutation to bring Relay back. Quit wants stop() instead — it is terminal.
+  // The re-armable fence, by design: sign-out and relaunch call this
+  // (main-window-core-services.ts onBeforeOrcaProfileSignOut / onBeforeRelaunch)
+  // and want the next authMutated to bring Relay back. Quit deliberately does
+  // NOT use this — it calls stop(), which is terminal. Keep the two apart.
   fenceAndCloseNow(hostCloseReason?: RelayHostCloseReason): void {
     // Why a latch rather than just clearing the timers: clearing only covered
     // the liveness tick, and everything else outliving the fence lands in
@@ -227,7 +229,9 @@ export class DesktopRelayService {
     this.refreshDemand({ skipLinger: true })
   }
 
-  // Terminal: no door re-arms this, which is what quit needs.
+  // Terminal: no door re-arms this. Quit calls it (main-process-quit.ts
+  // before-quit). The re-armable counterpart is fenceAndCloseNow, which quit
+  // must not use — a settling mint or an invite expiry re-arms that one.
   stop(): void {
     this.stopped = true
     this.clearTimers()

--- a/src/main/runtime/relay/desktop-relay-service.ts
+++ b/src/main/runtime/relay/desktop-relay-service.ts
@@ -12,11 +12,8 @@ import { RelayAuthCoordinator } from './relay-auth-coordinator'
 import { relayOfflineReasonMintFailureCode } from './relay-offline-reason'
 import { RelaySessionBroker, type RelayBrokerStatus } from './relay-session-broker'
 import type { PairingRelay } from '../../../shared/mobile-relay-pairing-offer'
-import type {
-  RelayRevokeOutbox,
-  RelayDeviceBinding,
-  RelayRevokeOutboxItem
-} from './relay-revoke-outbox'
+import type { RelayDeviceBinding, RelayRevokeOutboxItem } from './relay-revoke-outbox'
+import { RelayRevokeOutboxFlusher } from './relay-revoke-outbox-flush'
 import { deriveRelayHostId } from './relay-http-client'
 import { RelayDemandLedger } from './relay-demand-ledger'
 import { createRelayRegionPreferenceReader } from './relay-region-preference'
@@ -45,7 +42,7 @@ const RELAY_LIVENESS_INTERVAL_MS = 5 * 60_000
 
 export class DesktopRelayService {
   private readonly coordinator: RelayAuthCoordinator
-  private readonly revokeOutbox: RelayRevokeOutbox
+  private readonly revokeFlusher: RelayRevokeOutboxFlusher
   private readonly runtimeRpc: OrcaRuntimeRpcServer
   private readonly demandLedger: RelayDemandLedger
   private readonly hostMobilePairingConnectionMode?: () => MobilePairingConnectionMode
@@ -60,11 +57,15 @@ export class DesktopRelayService {
       throw new Error('mobile_runtime_not_ready')
     }
     this.runtimeRpc = options.runtimeRpc
-    this.revokeOutbox = options.runtimeRpc.getRelayRevokeOutbox()
+    const revokeOutbox = options.runtimeRpc.getRelayRevokeOutbox()
+    this.revokeFlusher = new RelayRevokeOutboxFlusher({
+      outbox: revokeOutbox,
+      onDrained: () => this.refreshDemand()
+    })
     this.hostMobilePairingConnectionMode = options.hostMobilePairingConnectionMode
     this.demandLedger = new RelayDemandLedger({
       deviceRegistry: options.runtimeRpc.getDeviceRegistry()!,
-      revokeOutbox: this.revokeOutbox,
+      revokeOutbox,
       relayHostId: deriveRelayHostId(keypair.publicKey),
       isRelayAllowedForDevice: (deviceId) => this.isRelayAllowedForDevice(deviceId)
     })
@@ -89,7 +90,7 @@ export class DesktopRelayService {
           onAssignedCellActive: regionPreference.noteAssignedCell,
           onStatus: options.onStatus
         })
-        void this.flushRevokeOutbox(broker)
+        void this.revokeFlusher.flushAll(broker)
         return broker
       },
       onStatus: options.onStatus
@@ -148,7 +149,7 @@ export class DesktopRelayService {
       broker.hostId === item.relayHostId &&
       broker.ownerIdentityKey === item.ownerIdentityKey
     ) {
-      void this.flushRevoke(broker, item)
+      void this.revokeFlusher.flushItem(broker, item)
     }
   }
 
@@ -233,12 +234,6 @@ export class DesktopRelayService {
     this.coordinator.stop()
   }
 
-  private async flushRevokeOutbox(broker: RelaySessionBroker): Promise<void> {
-    for (const item of this.revokeOutbox.pendingFor(broker.ownerIdentityKey, broker.hostId)) {
-      await this.flushRevoke(broker, item)
-    }
-  }
-
   private requireMobileDevice(deviceId: string): void {
     if (this.runtimeRpc.getDeviceRegistry()?.getDevice(deviceId)?.scope !== 'mobile') {
       throw new Error('mobile_device_not_found')
@@ -254,20 +249,6 @@ export class DesktopRelayService {
       context.transport.relayHostId !== broker.hostId
     ) {
       throw new Error('stale_relay_connection')
-    }
-  }
-
-  private async flushRevoke(
-    broker: RelaySessionBroker,
-    item: RelayRevokeOutboxItem
-  ): Promise<void> {
-    try {
-      await broker.revokeDevice(item.relayDeviceId, item.reqId)
-      this.revokeOutbox.remove(item.reqId)
-      this.refreshDemand()
-    } catch {
-      // Why: the durable item is the source of truth; reconnecting the same
-      // account/control retries this stable reqId without delaying local revoke.
     }
   }
 

--- a/src/main/runtime/relay/desktop-relay-service.ts
+++ b/src/main/runtime/relay/desktop-relay-service.ts
@@ -49,6 +49,8 @@ export class DesktopRelayService {
   private demandExpiryTimer: ReturnType<typeof setTimeout> | null = null
   private livenessTimer: ReturnType<typeof setInterval> | null = null
   private stopped = false
+  // Cleared only by an explicit re-arm (start/authMutated); see fenceAndCloseNow.
+  private fenced = false
 
   constructor(options: DesktopRelayServiceOptions) {
     const keypair = options.runtimeRpc.getE2EEKeypair()
@@ -60,6 +62,7 @@ export class DesktopRelayService {
     const revokeOutbox = options.runtimeRpc.getRelayRevokeOutbox()
     this.revokeFlusher = new RelayRevokeOutboxFlusher({
       outbox: revokeOutbox,
+      isHalted: () => this.stopped || this.fenced,
       onDrained: () => this.refreshDemand()
     })
     this.hostMobilePairingConnectionMode = options.hostMobilePairingConnectionMode
@@ -98,28 +101,31 @@ export class DesktopRelayService {
   }
 
   start(): void {
+    this.fenced = false
     this.refreshDemand()
   }
 
   // Safe to call from any wake signal (power resume, network change).
   ensureLive(): void {
-    if (!this.stopped) {
+    if (!this.stopped && !this.fenced) {
       this.coordinator.ensureLive()
     }
   }
 
   authMutated(): void {
+    this.fenced = false
     this.refreshDemand()
   }
 
+  // The re-armable fence: sign-out and relaunch, which want the next auth
+  // mutation to bring Relay back. Quit wants stop() instead — it is terminal.
   fenceAndCloseNow(hostCloseReason?: RelayHostCloseReason): void {
-    // Why: a fence must be hard — a surviving liveness tick could catch the
-    // window between the pre-sign-out fence and the profile wipe and briefly
-    // resurrect a broker. The next auth mutation re-arms via refreshDemand.
-    if (this.livenessTimer) {
-      clearInterval(this.livenessTimer)
-      this.livenessTimer = null
-    }
+    // Why a latch rather than just clearing the timers: clearing only covered
+    // the liveness tick, and everything else outliving the fence lands in
+    // refreshDemand and re-arms it — a settling mint's finally, a pending
+    // invite-expiry wake, a power-resume ensureLive.
+    this.fenced = true
+    this.clearTimers()
     this.coordinator.fenceAndCloseNow(hostCloseReason)
   }
 
@@ -221,8 +227,14 @@ export class DesktopRelayService {
     this.refreshDemand({ skipLinger: true })
   }
 
+  // Terminal: no door re-arms this, which is what quit needs.
   stop(): void {
     this.stopped = true
+    this.clearTimers()
+    this.coordinator.stop()
+  }
+
+  private clearTimers(): void {
     if (this.demandExpiryTimer) {
       clearTimeout(this.demandExpiryTimer)
       this.demandExpiryTimer = null
@@ -231,7 +243,6 @@ export class DesktopRelayService {
       clearInterval(this.livenessTimer)
       this.livenessTimer = null
     }
-    this.coordinator.stop()
   }
 
   private requireMobileDevice(deviceId: string): void {
@@ -308,7 +319,7 @@ export class DesktopRelayService {
   }
 
   private refreshDemand(options?: { skipLinger?: boolean }): void {
-    if (this.stopped) {
+    if (this.stopped || this.fenced) {
       return
     }
     if (!this.livenessTimer) {

--- a/src/main/runtime/relay/relay-auth-context.ts
+++ b/src/main/runtime/relay/relay-auth-context.ts
@@ -24,8 +24,15 @@ export async function readRelayAuthContext(
   // Why: refresh and org-selection can rewrite cloud linkage while the request
   // is in flight; identity must come from the post-refresh profile state.
   const refreshed = ensureActiveOrcaProfile(userDataPath)
+  // Why throw rather than return null, same argument as the unreadable session above:
+  // a profile switch landing inside this read is not a sign-out, and null spends the
+  // terminal SIGNED_OUT — latched by every paired phone, arming no retry — on a race
+  // the switch's own auth mutation re-reads moments later.
+  if (refreshed.profile.id !== active.profile.id) {
+    throw new Error('orca_profile_switched_during_read')
+  }
   const cloud = refreshed.profile.cloud
-  if (!cloud || refreshed.profile.id !== active.profile.id) {
+  if (!cloud) {
     return null
   }
   return {

--- a/src/main/runtime/relay/relay-lifecycle-auth-context-identity-race.test.ts
+++ b/src/main/runtime/relay/relay-lifecycle-auth-context-identity-race.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RELAY_HOST_CLOSE_REASON } from '../../../shared/relay-host-close-reason'
+
+// Same taxonomy question 8972d744 answered for the session file, asked of the
+// other null exit: readRelayAuthContext re-reads the profile after the refresh,
+// and a profile switch landing in that window is not a sign-out.
+const fakes = vi.hoisted(() => ({
+  ensureActiveOrcaProfile: vi.fn(),
+  readFreshOrcaCloudSession: vi.fn()
+}))
+
+vi.mock('../../orca-profiles/profile-index-store', () => ({
+  ensureActiveOrcaProfile: fakes.ensureActiveOrcaProfile
+}))
+vi.mock('../../orca-profiles/profile-cloud-session-refresh', () => ({
+  readFreshOrcaCloudSession: fakes.readFreshOrcaCloudSession
+}))
+
+import { readRelayAuthContext } from './relay-auth-context'
+import { RelayAuthCoordinator } from './relay-auth-coordinator'
+
+const authConfig = {} as never
+
+function profile(id: string, cloud: object | null) {
+  return { profile: { id, ...(cloud ? { cloud } : {}) } }
+}
+
+const signedIn = { userId: 'u1', cloudProfileId: 'cp1', activeOrgId: 'org-1' }
+
+function foundSession() {
+  return {
+    status: 'found',
+    session: { accessToken: 'access-1', capabilities: { flags: { 'relay.use': true } } }
+  }
+}
+
+describe('readRelayAuthContext profile-switch race', () => {
+  it('refuses to call a mid-read profile switch a sign-out', async () => {
+    // ensureActiveOrcaProfile is called twice — once before the refresh and once
+    // after, because refresh and org selection can rewrite cloud linkage. A
+    // switch between them means "re-read", not "the cloud session is gone".
+    fakes.ensureActiveOrcaProfile
+      .mockReturnValueOnce(profile('profile-1', signedIn))
+      .mockReturnValueOnce(profile('profile-2', signedIn))
+    fakes.readFreshOrcaCloudSession.mockResolvedValue(foundSession())
+
+    await expect(readRelayAuthContext(authConfig, '/tmp/x')).rejects.toThrow(
+      'orca_profile_switched_during_read'
+    )
+  })
+
+  it('classifies the switch as auth_unavailable, never signed_out', async () => {
+    fakes.ensureActiveOrcaProfile
+      .mockReturnValueOnce(profile('profile-1', signedIn))
+      .mockReturnValueOnce(profile('profile-2', signedIn))
+    fakes.readFreshOrcaCloudSession.mockResolvedValue(foundSession())
+    const broker = { closeNow: vi.fn() }
+    const coordinator = new RelayAuthCoordinator({
+      readContext: () => readRelayAuthContext(authConfig, '/tmp/x'),
+      openBroker: async () => broker,
+      onStatus: vi.fn()
+    })
+    coordinator.reconcile()
+
+    const result = await coordinator.waitForLiveBrokerResult(0)
+    expect(result).toEqual({ broker: null, offlineReason: 'auth_unavailable' })
+    // SIGNED_OUT is terminal on the wire — the phone latches it and arms no retry.
+    expect(broker.closeNow).not.toHaveBeenCalledWith(RELAY_HOST_CLOSE_REASON.SIGNED_OUT)
+  })
+
+  it('still reports a profile that genuinely has no cloud linkage as gone', async () => {
+    fakes.ensureActiveOrcaProfile
+      .mockReturnValueOnce(profile('profile-1', signedIn))
+      .mockReturnValueOnce(profile('profile-1', null))
+    fakes.readFreshOrcaCloudSession.mockResolvedValue(foundSession())
+
+    await expect(readRelayAuthContext(authConfig, '/tmp/x')).resolves.toBeNull()
+  })
+
+  it('returns the post-refresh identity when the profile held still', async () => {
+    fakes.ensureActiveOrcaProfile
+      .mockReturnValueOnce(profile('profile-1', signedIn))
+      .mockReturnValueOnce(profile('profile-1', { ...signedIn, activeOrgId: 'org-2' }))
+    fakes.readFreshOrcaCloudSession.mockResolvedValue(foundSession())
+
+    await expect(readRelayAuthContext(authConfig, '/tmp/x')).resolves.toEqual({
+      identity: { userId: 'u1', profileId: 'cp1', organizationId: 'org-2' },
+      accessToken: 'access-1',
+      relayEntitled: true
+    })
+  })
+})

--- a/src/main/runtime/relay/relay-lifecycle-control-teardown.test.ts
+++ b/src/main/runtime/relay/relay-lifecycle-control-teardown.test.ts
@@ -1,0 +1,144 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import nacl from 'tweetnacl'
+import type WebSocket from 'ws'
+import { RelayControlClient } from './relay-control-client'
+
+// Teardown that runs before — or twice after — the first successful connect.
+// Every field closeNow touches has to be initialised at 'idle', and a second
+// pass must not re-fire onClose or leave the connect deadline armed.
+class FakeSocket extends EventEmitter {
+  readonly OPEN = 1
+  readyState = 0
+  readonly sent: string[] = []
+  readonly terminate = vi.fn()
+  readonly close = vi.fn()
+
+  send(payload: string): void {
+    this.sent.push(payload)
+  }
+
+  open(): void {
+    this.readyState = this.OPEN
+    this.emit('open')
+  }
+
+  deliver(message: object): void {
+    this.emit('message', Buffer.from(JSON.stringify(message)), false)
+  }
+}
+
+const keys = nacl.box.keyPair()
+
+function client(onClose = vi.fn()): { control: RelayControlClient; sockets: FakeSocket[] } {
+  const sockets: FakeSocket[] = []
+  const control = new RelayControlClient({
+    cellUrl: 'http://127.0.0.1:1/',
+    relayJwt: 'scoped-token',
+    relayHostId: 'AbCdEf0123_-xyZ9',
+    assignmentEpoch: 1,
+    identity: { userId: 'user-1', profileId: 'profile-1', organizationId: 'org-1' },
+    keypair: { ...keys, publicKeyB64: Buffer.from(keys.publicKey).toString('base64') },
+    appVersion: '1.4.188',
+    onConnectionOpen: vi.fn(),
+    onDrain: vi.fn(),
+    onClose,
+    createSocket: () => {
+      const socket = new FakeSocket()
+      sockets.push(socket)
+      return socket as unknown as WebSocket
+    }
+  })
+  return { control, sockets }
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe('RelayControlClient teardown before the first connect', () => {
+  it('closes cleanly at idle, when no socket or watchdog was ever created', () => {
+    const onClose = vi.fn()
+    const { control, sockets } = client(onClose)
+
+    expect(control.isLive()).toBe(false)
+    expect(() => control.closeNow()).not.toThrow()
+
+    expect(sockets).toHaveLength(0)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(control.pendingRequestCount).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('refuses a connect after teardown rather than reopening into a closed client', async () => {
+    const { control, sockets } = client()
+    control.closeNow()
+
+    await expect(control.connect()).rejects.toThrow('relay_control_already_started')
+    expect(sockets).toHaveLength(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('rejects a control request issued before connect without stranding a deadline', async () => {
+    const { control } = client()
+
+    await expect(control.revokeDevice('device-1', 'req-1')).rejects.toThrow(
+      'relay_control_not_active'
+    )
+    expect(control.pendingRequestCount).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('RelayControlClient teardown twice', () => {
+  it('settles the connect once and disarms the deadline on the first close', async () => {
+    const onClose = vi.fn()
+    const { control, sockets } = client(onClose)
+    const connecting = control.connect()
+    expect(vi.getTimerCount()).toBe(1)
+
+    control.closeNow()
+    await expect(connecting).rejects.toThrow('relay_control_closed')
+    expect(vi.getTimerCount()).toBe(0)
+    expect(sockets[0]!.terminate).toHaveBeenCalledTimes(1)
+
+    control.closeNow()
+    // The socket handle is dropped on the first pass, so the second is inert.
+    expect(sockets[0]!.terminate).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('leaves nothing armed when an active control is closed twice', async () => {
+    const { control, sockets } = client()
+    const connecting = control.connect()
+    const socket = sockets[0]!
+    socket.open()
+    socket.deliver({
+      type: 'host-hello-ack',
+      v: 1,
+      generation: 1,
+      controlResumeSecret: 'A'.repeat(43),
+      leaseExpiresAt: Date.now() + 60_000,
+      activeConnIds: [],
+      pendingConns: []
+    })
+    await connecting
+    expect(control.isLive()).toBe(true)
+    // Only the silence watchdog: activation already disarmed the connect deadline.
+    expect(vi.getTimerCount()).toBe(1)
+
+    const pending = control.createInvite('device-1', 'req-1')
+    const rejection = expect(pending).rejects.toThrow('relay_control_closed')
+    expect(control.pendingRequestCount).toBe(1)
+
+    control.closeNow()
+    await rejection
+    expect(control.isLive()).toBe(false)
+    expect(control.pendingRequestCount).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+
+    control.closeNow()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(socket.terminate).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/runtime/relay/relay-lifecycle-quit-fence.test.ts
+++ b/src/main/runtime/relay/relay-lifecycle-quit-fence.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OrcaCloudAuthConfig } from '../../orca-profiles/profile-cloud-auth-config'
+import type { OrcaRuntimeRpcServer } from '../runtime-rpc'
+
+// fenceAndCloseNow is what app quit and pre-sign-out both call (stop() is never
+// reached in production). Its own comment says the fence must be hard, yet every
+// path that survives it lands in refreshDemand, which re-arms the interval the
+// fence just cleared and starts a fresh reconcile.
+const fakes = vi.hoisted(() => ({
+  readRelayAuthContext: vi.fn(),
+  connect: vi.fn(),
+  brokers: [] as { closeNow: ReturnType<typeof vi.fn> }[]
+}))
+
+vi.mock('./relay-auth-context', () => ({ readRelayAuthContext: fakes.readRelayAuthContext }))
+
+vi.mock('./relay-session-broker', () => {
+  class RelaySessionBroker {
+    readonly hostId: string = hostId
+    readonly ownerIdentityKey = 'user-1\0profile-1\0org-1'
+    readonly endpoint = { v: 1 as const, relayHostId: hostId }
+    readonly closeNow = vi.fn()
+    createPairingRelay = vi.fn(async (relayDeviceId: string) => ({
+      v: 1,
+      relayHostId: this.hostId,
+      relayDeviceId,
+      inviteExpiresAt: 0
+    }))
+    isLive(): boolean {
+      return this.closeNow.mock.calls.length === 0
+    }
+    static connect = fakes.connect
+  }
+  return { RelaySessionBroker }
+})
+
+import { DesktopRelayService } from './desktop-relay-service'
+import { deriveRelayHostId } from './relay-http-client'
+import { RelaySessionBroker } from './relay-session-broker'
+
+const publicKey = new Uint8Array(32).fill(7)
+const hostId = deriveRelayHostId(publicKey)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+type FakeBroker = {
+  readonly hostId: string
+  readonly closeNow: ReturnType<typeof vi.fn>
+  createPairingRelay: (relayDeviceId: string) => Promise<unknown>
+}
+
+function newBroker(): FakeBroker {
+  const broker = new (RelaySessionBroker as unknown as new () => FakeBroker)()
+  fakes.brokers.push(broker)
+  return broker
+}
+
+// A paired phone: standing demand, plus the pending-expiry wake timer
+// refreshDemand arms while an invite is still unexpired.
+function pairedDevice(inviteExpiresAt?: number) {
+  return {
+    deviceId: 'device-1',
+    scope: 'mobile' as const,
+    relayBinding: {
+      relayHostId: hostId,
+      relayDeviceId: 'device-1',
+      ownerIdentityKey: 'user-1\0profile-1\0org-1',
+      ...(inviteExpiresAt === undefined ? {} : { inviteExpiresAt })
+    }
+  }
+}
+
+function service(device: ReturnType<typeof pairedDevice>): DesktopRelayService {
+  fakes.readRelayAuthContext.mockResolvedValue({
+    identity: { userId: 'user-1', profileId: 'profile-1', organizationId: 'org-1' },
+    accessToken: 'access-1',
+    relayEntitled: true
+  })
+  const runtimeRpc = {
+    getE2EEKeypair: () => ({
+      publicKey,
+      secretKey: new Uint8Array(32).fill(9),
+      publicKeyB64: 'x'
+    }),
+    getMobileSocketWiring: () => ({ attachTransport: () => () => {} }),
+    getRelayRevokeOutbox: () => ({ pendingFor: () => [], remove: vi.fn() }),
+    getDeviceRegistry: () => ({
+      listDevices: () => [device],
+      getDevice: () => device,
+      getMobilePairingConnectionMode: () => 'automatic'
+    })
+  } as unknown as OrcaRuntimeRpcServer
+  return new DesktopRelayService({
+    authConfig: {
+      relayDirectorUrl: 'https://relay.example.test',
+      relayTokenEndpoint: 'https://login.example.test/relay-token'
+    } as OrcaCloudAuthConfig,
+    userDataPath: '/tmp/orca-relay-quit-fence',
+    appVersion: '1.4.188',
+    runtimeRpc,
+    onStatus: () => {}
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  fakes.brokers.length = 0
+  fakes.connect.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('DesktopRelayService quit fence is hard', () => {
+  it('does not let a pending invite-expiry wake resurrect the broker after the fence', async () => {
+    const device = pairedDevice(Date.now() + 60_000)
+    fakes.connect.mockImplementation(async () => newBroker())
+    const relayService = service(device)
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fakes.connect).toHaveBeenCalledTimes(1)
+
+      relayService.fenceAndCloseNow()
+      expect(fakes.brokers[0]!.closeNow).toHaveBeenCalled()
+      // The fence cleared the liveness interval; nothing else may stay armed.
+      expect(vi.getTimerCount()).toBe(0)
+
+      await vi.advanceTimersByTimeAsync(120_000)
+      expect(fakes.connect).toHaveBeenCalledTimes(1)
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('does not let a mint settling after the fence re-arm the liveness tick', async () => {
+    const device = pairedDevice()
+    const broker = newBroker()
+    const mintCall = deferred<void>()
+    broker.createPairingRelay = vi.fn(async () => {
+      await mintCall.promise
+      throw new Error('relay_control_closed')
+    })
+    fakes.connect.mockResolvedValue(broker)
+    const relayService = service(device)
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      const mint = relayService.createPairingRelay('device-1')
+      const rejection = expect(mint).rejects.toThrow()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(broker.createPairingRelay).toHaveBeenCalled()
+
+      relayService.fenceAndCloseNow()
+      expect(vi.getTimerCount()).toBe(0)
+
+      mintCall.resolve()
+      await rejection
+      await vi.advanceTimersByTimeAsync(0)
+
+      // The settling mint's finally must not bring the fenced service back.
+      expect(vi.getTimerCount()).toBe(0)
+      expect(fakes.connect).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(10 * 60_000)
+      expect(fakes.connect).toHaveBeenCalledTimes(1)
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('does not let a power-resume ensureLive resurrect the broker after the fence', async () => {
+    const device = pairedDevice()
+    fakes.connect.mockImplementation(async () => newBroker())
+    const relayService = service(device)
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fakes.connect).toHaveBeenCalledTimes(1)
+
+      relayService.fenceAndCloseNow()
+      relayService.ensureLive()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fakes.connect).toHaveBeenCalledTimes(1)
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('still re-arms on the next auth mutation, which is the documented recovery', async () => {
+    const device = pairedDevice()
+    fakes.connect.mockImplementation(async () => newBroker())
+    const relayService = service(device)
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      relayService.fenceAndCloseNow()
+
+      relayService.authMutated()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fakes.connect).toHaveBeenCalledTimes(2)
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('re-arms on an explicit start, the other door out of the fence', async () => {
+    const device = pairedDevice()
+    fakes.connect.mockImplementation(async () => newBroker())
+    const relayService = service(device)
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      relayService.fenceAndCloseNow()
+
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fakes.connect).toHaveBeenCalledTimes(2)
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('stays fenced after stop, and a second stop changes nothing', async () => {
+    const device = pairedDevice(Date.now() + 60_000)
+    fakes.connect.mockImplementation(async () => newBroker())
+    const relayService = service(device)
+    relayService.start()
+    await vi.advanceTimersByTimeAsync(0)
+
+    relayService.stop()
+    expect(vi.getTimerCount()).toBe(0)
+    relayService.stop()
+    expect(vi.getTimerCount()).toBe(0)
+
+    // stop() is terminal: unlike a fence, no door re-arms it.
+    relayService.authMutated()
+    relayService.start()
+    relayService.ensureLive()
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(fakes.connect).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/runtime/relay/relay-lifecycle-revoke-outbox-crossing.test.ts
+++ b/src/main/runtime/relay/relay-lifecycle-revoke-outbox-crossing.test.ts
@@ -1,0 +1,286 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OrcaCloudAuthConfig } from '../../orca-profiles/profile-cloud-auth-config'
+import type { OrcaRuntimeRpcServer } from '../runtime-rpc'
+
+// The outbox flush is launched unawaited from inside the coordinator's open, so
+// it crosses every boundary the open does: a fence, a reconnect that replaced
+// the broker it was handed, and a second revoke queued for the same reqId.
+const fakes = vi.hoisted(() => ({
+  readRelayAuthContext: vi.fn(),
+  connect: vi.fn()
+}))
+
+vi.mock('./relay-auth-context', () => ({ readRelayAuthContext: fakes.readRelayAuthContext }))
+
+vi.mock('./relay-session-broker', () => {
+  class RelaySessionBroker {
+    readonly hostId: string = hostId
+    readonly ownerIdentityKey = ownerIdentityKey
+    readonly endpoint = { v: 1 as const, relayHostId: hostId }
+    readonly closeNow = vi.fn()
+    revokeDevice = vi.fn(async () => {})
+    isLive(): boolean {
+      return this.closeNow.mock.calls.length === 0
+    }
+    static connect = fakes.connect
+  }
+  return { RelaySessionBroker }
+})
+
+import { DesktopRelayService } from './desktop-relay-service'
+import { deriveRelayHostId } from './relay-http-client'
+import { RelayRevokeOutbox, type RelayRevokeOutboxItem } from './relay-revoke-outbox'
+import { RelaySessionBroker } from './relay-session-broker'
+
+const publicKey = new Uint8Array(32).fill(7)
+const hostId = deriveRelayHostId(publicKey)
+const ownerIdentityKey = 'user-1\0profile-1\0org-1'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+type FakeBroker = {
+  readonly hostId: string
+  readonly closeNow: ReturnType<typeof vi.fn>
+  revokeDevice: ReturnType<typeof vi.fn>
+}
+
+function newBroker(): FakeBroker {
+  return new (RelaySessionBroker as unknown as new () => FakeBroker)()
+}
+
+let userDataPath: string
+
+function outboxOnDisk(): RelayRevokeOutboxItem[] {
+  return JSON.parse(
+    readFileSync(join(userDataPath, 'mobile-relay-revoke-outbox.json'), 'utf-8')
+  ) as RelayRevokeOutboxItem[]
+}
+
+// A paired phone, so standing demand survives the outbox draining to empty and
+// the broker stays registered for the next queued revoke.
+const pairedDevice = {
+  deviceId: 'device-paired',
+  scope: 'mobile' as const,
+  relayBinding: { relayHostId: hostId, relayDeviceId: 'device-paired', ownerIdentityKey }
+}
+
+function service(
+  outbox: RelayRevokeOutbox,
+  onStatus: (status: string) => void = () => {},
+  devices: (typeof pairedDevice)[] = []
+): DesktopRelayService {
+  fakes.readRelayAuthContext.mockResolvedValue({
+    identity: { userId: 'user-1', profileId: 'profile-1', organizationId: 'org-1' },
+    accessToken: 'access-1',
+    relayEntitled: true
+  })
+  const runtimeRpc = {
+    getE2EEKeypair: () => ({
+      publicKey,
+      secretKey: new Uint8Array(32).fill(9),
+      publicKeyB64: 'x'
+    }),
+    getMobileSocketWiring: () => ({ attachTransport: () => () => {} }),
+    getRelayRevokeOutbox: () => outbox,
+    getDeviceRegistry: () => ({
+      listDevices: () => devices,
+      getDevice: () => ({ deviceId: 'device-1', scope: 'mobile' }),
+      getMobilePairingConnectionMode: () => 'automatic'
+    })
+  } as unknown as OrcaRuntimeRpcServer
+  return new DesktopRelayService({
+    authConfig: {
+      relayDirectorUrl: 'https://relay.example.test',
+      relayTokenEndpoint: 'https://login.example.test/relay-token'
+    } as OrcaCloudAuthConfig,
+    userDataPath,
+    appVersion: '1.4.188',
+    runtimeRpc,
+    onStatus
+  })
+}
+
+function queued(outbox: RelayRevokeOutbox, relayDeviceId: string): RelayRevokeOutboxItem {
+  return outbox.enqueue({ relayHostId: hostId, relayDeviceId, ownerIdentityKey })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  fakes.connect.mockReset()
+  userDataPath = mkdtempSync(join(tmpdir(), 'orca-relay-outbox-'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  rmSync(userDataPath, { recursive: true, force: true })
+})
+
+describe('revoke-outbox flush crossing a fence', () => {
+  it('does not issue control revokes through a broker the fence already discarded', async () => {
+    const outbox = new RelayRevokeOutbox(userDataPath)
+    queued(outbox, 'device-1')
+    const open = deferred<FakeBroker>()
+    fakes.connect.mockImplementation(() => open.promise)
+    const relayService = service(outbox)
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fakes.connect).toHaveBeenCalledTimes(1)
+
+      relayService.fenceAndCloseNow()
+      const broker = newBroker()
+      open.resolve(broker)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(broker.revokeDevice).not.toHaveBeenCalled()
+      expect(broker.closeNow).toHaveBeenCalled()
+      // Durable, so deferring to the next launch loses nothing.
+      expect(outboxOnDisk()).toHaveLength(1)
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('stops mid-flush when the fence lands between two items', async () => {
+    const outbox = new RelayRevokeOutbox(userDataPath)
+    queued(outbox, 'device-1')
+    queued(outbox, 'device-2')
+    const broker = newBroker()
+    const firstRevoke = deferred<void>()
+    broker.revokeDevice = vi.fn(async () => await firstRevoke.promise)
+    fakes.connect.mockResolvedValue(broker)
+    const relayService = service(outbox)
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(broker.revokeDevice).toHaveBeenCalledTimes(1)
+
+      relayService.fenceAndCloseNow()
+      firstRevoke.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+
+      // device-1 really was revoked, so its item is gone; device-2 never went out.
+      expect(broker.revokeDevice).toHaveBeenCalledTimes(1)
+      expect(outboxOnDisk().map((item) => item.relayDeviceId)).toEqual(['device-2'])
+    } finally {
+      relayService.stop()
+    }
+  })
+})
+
+describe('revoke-outbox flush driving the coordinator', () => {
+  it('drains a multi-item outbox on one broker instead of one open per item', async () => {
+    // The flush is launched from inside openBroker, so its per-item demand
+    // refresh reconciled against an ownership that was not registered yet: each
+    // removal opened a fresh director assignment and abandoned the broker still
+    // working through the loop. Measured before the fix: 3 opens for 3 items.
+    const outbox = new RelayRevokeOutbox(userDataPath)
+    queued(outbox, 'device-1')
+    queued(outbox, 'device-2')
+    queued(outbox, 'device-3')
+    const brokers: FakeBroker[] = []
+    const statuses: string[] = []
+    fakes.connect.mockImplementation(async () => {
+      const broker = newBroker()
+      brokers.push(broker)
+      return broker
+    })
+    const relayService = service(outbox, (status) => statuses.push(status))
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(fakes.connect).toHaveBeenCalledTimes(1)
+      expect(brokers[0]!.revokeDevice).toHaveBeenCalledTimes(3)
+      // One assignment: each extra `connecting` is a director open the drain
+      // caused and then abandoned.
+      expect(statuses.filter((status) => status === 'connecting')).toHaveLength(1)
+      expect(brokers[0]!.closeNow).not.toHaveBeenCalled()
+      expect(outboxOnDisk()).toEqual([])
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('still reconciles once the drain is done so the relay can reach standby', async () => {
+    const outbox = new RelayRevokeOutbox(userDataPath)
+    queued(outbox, 'device-1')
+    const statuses: string[] = []
+    const broker = newBroker()
+    fakes.connect.mockResolvedValue(broker)
+    const relayService = service(outbox, (status) => statuses.push(status))
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(outboxOnDisk()).toEqual([])
+      // The last demand is gone, so the drained broker must not stay registered.
+      expect(statuses.at(-1)).toBe('standby')
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('reaches standby when a queued revoke removes the last standing demand', async () => {
+    // The runtime drops the device from the registry and then queues the relay
+    // revoke, so this flush is what retires the demand holding the control open.
+    const outbox = new RelayRevokeOutbox(userDataPath)
+    const devices = [pairedDevice]
+    const statuses: string[] = []
+    const broker = newBroker()
+    fakes.connect.mockResolvedValue(broker)
+    const relayService = service(outbox, (status) => statuses.push(status), devices)
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(statuses.at(-1)).toBe('registered')
+
+      devices.length = 0
+      relayService.onDeviceRevokeQueued(queued(outbox, pairedDevice.deviceId))
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(broker.revokeDevice).toHaveBeenCalledTimes(1)
+      expect(statuses.at(-1)).toBe('standby')
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('settles both flushes when the same revoke is queued twice', async () => {
+    const outbox = new RelayRevokeOutbox(userDataPath)
+    const broker = newBroker()
+    fakes.connect.mockResolvedValue(broker)
+    const relayService = service(outbox, () => {}, [pairedDevice])
+    try {
+      relayService.start()
+      await vi.advanceTimersByTimeAsync(0)
+
+      // enqueue returns the existing item for a repeat, so both carry one reqId.
+      const item = queued(outbox, 'device-1')
+      expect(queued(outbox, 'device-1').reqId).toBe(item.reqId)
+      relayService.onDeviceRevokeQueued(item)
+      relayService.onDeviceRevokeQueued(item)
+      await vi.advanceTimersByTimeAsync(0)
+
+      // Dedup is the control layer's job (duplicate_relay_request_id); the
+      // service must simply settle both without stranding the item.
+      expect(broker.revokeDevice.mock.calls.map((call) => call[1])).toEqual([
+        item.reqId,
+        item.reqId
+      ])
+      expect(outboxOnDisk()).toEqual([])
+    } finally {
+      relayService.stop()
+    }
+  })
+})

--- a/src/main/runtime/relay/relay-revoke-outbox-flush.ts
+++ b/src/main/runtime/relay/relay-revoke-outbox-flush.ts
@@ -10,13 +10,18 @@ type RelayRevokeOutboxFlushOptions = {
   outbox: RelayRevokeOutbox
   /** True once the service is fenced or stopped; re-read between items. */
   isHalted: () => boolean
-  /** Removing an item can retire the demand holding the broker open. */
+  /** Called once per flush that emptied at least one item, never on a no-op. */
   onDrained: () => void
 }
 
 /**
  * Drains queued device revocations over a live relay control. Runs unawaited from
- * inside the coordinator's broker open, so it outlives its own caller.
+ * inside the coordinator's broker open, so it outlives its own caller and has to
+ * re-check the halt latch itself.
+ *
+ * Shared shape with the post-quit re-arm this landed beside: an operation that
+ * reconciles against state it assumes is registered, from a context where it is
+ * not — here the broker is not registered yet, there the service is already closed.
  */
 export class RelayRevokeOutboxFlusher {
   private readonly options: RelayRevokeOutboxFlushOptions
@@ -26,25 +31,40 @@ export class RelayRevokeOutboxFlusher {
   }
 
   async flushAll(broker: RevokingBroker): Promise<void> {
+    let drained = false
     for (const item of this.options.outbox.pendingFor(broker.ownerIdentityKey, broker.hostId)) {
       // Re-checked per item: a fence can land between two revokes. The outbox is
       // durable, so deferring to the next launch beats pushing control frames
       // through a fence that was supposed to end this session.
       if (this.options.isHalted()) {
-        return
+        break
       }
-      await this.flushItem(broker, item)
+      drained = (await this.revoke(broker, item)) || drained
+    }
+    // Why once, after the loop: this runs from inside the coordinator's open, so
+    // `broker` is not registered yet. Reconciling per item read a null ownership
+    // and opened a fresh director assignment for every remaining revoke, each one
+    // abandoning the broker still working through the loop.
+    if (drained) {
+      this.options.onDrained()
     }
   }
 
   async flushItem(broker: RevokingBroker, item: RelayRevokeOutboxItem): Promise<void> {
+    if (await this.revoke(broker, item)) {
+      this.options.onDrained()
+    }
+  }
+
+  private async revoke(broker: RevokingBroker, item: RelayRevokeOutboxItem): Promise<boolean> {
     try {
       await broker.revokeDevice(item.relayDeviceId, item.reqId)
       this.options.outbox.remove(item.reqId)
-      this.options.onDrained()
+      return true
     } catch {
       // Why: the durable item is the source of truth; reconnecting the same
       // account/control retries this stable reqId without delaying local revoke.
+      return false
     }
   }
 }

--- a/src/main/runtime/relay/relay-revoke-outbox-flush.ts
+++ b/src/main/runtime/relay/relay-revoke-outbox-flush.ts
@@ -1,0 +1,42 @@
+import type { RelayRevokeOutbox, RelayRevokeOutboxItem } from './relay-revoke-outbox'
+
+type RevokingBroker = {
+  hostId: string
+  ownerIdentityKey: string
+  revokeDevice(relayDeviceId: string, reqId: string): Promise<void>
+}
+
+type RelayRevokeOutboxFlushOptions = {
+  outbox: RelayRevokeOutbox
+  /** Removing an item can retire the demand holding the broker open. */
+  onDrained: () => void
+}
+
+/**
+ * Drains queued device revocations over a live relay control. Runs unawaited from
+ * inside the coordinator's broker open, so it outlives its own caller.
+ */
+export class RelayRevokeOutboxFlusher {
+  private readonly options: RelayRevokeOutboxFlushOptions
+
+  constructor(options: RelayRevokeOutboxFlushOptions) {
+    this.options = options
+  }
+
+  async flushAll(broker: RevokingBroker): Promise<void> {
+    for (const item of this.options.outbox.pendingFor(broker.ownerIdentityKey, broker.hostId)) {
+      await this.flushItem(broker, item)
+    }
+  }
+
+  async flushItem(broker: RevokingBroker, item: RelayRevokeOutboxItem): Promise<void> {
+    try {
+      await broker.revokeDevice(item.relayDeviceId, item.reqId)
+      this.options.outbox.remove(item.reqId)
+      this.options.onDrained()
+    } catch {
+      // Why: the durable item is the source of truth; reconnecting the same
+      // account/control retries this stable reqId without delaying local revoke.
+    }
+  }
+}

--- a/src/main/runtime/relay/relay-revoke-outbox-flush.ts
+++ b/src/main/runtime/relay/relay-revoke-outbox-flush.ts
@@ -8,6 +8,8 @@ type RevokingBroker = {
 
 type RelayRevokeOutboxFlushOptions = {
   outbox: RelayRevokeOutbox
+  /** True once the service is fenced or stopped; re-read between items. */
+  isHalted: () => boolean
   /** Removing an item can retire the demand holding the broker open. */
   onDrained: () => void
 }
@@ -25,6 +27,12 @@ export class RelayRevokeOutboxFlusher {
 
   async flushAll(broker: RevokingBroker): Promise<void> {
     for (const item of this.options.outbox.pendingFor(broker.ownerIdentityKey, broker.hostId)) {
+      // Re-checked per item: a fence can land between two revokes. The outbox is
+      // durable, so deferring to the next launch beats pushing control frames
+      // through a fence that was supposed to end this session.
+      if (this.options.isHalted()) {
+        return
+      }
       await this.flushItem(broker, item)
     }
   }

--- a/src/main/startup/desktop-relay-teardown-call-site-ratchet.test.ts
+++ b/src/main/startup/desktop-relay-teardown-call-site-ratchet.test.ts
@@ -14,6 +14,10 @@ import { describe, expect, it } from 'vitest'
  * This test is the compile error that swap cannot produce. Both directions matter: quit must not
  * regain the re-armable fence, and sign-out/relaunch must not lose it — collapsing them either way
  * destroys the distinction the defect came from.
+ *
+ * If you are here because this went red on a refactor that looks harmless, that is the intended
+ * trade: a ratchet that fails loudly on a benign change beats one that passes silently on a
+ * harmful one. Re-read which teardown your call site now runs before relaxing the pattern.
  */
 const STARTUP_DIR = __dirname
 const QUIT_MODULE = 'main-process-quit.ts'

--- a/src/main/startup/desktop-relay-teardown-call-site-ratchet.test.ts
+++ b/src/main/startup/desktop-relay-teardown-call-site-ratchet.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guard which DesktopRelayService teardown each lifecycle event calls.
+ *
+ * `stop()` is terminal; `fenceAndCloseNow()` is re-armable by design, so sign-out comes back on the
+ * next auth mutation. Nothing in the types says so — both take an optional argument and return
+ * void, so swapping one for the other compiles clean and passes every unit test. Quit used the
+ * fence, and a settling mint, a pending invite expiry or a power-resume `ensureLive` each reopened
+ * a broker after quit; the damage only shows up in timer state, minutes later.
+ *
+ * This test is the compile error that swap cannot produce. Both directions matter: quit must not
+ * regain the re-armable fence, and sign-out/relaunch must not lose it — collapsing them either way
+ * destroys the distinction the defect came from.
+ */
+const STARTUP_DIR = __dirname
+const QUIT_MODULE = 'main-process-quit.ts'
+const AUTH_LIFECYCLE_MODULE = 'main-window-core-services.ts'
+
+// Qualified by the receiver on purpose: the quit handler stops five unrelated services, so a bare
+// `.stop()` would match `rateLimits`, `starNag`, `automations` and the rest. Literal enough that
+// hoisting the call behind a local also trips it — a refactor that hides which teardown runs at
+// quit is exactly what should get a second look.
+const RELAY_TERMINAL_STOP = /desktopRelayService\?\.stop\(\)/
+const RELAY_REARMABLE_FENCE = /desktopRelayService\?\.fenceAndCloseNow\(/
+
+function startupSource(module: string): string {
+  return readFileSync(join(STARTUP_DIR, module), 'utf8')
+}
+
+describe('desktop relay teardown call sites', () => {
+  it('ends the relay terminally at quit, never through the re-armable fence', () => {
+    const source = startupSource(QUIT_MODULE)
+
+    expect(source).toMatch(RELAY_TERMINAL_STOP)
+    expect(source).not.toMatch(RELAY_REARMABLE_FENCE)
+  })
+
+  it('keeps sign-out and relaunch on the fence, so the next auth mutation re-arms', () => {
+    const source = startupSource(AUTH_LIFECYCLE_MODULE)
+
+    expect(source).toMatch(RELAY_REARMABLE_FENCE)
+    expect(source).not.toMatch(RELAY_TERMINAL_STOP)
+  })
+})

--- a/src/main/startup/main-process-quit.ts
+++ b/src/main/startup/main-process-quit.ts
@@ -71,7 +71,11 @@ function installBeforeQuitHandler(): void {
       })
     }
     state.isQuitting = true
-    state.desktopRelayService?.fenceAndCloseNow()
+    // Why stop() and not the fence: the fence is re-armable by design (sign-out
+    // waits for the next auth mutation), so at quit a settling mint, an invite
+    // expiry or a power-resume could still reopen a broker. Quit is terminal,
+    // and the provider null below already ends pairing even on a vetoed quit.
+    state.desktopRelayService?.stop()
     state.runtimeRpc?.setMobileRelayPairingProvider(null)
     state.unsubscribeAgentAwakeStatusChanges?.()
     state.unsubscribeAgentAwakeStatusChanges = null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​848 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​848 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​41 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​84 |

<!-- /orca-pr-loc -->

## What breaks

Orca can open a fresh Relay control session **after the user has quit the app**. Three separate things reach it, each measured against a fresh service:

| door | measured |
|---|---|
| a pending invite-expiry wake | `getTimerCount()` is 1 immediately after quit; the timer fires and reopens the broker |
| a pairing mint settling after quit | 0 timers at quit, 1 once the mint settles, and `connect` runs again |
| a power-resume `ensureLive()` | `connect` called twice — a new control session opened post-quit |

The same hole sits between the pre-sign-out fence and the profile wipe, which is the window that fence exists to close.

## Why it survived

`DesktopRelayService.stop()` has **zero production callers**. Quit, relaunch and pre-sign-out all go through `fenceAndCloseNow()`.

The two are not equivalent. `stop()` sets `stopped` and clears both timers. The fence cleared only `livenessTimer`, left `demandExpiryTimer` armed, and left `stopped` false — and its comment, *"the next auth mutation re-arms via refreshDemand"*, is correct for sign-out and exactly wrong for quit.

So the path production takes was the one that permitted the resurrection, and the test suite was exercising the other one. `stop()` is genuinely hard; nobody was calling it. That asymmetry is the whole bug, and it is worth not re-litigating in review.

## The fix: two intents, kept apart

Rather than unifying them:

- `fenceAndCloseNow()` gains a `fenced` latch cleared only by `start()`/`authMutated()`. Sign-out and relaunch keep the re-arm the old comment protects; the dangerous window stays shut.
- Quit calls `stop()`, which is terminal. Wire behaviour is unchanged — `coordinator.stop()` fences reasonlessly exactly as the old call did.

Collapsing them would destroy the distinction the defect came from.

## Why a new file, and why it lands first

`relay-revoke-outbox-flush.ts` is an **extraction, behaviour-preserving, no logic change** — `flushRevokeOutbox`/`flushRevoke` moved out of `DesktopRelayService` verbatim.

It had to land first because `desktop-relay-service.ts` has no headroom under the 300-line cap: the fix alone puts it at 304 and the pre-commit hook rejects it. A `max-lines` disable is not an option in this repo.

On reuse — nothing existing drains the outbox. `RelayRevokeOutbox` is the durable store, and making it drain itself over a control would give the persistence layer a dependency on a broker. `RelayControlRequests` dedups in-flight reqIds on a single socket, not queued items across reconnects. `RelayDemandLedger` reads the outbox for demand and never mutates it. The only new code is an options type and a class shell.

## Commits — each independently green

Typecheck, lint, and the full relay + startup suites were run **at each commit**, not just at the tip, so the stack is genuinely splittable.

| | |
|---|---|
| `b0d02c30022` | `refactor(relay)`: extract the revoke-outbox flush into its own module |
| `9a8eef01372` | `fix(relay)`: make the quit fence hard, and route quit to the terminal `stop()` |
| `74f9feb47c7` | `fix(relay)`: drain the revoke outbox on one broker, not one open per item |
| `5f5aa6658cb` | `fix(relay)`: stop a mid-read profile switch reporting as a sign-out |
| `3a71739e3c6` | `test(relay)`: pin `RelayControlClient` teardown before, and twice after, connect |
| `572055ae36a` | `docs(relay)`: cross-reference the terminal `stop()` and the re-armable fence |
| `33e3bd42778` | `test(relay)`: ratchet which teardown each lifecycle event calls |
| `8cde428aaeb` | `docs(relay)`: address the teardown ratchet's docstring to whoever it goes red on |

### The other two fixes in the stack

**`74f9feb47c7` — one director open per outbox item.** `flushAll` runs unawaited from inside the coordinator's `openBroker`, so its broker is not registered yet; refreshing demand after every removal reconciled against a null ownership. Measured with a real outbox on disk: **3 queued revocations produced 3 `connect` calls and 2 abandoned brokers**, against a relay that rate-limits assignment. After: 1 connect, 3 revokes, outbox empty.

**`5f5aa6658cb` — a mid-read profile switch reported as a sign-out.** Same taxonomy error `8972d744` fixed for the session file, in the other `null` exit. Measured before: `offlineReason: "signed-out"` — the terminal wire reason every paired phone latches as *"sign in on your desktop to reconnect"*, arming no retry — for a race the switch's own `authMutated()` resolves moments later. After: `auth_unavailable`, which is retryable.

## Two decisions made, not asked

**A vetoed quit leaves Relay down for the session.** `before-quit` already nulls the mobile pairing provider unconditionally on the next line, so pairing is dead there regardless — a re-armed broker would be a zombie holding a control session nothing can reach. A user who cancels a quit can toggle Relay back; an unreachable broker is not recoverable by any user action.

**`fenced` is not set by `stop()`.** The two latches stay independent. Collapsing them would merge two guards that pin different properties, which is the shape that caused this.

## Residual risk

The cross-reference comments (`572055ae36a`) protect a reader who *arrives* at either method. They do nothing about someone editing the quit handler back to the fence — which is the edit that reintroduces the defect.

`33e3bd42778` closes that. It is a source-text ratchet, no harness, matching the existing `runtime-file-target-connection-field-ratchet.test.ts`: both methods take an optional argument and return `void`, so swapping them compiles clean and passes every unit test, and the difference only surfaces in timer state minutes later. Mutation-verified in three directions — reverting quit to the fence fails one test only, collapsing sign-out onto `stop()` fails the other only, and renaming an unrelated service's `stop()` fires neither. Regexes are receiver-qualified because the quit handler stops five unrelated services.

Known limit, chosen deliberately: the match is literal, so hoisting the call behind a local trips it as a false positive. A refactor that obscures which teardown runs at quit should get a second look.

**Not fixed here:** `ensureActiveOrcaProfile` treats an unreadable profile index the same as a corrupt one — it catches every error including `EACCES`/`EMFILE`, fabricates a default local profile, and writes it over the unreadable file. The relay then reports a sign-out honestly, because by that point the index really has been replaced. That belongs in `profile-index-store.ts` and changes app-wide sign-in semantics — the same caveat `8972d744` raised for `decrypt-failed`.

## Verification

`pnpm tc:node` clean, `oxlint` clean on `src/main/runtime/relay/` and `src/main/startup/`, `pnpm test src/main/runtime src/main/startup` → **8152 passed, 0 `ELIFECYCLE`**.

Every assertion added in this stack was mutation-tested: the specific line it protects was mutated, only that assertion was confirmed to fail, and the mutation was reverted. One survivor is documented in `74f9feb47c7`'s message as genuinely inert.

## Base — retargeted

This PR was based on `nwparker/adv2-concurrency-fixes`, **an integration branch with no PR of its own**. It could never have merged through that base, and a reviewer approving it there would have been approving a diff against a tree that is not going anywhere.

The real dependency set is two commits, not sixty. Rebasing this stack onto them reproduces the diff of this PR **byte for byte** — same nine files, same +943/−42, identical blob hashes — which is the proof that `adv2-concurrency-fixes` contributed nothing else:

| | |
|---|---|
| #19870 `fix/18211-lan-mode-applies-to-paired-devices` | supplies `hostMobilePairingConnectionMode` and `isRelayAllowedForDevice`, which `desktop-relay-service.ts` reads here. Without it the extraction commit conflicts on `main`. |
| #20055 `nwparker/relay-unreadable-session-taxonomy` | the sibling taxonomy fix `8972d744`, cited by name in the commit below and by the code comment it adds. |

Base is now **#20055**, which is itself stacked on #19870. Merge order: **#19870 → #20055 → this**.

### Commit SHAs moved

The rebase rewrote all eight SHAs. The old commits stay reachable via `nwparker/adv2-concurrency-fixes`, `nwparker/adv3-map-composed` and the `nwparker/j4-*` stacks, so any citation elsewhere still resolves with `git show`.

| was | now |
|---|---|
| `cd175054c5f` | `b0d02c30022` |
| `4733b21cdcb` | `9a8eef01372` |
| `f1eb8037c85` | `74f9feb47c7` |
| `ed35db892bc` | `5f5aa6658cb` |
| `83369d0ffce` | `3a71739e3c6` |
| `ae4c1304229` | `572055ae36a` |
| `762e1faa80d` | `33e3bd42778` |
| `d4f77000628` | `8cde428aaeb` |

### The splittable property survived the rebase

Re-verified per commit on the new base, all nine including the base commit: `tsc --noEmit -p config/tsconfig.node.json` clean at each, and `src/main/runtime/relay` + `src/main/startup` green at each, with the test-file count rising monotonically 76 → 81 as the stack builds. No commit is green only because a later one repairs it.

(The one red in that range, `src/main/startup/ensure-virtual-display.test.ts › reports failure when a stale socket blocks the Xvfb rebind`, reproduces on the untouched base and is excluded as pre-existing.)

### Not folded in, deliberately

**`6bd997b2cca` `fix(relay)`: clear the demand-expiry timeout on a fence, not only in `stop()` — superseded by this PR. Re-applying it is a regression, not a duplicate.**

It attacks the same defect from the same starting observation (`fenceAndCloseNow` cleared `livenessTimer` and left `demandExpiryTimer` armed; `stop()` cleared both but has no production caller). It stops at clearing both timers, via a shared `disarmTimers()`.

This PR already contains that dedup — `clearTimers()`, same shape, shared by the fence and `stop()`, relieving the same `max-lines` pressure — **and strictly more**: the `fenced` latch, cleared only by `start()`/`authMutated()` and wired into the coordinator as `isHalted: () => this.stopped || this.fenced`, plus routing quit to the terminal `stop()`.

The latch is not decoration. This PR's own comment is a direct rebuttal of the timer-clearing approach: *"Why a latch rather than just clearing the timers: clearing only covered the liveness tick, and everything else outliving the fence lands in `refreshDemand` and re-arms it — a settling mint's `finally`, a pending invite-expiry wake, a power-resume `ensureLive`."* Clearing both timers closes **one** of the three doors measured at the top of this PR; the settling-mint and power-resume doors reach `refreshDemand` without any timer.

So the hazard is a merge resolution, not a merge conflict. `6bd997b2cca` is older and looks simpler, and it touches the same lines — anyone resolving toward it **deletes the latch and reopens two of three doors**. Patch-id does not catch this: the two differ, so it reads as a missing commit rather than a superseded one.

Its two genuinely unique observations are both already carried: the note on why the existing lifecycle test missed this (it stubs `demandLedger: { nextPendingExpiry: () => null }`, so the second timer is never armed) and the `waitForLiveBrokerResult` deadline-not-re-checked caveat, which is **fixed** by `0549bd19a65` in #20061.


`ec0a2c19db9` *"fix(relay): drop the outbox method the lifecycle merge orphaned"* looks like a fix for this PR and **is not one**. `flushRevokeOutbox` does not exist on this branch — the extraction commit removed it. The orphan appears only in the *union* of this branch and `adv3-map-composed`, where the merge kept a method reading `this.revokeOutbox`/`this.flushRevoke` that this branch moved into the coordinator. It is an integration-only typecheck break and belongs to whoever composes those two, not here. Applying it to `main` would delete a method that still has a live caller at `desktop-relay-service.ts:95`.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Stack preserved: base stays `nwparker/relay-unreadable-session-taxonomy` (#20055), which itself stacks on #19870. Both were rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c` first; this branch was replayed with `git rebase --onto 0dc273fd9090210d41ea50af66c7edfdca32a57c aff7b40fff5112e9806a0a7f9c297f01cef77936`.

| | SHA |
| --- | --- |
| old head | `8cde428aaebfc692f6639eec337efd76a680cd7c` |
| new head | `c0907f78c8b41238a843a027613c9413e3aac590` |
| new base (#20055) | `0dc273fd9090210d41ea50af66c7edfdca32a57c` |

No conflicts across all eight commits.

Gates on the rebased head: typecheck exit 0 (proven failable); `vitest run --config config/vitest.config.ts src/main/runtime/relay src/main/startup/desktop-relay-startup.test.ts` — 30 files / 226 tests passed. `desktop-relay-service.ts` is 347 physical lines and passes the 300-line `max-lines` cap (blank/comment-skipping); the revoke-outbox extraction on this branch is what provides that headroom and was kept, not re-inlined.
<!-- /rebase-record -->

## Fix: the terminal stop() belongs on the committed quit handler

`77d8b28aa2b`. Moving quit off the re-armable fence was right; putting `stop()` in `before-quit` was not.

`before-quit` is vetoable — a renderer `beforeunload` can cancel the quit — and **nothing anywhere clears `stopped`**. `refreshDemand` returns early on it, so a quit the user backed out of left Relay dead for the rest of the session: no liveness tick, no reconcile, no door back. The comment three lines below in the same handler warns about precisely this, and `desktopPushService` in the same file is already split across the two handlers for the same reason.

The original justification in this PR — *"the provider null below already ends pairing even on a vetoed quit"* — does not hold up. That is a second defect on the vetoed-quit path, not a licence to add a third.

Now:

- **`before-quit` fences.** It closes the broker just as promptly and latches `fenced`, which `refreshDemand` also refuses — so the settling mint, the pending invite-expiry wake and the power-resume `ensureLive` still cannot reopen a broker in the window before `will-quit`. That was the whole point of this PR and it is intact.
- **`will-quit` — the committed path — calls `stop()`** and makes it terminal.
- On a veto, the next auth mutation clears `fenced` and Relay comes back.

The call-site ratchet guarded the *module*, which could not express this: the quit module legitimately holds both a latch and a fence. It now resolves each handler body and guards them separately — the vetoable handler must fence and must not latch, the committed handler the reverse. Mutation-verified: restoring the `before-quit` `stop()` fails both new cases.

## Merge-order constraints

- This PR is **three deep**: `main ← #19870 ← #20055 ← #19963`. It cannot be built or evaluated against `main` alone — it references `hostMobilePairingConnectionMode`, `isRelayAllowedForDevice`, `relayOfflineReasonMintFailureCode` and `refreshDemand({ skipLinger })`, none of which exist on `main`.
- **#20062 collides with this PR's refactor.** Its test builds the service with `Object.create(DesktopRelayService.prototype)` and calls `service.flushRevokeOutbox(...)`. This PR moves that method into `RelayRevokeOutboxFlusher` and takes `revokeOutbox` off the service, so whichever of the two lands second must update that test. No production-line conflict.

## The #20062 collision, with a tested patch ready

#20062 is independent and lands first; this PR is three deep, so **this PR carries the fix**.

The collision is real and confirmed by execution, not predicted. Landing #20062's test file onto this tree gives:

```
FAIL  relay-revoke-permanent-failure.test.ts > stops pinning relay demand once its window passes, but is never abandoned
TypeError: service.flushRevokeOutbox is not a function
FAIL  relay-revoke-permanent-failure.test.ts > still lets a revoke that lands remove the item and release demand
TypeError: service.flushRevokeOutbox is not a function
```

That test builds a service with `Object.create(DesktopRelayService.prototype)` and calls the private `flushRevokeOutbox`. This PR moves that loop into `RelayRevokeOutboxFlusher` and takes `revokeOutbox` off the service, so the method is gone.

The fix makes the test *simpler*, because `RelayRevokeOutboxFlusher` is exported and directly constructible — the prototype fixture and all three of its type assertions disappear. Apply to `src/main/runtime/relay/relay-revoke-permanent-failure.test.ts` after rebasing past #20062:

```diff
-import { DesktopRelayService } from './desktop-relay-service'
+import { RelayRevokeOutboxFlusher } from './relay-revoke-outbox-flush'

-function permanentlyFailingBroker(revokeDevice: ReturnType<typeof vi.fn>) {
-  // oxlint-disable-next-line typescript/consistent-type-assertions -- SAFETY: ...
-  return { ownerIdentityKey, hostId: relayHostId, revokeDevice } as never
+function permanentlyFailingBroker(revokeDevice: (id: string, reqId: string) => Promise<void>) {
+  return { ownerIdentityKey, hostId: relayHostId, revokeDevice }
 }

-function serviceOver(revokeOutbox: RelayRevokeOutbox, ledger: RelayDemandLedger) {
-  // oxlint-disable-next-line typescript/consistent-type-assertions -- SAFETY: ...
-  const service = Object.create(DesktopRelayService.prototype) as DesktopRelayService
-  Object.assign(service, {
-    revokeOutbox,
-    demandLedger: ledger,
-    coordinator: { reconcile: vi.fn(), ensureLive: vi.fn(), getActiveBroker: () => null },
-    stopped: false,
-    livenessTimer: null,
-    demandExpiryTimer: null
-  })
-  // oxlint-disable-next-line typescript/consistent-type-assertions -- SAFETY: ...
-  return service as unknown as { flushRevokeOutbox: (broker: unknown) => Promise<void> }
+/** #19963 moved the drain loop off DesktopRelayService, so the flusher is driven directly
+ *  instead of faking a service through its prototype. */
+function flusherOver(revokeOutbox: RelayRevokeOutbox): RelayRevokeOutboxFlusher {
+  return new RelayRevokeOutboxFlusher({
+    outbox: revokeOutbox,
+    isHalted: () => false,
+    onDrained: () => {}
+  })
 }
```

and at both call sites:

```diff
-    const service = serviceOver(revokeOutbox, ledger)
+    const flusher = flusherOver(revokeOutbox)
-      await service.flushRevokeOutbox(permanentlyFailingBroker(revokeDevice))
+      await flusher.flushAll(permanentlyFailingBroker(revokeDevice))
```

**Verified on this tree, not just written:** both tests pass with the patch applied, and the guard keeps its teeth — reverting #20062's demand-window change still fails `stops pinning relay demand once its window passes` with `expected true to be false`, the same signature it produces on #20062's own branch. The second test survives that mutation there too; it is a deliberate happy-path control, not coverage.

## Verification against the current base

Re-run after `nwparker/relay-unreadable-session-taxonomy` advanced to `287e850e537`:

- merges clean onto the new base
- `pnpm tc` exit 0, zero `error TS`
- `src/main/runtime/relay` + `src/main/startup` + `src/main/orca-profiles`: **114 files, 921 tests passed, 8 skipped, 0 failed**

This PR has still never been built against `main` alone — it cannot be, at three deep. That remains an explicit gap, not a verdict.
