### PR TITLE
perf(daemon): stop scanning every cell for OSC links that cannot exist

### DIFF
--- a/src/main/daemon/headless-osc-link-ranges.test.ts
+++ b/src/main/daemon/headless-osc-link-ranges.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { HeadlessEmulator } from './headless-emulator'
+
+// Why this suite: collectHeadlessOscLinkRanges skips its per-cell scan when
+// xterm holds no OSC 8 registration. That skip is only safe if it can never
+// fire while a link is reachable, so each case below pins one way it could.
+let emulator: HeadlessEmulator | undefined
+
+const link = (uri: string, text: string): string => `\x1b]8;;${uri}\x1b\\${text}\x1b]8;;\x1b\\`
+
+afterEach(() => {
+  emulator?.dispose()
+  emulator = undefined
+})
+
+describe('headless OSC link ranges', () => {
+  it('finds a link written into the buffer', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write(`before ${link('https://example.com/a', 'CLICK')} after`)
+
+    const ranges = emulator.getSnapshot().oscLinks ?? []
+    expect(ranges).toHaveLength(1)
+    expect(ranges[0]).toMatchObject({ row: 0, uri: 'https://example.com/a' })
+  })
+
+  it('returns nothing for a buffer that never emitted a link', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('plain output with no hyperlink\r\n'.repeat(50))
+
+    expect(emulator.getSnapshot().oscLinks).toEqual([])
+  })
+
+  // The dangerous case: restored ranges are seeded without xterm registering
+  // anything, so an early-out keyed only on the registry would drop them.
+  it('still maps restored ranges when the buffer itself has no link', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('restored row')
+    const restored = { row: 0, startCol: 0, endCol: 4, uri: 'https://example.com/restored' }
+    emulator.setRestoredOscLinks([restored])
+
+    expect(emulator.getSnapshot().oscLinks).toEqual([restored])
+  })
+
+  it('finds links far down a long scrollback, not just the visible screen', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24, scrollback: 5_000 })
+    await emulator.write(`${link('https://example.com/top', 'TOP')}\r\n`)
+    await emulator.write('filler\r\n'.repeat(2_000))
+
+    const ranges = emulator.getSnapshot({ scrollbackRows: 5_000 }).oscLinks ?? []
+    expect(ranges.map((range) => range.uri)).toContain('https://example.com/top')
+  })
+
+  it('keeps every distinct link when several are present', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write(
+      `${link('https://example.com/1', 'ONE')} ${link('https://example.com/2', 'TWO')}`
+    )
+
+    const uris = (emulator.getSnapshot().oscLinks ?? []).map((range) => range.uri)
+    expect(uris).toContain('https://example.com/1')
+    expect(uris).toContain('https://example.com/2')
+  })
+})

--- a/src/main/daemon/headless-osc-link-ranges.ts
+++ b/src/main/daemon/headless-osc-link-ranges.ts
@@ -1,10 +1,14 @@
-import type { Terminal } from '@xterm/headless'
+import type { IBufferCell, IBufferLine, Terminal } from '@xterm/headless'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
 
 type TerminalWithOscLinks = Terminal & {
   _core?: {
     _oscLinkService?: {
       getLinkData: (linkId: number) => { uri?: string } | undefined
+      // Why read it: xterm registers every OSC 8 id here, so an empty registry
+      // proves the buffer holds no hyperlink and the per-cell scan can be skipped.
+      // Optional because it is private — an xterm that renames it just scans.
+      _dataByLinkId?: { size?: number }
     }
   }
 }
@@ -12,6 +16,11 @@ type TerminalWithOscLinks = Terminal & {
 type CellWithOscLink = {
   extended?: { urlId?: number }
   hasExtendedAttrs?: () => boolean
+}
+
+/** True when xterm holds no OSC 8 registration at all, so no cell can carry one. */
+function hasNoRegisteredOscLinks(service: { _dataByLinkId?: { size?: number } }): boolean {
+  return service._dataByLinkId?.size === 0
 }
 
 export function collectHeadlessOscLinkRanges(
@@ -26,9 +35,19 @@ export function collectHeadlessOscLinkRanges(
     return []
   }
   const buffer = terminal.buffer.active
+  // Why before the scan: the walk below reads every cell of every row, and a
+  // session that never emitted a hyperlink — the overwhelming majority — would
+  // pay that for a guaranteed-empty result. `restoredLinks` still needs mapping.
+  if (hasNoRegisteredOscLinks(service) && restoredLinks.length === 0) {
+    return []
+  }
   const startRow =
     scrollbackRows === undefined ? 0 : Math.max(0, buffer.length - terminal.rows - scrollbackRows)
   const ranges: TerminalOscLinkRange[] = []
+  // Why one cell for the whole walk: xterm's getCell allocates a fresh CellData
+  // per call unless handed a target, which is a per-cell allocation across the
+  // entire scrollback. See the IBufferLine.getCell docs.
+  const scratchCell = buffer.getNullCell()
   for (let row = startRow; row < buffer.length; row += 1) {
     const line = buffer.getLine(row)
     if (!line) {
@@ -38,7 +57,7 @@ export function collectHeadlessOscLinkRanges(
     let currentUrlId = 0
     let currentStart = -1
     for (let col = 0; col <= lineLength; col += 1) {
-      const urlId = col < lineLength ? getOscLinkIdAtCell(line, col) : 0
+      const urlId = col < lineLength ? getOscLinkIdAtCell(line, col, scratchCell) : 0
       if (urlId === currentUrlId) {
         continue
       }
@@ -83,8 +102,8 @@ function dedupeOscLinkRanges(ranges: TerminalOscLinkRange[]): TerminalOscLinkRan
   })
 }
 
-function getOscLinkIdAtCell(line: { getCell: (col: number) => unknown }, col: number): number {
-  const cell = line.getCell(col) as CellWithOscLink | undefined
+function getOscLinkIdAtCell(line: IBufferLine, col: number, scratchCell: IBufferCell): number {
+  const cell = line.getCell(col, scratchCell) as (IBufferCell & CellWithOscLink) | undefined
   // Why: OSC link IDs live in extended cell attrs; missing attrs means no link.
   return cell?.hasExtendedAttrs?.() && cell.extended?.urlId ? cell.extended.urlId : 0
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

## ELI5

Every time Orca saves a terminal's contents, it also scanned every single character looking for clickable links — even in terminals that have never contained one. That scan created a throwaway object per character, so a long session paid for millions of them to find nothing.

Now it checks first whether the terminal has any links at all, and skips the scan when it doesn't.

## Problem

`collectHeadlessOscLinkRanges` runs on every `getSnapshot()`, walking every cell of every row. Two costs, both avoidable:

1. **No early-out.** A session that never emitted an OSC 8 hyperlink — the overwhelming majority — still walked the whole scrollback for a guaranteed-empty result.
2. **Per-cell allocation.** `getOscLinkIdAtCell` called `line.getCell(col)` without the reuse argument, so xterm allocated a fresh `CellData` per cell. At 5000×200 that is a million allocations per snapshot.

This is squarely our bug, not an xterm one. xterm already reuses two alternating cells in its own `SerializeAddon` walk, already emits OSC 8 inline during that single pass, and its headless typings document the overload we were not using:

> `line.getCell(x, cell)`. Use this to avoid costly recreation…
> — `@xterm/headless` typings, `IBufferLine.getCell`

No package patching, no vendoring — the fix is entirely in our own file.

## Fix

- Skip the scan when xterm's OSC link registry is empty **and** there are no restored ranges to map.
- Reuse a single scratch cell across the walk.

The registry read is private (`_oscLinkService._dataByLinkId`), so it is typed optional: an xterm that renames it simply scans as before rather than breaking.

## Proof

`collectHeadlessOscLinkRanges` over a 5000-row link-free buffer at 200 cols, agent-transcript-shaped content, same harness run back to back, median of 25 iterations:

The two halves are independent, so both cases improve. Same buffer shape, agent-transcript-shaped content, each arm run back to back in the same harness, median of 25 iterations:

| 5000-row buffer, 200 cols | Before | After | |
|---|---|---|---|
| No hyperlinks (early-out fires) | **43.85 ms** | **0.00 ms** | scan skipped |
| 250 hyperlinks (early-out cannot fire) | **13.49 ms** | **3.62 ms** | 3.7x, from cell reuse alone |

Both arms of the second row find the same 250 links, so that is a pure speed-up rather than a behaviour change.

Note the link-free buffer was the *slower* of the two before the fix despite doing less work — with no links the walk touches and allocates for every cell. The allocation, not the scanning, was the dominant cost in both cases.

Where it lands: `getSnapshot()` runs on daemon reattach (the worktree-switch click path) and on the periodic checkpoint during an active agent session, where it repeats at full depth — so the saving compounds there rather than being a one-off.

## Correctness

New `headless-osc-link-ranges.test.ts`, 5 cases, all of them aimed at the one way an early-out can be wrong — firing while a link is still reachable:

- finds a link written into the buffer
- returns nothing when none was ever emitted
- **still maps restored ranges when the buffer itself has no link** — restored ranges are seeded without xterm registering anything, so an early-out keyed only on the registry would silently drop them. Verified load-bearing: dropping the `restoredLinks` half of the guard fails this test and only this test.
- finds links deep in a 5000-row scrollback, not just the visible screen
- keeps every distinct link when several are present

`pnpm tc` clean, `check:code-quality:changed` 0 new findings, 1,863 daemon tests pass.

