### PR TITLE
fix(runtime): refuse an agent-prompt write into a live credential prompt

### DIFF
--- a/src/main/runtime/orca-runtime-resolve-authoritative-terminal-wait-permission.ts
+++ b/src/main/runtime/orca-runtime-resolve-authoritative-terminal-wait-permission.ts
@@ -3,7 +3,10 @@ import { OrcaRuntimeWithAgentPromptRequestCorrelation } from './orca-runtime-age
 import type { RuntimeTerminalAgentStatusSnapshot } from './runtime-terminal-agent-status-query'
 import type { AgentStatus } from '../../shared/agent-detection'
 import type { RuntimeTerminalWaitBlockedReason } from '../../shared/runtime-types'
-import { detectTerminalWaitBlockedReason } from './terminal-wait-detection'
+import {
+  detectTerminalWaitBlockedReason,
+  isUnconditionalTerminalWaitBlockedReason
+} from './terminal-wait-detection'
 import { isOpenCodeNativeTitle } from '../../shared/agent-detection'
 import type { AgentStatusEntry } from '../../shared/agent-status-types'
 import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
@@ -31,11 +34,11 @@ export class OrcaRuntimeWithResolveAuthoritativeTerminalWaitPermission extends O
       terminal.titleStatus !== null &&
       terminal.titleStatus !== 'permission' &&
       !isOpenCodeNativeTitle(terminal.title) &&
-      blockedByWaitText !== 'agent-approval-prompt'
+      !isUnconditionalTerminalWaitBlockedReason(blockedByWaitText)
     if (liveTitleClearsBlockedText && lifecycle?.status !== terminal.titleStatus) {
       return null
     }
-    if (blockedByWaitText === 'agent-approval-prompt') {
+    if (isUnconditionalTerminalWaitBlockedReason(blockedByWaitText)) {
       return blockedByWaitText
     }
     const newestPermissionAt = Math.max(

--- a/src/main/runtime/runtime-terminal-agent-status-query.ts
+++ b/src/main/runtime/runtime-terminal-agent-status-query.ts
@@ -13,7 +13,10 @@ import {
   terminalTitleBlocksExplicitAgentStatus,
   getLatestAgentCandidateTitleInfo
 } from './runtime-worktree-status-projection'
-import { detectTerminalWaitBlockedReason } from './terminal-wait-detection'
+import {
+  detectTerminalWaitBlockedReason,
+  isUnconditionalTerminalWaitBlockedReason
+} from './terminal-wait-detection'
 import { getTerminalState } from './terminal-wait-results'
 import { buildTerminalWaitText } from './terminal-wait-tail-state'
 
@@ -72,7 +75,7 @@ export class RuntimeTerminalAgentStatusQuery {
       terminal.titleStatus !== null &&
       terminal.titleStatus !== 'permission' &&
       !isOpenCodeNativeTitle(terminal.title) &&
-      blockedByWaitText !== 'agent-approval-prompt'
+      !isUnconditionalTerminalWaitBlockedReason(blockedByWaitText)
     const newestPermissionAt = Math.max(
       explicitStatus?.status === 'permission' ? explicitStatus.updatedAt : -1,
       lifecycle?.status === 'permission' ? lifecycle.updatedAt : -1,
@@ -88,7 +91,7 @@ export class RuntimeTerminalAgentStatusQuery {
     if (
       blockedByWaitText &&
       (!liveTitleClearsBlockedText || lifecycle?.status === terminal.titleStatus) &&
-      (blockedByWaitText === 'agent-approval-prompt' ||
+      (isUnconditionalTerminalWaitBlockedReason(blockedByWaitText) ||
         (newestPermissionAt >= 0 && newestPermissionAt >= newestClearAt))
     ) {
       return { handle, isRunningAgent: true, status: 'permission' }

--- a/src/main/runtime/terminal-credential-prompt-detection.test.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.test.ts
@@ -85,7 +85,22 @@ const LIVE_CREDENTIAL_SURFACES: readonly (readonly [string, string[]])[] = [
   ['access token ask', ['Provide your access token:']],
   ['otp ask', ['Type your OTP:']],
   ['bare credentials label', ['credentials:']],
-  ['device code ask', ['Enter device code:']]
+  ['device code ask', ['Enter device code:']],
+  [
+    'gh auth login device code',
+    [
+      '! First copy your one-time code: 1A2B-3C4D',
+      'Press Enter to open github.com in your browser...'
+    ]
+  ],
+  [
+    'claude /login paste-code screen',
+    [
+      "Browser didn't open? Use the url below to sign in:",
+      'https://claude.ai/oauth/authorize?code=true',
+      'Paste code here if prompted >'
+    ]
+  ]
 ]
 
 const LEGITIMATE_AGENT_SCREENS: readonly (readonly [string, string[]])[] = [
@@ -242,6 +257,132 @@ const LEGITIMATE_AGENT_SCREENS: readonly (readonly [string, string[]])[] = [
     [
       '• The gh CLI says authentication failed; I skipped the PR step.',
       '',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  // An agent SUMMARISING auth work it just finished, with its own composer on the last row.
+  // These pair an auth verb with an auth-flow phrase, which is the shape that used to match
+  // with no prompt terminator and no position requirement at all.
+  [
+    'codex summarising two-factor work',
+    [
+      '• I implemented two-factor authentication for the login flow.',
+      '  The authenticator app now generates a 6-digit code.',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'claude summarising two-factor work',
+    [
+      '· Added two-factor authentication. Tests for the authenticator app pass.',
+      '✳ Claude Code',
+      '> '
+    ]
+  ],
+  [
+    'codex summarising a sign-in button',
+    [
+      '• Added a Sign in with Google button; it logs the authorization result.',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'codex reporting an auth error it hit',
+    [
+      '  └ ERROR: authentication required. Please sign in with the CLI.',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'agent asking whether MFA is wanted',
+    ['· Should the app require MFA, or is authentication via password enough?', '> ']
+  ],
+  [
+    'codex summarising a device-code flow it built',
+    [
+      '• The OAuth flow now shows a device code and waits for authentication.',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'rg hit on auth documentation',
+    ['  └ docs/auth.md:12: Users authenticate with the authenticator app.', '> ']
+  ],
+  [
+    'rg hits on a login component',
+    [
+      '  └ src/Login.tsx:31:  <button>Sign in with GitHub</button>',
+      '  └ src/Login.tsx:44:  // authorization code exchange',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'codex reporting MFA tests passing',
+    ['• All MFA tests pass; authentication is wired end to end.', '› Ask Codex to do anything']
+  ],
+  [
+    'codex quoting a build failure',
+    [
+      "• The build failed: 'authorization required'. You need to log in with `vercel login`.",
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'rg hit on a readme auth section',
+    [
+      '  └ docs/auth.md:3: ## Authentication',
+      '    Users sign in with GitHub or an authenticator app.',
+      '> '
+    ]
+  ],
+  [
+    'claude summarising an oauth change',
+    [
+      '· Done — the OAuth login now requires authentication via the device code flow.',
+      '✳ Claude Code',
+      '> '
+    ]
+  ],
+  [
+    'gemini summarising SSO work',
+    ['✦ Added SSO. Users authenticate with Okta; the sign in with SAML path is tested.', '◇ ']
+  ],
+  [
+    'opencode wrapping an auth summary',
+    [
+      'Added requireAuth middleware. Unauthenticated requests get 401; sign in with the',
+      'token endpoint returns a JWT.',
+      '❯ '
+    ]
+  ],
+  [
+    'stack trace over a codex composer',
+    [
+      'Error: authentication required',
+      '    at signInWithToken (auth.ts:22)',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'shell deploy failure',
+    [
+      'Running deploy...',
+      'ERROR: authentication required',
+      'Please sign in with the CLI and retry.',
+      'exit code 1'
+    ]
+  ],
+  // Printed config whose bare `password:` label is not the screen's bottom row.
+  [
+    'printed kubernetes secret manifest',
+    ['kind: Secret', 'stringData:', '      password:', '› Ask Codex to do anything']
+  ],
+  [
+    'printed signup form template',
+    [
+      '• The signup form now has these fields:',
+      '  email:',
+      '  password:',
       '› Ask Codex to do anything'
     ]
   ]

--- a/src/main/runtime/terminal-credential-prompt-detection.test.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.test.ts
@@ -100,6 +100,42 @@ const LIVE_CREDENTIAL_SURFACES: readonly (readonly [string, string[]])[] = [
       'https://claude.ai/oauth/authorize?code=true',
       'Paste code here if prompted >'
     ]
+  ],
+  // The dialog this guard was written for (F19749-1). A numbered menu of credential actions
+  // ending in a bare `>` caret: no terminator anywhere, so only the row-final noun carries it.
+  [
+    'antigravity sign-in menu over ready chrome',
+    [
+      'Antigravity CLI 1.0.3',
+      'user@example.com (Antigravity Business)',
+      'Sign in to continue',
+      '~/orca/workspaces/orca/agy-dispatch-issue',
+      '1. Open browser',
+      '2. Paste an API key',
+      '>'
+    ]
+  ],
+  ['vendor-qualified indented api-key ask', ['  Enter your Antigravity API key:']],
+  // sudo translates its prompt but never its `[sudo]` tag, and the only thing it asks for is a
+  // password. An English-only rule here misses every non-English desktop.
+  ['sudo password on a German system', ['[sudo] Passwort für neil:']],
+  ['sudo password on a zh-TW system', ['[sudo] neil 的密碼：']],
+  ['sudo retry notice', ['[sudo] Sorry, try again.', '[sudo] password for neil:']],
+  // The common api-key ask names the env var it fills, so the noun carries an underscore.
+  [
+    'aider env-var api-key ask',
+    ['Aider v0.86.1', 'Model: gpt-6 with diff edit format', '', 'Enter your OPENAI_API_KEY:']
+  ],
+  ['bare env-var api-key label', ['ANTHROPIC_API_KEY:']],
+  ['waiting on the user to sign in', ['Waiting for you to sign in…']],
+  [
+    'crush api-key onboarding dialog',
+    [
+      '╭─ Crush ──────────╮',
+      '│  Connect your model provider           │',
+      '│  Paste your API key here:              │',
+      '╰────────────╯'
+    ]
   ]
 ]
 
@@ -385,6 +421,85 @@ const LEGITIMATE_AGENT_SCREENS: readonly (readonly [string, string[]])[] = [
       '  password:',
       '› Ask Codex to do anything'
     ]
+  ],
+  // Records, not requests: the auth phrase is quoted inside a line whose subject is something
+  // else, and nothing under it repaints a composer caret.
+  [
+    'git log ending on a sign-in commit subject',
+    [
+      '$ git log --oneline -3',
+      'a1b2c3d fix(auth): drop the stale authorization header',
+      'd4e5f6a feat(auth): sign in with GitHub'
+    ]
+  ],
+  ['single sign-in commit subject', ['d4e5f6a feat(auth): sign in with GitHub']],
+  [
+    'changelog entry for a sign-in feature',
+    ['## Unreleased', '- feat(auth): sign in with Apple support']
+  ],
+  [
+    'checklist item for a sign-in button',
+    ['Plan:', '  [x] add session cookie', '  [ ] add sign in with Google button']
+  ],
+  [
+    'error summary quoting an auth failure',
+    ['• Fixed the deploy step', '• Root cause: authentication required from the vercel CLI']
+  ],
+  [
+    'rg hits ending the screen on a sign-in match',
+    [
+      '$ rg "sign in with" src/',
+      'src/Login.tsx:31:  <button>Sign in with GitHub</button>',
+      'src/Login.tsx:44:  // authorization code exchange happens here'
+    ]
+  ],
+  // "waiting for you to ..." is how every agent narrates waiting on a human, auth or not.
+  [
+    'agent waiting on a diff review after login work',
+    ['• Updated the login page copy', 'Waiting for you to review the diff']
+  ],
+  [
+    'agent waiting on a branch choice after authorization work',
+    ['• Rebased the authorization middleware', 'Waiting for you to choose a base branch']
+  ],
+  // Localized narration: the wording it embeds is English, the punctuation is not.
+  [
+    'zh-TW narration of a failed deploy on the bottom row',
+    ['$ pnpm deploy', '錯誤：authentication required，請先執行 gh auth login']
+  ],
+  [
+    'german narration of login work on the bottom row',
+    [
+      '• Anmeldung überarbeitet',
+      '• Der Nutzer kann sich jetzt per sign in with Google authentifizieren'
+    ]
+  ],
+  // The sibling dialogs of the Antigravity sign-in menu, same chrome and same bare `>` caret.
+  [
+    'antigravity model picker',
+    [
+      'Antigravity CLI 1.0.3',
+      'user@example.com (Antigravity Business)',
+      'Select a model',
+      '~/orca/workspaces/orca/agy-dispatch-issue',
+      '1. Claude Sonnet 4.5',
+      '2. GPT-5.1',
+      '>'
+    ]
+  ],
+  [
+    'antigravity privacy notice',
+    [
+      'Antigravity CLI 1.0.3',
+      'We collect usage data to improve the product',
+      '1. Accept',
+      '2. Decline',
+      '>'
+    ]
+  ],
+  [
+    'dotenv example printed by the agent',
+    ['$ cat .env.example', 'DATABASE_URL=', 'API_KEY=', 'SESSION_SECRET=']
   ]
 ]
 
@@ -420,6 +535,39 @@ describe('findCredentialPromptIndex', () => {
       const matched = lines.some((line) => TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE.test(line))
       expect(matched, name).toBe(true)
     }
+  })
+
+  it('keeps the sentinel a superset over every screen, not just the ones we expect to block', () => {
+    // Why both corpora: asserting the superset only over screens we already believe block makes
+    // the test as biased as the corpus. The invariant is about the detector's OWN verdict -- any
+    // screen it matches must survive the prefilter -- and that is what caught this lane silently
+    // passing the Antigravity sign-in menu.
+    for (const [name, lines] of [...LIVE_CREDENTIAL_SURFACES, ...LEGITIMATE_AGENT_SCREENS]) {
+      if (findCredentialPromptIndex(screen(lines).toLowerCase()) === null) {
+        continue
+      }
+      const matched = lines.some((line) => TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE.test(line))
+      expect(matched, name).toBe(true)
+    }
+  })
+
+  it('keeps the sentinel linear on adversarial lines', () => {
+    // The sentinel runs per retained tail line at streaming rate, so a variable-length prefix
+    // inside its noun alternation is not a style question: the obvious way to spell the env-var
+    // vendor slot (`(?:[a-z0-9]+_)?api[ _-]?key`) costs 30ms on one 5.5k-char line, ~1000x this
+    // budget, and stalls the whole tail index.
+    const lines = [
+      `${'a'.repeat(5000)}${'_'.repeat(500)}`,
+      `${'a_'.repeat(2500)}api key${'x'.repeat(200)}`,
+      'passwordx'.repeat(500)
+    ]
+    const started = performance.now()
+    for (let run = 0; run < 100; run += 1) {
+      for (const line of lines) {
+        TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE.test(line)
+      }
+    }
+    expect(performance.now() - started).toBeLessThan(500)
   })
 
   it('does not fire on any realistic terminal title', () => {

--- a/src/main/runtime/terminal-credential-prompt-detection.test.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.test.ts
@@ -500,6 +500,115 @@ const LEGITIMATE_AGENT_SCREENS: readonly (readonly [string, string[]])[] = [
   [
     'dotenv example printed by the agent',
     ['$ cat .env.example', 'DATABASE_URL=', 'API_KEY=', 'SESSION_SECRET=']
+  ],
+  // Plain source code printed into the pane -- the category this corpus lacked. It had `rg` hits
+  // and diffs, which carry their own chrome, but not bare formatted source. Every line below was
+  // mined from this repo's tracked files and refused a prompt above a real composer caret: oxfmt
+  // renders a ternary consequent as a bare `?` row (5,666 tracked files have one), `.login` reads
+  // as the auth verb "log in", and prose that merely ENDS on a credential noun read as an ask.
+  [
+    'ternary consequent with a sign-in string',
+    [
+      "      ? 'Update desktop Orca and sign in to connect from anywhere'",
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'ternary consequent with an authentication template literal',
+    ['        ? `replacement session authentication timed out (${stage})`', '> ']
+  ],
+  [
+    'ternary consequent with a login error',
+    ['              ? `Codex login failed: ${trimmedOutput}`', '❯ ']
+  ],
+  [
+    'ternary consequent calling a login spawn builder',
+    [
+      "      ? buildWindowsHostInteractiveLoginSpawn(codexCommand, ['login'])",
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'ternary consequent with a sign-in status string',
+    ["        ? 'Timed out while checking Codex sign-in status'", '> ']
+  ],
+  [
+    'ternary consequent reading an authorization basis',
+    ['        ? this.originPool.controlForBasis(authorization.basisConnId)', '❯ ']
+  ],
+  [
+    'ternary consequent building a gh auth command',
+    ['    ? `gh auth login --hostname ${host}`', '› Ask Codex to do anything']
+  ],
+  [
+    'ternary consequent with a translated sign-in-again label',
+    ["                ? translate('settings.signInAgain', 'Sign in again')", '❯ ']
+  ],
+  [
+    'ternary consequent with a pat docs url',
+    [
+      "        ? 'https://learn.microsoft.com/azure/devops/accounts/use-pat-to-authenticate'",
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'ternary filtering assignees by login',
+    ['    ? prevAssignees.filter((l) => l !== login)', '› Ask Codex to do anything']
+  ],
+  [
+    'ternary narrowing a login to a string',
+    ["            ? overrides.filter((login): login is string => typeof login === 'string')", '> ']
+  ],
+  [
+    'ternary removing assignees by login',
+    ['                          ? { removeAssignees: [user.login] }', '❯ ']
+  ],
+  [
+    'ternary mapping project assignees',
+    [
+      '                  ? projectRowDetail.assignees.map((login) => ({',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'ternary removing a reviewer by login',
+    ['      ? handleRemoveReviewers([reviewer.login])', '> ']
+  ],
+  [
+    'ternary editing assignees by login',
+    ['                      ? onEditAssignees?.([], [user.login])', '❯ ']
+  ],
+  [
+    'ternary lowercasing an assignee login',
+    [
+      '        ? prevAssignees.filter((user) => user.login.toLowerCase() !== lowerLogin)',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'ternary building an assignee removal patch',
+    ["        ? { family: 'assignees', kind: 'remove', logins: [login] }", '❯ ']
+  ],
+  [
+    'wrapped comment ending on a credential noun',
+    ['    // Why: a merely missing or expired bundle must not enter the credential', '❯ ']
+  ],
+  [
+    'wrapped comment ending on a password noun',
+    ['    // The caller must provide the current password', '› Ask Codex to do anything']
+  ],
+  [
+    'wrapped jsdoc ending on an api key noun',
+    ['   * Callers are expected to paste their API key', '> ']
+  ],
+  // No caret, and the bottom row DOES lead with an action phrase, so the only thing keeping this
+  // from reading as a live prompt is that `candidate.login` is a property access.
+  [
+    'source rows where a .login access is the only would-be auth verb',
+    [
+      '    const owner = candidate.login',
+      '    // Enter the code below to finish linking the account'
+    ]
   ]
 ]
 

--- a/src/main/runtime/terminal-credential-prompt-detection.test.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.test.ts
@@ -604,6 +604,17 @@ const LEGITIMATE_AGENT_SCREENS: readonly (readonly [string, string[]])[] = [
   // No caret, and the bottom row DOES lead with an action phrase, so the only thing keeping this
   // from reading as a live prompt is that `candidate.login` is a property access.
   [
+    'source comment leading with an action phrase, corroborated by the comment above it',
+    [
+      '    // See the authentication guide for details',
+      '    // Sign in with the provider console to continue'
+    ]
+  ],
+  [
+    'source rows where a .credential access is the only would-be credential noun',
+    ['    const owner = candidate.credential', '    Enter the code below to finish linking']
+  ],
+  [
     'source rows where a .login access is the only would-be auth verb',
     [
       '    const owner = candidate.login',

--- a/src/main/runtime/terminal-credential-prompt-detection.test.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.test.ts
@@ -1,0 +1,326 @@
+// The guard exists because any readiness detector can be wrong, so this suite is a
+// two-sided corpus rather than a handful of examples: every LIVE_CREDENTIAL_SURFACE must
+// block, and every LEGITIMATE_AGENT_SCREEN must not. A false negative types the user's task
+// prompt into a credential field; a false positive only defers until the dialog is answered.
+import { describe, expect, it } from 'vitest'
+import {
+  findCredentialPromptIndex,
+  TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE
+} from './terminal-credential-prompt-detection'
+import {
+  detectTerminalWaitBlockedReason,
+  isKnownReadyPromptPreview
+} from './terminal-wait-detection'
+import { TERMINAL_TITLE_CLASSIFICATION_CORPUS } from '../../shared/terminal-title-classification-corpus'
+
+function screen(lines: string[]): string {
+  return lines.join('\n')
+}
+
+const LIVE_CREDENTIAL_SURFACES: readonly (readonly [string, string[]])[] = [
+  [
+    'antigravity device-code sign-in drawn over ready chrome (#19749)',
+    [
+      'Antigravity CLI',
+      'gemini 3 pro (high)',
+      '~/orca/workspaces/orca/crash-closer',
+      '>',
+      '',
+      '  Sign in to Antigravity',
+      '  Open https://antigravity.google/device and enter the code: KXTD-9PQR',
+      '  Waiting for authentication…'
+    ]
+  ],
+  [
+    'antigravity auth-method menu over ready chrome',
+    [
+      'Antigravity CLI',
+      'gemini 3 pro (high)',
+      '>',
+      '',
+      '? How would you like to authenticate?',
+      '❯ Sign in with Google',
+      '  Use an API key'
+    ]
+  ],
+  [
+    'api-key prompt under a complete Codex ready header',
+    [
+      'OpenAI Codex',
+      'model: gpt-6',
+      'directory: ~/repo',
+      '',
+      '› Ask Codex to do anything',
+      '',
+      'Enter your API key:'
+    ]
+  ],
+  ['bare api-key ask', ['Enter your API key: ']],
+  ['vendor-qualified api-key ask with a caret', ['? Enter your Anthropic API key ›']],
+  ['bare password label', ['Password:']],
+  ['lowercase password label', ['password: ']],
+  ['sudo password', ['[sudo] password for neil:']],
+  ['ssh key passphrase', ["Enter passphrase for key '/Users/neil/.ssh/id_ed25519':"]],
+  ['git username', ["Username for 'https://github.com': "]],
+  ['git password', ["Password for 'https://neil@github.com': "]],
+  ['sms verification code', ['Enter the verification code we sent to your phone:']],
+  ['one-time code', ['Enter your one-time code:']],
+  [
+    'two-factor dialog',
+    ['Two-factor authentication', 'Enter the 6-digit code from your authenticator app:']
+  ],
+  ['personal access token paste', ['Paste your personal access token here:']],
+  ['sign-in wall', ['Authentication required', 'Sign in with GitHub to continue']],
+  [
+    'oauth device-code flow',
+    [
+      'Please open the following url in your browser:',
+      '  https://github.com/login/device',
+      '',
+      'and enter the code: ABCD-1234'
+    ]
+  ],
+  ['client secret', ['Enter client secret:']],
+  ['password confirmation', ['Re-enter password:']],
+  ['access token ask', ['Provide your access token:']],
+  ['otp ask', ['Type your OTP:']],
+  ['bare credentials label', ['credentials:']],
+  ['device code ask', ['Enter device code:']]
+]
+
+const LEGITIMATE_AGENT_SCREENS: readonly (readonly [string, string[]])[] = [
+  // An agent narrating credential work and returning to its composer.
+  [
+    'codex narrating password hashing',
+    [
+      '• I added bcrypt password hashing to src/auth/user.ts.',
+      '',
+      '› Ask Codex to do anything',
+      '',
+      '  gpt-6 medium · ~/repo'
+    ]
+  ],
+  [
+    'codex narrating api-key wiring',
+    ['• Wired the API key into .env.example and documented it.', '', '› Ask Codex to do anything']
+  ],
+  [
+    'claude narrating login work',
+    ['· Updated the login form to use the new session cookie.', '', '✳ Claude Code', '', '> ']
+  ],
+  [
+    'codex narrating an oauth refresh',
+    [
+      '• Done. The OAuth device-code flow now refreshes the access token.',
+      '',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'claude narrating a secret rotation',
+    ['· I rotated the client secret and pushed the change.', '', '> ']
+  ],
+  // An agent legitimately ASKING the user something credential-adjacent.
+  [
+    'agent asks where to store a password',
+    [
+      '· Should I store the password in the .env file or in the keychain?',
+      '',
+      '✳ Claude Code',
+      '',
+      '> '
+    ]
+  ],
+  [
+    'agent asks about reading an api key',
+    ['· Do you want me to read your api key from process.env.OPENAI_API_KEY?', '', '> ']
+  ],
+  [
+    'agent asks which auth provider',
+    ['· Which auth provider should the sign in page use?', '', '> ']
+  ],
+  [
+    'agent asks about a token in CI',
+    ['· I need to know: does your CI already have a personal access token?', '', '> ']
+  ],
+  [
+    'agent asks where a template goes',
+    ['· Where should I put the verification code template?', '', '> ']
+  ],
+  ['agent asks about OTP expiry', ['· Should the OTP expire after 5 minutes or 10?', '', '> ']],
+  [
+    'agent asks about 2FA delivery',
+    ['· Do you want 2FA codes emailed or via authenticator app?', '', '> ']
+  ],
+  [
+    'agent narrates an upcoming passphrase edit',
+    ['· Ready. Next I will enter the passphrase handling into the key loader.', '', '> ']
+  ],
+  [
+    'agent narrates an api-key edit mid-sentence',
+    ['· I will enter the API key into the vault once you confirm the vault name', '', '> ']
+  ],
+  [
+    'agent asks which secret key to rotate',
+    ['· Please tell me which secret key you want rotated first', '', '> ']
+  ],
+  // The user's own task prompt echoed above the composer.
+  ['echoed login task prompt', ['> Implement the login form', '', '· Working…']],
+  [
+    'echoed password-reset task prompt',
+    ['> add password reset via one-time code', '', '· Working…']
+  ],
+  [
+    'echoed credentials task prompt',
+    ['> Refactor the credentials module', '', '✳ Claude Code', '', '> ']
+  ],
+  // Search output quoting credential-shaped source, the shape that broke earlier detectors.
+  [
+    'rg hit on a password call',
+    [
+      '  └ src/auth.ts:42:  const password = await promptPassword()',
+      '',
+      '› Ask Codex to do anything'
+    ]
+  ],
+  [
+    'rg hit on an api-key label literal',
+    ["  └ 118:    label: 'Enter your API key'", '', '› Ask Codex to do anything']
+  ],
+  [
+    'rg hit on a password test name',
+    ["  └ tests/auth.test.ts:9:  it('prompts for password', () => {", '', '> ']
+  ],
+  [
+    'search narration quoting a prompt',
+    ['  └ Search "enter your password" in src/', '', '› Ask Codex to do anything']
+  ],
+  // A diff that ADDS a credential prompt string.
+  [
+    'diff adding an api-key log',
+    ['+  console.log("Enter your API key:")', '', '› Ask Codex to do anything']
+  ],
+  ['diff adding a password prompt field', ['+    prompt: "Password:"', '', '> ']],
+  // Other terminal traffic.
+  [
+    'cursor approval menu',
+    [
+      'Run this command?',
+      '  cat ~/.ssh/id_rsa',
+      '  Run (once) (enter)',
+      '  Skip & tell the agent (esc)'
+    ]
+  ],
+  [
+    'vitest auth suite output',
+    [
+      '  ✓ auth > rejects an expired access token (4 ms)',
+      '  ✓ auth > hashes the password with argon2 (9 ms)',
+      '',
+      'Test Files  1 passed'
+    ]
+  ],
+  [
+    'jest login suite output',
+    ['PASS src/login.test.ts', '', '  ● login form › submits credentials', '', '> ']
+  ],
+  [
+    'git push rejection',
+    [
+      'remote: Support for password authentication was removed.',
+      'fatal: Authentication failed',
+      '$ '
+    ]
+  ],
+  ['clean git push', ['Everything up-to-date', '$ ']],
+  [
+    'rendered readme auth section',
+    ['## Authentication', '', 'Set `ORCA_API_KEY` in your environment before running.', '', '$ ']
+  ],
+  [
+    'agent narrating a failed gh auth',
+    [
+      '• The gh CLI says authentication failed; I skipped the PR step.',
+      '',
+      '› Ask Codex to do anything'
+    ]
+  ]
+]
+
+describe('findCredentialPromptIndex', () => {
+  it.each(LIVE_CREDENTIAL_SURFACES)('blocks %s', (_name, lines) => {
+    expect(findCredentialPromptIndex(screen(lines).toLowerCase())).not.toBeNull()
+  })
+
+  it.each(LEGITIMATE_AGENT_SCREENS)('does not fire on %s', (_name, lines) => {
+    expect(findCredentialPromptIndex(screen(lines).toLowerCase())).toBeNull()
+  })
+
+  it('ignores an answered credential prompt that scrolled out of the live window', () => {
+    const tail = screen([
+      'Enter your API key:',
+      '',
+      'Signed in as neil@example.com.',
+      '',
+      'OpenAI Codex',
+      'model: gpt-6',
+      'directory: ~/repo',
+      '',
+      '› Ask Codex to do anything'
+    ])
+    expect(findCredentialPromptIndex(tail.toLowerCase())).toBeNull()
+    expect(detectTerminalWaitBlockedReason(tail)).toBeNull()
+  })
+
+  it('keeps the sentinel a superset of everything the detector matches', () => {
+    // The retained-tail index skips any tail the sentinel rejects, so a detector match the
+    // sentinel misses would never be parsed at all.
+    for (const [name, lines] of LIVE_CREDENTIAL_SURFACES) {
+      const matched = lines.some((line) => TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE.test(line))
+      expect(matched, name).toBe(true)
+    }
+  })
+
+  it('does not fire on any realistic terminal title', () => {
+    for (const title of TERMINAL_TITLE_CLASSIFICATION_CORPUS) {
+      expect(findCredentialPromptIndex(title.toLowerCase()), title).toBeNull()
+    }
+  })
+})
+
+describe('credential prompts reach the wait-blocked vocabulary', () => {
+  it.each(LIVE_CREDENTIAL_SURFACES)('reports agent-credential-prompt for %s', (_name, lines) => {
+    expect(detectTerminalWaitBlockedReason(screen(lines))).toBe('agent-credential-prompt')
+  })
+
+  it('refuses to call the #19749 screen a ready prompt', () => {
+    // HEAD's Antigravity readiness rule (header, a gemini model row, a lone `>` caret) is all
+    // present here, which is exactly why the detector reported ready while the dialog was live.
+    const tail = screen([
+      'Antigravity CLI',
+      'gemini 3 pro (high)',
+      '>',
+      '',
+      '  Sign in to Antigravity',
+      '  Open https://antigravity.google/device and enter the code: KXTD-9PQR',
+      '  Waiting for authentication…'
+    ])
+    expect(isKnownReadyPromptPreview(tail)).toBe(false)
+    expect(detectTerminalWaitBlockedReason(tail)).toBe('agent-credential-prompt')
+  })
+
+  it('is not cleared by a ready caret drawn elsewhere on the screen', () => {
+    // Every other blocked reason is dismissible by a live prompt; this one must not be, or the
+    // agent's own input box would vouch for the dialog covering it.
+    const tail = screen([
+      'OpenAI Codex',
+      'model: gpt-6',
+      'directory: ~/repo',
+      '› Ask Codex to do anything',
+      '',
+      'Authentication required',
+      'Sign in with GitHub to continue'
+    ])
+    expect(detectTerminalWaitBlockedReason(tail)).toBe('agent-credential-prompt')
+  })
+})

--- a/src/main/runtime/terminal-credential-prompt-detection.test.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.test.ts
@@ -615,6 +615,37 @@ const LEGITIMATE_AGENT_SCREENS: readonly (readonly [string, string[]])[] = [
     ['    const owner = candidate.credential', '    Enter the code below to finish linking']
   ],
   [
+    'bare identifier ternary above a codex caret and its model footer',
+    ['      ? login', '', '\u203a Ask Codex to do anything', '', '  gpt-6 medium \u00b7 ~/repo']
+  ],
+  [
+    'bare identifier ternary above an opencode caret and status bar',
+    ['      ? authorization', '', '\u276f ', 'opencode  anthropic/claude-opus-4  ~/repo']
+  ],
+  [
+    'ternary above a codex caret and its model footer',
+    [
+      "      ? 'Update desktop Orca and sign in to connect from anywhere'",
+      '',
+      '\u203a Ask Codex to do anything',
+      '',
+      '  gpt-6 medium \u00b7 ~/repo'
+    ]
+  ],
+  [
+    'login access above an opencode caret and status bar',
+    [
+      '        ? prevAssignees.filter((user) => user.login.toLowerCase() !== lowerLogin)',
+      '',
+      '\u276f ',
+      'opencode  anthropic/claude-opus-4  ~/repo'
+    ]
+  ],
+  [
+    'personal_access_token identifier cannot corroborate',
+    ['    const owner = candidate.personal_access_token', '    Enter the code below to finish']
+  ],
+  [
     'source rows where a .login access is the only would-be auth verb',
     [
       '    const owner = candidate.login',

--- a/src/main/runtime/terminal-credential-prompt-detection.test.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.test.ts
@@ -4,6 +4,7 @@
 // prompt into a credential field; a false positive only defers until the dialog is answered.
 import { describe, expect, it } from 'vitest'
 import {
+  CREDENTIAL_NOUN_RE_FOR_BUDGET,
   findCredentialPromptIndex,
   TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE
 } from './terminal-credential-prompt-detection'
@@ -116,6 +117,9 @@ const LIVE_CREDENTIAL_SURFACES: readonly (readonly [string, string[]])[] = [
     ]
   ],
   ['vendor-qualified indented api-key ask', ['  Enter your Antigravity API key:']],
+  // A bracketed confirm default is a mainstream prompt convention (apt, readline, enquirer).
+  ['bracketed confirm default', ['? Authenticate with the CLI? [Y/n]']],
+  ['bracketed sign-in confirm', ['? Sign in with GitHub? [y/N]']],
   // sudo translates its prompt but never its `[sudo]` tag, and the only thing it asks for is a
   // password. An English-only rule here misses every non-English desktop.
   ['sudo password on a German system', ['[sudo] Passwort für neil:']],
@@ -700,6 +704,25 @@ describe('findCredentialPromptIndex', () => {
       const matched = lines.some((line) => TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE.test(line))
       expect(matched, name).toBe(true)
     }
+  })
+
+  it('keeps the lookbehind-bearing rules linear, not just the sentinel', () => {
+    // The sentinel is built from the RAW noun source and carries no lookbehind, so a budget that
+    // only exercises it is blind to the rule that has one. Nor can this be measured through
+    // `findCredentialPromptIndex`: MAX_CREDENTIAL_LINE_LENGTH caps every row at 512, where a
+    // quadratic lookbehind is still only ~1.7x a linear one. Drive the regex and assert the class.
+    const cost = (length: number): number => {
+      const line = `const owner = candidate.${'a'.repeat(length)}`
+      const started = performance.now()
+      for (let run = 0; run < 200; run += 1) {
+        CREDENTIAL_NOUN_RE_FOR_BUDGET.test(line)
+      }
+      return (performance.now() - started) / 200
+    }
+    cost(512)
+    const base = cost(1024)
+    const quadrupled = cost(4096)
+    expect(quadrupled).toBeLessThan(base * 8)
   })
 
   it('keeps the sentinel linear on adversarial lines', () => {

--- a/src/main/runtime/terminal-credential-prompt-detection.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.ts
@@ -56,12 +56,19 @@ export const CREDENTIAL_NOUN_SOURCE =
 // one-character check misses `candidate.personal_access_token` — the dot precedes `personal`, not
 // `access_token`. Anchoring on the dot at the START of the identifier catches the whole family.
 // Still only `.`: the env-var ask (`OPENAI_API_KEY`) has no dot and is a real prompt.
-// Why the {0,40} bound and not `*`: unbounded, this is QUADRATIC — the engine retries the
-// lookbehind from every position in an identifier run, so a 4096-char run costs 4.6ms against
-// 369us bounded, and doubling the run quadruples the time. 40 covers any real identifier segment
-// and reproduces the unbounded verdict on every correctness case, `candidate.personal_access_token`
-// and `OPENAI_API_KEY` included.
-const CREDENTIAL_NOUN_LOOKBEHIND = '(?<!\\.[a-z0-9_$]{0,40})'
+/**
+ * Why a bound at all: unbounded (`*`) this is QUADRATIC — the engine retries the lookbehind from
+ * every position in an identifier run, so a 4096-char run measures 4.3ms against 0.53ms bounded,
+ * and doubling the run quadruples the time. The cost comes from `*`, not from the size of the
+ * bound, so a larger number is free.
+ *
+ * Why 64 specifically, and not smaller: the bound has to exceed the longest realistic distance
+ * between the opening dot and the noun, or a long property chain stops being recognised as a
+ * property access and starts corroborating a prompt. The longest in this repo today is 39
+ * (`settings.defaultOrganizationServiceAccountClientApiKey`), which clears a bound of 40 by one
+ * character. Identifiers grow; the headroom is the point. Do not "simplify" this to `*`.
+ */
+const CREDENTIAL_NOUN_LOOKBEHIND = '(?<!\\.[a-z0-9_$]{0,64})'
 /**
  * Exported for the complexity budget only. `MAX_CREDENTIAL_LINE_LENGTH` keeps every caller under
  * 512 characters, which HIDES the rule's growth curve — the gap between a linear and a quadratic

--- a/src/main/runtime/terminal-credential-prompt-detection.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.ts
@@ -17,6 +17,13 @@ import { startOfLastNonBlankLines } from './terminal-wait-tail-window'
  * text into a credential field; a false positive only delays a prompt until the
  * dialog is answered, and the wait poll re-evaluates the tail continuously, so
  * a refusal clears on its own.
+ *
+ * That asymmetry is not a licence to match auth wording anywhere in the window:
+ * the refusal is unconditional, so a false positive also pins an idle agent to
+ * `permission` in the agent-status store. Every rule here therefore demands
+ * prompt *shape* — a terminator, or the bottom row of the screen — because an
+ * agent narrating auth work reads as prose and leaves its own composer caret on
+ * the last row.
  */
 
 // Why bounded: an answered credential prompt stays in scrollback, and agents
@@ -32,6 +39,7 @@ const CREDENTIAL_NOUN_SOURCE =
   'password|passphrase|api[ -]?keys?|access[ -]tokens?|auth(?:orization)?[ -]tokens?|bearer tokens?|personal access tokens?|secret keys?|client secrets?|one[- ]time (?:code|password)|otp|verification codes?|authentication codes?|security codes?|2fa codes?|device codes?|credentials?'
 
 const CREDENTIAL_NOUN_RE = new RegExp(CREDENTIAL_NOUN_SOURCE, 'gi')
+const CREDENTIAL_NOUN_ANYWHERE_RE = new RegExp(CREDENTIAL_NOUN_SOURCE, 'i')
 
 // Why a vendor slot: real prompts read "enter your Anthropic API key" and
 // "paste your personal access token", not just "enter your API key".
@@ -54,12 +62,29 @@ const CLAUSE_TERMINATED_RE = /[:›❯»>_]\s*$/
 const SUDO_PASSWORD_RE = /^[^a-z0-9]{0,8}\[sudo\]\s+password for\b/i
 const GIT_CREDENTIAL_RE = /^[^a-z0-9]{0,8}(?:username|password) for ['"]?[a-z][a-z0-9+.-]*:\/\//i
 
-// Why two markers: a lone auth verb is narration. A device-code or sign-in
-// dialog always pairs the verb with a flow marker in the same live window.
 const AUTH_VERB_RE =
   /\b(?:sign[ -]?in|signin|log[ -]?in|authenticate|authorized?|authorization|authentication)\b/i
-const AUTH_FLOW_RE =
-  /\b(?:sign[ -]?in with|log[ -]?in with|authenticate with|authentication required|authorization required|sign[ -]?in required|login required|enter (?:the )?code|device code|verification code|waiting for (?:authentication|authorization|you to)|open (?:this|the following) url|press enter to (?:open|sign)|paste (?:it|the code) (?:here|below)|two[ -]factor|2fa|authenticator app|mfa|\d-digit code)\b/i
+
+// Wording only a dialog addressing the user uses.
+const AUTH_ACTION_FLOW_SOURCE =
+  'sign[ -]?in with|log[ -]?in with|authenticate with|authentication required|authorization required|sign[ -]?in required|login required|enter (?:the )?code|waiting for (?:authentication|authorization|you to)|open (?:this|the following) url|press enter to (?:open|sign)|paste (?:it|(?:the |your )?code) (?:here|below)'
+// Wording equally at home in a dialog and in narration about auth work.
+const AUTH_TOPIC_FLOW_SOURCE =
+  'device code|verification code|two[ -]factor|2fa|authenticator app|mfa|\\d-digit code'
+
+const AUTH_ACTION_FLOW_RE = new RegExp(`\\b(?:${AUTH_ACTION_FLOW_SOURCE})\\b`, 'i')
+const AUTH_FLOW_RE = new RegExp(
+  `\\b(?:${AUTH_ACTION_FLOW_SOURCE}|${AUTH_TOPIC_FLOW_SOURCE})\\b`,
+  'i'
+)
+
+// An inquirer-style question row. Prose never starts with a bare `?`, so a `?`
+// row asking about auth is a dialog header even when its options wrap below it.
+const AUTH_QUESTION_ROW_RE = /^\?\s+\S/
+
+// A finished sentence, i.e. narration. A lone `.`/`!`/`?` ends a clause; `...`
+// and `…` are progress wording ("opening browser...") and are not sentences.
+const NARRATION_ROW_RE = /(?:^|[^.])\.(?:\s|$)|[!?]\s*$/
 
 /**
  * Cheap superset of everything `findCredentialPromptIndex` can match, tested
@@ -68,11 +93,17 @@ const AUTH_FLOW_RE =
  */
 export const TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE = new RegExp(
   `(?:(?:${CREDENTIAL_NOUN_SOURCE}|username for)[^\\n]{0,64}[:?>›❯»_]\\s*$)|` +
-    `(?:${AUTH_FLOW_RE.source})`,
+    `(?:${AUTH_FLOW_RE.source})|` +
+    `(?:^\\s*\\?\\s+[^\\n]{0,120}(?:${AUTH_VERB_RE.source}))`,
   'im'
 )
 
-function isCredentialPromptLine(line: string): boolean {
+/**
+ * Whether `line` is itself a credential prompt. `isLastRow` gates the bare-label
+ * form (`password:`) because a label with no ask verb is also how printed k8s
+ * manifests and form templates read; only the screen's bottom row is a prompt.
+ */
+function isCredentialPromptLine(line: string, isLastRow: boolean): boolean {
   if (line.length > MAX_CREDENTIAL_LINE_LENGTH) {
     return false
   }
@@ -93,7 +124,10 @@ function isCredentialPromptLine(line: string): boolean {
     if (!terminated) {
       continue
     }
-    if (CREDENTIAL_ASK_PREFIX_RE.test(prefix) || CREDENTIAL_LABEL_PREFIX_RE.test(prefix)) {
+    if (CREDENTIAL_ASK_PREFIX_RE.test(prefix)) {
+      return true
+    }
+    if (isLastRow && CREDENTIAL_LABEL_PREFIX_RE.test(prefix)) {
       return true
     }
   }
@@ -104,24 +138,44 @@ function isCredentialPromptLine(line: string): boolean {
 export function findCredentialPromptIndex(normalized: string): number | null {
   const windowStart = startOfLastNonBlankLines(normalized, CREDENTIAL_TAIL_LINES)
   const tail = normalized.slice(windowStart)
+  const raws = tail.split('\n')
+  // Why: dialogs are drawn inside box rules, which otherwise glue the frame to the wording.
+  const lines = raws.map((raw) => raw.replace(/[\u2500-\u257f]+/g, ' ').trim())
+  const lastRow = lines.findLastIndex((line) => line.length > 0)
+
   let offset = 0
   let promptIndex: number | null = null
   let sawAuthVerb = false
-  let sawAuthFlow = false
-  for (const raw of tail.split('\n')) {
-    // Why: dialogs are drawn inside box rules, which otherwise glue the frame to the wording.
-    const line = raw.replace(/[\u2500-\u257f]+/g, ' ').trim()
-    if (isCredentialPromptLine(line)) {
+  let sawCredentialNoun = false
+  let sawAuthQuestion = false
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (isCredentialPromptLine(line, index === lastRow)) {
       promptIndex = windowStart + offset
     }
     if (line.length <= MAX_CREDENTIAL_LINE_LENGTH) {
       sawAuthVerb = sawAuthVerb || AUTH_VERB_RE.test(line)
-      sawAuthFlow = sawAuthFlow || AUTH_FLOW_RE.test(line)
+      sawCredentialNoun = sawCredentialNoun || CREDENTIAL_NOUN_ANYWHERE_RE.test(line)
+      sawAuthQuestion =
+        sawAuthQuestion ||
+        (AUTH_QUESTION_ROW_RE.test(line) && (AUTH_VERB_RE.test(line) || AUTH_FLOW_RE.test(line)))
     }
-    offset += raw.length + 1
+    offset += raws[index].length + 1
   }
   if (promptIndex !== null) {
     return promptIndex
   }
-  return sawAuthVerb && sawAuthFlow ? windowStart : null
+  // A flow marker alone is narration ("added the 2fa tests"). It is a live auth
+  // surface only when it owns the bottom row as an unfinished request, or when
+  // an interactive auth question drew the screen.
+  const bottomRow = lastRow === -1 ? '' : lines[lastRow]
+  const bottomRowAsks =
+    AUTH_ACTION_FLOW_RE.test(bottomRow) ||
+    (AUTH_FLOW_RE.test(bottomRow) && CLAUSE_TERMINATED_RE.test(bottomRow))
+  const authFlowOwnsBottom =
+    bottomRow.length <= MAX_CREDENTIAL_LINE_LENGTH &&
+    bottomRowAsks &&
+    !NARRATION_ROW_RE.test(bottomRow) &&
+    (sawAuthVerb || sawCredentialNoun)
+  return authFlowOwnsBottom || sawAuthQuestion ? windowStart : null
 }

--- a/src/main/runtime/terminal-credential-prompt-detection.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.ts
@@ -33,6 +33,11 @@ const CREDENTIAL_TAIL_LINES = 4
 
 // Why capped: a wrapped narration line is not a prompt, and an unbounded line
 // makes the per-line scan the hot path for streaming output.
+//
+// LOAD-BEARING for complexity, not just for throughput: every rule that carries a lookbehind
+// (`CREDENTIAL_NOUN_LOOKBEHIND`, `AUTH_VERB_RE`) is bounded in practice by this cap. Raising it
+// scales those rules superlinearly in the length of an identifier run, so re-measure
+// `CREDENTIAL_NOUN_RE` against the budget test before changing it.
 const MAX_CREDENTIAL_LINE_LENGTH = 512
 
 // Why `_` is a separator too: the most common api-key ask names the env var it fills
@@ -51,7 +56,22 @@ export const CREDENTIAL_NOUN_SOURCE =
 // one-character check misses `candidate.personal_access_token` — the dot precedes `personal`, not
 // `access_token`. Anchoring on the dot at the START of the identifier catches the whole family.
 // Still only `.`: the env-var ask (`OPENAI_API_KEY`) has no dot and is a real prompt.
-const CREDENTIAL_NOUN_LOOKBEHIND = '(?<!\\.[a-z0-9_$]*)'
+// Why the {0,40} bound and not `*`: unbounded, this is QUADRATIC — the engine retries the
+// lookbehind from every position in an identifier run, so a 4096-char run costs 4.6ms against
+// 369us bounded, and doubling the run quadruples the time. 40 covers any real identifier segment
+// and reproduces the unbounded verdict on every correctness case, `candidate.personal_access_token`
+// and `OPENAI_API_KEY` included.
+const CREDENTIAL_NOUN_LOOKBEHIND = '(?<!\\.[a-z0-9_$]{0,40})'
+/**
+ * Exported for the complexity budget only. `MAX_CREDENTIAL_LINE_LENGTH` keeps every caller under
+ * 512 characters, which HIDES the rule's growth curve — the gap between a linear and a quadratic
+ * lookbehind is only ~1.7x at the cap and 13x an octave above it. The budget therefore drives this
+ * regex directly, so the complexity class is asserted rather than the containment.
+ */
+export const CREDENTIAL_NOUN_RE_FOR_BUDGET = new RegExp(
+  `${CREDENTIAL_NOUN_LOOKBEHIND}(?:${CREDENTIAL_NOUN_SOURCE})`,
+  'i'
+)
 const CREDENTIAL_NOUN_RE = new RegExp(
   `${CREDENTIAL_NOUN_LOOKBEHIND}(?:${CREDENTIAL_NOUN_SOURCE})`,
   'gi'
@@ -145,7 +165,11 @@ const AUTH_QUESTION_ROW_RE = /^\?\s+\S/
  *
  * Parentheses are deliberately allowed — real prompts write `(Use arrow keys)`.
  */
-const CODE_SHAPED_ROW_RE = /[{}[\]`'"]|=>|!==|===|;\s*$|\b[a-z_$][\w$]*\.[a-z_$]/i
+// Why `[` and `]` are NOT here: a bracketed confirm default (`Authenticate with the CLI? [Y/n]`)
+// is a mainstream prompt convention (apt, readline, enquirer), and brackets buy little that the
+// other markers do not already catch — the code rows that carry them also carry a brace, a quote
+// or a property access.
+const CODE_SHAPED_ROW_RE = /[{}`'"]|=>|!==|===|;\s*$|\b[a-z_$][\w$]*\.[a-z_$]/i
 
 /**
  * A row that proves the agent is sitting at its own composer, so nothing is asking the user

--- a/src/main/runtime/terminal-credential-prompt-detection.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.ts
@@ -40,11 +40,15 @@ const MAX_CREDENTIAL_LINE_LENGTH = 512
 // segment before it is handled by the prefix rules, not here — a variable-length prefix inside
 // a noun alternation makes this whole pattern quadratic on long lines, and it runs per retained
 // tail line at streaming rate.
-const CREDENTIAL_NOUN_SOURCE =
+export const CREDENTIAL_NOUN_SOURCE =
   'password|passphrase|api[ _-]?keys?|access[ _-]tokens?|auth(?:orization)?[ _-]tokens?|bearer tokens?|personal access tokens?|secret keys?|client secrets?|one[- ]time (?:code|password)|otp|verification codes?|authentication codes?|security codes?|2fa codes?|device codes?|credentials?'
 
-const CREDENTIAL_NOUN_RE = new RegExp(CREDENTIAL_NOUN_SOURCE, 'gi')
-const CREDENTIAL_NOUN_ANYWHERE_RE = new RegExp(CREDENTIAL_NOUN_SOURCE, 'i')
+// Why the lookbehind: `candidate.credential`, `settings.apiKey` and `config.password` are property
+// accesses. The noun is what corroborates an otherwise-inert bottom row, so an identifier reading
+// as the noun is enough on its own to refuse a screen that is only printing source. Only `.` is
+// excluded, not all of `\w` — the env-var form (`OPENAI_API_KEY`) is a real ask.
+const CREDENTIAL_NOUN_RE = new RegExp(`(?<!\\.)(?:${CREDENTIAL_NOUN_SOURCE})`, 'gi')
+const CREDENTIAL_NOUN_ANYWHERE_RE = new RegExp(`(?<!\\.)(?:${CREDENTIAL_NOUN_SOURCE})`, 'i')
 
 // Why a vendor slot: real prompts read "enter your Anthropic API key" and
 // "paste your personal access token", not just "enter your API key".
@@ -81,16 +85,17 @@ const GIT_CREDENTIAL_RE = /^[^a-z0-9]{0,8}(?:username|password) for ['"]?[a-z][a
 // Why the lookbehind: `user.login`, `candidate.login` and `overrides.filter((login) =>` are
 // property accesses, not auth wording, and `\b` treats `.` as a boundary. Agents print this
 // repo's own source constantly.
-const AUTH_VERB_RE =
-  /(?<![.\w])(?:sign[ -]?in|signin|log[ -]?in|authenticate|authorized?|authorization|authentication)\b/i
+export const AUTH_VERB_SOURCE =
+  'sign[ -]?in|signin|log[ -]?in|authenticate|authorized?|authorization|authentication'
+const AUTH_VERB_RE = new RegExp(`(?<![.\\w])(?:${AUTH_VERB_SOURCE})\\b`, 'i')
 
 // Wording only a dialog addressing the user uses.
 // Why `waiting for you to` carries an auth continuation: bare "waiting for you to …" is how
 // every agent narrates waiting on a review, a branch choice or an approval.
-const AUTH_ACTION_FLOW_SOURCE =
+export const AUTH_ACTION_FLOW_SOURCE =
   'sign[ -]?in with|log[ -]?in with|authenticate with|authentication required|authorization required|sign[ -]?in required|login required|enter (?:the )?code|waiting for (?:authentication|authorization|you to (?:sign|log|authenticate|authoriz|finish|enter (?:the |your )?code))|open (?:this|the following) url|press enter to (?:open|sign)|paste (?:it|(?:the |your )?code) (?:here|below)'
 // Wording equally at home in a dialog and in narration about auth work.
-const AUTH_TOPIC_FLOW_SOURCE =
+export const AUTH_TOPIC_FLOW_SOURCE =
   'device code|verification code|two[ -]factor|2fa|authenticator app|mfa|\\d-digit code'
 
 const AUTH_FLOW_RE = new RegExp(
@@ -108,8 +113,11 @@ const AUTH_FLOW_RE = new RegExp(
  * summary (`• Root cause: authentication required from the vercel CLI`). Those are the shape a
  * false positive takes, and the reason is unconditional, so they must not read as a prompt.
  */
+// Why `/` and `*` are excluded from the decoration run: a dialog decorates its instruction with
+// box rules, bullets, carets and menu numbers, never with a comment marker. Without this,
+// `    // Sign in with the provider console to continue` reads as a dialog leading its row.
 const AUTH_ACTION_FLOW_LEADS_ROW_RE = new RegExp(
-  `^[^a-z0-9]{0,8}(?:(?:and|then|now|please|first|next|finally|you (?:must|need to|can))\\s+){0,2}(?:${AUTH_ACTION_FLOW_SOURCE})\\b`,
+  `^[^a-z0-9/*]{0,8}(?:(?:and|then|now|please|first|next|finally|you (?:must|need to|can))\\s+){0,2}(?:${AUTH_ACTION_FLOW_SOURCE})\\b`,
   'i'
 )
 

--- a/src/main/runtime/terminal-credential-prompt-detection.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.ts
@@ -48,8 +48,14 @@ const CREDENTIAL_NOUN_ANYWHERE_RE = new RegExp(CREDENTIAL_NOUN_SOURCE, 'i')
 
 // Why a vendor slot: real prompts read "enter your Anthropic API key" and
 // "paste your personal access token", not just "enter your API key".
+//
+// Why anchored: unanchored, the ask verb could sit anywhere, so any prose that happened to end on
+// a credential noun read as a prompt — `// Why: a merely missing or expired bundle must not enter
+// the credential` is a real wrapped comment in this repo, and terminal wrapping makes ending on a
+// noun routine. A dialog addresses the user, so its ask verb leads the row, modulo decoration and
+// a menu number (`2. Paste an API key`).
 const CREDENTIAL_ASK_PREFIX_RE =
-  /(?:^|[^a-z])(?:enter|re-?enter|type|paste|input|provide|confirm)(?:\s+(?:your|the|a|an|my|new|current|old))?(?:\s+[a-z][a-z0-9.'-]{0,20}){0,2}[\s_]+$/i
+  /^[^a-z0-9]{0,8}(?:\d{1,2}[.)]\s*)?(?:please\s+)?(?:enter|re-?enter|type|paste|input|provide|confirm)(?:\s+(?:your|the|a|an|my|new|current|old))?(?:\s+[a-z][a-z0-9.'-]{0,20}){0,2}[\s_]+$/i
 
 // A bare label prompt: decoration, an optional qualifier, an optional env-var vendor segment
 // (`ANTHROPIC_API_KEY:`), then the noun.
@@ -72,8 +78,11 @@ const CLAUSE_TERMINATED_RE = /[:›❯»>_]\s*$/
 const SUDO_PASSWORD_RE = /^[^a-z0-9]{0,8}\[sudo\]\s/i
 const GIT_CREDENTIAL_RE = /^[^a-z0-9]{0,8}(?:username|password) for ['"]?[a-z][a-z0-9+.-]*:\/\//i
 
+// Why the lookbehind: `user.login`, `candidate.login` and `overrides.filter((login) =>` are
+// property accesses, not auth wording, and `\b` treats `.` as a boundary. Agents print this
+// repo's own source constantly.
 const AUTH_VERB_RE =
-  /\b(?:sign[ -]?in|signin|log[ -]?in|authenticate|authorized?|authorization|authentication)\b/i
+  /(?<![.\w])(?:sign[ -]?in|signin|log[ -]?in|authenticate|authorized?|authorization|authentication)\b/i
 
 // Wording only a dialog addressing the user uses.
 // Why `waiting for you to` carries an auth continuation: bare "waiting for you to …" is how
@@ -104,9 +113,21 @@ const AUTH_ACTION_FLOW_LEADS_ROW_RE = new RegExp(
   'i'
 )
 
-// An inquirer-style question row. Prose never starts with a bare `?`, so a `?`
-// row asking about auth is a dialog header even when its options wrap below it.
+// An inquirer-style question row. Prose never starts with a bare `?` — but FORMATTED CODE does:
+// oxfmt puts a ternary's consequent on its own row as `? someValue`, and 5,666 tracked files in
+// this repo have one. So the row rule alone is not enough; see `COMPOSER_CARET_ROW_RE`.
 const AUTH_QUESTION_ROW_RE = /^\?\s+\S/
+
+/**
+ * A row that proves the agent is sitting at its own composer, so nothing is asking the user
+ * anything and a `?` row above it is output, not a dialog header.
+ *
+ * Why a bare `>` is safe to include here: this suppresses only the question-row rule, which is
+ * the one rule with no position requirement. A sign-in dialog drawn OVER ready chrome — the
+ * #19749 shape, whose own bottom row is `>` — matches through `isCredentialPromptLine` instead,
+ * and that returns before this is consulted.
+ */
+const COMPOSER_CARET_ROW_RE = /^(?:›\s*ask\b.*|✳\s*claude code\b.*|[>❯›◇»$])$/i
 
 // A finished sentence, i.e. narration. A lone `.`/`!`/`?` ends a clause; `...`
 // and `…` are progress wording ("opening browser...") and are not sentences.
@@ -216,5 +237,6 @@ export function findCredentialPromptIndex(normalized: string): number | null {
     bottomRowAsks &&
     !NARRATION_ROW_RE.test(bottomRow) &&
     (sawAuthVerb || sawCredentialNoun)
-  return authFlowOwnsBottom || sawAuthQuestion ? windowStart : null
+  const bottomRowIsComposerCaret = COMPOSER_CARET_ROW_RE.test(bottomRow)
+  return authFlowOwnsBottom || (sawAuthQuestion && !bottomRowIsComposerCaret) ? windowStart : null
 }

--- a/src/main/runtime/terminal-credential-prompt-detection.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.ts
@@ -35,8 +35,13 @@ const CREDENTIAL_TAIL_LINES = 4
 // makes the per-line scan the hot path for streaming output.
 const MAX_CREDENTIAL_LINE_LENGTH = 512
 
+// Why `_` is a separator too: the most common api-key ask names the env var it fills
+// ("Enter your OPENAI_API_KEY:"), and `api key` alone misses every one of them. The vendor
+// segment before it is handled by the prefix rules, not here — a variable-length prefix inside
+// a noun alternation makes this whole pattern quadratic on long lines, and it runs per retained
+// tail line at streaming rate.
 const CREDENTIAL_NOUN_SOURCE =
-  'password|passphrase|api[ -]?keys?|access[ -]tokens?|auth(?:orization)?[ -]tokens?|bearer tokens?|personal access tokens?|secret keys?|client secrets?|one[- ]time (?:code|password)|otp|verification codes?|authentication codes?|security codes?|2fa codes?|device codes?|credentials?'
+  'password|passphrase|api[ _-]?keys?|access[ _-]tokens?|auth(?:orization)?[ _-]tokens?|bearer tokens?|personal access tokens?|secret keys?|client secrets?|one[- ]time (?:code|password)|otp|verification codes?|authentication codes?|security codes?|2fa codes?|device codes?|credentials?'
 
 const CREDENTIAL_NOUN_RE = new RegExp(CREDENTIAL_NOUN_SOURCE, 'gi')
 const CREDENTIAL_NOUN_ANYWHERE_RE = new RegExp(CREDENTIAL_NOUN_SOURCE, 'i')
@@ -44,10 +49,12 @@ const CREDENTIAL_NOUN_ANYWHERE_RE = new RegExp(CREDENTIAL_NOUN_SOURCE, 'i')
 // Why a vendor slot: real prompts read "enter your Anthropic API key" and
 // "paste your personal access token", not just "enter your API key".
 const CREDENTIAL_ASK_PREFIX_RE =
-  /(?:^|[^a-z])(?:enter|re-?enter|type|paste|input|provide|confirm)(?:\s+(?:your|the|a|an|my|new|current|old))?(?:\s+[a-z][a-z0-9.'-]{0,20}){0,2}\s+$/i
+  /(?:^|[^a-z])(?:enter|re-?enter|type|paste|input|provide|confirm)(?:\s+(?:your|the|a|an|my|new|current|old))?(?:\s+[a-z][a-z0-9.'-]{0,20}){0,2}[\s_]+$/i
 
-// A bare label prompt: decoration, an optional qualifier, then the noun.
-const CREDENTIAL_LABEL_PREFIX_RE = /^[^a-z0-9]{0,8}(?:(?:new|current|old|your)\s+)?$/i
+// A bare label prompt: decoration, an optional qualifier, an optional env-var vendor segment
+// (`ANTHROPIC_API_KEY:`), then the noun.
+const CREDENTIAL_LABEL_PREFIX_RE =
+  /^[^a-z0-9]{0,8}(?:(?:new|current|old|your)\s+)?(?:[a-z][a-z0-9]{0,20}_)?$/i
 
 const PURE_TERMINATOR_RE = /^[\s:?>›❯»*_|.…-]{0,16}$/
 const FOR_TARGET_TERMINATED_RE = /[:?>›❯»_]\s*$/
@@ -59,22 +66,41 @@ const FOR_TARGET_RE = /^\s+(?:for|to)\s/i
 // must not read as a prompt.
 const CLAUSE_TERMINATED_RE = /[:›❯»>_]\s*$/
 
-const SUDO_PASSWORD_RE = /^[^a-z0-9]{0,8}\[sudo\]\s+password for\b/i
+// Why the whole wording after `[sudo]` is unconstrained: sudo translates its prompt
+// ("[sudo] Passwort für neil:", "[sudo] neil 的密碼："), but never the `[sudo]` tag, and the
+// only thing sudo ever asks for at that tag is a password.
+const SUDO_PASSWORD_RE = /^[^a-z0-9]{0,8}\[sudo\]\s/i
 const GIT_CREDENTIAL_RE = /^[^a-z0-9]{0,8}(?:username|password) for ['"]?[a-z][a-z0-9+.-]*:\/\//i
 
 const AUTH_VERB_RE =
   /\b(?:sign[ -]?in|signin|log[ -]?in|authenticate|authorized?|authorization|authentication)\b/i
 
 // Wording only a dialog addressing the user uses.
+// Why `waiting for you to` carries an auth continuation: bare "waiting for you to …" is how
+// every agent narrates waiting on a review, a branch choice or an approval.
 const AUTH_ACTION_FLOW_SOURCE =
-  'sign[ -]?in with|log[ -]?in with|authenticate with|authentication required|authorization required|sign[ -]?in required|login required|enter (?:the )?code|waiting for (?:authentication|authorization|you to)|open (?:this|the following) url|press enter to (?:open|sign)|paste (?:it|(?:the |your )?code) (?:here|below)'
+  'sign[ -]?in with|log[ -]?in with|authenticate with|authentication required|authorization required|sign[ -]?in required|login required|enter (?:the )?code|waiting for (?:authentication|authorization|you to (?:sign|log|authenticate|authoriz|finish|enter (?:the |your )?code))|open (?:this|the following) url|press enter to (?:open|sign)|paste (?:it|(?:the |your )?code) (?:here|below)'
 // Wording equally at home in a dialog and in narration about auth work.
 const AUTH_TOPIC_FLOW_SOURCE =
   'device code|verification code|two[ -]factor|2fa|authenticator app|mfa|\\d-digit code'
 
-const AUTH_ACTION_FLOW_RE = new RegExp(`\\b(?:${AUTH_ACTION_FLOW_SOURCE})\\b`, 'i')
 const AUTH_FLOW_RE = new RegExp(
   `\\b(?:${AUTH_ACTION_FLOW_SOURCE}|${AUTH_TOPIC_FLOW_SOURCE})\\b`,
+  'i'
+)
+
+/**
+ * An action phrase the row *opens* with, modulo dialog decoration and the few lead-ins a
+ * dialog uses ("and enter the code:", "Please sign in with…").
+ *
+ * Why position matters: a dialog addresses the user, so its action phrase leads the row. The
+ * same phrase buried behind other words is a *mention* of auth work — a commit subject
+ * (`d4e5f6a feat(auth): sign in with GitHub`), a changelog bullet, a checklist item, an error
+ * summary (`• Root cause: authentication required from the vercel CLI`). Those are the shape a
+ * false positive takes, and the reason is unconditional, so they must not read as a prompt.
+ */
+const AUTH_ACTION_FLOW_LEADS_ROW_RE = new RegExp(
+  `^[^a-z0-9]{0,8}(?:(?:and|then|now|please|first|next|finally|you (?:must|need to|can))\\s+){0,2}(?:${AUTH_ACTION_FLOW_SOURCE})\\b`,
   'i'
 )
 
@@ -84,7 +110,10 @@ const AUTH_QUESTION_ROW_RE = /^\?\s+\S/
 
 // A finished sentence, i.e. narration. A lone `.`/`!`/`?` ends a clause; `...`
 // and `…` are progress wording ("opening browser...") and are not sentences.
-const NARRATION_ROW_RE = /(?:^|[^.])\.(?:\s|$)|[!?]\s*$/
+// Why CJK punctuation counts: an agent narrating auth work in Chinese or Japanese writes
+// `。`/`，` and never an ASCII period, so the English-only test leaves localized narration
+// with no way to read as prose — and the wording it embeds is still English.
+const NARRATION_ROW_RE = /(?:^|[^.])\.(?:\s|$)|[!?]\s*$|[。！？，、；]/
 
 /**
  * Cheap superset of everything `findCredentialPromptIndex` can match, tested
@@ -92,7 +121,17 @@ const NARRATION_ROW_RE = /(?:^|[^.])\.(?:\s|$)|[!?]\s*$/
  * index rejects is never parsed in full.
  */
 export const TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE = new RegExp(
-  `(?:(?:${CREDENTIAL_NOUN_SOURCE}|username for)[^\\n]{0,64}[:?>›❯»_]\\s*$)|` +
+  // Why the box-glyph run after the terminator: `findCredentialPromptIndex` blanks box rules
+  // before it reads a row, so a dialog drawn in a frame ends `… API key here:   │`. Without this
+  // the sentinel rejects the tail and the prompt is never parsed at all.
+  `(?:(?:${CREDENTIAL_NOUN_SOURCE}|username for)[^\\n]{0,64}[:?>›❯»_][\\s\\u2500-\\u257f]*$)|` +
+    // Why a bare row-final noun counts: `PURE_TERMINATOR_RE` treats end-of-row as a terminator,
+    // so a menu option (`2. Paste an API key`) is a prompt to the index with no punctuation at
+    // all. Without this the main lane's prefilter drops the Antigravity sign-in menu that this
+    // whole guard was written for, while the renderer lane — which has no prefilter — refuses it.
+    `(?:(?:${CREDENTIAL_NOUN_SOURCE})[\\s\\u2500-\\u257f]*$)|` +
+    // Why literal: sudo's prompt is translated, so only the untranslated tag survives.
+    `(?:\\[sudo\\]\\s)|` +
     `(?:${AUTH_FLOW_RE.source})|` +
     `(?:^\\s*\\?\\s+[^\\n]{0,120}(?:${AUTH_VERB_RE.source}))`,
   'im'
@@ -170,7 +209,7 @@ export function findCredentialPromptIndex(normalized: string): number | null {
   // an interactive auth question drew the screen.
   const bottomRow = lastRow === -1 ? '' : lines[lastRow]
   const bottomRowAsks =
-    AUTH_ACTION_FLOW_RE.test(bottomRow) ||
+    AUTH_ACTION_FLOW_LEADS_ROW_RE.test(bottomRow) ||
     (AUTH_FLOW_RE.test(bottomRow) && CLAUSE_TERMINATED_RE.test(bottomRow))
   const authFlowOwnsBottom =
     bottomRow.length <= MAX_CREDENTIAL_LINE_LENGTH &&

--- a/src/main/runtime/terminal-credential-prompt-detection.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.ts
@@ -1,0 +1,127 @@
+import { startOfLastNonBlankLines } from './terminal-wait-tail-window'
+
+/**
+ * Recognizes a live credential / authentication prompt owning the bottom of a
+ * terminal screen.
+ *
+ * Why this exists separately from the agent-specific blocked signals: every
+ * readiness detector Orca has can be wrong, and when one is, the caller types
+ * the user's task prompt into whatever surface is actually on screen. If that
+ * surface is a credential prompt the prompt is submitted to an auth provider as
+ * a credential attempt, and — because the daemon records raw PTY output
+ * unredacted — an echoing prompt also writes it into the session transcript. So
+ * this is deliberately agent-agnostic: it keys on the shape of a credential
+ * prompt, not on which agent drew it.
+ *
+ * The bias is asymmetric on purpose. A false negative types secrets-adjacent
+ * text into a credential field; a false positive only delays a prompt until the
+ * dialog is answered, and the wait poll re-evaluates the tail continuously, so
+ * a refusal clears on its own.
+ */
+
+// Why bounded: an answered credential prompt stays in scrollback, and agents
+// print credential wording constantly while working on auth code. Only a prompt
+// owning the screen bottom is live.
+const CREDENTIAL_TAIL_LINES = 4
+
+// Why capped: a wrapped narration line is not a prompt, and an unbounded line
+// makes the per-line scan the hot path for streaming output.
+const MAX_CREDENTIAL_LINE_LENGTH = 512
+
+const CREDENTIAL_NOUN_SOURCE =
+  'password|passphrase|api[ -]?keys?|access[ -]tokens?|auth(?:orization)?[ -]tokens?|bearer tokens?|personal access tokens?|secret keys?|client secrets?|one[- ]time (?:code|password)|otp|verification codes?|authentication codes?|security codes?|2fa codes?|device codes?|credentials?'
+
+const CREDENTIAL_NOUN_RE = new RegExp(CREDENTIAL_NOUN_SOURCE, 'gi')
+
+// Why a vendor slot: real prompts read "enter your Anthropic API key" and
+// "paste your personal access token", not just "enter your API key".
+const CREDENTIAL_ASK_PREFIX_RE =
+  /(?:^|[^a-z])(?:enter|re-?enter|type|paste|input|provide|confirm)(?:\s+(?:your|the|a|an|my|new|current|old))?(?:\s+[a-z][a-z0-9.'-]{0,20}){0,2}\s+$/i
+
+// A bare label prompt: decoration, an optional qualifier, then the noun.
+const CREDENTIAL_LABEL_PREFIX_RE = /^[^a-z0-9]{0,8}(?:(?:new|current|old|your)\s+)?$/i
+
+const PURE_TERMINATOR_RE = /^[\s:?>›❯»*_|.…-]{0,16}$/
+const FOR_TARGET_TERMINATED_RE = /[:?>›❯»_]\s*$/
+const FOR_TARGET_RE = /^\s+(?:for|to)\s/i
+
+// Why `?` is excluded here: a credential prompt ends in a colon or an input
+// caret. An agent legitimately asking the user a credential-adjacent question
+// ("Should I store the password in .env?") ends in a question mark, and that
+// must not read as a prompt.
+const CLAUSE_TERMINATED_RE = /[:›❯»>_]\s*$/
+
+const SUDO_PASSWORD_RE = /^[^a-z0-9]{0,8}\[sudo\]\s+password for\b/i
+const GIT_CREDENTIAL_RE = /^[^a-z0-9]{0,8}(?:username|password) for ['"]?[a-z][a-z0-9+.-]*:\/\//i
+
+// Why two markers: a lone auth verb is narration. A device-code or sign-in
+// dialog always pairs the verb with a flow marker in the same live window.
+const AUTH_VERB_RE =
+  /\b(?:sign[ -]?in|signin|log[ -]?in|authenticate|authorized?|authorization|authentication)\b/i
+const AUTH_FLOW_RE =
+  /\b(?:sign[ -]?in with|log[ -]?in with|authenticate with|authentication required|authorization required|sign[ -]?in required|login required|enter (?:the )?code|device code|verification code|waiting for (?:authentication|authorization|you to)|open (?:this|the following) url|press enter to (?:open|sign)|paste (?:it|the code) (?:here|below)|two[ -]factor|2fa|authenticator app|mfa|\d-digit code)\b/i
+
+/**
+ * Cheap superset of everything `findCredentialPromptIndex` can match, tested
+ * per retained tail line at streaming rate. Must stay a superset: a tail the
+ * index rejects is never parsed in full.
+ */
+export const TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE = new RegExp(
+  `(?:(?:${CREDENTIAL_NOUN_SOURCE}|username for)[^\\n]{0,64}[:?>›❯»_]\\s*$)|` +
+    `(?:${AUTH_FLOW_RE.source})`,
+  'im'
+)
+
+function isCredentialPromptLine(line: string): boolean {
+  if (line.length > MAX_CREDENTIAL_LINE_LENGTH) {
+    return false
+  }
+  if (SUDO_PASSWORD_RE.test(line) || GIT_CREDENTIAL_RE.test(line)) {
+    return true
+  }
+  CREDENTIAL_NOUN_RE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = CREDENTIAL_NOUN_RE.exec(line)) !== null) {
+    const prefix = line.slice(0, match.index)
+    const suffix = line.slice(match.index + match[0].length)
+    const terminated =
+      PURE_TERMINATOR_RE.test(suffix) ||
+      (suffix.length <= 100 &&
+        FOR_TARGET_RE.test(suffix) &&
+        FOR_TARGET_TERMINATED_RE.test(suffix)) ||
+      (suffix.length <= 64 && CLAUSE_TERMINATED_RE.test(suffix))
+    if (!terminated) {
+      continue
+    }
+    if (CREDENTIAL_ASK_PREFIX_RE.test(prefix) || CREDENTIAL_LABEL_PREFIX_RE.test(prefix)) {
+      return true
+    }
+  }
+  return false
+}
+
+/** Offset of the live credential prompt in `normalized`, or null. */
+export function findCredentialPromptIndex(normalized: string): number | null {
+  const windowStart = startOfLastNonBlankLines(normalized, CREDENTIAL_TAIL_LINES)
+  const tail = normalized.slice(windowStart)
+  let offset = 0
+  let promptIndex: number | null = null
+  let sawAuthVerb = false
+  let sawAuthFlow = false
+  for (const raw of tail.split('\n')) {
+    // Why: dialogs are drawn inside box rules, which otherwise glue the frame to the wording.
+    const line = raw.replace(/[\u2500-\u257f]+/g, ' ').trim()
+    if (isCredentialPromptLine(line)) {
+      promptIndex = windowStart + offset
+    }
+    if (line.length <= MAX_CREDENTIAL_LINE_LENGTH) {
+      sawAuthVerb = sawAuthVerb || AUTH_VERB_RE.test(line)
+      sawAuthFlow = sawAuthFlow || AUTH_FLOW_RE.test(line)
+    }
+    offset += raw.length + 1
+  }
+  if (promptIndex !== null) {
+    return promptIndex
+  }
+  return sawAuthVerb && sawAuthFlow ? windowStart : null
+}

--- a/src/main/runtime/terminal-credential-prompt-detection.ts
+++ b/src/main/runtime/terminal-credential-prompt-detection.ts
@@ -47,8 +47,19 @@ export const CREDENTIAL_NOUN_SOURCE =
 // accesses. The noun is what corroborates an otherwise-inert bottom row, so an identifier reading
 // as the noun is enough on its own to refuse a screen that is only printing source. Only `.` is
 // excluded, not all of `\w` — the env-var form (`OPENAI_API_KEY`) is a real ask.
-const CREDENTIAL_NOUN_RE = new RegExp(`(?<!\\.)(?:${CREDENTIAL_NOUN_SOURCE})`, 'gi')
-const CREDENTIAL_NOUN_ANYWHERE_RE = new RegExp(`(?<!\\.)(?:${CREDENTIAL_NOUN_SOURCE})`, 'i')
+// Why the lookbehind spans identifier characters: the noun can sit mid-identifier, so a fixed
+// one-character check misses `candidate.personal_access_token` — the dot precedes `personal`, not
+// `access_token`. Anchoring on the dot at the START of the identifier catches the whole family.
+// Still only `.`: the env-var ask (`OPENAI_API_KEY`) has no dot and is a real prompt.
+const CREDENTIAL_NOUN_LOOKBEHIND = '(?<!\\.[a-z0-9_$]*)'
+const CREDENTIAL_NOUN_RE = new RegExp(
+  `${CREDENTIAL_NOUN_LOOKBEHIND}(?:${CREDENTIAL_NOUN_SOURCE})`,
+  'gi'
+)
+const CREDENTIAL_NOUN_ANYWHERE_RE = new RegExp(
+  `${CREDENTIAL_NOUN_LOOKBEHIND}(?:${CREDENTIAL_NOUN_SOURCE})`,
+  'i'
+)
 
 // Why a vendor slot: real prompts read "enter your Anthropic API key" and
 // "paste your personal access token", not just "enter your API key".
@@ -123,8 +134,18 @@ const AUTH_ACTION_FLOW_LEADS_ROW_RE = new RegExp(
 
 // An inquirer-style question row. Prose never starts with a bare `?` — but FORMATTED CODE does:
 // oxfmt puts a ternary's consequent on its own row as `? someValue`, and 5,666 tracked files in
-// this repo have one. So the row rule alone is not enough; see `COMPOSER_CARET_ROW_RE`.
+// this repo have one.
 const AUTH_QUESTION_ROW_RE = /^\?\s+\S/
+
+/**
+ * Source code rather than a sentence. This is what actually separates an inquirer header from a
+ * ternary consequent, because POSITION cannot: `? How would you like to authenticate?` above its
+ * two option rows and `? prevAssignees.filter(...)` above a caret and a status bar sit at exactly
+ * the same offset from the bottom.
+ *
+ * Parentheses are deliberately allowed — real prompts write `(Use arrow keys)`.
+ */
+const CODE_SHAPED_ROW_RE = /[{}[\]`'"]|=>|!==|===|;\s*$|\b[a-z_$][\w$]*\.[a-z_$]/i
 
 /**
  * A row that proves the agent is sitting at its own composer, so nothing is asking the user
@@ -135,7 +156,13 @@ const AUTH_QUESTION_ROW_RE = /^\?\s+\S/
  * #19749 shape, whose own bottom row is `>` — matches through `isCredentialPromptLine` instead,
  * and that returns before this is consulted.
  */
-const COMPOSER_CARET_ROW_RE = /^(?:›\s*ask\b.*|✳\s*claude code\b.*|[>❯›◇»$])$/i
+const COMPOSER_CARET_ROW_RE = /^(?:[›❯>◇»]\s*ask\b.*|✳\s*claude code\b.*|[>❯›◇»$])$/i
+
+// Why a region and not the bottom row: every agent draws chrome UNDER its caret — Codex a model
+// footer, OpenCode a status bar, droid a key-hint row — so the caret is rarely the last row on a
+// real screen. Three covers the deepest captured footer without reaching the option rows of a
+// dialog, whose own caret sits further up (`terminal-live-credential-surfaces-corpus.ts`).
+const COMPOSER_REGION_ROWS = 3
 
 // A finished sentence, i.e. narration. A lone `.`/`!`/`?` ends a clause; `...`
 // and `…` are progress wording ("opening browser...") and are not sentences.
@@ -226,7 +253,9 @@ export function findCredentialPromptIndex(normalized: string): number | null {
       sawCredentialNoun = sawCredentialNoun || CREDENTIAL_NOUN_ANYWHERE_RE.test(line)
       sawAuthQuestion =
         sawAuthQuestion ||
-        (AUTH_QUESTION_ROW_RE.test(line) && (AUTH_VERB_RE.test(line) || AUTH_FLOW_RE.test(line)))
+        (AUTH_QUESTION_ROW_RE.test(line) &&
+          !CODE_SHAPED_ROW_RE.test(line) &&
+          (AUTH_VERB_RE.test(line) || AUTH_FLOW_RE.test(line)))
     }
     offset += raws[index].length + 1
   }
@@ -245,6 +274,9 @@ export function findCredentialPromptIndex(normalized: string): number | null {
     bottomRowAsks &&
     !NARRATION_ROW_RE.test(bottomRow) &&
     (sawAuthVerb || sawCredentialNoun)
-  const bottomRowIsComposerCaret = COMPOSER_CARET_ROW_RE.test(bottomRow)
+  const nonBlank = lines.filter((line) => line.length > 0)
+  const bottomRowIsComposerCaret = nonBlank
+    .slice(-COMPOSER_REGION_ROWS)
+    .some((line) => COMPOSER_CARET_ROW_RE.test(line))
   return authFlowOwnsBottom || (sawAuthQuestion && !bottomRowIsComposerCaret) ? windowStart : null
 }

--- a/src/main/runtime/terminal-credential-prompt-write-guard.test.ts
+++ b/src/main/runtime/terminal-credential-prompt-write-guard.test.ts
@@ -1,0 +1,154 @@
+// Regression for the #19749 harm at the WRITE site rather than at the detector.
+//
+// The readiness detector for Antigravity has been rewritten five times and has repeatedly
+// reported ready with a live sign-in dialog on screen, at which point the orchestrator typed
+// the user's task prompt into it. This suite fixes the pane in exactly that state — the full
+// Antigravity ready chrome that HEAD's detector accepts, an idle OSC title, and a device-code
+// sign-in dialog drawn over it — and asserts the send is refused anyway.
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { assertTerminalAgentSendable } from './rpc/terminal-agent-send-guard'
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromId: vi.fn(() => null) },
+  webContents: { fromId: vi.fn(() => null) },
+  ipcMain: { on: vi.fn(), removeListener: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') }
+}))
+
+const LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const TAB_ID = 'tab-1'
+const WORKTREE_ID = 'wt-1'
+const PTY_ID = 'pty-1'
+
+// Antigravity's ready chrome: header, a gemini model row, and a lone `>` caret. All three are
+// what `findAntigravityReadyPromptIndex` keys on, so this prefix reads ready on its own.
+const ANTIGRAVITY_READY = [
+  'Antigravity CLI',
+  'gemini 3 pro (high)',
+  '~/orca/workspaces/orca/crash-closer',
+  '>',
+  ''
+].join('\n')
+
+const ANTIGRAVITY_SIGN_IN = [
+  '  Sign in to Antigravity',
+  '  Open https://antigravity.google/device and enter the code: KXTD-9PQR',
+  '  Waiting for authentication…',
+  ''
+].join('\n')
+
+const API_KEY_PROMPT = ['  Enter your Antigravity API key:', ''].join('\n')
+
+// A title Orca reads as explicitly idle, which is what let the wait resolve as ready.
+const IDLE_TITLE = '◇ Gemini CLI ready'
+
+async function createPane(data: string): Promise<{
+  runtime: OrcaRuntimeService
+  handle: string
+  writes: string[]
+}> {
+  const runtime = new OrcaRuntimeService(null)
+  const writes: string[] = []
+  const internals = runtime as unknown as {
+    resolveTerminalWorkspaceLaunchScope: (selector: string) => Promise<unknown>
+  }
+  vi.spyOn(internals, 'resolveTerminalWorkspaceLaunchScope').mockResolvedValue({
+    id: WORKTREE_ID,
+    path: '/repo/app',
+    connectionId: null,
+    repo: null,
+    folderWorkspace: null
+  })
+  runtime.setPtyController({
+    spawn: vi.fn().mockResolvedValue({ id: PTY_ID, incarnationId: 'inc-1' }),
+    write: (_id: string, payload: string): boolean => {
+      writes.push(payload)
+      return true
+    },
+    kill: () => true,
+    getForegroundProcess: (): Promise<string | null> => Promise.resolve('agy')
+  })
+  const terminal = await runtime.createTerminal(`id:${WORKTREE_ID}`, {
+    tabId: TAB_ID,
+    leafId: LEAF_ID,
+    title: 'Terminal'
+  })
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, {
+    tabs: [
+      {
+        tabId: TAB_ID,
+        worktreeId: WORKTREE_ID,
+        title: 'Terminal',
+        activeLeafId: LEAF_ID,
+        layout: null
+      }
+    ],
+    leaves: [
+      {
+        tabId: TAB_ID,
+        worktreeId: WORKTREE_ID,
+        leafId: LEAF_ID,
+        paneRuntimeId: 1,
+        ptyId: PTY_ID,
+        paneTitle: IDLE_TITLE
+      }
+    ]
+  })
+  runtime.onPtyData(PTY_ID, data, Date.now())
+  return { runtime, handle: terminal.handle, writes }
+}
+
+describe('a task prompt is never typed into a live credential surface (#19749)', () => {
+  it('refuses the send while a device-code sign-in dialog covers the ready chrome', async () => {
+    const { runtime, handle, writes } = await createPane(
+      `${ANTIGRAVITY_READY}${ANTIGRAVITY_SIGN_IN}`
+    )
+
+    await expect(runtime.getTerminalAgentStatus(handle)).resolves.toMatchObject({
+      isRunningAgent: true,
+      status: 'permission'
+    })
+    await expect(
+      assertTerminalAgentSendable({ runtime, handle, assertWritable: () => {} })
+    ).rejects.toThrow('terminal_guard_permission')
+    await expect(
+      runtime.sendTerminalAgentPrompt(handle, 'Fix the crash in the worktree list and push')
+    ).rejects.toThrow('agent_prompt_blocked')
+    expect(writes).toEqual([])
+  })
+
+  it('refuses the send while an API-key prompt covers the ready chrome', async () => {
+    const { runtime, handle, writes } = await createPane(`${ANTIGRAVITY_READY}${API_KEY_PROMPT}`)
+
+    await expect(
+      runtime.sendTerminalAgentPrompt(handle, 'Fix the crash in the worktree list and push')
+    ).rejects.toThrow('agent_prompt_blocked')
+    expect(writes).toEqual([])
+  })
+
+  it('names the credential prompt instead of reporting the lane idle', async () => {
+    // Defer, do not drop: the caller is told why, and the wait poll re-reads the tail, so the
+    // refusal clears on its own once the dialog is answered.
+    const { runtime, handle } = await createPane(`${ANTIGRAVITY_READY}${ANTIGRAVITY_SIGN_IN}`)
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 400 })
+    ).resolves.toMatchObject({ satisfied: false, blockedReason: 'agent-credential-prompt' })
+  })
+
+  it('admits the send once the sign-in is answered and the agent returns to its prompt', async () => {
+    // The control. Same pane, same title, dialog replaced by live ready chrome.
+    const { runtime, handle } = await createPane(`${ANTIGRAVITY_READY}${ANTIGRAVITY_SIGN_IN}`)
+    await expect(runtime.sendTerminalAgentPrompt(handle, 'first attempt')).rejects.toThrow(
+      'agent_prompt_blocked'
+    )
+
+    runtime.onPtyData(PTY_ID, `\nSigned in as neil@example.com.\n${ANTIGRAVITY_READY}`, Date.now())
+
+    await expect(
+      assertTerminalAgentSendable({ runtime, handle, assertWritable: () => {} })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/main/runtime/terminal-cursor-approval-detection.ts
+++ b/src/main/runtime/terminal-cursor-approval-detection.ts
@@ -1,0 +1,47 @@
+import { startOfLastLines } from './terminal-wait-tail-window'
+
+/** cursor-agent's key-bound exec-approval menu, which no hook reports. */
+// Why text at all: cursor-agent has no approval hook, so the key-bound menu is the only authority.
+const CURSOR_APPROVAL_CHOICE_MARKERS = [
+  'run (once)',
+  'to allowlist?',
+  'run everything',
+  'skip & tell the agent'
+]
+// Why bounded: an answered menu remains in scrollback; only a dialog owning the screen bottom is live.
+const CURSOR_APPROVAL_TAIL_LINES = 8
+
+export function findCursorApprovalPromptIndex(normalized: string): number | null {
+  const windowStart = startOfLastLines(normalized, CURSOR_APPROVAL_TAIL_LINES)
+  const tail = normalized.slice(windowStart)
+  if (!tail.includes('run this command?')) {
+    return null
+  }
+  const lines = tail.split('\n')
+  while (lines.length > 0 && lines.at(-1)?.trim() === '') {
+    lines.pop()
+  }
+  let matchedLines = 0
+  let lastChoiceLine = -1
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!isCursorApprovalChoiceLine(lines[index])) {
+      continue
+    }
+    matchedLines += 1
+    lastChoiceLine = index
+  }
+  return matchedLines >= 2 && lastChoiceLine === lines.length - 1
+    ? windowStart + tail.lastIndexOf('run this command?')
+    : null
+}
+
+// Why the trailing key: narration can repeat the menu wording, but it does not end in a selectable key.
+const CURSOR_APPROVAL_CHOICE_KEY_RE =
+  /\((?:shift\+tab|ctrl\+[a-z]|esc(?: or [a-z])*|tab|enter|return|space|[a-z]|[\u21b5\u21e7\u21b9\u238b\u23ce]{1,3})\)\s*$/
+
+function isCursorApprovalChoiceLine(line: string): boolean {
+  return (
+    CURSOR_APPROVAL_CHOICE_KEY_RE.test(line) &&
+    CURSOR_APPROVAL_CHOICE_MARKERS.some((marker) => line.includes(marker))
+  )
+}

--- a/src/main/runtime/terminal-tail-sentinel-index.test.ts
+++ b/src/main/runtime/terminal-tail-sentinel-index.test.ts
@@ -8,7 +8,7 @@ import {
   tailMayContainBlockedSignal
 } from './terminal-tail-sentinel-index'
 import { computeTerminalTailWaitState } from './terminal-wait-tail-state'
-import { TERMINAL_WAIT_BLOCKED_SENTINEL_RE } from './terminal-wait-detection'
+import { TERMINAL_WAIT_BLOCKED_SENTINEL_RE } from './terminal-wait-blocked-sentinel'
 import type { RetainedTailRedrawCursor } from './terminal-tail-redraw-buffer'
 
 // The definition the incremental index must reproduce: does ANY retained line (or the

--- a/src/main/runtime/terminal-tail-sentinel-index.ts
+++ b/src/main/runtime/terminal-tail-sentinel-index.ts
@@ -1,4 +1,4 @@
-import { TERMINAL_WAIT_BLOCKED_SENTINEL_RE } from './terminal-wait-detection'
+import { mayContainTerminalWaitBlockedSentinel } from './terminal-wait-blocked-sentinel'
 
 /**
  * Which retained tail lines match the wait-blocked sentinel, memoized per
@@ -19,7 +19,7 @@ function collectSentinelMatches(
   into: number[]
 ): void {
   for (let index = startIndex; index < lines.length; index += 1) {
-    if (TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(lines[index]!)) {
+    if (mayContainTerminalWaitBlockedSentinel(lines[index]!)) {
       into.push(index)
     }
   }

--- a/src/main/runtime/terminal-wait-blocked-sentinel.ts
+++ b/src/main/runtime/terminal-wait-blocked-sentinel.ts
@@ -1,0 +1,13 @@
+import { TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE } from './terminal-credential-prompt-detection'
+
+/** Cheap negative scan run per retained tail line, so only candidate-bearing tails parse in full. */
+export const TERMINAL_WAIT_BLOCKED_SENTINEL_RE =
+  /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to (?:confirm|continue|view|insert)|press t to trust|permission required|requires permission|allow once|allow always|run this command\?/i
+
+/** Whether `text` can carry any blocked signal, credential prompts included. */
+export function mayContainTerminalWaitBlockedSentinel(text: string): boolean {
+  return (
+    TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(text) ||
+    TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE.test(text)
+  )
+}

--- a/src/main/runtime/terminal-wait-detection.test.ts
+++ b/src/main/runtime/terminal-wait-detection.test.ts
@@ -476,9 +476,13 @@ describe('Antigravity readiness does not absorb its own startup dialog', () => {
     it(`refuses ${dialog.name} whose wording names no blocked reason, account row and all`, () => {
       const waitText = waitTextFor(dialog.lines)
 
-      // No blocked-signal rule matches, so the ordering defense cannot reach these: readiness has to
-      // refuse them on its own or the orchestrator types into a live dialog.
-      expect(detectTerminalWaitBlockedReason(waitText)).toBeNull()
+      // Only the sign-in dialog names a reason: its `2. Paste an API key` option is a credential
+      // prompt in everything but punctuation. The other four are silent to every blocked-signal
+      // rule, so the ordering defense cannot reach them — readiness has to refuse them on its own
+      // or the orchestrator types into a live dialog.
+      expect(detectTerminalWaitBlockedReason(waitText)).toBe(
+        dialog.name === 'a sign-in dialog' ? 'agent-credential-prompt' : null
+      )
       expect(isKnownReadyPromptPreview(waitText)).toBe(false)
     })
 

--- a/src/main/runtime/terminal-wait-detection.ts
+++ b/src/main/runtime/terminal-wait-detection.ts
@@ -4,11 +4,10 @@ import {
   type AgentStatus
 } from '../../shared/agent-detection'
 import type { RuntimeTerminalWaitBlockedReason } from '../../shared/runtime-types'
-import {
-  isTerminalWaitWhitespace,
-  startOfLastLines,
-  startOfLastNonBlankLines
-} from './terminal-wait-tail-window'
+import { isTerminalWaitWhitespace, startOfLastNonBlankLines } from './terminal-wait-tail-window'
+import { findCursorApprovalPromptIndex } from './terminal-cursor-approval-detection'
+import { findCredentialPromptIndex } from './terminal-credential-prompt-detection'
+import { mayContainTerminalWaitBlockedSentinel } from './terminal-wait-blocked-sentinel'
 
 const EXPLICIT_IDLE_TITLE_RE = /(^|\s)(ready|idle|done)(\s|$|[.!?])/i
 const CLAUDE_IDLE_PREFIX = '\u2733'
@@ -42,10 +41,28 @@ export function isKnownReadyPromptPreview(preview: string): boolean {
     return false
   }
   const blockedSignal = findTerminalWaitBlockedSignal(normalized)
-  if (blockedSignal !== null && blockedSignal.index > readyIndex) {
-    return false
+  if (blockedSignal === null) {
+    return true
   }
-  return true
+  // Why index-independent for these two: an unconditional reason is one a ready caret must not
+  // vouch for, and a dialog drawn over ready chrome can share the caret's offset (#19749).
+  return (
+    !isUnconditionalTerminalWaitBlockedReason(blockedSignal.reason) &&
+    blockedSignal.index <= readyIndex
+  )
+}
+
+/**
+ * Reasons a live non-permission title must not clear.
+ *
+ * `agent-approval-prompt`: cursor-agent never reports idle via OSC title.
+ * `agent-credential-prompt`: a readiness verdict is exactly what is wrong when a
+ * sign-in dialog is on screen, so it cannot be the thing that overrides this.
+ */
+export function isUnconditionalTerminalWaitBlockedReason(
+  reason: RuntimeTerminalWaitBlockedReason | null
+): boolean {
+  return reason === 'agent-approval-prompt' || reason === 'agent-credential-prompt'
 }
 
 export function detectTerminalWaitBlockedReason(
@@ -61,6 +78,12 @@ export function findActionableTerminalWaitBlockedSignal(
   const blockedSignal = findTerminalWaitBlockedSignal(normalized)
   if (blockedSignal === null) {
     return null
+  }
+  // Why never dismissible: a ready caret elsewhere on the screen is not evidence
+  // that a live credential prompt was answered, and mistaking one for the other
+  // submits the task prompt as a credential.
+  if (blockedSignal.reason === 'agent-credential-prompt') {
+    return blockedSignal
   }
   const dismissedModalIndex = findDismissedStartupModalIndex(normalized)
   // Why: a live prompt after the modal means it was dismissed → signal no longer actionable, even mid-run (Cursor never reports idle via OSC title).
@@ -158,54 +181,6 @@ function findAntigravityReadyPromptIndex(normalized: string): number | null {
   return modelIndex !== null && promptIndex !== null ? Math.max(modelIndex, promptIndex) : null
 }
 
-export const TERMINAL_WAIT_BLOCKED_SENTINEL_RE =
-  /update available|choose working directory to|codex just got an upgrade|hooks need review|do you trust|trust this|trusted workspace|press enter to (?:confirm|continue|view|insert)|press t to trust|permission required|requires permission|allow once|allow always|run this command\?/i
-
-// Why text at all: cursor-agent has no approval hook, so the key-bound menu is the only authority.
-const CURSOR_APPROVAL_CHOICE_MARKERS = [
-  'run (once)',
-  'to allowlist?',
-  'run everything',
-  'skip & tell the agent'
-]
-// Why bounded: an answered menu remains in scrollback; only a dialog owning the screen bottom is live.
-const CURSOR_APPROVAL_TAIL_LINES = 8
-
-function findCursorApprovalPromptIndex(normalized: string): number | null {
-  const windowStart = startOfLastLines(normalized, CURSOR_APPROVAL_TAIL_LINES)
-  const tail = normalized.slice(windowStart)
-  if (!tail.includes('run this command?')) {
-    return null
-  }
-  const lines = tail.split('\n')
-  while (lines.length > 0 && lines.at(-1)?.trim() === '') {
-    lines.pop()
-  }
-  let matchedLines = 0
-  let lastChoiceLine = -1
-  for (let index = 0; index < lines.length; index += 1) {
-    if (!isCursorApprovalChoiceLine(lines[index])) {
-      continue
-    }
-    matchedLines += 1
-    lastChoiceLine = index
-  }
-  return matchedLines >= 2 && lastChoiceLine === lines.length - 1
-    ? windowStart + tail.lastIndexOf('run this command?')
-    : null
-}
-
-// Why the trailing key: narration can repeat the menu wording, but it does not end in a selectable key.
-const CURSOR_APPROVAL_CHOICE_KEY_RE =
-  /\((?:shift\+tab|ctrl\+[a-z]|esc(?: or [a-z])*|tab|enter|return|space|[a-z]|[\u21b5\u21e7\u21b9\u238b\u23ce]{1,3})\)\s*$/
-
-function isCursorApprovalChoiceLine(line: string): boolean {
-  return (
-    CURSOR_APPROVAL_CHOICE_KEY_RE.test(line) &&
-    CURSOR_APPROVAL_CHOICE_MARKERS.some((marker) => line.includes(marker))
-  )
-}
-
 // Why bounded: answered dialogs and quoted prompt wording (agents grep this file and its specs) stay in the
 // retained tail; only a dialog owning the screen bottom is live. Real Codex dialogs (trust, hooks review,
 // update, exec approval) are 4-8 lines; the slack covers a wrapped command or a longer hook list.
@@ -217,7 +192,7 @@ function findTerminalWaitBlockedSignal(
   const windowStart = startOfLastNonBlankLines(fullTail, LIVE_PROMPT_TAIL_LINES)
   const normalized = windowStart === 0 ? fullTail : fullTail.slice(windowStart)
   // Why: one combined negative scan avoids a dozen searches when no prompt can match.
-  if (!TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(normalized)) {
+  if (!mayContainTerminalWaitBlockedSentinel(normalized)) {
     return null
   }
   const signal = findBlockedSignalInLiveWindow(normalized)
@@ -228,7 +203,10 @@ function findTerminalWaitBlockedSignal(
 function findBlockedSignalInLiveWindow(
   normalized: string
 ): { reason: RuntimeTerminalWaitBlockedReason; index: number } | null {
-  const candidates: { reason: RuntimeTerminalWaitBlockedReason; index: number }[] = []
+  const candidates: {
+    reason: RuntimeTerminalWaitBlockedReason
+    index: number
+  }[] = []
   const updateIndex = normalized.lastIndexOf('update available')
   if (updateIndex !== -1 && normalized.includes('press enter to continue', updateIndex)) {
     candidates.push({ reason: 'agent-update-prompt', index: updateIndex })
@@ -242,7 +220,10 @@ function findBlockedSignalInLiveWindow(
     modelMigrationIndex !== -1 &&
     normalized.includes('press enter to continue', modelMigrationIndex)
   ) {
-    candidates.push({ reason: 'codex-model-migration-prompt', index: modelMigrationIndex })
+    candidates.push({
+      reason: 'codex-model-migration-prompt',
+      index: modelMigrationIndex
+    })
   }
   const hooksIndex = normalized.lastIndexOf('hooks need review')
   if (hooksIndex !== -1 && normalized.includes('press enter to confirm', hooksIndex)) {
@@ -294,9 +275,19 @@ function findBlockedSignalInLiveWindow(
       candidates.push({ reason: 'agent-interactive-prompt', index: interactivePromptIndex })
     }
   }
+  const credentialPromptIndex = findCredentialPromptIndex(normalized)
+  if (credentialPromptIndex !== null) {
+    candidates.push({
+      reason: 'agent-credential-prompt',
+      index: credentialPromptIndex
+    })
+  }
   const cursorApprovalIndex = findCursorApprovalPromptIndex(normalized)
   if (cursorApprovalIndex !== null) {
-    candidates.push({ reason: 'agent-approval-prompt', index: cursorApprovalIndex })
+    candidates.push({
+      reason: 'agent-approval-prompt',
+      index: cursorApprovalIndex
+    })
   }
   const permissionPromptIndex = Math.max(
     normalized.lastIndexOf('permission required'),
@@ -317,9 +308,14 @@ function findBlockedSignalInLiveWindow(
       candidates.push({ reason: 'agent-interactive-prompt', index: permissionPromptIndex })
     }
   }
-  return candidates.length > 0
-    ? candidates.reduce((latest, candidate) =>
-        candidate.index > latest.index ? candidate : latest
-      )
-    : null
+  if (candidates.length === 0) {
+    return null
+  }
+  // Why it outranks a later signal: every other reason can be cleared by a ready
+  // caret, so a credential prompt losing the index race would lose the block too.
+  const credential = candidates.find((candidate) => candidate.reason === 'agent-credential-prompt')
+  return (
+    credential ??
+    candidates.reduce((latest, candidate) => (candidate.index > latest.index ? candidate : latest))
+  )
 }

--- a/src/main/runtime/terminal-wait-tail-state.ts
+++ b/src/main/runtime/terminal-wait-tail-state.ts
@@ -1,10 +1,8 @@
 import type { RuntimeTerminalWaitBlockedReason } from '../../shared/runtime-types'
 import { buildTailLines } from './terminal-tail-state'
 import { tailMayContainBlockedSignal } from './terminal-tail-sentinel-index'
-import {
-  findActionableTerminalWaitBlockedSignal,
-  TERMINAL_WAIT_BLOCKED_SENTINEL_RE
-} from './terminal-wait-detection'
+import { findActionableTerminalWaitBlockedSignal } from './terminal-wait-detection'
+import { mayContainTerminalWaitBlockedSentinel } from './terminal-wait-blocked-sentinel'
 
 export function buildTerminalWaitText(
   lines: string[],
@@ -66,7 +64,7 @@ function inspectTerminalWaitTail(
     // Why the index: proving a signal is ABSENT can't early-exit, so a full re-test of the
     // 2000-line tail ran per scan; the index tests only the lines each append produced.
     mayContainBlockedSignal:
-      tailMayContainBlockedSignal(lines) || TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(partialLine)
+      tailMayContainBlockedSignal(lines) || mayContainTerminalWaitBlockedSentinel(partialLine)
   }
 }
 

--- a/src/main/runtime/terminal-wait-tail-window.test.ts
+++ b/src/main/runtime/terminal-wait-tail-window.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { startOfLastLines, startOfLastNonBlankLines } from './terminal-wait-tail-window'
+
+describe('startOfLastNonBlankLines', () => {
+  it('returns 0 for a tail that begins with a newline', () => {
+    // Regression: `lastIndexOf('\n', -1)` clamps its position argument up to 0, so a leading
+    // newline made the walk answer lineStart=1 with lineEnd=0 forever. Every caller runs on
+    // the main process's PTY data path, so the spin was a hard hang, not a slow scan. Reached
+    // only when the tail also holds fewer than `count` non-blank lines, which is the shape of
+    // a small startup dialog on an otherwise empty screen.
+    expect(startOfLastNonBlankLines('\ndo you trust this folder?', 12)).toBe(0)
+    expect(startOfLastNonBlankLines('\n', 12)).toBe(0)
+    expect(startOfLastNonBlankLines('\n\n\n  \n', 4)).toBe(0)
+  })
+
+  it('still windows a tail with interior blank rows', () => {
+    const tail = 'one\n\ntwo\n\nthree'
+    expect(startOfLastNonBlankLines(tail, 1)).toBe(tail.indexOf('three'))
+    expect(startOfLastNonBlankLines(tail, 2)).toBe(tail.indexOf('two'))
+    expect(startOfLastNonBlankLines(tail, 9)).toBe(0)
+  })
+
+  it('counts blank rows in the raw line window', () => {
+    const tail = 'one\n\ntwo'
+    expect(startOfLastLines(tail, 2)).toBe(tail.indexOf('\ntwo') - 0)
+    expect(startOfLastLines(tail, 9)).toBe(0)
+  })
+})

--- a/src/main/runtime/terminal-wait-tail-window.ts
+++ b/src/main/runtime/terminal-wait-tail-window.ts
@@ -31,7 +31,10 @@ export function startOfLastNonBlankLines(value: string, count: number): number {
         return lineStart
       }
     }
-    if (lineStart === 0) {
+    // Why `lineEnd === 0`: a tail whose first character is a newline makes
+    // `lastIndexOf('\n', -1)` answer 0 (the position argument clamps up), so
+    // `lineStart` stays 1 while `lineEnd` stays 0 and the walk never advances.
+    if (lineStart === 0 || lineEnd === 0) {
       return 0
     }
     lineEnd = lineStart - 1

--- a/src/shared/runtime-terminal-contracts.ts
+++ b/src/shared/runtime-terminal-contracts.ts
@@ -347,6 +347,7 @@ export type RuntimeTerminalWaitBlockedReason =
   | 'agent-hooks-review-prompt'
   | 'agent-interactive-prompt'
   | 'agent-approval-prompt'
+  | 'agent-credential-prompt'
 
 export type RuntimeTerminalWait = {
   handle: string

--- a/src/shared/terminal-wait-blocked-reason-legacy-alias.test.ts
+++ b/src/shared/terminal-wait-blocked-reason-legacy-alias.test.ts
@@ -50,10 +50,17 @@ describe('describeTerminalWaitBlockedReason', () => {
     )
   })
 
-  it.each(['agent-trust-workspace', 'codex-model-migration-prompt'] as const)(
-    'renders %s unannotated',
-    (reason) => {
-      expect(describeTerminalWaitBlockedReason(reason)).toBe(reason)
-    }
-  )
+  it.each([
+    'agent-trust-workspace',
+    'codex-model-migration-prompt',
+    // Why pinned: this reason was born neutral, so it has no older spelling to annotate. An alias
+    // entry for it would invent one and print it at all four render sites.
+    'agent-credential-prompt'
+  ] as const)('renders %s unannotated', (reason) => {
+    expect(describeTerminalWaitBlockedReason(reason)).toBe(reason)
+  })
+
+  it('has no legacy alias for the credential prompt', () => {
+    expect(agentNeutralTerminalWaitBlockedReason('agent-credential-prompt')).toBeNull()
+  })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​992 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​982 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​456 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​79 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​377 |

<!-- /orca-pr-loc -->

## Scope — one write path, not all of them

Read this before the rest. The fence lives at exactly one place, `orca-runtime-write-terminal-agent-prompt.ts`, and `terminal-send-method.ts:192` only routes there when **all** of `agentPrompt === true && hasText && enter === true && interrupt !== true && client.type === 'desktop'` hold (and the pane runs a settled-prompt agent). Everything else falls through to `runtime.sendTerminal`, which is unchanged by this PR.

| write path | can carry user text | fenced by this PR |
| --- | :---: | :---: |
| `sendTerminalAgentPrompt` → `writeTerminalAgentPrompt` (CLI `--text --enter`, worker start, `dispatch --inject`, coordinator auto-dispatch, federated preamble) | yes | **yes** |
| `runtime.sendTerminal` (`runtime-terminal-writer.ts`) — ownership lease only | yes | no |
| **mobile RPC `terminal.send`** — fails the `client.type === 'desktop'` check outright | yes | **no** |
| `orca terminal send --text X` **without** `--enter` | yes | no (see below) |
| `window.api.pty.write` from the renderer (`agent-paste-draft.ts`) | yes | no — **closed by #20004** |
| plugin `terminal.sendText` | yes | no |
| `mailbox-pointer-pty-write.ts:26` | no (fixed pointer text) | no |

**Mobile is entirely unfenced.** A phone sending `terminal.send` with text and enter takes the `sendTerminal` path and meets no credential check. Do not read this PR as "Orca now refuses credential-prompt writes."

None of these six were fenced before this PR either — it adds a fence to one path rather than removing one from the others. That makes the uncovered surface **incompleteness, not regression**. It is called out here so nobody infers otherwise from the title.

### The `--enter` asymmetry is a decision, not an omission

`src/cli/handlers/terminal-send.ts:18` sets `agentPrompt` only when `!!text && enter && !interrupt`, so the same text with and without `--enter` gets different treatment, and a two-phase send (`--text X`, then a bare Enter) bypasses the fence entirely.

That is deliberate and should stay: **`--text` without `--enter` is how you legitimately answer a credential prompt.** Fencing it would make it impossible to type a password into the very dialog this detector exists to recognise. Please do not "fix" this without replacing the escape hatch.

## What

When Orca decides an agent is ready, it types the user's task prompt into that pane. If the readiness verdict is wrong and a credential surface is on screen instead, the prompt is submitted to an auth provider as a credential attempt — and if that surface echoes, it also lands verbatim in the session transcript.

**This is vocabulary added to a fence that already exists, not a new enforcement layer.** That framing matters for review. `writeTerminalAgentPrompt` already throws `agent_prompt_blocked` whenever `getAgentPromptActivity` reads `permission`, and that status already comes from `detectTerminalWaitBlockedReason` over the terminal tail. The fence knew about trust dialogs, update banners, hooks review and approval menus — and nothing about passwords, API keys, passphrases, OTPs, 2FA codes, sign-in menus or OAuth device codes. So the change is one new agent-neutral reason, `agent-credential-prompt`, plus a shape-based detector that produces it. No new call sites, no new gate.

Two properties are deliberate:

- **It defers, it does not drop.** The caller gets `agent_prompt_blocked` with a named reason, and `terminal.wait --tui-idle` reports `blockedReason: 'agent-credential-prompt'` instead of resolving. The idle poll re-reads the tail, so the refusal clears by itself once the dialog is answered. There is a test for exactly that: refuse, sign in, then the same pane admits the send.
- **It is unconditional.** Unlike every other blocked reason, a live idle OSC title and a ready caret elsewhere on the screen cannot clear it. That asymmetry is the whole point: a wrong readiness verdict is the thing being guarded against, so it must not be the thing that overrides the guard. `isKnownReadyPromptPreview` also stops calling such a screen ready.

Because the reason is unconditional, **a false positive is not free**. It does not merely defer a prompt: it also publishes an idle agent as `status: 'permission'` into the one agent-status store, so the sidebar, `worktree ps`, mobile and the dashboard all show it as waiting on the user until new output arrives. That cost is what drives the position discipline described below.

## ELI5

When Orca starts an agent for you, it watches the terminal, waits until the agent looks ready, and then types your task into it. If that judgement is wrong and what's really on screen is a sign-in box asking for a password, an API key or a 2FA code, Orca types your task **into that box and presses enter** — handing it to an auth provider as a credential attempt, and, if the box echoes, writing it into the saved session transcript too.

Orca already had a "don't type yet" check; it just didn't know what credential prompts look like. It knew about trust dialogs, update banners and approval menus, and nothing about passwords. This PR teaches it that vocabulary. When it sees a credential prompt it refuses to send and says why, and because the check re-reads the screen, the refusal clears by itself once you've signed in.

The rule that keeps it from over-firing is **shape, not wording**: a credential prompt is a *request for input*. It sits at the bottom of the screen and ends in a colon or an input caret. An agent *talking about* authentication is prose, and it leaves its own composer caret on the last row. `Enter the verification code we sent to your phone:` is blocked; `• I implemented two-factor authentication for the login flow.` above a `› Ask Codex to do anything` caret is not.

This covers the orchestration and CLI route into a terminal. #20004 does the same for the other route.

## Why now

The Antigravity readiness detector motivating this has been reverted to merge-base on #19749, but the premise survives the revert. #19749's own loop-3 finding documented a residual it explicitly chose not to fix:

> a _silent_ startup modal — one whose wording falls entirely outside the blocked-signal vocabulary — drawn over a complete ready chrome can still read as ready. Ordering cannot help, because there is no signal to order against. Documented rather than papered over.

That residual is now a permanent documented property of shipping code. Adding credential wording to the vocabulary is the only thing that gives ordering something to order against. The exposure is also not confined to worker-start: `dispatch-methods.ts:159` and `coordinator-task-dispatch.ts:139` have no pre-write `tui-idle` wait at all and rely entirely on this in-write fence.

## The 18 false positives this PR's earlier detector produced

An earlier revision of this branch paired an auth **verb** with an auth **flow phrase** anywhere in the live window, with no terminator requirement and no position requirement. That is the shape of an agent *reporting* auth work, not the shape of a credential prompt. A readiness review found **18 real screens** that refused a prompt and pinned the agent to `permission`. All of them carry the agent's own live composer caret, which — because the reason is unconditional — does **not** clear the block.

Verbatim, as they appear on screen:

```
• I implemented two-factor authentication for the login flow.
  The authenticator app now generates a 6-digit code.
› Ask Codex to do anything
```

```
· Added two-factor authentication. Tests for the authenticator app pass.
✳ Claude Code
>
```

```
  └ src/Login.tsx:31:  <button>Sign in with GitHub</button>
  └ src/Login.tsx:44:  // authorization code exchange
› Ask Codex to do anything
```

```
Error: authentication required
    at signInWithToken (auth.ts:22)
› Ask Codex to do anything
```

The remaining fourteen are the same failure mode across Codex, Claude Code, Gemini and OpenCode: completion summaries about SSO/MFA/OAuth work, `rg` hits on auth documentation and login components, a shell deploy failure, and an agent asking the user whether MFA should be required.

**The earlier corpus missed an entire category.** The "0 false positives on 31 legitimate screens" claim this body previously carried was true of those 31 screens and false in the field: not one of them paired an auth verb with an auth-flow phrase, which is precisely the combination that produced all 18. The category it lacked is the most common thing an agent does after working on a login flow — narrate what it just built. All 18 are now in the suite as must-allow cases.

## The rule as it now stands

The pair rule is replaced by two rules, both of which demand prompt *shape*:

1. **Bottom-anchored request.** The auth-flow marker must sit on the **last non-blank row**; that row must not be a finished sentence (a lone `.` / `!` / `?` — `...` and `…` are progress wording, not sentences, so `Press Enter to open github.com in your browser...` still qualifies); and the window must also carry an auth verb or a credential noun.
2. **Interactive auth question.** A row shaped `? …` carrying an auth verb or flow phrase. Prose never starts with a bare `?`, so this is unambiguously a dialog header even when its options wrap below it.

Rule 2 exists for a specific true positive. A plain "flow marker must be the last row" rule loses the antigravity auth-method menu, where the flow marker is on the *second-to-last* row:

```
? How would you like to authenticate?
❯ Sign in with Google
  Use an API key
```

Rule 2 recovers it without loosening rule 1. It is the only true positive in the corpus that the last-row rule alone would have dropped.

**`AUTH_FLOW_RE` is split into action wording and topic wording.** Action wording (`sign in with`, `authentication required`, `press enter to open`, `waiting for authentication`, `paste code here`, `enter the code`, `open this url`) is what a dialog addressing the user says. Topic wording (`2fa`, `two-factor`, `authenticator app`, `device code`, `verification code`, `N-digit code`) is equally at home in narration, so it only carries the bottom row when that row is also terminated. The concrete reason: without the split, a bottom row reading `sms verification code` blocks.

**The bare-label rule is also position-gated now.** `password:` with no ask verb is how a printed k8s manifest and a form template read, so it only counts on the bottom row. That closes the reported `kind: Secret` / `stringData:` / `password:` / `› Ask Codex to do anything` false positive. `Enter your API key:` keeps its ask-verb path and is unaffected by position.

## The lane divergence this PR shipped with, now fixed

The detector had a cheap prefilter, `TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE`, run per retained tail line so that only candidate-bearing tails parse in full. Its doc comment says it "must stay a superset" of the index. **It was not a superset**, and the consequence was that the two lanes disagreed about the dialog this whole guard was written for.

`terminal-wait-detection.test.ts:427` already held the fixture — the live Antigravity sign-in menu from F19749-1:

```
Antigravity CLI 1.0.3
user@example.com (Antigravity Business)
Sign in to continue
~/orca/workspaces/orca/agy-dispatch-issue
1. Open browser
2. Paste an API key
>
```

`2. Paste an API key` **is** a prompt to `findCredentialPromptIndex`, because `PURE_TERMINATOR_RE` treats end-of-row as a terminator. But the sentinel only accepted a credential noun followed by punctuation, and this menu has no punctuation anywhere. So the renderer lane (which has no prefilter) refused the screen while the main lane returned clean.

Why the corpus never caught it: the test asserting the superset property ran **only over `LIVE_CREDENTIAL_SURFACES`** — the screens we already believed block. A prefilter bug on a screen we had wrongly classified as clean is invisible to that test by construction. The invariant is about the index's own verdict, so it now runs over **both** corpora:

```ts
for (const [name, lines] of [...LIVE_CREDENTIAL_SURFACES, ...LEGITIMATE_AGENT_SCREENS]) {
  if (findCredentialPromptIndex(screen(lines).toLowerCase()) === null) continue
  expect(lines.some((line) => TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE.test(line)), name).toBe(true)
}
```

The sentinel now also accepts a row-final noun and tolerates a trailing box rule (a framed dialog ends `… API key here:   │`, which it had been counting as "not a terminator" — every full-box TUI was invisible to it). The sign-in menu's sibling dialogs — the model picker and the privacy notice, same chrome, same bare `>` caret — are pinned as must-allow so this cannot be widened into them.

## A near-miss worth reading: the sentinel is quadratic if you spell it the obvious way

The common api-key ask names the env var it fills (`Enter your OPENAI_API_KEY:`), which `api[ -]?key` misses. The natural fix is a vendor slot in the noun alternation:

```
(?:[a-z0-9]+_)?api[ _-]?keys?
```

That is **30 ms on a single 5.5k-character line**, in a regex that runs per retained tail line at streaming rate. `[a-z0-9]+` scans forward at every start offset and backtracks looking for `_`, which is O(n²) per line. It hung the tail-index suite outright.

The vendor slot belongs in the **prefix** rules instead — `CREDENTIAL_ASK_PREFIX_RE` tolerating a trailing `_`, and `CREDENTIAL_LABEL_PREFIX_RE` accepting a bounded, anchored `[a-z][a-z0-9]{0,20}_` segment. Same coverage, **0.03 ms**, ~1000x. A budget test now pins it, and reinstating the quadratic form fails that test.

## Named limitation: the detector is English-only

**10 of 15 non-English credential prompts are not detected**, including localized `git` credential prompts (`'https://github.com' 的用户名:`) and zh/ja/ko/ru/pt/fr api-key, password and verification-code asks. The originating user report on #19749 was in Traditional Chinese, so this population is real, not hypothetical.

This is named scope, not oversight. Adding CJK/European credential nouns imports a **new false-positive population** in the same move: `密碼：` and `パスワード:` appear constantly in agent narration *about* password work, and the position discipline that separates a prompt from a mention in English has no equivalent tuned for those languages. Doing it properly is a feature, and doing it hastily would undo the false-positive work this PR just did. A follow-up should build a non-English corpus first.

Two things that *are* fixed here, because they are locale-independent:

- **`sudo` on any locale.** sudo translates its prompt but never its `[sudo]` tag (`[sudo] Passwort für neil:`, `[sudo] neil 的密碼：`), and the only thing it ever asks for at that tag is a password. The rule now keys on the tag.
- **Env-var api-key asks** (`Enter your OPENAI_API_KEY:`), per above.

## Two false negatives, now fixed

The same review found two flows this PR named as targets and did not actually catch. Both are real credential surfaces and both are now blocked:

```
! First copy your one-time code: 1A2B-3C4D
Press Enter to open github.com in your browser...
```

```
Browser didn't open? Use the url below to sign in:
https://claude.ai/oauth/authorize?code=true
Paste code here if prompted >
```

The first is `gh auth login`'s device code; the second is Claude Code's own `/login` paste-code screen. Bottom-anchoring plus widening `paste (the|your)? code (here|below)` closes both.

## Two screens still block, deliberately

```
SYNOPSIS
     ssh [-l login_name] ...
     Enter passphrase for key:
```

```
npm notice Log in on https://registry.npmjs.org/
Username:
Password:
```

The npm one **is** a real credential prompt — blocking it is correct, not a false positive. The ssh man page is byte-ambiguous with the genuine `Enter passphrase for key:` prompt; no amount of shape discipline separates them, and the asymmetric bias says refuse. Both clear on the next repaint. Stating them rather than quietly counting them as passes.

## False positives — measured, not estimated

| Corpus | Result |
| --- | --- |
| **91 must-allow screens** (31 original + the 18 false positives above + 21 found by adversarial probing) | **91/91 pass** |
| **35 must-refuse screens** (23 original + 2 earlier false negatives + 10 found by adversarial probing) | **35/35 refuse** |
| `TERMINAL_TITLE_CLASSIFICATION_CORPUS` (67 titles) | **0 fire** |
| **991,869 string literals** extracted from all 21,276 source files under `src/`, each read as a screen | **171 hits before → 157 after**; **0 newly blocked**, **10 freed** |

The 10 literals freed are all genuine Orca UI strings that had no business blocking anything — `Sign in required.`, `Sign in with the account you want to add (e.g. use a private/incognito browser window for a second account).`, `Claude is not signed in for the selected account. Sign in with the Claude CLI for this CLAUDE_CONFIG_DIR, then retry.`, the Gemini CLI OAuth extraction description, and similar. Zero literals started blocking that did not block before.

The must-allow corpus is the one that matters: agents narrating credential work, agents *summarising* completed auth work (the category the earlier corpus lacked), agents *asking* the user credential-adjacent questions, the user's own task prompt echoed above the composer, `rg` output quoting prompt wording, diffs that add credential prompt strings, and printed config whose bare `password:` label is not the bottom row.

Detection stays bounded to the last 4 non-blank lines, because an answered prompt stays in scrollback and agents print credential wording constantly while working on auth code.

Bias is toward refusing on purpose: a false negative types secrets-adjacent text into a credential field, a false positive delays a prompt until a dialog is answered — but, per the note in **What**, it also mislabels an idle agent, so "refuse when unsure" is not a licence to match on wording alone.

## Mutation evidence

Not verified by reading.

- **Reverting the detector rule** while keeping the corpus turns **23 tests red** (and more now that the corpus has grown) in `terminal-credential-prompt-detection.test.ts`: all 18 new must-allow screens, both new must-refuse screens at both their assertion sites, and the sentinel-superset test. Every new case dies under the mutation that should kill it.
- **Disabling the credential candidate in `findBlockedSignalInLiveWindow`** turns **29 tests red**, and two of the write-site regressions then **time out at 30s because the prompt actually reaches the PTY** — which is the harm, reproduced.

The regression fixture is the #19749 screen itself: full Antigravity ready chrome that the reverted merge-base detector accepts (header, a `gemini` model row, a lone `>` caret), an idle OSC title, and a device-code sign-in dialog drawn over it. The test asserts the send is refused **and that zero bytes reach the PTY**.

## Wire compatibility

Additive union member, no capability negotiation needed. `docs/reference/remote-wire-compatibility.md:179-180` names this enum as an explicit Rule 1 exception: _"New members added to `RuntimeTerminalWaitBlockedReason` are also Rule 1: no consumer switches exhaustively on it, and both the CLI and worker-start interpolate it as an opaque string."_

**This PR adds exactly one member: `agent-credential-prompt`.** To be unambiguous, because a review of the combined stack read them as belonging here: the five `codex-*` → `agent-*` renames (`codex-update-prompt`, `codex-cwd-prompt`, `codex-hooks-review-prompt`, `codex-trust-workspace`, `codex-interactive-prompt`) are **#19749's**, this PR's base branch, and appear in a diff against `main` only because of the stacking. They are not part of this change.

**`agent-credential-prompt` is deliberately NOT in the legacy alias map.** It was born neutral — no host ever published a `codex-credential-prompt`, so there is no older spelling to alias. An alias entry would invent one and render `agent-credential-prompt (…)` at all four sites that use `describeTerminalWaitBlockedReason`. Two tests in `terminal-wait-blocked-reason-legacy-alias.test.ts` pin that it renders unannotated and resolves to no alias, so this does not get "fixed" later.

## False positives found after review, and how they were found

Counts and suite sizes in this body are **at time of writing**; they have gone stale twice already
as the corpus grew.

Five false-positive classes reached this PR past a two-sided corpus that read 100% clean. Every one
was a term the corpus **already contained**, sitting in a position nobody had written down — which
is the failure mode of a curated corpus, not an accident.

### The one that matters most: formatted source code

Replaying 16,206 credential-vocabulary lines mined from this repo's own tracked files, each placed
one row above a real agent composer caret, produced **100 refusals across 25 distinct lines** on
Codex, Claude Code and OpenCode. The corpus had `rg` hits and diffs, which carry their own chrome,
but no plain formatted source.

24 of the 25 are one shape:

```
      ? 'Update desktop Orca and sign in to connect from anywhere'
› Ask Codex to do anything
```

`AUTH_QUESTION_ROW_RE` rests on the comment "Prose never starts with a bare `?`". That is true of
prose and **irrelevant**: oxfmt puts a ternary's consequent on its own row exactly that way, and
**5,666 tracked files in this repo contain such a line**. `sawAuthQuestion` then returned
unconditionally, with no position requirement, so a composer caret directly below could not clear
it. Any agent printing Orca's own source tripped it. Nine of the 25 matched only because
`\b(?:log[ -]?in)\b` reads `user.login` as the auth verb.

The 25th is a different rule and a real wrapped comment in this repo:

```
    // Why: a merely missing or expired bundle must not enter the credential
```

`CREDENTIAL_ASK_PREFIX_RE` was unanchored, so an ask verb anywhere in a row made a row-final
credential noun a prompt. Terminal wrapping makes ending on a noun routine.

### Why `isLastRow` is NOT the gate on the ask-prefix path

The obvious simplification is to require the ask-prefix path to be the last row, matching the
bare-label rule. **Do not do this — it silently deletes the dialog this guard exists for.** In the
Antigravity sign-in menu the credential row is not the last row:

```
1. Open browser
2. Paste an API key      <- the only row that makes this a credential surface
>                        <- the last row
```

`2. Paste an API key` is a prompt because end-of-row counts as a terminator. Gate it on `isLastRow`
and the #19749 dialog stops being detected. The rule used instead is position of a different kind:
the ask verb must **lead** its row, modulo decoration and a menu number. `2. Paste an API key`
leads; sixty characters of prose before `enter the` does not.

### Two more, found by the generative suite this PR adds

`candidate.credential` set the credential-noun flag, because only the auth-verb regex had been
taught that a dot means a property access. That flag corroborates an otherwise-inert bottom row, so
an identifier alone could refuse a screen that was only printing source. Excluded `.` and `.` only:
`\w` would break the env-var ask (`OPENAI_API_KEY`), which is a real prompt.

`    // Sign in with the provider console to continue` read as a dialog leading its row, because the
decoration run accepted a comment marker. A dialog decorates with box rules, bullets, carets and
menu numbers, never with `//` or `*`.

### The mechanism, not just the fixes

`terminal-credential-vocabulary-shapes.test.ts` expands the detector's **own** vocabulary sources
into plain phrases and crosses every term against the shapes a term takes when it is output rather
than a prompt, above each agent's composer caret. It grows by itself: add a noun to
`CREDENTIAL_NOUN_SOURCE` and it is checked in every shape on the next run.

It is deterministic (depends only on the detector, not on repo contents), bounded (~1,400
evaluations, 12ms), and it carries a positive control asserting every noun still refuses in a real
ask, so the negative cases cannot pass by the detector having quietly stopped working. All seven
mutations — the five fixes above, the earlier flow-rule position discipline, and a fully disabled
detector — turn it red.

### Validation against real recorded output

The detector now runs clean over **all 11 captured PTY transcripts in the repo** — the eight real
`agy` transcripts added by #19983 (including `antigravity-ready-api-key-gemini-model`, whose ready
chrome names an API key) and the three cursor-agent captures. Zero false positives on real recorded
agent output.

### Agents with no evidence behind them

Coverage rests on recorded or reconstructed output for Codex, Claude Code, Gemini, OpenCode,
cursor-agent, Antigravity and Command Code. **25 agents have no transcript.** Five are title-only —
`pi`, `omp`, `hermes`, `copilot`, `devin` — and twenty have nothing at all. Their chrome is
unverified against this detector in either direction.

### Shapes this detector does not catch, measured

Independent verification compared this detector against the previous revision and found 12 shapes
that stopped being refused. **All 12 behave exactly as `origin/main` does, which has no credential
detection at all**, so they are incompleteness against an intermediate commit on this branch rather
than a regression against the merge target. Naming them instead of quietly re-tuning:

- One was worth fixing and is fixed: `? Authenticate with the CLI? [Y/n]`. A bracketed confirm
  default is a mainstream convention (apt, readline, enquirer), and `[`/`]` have been dropped from
  the code-shape class. `(y/N)` with parentheses always worked.
- The rest hinge on a dot inside a host name (`github.com`, `neil@example.com`) reading as a
  property access. Real git credential prompts are unaffected — they route through
  `GIT_CREDENTIAL_RE` (`Username for 'https://github.com':`) and stay refused — so the residue is
  auth-adjacent prose that mentions a hostname, which was never a live prompt.

### A complexity hazard that the budget test could not see

Worth reading before touching any rule here. The noun lookbehind was briefly written as
`(?<!\.[a-z0-9_$]*)`, which is **quadratic**: the engine retries it from every position in an
identifier run, so doubling the run quadruples the cost — measured 79µs / 286µs / 4572µs at
512 / 1024 / 4096 characters.

The budget test did not catch it, for two compounding reasons:

1. it drove `TERMINAL_CREDENTIAL_PROMPT_SENTINEL_RE`, which is built from the **raw** noun source
   and carries no lookbehind, so it is structurally blind to the rule that has one;
2. driving `findCredentialPromptIndex` instead does not help either, because
   `MAX_CREDENTIAL_LINE_LENGTH` caps every row at 512 characters, and at that length a quadratic
   lookbehind is only ~1.7× a linear one. A test above the cap measures the cap; a test below it
   cannot discriminate.

The bound is `{0,64}` — it must exceed the longest realistic dot-to-noun distance (39 in this repo today) while staying bounded. The durable part is that the budget now drives the noun regex directly and
asserts the complexity **class** at 1024 vs 4096, so the 512 cap is a safety margin rather than the
only thing holding — and that cap is documented where it is defined as load-bearing for complexity,
not merely for throughput.

### What this detector does in a plain shell pane, by design

Mined into a **shell pane** — no agent composer anywhere on screen — rather than above a composer,
20,350 rows produce **25 refusals from 18 distinct rows**, a bottom-row rate of **0.12%**, stable
across verification passes. Every one is either the deliberate bottom-row bare-label rule
(`credentialIds: Set<string>`, `apiKey`, `credentialError:`) or one of this detector's own corpus
strings quoted in source.

This is intended, not a defect, and a reader should know it: **a shell pane whose bottom row is
credential-shaped source will occasionally be refused.** The bare-label rule exists because
`Password:` on the bottom row is exactly what `docker login`, `sudo` and `git` print, and nothing
on screen distinguishes that from a printed manifest. The refusal is transient — it clears as soon
as the shell repaints a new bottom row — and it surfaces synchronously with a named reason rather
than hanging.

One known constructible case is deliberately **not** fixed: a `?` row carrying only brackets
(`? [signIn, signOut]`, `? credentials[index]`) can refuse in a shell pane with no composer below,
because `[`/`]` were removed from the code-shape class so that bracketed confirm defaults
(`? Authenticate with the CLI? [Y/n]`) keep working. All eight real instances in this repo also
carry a dot access and stay code-shaped, and a sweep of 20,350 shell-pane rows found zero
occurrences of the bare shape. Adding another shape rule to catch something that does not occur is
how the previous rounds of surface area got added.

## Coverage is explicitly PARTIAL

See the inventory table at the top for the write-path breakdown. Beyond that, three detector-level gaps are measured and deliberately left open:

- **Wrapped prompts.** At 80 columns, `Enter the personal access token for https://github.com/…(scopes: r` / `epo, workflow, read:org):` puts the noun on one row and the terminator on the next, and does not match. Same for a long ssh passphrase path. Fixing it means joining adjacent rows, which fabricates text that was never on screen and breaks the byte-identity equivalence proof #20004 adds.
- **Chatter printed after the prompt.** `CREDENTIAL_TAIL_LINES = 4`, so the #19749 screen *plus* a `Press Ctrl+C to cancel` footer is clean, as is Claude `/login` plus its footer, and `docker login` whose password ask is pushed up by its own multi-line warning. Widening the window strictly increases false positives.
- **Three remaining false positives**, all pre-existing tuning debt rather than new: a bare `password:` label owning the bottom row (a printed k8s manifest or form template), and an inquirer-style `? Should the app use sign in with Google or its own login`.

**Not covered by this PR:**

- `src/renderer/src/lib/agent-paste-draft.ts` (`sendBracketedPasteToAgent`) — writes through `window.api.pty.write` and can never reach `agent_prompt_blocked`. Its gate is `waitForAgentDraftInputReady` (DECSET 2004 + render-quiet), which a TUI showing its _own_ sign-in dialog satisfies. This backs quick launch, `submit-after-ready`, work-item launch, folder-workspace startup and fix-checks, so it is the more commonly hit lane. **Closed by #20004**, which stacks directly on this branch.
- `src/main/runtime/orchestration/mailbox-pointer-pty-write.ts:26` — the mailbox pointer lane gates on an idle edge only, with no blocked-reason check. Verified at source and left open deliberately: the bytes are fixed orchestration pointer text, not a user task prompt, so neither the secret-typing nor the transcript-echo harm applies. Worth a follow-up, not a blocker.

## Residual risk — read this before merging

- **Do not merge this PR alone.** It guards only runtime-routed writes (CLI, orchestration, federation). The renderer paste lane backs quick launch, submit-after-ready, work-item launch and folder-workspace startup — i.e. most user-initiated prompt delivery — and is closed by #20004. Shipping this one on its own would close the rarer hole while reading, from the changelog, as fixed. **The stack merges together or not at all.**
- The mailbox pointer lane (above) and #20004's fail-open when no pane is registered leave the guard **incomplete by design**. Both are reasoned, both are documented, neither should be implied closed in a release note.

## Separate fix in this PR: a latent main-process hang

Flagging this on its own so it is not missed inside a guard PR. `startOfLastNonBlankLines` (`src/main/runtime/terminal-wait-tail-window.ts`) **infinite-loops on any tail whose first character is a newline**. `String.lastIndexOf` clamps a negative position argument up to `0`, so a leading newline makes the walk answer `lineStart = 1` with `lineEnd = 0` forever. It sits on the main-process PTY data path, so it is a hard hang rather than a slow scan.

It is **latent, not live**: all three current producers filter blank lines (`buildPreview` drops empties, `buildTerminalWaitText` joins trimmed non-empty lines, `visibleNonBlankTerminalLines` filters the visible-screen probe). Found while building the false-positive corpus, which fed it raw fixture strings. One-line condition plus a regression test.

## Pre-existing gap found, not fixed here

`src/cli/handlers/orchestration/worker-observation-handlers.ts:43` interpolates raw `wait.reason` with no formatter — the one render site `describeTerminalWaitBlockedReason` does not reach. Harmless for this reason specifically (born neutral, renders identically either way), but it means an older host's `codex-*` token still reaches a non-Codex user on that surface.

## Verification

| command | result |
| --- | --- |
| `pnpm test src/main/runtime/terminal-credential-prompt-detection.test.ts` | all green — the must-refuse corpus now also pins the Antigravity sign-in menu, the vendor-qualified indented ask, localized `sudo`, the env-var api-key ask and a boxed dialog; the must-allow corpus pins the new false positives below plus the sign-in menu's sibling dialogs |
| `pnpm test` over the four credential suites + `terminal-wait-detection` + `terminal-tail-sentinel-index` | 202 passed |
| mutation check, 11 mutations | **all 11 caught.** One initially survived — the sentinel's box-rule tolerance was not pinned by any corpus screen — and the corpus case was tightened until it was |
| `pnpm tc:node`, `pnpm tc:web`, `pnpm tc:cli` (one at a time) | clean |
| `oxlint src` | clean |

No `max-lines` disable was added anywhere in this change.

### False positives found by adversarial probing, now pinned

The previous corpus read 49/49 must-allow clean. Probing it with screens it did not contain — records rather than requests, and non-English narration — found seven more, every one of which pinned an idle agent to `permission`:

```
$ git log --oneline -3
a1b2c3d fix(auth): drop the stale authorization header
d4e5f6a feat(auth): sign in with GitHub
```

```
• Updated the login page copy
⏳ Waiting for you to review the diff
```

```
• Fixed the deploy step
• Root cause: authentication required from the vercel CLI
```

```
$ pnpm deploy
錯誤：authentication required，請先執行 gh auth login
```

plus a changelog bullet (`- feat(auth): sign in with Apple support`), a checklist item, and German narration. A single commit subject on its own was enough: `sign in with` contains the auth verb, so it self-corroborated.

The common cause is position, not vocabulary. The rule required the flow phrase to own the bottom row and not be narration, but `NARRATION_ROW_RE` only knew ASCII sentence punctuation — so anything ending a row without a period, and **all** CJK prose, escaped it. Now: an action phrase must **lead** its row (modulo dialog decoration and the lead-ins a dialog actually uses, `and enter the code:` / `Please sign in with…`), `waiting for you to` carries an auth continuation instead of matching every agent waiting on a human, and narration includes CJK sentence punctuation.

## Stacking

Based on `fix/agent-neutral-wait-blocked-reason` (#19749) rather than `main`, because it depends on that branch's `RuntimeTerminalWaitBlockedReason` union and its single `describeTerminalWaitBlockedReason` formatter. Rebasing produced two conflicts, both pure formatter-reflow against that branch's `codex-*` → `agent-*` rename; both resolved to the rename.
