### PR TITLE
i18n: Make file reveal labels translatable

### DIFF
--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
@@ -20,11 +20,19 @@ const isMac = navigator.userAgent.includes('Mac')
 const isLinux = navigator.userAgent.includes('Linux')
 
 /** Platform-appropriate label: macOS -> Finder, Windows -> File Explorer, Linux -> Files */
-const revealLabel = isMac
-  ? 'Reveal in Finder'
-  : isLinux
-    ? 'Open Containing Folder'
-    : 'Reveal in File Explorer'
+function getRevealLabel(): string {
+  return isMac
+    ? translate('auto.components.editor.EditorPanelHeader.revealInFinder', 'Reveal in Finder')
+    : isLinux
+      ? translate(
+          'auto.components.editor.EditorPanelHeader.openContainingFolder',
+          'Open Containing Folder'
+        )
+      : translate(
+          'auto.components.editor.EditorPanelHeader.revealInFileExplorer',
+          'Reveal in File Explorer'
+        )
+}
 
 type EditorPanelHeaderPathProps = {
   activeFile: OpenFile
@@ -196,7 +204,7 @@ export function EditorPanelHeaderPath({
           {!isVirtualEditorTab && (
             <DropdownMenuItem onSelect={onOpenContainingFolder}>
               <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
-              {revealLabel}
+              {getRevealLabel()}
             </DropdownMenuItem>
           )}
         </DropdownMenuContent>

--- a/src/renderer/src/components/right-sidebar/file-explorer-row-context-menu.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-row-context-menu.tsx
@@ -43,11 +43,19 @@ const isMac = navigator.userAgent.includes('Mac')
 const isLinux = navigator.userAgent.includes('Linux')
 
 /** Platform-appropriate label: macOS → Finder, Windows → File Explorer, Linux → Files */
-const revealLabel = isMac
-  ? 'Reveal in Finder'
-  : isLinux
-    ? 'Open Containing Folder'
-    : 'Reveal in File Explorer'
+function getRevealLabel(): string {
+  return isMac
+    ? translate('auto.components.right.sidebar.FileExplorerRow.revealInFinder', 'Reveal in Finder')
+    : isLinux
+      ? translate(
+          'auto.components.right.sidebar.FileExplorerRow.openContainingFolder',
+          'Open Containing Folder'
+        )
+      : translate(
+          'auto.components.right.sidebar.FileExplorerRow.revealInFileExplorer',
+          'Reveal in File Explorer'
+        )
+}
 
 function stopRightButtonMenuSelection(event: React.PointerEvent): void {
   if (event.button !== 2) {
@@ -290,7 +298,7 @@ export function FileExplorerRowContextMenu({
         }}
       >
         <ExternalLink />
-        {revealLabel}
+        {getRevealLabel()}
       </ContextMenuItem>
       <ContextMenuSeparator />
       <ContextMenuItem onSelect={() => onStartRename(node)}>

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -32,11 +32,22 @@ const isMac = navigator.userAgent.includes('Mac')
 const isLinux = navigator.userAgent.includes('Linux')
 
 /** Platform-appropriate label: macOS → Finder, Windows → File Explorer, Linux → Files */
-const revealLabel = isMac
-  ? 'Reveal in Finder'
-  : isLinux
-    ? 'Open Containing Folder'
-    : 'Reveal in File Explorer'
+function getRevealLabel(): string {
+  return isMac
+    ? translate(
+        'auto.components.tab.bar.EditorFileTabContextMenu.revealInFinder',
+        'Reveal in Finder'
+      )
+    : isLinux
+      ? translate(
+          'auto.components.tab.bar.EditorFileTabContextMenu.openContainingFolder',
+          'Open Containing Folder'
+        )
+      : translate(
+          'auto.components.tab.bar.EditorFileTabContextMenu.revealInFileExplorer',
+          'Reveal in File Explorer'
+        )
+}
 
 type EditorFileTabContextMenuProps = {
   open: boolean
@@ -251,7 +262,7 @@ export function EditorFileTabContextMenu({
           }}
         >
           <ExternalLink className="size-3.5" />
-          {revealLabel}
+          {getRevealLabel()}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3370,7 +3370,10 @@
             "1d04b1630b": "Split Down",
             "6b3efb106e": "Split Up",
             "fdd29eb669": "Pin Tab",
-            "8e9d603a09": "Unpin Tab"
+            "8e9d603a09": "Unpin Tab",
+            "revealInFinder": "Reveal in Finder",
+            "openContainingFolder": "Open Containing Folder",
+            "revealInFileExplorer": "Reveal in File Explorer"
           },
           "QuickLaunchButton": {
             "348a04c1ad": "Agent settings…",
@@ -11979,7 +11982,10 @@
             "3161c4e425": "folder",
             "e887fa4b2e": "Open in Terminal",
             "1d8e182c32": "View File",
-            "clipboardStagingUnavailable": "Could not copy the file because Orca's temporary storage is unavailable"
+            "clipboardStagingUnavailable": "Could not copy the file because Orca's temporary storage is unavailable",
+            "revealInFinder": "Reveal in Finder",
+            "openContainingFolder": "Open Containing Folder",
+            "revealInFileExplorer": "Reveal in File Explorer"
           },
           "FileExplorerToolbar": {
             "d238264654": "Show Git Ignored Files",
@@ -14679,7 +14685,10 @@
           "f0fd4174b5": "Open file tab to use rich markdown editing",
           "a10d9b8337": "Open file",
           "2076ecfc9c": "Previous change",
-          "631dab0df3": "Next change"
+          "631dab0df3": "Next change",
+          "revealInFinder": "Reveal in Finder",
+          "openContainingFolder": "Open Containing Folder",
+          "revealInFileExplorer": "Reveal in File Explorer"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "Export as PDF",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 |

<!-- /orca-pr-loc -->

## Problem

The "Reveal in Finder", "Open Containing Folder", and "Reveal in File Explorer" labels were hardcoded strings across three UI components, preventing them from being translated into other languages.

## Solution

Wrapped the platform-specific reveal labels with `translate()` function calls in three components and added the translation keys to en.json. This allows translators to provide localized versions of these labels for each platform.

## What Changed

Refactored hardcoded reveal labels into translatable strings:
- `src/renderer/src/components/editor/EditorPanelHeaderPath.tsx`: Converted `revealLabel` constant to `getRevealLabel()` function
- `src/renderer/src/components/right-sidebar/file-explorer-row-context-menu.tsx`: Same conversion
- `src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx`: Same conversion
- `src/renderer/src/i18n/locales/en.json`: Added translation keys for all three variants (revealInFinder, openContainingFolder, revealInFileExplorer)

## Why

Platform-specific UI labels must be translatable to provide a localized experience across macOS, Linux, and Windows in all supported languages.

## Visual Proof

N/A — No visual or interaction change; labels remain identical in English, but are now translatable.

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md`

## Notes

Cross-platform labels (Finder on macOS, File Explorer on Windows, Files folder on Linux) are now properly translatable while maintaining platform-specific distinctions.

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)