### PR TITLE
feat(cli): `orca terminal attach` for interactive PTY attach

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -135,7 +135,22 @@
     "../src/main/startup/cli-command-names.ts",
     "../src/main/runtime/runtime-metadata.ts",
     "../src/main/sqlite/sync-database.ts",
-    "../src/main/win32-utils.ts"
+    "../src/main/win32-utils.ts",
+    // Why: `orca terminal attach` speaks the daemon NDJSON protocol directly;
+    // the list is the transitive import closure of the CLI's daemon modules.
+    "../src/main/daemon/daemon-checkpoint-file.ts",
+    "../src/main/daemon/daemon-create-or-attach-result.ts",
+    "../src/main/daemon/daemon-errors.ts",
+    "../src/main/daemon/daemon-foreground-process-protocol.ts",
+    "../src/main/daemon/daemon-hello-protocol.ts",
+    "../src/main/daemon/daemon-protocol-version.ts",
+    "../src/main/daemon/daemon-respawn-throttle.ts",
+    "../src/main/daemon/daemon-spawner.ts",
+    "../src/main/daemon/daemon-stream-events.ts",
+    "../src/main/daemon/terminal-history-seed-transfer-protocol.ts",
+    "../src/main/daemon/terminal-modes.ts",
+    "../src/main/daemon/terminal-snapshot.ts",
+    "../src/main/daemon/types.ts"
   ],
   "compilerOptions": {
     "composite": true,

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -257,7 +257,11 @@ export const electronViteConfig: UserConfig = {
             'src/main/codex/managed-home-shell-preflight.ts'
           ),
           // Why: account import mutates the user's macOS Keychain from the CLI.
-          'claude-accounts/keychain': resolve('src/main/claude-accounts/keychain.ts')
+          'claude-accounts/keychain': resolve('src/main/claude-accounts/keychain.ts'),
+          // Why: the CLI imports these for `orca terminal attach`; they must survive out/main rebuilds.
+          'daemon/daemon-protocol-version': resolve('src/main/daemon/daemon-protocol-version.ts'),
+          'daemon/daemon-spawner': resolve('src/main/daemon/daemon-spawner.ts'),
+          'daemon/types': resolve('src/main/daemon/types.ts')
         },
         // Why: Rolldown's SSR default is ESM, but Electron and sidecar launchers
         // consume these stable CommonJS paths.

--- a/src/cli/handler-group-manifest.ts
+++ b/src/cli/handler-group-manifest.ts
@@ -89,6 +89,7 @@ export const HANDLER_GROUPS: readonly HandlerGroup[] = [
       'terminal show',
       'terminal read',
       'terminal send',
+      'terminal attach',
       'terminal wait',
       'terminal stop',
       'terminal rename',

--- a/src/cli/handlers/terminal-attach.ts
+++ b/src/cli/handlers/terminal-attach.ts
@@ -1,0 +1,21 @@
+import type { CommandHandler } from '../dispatch'
+import { RuntimeClientError } from '../runtime-client'
+import { attachToTerminalDaemon } from '../runtime/terminal-daemon-attach'
+import { getTerminalHandle } from '../selectors'
+
+export const terminalAttachHandler: CommandHandler = async ({ flags, client, cwd, json }) => {
+  if (json) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      '--json is not supported for terminal attach; the command is an interactive PTY bridge.'
+    )
+  }
+  if (client.isRemote) {
+    throw new RuntimeClientError(
+      'incompatible_runtime',
+      'terminal attach is local-only: this CLI is paired with a remote runtime, whose terminals live on the remote host. Run `orca terminal attach` on the remote host itself, or use the Orca desktop UI.'
+    )
+  }
+  const handle = await getTerminalHandle(flags, cwd, client)
+  await attachToTerminalDaemon(handle, { readOnly: flags.get('read-only') === true })
+}

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -37,6 +37,7 @@ import {
   getRequiredWorktreeSelector,
   getTerminalHandle
 } from '../selectors'
+import { terminalAttachHandler } from './terminal-attach'
 import { terminalCloseHandler } from './terminal-close'
 import { terminalSendHandler } from './terminal-send'
 
@@ -109,6 +110,7 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, formatTerminalRead)
   },
   'terminal send': terminalSendHandler,
+  'terminal attach': terminalAttachHandler,
   'terminal wait': async ({ flags, client, cwd, json }) => {
     const timeoutMs = getOptionalPositiveIntegerFlag(flags, 'timeout-ms')
     const result = await client.call<{ wait: RuntimeTerminalWait }>(

--- a/src/cli/runtime/terminal-daemon-attach-detach-scan.test.ts
+++ b/src/cli/runtime/terminal-daemon-attach-detach-scan.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { scanForDetach } from './terminal-daemon-attach'
+
+const CTRL_BACKSLASH = 0x1c
+const Q = 0x71
+
+describe('scanForDetach', () => {
+  it('forwards ordinary bytes unchanged', () => {
+    const r = scanForDetach(Buffer.from('ls\r'), false)
+    expect(r.bytes).toEqual([...Buffer.from('ls\r')])
+    expect(r.detached).toBe(false)
+    expect(r.prefixPending).toBe(false)
+  })
+
+  it('detaches on Ctrl-\\ then q in one chunk', () => {
+    const r = scanForDetach(Buffer.from([CTRL_BACKSLASH, Q]), false)
+    expect(r.detached).toBe(true)
+    expect(r.bytes).toEqual([])
+  })
+
+  it('forwards Ctrl-\\ followed by a non-q byte verbatim (both bytes)', () => {
+    const r = scanForDetach(Buffer.from([CTRL_BACKSLASH, 0x61]), false)
+    expect(r.detached).toBe(false)
+    expect(r.bytes).toEqual([CTRL_BACKSLASH, 0x61])
+    expect(r.prefixPending).toBe(false)
+  })
+
+  it('holds a lone trailing Ctrl-\\ across the chunk boundary', () => {
+    const first = scanForDetach(Buffer.from([0x61, CTRL_BACKSLASH]), false)
+    expect(first.bytes).toEqual([0x61])
+    expect(first.prefixPending).toBe(true)
+    // Next chunk's q completes the detach sequence.
+    const second = scanForDetach(Buffer.from([Q]), first.prefixPending)
+    expect(second.detached).toBe(true)
+  })
+
+  it('forwards a held Ctrl-\\ when the next chunk is not q', () => {
+    const first = scanForDetach(Buffer.from([CTRL_BACKSLASH]), false)
+    expect(first.prefixPending).toBe(true)
+    expect(first.bytes).toEqual([])
+    const second = scanForDetach(Buffer.from([0x62]), first.prefixPending)
+    expect(second.detached).toBe(false)
+    expect(second.bytes).toEqual([CTRL_BACKSLASH, 0x62])
+  })
+})

--- a/src/cli/runtime/terminal-daemon-attach.ts
+++ b/src/cli/runtime/terminal-daemon-attach.ts
@@ -130,7 +130,7 @@ export async function attachToTerminalDaemon(
 }
 
 // Why: Ctrl-\ is the detach prefix; a following q detaches, anything else forwards the swallowed byte.
-function scanForDetach(
+export function scanForDetach(
   chunk: Buffer,
   prefixPending: boolean
 ): { bytes: number[]; detached: boolean; prefixPending: boolean } {

--- a/src/cli/runtime/terminal-daemon-attach.ts
+++ b/src/cli/runtime/terminal-daemon-attach.ts
@@ -46,20 +46,25 @@ export async function attachToTerminalDaemon(
     })
     renderSnapshot(attach.snapshot)
 
-    connection.onEvent((raw) => {
-      const event = raw as DaemonEvent
-      if (event.sessionId !== sessionId) {
-        return
-      }
-      if (event.event === 'data') {
-        process.stdout.write(event.payload.data)
-      } else if (event.event === 'exit') {
-        endBridge({ kind: 'exit', code: event.payload.code ?? null })
-      }
-      // Why: terminalError/backgroundMarker/dataGap/transientFact are diagnostics; an attached viewer ignores them.
-    })
+    connection.onEvent(
+      (raw) => {
+        const event = raw as DaemonEvent
+        if (event.sessionId !== sessionId) {
+          return
+        }
+        if (event.event === 'data') {
+          process.stdout.write(event.payload.data)
+        } else if (event.event === 'exit') {
+          endBridge({ kind: 'exit', code: event.payload.code ?? null })
+        }
+        // Why: terminalError/backgroundMarker/dataGap/transientFact are diagnostics; an attached viewer ignores them.
+      },
+      // Why: the daemon dropped our stream (session gone / daemon exit); settle
+      // the bridge so teardown runs instead of awaiting forever.
+      () => endBridge({ kind: 'exit', code: null })
+    )
 
-    const restoreTty = enterRawMode(options.readOnly)
+    const restoreTty = enterRawMode()
     teardown.push(restoreTty)
     let detachPrefixPending = false
     const onStdinData = (chunk: Buffer): void => {
@@ -69,7 +74,8 @@ export async function attachToTerminalDaemon(
         endBridge({ kind: 'detach' })
         return
       }
-      if (scan.bytes.length > 0) {
+      // Why: read-only still scans for the detach key but never writes to the PTY.
+      if (!options.readOnly && scan.bytes.length > 0) {
         connection.notify('write', { sessionId, data: Buffer.from(scan.bytes).toString('utf8') })
       }
     }
@@ -80,7 +86,9 @@ export async function attachToTerminalDaemon(
       }
     }
     const onSignal = (): void => endBridge({ kind: 'detach' })
-    if (!options.readOnly) {
+    // Why: read stdin in both modes so Ctrl-\ q always detaches; only the PTY
+    // write and resize are suppressed under --read-only.
+    if (process.stdin.isTTY) {
       process.stdin.on('data', onStdinData)
       teardown.push(() => {
         process.stdin.removeListener('data', onStdinData)
@@ -88,6 +96,8 @@ export async function attachToTerminalDaemon(
         // process hangs after detach instead of exiting.
         process.stdin.pause()
       })
+    }
+    if (!options.readOnly) {
       const size = currentTerminalSize()
       if (size && (size.cols !== session.cols || size.rows !== session.rows)) {
         connection.notify('resize', { sessionId, ...size })
@@ -169,8 +179,8 @@ function currentTerminalSize(): { cols: number; rows: number } | null {
   return cols && rows ? { cols, rows } : null
 }
 
-function enterRawMode(readOnly: boolean): () => void {
-  if (readOnly || !process.stdin.isTTY) {
+function enterRawMode(): () => void {
+  if (!process.stdin.isTTY) {
     return () => {}
   }
   process.stdin.setRawMode(true)

--- a/src/cli/runtime/terminal-daemon-attach.ts
+++ b/src/cli/runtime/terminal-daemon-attach.ts
@@ -1,0 +1,178 @@
+import type {
+  CreateOrAttachResult,
+  DaemonEvent,
+  SessionInfo,
+  TerminalSnapshot
+} from '../../main/daemon/types'
+import { TerminalDaemonConnection } from './terminal-daemon-socket'
+
+const DETACH_PREFIX_BYTE = 0x1c // Ctrl-\
+const DETACH_CONFIRM_BYTE = 0x71 // q
+const DETACH_TIMEOUT_MS = 5_000
+
+export type TerminalAttachOptions = { readOnly: boolean }
+
+type AttachOutcome = { kind: 'detach' } | { kind: 'exit'; code: number | null }
+
+/** Attach the local terminal to the live daemon session behind `handle`. */
+export async function attachToTerminalDaemon(
+  handle: string,
+  options: TerminalAttachOptions
+): Promise<void> {
+  const connection = await TerminalDaemonConnection.connect()
+  let outcome: AttachOutcome | undefined
+  let sessionId: string | undefined
+  // Why: teardown must run on every exit path (normal, throw, signal) so raw mode
+  // is always restored and no listener leaks; register steps as they succeed.
+  const teardown: (() => void)[] = []
+  const { promise: bridgeEnded, resolve: endBridge } = Promise.withResolvers<AttachOutcome>()
+  try {
+    const sessions = await connection.request<{ sessions: SessionInfo[] }>(
+      'listSessions',
+      undefined
+    )
+    const session = sessions.sessions.find(
+      (candidate) => candidate.terminalHandle === handle && candidate.isAlive
+    )
+    if (!session) {
+      throw new Error(`No live terminal for handle "${handle}".`)
+    }
+    sessionId = session.sessionId
+    const attach = await connection.request<CreateOrAttachResult>('createOrAttach', {
+      sessionId,
+      cols: session.cols,
+      rows: session.rows,
+      attachOnly: true
+    })
+    renderSnapshot(attach.snapshot)
+
+    connection.onEvent((raw) => {
+      const event = raw as DaemonEvent
+      if (event.sessionId !== sessionId) {
+        return
+      }
+      if (event.event === 'data') {
+        process.stdout.write(event.payload.data)
+      } else if (event.event === 'exit') {
+        endBridge({ kind: 'exit', code: event.payload.code ?? null })
+      }
+      // Why: terminalError/backgroundMarker/dataGap/transientFact are diagnostics; an attached viewer ignores them.
+    })
+
+    const restoreTty = enterRawMode(options.readOnly)
+    teardown.push(restoreTty)
+    let detachPrefixPending = false
+    const onStdinData = (chunk: Buffer): void => {
+      const scan = scanForDetach(chunk, detachPrefixPending)
+      detachPrefixPending = scan.prefixPending
+      if (scan.detached) {
+        endBridge({ kind: 'detach' })
+        return
+      }
+      if (scan.bytes.length > 0) {
+        connection.notify('write', { sessionId, data: Buffer.from(scan.bytes).toString('utf8') })
+      }
+    }
+    const onResize = (): void => {
+      const size = currentTerminalSize()
+      if (size) {
+        connection.notify('resize', { sessionId, ...size })
+      }
+    }
+    const onSignal = (): void => endBridge({ kind: 'detach' })
+    if (!options.readOnly) {
+      process.stdin.on('data', onStdinData)
+      teardown.push(() => {
+        process.stdin.removeListener('data', onStdinData)
+        // Why: raw-mode stdin keeps the event loop alive; without this the CLI
+        // process hangs after detach instead of exiting.
+        process.stdin.pause()
+      })
+      const size = currentTerminalSize()
+      if (size && (size.cols !== session.cols || size.rows !== session.rows)) {
+        connection.notify('resize', { sessionId, ...size })
+      }
+      if (process.platform !== 'win32') {
+        process.on('SIGWINCH', onResize)
+        teardown.push(() => process.removeListener('SIGWINCH', onResize))
+      }
+    }
+    process.on('SIGINT', onSignal)
+    process.on('SIGTERM', onSignal)
+    teardown.push(() => {
+      process.removeListener('SIGINT', onSignal)
+      process.removeListener('SIGTERM', onSignal)
+    })
+    process.stderr.write(`Attached to ${handle}. Detach with Ctrl-\\ then q.\n`)
+
+    outcome = await bridgeEnded
+  } finally {
+    // Why: run in reverse so raw mode is restored last, after listeners are gone.
+    for (const step of teardown.toReversed()) {
+      try {
+        step()
+      } catch {
+        // Why: one failing teardown step must not skip the rest (esp. restoreTty).
+      }
+    }
+    if (outcome?.kind === 'detach' && sessionId !== undefined) {
+      try {
+        await connection.request('detach', { sessionId }, DETACH_TIMEOUT_MS)
+      } catch {
+        // Why: best effort — the session and its process must keep running regardless.
+      }
+    }
+    connection.close()
+    if (outcome?.kind === 'exit' && outcome.code !== null) {
+      process.exitCode = outcome.code
+    }
+  }
+}
+
+// Why: Ctrl-\ is the detach prefix; a following q detaches, anything else forwards the swallowed byte.
+function scanForDetach(
+  chunk: Buffer,
+  prefixPending: boolean
+): { bytes: number[]; detached: boolean; prefixPending: boolean } {
+  const bytes: number[] = []
+  let detached = false
+  for (const byte of chunk) {
+    if (prefixPending) {
+      prefixPending = false
+      if (byte === DETACH_CONFIRM_BYTE) {
+        detached = true
+        break
+      }
+      bytes.push(DETACH_PREFIX_BYTE, byte)
+      continue
+    }
+    if (byte === DETACH_PREFIX_BYTE) {
+      prefixPending = true
+      continue
+    }
+    bytes.push(byte)
+  }
+  return { bytes, detached, prefixPending }
+}
+
+function renderSnapshot(snapshot: TerminalSnapshot | null): void {
+  if (!snapshot) {
+    return
+  }
+  process.stdout.write(
+    snapshot.rehydrateSequences + snapshot.snapshotAnsi + (snapshot.pendingEscapeTailAnsi ?? '')
+  )
+}
+
+function currentTerminalSize(): { cols: number; rows: number } | null {
+  const { columns: cols, rows } = process.stdout
+  return cols && rows ? { cols, rows } : null
+}
+
+function enterRawMode(readOnly: boolean): () => void {
+  if (readOnly || !process.stdin.isTTY) {
+    return () => {}
+  }
+  process.stdin.setRawMode(true)
+  return () => process.stdin.setRawMode(false)
+}

--- a/src/cli/runtime/terminal-daemon-socket-utf8.test.ts
+++ b/src/cli/runtime/terminal-daemon-socket-utf8.test.ts
@@ -1,0 +1,36 @@
+import { StringDecoder } from 'node:string_decoder'
+import { describe, expect, it } from 'vitest'
+import { createNdjsonParser, encodeNdjson } from '../../shared/main-process-ndjson-framer'
+
+// Guards the socket-read decode contract in terminal-daemon-socket.ts: a multibyte
+// UTF-8 sequence split across two socket chunks must round-trip, not become U+FFFD.
+describe('daemon socket NDJSON UTF-8 decoding', () => {
+  it('reassembles a multibyte sequence split across chunks (StringDecoder path)', () => {
+    const messages: unknown[] = []
+    const decoder = new StringDecoder('utf8')
+    const parser = createNdjsonParser(
+      (msg) => messages.push(msg),
+      () => {}
+    )
+    // A CJK char (3 bytes) and an emoji (4 bytes) inside a JSON line.
+    const line = Buffer.from(encodeNdjson({ data: '数🐳' }), 'utf8')
+    // Split mid-codepoint at several boundaries.
+    for (let cut = 1; cut < line.length; cut += 3) {
+      parser.feed(decoder.write(line.subarray(0, cut)))
+      parser.feed(decoder.write(line.subarray(cut)))
+      const last = messages.pop() as { data: string }
+      expect(last.data).toBe('数🐳')
+      expect(last.data).not.toContain('�')
+    }
+  })
+
+  it('per-chunk toString would corrupt — sanity check of the failure mode', () => {
+    // The old code path: decoding each chunk independently yields replacement chars.
+    // Split at the exact middle of the 4-byte emoji so the cut lands inside it.
+    const emoji = Buffer.from('🐳', 'utf8') // 4 bytes
+    const head = Buffer.concat([Buffer.from('{"data":"', 'utf8'), emoji.subarray(0, 2)])
+    const tail = Buffer.concat([emoji.subarray(2), Buffer.from('"}', 'utf8')])
+    const naive = head.toString('utf8') + tail.toString('utf8')
+    expect(naive).toContain('�')
+  })
+})

--- a/src/cli/runtime/terminal-daemon-socket.ts
+++ b/src/cli/runtime/terminal-daemon-socket.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { connect, type Socket } from 'node:net'
 import { join } from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
 import { PROTOCOL_VERSION } from '../../main/daemon/daemon-protocol-version'
 import { getDaemonSocketPath, getDaemonTokenPath } from '../../main/daemon/daemon-spawner'
 import { NOTIFY_PREFIX, type RpcResponse } from '../../main/daemon/types'
@@ -30,7 +31,10 @@ function nextMessageReader(socket: Socket): (timeoutMs?: number) => Promise<unkn
     }
   }
   const parser = createNdjsonParser(deliver, (err) => socket.destroy(err))
-  socket.on('data', (chunk: Buffer) => parser.feed(chunk.toString('utf8')))
+  // Why: decode across chunk boundaries so a multibyte UTF-8 sequence split by a
+  // socket read isn't emitted as U+FFFD (matches the daemon's own readers).
+  const decoder = new StringDecoder('utf8')
+  socket.on('data', (chunk: Buffer) => parser.feed(decoder.write(chunk)))
   // Why: post-connect errors surface as 'close'; an unhandled 'error' would crash the process.
   socket.on('error', () => {})
   socket.once('close', () => {
@@ -84,6 +88,8 @@ function describeConnectError(err: unknown, socketPath: string): Error {
   return err instanceof Error ? err : new Error(String(err))
 }
 
+type DaemonIdentity = { pid?: number; startedAtMs?: number; launchNonce?: string }
+
 async function sendHello(
   socket: Socket,
   token: string,
@@ -91,11 +97,28 @@ async function sendHello(
   role: 'control' | 'stream',
   nextMessage: (timeoutMs?: number) => Promise<unknown>,
   timeoutMs: number
-): Promise<void> {
+): Promise<DaemonIdentity | undefined> {
   socket.write(encodeNdjson({ type: 'hello', version: PROTOCOL_VERSION, token, clientId, role }))
-  const response = (await nextMessage(timeoutMs)) as { ok?: boolean; error?: string } | undefined
+  const response = (await nextMessage(timeoutMs)) as
+    | { ok?: boolean; error?: string; daemonIdentity?: DaemonIdentity }
+    | undefined
   if (response?.ok !== true) {
     throw new Error(`Daemon rejected ${role} handshake: ${response?.error ?? 'unknown error'}`)
+  }
+  return response.daemonIdentity
+}
+
+// Why: a daemon replaced between the two connects would leave control and stream
+// talking to different processes; the launchNonce is unique per daemon lifetime.
+function assertSameDaemon(control?: DaemonIdentity, stream?: DaemonIdentity): void {
+  if (
+    control?.launchNonce !== undefined &&
+    stream?.launchNonce !== undefined &&
+    control.launchNonce !== stream.launchNonce
+  ) {
+    throw new Error(
+      'Orca daemon was replaced mid-handshake; control and stream sockets reached different daemons. Retry.'
+    )
   }
 }
 
@@ -119,11 +142,26 @@ export class TerminalDaemonConnection {
       throw describeConnectError(err, socketPath)
     })
     const nextControlMessage = nextMessageReader(control)
-    await sendHello(control, token, clientId, 'control', nextControlMessage, HANDSHAKE_TIMEOUT_MS)
+    const controlIdentity = await sendHello(
+      control,
+      token,
+      clientId,
+      'control',
+      nextControlMessage,
+      HANDSHAKE_TIMEOUT_MS
+    )
     // Why: the daemon silently drops a stream socket connected before the control handshake completes.
     const stream = await openSocket(socketPath, HANDSHAKE_TIMEOUT_MS)
     const nextStreamMessage = nextMessageReader(stream)
-    await sendHello(stream, token, clientId, 'stream', nextStreamMessage, HANDSHAKE_TIMEOUT_MS)
+    const streamIdentity = await sendHello(
+      stream,
+      token,
+      clientId,
+      'stream',
+      nextStreamMessage,
+      HANDSHAKE_TIMEOUT_MS
+    )
+    assertSameDaemon(controlIdentity, streamIdentity)
     return new TerminalDaemonConnection(control, stream, nextControlMessage, nextStreamMessage)
   }
 

--- a/src/cli/runtime/terminal-daemon-socket.ts
+++ b/src/cli/runtime/terminal-daemon-socket.ts
@@ -141,28 +141,36 @@ export class TerminalDaemonConnection {
     const control = await openSocket(socketPath, HANDSHAKE_TIMEOUT_MS).catch((err) => {
       throw describeConnectError(err, socketPath)
     })
-    const nextControlMessage = nextMessageReader(control)
-    const controlIdentity = await sendHello(
-      control,
-      token,
-      clientId,
-      'control',
-      nextControlMessage,
-      HANDSHAKE_TIMEOUT_MS
-    )
-    // Why: the daemon silently drops a stream socket connected before the control handshake completes.
-    const stream = await openSocket(socketPath, HANDSHAKE_TIMEOUT_MS)
-    const nextStreamMessage = nextMessageReader(stream)
-    const streamIdentity = await sendHello(
-      stream,
-      token,
-      clientId,
-      'stream',
-      nextStreamMessage,
-      HANDSHAKE_TIMEOUT_MS
-    )
-    assertSameDaemon(controlIdentity, streamIdentity)
-    return new TerminalDaemonConnection(control, stream, nextControlMessage, nextStreamMessage)
+    // Why: once control is open, any later failure must not leak an open socket.
+    let stream: Socket | undefined
+    try {
+      const nextControlMessage = nextMessageReader(control)
+      const controlIdentity = await sendHello(
+        control,
+        token,
+        clientId,
+        'control',
+        nextControlMessage,
+        HANDSHAKE_TIMEOUT_MS
+      )
+      // Why: the daemon silently drops a stream socket connected before the control handshake completes.
+      stream = await openSocket(socketPath, HANDSHAKE_TIMEOUT_MS)
+      const nextStreamMessage = nextMessageReader(stream)
+      const streamIdentity = await sendHello(
+        stream,
+        token,
+        clientId,
+        'stream',
+        nextStreamMessage,
+        HANDSHAKE_TIMEOUT_MS
+      )
+      assertSameDaemon(controlIdentity, streamIdentity)
+      return new TerminalDaemonConnection(control, stream, nextControlMessage, nextStreamMessage)
+    } catch (err) {
+      control.destroy()
+      stream?.destroy()
+      throw err
+    }
   }
 
   private requestCounter = 0
@@ -200,11 +208,14 @@ export class TerminalDaemonConnection {
     this.controlSocket.write(encodeNdjson({ id, type, payload }))
   }
 
-  onEvent(listener: (event: unknown) => void): void {
+  // Why: onClose lets the attach runtime settle its bridge when the daemon drops
+  // the stream (session gone / daemon exit) instead of awaiting forever.
+  onEvent(listener: (event: unknown) => void, onClose?: () => void): void {
     void (async () => {
       for (;;) {
         const event = await this.nextStreamMessage()
         if (event === undefined) {
+          onClose?.()
           return
         }
         listener(event)

--- a/src/cli/runtime/terminal-daemon-socket.ts
+++ b/src/cli/runtime/terminal-daemon-socket.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { connect, type Socket } from 'node:net'
+import { join } from 'node:path'
+import { PROTOCOL_VERSION } from '../../main/daemon/daemon-protocol-version'
+import { getDaemonSocketPath, getDaemonTokenPath } from '../../main/daemon/daemon-spawner'
+import { NOTIFY_PREFIX, type RpcResponse } from '../../main/daemon/types'
+import { createNdjsonParser, encodeNdjson } from '../../shared/main-process-ndjson-framer'
+import { getDefaultUserDataPath } from './metadata'
+
+const HANDSHAKE_TIMEOUT_MS = 5_000
+const REQUEST_TIMEOUT_MS = 30_000
+
+type MessageWaiter = {
+  resolve: (msg: unknown) => void
+  timer?: ReturnType<typeof setTimeout>
+}
+
+// Why: both sockets are pure NDJSON; this gives sequential, timeout-bounded reads.
+function nextMessageReader(socket: Socket): (timeoutMs?: number) => Promise<unknown> {
+  const buffered: unknown[] = []
+  const waiters: MessageWaiter[] = []
+  const deliver = (msg: unknown): void => {
+    const waiter = waiters.shift()
+    if (waiter) {
+      clearTimeout(waiter.timer)
+      waiter.resolve(msg)
+    } else {
+      buffered.push(msg)
+    }
+  }
+  const parser = createNdjsonParser(deliver, (err) => socket.destroy(err))
+  socket.on('data', (chunk: Buffer) => parser.feed(chunk.toString('utf8')))
+  // Why: post-connect errors surface as 'close'; an unhandled 'error' would crash the process.
+  socket.on('error', () => {})
+  socket.once('close', () => {
+    for (const waiter of waiters.splice(0)) {
+      clearTimeout(waiter.timer)
+      waiter.resolve(undefined)
+    }
+  })
+  return (timeoutMs) => {
+    if (buffered.length > 0) {
+      return Promise.resolve(buffered.shift())
+    }
+    return new Promise((resolve, reject) => {
+      const waiter: MessageWaiter = { resolve }
+      if (timeoutMs !== undefined) {
+        waiter.timer = setTimeout(() => {
+          waiters.splice(waiters.findIndex((w) => w.timer === waiter.timer), 1)
+          reject(new Error('Timed out waiting for daemon message'))
+        }, timeoutMs)
+      }
+      waiters.push(waiter)
+    })
+  }
+}
+
+async function openSocket(socketPath: string, timeoutMs: number): Promise<Socket> {
+  return await new Promise((resolve, reject) => {
+    const socket = connect(socketPath)
+    const onError = (err: Error): void => {
+      clearTimeout(timer)
+      reject(err)
+    }
+    const timer = setTimeout(() => {
+      socket.removeListener('error', onError)
+      socket.destroy()
+      reject(new Error(`Timed out connecting to daemon at ${socketPath}`))
+    }, timeoutMs)
+    socket.once('error', onError)
+    socket.once('connect', () => {
+      clearTimeout(timer)
+      socket.removeListener('error', onError)
+      resolve(socket)
+    })
+  })
+}
+
+function describeConnectError(err: unknown, socketPath: string): Error {
+  if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+    return new Error(`Orca daemon socket not found at ${socketPath}. Start the Orca app first.`)
+  }
+  return err instanceof Error ? err : new Error(String(err))
+}
+
+async function sendHello(
+  socket: Socket,
+  token: string,
+  clientId: string,
+  role: 'control' | 'stream',
+  nextMessage: (timeoutMs?: number) => Promise<unknown>,
+  timeoutMs: number
+): Promise<void> {
+  socket.write(encodeNdjson({ type: 'hello', version: PROTOCOL_VERSION, token, clientId, role }))
+  const response = (await nextMessage(timeoutMs)) as { ok?: boolean; error?: string } | undefined
+  if (response?.ok !== true) {
+    throw new Error(`Daemon rejected ${role} handshake: ${response?.error ?? 'unknown error'}`)
+  }
+}
+
+/** Two-socket NDJSON connection to the local Orca terminal daemon. */
+export class TerminalDaemonConnection {
+  static async connect(): Promise<TerminalDaemonConnection> {
+    const runtimeDir = join(getDefaultUserDataPath(), 'daemon')
+    const socketPath = getDaemonSocketPath(runtimeDir)
+    const tokenPath = getDaemonTokenPath(runtimeDir)
+    let token: string
+    try {
+      token = readFileSync(tokenPath, 'utf8').trim()
+    } catch (err) {
+      if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+        throw new Error(`Orca daemon token not found at ${tokenPath}. Start the Orca app first.`)
+      }
+      throw err
+    }
+    const clientId = randomUUID()
+    const control = await openSocket(socketPath, HANDSHAKE_TIMEOUT_MS).catch((err) => {
+      throw describeConnectError(err, socketPath)
+    })
+    const nextControlMessage = nextMessageReader(control)
+    await sendHello(control, token, clientId, 'control', nextControlMessage, HANDSHAKE_TIMEOUT_MS)
+    // Why: the daemon silently drops a stream socket connected before the control handshake completes.
+    const stream = await openSocket(socketPath, HANDSHAKE_TIMEOUT_MS)
+    const nextStreamMessage = nextMessageReader(stream)
+    await sendHello(stream, token, clientId, 'stream', nextStreamMessage, HANDSHAKE_TIMEOUT_MS)
+    return new TerminalDaemonConnection(control, stream, nextControlMessage, nextStreamMessage)
+  }
+
+  private requestCounter = 0
+  private notifyCounter = 0
+
+  private constructor(
+    private readonly controlSocket: Socket,
+    private readonly streamSocket: Socket,
+    private readonly nextControlMessage: (timeoutMs?: number) => Promise<unknown>,
+    private readonly nextStreamMessage: (timeoutMs?: number) => Promise<unknown>
+  ) {}
+
+  async request<T>(type: string, payload: unknown, timeoutMs = REQUEST_TIMEOUT_MS): Promise<T> {
+    const id = `req-${++this.requestCounter}`
+    this.controlSocket.write(encodeNdjson({ id, type, payload }))
+    for (;;) {
+      const response = (await this.nextControlMessage(timeoutMs)) as RpcResponse<T> | undefined
+      if (response === undefined) {
+        throw new Error('Daemon connection closed')
+      }
+      // Why: tolerate out-of-order responses from future protocol additions.
+      if (response.id !== id) {
+        continue
+      }
+      if (response.ok !== true) {
+        throw new Error(response.error)
+      }
+      return response.payload
+    }
+  }
+
+  // Why: fire-and-forget; the daemon never answers and the PTY keeps running regardless.
+  notify(type: string, payload: unknown): void {
+    const id = `${NOTIFY_PREFIX}${++this.notifyCounter}`
+    this.controlSocket.write(encodeNdjson({ id, type, payload }))
+  }
+
+  onEvent(listener: (event: unknown) => void): void {
+    void (async () => {
+      for (;;) {
+        const event = await this.nextStreamMessage()
+        if (event === undefined) {
+          return
+        }
+        listener(event)
+      }
+    })()
+  }
+
+  close(): void {
+    this.controlSocket.destroy()
+    this.streamSocket.destroy()
+  }
+}

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -2,6 +2,7 @@ import type { CommandSpec } from '../args'
 import { GLOBAL_FLAGS } from '../args'
 import { WORKTREE_LISTING_SCOPE_NOTES } from './worktree-listing-scope-notes'
 import { SERVE_COMMAND_SPECS } from './serve'
+import { TERMINAL_ATTACH_COMMAND_SPEC } from './terminal-attach'
 import { TERMINAL_SEND_COMMAND_SPEC } from './terminal-send'
 import { TERMINAL_CLOSE_COMMAND_SPEC } from './terminal-close'
 
@@ -226,6 +227,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     ]
   },
   TERMINAL_SEND_COMMAND_SPEC,
+  TERMINAL_ATTACH_COMMAND_SPEC,
   {
     path: ['terminal', 'wait'],
     summary: 'Wait for a terminal condition',

--- a/src/cli/specs/terminal-attach.ts
+++ b/src/cli/specs/terminal-attach.ts
@@ -1,0 +1,21 @@
+import type { CommandSpec } from '../args'
+import { GLOBAL_FLAGS } from '../args'
+
+export const TERMINAL_ATTACH_COMMAND_SPEC: CommandSpec = {
+  path: ['terminal', 'attach'],
+  summary: 'Attach to a live terminal with an interactive PTY',
+  usage: 'orca terminal attach [--terminal <handle>] [--read-only]',
+  allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'read-only'],
+  notes: [
+    'Bridges the local terminal directly to the Orca daemon: keystrokes are written to the session and output streams back live.',
+    'Detach with Ctrl-\\ then q. The session and its process keep running; attach never kills.',
+    '--read-only subscribes to output without forwarding input or resizing the session.',
+    'The daemon streams a session to one client at a time, so attaching takes over the live stream from the Orca desktop pane (it reconnects when you detach).',
+    'Local-only: terminals owned by a remote/SSH runtime cannot be attached. Run this command on the remote host, or use the Orca desktop UI.'
+  ],
+  examples: [
+    'orca terminal attach',
+    'orca terminal attach --terminal term_abc123',
+    'orca terminal attach --terminal term_abc123 --read-only'
+  ]
+}

--- a/src/cli/specs/terminal-attach.ts
+++ b/src/cli/specs/terminal-attach.ts
@@ -9,7 +9,7 @@ export const TERMINAL_ATTACH_COMMAND_SPEC: CommandSpec = {
   notes: [
     'Bridges the local terminal directly to the Orca daemon: keystrokes are written to the session and output streams back live.',
     'Detach with Ctrl-\\ then q. The session and its process keep running; attach never kills.',
-    '--read-only subscribes to output without forwarding input or resizing the session. It does not read stdin, so Ctrl-\\ q does not detach; end it with Ctrl-C, SIGTERM, or session exit.',
+    '--read-only mirrors output without writing to or resizing the session; Ctrl-\\ then q still detaches.',
     'The daemon streams a session to one client at a time, so attaching takes over the live stream from the Orca desktop pane (it reconnects when you detach).',
     'Local-only: terminals owned by a remote/SSH runtime cannot be attached. Run this command on the remote host, or use the Orca desktop UI.'
   ],

--- a/src/cli/specs/terminal-attach.ts
+++ b/src/cli/specs/terminal-attach.ts
@@ -9,7 +9,7 @@ export const TERMINAL_ATTACH_COMMAND_SPEC: CommandSpec = {
   notes: [
     'Bridges the local terminal directly to the Orca daemon: keystrokes are written to the session and output streams back live.',
     'Detach with Ctrl-\\ then q. The session and its process keep running; attach never kills.',
-    '--read-only subscribes to output without forwarding input or resizing the session.',
+    '--read-only subscribes to output without forwarding input or resizing the session. It does not read stdin, so Ctrl-\\ q does not detach; end it with Ctrl-C, SIGTERM, or session exit.',
     'The daemon streams a session to one client at a time, so attaching takes over the live stream from the Orca desktop pane (it reconnects when you detach).',
     'Local-only: terminals owned by a remote/SSH runtime cannot be attached. Run this command on the remote host, or use the Orca desktop UI.'
   ],

--- a/src/shared/cli-argument-boundary.ts
+++ b/src/shared/cli-argument-boundary.ts
@@ -30,6 +30,7 @@ export const CLI_BOOLEAN_FLAGS = new Set([
   'parent-current',
   'provision',
   'ready',
+  'read-only',
   'recipe-json',
   'references',
   'relations',


### PR DESCRIPTION
Closes #20080

## What

Adds `orca terminal attach [--terminal <handle>] [--read-only]` — a real interactive PTY attach to a live Orca-managed terminal from any external terminal (an editor's `:terminal`, a script, a plain shell). Keystrokes go to the session and its output streams back live, the way the desktop app reconnects to a session after an app restart.

Until now the CLI could only `terminal send` (a string plus optional `\r`/`\x03`, through agent-prompt/verified-delivery semantics) and `terminal read` (a bounded snapshot). Neither can drive an agent's TUI (arrow keys, Ctrl sequences, menus) or watch it live. This closes that gap.

## How

The desktop renderer already does interactive attach, and it does **not** use the runtime RPC layer — it talks to the daemon's own Unix socket with the native NDJSON protocol. This command does the same from the CLI:

1. Resolve the daemon socket + token (`getDaemonSocketPath`/`getDaemonTokenPath`, `PROTOCOL_VERSION` — imported, not hardcoded).
2. Open a **control** socket, hello-handshake, then a **stream** socket with the same `clientId` (order matters — the daemon drops a stream socket that connects before the control handshake completes).
3. `listSessions` → find the session whose `terminalHandle` matches and `isAlive`.
4. `createOrAttach` with `attachOnly: true`; render the returned snapshot so the current screen shows immediately.
5. Bridge: raw stdin → `write` notify; `data` events → stdout; `SIGWINCH` → `resize` notify.
6. Detach with **Ctrl-\ then q**: sends the daemon `detach` request and closes the sockets. Never `kill` — the PTY and process keep running.

New modules:
- `src/cli/specs/terminal-attach.ts` — command spec
- `src/cli/handlers/terminal-attach.ts` — thin handler (rejects `--json` and remote runtimes)
- `src/cli/runtime/terminal-daemon-socket.ts` — `TerminalDaemonConnection`: socket/token resolution, handshake, request/notify/events
- `src/cli/runtime/terminal-daemon-attach.ts` — attach orchestration + tty bridge

Wiring: registered in `core.ts` / `terminal.ts` / `handler-group-manifest.ts`; added the daemon modules the CLI now imports to `electron.vite.config.ts` and `config/tsconfig.cli.json`.

## Safety

- **Detach never kills.** No `kill`/signal is ever sent. Verified against the live daemon: session stays alive after detach.
- **Cooked mode always restored.** All teardown (raw-mode restore, listener removal, stdin pause) runs in a single `finally`, so a throw, SIGINT, SIGTERM, `exit` event, or socket drop can't leak raw mode or hang the process.
- **Local-only.** Remote/SSH handles and `--json` are rejected with guidance.

## Known limitation (documented in spec notes)

The daemon streams a session to **one client at a time** — `createOrAttach` detaches existing clients before attaching the new one (`terminal-host-session-create.ts:70`). So attaching **takes over the live stream from the Orca desktop pane**; the desktop reconnects when you detach. `--read-only` still attaches, so it has the same effect. A future enhancement could add multi-viewer fan-out or a dedicated read-only tap.

## Verification

- `tsc --noEmit -p config/tsconfig.tc.cli.json` — clean
- `oxlint` (+ type-aware) on all changed files — clean
- `vitest run` on `registry-parity`, `handler-group-manifest`, `main-module-bundle-parity` — 18/18
- Live daemon smoke test: handshake → attach → I/O round-trip → resize → detach → **session verified still alive** → cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)