### PR TITLE
i18n: add translations for remote browsing and skills

### DIFF
--- a/src/renderer/src/components/settings/NativeChatSupportedAgents.test.tsx
+++ b/src/renderer/src/components/settings/NativeChatSupportedAgents.test.tsx
@@ -82,12 +82,14 @@ describe('NativeChatSupportedAgents', () => {
     expect(value).toBe('Supported agents:')
   })
 
-  it('renders the English fallback when the active locale lacks the label key', async () => {
+  it('renders the Spanish label when the active locale provides it', async () => {
     await i18n.changeLanguage('es')
-    expect(i18n.getResource('es', 'translation', SUPPORTED_AGENTS_LABEL_KEY)).toBeUndefined()
+    expect(i18n.getResource('es', 'translation', SUPPORTED_AGENTS_LABEL_KEY)).toBe(
+      'Agentes compatibles:'
+    )
 
     const markup = renderToStaticMarkup(<NativeChatSupportedAgents />)
 
-    expect(markup).toContain('Supported agents:')
+    expect(markup).toContain('Agentes compatibles:')
   })
 })

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -38,7 +38,43 @@
       },
       "menuBarIcon": {
         "title": "Mostrar icono en la barra de menús",
-        "description": "Mantén un acceso directo de Orca e indicador de actividad en la barra de menús de macOS."
+        "description": "Mantén un acceso directo de Orca e indicador de actividad en la barra de menús de macOS.",
+        "keyword": {
+          "activity": "actividad",
+          "menuBar": "barra de menús",
+          "statusItem": "elemento de estado"
+        }
+      }
+    },
+    "browser": {
+      "clientHostedRemote": {
+        "optionDevice": "Este dispositivo",
+        "description": "Representa las páginas de espacios de trabajo remotos en este equipo; el tráfico de red sigue pasando por el host remoto. Solo se aplica a páginas nuevas.",
+        "optionDeviceTooltip": "Las páginas se representan en este equipo, por lo que la entrada y las ventanas emergentes se comportan de forma nativa.",
+        "optionServer": "Servidor (transmitido)",
+        "optionServerTooltip": "Las páginas se representan en el servidor remoto y se transmiten a este dispositivo.",
+        "rowDescription": "Dónde se representan las páginas. El tráfico siempre pasa por el servidor remoto. Solo se aplica a páginas nuevas.",
+        "rowTitle": "Espacios de trabajo de servidor remoto",
+        "title": "Alojar páginas remotas del navegador en este dispositivo"
+      },
+      "sshWorkspaceRouting": {
+        "optionDevice": "Este dispositivo",
+        "description": "Las páginas del navegador en espacios de trabajo SSH envían su tráfico a través del host SSH del espacio de trabajo, con DNS resuelto allí. Desactivado significa que las páginas navegan desde esta máquina.",
+        "disabledHosts": "Hosts que navegan desde este dispositivo:",
+        "enableHost": "Enrutar de nuevo",
+        "optionDeviceTooltip": "Las páginas navegan desde la red de esta máquina.",
+        "optionHost": "Host SSH",
+        "optionHostTooltip": "El tráfico y el DNS pasan por el host SSH del espacio de trabajo.",
+        "probeAgain": "Comprobar de nuevo",
+        "probeSkippedHosts": "Hosts enrutados sin la comprobación de conexión (Intentar de todos modos):",
+        "rowDescription": "Desde dónde sale el tráfico del navegador. Las páginas siempre se representan en este dispositivo.",
+        "rowTitle": "Espacios de trabajo SSH",
+        "title": "Navegar a través de hosts SSH de espacios de trabajo",
+        "useHost": "Usar host SSH"
+      },
+      "remoteBrowsing": {
+        "heading": "Navegación remota",
+        "headingDescription": "Dónde se representan las páginas de espacios de trabajo remotos y desde dónde sale su tráfico de red."
       }
     }
   },
@@ -87,7 +123,48 @@
       "issue": "Issue",
       "mr": "MR",
       "port": "Puerto",
-      "pr": "PR"
+      "pr": "PR",
+      "automation": "Ejecución",
+      "task": "Tarea"
+    },
+    "filter": {
+      "tabKey": "Tab",
+      "label": "Filtrar",
+      "hosts": "Hosts",
+      "searchProjects": "Filtrar proyectos...",
+      "activeCount": "{{value0}} activos",
+      "ariaActive": "Filtro: {{value0}} activos.",
+      "back": "Atrás",
+      "chipOverflow": "+{{value0}}",
+      "clearAll": "Borrar todo",
+      "clearHosts": "Borrar hosts",
+      "clearProjects": "Borrar proyectos",
+      "emptySubtitle": "Borra el filtro de arriba o amplíalo a más hosts y proyectos.",
+      "emptyTitle": "Ningún resultado coincide con el filtro activo",
+      "moreOptions": "{{value0}} más: sigue escribiendo para acotar",
+      "noHosts": "Sin hosts coincidentes",
+      "noOptions": "Sin hosts ni proyectos coincidentes",
+      "noProjects": "Sin proyectos coincidentes",
+      "projects": "Proyectos",
+      "removeChip": "Quitar filtro {{value0}}",
+      "search": "Filtrar por host o proyecto…",
+      "searchHosts": "Filtrar hosts…",
+      "selectAllMatching": "Seleccionar todas las coincidencias ({{value0}})",
+      "selectedCollapsed": "{{value0}} seleccionados — quítalos con las etiquetas o Borrar",
+      "trigger": "Filtrar resultados"
+    },
+    "linearIssue": {
+      "createHint": "Crear worktree desde un issue de Linear",
+      "createLabel": "Crear worktree desde el issue de Linear {{value0}}: {{value1}}",
+      "loadingHint": "Cargando issue de Linear…",
+      "loadingLabel": "Cargando issue de Linear {{value0}}",
+      "pendingLabel": "Crear worktree desde el issue de Linear {{value0}}"
+    },
+    "renderCapOverflow": "{{value0}} más",
+    "seeMore": "Ver más",
+    "taskUrl": {
+      "createHint": "Crear worktree desde {{value0}}",
+      "loadingHint": "Cargando {{value0}}…"
     }
   },
   "auto": {
@@ -158,7 +235,8 @@
         "runtimeEnvironmentManuallyDisconnected": "El entorno de ejecución se ha desconectado manualmente.",
         "loopbackPairingBlocked": "Este enlace de acceso apunta de nuevo a este dispositivo.",
         "remotePairingUnreachable": "No se puede acceder a Orca en {{endpoint}}.",
-        "remotePairingInvalidDetails": "Este enlace de acceso contiene datos de conexión no válidos."
+        "remotePairingInvalidDetails": "Este enlace de acceso contiene datos de conexión no válidos.",
+        "remotePairingSaveFailed": "Orca verificó el host pero no pudo guardarlo. Revisa el almacenamiento del navegador e inténtalo de nuevo."
       },
       "web": {
         "preload": {
@@ -201,7 +279,8 @@
           "51f15c37d3": "No se puede abrir la carpeta: {{value0}}",
           "f2e00db373": "No se encontró el archivo: {{value0}}",
           "checkRunDetailsUnavailable": "No hay detalles disponibles para este check.",
-          "checkRunDetailsLoadFailed": "No se pudieron cargar los detalles del check."
+          "checkRunDetailsLoadFailed": "No se pudieron cargar los detalles del check.",
+          "checkRunDetailsRepoUnavailable": "Los detalles del repositorio no están disponibles para esta comprobación."
         },
         "github": {
           "f129c42773": "GitHub no devolvió el comentario nuevo.",
@@ -233,7 +312,12 @@
         "workspace": {
           "cleanup": {
             "9d6e531da6": "El espacio de trabajo ya no existe.",
-            "changedSinceConfirmation": "El espacio de trabajo cambió después de la confirmación. Actualiza para revisarlo antes de eliminarlo."
+            "changedSinceConfirmation": "El espacio de trabajo cambió después de la confirmación. Actualiza para revisarlo antes de eliminarlo.",
+            "forceNeedsApproval": "Revisa y confirma este espacio de trabajo antes de eliminarlo forzadamente.",
+            "gitStatusUnavailable": "Orca no pudo comprobar el estado de git de este espacio de trabajo. Inténtalo de nuevo o elimínalo desde su barra lateral o lista de proyectos específica del host.",
+            "gitStatusUnavailableOlderPeer": "Orca no pudo asociar este error de estado de git a un host. Actualiza el par conectado más antiguo o elimina el espacio de trabajo desde su barra lateral o lista de proyectos específica del host.",
+            "hostCollision": "Error: este espacio de trabajo existe en varios hosts en la misma ruta",
+            "hostUnresolved": "Orca no puede determinar qué host es propietario de este espacio de trabajo. Actualiza los proyectos y revísalo de nuevo."
           }
         },
         "worktrees": {
@@ -267,7 +351,25 @@
           "runtimeScopeForbiddenDescription": "Los espacios de trabajo no están disponibles con un emparejamiento de acceso móvil. Vuelve a conectarte con el enlace del navegador desde Ajustes → Servidores remotos de Orca → Comparte este servidor Orca.",
           "createdWithoutParentNesting": "Creado sin anidarlo bajo \"{{value0}}\"",
           "createdWithoutParentNestingUnnamed": "Creado sin anidarlo bajo el worktree padre seleccionado",
-          "createdWithoutParentNestingDetail": "El espacio de trabajo padre ya no estaba disponible. Puedes establecerlo desde el menú del espacio de trabajo."
+          "createdWithoutParentNestingDetail": "El espacio de trabajo padre ya no estaba disponible. Puedes establecerlo desde el menú del espacio de trabajo.",
+          "a17f4d2e93": "No se pudo actualizar este espacio de trabajo.",
+          "c6cf133786": "Este espacio de trabajo ya no está disponible.",
+          "metadata": {
+            "worktree": {
+              "meta": {
+                "persist": {
+                  "4367540861": "Actualiza el runtime remoto para vincular issues de Linear",
+                  "877e3638d8": "Actualiza el runtime remoto para cambiar el issue vinculado de este espacio de trabajo",
+                  "github": {
+                    "pr": {
+                      "suppression": "Actualiza el runtime remoto para desvincular pull requests de GitHub"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "preservedBranchCleanupHostAmbiguous": "Hay varias limpiezas de ramas conservadas pendientes para «{{value0}}»; especifica el host."
         },
         "repos": {
           "2975400634": "Actualiza el servidor Orca para abrir carpetas que no sean Git en este host.",
@@ -281,7 +383,10 @@
           "3be0f7df04": "No se puede abrir la carpeta en el host seleccionado",
           "15cf5319ec": "{{path}} se verificó en {{hostName}}, pero ese host no reportó ninguna carpeta utilizable.",
           "2dcd706774": "El proyecto también existe en otro perfil",
-          "presenceProfileOverflow": "{{names}} +{{count}} más"
+          "presenceProfileOverflow": "{{names}} +{{count}} más",
+          "removeProjectFailed": "No se pudo eliminar el proyecto",
+          "wslFilesystemBoundaryDescription": "Git para este proyecto se ejecuta en {{distro}}, que accede a las unidades de Windows a través del puente del sistema de archivos WSL. Git será unas 20 veces más lento que en una copia dentro de {{distro}}.",
+          "wslFilesystemBoundaryTitle": "Este proyecto está almacenado en una unidad de Windows"
         },
         "settings": {
           "e12dab333b": "No se pudo cambiar de servidor",
@@ -313,6 +418,23 @@
             "7d4bc516ee": "Error al cambiar perfil",
             "f518e89aa5": "El proyecto ya existe en ese perfil",
             "f03ae7f27b": "Error al transferir proyecto"
+          }
+        },
+        "runtime": {
+          "status": {
+            "runtimeHostDisconnectedDescription": "Comprueba que Orca se esté ejecutando en este servidor y que tu conexión de red funcione, e inténtalo de nuevo.",
+            "runtimeHostUnreachable": "No se puede acceder al servidor de Orca",
+            "runtimeHostUnreachableNamed": "No se puede acceder a {{hostName}}",
+            "tryAgain": "Intentar de nuevo"
+          }
+        },
+        "terminal": {
+          "quick": {
+            "command": {
+              "hosts": {
+                "5b7d781d67": "No se pudo guardar el comando rápido"
+              }
+            }
           }
         }
       }
@@ -487,7 +609,12 @@
             "9e37a5b1b3": "Ejecutar trabajo independiente en paralelo",
             "bddc4c09b8": "Ejecutar un flujo de trabajo por fases",
             "ab0e9803b7": "Entregar a otro worktree",
-            "5e0d489fe1": "Entregar una tarea activa"
+            "5e0d489fe1": "Entregar una tarea activa",
+            "childParallelSummary": "Divide tareas de investigación o implementación independientes entre agentes secundarios.",
+            "childSequenceSummary": "Usa agentes secundarios uno tras otro cuando cada fase depende de la anterior.",
+            "handoffSummary": "Transfiere la responsabilidad a otro agente con contexto suficiente para continuar.",
+            "prSplitSummary": "Asigna a cada agente secundario su propio worktree para que la implementación en paralelo siga siendo revisable.",
+            "worktreeHandoffSummary": "Mueve el trabajo a un agente que ya se ejecuta en otra rama."
           }
         }
       },
@@ -589,6 +716,15 @@
         },
         "activation": {
           "cannotOpenFolderWorkspace": "No se puede abrir el espacio de trabajo de carpeta"
+        },
+        "creation": {
+          "flow": {
+            "structured": {
+              "launch": {
+                "unknown": "No se pudo confirmar si el chat de Codex se abrió. Reintenta para comprobarlo de nuevo."
+              }
+            }
+          }
         }
       },
       "folderWorkspacePathStatus": {
@@ -596,13 +732,15 @@
           "missing": "Carpeta no encontrada",
           "notDirectory": "La ruta no es una carpeta",
           "ambiguousConnection": "No se puede determinar la conexión",
-          "unavailable": "No se puede verificar la carpeta"
+          "unavailable": "No se puede verificar la carpeta",
+          "unrecognized": "La carpeta no se puede usar"
         },
         "description": {
           "missing": "Orca no puede encontrar {{path}}. Elimina y vuelve a importar este espacio de trabajo de carpeta.",
           "notDirectory": "{{path}} existe, pero no es una carpeta.",
           "ambiguousConnection": "Orca no puede determinar a qué conexión SSH pertenece este alcance de carpeta.",
-          "unavailable": "Orca no puede verificar esta carpeta ahora mismo. Revisa el host o la conexión SSH e inténtalo de nuevo."
+          "unavailable": "Orca no puede verificar esta carpeta ahora mismo. Revisa el host o la conexión SSH e inténtalo de nuevo.",
+          "unrecognized": "Orca no puede usar {{path}} y esta versión no reconoce el motivo. Actualiza Orca para ver los detalles."
         },
         "createError": {
           "title": {
@@ -630,7 +768,8 @@
         "wakeEphemeralVmFailed": "Error al activar el espacio de trabajo VM efímera"
       },
       "ephemeralVmWorkspaceTarget": {
-        "projectRootRegistrationFailed": "Error al registrar la raíz del proyecto creada por la receta en el entorno de ejecución"
+        "projectRootRegistrationFailed": "Error al registrar la raíz del proyecto creada por la receta en el entorno de ejecución",
+        "provisionedRootRequiresSsh": "Las recetas de raíz aprovisionada requieren actualmente una conexión SSH directa."
       },
       "blocked": {
         "notification": {
@@ -680,7 +819,21 @@
           "import": {
             "toast": {
               "restartFallbackUnavailableNone": "None of the {{value0}} cookies could be loaded, and the restart fallback was unavailable. The previous cookies for this profile were replaced. Try the import again.",
-              "restartFallbackUnavailablePartial": "Imported {{value0}} of {{value1}} cookies. The rest could not be loaded, and the restart fallback was unavailable. Try the import again."
+              "restartFallbackUnavailablePartial": "Imported {{value0}} of {{value1}} cookies. The rest could not be loaded, and the restart fallback was unavailable. Try the import again.",
+              "googleCookiesSkipped": "No se importaron las cookies de Google. Abre un navegador en Orca en {{value0}} con este perfil e inicia sesión en Google.",
+              "googleCookiesSkippedClientHosted": "No se importaron las cookies de Google. Abre una pestaña del navegador en el espacio de trabajo {{value0}} con este perfil — se abre en este dispositivo — e inicia sesión en Google.",
+              "googleCookiesSkippedLocal": "No se importaron las cookies de Google. Abre un navegador en Orca con este perfil e inicia sesión en Google.",
+              "googleCookiesSkippedRemoteWorkspace": "No se importaron las cookies de Google. Abre una pestaña del navegador en el espacio de trabajo {{value0}} con este perfil e inicia sesión en Google.",
+              "locationClientHosted": "Leídas desde este dispositivo y almacenadas aquí para el espacio de trabajo {{value0}}.",
+              "locationRemoteHost": "Leídas desde navegadores en {{value0}} y almacenadas allí.",
+              "partitionSkipped": "{{value0}} cookies no se importaron porque no se pudo leer su partición de sitio. Inicia sesión de nuevo en esos sitios en Orca.",
+              "undecryptableAppBound": "Orca no puede descifrar {{value0}} de las cookies de este navegador porque usan cifrado vinculado a la app. Puedes importar cookies desde un archivo con «Desde archivo…».",
+              "undecryptableAppBoundMixed": "Orca no puede descifrar {{value0}} de las cookies de este navegador porque usan cifrado vinculado a la app; {{value1}} más no se pudieron descifrar por otro motivo. Puedes importar cookies desde un archivo con «Desde archivo…».",
+              "undecryptableKeyring": "{{value0}} cookies no se pudieron descifrar porque el llavero del sistema no estaba disponible. Desbloquea tu llavero de inicio de sesión (o instala un proveedor de Secret Service como gnome-keyring) e importa de nuevo.",
+              "undecryptableKeyringMixed": "{{value0}} cookies no se pudieron descifrar porque el llavero del sistema no estaba disponible; {{value1}} más no se pudieron descifrar por otro motivo. Desbloquea tu llavero de inicio de sesión (o instala un proveedor de Secret Service como gnome-keyring) e importa de nuevo.",
+              "undecryptableUnknown": "{{value0}} cookies no se pudieron descifrar y se omitieron. Cierra por completo el navegador de origen e inténtalo de nuevo.",
+              "undecryptableUnrecognizedReason": "{{value0}} cookies no se pudieron descifrar y se omitieron por un motivo que esta versión de Orca no reconoce. Actualiza Orca para ver los detalles e inténtalo de nuevo.",
+              "unrecognizedWarning": "La importación de cookies terminó con una advertencia que esta versión de Orca no reconoce. Actualiza Orca para ver los detalles y revisa este perfil antes de confiar en sus cookies."
             }
           }
         }
@@ -701,6 +854,22 @@
             "additionalErrors": "{{count}} additional images could not be attached."
           }
         }
+      },
+      "activateAiVaultStructuredSession": {
+        "gone": "Este chat ya no está en este host, por lo que no se puede reabrir aquí.",
+        "hostCannotOpen": "Este chat no se puede reabrir hasta que se actualice Orca.",
+        "unavailable": "La sesión estructurada de agente aún no está disponible. Reintenta en un momento."
+      },
+      "ephemeralVmWorktreeCreation": {
+        "sparseCheckoutUnsupported": "Las recetas de raíz aprovisionada no admiten sparse checkout."
+      },
+      "file": {
+        "preview": {
+          "pairedOutsideWorktree": "Los archivos fuera del espacio de trabajo aún no se pueden previsualizar en un servidor emparejado."
+        }
+      },
+      "worktreeJumpNavigation": {
+        "filteredNotice": "Este worktree está oculto por los filtros de la barra lateral. El espacio de trabajo se abrió, pero no se muestra en Espacios."
       }
     },
     "hooks": {
@@ -708,7 +877,8 @@
         "59718b120b": "El espacio de trabajo de destino ya no está disponible.",
         "16a21d6413": "La reconexión SSH requiere credenciales interactivas.",
         "386db94f3e": "El proyecto de destino ya no está disponible.",
-        "3ad7d77f57": "El espacio de trabajo de destino está en un host distinto al destino de ejecución de esta automatización."
+        "3ad7d77f57": "El espacio de trabajo de destino está en un host distinto al destino de ejecución de esta automatización.",
+        "workspaceHostUnresolved": "El espacio de trabajo de destino abarca más de un host, por lo que esta ejecución no tiene un único host que usar."
       },
       "useComposerState": {
         "7eb3f44ff7": "El agente seleccionado está deshabilitado. Elige un agente habilitado antes de crear.",
@@ -829,7 +999,14 @@
         "linearDescription": "Cómo funciona Linear en Orca, lista de configuración, habilidad del agente y ejemplos de prompts.",
         "pluginsTitle": "Plugins",
         "pluginsDescription": "Instala y administra plugins experimentales de Orca.",
-        "tasksDescription": "Conecta proveedores, instala la habilidad de Linear y elige qué aparece en Tareas."
+        "tasksDescription": "Conecta proveedores, instala la habilidad de Linear y elige qué aparece en Tareas.",
+        "automationsTitle": "Automatizaciones",
+        "artifactsDescription": "Comparte archivos HTML y Markdown con tu equipo y gestiona sus enlaces públicos.",
+        "artifactsTitle": "Artefactos",
+        "automationsDescription": "Programa trabajo de agentes y elige si Automatizaciones aparece en la barra lateral.",
+        "floatingWorkspaceWebDescription": "Pestañas globales de terminal y markdown.",
+        "shareSkillsDescription": "Comparte tus skills con un enlace no listado. Cualquiera que lo tenga puede instalarlos.",
+        "shareSkillsTitle": "Compartir skills"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "El contenido pegado es demasiado grande."
@@ -842,6 +1019,33 @@
         "description": "Los mensajes de permisos de macOS pueden aparecer cuando un agente o una herramienta de terminal que se ejecuta en Orca intenta acceder a archivos protegidos. Concede acceso total al disco en Ajustes para reducir estos avisos.",
         "openSettings": "Abrir ajustes",
         "dismiss": "No volver a mostrar"
+      },
+      "useInstalledAgentSkills": {
+        "unreadableSkillSource": "Una carpeta de skills no respondió, por lo que este estado puede estar incompleto."
+      },
+      "useMacTccAttributionSeveredNotice": {
+        "description": "Las terminales de Orca en ejecución están alojadas por un daemon iniciado por una instalación anterior de Orca. Es posible que macOS no aplique los permisos de Accesibilidad, Automatización o archivos protegidos de Orca a ellas. Reinicia el daemon desde Gestionar sesiones para restaurar el acceso. Esto cerrará todas las terminales de Orca en ejecución.",
+        "openManageSessions": "Abrir Gestionar sesiones",
+        "title": "Es posible que los permisos de macOS no lleguen a las terminales de Orca",
+        "dismiss": "Descartar"
+      },
+      "ipc": {
+        "events": {
+          "browserStateIpcBridge": {
+            "docPreviewLinkFailed": "No se pudo abrir este enlace en el navegador Orca."
+          },
+          "os": {
+            "markdown": {
+              "file": {
+                "open": {
+                  "bridge": {
+                    "1e9a1a63c4": "No se pudo abrir el archivo Markdown."
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "components": {
@@ -851,7 +1055,11 @@
         "a4c8e1b2f7": "Codex sigue conectado como {{value0}}",
         "d3e8a1f4b2": "Cuenta cambiada",
         "9375620cc3": "Reinicia esta sesión para usar {{value0}}. Se mantiene en la cuenta anterior hasta que lo hagas.",
-        "6133594b12": "Mantener cuenta anterior"
+        "6133594b12": "Mantener cuenta anterior",
+        "3ea91b5c07": "Esta sesión de Codex usa una configuración desactualizada",
+        "7b1d20f4c8": "Mantener sesión actual",
+        "8f0d5c92a1": "La configuración de Codex cambió",
+        "e6b7139d2a": "Reinicia esta sesión para cargar tu configuración actual de Codex."
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "Descartar aviso",
@@ -1053,7 +1261,18 @@
           "activity": "Actividad",
           "noActivity": "Sin actividad aún."
         },
-        "checkActionRequiredHint": "Esta verificación necesita una acción manual en GitHub (por ejemplo, aprobar la ejecución del workflow) antes de que se desbloquee la fusión."
+        "checkActionRequiredHint": "Esta verificación necesita una acción manual en GitHub (por ejemplo, aprobar la ejecución del workflow) antes de que se desbloquee la fusión.",
+        "e15a8b77ef": "No hay detalles en línea disponibles para este check.",
+        "e45324fbed": "No se pudieron cargar los detalles del check.",
+        "d9fa90b625": "No se pudo cargar la diferencia.",
+        "8812225174": "Reabrir",
+        "09d67a0f9b": "No se pudo cerrar el pull request",
+        "88809e79db": "No se pudo reabrir el pull request",
+        "00f55cc17b": "El acceso al repositorio no está disponible para este pull request.",
+        "4aecf121e7": "Cerrar",
+        "85a2b66f54": "Abrir archivos en GitHub",
+        "86d84a17ca": "Añadir un comentario de revisión",
+        "dcb3c546fe": "Reintentar"
       },
       "GitLabItemDialog": {
         "65e784c1f1": "Reabrir",
@@ -1118,7 +1337,8 @@
         "3a051b8ade": "Work item",
         "32f8bef818": "Sin output de log.",
         "4168eb2c51": "Resolver",
-        "commentTooLarge": "El comentario es demasiado grande para enviarlo de forma segura."
+        "commentTooLarge": "El comentario es demasiado grande para enviarlo de forma segura.",
+        "gitlabActionFailed": "La acción de GitLab falló."
       },
       "JiraIssueWorkspace": {
         "b0b92666c9": "Comentar",
@@ -1367,7 +1587,10 @@
         "addSshHostHint": "Use an existing machine over SSH",
         "addRemoteOrcaServer": "Add Remote Orca Server",
         "addRemoteOrcaServerHint": "Pair another Orca runtime",
-        "hostConnectionFailed": "Connection failed"
+        "hostConnectionFailed": "Connection failed",
+        "setLocation": "Establecer ubicación del proyecto",
+        "setLocationOnHost": "Establecer ubicación del proyecto en {{host}}",
+        "setLocationTooltip": "Elige una carpeta o clona este proyecto en {{host}}."
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Crear worktree",
@@ -1548,7 +1771,10 @@
         "4b8ae7303f": "No se pudo cargar la diferencia.",
         "closePullRequestFailed": "No se pudo cerrar el pull request",
         "reopenPullRequestFailed": "No se pudo reabrir el pull request",
-        "diffLoadTimedOut": "Se agotó el tiempo de espera al cargar esta diferencia."
+        "diffLoadTimedOut": "Se agotó el tiempo de espera al cargar esta diferencia.",
+        "6b1d5ee3e4": "No hay detalles en línea disponibles para este check.",
+        "e04c027d98": "No se pudieron cargar los detalles del check.",
+        "5df7c41d2a": "Reintentar"
       },
       "QuickOpen": {
         "1dbd3f59ff": "Mover",
@@ -1937,7 +2163,9 @@
         "61ed600d29": "\"{{value0}}\" tiene cambios no guardados. ¿Quieres guardar antes de cerrar?",
         "cdc9ac4b2d": "editor",
         "e57db40c11": "No se pudo generar el comando de inicio para {{value0}}.",
-        "5b2c1a9e44": "No se detectó ninguna CLI de agente; instala una o elige un agente predeterminado en Ajustes."
+        "5b2c1a9e44": "No se detectó ninguna CLI de agente; instala una o elige un agente predeterminado en Ajustes.",
+        "b7c1f0a934": "No se pudo contactar a un host remoto, por lo que Orca no puede saber si el trabajo sigue en ejecución allí. ¿Cerrar la ventana de todos modos?",
+        "quitSnapshotSaveFailed": "Cierre cancelado: no se pudo guardar la instantánea de la sesión ({{value0}})."
       },
       "TerminalSearch": {
         "db234b7519": "Cerrar",
@@ -1993,7 +2221,8 @@
         "a4650b0dc4": "No se pudo usar la compilación local",
         "b1e390250d": "No se pudo completar el cambio de compilación local.",
         "d29740d175": "La compilación seleccionada no pudo ser usada.",
-        "37d45c9ec1": "Elegir otra compilación"
+        "37d45c9ec1": "Elegir otra compilación",
+        "7f1a4c9e02": "Tu gestor de paquetes del sistema instaló Orca, así que actualízalo desde allí; Orca no puede instalar esta versión por sí mismo."
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "Mover",
@@ -2037,7 +2266,8 @@
         "pluginCommandFailed": "No se pudo ejecutar el comando del plugin.",
         "27f10cca63": "Busca chats, terminales, worktrees, ajustes y acciones...",
         "2770f02910": "Busca chats, terminales, worktrees, ajustes y acciones",
-        "recentChatsTerminalsHeader": "Chats y terminales recientes"
+        "recentChatsTerminalsHeader": "Chats y terminales recientes",
+        "lastActiveTime": "Activo por última vez hace {{value0}}"
       },
       "github": {
         "pr": {
@@ -2218,6 +2448,30 @@
                 "7c302f8174": "Sin título"
               }
             }
+          },
+          "ProjectRoadmap": {
+            "6405e036e0": "Mes",
+            "0bb1c1bc07": "Zoom de cronología",
+            "343888b143": "Ubicado por {{value0}}",
+            "6a088a5da1": "{{value0}} sin fechas",
+            "86eebd6020": "Hoy",
+            "b6afc6fe45": "Año",
+            "be52f7b6db": "Esta vista de roadmap no tiene campo de fecha o iteración donde ubicar elementos, así que Orca los muestra como lista.",
+            "e077c79083": "Sin fechas",
+            "e304235879": "Elemento",
+            "f2b1cabef7": "Trimestre"
+          },
+          "ProjectRoadmapBar": {
+            "7d1220d979": "Elemento restringido",
+            "cd68ccc17a": "{{value0}} — {{value1}}"
+          },
+          "ProjectPickerPanels": {
+            "9fe1ac868c": "No compatible",
+            "04ec212ccb": "Roadmap"
+          },
+          "ProjectViewStates": {
+            "ac83c45672": "Cambia a una vista de tabla o roadmap para trabajar con este proyecto en Orca.",
+            "e4cc8b14f2": "Orca representa vistas de proyecto de tabla y roadmap. Esta vista usa un diseño que aún no puede representar."
           }
         },
         "GitHubMarkdownComposer": {
@@ -2346,6 +2600,11 @@
             "label": "Cerrar como duplicado",
             "description": "Duplicado de otro issue"
           }
+        },
+        "CommentReactions": {
+          "addNamedReaction": "Añadir reacción {{value0}}",
+          "addReaction": "Añadir reacción",
+          "removeNamedReaction": "Quitar reacción {{value0}}"
         }
       },
       "linear": {
@@ -2552,7 +2811,9 @@
             "selectedForDeletionCount": "Seleccionados para eliminar: {{value0}}",
             "deleteButtonCount": "Eliminar {{value0}}",
             "archivedStatus": "Archivado",
-            "readyStatus": "Listo"
+            "readyStatus": "Listo",
+            "74f6c16279": "Volver",
+            "f637f63882": "El Gestor de recursos cuenta {{value0}}; esta lista encontró {{value1}}. Ese contador solo lee el registro de actividad de Orca, mientras que este análisis también revisa el historial de git de cada espacio de trabajo y omite los remotos desconectados."
           },
           "backgroundRemoval": {
             "removed": "Espacios de trabajo eliminados: {{value0}}",
@@ -2599,6 +2860,16 @@
             "dirtyFilesBlocker": "Archivos modificados",
             "unknownBaseBlocker": "No se pudieron verificar confirmaciones sin enviar",
             "dismissedBlocker": "Ignorado"
+          },
+          "workspace": {
+            "cleanup": {
+              "candidate": {
+                "row": {
+                  "b5d2b33e47": "Eliminando…",
+                  "e1135728e3": "En cola para eliminación"
+                }
+              }
+            }
           }
         }
       },
@@ -2633,12 +2904,15 @@
           "commands": {
             "TerminalQuickCommandActionToggle": {
               "b0d58e37ed": "Prompt de agente",
-              "b5ea4d64f6": "Comando de terminal"
+              "b5ea4d64f6": "Comando de terminal",
+              "terminal_short": "Terminal",
+              "agent_short": "Agente"
             },
             "TerminalQuickCommandAppendEnterSwitch": {
               "e4e5fed3b3": "Alternar agregar Enter",
               "c936c2d6d2": "Enviar inmediatamente en lugar de solo insertar texto.",
-              "5fa607d807": "Agregar Enter"
+              "5fa607d807": "Agregar Enter",
+              "767e4be3e3": "Añadir Enter — ejecutar de inmediato"
             },
             "TerminalQuickCommandDialog": {
               "925b8e0f6e": "Avanzado",
@@ -2655,7 +2929,11 @@
               "dc921c17ee": "Prompt",
               "5b3f634a55": "Agregar comando rápido",
               "f9b184fc16": "Editar comando rápido",
-              "6751598542": "editar"
+              "6751598542": "editar",
+              "command_label": "Comando",
+              "agent_footer_hint": "Los prompts multilínea están bien; mantenlos enfocados.",
+              "agent_toolbar_hint": "Admite /goal, skills y rutas",
+              "resize_hint": "Arrastra la esquina para redimensionar"
             },
             "TerminalQuickCommandDialogFooter": {
               "2e2b958dfc": "Guardar",
@@ -2736,14 +3014,23 @@
             "c2f0b72b8d": "Insertar",
             "925f49f210": "Expandir panel",
             "df766809e0": "Contraer panel",
-            "cff67afad1": "Copiar contexto"
+            "cff67afad1": "Copiar contexto",
+            "15dd899676": "Añadir a {{value0}}…"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Reiniciar servicio",
             "a7e2fd2699": "abre un issue",
             "5c8ce20be6": "Si esto persiste, por favor",
             "cc6d997c65": "Reinicia el servicio del terminal desde aquí para borrar el estado obsoleto.",
-            "remoteTerminalClosed": "La terminal remota se cerró."
+            "remoteTerminalClosed": "La terminal remota se cerró.",
+            "retrying": "Reintentando…",
+            "42b283ecfc": "Orca no pudo reconectar esta terminal de forma segura porque el host no pudo verificar su sesión guardada. Orca dejó la sesión guardada sin cambios. Haz clic en Reintentar para reconectar ahora. Si aún no puede reconectar, abre una terminal nueva.",
+            "e16012e31e": "El daemon de terminal propietario de esta sesión terminó, por lo que la sesión y su historial no se pudieron recuperar. Abre una terminal nueva para continuar.",
+            "ownerUnknown": "Orca no pudo verificar el propietario de esta terminal.",
+            "retry": "Reintentar",
+            "retryUnavailable": "Reintentar aún no pudo reconectar. Inténtalo de nuevo en breve.",
+            "sessionUnavailable": "Orca no pudo reasociar la sesión de terminal de este panel en el host. Abre una terminal nueva para continuar.",
+            "sourceRestoring": "Reconectando esta terminal; su salida se está restableciendo. La sesión sigue en ejecución."
           },
           "TerminalProcessExitOverlay": {
             "capacityTitle": "Se alcanzó el límite de consolas de Git Bash",
@@ -2885,6 +3172,29 @@
             "retryingBody": "Orca is retrying automatically. This terminal will resume if the connection returns.",
             "disconnectedBody": "Automatic retries stopped. Reconnect to resume this terminal session.",
             "reconnectButton": "Reconnect"
+          },
+          "TerminalLinkActionPopover": {
+            "openLink": "Abrir enlace",
+            "openFile": "Abrir archivo",
+            "copyLink": "Copiar enlace",
+            "copiedLink": "Enlace copiado",
+            "copyLinkFailed": "No se pudo copiar el enlace",
+            "downloadOpenFailed": "No se pudo descargar '{{value0}}'.",
+            "copied": "Copiado",
+            "downloadOpenWithDefaultApp": "Descargar y abrir con la app predeterminada",
+            "openFolder": "Abrir carpeta",
+            "openInFinder": "Abrir en Finder",
+            "openTaskTerminal": "Abrir terminal de tarea",
+            "openWithDefaultApp": "Abrir con la app predeterminada",
+            "orcaBrowser": "Navegador Orca",
+            "switchTerminal": "Cambiar de terminal",
+            "switchWorkspace": "Cambiar de espacio de trabajo",
+            "systemBrowser": "Navegador del sistema",
+            "terminalLinkSettings": "Ajustes de enlaces de terminal"
+          },
+          "TerminalQuickCommandsSubmenu": {
+            "3ccc7981bb": "Host no disponible",
+            "54f29b7c0d": "Cargando host…"
           }
         }
       },
@@ -2947,7 +3257,10 @@
             "1d04b1630b": "Dividir hacia abajo",
             "6b3efb106e": "Dividir hacia arriba",
             "fdd29eb669": "Fijar pestaña",
-            "8e9d603a09": "Desanclar pestaña"
+            "8e9d603a09": "Desanclar pestaña",
+            "openContainingFolder": "Abrir carpeta contenedora",
+            "revealInFileExplorer": "Mostrar en el Explorador de archivos",
+            "revealInFinder": "Mostrar en Finder"
           },
           "QuickLaunchButton": {
             "348a04c1ad": "Ajustes de Agents…",
@@ -3111,6 +3424,14 @@
           },
           "TerminalTabLeadingIcon": {
             "7ab2964bea": "Finalización de agente sin leer"
+          },
+          "TabBarQuickCommandAddActions": {
+            "45a2f36d51": "Comando",
+            "b856c833ae": "Comando en {{value0}}"
+          },
+          "TabBarQuickCommandHostLoadStatus": {
+            "82e294f3ca": "Host no disponible",
+            "7c129b08ff": "Cargando host…"
           }
         }
       },
@@ -3228,7 +3549,9 @@
             "connectedHostCount_other": "{{count}} hosts",
             "connecting": "Conectando…",
             "workspaceConflict": "Conflicto del espacio de trabajo",
-            "workspaceSyncError": "Error de sincronización del espacio de trabajo"
+            "workspaceSyncError": "Error de sincronización del espacio de trabajo",
+            "runtime_unavailable_transport_up": "Orca no disponible",
+            "runtime_workspace_window_closed": "Ventana de espacio de trabajo cerrada"
           },
           "CaffeinateStatusSegment": {
             "active": "Activo",
@@ -3462,7 +3785,14 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
+            "minimax": {
+              "expired": {
+                "apiKey": "La clave API de MiniMax caducó. Reemplázala en Ajustes.",
+                "cookie": "La cookie de sesión de MiniMax caducó. Reemplázala en Ajustes.",
+                "label": "Inicio de sesión caducado"
+              }
+            }
           },
           "SshTargetStatusRow": {
             "sshHost": "Host SSH"
@@ -3542,6 +3872,18 @@
             "stoppingLabel": "Stopping update",
             "stoppingTooltip": "Stopping the skill update…",
             "stoppingAria": "Stopping the skill update. Click to open details."
+          },
+          "RuntimeHostStatusRow": {
+            "reconnect_attempt": "Intento {{value0}}",
+            "checking_host": "Orca está comprobando si este host es accesible",
+            "contact_note": "Es posible que el host siga en ejecución; solo la conexión de Orca no está disponible.",
+            "host_unreachable": "Orca no es accesible en este host",
+            "last_connected": "Última conexión {{value0}}",
+            "previous_connection_closed": "La conexión anterior se cerró",
+            "restoring_connection": "Orca está intentando restaurar la conexión",
+            "runtime_unavailable": "El transporte SSH está conectado, pero el runtime de Orca no está disponible",
+            "runtime_unavailable_explanation": "Es posible que el host remoto siga en ejecución; solo la conexión del runtime de Orca no está disponible.",
+            "workspace_window_closed": "La ventana del espacio de trabajo está cerrada"
           }
         }
       },
@@ -3728,7 +4070,8 @@
           "908c470587": "codex",
           "eb6a066185": "claude",
           "eee19cfade": "resumen",
-          "grokUsageTab": "Grok"
+          "grokUsageTab": "Grok",
+          "trackingSince": "Registrando desde {{value0}}"
         },
         "UsageOverviewPane": {
           "22ed1b7669": "sesiones",
@@ -3816,13 +4159,19 @@
               "6762f6a682": "tokens",
               "a7f937fb29": "{{value0}} sesiones - {{value1}} {{value2}}",
               "c8f3a2d1e0b4": "turnos",
-              "d9a4b3e2f1c5": "eventos"
+              "d9a4b3e2f1c5": "eventos",
+              "statusEnabled": "Habilitado",
+              "statusOff": "Desactivado",
+              "statusScanning": "Escaneando"
             }
           }
         },
         "UsageBreakdownSection": {
           "7765a4c3e1": "n/a",
-          "247c93ca92": "• precios inferidos"
+          "247c93ca92": "• precios inferidos",
+          "32176e1d44": "turnos",
+          "79a69522a5": "eventos",
+          "02a046792e": "sesiones •"
         },
         "UsageSessionsTable": {
           "1afc25eb06": "Turnos",
@@ -3906,10 +4255,32 @@
           "remoteShareNotice": "Estas skills están en {{host}}. Abre Skills en esa máquina para compartirlas.",
           "viewSwitch": "Mostrar",
           "searchLinks": "Buscar enlaces",
-          "deleteSkills": "Eliminar skills…"
+          "deleteSkills": "Eliminar skills…",
+          "984405683f": "Plugin",
+          "aa59462502": "Repositorio",
+          "571c5818c1": "Inicio",
+          "fb6bf60b52": "Claude",
+          "426be2aac6": "Codex",
+          "b088e0785d": "Beta",
+          "0bc1379f4c": "Todas las fuentes",
+          "0c74e7ff34": "Instalado",
+          "38e0951c3a": "Skills de agente",
+          "39b6998ddb": "Todos los proveedores",
+          "4d177feabd": "Incluidos",
+          "7e828fb2c6": "Atrás",
+          "ab5b777350": "Se revisaron las carpetas de skills de inicio, repositorio, incluidas y de plugins.",
+          "e46e162e2e": "de"
         },
         "SkillShareSelectionControls": {
-          "01c5a15e02": "Compartir skills"
+          "01c5a15e02": "Compartir skills",
+          "01c5a15e01": "Cancelar uso compartido",
+          "01c5a15e03": "{{value0}} seleccionados",
+          "01c5a15e04": "Seleccionar todos los resultados",
+          "01c5a15e05": "Compartir {{value0}} skills",
+          "01c5a15e06": "Abre este skill en su máquina propietaria para compartirlo.",
+          "01c5a15e07": "Instala este skill antes de compartirlo.",
+          "01c5a15e08": "Solo se pueden compartir skills de inicio y de espacios de trabajo.",
+          "01c5a15e09": "Ya hay un skill con este nombre seleccionado desde otra fuente."
         },
         "SkillRow": {
           "updatedUnknown": "Sin fecha",
@@ -3918,7 +4289,11 @@
           "detailPath": "Ruta",
           "skillActions": "Acciones para {{value0}}",
           "viewDetails": "Ver detalles",
-          "deleteSkill": "Eliminar…"
+          "deleteSkill": "Eliminar…",
+          "detailContents": "Contenido",
+          "detailSource": "Fuente",
+          "notDeletable": "No eliminable",
+          "notShareable": "No compartible"
         },
         "SkillsList": {
           "listLabel": "Skills"
@@ -3950,7 +4325,19 @@
           "shareOne": "Compartir {{count}} skill",
           "shareOther": "Compartir {{count}} skills",
           "linkOne": "{{count}} enlace",
-          "linkOther": "{{count}} enlaces"
+          "linkOther": "{{count}} enlaces",
+          "deleteLinkOne": "{{count}} enlace",
+          "deleteLinkOther": "{{count}} enlaces",
+          "deleteFolderOne": "{{count}} carpeta",
+          "deleteFolderOther": "{{count}} carpetas",
+          "deleteOne": "Eliminar {{count}} skill",
+          "deleteOther": "Eliminar {{count}} skills",
+          "deletedOne": "{{count}} skill eliminado",
+          "deletedOther": "{{count}} skills eliminados",
+          "installOne": "Instalar {{count}} skill",
+          "installOther": "Instalar {{count}} skills",
+          "retryOne": "Reintentar {{count}} skill",
+          "retryOther": "Reintentar {{count}} skills"
         },
         "filter": {
           "allAgents": "Todos los agentes",
@@ -4057,7 +4444,9 @@
           "upToDate": "Actualizado",
           "installed": "Instalado",
           "details": "Details",
-          "needsAttention": "Review skill"
+          "needsAttention": "Review skill",
+          "checkFailed": "La comprobación falló",
+          "checking": "Comprobando…"
         },
         "SkillUpdateResultRows": {
           "stillOutdated": "Still out of date after the update ran."
@@ -4069,6 +4458,376 @@
         "host": {
           "local": "Esta máquina",
           "remote": "Entorno conectado"
+        },
+        "SkillShareDialog": {
+          "30985d4fc0": "Cancelar",
+          "0f07fa2a79": "Publicar skill",
+          "3a51d0f34f": "Cancelar carga",
+          "3af85f6add": "Hecho",
+          "7aa4ba0dba": "Publicar nueva versión",
+          "cancelRequestFailed": "Orca no pudo enviar la solicitud de cancelación. La carga podría completarse.",
+          "copied": "Enlace para compartir copiado",
+          "description": "Revisa los archivos exactos, elige quién puede acceder a ellos y publica una versión inmutable.",
+          "descriptionV2": "Revisa los archivos exactos y publica una versión inmutable tras un enlace no listado.",
+          "e9d652ae3d": "Cancelando…",
+          "newVersionDescription": "Revisa los archivos exactos y publica una versión inmutable en el paquete Cloud existente.",
+          "peopleRequired": "Selecciona al menos un compañero de equipo.",
+          "prepareFailed": "No se pudo preparar este skill para compartir.",
+          "preparing": "Preparando vista previa…",
+          "publishBundle": "Publicar paquete",
+          "publishCancelled": "Carga cancelada. La copia preparada sigue disponible para reintentar.",
+          "publishFailed": "No se pudo publicar este skill. La copia preparada sigue disponible para reintentar.",
+          "ready": "Enlace del skill listo",
+          "readyDescription": "Los destinatarios se autentican con Orca antes de poder inspeccionarlo o instalarlo.",
+          "readyDescriptionV2": "Cualquiera con este enlace no listado puede inspeccionar e instalar los skills.",
+          "reconnect": "Reconecta tu cuenta de Orca antes de compartir.",
+          "title": "Compartir skill",
+          "unconfigured": "Conecta una cuenta de Orca Cloud antes de compartir."
+        },
+        "SkillCloudManagementActions": {
+          "copyLink": "Copiar enlace",
+          "0ac5c175fd": "Confirmar que se deja de compartir",
+          "2552c12fea": "Acceso",
+          "2b8c569ea7": "Organización actual",
+          "3d346ddce8": "destinatario existente",
+          "505cd6105c": "Controles de uso compartido Cloud",
+          "640bc6b92e": "Confirmar eliminación del paquete",
+          "6b6adf68c1": "Eliminar versión Cloud seleccionada",
+          "7a80285dad": "Dejar de compartir",
+          "8cac3b9362": "Enlaces activos",
+          "9e6bd31487": "Sin enlaces para compartir activos.",
+          "activeLinkBearerDescription": "Cualquiera con un enlace activo puede inspeccionar e instalar los skills. Revocar bloquea el acceso futuro, pero deja sin cambios las copias instaladas.",
+          "bbec37d8f8": "Confirmar eliminación de la versión",
+          "c7f2b69122": "Dejar de compartir bloquea futuras instalaciones. Las copias ya instaladas en cualquier máquina permanecen allí.",
+          "cc8e4ef6ba": "Guardar acceso",
+          "eb603f7888": "fuera de la lista actual se conservará.",
+          "ed753624c0": "Eliminar paquete Cloud",
+          "linkCopied": "Enlace para compartir copiado"
+        },
+        "SkillInstallDialog": {
+          "241e72f9d6": "Instalando…",
+          "01c5a14e01": "Instalar skills compartidos",
+          "05588076a9": "Cancelar instalación",
+          "39acb9e8f4": "Instalar skill",
+          "4a00d133c5": "Orca verifica el acceso y la identidad del paquete antes de cambiar la máquina seleccionada.",
+          "59c3b76cdd": "Reintentar instalación",
+          "d198ec91e5": "Cerrar",
+          "fcbec627cc": "Instalar skill compartido",
+          "opening": "Abriendo este enlace…"
+        },
+        "SkillInstallManagementDialog": {
+          "6cb1fbe039": "Este equipo",
+          "070654c6d1": "Orca los conservará a menos que descartes explícitamente los cambios locales.",
+          "0900db719a": "— desconectado",
+          "176fef9516": "· SSH",
+          "1c9e7f420a": "Skills del paquete instalado",
+          "2ae587d39c": "Reintentar cobertura incompleta",
+          "34c2ef9e71": "Instalar {{count}} skills",
+          "3677ae58e7": "Actualiza, revierte o elimina de forma segura versiones instaladas por Orca.",
+          "44d118a8f7": "Gestionar skills instalados",
+          "470d8d2476": "Confirmar eliminación",
+          "561e49ccd1": "Instalar versión seleccionada",
+          "64c71cf7b9": "No se encontraron instalaciones de skills gestionadas por Orca en esta máquina.",
+          "74b70892ea": "Se modificaron archivos locales",
+          "8095927ff3": "Cerrar",
+          "86ed219b55": "Elige una versión",
+          "9c04bd0120": "Versión instalada",
+          "a0cab67c2f": "Eliminar {{count}} skills",
+          "c1d03ee50d": "Cancelar instalación",
+          "dab29e4b54": "{{installed}} instalados · {{updated}} actualizados · {{keptLocal}} conservados localmente",
+          "e1884c812e": "Descartar cambios e instalar versión",
+          "e91af0079f": "Eliminar",
+          "f7c5075e77": "Descartar cambios y eliminar",
+          "f970d8088d": "Confirmar eliminación de {{count}} skills",
+          "installAnotherMachine": "Instalar en otra máquina"
+        },
+        "SkillInstallReviewContent": {
+          "fab8fce842": "archivos",
+          "157de228b4": "Inspeccionar skill",
+          "1b6ad2ca5c": "comprobados.",
+          "27672470d9": "Abrir el enlace no instala nada. Revisa primero la versión inmutable.",
+          "2a31912f14": "Orca encontró",
+          "37d990b94c": "modificado",
+          "3d8421ca2f": "ejecutables",
+          "3fc62a61eb": "ubicación",
+          "651b7d8a57": "La copia local requiere decisión",
+          "66270286ac": "· Puedes reintentar sin riesgo.",
+          "66cff7a804": "https://app.orca.dev/skills/share/…",
+          "69236de8d6": "Comprobando…",
+          "87137bcb8d": "scripts",
+          "89e2601162": "Descartar y reemplazar",
+          "8f9833d509": "Versión inmutable",
+          "93eb0fe8c7": "Enlace de skill de Orca",
+          "98ed90e523": "Un skill contiene instrucciones y puede incluir scripts. Trátalo como código de su autor.",
+          "a5675fb371": "contenido y lo dejó intacto. Consérvalo o descártalo explícitamente y reemplázalo con esta versión.",
+          "f72ee4022a": "SHA-256",
+          "releaseNotes": "Notas de la versión:",
+          "targetHeader": "Destino de instalación"
+        },
+        "SkillInstallTargetFields": {
+          "7a366323e7": "Carpeta",
+          "8562dd1e6e": "Este equipo",
+          "0785d0a503": "— actualización requerida",
+          "0c10a406fb": "WSL ·",
+          "0e5b43a9e3": "Espacio de trabajo",
+          "63cc9e31fe": "Destino",
+          "71eefd7660": "— desconectado",
+          "8e6a972229": "No se conocen espacios de trabajo en esta máquina.",
+          "a4dfd33095": "Un espacio de trabajo",
+          "b8a0b706ad": "Máquina",
+          "c779621aa0": "Skills globales",
+          "cb47652227": "Entorno de ejecución",
+          "d628c416a2": "Worktree de Git",
+          "e5b0d15e64": "Sistema operativo del host",
+          "5845cfe543": "Elige un worktree o carpeta",
+          "85d85880df": "· SSH"
+        },
+        "SkillInstallWorkspaceCombobox": {
+          "search": "Buscar espacios de trabajo...",
+          "empty": "No se encontraron espacios de trabajo."
+        },
+        "SkillShareReviewContent": {
+          "6d6233a3a4": "Copiar enlace",
+          "f0c0411549": "Notas de la versión",
+          "3121f44358": "archivos",
+          "0142581727": "Subiendo…",
+          "01c5a17e01": "{{value0}} skills",
+          "01c5a17e02": "Revisar skills incluidos",
+          "01c5a17e03": "{{value0}} archivos · {{value1}}",
+          "0a49d901ab": "Organización",
+          "0cd4b3e396": "Todos los actuales en",
+          "266527d295": "Publicando como {{value0}}{{value1}}.",
+          "2dca0b720b": "Publicar nueva versión del skill",
+          "4895d3e0ee": "No hay compañeros de equipo disponibles.",
+          "6817a7f6f8": "Acceso al skill",
+          "77f636eac3": "ejecutables",
+          "78d863235c": "Acceso",
+          "8188f5d765": "puede acceder al enlace.",
+          "8edd32622f": "scripts",
+          "ad940367a5": "Validando y publicando…",
+          "b3b1d4b911": "SHA-256",
+          "bf02d6ed9e": "¿Qué cambió en esta versión?",
+          "bundleReady": "Enlace del paquete de skills listo",
+          "c15d90c10b": "Se requiere una cuenta conectada de Orca Cloud.",
+          "e3caf6baeb": "Revocar este enlace bloquea el acceso futuro. No elimina las copias ya instaladas en las máquinas de los destinatarios.",
+          "f25429e266": "Personas seleccionadas",
+          "fe204e06f0": "la organización",
+          "publishBundleVersion": "Publicar nueva versión del paquete de skills",
+          "publishingLink": "Publicando enlace…",
+          "shareBundle": "Compartir paquete de skills",
+          "unlistedLinkDetails": "El enlace no es buscable ni público. Revócalo para bloquear el acceso futuro; las copias instaladas permanecen.",
+          "unlistedLinkTitle": "Enlace no listado",
+          "unlistedPublishingAs": "Publicando como {{value0}}. Cualquiera con el enlace puede inspeccionar e instalar estos skills.",
+          "verifyingPackage": "Verificando paquete…"
+        },
+        "SkillBundleInstallFlow": {
+          "01c5a13e03": "Instalando…",
+          "01c5a13e01": "Cerrar",
+          "01c5a13e02": "Cancelar instalación",
+          "01c5a13e04": "Reintentar {{value0}} skills",
+          "01c5a13e05": "Instalar {{value0}} skills"
+        },
+        "SkillBundleInstallOutcome": {
+          "01c5a12e06": "Cancelado",
+          "01c5a12e01": "Instalado",
+          "01c5a12e02": "Actualizado",
+          "01c5a12e03": "Sin cambios",
+          "01c5a12e04": "Conservado localmente",
+          "01c5a12e05": "Fallido",
+          "01c5a12e07": "La instalación del paquete requiere atención.",
+          "01c5a12e08": "Skills instalados y verificados.",
+          "01c5a12e09": "{{value0}} skills seleccionados comprobados.",
+          "01c5a12e10": "Requiere reintento"
+        },
+        "SkillBundleInstallReview": {
+          "01c5a11e0d": "Seleccionar todo",
+          "01c5a11e01": "Versión inmutable",
+          "01c5a11e02": "{{value0}} skills",
+          "01c5a11e03": "{{value0}} archivos",
+          "01c5a11e04": "{{value0}} scripts",
+          "01c5a11e05": "{{value0}} ejecutables",
+          "01c5a11e06": "SHA-256",
+          "01c5a11e09": "Notas de la versión:",
+          "01c5a11e0a": "Los skills contienen instrucciones y pueden incluir scripts. Trátalos como código de su autor.",
+          "01c5a11e0b": "Skills a instalar",
+          "01c5a11e0c": "Elige cualquier subconjunto de este paquete.",
+          "01c5a11e0e": "Sin descripción",
+          "01c5a11e0f": "{{value0}} archivos · {{value1}} scripts",
+          "01c5a11e10": "{{value0}} ejecutables",
+          "01c5a11e11": "Las copias locales requieren decisión",
+          "01c5a11e12": "Orca conservará estas copias locales por defecto. Selecciona solo las copias que quieras descartar y reemplazar.",
+          "01c5a11e13": "Reemplazar {{value0}} ({{value1}})",
+          "01c5a11e14": "{{value0}} nuevos",
+          "01c5a11e15": "{{value0}} sin cambios",
+          "01c5a11e16": "{{value0}} actualizaciones",
+          "01c5a11e17": "{{value0}} conflictos"
+        },
+        "SkillSelectionBar": {
+          "selectAll": "Seleccionar las {{count}} aptas",
+          "clear": "Borrar"
+        },
+        "share": {
+          "fileScript": "script",
+          "releaseNotesVersion": "Notas de la versión",
+          "accessSummary": "Cualquiera con el enlace puede instalar esto. No está listado en ningún lugar, y revocarlo bloquea nuevas instalaciones, no las copias ya instaladas. Publicando como {{value0}}.",
+          "accessSummaryPlain": "Enlace no listado — cualquiera con él puede instalar esto.",
+          "accessSummaryShort": "Enlace no listado — cualquiera con él puede instalar esto. Publicando como {{value0}}.",
+          "description": "Publica una versión inmutable tras un enlace no listado.",
+          "executableOne": "{{count}} ejecutable",
+          "executableOther": "{{count}} ejecutables",
+          "fileExecutable": "ejecutable",
+          "manageLinks": "Gestiona o revoca este enlace en Ajustes",
+          "newVersionDescription": "Publica una versión inmutable en el paquete existente.",
+          "newVersionDescriptionPlain": "Añade una nueva versión al enlace existente.",
+          "noExecutableContent": "Sin scripts ni ejecutables",
+          "readyDescription": "Copia el enlace para compartirlo.",
+          "releaseNotesFirst": "Describe esta versión",
+          "releaseNotesOptional": "Añade notas de la versión (opcional)",
+          "reviewFiles": "Revisar archivos que pueden ejecutarse",
+          "reviewSkills": "Revisar skills incluidos",
+          "scriptOne": "{{count}} script",
+          "scriptOther": "{{count}} scripts"
+        },
+        "description": {
+          "showLess": "Mostrar menos",
+          "showMore": "Mostrar más"
+        },
+        "install": {
+          "agentNotInstalled": "No instalado",
+          "agentsNone": "Ningún agente seleccionado",
+          "rowNew": "Nuevo",
+          "fileBinary": "binario",
+          "selectAll": "Seleccionar todo",
+          "agentAlways": "Siempre",
+          "agentsCanonical": "Siempre instalado para {{value0}}, que lee {{value1}}.",
+          "agentsCanonicalNote": "{{value0}} lee {{value1}}, que cada instalación escribe.",
+          "agentsLabel": "Agentes",
+          "agentsNoneChosen": "Sin agentes adicionales",
+          "agentsSelected": "Instalando para: {{value0}}",
+          "agentsSummary": "También: {{value0}}",
+          "authorizing": "Autorizando acceso al paquete…",
+          "bundleDestinationSummary": "{{value0}} nuevos · {{value1}} ya instalados · {{value2}} requieren decisión",
+          "bundleSkillsMissing": "Esta versión no contiene ninguno de los skills del paquete instalado.",
+          "bundleVerificationFailed": "La instalación falló antes de que Orca pudiera verificar el paquete solicitado.",
+          "chooseSkills": "Elige qué instalar desde este enlace.",
+          "chooseWorkspace": "Elige un espacio de trabajo.",
+          "destinationAlreadyFinished": "El destino ya había terminado esta instalación.",
+          "enterShareLink": "Introduce un enlace para compartir skills de Orca.",
+          "inspectManagedFailed": "Orca no pudo inspeccionar las instalaciones gestionadas en esta máquina.",
+          "installing": "Descargando, verificando e instalando…",
+          "linkHint": "Abrir un enlace nunca instala nada; primero lo revisas.",
+          "reconnectBeforeInstalling": "Reconecta tu cuenta de Orca antes de instalar.",
+          "reconnectBeforeVersionChange": "Reconecta tu cuenta de Orca antes de cambiar de versión.",
+          "reconnectForVersionHistory": "Reconecta tu cuenta de Orca para cargar el historial de versiones.",
+          "removeFailed": "Orca no pudo eliminar este skill de forma segura.",
+          "requestedVersionVerificationFailed": "La instalación falló antes de que Orca pudiera verificar la versión solicitada.",
+          "rowInstalled": "Ya instalado",
+          "rowNeedsDecision": "Requiere decisión",
+          "rowUpdate": "Actualizar",
+          "selectSkill": "Selecciona al menos un skill.",
+          "shareUnavailable": "Este recurso compartido no está disponible. Es posible que el enlace no sea válido, haya caducado o se haya revocado.",
+          "singleRunnableWarning": "Este skill incluye scripts o archivos binarios.",
+          "trustNote": "Los skills son instrucciones y código de su autor. Instala lo que te inspire confianza.",
+          "versionHistoryUnavailable": "El historial de versiones no está disponible para este skill.",
+          "versionVerificationFailed": "Orca no pudo verificar la versión solicitada.",
+          "agentAccessWarning": "Los skills contienen instrucciones que tu agente podría seguir. Continúa solo si confías en la fuente de este enlace compartido.",
+          "agentsCountBadge": "{{count}} seleccionados",
+          "agentsCountLabel": "{{count}} {{label}}",
+          "additionalAgentsHeader": "Directorios de agentes adicionales",
+          "canonicalExplanation": "Estos agentes leen nativamente {{root}}, donde Orca instala por defecto:",
+          "canonicalHeader": "Agentes estándar (siempre incluidos)",
+          "deselectAll": "Deseleccionar opcionales",
+          "fileRunnable": "ejecutable",
+          "reviewInstructions": "Acerca de este skill",
+          "reviewRunnableFiles": "Incluye scripts o archivos binarios",
+          "reviewSupportingFiles": "Incluye archivos de apoyo",
+          "runnableWarning": "{{affectedCount}} de {{selectedCount}} skills seleccionados incluyen scripts o archivos binarios: {{affected}}.",
+          "supportingFileWarning": "Los skills seleccionados incluyen {{fileCount}} además de SKILL.md.",
+          "targetAgentsHeader": "Agentes de destino"
+        },
+        "managedInstall": {
+          "versionLabel": "Versión",
+          "cancel": "Cancelar",
+          "scopeWorkspace": "Este espacio de trabajo",
+          "skillMissing": "Falta",
+          "confirmRemove": "Confirmar eliminación",
+          "discardEdits": "Descartar mis ediciones y reinstalar",
+          "discardEditsRemove": "Descartar mis ediciones y eliminar",
+          "editedWarning": "Tus ediciones se conservan a menos que elijas descartarlas.",
+          "finishInstall": "Terminar instalación",
+          "installElsewhere": "Instalar en otro lugar…",
+          "installedOn": "Instalado {{date}}",
+          "reinstall": "Reinstalar",
+          "remove": "Eliminar",
+          "scopeGlobal": "En todas partes",
+          "sendToMachine": "Enviar a otra máquina",
+          "skillEdited": "Editado",
+          "stateEdited": "Editado tras instalar",
+          "stateMissing": "Faltan archivos",
+          "titleMore": "{{name}} +{{count}}",
+          "useVersion": "Usar esta versión",
+          "versionCurrent": "{{date}} (instalada)"
+        },
+        "SkillDelete": {
+          "confirmPermanent": "Esto no se puede deshacer.",
+          "placementJoin": " y ",
+          "blockedLine": "{{count}} × {{reason}}",
+          "confirmHost": "En {{host}}.",
+          "dismissResults": "Descartar",
+          "failed": "No se pudieron eliminar los skills",
+          "hostUnavailable": "No se pudo contactar la máquina seleccionada. Actualiza e inténtalo de nuevo.",
+          "hostUnresolved": "Aún buscando la máquina propietaria de estos skills.",
+          "hostUpdateRequired": "Actualiza Orca en la máquina seleccionada para eliminar skills.",
+          "nothingOne": "Ese skill no se puede eliminar desde aquí.",
+          "nothingOther": "Ninguno de los {{count}} skills seleccionados se puede eliminar desde aquí.",
+          "placementSummaryParts": "Elimina {{parts}} en {{roots}}.",
+          "reasonBundled": "Incluido con Orca — se restauraría",
+          "reasonMissing": "Este skill ya no está en disco",
+          "reasonPlugin": "Instalado por un plugin — elimina el plugin en su lugar",
+          "reasonStale": "Este skill cambió desde que se cargó la lista — actualiza e inténtalo de nuevo",
+          "reasonUnowned": "Este skill vive fuera de las carpetas de skills de Orca — elimínalo donde esté almacenado",
+          "resultLine": "{{count}} × {{label}}",
+          "retainedSource": "El skill permanece en {{path}}.",
+          "statusBusy": "Ocupado — otra operación de skills está en curso",
+          "statusDeleted": "Eliminado",
+          "statusFailed": "Fallido — sin cambios",
+          "statusPartial": "Parcialmente eliminado — algunos archivos siguen en disco con un nombre oculto",
+          "statusSkipped": "Omitido"
+        },
+        "SkillCard": {
+          "01c5a16e01": "Seleccionar {{value0}}",
+          "d25a1b8ae6": "Compartir skill"
+        },
+        "skill-install-progress-state": {
+          "currentSkill": "Instalando {{value0}} de {{value1}}: {{value2}}…"
+        },
+        "SkillManagedInstallList": {
+          "86c76cb262": "{{count}} paquete de skills"
+        },
+        "skillWarningPreview": {
+          "binaryFilesDescription": "Incluye recursos opacos y un binario ejecutable.",
+          "bundleDescription": "Un paquete de vista previa que cubre cada nivel de advertencia.",
+          "instructionsOnlyDescription": "Instrucciones contenidas por completo en SKILL.md.",
+          "runnableFilesDescription": "Incluye scripts que un agente podría ejecutar con tu acceso.",
+          "supportingFilesDescription": "Incluye archivos legibles de referencia más allá de las instrucciones principales."
+        },
+        "SkillSharedLinkRow": {
+          "confirmDelete": "Confirmar eliminación",
+          "contentsUnavailable": "No se pudo cargar el contenido de este enlace.",
+          "deleteFailed": "Orca no pudo eliminar esto de Cloud.",
+          "deletePackage": "Eliminar de Cloud",
+          "deleted": "Eliminado de Cloud",
+          "loading": "Cargando contenido…",
+          "moreActions": "Más acciones para {{name}}"
+        },
+        "SkillSharedLinksView": {
+          "loading": "Cargando enlaces compartidos…",
+          "noMatches": "Ningún enlace coincide con esta búsqueda."
+        },
+        "SkillsSharedLinksHeader": {
+          "back": "Volver a skills",
+          "backTooltip": "Volver a skills · Esc",
+          "unlisted": "No listado — solo personas con un enlace pueden abrirlo."
         }
       },
       "sidebar": {
@@ -4202,7 +4961,8 @@
           "32a7256d85": "Clonar",
           "69f5b5380d": "Clonando...",
           "cloneOnHostDescription": "Introduce la URL de Git y elige dónde clonarlo en {{value0}}.",
-          "cloneParentFolder": "Carpeta padre"
+          "cloneParentFolder": "Carpeta padre",
+          "remoteCloneParentPlaceholder": "/home/user/projects"
         },
         "AutoRenameFailedDialog": {
           "aed1623b1e": "Cerrar",
@@ -4323,7 +5083,8 @@
           "d36883e046": "Cancelar",
           "b79b39d865": "Quitar proyecto",
           "removeDescriptionSsh": "Esto solo elimina {{name}} de Orca. Sus archivos permanecen en {{host}}; vuelve a añadir ese host SSH para recuperarlo.",
-          "removeDescriptionLocal": "Esto solo elimina {{name}} de Orca. Sigue estando en tu disco."
+          "removeDescriptionLocal": "Esto solo elimina {{name}} de Orca. Sigue estando en tu disco.",
+          "removeDescriptionVmRecipe": "Esto elimina {{name}} de Orca. Su receta de VM determina si el entorno y sus archivos se eliminan permanentemente."
         },
         "ScrollToCurrentWorkspaceToolbarButton": {
           "23989bb663": "Mostrar espacio de trabajo activo"
@@ -4426,7 +5187,9 @@
           "196c1b5362": "Abrir tareas de GitLab",
           "0ccba862b8": "Abrir tareas de GitHub",
           "fee535205b": "Tareas",
-          "d599269755": "Ocultar de la barra lateral"
+          "d599269755": "Ocultar de la barra lateral",
+          "artifacts": "Artefactos",
+          "skills": "Skills"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "Limpiar",
@@ -4473,7 +5236,9 @@
           "cliCreated": "Hide CLI-created",
           "detachedHead": "Ocultar HEAD desacoplado",
           "keepDefaultBranch": "Excepto la rama predeterminada",
-          "keepDefaultBranchAria": "Mantener visible la rama predeterminada al ocultar los espacios de trabajo en reposo"
+          "keepDefaultBranchAria": "Mantener visible la rama predeterminada al ocultar los espacios de trabajo en reposo",
+          "otherClients": "Ocultar espacios de trabajo de otros clientes",
+          "otherClientsAria": "Ocultar espacios de trabajo creados desde otros clientes de Orca en servidores remotos compartidos"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "Diseño de actividad del Agent",
@@ -4532,7 +5297,8 @@
           "65a9820bd1": "Estados de Agents",
           "219ebf1961": "Nombre de rama",
           "folderPathIdentity": "Rama / ruta de carpeta",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "workspaceOptions": "Opciones de espacio de trabajo"
         },
         "SshTargetRow": {
           "4677394048": "Conectando…",
@@ -4649,7 +5415,8 @@
           "cliCreated": "Created by Orca CLI",
           "jiraIssue": "Jira {{value0}}",
           "viewOnJira": "Ver en Jira",
-          "linkedJira": "Jira {{value0}} vinculado"
+          "linkedJira": "Jira {{value0}} vinculado",
+          "openInOrcaBrowser": "Abrir en el navegador Orca"
         },
         "WorktreeCardMetadataStatusBadges": {
           "fe188062a1": "Estado: Abierto",
@@ -4699,7 +5466,10 @@
           "setParentWorkspace": "Establecer worktree padre...",
           "workspaceSection": "Espacio de trabajo",
           "primaryDeleteDisabled": "El worktree principal no se puede eliminar. Quita el proyecto en su lugar.",
-          "deleteWorktree": "Eliminar worktree"
+          "deleteWorktree": "Eliminar worktree",
+          "deleteWithDescendants": "Eliminar con descendientes…",
+          "sleepWithDescendants": "Suspender con descendientes ({{value0}})",
+          "sleepWithDescendantsDescription": "Cierra los paneles activos en este espacio de trabajo y en cada descendiente anidado para liberar memoria y CPU."
         },
         "WorktreeList": {
           "d880ea0744": "Crea un grupo y mueve este proyecto a él.",
@@ -4743,7 +5513,9 @@
           "hostDisconnected": "Desconectado",
           "failedNestWorkspace": "No se pudo anidar el espacio de trabajo",
           "sidebarRowMissing": "El destino ya no existe",
-          "failedUnnestWorkspace": "Error al expandir el espacio de trabajo"
+          "failedUnnestWorkspace": "Error al expandir el espacio de trabajo",
+          "groupRenameFailed": "No se pudo renombrar el grupo",
+          "groupRenameFailedDesc": "Orca no pudo confirmar el nuevo nombre con el host del grupo. Revisa el grupo tras reconectar."
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancelar",
@@ -4764,7 +5536,12 @@
           "65770ad0f0": "Edita enlaces y notas de GitHub para este espacio de trabajo.",
           "382fd11a3e": "Editar detalles del worktree",
           "2174f17011": "Guardar",
-          "61d6f612cf": "Guardando..."
+          "61d6f612cf": "Guardando...",
+          "a0d191b7a7": "Edita enlaces de issues, enlaces de pull requests y notas para este espacio de trabajo.",
+          "gitlabDescription": "Edita enlaces de issues, enlaces de merge requests y notas para este espacio de trabajo.",
+          "gitlabHelp": "Pega una URL de merge request o introduce un número. Deja en blanco para quitar el enlace.",
+          "gitlabMR": "MR de GitLab",
+          "gitlabPlaceholder": "MR ! o URL de GitLab"
         },
         "WorktreeOpenInMenu": {
           "1417fd8380": "Personalizar apps...",
@@ -4890,7 +5667,8 @@
               "ae57cbf6e4": "No se pudo eliminar el espacio de trabajo",
               "7488ed8711": "Ver",
               "2b20ce87b3": "Forzar eliminación",
-              "4f3876c0f5": "Falló la eliminación forzada"
+              "4f3876c0f5": "Falló la eliminación forzada",
+              "workspaceListChanged": "La lista de espacios de trabajo cambió"
             },
             "toast": {
               "1d0fa5c0a5": "No se pudo eliminar el espacio de trabajo {{value0}}",
@@ -4898,7 +5676,10 @@
               "905fc8efac": "Git ya eliminó este espacio de trabajo. Usa Forzar eliminación para borrarlo de Orca.",
               "0899ebdb28": "Git ya olvidó este espacio de trabajo, pero su directorio todavía está en disco. Usa Forzar eliminación para eliminar el directorio huérfano.",
               "locked": "Este espacio de trabajo está bloqueado por Git. Ejecute git worktree unlock <worktree-path> desde su repositorio, luego intente la eliminación de nuevo.",
-              "lockedReason": "Este espacio de trabajo está bloqueado por Git. Git reportó: {{value0}}. Ejecute git worktree unlock <worktree-path> desde su repositorio, luego intente la eliminación de nuevo."
+              "lockedReason": "Este espacio de trabajo está bloqueado por Git. Git reportó: {{value0}}. Ejecute git worktree unlock <worktree-path> desde su repositorio, luego intente la eliminación de nuevo.",
+              "runningAgentSession": "Este espacio de trabajo aún tiene sesiones de agente en ejecución, así que Orca se detuvo antes de eliminar archivos. Eliminar forzadamente las cerrará y descartará el trabajo que contengan.",
+              "unstoppedPty": "Orca no pudo confirmar que cada terminal de este espacio de trabajo haya terminado, así que se detuvo antes de eliminar archivos. Usa Eliminar forzadamente para quitarlo de todos modos.",
+              "unstoppedPtyLive": "Este espacio de trabajo aún tiene terminales en ejecución, así que Orca se detuvo antes de eliminar archivos. Eliminar forzadamente las terminará y descartará el trabajo sin confirmar que contengan."
             }
           }
         },
@@ -5176,7 +5957,12 @@
         "NewExternalWorktreesInboxLine": {
           "9f2d4c8b17": "Ocultar worktrees externos permanentemente para {{value0}}",
           "5e1b8d3f62": "Ocultar worktrees externos permanentemente",
-          "c3e8a1f4b2": "No volver a mostrar"
+          "c3e8a1f4b2": "No volver a mostrar",
+          "2a6f31d8c7": "worktree oculto",
+          "4e2b7a9c05": "Revisar {{value0}} worktrees ocultos en {{value1}}",
+          "5b90e4a2f6": "worktrees ocultos",
+          "6c07f3a91e": "{{value0}} en {{value1}}",
+          "7f18c5b0d3": "Revisar {{value0}} worktree oculto en {{value1}}"
         },
         "NoticeHostGlyph": {
           "hostDisconnected": "{{hostName}} está desconectado",
@@ -5240,7 +6026,34 @@
           "linkDestination": "Destino del enlace",
           "sshTunnel": "Estoy usando un túnel SSH",
           "sshTunnelHelp": "De lo contrario, este enlace apunta a este dispositivo y no puede identificar el otro equipo.",
-          "loopbackBlocked": "Activa la opción de túnel SSH o crea un enlace nuevo con la dirección de Tailscale o LAN del otro host."
+          "loopbackBlocked": "Activa la opción de túnel SSH o crea un enlace nuevo con la dirección de Tailscale o LAN del otro host.",
+          "fillFromSshConfig": "Rellenar desde ~/.ssh/config…",
+          "identityFileFromConfigHint": "Vacío a propósito: Orca usa cada clave que ~/.ssh/config resuelve para {{value0}}. Escribe una ruta para usar solo esa clave.",
+          "sshAlreadyExists": "Ese host SSH ya está en Orca.",
+          "sshConfigPickerAddAll": "Añadir los {{value0}} a Orca",
+          "sshConfigPickerAddAllEmpty": "Añadir todos a Orca",
+          "sshConfigPickerAddingAll": "Añadiendo hosts…",
+          "sshConfigPickerBack": "Atrás",
+          "sshConfigPickerBulkHint": "La sincronización masiva sigue en Ajustes → SSH",
+          "sshConfigPickerDescription": "Elige un host para rellenar el formulario. Nada se guarda hasta que hagas clic en Guardar.",
+          "sshConfigPickerEmpty": "Sin hosts en ~/.ssh/config",
+          "sshConfigPickerEmptyHint": "Añade una entrada Host allí o vuelve y escribe los detalles manualmente.",
+          "sshConfigPickerFilled": "Rellenado desde {{value0}}. Revisa y guarda.",
+          "sshConfigPickerFilter": "Filtrar hosts…",
+          "sshConfigPickerHostsLabel": "Hosts de configuración SSH",
+          "sshConfigPickerInOrca": "En Orca",
+          "sshConfigPickerLoadFailed": "No se pudo leer ~/.ssh/config.",
+          "sshConfigPickerLoading": "Leyendo ~/.ssh/config…",
+          "sshConfigPickerMoreResults": "Mostrando las primeras {{value0}} coincidencias. Acota el filtro para encontrar más.",
+          "sshConfigPickerNoMatch": "Sin hosts coincidentes",
+          "sshConfigPickerNoMatchHint": "Prueba otro filtro o vuelve y escribe manualmente.",
+          "sshConfigPickerNoNewHosts": "Sin hosts nuevos que añadir",
+          "sshConfigPickerPreviouslyRemoved": "Eliminado de Orca",
+          "sshConfigPickerResolveFailed": "No se pudo resolver ese host de configuración SSH.",
+          "sshConfigPickerResolving": "Leyendo…",
+          "sshConfigPickerRestartRequired": "Reinicia Orca para terminar de aplicar la actualización del selector de configuración SSH.",
+          "sshConfigPickerRetry": "Intentar de nuevo",
+          "sshConfigPickerTitle": "Elegir desde ~/.ssh/config"
         },
         "ForgetSshWorkspaceDialog": {
           "reconnectFailed": "Error de reconexión",
@@ -5273,6 +6086,86 @@
           "3b7ea51793": "Borrar búsqueda",
           "7f1c2e94a5": "El texto de búsqueda es demasiado largo: el tablero no está filtrado",
           "9a4d0f6b21": "Demasiado largo"
+        },
+        "WorktreeIssueLinkField": {
+          "25852bfc59": "Linear",
+          "5b440069e6": "GitHub",
+          "ad78f9bee2": "Issue",
+          "0a7a2c6efd": "No es un número de issue de GitHub ni una URL de issue.",
+          "161b2d053a": "Abrir issue vinculado",
+          "269198eeda": "No se pudo abrir ese issue. Revisa el número y tu conexión de GitHub.",
+          "2c245ac134": "Guardar desvincula {{link}} — un espacio de trabajo sigue un solo issue.",
+          "662ae142f8": "Issue n.º o URL de GitHub o Linear",
+          "72486800ff": "Guardar desvincula {{first}} y {{second}} — un espacio de trabajo sigue un solo issue.",
+          "929c98d05a": "Proveedor de issues",
+          "964d9bc00a": "No es una clave de issue de Linear ni una URL de issue de linear.app.",
+          "d4785f9954": "Los enlaces de issues se establecen al crear un espacio de trabajo de carpeta y aún no se pueden cambiar aquí.",
+          "d8c8a30d1f": "No se pudo abrir ese issue. Revisa el identificador y tu conexión de Linear.",
+          "f047887705": "Pega una URL de GitHub o Linear, o introduce un número. Deja en blanco para quitar el enlace."
+        },
+        "WorktreeCardSshHostControl": {
+          "connectFailed": "Error de conexión SSH",
+          "authFailedName": "Reconectar host SSH {{value0}} — falló la autenticación",
+          "authFailedTooltip": "{{value0}} · falló la autenticación",
+          "connectName": "Conectar al host SSH {{value0}}",
+          "connectedName": "Proyecto en el host SSH {{value0}}",
+          "connectedTooltip": "Proyecto en host SSH",
+          "connectingName": "Conectando al host SSH {{value0}}",
+          "failedTooltip": "{{value0}} · falló la conexión",
+          "removedName": "Host SSH {{value0}} eliminado",
+          "removedTooltip": "Host SSH eliminado — reconexión no disponible",
+          "retryName": "Reintentar conexión SSH a {{value0}}"
+        },
+        "PreservedBranchBatchReviewDialog": {
+          "38c947f7c5": "Seleccionar todo",
+          "285e1e4882": "Cancelar",
+          "676db406fd": "Head no disponible",
+          "9602129d38": "{{value0}} de {{value1}} seleccionadas",
+          "a0f9863597": "Eliminar forzadamente {{count}} ramas",
+          "c4bf8e7eaf": "Revisar ramas conservadas",
+          "ee39e872d5": "Podría no estar fusionada",
+          "f21976c9a8": "Selecciona las ramas locales que quieras eliminar forzadamente. Las no seleccionadas permanecen en sus repositorios.",
+          "a0f9863597_one": "Eliminar forzadamente {{count}} rama",
+          "a0f9863597_other": "Eliminar forzadamente {{count}} ramas"
+        },
+        "preserved": {
+          "branch": {
+            "batch": {
+              "toast": {
+                "0e0379f24a": "{{count}} ramas conservadas",
+                "0e0379f24a_one": "{{count}} rama conservada",
+                "0e0379f24a_other": "{{count}} ramas conservadas",
+                "1e1a5f6763": "Ramas locales eliminadas: {{value0}}",
+                "43d9395605": "{{value0}} eliminadas, {{value1}} no eliminadas",
+                "4cf75caab7": "{{value0}}, {{value1}}",
+                "6310412304": "Revisar {{count}} ramas",
+                "6310412304_one": "Revisar {{count}} rama",
+                "6310412304_other": "Revisar {{count}} ramas",
+                "a3cdd9d9e6": "Git conservó {{count}} ramas locales porque podrían contener commits sin fusionar. Las ramas conservadas no retienen carpetas de espacios de trabajo; sus commits permanecen en el repositorio. Orca podría seguir liberando espacio en disco en segundo plano.",
+                "a3cdd9d9e6_one": "Git conservó {{count}} rama local porque podría contener commits sin fusionar. Las ramas conservadas no retienen carpetas de espacios de trabajo; sus commits permanecen en el repositorio. Orca podría seguir liberando espacio en disco en segundo plano.",
+                "a3cdd9d9e6_other": "Git conservó {{count}} ramas locales porque podrían contener commits sin fusionar. Las ramas conservadas no retienen carpetas de espacios de trabajo; sus commits permanecen en el repositorio. Orca podría seguir liberando espacio en disco en segundo plano.",
+                "cea24c2b7d": "{{count}} espacios de trabajo eliminados",
+                "cea24c2b7d_one": "{{count}} espacio de trabajo eliminado",
+                "cea24c2b7d_other": "{{count}} espacios de trabajo eliminados",
+                "d42f1f14e0": "Reintentar {{count}} ramas",
+                "d42f1f14e0_one": "Reintentar {{count}} rama",
+                "d42f1f14e0_other": "Reintentar {{count}} ramas",
+                "e61d78054f": "Eliminando ramas locales: {{value0}}"
+              }
+            }
+          }
+        },
+        "worktreeIssueDisplacement": {
+          "3f61c0a8d2": "Linear {{value}}",
+          "9c4b7e1f60": "GitHub #{{value}}"
+        },
+        "RepoScanUnavailableIndicator": {
+          "retained": "Los worktrees existentes se conservan hasta que un análisis tenga éxito. Haz clic para reintentar.",
+          "retry": "Reintentar análisis",
+          "title": "El análisis de worktrees falló para {{value0}}"
+        },
+        "WorktreeListScrollToTopButton": {
+          "jumpToTop": "Ir arriba"
         }
       },
       "shared": {
@@ -5466,7 +6359,25 @@
           "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
           "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
           "codexConfigSyncManagedHomeUnavailable": "Orca no pudo leer los archivos de Codex de esta cuenta en este momento, por lo que es posible que la configuración no se esté sincronizando. Normalmente se resuelve solo: un antivirus o una herramienta de copia de seguridad puede bloquearlos brevemente.",
-          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions.",
+          "0b3a9f6c2e": "Elige el host que corresponda a tu cuenta. Tanto el extranjero (platform.minimax.io) como China (platform.minimaxi.com) aceptan una cookie de sesión o una clave API.",
+          "4d2c7b9e83": "Clave API de MiniMax guardada.",
+          "4f2c8a7e1b": "Pega tu clave API de MiniMax",
+          "7c5d8a4e1b": "La clave API de MiniMax no se guardó.",
+          "83b6a1f7c4": "Clave API de MiniMax",
+          "a7b1e3c5d2": "Olvidar clave",
+          "apiKeyInstructions": "Copia la clave API desde tu consola de MiniMax → claves API. Una clave API guardada tiene prioridad sobre la cookie; usa Olvidar clave para volver a la cookie.",
+          "apiKeySelectedEndpoint": "Pega la clave API desde tu consola de MiniMax → claves API. Se almacena localmente y se envía al endpoint de MiniMax seleccionado para actualizar el uso. La clave API tiene prioridad sobre la cookie.",
+          "cookieSelectedEndpoint": "Se almacena localmente y se envía al endpoint de MiniMax seleccionado para actualizar el uso.",
+          "copySelectedConsoleCookie": "Abre la consola seleccionada, inicia sesión y copia el encabezado Cookie de la solicitud desde DevTools (Red → cualquier solicitud restante → Cookie).",
+          "credentialsNotSet": "Credenciales no establecidas",
+          "d6f1b9b6a2": "Se requiere la clave API de MiniMax.",
+          "endpointChina": "China (platform.minimaxi.com)",
+          "endpointOverseas": "Extranjero (platform.minimax.io)",
+          "f8a4b9d210": "Endpoint de MiniMax",
+          "openSelectedConsole": "Abre {{url}} en tu navegador e inicia sesión.",
+          "selectedEndpointStorage": "Se almacena localmente y se envía al endpoint de MiniMax seleccionado para actualizar el uso.",
+          "usageTracking": "Configura el seguimiento de uso de MiniMax para tu cuenta."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reiniciar",
@@ -5506,7 +6417,10 @@
           "5f818f12ab": "Preparando...",
           "4c05b9d7cb": "Preparando el terminal de configuración.",
           "installLabel": "Instalar",
-          "updateLabel": "Actualizar"
+          "updateLabel": "Actualizar",
+          "retrySetup": "Reintentar",
+          "setupCommandFailed": "El comando de configuración terminó con el código {{value0}}. Este error desaparecerá tras un reintento exitoso.",
+          "setupFailed": "La configuración falló"
         },
         "AgentsPane": {
           "d83834f5e6": "Detectando agents instalados…",
@@ -5555,7 +6469,9 @@
           "03e1a5081a": "on {{value0}}",
           "25a41a9aad": "Re-detect agents installed on the active server",
           "remoteDetectionFailed": "Couldn’t detect installed agents. Check the host connection and try again.",
-          "retryDetection": "Retry"
+          "retryDetection": "Retry",
+          "noAgentsDetected": "No se detectaron agentes. Si hay uno instalado, es posible que la prueba haya caducado.",
+          "storedDefaultUndetected": "Guardado como predeterminado, pero no detectado en este momento"
         },
         "AppIconSelector": {
           "d5a112dc9b": "Icono siguiente",
@@ -5728,7 +6644,8 @@
           "b4c167764d": "Se importaron {{value0}} cookies desde un archivo a {{value1}}.",
           "a3f8c2d1e0b4": "Se importaron {{value0}} cookies de {{value1}} ({{value2}}) a {{value3}}.",
           "b4e9d3f2a1c5": "Se importaron {{value0}} cookies de {{value1}} a {{value2}}.",
-          "c5a273a809": "Desde {{value0}}"
+          "c5a273a809": "Desde {{value0}}",
+          "b5c0479e21": "Agente de usuario sin modificar"
         },
         "BrowserUseComputerUseNotice": {
           "15b5e680ba": "Abrir Computer Use",
@@ -5815,7 +6732,9 @@
           "14444243ba": "¿Eliminar `{{value0}}` de PATH?",
           "5d432fe44d": "instalado",
           "8a9b784c60": "desactualizado",
-          "d363e5929b": "Comprobando registro de CLI..."
+          "d363e5929b": "Comprobando registro de CLI...",
+          "installFailureConflictRemedy": "Elimina {{value0}} y registra de nuevo si ya no lo necesitas.",
+          "installFailureUnknownReason": "Orca no pudo completar el registro de CLI y no informó el motivo."
         },
         "CliSkillRuntimeSetup": {
           "04325573f8": "WSL",
@@ -5893,7 +6812,10 @@
           "6b5a2cd3a5": "Accesibilidad",
           "6b17602073": "Restablecer acceso",
           "506f2acf7a": "Restableciendo acceso...",
-          "4b65070096": "darwin"
+          "4b65070096": "darwin",
+          "statusGranted": "Otorgado",
+          "statusNotEnabled": "No habilitado",
+          "statusUnsupported": "Solo macOS"
         },
         "DeveloperPermissionsPane": {
           "4c17304beb": "Actualizar",
@@ -5922,7 +6844,39 @@
           "e5b5f3d6b9": "Cámara",
           "cc8151d9fa": "Entrada de voz, transcripción, grabación de audio, sox, ffmpeg y CLI de Whisper.",
           "16381e040a": "Micrófono",
-          "dac08ec03e": "Trabajando..."
+          "dac08ec03e": "Trabajando...",
+          "statusGranted": "Otorgado",
+          "statusRestricted": "Restringido",
+          "localNetworkOpenSettings": "Abrir Configuración del sistema",
+          "localNetworkOpenSystemSettings": "Abrir Configuración del sistema",
+          "connectionTestHost": "Host",
+          "connectionTestPort": "Puerto",
+          "connectionTestRunning": "Probando...",
+          "connectionTestAction": "Probar conexión",
+          "actionOpenSettings": "Abrir Ajustes",
+          "actionRequest": "Solicitar",
+          "actionRequestAccess": "Solicitar acceso",
+          "actionTriggerPrompt": "Mostrar aviso",
+          "connectionTestDescription": "Introduce un servicio en otro dispositivo de tu red local. Orca prueba la misma ruta de red que usan las herramientas de terminal.",
+          "connectionTestFailed": "No se pudo completar la prueba de conexión.",
+          "connectionTestInvalidTarget": "Introduce un nombre de host o IP LAN privada y un puerto del 1 al 65535.",
+          "connectionTestLastVerified": "Última verificación",
+          "connectionTestNotYetVerified": "Sin pruebas exitosas guardadas.",
+          "connectionTestRefused": "El host respondió, pero el puerto rechazó la conexión.",
+          "connectionTestTimeout": "La conexión caducó. Revisa el destino, el servicio y los ajustes de red local de macOS.",
+          "connectionTestTitle": "Probar conexión",
+          "connectionTestUnreachable": "No se pudo alcanzar el destino.",
+          "connectionTestUnresolved": "No se pudo resolver el nombre de host.",
+          "connectionTestUnsupported": "Las pruebas de conexión están disponibles en la app de escritorio de macOS.",
+          "localNetworkPromptCheck": "Comprobar si hay un aviso de macOS",
+          "localNetworkPromptGuidance": "Si aparece un aviso, elige Permitir. Si no aparece ningún aviso, abre Ajustes del Sistema y habilita Orca en Privacidad y seguridad → Red local.",
+          "openSettingsFailed": "No se pudo abrir Ajustes del Sistema",
+          "statusCheckManually": "Comprobar manualmente",
+          "statusDenied": "Denegado",
+          "statusEntitled": "Autorizado",
+          "statusManagedByMacOS": "Gestionado por macOS",
+          "statusNotRequested": "No solicitado",
+          "statusUnsupported": "Solo macOS"
         },
         "ExperimentalPane": {
           "9762364929": "Usa APFS clone-copy en macOS cuando sea posible; si no, crea symlinks de las carpetas o archivos configurados en los worktrees creados.",
@@ -5961,7 +6915,11 @@
             "defaultCopy": "Elige cómo se abren las nuevas pestañas de terminal de agentes compatibles.",
             "defaultViewLabel": "Vista predeterminada de Chat UI",
             "defaultViewTerminal": "Chat en terminal",
-            "defaultViewNative": "Chat UI"
+            "defaultViewNative": "Chat UI",
+            "structuredCopy": "Activa el runtime estructurado de chat nativo del host para Codex y Claude. Desactivado mantiene la ruta de chat basada en terminal existente.",
+            "structuredScope": "Solo sesiones locales por ahora. WSL y hosts de ejecución remotos (incluido SSH) siguen usando el chat de terminal, y Windows recurre a él a menos que Orca pueda leer las horas de inicio de procesos.",
+            "structuredTitle": "Usar chat nativo estructurado actualizado",
+            "structuredToggleLabel": "Alternar chat nativo estructurado actualizado"
           },
           "agentDashboard": {
             "title": "Panel de agentes",
@@ -6030,7 +6988,9 @@
           "b82f86d7d2": "Corrector ortográfico de Rich Markdown",
           "5195f0b9ef": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
           "7ddd66fede": "Ajuste de línea en el editor",
-          "9b18de6eea": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal."
+          "9b18de6eea": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal.",
+          "94a479cef3": "Mostrar diferencias de espacios en blanco iniciales y finales en los diffs.",
+          "f1b3ceeb98": "Diff: mostrar espacios en blanco"
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",
@@ -6093,7 +7053,8 @@
           "31fd7150cf": "Buscando actualizaciones...",
           "3394d1f663": "de cheques",
           "d69a09b672": "Las actualizaciones se verifican automáticamente al iniciarse.",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "e3b9d21c07": "está disponible. Actualiza Orca mediante tu gestor de paquetes del sistema; Orca no puede instalar esta versión por sí mismo."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "Elige las apps disponibles en el menú Abrir en de un espacio de trabajo.",
@@ -6114,7 +7075,10 @@
           "externalWorktrees": "Worktrees externos",
           "externalWorktreesDescription": "Elige si los worktrees creados fuera de Orca aparecen de forma predeterminada.",
           "show": "Mostrar",
-          "hide": "Ocultar"
+          "hide": "Ocultar",
+          "31e300af1c": "Preguntar antes de eliminar artefactos",
+          "bf46474e33": "Mostrar una confirmación antes de eliminar un artefacto compartido. Quien tenga su enlace público pierde el acceso.",
+          "fb29a73a17": "Mostrar un diálogo de confirmación antes de eliminar un artefacto compartido y romper su enlace público."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "Aplicar cambios",
@@ -6417,7 +7381,11 @@
           "1b1b70279a": "Aún no hay dispositivos emparejados.",
           "1592afcc7a": "Aún no hay dispositivos emparejados. Escanea el código QR con la aplicación móvil de Orca.",
           "relayDegradedNotice": "No se pudo contactar con Relay: este código solo funciona en tu LAN o Tailscale. Genera uno nuevo e inténtalo de nuevo.",
-          "pairingQrError": "Este código de emparejamiento no se pudo representar como código QR. Cópialo en Orca Mobile."
+          "pairingQrError": "Este código de emparejamiento no se pudo representar como código QR. Cópialo en Orca Mobile.",
+          "copyPairingCode": "Copiar código de emparejamiento",
+          "diagnosticsCopied": "Diagnósticos copiados",
+          "diagnosticsCopyFailed": "No se pudieron copiar los diagnósticos",
+          "pairingCodeReady": "Código de emparejamiento listo"
         },
         "MobileSettingsPane": {
           "9a3c280e49": "GitHub Releases",
@@ -6508,7 +7476,9 @@
           "9bedd2a6e5": "Permite a los agentes transferir contexto y coordinar el trabajo a través de Orca.",
           "07641b9768": "Skill de orquestación",
           "2aacdb0517": "Coordina agentes de programación en handoffs, handoffs de worktree y trabajo de agentes secundarios.",
-          "191ac34567": "Orquestación de agentes"
+          "191ac34567": "Orquestación de agentes",
+          "nestedWorkerDepthDescription": "Cuántas generaciones de workers enviados pueden generar sus propios workers. 1 mantiene plano el árbol de agentes: un coordinador envía workers, y esos workers no envían más.",
+          "nestedWorkerDepthTitle": "Profundidad de workers anidados"
         },
         "OrchestrationSetupCard": {
           "e7d2a5146c": "Permite a los agentes transferir contexto y coordinar el trabajo a través de Orca.",
@@ -6517,7 +7487,13 @@
         "OrchestrationSkillAgentCoverage": {
           "6dec5ce2d2": "Cobertura de agentes",
           "ffe13e36fb": "Falta",
-          "1e8f8d8fae": "Listo"
+          "1e8f8d8fae": "Listo",
+          "checking": "Comprobando agentes instalados y rutas de skills…",
+          "fullCoverage_one": "El 1 agente detectado tiene el skill.",
+          "fullCoverage_other": "Los {{value0}} agentes detectados tienen el skill.",
+          "noAgents": "No se detectaron CLI de agentes en PATH. Instala agentes en Ajustes → Agentes y vuelve a comprobar.",
+          "noCoverage": "Instala el skill de arriba y vuelve a comprobar.",
+          "partialCoverage": "{{value0}} de {{value1}} agentes detectados tienen el skill."
         },
         "OrchestrationSkillPromptDialog": {
           "f08d45293d": "Copiar comando",
@@ -6585,7 +7561,13 @@
           "8d525e5f15": "Copiado",
           "53b17a4b1b": "No se pudo copiar",
           "a9a564b7e7": "Copiar {{value0}}",
-          "69a1441a21": "Nada que copiar"
+          "69a1441a21": "Nada que copiar",
+          "601d6af51f": "Cargando comandos…",
+          "7ecfee5b8e": "Reintentar",
+          "89f7e57fcc": "Guardado el",
+          "923ba89646": "No se pudieron actualizar los comandos desde este host. Mostrando los últimos comandos cargados.",
+          "d59bd333c3": "Actualiza este servidor de Orca para gestionar sus comandos rápidos.",
+          "f2bf411640": "No se pudieron cargar los comandos desde este host."
         },
         "RecentTabOrderControl": {
           "3b17c81ede": "Orden de la barra de pestañas",
@@ -6783,7 +7765,9 @@
           "show": "Mostrar",
           "hide": "Ocultar",
           "externalWorktreesGlobal": "Valor global predeterminado: {{value0}}",
-          "useGlobal": "Usar valor global"
+          "useGlobal": "Usar valor global",
+          "hostStateWorkspaceWindowClosed": "Ventana de espacio de trabajo cerrada",
+          "hostWorkspaceWindowClosedHelp": "El servidor es accesible pero su ventana de Orca está cerrada. Abre Orca en {{value0}} para usar esta configuración."
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "Plantilla de comando",
@@ -6938,7 +7922,11 @@
           "troubleshootStepRegenerate": "Genera un enlace de acceso nuevo y usa aquí solo el más reciente.",
           "troubleshootTunnel": "¿Usas un reenvío local SSH? Vuelve a Conectarse a un host, pega el enlace de bucle local y activa «Estoy usando un túnel SSH» en Avanzado.",
           "cloudVmWorkflow": "VM en la nube",
-          "cloudVmWorkflowHelp": "Gestionar máquinas en la nube creadas mediante recetas"
+          "cloudVmWorkflowHelp": "Gestionar máquinas en la nube creadas mediante recetas",
+          "serverReconnecting": "Reconectando",
+          "serverRuntimeUnavailable": "Orca no disponible",
+          "serverRuntimeUnavailableDescription": "El transporte SSH está conectado, pero el runtime de Orca no respondió. Es posible que el host siga en ejecución.",
+          "serverWorkspaceWindowClosed": "Ventana de espacio de trabajo cerrada"
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "Copiar {{value0}}"
@@ -7219,7 +8207,8 @@
           "4db9afce1c": "El puerto debe estar entre 1 y 65535",
           "0e5aa04161": "Se requiere un host o alias de configuración SSH",
           "f1fc50dad2": "No se pudieron cargar destinos SSH",
-          "0cda732f43": "La prueba de conexión falló"
+          "0cda732f43": "La prueba de conexión falló",
+          "terminateUnverifiable": "No se pudo contactar {{terminals}} terminales remotas. Reconecta para terminarlas."
         },
         "SshPassphraseDialog": {
           "d5a234456f": "Cancelar",
@@ -7234,7 +8223,11 @@
           "8a349e3fac": "Frase de contraseña para {{value0}}",
           "cab3d5f5a5": "Contraseña para {{value0}}",
           "1f3dde805d": "Frase de contraseña de clave SSH",
-          "106bd57f4a": "Contraseña SSH"
+          "106bd57f4a": "Contraseña SSH",
+          "456516603b": "Introduce respuesta",
+          "981352fb42": "Completa el desafío de verificación para",
+          "a21f9e74c0": "Verificación SSH",
+          "c624f64b86": "Continuar"
         },
         "SshTargetCard": {
           "ec6543cee9": "Conectar",
@@ -7710,7 +8703,12 @@
             "d2c6a0e8f1": "grok",
             "c1b5f9d7e0": "xai",
             "b0a4e8c6d9": "OAuth",
-            "a9f3d7b5c8": "inicio de sesión"
+            "a9f3d7b5c8": "inicio de sesión",
+            "d16378a88f": "minimax",
+            "3a9b6d2c4e": "clave api",
+            "5d8f1a3b7c": "china",
+            "7e2a4b8c1d": "extranjero",
+            "b2c4e7f1a8": "endpoint"
           }
         },
         "advanced": {
@@ -7789,7 +8787,16 @@
             "agentPermissions": "Permisos de agentes",
             "agentPermissionsDescription": "Cambia los permisos predeterminados de los agentes entre Yolo y Manual.",
             "agentRuntime": "Runtime del agente",
-            "agentRuntimeDescription": "Elige si los agentes se detectan y ejecutan en Windows o en WSL de forma predeterminada."
+            "agentRuntimeDescription": "Elige si los agentes se detectan y ejecutan en Windows o en WSL de forma predeterminada.",
+            "runtime": "runtime",
+            "permissions": "permisos",
+            "skip": "saltar",
+            "agentLocation": "ubicación del agente",
+            "checks": "comprobaciones",
+            "installedAgentsWsl": "agentes instalados en wsl",
+            "manual": "manual",
+            "permission": "permiso",
+            "yolo": "yolo"
           }
         },
         "appearance": {
@@ -7910,7 +8917,11 @@
             },
             "leftSidebarAppearance": {
               "title": "Apariencia de la barra lateral izquierda",
-              "description": "Haz que la barra lateral izquierda coincida con tu terminal, conserve el valor predeterminado o use un tinte."
+              "description": "Haz que la barra lateral izquierda coincida con tu terminal, conserve el valor predeterminado o use un tinte.",
+              "project": "proyecto",
+              "background": "fondo",
+              "terminal": "terminal",
+              "tint": "matiz"
             },
             "workspaceCardLayout": {
               "title": "Diseño de tarjetas de espacios de trabajo",
@@ -7927,7 +8938,15 @@
             "4d5b9427b5": "Cuando está activado, cerrar la ventana mantiene Orca en ejecución en la bandeja del sistema en lugar de salir.",
             "showPinnedWorktreesInGroups": {
               "title": "Mostrar también los worktrees fijados en sus listas originales",
-              "description": "Los worktrees fijados permanecen en Fijados y también aparecen en Todos, Proyecto, Estado y PR."
+              "description": "Los worktrees fijados permanecen en Fijados y también aparecen en Todos, Proyecto, Estado y PR.",
+              "worktree": "worktree",
+              "workspace": "espacio de trabajo",
+              "all": "todo",
+              "project": "proyecto",
+              "status": "estado",
+              "duplicate": "duplicado",
+              "pinned": "fijado",
+              "pr": "PR"
             },
             "antigravityUsageTitle": "Uso de Antigravity",
             "antigravityUsageDescription": "Muestra el uso de suscripción de Antigravity en la barra de estado.",
@@ -7937,7 +8956,15 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Porcentajes de uso",
-            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante."
+            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante.",
+            "tray": {
+              "close": "cerrar",
+              "background": "fondo",
+              "minimize": "minimizar",
+              "notification": "área de notificación",
+              "system": "bandeja del sistema",
+              "tray": "bandeja"
+            }
           }
         },
         "auto": {
@@ -8023,7 +9050,35 @@
             "a942905148": "URL abierta al crear una nueva pestaña del navegador. Déjelo vacío para abrir una pestaña en blanco.",
             "c3903322d2": "Página de inicio predeterminada",
             "19ea5607cf": "Etiquetas de localhost para worktrees",
-            "4e0fdf0a3f": "Abre los puertos del workspace como URL localhost de Orca específicas del worktree para que las pestañas del navegador sean más fáciles de distinguir."
+            "4e0fdf0a3f": "Abre los puertos del workspace como URL localhost de Orca específicas del worktree para que las pestañas del navegador sean más fáciles de distinguir.",
+            "terminalLinkActions": {
+              "menu": "menú",
+              "disable": "desactivar",
+              "actions": "acciones",
+              "chat": "chat",
+              "click": "clic",
+              "popover": "ventana emergente",
+              "terminal": "terminal"
+            },
+            "6f5199381e": "puertos",
+            "8f036ea11f": "worktree",
+            "a8c55c9c91": "favicon",
+            "660c1dd007": "etiquetas",
+            "clientHostedRemote": {
+              "client": "cliente",
+              "desktop": "escritorio",
+              "host": "host",
+              "placement": "ubicación",
+              "remote": "remoto"
+            },
+            "sshWorkspaceRouting": {
+              "proxy": "proxy",
+              "routing": "enrutamiento",
+              "network": "red",
+              "ssh": "ssh",
+              "tunnel": "túnel"
+            },
+            "c4e3bf3282": "pestañas"
           },
           "use": {
             "search": {
@@ -8230,12 +9285,26 @@
             "nativeChat": {
               "title": "Chat UI",
               "description": "Previsualiza la interfaz de chat de escritorio para sesiones de terminal de agentes compatibles.",
-              "grok": "grok"
+              "grok": "grok",
+              "native": "nativo",
+              "openclaude": "openclaude",
+              "omp": "omp",
+              "agent": "agente",
+              "chat": "chat",
+              "claude": "claude",
+              "codex": "codex",
+              "terminal": "terminal"
             },
             "agentDashboard": {
               "title": "Panel de agentes",
               "description": "Tablero Kanban para monitorear agentes en diferentes worktrees, en ventana o como ventana emergente.",
-              "dashboard": "panel"
+              "dashboard": "panel",
+              "board": "board",
+              "worktrees": "worktrees",
+              "agent": "agente",
+              "inWindow": "en ventana",
+              "kanban": "kanban",
+              "popout": "ventana separada"
             }
           }
         },
@@ -8407,7 +9476,24 @@
             "editorFontFamily": "Fuente del editor",
             "editorFontFamilyDesc": "Fuente utilizada por los editores de archivos y vistas de diferencias. Dejar vacío para seguir la fuente de la terminal.",
             "externalWorktrees": "Worktrees externos",
-            "externalWorktreesDescription": "Elige si los worktrees creados fuera de Orca aparecen de forma predeterminada."
+            "externalWorktreesDescription": "Elige si los worktrees creados fuera de Orca aparecen de forma predeterminada.",
+            "editorFontKw": "fuente",
+            "runtime": "runtime",
+            "distro": "distribución",
+            "externalKeyword": "externo",
+            "sidebar": "barra lateral",
+            "afa37a34e1": "cerrar",
+            "5250cf0e48": "fijar",
+            "641358460a": "ortografía",
+            "867dddea41": "fijado",
+            "a51d23f4a1": "revisión ortográfica",
+            "d755962089": "subrayado rojo",
+            "execution": "ejecución",
+            "f96cdaf37d": "corrector ortográfico",
+            "projectRuntime": "runtime del proyecto",
+            "visibility": "visibilidad",
+            "windowsHost": "host de windows",
+            "wsl": "wsl"
           }
         },
         "git": {
@@ -8461,7 +9547,8 @@
             "defaultCompareBase": "base de comparación predeterminada",
             "defaultBranch": "rama predeterminada",
             "repositoryDefault": "predeterminada del repositorio",
-            "branchUpstream": "upstream de la rama"
+            "branchUpstream": "upstream de la rama",
+            "diffBase": "base del diff"
           }
         },
         "input": {
@@ -8518,7 +9605,9 @@
             "41ccade05c": "gh",
             "b79c21bd42": "github",
             "7166b9090c": "Autenticación de GitHub a través de la CLI de gh.",
-            "f16e41cc72": "Integración de GitHub"
+            "f16e41cc72": "Integración de GitHub",
+            "760e2446e0": "Autenticación de Bitbucket Cloud con un token API guardado o variables de entorno.",
+            "af5ae87847": "token de acceso"
           }
         },
         "jira": {
@@ -8547,7 +9636,9 @@
               "d5c5b47bb9": "actualizar",
               "fb854902d9": "conectando",
               "9a9f8d4910": "Conecta Jira Cloud para explorar, crear y vincular issues.",
-              "74f3063026": "{{value0}} sitio{{value1}} con conexión"
+              "74f3063026": "{{value0}} sitio{{value1}} con conexión",
+              "statusConnected": "Conectado",
+              "statusNotConnected": "No conectado"
             }
           }
         },
@@ -8652,7 +9743,13 @@
               "1de96ec8a6": "Mostrar botón de Orca Mobile",
               "682293cadf": "Mostrar el botón de Orca Mobile en la parte superior de la barra lateral izquierda.",
               "e4f4daea0e": "relé",
-              "5d5af8e041": "iPhone"
+              "5d5af8e041": "iPhone",
+              "74618577c7": "móvil",
+              "5e5b8878bf": "teléfono",
+              "5bff6a2ef0": "barra lateral",
+              "6cf5f54ce1": "botón",
+              "ac79fe4a04": "mostrar",
+              "648eeada79": "ocultar"
             }
           }
         },
@@ -8895,7 +9992,25 @@
             "externalWorktreesDescription": "Sobrescribe si los worktrees creados fuera de Orca aparecen en este proyecto.",
             "copy": "copy",
             "clone": "clone",
-            "apfs": "apfs"
+            "apfs": "apfs",
+            "external": "externo",
+            "sidebar": "barra lateral",
+            "upstream": "upstream",
+            "origin": "origin",
+            "defaultBranch": "rama predeterminada",
+            "runtime": "runtime",
+            "distro": "distribución",
+            "agentRuntime": "runtime del agente",
+            "behindUpstream": "detrás de upstream",
+            "execution": "ejecución",
+            "fastForward": "avance rápido",
+            "fork": "fork",
+            "skillRuntime": "runtime del skill",
+            "syncFork": "sincronizar fork",
+            "visibility": "visibilidad",
+            "waitForSetupBeforeAgent": "esperar configuración antes de iniciar el agente",
+            "windowsHost": "host de windows",
+            "wsl": "wsl"
           }
         },
         "runtime": {
@@ -8934,7 +10049,8 @@
             "7e3fc707aa": "terminal",
             "0ecba9aa5f": "teclado",
             "ebd7d81e1d": "Elige si Orca o el terminal con foco tiene prioridad cuando los atajos se superponen.",
-            "f052906167": "Atajos en terminal"
+            "f052906167": "Atajos en terminal",
+            "groupShortcut": "Atajo de {{value0}}"
           }
         },
         "ssh": {
@@ -9006,7 +10122,9 @@
               "c38c18be15": "selección",
               "797fdfe4ca": "seleccionar",
               "603818e8d8": "Copia automáticamente las selecciones del terminal al portapapeles en cuanto se hace una selección.",
-              "3bdc84f059": "Copiar al seleccionar"
+              "3bdc84f059": "Copiar al seleccionar",
+              "grok": "grok",
+              "zellij": "zellij"
             }
           },
           "search": {
@@ -9200,7 +10318,35 @@
               "title": "Modo del tema",
               "keyword_target": "destino",
               "keyword_editing": "edición"
-            }
+            },
+            "scroll": "desplazamiento",
+            "tui": "TUI",
+            "a0c44061ee": "confirmar",
+            "close_terminal": "cerrar",
+            "running": "en ejecución",
+            "command": "comando",
+            "prompt": "prompt",
+            "39ea7c0d28": "terminal",
+            "scrolling": "desplazamiento",
+            "agent": "agente",
+            "minimumContrast": {
+              "colors": "colores",
+              "contrast": "contraste",
+              "description": "Mejora la legibilidad del texto o conserva los colores elegidos por los programas de terminal.",
+              "dim": "tenue",
+              "minimum": "mínimo",
+              "powerline": "powerline",
+              "ratio": "proporción",
+              "readability": "legibilidad",
+              "statusline": "línea de estado",
+              "title": "Contraste de color",
+              "wcag": "wcag"
+            },
+            "process": "proceso",
+            "speed": "velocidad",
+            "stop": "detener",
+            "trackpad": "trackpad",
+            "wheel": "rueda"
           },
           "windows": {
             "search": {
@@ -9264,7 +10410,13 @@
               "20574cbc72": "Habilitar dictado de voz",
               "322d457a0d": "transcripción",
               "dcc7846641": "Configure la clave API de OpenAI utilizada para los modelos de voz a texto en la nube.",
-              "ebfd0b32e5": "Transcripción OpenAI"
+              "ebfd0b32e5": "Transcripción OpenAI",
+              "microphoneTitle": "Micrófono",
+              "micInput": "entrada",
+              "micDevice": "dispositivo",
+              "micAirpods": "airpods",
+              "micDefault": "predeterminado del sistema",
+              "microphoneDescription": "Elige qué dispositivo de entrada usa el dictado por voz."
             }
           }
         },
@@ -9293,7 +10445,9 @@
           "e5995ce268": "Mantener la computadora activa mientras los agentes están trabajando",
           "95d3031db2": "Mantiene esta computadora y la pantalla activas mientras los agentes están trabajando. El comportamiento al cerrar la tapa sigue la configuración de energía de este dispositivo.",
           "a42f6fbdd8": "Mantiene esta computadora y la pantalla activas mientras los agentes están trabajando. Orca también le pide a este dispositivo que permanezca activo cuando la tapa está cerrada, sujeto a su política de energía.",
-          "modeTitle": "Mantener la computadora activa"
+          "modeTitle": "Mantener la computadora activa",
+          "modeDescriptionDefault": "Elige Activado, Agente o Desactivado. El modo Agente permanece activo mientras los agentes trabajan. Orca también pide a este dispositivo que permanezca activo con la tapa cerrada, según su política de energía.",
+          "modeDescriptionWindows": "Elige Activado, Agente o Desactivado. El modo Agente permanece activo mientras los agentes trabajan; el comportamiento al cerrar la tapa sigue los ajustes de energía de este dispositivo."
         },
         "AgentAwakeSetting": {
           "on": "Activado",
@@ -9367,7 +10521,11 @@
                   "6f30fc4216": "El estado de la CLI de GitHub aún no está disponible en este runtime.",
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "Pull requests, issues y checks mediante la",
-                  "account_scope_prefix": "Alcance de la cuenta"
+                  "account_scope_prefix": "Alcance de la cuenta",
+                  "statusConnected": "Conectado",
+                  "statusNotInstalled": "No instalado",
+                  "statusNotAuthenticated": "No autenticado",
+                  "statusUnavailable": "No disponible"
                 }
               }
             }
@@ -9399,7 +10557,9 @@
                 "disconnect_all": "Desconectar todo",
                 "account_scope_prefix": "Alcance de la cuenta",
                 "2d60ec7921": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token or username and password. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.",
-                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token or username and password. Credentials are stored locally and encrypted when local runtime storage supports it."
+                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token or username and password. Credentials are stored locally and encrypted when local runtime storage supports it.",
+                "statusConnected": "Conectado",
+                "statusNotConnected": "No conectado"
               }
             }
           }
@@ -9440,7 +10600,13 @@
                   "63a7f47392": "ORCA_BITBUCKET_EMAIL",
                   "24ac1c69dc": "El estado de Bitbucket aún no está disponible en este runtime.",
                   "a924e8dcd1": "Pull requests y estados de build mediante tokens de la API de Bitbucket Cloud.",
-                  "0fa5629dad": "Pull requests y estados de build"
+                  "0fa5629dad": "Pull requests y estados de build",
+                  "statusConnected": "Conectado",
+                  "statusNotConfigured": "No configurado",
+                  "statusAuthFailed": "Error de autenticación",
+                  "statusConfigured": "Configurado",
+                  "statusOptionalSetup": "Configuración opcional",
+                  "statusUnavailable": "No disponible"
                 }
               }
             }
@@ -9491,7 +10657,9 @@
           "hostOverride": "Anulación del host",
           "workspaceDirectory": "Se hereda el valor predeterminado del cliente hasta que un host necesite su propio directorio de worktree.",
           "providerHost": "Host del proveedor",
-          "providerAccounts": "Las credenciales y comprobaciones de cuenta pertenecen al cliente local o al servidor remoto seleccionado que posee la integración del proveedor."
+          "providerAccounts": "Las credenciales y comprobaciones de cuenta pertenecen al cliente local o al servidor remoto seleccionado que posee la integración del proveedor.",
+          "hostCollectionProjectScopes": "Colección de hosts + ámbitos de proyecto",
+          "terminalQuickCommandHostCollections": "Los comandos se guardan en el host de Orca seleccionado y luego se limitan globalmente o a una configuración de proyecto. Los comandos de este dispositivo también siguen disponibles en espacios de trabajo remotos."
         },
         "RepositoryForkSyncSection": {
           "defaultBranch": "rama predeterminada",
@@ -9691,12 +10859,21 @@
           "cloudVmTitle": "Runtimes de VM en la nube",
           "cloudVmRefresh": "Actualizar runtimes de VM en la nube",
           "cloudVmLoading": "Comprobando runtimes de VM en la nube…",
-          "cloudVmEmptyWithSetup": "Aún no hay runtimes de VM en la nube. Crea uno desde un espacio de trabajo mediante una receta de entorno."
+          "cloudVmEmptyWithSetup": "Aún no hay runtimes de VM en la nube. Crea uno desde un espacio de trabajo mediante una receta de entorno.",
+          "stoppingCleanup": "Stopping…",
+          "cleanupStopped": "Limpieza detenida",
+          "stopCleanup": "Detener limpieza",
+          "stopCleanupFailed": "No se pudo detener la limpieza de VM Cloud."
         },
         "ephemeralVms": {
           "search": {
             "description": "Aprende cómo las recetas del repositorio dan a cada espacio de trabajo su propio entorno desechable bajo demanda.",
-            "cloudVmTitle": "VM en la nube"
+            "cloudVmTitle": "VM en la nube",
+            "keywordVm": "vm",
+            "keywordCloud": "nube",
+            "keywordEphemeral": "efímero",
+            "keywordRecipe": "receta",
+            "keywordSandbox": "sandbox"
           }
         },
         "EphemeralVmsPane": {
@@ -9754,7 +10931,12 @@
               },
               "search": {
                 "title": "Linear",
-                "description": "Estado de la habilidad de Linear, ejemplos de uso y enlaces a la configuración de Fuentes de tareas."
+                "description": "Estado de la habilidad de Linear, ejemplos de uso y enlaces a la configuración de Fuentes de tareas.",
+                "issues": "issues",
+                "linear": "linear",
+                "orcaLinear": "orca-linear",
+                "skill": "skill",
+                "tickets": "tickets"
               }
             }
           }
@@ -9776,7 +10958,9 @@
           "e6dadc1e2b": "Monthly usage",
           "75e396bf42": "Included monthly usage for Grok unified-billing accounts.",
           "b36fa2c908": "Signed in. Orca reads the Grok CLI session stored on disk.",
-          "f08c41de73": "Session expired — run grok on the computer running Orca and wait for it to start. If prompted, complete sign-in, then click Refresh usage. No chat message is needed."
+          "f08c41de73": "Session expired — run grok on the computer running Orca and wait for it to start. If prompted, complete sign-in, then click Refresh usage. No chat message is needed.",
+          "0bb18642b7": "Uso",
+          "a8f4139350": "Grok no informó porcentaje de uso para esta cuenta."
         },
         "AppearanceWindowSidebarSection": {
           "usagePercentageDisplayUsed": "Usado",
@@ -9814,7 +10998,9 @@
           "signInRequired": "Solo Relay — LAN no necesita una cuenta.",
           "relayUnavailable": "Orca Relay no está disponible en esta compilación. Usa LAN.",
           "signInAgain": "Volver a iniciar sesión para Relay",
-          "localTitle": "LAN"
+          "localTitle": "LAN",
+          "relayCell": "Celda de retransmisión",
+          "retrying": "Reintentando"
         },
         "MobilePairingSetupSection": {
           "title": "Vincular un teléfono",
@@ -10270,7 +11456,9 @@
           "connectionDetails": "Detalles de conexión",
           "endpointKind": "Tipo de destino",
           "networkConnection": "Conexión de red",
-          "notAttempted": "No se intentó"
+          "notAttempted": "No se intentó",
+          "saveFailed": "No se pudo guardar el host",
+          "saveFailedHelp": "El host se verificó, pero Orca no pudo guardarlo. Revisa el nombre y el almacenamiento local de ajustes e inténtalo de nuevo."
         },
         "CloudVmSetupGuide": {
           "title": "Crear una VM en la nube",
@@ -10283,6 +11471,264 @@
           "saveFailed": "No se pudieron guardar los valores predeterminados de visibilidad.",
           "updateServer": "Actualiza este servidor para configurar los valores predeterminados de las fuentes.",
           "updateServerDefaults": "Actualiza este servidor para configurar los valores predeterminados de visibilidad."
+        },
+        "ReleaseChannelSection": {
+          "title": "Canal de versión",
+          "devOnly": "Solo para desarrollo",
+          "willSwitch": "{{value0}} → {{value1}}",
+          "alreadyRunning": "Esta es la compilación que estás ejecutando.",
+          "adhocWarning": "Las compilaciones adhoc provienen de una rama aún no integrada, y las de Windows no están firmadas. Quien la haya creado podría abandonarla; mantén a mano una compilación estable.",
+          "channelAriaLabel": "Canal de actualización",
+          "dailyWarning": "Las compilaciones diarias salen directo de main sin puerta de pruebas, y las de Windows no están firmadas. Mantén a mano una compilación estable.",
+          "description": "Cambia de canal de actualización o salta a cualquier compilación publicada, incluidas anteriores. Se permiten downgrades y las compilaciones no verificadas pueden fallar.",
+          "devChannelUnsupported": "Las compilaciones {{value0}} solo se producen para {{value1}}. Linux permanece en Estable o RC.",
+          "devChannelUnsupportedAria": "{{value0}} (solo {{value1}})",
+          "downloadInstaller": "Descargar instalador",
+          "hourlyWarning": "Las compilaciones por hora salen directo de main sin puerta de pruebas, y las de Windows no están firmadas. Mantén a mano una compilación estable.",
+          "loadingBuilds": "Cargando compilaciones…",
+          "manualInstallHint": "Las compilaciones {{value0}} no están firmadas en Windows, así que el actualizador integrado no puede instalar una sobre una compilación firmada. Ejecuta una vez el instalador descargado — Windows advertirá sobre un publicador desconocido — y cada cambio posterior, incluido volver a Estable, funciona desde aquí.",
+          "noBuilds": "Sin compilaciones encontradas",
+          "refresh": "Actualizar lista de compilaciones",
+          "switchFailed": "No se pudo cambiar a esa compilación.",
+          "switchTo": "Cambiar a la compilación",
+          "webUnavailable": "Cambiar de compilación solo está disponible en la app de escritorio."
+        },
+        "VoiceMicrophoneSetting": {
+          "systemDefault": "Predeterminado del sistema",
+          "label": "Micrófono",
+          "accessHint": "Permite el acceso al micrófono para listar dispositivos de entrada.",
+          "allowAccess": "Permitir acceso",
+          "description": "Dispositivo de entrada usado para el dictado por voz. El predeterminado del sistema sigue el ajuste de micrófono del SO.",
+          "unavailable": "no disponible"
+        },
+        "artifacts": {
+          "connected": "Conectado",
+          "keywordShare": "compartir",
+          "keywordHtml": "HTML",
+          "keywordMarkdown": "Markdown",
+          "allowPublishing": "Permitir publicar enlaces públicos de artefactos",
+          "allowPublishingDescription": "Publica archivos HTML y Markdown como enlaces que cualquiera con la URL puede abrir. Los enlaces existentes permanecen hasta que los elimines de Artefactos.",
+          "allowPublishingSearchDescription": "Permitir que Orca publique archivos HTML y Markdown como enlaces públicos.",
+          "allowPublishingWebDescription": "Solo escritorio. Abre Ajustes → Artefactos en el dispositivo host para cambiar este ajuste.",
+          "description": "Comparte archivos HTML y Markdown con tu equipo y gestiona sus enlaces públicos.",
+          "enable": "Habilitar Artefactos",
+          "enableDescription": "Añade Artefactos a la barra lateral para abrir y eliminar archivos compartidos.",
+          "enableStepDescription": "Activa «Permitir publicar enlaces públicos de artefactos» arriba.",
+          "enableStepTitle": "Habilitar uso compartido de artefactos",
+          "enableStepWebDescription": "Abre Ajustes → Artefactos en la app de escritorio de Orca en el dispositivo host y habilita la publicación.",
+          "account": "Cuenta de Orca",
+          "howToDescription": "Publica archivos HTML o Markdown como enlaces públicos y compártelos con tu equipo.",
+          "howToDescriptionDisabled": "Habilita el uso compartido de artefactos arriba para publicar archivos HTML o Markdown como enlaces públicos.",
+          "howToTitle": "Cómo usar Artefactos",
+          "keywordArtifacts": "artefactos",
+          "keywordPermission": "permiso",
+          "keywordPublic": "público",
+          "keywordPublish": "publicar",
+          "keywordUpload": "subir",
+          "linkStepDescription": "Tras publicar, copia el enlace y envíaselo a tu equipo.",
+          "linkStepTitle": "Copia el enlace público",
+          "manageStepDescription": "Abre Artefactos desde la barra lateral para previsualizar o quitar enlaces.",
+          "manageStepTitle": "Gestiónalo en Orca",
+          "openArtifacts": "Abrir Artefactos",
+          "openArtifactsDescription": "Ve y elimina enlaces compartidos mediante tu cuenta.",
+          "openArtifactsDescriptionV2": "Previsualiza, copia y gestiona enlaces compartidos mediante tu cuenta.",
+          "shareStepDescription": "Abre un archivo HTML o Markdown y selecciona Compartir como artefacto, o pide a un agente que lo comparta.",
+          "shareStepTitle": "Elige un archivo para compartir",
+          "showButton": "Mostrar botón de Artefactos",
+          "showButtonDescription": "Mostrar el acceso directo de Artefactos en la barra lateral.",
+          "signIn": "Iniciar sesión en Orca",
+          "signInAgain": "Iniciar sesión de nuevo",
+          "signInDescription": "Usa tu cuenta de Orca para subir artefactos y gestionar sus enlaces públicos.",
+          "signInRequired": "Debes iniciar sesión para subir y gestionar artefactos.",
+          "signInTitle": "Inicia sesión para compartir artefactos",
+          "signingIn": "Iniciando sesión…",
+          "title": "Artefactos"
+        },
+        "orcaAccount": {
+          "connected": "Conectado",
+          "signOut": "Cerrar sesión",
+          "relayTitle": "Orca Relay",
+          "keywordAccount": "cuenta",
+          "keywordLogin": "inicio de sesión",
+          "keywordSignIn": "iniciar sesión",
+          "keywordRelay": "relé",
+          "keywordCloud": "nube",
+          "account": "Cuenta de Orca",
+          "artifactsDescription": "Publica archivos HTML y Markdown y gestiona cada enlace compartido desde Orca.",
+          "artifactsTitle": "Uso compartido de artefactos",
+          "benefitsTitle": "Incluido con tu cuenta",
+          "checking": "Comprobando estado de la cuenta…",
+          "description": "Comparte trabajo al instante y accede a tu escritorio desde Orca Mobile donde estés.",
+          "keywordLogout": "cerrar sesión",
+          "keywordSignOut": "cerrar sesión",
+          "reconnectRequired": "Tu sesión caducó. Inicia sesión de nuevo para usar funciones cloud.",
+          "relayDescription": "Conecta Orca Mobile a este escritorio por datos móviles o cualquier wifi.",
+          "searchDescription": "Inicia o cierra sesión de la cuenta usada por Artefactos y Orca Relay.",
+          "signIn": "Iniciar sesión en Orca",
+          "signInAgain": "Iniciar sesión de nuevo",
+          "signedOut": "Inicia sesión para ampliar Orca con funciones cloud, incluidos Artefactos y Orca Relay.",
+          "signingIn": "Iniciando sesión…",
+          "skillsDescription": "Comparte un skill o un conjunto tras un enlace no listado e instálalos en cualquier máquina que uses.",
+          "skillsTitle": "Uso compartido de skills",
+          "title": "Cuenta Orca",
+          "unavailable": "El inicio de sesión de Orca no está disponible en esta compilación."
+        },
+        "automations": {
+          "title": "Automatizaciones",
+          "keywordAutomations": "automatizaciones",
+          "keywordSchedule": "cronograma",
+          "keywordRuns": "corre",
+          "defineStepDescription": "Elige un proyecto, agente, prompt y horario.",
+          "defineStepTitle": "Describe el trabajo",
+          "description": "Programa trabajo de agentes y elige si Automatizaciones aparece en la barra lateral.",
+          "howItWorksDescription": "Programa el trabajo del agente una vez y deja que Orca cree cada ejecución y mantenga juntos sus resultados.",
+          "howItWorksTitle": "Cómo funcionan las Automatizaciones",
+          "keywordAgent": "agente",
+          "openAutomations": "Abrir Automatizaciones",
+          "openAutomationsDescription": "Crea horarios e inspecciona ejecuciones recientes.",
+          "reviewStepDescription": "Inspecciona ejecuciones recientes y continúa el trabajo cuando lo necesites.",
+          "reviewStepTitle": "Revisa los resultados",
+          "runStepDescription": "El agente seleccionado obtiene un espacio de trabajo nuevo cuando vence el horario.",
+          "runStepTitle": "Orca inicia cada ejecución",
+          "showButton": "Mostrar botón de Automatizaciones",
+          "showButtonDescription": "Mostrar el acceso directo de Automatizaciones en la barra lateral."
+        },
+        "shareSkills": {
+          "copyLink": "Copiar enlace",
+          "keywordSkills": "habilidades",
+          "keywordShare": "compartir",
+          "keywordLink": "enlace",
+          "keywordRevoke": "revocar",
+          "activeLinks": "Enlaces compartidos activos",
+          "activeLinksDescription": "Solo personas con un enlace pueden abrirlo. Deja de compartir un enlace para bloquear futuras inspecciones e instalaciones.",
+          "allowAgentPublishing": "Permitir que agentes y la CLI de Orca publiquen enlaces de skills",
+          "allowAgentPublishingDescription": "Permite que los comandos publiquen skills instalados con nombre explícito. Las carpetas de skills pueden contener scripts, configuración o secretos, así que esto está desactivado por defecto.",
+          "allowAgentPublishingWebDescription": "Solo escritorio. Abre Ajustes → Compartir skills en el dispositivo host para cambiar este ajuste.",
+          "copyDescription": "Cualquiera con el enlace puede inspeccionar e instalar todos o los skills seleccionados sin iniciar sesión.",
+          "copyTitle": "Copia el enlace no listado",
+          "description": "Comparte tus skills con un enlace no listado. Cualquiera que lo tenga puede instalarlos.",
+          "howToDescription": "Publica un skill o un paquete, como una colección de 30 skills, tras un enlace.",
+          "howToTitle": "Cómo compartir skills",
+          "linkCopied": "Enlace para compartir copiado",
+          "linkDescription": "Los paquetes compartidos no son buscables ni están listados en Orca. El enlace es la credencial, así que envíalo solo a personas de confianza.",
+          "linkRevoked": "Enlace revocado",
+          "linkTitle": "Enlaces de skills no listados",
+          "linksReconnect": "Inicia sesión de nuevo para gestionar enlaces compartidos.",
+          "linksUnavailable": "Los enlaces compartidos no están disponibles en este momento.",
+          "manageDescription": "Revocar bloquea el acceso futuro. Los skills ya instalados en otra máquina permanecen allí.",
+          "manageTitle": "Gestionar o revocar enlaces",
+          "openSkills": "Abrir Skills",
+          "openSkillsDescription": "Publica un paquete, instala desde un enlace o gestiona skills instalados y compartidos.",
+          "reviewDescription": "Revisa archivos, scripts y ejecutables incluidos antes de subir el paquete inmutable.",
+          "reviewTitle": "Revisar y publicar",
+          "revokeFailed": "Orca no pudo revocar este enlace.",
+          "searchDescription": "Comparte tus skills con un enlace no listado. Cualquiera que lo tenga puede instalarlos.",
+          "selectDescription": "Abre Skills, elige Compartir skills y selecciona los skills a agrupar tras un enlace.",
+          "selectTitle": "Selecciona uno o más skills",
+          "signIn": "Iniciar sesión en Orca",
+          "signInAgain": "Iniciar sesión de nuevo",
+          "signInDescription": "Usa tu cuenta de Orca para publicar paquetes y gestionar sus enlaces. Los destinatarios no necesitan cuenta.",
+          "signInTitle": "Inicia sesión para compartir skills",
+          "signInWebDescription": "La publicación y gestión de enlaces están disponibles en la app de escritorio de Orca.",
+          "signingIn": "Iniciando sesión…",
+          "title": "Compartir skills",
+          "confirmUnshare": "Confirmar que se deja de compartir",
+          "keywordBundle": "paquete",
+          "keywordUnlisted": "no listado",
+          "manageInSkills": "Gestionar en Skills",
+          "noActiveLinks": "Sin enlaces activos. Publica un paquete de skills desde Skills para crear uno.",
+          "refreshLinks": "Actualizar",
+          "showButton": "Mostrar botón de Skills",
+          "showButtonDescription": "Mostrar el acceso directo de Skills en la barra lateral.",
+          "unshare": "Dejar de compartir"
+        },
+        "bitbucket": {
+          "credentials": {
+            "dialog": {
+              "apiToken": "Token de API",
+              "apiTokenPlaceholder": "Token API de Atlassian",
+              "cancel": "Cancelar",
+              "verifying": "Verificando...",
+              "accessToken": "Token de acceso",
+              "accessTokenPlaceholder": "Token de acceso de repositorio, proyecto o espacio de trabajo",
+              "authModeLabel": "Método de autenticación de Bitbucket",
+              "baseUrl": "URL base de API (opcional)",
+              "baseUrlPlaceholder": "https://api.bitbucket.org/2.0",
+              "basicHint": "Crea un token API de Atlassian para tu cuenta y combínalo con el correo que lo posee.",
+              "connect": "Conectar",
+              "connectFailed": "La conexión falló",
+              "description": "Usa una credencial de Bitbucket Cloud para ver pull requests y estados de compilación. Orca la verifica antes de guardarla.",
+              "docsLink": "Documentos de tokens API de Bitbucket",
+              "email": "Correo de cuenta Atlassian",
+              "emailPlaceholder": "you@example.com",
+              "environmentManaged": "Bitbucket ya está configurado mediante variables de entorno ORCA_BITBUCKET_*, que tienen prioridad. Quítalas para guardar una credencial en Orca.",
+              "modeBasic": "Correo y token API",
+              "modeToken": "Token de acceso",
+              "remoteRuntime": "Las credenciales de Bitbucket guardadas aquí solo se almacenan en esta máquina local. Configura variables de entorno ORCA_BITBUCKET_* en el runtime remoto en su lugar.",
+              "storageNote": "Almacenado en esta máquina con almacenamiento cifrado cuando el llavero del SO está disponible. Las variables de entorno ORCA_BITBUCKET_* siempre tienen prioridad sobre lo que guardes aquí.",
+              "title": "Conectar Bitbucket",
+              "tokenHint": "Los tokens de acceso de repositorio, proyecto y espacio de trabajo se crean desde la página de ajustes de Bitbucket correspondiente y necesitan acceso de lectura a pull requests."
+            }
+          },
+          "integration": {
+            "card": {
+              "accountUnknown": "Bitbucket Cloud",
+              "authModeBasic": "Correo y token API",
+              "authModeToken": "Token de acceso",
+              "connect": "Conectar",
+              "description": "Pull requests y estados de compilación para Bitbucket Cloud.",
+              "disconnect": "Desconectar Bitbucket",
+              "disconnectFailed": "No se pudo eliminar la credencial guardada de Bitbucket.",
+              "edit": "Editar credenciales",
+              "envManaged": "Configurado vía variables de entorno. Quita las variables ORCA_BITBUCKET_* para gestionar esta credencial en Orca.",
+              "notConfigured": "Conecta una cuenta de Bitbucket Cloud con un token API de Atlassian o un token de acceso. Las variables de entorno ORCA_BITBUCKET_* también funcionan y tienen prioridad.",
+              "storedAuthFailed": "La credencial guardada de Bitbucket no pudo autenticarse. Edítala o comprueba que el token aún tenga acceso a pull requests.",
+              "storedCredential": "Guardada en Orca en esta máquina. Las variables de entorno ORCA_BITBUCKET_* tienen prioridad cuando están definidas."
+            }
+          }
+        },
+        "EphemeralVmCleanupStopDialog": {
+          "stopping": "Stopping…",
+          "cancel": "Seguir limpiando",
+          "confirm": "Detener limpieza",
+          "description": "La VM podría seguir en ejecución y generar cargos. Puedes reintentar la limpieza más tarde.",
+          "title": "¿Detener limpieza?"
+        },
+        "contrast": {
+          "custom": "Personalizado",
+          "auto": "Automático",
+          "autoDescription": "Equilibra legibilidad con tu tema de terminal. Recomendado.",
+          "customDescription": "Elige cuánto aumentar el contraste entre el texto y su fondo.",
+          "description": "Mejora la legibilidad del texto o conserva los colores elegidos por los programas de terminal.",
+          "off": "Desactivado",
+          "offDescription": "Mantiene sin cambios los colores de los programas, incluidos texto tenue y separadores Powerline.",
+          "ratio": "Objetivo de contraste",
+          "strong": "Fuerte",
+          "subtle": "Sutil",
+          "targetDescription": "Valores más altos aumentan el contraste donde es posible. Los colores de fondo no cambian.",
+          "title": "Contraste de color"
+        },
+        "QuickCommandsList": {
+          "noSearchMatches": "Ningún comando coincide con esta búsqueda."
+        },
+        "QuickCommandsToolbar": {
+          "searchLabel": "Buscar comandos"
+        },
+        "TerminalAdvancedTypographyControls": {
+          "0e0d1ee15a": "Ajusta independientemente del grosor de fuente. Algunas fuentes asignan varios valores a una misma cara, así que baja el grosor de fuente o elige otra fuente si la negrita no cambia.",
+          "f5fa1a08f1": "Grosor de negrita"
+        },
+        "BrowserTerminalLinkActionsSetting": {
+          "description": "Muestra acciones disponibles al hacer clic en un enlace de la terminal o de una transcripción de chat. Desactívalo para requerir {{modifier}}-clic en la terminal.",
+          "title": "Mostrar acciones de enlace"
+        },
+        "TerminalTccAttributionNotice": {
+          "body": "El daemon de terminal fue iniciado por una instalación de Orca que ya no existe, así que macOS no puede atribuirle sus comandos a Orca — las concesiones de Accesibilidad y Automatización se ignoran en silencio (osascript falla con el error -25211). Reiniciar el daemon lo corrige; las sesiones de terminal en ejecución se cerrarán.",
+          "openManageSessions": "Abrir Gestionar sesiones",
+          "title": "Las concesiones de permisos de macOS no llegan a las terminales"
+        },
+        "NativeChatSupportedAgents": {
+          "label": "Agentes compatibles:"
         }
       },
       "right": {
@@ -10341,7 +11787,11 @@
               "branch": "Sync Branch"
             },
             "7e4b2a19c0": "No se pudo resolver el PR de GitHub para responder.",
-            "430f1a62d4": "No se pudo resolver el hilo seleccionado en el host."
+            "430f1a62d4": "No se pudo resolver el hilo seleccionado en el host.",
+            "gitlabLinkAnother": "Vincular otro MR",
+            "gitlabMoreActions": "Más acciones de MR",
+            "gitlabUnlink": "Desvincular MR",
+            "updateReactionFailed": "No se pudo actualizar la reacción."
           },
           "CreatePullRequestDialog": {
             "2bc1b4345e": "Cancelar",
@@ -10417,7 +11867,11 @@
             "f9d7ca753d": "Copiar rutas",
             "3161c4e425": "carpeta",
             "e887fa4b2e": "Abrir en terminal",
-            "1d8e182c32": "Ver archivo"
+            "1d8e182c32": "Ver archivo",
+            "clipboardStagingUnavailable": "No se pudo copiar el archivo porque el almacenamiento temporal de Orca no está disponible",
+            "openContainingFolder": "Abrir carpeta contenedora",
+            "revealInFileExplorer": "Mostrar en el Explorador de archivos",
+            "revealInFinder": "Mostrar en Finder"
           },
           "FileExplorerToolbar": {
             "d238264654": "Mostrar archivos ignorados por Git",
@@ -10461,7 +11915,19 @@
             "b25f63edd7": "abierto",
             "d2ca293f3d": "Procesando…",
             "ef064cb7c3": "por defecto",
-            "59b4dccf70": "destructivo"
+            "59b4dccf70": "destructivo",
+            "draftMoreActions": "Más acciones de {{value0}}",
+            "38a1bccb14": "Encolar vía #{{pr}} · {{count}} PR",
+            "3de88351c5": "GitHub añadirá este pull request y cada pull request debajo de él a la cola de fusión.",
+            "73e0e1819d": "Encolando stack…",
+            "9a41a687b7": "Encolar vía #{{pr}} · {{count}} PR",
+            "a32fe6dba6": "GitHub fusionará este pull request y cada pull request debajo de él en el stack.",
+            "closeDraft": "Cerrar",
+            "closedToast": "{{value0}} cerrado",
+            "e555a41d32": "Fusionando stack…",
+            "markReady": "Marcar listo para revisión",
+            "markingReady": "Marcando listo…",
+            "readyToast": "{{value0}} marcado listo para revisión"
           },
           "PortsPanel": {
             "3ea4a02a8f": "Cancelar",
@@ -10942,7 +12408,10 @@
                 "actionRequiredHint": "Este check requiere una acción manual en GitHub (por ejemplo, aprobar la ejecución del workflow) antes de que el merge quede desbloqueado.",
                 "b3195cba33": "Desmarcar autor como bot",
                 "f588b46a6c": "Marcar autor como bot",
-                "e45324fbed": "No se pudieron cargar los detalles del check."
+                "e45324fbed": "No se pudieron cargar los detalles del check.",
+                "checksUnresolvedChip": "sin resolver",
+                "checksUnresolvedStripHint": "Estos checks terminaron sin veredicto de aprobado o fallido.",
+                "dcb3c546fe": "Reintentar"
               },
               "empty": {
                 "state": {
@@ -11113,7 +12582,24 @@
                   "2388413f28": "Esta solicitud de fusión está cerrada",
                   "88d044c42f": "Cerrado",
                   "ee482a2bad": "Este merge request ya se hizo merge",
-                  "fae95ae20d": "Mergeado"
+                  "fae95ae20d": "Mergeado",
+                  "5105b0e584": "Se requiere aprobación",
+                  "893a999c8c": "Cambios solicitados",
+                  "382c70faeb": "Por detrás",
+                  "2c61100b3a": "Actualiza la rama antes de hacer merge",
+                  "4ecc0d90ee": "Bloqueado",
+                  "01ab632a21": "Hilos sin resolver",
+                  "049ea91a82": "El pipeline sigue en ejecución",
+                  "195917574e": "Comprobando",
+                  "37d8637c70": "GitLab requiere que el pipeline tenga éxito antes de fusionar este MR",
+                  "4191fdfcec": "GitLab requiere resolver las discusiones sin resolver antes de fusionar",
+                  "46dc85711b": "GitLab requiere aprobación antes de fusionar este MR",
+                  "804ecf93e8": "GitLab aún no ha informado un estado final de fusión",
+                  "a0f3de7023": "GitLab informa que este merge request está bloqueado",
+                  "a5c049afe4": "GitLab indica que este MR se puede fusionar",
+                  "bf628700f6": "Los checks deben pasar",
+                  "c65408a99d": "Un revisor solicitó cambios en este merge request",
+                  "ff6db2db63": "GitLab aún está calculando el estado de este merge request"
                 }
               }
             }
@@ -11281,6 +12767,72 @@
                   "8f9a0b1c2d": "No hay nada para hacer commit. La rama está actualizada.",
                   "h3i4j5k607": "Comprobando si esta rama puede crear un {{value0}}…"
                 }
+              },
+              "conflict": {
+                "status": {
+                  "cards": {
+                    "5302a1ddba": "Conflictos de merge",
+                    "bdf8772106": "Conflictos",
+                    "35eb76d323": "Operación en curso",
+                    "5c3707aa44": "Rebase en curso",
+                    "6a8e9ad490": "Conflictos de cherry-pick",
+                    "7f3af87549": "Conflictos de rebase",
+                    "edc2d82a2b": "Fusión en curso",
+                    "ffe53a1da6": "Cherry-pick en curso"
+                  }
+                }
+              },
+              "content": {
+                "status": {
+                  "8deb86bbec": "base",
+                  "00c07771b7": "Ningún archivo modificado coincide con «{{value0}}»",
+                  "0bce43409f": "Usa un filtro de archivos más corto.",
+                  "1b6caf533d": "Sin archivos coincidentes",
+                  "3f425c239c": "Sin cambios en esta rama",
+                  "640f6fdb36": "Este espacio de trabajo está limpio y esta rama no tiene cambios por delante de {{value0}}",
+                  "978eba351e": "El texto de búsqueda es demasiado grande"
+                }
+              },
+              "commit": {
+                "area": {
+                  "cc5739bd1d": "Generando mensaje de commit…",
+                  "4cbd0cd9d2": "Commit en curso…",
+                  "0904be2505": "Borra el mensaje para regenerarlo.",
+                  "1ea9ba37aa": "Elige un agente en Ajustes → Git → IA de control de código.",
+                  "e7876a2bde": "Añade al stage al menos un archivo para generar un mensaje."
+                }
+              },
+              "branch": {
+                "line": {
+                  "total": {
+                    "chip": {
+                      "3d7e9b1042": "No generado",
+                      "4c1f70ba92": "{{value0}} — código de prueba: {{value1}} líneas añadidas, {{value2}} líneas eliminadas",
+                      "52c366d88d": "{{value0}} líneas eliminadas",
+                      "6b2d0f14a7": "Pruebas",
+                      "7a04c6f8b3": "Generado",
+                      "7f3e1a9c24": "{{value0}} — generado: {{value1}} líneas añadidas, {{value2}} líneas eliminadas",
+                      "8a9b97b666": "{{value0}} líneas añadidas",
+                      "9e4a3c5081": "No prueba",
+                      "a1b2c3d4e5": "Desglose de código",
+                      "b2c3d4e5f6": "Líneas de código",
+                      "c8d5b21e07": "Fuente",
+                      "daa8e8e59b": "{{value0}} líneas añadidas, {{value1}} líneas eliminadas"
+                    }
+                  }
+                }
+              },
+              "compare": {
+                "summary": {
+                  "dd72a6fd37": "{{value0}} commit{{value1}} por delante de {{value2}}"
+                }
+              },
+              "diff": {
+                "comments": {
+                  "list": {
+                    "cefacd0ec7": "archivo completo"
+                  }
+                }
               }
             }
           },
@@ -11289,6 +12841,11 @@
               "control": {
                 "ai": {
                   "cfafa92509": "No hay conflictos sin resolver para enviar."
+                },
+                "bulk": {
+                  "actions": {
+                    "2f67630884": "Falló el stage/unstage masivo"
+                  }
                 }
               }
             }
@@ -11333,6 +12890,17 @@
                   }
                 }
               }
+            },
+            "hosted": {
+              "review": {
+                "button": {
+                  "label": {
+                    "8df1a05952": "Crear PR en stack",
+                    "8e8149a0bf": "Crear PR borrador en stack",
+                    "96ae7358e0": "Push y crear PR en stack"
+                  }
+                }
+              }
             }
           },
           "AiVaultPanel": {
@@ -11364,7 +12932,10 @@
             "sessionHostMismatchUnsupported": "Esta sesión pertenece a un host diferente. Abre un espacio de trabajo en el mismo host para reanudarla.",
             "prepareSessionResumeFailed": "Could not prepare this session for resume.",
             "sessionDeleted": "Sesión eliminada",
-            "sessionDeleteFailed": "No se pudo eliminar la sesión"
+            "sessionDeleteFailed": "No se pudo eliminar la sesión",
+            "resumeInChatConflict": "Otro chat ya está usando esta conversación.",
+            "resumeInChatFailed": "No se pudo retomar esta sesión en un chat nuevo.",
+            "resumeInChatTranscriptMissing": "No se pudo cargar el historial de esta conversación, por lo que no se puede retomar en el chat."
           },
           "AiVaultPanelControls": {
             "scanningSessions": "Buscando sesiones",
@@ -11500,7 +13071,8 @@
             "delete": "Eliminar",
             "deleteReasonNonLocalHost": "Solo se pueden eliminar las sesiones de este dispositivo.",
             "deleteReasonSyntheticPath": "Esta sesión no se puede eliminar desde Orca.",
-            "deleteReasonUnsupportedAgent": "Las sesiones de {{value0}} no se pueden eliminar desde Orca."
+            "deleteReasonUnsupportedAgent": "Las sesiones de {{value0}} no se pueden eliminar desde Orca.",
+            "resumeInNewChat": "Retomar en chat nuevo"
           },
           "AiVaultSessionDeleteDialog": {
             "title": "¿Eliminar esta sesión?",
@@ -11587,6 +13159,34 @@
                   "d9dd7c6687": "Couldn't refresh from GitHub. Showing the last known status."
                 }
               }
+            },
+            "pr": {
+              "stack": {
+                "confirmation": {
+                  "1feef35ca4": "¿Fusionar vía #{{pr}}?",
+                  "369aba4b32": "{{included}}GitHub fusionará {{count}} pull requests de forma atómica con {{method}}. Si alguno no puede fusionarse, ninguno lo hará.",
+                  "478a527b15": "Encolar {{count}} PR",
+                  "4809f55cdb": "{{included}}GitHub añadirá {{count}} pull request a la cola de fusión juntos. La cola elige el método de fusión y podría fusionarlos en grupos separados.",
+                  "493c78f521": "Fusionar {{count}} PR",
+                  "541984b2eb": "¿Encolar vía #{{pr}}?",
+                  "84f6f5b9eb": "Incluidos: {{numbers}}. ",
+                  "92ca033e72": "Encolar {{count}} PR",
+                  "be8f2621be": "{{included}}GitHub añadirá {{count}} pull requests a la cola de fusión juntos. La cola elige el método de fusión y podría fusionarlos en grupos separados.",
+                  "c3e036c99f": "{{included}}GitHub fusionará {{count}} pull request de forma atómica con {{method}}. Si no puede fusionarlo, no se fusionará nada.",
+                  "eb7051d268": "Fusionar {{count}} PR"
+                },
+                "merge": {
+                  "189d0ec614": "#{{pr}} aún es borrador.",
+                  "2bb21fc326": "#{{pr}} aún necesita aprobación de revisión.",
+                  "46ffcbda75": "#{{pr}} tiene conflictos de fusión.",
+                  "55ae29b907": "Fusionar vía #{{pr}} · {{count}} PR",
+                  "640fb50d9c": "#{{pr}} está cerrado.",
+                  "6dabefd63e": "#{{pr}} tiene cambios solicitados.",
+                  "b8446f6ec2": "Fusionar vía #{{pr}} · {{count}} PR",
+                  "c23faf74df": "#{{pr}} debe actualizarse.",
+                  "f561e80968": "#{{pr}} está bloqueado."
+                }
+              }
             }
           },
           "PluginPanel": {
@@ -11605,6 +13205,34 @@
             "mayBeSlower": "Puede ser más lento",
             "slowest": "Más lento",
             "unlimited": "Sin límite"
+          },
+          "GitHubPRStackMap": {
+            "3511405914": "cerrado",
+            "568c647ccd": "borrador",
+            "bea9ade223": "conflictos",
+            "d3d97cf3f2": "aprobado",
+            "0c1645ebd0": "Expandir stack #{{value0}}",
+            "316039b5db": "checks pendientes",
+            "4b1e5ee9d3": "cambios solicitados",
+            "525259fa17": "Los detalles del stack no están disponibles temporalmente.",
+            "7737bd66be": "Contraer stack #{{value0}}",
+            "838aadf512": "checks fallidos",
+            "8a9bdc36c0": "fusionado",
+            "9a17b5255c": "revisión necesaria",
+            "cb440931b7": "{{value0}} de {{value1}} · {{value2}}",
+            "e3ee2daa32": "Stack #{{value0}}",
+            "e6cb964305": "abierto"
+          },
+          "CreateHostedReviewBasePicker": {
+            "205ef284fa": "Rama base",
+            "5a9315b61a": "Ninguna rama coincide con «{{value0}}». Pulsa Enter para usarla de todos modos.",
+            "bb4b41d563": "desde {{value0}}",
+            "da4d57c9c2": "Deja vacío para usar {{value0}}."
+          },
+          "CreateHostedReviewComposerFields": {
+            "29732f2fb0": "nuevo PR",
+            "90cabf6cfc": "Apila este PR sobre #{{value0}}",
+            "ff81473a57": "Crea un Stack de GitHub o amplía el stack existente del padre."
           }
         }
       },
@@ -11889,7 +13517,8 @@
             "searchJira": "Busca issues de Jira o pega la URL de un issue",
             "jiraMode": "Jira",
             "jiraSelectBindFailed": "Couldn’t link this Jira issue. Pick the matching site or reconnect Jira, then try again.",
-            "emoji": "Emoji"
+            "emoji": "Emoji",
+            "loadingLinearIssue": "Cargando issue de Linear…"
           },
           "ProjectCombobox": {
             "empty": "Ningún proyecto coincide con tu búsqueda.",
@@ -11903,6 +13532,15 @@
             "listLabel": "Run targets",
             "label": "Run on",
             "browse": "Browse run targets"
+          },
+          "SetProjectLocationDialog": {
+            "browseFolder": "Explorar carpeta",
+            "browseFolderHelp": "Usa un checkout o una carpeta existente en este host.",
+            "cloneFromUrl": "Clonar desde URL",
+            "cloneFromUrlHelp": "Clona este repositorio en {{host}}.",
+            "description": "Elige dónde vive {{project}} en {{host}}.",
+            "saveLocation": "Establecer ubicación",
+            "title": "Establecer ubicación del proyecto"
           }
         }
       },
@@ -11955,7 +13593,19 @@
           "relayDegradedNotice": "No se pudo contactar con Relay: este código solo funciona en tu LAN o Tailscale.",
           "pairingQrError": "Este código de emparejamiento no se pudo representar como código QR. Cópialo en Orca Mobile.",
           "directAddressDisclosure": "También usar una ruta local más rápida",
-          "directAddressHint": "Opcional. Elige la dirección Wi‑Fi o Tailscale que el teléfono usará cuando esté cerca — suele ser más rápido que Relay. Relay sigue funcionando cuando estás fuera."
+          "directAddressHint": "Opcional. Elige la dirección Wi‑Fi o Tailscale que el teléfono usará cuando esté cerca — suele ser más rápido que Relay. Relay sigue funcionando cuando estás fuera.",
+          "noPairingCode": "Sin código de emparejamiento disponible",
+          "noRelayCode": "Sin código de emparejamiento disponible",
+          "pairThisComputer": "Empareja este equipo.",
+          "pairThisMac": "Empareja este Mac.",
+          "pairThisPc": "Empareja este PC.",
+          "pairingCodeReady": "Código de emparejamiento listo",
+          "qrGeneratePrompt": "Genera un código de emparejamiento para continuar",
+          "qrRenderFailed": "El QR no se pudo generar — copia el código de abajo",
+          "qrSignInRequired": "Inicia sesión para crear un código de emparejamiento Relay",
+          "androidHelp": {
+            "guide": "Guía de instalación"
+          }
         },
         "MobilePage": {
           "e17393c6a3": "Vista previa del teléfono",
@@ -11968,7 +13618,9 @@
           "4e1eb5d55c": "No se pudo revocar el dispositivo",
           "255372e6e8": "Dispositivo revocado",
           "1b4509a8a1": "emparejado",
-          "c5909374cf": "introducción"
+          "c5909374cf": "introducción",
+          "diagnosticsCopied": "Diagnósticos copiados",
+          "diagnosticsCopyFailed": "No se pudieron copiar los diagnósticos"
         },
         "MobilePageToolbar": {
           "ad2284a9e2": "Cerrar · Esc",
@@ -12083,7 +13735,10 @@
         "NetworkInterfacePicker": {
           "trigger-label": "Dirección de red para anunciar",
           "custom-option": "{{address}} (personalizada)",
-          "add-custom": "Añadir dirección personalizada…"
+          "add-custom": "Añadir dirección personalizada…",
+          "custom-section": "Personalizado",
+          "no-address-selected": "Sin dirección seleccionada",
+          "remove-custom": "Quitar {{address}}"
         },
         "WindowsFirewallNotice": {
           "repair-success": "Windows Firewall now allows Orca Mobile on private networks",
@@ -12100,6 +13755,20 @@
           "blocked-description": "An existing inbound Block rule can override the pairing exception. Repair removes conflicting TCP rules for this Orca app, then allows port {{port}} on Private networks.",
           "repair": "Repair firewall access",
           "relay-note": "El emparejamiento sigue funcionando por Orca Relay: permitirlo solo añade la conexión local más rápida."
+        },
+        "MobileRelayMintFailureNotice": {
+          "retrying": "Reintentando…",
+          "body": "Reintenta o usa LAN para emparejar por Tailscale o el mismo wifi.",
+          "copyDiagnostics": "Copiar diagnósticos",
+          "reconnectBody": "Inicia sesión de nuevo para usar Orca Relay o usa LAN para emparejar por Tailscale o el mismo wifi.",
+          "reconnectTitle": "Tu sesión de cuenta de Orca caducó.",
+          "retry": "Reintentar Relay",
+          "retryingBody": "Creando un código de emparejamiento nuevo. Puede tardar un momento en una conexión remota.",
+          "retryingTitle": "Reintentando Orca Relay…",
+          "title": "No se pudo crear un código de emparejamiento Relay.",
+          "unavailableBody": "Usa LAN para emparejar por Tailscale o el mismo wifi.",
+          "unavailableTitle": "Orca Relay no está disponible en este equipo.",
+          "useLan": "Usar LAN"
         }
       },
       "gitlab": {
@@ -12413,6 +14082,30 @@
                   "b94ec70eda": "Seguimiento no configurado",
                   "cc39a87288": "Conectado · Sistema predeterminado",
                   "00087eecb2": "Conectado · {{value0}}"
+                }
+              },
+              "setup": {
+                "checklist": {
+                  "localized": {
+                    "copy": {
+                      "06fe30fdb0": "Inicia un agente desde una tarea con un clic y mantén el estado del PR a la vista.",
+                      "29aa2c2077": "Activa las notificaciones",
+                      "2cf795433b": "Empieza a trabajar en varios repos",
+                      "42525ba8a4": "Trae tus repos clave a Orca para empezar el trabajo de agentes sin buscar carpetas.",
+                      "43781563c3": "Navega por tu app web sin salir de Orca. Toma cualquier elemento y envía su fuente exacta y estilos a un agente con un clic.",
+                      "46db810da8": "Elige tu agente predeterminado",
+                      "62bac8f43c": "Trabaja en 2 worktrees distintos a la vez. Cada uno está aislado (incluso en el mismo proyecto). Perfecto para trabajar en 2 funciones a la vez.",
+                      "71bd9a8c95": "Entérate en el momento en que un agente termina, necesita atención o se bloquea.",
+                      "7bcb4097fa": "Registra el comando shell de Orca e instala skills de agente para flujos de navegador, equipo y orquestación.",
+                      "908898c3ee": "Usa el navegador de Orca",
+                      "ad342dd4c6": "Conecta integraciones",
+                      "b8e5bae17f": "Empieza trabajo nuevo más rápido con tu agente preferido ya seleccionado.",
+                      "ec0a363633": "Multitarea",
+                      "eddc532e58": "Automatiza la configuración del espacio de trabajo",
+                      "fee5557b02": "Habilita la CLI de Orca",
+                      "56049b74c2": "Ejecuta comandos de instalación y configuración automáticamente para que cada worktree nuevo esté listo para agentes."
+                    }
+                  }
                 }
               }
             }
@@ -12792,7 +14485,9 @@
           "724a13568d": "en {{value0}}",
           "6094135eec": "frente a {{value0}}",
           "a4420ca1f7": "Ajuste activado",
-          "dde325ddfe": "Ajuste desactivado"
+          "dde325ddfe": "Ajuste desactivado",
+          "2bf19c54ad": "Espacios en blanco: no",
+          "2e91bc89d1": "Espacios en blanco: sí"
         },
         "ConflictComponents": {
           "f338288514": "Cargando contenido del conflicto…",
@@ -12876,14 +14571,18 @@
           "f0fd4174b5": "Abre la pestaña de archivo para usar la edición enriquecida de Markdown",
           "a10d9b8337": "Abrir archivo",
           "2076ecfc9c": "Cambio anterior",
-          "631dab0df3": "Cambio siguiente"
+          "631dab0df3": "Cambio siguiente",
+          "openContainingFolder": "Abrir carpeta contenedora",
+          "revealInFileExplorer": "Mostrar en el Explorador de archivos",
+          "revealInFinder": "Mostrar en Finder"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "Exportar como PDF",
           "561251019a": "Más acciones",
           "8c8b7f5ff5": "Mostrar front matter",
           "10c39d58c1": "Ocultar front matter",
-          "1eef809708": "Ajuste de línea"
+          "1eef809708": "Ajuste de línea",
+          "4dedd55efa": "Mostrar espacios en blanco"
         },
         "EditorPanelShell": {
           "e2c4dec350": "Cargando editor…"
@@ -13297,7 +14996,8 @@
           "e2b4d7c8a1": "Elige un agente para esta comprobación",
           "f1c9e3a6d4": "Elige un agente para corregir la comprobación",
           "5e2a9c3f88": "Abrir archivo en esta línea",
-          "actionRequired": "Acción requerida"
+          "actionRequired": "Acción requerida",
+          "copyOutput": "Copiar salida"
         },
         "check": {
           "run": {
@@ -13324,7 +15024,8 @@
           "2d3b8f1a55": "saltado",
           "3e6c9a2b71": "pendiente",
           "4f7d0c3e88": "pasos fallidos",
-          "5a8e1d4f23": " · "
+          "5a8e1d4f23": " · ",
+          "copy": "Copiar jobs"
         },
         "ExternalFileChangeBanner": {
           "7c41e90d12": "Este archivo cambió en el disco mientras tenías ediciones sin guardar. Guardar sobrescribirá el contenido más reciente del disco.",
@@ -13370,6 +15071,47 @@
               }
             }
           }
+        },
+        "CheckRunCopyButton": {
+          "failed": "No se pudo copiar",
+          "empty": "Nada que copiar",
+          "copied": "Copiado"
+        },
+        "CheckRunAnnotations": {
+          "copy": "Copiar anotaciones"
+        },
+        "HtmlDocPreview": {
+          "allowDirectories": "Permitir {{count}} carpetas",
+          "allowDirectory": "Permitir carpeta",
+          "assetTooLargeNotice": "{{path}} es demasiado grande para cargarse en esta vista previa.",
+          "assetUnreadableNotice": "Orca no pudo leer {{path}} desde el espacio de trabajo.",
+          "assetUnsupportedNotice": "Este espacio de trabajo no puede enviar {{path}} a una vista previa.",
+          "copyDocumentPathControl": "Copiar ruta del archivo",
+          "copyDocumentRelativePathControl": "Copiar ruta relativa",
+          "directoryAccessRequest": "Esta vista previa quiere leer archivos en {{path}}.",
+          "directoryAccessRequestMultiple": "Esta vista previa quiere leer archivos en {{folders}}.",
+          "directoryAccessRequestOverflow": "{{folders}} y {{count}} más",
+          "directoryAuthorizationFailed": "No se pudo permitir el acceso a este directorio.",
+          "dismissAccessRequest": "Descartar",
+          "documentPathCopied": "Copiado",
+          "documentTooLargePanel": "Este documento es demasiado grande para previsualizarlo. Ábrelo en el editor.",
+          "documentUnreadablePanel": "Orca no pudo leer este archivo desde el espacio de trabajo.",
+          "downloadBlockedNotice": "Las descargas están deshabilitadas en vistas previas de documentos.",
+          "editAddressControl": "Editar dirección",
+          "multipleAssetsFailedNotice": "{{count}} archivos de este documento no se pudieron cargar.",
+          "openExternallyControl": "Abrir con la app predeterminada",
+          "openExternallyUnknownHostError": "No se puede abrir «{{value0}}»: el host propietario ya no es conocido.",
+          "openSourceControl": "Abrir archivo fuente",
+          "previewAriaLabel": "Vista previa HTML",
+          "previewMenuControl": "Opciones de vista previa",
+          "previewUnavailableTitle": "Vista previa no disponible",
+          "reloadPreviewControl": "Recargar vista previa",
+          "workspaceFileChipLabel": "Archivo del espacio de trabajo"
+        },
+        "LargeDiffLoadPrompt": {
+          "a0af0198aa": "Los diffs grandes no se representan por defecto.",
+          "c3d9f4a712": "Aún no se conoce el tamaño de este diff, así que se carga a petición.",
+          "f7fa7a40d0": "Cargar diff"
         }
       },
       "diff": {
@@ -13401,7 +15143,9 @@
           "55127a3706": "Dictado fallido: {{value0}}",
           "bb7f599ee7": "Abrir configuración",
           "2d5b9fabf9": "Acceso al micrófono denegado. Conceda acceso en la configuración del sistema, luego reinicie Orca.",
-          "5d2c3e7ae3": "No se detectó ninguna voz."
+          "5d2c3e7ae3": "No se detectó ninguna voz.",
+          "micDisconnected": "Micrófono desconectado. Dictado detenido.",
+          "micFallback": "Micrófono seleccionado no disponible. Usando el predeterminado del sistema."
         },
         "DictationIndicator": {
           "335e1bc6cb": "Detener dictado",
@@ -13477,7 +15221,8 @@
             "4a9568f773": "Atrás",
             "4f86e2a10b": "Saltar recorrido",
             "d974f32a83": "Descartar recorrido",
-            "ffa4412b66": "próximo"
+            "ffa4412b66": "próximo",
+            "complete": "Hecho"
           },
           "ContextualTourProgressDots": {
             "7734cb8ad3": "de",
@@ -13487,7 +15232,27 @@
             "tour": {
               "overlay": {
                 "measurement": {
-                  "38b3155418": "Próximo"
+                  "38b3155418": "Próximo",
+                  "automations": {
+                    "intro": {
+                      "body": "Las automatizaciones ejecutan trabajo de agentes según un horario. Añade una automatización con este botón.",
+                      "title": "¿Qué es una automatización?"
+                    },
+                    "results": {
+                      "body": "Las ejecuciones muestran cuándo se ejecutaron las automatizaciones, qué pasó y dónde inspeccionar su salida.",
+                      "title": "Encuentra los resultados"
+                    }
+                  },
+                  "client": {
+                    "hosted": {
+                      "browser": {
+                        "intro": {
+                          "body": "Las pestañas remotas del navegador ahora se representan en este dispositivo. El tráfico de red sigue pasando por el host remoto.",
+                          "title": "Esta página se representa en tu equipo"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -13532,8 +15297,18 @@
                 "removeWorktree": "quitar worktree",
                 "trashWorktree": "mandar worktree a la papelera",
                 "addQuickCommand": "agregar comando rápido",
-                "newQuickCommand": "nuevo comando rápido"
-              }
+                "newQuickCommand": "nuevo comando rápido",
+                "chatPaneBelow": "panel de chat abajo",
+                "chatPaneRight": "panel de chat a la derecha",
+                "moveChatDown": "mover chat abajo",
+                "moveChatRight": "mover chat a la derecha",
+                "splitChatDown": "dividir chat abajo",
+                "splitChatRight": "dividir chat a la derecha"
+              },
+              "splitChatDown": "Dividir chat abajo",
+              "splitChatDownDescription": "Abre el chat activo en un panel dividido debajo.",
+              "splitChatRight": "Dividir chat a la derecha",
+              "splitChatRightDescription": "Abre el chat activo en un panel dividido a la derecha."
             }
           },
           "palette": {
@@ -13576,7 +15351,8 @@
             "a6914ee43f": "Devolver",
             "f4ecd61552": "Esta pestaña se controla desde su teléfono. Vuelva a usarlo en el escritorio.",
             "d9768ec642": "La entrada del navegador está en pausa",
-            "20539eca03": "El móvil impulsa este navegador"
+            "20539eca03": "El móvil impulsa este navegador",
+            "7c31b0da94": "No se pudo recuperar esta pestaña. Revisa la sesión del teléfono e inténtalo de nuevo."
           },
           "BrowserPane": {
             "1ded0d3168": "Copiar captura de pantalla",
@@ -13664,7 +15440,9 @@
             "6e776f9ef9": "Falló la descarga",
             "756bfc25c9": "Abrir",
             "09a9489aa5": "Mostrar",
-            "2a4c4b8e1f": "Copiar"
+            "2a4c4b8e1f": "Copiar",
+            "b71dc3d930": "Reconectar",
+            "fileUrlUnsupported": "Esta pestaña del navegador no puede abrir archivos locales. Usa «Abrir vista previa al lado» en el archivo."
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "Cancelar",
@@ -13713,6 +15491,69 @@
                 "suggestions": {
                   "87fcdd0da9": "{{value0}} Buscar"
                 }
+              }
+            }
+          },
+          "annotate": {
+            "use": {
+              "browser": {
+                "page": {
+                  "grab": {
+                    "annotations": {
+                      "c937229f19": "Captura de pantalla",
+                      "0c7b9b2b7a": "Copiado",
+                      "1f5cb19034": "Anotación añadida"
+                    }
+                  }
+                }
+              }
+            },
+            "browser": {
+              "page": {
+                "annotation": {
+                  "tray": {
+                    "c16f932cb3": "Guardar",
+                    "024467ceac": "Cancelar",
+                    "449d2c2629": "Intención de anotación",
+                    "09a7c1df70": "Editar anotación {{value0}}"
+                  }
+                }
+              }
+            }
+          },
+          "download": {
+            "savedToRemote": "Guardado en {{value1}} en {{value2}}"
+          },
+          "navigate": {
+            "use": {
+              "browser": {
+                "page": {
+                  "navigation": {
+                    "downloads": {
+                      "22272f2784": "Suelta archivos sobre la página del navegador, no sobre la barra de herramientas.",
+                      "8683b84b9e": "La página del navegador no está lista para recibir archivos."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "webauthn": {
+          "account": {
+            "cancel": "Cancelar",
+            "description": "Elige la cuenta a usar con esta llave de seguridad.",
+            "fallback": "Passkey",
+            "site": "Sitio",
+            "title": "Elige una passkey"
+          }
+        },
+        "profile": {
+          "user": {
+            "agent": {
+              "option": {
+                "04af3dc12b": "Usar agente de usuario sin modificar",
+                "5bf47a3c91": "Podría mejorar el inicio de sesión de Google, pero puede reducir la compatibilidad con sitios protegidos contra bots."
               }
             }
           }
@@ -13822,7 +15663,8 @@
           "4133d33862": "Crear automatización",
           "0a75e5e2fa": "Crear automatización Hermes",
           "03142e7721": "Editar la automatización de Hermes",
-          "17086b48ee": "Editar automatización"
+          "17086b48ee": "Editar automatización",
+          "4c8e1a72b9": "Una tarea recurrente de agente"
         },
         "AutomationMissedRunGraceField": {
           "0f4459e91d": "48 horas",
@@ -13855,7 +15697,8 @@
           "8faaa00726": "Correr",
           "53fc5f07ab": "Historial de ejecución",
           "a00e38d1a3": "n / A",
-          "fdb3caa8fb": "conocido"
+          "fdb3caa8fb": "conocido",
+          "historyUnavailable": "El historial de ejecuciones no está disponible desde este host. Esto no significa que la automatización haya fallado o no tenga ejecuciones."
         },
         "AutomationRunPageFrame": {
           "40a511bed4": "Ejecutar contexto",
@@ -13979,7 +15822,11 @@
           "tableStatus": "Estado",
           "tableActions": "Acciones",
           "newAutomation": "Nueva automatización",
-          "rowActions": "Acciones de automatización"
+          "rowActions": "Acciones de automatización",
+          "destinationProjectUnavailable": "Elige un proyecto del destino de automatización seleccionado.",
+          "noListMatches": "Ninguna automatización coincide.",
+          "ownerChanged": "Esta automatización cambió de host. Actualiza e inténtalo de nuevo.",
+          "tableLastRun": "Última ejecución"
         },
         "CreateFromPicker": {
           "f061f49e3f": "Buscar ramas del repositorio...",
@@ -14080,6 +15927,14 @@
               "ba20c92073": "Programación personalizada",
               "086a5a9fe2": "Programación no válida"
             }
+          },
+          "list": {
+            "last": {
+              "run": {
+                "done": "Hecho",
+                "failed": "Fallido"
+              }
+            }
           }
         },
         "external": {
@@ -14141,6 +15996,105 @@
           "noProjects": "No hay proyectos configurados en {host}. Agregue uno allí o elija otro host.",
           "updateRequired": "Actualice el servidor de Orca en {hosts} para almacenar automatizaciones allí.",
           "move": "Al guardar se crea esta automatización en {host} y se eliminan la original y su historial de ejecuciones."
+        },
+        "hostPicker": {
+          "allHosts": "Todos los hosts",
+          "loadingHost": "Cargando host…"
+        },
+        "hostStatus": {
+          "authority": {
+            "loading": "Cargando",
+            "refreshing": "Actualizando",
+            "fresh": "Actualizado",
+            "freshDescription": "Automatizaciones cargadas desde este host.",
+            "incompatible": "Actualizar servidor",
+            "incompatibleDescription": "Este servidor no admite consultas de automatizaciones por host. Actualízalo para cargar automatizaciones de este host.",
+            "loadingDescription": "Cargando automatizaciones desde este host.",
+            "refreshingDescription": "Comprobando cambios en este host.",
+            "staleError": "Sin actualizar",
+            "staleErrorDescription": "Mostrando las automatizaciones cargadas por última vez desde este host. La actualización más reciente no se completó.",
+            "unavailable": "Inalcanzable",
+            "unavailableDescription": "No se pudo contactar este host, así que no se pudieron cargar sus automatizaciones."
+          },
+          "execution": {
+            "connected": "Conectado",
+            "disconnected": "No conectado",
+            "connectedDescription": "Este host está conectado y puede ejecutar automatizaciones.",
+            "connecting": "Conectando",
+            "connectingDescription": "Conectando a este host.",
+            "disconnectedDescription": "Las automatizaciones en este host no pueden ejecutarse hasta que se restaure la conexión.",
+            "unavailable": "No disponible",
+            "unavailableDescription": "Este destino de ejecución ya no está disponible.",
+            "unknown": "Conexión desconocida",
+            "unknownDescription": "El estado de conexión de este host aún no se ha cargado."
+          },
+          "query": {
+            "incompatible": "Actualizar servidor",
+            "incompatibleDescription": "Este servidor es demasiado antiguo para limitar automatizaciones por host. Actualízalo para gestionar automatizaciones aquí.",
+            "legacyUnscopedDescription": "Este servidor lista automatizaciones sin límite de host, por lo que no se pueden editar ni ejecutar desde aquí.",
+            "targetRemovedDescription": "Este host fue eliminado, por lo que sus automatizaciones ya no se pueden editar ni ejecutar desde aquí.",
+            "targetUnverifiedDescription": "Este host no se ha verificado desde que se cayó su conexión, por lo que sus automatizaciones no se pueden editar ni ejecutar desde aquí.",
+            "viewOnly": "Solo vista",
+            "targetUnregisteredDescription": "Este host no tiene registro, por lo que sus automatizaciones no se pueden editar ni ejecutar desde aquí."
+          },
+          "action": {
+            "reconnect": "Reconectar",
+            "retry": "Reintentar",
+            "updateServer": "Actualizar servidor"
+          }
+        },
+        "AutomationEditorPromptSection": {
+          "a7c3e91b04": "Editar nombre"
+        },
+        "AutomationListSortHeader": {
+          "sortedAscending": "{{value0}}, orden ascendente",
+          "sortedDescending": "{{value0}}, orden descendente"
+        },
+        "capturedOwner": {
+          "orphan": "Esta automatización no tiene host donde ejecutarse. Elimínala o vuelve a añadir el host al que pertenece.",
+          "unfenced": "Orca en este host necesita actualizarse antes de que puedas ver el historial de ejecuciones o gestionar esta automatización. Las ejecuciones programadas podrían continuar en el host."
+        },
+        "emptyState": {
+          "allHostsEmpty": "Sin automatizaciones en los hosts cargados",
+          "filtersNoMatch": "Ninguna automatización coincide con tus filtros",
+          "hostEmpty": "Sin automatizaciones en {{hostLabel}}",
+          "hostError": "No se pudieron cargar las automatizaciones desde {{hostLabel}}",
+          "hostIncompatibleDetail": "Este servidor es demasiado antiguo para limitar automatizaciones por host.",
+          "hostLoading": "Cargando host…",
+          "hostLoadingDetail": "Esperando que {{hostLabel}} informe sus automatizaciones.",
+          "hostNotConnected": "{{hostLabel}} no está conectado",
+          "hostNotConnectedDetail": "Conéctate a este host para ver las automatizaciones guardadas en él.",
+          "hostStaleDetail": "La actualización más reciente no se completó.",
+          "hostUnavailableDetail": "No se pudo contactar el host, así que sus automatizaciones son desconocidas.",
+          "searchNoMatch": "Ninguna automatización coincide con tu búsqueda",
+          "unknownHost": "este host"
+        },
+        "hostNotice": {
+          "ghost": "{{hostLabel}} fue eliminado. Las automatizaciones aún asignadas a él siguen listadas.",
+          "loading": "Cargando host…",
+          "removed": "El host seleccionado ya no está disponible. Mostrando todos los hosts.",
+          "unavailable": "No se pudo contactar {{hostLabel}}. Mostrando las automatizaciones cargadas por última vez desde él."
+        },
+        "hostSummary": {
+          "partialFailure": "{{failed}} de {{total}} hosts no se pudieron cargar"
+        },
+        "ownerConflict": {
+          "dismiss": "Descartar"
+        },
+        "enablement": {
+          "paused": "En pausa"
+        },
+        "externalScope": {
+          "uncheckedHost": "No se pudieron comprobar los gestores externos de automatizaciones en {{hostLabel}}.",
+          "uncheckedHosts": "No se pudieron comprobar los gestores externos de automatizaciones en {{count}} hosts.",
+          "unknownManager": "Esta automatización externa ya no aparece para ningún host a la vista."
+        },
+        "ownerAction": {
+          "failed": "Esa acción de automatización no se completó."
+        },
+        "runHistory": {
+          "occurrences": "{{times}} veces",
+          "occurrencesWithLatest": "{{times}} veces, la más reciente {{date}}"
         }
       },
       "agent": {
@@ -14209,7 +16163,8 @@
           "viewSection": "Vista"
         },
         "ActivityScopeFilterControls": {
-          "resetScope": "Mostrar todos los hosts y proyectos"
+          "resetScope": "Mostrar todos los hosts y proyectos",
+          "hiddenCount": "{{value0}} ocultos"
         },
         "ActivityThreadRow": {
           "clearNotification": "Borrar notificación"
@@ -14218,12 +16173,37 @@
           "f915168c8e": "no leído",
           "d6a8de3934": "agentes",
           "dc708f3eff": "Agents cercanos"
+        },
+        "clearCompleted": {
+          "undo": "Deshacer",
+          "clearedMany": "{{count}} agentes completados eliminados",
+          "clearedOne": "1 agente completado eliminado"
+        },
+        "ActivityThreadHoverCard": {
+          "copyPath": "Copiar ruta",
+          "jumpToWorkspace": "Ir al workspace",
+          "copyPathFailed": "No se pudo copiar la ruta",
+          "pathCopied": "Ruta copiada al portapapeles",
+          "workspace": "Espacio de trabajo"
+        },
+        "standaloneWorktree": {
+          "floatingTerminal": "Terminal flotante",
+          "standaloneTerminal": "Terminal independiente"
         }
       },
       "confirmation": {
         "dialog": {
           "8490e5d36a": "Confirmar",
-          "56f5c60e0c": "Cancelar"
+          "56f5c60e0c": "Cancelar",
+          "92bac3217e": "No preguntar de nuevo"
+        },
+        "skip": {
+          "saved": "Omitiremos esta confirmación la próxima vez.",
+          "openSettings": "Abrir Ajustes",
+          "preference": {
+            "0b0cb6e3f9": "No se pudo guardar la preferencia de confirmación."
+          },
+          "savedDescription": "Puedes cambiar esto en Ajustes."
         }
       },
       "jira": {
@@ -14377,6 +16357,114 @@
               "chooseSource": "Elige el origen de tareas"
             }
           }
+        },
+        "page": {
+          "dialogs": {
+            "new": {
+              "linear": {
+                "issue": {
+                  "dialog": {
+                    "dialogTitle": "Nuevo issue de Linear",
+                    "dialogDescription": "Crea un issue de Linear para el equipo seleccionado."
+                  }
+                }
+              },
+              "github": {
+                "issue": {
+                  "dialog": {
+                    "e02508846c": "este repositorio"
+                  }
+                }
+              }
+            },
+            "task": {
+              "page": {
+                "connect": {
+                  "dialogs": {
+                    "353c7dc71d": "Actualizar acceso"
+                  }
+                }
+              }
+            }
+          },
+          "github": {
+            "github": {
+              "work": {
+                "item": {
+                  "row": {
+                    "pullRequest": "Pull request",
+                    "issue": "Issue",
+                    "draftPullRequest": "Pull request borrador"
+                  }
+                }
+              },
+              "detail": {
+                "host": {
+                  "312ca15778": "Lista de GitHub",
+                  "8d5cde4770": "Pull requests"
+                }
+              },
+              "issue": {
+                "label": {
+                  "selector": {
+                    "2a1862c470": "Cargando etiquetas…"
+                  }
+                }
+              }
+            }
+          },
+          "chrome": {
+            "task": {
+              "page": {
+                "gitlab": {
+                  "filters": {
+                    "2328f6a40c": "Mis pendientes",
+                    "e157d7ce4d": "MR"
+                  }
+                }
+              }
+            }
+          },
+          "hooks": {
+            "use": {
+              "task": {
+                "page": {
+                  "jira": {
+                    "create": {
+                      "dialog": {
+                        "jiraRequiredFieldsLoadFailed": "No se pudieron cargar los campos obligatorios de Jira."
+                      }
+                    }
+                  },
+                  "linear": {
+                    "active": {
+                      "collection": {
+                        "68462f8b29": "Vista: {{value0}}",
+                        "d8b3cd9488": "Proyecto: {{value0}}"
+                      }
+                    }
+                  },
+                  "session": {
+                    "resume": {
+                      "savedLinearProjectMissing": "No se encontró el proyecto guardado de Linear.",
+                      "savedLinearProjectRestoreFailed": "No se pudo restaurar el proyecto guardado de Linear.",
+                      "savedLinearViewMissing": "No se encontró la vista guardada de Linear.",
+                      "savedLinearViewRestoreFailed": "No se pudo restaurar la vista guardada de Linear."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "linear": {
+            "linear": {
+              "connect": {
+                "empty": {
+                  "3e00e8ebd4": "Cargando Linear"
+                }
+              }
+            }
+          }
         }
       },
       "taskPageEmptyState": {
@@ -14439,7 +16527,9 @@
         "allWorkspacesTitle": "Selecciona un espacio de trabajo",
         "allWorkspacesBody": "Los filtros de estado, asignatario y etiquetas usan IDs de un solo espacio de trabajo de Linear. Elige un espacio de trabajo para filtrar por esos atributos.",
         "optionsFromTeam": "Opciones de {{team}}",
-        "clearAll": "Limpiar todos los filtros"
+        "clearAll": "Limpiar todos los filtros",
+        "partialCoverage": "parcial",
+        "partialCoverageTitle": "Algunos equipos podrían quedar fuera de este filtro. Abre Filtros para detalles."
       },
       "linear-issue-attribute-filter-sections": {
         "status": "Estado",
@@ -14453,7 +16543,8 @@
         "searchStatus": "Filtrar estado…",
         "searchLabels": "Filtrar etiquetas…",
         "searchAssignee": "Filtrar asignatario…",
-        "back": "Atrás"
+        "back": "Atrás",
+        "partialCoverageMarker": "· parcial"
       },
       "browser-pane": {
         "markup": {
@@ -14518,8 +16609,117 @@
         "ArtifactsPage": {
           "deleteTitle": "¿Eliminar el artefacto?",
           "deleteDescription": "“{{name}}” ya no estará disponible en su enlace público.",
-          "delete": "Eliminar"
-        }
+          "delete": "Eliminar",
+          "deleteArtifact": "Eliminar artefacto",
+          "deleteFailed": "No se pudo eliminar el artefacto.",
+          "empty": "Sin artefactos compartidos",
+          "emptyCopy": "Abre un archivo HTML o Markdown y selecciona Compartir como artefacto, o pide a tu agente que lo comparta.",
+          "loadFailed": "No se pudieron cargar los artefactos.",
+          "loadMoreFailed": "No se pudieron cargar más artefactos.",
+          "moreAvailable": "Hay más artefactos disponibles",
+          "moreAvailableCopy": "Carga la página siguiente para continuar.",
+          "openAccountSettings": "Abrir ajustes de cuenta",
+          "openArtifact": "Abrir artefacto",
+          "openArtifactsSettings": "Abrir Ajustes → Artefactos",
+          "publishingOff": "La publicación está desactivada",
+          "publishingOffCopy": "Nada en este dispositivo puede crear aún un enlace público de artefacto. Permite la publicación en Ajustes → Artefactos y comparte desde un archivo HTML o Markdown abierto o pide a tu agente.",
+          "reconnectCopy": "Inicia sesión de nuevo para ver y gestionar los artefactos compartidos mediante tu cuenta.",
+          "reconnectHeading": "Inicia sesión en Orca de nuevo",
+          "refresh": "Actualizar",
+          "retry": "Reintentar",
+          "signIn": "Iniciar sesión en Orca",
+          "signInAgain": "Inicia sesión en Orca de nuevo para cargar artefactos.",
+          "signInAgainAction": "Iniciar sesión de nuevo",
+          "signInCopy": "Inicia sesión para ver y gestionar artefactos compartidos mediante tu cuenta.",
+          "signInHeading": "Iniciar sesión en Orca",
+          "signingIn": "Iniciando sesión…",
+          "title": "Artefactos",
+          "unconfiguredCopy": "El inicio de sesión de cuenta Orca aún no está configurado en esta máquina."
+        },
+        "copyLink": "Copiar enlace",
+        "openInBrowser": "Abrir en el navegador",
+        "artifact-publish-flow": {
+          "5cb4f5ec36": "Copiar enlace",
+          "29a406be09": "Los artefactos deben contener texto.",
+          "2fc727c831": "Artefacto actualizado",
+          "430019efd0": "Artefacto compartido",
+          "54b1805328": "No se pudo compartir el artefacto",
+          "6112db5a1c": "Este artefacto es demasiado grande para compartirlo.",
+          "6d475e9b25": "Solo archivos HTML y Markdown locales se pueden compartir como artefactos.",
+          "9a078a0c65": "El uso compartido de artefactos no está disponible",
+          "bba20daa6d": "Inicia sesión en Orca e inténtalo de nuevo.",
+          "e2ed5acd8c": "Orca no pudo leer este archivo. Ábrelo desde un espacio de trabajo e inténtalo de nuevo.",
+          "fbb5018602": "Este archivo está vacío."
+        },
+        "ArtifactPublishedLinkPanel": {
+          "copyLink": "Copiar enlace",
+          "openLink": "Abrir enlace",
+          "updating": "Updating…",
+          "update": "Actualizar contenido compartido"
+        },
+        "ArtifactListSearchField": {
+          "placeholder": "Buscar...",
+          "clear": "Borrar búsqueda",
+          "label": "Buscar artefactos"
+        },
+        "ArtifactListTableHeader": {
+          "name": "Nombre",
+          "type": "Tipo",
+          "size": "Tamaño",
+          "actions": "Acciones",
+          "expires": "Caduca",
+          "updated": "Actualizado"
+        },
+        "typeMarkdown": "Markdown",
+        "typeHtml": "HTML",
+        "ArtifactActions": {
+          "more": "Más acciones de artefacto"
+        },
+        "ArtifactCollection": {
+          "loadMore": "Cargar más",
+          "noMatches": "Sin coincidencias"
+        },
+        "ArtifactDetailDrawer": {
+          "description": "Previsualiza y gestiona este artefacto compartido."
+        },
+        "ArtifactDetailHeader": {
+          "close": "Cerrar",
+          "publicLink": "Cualquiera con este enlace puede verlo"
+        },
+        "ArtifactPublishButton": {
+          "accountDescription": "Inicia sesión para crear y gestionar este enlace.",
+          "accountTitle": "Cuenta de Orca",
+          "a4a49da6af": "Compartir como artefacto",
+          "checkFailed": "No se pudo comprobar si existe un enlace.",
+          "checkingLink": "Comprobando si existe un enlace…",
+          "confirmDescription": "Esto publica el archivo actual en un enlace que cualquiera con la URL puede ver.",
+          "confirmTitle": "Compartir como artefacto",
+          "openSettings": "Abrir ajustes de Artefactos",
+          "publishedDescription": "Cualquiera con este enlace puede ver el archivo compartido.",
+          "publishingOffDescription": "Infórmate sobre enlaces públicos y habilita el uso compartido en Ajustes.",
+          "publishingOffTitle": "El uso compartido de artefactos está desactivado",
+          "sharePublicLink": "Generar enlace",
+          "sharing": "Compartiendo…",
+          "signIn": "Iniciar sesión",
+          "signInAgain": "Iniciar sesión de nuevo",
+          "signingIn": "Iniciando sesión…",
+          "tryAgain": "Intentar de nuevo"
+        },
+        "ArtifactsPageSkeleton": {
+          "loading": "Cargando artefactos"
+        },
+        "actions": "Acciones de artefacto",
+        "copyFailed": "No se pudo copiar el enlace del artefacto",
+        "copySuccess": "Enlace del artefacto copiado",
+        "expired": "Enlace caducado",
+        "expiredCompact": "Caducado",
+        "expires": "El enlace caduca {{when}}",
+        "expiryUnknown": "Caducidad desconocida",
+        "preview": "Vista previa del artefacto",
+        "previewUnavailable": "Vista previa no disponible",
+        "previewUnavailableDescription": "Abre este artefacto en tu navegador para verlo.",
+        "updatedAt": "Actualizado {{when}}",
+        "updatedRecently": "recientemente"
       },
       "ComposerParentWorktreePicker": {
         "label": "Worktree padre",
@@ -14527,6 +16727,79 @@
         "description": "Anida este espacio de trabajo bajo otro en la barra lateral. No cambia la rama base.",
         "searchPlaceholder": "Buscar espacios de trabajo...",
         "noMatches": "No hay coincidencias."
+      },
+      "browserPane": {
+        "workspaceDoc": {
+          "externalLinkConfirm": "Abrir enlace",
+          "externalLinkCancel": "Cancelar",
+          "externalLinkTitle": "¿Abrir enlace a {{host}}?"
+        }
+      },
+      "UnexpectedSignoutCard": {
+        "6e3f1a9c5b": "Orca Relay",
+        "1f6b2c9d4e": "Lo que recuperas",
+        "2c9a5b6e8d": "Publica archivos HTML y Markdown y gestiona cada enlace compartido desde Orca.",
+        "3d8e5f1b9c": "Comparte skills tras un enlace no listado e instálalos en cualquier máquina que uses.",
+        "3e8f5c2a91": "Descartar",
+        "4b7d2e8f1a": "Conecta Orca Mobile a este escritorio por datos móviles o cualquier wifi.",
+        "5a1c8d3e6f": "Inicia sesión de nuevo para restaurar el uso compartido de Artefactos, Orca Relay y el uso compartido de skills.",
+        "7b4d9e1f2a": "Inicia sesión de nuevo como {{value0}} para restaurar el uso compartido de Artefactos, Orca Relay y el uso compartido de skills.",
+        "7e1a9c4d2f": "Iniciando sesión…",
+        "8d2e4f7a1b": "Uso compartido de artefactos",
+        "9a4c6b2d7e": "Uso compartido de skills",
+        "9f2c1a4b7d": "Se cerró tu sesión",
+        "c5b3e8a17d": "Iniciar sesión en Orca"
+      },
+      "BrowserCookieImportDisclosure": {
+        "description": "Inicia sesión en Google directamente en Orca.",
+        "title": "Los inicios de sesión de Google no se importan"
+      },
+      "BrowserCookieImportMachineNotice": {
+        "clientLabel": "Navegadores en este dispositivo",
+        "clientNoteLocalStorage": "Las importaciones leen los navegadores de este dispositivo. Las cookies se almacenan localmente.",
+        "remoteLabel": "Navegadores en {{value0}}",
+        "remoteNoteRemoteStorage": "Las importaciones leen navegadores en {{value0}}. Las cookies se almacenan en esa máquina y podría aparecer un aviso de permiso en su pantalla."
+      },
+      "BrowserPane": {
+        "streamCapabilityUnsupported": "El runtime seleccionado no admite transmisión remota del navegador.",
+        "streamConnectionLost": "Se perdió la conexión con el servidor remoto.",
+        "streamConnectionUnreachable": "No se puede acceder al servidor remoto.",
+        "streamRestartFailed": "No se pudo reiniciar la transmisión remota del navegador."
+      },
+      "HostedReviewUnlinkMenuItem": {
+        "description": "Orca ocultará los detalles de {{value0}} {{value1}} para este espacio de trabajo. No se cambiarán {{value0}} ni la rama en {{value2}}.",
+        "label": "Desvincular {{value0}} del espacio de trabajo"
+      },
+      "LinuxPackageInstallRecoveryCard": {
+        "53c4b8e148": "Ningún agente de autenticación utilizable respondió a la solicitud de instalación privilegiada.",
+        "53e1559f99": "Instalación manual requerida",
+        "55c86654b7": "Copiar comando de instalación",
+        "82c6dbea00": "Copia el comando, sal de Orca y ejecútalo en una terminal del sistema en el equipo donde está instalado Orca. Vuelve a abrir Orca cuando termine.",
+        "a7ac6ec78b": "Orca descargó el paquete del sistema. Sal de Orca antes de terminar la actualización desde una terminal.",
+        "aa57fa4f80": "Comando copiado. Sal de Orca, ejecútalo en una terminal del sistema para instalar {{value0}} y vuelve a abrir Orca.",
+        "b7e7c5bc95": "Orca verifica el archivo descargado contra los metadatos de la versión en el momento de generar este comando. El paquete del sistema en sí no está verificado por firma, y Orca no puede responder por el archivo después de ese punto.",
+        "c732bcbf8f": "Comprobando paquete…",
+        "e3de29c86a": "Mostrar paquete"
+      },
+      "WorktreeBaseFallbackDialog": {
+        "description": "La ref de seguimiento remoto «{{value0}}» no estaba disponible, así que Orca usó la local «{{value1}}». Es posible que este espacio de trabajo no incluya los últimos cambios remotos.",
+        "dismiss": "Entendido",
+        "title": "Espacio de trabajo creado desde una base local"
+      },
+      "native": {
+        "chat": {
+          "NativeChatStructuredSession": {
+            "1f772bb5d0": "La entrega del mensaje no está confirmada.",
+            "93ef441197": "El mensaje no se envió.",
+            "a5e7f14068": "Reintentar"
+          }
+        }
+      },
+      "linear-issue-attribute-filter-coverage-notice": {
+        "labelsAtIdLimit": "Filtrando el máximo posible: {{value0}} etiquetas de equipo. Las filas elegidas de más quedan fuera.",
+        "labelsPartialTeamCoverage": "Filtrando {{value0}} de {{value1}} etiquetas de equipo — los issues de los equipos restantes no están incluidos.",
+        "statusAtIdLimit": "Filtrando el máximo posible: {{value0}} estados de equipo. Las filas elegidas de más quedan fuera.",
+        "statusPartialTeamCoverage": "Filtrando {{value0}} de {{value1}} estados de equipo — los issues de los equipos restantes no están incluidos."
       }
     },
     "i18n": {
@@ -14562,6 +16835,12 @@
         "loadFailed": "No se pudo cargar el registro del job de GitLab.",
         "emptyTrace": "No hay ningún registro disponible para este job de GitLab.",
         "timedOut": "Se agotó el tiempo de espera al cargar el registro del job de GitLab."
+      },
+      "gitlabIpcTimeout": {
+        "timedOut": "Se agotó el tiempo hablando con GitLab."
+      },
+      "githubCheckDetailsTimeout": {
+        "timedOut": "Se agotó el tiempo cargando detalles del check."
       }
     },
     "ssh": {
@@ -14646,14 +16925,46 @@
         "skillScopeBuiltIn": "Integrado",
         "skillScopePlugin": "Plugin",
         "skillsLoaded": "Habilidades cargadas",
-        "noCommands": "No hay comandos coincidentes"
+        "noCommands": "No hay comandos coincidentes",
+        "imagePreview": "Vista previa de imagen a tamaño completo",
+        "imagePreviewUnavailable": "Vista previa no disponible",
+        "imageSaving": "Guardando imagen pegada…",
+        "pendingAttachmentLimit": "Demasiados adjuntos en espera. Termina de redactar antes de adjuntar más.",
+        "viewAttachment": "Ver imagen"
       },
       "tool": {
         "running": "Ejecutando…",
-        "result": "Resultado"
+        "result": "Resultado",
+        "moreCalls": "+{{value0}} más",
+        "addedFile": "Archivo añadido",
+        "copyDiff": "Copiar diff",
+        "countN": "{{value0}} llamadas a herramientas",
+        "countOne": "1 llamada a herramienta",
+        "deletedFile": "Archivo eliminado",
+        "diffGap": "Líneas no mostradas",
+        "diffTruncated": "Diff truncado",
+        "editedFile": "Archivo editado",
+        "exitCode": "salida {{value0}}",
+        "milliseconds": "{{value0}} ms",
+        "ranCommandManyToolsSummary": "Ejecutó {{commandCount}} comando y usó {{toolCount}} herramientas",
+        "ranCommandOneToolSummary": "Ejecutó {{commandCount}} comando y usó {{toolCount}} herramienta",
+        "ranCommandsManyToolsSummary": "Ejecutó {{commandCount}} comandos y usó {{toolCount}} herramientas",
+        "ranCommandsOneToolSummary": "Ejecutó {{commandCount}} comandos y usó {{toolCount}} herramienta",
+        "renamedFile": "Archivo renombrado",
+        "runningCommand": "Ejecutando comando",
+        "runningNamed": "Ejecutando {{toolName}}",
+        "runningNamedPreview": "Ejecutando {{toolName}} {{preview}}",
+        "runningPreview": "Ejecutando {{preview}}",
+        "usedManySummary": "Usó {{toolCount}} herramientas",
+        "usedOneSummary": "Usó 1 herramienta"
       },
       "status": {
-        "responding": "El agente está respondiendo"
+        "responding": "El agente está respondiendo",
+        "thinking": "Razonamiento",
+        "toggleDetails": "Alternar detalles del turno",
+        "workedFor": "Trabajó {{value0}}",
+        "working": "Trabajando…",
+        "workingFor": "Trabajando {{value0}}"
       },
       "jumpToLatest": "Saltar a lo último",
       "toggle": {
@@ -14702,7 +17013,146 @@
         "allow": "Permitir",
         "deny": "Denegar"
       },
-      "launchPromptNotDelivered": "No entregado — revisa la terminal"
+      "launchPromptNotDelivered": "No entregado — revisa la terminal",
+      "taskList": {
+        "title": "Tareas",
+        "inProgress": "En curso",
+        "pending": "Pendiente",
+        "added": "Añadida {{task}}",
+        "completed": "Completado",
+        "empty": "Sin tareas",
+        "finished": "Completada {{task}}",
+        "progress": "{{completed}} de {{total}} tareas completadas",
+        "removed": "Eliminada {{task}}",
+        "reset": "Marcada pendiente: {{task}}",
+        "showAll": "Lista completa de tareas",
+        "started": "Iniciada {{task}}",
+        "unchanged": "Tareas sin cambios",
+        "updated": "Actualizada {{task}}"
+      },
+      "receipt": {
+        "cancelled": "Cancelado",
+        "resolved": "Resuelto",
+        "cancelledBy": "Cancelado en {{device}}",
+        "resolver": "Respondido en {{device}}",
+        "unavailable": "Respuesta seleccionada no disponible"
+      },
+      "backgroundTasks": {
+        "monitoring": "Supervisando tareas en segundo plano",
+        "stateWaiting": "esperando",
+        "stateDone": "hecho",
+        "stateIdle": "detenido",
+        "groupShell": "Shell",
+        "groupWorkflows": "Flujos de trabajo",
+        "groupTasks": "Tareas",
+        "agent": "Agente en segundo plano",
+        "command": "Comando en segundo plano",
+        "countAgentsMany": "{{value0}} agentes",
+        "countAgentsOne": "1 agente",
+        "countMonitorsMany": "{{value0}} monitores",
+        "countMonitorsOne": "1 monitor",
+        "countShellCommandOne": "1 comando shell",
+        "countShellMany": "{{value0}} shells",
+        "countShellOne": "1 shell",
+        "countTasksMany": "{{value0}} tareas",
+        "countTasksOne": "1 tarea",
+        "countWorkflowsMany": "{{value0}} flujos",
+        "countWorkflowsOne": "1 flujo",
+        "detailsUnavailable": "Los detalles de la tarea no están disponibles para esta sesión.",
+        "groupAgents": "Agentes",
+        "groupMonitors": "Monitores",
+        "headerTotal": "{{value0}} tareas en segundo plano",
+        "monitor": "Monitor en segundo plano",
+        "reasonBlocked": "fallido",
+        "reasonUnverifiable": "sin contacto",
+        "reasonWaiting": "requiere aprobación",
+        "stateBlocked": "bloqueado",
+        "stateMonitoring": "monitoreando",
+        "stateUnverifiable": "no verificable",
+        "stateWorking": "trabajando",
+        "stop": "Detener",
+        "stopAll": "Detener tareas en segundo plano",
+        "stopTask": "Detener {{value0}}",
+        "task": "Tarea en segundo plano",
+        "workflow": "Flujo en segundo plano"
+      },
+      "handoff": {
+        "mode": {
+          "terminal": "Terminal",
+          "chat": "Chat",
+          "switching": "Cambiando"
+        },
+        "cancel": "Cancelar",
+        "agentOpen": "El agente está abierto en la terminal.",
+        "agentOpenOnHost": "El agente está abierto en la terminal en {{value0}}.",
+        "details": "Detalles",
+        "exitTerminal": "Sal de la terminal del agente para continuar en el chat.",
+        "openAgentTui": "Abrir TUI del agente",
+        "retry": "Reintentar",
+        "retryProof": "Reintentar prueba",
+        "returnAfterTurn": "Volver tras este turno",
+        "returnToChat": "Volver al chat",
+        "returningAfterTurn": "Volviendo tras este turno",
+        "stage": {
+          "finishingChat": "Terminando sesión de chat…",
+          "finishingTerminal": "Terminando terminal del agente…",
+          "manualRecovery": "La sesión del agente necesita recuperación",
+          "openingTerminal": "Abriendo terminal del agente…",
+          "recovering": "Recuperando sesión del agente…",
+          "resumingChat": "Retomando sesión de chat…",
+          "verifyingChat": "Verificando sesión de chat…",
+          "verifyingTerminal": "Verificando terminal del agente…"
+        },
+        "switchAfterTurn": "Cambiar tras este turno",
+        "switchingAfterTurn": "Cambiando tras este turno",
+        "switchingOwner": "Cambiando propietario de la sesión…",
+        "stopTurnAndSwitch": "Detener turno y cambiar"
+      },
+      "subagents": {
+        "state": {
+          "stopped": "detenido",
+          "failedCount": "{{value0}} falló",
+          "completed": "completado",
+          "failed": "fallido",
+          "idle": "idle",
+          "idleCount": "{{value0}} idle",
+          "stoppedCount": "{{value0}} detenidos",
+          "unverifiable": "no verificable",
+          "unverifiableCount": "{{value0}} no verificables",
+          "working": "trabajando",
+          "workingCount": "{{value0}} trabajando"
+        },
+        "ranN": "Ejecutó {{value0}} subagentes",
+        "ranOne": "Ejecutó 1 subagente",
+        "startedN": "Inició {{value0}} subagentes",
+        "startedOne": "Inició 1 subagente",
+        "tokens": "{{value0}} tokens"
+      },
+      "conversationCommand": {
+        "pendingWork": "Espera a que el trabajo y los mensajes pendientes terminen antes de usar este comando.",
+        "unconfirmed": "La operación de conversación no se confirmó."
+      },
+      "notices": {
+        "compaction": "Contexto compactado",
+        "details": "Detalles",
+        "plan": "Plan"
+      },
+      "providerFrame": {
+        "byteLength": "{{value0}} bytes"
+      },
+      "structuredSessionCloseFailed": "No se pudo cerrar esta sesión de chat",
+      "structuredSessionCloseFailedDescription": "La terminal quedó abierta para que el proveedor siga siendo recuperable.",
+      "structuredSessionFellBackToTerminal": "El chat estructurado no está disponible",
+      "structuredSessionFellBackToTerminalDescription": "Orca intentó abrir una terminal {{value0}} en su lugar.",
+      "structuredSessionLaunchFailed": "No se pudo abrir el chat {{value0}}",
+      "structuredSessionLaunchFailedDescription": "Orca no pudo abrir un chat estructurado {{value0}}. Consulta los registros para detalles.",
+      "structuredSessionLaunchPending": "Iniciando chat {{value0}}…",
+      "turnDiff": {
+        "many": "{{count}} archivos modificados",
+        "one": "1 archivo modificado",
+        "partial": "Diff parcial",
+        "recorded": "Totales de ediciones registradas en este turno."
+      }
     },
     "tab": {
       "bar": {
@@ -14729,6 +17179,232 @@
         "presentation": {
           "gitlabMergeRequestNumber": "MR #{{value0}}",
           "githubPullRequestNumber": "PR #{{value0}}"
+        },
+        "browse": {
+          "measureSizes": "Escanear",
+          "searchLabel": "Buscar espacios de trabajo",
+          "filters": "Filtros",
+          "facet": {
+            "git": "Git",
+            "location": "Ubicación",
+            "activity": "Actividad",
+            "status": "Estado del espacio de trabajo",
+            "agent": "Agente",
+            "context": "Contexto local",
+            "review": "Revisión",
+            "safety": "Seguridad",
+            "size": "Tamaño en disco",
+            "ticket": "Tickets"
+          },
+          "host": "Host",
+          "repo": "Repositorio",
+          "tier": {
+            "ready": "Listo",
+            "protected": "Protegidos",
+            "review": "Necesitan revisión"
+          },
+          "archived": "Archivado",
+          "unread": "No leído",
+          "noWorkspaces": "No se encontraron espacios de trabajo.",
+          "noMatches": "Ningún espacio de trabajo coincide con estos filtros.",
+          "sortBy": "Ordenar por",
+          "sortByField": "Ordenar por {{value0}}",
+          "sort": {
+            "size": "Tamaño",
+            "repo": "Repositorio",
+            "path": "Ruta",
+            "host": "Host",
+            "workspaceStatus": "Estado",
+            "agent": "Agente",
+            "git": "Git",
+            "behind": "Por detrás",
+            "branch": "Rama",
+            "ahead": "Por delante",
+            "blockerCount": "Bloqueadores",
+            "created": "Creado",
+            "lastActivity": "Última actividad",
+            "lastVisited": "Última apertura",
+            "localContext": "Contexto abierto",
+            "name": "Espacio de trabajo",
+            "review": "Revisión",
+            "ticket": "Ticket",
+            "tier": "Seguridad"
+          },
+          "review": {
+            "draft": "Borrador",
+            "otherProvider": "Otro",
+            "closed": "Cerrado",
+            "merged": "Fusionado",
+            "open": "Abierto",
+            "unknown": "Desconocido"
+          },
+          "ticket": {
+            "workItem": "Work item",
+            "linear": "Linear",
+            "issue": "Issue"
+          },
+          "refreshing": "Actualizando…",
+          "openWorkspaceNamed": "Abrir {{value0}}",
+          "openWorkspace": "Abrir espacio de trabajo",
+          "chip": {
+            "list": "{{value0}}: {{value1}}",
+            "triState": "{{value0}}: {{value1}}",
+            "presence": "{{value0}}: {{value1}}",
+            "kind": {
+              "status": "Estado",
+              "agent": "Agente",
+              "git": "Git",
+              "context": "Contexto",
+              "host": "Host",
+              "repo": "Repositorio",
+              "archived": "Archivado",
+              "unread": "No leído",
+              "blocker": "Bloqueador",
+              "comment": "Comentario",
+              "dismissed": "Ignorados",
+              "locked": "Bloqueados",
+              "pinned": "Fijados",
+              "prunable": "Podables",
+              "retainedAgents": "Agentes terminados",
+              "review": "Revisión",
+              "reviewProvider": "Proveedor",
+              "reviewState": "Estado de revisión",
+              "ticket": "Ticket",
+              "ticketSource": "Fuente del ticket",
+              "tier": "Seguridad"
+            },
+            "branchQuery": "Rama: {{value0}}",
+            "completelyEmpty": "Nada que perder",
+            "exclude": "Excluidos",
+            "excludesStatusless": "Con estado",
+            "excludesUnsized": "Solo medidos",
+            "has": "Tiene",
+            "idleDays": "Inactivo {{value0}} d+",
+            "maxSize": "Como máximo {{value0}} MB",
+            "minAhead": "Por delante {{value0}}+",
+            "minBehind": "Por detrás {{value0}}+",
+            "minSize": "Al menos {{value0}} MB",
+            "neverVisited": "Nunca visitado",
+            "none": "Ninguno",
+            "only": "Solo",
+            "pathPrefix": "Ruta: {{value0}}",
+            "selectableOnly": "Solo eliminables"
+          },
+          "blockerMode": "Coincidencia de bloqueadores",
+          "blockerModeAny": "Tiene alguno",
+          "blockerModeNone": "No tiene ninguno",
+          "blockers": "Bloqueadores",
+          "branchQuery": "La rama contiene",
+          "checkingGit": "Comprobando estado de git: faltan {{value0}}",
+          "checkingGitRow": "Comprobando estado de git",
+          "clearFilters": "Borrar filtros",
+          "dismissed": "Ignorados",
+          "idleSignal": {
+            "lastActivity": "Sin actividad",
+            "lastVisited": "Sin abrir",
+            "created": "Creado antes"
+          },
+          "locked": "Bloqueados",
+          "measureSizesDescription": "Analiza el uso de disco para comparar, ordenar y filtrar espacios de trabajo por tamaño.",
+          "measureSizesTitle": "Analizar tamaños de espacios de trabajo",
+          "minAhead": "Commits por delante ≥",
+          "minBehind": "Commits por detrás ≥",
+          "noSizes": "Aún no se midieron tamaños de espacios de trabajo.",
+          "noSizesDescription": "Los tamaños aparecen tras medir el uso de disco.",
+          "pathPrefix": "La ruta empieza con",
+          "prunable": "Podables",
+          "reviewPresence": "PR / MR",
+          "reviewProvider": "Proveedor",
+          "searchPlaceholder": "Buscar nombre, repo, rama, ruta, host",
+          "showingCount": "Mostrando {{value0}} de {{value1}}",
+          "selectableOnly": "Solo espacios de trabajo que puedo eliminar ahora",
+          "sizeOnDisk": "Tamaño en disco: {{value0}}",
+          "ticketPresence": "Ticket vinculado",
+          "agent": {
+            "idle": "Idle",
+            "permission": "Esperándote",
+            "working": "Trabajando"
+          },
+          "appliedFilters": "Filtros aplicados",
+          "comment": "Tiene comentario",
+          "completelyEmpty": "Nada que perder",
+          "contextPresence": "Pestañas, terminales y comentarios abiertos",
+          "days": "días",
+          "deleteAnyway": "Eliminar de todos modos",
+          "forceDeleteProjectionMany": "{{count}} espacios de trabajo muestran riesgo actualmente y podrían requerir eliminación forzada",
+          "forceDeleteProjectionOne": "{{count}} espacio de trabajo muestra riesgo actualmente y podría requerir eliminación forzada",
+          "git": {
+            "clean": "Limpio",
+            "dirty": "Cambios sin confirmar",
+            "unknown": "Sin comprobar",
+            "unpushed": "Commits sin push"
+          },
+          "gitStatusCheckFailed": "Falló la comprobación de estado de git",
+          "gitStatusUnverified": "No se pudo verificar el estado de git",
+          "idleMinDays": "Inactivo por al menos",
+          "idleSignalField": "Señal de inactividad",
+          "includeUnsized": "Incluir espacios de trabajo sin medir",
+          "matchStatusless": "Incluir espacios de trabajo sin estado",
+          "maxSize": "Como máximo",
+          "measureSizesFailed": "No se pudieron analizar los tamaños de espacios de trabajo",
+          "measuringSizes": "Analizando tamaños",
+          "measuringSizesProgress": "Analizando {{value0}}/{{value1}}",
+          "minSize": "Al menos",
+          "neverVisited": "Nunca abierto",
+          "noMatchesDescription": "Cada espacio de trabajo está en una lista — amplía una faceta o borra los filtros.",
+          "notMeasured": "Sin medir",
+          "pinned": "Fijados",
+          "presence": {
+            "any": "Cualquiera",
+            "none": "No tiene ninguno",
+            "some": "Tiene uno"
+          },
+          "refreshingProgress": "Actualizando {{value0}}/{{value1}}",
+          "removeFilter": "Quitar filtro {{value0}}",
+          "retainedDoneAgents": "Transcripciones de agentes terminados",
+          "selectAll": "Seleccionar todos los espacios de trabajo coincidentes",
+          "selectAllCount": "Seleccionar los {{value0}} espacios de trabajo verificados",
+          "selectAllCountOne": "Seleccionar 1 espacio de trabajo verificado",
+          "selectedCount": "{{value0}} seleccionados",
+          "selectionVanished": "{{value0}} espacios de trabajo seleccionados ya no existen.",
+          "selectionVanishedOne": "1 espacio de trabajo seleccionado ya no existe.",
+          "selectionWithheld": "{{value0}} espacios de trabajo seleccionados están ocultos por los filtros actuales y fueron deseleccionados.",
+          "selectionWithheldOne": "1 espacio de trabajo seleccionado está oculto por los filtros actuales y fue deseleccionado.",
+          "tierField": "Nivel de limpieza",
+          "triState": {
+            "any": "Cualquiera",
+            "exclude": "Excluir",
+            "only": "Solo"
+          },
+          "updatedAgo": "Actualizado {{value0}}",
+          "workspaceStatus": "Estado del espacio de trabajo: {{value0}}"
+        },
+        "scan": {
+          "noWorkspaces": "No se encontraron espacios de trabajo.",
+          "fallbackRepository": "un repositorio",
+          "gitListFailed": "Git no pudo listar worktrees",
+          "moreErrors": ", +{{value0}} más",
+          "multipleErrors": "No se pudieron comprobar {{value0}} repositorios ({{value1}}{{value2}}). Podrían faltar espacios de trabajo. Actualiza para reintentar.",
+          "progress": "Analizando espacios de trabajo ({{value0}}/{{value1}})",
+          "readyMany": "{{value0}} espacios de trabajo encontrados.",
+          "readyManyMany": "{{value0}} espacios de trabajo encontrados, con {{value1}} sugerencias de limpieza.",
+          "readyManyOne": "{{value0}} espacios de trabajo encontrados, con 1 sugerencia de limpieza.",
+          "readyOne": "1 espacio de trabajo encontrado.",
+          "readyOneMany": "1 espacio de trabajo encontrado, con {{value0}} sugerencias de limpieza.",
+          "readyOneOne": "1 espacio de trabajo encontrado, con 1 sugerencia de limpieza.",
+          "singleError": "No se pudo comprobar {{value0}}: {{value1}}. Podrían faltar espacios de trabajo. Actualiza para reintentar."
+        },
+        "relativeTime": {
+          "justNow": "Ahora mismo",
+          "minutesAgo": "hace {{value0}}m",
+          "hoursAgo": "hace {{value0}}h",
+          "daysAgo": "hace {{value0}}d",
+          "never": "Nunca"
+        },
+        "host": {
+          "label": "Host: {{value0}}",
+          "candidateName": "{{value0}} en {{value1}}",
+          "unknown": "Host desconocido"
         }
       }
     },
@@ -14764,6 +17440,61 @@
         "copySessionIdSuccess": "ID de sesión copiado",
         "copySessionIdError": "No se pudo copiar el ID de sesión"
       }
+    },
+    "onboarding": {
+      "flow": {
+        "stepTooltip": {
+          "theme": "Apariencia",
+          "notifications": "Notificaciones",
+          "integrations": "Integraciones",
+          "agent": "Agente predeterminado",
+          "windowsTerminal": "Terminal de Windows"
+        },
+        "actions": {
+          "addFirstProject": "Añade tu primer proyecto",
+          "continue": "Continuar",
+          "openingAddProject": "Abriendo Añadir proyecto…"
+        }
+      },
+      "skipConfirmation": {
+        "skip": "Omitir",
+        "keepGoing": "No, seguir"
+      },
+      "theme": {
+        "hints": {
+          "dark": "Suave para la vista",
+          "system": "Igual que el SO",
+          "light": "Brillante y nítido"
+        }
+      },
+      "integrations": {
+        "capabilities": {
+          "browseIssues": "Explora issues y pull requests de GitHub en la vista Tareas sin salir de Orca",
+          "managePullRequests": "Lee, comenta y fusiona pull requests sin salir de Orca",
+          "reviewStatus": "Ve estado de issues, estado de revisión y checks de CI en cada worktree",
+          "startWorkspaceFromIssue": "Inicia un espacio de trabajo desde cualquier issue o pull request de GitHub, prellenado con su título y contexto"
+        }
+      }
+    },
+    "jiraUserPicker": {
+      "empty": "Sin usuarios encontrados",
+      "search": "Buscar usuarios",
+      "select": "Seleccionar {{value0}}"
+    },
+    "cmd-j": {
+      "paletteSessionAge": {
+        "days": "{{value0}} d",
+        "hours": "{{value0}} h",
+        "minutes": "{{value0}} min",
+        "underOneMinute": "<1 min"
+      }
+    },
+    "status": {
+      "bar": {
+        "workspaceSpace": {
+          "otherTopLevelItems": "Otros elementos de nivel superior ({{value0}})"
+        }
+      }
     }
   },
   "dashboardPopout": {
@@ -14786,7 +17517,58 @@
       "zoomIn": "Acercar",
       "fit": "Ajustar",
       "projectCount": "{{agents}} agentes · {{workspaces}} espacios de trabajo",
-      "agentCount": "{{count}} agentes"
+      "agentCount": "{{count}} agentes",
+      "filters": {
+        "time": "Tiempo",
+        "agentlessWorkspaces": "Espacios de trabajo sin agentes",
+        "agents": "Agentes",
+        "lifespan": "Duración de sesión",
+        "ofTotalAgents": "de {{total}} agentes mostrados",
+        "orchestrationLinks": "Enlaces de orquestación",
+        "orchestrationLinksHidden": "Enlaces de orquestación ocultos",
+        "quickViews": "Vistas rápidas",
+        "reset": "Restablecer",
+        "resetRanges": "Restablecer rangos",
+        "showStates": "Estados de agentes",
+        "sinceMessage": "Desde el último mensaje",
+        "stateChip": "Estado: {{states}}",
+        "summaryAll": "Todo",
+        "summaryCount": "{{shown}} de {{total}}",
+        "summarySelected": "{{count}} seleccionados",
+        "timeAny": "cualquiera",
+        "timeInState": "Tiempo en estado actual",
+        "timeMaximum": "{{label}} máximo",
+        "timeMinimum": "{{label}} mínimo",
+        "timeRangeCount": "{{count}} rangos",
+        "title": "Controles del mapa",
+        "workspace": "Espacio de trabajo",
+        "workspaceVisibility": "Contenido del mapa"
+      },
+      "agentCount_other": "{{count}} agentes",
+      "quickView": {
+        "unread": "No leído",
+        "orchestration": "Orquestación",
+        "attention": "Requieren atención",
+        "everything": "Todo",
+        "longRunning": "De larga duración",
+        "recent": "Últimos 30 min",
+        "stale": "Inactivos > 3 d",
+        "stuck": "Atascados"
+      },
+      "agentCount_one": "{{count}} agente",
+      "noLaunchableAgents": "Sin agentes habilitados detectados.",
+      "noWorkspaceAgents": "Sin agentes en este espacio de trabajo.",
+      "openFolderWorkspace": "Abrir detalles del espacio de trabajo de carpeta {{workspace}}",
+      "openWorktree": "Abrir detalles del worktree {{worktree}}",
+      "runningAgents": "Agentes",
+      "sleepWorkspace": "Suspender",
+      "spawnAgent": "Iniciar un agente nuevo",
+      "status": {
+        "doneSeen": "Hecho, visto"
+      },
+      "worktreeSummary": "{{total}} agentes · {{active}} activos · {{done}} terminados",
+      "worktreeSummary_one": "{{total}} agente · {{active}} activo · {{done}} terminado",
+      "worktreeSummary_other": "{{total}} agentes · {{active}} activos · {{done}} terminados"
     },
     "placeholder": {
       "title": "Agent dashboard",
@@ -14825,7 +17607,8 @@
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
       "focusWorktree": "Open worktree",
-      "close": "Close"
+      "close": "Close",
+      "remotePreviewUnavailable": "Sin vista previa para esta sesión remota — abre el espacio de trabajo para ver la terminal."
     },
     "close": "Close dashboard",
     "settingsTooltip": "Configuración del tablero",
@@ -14845,7 +17628,8 @@
       "project": "Proyecto",
       "workspaceStatus": "Estado del espacio de trabajo",
       "reviewStatus": "Estado de PR / MR",
-      "clearAll": "Limpiar todos los filtros"
+      "clearAll": "Limpiar todos los filtros",
+      "removeChip": "Quitar {{filter}}"
     },
     "search": {
       "placeholder": "Buscar worktree, proyecto o agente…",
@@ -14857,6 +17641,12 @@
     "settings": {
       "showIdle": "Mostrar agentes inactivos",
       "showIdleCopy": "Incluye agentes que han permanecido inactivos durante 30 minutos sin informar que finalizaron. Ocultos de forma predeterminada."
+    },
+    "host": {
+      "remote": "Host remoto de Orca",
+      "remoteNamed": "Host remoto de Orca · {{host}}",
+      "ssh": "Host SSH",
+      "sshNamed": "Host SSH · {{host}}"
     }
   },
   "dashboard": {
@@ -14889,7 +17679,77 @@
       "certificateChallengeExpired": "Esta aprobación de certificado caducó. Vuelve a intentarlo con la página para solicitar una nueva.",
       "certificateChallengeChanged": "La solicitud de certificado cambió. Vuelve a intentarlo con la página y revisa la nueva advertencia.",
       "certificateChallengeUnavailable": "Esta solicitud de certificado ya no está disponible. Vuelve a intentarlo con la página para solicitar una nueva.",
-      "certificateProceedFailed": "Orca no pudo aprobar esta solicitud de certificado. Vuelve a intentarlo con la página e inténtalo de nuevo."
+      "certificateProceedFailed": "Orca no pudo aprobar esta solicitud de certificado. Vuelve a intentarlo con la página e inténtalo de nuevo.",
+      "recheckSshRoute": "Ejecutar comprobación de conexión",
+      "sshRoutedHint": "Esta página navega a través del host SSH del espacio de trabajo; es posible que el host esté desconectado o no pueda acceder a este sitio."
+    },
+    "navigation": {
+      "reload": "Recargar",
+      "back": "Atrás",
+      "forward": "Adelante"
+    },
+    "sshRoute": {
+      "showDetails": "Mostrar detalles",
+      "browseLocally": "Navegar desde este dispositivo",
+      "errorDescription": "Las páginas de este espacio de trabajo navegan a través de su host SSH, y esa conexión no está disponible en este momento.",
+      "errorTitle": "Enrutamiento SSH del navegador no disponible",
+      "forwardingBlockedDescription": "Este servidor rechaza el reenvío TCP (a menudo «AllowTcpForwarding no» en su configuración sshd), necesario para navegar a través de él. Pide a su administrador que permita el reenvío o navega desde este dispositivo.",
+      "forwardingBlockedTitle": "El servidor SSH bloquea el tráfico del navegador",
+      "preparingTitle": "Conectando a través del host SSH",
+      "retry": "Reintentar",
+      "sshUnavailableDescription": "Las páginas de este espacio de trabajo navegan a través de su host SSH, y esa conexión no está disponible en este momento. Reconecta el host e inténtalo de nuevo.",
+      "sshUnavailableTitle": "Conexión SSH no disponible",
+      "tryAnyway": "Intentar de todos modos"
+    },
+    "sshEgress": {
+      "localChip": "Este dispositivo",
+      "localDetail": "Las páginas se cargan desde esta máquina y su red.",
+      "localTooltip": "Navegando desde este dispositivo, no desde {{value0}}",
+      "routedDetail": "El tráfico de red y el DNS pasan por el host SSH del espacio de trabajo.",
+      "routedTooltip": "Navegando a través de {{value0}}",
+      "settingsLink": "Ajustes de enrutamiento"
+    },
+    "clientHosted": {
+      "download": {
+        "canceled": "Descarga cancelada.",
+        "completed": "Se descargó {{filename}}.",
+        "failed": "No se pudo completar la descarga.",
+        "started": "Descargando {{filename}}…"
+      },
+      "hostPaneDescription": "Esta página se representa en el equipo emparejado que la abrió.",
+      "hostPaneOfflineDescription": "Esta página sigue en la lista para que puedas cerrarla desde aquí. Volverá cuando el dispositivo se reconecte.",
+      "hostPaneOfflineTitle": "Ese dispositivo ya no está conectado",
+      "hostPaneTitle": "Mostrándose en otro dispositivo",
+      "hostPaneNamedTitle": "Mostrándose en {{device}}",
+      "hostRow": "Alojada en otro dispositivo",
+      "hostRowClose": "Cerrar página alojada",
+      "hostRowCloseFailed": "No se pudo cerrar esta página. Es posible que el dispositivo que la aloja esté ocupado; inténtalo de nuevo.",
+      "hostRowNamed": "Alojada en {{device}}",
+      "hostRowOffline": "Sin conexión — el dispositivo que la alojaba se cerró",
+      "hostRowOfflineNamed": "Sin conexión — estaba alojada en {{device}}",
+      "popupBlocked": "Ventana emergente bloqueada: {{origin}}",
+      "preparationFailed": "No se pudo iniciar el navegador remoto en este equipo. Revisa la conexión emparejada e inténtalo de nuevo.",
+      "unavailableDescription": "Esta página está asociada a otro equipo o ya no está disponible.",
+      "unavailableTitle": "Navegador alojado en el cliente no disponible"
+    },
+    "guestRecovery": {
+      "failed": "La página del navegador se detuvo inesperadamente. Reintenta para restaurarla.",
+      "title": "La página del navegador se detuvo"
+    },
+    "remote": {
+      "findUnavailable": "Buscar en la página no está disponible mientras esta página se transmite desde el host remoto."
+    },
+    "remoteEgress": {
+      "clientHostedDetail": "La página se representa en este dispositivo. El tráfico de red y el DNS pasan por el host remoto.",
+      "clientHostedTooltip": "Navegando a través de {{value0}}",
+      "streamedDetail": "La página se ejecuta en el host remoto y se transmite a este dispositivo.",
+      "streamedTooltip": "Navegando en {{value0}}"
+    },
+    "reopenOnServer": {
+      "action": "Reabrir en el servidor",
+      "caveat": "Esto abre una página nueva en el host remoto con la última dirección de esta página. El estado de sesión y otros estados transitorios pueden variar, y una página proveniente de un envío de formulario se abre en blanco.",
+      "failed": "No se pudo abrir esta página en el host remoto. Revisa la conexión e inténtalo de nuevo.",
+      "pending": "Reabriendo…"
     }
   },
   "runtimeRpc": {
@@ -14929,6 +17789,61 @@
       "working": "trabajando",
       "stopped": "detenido",
       "finished": "finalizado"
+    }
+  },
+  "featureTips": {
+    "voice": {
+      "startDictation": "Iniciar dictado",
+      "agentPromptTitle": "Prompt del agente",
+      "demoPrompt": "Revisa este diff por casos límite y añade pruebas para lo que encuentres.",
+      "focusPaneInstruction": "Enfoca una terminal, editor o prompt de agente y pulsa",
+      "listening": "Escuchando…",
+      "settingsInstruction": "Cambia el modelo, modo de dictado o atajo cuando quieras en",
+      "settingsLink": "Ajustes → Voz",
+      "startInstruction": "para iniciar el dictado por voz. Pulsa",
+      "stopInstruction": "de nuevo para detener.",
+      "unassignedInstruction": "Asigna un atajo de dictado antes de iniciar el dictado por voz en un panel enfocado."
+    }
+  },
+  "rendererRecovery": {
+    "reload": "Recargar",
+    "quit": "Salir",
+    "crashLoopDetail": "Orca intentó recuperarse {{recoveryCount}} veces seguidas sin éxito.",
+    "crashLoopMessage": "La ventana de la app falló repetidamente y dejó de recargarse automáticamente.",
+    "driverFallback": "Si eso no ayuda, la causa suele ser un controlador de gráficos.",
+    "genericDetail": "Suele ser un problema del controlador de gráficos o de la instalación. Recarga para reintentar o sal y vuelve a abrir Orca.",
+    "copyCommands": "Copiar comandos",
+    "stalledDetail": "Orca recargó la ventana tras un fallo, pero nunca terminó de cargar.",
+    "stalledMessage": "La ventana de la app dejó de responder al recargar tras un fallo.",
+    "title": "Orca sigue sin poder cargar"
+  },
+  "editor": {
+    "richMarkdown": {
+      "openAnyway": "Abrir de todos modos",
+      "tooLarge": "El archivo supera el límite de edición enriquecida de {{limit}}. Mostrando el modo de código fuente."
+    }
+  },
+  "sidebar": {
+    "revealFiltered": {
+      "cancel": "Mantener filtros",
+      "confirm": "Borrar filtros y mostrar",
+      "description": "El espacio de trabajo activo está oculto en la barra lateral. Mostrarlo borrará los filtros de la barra lateral.",
+      "title": "¿Mostrar el espacio de trabajo oculto?"
+    }
+  },
+  "checksPanel": {
+    "unlinked": {
+      "description": "El PR #{{number}} está oculto para este espacio de trabajo. Vincúlalo de nuevo para restaurar checks y detalles de revisión.",
+      "relink": "Vincular PR #{{number}}",
+      "title": "Pull request desvinculado"
+    }
+  },
+  "quickOpen": {
+    "moreMatchesAvailable": "Podría haber más coincidencias. Refina tu búsqueda para acotar los resultados."
+  },
+  "sourceControl": {
+    "unlinkedPr": {
+      "status": "PR #{{number}} desvinculado"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -27,11 +27,77 @@
       "certificateChallengeExpired": "Cette approbation de certificat a expiré. Rechargez la page pour en demander une nouvelle.",
       "certificateChallengeChanged": "La demande de certificat a changé. Rechargez la page et examinez le nouvel avertissement.",
       "certificateChallengeUnavailable": "Cette demande de certificat n'est plus disponible. Rechargez la page pour en demander une nouvelle.",
-      "certificateProceedFailed": "Orca n'a pas pu approuver cette demande de certificat. Rechargez la page et réessayez."
+      "certificateProceedFailed": "Orca n'a pas pu approuver cette demande de certificat. Rechargez la page et réessayez.",
+      "sshRoutedHint": "Cette page navigue via l'hôte SSH de l'espace de travail — l'hôte est peut-être déconnecté ou incapable d'atteindre ce site.",
+      "recheckSshRoute": "Lancer la vérification de connexion"
     },
     "guestRecovery": {
       "title": "Page du navigateur arrêtée",
       "failed": "La page du navigateur s'est arrêtée de manière inattendue. Réessayez pour la restaurer."
+    },
+    "clientHosted": {
+      "preparationFailed": "Impossible de démarrer le navigateur distant sur ce poste. Vérifiez la connexion appairée et réessayez.",
+      "unavailableTitle": "Navigateur hébergé par le client indisponible",
+      "unavailableDescription": "Cette page est rattachée à un autre poste ou n'est plus disponible.",
+      "download": {
+        "started": "Téléchargement de {{filename}}…",
+        "completed": "{{filename}} téléchargé",
+        "canceled": "Téléchargement annulé.",
+        "failed": "Impossible de terminer le téléchargement."
+      },
+      "popupBlocked": "Fenêtre contextuelle bloquée : {{origin}}",
+      "hostPaneOfflineTitle": "Cet appareil n'est plus connecté",
+      "hostPaneNamedTitle": "Affiché sur {{device}}",
+      "hostPaneTitle": "Affiché sur un autre appareil",
+      "hostPaneOfflineDescription": "Cette page reste répertoriée pour que vous puissiez la fermer depuis ici. Elle réapparaîtra lorsque l'appareil se reconnectera.",
+      "hostPaneDescription": "Cette page est rendue sur le poste appairé qui l'a ouverte.",
+      "hostRowClose": "Fermer la page hébergée",
+      "hostRowCloseFailed": "Impossible de fermer cette page. L'appareil qui l'héberge est peut-être occupé — réessayez.",
+      "hostRowOfflineNamed": "Hors ligne — était hébergé sur {{device}}",
+      "hostRowOffline": "Hors ligne — l'appareil qui l'hébergeait a quitté",
+      "hostRowNamed": "Hébergé sur {{device}}",
+      "hostRow": "Hébergé sur un autre appareil"
+    },
+    "navigation": {
+      "back": "Précédent",
+      "forward": "Suivant",
+      "reload": "Recharger"
+    },
+    "reopenOnServer": {
+      "action": "Rouvrir sur le serveur",
+      "pending": "Réouverture…",
+      "caveat": "Ceci ouvre une nouvelle page sur l'hôte distant à la dernière adresse de cette page. L'état de connexion et les autres états transitoires peuvent différer, et une page issue d'un envoi de formulaire s'ouvre vide.",
+      "failed": "Impossible d'ouvrir cette page sur l'hôte distant. Vérifiez la connexion et réessayez."
+    },
+    "sshRoute": {
+      "preparingTitle": "Connexion via l'hôte SSH",
+      "errorTitle": "Routage SSH du navigateur indisponible",
+      "errorDescription": "Les pages de cet espace de travail passent par son hôte SSH, et cette connexion n'est pas disponible pour le moment.",
+      "retry": "Réessayer",
+      "tryAnyway": "Essayer quand même",
+      "browseLocally": "Naviguer depuis cet appareil",
+      "forwardingBlockedTitle": "Le serveur SSH bloque le trafic du navigateur",
+      "sshUnavailableTitle": "Connexion SSH indisponible",
+      "forwardingBlockedDescription": "Ce serveur refuse la redirection TCP (souvent « AllowTcpForwarding no » dans sa configuration sshd), nécessaire pour naviguer via lui. Demandez à son administrateur d'autoriser la redirection, ou naviguez depuis cet appareil.",
+      "sshUnavailableDescription": "Les pages de cet espace de travail passent par son hôte SSH, et cette connexion n'est pas disponible pour le moment. Reconnectez l'hôte, puis réessayez.",
+      "showDetails": "Afficher les détails"
+    },
+    "sshEgress": {
+      "routedTooltip": "Navigation via {{value0}}",
+      "localTooltip": "Navigation depuis cet appareil, pas via {{value0}}",
+      "localChip": "Cet appareil",
+      "routedDetail": "Le trafic réseau et le DNS passent par l'hôte SSH de l'espace de travail.",
+      "localDetail": "Les pages se chargent depuis cette machine et son réseau.",
+      "settingsLink": "Paramètres de routage"
+    },
+    "remoteEgress": {
+      "clientHostedTooltip": "Navigation via {{value0}}",
+      "streamedTooltip": "Navigation sur {{value0}}",
+      "clientHostedDetail": "La page est rendue sur cet appareil. Le trafic réseau et le DNS passent par l'hôte distant.",
+      "streamedDetail": "La page s'exécute sur l'hôte distant et est diffusée vers cet appareil."
+    },
+    "remote": {
+      "findUnavailable": "La recherche dans la page n'est pas disponible pendant que cette page est diffusée depuis l'hôte distant."
     }
   },
   "githubChecks": {
@@ -65,7 +131,43 @@
       },
       "menuBarIcon": {
         "title": "Afficher l'icône dans la barre de menus",
-        "description": "Garder un raccourci Orca et un indicateur d'activité dans la barre de menus macOS."
+        "description": "Garder un raccourci Orca et un indicateur d'activité dans la barre de menus macOS.",
+        "keyword": {
+          "menuBar": "barre de menus",
+          "statusItem": "élément de statut",
+          "activity": "activité"
+        }
+      }
+    },
+    "browser": {
+      "clientHostedRemote": {
+        "title": "Héberger les pages distantes du navigateur sur cet appareil",
+        "description": "Rend les pages des espaces de travail distants sur ce poste ; le trafic réseau passe toujours par l'hôte distant. S'applique uniquement aux nouvelles pages.",
+        "optionDevice": "Cet appareil",
+        "optionDeviceTooltip": "Les pages sont rendues sur ce poste, donc la saisie et les fenêtres contextuelles se comportent nativement.",
+        "optionServer": "Serveur (diffusé)",
+        "optionServerTooltip": "Les pages sont rendues sur le serveur distant et diffusées vers cet appareil.",
+        "rowTitle": "Espaces de travail du serveur distant",
+        "rowDescription": "Où les pages sont rendues. Le trafic passe toujours par le serveur distant. S'applique uniquement aux nouvelles pages."
+      },
+      "sshWorkspaceRouting": {
+        "title": "Naviguer via les hôtes SSH des espaces de travail",
+        "description": "Les pages du navigateur dans les espaces de travail SSH font transiter leur trafic par l'hôte SSH de l'espace de travail, avec le DNS résolu sur place. Désactivé signifie que les pages naviguent depuis cette machine.",
+        "disabledHosts": "Hôtes naviguant depuis cet appareil :",
+        "enableHost": "Router à nouveau",
+        "optionHost": "Hôte SSH",
+        "optionHostTooltip": "Le trafic et le DNS passent par l'hôte SSH de l'espace de travail.",
+        "optionDevice": "Cet appareil",
+        "optionDeviceTooltip": "Les pages naviguent depuis le réseau de cette machine.",
+        "rowTitle": "Espaces de travail SSH",
+        "rowDescription": "D'où part le trafic du navigateur. Les pages sont toujours rendues sur cet appareil.",
+        "useHost": "Utiliser l'hôte SSH",
+        "probeSkippedHosts": "Hôtes routés sans vérification de connexion (Essayer quand même) :",
+        "probeAgain": "Vérifier à nouveau"
+      },
+      "remoteBrowsing": {
+        "heading": "Navigation à distance",
+        "headingDescription": "Où les pages des espaces de travail distants sont rendues, et d'où part leur trafic réseau."
       }
     }
   },
@@ -155,7 +257,8 @@
     "taskUrl": {
       "loadingHint": "Chargement de {{value0}}…",
       "createHint": "Créer un worktree à partir de {{value0}}"
-    }
+    },
+    "seeMore": "Voir plus"
   },
   "auto": {
     "App": {
@@ -347,11 +450,19 @@
               "meta": {
                 "persist": {
                   "877e3638d8": "Mettez à jour le runtime distant pour modifier l'issue liée à cet espace de travail",
-                  "4367540861": "Mettez à jour le runtime distant pour lier des issues Linear"
+                  "4367540861": "Mettez à jour le runtime distant pour lier des issues Linear",
+                  "github": {
+                    "pr": {
+                      "suppression": "Mettez à jour le runtime distant pour dissocier les pull requests GitHub"
+                    }
+                  }
                 }
               }
             }
-          }
+          },
+          "createdWithoutParentNesting": "Créé sans imbrication sous « {{value0}} »",
+          "createdWithoutParentNestingUnnamed": "Créé sans imbrication sous le parent sélectionné",
+          "createdWithoutParentNestingDetail": "L'espace de travail parent n'était plus disponible. Vous pouvez le définir depuis le menu de l'espace de travail."
         },
         "repos": {
           "2975400634": "Mettez à jour le serveur Orca pour ouvrir des dossiers non Git sur ce runtime.",
@@ -366,7 +477,9 @@
           "15cf5319ec": "{{path}} a été vérifié sur {{hostName}}, mais cet hôte n'a pas signalé de dossier exploitable.",
           "2dcd706774": "Le projet existe aussi dans un autre profil",
           "presenceProfileOverflow": "{{names}} +{{count}} autres",
-          "removeProjectFailed": "Échec de la suppression du projet"
+          "removeProjectFailed": "Échec de la suppression du projet",
+          "wslFilesystemBoundaryTitle": "Ce projet est stocké sur un lecteur Windows",
+          "wslFilesystemBoundaryDescription": "Git pour ce projet s'exécute dans {{distro}}, qui accède aux lecteurs Windows via le pont de système de fichiers WSL. Attendez-vous à ce que git soit environ 20 fois plus lent que sur une copie stockée dans {{distro}}."
         },
         "settings": {
           "e12dab333b": "Échec du changement de serveur",
@@ -696,6 +809,15 @@
         },
         "activation": {
           "cannotOpenFolderWorkspace": "Impossible d'ouvrir l'espace de travail de type dossier"
+        },
+        "creation": {
+          "flow": {
+            "structured": {
+              "launch": {
+                "unknown": "Impossible de confirmer si le chat Codex s'est ouvert. Réessayez pour vérifier à nouveau."
+              }
+            }
+          }
         }
       },
       "folderWorkspacePathStatus": {
@@ -799,7 +921,12 @@
               "undecryptableUnknown": "{{value0}} cookies n'ont pas pu être déchiffrés et ont été ignorés. Fermez complètement le navigateur source, puis réessayez l'importation.",
               "unrecognizedWarning": "L'importation des cookies s'est terminée avec un avertissement que cette version d'Orca ne reconnaît pas. Mettez Orca à jour pour voir les détails, puis vérifiez ce profil avant de vous fier à ses cookies.",
               "undecryptableUnrecognizedReason": "{{value0}} cookies n'ont pas pu être déchiffrés et ont été ignorés pour une raison que cette version d'Orca ne reconnaît pas. Mettez Orca à jour pour voir les détails, puis réessayez l'importation.",
-              "partitionSkipped": "{{value0}} cookies n'ont pas été importés car leur partition de site n'a pas pu être lue. Connectez-vous à nouveau à ces sites dans Orca."
+              "partitionSkipped": "{{value0}} cookies n'ont pas été importés car leur partition de site n'a pas pu être lue. Connectez-vous à nouveau à ces sites dans Orca.",
+              "locationClientHosted": "Lu depuis cet appareil et stocké ici pour l'espace de travail {{value0}}.",
+              "locationRemoteHost": "Lu depuis les navigateurs sur {{value0}} et stocké là-bas.",
+              "googleCookiesSkippedLocal": "Les cookies Google n'ont pas été importés. Ouvrez un navigateur dans Orca avec ce profil, puis connectez-vous à Google.",
+              "googleCookiesSkippedClientHosted": "Les cookies Google n'ont pas été importés. Ouvrez un onglet de navigateur dans l'espace de travail {{value0}} avec ce profil — il s'ouvre sur cet appareil — puis connectez-vous à Google.",
+              "googleCookiesSkippedRemoteWorkspace": "Les cookies Google n'ont pas été importés. Ouvrez un onglet de navigateur dans l'espace de travail {{value0}} avec ce profil, puis connectez-vous à Google."
             }
           }
         }
@@ -823,6 +950,19 @@
       },
       "ephemeralVmWorktreeCreation": {
         "sparseCheckoutUnsupported": "Les recettes à racine provisionnée ne prennent pas en charge le sparse checkout."
+      },
+      "activateAiVaultStructuredSession": {
+        "unavailable": "La session d'agent structurée n'est pas encore disponible. Réessayez dans un instant.",
+        "gone": "Ce chat ne se trouve plus sur cet hôte, il ne peut donc pas y être rouvert.",
+        "hostCannotOpen": "Ce chat ne pourra être rouvert qu'une fois Orca mis à jour."
+      },
+      "worktreeJumpNavigation": {
+        "filteredNotice": "Cet espace de travail est masqué par les filtres de la barre latérale. L'espace de travail a été ouvert, mais il n'apparaît pas dans Espaces."
+      },
+      "file": {
+        "preview": {
+          "pairedOutsideWorktree": "Les fichiers hors de l'espace de travail ne peuvent pas encore être prévisualisés sur un serveur appairé."
+        }
       }
     },
     "hooks": {
@@ -830,7 +970,8 @@
         "59718b120b": "L'espace de travail cible n'est plus disponible.",
         "16a21d6413": "La reconnexion SSH nécessite des identifiants interactifs.",
         "386db94f3e": "Le projet cible n'est plus disponible.",
-        "3ad7d77f57": "L'espace de travail cible se trouve sur un hôte différent de la cible de cette exécution d'automatisation."
+        "3ad7d77f57": "L'espace de travail cible se trouve sur un hôte différent de la cible de cette exécution d'automatisation.",
+        "workspaceHostUnresolved": "L'espace de travail cible s'étend sur plusieurs hôtes, cette exécution n'a donc aucun hôte unique à utiliser."
       },
       "useComposerState": {
         "7eb3f44ff7": "L'agent sélectionné est désactivé. Choisissez un agent activé avant de créer.",
@@ -980,6 +1121,24 @@
         "description": "Les terminaux Orca en cours d'exécution sont hébergés par un daemon démarré par une installation précédente d'Orca. macOS peut ne pas leur appliquer les autorisations Accessibilité, Automatisation ou fichiers protégés d'Orca. Redémarrez le daemon depuis Gérer les sessions pour restaurer l'accès. Cela fermera tous les terminaux Orca en cours d'exécution.",
         "openManageSessions": "Ouvrir Gérer les sessions",
         "dismiss": "Ignorer"
+      },
+      "ipc": {
+        "events": {
+          "browserStateIpcBridge": {
+            "docPreviewLinkFailed": "Impossible d'ouvrir ce lien dans le navigateur Orca."
+          },
+          "os": {
+            "markdown": {
+              "file": {
+                "open": {
+                  "bridge": {
+                    "1e9a1a63c4": "Échec de l'ouverture du fichier Markdown."
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "components": {
@@ -1275,7 +1434,8 @@
         "3a051b8ade": "Élément de travail",
         "32f8bef818": "Aucune sortie de log.",
         "4168eb2c51": "Résoudre",
-        "commentTooLarge": "Le commentaire est trop volumineux pour être envoyé sans risque."
+        "commentTooLarge": "Le commentaire est trop volumineux pour être envoyé sans risque.",
+        "gitlabActionFailed": "L'action GitLab a échoué."
       },
       "JiraIssueWorkspace": {
         "b0b92666c9": "Commentaire",
@@ -2100,7 +2260,9 @@
         "61ed600d29": "« {{value0}} » contient des modifications non enregistrées. Voulez-vous enregistrer avant de fermer ?",
         "cdc9ac4b2d": "éditeur",
         "e57db40c11": "Impossible de construire la commande de lancement pour {{value0}}.",
-        "5b2c1a9e44": "Aucun CLI d'agent détecté — installez-en un ou choisissez un agent par défaut dans les paramètres."
+        "5b2c1a9e44": "Aucun CLI d'agent détecté — installez-en un ou choisissez un agent par défaut dans les paramètres.",
+        "b7c1f0a934": "Un hôte distant n'a pas pu être joint, Orca ne peut donc pas dire si du travail y est toujours en cours. Fermer la fenêtre quand même ?",
+        "quitSnapshotSaveFailed": "Abandon annulé : l'instantané de session n'a pas pu être enregistré ({{value0}})."
       },
       "TerminalSearch": {
         "db234b7519": "Fermer",
@@ -2156,7 +2318,8 @@
         "a4650b0dc4": "Impossible d'utiliser le build local",
         "b1e390250d": "Impossible de finaliser le basculement vers le build local.",
         "d29740d175": "Le build sélectionné n'a pas pu être utilisé.",
-        "37d45c9ec1": "Choisir un autre build"
+        "37d45c9ec1": "Choisir un autre build",
+        "7f1a4c9e02": "Votre gestionnaire de paquets système a installé Orca, mettez-le à jour depuis celui-ci — Orca ne peut pas installer cette version lui-même."
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "Déplacer",
@@ -2382,6 +2545,30 @@
                 "7c302f8174": "Sans titre"
               }
             }
+          },
+          "ProjectRoadmap": {
+            "be52f7b6db": "Cette vue de feuille de route n'a aucun champ de date ou d'itération pour placer les éléments, Orca les répertorie donc à la place.",
+            "6405e036e0": "Mois",
+            "f2b1cabef7": "Trimestre",
+            "b6afc6fe45": "Année",
+            "343888b143": "Placé par {{value0}}",
+            "6a088a5da1": "{{value0}} sans dates",
+            "86eebd6020": "Aujourd'hui",
+            "0bb1c1bc07": "Zoom de la chronologie",
+            "e304235879": "Élément",
+            "e077c79083": "Sans dates"
+          },
+          "ProjectRoadmapBar": {
+            "cd68ccc17a": "{{value0}} — {{value1}}",
+            "7d1220d979": "Élément restreint"
+          },
+          "ProjectPickerPanels": {
+            "04ec212ccb": "Feuille de route",
+            "9fe1ac868c": "Non pris en charge"
+          },
+          "ProjectViewStates": {
+            "ac83c45672": "Passez à une vue Tableau ou Feuille de route pour travailler avec ce projet dans Orca.",
+            "e4cc8b14f2": "Orca affiche les vues de projet tableau et feuille de route. Cette vue utilise une disposition qu'il ne peut pas encore afficher."
           }
         },
         "GitHubMarkdownComposer": {
@@ -2933,7 +3120,14 @@
             "5c8ce20be6": "Si le problème persiste, veuillez",
             "cc6d997c65": "Redémarrez le daemon de terminal depuis ici pour effacer un état de daemon obsolète.",
             "e16012e31e": "Le daemon de terminal propriétaire de cette session s'est arrêté ; la session et son historique de défilement n'ont pas pu être récupérés. Ouvrez un nouveau terminal pour continuer.",
-            "sessionUnavailable": "Orca n'a pas pu se rattacher à la session de terminal de ce volet sur l'hôte. Ouvrez un nouveau terminal pour continuer."
+            "sessionUnavailable": "Orca n'a pas pu se rattacher à la session de terminal de ce volet sur l'hôte. Ouvrez un nouveau terminal pour continuer.",
+            "retry": "Réessayer",
+            "retrying": "Nouvelle tentative…",
+            "retryUnavailable": "La nouvelle tentative n'a pas encore pu reconnecter. Réessayez dans un instant.",
+            "ownerUnknown": "Orca n'a pas pu vérifier le propriétaire de ce terminal.",
+            "42b283ecfc": "Orca n'a pas pu reconnecter ce terminal en toute sécurité car l'hôte n'a pas pu vérifier sa session enregistrée. Orca a laissé la session enregistrée inchangée. Cliquez sur Réessayer pour tenter de reconnecter maintenant. Si la reconnexion échoue toujours, ouvrez un nouveau terminal.",
+            "sourceRestoring": "Reconnexion de ce terminal — sa sortie est en cours de rétablissement. La session est toujours en cours.",
+            "remoteTerminalClosed": "Le terminal distant a été fermé."
           },
           "TerminalProcessExitOverlay": {
             "capacityTitle": "Limite de consoles Git Bash atteinte",
@@ -2964,7 +3158,9 @@
             "copyLink": "Copier le lien",
             "copied": "Copied",
             "copiedLink": "Lien copié",
-            "copyLinkFailed": "Échec de la copie du lien"
+            "copyLinkFailed": "Échec de la copie du lien",
+            "downloadOpenWithDefaultApp": "Télécharger et ouvrir avec l'application par défaut",
+            "downloadOpenFailed": "Échec du téléchargement de « {{value0}} »."
           },
           "TerminalSessionStateSaveFailureDialog": {
             "6bee0c8f17": "Ouvrir l'Analyseur d'espace disque",
@@ -3158,7 +3354,10 @@
             "1d04b1630b": "Scinder vers le bas",
             "6b3efb106e": "Scinder vers le haut",
             "fdd29eb669": "Épingler l'onglet",
-            "8e9d603a09": "Détacher l'onglet"
+            "8e9d603a09": "Détacher l'onglet",
+            "revealInFinder": "Révéler dans le Finder",
+            "openContainingFolder": "Ouvrir le dossier parent",
+            "revealInFileExplorer": "Révéler dans l'explorateur de fichiers"
           },
           "QuickLaunchButton": {
             "348a04c1ad": "Paramètres de l'agent…",
@@ -3231,7 +3430,9 @@
             "d7d496a451": "La page du navigateur n'existe plus",
             "7726ce9970": "L'onglet émulateur mobile n'existe plus",
             "chooseAction": "Choisissez une action.",
-            "searchProvider": "Rechercher {{value0}}"
+            "searchProvider": "Rechercher {{value0}}",
+            "openPage": "Ouvrir une page",
+            "omniboxPlaceholderWithHistory": "Rechercher onglets ouverts, historique, fichiers, URL, agents…"
           },
           "TabBarQuickCommandsButton": {
             "a2c7a33831": "Commande",
@@ -3446,7 +3647,8 @@
             "connectedHostCount_other": "{{count}} hôtes",
             "connecting": "Connexion…",
             "workspaceConflict": "Conflit de espace de travail",
-            "workspaceSyncError": "Erreur de synchronisation de l'espace de travail"
+            "workspaceSyncError": "Erreur de synchronisation de l'espace de travail",
+            "runtime_unavailable_transport_up": "Orca indisponible"
           },
           "StatusBar": {
             "9659e38343": "Ports",
@@ -3688,7 +3890,14 @@
             "e2c6a4f917": "Exécutez Grok pour actualiser",
             "d1b7f509ac": "Exécutez grok dans un terminal sur l'ordinateur qui fait tourner Orca et attendez son démarrage. Si demandé, terminez la connexion, puis réessayez l'utilisation. Inutile d'envoyer un message.",
             "f90b3d7a16": "Exécutez Kimi pour actualiser",
-            "a37e8c15d4": "Exécutez kimi dans un terminal sur l'ordinateur qui fait tourner Orca et attendez son démarrage, puis réessayez l'utilisation."
+            "a37e8c15d4": "Exécutez kimi dans un terminal sur l'ordinateur qui fait tourner Orca et attendez son démarrage, puis réessayez l'utilisation.",
+            "minimax": {
+              "expired": {
+                "label": "Connexion expirée",
+                "apiKey": "La clé API MiniMax a expiré. Remplacez-la dans les paramètres.",
+                "cookie": "Le cookie de session MiniMax a expiré. Remplacez-le dans les paramètres."
+              }
+            }
           },
           "SshTargetStatusRow": {
             "sshHost": "Hôte SSH"
@@ -3733,7 +3942,8 @@
             "memory": {
               "metric": {
                 "workingSetDescription": "Somme des working sets (WS). Les pages partagées peuvent apparaître dans plusieurs processus.",
-                "rssDescription": "Somme des tailles résidentes (RSS). Les pages partagées ou aliasées peuvent apparaître dans plusieurs processus."
+                "rssDescription": "Somme des tailles résidentes (RSS). Les pages partagées ou aliasées peuvent apparaître dans plusieurs processus.",
+                "privateBytesDescription": "Octets privés cumulés : mémoire que ces processus ont engagée, qu'elle soit résidente ou paginée. C'est ce que l'hôte impute à sa limite d'engagement, elle continue donc d'augmenter tandis que l'ensemble de travail ci-dessus diminue sous l'effet de la pagination."
               }
             },
             "manager": {
@@ -3759,6 +3969,18 @@
             "onDescription": "Maintenir cet ordinateur éveillé en permanence",
             "autoDescription": "Rester éveillé pendant qu'un agent travaille",
             "offDescription": "Autoriser le comportement de veille normal du système"
+          },
+          "RuntimeHostStatusRow": {
+            "previous_connection_closed": "La connexion précédente s'est fermée",
+            "workspace_window_closed": "La fenêtre de l'espace de travail est fermée",
+            "checking_host": "Orca vérifie si cet hôte est accessible",
+            "restoring_connection": "Orca tente de rétablir la connexion",
+            "host_unreachable": "Orca n'est pas accessible sur cet hôte",
+            "runtime_unavailable": "Le transport SSH est connecté, mais le runtime Orca est indisponible",
+            "runtime_unavailable_explanation": "L'hôte distant est peut-être toujours en cours d'exécution ; seule la connexion au runtime Orca est indisponible.",
+            "contact_note": "L'hôte est peut-être toujours en cours d'exécution ; seule la connexion Orca est indisponible.",
+            "last_connected": "Dernière connexion {{value0}}",
+            "reconnect_attempt": "Tentative {{value0}}"
           }
         }
       },
@@ -4267,7 +4489,8 @@
           "3af85f6add": "Terminé",
           "readyDescriptionV2": "Toute personne disposant de ce lien non répertorié peut inspecter et installer les skills.",
           "descriptionV2": "Vérifiez les fichiers exacts, puis publiez une version immuable protégée par un lien non répertorié.",
-          "publishBundle": "Publier le bundle"
+          "publishBundle": "Publier le bundle",
+          "cancelRequestFailed": "Orca n'a pas pu envoyer la demande d'annulation. Le téléversement peut tout de même se terminer."
         },
         "SkillCard": {
           "d25a1b8ae6": "Partager le skill",
@@ -4593,7 +4816,24 @@
           "selectAll": "Tout sélectionner",
           "canonicalHeader": "Agents standard (toujours inclus)",
           "canonicalExplanation": "Ces agents lisent nativement {{root}}, où Orca installe par défaut :",
-          "additionalAgentsHeader": "Répertoires d'agents supplémentaires"
+          "additionalAgentsHeader": "Répertoires d'agents supplémentaires",
+          "authorizing": "Autorisation de l'accès au paquet…",
+          "installing": "Téléchargement, vérification et installation…",
+          "selectSkill": "Sélectionnez au moins une skill.",
+          "chooseWorkspace": "Choisissez un espace de travail.",
+          "reconnectBeforeInstalling": "Reconnectez votre compte Orca avant l'installation.",
+          "bundleVerificationFailed": "L'installation a échoué avant qu'Orca ne puisse vérifier le lot demandé.",
+          "destinationAlreadyFinished": "La destination avait déjà terminé cette installation.",
+          "enterShareLink": "Saisissez un lien de partage de skill Orca.",
+          "shareUnavailable": "Ce partage est indisponible. Le lien est peut-être invalide, expiré ou révoqué.",
+          "requestedVersionVerificationFailed": "L'installation a échoué avant qu'Orca ne puisse vérifier la version demandée.",
+          "versionVerificationFailed": "Orca n'a pas pu vérifier la version demandée.",
+          "inspectManagedFailed": "Orca n'a pas pu inspecter les installations gérées sur cette machine.",
+          "reconnectForVersionHistory": "Reconnectez votre compte Orca pour charger l'historique des versions.",
+          "versionHistoryUnavailable": "L'historique des versions est indisponible pour cette skill.",
+          "bundleSkillsMissing": "Cette version ne contient aucune des skills du lot installé.",
+          "reconnectBeforeVersionChange": "Reconnectez votre compte Orca avant de changer de version.",
+          "removeFailed": "Orca n'a pas pu supprimer cette skill en toute sécurité."
         },
         "filter": {
           "allAgents": "Tous les agents",
@@ -5042,7 +5282,10 @@
           "49f62c5665": "Tableau des espaces de travail",
           "5c9c7c16aa": "Ajoutez un projet pour créer des espaces de travail",
           "a30e34eb5c": "Fermer le tableau des espaces de travail",
-          "addProject": "Ajouter un projet"
+          "addProject": "Ajouter un projet",
+          "projects": "Projets",
+          "spaces": "Espaces",
+          "views": "Vue de la barre latérale"
         },
         "SidebarNav": {
           "80611a8b10": "Recherche",
@@ -5174,7 +5417,8 @@
           "65a9820bd1": "Statuts des agents",
           "219ebf1961": "Nom de branche",
           "folderPathIdentity": "Branche / chemin de dossier",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "workspaceOptions": "Options de l'espace de travail"
         },
         "SshTargetRow": {
           "4677394048": "Connexion…",
@@ -5291,7 +5535,8 @@
           "cliCreated": "Créé par Orca CLI",
           "jiraIssue": "Jira {{value0}}",
           "viewOnJira": "Voir sur Jira",
-          "linkedJira": "Lié à Jira {{value0}}"
+          "linkedJira": "Lié à Jira {{value0}}",
+          "openInOrcaBrowser": "Ouvrir dans le navigateur Orca"
         },
         "WorktreeCardMetadataStatusBadges": {
           "fe188062a1": "État : ouvert",
@@ -5412,7 +5657,11 @@
           "382fd11a3e": "Modifier les détails du worktree",
           "2174f17011": "Enregistrer",
           "61d6f612cf": "Enregistrement...",
-          "a0d191b7a7": "Modifiez les liens d'issues, de pull requests et les notes de cet espace de travail."
+          "a0d191b7a7": "Modifiez les liens d'issues, de pull requests et les notes de cet espace de travail.",
+          "gitlabDescription": "Modifiez les liens d'incidents, les liens de merge requests et les notes de cet espace de travail.",
+          "gitlabMR": "MR GitLab",
+          "gitlabPlaceholder": "MR ! ou URL GitLab",
+          "gitlabHelp": "Collez une URL de merge request, ou saisissez un numéro. Laissez vide pour supprimer le lien."
         },
         "WorktreeOpenInMenu": {
           "localOnly": "Local uniquement",
@@ -5523,7 +5772,8 @@
               "locked": "Cet espace de travail est verrouillé par Git. Exécutez git worktree unlock <worktree-path> depuis son dépôt, puis relancez la suppression.",
               "lockedReason": "Cet espace de travail est verrouillé par Git. Git a signalé : {{value0}}. Exécutez git worktree unlock <worktree-path> depuis son dépôt, puis relancez la suppression.",
               "unstoppedPty": "Orca n'a pas pu confirmer que tous les terminaux de cet espace de travail sont fermés, il s'est donc arrêté avant de supprimer des fichiers. Utilisez Forcer la suppression pour le retirer quand même.",
-              "unstoppedPtyLive": "Cet espace de travail a encore des terminaux actifs, Orca s'est donc arrêté avant de supprimer des fichiers. Forcer la suppression les arrêtera et abandonnera tout travail non commité qu'ils contiennent."
+              "unstoppedPtyLive": "Cet espace de travail a encore des terminaux actifs, Orca s'est donc arrêté avant de supprimer des fichiers. Forcer la suppression les arrêtera et abandonnera tout travail non commité qu'ils contiennent.",
+              "runningAgentSession": "Cet espace de travail comporte encore des sessions d'agent en cours, Orca s'est donc arrêté avant de supprimer des fichiers. La suppression forcée les fermera et abandonnera tout travail qu'elles contiennent."
             }
           }
         },
@@ -6008,6 +6258,11 @@
           "projectOnly": "Ajouté dans ce projet uniquement.",
           "useGlobalFor": "Utiliser la valeur globale pour {{value0}}",
           "useGlobal": "Utiliser la valeur globale"
+        },
+        "RepoScanUnavailableIndicator": {
+          "title": "Échec de l'analyse du worktree pour {{value0}}",
+          "retry": "Relancer l'analyse",
+          "retained": "Les worktrees existants sont conservés jusqu'à ce qu'une analyse réussisse. Cliquez pour réessayer."
         }
       },
       "shared": {
@@ -6201,7 +6456,25 @@
           "codexConfigSyncMissingSource": "Codex utilise toujours les derniers paramètres synchronisés car {{value0}} est absent. Restaurez ce fichier pour reprendre la synchronisation.",
           "codexConfigSyncBlankSource": "Codex utilise toujours les derniers paramètres synchronisés car {{value0}} est vide. C'est attendu tant qu'un dossier synchronisé finit de se télécharger.",
           "codexConfigSyncManagedHomeUnavailable": "Orca n'a pas réussi à lire les fichiers Codex de ce compte à l'instant ; les paramètres peuvent donc ne plus se synchroniser. Cela se résout généralement tout seul — un antivirus ou un outil de sauvegarde les verrouille brièvement.",
-          "codexConfigSyncUnreadableSource": "Codex utilise toujours les derniers paramètres synchronisés car {{value0}} n'a pas pu être lu. Vérifiez les permissions de ce fichier."
+          "codexConfigSyncUnreadableSource": "Codex utilise toujours les derniers paramètres synchronisés car {{value0}} n'a pas pu être lu. Vérifiez les permissions de ce fichier.",
+          "d6f1b9b6a2": "La clé API MiniMax est requise.",
+          "7c5d8a4e1b": "La clé API MiniMax n'a pas été enregistrée.",
+          "4d2c7b9e83": "Clé API MiniMax enregistrée.",
+          "f8a4b9d210": "Point de terminaison MiniMax",
+          "0b3a9f6c2e": "Choisissez l'hôte correspondant à votre compte. L'international (platform.minimax.io) comme la Chine (platform.minimaxi.com) acceptent soit un cookie de session, soit une clé API.",
+          "83b6a1f7c4": "Clé API MiniMax",
+          "4f2c8a7e1b": "Collez votre clé API MiniMax",
+          "a7b1e3c5d2": "Oublier la clé",
+          "usageTracking": "Configurez le suivi d'utilisation MiniMax pour votre compte.",
+          "credentialsNotSet": "Identifiants non définis",
+          "selectedEndpointStorage": "Stocké localement et envoyé au point de terminaison MiniMax sélectionné pour les actualisations d'utilisation.",
+          "endpointOverseas": "International (platform.minimax.io)",
+          "endpointChina": "Chine (platform.minimaxi.com)",
+          "openSelectedConsole": "Ouvrez {{url}} dans votre navigateur et connectez-vous.",
+          "cookieSelectedEndpoint": "Stocké localement et envoyé au point de terminaison MiniMax sélectionné pour les actualisations d'utilisation.",
+          "copySelectedConsoleCookie": "Ouvrez la console sélectionnée, connectez-vous, puis copiez l'en-tête de requête Cookie depuis DevTools (Réseau → n'importe quelle requête → Cookie).",
+          "apiKeySelectedEndpoint": "Collez la clé API depuis votre console MiniMax → Clés API. Stockée localement et envoyée au point de terminaison MiniMax sélectionné pour les actualisations d'utilisation. La clé API prime sur le cookie.",
+          "apiKeyInstructions": "Copiez la clé API depuis votre console MiniMax → Clés API. Une clé API enregistrée prime sur le cookie ; utilisez Oublier la clé pour revenir au cookie."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Redémarrer",
@@ -6556,7 +6829,9 @@
           "8a9b784c60": "périmé",
           "d363e5929b": "Vérification de l'enregistrement de la CLI…",
           "cliSkillTerminalTitle": "Configuration de la skill CLI",
-          "cliSkillTerminalAria": "Terminal d'installation de la skill CLI"
+          "cliSkillTerminalAria": "Terminal d'installation de la skill CLI",
+          "installFailureUnknownReason": "Orca n'a pas pu terminer l'enregistrement CLI et n'a indiqué aucun motif.",
+          "installFailureConflictRemedy": "Supprimez {{value0}} et enregistrez à nouveau si ce n'est plus nécessaire."
         },
         "CliSkillRuntimeSetup": {
           "04325573f8": "WSL",
@@ -6737,7 +7012,11 @@
             "defaultCopy": "Choisissez comment s'ouvrent les nouveaux onglets de terminal d'agents pris en charge.",
             "defaultViewLabel": "Vue Chat UI par défaut",
             "defaultViewTerminal": "Chat dans le terminal",
-            "defaultViewNative": "Chat UI"
+            "defaultViewNative": "Chat UI",
+            "structuredTitle": "Utiliser le chat natif structuré mis à jour",
+            "structuredCopy": "Optez pour le runtime de chat structuré de l'hôte pour Codex et Claude. Désactivé conserve le chemin de chat existant basé sur le terminal.",
+            "structuredScope": "Sessions locales uniquement pour l'instant. WSL et les hôtes d'exécution distants (y compris SSH) continuent d'utiliser le chat par terminal, et Windows s'y replie sauf si Orca peut lire les heures de démarrage des processus.",
+            "structuredToggleLabel": "Activer ou désactiver le chat natif structuré mis à jour"
           },
           "agentDashboard": {
             "title": "Tableau de bord des agents",
@@ -6806,7 +7085,9 @@
           "b82f86d7d2": "Vérification orthographique du Markdown enrichi",
           "5195f0b9ef": "Affiche les soulignements d'orthographe et les suggestions du navigateur pendant l'édition du Markdown enrichi.",
           "7ddd66fede": "Retour à la ligne dans l'éditeur",
-          "9b18de6eea": "Renvoie à la ligne les lignes longues dans les éditeurs de fichiers au lieu d'imposer un défilement horizontal."
+          "9b18de6eea": "Renvoie à la ligne les lignes longues dans les éditeurs de fichiers au lieu d'imposer un défilement horizontal.",
+          "f1b3ceeb98": "Diff : afficher les espaces",
+          "94a479cef3": "Afficher les différences d'espaces en début et fin de ligne dans les diffs."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",
@@ -6869,7 +7150,8 @@
           "31fd7150cf": "Recherche de mises à jour...",
           "3394d1f663": "vérification",
           "d69a09b672": "Les mises à jour sont vérifiées automatiquement au lancement.",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "e3b9d21c07": "est disponible. Mettez à jour Orca via votre gestionnaire de paquets système — Orca ne peut pas installer cette version lui-même."
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "Choisissez les applications proposées dans le menu « Ouvrir dans » d'un espace de travail.",
@@ -7323,7 +7605,9 @@
           "9bedd2a6e5": "Permet aux agents de transmettre le contexte et de coordonner le travail via Orca.",
           "07641b9768": "Skill d'orchestration",
           "2aacdb0517": "Coordonnez les agents de codage entre passations, transferts de worktree et travaux d'agents enfants.",
-          "191ac34567": "Orchestration d'agents"
+          "191ac34567": "Orchestration d'agents",
+          "nestedWorkerDepthTitle": "Profondeur des workers imbriqués",
+          "nestedWorkerDepthDescription": "Combien de générations de workers distribués peuvent engendrer leurs propres workers. 1 maintient l'arbre d'agents plat : un coordinateur distribue des workers, et ces workers n'en distribuent pas."
         },
         "OrchestrationSetupCard": {
           "e7d2a5146c": "Permet aux agents de transmettre le contexte et de coordonner le travail via Orca.",
@@ -7773,7 +8057,11 @@
           "troubleshootStepRegenerate": "Générez un nouveau lien d'accès et utilisez ici uniquement le lien le plus récent.",
           "troubleshootTunnel": "Vous utilisez une redirection locale SSH ? Revenez à « Se connecter à un hôte », collez le lien loopback, puis activez « J'utilise un tunnel SSH » sous « Avancé ».",
           "cloudVmWorkflow": "VM cloud",
-          "cloudVmWorkflowHelp": "Gérer les machines cloud créées par recette"
+          "cloudVmWorkflowHelp": "Gérer les machines cloud créées par recette",
+          "serverWorkspaceWindowClosed": "Fenêtre de l'espace de travail fermée",
+          "serverRuntimeUnavailable": "Orca indisponible",
+          "serverRuntimeUnavailableDescription": "Le transport SSH est connecté, mais le runtime Orca n'a pas répondu. L'hôte est peut-être toujours en cours d'exécution.",
+          "serverReconnecting": "Reconnexion"
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "Copier {{value0}}"
@@ -8054,7 +8342,8 @@
           "4db9afce1c": "Le port doit être compris entre 1 et 65535",
           "0e5aa04161": "Un hôte ou un alias de config SSH est requis",
           "f1fc50dad2": "Échec du chargement des cibles SSH",
-          "0cda732f43": "Échec du test de connexion"
+          "0cda732f43": "Échec du test de connexion",
+          "terminateUnverifiable": "{{terminals}} terminaux distants n'ont pas pu être joints. Reconnectez-vous pour les terminer."
         },
         "SshPassphraseDialog": {
           "d5a234456f": "Annuler",
@@ -8069,7 +8358,11 @@
           "8a349e3fac": "Phrase secrète pour {{value0}}",
           "cab3d5f5a5": "Mot de passe pour {{value0}}",
           "1f3dde805d": "Phrase secrète de la clé SSH",
-          "106bd57f4a": "Mot de passe SSH"
+          "106bd57f4a": "Mot de passe SSH",
+          "a21f9e74c0": "Vérification SSH",
+          "981352fb42": "Relevez le défi de vérification pour",
+          "456516603b": "Saisissez la réponse",
+          "c624f64b86": "Continuer"
         },
         "SshTargetCard": {
           "a883f5a00f": "délai d'inactivité du terminal : {{value0}}",
@@ -8549,7 +8842,12 @@
             "d2c6a0e8f1": "grok",
             "c1b5f9d7e0": "xai",
             "b0a4e8c6d9": "oauth",
-            "a9f3d7b5c8": "connexion"
+            "a9f3d7b5c8": "connexion",
+            "d16378a88f": "minimax",
+            "b2c4e7f1a8": "point de terminaison",
+            "3a9b6d2c4e": "clé api",
+            "5d8f1a3b7c": "chine",
+            "7e2a4b8c1d": "international"
           }
         },
         "advanced": {
@@ -8628,7 +8926,16 @@
             "agentPermissions": "Permissions des agents",
             "agentPermissionsDescription": "Basculer les autorisations d'agent par défaut entre Yolo et Manuelle.",
             "agentRuntime": "Runtime des agents",
-            "agentRuntimeDescription": "Choisissez si les agents sont détectés et lancés par défaut sous Windows ou dans WSL."
+            "agentRuntimeDescription": "Choisissez si les agents sont détectés et lancés par défaut sous Windows ou dans WSL.",
+            "runtime": "runtime",
+            "agentLocation": "emplacement de l'agent",
+            "installedAgentsWsl": "agents installés dans wsl",
+            "permission": "autorisation",
+            "permissions": "autorisations",
+            "yolo": "yolo",
+            "manual": "manuel",
+            "skip": "ignorer",
+            "checks": "checks"
           }
         },
         "appearance": {
@@ -8751,7 +9058,11 @@
             },
             "leftSidebarAppearance": {
               "title": "Apparence de la barre latérale gauche",
-              "description": "Accordez la barre latérale gauche à votre terminal, gardez-la par défaut ou appliquez une teinte."
+              "description": "Accordez la barre latérale gauche à votre terminal, gardez-la par défaut ou appliquez une teinte.",
+              "project": "projet",
+              "terminal": "terminal",
+              "background": "arrière-plan",
+              "tint": "teinte"
             },
             "workspaceCardLayout": {
               "title": "Disposition des cartes d'espace de travail",
@@ -8766,7 +9077,15 @@
             },
             "showPinnedWorktreesInGroups": {
               "title": "Afficher aussi les worktrees épinglés dans leurs listes d'origine",
-              "description": "Les worktrees épinglés restent dans Épinglés et apparaissent aussi dans Tous, Projet, Statut et PR."
+              "description": "Les worktrees épinglés restent dans Épinglés et apparaissent aussi dans Tous, Projet, Statut et PR.",
+              "pinned": "épinglé",
+              "worktree": "worktree",
+              "workspace": "espace de travail",
+              "all": "tout",
+              "project": "projet",
+              "status": "statut",
+              "pr": "pr",
+              "duplicate": "doublon"
             },
             "antigravityUsageTitle": "Utilisation Antigravity",
             "antigravityUsageDescription": "Afficher l'utilisation de l'abonnement Antigravity dans la barre d'état.",
@@ -8776,7 +9095,15 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Pourcentages d'utilisation",
-            "usagePercentageDisplayDescription": "Choisissez si les limites des fournisseurs affichent le pourcentage utilisé ou restant."
+            "usagePercentageDisplayDescription": "Choisissez si les limites des fournisseurs affichent le pourcentage utilisé ou restant.",
+            "tray": {
+              "tray": "zone de notification",
+              "system": "zone de notification système",
+              "minimize": "réduire",
+              "close": "fermer",
+              "notification": "zone de notification",
+              "background": "arrière-plan"
+            }
           }
         },
         "auto": {
@@ -8835,7 +9162,8 @@
               "actions": "actions",
               "popover": "popover",
               "menu": "menu",
-              "disable": "désactiver"
+              "disable": "désactiver",
+              "chat": "chat"
             },
             "72c58f7792": "webview",
             "82ba1c80ea": "localhost",
@@ -8870,7 +9198,26 @@
             "a942905148": "URL ouverte à la création d'un nouvel onglet du navigateur. Laissez vide pour un onglet vierge.",
             "c3903322d2": "Page d'accueil par défaut",
             "19ea5607cf": "Libellés localhost des worktrees",
-            "4e0fdf0a3f": "Ouvrir les ports des espaces de travail sous forme d'URL localhost Orca propres à chaque worktree, pour mieux distinguer les onglets du navigateur."
+            "4e0fdf0a3f": "Ouvrir les ports des espaces de travail sous forme d'URL localhost Orca propres à chaque worktree, pour mieux distinguer les onglets du navigateur.",
+            "6f5199381e": "ports",
+            "8f036ea11f": "worktree",
+            "c4e3bf3282": "onglets",
+            "a8c55c9c91": "favicon",
+            "660c1dd007": "labels",
+            "clientHostedRemote": {
+              "remote": "distant",
+              "client": "client",
+              "host": "hôte",
+              "desktop": "bureau",
+              "placement": "emplacement"
+            },
+            "sshWorkspaceRouting": {
+              "ssh": "ssh",
+              "proxy": "proxy",
+              "tunnel": "tunnel",
+              "routing": "routage",
+              "network": "réseau"
+            }
           },
           "use": {
             "search": {
@@ -9077,11 +9424,26 @@
             "nativeChat": {
               "title": "Chat UI",
               "description": "Prévisualisez la surface de chat de bureau pour les sessions de terminal d'agents prises en charge.",
-              "grok": "grok"
+              "grok": "grok",
+              "native": "natif",
+              "chat": "chat",
+              "claude": "claude",
+              "codex": "codex",
+              "openclaude": "openclaude",
+              "omp": "omp",
+              "terminal": "terminal",
+              "agent": "agent"
             },
             "agentDashboard": {
               "title": "Tableau de bord des agents",
-              "description": "Tableau Kanban pour surveiller les agents de tous les worktrees, dans la fenêtre ou en fenêtre indépendante."
+              "description": "Tableau Kanban pour surveiller les agents de tous les worktrees, dans la fenêtre ou en fenêtre indépendante.",
+              "dashboard": "tableau de bord",
+              "agent": "agent",
+              "kanban": "kanban",
+              "popout": "pop-out",
+              "board": "tableau",
+              "inWindow": "in-window",
+              "worktrees": "worktrees"
             }
           }
         },
@@ -9253,7 +9615,24 @@
             "editorFontFamily": "Police de l'éditeur",
             "editorFontFamilyDesc": "Police utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la police du terminal.",
             "externalWorktrees": "Worktrees externes",
-            "externalWorktreesDescription": "Choisissez si les worktrees créés en dehors d'Orca apparaissent par défaut."
+            "externalWorktreesDescription": "Choisissez si les worktrees créés en dehors d'Orca apparaissent par défaut.",
+            "editorFontKw": "police",
+            "f96cdaf37d": "correction orthographique",
+            "a51d23f4a1": "correction orthographique",
+            "641358460a": "orthographe",
+            "d755962089": "soulignement rouge",
+            "projectRuntime": "runtime du projet",
+            "runtime": "runtime",
+            "windowsHost": "hôte Windows",
+            "wsl": "wsl",
+            "distro": "distro",
+            "execution": "exécution",
+            "externalKeyword": "externe",
+            "visibility": "visibilité",
+            "sidebar": "barre latérale",
+            "867dddea41": "épinglé",
+            "5250cf0e48": "épingler",
+            "afa37a34e1": "fermer"
           }
         },
         "git": {
@@ -9307,7 +9686,8 @@
             "upstream": "upstream",
             "localChanges": "modifications locales",
             "originMaster": "origin/master",
-            "committedChanges": "modifications committées"
+            "committedChanges": "modifications committées",
+            "diffBase": "base du diff"
           }
         },
         "input": {
@@ -9502,7 +9882,13 @@
               "1de96ec8a6": "Afficher le bouton Orca Mobile",
               "682293cadf": "Afficher le bouton Orca Mobile en haut de la barre latérale gauche.",
               "e4f4daea0e": "relais",
-              "5d5af8e041": "iPhone"
+              "5d5af8e041": "iPhone",
+              "74618577c7": "mobile",
+              "5e5b8878bf": "téléphone",
+              "5bff6a2ef0": "barre latérale",
+              "6cf5f54ce1": "bouton",
+              "648eeada79": "masquer",
+              "ac79fe4a04": "afficher"
             }
           }
         },
@@ -9745,7 +10131,25 @@
             "projectRuntime": "Runtime des projets",
             "projectRuntimeDescription": "Choisissez si ce projet s'exécute sous Windows ou WSL.",
             "externalWorktrees": "Worktrees externes",
-            "externalWorktreesDescription": "Définir si les worktrees créés hors d'Orca apparaissent pour ce projet."
+            "externalWorktreesDescription": "Définir si les worktrees créés hors d'Orca apparaissent pour ce projet.",
+            "waitForSetupBeforeAgent": "attendre la configuration avant de démarrer l'agent",
+            "external": "externe",
+            "visibility": "visibilité",
+            "sidebar": "barre latérale",
+            "fork": "fork",
+            "upstream": "upstream",
+            "syncFork": "synchroniser le fork",
+            "fastForward": "fast-forward",
+            "behindUpstream": "derrière upstream",
+            "origin": "origin",
+            "defaultBranch": "branche par défaut",
+            "runtime": "runtime",
+            "execution": "exécution",
+            "windowsHost": "hôte Windows",
+            "wsl": "wsl",
+            "distro": "distro",
+            "agentRuntime": "runtime de l'agent",
+            "skillRuntime": "runtime des skills"
           }
         },
         "runtime": {
@@ -9854,7 +10258,9 @@
               "c38c18be15": "sélection",
               "797fdfe4ca": "sélectionner",
               "603818e8d8": "Copiez automatiquement les sélections du terminal vers le presse-papiers dès qu'une sélection est faite.",
-              "3bdc84f059": "Copie à la sélection"
+              "3bdc84f059": "Copie à la sélection",
+              "zellij": "zellij",
+              "grok": "grok"
             }
           },
           "search": {
@@ -10048,6 +10454,34 @@
               "title": "Mode de thème",
               "keyword_target": "cible",
               "keyword_editing": "édition"
+            },
+            "39ea7c0d28": "terminal",
+            "scroll": "défilement",
+            "scrolling": "défilement",
+            "speed": "vitesse",
+            "wheel": "molette",
+            "trackpad": "trackpad",
+            "tui": "tui",
+            "a0c44061ee": "confirmer",
+            "close_terminal": "fermer",
+            "running": "en cours",
+            "command": "command",
+            "agent": "agent",
+            "process": "processus",
+            "prompt": "prompt",
+            "stop": "arrêter",
+            "minimumContrast": {
+              "title": "Contraste des couleurs",
+              "description": "Améliorez la lisibilité du texte ou conservez les couleurs choisies par les programmes du terminal.",
+              "contrast": "contraste",
+              "minimum": "minimum",
+              "ratio": "ratio",
+              "readability": "lisibilité",
+              "wcag": "wcag",
+              "powerline": "powerline",
+              "statusline": "statusline",
+              "dim": "atténué",
+              "colors": "couleurs"
             }
           },
           "windows": {
@@ -10528,7 +10962,12 @@
         "ephemeralVms": {
           "search": {
             "description": "Découvrez comment les recettes détenues par le dépôt offrent à chaque workspace son propre environnement jetable à la demande.",
-            "cloudVmTitle": "VM cloud"
+            "cloudVmTitle": "VM cloud",
+            "keywordVm": "VM",
+            "keywordSandbox": "bac à sable",
+            "keywordCloud": "cloud",
+            "keywordRecipe": "recette",
+            "keywordEphemeral": "éphémère"
           }
         },
         "EphemeralVmsPane": {
@@ -10586,7 +11025,12 @@
               },
               "search": {
                 "title": "Linear",
-                "description": "Statut de la skill Linear, exemples d'utilisation et liens vers la configuration de Task Sources."
+                "description": "Statut de la skill Linear, exemples d'utilisation et liens vers la configuration de Task Sources.",
+                "linear": "linear",
+                "tickets": "tickets",
+                "issues": "tickets",
+                "skill": "skill",
+                "orcaLinear": "orca-linear"
               }
             }
           }
@@ -10608,7 +11052,9 @@
           "e6dadc1e2b": "Utilisation mensuelle",
           "75e396bf42": "Utilisation mensuelle incluse pour les comptes Grok à facturation unifiée.",
           "b36fa2c908": "Connecté. Orca lit la session Grok CLI stockée sur disque.",
-          "f08c41de73": "Session expirée — lancez grok sur l'ordinateur qui exécute Orca et attendez son démarrage. Complétez la connexion si une invite apparaît, puis cliquez sur Actualiser l'utilisation. Aucun message dans le chat n'est nécessaire."
+          "f08c41de73": "Session expirée — lancez grok sur l'ordinateur qui exécute Orca et attendez son démarrage. Complétez la connexion si une invite apparaît, puis cliquez sur Actualiser l'utilisation. Aucun message dans le chat n'est nécessaire.",
+          "0bb18642b7": "Utilisation",
+          "a8f4139350": "Grok n'a indiqué aucun pourcentage d'utilisation pour ce compte."
         },
         "AppearanceWindowSidebarSection": {
           "usagePercentageDisplayUsed": "Utilisé",
@@ -10647,7 +11093,8 @@
           "signInAgain": "Se reconnecter pour Relay",
           "localTitle": "LAN",
           "localDescription": "Le téléphone doit être sur ce Wi‑Fi ou connecté via Tailscale. Aucun compte requis.",
-          "retrying": "Nouvelle tentative"
+          "retrying": "Nouvelle tentative",
+          "relayCell": "Cellule de relais"
         },
         "MobilePairingSetupSection": {
           "title": "Jumeler un téléphone",
@@ -11185,7 +11632,15 @@
           "allowPublishingWebDescription": "Bureau uniquement. Ouvrez Paramètres → Artifacts sur l'appareil hôte pour modifier ce paramètre.",
           "allowPublishingDescription": "Publiez des fichiers HTML et Markdown sous forme de liens ouvrables par quiconque possède l'URL. Les liens existants demeurent jusqu'à leur suppression dans Artifacts.",
           "howToDescriptionDisabled": "Activez le partage d'artifacts ci-dessus pour publier des fichiers HTML ou Markdown sous forme de liens publics.",
-          "allowPublishingSearchDescription": "Autoriser Orca à publier des fichiers HTML et Markdown sous forme de liens publics."
+          "allowPublishingSearchDescription": "Autoriser Orca à publier des fichiers HTML et Markdown sous forme de liens publics.",
+          "keywordArtifacts": "artefacts",
+          "keywordShare": "partager",
+          "keywordPublish": "publier",
+          "keywordPublic": "public",
+          "keywordPermission": "autorisation",
+          "keywordHtml": "HTML",
+          "keywordMarkdown": "Markdown",
+          "keywordUpload": "téléversement"
         },
         "orcaAccount": {
           "connected": "Connecté",
@@ -11207,7 +11662,14 @@
           "relayTitle": "Orca Relay",
           "relayDescription": "Connectez Orca Mobile à ce poste via réseau mobile ou n'importe quel Wi-Fi.",
           "skillsTitle": "Partage de skills",
-          "skillsDescription": "Partagez une skill ou tout un ensemble derrière un lien non répertorié, et installez-les sur toutes les machines que vous utilisez."
+          "skillsDescription": "Partagez une skill ou tout un ensemble derrière un lien non répertorié, et installez-les sur toutes les machines que vous utilisez.",
+          "keywordAccount": "compte",
+          "keywordLogin": "connexion",
+          "keywordLogout": "déconnexion",
+          "keywordSignIn": "connexion",
+          "keywordSignOut": "déconnexion",
+          "keywordRelay": "relais",
+          "keywordCloud": "cloud"
         },
         "automations": {
           "showButton": "Afficher le bouton Automatisations",
@@ -11223,7 +11685,11 @@
           "openAutomations": "Ouvrir Automations",
           "openAutomationsDescription": "Créez des planifications et inspectez les exécutions récentes.",
           "title": "Automatisations",
-          "description": "Planifiez le travail des agents et choisissez si Automatisations apparaît dans la barre latérale."
+          "description": "Planifiez le travail des agents et choisissez si Automatisations apparaît dans la barre latérale.",
+          "keywordAutomations": "automatisations",
+          "keywordSchedule": "planification",
+          "keywordAgent": "agent",
+          "keywordRuns": "exécutions"
         },
         "AgentAwakeSetting": {
           "on": "Activé",
@@ -11271,7 +11737,13 @@
           "unshare": "Ne plus partager",
           "showButton": "Afficher le bouton Skills",
           "showButtonDescription": "Afficher le raccourci Skills dans la barre latérale.",
-          "manageInSkills": "Gérer dans Skills"
+          "manageInSkills": "Gérer dans Skills",
+          "keywordSkills": "skills",
+          "keywordShare": "partager",
+          "keywordBundle": "lot",
+          "keywordLink": "lien",
+          "keywordUnlisted": "non répertorié",
+          "keywordRevoke": "révoquer"
         },
         "bitbucket": {
           "credentials": {
@@ -11332,6 +11804,28 @@
         },
         "shortcutDefinitionCatalog": {
           "missionControlConflict": "Bloqué par Mission Control. Remappez ici ou changez-le dans Réglages Système."
+        },
+        "HiddenExperimentalGroup": {
+          "7c4e18d2f6": "Arme les gestes de capture de scintillement sur cette machine : {{samplingShortcut}} démarre une rafale d'échantillonnage ; {{captureShortcut}} capture les preuves du volet sur disque.",
+          "b09f24a51d": "Diagnostics de rendu du terminal",
+          "f2c81d904a": "Paramètres expérimentaux masqués"
+        },
+        "NativeChatSupportedAgents": {
+          "label": "Agents pris en charge :"
+        },
+        "contrast": {
+          "title": "Contraste des couleurs",
+          "description": "Améliorez la lisibilité du texte ou conservez les couleurs choisies par les programmes du terminal.",
+          "ratio": "Cible de contraste",
+          "autoDescription": "Équilibre lisibilité et thème de votre terminal. Recommandé.",
+          "offDescription": "Conserve les couleurs des programmes inchangées, y compris le texte atténué et les séparateurs Powerline.",
+          "customDescription": "Choisissez dans quelle mesure augmenter le contraste entre le texte et son arrière-plan.",
+          "auto": "Automatique",
+          "off": "Désactivé",
+          "custom": "Personnalisé",
+          "targetDescription": "Des valeurs plus élevées augmentent le contraste lorsque c'est possible. Les couleurs d'arrière-plan restent inchangées.",
+          "subtle": "Subtil",
+          "strong": "Fort"
         }
       },
       "right": {
@@ -11391,7 +11885,10 @@
             },
             "7e4b2a19c0": "Impossible d'identifier la PR GitHub sur laquelle répondre.",
             "430f1a62d4": "Impossible de résoudre le fil sélectionné côté hôte.",
-            "updateReactionFailed": "Échec de la mise à jour de la réaction."
+            "updateReactionFailed": "Échec de la mise à jour de la réaction.",
+            "gitlabMoreActions": "Autres actions MR",
+            "gitlabUnlink": "Dissocier la MR",
+            "gitlabLinkAnother": "Lier une autre MR"
           },
           "CreatePullRequestDialog": {
             "2bc1b4345e": "Annuler",
@@ -11468,7 +11965,10 @@
             "3161c4e425": "dossier",
             "e887fa4b2e": "Ouvrir dans le terminal",
             "1d8e182c32": "Afficher le fichier",
-            "clipboardStagingUnavailable": "Impossible de copier le fichier car le stockage temporaire d'Orca est indisponible"
+            "clipboardStagingUnavailable": "Impossible de copier le fichier car le stockage temporaire d'Orca est indisponible",
+            "revealInFinder": "Révéler dans le Finder",
+            "openContainingFolder": "Ouvrir le dossier parent",
+            "revealInFileExplorer": "Révéler dans l'explorateur de fichiers"
           },
           "FileExplorerToolbar": {
             "d238264654": "Afficher les fichiers ignorés par Git",
@@ -11519,7 +12019,12 @@
             "3de88351c5": "GitHub ajoutera cette pull request et toutes celles situées en dessous à la file de merge.",
             "a32fe6dba6": "GitHub mergera cette pull request et toutes celles situées en dessous dans la pile.",
             "73e0e1819d": "Mise en file de la pile...",
-            "e555a41d32": "Merge de la pile..."
+            "e555a41d32": "Merge de la pile...",
+            "markingReady": "Marquage comme prêt…",
+            "markReady": "Marquer comme prêt à réviser",
+            "draftMoreActions": "Autres actions {{value0}}",
+            "closeDraft": "Fermer",
+            "readyToast": "{{value0}} marqué comme prêt à réviser"
           },
           "PortsPanel": {
             "3ea4a02a8f": "Annuler",
@@ -11842,7 +12347,13 @@
             "a4e93c21d7": "Branche actuelle : {{value0}}",
             "c7d4e2f801": "Modifier la ref de base : {{value0}}",
             "f3a1b8c204": "upstream",
-            "createPrIntentGenerateDetailsFailed": "Impossible de générer les détails de revue. Réessayez Créer une PR."
+            "createPrIntentGenerateDetailsFailed": "Impossible de générer les détails de revue. Réessayez Créer une PR.",
+            "branchFilesChangedVsBaseOne": "1 fichier modifié par rapport à {{ref}}",
+            "branchFilesChangedVsBaseOther": "{{count}} fichiers modifiés par rapport à {{ref}}",
+            "compareBaseCommitsAheadOne": "1 commit d'avance sur {{ref}}",
+            "compareBaseCommitsAheadOther": "{{count}} commits d'avance sur {{ref}}",
+            "compareBaseCommitsBehindOne": "1 commit de retard sur {{ref}}",
+            "compareBaseCommitsBehindOther": "{{count}} commits de retard sur {{ref}}"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "Impossible de démarrer l'agent sélectionné.",
@@ -12518,7 +13029,10 @@
             "localSessionSshWorkspaceUnsupported": "L'historique de cette session est stocké sur cette machine ; impossible de la reprendre dans un espace de travail SSH. Ouvrez plutôt un espace de travail local.",
             "prepareSessionResumeFailed": "Impossible de préparer cette session pour la reprise.",
             "sessionDeleted": "Session supprimée",
-            "sessionDeleteFailed": "Impossible de supprimer la session"
+            "sessionDeleteFailed": "Impossible de supprimer la session",
+            "resumeInChatConflict": "Un autre chat détient déjà cette conversation.",
+            "resumeInChatTranscriptMissing": "L'historique de cette conversation n'a pas pu être chargé, elle ne peut donc pas être reprise dans le chat.",
+            "resumeInChatFailed": "Impossible de reprendre cette session dans un nouveau chat."
           },
           "AiVaultPanelControls": {
             "scanningSessions": "Analyse des sessions",
@@ -12654,7 +13168,8 @@
             "delete": "Supprimer",
             "deleteReasonNonLocalHost": "Seules les sessions de cet appareil peuvent être supprimées.",
             "deleteReasonSyntheticPath": "Cette session ne peut pas être supprimée depuis Orca.",
-            "deleteReasonUnsupportedAgent": "{{value0}} sessions ne peuvent pas être supprimées depuis Orca."
+            "deleteReasonUnsupportedAgent": "{{value0}} sessions ne peuvent pas être supprimées depuis Orca.",
+            "resumeInNewChat": "Reprendre dans un nouveau chat"
           },
           "AiVaultSessionDeleteDialog": {
             "title": "Supprimer cette session ?",
@@ -13348,7 +13863,9 @@
           "useLan": "Utiliser le LAN",
           "retrying": "Nouvelle tentative…",
           "retry": "Réessayer Relay",
-          "copyDiagnostics": "Copier les diagnostics"
+          "copyDiagnostics": "Copier les diagnostics",
+          "reconnectTitle": "Votre session de compte Orca a expiré.",
+          "reconnectBody": "Reconnectez-vous pour utiliser Orca Relay, ou utilisez le réseau local pour appairer via Tailscale ou le même Wi-Fi."
         }
       },
       "gitlab": {
@@ -13662,6 +14179,30 @@
                   "b94ec70eda": "Suivi non configuré",
                   "cc39a87288": "Connecté · Par défaut du système",
                   "00087eecb2": "Connecté · {{value0}}"
+                }
+              },
+              "setup": {
+                "checklist": {
+                  "localized": {
+                    "copy": {
+                      "ec0a363633": "Multitâche",
+                      "62bac8f43c": "Travaillez dans 2 worktrees différents à la fois. Chacun est isolé (même dans le même projet). Idéal pour travailler sur 2 fonctionnalités en même temps.",
+                      "908898c3ee": "Utilisez le navigateur d'Orca",
+                      "43781563c3": "Naviguez dans votre application web sans quitter Orca. Capturez n'importe quel élément et envoyez sa source exacte et ses styles à un agent en un clic.",
+                      "29aa2c2077": "Activez les notifications",
+                      "71bd9a8c95": "Soyez informé dès qu'un agent termine, a besoin d'attention ou est bloqué.",
+                      "46db810da8": "Choisissez votre agent par défaut",
+                      "b8e5bae17f": "Démarrez plus vite avec votre agent préféré déjà sélectionné.",
+                      "fee5557b02": "Activez Orca CLI",
+                      "7bcb4097fa": "Enregistrez la commande shell Orca et installez les skills d'agent pour les workflows navigateur, ordinateur et orchestration.",
+                      "ad342dd4c6": "Connectez les intégrations",
+                      "06fe30fdb0": "Démarrez un agent depuis une tâche en un clic et gardez le statut des PR en vue.",
+                      "eddc532e58": "Automatisez la configuration de l'espace de travail",
+                      "56049b74c2": "Exécutez automatiquement les commandes d'installation et de configuration pour que chaque nouveau worktree soit prêt pour les agents.",
+                      "2cf795433b": "Travaillez dans plusieurs dépôts",
+                      "42525ba8a4": "Importez vos dépôts clés dans Orca pour démarrer le travail d'agent sans chercher de dossiers."
+                    }
+                  }
                 }
               }
             }
@@ -14038,7 +14579,12 @@
           "724a13568d": " dans {{value0}}",
           "6094135eec": " vs {{value0}}",
           "a4420ca1f7": "Retour à la ligne activé",
-          "dde325ddfe": "Retour à la ligne désactivé"
+          "dde325ddfe": "Retour à la ligne désactivé",
+          "skippedConflictsExcluded": "{{count}} conflits non résolus ont été exclus de cette vue de diff.",
+          "skippedConflictsExcluded_one": "{{count}} conflit non résolu a été exclu de cette vue de diff.",
+          "skippedConflictsExcluded_other": "{{count}} conflits non résolus ont été exclus de cette vue de diff.",
+          "2e91bc89d1": "Espaces affichés",
+          "2bf19c54ad": "Espaces masqués"
         },
         "ConflictComponents": {
           "f338288514": "Chargement du contenu des conflits...",
@@ -14122,14 +14668,18 @@
           "f0fd4174b5": "Ouvrez un onglet de fichier pour utiliser l'édition Markdown enrichie",
           "a10d9b8337": "Ouvrir le fichier",
           "2076ecfc9c": "Modification précédente",
-          "631dab0df3": "Modification suivante"
+          "631dab0df3": "Modification suivante",
+          "revealInFinder": "Révéler dans le Finder",
+          "openContainingFolder": "Ouvrir le dossier parent",
+          "revealInFileExplorer": "Révéler dans l'explorateur de fichiers"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "Exporter en PDF",
           "561251019a": "Plus d'actions",
           "8c8b7f5ff5": "Afficher le front matter",
           "10c39d58c1": "Masquer le front matter",
-          "1eef809708": "Retour à la ligne"
+          "1eef809708": "Retour à la ligne",
+          "4dedd55efa": "Afficher les espaces"
         },
         "EditorPanelShell": {
           "e2c4dec350": "Chargement de l'éditeur..."
@@ -14529,14 +15079,16 @@
           "d5a8c2f1b9": "Démarrer l'agent IA par défaut pour corriger cette vérification",
           "e2b4d7c8a1": "Choisir un agent pour cette vérification",
           "f1c9e3a6d4": "Choisir un agent pour corriger la vérification",
-          "actionRequired": "Action requise"
+          "actionRequired": "Action requise",
+          "copyOutput": "Copier la sortie"
         },
         "CheckRunJobs": {
           "1c0a4d7e02": "réussi",
           "2d3b8f1a55": "ignoré",
           "3e6c9a2b71": "en attente",
           "4f7d0c3e88": "étapes en échec",
-          "5a8e1d4f23": " · "
+          "5a8e1d4f23": " · ",
+          "copy": "Copier les jobs"
         },
         "check": {
           "run": {
@@ -14616,6 +15168,47 @@
           "insertColumnRight": "Insérer une colonne à droite",
           "deleteRow": "Supprimer la ligne",
           "deleteColumn": "Supprimer la colonne"
+        },
+        "CheckRunAnnotations": {
+          "copy": "Copier les annotations"
+        },
+        "CheckRunCopyButton": {
+          "copied": "Copié",
+          "failed": "Copie impossible",
+          "empty": "Rien à copier"
+        },
+        "HtmlDocPreview": {
+          "documentTooLargePanel": "Ce document est trop volumineux pour être prévisualisé. Ouvrez-le plutôt dans l'éditeur.",
+          "documentUnreadablePanel": "Orca n'a pas pu lire ce fichier depuis l'espace de travail.",
+          "multipleAssetsFailedNotice": "{{count}} fichiers de ce document n'ont pas pu être chargés.",
+          "assetTooLargeNotice": "{{path}} est trop volumineux pour être chargé dans cette prévisualisation.",
+          "assetUnsupportedNotice": "Cet espace de travail ne peut pas envoyer {{path}} vers une prévisualisation.",
+          "assetUnreadableNotice": "Orca n'a pas pu lire {{path}} depuis l'espace de travail.",
+          "previewAriaLabel": "Prévisualisation HTML",
+          "reloadPreviewControl": "Recharger la prévisualisation",
+          "previewUnavailableTitle": "Prévisualisation indisponible",
+          "copyDocumentPathControl": "Copier le chemin du fichier",
+          "documentPathCopied": "Copié",
+          "workspaceFileChipLabel": "Fichier de l'espace de travail",
+          "previewMenuControl": "Options de prévisualisation",
+          "openSourceControl": "Ouvrir le fichier source",
+          "openExternallyControl": "Ouvrir avec l'application par défaut",
+          "copyDocumentRelativePathControl": "Copier le chemin relatif",
+          "openExternallyUnknownHostError": "Impossible d'ouvrir « {{value0}} » : l'hôte propriétaire n'est plus connu.",
+          "downloadBlockedNotice": "Les téléchargements sont désactivés dans les prévisualisations de documents.",
+          "directoryAuthorizationFailed": "Impossible d'autoriser l'accès à ce répertoire.",
+          "directoryAccessRequest": "Cette prévisualisation veut lire les fichiers dans {{path}}.",
+          "dismissAccessRequest": "Ignorer",
+          "allowDirectory": "Autoriser le dossier",
+          "directoryAccessRequestOverflow": "{{folders}}, et {{count}} autres",
+          "directoryAccessRequestMultiple": "Cette prévisualisation veut lire les fichiers dans {{folders}}.",
+          "allowDirectories": "Autoriser {{count}} dossiers",
+          "editAddressControl": "Modifier l'adresse"
+        },
+        "LargeDiffLoadPrompt": {
+          "a0af0198aa": "Les grands diffs ne sont pas affichés par défaut.",
+          "c3d9f4a712": "La taille de ce diff n'est pas encore connue, il se charge donc à la demande.",
+          "f7fa7a40d0": "Charger le diff"
         }
       },
       "diff": {
@@ -14746,6 +15339,16 @@
                       "title": "Trouver les résultats",
                       "body": "Les exécutions montrent quand les automatisations ont tourné, ce qui s'est passé et où inspecter leur sortie."
                     }
+                  },
+                  "client": {
+                    "hosted": {
+                      "browser": {
+                        "intro": {
+                          "title": "Cette page est rendue sur votre poste",
+                          "body": "Les onglets de navigateur distants sont désormais rendus sur cet appareil. Le trafic réseau passe toujours par l'hôte distant."
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -14791,8 +15394,18 @@
                 "removeWorktree": "retirer le worktree",
                 "trashWorktree": "mettre le worktree à la corbeille",
                 "addQuickCommand": "ajouter une commande rapide",
-                "newQuickCommand": "nouvelle commande rapide"
-              }
+                "newQuickCommand": "nouvelle commande rapide",
+                "splitChatRight": "diviser le chat vers la droite",
+                "moveChatRight": "déplacer le chat vers la droite",
+                "chatPaneRight": "volet de chat à droite",
+                "splitChatDown": "diviser le chat vers le bas",
+                "moveChatDown": "déplacer le chat vers le bas",
+                "chatPaneBelow": "volet de chat en dessous"
+              },
+              "splitChatRight": "Diviser le chat vers la droite",
+              "splitChatRightDescription": "Ouvrir le chat actif dans un volet divisé à droite.",
+              "splitChatDown": "Diviser le chat vers le bas",
+              "splitChatDownDescription": "Ouvrir le chat actif dans un volet divisé en dessous."
             }
           },
           "palette": {
@@ -14925,7 +15538,8 @@
             "6e776f9ef9": "Échec du téléchargement",
             "756bfc25c9": "Ouvert",
             "09a9489aa5": "Afficher",
-            "2a4c4b8e1f": "Copier"
+            "2a4c4b8e1f": "Copier",
+            "fileUrlUnsupported": "Cet onglet de navigateur ne peut pas ouvrir de fichiers locaux. Utilisez plutôt « Ouvrir la prévisualisation à côté » sur le fichier."
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "Annuler",
@@ -14990,6 +15604,18 @@
                   }
                 }
               }
+            },
+            "browser": {
+              "page": {
+                "annotation": {
+                  "tray": {
+                    "09a7c1df70": "Modifier l'annotation {{value0}}",
+                    "c16f932cb3": "Enregistrer",
+                    "024467ceac": "Annuler",
+                    "449d2c2629": "Intention de l'annotation"
+                  }
+                }
+              }
             }
           },
           "navigate": {
@@ -15005,6 +15631,9 @@
                 }
               }
             }
+          },
+          "download": {
+            "savedToRemote": "Enregistré dans {{value1}} sur {{value2}}"
           }
         },
         "profile": {
@@ -15069,7 +15698,8 @@
           "51a470b966": "ssh",
           "b09b2384fd": "En pause",
           "eaa02014f8": "Activé",
-          "29baf8f4c2": "Source"
+          "29baf8f4c2": "Source",
+          "host": "Hôte"
         },
         "AutomationEditorDialog": {
           "fb1896a5e7": "Annuler",
@@ -15138,7 +15768,8 @@
           "8faaa00726": "Exécution",
           "53fc5f07ab": "Historique des exécutions",
           "a00e38d1a3": "n/d",
-          "fdb3caa8fb": "connu"
+          "fdb3caa8fb": "connu",
+          "historyUnavailable": "L'historique des exécutions est indisponible depuis cet hôte. Cela ne signifie pas que l'automatisation a échoué ou n'a aucune exécution."
         },
         "AutomationRunPageFrame": {
           "40a511bed4": "Contexte d'exécution",
@@ -15260,7 +15891,13 @@
           "newAutomation": "Nouvelle automatisation",
           "rowActions": "Actions d'automatisation",
           "tableLastRun": "Dernière exécution",
-          "noListMatches": "Aucune automatisation ne correspond."
+          "noListMatches": "Aucune automatisation ne correspond.",
+          "moved": "Automatisation déplacée vers {host}.",
+          "moveOriginalKept": "Créée sur {host}, mais l'original n'a pas pu être supprimé. Supprimez-le sur l'ancien hôte.",
+          "moveOriginalUnverified": "Créée sur {host}, mais la suppression de l'original n'a pas pu être vérifiée. Vérifiez l'ancien hôte avant de réessayer.",
+          "tableHost": "Hôte",
+          "destinationProjectUnavailable": "Choisissez un projet appartenant à la destination d'automatisation sélectionnée.",
+          "ownerChanged": "Cette automatisation a changé d'hôte. Actualisez et réessayez."
         },
         "AutomationsPageSkeleton": {
           "55527b7bcf": "Chargement des automatisations"
@@ -15421,6 +16058,140 @@
         "AutomationListSortHeader": {
           "sortedAscending": "{{value0}}, tri croissant",
           "sortedDescending": "{{value0}}, tri décroissant"
+        },
+        "hostSummary": {
+          "partialFailure": "{{failed}} hôtes sur {{total}} n'ont pas pu être chargés"
+        },
+        "emptyState": {
+          "unknownHost": "cet hôte",
+          "hostLoading": "Chargement de l'hôte…",
+          "hostLoadingDetail": "En attente que {{hostLabel}} rapporte ses automatisations.",
+          "hostError": "Les automatisations n'ont pas pu être chargées depuis {{hostLabel}}",
+          "hostUnavailableDetail": "L'hôte n'a pas pu être joint, ses automatisations sont donc inconnues.",
+          "hostIncompatibleDetail": "Ce serveur est trop ancien pour limiter les automatisations par hôte.",
+          "hostStaleDetail": "L'actualisation la plus récente ne s'est pas terminée.",
+          "hostNotConnected": "{{hostLabel}} n'est pas connecté",
+          "hostNotConnectedDetail": "Connectez-vous à cet hôte pour voir les automatisations qui y sont stockées.",
+          "hostEmpty": "Aucune automatisation sur {{hostLabel}}",
+          "searchNoMatch": "Aucune automatisation ne correspond à votre recherche",
+          "filtersNoMatch": "Aucune automatisation ne correspond à vos filtres",
+          "allHostsEmpty": "Aucune automatisation sur les hôtes chargés"
+        },
+        "hostNotice": {
+          "loading": "Chargement de l'hôte…",
+          "unavailable": "{{hostLabel}} n'a pas pu être joint. Affichage des automatisations chargées précédemment depuis cet hôte.",
+          "ghost": "{{hostLabel}} a été supprimé. Les automatisations qui lui sont encore attribuées restent répertoriées.",
+          "removed": "L'hôte sélectionné n'est plus disponible. Affichage de tous les hôtes."
+        },
+        "hostPicker": {
+          "allHosts": "Tous les hôtes",
+          "loadingHost": "Chargement de l'hôte…"
+        },
+        "ownerConflict": {
+          "dismiss": "Ignorer"
+        },
+        "capturedOwner": {
+          "orphan": "Cette automatisation n'a aucun hôte sur lequel s'exécuter. Supprimez-la, ou rajoutez l'hôte auquel elle appartient.",
+          "unfenced": "Orca sur cet hôte doit être mis à jour avant que vous puissiez voir l'historique des exécutions ou gérer cette automatisation. Les exécutions planifiées peuvent continuer sur l'hôte."
+        },
+        "hostStatus": {
+          "authority": {
+            "loading": "Chargement",
+            "loadingDescription": "Chargement des automatisations depuis cet hôte.",
+            "fresh": "À jour",
+            "freshDescription": "Automatisations chargées depuis cet hôte.",
+            "refreshing": "Actualisation",
+            "refreshingDescription": "Vérification des modifications sur cet hôte.",
+            "staleError": "Non actualisé",
+            "staleErrorDescription": "Affichage des automatisations chargées précédemment depuis cet hôte. L'actualisation la plus récente ne s'est pas terminée.",
+            "unavailable": "Injoignable",
+            "unavailableDescription": "Cet hôte n'a pas pu être joint, ses automatisations n'ont donc pas pu être chargées.",
+            "incompatible": "Mettre à jour le serveur",
+            "incompatibleDescription": "Ce serveur ne prend pas en charge les requêtes d'automatisations limitées par hôte. Mettez-le à jour pour charger les automatisations de cet hôte."
+          },
+          "execution": {
+            "connected": "Connecté",
+            "connectedDescription": "Cet hôte est connecté et peut exécuter des automatisations.",
+            "connecting": "Connexion",
+            "connectingDescription": "Connexion à cet hôte.",
+            "disconnected": "Non connecté",
+            "disconnectedDescription": "Les automatisations sur cet hôte ne peuvent pas s'exécuter tant que la connexion n'est pas rétablie.",
+            "unavailable": "Indisponible",
+            "unavailableDescription": "Cette cible d'exécution n'est plus disponible.",
+            "unknown": "Connexion inconnue",
+            "unknownDescription": "L'état de connexion de cet hôte n'est pas encore chargé."
+          },
+          "query": {
+            "legacyUnscopedDescription": "Ce serveur répertorie les automatisations sans limitation par hôte, elles ne peuvent donc pas être modifiées ni exécutées depuis ici.",
+            "incompatible": "Mettre à jour le serveur",
+            "incompatibleDescription": "Ce serveur est trop ancien pour limiter les automatisations par hôte. Mettez-le à jour pour gérer les automatisations ici.",
+            "viewOnly": "Lecture seule",
+            "targetRemovedDescription": "Cet hôte a été supprimé, ses automatisations ne peuvent donc plus être modifiées ni exécutées depuis ici.",
+            "targetUnverifiedDescription": "Cet hôte n'a pas été vérifié depuis la perte de sa connexion, ses automatisations ne peuvent donc pas être modifiées ni exécutées depuis ici.",
+            "targetUnregisteredDescription": "Cet hôte n'a aucun enregistrement, ses automatisations ne peuvent donc pas être modifiées ni exécutées depuis ici."
+          },
+          "action": {
+            "retry": "Réessayer",
+            "reconnect": "Reconnecter",
+            "updateServer": "Mettre à jour le serveur"
+          }
+        },
+        "ownerAction": {
+          "failed": "Cette action d'automatisation ne s'est pas terminée."
+        },
+        "externalScope": {
+          "unknownManager": "Cette automatisation externe n'est plus répertoriée pour aucun hôte affiché.",
+          "uncheckedHost": "Les gestionnaires d'automatisations externes sur {{hostLabel}} n'ont pas pu être vérifiés.",
+          "uncheckedHosts": "Les gestionnaires d'automatisations externes sur {{count}} hôtes n'ont pas pu être vérifiés."
+        },
+        "enablement": {
+          "paused": "En pause"
+        },
+        "runHistory": {
+          "occurrencesWithLatest": "{{times}} fois, le plus récemment le {{date}}",
+          "occurrences": "{{times}} fois"
+        },
+        "createDestination": {
+          "label": "Hôte",
+          "placeholder": "Sélectionnez un hôte",
+          "storedOn": "Stockée et planifiée par {authority}.",
+          "unselected": "Choisissez l'hôte qui stocke et planifie cette automatisation.",
+          "orphan": "Les automatisations sans hôte ne peuvent pas en accueillir de nouvelles. Choisissez un hôte pour y créer cette automatisation.",
+          "unavailable": "Cet hôte ne peut pas encore accueillir une nouvelle automatisation. Choisissez un autre hôte pour y créer celle-ci.",
+          "stale": "{host} a changé pendant que ce formulaire était ouvert. Choisissez-le à nouveau avant d'enregistrer.",
+          "projectMismatch": "Ce projet ne se trouve pas sur {host}. Choisissez un projet sur cet hôte, ou un autre hôte.",
+          "noProjects": "Aucun projet n'est configuré sur {host}. Ajoutez-en un là-bas, ou choisissez un autre hôte.",
+          "updateRequired": "Mettez à jour le serveur Orca sur {hosts} pour y stocker des automatisations.",
+          "move": "L'enregistrement crée cette automatisation sur {host} et supprime l'original ainsi que son historique d'exécutions."
+        },
+        "AutomationListToolbar": {
+          "runs": "Exécutions"
+        },
+        "AutomationRunsDashboard": {
+          "search": "Rechercher des exécutions…",
+          "filters": "Filtres",
+          "host": "Hôte",
+          "status": "Statut",
+          "refresh": "Actualiser les exécutions",
+          "successful24h": "Réussies · 24 h",
+          "failed24h": "Échouées · 24 h",
+          "successful7d": "Réussies · 7 j",
+          "failed7d": "Échouées · 7 j",
+          "historyUnavailableOne": "L'historique des exécutions est indisponible pour 1 automatisation. Les compteurs incluent uniquement l'historique disponible.",
+          "historyUnavailableMany": "L'historique des exécutions est indisponible pour {{count}} automatisations. Les compteurs incluent uniquement l'historique disponible.",
+          "automation": "Automatisation",
+          "triggered": "Déclenchée",
+          "trigger": "Déclencheur",
+          "loading": "Chargement des exécutions…",
+          "noRuns": "Aucune exécution pour l'instant",
+          "emptyDescription": "Les exécutions apparaissent ici une fois qu'une automatisation est déclenchée.",
+          "runs": "Exécutions",
+          "local": "Local",
+          "remote": "Distant"
+        },
+        "AutomationsPageBreadcrumb": {
+          "ariaLabel": "Fil d'Ariane des automatisations",
+          "runDetails": "Détails de l'exécution"
         }
       },
       "agent": {
@@ -15469,10 +16240,28 @@
           "beb2c19173": "Non lus",
           "5651b216c6": "Projet inconnu",
           "22b22034bc": "Terminal autonome indisponible dans Activité.",
-          "afdc2139a8": "Terminal de l'agent fermé. Ouvrez un nouveau terminal dans cet espace de travail pour continuer."
+          "afdc2139a8": "Terminal de l'agent fermé. Ouvrez un nouveau terminal dans cet espace de travail pour continuer.",
+          "markThreadRead": "Marquer le fil comme lu",
+          "clearCompleted": "Effacer les éléments terminés",
+          "none": "Aucun",
+          "search": "Rechercher",
+          "activityOptions": "Options d'activité",
+          "interrupted": "Interrompu",
+          "state": {
+            "working": "En cours",
+            "monitoring": "Surveillance des tâches en arrière-plan",
+            "blocked": "Bloqué",
+            "waiting": "En attente de saisie",
+            "failed": "Échoué",
+            "done": "Terminé",
+            "idle": "Inactif",
+            "unverifiable": "Aucune mise à jour récente",
+            "permission": "Nécessite votre attention"
+          }
         },
         "ActivityScopeFilterControls": {
-          "resetScope": "Afficher tous les hôtes et projets"
+          "resetScope": "Afficher tous les hôtes et projets",
+          "hiddenCount": "{{value0}} masqués"
         },
         "ActivityThreadRow": {
           "clearNotification": "Effacer la notification"
@@ -15481,6 +16270,22 @@
           "f915168c8e": "non lu",
           "d6a8de3934": "agents",
           "dc708f3eff": "Fermer les agents"
+        },
+        "clearCompleted": {
+          "clearedOne": "1 agent terminé effacé",
+          "clearedMany": "{{count}} agents terminés effacés",
+          "undo": "Annuler"
+        },
+        "standaloneWorktree": {
+          "floatingTerminal": "Terminal flottant",
+          "standaloneTerminal": "Terminal autonome"
+        },
+        "ActivityThreadHoverCard": {
+          "pathCopied": "Chemin copié dans le presse-papiers",
+          "copyPathFailed": "Échec de la copie du chemin",
+          "workspace": "Espace de travail",
+          "copyPath": "Copier le chemin",
+          "jumpToWorkspace": "Aller à l'espace de travail"
         }
       },
       "confirmation": {
@@ -15649,6 +16454,114 @@
               "chooseSource": "Choisir la source des tâches"
             }
           }
+        },
+        "page": {
+          "chrome": {
+            "task": {
+              "page": {
+                "gitlab": {
+                  "filters": {
+                    "e157d7ce4d": "MRs",
+                    "2328f6a40c": "Mes tâches"
+                  }
+                }
+              }
+            }
+          },
+          "dialogs": {
+            "new": {
+              "github": {
+                "issue": {
+                  "dialog": {
+                    "e02508846c": "ce dépôt"
+                  }
+                }
+              },
+              "linear": {
+                "issue": {
+                  "dialog": {
+                    "dialogTitle": "Nouvelle issue Linear",
+                    "dialogDescription": "Créez une issue Linear pour l'équipe sélectionnée."
+                  }
+                }
+              }
+            },
+            "task": {
+              "page": {
+                "connect": {
+                  "dialogs": {
+                    "353c7dc71d": "Mettre à jour l'accès"
+                  }
+                }
+              }
+            }
+          },
+          "github": {
+            "github": {
+              "detail": {
+                "host": {
+                  "8d5cde4770": "Pull requests",
+                  "312ca15778": "Liste GitHub"
+                }
+              },
+              "issue": {
+                "label": {
+                  "selector": {
+                    "2a1862c470": "Chargement des labels…"
+                  }
+                }
+              },
+              "work": {
+                "item": {
+                  "row": {
+                    "draftPullRequest": "Pull request brouillon",
+                    "pullRequest": "Pull request",
+                    "issue": "Issue"
+                  }
+                }
+              }
+            }
+          },
+          "hooks": {
+            "use": {
+              "task": {
+                "page": {
+                  "jira": {
+                    "create": {
+                      "dialog": {
+                        "jiraRequiredFieldsLoadFailed": "Échec du chargement des champs Jira requis."
+                      }
+                    }
+                  },
+                  "linear": {
+                    "active": {
+                      "collection": {
+                        "d8b3cd9488": "Projet : {{value0}}",
+                        "68462f8b29": "Vue : {{value0}}"
+                      }
+                    }
+                  },
+                  "session": {
+                    "resume": {
+                      "savedLinearProjectMissing": "Le projet Linear enregistré est introuvable.",
+                      "savedLinearProjectRestoreFailed": "Échec de la restauration du projet Linear enregistré.",
+                      "savedLinearViewMissing": "La vue Linear enregistrée est introuvable.",
+                      "savedLinearViewRestoreFailed": "Échec de la restauration de la vue Linear enregistrée."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "linear": {
+            "linear": {
+              "connect": {
+                "empty": {
+                  "3e00e8ebd4": "Chargement de Linear"
+                }
+              }
+            }
+          }
         }
       },
       "taskPageEmptyState": {
@@ -15711,7 +16624,9 @@
         "allWorkspacesTitle": "Sélectionnez un espace de travail",
         "allWorkspacesBody": "Les filtres de statut, responsable et étiquette utilisent des identifiants issus d'un seul espace de travail Linear. Choisissez-en un pour filtrer selon ces attributs.",
         "optionsFromTeam": "Options de {{team}}",
-        "clearAll": "Effacer tous les filtres"
+        "clearAll": "Effacer tous les filtres",
+        "partialCoverage": "partiel",
+        "partialCoverageTitle": "Certaines équipes peuvent être exclues de ce filtre. Ouvrez Filtres pour plus de détails."
       },
       "linear-issue-attribute-filter-sections": {
         "status": "Statut",
@@ -15725,7 +16640,8 @@
         "searchStatus": "Filtrer par statut…",
         "searchLabels": "Filtrer par étiquette…",
         "searchAssignee": "Filtrer par responsable…",
-        "back": "Retour"
+        "back": "Retour",
+        "partialCoverageMarker": "· partiel"
       },
       "browser-pane": {
         "markup": {
@@ -15923,6 +16839,60 @@
         "expiredCompact": "Expiré",
         "typeMarkdown": "Markdown",
         "typeHtml": "HTML"
+      },
+      "linear-issue-attribute-filter-coverage-notice": {
+        "statusPartialTeamCoverage": "Filtrage de {{value0}} statuts d'équipe sur {{value1}} — les issues des autres équipes ne sont pas incluses.",
+        "labelsPartialTeamCoverage": "Filtrage de {{value0}} labels d'équipe sur {{value1}} — les issues des autres équipes ne sont pas incluses.",
+        "statusAtIdLimit": "Filtrage au maximum possible : {{value0}} statuts d'équipe. Les lignes choisies au-delà sont exclues.",
+        "labelsAtIdLimit": "Filtrage au maximum possible : {{value0}} labels d'équipe. Les lignes choisies au-delà sont exclues."
+      },
+      "BrowserCookieImportMachineNotice": {
+        "clientLabel": "Navigateurs sur cet appareil",
+        "remoteLabel": "Navigateurs sur {{value0}}",
+        "clientNoteLocalStorage": "Les imports lisent les navigateurs de cet appareil. Les cookies sont stockés localement.",
+        "remoteNoteRemoteStorage": "Les imports lisent les navigateurs sur {{value0}}. Les cookies y sont stockés, et une invite d'autorisation peut apparaître sur son écran."
+      },
+      "native": {
+        "chat": {
+          "NativeChatStructuredSession": {
+            "1f772bb5d0": "La livraison du message n'est pas confirmée.",
+            "93ef441197": "Le message n'a pas été envoyé.",
+            "a5e7f14068": "Réessayer"
+          }
+        }
+      },
+      "ComposerParentWorktreePicker": {
+        "label": "Worktree parent",
+        "noParent": "Aucun parent",
+        "description": "Imbrique cet espace de travail sous un autre dans la barre latérale. Ne change pas la branche de base.",
+        "searchPlaceholder": "Rechercher des espaces de travail…",
+        "noMatches": "Aucun résultat."
+      },
+      "browserPane": {
+        "workspaceDoc": {
+          "externalLinkTitle": "Ouvrir le lien vers {{host}} ?",
+          "externalLinkConfirm": "Ouvrir le lien",
+          "externalLinkCancel": "Annuler"
+        }
+      },
+      "HostedReviewUnlinkMenuItem": {
+        "label": "Dissocier {{value0}} de l'espace de travail",
+        "description": "Orca masquera les détails {{value1}} de {{value0}} pour cet espace de travail. {{value0}} et la branche sur {{value2}} ne seront pas modifiés."
+      },
+      "UnexpectedSignoutCard": {
+        "9f2c1a4b7d": "Vous avez été déconnecté",
+        "3e8f5c2a91": "Ignorer",
+        "7b4d9e1f2a": "Reconnectez-vous en tant que {{value0}} pour restaurer le partage d'artefacts, Orca Relay et le partage de skills.",
+        "5a1c8d3e6f": "Reconnectez-vous pour restaurer le partage d'artefacts, Orca Relay et le partage de skills.",
+        "1f6b2c9d4e": "Ce que vous récupérez",
+        "8d2e4f7a1b": "Partage d'artefacts",
+        "2c9a5b6e8d": "Publiez des fichiers HTML et Markdown et gérez tous les liens partagés depuis Orca.",
+        "6e3f1a9c5b": "Orca Relay",
+        "4b7d2e8f1a": "Connectez Orca Mobile à ce poste via réseau cellulaire ou n'importe quel Wi-Fi.",
+        "9a4c6b2d7e": "Partage de skills",
+        "3d8e5f1b9c": "Partagez des skills via un lien non répertorié et installez-les sur toutes les machines que vous utilisez.",
+        "7e1a9c4d2f": "Connexion…",
+        "c5b3e8a17d": "Se connecter à Orca"
       }
     },
     "i18n": {
@@ -15961,6 +16931,9 @@
       },
       "githubCheckDetailsTimeout": {
         "timedOut": "Délai dépassé lors du chargement des détails des vérifications."
+      },
+      "gitlabIpcTimeout": {
+        "timedOut": "Délai dépassé lors de la communication avec GitLab."
       }
     },
     "ssh": {
@@ -16045,16 +17018,46 @@
           "ultra": "Ultra",
           "on": "Activé",
           "off": "Désactivé"
-        }
+        },
+        "imageSaving": "Enregistrement de l'image collée…",
+        "pendingAttachmentLimit": "Trop de pièces jointes sont en attente. Terminez votre message avant d'en joindre d'autres.",
+        "viewAttachment": "Voir l'image",
+        "imagePreview": "Prévisualisation de l'image en taille réelle",
+        "imagePreviewUnavailable": "Prévisualisation indisponible"
       },
       "tool": {
         "running": "En cours…",
         "result": "Résultat",
         "countOne": "1 appel d'outil",
-        "countN": "{{value0}} appels d'outils"
+        "countN": "{{value0}} appels d'outils",
+        "exitCode": "sortie {{value0}}",
+        "milliseconds": "{{value0}} ms",
+        "moreCalls": "+{{value0}} autres",
+        "runningPreview": "Exécution de {{preview}}",
+        "runningCommand": "Exécution de la commande",
+        "runningNamedPreview": "Exécution de {{toolName}} {{preview}}",
+        "runningNamed": "Exécution de {{toolName}}",
+        "ranCommandOneToolSummary": "{{commandCount}} commande exécutée et {{toolCount}} outil utilisé",
+        "ranCommandManyToolsSummary": "{{commandCount}} commande exécutée et {{toolCount}} outils utilisés",
+        "ranCommandsOneToolSummary": "{{commandCount}} commandes exécutées et {{toolCount}} outil utilisé",
+        "ranCommandsManyToolsSummary": "{{commandCount}} commandes exécutées et {{toolCount}} outils utilisés",
+        "usedOneSummary": "1 outil utilisé",
+        "usedManySummary": "{{toolCount}} outils utilisés",
+        "editedFile": "Fichier modifié",
+        "addedFile": "Fichier ajouté",
+        "deletedFile": "Fichier supprimé",
+        "renamedFile": "Fichier renommé",
+        "copyDiff": "Copier le diff",
+        "diffGap": "Lignes non affichées",
+        "diffTruncated": "Diff tronqué"
       },
       "status": {
-        "responding": "L'agent répond"
+        "responding": "L'agent répond",
+        "working": "Travail en cours…",
+        "thinking": "Réflexion",
+        "workingFor": "Travail en cours depuis {{value0}}",
+        "workedFor": "Travail effectué pendant {{value0}}",
+        "toggleDetails": "Afficher ou masquer les détails du tour"
       },
       "jumpToLatest": "Aller au dernier message",
       "toggle": {
@@ -16103,7 +17106,146 @@
         "allow": "Autoriser",
         "deny": "Refuser"
       },
-      "launchPromptNotDelivered": "Non livré — vérifiez le terminal"
+      "launchPromptNotDelivered": "Non livré — vérifiez le terminal",
+      "taskList": {
+        "title": "Tâches",
+        "completed": "Terminées",
+        "inProgress": "En cours",
+        "pending": "En attente",
+        "empty": "Aucune tâche",
+        "progress": "{{completed}} tâches sur {{total}} terminées",
+        "added": "{{task}} ajoutée",
+        "removed": "{{task}} supprimée",
+        "started": "{{task}} démarrée",
+        "finished": "{{task}} terminée",
+        "reset": "Marquée en attente : {{task}}",
+        "updated": "{{task}} mise à jour",
+        "unchanged": "Tâches inchangées",
+        "showAll": "Liste complète des tâches"
+      },
+      "turnDiff": {
+        "one": "1 fichier modifié",
+        "many": "{{count}} fichiers modifiés",
+        "partial": "Diff partiel",
+        "recorded": "Totaux des modifications enregistrées dans ce tour."
+      },
+      "receipt": {
+        "unavailable": "Réponse sélectionnée indisponible",
+        "cancelled": "Annulé",
+        "resolved": "Résolu",
+        "resolver": "Répondu sur {{device}}",
+        "cancelledBy": "Annulé sur {{device}}"
+      },
+      "notices": {
+        "compaction": "Contexte compacté",
+        "details": "Détails",
+        "plan": "Plan"
+      },
+      "providerFrame": {
+        "byteLength": "{{value0}} octets"
+      },
+      "backgroundTasks": {
+        "monitoring": "Surveillance des tâches en arrière-plan",
+        "stop": "Arrêter",
+        "stopTask": "Arrêter {{value0}}",
+        "stopAll": "Arrêter les tâches en arrière-plan",
+        "agent": "Agent en arrière-plan",
+        "workflow": "Workflow en arrière-plan",
+        "command": "Commande en arrière-plan",
+        "monitor": "Moniteur en arrière-plan",
+        "task": "Tâche en arrière-plan",
+        "detailsUnavailable": "Les détails de la tâche sont indisponibles pour cette session.",
+        "countAgentsOne": "1 agent",
+        "countAgentsMany": "{{value0}} agents",
+        "countShellOne": "1 shell",
+        "countShellMany": "{{value0}} shells",
+        "countShellCommandOne": "1 commande shell",
+        "countMonitorsOne": "1 moniteur",
+        "countMonitorsMany": "{{value0}} moniteurs",
+        "countWorkflowsOne": "1 workflow",
+        "countWorkflowsMany": "{{value0}} workflows",
+        "countTasksOne": "1 tâche",
+        "countTasksMany": "{{value0}} tâches",
+        "headerTotal": "{{value0}} tâches en arrière-plan",
+        "stateWorking": "en cours",
+        "stateMonitoring": "surveillance",
+        "stateWaiting": "en attente",
+        "stateBlocked": "bloqué",
+        "stateDone": "terminé",
+        "stateIdle": "arrêté",
+        "stateUnverifiable": "invérifiable",
+        "reasonWaiting": "nécessite une approbation",
+        "reasonUnverifiable": "sans contact",
+        "reasonBlocked": "échoué",
+        "groupAgents": "Agents",
+        "groupShell": "Shell",
+        "groupMonitors": "Moniteurs",
+        "groupWorkflows": "Workflows",
+        "groupTasks": "Tâches"
+      },
+      "structuredSessionCloseFailed": "Impossible de fermer cette session de chat",
+      "structuredSessionLaunchFailed": "Impossible d'ouvrir le chat {{value0}}",
+      "structuredSessionLaunchPending": "Démarrage du chat {{value0}}…",
+      "structuredSessionCloseFailedDescription": "Le terminal est resté ouvert pour que le fournisseur reste récupérable.",
+      "handoff": {
+        "stage": {
+          "finishingChat": "Terminaison de la session de chat…",
+          "finishingTerminal": "Terminaison du terminal de l'agent…",
+          "openingTerminal": "Ouverture du terminal de l'agent…",
+          "resumingChat": "Reprise de la session de chat…",
+          "verifyingTerminal": "Vérification du terminal de l'agent…",
+          "verifyingChat": "Vérification de la session de chat…",
+          "recovering": "Récupération de la session d'agent…",
+          "manualRecovery": "La session d'agent nécessite une récupération"
+        },
+        "switchingOwner": "Changement de propriétaire de session…",
+        "mode": {
+          "switching": "Basculement",
+          "terminal": "Terminal",
+          "chat": "Chat"
+        },
+        "switchingAfterTurn": "Basculement après ce tour",
+        "returningAfterTurn": "Retour après ce tour",
+        "cancel": "Annuler",
+        "switchAfterTurn": "Basculer après ce tour",
+        "stopTurnAndSwitch": "Arrêter le tour et basculer",
+        "openAgentTui": "Ouvrir le TUI de l'agent",
+        "returnAfterTurn": "Revenir après ce tour",
+        "returnToChat": "Revenir au chat",
+        "agentOpenOnHost": "L'agent est ouvert dans le terminal sur {{value0}}.",
+        "agentOpen": "L'agent est ouvert dans le terminal.",
+        "exitTerminal": "Quittez le terminal de l'agent pour continuer dans le chat.",
+        "retryProof": "Relancer la vérification",
+        "retry": "Réessayer",
+        "details": "Détails"
+      },
+      "structuredSessionFellBackToTerminal": "Le chat structuré n'est pas disponible",
+      "structuredSessionFellBackToTerminalDescription": "Orca a essayé d'ouvrir un terminal {{value0}} à la place.",
+      "structuredSessionLaunchFailedDescription": "Orca n'a pas pu ouvrir un chat {{value0}} structuré. Consultez les journaux pour plus de détails.",
+      "subagents": {
+        "state": {
+          "completed": "terminé",
+          "working": "en cours",
+          "idle": "inactif",
+          "failed": "échoué",
+          "stopped": "arrêté",
+          "unverifiable": "invérifiable",
+          "workingCount": "{{value0}} en cours",
+          "idleCount": "{{value0}} inactifs",
+          "failedCount": "{{value0}} échoués",
+          "stoppedCount": "{{value0}} arrêtés",
+          "unverifiableCount": "{{value0}} invérifiables"
+        },
+        "startedOne": "1 sous-agent lancé",
+        "startedN": "{{value0}} sous-agents lancés",
+        "ranOne": "1 sous-agent exécuté",
+        "ranN": "{{value0}} sous-agents exécutés",
+        "tokens": "{{value0}} tokens"
+      },
+      "conversationCommand": {
+        "pendingWork": "Attendez la fin des travaux et messages en attente avant d'utiliser cette commande.",
+        "unconfirmed": "L'opération de conversation n'a pas été confirmée."
+      }
     },
     "tab": {
       "bar": {
@@ -16399,6 +17541,53 @@
         "days": "{{value0}} j",
         "underOneMinute": "<1 min"
       }
+    },
+    "onboarding": {
+      "flow": {
+        "stepTooltip": {
+          "agent": "Agent par défaut",
+          "theme": "Apparence",
+          "windowsTerminal": "Terminal Windows",
+          "notifications": "Notifications",
+          "integrations": "Intégrations"
+        },
+        "actions": {
+          "addFirstProject": "Ajoutez votre premier projet",
+          "continue": "Continuer",
+          "openingAddProject": "Ouverture de l'ajout de projet…"
+        }
+      },
+      "skipConfirmation": {
+        "skip": "Ignorer",
+        "keepGoing": "Non, continuer"
+      },
+      "theme": {
+        "hints": {
+          "system": "Suivre le système",
+          "dark": "Doux pour les yeux",
+          "light": "Clair et net"
+        }
+      },
+      "integrations": {
+        "capabilities": {
+          "startWorkspaceFromIssue": "Démarrez un espace de travail depuis n'importe quelle issue ou pull request GitHub, prérempli avec son titre et son contexte",
+          "browseIssues": "Parcourez les issues et pull requests GitHub dans la vue Tâches sans quitter Orca",
+          "reviewStatus": "Voyez l'état des issues, le statut des revues et les vérifications CI sur chaque worktree",
+          "managePullRequests": "Lisez, commentez et fusionnez les pull requests sans quitter Orca"
+        }
+      }
+    },
+    "jiraUserPicker": {
+      "select": "Sélectionner {{value0}}",
+      "search": "Rechercher des utilisateurs",
+      "empty": "Aucun utilisateur trouvé"
+    },
+    "terminalPane": {
+      "TerminalContextMenu": {
+        "copySessionId": "Copier l'ID de session",
+        "copySessionIdSuccess": "ID de session copié",
+        "copySessionIdError": "Impossible de copier l'ID de session"
+      }
     }
   },
   "dashboardPopout": {
@@ -16517,7 +17706,8 @@
     "terminal": {
       "closed": "Pas de terminal en direct — le volet de cet agent est fermé.",
       "focusWorktree": "Ouvrir le worktree",
-      "close": "Fermer"
+      "close": "Fermer",
+      "remotePreviewUnavailable": "Aucune prévisualisation pour cette session distante — ouvrez l'espace de travail pour voir le terminal."
     },
     "filters": {
       "remove": "Retirer le filtre {{label}}",
@@ -16554,7 +17744,12 @@
   },
   "dashboard": {
     "sidebar": {
-      "label": "Tableau de bord des agents"
+      "label": "Tableau de bord des agents",
+      "dashboardLabel": "Tableau de bord des agents",
+      "openActivity": "Voir l'activité",
+      "closeActivity": "Désactiver la vue d'activité",
+      "projects": "Projets",
+      "workspaces": "Espaces de travail"
     }
   },
   "runtimeRpc": {
@@ -16597,5 +17792,58 @@
       "stopped": "arrêté",
       "finished": "terminé"
     }
+  },
+  "sidebar": {
+    "revealFiltered": {
+      "title": "Révéler l'espace de travail masqué ?",
+      "description": "L'espace de travail actif est masqué dans la barre latérale. Le révéler effacera vos filtres de barre latérale.",
+      "confirm": "Effacer les filtres et révéler",
+      "cancel": "Conserver les filtres"
+    }
+  },
+  "editor": {
+    "richMarkdown": {
+      "tooLarge": "Le fichier dépasse la limite d'édition enrichie de {{limit}}. Affichage du mode source à la place.",
+      "openAnyway": "Ouvrir quand même"
+    }
+  },
+  "checksPanel": {
+    "unlinked": {
+      "title": "Pull request dissociée",
+      "description": "La PR #{{number}} est masquée pour cet espace de travail. Reliez-la à nouveau pour restaurer les vérifications et les détails de revue.",
+      "relink": "Relier la PR #{{number}}"
+    }
+  },
+  "sourceControl": {
+    "unlinkedPr": {
+      "status": "PR #{{number}} dissociée"
+    }
+  },
+  "agentsSidebarIntro": {
+    "migrated": {
+      "title": "Les agents sont plus faciles à trouver",
+      "description": "Votre vue Agents est désormais un onglet dédié de la barre latérale. Votre activité et vos filtres sont conservés.",
+      "dismiss": "Compris",
+      "action": "Ouvrir Agents"
+    },
+    "new": {
+      "title": "Découvrez votre onglet Agents",
+      "description": "Voyez sur quoi travaillent vos agents, ce qui est terminé et où vous devez intervenir.",
+      "hide": "Masquer Agents",
+      "action": "Essayer Agents",
+      "hiddenToast": "Onglet Agents masqué. Réactivez-le dans Paramètres → Expérimental."
+    }
+  },
+  "rendererRecovery": {
+    "reload": "Recharger",
+    "copyCommands": "Copier les commandes",
+    "quit": "Quitter",
+    "stalledDetail": "Orca a rechargé la fenêtre après un plantage, mais le chargement ne s'est jamais terminé.",
+    "crashLoopDetail": "Orca a tenté de récupérer {{recoveryCount}} fois de suite sans succès.",
+    "driverFallback": "Si cela ne résout rien, la cause est généralement un pilote graphique.",
+    "genericDetail": "Il s'agit souvent d'un problème de pilote graphique ou d'installation. Rechargez pour réessayer, ou quittez et relancez Orca.",
+    "title": "Orca n'arrive pas à charger",
+    "stalledMessage": "La fenêtre de l'application a cessé de répondre lors du rechargement après un plantage.",
+    "crashLoopMessage": "La fenêtre de l'application a planté à répétition et a cessé de se recharger automatiquement."
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -38,7 +38,43 @@
       },
       "menuBarIcon": {
         "title": "メニューバーアイコンを表示",
-        "description": "macOS メニューバーに Orca のショートカットとアクティビティインジケーターを表示します。"
+        "description": "macOS メニューバーに Orca のショートカットとアクティビティインジケーターを表示します。",
+        "keyword": {
+          "activity": "アクティビティ",
+          "menuBar": "メニューバー",
+          "statusItem": "ステータス項目"
+        }
+      }
+    },
+    "browser": {
+      "clientHostedRemote": {
+        "optionDevice": "このデバイス",
+        "title": "リモートのブラウザページをこのデバイスでホスト",
+        "description": "リモートワークスペースのページをこのデスクトップでレンダリングします。ネットワーク通信は引き続きリモートホストを経由します。新規ページにのみ適用されます。",
+        "optionDeviceTooltip": "ページはこのデスクトップでレンダリングされるため、入力やポップアップはネイティブに動作します。",
+        "optionServer": "サーバー（ストリーミング）",
+        "optionServerTooltip": "ページはリモートサーバーでレンダリングされ、このデバイスにストリーミングされます。",
+        "rowTitle": "リモートサーバーのワークスペース",
+        "rowDescription": "ページのレンダリング先。通信は常にリモートサーバーを経由します。新規ページにのみ適用されます。"
+      },
+      "sshWorkspaceRouting": {
+        "optionDevice": "このデバイス",
+        "title": "SSH ワークスペースのホスト経由で表示",
+        "description": "SSH ワークスペースのブラウザページは、ワークスペースの SSH ホスト経由で通信し、DNS もそこで解決されます。オフにすると、このマシンからページを表示します。",
+        "disabledHosts": "代わりにこのデバイスから表示しているホスト:",
+        "enableHost": "再度経由する",
+        "optionHost": "SSH ホスト",
+        "optionHostTooltip": "通信と DNS は、ワークスペースの SSH ホストを経由します。",
+        "optionDeviceTooltip": "ページはこのマシンのネットワークから表示します。",
+        "rowTitle": "SSH ワークスペース",
+        "rowDescription": "ブラウザ通信の送信元。ページは常にこのデバイス上でレンダリングされます。",
+        "useHost": "SSH ホストを使用",
+        "probeSkippedHosts": "接続確認なしで経由しているホスト（そのまま試す）:",
+        "probeAgain": "再確認"
+      },
+      "remoteBrowsing": {
+        "heading": "リモートブラウジング",
+        "headingDescription": "リモートワークスペースのページのレンダリング先と、ネットワーク通信の送信元。"
       }
     }
   },
@@ -87,7 +123,48 @@
       "issue": "Issue",
       "mr": "MR",
       "port": "ポート",
-      "pr": "PR"
+      "pr": "PR",
+      "automation": "実行",
+      "task": "タスク"
+    },
+    "filter": {
+      "tabKey": "タブ",
+      "label": "フィルター",
+      "clearAll": "すべてクリア",
+      "hosts": "ホスト",
+      "projects": "プロジェクト",
+      "searchProjects": "プロジェクトをフィルタリング…",
+      "back": "戻る",
+      "emptyTitle": "アクティブなフィルターに一致する結果がありません",
+      "emptySubtitle": "上のフィルターをクリアするか、対象のホストやプロジェクトを広げてください。",
+      "activeCount": "{{value0}} 件がアクティブ",
+      "removeChip": "フィルター {{value0}} を解除",
+      "chipOverflow": "+{{value0}}",
+      "trigger": "結果をフィルター",
+      "search": "ホストまたはプロジェクトでフィルター…",
+      "searchHosts": "ホストでフィルター…",
+      "noOptions": "一致するホストまたはプロジェクトがありません",
+      "noHosts": "一致するホストがありません",
+      "noProjects": "一致するプロジェクトがありません",
+      "moreOptions": "他 {{value0}} 件 — 絞り込むには入力を続けてください",
+      "selectAllMatching": "一致するすべてを選択（{{value0}}）",
+      "selectedCollapsed": "{{value0}} 件を選択中 — チップまたはクリアで解除",
+      "clearHosts": "ホストをクリア",
+      "clearProjects": "プロジェクトをクリア",
+      "ariaActive": "フィルター: {{value0}} 件がアクティブです。"
+    },
+    "linearIssue": {
+      "createLabel": "Linear Issue {{value0}} からワークツリーを作成: {{value1}}",
+      "pendingLabel": "Linear Issue {{value0}} からワークツリーを作成",
+      "loadingLabel": "Linear Issue {{value0}} を読み込み中",
+      "createHint": "Linear Issue からワークツリーを作成",
+      "loadingHint": "Linear Issue を読み込み中…"
+    },
+    "renderCapOverflow": "他 {{value0}} 件",
+    "seeMore": "さらに表示",
+    "taskUrl": {
+      "loadingHint": "{{value0}} を読み込み中…",
+      "createHint": "{{value0}} からワークツリーを作成"
     }
   },
   "auto": {
@@ -158,7 +235,8 @@
         "runtimeEnvironmentManuallyDisconnected": "ランタイム環境は手動で切断されています。",
         "loopbackPairingBlocked": "このアクセスリンクはこのデバイス自身を指しています。",
         "remotePairingUnreachable": "{{endpoint}} の Orca に接続できません。",
-        "remotePairingInvalidDetails": "このアクセスリンクには無効な接続情報が含まれています。"
+        "remotePairingInvalidDetails": "このアクセスリンクには無効な接続情報が含まれています。",
+        "remotePairingSaveFailed": "Orca はホストを確認しましたが、保存できませんでした。ブラウザのストレージを確認して、再試行してください。"
       },
       "web": {
         "preload": {
@@ -201,7 +279,8 @@
           "51f15c37d3": "ディレクトリを開けません: {{value0}}",
           "f2e00db373": "ファイルが見つかりません: {{value0}}",
           "checkRunDetailsUnavailable": "このチェックの詳細はありません。",
-          "checkRunDetailsLoadFailed": "チェック詳細の読み込みに失敗しました。"
+          "checkRunDetailsLoadFailed": "チェック詳細の読み込みに失敗しました。",
+          "checkRunDetailsRepoUnavailable": "このチェックではリポジトリの詳細を利用できません。"
         },
         "github": {
           "f129c42773": "GitHub は新規コメントを返しませんでした。",
@@ -233,7 +312,12 @@
         "workspace": {
           "cleanup": {
             "9d6e531da6": "ワークスペースはもう存在しません。",
-            "changedSinceConfirmation": "確認後にワークスペースが変更されました。削除する前に更新して確認してください。"
+            "changedSinceConfirmation": "確認後にワークスペースが変更されました。削除する前に更新して確認してください。",
+            "hostCollision": "エラー: このワークスペースは複数のホスト上に同じパスで存在します",
+            "hostUnresolved": "Orca はどのホストがこのワークスペースを所有しているか特定できません。プロジェクトを更新して、再度確認してください。",
+            "gitStatusUnavailable": "Orca はこのワークスペースの git ステータスを確認できませんでした。再試行するか、ホスト別のサイドバーまたはプロジェクト一覧から削除してください。",
+            "gitStatusUnavailableOlderPeer": "Orca はこの git ステータスの失敗をホストに特定できませんでした。古い接続先ピアを更新するか、ホスト別のサイドバーまたはプロジェクト一覧からワークスペースを削除してください。",
+            "forceNeedsApproval": "強制削除する前に、このワークスペースを確認してください。"
           }
         },
         "worktrees": {
@@ -267,7 +351,25 @@
           "runtimeScopeForbiddenDescription": "モバイル向けペアリングではワークスペースを使用できません。[設定] → [リモート Orca サーバー] → [この Orca サーバーを共有する] から、ブラウザ用リンクで再接続してください。",
           "createdWithoutParentNesting": "「{{value0}}」の配下にネストせずに作成しました",
           "createdWithoutParentNestingUnnamed": "選択した親ワークツリーの配下にネストせずに作成しました",
-          "createdWithoutParentNestingDetail": "親ワークスペースは利用できなくなりました。ワークスペースメニューから設定できます。"
+          "createdWithoutParentNestingDetail": "親ワークスペースは利用できなくなりました。ワークスペースメニューから設定できます。",
+          "c6cf133786": "このワークスペースは利用できなくなりました。",
+          "a17f4d2e93": "このワークスペースを更新できませんでした。",
+          "preservedBranchCleanupHostAmbiguous": "「{{value0}}」の保持ブランチのクリーンアップが複数保留中のため、ホストを指定してください。",
+          "metadata": {
+            "worktree": {
+              "meta": {
+                "persist": {
+                  "877e3638d8": "このワークスペースのリンクされた Issue を変更するには、リモートランタイムを更新してください",
+                  "4367540861": "Linear Issue をリンクするには、リモートランタイムを更新してください",
+                  "github": {
+                    "pr": {
+                      "suppression": "GitHub PR のリンクを解除するには、リモートランタイムを更新してください"
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "repos": {
           "2975400634": "Orca サーバーを更新して、このランタイムで Git 以外のフォルダーを開くようにします。",
@@ -281,7 +383,10 @@
           "3be0f7df04": "選択したランタイムでフォルダーを開けません",
           "15cf5319ec": "{{path}} は {{hostName}} でチェックされましたが、そのホストは使用可能なフォルダーを報告しませんでした。",
           "2dcd706774": "プロジェクトは別のプロファイルにも存在します",
-          "presenceProfileOverflow": "{{names}} 他 {{count}} 件"
+          "presenceProfileOverflow": "{{names}} 他 {{count}} 件",
+          "removeProjectFailed": "プロジェクトの削除に失敗しました",
+          "wslFilesystemBoundaryTitle": "このプロジェクトは Windows ドライブに保存されています",
+          "wslFilesystemBoundaryDescription": "このプロジェクトの Git は {{distro}} 上で実行されており、WSL ファイルシステムブリッジ経由で Windows ドライブにアクセスします。{{distro}} 内に保存したコピーと比べて、git は約 20 倍遅くなる見込みです。"
         },
         "settings": {
           "e12dab333b": "サーバーの切り替えに失敗しました",
@@ -313,6 +418,23 @@
             "7d4bc516ee": "プロファイルの切り替えに失敗しました",
             "f518e89aa5": "プロジェクトはそのプロファイルに既に存在します",
             "f03ae7f27b": "プロジェクトの転送に失敗しました"
+          }
+        },
+        "runtime": {
+          "status": {
+            "tryAgain": "再試行",
+            "runtimeHostDisconnectedDescription": "このサーバーで Orca が実行中であることと、ネットワーク接続が有効であることを確認してから、再試行してください。",
+            "runtimeHostUnreachableNamed": "{{hostName}} に接続できません",
+            "runtimeHostUnreachable": "Orca サーバーに接続できません"
+          }
+        },
+        "terminal": {
+          "quick": {
+            "command": {
+              "hosts": {
+                "5b7d781d67": "クイックコマンドの保存に失敗しました"
+              }
+            }
           }
         }
       }
@@ -487,7 +609,12 @@
             "9e37a5b1b3": "独立した作業を並行して実行する",
             "bddc4c09b8": "段階的なワークフローを実行する",
             "ab0e9803b7": "別のワークツリーにハンドオフ",
-            "5e0d489fe1": "アクティブなタスクを引き渡す"
+            "5e0d489fe1": "アクティブなタスクを引き渡す",
+            "handoffSummary": "継続に十分なコンテキストとともに、所有権を別の Agent に移します。",
+            "worktreeHandoffSummary": "別のブランチで実行中の Agent に作業を移します。",
+            "childSequenceSummary": "各フェーズが前のフェーズに依存する場合は、子 Agent を順番に使います。",
+            "childParallelSummary": "重ならない調査タスクや実装タスクを子 Agent に分割します。",
+            "prSplitSummary": "並列実装をレビュー可能な状態に保つため、各子 Agent に専用のワークツリーを与えます。"
           }
         }
       },
@@ -589,6 +716,15 @@
         },
         "activation": {
           "cannotOpenFolderWorkspace": "フォルダーワークスペースを開けません"
+        },
+        "creation": {
+          "flow": {
+            "structured": {
+              "launch": {
+                "unknown": "Codex チャットが開いたか確認できませんでした。再試行して再度確認してください。"
+              }
+            }
+          }
         }
       },
       "folderWorkspacePathStatus": {
@@ -596,13 +732,15 @@
           "missing": "フォルダーが見つかりません",
           "notDirectory": "パスはフォルダーではありません",
           "ambiguousConnection": "接続を特定できません",
-          "unavailable": "フォルダーを確認できません"
+          "unavailable": "フォルダーを確認できません",
+          "unrecognized": "フォルダーは使用できません"
         },
         "description": {
           "missing": "Orca は {{path}} を見つけられません。このフォルダーワークスペースを削除して再インポートしてください。",
           "notDirectory": "{{path}} は存在しますが、フォルダーではありません。",
           "ambiguousConnection": "Orca はこのフォルダースコープをどの SSH 接続が所有しているか判別できません。",
-          "unavailable": "Orca は現在このフォルダーを確認できません。ランタイムまたは SSH 接続を確認して再試行してください。"
+          "unavailable": "Orca は現在このフォルダーを確認できません。ランタイムまたは SSH 接続を確認して再試行してください。",
+          "unrecognized": "{{path}} は Orca で使用できず、このバージョンでは理由を特定できません。Orca を更新して詳細を確認してください。"
         },
         "createError": {
           "title": {
@@ -630,7 +768,8 @@
         "wakeEphemeralVmFailed": "一時的なVMワークスペースの起動に失敗しました"
       },
       "ephemeralVmWorkspaceTarget": {
-        "projectRootRegistrationFailed": "レシピによって作成されたプロジェクトルートをランタイムに登録できませんでした。"
+        "projectRootRegistrationFailed": "レシピによって作成されたプロジェクトルートをランタイムに登録できませんでした。",
+        "provisionedRootRequiresSsh": "プロビジョニング済みルートのレシピでは、現在は直接 SSH 接続が必要です。"
       },
       "blocked": {
         "notification": {
@@ -680,7 +819,21 @@
           "import": {
             "toast": {
               "restartFallbackUnavailableNone": "{{value0}} 件の Cookie をいずれも読み込めず、再起動によるフォールバックも利用できませんでした。このプロファイルの以前の Cookie は置き換えられています。もう一度インポートしてください。",
-              "restartFallbackUnavailablePartial": "{{value1}} 件中 {{value0}} 件の Cookie をインポートしました。残りは読み込めず、再起動によるフォールバックも利用できませんでした。もう一度インポートしてください。"
+              "restartFallbackUnavailablePartial": "{{value1}} 件中 {{value0}} 件の Cookie をインポートしました。残りは読み込めず、再起動によるフォールバックも利用できませんでした。もう一度インポートしてください。",
+              "googleCookiesSkipped": "Google Cookie はインポートされませんでした。このプロファイルで {{value0}} 上の Orca 内ブラウザを開き、Google にサインインしてください。",
+              "undecryptableAppBound": "このブラウザの Cookie のうち {{value0}} は、アプリバウンド暗号化のため Orca で復号できません。「ファイルから…」を使ってファイルから Cookie をインポートできます。",
+              "undecryptableAppBoundMixed": "Orca はこのブラウザの Cookie のうち {{value0}} をアプリバウンド暗号化のため復号できず、他に {{value1}} は別の理由で復号できませんでした。「ファイルから…」を使ってファイルから Cookie をインポートできます。",
+              "undecryptableKeyring": "{{value0}} の Cookie は、システムキーリングが利用できないため復号できませんでした。ログインキーリングのロックを解除するか、Secret Service プロバイダー（gnome-keyring など）をインストールしてから、再度インポートしてください。",
+              "undecryptableKeyringMixed": "{{value0}} の Cookie はシステムキーリングが利用できないため復号できず、他に {{value1}} は別の理由で復号できませんでした。ログインキーリングのロックを解除するか、Secret Service プロバイダー（gnome-keyring など）をインストールしてから、再度インポートしてください。",
+              "undecryptableUnknown": "{{value0}} の Cookie は復号できずスキップされました。元のブラウザを完全に終了してから、再度インポートしてください。",
+              "unrecognizedWarning": "Cookie のインポートは、このバージョンの Orca では認識できない警告とともに終了しました。Orca を更新して詳細を確認し、その Cookie に依存する前にこのプロファイルを確認してください。",
+              "undecryptableUnrecognizedReason": "{{value0}} の Cookie は、このバージョンの Orca では認識できない理由で復号できずスキップされました。Orca を更新して詳細を確認し、再度インポートしてください。",
+              "partitionSkipped": "{{value0}} の Cookie は、サイトパーティションを読み取れなかったためインポートされませんでした。Orca でそれらのサイトに再度サインインしてください。",
+              "locationClientHosted": "このデバイスから読み取り、{{value0}} ワークスペース用にここに保存しました。",
+              "locationRemoteHost": "{{value0}} 上のブラウザから読み取り、そこに保存しました。",
+              "googleCookiesSkippedLocal": "Google Cookie はインポートされませんでした。このプロファイルで Orca 内ブラウザを開き、Google にサインインしてください。",
+              "googleCookiesSkippedClientHosted": "Google Cookie はインポートされませんでした。このプロファイルで {{value0}} ワークスペースのブラウザタブを開いて（このデバイス上で開きます）、Google にサインインしてください。",
+              "googleCookiesSkippedRemoteWorkspace": "Google Cookie はインポートされませんでした。このプロファイルで {{value0}} ワークスペースのブラウザタブを開き、Google にサインインしてください。"
             }
           }
         }
@@ -701,6 +854,22 @@
             "additionalErrors": "ほかに {{count}} 件の画像を添付できませんでした。"
           }
         }
+      },
+      "activateAiVaultStructuredSession": {
+        "unavailable": "構造化 Agent セッションはまだ利用できません。しばらくしてから再試行してください。",
+        "gone": "このチャットはこのホスト上にもう存在しないため、ここでは開き直せません。",
+        "hostCannotOpen": "Orca を更新するまで、このチャットは開き直せません。"
+      },
+      "ephemeralVmWorktreeCreation": {
+        "sparseCheckoutUnsupported": "プロビジョニング済みルートのレシピでは、スパースチェックアウトに対応していません。"
+      },
+      "worktreeJumpNavigation": {
+        "filteredNotice": "このワークツリーはサイドバーフィルターで非表示になっています。ワークスペースは開きましたが、スペースには表示されません。"
+      },
+      "file": {
+        "preview": {
+          "pairedOutsideWorktree": "ワークスペース外のファイルは、ペアリングされたサーバー上ではまだプレビューできません。"
+        }
       }
     },
     "hooks": {
@@ -708,7 +877,8 @@
         "59718b120b": "ターゲットワークスペースは使用できなくなりました。",
         "16a21d6413": "SSH の再接続には対話型の認証情報が必要です。",
         "386db94f3e": "対象のプロジェクトは利用できなくなりました。",
-        "3ad7d77f57": "対象ワークスペースは、この自動化実行ターゲットとは別のホスト上にあります。"
+        "3ad7d77f57": "対象ワークスペースは、この自動化実行ターゲットとは別のホスト上にあります。",
+        "workspaceHostUnresolved": "対象のワークスペースは複数のホストにまたがっているため、この実行で使用する単一のホストがありません。"
       },
       "useComposerState": {
         "7eb3f44ff7": "選択した Agent は無効です。作成する前に、有効な Agent を選択してください。",
@@ -829,7 +999,14 @@
         "linearDescription": "Orca での Linear の仕組み、セットアップチェックリスト、Agent スキル、プロンプト例。",
         "pluginsTitle": "プラグイン",
         "pluginsDescription": "実験的機能の Orca プラグインをインストール・管理します。",
-        "tasksDescription": "プロバイダーを接続し、Linear スキルをインストールして、タスクに表示する項目を選択します。"
+        "tasksDescription": "プロバイダーを接続し、Linear スキルをインストールして、タスクに表示する項目を選択します。",
+        "automationsTitle": "自動化",
+        "artifactsTitle": "成果物",
+        "artifactsDescription": "HTML ファイルと Markdown ファイルをチームと共有し、公開リンクを管理します。",
+        "automationsDescription": "Agent の作業をスケジュールし、自動化をサイドバーに表示するかどうかを選択します。",
+        "shareSkillsTitle": "スキルを共有",
+        "shareSkillsDescription": "スキルを限定公開リンクで共有します。リンクを知っている人は誰でもインストールできます。",
+        "floatingWorkspaceWebDescription": "グローバルターミナルと markdown タブ。"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "貼り付け内容が大きすぎます。"
@@ -842,6 +1019,33 @@
         "description": "Orca で実行中の Agent やターミナルツールが保護されたファイルにアクセスしようとすると、macOS の権限メッセージが表示されることがあります。これらの確認を減らすには、設定でフルディスクアクセスを許可してください。",
         "openSettings": "設定を開く",
         "dismiss": "今後表示しない"
+      },
+      "useMacTccAttributionSeveredNotice": {
+        "dismiss": "閉じる",
+        "title": "macOS の権限が Orca ターミナルに届いていない可能性があります",
+        "description": "実行中の Orca ターミナルは、以前の Orca インストールが起動したデーモンによってホストされています。macOS では Orca のアクセシビリティ、オートメーション、保護されたファイルへの権限が適用されない可能性があります。アクセスを復元するには、セッション管理からデーモンを再起動してください。これにより、実行中のすべての Orca ターミナルが閉じます。",
+        "openManageSessions": "セッション管理を開く"
+      },
+      "useInstalledAgentSkills": {
+        "unreadableSkillSource": "スキルフォルダーが応答しなかったため、このステータスは不完全な可能性があります。"
+      },
+      "ipc": {
+        "events": {
+          "browserStateIpcBridge": {
+            "docPreviewLinkFailed": "このリンクを Orca ブラウザで開けませんでした。"
+          },
+          "os": {
+            "markdown": {
+              "file": {
+                "open": {
+                  "bridge": {
+                    "1e9a1a63c4": "Markdown ファイルを開けませんでした。"
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "components": {
@@ -851,7 +1055,11 @@
         "a4c8e1b2f7": "Codex はまだ {{value0}} としてサインインしています",
         "d3e8a1f4b2": "アカウントを切り替えました",
         "9375620cc3": "このセッションを再起動して {{value0}} を使用してください。それまでは前のアカウントのままです。",
-        "6133594b12": "以前のアカウントを保持"
+        "6133594b12": "以前のアカウントを保持",
+        "8f0d5c92a1": "Codex 設定が変更されました",
+        "3ea91b5c07": "この Codex セッションは古い設定を使用しています",
+        "e6b7139d2a": "現在の Codex 設定を読み込むには、このセッションを再起動してください。",
+        "7b1d20f4c8": "現在のセッションを維持"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "通知を閉じる",
@@ -1053,7 +1261,18 @@
           "activity": "アクティビティ",
           "noActivity": "まだアクティビティはありません。"
         },
-        "checkActionRequiredHint": "マージのブロックが解除されるまでに、このチェックには GitHub 上での手動操作（例: ワークフロー実行の承認）が必要です。"
+        "checkActionRequiredHint": "マージのブロックが解除されるまでに、このチェックには GitHub 上での手動操作（例: ワークフロー実行の承認）が必要です。",
+        "e15a8b77ef": "このチェックではインライン詳細は利用できません。",
+        "e45324fbed": "チェック詳細の読み込みに失敗しました。",
+        "dcb3c546fe": "再試行",
+        "d9fa90b625": "差分の読み込みに失敗しました。",
+        "4aecf121e7": "閉じる",
+        "8812225174": "再オープン",
+        "09d67a0f9b": "PR のクローズに失敗しました",
+        "88809e79db": "PR の再オープンに失敗しました",
+        "85a2b66f54": "GitHub でファイルを開く",
+        "86d84a17ca": "レビューコメントを追加",
+        "00f55cc17b": "この PR ではリポジトリアクセスを利用できません。"
       },
       "GitLabItemDialog": {
         "65e784c1f1": "再度開く",
@@ -1118,7 +1337,8 @@
         "3a051b8ade": "作業項目",
         "32f8bef818": "ログは出力されません。",
         "4168eb2c51": "解決",
-        "commentTooLarge": "コメントが大きすぎるため安全に送信できません。"
+        "commentTooLarge": "コメントが大きすぎるため安全に送信できません。",
+        "gitlabActionFailed": "GitLab の操作に失敗しました。"
       },
       "JiraIssueWorkspace": {
         "b0b92666c9": "コメント",
@@ -1367,7 +1587,10 @@
         "addSshHostHint": "既存のマシンを SSH 経由で使用します",
         "addRemoteOrcaServer": "リモート Orca サーバーを追加",
         "addRemoteOrcaServerHint": "別の Orca ランタイムとペアリングします",
-        "hostConnectionFailed": "接続に失敗しました"
+        "hostConnectionFailed": "接続に失敗しました",
+        "setLocation": "プロジェクトの場所を設定",
+        "setLocationOnHost": "{{host}} 上のプロジェクトの場所を設定",
+        "setLocationTooltip": "フォルダーを選択するか、このプロジェクトを {{host}} にクローンしてください。"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "ワークツリーを作成する",
@@ -1548,7 +1771,10 @@
         "4b8ae7303f": "差分の読み込みに失敗しました。",
         "closePullRequestFailed": "PR のクローズに失敗しました",
         "reopenPullRequestFailed": "PR の再オープンに失敗しました",
-        "diffLoadTimedOut": "この差分の読み込みがタイムアウトしました。"
+        "diffLoadTimedOut": "この差分の読み込みがタイムアウトしました。",
+        "6b1d5ee3e4": "このチェックではインライン詳細は利用できません。",
+        "e04c027d98": "チェック詳細の読み込みに失敗しました。",
+        "5df7c41d2a": "再試行"
       },
       "QuickOpen": {
         "1dbd3f59ff": "移動",
@@ -1937,7 +2163,9 @@
         "61ed600d29": "「{{value0}}」には未保存の変更があります。閉じる前に保存しますか?",
         "cdc9ac4b2d": "エディター",
         "e57db40c11": "{{value0}} の起動コマンドを作成できませんでした。",
-        "5b2c1a9e44": "Agent CLI が検出されません。インストールするか、設定で既定の Agent を選択してください。"
+        "5b2c1a9e44": "Agent CLI が検出されません。インストールするか、設定で既定の Agent を選択してください。",
+        "b7c1f0a934": "リモートホストに接続できなかったため、Orca はその場所で作業が継続中かどうか特定できません。このままウィンドウを閉じますか?",
+        "quitSnapshotSaveFailed": "終了をキャンセルしました: セッションのスナップショットを保存できませんでした（{{value0}}）。"
       },
       "TerminalSearch": {
         "db234b7519": "閉じる",
@@ -1993,7 +2221,8 @@
         "a4650b0dc4": "ローカルビルドを使用できません",
         "b1e390250d": "ローカルビルドの切り替えを完了できませんでした。",
         "d29740d175": "選択したビルドを使用できませんでした。",
-        "37d45c9ec1": "別のビルドを選択"
+        "37d45c9ec1": "別のビルドを選択",
+        "7f1a4c9e02": "システムのパッケージマネージャーが Orca をインストールしたため、そこから更新してください。Orca 自体ではこのリリースをインストールできません。"
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "移動",
@@ -2037,7 +2266,8 @@
         "pluginCommandFailed": "プラグインのコマンドを実行できませんでした。",
         "27f10cca63": "チャット、ターミナル、ワークツリー、設定、操作を検索します…",
         "2770f02910": "チャット、ターミナル、ワークツリー、設定、操作を検索します",
-        "recentChatsTerminalsHeader": "最近のチャットとターミナル"
+        "recentChatsTerminalsHeader": "最近のチャットとターミナル",
+        "lastActiveTime": "最終アクティブ: {{value0}} 前"
       },
       "github": {
         "pr": {
@@ -2218,6 +2448,30 @@
                 "7c302f8174": "無題"
               }
             }
+          },
+          "ProjectRoadmap": {
+            "6405e036e0": "月",
+            "be52f7b6db": "このロードマップビューには、アイテムを配置するための日付またはイテレーションのフィールドがありません。そのため、Orca では一覧表示しています。",
+            "f2b1cabef7": "四半期",
+            "b6afc6fe45": "年",
+            "343888b143": "{{value0}} による配置",
+            "6a088a5da1": "日付のない {{value0}}",
+            "86eebd6020": "今日",
+            "0bb1c1bc07": "タイムラインのズーム",
+            "e304235879": "アイテム",
+            "e077c79083": "日付なし"
+          },
+          "ProjectRoadmapBar": {
+            "7d1220d979": "制限事項",
+            "cd68ccc17a": "{{value0}} — {{value1}}"
+          },
+          "ProjectPickerPanels": {
+            "9fe1ac868c": "未対応",
+            "04ec212ccb": "ロードマップ"
+          },
+          "ProjectViewStates": {
+            "ac83c45672": "Orca でこのプロジェクトを操作するには、テーブルビューまたはロードマップビューに切り替えてください。",
+            "e4cc8b14f2": "Orca はテーブルビューとロードマップビューのプロジェクトを表示します。このビューは、まだ表示できないレイアウトを使用しています。"
           }
         },
         "GitHubMarkdownComposer": {
@@ -2346,6 +2600,11 @@
             "label": "重複として閉じる",
             "description": "別の Issue と重複"
           }
+        },
+        "CommentReactions": {
+          "addReaction": "リアクションを追加",
+          "removeNamedReaction": "{{value0}} のリアクションを解除",
+          "addNamedReaction": "{{value0}} のリアクションを追加"
         }
       },
       "linear": {
@@ -2552,7 +2811,9 @@
             "selectedForDeletionCount": "削除対象として選択済み: {{value0}}",
             "deleteButtonCount": "{{value0}} を削除",
             "archivedStatus": "アーカイブ済み",
-            "readyStatus": "準備完了"
+            "readyStatus": "準備完了",
+            "74f6c16279": "戻る",
+            "f637f63882": "リソースマネージャーは {{value0}} と数えていますが、この一覧では {{value1}} が見つかりました。そのカウンターは Orca のアクティビティ記録のみを読み取りますが、このスキャンでは各ワークスペースの git 履歴も確認し、切断されたリモートをスキップします。"
           },
           "backgroundRemoval": {
             "removed": "削除済みワークスペース: {{value0}}",
@@ -2599,6 +2860,16 @@
             "dirtyFilesBlocker": "変更済みファイル",
             "unknownBaseBlocker": "未プッシュのコミットを確認できませんでした",
             "dismissedBlocker": "無視済み"
+          },
+          "workspace": {
+            "cleanup": {
+              "candidate": {
+                "row": {
+                  "b5d2b33e47": "削除中…",
+                  "e1135728e3": "削除待ち"
+                }
+              }
+            }
           }
         }
       },
@@ -2633,12 +2904,15 @@
           "commands": {
             "TerminalQuickCommandActionToggle": {
               "b0d58e37ed": "Agent プロンプト",
-              "b5ea4d64f6": "ターミナルコマンド"
+              "b5ea4d64f6": "ターミナルコマンド",
+              "terminal_short": "ターミナル",
+              "agent_short": "Agent"
             },
             "TerminalQuickCommandAppendEnterSwitch": {
               "e4e5fed3b3": "追加を切り替え Enter",
               "c936c2d6d2": "テキストを挿入するだけでなく、すぐに送信してください。",
-              "5fa607d807": "追加 Enter"
+              "5fa607d807": "追加 Enter",
+              "767e4be3e3": "Enter を追加 — すぐに実行"
             },
             "TerminalQuickCommandDialog": {
               "925b8e0f6e": "詳細設定",
@@ -2655,7 +2929,11 @@
               "dc921c17ee": "プロンプト",
               "5b3f634a55": "クイックコマンドを追加",
               "f9b184fc16": "クイックコマンドの編集",
-              "6751598542": "編集"
+              "6751598542": "編集",
+              "command_label": "コマンド",
+              "agent_toolbar_hint": "/goal、スキル、パスに対応しています",
+              "agent_footer_hint": "複数行のプロンプトも可能です。焦点を絞って記述してください。",
+              "resize_hint": "角をドラッグしてサイズ変更"
             },
             "TerminalQuickCommandDialogFooter": {
               "2e2b958dfc": "保存",
@@ -2736,14 +3014,23 @@
             "c2f0b72b8d": "入れる",
             "925f49f210": "ペインを展開する",
             "df766809e0": "ペインを折りたたむ",
-            "cff67afad1": "コンテキストをコピー"
+            "cff67afad1": "コンテキストをコピー",
+            "15dd899676": "{{value0}} に追加…"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "デーモンを再起動します",
             "a7e2fd2699": "Issue を登録",
             "5c8ce20be6": "この状態が続く場合は、",
             "cc6d997c65": "ここからターミナルデーモンを再起動して、古いデーモン状態をクリアします。",
-            "remoteTerminalClosed": "リモートターミナルが閉じられました。"
+            "remoteTerminalClosed": "リモートターミナルが閉じられました。",
+            "retry": "再試行",
+            "retrying": "再試行中…",
+            "retryUnavailable": "再試行ではまだ再接続できませんでした。しばらくしてから再度お試しください。",
+            "ownerUnknown": "Orca はこのターミナルの所有者を確認できませんでした。",
+            "42b283ecfc": "ホストが保存済みセッションを確認できなかったため、Orca はこのターミナルを安全に再接続できませんでした。保存済みセッションは変更していません。今すぐ再接続するには「再試行」をクリックしてください。それでも再接続できない場合は、新規ターミナルを開いてください。",
+            "e16012e31e": "このセッションを所有していたターミナルデーモンが終了したため、セッションとスクロールバックを復元できませんでした。続けるには新規ターミナルを開いてください。",
+            "sessionUnavailable": "Orca はホスト上のこのペインのターミナルセッションに再アタッチできませんでした。続けるには新規ターミナルを開いてください。",
+            "sourceRestoring": "このターミナルを再接続中です。出力を再確立しています。セッションは実行中です。"
           },
           "TerminalProcessExitOverlay": {
             "capacityTitle": "Git Bash のコンソール上限に達しました",
@@ -2885,6 +3172,29 @@
             "retryingBody": "Orca は自動的に再試行します。接続が復元されると、このターミナルが再開されます。",
             "disconnectedBody": "自動再試行が停止しました。このターミナルセッションを再開するには再接続してください。",
             "reconnectButton": "再接続"
+          },
+          "TerminalLinkActionPopover": {
+            "openLink": "リンクを開く",
+            "openFile": "ファイルを開く",
+            "copyLink": "リンクをコピー",
+            "copied": "コピーしました",
+            "copiedLink": "リンクをコピーしました",
+            "copyLinkFailed": "リンクのコピーに失敗しました",
+            "downloadOpenFailed": "「{{value0}}」のダウンロードに失敗しました。",
+            "switchWorkspace": "ワークスペースを切り替え",
+            "openInFinder": "Finder で開く",
+            "openFolder": "フォルダーを開く",
+            "openWithDefaultApp": "デフォルトのアプリで開く",
+            "switchTerminal": "ターミナルを切り替え",
+            "openTaskTerminal": "タスクターミナルを開く",
+            "systemBrowser": "システムブラウザ",
+            "orcaBrowser": "Orca ブラウザ",
+            "terminalLinkSettings": "ターミナルリンク設定",
+            "downloadOpenWithDefaultApp": "ダウンロードしてデフォルトのアプリで開く"
+          },
+          "TerminalQuickCommandsSubmenu": {
+            "3ccc7981bb": "ホストを利用できません",
+            "54f29b7c0d": "ホストを読み込み中…"
           }
         }
       },
@@ -2947,7 +3257,10 @@
             "1d04b1630b": "下に分割",
             "6b3efb106e": "上に分割",
             "fdd29eb669": "ピンタブ",
-            "8e9d603a09": "タブの固定を解除する"
+            "8e9d603a09": "タブの固定を解除する",
+            "revealInFinder": "Finder で表示",
+            "openContainingFolder": "含まれるフォルダーを開く",
+            "revealInFileExplorer": "エクスプローラーで表示"
           },
           "QuickLaunchButton": {
             "348a04c1ad": "Agent 設定…",
@@ -3111,6 +3424,14 @@
           },
           "TerminalTabLeadingIcon": {
             "7ab2964bea": "未読の Agent 完了"
+          },
+          "TabBarQuickCommandAddActions": {
+            "45a2f36d51": "コマンド",
+            "b856c833ae": "{{value0}} 上のコマンド"
+          },
+          "TabBarQuickCommandHostLoadStatus": {
+            "82e294f3ca": "ホストを利用できません",
+            "7c129b08ff": "ホストを読み込み中…"
           }
         }
       },
@@ -3228,7 +3549,9 @@
             "connectedHostCount_other": "{{count}} 台のホスト",
             "connecting": "接続中…",
             "workspaceConflict": "ワークスペースの競合",
-            "workspaceSyncError": "ワークスペースの同期エラー"
+            "workspaceSyncError": "ワークスペースの同期エラー",
+            "runtime_unavailable_transport_up": "Orca を利用できません",
+            "runtime_workspace_window_closed": "ワークスペースウィンドウを閉じました"
           },
           "CaffeinateStatusSegment": {
             "active": "アクティブ",
@@ -3462,7 +3785,14 @@
             "e2c6a4f917": "Grok を実行して更新",
             "d1b7f509ac": "Orca を実行しているコンピュータのターミナルで grok を実行し、起動するまで待ってください。サインインを求められた場合は完了してから、使用状況を再取得してください。チャットメッセージを送る必要はありません。",
             "f90b3d7a16": "Kimi を実行して更新",
-            "a37e8c15d4": "Orca を実行しているコンピュータのターミナルで kimi を実行し、起動するまで待ってから、使用状況を再取得してください。"
+            "a37e8c15d4": "Orca を実行しているコンピュータのターミナルで kimi を実行し、起動するまで待ってから、使用状況を再取得してください。",
+            "minimax": {
+              "expired": {
+                "label": "サインインの有効期限切れ",
+                "apiKey": "MiniMax API キーの有効期限が切れています。設定で置き換えてください。",
+                "cookie": "MiniMax セッション Cookie の有効期限が切れています。設定で置き換えてください。"
+              }
+            }
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH ホスト"
@@ -3542,6 +3872,18 @@
             "stoppingLabel": "更新を停止しています",
             "stoppingTooltip": "スキルの更新を停止しています…",
             "stoppingAria": "スキルの更新を停止しています。クリックすると詳細を開きます。"
+          },
+          "RuntimeHostStatusRow": {
+            "reconnect_attempt": "試行 {{value0}}",
+            "previous_connection_closed": "前回の接続が閉じました",
+            "workspace_window_closed": "ワークスペースウィンドウが閉じています",
+            "checking_host": "Orca はこのホストに到達できるか確認しています",
+            "restoring_connection": "Orca は接続の復元を試みています",
+            "host_unreachable": "Orca はこのホスト上で到達できません",
+            "runtime_unavailable": "SSH トランスポートは接続されていますが、Orca ランタイムを利用できません",
+            "runtime_unavailable_explanation": "リモートホストは実行中の可能性があります。Orca ランタイム接続のみが利用できません。",
+            "contact_note": "ホストは実行中の可能性があります。Orca 接続のみが利用できません。",
+            "last_connected": "最終接続: {{value0}}"
           }
         }
       },
@@ -3728,7 +4070,8 @@
           "908c470587": "codex",
           "eb6a066185": "claude",
           "eee19cfade": "概要",
-          "grokUsageTab": "Grok"
+          "grokUsageTab": "Grok",
+          "trackingSince": "{{value0}} から追跡中"
         },
         "UsageOverviewPane": {
           "22ed1b7669": "セッション",
@@ -3816,13 +4159,19 @@
               "6762f6a682": "トークン",
               "a7f937fb29": "{{value0}} セッション - {{value1}} {{value2}}",
               "c8f3a2d1e0b4": "ターン",
-              "d9a4b3e2f1c5": "イベント"
+              "d9a4b3e2f1c5": "イベント",
+              "statusEnabled": "有効",
+              "statusOff": "オフ",
+              "statusScanning": "スキャン中"
             }
           }
         },
         "UsageBreakdownSection": {
           "7765a4c3e1": "該当なし",
-          "247c93ca92": "• 推定価格"
+          "247c93ca92": "• 推定価格",
+          "32176e1d44": "ターン",
+          "79a69522a5": "イベント",
+          "02a046792e": "セッション •"
         },
         "UsageSessionsTable": {
           "1afc25eb06": "ターン",
@@ -3906,10 +4255,32 @@
           "remoteShareNotice": "これらのスキルは {{host}} にあります。共有するには、そのマシンでスキルを開いてください。",
           "viewSwitch": "表示",
           "searchLinks": "リンクを検索",
-          "deleteSkills": "スキルを削除…"
+          "deleteSkills": "スキルを削除…",
+          "984405683f": "プラグイン",
+          "4d177feabd": "同梱",
+          "aa59462502": "リポジトリ",
+          "571c5818c1": "ホーム",
+          "fb6bf60b52": "Claude",
+          "426be2aac6": "Codex",
+          "e46e162e2e": "から",
+          "b088e0785d": "ベータ",
+          "7e828fb2c6": "戻る",
+          "0c74e7ff34": "インストール済み",
+          "0bc1379f4c": "すべてのソース",
+          "38e0951c3a": "Agent スキル",
+          "39b6998ddb": "すべてのプロバイダー",
+          "ab5b777350": "ホーム、リポジトリ、同梱、プラグインのスキルフォルダーを確認しました。"
         },
         "SkillShareSelectionControls": {
-          "01c5a15e02": "スキルを共有"
+          "01c5a15e02": "スキルを共有",
+          "01c5a15e05": "{{value0}} のスキルを共有",
+          "01c5a15e01": "共有をキャンセル",
+          "01c5a15e03": "{{value0}} を選択中",
+          "01c5a15e04": "検索結果をすべて選択",
+          "01c5a15e06": "共有するには、所有マシン上でこのスキルを開いてください。",
+          "01c5a15e07": "共有する前に、このスキルをインストールしてください。",
+          "01c5a15e08": "共有できるのはホームとワークスペースのスキルのみです。",
+          "01c5a15e09": "この名前のスキルは、別のソースからすでに選択されています。"
         },
         "SkillRow": {
           "updatedUnknown": "日付なし",
@@ -3918,7 +4289,11 @@
           "detailPath": "パス",
           "skillActions": "{{value0}} の操作",
           "viewDetails": "詳細を表示",
-          "deleteSkill": "削除…"
+          "deleteSkill": "削除…",
+          "detailSource": "ソース",
+          "detailContents": "内容",
+          "notShareable": "共有不可",
+          "notDeletable": "削除不可"
         },
         "SkillsList": {
           "listLabel": "スキル"
@@ -3950,7 +4325,19 @@
           "shareOne": "{{count}} 件のスキルを共有",
           "shareOther": "{{count}} 件のスキルを共有",
           "linkOne": "{{count}} 件のリンク",
-          "linkOther": "{{count}} 件のリンク"
+          "linkOther": "{{count}} 件のリンク",
+          "deleteLinkOne": "{{count}} 件のリンク",
+          "deleteLinkOther": "{{count}} 件のリンク",
+          "installOne": "{{count}} のスキルをインストール",
+          "installOther": "{{count}} のスキルをインストール",
+          "retryOne": "{{count}} のスキルを再試行",
+          "retryOther": "{{count}} のスキルを再試行",
+          "deleteOne": "{{count}} のスキルを削除",
+          "deleteOther": "{{count}} のスキルを削除",
+          "deletedOne": "{{count}} のスキルを削除しました",
+          "deletedOther": "{{count}} のスキルを削除しました",
+          "deleteFolderOne": "{{count}} フォルダー",
+          "deleteFolderOther": "{{count}} フォルダー"
         },
         "filter": {
           "allAgents": "すべての Agent",
@@ -4057,7 +4444,9 @@
           "upToDate": "最新",
           "installed": "インストール済み",
           "details": "詳細",
-          "needsAttention": "スキルを確認"
+          "needsAttention": "スキルを確認",
+          "checking": "確認中…",
+          "checkFailed": "確認に失敗"
         },
         "SkillUpdateResultRows": {
           "stillOutdated": "更新を実行しましたが、まだ最新ではありません。"
@@ -4069,6 +4458,376 @@
         "host": {
           "local": "このマシン",
           "remote": "接続済みランタイム"
+        },
+        "SkillShareDialog": {
+          "30985d4fc0": "キャンセル",
+          "3af85f6add": "完了",
+          "reconnect": "共有する前に、Orca アカウントに再接続してください。",
+          "unconfigured": "共有する前に、Orca Cloud アカウントに接続してください。",
+          "prepareFailed": "このスキルを共有用に準備できませんでした。",
+          "peopleRequired": "少なくとも 1 人のチームメイトを選択してください。",
+          "publishCancelled": "アップロードをキャンセルしました。準備済みのコピーは残っているため、再試行できます。",
+          "publishFailed": "このスキルを公開できませんでした。準備済みのコピーは残っているため、再試行できます。",
+          "copied": "共有リンクをコピーしました",
+          "preparing": "プレビューを準備中…",
+          "ready": "スキルリンクの準備完了",
+          "title": "スキルを共有",
+          "readyDescription": "受信者は、確認やインストールの前に Orca で認証します。",
+          "newVersionDescription": "正確なファイルを確認してから、既存の Cloud パッケージに不変のバージョンを公開します。",
+          "description": "正確なファイルを確認し、アクセスできる相手を選択してから、不変のバージョンを公開します。",
+          "0f07fa2a79": "スキルを公開",
+          "7aa4ba0dba": "新規バージョンを公開",
+          "3a51d0f34f": "アップロードをキャンセル",
+          "e9d652ae3d": "キャンセル中…",
+          "readyDescriptionV2": "この限定公開リンクを知っている人は誰でも、スキルを確認・インストールできます。",
+          "descriptionV2": "正確なファイルを確認してから、限定公開リンクの背後で不変のバージョンを公開します。",
+          "publishBundle": "バンドルを公開",
+          "cancelRequestFailed": "Orca はキャンセルリクエストを送信できませんでした。アップロードは完了する可能性があります。"
+        },
+        "SkillCard": {
+          "01c5a16e01": "{{value0}} を選択",
+          "d25a1b8ae6": "スキルを共有"
+        },
+        "SkillCloudManagementActions": {
+          "copyLink": "リンクをコピー",
+          "ed753624c0": "Cloud パッケージを削除",
+          "640bc6b92e": "パッケージの削除を確認",
+          "6b6adf68c1": "選択した Cloud バージョンを削除",
+          "bbec37d8f8": "バージョンの削除を確認",
+          "7a80285dad": "共有を解除",
+          "0ac5c175fd": "共有解除を確認",
+          "9e6bd31487": "アクティブな共有リンクはありません。",
+          "c7f2b69122": "共有を解除すると、今後のインストールがブロックされます。すでに各マシンにインストール済みのコピーは残ります。",
+          "8cac3b9362": "アクティブなリンク",
+          "cc8e4ef6ba": "アクセスを保存",
+          "eb603f7888": "現在の名簿外は保持されます。",
+          "3d346ddce8": "既存の受信者",
+          "2b8c569ea7": "現在の組織",
+          "2552c12fea": "アクセス",
+          "505cd6105c": "Cloud 共有設定",
+          "linkCopied": "共有リンクをコピーしました",
+          "activeLinkBearerDescription": "アクティブなリンクを知っている人は誰でも、スキルを確認・インストールできます。取り消すと今後のアクセスはブロックされますが、インストール済みのコピーは変更されません。"
+        },
+        "SkillInstallDialog": {
+          "241e72f9d6": "インストール中…",
+          "d198ec91e5": "閉じる",
+          "39acb9e8f4": "スキルをインストール",
+          "59c3b76cdd": "インストールを再試行",
+          "05588076a9": "インストールをキャンセル",
+          "4a00d133c5": "Orca は、選択したマシンを変更する前に、アクセスとパッケージの同一性を確認します。",
+          "fcbec627cc": "共有スキルをインストール",
+          "01c5a14e01": "共有スキルをインストール",
+          "opening": "このリンクを開いています…"
+        },
+        "SkillInstallManagementDialog": {
+          "8095927ff3": "閉じる",
+          "e91af0079f": "削除",
+          "6cb1fbe039": "このコンピュータ",
+          "470d8d2476": "削除を確認",
+          "c1d03ee50d": "インストールをキャンセル",
+          "561e49ccd1": "選択したバージョンをインストール",
+          "2ae587d39c": "不完全なカバレッジを再試行",
+          "f7c5075e77": "変更を破棄して削除",
+          "e1884c812e": "変更を破棄してバージョンをインストール",
+          "070654c6d1": "Orca は、ローカルの変更を明示的に破棄しない限り、それらを保持します。",
+          "74b70892ea": "ローカルファイルが変更されました",
+          "86ed219b55": "バージョンを選択",
+          "9c04bd0120": "インストール済みバージョン",
+          "64c71cf7b9": "このマシンには、Orca が管理するスキルのインストールが見つかりませんでした。",
+          "0900db719a": "— 切断中",
+          "176fef9516": "· SSH",
+          "3677ae58e7": "Orca がインストールしたバージョンを更新、ロールバック、安全に削除します。",
+          "44d118a8f7": "インストール済みスキルを管理",
+          "1c9e7f420a": "インストール済みバンドルスキル",
+          "34c2ef9e71": "{{count}} のスキルをインストール",
+          "a0cab67c2f": "{{count}} のスキルを削除",
+          "f970d8088d": "{{count}} のスキル削除を確認",
+          "dab29e4b54": "{{installed}} 件インストール済み · {{updated}} 件更新済み · {{keptLocal}} 件はローカルを維持",
+          "installAnotherMachine": "別のマシンにインストール"
+        },
+        "SkillInstallReviewContent": {
+          "fab8fce842": "ファイル",
+          "69236de8d6": "確認中…",
+          "89e2601162": "破棄して置換",
+          "a5675fb371": "の内容を変更せずに残しました。そのまま残すか、このバージョンで明示的に破棄・置換してください。",
+          "37d990b94c": "変更済み",
+          "2a31912f14": "Orca が検出",
+          "651b7d8a57": "ローカルコピーの判断が必要です",
+          "98ed90e523": "スキルには手順が含まれ、スクリプトを含む場合があります。作成者のコードとして扱ってください。",
+          "f72ee4022a": "SHA-256",
+          "3d8421ca2f": "実行可能",
+          "87137bcb8d": "スクリプト",
+          "8f9833d509": "不変のバージョン",
+          "66270286ac": "・安全に再試行できます。",
+          "1b6ad2ca5c": "確認済み。",
+          "3fc62a61eb": "配置先",
+          "157de228b4": "スキルを確認",
+          "27672470d9": "リンクを開いても何もインストールされません。まず不変のバージョンを確認してください。",
+          "66cff7a804": "https://app.orca.dev/skills/share/…",
+          "93eb0fe8c7": "Orca スキルリンク",
+          "releaseNotes": "リリースノート:",
+          "targetHeader": "インストール先"
+        },
+        "SkillInstallTargetFields": {
+          "7a366323e7": "フォルダー",
+          "0e5b43a9e3": "ワークスペース",
+          "8562dd1e6e": "このコンピュータ",
+          "8e6a972229": "このマシン上に既知のワークスペースはありません。",
+          "d628c416a2": "Git ワークツリー",
+          "5845cfe543": "ワークツリーまたはフォルダーを選択",
+          "0c10a406fb": "WSL ·",
+          "e5b0d15e64": "ホスト OS",
+          "cb47652227": "実行環境",
+          "a4dfd33095": "1 つのワークスペース",
+          "c779621aa0": "グローバルスキル",
+          "63cc9e31fe": "保存先",
+          "85d85880df": "· SSH",
+          "71eefd7660": "— 切断中",
+          "0785d0a503": "— 更新が必要です",
+          "b8a0b706ad": "マシン"
+        },
+        "SkillInstallWorkspaceCombobox": {
+          "search": "ワークスペースを検索…",
+          "empty": "ワークスペースが見つかりません。"
+        },
+        "SkillShareReviewContent": {
+          "6d6233a3a4": "リンクをコピー",
+          "f0c0411549": "リリースノート",
+          "3121f44358": "ファイル",
+          "e3caf6baeb": "このリンクを取り消すと、今後のアクセスがブロックされます。受信者のマシンにすでにインストールされたコピーは削除されません。",
+          "0142581727": "アップロード中…",
+          "ad940367a5": "検証・公開中…",
+          "bf02d6ed9e": "このバージョンの変更点は?",
+          "4895d3e0ee": "利用可能なチームメイトがいません。",
+          "8188f5d765": "がリンクにアクセスできます。",
+          "fe204e06f0": "組織",
+          "0cd4b3e396": "現在所属している全員",
+          "f25429e266": "選択した相手",
+          "0a49d901ab": "組織",
+          "6817a7f6f8": "スキルへのアクセス",
+          "c15d90c10b": "接続済みの Orca Cloud アカウントが必要です。",
+          "266527d295": "{{value0}}{{value1}} として公開しています。",
+          "78d863235c": "アクセス",
+          "b3b1d4b911": "SHA-256",
+          "8edd32622f": "スクリプト",
+          "2dca0b720b": "スキルの新バージョンを公開",
+          "01c5a17e01": "{{value0}} のスキル",
+          "01c5a17e02": "含まれるスキルを確認",
+          "01c5a17e03": "{{value0}} ファイル · {{value1}}",
+          "unlistedLinkTitle": "限定公開リンク",
+          "unlistedPublishingAs": "{{value0}} として公開しています。リンクを知っている人は誰でも、これらのスキルを確認・インストールできます。",
+          "unlistedLinkDetails": "リンクは検索できず、公開もされません。今後のアクセスをブロックするには取り消してください。インストール済みのコピーは残ります。",
+          "bundleReady": "スキルバンドルのリンクの準備完了",
+          "publishBundleVersion": "スキルバンドルの新バージョンを公開",
+          "shareBundle": "スキルバンドルを共有",
+          "publishingLink": "リンクを公開中…",
+          "verifyingPackage": "パッケージを確認中…",
+          "77f636eac3": "実行可能"
+        },
+        "SkillBundleInstallFlow": {
+          "01c5a13e01": "閉じる",
+          "01c5a13e03": "インストール中…",
+          "01c5a13e02": "インストールをキャンセル",
+          "01c5a13e04": "{{value0}} のスキルを再試行",
+          "01c5a13e05": "{{value0}} のスキルをインストール"
+        },
+        "SkillBundleInstallOutcome": {
+          "01c5a12e01": "インストール済み",
+          "01c5a12e02": "更新済み",
+          "01c5a12e05": "失敗",
+          "01c5a12e06": "キャンセル済み",
+          "01c5a12e03": "変更なし",
+          "01c5a12e04": "ローカルを維持",
+          "01c5a12e07": "バンドルのインストールに確認が必要です。",
+          "01c5a12e08": "スキルをインストールして検証しました。",
+          "01c5a12e09": "選択した {{value0}} のスキルを確認しました。",
+          "01c5a12e10": "再試行が必要"
+        },
+        "SkillBundleInstallReview": {
+          "01c5a11e0d": "すべて選択",
+          "01c5a11e01": "不変のバージョン",
+          "01c5a11e02": "{{value0}} のスキル",
+          "01c5a11e03": "{{value0}} ファイル",
+          "01c5a11e04": "{{value0}} スクリプト",
+          "01c5a11e05": "{{value0}} 実行可能",
+          "01c5a11e06": "SHA-256",
+          "01c5a11e09": "リリースノート:",
+          "01c5a11e0a": "スキルには手順が含まれ、スクリプトを含む場合があります。作成者のコードとして扱ってください。",
+          "01c5a11e0b": "インストールするスキル",
+          "01c5a11e0c": "このバンドルから任意のサブセットを選択してください。",
+          "01c5a11e0e": "説明なし",
+          "01c5a11e0f": "{{value0}} ファイル · {{value1}} スクリプト",
+          "01c5a11e10": "{{value0}} 実行可能",
+          "01c5a11e11": "ローカルコピーの判断が必要です",
+          "01c5a11e12": "Orca は既定でこれらのローカルコピーを保持します。破棄して置換したいコピーのみを選択してください。",
+          "01c5a11e13": "{{value0}}（{{value1}}）を置換",
+          "01c5a11e14": "{{value0}} 新規",
+          "01c5a11e15": "{{value0}} 変更なし",
+          "01c5a11e16": "{{value0}} 更新あり",
+          "01c5a11e17": "{{value0}} 競合あり"
+        },
+        "SkillSelectionBar": {
+          "selectAll": "対象の {{count}} 件をすべて選択",
+          "clear": "クリア"
+        },
+        "share": {
+          "fileScript": "スクリプト",
+          "releaseNotesVersion": "リリースノート",
+          "fileExecutable": "実行可能",
+          "reviewFiles": "実行可能なファイルを確認",
+          "reviewSkills": "含まれるスキルを確認",
+          "releaseNotesOptional": "リリースノートを追加（任意）",
+          "releaseNotesFirst": "このリリースについて説明",
+          "readyDescription": "リンクをコピーして共有します。",
+          "newVersionDescription": "既存のパッケージに不変のバージョンを公開します。",
+          "description": "限定公開リンクの背後で不変のバージョンを公開します。",
+          "accessSummary": "リンクを知っている人は誰でもインストールできます。どこにも掲載されず、取り消すと新規インストールがブロックされます（インストール済みのコピーは除く）。{{value0}} として公開しています。",
+          "manageLinks": "設定でリンクを管理・取り消す",
+          "scriptOne": "{{count}} スクリプト",
+          "scriptOther": "{{count}} スクリプト",
+          "executableOne": "{{count}} 実行可能",
+          "executableOther": "{{count}} 実行可能",
+          "noExecutableContent": "スクリプトや実行可能ファイルなし",
+          "newVersionDescriptionPlain": "既存のリンクに新規バージョンを追加します。",
+          "accessSummaryShort": "限定公開リンク — 知っている人は誰でもインストールできます。{{value0}} として公開しています。",
+          "accessSummaryPlain": "限定公開リンク — 知っている人は誰でもインストールできます。"
+        },
+        "description": {
+          "showLess": "折りたたむ",
+          "showMore": "さらに表示"
+        },
+        "install": {
+          "agentsLabel": "Agent",
+          "agentNotInstalled": "未インストール",
+          "agentsNone": "Agent が選択されていません",
+          "rowUpdate": "更新",
+          "rowNew": "新規",
+          "fileBinary": "バイナリ",
+          "agentsCountBadge": "{{count}} 件選択中",
+          "selectAll": "すべて選択",
+          "authorizing": "パッケージアクセスを認証中…",
+          "installing": "ダウンロード、検証、インストール中…",
+          "selectSkill": "少なくとも 1 つのスキルを選択してください。",
+          "chooseWorkspace": "ワークスペースを選択してください。",
+          "reconnectBeforeInstalling": "インストールする前に、Orca アカウントに再接続してください。",
+          "bundleVerificationFailed": "リクエストされたバンドルを Orca が検証する前に、インストールが失敗しました。",
+          "destinationAlreadyFinished": "保存先では、このインストールはすでに完了しています。",
+          "enterShareLink": "Orca スキル共有リンクを入力してください。",
+          "shareUnavailable": "この共有は利用できません。リンクが無効、期限切れ、または取り消された可能性があります。",
+          "requestedVersionVerificationFailed": "リクエストされたバージョンを Orca が検証する前に、インストールが失敗しました。",
+          "versionVerificationFailed": "Orca はリクエストされたバージョンを検証できませんでした。",
+          "inspectManagedFailed": "Orca はこのマシン上の管理対象インストールを確認できませんでした。",
+          "reconnectForVersionHistory": "バージョン履歴を読み込むには、Orca アカウントに再接続してください。",
+          "versionHistoryUnavailable": "このスキルのバージョン履歴は利用できません。",
+          "bundleSkillsMissing": "このバージョンには、インストール済みバンドルスキルが含まれていません。",
+          "reconnectBeforeVersionChange": "バージョンを変更する前に、Orca アカウントに再接続してください。",
+          "removeFailed": "Orca はこのスキルを安全に削除できませんでした。",
+          "agentsCanonical": "{{value0}} には常にインストールされます（{{value1}} を読み取ります）。",
+          "agentsNoneChosen": "追加の Agent なし",
+          "agentsSummary": "その他: {{value0}}",
+          "bundleDestinationSummary": "{{value0}} 新規 · {{value1}} インストール済み · {{value2}} は判断が必要",
+          "trustNote": "スキルは作成者による手順とコードです。信頼できるものをインストールしてください。",
+          "agentsSelected": "インストール先: {{value0}}",
+          "agentAlways": "常時",
+          "agentsCanonicalNote": "{{value0}} は {{value1}} を読み取ります。すべてのインストールはそこに書き込みます。",
+          "linkHint": "リンクを開いてもインストールされません。必ず事前に確認します。",
+          "rowNeedsDecision": "判断が必要",
+          "rowInstalled": "インストール済み",
+          "chooseSkills": "このリンクからインストールする内容を選択してください。",
+          "singleRunnableWarning": "このスキルにはスクリプトまたはバイナリファイルが含まれています。",
+          "runnableWarning": "選択した {{selectedCount}} のスキルのうち {{affectedCount}} にスクリプトまたはバイナリファイルが含まれています: {{affected}}。",
+          "reviewRunnableFiles": "スクリプトまたはバイナリファイルを含む",
+          "reviewSupportingFiles": "サポートファイルを含む",
+          "reviewInstructions": "このスキルについて",
+          "supportingFileWarning": "選択したスキルには、SKILL.md 以外に {{fileCount}} が含まれています。",
+          "agentAccessWarning": "スキルには Agent が従う可能性のある手順が含まれています。この共有リンクの提供元を信頼できる場合のみ続けてください。",
+          "fileRunnable": "実行可能",
+          "agentsCountLabel": "{{count}} {{label}}",
+          "targetAgentsHeader": "対象 Agent",
+          "deselectAll": "任意の選択を解除",
+          "canonicalHeader": "標準 Agent（常に含まれる）",
+          "canonicalExplanation": "これらの Agent は {{root}} をネイティブに読み取ります。Orca は既定でそこにインストールします:",
+          "additionalAgentsHeader": "追加の Agent ディレクトリ"
+        },
+        "managedInstall": {
+          "versionLabel": "バージョン",
+          "cancel": "キャンセル",
+          "remove": "削除",
+          "scopeWorkspace": "このワークスペース",
+          "skillMissing": "不足",
+          "editedWarning": "破棄を選択しない限り、編集内容は保持されます。",
+          "finishInstall": "インストールを完了",
+          "useVersion": "このバージョンを使用",
+          "reinstall": "再インストール",
+          "sendToMachine": "別のマシンに送信",
+          "confirmRemove": "削除を確認",
+          "discardEditsRemove": "編集を破棄して削除",
+          "discardEdits": "編集を破棄して再インストール",
+          "titleMore": "{{name}} +{{count}}",
+          "scopeGlobal": "すべて",
+          "installedOn": "{{date}} にインストール",
+          "stateEdited": "インストール後に編集済み",
+          "stateMissing": "ファイルがありません",
+          "skillEdited": "編集済み",
+          "versionCurrent": "{{date}}（インストール済み）",
+          "installElsewhere": "別の場所にインストール…"
+        },
+        "SkillDelete": {
+          "dismissResults": "閉じる",
+          "statusSkipped": "スキップ済み",
+          "confirmPermanent": "これを元に戻すことはできません。",
+          "placementJoin": " と ",
+          "reasonBundled": "Orca に同梱 — 復元されます",
+          "reasonPlugin": "プラグインがインストール — 代わりにプラグインを削除してください",
+          "reasonUnowned": "このスキルは Orca のスキルフォルダー外にあります — 保存場所で削除してください",
+          "reasonMissing": "このスキルはディスク上にもうありません",
+          "reasonStale": "一覧の読み込み後にこのスキルが変更されました — 更新して再試行してください",
+          "blockedLine": "{{count}} × {{reason}}",
+          "resultLine": "{{count}} × {{label}}",
+          "statusBusy": "ビジー — 別のスキル操作を実行中です",
+          "statusPartial": "一部削除 — 隠し名でディスク上に残っているファイルがあります",
+          "statusFailed": "失敗 — 何も変更されませんでした",
+          "statusDeleted": "削除済み",
+          "confirmHost": "{{host}} 上。",
+          "failed": "スキルを削除できませんでした",
+          "hostUnavailable": "選択したマシンに接続できませんでした。更新して再試行してください。",
+          "hostUnresolved": "これらのスキルを所有するマシンを特定中です。",
+          "hostUpdateRequired": "スキルを削除するには、選択したマシン上の Orca を更新してください。",
+          "nothingOne": "そのスキルはここからは削除できません。",
+          "nothingOther": "選択した {{count}} のスキルは、ここからはどれも削除できません。",
+          "placementSummaryParts": "{{roots}} 全体で {{parts}} を削除します。",
+          "retainedSource": "スキル自体は {{path}} に残ります。"
+        },
+        "SkillManagedInstallList": {
+          "86c76cb262": "{{count}} スキルバンドル"
+        },
+        "skill-install-progress-state": {
+          "currentSkill": "{{value1}} 中 {{value0}} をインストール中: {{value2}}…"
+        },
+        "SkillSharedLinkRow": {
+          "contentsUnavailable": "このリンクの内容を読み込めませんでした。",
+          "loading": "内容を読み込み中…",
+          "deleteFailed": "Orca はこれを Cloud から削除できませんでした。",
+          "deleted": "Cloud から削除しました",
+          "confirmDelete": "削除を確認",
+          "moreActions": "{{name}} のその他の操作",
+          "deletePackage": "Cloud から削除"
+        },
+        "SkillSharedLinksView": {
+          "loading": "共有リンクを読み込み中…",
+          "noMatches": "この検索に一致するリンクはありません。"
+        },
+        "SkillsSharedLinksHeader": {
+          "back": "スキルに戻る",
+          "backTooltip": "スキルに戻る · Esc",
+          "unlisted": "限定公開 — リンクを知っている人のみ開けます。"
+        },
+        "skillWarningPreview": {
+          "bundleDescription": "すべての警告レベルをカバーするプレビューバンドル。",
+          "instructionsOnlyDescription": "手順はすべて SKILL.md 内に記載。",
+          "supportingFilesDescription": "主要な手順以外の参照用読み取りファイルを含む。",
+          "runnableFilesDescription": "Agent がお客様の権限で実行する可能性のあるスクリプトを含む。",
+          "binaryFilesDescription": "不透明なアセットと実行可能バイナリを含む。"
         }
       },
       "sidebar": {
@@ -4183,7 +4942,8 @@
           "32a7256d85": "クローン",
           "69f5b5380d": "クローン作成中…",
           "cloneOnHostDescription": "Git URL を入力し、{{value0}} 上のクローン先を選択してください。",
-          "cloneParentFolder": "親フォルダー"
+          "cloneParentFolder": "親フォルダー",
+          "remoteCloneParentPlaceholder": "/home/user/projects"
         },
         "AutoRenameFailedDialog": {
           "aed1623b1e": "閉じる",
@@ -4304,7 +5064,8 @@
           "d36883e046": "キャンセル",
           "b79b39d865": "プロジェクトの削除",
           "removeDescriptionSsh": "この操作は {{name}} を Orca から削除するだけです。ファイルは {{host}} に残っており、その SSH ホストを再追加すれば復元できます。",
-          "removeDescriptionLocal": "この操作は {{name}} を Orca から削除するだけです。ファイルはディスクに残っています。"
+          "removeDescriptionLocal": "この操作は {{name}} を Orca から削除するだけです。ファイルはディスクに残っています。",
+          "removeDescriptionVmRecipe": "{{name}} を Orca から削除します。環境とそのファイルが完全に削除されるかどうかは、VM レシピによります。"
         },
         "ScrollToCurrentWorkspaceToolbarButton": {
           "23989bb663": "アクティブなワークスペースを表示する"
@@ -4407,7 +5168,9 @@
           "196c1b5362": "GitLab タスクを開く",
           "0ccba862b8": "GitHub タスクを開く",
           "fee535205b": "タスク",
-          "d599269755": "サイドバーから非表示"
+          "d599269755": "サイドバーから非表示",
+          "skills": "スキル",
+          "artifacts": "成果物"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "クリア",
@@ -4454,7 +5217,9 @@
           "cliCreated": "CLI が作成したものを非表示",
           "detachedHead": "分離 HEAD を非表示",
           "keepDefaultBranch": "デフォルトのブランチを除く",
-          "keepDefaultBranchAria": "スリープ中のワークスペースを非表示にしてもデフォルトのブランチは表示したままにする"
+          "keepDefaultBranchAria": "スリープ中のワークスペースを非表示にしてもデフォルトのブランチは表示したままにする",
+          "otherClients": "他のクライアントのワークスペースを非表示",
+          "otherClientsAria": "共有リモートサーバー上で他の Orca クライアントから作成されたワークスペースを非表示"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "Agent アクティビティのレイアウト",
@@ -4513,7 +5278,8 @@
           "219ebf1961": "ブランチ名",
           "automation": "オートメーション",
           "folderPathIdentity": "ブランチ / フォルダーパス",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "workspaceOptions": "ワークスペースのオプション"
         },
         "SshTargetRow": {
           "4677394048": "接続中…",
@@ -4630,7 +5396,8 @@
           "cliCreated": "Orca CLI が作成",
           "jiraIssue": "Jira {{value0}}",
           "viewOnJira": "Jira で表示",
-          "linkedJira": "リンク済み Jira {{value0}}"
+          "linkedJira": "リンク済み Jira {{value0}}",
+          "openInOrcaBrowser": "Orca ブラウザで開く"
         },
         "WorktreeCardMetadataStatusBadges": {
           "fe188062a1": "状態: オープン",
@@ -4680,7 +5447,10 @@
           "setParentWorkspace": "親ワークツリーを設定…",
           "workspaceSection": "ワークスペース",
           "primaryDeleteDisabled": "プライマリワークツリーは削除できません。代わりにプロジェクトを削除してください。",
-          "deleteWorktree": "ワークツリーを削除"
+          "deleteWorktree": "ワークツリーを削除",
+          "sleepWithDescendants": "子孫とともにスリープ（{{value0}}）",
+          "sleepWithDescendantsDescription": "このワークスペースとネストされたすべての子孫のアクティブなパネルを閉じて、メモリと CPU を解放します。",
+          "deleteWithDescendants": "子孫とともに削除…"
         },
         "WorktreeList": {
           "d880ea0744": "グループを作成し、このプロジェクトをそのグループに移動します。",
@@ -4724,7 +5494,9 @@
           "hostDisconnected": "切断済み",
           "failedNestWorkspace": "ワークスペースをネストできませんでした",
           "sidebarRowMissing": "対象はもう存在しません",
-          "failedUnnestWorkspace": "ワークスペースの展開に失敗しました"
+          "failedUnnestWorkspace": "ワークスペースの展開に失敗しました",
+          "groupRenameFailed": "グループ名の変更に失敗しました",
+          "groupRenameFailedDesc": "Orca はグループのホストで新規の名前を確認できませんでした。再接続後にグループを再確認してください。"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "キャンセル",
@@ -4745,7 +5517,12 @@
           "65770ad0f0": "このワークスペースの GitHub リンクとメモを編集します。",
           "382fd11a3e": "ワークツリーの詳細の編集",
           "2174f17011": "保存",
-          "61d6f612cf": "保存中…"
+          "61d6f612cf": "保存中…",
+          "a0d191b7a7": "このワークスペースの Issue リンク、PR リンク、メモを編集します。",
+          "gitlabDescription": "このワークスペースの Issue リンク、MR リンク、メモを編集します。",
+          "gitlabMR": "GitLab MR",
+          "gitlabPlaceholder": "MR ! または GitLab URL",
+          "gitlabHelp": "MR の URL を貼り付けるか、番号を入力します。リンクを解除するには空白のままにします。"
         },
         "WorktreeOpenInMenu": {
           "1417fd8380": "アプリをカスタマイズ…",
@@ -4871,7 +5648,8 @@
               "ae57cbf6e4": "ワークスペースの削除に失敗しました",
               "7488ed8711": "表示",
               "2b20ce87b3": "強制削除",
-              "4f3876c0f5": "強制削除に失敗しました"
+              "4f3876c0f5": "強制削除に失敗しました",
+              "workspaceListChanged": "ワークスペース一覧が変更されました"
             },
             "toast": {
               "1d0fa5c0a5": "ワークスペース {{value0}} の削除に失敗しました",
@@ -4879,7 +5657,10 @@
               "905fc8efac": "Git はこのワークスペースをすでに削除しています。 Orca から削除するには、強制削除を使用します。",
               "0899ebdb28": "Git はすでにこのワークスペースを忘れていますが、そのディレクトリはまだディスク上にあります。孤立したディレクトリを削除するには、強制削除を使用します。",
               "locked": "このワークスペースは Git によってロックされています。リポジトリで git worktree unlock <worktree-path> を実行してから、削除を再試行してください。",
-              "lockedReason": "このワークスペースは Git によってロックされています。Git の報告: {{value0}}。リポジトリで git worktree unlock <worktree-path> を実行してから、削除を再試行してください。"
+              "lockedReason": "このワークスペースは Git によってロックされています。Git の報告: {{value0}}。リポジトリで git worktree unlock <worktree-path> を実行してから、削除を再試行してください。",
+              "unstoppedPty": "Orca はこのワークスペースのすべてのターミナルが終了したか確認できなかったため、ファイルを削除する前に停止しました。そのまま削除するには強制削除を使用してください。",
+              "unstoppedPtyLive": "このワークスペースには実行中のターミナルがまだあるため、Orca はファイルを削除する前に停止しました。強制削除すると、それらを終了し、保持している未コミットの作業を破棄します。",
+              "runningAgentSession": "このワークスペースには実行中の Agent セッションがまだあるため、Orca はファイルを削除する前に停止しました。強制削除すると、それらを閉じ、保持している作業を破棄します。"
             }
           }
         },
@@ -5176,7 +5957,12 @@
         "NewExternalWorktreesInboxLine": {
           "9f2d4c8b17": "{{value0}} の外部ワークツリーを完全に非表示にする",
           "5e1b8d3f62": "外部ワークツリーを完全に非表示にする",
-          "c3e8a1f4b2": "今後表示しない"
+          "c3e8a1f4b2": "今後表示しない",
+          "2a6f31d8c7": "非表示のワークツリー",
+          "5b90e4a2f6": "非表示のワークツリー",
+          "7f18c5b0d3": "{{value1}} 内の非表示のワークツリー {{value0}} を確認",
+          "4e2b7a9c05": "{{value1}} 内の非表示のワークツリー {{value0}} を確認",
+          "6c07f3a91e": "{{value1}} 上の {{value0}}"
         },
         "NoticeHostGlyph": {
           "hostDisconnected": "{{hostName}} が切断されました",
@@ -5240,7 +6026,34 @@
           "linkDestination": "リンク先",
           "sshTunnel": "SSH トンネルを使用しています",
           "sshTunnelHelp": "それ以外の場合、このリンクはこのデバイス自身を指すため、もう一方のコンピュータを識別できません。",
-          "loopbackBlocked": "SSH トンネルの上書きを有効にするか、もう一方のホストの Tailscale または LAN アドレスを使って新規リンクを作成してください。"
+          "loopbackBlocked": "SSH トンネルの上書きを有効にするか、もう一方のホストの Tailscale または LAN アドレスを使って新規リンクを作成してください。",
+          "sshConfigPickerBack": "戻る",
+          "sshConfigPickerRetry": "再試行",
+          "sshAlreadyExists": "その SSH ホストはすでに Orca にあります。",
+          "sshConfigPickerLoadFailed": "~/.ssh/config を読み取れませんでした。",
+          "sshConfigPickerResolveFailed": "その SSH config ホストを解決できませんでした。",
+          "sshConfigPickerRestartRequired": "SSH config ピッカーの更新を適用するには、Orca を再起動してください。",
+          "sshConfigPickerFilled": "{{value0}} から入力しました。確認して保存してください。",
+          "sshConfigPickerTitle": "~/.ssh/config から選択",
+          "sshConfigPickerDescription": "ホストを選択してフォームに入力します。保存をクリックするまで何も保存されません。",
+          "sshConfigPickerFilter": "ホストでフィルター…",
+          "sshConfigPickerHostsLabel": "SSH config ホスト",
+          "sshConfigPickerLoading": "~/.ssh/config を読み取り中…",
+          "sshConfigPickerEmpty": "~/.ssh/config にホストがありません",
+          "sshConfigPickerNoMatch": "一致するホストがありません",
+          "sshConfigPickerEmptyHint": "そこに Host エントリを追加するか、戻って詳細を手入力してください。",
+          "sshConfigPickerNoMatchHint": "別のフィルターを試すか、戻って手入力してください。",
+          "sshConfigPickerMoreResults": "最初の {{value0}} の一致を表示しています。さらに見つけるにはフィルターを絞ってください。",
+          "sshConfigPickerInOrca": "Orca 内",
+          "sshConfigPickerPreviouslyRemoved": "Orca から削除済み",
+          "sshConfigPickerBulkHint": "一括同期は「設定」→「SSH」のままです",
+          "fillFromSshConfig": "~/.ssh/config から入力…",
+          "sshConfigPickerAddingAll": "ホストを追加中…",
+          "sshConfigPickerAddAll": "{{value0}} すべてを Orca に追加",
+          "sshConfigPickerNoNewHosts": "追加する新規ホストはありません",
+          "sshConfigPickerAddAllEmpty": "すべてを Orca に追加",
+          "identityFileFromConfigHint": "意図的に空にしています: Orca は {{value0}} に対して ~/.ssh/config が解決するすべてのキーを使用します。そのキーのみを使うにはパスを入力してください。",
+          "sshConfigPickerResolving": "読み取り中…"
         },
         "ForgetSshWorkspaceDialog": {
           "reconnectFailed": "再接続に失敗しました",
@@ -5273,6 +6086,86 @@
           "3b7ea51793": "検索をクリア",
           "7f1c2e94a5": "検索テキストが長すぎます — ボードは絞り込まれていません",
           "9a4d0f6b21": "長すぎます"
+        },
+        "WorktreeIssueLinkField": {
+          "25852bfc59": "Linear",
+          "5b440069e6": "GitHub",
+          "ad78f9bee2": "Issue",
+          "161b2d053a": "リンクされた Issue を開く",
+          "d4785f9954": "Issue リンクはフォルダーワークスペースの作成時に設定され、ここではまだ変更できません。",
+          "964d9bc00a": "Linear Issue キーまたは linear.app の Issue URL ではありません。",
+          "0a7a2c6efd": "GitHub Issue 番号または Issue URL ではありません。",
+          "72486800ff": "保存すると {{first}} と {{second}} のリンクが解除されます — ワークスペースが追跡する Issue は 1 件です。",
+          "2c245ac134": "保存すると {{link}} のリンクが解除されます — ワークスペースが追跡する Issue は 1 件です。",
+          "d8c8a30d1f": "その Issue を開けませんでした。識別子と Linear 接続を確認してください。",
+          "269198eeda": "その Issue を開けませんでした。番号と GitHub 接続を確認してください。",
+          "f047887705": "GitHub または Linear の URL を貼り付けるか、番号を入力します。リンクを解除するには空白のままにします。",
+          "662ae142f8": "Issue #、または GitHub ・ Linear の URL",
+          "929c98d05a": "Issue プロバイダー"
+        },
+        "WorktreeCardSshHostControl": {
+          "connectFailed": "SSH 接続に失敗しました",
+          "connectedTooltip": "SSH ホスト上のプロジェクト",
+          "removedTooltip": "SSH ホストが削除されました — 再接続できません",
+          "removedName": "SSH ホスト {{value0}} は削除されました",
+          "connectedName": "SSH ホスト {{value0}} 上のプロジェクト",
+          "connectingName": "SSH ホスト {{value0}} に接続中",
+          "authFailedName": "SSH ホスト {{value0}} に再接続 — 認証に失敗しました",
+          "retryName": "{{value0}} への SSH 接続を再試行",
+          "connectName": "SSH ホスト {{value0}} に接続",
+          "authFailedTooltip": "{{value0}} · 認証に失敗しました",
+          "failedTooltip": "{{value0}} · 接続に失敗しました"
+        },
+        "PreservedBranchBatchReviewDialog": {
+          "38c947f7c5": "すべて選択",
+          "285e1e4882": "キャンセル",
+          "c4bf8e7eaf": "保持されたブランチを確認",
+          "f21976c9a8": "強制削除するローカルブランチを選択してください。選択されていないブランチはリポジトリに残ります。",
+          "9602129d38": "{{value1}} 中 {{value0}} を選択中",
+          "ee39e872d5": "未マージの可能性あり",
+          "676db406fd": "Head を利用できません",
+          "a0f9863597": "{{count}} のブランチを強制削除",
+          "a0f9863597_one": "{{count}} のブランチを強制削除",
+          "a0f9863597_other": "{{count}} のブランチを強制削除"
+        },
+        "worktreeIssueDisplacement": {
+          "3f61c0a8d2": "Linear {{value}}",
+          "9c4b7e1f60": "GitHub #{{value}}"
+        },
+        "preserved": {
+          "branch": {
+            "batch": {
+              "toast": {
+                "a3cdd9d9e6": "Git は、マージされていないコミットを含む可能性があるため、{{count}} のローカルブランチを保持しました。保持されたブランチにワークスペースフォルダーは残りませんが、コミットはリポジトリに残ります。Orca はバックグラウンドでワークスペースのディスク領域の解放を続ける場合があります。",
+                "a3cdd9d9e6_one": "Git は、マージされていないコミットを含む可能性があるため、{{count}} のローカルブランチを保持しました。保持されたブランチにワークスペースフォルダーは残りませんが、コミットはリポジトリに残ります。Orca はバックグラウンドでワークスペースのディスク領域の解放を続ける場合があります。",
+                "a3cdd9d9e6_other": "Git は、マージされていないコミットを含む可能性があるため、{{count}} のローカルブランチを保持しました。保持されたブランチにワークスペースフォルダーは残りませんが、コミットはリポジトリに残ります。Orca はバックグラウンドでワークスペースのディスク領域の解放を続ける場合があります。",
+                "6310412304": "{{count}} のブランチを確認",
+                "6310412304_one": "{{count}} のブランチを確認",
+                "6310412304_other": "{{count}} のブランチを確認",
+                "cea24c2b7d": "{{count}} のワークスペースを削除しました",
+                "cea24c2b7d_one": "{{count}} のワークスペースを削除しました",
+                "cea24c2b7d_other": "{{count}} のワークスペースを削除しました",
+                "0e0379f24a": "{{count}} のブランチを保持しました",
+                "0e0379f24a_one": "{{count}} のブランチを保持しました",
+                "0e0379f24a_other": "{{count}} のブランチを保持しました",
+                "4cf75caab7": "{{value0}}、{{value1}}",
+                "e61d78054f": "ローカルブランチを削除中: {{value0}}",
+                "1e1a5f6763": "ローカルブランチを削除しました: {{value0}}",
+                "43d9395605": "{{value0}} を削除、{{value1}} は未削除",
+                "d42f1f14e0": "{{count}} のブランチを再試行",
+                "d42f1f14e0_one": "{{count}} のブランチを再試行",
+                "d42f1f14e0_other": "{{count}} のブランチを再試行"
+              }
+            }
+          }
+        },
+        "WorktreeListScrollToTopButton": {
+          "jumpToTop": "トップへ移動"
+        },
+        "RepoScanUnavailableIndicator": {
+          "title": "{{value0}} のワークツリースキャンに失敗しました",
+          "retry": "スキャンを再試行",
+          "retained": "スキャンが成功するまで、既存のワークツリーは保持されます。クリックして再試行します。"
         }
       },
       "shared": {
@@ -5451,7 +6344,25 @@
           "codexConfigSyncMissingSource": "{{value0}} が見つからないため、Codex は最後に同期した設定を使い続けています。同期を再開するには、そのファイルを復元してください。",
           "codexConfigSyncBlankSource": "{{value0}} が空のため、Codex は最後に同期した設定を使い続けています。同期フォルダーのダウンロードが完了するまでは正常な状態です。",
           "codexConfigSyncManagedHomeUnavailable": "Orca は現在このアカウントの Codex ファイルを読み取れないため、設定が同期されていない可能性があります。ウイルス対策ソフトやバックアップツールによる一時的なロックが原因で、通常は自動的に解消されます。",
-          "codexConfigSyncUnreadableSource": "{{value0}} を読み取れなかったため、Codex は最後に同期した設定を使い続けています。そのファイルの権限を確認してください。"
+          "codexConfigSyncUnreadableSource": "{{value0}} を読み取れなかったため、Codex は最後に同期した設定を使い続けています。そのファイルの権限を確認してください。",
+          "d6f1b9b6a2": "MiniMax API キーが必要です。",
+          "7c5d8a4e1b": "MiniMax API キーは保存されませんでした。",
+          "4d2c7b9e83": "MiniMax API キーを保存しました。",
+          "f8a4b9d210": "MiniMax エンドポイント",
+          "0b3a9f6c2e": "アカウントに合ったホストを選択してください。海外版（platform.minimax.io）と中国版（platform.minimaxi.com）のどちらも、セッション Cookie または API キーのいずれかに対応しています。",
+          "83b6a1f7c4": "MiniMax API キー",
+          "4f2c8a7e1b": "MiniMax API キーを貼り付け",
+          "a7b1e3c5d2": "キーを削除",
+          "usageTracking": "アカウントの MiniMax 使用状況トラッキングを設定します。",
+          "credentialsNotSet": "認証情報が未設定です",
+          "selectedEndpointStorage": "ローカルに保存され、使用状況の更新のために選択した MiniMax エンドポイントに送信されます。",
+          "endpointOverseas": "海外版（platform.minimax.io）",
+          "endpointChina": "中国版（platform.minimaxi.com）",
+          "openSelectedConsole": "{{url}} をブラウザで開いてサインインします。",
+          "cookieSelectedEndpoint": "ローカルに保存され、使用状況の更新のために選択した MiniMax エンドポイントに送信されます。",
+          "copySelectedConsoleCookie": "選択したコンソールを開いてサインインし、DevTools（Network → 任意のリクエスト → Cookie）から Cookie リクエストヘッダーをコピーします。",
+          "apiKeySelectedEndpoint": "MiniMax コンソール → API キーから API キーを貼り付けます。ローカルに保存され、使用状況の更新のために選択した MiniMax エンドポイントに送信されます。API キーは Cookie より優先されます。",
+          "apiKeyInstructions": "MiniMax コンソール → API キーから API キーをコピーします。保存済み API キーは Cookie より優先されます。Cookie に戻すには「キーを削除」を使います。"
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",
@@ -5491,7 +6402,10 @@
           "5f818f12ab": "準備中…",
           "4c05b9d7cb": "セットアップ用ターミナルを準備しています。",
           "installLabel": "インストール",
-          "updateLabel": "更新"
+          "updateLabel": "更新",
+          "retrySetup": "再試行",
+          "setupCommandFailed": "セットアップコマンドはコード {{value0}} で終了しました。このエラーは、再試行が成功すると消えます。",
+          "setupFailed": "セットアップに失敗しました"
         },
         "AgentsPane": {
           "d83834f5e6": "インストールされている Agent を検出しています…",
@@ -5540,7 +6454,9 @@
           "03e1a5081a": "{{value0}} 上",
           "25a41a9aad": "アクティブなサーバーにインストールされている Agent を再検出",
           "remoteDetectionFailed": "インストールされている Agent を検出できませんでした。ホストへの接続を確認して、もう一度お試しください。",
-          "retryDetection": "再試行"
+          "retryDetection": "再試行",
+          "storedDefaultUndetected": "デフォルトとして保存されていますが、現在は検出されません",
+          "noAgentsDetected": "Agent が検出されません。インストール済みの場合は、プローブがタイムアウトした可能性があります。"
         },
         "AppIconSelector": {
           "d5a112dc9b": "次へのアイコン",
@@ -5713,7 +6629,8 @@
           "b4c167764d": "ファイルから {{value0}} 個の Cookie を {{value1}} にインポートしました。",
           "a3f8c2d1e0b4": "{{value1}} ({{value2}}) から {{value0}} 件の Cookie を {{value3}} にインポートしました。",
           "b4e9d3f2a1c5": "{{value1}} から {{value0}} 件の Cookie を {{value2}} にインポートしました。",
-          "c5a273a809": "{{value0}} から"
+          "c5a273a809": "{{value0}} から",
+          "b5c0479e21": "未変更のユーザー Agent"
         },
         "BrowserUseComputerUseNotice": {
           "15b5e680ba": "コンピュータ操作を開く",
@@ -5800,7 +6717,9 @@
           "14444243ba": "PATH から {{value0}} を削除しますか?",
           "5d432fe44d": "インストール済み",
           "8a9b784c60": "古い",
-          "d363e5929b": "CLI の登録を確認しています…"
+          "d363e5929b": "CLI の登録を確認しています…",
+          "installFailureUnknownReason": "Orca は CLI 登録を完了できず、理由も報告されませんでした。",
+          "installFailureConflictRemedy": "{{value0}} を削除し、不要であれば再度登録してください。"
         },
         "CliSkillRuntimeSetup": {
           "04325573f8": "WSL",
@@ -5878,7 +6797,10 @@
           "6b5a2cd3a5": "アクセシビリティ",
           "6b17602073": "アクセスをリセットする",
           "506f2acf7a": "アクセスをリセットしています…",
-          "4b65070096": "darwin"
+          "4b65070096": "darwin",
+          "statusGranted": "許可済み",
+          "statusUnsupported": "macOS のみ",
+          "statusNotEnabled": "有効になっていません"
         },
         "DeveloperPermissionsPane": {
           "4c17304beb": "更新",
@@ -5907,7 +6829,39 @@
           "e5b5f3d6b9": "カメラ",
           "cc8151d9fa": "音声入力、文字起こし、オーディオ録音、sox、ffmpeg、および Whisper CLI。",
           "16381e040a": "マイクロフォン",
-          "dac08ec03e": "処理中…"
+          "dac08ec03e": "処理中…",
+          "actionOpenSettings": "設定を開く",
+          "statusGranted": "許可済み",
+          "statusRestricted": "制限付き",
+          "localNetworkOpenSettings": "システム設定を開く",
+          "localNetworkOpenSystemSettings": "システム設定を開く",
+          "connectionTestHost": "ホスト",
+          "connectionTestPort": "ポート",
+          "connectionTestRunning": "テスト中…",
+          "connectionTestAction": "テスト接続",
+          "actionRequest": "リクエスト",
+          "actionTriggerPrompt": "プロンプトを起動",
+          "statusDenied": "拒否",
+          "statusNotRequested": "未リクエスト",
+          "statusUnsupported": "macOS のみ",
+          "statusEntitled": "付与済み",
+          "statusCheckManually": "手動で確認",
+          "actionRequestAccess": "アクセスをリクエスト",
+          "localNetworkPromptCheck": "macOS プロンプトを確認",
+          "localNetworkPromptGuidance": "プロンプトが表示されたら「許可」を選択します。表示されない場合は、システム設定を開き、「プライバシーとセキュリティ」→「ローカルネットワーク」で Orca を有効にします。",
+          "openSettingsFailed": "システム設定を開けませんでした",
+          "statusManagedByMacOS": "macOS が管理",
+          "connectionTestInvalidTarget": "ホスト名またはプライベート LAN IP と、1〜65535 のポートを入力してください。",
+          "connectionTestTimeout": "接続がタイムアウトしました。対象、サービス、macOS ローカルネットワーク設定を確認してください。",
+          "connectionTestRefused": "ホストは応答しましたが、ポートが接続を拒否しました。",
+          "connectionTestUnreachable": "対象に到達できませんでした。",
+          "connectionTestUnresolved": "ホスト名を解決できませんでした。",
+          "connectionTestUnsupported": "接続テストは macOS デスクトップアプリで利用できます。",
+          "connectionTestFailed": "接続テストを完了できませんでした。",
+          "connectionTestTitle": "接続をテスト",
+          "connectionTestDescription": "ローカルネットワーク上の別デバイスのサービスを入力します。Orca はターミナルツールと同じネットワーク経路をテストします。",
+          "connectionTestLastVerified": "最終確認",
+          "connectionTestNotYetVerified": "成功したテストは保存されていません。"
         },
         "ExperimentalPane": {
           "9762364929": "可能な場合は macOS で APFS clone-copy を使用し、それ以外の場合は設定済みのフォルダーまたはファイルを作成済みワークツリーへシンボリックリンクします。",
@@ -5946,7 +6900,11 @@
             "defaultCopy": "対応 Agent の新規ターミナルタブを開く方法を選択します。",
             "defaultViewLabel": "デフォルトの Chat UI ビュー",
             "defaultViewTerminal": "ターミナルチャット",
-            "defaultViewNative": "Chat UI"
+            "defaultViewNative": "Chat UI",
+            "structuredTitle": "更新された構造化ネイティブチャットを使用",
+            "structuredCopy": "Codex と Claude 向けに、ホスト所有の構造化チャットランタイムを試します。オフのままにすると、既存のターミナルベースのチャット経路を使います。",
+            "structuredScope": "当面はローカルセッションのみ。WSL とリモート実行ホスト（SSH を含む）では引き続きターミナルチャットを使用し、Orca がプロセス開始時刻を読み取れない限り Windows でもフォールバックします。",
+            "structuredToggleLabel": "更新された構造化ネイティブチャットを切り替え"
           },
           "agentDashboard": {
             "title": "Agent ダッシュボード",
@@ -6015,7 +6973,9 @@
           "b82f86d7d2": "リッチ Markdown のスペルチェック",
           "5195f0b9ef": "リッチ Markdown の編集中に、ブラウザのスペルミス下線と修正候補を表示します。",
           "7ddd66fede": "エディターのワードラップ",
-          "9b18de6eea": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。"
+          "9b18de6eea": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。",
+          "f1b3ceeb98": "差分の空白表示",
+          "94a479cef3": "差分内の先頭・末尾の空白の差異を表示します。"
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",
@@ -6078,7 +7038,8 @@
           "31fd7150cf": "アップデートをチェックしています…",
           "3394d1f663": "チェック中",
           "d69a09b672": "アップデートは起動時に自動的にチェックされます。",
-          "7173352632": "idle"
+          "7173352632": "idle",
+          "e3b9d21c07": "が利用可能です。システムのパッケージマネージャーから Orca を更新してください。Orca 自体ではこのリリースをインストールできません。"
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "ワークスペースの「開く」メニューから利用可能なアプリを選択します。",
@@ -6099,7 +7060,10 @@
           "externalWorktrees": "外部ワークツリー",
           "externalWorktreesDescription": "Orca 外で作成されたワークツリーをデフォルトで表示するかどうかを選択します。",
           "show": "表示",
-          "hide": "非表示"
+          "hide": "非表示",
+          "31e300af1c": "成果物の削除前に確認",
+          "fb29a73a17": "共有された成果物を削除して公開リンクを無効にする前に、確認ダイアログを表示します。",
+          "bf46474e33": "共有された成果物を削除する前に確認を表示します。公開リンクを持つ人はアクセスできなくなります。"
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "変更を適用する",
@@ -6439,7 +7403,11 @@
           "1b1b70279a": "まだデバイスがペアリングされていません。",
           "1592afcc7a": "まだデバイスがペアリングされていません。 Orca モバイルアプリで QR コードをスキャンします。",
           "relayDegradedNotice": "Relay に接続できませんでした — このコードは LAN または Tailscale でのみ動作します。再生成してからお試しください。",
-          "pairingQrError": "このペアリングコードを QR コードとして表示できませんでした。代わりに Orca Mobile にコピーしてください。"
+          "pairingQrError": "このペアリングコードを QR コードとして表示できませんでした。代わりに Orca Mobile にコピーしてください。",
+          "copyPairingCode": "ペアリングコードをコピーする",
+          "pairingCodeReady": "ペアリングコードの準備完了",
+          "diagnosticsCopied": "診断情報をコピーしました",
+          "diagnosticsCopyFailed": "診断情報のコピーに失敗しました"
         },
         "MobileSettingsPane": {
           "9a3c280e49": "GitHub リリース",
@@ -6530,7 +7498,9 @@
           "9bedd2a6e5": "Agent がコンテキストを引き継ぎ、Orca を通じて作業を調整できるようにします。",
           "07641b9768": "オーケストレーションスキル",
           "2aacdb0517": "ハンドオフ、ワークツリーのハンドオーバー、および子 Agent の作業全体にわたってコーディング Agent を調整します。",
-          "191ac34567": "Agent オーケストレーション"
+          "191ac34567": "Agent オーケストレーション",
+          "nestedWorkerDepthTitle": "ネストされたワーカーの深さ",
+          "nestedWorkerDepthDescription": "ディスパッチされたワーカーが何世代まで自分のワーカーを生成できるか。1 にすると Agent ツリーはフラットになります: コーディネーターがワーカーをディスパッチし、そのワーカーはディスパッチしません。"
         },
         "OrchestrationSetupCard": {
           "e7d2a5146c": "Agent がコンテキストを引き継ぎ、Orca を通じて作業を調整できるようにします。",
@@ -6539,7 +7509,13 @@
         "OrchestrationSkillAgentCoverage": {
           "6dec5ce2d2": "Agent の範囲",
           "ffe13e36fb": "不足",
-          "1e8f8d8fae": "準備完了"
+          "1e8f8d8fae": "準備完了",
+          "checking": "インストール済み Agent とスキルパスを確認中…",
+          "noAgents": "PATH 上に Agent CLI が検出されません。「設定」→「Agent」で Agent をインストールしてから、再確認してください。",
+          "fullCoverage_one": "検出された 1 の Agent すべてにスキルがあります。",
+          "fullCoverage_other": "検出された {{value0}} の Agent すべてにスキルがあります。",
+          "noCoverage": "上記のスキルをインストールしてから、再確認してください。",
+          "partialCoverage": "検出された {{value1}} の Agent のうち {{value0}} にスキルがあります。"
         },
         "OrchestrationSkillPromptDialog": {
           "f08d45293d": "コマンドをコピー",
@@ -6607,7 +7583,13 @@
           "8d525e5f15": "コピーしました",
           "53b17a4b1b": "コピーできませんでした",
           "a9a564b7e7": "{{value0}} をコピー",
-          "69a1441a21": "コピーする内容がありません"
+          "69a1441a21": "コピーする内容がありません",
+          "7ecfee5b8e": "再試行",
+          "89f7e57fcc": "保存先",
+          "d59bd333c3": "クイックコマンドを管理するには、この Orca サーバーを更新してください。",
+          "f2bf411640": "このホストからコマンドを読み込めませんでした。",
+          "601d6af51f": "コマンドを読み込み中…",
+          "923ba89646": "このホストからコマンドを更新できませんでした。最後に読み込んだコマンドを表示しています。"
         },
         "RecentTabOrderControl": {
           "3b17c81ede": "タブストリップの順序",
@@ -6805,7 +7787,9 @@
           "show": "表示",
           "hide": "非表示",
           "externalWorktreesGlobal": "グローバルデフォルト: {{value0}}",
-          "useGlobal": "グローバル設定を使用"
+          "useGlobal": "グローバル設定を使用",
+          "hostStateWorkspaceWindowClosed": "ワークスペースウィンドウを閉じました",
+          "hostWorkspaceWindowClosedHelp": "サーバーには到達できますが、その Orca ウィンドウが閉じています。このセットアップを使うには、{{value0}} 上で Orca を開いてください。"
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "コマンドテンプレート",
@@ -6960,7 +7944,11 @@
           "troubleshootStepRegenerate": "新規アクセスリンクを生成し、ここでは最新のリンクだけを使います。",
           "troubleshootTunnel": "SSH ローカルフォワードを使う場合は、「ホストに接続」に戻ってループバックリンクを貼り付け、「詳細」で「SSH トンネルを使用しています」を有効にします。",
           "cloudVmWorkflow": "クラウド VM",
-          "cloudVmWorkflowHelp": "レシピで作成したクラウドマシンを管理"
+          "cloudVmWorkflowHelp": "レシピで作成したクラウドマシンを管理",
+          "serverReconnecting": "再接続中",
+          "serverWorkspaceWindowClosed": "ワークスペースウィンドウを閉じました",
+          "serverRuntimeUnavailable": "Orca を利用できません",
+          "serverRuntimeUnavailableDescription": "SSH トランスポートは接続されていますが、Orca ランタイムが応答しませんでした。ホストは実行中の可能性があります。"
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "{{value0}}をコピー"
@@ -7241,7 +8229,8 @@
           "4db9afce1c": "ポートは 1 ～ 65535 でなければなりません",
           "0e5aa04161": "ホストまたは SSH 構成エイリアスが必要です",
           "f1fc50dad2": "SSH ターゲットのロードに失敗しました",
-          "0cda732f43": "接続テストに失敗しました"
+          "0cda732f43": "接続テストに失敗しました",
+          "terminateUnverifiable": "{{terminals}} のリモートターミナルに接続できませんでした。終了するには再接続してください。"
         },
         "SshPassphraseDialog": {
           "d5a234456f": "キャンセル",
@@ -7256,7 +8245,11 @@
           "8a349e3fac": "{{value0}} のパスフレーズ",
           "cab3d5f5a5": "{{value0}} のパスワード",
           "1f3dde805d": "SSH キーのパスフレーズ",
-          "106bd57f4a": "SSH パスワード"
+          "106bd57f4a": "SSH パスワード",
+          "c624f64b86": "続行",
+          "a21f9e74c0": "SSH 検証",
+          "981352fb42": "の検証チャレンジを完了してください",
+          "456516603b": "応答を入力"
         },
         "SshTargetCard": {
           "ec6543cee9": "接続",
@@ -7732,7 +8725,12 @@
             "d2c6a0e8f1": "grok",
             "c1b5f9d7e0": "xai",
             "b0a4e8c6d9": "認証",
-            "a9f3d7b5c8": "ログイン"
+            "a9f3d7b5c8": "ログイン",
+            "d16378a88f": "minimax",
+            "3a9b6d2c4e": "APIキー",
+            "b2c4e7f1a8": "エンドポイント",
+            "5d8f1a3b7c": "中国",
+            "7e2a4b8c1d": "海外"
           }
         },
         "advanced": {
@@ -7811,7 +8809,16 @@
             "agentPermissions": "Agent の権限",
             "agentPermissionsDescription": "Agent の権限の既定値を Yolo と Manual で切り替えます。",
             "agentRuntime": "Agent のランタイム",
-            "agentRuntimeDescription": "デフォルトで Agent を Windows または WSL のどちらで検出および起動するかを選択します。"
+            "agentRuntimeDescription": "デフォルトで Agent を Windows または WSL のどちらで検出および起動するかを選択します。",
+            "runtime": "ランタイム",
+            "permissions": "権限",
+            "skip": "スキップ",
+            "checks": "チェック",
+            "agentLocation": "Agent の実行場所",
+            "installedAgentsWsl": "WSL にインストール済みの Agent",
+            "permission": "権限",
+            "yolo": "YOLO",
+            "manual": "手動"
           }
         },
         "appearance": {
@@ -7932,7 +8939,11 @@
             },
             "leftSidebarAppearance": {
               "title": "左サイドバーの外観",
-              "description": "左サイドバーをターミナルに合わせるか、既定のままにするか、色合いを加えます。"
+              "description": "左サイドバーをターミナルに合わせるか、既定のままにするか、色合いを加えます。",
+              "project": "プロジェクト",
+              "terminal": "ターミナル",
+              "background": "背景",
+              "tint": "色合い"
             },
             "workspaceCardLayout": {
               "title": "ワークスペースカードのレイアウト",
@@ -7949,7 +8960,15 @@
             "4d5b9427b5": "有効にすると、ウィンドウを閉じても Orca は終了せず、システムトレイで実行を続けます。",
             "showPinnedWorktreesInGroups": {
               "title": "ピン留めしたワークツリーを元のリストにも表示",
-              "description": "ピン留めしたワークツリーを Pinned に残したまま、すべて、プロジェクト、ステータス、PR にも表示します。"
+              "description": "ピン留めしたワークツリーを Pinned に残したまま、すべて、プロジェクト、ステータス、PR にも表示します。",
+              "worktree": "ワークツリー",
+              "workspace": "ワークスペース",
+              "all": "全て",
+              "project": "プロジェクト",
+              "status": "状態",
+              "pr": "PR",
+              "pinned": "ピン留め",
+              "duplicate": "重複"
             },
             "antigravityUsageTitle": "Antigravity の使用状況",
             "antigravityUsageDescription": "ステータスバーに Antigravity サブスクリプションの使用量を表示します。",
@@ -7959,7 +8978,15 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "使用率",
-            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。"
+            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。",
+            "tray": {
+              "close": "閉じる",
+              "background": "背景",
+              "tray": "トレイ",
+              "system": "システムトレイ",
+              "minimize": "最小化",
+              "notification": "通知領域"
+            }
           }
         },
         "auto": {
@@ -8045,7 +9072,35 @@
             "a942905148": "新規ブラウザタブを作成するときに開かれる URL。空白のタブを開くには、空白のままにします。",
             "c3903322d2": "デフォルトのホームページ",
             "19ea5607cf": "ローカルホストのワークツリーのラベル",
-            "4e0fdf0a3f": "ワークスペースポートをワークツリー固有の Orca localhost URL として開くと、ブラウザのタブを区別しやすくなります。"
+            "4e0fdf0a3f": "ワークスペースポートをワークツリー固有の Orca localhost URL として開くと、ブラウザのタブを区別しやすくなります。",
+            "terminalLinkActions": {
+              "terminal": "ターミナル",
+              "menu": "メニュー",
+              "disable": "無効化",
+              "chat": "チャット",
+              "click": "クリック",
+              "actions": "操作",
+              "popover": "ポップオーバー"
+            },
+            "6f5199381e": "ポート",
+            "8f036ea11f": "ワークツリー",
+            "a8c55c9c91": "ファビコン",
+            "660c1dd007": "ラベル",
+            "clientHostedRemote": {
+              "remote": "リモート",
+              "client": "クライアント",
+              "host": "ホスト",
+              "desktop": "デスクトップ",
+              "placement": "配置"
+            },
+            "sshWorkspaceRouting": {
+              "ssh": "ssh",
+              "proxy": "プロキシ",
+              "routing": "ルーティング",
+              "network": "ネットワーク",
+              "tunnel": "トンネル"
+            },
+            "c4e3bf3282": "タブ"
           },
           "use": {
             "search": {
@@ -8252,12 +9307,26 @@
             "nativeChat": {
               "title": "Chat UI",
               "description": "対応 Agent のターミナルセッション用デスクトップチャット画面をプレビューします。",
-              "grok": "grok"
+              "grok": "grok",
+              "native": "ネイティブ",
+              "claude": "claude",
+              "codex": "codex",
+              "openclaude": "openclaude",
+              "omp": "omp",
+              "terminal": "ターミナル",
+              "agent": "Agent",
+              "chat": "チャット"
             },
             "agentDashboard": {
               "title": "Agent ダッシュボード",
               "description": "ワークツリー Agent を監視するカンバンボード。ウィンドウ内またはポップアウトで表示できます。",
-              "dashboard": "ダッシュボード"
+              "dashboard": "ダッシュボード",
+              "agent": "Agent",
+              "board": "ボード",
+              "worktrees": "ワークツリー",
+              "kanban": "カンバン",
+              "popout": "ポップアウト",
+              "inWindow": "ウィンドウ内"
             }
           }
         },
@@ -8429,7 +9498,24 @@
             "editorFontFamily": "エディターフォント",
             "editorFontFamilyDesc": "ファイルエディターと差分ビューで使用されるフォント。空の場合はターミナルフォントに従います。",
             "externalWorktrees": "外部ワークツリー",
-            "externalWorktreesDescription": "Orca 外で作成されたワークツリーをデフォルトで表示するかどうかを選択します。"
+            "externalWorktreesDescription": "Orca 外で作成されたワークツリーをデフォルトで表示するかどうかを選択します。",
+            "editorFontKw": "フォント",
+            "runtime": "ランタイム",
+            "wsl": "wsl",
+            "distro": "ディストリビューション",
+            "externalKeyword": "外部",
+            "sidebar": "サイドバー",
+            "afa37a34e1": "閉じる",
+            "f96cdaf37d": "スペルチェック",
+            "a51d23f4a1": "スペルチェック",
+            "641358460a": "スペル",
+            "d755962089": "赤い下線",
+            "projectRuntime": "プロジェクトのランタイム",
+            "windowsHost": "Windows ホスト",
+            "execution": "実行",
+            "visibility": "可視性",
+            "867dddea41": "ピン留め",
+            "5250cf0e48": "ピン"
           }
         },
         "git": {
@@ -8483,7 +9569,8 @@
             "defaultCompareBase": "既定の比較ベース",
             "defaultBranch": "デフォルトブランチ",
             "repositoryDefault": "リポジトリ既定",
-            "branchUpstream": "ブランチ upstream"
+            "branchUpstream": "ブランチ upstream",
+            "diffBase": "差分ベース"
           }
         },
         "input": {
@@ -8540,7 +9627,9 @@
             "41ccade05c": "gh",
             "b79c21bd42": "GitHub",
             "7166b9090c": "gh CLI を介した GitHub 認証。",
-            "f16e41cc72": "GitHub 連携"
+            "f16e41cc72": "GitHub 連携",
+            "760e2446e0": "保存済み API トークンまたは環境変数による Bitbucket Cloud 認証。",
+            "af5ae87847": "アクセストークン"
           }
         },
         "jira": {
@@ -8569,7 +9658,9 @@
               "d5c5b47bb9": "更新",
               "fb854902d9": "接続する",
               "9a9f8d4910": "Jira Cloud に接続して、Issue を参照、作成、リンクします。",
-              "74f3063026": "{{value0}} サイト{{value1}} が接続されました"
+              "74f3063026": "{{value0}} サイト{{value1}} が接続されました",
+              "statusConnected": "接続済み",
+              "statusNotConnected": "未接続"
             }
           }
         },
@@ -8674,7 +9765,13 @@
               "1de96ec8a6": "Orca Mobile ボタンを表示",
               "682293cadf": "左サイドバー上部に Orca Mobile ボタンを表示します。",
               "e4f4daea0e": "リレー",
-              "5d5af8e041": "iPhone"
+              "5d5af8e041": "iPhone",
+              "74618577c7": "モバイル",
+              "5e5b8878bf": "スマートフォン",
+              "5bff6a2ef0": "サイドバー",
+              "6cf5f54ce1": "ボタン",
+              "648eeada79": "非表示",
+              "ac79fe4a04": "表示"
             }
           }
         },
@@ -8917,7 +10014,25 @@
             "externalWorktreesDescription": "このプロジェクトで Orca 外のワークツリーを表示するかどうかを上書きします。",
             "copy": "コピー",
             "clone": "clone",
-            "apfs": "apfs"
+            "apfs": "apfs",
+            "external": "外部",
+            "sidebar": "サイドバー",
+            "upstream": "upstream",
+            "origin": "origin",
+            "defaultBranch": "デフォルトブランチ",
+            "runtime": "ランタイム",
+            "wsl": "wsl",
+            "distro": "ディストリビューション",
+            "waitForSetupBeforeAgent": "Agent 開始前にセットアップを待機",
+            "visibility": "可視性",
+            "fork": "フォーク",
+            "syncFork": "フォークを同期",
+            "fastForward": "fast-forward",
+            "behindUpstream": "upstream より遅れ",
+            "execution": "実行",
+            "windowsHost": "Windows ホスト",
+            "agentRuntime": "Agent ランタイム",
+            "skillRuntime": "スキルランタイム"
           }
         },
         "runtime": {
@@ -8956,7 +10071,8 @@
             "7e3fc707aa": "ターミナル",
             "0ecba9aa5f": "キーボード",
             "ebd7d81e1d": "ショートカットが重なった場合に、Orca とフォーカスされたターミナルのどちらが優先されるかを選択します。",
-            "f052906167": "ターミナルのショートカット"
+            "f052906167": "ターミナルのショートカット",
+            "groupShortcut": "{{value0}} のショートカット"
           }
         },
         "ssh": {
@@ -9028,7 +10144,9 @@
               "c38c18be15": "選択",
               "797fdfe4ca": "選択する",
               "603818e8d8": "ターミナルの選択が行われるとすぐに、その選択内容をクリップボードに自動的にコピーします。",
-              "3bdc84f059": "選択時にコピー"
+              "3bdc84f059": "選択時にコピー",
+              "grok": "grok",
+              "zellij": "zellij"
             }
           },
           "search": {
@@ -9222,6 +10340,34 @@
               "title": "テーマモード",
               "keyword_target": "対象",
               "keyword_editing": "編集"
+            },
+            "39ea7c0d28": "ターミナル",
+            "scroll": "スクロール",
+            "tui": "トゥイ",
+            "a0c44061ee": "確認",
+            "close_terminal": "閉じる",
+            "running": "実行中",
+            "command": "コマンド",
+            "agent": "Agent",
+            "prompt": "プロンプト",
+            "scrolling": "スクロール",
+            "speed": "速度",
+            "wheel": "ホイール",
+            "trackpad": "トラックパッド",
+            "process": "プロセス",
+            "stop": "停止",
+            "minimumContrast": {
+              "title": "色のコントラスト",
+              "description": "テキストの可読性を向上させるか、ターミナルプログラムが選んだ色を保持します。",
+              "contrast": "コントラスト",
+              "minimum": "最小",
+              "ratio": "比率",
+              "readability": "可読性",
+              "wcag": "WCAG",
+              "powerline": "Powerline",
+              "statusline": "ステータスライン",
+              "dim": "減光",
+              "colors": "色"
             }
           },
           "windows": {
@@ -9286,7 +10432,13 @@
               "20574cbc72": "音声ディクテーションを有効にする",
               "322d457a0d": "転写",
               "dcc7846641": "クラウド音声テキスト変換モデルに使用される OpenAI API キーを構成します。",
-              "ebfd0b32e5": "OpenAI 文字起こし"
+              "ebfd0b32e5": "OpenAI 文字起こし",
+              "microphoneTitle": "マイクロフォン",
+              "micInput": "入力",
+              "micDevice": "デバイス",
+              "microphoneDescription": "音声ディクテーションが使用する入力デバイスを選択します。",
+              "micAirpods": "AirPods",
+              "micDefault": "システムデフォルト"
             }
           }
         },
@@ -9315,7 +10467,9 @@
           "e5995ce268": "Agent 作業中はコンピュータを起きたままにする",
           "95d3031db2": "Agent が作業している間、このコンピュータとディスプレイを起きたままにします。蓋を閉じたときの動作は、このデバイスの電源設定に従います。",
           "a42f6fbdd8": "Agent が作業している間、このコンピュータとディスプレイを起きたままにします。Orca は電源ポリシーに従い、蓋が閉じているときもこのデバイスを起きたままにするよう要求します。",
-          "modeTitle": "コンピュータをスリープさせない"
+          "modeTitle": "コンピュータをスリープさせない",
+          "modeDescriptionWindows": "オン、Agent、オフから選択します。Agent モードは Agent の作業中はスリープしません。蓋を閉じた際の動作は、このデバイスの電源設定に従います。",
+          "modeDescriptionDefault": "オン、Agent、オフから選択します。Agent モードは Agent の作業中はスリープしません。Orca は電源ポリシーの範囲内で、蓋を閉じてもこのデバイスのスリープを抑止するよう要求します。"
         },
         "AgentAwakeSetting": {
           "on": "オン",
@@ -9367,7 +10521,11 @@
                   "6f30fc4216": "このランタイムでは、GitHub CLI の状態をまだ取得できません。",
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "PR、Issue、チェックは",
-                  "account_scope_prefix": "アカウントスコープ"
+                  "account_scope_prefix": "アカウントスコープ",
+                  "statusConnected": "接続済み",
+                  "statusUnavailable": "利用不可",
+                  "statusNotInstalled": "未インストール",
+                  "statusNotAuthenticated": "認証されていません"
                 }
               }
             }
@@ -9399,7 +10557,9 @@
                 "disconnect_all": "切断",
                 "account_scope_prefix": "アカウントスコープ",
                 "2d60ec7921": "APIトークンを使用して Jira Cloudサイトに接続するか、パーソナルアクセストークンまたはユーザー名とパスワードを使用してセルフホスト Jira に接続します。認証情報は選択されたリモートランタイムに送信され、ランタイムがサポートする暗号化で保存されます。",
-                "977e360b71": "APIトークンを使用して Jira Cloudサイトに接続するか、パーソナルアクセストークンまたはユーザー名とパスワードを使用してセルフホスト Jira に接続します。認証情報はローカルに保存され、ローカルランタイムストレージがサポートする場合は暗号化されます。"
+                "977e360b71": "APIトークンを使用して Jira Cloudサイトに接続するか、パーソナルアクセストークンまたはユーザー名とパスワードを使用してセルフホスト Jira に接続します。認証情報はローカルに保存され、ローカルランタイムストレージがサポートする場合は暗号化されます。",
+                "statusConnected": "接続済み",
+                "statusNotConnected": "未接続"
               }
             }
           }
@@ -9440,7 +10600,13 @@
                   "63a7f47392": "ORCA_BITBUCKET_EMAIL",
                   "24ac1c69dc": "このランタイムでは、Bitbucket の状態をまだ取得できません。",
                   "a924e8dcd1": "Bitbucket Cloud API トークン経由の PR とビルドステータス。",
-                  "0fa5629dad": "PR とビルドステータス"
+                  "0fa5629dad": "PR とビルドステータス",
+                  "statusConnected": "接続済み",
+                  "statusUnavailable": "利用不可",
+                  "statusNotConfigured": "未設定",
+                  "statusAuthFailed": "認証に失敗しました",
+                  "statusConfigured": "設定済み",
+                  "statusOptionalSetup": "オプションのセットアップ"
                 }
               }
             }
@@ -9491,7 +10657,9 @@
           "hostOverride": "ホストごとの上書き",
           "workspaceDirectory": "ホストが独自のワークツリーディレクトリを必要とするまでは、クライアントの既定値を継承します。",
           "providerHost": "プロバイダーのホスト",
-          "providerAccounts": "認証情報とアカウント確認は、プロバイダー連携を管理するローカルクライアントまたは選択したリモートサーバーに属します。"
+          "providerAccounts": "認証情報とアカウント確認は、プロバイダー連携を管理するローカルクライアントまたは選択したリモートサーバーに属します。",
+          "hostCollectionProjectScopes": "ホストコレクション + プロジェクトスコープ",
+          "terminalQuickCommandHostCollections": "コマンドは選択した Orca ホストに保存され、グローバルまたはプロジェクトセットアップにスコープされます。このデバイスのコマンドはリモートワークスペースでも利用可能なままです。"
         },
         "RepositoryForkSyncSection": {
           "defaultBranch": "デフォルトブランチ",
@@ -9691,12 +10859,21 @@
           "cloudVmTitle": "クラウド VM ランタイム",
           "cloudVmRefresh": "クラウド VM ランタイムを更新",
           "cloudVmLoading": "クラウド VM ランタイムを確認中…",
-          "cloudVmEmptyWithSetup": "クラウド VM ランタイムはまだありません。環境レシピを使用してワークスペースから作成してください。"
+          "cloudVmEmptyWithSetup": "クラウド VM ランタイムはまだありません。環境レシピを使用してワークスペースから作成してください。",
+          "stoppingCleanup": "Stopping…",
+          "stopCleanup": "クリーンアップを停止",
+          "cleanupStopped": "クリーンアップを停止しました",
+          "stopCleanupFailed": "Cloud VM のクリーンアップを停止できませんでした。"
         },
         "ephemeralVms": {
           "search": {
             "description": "リポジトリ所有のレシピが各ワークスペースに独自のオンデマンドの使い捨て環境を与える方法を学びましょう。",
-            "cloudVmTitle": "クラウド VM"
+            "cloudVmTitle": "クラウド VM",
+            "keywordVm": "vm",
+            "keywordCloud": "雲",
+            "keywordSandbox": "サンドボックス",
+            "keywordRecipe": "レシピ",
+            "keywordEphemeral": "エフェメラル"
           }
         },
         "EphemeralVmsPane": {
@@ -9754,7 +10931,12 @@
               },
               "search": {
                 "title": "Linear",
-                "description": "Linear スキルの状態、使用例、タスクソース設定へのリンク。"
+                "description": "Linear スキルの状態、使用例、タスクソース設定へのリンク。",
+                "linear": "Linear",
+                "issues": "Issue",
+                "skill": "スキル",
+                "tickets": "チケット",
+                "orcaLinear": "orca-linear"
               }
             }
           }
@@ -9776,7 +10958,9 @@
           "e6dadc1e2b": "月間の使用状況",
           "75e396bf42": "Grok の統合請求アカウントに含まれる月間使用量。",
           "b36fa2c908": "サインイン済み。Orca は、ディスクに保存された Grok CLI のセッションを読み取ります。",
-          "f08c41de73": "セッションの有効期限が切れました。Orca を実行しているコンピュータで grok を実行し、起動するまで待ちます。サインインを求められた場合は完了してから、[使用状況を更新] をクリックしてください。チャットメッセージを送る必要はありません。"
+          "f08c41de73": "セッションの有効期限が切れました。Orca を実行しているコンピュータで grok を実行し、起動するまで待ちます。サインインを求められた場合は完了してから、[使用状況を更新] をクリックしてください。チャットメッセージを送る必要はありません。",
+          "0bb18642b7": "使用量",
+          "a8f4139350": "Grok はこのアカウントの使用率を報告しませんでした。"
         },
         "AppearanceWindowSidebarSection": {
           "usagePercentageDisplayUsed": "使用済み",
@@ -9814,7 +10998,9 @@
           "signInRequired": "Relay のみ — LAN にはアカウントは不要です。",
           "relayUnavailable": "このビルドでは Orca Relay を利用できません。LAN をご利用ください。",
           "signInAgain": "Relay に再サインイン",
-          "localTitle": "LAN"
+          "localTitle": "LAN",
+          "retrying": "再試行中",
+          "relayCell": "リレーセル"
         },
         "MobilePairingSetupSection": {
           "title": "スマートフォンをペアリング",
@@ -10270,7 +11456,9 @@
           "connectionDetails": "接続の詳細",
           "endpointKind": "接続先の種類",
           "networkConnection": "ネットワーク接続",
-          "notAttempted": "未試行"
+          "notAttempted": "未試行",
+          "saveFailed": "ホストを保存できませんでした",
+          "saveFailedHelp": "ホストは検証されましたが、Orca は保存できませんでした。名前とローカルの設定ストレージを確認してから、再試行してください。"
         },
         "CloudVmSetupGuide": {
           "title": "クラウド VM を作成",
@@ -10283,6 +11471,264 @@
           "saveFailed": "表示設定のデフォルトを保存できませんでした。",
           "updateServer": "ソースのデフォルトを設定するには、このサーバーを更新してください。",
           "updateServerDefaults": "表示のデフォルトを設定するには、このサーバーを更新してください。"
+        },
+        "ReleaseChannelSection": {
+          "title": "リリースチャンネル",
+          "devOnly": "開発専用",
+          "willSwitch": "{{value0}} → {{value1}}",
+          "switchFailed": "そのビルドに切り替えられませんでした。",
+          "description": "更新チャネルを切り替えるか、過去のものを含む公開済みビルドにジャンプします。ダウングレードも可能で、未検証のビルドは壊れている場合があります。",
+          "channelAriaLabel": "更新チャネル",
+          "hourlyWarning": "Hourly ビルドはテストゲートなしで main から直接出荷され、Windows 版は署名なしです。安定版ビルドを手元に残してください。",
+          "dailyWarning": "Daily ビルドはテストゲートなしで main から直接出荷され、Windows 版は署名なしです。安定版ビルドを手元に残してください。",
+          "adhocWarning": "Adhoc ビルドは未マージのブランチ由来で、Windows 版は署名なしです。作成者が破棄する可能性があります。安定版ビルドを手元に残してください。",
+          "loadingBuilds": "ビルドを読み込み中…",
+          "noBuilds": "ビルドが見つかりません",
+          "refresh": "ビルド一覧を更新",
+          "switchTo": "ビルドに切り替え",
+          "alreadyRunning": "実行中のビルドです。",
+          "webUnavailable": "ビルドの切り替えはデスクトップアプリでのみ利用できます。",
+          "devChannelUnsupportedAria": "{{value0}}（{{value1}} のみ）",
+          "devChannelUnsupported": "{{value0}} ビルドは {{value1}} 向けにのみ生成されます。Linux では Stable または RC のままです。",
+          "downloadInstaller": "インストーラーをダウンロード",
+          "manualInstallHint": "{{value0}} ビルドは Windows では署名なしのため、アプリ内アップデーターでは署名済みビルドに上書きインストールできません。ダウンロードしたインストーラーを一度実行してください（不明な発行元の警告が出ます）。それ以降の切り替えは、Stable に戻す場合も含めてここから行えます。"
+        },
+        "VoiceMicrophoneSetting": {
+          "systemDefault": "システムのデフォルト",
+          "label": "マイクロフォン",
+          "unavailable": "利用不可",
+          "description": "音声ディクテーションに使う入力デバイス。システムデフォルトは OS のマイク設定に従います。",
+          "accessHint": "入力デバイスを一覧するには、マイクへのアクセスを許可してください。",
+          "allowAccess": "アクセスを許可"
+        },
+        "artifacts": {
+          "connected": "接続済み",
+          "keywordShare": "共有",
+          "keywordHtml": "HTML",
+          "keywordMarkdown": "Markdown",
+          "enable": "成果物を有効にする",
+          "enableDescription": "成果物をサイドバーに追加して、共有ファイルを開いたり削除したりできます。",
+          "account": "Orca アカウント",
+          "signInRequired": "成果物のアップロードと管理にはサインインが必要です。",
+          "signingIn": "サインイン中…",
+          "signIn": "Orca にサインイン",
+          "title": "成果物",
+          "description": "HTML ファイルと Markdown ファイルをチームと共有し、公開リンクを管理します。",
+          "howToTitle": "成果物の使い方",
+          "howToDescription": "HTML または Markdown ファイルを公開リンクとして公開し、チームと共有します。",
+          "shareStepTitle": "共有するファイルを選択",
+          "shareStepDescription": "HTML または Markdown ファイルを開いて「成果物として共有」を選択するか、Agent に共有を依頼します。",
+          "linkStepTitle": "公開リンクをコピー",
+          "linkStepDescription": "公開後にリンクをコピーしてチームに送ります。",
+          "manageStepTitle": "Orca で管理",
+          "manageStepDescription": "サイドバーから成果物を開いて、リンクをプレビューまたは削除します。",
+          "openArtifacts": "成果物を開く",
+          "openArtifactsDescription": "アカウント経由で共有されたリンクを表示・削除します。",
+          "showButton": "成果物ボタンを表示",
+          "showButtonDescription": "サイドバーに成果物のショートカットを表示します。",
+          "openArtifactsDescriptionV2": "アカウント経由で共有されたリンクをプレビュー、コピー、管理します。",
+          "signInTitle": "サインインして成果物を共有",
+          "signInDescription": "Orca アカウントで成果物をアップロードし、公開リンクを管理します。",
+          "signInAgain": "再サインイン",
+          "enableStepTitle": "成果物の共有を有効にする",
+          "enableStepWebDescription": "ホストデバイス上の Orca デスクトップアプリで「設定」→「成果物」を開き、公開を有効にします。",
+          "enableStepDescription": "上記の「公開成果物リンクの公開を許可」をオンにします。",
+          "allowPublishing": "公開成果物リンクの公開を許可",
+          "allowPublishingWebDescription": "デスクトップのみ。この設定を変更するには、ホストデバイスで「設定」→「成果物」を開きます。",
+          "allowPublishingDescription": "HTML ファイルと Markdown ファイルを、URL を知っている人が開けるリンクとして公開します。既存のリンクは、成果物から削除するまで残ります。",
+          "howToDescriptionDisabled": "HTML または Markdown ファイルを公開リンクとして公開するには、上記で成果物の共有を有効にします。",
+          "allowPublishingSearchDescription": "HTML ファイルと Markdown ファイルを公開リンクとして公開することを Orca に許可します。",
+          "keywordArtifacts": "成果物",
+          "keywordPublish": "公開",
+          "keywordPublic": "公開",
+          "keywordPermission": "権限",
+          "keywordUpload": "アップロード"
+        },
+        "orcaAccount": {
+          "connected": "接続済み",
+          "signOut": "サインアウト",
+          "relayTitle": "Orca Relay",
+          "keywordAccount": "アカウント",
+          "keywordLogin": "ログイン",
+          "keywordSignIn": "サインイン",
+          "keywordRelay": "リレー",
+          "keywordCloud": "雲",
+          "reconnectRequired": "セッションの有効期限が切れました。クラウド機能を使うには再サインインしてください。",
+          "unavailable": "このビルドでは Orca サインインを利用できません。",
+          "signedOut": "サインインすると、成果物や Orca Relay などのクラウド機能で Orca を拡張できます。",
+          "checking": "アカウントの状態を確認中…",
+          "account": "Orca アカウント",
+          "signingIn": "サインイン中…",
+          "signInAgain": "再サインイン",
+          "signIn": "Orca にサインイン",
+          "title": "Orca アカウント",
+          "description": "作業を即座に共有し、どこからでも Orca Mobile でデスクトップに接続します。",
+          "searchDescription": "成果物と Orca Relay で使うアカウントにサインイン・サインアウトします。",
+          "benefitsTitle": "アカウントに含まれるもの",
+          "artifactsTitle": "成果物の共有",
+          "artifactsDescription": "HTML ファイルと Markdown ファイルを公開し、共有リンクをすべて Orca から管理します。",
+          "relayDescription": "モバイル回線や Wi-Fi 越しに Orca Mobile をこのデスクトップに接続します。",
+          "skillsTitle": "スキルの共有",
+          "skillsDescription": "1 つのスキルやスキルセットを限定公開リンクの背後で共有し、使用する任意のマシンにインストールします。",
+          "keywordLogout": "ログアウト",
+          "keywordSignOut": "サインアウト"
+        },
+        "automations": {
+          "showButton": "オートメーションボタンを表示",
+          "title": "自動化",
+          "keywordAutomations": "自動化",
+          "keywordSchedule": "スケジュール",
+          "keywordAgent": "Agent",
+          "keywordRuns": "走る",
+          "showButtonDescription": "サイドバーに自動化のショートカットを表示します。",
+          "howItWorksTitle": "自動化の仕組み",
+          "howItWorksDescription": "Agent の作業を一度スケジュールすれば、Orca が各実行を作成し、結果をまとめて保持します。",
+          "defineStepTitle": "作業内容を記述",
+          "defineStepDescription": "プロジェクト、Agent、プロンプト、スケジュールを選択します。",
+          "runStepTitle": "Orca が各実行を開始",
+          "runStepDescription": "スケジュール時刻になると、選択した Agent に新しいワークスペースが用意されます。",
+          "reviewStepTitle": "結果を確認",
+          "reviewStepDescription": "最近の実行を確認し、必要に応じていつでも作業を続けます。",
+          "openAutomations": "自動化を開く",
+          "openAutomationsDescription": "スケジュールを作成し、最近の実行を確認します。",
+          "description": "Agent の作業をスケジュールし、自動化をサイドバーに表示するかどうかを選択します。"
+        },
+        "shareSkills": {
+          "refreshLinks": "更新",
+          "copyLink": "リンクをコピー",
+          "keywordSkills": "スキル",
+          "keywordShare": "共有",
+          "keywordLink": "リンク",
+          "keywordRevoke": "取り消す",
+          "title": "スキルを共有",
+          "description": "スキルを限定公開リンクで共有します。リンクを知っている人は誰でもインストールできます。",
+          "allowAgentPublishing": "Agent と Orca CLI によるスキルリンクの公開を許可",
+          "allowAgentPublishingDescription": "明示的に名前を指定したインストール済みスキルをコマンドが公開できるようにします。スキルフォルダーにはスクリプト、設定、シークレットが含まれる場合があるため、既定ではオフです。",
+          "allowAgentPublishingWebDescription": "デスクトップのみ。この設定を変更するには、ホストデバイスで「設定」→「スキルを共有」を開きます。",
+          "selectTitle": "1 つ以上のスキルを選択",
+          "selectDescription": "スキルを開き、「スキルを共有」を選択して、1 つのリンクの背後にまとめるスキルを選びます。",
+          "reviewTitle": "確認して公開",
+          "reviewDescription": "不変のバンドルをアップロードする前に、含まれるファイル、スクリプト、実行可能ファイルを確認します。",
+          "copyTitle": "限定公開リンクをコピー",
+          "copyDescription": "リンクを知っている人は、サインインなしでスキルをすべてまたは選択して確認・インストールできます。",
+          "manageTitle": "リンクを管理・取り消す",
+          "manageDescription": "取り消すと今後のアクセスがブロックされます。別のマシンにすでにインストールされたスキルは残ります。",
+          "linkTitle": "限定公開スキルリンク",
+          "linkDescription": "共有バンドルは検索できず、Orca 内にも掲載されません。リンク自体が認証情報のため、信頼できる相手にのみ送ってください。",
+          "signInTitle": "サインインしてスキルを共有",
+          "signInWebDescription": "公開とリンク管理は Orca デスクトップアプリで利用できます。",
+          "signInDescription": "Orca アカウントでバンドルを公開し、リンクを管理します。受信者にアカウントは不要です。",
+          "signingIn": "サインイン中…",
+          "signInAgain": "再サインイン",
+          "signIn": "Orca にサインイン",
+          "howToTitle": "スキルの共有方法",
+          "howToDescription": "1 つのスキルや、30 のスキルのコレクションなどのバンドルを 1 つのリンクの背後で公開します。",
+          "openSkills": "スキルを開く",
+          "openSkillsDescription": "バンドルを公開、リンクからインストール、インストール済み・共有済みスキルを管理します。",
+          "searchDescription": "スキルを限定公開リンクで共有します。リンクを知っている人は誰でもインストールできます。",
+          "linksReconnect": "共有リンクを管理するには、再サインインしてください。",
+          "linksUnavailable": "共有リンクは現在利用できません。",
+          "linkCopied": "共有リンクをコピーしました",
+          "linkRevoked": "リンクを取り消しました",
+          "revokeFailed": "Orca はこのリンクを取り消せませんでした。",
+          "activeLinks": "アクティブな共有リンク",
+          "activeLinksDescription": "リンクを知っている人のみ開けます。共有を解除すると、今後の確認とインストールがブロックされます。",
+          "noActiveLinks": "アクティブなリンクはありません。スキルからスキルバンドルを公開して作成します。",
+          "confirmUnshare": "共有解除を確認",
+          "unshare": "共有を解除",
+          "showButton": "スキルボタンを表示",
+          "showButtonDescription": "サイドバーにスキルのショートカットを表示します。",
+          "manageInSkills": "スキルで管理",
+          "keywordBundle": "バンドル",
+          "keywordUnlisted": "限定公開"
+        },
+        "bitbucket": {
+          "credentials": {
+            "dialog": {
+              "connectFailed": "接続に失敗しました",
+              "emailPlaceholder": "you@example.com",
+              "apiToken": "APIトークン",
+              "apiTokenPlaceholder": "Atlassian API トークン",
+              "cancel": "キャンセル",
+              "verifying": "確認中…",
+              "connect": "接続",
+              "title": "Bitbucket に接続",
+              "description": "Bitbucket Cloud の認証情報で PR とビルドステータスを閲覧します。Orca は保存前に検証します。",
+              "remoteRuntime": "ここに保存した Bitbucket 認証情報は、このローカルマシンにのみ保存されます。代わりにリモートランタイム上で ORCA_BITBUCKET_* 環境変数を設定してください。",
+              "environmentManaged": "Bitbucket はすでに ORCA_BITBUCKET_* 環境変数で設定されており、そちらが優先されます。Orca に認証情報を保存するには、それらの設定を解除してください。",
+              "authModeLabel": "Bitbucket 認証方式",
+              "modeBasic": "メールアドレスと API トークン",
+              "modeToken": "アクセストークン",
+              "accessToken": "アクセストークン",
+              "accessTokenPlaceholder": "リポジトリ、プロジェクト、ワークスペースのアクセストークン",
+              "email": "Atlassian アカウントのメールアドレス",
+              "baseUrl": "API ベース URL（任意）",
+              "baseUrlPlaceholder": "https://api.bitbucket.org/2.0",
+              "tokenHint": "リポジトリ、プロジェクト、ワークスペースのアクセストークンは、対応する Bitbucket 設定ページで作成し、PR への読み取りアクセスが必要です。",
+              "basicHint": "アカウントの Atlassian API トークンを作成し、それを所有するメールアドレスと組み合わせます。",
+              "docsLink": "Bitbucket API トークンのドキュメント",
+              "storageNote": "OS キーチェーンが利用可能な場合は暗号化ストレージでこのマシンに保存されます。ORCA_BITBUCKET_* 環境変数は、ここに保存した内容より常に優先されます。"
+            }
+          },
+          "integration": {
+            "card": {
+              "connect": "接続",
+              "description": "Bitbucket Cloud の PR とビルドステータス。",
+              "edit": "認証情報を編集",
+              "accountUnknown": "Bitbucket Cloud",
+              "authModeToken": "アクセストークン",
+              "authModeBasic": "メールアドレスと API トークン",
+              "disconnect": "Bitbucket を切断",
+              "envManaged": "環境変数で設定されています。Orca でこの認証情報を管理するには、ORCA_BITBUCKET_* 変数の設定を解除してください。",
+              "storedAuthFailed": "保存済み Bitbucket 認証情報で認証できませんでした。編集するか、トークンに PR へのアクセスが残っているか確認してください。",
+              "storedCredential": "このマシン上の Orca に保存済み。設定されている場合、ORCA_BITBUCKET_* 環境変数が優先されます。",
+              "notConfigured": "Atlassian API トークンまたはアクセストークンで Bitbucket Cloud アカウントに接続します。ORCA_BITBUCKET_* 環境変数も使え、そちらが優先されます。",
+              "disconnectFailed": "保存済み Bitbucket 認証情報を削除できませんでした。"
+            }
+          }
+        },
+        "EphemeralVmCleanupStopDialog": {
+          "stopping": "Stopping…",
+          "title": "クリーンアップを停止しますか?",
+          "description": "VM が実行中のままになり、料金が発生する可能性があります。後でクリーンアップを再試行できます。",
+          "cancel": "クリーンアップを続ける",
+          "confirm": "クリーンアップを停止"
+        },
+        "contrast": {
+          "off": "オフ",
+          "custom": "カスタム",
+          "title": "色のコントラスト",
+          "description": "テキストの可読性を向上させるか、ターミナルプログラムが選んだ色を保持します。",
+          "ratio": "コントラスト目標",
+          "autoDescription": "可読性とターミナルテーマのバランスを取ります。推奨。",
+          "offDescription": "減光テキストや Powerline セパレーターを含め、プログラムの色を変更しません。",
+          "customDescription": "テキストと背景のコントラストをどれだけ上げるか選択します。",
+          "auto": "自動",
+          "targetDescription": "値を上げると可能な範囲でコントラストが上がります。背景色は変わりません。",
+          "subtle": "控えめ",
+          "strong": "強い"
+        },
+        "QuickCommandsList": {
+          "noSearchMatches": "この検索に一致するコマンドはありません。"
+        },
+        "QuickCommandsToolbar": {
+          "searchLabel": "コマンドを検索"
+        },
+        "TerminalAdvancedTypographyControls": {
+          "f5fa1a08f1": "太字のフォントウェイト",
+          "0e0d1ee15a": "フォントウェイトとは独立して調整します。一部のフォントでは複数の値が 1 つのフェイスに対応するため、太字が変わらない場合はフォントウェイトを下げるか、別のフォントを選択してください。"
+        },
+        "BrowserTerminalLinkActionsSetting": {
+          "title": "リンク操作を表示",
+          "description": "ターミナルやチャットの記録内のリンクをクリックしたときに、利用可能な操作を表示します。オフにすると、ターミナルでは {{modifier}} キーとの同時クリックが必要になります。"
+        },
+        "TerminalTccAttributionNotice": {
+          "body": "ターミナルデーモンは、すでに存在しない Orca インストールによって起動されたため、macOS はそのコマンドを Orca に帰属付けできません。アクセシビリティとオートメーションの許可は無視されます（osascript はエラー -25211 で失敗します）。デーモンを再起動すると解決します。実行中のターミナルセッションは閉じます。",
+          "openManageSessions": "セッション管理を開く",
+          "title": "macOS の権限付与がターミナルに届いていません"
+        },
+        "NativeChatSupportedAgents": {
+          "label": "対応 Agent:"
         }
       },
       "right": {
@@ -10341,7 +11787,11 @@
               "branch": "ブランチを同期"
             },
             "7e4b2a19c0": "返信先の GitHub PR を特定できませんでした。",
-            "430f1a62d4": "選択したスレッドをホスト上で解決できませんでした。"
+            "430f1a62d4": "選択したスレッドをホスト上で解決できませんでした。",
+            "updateReactionFailed": "リアクションの更新に失敗しました。",
+            "gitlabMoreActions": "その他の MR 操作",
+            "gitlabUnlink": "MR のリンクを解除",
+            "gitlabLinkAnother": "別の MR をリンク"
           },
           "CreatePullRequestDialog": {
             "2bc1b4345e": "キャンセル",
@@ -10417,7 +11867,11 @@
             "f9d7ca753d": "パスのコピー",
             "3161c4e425": "フォルダー",
             "e887fa4b2e": "ターミナルで開く",
-            "1d8e182c32": "ファイルを表示"
+            "1d8e182c32": "ファイルを表示",
+            "clipboardStagingUnavailable": "Orca の一時ストレージが利用できないため、ファイルをコピーできませんでした",
+            "revealInFinder": "Finder で表示",
+            "openContainingFolder": "含まれるフォルダーを開く",
+            "revealInFileExplorer": "エクスプローラーで表示"
           },
           "FileExplorerToolbar": {
             "d238264654": "Git で無視されたファイルを表示",
@@ -10461,7 +11915,19 @@
             "b25f63edd7": "開く",
             "d2ca293f3d": "処理中…",
             "ef064cb7c3": "デフォルト",
-            "59b4dccf70": "破壊的な"
+            "59b4dccf70": "破壊的な",
+            "draftMoreActions": "その他の {{value0}} 操作",
+            "closeDraft": "閉じる",
+            "closedToast": "{{value0}} をクローズしました",
+            "9a41a687b7": "#{{pr}} 経由でキュー · {{count}} PR",
+            "38a1bccb14": "#{{pr}} 経由でキュー · {{count}} PR",
+            "3de88351c5": "GitHub はこの PR と、その下のすべての PR をマージキューに追加します。",
+            "a32fe6dba6": "GitHub はこの PR と、スタック内でその下にあるすべての PR をマージします。",
+            "73e0e1819d": "スタックをキュー中…",
+            "e555a41d32": "スタックをマージ中…",
+            "markingReady": "レビュー可能に変更中…",
+            "markReady": "レビュー可能にする",
+            "readyToast": "{{value0}} をレビュー可能にしました"
           },
           "PortsPanel": {
             "3ea4a02a8f": "キャンセル",
@@ -10942,7 +12408,10 @@
                 "actionRequiredHint": "マージのブロックが解除されるまでに、このチェックには GitHub 上での手動操作（例: ワークフロー実行の承認）が必要です。",
                 "b3195cba33": "作成者のボット指定を解除",
                 "f588b46a6c": "作成者をボットとして指定",
-                "e45324fbed": "チェック詳細の読み込みに失敗しました。"
+                "e45324fbed": "チェック詳細の読み込みに失敗しました。",
+                "dcb3c546fe": "再試行",
+                "checksUnresolvedChip": "未解決",
+                "checksUnresolvedStripHint": "これらのチェックは、合格・不合格の判定なしに終了しました。"
               },
               "empty": {
                 "state": {
@@ -11113,7 +12582,24 @@
                   "2388413f28": "この MR はクローズされています",
                   "88d044c42f": "クローズ",
                   "ee482a2bad": "この MR はすでにマージされています",
-                  "fae95ae20d": "マージ済み"
+                  "fae95ae20d": "マージ済み",
+                  "5105b0e584": "承認が必要です",
+                  "893a999c8c": "変更要求",
+                  "382c70faeb": "遅れ",
+                  "2c61100b3a": "マージする前にブランチを更新する",
+                  "195917574e": "確認中",
+                  "4ecc0d90ee": "ブロック中",
+                  "46dc85711b": "この MR をマージするには GitLab の承認が必要です",
+                  "c65408a99d": "レビュアーがこの MR に変更を要求しました",
+                  "01ab632a21": "未解決のスレッド",
+                  "4191fdfcec": "マージ前に未解決のディスカッションの解決が GitLab で必要です",
+                  "bf628700f6": "チェックに合格する必要があります",
+                  "37d8637c70": "この MR をマージするにはパイプラインの成功が GitLab で必要です",
+                  "049ea91a82": "パイプラインはまだ実行中です",
+                  "ff6db2db63": "GitLab はこの MR のステータスをまだ計算中です",
+                  "a0f3de7023": "GitLab はこの MR がブロックされていると報告しています",
+                  "804ecf93e8": "GitLab は最終的なマージステータスをまだ報告していません",
+                  "a5c049afe4": "GitLab によると、この MR はマージ可能です"
                 }
               }
             }
@@ -11281,6 +12767,72 @@
                   "8f9a0b1c2d": "コミットするものがありません。ブランチは最新です。",
                   "h3i4j5k607": "このブランチが {{value0}} を作成できるか確認中…"
                 }
+              },
+              "branch": {
+                "line": {
+                  "total": {
+                    "chip": {
+                      "c8d5b21e07": "ソース",
+                      "daa8e8e59b": "{{value0}} 行追加、{{value1}} 行削除",
+                      "8a9b97b666": "{{value0}} 行追加",
+                      "52c366d88d": "{{value0}} 行削除",
+                      "4c1f70ba92": "{{value0}} — テストコード: {{value1}} 行追加、{{value2}} 行削除",
+                      "6b2d0f14a7": "テスト",
+                      "9e4a3c5081": "非テスト",
+                      "3d7e9b1042": "非生成",
+                      "a1b2c3d4e5": "コード内訳",
+                      "b2c3d4e5f6": "コード行数",
+                      "7f3e1a9c24": "{{value0}} — 生成: {{value1}} 行追加、{{value2}} 行削除",
+                      "7a04c6f8b3": "生成"
+                    }
+                  }
+                }
+              },
+              "conflict": {
+                "status": {
+                  "cards": {
+                    "5302a1ddba": "マージ競合",
+                    "bdf8772106": "競合",
+                    "7f3af87549": "リベースの競合",
+                    "6a8e9ad490": "チェリーピックの競合",
+                    "edc2d82a2b": "マージ進行中",
+                    "5c3707aa44": "リベース進行中",
+                    "ffe53a1da6": "チェリーピック進行中",
+                    "35eb76d323": "操作進行中"
+                  }
+                }
+              },
+              "content": {
+                "status": {
+                  "8deb86bbec": "ベース",
+                  "3f425c239c": "このブランチに変更はありません",
+                  "640f6fdb36": "このワークスペースはクリーンで、このブランチは {{value0}} より進んだ変更がありません",
+                  "978eba351e": "検索テキストが大きすぎます",
+                  "0bce43409f": "短いファイルフィルターを使用してください。",
+                  "1b6caf533d": "一致するファイルがありません",
+                  "00c07771b7": "「{{value0}}」に一致する変更ファイルがありません"
+                }
+              },
+              "commit": {
+                "area": {
+                  "cc5739bd1d": "コミットメッセージを生成中…",
+                  "4cbd0cd9d2": "コミット中です…",
+                  "e7876a2bde": "メッセージを生成するには、少なくとも 1 つのファイルをステージします。",
+                  "0904be2505": "再生成するにはメッセージをクリアします。",
+                  "1ea9ba37aa": "「設定」→「Git」→「ソース管理 AI」で Agent を選択します。"
+                }
+              },
+              "compare": {
+                "summary": {
+                  "dd72a6fd37": "{{value2}} より {{value0}} コミット{{value1}}進んでいます"
+                }
+              },
+              "diff": {
+                "comments": {
+                  "list": {
+                    "cefacd0ec7": "ファイル全体"
+                  }
+                }
               }
             }
           },
@@ -11289,6 +12841,11 @@
               "control": {
                 "ai": {
                   "cfafa92509": "送信する未解決の競合はありません。"
+                },
+                "bulk": {
+                  "actions": {
+                    "2f67630884": "一括ステージ/アンステージに失敗しました"
+                  }
                 }
               }
             }
@@ -11333,6 +12890,17 @@
                   }
                 }
               }
+            },
+            "hosted": {
+              "review": {
+                "button": {
+                  "label": {
+                    "96ae7358e0": "プッシュしてスタックに PR を作成",
+                    "8e8149a0bf": "スタックにドラフト PR を作成",
+                    "8df1a05952": "スタックに PR を作成"
+                  }
+                }
+              }
             }
           },
           "AiVaultPanel": {
@@ -11364,7 +12932,10 @@
             "sessionHostMismatchUnsupported": "このセッションは別のホストに属しています。再開するには同じホスト上のワークスペースを開いてください。",
             "prepareSessionResumeFailed": "このセッションを再開用に準備できませんでした。",
             "sessionDeleted": "セッションを削除しました",
-            "sessionDeleteFailed": "セッションを削除できませんでした"
+            "sessionDeleteFailed": "セッションを削除できませんでした",
+            "resumeInChatConflict": "別のチャットがすでにこの会話を保持しています。",
+            "resumeInChatTranscriptMissing": "この会話の履歴を読み込めなかったため、チャットで再開できません。",
+            "resumeInChatFailed": "このセッションを新規チャットで再開できませんでした。"
           },
           "AiVaultPanelControls": {
             "scanningSessions": "セッションをスキャンしています",
@@ -11500,7 +13071,8 @@
             "delete": "削除",
             "deleteReasonNonLocalHost": "このデバイス上のセッションのみ削除できます。",
             "deleteReasonSyntheticPath": "このセッションは Orca では削除できません。",
-            "deleteReasonUnsupportedAgent": "{{value0}} のセッションは Orca では削除できません。"
+            "deleteReasonUnsupportedAgent": "{{value0}} のセッションは Orca では削除できません。",
+            "resumeInNewChat": "新規チャットで再開"
           },
           "AiVaultSessionDeleteDialog": {
             "title": "このセッションを削除しますか?",
@@ -11587,6 +13159,34 @@
                   "d9dd7c6687": "GitHub から更新できませんでした。最後に取得した状態を表示しています。"
                 }
               }
+            },
+            "pr": {
+              "stack": {
+                "confirmation": {
+                  "84f6f5b9eb": "含まれるもの: {{numbers}}。",
+                  "541984b2eb": "#{{pr}} 経由でキューしますか?",
+                  "4809f55cdb": "{{included}}GitHub は {{count}} の PR をまとめてマージキューに追加します。マージ方法はキューが選択し、別のグループに分けてマージする場合があります。",
+                  "be8f2621be": "{{included}}GitHub は {{count}} の PR をまとめてマージキューに追加します。マージ方法はキューが選択し、別のグループに分けてマージする場合があります。",
+                  "92ca033e72": "{{count}} PR をキュー",
+                  "478a527b15": "{{count}} PR をキュー",
+                  "1feef35ca4": "#{{pr}} 経由でマージしますか?",
+                  "c3e036c99f": "{{included}}GitHub は {{method}} で {{count}} の PR をアトミックにマージします。マージできない場合、何もマージされません。",
+                  "369aba4b32": "{{included}}GitHub は {{method}} で {{count}} の PR をアトミックにマージします。1 つでもマージできない場合、すべてマージされません。",
+                  "493c78f521": "{{count}} PR をマージ",
+                  "eb7051d268": "{{count}} PR をマージ"
+                },
+                "merge": {
+                  "55ae29b907": "#{{pr}} 経由でマージ · {{count}} PR",
+                  "b8446f6ec2": "#{{pr}} 経由でマージ · {{count}} PR",
+                  "189d0ec614": "#{{pr}} はまだドラフトです。",
+                  "640fb50d9c": "#{{pr}} はクローズされています。",
+                  "46ffcbda75": "#{{pr}} にマージの競合があります。",
+                  "6dabefd63e": "#{{pr}} に変更が要求されています。",
+                  "2bb21fc326": "#{{pr}} はまだレビュー承認が必要です。",
+                  "c23faf74df": "#{{pr}} を更新する必要があります。",
+                  "f561e80968": "#{{pr}} はブロックされています。"
+                }
+              }
             }
           },
           "PluginPanel": {
@@ -11605,6 +13205,34 @@
             "mayBeSlower": "遅くなる可能性あり",
             "slowest": "最も低速",
             "unlimited": "無制限"
+          },
+          "GitHubPRStackMap": {
+            "3511405914": "閉まっている",
+            "568c647ccd": "下書き",
+            "bea9ade223": "衝突",
+            "d3d97cf3f2": "承認された",
+            "e6cb964305": "開く",
+            "8a9bdc36c0": "マージ済み",
+            "838aadf512": "チェック失敗",
+            "316039b5db": "チェック保留中",
+            "4b1e5ee9d3": "変更要求あり",
+            "9a17b5255c": "レビューが必要",
+            "7737bd66be": "スタック #{{value0}} を折りたたむ",
+            "0c1645ebd0": "スタック #{{value0}} を展開",
+            "e3ee2daa32": "スタック #{{value0}}",
+            "cb440931b7": "{{value1}} 中 {{value0}} · {{value2}}",
+            "525259fa17": "スタックの詳細は一時的に利用できません。"
+          },
+          "CreateHostedReviewBasePicker": {
+            "205ef284fa": "ベースブランチ",
+            "bb4b41d563": "{{value0}} から",
+            "5a9315b61a": "「{{value0}}」に一致するブランチがありません。そのまま使うには Enter を押します。",
+            "da4d57c9c2": "{{value0}} を使うには空のままにします。"
+          },
+          "CreateHostedReviewComposerFields": {
+            "90cabf6cfc": "この PR を #{{value0}} の上にスタック",
+            "ff81473a57": "GitHub スタックを作成するか、親の既存スタックを拡張します。",
+            "29732f2fb0": "新規 PR"
           }
         }
       },
@@ -11889,7 +13517,8 @@
             "searchJira": "Jira Issue を検索するか、Issue URL を貼り付け",
             "jiraMode": "Jira",
             "jiraSelectBindFailed": "この Jira Issue をリンクできませんでした。該当するサイトを選択するか Jira に再接続してから、もう一度お試しください。",
-            "emoji": "絵文字"
+            "emoji": "絵文字",
+            "loadingLinearIssue": "Linear Issue を読み込み中…"
           },
           "ProjectCombobox": {
             "empty": "検索条件に一致するプロジェクトはありません。",
@@ -11903,6 +13532,15 @@
             "listLabel": "実行ターゲット",
             "label": "実行先",
             "browse": "実行ターゲットを参照"
+          },
+          "SetProjectLocationDialog": {
+            "browseFolder": "フォルダーを参照",
+            "browseFolderHelp": "このホスト上の既存のチェックアウトまたはフォルダーを使用します。",
+            "cloneFromUrl": "URL からクローン",
+            "title": "プロジェクトの場所を設定",
+            "description": "{{host}} 上で {{project}} の場所を選択します。",
+            "cloneFromUrlHelp": "このリポジトリを {{host}} にクローンします。",
+            "saveLocation": "場所を設定"
           }
         }
       },
@@ -11955,7 +13593,19 @@
           "relayDegradedNotice": "Relay に接続できませんでした — このコードは LAN または Tailscale でのみ動作します。",
           "pairingQrError": "このペアリングコードを QR コードとして表示できませんでした。代わりに Orca Mobile にコピーしてください。",
           "directAddressDisclosure": "より速いローカル経路も使う",
-          "directAddressHint": "任意。近く（同じ Wi‑Fi または Tailscale）にいるときにスマホが使うアドレスを選びます。通常は Relay より高速です。外出中は引き続き Relay が使われます。"
+          "directAddressHint": "任意。近く（同じ Wi‑Fi または Tailscale）にいるときにスマホが使うアドレスを選びます。通常は Relay より高速です。外出中は引き続き Relay が使われます。",
+          "noRelayCode": "ペアリングコードがありません",
+          "noPairingCode": "ペアリングコードがありません",
+          "qrSignInRequired": "Relay ペアリングコードを作成するにはサインインします",
+          "qrRenderFailed": "QR を表示できませんでした — 以下のコードをコピーしてください",
+          "qrGeneratePrompt": "続けるにはペアリングコードを生成します",
+          "pairingCodeReady": "ペアリングコードの準備完了",
+          "pairThisMac": "この Mac をペアリングします。",
+          "pairThisPc": "この PC をペアリングします。",
+          "pairThisComputer": "このコンピュータをペアリングします。",
+          "androidHelp": {
+            "guide": "インストールガイド"
+          }
         },
         "MobilePage": {
           "e17393c6a3": "スマートフォンプレビュー",
@@ -11968,7 +13618,9 @@
           "4e1eb5d55c": "デバイスの取り消しに失敗しました",
           "255372e6e8": "デバイスが取り消されました",
           "1b4509a8a1": "ペアになった",
-          "c5909374cf": "イントロ"
+          "c5909374cf": "イントロ",
+          "diagnosticsCopied": "診断情報をコピーしました",
+          "diagnosticsCopyFailed": "診断情報のコピーに失敗しました"
         },
         "MobilePageToolbar": {
           "ad2284a9e2": "閉じる・Esc",
@@ -12083,7 +13735,10 @@
         "NetworkInterfacePicker": {
           "trigger-label": "通知するネットワークアドレス",
           "custom-option": "{{address}}（カスタム）",
-          "add-custom": "カスタムアドレスを追加…"
+          "add-custom": "カスタムアドレスを追加…",
+          "custom-section": "カスタム",
+          "no-address-selected": "アドレスが未選択です",
+          "remove-custom": "{{address}} を削除"
         },
         "WindowsFirewallNotice": {
           "repair-success": "Windows ファイアウォールで、プライベートネットワーク上の Orca Mobile を許可しました",
@@ -12100,6 +13755,20 @@
           "blocked-description": "既存のインバウンドブロックルールがペアリング例外を上書きする可能性があります。修復はこの Orca アプリの競合するTCPルールを削除し、プライベートネットワーク上のポート{{port}}を許可します。",
           "repair": "ファイアウォールアクセスを修復",
           "relay-note": "ペアリングは Orca Relay 経由で引き続き機能します。許可すると、より高速なローカル接続が追加されるだけです。"
+        },
+        "MobileRelayMintFailureNotice": {
+          "retrying": "再試行中…",
+          "retryingTitle": "Orca Relay を再試行中…",
+          "unavailableTitle": "Orca Relay はこのデスクトップでは利用できません。",
+          "title": "Relay ペアリングコードを作成できませんでした。",
+          "retryingBody": "新規ペアリングコードを作成しています。リモート接続では時間がかかる場合があります。",
+          "unavailableBody": "Tailscale または同じ Wi-Fi 越しに LAN でペアリングします。",
+          "body": "再試行するか、Tailscale または同じ Wi-Fi 越しに LAN でペアリングします。",
+          "useLan": "LAN を使用",
+          "retry": "Relay を再試行",
+          "copyDiagnostics": "診断情報をコピー",
+          "reconnectTitle": "Orca アカウントのセッションが期限切れです。",
+          "reconnectBody": "Orca Relay を使うには再サインインするか、Tailscale または同じ Wi-Fi 越しに LAN でペアリングします。"
         }
       },
       "gitlab": {
@@ -12413,6 +14082,30 @@
                   "b94ec70eda": "追跡が設定されていません",
                   "cc39a87288": "接続済み · システムのデフォルト",
                   "00087eecb2": "接続されました · {{value0}}"
+                }
+              },
+              "setup": {
+                "checklist": {
+                  "localized": {
+                    "copy": {
+                      "fee5557b02": "Orca CLI を有効化",
+                      "ec0a363633": "マルチタスク",
+                      "62bac8f43c": "2 つの異なるワークツリーで同時に作業します。各ワークツリーは分離されています（同じプロジェクトでも）。2 つの機能の同時作業に最適です。",
+                      "908898c3ee": "Orca のブラウザを使用",
+                      "43781563c3": "Orca から離れずに Web アプリを閲覧します。任意の要素を取得し、その正確なソースとスタイルをワンクリックで Agent に送信します。",
+                      "29aa2c2077": "通知をオンにする",
+                      "71bd9a8c95": "Agent の完了、注意が必要な状態、ブロックを即座に把握します。",
+                      "46db810da8": "デフォルトの Agent を選択",
+                      "b8e5bae17f": "よく使う Agent を選択済みにして、新たな作業をすばやく開始します。",
+                      "7bcb4097fa": "Orca シェルコマンドを登録し、ブラウザ、コンピュータ、オーケストレーションのワークフロー向けに Agent スキルをインストールします。",
+                      "ad342dd4c6": "連携を接続",
+                      "06fe30fdb0": "タスクからワンクリックで Agent を開始し、PR ステータスを確認し続けます。",
+                      "eddc532e58": "ワークスペースのセットアップを自動化",
+                      "56049b74c2": "インストールとセットアップのコマンドを自動実行し、新規ワークツリーを Agent 用に準備します。",
+                      "2cf795433b": "複数のリポジトリで作業を開始",
+                      "42525ba8a4": "主要なリポジトリを Orca に取り込み、フォルダーを探さずに Agent 作業を開始できます。"
+                    }
+                  }
                 }
               }
             }
@@ -12792,7 +14485,9 @@
           "724a13568d": "（{{value0}}）",
           "6094135eec": " vs {{value0}}",
           "a4420ca1f7": "ラップオン",
-          "dde325ddfe": "ラップオフ"
+          "dde325ddfe": "ラップオフ",
+          "2e91bc89d1": "空白オン",
+          "2bf19c54ad": "空白オフ"
         },
         "ConflictComponents": {
           "f338288514": "競合するコンテンツを読み込んでいます…",
@@ -12876,14 +14571,18 @@
           "f0fd4174b5": "ファイルタブを開いてリッチ markdown 編集を使用する",
           "a10d9b8337": "ファイルを開く",
           "2076ecfc9c": "前の変更",
-          "631dab0df3": "次の変更"
+          "631dab0df3": "次の変更",
+          "revealInFinder": "Finder で表示",
+          "openContainingFolder": "含まれるフォルダーを開く",
+          "revealInFileExplorer": "エクスプローラーで表示"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "PDFとしてエクスポート",
           "561251019a": "その他の操作",
           "8c8b7f5ff5": "前付を表示",
           "10c39d58c1": "前付を隠す",
-          "1eef809708": "ワードラップ"
+          "1eef809708": "ワードラップ",
+          "4dedd55efa": "空白を表示"
         },
         "EditorPanelShell": {
           "e2c4dec350": "エディターを読み込み中…"
@@ -13297,7 +14996,8 @@
           "e2b4d7c8a1": "このチェックの Agent を選択",
           "f1c9e3a6d4": "チェックを修正する Agent を選択",
           "5e2a9c3f88": "この行でファイルを開く",
-          "actionRequired": "操作が必要です"
+          "actionRequired": "操作が必要です",
+          "copyOutput": "出力をコピー"
         },
         "check": {
           "run": {
@@ -13324,7 +15024,8 @@
           "2d3b8f1a55": "スキップしました",
           "3e6c9a2b71": "保留中",
           "4f7d0c3e88": "失敗したステップ",
-          "5a8e1d4f23": " · "
+          "5a8e1d4f23": " · ",
+          "copy": "ジョブをコピー"
         },
         "ExternalFileChangeBanner": {
           "7c41e90d12": "未保存の編集がある状態で、このファイルがディスク上で変更されました。保存すると、ディスク上の最新の内容を上書きします。",
@@ -13370,6 +15071,47 @@
               }
             }
           }
+        },
+        "CheckRunCopyButton": {
+          "copied": "コピーしました",
+          "failed": "コピーできませんでした",
+          "empty": "コピーする内容がありません"
+        },
+        "HtmlDocPreview": {
+          "documentPathCopied": "コピーしました",
+          "dismissAccessRequest": "閉じる",
+          "documentTooLargePanel": "このドキュメントは大きすぎてプレビューできません。代わりにエディターで開きます。",
+          "documentUnreadablePanel": "Orca はこのファイルをワークスペースから読み取れませんでした。",
+          "multipleAssetsFailedNotice": "このドキュメント内の {{count}} ファイルを読み込めませんでした。",
+          "assetTooLargeNotice": "{{path}} は大きすぎてこのプレビューに読み込めません。",
+          "assetUnsupportedNotice": "このワークスペースは {{path}} をプレビューに送信できません。",
+          "assetUnreadableNotice": "Orca は {{path}} をワークスペースから読み取れませんでした。",
+          "previewAriaLabel": "HTML プレビュー",
+          "reloadPreviewControl": "プレビューを再読み込み",
+          "previewUnavailableTitle": "プレビューを利用できません",
+          "copyDocumentPathControl": "ファイルパスをコピー",
+          "workspaceFileChipLabel": "ワークスペースファイル",
+          "previewMenuControl": "プレビューオプション",
+          "openSourceControl": "ソースファイルを開く",
+          "openExternallyControl": "デフォルトのアプリで開く",
+          "copyDocumentRelativePathControl": "相対パスをコピー",
+          "openExternallyUnknownHostError": "「{{value0}}」を開けません: 所有ホストが不明です。",
+          "downloadBlockedNotice": "ドキュメントプレビューではダウンロードは無効です。",
+          "directoryAuthorizationFailed": "このディレクトリへのアクセスを許可できませんでした。",
+          "directoryAccessRequest": "このプレビューは {{path}} 内のファイルの読み取りを求めています。",
+          "allowDirectory": "フォルダーを許可",
+          "directoryAccessRequestOverflow": "{{folders}}、他 {{count}} 件",
+          "directoryAccessRequestMultiple": "このプレビューは {{folders}} 内のファイルの読み取りを求めています。",
+          "allowDirectories": "{{count}} フォルダーを許可",
+          "editAddressControl": "アドレスを編集"
+        },
+        "CheckRunAnnotations": {
+          "copy": "注釈をコピー"
+        },
+        "LargeDiffLoadPrompt": {
+          "a0af0198aa": "大きな差分は既定で表示されません。",
+          "c3d9f4a712": "この差分のサイズはまだ不明のため、要求時に読み込みます。",
+          "f7fa7a40d0": "差分を読み込む"
         }
       },
       "diff": {
@@ -13401,7 +15143,9 @@
           "55127a3706": "ディクテーションが失敗しました: {{value0}}",
           "bb7f599ee7": "設定を開く",
           "2d5b9fabf9": "マイクへのアクセスが拒否されました。システム設定でアクセスを許可し、Orca を再起動。",
-          "5d2c3e7ae3": "音声が検出されませんでした。"
+          "5d2c3e7ae3": "音声が検出されませんでした。",
+          "micFallback": "選択したマイクを利用できません。システムデフォルトを使用します。",
+          "micDisconnected": "マイクが切断されました。ディクテーションを停止しました。"
         },
         "DictationIndicator": {
           "335e1bc6cb": "ディクテーションを停止する",
@@ -13477,7 +15221,8 @@
             "4a9568f773": "戻る",
             "4f86e2a10b": "ツアーをスキップ",
             "d974f32a83": "ツアーを閉じる",
-            "ffa4412b66": "次"
+            "ffa4412b66": "次",
+            "complete": "完了"
           },
           "ContextualTourProgressDots": {
             "7734cb8ad3": "の",
@@ -13487,7 +15232,27 @@
             "tour": {
               "overlay": {
                 "measurement": {
-                  "38b3155418": "次へ"
+                  "38b3155418": "次へ",
+                  "automations": {
+                    "intro": {
+                      "title": "自動化とは?",
+                      "body": "自動化は Agent の作業をスケジュール実行します。このボタンをクリックして自動化を追加します。"
+                    },
+                    "results": {
+                      "title": "結果を確認",
+                      "body": "実行では、自動化の実行時刻、内容、出力の確認先が表示されます。"
+                    }
+                  },
+                  "client": {
+                    "hosted": {
+                      "browser": {
+                        "intro": {
+                          "title": "このページはデスクトップ上で表示されます",
+                          "body": "リモートブラウザタブはこのデバイス上で表示されるようになりました。ネットワーク通信は引き続きリモートホストを経由します。"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -13532,8 +15297,18 @@
                 "removeWorktree": "ワークツリーを削除する",
                 "trashWorktree": "ゴミ箱ワークツリー",
                 "addQuickCommand": "クイックコマンドを追加",
-                "newQuickCommand": "新規クイックコマンド"
-              }
+                "newQuickCommand": "新規クイックコマンド",
+                "splitChatRight": "チャットを右に分割",
+                "moveChatRight": "チャットを右に移動",
+                "chatPaneRight": "チャットペインを右に",
+                "splitChatDown": "チャットを下に分割",
+                "moveChatDown": "チャットを下に移動",
+                "chatPaneBelow": "チャットペインを下に"
+              },
+              "splitChatRight": "チャットを右に分割",
+              "splitChatRightDescription": "アクティブなチャットを右の分割ペインで開きます。",
+              "splitChatDown": "チャットを下に分割",
+              "splitChatDownDescription": "アクティブなチャットを下の分割ペインで開きます。"
             }
           },
           "palette": {
@@ -13576,7 +15351,8 @@
             "a6914ee43f": "操作を取り戻す",
             "f4ecd61552": "このタブはスマートフォンから制御されています。持ち帰ってデスクトップで使用します。",
             "d9768ec642": "ブラウザ入力が一時停止されています",
-            "20539eca03": "モバイルがこのブラウザを操作しています"
+            "20539eca03": "モバイルがこのブラウザを操作しています",
+            "7c31b0da94": "このタブを取り戻せませんでした。スマートフォンのセッションを確認してから、再試行してください。"
           },
           "BrowserPane": {
             "1ded0d3168": "スクリーンショットをコピー",
@@ -13664,7 +15440,9 @@
             "6e776f9ef9": "ダウンロードに失敗しました",
             "756bfc25c9": "開く",
             "09a9489aa5": "表示",
-            "2a4c4b8e1f": "コピー"
+            "2a4c4b8e1f": "コピー",
+            "b71dc3d930": "再接続",
+            "fileUrlUnsupported": "このブラウザタブではローカルファイルを開けません。代わりにファイルで「横にプレビューを開く」を使います。"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "キャンセル",
@@ -13713,6 +15491,69 @@
                 "suggestions": {
                   "87fcdd0da9": "{{value0}} 検索"
                 }
+              }
+            }
+          },
+          "annotate": {
+            "use": {
+              "browser": {
+                "page": {
+                  "grab": {
+                    "annotations": {
+                      "0c7b9b2b7a": "コピーしました",
+                      "c937229f19": "スクリーンショット",
+                      "1f5cb19034": "注釈を追加しました"
+                    }
+                  }
+                }
+              }
+            },
+            "browser": {
+              "page": {
+                "annotation": {
+                  "tray": {
+                    "c16f932cb3": "保存",
+                    "024467ceac": "キャンセル",
+                    "449d2c2629": "注釈の意図",
+                    "09a7c1df70": "注釈 {{value0}} を編集"
+                  }
+                }
+              }
+            }
+          },
+          "download": {
+            "savedToRemote": "{{value2}} 上の {{value1}} に保存しました"
+          },
+          "navigate": {
+            "use": {
+              "browser": {
+                "page": {
+                  "navigation": {
+                    "downloads": {
+                      "8683b84b9e": "ブラウザページはファイルドロップの準備ができていません。",
+                      "22272f2784": "ツールバーではなく、ブラウザページ上にファイルをドロップしてください。"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "webauthn": {
+          "account": {
+            "cancel": "キャンセル",
+            "fallback": "パスキー",
+            "title": "パスキーを選択",
+            "description": "このセキュリティキーで使うアカウントを選択します。",
+            "site": "サイト"
+          }
+        },
+        "profile": {
+          "user": {
+            "agent": {
+              "option": {
+                "04af3dc12b": "未変更のユーザー Agent を使用",
+                "5bf47a3c91": "Google サインインが改善する場合がありますが、ボット対策サイトとの互換性が下がる場合があります。"
               }
             }
           }
@@ -13822,7 +15663,8 @@
           "4133d33862": "オートメーションの作成",
           "0a75e5e2fa": "Hermes オートメーションを作成する",
           "03142e7721": "Hermes オートメーションを編集する",
-          "17086b48ee": "オートメーションの編集"
+          "17086b48ee": "オートメーションの編集",
+          "4c8e1a72b9": "定期的な Agent タスク"
         },
         "AutomationMissedRunGraceField": {
           "0f4459e91d": "48時間",
@@ -13855,7 +15697,8 @@
           "8faaa00726": "実行",
           "53fc5f07ab": "実行履歴",
           "a00e38d1a3": "該当なし",
-          "fdb3caa8fb": "知られている"
+          "fdb3caa8fb": "知られている",
+          "historyUnavailable": "このホストからは実行履歴を利用できません。自動化が失敗した、または実行がないという意味ではありません。"
         },
         "AutomationRunPageFrame": {
           "40a511bed4": "実行コンテキスト",
@@ -13979,7 +15822,11 @@
           "tableStatus": "ステータス",
           "tableActions": "操作",
           "newAutomation": "新しい自動化",
-          "rowActions": "自動化の操作"
+          "rowActions": "自動化の操作",
+          "tableLastRun": "前回の実行",
+          "noListMatches": "一致する自動化がありません。",
+          "destinationProjectUnavailable": "選択した自動化の保存先が所有するプロジェクトを選択してください。",
+          "ownerChanged": "この自動化はホストが変わりました。更新して再試行してください。"
         },
         "CreateFromPicker": {
           "f061f49e3f": "リポジトリブランチを検索…",
@@ -14080,6 +15927,14 @@
               "ba20c92073": "カスタムスケジュール",
               "086a5a9fe2": "無効なスケジュール"
             }
+          },
+          "list": {
+            "last": {
+              "run": {
+                "done": "完了",
+                "failed": "失敗"
+              }
+            }
           }
         },
         "external": {
@@ -14141,6 +15996,105 @@
           "noProjects": "{host} にはプロジェクトが設定されていません。そこに追加するか、別のホストを選択してください。",
           "updateRequired": "{hosts} の Orca サーバーを更新すると、そこに自動化を保存できます。",
           "move": "保存すると、この自動化は {host} に作成され、元の自動化と実行履歴は削除されます。"
+        },
+        "hostPicker": {
+          "allHosts": "すべてのホスト",
+          "loadingHost": "ホストを読み込み中…"
+        },
+        "ownerConflict": {
+          "dismiss": "閉じる"
+        },
+        "hostStatus": {
+          "authority": {
+            "loading": "読み込み中",
+            "fresh": "最新",
+            "refreshing": "更新中",
+            "incompatible": "サーバーを更新",
+            "loadingDescription": "このホストから自動化を読み込み中。",
+            "freshDescription": "このホストから自動化を読み込みました。",
+            "refreshingDescription": "このホストに変更がないか確認中。",
+            "staleError": "更新されていません",
+            "staleErrorDescription": "このホストから前回読み込んだ自動化を表示しています。最新の更新は完了しませんでした。",
+            "unavailable": "到達不可",
+            "unavailableDescription": "このホストに接続できなかったため、その自動化を読み込めませんでした。",
+            "incompatibleDescription": "このサーバーはホストスコープの自動化クエリに対応していません。このホストの自動化を読み込むには更新してください。"
+          },
+          "execution": {
+            "connected": "接続済み",
+            "connecting": "接続中",
+            "disconnected": "未接続",
+            "unavailable": "利用不可",
+            "connectedDescription": "このホストは接続されており、自動化を実行できます。",
+            "connectingDescription": "このホストに接続中。",
+            "disconnectedDescription": "接続が復元されるまで、このホスト上の自動化は実行できません。",
+            "unavailableDescription": "この実行対象は利用できなくなりました。",
+            "unknown": "接続不明",
+            "unknownDescription": "このホストの接続状態はまだ読み込まれていません。"
+          },
+          "query": {
+            "incompatible": "サーバーを更新",
+            "legacyUnscopedDescription": "このサーバーは自動化をホストスコープなしで一覧するため、ここからは編集も実行もできません。",
+            "incompatibleDescription": "このサーバーは古いため、自動化をホスト別に扱えません。ここで管理するには更新してください。",
+            "viewOnly": "表示のみ",
+            "targetRemovedDescription": "このホストは削除されたため、その自動化をここから編集・実行できなくなりました。",
+            "targetUnverifiedDescription": "接続切断後にこのホストが検証されていないため、その自動化をここから編集・実行できません。",
+            "targetUnregisteredDescription": "このホストに登録記録がないため、その自動化をここから編集・実行できません。"
+          },
+          "action": {
+            "retry": "再試行",
+            "reconnect": "再接続",
+            "updateServer": "サーバーを更新"
+          }
+        },
+        "enablement": {
+          "paused": "一時停止中"
+        },
+        "AutomationEditorPromptSection": {
+          "a7c3e91b04": "名前を編集"
+        },
+        "AutomationListSortHeader": {
+          "sortedAscending": "{{value0}}、昇順で並べ替え",
+          "sortedDescending": "{{value0}}、降順で並べ替え"
+        },
+        "hostSummary": {
+          "partialFailure": "{{total}} ホストのうち {{failed}} を読み込めませんでした"
+        },
+        "emptyState": {
+          "unknownHost": "このホスト",
+          "hostLoading": "ホストを読み込み中…",
+          "hostLoadingDetail": "{{hostLabel}} が自動化を報告するのを待っています。",
+          "hostError": "{{hostLabel}} から自動化を読み込めませんでした",
+          "hostUnavailableDetail": "ホストに接続できなかったため、その自動化は不明です。",
+          "hostIncompatibleDetail": "このサーバーは古いため、自動化をホスト別に扱えません。",
+          "hostStaleDetail": "最新の更新は完了しませんでした。",
+          "hostNotConnected": "{{hostLabel}} は接続されていません",
+          "hostNotConnectedDetail": "その自動化を確認するには、このホストに接続してください。",
+          "hostEmpty": "{{hostLabel}} に自動化がありません",
+          "searchNoMatch": "検索に一致する自動化がありません",
+          "filtersNoMatch": "フィルターに一致する自動化がありません",
+          "allHostsEmpty": "読み込んだホスト全体に自動化がありません"
+        },
+        "hostNotice": {
+          "loading": "ホストを読み込み中…",
+          "unavailable": "{{hostLabel}} に接続できませんでした。前回読み込んだ自動化を表示しています。",
+          "ghost": "{{hostLabel}} は削除されました。それに割り当てられた自動化は引き続き表示されます。",
+          "removed": "選択したホストは利用できなくなりました。すべてのホストを表示しています。"
+        },
+        "capturedOwner": {
+          "orphan": "この自動化には実行ホストがありません。削除するか、所属ホストを再追加してください。",
+          "unfenced": "実行履歴の表示やこの自動化の管理には、このホスト上の Orca の更新が必要です。スケジュール実行はホスト上で継続する場合があります。"
+        },
+        "ownerAction": {
+          "failed": "その自動化の操作は完了しませんでした。"
+        },
+        "externalScope": {
+          "unknownManager": "この外部自動化は、表示中のどのホストにも掲載されなくなりました。",
+          "uncheckedHost": "{{hostLabel}} 上の外部自動化マネージャーを確認できませんでした。",
+          "uncheckedHosts": "{{count}} ホスト上の外部自動化マネージャーを確認できませんでした。"
+        },
+        "runHistory": {
+          "occurrencesWithLatest": "{{times}} 回、最新は {{date}}",
+          "occurrences": "{{times}} 回"
         }
       },
       "agent": {
@@ -14209,7 +16163,8 @@
           "viewSection": "表示"
         },
         "ActivityScopeFilterControls": {
-          "resetScope": "すべてのホストとプロジェクトを表示"
+          "resetScope": "すべてのホストとプロジェクトを表示",
+          "hiddenCount": "{{value0}} 件を非表示"
         },
         "ActivityThreadRow": {
           "clearNotification": "通知を消去"
@@ -14218,12 +16173,37 @@
           "f915168c8e": "未読",
           "d6a8de3934": "Agent",
           "dc708f3eff": "Agent を閉じる"
+        },
+        "clearCompleted": {
+          "undo": "元に戻す",
+          "clearedOne": "完了済み Agent 1 をクリアしました",
+          "clearedMany": "完了済み Agent {{count}} をクリアしました"
+        },
+        "ActivityThreadHoverCard": {
+          "workspace": "ワークスペース",
+          "copyPath": "パスをコピー",
+          "jumpToWorkspace": "ワークスペースにジャンプ",
+          "pathCopied": "パスをクリップボードにコピーしました",
+          "copyPathFailed": "パスのコピーに失敗しました"
+        },
+        "standaloneWorktree": {
+          "floatingTerminal": "フローティングターミナル",
+          "standaloneTerminal": "スタンドアロンターミナル"
         }
       },
       "confirmation": {
         "dialog": {
           "8490e5d36a": "確認する",
-          "56f5c60e0c": "キャンセル"
+          "56f5c60e0c": "キャンセル",
+          "92bac3217e": "今後表示しない"
+        },
+        "skip": {
+          "saved": "次回からはこの確認は省略させていただきます。",
+          "savedDescription": "これは設定で変更できます。",
+          "openSettings": "設定を開く",
+          "preference": {
+            "0b0cb6e3f9": "確認設定を保存できませんでした。"
+          }
         }
       },
       "jira": {
@@ -14377,6 +16357,114 @@
               "chooseSource": "タスクソースを選択"
             }
           }
+        },
+        "page": {
+          "dialogs": {
+            "new": {
+              "linear": {
+                "issue": {
+                  "dialog": {
+                    "dialogTitle": "新規 Linear イシュー",
+                    "dialogDescription": "選択したチームの Linear Issue を作成します。"
+                  }
+                }
+              },
+              "github": {
+                "issue": {
+                  "dialog": {
+                    "e02508846c": "このリポジトリ"
+                  }
+                }
+              }
+            },
+            "task": {
+              "page": {
+                "connect": {
+                  "dialogs": {
+                    "353c7dc71d": "アクセスを更新"
+                  }
+                }
+              }
+            }
+          },
+          "github": {
+            "github": {
+              "work": {
+                "item": {
+                  "row": {
+                    "pullRequest": "PR",
+                    "issue": "Issue",
+                    "draftPullRequest": "ドラフト PR"
+                  }
+                }
+              },
+              "detail": {
+                "host": {
+                  "8d5cde4770": "PR",
+                  "312ca15778": "GitHub 一覧"
+                }
+              },
+              "issue": {
+                "label": {
+                  "selector": {
+                    "2a1862c470": "ラベルを読み込み中…"
+                  }
+                }
+              }
+            }
+          },
+          "chrome": {
+            "task": {
+              "page": {
+                "gitlab": {
+                  "filters": {
+                    "e157d7ce4d": "MR",
+                    "2328f6a40c": "自分の ToDo"
+                  }
+                }
+              }
+            }
+          },
+          "hooks": {
+            "use": {
+              "task": {
+                "page": {
+                  "jira": {
+                    "create": {
+                      "dialog": {
+                        "jiraRequiredFieldsLoadFailed": "必須の Jira フィールドを読み込めませんでした。"
+                      }
+                    }
+                  },
+                  "linear": {
+                    "active": {
+                      "collection": {
+                        "d8b3cd9488": "プロジェクト: {{value0}}",
+                        "68462f8b29": "ビュー: {{value0}}"
+                      }
+                    }
+                  },
+                  "session": {
+                    "resume": {
+                      "savedLinearProjectMissing": "保存済み Linear プロジェクトが見つかりませんでした。",
+                      "savedLinearProjectRestoreFailed": "保存済み Linear プロジェクトを復元できませんでした。",
+                      "savedLinearViewMissing": "保存済み Linear ビューが見つかりませんでした。",
+                      "savedLinearViewRestoreFailed": "保存済み Linear ビューを復元できませんでした。"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "linear": {
+            "linear": {
+              "connect": {
+                "empty": {
+                  "3e00e8ebd4": "Linear を読み込み中"
+                }
+              }
+            }
+          }
         }
       },
       "taskPageEmptyState": {
@@ -14439,7 +16527,9 @@
         "allWorkspacesTitle": "ワークスペースを選択",
         "allWorkspacesBody": "ステータス、担当者、ラベルのフィルターは単一の Linear ワークスペースのIDを使用します。フィルタリングするワークスペースを選択してください。",
         "optionsFromTeam": "{{team}}からのオプション",
-        "clearAll": "すべてのフィルターをクリア"
+        "clearAll": "すべてのフィルターをクリア",
+        "partialCoverage": "部分的",
+        "partialCoverageTitle": "一部のチームがこのフィルターから漏れる可能性があります。詳細はフィルターを開いてください。"
       },
       "linear-issue-attribute-filter-sections": {
         "status": "状態",
@@ -14453,7 +16543,8 @@
         "searchStatus": "ステータスをフィルター…",
         "searchLabels": "ラベルをフィルター…",
         "searchAssignee": "担当者をフィルター…",
-        "back": "戻る"
+        "back": "戻る",
+        "partialCoverageMarker": "· 部分的"
       },
       "browser-pane": {
         "markup": {
@@ -14518,8 +16609,117 @@
         "ArtifactsPage": {
           "deleteTitle": "成果物を削除しますか？",
           "deleteDescription": "「{{name}}」は公開リンクで利用できなくなります。",
-          "delete": "削除"
-        }
+          "delete": "削除",
+          "refresh": "更新",
+          "retry": "再試行",
+          "signInAgain": "成果物を読み込むには、Orca に再サインインします。",
+          "loadFailed": "成果物を読み込めませんでした。",
+          "deleteFailed": "成果物を削除できませんでした。",
+          "title": "成果物",
+          "signInHeading": "Orca にサインイン",
+          "signInCopy": "サインインして、アカウント経由で共有された成果物を表示・管理します。",
+          "signingIn": "サインイン中…",
+          "signIn": "Orca にサインイン",
+          "empty": "共有された成果物がありません",
+          "emptyCopy": "HTML または Markdown ファイルを開いて「成果物として共有」を選択するか、Agent に共有を依頼します。",
+          "openArtifact": "成果物を開く",
+          "deleteArtifact": "成果物を削除",
+          "moreAvailable": "さらに成果物があります",
+          "moreAvailableCopy": "次のページを読み込んで続けます。",
+          "loadMoreFailed": "さらに成果物を読み込めませんでした。",
+          "publishingOff": "公開はオフです",
+          "publishingOffCopy": "このデバイスではまだ公開成果物リンクを作成できません。「設定」→「成果物」で公開を許可してから、開いている HTML・ Markdown ファイルから共有するか、Agent に依頼します。",
+          "openArtifactsSettings": "「設定」→「成果物」を開く",
+          "reconnectHeading": "Orca に再サインイン",
+          "reconnectCopy": "アカウント経由で共有された成果物を表示・管理するには、再サインインします。",
+          "signInAgainAction": "再サインイン",
+          "unconfiguredCopy": "このマシンでは Orca アカウントのサインインがまだ設定されていません。",
+          "openAccountSettings": "アカウント設定を開く"
+        },
+        "copyLink": "リンクをコピー",
+        "openInBrowser": "ブラウザで開く",
+        "ArtifactCollection": {
+          "noMatches": "一致なし",
+          "loadMore": "さらに読み込む"
+        },
+        "ArtifactDetailHeader": {
+          "close": "閉じる",
+          "publicLink": "このリンクを知っている人は閲覧できます"
+        },
+        "ArtifactPublishButton": {
+          "signIn": "サインイン",
+          "tryAgain": "再試行",
+          "a4a49da6af": "成果物として共有",
+          "confirmTitle": "成果物として共有",
+          "confirmDescription": "現在のファイルを、URL を知っている人が閲覧できるリンクで公開します。",
+          "accountTitle": "Orca アカウント",
+          "accountDescription": "このリンクを作成・管理するにはサインインします。",
+          "signingIn": "サインイン中…",
+          "signInAgain": "再サインイン",
+          "publishingOffTitle": "成果物の共有はオフです",
+          "publishingOffDescription": "公開リンクについて学び、設定で共有を有効にします。",
+          "openSettings": "成果物設定を開く",
+          "sharing": "共有中…",
+          "sharePublicLink": "リンクを生成",
+          "publishedDescription": "このリンクを知っている人は共有ファイルを閲覧できます。",
+          "checkingLink": "既存のリンクを確認中…",
+          "checkFailed": "既存のリンクを確認できませんでした。"
+        },
+        "artifact-publish-flow": {
+          "5cb4f5ec36": "リンクをコピー",
+          "9a078a0c65": "成果物の共有は利用できません",
+          "bba20daa6d": "Orca にサインインして再試行してください。",
+          "54b1805328": "成果物を共有できませんでした",
+          "430019efd0": "成果物を共有しました",
+          "2fc727c831": "成果物を更新しました",
+          "fbb5018602": "このファイルは空です。",
+          "6112db5a1c": "この成果物は大きすぎて共有できません。",
+          "e2ed5acd8c": "Orca はこのファイルを読み取れませんでした。ワークスペースから開いて再試行してください。",
+          "6d475e9b25": "成果物として共有できるのはローカルの HTML・ Markdown ファイルのみです。",
+          "29a406be09": "成果物にはテキストが必要です。"
+        },
+        "ArtifactPublishedLinkPanel": {
+          "copyLink": "リンクをコピー",
+          "openLink": "リンクを開く",
+          "updating": "Updating…",
+          "update": "共有内容を更新"
+        },
+        "ArtifactListSearchField": {
+          "placeholder": "検索…",
+          "clear": "検索をクリア",
+          "label": "成果物を検索"
+        },
+        "ArtifactListTableHeader": {
+          "name": "名前",
+          "type": "タイプ",
+          "size": "サイズ",
+          "updated": "更新日",
+          "actions": "操作",
+          "expires": "有効期限"
+        },
+        "typeMarkdown": "Markdown",
+        "typeHtml": "HTML",
+        "copySuccess": "成果物リンクをコピーしました",
+        "copyFailed": "成果物リンクをコピーできませんでした",
+        "preview": "成果物プレビュー",
+        "previewUnavailable": "プレビューを利用できません",
+        "previewUnavailableDescription": "表示するには、この成果物をブラウザで開きます。",
+        "actions": "成果物の操作",
+        "ArtifactActions": {
+          "more": "その他の成果物操作"
+        },
+        "updatedAt": "{{when}} に更新",
+        "updatedRecently": "最近",
+        "expiryUnknown": "有効期限不明",
+        "expired": "リンクの有効期限切れ",
+        "expires": "リンクの有効期限: {{when}}",
+        "ArtifactDetailDrawer": {
+          "description": "この共有成果物をプレビュー・管理します。"
+        },
+        "ArtifactsPageSkeleton": {
+          "loading": "成果物を読み込み中"
+        },
+        "expiredCompact": "期限切れ"
       },
       "ComposerParentWorktreePicker": {
         "label": "親ワークツリー",
@@ -14527,6 +16727,79 @@
         "description": "このワークスペースをサイドバー内の別のワークスペースの配下にネストします。ベースブランチは変更されません。",
         "searchPlaceholder": "ワークスペースを検索...",
         "noMatches": "一致する項目がありません。"
+      },
+      "WorktreeBaseFallbackDialog": {
+        "dismiss": "了解",
+        "title": "ローカルベースから作成されたワークスペース",
+        "description": "リモート追跡 ref「{{value0}}」が利用できなかったため、Orca は代わりにローカル「{{value1}}」を使用しました。このワークスペースには最新のリモート変更が含まれていない可能性があります。"
+      },
+      "native": {
+        "chat": {
+          "NativeChatStructuredSession": {
+            "a5e7f14068": "再試行",
+            "1f772bb5d0": "メッセージの配信は未確認です。",
+            "93ef441197": "メッセージは送信されませんでした。"
+          }
+        }
+      },
+      "browserPane": {
+        "workspaceDoc": {
+          "externalLinkConfirm": "リンクを開く",
+          "externalLinkCancel": "キャンセル",
+          "externalLinkTitle": "{{host}} へのリンクを開きますか?"
+        }
+      },
+      "UnexpectedSignoutCard": {
+        "3e8f5c2a91": "閉じる",
+        "6e3f1a9c5b": "Orca Relay",
+        "9f2c1a4b7d": "サインアウトされました",
+        "7b4d9e1f2a": "成果物の共有、Orca Relay、スキルの共有を復元するには、{{value0}} として再サインインします。",
+        "5a1c8d3e6f": "成果物の共有、Orca Relay、スキルの共有を復元するには、再サインインします。",
+        "1f6b2c9d4e": "戻るもの",
+        "8d2e4f7a1b": "成果物の共有",
+        "2c9a5b6e8d": "HTML ファイルと Markdown ファイルを公開し、共有リンクをすべて Orca から管理します。",
+        "4b7d2e8f1a": "モバイル回線や Wi-Fi 越しに Orca Mobile をこのデスクトップに接続します。",
+        "9a4c6b2d7e": "スキルの共有",
+        "3d8e5f1b9c": "スキルを限定公開リンクの背後で共有し、使用する任意のマシンにインストールします。",
+        "7e1a9c4d2f": "サインイン中…",
+        "c5b3e8a17d": "Orca にサインイン"
+      },
+      "BrowserCookieImportDisclosure": {
+        "title": "Google ログインはインポートされません",
+        "description": "Orca で直接 Google にサインインしてください。"
+      },
+      "linear-issue-attribute-filter-coverage-notice": {
+        "statusPartialTeamCoverage": "{{value1}} チームのステータスのうち {{value0}} でフィルター中 — 残りのチームの Issue は含まれません。",
+        "labelsPartialTeamCoverage": "{{value1}} チームのラベルのうち {{value0}} でフィルター中 — 残りのチームの Issue は含まれません。",
+        "statusAtIdLimit": "上限いっぱいでフィルター中: {{value0}} チームのステータス。それ以降に選んだ行は除外されます。",
+        "labelsAtIdLimit": "上限いっぱいでフィルター中: {{value0}} チームのラベル。それ以降に選んだ行は除外されます。"
+      },
+      "LinuxPackageInstallRecoveryCard": {
+        "e3de29c86a": "パッケージを表示",
+        "55c86654b7": "インストールコマンドをコピー",
+        "53e1559f99": "手動インストールが必要です",
+        "a7ac6ec78b": "Orca はシステムパッケージをダウンロードしました。ターミナルから更新を完了する前に Orca を終了してください。",
+        "82c6dbea00": "コマンドをコピーし、Orca を終了して、Orca がインストールされているコンピュータのシステムターミナルで実行します。完了後に Orca を開き直してください。",
+        "53c4b8e148": "特権インストール要求に応答できる認証 Agent がありませんでした。",
+        "c732bcbf8f": "パッケージを確認中…",
+        "aa57fa4f80": "コマンドをコピーしました。Orca を終了し、{{value0}} をインストールするためにシステムターミナルで実行してから、Orca を開き直してください。",
+        "b7e7c5bc95": "Orca はこのコマンドを組み立てる時点で、ダウンロードしたファイルをリリースメタデータと照合します。システムパッケージ自体は署名確認されず、その後のファイルについて Orca は保証できません。"
+      },
+      "BrowserPane": {
+        "streamConnectionLost": "リモートサーバーとの接続が切れました。",
+        "streamConnectionUnreachable": "リモートサーバーに到達できません。",
+        "streamRestartFailed": "リモートブラウザストリームを再起動できませんでした。",
+        "streamCapabilityUnsupported": "選択したランタイムはリモートブラウザストリーミングに対応していません。"
+      },
+      "BrowserCookieImportMachineNotice": {
+        "clientLabel": "このデバイス上のブラウザ",
+        "remoteLabel": "{{value0}} 上のブラウザ",
+        "clientNoteLocalStorage": "インポートはこのデバイスのブラウザを読み取ります。Cookie はローカルに保存されます。",
+        "remoteNoteRemoteStorage": "インポートは {{value0}} 上のブラウザを読み取ります。Cookie はそのマシンに保存され、画面に許可プロンプトが表示される場合があります。"
+      },
+      "HostedReviewUnlinkMenuItem": {
+        "label": "{{value0}} をワークスペースからリンク解除",
+        "description": "Orca はこのワークスペースの {{value0}}{{value1}} 詳細を非表示にします。{{value2}} 上の {{value0}} とブランチは変更されません。"
       }
     },
     "i18n": {
@@ -14562,6 +16835,12 @@
         "loadFailed": "GitLab ジョブのログを読み込めませんでした。",
         "emptyTrace": "この GitLab ジョブのログはありません。",
         "timedOut": "GitLab ジョブのログの読み込みがタイムアウトしました。"
+      },
+      "githubCheckDetailsTimeout": {
+        "timedOut": "チェック詳細の読み込みがタイムアウトしました。"
+      },
+      "gitlabIpcTimeout": {
+        "timedOut": "GitLab との通信がタイムアウトしました。"
       }
     },
     "ssh": {
@@ -14681,14 +16960,46 @@
         "skillScopeBuiltIn": "組み込み",
         "skillScopePlugin": "プラグイン",
         "skillsLoaded": "スキルを読み込みました",
-        "noCommands": "一致するコマンドがありません"
+        "noCommands": "一致するコマンドがありません",
+        "imagePreview": "フルサイズの画像プレビュー",
+        "imageSaving": "貼り付けた画像を保存中…",
+        "pendingAttachmentLimit": "待機中の添付が多すぎます。さらに添付する前に作成を完了してください。",
+        "viewAttachment": "画像を表示",
+        "imagePreviewUnavailable": "プレビューを利用できません"
       },
       "tool": {
         "running": "実行中…",
-        "result": "結果"
+        "result": "結果",
+        "moreCalls": "他 +{{value0}} 件",
+        "exitCode": "終了 {{value0}}",
+        "milliseconds": "{{value0}}ms",
+        "countOne": "ツール呼び出し 1 回",
+        "countN": "ツール呼び出し {{value0}} 回",
+        "runningPreview": "{{preview}} を実行中",
+        "runningCommand": "コマンドを実行中",
+        "runningNamedPreview": "{{toolName}} {{preview}} を実行中",
+        "runningNamed": "{{toolName}} を実行中",
+        "ranCommandOneToolSummary": "{{commandCount}} コマンドを実行し、{{toolCount}} ツールを使用しました",
+        "ranCommandManyToolsSummary": "{{commandCount}} コマンドを実行し、{{toolCount}} ツールを使用しました",
+        "ranCommandsOneToolSummary": "{{commandCount}} コマンドを実行し、{{toolCount}} ツールを使用しました",
+        "ranCommandsManyToolsSummary": "{{commandCount}} コマンドを実行し、{{toolCount}} ツールを使用しました",
+        "usedOneSummary": "1 ツールを使用しました",
+        "usedManySummary": "{{toolCount}} ツールを使用しました",
+        "editedFile": "ファイルを編集しました",
+        "addedFile": "ファイルを追加しました",
+        "deletedFile": "ファイルを削除しました",
+        "renamedFile": "ファイル名を変更しました",
+        "copyDiff": "差分をコピー",
+        "diffGap": "表示されていない行",
+        "diffTruncated": "差分は切り詰められました"
       },
       "status": {
-        "responding": "Agent が応答中です"
+        "responding": "Agent が応答中です",
+        "working": "処理中…",
+        "thinking": "思考",
+        "workingFor": "{{value0}} 作業中",
+        "workedFor": "{{value0}} 作業しました",
+        "toggleDetails": "ターンの詳細を切り替え"
       },
       "jumpToLatest": "最新にジャンプ",
       "toggle": {
@@ -14737,7 +17048,146 @@
         "allow": "許可する",
         "deny": "拒否"
       },
-      "launchPromptNotDelivered": "配信されませんでした — ターミナルを確認してください"
+      "launchPromptNotDelivered": "配信されませんでした — ターミナルを確認してください",
+      "taskList": {
+        "title": "タスク",
+        "completed": "完了",
+        "inProgress": "進行中",
+        "pending": "保留中",
+        "empty": "タスクがありません",
+        "progress": "{{total}} タスク中 {{completed}} 完了",
+        "added": "{{task}} を追加しました",
+        "removed": "{{task}} を削除しました",
+        "started": "{{task}} を開始しました",
+        "finished": "{{task}} を完了しました",
+        "reset": "保留中に戻しました: {{task}}",
+        "updated": "{{task}} を更新しました",
+        "unchanged": "タスクに変更なし",
+        "showAll": "タスク一覧全体"
+      },
+      "receipt": {
+        "cancelled": "キャンセル済み",
+        "resolved": "解決済み",
+        "unavailable": "選択した回答は利用できません",
+        "resolver": "{{device}} で回答",
+        "cancelledBy": "{{device}} でキャンセル"
+      },
+      "notices": {
+        "details": "詳細",
+        "compaction": "コンテキストを圧縮しました",
+        "plan": "プラン"
+      },
+      "backgroundTasks": {
+        "monitoring": "バックグラウンドタスクを監視中",
+        "stop": "停止",
+        "stateWorking": "実行中",
+        "stateWaiting": "待機",
+        "stateDone": "完了",
+        "stateIdle": "停止",
+        "groupAgents": "Agent",
+        "groupShell": "シェル",
+        "groupWorkflows": "ワークフロー",
+        "groupTasks": "タスク",
+        "stopTask": "{{value0}} を停止",
+        "stopAll": "バックグラウンドタスクを停止",
+        "agent": "バックグラウンド Agent",
+        "workflow": "バックグラウンドワークフロー",
+        "command": "バックグラウンドコマンド",
+        "monitor": "バックグラウンドモニター",
+        "task": "バックグラウンドタスク",
+        "detailsUnavailable": "このセッションではタスクの詳細を利用できません。",
+        "countAgentsOne": "Agent 1",
+        "countAgentsMany": "Agent {{value0}}",
+        "countShellOne": "シェル 1",
+        "countShellMany": "シェル {{value0}}",
+        "countShellCommandOne": "シェルコマンド 1",
+        "countMonitorsOne": "モニター 1",
+        "countMonitorsMany": "モニター {{value0}}",
+        "countWorkflowsOne": "ワークフロー 1",
+        "countWorkflowsMany": "ワークフロー {{value0}}",
+        "countTasksOne": "タスク 1",
+        "countTasksMany": "タスク {{value0}}",
+        "headerTotal": "バックグラウンドタスク {{value0}}",
+        "stateMonitoring": "監視中",
+        "stateBlocked": "ブロック中",
+        "stateUnverifiable": "未確認",
+        "reasonWaiting": "承認待ち",
+        "reasonUnverifiable": "連絡なし",
+        "reasonBlocked": "失敗",
+        "groupMonitors": "モニター"
+      },
+      "handoff": {
+        "mode": {
+          "terminal": "ターミナル",
+          "switching": "切り替え中",
+          "chat": "チャット"
+        },
+        "cancel": "キャンセル",
+        "retry": "再試行",
+        "details": "詳細",
+        "stage": {
+          "finishingChat": "チャットセッションを終了中…",
+          "finishingTerminal": "Agent ターミナルを終了中…",
+          "openingTerminal": "Agent ターミナルを開いています…",
+          "resumingChat": "チャットセッションを再開中…",
+          "verifyingTerminal": "Agent ターミナルを確認中…",
+          "verifyingChat": "チャットセッションを確認中…",
+          "recovering": "Agent セッションを回復中…",
+          "manualRecovery": "Agent セッションの回復が必要です"
+        },
+        "switchingOwner": "セッション所有者を切り替え中…",
+        "switchingAfterTurn": "このターンの後に切り替えます",
+        "returningAfterTurn": "このターンの後に戻ります",
+        "switchAfterTurn": "このターンの後に切り替え",
+        "stopTurnAndSwitch": "ターンを停止して切り替え",
+        "openAgentTui": "Agent TUI を開く",
+        "returnAfterTurn": "このターンの後に戻る",
+        "returnToChat": "チャットに戻る",
+        "agentOpenOnHost": "Agent は {{value0}} 上のターミナルで開いています。",
+        "agentOpen": "Agent はターミナルで開いています。",
+        "exitTerminal": "チャットで続けるには、Agent ターミナルを終了します。",
+        "retryProof": "再試行の証明"
+      },
+      "subagents": {
+        "state": {
+          "working": "実行中",
+          "idle": "idle",
+          "stopped": "停止",
+          "failedCount": "{{value0}} 件失敗",
+          "completed": "完了",
+          "failed": "失敗",
+          "unverifiable": "未確認",
+          "workingCount": "{{value0}} が作業中",
+          "idleCount": "{{value0}} がアイドル",
+          "stoppedCount": "{{value0}} が停止",
+          "unverifiableCount": "{{value0}} が未確認"
+        },
+        "startedOne": "サブ Agent 1 を開始しました",
+        "startedN": "サブ Agent {{value0}} を開始しました",
+        "ranOne": "サブ Agent 1 を実行しました",
+        "ranN": "サブ Agent {{value0}} を実行しました",
+        "tokens": "{{value0}} トークン"
+      },
+      "turnDiff": {
+        "one": "変更ファイル 1 件",
+        "many": "変更ファイル {{count}} 件",
+        "partial": "部分的な差分",
+        "recorded": "このターンの記録済み編集からの合計。"
+      },
+      "providerFrame": {
+        "byteLength": "{{value0}} バイト"
+      },
+      "structuredSessionCloseFailed": "このチャットセッションを閉じることができませんでした",
+      "structuredSessionLaunchFailed": "{{value0}} チャットを開けませんでした",
+      "structuredSessionLaunchPending": "{{value0}} チャットを開始中…",
+      "structuredSessionCloseFailedDescription": "プロバイダーを回復可能なままにするため、ターミナルは開いたままです。",
+      "structuredSessionFellBackToTerminal": "構造化チャットを利用できません",
+      "structuredSessionFellBackToTerminalDescription": "Orca は代わりに {{value0}} ターミナルを開こうとしました。",
+      "structuredSessionLaunchFailedDescription": "Orca は構造化 {{value0}} チャットを開けませんでした。詳細はログを確認してください。",
+      "conversationCommand": {
+        "pendingWork": "このコマンドを使う前に、保留中の作業とメッセージが終わるのを待ってください。",
+        "unconfirmed": "会話操作は確認されませんでした。"
+      }
     },
     "tab": {
       "bar": {
@@ -14764,6 +17214,232 @@
         "presentation": {
           "gitlabMergeRequestNumber": "MR #{{value0}}",
           "githubPullRequestNumber": "PR #{{value0}}"
+        },
+        "browse": {
+          "measureSizes": "スキャン",
+          "searchLabel": "ワークスペースの検索",
+          "filters": "フィルター",
+          "clearFilters": "フィルターをクリア",
+          "facet": {
+            "git": "Git",
+            "review": "レビュー",
+            "location": "位置",
+            "activity": "アクティビティ",
+            "status": "ワークスペースのステータス",
+            "agent": "Agent",
+            "ticket": "チケット",
+            "safety": "安全性",
+            "size": "ディスク上のサイズ",
+            "context": "ローカルコンテキスト"
+          },
+          "host": "ホスト",
+          "repo": "リポジトリ",
+          "tier": {
+            "ready": "準備完了",
+            "review": "レビュー待ち",
+            "protected": "保護済み"
+          },
+          "dismissed": "無視済み",
+          "archived": "アーカイブ済み",
+          "pinned": "ピン留め済み",
+          "unread": "未読",
+          "noWorkspaces": "ワークスペースが見つかりません。",
+          "noMatches": "これらのフィルターに一致するワークスペースはありません。",
+          "sortBy": "並べ替え",
+          "sortByField": "{{value0}} で並べ替え",
+          "sort": {
+            "created": "作成日時",
+            "size": "サイズ",
+            "name": "ワークスペース",
+            "repo": "リポジトリ",
+            "path": "パス",
+            "host": "ホスト",
+            "workspaceStatus": "状態",
+            "agent": "Agent",
+            "git": "Git",
+            "behind": "遅れ",
+            "branch": "ブランチ",
+            "review": "レビュー",
+            "lastActivity": "最終アクティビティ",
+            "lastVisited": "最終オープン",
+            "ahead": "先行",
+            "ticket": "チケット",
+            "localContext": "開いているコンテキスト",
+            "tier": "安全性",
+            "blockerCount": "ブロッカー"
+          },
+          "git": {
+            "dirty": "未コミットの変更",
+            "unpushed": "未プッシュのコミット",
+            "clean": "クリーン",
+            "unknown": "未確認"
+          },
+          "agent": {
+            "working": "作業中",
+            "idle": "アイドル",
+            "permission": "あなたの対応待ち"
+          },
+          "review": {
+            "open": "開く",
+            "draft": "下書き",
+            "merged": "マージ済み",
+            "closed": "クローズ",
+            "unknown": "不明",
+            "otherProvider": "その他"
+          },
+          "ticket": {
+            "workItem": "作業項目",
+            "linear": "Linear",
+            "issue": "Issue"
+          },
+          "updatedAgo": "{{value0}} を更新しました",
+          "refreshing": "更新中…",
+          "openWorkspaceNamed": "{{value0}} を開く",
+          "openWorkspace": "ワークスペースを開く",
+          "chip": {
+            "list": "{{value0}}: {{value1}}",
+            "triState": "{{value0}}: {{value1}}",
+            "presence": "{{value0}}: {{value1}}",
+            "none": "なし",
+            "kind": {
+              "status": "状態",
+              "agent": "Agent",
+              "git": "Git",
+              "review": "レビュー",
+              "context": "コンテキスト",
+              "host": "ホスト",
+              "repo": "Repo",
+              "dismissed": "無視済み",
+              "archived": "アーカイブ済み",
+              "pinned": "ピン留め済み",
+              "unread": "未読",
+              "comment": "コメント",
+              "reviewState": "レビュー状態",
+              "reviewProvider": "プロバイダー",
+              "ticket": "チケット",
+              "ticketSource": "チケットソース",
+              "blocker": "ブロッカー",
+              "tier": "安全性",
+              "prunable": "整理可能",
+              "locked": "ロック済み",
+              "retainedAgents": "完了済み Agent"
+            },
+            "idleDays": "アイドル {{value0}} 日以上",
+            "neverVisited": "未訪問",
+            "minSize": "{{value0}} MB 以上",
+            "maxSize": "{{value0}} MB 以下",
+            "excludesUnsized": "計測済みのみ",
+            "excludesStatusless": "ステータスあり",
+            "only": "のみ",
+            "exclude": "除外済み",
+            "minAhead": "先行 {{value0}} 以上",
+            "minBehind": "遅延 {{value0}} 以上",
+            "branchQuery": "ブランチ: {{value0}}",
+            "pathPrefix": "パス: {{value0}}",
+            "has": "あり",
+            "completelyEmpty": "失うものなし",
+            "selectableOnly": "削除可能のみ"
+          },
+          "noSizes": "ワークスペースサイズはまだ計測されていません。",
+          "noSizesDescription": "ディスク使用量の計測後にサイズが表示されます。",
+          "measureSizesTitle": "ワークスペースサイズをスキャン",
+          "measureSizesDescription": "ディスク使用量をスキャンして、サイズでワークスペースを比較・並べ替え・フィルターします。",
+          "sizeOnDisk": "ディスク上のサイズ: {{value0}}",
+          "checkingGitRow": "git ステータスを確認中",
+          "searchPlaceholder": "名前、リポジトリ、ブランチ、パス、ホストを検索",
+          "showingCount": "{{value1}} 中 {{value0}} を表示",
+          "checkingGit": "git ステータスを確認中: 残り {{value0}}",
+          "minAhead": "先行コミット ≥",
+          "minBehind": "遅延コミット ≥",
+          "branchQuery": "ブランチを含む",
+          "prunable": "整理可能",
+          "locked": "ロック済み",
+          "reviewPresence": "PR / MR",
+          "reviewProvider": "プロバイダー",
+          "ticketPresence": "リンクされたチケット",
+          "pathPrefix": "パスが始まる",
+          "blockerMode": "ブロッカーの一致",
+          "blockerModeAny": "いずれかあり",
+          "blockerModeNone": "なし",
+          "blockers": "ブロッカー",
+          "selectableOnly": "今削除できるワークスペースのみ",
+          "idleSignal": {
+            "lastVisited": "未オープン",
+            "lastActivity": "アクティビティなし",
+            "created": "以前に作成"
+          },
+          "idleMinDays": "アイドル期間が少なくとも",
+          "days": "日",
+          "neverVisited": "開いたことがない",
+          "minSize": "少なくとも",
+          "maxSize": "多くとも",
+          "includeUnsized": "未計測のワークスペースを含む",
+          "matchStatusless": "ステータスのないワークスペースを含む",
+          "comment": "コメントあり",
+          "retainedDoneAgents": "完了済み Agent の記録",
+          "contextPresence": "開いているタブ、ターミナル、コメント",
+          "completelyEmpty": "失うものは何もありません",
+          "noMatchesDescription": "すべてのワークスペースは 1 つの一覧にあります。ファセットを広げるか、フィルターをクリアしてください。",
+          "selectAll": "一致するワークスペースをすべて選択",
+          "triState": {
+            "any": "すべて",
+            "only": "のみ",
+            "exclude": "除外"
+          },
+          "presence": {
+            "any": "すべて",
+            "some": "あり",
+            "none": "なし"
+          },
+          "tierField": "クリーンアップ層",
+          "idleSignalField": "アイドル信号",
+          "selectionVanishedOne": "選択したワークスペース 1 はもう存在しません。",
+          "selectionVanished": "選択した {{value0}} ワークスペースはもう存在しません。",
+          "refreshingProgress": "更新中 {{value0}}/{{value1}}",
+          "notMeasured": "未計測",
+          "workspaceStatus": "ワークスペースの状態: {{value0}}",
+          "measuringSizesProgress": "スキャン中 {{value0}}/{{value1}}",
+          "measuringSizes": "サイズをスキャン中",
+          "measureSizesFailed": "ワークスペースサイズをスキャンできませんでした",
+          "selectedCount": "{{value0}} を選択中",
+          "gitStatusCheckFailed": "git ステータスの確認に失敗しました",
+          "gitStatusUnverified": "git ステータスを確認できませんでした",
+          "deleteAnyway": "そのまま削除",
+          "forceDeleteProjectionOne": "{{count}} ワークスペースに現在リスクが表示されており、強制削除が必要な可能性があります",
+          "forceDeleteProjectionMany": "{{count}} ワークスペースに現在リスクが表示されており、強制削除が必要な可能性があります",
+          "selectionWithheldOne": "選択したワークスペース 1 は現在のフィルターで非表示のため、選択解除されました。",
+          "selectionWithheld": "選択した {{value0}} ワークスペースは現在のフィルターで非表示のため、選択解除されました。",
+          "selectAllCountOne": "安全性確認済みワークスペース 1 を選択",
+          "selectAllCount": "安全性確認済みワークスペース {{value0}} をすべて選択",
+          "appliedFilters": "適用済みフィルター",
+          "removeFilter": "フィルター {{value0}} を解除"
+        },
+        "scan": {
+          "noWorkspaces": "ワークスペースが見つかりません。",
+          "progress": "ワークスペースをスキャン中（{{value0}}/{{value1}}）",
+          "singleError": "{{value0}} を確認できませんでした: {{value1}}。一部のワークスペースが不足している可能性があります。更新して再試行してください。",
+          "moreErrors": "、他 +{{value0}} 件",
+          "multipleErrors": "{{value0}} リポジトリを確認できませんでした（{{value1}}{{value2}}）。一部のワークスペースが不足している可能性があります。更新して再試行してください。",
+          "readyOneOne": "ワークスペース 1 が見つかり、クリーンアップ提案 1 があります。",
+          "readyOneMany": "ワークスペース 1 が見つかり、クリーンアップ提案 {{value0}} があります。",
+          "readyManyOne": "ワークスペース {{value0}} が見つかり、クリーンアップ提案 1 があります。",
+          "readyManyMany": "ワークスペース {{value0}} が見つかり、クリーンアップ提案 {{value1}} があります。",
+          "fallbackRepository": "リポジトリ",
+          "gitListFailed": "Git はワークツリーを一覧できませんでした",
+          "readyOne": "ワークスペース 1 が見つかりました。",
+          "readyMany": "ワークスペース {{value0}} が見つかりました。"
+        },
+        "relativeTime": {
+          "justNow": "たった今",
+          "minutesAgo": "{{value0}} 分前",
+          "hoursAgo": "{{value0}} 時間前",
+          "daysAgo": "{{value0}} 日前",
+          "never": "なし"
+        },
+        "host": {
+          "label": "ホスト: {{value0}}",
+          "unknown": "不明なホスト",
+          "candidateName": "{{value1}} 上の {{value0}}"
         }
       }
     },
@@ -14799,6 +17475,26 @@
         "copySessionIdSuccess": "セッション ID をコピーしました",
         "copySessionIdError": "セッション ID のコピーに失敗しました"
       }
+    },
+    "jiraUserPicker": {
+      "select": "{{value0}} を選択",
+      "search": "ユーザーを検索",
+      "empty": "ユーザーが見つかりません"
+    },
+    "status": {
+      "bar": {
+        "workspaceSpace": {
+          "otherTopLevelItems": "その他のトップレベル項目（{{value0}}）"
+        }
+      }
+    },
+    "cmd-j": {
+      "paletteSessionAge": {
+        "minutes": "{{value0}} 分",
+        "hours": "{{value0}} 時間",
+        "days": "{{value0}} 日",
+        "underOneMinute": "1 分未満"
+      }
     }
   },
   "dashboardPopout": {
@@ -14821,7 +17517,58 @@
       "zoomIn": "ズームイン",
       "fit": "全体表示",
       "projectCount": "{{agents}}件の Agent · {{workspaces}}件のワークスペース",
-      "agentCount": "{{count}}件の Agent"
+      "agentCount": "{{count}}件の Agent",
+      "filters": {
+        "reset": "リセット",
+        "agents": "Agent",
+        "time": "時間",
+        "summaryAll": "全て",
+        "summarySelected": "{{count}} 件選択中",
+        "workspace": "ワークスペース",
+        "showStates": "Agent の状態",
+        "agentlessWorkspaces": "Agent のないワークスペース",
+        "orchestrationLinks": "オーケストレーションリンク",
+        "orchestrationLinksHidden": "オーケストレーションリンクを非表示",
+        "workspaceVisibility": "マップの内容",
+        "title": "マップ操作",
+        "ofTotalAgents": "{{total}} Agent 中を表示",
+        "quickViews": "クイックビュー",
+        "lifespan": "セッション期間",
+        "sinceMessage": "最終メッセージから",
+        "timeInState": "現在の状態の継続時間",
+        "timeMinimum": "{{label}}（最小）",
+        "timeMaximum": "{{label}}（最大）",
+        "timeAny": "すべて",
+        "timeRangeCount": "{{count}} 範囲",
+        "resetRanges": "範囲をリセット",
+        "summaryCount": "{{total}} 中 {{shown}}",
+        "stateChip": "状態: {{states}}"
+      },
+      "runningAgents": "Agent",
+      "agentCount_other": "{{count}}件の Agent",
+      "quickView": {
+        "unread": "未読",
+        "orchestration": "オーケストレーション",
+        "everything": "すべて",
+        "attention": "要対応",
+        "stuck": "スタック",
+        "recent": "直近 30 分",
+        "longRunning": "長時間実行",
+        "stale": "古い（3 日超）"
+      },
+      "openWorktree": "{{worktree}} ワークツリーの詳細を開く",
+      "openFolderWorkspace": "{{workspace}} フォルダーワークスペースの詳細を開く",
+      "worktreeSummary": "{{total}} Agent · {{active}} 実行中 · {{done}} 完了",
+      "worktreeSummary_one": "{{total}} Agent · {{active}} 実行中 · {{done}} 完了",
+      "worktreeSummary_other": "{{total}} Agent · {{active}} 実行中 · {{done}} 完了",
+      "spawnAgent": "新規 Agent を開始",
+      "noLaunchableAgents": "有効な Agent が検出されません。",
+      "sleepWorkspace": "スリープ",
+      "agentCount_one": "{{count}} Agent",
+      "noWorkspaceAgents": "このワークスペースに Agent がいません。",
+      "status": {
+        "doneSeen": "完了、確認済み"
+      }
     },
     "placeholder": {
       "title": "Agent ダッシュボード",
@@ -14860,7 +17607,8 @@
     "terminal": {
       "closed": "実行中のターミナルがありません。この Agent のペインは閉じられています。",
       "focusWorktree": "ワークツリーを開く",
-      "close": "閉じる"
+      "close": "閉じる",
+      "remotePreviewUnavailable": "このリモートセッションのプレビューはありません — ターミナルを見るにはワークスペースを開きます。"
     },
     "close": "ダッシュボードを閉じる",
     "settingsTooltip": "ボード設定",
@@ -14880,7 +17628,8 @@
       "project": "プロジェクト",
       "workspaceStatus": "ワークスペースのステータス",
       "reviewStatus": "PR / MR ステータス",
-      "clearAll": "すべてのフィルターをクリア"
+      "clearAll": "すべてのフィルターをクリア",
+      "removeChip": "{{filter}} を解除"
     },
     "search": {
       "placeholder": "ワークツリー、プロジェクト、Agent を検索…",
@@ -14892,6 +17641,12 @@
     "settings": {
       "showIdle": "アイドル状態の Agent を表示",
       "showIdleCopy": "完了を報告せずに30分間停止している Agent を含めます。デフォルトでは非表示です。"
+    },
+    "host": {
+      "sshNamed": "SSH ホスト · {{host}}",
+      "ssh": "SSH ホスト",
+      "remoteNamed": "リモート Orca ホスト · {{host}}",
+      "remote": "リモート Orca ホスト"
     }
   },
   "dashboard": {
@@ -14924,7 +17679,77 @@
       "certificateChallengeExpired": "この証明書の承認は期限切れです。ページを再試行して、承認をもう一度リクエストしてください。",
       "certificateChallengeChanged": "証明書のリクエストが変更されました。ページを再試行して、警告の内容を改めて確認してください。",
       "certificateChallengeUnavailable": "この証明書のリクエストは利用できなくなりました。ページを再試行して、もう一度リクエストしてください。",
-      "certificateProceedFailed": "Orca はこの証明書のリクエストを承認できませんでした。ページを再試行して、もう一度お試しください。"
+      "certificateProceedFailed": "Orca はこの証明書のリクエストを承認できませんでした。ページを再試行して、もう一度お試しください。",
+      "sshRoutedHint": "このページはワークスペースの SSH ホスト経由で表示しています。ホストが切断されているか、このサイトに接続できない可能性があります。",
+      "recheckSshRoute": "接続を確認"
+    },
+    "navigation": {
+      "back": "戻る",
+      "forward": "進む",
+      "reload": "リロード"
+    },
+    "sshRoute": {
+      "retry": "再試行",
+      "showDetails": "詳細を表示",
+      "preparingTitle": "SSH ホスト経由で接続中",
+      "errorTitle": "SSH ブラウザルーティングを利用できません",
+      "errorDescription": "このワークスペースのページは SSH ホスト経由で表示しますが、その接続は現在利用できません。",
+      "tryAnyway": "そのまま試す",
+      "browseLocally": "代わりにこのデバイスから表示",
+      "forwardingBlockedTitle": "SSH サーバーがブラウザの通信をブロックしています",
+      "sshUnavailableTitle": "SSH 接続を利用できません",
+      "forwardingBlockedDescription": "このサーバーは TCP フォワーディングを拒否しています（sshd 設定の「AllowTcpForwarding no」などが原因）。これを経由した表示にはフォワーディングが必要です。管理者にフォワーディングの許可を依頼するか、代わりにこのデバイスから表示してください。",
+      "sshUnavailableDescription": "このワークスペースのページは SSH ホスト経由で表示しますが、その接続は現在利用できません。ホストに再接続してから、再試行してください。"
+    },
+    "sshEgress": {
+      "localChip": "このデバイス",
+      "routedTooltip": "{{value0}} 経由で表示中",
+      "localTooltip": "{{value0}} ではなくこのデバイスから表示中",
+      "routedDetail": "ネットワーク通信と DNS は、ワークスペースの SSH ホストを経由します。",
+      "localDetail": "ページはこのマシンとそのネットワークから読み込まれます。",
+      "settingsLink": "ルーティング設定"
+    },
+    "guestRecovery": {
+      "title": "ブラウザページが停止しました",
+      "failed": "ブラウザページが予期せず停止しました。再試行すると復元できます。"
+    },
+    "clientHosted": {
+      "preparationFailed": "このデスクトップでリモートブラウザを開始できませんでした。ペアリング接続を確認して、再試行してください。",
+      "unavailableTitle": "クライアントホスト型ブラウザを利用できません",
+      "unavailableDescription": "このページは別のデスクトップに接続されているか、すでに利用できなくなっています。",
+      "download": {
+        "started": "{{filename}} をダウンロード中…",
+        "completed": "{{filename}} をダウンロードしました",
+        "canceled": "ダウンロードをキャンセルしました。",
+        "failed": "ダウンロードを完了できませんでした。"
+      },
+      "popupBlocked": "ポップアップをブロックしました: {{origin}}",
+      "hostPaneOfflineTitle": "そのデバイスは接続されていません",
+      "hostPaneNamedTitle": "{{device}} に表示中",
+      "hostPaneTitle": "別のデバイスに表示中",
+      "hostPaneOfflineDescription": "このページは一覧に残るため、ここから閉じることができます。デバイスが再接続すると復元されます。",
+      "hostPaneDescription": "このページは、開いたペアリング済みデスクトップ上でレンダリングされます。",
+      "hostRowClose": "ホストされたページを閉じる",
+      "hostRowCloseFailed": "このページを閉じることができませんでした。ホスト側のデバイスがビジー状態の可能性があります。再試行してください。",
+      "hostRowOfflineNamed": "オフライン — {{device}} でホストされていました",
+      "hostRowOffline": "オフライン — ホスト側のデバイスが終了しました",
+      "hostRowNamed": "{{device}} でホスト中",
+      "hostRow": "別のデバイスでホスト中"
+    },
+    "reopenOnServer": {
+      "action": "サーバーで開き直す",
+      "pending": "開き直し中…",
+      "caveat": "このページの最後のアドレスを使って、リモートホスト上に新規ページを開きます。サインイン状態などの一時的なページ状態は引き継がれない場合があり、フォーム送信から開いたページは空白で開きます。",
+      "failed": "このページをリモートホストで開けませんでした。接続を確認して、再試行してください。"
+    },
+    "remoteEgress": {
+      "clientHostedTooltip": "{{value0}} 経由で表示中",
+      "streamedTooltip": "{{value0}} 上で表示中",
+      "clientHostedDetail": "ページはこのデバイス上でレンダリングされます。ネットワーク通信と DNS はリモートホストを経由します。",
+      "streamedDetail": "ページはリモートホスト上で実行され、このデバイスにストリーミングされます。"
+    },
+    "remote": {
+      "findUnavailable": "このページがリモートホストからストリーミングされている間は、ページ内検索を利用できません。"
     }
   },
   "runtimeRpc": {
@@ -14964,6 +17789,61 @@
       "working": "処理中",
       "stopped": "停止",
       "finished": "完了"
+    }
+  },
+  "featureTips": {
+    "voice": {
+      "startDictation": "ディクテーションを開始する",
+      "demoPrompt": "この差分をエッジケース観点でレビューし、見つけたものにテストを追加します。",
+      "agentPromptTitle": "Agent プロンプト",
+      "listening": "聞き取り中…",
+      "focusPaneInstruction": "ターミナル、エディター、Agent プロンプトにフォーカスしてから押します",
+      "startInstruction": "音声ディクテーションを開始します。押します",
+      "stopInstruction": "再度押すと停止します。",
+      "unassignedInstruction": "フォーカスしたペインで音声ディクテーションを開始する前に、ディクテーションのショートカットを割り当てます。",
+      "settingsInstruction": "モデル、ディクテーションモード、ショートカットはいつでも変更できます:",
+      "settingsLink": "設定 → 音声"
+    }
+  },
+  "rendererRecovery": {
+    "reload": "リロード",
+    "quit": "終了",
+    "copyCommands": "コマンドをコピー",
+    "stalledDetail": "Orca はクラッシュ後にウィンドウを再読み込みしましたが、読み込みが完了しませんでした。",
+    "crashLoopDetail": "Orca は連続 {{recoveryCount}} 回の回復を試みましたが成功しませんでした。",
+    "driverFallback": "解決しない場合、原因は通常グラフィックスドライバーです。",
+    "genericDetail": "多くの場合、グラフィックスドライバーまたはインストールの問題です。再読み込みして再試行するか、Orca を終了して開き直してください。",
+    "title": "Orca の読み込みに繰り返し失敗しています",
+    "stalledMessage": "クラッシュ後の再読み込み中にアプリウィンドウが応答しなくなりました。",
+    "crashLoopMessage": "アプリウィンドウが繰り返しクラッシュし、自動再読み込みを停止しました。"
+  },
+  "sidebar": {
+    "revealFiltered": {
+      "title": "非表示のワークスペースを表示しますか?",
+      "description": "アクティブなワークスペースはサイドバーで非表示になっています。表示すると、サイドバーのフィルターがクリアされます。",
+      "confirm": "フィルターをクリアして表示",
+      "cancel": "フィルターを維持"
+    }
+  },
+  "editor": {
+    "richMarkdown": {
+      "tooLarge": "ファイルがリッチ編集の上限 {{limit}} を超えています。代わりにソースモードで表示します。",
+      "openAnyway": "そのまま開く"
+    }
+  },
+  "quickOpen": {
+    "moreMatchesAvailable": "さらに一致がある可能性があります。検索を絞って結果を狭めてください。"
+  },
+  "checksPanel": {
+    "unlinked": {
+      "title": "PR のリンクを解除しました",
+      "description": "PR #{{number}} はこのワークスペースで非表示です。再度リンクするとチェックとレビュー詳細が復元されます。",
+      "relink": "PR #{{number}} をリンク"
+    }
+  },
+  "sourceControl": {
+    "unlinkedPr": {
+      "status": "PR #{{number}} のリンク解除済み"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -38,7 +38,43 @@
       },
       "menuBarIcon": {
         "title": "显示菜单栏图标",
-        "description": "在 macOS 菜单栏中保留 Orca 快捷方式和活动指示器。"
+        "description": "在 macOS 菜单栏中保留 Orca 快捷方式和活动指示器。",
+        "keyword": {
+          "menuBar": "菜单栏",
+          "statusItem": "状态项",
+          "activity": "活动"
+        }
+      }
+    },
+    "browser": {
+      "clientHostedRemote": {
+        "title": "在此设备上托管远程浏览器页面",
+        "description": "在此桌面上渲染远程工作区页面；网络流量仍通过远程主机传输。仅对新页面生效。",
+        "optionDevice": "此设备",
+        "optionDeviceTooltip": "页面在此桌面上渲染，因此输入和弹出窗口表现为原生行为。",
+        "optionServer": "服务器（串流）",
+        "optionServerTooltip": "页面在远程服务器上渲染并传输到此设备。",
+        "rowTitle": "远程服务器工作区",
+        "rowDescription": "页面渲染位置。流量始终通过远程服务器传输。仅对新页面生效。"
+      },
+      "sshWorkspaceRouting": {
+        "title": "通过 SSH 工作区主机浏览",
+        "description": "SSH 工作区中的浏览器页面通过工作区的 SSH 主机传输流量，并在该主机上解析 DNS。关闭表示页面从本机浏览。",
+        "disabledHosts": "改为从此设备浏览的主机：",
+        "enableHost": "恢复路由",
+        "optionHost": "SSH 主机",
+        "optionHostTooltip": "流量和 DNS 通过工作区的 SSH 主机传输。",
+        "optionDevice": "此设备",
+        "optionDeviceTooltip": "页面从本机网络浏览。",
+        "rowTitle": "SSH 工作区",
+        "rowDescription": "浏览器流量的出口位置。页面始终在此设备上渲染。",
+        "useHost": "使用 SSH 主机",
+        "probeSkippedHosts": "跳过连接检查直接路由的主机（仍要尝试）：",
+        "probeAgain": "重新检查"
+      },
+      "remoteBrowsing": {
+        "heading": "远程浏览",
+        "headingDescription": "远程工作区页面的渲染位置及其网络流量的出口位置。"
       }
     }
   },
@@ -87,7 +123,48 @@
       "issue": "议题",
       "mr": "MR",
       "port": "端口",
-      "pr": "PR"
+      "pr": "PR",
+      "task": "任务",
+      "automation": "运行"
+    },
+    "linearIssue": {
+      "createLabel": "从 Linear 议题 {{value0}} 创建工作区：{{value1}}",
+      "pendingLabel": "从 Linear 议题 {{value0}} 创建工作区",
+      "loadingLabel": "正在加载 Linear 议题 {{value0}}",
+      "createHint": "从 Linear 议题创建工作区",
+      "loadingHint": "正在加载 Linear 议题…"
+    },
+    "renderCapOverflow": "还有 {{value0}} 项",
+    "seeMore": "查看更多",
+    "filter": {
+      "emptyTitle": "没有与当前筛选匹配的结果",
+      "emptySubtitle": "清除上方筛选，或扩大到更多主机和项目。",
+      "tabKey": "选项卡",
+      "label": "筛选",
+      "activeCount": "{{value0}} 项生效中",
+      "removeChip": "移除筛选 {{value0}}",
+      "chipOverflow": "+{{value0}}",
+      "clearAll": "全部清除",
+      "hosts": "主机",
+      "projects": "项目",
+      "trigger": "筛选结果",
+      "search": "按主机或项目筛选…",
+      "searchHosts": "筛选主机…",
+      "searchProjects": "筛选项目...",
+      "noOptions": "没有匹配的主机或项目",
+      "noHosts": "没有匹配的主机",
+      "noProjects": "没有匹配的项目",
+      "moreOptions": "还有 {{value0}} 项——继续输入以缩小范围",
+      "selectAllMatching": "全选匹配项（{{value0}}）",
+      "selectedCollapsed": "已选 {{value0}} 项——通过标签或“清除”移除",
+      "clearHosts": "清除主机",
+      "clearProjects": "清除项目",
+      "back": "返回",
+      "ariaActive": "筛选：{{value0}} 项生效。"
+    },
+    "taskUrl": {
+      "loadingHint": "正在加载 {{value0}}…",
+      "createHint": "从 {{value0}} 创建工作区"
     }
   },
   "auto": {
@@ -158,7 +235,8 @@
         "runtimeEnvironmentManuallyDisconnected": "运行时环境已手动断开连接。",
         "loopbackPairingBlocked": "此访问链接会指回此设备。",
         "remotePairingUnreachable": "无法连接 {{endpoint}} 上的 Orca。",
-        "remotePairingInvalidDetails": "此访问链接包含无效的连接信息。"
+        "remotePairingInvalidDetails": "此访问链接包含无效的连接信息。",
+        "remotePairingSaveFailed": "Orca 已验证该主机，但无法保存。请检查浏览器存储后重试。"
       },
       "web": {
         "preload": {
@@ -201,7 +279,8 @@
           "51f15c37d3": "无法打开目录：{{value0}}",
           "f2e00db373": "未找到文件：{{value0}}",
           "checkRunDetailsUnavailable": "此检查没有可用的详细信息。",
-          "checkRunDetailsLoadFailed": "加载检查详细信息失败。"
+          "checkRunDetailsLoadFailed": "加载检查详细信息失败。",
+          "checkRunDetailsRepoUnavailable": "此检查的仓库详情不可用。"
         },
         "github": {
           "f129c42773": "GitHub 没有回复新评论。",
@@ -236,7 +315,9 @@
             "changedSinceConfirmation": "工作区在确认后发生了更改。请刷新并在删除前重新检查。",
             "gitStatusUnavailable": "Orca 无法检查此工作区的 Git 状态。请重试，或从对应主机的侧边栏或项目列表中将其删除。",
             "gitStatusUnavailableOlderPeer": "Orca 无法将此 Git 状态检查失败与主机匹配。请更新较旧的已连接端，或从对应主机的侧边栏或项目列表中删除该工作区。",
-            "forceNeedsApproval": "请先检查并确认此工作区，然后再强制删除。"
+            "forceNeedsApproval": "请先检查并确认此工作区，然后再强制删除。",
+            "hostCollision": "错误：此工作区在多台主机的相同路径下存在",
+            "hostUnresolved": "Orca 无法判断此工作区属于哪台主机。请刷新项目后重新检查。"
           }
         },
         "worktrees": {
@@ -270,7 +351,25 @@
           "runtimeScopeForbiddenDescription": "移动端范围的配对无法使用工作区。请通过设置 → 远程 Orca 服务器 → 分享此 Orca 服务器中的浏览器访问链接重新连接。",
           "createdWithoutParentNesting": "已创建，但未嵌套在“{{value0}}”下",
           "createdWithoutParentNestingUnnamed": "已创建，但未嵌套在所选父工作树下",
-          "createdWithoutParentNestingDetail": "父工作树已不可用。您可以从工作区菜单中重新设置。"
+          "createdWithoutParentNestingDetail": "父工作树已不可用。您可以从工作区菜单中重新设置。",
+          "c6cf133786": "此工作区已不可用。",
+          "a17f4d2e93": "无法更新此工作区。",
+          "preservedBranchCleanupHostAmbiguous": "“{{value0}}”有多个待处理的保留分支清理，请指定主机。",
+          "metadata": {
+            "worktree": {
+              "meta": {
+                "persist": {
+                  "877e3638d8": "更新远程运行时以更改此工作区关联的议题",
+                  "4367540861": "更新远程运行时以关联 Linear 议题",
+                  "github": {
+                    "pr": {
+                      "suppression": "更新远程运行时以取消关联 GitHub 拉取请求"
+                    }
+                  }
+                }
+              }
+            }
+          }
         },
         "repos": {
           "2975400634": "请更新 Orca 服务器，以便在此运行时打开非 Git 文件夹。",
@@ -284,7 +383,10 @@
           "3be0f7df04": "无法在所选运行时打开文件夹",
           "15cf5319ec": "已在 {{hostName}} 上检查 {{path}}，但该主机未报告可用文件夹。",
           "2dcd706774": "该项目也存在于另一个配置文件中",
-          "presenceProfileOverflow": "{{names}} 及另外 {{count}} 个"
+          "presenceProfileOverflow": "{{names}} 及另外 {{count}} 个",
+          "removeProjectFailed": "删除项目失败",
+          "wslFilesystemBoundaryTitle": "此项目存放在 Windows 磁盘上",
+          "wslFilesystemBoundaryDescription": "此项目的 Git 在 {{distro}} 中运行，它通过 WSL 文件系统桥接访问 Windows 磁盘。预计 Git 速度比存放在 {{distro}} 内部的副本慢约 20 倍。"
         },
         "settings": {
           "e12dab333b": "切换服务器失败",
@@ -316,6 +418,23 @@
             "7d4bc516ee": "切换配置文件失败",
             "f518e89aa5": "该项目已存在于那个配置文件中",
             "f03ae7f27b": "转移项目失败"
+          }
+        },
+        "runtime": {
+          "status": {
+            "runtimeHostDisconnectedDescription": "请确认 Orca 正在此服务器上运行且网络连接正常，然后重试。",
+            "runtimeHostUnreachableNamed": "无法连接到 {{hostName}}",
+            "runtimeHostUnreachable": "无法连接到 Orca 服务器",
+            "tryAgain": "重试"
+          }
+        },
+        "terminal": {
+          "quick": {
+            "command": {
+              "hosts": {
+                "5b7d781d67": "保存快捷命令失败"
+              }
+            }
           }
         }
       }
@@ -490,7 +609,12 @@
             "9e37a5b1b3": "并行运行独立工作",
             "bddc4c09b8": "运行分阶段工作流程",
             "ab0e9803b7": "移交给另一个工作树",
-            "5e0d489fe1": "移交活动任务"
+            "5e0d489fe1": "移交活动任务",
+            "handoffSummary": "将所有权移交给另一个代理，并提供足够的上下文以便继续。",
+            "worktreeHandoffSummary": "将工作移交给已在其他分支中运行的代理。",
+            "childSequenceSummary": "当前后阶段存在依赖时，依次使用子代理完成各阶段。",
+            "childParallelSummary": "将互不重叠的调查或实现任务分配给多个子代理并行处理。",
+            "prSplitSummary": "为每个子代理分配独立的工作区，使并行实现保持可评审。"
           }
         }
       },
@@ -592,6 +716,15 @@
         },
         "activation": {
           "cannotOpenFolderWorkspace": "无法打开文件夹工作区"
+        },
+        "creation": {
+          "flow": {
+            "structured": {
+              "launch": {
+                "unknown": "无法确认 Codex 聊天是否已打开。请重试以再次检查。"
+              }
+            }
+          }
         }
       },
       "folderWorkspacePathStatus": {
@@ -599,13 +732,15 @@
           "missing": "未找到文件夹",
           "notDirectory": "路径不是文件夹",
           "ambiguousConnection": "无法确定连接",
-          "unavailable": "无法检查文件夹"
+          "unavailable": "无法检查文件夹",
+          "unrecognized": "文件夹不可用"
         },
         "description": {
           "missing": "Orca 找不到 {{path}}。请移除并重新导入此文件夹工作区。",
           "notDirectory": "{{path}} 存在，但它不是文件夹。",
           "ambiguousConnection": "Orca 无法判断哪个 SSH 连接拥有此文件夹范围。",
-          "unavailable": "Orca 现在无法验证此文件夹。请检查运行时或 SSH 连接，然后重试。"
+          "unavailable": "Orca 现在无法验证此文件夹。请检查运行时或 SSH 连接，然后重试。",
+          "unrecognized": "Orca 无法使用 {{path}}，且当前版本无法识别原因。请更新 Orca 查看详情。"
         },
         "createError": {
           "title": {
@@ -633,7 +768,8 @@
         "wakeEphemeralVmFailed": "唤醒临时虚拟机工作区失败"
       },
       "ephemeralVmWorkspaceTarget": {
-        "projectRootRegistrationFailed": "在运行时上注册环境模板创建的项目根目录失败"
+        "projectRootRegistrationFailed": "在运行时上注册环境模板创建的项目根目录失败",
+        "provisionedRootRequiresSsh": "预配根目录方案目前需要直接 SSH 连接。"
       },
       "blocked": {
         "notification": {
@@ -683,7 +819,21 @@
           "import": {
             "toast": {
               "restartFallbackUnavailableNone": "{{value0}} 个 Cookie 均无法加载，且重启回退不可用。此配置文件的旧 Cookie 已被替换。请重试导入。",
-              "restartFallbackUnavailablePartial": "已导入 {{value1}} 个 Cookie 中的 {{value0}} 个。其余无法加载，且重启回退不可用。请重试导入。"
+              "restartFallbackUnavailablePartial": "已导入 {{value1}} 个 Cookie 中的 {{value0}} 个。其余无法加载，且重启回退不可用。请重试导入。",
+              "googleCookiesSkipped": "Google Cookie 未导入。请在 {{value0}} 上用此配置文件在 Orca 中打开浏览器，然后登录 Google。",
+              "undecryptableAppBound": "Orca 无法解密此浏览器中 {{value0}} 的 Cookie，因为它们使用了应用绑定加密。您可以使用“从文件导入…”从文件导入 Cookie。",
+              "undecryptableAppBoundMixed": "Orca 无法解密此浏览器中 {{value0}} 的 Cookie，因为它们使用了应用绑定加密；还有 {{value1}} 个因其他原因无法解密。您可以使用“从文件导入…”从文件导入 Cookie。",
+              "undecryptableKeyring": "{{value0}} 个 Cookie 因系统密钥环不可用而无法解密。请解锁登录密钥环（或安装 Secret Service 提供程序，如 gnome-keyring）后重新导入。",
+              "undecryptableKeyringMixed": "{{value0}} 个 Cookie 因系统密钥环不可用而无法解密；还有 {{value1}} 个因其他原因无法解密。请解锁登录密钥环（或安装 Secret Service 提供程序，如 gnome-keyring）后重新导入。",
+              "undecryptableUnknown": "{{value0}} 个 Cookie 无法解密，已跳过。请完全关闭源浏览器后重试导入。",
+              "unrecognizedWarning": "Cookie 导入完成，但出现当前版本 Orca 无法识别的警告。请更新 Orca 查看详情，并在使用这些 Cookie 前检查此配置文件。",
+              "undecryptableUnrecognizedReason": "{{value0}} 个 Cookie 因当前版本 Orca 无法识别的原因而无法解密，已跳过。请更新 Orca 查看详细信息，然后重试导入。",
+              "partitionSkipped": "{{value0}} 个 Cookie 因无法读取其站点分区而未导入。请在 Orca 中重新登录这些网站。",
+              "locationClientHosted": "从此设备读取，并存储在此处供 {{value0}} 工作区使用。",
+              "locationRemoteHost": "从 {{value0}} 上的浏览器读取并存储在该处。",
+              "googleCookiesSkippedLocal": "Google Cookie 未导入。请在 Orca 中用此配置文件打开浏览器，然后登录 Google。",
+              "googleCookiesSkippedClientHosted": "Google Cookie 未导入。请在此设备上打开的 {{value0}} 工作区浏览器标签页中使用此配置文件，然后登录 Google。",
+              "googleCookiesSkippedRemoteWorkspace": "Google Cookie 未导入。请在 {{value0}} 工作区中用此配置文件打开浏览器标签页，然后登录 Google。"
             }
           }
         }
@@ -704,6 +854,22 @@
             "additionalErrors": "还有 {{count}} 张图片无法附加。"
           }
         }
+      },
+      "activateAiVaultStructuredSession": {
+        "unavailable": "结构化代理会话暂不可用。请稍后重试。",
+        "gone": "此聊天已不在此主机上，因此无法在此处重新打开。",
+        "hostCannotOpen": "更新 Orca 后才能重新打开此聊天。"
+      },
+      "ephemeralVmWorktreeCreation": {
+        "sparseCheckoutUnsupported": "预配根目录方案不支持稀疏检出。"
+      },
+      "worktreeJumpNavigation": {
+        "filteredNotice": "此工作区被侧边栏筛选隐藏。工作区已打开，但未在 Spaces 中显示。"
+      },
+      "file": {
+        "preview": {
+          "pairedOutsideWorktree": "工作区之外的文件暂无法在配对服务器上预览。"
+        }
       }
     },
     "hooks": {
@@ -711,7 +877,8 @@
         "59718b120b": "目标工作区不再可用。",
         "16a21d6413": "SSH 重新连接需要交互式凭据。",
         "386db94f3e": "目标项目不再可用。",
-        "3ad7d77f57": "目标工作区所在的主机与此自动化运行目标不同。"
+        "3ad7d77f57": "目标工作区所在的主机与此自动化运行目标不同。",
+        "workspaceHostUnresolved": "目标工作区跨越多台主机，因此此次运行没有可用的单一主机。"
       },
       "useComposerState": {
         "7eb3f44ff7": "所选智能体已禁用。创建之前选择启用的智能体。",
@@ -832,7 +999,14 @@
         "linearDescription": "Linear 在 Orca 中的工作方式、设置清单、智能体技能和提示词示例。",
         "pluginsTitle": "插件",
         "pluginsDescription": "安装和管理实验性 Orca 插件。",
-        "tasksDescription": "连接提供商、安装 Linear 技能并选择要在任务中显示的内容。"
+        "tasksDescription": "连接提供商、安装 Linear 技能并选择要在任务中显示的内容。",
+        "artifactsTitle": "工件",
+        "artifactsDescription": "与团队分享 HTML 和 Markdown 文件，并管理其公开链接。",
+        "automationsTitle": "自动化",
+        "automationsDescription": "安排代理工作，并选择是否在侧边栏中显示自动化。",
+        "shareSkillsTitle": "分享技能",
+        "shareSkillsDescription": "通过非公开链接分享您的技能。拥有链接的任何人都可以安装它们。",
+        "floatingWorkspaceWebDescription": "全局终端和 Markdown 标签页。"
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "粘贴内容过大。"
@@ -845,6 +1019,33 @@
         "description": "当 Orca 中运行的代理或终端工具尝试访问受保护的文件时，macOS 可能会显示权限信息。请在“设置”中授予“完全磁盘访问权限”，以减少此类提示。",
         "openSettings": "打开设置",
         "dismiss": "不再显示"
+      },
+      "useInstalledAgentSkills": {
+        "unreadableSkillSource": "某个技能文件夹无响应，因此此状态可能不完整。"
+      },
+      "useMacTccAttributionSeveredNotice": {
+        "title": "macOS 权限可能无法作用于 Orca 终端",
+        "description": "正在运行的 Orca 终端由旧版 Orca 安装启动的守护进程托管。macOS 可能不会将 Orca 的辅助功能、自动化或受保护文件权限应用于它们。请从会话管理重启守护进程以恢复访问。这将关闭所有正在运行的 Orca 终端。",
+        "openManageSessions": "打开会话管理",
+        "dismiss": "关闭"
+      },
+      "ipc": {
+        "events": {
+          "browserStateIpcBridge": {
+            "docPreviewLinkFailed": "无法在 Orca 浏览器中打开此链接。"
+          },
+          "os": {
+            "markdown": {
+              "file": {
+                "open": {
+                  "bridge": {
+                    "1e9a1a63c4": "打开 Markdown 文件失败。"
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "components": {
@@ -854,7 +1055,11 @@
         "a4c8e1b2f7": "Codex 仍以 {{value0}} 身份登录",
         "d3e8a1f4b2": "账户已切换",
         "9375620cc3": "重启此会话以使用 {{value0}}。在重启之前，它将继续使用旧账户。",
-        "6133594b12": "保留旧账户"
+        "6133594b12": "保留旧账户",
+        "8f0d5c92a1": "Codex 设置已更改",
+        "3ea91b5c07": "此 Codex 会话正在使用过期的配置",
+        "e6b7139d2a": "重启此会话以加载当前 Codex 配置。",
+        "7b1d20f4c8": "保留当前会话"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "关闭通知",
@@ -1056,7 +1261,18 @@
           "activity": "活动",
           "noActivity": "暂无活动。"
         },
-        "checkActionRequiredHint": "此检查需要在 GitHub 上执行手动操作（例如批准工作流运行）后才能解除合并阻止。"
+        "checkActionRequiredHint": "此检查需要在 GitHub 上执行手动操作（例如批准工作流运行）后才能解除合并阻止。",
+        "e15a8b77ef": "此检查没有可用的内联详细信息。",
+        "e45324fbed": "加载检查详细信息失败。",
+        "dcb3c546fe": "重试",
+        "85a2b66f54": "在 GitHub 上打开文件",
+        "86d84a17ca": "添加评审评论",
+        "d9fa90b625": "加载差异失败。",
+        "4aecf121e7": "关闭",
+        "8812225174": "重新打开",
+        "09d67a0f9b": "关闭 PR 失败",
+        "88809e79db": "重新打开 PR 失败",
+        "00f55cc17b": "此拉取请求的仓库访问不可用。"
       },
       "GitLabItemDialog": {
         "65e784c1f1": "重新打开",
@@ -1121,7 +1337,8 @@
         "3a051b8ade": "工作项目",
         "32f8bef818": "无日志输出。",
         "4168eb2c51": "解决",
-        "commentTooLarge": "评论过长，无法安全提交。"
+        "commentTooLarge": "评论过长，无法安全提交。",
+        "gitlabActionFailed": "GitLab 操作失败。"
       },
       "JiraIssueWorkspace": {
         "b0b92666c9": "评论",
@@ -1370,7 +1587,10 @@
         "addSshHostHint": "通过 SSH 使用现有机器",
         "addRemoteOrcaServer": "添加远程 Orca 服务器",
         "addRemoteOrcaServerHint": "配对另一个 Orca 运行时",
-        "hostConnectionFailed": "Connection failed"
+        "hostConnectionFailed": "Connection failed",
+        "setLocation": "设置项目位置",
+        "setLocationOnHost": "在 {{host}} 上设置项目位置",
+        "setLocationTooltip": "选择文件夹，或将此项目克隆到 {{host}}。"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "创建工作树",
@@ -1551,7 +1771,10 @@
         "4b8ae7303f": "加载差异失败。",
         "closePullRequestFailed": "关闭PR失败",
         "reopenPullRequestFailed": "重新打开PR失败",
-        "diffLoadTimedOut": "加载此差异超时。"
+        "diffLoadTimedOut": "加载此差异超时。",
+        "6b1d5ee3e4": "此检查没有可用的内联详细信息。",
+        "e04c027d98": "加载检查详细信息失败。",
+        "5df7c41d2a": "重试"
       },
       "QuickOpen": {
         "1dbd3f59ff": "移动",
@@ -1940,7 +2163,9 @@
         "61ed600d29": "“{{value0}}”有未保存的更改。您想在关闭前保存吗？",
         "cdc9ac4b2d": "编辑",
         "e57db40c11": "无法为 {{value0}} 构建启动命令。",
-        "5b2c1a9e44": "未检测到智能体 CLI，请安装一个，或在设置中选择默认智能体。"
+        "5b2c1a9e44": "未检测到智能体 CLI，请安装一个，或在设置中选择默认智能体。",
+        "b7c1f0a934": "无法连接到远程主机，因此 Orca 无法判断那里的工作是否仍在运行。仍要关闭窗口吗？",
+        "quitSnapshotSaveFailed": "已取消退出：无法保存会话快照（{{value0}}）。"
       },
       "TerminalSearch": {
         "db234b7519": "关闭",
@@ -1996,7 +2221,8 @@
         "a4650b0dc4": "无法使用本地构建",
         "b1e390250d": "无法完成本地构建切换。",
         "d29740d175": "无法使用所选的构建。",
-        "37d45c9ec1": "选择其他构建"
+        "37d45c9ec1": "选择其他构建",
+        "7f1a4c9e02": "Orca 由系统包管理器安装，请在那里更新——Orca 无法自行安装此版本。"
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "移动",
@@ -2040,7 +2266,8 @@
         "pluginCommandFailed": "无法运行插件命令。",
         "27f10cca63": "搜索聊天、终端、工作树、设置和操作...",
         "2770f02910": "搜索聊天、终端、工作树、设置和操作",
-        "recentChatsTerminalsHeader": "最近的聊天和终端"
+        "recentChatsTerminalsHeader": "最近的聊天和终端",
+        "lastActiveTime": "{{value0}} 前活跃"
       },
       "github": {
         "pr": {
@@ -2221,6 +2448,30 @@
                 "7c302f8174": "无标题"
               }
             }
+          },
+          "ProjectRoadmap": {
+            "be52f7b6db": "此路线图视图没有可用于放置条目的日期或迭代字段，因此 Orca 改为列表显示。",
+            "6405e036e0": "月",
+            "f2b1cabef7": "季度",
+            "b6afc6fe45": "年",
+            "343888b143": "由 {{value0}} 放置",
+            "6a088a5da1": "{{value0}} 个无日期项",
+            "86eebd6020": "今天",
+            "0bb1c1bc07": "时间轴缩放",
+            "e304235879": "条目",
+            "e077c79083": "无日期"
+          },
+          "ProjectRoadmapBar": {
+            "cd68ccc17a": "{{value0}} — {{value1}}",
+            "7d1220d979": "受限条目"
+          },
+          "ProjectPickerPanels": {
+            "04ec212ccb": "路线图",
+            "9fe1ac868c": "不支持"
+          },
+          "ProjectViewStates": {
+            "ac83c45672": "切换到表格或路线图视图，以便在 Orca 中使用此项目。",
+            "e4cc8b14f2": "Orca 可渲染表格和路线图项目视图。此视图使用的布局暂不支持渲染。"
           }
         },
         "GitHubMarkdownComposer": {
@@ -2349,6 +2600,11 @@
             "label": "标记为重复",
             "description": "与其他议题重复"
           }
+        },
+        "CommentReactions": {
+          "addReaction": "添加表情回应",
+          "removeNamedReaction": "移除 {{value0}} 表情回应",
+          "addNamedReaction": "添加 {{value0}} 表情回应"
         }
       },
       "linear": {
@@ -2648,12 +2904,15 @@
           "commands": {
             "TerminalQuickCommandActionToggle": {
               "b0d58e37ed": "智能体提示",
-              "b5ea4d64f6": "终端命令"
+              "b5ea4d64f6": "终端命令",
+              "terminal_short": "终端",
+              "agent_short": "代理"
             },
             "TerminalQuickCommandAppendEnterSwitch": {
               "e4e5fed3b3": "切换追加 Enter",
               "c936c2d6d2": "立即提交，而不仅仅是插入文本。",
-              "5fa607d807": "追加输入"
+              "5fa607d807": "追加输入",
+              "767e4be3e3": "追加回车——立即运行"
             },
             "TerminalQuickCommandDialog": {
               "925b8e0f6e": "高级",
@@ -2670,7 +2929,11 @@
               "dc921c17ee": "提示词",
               "5b3f634a55": "添加快捷命令",
               "f9b184fc16": "编辑快捷命令",
-              "6751598542": "编辑"
+              "6751598542": "编辑",
+              "command_label": "命令",
+              "agent_toolbar_hint": "支持 /goal、技能和路径",
+              "agent_footer_hint": "多行提示词也可以——保持聚焦即可。",
+              "resize_hint": "拖动角落以调整大小"
             },
             "TerminalQuickCommandDialogFooter": {
               "2e2b958dfc": "保存",
@@ -2751,14 +3014,23 @@
             "c2f0b72b8d": "插入",
             "925f49f210": "展开窗格",
             "df766809e0": "折叠窗格",
-            "cff67afad1": "复制上下文"
+            "cff67afad1": "复制上下文",
+            "15dd899676": "添加到 {{value0}}…"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "重新启动守护进程",
             "a7e2fd2699": "提交议题",
             "5c8ce20be6": "如果这种情况持续存在，请",
             "cc6d997c65": "从此处重新启动终端守护进程以清除失效的守护进程状态。",
-            "remoteTerminalClosed": "远程终端已关闭。"
+            "remoteTerminalClosed": "远程终端已关闭。",
+            "retry": "重试",
+            "retrying": "正在重试...",
+            "retryUnavailable": "重试暂未能重新连接。请稍后再试。",
+            "ownerUnknown": "Orca 无法验证此终端的所有者。",
+            "42b283ecfc": "Orca 无法安全地重新连接此终端，因为主机无法验证其保存的会话。Orca 未改动已保存的会话。请点击重试立即尝试重新连接。如果仍无法连接，请打开新的终端。",
+            "e16012e31e": "拥有此会话的终端守护进程已退出，因此会话及其回滚内容无法恢复。请打开新的终端继续。",
+            "sessionUnavailable": "Orca 无法重新关联此窗格在主机上的终端会话。请打开新的终端继续。",
+            "sourceRestoring": "正在重新连接此终端——其输出正在恢复中。会话仍在运行。"
           },
           "TerminalProcessExitOverlay": {
             "capacityTitle": "已达到 Git Bash 控制台上限",
@@ -2900,6 +3172,29 @@
             "retryingBody": "Orca 正在自动重试。如果连接恢复，此终端将恢复。",
             "disconnectedBody": "自动重试已停止。重新连接以恢复此终端会话。",
             "reconnectButton": "重新连接"
+          },
+          "TerminalLinkActionPopover": {
+            "openLink": "打开链接",
+            "openFile": "打开文件",
+            "switchWorkspace": "切换工作区",
+            "openInFinder": "在 Finder 中打开",
+            "openFolder": "打开文件夹",
+            "openWithDefaultApp": "用默认应用打开",
+            "switchTerminal": "切换终端",
+            "openTaskTerminal": "打开任务终端",
+            "systemBrowser": "系统浏览器",
+            "orcaBrowser": "Orca 浏览器",
+            "terminalLinkSettings": "终端链接设置",
+            "copyLink": "复制链接",
+            "copied": "已复制",
+            "copiedLink": "已复制链接",
+            "copyLinkFailed": "复制链接失败",
+            "downloadOpenWithDefaultApp": "下载并用默认应用打开",
+            "downloadOpenFailed": "无法下载“{{value0}}”。"
+          },
+          "TerminalQuickCommandsSubmenu": {
+            "3ccc7981bb": "主机不可用",
+            "54f29b7c0d": "正在加载主机…"
           }
         }
       },
@@ -2962,7 +3257,10 @@
             "1d04b1630b": "向下拆分",
             "6b3efb106e": "向上拆分",
             "fdd29eb669": "固定标签",
-            "8e9d603a09": "取消固定标签"
+            "8e9d603a09": "取消固定标签",
+            "revealInFinder": "在 Finder 中显示",
+            "openContainingFolder": "打开所在文件夹",
+            "revealInFileExplorer": "在文件资源管理器中显示"
           },
           "QuickLaunchButton": {
             "348a04c1ad": "智能体设置...",
@@ -3126,6 +3424,14 @@
           },
           "TerminalTabLeadingIcon": {
             "7ab2964bea": "未读的代理完成"
+          },
+          "TabBarQuickCommandAddActions": {
+            "45a2f36d51": "命令",
+            "b856c833ae": "在 {{value0}} 上执行命令"
+          },
+          "TabBarQuickCommandHostLoadStatus": {
+            "82e294f3ca": "主机不可用",
+            "7c129b08ff": "正在加载主机…"
           }
         }
       },
@@ -3243,7 +3549,9 @@
             "connectedHostCount_other": "{{count}} 个主机",
             "connecting": "正在连接…",
             "workspaceConflict": "工作区冲突",
-            "workspaceSyncError": "工作区同步错误"
+            "workspaceSyncError": "工作区同步错误",
+            "runtime_unavailable_transport_up": "Orca 不可用",
+            "runtime_workspace_window_closed": "工作区窗口已关闭"
           },
           "CaffeinateStatusSegment": {
             "active": "生效中",
@@ -3477,7 +3785,14 @@
             "e2c6a4f917": "运行 Grok 以刷新",
             "d1b7f509ac": "在运行 Orca 的电脑上的终端中运行 grok，并等待其启动。如有提示，请完成登录，然后重试用量检查。您无需发送聊天消息。",
             "f90b3d7a16": "运行 Kimi 以刷新",
-            "a37e8c15d4": "在运行 Orca 的电脑上的终端中运行 kimi，等待其启动，然后重试用量检查。"
+            "a37e8c15d4": "在运行 Orca 的电脑上的终端中运行 kimi，等待其启动，然后重试用量检查。",
+            "minimax": {
+              "expired": {
+                "label": "登录已过期",
+                "apiKey": "MiniMax API 密钥已过期。请在设置中更换。",
+                "cookie": "MiniMax 会话 Cookie 已过期。请在设置中更换。"
+              }
+            }
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 主机"
@@ -3557,6 +3872,18 @@
             "stoppingLabel": "Stopping update",
             "stoppingTooltip": "正在停止技能更新…",
             "stoppingAria": "正在停止技能更新。点击查看详情。"
+          },
+          "RuntimeHostStatusRow": {
+            "previous_connection_closed": "上一个连接已关闭",
+            "workspace_window_closed": "工作区窗口已关闭",
+            "checking_host": "Orca 正在检查此主机是否可达",
+            "restoring_connection": "Orca 正在尝试恢复连接",
+            "host_unreachable": "此主机上的 Orca 不可达",
+            "runtime_unavailable": "SSH 传输已连接，但 Orca 运行时不可用",
+            "runtime_unavailable_explanation": "远程主机可能仍在运行；仅 Orca 运行时连接不可用。",
+            "contact_note": "主机可能仍在运行；仅 Orca 连接不可用。",
+            "last_connected": "上次连接 {{value0}}",
+            "reconnect_attempt": "第 {{value0}} 次尝试"
           }
         }
       },
@@ -3743,7 +4070,8 @@
           "908c470587": "codex",
           "eb6a066185": "claude",
           "eee19cfade": "概览",
-          "grokUsageTab": "Grok"
+          "grokUsageTab": "Grok",
+          "trackingSince": "自 {{value0}} 起统计"
         },
         "UsageOverviewPane": {
           "22ed1b7669": "会话",
@@ -3831,13 +4159,19 @@
               "6762f6a682": "token",
               "a7f937fb29": "{{value0}} 个会话 - {{value1}} {{value2}}",
               "c8f3a2d1e0b4": "轮次",
-              "d9a4b3e2f1c5": "事件"
+              "d9a4b3e2f1c5": "事件",
+              "statusScanning": "正在扫描",
+              "statusEnabled": "已启用",
+              "statusOff": "关闭"
             }
           }
         },
         "UsageBreakdownSection": {
           "7765a4c3e1": "n/a",
-          "247c93ca92": "• 推理价格"
+          "247c93ca92": "• 推理价格",
+          "32176e1d44": "轮次",
+          "79a69522a5": "事件",
+          "02a046792e": "会话 •"
         },
         "UsageSessionsTable": {
           "1afc25eb06": "轮次",
@@ -3921,10 +4255,32 @@
           "remoteShareNotice": "这些技能位于 {{host}}。请在该机器上打开“技能”以进行共享。",
           "viewSwitch": "显示",
           "searchLinks": "搜索链接",
-          "deleteSkills": "删除技能…"
+          "deleteSkills": "删除技能…",
+          "984405683f": "插件",
+          "4d177feabd": "内置",
+          "aa59462502": "仓库",
+          "571c5818c1": "主目录",
+          "0bc1379f4c": "全部来源",
+          "38e0951c3a": "代理技能",
+          "fb6bf60b52": "Claude",
+          "426be2aac6": "Codex",
+          "39b6998ddb": "全部提供方",
+          "e46e162e2e": "从",
+          "b088e0785d": "测试版",
+          "7e828fb2c6": "返回",
+          "ab5b777350": "已检查主目录、仓库、内置和插件技能文件夹。",
+          "0c74e7ff34": "已安装"
         },
         "SkillShareSelectionControls": {
-          "01c5a15e02": "共享技能"
+          "01c5a15e02": "共享技能",
+          "01c5a15e05": "分享 {{value0}} 个技能",
+          "01c5a15e01": "取消分享",
+          "01c5a15e03": "已选 {{value0}} 项",
+          "01c5a15e04": "选择全部结果",
+          "01c5a15e06": "请在其所属机器上打开此技能以进行分享。",
+          "01c5a15e07": "请先安装此技能，再进行分享。",
+          "01c5a15e08": "仅可分享主目录和工作区技能。",
+          "01c5a15e09": "已从其他来源选择了同名技能。"
         },
         "SkillRow": {
           "updatedUnknown": "无日期",
@@ -3933,7 +4289,11 @@
           "detailPath": "路径",
           "skillActions": "{{value0}} 的操作",
           "viewDetails": "查看详情",
-          "deleteSkill": "删除…"
+          "deleteSkill": "删除…",
+          "notShareable": "不可分享",
+          "detailSource": "来源",
+          "detailContents": "内容",
+          "notDeletable": "不可删除"
         },
         "SkillsList": {
           "listLabel": "技能"
@@ -3973,7 +4333,11 @@
           "deleteFolderOne": "{{count}} 个文件夹",
           "deleteFolderOther": "{{count}} 个文件夹",
           "deleteLinkOne": "{{count}} 个链接",
-          "deleteLinkOther": "{{count}} 个链接"
+          "deleteLinkOther": "{{count}} 个链接",
+          "installOne": "安装 {{count}} 个技能",
+          "installOther": "安装 {{count}} 个技能",
+          "retryOne": "重试 {{count}} 个技能",
+          "retryOther": "重试 {{count}} 个技能"
         },
         "filter": {
           "allAgents": "所有 Agent",
@@ -4080,7 +4444,9 @@
           "upToDate": "已是最新",
           "installed": "已安装",
           "details": "Details",
-          "needsAttention": "Review skill"
+          "needsAttention": "Review skill",
+          "checking": "检查中...",
+          "checkFailed": "检查失败"
         },
         "SkillUpdateResultRows": {
           "stillOutdated": "更新运行后仍为过期状态。"
@@ -4116,7 +4482,352 @@
           "hostUnresolved": "仍在查找存储这些技能的计算机。",
           "hostUpdateRequired": "请更新所选机器上的 Orca 以删除技能。",
           "nothingOne": "无法从这里删除该技能。",
-          "nothingOther": "所选的 {{count}} 个技能均无法从这里删除。"
+          "nothingOther": "所选的 {{count}} 个技能均无法从这里删除。",
+          "hostUnavailable": "无法连接到所选机器。请刷新后重试。"
+        },
+        "SkillShareDialog": {
+          "reconnect": "分享前请重新连接 Orca 账户。",
+          "unconfigured": "分享前请连接 Orca Cloud 账户。",
+          "prepareFailed": "无法准备此技能以进行分享。",
+          "peopleRequired": "请至少选择一位队友。",
+          "publishCancelled": "上传已取消。已准备的副本仍可重试。",
+          "publishFailed": "无法发布此技能。已准备的副本仍可重试。",
+          "copied": "分享链接已复制",
+          "preparing": "正在准备预览…",
+          "ready": "技能链接已就绪",
+          "title": "分享技能",
+          "readyDescription": "接收者需要先通过 Orca 身份验证，才能查看或安装它。",
+          "newVersionDescription": "检查确切文件，然后向现有 Cloud 包发布不可变版本。",
+          "description": "检查确切文件，选择可访问人员，然后发布不可变版本。",
+          "0f07fa2a79": "发布技能",
+          "7aa4ba0dba": "发布新版本",
+          "3a51d0f34f": "取消上传",
+          "e9d652ae3d": "正在取消…",
+          "30985d4fc0": "取消",
+          "3af85f6add": "完成",
+          "readyDescriptionV2": "拥有此非公开链接的任何人都可以查看和安装这些技能。",
+          "descriptionV2": "检查确切文件，然后在非公开链接后发布不可变版本。",
+          "publishBundle": "发布捆绑包",
+          "cancelRequestFailed": "Orca 无法发送取消请求。上传可能仍会完成。"
+        },
+        "SkillCard": {
+          "d25a1b8ae6": "分享技能",
+          "01c5a16e01": "选择 {{value0}}"
+        },
+        "SkillCloudManagementActions": {
+          "ed753624c0": "删除 Cloud 包",
+          "640bc6b92e": "确认删除包",
+          "6b6adf68c1": "删除选定的 Cloud 版本",
+          "bbec37d8f8": "确认删除版本",
+          "7a80285dad": "取消分享",
+          "0ac5c175fd": "确认取消分享",
+          "9e6bd31487": "没有生效中的分享链接。",
+          "c7f2b69122": "取消分享将阻止未来安装。已安装到任何机器上的副本会保留。",
+          "8cac3b9362": "生效中的链接",
+          "cc8e4ef6ba": "保存访问权限",
+          "eb603f7888": "当前名单之外的访问权限将被保留。",
+          "3d346ddce8": "现有接收者",
+          "2b8c569ea7": "当前组织",
+          "2552c12fea": "访问权限",
+          "505cd6105c": "Cloud 分享控制",
+          "linkCopied": "分享链接已复制",
+          "activeLinkBearerDescription": "拥有生效链接的任何人都可以查看和安装这些技能。撤销将阻止未来访问，但已安装的副本不受影响。",
+          "copyLink": "复制链接"
+        },
+        "SkillInstallDialog": {
+          "39acb9e8f4": "安装技能",
+          "59c3b76cdd": "重试安装",
+          "241e72f9d6": "正在安装…",
+          "05588076a9": "取消安装",
+          "d198ec91e5": "关闭",
+          "4a00d133c5": "Orca 会在更改所选机器之前验证访问权限和包身份。",
+          "fcbec627cc": "安装分享的技能",
+          "01c5a14e01": "安装分享的技能",
+          "opening": "正在打开此链接…"
+        },
+        "SkillInstallManagementDialog": {
+          "8095927ff3": "关闭",
+          "e91af0079f": "移除",
+          "470d8d2476": "确认移除",
+          "c1d03ee50d": "取消安装",
+          "561e49ccd1": "安装选定版本",
+          "2ae587d39c": "重试未覆盖完整的内容",
+          "f7c5075e77": "放弃更改并移除",
+          "e1884c812e": "放弃更改并安装该版本",
+          "070654c6d1": "除非您明确放弃本地更改，否则 Orca 会保留它们。",
+          "74b70892ea": "本地文件已被修改",
+          "86ed219b55": "选择版本",
+          "9c04bd0120": "已安装版本",
+          "64c71cf7b9": "在此机器上未找到 Orca 管理的技能安装。",
+          "0900db719a": "——已断开连接",
+          "176fef9516": "· SSH",
+          "6cb1fbe039": "本机",
+          "3677ae58e7": "更新、回滚或安全移除由 Orca 安装的版本。",
+          "44d118a8f7": "管理已安装的技能",
+          "1c9e7f420a": "已安装的捆绑包技能",
+          "34c2ef9e71": "安装 {{count}} 个技能",
+          "a0cab67c2f": "移除 {{count}} 个技能",
+          "f970d8088d": "确认移除 {{count}} 个技能",
+          "dab29e4b54": "已安装 {{installed}} · 已更新 {{updated}} · 保留本地 {{keptLocal}}",
+          "installAnotherMachine": "在其他机器上安装"
+        },
+        "SkillInstallReviewContent": {
+          "89e2601162": "放弃并替换",
+          "a5675fb371": "的内容，未做改动。可以保留，或明确放弃并替换为此版本。",
+          "37d990b94c": "已更改",
+          "2a31912f14": "Orca 发现",
+          "651b7d8a57": "本地副本需要处理",
+          "98ed90e523": "技能包含指令，可能附带脚本。请将其视为作者提供的代码。",
+          "f72ee4022a": "SHA-256",
+          "3d8421ca2f": "可执行文件",
+          "87137bcb8d": "脚本",
+          "fab8fce842": "文件",
+          "8f9833d509": "不可变版本",
+          "66270286ac": "· 可以安全重试。",
+          "1b6ad2ca5c": "已检查。",
+          "3fc62a61eb": "放置位置",
+          "157de228b4": "检查技能",
+          "69236de8d6": "正在检查…",
+          "27672470d9": "打开链接不会安装任何内容。请先检查不可变版本。",
+          "66cff7a804": "https://app.orca.dev/skills/share/…",
+          "93eb0fe8c7": "Orca 技能链接",
+          "releaseNotes": "发布说明：",
+          "targetHeader": "安装目标"
+        },
+        "SkillInstallTargetFields": {
+          "8e6a972229": "此机器上没有已知的工作区。",
+          "7a366323e7": "文件夹",
+          "d628c416a2": "Git 工作区",
+          "5845cfe543": "选择工作区或文件夹",
+          "0e5b43a9e3": "工作区",
+          "0c10a406fb": "WSL ·",
+          "e5b0d15e64": "主机操作系统",
+          "cb47652227": "执行环境",
+          "a4dfd33095": "单个工作区",
+          "c779621aa0": "全局技能",
+          "63cc9e31fe": "目标位置",
+          "85d85880df": "· SSH",
+          "71eefd7660": "——已断开连接",
+          "0785d0a503": "——需要更新",
+          "8562dd1e6e": "本机",
+          "b8a0b706ad": "机器"
+        },
+        "SkillInstallWorkspaceCombobox": {
+          "search": "搜索工作区…",
+          "empty": "未找到工作区。"
+        },
+        "SkillShareReviewContent": {
+          "e3caf6baeb": "撤销此链接将阻止未来访问。不会删除接收者机器上已安装的副本。",
+          "6d6233a3a4": "复制链接",
+          "0142581727": "正在上传…",
+          "ad940367a5": "正在验证并发布…",
+          "bf02d6ed9e": "此版本有什么变化？",
+          "f0c0411549": "发行说明",
+          "4895d3e0ee": "没有可用的队友。",
+          "8188f5d765": "可以访问该链接。",
+          "fe204e06f0": "该组织",
+          "0cd4b3e396": "当前在职的每个人",
+          "f25429e266": "选定的人员",
+          "0a49d901ab": "组织",
+          "6817a7f6f8": "技能访问权限",
+          "c15d90c10b": "需要连接 Orca Cloud 账户。",
+          "266527d295": "正以 {{value0}}{{value1}} 身份发布。",
+          "78d863235c": "访问权限",
+          "b3b1d4b911": "SHA-256",
+          "77f636eac3": "可执行文件",
+          "8edd32622f": "脚本",
+          "3121f44358": "文件",
+          "2dca0b720b": "发布新的技能版本",
+          "01c5a17e01": "{{value0}} 个技能",
+          "01c5a17e02": "检查包含的技能",
+          "01c5a17e03": "{{value0}} 个文件 · {{value1}}",
+          "unlistedLinkTitle": "非公开链接",
+          "unlistedPublishingAs": "正以 {{value0}} 身份发布。拥有链接的任何人都可以查看和安装这些技能。",
+          "unlistedLinkDetails": "该链接不可搜索，也不会公开列出。撤销后可阻止未来访问；已安装的副本会保留。",
+          "bundleReady": "技能捆绑包链接已就绪",
+          "publishBundleVersion": "发布新的技能捆绑包版本",
+          "shareBundle": "分享技能捆绑包",
+          "publishingLink": "正在发布链接…",
+          "verifyingPackage": "正在验证包…"
+        },
+        "SkillBundleInstallFlow": {
+          "01c5a13e01": "关闭",
+          "01c5a13e02": "取消安装",
+          "01c5a13e03": "正在安装…",
+          "01c5a13e04": "重试 {{value0}} 个技能",
+          "01c5a13e05": "安装 {{value0}} 个技能"
+        },
+        "SkillBundleInstallOutcome": {
+          "01c5a12e01": "已安装",
+          "01c5a12e02": "已更新",
+          "01c5a12e03": "未更改",
+          "01c5a12e04": "保留本地版本",
+          "01c5a12e05": "失败",
+          "01c5a12e06": "已取消",
+          "01c5a12e07": "捆绑包安装需要注意。",
+          "01c5a12e08": "技能已安装并验证。",
+          "01c5a12e09": "已检查选定的 {{value0}} 个技能。",
+          "01c5a12e10": "需要重试"
+        },
+        "SkillBundleInstallReview": {
+          "01c5a11e01": "不可变版本",
+          "01c5a11e02": "{{value0}} 个技能",
+          "01c5a11e03": "{{value0}} 个文件",
+          "01c5a11e04": "{{value0}} 个脚本",
+          "01c5a11e05": "{{value0}} 个可执行文件",
+          "01c5a11e06": "SHA-256",
+          "01c5a11e09": "发布说明：",
+          "01c5a11e0a": "技能包含指令，可能附带脚本。请将其视为作者提供的代码。",
+          "01c5a11e0b": "待安装的技能",
+          "01c5a11e0c": "从此捆绑包中选择任意子集。",
+          "01c5a11e0d": "全选",
+          "01c5a11e0e": "无描述",
+          "01c5a11e0f": "{{value0}} 个文件 · {{value1}} 个脚本",
+          "01c5a11e10": "{{value0}} 个可执行文件",
+          "01c5a11e11": "本地副本需要处理",
+          "01c5a11e12": "Orca 默认保留这些本地副本。仅选择要放弃并替换的副本。",
+          "01c5a11e13": "替换 {{value0}}（{{value1}}）",
+          "01c5a11e14": "{{value0}} 个新增",
+          "01c5a11e15": "{{value0}} 个未更改",
+          "01c5a11e16": "{{value0}} 个更新",
+          "01c5a11e17": "{{value0}} 个冲突"
+        },
+        "SkillManagedInstallList": {
+          "86c76cb262": "{{count}} 个技能捆绑包"
+        },
+        "skill-install-progress-state": {
+          "currentSkill": "正在安装 {{value1}} 中的第 {{value0}} 个：{{value2}}…"
+        },
+        "SkillSelectionBar": {
+          "selectAll": "选择全部 {{count}} 个符合条件的项目",
+          "clear": "清除"
+        },
+        "share": {
+          "fileExecutable": "可执行文件",
+          "fileScript": "脚本",
+          "reviewFiles": "检查可运行的文件",
+          "reviewSkills": "检查包含的技能",
+          "releaseNotesVersion": "发行说明",
+          "releaseNotesOptional": "添加发布说明（可选）",
+          "releaseNotesFirst": "描述此版本",
+          "readyDescription": "复制链接以进行分享。",
+          "newVersionDescription": "向现有包发布不可变版本。",
+          "description": "在非公开链接后发布不可变版本。",
+          "accessSummary": "拥有链接的任何人都可以安装它。它不会在任何位置列出，撤销后可阻止新安装——但不影响已安装的副本。正以 {{value0}} 身份发布。",
+          "manageLinks": "在设置中管理或撤销此链接",
+          "scriptOne": "{{count}} 个脚本",
+          "scriptOther": "{{count}} 个脚本",
+          "executableOne": "{{count}} 个可执行文件",
+          "executableOther": "{{count}} 个可执行文件",
+          "noExecutableContent": "无脚本或可执行文件",
+          "newVersionDescriptionPlain": "向现有链接添加新版本。",
+          "accessSummaryShort": "非公开链接——拥有它的任何人都可以安装它。正以 {{value0}} 身份发布。",
+          "accessSummaryPlain": "非公开链接——拥有它的任何人都可以安装它。"
+        },
+        "description": {
+          "showLess": "收起",
+          "showMore": "显示更多"
+        },
+        "install": {
+          "authorizing": "正在授权包访问权限…",
+          "installing": "正在下载、验证和安装…",
+          "selectSkill": "请至少选择一个技能。",
+          "chooseWorkspace": "选择工作区。",
+          "reconnectBeforeInstalling": "安装前请重新连接 Orca 账户。",
+          "bundleVerificationFailed": "Orca 未能验证请求的捆绑包，安装失败。",
+          "destinationAlreadyFinished": "目标位置已完成此安装。",
+          "enterShareLink": "输入 Orca 技能分享链接。",
+          "shareUnavailable": "此分享不可用。链接可能无效、已过期或已被撤销。",
+          "requestedVersionVerificationFailed": "Orca 未能验证请求的版本，安装失败。",
+          "versionVerificationFailed": "Orca 无法验证请求的版本。",
+          "inspectManagedFailed": "Orca 无法检查此机器上的托管安装。",
+          "reconnectForVersionHistory": "重新连接 Orca 账户以加载版本历史。",
+          "versionHistoryUnavailable": "此技能的版本历史不可用。",
+          "bundleSkillsMissing": "此版本不包含任何已安装的捆绑包技能。",
+          "reconnectBeforeVersionChange": "更改版本前请重新连接 Orca 账户。",
+          "removeFailed": "Orca 无法安全地移除此技能。",
+          "agentsLabel": "代理",
+          "agentsCanonical": "始终为 {{value0}} 安装，它们读取 {{value1}}。",
+          "agentsNoneChosen": "无其他代理",
+          "agentsSummary": "另有：{{value0}}",
+          "agentNotInstalled": "未安装",
+          "bundleDestinationSummary": "新增 {{value0}} · 已安装 {{value1}} · 待处理 {{value2}}",
+          "trustNote": "技能是作者提供的指令和代码。请只安装您信任的内容。",
+          "agentsNone": "未选择任何代理",
+          "agentsSelected": "安装目标：{{value0}}",
+          "agentAlways": "始终",
+          "agentsCanonicalNote": "{{value0}} 读取 {{value1}}，每次安装都会写入该处。",
+          "linkHint": "打开链接永远不会安装任何内容——您需要先检查。",
+          "rowNeedsDecision": "待处理",
+          "rowInstalled": "已安装",
+          "rowUpdate": "更新",
+          "rowNew": "新建",
+          "chooseSkills": "选择要从此链接安装的内容。",
+          "singleRunnableWarning": "此技能包含脚本或二进制文件。",
+          "runnableWarning": "选定的 {{selectedCount}} 个技能中有 {{affectedCount}} 个包含脚本或二进制文件：{{affected}}。",
+          "reviewRunnableFiles": "包含脚本或二进制文件",
+          "reviewSupportingFiles": "包含支持文件",
+          "reviewInstructions": "关于此技能",
+          "supportingFileWarning": "选定的技能除 SKILL.md 外还包含 {{fileCount}} 个文件。",
+          "agentAccessWarning": "技能包含代理可能遵循的指令。仅在信任此分享链接的来源时继续。",
+          "fileBinary": "二进制",
+          "fileRunnable": "可运行",
+          "agentsCountBadge": "已选择 {{count}} 个",
+          "agentsCountLabel": "{{count}} {{label}}",
+          "targetAgentsHeader": "目标代理",
+          "deselectAll": "取消选择可选内容",
+          "selectAll": "全选",
+          "canonicalHeader": "标准代理（始终包含）",
+          "canonicalExplanation": "这些代理原生读取 {{root}}，Orca 默认安装到该处：",
+          "additionalAgentsHeader": "其他代理目录"
+        },
+        "SkillSharedLinkRow": {
+          "contentsUnavailable": "无法加载此链接包含的内容。",
+          "loading": "正在加载内容…",
+          "deleteFailed": "Orca 无法从 Cloud 删除它。",
+          "deleted": "已从 Cloud 删除",
+          "confirmDelete": "确认删除",
+          "moreActions": "{{name}} 的更多操作",
+          "deletePackage": "从 Cloud 删除"
+        },
+        "SkillSharedLinksView": {
+          "loading": "正在加载分享链接…",
+          "noMatches": "没有与此搜索匹配的链接。"
+        },
+        "SkillsSharedLinksHeader": {
+          "back": "返回技能",
+          "backTooltip": "返回技能 · Esc",
+          "unlisted": "非公开——仅拥有链接的人可以打开。"
+        },
+        "managedInstall": {
+          "versionLabel": "版本",
+          "editedWarning": "除非您选择放弃，否则您的编辑会被保留。",
+          "finishInstall": "完成安装",
+          "useVersion": "使用此版本",
+          "reinstall": "重新安装",
+          "cancel": "取消",
+          "sendToMachine": "发送到其他机器",
+          "confirmRemove": "确认移除",
+          "remove": "移除",
+          "discardEditsRemove": "放弃我的编辑并移除",
+          "discardEdits": "放弃我的编辑并重新安装",
+          "titleMore": "{{name}} 等 {{count}} 个",
+          "scopeWorkspace": "此工作区",
+          "scopeGlobal": "所有位置",
+          "installedOn": "安装于 {{date}}",
+          "stateEdited": "安装后被编辑过",
+          "stateMissing": "文件缺失",
+          "skillEdited": "已编辑",
+          "skillMissing": "缺失",
+          "versionCurrent": "{{date}}（已安装）",
+          "installElsewhere": "安装到别处…"
+        },
+        "skillWarningPreview": {
+          "bundleDescription": "覆盖所有警告级别的预览捆绑包。",
+          "instructionsOnlyDescription": "指令完全包含在 SKILL.md 中。",
+          "supportingFilesDescription": "除主要指令外还包含可读的参考文件。",
+          "runnableFilesDescription": "包含代理可能以您的权限运行的脚本。",
+          "binaryFilesDescription": "包含不透明资源和可执行二进制文件。"
         }
       },
       "sidebar": {
@@ -4231,7 +4942,8 @@
           "32a7256d85": "克隆",
           "69f5b5380d": "克隆...",
           "cloneOnHostDescription": "输入 Git URL，并选择要在 {{value0}} 上克隆到的位置。",
-          "cloneParentFolder": "父文件夹"
+          "cloneParentFolder": "父文件夹",
+          "remoteCloneParentPlaceholder": "/home/user/projects"
         },
         "AutoRenameFailedDialog": {
           "aed1623b1e": "关闭",
@@ -4352,7 +5064,8 @@
           "d36883e046": "取消",
           "b79b39d865": "删除项目",
           "removeDescriptionSsh": "此操作仅将 {{name}} 从 Orca 中移除。文件仍保留在 {{host}} 上 — 重新添加该 SSH 主机即可恢复。",
-          "removeDescriptionLocal": "此操作仅将 {{name}} 从 Orca 中移除。文件仍保留在您的磁盘上。"
+          "removeDescriptionLocal": "此操作仅将 {{name}} 从 Orca 中移除。文件仍保留在您的磁盘上。",
+          "removeDescriptionVmRecipe": "这将从 Orca 中移除 {{name}}。其 VM 方案决定环境及其文件是否被永久删除。"
         },
         "ScrollToCurrentWorkspaceToolbarButton": {
           "23989bb663": "显示活动工作区"
@@ -4455,7 +5168,9 @@
           "196c1b5362": "打开 GitLab 任务",
           "0ccba862b8": "打开 GitHub 任务",
           "fee535205b": "任务",
-          "d599269755": "从侧边栏隐藏"
+          "d599269755": "从侧边栏隐藏",
+          "artifacts": "工件",
+          "skills": "技能"
         },
         "SidebarRepositoryFilterSection": {
           "d3a9c4cea1": "清除",
@@ -4502,7 +5217,9 @@
           "cliCreated": "Hide CLI-created",
           "detachedHead": "隐藏分离 HEAD",
           "keepDefaultBranch": "默认分支除外",
-          "keepDefaultBranchAria": "隐藏休眠工作区时仍显示默认分支"
+          "keepDefaultBranchAria": "隐藏休眠工作区时仍显示默认分支",
+          "otherClients": "隐藏其他客户端的工作区",
+          "otherClientsAria": "隐藏共享远程服务器上其他 Orca 客户端创建的工作区"
         },
         "SidebarWorkspaceOptionsMenu": {
           "95c9754653": "智能体活动布局",
@@ -4561,7 +5278,8 @@
           "219ebf1961": "分支名称",
           "automation": "自动化",
           "folderPathIdentity": "分支 / 文件夹路径",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "workspaceOptions": "工作区选项"
         },
         "SshTargetRow": {
           "4677394048": "正在连接…",
@@ -4678,7 +5396,8 @@
           "cliCreated": "由 Orca CLI 创建",
           "jiraIssue": "Jira {{value0}}",
           "viewOnJira": "在 Jira 中查看",
-          "linkedJira": "已关联 Jira {{value0}}"
+          "linkedJira": "已关联 Jira {{value0}}",
+          "openInOrcaBrowser": "在 Orca 浏览器中打开"
         },
         "WorktreeCardMetadataStatusBadges": {
           "fe188062a1": "状态：开放",
@@ -4728,7 +5447,10 @@
           "setParentWorkspace": "设置父工作树...",
           "workspaceSection": "工作区",
           "primaryDeleteDisabled": "主工作树不能删除。请改为移除项目。",
-          "deleteWorktree": "删除工作树"
+          "deleteWorktree": "删除工作树",
+          "sleepWithDescendants": "连同子项休眠（{{value0}}）",
+          "sleepWithDescendantsDescription": "关闭此工作区及所有嵌套子项中的活动面板，以释放内存和 CPU。",
+          "deleteWithDescendants": "连同子项删除…"
         },
         "WorktreeList": {
           "d880ea0744": "创建一个组并将该项目移入其中。",
@@ -4772,7 +5494,9 @@
           "hostDisconnected": "已断开连接",
           "failedNestWorkspace": "无法嵌套工作区",
           "sidebarRowMissing": "目标不再存在",
-          "failedUnnestWorkspace": "展开工作区失败"
+          "failedUnnestWorkspace": "展开工作区失败",
+          "groupRenameFailed": "重命名分组失败",
+          "groupRenameFailedDesc": "Orca 无法与该分组的主机确认新名称。重新连接后请再次检查该分组。"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "取消",
@@ -4793,7 +5517,12 @@
           "65770ad0f0": "编辑此工作区的 GitHub 链接和注释。",
           "382fd11a3e": "编辑工作树详细信息",
           "2174f17011": "保存",
-          "61d6f612cf": "保存中..."
+          "61d6f612cf": "保存中...",
+          "a0d191b7a7": "编辑此工作区的议题链接、拉取请求链接和备注。",
+          "gitlabDescription": "编辑此工作区的议题链接、合并请求链接和备注。",
+          "gitlabMR": "GitLab MR",
+          "gitlabPlaceholder": "MR ! 或 GitLab URL",
+          "gitlabHelp": "粘贴合并请求 URL，或输入编号。留空以移除链接。"
         },
         "WorktreeOpenInMenu": {
           "1417fd8380": "自定义应用程序...",
@@ -4919,7 +5648,8 @@
               "ae57cbf6e4": "删除工作区失败",
               "7488ed8711": "查看",
               "2b20ce87b3": "强制删除",
-              "4f3876c0f5": "强制删除失败"
+              "4f3876c0f5": "强制删除失败",
+              "workspaceListChanged": "工作区列表已更改"
             },
             "toast": {
               "1d0fa5c0a5": "无法删除工作区 {{value0}}",
@@ -4927,7 +5657,10 @@
               "905fc8efac": "Git 已经删除了这个工作区。使用强制删除将其从 Orca 中清除。",
               "0899ebdb28": "Git 已经忘记了这个工作区，但它的目录仍然在磁盘上。使用强制删除来删除孤立目录。",
               "locked": "此工作区被 Git 锁定。请在其仓库中运行 git worktree unlock <worktree-path>，然后重试删除。",
-              "lockedReason": "此工作区被 Git 锁定。Git 报告：{{value0}}。请在其仓库中运行 git worktree unlock <worktree-path>，然后重试删除。"
+              "lockedReason": "此工作区被 Git 锁定。Git 报告：{{value0}}。请在其仓库中运行 git worktree unlock <worktree-path>，然后重试删除。",
+              "unstoppedPty": "Orca 无法确认此工作区中的每个终端都已退出，因此在删除任何文件前已停止。请使用强制删除仍要将其移除。",
+              "unstoppedPtyLive": "此工作区仍有运行中的终端，因此 Orca 在删除任何文件前已停止。强制删除将终止它们并丢弃其中未提交的工作。",
+              "runningAgentSession": "此工作区仍有运行中的代理会话，因此 Orca 在删除任何文件前已停止。强制删除将关闭它们并丢弃其持有的工作。"
             }
           }
         },
@@ -5224,7 +5957,12 @@
         "NewExternalWorktreesInboxLine": {
           "9f2d4c8b17": "永久隐藏 {{value0}} 的外部工作树",
           "5e1b8d3f62": "永久隐藏外部工作树",
-          "c3e8a1f4b2": "不再显示"
+          "c3e8a1f4b2": "不再显示",
+          "2a6f31d8c7": "个隐藏的工作区",
+          "5b90e4a2f6": "个隐藏的工作区",
+          "7f18c5b0d3": "在 {{value1}} 中检查 {{value0}} 个隐藏的工作区",
+          "4e2b7a9c05": "在 {{value1}} 中检查 {{value0}} 个隐藏的工作区",
+          "6c07f3a91e": "{{value1}} 上的 {{value0}}"
         },
         "NoticeHostGlyph": {
           "hostDisconnected": "{{hostName}} 已断开连接",
@@ -5288,7 +6026,34 @@
           "linkDestination": "链接目标",
           "sshTunnel": "我正在使用 SSH 隧道",
           "sshTunnelHelp": "否则，此链接会指回此设备，无法识别另一台计算机。",
-          "loopbackBlocked": "启用 SSH 隧道选项，或使用另一台主机的 Tailscale 或 LAN 地址创建新链接。"
+          "loopbackBlocked": "启用 SSH 隧道选项，或使用另一台主机的 Tailscale 或 LAN 地址创建新链接。",
+          "sshAlreadyExists": "该 SSH 主机已在 Orca 中。",
+          "sshConfigPickerLoadFailed": "读取 ~/.ssh/config 失败。",
+          "sshConfigPickerResolveFailed": "解析该 SSH 配置主机失败。",
+          "sshConfigPickerRestartRequired": "重启 Orca 以完成应用 SSH 配置选择器更新。",
+          "sshConfigPickerFilled": "已从 {{value0}} 填入。请检查并保存。",
+          "sshConfigPickerTitle": "从 ~/.ssh/config 中选择",
+          "sshConfigPickerDescription": "选择主机以填写表单。点击保存前不会保存任何内容。",
+          "sshConfigPickerFilter": "筛选主机…",
+          "sshConfigPickerHostsLabel": "SSH 配置主机",
+          "sshConfigPickerLoading": "正在读取 ~/.ssh/config…",
+          "sshConfigPickerEmpty": "~/.ssh/config 中没有主机",
+          "sshConfigPickerNoMatch": "没有匹配的主机",
+          "sshConfigPickerEmptyHint": "在该处添加 Host 条目，或返回并手动输入详细信息。",
+          "sshConfigPickerNoMatchHint": "换个筛选条件，或返回并手动输入。",
+          "sshConfigPickerMoreResults": "仅显示前 {{value0}} 个匹配项。缩小筛选以查找更多。",
+          "sshConfigPickerInOrca": "已在 Orca 中",
+          "sshConfigPickerPreviouslyRemoved": "已从 Orca 移除",
+          "sshConfigPickerBulkHint": "批量同步保留在设置 → SSH 中",
+          "sshConfigPickerBack": "返回",
+          "fillFromSshConfig": "从 ~/.ssh/config 填入…",
+          "sshConfigPickerAddingAll": "正在添加主机…",
+          "sshConfigPickerAddAll": "将全部 {{value0}} 个添加到 Orca",
+          "sshConfigPickerNoNewHosts": "没有可添加的新主机",
+          "sshConfigPickerAddAllEmpty": "全部添加到 Orca",
+          "identityFileFromConfigHint": "有意留空：Orca 会使用 ~/.ssh/config 为 {{value0}} 解析出的所有密钥。输入路径以仅使用该密钥。",
+          "sshConfigPickerRetry": "重试",
+          "sshConfigPickerResolving": "正在读取…"
         },
         "ForgetSshWorkspaceDialog": {
           "reconnectFailed": "重新连接失败",
@@ -5321,6 +6086,86 @@
           "3b7ea51793": "清除搜索",
           "7f1c2e94a5": "搜索文本过长 — 看板未被筛选",
           "9a4d0f6b21": "过长"
+        },
+        "WorktreeIssueLinkField": {
+          "25852bfc59": "Linear",
+          "5b440069e6": "GitHub",
+          "161b2d053a": "打开关联的议题",
+          "d4785f9954": "议题链接在创建文件夹工作区时设置，暂无法在此处更改。",
+          "964d9bc00a": "不是 Linear 议题键或 linear.app 议题 URL。",
+          "0a7a2c6efd": "不是 GitHub 议题编号或议题 URL。",
+          "72486800ff": "保存将取消关联 {{first}} 和 {{second}}——一个工作区只跟踪一个议题。",
+          "2c245ac134": "保存将取消关联 {{link}}——一个工作区只跟踪一个议题。",
+          "d8c8a30d1f": "无法打开该议题。请检查标识符和 Linear 连接。",
+          "269198eeda": "无法打开该议题。请检查编号和 GitHub 连接。",
+          "f047887705": "粘贴 GitHub 或 Linear URL，或输入编号。留空以移除链接。",
+          "ad78f9bee2": "议题",
+          "662ae142f8": "议题编号，或 GitHub / Linear URL",
+          "929c98d05a": "议题提供方"
+        },
+        "worktreeIssueDisplacement": {
+          "3f61c0a8d2": "Linear {{value}}",
+          "9c4b7e1f60": "GitHub #{{value}}"
+        },
+        "WorktreeCardSshHostControl": {
+          "connectFailed": "SSH 连接失败",
+          "removedTooltip": "SSH 主机已移除——无法重新连接",
+          "removedName": "SSH 主机 {{value0}} 已被移除",
+          "connectedTooltip": "SSH 主机上的项目",
+          "connectedName": "{{value0}} 上的 SSH 主机项目",
+          "connectingName": "正在连接到 SSH 主机 {{value0}}",
+          "authFailedName": "重新连接 SSH 主机 {{value0}}——身份验证失败",
+          "retryName": "重试与 {{value0}} 的 SSH 连接",
+          "connectName": "连接到 SSH 主机 {{value0}}",
+          "authFailedTooltip": "{{value0}} · 身份验证失败",
+          "failedTooltip": "{{value0}} · 连接失败"
+        },
+        "preserved": {
+          "branch": {
+            "batch": {
+              "toast": {
+                "a3cdd9d9e6": "Git 保留了 {{count}} 个本地分支，因为它们可能包含未合并的提交。保留的分支不保留工作区文件夹；其提交保留在仓库中。Orca 可能继续在后台释放工作区磁盘空间。",
+                "a3cdd9d9e6_one": "Git 保留了 {{count}} 个本地分支，因为它可能包含未合并的提交。保留的分支不保留工作区文件夹；其提交保留在仓库中。Orca 可能继续在后台释放工作区磁盘空间。",
+                "a3cdd9d9e6_other": "Git 保留了 {{count}} 个本地分支，因为它们可能包含未合并的提交。保留的分支不保留工作区文件夹；其提交保留在仓库中。Orca 可能继续在后台释放工作区磁盘空间。",
+                "6310412304": "检查 {{count}} 个分支",
+                "6310412304_one": "检查 {{count}} 个分支",
+                "6310412304_other": "检查 {{count}} 个分支",
+                "cea24c2b7d": "已移除 {{count}} 个工作区",
+                "cea24c2b7d_one": "已移除 {{count}} 个工作区",
+                "cea24c2b7d_other": "已移除 {{count}} 个工作区",
+                "0e0379f24a": "保留了 {{count}} 个分支",
+                "0e0379f24a_one": "保留了 {{count}} 个分支",
+                "0e0379f24a_other": "保留了 {{count}} 个分支",
+                "4cf75caab7": "{{value0}}，{{value1}}",
+                "e61d78054f": "正在删除本地分支：{{value0}}",
+                "1e1a5f6763": "已删除本地分支：{{value0}}",
+                "43d9395605": "已删除 {{value0}}，未删除 {{value1}}",
+                "d42f1f14e0": "重试 {{count}} 个分支",
+                "d42f1f14e0_one": "重试 {{count}} 个分支",
+                "d42f1f14e0_other": "重试 {{count}} 个分支"
+              }
+            }
+          }
+        },
+        "PreservedBranchBatchReviewDialog": {
+          "c4bf8e7eaf": "检查保留的分支",
+          "f21976c9a8": "选择要强制删除的本地分支。未选择的分支保留在其仓库中。",
+          "38c947f7c5": "全选",
+          "9602129d38": "已选 {{value1}} 中的 {{value0}} 个",
+          "ee39e872d5": "可能未合并",
+          "676db406fd": "Head 不可用",
+          "285e1e4882": "取消",
+          "a0f9863597": "强制删除 {{count}} 个分支",
+          "a0f9863597_one": "强制删除 {{count}} 个分支",
+          "a0f9863597_other": "强制删除 {{count}} 个分支"
+        },
+        "WorktreeListScrollToTopButton": {
+          "jumpToTop": "回到顶部"
+        },
+        "RepoScanUnavailableIndicator": {
+          "title": "{{value0}} 的工作区扫描失败",
+          "retry": "重试扫描",
+          "retained": "扫描成功之前会保留现有工作区。点击重试。"
         }
       },
       "shared": {
@@ -5557,7 +6402,10 @@
           "5f818f12ab": "正在准备...",
           "4c05b9d7cb": "正在准备设置终端。",
           "installLabel": "安装",
-          "updateLabel": "更新"
+          "updateLabel": "更新",
+          "setupCommandFailed": "设置命令以代码 {{value0}} 退出。成功重试后此错误将清除。",
+          "setupFailed": "设置失败",
+          "retrySetup": "重试"
         },
         "AgentsPane": {
           "d83834f5e6": "检测已安装的智能体...",
@@ -5606,7 +6454,9 @@
           "03e1a5081a": "on {{value0}}",
           "25a41a9aad": "重新检测活动服务器上安装的智能体",
           "remoteDetectionFailed": "无法检测已安装的智能体。请检查主机连接后重试。",
-          "retryDetection": "Retry"
+          "retryDetection": "Retry",
+          "storedDefaultUndetected": "已保存为默认值，但目前未检测到",
+          "noAgentsDetected": "未检测到代理。如果已安装，探测可能已超时。"
         },
         "AppIconSelector": {
           "d5a112dc9b": "下一个图标",
@@ -5779,7 +6629,8 @@
           "b4c167764d": "已从文件将 {{value0}} 个 Cookie 导入到 {{value1}}。",
           "a3f8c2d1e0b4": "已从 {{value1}} ({{value2}}) 导入 {{value0}} 个 Cookie 到 {{value3}}。",
           "b4e9d3f2a1c5": "已从 {{value1}} 导入 {{value0}} 个 Cookie 到 {{value2}}。",
-          "c5a273a809": "从 {{value0}}"
+          "c5a273a809": "从 {{value0}}",
+          "b5c0479e21": "未修改的用户代理"
         },
         "BrowserUseComputerUseNotice": {
           "15b5e680ba": "开放计算机使用",
@@ -5866,7 +6717,9 @@
           "14444243ba": "从路径中删除`{{value0}}`？",
           "5d432fe44d": "已安装",
           "8a9b784c60": "陈旧",
-          "d363e5929b": "正在检查 CLI 注册..."
+          "d363e5929b": "正在检查 CLI 注册...",
+          "installFailureUnknownReason": "Orca 未能完成 CLI 注册，且未报告原因。",
+          "installFailureConflictRemedy": "如果不再需要 {{value0}}，请将其移除后重新注册。"
         },
         "CliSkillRuntimeSetup": {
           "04325573f8": "WSL",
@@ -5944,7 +6797,10 @@
           "6b5a2cd3a5": "无障碍",
           "6b17602073": "重置访问权限",
           "506f2acf7a": "正在重置访问...",
-          "4b65070096": "darwin"
+          "4b65070096": "darwin",
+          "statusGranted": "已授予",
+          "statusUnsupported": "仅 macOS",
+          "statusNotEnabled": "未启用"
         },
         "DeveloperPermissionsPane": {
           "4c17304beb": "刷新",
@@ -5973,7 +6829,39 @@
           "e5b5f3d6b9": "相机",
           "cc8151d9fa": "语音输入、转录、录音、sox、ffmpeg 和 Whisper CLI。",
           "16381e040a": "麦克风",
-          "dac08ec03e": "处理中..."
+          "dac08ec03e": "处理中...",
+          "actionRequest": "请求",
+          "actionOpenSettings": "打开设置",
+          "actionTriggerPrompt": "触发提示",
+          "statusGranted": "已授予",
+          "statusDenied": "已拒绝",
+          "statusNotRequested": "未请求",
+          "statusRestricted": "受限",
+          "statusUnsupported": "仅 macOS",
+          "statusEntitled": "已授权",
+          "statusCheckManually": "手动检查",
+          "actionRequestAccess": "请求访问权限",
+          "localNetworkPromptCheck": "检查 macOS 提示",
+          "localNetworkPromptGuidance": "如出现提示，请选择允许。如果没有出现提示，请打开系统设置，在隐私与安全性 → 本地网络下启用 Orca。",
+          "localNetworkOpenSettings": "打开系统设置",
+          "openSettingsFailed": "无法打开系统设置",
+          "localNetworkOpenSystemSettings": "打开系统设置",
+          "statusManagedByMacOS": "由 macOS 管理",
+          "connectionTestInvalidTarget": "输入主机名或私有局域网 IP，以及 1 到 65535 的端口。",
+          "connectionTestTimeout": "连接超时。请检查目标、服务和 macOS 本地网络设置。",
+          "connectionTestRefused": "主机有响应，但端口拒绝了连接。",
+          "connectionTestUnreachable": "无法到达目标。",
+          "connectionTestUnresolved": "无法解析主机名。",
+          "connectionTestUnsupported": "连接测试仅在 macOS 桌面应用中可用。",
+          "connectionTestFailed": "无法完成连接测试。",
+          "connectionTestTitle": "测试连接",
+          "connectionTestDescription": "输入本地网络上另一台设备的服务。Orca 将测试终端工具使用的同一网络路径。",
+          "connectionTestLastVerified": "上次验证",
+          "connectionTestNotYetVerified": "没有保存的成功测试。",
+          "connectionTestHost": "主机",
+          "connectionTestPort": "端口",
+          "connectionTestRunning": "测试中...",
+          "connectionTestAction": "测试连接"
         },
         "ExperimentalPane": {
           "9762364929": "在可能时在 macOS 上使用 APFS clone-copy；否则，将配置的文件夹或文件符号链接到创建的工作树中。",
@@ -6012,7 +6900,11 @@
             "defaultCopy": "选择如何打开受支持智能体的新终端标签页。",
             "defaultViewLabel": "默认 Chat UI 视图",
             "defaultViewTerminal": "终端聊天",
-            "defaultViewNative": "Chat UI"
+            "defaultViewNative": "Chat UI",
+            "structuredTitle": "使用新版结构化原生聊天",
+            "structuredCopy": "为 Codex 和 Claude 选择加入由主机托管的结构化聊天运行时。关闭则保留现有的基于终端的聊天路径。",
+            "structuredScope": "目前仅限本地会话。WSL 和远程执行主机（包括 SSH）继续使用终端聊天；除非 Orca 能读取进程启动时间，否则 Windows 也会回退到终端聊天。",
+            "structuredToggleLabel": "切换新版结构化原生聊天"
           },
           "agentDashboard": {
             "title": "智能体仪表盘",
@@ -6081,7 +6973,9 @@
           "b82f86d7d2": "Markdown 拼写检查（富文本）",
           "5195f0b9ef": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
           "7ddd66fede": "编辑器自动换行",
-          "9b18de6eea": "在文件编辑器中自动换行长行，而无需水平滚动。"
+          "9b18de6eea": "在文件编辑器中自动换行长行，而无需水平滚动。",
+          "f1b3ceeb98": "差异显示空白",
+          "94a479cef3": "在差异中显示首尾空白差异。"
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "本地主机，127.0.0.1，*.internal",
@@ -6144,7 +7038,8 @@
           "31fd7150cf": "正在检查更新...",
           "3394d1f663": "检查中",
           "d69a09b672": "启动时会自动检查更新。",
-          "7173352632": "空闲"
+          "7173352632": "空闲",
+          "e3b9d21c07": "已可用。请通过系统包管理器更新 Orca——Orca 无法自行安装此版本。"
         },
         "GeneralWorkspaceSettingsSection": {
           "3d538a98f7": "从工作区的“打开方式”菜单中选择可用的应用程序。",
@@ -6165,7 +7060,10 @@
           "externalWorktrees": "外部工作树",
           "externalWorktreesDescription": "选择是否默认显示在 Orca 外部创建的工作树。",
           "show": "显示",
-          "hide": "隐藏"
+          "hide": "隐藏",
+          "31e300af1c": "删除工件前询问",
+          "fb29a73a17": "删除分享的工件并断开其公开链接前显示确认对话框。",
+          "bf46474e33": "删除分享的工件前显示确认。持有其公开链接的任何人都将失去访问权限。"
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "应用更改",
@@ -6468,7 +7366,11 @@
           "1b1b70279a": "尚未配对任何设备。",
           "1592afcc7a": "尚未配对任何设备。使用 Orca 手机应用程序扫描二维码。",
           "relayDegradedNotice": "无法连接 Relay — 此二维码仅在局域网或 Tailscale 内可用。请重新生成后再试。",
-          "pairingQrError": "无法将此配对码呈现为二维码。请改为将其复制到 Orca Mobile。"
+          "pairingQrError": "无法将此配对码呈现为二维码。请改为将其复制到 Orca Mobile。",
+          "pairingCodeReady": "配对码已就绪",
+          "copyPairingCode": "复制配对码",
+          "diagnosticsCopied": "诊断信息已复制",
+          "diagnosticsCopyFailed": "复制诊断信息失败"
         },
         "MobileSettingsPane": {
           "9a3c280e49": "GitHub 发布",
@@ -6559,7 +7461,9 @@
           "9bedd2a6e5": "使智能体能够通过 Orca 传递上下文并协调工作。",
           "07641b9768": "编排技能",
           "2aacdb0517": "跨切换、工作树切换和子智能体工作协调编码智能体。",
-          "191ac34567": "智能体编排"
+          "191ac34567": "智能体编排",
+          "nestedWorkerDepthTitle": "嵌套工作器深度",
+          "nestedWorkerDepthDescription": "允许派发的工作器再逐代生成自己的工作器的代数。设为 1 可保持代理树扁平：协调器派发工作器，工作器不再派发。"
         },
         "OrchestrationSetupCard": {
           "e7d2a5146c": "使智能体能够通过 Orca 传递上下文并协调工作。",
@@ -6568,7 +7472,13 @@
         "OrchestrationSkillAgentCoverage": {
           "6dec5ce2d2": "智能体覆盖范围",
           "ffe13e36fb": "缺失",
-          "1e8f8d8fae": "就绪"
+          "1e8f8d8fae": "就绪",
+          "checking": "正在检查已安装的代理和技能路径…",
+          "noAgents": "在 PATH 上未检测到代理 CLI。请在设置 → 代理中安装代理，然后重新检查。",
+          "fullCoverage_one": "已检测的 1 个代理都有该技能。",
+          "fullCoverage_other": "已检测的 {{value0}} 个代理都有该技能。",
+          "noCoverage": "请先安装上方技能，然后重新检查。",
+          "partialCoverage": "已检测的 {{value1}} 个代理中有 {{value0}} 个有该技能。"
         },
         "OrchestrationSkillPromptDialog": {
           "f08d45293d": "复制命令",
@@ -6636,7 +7546,13 @@
           "8d525e5f15": "已复制",
           "53b17a4b1b": "无法复制",
           "a9a564b7e7": "复制 {{value0}}",
-          "69a1441a21": "无可复制内容"
+          "69a1441a21": "无可复制内容",
+          "89f7e57fcc": "保存于",
+          "d59bd333c3": "更新此 Orca 服务器以管理其快捷命令。",
+          "f2bf411640": "无法从此主机加载命令。",
+          "7ecfee5b8e": "重试",
+          "601d6af51f": "正在加载命令…",
+          "923ba89646": "无法从此主机刷新命令。显示上次加载的命令。"
         },
         "RecentTabOrderControl": {
           "3b17c81ede": "标签条顺序",
@@ -6834,7 +7750,9 @@
           "show": "显示",
           "hide": "隐藏",
           "externalWorktreesGlobal": "全局默认值：{{value0}}",
-          "useGlobal": "使用全局设置"
+          "useGlobal": "使用全局设置",
+          "hostStateWorkspaceWindowClosed": "工作区窗口已关闭",
+          "hostWorkspaceWindowClosedHelp": "服务器可达，但其 Orca 窗口已关闭。请在 {{value0}} 上打开 Orca 以使用此设置。"
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "提示词模板",
@@ -6989,7 +7907,11 @@
           "troubleshootStepRegenerate": "生成新的访问链接，并仅在此处使用最新的链接。",
           "troubleshootTunnel": "正在使用 SSH 本地转发？返回“连接到主机”，粘贴环回链接，然后在“高级”下启用“我正在使用 SSH 隧道”。",
           "cloudVmWorkflow": "云虚拟机",
-          "cloudVmWorkflowHelp": "管理由配方创建的云端机器"
+          "cloudVmWorkflowHelp": "管理由配方创建的云端机器",
+          "serverWorkspaceWindowClosed": "工作区窗口已关闭",
+          "serverRuntimeUnavailable": "Orca 不可用",
+          "serverRuntimeUnavailableDescription": "SSH 传输已连接，但 Orca 运行时无响应。主机可能仍在运行。",
+          "serverReconnecting": "正在重新连接"
         },
         "RuntimePairingGeneratedUrlRows": {
           "0495f68959": "复制 {{value0}}"
@@ -7270,7 +8192,8 @@
           "4db9afce1c": "端口必须介于 1 和 65535 之间",
           "0e5aa04161": "需要主机或 SSH 配置别名",
           "f1fc50dad2": "无法加载 SSH 目标",
-          "0cda732f43": "连接测试失败"
+          "0cda732f43": "连接测试失败",
+          "terminateUnverifiable": "{{terminals}} 个远程终端无法连接。请重新连接后再结束它们。"
         },
         "SshPassphraseDialog": {
           "d5a234456f": "取消",
@@ -7285,7 +8208,11 @@
           "8a349e3fac": "{{value0}} 的密钥口令",
           "cab3d5f5a5": "{{value0}} 的密码",
           "1f3dde805d": "SSH 密钥口令",
-          "106bd57f4a": "SSH 密码"
+          "106bd57f4a": "SSH 密码",
+          "a21f9e74c0": "SSH 验证",
+          "981352fb42": "完成验证挑战：",
+          "456516603b": "输入响应",
+          "c624f64b86": "继续"
         },
         "SshTargetCard": {
           "ec6543cee9": "连接",
@@ -7765,7 +8692,8 @@
             "b2c4e7f1a8": "端点",
             "3a9b6d2c4e": "API 密钥",
             "5d8f1a3b7c": "中国",
-            "7e2a4b8c1d": "海外"
+            "7e2a4b8c1d": "海外",
+            "d16378a88f": "minimax"
           }
         },
         "advanced": {
@@ -7844,7 +8772,16 @@
             "agentPermissions": "智能体权限",
             "agentPermissionsDescription": "在 Yolo 和手动之间切换智能体权限默认值。",
             "agentRuntime": "智能体运行时",
-            "agentRuntimeDescription": "选择默认在 Windows 还是 WSL 中检测并启动智能体。"
+            "agentRuntimeDescription": "选择默认在 Windows 还是 WSL 中检测并启动智能体。",
+            "runtime": "运行时",
+            "agentLocation": "代理位置",
+            "installedAgentsWsl": "wsl 中已安装的代理",
+            "permission": "权限",
+            "permissions": "权限",
+            "yolo": "yolo",
+            "manual": "手动",
+            "skip": "跳过",
+            "checks": "检查"
           }
         },
         "appearance": {
@@ -7965,7 +8902,11 @@
             },
             "leftSidebarAppearance": {
               "title": "左侧边栏外观",
-              "description": "让左侧边栏匹配终端、保持默认，或使用色调。"
+              "description": "让左侧边栏匹配终端、保持默认，或使用色调。",
+              "project": "项目",
+              "terminal": "终端",
+              "background": "背景",
+              "tint": "色调"
             },
             "workspaceCardLayout": {
               "title": "工作区卡片布局",
@@ -7982,7 +8923,15 @@
             "4d5b9427b5": "启用后，关闭窗口会让 Orca 继续在系统托盘中运行，而不是退出。",
             "showPinnedWorktreesInGroups": {
               "title": "也在原来的列表中显示已固定的工作树",
-              "description": "已固定的工作树会保留在 Pinned 中，同时也显示在全部、项目、状态和 PR 中。"
+              "description": "已固定的工作树会保留在 Pinned 中，同时也显示在全部、项目、状态和 PR 中。",
+              "pinned": "已固定",
+              "worktree": "工作树",
+              "workspace": "工作区",
+              "all": "全部",
+              "project": "项目",
+              "status": "状态",
+              "pr": "PR",
+              "duplicate": "复制"
             },
             "antigravityUsageTitle": "Antigravity 使用情况",
             "antigravityUsageDescription": "在状态栏中显示 Antigravity 订阅使用情况。",
@@ -7992,7 +8941,15 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "用量百分比",
-            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。"
+            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。",
+            "tray": {
+              "tray": "托盘",
+              "system": "系统托盘",
+              "minimize": "最小化",
+              "close": "关闭",
+              "notification": "通知区域",
+              "background": "背景"
+            }
           }
         },
         "auto": {
@@ -8078,7 +9035,35 @@
             "a942905148": "创建新浏览器选项卡时打开的 URL。留空以打开空白选项卡。",
             "c3903322d2": "默认主页",
             "19ea5607cf": "本地主机工作区标签",
-            "4e0fdf0a3f": "将工作区端口打开为特定于工作区的 Orca localhost URL，便于区分浏览器标签页。"
+            "4e0fdf0a3f": "将工作区端口打开为特定于工作区的 Orca localhost URL，便于区分浏览器标签页。",
+            "terminalLinkActions": {
+              "terminal": "终端",
+              "chat": "聊天",
+              "click": "点击",
+              "actions": "操作",
+              "popover": "弹出框",
+              "menu": "菜单",
+              "disable": "禁用"
+            },
+            "6f5199381e": "端口",
+            "8f036ea11f": "工作树",
+            "c4e3bf3282": "标签页",
+            "a8c55c9c91": "图标",
+            "660c1dd007": "标签",
+            "clientHostedRemote": {
+              "remote": "远程",
+              "client": "客户",
+              "host": "主机",
+              "desktop": "桌面",
+              "placement": "放置位置"
+            },
+            "sshWorkspaceRouting": {
+              "ssh": "SSH",
+              "proxy": "代理",
+              "tunnel": "隧道",
+              "routing": "路由",
+              "network": "网络"
+            }
           },
           "use": {
             "search": {
@@ -8285,12 +9270,26 @@
             "nativeChat": {
               "title": "Chat UI",
               "description": "预览受支持的智能体终端会话的桌面聊天界面。",
-              "grok": "grok"
+              "grok": "grok",
+              "native": "本国的",
+              "chat": "聊天",
+              "claude": "claude",
+              "codex": "codex",
+              "openclaude": "openclaude",
+              "omp": "奥普",
+              "terminal": "终端",
+              "agent": "代理"
             },
             "agentDashboard": {
               "title": "智能体仪表盘",
               "description": "用于监控跨工作树的智能体的看板，支持窗口内或弹出窗口显示。",
-              "dashboard": "仪表盘"
+              "dashboard": "仪表盘",
+              "agent": "代理",
+              "kanban": "看板",
+              "popout": "弹出",
+              "board": "看板",
+              "inWindow": "窗口内",
+              "worktrees": "工作树"
             }
           }
         },
@@ -8462,7 +9461,24 @@
             "editorFontFamily": "编辑器字体",
             "editorFontFamilyDesc": "文件编辑器和差异视图使用的字体，留空则跟随终端字体。",
             "externalWorktrees": "外部工作树",
-            "externalWorktreesDescription": "选择是否默认显示在 Orca 外部创建的工作树。"
+            "externalWorktreesDescription": "选择是否默认显示在 Orca 外部创建的工作树。",
+            "editorFontKw": "字体",
+            "f96cdaf37d": "拼写检查",
+            "a51d23f4a1": "拼写检查",
+            "641358460a": "拼写",
+            "d755962089": "红色下划线",
+            "projectRuntime": "项目运行时",
+            "runtime": "运行时",
+            "windowsHost": "windows 主机",
+            "wsl": "wsl",
+            "distro": "发行版",
+            "execution": "执行",
+            "externalKeyword": "外部",
+            "visibility": "可见性",
+            "sidebar": "侧边栏",
+            "867dddea41": "已固定",
+            "5250cf0e48": "固定",
+            "afa37a34e1": "关闭"
           }
         },
         "git": {
@@ -8516,7 +9532,8 @@
             "defaultCompareBase": "默认对比基准",
             "defaultBranch": "默认分支",
             "repositoryDefault": "仓库默认",
-            "branchUpstream": "分支上游"
+            "branchUpstream": "分支上游",
+            "diffBase": "差异基准"
           }
         },
         "input": {
@@ -8573,7 +9590,9 @@
             "41ccade05c": "gh",
             "b79c21bd42": "GitHub",
             "7166b9090c": "通过 gh CLI 进行 GitHub 身份验证。",
-            "f16e41cc72": "GitHub 集成"
+            "f16e41cc72": "GitHub 集成",
+            "760e2446e0": "使用保存的 API Token 或环境变量进行 Bitbucket Cloud 身份验证。",
+            "af5ae87847": "访问 Token"
           }
         },
         "jira": {
@@ -8602,7 +9621,9 @@
               "d5c5b47bb9": "更新",
               "fb854902d9": "连接",
               "9a9f8d4910": "连接 Jira Cloud 以浏览、创建和链接议题。",
-              "74f3063026": "{{value0}} 站点{{value1}} 已连接"
+              "74f3063026": "{{value0}} 站点{{value1}} 已连接",
+              "statusConnected": "已连接",
+              "statusNotConnected": "未连接"
             }
           }
         },
@@ -8707,7 +9728,13 @@
               "1de96ec8a6": "显示 Orca Mobile 按钮",
               "682293cadf": "在左侧边栏顶部显示 Orca Mobile 按钮。",
               "e4f4daea0e": "中继",
-              "5d5af8e041": "iPhone"
+              "5d5af8e041": "iPhone",
+              "74618577c7": "移动端",
+              "5e5b8878bf": "手机",
+              "5bff6a2ef0": "侧边栏",
+              "6cf5f54ce1": "按钮",
+              "648eeada79": "隐藏",
+              "ac79fe4a04": "显示"
             }
           }
         },
@@ -8950,7 +9977,25 @@
             "externalWorktreesDescription": "覆盖是否为此项目显示在 Orca 外部创建的工作树。",
             "copy": "复制",
             "clone": "克隆",
-            "apfs": "apfs"
+            "apfs": "apfs",
+            "waitForSetupBeforeAgent": "启动代理前等待设置完成",
+            "external": "外部",
+            "visibility": "可见性",
+            "sidebar": "侧边栏",
+            "fork": "复刻",
+            "upstream": "upstream",
+            "syncFork": "同步复刻",
+            "fastForward": "快进",
+            "behindUpstream": "落后于上游",
+            "origin": "origin",
+            "defaultBranch": "默认分支",
+            "runtime": "运行时",
+            "execution": "执行",
+            "windowsHost": "windows 主机",
+            "wsl": "wsl",
+            "distro": "发行版",
+            "agentRuntime": "代理运行时",
+            "skillRuntime": "技能运行时"
           }
         },
         "runtime": {
@@ -8989,7 +10034,8 @@
             "7e3fc707aa": "终端",
             "0ecba9aa5f": "键盘",
             "ebd7d81e1d": "选择当快捷键重叠时 Orca 或焦点终端是否获胜。",
-            "f052906167": "终端中的快捷键"
+            "f052906167": "终端中的快捷键",
+            "groupShortcut": "{{value0}} 快捷键"
           }
         },
         "ssh": {
@@ -9061,7 +10107,9 @@
               "c38c18be15": "选择",
               "797fdfe4ca": "选择",
               "603818e8d8": "一旦做出选择，就会自动将终端选择复制到剪贴板。",
-              "3bdc84f059": "选择时复制"
+              "3bdc84f059": "选择时复制",
+              "zellij": "zellij",
+              "grok": "grok"
             }
           },
           "search": {
@@ -9255,6 +10303,34 @@
               "title": "主题模式",
               "keyword_target": "目标",
               "keyword_editing": "编辑"
+            },
+            "39ea7c0d28": "终端",
+            "scroll": "滚动",
+            "scrolling": "滚动",
+            "speed": "速度",
+            "wheel": "滚轮",
+            "trackpad": "触控板",
+            "tui": "推",
+            "a0c44061ee": "确认",
+            "close_terminal": "关闭",
+            "running": "运行中",
+            "command": "命令",
+            "agent": "代理",
+            "process": "进程",
+            "prompt": "提示词",
+            "stop": "停止",
+            "minimumContrast": {
+              "title": "颜色对比度",
+              "description": "提高文本可读性，或保留终端程序选择的颜色。",
+              "contrast": "对比度",
+              "minimum": "最小",
+              "ratio": "比率",
+              "readability": "可读性",
+              "wcag": "wcag",
+              "powerline": "powerline",
+              "statusline": "statusline",
+              "dim": "暗淡",
+              "colors": "颜色"
             }
           },
           "windows": {
@@ -9319,7 +10395,13 @@
               "20574cbc72": "启用语音听写",
               "322d457a0d": "转录",
               "dcc7846641": "配置用于云语音转文本模型的 OpenAI API 密钥。",
-              "ebfd0b32e5": "OpenAI 转录"
+              "ebfd0b32e5": "OpenAI 转录",
+              "microphoneTitle": "麦克风",
+              "microphoneDescription": "选择语音听写使用的输入设备。",
+              "micInput": "输入",
+              "micDevice": "设备",
+              "micAirpods": "airpods",
+              "micDefault": "系统默认"
             }
           }
         },
@@ -9348,7 +10430,9 @@
           "e5995ce268": "智能体工作时保持电脑唤醒",
           "95d3031db2": "在智能体工作时保持此电脑和显示器唤醒。合盖行为遵循此设备的电源设置。",
           "a42f6fbdd8": "在智能体工作时保持此电脑和显示器唤醒。Orca 还会根据电源策略，在合盖时请求此设备保持唤醒。",
-          "modeTitle": "防止电脑休眠"
+          "modeTitle": "防止电脑休眠",
+          "modeDescriptionWindows": "选择开、代理或关。代理模式在代理工作时保持唤醒；合盖行为遵循此设备的电源设置。",
+          "modeDescriptionDefault": "选择开、代理或关。代理模式在代理工作时保持唤醒；Orca 还会在合盖时请求设备保持唤醒（以其电源策略为准）。"
         },
         "AgentAwakeSetting": {
           "on": "开启",
@@ -9437,7 +10521,11 @@
                   "6f30fc4216": "此运行时暂不支持 GitHub CLI 状态。",
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "通过",
-                  "account_scope_prefix": "账户范围"
+                  "account_scope_prefix": "账户范围",
+                  "statusConnected": "已连接",
+                  "statusUnavailable": "不可用",
+                  "statusNotInstalled": "未安装",
+                  "statusNotAuthenticated": "未经过验证"
                 }
               }
             }
@@ -9469,7 +10557,9 @@
                 "disconnect_all": "断开连接",
                 "account_scope_prefix": "账户范围",
                 "2d60ec7921": "使用 API token 连接 Jira Cloud 站点，或使用个人访问令牌或用户名和密码连接自托管 Jira。凭据会发送到所选远程运行时并以运行时支持的加密方式存储。",
-                "977e360b71": "使用 API token 连接 Jira Cloud 站点，或使用个人访问令牌或用户名和密码连接自托管 Jira。凭据存储在本地，本地运行时存储支持时会进行加密。"
+                "977e360b71": "使用 API token 连接 Jira Cloud 站点，或使用个人访问令牌或用户名和密码连接自托管 Jira。凭据存储在本地，本地运行时存储支持时会进行加密。",
+                "statusConnected": "已连接",
+                "statusNotConnected": "未连接"
               }
             }
           }
@@ -9510,7 +10600,13 @@
                   "63a7f47392": "ORCA_BITBUCKET_EMAIL",
                   "24ac1c69dc": "此运行时暂不支持 Bitbucket 状态。",
                   "a924e8dcd1": "通过 Bitbucket Cloud API token 获取 pull request 和构建状态。",
-                  "0fa5629dad": "pull request 和构建状态"
+                  "0fa5629dad": "pull request 和构建状态",
+                  "statusConnected": "已连接",
+                  "statusUnavailable": "不可用",
+                  "statusNotConfigured": "未配置",
+                  "statusAuthFailed": "验证失败",
+                  "statusConfigured": "已配置",
+                  "statusOptionalSetup": "可选设置"
                 }
               }
             }
@@ -9561,7 +10657,9 @@
           "hostOverride": "主机覆盖",
           "workspaceDirectory": "在主机需要自己的工作树目录之前，继承客户端默认值。",
           "providerHost": "提供商主机",
-          "providerAccounts": "凭据和账户检查归属于本地客户端或拥有该提供商集成的所选远程服务器。"
+          "providerAccounts": "凭据和账户检查归属于本地客户端或拥有该提供商集成的所选远程服务器。",
+          "hostCollectionProjectScopes": "主机集合与项目范围",
+          "terminalQuickCommandHostCollections": "命令保存在选定的 Orca 主机上，再限定为全局或项目设置。此设备的命令在远程工作区中也可使用。"
         },
         "RepositoryForkSyncSection": {
           "defaultBranch": "默认分支",
@@ -9761,12 +10859,21 @@
           "cloudVmTitle": "云虚拟机运行时",
           "cloudVmRefresh": "刷新云虚拟机运行时",
           "cloudVmLoading": "正在检查云虚拟机运行时…",
-          "cloudVmEmptyWithSetup": "还没有云虚拟机运行时。请在创建工作区时使用环境模板来创建。"
+          "cloudVmEmptyWithSetup": "还没有云虚拟机运行时。请在创建工作区时使用环境模板来创建。",
+          "stoppingCleanup": "正在停止…",
+          "stopCleanup": "停止清理",
+          "cleanupStopped": "清理已停止",
+          "stopCleanupFailed": "无法停止 Cloud VM 清理。"
         },
         "ephemeralVms": {
           "search": {
             "description": "了解仓库自带的环境模板如何为每个工作区提供按需创建、可丢弃的独立环境。",
-            "cloudVmTitle": "云虚拟机"
+            "cloudVmTitle": "云虚拟机",
+            "keywordVm": "虚拟机",
+            "keywordSandbox": "沙盒",
+            "keywordCloud": "云",
+            "keywordRecipe": "方案",
+            "keywordEphemeral": "临时"
           }
         },
         "EphemeralVmsPane": {
@@ -9824,7 +10931,12 @@
               },
               "search": {
                 "title": "Linear",
-                "description": "Linear 技能状态、使用示例和任务来源设置链接。"
+                "description": "Linear 技能状态、使用示例和任务来源设置链接。",
+                "linear": "Linear",
+                "tickets": "工单",
+                "issues": "议题",
+                "skill": "技能",
+                "orcaLinear": "orca-linear"
               }
             }
           }
@@ -9846,7 +10958,9 @@
           "e6dadc1e2b": "Monthly usage",
           "75e396bf42": "Grok 统一计费账户的月度已用额度。",
           "b36fa2c908": "已登录。Orca 读取存储在磁盘上的 Grok CLI 会话。",
-          "f08c41de73": "会话已过期 — 在运行 Orca 的计算机上运行 grok 并等待其启动。如果提示，请完成登录，然后点击刷新使用量。无需发送聊天消息。"
+          "f08c41de73": "会话已过期 — 在运行 Orca 的计算机上运行 grok 并等待其启动。如果提示，请完成登录，然后点击刷新使用量。无需发送聊天消息。",
+          "0bb18642b7": "用量",
+          "a8f4139350": "Grok 未报告此账户的使用百分比。"
         },
         "AppearanceWindowSidebarSection": {
           "usagePercentageDisplayUsed": "已用",
@@ -9884,7 +10998,9 @@
           "signInRequired": "仅 Relay 需要 — 局域网无需账号。",
           "relayUnavailable": "此版本不支持 Orca Relay。请使用局域网。",
           "signInAgain": "重新登录以使用 Relay",
-          "localTitle": "局域网"
+          "localTitle": "局域网",
+          "retrying": "正在重试",
+          "relayCell": "中继单元"
         },
         "MobilePairingSetupSection": {
           "title": "配对手机",
@@ -10340,7 +11456,9 @@
           "connectionDetails": "连接详情",
           "endpointKind": "端点类型",
           "networkConnection": "网络连接",
-          "notAttempted": "未尝试"
+          "notAttempted": "未尝试",
+          "saveFailed": "无法保存主机",
+          "saveFailedHelp": "主机已验证，但 Orca 无法保存它。请检查名称和本地设置存储，然后重试。"
         },
         "CloudVmSetupGuide": {
           "title": "创建云虚拟机",
@@ -10361,6 +11479,256 @@
           "saveFailed": "无法保存可见性默认设置。",
           "updateServer": "请更新此服务器以配置来源默认设置。",
           "updateServerDefaults": "请更新此服务器以配置可见性默认设置。"
+        },
+        "QuickCommandsList": {
+          "noSearchMatches": "没有与此搜索匹配的命令。"
+        },
+        "QuickCommandsToolbar": {
+          "searchLabel": "搜索命令"
+        },
+        "TerminalAdvancedTypographyControls": {
+          "f5fa1a08f1": "粗体字重",
+          "0e0d1ee15a": "与字重独立调节。某些字体将多个取值映射到同一字形，因此如果粗体看起来没有变化，请降低字重或换一种字体。"
+        },
+        "BrowserTerminalLinkActionsSetting": {
+          "title": "显示链接操作",
+          "description": "点击终端或聊天记录中的链接时显示可用操作。关闭后，在终端中需要按住 {{modifier}} 再点击。"
+        },
+        "ReleaseChannelSection": {
+          "switchFailed": "无法切换到该构建。",
+          "title": "发布渠道",
+          "description": "切换更新渠道或跳转到任何已发布的构建，包括旧版本。允许降级；未经验证的构建可能无法使用。",
+          "devOnly": "仅开发",
+          "channelAriaLabel": "更新渠道",
+          "hourlyWarning": "Hourly 构建直接来自 main，未经过测试门禁，且 Windows 版本未签名。请保留一个稳定版本备用。",
+          "dailyWarning": "Daily 构建直接来自 main，未经过测试门禁，且 Windows 版本未签名。请保留一个稳定版本备用。",
+          "adhocWarning": "Adhoc 构建来自尚未合并的分支，且 Windows 版本未签名。构建者可能弃置它——请保留一个稳定版本备用。",
+          "loadingBuilds": "正在加载构建…",
+          "noBuilds": "未找到构建",
+          "refresh": "刷新构建列表",
+          "switchTo": "切换到此构建",
+          "alreadyRunning": "这就是您正在运行的构建。",
+          "willSwitch": "{{value0}} → {{value1}}",
+          "webUnavailable": "切换构建仅在桌面应用中可用。",
+          "devChannelUnsupportedAria": "{{value0}}（仅 {{value1}}）",
+          "devChannelUnsupported": "{{value0}} 构建仅为 {{value1}} 生成。Linux 请使用 Stable 或 RC。",
+          "downloadInstaller": "下载安装程序",
+          "manualInstallHint": "{{value0}} 构建在 Windows 上未签名，因此应用内更新器无法在已签名的构建上覆盖安装。请运行一次下载的安装程序——Windows 会警告发布者未知——之后每次切换（包括切回 Stable）都可在此处完成。"
+        },
+        "TerminalTccAttributionNotice": {
+          "body": "终端守护进程由已不存在的 Orca 安装启动，因此 macOS 无法将其命令归因于 Orca——辅助功能和自动化授权被静默忽略（osascript 报错 -25211）。重启守护进程可修复此问题；正在运行的终端会话将关闭。",
+          "openManageSessions": "打开会话管理",
+          "title": "macOS 权限授权未作用到终端"
+        },
+        "artifacts": {
+          "enable": "启用工件",
+          "enableDescription": "在侧边栏中添加工件，以便打开和删除分享的文件。",
+          "account": "Orca 账户",
+          "connected": "已连接",
+          "signInRequired": "上传和管理工件需要登录。",
+          "signingIn": "正在登录…",
+          "signIn": "登录 Orca",
+          "title": "工件",
+          "description": "与团队分享 HTML 和 Markdown 文件，并管理其公开链接。",
+          "howToTitle": "如何使用工件",
+          "howToDescription": "将 HTML 或 Markdown 文件发布为公开链接，然后分享给团队。",
+          "shareStepTitle": "选择要分享的文件",
+          "shareStepDescription": "打开 HTML 或 Markdown 文件并选择“分享为工件”，或让代理来分享。",
+          "linkStepTitle": "复制公开链接",
+          "linkStepDescription": "发布后复制链接并发送给团队。",
+          "manageStepTitle": "在 Orca 中管理",
+          "manageStepDescription": "从侧边栏打开工件以预览或移除链接。",
+          "openArtifacts": "打开工件",
+          "openArtifactsDescription": "查看和删除通过您的账户分享的链接。",
+          "showButton": "显示工件按钮",
+          "showButtonDescription": "在侧边栏中显示工件快捷方式。",
+          "openArtifactsDescriptionV2": "预览、复制和管理通过您的账户分享的链接。",
+          "signInTitle": "登录以分享工件",
+          "signInDescription": "使用 Orca 账户上传工件并管理其公开链接。",
+          "signInAgain": "重新登录",
+          "enableStepTitle": "启用工件分享",
+          "enableStepWebDescription": "在主机设备的 Orca 桌面应用中打开设置 → 工件，并启用发布。",
+          "enableStepDescription": "打开上方的“允许发布公开工件链接”。",
+          "allowPublishing": "允许发布公开工件链接",
+          "allowPublishingWebDescription": "仅桌面端。请在主机设备上的设置 → 工件中更改此设置。",
+          "allowPublishingDescription": "将 HTML 和 Markdown 文件发布为持有 URL 的任何人都能打开的链接。现有链接会保留，直到您从工件中删除它们。",
+          "howToDescriptionDisabled": "在上方启用工件分享，即可将 HTML 或 Markdown 文件发布为公开链接。",
+          "allowPublishingSearchDescription": "允许 Orca 将 HTML 和 Markdown 文件发布为公开链接。",
+          "keywordArtifacts": "工件",
+          "keywordShare": "分享",
+          "keywordPublish": "发布",
+          "keywordPublic": "公开",
+          "keywordPermission": "权限",
+          "keywordHtml": "超文本标记语言",
+          "keywordMarkdown": "Markdown",
+          "keywordUpload": "上传"
+        },
+        "orcaAccount": {
+          "connected": "已连接",
+          "reconnectRequired": "会话已过期。请重新登录以使用云功能。",
+          "unavailable": "此构建中 Orca 登录不可用。",
+          "signedOut": "登录以通过云功能扩展 Orca，包括工件和 Orca Relay。",
+          "checking": "正在检查账户状态…",
+          "account": "Orca 账户",
+          "signOut": "退出登录",
+          "signingIn": "正在登录…",
+          "signInAgain": "重新登录",
+          "signIn": "登录 Orca",
+          "title": "Orca 账户",
+          "description": "即时分享工作，随时随地从 Orca Mobile 连接您的桌面。",
+          "searchDescription": "登录或退出工件和 Orca Relay 使用的账户。",
+          "benefitsTitle": "账户包含",
+          "artifactsTitle": "工件分享",
+          "artifactsDescription": "发布 HTML 和 Markdown 文件，然后在 Orca 中管理每个分享链接。",
+          "relayTitle": "Orca Relay",
+          "relayDescription": "通过蜂窝网络或任何 Wi-Fi 将 Orca Mobile 连接到此桌面。",
+          "skillsTitle": "技能分享",
+          "skillsDescription": "通过非公开链接分享单个技能或整套技能，并在您使用的任何机器上安装它们。",
+          "keywordAccount": "账户",
+          "keywordLogin": "登录",
+          "keywordLogout": "退出登录",
+          "keywordSignIn": "登入",
+          "keywordSignOut": "退出登录",
+          "keywordRelay": "中继",
+          "keywordCloud": "云"
+        },
+        "automations": {
+          "showButton": "显示自动化按钮",
+          "showButtonDescription": "在侧边栏中显示自动化快捷方式。",
+          "howItWorksTitle": "自动化如何工作",
+          "howItWorksDescription": "安排一次代理工作，然后由 Orca 创建每次运行并将其结果归集在一起。",
+          "defineStepTitle": "描述工作内容",
+          "defineStepDescription": "选择项目、代理、提示词和计划。",
+          "runStepTitle": "Orca 启动每次运行",
+          "runStepDescription": "计划到期时，所选代理将获得全新的工作区。",
+          "reviewStepTitle": "检查结果",
+          "reviewStepDescription": "检查最近的运行，并在需要时继续工作。",
+          "openAutomations": "打开自动化",
+          "openAutomationsDescription": "创建计划并检查最近的运行。",
+          "title": "自动化",
+          "description": "安排代理工作，并选择是否在侧边栏中显示自动化。",
+          "keywordAutomations": "自动化",
+          "keywordSchedule": "日程",
+          "keywordAgent": "代理",
+          "keywordRuns": "运行"
+        },
+        "shareSkills": {
+          "title": "分享技能",
+          "description": "通过非公开链接分享您的技能。拥有链接的任何人都可以安装它们。",
+          "allowAgentPublishing": "允许代理和 Orca CLI 发布技能链接",
+          "allowAgentPublishingDescription": "允许命令发布明确指定的已安装技能。技能文件夹可能包含脚本、配置或密钥，因此默认关闭。",
+          "allowAgentPublishingWebDescription": "仅桌面端。请在主机设备上的设置 → 分享技能中更改此设置。",
+          "selectTitle": "选择一个或多个技能",
+          "selectDescription": "打开技能，选择分享技能，再选择要放在一个链接后的技能。",
+          "reviewTitle": "检查并发布",
+          "reviewDescription": "上传不可变捆绑包之前，请检查包含的文件、脚本和可执行文件。",
+          "copyTitle": "复制非公开链接",
+          "copyDescription": "拥有链接的任何人都可以查看和安装全部或选定的技能，无需登录。",
+          "manageTitle": "管理或撤销链接",
+          "manageDescription": "撤销将阻止未来访问。已安装到其他机器上的技能会保留。",
+          "linkTitle": "非公开技能链接",
+          "linkDescription": "分享的捆绑包不可搜索，也不会在 Orca 中列出。链接即凭证，请仅发送给信任的人。",
+          "signInTitle": "登录以分享技能",
+          "signInWebDescription": "发布和链接管理仅在 Orca 桌面应用中可用。",
+          "signInDescription": "使用 Orca 账户发布捆绑包并管理其链接。接收者不需要账户。",
+          "signingIn": "正在登录…",
+          "signInAgain": "重新登录",
+          "signIn": "登录 Orca",
+          "howToTitle": "如何分享技能",
+          "howToDescription": "在一个链接后发布单个技能或技能捆绑包，例如包含 30 个技能的合集。",
+          "openSkills": "打开技能",
+          "openSkillsDescription": "发布捆绑包、从链接安装，或管理已安装和已分享的技能。",
+          "searchDescription": "通过非公开链接分享您的技能。拥有链接的任何人都可以安装它们。",
+          "linksReconnect": "请重新登录以管理分享链接。",
+          "linksUnavailable": "分享链接目前不可用。",
+          "linkCopied": "分享链接已复制",
+          "linkRevoked": "链接已撤销",
+          "revokeFailed": "Orca 无法撤销此链接。",
+          "activeLinks": "生效中的分享链接",
+          "activeLinksDescription": "仅拥有链接的人可以打开。取消分享链接以阻止未来的查看和安装。",
+          "refreshLinks": "刷新",
+          "noActiveLinks": "没有生效中的链接。请从技能中发布技能捆绑包以创建一个。",
+          "copyLink": "复制链接",
+          "confirmUnshare": "确认取消分享",
+          "unshare": "取消分享",
+          "showButton": "显示技能按钮",
+          "showButtonDescription": "在侧边栏中显示技能快捷方式。",
+          "manageInSkills": "在技能中管理",
+          "keywordSkills": "技能",
+          "keywordShare": "分享",
+          "keywordBundle": "捆绑包",
+          "keywordLink": "关联",
+          "keywordUnlisted": "非公开",
+          "keywordRevoke": "撤销"
+        },
+        "bitbucket": {
+          "credentials": {
+            "dialog": {
+              "connectFailed": "连接失败",
+              "title": "连接 Bitbucket",
+              "description": "使用 Bitbucket Cloud 凭据浏览拉取请求和构建状态。Orca 会先验证再保存。",
+              "remoteRuntime": "此处保存的 Bitbucket 凭据仅存放在本机。请改为在远程运行时上设置 ORCA_BITBUCKET_* 环境变量。",
+              "environmentManaged": "Bitbucket 已通过 ORCA_BITBUCKET_* 环境变量配置，其优先级更高。取消设置这些变量后才能在 Orca 中保存凭据。",
+              "authModeLabel": "Bitbucket 身份验证方式",
+              "modeBasic": "邮箱 + API Token",
+              "modeToken": "访问 Token",
+              "accessToken": "访问 Token",
+              "accessTokenPlaceholder": "仓库、项目或工作区访问 Token",
+              "email": "Atlassian 账户邮箱",
+              "emailPlaceholder": "你@example.com",
+              "apiToken": "API 令牌",
+              "apiTokenPlaceholder": "Atlassian API 令牌",
+              "baseUrl": "API 基础 URL（可选）",
+              "baseUrlPlaceholder": "https://api.bitbucket.org/2.0",
+              "tokenHint": "仓库、项目和工作区访问 Token 在相应的 Bitbucket 设置页面创建，需要拉取请求的读取权限。",
+              "basicHint": "为您的账户创建 Atlassian API Token，再与拥有它的邮箱地址配对使用。",
+              "docsLink": "Bitbucket API Token 文档",
+              "storageNote": "当操作系统钥匙串可用时，使用加密存储存放在本机。ORCA_BITBUCKET_* 环境变量的优先级始终高于此处保存的内容。",
+              "cancel": "取消",
+              "verifying": "正在验证...",
+              "connect": "连接"
+            }
+          },
+          "integration": {
+            "card": {
+              "description": "Bitbucket Cloud 的拉取请求和构建状态。",
+              "edit": "编辑凭据",
+              "connect": "连接",
+              "accountUnknown": "Bitbucket Cloud",
+              "authModeToken": "访问 Token",
+              "authModeBasic": "邮箱 + API Token",
+              "disconnect": "断开 Bitbucket",
+              "envManaged": "已通过环境变量配置。取消设置 ORCA_BITBUCKET_* 变量后才能在 Orca 中管理此凭据。",
+              "storedAuthFailed": "保存的 Bitbucket 凭据无法通过身份验证。请编辑它，或检查 Token 是否仍有拉取请求访问权限。",
+              "storedCredential": "保存在本机的 Orca 中。设置 ORCA_BITBUCKET_* 环境变量后其优先级更高。",
+              "notConfigured": "使用 Atlassian API Token 或访问 Token 连接 Bitbucket Cloud 账户。ORCA_BITBUCKET_* 环境变量同样可用且优先级更高。",
+              "disconnectFailed": "无法移除保存的 Bitbucket 凭据。"
+            }
+          }
+        },
+        "EphemeralVmCleanupStopDialog": {
+          "title": "停止清理？",
+          "description": "VM 可能保持运行并产生费用。稍后可重试清理。",
+          "cancel": "继续清理",
+          "stopping": "正在停止…",
+          "confirm": "停止清理"
+        },
+        "NativeChatSupportedAgents": {
+          "label": "支持的代理："
+        },
+        "contrast": {
+          "title": "颜色对比度",
+          "description": "提高文本可读性，或保留终端程序选择的颜色。",
+          "ratio": "对比度目标",
+          "autoDescription": "在可读性与终端主题之间取得平衡。推荐。",
+          "offDescription": "保持程序颜色不变，包括暗淡文本和 Powerline 分隔符。",
+          "customDescription": "选择文本与其背景之间对比度的提升幅度。",
+          "auto": "自动",
+          "off": "关",
+          "custom": "自定义",
+          "targetDescription": "较高的值会尽可能提高对比度。背景色保持不变。",
+          "subtle": "轻微",
+          "strong": "强"
         }
       },
       "right": {
@@ -10419,7 +11787,11 @@
               "branch": "Sync Branch"
             },
             "7e4b2a19c0": "无法确定要回复的 GitHub PR。",
-            "430f1a62d4": "无法在主机上解决选中的讨论串。"
+            "430f1a62d4": "无法在主机上解决选中的讨论串。",
+            "updateReactionFailed": "更新表情回应失败。",
+            "gitlabMoreActions": "更多 MR 操作",
+            "gitlabUnlink": "取消关联 MR",
+            "gitlabLinkAnother": "关联其他 MR"
           },
           "CreatePullRequestDialog": {
             "2bc1b4345e": "取消",
@@ -10495,7 +11867,11 @@
             "f9d7ca753d": "复制路径",
             "3161c4e425": "文件夹",
             "e887fa4b2e": "在终端中打开",
-            "1d8e182c32": "查看文件"
+            "1d8e182c32": "查看文件",
+            "clipboardStagingUnavailable": "无法复制文件，因为 Orca 的临时存储不可用",
+            "revealInFinder": "在 Finder 中显示",
+            "openContainingFolder": "打开所在文件夹",
+            "revealInFileExplorer": "在文件资源管理器中显示"
           },
           "FileExplorerToolbar": {
             "d238264654": "显示 Git 忽略的文件",
@@ -10539,7 +11915,19 @@
             "b25f63edd7": "打开",
             "d2ca293f3d": "处理中...",
             "ef064cb7c3": "默认",
-            "59b4dccf70": "destructive"
+            "59b4dccf70": "destructive",
+            "closedToast": "{{value0}} 已关闭",
+            "9a41a687b7": "通过 #{{pr}} 进入队列 · {{count}} 个 PR",
+            "38a1bccb14": "通过 #{{pr}} 进入队列 · {{count}} 个 PR",
+            "3de88351c5": "GitHub 会将此拉取请求及其下方的每个拉取请求加入合并队列。",
+            "a32fe6dba6": "GitHub 将合并此拉取请求以及栈中其下方的每个拉取请求。",
+            "73e0e1819d": "正在加入队列…",
+            "e555a41d32": "正在合并栈…",
+            "markingReady": "正在标记…",
+            "markReady": "标记为待评审",
+            "draftMoreActions": "更多 {{value0}} 操作",
+            "closeDraft": "关闭",
+            "readyToast": "{{value0}} 已标记为待评审"
           },
           "PortsPanel": {
             "3ea4a02a8f": "取消",
@@ -11020,7 +12408,10 @@
                 "actionRequiredHint": "此检查需要在 GitHub 上执行手动操作（例如批准工作流运行）后才能解除合并阻止。",
                 "b3195cba33": "取消将作者标记为机器人",
                 "f588b46a6c": "将作者标记为机器人",
-                "e45324fbed": "加载检查详细信息失败。"
+                "e45324fbed": "加载检查详细信息失败。",
+                "checksUnresolvedChip": "未解决",
+                "checksUnresolvedStripHint": "这些检查完成时没有给出通过或失败结论。",
+                "dcb3c546fe": "重试"
               },
               "empty": {
                 "state": {
@@ -11191,7 +12582,24 @@
                   "2388413f28": "此合并请求已关闭",
                   "88d044c42f": "已关闭",
                   "ee482a2bad": "该合并请求已被合并",
-                  "fae95ae20d": "合并"
+                  "fae95ae20d": "合并",
+                  "5105b0e584": "需要批准",
+                  "46dc85711b": "GitLab 要求批准后此 MR 才能合并",
+                  "893a999c8c": "要求更改",
+                  "c65408a99d": "有评审人在此合并请求中要求更改",
+                  "01ab632a21": "未解决的讨论串",
+                  "4191fdfcec": "GitLab 要求在合并前解决未解决的讨论",
+                  "bf628700f6": "检查必须通过",
+                  "37d8637c70": "GitLab 要求流水线成功后此 MR 才能合并",
+                  "049ea91a82": "流水线仍在运行",
+                  "382c70faeb": "在后面",
+                  "2c61100b3a": "合并前更新分支",
+                  "195917574e": "检查中",
+                  "ff6db2db63": "GitLab 仍在计算此合并请求的状态",
+                  "4ecc0d90ee": "已阻塞",
+                  "a0f3de7023": "GitLab 报告此合并请求被阻塞",
+                  "804ecf93e8": "GitLab 尚未报告最终合并状态",
+                  "a5c049afe4": "GitLab 表示此 MR 可以合并"
                 }
               }
             }
@@ -11359,6 +12767,72 @@
                   "8f9a0b1c2d": "没有可提交的内容。分支已是最新状态。",
                   "h3i4j5k607": "正在检查此分支是否可以创建 {{value0}}…"
                 }
+              },
+              "branch": {
+                "line": {
+                  "total": {
+                    "chip": {
+                      "daa8e8e59b": "新增 {{value0}} 行，删除 {{value1}} 行",
+                      "8a9b97b666": "新增 {{value0}} 行",
+                      "52c366d88d": "删除 {{value0}} 行",
+                      "4c1f70ba92": "{{value0}}——测试代码：新增 {{value1}} 行，删除 {{value2}} 行",
+                      "6b2d0f14a7": "测试",
+                      "9e4a3c5081": "非测试",
+                      "3d7e9b1042": "非生成代码",
+                      "a1b2c3d4e5": "代码构成",
+                      "b2c3d4e5f6": "代码行数",
+                      "7f3e1a9c24": "{{value0}}——生成代码：新增 {{value1}} 行，删除 {{value2}} 行",
+                      "c8d5b21e07": "源码",
+                      "7a04c6f8b3": "生成代码"
+                    }
+                  }
+                }
+              },
+              "compare": {
+                "summary": {
+                  "dd72a6fd37": "比 {{value2}} 领先 {{value0}} 个提交{{value1}}"
+                }
+              },
+              "conflict": {
+                "status": {
+                  "cards": {
+                    "5302a1ddba": "合并冲突",
+                    "7f3af87549": "变基冲突",
+                    "6a8e9ad490": "Cherry-pick 冲突",
+                    "bdf8772106": "冲突",
+                    "edc2d82a2b": "合并进行中",
+                    "5c3707aa44": "变基进行中",
+                    "ffe53a1da6": "Cherry-pick 进行中",
+                    "35eb76d323": "操作进行中"
+                  }
+                }
+              },
+              "content": {
+                "status": {
+                  "3f425c239c": "此分支上没有更改",
+                  "640f6fdb36": "此工作区干净，此分支比 {{value0}} 没有超前更改",
+                  "8deb86bbec": "根据",
+                  "978eba351e": "搜索文本过大",
+                  "0bce43409f": "请使用更短的文件筛选。",
+                  "1b6caf533d": "没有匹配的文件",
+                  "00c07771b7": "没有与“{{value0}}”匹配的已更改文件"
+                }
+              },
+              "diff": {
+                "comments": {
+                  "list": {
+                    "cefacd0ec7": "整个文件"
+                  }
+                }
+              },
+              "commit": {
+                "area": {
+                  "cc5739bd1d": "正在生成提交信息…",
+                  "4cbd0cd9d2": "正在提交…",
+                  "e7876a2bde": "暂存至少一个文件以生成消息。",
+                  "0904be2505": "清空消息以重新生成。",
+                  "1ea9ba37aa": "在设置 → Git → 源代码管理 AI 中选择代理。"
+                }
               }
             }
           },
@@ -11367,6 +12841,11 @@
               "control": {
                 "ai": {
                   "cfafa92509": "没有未解决的冲突需要发送。"
+                },
+                "bulk": {
+                  "actions": {
+                    "2f67630884": "批量暂存/取消暂存失败"
+                  }
                 }
               }
             }
@@ -11411,6 +12890,17 @@
                   }
                 }
               }
+            },
+            "hosted": {
+              "review": {
+                "button": {
+                  "label": {
+                    "96ae7358e0": "推送并在栈中创建 PR",
+                    "8e8149a0bf": "在栈中创建草稿 PR",
+                    "8df1a05952": "在栈中创建 PR"
+                  }
+                }
+              }
             }
           },
           "AiVaultPanel": {
@@ -11442,7 +12932,10 @@
             "sessionHostMismatchUnsupported": "此会话属于其他主机。请打开同一主机上的工作区以恢复它。",
             "prepareSessionResumeFailed": "无法为恢复准备此会话。",
             "sessionDeleted": "会话已删除",
-            "sessionDeleteFailed": "无法删除会话"
+            "sessionDeleteFailed": "无法删除会话",
+            "resumeInChatConflict": "另一个聊天已占用此会话。",
+            "resumeInChatTranscriptMissing": "无法加载此会话的历史记录，因此无法在聊天中恢复。",
+            "resumeInChatFailed": "无法在新聊天中恢复此会话。"
           },
           "AiVaultPanelControls": {
             "scanningSessions": "正在扫描会话",
@@ -11578,7 +13071,8 @@
             "delete": "删除",
             "deleteReasonNonLocalHost": "只能删除此设备上的会话。",
             "deleteReasonSyntheticPath": "此会话无法在 Orca 中删除。",
-            "deleteReasonUnsupportedAgent": "{{value0}} 会话无法在 Orca 中删除。"
+            "deleteReasonUnsupportedAgent": "{{value0}} 会话无法在 Orca 中删除。",
+            "resumeInNewChat": "在新聊天中恢复"
           },
           "AiVaultSessionDeleteDialog": {
             "title": "要删除此会话吗？",
@@ -11665,6 +13159,34 @@
                   "d9dd7c6687": "无法从 GitHub 刷新。正在显示上次已知状态。"
                 }
               }
+            },
+            "pr": {
+              "stack": {
+                "confirmation": {
+                  "84f6f5b9eb": "包含：{{numbers}}。",
+                  "541984b2eb": "通过 #{{pr}} 进入队列？",
+                  "4809f55cdb": "{{included}}GitHub 会将 {{count}} 个拉取请求一起加入合并队列。队列选择合并方式，可能会分多组合并。",
+                  "be8f2621be": "{{included}}GitHub 会将 {{count}} 个拉取请求一起加入合并队列。队列选择合并方式，可能会分多组合并。",
+                  "92ca033e72": "将 {{count}} 个 PR 加入队列",
+                  "478a527b15": "将 {{count}} 个 PR 加入队列",
+                  "1feef35ca4": "通过 #{{pr}} 合并？",
+                  "c3e036c99f": "{{included}}GitHub 将使用 {{method}} 原子合并 {{count}} 个拉取请求。如果无法合并，则一个都不会合并。",
+                  "369aba4b32": "{{included}}GitHub 将使用 {{method}} 原子合并 {{count}} 个拉取请求。如果有任何一个无法合并，则一个都不会合并。",
+                  "493c78f521": "合并 {{count}} 个 PR",
+                  "eb7051d268": "合并 {{count}} 个 PR"
+                },
+                "merge": {
+                  "55ae29b907": "通过 #{{pr}} 合并 · {{count}} 个 PR",
+                  "b8446f6ec2": "通过 #{{pr}} 合并 · {{count}} 个 PR",
+                  "189d0ec614": "#{{pr}} 仍是草稿。",
+                  "640fb50d9c": "#{{pr}} 已关闭。",
+                  "46ffcbda75": "#{{pr}} 有合并冲突。",
+                  "6dabefd63e": "#{{pr}} 有要求更改的评审。",
+                  "2bb21fc326": "#{{pr}} 仍需评审批准。",
+                  "c23faf74df": "必须先更新 #{{pr}}。",
+                  "f561e80968": "#{{pr}} 被阻塞。"
+                }
+              }
             }
           },
           "PluginPanel": {
@@ -11683,6 +13205,34 @@
             "mayBeSlower": "可能较慢",
             "slowest": "最慢",
             "unlimited": "无限制"
+          },
+          "GitHubPRStackMap": {
+            "3511405914": "关闭",
+            "8a9bdc36c0": "已合并",
+            "568c647ccd": "草稿",
+            "bea9ade223": "冲突",
+            "838aadf512": "检查失败",
+            "316039b5db": "检查待定",
+            "4b1e5ee9d3": "要求更改",
+            "9a17b5255c": "需要评审",
+            "d3d97cf3f2": "已批准",
+            "e6cb964305": "打开",
+            "7737bd66be": "折叠栈 #{{value0}}",
+            "0c1645ebd0": "展开栈 #{{value0}}",
+            "e3ee2daa32": "栈 #{{value0}}",
+            "cb440931b7": "{{value1}} 中的第 {{value0}} 个 · {{value2}}",
+            "525259fa17": "栈详情暂时不可用。"
+          },
+          "CreateHostedReviewBasePicker": {
+            "205ef284fa": "基础分支",
+            "bb4b41d563": "基于 {{value0}}",
+            "5a9315b61a": "没有与“{{value0}}”匹配的分支。按回车仍使用它。",
+            "da4d57c9c2": "留空以使用 {{value0}}。"
+          },
+          "CreateHostedReviewComposerFields": {
+            "90cabf6cfc": "将此 PR 堆叠在 #{{value0}} 之上",
+            "ff81473a57": "创建 GitHub PR 栈，或扩展父级的现有栈。",
+            "29732f2fb0": "新 PR"
           }
         }
       },
@@ -11967,7 +13517,8 @@
             "searchJira": "搜索 Jira 议题或粘贴议题 URL",
             "jiraMode": "Jira",
             "jiraSelectBindFailed": "无法关联此 Jira 议题。请选择匹配的站点或重新连接 Jira，然后重试。",
-            "emoji": "Emoji"
+            "emoji": "Emoji",
+            "loadingLinearIssue": "正在加载 Linear 议题…"
           },
           "ProjectCombobox": {
             "empty": "没有匹配搜索的项目。",
@@ -11981,6 +13532,15 @@
             "listLabel": "运行目标",
             "label": "运行在",
             "browse": "浏览运行目标"
+          },
+          "SetProjectLocationDialog": {
+            "title": "设置项目位置",
+            "description": "选择 {{project}} 在 {{host}} 上的位置。",
+            "browseFolder": "浏览文件夹",
+            "browseFolderHelp": "使用此主机上已有的检出或文件夹。",
+            "cloneFromUrl": "从 URL 克隆",
+            "cloneFromUrlHelp": "将此仓库克隆到 {{host}}。",
+            "saveLocation": "设置位置"
           }
         }
       },
@@ -12033,7 +13593,19 @@
           "relayDegradedNotice": "无法连接 Relay — 此二维码仅在局域网或 Tailscale 内可用。",
           "pairingQrError": "无法将此配对码呈现为二维码。请改为将其复制到 Orca Mobile。",
           "directAddressDisclosure": "也可使用更快的本地连接",
-          "directAddressHint": "可选。选择手机在附近（同一 Wi‑Fi 或 Tailscale）时使用的地址，通常比 Relay 更快。外出时仍走 Relay。"
+          "directAddressHint": "可选。选择手机在附近（同一 Wi‑Fi 或 Tailscale）时使用的地址，通常比 Relay 更快。外出时仍走 Relay。",
+          "noRelayCode": "没有可用的配对码",
+          "noPairingCode": "没有可用的配对码",
+          "qrSignInRequired": "登录以创建 Relay 配对码",
+          "qrRenderFailed": "二维码无法渲染——请复制下方的代码",
+          "qrGeneratePrompt": "生成配对码以继续",
+          "pairingCodeReady": "配对码已就绪",
+          "pairThisMac": "配对这台 Mac。",
+          "pairThisPc": "配对这台电脑。",
+          "pairThisComputer": "配对这台电脑。",
+          "androidHelp": {
+            "guide": "安装指南"
+          }
         },
         "MobilePage": {
           "e17393c6a3": "手机预览",
@@ -12046,7 +13618,9 @@
           "4e1eb5d55c": "撤销设备失败",
           "255372e6e8": "设备已撤销",
           "1b4509a8a1": "配对的",
-          "c5909374cf": "简介"
+          "c5909374cf": "简介",
+          "diagnosticsCopied": "诊断信息已复制",
+          "diagnosticsCopyFailed": "复制诊断信息失败"
         },
         "MobilePageToolbar": {
           "ad2284a9e2": "关闭 · Esc",
@@ -12161,7 +13735,10 @@
         "NetworkInterfacePicker": {
           "trigger-label": "要公布的网络地址",
           "custom-option": "{{address}}（自定义）",
-          "add-custom": "添加自定义地址…"
+          "add-custom": "添加自定义地址…",
+          "no-address-selected": "未选择地址",
+          "custom-section": "自定义",
+          "remove-custom": "移除 {{address}}"
         },
         "WindowsFirewallNotice": {
           "repair-success": "Windows 防火墙现已允许 Orca Mobile 在专用网络上通信",
@@ -12178,6 +13755,20 @@
           "blocked-description": "现有的入站阻止规则可能会覆盖配对例外。修复将移除此 Orca 应用的冲突 TCP 规则，然后在专用网络上允许端口 {{port}}。",
           "repair": "修复防火墙访问权限",
           "relay-note": "配对仍可通过 Orca Relay 进行 — 允许后只是额外获得更快的本地连接。"
+        },
+        "MobileRelayMintFailureNotice": {
+          "retryingTitle": "正在重试 Orca Relay…",
+          "unavailableTitle": "此桌面上 Orca Relay 不可用。",
+          "title": "无法创建 Relay 配对码。",
+          "retryingBody": "正在创建新的配对码。通过远程连接可能需要一些时间。",
+          "unavailableBody": "使用局域网通过 Tailscale 或同一 Wi-Fi 配对。",
+          "body": "请重试，或使用局域网通过 Tailscale 或同一 Wi-Fi 配对。",
+          "useLan": "使用局域网",
+          "retrying": "正在重试...",
+          "retry": "重试 Relay",
+          "copyDiagnostics": "复制诊断信息",
+          "reconnectTitle": "Orca 账户会话已过期。",
+          "reconnectBody": "重新登录以使用 Orca Relay，或使用局域网通过 Tailscale 或同一 Wi-Fi 配对。"
         }
       },
       "gitlab": {
@@ -12491,6 +14082,30 @@
                   "b94ec70eda": "未设置跟踪",
                   "cc39a87288": "已连接·系统默认",
                   "00087eecb2": "已连接 · {{value0}}"
+                }
+              },
+              "setup": {
+                "checklist": {
+                  "localized": {
+                    "copy": {
+                      "ec0a363633": "多任务",
+                      "62bac8f43c": "同时在 2 个不同的工作区中工作。每个工作区相互隔离（即使在同一项目中）。非常适合同时处理 2 个功能。",
+                      "908898c3ee": "使用 Orca 浏览器",
+                      "43781563c3": "无需离开 Orca 即可浏览 Web 应用。抓取任意元素，一键将其确切源码和样式发送给代理。",
+                      "29aa2c2077": "打开通知",
+                      "71bd9a8c95": "代理完成、需要注意或被阻塞时第一时间知晓。",
+                      "46db810da8": "选择默认代理",
+                      "b8e5bae17f": "预选偏好的代理，更快开始新工作。",
+                      "fee5557b02": "启用 Orca CLI",
+                      "7bcb4097fa": "注册 Orca shell 命令，并为浏览器、计算机和编排工作流安装代理技能。",
+                      "ad342dd4c6": "连接集成",
+                      "06fe30fdb0": "一键从任务启动代理，并随时查看 PR 状态。",
+                      "eddc532e58": "自动设置工作区",
+                      "56049b74c2": "自动运行安装和设置命令，让每个新工作区都为代理准备就绪。",
+                      "2cf795433b": "在多个仓库中开始工作",
+                      "42525ba8a4": "将常用仓库引入 Orca，无需到处找文件夹即可开始代理工作。"
+                    }
+                  }
                 }
               }
             }
@@ -12870,7 +14485,9 @@
           "724a13568d": "在 {{value0}}",
           "6094135eec": "与 {{value0}}",
           "a4420ca1f7": "开启换行",
-          "dde325ddfe": "关闭换行"
+          "dde325ddfe": "关闭换行",
+          "2e91bc89d1": "空白开",
+          "2bf19c54ad": "空白关"
         },
         "ConflictComponents": {
           "f338288514": "正在加载冲突内容...",
@@ -12954,14 +14571,18 @@
           "f0fd4174b5": "打开文件选项卡以使用富文本 Markdown 编辑",
           "a10d9b8337": "打开文件",
           "2076ecfc9c": "上一个更改",
-          "631dab0df3": "下一个更改"
+          "631dab0df3": "下一个更改",
+          "revealInFinder": "在 Finder 中显示",
+          "openContainingFolder": "打开所在文件夹",
+          "revealInFileExplorer": "在文件资源管理器中显示"
         },
         "EditorPanelMarkdownActionsMenu": {
           "3e0ce48c24": "导出为 PDF",
           "561251019a": "更多操作",
           "8c8b7f5ff5": "显示前面的内容",
           "10c39d58c1": "隐藏前面的内容",
-          "1eef809708": "自动换行"
+          "1eef809708": "自动换行",
+          "4dedd55efa": "显示空白"
         },
         "EditorPanelShell": {
           "e2c4dec350": "正在加载编辑器..."
@@ -13375,7 +14996,8 @@
           "e2b4d7c8a1": "为此检查选择智能体",
           "f1c9e3a6d4": "选择智能体修复检查",
           "5e2a9c3f88": "在此行打开文件",
-          "actionRequired": "需要操作"
+          "actionRequired": "需要操作",
+          "copyOutput": "复制输出"
         },
         "check": {
           "run": {
@@ -13402,7 +15024,8 @@
           "2d3b8f1a55": "已跳过",
           "3e6c9a2b71": "等待中",
           "4f7d0c3e88": "步骤失败",
-          "5a8e1d4f23": " · "
+          "5a8e1d4f23": " · ",
+          "copy": "复制任务"
         },
         "ExternalFileChangeBanner": {
           "7c41e90d12": "此文件在您有未保存编辑时在磁盘上发生了更改。保存将覆盖较新的磁盘内容。",
@@ -13448,6 +15071,47 @@
               }
             }
           }
+        },
+        "CheckRunAnnotations": {
+          "copy": "复制批注"
+        },
+        "CheckRunCopyButton": {
+          "copied": "已复制",
+          "failed": "无法复制",
+          "empty": "无可复制内容"
+        },
+        "HtmlDocPreview": {
+          "documentTooLargePanel": "此文档过大，无法预览。请改用编辑器打开。",
+          "documentUnreadablePanel": "Orca 无法从工作区读取此文件。",
+          "multipleAssetsFailedNotice": "此文档中有 {{count}} 个文件无法加载。",
+          "assetTooLargeNotice": "{{path}} 过大，无法在此预览中加载。",
+          "assetUnsupportedNotice": "此工作区无法将 {{path}} 发送到预览。",
+          "assetUnreadableNotice": "Orca 无法从工作区读取 {{path}}。",
+          "previewAriaLabel": "HTML 预览",
+          "reloadPreviewControl": "重新加载预览",
+          "previewUnavailableTitle": "预览不可用",
+          "copyDocumentPathControl": "复制文件路径",
+          "documentPathCopied": "已复制",
+          "workspaceFileChipLabel": "工作区文件",
+          "previewMenuControl": "预览选项",
+          "openSourceControl": "打开源文件",
+          "openExternallyControl": "用默认应用打开",
+          "copyDocumentRelativePathControl": "复制相对路径",
+          "openExternallyUnknownHostError": "无法打开“{{value0}}”：拥有它的主机已未知。",
+          "downloadBlockedNotice": "文档预览中禁用下载。",
+          "directoryAuthorizationFailed": "无法允许访问此目录。",
+          "directoryAccessRequest": "此预览想要读取 {{path}} 中的文件。",
+          "dismissAccessRequest": "关闭",
+          "allowDirectory": "允许文件夹",
+          "directoryAccessRequestOverflow": "{{folders}} 等 {{count}} 个",
+          "directoryAccessRequestMultiple": "此预览想要读取 {{folders}} 中的文件。",
+          "allowDirectories": "允许 {{count}} 个文件夹",
+          "editAddressControl": "编辑地址"
+        },
+        "LargeDiffLoadPrompt": {
+          "a0af0198aa": "大型差异默认不渲染。",
+          "c3d9f4a712": "此差异的大小尚未知，因此按需加载。",
+          "f7fa7a40d0": "加载差异"
         }
       },
       "diff": {
@@ -13479,7 +15143,9 @@
           "55127a3706": "听写失败：{{value0}}",
           "bb7f599ee7": "打开设置",
           "2d5b9fabf9": "麦克风访问被拒绝。在系统设置中授予访问权限，然后重新启动 Orca。",
-          "5d2c3e7ae3": "未检测到语音。"
+          "5d2c3e7ae3": "未检测到语音。",
+          "micFallback": "所选麦克风不可用。已使用系统默认。",
+          "micDisconnected": "麦克风已断开。听写已停止。"
         },
         "DictationIndicator": {
           "335e1bc6cb": "停止听写",
@@ -13555,7 +15221,8 @@
             "4a9568f773": "返回",
             "4f86e2a10b": "跳过导览",
             "d974f32a83": "关闭导览",
-            "ffa4412b66": "下一步"
+            "ffa4412b66": "下一步",
+            "complete": "完成"
           },
           "ContextualTourProgressDots": {
             "7734cb8ad3": "的",
@@ -13565,7 +15232,27 @@
             "tour": {
               "overlay": {
                 "measurement": {
-                  "38b3155418": "下一步"
+                  "38b3155418": "下一步",
+                  "automations": {
+                    "intro": {
+                      "title": "什么是自动化？",
+                      "body": "自动化按计划运行代理工作。点击此按钮添加自动化。"
+                    },
+                    "results": {
+                      "title": "查找结果",
+                      "body": "运行记录显示自动化的运行时间、发生的情况以及查看其输出的位置。"
+                    }
+                  },
+                  "client": {
+                    "hosted": {
+                      "browser": {
+                        "intro": {
+                          "title": "此页面在您的桌面上渲染",
+                          "body": "远程浏览器标签页现在在此设备上渲染。网络流量仍通过远程主机传输。"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -13610,8 +15297,18 @@
                 "removeWorktree": "删除工作树",
                 "trashWorktree": "垃圾工作树",
                 "addQuickCommand": "添加快捷命令",
-                "newQuickCommand": "新的快捷命令"
-              }
+                "newQuickCommand": "新的快捷命令",
+                "splitChatRight": "向右拆分聊天",
+                "moveChatRight": "向右移动聊天",
+                "chatPaneRight": "右侧聊天窗格",
+                "splitChatDown": "向下拆分聊天",
+                "moveChatDown": "向下移动聊天",
+                "chatPaneBelow": "下方聊天窗格"
+              },
+              "splitChatRight": "向右拆分聊天",
+              "splitChatRightDescription": "在右侧拆分窗格中打开当前聊天。",
+              "splitChatDown": "向下拆分聊天",
+              "splitChatDownDescription": "在下方拆分窗格中打开当前聊天。"
             }
           },
           "palette": {
@@ -13654,7 +15351,8 @@
             "a6914ee43f": "收回",
             "f4ecd61552": "该选项卡由您的手机控制。收回来在桌面上使用它。",
             "d9768ec642": "浏览器输入已暂停",
-            "20539eca03": "移动端正在控制此浏览器"
+            "20539eca03": "移动端正在控制此浏览器",
+            "7c31b0da94": "无法收回此标签页。请检查手机会话后重试。"
           },
           "BrowserPane": {
             "1ded0d3168": "复制截图",
@@ -13742,7 +15440,9 @@
             "6e776f9ef9": "下载失败",
             "756bfc25c9": "打开",
             "09a9489aa5": "显示",
-            "2a4c4b8e1f": "复制"
+            "2a4c4b8e1f": "复制",
+            "b71dc3d930": "重新连接",
+            "fileUrlUnsupported": "此浏览器标签页无法打开本地文件。请改用该文件的“在侧边打开预览”。"
           },
           "BrowserToolbarMenu": {
             "429ef481f9": "取消",
@@ -13793,6 +15493,69 @@
                 }
               }
             }
+          },
+          "download": {
+            "savedToRemote": "已保存到 {{value2}} 上的 {{value1}}"
+          },
+          "annotate": {
+            "use": {
+              "browser": {
+                "page": {
+                  "grab": {
+                    "annotations": {
+                      "0c7b9b2b7a": "已复制",
+                      "c937229f19": "截图",
+                      "1f5cb19034": "已添加批注"
+                    }
+                  }
+                }
+              }
+            },
+            "browser": {
+              "page": {
+                "annotation": {
+                  "tray": {
+                    "09a7c1df70": "编辑批注 {{value0}}",
+                    "c16f932cb3": "保存",
+                    "024467ceac": "取消",
+                    "449d2c2629": "注释意图"
+                  }
+                }
+              }
+            }
+          },
+          "navigate": {
+            "use": {
+              "browser": {
+                "page": {
+                  "navigation": {
+                    "downloads": {
+                      "8683b84b9e": "浏览器页面尚未就绪，无法接收文件拖放。",
+                      "22272f2784": "请将文件拖放到浏览器页面上，而非工具栏。"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "profile": {
+          "user": {
+            "agent": {
+              "option": {
+                "04af3dc12b": "使用未修改的用户代理",
+                "5bf47a3c91": "可能改善 Google 登录，但会降低与机器人防护网站的兼容性。"
+              }
+            }
+          }
+        },
+        "webauthn": {
+          "account": {
+            "fallback": "通行密钥",
+            "title": "选择通行密钥",
+            "description": "选择要与此安全密钥配合使用的账户。",
+            "site": "网站",
+            "cancel": "取消"
           }
         }
       },
@@ -13900,7 +15663,8 @@
           "4133d33862": "创建自动化",
           "0a75e5e2fa": "创建 Hermes 自动化",
           "03142e7721": "编辑 Hermes 自动化",
-          "17086b48ee": "编辑自动化"
+          "17086b48ee": "编辑自动化",
+          "4c8e1a72b9": "周期性代理任务"
         },
         "AutomationMissedRunGraceField": {
           "0f4459e91d": "48小时",
@@ -13933,7 +15697,8 @@
           "8faaa00726": "执行",
           "53fc5f07ab": "运行历史",
           "a00e38d1a3": "不适用",
-          "fdb3caa8fb": "已知的"
+          "fdb3caa8fb": "已知的",
+          "historyUnavailable": "无法从此主机获取运行历史。这并不意味着自动化失败或没有运行。"
         },
         "AutomationRunPageFrame": {
           "40a511bed4": "运行上下文",
@@ -14057,7 +15822,11 @@
           "tableStatus": "状态",
           "tableActions": "操作",
           "newAutomation": "新建自动化",
-          "rowActions": "自动化操作"
+          "rowActions": "自动化操作",
+          "tableLastRun": "上次运行",
+          "noListMatches": "没有匹配的自动化。",
+          "destinationProjectUnavailable": "请选择所选自动化目标拥有的项目。",
+          "ownerChanged": "此自动化更换了主机。请刷新后重试。"
         },
         "CreateFromPicker": {
           "f061f49e3f": "搜索仓库分支...",
@@ -14158,6 +15927,14 @@
               "ba20c92073": "自定义日程",
               "086a5a9fe2": "无效日程"
             }
+          },
+          "list": {
+            "last": {
+              "run": {
+                "done": "完成",
+                "failed": "失败"
+              }
+            }
           }
         },
         "external": {
@@ -14219,6 +15996,105 @@
           "noProjects": "{host} 上未设置任何项目。请在该主机上添加一个，或选择另一台主机。",
           "updateRequired": "更新 {hosts} 上的 Orca 服务器即可在其中存储自动化。",
           "move": "保存后会在 {host} 上创建此自动化，并删除原有自动化及其运行历史。"
+        },
+        "AutomationEditorPromptSection": {
+          "a7c3e91b04": "编辑名称"
+        },
+        "AutomationListSortHeader": {
+          "sortedAscending": "{{value0}}，升序",
+          "sortedDescending": "{{value0}}，降序"
+        },
+        "hostSummary": {
+          "partialFailure": "{{total}} 台主机中有 {{failed}} 台无法加载"
+        },
+        "emptyState": {
+          "unknownHost": "此主机",
+          "hostLoading": "正在加载主机…",
+          "hostLoadingDetail": "正在等待 {{hostLabel}} 报告其自动化。",
+          "hostError": "无法从 {{hostLabel}} 加载自动化",
+          "hostUnavailableDetail": "无法连接到主机，因此其自动化未知。",
+          "hostIncompatibleDetail": "此服务器版本过旧，不支持按主机划分自动化。",
+          "hostStaleDetail": "最近一次刷新未完成。",
+          "hostNotConnected": "{{hostLabel}} 未连接",
+          "hostNotConnectedDetail": "连接此主机以查看为其存储的自动化。",
+          "hostEmpty": "{{hostLabel}} 上没有自动化",
+          "searchNoMatch": "没有与搜索匹配的自动化",
+          "filtersNoMatch": "没有与筛选匹配的自动化",
+          "allHostsEmpty": "已加载的主机上都没有自动化"
+        },
+        "hostNotice": {
+          "loading": "正在加载主机…",
+          "unavailable": "无法连接到 {{hostLabel}}。显示上次从它加载的自动化。",
+          "ghost": "{{hostLabel}} 已被移除。仍分配给它的自动化会继续列出。",
+          "removed": "所选主机已不可用。显示所有主机。"
+        },
+        "hostPicker": {
+          "allHosts": "所有主机",
+          "loadingHost": "正在加载主机…"
+        },
+        "ownerConflict": {
+          "dismiss": "关闭"
+        },
+        "capturedOwner": {
+          "orphan": "此自动化没有可运行的主机。请删除它，或重新添加其所属主机。",
+          "unfenced": "此主机上的 Orca 需要更新后才能查看运行历史或管理此自动化。计划运行可能仍在该主机上继续。"
+        },
+        "hostStatus": {
+          "authority": {
+            "loading": "加载中",
+            "loadingDescription": "正在从此主机加载自动化。",
+            "fresh": "已是最新",
+            "freshDescription": "已从此主机加载自动化。",
+            "refreshing": "刷新中",
+            "refreshingDescription": "正在检查此主机的更改。",
+            "staleError": "未刷新",
+            "staleErrorDescription": "显示上次从此主机加载的自动化。最近一次刷新未完成。",
+            "unavailable": "不可达",
+            "unavailableDescription": "无法连接到此主机，因此无法加载其自动化。",
+            "incompatible": "更新服务器",
+            "incompatibleDescription": "此服务器不支持按主机查询自动化。请更新它以加载此主机的自动化。"
+          },
+          "execution": {
+            "connected": "已连接",
+            "connectedDescription": "此主机已连接，可以运行自动化。",
+            "connecting": "正在连接",
+            "connectingDescription": "正在连接此主机。",
+            "disconnected": "未连接",
+            "disconnectedDescription": "连接恢复之前，此主机上的自动化无法运行。",
+            "unavailable": "不可用",
+            "unavailableDescription": "此执行目标已不可用。",
+            "unknown": "连接状态未知",
+            "unknownDescription": "此主机的连接状态尚未加载。"
+          },
+          "query": {
+            "legacyUnscopedDescription": "此服务器列出自动化时不按主机划分，因此无法在此处编辑或运行它们。",
+            "incompatible": "更新服务器",
+            "incompatibleDescription": "此服务器版本过旧，不支持按主机划分自动化。请更新它以在此处管理自动化。",
+            "viewOnly": "仅查看",
+            "targetRemovedDescription": "此主机已被移除，因此无法在此处编辑或运行其自动化。",
+            "targetUnverifiedDescription": "此主机在连接断开后未经验证，因此无法在此处编辑或运行其自动化。",
+            "targetUnregisteredDescription": "此主机没有注册记录，因此无法在此处编辑或运行其自动化。"
+          },
+          "action": {
+            "retry": "重试",
+            "reconnect": "重新连接",
+            "updateServer": "更新服务器"
+          }
+        },
+        "ownerAction": {
+          "failed": "该自动化操作未完成。"
+        },
+        "externalScope": {
+          "unknownManager": "此外部自动化已不在视图中任何主机的列表里。",
+          "uncheckedHost": "无法检查 {{hostLabel}} 上的外部自动化管理器。",
+          "uncheckedHosts": "无法检查 {{count}} 台主机上的外部自动化管理器。"
+        },
+        "enablement": {
+          "paused": "已暂停"
+        },
+        "runHistory": {
+          "occurrencesWithLatest": "{{times}} 次，最近 {{date}}",
+          "occurrences": "{{times}} 次"
         }
       },
       "agent": {
@@ -14287,7 +16163,8 @@
           "viewSection": "视图"
         },
         "ActivityScopeFilterControls": {
-          "resetScope": "显示所有主机和项目"
+          "resetScope": "显示所有主机和项目",
+          "hiddenCount": "已隐藏 {{value0}} 项"
         },
         "ActivityThreadRow": {
           "clearNotification": "清除通知"
@@ -14296,12 +16173,37 @@
           "f915168c8e": "未读",
           "d6a8de3934": "智能体",
           "dc708f3eff": "紧密智能体"
+        },
+        "clearCompleted": {
+          "clearedOne": "已清除 1 个已完成的代理",
+          "clearedMany": "已清除 {{count}} 个已完成的代理",
+          "undo": "撤销"
+        },
+        "standaloneWorktree": {
+          "floatingTerminal": "浮动终端",
+          "standaloneTerminal": "独立终端"
+        },
+        "ActivityThreadHoverCard": {
+          "pathCopied": "路径已复制到剪贴板",
+          "copyPathFailed": "复制路径失败",
+          "workspace": "工作区",
+          "copyPath": "复制路径",
+          "jumpToWorkspace": "跳转到工作区"
         }
       },
       "confirmation": {
         "dialog": {
           "8490e5d36a": "确认",
-          "56f5c60e0c": "取消"
+          "56f5c60e0c": "取消",
+          "92bac3217e": "不再询问"
+        },
+        "skip": {
+          "saved": "下次我们将跳过此确认。",
+          "savedDescription": "您可以在“设置”中更改此设置。",
+          "openSettings": "打开设置",
+          "preference": {
+            "0b0cb6e3f9": "无法保存确认偏好。"
+          }
         }
       },
       "jira": {
@@ -14455,6 +16357,114 @@
               "chooseSource": "选择任务来源"
             }
           }
+        },
+        "page": {
+          "chrome": {
+            "task": {
+              "page": {
+                "gitlab": {
+                  "filters": {
+                    "e157d7ce4d": "MR",
+                    "2328f6a40c": "我的待办"
+                  }
+                }
+              }
+            }
+          },
+          "dialogs": {
+            "new": {
+              "github": {
+                "issue": {
+                  "dialog": {
+                    "e02508846c": "此仓库"
+                  }
+                }
+              },
+              "linear": {
+                "issue": {
+                  "dialog": {
+                    "dialogTitle": "新建 Linear 议题",
+                    "dialogDescription": "为所选团队创建 Linear 议题。"
+                  }
+                }
+              }
+            },
+            "task": {
+              "page": {
+                "connect": {
+                  "dialogs": {
+                    "353c7dc71d": "更新访问权限"
+                  }
+                }
+              }
+            }
+          },
+          "github": {
+            "github": {
+              "detail": {
+                "host": {
+                  "8d5cde4770": "拉取请求",
+                  "312ca15778": "GitHub 列表"
+                }
+              },
+              "issue": {
+                "label": {
+                  "selector": {
+                    "2a1862c470": "正在加载标签…"
+                  }
+                }
+              },
+              "work": {
+                "item": {
+                  "row": {
+                    "draftPullRequest": "草稿拉取请求",
+                    "pullRequest": "PR",
+                    "issue": "议题"
+                  }
+                }
+              }
+            }
+          },
+          "hooks": {
+            "use": {
+              "task": {
+                "page": {
+                  "jira": {
+                    "create": {
+                      "dialog": {
+                        "jiraRequiredFieldsLoadFailed": "加载必需的 Jira 字段失败。"
+                      }
+                    }
+                  },
+                  "linear": {
+                    "active": {
+                      "collection": {
+                        "d8b3cd9488": "项目：{{value0}}",
+                        "68462f8b29": "视图：{{value0}}"
+                      }
+                    }
+                  },
+                  "session": {
+                    "resume": {
+                      "savedLinearProjectMissing": "未找到保存的 Linear 项目。",
+                      "savedLinearProjectRestoreFailed": "恢复保存的 Linear 项目失败。",
+                      "savedLinearViewMissing": "未找到保存的 Linear 视图。",
+                      "savedLinearViewRestoreFailed": "恢复保存的 Linear 视图失败。"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "linear": {
+            "linear": {
+              "connect": {
+                "empty": {
+                  "3e00e8ebd4": "正在加载 Linear"
+                }
+              }
+            }
+          }
         }
       },
       "taskPageEmptyState": {
@@ -14517,7 +16527,9 @@
         "allWorkspacesTitle": "选择一个工作区",
         "allWorkspacesBody": "状态、负责人和标签筛选器使用单个 Linear 工作区的 ID。请选择一个工作区以按这些属性进行筛选。",
         "optionsFromTeam": "来自 {{team}} 的选项",
-        "clearAll": "清除所有筛选器"
+        "clearAll": "清除所有筛选器",
+        "partialCoverage": "部分",
+        "partialCoverageTitle": "此筛选可能遗漏某些团队。请打开筛选查看详情。"
       },
       "linear-issue-attribute-filter-sections": {
         "status": "状态",
@@ -14531,7 +16543,8 @@
         "searchStatus": "筛选状态…",
         "searchLabels": "筛选标签…",
         "searchAssignee": "筛选负责人…",
-        "back": "返回"
+        "back": "返回",
+        "partialCoverageMarker": "· 部分"
       },
       "browser-pane": {
         "markup": {
@@ -14596,8 +16609,117 @@
         "ArtifactsPage": {
           "deleteTitle": "删除工件？",
           "deleteDescription": "“{{name}}” 将无法再通过其公共链接访问。",
-          "delete": "删除"
-        }
+          "delete": "删除",
+          "signInAgain": "重新登录 Orca 以加载工件。",
+          "loadFailed": "无法加载工件。",
+          "deleteFailed": "无法删除工件。",
+          "title": "工件",
+          "refresh": "刷新",
+          "signInHeading": "登录 Orca",
+          "signInCopy": "登录以查看和管理通过您的账户分享的工件。",
+          "signingIn": "正在登录…",
+          "signIn": "登录 Orca",
+          "empty": "没有分享的工件",
+          "emptyCopy": "打开 HTML 或 Markdown 文件并选择“分享为工件”，或让代理来分享。",
+          "openArtifact": "打开工件",
+          "deleteArtifact": "删除工件",
+          "moreAvailable": "还有更多工件",
+          "moreAvailableCopy": "加载下一页以继续。",
+          "loadMoreFailed": "无法加载更多工件。",
+          "publishingOff": "发布已关闭",
+          "publishingOffCopy": "此设备尚无法创建公开工件链接。请在设置 → 工件中允许发布，然后从打开的 HTML 或 Markdown 文件分享，或让代理来分享。",
+          "openArtifactsSettings": "打开设置 → 工件",
+          "retry": "重试",
+          "reconnectHeading": "重新登录 Orca",
+          "reconnectCopy": "重新登录以查看和管理通过您的账户分享的工件。",
+          "signInAgainAction": "重新登录",
+          "unconfiguredCopy": "此机器上尚未配置 Orca 账户登录。",
+          "openAccountSettings": "打开账户设置"
+        },
+        "copySuccess": "工件链接已复制",
+        "copyFailed": "无法复制工件链接",
+        "copyLink": "复制链接",
+        "openInBrowser": "在浏览器中打开",
+        "preview": "工件预览",
+        "previewUnavailable": "预览不可用",
+        "previewUnavailableDescription": "请在浏览器中打开此工件以查看。",
+        "actions": "工件操作",
+        "ArtifactActions": {
+          "more": "更多工件操作"
+        },
+        "ArtifactCollection": {
+          "loadMore": "加载更多",
+          "noMatches": "无匹配项"
+        },
+        "ArtifactDetailHeader": {
+          "publicLink": "拥有此链接的任何人都可以查看",
+          "close": "关闭"
+        },
+        "updatedAt": "更新于 {{when}}",
+        "updatedRecently": "刚刚",
+        "expiryUnknown": "过期时间未知",
+        "expired": "链接已过期",
+        "expires": "链接将于 {{when}} 过期",
+        "ArtifactPublishButton": {
+          "a4a49da6af": "分享为工件",
+          "confirmTitle": "分享为工件",
+          "confirmDescription": "这会将当前文件发布到持有 URL 的任何人都能查看的链接。",
+          "accountTitle": "Orca 账户",
+          "accountDescription": "登录以创建和管理此链接。",
+          "signingIn": "正在登录…",
+          "signInAgain": "重新登录",
+          "signIn": "登录",
+          "publishingOffTitle": "工件分享已关闭",
+          "publishingOffDescription": "在设置中了解公开链接并启用分享。",
+          "openSettings": "打开工件设置",
+          "sharing": "正在分享…",
+          "sharePublicLink": "生成链接",
+          "publishedDescription": "拥有此链接的任何人都可以查看分享的文件。",
+          "checkingLink": "正在检查现有链接…",
+          "checkFailed": "无法检查现有链接。",
+          "tryAgain": "重试"
+        },
+        "artifact-publish-flow": {
+          "9a078a0c65": "工件分享不可用",
+          "bba20daa6d": "请登录 Orca 后重试。",
+          "54b1805328": "无法分享工件",
+          "430019efd0": "工件已分享",
+          "2fc727c831": "工件已更新",
+          "5cb4f5ec36": "复制链接",
+          "fbb5018602": "此文件为空。",
+          "6112db5a1c": "此工件过大，无法分享。",
+          "e2ed5acd8c": "Orca 无法读取此文件。请从工作区打开它后重试。",
+          "6d475e9b25": "只有本地 HTML 和 Markdown 文件可以分享为工件。",
+          "29a406be09": "工件必须包含文本。"
+        },
+        "ArtifactPublishedLinkPanel": {
+          "copyLink": "复制链接",
+          "openLink": "打开链接",
+          "updating": "正在更新…",
+          "update": "更新分享的内容"
+        },
+        "ArtifactDetailDrawer": {
+          "description": "预览和管理此分享的工件。"
+        },
+        "ArtifactListSearchField": {
+          "label": "搜索工件",
+          "placeholder": "搜索...",
+          "clear": "清除搜索"
+        },
+        "ArtifactListTableHeader": {
+          "name": "名称",
+          "type": "类型",
+          "size": "尺寸",
+          "updated": "更新时间",
+          "expires": "过期时间",
+          "actions": "操作"
+        },
+        "ArtifactsPageSkeleton": {
+          "loading": "正在加载工件"
+        },
+        "expiredCompact": "已过期",
+        "typeMarkdown": "Markdown",
+        "typeHtml": "超文本标记语言"
       },
       "ComposerParentWorktreePicker": {
         "label": "父工作树",
@@ -14605,6 +16727,79 @@
         "description": "在侧边栏中将此工作区嵌套到另一个工作树下。不会更改基础分支。",
         "searchPlaceholder": "搜索工作树...",
         "noMatches": "无匹配项。"
+      },
+      "BrowserCookieImportDisclosure": {
+        "title": "Google 登录不会被导入",
+        "description": "直接在 Orca 中登录 Google。"
+      },
+      "linear-issue-attribute-filter-coverage-notice": {
+        "statusPartialTeamCoverage": "正在按 {{value1}} 个团队中的 {{value0}} 个的状态筛选——其余团队的议题不包含在内。",
+        "labelsPartialTeamCoverage": "正在按 {{value1}} 个团队中的 {{value0}} 个的标签筛选——其余团队的议题不包含在内。",
+        "statusAtIdLimit": "最多可承载 {{value0}} 个团队状态。超出后选择的行会被排除。",
+        "labelsAtIdLimit": "最多可承载 {{value0}} 个团队标签。超出后选择的行会被排除。"
+      },
+      "WorktreeBaseFallbackDialog": {
+        "title": "从本地基准创建的工作区",
+        "description": "远程跟踪引用“{{value0}}”不可用，因此 Orca 改用本地“{{value1}}”。此工作区可能不包含最新的远程更改。",
+        "dismiss": "知道了"
+      },
+      "LinuxPackageInstallRecoveryCard": {
+        "e3de29c86a": "显示包",
+        "55c86654b7": "复制安装命令",
+        "53e1559f99": "需要手动安装",
+        "a7ac6ec78b": "Orca 已下载系统包。请先退出 Orca，再从终端完成更新。",
+        "82c6dbea00": "复制命令，退出 Orca，在安装 Orca 的电脑上的系统终端中运行。完成后重新打开 Orca。",
+        "53c4b8e148": "没有可用的身份验证代理响应提权安装请求。",
+        "c732bcbf8f": "正在检查包…",
+        "aa57fa4f80": "命令已复制。请退出 Orca，在系统终端中运行以安装 {{value0}}，然后重新打开 Orca。",
+        "b7e7c5bc95": "Orca 在生成此命令时已按发布元数据校验下载的文件。系统包本身未经签名校验，此后 Orca 无法为该文件担保。"
+      },
+      "BrowserPane": {
+        "streamConnectionLost": "与远程服务器的连接已断开。",
+        "streamConnectionUnreachable": "无法连接到远程服务器。",
+        "streamRestartFailed": "重启远程浏览器串流失败。",
+        "streamCapabilityUnsupported": "所选运行时不支持远程浏览器串流。"
+      },
+      "BrowserCookieImportMachineNotice": {
+        "clientLabel": "此设备上的浏览器",
+        "remoteLabel": "{{value0}} 上的浏览器",
+        "clientNoteLocalStorage": "导入读取此设备的浏览器。Cookie 存放在本地。",
+        "remoteNoteRemoteStorage": "导入读取 {{value0}} 上的浏览器。Cookie 存放在该机器上，其屏幕上可能出现权限提示。"
+      },
+      "native": {
+        "chat": {
+          "NativeChatStructuredSession": {
+            "1f772bb5d0": "消息送达未确认。",
+            "93ef441197": "消息未发送。",
+            "a5e7f14068": "重试"
+          }
+        }
+      },
+      "browserPane": {
+        "workspaceDoc": {
+          "externalLinkTitle": "打开到 {{host}} 的链接？",
+          "externalLinkConfirm": "打开链接",
+          "externalLinkCancel": "取消"
+        }
+      },
+      "HostedReviewUnlinkMenuItem": {
+        "label": "取消 {{value0}} 与工作区的关联",
+        "description": "Orca 将隐藏此工作区的 {{value0}} {{value1}} 详情。{{value2}} 上的 {{value0}} 和分支不会改变。"
+      },
+      "UnexpectedSignoutCard": {
+        "9f2c1a4b7d": "您已退出登录",
+        "3e8f5c2a91": "关闭",
+        "7b4d9e1f2a": "重新以 {{value0}} 登录，以恢复工件分享、Orca Relay 和技能分享。",
+        "5a1c8d3e6f": "重新登录以恢复工件分享、Orca Relay 和技能分享。",
+        "1f6b2c9d4e": "恢复的内容",
+        "8d2e4f7a1b": "工件分享",
+        "2c9a5b6e8d": "发布 HTML 和 Markdown 文件，并在 Orca 中管理每个分享链接。",
+        "6e3f1a9c5b": "Orca Relay",
+        "4b7d2e8f1a": "通过蜂窝网络或任何 Wi-Fi 将 Orca Mobile 连接到此桌面。",
+        "9a4c6b2d7e": "技能分享",
+        "3d8e5f1b9c": "通过非公开链接分享技能，并在您使用的任何机器上安装它们。",
+        "7e1a9c4d2f": "正在登录…",
+        "c5b3e8a17d": "登录 Orca"
       }
     },
     "i18n": {
@@ -14640,6 +16835,12 @@
         "loadFailed": "加载 GitLab 作业日志失败。",
         "emptyTrace": "此 GitLab 作业没有可用的日志。",
         "timedOut": "加载 GitLab 作业日志超时。"
+      },
+      "githubCheckDetailsTimeout": {
+        "timedOut": "加载检查详情超时。"
+      },
+      "gitlabIpcTimeout": {
+        "timedOut": "与 GitLab 通信超时。"
       }
     },
     "ssh": {
@@ -14724,14 +16925,46 @@
         "skillScopeBuiltIn": "内置",
         "skillScopePlugin": "插件",
         "skillsLoaded": "技能已加载",
-        "noCommands": "没有匹配的命令"
+        "noCommands": "没有匹配的命令",
+        "imageSaving": "正在保存粘贴的图片…",
+        "pendingAttachmentLimit": "等待中的附件太多。请先完成编辑再添加更多附件。",
+        "viewAttachment": "查看图片",
+        "imagePreview": "全尺寸图像预览",
+        "imagePreviewUnavailable": "预览不可用"
       },
       "tool": {
         "running": "正在运行…",
-        "result": "结果"
+        "result": "结果",
+        "exitCode": "退出码 {{value0}}",
+        "milliseconds": "{{value0}} 毫秒",
+        "countOne": "1 次工具调用",
+        "countN": "{{value0}} 次工具调用",
+        "moreCalls": "还有 +{{value0}} 个",
+        "runningPreview": "正在运行 {{preview}}",
+        "runningCommand": "正在运行命令",
+        "runningNamedPreview": "正在运行 {{toolName}} {{preview}}",
+        "runningNamed": "正在运行 {{toolName}}",
+        "ranCommandOneToolSummary": "运行了 {{commandCount}} 条命令，使用了 {{toolCount}} 个工具",
+        "ranCommandManyToolsSummary": "运行了 {{commandCount}} 条命令，使用了 {{toolCount}} 个工具",
+        "ranCommandsOneToolSummary": "运行了 {{commandCount}} 条命令，使用了 {{toolCount}} 个工具",
+        "ranCommandsManyToolsSummary": "运行了 {{commandCount}} 条命令，使用了 {{toolCount}} 个工具",
+        "usedOneSummary": "使用了 1 个工具",
+        "usedManySummary": "使用了 {{toolCount}} 个工具",
+        "editedFile": "编辑了文件",
+        "addedFile": "添加了文件",
+        "deletedFile": "删除了文件",
+        "renamedFile": "重命名了文件",
+        "copyDiff": "复制差异",
+        "diffGap": "未显示的行",
+        "diffTruncated": "差异被截断"
       },
       "status": {
-        "responding": "智能体正在回复"
+        "responding": "智能体正在回复",
+        "working": "处理中…",
+        "thinking": "思考",
+        "workingFor": "已工作 {{value0}}",
+        "workedFor": "已工作 {{value0}}",
+        "toggleDetails": "切换轮次详情"
       },
       "jumpToLatest": "跳到最新消息",
       "toggle": {
@@ -14780,7 +17013,146 @@
         "allow": "允许",
         "deny": "拒绝"
       },
-      "launchPromptNotDelivered": "未送达 — 请检查终端"
+      "launchPromptNotDelivered": "未送达 — 请检查终端",
+      "taskList": {
+        "title": "任务",
+        "completed": "已完成",
+        "inProgress": "进行中",
+        "pending": "待处理",
+        "empty": "无任务",
+        "progress": "{{total}} 个任务中已完成 {{completed}} 个",
+        "added": "已添加 {{task}}",
+        "removed": "已移除 {{task}}",
+        "started": "已开始 {{task}}",
+        "finished": "已完成 {{task}}",
+        "reset": "已标为待处理：{{task}}",
+        "updated": "已更新 {{task}}",
+        "unchanged": "任务无变化",
+        "showAll": "完整任务列表"
+      },
+      "turnDiff": {
+        "one": "1 个已更改文件",
+        "many": "{{count}} 个已更改文件",
+        "partial": "部分差异",
+        "recorded": "本轮记录的编辑合计。"
+      },
+      "receipt": {
+        "unavailable": "所选回答不可用",
+        "cancelled": "已取消",
+        "resolved": "已解决",
+        "resolver": "在 {{device}} 上回答",
+        "cancelledBy": "在 {{device}} 上取消"
+      },
+      "notices": {
+        "compaction": "上下文已压缩",
+        "details": "详情",
+        "plan": "计划"
+      },
+      "providerFrame": {
+        "byteLength": "{{value0}} 字节"
+      },
+      "backgroundTasks": {
+        "monitoring": "监控后台任务",
+        "stop": "停止",
+        "stopTask": "停止 {{value0}}",
+        "stopAll": "停止后台任务",
+        "agent": "后台代理",
+        "workflow": "后台工作流",
+        "command": "后台命令",
+        "monitor": "后台监视器",
+        "task": "后台任务",
+        "detailsUnavailable": "此会话的任务详情不可用。",
+        "countAgentsOne": "1 个代理",
+        "countAgentsMany": "{{value0}} 个代理",
+        "countShellOne": "1 个 shell",
+        "countShellMany": "{{value0}} 个 shell",
+        "countShellCommandOne": "1 条 shell 命令",
+        "countMonitorsOne": "1 个监视器",
+        "countMonitorsMany": "{{value0}} 个监视器",
+        "countWorkflowsOne": "1 个工作流",
+        "countWorkflowsMany": "{{value0}} 个工作流",
+        "countTasksOne": "1 个任务",
+        "countTasksMany": "{{value0}} 个任务",
+        "headerTotal": "{{value0}} 个后台任务",
+        "stateWorking": "工作中",
+        "stateMonitoring": "监视中",
+        "stateWaiting": "等待",
+        "stateBlocked": "已阻塞",
+        "stateDone": "完成",
+        "stateIdle": "已停止",
+        "stateUnverifiable": "无法确认",
+        "reasonWaiting": "需要批准",
+        "reasonUnverifiable": "无联系",
+        "reasonBlocked": "失败",
+        "groupAgents": "代理",
+        "groupShell": "shell",
+        "groupMonitors": "监视器",
+        "groupWorkflows": "工作流程",
+        "groupTasks": "任务"
+      },
+      "structuredSessionCloseFailed": "无法关闭此聊天会话",
+      "structuredSessionLaunchFailed": "无法打开 {{value0}} 聊天",
+      "structuredSessionLaunchPending": "正在启动 {{value0}} 聊天…",
+      "structuredSessionCloseFailedDescription": "终端保持打开，以便提供方仍可恢复。",
+      "handoff": {
+        "stage": {
+          "finishingChat": "正在结束聊天会话…",
+          "finishingTerminal": "正在结束代理终端…",
+          "openingTerminal": "正在打开代理终端…",
+          "resumingChat": "正在恢复聊天会话…",
+          "verifyingTerminal": "正在验证代理终端…",
+          "verifyingChat": "正在验证聊天会话…",
+          "recovering": "正在恢复代理会话…",
+          "manualRecovery": "代理会话需要恢复"
+        },
+        "switchingOwner": "正在切换会话所有者…",
+        "mode": {
+          "switching": "正在切换",
+          "terminal": "终端",
+          "chat": "聊天"
+        },
+        "switchingAfterTurn": "本轮后切换",
+        "returningAfterTurn": "本轮后返回",
+        "cancel": "取消",
+        "switchAfterTurn": "本轮后切换",
+        "stopTurnAndSwitch": "停止本轮并切换",
+        "openAgentTui": "打开代理 TUI",
+        "returnAfterTurn": "本轮后返回",
+        "returnToChat": "返回聊天",
+        "agentOpenOnHost": "代理已在 {{value0}} 的终端中打开。",
+        "agentOpen": "代理已在终端中打开。",
+        "exitTerminal": "请退出代理终端以在聊天中继续。",
+        "retryProof": "重试验证",
+        "retry": "重试",
+        "details": "详情"
+      },
+      "structuredSessionFellBackToTerminal": "结构化聊天不可用",
+      "structuredSessionFellBackToTerminalDescription": "Orca 尝试改为打开 {{value0}} 终端。",
+      "structuredSessionLaunchFailedDescription": "Orca 无法打开结构化 {{value0}} 聊天。详情请查看日志。",
+      "subagents": {
+        "state": {
+          "completed": "已完成",
+          "working": "工作中",
+          "idle": "idle",
+          "failed": "失败",
+          "stopped": "已停止",
+          "unverifiable": "无法确认",
+          "workingCount": "{{value0}} 个工作中",
+          "idleCount": "{{value0}} 个空闲",
+          "failedCount": "{{value0}} 个失败",
+          "stoppedCount": "{{value0}} 个已停止",
+          "unverifiableCount": "{{value0}} 个无法确认"
+        },
+        "startedOne": "启动了 1 个子代理",
+        "startedN": "启动了 {{value0}} 个子代理",
+        "ranOne": "运行了 1 个子代理",
+        "ranN": "运行了 {{value0}} 个子代理",
+        "tokens": "{{value0}} 个 Token"
+      },
+      "conversationCommand": {
+        "pendingWork": "请等待待处理的工作和消息完成后再使用此命令。",
+        "unconfirmed": "会话操作未确认。"
+      }
     },
     "tab": {
       "bar": {
@@ -14856,11 +17228,164 @@
               "locked": "已锁定",
               "retainedAgents": "已完成的代理"
             }
-          }
+          },
+          "noSizes": "尚未测量工作区大小。",
+          "noSizesDescription": "测量磁盘用量后会显示大小。",
+          "measureSizes": "扫描",
+          "measureSizesTitle": "扫描工作区大小",
+          "measureSizesDescription": "扫描磁盘用量，以便按大小比较、排序和筛选工作区。",
+          "sizeOnDisk": "磁盘大小：{{value0}}",
+          "checkingGitRow": "正在检查 Git 状态",
+          "searchPlaceholder": "搜索名称、仓库、分支、路径、主机",
+          "searchLabel": "搜索工作区",
+          "filters": "筛选",
+          "showingCount": "共 {{value1}} 个，显示 {{value0}} 个",
+          "clearFilters": "清除筛选",
+          "checkingGit": "正在检查 Git 状态：还剩 {{value0}} 个",
+          "facet": {
+            "git": "Git",
+            "review": "评审",
+            "ticket": "工单",
+            "location": "位置",
+            "safety": "安全",
+            "activity": "活动",
+            "size": "磁盘大小",
+            "status": "工作区状态",
+            "agent": "代理",
+            "context": "本地上下文"
+          },
+          "minAhead": "超前提交数 ≥",
+          "minBehind": "落后提交数 ≥",
+          "branchQuery": "分支包含",
+          "prunable": "可修剪",
+          "locked": "已锁定",
+          "reviewPresence": "PR / MR",
+          "reviewProvider": "提供方",
+          "ticketPresence": "关联的工单",
+          "host": "主机",
+          "repo": "仓库",
+          "pathPrefix": "路径以此开头",
+          "tier": {
+            "ready": "就绪",
+            "review": "待评审",
+            "protected": "受保护"
+          },
+          "blockerMode": "阻塞项匹配",
+          "blockerModeAny": "有任意一项",
+          "blockerModeNone": "全都没有",
+          "blockers": "阻塞项",
+          "dismissed": "已忽略",
+          "selectableOnly": "仅我现在可删除的工作区",
+          "idleSignal": {
+            "lastVisited": "未打开",
+            "lastActivity": "无动态",
+            "created": "创建于之前"
+          },
+          "idleMinDays": "空闲至少",
+          "days": "天",
+          "neverVisited": "从未打开",
+          "minSize": "至少",
+          "maxSize": "至多",
+          "includeUnsized": "包含未测量的工作区",
+          "matchStatusless": "包含无状态的工作区",
+          "archived": "已归档",
+          "pinned": "已固定",
+          "unread": "未读",
+          "comment": "有评论",
+          "retainedDoneAgents": "已完成的代理记录",
+          "contextPresence": "打开的标签页、终端、评论",
+          "completelyEmpty": "无可失去的内容",
+          "noWorkspaces": "未找到工作区。",
+          "noMatches": "没有工作区匹配这些筛选条件。",
+          "noMatchesDescription": "每个工作区都在同一个列表中——放宽某个维度或清除筛选。",
+          "selectAll": "全选匹配的工作区",
+          "sortBy": "排序",
+          "sortByField": "按 {{value0}} 排序",
+          "sort": {
+            "lastActivity": "上次动态",
+            "lastVisited": "上次打开",
+            "created": "创建时间",
+            "size": "尺寸",
+            "name": "工作区",
+            "repo": "仓库",
+            "path": "路径",
+            "host": "主机",
+            "workspaceStatus": "状态",
+            "agent": "代理",
+            "git": "Git",
+            "ahead": "超前",
+            "behind": "在后面",
+            "branch": "分支",
+            "review": "评审",
+            "ticket": "工单",
+            "localContext": "打开的上下文",
+            "tier": "安全",
+            "blockerCount": "阻塞项"
+          },
+          "git": {
+            "clean": "干净",
+            "dirty": "未提交的更改",
+            "unpushed": "未推送的提交",
+            "unknown": "未检查"
+          },
+          "agent": {
+            "working": "工作中",
+            "permission": "等您处理",
+            "idle": "空闲"
+          },
+          "review": {
+            "open": "打开",
+            "draft": "草稿",
+            "merged": "已合并",
+            "closed": "已关闭",
+            "unknown": "未知",
+            "otherProvider": "其他"
+          },
+          "ticket": {
+            "workItem": "工作项目",
+            "linear": "Linear",
+            "issue": "议题"
+          },
+          "triState": {
+            "any": "任意",
+            "only": "仅",
+            "exclude": "排除"
+          },
+          "presence": {
+            "any": "任意",
+            "some": "有一项",
+            "none": "全都没有"
+          },
+          "tierField": "清理层级",
+          "idleSignalField": "空闲信号",
+          "selectionVanishedOne": "1 个选定的工作区已不存在。",
+          "selectionVanished": "{{value0}} 个选定的工作区已不存在。",
+          "updatedAgo": "已更新 {{value0}}",
+          "refreshing": "刷新中…",
+          "refreshingProgress": "正在刷新 {{value1}} 中的第 {{value0}} 个",
+          "notMeasured": "未测量",
+          "openWorkspaceNamed": "打开{{value0}}",
+          "openWorkspace": "打开工作区",
+          "workspaceStatus": "工作区状态：{{value0}}",
+          "measuringSizesProgress": "正在扫描 {{value1}} 中的第 {{value0}} 个",
+          "measuringSizes": "正在扫描大小",
+          "measureSizesFailed": "无法扫描工作区大小",
+          "selectedCount": "已选 {{value0}} 个"
         },
         "scan": {
           "readyOne": "找到 1 个工作区。",
-          "readyMany": "找到 {{value0}} 个工作区。"
+          "readyMany": "找到 {{value0}} 个工作区。",
+          "progress": "正在扫描工作区（{{value1}} 中的第 {{value0}} 个）",
+          "singleError": "无法检查 {{value0}}：{{value1}}。部分工作区可能缺失。请刷新重试。",
+          "moreErrors": "，另有 {{value0}} 个",
+          "multipleErrors": "无法检查 {{value0}} 个仓库（{{value1}}{{value2}}）。部分工作区可能缺失。请刷新重试。",
+          "noWorkspaces": "未找到工作区。",
+          "readyOneOne": "找到 1 个工作区，有 1 条清理建议。",
+          "readyOneMany": "找到 1 个工作区，有 {{value0}} 条清理建议。",
+          "readyManyOne": "找到 {{value0}} 个工作区，有 1 条清理建议。",
+          "readyManyMany": "找到 {{value0}} 个工作区，有 {{value1}} 条清理建议。",
+          "fallbackRepository": "某个仓库",
+          "gitListFailed": "Git 无法列出工作区"
         },
         "presentationFixtures": {
           "reviewAlphaCleanup": "评审 Alpha 清理"
@@ -14868,6 +17393,18 @@
         "presentation": {
           "gitlabMergeRequestNumber": "MR #{{value0}}",
           "githubPullRequestNumber": "PR #{{value0}}"
+        },
+        "relativeTime": {
+          "never": "从不",
+          "justNow": "刚刚",
+          "minutesAgo": "{{value0}} 分钟前",
+          "hoursAgo": "{{value0}} 小时前",
+          "daysAgo": "{{value0}} 天前"
+        },
+        "host": {
+          "label": "主机：{{value0}}",
+          "unknown": "未知主机",
+          "candidateName": "{{value1}} 上的 {{value0}}"
         }
       }
     },
@@ -14903,6 +17440,61 @@
         "copySessionIdSuccess": "已复制会话 ID",
         "copySessionIdError": "复制会话 ID 失败"
       }
+    },
+    "onboarding": {
+      "flow": {
+        "stepTooltip": {
+          "agent": "默认代理",
+          "theme": "外观",
+          "windowsTerminal": "Windows 终端",
+          "notifications": "通知",
+          "integrations": "集成"
+        },
+        "actions": {
+          "addFirstProject": "添加第一个项目",
+          "continue": "继续",
+          "openingAddProject": "正在打开添加项目…"
+        }
+      },
+      "skipConfirmation": {
+        "skip": "跳过",
+        "keepGoing": "不，继续"
+      },
+      "theme": {
+        "hints": {
+          "system": "跟随系统",
+          "dark": "护眼",
+          "light": "明亮清晰"
+        }
+      },
+      "integrations": {
+        "capabilities": {
+          "startWorkspaceFromIssue": "从任何 GitHub 议题或拉取请求启动工作区，预填其标题和上下文",
+          "browseIssues": "在任务视图中浏览 GitHub 议题和拉取请求，无需离开 Orca",
+          "reviewStatus": "在每个工作区上查看议题状态、评审状态和 CI 检查",
+          "managePullRequests": "无需离开 Orca 即可阅读、评论和合并拉取请求"
+        }
+      }
+    },
+    "jiraUserPicker": {
+      "select": "选择 {{value0}}",
+      "search": "搜索用户",
+      "empty": "未找到用户"
+    },
+    "status": {
+      "bar": {
+        "workspaceSpace": {
+          "otherTopLevelItems": "其他顶层条目（{{value0}}）"
+        }
+      }
+    },
+    "cmd-j": {
+      "paletteSessionAge": {
+        "minutes": "{{value0}} 分钟",
+        "hours": "{{value0}} 小时",
+        "days": "{{value0}} 天",
+        "underOneMinute": "<1 分钟"
+      }
     }
   },
   "dashboardPopout": {
@@ -14925,7 +17517,58 @@
       "zoomIn": "放大",
       "fit": "适配屏幕",
       "projectCount": "{{agents}} 个智能体 · {{workspaces}} 个工作区",
-      "agentCount": "{{count}} 个智能体"
+      "agentCount": "{{count}} 个智能体",
+      "filters": {
+        "showStates": "代理状态",
+        "agentlessWorkspaces": "无代理的工作区",
+        "orchestrationLinks": "编排关联",
+        "orchestrationLinksHidden": "编排关联已隐藏",
+        "workspaceVisibility": "地图内容",
+        "title": "地图控制",
+        "reset": "重置",
+        "ofTotalAgents": "共显示 {{total}} 个代理中的部分",
+        "quickViews": "快捷视图",
+        "agents": "代理",
+        "time": "时间",
+        "lifespan": "会话时长",
+        "sinceMessage": "距上条消息",
+        "timeInState": "当前状态时长",
+        "timeMinimum": "{{label}} 下限",
+        "timeMaximum": "{{label}} 上限",
+        "timeAny": "任意",
+        "timeRangeCount": "{{count}} 个范围",
+        "resetRanges": "重置范围",
+        "summaryAll": "全部",
+        "summaryCount": "{{total}} 中的 {{shown}} 个",
+        "summarySelected": "已选择 {{count}} 个",
+        "workspace": "工作区",
+        "stateChip": "状态：{{states}}"
+      },
+      "openWorktree": "打开 {{worktree}} 工作区详情",
+      "openFolderWorkspace": "打开 {{workspace}} 文件夹工作区详情",
+      "worktreeSummary": "{{total}} 个代理 · {{active}} 个活跃 · {{done}} 个已完成",
+      "worktreeSummary_one": "{{total}} 个代理 · {{active}} 个活跃 · {{done}} 个已完成",
+      "worktreeSummary_other": "{{total}} 个代理 · {{active}} 个活跃 · {{done}} 个已完成",
+      "runningAgents": "代理",
+      "spawnAgent": "启动新代理",
+      "noLaunchableAgents": "未检测到启用的代理。",
+      "sleepWorkspace": "休眠",
+      "agentCount_one": "{{count}} 个代理",
+      "agentCount_other": "{{count}} 个代理",
+      "noWorkspaceAgents": "此工作区中没有代理。",
+      "status": {
+        "doneSeen": "已完成，已查看"
+      },
+      "quickView": {
+        "everything": "全部",
+        "attention": "需要我处理",
+        "stuck": "卡住",
+        "unread": "未读",
+        "recent": "近 30 分钟",
+        "longRunning": "长期运行",
+        "stale": "闲置超 3 天",
+        "orchestration": "编排"
+      }
     },
     "placeholder": {
       "title": "智能体仪表盘",
@@ -14964,7 +17607,8 @@
     "terminal": {
       "closed": "没有活动的终端 — 该智能体的窗格已关闭。",
       "focusWorktree": "聚焦工作树",
-      "close": "关闭"
+      "close": "关闭",
+      "remotePreviewUnavailable": "此远程会话无预览——请打开工作区查看终端。"
     },
     "close": "关闭仪表盘",
     "settingsTooltip": "看板设置",
@@ -14984,7 +17628,8 @@
       "project": "项目",
       "workspaceStatus": "工作区状态",
       "reviewStatus": "PR / MR 状态",
-      "clearAll": "清除所有筛选条件"
+      "clearAll": "清除所有筛选条件",
+      "removeChip": "移除 {{filter}}"
     },
     "search": {
       "placeholder": "搜索工作树、项目或智能体…",
@@ -14996,6 +17641,12 @@
     "settings": {
       "showIdle": "显示空闲智能体",
       "showIdleCopy": "包括已安静 30 分钟且未报告完成的智能体。默认隐藏。"
+    },
+    "host": {
+      "sshNamed": "SSH 主机 · {{host}}",
+      "ssh": "SSH 主机",
+      "remoteNamed": "远程 Orca 主机 · {{host}}",
+      "remote": "远程 Orca 主机"
     }
   },
   "dashboard": {
@@ -15028,7 +17679,77 @@
       "certificateChallengeExpired": "此证书审批已过期。请重试该页面以请求新的审批。",
       "certificateChallengeChanged": "证书请求已更改。请重试该页面并查看新的警告。",
       "certificateChallengeUnavailable": "此证书请求已不可用。请重试该页面以重新请求。",
-      "certificateProceedFailed": "Orca 无法批准此证书请求。请重试该页面后再试。"
+      "certificateProceedFailed": "Orca 无法批准此证书请求。请重试该页面后再试。",
+      "sshRoutedHint": "此页面通过工作区的 SSH 主机浏览——该主机可能已断开连接，或无法访问此网站。",
+      "recheckSshRoute": "运行连接检查"
+    },
+    "guestRecovery": {
+      "title": "浏览器页面已停止",
+      "failed": "浏览器页面意外停止。请重试以恢复。"
+    },
+    "clientHosted": {
+      "preparationFailed": "无法在此桌面上启动远程浏览器。请检查配对连接后重试。",
+      "unavailableTitle": "客户端托管浏览器不可用",
+      "unavailableDescription": "此页面已关联到其他桌面或已不可用。",
+      "download": {
+        "started": "正在下载 {{filename}}…",
+        "completed": "已下载 {{filename}}",
+        "canceled": "下载已取消。",
+        "failed": "无法完成下载。"
+      },
+      "popupBlocked": "已阻止弹出窗口：{{origin}}",
+      "hostPaneOfflineTitle": "该设备已断开连接",
+      "hostPaneNamedTitle": "正在 {{device}} 上显示",
+      "hostPaneTitle": "正在其他设备上显示",
+      "hostPaneOfflineDescription": "此页面保留在列表中，方便您在此处关闭。设备重新连接后它会恢复。",
+      "hostPaneDescription": "此页面在打开它的配对桌面上渲染。",
+      "hostRowClose": "关闭托管页面",
+      "hostRowCloseFailed": "无法关闭此页面。托管它的设备可能正忙，请重试。",
+      "hostRowOfflineNamed": "已离线——之前托管在 {{device}} 上",
+      "hostRowOffline": "已离线——托管它的设备已退出",
+      "hostRowNamed": "托管在 {{device}} 上",
+      "hostRow": "托管在其他设备上"
+    },
+    "navigation": {
+      "back": "返回",
+      "forward": "向前",
+      "reload": "重新加载"
+    },
+    "reopenOnServer": {
+      "action": "在服务器上重新打开",
+      "pending": "正在重新打开…",
+      "caveat": "这将在远程主机上按此页面的上次地址打开新页面。登录态和其他临时页面状态可能不同，来自表单提交的页面将打开为空白页。",
+      "failed": "无法在远程主机上打开此页面。请检查连接后重试。"
+    },
+    "sshRoute": {
+      "preparingTitle": "正在通过 SSH 主机连接",
+      "errorTitle": "SSH 浏览器路由不可用",
+      "errorDescription": "此工作区中的页面通过其 SSH 主机浏览，而该连接目前不可用。",
+      "retry": "重试",
+      "tryAnyway": "仍要尝试",
+      "browseLocally": "改为从此设备浏览",
+      "forwardingBlockedTitle": "SSH 服务器阻止了浏览器流量",
+      "sshUnavailableTitle": "SSH 连接不可用",
+      "forwardingBlockedDescription": "此服务器拒绝 TCP 转发（其 sshd 配置中通常为“AllowTcpForwarding no”），而通过它浏览需要该功能。请联系管理员允许转发，或改为从此设备浏览。",
+      "sshUnavailableDescription": "此工作区中的页面通过其 SSH 主机浏览，而该连接目前不可用。请重新连接主机后重试。",
+      "showDetails": "显示详情"
+    },
+    "sshEgress": {
+      "routedTooltip": "通过 {{value0}} 浏览",
+      "localTooltip": "从此设备（而非 {{value0}}）浏览",
+      "localChip": "此设备",
+      "routedDetail": "网络流量和 DNS 通过工作区的 SSH 主机传输。",
+      "localDetail": "页面从本机及其网络加载。",
+      "settingsLink": "路由设置"
+    },
+    "remoteEgress": {
+      "clientHostedTooltip": "通过 {{value0}} 浏览",
+      "streamedTooltip": "在 {{value0}} 上浏览",
+      "clientHostedDetail": "页面在此设备上渲染。网络流量和 DNS 通过远程主机传输。",
+      "streamedDetail": "页面在远程主机上运行，并传输到此设备。"
+    },
+    "remote": {
+      "findUnavailable": "此页面正从远程主机传输时，无法使用页内查找。"
     }
   },
   "runtimeRpc": {
@@ -15069,5 +17790,60 @@
       "stopped": "已停止",
       "finished": "已完成"
     }
+  },
+  "sidebar": {
+    "revealFiltered": {
+      "title": "显示隐藏的工作区？",
+      "description": "活动工作区在侧边栏中被隐藏。显示它将清除侧边栏筛选。",
+      "confirm": "清除筛选并显示",
+      "cancel": "保留筛选"
+    }
+  },
+  "editor": {
+    "richMarkdown": {
+      "tooLarge": "文件超过 {{limit}} 富文本编辑上限。已改为显示源码模式。",
+      "openAnyway": "仍要打开"
+    }
+  },
+  "featureTips": {
+    "voice": {
+      "demoPrompt": "检查此差异中的边界情况，并为发现的问题添加测试。",
+      "startDictation": "开始听写",
+      "agentPromptTitle": "代理提示词",
+      "listening": "正在聆听…",
+      "focusPaneInstruction": "聚焦终端、编辑器或代理提示词，然后按",
+      "startInstruction": "开始语音听写。按",
+      "stopInstruction": "再次停止。",
+      "unassignedInstruction": "在聚焦窗格中开始语音听写之前，请先分配听写快捷键。",
+      "settingsInstruction": "随时在以下位置更改模型、听写模式或快捷键：",
+      "settingsLink": "设置 → 语音"
+    }
+  },
+  "quickOpen": {
+    "moreMatchesAvailable": "可能还有更多匹配项。细化搜索以缩小结果。"
+  },
+  "checksPanel": {
+    "unlinked": {
+      "title": "拉取请求已取消关联",
+      "description": "PR #{{number}} 已在此工作区隐藏。重新关联以恢复检查和评审详情。",
+      "relink": "关联 PR #{{number}}"
+    }
+  },
+  "sourceControl": {
+    "unlinkedPr": {
+      "status": "PR #{{number}} 已取消关联"
+    }
+  },
+  "rendererRecovery": {
+    "reload": "重新加载",
+    "copyCommands": "复制命令",
+    "quit": "退出",
+    "stalledDetail": "Orca 在崩溃后重新加载了窗口，但始终未能完成加载。",
+    "crashLoopDetail": "Orca 已连续尝试恢复 {{recoveryCount}} 次，均未成功。",
+    "driverFallback": "如果没有帮助，原因通常是显卡驱动。",
+    "genericDetail": "这通常是显卡驱动或安装问题。重新加载以重试，或退出并重新启动 Orca。",
+    "title": "Orca 一直无法加载",
+    "stalledMessage": "应用窗口在崩溃后重新加载期间停止响应。",
+    "crashLoopMessage": "应用窗口反复崩溃，已停止自动重新加载。"
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10322 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​503 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9819 |

<!-- /orca-pr-loc -->

## ELI5

Added translations for new UI features in Spanish, French, Japanese, and Chinese so users in those languages can understand remote browsing settings, skills installation, and SSH routing options.

## What Changed

Added comprehensive translation keys across four locale files (es.json, fr.json, ja.json, zh.json) covering:
- Remote browsing and client-hosted page rendering options
- SSH workspace routing configuration
- Skills installation, sharing, and management workflows
- New filter components and status indicators
- Error messages for remote pairing, workspace cleanup, and runtime status
- MiniMax provider settings and configuration strings

## Why

Recent feature additions for remote browsing, skills distribution, and advanced SSH routing need localized strings so non-English users can access and configure these capabilities.

## Linked Issue

Fixes #

## Visual Proof

N/A — Translation-only changes with no visual or behavior modifications.

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

Manual verification recommended: Open Orca UI with each language locale and verify new strings display correctly in Settings → Browser/Remote Browsing, Skills installation flows, and terminal quick command dialogs.

## AI Disclosure

None — human translation review recommended.

## Review

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)