### PR TITLE
perf(terminal): stop rebuilding per-workspace collections on a worktree switch

### DIFF
--- a/src/renderer/src/components/terminal-parked-watcher-sync-entries.test.tsx
+++ b/src/renderer/src/components/terminal-parked-watcher-sync-entries.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useTerminalWatcherEffects } from './use-terminal-watcher-effects'
+import type { ParkedTerminalTabWatcherSyncEntry } from './terminal-pane/terminal-parked-tab-watchers'
+import type { TerminalColdActivationController } from './terminal-cold-activation'
+
+const mocks = vi.hoisted(() => ({
+  sync: vi.fn(),
+  prune: vi.fn()
+}))
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(() => 'unverifiable', {
+    getState: () => ({ activeWorktreeId: null })
+  })
+}))
+vi.mock('@/lib/workspace-terminal-host-authority', () => ({
+  createWorkspaceTerminalHostAuthoritySelector: () => () => 'unverifiable'
+}))
+vi.mock('./terminal-pane/terminal-parked-tab-watchers', () => ({
+  canWatcherCoverParkedTerminalTab: () => true,
+  disposeAllParkedTerminalWatchers: vi.fn(),
+  pruneParkedTerminalWatchers: mocks.prune,
+  syncParkedTerminalTabWatchersForWorkspaces: mocks.sync,
+  terminalWatcherLiveWorkspaceIds: (ids: Iterable<string>) => new Set(ids)
+}))
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const SURFACE_COUNT = 423
+const PARKED_WORKTREE_ID = 'repo-1::/worktree-0'
+const surfaceIds = Array.from({ length: SURFACE_COUNT }, (_, index) => `repo-1::/worktree-${index}`)
+
+let root: Root | undefined
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  vi.clearAllMocks()
+})
+
+function renderWatcherEffects(): Promise<void> {
+  function Watcher(): null {
+    useTerminalWatcherEffects({
+      activationDeferredMountTabIdsByWorktreeRef: { current: new Map() },
+      activeTabId: null,
+      activeTabIdByWorktree: {},
+      activeView: 'terminal',
+      activeWorktreeId: null,
+      activityTerminalPortals: [],
+      anyMountedWorktreeHasLayout: false,
+      backgroundMountRevision: 0,
+      effectiveParkedTerminalWorktreeIds: new Set([PARKED_WORKTREE_ID]),
+      evictionExemptTerminalTabIds: new Set(['tab-exempt']),
+      getEffectiveLayoutForWorktree: () => null,
+      groupsByWorktree: {},
+      hydrationSucceeded: false,
+      measurableBackgroundWorktreeIdsRef: { current: new Set() },
+      mountedWorktreeIdsRef: { current: new Set([PARKED_WORKTREE_ID]) },
+      pendingStartupByTabId: {},
+      // Another workspace is on screen, so the mounted one is hidden and parks.
+      renderedActiveWorktreeId: 'repo-1::/worktree-9',
+      tabsByWorktree: {
+        [PARKED_WORKTREE_ID]: [{ id: 'tab-parked' }, { id: 'tab-exempt' }]
+      },
+      terminalParkingEnabled: true,
+      terminalStartupRestorationReady: false,
+      terminalTitleSnapshotAuthorityEnabled: true,
+      workspaceSessionReady: false,
+      workspaceSurfaceIds: surfaceIds
+    } as unknown as TerminalColdActivationController)
+    return null
+  }
+  root = createRoot(document.createElement('div'))
+  return act(async () => root?.render(<Watcher />))
+}
+
+function lastSyncEntries(): Map<string, ParkedTerminalTabWatcherSyncEntry> {
+  return mocks.sync.mock.calls.at(-1)?.[0] as Map<string, ParkedTerminalTabWatcherSyncEntry>
+}
+
+describe('parked terminal watcher sync entries', () => {
+  it('publishes an entry for every surface so closed-tab disposal still sees it', async () => {
+    await renderWatcherEffects()
+
+    const entries = lastSyncEntries()
+    expect(entries.size).toBe(SURFACE_COUNT)
+    expect([...entries.keys()]).toEqual(surfaceIds)
+    expect(mocks.prune).toHaveBeenCalledWith(new Set(surfaceIds))
+  })
+
+  it('parks the hidden mounted workspace tabs and exempts the eviction-exempt tab', async () => {
+    await renderWatcherEffects()
+
+    const parkedEntry = lastSyncEntries().get(PARKED_WORKTREE_ID)
+    expect([...(parkedEntry?.parkedTabIds ?? [])]).toEqual(['tab-parked'])
+  })
+
+  it('does not allocate a parked-tab-id set per unmounted surface', async () => {
+    await renderWatcherEffects()
+
+    const entries = lastSyncEntries()
+    const unmountedSets = new Set(
+      [...entries]
+        .filter(([workspaceId]) => workspaceId !== PARKED_WORKTREE_ID)
+        .map(([, entry]) => entry.parkedTabIds)
+    )
+    // Pre-fix this was one empty Set per surface (422 of them) on every fire.
+    expect(unmountedSets.size).toBe(1)
+    expect([...unmountedSets][0]?.size).toBe(0)
+  })
+})

--- a/src/renderer/src/components/terminal-workspace-surface-ids.test.tsx
+++ b/src/renderer/src/components/terminal-workspace-surface-ids.test.tsx
@@ -8,6 +8,7 @@ import { makeRepo, makeWorktree } from './worktree-jump-palette-test-fixtures'
 import { useTerminalWorkspaceFoundation } from './use-terminal-workspace-foundation'
 import { applyTerminalColdActivation } from './terminal-cold-activation'
 import { collectTerminalParkingPassCandidates } from './terminal-parking-pass-candidates'
+import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
 import type { WorkspaceSurface } from './workspace-surface-projection'
 import type { TerminalParkingFoundation } from './use-terminal-parking-foundation'
 
@@ -147,6 +148,84 @@ describe('workspace surface ids', () => {
     ])
     expect(hiddenSince.has('repo::/stale')).toBe(false)
   })
+  it('keeps the surface projection stable across a git-worktree switch', () => {
+    const repo = makeRepo()
+    const worktrees = Array.from({ length: 423 }, (_, index) =>
+      makeWorktree(`repo-1::/worktree-${index}`, `Workspace ${index}`)
+    )
+    useAppStore.setState({
+      worktreesByRepo: { [repo.id]: worktrees },
+      activeWorktreeId: worktrees[0].id
+    })
+
+    const { result } = renderHook(() => useTerminalWorkspaceFoundation())
+    const surfaces = result.current.workspaceSurfaces
+    const ids = result.current.workspaceSurfaceIds
+    const idSet = result.current.workspaceSurfaceIdSet
+    expect(surfaces).toHaveLength(423)
+
+    // Pre-fix every switch re-ran the projection (423 surface objects) and re-derived
+    // the id array, because the active id was a dep even with no folder host to tie-break.
+    for (let index = 1; index < 10; index += 1) {
+      act(() => {
+        useAppStore.setState({ activeWorktreeId: worktrees[index].id })
+      })
+      expect(result.current.renderedActiveWorktreeId).toBe(worktrees[index].id)
+      expect(result.current.workspaceSurfaces).toBe(surfaces)
+      expect(result.current.workspaceSurfaceIds).toBe(ids)
+      expect(result.current.workspaceSurfaceIdSet).toBe(idSet)
+    }
+  })
+
+  it('still re-projects when the active folder workspace owns the collision tie-break', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const localFolder: FolderWorkspace = {
+      id: 'folder-shared',
+      projectGroupId: 'group-shared',
+      name: 'orca',
+      folderPath: '/work/orca-local',
+      connectionId: null,
+      executionHostId: 'local',
+      linkedTask: null,
+      comment: '',
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 1,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const runtimeFolder: FolderWorkspace = {
+      ...localFolder,
+      folderPath: '/remote/orca',
+      executionHostId: 'runtime:env-1'
+    }
+    useAppStore.setState({
+      folderWorkspaces: [localFolder, runtimeFolder],
+      activeWorktreeId: 'folder:folder-shared',
+      activeWorkspaceExecutionHostId: 'runtime:env-1'
+    })
+
+    const { result } = renderHook(() => useTerminalWorkspaceFoundation())
+    expect(result.current.workspaceSurfaces).toEqual([
+      { id: 'folder:folder-shared', path: '/remote/orca' }
+    ])
+
+    // Leaving the folder workspace drops the tie-break, so the projection must re-run
+    // and fall back to first-wins rather than mount the previous host's path.
+    act(() => {
+      useAppStore.setState({
+        activeWorktreeId: 'repo-1::/worktree-0',
+        activeWorkspaceExecutionHostId: null
+      })
+    })
+    expect(result.current.workspaceSurfaces).toEqual([
+      { id: 'folder:folder-shared', path: '/work/orca-local' }
+    ])
+    warn.mockRestore()
+  })
+
   it('stops idle worktree writes from re-firing surface-keyed terminal effects', () => {
     const repo = makeRepo()
     const worktrees = Array.from({ length: 20 }, (_, index) =>

--- a/src/renderer/src/components/use-terminal-watcher-effects.ts
+++ b/src/renderer/src/components/use-terminal-watcher-effects.ts
@@ -17,6 +17,10 @@ import { getStructuredAgentLaunchStatus } from '@/lib/structured-agent-session-l
 import { AGENT_SESSION_PROVIDER_HANDLE_PROVIDERS } from '../../../shared/agent-session-provider-handle'
 import type { TerminalColdActivationController } from './terminal-cold-activation'
 
+// Why shared: only a mounted workspace can park a tab, and the watcher sync only reads
+// this set, so every other surface would otherwise allocate its own empty one per fire.
+const NO_PARKED_TAB_IDS: ReadonlySet<string> = new Set()
+
 export function useTerminalWatcherEffects(controller: TerminalColdActivationController): void {
   const {
     activationDeferredMountTabIdsByWorktreeRef,
@@ -58,9 +62,11 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
         continue
       }
       const tabs = tabsByWorktree[workspaceId] ?? []
-      const parkedTabIds = new Set<string>()
+      let parkedTabIds: ReadonlySet<string> = NO_PARKED_TAB_IDS
       let deferredTabIds: ReadonlySet<string> | null = null
       if (!anyMountedWorktreeHasLayout && mountedWorktreeIdsRef.current.has(workspaceId)) {
+        const mountedParkedTabIds = new Set<string>()
+        parkedTabIds = mountedParkedTabIds
         const isVisible = activeView === 'terminal' && workspaceId === renderedActiveWorktreeId
         const shouldMeasureHiddenWorktree =
           !isVisible && measurableBackgroundWorktreeIdsRef.current.has(workspaceId)
@@ -75,7 +81,7 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
               tabId: tab.id
             })
             if (!activityTerminalPortal && !evictionExemptTerminalTabIds.has(tab.id)) {
-              parkedTabIds.add(tab.id)
+              mountedParkedTabIds.add(tab.id)
             }
           }
         }
@@ -83,14 +89,14 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
         for (const tab of tabs) {
           if (
             deferredTabIds?.has(tab.id) &&
-            !parkedTabIds.has(tab.id) &&
+            !mountedParkedTabIds.has(tab.id) &&
             canWatcherCoverParkedTerminalTab(workspaceId, tab) &&
             !findActivityTerminalPortal(activityTerminalPortals, {
               worktreeId: workspaceId,
               tabId: tab.id
             })
           ) {
-            parkedTabIds.add(tab.id)
+            mountedParkedTabIds.add(tab.id)
           }
         }
       }

--- a/src/renderer/src/components/use-terminal-workspace-foundation.ts
+++ b/src/renderer/src/components/use-terminal-workspace-foundation.ts
@@ -37,15 +37,19 @@ export function useTerminalWorkspaceFoundation() {
     parseWorkspaceKey(renderedActiveWorktreeId ?? '')?.type === 'folder'
       ? activeWorktreeDeferralHostId
       : null
+  // Why gate the id on the host: the projection reads `activeWorkspaceId` only behind a
+  // truthy resolved host, so without one every active id yields the same surfaces — and a
+  // worktree switch must not re-project (and re-identify) every surface to rediscover that.
+  const activeFolderSurfaceId = activeFolderSurfaceHostId ? renderedActiveWorktreeId : null
   const workspaceSurfaces = useMemo(
     () =>
       projectWorkspaceSurfaces({
         worktreesById,
         folderWorkspaces,
-        activeWorkspaceId: renderedActiveWorktreeId,
+        activeWorkspaceId: activeFolderSurfaceId,
         activeWorkspaceResolvedHostId: activeFolderSurfaceHostId
       }),
-    [worktreesById, folderWorkspaces, renderedActiveWorktreeId, activeFolderSurfaceHostId]
+    [worktreesById, folderWorkspaces, activeFolderSurfaceId, activeFolderSurfaceHostId]
   )
   // Why split the ids out: every mount/park/activation pass reads only `.id`, but
   // the surface array is re-identified on any worktree write. Reusing the previous

--- a/src/renderer/src/components/workspace-surface-projection.test.ts
+++ b/src/renderer/src/components/workspace-surface-projection.test.ts
@@ -118,6 +118,24 @@ describe('projectWorkspaceSurfaces', () => {
     expect(surfaces).toEqual([{ id: 'folder:folder-shared', path: '/remote/orca' }])
   })
 
+  it('ignores the active workspace id entirely when no resolved host disambiguates', () => {
+    // The terminal foundation memo relies on this: with no resolved folder host it passes
+    // `null` instead of the active id, so a worktree switch cannot change the projection.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const folderWorkspaces = [localFolder, runtimeFolder]
+    const worktrees = [localWorktree]
+
+    const withoutActiveId = project({ worktrees, folderWorkspaces, activeWorkspaceId: null })
+    for (const activeWorkspaceId of [
+      'folder:folder-shared',
+      'folder:other-workspace',
+      SHARED_WORKTREE_ID
+    ]) {
+      expect(project({ worktrees, folderWorkspaces, activeWorkspaceId })).toEqual(withoutActiveId)
+    }
+    warn.mockRestore()
+  })
+
   it('keeps the first row when no resolved host disambiguates the folder collision', () => {
     const surfaces = project({
       folderWorkspaces: [runtimeFolder, localFolder]

--- a/src/renderer/src/components/workspace-surface-projection.ts
+++ b/src/renderer/src/components/workspace-surface-projection.ts
@@ -49,6 +49,7 @@ export function projectWorkspaceSurfaces({
 }: {
   worktreesById: ReadonlyMap<string, Pick<Worktree, 'path'>>
   folderWorkspaces: readonly FolderWorkspaceSurfaceRow[]
+  /** Read only when `activeWorkspaceResolvedHostId` is set; inert otherwise. */
   activeWorkspaceId: string | null
   /** Resolved (not user-selected) host of the active workspace; the folder tie-break. */
   activeWorkspaceResolvedHostId: ExecutionHostId | null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​207 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​207 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

When you click from one worktree to another, Orca rebuilds a couple of internal
lists that describe every workspace you have open — even though switching
workspaces can't change what's in those lists. If you keep a lot of worktrees
around, that's hundreds of throwaway objects per click, and again every time a
terminal publishes a title or a tab spawns. This stops building them when
nothing about them changed. Nothing looks or behaves differently; there is just
less work between your click and the terminal appearing. On a small workspace
list you will not notice; on a big one there is measurably less to do.

## What changed

Two per-workspace allocations that scale with your workspace count were being
rebuilt on inputs that cannot change their result.

**1. `workspaceSurfaces` no longer re-projects on a worktree switch.**

`projectWorkspaceSurfaces` reads `activeWorkspaceId` in exactly one place:

```ts
if (
  activeWorkspaceResolvedHostId &&   // <- short-circuits first
  id === activeWorkspaceId &&
  getStampedFolderWorkspaceHostId(workspace) === activeWorkspaceResolvedHostId
)
```

So the projection is independent of the active id whenever
`activeWorkspaceResolvedHostId` is null — and the call site already computes that
host as `null` unless the active workspace is itself a *folder* workspace
(`parseWorkspaceKey(...)?.type === 'folder'`; a git worktree id is `repoId::path`,
which `parseWorkspaceKey` returns `null` for). The memo nonetheless listed the
active id as a dependency, so every git-worktree switch re-projected every
surface and re-derived the id array to arrive at a byte-identical answer.

The fix passes `null` for the id when there is no host to tie-break with, so the
memo holds. The folder tie-break is untouched: when a host *is* resolved, the id
passed is the same one as before.

**2. The parked-watcher sync no longer allocates an empty `Set` per surface.**

`use-terminal-watcher-effects` built `new Set<string>()` for every workspace
surface, but only the branch gated on `mountedWorktreeIdsRef.current.has(...)`
can ever add to it, and `syncParkedTerminalTabWatchersForWorkspaces` only ever
calls `.has()` on it. Unmounted surfaces now share one read-only empty instance.
Every surface still gets a map entry — that is what lets the batch sync dispose
watchers for closed tabs — only the redundant `Set` is gone.

## Why this is safe

**No effect changed when it fires.** Neither change touches a `useEffect`
dependency array.

- Change 1 is a `useMemo`. Downstream, `workspaceSurfaceIds` is
  `useReusedArrayIdentity(useMemo(() => workspaceSurfaces.map(...), [workspaceSurfaces]))`,
  and `useReusedArrayIdentity` already returned the *previous* array whenever the
  ids were element-wise equal. So `workspaceSurfaceIds` / `workspaceSurfaceIdSet`
  had identical identity behaviour before and after — every effect keyed on them
  (parking pass, watcher sync, browser-guest retention, cold activation) fires on
  exactly the same renders it did before. The only consumers of the
  `workspaceSurfaces` array itself are three components that `.map` it during
  render; they re-render on a switch regardless, because they also read
  `renderedActiveWorktreeId`.
- Change 2 changes one object's identity, not the effect's deps or its map keys.

**Nothing stopped re-running on a worktree switch.** All four worktree-wide
effects flagged in the perf ledger genuinely read `renderedActiveWorktreeId` in
their bodies, so all four keep it as a dependency:

| Site | Reads the id? | Verdict |
| --- | --- | --- |
| `use-terminal-parking-pass.ts:178` | yes, via `collectTerminalParkingPassCandidates` (`isVisible`) | dep kept; this is what parks the worktree you just left |
| `use-terminal-watcher-effects.ts:117` | yes, line 64 (`isVisible`) | dep kept; this is what installs byte watchers over the tabs that just parked |
| `use-terminal-browser-retention.ts:84` | yes, lines 41/45/62 (LRU touch + eviction) | dep kept; this is the guest-retention LRU reorder |
| `use-terminal-workspace-foundation.ts:48` | only behind the folder tie-break | narrowed, with the proof above |

`applyTerminalColdActivation` (called in the render body from
`use-terminal-controller.ts:29`) is also left alone: it mutates the mount refs
during render on purpose so children see the right mount set in the same commit,
and its scans are bounded (`.some()` short-circuits; the prune walks only
worktrees that hold a background-mount restriction).

## Proof

### Deterministic (test-pinned)

| Metric | Before (`origin/main`) | After |
| --- | --- | --- |
| Distinct `workspaceSurfaces` arrays over 400 git-worktree switches, 423 worktrees | **401** | **1** |
| Distinct empty `parkedTabIds` sets per watcher-sync fire, 423 surfaces / 1 mounted | **422** | **1** |

Both numbers come from the new tests, and both tests were confirmed to fail
against `origin/main` source and pass with the change:

- `terminal-workspace-surface-ids.test.tsx` › *keeps the surface projection stable
  across a git-worktree switch* — fails on main with
  `AssertionError: expected [ Array(423) ] to be [ Array(423) ] // Object.is equality`.
- `terminal-parked-watcher-sync-entries.test.tsx` › *does not allocate a
  parked-tab-id set per unmounted surface* — fails on main with
  `AssertionError: expected 422 to be 1`.

### Correctness pins (pass both before and after — they pin the invariant, not the change)

- `workspace-surface-projection.test.ts` › *ignores the active workspace id
  entirely when no resolved host disambiguates* — asserts the projection is
  byte-identical for `activeWorkspaceId` of `null`, a colliding folder key, an
  unrelated folder key, and a worktree id, whenever the resolved host is null.
  This is the exact equivalence the memo gate relies on; if a future change makes
  the projection read the id outside the host guard, this test fails.
- `terminal-workspace-surface-ids.test.tsx` › *still re-projects when the active
  folder workspace owns the collision tie-break* — two folder rows colliding on
  one id across `local` and `runtime:env-1`; asserts the active one mounts
  `/remote/orca`, and that leaving it re-projects to first-wins `/work/orca-local`
  rather than stranding the previous host's path. This is the "the memo still
  re-runs when it must" pin.
- `terminal-parked-watcher-sync-entries.test.tsx` › *publishes an entry for every
  surface so closed-tab disposal still sees it* (423 entries, in order, plus the
  prune call) and › *parks the hidden mounted workspace tabs and exempts the
  eviction-exempt tab*.

### Wall clock (vitest, happy-dom, Apple Silicon; medians of 4 runs x 300-400 iterations)

Watcher-sync effect fire, 423 surfaces / 1 mounted worktree:

| | Before | After |
| --- | --- | --- |
| per fire | **101.2 µs** (99.88 / 94.88 / 102.54 / 104.84) | **68.5 µs** (71.55 / 68.11 / 68.84 / 66.08 / 69.31 / 65.28) |

At 40 surfaces the same effect measures 31.7 µs before vs 32.1 µs after — i.e. no
measurable change, which is expected: only ~39 `Set` allocations are saved there.
This effect fires on 17 dependencies (tab-model writes, portals, pending startups,
background-mount revisions), not only on a switch, so the 423-surface saving
recurs well beyond the switch itself.

`useTerminalWorkspaceFoundation` re-render per git-worktree switch, 423 worktrees:

| | Before | After |
| --- | --- | --- |
| per switch | **184.8 µs** (185.40 / 184.16 / 182.52 / 194.40) | **177.2 µs** (177.94 / 176.51 / 169.84 / 183.25) |

That is ~4%, and the before/after ranges partially overlap, so **treat the
end-to-end switch number as directional, not as a firm result** — the firm
result for change 1 is the deterministic 401 -> 1 projection count. Isolating just
the eliminated work (`projectWorkspaceSurfaces` + `.map` + `reuseArrayIfEqual`
over 20,000 iterations) gives **3.52 µs/switch at 423 worktrees** and
**0.47 µs/switch at 40**, plus the 423 surface objects and two arrays per switch
that no longer reach the GC.

### Not measured

No real-app (Electron) frame-time measurement was taken for either change. The
per-switch saving from change 1 (single-digit µs) is below the noise floor of the
available first-paint harness, so a real-app A/B would not have produced a
trustworthy number; the deterministic allocation counts are the honest evidence.

## Verification run

- `pnpm tc` — clean
- `pnpm test src/renderer` — 3704 files / 30940 tests passed, 2 files / 6 tests skipped
- `pnpm test src/renderer/src/components/terminal-pane/ src/renderer/src/components/terminal/ <new tests>` — 472 files / 4513 tests passed
- `npx oxlint <touched files>` — clean; `npx oxfmt --check <touched files>` — clean
- `pnpm run check:code-quality:changed` — `0 new finding(s)` for code quality, type-aware quality, and React Doctor across 6 changed files
- e2e (`--project=electron-headless --workers=1`, `ORCA_BACKGROUND_LAUNCH=1`, no window shown):
  - `terminal-hidden-view-parking` + `terminal-retention-budget` + `terminal-parked-memory` — 7 passed, 1 skipped
  - `terminal-pane-content-retention` + `terminal-parked-close-retirement` + `terminal-pinned-viewport-worktree-switch` + `terminal-osc8-cold-park-restore` — 6 passed
  - `browser-guest-attachment-validation` — 1 passed

`worktree-switch-responsiveness.spec.ts` is a known pre-existing flake in this
environment and was not used as a signal.

## Cross-cutting cases

- **Folder workspaces:** the only behaviour the narrowed dep could affect. Covered
  by the new hook test (folder collision across `local` / `runtime:env-1`, and the
  transition off it) and by the existing `projectWorkspaceSurfaces` suite.
- **SSH / paired-runtime execution hosts:** the tie-break input is the *resolved*
  execution host, unchanged here; the remote-host collision cases in
  `workspace-surface-projection.test.ts` (STA-4343 / STA-4846) still pass.
- **Remote wire:** no RPC params, stream frames, or published content touched.
- **Cross-platform:** renderer-only, no paths, no process spawning, no shortcuts.
