### PR TITLE
Hide desktop theme imports from paired web clients

### DIFF
--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -147,7 +147,10 @@ export function AppearancePane({
   ]
   const terminalSearchEntries = [
     { title: terminalTitle },
-    ...getTerminalAppearanceSearchEntries({ showWarpImport: !isWebClient })
+    ...getTerminalAppearanceSearchEntries({
+      showWarpImport: !isWebClient,
+      showGhosttyImport: !isWebClient
+    })
   ]
   const windowSearchEntries = [
     {

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -148,8 +148,7 @@ export function AppearancePane({
   const terminalSearchEntries = [
     { title: terminalTitle },
     ...getTerminalAppearanceSearchEntries({
-      showWarpImport: !isWebClient,
-      showGhosttyImport: !isWebClient
+      showDesktopThemeImports: !isWebClient
     })
   ]
   const windowSearchEntries = [

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
@@ -473,9 +473,7 @@ describe('TerminalAppearanceSection ghostty import wiring', () => {
     })
 
     expect(findComponentByTypeName(element, 'TerminalFontSizeSetting')).toBeNull()
-    expect(
-      findButtons(element).some((button) => button.text === 'Import from Ghostty')
-    ).toBe(false)
+    expect(findButtons(element).some((button) => button.text === 'Import from Ghostty')).toBe(false)
   })
 
   it('shows the Ghostty import button for Ghostty-only searches', () => {
@@ -529,6 +527,32 @@ describe('TerminalAppearanceSection ghostty import wiring', () => {
     expect(findButtons(element).some((button) => button.text === 'Import from Ghostty')).toBe(false)
     expect(findGhosttyImportModal(element)).toBeNull()
   })
+
+  it.each([false, true])(
+    'hides Ghostty search results on web clients with forceVisiblePrimary=%s',
+    (forceVisiblePrimary) => {
+      vi.stubGlobal('window', { __ORCA_WEB_CLIENT__: true })
+      mockSettingsSearchQuery = 'ghostty'
+
+      const element = TerminalAppearanceSection({
+        settings: {} as never,
+        updateSettings: () => {},
+        systemPrefersDark: true,
+        terminalFontSuggestions: [],
+        ghostty: ghosttyMock,
+        warpThemes: warpThemesMock,
+        forceVisiblePrimary
+      })
+
+      expect(findButtons(element).some((button) => button.text === 'Import from Ghostty')).toBe(
+        false
+      )
+      expect(findGhosttyImportModal(element)).toBeNull()
+      if (!forceVisiblePrimary) {
+        expect(findComponentByTypeName(element, 'SettingsSubsectionHeader')).toBeNull()
+      }
+    }
+  )
 
   it('passes hook state to GhosttyImportModal', () => {
     const element = TerminalAppearanceSection({

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
@@ -473,7 +473,9 @@ describe('TerminalAppearanceSection ghostty import wiring', () => {
     })
 
     expect(findComponentByTypeName(element, 'TerminalFontSizeSetting')).toBeNull()
-    expect(findButtons(element).some((button) => button.text === 'Import from Ghostty')).toBe(false)
+    expect(
+      findButtons(element).some((button) => button.text === 'Import from Ghostty')
+    ).toBe(false)
   })
 
   it('shows the Ghostty import button for Ghostty-only searches', () => {
@@ -524,6 +526,8 @@ describe('TerminalAppearanceSection ghostty import wiring', () => {
 
     expect(findTerminalThemeCatalogSection(element)?.props.showThemeImport).toBe(false)
     expect(findWarpThemeImportModal(element)).toBeNull()
+    expect(findButtons(element).some((button) => button.text === 'Import from Ghostty')).toBe(false)
+    expect(findGhosttyImportModal(element)).toBeNull()
   })
 
   it('passes hook state to GhosttyImportModal', () => {

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
@@ -34,7 +34,7 @@ import { GhosttyImportModal } from './GhosttyImportModal'
 import type { UseGhosttyImportReturn } from './useGhosttyImport'
 import { WarpThemeImportModal } from './WarpThemeImportModal'
 import type { UseWarpThemeImportReturn } from './useWarpThemeImport'
-import { isWebClientLocation } from '@/hooks/useSettingsNavigationMetadata'
+import { isWebClientLocation } from '@/lib/web-client-location'
 import ghosttyIcon from '../../../../../resources/ghostty.svg'
 import { translate } from '@/i18n/i18n'
 

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
@@ -83,7 +83,7 @@ export function TerminalAppearanceSection({
   const isSearching = normalizeSettingsSearchQuery(searchQuery).length > 0
   const [themeSearch, setThemeSearch] = useState('')
   const [previewFontFamily, setPreviewFontFamily] = useState<string | null>(null)
-  const showWarpThemeImport = !isWebClientLocation()
+  const showDesktopThemeImports = !isWebClientLocation()
   const darkThemeSearchEntries = getTerminalDarkThemeSearchEntries()
   const lightThemeSearchEntries = getTerminalLightThemeSearchEntries()
   const terminalTypographyEntries = getTerminalTypographySearchEntries()
@@ -92,7 +92,7 @@ export function TerminalAppearanceSection({
     ...getTerminalThemeTargetSearchEntries(),
     ...darkThemeSearchEntries,
     ...lightThemeSearchEntries,
-    ...(showWarpThemeImport
+    ...(showDesktopThemeImports
       ? [...getTerminalWarpImportSearchEntries(), ...getTerminalYamlImportSearchEntries()]
       : [])
   ]
@@ -116,14 +116,16 @@ export function TerminalAppearanceSection({
     searchQuery,
     terminalTypographyEntries.slice(0, 2)
   )
-  const ghosttyImportMatches = matchesSettingsSearch(searchQuery, ghosttyImportEntries)
+  const ghosttyImportMatches =
+    showDesktopThemeImports && matchesSettingsSearch(searchQuery, ghosttyImportEntries)
   const showPrimaryTypography =
     !isSearching ||
     forceVisiblePrimary ||
     primaryTypographyMatches ||
     typographyMatches ||
     ghosttyImportMatches
-  const showGhosttyImport = !isSearching || forceVisiblePrimary || ghosttyImportMatches
+  const showGhosttyImport =
+    showDesktopThemeImports && (!isSearching || forceVisiblePrimary || ghosttyImportMatches)
   const showTypographyAdvancedDisclosure = !isSearching || typographyMatches
 
   const advancedGroups = [
@@ -259,36 +261,38 @@ export function TerminalAppearanceSection({
           previewFontFamily={previewFontFamily}
           importedHighlightSignal={warpThemes.importSignal}
           warpThemes={warpThemes}
-          showThemeImport={showWarpThemeImport}
+          showThemeImport={showDesktopThemeImports}
           preferredTarget={preferredThemeTarget}
           advancedContent={previewAdvancedContent}
         />
       ) : null}
 
-      <GhosttyImportModal
-        open={ghostty.open}
-        onOpenChange={ghostty.handleOpenChange}
-        preview={ghostty.preview}
-        loading={ghostty.loading}
-        onApply={ghostty.handleApply}
-        applied={ghostty.applied}
-        applyError={ghostty.applyError}
-      />
-      {showWarpThemeImport ? (
-        <WarpThemeImportModal
-          open={warpThemes.open}
-          mode={warpThemes.mode}
-          preview={warpThemes.preview}
-          loading={warpThemes.loading}
-          desktopOnly={warpThemes.desktopOnly}
-          applyError={warpThemes.applyError}
-          selectedThemeIds={warpThemes.selectedThemeIds}
-          handlePreviewSource={warpThemes.handlePreviewSource}
-          handleToggleTheme={warpThemes.handleToggleTheme}
-          handleToggleAll={warpThemes.handleToggleAll}
-          handleApply={warpThemes.handleApply}
-          handleOpenChange={warpThemes.handleOpenChange}
-        />
+      {showDesktopThemeImports ? (
+        <>
+          <GhosttyImportModal
+            open={ghostty.open}
+            onOpenChange={ghostty.handleOpenChange}
+            preview={ghostty.preview}
+            loading={ghostty.loading}
+            onApply={ghostty.handleApply}
+            applied={ghostty.applied}
+            applyError={ghostty.applyError}
+          />
+          <WarpThemeImportModal
+            open={warpThemes.open}
+            mode={warpThemes.mode}
+            preview={warpThemes.preview}
+            loading={warpThemes.loading}
+            desktopOnly={warpThemes.desktopOnly}
+            applyError={warpThemes.applyError}
+            selectedThemeIds={warpThemes.selectedThemeIds}
+            handlePreviewSource={warpThemes.handlePreviewSource}
+            handleToggleTheme={warpThemes.handleToggleTheme}
+            handleToggleAll={warpThemes.handleToggleAll}
+            handleApply={warpThemes.handleApply}
+            handleOpenChange={warpThemes.handleOpenChange}
+          />
+        </>
       ) : null}
     </div>
   )

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -223,14 +223,13 @@ const getAppearanceSectionEntries = createLocalizedCatalog((): SettingsSearchEnt
 ])
 
 type AppearancePaneSearchOptions = {
-  showWarpImport?: boolean
-  showGhosttyImport?: boolean
+  showDesktopThemeImports?: boolean
   showSystemTray?: boolean
   showMenuBarIcon?: boolean
 }
 
-function buildAppearancePaneSearchEntries(
-  options: AppearancePaneSearchOptions
+export function getAppearancePaneSearchEntries(
+  options: AppearancePaneSearchOptions = {}
 ): SettingsSearchEntry[] {
   return [
     ...getAppearanceSectionEntries(),
@@ -247,15 +246,4 @@ function buildAppearancePaneSearchEntries(
     ...getSystemTrayEntries(options),
     ...getMenuBarIconEntries(options)
   ]
-}
-
-export function getAppearancePaneSearchEntries(
-  options: AppearancePaneSearchOptions = {}
-): SettingsSearchEntry[] {
-  return buildAppearancePaneSearchEntries({
-    showWarpImport: options.showWarpImport ?? true,
-    showGhosttyImport: options.showGhosttyImport ?? true,
-    showSystemTray: options.showSystemTray,
-    showMenuBarIcon: options.showMenuBarIcon
-  })
 }

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -224,6 +224,7 @@ const getAppearanceSectionEntries = createLocalizedCatalog((): SettingsSearchEnt
 
 type AppearancePaneSearchOptions = {
   showWarpImport?: boolean
+  showGhosttyImport?: boolean
   showSystemTray?: boolean
   showMenuBarIcon?: boolean
 }
@@ -253,6 +254,7 @@ export function getAppearancePaneSearchEntries(
 ): SettingsSearchEntry[] {
   return buildAppearancePaneSearchEntries({
     showWarpImport: options.showWarpImport ?? true,
+    showGhosttyImport: options.showGhosttyImport ?? true,
     showSystemTray: options.showSystemTray,
     showMenuBarIcon: options.showMenuBarIcon
   })

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -156,17 +156,17 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(matchesSettingsSearch(query, getAppearancePaneSearchEntries())).toBe(true)
   })
 
-  it('omits desktop-only import appearance entries when desktop-only controls are hidden', () => {
-    const desktopEntries = getAppearancePaneSearchEntries({ showWarpImport: true })
-    const webEntries = getAppearancePaneSearchEntries({
-      showWarpImport: false,
-      showGhosttyImport: false
-    })
+  it.each(['ghostty', 'warp', 'yaml'])(
+    'omits desktop-only %s search results on web clients',
+    (query) => {
+      const desktopEntries = getAppearancePaneSearchEntries()
+      const webEntries = getAppearancePaneSearchEntries({ showDesktopThemeImports: false })
 
-    expect(desktopEntries.some((entry) => entry.title === 'Import from Warp')).toBe(true)
-    expect(webEntries.some((entry) => entry.title === 'Import from Warp')).toBe(false)
-    expect(webEntries.some((entry) => entry.title === 'Import from Ghostty')).toBe(false)
-  })
+      expect(matchesSettingsSearch(query, desktopEntries)).toBe(true)
+      expect(matchesSettingsSearch(query, webEntries)).toBe(false)
+      expect(matchesSettingsSearch('font size', webEntries)).toBe(true)
+    }
+  )
 
   it('includes the system tray appearance entry only when desktop tray controls are shown', () => {
     const desktopEntries = getAppearancePaneSearchEntries({ showSystemTray: true })

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -156,13 +156,16 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(matchesSettingsSearch(query, getAppearancePaneSearchEntries())).toBe(true)
   })
 
-  it('omits the Warp import appearance entry when desktop-only controls are hidden', () => {
+  it('omits desktop-only import appearance entries when desktop-only controls are hidden', () => {
     const desktopEntries = getAppearancePaneSearchEntries({ showWarpImport: true })
-    const webEntries = getAppearancePaneSearchEntries({ showWarpImport: false })
+    const webEntries = getAppearancePaneSearchEntries({
+      showWarpImport: false,
+      showGhosttyImport: false
+    })
 
     expect(desktopEntries.some((entry) => entry.title === 'Import from Warp')).toBe(true)
     expect(webEntries.some((entry) => entry.title === 'Import from Warp')).toBe(false)
-    expect(webEntries.some((entry) => entry.title === 'Import from Ghostty')).toBe(true)
+    expect(webEntries.some((entry) => entry.title === 'Import from Ghostty')).toBe(false)
   })
 
   it('includes the system tray appearance entry only when desktop tray controls are shown', () => {

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -64,9 +64,10 @@ export {
 
 type TerminalAppearanceSearchOptions = {
   showWarpImport?: boolean
+  showGhosttyImport?: boolean
 }
 
-const getTerminalAppearanceSearchEntriesWithoutWarp = createLocalizedCatalog(
+const getTerminalAppearanceSearchEntriesCore = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
     ...getTerminalTypographySearchEntries(),
     ...getTerminalCursorSearchEntries(),
@@ -74,8 +75,7 @@ const getTerminalAppearanceSearchEntriesWithoutWarp = createLocalizedCatalog(
     ...getTerminalThemeTargetSearchEntries(),
     ...getTerminalDarkThemeSearchEntries(),
     ...getTerminalLightThemeSearchEntries(),
-    ...getTerminalWindowSearchEntries(),
-    ...getTerminalGhosttyImportSearchEntries()
+    ...getTerminalWindowSearchEntries()
   ]
 )
 
@@ -83,7 +83,7 @@ const getTerminalAppearanceSearchEntriesWithoutWarp = createLocalizedCatalog(
 // an English title would leak the Warp entry back in under non-English locales.
 const getTerminalAppearanceSearchEntriesWithWarp = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
-    ...getTerminalAppearanceSearchEntriesWithoutWarp(),
+    ...getTerminalAppearanceSearchEntriesCore(),
     ...getTerminalWarpImportSearchEntries(),
     ...getTerminalYamlImportSearchEntries()
   ]
@@ -92,9 +92,12 @@ const getTerminalAppearanceSearchEntriesWithWarp = createLocalizedCatalog(
 export function getTerminalAppearanceSearchEntries(
   options: TerminalAppearanceSearchOptions = {}
 ): SettingsSearchEntry[] {
-  return (options.showWarpImport ?? true)
-    ? getTerminalAppearanceSearchEntriesWithWarp()
-    : getTerminalAppearanceSearchEntriesWithoutWarp()
+  return [
+    ...((options.showWarpImport ?? true)
+      ? getTerminalAppearanceSearchEntriesWithWarp()
+      : getTerminalAppearanceSearchEntriesCore()),
+    ...((options.showGhosttyImport ?? true) ? getTerminalGhosttyImportSearchEntries() : [])
+  ]
 }
 
 export function getTerminalPaneSearchEntries(platform: {

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -63,11 +63,10 @@ export {
 } from './terminal-window-setup-search'
 
 type TerminalAppearanceSearchOptions = {
-  showWarpImport?: boolean
-  showGhosttyImport?: boolean
+  showDesktopThemeImports?: boolean
 }
 
-const getTerminalAppearanceSearchEntriesCore = createLocalizedCatalog(
+const getTerminalAppearanceSearchEntriesWithoutImports = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
     ...getTerminalTypographySearchEntries(),
     ...getTerminalCursorSearchEntries(),
@@ -79,11 +78,11 @@ const getTerminalAppearanceSearchEntriesCore = createLocalizedCatalog(
   ]
 )
 
-// Why: compose rather than filter — entry titles are localized, so matching on
-// an English title would leak the Warp entry back in under non-English locales.
-const getTerminalAppearanceSearchEntriesWithWarp = createLocalizedCatalog(
+// Compose catalogs because translated titles cannot reliably identify desktop-only entries.
+const getTerminalAppearanceSearchEntriesWithImports = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
-    ...getTerminalAppearanceSearchEntriesCore(),
+    ...getTerminalAppearanceSearchEntriesWithoutImports(),
+    ...getTerminalGhosttyImportSearchEntries(),
     ...getTerminalWarpImportSearchEntries(),
     ...getTerminalYamlImportSearchEntries()
   ]
@@ -92,12 +91,9 @@ const getTerminalAppearanceSearchEntriesWithWarp = createLocalizedCatalog(
 export function getTerminalAppearanceSearchEntries(
   options: TerminalAppearanceSearchOptions = {}
 ): SettingsSearchEntry[] {
-  return [
-    ...((options.showWarpImport ?? true)
-      ? getTerminalAppearanceSearchEntriesWithWarp()
-      : getTerminalAppearanceSearchEntriesCore()),
-    ...((options.showGhosttyImport ?? true) ? getTerminalGhosttyImportSearchEntries() : [])
-  ]
+  return (options.showDesktopThemeImports ?? true)
+    ? getTerminalAppearanceSearchEntriesWithImports()
+    : getTerminalAppearanceSearchEntriesWithoutImports()
 }
 
 export function getTerminalPaneSearchEntries(platform: {

--- a/src/renderer/src/hooks/settings-navigation-interface-sections.ts
+++ b/src/renderer/src/hooks/settings-navigation-interface-sections.ts
@@ -27,6 +27,7 @@ export function buildInterfaceSettingsSections({
       icon: Palette,
       searchEntries: getAppearancePaneSearchEntries({
         showWarpImport: showDesktopOnlySettings,
+        showGhosttyImport: showDesktopOnlySettings,
         showSystemTray: showDesktopOnlySettings && isWindows,
         showMenuBarIcon: showDesktopOnlySettings && isMac
       }),

--- a/src/renderer/src/hooks/settings-navigation-interface-sections.ts
+++ b/src/renderer/src/hooks/settings-navigation-interface-sections.ts
@@ -26,8 +26,7 @@ export function buildInterfaceSettingsSections({
       ),
       icon: Palette,
       searchEntries: getAppearancePaneSearchEntries({
-        showWarpImport: showDesktopOnlySettings,
-        showGhosttyImport: showDesktopOnlySettings,
+        showDesktopThemeImports: showDesktopOnlySettings,
         showSystemTray: showDesktopOnlySettings && isWindows,
         showMenuBarIcon: showDesktopOnlySettings && isMac
       }),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​56 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 |

<!-- /orca-pr-loc -->

## Problem

Ghostty and Warp/YAML theme imports were visible on paired web clients, where they are not applicable since theme import is a desktop-only feature.

## Solution

Hide all desktop-only theme imports from web clients by using a unified `showDesktopThemeImports` flag. This prevents import buttons, modals, and search results from appearing on web clients while keeping them available on desktop.

## Testing

- Added test case verifying Ghostty import is hidden on web clients with both `forceVisiblePrimary` states
- Verified Ghostty/Warp/YAML imports are filtered from search results on web clients
- Desktop clients continue to show all import options

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual: N/A — settings visibility change, no UI rendering changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (web client exclusion only)
- [x] `pnpm lint`, `pnpm typecheck`, and `pnpm test` pass