### PR TITLE
fix(runtime): repair a noncanonical session name instead of dropping the record

### DIFF
--- a/src/main/runtime/agent-session-record-read-repair.test.ts
+++ b/src/main/runtime/agent-session-record-read-repair.test.ts
@@ -139,6 +139,16 @@ describe('agent session record read repair', () => {
     expect(loaded.state.unreadableRecords.has(SESSION)).toBe(false)
   })
 
+  it('drops a null name rather than the record', async () => {
+    await establishOwnedRecord()
+    await writeStoredName(null)
+
+    const loaded = await load()
+
+    expect(loaded.state.records.get(SESSION)?.conversationName).toBeUndefined()
+    expect(loaded.state.unreadableRecords.has(SESSION)).toBe(false)
+  })
+
   it('still quarantines the whole record when the lease is structurally invalid', async () => {
     await establishOwnedRecord()
     await writeStoredName('Fix\nthe lease probe')

--- a/src/main/runtime/agent-session-record-read-repair.test.ts
+++ b/src/main/runtime/agent-session-record-read-repair.test.ts
@@ -1,0 +1,185 @@
+// Read repair: a recoverable optional field must never cost the session its lease, options and
+// provider-handle chain. Anything structural still quarantines the whole record.
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AgentSessionRecord } from '../../shared/agent-session-record'
+import { AgentSessionRecordStore } from './agent-session-record-store'
+import { agentSessionStorePath, loadAgentSessionStore } from './agent-session-record-store-file'
+import type { AgentSessionReserveRequest } from './agent-session-reservation-admission'
+
+const NOW = 1_800_000_000_000
+const SESSION = 'session-alpha'
+
+let directory: string
+let counter = 0
+
+function operationId(): string {
+  counter += 1
+  return `${NOW}-${String(counter)
+    .padStart(32, '0')
+    .replaceAll(/[^0-9a-f]/g, '0')}`
+}
+
+const reserveRequest = (): AgentSessionReserveRequest => ({
+  sessionId: SESSION,
+  location: {
+    executionHostId: 'local',
+    wslDistro: null,
+    workspaceId: 'workspace-1',
+    workspaceKind: 'git-worktree'
+  },
+  provider: 'claude',
+  accountHome: { variable: 'CLAUDE_CONFIG_DIR', path: '/home/dev/.claude-work' },
+  runtimeKind: 'native',
+  expectedFence: null,
+  spawnToken: 'spawn-a',
+  claimKeyId: 'key-1',
+  handoffOperationId: null,
+  probe: { outcome: 'indeterminate', reason: 'no answer' },
+  operation: { callerKey: 'client-1', operationId: operationId(), fingerprint: 'fp-1' },
+  now: NOW
+})
+
+/** Reserve, observe the spawn, prove the handle, carry options — a fully furnished record. */
+async function establishOwnedRecord(): Promise<AgentSessionRecord> {
+  const store = await AgentSessionRecordStore.open({ directory, hostId: 'local' })
+  const reserved = await store.reserveOwner(reserveRequest())
+  const fence = reserved.record.lease.runtimeFence
+  await store.commitProcessIdentity({
+    sessionId: SESSION,
+    fence,
+    process: {
+      hostId: 'local',
+      pid: 4242,
+      processStartTimeMs: 1_700_000_000_000,
+      spawnToken: reserved.record.lease.reservedSpawnToken ?? 'spawn-a'
+    },
+    now: NOW
+  })
+  return store.proveOwner({
+    sessionId: SESSION,
+    fence,
+    link: {
+      linkId: 'link-1',
+      handle: { provider: 'claude', sessionId: 'provider-session-1', leafUuid: 'leaf-1' },
+      origin: 'created',
+      mintedAtFence: fence,
+      observedAt: NOW
+    },
+    options: { model: 'opus' },
+    now: NOW
+  })
+}
+
+/** Write a name the single writer would have normalized away, as a stale build could have left it. */
+async function writeStoredName(name: unknown): Promise<void> {
+  const filePath = agentSessionStorePath(directory)
+  const raw = JSON.parse(await readFile(filePath, 'utf-8'))
+  raw.records[SESSION].conversationName = name
+  await writeFile(filePath, JSON.stringify(raw))
+}
+
+async function corruptStoredLease(): Promise<void> {
+  const filePath = agentSessionStorePath(directory)
+  const raw = JSON.parse(await readFile(filePath, 'utf-8'))
+  raw.records[SESSION].lease.runtimeFence = 'not-a-number'
+  await writeFile(filePath, JSON.stringify(raw))
+}
+
+const load = () => loadAgentSessionStore(agentSessionStorePath(directory), 'local')
+
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), 'orca-session-read-repair-'))
+})
+
+afterEach(async () => {
+  await rm(directory, { recursive: true, force: true })
+})
+
+describe('agent session record read repair', () => {
+  it('repairs a noncanonical name instead of discarding the record around it', async () => {
+    const owned = await establishOwnedRecord()
+    await writeStoredName('Fix\nthe lease probe')
+
+    const loaded = await load()
+
+    const record = loaded.state.records.get(SESSION)
+    expect(record?.conversationName).toBe('Fix the lease probe')
+    expect(loaded.state.unreadableRecords.has(SESSION)).toBe(false)
+    // The fields quarantine would have taken with it.
+    expect(record?.lease).toMatchObject({ claimStatus: 'live', runtimeFence: 1 })
+    expect(record?.options).toEqual({ model: 'opus' })
+    expect(record?.providerHandleChain).toEqual(owned.providerHandleChain)
+  })
+
+  it('drops only the field when the stored name normalizes to nothing', async () => {
+    await establishOwnedRecord()
+    await writeStoredName('\u202E\u200B ')
+
+    const loaded = await load()
+
+    const record = loaded.state.records.get(SESSION)
+    expect(record).toBeDefined()
+    expect(record?.conversationName).toBeUndefined()
+    expect(Object.hasOwn(record ?? {}, 'conversationName')).toBe(false)
+    expect(record?.lease.claimStatus).toBe('live')
+    expect(record?.options).toEqual({ model: 'opus' })
+  })
+
+  it('drops a name of the wrong type rather than the record', async () => {
+    await establishOwnedRecord()
+    await writeStoredName(42)
+
+    const loaded = await load()
+
+    expect(loaded.state.records.get(SESSION)?.conversationName).toBeUndefined()
+    expect(loaded.state.unreadableRecords.has(SESSION)).toBe(false)
+  })
+
+  it('still quarantines the whole record when the lease is structurally invalid', async () => {
+    await establishOwnedRecord()
+    await writeStoredName('Fix\nthe lease probe')
+    await corruptStoredLease()
+    // No committed copy may vouch for the session, or salvage would mask the quarantine.
+    await rm(`${agentSessionStorePath(directory)}.bak`, { force: true })
+
+    const loaded = await load()
+
+    expect(loaded.state.records.has(SESSION)).toBe(false)
+    expect(loaded.state.unreadableRecords.get(SESSION)?.reason).toBe('current_shape_invalid')
+    // Quarantined bytes stay verbatim: repair must not edit the row it could not rescue.
+    expect(loaded.state.unreadableRecords.get(SESSION)?.raw).toMatchObject({
+      conversationName: 'Fix\nthe lease probe'
+    })
+  })
+
+  it('leaves a canonical name alone and asks for no rewrite', async () => {
+    const store = await AgentSessionRecordStore.open({ directory, hostId: 'local' })
+    await store.reserveOwner(reserveRequest())
+    await store.setConversationName(SESSION, 'Fix the lease probe')
+
+    const loaded = await load()
+
+    expect(loaded.state.records.get(SESSION)?.conversationName).toBe('Fix the lease probe')
+    expect(loaded.needsRewrite).toBe(false)
+  })
+
+  it('marks the store for rewrite without touching the record business timestamp', async () => {
+    const owned = await establishOwnedRecord()
+    await writeStoredName('Fix\nthe lease probe')
+
+    const loaded = await load()
+    expect(loaded.needsRewrite).toBe(true)
+    expect(loaded.state.records.get(SESSION)?.updatedAt).toBe(owned.updatedAt)
+
+    // Opening the store persists that rewrite, so the next load has nothing left to repair.
+    await AgentSessionRecordStore.open({ directory, hostId: 'local' })
+    const persisted = JSON.parse(await readFile(agentSessionStorePath(directory), 'utf-8'))
+    expect(persisted.records[SESSION].conversationName).toBe('Fix the lease probe')
+    expect(persisted.records[SESSION].updatedAt).toBe(owned.updatedAt)
+    expect((await load()).needsRewrite).toBe(false)
+  })
+})

--- a/src/main/runtime/agent-session-record-read-repair.ts
+++ b/src/main/runtime/agent-session-record-read-repair.ts
@@ -1,0 +1,72 @@
+/**
+ * Read one stored agent-session record, repairing recoverable optional metadata before validation.
+ *
+ * Quarantine is whole-record: a rejected row loses its lease, its options and its provider-handle
+ * chain, not only the field that failed. `conversationName` is validated against its canonical
+ * normalization, so widening the normalizer by one codepoint would retroactively invalidate every
+ * name already on disk — and take those sessions with it. Repairing the field to canonical form
+ * keeps the record, and keeps the durable "Orca already named this session" marker that stops a
+ * later acquisition from spending another model call on a name it already has.
+ *
+ * Identity and ownership stay out of reach: an invalid lease, session id or handle chain still
+ * quarantines the whole record, because nothing here can tell what the right value would have been.
+ */
+
+import { normalizeAgentSessionConversationName } from '../../shared/agent-session-conversation-name'
+import {
+  AGENT_SESSION_RECORD_SCHEMA_VERSION,
+  isAgentSessionRecord,
+  type AgentSessionRecord
+} from '../../shared/agent-session-record'
+
+export type AgentSessionRecordReadResult =
+  | { record: AgentSessionRecord; repaired: boolean }
+  | { record: null; reason: string }
+
+/** Repaired shallow copy, or null when the stored field is already canonical or absent. The
+ *  original object is left untouched so a row that fails validation anyway quarantines verbatim. */
+function repairConversationName(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null
+  }
+  const stored = value as Record<string, unknown>
+  if (!Object.hasOwn(stored, 'conversationName')) {
+    return null
+  }
+  // Same predicate the validator applies, so repair and validation can never disagree.
+  const normalized = normalizeAgentSessionConversationName(stored.conversationName)
+  if (normalized === stored.conversationName) {
+    return null
+  }
+  const repaired = { ...stored }
+  if (normalized === null) {
+    delete repaired.conversationName
+  } else {
+    repaired.conversationName = normalized
+  }
+  return repaired
+}
+
+export function readAgentSessionRecord(
+  sessionId: string,
+  value: unknown
+): AgentSessionRecordReadResult {
+  const repaired = repairConversationName(value)
+  const candidate: unknown = repaired ?? value
+  const record = isAgentSessionRecord(candidate) ? candidate : null
+  if (record?.sessionId === sessionId) {
+    return { record, repaired: repaired !== null }
+  }
+  const storedSchemaVersion =
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { schemaVersion?: unknown }).schemaVersion
+  return {
+    record: null,
+    reason: record
+      ? 'record_key_session_id_mismatch'
+      : storedSchemaVersion === AGENT_SESSION_RECORD_SCHEMA_VERSION
+        ? 'current_shape_invalid'
+        : 'unsupported_schema'
+  }
+}

--- a/src/main/runtime/agent-session-record-read-repair.ts
+++ b/src/main/runtime/agent-session-record-read-repair.ts
@@ -12,7 +12,10 @@
  * quarantines the whole record, because nothing here can tell what the right value would have been.
  */
 
-import { normalizeAgentSessionConversationName } from '../../shared/agent-session-conversation-name'
+import {
+  isAgentSessionConversationName,
+  normalizeAgentSessionConversationName
+} from '../../shared/agent-session-conversation-name'
 import {
   AGENT_SESSION_RECORD_SCHEMA_VERSION,
   isAgentSessionRecord,
@@ -33,11 +36,14 @@ function repairConversationName(value: unknown): Record<string, unknown> | null 
   if (!Object.hasOwn(stored, 'conversationName')) {
     return null
   }
-  // Same predicate the validator applies, so repair and validation can never disagree.
-  const normalized = normalizeAgentSessionConversationName(stored.conversationName)
-  if (normalized === stored.conversationName) {
+  // Use the validator's clause before normalizing so null cannot masquerade as canonical absence.
+  if (
+    stored.conversationName === undefined ||
+    isAgentSessionConversationName(stored.conversationName)
+  ) {
     return null
   }
+  const normalized = normalizeAgentSessionConversationName(stored.conversationName)
   const repaired = { ...stored }
   if (normalized === null) {
     delete repaired.conversationName

--- a/src/main/runtime/agent-session-record-store-file.ts
+++ b/src/main/runtime/agent-session-record-store-file.ts
@@ -15,17 +15,14 @@ import {
   isAgentSessionOperationRow,
   type AgentSessionOperationRow
 } from '../../shared/agent-session-operation-ledger'
-import {
-  AGENT_SESSION_RECORD_SCHEMA_VERSION,
-  isAgentSessionRecord,
-  type AgentSessionRecord
-} from '../../shared/agent-session-record'
+import type { AgentSessionRecord } from '../../shared/agent-session-record'
 import {
   copyFileDurable,
   durableWriteTempPath,
   renameDurable,
   writeTempFileDurable
 } from '../durable-file-write'
+import { readAgentSessionRecord } from './agent-session-record-read-repair'
 import { parseVisibleSessionIds } from './agent-session-visible-tab-index'
 import { serializeAgentSessionStoreState } from './agent-session-store-serialization'
 
@@ -144,20 +141,13 @@ function parseState(
   let needsRewrite = false
   if (typeof file.records === 'object' && file.records !== null) {
     for (const [sessionId, value] of Object.entries(file.records)) {
-      const record = isAgentSessionRecord(value) ? value : null
-      if (record?.sessionId === sessionId) {
-        state.records.set(sessionId, record)
+      const read = readAgentSessionRecord(sessionId, value)
+      if (read.record) {
+        state.records.set(sessionId, read.record)
+        // A repaired record must be re-persisted, or the next load repairs it again.
+        needsRewrite ||= read.repaired && schemaVersion === AGENT_SESSION_STORE_SCHEMA_VERSION
       } else {
-        const valueSchemaVersion =
-          typeof value === 'object' &&
-          value !== null &&
-          (value as { schemaVersion?: unknown }).schemaVersion
-        const reason = record
-          ? 'record_key_session_id_mismatch'
-          : valueSchemaVersion === AGENT_SESSION_RECORD_SCHEMA_VERSION
-            ? 'current_shape_invalid'
-            : 'unsupported_schema'
-        state.unreadableRecords.set(sessionId, { reason, raw: value })
+        state.unreadableRecords.set(sessionId, { reason: read.reason, raw: value })
         needsRewrite ||= schemaVersion === AGENT_SESSION_STORE_SCHEMA_VERSION
       }
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->\n<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->\n\n| | Files | Added | Deleted | Net |\n| :--- | ---: | ---: | ---: | ---: |\n| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 |\n| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 |\n\n<!-- /orca-pr-loc -->\n\n## ELI5\n\nA session record on disk holds a chat's lease, its options, and which provider conversation it belongs to. If any one field fails validation when Orca loads that file, **the whole record is thrown away** — the session disappears.\n\nThat is right for a broken lease. It is far too harsh for a cosmetic name. This repairs the name instead of discarding the session around it.\n\n## What Changed\n\n — a new module the store's load loop calls. It normalizes  on a **shallow copy** first, then runs the unchanged strict validator:\n\n- Name normalizes to text → **repaired to canonical form**, record kept.\n- Name normalizes to nothing (wrong type, blank, invisible-only) → **that field alone removed**, record kept.\n- Anything structural — lease, identity, provider-handle relationships → **still quarantines the whole record**, exactly as before.\n\nThe store is marked for rewrite only when a repair actually happened, and a repair never touches the record's business  — a migration is not a business event.\n\n## Why\n\n#19908 added , and a review fix then required a stored value to already equal its canonical normalization. That clause is correct in spirit: a persisted name carrying newlines or bidi controls should not be trusted, because the only writer strips them.\n\nThe problem is what a failure costs. In the loader:\n\n\n\nA record failing validation is discarded **whole**. So one noncanonical name does not merely lose the name — it takes the lease, the options, and the provider-handle chain with it.\n\nThat is harmless today: the field is new and the sole writer normalizes. **The hazard is forward.** Change the normalizer even slightly — add one more invisible codepoint to the stripped set — and every previously stored name stops being canonical, so every affected session silently vanishes on load. A one-line normalizer edit would become a session-destroying migration, and no existing test would catch it.\n\n### Two alternatives, and why they were rejected\n\n**Validate canonical form on write only, leave the read validator on length alone.** Rejected: it lets noncanonical text into typed runtime state and makes safety depend indefinitely on "this field is never displayed" — an invariant nobody is enforcing.\n\n**Drop the field outright on read.** Rejected: it discards the durable "Orca already named this session" signal every time, so the next acquisition generates a title again and charges the user for a model call that was already paid for. Repairing to canonical form preserves that marker; only a name that normalizes to *nothing* triggers a retry.\n\n### One detail worth the reviewer's eye\n\nThe repair runs on a **copy**. A row that fails validation anyway is quarantined verbatim, so the salvage path still sees exactly what was on disk rather than a partially repaired shape.\n\nThe repair predicate is literally the clause the validator applies, so repair and validation cannot drift apart into disagreeing about what "canonical" means.\n\n## Linked Issue\n\nN/A — follow-up hardening on #19908.\n\n## Visual Proof\n\nThis load-path behavior has no standalone UI control, so the background Electron proof exercises the real Orca shell and terminal on this exact commit:\n\n![Orca terminal showing the focused read-repair suite passing](https://github.com/user-attachments/assets/b29fcd12-be04-469a-b4c6-05492b620f6f)\n\n[Validation details](https://github.com/stablyai/orca/pull/20008#issuecomment-5629839953): hidden renderer, isolated profile, CDP-only automation, exact worktree/commit identity, and the focused suite passing with 1 file / 7 tests. The corrupt-store repair itself remains unit-tested; this is not direct end-to-end corrupt-store UI coverage.\n\n## Testing\n\n- **Typecheck:** , ,  clean, run **sequentially**, both before and after merging current .\n- **Tests:** 7 new in , including stored . They drive the real  to a reserved → process-committed → proven-owner record carrying , then hand-edit the on-disk JSON — the same approach the existing unreadable-record salvage test uses. Final focused regression: 9 related files, 123 passed. The completed-worker retirement ownership oracle also passed. Full  plus the shared name suite: 762 files, 7,731 tests passed, exit 0.\n- **Ablations**, each applied → run → restored → symbol grepped back → re-run green:\n\n| Ablation | Result |\n|---|---|\n| Always drop instead of repairing to canonical | 2 failed |\n| Repair disabled entirely (pre-change behaviour) | 4 failed |\n| Strict validator bypassed | 1 failed — the structural-quarantine test |\n| Repair mutates the row in place instead of a copy | 1 failed |\n\n- [x] I manually tested these changes locally\n- [x] Automated tests added/updated, or explained why not below\n\n### Session reliability contract\n\n- **Existing gate:** .\n- **Invariant:** load-time repair may change only optional display metadata; it must preserve the lease, options, provider-handle chain, and the original unreadable bytes without creating duplicate resume authority.\n- **Oracle:** the seven read-repair tests cover canonical repair, drop-to-absence (including ), strict structural quarantine, timestamp stability, rewrite persistence, and no-op reload; the unreadable-backup salvage tests and completed-worker retirement oracle cover neighboring ownership behavior.\n- **Platforms/topologies:** this is a host-owned in-memory read path with no wire change. The existing gate covers local macOS plus daemon/remote-runtime contracts; Windows, Linux, SSH, and WSL remain CI/contract coverage rather than a live topology run.\n- **Performance and diagnostics:** one O(records) load pass, with name validation/normalization only when the field is present; repaired rows set , while rejected rows retain  verbatim.\n- **Residuals:** no direct corrupt-store Electron journey was run.  has the same whole-record-loss exposure for malformed persisted values (including empty direct-RPC values that Codex can retain for allowed non-model keys); that is a separate writer/validation contract issue and is intentionally not repaired in this PR.\n\n## Review\n\n### Why this is a new module rather than an edit in place\n\nBoth candidate homes were pinned at the 300-line  cap —  at 299, and  at **exactly 300** (probed: one added line reports ). So the logic went into its own module and the load loop was extracted rather than extended. The loader is now at 289.  is untouched. No  disable, no per-file cap bump.\n\n### Scope\n\nOnly  is repaired. No other optional field is touched, the normalizer and the writer are unchanged, and this is deliberately not a general migration framework.\n\n## Agent skill upstream boundary\n\n- [x] Not applicable.\n\n## Notes\n\n- **Security:** strictly narrowing — noncanonical text that previously could not enter runtime state still cannot; the change is only what happens to the *rest* of the record.\n- **Cross-platform / SSH / mobile:** pure in-memory validation on the load path; no paths, shells or processes.\n- **Performance:** one normalization per record carrying the field, only at load.\n- **Backwards compatibility:** strictly more permissive about surviving load. Records that loaded before still load; some that would have been discarded now survive repaired.\n\n## Checklist\n\n- [x] This PR is small and focused\n- [x] I explained what changed and why (including ELI5)\n- [x] Before/after screenshots or videos attached for UI changes, or  with reason\n- [x] Self-reviewed for correctness, security, and performance\n- [x] Cross-platform, SSH/remote, and path/shortcut impact considered\n- [x] Reliability gate manifest check passed for 120 gate(s).
max-lines ratchet OK — 7 grandfathered suppression(s), no new bypasses.
ts-nocheck ratchet OK — 171 grandfathered file(s), no new suppressions.
[runtime-electron-ratchet] ok — 0 entries, unchanged.
Verified 14448 localization key references against en.json.
es.json coverage: 12036/14252 translated, 2216 missing.
Verified 12036 existing es.json entries.
fr.json coverage: 13367/14252 translated, 885 missing.
Verified 13367 existing fr.json entries.
ja.json coverage: 12053/14252 translated, 2199 missing.
Verified 12053 existing ja.json entries.
ko.json coverage: 12166/14252 translated, 2086 missing.
Verified 12166 existing ko.json entries.
zh.json coverage: 12155/14252 translated, 2097 missing.
Verified 12155 existing zh.json entries.
en-runtime-required.json covers en.json: 1680 of 14252 English entries must ship in the boot bundle.
Extracted 12702 keys; 36 dynamic defaults are report-only, 1550 existing English entries are not statically referenced, and 52 inline defaults differ.
Localization coverage check passed with 13 allowlisted candidates., , 
 RUN  v4.1.11 /Users/brennanbenson/orca/workspaces/orca/review-20008

 ❯ src/main/codex-accounts/runtime-home-retained-auth-provenance.test.ts (18 tests | 11 failed) 530ms
     × fences retained shared auth when a self-contained managed transition begins 177ms
     × refreshes untouched retained-pane auth during real-home rate polling 22ms
     × clears managed transition state before later retained-auth reconciliation 40ms
     × does not overwrite auth changed by a retained Codex process 23ms
     × applies source logout after a retained pane refreshes the same identity 15ms
     × repairs a completed pending system-auth replacement after restart 16ms
     × fences a pending auth replacement when runtime bytes do not match its intent 19ms
     × does not treat malformed provenance as a missing migration marker 17ms
     × recreates proven logged-out shared auth after a real-home re-login 14ms
     × recreates retained auth after a committed provenance crash between logout deletion and metadata commit 16ms
     × recreates retained auth after a pre-provenance migration crash between logout deletion and metadata commit 14ms
 ❯ src/main/codex-accounts/runtime-home-system-default-snapshot.test.ts (15 tests | 1 failed) 663ms
     × recreates retained auth after a logged-out system default logs back in 38ms
 ❯ src/main/codex-accounts/runtime-home-per-account-homes.test.ts (11 tests | 2 failed) 334ms
     × keeps per-account auth canonical when the real-home lane takes over 23ms
     × does not read shared auth when polling observes a managed-to-real-home transition 27ms
 ❯ src/main/codex-accounts/runtime-home-real-home-lane-routing.test.ts (7 tests | 5 failed) 238ms
     × returns the Orca-managed runtime home for Codex launch and rate-limit preparation 121ms
     × routes host system default to the real home 16ms
     × skips retired-home reconciliation when no retained host pane can use it 23ms
     × keeps pre-rollout shared-home panes authenticated on the real-home lane 19ms
     × preserves retained managed auth across a real-home main-process restart 21ms
 ❯ src/main/codex-accounts/runtime-home-managed-auth-recovery.test.ts (4 tests | 2 failed) 320ms
     × preserves selected identity when per-account auth disappears before launch 164ms
     × ignores shared auth on an explicit managed-to-real-home deselect 53ms
 ❯ src/main/codex-accounts/sta-4422-transient-ownership-error.test.ts (2 tests | 1 failed) 160ms
     × still clears the selection when the home is genuinely untrusted 30ms
 ❯ src/main/codex-accounts/runtime-home-session-migration-pass.test.ts (5 tests | 2 failed) 261ms
     × does not demand a full scan when the same history home is spelled differently 29ms
     × still demands a full scan when the history home really moves 13ms
 ❯ config/scripts/skill-recipe-shell.test.mjs (5 tests | 1 failed) 58ms
     × reports failed cleanup even after an otherwise successful snapshot 10ms

 Test Files  8 failed | 8429 passed | 62 skipped (8499)
      Tests  25 failed | 78322 passed | 384 skipped (78731)
   Start at  22:20:07
   Duration  450.91s (transform 505.88s, setup 179.35s, import 3643.89s, tests 2430.85s, environment 250.09s) pass locally\n