### PR TITLE
fix(mobile): a relay status we could not read is not "offline"

### DIFF
--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -152,12 +152,12 @@ export default function MobilePage(): React.JSX.Element {
     if (relayMintFailure == null) {
       return
     }
-    // Why: users share this payload — an address (selected or relay cell) would leak a LAN/Tailscale IP or hostname.
-    const payload = await collectMobileRelayDiagnosticsPayload({
-      connectionMode,
-      failure: relayMintFailure
-    })
     try {
+      // Why: users share this payload — an address (selected or relay cell) would leak a LAN/Tailscale IP or hostname.
+      const payload = await collectMobileRelayDiagnosticsPayload({
+        connectionMode,
+        failure: relayMintFailure
+      })
       await window.api.ui.writeClipboardText(JSON.stringify(payload, null, 2))
       if (mountedRef.current) {
         toast.success(

--- a/src/renderer/src/components/mobile/mobile-relay-diagnostics-payload.test.ts
+++ b/src/renderer/src/components/mobile/mobile-relay-diagnostics-payload.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest'
-import { buildMobileRelayDiagnosticsPayload } from './mobile-relay-diagnostics-payload'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildMobileRelayDiagnosticsPayload,
+  collectMobileRelayDiagnosticsPayload
+} from './mobile-relay-diagnostics-payload'
 import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-mint-failure'
 
 const failure: MobileRelayMintFailure = {
@@ -45,5 +48,53 @@ describe('buildMobileRelayDiagnosticsPayload', () => {
     ])
     expect(payload).not.toHaveProperty('selectedAddress')
     expect(payload).not.toHaveProperty('cellUrl')
+  })
+})
+
+// Why this matters beyond the field value: the payload is what a user pastes into a bug report,
+// and both Copy-diagnostics buttons fire the collector as `void copyRelayDiagnostics()` with the
+// await sitting ahead of their try/catch — so a rejection here is a click that writes no
+// clipboard and shows no toast at all.
+describe('collectMobileRelayDiagnosticsPayload', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, 'window')
+  })
+
+  function stubWindow(mobile: unknown): void {
+    const api: Record<string, unknown> = {}
+    if (mobile !== undefined) {
+      api.mobile = mobile
+    }
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: { api } })
+  }
+
+  it("reports 'unreadable' rather than the definite 'offline' when the status lookup fails", async () => {
+    stubWindow({ getRelayStatus: vi.fn().mockRejectedValue(new Error('ipc down')) })
+
+    const payload = await collectMobileRelayDiagnosticsPayload({
+      connectionMode: 'automatic',
+      failure
+    })
+
+    expect(payload.relayStatus).toBe('unreadable')
+  })
+
+  it('still resolves when the mobile bridge is missing entirely', async () => {
+    stubWindow(undefined)
+
+    await expect(
+      collectMobileRelayDiagnosticsPayload({ connectionMode: 'automatic', failure })
+    ).resolves.toMatchObject({ relayStatus: 'unreadable' })
+  })
+
+  it('reports a host-answered offline as offline', async () => {
+    stubWindow({ getRelayStatus: vi.fn().mockResolvedValue({ status: 'offline' }) })
+
+    const payload = await collectMobileRelayDiagnosticsPayload({
+      connectionMode: 'automatic',
+      failure
+    })
+
+    expect(payload.relayStatus).toBe('offline')
   })
 })

--- a/src/renderer/src/components/mobile/mobile-relay-diagnostics-payload.ts
+++ b/src/renderer/src/components/mobile/mobile-relay-diagnostics-payload.ts
@@ -3,11 +3,18 @@ import type { MobileRelayMintFailure } from '../../../../shared/mobile-relay-min
 import type { MobileRelayStatus } from '../../../../shared/mobile-relay-status'
 import { resolveClientEnvironmentInfo } from '@/lib/client-environment-info'
 
+/** The status lookup's own failure, kept distinct from the host answering 'offline'. */
+export const MOBILE_RELAY_DIAGNOSTICS_STATUS_UNREADABLE = 'unreadable'
+
+export type MobileRelayDiagnosticsStatus =
+  | MobileRelayStatus
+  | typeof MOBILE_RELAY_DIAGNOSTICS_STATUS_UNREADABLE
+
 export type MobileRelayDiagnosticsPayload = {
   kind: 'mobile_pairing_relay_failure'
   preferredConnectionMode: MobilePairingConnectionMode
   failure: MobileRelayMintFailure
-  relayStatus: MobileRelayStatus
+  relayStatus: MobileRelayDiagnosticsStatus
   appVersion: string
   at: string
 }
@@ -17,7 +24,7 @@ export type MobileRelayDiagnosticsPayload = {
 export function buildMobileRelayDiagnosticsPayload(args: {
   connectionMode: MobilePairingConnectionMode
   failure: MobileRelayMintFailure
-  relayStatus: MobileRelayStatus
+  relayStatus: MobileRelayDiagnosticsStatus
   appVersion: string
 }): MobileRelayDiagnosticsPayload {
   return {
@@ -30,6 +37,25 @@ export function buildMobileRelayDiagnosticsPayload(args: {
   }
 }
 
+/**
+ * Why not 'offline' on failure: this payload is what a user pastes into a bug report, and
+ * 'offline' is a claim the broker was down. A status call this renderer could not complete
+ * observed nothing (docs/reference/ssh-execution-boundary.md), and reporting it as the definite
+ * neighbour points triage at the relay instead of at the lookup that actually failed.
+ *
+ * Why the whole call and not just a `.catch`: both Copy-diagnostics buttons fire this as
+ * `void copyRelayDiagnostics()`, and the await now sits ahead of their try/catch, so a bridge
+ * missing `mobile` — which throws where a rejected promise was expected — would leave the click
+ * with no clipboard write and no toast at all.
+ */
+async function readRelayStatusForDiagnostics(): Promise<MobileRelayDiagnosticsStatus> {
+  try {
+    return (await window.api.mobile.getRelayStatus()).status
+  } catch {
+    return MOBILE_RELAY_DIAGNOSTICS_STATUS_UNREADABLE
+  }
+}
+
 // Why here rather than at each call site: both "Copy diagnostics" buttons must
 // fetch the same two fields the same way, and MobilePane sits at the line ceiling.
 export async function collectMobileRelayDiagnosticsPayload(args: {
@@ -37,10 +63,7 @@ export async function collectMobileRelayDiagnosticsPayload(args: {
   failure: MobileRelayMintFailure
 }): Promise<MobileRelayDiagnosticsPayload> {
   const [relayStatus, environment] = await Promise.all([
-    window.api.mobile
-      .getRelayStatus()
-      .then((detail) => detail.status)
-      .catch(() => 'offline' as const),
+    readRelayStatusForDiagnostics(),
     resolveClientEnvironmentInfo()
   ])
   return buildMobileRelayDiagnosticsPayload({

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -306,12 +306,12 @@ export function MobilePane(): React.JSX.Element {
     if (relayMintFailure == null) {
       return
     }
-    // Why: users share this payload, so it carries no address (selected or relay cell).
-    const payload = await collectMobileRelayDiagnosticsPayload({
-      connectionMode,
-      failure: relayMintFailure
-    })
     try {
+      // Why: users share this payload, so it carries no address (selected or relay cell).
+      const payload = await collectMobileRelayDiagnosticsPayload({
+        connectionMode,
+        failure: relayMintFailure
+      })
       await window.api.ui.writeClipboardText(JSON.stringify(payload, null, 2))
       if (mountedRef.current) {
         toast.success(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

> **Stacked on #19870** (`fix/18211-lan-mode-applies-to-paired-devices`). Review the top commit only.

Two problems in the same newly-extracted diagnostics collector — both in the artifact a user pastes into a bug report, which is the one place a wrong answer costs a support engineer a round trip.

## 1. `offline` was asserted for a status nobody read

`.catch(() => 'offline' as const)` reported the **definite** neighbour for a lookup that observed **nothing**. A support engineer could not tell a host that genuinely reported offline from one that never answered at all.

It reports `unreadable` now. This is the same distinction [`docs/reference/ssh-execution-boundary.md`](../blob/main/docs/reference/ssh-execution-boundary.md) draws for execution verdicts: loss of contact is not evidence of a state.

## 2. The collector could reject, and killed the whole interaction

`window.api.mobile.getRelayStatus()` throws **synchronously** when the bridge has no `mobile` — before `.catch` is attached. Both call sites fire this as `void copyRelayDiagnostics()` with the `await` sitting **ahead of** their `try`/`catch`.

**Measured: the click wrote no clipboard and showed no toast at all.** Not a wrong diagnostic — no response whatsoever to a button press. The pre-extraction inline payload build could not fail this way, so this was introduced by the extraction.

The collector is total now, and the `await` moved **inside** the try, so a future addition cannot silently kill the toast again.

## Base

`main` does not work — the collector this fixes is introduced by `fb135c95f71` *"share the diagnostics payload with the settings pane"*, which is in #19870's stack. This is a fix for a defect in that extraction. Merge order: **#19870 → this**.

## Verification

`tsc --noEmit -p config/tsconfig.node.json` clean · `src/renderer/src/components/mobile` + `src/renderer/src/components/settings` — **184 files / 1208 tests passed**, 0 failures.

Note for anyone re-running: these are renderer tests and need `vitest run --config config/vitest.config.ts`. Invoking `vitest` without it silently fails to resolve the `@/` alias and reports 144 *files* failing with 0 test failures — an infrastructure error that looks nothing like a real regression and reproduces identically on the untouched base.

`oxlint` clean · `oxfmt --check` clean. Cherry-picked from `nwparker/adv3-failure-fixes`, which has no PR.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Stack preserved: base stays `fix/18211-lan-mode-applies-to-paired-devices` (#19870), rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c` first. Replayed with `git rebase --onto 13eee7eacf8a6fcd4bb77ff680d18f727fca1171 9ce190247edbdb508b452e8c62a63c4c2cdd0089`.

| | SHA |
| --- | --- |
| old head | `42ec350247d40d6fc40f4155f040198653f16459` |
| new head | `a8a8a954c72b3e21fdc73240cb2b7d7a0a627170` |
| new base (#19870) | `13eee7eacf8a6fcd4bb77ff680d18f727fca1171` |

No conflicts.
<!-- /rebase-record -->
