### PR TITLE
Remove deprecated `verified:` parameter from cask url stanzas

### DIFF
--- a/Casks/orca.rb
+++ b/Casks/orca.rb
@@ -5,8 +5,7 @@ cask "orca" do
   sha256 arm:   "fc707f290ff3b631b7b7947bf339885b61a43d2e89475997c125b61268ed4966",
          intel: "5f677c13a08f7a5740442e29d388285a86488c8c1f7aa5f10a8721a2c6ede8e4"
 
-  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
-      verified: "github.com/stablyai/orca/"
+  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg"
   name "Orca"
   desc "IDE for orchestrating AI coding agents across terminals and worktrees"
   homepage "https://onorca.dev/"

--- a/Casks/orca@rc.rb
+++ b/Casks/orca@rc.rb
@@ -5,8 +5,7 @@ cask "orca@rc" do
   sha256 arm:   "563b6b14323fc9d5489299c82442d514bc12cabffc9d06d3964ed572af4b3955",
          intel: "457088c7021f07de1a419197f7b2bd00092741ad4727d4fef3d86af38a6831e7"
 
-  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
-      verified: "github.com/stablyai/orca/"
+  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg"
   name "Orca RC"
   desc "IDE for orchestrating AI coding agents across terminals and worktrees"
   homepage "https://onorca.dev/"


### PR DESCRIPTION
## ELI5

Homebrew used to let a cask say "I promise this download URL is really mine" with a `verified:` line. Homebrew stopped using that line — it now ignores it completely and just prints a warning telling you to delete it. Because Orca's cask still has the line, anyone with the tap installed sees that warning on basically every `brew` command. This deletes the line. Nothing about where the download comes from changes.

## What Changed

Removed the deprecated `verified:` parameter from the `url` stanza in both channel templates:

- `Casks/orca.rb`
- `Casks/orca@rc.rb`

No other stanza touched.

## Why

Homebrew now treats `verified` as a no-op. In current Homebrew:

- `Cask::URL::DEPRECATED_URL_SPECS` is `[:verified]`, commented as *"URL kwargs still accepted from existing cask metadata but otherwise ignored."*
- `Cask::DSL#url` strips it before constructing the URL: `URL.new(uri, **options.except(*URL::DEPRECATED_URL_SPECS), caller_location:)`
- `Cask::URL#initialize` carries it only as `# 'verified' is accepted as a no-op for compatibility with existing casks.`

So the parameter has no effect on download or verification behaviour, and its only remaining output is the deprecation warning:

```
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
Please report this issue to the stablyai/homebrew-orca tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/stablyai/homebrew-orca/Casks/orca.rb:8
```

That warning prints on every `brew` invocation that loads the tap, including `brew doctor`, `brew info` and `brew uninstall`, and it fires multiple times per `brew doctor` run. Removing the parameter is the fix the deprecation message itself directs to.

Both channel templates are changed together so stable and RC stay consistent, and because `orca@rc.rb` carries the identical line.

This propagates to the tap without extra work: `.github/workflows/homebrew-bump.yml` templates `Casks/<token>.rb` from this repo, rewrites only the `version` and `sha256 arm:/intel:` lines, then copies the file into `stablyai/homebrew-orca`. Neither regex touches the `url` stanza, so the next release bump carries the fix through.

## Linked Issue

Fixes #19580

Also reported in #19573 and #18849.

## Visual Proof

`N/A` — cask metadata only, no UI or interaction surface in the app.

Behavioural proof instead, with the change applied to an installed tap copy:

Before:
```
$ brew info --cask orca
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! ...
  /opt/homebrew/Library/Taps/stablyai/homebrew-orca/Casks/orca.rb:8
```

After:
```
$ brew info --cask stablyai/orca/orca
==> orca (Orca): 1.4.199 (auto_updates)
IDE for orchestrating AI coding agents across terminals and worktrees
https://onorca.dev/
Installed (on request)
/opt/homebrew/Caskroom/orca/1.4.199 (525.8MB)
From: https://github.com/stablyai/homebrew-orca/blob/HEAD/Casks/orca.rb
```

Resolution, install source, version and `auto_updates` are unchanged; only the warning is gone.

## Testing

Tested on macOS 27.0 arm64, Homebrew 6.0.22, with the stable cask installed from the tap.

1. Applied the same one-line removal to the installed tap copy at `/opt/homebrew/Library/Taps/stablyai/homebrew-orca/Casks/orca.rb`.
2. Ran `brew info --cask orca` — deprecation warning gone.
3. Confirmed `brew info --cask stablyai/orca/orca` still resolves to the tap, reports `1.4.199`, `auto_updates`, and the correct install source.
4. `ruby -c` clean on both `Casks/orca.rb` and `Casks/orca@rc.rb`.
5. Reverted the local tap edit afterwards.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No automated test added: these are cask metadata templates, not application code, and the repo has no cask-rendering test harness. The behaviour is enforced by Homebrew's own deprecation path.

Platforms: macOS only by nature — Homebrew casks are a macOS install surface. No Linux, Windows, SSH/remote, mobile, agent, integration or git-provider behaviour is touched.

## AI Disclosure

Claude Code (model `claude-opus-5`) was used to research the Homebrew deprecation, confirm the parameter is a no-op in Homebrew source, verify the tap propagation path, prepare the change and draft this description. Reviewed before submitting.

## Review

Reviewed against the areas the template calls out:

- **Security** — neutral to slightly positive. `verified` performed no verification in current Homebrew; it was stripped before the URL was built. Removal changes no download source and no checksum. `sha256` per-arch pinning, which is what actually guarantees artifact integrity, is untouched.
- **Cross-platform (macOS / Linux / Windows)** — no impact. Casks are macOS-only and carry no app code.
- **Remote SSH** — no impact. Not part of any runtime path.
- **Mobile** — no impact.
- **Backwards compatibility** — safe on older Homebrew too: `verified` was optional there and its absence is valid across supported versions, so older clients parse the cask fine.
- **Performance** — negligible, marginally positive: removes repeated deprecation formatting on every tap load.
- **UI quality** — not applicable.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Scope is deliberately two lines. Two adjacent things noticed while working but **not** changed here, to keep this focused:

- `Casks/orca.rb` in this repo still reads `version "1.3.24"` while the tap is on `1.4.199`, since the bump workflow rewrites the version only in the copy it pushes to the tap. Harmless for templating, but it does make the checked-in template look stale.
- The bare `orca` cask token still collides with Plotly's `orca` in `homebrew-cask`, so `brew info --cask orca` resolves to that one. That is #14591 and is untouched here.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Not run locally: this branch was prepared as a sparse checkout of `Casks/` only, and the change is two lines of cask metadata that no lint, typecheck, test or build step reads. Leaving this to CI rather than ticking a box I did not actually verify.
