### PR TITLE
fix(crash-reporting): let a late sibling amend withdraw the attribution it disproves

### DIFF
--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -9,6 +9,7 @@ import {
   sanitizeCrashReportBreadcrumbs,
   sanitizeCrashReportDetails,
   type CrashReportCreateInput,
+  type CrashReportDetailValue,
   type CrashReportRecord,
   type CrashReportStatus
 } from '../../shared/crash-reporting'
@@ -37,6 +38,26 @@ function isRelatedCrashEvent(anchor: CrashReportRecord, candidate: CrashReportRe
     anchor.appVersion === candidate.appVersion &&
     anchor.platform === candidate.platform
   )
+}
+
+/**
+ * Applies an amend. A `null` value WITHDRAWS the key rather than storing it — see
+ * `attachDetails`. Nothing emits a null detail as data, and `record` never routes
+ * through here, so the initial write can still store one if a producer ever needs it.
+ */
+function mergeCrashReportDetails(
+  details: Record<string, CrashReportDetailValue>,
+  extraDetails: Record<string, unknown>
+): Record<string, CrashReportDetailValue> {
+  const merged = { ...details }
+  for (const [key, value] of Object.entries(sanitizeCrashReportDetails(extraDetails))) {
+    if (value === null) {
+      delete merged[key]
+    } else {
+      merged[key] = value
+    }
+  }
+  return merged
 }
 
 function isRetryableWindowsFileOperationError(error: unknown): boolean {
@@ -111,6 +132,11 @@ export class CrashReportStore {
    * Merges late-arriving details into an existing report. Crashpad finishes
    * writing the minidump after the process-gone event that created the record,
    * so the signature can only be folded in afterwards.
+   *
+   * A `null` value withdraws the key instead of storing it: an amend can also disprove a
+   * label the first write made on partial evidence, and a merge alone could never take one
+   * back (report 11a9d459 kept a one-incident sibling attribution beside the repeat count
+   * that contradicted it).
    */
   async attachDetails(
     id: string,
@@ -122,10 +148,7 @@ export class CrashReportStore {
         if (report.id !== id) {
           return report
         }
-        result = {
-          ...report,
-          details: { ...report.details, ...sanitizeCrashReportDetails(extraDetails) }
-        }
+        result = { ...report, details: mergeCrashReportDetails(report.details, extraDetails) }
         return result
       })
       return { reports: nextReports, result }

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -44,6 +44,7 @@ function isRelatedCrashEvent(anchor: CrashReportRecord, candidate: CrashReportRe
  * Applies an amend. A `null` value WITHDRAWS the key rather than storing it — see
  * `attachDetails`. Nothing emits a null detail as data, and `record` never routes
  * through here, so the initial write can still store one if a producer ever needs it.
+ * `undefined` is not a withdrawal: sanitize drops it and the stored key survives.
  */
 function mergeCrashReportDetails(
   details: Record<string, CrashReportDetailValue>,

--- a/src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts
+++ b/src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts
@@ -1,0 +1,229 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '1.4.199-test',
+    getAppMetrics: () => [],
+    getPath: () => os.tmpdir()
+  }
+}))
+
+import { CrashReportStore } from './crash-report-store'
+import { clearCrashBreadcrumbsForTest } from './crash-breadcrumb-store'
+import { ProcessGoneDedupe } from './process-gone-dedupe'
+import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
+import {
+  collectLateSiblingAttributions,
+  resetProcessGoneSiblingCorrelationForTest,
+  trackRendererCrashReport,
+  type ChildProcessDeath
+} from './process-gone-sibling-correlation'
+import { _resetTracerForTests } from '../observability/tracer'
+
+// Field shape: crash report 11a9d459 (v1.4.199, win32 10.0.19045), renderer
+// crashed/-2147483645 (0x80000003) with a GPU process crash-looping at -17ms / +14ms / +61ms.
+const BREAKPOINT_EXIT = -2_147_483_645
+const GONE_AT = 1_789_021_889_062
+
+const noMinidump = async () => null
+const originalPlatform = process.platform
+
+function gpuChildCrash(): ProcessGoneCrashEvent {
+  return {
+    source: 'child',
+    processType: 'GPU',
+    reason: 'crashed',
+    exitCode: BREAKPOINT_EXIT,
+    expectedTeardown: 'none',
+    details: { serviceName: 'GPU', type: 'GPU' }
+  }
+}
+
+function networkServiceCrash(): ProcessGoneCrashEvent {
+  return {
+    source: 'child',
+    processType: 'Utility',
+    reason: 'crashed',
+    exitCode: BREAKPOINT_EXIT,
+    expectedTeardown: 'none',
+    details: { serviceName: 'network.mojom.NetworkService', type: 'Utility' }
+  }
+}
+
+function rendererCrash(): ProcessGoneCrashEvent {
+  return {
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'crashed',
+    exitCode: BREAKPOINT_EXIT,
+    expectedTeardown: 'none',
+    details: { processType: 'renderer' },
+    webContentsId: 1
+  }
+}
+
+/** The amend is fire-and-forget behind two real file writes, so poll the stored document. */
+async function rendererDetails(
+  store: CrashReportStore,
+  expectedSiblingCount: number
+): Promise<Record<string, unknown>> {
+  return vi.waitFor(async () => {
+    const [report] = await store.listRecent()
+    expect(report?.details.siblingProcessDeathCount).toBe(expectedSiblingCount)
+    return report.details
+  })
+}
+
+describe('sibling attribution withdrawal', () => {
+  let directory: string
+  let store: CrashReportStore
+
+  beforeEach(async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'orca-sibling-attr-'))
+    store = new CrashReportStore(path.join(directory, 'crash-reports.json'))
+    resetProcessGoneSiblingCorrelationForTest()
+    clearCrashBreadcrumbsForTest()
+    _resetTracerForTests()
+  })
+
+  afterEach(async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    vi.restoreAllMocks()
+    resetProcessGoneSiblingCorrelationForTest()
+    clearCrashBreadcrumbsForTest()
+    _resetTracerForTests()
+    await fs.rm(directory, { recursive: true, force: true })
+  })
+
+  it('drops crashAttribution once a repeating sibling identity disqualifies it', async () => {
+    const dedupe = new ProcessGoneDedupe()
+    const now = vi.spyOn(Date, 'now')
+
+    now.mockReturnValue(GONE_AT - 17)
+    recordProcessGoneCrash(store, gpuChildCrash(), dedupe, noMinidump)
+
+    now.mockReturnValue(GONE_AT)
+    recordProcessGoneCrash(store, rendererCrash(), dedupe, noMinidump)
+
+    // Same GPU identity dies twice more: a crash-looping child, which
+    // isOneIncident() explicitly refuses to call concurrent-process-deaths.
+    now.mockReturnValue(GONE_AT + 14)
+    recordProcessGoneCrash(store, gpuChildCrash(), dedupe, noMinidump)
+    now.mockReturnValue(GONE_AT + 61)
+    recordProcessGoneCrash(store, gpuChildCrash(), dedupe, noMinidump)
+
+    const details = await rendererDetails(store, 3)
+    expect(details.siblingProcessDeathRepeats).toBe(2)
+    expect(details.siblingProcessDeaths).toBe('GPU +14ms, GPU -17ms, GPU +61ms')
+    expect(details).not.toHaveProperty('crashAttribution')
+  })
+
+  it('keeps the label when a second distinct sibling leaves the incident intact', async () => {
+    const dedupe = new ProcessGoneDedupe()
+    const now = vi.spyOn(Date, 'now')
+
+    now.mockReturnValue(GONE_AT - 17)
+    recordProcessGoneCrash(store, gpuChildCrash(), dedupe, noMinidump)
+    now.mockReturnValue(GONE_AT)
+    recordProcessGoneCrash(store, rendererCrash(), dedupe, noMinidump)
+    now.mockReturnValue(GONE_AT + 14)
+    recordProcessGoneCrash(store, networkServiceCrash(), dedupe, noMinidump)
+
+    const details = await rendererDetails(store, 2)
+    expect(details.siblingProcessDeathRepeats).toBeUndefined()
+    expect(details.crashAttribution).toBe('concurrent-process-deaths')
+  })
+
+  it('withdraws only the disproved key and leaves the rest of the report intact', async () => {
+    const recorded = await store.record({
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: BREAKPOINT_EXIT,
+      appVersion: '1.4.199-test',
+      platform: 'win32',
+      osRelease: '10.0.19045',
+      arch: 'x64',
+      electronVersion: '38.0.0',
+      chromeVersion: '140.0.0.0',
+      details: { crashAttribution: 'concurrent-process-deaths', minidumpStatus: 'captured' }
+    })
+
+    const amended = await store.attachDetails(recorded.id, {
+      crashAttribution: null,
+      siblingProcessDeathRepeats: 2
+    })
+
+    expect(amended?.details).toEqual({
+      minidumpStatus: 'captured',
+      siblingProcessDeathRepeats: 2
+    })
+    // Withdrawal must survive the round trip, not just the in-memory result.
+    const [persisted] = await store.listRecent()
+    expect(persisted.details).not.toHaveProperty('crashAttribution')
+  })
+})
+
+/**
+ * The amend is fire-and-forget: `attachAttribution` logs a failed write and moves on. A
+ * withdrawal that never reached the file has to stay owed, or the Windows retry ladder
+ * exhausting once (EPERM/EBUSY) ships the stale label the amend existed to take back.
+ */
+describe('a withdrawal amend whose write never lands', () => {
+  const gpuDeath = (at: number): ChildProcessDeath => ({
+    at,
+    processType: 'GPU',
+    serviceName: 'GPU',
+    reason: 'crashed',
+    exitCode: BREAKPOINT_EXIT
+  })
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    resetProcessGoneSiblingCorrelationForTest()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    resetProcessGoneSiblingCorrelationForTest()
+  })
+
+  it('re-emits it on the next late sibling instead of reporting it withdrawn', () => {
+    trackRendererCrashReport(
+      {
+        at: GONE_AT,
+        reason: 'crashed',
+        exitCode: BREAKPOINT_EXIT,
+        attachAttribution: () => {
+          throw new Error('the amend is fire-and-forget; this write is dropped')
+        }
+      },
+      [gpuDeath(GONE_AT - 17)]
+    )
+
+    const [dropped] = collectLateSiblingAttributions(gpuDeath(GONE_AT + 14))
+    expect(dropped.attribution.crashAttribution).toBeNull()
+    const [retried] = collectLateSiblingAttributions(gpuDeath(GONE_AT + 61))
+    expect(retried.attribution.crashAttribution).toBeNull()
+  })
+
+  it('never withdraws a label the report was never given', () => {
+    trackRendererCrashReport(
+      {
+        at: GONE_AT,
+        reason: 'crashed',
+        exitCode: BREAKPOINT_EXIT,
+        attachAttribution: () => {}
+      },
+      // -900ms is in-window but too loose to attribute, so nothing was ever written.
+      [gpuDeath(GONE_AT - 900)]
+    )
+
+    const [attribution] = collectLateSiblingAttributions(gpuDeath(GONE_AT + 14))
+    expect(attribution.attribution).not.toHaveProperty('crashAttribution')
+  })
+})

--- a/src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts
+++ b/src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts
@@ -71,9 +71,11 @@ async function rendererDetails(
   expectedSiblingCount: number
 ): Promise<Record<string, unknown>> {
   return vi.waitFor(async () => {
-    const [report] = await store.listRecent()
+    // By source, not position: a recorded child report would otherwise head the list and
+    // make this poll time out instead of fail.
+    const report = (await store.listRecent()).find((candidate) => candidate.source === 'renderer')
     expect(report?.details.siblingProcessDeathCount).toBe(expectedSiblingCount)
-    return report.details
+    return report!.details
   })
 }
 

--- a/src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts
+++ b/src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts
@@ -16,17 +16,23 @@ import { clearCrashBreadcrumbsForTest } from './crash-breadcrumb-store'
 import { ProcessGoneDedupe } from './process-gone-dedupe'
 import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
 import {
+  correlateChildProcessDeath,
+  trackRendererSiblingAttribution
+} from './process-gone-sibling-attribution'
+import {
   collectLateSiblingAttributions,
   resetProcessGoneSiblingCorrelationForTest,
   trackRendererCrashReport,
   type ChildProcessDeath
 } from './process-gone-sibling-correlation'
 import { _resetTracerForTests } from '../observability/tracer'
+import type { CrashReportCreateInput } from '../../shared/crash-reporting'
 
 // Field shape: crash report 11a9d459 (v1.4.199, win32 10.0.19045), renderer
 // crashed/-2147483645 (0x80000003) with a GPU process crash-looping at -17ms / +14ms / +61ms.
 const BREAKPOINT_EXIT = -2_147_483_645
 const GONE_AT = 1_789_021_889_062
+const CONCURRENT = 'concurrent-process-deaths'
 
 const noMinidump = async () => null
 const originalPlatform = process.platform
@@ -65,11 +71,55 @@ function rendererCrash(): ProcessGoneCrashEvent {
   }
 }
 
+function gpuDeath(at: number): ChildProcessDeath {
+  return {
+    at,
+    processType: 'GPU',
+    serviceName: 'GPU',
+    reason: 'crashed',
+    exitCode: BREAKPOINT_EXIT
+  }
+}
+
+function rendererReportInput(details: Record<string, unknown>): CrashReportCreateInput {
+  return {
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'crashed',
+    exitCode: BREAKPOINT_EXIT,
+    appVersion: '1.4.199-test',
+    platform: 'win32',
+    osRelease: '10.0.19045',
+    arch: 'x64',
+    electronVersion: '38.0.0',
+    chromeVersion: '140.0.0.0',
+    details
+  }
+}
+
+let directory: string
+let store: CrashReportStore
+
+beforeEach(async () => {
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  directory = await fs.mkdtemp(path.join(os.tmpdir(), 'orca-sibling-attr-'))
+  store = new CrashReportStore(path.join(directory, 'crash-reports.json'))
+  resetProcessGoneSiblingCorrelationForTest()
+  clearCrashBreadcrumbsForTest()
+  _resetTracerForTests()
+})
+
+afterEach(async () => {
+  Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+  vi.restoreAllMocks()
+  resetProcessGoneSiblingCorrelationForTest()
+  clearCrashBreadcrumbsForTest()
+  _resetTracerForTests()
+  await fs.rm(directory, { recursive: true, force: true })
+})
+
 /** The amend is fire-and-forget behind two real file writes, so poll the stored document. */
-async function rendererDetails(
-  store: CrashReportStore,
-  expectedSiblingCount: number
-): Promise<Record<string, unknown>> {
+async function rendererDetails(expectedSiblingCount: number): Promise<Record<string, unknown>> {
   return vi.waitFor(async () => {
     // By source, not position: a recorded child report would otherwise head the list and
     // make this poll time out instead of fail.
@@ -80,27 +130,6 @@ async function rendererDetails(
 }
 
 describe('sibling attribution withdrawal', () => {
-  let directory: string
-  let store: CrashReportStore
-
-  beforeEach(async () => {
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
-    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'orca-sibling-attr-'))
-    store = new CrashReportStore(path.join(directory, 'crash-reports.json'))
-    resetProcessGoneSiblingCorrelationForTest()
-    clearCrashBreadcrumbsForTest()
-    _resetTracerForTests()
-  })
-
-  afterEach(async () => {
-    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
-    vi.restoreAllMocks()
-    resetProcessGoneSiblingCorrelationForTest()
-    clearCrashBreadcrumbsForTest()
-    _resetTracerForTests()
-    await fs.rm(directory, { recursive: true, force: true })
-  })
-
   it('drops crashAttribution once a repeating sibling identity disqualifies it', async () => {
     const dedupe = new ProcessGoneDedupe()
     const now = vi.spyOn(Date, 'now')
@@ -118,7 +147,7 @@ describe('sibling attribution withdrawal', () => {
     now.mockReturnValue(GONE_AT + 61)
     recordProcessGoneCrash(store, gpuChildCrash(), dedupe, noMinidump)
 
-    const details = await rendererDetails(store, 3)
+    const details = await rendererDetails(3)
     expect(details.siblingProcessDeathRepeats).toBe(2)
     expect(details.siblingProcessDeaths).toBe('GPU +14ms, GPU -17ms, GPU +61ms')
     expect(details).not.toHaveProperty('crashAttribution')
@@ -135,25 +164,15 @@ describe('sibling attribution withdrawal', () => {
     now.mockReturnValue(GONE_AT + 14)
     recordProcessGoneCrash(store, networkServiceCrash(), dedupe, noMinidump)
 
-    const details = await rendererDetails(store, 2)
+    const details = await rendererDetails(2)
     expect(details.siblingProcessDeathRepeats).toBeUndefined()
-    expect(details.crashAttribution).toBe('concurrent-process-deaths')
+    expect(details.crashAttribution).toBe(CONCURRENT)
   })
 
   it('withdraws only the disproved key and leaves the rest of the report intact', async () => {
-    const recorded = await store.record({
-      source: 'renderer',
-      processType: 'renderer',
-      reason: 'crashed',
-      exitCode: BREAKPOINT_EXIT,
-      appVersion: '1.4.199-test',
-      platform: 'win32',
-      osRelease: '10.0.19045',
-      arch: 'x64',
-      electronVersion: '38.0.0',
-      chromeVersion: '140.0.0.0',
-      details: { crashAttribution: 'concurrent-process-deaths', minidumpStatus: 'captured' }
-    })
+    const recorded = await store.record(
+      rendererReportInput({ crashAttribution: CONCURRENT, minidumpStatus: 'captured' })
+    )
 
     const amended = await store.attachDetails(recorded.id, {
       crashAttribution: null,
@@ -171,46 +190,42 @@ describe('sibling attribution withdrawal', () => {
 })
 
 /**
- * The amend is fire-and-forget: `attachAttribution` logs a failed write and moves on. A
- * withdrawal that never reached the file has to stay owed, or the Windows retry ladder
+ * The amend is fire-and-forget: `siblingAttributionAttacher` logs a failed write and moves
+ * on. A withdrawal that never reached the file has to stay owed, or the Windows retry ladder
  * exhausting once (EPERM/EBUSY) ships the stale label the amend existed to take back.
  */
 describe('a withdrawal amend whose write never lands', () => {
-  const gpuDeath = (at: number): ChildProcessDeath => ({
-    at,
-    processType: 'GPU',
-    serviceName: 'GPU',
-    reason: 'crashed',
-    exitCode: BREAKPOINT_EXIT
-  })
+  it('re-emits it on the next late sibling until the report loses the label', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const recorded = await store.record(
+      rendererReportInput({ crashAttribution: CONCURRENT, siblingProcessDeathCount: 1 })
+    )
+    const attachDetails = vi
+      .fn<(reportId: string, details: Record<string, unknown>) => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('EBUSY'))
+      .mockImplementation((reportId, details) => store.attachDetails(reportId, details))
 
-  beforeEach(() => {
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
-    resetProcessGoneSiblingCorrelationForTest()
-  })
-
-  afterEach(() => {
-    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
-    resetProcessGoneSiblingCorrelationForTest()
-  })
-
-  it('re-emits it on the next late sibling instead of reporting it withdrawn', () => {
-    trackRendererCrashReport(
-      {
-        at: GONE_AT,
-        reason: 'crashed',
-        exitCode: BREAKPOINT_EXIT,
-        attachAttribution: () => {
-          throw new Error('the amend is fire-and-forget; this write is dropped')
-        }
-      },
-      [gpuDeath(GONE_AT - 17)]
+    trackRendererSiblingAttribution(
+      { source: 'renderer', reason: 'crashed', exitCode: BREAKPOINT_EXIT },
+      GONE_AT,
+      [gpuDeath(GONE_AT - 17)],
+      attachDetails,
+      Promise.resolve(recorded),
+      { source: 'renderer', processType: 'renderer', reason: 'crashed', exitCode: BREAKPOINT_EXIT }
     )
 
-    const [dropped] = collectLateSiblingAttributions(gpuDeath(GONE_AT + 14))
-    expect(dropped.attribution.crashAttribution).toBeNull()
-    const [retried] = collectLateSiblingAttributions(gpuDeath(GONE_AT + 61))
-    expect(retried.attribution.crashAttribution).toBeNull()
+    correlateChildProcessDeath(gpuDeath(GONE_AT + 14))
+    correlateChildProcessDeath(gpuDeath(GONE_AT + 61))
+
+    await vi.waitFor(async () => {
+      const [persisted] = await store.listRecent()
+      expect(persisted.details).not.toHaveProperty('crashAttribution')
+    })
+    // Both amends carry it: the first was dropped, so the second still owes the withdrawal.
+    expect(attachDetails.mock.calls.map(([, details]) => details.crashAttribution)).toEqual([
+      null,
+      null
+    ])
   })
 
   it('never withdraws a label the report was never given', () => {

--- a/src/main/crash-reporting/process-gone-sibling-correlation.test.ts
+++ b/src/main/crash-reporting/process-gone-sibling-correlation.test.ts
@@ -215,7 +215,8 @@ describe('sibling process-death attribution', () => {
     await vi.waitFor(() => expect(siblingAttaches(store)).toHaveLength(2))
     expect(siblingAttaches(store)[0]).toMatchObject({ crashAttribution: CONCURRENT })
     expect(siblingAttaches(store)[1]).toMatchObject({ siblingProcessDeathRepeats: 1 })
-    expect(siblingAttaches(store)[1]).not.toHaveProperty('crashAttribution')
+    // Null withdraws the label the first attach wrote: a merge alone can never take it back.
+    expect(siblingAttaches(store)[1]).toMatchObject({ crashAttribution: null })
   })
 
   it('does not erase recorded sibling evidence during unrelated child churn', async () => {

--- a/src/main/crash-reporting/process-gone-sibling-correlation.ts
+++ b/src/main/crash-reporting/process-gone-sibling-correlation.ts
@@ -69,6 +69,12 @@ export type PendingRendererCrashReport = {
 type TrackedRendererCrashReport = PendingRendererCrashReport & {
   siblingDeaths: ChildProcessDeath[]
   lateAttaches: number
+  /**
+   * Whether the one-incident label may still be on the persisted report. Sticky once set:
+   * the amend that withdraws it is fire-and-forget, so a failed write must leave the next
+   * amend still trying rather than treating the label as already gone.
+   */
+  attributedOneIncident: boolean
 }
 
 export type LateSiblingAttribution = {
@@ -135,7 +141,12 @@ export function trackRendererCrashReport(
     .slice(-(MAX_PENDING_RENDERER_REPORTS - 1))
   pendingRendererReports = [
     ...liveReports,
-    { ...pending, siblingDeaths: [...siblingDeaths], lateAttaches: 0 }
+    {
+      ...pending,
+      siblingDeaths: [...siblingDeaths],
+      lateAttaches: 0,
+      attributedOneIncident: isOneIncident(siblingDeaths, pending.at)
+    }
   ]
 }
 
@@ -181,13 +192,22 @@ function isOneIncident(siblings: ChildProcessDeath[], rendererAt: number): boole
   )
 }
 
+/**
+ * `withdrawStaleAttribution` is for an amend onto a report that already carries the label:
+ * attachDetails merges, so evidence that disproves one incident (report 11a9d459 shipped
+ * `crashAttribution=concurrent-process-deaths` beside `siblingProcessDeathRepeats=2`) has
+ * to say so explicitly. A null detail value withdraws the key.
+ */
 export function siblingProcessDeathDetails(
   siblings: ChildProcessDeath[],
-  rendererAt: number
+  rendererAt: number,
+  { withdrawStaleAttribution = false }: { withdrawStaleAttribution?: boolean } = {}
 ): Record<string, CrashReportDetailValue> {
   const repeats = repeatedIdentityCount(siblings)
+  const oneIncident = isOneIncident(siblings, rendererAt)
   return {
-    ...(isOneIncident(siblings, rendererAt) ? { crashAttribution: CONCURRENT_PROCESS_DEATHS } : {}),
+    ...(oneIncident ? { crashAttribution: CONCURRENT_PROCESS_DEATHS } : {}),
+    ...(!oneIncident && withdrawStaleAttribution ? { crashAttribution: null } : {}),
     siblingProcessDeathCount: siblings.length,
     ...(repeats > 0 ? { siblingProcessDeathRepeats: repeats } : {}),
     siblingProcessDeaths: describeSiblingDeaths(siblings, rendererAt)
@@ -212,10 +232,11 @@ export function collectLateSiblingAttributions(death: ChildProcessDeath): LateSi
     }
     pending.siblingDeaths.push(death)
     pending.lateAttaches += 1
-    attributions.push({
-      pending,
-      attribution: siblingProcessDeathDetails(pending.siblingDeaths, pending.at)
+    const attribution = siblingProcessDeathDetails(pending.siblingDeaths, pending.at, {
+      withdrawStaleAttribution: pending.attributedOneIncident
     })
+    pending.attributedOneIncident ||= attribution.crashAttribution === CONCURRENT_PROCESS_DEATHS
+    attributions.push({ pending, attribution })
   }
   return attributions
 }


### PR DESCRIPTION
## What

On Windows, a crash-looping GPU child got filed as an environmental mass death. Report
`11a9d459-28a0-4420-9cf8-443f07a45efc` (**v1.4.199**, win32 10.0.19045, Slack ts
`1789021900.897679`) shipped `crashAttribution: concurrent-process-deaths` sitting right next to
`siblingProcessDeathRepeats: 2` — a pair the producer can never emit in one payload, because
`isOneIncident()` refuses to call a repeating sibling identity one incident. The wrong label sends
triage down the environmental path for what is actually an Orca-side crash loop. It is a generic
mislabel: it can stamp `concurrent-process-deaths` on any crash whose sibling set later turns out
to be a loop. It is the only report in this scan's 27 with that contradiction; the other 9 Windows
mass-death reports were genuinely environmental and correctly labelled.

## Fix evidence

### Root cause

`src/main/crash-reporting/process-gone-sibling-correlation.ts:196` (pre-fix) emitted the label as a
conditional spread:

```ts
...(isOneIncident(siblings, rendererAt) ? { crashAttribution: CONCURRENT_PROCESS_DEATHS } : {}),
```

When later evidence made `isOneIncident()` false the key was simply **omitted** from the late-attach
payload. That payload lands through `CrashReportStore.attachDetails`
(`src/main/crash-reporting/crash-report-store.ts:125`, pre-fix), which was a merge:

```ts
details: { ...report.details, ...sanitizeCrashReportDetails(extraDetails) }
```

Omission is not retraction. The label written by the initial `record()` survived every amend.

### Field evidence tying the code path to the report

From `1789021900.897679.diagnostics.ndjson`, the two writers, 13 ms apart, in the same report:

`electron.process_gone` span (the initial `record()`, ts `1789021889062000000`) —

```
"crashAttribution":"concurrent-process-deaths","siblingProcessDeathCount":1,"siblingProcessDeaths":"GPU -17ms"
```

`process_gone_sibling_attribution` breadcrumb (the late amend, ts `1789021889075000000`) —

```
"siblingProcessDeathCount":2,"siblingProcessDeathRepeats":1,"siblingProcessDeaths":"GPU +14ms, GPU -17ms"
```

The amend had already worked out that the label no longer held — there is **no** `crashAttribution`
key in it. That absence *was* the retraction, and the merge silently dropped it. The stored report
ends up at:

```
- crashAttribution: concurrent-process-deaths
- siblingProcessDeathCount: 3
- siblingProcessDeaths: GPU +14ms, GPU -17ms, GPU +61ms
- siblingProcessDeathRepeats: 2
```

The 0x80000003 / `STATUS_BREAKPOINT` shape is what lets the GPU deaths in as siblings at all: every
death, renderer included, carries `exitCode: -2147483645`, which is the equality
`hasMatchingFailureSignature` gates on for win32. The loop is visible in the breadcrumbs as
`process_gone_suppressed (processType=GPU, exitCode=-2147483645)` — and `correlateChildProcessDeath`
runs at `process-gone-recorder.ts:181`, **before** the `shouldRecordProcessGoneCrash` suppression at
`:192`, so a suppressed GPU CHECK loop still feeds the sibling ring.

### The fix

- `attachDetails` now merges through `mergeCrashReportDetails`, where a `null` value **withdraws**
  the key instead of storing it (`crash-report-store.ts`).
- `siblingProcessDeathDetails` takes `withdrawStaleAttribution` and emits `crashAttribution: null`
  when the accumulated set no longer supports the label.
- The tracked report carries `attributedOneIncident`, sticky once set. The amend is fire-and-forget
  (`siblingAttributionAttacher` logs a failed write and moves on), so a withdrawal whose write never
  landed stays owed and is re-emitted by the next late sibling.

### FAIL before — production files reverted to `origin/main`, tests untouched

`git checkout origin/main -- src/main/crash-reporting/crash-report-store.ts src/main/crash-reporting/process-gone-sibling-correlation.ts`

```
 RUN  v4.1.11 /Users/m4air/orca/orca/.claude/worktrees/wf_7f003f73-559-20

 ❯ src/main/crash-reporting/process-gone-sibling-correlation.test.ts (14 tests | 1 failed) 552ms
     × stops rewriting the report once a child starts looping 64ms
 ❯ src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts (5 tests | 3 failed) 1182ms
     × drops crashAttribution once a repeating sibling identity disqualifies it 83ms
     × withdraws only the disproved key and leaves the rest of the report intact 16ms
     × re-emits it on the next late sibling until the report loses the label 1010ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts > sibling attribution withdrawal > drops crashAttribution once a repeating sibling identity disqualifies it
AssertionError: expected { processType: 'renderer', …(20) } to not have property "crashAttribution"

- Expected:
undefined

+ Received:
"concurrent-process-deaths"

 ❯ src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts:153:25
    151|     expect(details.siblingProcessDeathRepeats).toBe(2)
    152|     expect(details.siblingProcessDeaths).toBe('GPU +14ms, GPU -17ms, G…
    153|     expect(details).not.toHaveProperty('crashAttribution')
       |                         ^
    154|   })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/4]⎯

 FAIL  … > withdraws only the disproved key and leaves the rest of the report intact
AssertionError: expected { crashAttribution: null, …(2) } to deeply equal { minidumpStatus: 'captured', …(1) }
 ❯ src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts:182:30

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/4]⎯

 FAIL  … > a withdrawal amend whose write never lands > re-emits it on the next late sibling until the report loses the label
AssertionError: expected { …(4) } to not have property "crashAttribution"

- Expected:
undefined

+ Received:
"concurrent-process-deaths"

 ❯ src/main/crash-reporting/process-gone-sibling-attribution-withdrawal.test.ts:222:37

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[3/4]⎯

 FAIL  src/main/crash-reporting/process-gone-sibling-correlation.test.ts > sibling process-death attribution > stops rewriting the report once a child starts looping
AssertionError: expected { siblingProcessDeathCount: 2, …(2) } to match object { crashAttribution: null }
(3 matching properties omitted from actual)

- Expected
+ Received

  {
-   "crashAttribution": null,
+   "siblingProcessDeathCount": 2,
+   "siblingProcessDeathRepeats": 1,
+   "siblingProcessDeaths": "Utility/network.mojom.NetworkService +1ms, Utility/network.mojom.NetworkService +2ms",
  }

 ❯ src/main/crash-reporting/process-gone-sibling-correlation.test.ts:219:39

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯

 Test Files  2 failed (2)
      Tests  4 failed | 15 passed (19)
```

The repro drives the **real** recorder to the exact field state — count 3, repeats 2,
`GPU +14ms, GPU -17ms, GPU +61ms`, exit code `-2147483645`, `process.platform` forced to `win32`.
The 15 that pass in both states include two deliberate over-withdrawal controls ("keeps the label
when a second *distinct* sibling leaves the incident intact", "never withdraws a label the report
was never given").

### PASS after — fix restored

```
 RUN  v4.1.11 /Users/m4air/orca/orca/.claude/worktrees/wf_7f003f73-559-20

 Test Files  2 passed (2)
      Tests  19 passed (19)
   Duration  1.11s
```

Full suite, `pnpm test src/main/crash-reporting src/shared/crash-reporting.test.ts`:

```
 Test Files  29 passed (29)
      Tests  312 passed (312)
```

`pnpm tc` — exit 0.

`pnpm run check:code-quality:changed`:

```
code quality: 0 new finding(s) across 4 changed file(s).
type-aware code quality: 0 new finding(s) across 4 changed file(s).
React Doctor: 0 new finding(s) across 4 changed file(s).
Changed-code quality gate passed since 2ecde717b456.
```

`git diff --stat origin/main...HEAD` is exactly the 4 intended files, nothing else.

## ELI5

When a renderer process dies, Orca looks at which other Electron child processes died around the
same moment. If exactly one other process died close by and nothing died twice, it writes a note on
the crash report: `concurrent-process-deaths` — meaning "these all went down together, probably the
machine, not us."

The catch is that more child processes can die a few milliseconds *after* the report is already
saved to disk. Orca folds those in with an amend. If the extra deaths reveal that the same GPU
process died three times, that is a crash **loop**, not one incident, and the note is wrong.

The amend correctly stopped including the note — but an amend is a merge, so leaving a key out
changes nothing. The old, wrong note just stayed on the report. Report `11a9d459` shipped "these
died together" right next to "the same process died 2 extra times", which contradict each other.

The fix: an amend can now send `crashAttribution: null`, and the store reads null as "delete this
key" rather than "store the value null". The late sibling code sends that null whenever the new
evidence disproves a label the report was already given. So the report retracts the bad verdict
instead of carrying it forever.

## Trade-offs

1. **Null is now an overloaded sentinel on `attachDetails(id, Record<string, unknown>)`.** I audited
   it and it collides with nothing today: the only three amend producers are
   `{ minidumpStatus: 'absent' }`, `minidumpSignatureDetails` (typed
   `Record<string, string | number>`, so TypeScript forbids null at that boundary), and this sibling
   attribution — none emits null as data, and `sanitizeCrashReportDetails`
   (`src/shared/crash-report-redaction.ts:75`) preserves null so the sentinel reaches the merge
   intact. I kept null rather than adding a separate `withdraw: string[]` parameter because it also
   makes the retraction **visible** in the `process_gone_sibling_attribution` breadcrumb
   (`crashAttribution=null`) — the field diagnostics were confusing precisely because the retraction
   was an invisible omission. **Cost:** a future amend producer that means "this value is unknown" by
   passing null would silently delete instead. Documented on both `attachDetails` and
   `mergeCrashReportDetails`. Note the asymmetry, also documented: `undefined` is **not** a
   withdrawal — sanitize drops it and the stored key survives.

2. **`record()` deliberately does not route through the merge**, so the initial write can still store
   a literal null if a producer ever wants one. The only thing stopping a null leaking into the
   initial write is `withdrawStaleAttribution` defaulting to `false` in `siblingProcessDeathDetails`.

3. **`attributedOneIncident` is sticky and never cleared.** The amend is fire-and-forget, so a
   withdrawal whose write is lost (Windows EPERM/EBUSY ladder exhausting) must stay owed.
   Consequence: once set, every later non-one-incident amend re-emits the withdrawal even if the
   first one landed. That is a harmless no-op (deleting an absent key) and is the safe direction.

4. **Residual hole left unchanged** (pre-existing, byte-identical before and after this fix):
   `MAX_LATE_SIBLING_ATTACHES = 2` caps how many late deaths are folded in at all. If the first two
   late siblings are distinct and the third is the repeat, the repeat is never recorded and the label
   survives. I did not widen the budget — it exists to stop a child looping at 1459/min from
   rewriting the record continuously, and in that case the stored report stays *self-consistent* (no
   repeat count shown) rather than self-contradictory, which is the actual triage failure being
   fixed. Re-tuning a deliberately-chosen flood guard is a new risk outside this fix.

5. **`hasMatchingFailureSignature` still gates win32 siblings on exact exit-code equality.** A GPU
   loop whose iterations exit with *different* codes is never admitted as a sibling at all, so it
   cannot trigger a withdrawal. Widening that gate is a separate behaviour change and out of scope.

6. **Breadcrumb text change.** The `process_gone_sibling_attribution` breadcrumb now renders
   `crashAttribution=null` where the key used to be absent. That is intentional (see 1), but it is a
   visible change in the crash report's "Recent activity" text.

## Adversarial review

**4 loops run.** No blocking defect was ever found in the production change; all three changes across
the four loops were to tests and comments.

- **Loop 1 — found nothing blocking; changed one test.** Audited the three questions the fix raises:
  null cannot collide with a legitimate detail value (three `attachDetails` call sites, none able to
  emit null; `record()` bypasses the merge); `sanitizeCrashReportDetails` *does* preserve null
  (`crash-report-redaction.ts:75`), and that preservation is itself now test-covered, so tightening
  sanitize later fails a test rather than silently resurrecting the bug; and the withdrawal *does*
  fire on the 0x80000003 path because child correlation runs before suppression in the recorder.
  **Change:** the withdrawal poll took the renderer report by list position (`const [report] = await
  store.listRecent()`), and `record()` prepends — so if child-crash suppression ever changed, the
  test would spin to its `vi.waitFor` timeout instead of failing the assertion. It now selects by
  `source === 'renderer'`.

- **Loop 2 — found one real test defect; fixed it.** The describe block "a withdrawal amend whose
  write never lands" supplied a throwing `attachAttribution`, but `collectLateSiblingAttributions()`
  — the only function the test called — never invokes it. The throw was dead code, so the test named
  for a dropped write exercised neither a dropped write nor `siblingAttributionAttacher`'s catch
  path, while advertising both. Rewritten end-to-end: it now records the label into a real
  `CrashReportStore`, wires an `attachDetails` that rejects once with `EBUSY` and then delegates to
  the real store, drives two `correlateChildProcessDeath()` calls, and asserts the persisted document
  ends with no `crashAttribution` and that both amends carried `crashAttribution: null`. Loop 2 also
  ran the revert-and-rerun itself (4 fail / 15 pass) rather than trusting loop 1.

- **Loop 3 — clean, no changes.** Re-derived every claim from source and re-ran fail-before /
  pass-after independently. Additionally checked the prototype-key hazard in the new merge
  (`merged[key] = value` goes through the `Object.prototype` setter where the old spread wrote an own
  `__proto__`; unreachable, every key is a fixed literal, and the new form is the safer of the two)
  and write ordering (`withWrite` claims `this.writeChain` synchronously, so amends serialize in
  registration order). Also rebased onto the then-current `origin/main` to prove the change was not
  stale.

- **Loop 4 — clean; one comment-only edit.** Ran four adversarial probes through the real recorder
  that no earlier loop had run. Three cleared: repeats-at-record-time never labels; a later minidump
  amend cannot resurrect a withdrawn key; `undefined` silently no-ops. The fourth surfaced the
  residual `MAX_LATE_SIBLING_ATTACHES` hole — pre-existing, unchanged by this fix, and now disclosed
  as trade-off 4 rather than left inside an "airtight" claim. **Change:** one line added to the
  `mergeCrashReportDetails` doc block stating that `undefined` is not a withdrawal.

**Final verdict: ship.** The fix addresses the root cause — a merge-only amend could never retract a
label the first write made on partial evidence — not the symptom the repro pins. The exact reported
contradiction is now structurally unreachable, not merely test-pinned: `isOneIncident` can only flip
true→false as siblings accumulate (`repeatedIdentityCount` is monotone non-decreasing, the proximity
`some()` is monotone non-decreasing), evidence and withdrawal travel in the *same* payload so
"label + repeats" cannot be assembled across two amends, and the sticky `attributedOneIncident` flag
is seeded from the identical inputs the initial record used. `crashAttribution` has exactly two
writers in the tree and both set the flag. Not a wire surface — no crash-report type appears in
`src/shared/rpc-contract/`, every consumer is `src/main/ipc/crash-reporting*.ts` or the renderer
dialog, and `CrashReportDetailValue` already admitted `null`. No platform-conditional code added;
both the win32 and POSIX branches are covered by tests.
