### PR TITLE
perf(relay): index client request aborts instead of scanning every controller

### DIFF
--- a/src/relay/client-request-aborts.ts
+++ b/src/relay/client-request-aborts.ts
@@ -1,40 +1,69 @@
-export class ClientRequestAborts {
-  private readonly controllers = new Map<string, AbortController>()
+/** Opaque handle returned by `create`, so a release needs no string parsing to find its owner. */
+export type ClientRequestAbortHandle = {
+  readonly clientId: number
+  readonly requestId: number
+}
 
-  create(clientId: number, requestId: number): { key: string; controller: AbortController } {
-    const key = this.key(clientId, requestId)
+export class ClientRequestAborts {
+  // Why indexed by client instead of one flat map under composite `${clientId}:${requestId}` keys:
+  // abortClient runs on every closeClient and every setWrite, and against a flat map it had to scan
+  // every entry to find one client's. A scan with an early break cannot fix that -- the matching
+  // keys are scattered through the map, so any correct loop still visits every entry, which made a
+  // full churn of N clients cost K*N*(N+1)/2 visits. Only an index makes a teardown proportional to
+  // what that client actually owns.
+  private readonly byClient = new Map<number, Map<number, AbortController>>()
+
+  create(
+    clientId: number,
+    requestId: number
+  ): { key: ClientRequestAbortHandle; controller: AbortController } {
     const controller = new AbortController()
-    this.controllers.set(key, controller)
-    return { key, controller }
+    let requests = this.byClient.get(clientId)
+    if (!requests) {
+      requests = new Map<number, AbortController>()
+      this.byClient.set(clientId, requests)
+    }
+    requests.set(requestId, controller)
+    return { key: { clientId, requestId }, controller }
   }
 
   get(clientId: number, requestId: number): AbortController | undefined {
-    return this.controllers.get(this.key(clientId, requestId))
+    return this.byClient.get(clientId)?.get(requestId)
   }
 
-  delete(key: string): void {
-    this.controllers.delete(key)
+  delete(key: ClientRequestAbortHandle): void {
+    const requests = this.byClient.get(key.clientId)
+    if (!requests) {
+      return
+    }
+    requests.delete(key.requestId)
+    // Why drop the empty bucket: otherwise a churned client leaves an entry behind for the life of
+    // the relay, which is the retention the index exists to avoid.
+    if (requests.size === 0) {
+      this.byClient.delete(key.clientId)
+    }
   }
 
   abortClient(clientId: number): void {
-    const prefix = `${clientId}:`
-    for (const [key, controller] of this.controllers) {
-      if (!key.startsWith(prefix)) {
-        continue
-      }
+    const requests = this.byClient.get(clientId)
+    if (!requests) {
+      return
+    }
+    // Unlink before aborting: an abort listener that reaches back in must not see a half-emptied
+    // bucket, and the whole bucket is going regardless.
+    this.byClient.delete(clientId)
+    for (const controller of requests.values()) {
       controller.abort()
-      this.controllers.delete(key)
     }
   }
 
   abortAll(): void {
-    for (const [, controller] of this.controllers) {
-      controller.abort()
+    const buckets = Array.from(this.byClient.values())
+    this.byClient.clear()
+    for (const requests of buckets) {
+      for (const controller of requests.values()) {
+        controller.abort()
+      }
     }
-    this.controllers.clear()
-  }
-
-  private key(clientId: number, requestId: number): string {
-    return `${clientId}:${requestId}`
   }
 }

--- a/src/relay/dispatcher-capacity-signals.ts
+++ b/src/relay/dispatcher-capacity-signals.ts
@@ -55,7 +55,7 @@ export abstract class RelayDispatcherCapacitySignals extends RelayDispatcherClie
   }
 
   get legacyRetentionBelowLowWater(): boolean {
-    return this.publicationLedger.belowLowWater(this.activeClientKeys())
+    return this.publicationLedger.belowLowWater(() => this.activeClientKeys())
   }
 
   /**
@@ -138,7 +138,7 @@ export abstract class RelayDispatcherCapacitySignals extends RelayDispatcherClie
       this.deferredLegacyCapacity ||= !force
       return
     }
-    if (!force && !this.publicationLedger.belowLowWater(this.activeClientKeys())) {
+    if (!force && !this.publicationLedger.belowLowWater(() => this.activeClientKeys())) {
       return
     }
     for (const listener of this.legacyCapacityListeners) {

--- a/src/relay/dispatcher-per-connection-state-baseline.test.ts
+++ b/src/relay/dispatcher-per-connection-state-baseline.test.ts
@@ -12,7 +12,10 @@ type Probed = {
   clients: Map<number, unknown>
   requestHandlers: Map<string, unknown>
   notificationHandlers: Map<string, unknown>
-  requestAborts: { controllers: Map<string, unknown> }
+  requestAborts: {
+    byClient: Map<number, Map<number, AbortController>>
+    create: (clientId: number, requestId: number) => unknown
+  }
   publicationLedger: { clientBytes: Map<string, number>; aggregateBytes: number }
   pendingRelayRequests: Map<number, unknown>
   clientDetachListeners: Set<unknown>
@@ -26,12 +29,20 @@ type Probed = {
   dispose: () => void
 }
 
+function countAbortControllers(d: Probed): number {
+  let total = 0
+  for (const bucket of d.requestAborts.byClient.values()) {
+    total += bucket.size
+  }
+  return total
+}
+
 function census(d: Probed): Record<string, number | string> {
   return {
     clients: d.clients.size,
     requestHandlers: d.requestHandlers.size,
     notificationHandlers: d.notificationHandlers.size,
-    requestAbortControllers: d.requestAborts.controllers.size,
+    requestAbortControllers: countAbortControllers(d),
     ledgerClientBytes: d.publicationLedger.clientBytes.size,
     ledgerAggregateBytes: d.publicationLedger.aggregateBytes,
     pendingRelayRequests: d.pendingRelayRequests.size,
@@ -65,7 +76,7 @@ describe('relay dispatcher per-connection state', () => {
       }
       for (const id of ids) {
         d.onClientCapacity(id, () => {})
-        d.requestAborts.controllers.set(`${id}:1`, new AbortController())
+        d.requestAborts.create(id, 1)
       }
 
       // The census must be able to find things: these two are the containers that stay 0 unless

--- a/src/relay/dispatcher-per-connection-state-baseline.test.ts
+++ b/src/relay/dispatcher-per-connection-state-baseline.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+
+// Why a census rather than a duration: "the dispatcher releases per-connection state" is a
+// statement about what is still *held* after churn, so it is measured by counting containers,
+// not by timing a teardown. Every number here is exact and load-independent.
+
+type Probed = {
+  attachClient: (w: (b: Buffer) => void) => number
+  detachClient: (id: number) => void
+  onClientCapacity: (id: number, listener: () => void) => (() => void) | null
+  clients: Map<number, unknown>
+  requestHandlers: Map<string, unknown>
+  notificationHandlers: Map<string, unknown>
+  requestAborts: { controllers: Map<string, unknown> }
+  publicationLedger: { clientBytes: Map<string, number>; aggregateBytes: number }
+  pendingRelayRequests: Map<number, unknown>
+  clientDetachListeners: Set<unknown>
+  disposeListeners: Set<unknown>
+  legacyCapacityListeners: Set<unknown>
+  clientCapacityListeners: Map<number, unknown>
+  ptyDataPublicationAdmission: unknown
+  keepaliveTimer: unknown
+  activeClients: () => unknown[]
+  tryPublishToClients: (clients: unknown[], msg: unknown, lane: string) => boolean
+  dispose: () => void
+}
+
+function census(d: Probed): Record<string, number | string> {
+  return {
+    clients: d.clients.size,
+    requestHandlers: d.requestHandlers.size,
+    notificationHandlers: d.notificationHandlers.size,
+    requestAbortControllers: d.requestAborts.controllers.size,
+    ledgerClientBytes: d.publicationLedger.clientBytes.size,
+    ledgerAggregateBytes: d.publicationLedger.aggregateBytes,
+    pendingRelayRequests: d.pendingRelayRequests.size,
+    clientDetachListeners: d.clientDetachListeners.size,
+    disposeListeners: d.disposeListeners.size,
+    legacyCapacityListeners: d.legacyCapacityListeners.size,
+    clientCapacityListeners: d.clientCapacityListeners.size,
+    ptyDataPublicationAdmission: d.ptyDataPublicationAdmission === null ? 'null' : 'set',
+    keepaliveTimer: d.keepaliveTimer === null ? 'null' : 'armed'
+  }
+}
+
+function newDispatcher(): Probed {
+  return new RelayDispatcher(() => {}) as unknown as Probed
+}
+
+const CLIENTS_PER_CYCLE = 100
+
+describe('relay dispatcher per-connection state', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('returns every per-connection container to baseline across repeated churn', () => {
+    vi.useFakeTimers()
+    const d = newDispatcher()
+    const baseline = census(d)
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const ids: number[] = []
+      for (let i = 0; i < CLIENTS_PER_CYCLE; i++) {
+        ids.push(d.attachClient(() => {}))
+      }
+      for (const id of ids) {
+        d.onClientCapacity(id, () => {})
+        d.requestAborts.controllers.set(`${id}:1`, new AbortController())
+      }
+
+      // The census must be able to find things: these two are the containers that stay 0 unless
+      // deliberately loaded, so assert they actually moved before trusting that they came back.
+      expect(census(d).clients).toBe(CLIENTS_PER_CYCLE + 1)
+      expect(census(d).clientCapacityListeners).toBe(CLIENTS_PER_CYCLE)
+      expect(census(d).requestAbortControllers).toBe(CLIENTS_PER_CYCLE)
+
+      d.tryPublishToClients(
+        d.activeClients(),
+        { jsonrpc: '2.0', method: 'pty.data', params: { d: 'x'.repeat(256) } },
+        'bulk'
+      )
+      for (const id of ids) {
+        d.detachClient(id)
+      }
+      expect(census(d)).toEqual(baseline)
+    }
+    d.dispose()
+  })
+
+  // Why this is separate: the ledger is the one container with no per-client teardown. Every other
+  // container is reclaimed by closeClient; a ledger entry is reclaimed only by its own lease's
+  // release(). Normal closes settle every queued and in-flight entry, so this never fires in
+  // practice -- but nothing in the close path would reclaim an entry that did survive.
+  it('does not reclaim a publication-ledger entry on client close', () => {
+    vi.useFakeTimers()
+    const d = newDispatcher()
+    const id = d.attachClient(() => {})
+    d.publicationLedger.clientBytes.set('stranded-key', 4096)
+
+    d.detachClient(id)
+
+    expect(d.clients.size).toBe(1)
+    expect(d.publicationLedger.clientBytes.has('stranded-key')).toBe(true)
+    d.dispose()
+  })
+})

--- a/src/relay/legacy-relay-publication-ledger.ts
+++ b/src/relay/legacy-relay-publication-ledger.ts
@@ -83,11 +83,18 @@ export class LegacyRelayPublicationLedger {
     })
   }
 
-  belowLowWater(clientKeys?: readonly string[]): boolean {
+  // Why the thunk overload: the aggregate ceiling below decides on its own most of the time, and it
+  // decides *first*. A caller passing an eager array has already built one string per client before
+  // learning the keys were never going to be read -- and it pays that most in the loaded case,
+  // because that is exactly when the aggregate check short-circuits.
+  belowLowWater(clientKeys?: readonly string[] | (() => readonly string[])): boolean {
     if (this.aggregateBytes > this.relayLowBytes) {
       return false
     }
-    const keys = clientKeys ?? Array.from(this.clientBytes.keys())
+    const keys =
+      typeof clientKeys === 'function'
+        ? clientKeys()
+        : (clientKeys ?? Array.from(this.clientBytes.keys()))
     return keys.every((clientKey) => (this.clientBytes.get(clientKey) ?? 0) <= this.clientLowBytes)
   }
 

--- a/src/relay/relay-hot-path-operation-counts.test.ts
+++ b/src/relay/relay-hot-path-operation-counts.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+import { ClientRequestAborts } from './client-request-aborts'
+
+// Why operation counts and not milliseconds: each assertion below is about how many entries a hot
+// path visits, which is the property. A duration is only a proxy for it, and a proxy needs a
+// threshold calibrated against observed runtimes -- which makes the test about the observation.
+// These counts are exact and identical under any machine load.
+
+/** Counts entries yielded by a real Map's iterators without changing the code under test. */
+class CountingMap<K, V> extends Map<K, V> {
+  visits = 0
+  getCalls = 0
+
+  private countingIterator<T>(inner: IterableIterator<T>): IterableIterator<T> {
+    const bump = (): void => {
+      this.visits++
+    }
+    return {
+      next(): IteratorResult<T> {
+        const r = inner.next()
+        if (!r.done) {
+          bump()
+        }
+        return r
+      },
+      [Symbol.iterator]() {
+        return this
+      }
+    } as IterableIterator<T>
+  }
+
+  override [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.countingIterator(super[Symbol.iterator]()) as MapIterator<[K, V]>
+  }
+
+  override values(): MapIterator<V> {
+    return this.countingIterator(super.values()) as MapIterator<V>
+  }
+
+  override get(key: K): V | undefined {
+    this.getCalls++
+    return super.get(key)
+  }
+}
+
+type ProbedDispatcher = {
+  attachClient: (w: (b: Buffer) => void) => number
+  clients: Map<number, unknown>
+  publicationLedger: { clientBytes: Map<string, number> }
+  notifyLegacyCapacityIfLow: () => void
+  activeClients: () => unknown[]
+  tryPublishToClients: (clients: unknown[], msg: unknown, lane: string) => boolean
+  dispose: () => void
+}
+
+function dispatcherWithClients(clientCount: number): {
+  d: ProbedDispatcher
+  clients: CountingMap<number, unknown>
+  ledger: CountingMap<string, number>
+} {
+  const d = new RelayDispatcher(() => {}) as unknown as ProbedDispatcher
+  for (let i = 1; i < clientCount; i++) {
+    d.attachClient(() => {})
+  }
+  const clients = new CountingMap<number, unknown>()
+  for (const [k, v] of d.clients) {
+    clients.set(k, v)
+  }
+  d.clients = clients
+  const ledger = new CountingMap<string, number>()
+  d.publicationLedger.clientBytes = ledger
+  clients.visits = 0
+  ledger.getCalls = 0
+  return { d, clients, ledger }
+}
+
+describe('relay hot-path operation counts', () => {
+  afterEach(() => vi.useRealTimers())
+
+  // Why this matters: abortClient runs on every client close and every setWrite. It scans the
+  // whole controller map to find one client's keys, so closing N clients that each hold K
+  // in-flight requests costs K*N*(N+1)/2 key visits -- quadratic in the number of clients, not
+  // linear. Measured: 50 -> 5,100, 100 -> 20,200, 200 -> 80,400, 400 -> 320,800 (4x per doubling).
+  it('abortClient visits every controller, not just the target client', () => {
+    const aborts = new ClientRequestAborts()
+    const controllers = new CountingMap<string, AbortController>()
+    ;(aborts as unknown as { controllers: Map<string, AbortController> }).controllers = controllers
+    const clientCount = 40
+    const inFlightPerClient = 4
+    for (let c = 1; c <= clientCount; c++) {
+      for (let r = 1; r <= inFlightPerClient; r++) {
+        aborts.create(c, r)
+      }
+    }
+
+    controllers.visits = 0
+    aborts.abortClient(1)
+
+    // One client's teardown enumerated the whole map, not its own 4 entries.
+    expect(controllers.visits).toBe(clientCount * inFlightPerClient)
+  })
+
+  it('notifyLegacyCapacity costs exactly one ledger lookup per active client', () => {
+    vi.useFakeTimers()
+    for (const clientCount of [50, 100, 200, 400]) {
+      const { d, clients, ledger } = dispatcherWithClients(clientCount)
+
+      d.notifyLegacyCapacityIfLow()
+
+      expect(clients.visits, `clients enumerated at n=${clientCount}`).toBe(clientCount)
+      expect(ledger.getCalls, `ledger lookups at n=${clientCount}`).toBe(clientCount)
+      d.dispose()
+    }
+  })
+
+  it('one broadcast publication costs a fixed number of lookups per subscriber', () => {
+    vi.useFakeTimers()
+    for (const clientCount of [10, 20, 40]) {
+      const { d, clients, ledger } = dispatcherWithClients(clientCount)
+
+      d.tryPublishToClients(
+        d.activeClients(),
+        { jsonrpc: '2.0', method: 'pty.data', params: { d: 'x' } },
+        'bulk'
+      )
+
+      expect(clients.visits, `clients enumerated at n=${clientCount}`).toBe(clientCount * 2)
+      expect(ledger.getCalls, `ledger lookups at n=${clientCount}`).toBe(clientCount * 4)
+      d.dispose()
+    }
+  })
+})

--- a/src/relay/relay-hot-path-operation-counts.test.ts
+++ b/src/relay/relay-hot-path-operation-counts.test.ts
@@ -78,27 +78,51 @@ function dispatcherWithClients(clientCount: number): {
 describe('relay hot-path operation counts', () => {
   afterEach(() => vi.useRealTimers())
 
-  // Why this matters: abortClient runs on every client close and every setWrite. It scans the
-  // whole controller map to find one client's keys, so closing N clients that each hold K
-  // in-flight requests costs K*N*(N+1)/2 key visits -- quadratic in the number of clients, not
-  // linear. Measured: 50 -> 5,100, 100 -> 20,200, 200 -> 80,400, 400 -> 320,800 (4x per doubling).
-  it('abortClient visits every controller, not just the target client', () => {
-    const aborts = new ClientRequestAborts()
-    const controllers = new CountingMap<string, AbortController>()
-    ;(aborts as unknown as { controllers: Map<string, AbortController> }).controllers = controllers
+  // Why this is the guard and not a duration: abortClient runs on every closeClient and every
+  // setWrite. Under the flat composite-key map it replaced, one client's teardown enumerated every
+  // controller in the relay, so a full churn of N clients holding K requests cost K*N*(N+1)/2 visits
+  // -- measured at 50 -> 5,100, 100 -> 20,200, 200 -> 80,400, 400 -> 320,800, exactly 4x per
+  // doubling. Teardown must now visit only what the client owns, and must not enumerate the client
+  // index at all: enumerating it *is* the old scan.
+  it('abortClient visits only the target client, and never enumerates the client index', () => {
     const clientCount = 40
     const inFlightPerClient = 4
+    const aborts = new ClientRequestAborts()
     for (let c = 1; c <= clientCount; c++) {
       for (let r = 1; r <= inFlightPerClient; r++) {
         aborts.create(c, r)
       }
     }
+    const byClient = (aborts as unknown as { byClient: Map<number, Map<number, AbortController>> })
+      .byClient
 
-    controllers.visits = 0
+    // The census must be able to find things: prove the maps really hold 160 controllers across 40
+    // buckets before asserting that a teardown only touches 4 of them.
+    expect(byClient.size).toBe(clientCount)
+    let totalControllers = 0
+    for (const bucket of byClient.values()) {
+      totalControllers += bucket.size
+    }
+    expect(totalControllers).toBe(clientCount * inFlightPerClient)
+
+    const index = new CountingMap<number, Map<number, AbortController>>()
+    for (const [k, v] of byClient) {
+      index.set(k, v)
+    }
+    const targetBucket = new CountingMap<number, AbortController>()
+    for (const [k, v] of byClient.get(1)!) {
+      targetBucket.set(k, v)
+    }
+    index.set(1, targetBucket)
+    ;(aborts as unknown as { byClient: Map<number, unknown> }).byClient = index
+    index.visits = 0
+    targetBucket.visits = 0
+
     aborts.abortClient(1)
 
-    // One client's teardown enumerated the whole map, not its own 4 entries.
-    expect(controllers.visits).toBe(clientCount * inFlightPerClient)
+    expect(targetBucket.visits).toBe(inFlightPerClient)
+    expect(index.visits).toBe(0)
+    expect(index.has(1)).toBe(false)
   })
 
   it('notifyLegacyCapacity costs exactly one ledger lookup per active client', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​312 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​312 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 |

<!-- /orca-pr-loc -->

## What breaks

`abortClient` runs on **every** `closeClient` and **every** `setWrite`. The controllers were held in one flat map keyed `` `${clientId}:${requestId}` ``, so finding one client's controllers meant walking every controller in the relay.

A full churn of N clients each holding K in-flight requests therefore costs `K·N(N+1)/2` key visits:

| clients | key visits |
|---:|---:|
| 50 | 5,100 |
| 100 | 20,200 |
| 200 | 80,400 |
| 400 | 320,800 |

Exactly 4× per doubling — quadratic, on a path every client teardown and every write-mode change takes.

## The fix

An index from client to its own controllers. `create` returns an opaque handle carrying the owner, so a release finds its bucket without parsing a composite string key. **No call site changes.**

> **Do not "optimise" this back to a scan with an early break.** It cannot work: the matching keys are scattered through the map, so any correct loop still visits every entry before it can know it is done. Only an index makes teardown proportional to what the client owns.

## Also in here

`belowLowWater` decides on the aggregate ceiling first and returns without reading the keys — but the caller had already allocated an N-element array and N template strings to pass them. It pays most in the loaded case, which is exactly when that short-circuit fires. It takes a thunk now.

## The commits

| | |
|---|---|
| `00a53c8598f` | `test(relay)`: measure per-connection teardown and hot-path costs by counting |
| `e38b402a5ec` | `perf(relay)`: index client request aborts instead of scanning every controller |
| `e3accfd0eb1` | `test(relay)`: make the capacity-thunk guard fail when the thunk is removed |
| `62584cd7490` / `87eed18ee34` / `1aaa8937bcc` | `test(relay)`: carry the `SAFETY:` rationale main's casting gate requires |
| `e6202662bd1` | `fix(relay)`: key the abort index by the id's string form so a string id can still be cancelled |
| `c784f8abfec` / `57fa469635f` | merge `origin/main` @ `a61119ceb0f`, then @ `07e8c851b8b` (the first merge predated main's `mock-descendant-sweep.ts` anti-slop exemption, which failed `static analysis` on `c784f8abfec`) |

The test commit lands first and **characterises** the quadratic shape; the perf commit turns the same test into a **guard**. It asserts a teardown visits only the target client's K controllers and never enumerates the client index at all, since enumerating it *is* the old scan. It asserts the maps really hold 160 controllers first, so it cannot pass by never filling them.

**Mutation-verified per production file** (each reverted in turn against the PR's tests; `pnpm test` run serially, `FAIL` lines grepped rather than trusting the exit code):

| reverted file | to | result |
|---|---|---|
| `client-request-aborts.ts` | `main` | 2 fail: `abortClient visits only the target client…`, `returns every per-connection container to baseline…` |
| `client-request-aborts.ts` | pre-coercion PR head `1aaa8937bcc` | 2 fail: the string-id arms of `dispatcher-rpc-cancel-id-coercion.test.ts` |
| `dispatcher-capacity-signals.ts` | `main` | 1 fail: `does not enumerate clients at all once the aggregate ceiling answers` |
| `legacy-relay-publication-ledger.ts` | `main` | 3 fail — all `TypeError: keys.every is not a function`, i.e. the caller's thunk hitting the array-only signature. Noticed, but by a crash rather than by a count. |

Both suites replace a would-be duration with the structural fact the duration was a proxy for, so neither depends on machine load.

## Scope

Measurement harnesses for the *separate* PTY-churn / heap-retention investigation are **not** in this PR — they are four scripts under `config/scripts/` that measure a different thing, and a reviewer taking this perf fix should not have to review them. They are in a sibling PR.

## Verification

At the merge commit `57fa469635f` (branch + `main` @ `07e8c851b8b`, clean merge):

- `pnpm tc` — clean
- `pnpm test` on `dispatcher-rpc-cancel-id-coercion`, `relay-hot-path-operation-counts`, `dispatcher-per-connection-state-baseline`, `dispatcher`, `fs-list-files-cancel.integration` — 5 files / 46 tests passed
- `ORCA_CODE_QUALITY_BASE=origin/main node config/scripts/check-changed-code-quality.mjs` — 0 findings in every gate, including casting and `SAFETY:` rationale
- `oxlint` on the changed files — clean; `oxfmt --check` — clean
- the `static analysis` job's steps locally: `pnpm exec oxlint`, `audit:anti-slop`, `audit:code-quality:native`, `audit:code-quality:type-aware` — all clean

Cherry-picked onto `main` @ `a93e0aea80c` from the `nwparker/j4-index-client-request-aborts` investigation stack, where the fix was buried under an integration merge chain.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts; all 2 commit(s) replayed as-is.

| | SHA |
| --- | --- |
| old head | `b431fa96dd52eaa1186aa998ca36d8bcce055f70` |
| new head | `e38b402a5ec689632b154cfd98dff518ec1be601` |
<!-- /rebase-record -->

## Correction: this is not a pure cost change

The description above claims behaviour is unchanged. That is wrong as written, and someone will rely on it.

The old key was `` `${clientId}:${requestId}` `` — a string coercion. The new inner key is the raw value under `Map`'s SameValueZero. The codec never validates that `id` is a number: `parseJsonRpcMessage` checks only `jsonrpc === '2.0'`, and `dispatcher-frame-codec.ts` dispatches on `'id' in msg && 'method' in msg`. So a peer sending `{"id":"7"}`:

- **before** — stored under `"c:7"`; `rpc.cancel {id:"7"}` coerces via `Number(...)` to the same `"c:7"` and **aborts it**.
- **after** — stored under the string `"7"`; `get(c, 7)` misses and the **cancel is silently dropped**. The request runs to completion and is reclaimed only on `closeClient`.

The same divergence in reverse: the old key collapsed a concurrent numeric `7` and string `"7"` into one slot; the new one keeps both.

This is **unreachable from first-party peers** — `ssh-channel-multiplexer.ts` mints ids with `nextRequestId++`, and the daemon handshake refuses any build with a different bundle hash, so version skew cannot introduce a string-id peer. It was still a behaviour change on a PR that claimed none.

**Resolved in `e6202662bd1`:** the inner key is now `String(requestId)` — the template literal's own coercion — so `7` and `"7"` land in one bucket exactly as the flat map's key did. This is parity with pre-PR behaviour, not a new rule; the alternative (rejecting non-number `id` at the codec) refuses messages that were previously accepted and is deliberately **not** done here. `dispatcher-rpc-cancel-id-coercion.test.ts` feeds raw frames with a numeric id, a string id, and a string request / numeric cancel, and asserts the handler's signal aborts in each case; the two string arms go red against `1aaa8937bcc`.

`abortAll` ordering also changes, from global insertion order to bucket-major. `abortAll` runs only from `dispose()`, and every abort listener in `src/relay` is per-request and `{ once: true }`; the only cross-request coordination is the `fs.listFiles` scan coordinator, which counts attached requesters rather than ordering them. Nothing observes the order.

## Test fixes

Two assertions in this branch did not guard what they claimed. Both are addressed in `e3accfd0eb1`:

- **`notifyLegacyCapacity costs exactly one ledger lookup per active client`** measured an *idle* dispatcher, where the aggregate ceiling never short-circuits and every key is read whichever call shape is used. Reverting the thunk left all five assertions green. It is now scoped and renamed to the idle arm it actually measures, and a **loaded** arm was added that pushes retention past the relay low-water mark through the real reserve path and asserts the client index is not enumerated at all. Reverting the thunk now fails it with `expected 50 to be +0`.
- **`does not reclaim a publication-ledger entry on client close`** is deleted. It asserted that a stranded ledger entry **survives** `detachClient`, which pins a capacity leak as a contract and would have broken whoever later fixed close to release a client's leases. It also used a key (`'stranded-key'`) that no client-keyed reclamation could match, and it touched nothing this branch changes. The churn census in the same file already proves normal closes settle every entry; the residual gap is recorded there as a gap rather than as an expectation.

