### PR TITLE
fix(relay): a throwing retry step must not kill the retry chain

### DIFF
--- a/src/main/runtime/relay/relay-retry-schedule.test.ts
+++ b/src/main/runtime/relay/relay-retry-schedule.test.ts
@@ -27,6 +27,32 @@ describe('RelayRetrySchedule', () => {
     expect(schedule.settled).toBeNull()
   })
 
+  // Why this matters beyond the throw itself: the retry callback is the caller's whole recovery
+  // step (the origin pool's `handleDrain` reaches `onStatus` -> `webContents.send`). A throw used
+  // to escape the timer AND skip the resolve, parking every `settled` waiter on a promise nothing
+  // would settle while the schedule held no armed timer — dead with no re-entry.
+  it('settles and stays reschedulable when the retry throws', async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const schedule = new RelayRetrySchedule(() => 0.5)
+    schedule.schedule(0, () => {
+      throw new Error('recovery step blew up')
+    })
+    const settled = schedule.settled!
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(settled).resolves.toBeUndefined()
+    expect(schedule.pending).toBe(false)
+    expect(consoleError).toHaveBeenCalled()
+
+    const next = vi.fn()
+    schedule.schedule(0, next)
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(next).toHaveBeenCalledTimes(1)
+    consoleError.mockRestore()
+  })
+
   it('settles on cancel without running the retry', async () => {
     vi.useFakeTimers()
     const schedule = new RelayRetrySchedule(() => 0.5)

--- a/src/main/runtime/relay/relay-retry-schedule.ts
+++ b/src/main/runtime/relay/relay-retry-schedule.ts
@@ -28,8 +28,18 @@ export class RelayRetrySchedule {
     this.timer = setTimeout(() => {
       this.timer = null
       this.armed = null
-      retry()
-      armed.resolve()
+      // Why contained: `retry` is the caller's whole recovery step, run bare inside a timer. A
+      // synchronous throw there escaped as an uncaughtException AND skipped the resolve, so every
+      // waiter on `settled` parked on a promise nothing would ever settle, while the schedule was
+      // left with no armed timer — the chain dead with no re-entry. Waking the waiters is right
+      // either way: the retry is over, however it ended.
+      try {
+        retry()
+      } catch (error) {
+        console.error('[relay] scheduled retry threw:', error)
+      } finally {
+        armed.resolve()
+      }
     }, delayMs)
   }
 

--- a/src/main/startup/main-process-relay-status.ts
+++ b/src/main/startup/main-process-relay-status.ts
@@ -14,5 +14,10 @@ export function publishDesktopRelayStatus(
 ): void {
   state.desktopRelayStatus = status
   state.desktopRelayCellUrl = cellUrl
-  state.mainWindow?.webContents.send('mobile:relayStatusChanged', getDesktopRelayStatus())
+  // Why isDestroyed and not just the optional chain: `state.mainWindow` is nulled on 'closed',
+  // so between destroy and that event `webContents.send` throws "Object has been destroyed".
+  // This runs from inside a bare `setTimeout` recovery step, where a throw killed the retry chain.
+  if (state.mainWindow && !state.mainWindow.isDestroyed()) {
+    state.mainWindow.webContents.send('mobile:relayStatusChanged', getDesktopRelayStatus())
+  }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |

<!-- /orca-pr-loc -->

> **Stacked on #19870** (`fix/18211-lan-mode-applies-to-paired-devices`). Review the top commit only.

## What breaks

`RelayRetrySchedule` ran the caller's recovery step **bare inside its timer** and resolved `armed` only on the line after it.

Injected a synchronous throw:

- the error escaped the timer as an **uncaughtException**
- `armed.resolve()` never ran
- the schedule was left with **no armed timer**

So every waiter on `settled` parked on a promise nothing would ever settle, and nothing re-entered the chain. Relay retry is dead for the rest of the process, silently.

## The reachable trigger

Not hypothetical. The origin pool's drain recovery calls `onStatus('draining')` straight through to `webContents.send`. `state.mainWindow` is nulled only on `'closed'` — so in the window between destroy and that event, the send throws `Object has been destroyed`.

**Every other `webContents.send` under `src/main/startup/` already guards with `isDestroyed()`.** This one did not.

## The fix, both halves

- **Contain it:** the retry step is wrapped so a throw cannot escape the timer or skip `armed.resolve()`. The chain survives a throwing step.
- **Remove the trigger:** guard the `webContents.send` with `isDestroyed()`, matching every sibling call site.

Containing without removing would have left a real crash path producing a caught-and-ignored error; removing without containing would have left the next throwing step to kill the chain again.

## Base

`main` does not work — `relay-retry-schedule.ts` is changed by #19436's scheduled-retry work, which is in #19870's stack. Merge order: **#19870 → this**.

## Verification

`tsc --noEmit -p config/tsconfig.node.json` clean · `src/main/runtime/relay` + `src/main/startup` — **75 files / 659 tests passed, 2 files / 8 tests skipped**, 0 failures · `oxlint` clean · `oxfmt --check` clean.

Cherry-picked from `nwparker/adv3-failure-fixes`, which has no PR.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Stack preserved: base stays `fix/18211-lan-mode-applies-to-paired-devices` (#19870), rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c` first. Replayed with `git rebase --onto 13eee7eacf8a6fcd4bb77ff680d18f727fca1171 9ce190247edbdb508b452e8c62a63c4c2cdd0089`.

| | SHA |
| --- | --- |
| old head | `6d7bda07b046a8e3a0ad4f0e68a96edec98bc58a` |
| new head | `39873c2e6e87bd45f416617d4708993f97e8cc0a` |
| new base (#19870) | `13eee7eacf8a6fcd4bb77ff680d18f727fca1171` |

**Conflict, and the `isDestroyed` guard moved file.** `main` (#19935) had meanwhile extracted the relay `onStatus` callback out of the startup path into `src/main/startup/main-process-relay-status.ts` as `publishDesktopRelayStatus`, so the inline callback this commit guarded no longer exists at the old site. Rather than re-inline it, the guard now lives in `publishDesktopRelayStatus` itself — same file tree (`src/main/startup/`), same behaviour, and it now covers every publisher of `mobile:relayStatusChanged` instead of only the one call site. `desktop-relay-startup.ts` resolves to `onStatus: publishDesktopRelayStatus`.

Gates on the rebased head: typecheck exit 0 (proven failable); `vitest run --config config/vitest.config.ts src/main/runtime/relay/relay-retry-schedule.test.ts src/main/startup/desktop-relay-startup.test.ts` — 2 files / 8 tests passed.
<!-- /rebase-record -->
