### PR TITLE
fix(workspaces): keep slept workspaces parked so they stop waking themselves

### DIFF
--- a/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
@@ -54,7 +54,8 @@ describe('sleep flow vs slept-workspace activation', () => {
         ephemeralVm: {
           resumeWorkspace: mocks.resumeWorkspace
         }
-      }
+      },
+      dispatchEvent: vi.fn()
     })
     mocks.state.activeWorktreeId = 'wt-parent'
     mocks.state.setActiveWorktree.mockClear()

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -15,9 +15,11 @@ const mocks = vi.hoisted(() => {
   const toastError = vi.fn()
   const markWorktreeSleepIntent = vi.fn()
   const clearWorktreeSleepIntent = vi.fn()
+  const requestManualTerminalWorktreePark = vi.fn()
   return {
     clearWorktreeSleepIntent,
     markWorktreeSleepIntent,
+    requestManualTerminalWorktreePark,
     state,
     suspendWorkspace,
     toastError
@@ -34,6 +36,9 @@ vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
 vi.mock('@/lib/worktree-sleep-intent', () => ({
   clearWorktreeSleepIntent: mocks.clearWorktreeSleepIntent,
   markWorktreeSleepIntent: mocks.markWorktreeSleepIntent
+}))
+vi.mock('@/lib/manual-terminal-worktree-parking', () => ({
+  requestManualTerminalWorktreePark: mocks.requestManualTerminalWorktreePark
 }))
 
 import { runSleepWorktree, runSleepWorktrees } from './sleep-worktree-flow'
@@ -57,6 +62,7 @@ describe('runSleepWorktree', () => {
     mocks.suspendWorkspace.mockClear().mockResolvedValue(null)
     mocks.markWorktreeSleepIntent.mockClear()
     mocks.clearWorktreeSleepIntent.mockClear()
+    mocks.requestManualTerminalWorktreePark.mockClear()
     mocks.toastError.mockClear()
     mocks.state.activeWorktreeId = null
     mocks.state.tabsByWorktree = {}
@@ -82,6 +88,30 @@ describe('runSleepWorktree', () => {
     const suspendCallOrder = mocks.suspendWorkspace.mock.invocationCallOrder[0]
     expect(browsersCallOrder).toBeLessThan(terminalsCallOrder)
     expect(terminalsCallOrder).toBeLessThan(suspendCallOrder)
+  })
+
+  it('latches a sleep park so an unpark remount cannot respawn the killed sessions', async () => {
+    mocks.state.activeWorktreeId = 'wt-other'
+
+    await runSleepWorktree('wt-1')
+
+    expect(mocks.requestManualTerminalWorktreePark).toHaveBeenCalledWith('wt-1', 'workspace-sleep')
+    // Why last: only a workspace that finished every teardown step earns the latch.
+    const suspend = mocks.suspendWorkspace.mock.invocationCallOrder[0]
+    const parkRequest = mocks.requestManualTerminalWorktreePark.mock.invocationCallOrder[0]
+    expect(suspend).toBeLessThan(parkRequest)
+  })
+
+  it.each([
+    ['terminal shutdown', () => mocks.state.shutdownWorktreeTerminals],
+    ['host suspension', () => mocks.suspendWorkspace]
+  ])('does not park a workspace whose %s failed', async (_label, getStep) => {
+    mocks.state.activeWorktreeId = 'wt-other'
+    getStep().mockRejectedValueOnce(new Error('boom'))
+
+    await runSleepWorktree('wt-1')
+
+    expect(mocks.requestManualTerminalWorktreePark).not.toHaveBeenCalled()
   })
 
   it('clears activeWorktreeId before teardown when the slept worktree is active', async () => {

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -1,6 +1,7 @@
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { clearWorktreeSleepIntent, markWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
+import { requestManualTerminalWorktreePark } from '@/lib/manual-terminal-worktree-parking'
 import { VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } from '@/hooks/useVirtualizedScrollAnchor'
 import { translate } from '@/i18n/i18n'
 
@@ -182,6 +183,11 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
         if (typeof window !== 'undefined' && window.api?.ephemeralVm?.suspendWorkspace) {
           await window.api.ephemeralVm.suspendWorkspace({ workspaceId: worktreeId })
         }
+        // Why last, and why at all: sleep leaves the workspace in the terminal workbench's mounted
+        // set, so an ordinary unpark remount reattaches the sessions this just killed, misses, and
+        // cold-restores them — the workspace wakes itself minutes later with no user action. Only a
+        // fully slept workspace earns the latch, which holds until a reveal or background wake.
+        requestManualTerminalWorktreePark(worktreeId, 'workspace-sleep')
       } catch (err) {
         console.error('[sleep-worktree] terminal or host suspension failed', {
           worktreeId,

--- a/src/renderer/src/components/terminal-pane/terminal-worktree-sleep-park-latch.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-worktree-sleep-park-latch.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT } from '@/constants/terminal'
+import {
+  requestManualTerminalWorktreePark,
+  takeAllPendingManualTerminalWorktreeParks
+} from '@/lib/manual-terminal-worktree-parking'
+import { useManualTerminalWorktreeParking } from './use-manual-terminal-worktree-parking'
+
+const toastWarning = vi.hoisted(() => vi.fn())
+vi.mock('sonner', () => ({ toast: { warning: toastWarning } }))
+
+function renderParking(renderedActiveWorktreeId: string | null) {
+  return renderHook(
+    (props: { renderedActiveWorktreeId: string | null }) =>
+      useManualTerminalWorktreeParking({ activeView: 'terminal', ...props }),
+    { initialProps: { renderedActiveWorktreeId } }
+  )
+}
+
+describe('workspace-sleep park latch', () => {
+  beforeEach(() => {
+    takeAllPendingManualTerminalWorktreeParks()
+    toastWarning.mockClear()
+  })
+  afterEach(cleanup)
+
+  // Why this bypass matters: a slept workspace has no surviving PTY, so the on-demand eligibility
+  // gates can never pass — and without the park its panes remount and respawn what sleep killed.
+  it('parks a slept workspace that the on-demand gates would refuse', () => {
+    const { result } = renderParking(null)
+
+    act(() => requestManualTerminalWorktreePark('wt-slept', 'workspace-sleep'))
+
+    expect(result.current).toEqual(new Set(['wt-slept']))
+    expect(toastWarning).not.toHaveBeenCalled()
+  })
+
+  it('still refuses — and warns about — an ineligible manual park', () => {
+    const { result } = renderParking(null)
+
+    act(() => requestManualTerminalWorktreePark('wt-manual'))
+
+    expect(result.current).toEqual(new Set())
+    expect(toastWarning).toHaveBeenCalledOnce()
+  })
+
+  it('releases the latch when the workspace is revealed', () => {
+    const { result, rerender } = renderParking(null)
+    act(() => requestManualTerminalWorktreePark('wt-slept', 'workspace-sleep'))
+
+    rerender({ renderedActiveWorktreeId: 'wt-slept' })
+
+    expect(result.current).toEqual(new Set())
+  })
+
+  it('releases the latch on a navigation-free background wake', () => {
+    const { result } = renderParking(null)
+    act(() => requestManualTerminalWorktreePark('wt-slept', 'workspace-sleep'))
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT, {
+          detail: { worktreeId: 'wt-slept' }
+        })
+      )
+    })
+
+    expect(result.current).toEqual(new Set())
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-manual-terminal-worktree-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-manual-terminal-worktree-parking.ts
@@ -4,10 +4,15 @@ import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import {
+  BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT,
+  type BackgroundMountTerminalWorktreeDetail
+} from '@/constants/terminal'
+import {
   MANUAL_TERMINAL_WORKTREE_PARK_EVENT,
   takeAllPendingManualTerminalWorktreeParks,
   takePendingManualTerminalWorktreePark,
-  type ManualTerminalWorktreeParkDetail
+  type ManualTerminalWorktreeParkDetail,
+  type ManualTerminalWorktreeParkReason
 } from '@/lib/manual-terminal-worktree-parking'
 import { canManuallyParkTerminalWorktreeRenderers } from './manual-terminal-worktree-park-eligibility'
 import { canWatcherCoverParkedTerminalTab } from './terminal-parked-tab-watchers'
@@ -28,6 +33,20 @@ function removeWorktreeId(current: ReadonlySet<string>, worktreeId: string): Rea
   return next
 }
 
+function canParkWorktreeOnDemand(worktreeId: string): boolean {
+  const state = useAppStore.getState()
+  const terminalTabs = state.tabsByWorktree[worktreeId] ?? []
+  return (
+    canManuallyParkTerminalWorktreeRenderers({
+      worktreeId,
+      terminalTabs,
+      pendingStartupByTabId: state.pendingStartupByTabId,
+      parkingEnabled: state.settings?.terminalHiddenViewParking !== false,
+      hasLivePty: (tabId) => tabHasLivePty(state.ptyIdsByTabId, tabId)
+    }) && terminalTabs.every((tab) => canWatcherCoverParkedTerminalTab(worktreeId, tab))
+  )
+}
+
 export function combineTerminalWorktreeParkIds(
   automaticIds: ReadonlySet<string>,
   manualIds: ReadonlySet<string>
@@ -46,41 +65,39 @@ export function useManualTerminalWorktreeParking(args: {
     () => new Set()
   )
 
-  const parkWorktree = useCallback((worktreeId: string) => {
-    const state = useAppStore.getState()
-    const terminalTabs = state.tabsByWorktree[worktreeId] ?? []
-    const canPark =
-      canManuallyParkTerminalWorktreeRenderers({
-        worktreeId,
-        terminalTabs,
-        pendingStartupByTabId: state.pendingStartupByTabId,
-        parkingEnabled: state.settings?.terminalHiddenViewParking !== false,
-        hasLivePty: (tabId) => tabHasLivePty(state.ptyIdsByTabId, tabId)
-      }) && terminalTabs.every((tab) => canWatcherCoverParkedTerminalTab(worktreeId, tab))
-    if (!canPark) {
-      toast.warning(
-        translate(
-          'auto.components.terminalPane.useManualTerminalWorktreeParking.cannotPark',
-          'These terminals cannot be parked safely.'
+  const parkWorktree = useCallback(
+    (worktreeId: string, reason: ManualTerminalWorktreeParkReason) => {
+      // Why sleep skips the gates: they protect live output, and sleep already verified every PTY
+      // is gone. Refusing would leave the workspace mounted, and the next unpark would respawn the
+      // sessions sleep just killed.
+      if (reason !== 'workspace-sleep' && !canParkWorktreeOnDemand(worktreeId)) {
+        toast.warning(
+          translate(
+            'auto.components.terminalPane.useManualTerminalWorktreeParking.cannotPark',
+            'These terminals cannot be parked safely.'
+          )
         )
-      )
-      return
-    }
-    setManuallyParkedWorktreeIds((current) => addWorktreeId(current, worktreeId))
-  }, [])
+        return
+      }
+      setManuallyParkedWorktreeIds((current) => addWorktreeId(current, worktreeId))
+    },
+    []
+  )
 
   useEffect(() => {
     const handleParkRequest = (event: Event): void => {
-      const worktreeId = (event as CustomEvent<ManualTerminalWorktreeParkDetail>).detail?.worktreeId
-      if (!worktreeId) {
+      const detail = (event as CustomEvent<ManualTerminalWorktreeParkDetail>).detail
+      if (!detail?.worktreeId) {
         return
       }
-      takePendingManualTerminalWorktreePark(worktreeId)
-      parkWorktree(worktreeId)
+      parkWorktree(
+        detail.worktreeId,
+        takePendingManualTerminalWorktreePark(detail.worktreeId) ?? detail.reason
+      )
     }
     window.addEventListener(MANUAL_TERMINAL_WORKTREE_PARK_EVENT, handleParkRequest as EventListener)
-    for (const worktreeId of takeAllPendingManualTerminalWorktreeParks()) {
-      parkWorktree(worktreeId)
+    for (const pending of takeAllPendingManualTerminalWorktreeParks()) {
+      parkWorktree(pending.worktreeId, pending.reason)
     }
     return () =>
       window.removeEventListener(
@@ -88,6 +105,29 @@ export function useManualTerminalWorktreeParking(args: {
         handleParkRequest as EventListener
       )
   }, [parkWorktree])
+
+  useEffect(() => {
+    // Why a background mount releases the park: it is a navigation-free wake (mobile, CLI reveal)
+    // and only suspends the park for its measure window, so a park left latched would unmount the
+    // panes it just woke seconds later.
+    const handleBackgroundMount = (event: Event): void => {
+      const worktreeId = (event as CustomEvent<BackgroundMountTerminalWorktreeDetail>).detail
+        ?.worktreeId
+      if (!worktreeId) {
+        return
+      }
+      setManuallyParkedWorktreeIds((current) => removeWorktreeId(current, worktreeId))
+    }
+    window.addEventListener(
+      BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT,
+      handleBackgroundMount as EventListener
+    )
+    return () =>
+      window.removeEventListener(
+        BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT,
+        handleBackgroundMount as EventListener
+      )
+  }, [])
 
   useEffect(() => {
     const revealedWorktreeId = args.renderedActiveWorktreeId

--- a/src/renderer/src/lib/manual-terminal-worktree-parking.test.ts
+++ b/src/renderer/src/lib/manual-terminal-worktree-parking.test.ts
@@ -17,7 +17,8 @@ describe('manual terminal worktree parking requests', () => {
   it('dispatches the target worktree and records it for a late Terminal mount', () => {
     const listener = vi.fn((event: Event) => {
       expect((event as CustomEvent<ManualTerminalWorktreeParkDetail>).detail).toEqual({
-        worktreeId: 'worktree-1'
+        worktreeId: 'worktree-1',
+        reason: 'manual'
       })
     })
     window.addEventListener(MANUAL_TERMINAL_WORKTREE_PARK_EVENT, listener)
@@ -25,7 +26,7 @@ describe('manual terminal worktree parking requests', () => {
     requestManualTerminalWorktreePark('worktree-1')
 
     expect(listener).toHaveBeenCalledOnce()
-    expect(takePendingManualTerminalWorktreePark('worktree-1')).toBe(true)
+    expect(takePendingManualTerminalWorktreePark('worktree-1')).toBe('manual')
     window.removeEventListener(MANUAL_TERMINAL_WORKTREE_PARK_EVENT, listener)
   })
 
@@ -37,6 +38,22 @@ describe('manual terminal worktree parking requests', () => {
 
     expect(listener).not.toHaveBeenCalled()
     expect(takeAllPendingManualTerminalWorktreeParks()).toEqual([])
+    window.removeEventListener(MANUAL_TERMINAL_WORKTREE_PARK_EVENT, listener)
+  })
+
+  it('carries the workspace-sleep reason through the event and the pending queue', () => {
+    const details: ManualTerminalWorktreeParkDetail[] = []
+    const listener = (event: Event): void => {
+      details.push((event as CustomEvent<ManualTerminalWorktreeParkDetail>).detail)
+    }
+    window.addEventListener(MANUAL_TERMINAL_WORKTREE_PARK_EVENT, listener)
+
+    requestManualTerminalWorktreePark('worktree-2', 'workspace-sleep')
+
+    expect(details).toEqual([{ worktreeId: 'worktree-2', reason: 'workspace-sleep' }])
+    expect(takeAllPendingManualTerminalWorktreeParks()).toEqual([
+      { worktreeId: 'worktree-2', reason: 'workspace-sleep' }
+    ])
     window.removeEventListener(MANUAL_TERMINAL_WORKTREE_PARK_EVENT, listener)
   })
 })

--- a/src/renderer/src/lib/manual-terminal-worktree-parking.ts
+++ b/src/renderer/src/lib/manual-terminal-worktree-parking.ts
@@ -1,29 +1,46 @@
 export const MANUAL_TERMINAL_WORKTREE_PARK_EVENT = 'orca-manual-terminal-worktree-park'
 
+/** Why workspace-sleep is a distinct reason: sleep leaves the workspace in the terminal
+ *  workbench's mounted set, so an ordinary unpark remount reattaches the sessions sleep killed,
+ *  misses, and cold-restores them. Its park skips the on-demand eligibility gates, which a
+ *  workspace with no surviving PTY can never satisfy. */
+export type ManualTerminalWorktreeParkReason = 'manual' | 'workspace-sleep'
+
 export type ManualTerminalWorktreeParkDetail = {
   worktreeId: string
+  reason: ManualTerminalWorktreeParkReason
 }
 
-const pendingWorktreeIds = new Set<string>()
+const pendingReasonsByWorktreeId = new Map<string, ManualTerminalWorktreeParkReason>()
 
-export function requestManualTerminalWorktreePark(worktreeId: string): void {
+export function requestManualTerminalWorktreePark(
+  worktreeId: string,
+  reason: ManualTerminalWorktreeParkReason = 'manual'
+): void {
   if (!worktreeId) {
     return
   }
-  pendingWorktreeIds.add(worktreeId)
+  pendingReasonsByWorktreeId.set(worktreeId, reason)
   window.dispatchEvent(
     new CustomEvent<ManualTerminalWorktreeParkDetail>(MANUAL_TERMINAL_WORKTREE_PARK_EVENT, {
-      detail: { worktreeId }
+      detail: { worktreeId, reason }
     })
   )
 }
 
-export function takePendingManualTerminalWorktreePark(worktreeId: string): boolean {
-  return pendingWorktreeIds.delete(worktreeId)
+export function takePendingManualTerminalWorktreePark(
+  worktreeId: string
+): ManualTerminalWorktreeParkReason | null {
+  const reason = pendingReasonsByWorktreeId.get(worktreeId) ?? null
+  pendingReasonsByWorktreeId.delete(worktreeId)
+  return reason
 }
 
-export function takeAllPendingManualTerminalWorktreeParks(): string[] {
-  const pending = [...pendingWorktreeIds]
-  pendingWorktreeIds.clear()
+export function takeAllPendingManualTerminalWorktreeParks(): ManualTerminalWorktreeParkDetail[] {
+  const pending = [...pendingReasonsByWorktreeId].map(([worktreeId, reason]) => ({
+    worktreeId,
+    reason
+  }))
+  pendingReasonsByWorktreeId.clear()
   return pending
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​123 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​120 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 |

<!-- /orca-pr-loc -->

## ELI5

You put a workspace to sleep. Twenty minutes later it's awake again, with your agent relaunched, and you never touched it. Sleep killed the terminals but forgot to tell the UI to stop re-opening them — so the next time Orca shuffled hidden workspaces in the background, it tried to reconnect to the terminals sleep had just killed, failed, and started fresh ones. Now sleeping also tells the UI "leave this one alone until I come back."

## What Changed

- `requestManualTerminalWorktreePark` takes a `reason` (`'manual' | 'workspace-sleep'`).
- A `'workspace-sleep'` park skips the on-demand eligibility gates. A slept workspace has no surviving PTY, so `canManuallyParkTerminalWorktreeRenderers` can never pass (`isParkRestorableTerminalPty` is false for a dead local PTY, and the gate is off entirely when `terminalHiddenViewParking` is disabled) — and it would toast "These terminals cannot be parked safely." on every sleep. Manual parks keep the gates and the warning.
- `runSleepWorktrees` latches that park after the *last* teardown step, so only a workspace that fully slept earns it.
- The latch releases on reveal (existing effect) **and** on `BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT` — a navigation-free wake (mobile, CLI reveal) only suspends the park for its 3s measure window, so a latch left set would unmount the panes it just woke.

## Why

Fixes the "no durable stay-dead-until-Wake gate" this issue identifies.

Sleep kills the workspace's PTYs but keeps the tab records and layout pty ids (`keepIdentifiers: true`), and leaves the workspace in `mountedWorktreeIdsRef` — which `terminal-cold-activation.ts` only prunes when a worktree leaves `workspaceSurfaceIds`, i.e. when it is deleted. The panes then cold-park like any hidden workspace. When the park verdict flips back, they remount, `runDeferredSessionReattachChoice` reattaches to the restored session id, misses, and `handleReattachResult` falls through to `startFreshColdRestoreAgentResume` — a fresh spawn under the same deterministic session id, re-running the agent's `--resume`. Live PTYs reappear, `hasActiveWorkspaceActivity` goes true, and the sidebar row un-sleeps.

From my own daemon log — every respawn trails another hidden workspace's pane remounting in the same sweep by ~100ms. `crash-closer` *attaches* (its PTY is alive); the slept workspace *spawns* (sleep killed its PTY):

```
04:27:22.902  session-attached  crash-closer@@9cc873ad          ← unpark sweep
04:27:23.007  session-created   fix-inline-…@@c490b5b6          ← dead session → fresh spawn
04:27:24.884  session-created   fix-inline-…@@cc62a5d4            (hasCommand: true → claude --resume)

05:15:37.086  session-attached  crash-closer@@9cc873ad
05:15:37.212  session-created   fix-inline-…@@c490b5b6
05:15:37.384  session-created   fix-inline-…@@cc62a5d4
```

Three sleeps (04:03, 04:31, 04:59) produced three self-wakes (04:27, 04:59, 05:15) at irregular 16–28 min gaps matching park-verdict churn, with no sidebar activation for that workspace in between.

**Why park rather than block the spawn:** the reattach→cold-restore fallback is *correct* behaviour for a real wake — it is how waking a slept workspace restores its agents. The bug is that the panes remount at all. Keeping them parked leaves the existing, tested wake path untouched; reveal releases the latch and wake proceeds normally.

## Linked Issue

Fixes #10205

## Visual Proof

N/A — the change has no visual delta to capture. What it fixes is the *absence* of an event: a slept row that previously re-appeared after 16–28 minutes now stays slept. The daemon-log evidence above is the observable signal; `tests/e2e/terminal-sleep-wake-restore.spec.ts` covers the visible sleep→wake path and still passes.

## Testing

Tested on macOS (local execution host). Not exercised on Windows/Linux/SSH — the change is renderer-only with no platform-dependent code (no paths, processes, shells, or native modules).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Added `terminal-worktree-sleep-park-latch.test.tsx` (4 cases): the sleep reason parks a workspace the gates would refuse; a manual park still refuses *and* warns; the latch releases on reveal; the latch releases on a background wake. Extended `sleep-worktree-flow.test.ts` with the latch, its ordering, and a parameterised case that no park is latched when terminal shutdown *or* host suspension fails.

- `pnpm tc` — clean
- `pnpm test src/renderer/src/components src/renderer/src/lib` — 2949 files / 24 656 tests pass
- `pnpm test src/renderer/src/components/sidebar src/renderer/src/components/terminal-pane` — 745 files / 6790 tests pass
- `tests/e2e/terminal-sleep-wake-restore.spec.ts` (electron-headless) — passes: slept terminal output restores and accepts fresh input after wake

Verified while reviewing, not just assumed:
- Parked byte watchers only `subscribeToPtyData` — they never connect or spawn, so parking a slept workspace cannot itself start a process.
- `handlePtyExit` bails on `consumeSuppressedPtyExit` before any parked-exit tab-close logic, so the sleep kill cannot close the slept tabs.
- The worktree-level park short-circuits the per-tab policy, so the latch works even with `terminalHiddenViewParking` off — which is exactly the configuration where the eligibility gate would have refused.

**Residual risk:** the latch is component state, so it is lost on renderer reload; after a restart nothing mounts a hidden workspace anyway, so this is not a re-wake path. Stale ids for deleted worktrees are never pruned from the set — inert (membership is only tested against live surfaces) and bounded by worktree count. As before this PR, a worktree-level park bypasses `terminalSshViewParking`; for a slept SSH workspace there is no scrollback to lose, since sleep already captured buffers into `buffersByLeafId`.

## AI Disclosure

Investigated and implemented with Claude Opus 4.6 in Claude Code.

## Review

Reviewed against `readiness-checklist` (two passes). The first pass caught a real defect in the first draft of this fix: the latch was only released on reveal, so a mobile/CLI background wake would have re-parked the panes ~3s later, once the measure window closed. That is the `BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT` release above, with a test. Second pass: no candidate findings.

Reviewer questions worth a second opinion:
1. Should the latch survive a renderer reload (persisted), or is in-memory correct?
2. Is releasing the latch on *any* background mount too broad — should a mobile wake of an explicitly-slept workspace stay parked instead?
