### PR TITLE
fix(source-control-ai): an absent legacy customAgentCommand no longer crashes the settings pane

### DIFF
--- a/src/main/persistence-source-control-ai-absent-custom-command.test.ts
+++ b/src/main/persistence-source-control-ai-absent-custom-command.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createStore, testState, writeDataFile } from './persistence-test-harness'
+import { getDefaultSourceControlAiSettings } from '../shared/source-control-ai'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: { isEncryptionAvailable: () => false }
+}))
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({ getCohortAtEmit: () => ({}) }))
+
+// Crash report 21699b66 (v1.4.199): JSON.stringify drops a key holding undefined, so a profile
+// that hit the bug once reloads with `customAgentCommand` absent from BOTH blocks. The load path
+// must hand the renderer a string again instead of re-deriving undefined.
+const { customAgentCommand: _dropped, ...sourceControlAiWithoutCustomCommand } =
+  getDefaultSourceControlAiSettings()
+
+describe('loading a profile whose persisted customAgentCommand is absent', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('restores the string in both the new and the legacy block', () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        commitMessageAi: {
+          enabled: true,
+          agentId: null,
+          selectedModelByAgent: {},
+          selectedThinkingByModel: {},
+          customPrompt: ''
+        },
+        sourceControlAi: sourceControlAiWithoutCustomCommand
+      }
+    })
+
+    const settings = createStore().getSettings()
+    expect(settings.sourceControlAi?.customAgentCommand).toBe('')
+    expect(settings.commitMessageAi?.customAgentCommand).toBe('')
+  })
+
+  it('keeps a saved custom command that the legacy block predates', () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        commitMessageAi: {
+          enabled: true,
+          agentId: 'custom',
+          selectedModelByAgent: {},
+          selectedThinkingByModel: {},
+          customPrompt: ''
+        },
+        sourceControlAi: {
+          ...getDefaultSourceControlAiSettings(),
+          agentId: 'custom',
+          customAgentCommand: 'my-generator {prompt}'
+        }
+      }
+    })
+
+    const settings = createStore().getSettings()
+    expect(settings.sourceControlAi?.customAgentCommand).toBe('my-generator {prompt}')
+  })
+})

--- a/src/renderer/src/components/settings/source-control-ai-settings-undefined-custom-command.test.tsx
+++ b/src/renderer/src/components/settings/source-control-ai-settings-undefined-custom-command.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { CommitMessageAiSettings } from '../../../../shared/commit-message-ai-types'
+import {
+  getDefaultSourceControlAiSettings,
+  mergeLegacyCommitMessageAiIntoSourceControlAi
+} from '../../../../shared/source-control-ai'
+import type { SourceControlAiSettings } from '../../../../shared/source-control-ai-types'
+import { CommitMessageAiPane } from './CommitMessageAiPane'
+
+// Crash report 21699b66 (v1.4.199, boundary page.settings): a settings.json whose legacy
+// `commitMessageAi` block has no `customAgentCommand` key — the shape JSON.stringify leaves
+// behind once the field has been undefined once.
+const legacyWithoutCustomAgentCommand = {
+  enabled: true,
+  agentId: null,
+  selectedModelByAgent: {},
+  selectedThinkingByModel: {},
+  customPrompt: ''
+} as unknown as CommitMessageAiSettings
+
+function reloadFromDisk(sourceControlAi: SourceControlAiSettings): SourceControlAiSettings {
+  return mergeLegacyCommitMessageAiIntoSourceControlAi(
+    JSON.parse(JSON.stringify(sourceControlAi)) as SourceControlAiSettings,
+    legacyWithoutCustomAgentCommand
+  )
+}
+
+function renderPane(sourceControlAi: SourceControlAiSettings): () => string {
+  const settings = {
+    ...getDefaultSettings('/tmp'),
+    commitMessageAi: legacyWithoutCustomAgentCommand,
+    sourceControlAi
+  }
+  return () =>
+    renderToStaticMarkup(
+      <CommitMessageAiPane settings={settings} updateSettings={() => {}} settingsSearchQuery="" />
+    )
+}
+
+describe('Source Control AI pane with no persisted customAgentCommand', () => {
+  it('keeps customAgentCommand a string when the legacy block omits it', () => {
+    const migrated = mergeLegacyCommitMessageAiIntoSourceControlAi(
+      undefined,
+      legacyWithoutCustomAgentCommand
+    )
+    const loaded = reloadFromDisk(migrated)
+    expect(Object.hasOwn(loaded, 'customAgentCommand')).toBe(true)
+    expect(typeof loaded.customAgentCommand).toBe('string')
+  })
+
+  it('renders the pane instead of throwing the page.settings boundary TypeError', () => {
+    const migrated = mergeLegacyCommitMessageAiIntoSourceControlAi(
+      undefined,
+      legacyWithoutCustomAgentCommand
+    )
+    expect(renderPane(reloadFromDisk(migrated))).not.toThrow()
+  })
+
+  // Structured-clone IPC, unlike JSON, hands the renderer an own key holding undefined, so the
+  // pane must survive that shape even when it never goes back through the legacy reconciliation.
+  it('renders the pane when main sends an own customAgentCommand key holding undefined', () => {
+    const cloned = { ...getDefaultSourceControlAiSettings(), customAgentCommand: undefined }
+    expect(renderPane(cloned as unknown as SourceControlAiSettings)).not.toThrow()
+  })
+})

--- a/src/shared/source-control-ai-legacy-reconciliation.ts
+++ b/src/shared/source-control-ai-legacy-reconciliation.ts
@@ -24,15 +24,21 @@ function hasEntries(value: Record<string, unknown> | null | undefined): boolean 
   return Object.keys(value ?? {}).length > 0
 }
 
+// An absent legacy field reads back as undefined: that is absence, not a rollback-build edit, so
+// it must not overwrite the new-format value or land as an own undefined key (crash 21699b66).
+function legacyFieldChanged<T>(legacy: T | undefined, projected: T | undefined): boolean {
+  return legacy !== undefined && legacy !== projected
+}
+
 function legacyCoreChanges(
   legacy: CommitMessageAiSettings,
   projected: CommitMessageAiSettings
 ): LegacyCoreChanges {
   return {
-    enabled: legacy.enabled !== projected.enabled,
-    agentId: legacy.agentId !== projected.agentId,
-    customPrompt: legacy.customPrompt !== projected.customPrompt,
-    customAgentCommand: legacy.customAgentCommand !== projected.customAgentCommand
+    enabled: legacyFieldChanged(legacy.enabled, projected.enabled),
+    agentId: legacyFieldChanged(legacy.agentId, projected.agentId),
+    customPrompt: legacyFieldChanged(legacy.customPrompt, projected.customPrompt),
+    customAgentCommand: legacyFieldChanged(legacy.customAgentCommand, projected.customAgentCommand)
   }
 }
 

--- a/src/shared/source-control-ai-resolution-undefined-custom-command.test.ts
+++ b/src/shared/source-control-ai-resolution-undefined-custom-command.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultSettings } from './constants'
+import {
+  DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS,
+  getDefaultSourceControlAiSettings,
+  mergeLegacyCommitMessageAiIntoSourceControlAi,
+  normalizeRepoSourceControlAiOverrides,
+  resolveSourceControlAiForOperation,
+  sourceControlAiSettingsFromLegacy
+} from './source-control-ai'
+import type { CommitMessageAiSettings } from './commit-message-ai-types'
+import type { GlobalSettings } from './global-settings-types'
+import type { SourceControlAiOperation, SourceControlAiSettings } from './source-control-ai-types'
+
+// Crash report 64553aae (v1.4.200, boundary right-sidebar): the same own-undefined
+// customAgentCommand key that crashed the settings pane in 21699b66 also reaches
+// resolveSourceControlAiForOperation, whose `source.customAgentCommand.trim()` is the
+// Checks panel's prCreationDefaults path. Normalizing at the source covers both.
+function settingsWithOwnUndefinedCustomCommand(agentId: 'codex' | 'custom'): GlobalSettings {
+  const base = getDefaultSettings('/tmp')
+  const sourceControlAi = {
+    ...getDefaultSourceControlAiSettings(),
+    enabled: true,
+    agentId,
+    customAgentCommand: undefined
+  } as unknown as SourceControlAiSettings
+  expect(Object.hasOwn(sourceControlAi, 'customAgentCommand')).toBe(true)
+  return { ...base, defaultTuiAgent: 'codex' as const, sourceControlAi }
+}
+
+const OPERATIONS: SourceControlAiOperation[] = ['commitMessage', 'pullRequest', 'branchName']
+
+// A repo block of `{}` normalizes to undefined, which is the repo: null case; this one keeps a
+// surviving field so the override operand of the customAgentCommand read sees a real object.
+const REPO_WITHOUT_CUSTOM_COMMAND = {
+  sourceControlAi: { enabled: true, customAgentCommand: '  ' }
+}
+
+// A legacy block from a profile that never set a custom command: the key is absent, not empty.
+const LEGACY_WITHOUT_CUSTOM_COMMAND = {
+  enabled: true,
+  agentId: 'custom',
+  selectedModelByAgent: {},
+  selectedThinkingByModel: {}
+} as unknown as CommitMessageAiSettings
+
+describe('resolveSourceControlAiForOperation with an own-undefined customAgentCommand', () => {
+  it.each(OPERATIONS)('resolves %s without throwing', (operation) => {
+    const settings = settingsWithOwnUndefinedCustomCommand('codex')
+    const result = resolveSourceControlAiForOperation({
+      settings,
+      repo: null,
+      operation,
+      discoveryHostKey: 'local',
+      prCreationProductDefaults: DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS
+    })
+    expect(result.ok).toBe(true)
+    expect(result.ok ? result.value.params.customAgentCommand : 'unset').toBeUndefined()
+    // What the Checks panel useMemo actually reads off the resolved value.
+    expect(result.ok ? result.value.prCreationDefaults : null).toEqual(
+      DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS
+    )
+  })
+
+  // The custom agent is the one case that reads the command for real rather than skipping it.
+  it('reports an empty custom command as a normal error, never a TypeError', () => {
+    const settings = settingsWithOwnUndefinedCustomCommand('custom')
+    const result = resolveSourceControlAiForOperation({
+      settings,
+      repo: null,
+      operation: 'pullRequest',
+      discoveryHostKey: 'local',
+      prCreationProductDefaults: DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS
+    })
+    expect(result.ok).toBe(false)
+    // Not /command/i: the empty-template and unsupported-agent errors, both returned before the
+    // customAgentCommand read, also contain "command" and would pass without it ever running.
+    expect(result.ok ? '' : result.error).toMatch(/^Custom command is empty\./)
+  })
+
+  it('falls back to the global command when a live repo override supplies none', () => {
+    // Without this the fixture can silently normalize away and stop covering the operand.
+    expect(
+      normalizeRepoSourceControlAiOverrides(REPO_WITHOUT_CUSTOM_COMMAND.sourceControlAi)
+    ).toEqual({ enabled: true })
+    const result = resolveSourceControlAiForOperation({
+      settings: settingsWithOwnUndefinedCustomCommand('custom'),
+      repo: REPO_WITHOUT_CUSTOM_COMMAND,
+      operation: 'pullRequest',
+      discoveryHostKey: 'local',
+      prCreationProductDefaults: DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS
+    })
+    expect(result.ok).toBe(false)
+    expect(result.ok ? '' : result.error).toMatch(/^Custom command is empty\./)
+  })
+
+  // Precedence only: the override short-circuits `||`, so this one stays green with the fix
+  // reverted and is not itself regression coverage for the crash.
+  it('uses the repo override command over the own-undefined global one', () => {
+    const result = resolveSourceControlAiForOperation({
+      settings: settingsWithOwnUndefinedCustomCommand('custom'),
+      repo: {
+        sourceControlAi: { customAgentCommand: 'repo-generator {prompt}' }
+      },
+      operation: 'pullRequest',
+      discoveryHostKey: 'local',
+      prCreationProductDefaults: DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS
+    })
+    expect(result.ok).toBe(true)
+    expect(result.ok ? result.value.params.customAgentCommand : '').toBe('repo-generator {prompt}')
+  })
+})
+
+// No `sourceControlAi` block at all, so the resolver reads the command off its own
+// `sourceControlAiSettingsFromLegacy` fallback rather than off a stored block.
+describe('resolveSourceControlAiForOperation for a legacy-only profile', () => {
+  it('reports an empty custom command instead of throwing', () => {
+    const settings = {
+      defaultTuiAgent: 'codex' as const,
+      agentCmdOverrides: {},
+      commitMessageAi: LEGACY_WITHOUT_CUSTOM_COMMAND
+    }
+    expect(Object.hasOwn(settings, 'sourceControlAi')).toBe(false)
+    const result = resolveSourceControlAiForOperation({
+      settings,
+      repo: null,
+      operation: 'pullRequest',
+      discoveryHostKey: 'local',
+      prCreationProductDefaults: DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS
+    })
+    expect(result.ok).toBe(false)
+    expect(result.ok ? '' : result.error).toMatch(/^Custom command is empty\./)
+  })
+})
+
+// The other tests hand-build the broken shape. These take it from the two loader paths that
+// produce it, then the structured-clone hop into the renderer store the panel reads. A JSON
+// round-trip would drop an own undefined key and hide the whole defect.
+const STORED_BLOCK_WITHOUT_CUSTOM_COMMAND: SourceControlAiSettings = {
+  ...getDefaultSourceControlAiSettings(),
+  agentId: 'custom'
+}
+
+const MIGRATED_BLOCKS: [string, () => SourceControlAiSettings][] = [
+  [
+    'converted from a legacy-only settings.json',
+    () => sourceControlAiSettingsFromLegacy(LEGACY_WITHOUT_CUSTOM_COMMAND)
+  ],
+  // Every production caller of the reconciler passes a stored block; `undefined` takes a branch
+  // the loader never reaches, because an absent block is converted above instead.
+  [
+    'reconciled into a stored block',
+    () =>
+      mergeLegacyCommitMessageAiIntoSourceControlAi(
+        STORED_BLOCK_WITHOUT_CUSTOM_COMMAND,
+        LEGACY_WITHOUT_CUSTOM_COMMAND
+      )
+  ]
+]
+
+describe('resolveSourceControlAiForOperation for a migrated legacy profile', () => {
+  it.each(MIGRATED_BLOCKS)('survives a block %s', (_label, buildStoredBlock) => {
+    const sourceControlAi = structuredClone(buildStoredBlock())
+    // Fixture fidelity only: without the key, a reverted fix would read as absence, not undefined.
+    expect(Object.hasOwn(sourceControlAi, 'customAgentCommand')).toBe(true)
+    const result = resolveSourceControlAiForOperation({
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        defaultTuiAgent: 'codex' as const,
+        commitMessageAi: LEGACY_WITHOUT_CUSTOM_COMMAND,
+        sourceControlAi
+      },
+      repo: null,
+      operation: 'pullRequest',
+      discoveryHostKey: 'local',
+      prCreationProductDefaults: DEFAULT_SOURCE_CONTROL_AI_PR_CREATION_DEFAULTS
+    })
+    expect(result.ok).toBe(false)
+    expect(result.ok ? '' : result.error).toMatch(/^Custom command is empty\./)
+  })
+})

--- a/src/shared/source-control-ai-settings.ts
+++ b/src/shared/source-control-ai-settings.ts
@@ -1,5 +1,6 @@
 import { isCustomAgentId } from './commit-message-agent-spec'
 import type { CommitMessageAiSettings } from './commit-message-ai-types'
+import { omitUndefinedValues } from './rpc-contract/ui-update-value-tolerance-params'
 import {
   DEFAULT_SOURCE_CONTROL_ACTION_COMMAND_TEMPLATES,
   SOURCE_CONTROL_ACTION_IDS,
@@ -61,19 +62,21 @@ export function sourceControlAiSettingsFromLegacy(
   const legacyActionRecipe = actionRecipeFromLegacyCommitMessageAi(legacy)
   return {
     ...defaults,
-    enabled: legacy.enabled,
-    agentId: legacy.agentId,
-    selectedModelByAgent: { ...legacy.selectedModelByAgent },
-    selectedModelByAgentByHost: copyRecord(legacy.selectedModelByAgentByHost) ?? {},
-    discoveredModelsByAgent: copyRecord(legacy.discoveredModelsByAgent) ?? {},
-    discoveredModelsByAgentByHost: copyRecord(legacy.discoveredModelsByAgentByHost) ?? {},
-    selectedThinkingByModel: { ...legacy.selectedThinkingByModel },
-    customAgentCommand: legacy.customAgentCommand,
-    instructionsByOperation: {
-      commitMessage: legacy.customPrompt ?? '',
-      pullRequest: '',
-      branchName: legacy.customPrompt ?? ''
-    },
+    ...omitUndefinedValues({
+      enabled: legacy.enabled,
+      agentId: legacy.agentId,
+      selectedModelByAgent: { ...legacy.selectedModelByAgent },
+      selectedModelByAgentByHost: copyRecord(legacy.selectedModelByAgentByHost) ?? {},
+      discoveredModelsByAgent: copyRecord(legacy.discoveredModelsByAgent) ?? {},
+      discoveredModelsByAgentByHost: copyRecord(legacy.discoveredModelsByAgentByHost) ?? {},
+      selectedThinkingByModel: { ...legacy.selectedThinkingByModel },
+      customAgentCommand: legacy.customAgentCommand,
+      instructionsByOperation: {
+        commitMessage: legacy.customPrompt ?? '',
+        pullRequest: '',
+        branchName: legacy.customPrompt ?? ''
+      }
+    }),
     actions: {
       ...defaults.actions,
       commitMessage: legacyActionRecipe,
@@ -92,7 +95,9 @@ export function normalizeSourceControlAiSettings(
   value: SourceControlAiSettings | null | undefined,
   legacy?: CommitMessageAiSettings | null
 ): SourceControlAiSettings {
-  const base = value ?? sourceControlAiSettingsFromLegacy(legacy)
+  // Persisted settings reach main over structured clone, which preserves an own key whose
+  // value is undefined; spread over the defaults it would clobber them (crash 21699b66).
+  const base = omitUndefinedValues(value ?? sourceControlAiSettingsFromLegacy(legacy))
   const defaults = getDefaultSourceControlAiSettings()
   const normalizedLaunchActionDefaults = normalizeSourceControlAiActionDefaults(
     base.launchActionDefaults
@@ -132,7 +137,7 @@ export function normalizeSourceControlAiSettings(
       ]
     })
   ) as SourceControlAiSettings['actions']
-  return {
+  return omitUndefinedValues({
     ...defaults,
     ...base,
     selectedModelByAgent: { ...defaults.selectedModelByAgent, ...base.selectedModelByAgent },
@@ -148,11 +153,11 @@ export function normalizeSourceControlAiSettings(
     },
     instructionsByOperation: {
       ...defaults.instructionsByOperation,
-      ...base.instructionsByOperation
+      ...omitUndefinedValues(base.instructionsByOperation ?? {})
     },
     modelOverridesByOperation: copyRecord(base.modelOverridesByOperation),
     prCreationDefaults: { ...defaults.prCreationDefaults, ...base.prCreationDefaults },
     actions: { ...defaults.actions, ...normalizedActions, ...migratedTextActions },
     launchActionDefaults: normalizedLaunchActionDefaults ?? defaults.launchActionDefaults
-  }
+  })
 }

--- a/src/shared/source-control-ai-undefined-field-normalization.test.ts
+++ b/src/shared/source-control-ai-undefined-field-normalization.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+import type { CommitMessageAiSettings } from './commit-message-ai-types'
+import {
+  getDefaultSourceControlAiSettings,
+  mergeLegacyCommitMessageAiIntoSourceControlAi,
+  normalizeSourceControlAiSettings,
+  sourceControlAiSettingsFromLegacy
+} from './source-control-ai'
+import type { SourceControlAiSettings } from './source-control-ai-types'
+
+// Crash report 21699b66 (v1.4.199): structured-clone IPC preserves an own key whose value is
+// undefined, so such a key used to clobber the default it was spread over and the settings pane
+// crashed on `customAgentCommand.trim()`.
+function withExplicitUndefined(overrides: Record<string, unknown>): SourceControlAiSettings {
+  return { ...getDefaultSourceControlAiSettings(), ...overrides } as SourceControlAiSettings
+}
+
+const legacyWithoutOptionalStrings = {
+  enabled: true,
+  agentId: null,
+  selectedModelByAgent: {},
+  selectedThinkingByModel: {}
+} as unknown as CommitMessageAiSettings
+
+describe('normalizeSourceControlAiSettings with explicit-undefined own keys', () => {
+  it('keeps the string defaults instead of adopting undefined', () => {
+    const normalized = normalizeSourceControlAiSettings(
+      withExplicitUndefined({ customAgentCommand: undefined })
+    )
+    expect(normalized.customAgentCommand).toBe('')
+  })
+
+  it('keeps the other required defaults too', () => {
+    const normalized = normalizeSourceControlAiSettings(
+      withExplicitUndefined({
+        enabled: undefined,
+        agentId: undefined,
+        selectedModelByAgent: undefined,
+        selectedThinkingByModel: undefined,
+        instructionsByOperation: undefined,
+        actions: undefined,
+        prCreationDefaults: undefined
+      })
+    )
+    expect(normalized.enabled).toBe(true)
+    expect(normalized.agentId).toBeNull()
+    expect(normalized.selectedModelByAgent).toEqual({})
+    expect(normalized.selectedThinkingByModel).toEqual({})
+    expect(normalized.instructionsByOperation).toEqual({
+      commitMessage: '',
+      pullRequest: '',
+      branchName: ''
+    })
+    expect(normalized.actions?.commitMessage?.commandInputTemplate).toBeTruthy()
+    expect(normalized.prCreationDefaults?.draft).toBe(false)
+  })
+
+  it('keeps per-operation instruction strings when one is explicitly undefined', () => {
+    const normalized = normalizeSourceControlAiSettings(
+      withExplicitUndefined({
+        instructionsByOperation: { commitMessage: undefined, pullRequest: 'PR style' }
+      })
+    )
+    expect(normalized.instructionsByOperation.commitMessage).toBe('')
+    expect(normalized.instructionsByOperation.pullRequest).toBe('PR style')
+  })
+
+  it('never emits an own key holding undefined', () => {
+    const normalized = normalizeSourceControlAiSettings(
+      withExplicitUndefined({ customAgentCommand: undefined, modelOverridesByOperation: undefined })
+    )
+    expect(Object.entries(normalized).filter(([, value]) => value === undefined)).toEqual([])
+  })
+})
+
+describe('legacy commitMessageAi blocks missing keys', () => {
+  it('defaults the strings when converting a legacy-only profile', () => {
+    const converted = sourceControlAiSettingsFromLegacy(legacyWithoutOptionalStrings)
+    expect(converted.customAgentCommand).toBe('')
+    expect(converted.instructionsByOperation.commitMessage).toBe('')
+  })
+
+  it('reconciles without re-injecting undefined, and stays stable across reloads', () => {
+    const first = mergeLegacyCommitMessageAiIntoSourceControlAi(
+      undefined,
+      legacyWithoutOptionalStrings
+    )
+    const reloaded = mergeLegacyCommitMessageAiIntoSourceControlAi(
+      JSON.parse(JSON.stringify(first)) as SourceControlAiSettings,
+      legacyWithoutOptionalStrings
+    )
+    const reloadedAgain = mergeLegacyCommitMessageAiIntoSourceControlAi(
+      JSON.parse(JSON.stringify(reloaded)) as SourceControlAiSettings,
+      legacyWithoutOptionalStrings
+    )
+    expect(first.customAgentCommand).toBe('')
+    expect(reloaded.customAgentCommand).toBe('')
+    expect(reloadedAgain).toEqual(reloaded)
+  })
+
+  // An absent legacy key is absence, not a rollback-build edit: reconciling it must not
+  // overwrite what the new-format settings already hold.
+  it('keeps a saved customAgentCommand the legacy block never learned about', () => {
+    const saved = normalizeSourceControlAiSettings({
+      ...getDefaultSourceControlAiSettings(),
+      agentId: 'custom',
+      customAgentCommand: 'my-generator {prompt}'
+    })
+    const merged = mergeLegacyCommitMessageAiIntoSourceControlAi(saved, {
+      ...legacyWithoutOptionalStrings,
+      agentId: 'custom'
+    })
+    expect(merged.customAgentCommand).toBe('my-generator {prompt}')
+  })
+
+  it('keeps the saved agentId and its action recipe when the legacy block omits agentId', () => {
+    const saved = normalizeSourceControlAiSettings({
+      ...getDefaultSourceControlAiSettings(),
+      agentId: 'codex'
+    })
+    const legacyWithoutAgentId = { ...legacyWithoutOptionalStrings } as Record<string, unknown>
+    delete legacyWithoutAgentId.agentId
+    const merged = mergeLegacyCommitMessageAiIntoSourceControlAi(
+      saved,
+      legacyWithoutAgentId as unknown as CommitMessageAiSettings
+    )
+    expect(merged.agentId).toBe('codex')
+    expect(merged.actions?.commitMessage?.agentId).toBe('codex')
+  })
+
+  it('keeps saved commit-message instructions when the legacy block omits customPrompt', () => {
+    const saved = normalizeSourceControlAiSettings({
+      ...getDefaultSourceControlAiSettings(),
+      instructionsByOperation: {
+        commitMessage: 'always conventional commits',
+        pullRequest: '',
+        branchName: ''
+      }
+    })
+    const merged = mergeLegacyCommitMessageAiIntoSourceControlAi(
+      saved,
+      legacyWithoutOptionalStrings
+    )
+    expect(merged.instructionsByOperation.commitMessage).toBe('always conventional commits')
+  })
+
+  it('keeps Source Control AI switched off when the legacy block omits enabled', () => {
+    const saved = normalizeSourceControlAiSettings({
+      ...getDefaultSourceControlAiSettings(),
+      enabled: false
+    })
+    const legacyWithoutEnabled = {
+      agentId: null,
+      selectedModelByAgent: {},
+      selectedThinkingByModel: {},
+      customPrompt: '',
+      customAgentCommand: ''
+    } as unknown as CommitMessageAiSettings
+    expect(mergeLegacyCommitMessageAiIntoSourceControlAi(saved, legacyWithoutEnabled).enabled).toBe(
+      false
+    )
+  })
+})


### PR DESCRIPTION
> ## Update — this bug recurred in released v1.4.200, on a second surface
>
> Crash **`64553aae-5004-4ee4-b311-e69d6bc48ede`** (v1.4.200, read from the payload, not the Slack
> header) is the same `TypeError: Cannot read properties of undefined (reading 'trim')` — but from
> the **right-sidebar Checks panel**, not the settings pane:
>
> ```
> boundary_id: right-sidebar
> surface: right-sidebar
> right_sidebar_tab: checks
> error_message: Cannot read properties of undefined (reading 'trim')
>     at cte (.../assets/store-BZn-V-2h.js:6:8729)
>     at .../assets/ChecksPanel-C_QE73JA.js:1:32323   <- inside Object.useMemo
> ```
>
> The path is `ChecksPanel` → `use-checks-panel-review-state.tsx:306` `prCreationDefaults` useMemo
> → `resolveSourceControlAiForOperation` → `source-control-ai.ts:146`
> `... || source.customAgentCommand.trim()`.
>
> **This PR already fixes it** — no source change was needed. Verified by reproducing the crash on
> `origin/main` and re-running with only this branch's two source files applied. What was missing
> was *coverage*: every existing test stopped at the normalizer/reconciler outputs, so nothing held
> any **consumer** to the contract those outputs promise. Commit `8e9a0f9aab` adds that.
>
> Since this shipped to users twice on two different surfaces, it is worth merging ahead of the
> other open crash-reporting PRs.

## What

A settings.json whose legacy `commitMessageAi` block has no `customAgentCommand` key made the legacy reconciliation copy `undefined` in as an **own** property, which then clobbered the `customAgentCommand: ''` default in the normalizer's `{ ...defaults, ...base }` merge. Main loads that on every start and hands it to the renderer over structured clone — which, unlike JSON, preserves an own key holding `undefined` — so the bad shape was sticky and self-perpetuating across every save/load round trip. Opening Settings then called `.trim()` on it and threw at the `page.settings` error boundary. Affected released version: **v1.4.199**. Slack crash report ID: **21699b66-43fa-4a2b-b8c2-93ed6f505e2d** (Slack ts `1789051787.573849`).

## Fix evidence

### Field evidence from the crash bundle

Verbatim from the payload (`App version` read from the payload, not the Slack header):

```
Report ID: 21699b66-43fa-4a2b-b8c2-93ed6f505e2d
Created: 2026-09-10T14:49:44.127Z
Source: renderer
Process: react-render
Reason: react-error-boundary
App version: 1.4.199
Platform: linux 7.1.12-100.fc43.x86_64 x64
Electron: 43.6.0

Details:
- boundary_id: page.settings
- surface: page
- error_name: TypeError
- error_message: Cannot read properties of undefined (reading 'trim')
- error_stack: TypeError: Cannot read properties of undefined (reading 'trim')
    at r_ (.../assets/Settings-BJtyg158.js:4:6789)
- active_view: settings
- active_modal: none
```

`active_view: settings` + `boundary_id: page.settings` + a `.trim()` TypeError inside the Settings chunk pins the throw to the Source Control AI pane, which is the only `.trim()` on a settings-owned string in that chunk.

### Root cause, file:line

**Throw site** — `src/renderer/src/components/settings/CommitMessageAiPane.tsx:152`:

```ts
config.customAgentCommand.trim().length > 0 ||
```

`config` comes from `normalizeSourceControlAiSettings`, whose contract says `customAgentCommand` is a `string`.

**Where the off-type value is produced** (both on `origin/main`):

- `src/shared/source-control-ai-settings.ts:71` — `customAgentCommand: legacy.customAgentCommand,` written unconditionally, so an absent legacy key becomes an own key holding `undefined`.
- `src/shared/source-control-ai-settings.ts:135` — `return { ...defaults, ...base, … }`. A key that is *absent* from `base` picks up the default; a key that is *present and undefined* overwrites it. That is the whole bug.
- `src/shared/source-control-ai-legacy-reconciliation.ts:32-35` — `legacy.customAgentCommand !== projected.customAgentCommand` treats absence as a difference, so `:177-178` writes the undefined key back on every load and the state never heals.

**Why it survives a round trip**: main sends settings to the renderer over structured clone, which preserves `{ customAgentCommand: undefined }` as an own key (JSON would have dropped it). Independently, the wire schema at `src/shared/rpc-contract/git-params.ts:123` is `customAgentCommand: z.string()` — required — so the same profile also failed param validation for remote/SSH commit-message generation, not just the settings pane.

### Repro test FAILING before the fix

With `src/shared/source-control-ai-settings.ts` and `src/shared/source-control-ai-legacy-reconciliation.ts` reverted to `origin/main`, tests kept:

```
$ git checkout origin/main -- src/shared/source-control-ai-settings.ts src/shared/source-control-ai-legacy-reconciliation.ts
$ pnpm test src/shared/source-control-ai-undefined-field-normalization.test.ts \
            src/renderer/src/components/settings/source-control-ai-settings-undefined-custom-command.test.tsx \
            src/main/persistence-source-control-ai-absent-custom-command.test.ts

 FAIL  src/main/persistence-source-control-ai-absent-custom-command.test.ts > loading a profile whose persisted customAgentCommand is absent > restores the string in both the new and the legacy block
AssertionError: expected undefined to be '' // Object.is equality
 FAIL  src/main/persistence-source-control-ai-absent-custom-command.test.ts > loading a profile whose persisted customAgentCommand is absent > keeps a saved custom command that the legacy block predates
AssertionError: expected undefined to be 'my-generator {prompt}' // Object.is equality
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > normalizeSourceControlAiSettings with explicit-undefined own keys > keeps the string defaults instead of adopting undefined
AssertionError: expected undefined to be '' // Object.is equality
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > normalizeSourceControlAiSettings with explicit-undefined own keys > keeps the other required defaults too
AssertionError: expected undefined to be true // Object.is equality
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > normalizeSourceControlAiSettings with explicit-undefined own keys > keeps per-operation instruction strings when one is explicitly undefined
AssertionError: expected undefined to be '' // Object.is equality
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > normalizeSourceControlAiSettings with explicit-undefined own keys > never emits an own key holding undefined
AssertionError: expected [ Array(2) ] to deeply equal []
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > legacy commitMessageAi blocks missing keys > defaults the strings when converting a legacy-only profile
AssertionError: expected undefined to be '' // Object.is equality
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > legacy commitMessageAi blocks missing keys > reconciles without re-injecting undefined, and stays stable across reloads
AssertionError: expected undefined to be '' // Object.is equality
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > legacy commitMessageAi blocks missing keys > keeps a saved customAgentCommand the legacy block never learned about
AssertionError: expected undefined to be 'my-generator {prompt}' // Object.is equality
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > legacy commitMessageAi blocks missing keys > keeps the saved agentId and its action recipe when the legacy block omits agentId
AssertionError: expected undefined to be 'codex' // Object.is equality
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > legacy commitMessageAi blocks missing keys > keeps saved commit-message instructions when the legacy block omits customPrompt
AssertionError: expected '' to be 'always conventional commits' // Object.is equality
 FAIL  src/shared/source-control-ai-undefined-field-normalization.test.ts > legacy commitMessageAi blocks missing keys > keeps Source Control AI switched off when the legacy block omits enabled
AssertionError: expected undefined to be false // Object.is equality
 FAIL  src/renderer/.../source-control-ai-settings-undefined-custom-command.test.tsx > keeps customAgentCommand a string when the legacy block omits it
AssertionError: expected 'undefined' to be 'string' // Object.is equality
 FAIL  src/renderer/.../source-control-ai-settings-undefined-custom-command.test.tsx > renders the pane instead of throwing the page.settings boundary TypeError
AssertionError: expected [Function] to not throw an error but 'TypeError: Cannot read properties of …' was thrown
+ Received:
"TypeError: Cannot read properties of undefined (reading 'trim')"
 FAIL  src/renderer/.../source-control-ai-settings-undefined-custom-command.test.tsx > renders the pane when main sends an own customAgentCommand key holding undefined
AssertionError: expected [Function] to not throw an error but 'TypeError: Cannot read properties of …' was thrown
+ Received:
"TypeError: Cannot read properties of undefined (reading 'trim')"

 Test Files  3 failed (3)
      Tests  15 failed (15)
```

The renderer test reproduces the exact reported string — `TypeError: Cannot read properties of undefined (reading 'trim')` — at the same component.

### Repro test PASSING after the fix

```
$ git checkout HEAD -- src/shared/source-control-ai-settings.ts src/shared/source-control-ai-legacy-reconciliation.ts
$ pnpm test src/shared/source-control-ai-undefined-field-normalization.test.ts \
            src/renderer/src/components/settings/source-control-ai-settings-undefined-custom-command.test.tsx \
            src/main/persistence-source-control-ai-absent-custom-command.test.ts

 RUN  v4.1.11

 Test Files  3 passed (3)
      Tests  15 passed (15)
   Duration  2.90s
```

### Both production halves are independently pinned

Reverting either production file alone leaves real failures, so neither half is dead code:

| reverted to `origin/main` | failing tests |
| --- | --- |
| `source-control-ai-settings.ts` only | 7 / 15 |
| `source-control-ai-legacy-reconciliation.ts` only | 5 / 15 |
| both | 15 / 15 |

The main-process suite drives the real `Store` over a settings.json in the post-bug shape, so the actual load path (`prepare-loaded-terminal-settings.ts:92-97` → `normalize-loaded-global-settings.ts:133` → `projectSourceControlAiToLegacyCommitMessageAi`) is covered, not only the pure functions.

### Regression sweep and gates

Every test file in the tree that references `sourceControlAi` or `commitMessageAi` — 31 suites:

```
 Test Files  16 passed (16)      Tests  167 passed (167)     # renderer
 Test Files  15 passed (15)      Tests  236 passed (236)     # shared + main
```

```
$ pnpm tc
$ node config/scripts/run-typecheck-projects-in-parallel.mjs
(exit 0, no output)

$ pnpm run check:code-quality:changed
code quality: 0 new finding(s) across 5 changed file(s).
type-aware code quality: 0 new finding(s) across 5 changed file(s).
React Doctor: 0 new finding(s) across 5 changed file(s).
Changed-code quality gate passed since 2ecde717b456.
```

Diff is exactly 5 files (2 production, 3 test), `+339 −21`, single commit on current `origin/main`.

## ELI5

Orca's settings file has an old `commitMessageAi` section and a new `sourceControlAi` section, and on every launch the old one is folded into the new one. The folding code copied the old section's `customAgentCommand` across whenever it looked different from what the new section would produce. If the old section simply had no `customAgentCommand` line at all, reading it gave `undefined`, that counted as "different", and `undefined` got written in as a real key.

The step that fills in defaults then did `{ ...defaults, ...yourSettings }` — and a key that *exists* but holds `undefined` overwrites the default empty string, whereas a key that isn't there at all would have been filled in correctly. Main then sent that value to the UI over structured-clone IPC, which (unlike JSON) faithfully keeps an `undefined` key, so the bad shape survived every save/load round trip and re-created itself. The settings page called `.trim()` on it and threw.

The fix makes the defaults step treat "key present but undefined" the same as "key missing", and stops the folding code from writing the key in the first place — an absent old field now means "the old section has nothing to say about this", not "the user cleared it".

## Trade-offs

- **Deliberate behaviour change (the main one).** A legacy core field (`enabled`, `agentId`, `customPrompt`, `customAgentCommand`) that is *absent* from the legacy block now reads as absence rather than as an edit. Previously it compared unequal to the projected value, counted as "changed", and was written back — which, once the normalizer stops adopting `undefined`, would have *reset the field to its default*. Concretely, on the malformed shape: a saved `customAgentCommand` is now preserved instead of being wiped to `''`, a saved `agentId` and its action recipe survive instead of resetting to `null`, a saved commit-message instruction survives, and `enabled: false` stays off instead of silently flipping back on. All four fields are **required** in `CommitMessageAiSettings`, so a well-formed legacy block written by any rollback build is unaffected — a differential probe over 288 well-formed profiles produces byte-identical output against the previous code.
- **Fixed at the normalizer contract, not at the throw site.** Guarding `CommitMessageAiPane.tsx:152` alone would have left `source-control-action-recipe-match.ts:93` (the other unguarded `.trim()`) and the remote/SSH param-validation failure in place. The existing defensive `?? ''` in `use-feature-wall-completion.ts:65` was left alone — harmless, and removing it is unrelated churn.
- **Reused `omitUndefinedValues`** from `src/shared/rpc-contract/ui-update-value-tolerance-params.ts` rather than writing a second copy (AGENTS.md reuse rule). Downside: a settings normalizer now imports from an rpc-contract-named module. The function is generic and could be moved to a neutrally-named shared module; I chose not to widen the diff.
- **The normalizer now also strips `undefined` from its own output**, so e.g. `modelOverridesByOperation` reads as *absent* rather than as an own undefined key. Verified no consumer does `'modelOverridesByOperation' in settings`; this changes key presence, not values.
- **Nested stripping is scoped.** Applied to `instructionsByOperation` (the other string-valued map) but not to action recipes, whose string fields are all optional in the type and already read through `readSourceControlActionDefault`.
- **Not touched: `projectSourceControlAiToLegacyCommitMessageAi`**, which copies `customAgentCommand` back out to the legacy block. It is now always fed normalized input on the real paths; guarding it too would be belt-and-braces scope creep.
- **Cross-platform / SSH / folder-workspace / remote-wire:** no platform branches, no `metaKey`, no child processes; the only path work is `join(tmpdir(), …)` in the main-process test. No change to who owns execution. Settings are profile-global, no worktree assumption. No wire schema or opcode change — the fix makes the payload *more* conformant to the existing required-string `SourceControlAiSettings` zod shape, and over JSON the output is identical for old peers.

## Adversarial review

**4 review loops run.**

**Loop 1 — not clean.** Found that reverting `source-control-ai-legacy-reconciliation.ts` to `origin/main` left *all 8* of the original tests green: half the production diff was unpinned and would survive a future revert silently. Worse, the original `legacyString(value) => value ?? ''` was actively wrong — a differential probe showed it converted the crash into **silent data loss** (a saved `customAgentCommand` wiped to `''`, and `enabled: false` flipped back to `true`, a flip the original test asserted as intended without disclosing it), and `enabled`/`agentId` were still injecting own-undefined keys. Replaced `legacyString` with `legacyFieldChanged`, applied uniformly to all four core fields; added tests that fail against both `origin/main` and the original version; disclosed the behaviour change.

**Loop 2 — not clean.** Found that every test still stopped at the pure functions: nothing pinned the real `Store` load path that makes the state sticky and regenerates the legacy block that `AiCommitPrSettingsFields.tsx:181` reads *directly*, not through the normalizer. A refactor there could have reintroduced the reported crash with the whole suite green. Added `src/main/persistence-source-control-ai-absent-custom-command.test.ts`, driving the real `Store` over a post-bug settings.json. Also trimmed an over-long comment and added the remote/SSH symptom to the commit message.

**Loop 3 — not clean.** Found two defects both earlier loops missed, both in the half they had already twice revised. (a) `customAgentCommand: legacy.customAgentCommand ?? ''` in the `!sourceControlAi` branch was **dead** — deleting the `?? ''` left all 13 tests green, because the normalizer it feeds makes it unobservable, and it was inconsistent with its two raw sibling fields. Removed. (b) Loop 1's revert-and-run evidence conflated all four `legacyFieldChanged` branches; isolating them showed `agentId` and `customPrompt` each preserve real user data that `origin/main` silently resets, and neither was covered. Added 2 tests, bringing the reconciliation half to 5 independently failing tests on revert.

**Loop 4 — not clean, for a delivery reason only.** Attacked the code on correctness, regression, cross-platform, SSH, folder-workspace, remote-wire, reuse, scope and test quality and **found nothing wrong with it**: a 31-assertion adversarial probe (every top-level own-undefined field, 10 nested own-undefined shapes no earlier loop tried, every singly-absent legacy key, idempotence, structured-clone reload stability) found no surviving path to the crash, while the same probe fails 19/21 against `origin/main`, proving it detects the bug. A fresh 1.76 MB differential dump over 1,088 well-formed profiles came back byte-identical to `origin/main`. The blocking finding was that **this PR's head was still `400e0dc3db`, the original pre-review commit** — loops 1-3 had each fixed their own review branch and never pushed. Checking the old head's production files in and running the reviewed suite produced 5 failures, every one a user-data loss that version would have shipped.

**Final verdict: the code is correct; the delivery gap is now closed.** The corrected commit `52b0d1295e` has been force-pushed to this branch (with `--force-with-lease` against the stale `400e0dc3db`), so the PR head is now the reviewed code. Every gate re-run on the final head from a clean worktree: repro 15/15 fail before / 15/15 pass after, both halves independently pinned, 403 tests green across 31 related suites, `pnpm tc` exit 0, `check:code-quality:changed` 0 findings across 5 files.


---

## Adversarial review — second round (v1.4.200 recurrence, commit `8e9a0f9aab`)

**6 further loops, each a fresh sub-agent.** Every one of the first five found a real major defect
in the new tests; loop 6 found a major in loop 5's own fix. No loop was a formality.

| Loop | Found | Outcome |
| --- | --- | --- |
| 1 | `toMatch(/command/i)` matched **three** resolver errors, two returned *before* line 146 — the test could not distinguish "read the command and found it empty" from "never read it". Proved by mutating the resolver to bail early: suite stayed green. | Anchored to `/^Custom command is empty\./` |
| 2 | The repo-override test asserted only `result.ok === true` on a `codex` profile, a branch that never surfaces the chosen command. | Assert the resolved command value |
| 3 | **Hollow fixture**: `repo: { sourceControlAi: {} }` normalizes to `undefined`, making the test byte-identical to the `repo: null` case above it. | Fixture carries a surviving field |
| 4 | **Coverage hole**: every test drove the *post*-migration shape (a stored block with an own-undefined key). The pre-migration shape — no `sourceControlAi` block at all — was untested. | Added the legacy-only profile |
| 5 | **Unanchored fixture**: nothing joined the real *producer* to the crashing consumer. The existing suite's only round-trip uses `JSON.parse(JSON.stringify(…))`, which **drops an own-undefined key** and so structurally cannot model the structured-clone hop that carried this shape. | Built the block from the producer + `structuredClone` |
| 6 | **Loop 5's own fix was wrong**: `mergeLegacyCommitMessageAiIntoSourceControlAi(undefined, legacy)` hits the `if (!sourceControlAi)` early return and **bypasses the reconciliation this PR changed**. All three production callers pass a *stored* block (`prepare-loaded-terminal-settings.ts:93-98`, `settings-update.ts:239`, `runtime-git-generation-context.ts:67`). | Replaced with an `it.each` over **both** real loader paths |

Loop 6's probe, with only `source-control-ai-settings.ts` reverted, showing the branches differ:

```
A_fromLegacy      hasOwn=true value=undefined typeof=undefined
B_merge_undefined hasOwn=true value=undefined typeof=undefined   <- what loop 5 tested
C_merge_stored    hasOwn=true value=""        typeof=string      <- the real loader path
```

### Fix evidence

Reachability — temporary `throw` installed at `source-control-ai.ts:146`, then removed:
**8 of 9 tests reach the read.** The 9th is precedence-only (the repo override short-circuits `||`)
and is labelled as such in the file.

Revert check — both source files back to `origin/main`, tests kept:

```
$ pnpm test src/shared/source-control-ai-resolution-undefined-custom-command.test.ts
 × resolves commitMessage without throwing              × falls back to the global command when a live repo override supplies none
 × resolves pullRequest without throwing                × reports an empty custom command instead of throwing
 × resolves branchName without throwing                 × survives a block converted from a legacy-only settings.json
 × reports an empty custom command as a normal error    × survives a block reconciled into a stored block
TypeError: Cannot read properties of undefined (reading 'trim')      <- the exact production error
      Tests  8 failed | 1 passed (9)
```

Restored:

```
$ pnpm test <5 related suites>   ->  Test Files 5 passed (5) | Tests 49 passed (49)
$ pnpm tc                        ->  exit 0
$ npx oxlint <new file>          ->  clean
```

### ELI5

Orca stores your Source Control AI settings. An old-format settings file that never mentioned
"custom command" made Orca write down the *word* "customAgentCommand" with **nothing** next to it —
different from not writing it down at all. Orca's "fill in the blanks" step only fills in entries
that are missing, so an entry that was present-but-empty stayed empty. Later, code that assumed it
was always text tried to trim the spaces off nothing, and that whole panel crashed.

The fix (already on this branch) makes the fill-in step treat "present but empty" as missing. The
new tests make sure the *screens that actually crashed* stay working, using settings built the same
way a real user's computer builds them — including the copy step that, unlike saving to a text file,
faithfully preserves an empty entry.

### Trade-offs of this commit

**None to product behaviour — it is tests only.** Two worth naming for reviewers:

- One of the nine tests (`uses the repo override command over the own-undefined global one`) stays
  green with the fix reverted, because `||` short-circuits before the global read. It is precedence
  coverage, not regression coverage, and says so in a comment rather than being quietly counted.
- Loops 1-6 repeatedly confirmed a **pre-existing, non-crashing** type-lie left untouched: the
  normalizer's undefined-stripping is shallow, so an own-undefined member of the nested
  `prCreationDefaults` would survive and contradict the declared
  `Required<SourceControlAiPrCreationDefaults>`. All four members are booleans, no `.trim()` is at
  risk, and no writer produces that shape. Deliberately **not** fixed here — it would widen this
  PR's blast radius for a defect with no reachable symptom.
