### PR TITLE
test(relay): measure per-connection teardown and hot-path costs by counting

### DIFF
--- a/src/relay/dispatcher-per-connection-state-baseline.test.ts
+++ b/src/relay/dispatcher-per-connection-state-baseline.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+
+// Why a census rather than a duration: "the dispatcher releases per-connection state" is a
+// statement about what is still *held* after churn, so it is measured by counting containers,
+// not by timing a teardown. Every number here is exact and load-independent.
+
+type Probed = {
+  attachClient: (w: (b: Buffer) => void) => number
+  detachClient: (id: number) => void
+  onClientCapacity: (id: number, listener: () => void) => (() => void) | null
+  clients: Map<number, unknown>
+  requestHandlers: Map<string, unknown>
+  notificationHandlers: Map<string, unknown>
+  requestAborts: { controllers: Map<string, unknown> }
+  publicationLedger: { clientBytes: Map<string, number>; aggregateBytes: number }
+  pendingRelayRequests: Map<number, unknown>
+  clientDetachListeners: Set<unknown>
+  disposeListeners: Set<unknown>
+  legacyCapacityListeners: Set<unknown>
+  clientCapacityListeners: Map<number, unknown>
+  ptyDataPublicationAdmission: unknown
+  keepaliveTimer: unknown
+  activeClients: () => unknown[]
+  tryPublishToClients: (clients: unknown[], msg: unknown, lane: string) => boolean
+  dispose: () => void
+}
+
+function census(d: Probed): Record<string, number | string> {
+  return {
+    clients: d.clients.size,
+    requestHandlers: d.requestHandlers.size,
+    notificationHandlers: d.notificationHandlers.size,
+    requestAbortControllers: d.requestAborts.controllers.size,
+    ledgerClientBytes: d.publicationLedger.clientBytes.size,
+    ledgerAggregateBytes: d.publicationLedger.aggregateBytes,
+    pendingRelayRequests: d.pendingRelayRequests.size,
+    clientDetachListeners: d.clientDetachListeners.size,
+    disposeListeners: d.disposeListeners.size,
+    legacyCapacityListeners: d.legacyCapacityListeners.size,
+    clientCapacityListeners: d.clientCapacityListeners.size,
+    ptyDataPublicationAdmission: d.ptyDataPublicationAdmission === null ? 'null' : 'set',
+    keepaliveTimer: d.keepaliveTimer === null ? 'null' : 'armed'
+  }
+}
+
+function newDispatcher(): Probed {
+  return new RelayDispatcher(() => {}) as unknown as Probed
+}
+
+const CLIENTS_PER_CYCLE = 100
+
+describe('relay dispatcher per-connection state', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('returns every per-connection container to baseline across repeated churn', () => {
+    vi.useFakeTimers()
+    const d = newDispatcher()
+    const baseline = census(d)
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const ids: number[] = []
+      for (let i = 0; i < CLIENTS_PER_CYCLE; i++) {
+        ids.push(d.attachClient(() => {}))
+      }
+      for (const id of ids) {
+        d.onClientCapacity(id, () => {})
+        d.requestAborts.controllers.set(`${id}:1`, new AbortController())
+      }
+
+      // The census must be able to find things: these two are the containers that stay 0 unless
+      // deliberately loaded, so assert they actually moved before trusting that they came back.
+      expect(census(d).clients).toBe(CLIENTS_PER_CYCLE + 1)
+      expect(census(d).clientCapacityListeners).toBe(CLIENTS_PER_CYCLE)
+      expect(census(d).requestAbortControllers).toBe(CLIENTS_PER_CYCLE)
+
+      d.tryPublishToClients(
+        d.activeClients(),
+        { jsonrpc: '2.0', method: 'pty.data', params: { d: 'x'.repeat(256) } },
+        'bulk'
+      )
+      for (const id of ids) {
+        d.detachClient(id)
+      }
+      expect(census(d)).toEqual(baseline)
+    }
+    d.dispose()
+  })
+
+  // Why this is separate: the ledger is the one container with no per-client teardown. Every other
+  // container is reclaimed by closeClient; a ledger entry is reclaimed only by its own lease's
+  // release(). Normal closes settle every queued and in-flight entry, so this never fires in
+  // practice -- but nothing in the close path would reclaim an entry that did survive.
+  it('does not reclaim a publication-ledger entry on client close', () => {
+    vi.useFakeTimers()
+    const d = newDispatcher()
+    const id = d.attachClient(() => {})
+    d.publicationLedger.clientBytes.set('stranded-key', 4096)
+
+    d.detachClient(id)
+
+    expect(d.clients.size).toBe(1)
+    expect(d.publicationLedger.clientBytes.has('stranded-key')).toBe(true)
+    d.dispose()
+  })
+})

--- a/src/relay/relay-hot-path-operation-counts.test.ts
+++ b/src/relay/relay-hot-path-operation-counts.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+import { ClientRequestAborts } from './client-request-aborts'
+
+// Why operation counts and not milliseconds: each assertion below is about how many entries a hot
+// path visits, which is the property. A duration is only a proxy for it, and a proxy needs a
+// threshold calibrated against observed runtimes -- which makes the test about the observation.
+// These counts are exact and identical under any machine load.
+
+/** Counts entries yielded by a real Map's iterators without changing the code under test. */
+class CountingMap<K, V> extends Map<K, V> {
+  visits = 0
+  getCalls = 0
+
+  private countingIterator<T>(inner: IterableIterator<T>): IterableIterator<T> {
+    const bump = (): void => {
+      this.visits++
+    }
+    return {
+      next(): IteratorResult<T> {
+        const r = inner.next()
+        if (!r.done) {
+          bump()
+        }
+        return r
+      },
+      [Symbol.iterator]() {
+        return this
+      }
+    } as IterableIterator<T>
+  }
+
+  override [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.countingIterator(super[Symbol.iterator]()) as MapIterator<[K, V]>
+  }
+
+  override values(): MapIterator<V> {
+    return this.countingIterator(super.values()) as MapIterator<V>
+  }
+
+  override get(key: K): V | undefined {
+    this.getCalls++
+    return super.get(key)
+  }
+}
+
+type ProbedDispatcher = {
+  attachClient: (w: (b: Buffer) => void) => number
+  clients: Map<number, unknown>
+  publicationLedger: { clientBytes: Map<string, number> }
+  notifyLegacyCapacityIfLow: () => void
+  activeClients: () => unknown[]
+  tryPublishToClients: (clients: unknown[], msg: unknown, lane: string) => boolean
+  dispose: () => void
+}
+
+function dispatcherWithClients(clientCount: number): {
+  d: ProbedDispatcher
+  clients: CountingMap<number, unknown>
+  ledger: CountingMap<string, number>
+} {
+  const d = new RelayDispatcher(() => {}) as unknown as ProbedDispatcher
+  for (let i = 1; i < clientCount; i++) {
+    d.attachClient(() => {})
+  }
+  const clients = new CountingMap<number, unknown>()
+  for (const [k, v] of d.clients) {
+    clients.set(k, v)
+  }
+  d.clients = clients
+  const ledger = new CountingMap<string, number>()
+  d.publicationLedger.clientBytes = ledger
+  clients.visits = 0
+  ledger.getCalls = 0
+  return { d, clients, ledger }
+}
+
+describe('relay hot-path operation counts', () => {
+  afterEach(() => vi.useRealTimers())
+
+  // Why this matters: abortClient runs on every client close and every setWrite. It scans the
+  // whole controller map to find one client's keys, so closing N clients that each hold K
+  // in-flight requests costs K*N*(N+1)/2 key visits -- quadratic in the number of clients, not
+  // linear. Measured: 50 -> 5,100, 100 -> 20,200, 200 -> 80,400, 400 -> 320,800 (4x per doubling).
+  it('abortClient visits every controller, not just the target client', () => {
+    const aborts = new ClientRequestAborts()
+    const controllers = new CountingMap<string, AbortController>()
+    ;(aborts as unknown as { controllers: Map<string, AbortController> }).controllers = controllers
+    const clientCount = 40
+    const inFlightPerClient = 4
+    for (let c = 1; c <= clientCount; c++) {
+      for (let r = 1; r <= inFlightPerClient; r++) {
+        aborts.create(c, r)
+      }
+    }
+
+    controllers.visits = 0
+    aborts.abortClient(1)
+
+    // One client's teardown enumerated the whole map, not its own 4 entries.
+    expect(controllers.visits).toBe(clientCount * inFlightPerClient)
+  })
+
+  it('notifyLegacyCapacity costs exactly one ledger lookup per active client', () => {
+    vi.useFakeTimers()
+    for (const clientCount of [50, 100, 200, 400]) {
+      const { d, clients, ledger } = dispatcherWithClients(clientCount)
+
+      d.notifyLegacyCapacityIfLow()
+
+      expect(clients.visits, `clients enumerated at n=${clientCount}`).toBe(clientCount)
+      expect(ledger.getCalls, `ledger lookups at n=${clientCount}`).toBe(clientCount)
+      d.dispose()
+    }
+  })
+
+  it('one broadcast publication costs a fixed number of lookups per subscriber', () => {
+    vi.useFakeTimers()
+    for (const clientCount of [10, 20, 40]) {
+      const { d, clients, ledger } = dispatcherWithClients(clientCount)
+
+      d.tryPublishToClients(
+        d.activeClients(),
+        { jsonrpc: '2.0', method: 'pty.data', params: { d: 'x' } },
+        'bulk'
+      )
+
+      expect(clients.visits, `clients enumerated at n=${clientCount}`).toBe(clientCount * 2)
+      expect(ledger.getCalls, `ledger lookups at n=${clientCount}`).toBe(clientCount * 4)
+      d.dispose()
+    }
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​239 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​239 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Test-only. Two suites that pin relay cost as **operation counts**, on `main`, with no production change.

## Why counts and not milliseconds

Each assertion is about **how many entries a hot path visits**, which is the actual property. A duration is only a proxy for it, and a proxy needs a threshold calibrated against observed runtimes — which makes the test about the observation rather than the code. These counts are exact and identical under any machine load, so they do not flake on a loaded CI box.

## What they pin

**`relay-hot-path-operation-counts.test.ts`**
- `abortClient` visits every controller, not just the target client's — the cost is `clientCount * inFlightPerClient`, pinned literally so the fan-out is visible rather than assumed.
- `notifyLegacyCapacity` costs exactly one ledger lookup per active client.
- One broadcast publication costs a fixed number of lookups per subscriber (`clientCount * 2` enumerations, `clientCount * 4` ledger lookups).

**`dispatcher-per-connection-state-baseline.test.ts`**
- Every per-connection container returns to baseline across repeated churn.
- `does not reclaim a publication-ledger entry on client close` — pins a known gap as a fact, so a future change that closes it turns the cell red on purpose rather than silently.

## How they measure

A `CountingMap` subclass of a real `Map` instruments the iterators **without changing the code under test**. The suites drive the real `RelayDispatcher` and `ClientRequestAborts`, not a paraphrase of them.

## Verification

- 5 passed, on `main`, under the project config (`config/vitest.config.ts`).
- Typecheck clean (`tsconfig.node.json`, config verified to resolve — not a TS5058 phantom).
- Green alone is not evidence, so the wiring was proven by mutation: rewriting `abortClient` to pre-filter the keys instead of scanning the map **fails the fan-out row**. The counts track the real production path rather than a local fixture.

## Split note

Lifted off `nwparker/j4-upgrade-downgrade-stack-v2`, which had no PR and carried these measurement suites together with an unrelated CLI/relay connect-bound fix (now **#20049**) and duplicate copies of the cross-version skew suites (now **#20056**). These cherry-pick clean onto `main` and stand on their own.
