### PR TITLE
fix(mobile): show Codex async decision cards and compose replies

### DIFF
--- a/mobile/src/session/MobileNativeChatAsk.tsx
+++ b/mobile/src/session/MobileNativeChatAsk.tsx
@@ -3,6 +3,7 @@ import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-
 import { Check } from 'lucide-react-native'
 import type { AskAnswerSelection, AskPrompt } from '../../../src/shared/native-chat-ask'
 import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+import { isMobileAsyncAsk } from './mobile-native-chat-async-ask'
 
 type Props = {
   prompt: AskPrompt
@@ -21,6 +22,7 @@ const OTHER = -1
  *  on the last step), and a Cancel that dismisses the prompt. Neutral styling
  *  with a subtle green accent on the active choice to match the rest of the app. */
 export function MobileNativeChatAsk({ prompt, onAnswer, onCancel }: Props): React.JSX.Element {
+  const composeAnswer = isMobileAsyncAsk(prompt)
   const [index, setIndex] = useState(0)
   const [selections, setSelections] = useState<number[][]>(() => prompt.questions.map(() => []))
   const [otherText, setOtherText] = useState<string[]>(() => prompt.questions.map(() => ''))
@@ -174,7 +176,7 @@ export function MobileNativeChatAsk({ prompt, onAnswer, onCancel }: Props): Reac
           disabled={submitting}
           hitSlop={8}
         >
-          <Text style={styles.cancelText}>Cancel</Text>
+          <Text style={styles.cancelText}>{composeAnswer ? 'Dismiss' : 'Cancel'}</Text>
         </Pressable>
         {total > 1 ? (
           <Text style={styles.progress}>
@@ -187,7 +189,7 @@ export function MobileNativeChatAsk({ prompt, onAnswer, onCancel }: Props): Reac
           disabled={!canAdvance}
         >
           <Text style={[styles.nextText, !canAdvance && styles.nextTextDisabled]}>
-            {isLast ? 'Submit' : 'Next'}
+            {isLast ? (composeAnswer ? 'Add to message' : 'Submit') : 'Next'}
           </Text>
         </Pressable>
       </View>

--- a/mobile/src/session/MobileNativeChatAsyncAsk.test.tsx
+++ b/mobile/src/session/MobileNativeChatAsyncAsk.test.tsx
@@ -1,0 +1,150 @@
+import { createElement, useState } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AskPrompt } from '../../../src/shared/native-chat-ask'
+import { MobileNativeChatPromptCard } from './MobileNativeChatPromptCard'
+import type { MobileAsyncAskPrompt } from './mobile-native-chat-async-ask'
+import { useMobileNativeChatAskActions } from './use-mobile-native-chat-ask-actions'
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Text: 'Text',
+  TextInput: 'TextInput',
+  View: 'View'
+}))
+vi.mock('lucide-react-native', () => ({
+  Check: 'Check',
+  ArrowUp: 'ArrowUp',
+  CircleHelp: 'CircleHelp',
+  ShieldQuestion: 'ShieldQuestion'
+}))
+const blocking = {
+  answer: vi.fn(async () => true),
+  cancel: vi.fn(async () => true)
+}
+
+const prompt: MobileAsyncAskPrompt = {
+  asyncCallIds: ['async-1'],
+  questions: [
+    {
+      question: 'Which color?',
+      multiSelect: false,
+      options: [{ label: 'Red (Recommended)' }, { label: 'Blue' }]
+    },
+    { question: 'Any constraints?', multiSelect: false, options: [] }
+  ]
+}
+
+describe('mobile async decision card', () => {
+  let renderer: ReactTestRenderer | null = null
+  let composer = ''
+  let actions: ReturnType<typeof useMobileNativeChatAskActions>
+  const resolved = vi.fn()
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    vi.clearAllMocks()
+  })
+  function Harness({
+    activePrompt = prompt,
+    session = 'session'
+  }: {
+    activePrompt?: AskPrompt
+    session?: string
+  }) {
+    const [text, setText] = useState('Existing draft')
+    const [dismissed, setDismissed] = useState(false)
+    composer = text
+    actions = useMobileNativeChatAskActions({
+      prompt: activePrompt,
+      setComposerText: setText,
+      onSendResolved: resolved,
+      streamIdentity: `host:${session}`,
+      answerBlocking: blocking.answer,
+      cancelBlocking: blocking.cancel
+    })
+    return (
+      <MobileNativeChatPromptCard
+        ask={dismissed ? null : activePrompt}
+        onAnswerAsk={actions.answer}
+        onCancelAsk={actions.cancel}
+        onDismissAsk={() => setDismissed(true)}
+      />
+    )
+  }
+  async function mount(activePrompt: AskPrompt = prompt) {
+    await act(async () => {
+      renderer = create(createElement(Harness, { activePrompt }))
+    })
+  }
+  function button(label: string) {
+    return renderer!.root
+      .findAllByType('Pressable')
+      .find((node) => node.findAllByType('Text').some((text) => text.children.join('') === label))!
+  }
+  async function press(label: string) {
+    await act(async () => button(label).props.onPress())
+  }
+
+  it('collects a non-default choice and free text into the preserved composer without sending', async () => {
+    await mount()
+    expect(button('Next').props.disabled).toBe(true)
+    await press('Blue')
+    await press('Next')
+    await press('Other…')
+    await act(async () => renderer!.root.findByType('TextInput').props.onChangeText('No gradients'))
+    expect(button('Add to message').props.disabled).toBe(false)
+    await press('Add to message')
+    expect(composer).toBe('Existing draft\n\nWhich color?\nBlue\n\nAny constraints?\nNo gradients')
+    expect(renderer!.toJSON()).toBeNull()
+    expect(blocking.answer).not.toHaveBeenCalled()
+    expect(blocking.cancel).not.toHaveBeenCalled()
+    expect(resolved).not.toHaveBeenCalled()
+  })
+
+  it('dismisses locally without Escape, input writes or draft changes', async () => {
+    await mount()
+    await press('Dismiss')
+    expect(composer).toBe('Existing draft')
+    expect(renderer!.toJSON()).toBeNull()
+    expect(blocking.cancel).not.toHaveBeenCalled()
+    expect(resolved).not.toHaveBeenCalled()
+  })
+
+  it('refuses incomplete answers and answers for another prompt', async () => {
+    await mount()
+    expect(await actions.answer(prompt, [{ indices: [1] }])).toBe(false)
+    expect(
+      await actions.answer({ ...prompt, asyncCallIds: ['older'] }, [
+        { indices: [1] },
+        { indices: [], other: 'None' }
+      ])
+    ).toBe(false)
+    expect(composer).toBe('Existing draft')
+    expect(blocking.answer).not.toHaveBeenCalled()
+  })
+
+  it('preserves blocking answer and cancellation delivery', async () => {
+    const blockingPrompt = { questions: [prompt.questions[0]] }
+    await mount(blockingPrompt)
+    expect(await actions.answer(blockingPrompt, [{ indices: [1] }])).toBe(true)
+    expect(blocking.answer).toHaveBeenCalledWith(blockingPrompt, [{ indices: [1] }])
+    expect(await actions.cancel()).toBe(true)
+    expect(blocking.cancel).toHaveBeenCalledOnce()
+    expect(resolved).toHaveBeenCalledTimes(2)
+    expect(composer).toBe('Existing draft')
+  })
+
+  it('refuses a retained callback after a session switch even when the prompt content matches', async () => {
+    await mount()
+    const oldAnswer = actions.answer
+    await act(async () =>
+      renderer!.update(createElement(Harness, { session: 'different-session' }))
+    )
+    expect(await oldAnswer(prompt, [{ indices: [1] }, { indices: [], other: 'None' }])).toBe(false)
+    expect(composer).toBe('Existing draft')
+    expect(blocking.answer).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/session/mobile-native-chat-async-ask.ts
+++ b/mobile/src/session/mobile-native-chat-async-ask.ts
@@ -1,0 +1,83 @@
+import { nativeChatAskDismissKey, type AskPrompt } from '../../../src/shared/native-chat-ask'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+
+export type MobileAsyncAskPrompt = AskPrompt & { asyncCallIds: string[] }
+
+export function isMobileAsyncAsk(prompt: AskPrompt | null): prompt is MobileAsyncAskPrompt {
+  return prompt !== null && 'asyncCallIds' in prompt
+}
+
+export function mobileNativeChatAskKey(prompt: AskPrompt | null): string | null {
+  return isMobileAsyncAsk(prompt)
+    ? `async:${JSON.stringify(prompt.asyncCallIds)}:${nativeChatAskDismissKey(prompt)}`
+    : nativeChatAskDismissKey(prompt)
+}
+
+function parseAsyncQuestions(input: unknown): AskPrompt['questions'] | null {
+  try {
+    const parsed = typeof input === 'string' ? JSON.parse(input) : input
+    if (!parsed || !Array.isArray(parsed.questions) || parsed.questions.length === 0) {
+      return null
+    }
+    const questions: AskPrompt['questions'] = []
+    for (const question of parsed.questions) {
+      if (!question || typeof question.title !== 'string' || !question.title.trim()) {
+        return null
+      }
+      const options: unknown = question.options
+      if (
+        options !== undefined &&
+        (!Array.isArray(options) ||
+          options.length === 0 ||
+          options.some((option) => typeof option !== 'string' || !option.trim()))
+      ) {
+        return null
+      }
+      questions.push({
+        question: question.title,
+        multiSelect: false,
+        options: ((options ?? []) as string[]).map((label) => ({ label }))
+      })
+    }
+    return questions
+  } catch {
+    return null
+  }
+}
+
+/** Async acceptance is an assistant item with the call id, not a FIFO tool result. */
+export function extractMobileAsyncAsk(
+  messages: readonly NativeChatMessage[]
+): MobileAsyncAskPrompt | null {
+  const calls = new Map<string, AskPrompt['questions']>()
+  const completed = new Set<string>()
+  for (const message of messages) {
+    if (message.role === 'user') {
+      calls.clear()
+      completed.clear()
+    }
+    if (message.role === 'assistant' && message.blocks.some((block) => block.type === 'text')) {
+      completed.add(message.id)
+    }
+    for (const block of message.blocks) {
+      if (
+        block.type !== 'tool-call' ||
+        block.name !== 'request_user_input_async' ||
+        !block.callId
+      ) {
+        continue
+      }
+      const questions = parseAsyncQuestions(block.input)
+      if (questions) {
+        calls.set(block.callId, questions)
+      }
+    }
+  }
+  const pending = [...calls].filter(([id]) => completed.has(id))
+  return pending.length > 0
+    ? {
+        asyncCallIds: pending.map(([id]) => id),
+        questions: pending.flatMap(([, questions]) => questions)
+      }
+    : null
+}

--- a/mobile/src/session/mobile-native-chat-async-projection.test.ts
+++ b/mobile/src/session/mobile-native-chat-async-projection.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { extractMobileAsyncAsk } from './mobile-native-chat-async-ask'
+import { extractPendingAsk } from '../../../src/shared/native-chat-ask'
+import { sanitizeNativeChatRpcBlock } from '../../../src/main/runtime/rpc/methods/native-chat-rpc-block-sanitize'
+import { decodeCodexTranscriptLine } from '../../../src/main/native-chat/transcript-line-decoders-codex'
+
+// Synthetic Codex 0.153.4 rollout envelopes; titles and ids contain no session data.
+const input = { questions: [{ title: 'Which color?', options: ['Red', 'Blue'] }] }
+const records = [
+  {
+    type: 'response_item',
+    payload: {
+      type: 'function_call',
+      name: 'request_user_input_async',
+      call_id: 'ask-1',
+      arguments: JSON.stringify(input)
+    }
+  },
+  {
+    type: 'event_msg',
+    payload: {
+      type: 'item_completed',
+      item: {
+        type: 'AgentMessage',
+        id: 'ask-1',
+        delivery: 'async',
+        phase: 'final_answer',
+        questions: input.questions,
+        content: [{ type: 'Text', text: 'Which color?\n- Red\n- Blue' }]
+      }
+    }
+  },
+  {
+    type: 'response_item',
+    payload: { type: 'function_call_output', call_id: 'ask-1', output: '{"accepted":true}' }
+  }
+]
+
+describe('Codex async question mobile projection', () => {
+  it('retains the call identity through decoding and the existing mobile RPC sanitizer', () => {
+    const messages = records.map((record, i) => {
+      const message = decodeCodexTranscriptLine(JSON.stringify(record), `line-${i}`)!
+      return {
+        ...message,
+        blocks: message.blocks.map((block) => sanitizeNativeChatRpcBlock(block, 'mobile'))
+      }
+    })
+    expect(messages[1]).toMatchObject({
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'Which color?\n- Red\n- Blue' }]
+    })
+    expect(extractMobileAsyncAsk(messages)).toEqual({
+      asyncCallIds: ['ask-1'],
+      questions: [
+        {
+          question: 'Which color?',
+          multiSelect: false,
+          options: [{ label: 'Red' }, { label: 'Blue' }]
+        }
+      ]
+    })
+    expect(extractPendingAsk(messages)).toBeNull()
+  })
+
+  it('does not invent a blocking selector for an object-shaped async call', () => {
+    const message = decodeCodexTranscriptLine(
+      JSON.stringify({
+        type: 'response_item',
+        payload: { type: 'function_call', name: 'request_user_input_async', arguments: input }
+      }),
+      'ask'
+    )!
+    expect(extractPendingAsk([message])).toBeNull()
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-ask-actions.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-actions.ts
@@ -1,0 +1,64 @@
+import { useCallback, useLayoutEffect, useRef, type Dispatch, type SetStateAction } from 'react'
+import {
+  formatAskAnswer,
+  type AskAnswerSelection,
+  type AskPrompt
+} from '../../../src/shared/native-chat-ask'
+import { isMobileAsyncAsk, mobileNativeChatAskKey } from './mobile-native-chat-async-ask'
+import { useNativeChatAcceptedAction } from './use-native-chat-action-outcomes'
+
+/** Async choices prepare an ordinary message; only blocking prompts write selector keys. */
+export function useMobileNativeChatAskActions(args: {
+  prompt: AskPrompt | null
+  setComposerText: Dispatch<SetStateAction<string>>
+  onSendResolved: () => void
+  streamIdentity: string
+  answerBlocking: (prompt: AskPrompt, selections: AskAnswerSelection[]) => Promise<boolean>
+  cancelBlocking: () => Promise<boolean>
+}): {
+  answer: (prompt: AskPrompt, selections: AskAnswerSelection[]) => Promise<boolean>
+  cancel: () => Promise<boolean>
+} {
+  const { prompt, setComposerText, onSendResolved, streamIdentity } = args
+  const origin = JSON.stringify([streamIdentity, mobileNativeChatAskKey(prompt)])
+  const activeOrigin = useRef<string | null>(origin)
+  useLayoutEffect(() => {
+    activeOrigin.current = origin
+    return () => {
+      activeOrigin.current = null
+    }
+  }, [origin])
+  const answerBlocking = useNativeChatAcceptedAction(args.answerBlocking, onSendResolved)
+  const cancelBlocking = useNativeChatAcceptedAction(args.cancelBlocking, onSendResolved)
+  const answer = useCallback(
+    async (selectedPrompt: AskPrompt, selections: AskAnswerSelection[]) => {
+      if (!isMobileAsyncAsk(selectedPrompt)) {
+        return answerBlocking(selectedPrompt, selections)
+      }
+      if (
+        activeOrigin.current !== origin ||
+        mobileNativeChatAskKey(selectedPrompt) !== mobileNativeChatAskKey(prompt)
+      ) {
+        return false
+      }
+      const answers = selectedPrompt.questions.map((question, index) => {
+        const text = formatAskAnswer({ questions: [question] }, [
+          selections[index] ?? { indices: [] }
+        ])
+        return text ? `${question.question}\n${text}` : ''
+      })
+      if (answers.some((text) => !text)) {
+        return false
+      }
+      const text = answers.join('\n\n')
+      setComposerText((previous) => (previous ? `${previous}\n\n${text}` : text))
+      return true
+    },
+    [answerBlocking, origin, prompt, setComposerText]
+  )
+  const cancel = useCallback(
+    async () => (isMobileAsyncAsk(prompt) ? true : cancelBlocking()),
+    [cancelBlocking, prompt]
+  )
+  return { answer, cancel }
+}

--- a/mobile/src/session/use-mobile-native-chat-ask-dismiss.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-dismiss.test.ts
@@ -66,6 +66,15 @@ describe('useMobileNativeChatAskDismiss', () => {
     ]
   }
 
+  it('shows a repeated async question with a different call id after dismissal', async () => {
+    const firstAsync = { ...first, asyncCallIds: ['call-1'] }
+    await mount({ prompt: firstAsync })
+    act(() => state?.dismissAsk())
+    expect(state?.showAsk).toBe(false)
+    await update({ prompt: { ...firstAsync, asyncCallIds: ['call-2'] } })
+    expect(state?.showAsk).toBe(true)
+  })
+
   it('shows a structurally different replacement without an intervening null', async () => {
     await mount({ prompt: first })
     act(() => state?.dismissAsk())

--- a/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
+++ b/mobile/src/session/use-mobile-native-chat-ask-dismiss.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { nativeChatAskDismissKey, type AskPrompt } from '../../../src/shared/native-chat-ask'
+import type { AskPrompt } from '../../../src/shared/native-chat-ask'
+import { mobileNativeChatAskKey } from './mobile-native-chat-async-ask'
 
 type AskDismissal = { sessionKey: string | null; askKey: string }
 type DetectedAsk = { sessionKey: string | null; askKey: string | null }
@@ -31,8 +32,8 @@ export function useMobileNativeChatAskDismiss(args: {
   dismissAsk: () => void
 } {
   const { ask, detectedAsk, scopeKey, sessionKey, observing } = args
-  const askKey = useMemo(() => nativeChatAskDismissKey(ask), [ask])
-  const detectedAskKey = useMemo(() => nativeChatAskDismissKey(detectedAsk), [detectedAsk])
+  const askKey = useMemo(() => mobileNativeChatAskKey(ask), [ask])
+  const detectedAskKey = useMemo(() => mobileNativeChatAskKey(detectedAsk), [detectedAsk])
   const detectedByScopeRef = useRef(new Map<string | null, DetectedAsk>())
   const [dismissedByScope, setDismissedByScope] = useState<Map<string | null, AskDismissal>>(
     () => new Map()

--- a/mobile/src/session/use-mobile-native-chat-async-ask.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-async-ask.test.ts
@@ -1,0 +1,147 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { useMobileNativeChatPrompts } from './use-mobile-native-chat-prompts'
+import { extractMobileAsyncAsk } from './mobile-native-chat-async-ask'
+
+const asyncInput = {
+  questions: [
+    { title: 'Which color?', options: ['Red (Recommended)', 'Blue'] },
+    { title: 'Any constraints?' }
+  ]
+}
+const call: NativeChatMessage = {
+  id: 'ask',
+  role: 'assistant',
+  timestamp: 1,
+  source: 'transcript',
+  blocks: [
+    {
+      type: 'tool-call',
+      name: 'request_user_input_async',
+      callId: 'async-1',
+      input: JSON.stringify(asyncInput)
+    }
+  ]
+}
+const accepted: NativeChatMessage = {
+  id: 'accepted',
+  role: 'tool',
+  timestamp: 2,
+  source: 'transcript',
+  blocks: [{ type: 'tool-result', output: '{"accepted":true}' }]
+}
+const completed: NativeChatMessage = {
+  id: 'async-1',
+  role: 'assistant',
+  timestamp: 2,
+  source: 'transcript',
+  blocks: [{ type: 'text', text: 'Which color?\n- Red (Recommended)\n- Blue\n\nAny constraints?' }]
+}
+
+describe('mobile async Codex question visibility', () => {
+  let renderer: ReactTestRenderer | null = null
+  let prompts: ReturnType<typeof useMobileNativeChatPrompts>
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  function Harness({
+    messages,
+    loading = false
+  }: {
+    messages: NativeChatMessage[]
+    loading?: boolean
+  }) {
+    prompts = useMobileNativeChatPrompts({
+      enabled: true,
+      status: null,
+      messages,
+      transcriptLoading: loading
+    })
+    return null
+  }
+
+  async function render(messages: NativeChatMessage[], loading = false) {
+    await act(async () => {
+      const element = createElement(Harness, { messages, loading })
+      if (renderer) {
+        renderer.update(element)
+      } else {
+        renderer = create(element)
+      }
+    })
+  }
+
+  it('shows titles, choices and free text after immediate acceptance while the agent continues', async () => {
+    await render([call, completed, accepted])
+    expect(prompts.ask?.questions).toEqual([
+      {
+        question: 'Which color?',
+        multiSelect: false,
+        options: [{ label: 'Red (Recommended)' }, { label: 'Blue' }]
+      },
+      { question: 'Any constraints?', multiSelect: false, options: [] }
+    ])
+    expect(prompts.permission).toBeNull()
+    await render([
+      call,
+      completed,
+      accepted,
+      { ...call, id: 'exec', blocks: [{ type: 'tool-call', name: 'exec_command', input: '{}' }] },
+      accepted
+    ])
+    expect(prompts.ask?.questions).toHaveLength(2)
+  })
+
+  it('withholds a cached card during reconnect and restores it after replay settles', async () => {
+    await render([call, completed, accepted], true)
+    expect(prompts.ask).toBeNull()
+    await render([call, completed, accepted])
+    expect(prompts.ask?.questions[0].question).toBe('Which color?')
+    await render([
+      call,
+      completed,
+      accepted,
+      {
+        id: 'answer',
+        role: 'user',
+        timestamp: 3,
+        source: 'transcript',
+        blocks: [{ type: 'text', text: 'Which color? Blue' }]
+      }
+    ])
+    expect(prompts.ask).toBeNull()
+  })
+
+  it('needs loaded call history and recovers the card when earlier messages are loaded', async () => {
+    const later = Array.from({ length: 40 }, (_, index) => ({ ...accepted, id: `later-${index}` }))
+    const history = [call, completed, accepted, ...later]
+    await render(history.slice(-40))
+    expect(prompts.ask).toBeNull()
+    await render(history)
+    expect(prompts.ask?.questions).toHaveLength(2)
+  })
+
+  it('does not infer acceptance from a result or an unrelated assistant message', () => {
+    expect(extractMobileAsyncAsk([call, accepted])).toBeNull()
+    expect(extractMobileAsyncAsk([call, { ...completed, id: 'unrelated' }, accepted])).toBeNull()
+  })
+
+  it.each([
+    '{broken',
+    '{"questions":[]}',
+    '{"questions":[{"title":"","options":["A"]}]}',
+    '{"questions":[{"title":"Choose","options":["A",null]}]}'
+  ])('leaves malformed input as ordinary transcript content: %s', (input) => {
+    const malformed = {
+      ...call,
+      blocks: [
+        { type: 'tool-call' as const, name: 'request_user_input_async', callId: 'async-1', input }
+      ]
+    }
+    expect(extractMobileAsyncAsk([malformed, completed, accepted])).toBeNull()
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-async-ask.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-async-ask.test.ts
@@ -1,8 +1,10 @@
 import { createElement } from 'react'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../src/shared/agent-status-types'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { useMobileNativeChatPrompts } from './use-mobile-native-chat-prompts'
+import { useMobileNativeChatAskDismiss } from './use-mobile-native-chat-ask-dismiss'
 import { extractMobileAsyncAsk } from './mobile-native-chat-async-ask'
 
 const asyncInput = {
@@ -43,6 +45,7 @@ const completed: NativeChatMessage = {
 describe('mobile async Codex question visibility', () => {
   let renderer: ReactTestRenderer | null = null
   let prompts: ReturnType<typeof useMobileNativeChatPrompts>
+  let dismissal: ReturnType<typeof useMobileNativeChatAskDismiss>
   afterEach(() => {
     act(() => renderer?.unmount())
     renderer = null
@@ -50,23 +53,36 @@ describe('mobile async Codex question visibility', () => {
 
   function Harness({
     messages,
-    loading = false
+    loading = false,
+    status = null
   }: {
     messages: NativeChatMessage[]
     loading?: boolean
+    status?: Partial<AgentStatusEntry> | null
   }) {
     prompts = useMobileNativeChatPrompts({
       enabled: true,
-      status: null,
+      status: status as AgentStatusEntry | null,
       messages,
       transcriptLoading: loading
+    })
+    dismissal = useMobileNativeChatAskDismiss({
+      ask: prompts.ask,
+      detectedAsk: prompts.detectedAsk,
+      scopeKey: 'tab',
+      sessionKey: 'session',
+      observing: !loading
     })
     return null
   }
 
-  async function render(messages: NativeChatMessage[], loading = false) {
+  async function render(
+    messages: NativeChatMessage[],
+    loading = false,
+    status: Partial<AgentStatusEntry> | null = null
+  ) {
     await act(async () => {
-      const element = createElement(Harness, { messages, loading })
+      const element = createElement(Harness, { messages, loading, status })
       if (renderer) {
         renderer.update(element)
       } else {
@@ -74,6 +90,28 @@ describe('mobile async Codex question visibility', () => {
       }
     })
   }
+
+  it.each(['working', 'done'] as const)(
+    'dismisses the async card despite a sticky blocking prompt while %s',
+    async (state) => {
+      const status = {
+        state,
+        interactivePrompt: JSON.stringify({
+          questions: [{ question: 'Old blocking question', options: ['A', 'B'] }]
+        })
+      }
+      const history = [call, completed, accepted]
+      await render(history, false, status)
+      expect(prompts.ask?.questions[0].question).toBe('Which color?')
+      expect(dismissal.showAsk).toBe(true)
+      act(() => dismissal.dismissAsk())
+      expect(dismissal.showAsk).toBe(false)
+
+      await render(history, true, status)
+      await render(history, false, status)
+      expect(dismissal.showAsk).toBe(false)
+    }
+  )
 
   it('shows titles, choices and free text after immediate acceptance while the agent continues', async () => {
     await render([call, completed, accepted])

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -16,6 +16,7 @@ import { useThrottledLatestValue } from './use-throttled-latest-value'
 import type { MobileNativeChatController } from './mobile-native-chat-controller-contract'
 import { useMobileBridgeChatPromptWrites } from './use-mobile-bridge-chat-prompt-writes'
 import { useMobileNativeChatActiveResolution } from './use-mobile-native-chat-active-resolution'
+import { useMobileNativeChatAskActions } from './use-mobile-native-chat-ask-actions'
 
 export type { MobileNativeChatController } from './mobile-native-chat-controller-contract'
 
@@ -251,8 +252,14 @@ export function useMobileNativeChatController(args: {
     recordSessionOptionCommandRef.current = recordNativeChatSessionOptionCommand
   }, [recordNativeChatSessionOptionCommand])
   // Card actions retire the route's held failure banner too, not just sends.
-  const answerAsk = useNativeChatAcceptedAction(handleNativeChatAnswerAsk, onSendResolved)
-  const cancelAsk = useNativeChatAcceptedAction(handleNativeChatCancelAsk, onSendResolved)
+  const { answer: answerAsk, cancel: cancelAsk } = useMobileNativeChatAskActions({
+    prompt: nativeChatAskPrompt,
+    setComposerText: setChatComposerText,
+    streamIdentity,
+    answerBlocking: handleNativeChatAnswerAsk,
+    cancelBlocking: handleNativeChatCancelAsk,
+    onSendResolved
+  })
   const handleNativeChatRespondPermission = activeChatStructured
     ? structuredNativeChat.respondPermission
     : legacyHandleNativeChatRespondPermission

--- a/mobile/src/session/use-mobile-native-chat-prompts.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.ts
@@ -4,6 +4,7 @@ import { parseAskFromStatus, resolveNativeChatAsk } from '../../../src/shared/na
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { detectAgentPermission, parseApprovalFromStatus } from './mobile-native-chat-permission'
 import { parseAgentQuestion } from './mobile-native-chat-question'
+import { extractMobileAsyncAsk } from './mobile-native-chat-async-ask'
 
 export type MobileNativeChatPrompts = {
   permission: ReturnType<typeof detectAgentPermission>
@@ -51,7 +52,8 @@ export function useMobileNativeChatPrompts(args: {
     [askFromStatus, transcriptLoading, messages]
   )
   const askFromMessages = askFromStatus ? null : resolvedAsk
-  const detectedAsk = askFromStatus ?? askFromMessages
+  const asyncAsk = useMemo(() => extractMobileAsyncAsk(messages), [messages])
+  const detectedAsk = askFromStatus ?? askFromMessages ?? asyncAsk
 
   return {
     permission,
@@ -62,6 +64,10 @@ export function useMobileNativeChatPrompts(args: {
     // transcript fallback clears itself when the tool result lands, and it is the
     // only source left once the hook row goes stale and projects to `done` with
     // no interactivePrompt — gating it too strands a genuinely pending question.
-    ask: enabled ? ((blocked ? askFromStatus : null) ?? askFromMessages) : null
+    ask: enabled
+      ? ((blocked ? askFromStatus : null) ??
+        askFromMessages ??
+        (!permission && !transcriptLoading ? asyncAsk : null))
+      : null
   }
 }

--- a/mobile/src/session/use-mobile-native-chat-prompts.ts
+++ b/mobile/src/session/use-mobile-native-chat-prompts.ts
@@ -53,7 +53,9 @@ export function useMobileNativeChatPrompts(args: {
   )
   const askFromMessages = askFromStatus ? null : resolvedAsk
   const asyncAsk = useMemo(() => extractMobileAsyncAsk(messages), [messages])
-  const detectedAsk = askFromStatus ?? askFromMessages ?? asyncAsk
+  // A hidden sticky blocking prompt must not own a displayed async card's dismissal.
+  const detectedAsk =
+    (blocked ? askFromStatus : null) ?? askFromMessages ?? asyncAsk ?? askFromStatus
 
   return {
     permission,

--- a/src/shared/native-chat-ask.test.ts
+++ b/src/shared/native-chat-ask.test.ts
@@ -168,6 +168,11 @@ describe('extractPendingAsk', () => {
 })
 
 describe('parseAskFromStatus', () => {
+  it('never treats async request_user_input as a blocking selector', () => {
+    expect(
+      parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT), 'request_user_input_async')
+    ).toBeNull()
+  })
   it('accepts the canonical shape from any tool name and rejects broken JSON', () => {
     expect(
       parseAskFromStatus(JSON.stringify(QUESTIONS_INPUT), 'SomeNewTool')?.questions

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -77,6 +77,10 @@ for (const name of ['AskUserQuestion', 'ask_user_question', 'askUserQuestion']) 
 }
 
 function parseToolInput(toolName: string | undefined, input: unknown): AskPrompt | null {
+  // Async questions return before the user answers and never own a blocking selector.
+  if (toolName === 'request_user_input_async') {
+    return null
+  }
   const parser = toolName ? QUESTION_TOOL_PARSERS.get(toolName) : undefined
   return (parser ? parser(input) : null) ?? parseQuestionsShape(input)
 }


### PR DESCRIPTION
## ELI5

Codex can ask questions while it keeps working. Orca mobile now shows those questions and choices in a card. **Add to message** puts the selected answers into the message box while preserving the existing draft; the user reviews and sends the message normally. **Dismiss** closes the mobile card locally.

## What Changed

- Recognize `request_user_input_async` titles, string options and title-only questions from loaded Codex transcripts, after the matching assistant completion confirms that Codex displayed them.
- Keep the card through immediate `{"accepted":true}` results, unrelated tool activity and settled replay; a new user message clears the local projection.
- Reuse the mobile question wizard and existing composer. Separate async draft composition from blocking selector delivery, including cancellation and send-error handling.
- Key dismissal by call identity, and reject stale callbacks after prompt/session changes. A previous sticky blocking prompt cannot prevent the displayed async card from dismissing.
- Exclude async calls from the shared blocking-question parser, so object-shaped inputs cannot accidentally receive selector keys.

## Why

The missing card is reproducible on main. Codex 0.153.4's [async handler](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/core/src/tools/handlers/request_user_input_async.rs) emits an assistant item and returns immediately; its questions use `title` and optional string options. It does not use the pending JSON-RPC request or blocking TUI selector lifecycle of `request_user_input`.

The installed 1.4.188 bundle and current main already decode the ordinary assistant text. This change adds the missing mobile decision surface, without claiming that the whole transcript was blank.

## Linked Issue

Refs #20073



## Visual Proof

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/22482385-3ba4-4527-be1d-f037eb06c4b1) | ![After](https://github.com/user-attachments/assets/fce5cdde-48d4-4544-b3d7-fa7969861b1d) |

[Selected answers appended to the existing draft](https://github.com/user-attachments/assets/4de1108a-cff5-4987-aac4-c598264fc28a)

These show the real mobile prompt components mounted in an isolated React Native Web harness at 390×844. The before build uses the base prompt hook. The harness disables transport; it is not an iOS/Android or paired-device screenshot.

## Testing

- [x] Automated tests added/updated
- [ ] Manually tested on an actual mobile device

All commands used `ORCA_BACKGROUND_LAUNCH=1` where applicable.

- Root focused Vitest: **4 files, 43 tests passed** — shared ask parser/FIFO and Codex hook question lifecycle.
- Mobile focused Vitest: **13 files, 164 tests passed** — decoder→mobile sanitizer→card projection, immediate acceptance, concurrent tools, replay/page boundary, new-user answer, repeated call identity, draft preservation, no async digit/Escape delivery, stale-session callback, existing controller and blocking-answer behavior, plus the new upstream live-turn indicator/view suites.
- Added integrated prompt/dismissal regressions for sticky blocking status during `working` and `done`, including reconnect retention. Both assertions failed before the correction and pass afterward.
- Targeted strict TypeScript check of the changed parser/action/prompt/dismissal modules passed.
- Changed-file root/mobile oxlint, max-lines rules, formatting and `git diff --check` passed.
- Headless Chromium click flow selected a non-default option and free text, then verified the preserved draft; no page errors.

GitHub PR/Mobile checks currently require approval to run for this external contribution; no full-CI success is claimed. Full workspace typecheck, build and full test suite were not run. Validation used a bounded temporary dependency set (Vitest 4.1.11, TypeScript 6.0.3) because this is a sparse checkout with limited disk space; the local pnpm launcher also fails before execution. Changed JSX/controller behavior has component/controller and browser coverage, not a full Expo typecheck.

## AI Disclosure

OpenAI Codex (GPT-6 Astra) assisted with investigation, implementation, tests and review.

## Author

GitHub: @jakeparkcolde. X/Twitter handle not supplied.

## Review

Self-review found no new platform-specific path/keyboard behavior, RPC method, stream opcode, host status producer, auth/permission policy, or git-provider dependency. SSH/local/folder-workspace behavior uses the existing transcript and draft paths. Work is linear in the loaded transcript; no background poller or persistent host cache is added. Existing mobile theme tokens and the existing question wizard are reused. Async card actions perform no network write and cannot clear a prior send-failure banner as if an answer had been delivered.

Coordinator reviewed the final diff, test output and visual artifacts; actual device/transport verification and full workspace CI remain pending. Latest commit: `d17acefc20ef6a748bf952b23d60ff6776b6fd49`, based on upstream `fab78c766952404a1296d519a1dd76df6ed8d12e`. The overlap with #19977 was resolved by reusing its new `useMobileBridgeChatPromptWrites` hook. An additional independent review found and verified the sticky-status dismissal correction; its focused rerun passed 42 tests across 5 files, with no remaining blocking finding in the reviewed scope.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer material is copied.

## Notes

- **Loaded-history limit:** mobile initially loads 40 messages. Both the async call and its matching assistant item must be loaded. Older calls require loading earlier history. Invalid/clipped tool input is not converted into a partial card; the existing assistant prose remains the fallback. Tests cover the page boundary and recovery after loading earlier records.
- **Composition only:** Add to message prepares a draft; it does not submit an answer or resolve Codex's retained question editor. Actual Codex TUI/paired-network reply delivery, iOS/Android, native desktop, SSH and cross-version device runs remain unverified.
- A new user message ends the local question projection; this is not a claim that Codex emitted `serverRequest/resolved` for an async question.
- Native structured app-server sessions are outside this change. The separate blocking serialized-arguments fallback issue discovered during investigation is not fixed or claimed here.

## Checklist

- [x] Small, focused mobile decision-card improvement
- [x] Behavior and boundaries explained
- [x] Before/after attachments uploaded to GitHub
- [x] Self-reviewed for correctness, security and performance
- [x] Cross-platform, SSH/remote and folder-workspace impact considered
- [ ] Full lint/typecheck/test/build CI gates completed
