### PR TITLE
fix(relay): the demand wake signal must not fail the grant it wakes for

### DIFF
--- a/src/main/runtime/relay/desktop-relay-service-transient-demand-teardown.test.ts
+++ b/src/main/runtime/relay/desktop-relay-service-transient-demand-teardown.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DesktopRelayService } from './desktop-relay-service'
+import type { MobilePairingConnectionMode } from '../../../shared/mobile-pairing-connection-mode'
+
+/**
+ * `withTransientDemand`'s teardown runs work that can fail on its own.
+ *
+ * `refreshDemand` reaches the device registry (`nextPendingExpiry` -> `listDevices`) and the
+ * settings store (`hasDemand` -> `isRelayAllowedForDevice`). Running it bare in the `finally` let
+ * its failure replace the operation's result in BOTH directions: a named mint failure arrived as
+ * an unrelated message, and a successful mint arrived as a rejection. Before the operation it was
+ * worse still: the throw landed after the transient ref was acquired, so the ref was never
+ * released, and transient refs have no expiry.
+ */
+type TransientDemandHost = {
+  withTransientDemand: (
+    kind: string,
+    deviceId: string,
+    operation: () => Promise<unknown>
+  ) => Promise<unknown>
+}
+
+function serviceWithTeardown(options: {
+  release?: () => void
+  refreshDemand?: () => void
+}): (operation: () => Promise<unknown>) => Promise<unknown> {
+  const service = Object.create(DesktopRelayService.prototype) as DesktopRelayService
+  Object.assign(service, {
+    hostMobilePairingConnectionMode: () => 'automatic' as MobilePairingConnectionMode,
+    runtimeRpc: {
+      getDeviceRegistry: () => ({ getMobilePairingConnectionMode: () => 'automatic' })
+    },
+    demandLedger: { acquireTransient: () => options.release ?? ((): void => {}) },
+    refreshDemand: options.refreshDemand ?? ((): void => {})
+  })
+  const host = service as unknown as TransientDemandHost
+  return (operation) => host.withTransientDemand.call(service, 'pairing', 'device-1', operation)
+}
+
+describe('DesktopRelayService transient-demand teardown', () => {
+  it('keeps the operation failure when the demand refresh throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const run = serviceWithTeardown({
+      refreshDemand: () => {
+        throw new Error('listDevices exploded')
+      }
+    })
+
+    await expect(
+      run(async () => {
+        throw new Error('relay_broker_rejected')
+      })
+    ).rejects.toThrow('relay_broker_rejected')
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('does not strand the demand ref when the pre-operation refresh throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const release = vi.fn()
+    const operation = vi.fn(async () => 'minted')
+    const run = serviceWithTeardown({
+      release,
+      refreshDemand: () => {
+        throw new Error('listDevices exploded')
+      }
+    })
+
+    // The ref has no expiry, so failing the wake signal must not take the release with it.
+    await expect(run(operation)).resolves.toBe('minted')
+    expect(operation).toHaveBeenCalledTimes(1)
+    expect(release).toHaveBeenCalledTimes(1)
+    warn.mockRestore()
+  })
+
+  it('keeps a successful mint successful when the demand refresh throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const run = serviceWithTeardown({
+      refreshDemand: () => {
+        throw new Error('listDevices exploded')
+      }
+    })
+
+    await expect(run(async () => 'minted')).resolves.toBe('minted')
+    warn.mockRestore()
+  })
+
+  it('carries the original failure as the cause of a mid-operation policy flip', async () => {
+    const mode = { current: 'automatic' as MobilePairingConnectionMode }
+    const service = Object.create(DesktopRelayService.prototype) as DesktopRelayService
+    Object.assign(service, {
+      hostMobilePairingConnectionMode: () => mode.current,
+      runtimeRpc: {
+        getDeviceRegistry: () => ({ getMobilePairingConnectionMode: () => 'automatic' })
+      },
+      demandLedger: { acquireTransient: () => (): void => {} },
+      refreshDemand: () => {}
+    })
+    const host = service as unknown as TransientDemandHost
+
+    const rejection = await host.withTransientDemand
+      .call(service, 'pairing', 'device-1', async () => {
+        mode.current = 'local-only'
+        throw new Error('relay_token_exchange_failed_503')
+      })
+      .catch((error: unknown) => error)
+
+    expect((rejection as Error).message).toBe('relay_disabled_for_device')
+    expect(((rejection as Error).cause as Error | undefined)?.message).toBe(
+      'relay_token_exchange_failed_503'
+    )
+  })
+})

--- a/src/main/runtime/relay/desktop-relay-service.ts
+++ b/src/main/runtime/relay/desktop-relay-service.ts
@@ -18,7 +18,7 @@ import type {
   RelayRevokeOutboxItem
 } from './relay-revoke-outbox'
 import { deriveRelayHostId } from './relay-http-client'
-import { RelayDemandLedger } from './relay-demand-ledger'
+import { RelayDemandLedger, refreshRelayDemandBestEffort } from './relay-demand-ledger'
 import { createRelayRegionPreferenceReader } from './relay-region-preference'
 import { pairingAuthorizationForContext } from './relay-pairing-authorization'
 import { buildPairingEndpointsResult } from './relay-pairing-endpoints-result'
@@ -292,7 +292,7 @@ export class DesktopRelayService {
       throw new Error('relay_disabled_for_device')
     }
     const release = this.demandLedger.acquireTransient(`${kind}:${deviceId}`, deviceId)
-    this.refreshDemand()
+    refreshRelayDemandBestEffort(() => this.refreshDemand())
     try {
       return await operation()
     } catch (error) {
@@ -301,12 +301,12 @@ export class DesktopRelayService {
       // reaches `standby` and clears the offline reason. The wait then ends with no cause at all
       // — the generic `relay_control_not_active` — when the flip is exactly the cause.
       if (!this.isRelayAllowedForDevice(deviceId)) {
-        throw new Error('relay_disabled_for_device')
+        throw new Error('relay_disabled_for_device', { cause: error })
       }
       throw error
     } finally {
       release()
-      this.refreshDemand()
+      refreshRelayDemandBestEffort(() => this.refreshDemand())
     }
   }
 

--- a/src/main/runtime/relay/relay-demand-ledger.ts
+++ b/src/main/runtime/relay/relay-demand-ledger.ts
@@ -13,6 +13,25 @@ type RelayDemandLedgerOptions = {
 
 type TransientRef = { deviceId: string; count: number }
 
+/**
+ * Run a demand refresh as the wake signal it is.
+ *
+ * A refresh reaches the device registry (`nextPendingExpiry` -> `listDevices`) and the settings
+ * store (`hasDemand` -> the host pairing mode), so it can fail on its own. Bare, it failed the
+ * caller it was waking for: before an operation it threw with a transient ref already acquired —
+ * and those have no expiry, so the ref held relay demand for the rest of the process — and after
+ * one it replaced the operation's own result, turning a named mint failure into an unrelated
+ * message and a successful mint into a rejection. A lost wake signal is recoverable; the liveness
+ * tick and the next refresh both re-ask.
+ */
+export function refreshRelayDemandBestEffort(refresh: () => void): void {
+  try {
+    refresh()
+  } catch (error) {
+    console.warn('[relay] demand refresh failed:', error)
+  }
+}
+
 export class RelayDemandLedger {
   private readonly options: RelayDemandLedgerOptions
   private readonly transientRefs = new Map<string, TransientRef>()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

> **Stacked on #19870** (`fix/18211-lan-mode-applies-to-paired-devices`). Review the top commit only.

## What breaks

`withTransientDemand` called `refreshDemand()` **bare on both sides** of the operation it wraps. That call is not pure — it reaches the device registry (`nextPendingExpiry` → `listDevices`) and the settings store (`hasDemand` → `isRelayAllowedForDevice`), so it can fail on its own.

Measured, each call site failed the operation instead:

**The pre-call** threw with the transient ref **already acquired**. The ref was never released and the operation never ran. Transient refs have **no expiry**, so that ref holds relay demand for the rest of the process — the relay stays online forever because a wake signal failed.

**The teardown call** replaced the operation's own result, in both directions:
- a named mint failure arrived as `listDevices exploded`
- **a *successful* mint arrived as a rejection**

## Why containment is the right shape

Both calls are **wake signals**. The liveness tick and the next refresh re-ask, so a lost signal is recoverable — where a stranded transient ref is not, and a successful mint reported as a failure is not. Containing the signal trades a recoverable loss for two unrecoverable ones.

The containment lives **beside the ledger that owns the ref**, not in `desktop-relay-service.ts` — that file is at its `max-lines` ceiling and this must not cost it a line. (A `max-lines` disable is not an option in this repo.)

## Also in here

The mid-operation policy-flip rewrite was **discarding the original error**. It now carries it as `cause` — the one place in a commit about naming causes that was destroying one.

## Base

`main` does not work — this touches `desktop-relay-service.ts` and `relay-demand-ledger.ts` as they stand after #19870's stack. Merge order: **#19870 → this**.

## Verification

`tsc --noEmit -p config/tsconfig.node.json` clean · `src/main/runtime/relay` — **25 files / 204 tests passed**, 0 failures · `oxlint` clean · `oxfmt --check` clean.

Cherry-picked from `nwparker/adv3-failure-fixes`, which has no PR.

<!-- cause-correction -->
## Correction to the analysis above (2026-09-16)

The claim that `hasDemand` → `isRelayAllowedForDevice` can fail the caller is **wrong**, and the fix is narrower than the description implies. `coordinator.reconcile()` → `beginReconcile` → `reconcileEpoch` is an `async` function whose whole body — including `readContext()` and `hasDemand?.(context)` — runs inside its own `try/catch`, so a throw there becomes a caught rejection logged as `[relay] broker reconcile failed:`. It cannot escape `refreshDemand`.

The only synchronous throw surface that can is `nextPendingExpiry()` → `listDevices()`, and it runs *after* the coordinator has already been woken. So what a contained throw actually costs is the `demandExpiryTimer` re-arm, not the wake.

That also narrows the "recoverable" argument: `ensureLive()` returns early when ownership is valid and live and never touches the expiry timer, so an unscanned invite's expiry cannot drop standing demand until some later `refreshDemand`. The containment is still correct and worth having — this note only corrects *why*.

Pre-existing, not introduced by this PR: the same throw point behaved this way before.
<!-- /cause-correction -->

<!-- rebase-record -->
## Rebase record (2026-09-11)

Stack preserved: base stays `fix/18211-lan-mode-applies-to-paired-devices` (#19870), rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c` first. Replayed with `git rebase --onto 13eee7eacf8a6fcd4bb77ff680d18f727fca1171 9ce190247edbdb508b452e8c62a63c4c2cdd0089`.

| | SHA |
| --- | --- |
| old head | `417707ea34733fbed01b72cd4819cd23e0d851dd` |
| new head | `4450e1ddae6a3ea1c103a189988447fac8829737` |
| new base (#19870) | `13eee7eacf8a6fcd4bb77ff680d18f727fca1171` |

No conflicts.
<!-- /rebase-record -->

