### PR TITLE
fix: drop the deprecated `verified` url parameter from the cask templates

### DIFF
--- a/Casks/orca.rb
+++ b/Casks/orca.rb
@@ -5,8 +5,7 @@ cask "orca" do
   sha256 arm:   "fc707f290ff3b631b7b7947bf339885b61a43d2e89475997c125b61268ed4966",
          intel: "5f677c13a08f7a5740442e29d388285a86488c8c1f7aa5f10a8721a2c6ede8e4"
 
-  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
-      verified: "github.com/stablyai/orca/"
+  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg"
   name "Orca"
   desc "IDE for orchestrating AI coding agents across terminals and worktrees"
   homepage "https://onorca.dev/"

--- a/Casks/orca@rc.rb
+++ b/Casks/orca@rc.rb
@@ -5,8 +5,7 @@ cask "orca@rc" do
   sha256 arm:   "563b6b14323fc9d5489299c82442d514bc12cabffc9d06d3964ed572af4b3955",
          intel: "457088c7021f07de1a419197f7b2bd00092741ad4727d4fef3d86af38a6831e7"
 
-  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
-      verified: "github.com/stablyai/orca/"
+  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg"
   name "Orca RC"
   desc "IDE for orchestrating AI coding agents across terminals and worktrees"
   homepage "https://onorca.dev/"


### PR DESCRIPTION
## ELI5

Homebrew used to want casks to say "yes, this download really does come from our GitHub repo". It now checks that by itself, and complains about anyone still saying it. These two files are the templates the tap's casks are generated from, so the complaint goes out to every Orca user on macOS until the line is deleted here.

## What Changed

Removed `verified: "github.com/stablyai/orca/"` from the `url` stanza in `Casks/orca.rb` and `Casks/orca@rc.rb`. The download URLs, versions and hashes are untouched, and nothing else in either file changes.

This is the source half of stablyai/homebrew-orca#252, which removes the same line from the two casks in the tap. Both are needed: `homebrew-bump.yml` copies these templates straight over the tap files on every release (`cp "$CASK_PATH" "tap/$CASK_PATH"`), so without this change the next stable or RC bump puts the deprecation back.

## Why

Homebrew verifies cask download URLs by default now, and `verified:` has become a no-op:

- `Cask::URL::DEPRECATED_URL_SPECS = [:verified]` — *"URL kwargs still accepted from existing cask metadata but otherwise ignored"* (`Library/Homebrew/cask/url.rb`)
- `Cask::DSL#url` strips those keys before building the URL and calls `odeprecated` for each one (`Library/Homebrew/cask/dsl.rb`)

So it no longer affects the download. What it does is print this on every command that loads the cask — `install`, `upgrade`, `info`, `outdated`:

```
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
Please report this issue to the stablyai/homebrew-orca tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/stablyai/homebrew-orca/Casks/orca.rb:8
```

For anyone with `HOMEBREW_DEVELOPER=1` it is worse than noise. `odeprecated` defaults to `disable_for_developers: true`, so the deprecation is raised rather than printed and the cask does not load at all:

```
$ HOMEBREW_DEVELOPER=1 brew info --cask orca
Error: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
```

When Homebrew promotes this from `odeprecated` to `odisabled` — which is the normal path for a deprecation — that hard failure becomes the behaviour for every user, and `brew install --cask orca` stops working until the line is removed.

## Linked Issue

Fixes # — N/A, no issue filed. This surfaced as warning output from `brew`, not from the tracker. Happy to open one to link if the project would rather have it recorded.

## Visual Proof

`N/A` — no UI or behaviour change. The only user-visible difference is terminal output, included above (warning present) and below (warning gone).

## Testing

Verified on macOS 26 (Apple Silicon) with Homebrew 6.0.22 by tapping a copy of the tap carrying these patched casks:

- `brew info --cask orca` and `orca@rc`: warning gone, both exit 0, with and without `HOMEBREW_DEVELOPER=1`. Against the current casks, `HOMEBREW_DEVELOPER=1 brew info --cask orca` exits 1.
- `brew install --cask orca` from the patched cask: installs clean, `/Applications/Orca.app` and the `orca` CLI symlink in place, `orca --version` → `1.4.200`. Uninstalled and reinstalled from `stablyai/orca` afterwards to confirm both paths behave the same.
- `brew audit --cask --strict --online` and `brew style --cask`: identical results before and after — one pre-existing finding on both casks (`Artifact defined :monterey as the minimum macOS version but the cask declared no minimum macOS version`) and one pre-existing correctable style offense, neither related to this change and neither touched here.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No automated test: these files are cask templates consumed by `homebrew-bump.yml`, and the repo has no harness that loads them. The equivalent check is `brew style --cask` / `brew audit --cask` against the generated tap, which is where the deprecation shows up and where it was verified.

## AI Disclosure

Prepared with Claude Code (Claude Opus). Every command quoted above was run locally against a real Homebrew install rather than inferred.

## Review

Small and mechanical: two lines deleted, one from each file. The thing worth a reviewer's attention is not this diff but the pairing — merging stablyai/homebrew-orca#252 without this PR only holds until the next bump.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security:** neutral-to-positive. `verified:` no longer gates anything — Homebrew ignores the value — so removing it changes no trust decision. URL verification now happens by default.
- **Cross-platform:** macOS-only files; no Linux, Windows, SSH or mobile surface.
- **Backwards compatibility:** older Homebrew releases accept a `url` stanza without `verified:` — it has always been optional — so the casks keep working on versions that predate the deprecation.
- **Performance:** none.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Not run locally: this change touches no TypeScript, and the two files are not part of any build or lint target. Leaving it to CI rather than claiming a run I did not do.
