### PR TITLE
fix(pi): load extension providers for source control generation

### DIFF
--- a/.github/workflows/pi-provider-runtime.yml
+++ b/.github/workflows/pi-provider-runtime.yml
@@ -1,0 +1,28 @@
+name: Pi extension provider verification
+on:
+  pull_request:
+    paths:
+      - 'src/shared/commit-message-agent-specs-primary.ts'
+      - 'tests/tools/pi-provider-runtime-smoke.mjs'
+      - '.github/workflows/pi-provider-runtime.yml'
+permissions:
+  contents: read
+jobs:
+  runtime:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    env:
+      ORCA_BACKGROUND_LAUNCH: '1'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/install-node-dependencies
+      - name: Install pinned Pi runtime
+        run: npm install --prefix .cache/pi-provider --ignore-scripts --no-audit --no-fund @earendil-works/pi-coding-agent@0.84.2
+      - name: Verify extension model generation before and after
+        run: node tests/tools/pi-provider-runtime-smoke.mjs .cache/pi-provider/node_modules/@earendil-works/pi-coding-agent/dist/cli.js

--- a/src/shared/commit-message-agent-specs-primary.ts
+++ b/src/shared/commit-message-agent-specs-primary.ts
@@ -197,7 +197,6 @@ export function buildPrimaryCommitMessageAgentSpecs({
         '--print',
         '--no-session',
         '--no-tools',
-        '--no-extensions',
         '--no-skills',
         '--no-context-files',
         '--mode',

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -2,6 +2,29 @@ import { describe, expect, it } from 'vitest'
 import { planCommitMessageGeneration, planAgentBinary } from './commit-message-plan'
 
 describe('planCommitMessageGeneration', () => {
+  it('keeps extension-provided Pi models available in generated Git text plans', () => {
+    const result = planCommitMessageGeneration(
+      { agentId: 'pi', model: 'local-extension/model' },
+      'Write a commit message'
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      throw new Error(result.error)
+    }
+    expect(result.plan.args).not.toContain('--no-extensions')
+    expect(result.plan.args).toEqual(
+      expect.arrayContaining([
+        '--no-session',
+        '--no-tools',
+        '--no-skills',
+        '--no-context-files',
+        '--model',
+        'local-extension/model'
+      ])
+    )
+    expect(result.plan.stdinPayload).toBe('Write a commit message')
+  })
+
   it('plans Claude non-interactive generation with the prompt on stdin only', () => {
     const result = planCommitMessageGeneration(
       {

--- a/tests/tools/pi-provider-runtime-smoke.mjs
+++ b/tests/tools/pi-provider-runtime-smoke.mjs
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { build } from 'esbuild'
+const piCli = process.argv[2] && resolve(process.argv[2])
+assert.ok(piCli, 'Pass the installed Pi CLI entrypoint')
+const scratch = await mkdtemp(join(tmpdir(), 'orca-pi-provider-'))
+const requests = []
+const server = createServer(async (req, res) => {
+  let body = ''
+  for await (const part of req) {
+    body += part
+  }
+  requests.push(JSON.parse(body))
+  res.writeHead(200, { 'content-type': 'text/event-stream' })
+  for (const chunk of [
+    {
+      id: 'proof',
+      object: 'chat.completion.chunk',
+      choices: [
+        {
+          index: 0,
+          delta: { role: 'assistant', content: 'fixture-generated-commit' },
+          finish_reason: null
+        }
+      ]
+    },
+    {
+      id: 'proof',
+      object: 'chat.completion.chunk',
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }
+  ]) {
+    res.write(`data: ${JSON.stringify(chunk)}\n\n`)
+  }
+  res.end('data: [DONE]\n\n')
+})
+try {
+  const bundle = join(scratch, 'orca.cjs')
+  await build({
+    stdin: {
+      contents:
+        "export {planCommitMessageGeneration} from './src/shared/commit-message-plan'; export {runProcess} from './src/shared/child-process/run-process';",
+      resolveDir: process.cwd()
+    },
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    outfile: bundle,
+    packages: 'external'
+  })
+  const { planCommitMessageGeneration, runProcess } = createRequire(import.meta.url)(bundle)
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const dir = join(scratch, 'agent')
+  await mkdir(join(dir, 'extensions'), { recursive: true })
+  await writeFile(
+    join(dir, 'extensions', 'provider.ts'),
+    `export default function(pi){pi.registerProvider('orca-proof',{name:'Proof',baseUrl:'http://127.0.0.1:${server.address().port}/v1',apiKey:'fixture-only',api:'openai-completions',models:[{id:'local',name:'Proof',reasoning:false,input:['text'],cost:{input:0,output:0,cacheRead:0,cacheWrite:0},contextWindow:8192,maxTokens:256}]})}`
+  )
+  await writeFile(
+    join(dir, 'settings.json'),
+    JSON.stringify({ defaultProvider: 'orca-proof', defaultModel: 'local' })
+  )
+  const planned = planCommitMessageGeneration(
+    { agentId: 'pi', model: 'orca-proof/local' },
+    'Generate one short commit message.'
+  )
+  assert.equal(planned.ok, true)
+  const fixedArgs = planned.plan.args
+  assert.ok(!fixedArgs.includes('--no-extensions'))
+  const variants = [
+    ['baseline', [...fixedArgs, '--no-extensions']],
+    ['extensions-enabled', fixedArgs]
+  ]
+  const results = []
+  for (const [variant, args] of variants) {
+    const n = requests.length
+    const result = await runProcess({
+      program: process.execPath,
+      args: [piCli, ...args],
+      cwd: scratch,
+      env: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        WINDIR: process.env.WINDIR,
+        HOME: scratch,
+        USERPROFILE: scratch,
+        ORCA_BACKGROUND_LAUNCH: '1',
+        PI_CODING_AGENT_DIR: dir
+      },
+      input: planned.plan.stdinPayload,
+      timeoutMs: 20000
+    })
+    results.push({
+      variant,
+      args,
+      code: result.code,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      requests: requests.length - n
+    })
+  }
+  assert.equal(results[0].requests, 0)
+  assert.notEqual(results[0].code, 0)
+  assert.equal(results[1].code, 0, results[1].stderr)
+  assert.match(results[1].stdout, /fixture-generated-commit/)
+  assert.equal(results[1].requests, 1)
+  console.log(
+    JSON.stringify(
+      {
+        scope:
+          'Actual Pi CLI and production command planner; isolated extension provider with local OpenAI-compatible fixture.',
+        platform: process.platform,
+        results
+      },
+      null,
+      2
+    )
+  )
+} finally {
+  server.closeAllConnections()
+  server.close()
+  await rm(scratch, { recursive: true, force: true })
+}


### PR DESCRIPTION
Pi Source Control AI always passed `--no-extensions`, so an extension-provided model failed before its provider could load. Keep extensions enabled while retaining print mode and the existing no-session, no-tools, no-skills and no-context-files arguments. This isolates the Pi fix proposed in community PR #14838 by @kaluli123123 from that PR's unrelated changes.

Fixes #14951.

### Rendered before/after proof

Verified in a hidden Orca Electron build of this PR, identity-confirmed through CDP. Registered an isolated repository with a staged README change, configured a real Pi extension provider, and clicked **Generate commit message with AI** in the actual Source Control UI. The endpoint is a deterministic OpenAI-compatible streaming fixture; Pi itself, Orca's planner, subprocess launch, IPC and rendered result are real.

**Baseline-equivalent invocation:** explicitly reintroduced the old `--no-extensions` flag in the action's CLI arguments. Orca displays model-not-found; zero provider requests.

![Baseline model-not-found error](https://github.com/user-attachments/assets/931db2ca-9447-4ea6-988f-49532ce9743e)

**Fixed production invocation:** removed that baseline flag and clicked the same button. The commit textbox contains `Fix extension provider commit generation`, the error disappears, and exactly one provider request is recorded.

![Fixed generated commit message](https://github.com/user-attachments/assets/b96bd076-ce40-4fd8-a8c0-62620c242772)

The command logs differ only by `--no-extensions`. Screenshots are cropped from actual hidden-renderer captures; they are not mockups. No commit was created by the UI action.

### Validation

- 70 planner/spec tests passed; Node typecheck and changed-file lint/format passed.
- Actual Pi CLI + production planner before/after passed on macOS Pi0.83.0 and the connected Windows host awin Pi0.84.2.
- Pinned Pi0.84.2 Linux/macOS/Windows runtime workflow passed: https://github.com/stablyai/orca/actions/runs/34576036342 .
- Full PR CI passed, including all eight test shards, typecheck, static analysis, Linux packaging, Windows packaging, and the final aggregate: https://github.com/stablyai/orca/actions/runs/34576036521 . This completed the rerun after the original packaging job was cancelled when the PR was marked ready.

The one-line planner change is shared by local and remote execution. No remote wire or provider-specific network implementation changes. LM Studio itself was not installed; the reported failure is provider-extension loading, reproduced with a real registered extension and an equivalent API fixture. The separate forced-Copilot default is handled in #15649.
