### PR TITLE
test(wsl): give the login-shell contrast its own HOME so a sibling suite cannot stall it

### DIFF
--- a/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
+++ b/src/main/local-worktree-filesystem-wsl-banner.wsl.test.ts
@@ -10,6 +10,9 @@ const runRealWsl = process.platform === 'win32' && process.env.ORCA_REAL_WSL_BAN
 
 const FILE_CONTENTS = 'line one\nline two\n'
 
+/** Printed by the fixture HOME's own `.profile`, so the contrast below proves rc really ran. */
+const RC_CHATTER = 'ORCA_RC_CHATTER'
+
 function unc(linuxPath: string): string {
   return `\\\\wsl.localhost\\${DISTRO}${linuxPath.replaceAll('/', '\\')}`
 }
@@ -23,11 +26,25 @@ async function wsl(command: string, ...args: string[]): Promise<string> {
   return stdout.trim()
 }
 
-/** What an unfenced login-shell read returns — the shape this suite exists to rule out. */
-async function readThroughRawLoginShell(linuxPath: string): Promise<string> {
+/** What an unfenced login-shell read returns — the shape this suite exists to rule out.
+ *
+ *  `HOME` is the fixture's, not the distro user's. One distro is shared by every suite in the
+ *  run and by the developer running it, and `wsl-runner.wsl.test.ts` appends `sleep 60` to the
+ *  real `~/.profile` for the length of its describe (#14288, reproduced not simulated). Reading
+ *  the real HOME here made that sibling's state observable: run in the same Vitest invocation,
+ *  this call inherited the 60s stall and died on its own 30s timeout, while each suite passed
+ *  alone. Owning the rc file the contrast reads is what makes the overlap impossible rather
+ *  than unlikely — and it also stops a developer's own slow `.profile` from failing this. */
+async function readThroughRawLoginShell(linuxPath: string, home: string): Promise<string> {
   const { stdout } = await execFileAsync(
     'wsl.exe',
-    buildWslExecArgs(DISTRO, ['sh', '-lc', buildWslLoginShellCommand(`cat -- '${linuxPath}'`)]),
+    buildWslExecArgs(DISTRO, [
+      'env',
+      `HOME=${home}`,
+      'sh',
+      '-lc',
+      buildWslLoginShellCommand(`cat -- '${linuxPath}'`)
+    ]),
     { encoding: 'utf-8', timeout: 30000 }
   )
   return stdout
@@ -39,6 +56,11 @@ describe.skipIf(!runRealWsl)('WSL worktree reads carry no shell chatter', () => 
   beforeAll(async () => {
     fixtureRoot = await wsl("mktemp -d -p /tmp 'orca-wsl-banner.XXXXXX'")
     await wsl('mkdir -p "$1/dir" && printf \'%s\' "$2" > "$1/file.txt"', fixtureRoot, FILE_CONTENTS)
+    await wsl(
+      'mkdir -p "$1/home" && printf \'echo %s\\n\' "$2" > "$1/home/.profile"',
+      fixtureRoot,
+      RC_CHATTER
+    )
   }, 120_000)
 
   afterAll(async () => {
@@ -55,22 +77,23 @@ describe.skipIf(!runRealWsl)('WSL worktree reads carry no shell chatter', () => 
 
   it('is unaffected by what a login shell would have printed', async () => {
     const { readPath } = getLocalWorktreePathAccess({ wslDistro: DISTRO })
-    const raw = await readThroughRawLoginShell(`${fixtureRoot}/file.txt`)
+    const raw = await readThroughRawLoginShell(`${fixtureRoot}/file.txt`, `${fixtureRoot}/home`)
 
     // Precondition, not decoration. This row is the suite's only contrast, and
     // `endsWith` alone holds whether or not the rc files printed anything -- so
     // without this line the contrast is satisfied by a machine that produces no
     // banner at all, and the suite reports success having exercised nothing.
     //
-    // The banner is conditional on distro user state this suite does not own:
-    // Ubuntu's sudo hint is gated on `~/.sudo_as_admin_successful` and the MOTD
-    // on `~/.motd_shown` (once per day per HOME). On any machine where the user
-    // has sudo'd and today's MOTD already fired -- every developer box after day
-    // one -- `raw` is exactly the file. Fail loudly there instead: "the hazard is
-    // not reproducible on this machine" is a real answer, and a green run that
-    // never met the banner is not.
-    expect(raw).not.toBe(FILE_CONTENTS)
+    // The distro's own banner could not carry that precondition: it is gated on
+    // user state this suite does not own (Ubuntu's sudo hint on
+    // `~/.sudo_as_admin_successful`, the MOTD on `~/.motd_shown`, once per day
+    // per HOME), so it is silently absent on every developer box after day one.
+    // The fixture HOME set up in beforeAll supplies an rc file that always prints RC_CHATTER,
+    // which makes the chatter a property of the fixture rather than of the
+    // machine -- deterministic where the banner was merely likely.
+    expect(raw).toContain(RC_CHATTER)
     expect(raw.endsWith(FILE_CONTENTS)).toBe(true)
+    // These reads use a plain `sh -c`, which runs no rc at all, so they are exactly the file.
     expect(await readPath(unc(`${fixtureRoot}/file.txt`))).toBe(FILE_CONTENTS)
   }, 60_000)
 

--- a/src/main/wsl/wsl-runner.wsl.test.ts
+++ b/src/main/wsl/wsl-runner.wsl.test.ts
@@ -23,6 +23,15 @@ import { resolveWslExecutablePath } from './wsl-executable-path'
  *     deletes or reverts the user's profile.
  * Verified by hashing `$HOME/.profile` either side of a run, which is the check
  * to repeat if you must run it somewhere shared -- do not assume the restore.
+ *
+ * The mutation has to be distro-global: the stall it reproduces happens inside
+ * `getWslGuestEnvironment`'s probe, which takes no HOME from the caller. So for
+ * the length of this describe, every login shell in the distro blocks for 60s —
+ * including any run by a sibling suite in the same Vitest invocation. That is
+ * not hypothetical: it silently timed out the login-shell contrast read in
+ * `local-worktree-filesystem-wsl-banner.wsl.test.ts`, which passed alone and
+ * failed in the pair. Any new WSL suite that needs a predictable `~/.profile`
+ * must own the HOME it reads rather than the distro user's, as that one now does.
  */
 const DISTRO = process.env.ORCA_WSL_TEST_DISTRO ?? 'Ubuntu-24.04'
 const enabled = process.platform === 'win32' && process.env.ORCA_REAL_WSL_RUNNER_TEST === '1'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

> **Stacked on #19957.** Base is `nwparker/wsl-banner-suite-precondition`; review that first. This PR is the last commit.

## Two suites that are each correct, and broken as a pair

`local-worktree-filesystem-wsl-banner.wsl.test.ts` read its contrast through the distro user's real `~/.profile`.

`wsl-runner.wsl.test.ts` appends `sleep 60` to that same file for the length of its `describe`. **It has to** — the stall it reproduces (#14288) happens inside `getWslGuestEnvironment`'s probe, which takes no HOME from its caller, so the mutation is necessarily distro-global.

Run in one Vitest invocation, the two overlap: the contrast read inherits the 60 s stall and dies on its own 30 s timeout.

## Measured

On a Windows 11 host with real WSL2 Ubuntu-24.04, at pinned `origin/main` **cdf41df37c** — so this is not an artifact of the surrounding stack:

| run | result |
|---|---|
| all four suites together | 1 failed / 15 passed |
| the banner suite alone | 5 passed / 5 |
| the interfering pair | **failed 2/2, at 30,013 ms and 30,017 ms** |

Each suite is correct in isolation. Only the pair is broken — which is exactly why nobody had seen it.

## Why isolation, not serialisation

Serialising the files would have **hidden the coupling** rather than removed it: the next suite to read the distro user's `~/.profile` reintroduces it silently.

The contrast now runs under `env HOME=<fixture>/home` with an rc file the suite writes. The sibling's mutation becomes **unobservable rather than merely unlikely to overlap** — and a developer's own slow `.profile` stops failing this suite too.

`wsl-runner.wsl.test.ts` gains **no behaviour change**, only a header stating that its mutation is distro-global and what that costs a sibling, so the next author does not rediscover this.

## It also finishes what #19957 started

#19957 made the contrast a precondition via `expect(raw).not.toBe(FILE_CONTENTS)`, and named the limit it could not fix: the banner is gated on distro user state the suite does not own (Ubuntu's sudo hint on `~/.sudo_as_admin_successful`, the MOTD on `~/.motd_shown`, once per day per HOME), so it is silently absent on every developer box after day one.

Owning the HOME removes that dependency. The fixture rc always prints a marker and the row now requires it (`expect(raw).toContain(RC_CHATTER)`), so **"the login shell really does add chatter" is proven rather than assumed** — deterministic where the distro banner was merely likely. That subsumes the `not.toBe` form, which is why this PR replaces rather than adds to it.

## Verification

- Typecheck clean (`tsconfig.node.json`).
- `win32-test-lane-registration` — 31 passed.
- The two WSL suites are `skipIf(!runRealWsl)` + win32-gated, so on this macOS checkout they **skip (11 skipped)** — that is expected, and I am not presenting it as a pass. The measurements above were taken on the real Windows/WSL2 host; the pair-run needs re-confirming on Windows CI.

## Conflict resolution note

The cherry-pick conflicted with #19957 in two places, both resolved by keeping the substance of each side rather than taking one:
- `wsl-runner.wsl.test.ts` — both header blocks retained (the shared-distro safety warning from #19957, and the sibling-coupling explanation from this commit).
- the banner suite — this commit's deterministic precondition retained, carrying forward #19957's reasoning for *why* the contrast must be a precondition.

## Split note

This was previously commingled on `nwparker/win-relay-orphan-sweep-silence` with an unrelated Windows SSH relay orphan-sweep logging fix, which now ships as **#20045**. A reviewer should not have to review a WSL test-isolation change to get a Windows logging fix.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Stack preserved: base stays `nwparker/wsl-banner-suite-precondition` (#19957), which was rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c` first. Replayed with `git rebase --onto 065b3fab2433dfd552c8808ff719128709585da6 469289e5a6d037d154f38a50bb5abba64626696e`.

| | SHA |
| --- | --- |
| old head | `52a10d1759ff00a54f54b24d88c2ce246a4b42b7` |
| new head | `d55bfd7ae909e864fbd31c451855c8ad0d56868f` |
| new base (#19957) | `065b3fab2433dfd552c8808ff719128709585da6` |

No conflicts.
<!-- /rebase-record -->
