### PR TITLE
fix(ssh): record the superseded-relay pass the Windows arm abandons

### DIFF
--- a/src/main/ssh/ssh-relay-superseded-endpoints.test.ts
+++ b/src/main/ssh/ssh-relay-superseded-endpoints.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
 
 const execCommand = vi.fn()
 vi.mock('./ssh-relay-deploy-helpers', () => ({
@@ -41,6 +41,13 @@ function incumbent(lines: string[]): ReturnType<typeof parseRelayEndpointIncumbe
 
 function issuedCommands(): string[] {
   return execCommand.mock.calls.map((call) => String(call[1]))
+}
+
+/** The `beforeEach` spy is reinstalled, not reset, so its calls survive the previous test. */
+function warnSpy(): MockInstance<typeof console.warn> {
+  const spy = vi.spyOn(console, 'warn')
+  spy.mockClear()
+  return spy
 }
 
 beforeEach(() => {
@@ -157,8 +164,21 @@ describe('sweepSupersededRelayEndpoints', () => {
     await expect(sweepSupersededRelayEndpoints(CONN, HOST, SWEEP)).resolves.toEqual([])
   })
 
+  it('records the abandoned pass when the listing fails, so it reads apart from an empty host', async () => {
+    const warn = warnSpy()
+    execCommand.mockRejectedValueOnce(new Error('exec failed'))
+    await sweepSupersededRelayEndpoints(CONN, HOST, SWEEP)
+    expect(warn.mock.calls.flat().join('\n')).toContain('no pass ran: exec failed')
+  })
+
   it('does not run against Windows hosts, whose endpoints are named pipes', async () => {
+    const warn = warnSpy()
     await expect(sweepSupersededRelayEndpoints(CONN, WINDOWS_HOST, SWEEP)).resolves.toEqual([])
     expect(execCommand).not.toHaveBeenCalled()
+    // The skip has to leave a trace: a Windows orphan is never listed and never reclaimed, and
+    // an empty return is otherwise indistinguishable from a host that had nothing to sweep.
+    const logged = warn.mock.calls.flat().join('\n')
+    expect(logged).toContain('Superseded relay sweep did not run')
+    expect(logged).toContain(CURRENT_DIR)
   })
 })

--- a/src/main/ssh/ssh-relay-superseded-endpoints.ts
+++ b/src/main/ssh/ssh-relay-superseded-endpoints.ts
@@ -118,6 +118,17 @@ export async function sweepSupersededRelayEndpoints(
   options: SupersededRelaySweepOptions
 ): Promise<SupersededRelayFinding[]> {
   if (isWindowsRemoteHost(hostPlatform)) {
+    // No pass runs here: a Windows endpoint is a named pipe with no inode to stat, so the
+    // `$HOME` glob cannot see it, and `probeRelayEndpointIncumbent` answers `unverifiable` for
+    // every Windows path anyway — nothing on this host could be classified, let alone reaped.
+    // The population is real all the same (`relayEndpointForHost` hashes the version dir into
+    // the pipe name, so an update strands the incumbent exactly as it does on POSIX), and with
+    // `--grace-time 0` it keeps its PTYs forever. Returning silently was the whole bug: this
+    // sweep exists to make that population visible, and on Windows it made it invisible.
+    console.warn(
+      `[ssh-relay] Superseded relay sweep did not run (Windows named-pipe endpoints are not enumerated); ` +
+        `orphans from earlier builds are neither listed nor reclaimed: current=${options.currentRelayDir}`
+    )
     return []
   }
   let listing: string
@@ -126,7 +137,14 @@ export async function sweepSupersededRelayEndpoints(
       wrapCommand: true,
       signal: options.signal
     })
-  } catch {
+  } catch (err) {
+    // Same reason the Windows arm logs: an abandoned pass and an empty host are the same return
+    // value, and only the log tells them apart.
+    console.warn(
+      `[ssh-relay] Superseded relay listing failed; no pass ran: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
     return []
   }
   const sockPaths = listing


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 |

<!-- /orca-pr-loc -->

## The defect

`sweepSupersededRelayEndpoints` returned `[]` for **every Windows remote host** and for **every failed listing**, without writing a single line. Both returns are byte-identical to "this host had no orphans" — which is the one thing this sweep exists not to be. Its own header says it makes the orphan population *"visible and deliberate rather than silent"*.

## The Windows population is real

`relayEndpointForHost` hashes the version directory into the pipe name, so an app update strands the incumbent exactly as it does on POSIX. With `--grace-time 0` that relay keeps its PTYs and agents forever.

Measured on a Windows 11 host (`awin`):

- the NPFS root lists **262 named pipes** from an unprivileged shell;
- the count of `orca-relay-*` names goes **0 → 1** the moment a relay binds.

So the endpoints are enumerable. The repo already enumerates them for GC via `relayLivenessProbeCommand`'s `.windows-active-pipe-*` marker scan.

## Scope: visibility, deliberately not reclamation

**No kill authority is added, and that is the correct scope — not an unfinished one.** `probeRelayEndpointIncumbent` answers `unverifiable` for every Windows path, so nothing here *could* be classified, let alone reaped. Per `docs/reference/ssh-execution-boundary.md`, loss of contact is never evidence of process death, and `unverifiable` is a terminal verdict, not a synonym for dead. Reaping an endpoint nothing can classify would be exactly the bug that boundary exists to prevent.

Making an invisible population visible **is** the fix. Nothing about the kill path moves.

## Verification

`src/main/ssh/ssh-relay-superseded-endpoints.test.ts` — 13 passed.

Teeth proven by mutation, not assumed: with every `console.warn` in the production file replaced by a no-op, **exactly the 2 new tests fail** (2 failed | 11 passed). The added `warnSpy()` helper `mockClear()`s rather than re-stubs, because the `beforeEach` spy is reinstalled rather than reset and calls would otherwise survive the previous test — a trap that would have made both new rows pass vacuously.

## Split note

This was previously commingled on `nwparker/win-relay-orphan-sweep-silence` with an unrelated WSL test-isolation fix. Split so a reviewer takes one defect. The WSL half ships separately.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts; all 1 commit(s) replayed as-is.

| | SHA |
| --- | --- |
| old head | `98731ee143e5e07932a0d4016372e8244ab13686` |
| new head | `b1f93b90c5cf73207a4c260dc15abe8d2ad1d9bc` |
<!-- /rebase-record -->
