### PR TITLE
test(monaco): drive the real Monarch tokenizer instead of walking rule tables

### DIFF
--- a/src/renderer/src/lib/monaco-languages/monarch-embed-entry-recursion.test.ts
+++ b/src/renderer/src/lib/monaco-languages/monarch-embed-entry-recursion.test.ts
@@ -1,9 +1,11 @@
 import type * as Monaco from 'monaco-editor'
 import { describe, expect, it } from 'vitest'
-import { EMBED_ENTRY_REST_OF_LINE_BUDGET } from './monarch-embed-entry-budget'
+import {
+  EMBED_ENTRY_REST_OF_LINE_BUDGET,
+  MAX_TOKENIZATION_LINE_LENGTH
+} from './monarch-embed-entry-budget'
 import {
   createMonarchTokenizer,
-  DEFAULT_MAX_TOKENIZATION_LINE_LENGTH,
   endEmbeddedLanguages,
   measureNestedDepth,
   tokenizeLines
@@ -15,10 +17,15 @@ import { vueMonarchLanguage } from './register-vue'
 // Monarch tokenizes embedded languages by mutual recursion: `_nestedTokenize`
 // tail-calls `_myTokenize`, which tail-calls `_nestedTokenize` again for every
 // embed entered mid-line. V8 has no TCO, so each mid-line embed entry costs
-// real JS stack. Before the embed-entry budget, one 17_000-character line of
-// `<script></script>` (under Monaco's own 20_000 line cap) reached ~1743 nested
-// levels and died with `RangeError: Maximum call stack size exceeded` — the
-// renderer-side STATUS_STACK_OVERFLOW this suite guards.
+// real JS stack. Embeds cannot nest (monarchLexer throws "cannot enter embedded
+// language from within an embedded language"), so these are sequential
+// enter/exit transitions on one line, each holding a frame until the line ends.
+//
+// Before the embed-entry budget, one 17_000-character line of `<script></script>`
+// (under Monaco's own 20_000 line cap) reached ~1743 frames and threw
+// `RangeError: Maximum call stack size exceeded`. Monaco's `safeTokenize` catches
+// that per line, so the visible failure is a line that silently loses all
+// highlighting; the frame count is what this suite bounds.
 
 // 6600 is the largest `{a}` count under Monaco's line cap (19_800 chars); the
 // filter below drops it for the longer chunk shapes, so the densest embed
@@ -46,15 +53,13 @@ const PATHOLOGICAL_LINES: [string, (count: number) => string][] = [
 describe.each([
   ['svelte', svelteMonarchLanguage],
   ['astro', astroMonarchLanguage]
-])('%s embedded-tokenizer recursion depth', (languageId, language) => {
+])('%s embed-entry recursion', (languageId, language) => {
   it.each(PATHOLOGICAL_LINES)(
     'stays within the embed budget for a line of %s',
     (_name, buildLine) => {
       // Monaco refuses to tokenize at all past its line cap, so the ramp stops
       // where a real editor would.
-      const ramp = RAMP.filter(
-        (count) => buildLine(count).length < DEFAULT_MAX_TOKENIZATION_LINE_LENGTH
-      )
+      const ramp = RAMP.filter((count) => buildLine(count).length < MAX_TOKENIZATION_LINE_LENGTH)
       expect(ramp.length).toBeGreaterThanOrEqual(3)
 
       const depths = ramp.map((count) =>
@@ -122,9 +127,9 @@ describe.each([
 
 describe('unguarded embedded tokenizer', () => {
   // Control: the same markup/expression shape with no budget on embed entry.
-  // Depth then tracks the interpolation count one-for-one, which is what took
-  // the renderer down; ~1700 levels is already a RangeError in this runtime,
-  // so the ramp stops short of the overflow to stay deterministic.
+  // The frame count then tracks the interpolation count one-for-one; ~1700
+  // frames is already a RangeError in this runtime, so the ramp stops short of
+  // the overflow to stay deterministic.
   const perInterpolationEmbedLanguage: Monaco.languages.IMonarchLanguage = {
     defaultToken: '',
     tokenizer: {
@@ -148,13 +153,13 @@ describe('unguarded embedded tokenizer', () => {
   })
 })
 
-describe('vue embedded-tokenizer recursion depth', () => {
+describe('vue embed-entry recursion', () => {
   const templateLine = (count: number): string =>
     `<template><p>${'{{a}}'.repeat(count)}</p></template>`
 
   it('stays within the embed budget for a line of interpolations', () => {
     const ramp = [50, 200, 1000, 2500, 3900].filter(
-      (count) => templateLine(count).length < DEFAULT_MAX_TOKENIZATION_LINE_LENGTH
+      (count) => templateLine(count).length < MAX_TOKENIZATION_LINE_LENGTH
     )
     expect(ramp.length).toBeGreaterThanOrEqual(3)
 

--- a/src/renderer/src/lib/monaco-languages/monarch-embedded-recursion-depth.test.ts
+++ b/src/renderer/src/lib/monaco-languages/monarch-embedded-recursion-depth.test.ts
@@ -1,11 +1,13 @@
 import type * as Monaco from 'monaco-editor'
-import { compile } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchCompile.js'
-import { MonarchTokenizer } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchLexer.js'
 import { describe, expect, it } from 'vitest'
+import { EMBED_ENTRY_REST_OF_LINE_BUDGET } from './monarch-embed-entry-budget'
 import {
-  EMBED_ENTRY_REST_OF_LINE_BUDGET,
-  MAX_TOKENIZATION_LINE_LENGTH
-} from './monarch-embed-entry-budget'
+  createMonarchTokenizer,
+  DEFAULT_MAX_TOKENIZATION_LINE_LENGTH,
+  endEmbeddedLanguages,
+  measureNestedDepth,
+  tokenizeLines
+} from './monarch-tokenizer-test-harness'
 import { astroMonarchLanguage } from './register-astro'
 import { svelteMonarchLanguage } from './register-svelte'
 import { vueMonarchLanguage } from './register-vue'
@@ -17,89 +19,6 @@ import { vueMonarchLanguage } from './register-vue'
 // `<script></script>` (under Monaco's own 20_000 line cap) reached ~1743 nested
 // levels and died with `RangeError: Maximum call stack size exceeded` — the
 // renderer-side STATUS_STACK_OVERFLOW this suite guards.
-
-type MonarchEndState = { embeddedLanguageData?: { languageId: string } | null }
-
-type MonarchTokenizerInstance = {
-  getInitialState: () => unknown
-  tokenize: (line: string, hasEOL: boolean, state: unknown) => { endState: MonarchEndState }
-  _nestedTokenize: (...args: unknown[]) => unknown
-}
-
-function createMonarchTokenizer(
-  languageId: string,
-  language: Monaco.languages.IMonarchLanguage,
-  maxTokenizationLineLength = MAX_TOKENIZATION_LINE_LENGTH
-): MonarchTokenizerInstance {
-  // Nested languages stay unregistered: `_getNestedEmbeddedLanguageData` then
-  // hands back a null state, which changes what the embed *emits* but not
-  // whether monarch recurses into it — the depth measurement is unaffected.
-  const languageService = {
-    languageIdCodec: { encodeLanguageId: () => 1, decodeLanguageId: () => '' },
-    getLanguageIdByLanguageName: () => null,
-    getLanguageIdByMimeType: () => null,
-    isRegisteredLanguageId: () => false,
-    requestBasicLanguageFeatures: () => {}
-  }
-  const themeService = { getColorTheme: () => ({ tokenTheme: {} }) }
-  const configurationService = {
-    getValue: () => maxTokenizationLineLength,
-    onDidChangeConfiguration: () => ({ dispose: () => {} })
-  }
-
-  return new MonarchTokenizer(
-    languageService,
-    themeService,
-    languageId,
-    compile(languageId, language),
-    configurationService
-  ) as MonarchTokenizerInstance
-}
-
-type TokenizeMeasurement = { maxNestedDepth: number; error: Error | undefined }
-
-function measureNestedDepth(
-  tokenizer: MonarchTokenizerInstance,
-  lines: string[]
-): TokenizeMeasurement {
-  const nestedTokenize = tokenizer._nestedTokenize.bind(tokenizer)
-  let depth = 0
-  let maxNestedDepth = 0
-  tokenizer._nestedTokenize = (...args: unknown[]) => {
-    depth += 1
-    maxNestedDepth = Math.max(maxNestedDepth, depth)
-    try {
-      return nestedTokenize(...args)
-    } finally {
-      depth -= 1
-    }
-  }
-
-  let error: Error | undefined
-  let state = tokenizer.getInitialState()
-  try {
-    for (const line of lines) {
-      state = tokenizer.tokenize(line, true, state).endState
-    }
-  } catch (thrown) {
-    error = thrown as Error
-  }
-  return { maxNestedDepth, error }
-}
-
-// The embedded language each line *ends* in — `null` means the line left the
-// tokenizer with no embed, i.e. that region renders unhighlighted.
-function embeddedLanguagePerLine(
-  tokenizer: MonarchTokenizerInstance,
-  lines: string[]
-): (string | null)[] {
-  let state: unknown = tokenizer.getInitialState()
-  return lines.map((line) => {
-    const endState = tokenizer.tokenize(line, true, state).endState
-    state = endState
-    return endState.embeddedLanguageData?.languageId ?? null
-  })
-}
 
 // 6600 is the largest `{a}` count under Monaco's line cap (19_800 chars); the
 // filter below drops it for the longer chunk shapes, so the densest embed
@@ -133,7 +52,9 @@ describe.each([
     (_name, buildLine) => {
       // Monaco refuses to tokenize at all past its line cap, so the ramp stops
       // where a real editor would.
-      const ramp = RAMP.filter((count) => buildLine(count).length < MAX_TOKENIZATION_LINE_LENGTH)
+      const ramp = RAMP.filter(
+        (count) => buildLine(count).length < DEFAULT_MAX_TOKENIZATION_LINE_LENGTH
+      )
       expect(ramp.length).toBeGreaterThanOrEqual(3)
 
       const depths = ramp.map((count) =>
@@ -175,12 +96,14 @@ describe.each([
     // budget, so the body starts unembedded. Every following short line must
     // recover the embed (and the `lang=` language) instead of leaving the whole
     // block unhighlighted until the closing tag.
-    const embeds = embeddedLanguagePerLine(createMonarchTokenizer(languageId, language), [
-      `<${tag} lang="${lang}">a = "${'x'.repeat(EMBED_ENTRY_REST_OF_LINE_BUDGET)}"`,
-      '  b',
-      '  c',
-      `</${tag}>`
-    ])
+    const embeds = endEmbeddedLanguages(
+      tokenizeLines(createMonarchTokenizer(languageId, language), [
+        `<${tag} lang="${lang}">a = "${'x'.repeat(EMBED_ENTRY_REST_OF_LINE_BUDGET)}"`,
+        '  b',
+        '  c',
+        `</${tag}>`
+      ])
+    )
 
     expect(embeds).toEqual([null, embeddedLanguageId, embeddedLanguageId, null])
   })
@@ -231,7 +154,7 @@ describe('vue embedded-tokenizer recursion depth', () => {
 
   it('stays within the embed budget for a line of interpolations', () => {
     const ramp = [50, 200, 1000, 2500, 3900].filter(
-      (count) => templateLine(count).length < MAX_TOKENIZATION_LINE_LENGTH
+      (count) => templateLine(count).length < DEFAULT_MAX_TOKENIZATION_LINE_LENGTH
     )
     expect(ramp.length).toBeGreaterThanOrEqual(3)
 
@@ -252,11 +175,13 @@ describe('vue embedded-tokenizer recursion depth', () => {
     ['script', 'ts', 'typescript'],
     ['style', 'scss', 'scss']
   ])('re-embeds a %s body after an over-budget opening line', (tag, lang, embeddedLanguageId) => {
-    const embeds = embeddedLanguagePerLine(createMonarchTokenizer('vue', vueMonarchLanguage), [
-      `<${tag} lang="${lang}">a = "${'x'.repeat(EMBED_ENTRY_REST_OF_LINE_BUDGET)}"`,
-      '  b',
-      `</${tag}>`
-    ])
+    const embeds = endEmbeddedLanguages(
+      tokenizeLines(createMonarchTokenizer('vue', vueMonarchLanguage), [
+        `<${tag} lang="${lang}">a = "${'x'.repeat(EMBED_ENTRY_REST_OF_LINE_BUDGET)}"`,
+        '  b',
+        `</${tag}>`
+      ])
+    )
 
     expect(embeds).toEqual([null, embeddedLanguageId, null])
   })

--- a/src/renderer/src/lib/monaco-languages/monarch-tokenizer-test-harness.ts
+++ b/src/renderer/src/lib/monaco-languages/monarch-tokenizer-test-harness.ts
@@ -1,6 +1,7 @@
 import type * as Monaco from 'monaco-editor'
 import { compile } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchCompile.js'
 import { MonarchTokenizer } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchLexer.js'
+import { MAX_TOKENIZATION_LINE_LENGTH } from './monarch-embed-entry-budget'
 
 // Drives the real `MonarchTokenizer` shipped with monaco-editor rather than
 // walking a grammar's rule table. A table walk cannot see the failures that
@@ -22,13 +23,10 @@ export type MonarchTokenizerInstance = {
   _nestedTokenize: (...args: unknown[]) => unknown
 }
 
-/** Monaco's default `editor.maxTokenizationLineLength`; longer lines are never tokenized. */
-export const DEFAULT_MAX_TOKENIZATION_LINE_LENGTH = 20_000
-
 export function createMonarchTokenizer(
   languageId: string,
   language: Monaco.languages.IMonarchLanguage,
-  maxTokenizationLineLength = DEFAULT_MAX_TOKENIZATION_LINE_LENGTH
+  maxTokenizationLineLength = MAX_TOKENIZATION_LINE_LENGTH
 ): MonarchTokenizerInstance {
   // Nested languages stay unregistered, so `nestedLanguageTokenize` emits one
   // empty-typed token tagged with the embedded language id instead of running
@@ -128,10 +126,11 @@ export function formatTokenizedLines(lines: TokenizedLine[]): string[] {
 export type TokenizeMeasurement = { maxNestedDepth: number; error: Error | undefined }
 
 /**
- * Tokenizes `lines`, recording peak `_nestedTokenize` recursion. Monarch enters
- * an embed by mutual recursion with no TCO, so this is the renderer's real JS
- * stack cost. Errors are captured rather than thrown so a caller can assert on
- * depth and failure together.
+ * Tokenizes `lines`, recording peak `_nestedTokenize` recursion — the real JS
+ * stack cost, since Monarch enters an embed by mutual recursion with no TCO.
+ * Embeds cannot nest, so this counts sequential embed enter/exit transitions on
+ * one line, each holding a frame until the line ends. Errors are captured rather
+ * than thrown so a caller can assert on frame count and failure together.
  */
 export function measureNestedDepth(
   tokenizer: MonarchTokenizerInstance,

--- a/src/renderer/src/lib/monaco-languages/monarch-tokenizer-test-harness.ts
+++ b/src/renderer/src/lib/monaco-languages/monarch-tokenizer-test-harness.ts
@@ -1,0 +1,160 @@
+import type * as Monaco from 'monaco-editor'
+import { compile } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchCompile.js'
+import { MonarchTokenizer } from 'monaco-editor/esm/vs/editor/standalone/common/monarch/monarchLexer.js'
+
+// Drives the real `MonarchTokenizer` shipped with monaco-editor rather than
+// walking a grammar's rule table. A table walk cannot see the failures that
+// actually reach the renderer — a grammar that throws on every `{expr}`, or
+// that silently drops an embed, still has a well-formed rule table.
+
+/** One Monaco token. `language` is the (embedded) language the region belongs to. */
+export type MonarchToken = { offset: number; type: string; language: string }
+
+type MonarchEndState = { embeddedLanguageData?: { languageId: string } | null }
+
+export type MonarchTokenizerInstance = {
+  getInitialState: () => unknown
+  tokenize: (
+    line: string,
+    hasEOL: boolean,
+    state: unknown
+  ) => { tokens: MonarchToken[]; endState: MonarchEndState }
+  _nestedTokenize: (...args: unknown[]) => unknown
+}
+
+/** Monaco's default `editor.maxTokenizationLineLength`; longer lines are never tokenized. */
+export const DEFAULT_MAX_TOKENIZATION_LINE_LENGTH = 20_000
+
+export function createMonarchTokenizer(
+  languageId: string,
+  language: Monaco.languages.IMonarchLanguage,
+  maxTokenizationLineLength = DEFAULT_MAX_TOKENIZATION_LINE_LENGTH
+): MonarchTokenizerInstance {
+  // Nested languages stay unregistered, so `nestedLanguageTokenize` emits one
+  // empty-typed token tagged with the embedded language id instead of running
+  // that language's tokenizer. That is what makes `token.language` a direct
+  // readout of which embed covers which region.
+  const languageService = {
+    languageIdCodec: { encodeLanguageId: () => 1, decodeLanguageId: () => '' },
+    getLanguageIdByLanguageName: () => null,
+    getLanguageIdByMimeType: () => null,
+    isRegisteredLanguageId: () => false,
+    requestBasicLanguageFeatures: () => {}
+  }
+  const themeService = { getColorTheme: () => ({ tokenTheme: {} }) }
+  const configurationService = {
+    getValue: () => maxTokenizationLineLength,
+    onDidChangeConfiguration: () => ({ dispose: () => {} })
+  }
+
+  return new MonarchTokenizer(
+    languageService,
+    themeService,
+    languageId,
+    compile(languageId, language),
+    configurationService
+  ) as MonarchTokenizerInstance
+}
+
+export type TokenizedLine = {
+  text: string
+  tokens: MonarchToken[]
+  /** Embedded language still active at end of line; `null` means that region renders unhighlighted. */
+  endEmbeddedLanguageId: string | null
+}
+
+/** Tokenizes `lines` as one document, threading tokenizer state line to line. */
+export function tokenizeLines(
+  tokenizer: MonarchTokenizerInstance,
+  lines: string[]
+): TokenizedLine[] {
+  let state: unknown = tokenizer.getInitialState()
+  return lines.map((text) => {
+    const { tokens, endState } = tokenizer.tokenize(text, true, state)
+    state = endState
+    return {
+      text,
+      tokens,
+      endEmbeddedLanguageId: endState.embeddedLanguageData?.languageId ?? null
+    }
+  })
+}
+
+export function tokenizeMonarchDocument(
+  languageId: string,
+  language: Monaco.languages.IMonarchLanguage,
+  source: string
+): TokenizedLine[] {
+  return tokenizeLines(createMonarchTokenizer(languageId, language), source.split('\n'))
+}
+
+/** The embedded language each line *ends* in — `null` for no embed. */
+export function endEmbeddedLanguages(lines: TokenizedLine[]): (string | null)[] {
+  return lines.map((line) => line.endEmbeddedLanguageId)
+}
+
+/** The distinct languages a line's tokens were attributed to, in order. */
+export function tokenLanguages(line: TokenizedLine): string[] {
+  return line.tokens
+    .map((token) => token.language)
+    .filter((language, index, all) => language !== all[index - 1])
+}
+
+/**
+ * Per line, which languages actually cover it. This is the readout that catches
+ * a silently dropped embed: the region falls back to the host grammar's own id
+ * instead of `html` / `typescript` / `scss`, and renders unhighlighted.
+ */
+export function tokenLanguagesPerLine(lines: TokenizedLine[]): string[][] {
+  return lines.map(tokenLanguages)
+}
+
+/** Token type covering `index`, without the grammar's `tokenPostfix`. */
+export function tokenTypeAt(line: TokenizedLine, index: number): string {
+  const covering = line.tokens.findLast((token) => token.offset <= index)
+  return covering?.type.split('.').slice(0, -1).join('.') ?? ''
+}
+
+/** One `text | offset:type@language … | embed=…` row per line, for snapshots. */
+export function formatTokenizedLines(lines: TokenizedLine[]): string[] {
+  return lines.map((line) => {
+    const tokens = line.tokens
+      .map((token) => `${token.offset}:${token.type || '-'}@${token.language}`)
+      .join(' ')
+    return `${line.text} | ${tokens} | embed=${line.endEmbeddedLanguageId ?? 'none'}`
+  })
+}
+
+export type TokenizeMeasurement = { maxNestedDepth: number; error: Error | undefined }
+
+/**
+ * Tokenizes `lines`, recording peak `_nestedTokenize` recursion. Monarch enters
+ * an embed by mutual recursion with no TCO, so this is the renderer's real JS
+ * stack cost. Errors are captured rather than thrown so a caller can assert on
+ * depth and failure together.
+ */
+export function measureNestedDepth(
+  tokenizer: MonarchTokenizerInstance,
+  lines: string[]
+): TokenizeMeasurement {
+  const nestedTokenize = tokenizer._nestedTokenize.bind(tokenizer)
+  let depth = 0
+  let maxNestedDepth = 0
+  tokenizer._nestedTokenize = (...args: unknown[]) => {
+    depth += 1
+    maxNestedDepth = Math.max(maxNestedDepth, depth)
+    try {
+      return nestedTokenize(...args)
+    } finally {
+      depth -= 1
+    }
+  }
+
+  let error: Error | undefined
+  try {
+    tokenizeLines(tokenizer, lines)
+  } catch (thrown) {
+    error = thrown as Error
+  }
+  return { maxNestedDepth, error }
+}

--- a/src/renderer/src/lib/monaco-languages/monarch-upstream-mdx-recursion.test.ts
+++ b/src/renderer/src/lib/monaco-languages/monarch-upstream-mdx-recursion.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+// Why happy-dom: monaco's `basic-languages` entry points import the full
+// browser editor before they export the grammar.
+import { language as mdxLanguage } from 'monaco-editor/esm/vs/basic-languages/mdx/mdx.js'
+import { describe, expect, it } from 'vitest'
+import {
+  EMBED_ENTRY_REST_OF_LINE_BUDGET,
+  MAX_TOKENIZATION_LINE_LENGTH
+} from './monarch-embed-entry-budget'
+import { createMonarchTokenizer, measureNestedDepth } from './monarch-tokenizer-test-harness'
+import { svelteMonarchLanguage } from './register-svelte'
+
+// Why pin a third-party grammar: monaco's OWN shipped mdx grammar enters a `js`
+// embed on every `{` and pops on `}` with no budget, so it reproduces the
+// unbounded embed-entry recursion exactly. That makes it the proof this shape is
+// monaco's, not something Orca's svelte/astro/vue grammars invented — and it is
+// the tripwire for a monaco upgrade that changes the recursion shape. Do not
+// delete as "not our code".
+
+/** One `js` embed enter/exit transition per repeat, in 3 characters. */
+const interpolations = (count: number): string => '{a}'.repeat(count)
+
+/** Longest run of them monaco will still tokenize at all. */
+const UNTOKENIZABLE_ABOVE = Math.floor(MAX_TOKENIZATION_LINE_LENGTH / 3) - 1
+
+describe('upstream monaco mdx grammar', () => {
+  it('spends one stack frame per interpolation, unbounded', () => {
+    const frames = [50, 200, 500].map(
+      (count) =>
+        measureNestedDepth(createMonarchTokenizer('mdx', mdxLanguage), [interpolations(count)])
+          .maxNestedDepth
+    )
+
+    expect(frames).toEqual([50, 200, 500])
+  })
+
+  it('exhausts the JS stack on a line monaco is still willing to tokenize', () => {
+    const line = interpolations(UNTOKENIZABLE_ABOVE)
+    expect(line.length).toBeLessThan(MAX_TOKENIZATION_LINE_LENGTH)
+
+    const measurement = measureNestedDepth(createMonarchTokenizer('mdx', mdxLanguage), [line])
+
+    // The frame ceiling is runtime-dependent (~1145 measured here), so assert the
+    // failure rather than the number.
+    expect(measurement.error).toBeInstanceOf(RangeError)
+    expect(measurement.maxNestedDepth).toBeLessThan(UNTOKENIZABLE_ABOVE)
+  })
+
+  it('is what the embed-entry budget holds: the same shape stays bounded', () => {
+    const measurement = measureNestedDepth(
+      createMonarchTokenizer('svelte', svelteMonarchLanguage),
+      [interpolations(UNTOKENIZABLE_ABOVE)]
+    )
+
+    expect(measurement.error).toBeUndefined()
+    expect(measurement.maxNestedDepth).toBeLessThanOrEqual(EMBED_ENTRY_REST_OF_LINE_BUDGET)
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-astro.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-astro.test.ts
@@ -1,112 +1,32 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  endEmbeddedLanguages,
+  formatTokenizedLines,
+  tokenizeMonarchDocument,
+  tokenLanguages,
+  tokenLanguagesPerLine
+} from './monarch-tokenizer-test-harness'
+import {
   astroLanguageConfiguration,
   astroMonarchLanguage,
   registerAstroLanguage
 } from './register-astro'
 
-type MonarchAction = {
-  next?: string
-  nextEmbedded?: string
-  switchTo?: string
-}
-type MonarchRule = [RegExp, string | MonarchAction, string?] | { include: string }
-
-function normalizeState(nextState: string): string {
-  return nextState.startsWith('@') ? nextState.slice(1) : nextState
+// Driven through the real `MonarchTokenizer`: a rule-table walk cannot tell a
+// working grammar from one that throws on every `{expr}`, which is how broken
+// Astro highlighting shipped green.
+function tokenizeAstro(source: string) {
+  return tokenizeMonarchDocument('astro', astroMonarchLanguage, source)
 }
 
-function isRuleEntry(rule: MonarchRule): rule is [RegExp, string | MonarchAction, string?] {
-  return Array.isArray(rule)
-}
-
-function getRuleAction(rule: [RegExp, string | MonarchAction, string?]): MonarchAction | undefined {
-  const [, action, nextStateShortcut] = rule
-  return typeof action === 'object'
-    ? action
-    : nextStateShortcut
-      ? { next: nextStateShortcut }
-      : undefined
-}
-
-function findRuleAction(
-  state: string,
-  source: string,
-  { embedPopOnly = false }: { embedPopOnly?: boolean } = {}
-): MonarchAction | undefined {
-  const tokenizer = astroMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
-  const stateRules = tokenizer[state] ?? tokenizer[state.split('.')[0]]
-  const candidateRules = embedPopOnly
-    ? stateRules.filter((rule) => {
-        if (!isRuleEntry(rule)) {
-          return false
-        }
-        return getRuleAction(rule)?.nextEmbedded === '@pop'
-      })
-    : stateRules
-  const matchedRule = candidateRules.find((rule) => {
-    if (!isRuleEntry(rule)) {
-      return false
-    }
-    const [regexp] = rule
-    regexp.lastIndex = 0
-    const match = regexp.exec(source)
-    return match !== null && match.index === 0
-  })
-
-  return matchedRule && isRuleEntry(matchedRule) ? getRuleAction(matchedRule) : undefined
-}
-
-function collectFixtureRuleActions(source: string): string[] {
-  const ruleActions: string[] = []
-  const tokenizer = astroMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
-  const lines = source.split('\n')
-  const checks: { line: number; state: string; pattern: string }[] = [
-    { line: 1, state: 'root', pattern: '---' },
-    { line: 4, state: 'frontmatter', pattern: '---' },
-    // After the frontmatter closes we are back in `markupReenter`; the next
-    // non-structural character switches into `markup` with html active.
-    { line: 6, state: 'markupReenter', pattern: '' },
-    { line: 6, state: 'markup', pattern: '{' },
-    { line: 6, state: 'astroExpression', pattern: '}' },
-    { line: 8, state: 'markup', pattern: '<script' },
-    { line: 8, state: 'scriptOpen.javascript', pattern: '>' },
-    { line: 10, state: 'scriptBody.javascript', pattern: '</script>' },
-    { line: 12, state: 'markup', pattern: '<style' },
-    { line: 12, state: 'styleOpen.css', pattern: '>' },
-    { line: 14, state: 'styleBody.css', pattern: '</style>' }
-  ]
-
-  checks.forEach((check) => {
-    const line = lines.at(check.line - 1) ?? ''
-    const stateRules = tokenizer[check.state] ?? tokenizer[check.state.split('.')[0]]
-    const matchedRule = stateRules.find((rule) => {
-      if (!isRuleEntry(rule)) {
-        return false
-      }
-      const [regexp] = rule
-      regexp.lastIndex = 0
-      const match = regexp.exec(line)
-      return match !== null && match[0] === check.pattern
-    })
-    if (!matchedRule || !isRuleEntry(matchedRule)) {
-      return
-    }
-
-    const actionObject = getRuleAction(matchedRule)
-
-    const nextState = actionObject?.next ? normalizeState(actionObject.next) : '-'
-    const nextEmbedded = actionObject?.nextEmbedded ?? '-'
-    const switchTo = actionObject?.switchTo ? normalizeState(actionObject.switchTo) : '-'
-    ruleActions.push(
-      `${check.line}:${check.state}:${check.pattern || '<html>'} -> next=${nextState}, embedded=${nextEmbedded}, switch=${switchTo}`
-    )
-  })
-
-  return ruleActions
+/** Which languages actually cover each line — a dropped embed shows up as `astro`. */
+function languagesPerLine(source: string): string[][] {
+  return tokenLanguagesPerLine(tokenizeAstro(source))
 }
 
 describe('registerAstroLanguage registration', () => {
+  // Structural by necessity: covers the registration call itself (ids,
+  // extensions, idempotence), which tokenizing cannot observe.
   it('registers the astro language, Monarch tokenizer, and configuration once', () => {
     const languages: { id: string }[] = [{ id: 'typescript' }]
     const register = vi.fn((entry: { id: string }) => {
@@ -140,8 +60,8 @@ describe('registerAstroLanguage registration', () => {
   })
 })
 
-describe('astro tokenizer transitions', () => {
-  it('captures Astro tokenizer transitions for a representative component fixture', () => {
+describe('astro tokenization', () => {
+  it('tokenizes a representative component', () => {
     const fixture = `---
 import Layout from '../layouts/Layout.astro'
 const title = 'Home'
@@ -157,111 +77,108 @@ const title = 'Home'
   h1 { color: rebeccapurple; }
 </style>`
 
-    const ruleActions = collectFixtureRuleActions(fixture)
-
-    expect(ruleActions).toMatchInlineSnapshot(`
+    expect(formatTokenizedLines(tokenizeAstro(fixture))).toMatchInlineSnapshot(`
       [
-        "1:root:--- -> next=-, embedded=typescript, switch=frontmatter",
-        "4:frontmatter:--- -> next=-, embedded=@pop, switch=markupReenter",
-        "6:markupReenter:<html> -> next=-, embedded=html, switch=markup",
-        "6:markup:{ -> next=-, embedded=@pop, switch=astroExpressionEnter",
-        "6:astroExpression:} -> next=-, embedded=@pop, switch=markupReenter",
-        "8:markup:<script -> next=-, embedded=@pop, switch=scriptOpen.javascript",
-        "8:scriptOpen.javascript:> -> next=-, embedded=$S2, switch=scriptBody.$S2",
-        "10:scriptBody.javascript:</script> -> next=-, embedded=@pop, switch=markupReenter",
-        "12:markup:<style -> next=-, embedded=@pop, switch=styleOpen.css",
-        "12:styleOpen.css:> -> next=-, embedded=$S2, switch=styleBody.$S2",
-        "14:styleBody.css:</style> -> next=-, embedded=@pop, switch=markupReenter",
+        "--- | 0:keyword.astro@astro | embed=typescript",
+        "import Layout from '../layouts/Layout.astro' | 0:-@typescript | embed=typescript",
+        "const title = 'Home' | 0:-@typescript | embed=typescript",
+        "--- | 0:keyword.astro@astro | embed=none",
+        " |  | embed=html",
+        "<h1>{title}</h1> | 0:-@html 4:delimiter.curly.astro@astro 5:-@typescript 10:delimiter.curly.astro@astro 11:-@html | embed=html",
+        " | 0:-@html | embed=html",
+        "<script> | 0:tag.astro@astro | embed=javascript",
+        "  console.log('hi') | 0:-@javascript | embed=javascript",
+        "</script> | 0:tag.astro@astro | embed=none",
+        " |  | embed=html",
+        "<style lang="scss"> | 0:tag.astro@astro 6:white.astro@astro 7:attribute.name.astro@astro 11:delimiter.astro@astro 12:attribute.value.astro@astro 18:tag.astro@astro | embed=scss",
+        "  h1 { color: rebeccapurple; } | 0:-@scss | embed=scss",
+        "</style> | 0:tag.astro@astro | embed=none",
       ]
     `)
   })
-})
 
-describe('astro tokenizer regressions', () => {
-  // Regression: a file that opens with a markup expression like `{title}` has
-  // no html embed active yet. If `root` itself ever emitted `nextEmbedded:
-  // '@pop'` Monaco would throw "cannot pop embedded language if not inside
-  // one" before any push had occurred. Enforce the invariant directly.
-  it('never pops an embedded language from the root state', () => {
-    const tokenizer = astroMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
-    const popRules = tokenizer.root.filter((rule) => {
-      if (!isRuleEntry(rule)) {
-        return false
-      }
-      return getRuleAction(rule)?.nextEmbedded === '@pop'
-    })
-    expect(popRules).toHaveLength(0)
+  it('embeds the frontmatter fence as typescript', () => {
+    expect(
+      endEmbeddedLanguages(tokenizeAstro("---\nconst title = 'Home'\n---\n<h1>hi</h1>"))
+    ).toEqual(['typescript', 'typescript', null, 'html'])
   })
 
-  // Regression (verified live in the Electron app): when entry from root went
-  // straight to `@markup` with `nextEmbedded: 'html'`, while the embed-pop
-  // path also went via `@markupReenter`, Monarch's nested tokenizer reported
-  // "cannot pop embedded language if not inside one" on `{expr}` in markup.
-  // Routing every push of the html embed through `markupReenter` keeps the
-  // embed-stack invariant identical for every entry into `markup`.
-  it('routes all entries into markup through markupReenter', () => {
-    expect(findRuleAction('root', '<h1>Hello</h1>')).toMatchObject({
-      switchTo: '@markupReenter'
-    })
-    expect(findRuleAction('root', '{title}')).toMatchObject({
-      switchTo: '@markupReenter'
-    })
-    expect(findRuleAction('markupReenter', '<h1>Hello</h1>')).toMatchObject({
-      switchTo: '@markup',
-      nextEmbedded: 'html'
-    })
+  // Regression (verified live in the Electron app): an expression in the first
+  // markup line popped the html embed before any push, and Monarch threw
+  // "cannot pop embedded language if not inside one".
+  it('highlights an expression in the first markup line', () => {
+    const [line] = tokenizeAstro('<p>a {title} b</p>')
+
+    expect(tokenLanguages(line)).toEqual(['html', 'astro', 'typescript', 'astro', 'html'])
   })
 
-  // Regression: while the html embed is active, only parent rules whose action
-  // pops the embed are consulted before delegating to html. The `markup`
-  // state must wire `nextEmbedded: '@pop'` on the structural rules so a
-  // trailing `<script>` or `<style>` after page markup can switch language.
-  it('pops the html embed when later script/style/comment markers appear', () => {
-    expect(findRuleAction('markup', '<script>', { embedPopOnly: true })).toMatchObject({
-      switchTo: '@scriptOpen.javascript',
-      nextEmbedded: '@pop'
-    })
-    expect(findRuleAction('markup', '<style lang="scss">', { embedPopOnly: true })).toMatchObject({
-      switchTo: '@styleOpen.css',
-      nextEmbedded: '@pop'
-    })
-    expect(findRuleAction('markup', '<!-- comment -->', { embedPopOnly: true })).toMatchObject({
-      switchTo: '@comment',
-      nextEmbedded: '@pop'
-    })
-    expect(findRuleAction('markup', '{title}', { embedPopOnly: true })).toMatchObject({
-      switchTo: '@astroExpressionEnter',
-      nextEmbedded: '@pop'
-    })
+  it('opens a file on an expression without popping a missing embed', () => {
+    // A file with no frontmatter that starts on `{expr}`: no html embed exists
+    // yet, so the entry rule must not pop one.
+    expect(tokenLanguages(tokenizeAstro('{title}')[0])).toEqual(['astro', 'typescript', 'astro'])
+  })
+
+  it('pops the html embed for a comment that follows markup', () => {
+    expect(languagesPerLine('<h1>hi</h1>\n<!-- a note -->\n<p>{x}</p>')).toEqual([
+      ['html'],
+      ['astro'],
+      ['html', 'astro', 'typescript', 'astro', 'html']
+    ])
+  })
+
+  it('does not enter typescript for an empty expression', () => {
+    // `{}` pops html on entry but never pushes typescript; the close must unwind
+    // only the state, or the tokenizer pops an embed that is not there.
+    expect(tokenLanguages(tokenizeAstro('<p>{}</p>')[0])).toEqual(['html', 'astro', 'html'])
   })
 })
 
 describe('astro embedded language attributes', () => {
-  it('tracks embedded languages from Astro expressions and lang= attributes', () => {
-    expect(findRuleAction('astroExpressionEnter', 'title }')).toMatchObject({
-      nextEmbedded: 'typescript',
-      switchTo: '@astroExpression'
-    })
-    expect(findRuleAction('scriptLangValue.javascript', '"ts"')).toMatchObject({
-      switchTo: '@scriptOpen.typescript'
-    })
-    expect(findRuleAction('scriptLangValue.typescript', '"js"')).toMatchObject({
-      switchTo: '@scriptOpen.javascript'
-    })
-    expect(findRuleAction('scriptLangValue.javascript', 'ts')).toMatchObject({
-      switchTo: '@scriptOpen.typescript'
-    })
-    expect(findRuleAction('styleLangValue.css', '"scss"')).toMatchObject({
-      switchTo: '@styleOpen.scss'
-    })
-    expect(findRuleAction('styleLangValue.css', "'sass'")).toMatchObject({
-      switchTo: '@styleOpen.scss'
-    })
-    expect(findRuleAction('styleLangValue.css', 'less')).toMatchObject({
-      switchTo: '@styleOpen.less'
-    })
-    expect(findRuleAction('styleLangValue.scss', '"css"')).toMatchObject({
-      switchTo: '@styleOpen.css'
-    })
+  // Astro `<script>` defaults to JavaScript (unlike Svelte/Vue).
+  it.each([
+    ['<script>', 'javascript'],
+    ['<script lang="js">', 'javascript'],
+    ['<script lang="ts">', 'typescript'],
+    ["<script lang='typescript'>", 'typescript'],
+    ['<script lang=ts>', 'typescript'],
+    ['<script lang="unknown">', 'javascript']
+  ])('embeds a %s body as %s', (openingTag, embeddedLanguageId) => {
+    expect(languagesPerLine(`<h1>hi</h1>\n${openingTag}\n  a\n</script>`)).toEqual([
+      ['html'],
+      ['astro'],
+      [embeddedLanguageId],
+      ['astro']
+    ])
+  })
+
+  it.each([
+    ['<style>', 'css'],
+    ['<style lang="css">', 'css'],
+    ['<style lang="scss">', 'scss'],
+    ["<style lang='sass'>", 'scss'],
+    ['<style lang=less>', 'less'],
+    ['<style lang="unknown">', 'css']
+  ])('embeds a %s body as %s', (openingTag, embeddedLanguageId) => {
+    expect(languagesPerLine(`<h1>hi</h1>\n${openingTag}\n  h1 { color: red; }\n</style>`)).toEqual([
+      ['html'],
+      ['astro'],
+      [embeddedLanguageId],
+      ['astro']
+    ])
+  })
+})
+
+describe('astro root state invariant', () => {
+  // Structural on purpose: behaviour can only reach the root rules some fixture
+  // happens to exercise, and a root rule that pops an embed throws on the very
+  // first character of a file. Guard every root rule, exercised or not.
+  it('has no root rule that pops an embedded language', () => {
+    const rootRules = (astroMonarchLanguage.tokenizer as Record<string, unknown[]>).root
+    const popRules = rootRules.filter(
+      (rule) =>
+        Array.isArray(rule) && (rule[1] as { nextEmbedded?: string })?.nextEmbedded === '@pop'
+    )
+
+    expect(popRules).toEqual([])
   })
 })

--- a/src/renderer/src/lib/monaco-languages/register-astro.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-astro.test.ts
@@ -103,6 +103,18 @@ const title = 'Home'
     ).toEqual(['typescript', 'typescript', null, 'html'])
   })
 
+  // Pins monaco-editor#1127: the pop rule's `^` survives Monaco's regex
+  // rebuild, so an indented or trailing `---` must not close the fence early.
+  it('keeps the frontmatter fence open past a --- that is not at column 0', () => {
+    expect(endEmbeddedLanguages(tokenizeAstro('---\n// ---\n  ---\n---\n<h1>hi</h1>'))).toEqual([
+      'typescript',
+      'typescript',
+      'typescript',
+      null,
+      'html'
+    ])
+  })
+
   // Regression (verified live in the Electron app): an expression in the first
   // markup line popped the html embed before any push, and Monarch threw
   // "cannot pop embedded language if not inside one".

--- a/src/renderer/src/lib/monaco-languages/register-jsonl.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsonl.test.ts
@@ -84,16 +84,42 @@ describe('jsonl tokenization', () => {
     expect(tokenTypeAt(line, 8)).toBe('string')
   })
 
-  // KNOWN DEFECT, found by this suite once it started running the real
-  // tokenizer. Each JSONL line is an independent JSON value, but the `@string`
-  // state survives the line break, so one truncated record (common in logs)
-  // renders every record after it as a single string. `it.fails` pins it: this
-  // flips to a failure the moment the grammar is fixed, so the fix lands with
-  // this expectation inverted rather than silently.
-  it.fails('never carries string state across a record boundary', () => {
-    const [, second] = tokenizeJsonl('{"a": "unterminated\n{"b": 1}')
+  // Regression, found by this suite once it started running the real tokenizer:
+  // `@string` used to survive the line break, so one truncated record rendered
+  // every record after it as a single string.
+  it.each([
+    ['mid-string', '{"a": "truncated here'],
+    ['mid-escape', '{"a": "truncated\\'],
+    ['on a trailing backslash', '{"a": "x\\']
+  ])('does not let a record truncated %s poison the next one', (_name, truncated) => {
+    const [, second] = tokenizeJsonl(`${truncated}\n{"b": 1}`)
 
     expect(tokenTypeAt(second, 1)).toBe('type.identifier')
     expect(tokenTypeAt(second, 6)).toBe('number')
+  })
+
+  it('marks the unterminated remainder of a truncated record', () => {
+    const [first] = tokenizeJsonl('{"a": "truncated here')
+
+    expect(tokenTypeAt(first, 6)).toBe('string.invalid')
+  })
+
+  it.each([
+    ['escaped quote', '{"m": "he said \\"hi\\""}', 15],
+    ['escaped backslash', '{"m": "C:\\\\Users"}', 10],
+    ['unicode escape', '{"m": "\\u00e9"}', 7],
+    ['newline escape', '{"m": "a\\nb"}', 8]
+  ])('still highlights an %s inside a well-formed record', (_name, record, escapeOffset) => {
+    // The fix must not cost escape fidelity on the common case: a candidate that
+    // collapsed the string into one regex lost every one of these.
+    const [line] = tokenizeJsonl(record)
+
+    expect(tokenTypeAt(line, escapeOffset)).toBe('string.escape')
+  })
+
+  it('flags an invalid escape inside a well-formed record', () => {
+    const [line] = tokenizeJsonl('{"m": "a\\qb"}')
+
+    expect(tokenTypeAt(line, 8)).toBe('string.escape.invalid')
   })
 })

--- a/src/renderer/src/lib/monaco-languages/register-jsonl.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsonl.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  formatTokenizedLines,
+  tokenizeMonarchDocument,
+  tokenTypeAt
+} from './monarch-tokenizer-test-harness'
+import {
   JSONL_LANGUAGE_ID,
   jsonlLanguageConfiguration,
   jsonlMonarchLanguage,
   registerJsonlLanguage
 } from './register-jsonl'
+
+function tokenizeJsonl(source: string) {
+  return tokenizeMonarchDocument(JSONL_LANGUAGE_ID, jsonlMonarchLanguage, source)
+}
 
 function createMonacoMock(existingLanguageIds: string[] = []) {
   return {
@@ -50,5 +59,41 @@ describe('registerJsonlLanguage', () => {
 
     expect(monaco.languages.register).not.toHaveBeenCalled()
     expect(monaco.languages.setMonarchTokensProvider).not.toHaveBeenCalled()
+  })
+})
+
+describe('jsonl tokenization', () => {
+  it('tokenizes a representative pair of records', () => {
+    const fixture = `{"a": 1, "b": "x", "c": true, "d": null}
+{"e": [1, -2.5e3], "f": "a\\"b"}`
+
+    expect(formatTokenizedLines(tokenizeJsonl(fixture))).toMatchInlineSnapshot(`
+      [
+        "{"a": 1, "b": "x", "c": true, "d": null} | 0:delimiter.curly.jsonl@jsonl 1:type.identifier.jsonl@jsonl 4:delimiter.jsonl@jsonl 5:white.jsonl@jsonl 6:number.jsonl@jsonl 7:delimiter.jsonl@jsonl 8:white.jsonl@jsonl 9:type.identifier.jsonl@jsonl 12:delimiter.jsonl@jsonl 13:white.jsonl@jsonl 14:string.jsonl@jsonl 17:delimiter.jsonl@jsonl 18:white.jsonl@jsonl 19:type.identifier.jsonl@jsonl 22:delimiter.jsonl@jsonl 23:white.jsonl@jsonl 24:keyword.jsonl@jsonl 28:delimiter.jsonl@jsonl 29:white.jsonl@jsonl 30:type.identifier.jsonl@jsonl 33:delimiter.jsonl@jsonl 34:white.jsonl@jsonl 35:keyword.jsonl@jsonl 39:delimiter.curly.jsonl@jsonl | embed=none",
+        "{"e": [1, -2.5e3], "f": "a\\"b"} | 0:delimiter.curly.jsonl@jsonl 1:type.identifier.jsonl@jsonl 4:delimiter.jsonl@jsonl 5:white.jsonl@jsonl 6:delimiter.square.jsonl@jsonl 7:number.jsonl@jsonl 8:delimiter.jsonl@jsonl 9:white.jsonl@jsonl 10:number.jsonl@jsonl 16:delimiter.square.jsonl@jsonl 17:delimiter.jsonl@jsonl 18:white.jsonl@jsonl 19:type.identifier.jsonl@jsonl 22:delimiter.jsonl@jsonl 23:white.jsonl@jsonl 24:string.jsonl@jsonl 26:string.escape.jsonl@jsonl 28:string.jsonl@jsonl 30:delimiter.curly.jsonl@jsonl | embed=none",
+      ]
+    `)
+  })
+
+  it('colours a property key differently from a string value', () => {
+    // The `(?=\s*:)` lookahead is the only thing separating the two; a regression
+    // there makes every key look like a value.
+    const [line] = tokenizeJsonl('{"key": "value"}')
+
+    expect(tokenTypeAt(line, 1)).toBe('type.identifier')
+    expect(tokenTypeAt(line, 8)).toBe('string')
+  })
+
+  // KNOWN DEFECT, found by this suite once it started running the real
+  // tokenizer. Each JSONL line is an independent JSON value, but the `@string`
+  // state survives the line break, so one truncated record (common in logs)
+  // renders every record after it as a single string. `it.fails` pins it: this
+  // flips to a failure the moment the grammar is fixed, so the fix lands with
+  // this expectation inverted rather than silently.
+  it.fails('never carries string state across a record boundary', () => {
+    const [, second] = tokenizeJsonl('{"a": "unterminated\n{"b": 1}')
+
+    expect(tokenTypeAt(second, 1)).toBe('type.identifier')
+    expect(tokenTypeAt(second, 6)).toBe('number')
   })
 })

--- a/src/renderer/src/lib/monaco-languages/register-jsonl.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsonl.ts
@@ -34,7 +34,14 @@ export const jsonlMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       { include: '@whitespace' },
       // Property key vs string value are both quoted; color keys distinctly.
       [/"(?:[^"\\]|\\.)*"(?=\s*:)/, 'type.identifier'],
-      [/"/, 'string', '@string'],
+      // Why the lookahead: each JSONL line is an independent value, but Monarch
+      // state survives the line break. Pushing `@string` unconditionally meant
+      // one truncated record (a normal way for a log to end) left every later
+      // record inside the string state, rendering the rest of the file as one
+      // string. Only enter the escape-aware state once a closing quote is known
+      // to be on this line; an unterminated remainder is consumed below instead.
+      [/"(?=(?:[^"\\]|\\.)*")/, 'string', '@string'],
+      [/"(?:[^"\\]|\\.)*\\?$/, 'string.invalid'],
       [/[{}[\]]/, '@brackets'],
       [/-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/, 'number'],
       [/\b(?:true|false)\b/, 'keyword'],

--- a/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-svelte.test.ts
@@ -1,124 +1,33 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  endEmbeddedLanguages,
+  formatTokenizedLines,
+  tokenizeMonarchDocument,
+  tokenLanguages,
+  tokenLanguagesPerLine,
+  tokenTypeAt
+} from './monarch-tokenizer-test-harness'
+import {
   registerSvelteLanguage,
   svelteLanguageConfiguration,
   svelteMonarchLanguage
 } from './register-svelte'
 
-type MonarchAction = {
-  next?: string
-  nextEmbedded?: string
-  switchTo?: string
-}
-type MonarchRule = [RegExp, string | MonarchAction, string?] | { include: string }
-
-function normalizeState(nextState: string): string {
-  return nextState.startsWith('@') ? nextState.slice(1) : nextState
+// These tests drive the real `MonarchTokenizer`. Walking the rule table instead
+// let a grammar that threw on 100% of Svelte inputs — including `<p>a {b}</p>` —
+// ship with a green suite, because a broken grammar still has a valid table.
+function tokenizeSvelte(source: string) {
+  return tokenizeMonarchDocument('svelte', svelteMonarchLanguage, source)
 }
 
-function isRuleEntry(rule: MonarchRule): rule is [RegExp, string | MonarchAction, string?] {
-  return Array.isArray(rule)
-}
-
-function getRuleAction(rule: [RegExp, string | MonarchAction, string?]): MonarchAction | undefined {
-  const [, action, nextStateShortcut] = rule
-  return typeof action === 'object'
-    ? action
-    : nextStateShortcut
-      ? { next: nextStateShortcut }
-      : undefined
-}
-
-function findRuleAction(
-  state: string,
-  source: string,
-  { embedPopOnly = false }: { embedPopOnly?: boolean } = {}
-): MonarchAction | undefined {
-  const tokenizer = svelteMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
-  const stateRules = tokenizer[state] ?? tokenizer[state.split('.')[0]]
-  // When the html embed is active inside `markup`, Monaco's
-  // `_findLeavingNestedLanguageOffset` only consults rules whose action has
-  // `nextEmbedded: '@pop'` — the zero-width `@rematch` catch-all is
-  // skipped. Mirror that when callers want to verify the "structural rule
-  // pops the embed" path.
-  const candidateRules = embedPopOnly
-    ? stateRules.filter((rule) => {
-        if (!isRuleEntry(rule)) {
-          return false
-        }
-        return getRuleAction(rule)?.nextEmbedded === '@pop'
-      })
-    : stateRules
-  const matchedRule = candidateRules.find((rule) => {
-    if (!isRuleEntry(rule)) {
-      return false
-    }
-    const [regexp] = rule
-    regexp.lastIndex = 0
-    const match = regexp.exec(source)
-    return match !== null && match.index === 0
-  })
-
-  return matchedRule && isRuleEntry(matchedRule) ? getRuleAction(matchedRule) : undefined
-}
-
-function collectFixtureRuleActions(source: string): string[] {
-  const ruleActions: string[] = []
-  const tokenizer = svelteMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
-  const lines = source.split('\n')
-  const checks: { line: number; state: string; pattern: string }[] = [
-    { line: 1, state: 'root', pattern: '<script' },
-    { line: 1, state: 'scriptOpen.typescript', pattern: '>' },
-    { line: 4, state: 'scriptBody.typescript', pattern: '</script>' },
-    // After </script> pops back to root and the next non-structural character
-    // switches root -> markup with the html embed active.
-    { line: 6, state: 'root', pattern: '' },
-    { line: 7, state: 'markup', pattern: '{#if' },
-    { line: 7, state: 'svelteBlockExpression', pattern: '}' },
-    { line: 8, state: 'markup', pattern: '{' },
-    { line: 8, state: 'svelteExpression', pattern: '}' },
-    { line: 9, state: 'markup', pattern: '{:else' },
-    { line: 9, state: 'svelteBlockExpressionEnter', pattern: '}' },
-    { line: 11, state: 'markup', pattern: '{/if}' },
-    { line: 13, state: 'markup', pattern: '{' },
-    { line: 13, state: 'svelteExpression', pattern: '}' },
-    { line: 14, state: 'markup', pattern: '{@html' },
-    { line: 14, state: 'svelteExpression', pattern: '}' },
-    { line: 16, state: 'markup', pattern: '<style' },
-    { line: 16, state: 'styleOpen.css', pattern: '>' },
-    { line: 18, state: 'styleBody.css', pattern: '</style>' }
-  ]
-
-  checks.forEach((check) => {
-    const line = lines.at(check.line - 1) ?? ''
-    const stateRules = tokenizer[check.state] ?? tokenizer[check.state.split('.')[0]]
-    const matchedRule = stateRules.find((rule) => {
-      if (!isRuleEntry(rule)) {
-        return false
-      }
-      const [regexp] = rule
-      regexp.lastIndex = 0
-      const match = regexp.exec(line)
-      return match !== null && match[0] === check.pattern
-    })
-    if (!matchedRule || !isRuleEntry(matchedRule)) {
-      return
-    }
-
-    const actionObject = getRuleAction(matchedRule)
-
-    const nextState = actionObject?.next ? normalizeState(actionObject.next) : '-'
-    const nextEmbedded = actionObject?.nextEmbedded ?? '-'
-    const switchTo = actionObject?.switchTo ? normalizeState(actionObject.switchTo) : '-'
-    ruleActions.push(
-      `${check.line}:${check.state}:${check.pattern || '<html>'} -> next=${nextState}, embedded=${nextEmbedded}, switch=${switchTo}`
-    )
-  })
-
-  return ruleActions
+/** Which languages actually cover each line — a dropped embed shows up as `svelte`. */
+function languagesPerLine(source: string): string[][] {
+  return tokenLanguagesPerLine(tokenizeSvelte(source))
 }
 
 describe('registerSvelteLanguage registration', () => {
+  // Structural by necessity: this covers the registration call itself
+  // (ids, extensions, idempotence), which no amount of tokenizing can observe.
   it('registers the svelte language, Monarch tokenizer, and configuration once', () => {
     const languages: { id: string }[] = [{ id: 'typescript' }]
     const register = vi.fn((entry: { id: string }) => {
@@ -152,8 +61,8 @@ describe('registerSvelteLanguage registration', () => {
   })
 })
 
-describe('svelte tokenizer transitions', () => {
-  it('captures Svelte tokenizer transitions for a representative SFC fixture', () => {
+describe('svelte tokenization', () => {
+  it('tokenizes a representative SFC', () => {
     const fixture = `<script lang="ts">
   let count = 0
   $: doubled = count * 2
@@ -173,103 +82,159 @@ describe('svelte tokenizer transitions', () => {
   h1 { color: rebeccapurple; }
 </style>`
 
-    const ruleActions = collectFixtureRuleActions(fixture)
-
-    expect(ruleActions).toMatchInlineSnapshot(`
+    expect(formatTokenizedLines(tokenizeSvelte(fixture))).toMatchInlineSnapshot(`
       [
-        "1:root:<script -> next=-, embedded=-, switch=scriptOpen.typescript",
-        "1:scriptOpen.typescript:> -> next=-, embedded=$S2, switch=scriptBody.$S2",
-        "4:scriptBody.typescript:</script> -> next=-, embedded=@pop, switch=markupReenter",
-        "6:root:<html> -> next=-, embedded=html, switch=markup",
-        "7:markup:{#if -> next=-, embedded=@pop, switch=svelteBlockExpressionEnter",
-        "7:svelteBlockExpression:} -> next=-, embedded=@pop, switch=markupReenter",
-        "8:markup:{ -> next=-, embedded=@pop, switch=svelteExpressionEnter",
-        "8:svelteExpression:} -> next=-, embedded=@pop, switch=markupReenter",
-        "9:markup:{:else -> next=-, embedded=@pop, switch=svelteBlockExpressionEnter",
-        "9:svelteBlockExpressionEnter:} -> next=-, embedded=-, switch=markupReenter",
-        "11:markup:{/if} -> next=-, embedded=-, switch=-",
-        "13:markup:{ -> next=-, embedded=@pop, switch=svelteExpressionEnter",
-        "13:svelteExpression:} -> next=-, embedded=@pop, switch=markupReenter",
-        "14:markup:{@html -> next=-, embedded=@pop, switch=svelteExpressionEnter",
-        "14:svelteExpression:} -> next=-, embedded=@pop, switch=markupReenter",
-        "16:markup:<style -> next=-, embedded=@pop, switch=styleOpen.css",
-        "16:styleOpen.css:> -> next=-, embedded=$S2, switch=styleBody.$S2",
-        "18:styleBody.css:</style> -> next=-, embedded=@pop, switch=markupReenter",
+        "<script lang="ts"> | 0:tag.svelte@svelte 7:white.svelte@svelte 8:attribute.name.svelte@svelte 12:delimiter.svelte@svelte 13:attribute.value.svelte@svelte 17:tag.svelte@svelte | embed=typescript",
+        "  let count = 0 | 0:-@typescript | embed=typescript",
+        "  $: doubled = count * 2 | 0:-@typescript | embed=typescript",
+        "</script> | 0:tag.svelte@svelte | embed=none",
+        " |  | embed=html",
+        "<h1>Counter</h1> | 0:-@html | embed=html",
+        "{#if count > 0} | 0:keyword.control.svelte@svelte 4:-@typescript 14:keyword.control.svelte@svelte | embed=none",
+        "  <p>{count} clicked</p> | 0:-@html 5:delimiter.curly.svelte@svelte 6:-@typescript 11:delimiter.curly.svelte@svelte 12:-@html | embed=html",
+        "{:else} | 0:keyword.control.svelte@svelte | embed=none",
+        "  <p>not yet</p> | 0:-@html | embed=html",
+        "{/if} | 0:-@html | embed=html",
+        " | 0:-@html | embed=html",
+        "<button on:click={increment}>{count}</button> | 0:-@html 17:delimiter.curly.svelte@svelte 18:-@typescript 27:delimiter.curly.svelte@svelte 28:-@html 29:delimiter.curly.svelte@svelte 30:-@typescript 35:delimiter.curly.svelte@svelte 36:-@html | embed=html",
+        "{@html '<em>raw</em>'} | 0:keyword.control.svelte@svelte 6:-@typescript 21:delimiter.curly.svelte@svelte | embed=none",
+        " |  | embed=html",
+        "<style> | 0:tag.svelte@svelte | embed=css",
+        "  h1 { color: rebeccapurple; } | 0:-@css | embed=css",
+        "</style> | 0:tag.svelte@svelte | embed=none",
       ]
     `)
   })
-})
 
-describe('svelte tokenizer regressions', () => {
-  // Regression: when a Svelte file starts with `{#if}`, `{name}`, or `{@html}`,
-  // no html embed is active yet. Earlier drafts unconditionally emitted
-  // `nextEmbedded: '@pop'` from root, which Monaco rejects with
-  // "cannot pop embedded language if not inside one". The fix splits the
-  // entry-only `root` state from the html-embedded `markup` state.
-  it('does not pop a non-existent embed when a file starts with a Svelte block', () => {
-    const action = findRuleAction('root', '{#if foo}')
-    expect(action).toMatchObject({ switchTo: '@svelteBlockExpressionEnter' })
-    expect(action?.nextEmbedded).toBeUndefined()
+  // Regression (the field failure): the first interpolation of a file threw
+  // "cannot pop embedded language if not inside one" — every Svelte file with a
+  // `{}` in it, which is essentially all of them.
+  it('highlights every interpolation of a markup line', () => {
+    const [line] = tokenizeSvelte('<p>a {first} b {second} c</p>')
+
+    expect(tokenLanguages(line)).toEqual([
+      'html',
+      'svelte',
+      'typescript',
+      'svelte',
+      'html',
+      'svelte',
+      'typescript',
+      'svelte',
+      'html'
+    ])
   })
 
-  it('starts the html embed and switches to markup when markup begins', () => {
-    expect(findRuleAction('root', '<h1>Counter</h1>')).toMatchObject({
-      switchTo: '@markup',
-      nextEmbedded: 'html'
-    })
+  it('opens a file on a Svelte block without popping a missing embed', () => {
+    // No html embed exists yet at file start, so the block's entry rule must not
+    // pop one — Monarch throws outright if it does.
+    const [line] = tokenizeSvelte('{#if count > 0}')
+
+    expect(tokenTypeAt(line, 0)).toBe('keyword.control')
+    expect(tokenLanguages(line)).toEqual(['svelte', 'typescript', 'svelte'])
   })
 
-  // Regression: while the html embed is active, only parent rules whose action
-  // pops the embed are consulted before delegating to html. The first draft
-  // omitted `nextEmbedded: '@pop'` from `<script>` / `<style>` / `<!--` rules,
-  // so a trailing `<style lang="scss">` after markup never reached the
-  // lang-switching code. The `markup` state wires the embed pop in.
-  it('pops the html embed when later script/style/comment markers appear', () => {
-    expect(findRuleAction('markup', '<script lang="ts">', { embedPopOnly: true })).toMatchObject({
-      switchTo: '@scriptOpen.typescript',
-      nextEmbedded: '@pop'
-    })
-    expect(findRuleAction('markup', '<style lang="scss">', { embedPopOnly: true })).toMatchObject({
-      switchTo: '@styleOpen.css',
-      nextEmbedded: '@pop'
-    })
-    expect(findRuleAction('markup', '<!-- comment -->', { embedPopOnly: true })).toMatchObject({
-      switchTo: '@comment',
-      nextEmbedded: '@pop'
-    })
+  it('enters the html embed when markup begins', () => {
+    expect(endEmbeddedLanguages(tokenizeSvelte('<h1>Counter</h1>'))).toEqual(['html'])
+  })
+
+  it('pops the html embed for a comment that follows markup', () => {
+    // Once html is active Monaco only consults parent rules that pop the embed,
+    // so `<!--` after markup is unreachable without one.
+    expect(languagesPerLine('<h1>hi</h1>\n<!-- a note -->\n<p>after</p>')).toEqual([
+      ['html'],
+      ['svelte'],
+      ['html']
+    ])
+  })
+
+  it('keeps markup embedded across a Svelte block', () => {
+    expect(
+      languagesPerLine(
+        '<h1>hi</h1>\n{#if ok}\n  <p>yes</p>\n{:else}\n  <p>no</p>\n{/if}\n<p>done</p>'
+      )
+    ).toEqual([
+      ['html'],
+      ['svelte', 'typescript', 'svelte'],
+      ['html'],
+      ['svelte'],
+      ['html'],
+      ['html'],
+      ['html']
+    ])
+  })
+
+  it('keeps markup highlighted across a whole multi-line file', () => {
+    // A grammar that drops the embed leaves plain `svelte` on these rows, which
+    // is the silently-unhighlighted failure a rule-table walk cannot see.
+    expect(
+      languagesPerLine(
+        '<h1>hi</h1>\n<p>{a}</p>\n<!-- note -->\n<p>{b}</p>\n<button on:click={go}>x</button>'
+      )
+    ).toEqual([
+      ['html'],
+      ['html', 'svelte', 'typescript', 'svelte', 'html'],
+      ['svelte'],
+      ['html', 'svelte', 'typescript', 'svelte', 'html'],
+      ['html', 'svelte', 'typescript', 'svelte', 'html']
+    ])
+  })
+
+  it('does not enter typescript for an empty expression', () => {
+    // `{}` pops html on entry but never pushes typescript; the close must unwind
+    // only the state, or the tokenizer pops an embed that is not there.
+    expect(tokenLanguages(tokenizeSvelte('<p>{}</p>')[0])).toEqual(['html', 'svelte', 'html'])
   })
 })
 
 describe('svelte embedded language attributes', () => {
-  it('tracks embedded languages from Svelte block attributes and expressions', () => {
-    expect(findRuleAction('svelteExpressionEnter', 'count }')).toMatchObject({
-      nextEmbedded: 'typescript',
-      switchTo: '@svelteExpression'
-    })
-    expect(findRuleAction('svelteBlockExpressionEnter', 'count > 0}')).toMatchObject({
-      nextEmbedded: 'typescript',
-      switchTo: '@svelteBlockExpression'
-    })
-    expect(findRuleAction('scriptLangValue.typescript', '"js"')).toMatchObject({
-      switchTo: '@scriptOpen.javascript'
-    })
-    expect(findRuleAction('scriptLangValue.javascript', '"ts"')).toMatchObject({
-      switchTo: '@scriptOpen.typescript'
-    })
-    expect(findRuleAction('scriptLangValue.typescript', 'js')).toMatchObject({
-      switchTo: '@scriptOpen.javascript'
-    })
-    expect(findRuleAction('styleLangValue.css', '"scss"')).toMatchObject({
-      switchTo: '@styleOpen.scss'
-    })
-    expect(findRuleAction('styleLangValue.css', 'less')).toMatchObject({
-      switchTo: '@styleOpen.less'
-    })
-    expect(findRuleAction('styleLangValue.css', "'sass'")).toMatchObject({
-      switchTo: '@styleOpen.scss'
-    })
-    expect(findRuleAction('styleLangValue.scss', '"css"')).toMatchObject({
-      switchTo: '@styleOpen.css'
-    })
+  // `lang=` picks the embedded language for the block body. The assertion is on
+  // the body row, which is the region a reader sees highlighted (or not).
+  it.each([
+    ['<script>', 'typescript'],
+    ['<script lang="ts">', 'typescript'],
+    ['<script lang="typescript">', 'typescript'],
+    ['<script lang="js">', 'javascript'],
+    ["<script lang='javascript'>", 'javascript'],
+    ['<script lang=js>', 'javascript'],
+    ['<script lang="unknown">', 'typescript']
+  ])('embeds a %s body as %s', (openingTag, embeddedLanguageId) => {
+    expect(languagesPerLine(`<h1>hi</h1>\n${openingTag}\n  a\n</script>`)).toEqual([
+      ['html'],
+      ['svelte'],
+      [embeddedLanguageId],
+      ['svelte']
+    ])
+  })
+
+  it.each([
+    ['<style>', 'css'],
+    ['<style lang="css">', 'css'],
+    ['<style lang="scss">', 'scss'],
+    ["<style lang='sass'>", 'scss'],
+    ['<style lang=less>', 'less'],
+    ['<style lang="unknown">', 'css']
+  ])('embeds a %s body as %s', (openingTag, embeddedLanguageId) => {
+    expect(languagesPerLine(`<h1>hi</h1>\n${openingTag}\n  h1 { color: red; }\n</style>`)).toEqual([
+      ['html'],
+      ['svelte'],
+      [embeddedLanguageId],
+      ['svelte']
+    ])
+  })
+})
+
+describe('svelte root state invariant', () => {
+  // Structural on purpose: behaviour can only reach the root rules some fixture
+  // happens to exercise, and a root rule that pops an embed throws on the very
+  // first character of a file. Guard every root rule, exercised or not.
+  it('has no root rule that pops an embedded language', () => {
+    const rootRules = (svelteMonarchLanguage.tokenizer as Record<string, unknown[]>).root
+    const popRules = rootRules.filter(
+      (rule) =>
+        Array.isArray(rule) && (rule[1] as { nextEmbedded?: string })?.nextEmbedded === '@pop'
+    )
+
+    expect(popRules).toEqual([])
   })
 })

--- a/src/renderer/src/lib/monaco-languages/register-vue.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-vue.test.ts
@@ -1,110 +1,28 @@
 import { describe, expect, it, vi } from 'vitest'
+import {
+  endEmbeddedLanguages,
+  formatTokenizedLines,
+  tokenizeMonarchDocument,
+  tokenLanguages,
+  tokenLanguagesPerLine
+} from './monarch-tokenizer-test-harness'
 import { registerVueLanguage, vueLanguageConfiguration, vueMonarchLanguage } from './register-vue'
 
-type MonarchAction = {
-  next?: string
-  nextEmbedded?: string
-  switchTo?: string
-}
-type MonarchRule = [RegExp, string | MonarchAction, string?] | { include: string }
-
-function normalizeState(nextState: string): string {
-  return nextState.startsWith('@') ? nextState.slice(1) : nextState
+// Driven through the real `MonarchTokenizer`: a rule-table walk cannot tell a
+// working grammar from one that throws on every `{{ }}`, which is how broken
+// Vue highlighting shipped green.
+function tokenizeVue(source: string) {
+  return tokenizeMonarchDocument('vue', vueMonarchLanguage, source)
 }
 
-function isRuleEntry(rule: MonarchRule): rule is [RegExp, string | MonarchAction, string?] {
-  return Array.isArray(rule)
+/** Which languages actually cover each line — a dropped embed shows up as `vue`. */
+function languagesPerLine(source: string): string[][] {
+  return tokenLanguagesPerLine(tokenizeVue(source))
 }
 
-function getRuleAction(rule: [RegExp, string | MonarchAction, string?]): MonarchAction | undefined {
-  const [, action, nextStateShortcut] = rule
-  return typeof action === 'object'
-    ? action
-    : nextStateShortcut
-      ? { next: nextStateShortcut }
-      : undefined
-}
-
-function findRuleAction(state: string, source: string): MonarchAction | undefined {
-  const tokenizer = vueMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
-  const stateRules = tokenizer[state] ?? tokenizer[state.split('.')[0]]
-  const matchedRule = stateRules.find((rule) => {
-    if (!isRuleEntry(rule)) {
-      return false
-    }
-    const [regexp] = rule
-    regexp.lastIndex = 0
-    const match = regexp.exec(source)
-    return match !== null && match.index === 0
-  })
-
-  return matchedRule && isRuleEntry(matchedRule) ? getRuleAction(matchedRule) : undefined
-}
-
-function collectFixtureRuleActions(source: string): {
-  line: number
-  state: string
-  matched: string
-  nextState?: string
-  nextEmbedded?: string
-  switchTo?: string
-}[] {
-  const ruleActions: {
-    line: number
-    state: string
-    matched: string
-    nextState?: string
-    nextEmbedded?: string
-    switchTo?: string
-  }[] = []
-  const tokenizer = vueMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
-  const lines = source.split('\n')
-  const checks: { line: number; state: string; pattern: string }[] = [
-    { line: 1, state: 'root', pattern: '<template' },
-    { line: 1, state: 'templateOpen', pattern: '>' },
-    { line: 2, state: 'templateBody', pattern: '{{' },
-    { line: 2, state: 'templateExpression', pattern: '}}' },
-    { line: 3, state: 'templateBody', pattern: '</template>' },
-    { line: 5, state: 'root', pattern: '<script' },
-    { line: 5, state: 'scriptOpen.typescript', pattern: '>' },
-    { line: 7, state: 'scriptBody.typescript', pattern: '</script>' },
-    { line: 9, state: 'root', pattern: '<style' },
-    { line: 9, state: 'styleOpen.css', pattern: '>' },
-    { line: 11, state: 'styleBody.css', pattern: '</style>' }
-  ]
-
-  checks.forEach((check) => {
-    const line = lines.at(check.line - 1) ?? ''
-    const stateRules = tokenizer[check.state] ?? tokenizer[check.state.split('.')[0]]
-    const matchedRule = stateRules.find((rule) => {
-      if (!isRuleEntry(rule)) {
-        return false
-      }
-      const [regexp] = rule
-      regexp.lastIndex = 0
-      const match = regexp.exec(line)
-      return match !== null && match[0] === check.pattern
-    })
-    if (!matchedRule || !isRuleEntry(matchedRule)) {
-      return
-    }
-
-    const actionObject = getRuleAction(matchedRule)
-
-    ruleActions.push({
-      line: check.line,
-      state: check.state,
-      matched: check.pattern,
-      nextState: actionObject?.next ? normalizeState(actionObject.next) : undefined,
-      nextEmbedded: actionObject?.nextEmbedded,
-      switchTo: actionObject?.switchTo ? normalizeState(actionObject.switchTo) : undefined
-    })
-  })
-
-  return ruleActions
-}
-
-describe('registerVueLanguage', () => {
+describe('registerVueLanguage registration', () => {
+  // Structural by necessity: covers the registration call itself (ids,
+  // extensions, idempotence), which tokenizing cannot observe.
   it('registers the vue language, Monarch tokenizer, and configuration once', () => {
     const languages: { id: string }[] = [{ id: 'typescript' }]
     const register = vi.fn((entry: { id: string }) => {
@@ -136,8 +54,10 @@ describe('registerVueLanguage', () => {
     expect(setLanguageConfiguration).toHaveBeenCalledTimes(1)
     expect(setLanguageConfiguration).toHaveBeenCalledWith('vue', vueLanguageConfiguration)
   })
+})
 
-  it('captures Vue tokenizer transitions for a representative SFC fixture', () => {
+describe('vue tokenization', () => {
+  it('tokenizes a representative SFC', () => {
     const fixture = `<template>
   <p>{{ message.toUpperCase() }}</p>
 </template>
@@ -150,121 +70,110 @@ const message = 'hello'
 p { color: rebeccapurple; }
 </style>`
 
-    const ruleActions = collectFixtureRuleActions(fixture)
-
-    expect(ruleActions).toMatchInlineSnapshot(`
+    expect(formatTokenizedLines(tokenizeVue(fixture))).toMatchInlineSnapshot(`
       [
-        {
-          "line": 1,
-          "matched": "<template",
-          "nextEmbedded": undefined,
-          "nextState": "templateOpen",
-          "state": "root",
-          "switchTo": undefined,
-        },
-        {
-          "line": 1,
-          "matched": ">",
-          "nextEmbedded": "html",
-          "nextState": undefined,
-          "state": "templateOpen",
-          "switchTo": "templateBody",
-        },
-        {
-          "line": 2,
-          "matched": "{{",
-          "nextEmbedded": "@pop",
-          "nextState": undefined,
-          "state": "templateBody",
-          "switchTo": "templateExpressionEnter",
-        },
-        {
-          "line": 2,
-          "matched": "}}",
-          "nextEmbedded": "@pop",
-          "nextState": undefined,
-          "state": "templateExpression",
-          "switchTo": "templateBodyReenter",
-        },
-        {
-          "line": 3,
-          "matched": "</template>",
-          "nextEmbedded": "@pop",
-          "nextState": "pop",
-          "state": "templateBody",
-          "switchTo": undefined,
-        },
-        {
-          "line": 5,
-          "matched": "<script",
-          "nextEmbedded": undefined,
-          "nextState": "scriptOpen.typescript",
-          "state": "root",
-          "switchTo": undefined,
-        },
-        {
-          "line": 5,
-          "matched": ">",
-          "nextEmbedded": "$S2",
-          "nextState": undefined,
-          "state": "scriptOpen.typescript",
-          "switchTo": "scriptBody.$S2",
-        },
-        {
-          "line": 7,
-          "matched": "</script>",
-          "nextEmbedded": "@pop",
-          "nextState": "pop",
-          "state": "scriptBody.typescript",
-          "switchTo": undefined,
-        },
-        {
-          "line": 9,
-          "matched": "<style",
-          "nextEmbedded": undefined,
-          "nextState": "styleOpen.css",
-          "state": "root",
-          "switchTo": undefined,
-        },
-        {
-          "line": 9,
-          "matched": ">",
-          "nextEmbedded": "$S2",
-          "nextState": undefined,
-          "state": "styleOpen.css",
-          "switchTo": "styleBody.$S2",
-        },
-        {
-          "line": 11,
-          "matched": "</style>",
-          "nextEmbedded": "@pop",
-          "nextState": "pop",
-          "state": "styleBody.css",
-          "switchTo": undefined,
-        },
+        "<template> | 0:tag.vue@vue | embed=html",
+        "  <p>{{ message.toUpperCase() }}</p> | 0:-@html 5:delimiter.curly.vue@vue 7:-@typescript 30:delimiter.curly.vue@vue 32:-@html | embed=html",
+        "</template> | 0:tag.vue@vue | embed=none",
+        " |  | embed=none",
+        "<script setup lang="ts"> | 0:tag.vue@vue 7:white.vue@vue 8:attribute.name.vue@vue 13:white.vue@vue 14:attribute.name.vue@vue 18:delimiter.vue@vue 19:attribute.value.vue@vue 23:tag.vue@vue | embed=typescript",
+        "const message = 'hello' | 0:-@typescript | embed=typescript",
+        "</script> | 0:tag.vue@vue | embed=none",
+        " |  | embed=none",
+        "<style scoped> | 0:tag.vue@vue 6:white.vue@vue 7:attribute.name.vue@vue 13:tag.vue@vue | embed=css",
+        "p { color: rebeccapurple; } | 0:-@css | embed=css",
+        "</style> | 0:tag.vue@vue | embed=none",
       ]
     `)
   })
 
-  it('tracks embedded languages from Vue block attributes', () => {
-    expect(findRuleAction('templateExpressionEnter', 'message }}')).toMatchObject({
-      nextEmbedded: 'typescript',
-      switchTo: '@templateExpression'
-    })
-    expect(findRuleAction('scriptLangValue.typescript', '"js"')).toMatchObject({
-      switchTo: '@scriptOpen.javascript'
-    })
-    expect(findRuleAction('scriptLangValue.javascript', '"ts"')).toMatchObject({
-      switchTo: '@scriptOpen.typescript'
-    })
-    expect(findRuleAction('scriptLangValue.typescript', 'js')).toMatchObject({
-      switchTo: '@scriptOpen.javascript'
-    })
-    expect(findRuleAction('styleLangValue.css', '"scss"')).toMatchObject({
-      switchTo: '@styleOpen.scss'
-    })
-    expect(findRuleAction('styleLangValue.css', 'less')).toMatchObject({
-      switchTo: '@styleOpen.less'
-    })
+  // Regression: every `{{ }}` threw "cannot pop embedded language if not inside
+  // one" once the template body lost its html embed.
+  it('highlights every interpolation in a template line', () => {
+    const [, line] = tokenizeVue('<template>\n  <p>{{ a }} and {{ b }}</p>\n</template>')
+
+    expect(tokenLanguages(line)).toEqual([
+      'html',
+      'vue',
+      'typescript',
+      'vue',
+      'html',
+      'vue',
+      'typescript',
+      'vue',
+      'html'
+    ])
+  })
+
+  it('embeds the template body as html', () => {
+    expect(endEmbeddedLanguages(tokenizeVue('<template>\n  <p>x</p>\n</template>'))).toEqual([
+      'html',
+      'html',
+      null
+    ])
+  })
+
+  it('keeps the template embedded across a comment before it', () => {
+    expect(languagesPerLine('<!-- a note -->\n<template>\n  <p>x</p>\n</template>')).toEqual([
+      ['vue'],
+      ['vue'],
+      ['html'],
+      ['vue']
+    ])
+  })
+
+  it('does not enter typescript for an empty interpolation', () => {
+    // `{{}}` pops html on entry but never pushes typescript; the close must
+    // unwind only the state, or it pops an embed that is not there.
+    const [, line] = tokenizeVue('<template>\n  <p>{{}}</p>\n</template>')
+
+    expect(tokenLanguages(line)).toEqual(['html', 'vue', 'html'])
+  })
+})
+
+describe('vue embedded language attributes', () => {
+  it.each([
+    ['<script>', 'typescript'],
+    ['<script lang="ts">', 'typescript'],
+    ['<script setup lang="typescript">', 'typescript'],
+    ['<script lang="js">', 'javascript'],
+    ['<script setup lang=js>', 'javascript'],
+    ['<script lang="unknown">', 'typescript']
+  ])('embeds a %s body as %s', (openingTag, embeddedLanguageId) => {
+    expect(languagesPerLine(`${openingTag}\n  a\n</script>`)).toEqual([
+      ['vue'],
+      [embeddedLanguageId],
+      ['vue']
+    ])
+  })
+
+  it.each([
+    ['<style>', 'css'],
+    ['<style scoped>', 'css'],
+    ['<style lang="scss">', 'scss'],
+    ["<style lang='sass'>", 'scss'],
+    ['<style lang=less>', 'less'],
+    ['<style lang="unknown">', 'css']
+  ])('embeds a %s body as %s', (openingTag, embeddedLanguageId) => {
+    expect(languagesPerLine(`${openingTag}\n  h1 { color: red; }\n</style>`)).toEqual([
+      ['vue'],
+      [embeddedLanguageId],
+      ['vue']
+    ])
+  })
+})
+
+describe('vue root state invariant', () => {
+  // Structural on purpose: behaviour can only reach the root rules some fixture
+  // happens to exercise, and a root rule that pops an embed throws on the very
+  // first character of a file. Guard every root rule, exercised or not.
+  it('has no root rule that pops an embedded language', () => {
+    const rootRules = (vueMonarchLanguage.tokenizer as Record<string, unknown[]>).root
+    const popRules = rootRules.filter(
+      (rule) =>
+        Array.isArray(rule) && (rule[1] as { nextEmbedded?: string })?.nextEmbedded === '@pop'
+    )
+
+    expect(popRules).toEqual([])
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​567 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​705 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​138 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​167 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 |

<!-- /orca-pr-loc -->

Stacked on #19748 (`fix/monarch-embed-recursion-budget`) — this PR targets that branch, not `main`.

#19748 fixed two real bugs in the Svelte/Astro/Vue Monarch grammars. Both shipped with a green test suite. This PR fixes the reason they could.

## ELI5

The tests for Svelte/Astro/Vue syntax highlighting never highlighted anything. They read the grammar's *rulebook* and checked that the rules looked well-formed — proofreading the recipe instead of tasting the food. A grammar that threw an error on the first character of every real file still has a tidy rulebook, so it passed with a green tick. That's how the bugs in #19748 shipped: the suite was green the whole time.

Now the tests run the actual highlighter over actual snippets and assert on the colours that come out. Replayed against the old, broken grammars, 50 of them fail loudly with the exact error users were seeing in the logs.

Switching to real tokenizing immediately turned up a live bug nobody knew about: in `.jsonl` log files, one record cut off mid-string — which is simply how a log ends when something is killed — left the highlighter stuck "inside a string" forever, so every line below it rendered as one long string. Fixed here too.

## The blind spot

`register-{svelte,astro,vue}.test.ts` walked the rule **table** — asserting on the grammar's data structure — instead of running the tokenizer. A grammar that throws on every real file still has a well-formed rule table, so it passes a table-walking test.

Auditing every test file in the folder, the gap was **4 of 8 files**, not the 3 already named:

| File | Verdict (before) | Action |
|---|---|---|
| `register-svelte.test.ts` | **Table-walking** — `findRuleAction` + inline snapshot of rule actions, never tokenized | Converted |
| `register-astro.test.ts` | **Table-walking** — same helpers, same blind spot | Converted |
| `register-vue.test.ts` | **Table-walking** — same | Converted |
| `register-jsonl.test.ts` | **Blind in a different way** — mock-registration only; `jsonlMonarchLanguage` was never executed at all | Real tokenizer coverage added |
| `register-nim.test.ts` | Registration mock + real grammar-JSON load; Nim is TextMate, not Monarch | No change (not a gap — see below) |
| `textmate-token-provider.test.ts` | **Already real** — vscode-textmate + oniguruma WASM, asserts actual scopes on real Nim source | No change |
| `textmate-language-registration.test.ts` | Wiring / lazy-factory only, no grammar involved | No change |
| `monarch-embedded-recursion-depth.test.ts` | **Already real** (the reference harness from #19748) | Refactored onto the shared harness |

`register-jsonl.test.ts` is the one nobody had identified: it asserted that `setMonarchTokensProvider` was called with the grammar object, and never ran a single character through it.

## The mechanism (the reusable bit)

The harness from #19748 leaves nested languages **unregistered**. Monaco's `MonarchClassicTokensCollector.nestedLanguageTokenize` then emits one empty-typed token tagged with the embedded language id rather than delegating to that language's tokenizer. That makes `token.language` a direct readout of *which embed covers which region*.

So `tokenLanguagesPerLine` reports, per line, which languages actually cover it — and **a dropped embed shows up as the host grammar's own id (`svelte`/`astro`/`vue`) instead of `html`/`typescript`/`scss`**. That is exactly the silently-unhighlighted failure a rule-table walk cannot see, and it is now a one-line assertion.

Extracted to `monarch-tokenizer-test-harness.ts` (repo convention `*-test-harness.ts`). The recursion-depth test consumes it — one harness, not a fork.

Tests go **48 → 98**. The fixture inline snapshots now capture real tokenizer output instead of rule-table dumps.

## Proof the new tests would have caught the shipped bug

Checked out each grammar's pre-#19748 version (`git show $(git merge-base origin/main 3096ef4c4b8):<path>`) and re-ran the converted tests against it:

| Grammar | Result | Error |
|---|---|---|
| Svelte | **21 of 23 fail** | `svelte: cannot pop embedded language if not inside one` |
| Astro | **4 of 20 fail** | `astro: cannot pop embedded language if not inside one` |
| Vue | **3 of 19 fail** | `vue: cannot pop embedded language if not inside one` + `vue: no progress in tokenizer in rule: (unknown)` |

Whole folder against the pre-fix grammars: **50 failed / 47 passed / 1 expected-fail**.

This is the evidence. The old tests were green on these exact grammars; the new ones fail loudly with the same error users hit in the field. The only tests that still pass are the registration and root-invariant ones, which correctly do not depend on grammar behaviour.

**Why Astro and Vue have a narrower blast radius than Svelte:** their pre-fix `<script>` / `<style>` / `lang=` paths genuinely worked — only `{expr}` and `{{ }}` threw. Svelte's entry state was broken for markup generally, so nearly every case fails. The failure counts reflect the real scope of each bug, not weaker tests.

## Structural assertions deliberately kept

Behaviour-driving replaced table-walking everywhere it could. Three cases stay structural because behaviour cannot reach them:

1. **`register*Language` registration tests** (×3) — ids, extensions, and idempotence of the registration call itself. No amount of tokenizing observes whether `register` was called twice.
2. **"no root rule pops an embedded language"** (×3, ~8 lines each) — this is the one a reviewer will ask about. Behaviour can only reach the root rules some fixture happens to exercise, and a root rule that pops an embed throws on the *first character* of a file. The guard covers every root rule, exercised or not. It replaces Astro's original version of this check and generalises it to Svelte and Vue.
3. **`textmate-language-registration.test.ts`** — lazy-factory wiring with no grammar in play; mocks are the right tool.

## Skipped, and why it is not a gap

- **Nim grammar tokenization** — already covered. `textmate-token-provider.test.ts` tokenizes the vendored Nim grammar for real (oniguruma WASM) and asserts actual scopes; `register-nim.test.ts` covers the loader. There is a small seam in that the provider test uses its own loader rather than `loadNimTextMateGrammar`, but both halves are covered and wiring them together was not worth the churn.
- **`textmate-language-registration.test.ts`** — no grammar to tokenize.

## Behavioural change: JSONL string-state poisoning

Not test-only — flagging explicitly.

The new JSONL coverage found a live defect: the `@string` state survived the line break, so **one truncated record poisoned every record after it**, rendering the rest of the file as a single string. Plausible in practice, since truncated records are a normal failure mode for `.jsonl` logs.

**Fixed, and chosen on measurement.** Three candidates were A/B'd against the real tokenizer over realistic JSONL (escaped quotes, escaped backslashes, unicode escapes, `\n` in strings, truncation mid-string, truncation mid-escape, unterminated escape at EOL):

| Candidate | Escapes on well-formed | Trunc mid-string | Trunc mid-escape | Unterm. escape EOL |
|---|---|---|---|---|
| baseline | correct | **poisons** | **poisons** | **poisons** |
| A — one regex, no pushed state | **all escapes lost** | fixed | fixed | fixed |
| B — `includeLF`, pop at EOL | correct | **still poisons** | fixed | fixed |
| **F — lookahead-gated push** | **correct** | **fixed** | **fixed** | **fixed** |

Shipped **F**: gate the `@string` push on a lookahead proving the closing quote is on this line, and consume an unterminated remainder as `string.invalid` without pushing.

Two results worth recording:

- **B does not work**, and not subtly — `[^"\\]+` matches greedily *through* the newline, consuming the line break before any EOL rule can see it, so the primary truncation case is untouched. It would have shipped as a non-fix had it been reasoned about rather than run.
- **A's cost is real**: on `{"msg":"he said \"hi\""}` both `string.escape` tokens collapse into flat `string`, and likewise for every unicode/backslash/newline/invalid escape in the corpus.

The strongest evidence that F is free on the common case: **the existing inline snapshot did not move.** Byte-identical token stream on every well-formed record, so the fidelity guarantee is mechanically checked rather than claimed. Truncated records also improve — `string.invalid` instead of plain `string`.

Perf-checked too, given what #19748 was about: the alternation is disjoint so there is no catastrophic backtracking, and across five 19k pathological shapes F is at or faster than baseline (0.2ms vs 1.2ms on an unterminated 19k run).

The `it.fails` is now a passing assertion across all three truncation shapes, plus new tests pinning escape fidelity — i.e. tests that would have caught candidate A. Mutation-checked: reverting the grammar makes exactly those 4 fail while the escape tests keep passing.

**User-visible effect:** a truncated record in a `.jsonl` log now renders as `string.invalid` (error styling) instead of silently turning every following record into one long string.

## Verification

- `pnpm test src/renderer/src/lib/monaco-languages/` — 8 files, all green
- `pnpm tc` — exit 0
- `oxlint` — clean
- `pnpm run check:code-quality:changed` — 0 new findings
- No `max-lines` disable added; harness is 160 lines against a 300 limit


