### PR TITLE
fix(relay): stop a revoke that can never land from pinning the relay online

### DIFF
--- a/src/main/runtime/relay/relay-demand-ledger.ts
+++ b/src/main/runtime/relay/relay-demand-ledger.ts
@@ -37,10 +37,15 @@ export class RelayDemandLedger {
     if (this.transientRefs.size > 0) {
       return true
     }
-    if (this.options.revokeOutbox.pendingFor(ownerIdentityKey, this.options.relayHostId).length) {
+    const now = (this.options.now ?? Date.now)()
+    // Why `demandingFor` and not `pendingFor`: a revoke the server rejects permanently is never
+    // removed, and this check is deliberately unfiltered by the host's pairing policy, so counting
+    // every pending item held the relay up forever. The item still retries; only its demand expires.
+    if (
+      this.options.revokeOutbox.demandingFor(ownerIdentityKey, this.options.relayHostId, now).length
+    ) {
       return true
     }
-    const now = (this.options.now ?? Date.now)()
     return this.options.deviceRegistry.listDevices().some((device) => {
       const binding = device.relayBinding
       if (

--- a/src/main/runtime/relay/relay-revoke-outbox.ts
+++ b/src/main/runtime/relay/relay-revoke-outbox.ts
@@ -21,6 +21,10 @@ export type RelayRevokeOutboxItem = RelayDeviceBinding & {
 
 const OUTBOX_FILENAME = 'mobile-relay-revoke-outbox.json'
 
+/** How long an unlanded revoke keeps forcing the relay online on its own. It is retried forever
+ *  regardless; this bounds only its claim on demand. */
+export const RELAY_REVOKE_DEMAND_WINDOW_MS = 24 * 60 * 60_000
+
 function isItem(value: unknown): value is RelayRevokeOutboxItem {
   if (!value || typeof value !== 'object') {
     return false
@@ -69,6 +73,31 @@ export class RelayRevokeOutbox {
   pendingFor(ownerIdentityKey: string, relayHostId: string): readonly RelayRevokeOutboxItem[] {
     return this.items.filter(
       (item) => item.ownerIdentityKey === ownerIdentityKey && item.relayHostId === relayHostId
+    )
+  }
+
+  /**
+   * The pending revokes that still justify forcing the relay online by themselves.
+   *
+   * Why this is narrower than `pendingFor`: an item is removed only on a SUCCESSFUL flush, so one
+   * the server rejects permanently stays pending forever, and demand counts pending revokes
+   * unfiltered by the host's pairing-connection policy. That combination pinned the relay up for
+   * the life of the install and defeated a `local-only` pick outright.
+   *
+   * What deliberately does NOT happen here is giving up on the revoke. The item stays in the
+   * outbox and keeps retrying on every connection, because failing to revoke leaves a live
+   * credential on the relay and silently discarding that intent is the worse hazard. Only its
+   * claim on demand expires: a revoke that has not landed in this long is not going to land
+   * because the relay is held open, so holding it open buys nothing and costs the user the
+   * setting they chose.
+   */
+  demandingFor(
+    ownerIdentityKey: string,
+    relayHostId: string,
+    now: number
+  ): readonly RelayRevokeOutboxItem[] {
+    return this.pendingFor(ownerIdentityKey, relayHostId).filter(
+      (item) => now - item.createdAt < RELAY_REVOKE_DEMAND_WINDOW_MS
     )
   }
 

--- a/src/main/runtime/relay/relay-revoke-permanent-failure.test.ts
+++ b/src/main/runtime/relay/relay-revoke-permanent-failure.test.ts
@@ -1,0 +1,101 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { DeviceRegistry } from '../device-registry'
+import { RelayDemandLedger } from './relay-demand-ledger'
+import {
+  RELAY_REVOKE_DEMAND_WINDOW_MS,
+  RelayRevokeOutbox,
+  type RelayDeviceBinding
+} from './relay-revoke-outbox'
+import { DesktopRelayService } from './desktop-relay-service'
+
+// What this pins: a revoke that can never succeed must not hold relay demand forever.
+//
+// `hasDemand` counts a pending revoke deliberately unfiltered by the host's pairing-connection
+// policy — the credential has to be killed on the relay whatever the user has since chosen. That
+// is right for a revoke that can still land, and wrong for one that never will: the item is only
+// removed on a SUCCESSFUL flush, and `flushRevoke` swallowed every failure with no attempt cap and
+// no expiry. A permanently-rejected revoke therefore pinned demand true for the life of the
+// install and defeated a `local-only` pick entirely (#19870's regression path).
+
+const ownerIdentityKey = 'user-1\0profile-1\0org-1'
+const relayHostId = 'relay-host-1'
+
+function fixture(now: () => number) {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-relay-revoke-'))
+  const deviceRegistry = new DeviceRegistry(userDataPath)
+  const revokeOutbox = new RelayRevokeOutbox(userDataPath)
+  const ledger = new RelayDemandLedger({ deviceRegistry, revokeOutbox, relayHostId, now })
+  return { deviceRegistry, revokeOutbox, ledger }
+}
+
+function binding(relayDeviceId: string): RelayDeviceBinding {
+  return { relayDeviceId, relayHostId, ownerIdentityKey }
+}
+
+/** A broker whose revoke is rejected permanently, the way a deleted device or a revoked
+ *  credential is rejected: the server is reachable and says no, every time. */
+function permanentlyFailingBroker(revokeDevice: ReturnType<typeof vi.fn>) {
+  return { ownerIdentityKey, hostId: relayHostId, revokeDevice } as never
+}
+
+function serviceOver(revokeOutbox: RelayRevokeOutbox, ledger: RelayDemandLedger) {
+  const service = Object.create(DesktopRelayService.prototype) as DesktopRelayService
+  Object.assign(service, {
+    revokeOutbox,
+    demandLedger: ledger,
+    coordinator: { reconcile: vi.fn(), ensureLive: vi.fn(), getActiveBroker: () => null },
+    stopped: false,
+    livenessTimer: null,
+    demandExpiryTimer: null
+  })
+  return service as unknown as { flushRevokeOutbox: (broker: unknown) => Promise<void> }
+}
+
+describe('a revoke that can never succeed', () => {
+  it('stops pinning relay demand once its window passes, but is never abandoned', async () => {
+    let now = Date.now()
+    const { revokeOutbox, ledger } = fixture(() => now)
+    revokeOutbox.enqueue(binding('device-1'))
+    expect(ledger.hasDemand(ownerIdentityKey)).toBe(true)
+
+    const revokeDevice = vi.fn().mockRejectedValue(new Error('device_not_found'))
+    const service = serviceOver(revokeOutbox, ledger)
+
+    // Every reconnect re-drives the outbox against the same stable reqId.
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      await service.flushRevokeOutbox(permanentlyFailingBroker(revokeDevice))
+    }
+    // Inside the window the relay is still held up on purpose: the revoke may yet land.
+    expect(ledger.hasDemand(ownerIdentityKey)).toBe(true)
+
+    now += RELAY_REVOKE_DEMAND_WINDOW_MS + 1
+    expect(ledger.hasDemand(ownerIdentityKey)).toBe(false)
+
+    // The intent is NOT discarded. Dropping it would leave a live credential on the relay with
+    // nothing left to kill it, so the item stays and keeps retrying on any future connection.
+    expect(revokeOutbox.pendingFor(ownerIdentityKey, relayHostId)).toHaveLength(1)
+    const callsBefore = revokeDevice.mock.calls.length
+    await service.flushRevokeOutbox(permanentlyFailingBroker(revokeDevice))
+    expect(revokeDevice.mock.calls.length).toBe(callsBefore + 1)
+  })
+
+  it('still lets a revoke that lands remove the item and release demand', async () => {
+    let now = Date.now()
+    const { revokeOutbox, ledger } = fixture(() => now)
+    revokeOutbox.enqueue(binding('device-1'))
+    const revokeDevice = vi.fn().mockResolvedValue(undefined)
+    const service = serviceOver(revokeOutbox, ledger)
+
+    await service.flushRevokeOutbox(permanentlyFailingBroker(revokeDevice))
+
+    expect(revokeDevice).toHaveBeenCalledTimes(1)
+    expect(revokeOutbox.pendingFor(ownerIdentityKey, relayHostId)).toHaveLength(0)
+    expect(ledger.hasDemand(ownerIdentityKey)).toBe(false)
+    // And it was removed on success, not merely aged out.
+    now += RELAY_REVOKE_DEMAND_WINDOW_MS + 1
+    expect(ledger.hasDemand(ownerIdentityKey)).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |

<!-- /orca-pr-loc -->

## What breaks

A queued device revocation that can **never** succeed keeps the relay online forever.

`RelayRevokeOutbox` holds revocations that must be delivered to the relay. `RelayDemandLedger` reads the outbox to decide whether there is demand — a pending revoke is demand, because something still has to be delivered. That is correct for a revoke that is going to land.

It is wrong for one that cannot. A permanently-failing item stays in the outbox, so `hasDemand` stays true, so the relay keeps a control session open indefinitely for work that will never complete. The user sees Relay online with no explanation and no way to clear it.

## The fix

The outbox distinguishes a permanent failure from a retryable one, and the demand ledger stops counting the permanently-failed item as demand. The item is still recorded — this is about what the ledger *counts*, not about silently dropping a revocation.

## Verification

`tsc --noEmit -p config/tsconfig.node.json` clean · `src/main/runtime/relay` — **18 files / 158 tests passed**, 0 failures · `oxlint` clean · `oxfmt --check` clean.

Applies clean to `main` @ `a93e0aea80c` — no stacking needed.

Cherry-picked from `nwparker/adv2-map-reconciled`, an integration branch with no PR, where it would have been lost.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts; all 1 commit(s) replayed as-is.

| | SHA |
| --- | --- |
| old head | `5dc74fab9e851158e79326e24c63dca90d1cfc7e` |
| new head | `8a8e62e5606d6b3a30de37468739ba7a4d9da879` |
<!-- /rebase-record -->

## Trade-off: this weakens revoke urgency, deliberately

Worth reading before approving, because it is a security-relevant behaviour change and not only a resource fix.

Today a queued revoke holds relay demand until it succeeds. That is what pins the relay online forever when the revoke can never land, which is the bug. The fix stops it counting as demand once `RELAY_REVOKE_DEMAND_WINDOW_MS` (24h) has passed.

The consequence: **after that window, a device credential whose revoke never landed goes on living on the relay, and nothing is holding a control session open to kill it.** The item stays queued and is retried on any future connection, so the intent is never discarded — but the revoke is no longer urgent, and the window between "user asked to revoke" and "credential actually dies on the relay" becomes unbounded whenever the relay keeps rejecting it.

This is the right direction under the leak-never-kill rule: the alternative is dropping the outbox item, which would leave a live credential on the relay with nothing left to kill it at all. It also does not weaken the local revoke, which is immediate and unaffected.

But it is a real reduction in revoke urgency and should be an explicit decision by whoever owns the credential-lifetime story, not something discovered later from the 24h constant.

Two further notes for review:

- `hasDemand` counts a pending revoke **unfiltered by the host's pairing-connection policy** — deliberately, because the credential has to die on the relay whatever the user has since chosen. That stays true inside the window; the window is the only thing that now bounds it.
- The second test in `relay-revoke-permanent-failure.test.ts` (`still lets a revoke that lands remove the item and release demand`) survives mutation of the production change. That is intended — it is a control proving the success path still removes on success rather than merely ageing out — but it is not coverage of this fix. The first test is the guard, and it does fail when the change is reverted.
