### PR TITLE
perf(terminal): stop spending reveal-restore frames on panes that replay nothing

### DIFF
--- a/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.test.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
 
 import {
   cancelScheduledHiddenOutputRestore,
   resetHiddenOutputRestoreSchedulerForTests,
   scheduleHiddenOutputRestore
 } from './hidden-output-restore-scheduler'
+
+/** A pane that actually replays scrollback when its turn comes. */
+const replaying = (): Mock<() => boolean> => vi.fn(() => true)
+/** A pane whose guards decline — hidden, disposed, or superseded restore. */
+const declining = (): Mock<() => boolean> => vi.fn(() => false)
 
 describe('hidden output restore scheduler', () => {
   beforeEach(() => {
@@ -19,7 +25,7 @@ describe('hidden output restore scheduler', () => {
 
   it('runs active restores immediately', () => {
     const target = {}
-    const requestRestore = vi.fn()
+    const requestRestore = replaying()
 
     scheduleHiddenOutputRestore(target, requestRestore, 'active')
 
@@ -27,8 +33,8 @@ describe('hidden output restore scheduler', () => {
   })
 
   it('spreads inactive restores across timer ticks', () => {
-    const firstRestore = vi.fn()
-    const secondRestore = vi.fn()
+    const firstRestore = replaying()
+    const secondRestore = replaying()
 
     scheduleHiddenOutputRestore({}, firstRestore, 'inactive')
     scheduleHiddenOutputRestore({}, secondRestore, 'inactive')
@@ -46,8 +52,8 @@ describe('hidden output restore scheduler', () => {
 
   it('cancels pending inactive restore when a target is promoted', () => {
     const target = {}
-    const inactiveRestore = vi.fn()
-    const activeRestore = vi.fn()
+    const inactiveRestore = replaying()
+    const activeRestore = replaying()
 
     scheduleHiddenOutputRestore(target, inactiveRestore, 'inactive')
     scheduleHiddenOutputRestore(target, activeRestore, 'active')
@@ -59,12 +65,77 @@ describe('hidden output restore scheduler', () => {
 
   it('can cancel pending inactive restores', () => {
     const target = {}
-    const requestRestore = vi.fn()
+    const requestRestore = replaying()
 
     scheduleHiddenOutputRestore(target, requestRestore, 'inactive')
     cancelScheduledHiddenOutputRestore(target)
     vi.runOnlyPendingTimers()
 
     expect(requestRestore).not.toHaveBeenCalled()
+  })
+
+  it('does not charge a frame to panes that replay nothing', () => {
+    const hiddenPanes = [declining(), declining(), declining()]
+    const visibleRestore = replaying()
+
+    for (const hiddenPane of hiddenPanes) {
+      scheduleHiddenOutputRestore({}, hiddenPane, 'inactive')
+    }
+    scheduleHiddenOutputRestore({}, visibleRestore, 'inactive')
+
+    vi.advanceTimersByTime(16)
+
+    for (const hiddenPane of hiddenPanes) {
+      expect(hiddenPane).toHaveBeenCalledTimes(1)
+    }
+    expect(visibleRestore).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps one replay per frame once a queued pane replays', () => {
+    const firstRestore = replaying()
+    const declined = declining()
+    const secondRestore = replaying()
+
+    scheduleHiddenOutputRestore({}, firstRestore, 'inactive')
+    scheduleHiddenOutputRestore({}, declined, 'inactive')
+    scheduleHiddenOutputRestore({}, secondRestore, 'inactive')
+
+    vi.advanceTimersByTime(16)
+    expect(firstRestore).toHaveBeenCalledTimes(1)
+    expect(declined).not.toHaveBeenCalled()
+    expect(secondRestore).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(16)
+    expect(declined).toHaveBeenCalledTimes(1)
+    expect(secondRestore).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops declining panes instead of retrying them', () => {
+    const declined = declining()
+
+    scheduleHiddenOutputRestore({}, declined, 'inactive')
+    vi.advanceTimersByTime(16)
+    vi.advanceTimersByTime(160)
+
+    expect(declined).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does not re-enter a pane queued by a restore that ran in the same drain', () => {
+    const requeued = declining()
+    const target = {}
+    const reschedulingRestore = vi.fn(() => {
+      scheduleHiddenOutputRestore(target, requeued, 'inactive')
+      return false
+    })
+
+    scheduleHiddenOutputRestore({}, reschedulingRestore, 'inactive')
+    vi.advanceTimersByTime(16)
+
+    expect(reschedulingRestore).toHaveBeenCalledTimes(1)
+    expect(requeued).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(16)
+    expect(requeued).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
@@ -1,6 +1,7 @@
 type HiddenOutputRestorePriority = 'active' | 'inactive'
 
-type HiddenOutputRestoreRequest = () => void
+/** Returns whether the pane actually started a replay; a guard-only return is free. */
+type HiddenOutputRestoreRequest = () => boolean
 
 type HiddenOutputRestoreEntry = {
   requestRestore: HiddenOutputRestoreRequest
@@ -30,13 +31,22 @@ function scheduleInactiveRestoreDrain(): void {
 
 function drainInactiveRestoreQueue(): void {
   inactiveRestoreTimer = null
-  const next = inactiveRestoreQueue.entries().next()
-  if (next.done) {
-    return
+  // Why the loop: an entry whose pane went hidden, was disposed, or had its restore
+  // superseded replays nothing, so charging it a whole frame only delays the next
+  // on-screen pane. Still at most one real replay per frame; the skips are guard reads.
+  let remaining = inactiveRestoreQueue.size
+  while (remaining > 0) {
+    remaining -= 1
+    const next = inactiveRestoreQueue.entries().next()
+    if (next.done) {
+      break
+    }
+    const [target, entry] = next.value
+    inactiveRestoreQueue.delete(target)
+    if (entry.requestRestore()) {
+      break
+    }
   }
-  const [target, entry] = next.value
-  inactiveRestoreQueue.delete(target)
-  entry.requestRestore()
   scheduleInactiveRestoreDrain()
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection/hidden-output-restore-request.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/hidden-output-restore-request.ts
@@ -68,7 +68,7 @@ export function bindHiddenOutputRestoreRequest(session: ConnectPanePtySession): 
           // Why: resume can reveal many split panes at once; spread inactive replays across frames so xterm scrollback replay doesn't block return.
           scheduleHiddenOutputRestore(
             session.pane.terminal,
-            () => {
+            (): boolean => {
               session.hiddenOutputRestoreScheduled = false
               if (
                 session.disposed ||
@@ -80,9 +80,11 @@ export function bindHiddenOutputRestoreRequest(session: ConnectPanePtySession): 
                   session.hiddenOutputRestorePendingChunks.length === 0) ||
                 !shouldWritePtyOutputForeground(session.deps.isVisibleRef.current)
               ) {
-                return
+                // Why report false: nothing replayed here, so the scheduler can spend
+                // this frame on the next queued pane instead of on a hidden/stale one.
+                return false
               }
-              session.requestHiddenOutputRestoreIfNeeded({ bypassScheduler: true })
+              return session.requestHiddenOutputRestoreIfNeeded({ bypassScheduler: true }) === true
             },
             priority
           )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

Ledger item 2.3 ("active-pane priority on the reveal restore queue"). **The ledger's premise did not hold, so this is not a priority queue.** See *What 2.3 claimed* below.

`scheduleHiddenOutputRestore` drains its inactive queue one entry per 16 ms frame. Some entries replay nothing: the scheduled callback in `hidden-output-restore-request.ts` bails when the pane went hidden, was disposed, changed PTY, had its restore generation superseded, or no longer needs one. Today that dead entry still costs the whole frame, so the next pane — which may be on screen — waits another 16 ms for nothing.

The callback now returns whether it actually started a replay, and the drain walks past `false` entries inside the same tick.

- Order is unchanged. Strict FIFO, no promotion, no demotion — so nothing is traded against anything.
- Pacing is unchanged. The loop stops at the first entry that replays, so it is still at most one xterm scrollback replay per frame. The design intent in the comment above `INACTIVE_RESTORE_INTERVAL_MS` is preserved verbatim.
- The loop is bounded by the queue size sampled at tick entry, so a callback that re-queues cannot spin it.

## ELI5

When you flip to another worktree, the terminal panes that were off-screen have to redraw what they missed. Orca redraws one of them per screen frame so the app stays responsive. The problem: some of those queued redraws have nothing left to do — the pane got hidden again, or was already caught up — but they still used up their turn, and a pane you were actually looking at sat there blank for an extra sixteenth of a second per wasted turn. Now the empty turns are skipped instantly and the first pane that really has something to draw gets that frame. Nothing draws later than it used to; some things draw sooner.

## Proof

### Measured before/after

Deterministic fake-timer harness (temporary, not committed): queue *N* entries whose restore declines, then one entry that replays, and record the wall-clock at which the replaying entry runs. Run identically against the `origin/main` scheduler and against this branch.

| declining entries ahead | before (`origin/main`) | after |
| --- | --- | --- |
| 1 | 32 ms | 16 ms |
| 3 | 64 ms | 16 ms |
| 5 | 96 ms | 16 ms |

Raw assertion output, before:
```
expected { declining: 1, visibleAtMs: 32 } ...
expected { declining: 3, visibleAtMs: 64 } ...
expected { declining: 5, visibleAtMs: 96 } ...
```
after:
```
expected { declining: 1, visibleAtMs: 16 } ...
expected { declining: 3, visibleAtMs: 16 } ...
expected { declining: 5, visibleAtMs: 16 } ...
```

### Not measured, and why

**I did not produce an end-to-end worktree-switch first-paint number for this change, and I am not claiming one.** The size of the real-world win is the number of dead entries sitting in the queue at the moment of a switch, which depends on history the harness cannot stage deterministically (a pane that overflowed its background backlog and then got hidden; a rapid switch away before a pending entry drained). I could not construct a repeatable e2e scenario that reliably parks dead entries in the queue at switch time, so the honest claim is the one above: **each dead entry stops costing a visible pane one frame.** Whether a given switch has 0 or 5 of them is workload-dependent.

### Tests that lock the behaviour

`src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.test.ts` — the four pre-existing cases are kept (their mocks now return `true`, i.e. "this pane really replayed") plus:

- `does not charge a frame to panes that replay nothing` — three declining entries ahead of a replaying one; all four run on the first 16 ms tick. **Fails on `origin/main`.**
- `keeps one replay per frame once a queued pane replays` — pins that the loop stops at the first real replay, so pacing is not lost. **Fails on `origin/main`.**
- `drops declining panes instead of retrying them` — a declining entry is consumed, not requeued, and leaves no pending timer.
- `does not re-enter a pane queued by a restore that ran in the same drain` — bounds the loop against re-entrant scheduling.

Confirmed both new ordering tests fail against the unmodified scheduler:
```
× does not charge a frame to panes that replay nothing
× keeps one replay per frame once a queued pane replays
Tests  2 failed | 6 passed (8)
```

### Trade-off audit

- **Nothing is delayed.** Skipped entries did nothing when they ran. Every remaining entry keeps its FIFO position and runs at a tick no later than before.
- **No added main-thread work in a frame.** Still ≤ 1 replay per tick. A skip is the callback's existing guard chain — property reads and a `shouldWritePtyOutputForeground` call.
- **No starvation.** There are no tiers to starve; ordering is untouched.
- **No lost restore.** A declining entry leaves exactly the state it left before: `hiddenOutputRestoreScheduled = false`, `hiddenOutputRestoreNeeded` untouched. Reveal re-requests via `resumeTerminalVisibility` → `requestTerminalBacklogRecovery` → `requestHiddenOutputRestoreIfNeeded`, on both the light and heavy resume paths. That was already the only thing keeping a hidden pane's restore alive.
- **SSH / remote hosts.** `requestRestore` returns as soon as the async restore task is created; the remote round trip is not awaited in the drain. A remote pane that starts a restore returns `true` and stops the loop exactly like a local one, so pacing over a relay is identical. `session.requestHiddenOutputRestoreIfNeeded` also returns `true` when a restore is already in flight, which is conservative in the safe direction — it stops the loop rather than letting it run on.
- **Folder workspaces.** The scheduler is keyed on the xterm instance and knows nothing about git worktrees; folder workspaces take the same path.
- **Wire compatibility.** Renderer-local scheduling only; no IPC, RPC, or stream format touched.

## What 2.3 claimed, and what is actually true

> on a worktree switch every pane in the revealed worktree is "inactive" for its own tab

This is **not** true on `origin/main`, so no priority queue is warranted:

- `TerminalPaneOverlayLayer.tsx:141-142` gives `isActive = true` to the active tab of the focused tab group, and `foreground-output-refresh.ts:205-211` gives `'active'` priority to that tab's focused pane. `hidden-output-restore-request.ts:62` then runs it **synchronously, bypassing the queue entirely**. The pane the user is staring at after a switch is never queued.
- `set-active-worktree.ts:183-196` writes `activeWorktreeId` and `activeTabId` in one store update, so there is no render where the new worktree is shown with the old worktree's active tab — the transient window that would have made the claim true does not exist.
- Every remaining entry in the queue during a switch belongs to a pane with `isVisibleRef.current === true` (another split pane of the revealed tab, or the active tab of another visible tab group). Those panes are all **on screen**, so promoting one over another would be a straight zero-sum trade and was deliberately not done.

What is left, and what this PR fixes, is the orthogonal waste: entries that reach the front of the queue and replay nothing still bill a visible pane a frame.
