### PR TITLE
fix(relay): stop an unreadable session file reporting as a sign-out

### DIFF
--- a/src/main/orca-profiles/profile-cloud-session-refresh.ts
+++ b/src/main/orca-profiles/profile-cloud-session-refresh.ts
@@ -32,6 +32,12 @@ const CLOUD_SESSION_REFRESH_SKEW_MS = 60_000
 export type FreshCloudSessionResult =
   | { status: 'found'; session: OrcaCloudSession }
   | { status: 'reconnect-required' }
+  /**
+   * The session file is there and this process could not read it (EACCES/EBUSY/EMFILE/…). Distinct
+   * from `reconnect-required`, which means the session is genuinely gone: the store refuses to
+   * delete an unreadable session for the same reason a caller must not report one as a sign-out.
+   */
+  | { status: 'unreadable' }
 
 export type CloudSessionOperationResult<T> =
   | { status: 'ok'; value: T }
@@ -226,6 +232,9 @@ export async function readFreshOrcaCloudSession(
   userDataPath: string
 ): Promise<FreshCloudSessionResult> {
   const session = readOrcaCloudSession(active.profile.id, userDataPath)
+  if (session.status === 'unreadable') {
+    return { status: 'unreadable' }
+  }
   if (session.status !== 'found') {
     return { status: 'reconnect-required' }
   }

--- a/src/main/runtime/relay/relay-auth-context-unreadable-session.test.ts
+++ b/src/main/runtime/relay/relay-auth-context-unreadable-session.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RELAY_HOST_CLOSE_REASON } from '../../../shared/relay-host-close-reason'
+
+const fakes = vi.hoisted(() => ({
+  ensureActiveOrcaProfile: vi.fn(),
+  readFreshOrcaCloudSession: vi.fn()
+}))
+
+vi.mock('../../orca-profiles/profile-index-store', () => ({
+  ensureActiveOrcaProfile: fakes.ensureActiveOrcaProfile
+}))
+vi.mock('../../orca-profiles/profile-cloud-session-refresh', () => ({
+  readFreshOrcaCloudSession: fakes.readFreshOrcaCloudSession
+}))
+
+import { readRelayAuthContext } from './relay-auth-context'
+import { RelayAuthCoordinator } from './relay-auth-coordinator'
+
+const profile = {
+  profile: {
+    id: 'profile-1',
+    cloud: { userId: 'u1', cloudProfileId: 'cp1', activeOrgId: 'org-1' }
+  }
+}
+
+const authConfig = {} as never
+
+describe('readRelayAuthContext session-read taxonomy', () => {
+  it('refuses to call an unreadable session file a sign-out', async () => {
+    // EACCES/EBUSY/EMFILE on the session file means "present, could not read it" — the store
+    // itself declines to delete one for that reason. Reporting it as signed-out tells every
+    // paired phone to sign in on the desktop for a failure a retry would have cleared.
+    fakes.ensureActiveOrcaProfile.mockReturnValue(profile)
+    fakes.readFreshOrcaCloudSession.mockResolvedValue({ status: 'unreadable' })
+
+    await expect(readRelayAuthContext(authConfig, '/tmp/x')).rejects.toThrow(
+      'orca_cloud_session_unreadable'
+    )
+  })
+
+  it('still reports a genuinely absent session as gone', async () => {
+    fakes.ensureActiveOrcaProfile.mockReturnValue(profile)
+    fakes.readFreshOrcaCloudSession.mockResolvedValue({ status: 'reconnect-required' })
+
+    await expect(readRelayAuthContext(authConfig, '/tmp/x')).resolves.toBeNull()
+  })
+
+  it('classifies an unreadable session as auth_unavailable, never signed_out', async () => {
+    fakes.ensureActiveOrcaProfile.mockReturnValue(profile)
+    fakes.readFreshOrcaCloudSession.mockResolvedValue({ status: 'unreadable' })
+    const broker = { closeNow: vi.fn() }
+    const coordinator = new RelayAuthCoordinator({
+      readContext: () => readRelayAuthContext(authConfig, '/tmp/x'),
+      openBroker: async () => broker,
+      onStatus: vi.fn()
+    })
+    coordinator.reconcile()
+
+    const result = await coordinator.waitForLiveBrokerResult(0)
+    expect(result).toEqual({ broker: null, offlineReason: 'auth_unavailable' })
+    expect(result.broker).toBeNull()
+    // The wire close reason is what the phone latches on; it must not be spent here.
+    expect(broker.closeNow).not.toHaveBeenCalledWith(RELAY_HOST_CLOSE_REASON.SIGNED_OUT)
+  })
+})

--- a/src/main/runtime/relay/relay-auth-context.ts
+++ b/src/main/runtime/relay/relay-auth-context.ts
@@ -12,6 +12,12 @@ export async function readRelayAuthContext(
     return null
   }
   const session = await readFreshOrcaCloudSession(authConfig, active, userDataPath)
+  // Why throw rather than return null: the coordinator reads null as "the cloud session is gone"
+  // and closes every paired phone's relay with signed-out, arming no retry. A session file this
+  // process could not read is intact, so the retryable auth_unavailable path is the honest word.
+  if (session.status === 'unreadable') {
+    throw new Error('orca_cloud_session_unreadable')
+  }
   if (session.status !== 'found') {
     return null
   }

--- a/src/main/runtime/relay/relay-auth-coordinator.ts
+++ b/src/main/runtime/relay/relay-auth-coordinator.ts
@@ -189,9 +189,12 @@ export class RelayAuthCoordinator {
       if (!context || !context.relayEntitled) {
         this.cancelLinger()
         this.retry.reset()
-        // Why only the null case: readContext throws on transient failures and
-        // returns null solely when the cloud session is gone (absent, or cleared
-        // by a 401). A present-but-unentitled context is still a signed-in
+        // Why only the null case: null must mean the cloud session is gone (absent, or cleared
+        // by a 401), and every other read outcome must throw so it lands in auth_unavailable.
+        // That is a contract readRelayAuthContext owes this branch, not something this branch
+        // can verify — it held for a refresh failure but not for a session file the process
+        // could not read, which spent SIGNED_OUT on transient I/O until relay-auth-context.ts
+        // started throwing for it. A present-but-unentitled context is still a signed-in
         // desktop, and "sign in to reconnect" would be wrong advice for it.
         this.invalidateOwnership(context ? undefined : RELAY_HOST_CLOSE_REASON.SIGNED_OUT)
         this.publish('offline', context ? 'not_entitled' : RELAY_HOST_CLOSE_REASON.SIGNED_OUT)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

> **Stacked on #19870** (`fix/18211-lan-mode-applies-to-paired-devices`). Review the top commit only.

## What breaks

The coordinator's own comment states the contract: `readContext` *"throws on transient failures and returns null solely when the cloud session is gone (absent, or cleared by a 401)"*. The implementation did not honour it.

`readFreshOrcaCloudSession` collapsed `readOrcaCloudSession`'s **`unreadable`** status into `reconnect-required`. So `readRelayAuthContext` returned `null`, and the coordinator published `RELAY_HOST_CLOSE_REASON.SIGNED_OUT`, closed the broker with that wire reason, and **armed no retry** — because a terminal cause arms none.

`unreadable` fires on `EPERM` / `EACCES` / `EBUSY` / `EMFILE` / `ENFILE` / `EIO` — descriptor exhaustion on a busy machine, a Windows AV file lock. The phone latches `setHostSignedOut` and shows *"Desktop signed out — sign in to Orca on your desktop to reconnect"* for a failure the next read would have cleared.

## Why `unreadable` in particular

It is the one status the session store's own doc says **"licenses nothing"**, and `clearCloudSessionIfUnchanged` already refuses to delete a session because of it — *"a session we were denied is not a session we may delete."* The relay taxonomy was the single place treating it as evidence the user signed out.

## The fix

Give it its own arm on `FreshCloudSessionResult` and throw for it in `readRelayAuthContext`, which lands it on the retryable `auth_unavailable` path the coordinator already has.

Every other caller tests `status !== 'found'`, so their behaviour is unchanged.

The coordinator comment is corrected to say what it actually depends on: **null-means-gone is a contract `readRelayAuthContext` owes it, not something that branch can verify.**

**Measured before:** `offlineReason: "signed-out"`, mint code `relay_signed_out`. **After:** `auth_unavailable`.

## Not fixed here, deliberately

`decrypt-failed` when `safeStorage.isEncryptionAvailable()` is false — a Linux keyring still locked at login — takes the same route to `SIGNED_OUT`. Reclassifying it changes sign-in semantics well beyond the relay and needs its own change.

## Why this has its own PR

It is the sibling of the fix in **#19963** (`fix(relay): stop a mid-read profile switch reporting as a sign-out`) — the same taxonomy error in the *other* `null` exit of the same function. #19963's commit cites this one by SHA and its code comment reads *"same argument as the unreadable session above"*, which only resolves once this lands. #19963 is stacked directly on this branch for that reason.

Until now this commit lived only on the un-PR'd integration branch `nwparker/relay-taxonomy-fixes`, so a reviewer merging #19963 would have silently missed it.

## Verification

`tsc --noEmit -p config/tsconfig.node.json` clean · `src/main/runtime/relay` + `src/main/startup` — **76 files / 661 tests passed, 2 files / 8 tests skipped**, 0 failures · `oxlint` clean.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Stack preserved: base stays `fix/18211-lan-mode-applies-to-paired-devices` (#19870), which was rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c` first. This branch was replayed with `git rebase --onto 13eee7eacf8a6fcd4bb77ff680d18f727fca1171 9ce190247edbdb508b452e8c62a63c4c2cdd0089`.

| | SHA |
| --- | --- |
| old head | `aff7b40fff5112e9806a0a7f9c297f01cef77936` |
| new head | `0dc273fd9090210d41ea50af66c7edfdca32a57c` |
| new base (#19870) | `13eee7eacf8a6fcd4bb77ff680d18f727fca1171` |

No conflicts. The PR is still the single top commit above its base.
<!-- /rebase-record -->
