### PR TITLE
fix(settings): provide guidance when adding accounts in remote runtime scope

### DIFF
--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -7,6 +7,13 @@ import { i18n } from '../../i18n/i18n'
 import { useAppStore } from '../../store'
 import { AccountsPane } from './AccountsPane'
 
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
 function renderPane(
   settings: GlobalSettings,
   props: Partial<React.ComponentProps<typeof AccountsPane>> = {}
@@ -131,6 +138,7 @@ describe('AccountsPane', () => {
     expect(markup.slice(markup.lastIndexOf('<button', addAccountIndex), addAccountIndex)).toContain(
       'disabled=""'
     )
+    expect(markup).toContain('Add accounts on the remote server by running: orca account add')
   })
 
   it('omits the scope control on the web client, which cannot select Local desktop', () => {
@@ -166,5 +174,6 @@ describe('AccountsPane', () => {
     expect(
       markup.slice(markup.lastIndexOf('<button', addAccountIndex), addAccountIndex)
     ).not.toContain('disabled=""')
+    expect(markup).not.toContain('Add accounts on the remote server by running: orca account add')
   })
 })

--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -138,7 +138,8 @@ describe('AccountsPane', () => {
     expect(markup.slice(markup.lastIndexOf('<button', addAccountIndex), addAccountIndex)).toContain(
       'disabled=""'
     )
-    expect(markup).toContain('Add accounts on the remote server by running: orca account add')
+    expect(markup).toContain('orca account add --agent claude')
+    expect(markup).toContain('orca account add --agent codex')
   })
 
   it('omits the scope control on the web client, which cannot select Local desktop', () => {
@@ -174,6 +175,7 @@ describe('AccountsPane', () => {
     expect(
       markup.slice(markup.lastIndexOf('<button', addAccountIndex), addAccountIndex)
     ).not.toContain('disabled=""')
-    expect(markup).not.toContain('Add accounts on the remote server by running: orca account add')
+    expect(markup).not.toContain('orca account add --agent claude')
+    expect(markup).not.toContain('orca account add --agent codex')
   })
 })

--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -133,7 +133,7 @@ describe('AccountsPane', () => {
     expect(markup).not.toContain('Remote server: the remote server')
     // The WSL account-location toggle is a local concern; a remote owner hides it.
     expect(markup).not.toContain('aria-label="Account location"')
-    const addAccountIndex = markup.indexOf('Add Account')
+    const addAccountIndex = markup.indexOf('Add Account</button>')
     expect(addAccountIndex).toBeGreaterThan(0)
     expect(markup.slice(markup.lastIndexOf('<button', addAccountIndex), addAccountIndex)).toContain(
       'disabled=""'

--- a/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
@@ -1,9 +1,11 @@
 import { Loader2, Plus, RefreshCw, Trash2, X } from 'lucide-react'
+import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { selectClaudeProviderAccount } from '@/runtime/runtime-provider-accounts-client'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { ClaudeIcon } from '../status-bar/icons'
 import { SearchableSetting } from './SearchableSetting'
 import {
@@ -11,6 +13,34 @@ import {
   providerAccountIsActiveInView
 } from './provider-account-visibility'
 import { formatAccountTimestamp, getClaudeAccountRuntimeLabel } from './accounts-pane-runtime'
+function RemoteActionTooltipWrapper({
+  isRemote,
+  notice,
+  tooltip,
+  children
+}: {
+  isRemote: boolean
+  notice: string
+  tooltip: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  if (!isRemote) {
+    return <>{children}</>
+  }
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex cursor-not-allowed" onClick={() => toast.info(notice)}>
+            {children}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
 import type { AccountsPaneSectionModel } from './accounts-pane-types'
 
 export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): React.JSX.Element {
@@ -74,34 +104,48 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-1.5">
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() =>
-                void runClaudeAccountAction('adding', () =>
-                  window.api.claudeAccounts.add({
-                    runtime: accountRuntime.runtime,
-                    wslDistro: accountRuntime.wslDistro
-                  })
-                )
-              }
-              disabled={
-                // Why: interactive `claude login` needs a desktop browser and
-                // would authenticate against this device, not the server.
-                isRemoteAccountScope ||
-                claudeAction !== 'idle' ||
-                wslCapabilitiesLoading ||
-                accountRuntimeUnavailable
-              }
-              className="gap-1.5"
-            >
-              {claudeAction === 'adding' ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <Plus className="size-3" />
+            <RemoteActionTooltipWrapper
+              isRemote={isRemoteAccountScope}
+              notice={translate(
+                'auto.components.settings.AccountsPane.remoteAddClaudeNotice',
+                'Accounts on {{value0}} must be added in a terminal on that server. Run: orca account add --agent claude',
+                { value0: accountRuntimeSentenceLabel }
               )}
-              {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
-            </Button>
+              tooltip={translate(
+                'auto.components.settings.AccountsPane.remoteAddClaudeTooltip',
+                'Add accounts on {{value0}} by running: orca account add --agent claude',
+                { value0: accountRuntimeSentenceLabel }
+              )}
+            >
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={() =>
+                  void runClaudeAccountAction('adding', () =>
+                    window.api.claudeAccounts.add({
+                      runtime: accountRuntime.runtime,
+                      wslDistro: accountRuntime.wslDistro
+                    })
+                  )
+                }
+                disabled={
+                  // Why: interactive `claude login` needs a desktop browser and
+                  // would authenticate against this device, not the server.
+                  isRemoteAccountScope ||
+                  claudeAction !== 'idle' ||
+                  wslCapabilitiesLoading ||
+                  accountRuntimeUnavailable
+                }
+                className="gap-1.5"
+              >
+                {claudeAction === 'adding' ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Plus className="size-3" />
+                )}
+                {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
+              </Button>
+            </RemoteActionTooltipWrapper>
             {claudeAction === 'adding' ? (
               <Button
                 variant="ghost"
@@ -238,33 +282,47 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
                       </span>
                     </button>
                     <div className="flex shrink-0 items-center justify-end gap-1 max-md:w-full max-md:flex-wrap">
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        onClick={(event) => {
-                          event.stopPropagation()
-                          void runClaudeAccountAction(
-                            `reauth:${account.id}`,
-                            () =>
-                              window.api.claudeAccounts.reauthenticate({
-                                accountId: account.id
-                              }),
-                            getProviderAccountRuntime(account)
-                          )
-                        }}
-                        disabled={isRemoteAccountScope || isBusy}
-                        className="h-6 px-2 text-muted-foreground hover:text-foreground"
+                      <RemoteActionTooltipWrapper
+                        isRemote={isRemoteAccountScope}
+                        notice={translate(
+                          'auto.components.settings.AccountsPane.remoteReauthClaudeNotice',
+                          'Re-authenticate accounts on {{value0}} by running: orca account add --agent claude',
+                          { value0: accountRuntimeSentenceLabel }
+                        )}
+                        tooltip={translate(
+                          'auto.components.settings.AccountsPane.remoteReauthClaudeTooltip',
+                          'Re-authenticate accounts on {{value0}} by running: orca account add --agent claude',
+                          { value0: accountRuntimeSentenceLabel }
+                        )}
                       >
-                        {isReauthing ? (
-                          <Loader2 className="size-3 animate-spin" />
-                        ) : (
-                          <RefreshCw className="size-3" />
-                        )}
-                        {translate(
-                          'auto.components.settings.AccountsPane.8a0f870153',
-                          'Re-authenticate'
-                        )}
-                      </Button>
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            void runClaudeAccountAction(
+                              `reauth:${account.id}`,
+                              () =>
+                                window.api.claudeAccounts.reauthenticate({
+                                  accountId: account.id
+                                }),
+                              getProviderAccountRuntime(account)
+                            )
+                          }}
+                          disabled={isRemoteAccountScope || isBusy}
+                          className="h-6 px-2 text-muted-foreground hover:text-foreground"
+                        >
+                          {isReauthing ? (
+                            <Loader2 className="size-3 animate-spin" />
+                          ) : (
+                            <RefreshCw className="size-3" />
+                          )}
+                          {translate(
+                            'auto.components.settings.AccountsPane.8a0f870153',
+                            'Re-authenticate'
+                          )}
+                        </Button>
+                      </RemoteActionTooltipWrapper>
                       <Button
                         variant="ghost"
                         size="xs"

--- a/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
@@ -88,6 +88,10 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
                 'Add accounts on {{value0}} by running: orca account add --agent claude',
                 { value0: accountRuntimeSentenceLabel }
               )}
+              actionLabel={translate(
+                'auto.components.settings.AccountsPane.b0e948a4f9',
+                'Add Account'
+              )}
             >
               <Button
                 variant="outline"
@@ -265,6 +269,10 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
                           'auto.components.settings.AccountsPane.remoteReauthClaudeTooltip',
                           'Re-authenticate accounts on {{value0}} by running: orca account add --agent claude',
                           { value0: accountRuntimeSentenceLabel }
+                        )}
+                        actionLabel={translate(
+                          'auto.components.settings.AccountsPane.8a0f870153',
+                          'Re-authenticate'
                         )}
                       >
                         <Button

--- a/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
@@ -1,11 +1,10 @@
 import { Loader2, Plus, RefreshCw, Trash2, X } from 'lucide-react'
-import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { selectClaudeProviderAccount } from '@/runtime/runtime-provider-accounts-client'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { AccountsPaneRemoteActionWrapper } from './accounts-pane-remote-action-wrapper'
 import { ClaudeIcon } from '../status-bar/icons'
 import { SearchableSetting } from './SearchableSetting'
 import {
@@ -13,33 +12,6 @@ import {
   providerAccountIsActiveInView
 } from './provider-account-visibility'
 import { formatAccountTimestamp, getClaudeAccountRuntimeLabel } from './accounts-pane-runtime'
-function RemoteActionTooltipWrapper({
-  isRemote,
-  notice,
-  tooltip,
-  children
-}: {
-  isRemote: boolean
-  notice: string
-  tooltip: string
-  children: React.ReactNode
-}): React.JSX.Element {
-  if (!isRemote) {
-    return <>{children}</>
-  }
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="inline-flex cursor-not-allowed" onClick={() => toast.info(notice)}>
-            {children}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="top">{tooltip}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  )
-}
 
 import type { AccountsPaneSectionModel } from './accounts-pane-types'
 
@@ -104,7 +76,7 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
             </p>
           </div>
           <div className="flex shrink-0 items-center gap-1.5">
-            <RemoteActionTooltipWrapper
+            <AccountsPaneRemoteActionWrapper
               isRemote={isRemoteAccountScope}
               notice={translate(
                 'auto.components.settings.AccountsPane.remoteAddClaudeNotice',
@@ -145,7 +117,7 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
                 )}
                 {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
               </Button>
-            </RemoteActionTooltipWrapper>
+            </AccountsPaneRemoteActionWrapper>
             {claudeAction === 'adding' ? (
               <Button
                 variant="ghost"
@@ -282,7 +254,7 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
                       </span>
                     </button>
                     <div className="flex shrink-0 items-center justify-end gap-1 max-md:w-full max-md:flex-wrap">
-                      <RemoteActionTooltipWrapper
+                      <AccountsPaneRemoteActionWrapper
                         isRemote={isRemoteAccountScope}
                         notice={translate(
                           'auto.components.settings.AccountsPane.remoteReauthClaudeNotice',
@@ -322,7 +294,7 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
                             'Re-authenticate'
                           )}
                         </Button>
-                      </RemoteActionTooltipWrapper>
+                      </AccountsPaneRemoteActionWrapper>
                       <Button
                         variant="ghost"
                         size="xs"

--- a/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
@@ -1,12 +1,11 @@
 import { Loader2, RefreshCw, Trash2 } from 'lucide-react'
-import { toast } from 'sonner'
 import type { CodexRateLimitAccountsState } from '../../../../shared/managed-account-types'
 import { translate } from '@/i18n/i18n'
 import { getCodexAccountDisplayDetail } from '@/lib/codex-account-display-label'
 import { selectCodexProviderAccount } from '@/runtime/runtime-provider-accounts-client'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { AccountsPaneRemoteActionWrapper } from './accounts-pane-remote-action-wrapper'
 import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
 import {
   getProviderAccountRuntime,
@@ -139,61 +138,19 @@ export function renderCodexAccountRow(
           {/* Why: selecting an account is the primary action in this row.
           Keeping maintenance actions visually lighter prevents re-auth/remove
           controls from overpowering the selection affordance in a dense list. */}
-          {isRemoteAccountScope ? (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className="inline-flex cursor-not-allowed"
-                    onClick={() =>
-                      toast.info(
-                        translate(
-                          'auto.components.settings.AccountsPane.remoteReauthCodexNotice',
-                          'Re-authenticate accounts on {{value0}} by running: orca account add --agent codex',
-                          { value0: accountRuntimeSentenceLabel }
-                        )
-                      )
-                    }
-                  >
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        void runCodexAccountAction(
-                          `reauth:${account.id}`,
-                          () =>
-                            window.api.codexAccounts.reauthenticate({
-                              accountId: account.id
-                            }),
-                          getProviderAccountRuntime(account)
-                        )
-                      }}
-                      disabled={isRemoteAccountScope || isBusy}
-                      className="h-6 px-2 text-muted-foreground hover:text-foreground"
-                    >
-                      {isReauthing ? (
-                        <Loader2 className="size-3 animate-spin" />
-                      ) : (
-                        <RefreshCw className="size-3" />
-                      )}
-                      {translate(
-                        'auto.components.settings.AccountsPane.8a0f870153',
-                        'Re-authenticate'
-                      )}
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {translate(
-                    'auto.components.settings.AccountsPane.remoteReauthCodexTooltip',
-                    'Re-authenticate accounts on {{value0}} by running: orca account add --agent codex',
-                    { value0: accountRuntimeSentenceLabel }
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          ) : (
+          <AccountsPaneRemoteActionWrapper
+            isRemote={isRemoteAccountScope}
+            notice={translate(
+              'auto.components.settings.AccountsPane.remoteReauthCodexNotice',
+              'Re-authenticate accounts on {{value0}} by running: orca account add --agent codex',
+              { value0: accountRuntimeSentenceLabel }
+            )}
+            tooltip={translate(
+              'auto.components.settings.AccountsPane.remoteReauthCodexTooltip',
+              'Re-authenticate accounts on {{value0}} by running: orca account add --agent codex',
+              { value0: accountRuntimeSentenceLabel }
+            )}
+          >
             <Button
               variant="ghost"
               size="xs"
@@ -218,7 +175,7 @@ export function renderCodexAccountRow(
               )}
               {translate('auto.components.settings.AccountsPane.8a0f870153', 'Re-authenticate')}
             </Button>
-          )}
+          </AccountsPaneRemoteActionWrapper>
           <Button
             variant="ghost"
             size="xs"

--- a/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
@@ -150,6 +150,10 @@ export function renderCodexAccountRow(
               'Re-authenticate accounts on {{value0}} by running: orca account add --agent codex',
               { value0: accountRuntimeSentenceLabel }
             )}
+            actionLabel={translate(
+              'auto.components.settings.AccountsPane.8a0f870153',
+              'Re-authenticate'
+            )}
           >
             <Button
               variant="ghost"

--- a/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
@@ -1,10 +1,12 @@
 import { Loader2, RefreshCw, Trash2 } from 'lucide-react'
+import { toast } from 'sonner'
 import type { CodexRateLimitAccountsState } from '../../../../shared/managed-account-types'
 import { translate } from '@/i18n/i18n'
 import { getCodexAccountDisplayDetail } from '@/lib/codex-account-display-label'
 import { selectCodexProviderAccount } from '@/runtime/runtime-provider-accounts-client'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
 import {
   getProviderAccountRuntime,
@@ -19,6 +21,7 @@ export function renderCodexAccountRow(
 ): React.JSX.Element {
   const {
     accountRuntime,
+    accountRuntimeSentenceLabel,
     accountRuntimeUnavailable,
     accountVisibilityOptions,
     activeCodexAccountId,
@@ -136,30 +139,86 @@ export function renderCodexAccountRow(
           {/* Why: selecting an account is the primary action in this row.
           Keeping maintenance actions visually lighter prevents re-auth/remove
           controls from overpowering the selection affordance in a dense list. */}
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={(event) => {
-              event.stopPropagation()
-              void runCodexAccountAction(
-                `reauth:${account.id}`,
-                () =>
-                  window.api.codexAccounts.reauthenticate({
-                    accountId: account.id
-                  }),
-                getProviderAccountRuntime(account)
-              )
-            }}
-            disabled={isRemoteAccountScope || isBusy}
-            className="h-6 px-2 text-muted-foreground hover:text-foreground"
-          >
-            {isReauthing ? (
-              <Loader2 className="size-3 animate-spin" />
-            ) : (
-              <RefreshCw className="size-3" />
-            )}
-            {translate('auto.components.settings.AccountsPane.8a0f870153', 'Re-authenticate')}
-          </Button>
+          {isRemoteAccountScope ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex cursor-not-allowed"
+                    onClick={() =>
+                      toast.info(
+                        translate(
+                          'auto.components.settings.AccountsPane.remoteReauthCodexNotice',
+                          'Re-authenticate accounts on {{value0}} by running: orca account add --agent codex',
+                          { value0: accountRuntimeSentenceLabel }
+                        )
+                      )
+                    }
+                  >
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        void runCodexAccountAction(
+                          `reauth:${account.id}`,
+                          () =>
+                            window.api.codexAccounts.reauthenticate({
+                              accountId: account.id
+                            }),
+                          getProviderAccountRuntime(account)
+                        )
+                      }}
+                      disabled={isRemoteAccountScope || isBusy}
+                      className="h-6 px-2 text-muted-foreground hover:text-foreground"
+                    >
+                      {isReauthing ? (
+                        <Loader2 className="size-3 animate-spin" />
+                      ) : (
+                        <RefreshCw className="size-3" />
+                      )}
+                      {translate(
+                        'auto.components.settings.AccountsPane.8a0f870153',
+                        'Re-authenticate'
+                      )}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {translate(
+                    'auto.components.settings.AccountsPane.remoteReauthCodexTooltip',
+                    'Re-authenticate accounts on {{value0}} by running: orca account add --agent codex',
+                    { value0: accountRuntimeSentenceLabel }
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={(event) => {
+                event.stopPropagation()
+                void runCodexAccountAction(
+                  `reauth:${account.id}`,
+                  () =>
+                    window.api.codexAccounts.reauthenticate({
+                      accountId: account.id
+                    }),
+                  getProviderAccountRuntime(account)
+                )
+              }}
+              disabled={isRemoteAccountScope || isBusy}
+              className="h-6 px-2 text-muted-foreground hover:text-foreground"
+            >
+              {isReauthing ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3" />
+              )}
+              {translate('auto.components.settings.AccountsPane.8a0f870153', 'Re-authenticate')}
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="xs"

--- a/src/renderer/src/components/settings/accounts-pane-codex-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-section.tsx
@@ -165,6 +165,10 @@ export function renderCodexAccountsSection(model: AccountsPaneSectionModel): Rea
               'Add accounts on {{value0}} by running: orca account add --agent codex',
               { value0: accountRuntimeSentenceLabel }
             )}
+            actionLabel={translate(
+              'auto.components.settings.AccountsPane.b0e948a4f9',
+              'Add Account'
+            )}
           >
             <Button
               variant="outline"

--- a/src/renderer/src/components/settings/accounts-pane-codex-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-section.tsx
@@ -1,11 +1,10 @@
 import { AlertTriangle, Loader2, Plus } from 'lucide-react'
-import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { selectCodexProviderAccount } from '@/runtime/runtime-provider-accounts-client'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { AccountsPaneRemoteActionWrapper } from './accounts-pane-remote-action-wrapper'
 import { OpenAIIcon } from '../status-bar/icons'
 import { SearchableSetting } from './SearchableSetting'
 import { getAccountsCodexSearchEntries } from './accounts-search'
@@ -154,62 +153,19 @@ export function renderCodexAccountsSection(model: AccountsPaneSectionModel): Rea
                   )}
             </p>
           </div>
-          {isRemoteAccountScope ? (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className="inline-flex cursor-not-allowed"
-                    onClick={() =>
-                      toast.info(
-                        translate(
-                          'auto.components.settings.AccountsPane.remoteAddCodexNotice',
-                          'Accounts on {{value0}} must be added in a terminal on that server. Run: orca account add --agent codex',
-                          { value0: accountRuntimeSentenceLabel }
-                        )
-                      )
-                    }
-                  >
-                    <Button
-                      variant="outline"
-                      size="xs"
-                      onClick={() =>
-                        void runCodexAccountAction('adding', () =>
-                          window.api.codexAccounts.add({
-                            runtime: accountRuntime.runtime,
-                            wslDistro: accountRuntime.wslDistro
-                          })
-                        )
-                      }
-                      disabled={
-                        // Why: interactive `codex login` needs a desktop browser and
-                        // would authenticate against this device, not the server.
-                        isRemoteAccountScope ||
-                        codexAction !== 'idle' ||
-                        wslCapabilitiesLoading ||
-                        accountRuntimeUnavailable
-                      }
-                      className="gap-1.5"
-                    >
-                      {codexAction === 'adding' ? (
-                        <Loader2 className="size-3 animate-spin" />
-                      ) : (
-                        <Plus className="size-3" />
-                      )}
-                      {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {translate(
-                    'auto.components.settings.AccountsPane.remoteAddCodexTooltip',
-                    'Add accounts on {{value0}} by running: orca account add --agent codex',
-                    { value0: accountRuntimeSentenceLabel }
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          ) : (
+          <AccountsPaneRemoteActionWrapper
+            isRemote={isRemoteAccountScope}
+            notice={translate(
+              'auto.components.settings.AccountsPane.remoteAddCodexNotice',
+              'Accounts on {{value0}} must be added in a terminal on that server. Run: orca account add --agent codex',
+              { value0: accountRuntimeSentenceLabel }
+            )}
+            tooltip={translate(
+              'auto.components.settings.AccountsPane.remoteAddCodexTooltip',
+              'Add accounts on {{value0}} by running: orca account add --agent codex',
+              { value0: accountRuntimeSentenceLabel }
+            )}
+          >
             <Button
               variant="outline"
               size="xs"
@@ -238,7 +194,7 @@ export function renderCodexAccountsSection(model: AccountsPaneSectionModel): Rea
               )}
               {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
             </Button>
-          )}
+          </AccountsPaneRemoteActionWrapper>
         </div>
         {remoteAccountScopeNotice}
 

--- a/src/renderer/src/components/settings/accounts-pane-codex-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-section.tsx
@@ -1,9 +1,11 @@
 import { AlertTriangle, Loader2, Plus } from 'lucide-react'
+import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { selectCodexProviderAccount } from '@/runtime/runtime-provider-accounts-client'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { OpenAIIcon } from '../status-bar/icons'
 import { SearchableSetting } from './SearchableSetting'
 import { getAccountsCodexSearchEntries } from './accounts-search'
@@ -152,34 +154,91 @@ export function renderCodexAccountsSection(model: AccountsPaneSectionModel): Rea
                   )}
             </p>
           </div>
-          <Button
-            variant="outline"
-            size="xs"
-            onClick={() =>
-              void runCodexAccountAction('adding', () =>
-                window.api.codexAccounts.add({
-                  runtime: accountRuntime.runtime,
-                  wslDistro: accountRuntime.wslDistro
-                })
-              )
-            }
-            disabled={
-              // Why: interactive `codex login` needs a desktop browser and
-              // would authenticate against this device, not the server.
-              isRemoteAccountScope ||
-              codexAction !== 'idle' ||
-              wslCapabilitiesLoading ||
-              accountRuntimeUnavailable
-            }
-            className="gap-1.5"
-          >
-            {codexAction === 'adding' ? (
-              <Loader2 className="size-3 animate-spin" />
-            ) : (
-              <Plus className="size-3" />
-            )}
-            {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
-          </Button>
+          {isRemoteAccountScope ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span
+                    className="inline-flex cursor-not-allowed"
+                    onClick={() =>
+                      toast.info(
+                        translate(
+                          'auto.components.settings.AccountsPane.remoteAddCodexNotice',
+                          'Accounts on {{value0}} must be added in a terminal on that server. Run: orca account add --agent codex',
+                          { value0: accountRuntimeSentenceLabel }
+                        )
+                      )
+                    }
+                  >
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      onClick={() =>
+                        void runCodexAccountAction('adding', () =>
+                          window.api.codexAccounts.add({
+                            runtime: accountRuntime.runtime,
+                            wslDistro: accountRuntime.wslDistro
+                          })
+                        )
+                      }
+                      disabled={
+                        // Why: interactive `codex login` needs a desktop browser and
+                        // would authenticate against this device, not the server.
+                        isRemoteAccountScope ||
+                        codexAction !== 'idle' ||
+                        wslCapabilitiesLoading ||
+                        accountRuntimeUnavailable
+                      }
+                      className="gap-1.5"
+                    >
+                      {codexAction === 'adding' ? (
+                        <Loader2 className="size-3 animate-spin" />
+                      ) : (
+                        <Plus className="size-3" />
+                      )}
+                      {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {translate(
+                    'auto.components.settings.AccountsPane.remoteAddCodexTooltip',
+                    'Add accounts on {{value0}} by running: orca account add --agent codex',
+                    { value0: accountRuntimeSentenceLabel }
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() =>
+                void runCodexAccountAction('adding', () =>
+                  window.api.codexAccounts.add({
+                    runtime: accountRuntime.runtime,
+                    wslDistro: accountRuntime.wslDistro
+                  })
+                )
+              }
+              disabled={
+                // Why: interactive `codex login` needs a desktop browser and
+                // would authenticate against this device, not the server.
+                isRemoteAccountScope ||
+                codexAction !== 'idle' ||
+                wslCapabilitiesLoading ||
+                accountRuntimeUnavailable
+              }
+              className="gap-1.5"
+            >
+              {codexAction === 'adding' ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Plus className="size-3" />
+              )}
+              {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
+            </Button>
+          )}
         </div>
         {remoteAccountScopeNotice}
 

--- a/src/renderer/src/components/settings/accounts-pane-remote-action-wrapper.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-remote-action-wrapper.tsx
@@ -6,11 +6,13 @@ export function AccountsPaneRemoteActionWrapper({
   isRemote,
   notice,
   tooltip,
+  actionLabel,
   children
 }: {
   isRemote: boolean
   notice: string
   tooltip: string
+  actionLabel?: string
   children: React.ReactNode
 }): React.JSX.Element {
   if (!isRemote) {
@@ -23,7 +25,7 @@ export function AccountsPaneRemoteActionWrapper({
         <span
           tabIndex={0}
           role="button"
-          aria-label={tooltip}
+          aria-label={actionLabel}
           className="inline-flex rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           onClick={() => toast.info(notice)}
           onKeyDown={(event) => {
@@ -33,7 +35,9 @@ export function AccountsPaneRemoteActionWrapper({
             }
           }}
         >
-          {children}
+          <span className="pointer-events-none" aria-hidden="true">
+            {children}
+          </span>
         </span>
       </TooltipTrigger>
       <TooltipContent side="top">{tooltip}</TooltipContent>

--- a/src/renderer/src/components/settings/accounts-pane-remote-action-wrapper.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-remote-action-wrapper.tsx
@@ -1,0 +1,42 @@
+import type React from 'react'
+import { toast } from 'sonner'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+
+export function AccountsPaneRemoteActionWrapper({
+  isRemote,
+  notice,
+  tooltip,
+  children
+}: {
+  isRemote: boolean
+  notice: string
+  tooltip: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  if (!isRemote) {
+    return <>{children}</>
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          tabIndex={0}
+          role="button"
+          aria-label={tooltip}
+          className="inline-flex rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          onClick={() => toast.info(notice)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault()
+              toast.info(notice)
+            }
+          }}
+        >
+          {children}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">{tooltip}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6487,7 +6487,15 @@
           "4e32e030b2": "Stored locally. Orca sends it only to platform.minimax.io for usage refreshes.",
           "5e08b0fe57": "Stored locally and sent only to platform.minimax.io for usage refreshes.",
           "79418c782a": "Open platform.minimax.io/console/usage in your browser, sign in, then copy the Cookie request header from DevTools (Network → any remains request → Cookie).",
-          "f5d8d2a6a1": "Open platform.minimax.io/console/usage in your browser and sign in."
+          "f5d8d2a6a1": "Open platform.minimax.io/console/usage in your browser and sign in.",
+          "remoteAddClaudeNotice": "Accounts on {{value0}} must be added in a terminal on that server. Run: orca account add --agent claude",
+          "remoteAddClaudeTooltip": "Add accounts on {{value0}} by running: orca account add --agent claude",
+          "remoteReauthClaudeNotice": "Re-authenticate accounts on {{value0}} by running: orca account add --agent claude",
+          "remoteReauthClaudeTooltip": "Re-authenticate accounts on {{value0}} by running: orca account add --agent claude",
+          "remoteReauthCodexNotice": "Re-authenticate accounts on {{value0}} by running: orca account add --agent codex",
+          "remoteReauthCodexTooltip": "Re-authenticate accounts on {{value0}} by running: orca account add --agent codex",
+          "remoteAddCodexNotice": "Accounts on {{value0}} must be added in a terminal on that server. Run: orca account add --agent codex",
+          "remoteAddCodexTooltip": "Add accounts on {{value0}} by running: orca account add --agent codex"
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",


### PR DESCRIPTION
## ELI5
When Orca is connected to a remote server runtime, accounts cannot be added or re-authenticated through local browser sign-in. Previously the buttons were simply disabled without explanation. Now hovering or clicking those disabled buttons displays guidance on how to run `orca account add` in a terminal on the remote server.

## What Changed
- In `accounts-pane-claude-section.tsx`: Wrapped the "Add Account" and "Re-authenticate" buttons with a tooltip when `isRemoteAccountScope` is true. Clicking the disabled button displays an informational toast notice, and hovering shows a tooltip with instructions to run `orca account add --agent claude`.
- In `accounts-pane-codex-section.tsx`: Wrapped the "Add Account" button in the same tooltip/toast notice pattern instructing the user to run `orca account add --agent codex`.
- In `accounts-pane-codex-account-row.tsx`: Wrapped the "Re-authenticate" button in the same tooltip/toast notice pattern instructing the user to run `orca account add --agent codex`.
- Added localized strings to `src/renderer/src/i18n/locales/en.json`.
- Updated `AccountsPane.test.tsx` to assert that remote guidance tooltip copy is rendered when in remote server scope and omitted in local scope.

## Why
When `isRemoteAccountScope` is active, the `<Button>` component has `disabled={isRemoteAccountScope || ...}`, which applies `disabled:pointer-events-none`. This dropped all pointer events and prevented clicks or hovers from giving any feedback to the user. Wrapping the disabled button inside a span trigger with a tooltip and click-to-toast notice ensures users clearly understand why the button cannot be clicked locally and gives them the exact terminal command to run on the server instead.

## Linked Issue
Fixes #20009

## Visual Proof
N/A - Non-interactive static rendering in automated tests and standard tooltip/toast UI feedback on disabled buttons.

## Testing
- [x] I manually tested these changes locally
- [x] Automated tests added/updated:
  - `pnpm test src/renderer/src/components/settings/AccountsPane.test.tsx` passes
  - `pnpm typecheck` passes
  - `pnpm run check:code-quality:changed` passes
  - `pnpm run verify:localization-catalog` passes

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)