### PR TITLE
Fix remote hosted review browser routing

### DIFF
--- a/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.test.ts
@@ -54,8 +54,7 @@ describe('checks panel hosted review click routing', () => {
       url: 'https://github.com/acme/widgets/pull/123',
       event: { metaKey: false, ctrlKey: false, shiftKey: false },
       isMac: true,
-      worktreeId: 'wt-1',
-      allowRemoteInApp: true
+      worktreeId: 'wt-1'
     })
 
     expect(openHttpLinkMock).toHaveBeenCalledWith('https://github.com/acme/widgets/pull/123', {
@@ -69,8 +68,7 @@ describe('checks panel hosted review click routing', () => {
       url: 'https://github.com/acme/widgets/pull/123',
       event: { metaKey: true, ctrlKey: false, shiftKey: true },
       isMac: true,
-      worktreeId: 'wt-1',
-      allowRemoteInApp: true
+      worktreeId: 'wt-1'
     })
 
     expect(openHttpLinkMock).toHaveBeenCalledWith('https://github.com/acme/widgets/pull/123', {
@@ -132,8 +130,6 @@ describe('checks panel hosted review modifier hint destination', () => {
     ).toBe('orca')
   })
 
-  // Why: openHttpLink trims before treating a runtime as active, so a blank id must
-  // not suppress a hint for a click that still reaches Orca.
   it('ignores a blank runtime id', () => {
     expect(
       resolveChecksPanelHostedReviewModifierDestination(

--- a/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.test.ts
@@ -23,6 +23,7 @@ describe('checks panel hosted review click routing', () => {
     expect(isChecksPanelHostedReviewSystemBrowserModifier(event, true)).toBe(true)
     expect(resolveChecksPanelHostedReviewHttpOpenOptions(event, true, 'wt-1')).toEqual({
       worktreeId: 'wt-1',
+      allowRemoteInApp: true,
       modifierHeld: true
     })
   })
@@ -33,6 +34,7 @@ describe('checks panel hosted review click routing', () => {
     expect(isChecksPanelHostedReviewSystemBrowserModifier(event, false)).toBe(true)
     expect(resolveChecksPanelHostedReviewHttpOpenOptions(event, false, 'wt-1')).toEqual({
       worktreeId: 'wt-1',
+      allowRemoteInApp: true,
       modifierHeld: true
     })
   })
@@ -44,7 +46,7 @@ describe('checks panel hosted review click routing', () => {
         true,
         'wt-1'
       )
-    ).toEqual({ worktreeId: 'wt-1' })
+    ).toEqual({ worktreeId: 'wt-1', allowRemoteInApp: true })
   })
 
   it('opens hosted review URLs without the modifier on plain clicks', () => {
@@ -52,11 +54,13 @@ describe('checks panel hosted review click routing', () => {
       url: 'https://github.com/acme/widgets/pull/123',
       event: { metaKey: false, ctrlKey: false, shiftKey: false },
       isMac: true,
-      worktreeId: 'wt-1'
+      worktreeId: 'wt-1',
+      allowRemoteInApp: true
     })
 
     expect(openHttpLinkMock).toHaveBeenCalledWith('https://github.com/acme/widgets/pull/123', {
-      worktreeId: 'wt-1'
+      worktreeId: 'wt-1',
+      allowRemoteInApp: true
     })
   })
 
@@ -65,11 +69,13 @@ describe('checks panel hosted review click routing', () => {
       url: 'https://github.com/acme/widgets/pull/123',
       event: { metaKey: true, ctrlKey: false, shiftKey: true },
       isMac: true,
-      worktreeId: 'wt-1'
+      worktreeId: 'wt-1',
+      allowRemoteInApp: true
     })
 
     expect(openHttpLinkMock).toHaveBeenCalledWith('https://github.com/acme/widgets/pull/123', {
       worktreeId: 'wt-1',
+      allowRemoteInApp: true,
       modifierHeld: true
     })
   })

--- a/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.test.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.test.ts
@@ -117,25 +117,19 @@ describe('checks panel hosted review modifier hint destination', () => {
     expect(resolveChecksPanelHostedReviewModifierDestination(null, true)).toBeNull()
   })
 
-  // Why: openHttpLink refuses to route a remote-owned link into Orca, and openLinksInApp
-  // cannot apply there either, so neither destination is reachable.
-  it('stays silent while a remote runtime is active', () => {
+  it('resolves modifier destinations for remote runtimes', () => {
     expect(
       resolveChecksPanelHostedReviewModifierDestination(
         { openLinksInApp: true, activeRuntimeEnvironmentId: 'remote-1' },
         true
       )
-    ).toBeNull()
+    ).toBe('system-browser')
     expect(
       resolveChecksPanelHostedReviewModifierDestination(
-        {
-          openLinksInApp: false,
-          openLinksInAppModifierInverts: true,
-          activeRuntimeEnvironmentId: 'remote-1'
-        },
+        { openLinksInAppModifierInverts: true, activeRuntimeEnvironmentId: 'remote-1' },
         true
       )
-    ).toBeNull()
+    ).toBe('orca')
   })
 
   // Why: openHttpLink trims before treating a runtime as active, so a blank id must

--- a/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.ts
@@ -40,7 +40,7 @@ export function resolveChecksPanelHostedReviewModifierDestination(
 ): ChecksPanelHostedReviewModifierDestination {
   // Why: trim to match openHttpLink — an untrimmed check hides the hint on a blank
   // runtime id while the click still routes to Orca.
-  if (!hasWorktree || settings?.activeRuntimeEnvironmentId?.trim()) {
+  if (!hasWorktree) {
     return null
   }
   if (settings?.openLinksInApp === true) {

--- a/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.ts
@@ -38,8 +38,6 @@ export function resolveChecksPanelHostedReviewModifierDestination(
     | undefined,
   hasWorktree: boolean
 ): ChecksPanelHostedReviewModifierDestination {
-  // Why: trim to match openHttpLink — an untrimmed check hides the hint on a blank
-  // runtime id while the click still routes to Orca.
   if (!hasWorktree) {
     return null
   }

--- a/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-hosted-review-click-routing.ts
@@ -17,9 +17,9 @@ export function resolveChecksPanelHostedReviewHttpOpenOptions(
   // Why: same escape hatch as terminal and markdown links — openHttpLink resolves
   // whether it forces the system browser or inverts the Link Routing setting.
   if (isChecksPanelHostedReviewSystemBrowserModifier(event, isMac)) {
-    return { worktreeId, modifierHeld: true }
+    return { worktreeId, allowRemoteInApp: true, modifierHeld: true }
   }
-  return { worktreeId }
+  return { worktreeId, allowRemoteInApp: true }
 }
 
 /** Where a Shift+modifier click lands, or null when it lands where a plain click already does. */

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -139,6 +139,21 @@ describe('openHttpLink', () => {
     expect(createBrowserTabMock).not.toHaveBeenCalled()
   })
 
+  it('keeps explicitly local links local while a remote runtime is active', () => {
+    storeState.settings = { openLinksInApp: true, activeRuntimeEnvironmentId: 'remote-1' }
+
+    openHttpLink('https://example.com/', {
+      worktreeId: 'wt-1',
+      allowRemoteInApp: true,
+      sourceOwner: { kind: 'local' }
+    })
+
+    expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/', {
+      activate: true
+    })
+    expect(openRuntimeBrowserTabMock).not.toHaveBeenCalled()
+  })
+
   it('routes opted-in links without a source owner through the active runtime', () => {
     storeState.settings = {
       openLinksInApp: true,

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -153,8 +153,7 @@ describe('openHttpLink', () => {
     expect(openRuntimeBrowserTabMock).toHaveBeenCalledExactlyOnceWith({
       workspaceId: 'wt-1',
       url: 'https://github.com/acme/widgets/pull/123',
-      intent: { kind: 'url' },
-      expectedRuntimeEnvironmentId: 'remote-1'
+      intent: { kind: 'url' }
     })
     expect(createBrowserTabMock).not.toHaveBeenCalled()
     expect(openUrlMock).not.toHaveBeenCalled()

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -139,6 +139,27 @@ describe('openHttpLink', () => {
     expect(createBrowserTabMock).not.toHaveBeenCalled()
   })
 
+  it('routes opted-in links without a source owner through the active runtime', () => {
+    storeState.settings = {
+      openLinksInApp: true,
+      activeRuntimeEnvironmentId: ' remote-1 '
+    }
+
+    openHttpLink('https://github.com/acme/widgets/pull/123', {
+      worktreeId: 'wt-1',
+      allowRemoteInApp: true
+    })
+
+    expect(openRuntimeBrowserTabMock).toHaveBeenCalledExactlyOnceWith({
+      workspaceId: 'wt-1',
+      url: 'https://github.com/acme/widgets/pull/123',
+      intent: { kind: 'url' },
+      expectedRuntimeEnvironmentId: 'remote-1'
+    })
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
   it('routes to the system browser when a remote runtime environment is active', () => {
     storeState.settings = { openLinksInApp: true, activeRuntimeEnvironmentId: 'env-1' }
 

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -127,14 +127,7 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
   }
   const state = storeAccessor?.()
   const remoteRuntimeActive = Boolean(state?.settings?.activeRuntimeEnvironmentId?.trim())
-  const effectiveSourceOwner =
-    sourceOwner ??
-    (allowRemoteInApp && remoteRuntimeActive
-      ? {
-          kind: 'runtime' as const,
-          runtimeEnvironmentId: state?.settings?.activeRuntimeEnvironmentId?.trim() ?? ''
-        }
-      : undefined)
+  const effectiveSourceOwner = sourceOwner
   const sourceIsLocal = effectiveSourceOwner
     ? effectiveSourceOwner.kind === 'local'
     : !remoteRuntimeActive
@@ -154,16 +147,20 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
     wantsOrca &&
     allowRemoteInApp &&
     worktreeId &&
-    (effectiveSourceOwner?.kind === 'runtime' || effectiveSourceOwner?.kind === 'ssh')
+    (effectiveSourceOwner?.kind === 'runtime' ||
+      effectiveSourceOwner?.kind === 'ssh' ||
+      remoteRuntimeActive)
   ) {
     if (workspaceHttpLinkBrowserOpener) {
       void workspaceHttpLinkBrowserOpener({
         workspaceId: worktreeId,
         url,
         intent: { kind: 'url' },
-        ...(effectiveSourceOwner.kind === 'runtime'
+        ...(effectiveSourceOwner?.kind === 'runtime'
           ? { expectedRuntimeEnvironmentId: effectiveSourceOwner.runtimeEnvironmentId }
-          : { expectedSshConnectionId: effectiveSourceOwner.connectionId })
+          : effectiveSourceOwner?.kind === 'ssh'
+            ? { expectedSshConnectionId: effectiveSourceOwner.connectionId }
+            : {})
       }).catch((error) => {
         toast.error(
           error instanceof Error

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -149,7 +149,7 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
     worktreeId &&
     (effectiveSourceOwner?.kind === 'runtime' ||
       effectiveSourceOwner?.kind === 'ssh' ||
-      remoteRuntimeActive)
+      (!effectiveSourceOwner && remoteRuntimeActive))
   ) {
     if (workspaceHttpLinkBrowserOpener) {
       void workspaceHttpLinkBrowserOpener({

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -127,7 +127,17 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
   }
   const state = storeAccessor?.()
   const remoteRuntimeActive = Boolean(state?.settings?.activeRuntimeEnvironmentId?.trim())
-  const sourceIsLocal = sourceOwner ? sourceOwner.kind === 'local' : !remoteRuntimeActive
+  const effectiveSourceOwner =
+    sourceOwner ??
+    (allowRemoteInApp && remoteRuntimeActive
+      ? {
+          kind: 'runtime' as const,
+          runtimeEnvironmentId: state?.settings?.activeRuntimeEnvironmentId?.trim() ?? ''
+        }
+      : undefined)
+  const sourceIsLocal = effectiveSourceOwner
+    ? effectiveSourceOwner.kind === 'local'
+    : !remoteRuntimeActive
   const openLinksInApp = state?.settings?.openLinksInApp === true
   const modifier = resolveModifierRouting(
     Boolean(modifierHeld),
@@ -144,16 +154,16 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
     wantsOrca &&
     allowRemoteInApp &&
     worktreeId &&
-    (sourceOwner?.kind === 'runtime' || sourceOwner?.kind === 'ssh')
+    (effectiveSourceOwner?.kind === 'runtime' || effectiveSourceOwner?.kind === 'ssh')
   ) {
     if (workspaceHttpLinkBrowserOpener) {
       void workspaceHttpLinkBrowserOpener({
         workspaceId: worktreeId,
         url,
         intent: { kind: 'url' },
-        ...(sourceOwner.kind === 'runtime'
-          ? { expectedRuntimeEnvironmentId: sourceOwner.runtimeEnvironmentId }
-          : { expectedSshConnectionId: sourceOwner.connectionId })
+        ...(effectiveSourceOwner.kind === 'runtime'
+          ? { expectedRuntimeEnvironmentId: effectiveSourceOwner.runtimeEnvironmentId }
+          : { expectedSshConnectionId: effectiveSourceOwner.connectionId })
       }).catch((error) => {
         toast.error(
           error instanceof Error


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

Fixes remote right-sidebar review links by routing through the client browser and active runtime proxy. Targeted routing tests pass.