### PR TITLE
fix(terminal): stop mouse motion typing SGR reports into the pane

### DIFF
--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -455,8 +455,8 @@ describe('HeadlessEmulator', () => {
       const snapshot = emulator.getSnapshot()
       expect(snapshot.modes.mouseTrackingMode).toBe('drag')
       expect(snapshot.modes.sgrMouseMode).toBe(true)
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1002h')
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1006h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
 
     it('tracks private mouse modes with leading zero params', async () => {
@@ -467,8 +467,8 @@ describe('HeadlessEmulator', () => {
       const snapshot = emulator.getSnapshot()
       expect(snapshot.modes.mouseTrackingMode).toBe('drag')
       expect(snapshot.modes.sgrMouseMode).toBe(true)
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1002h')
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1006h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
 
     it('tracks C1 CSI private mouse mode sequences', async () => {
@@ -479,8 +479,8 @@ describe('HeadlessEmulator', () => {
       const snapshot = emulator.getSnapshot()
       expect(snapshot.modes.mouseTrackingMode).toBe('drag')
       expect(snapshot.modes.sgrMouseMode).toBe(true)
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1002h')
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1006h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
 
     it('tracks split C1 CSI private mouse mode sequences', async () => {
@@ -494,7 +494,7 @@ describe('HeadlessEmulator', () => {
       expect(snapshot.modes.mouseTracking).toBe(false)
       expect(snapshot.modes.sgrMouseMode).toBe(true)
       expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1006h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
 
     it('tracks C1 CSI split before private marker', async () => {
@@ -506,8 +506,8 @@ describe('HeadlessEmulator', () => {
       const snapshot = emulator.getSnapshot()
       expect(snapshot.modes.mouseTrackingMode).toBe('drag')
       expect(snapshot.modes.sgrMouseMode).toBe(true)
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1002h')
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1006h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
 
     it('does not retain complete private CSI queries as scan tail', async () => {
@@ -540,8 +540,8 @@ describe('HeadlessEmulator', () => {
       expect(after.modes.mouseTrackingMode).toBe('drag')
       expect(after.modes.sgrMouseMode).toBe(true)
       expect(after.rehydrateSequences).toContain('\x1b[?1049h')
-      expect(after.rehydrateSequences).toContain('\x1b[?1002h')
-      expect(after.rehydrateSequences).toContain('\x1b[?1006h')
+      expect(after.rehydrateSequences).not.toContain('\x1b[?1002h')
+      expect(after.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
 
     it('clears SGR mouse reporting on full terminal reset', async () => {
@@ -554,7 +554,7 @@ describe('HeadlessEmulator', () => {
       const snapshot = emulator.getSnapshot()
       expect(snapshot.modes.mouseTrackingMode).toBe('drag')
       expect(snapshot.modes.sgrMouseMode).toBe(false)
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1002h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
       expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
 
@@ -568,8 +568,8 @@ describe('HeadlessEmulator', () => {
       expect(snapshot.modes.mouseTrackingMode).toBe('drag')
       expect(snapshot.modes.sgrMouseMode).toBe(false)
       expect(snapshot.modes.sgrMousePixelsMode).toBe(true)
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1002h')
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1016h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1016h')
       expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
   })
@@ -640,30 +640,30 @@ describe('HeadlessEmulator', () => {
       expect(snapshot.rehydrateSequences).toBe('')
     })
 
-    it('rehydrates mouse reporting after alternate screen activation', async () => {
+    it('rehydrates alternate screen without restoring mouse reporting', async () => {
       emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
       await emulator.write('\x1b[?1049h\x1b[?1002;1006h')
 
       const snapshot = emulator.getSnapshot()
+      expect(snapshot.modes.mouseTrackingMode).toBe('drag')
+      expect(snapshot.modes.sgrMouseMode).toBe(true)
       expect(snapshot.rehydrateSequences).toContain('\x1b[?1049h')
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1002h')
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1006h')
-      expect(snapshot.rehydrateSequences.indexOf('\x1b[?1049h')).toBeLessThan(
-        snapshot.rehydrateSequences.indexOf('\x1b[?1002h')
-      )
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
 
-    it('preserves mouse modes after mobile normalizes an alternate-screen replay', async () => {
+    it('keeps a single alt-screen switch when mobile normalizes an alternate-screen replay', async () => {
       emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
       await emulator.write('normal buffer\r\n\x1b[?1049h\x1b[?2004h\x1b[?1002;1006halternate')
       const snapshot = emulator.getSnapshot()
       const payload = snapshot.rehydrateSequences + snapshot.snapshotAnsi
       expect(payload.split('\x1b[?1049h')).toHaveLength(2)
-      expect(payload.slice(payload.lastIndexOf('\x1b[?1049h'))).toContain('\x1b[?1002h')
-      expect(payload.slice(payload.lastIndexOf('\x1b[?1049h'))).toContain('\x1b[?1006h')
+      expect(snapshot.rehydrateSequences).toContain('\x1b[?2004h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
     })
 
-    it('rehydrates mouse encoding independently from reporting mode', async () => {
+    it('does not rehydrate leftover SGR mouse encoding after reporting is off', async () => {
       emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
       await emulator.write('\x1b[?1002;1006h')
       await emulator.write('\x1b[?1002l')
@@ -671,7 +671,7 @@ describe('HeadlessEmulator', () => {
       const snapshot = emulator.getSnapshot()
       expect(snapshot.modes.mouseTracking).toBe(false)
       expect(snapshot.modes.sgrMouseMode).toBe(true)
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1006h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
       expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1002h')
     })
 

--- a/src/main/daemon/repro-12101-mouse-tracking-survives-agent-death.test.ts
+++ b/src/main/daemon/repro-12101-mouse-tracking-survives-agent-death.test.ts
@@ -115,7 +115,7 @@ describe('#12101 mouse tracking survives the death of the process that armed it'
     const armed = agent.getSnapshot()
     expect(armed?.modes.mouseTracking).toBe(true)
     expect(armed?.modes.mouseTrackingMode).toBe('any')
-    expect(armed?.rehydrateSequences).toContain(ANY_MOTION_TRACKING_ON)
+    expect(armed?.rehydrateSequences).not.toContain(ANY_MOTION_TRACKING_ON)
 
     // 2. Sleep/hibernation takes its final teardown checkpoint while the agent
     //    is still alive with mouse armed (daemon-pty-adapter's {final,teardown}).

--- a/src/main/daemon/repro-7329-remote-snapshot-corruption.test.ts
+++ b/src/main/daemon/repro-7329-remote-snapshot-corruption.test.ts
@@ -58,8 +58,10 @@ describe('#7329 remote-server snapshot corruption', () => {
       await emulatorWrite(emu, 'user@host:~$ ')
 
       const snapshot = emu.getSnapshot({ scrollbackRows: 0 })
-      // The daemon snapshot re-arms the modes it observed.
+      // Bracketed paste is restored; mouse tracking is recorded but not replayed.
       expect(snapshot.rehydrateSequences).toContain('\x1b[?2004h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1000h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1006h')
       expect(snapshot.modes.bracketedPaste).toBe(true)
       expect(snapshot.modes.mouseTracking).toBe(true)
 
@@ -88,8 +90,9 @@ describe('#7329 remote-server snapshot corruption', () => {
       await emulatorWrite(emu, 'user@host:~$ ')
 
       const snapshot = emu.getSnapshot({ scrollbackRows: 0 })
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1003h')
-      expect(snapshot.rehydrateSequences).toContain('\x1b[?1016h')
+      expect(snapshot.modes.mouseTracking).toBe(true)
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1003h')
+      expect(snapshot.rehydrateSequences).not.toContain('\x1b[?1016h')
 
       await replayRemoteSnapshot(term, snapshot)
 

--- a/src/main/daemon/terminal-history-cold-restore-info.ts
+++ b/src/main/daemon/terminal-history-cold-restore-info.ts
@@ -1,5 +1,6 @@
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
 import type { SessionMeta } from './terminal-history-metadata'
+import { omitMouseTrackingFromRehydrateSequences } from './terminal-mode-rehydrate-sequences'
 import type { TerminalModes } from './types'
 import type { TerminalOwner } from '../../shared/terminal-owner'
 
@@ -46,7 +47,7 @@ export function coldRestoreInfoFromSnapshot(
     snapshotAnsi: snapshot.snapshotAnsi,
     scrollbackAnsi,
     oscLinks: snapshot.oscLinks,
-    rehydrateSequences: snapshot.rehydrateSequences,
+    rehydrateSequences: omitMouseTrackingFromRehydrateSequences(snapshot.rehydrateSequences),
     cwd: cwd ?? meta.cwd,
     cols: snapshot.cols,
     rows: snapshot.rows,

--- a/src/main/daemon/terminal-history-seed-segments.test.ts
+++ b/src/main/daemon/terminal-history-seed-segments.test.ts
@@ -41,8 +41,7 @@ describe('getRecoveredHistorySeedSegments', () => {
       restoreInfo({ pendingEscapeTailAnsi: '\x1b[3' })
     )
     expect(segments).toEqual([
-      `${RESET_GRAPHIC_RENDITION}\x1b[?1003h\x1b[?1006h`,
-      'user@host ~ $ \x1b[?1003h',
+      `${RESET_GRAPHIC_RENDITION}user@host ~ $ \x1b[?1003h`,
       MOUSE_OFF,
       '\x1b[3'
     ])
@@ -114,15 +113,15 @@ describe('getRecoveredHistorySeedSegments', () => {
     }
   })
 
-  it('does not touch the live-session reattach payload (mobile scroll gestures)', () => {
-    // Why: only recovery seeding knows the arming TUI is dead; live reattach
-    // snapshots must keep re-arming or an alt-screen TUI loses scroll forever.
-    expect(buildRehydrateSequences(ARMED_MODES)).toBe('\x1b[?1003h\x1b[?1006h')
+  it('does not re-arm mouse tracking on live-session rehydrate (#18424)', () => {
+    // Why: the owning TUI re-asserts DECSET on startup; restoring it from a
+    // checkpoint whose TUI did not come back types SGR reports into readline.
+    expect(buildRehydrateSequences(ARMED_MODES)).toBe('')
   })
 
   it('grounds the pen before re-entering the alternate screen', () => {
     expect(buildRehydrateSequences({ ...ARMED_MODES, alternateScreen: true })).toBe(
-      `${RESET_GRAPHIC_RENDITION}\x1b[?1049h\x1b[?1003h\x1b[?1006h`
+      `${RESET_GRAPHIC_RENDITION}\x1b[?1049h`
     )
   })
 })

--- a/src/main/daemon/terminal-history-seed-segments.ts
+++ b/src/main/daemon/terminal-history-seed-segments.ts
@@ -4,12 +4,12 @@ import {
   RESET_GRAPHIC_RENDITION
 } from '../../shared/terminal-mode-reset-profiles'
 
-// Why the reset belongs in the seed and not only at replay: the recovered stream
-// re-arms mouse reporting from two independent sources (rehydrateSequences AND
-// SerializeAddon's own mode trailer inside snapshotAnsi), and the seed is what
-// feeds the daemon's emulator — so without it every downstream consumer that
-// re-serializes from that emulator, including mobile, inherits the dead TUI's
-// modes no matter which profile the desktop renderer applies. See
+// Why the reset belongs in the seed and not only at replay: SerializeAddon's
+// mode trailer inside snapshotAnsi can still re-arm mouse reporting even
+// after rehydrateSequences omits DECSET 1003/1006 (#18424), and the seed is
+// what feeds the daemon's emulator — so without it every downstream consumer
+// that re-serializes from that emulator, including mobile, inherits the dead
+// TUI's modes no matter which profile the desktop renderer applies. See
 // COLD_RESTORE_SEED_MODE_RESET for the precondition and the choice of bits.
 
 export function getRecoveredHistorySeedSegments(restoreInfo: ColdRestoreInfo): readonly string[] {

--- a/src/main/daemon/terminal-mode-rehydrate-sequences.test.ts
+++ b/src/main/daemon/terminal-mode-rehydrate-sequences.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { RESET_GRAPHIC_RENDITION } from '../../shared/terminal-mode-reset-profiles'
+import { HeadlessEmulator } from './headless-emulator'
+import { coldRestoreInfoFromSnapshot } from './terminal-history-cold-restore-info'
+import {
+  buildRehydrateSequences,
+  omitMouseTrackingFromRehydrateSequences
+} from './terminal-mode-rehydrate-sequences'
+import type { TerminalModes } from './types'
+
+const ARMED_MOUSE: TerminalModes = {
+  bracketedPaste: true,
+  mouseTracking: true,
+  mouseTrackingMode: 'any',
+  sgrMouseMode: true,
+  applicationCursor: false,
+  alternateScreen: true
+}
+
+function expectNoMouseRehydrate(sequences: string): void {
+  expect(sequences).not.toContain('\x1b[?9h')
+  expect(sequences).not.toContain('\x1b[?1000h')
+  expect(sequences).not.toContain('\x1b[?1002h')
+  expect(sequences).not.toContain('\x1b[?1003h')
+  expect(sequences).not.toContain('\x1b[?1006h')
+  expect(sequences).not.toContain('\x1b[?1016h')
+}
+
+describe('buildRehydrateSequences', () => {
+  it('omits any-event SGR mouse tracking while keeping alt-screen and paste (#18424)', () => {
+    const sequences = buildRehydrateSequences(ARMED_MOUSE)
+    expect(sequences).toContain(`${RESET_GRAPHIC_RENDITION}\x1b[?1049h`)
+    expect(sequences).toContain('\x1b[?2004h')
+    expectNoMouseRehydrate(sequences)
+  })
+
+  it('omits every mouse protocol the generator used to restore', () => {
+    for (const mouseTrackingMode of ['x10', 'vt200', 'drag', 'any'] as const) {
+      expectNoMouseRehydrate(
+        buildRehydrateSequences({
+          ...ARMED_MOUSE,
+          alternateScreen: false,
+          bracketedPaste: false,
+          mouseTrackingMode
+        })
+      )
+    }
+  })
+
+  it('omits leftover SGR encoding when reporting is already off', () => {
+    const sequences = buildRehydrateSequences({
+      bracketedPaste: false,
+      mouseTracking: false,
+      mouseTrackingMode: 'none',
+      sgrMouseMode: true,
+      applicationCursor: false,
+      alternateScreen: false
+    })
+    expect(sequences).toBe('')
+  })
+
+  it('omits SGR-pixels encoding as well as SGR', () => {
+    const sequences = buildRehydrateSequences({
+      ...ARMED_MOUSE,
+      sgrMouseMode: false,
+      sgrMousePixelsMode: true
+    })
+    expect(sequences).toContain('\x1b[?1049h')
+    expectNoMouseRehydrate(sequences)
+  })
+})
+
+describe('omitMouseTrackingFromRehydrateSequences', () => {
+  it('strips baked-in mouse DECSET from an older checkpoint string', () => {
+    const stored = `${RESET_GRAPHIC_RENDITION}\x1b[?1049h\x1b[?2004h\x1b[?1003h\x1b[?1006h`
+    const sequences = omitMouseTrackingFromRehydrateSequences(stored)
+    expect(sequences).toBe(`${RESET_GRAPHIC_RENDITION}\x1b[?1049h\x1b[?2004h`)
+  })
+})
+
+describe('cold restore of a checkpoint that recorded mouse tracking', () => {
+  it('does not replay ?1003h/?1006h from stored rehydrateSequences (#18424)', () => {
+    const info = coldRestoreInfoFromSnapshot(
+      {
+        snapshotAnsi: 'user@host ~ $ ',
+        scrollbackAnsi: '',
+        rehydrateSequences: `${RESET_GRAPHIC_RENDITION}\x1b[?1049h\x1b[?2004h\x1b[?1003h\x1b[?1006h`,
+        cols: 80,
+        rows: 24,
+        modes: ARMED_MOUSE
+      },
+      '/w',
+      {
+        cwd: '/w',
+        cols: 80,
+        rows: 24,
+        startedAt: '2026-09-03T00:00:00.000Z',
+        endedAt: null,
+        exitCode: null
+      }
+    )
+    expect(info.rehydrateSequences).toContain('\x1b[?1049h')
+    expect(info.rehydrateSequences).toContain('\x1b[?2004h')
+    expectNoMouseRehydrate(info.rehydrateSequences)
+    expect(info.modes.mouseTracking).toBe(true)
+    expect(info.modes.mouseTrackingMode).toBe('any')
+    expect(info.modes.sgrMouseMode).toBe(true)
+  })
+})
+
+describe('HeadlessEmulator rehydrateSequences', () => {
+  let emulator: HeadlessEmulator
+
+  afterEach(() => {
+    emulator?.dispose()
+  })
+
+  it('does not put armed mouse tracking into a snapshot rehydrate prefix', async () => {
+    emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+    await emulator.write('\x1b[?1049h\x1b[?2004h\x1b[?1003h\x1b[?1006h')
+
+    const snapshot = emulator.getSnapshot()
+    expect(snapshot.modes.mouseTracking).toBe(true)
+    expect(snapshot.modes.mouseTrackingMode).toBe('any')
+    expect(snapshot.modes.sgrMouseMode).toBe(true)
+    expect(snapshot.rehydrateSequences).toContain('\x1b[?1049h')
+    expect(snapshot.rehydrateSequences).toContain('\x1b[?2004h')
+    expectNoMouseRehydrate(snapshot.rehydrateSequences)
+  })
+})

--- a/src/main/daemon/terminal-mode-rehydrate-sequences.ts
+++ b/src/main/daemon/terminal-mode-rehydrate-sequences.ts
@@ -1,6 +1,25 @@
 import type { TerminalModes } from './types'
 import { RESET_GRAPHIC_RENDITION } from '../../shared/terminal-mode-reset-profiles'
 
+// Why: older checkpoints baked these into the stored rehydrateSequences string.
+// Strip on restore so a dead TUI's DECSET cannot reach a replacement shell.
+const MOUSE_REHYDRATE_ENABLE_SEQUENCES = [
+  '\x1b[?9h',
+  '\x1b[?1000h',
+  '\x1b[?1002h',
+  '\x1b[?1003h',
+  '\x1b[?1006h',
+  '\x1b[?1016h'
+] as const
+
+export function omitMouseTrackingFromRehydrateSequences(sequences: string): string {
+  let result = sequences
+  for (const sequence of MOUSE_REHYDRATE_ENABLE_SEQUENCES) {
+    result = result.replaceAll(sequence, '')
+  }
+  return result
+}
+
 // Why no kitty flags here: rehydrateSequences feeds renderer xterms, and
 // POST_REPLAY_REATTACH_RESET's deliberate kitty reset (stale CSI-u Ctrl+C
 // hazard) must stay authoritative. modes.kittyKeyboardFlags exists for
@@ -19,30 +38,8 @@ export function buildRehydrateSequences(modes: TerminalModes): string {
   if (modes.applicationCursor) {
     seqs.push('\x1b[?1h')
   }
-  // Why: mobile alt-screen scroll gestures need xterm's mouse mode restored
-  // from cold snapshots; OpenCode/OpenTUI enables scrollable panes this way.
-  switch (modes.mouseTracking ? (modes.mouseTrackingMode ?? 'vt200') : 'none') {
-    case 'x10':
-      seqs.push('\x1b[?9h')
-      break
-    case 'vt200':
-      seqs.push('\x1b[?1000h')
-      break
-    case 'drag':
-      seqs.push('\x1b[?1002h')
-      break
-    case 'any':
-      seqs.push('\x1b[?1003h')
-      break
-    case 'none':
-      break
-  }
-  // Why: xterm tracks the mouse protocol and SGR encoding as independent
-  // modes, so snapshots must preserve the encoding even when reporting is off.
-  if (modes.sgrMousePixelsMode) {
-    seqs.push('\x1b[?1016h')
-  } else if (modes.sgrMouseMode) {
-    seqs.push('\x1b[?1006h')
-  }
+  // Why omitted: restoring DECSET 1003/1006 without the TUI that owned them
+  // types SGR motion reports into readline (#18424). Live TUIs re-assert on
+  // startup; alt-screen frame restore still carries mouse for a live owner.
   return seqs.join('')
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
@@ -199,6 +199,22 @@ describe('connectPanePty', () => {
     expect(staleTracker.flags).toBe(0)
   })
 
+  it('disarms leftover mouse tracking when spawning a fresh PTY (#15625)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { RESET_MOUSE_REPORTING } =
+      await import('../../../../shared/terminal-mode-reset-profiles')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    const pane = createPane(92)
+    const deps = createDeps({ tabId: 'tab-mouse-fresh-spawn' })
+
+    connectPanePty(pane as never, createManager(92) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(pane.terminal.write).toHaveBeenCalledWith(RESET_MOUSE_REPORTING, expect.any(Function))
+    expect(transport.connect).toHaveBeenCalled()
+  })
+
   // Why: deleting a worktree kills its PTYs for the filesystem teardown; the
   // renderer must not race a doomed respawn into a directory main is deleting
   // (main fences it with TerminalRemovalInProgressError and the pane is about to

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
@@ -16,6 +16,7 @@ import type {
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
 import { findTerminalTabForPane } from './terminal-tab-id'
+import { RESET_MOUSE_REPORTING } from '../../../../../shared/terminal-mode-reset-profiles'
 
 export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
   session.startFreshSpawn = (
@@ -57,6 +58,9 @@ export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
     // replaced PTY takes the stale-transport early return and skips it, so
     // a restart-in-place would leak the old TUI's flags into a fresh shell.
     session.kittyKeyboardModes.reset()
+    // Why: the same reused xterm can keep DECSET 1003/1006 from the killed
+    // TUI; motion then types SGR reports into the replacement shell (#15625).
+    session.writeReplayData(RESET_MOUSE_REPORTING)
     session.prepareFreshShellViewportForSpawn(options)
     const coldRestoreOverride =
       startupOverride && 'launchConfig' in startupOverride

--- a/src/shared/agent-tui-ansi-fuzz-stream.ts
+++ b/src/shared/agent-tui-ansi-fuzz-stream.ts
@@ -10,7 +10,7 @@
 // garble bug):
 // - DECAWM (?7l) and IRM (CSI 4h): SerializeAddon does not re-emit them and
 //   rehydrateSequences (headless-emulator.ts buildRehydrateSequences) only
-//   covers alt-screen/bracketed-paste/app-cursor/mouse modes.
+//   covers alt-screen/bracketed-paste/app-cursor (mouse is not restored).
 // - Terminal queries (DA/DSR/DECRQM): the emulator is write-only by contract
 //   (headless-emulator.ts onQueryReply gating); replies are a separate
 //   authority problem with its own pinned tests (session.test.ts).


### PR DESCRIPTION
## ELI5

When a TUI such as Grok or Claude Code turns on mouse tracking and then dies, Orca used to restore that mouse mode onto the next shell. Moving the mouse then typed garbage like `35;42;47M` into the window. This change stops restoring mouse tracking from checkpoints, and a replacement PTY also turns leftover mouse tracking off.

## What Changed

- `buildRehydrateSequences` no longer emits DECSET `?9h` / `?1000h` / `?1002h` / `?1003h` / `?1006h` / `?1016h`. Live TUIs re-assert those modes on startup. Alt-screen `frameRestoreAnsi` still carries mouse for a still-running TUI.
- Older checkpoints that already baked those sequences into `rehydrateSequences` are stripped on restore without changing the checkpoint schema (`modes.mouseTracking` is still recorded).
- A fresh PTY spawn writes `RESET_MOUSE_REPORTING` into the reused xterm after the existing kitty-keyboard reset, so a remounted pane cannot keep a dead TUI's any-event tracking.

## Why

Mouse motion with DECSET 1003 + SGR 1006 is encoded as `CSI < 35;col;row M`. Readline consumes `ESC[<` as an unbound sequence and self-inserts the rest, so every pointer move fills the prompt with control characters. Cold restore already appended a seed reset, but live rehydrate and the renderer `startFreshSpawn` path could still re-arm the emulator.

This is the same class of bug as #18424 (checkpoint rehydrate) and #15625 (fresh spawn after sleep). Related user reports: #13077, #18064.

Overlaps community PR #18454 (rehydrate-only). This PR also covers the fresh-spawn renderer gap called out on #15625.

## Linked Issue

Fixes #18424
Fixes #15625

## Visual Proof

N/A — no UI chrome change. The behavior change is that mouse motion over a replacement shell no longer inserts SGR report tails.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Targeted vitest (all passed):

- `src/main/daemon/terminal-mode-rehydrate-sequences.test.ts`
- `src/main/daemon/headless-emulator.test.ts`
- `src/main/daemon/terminal-history-seed-segments.test.ts`
- `src/main/daemon/repro-12101-mouse-tracking-survives-agent-death.test.ts`
- `src/main/daemon/repro-7329-remote-snapshot-corruption.test.ts`
- `src/main/daemon/history-reader.test.ts`
- `src/main/daemon/hibernation-cold-restore-repro.test.ts`
- `src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts`
- `src/renderer/src/components/terminal-pane/pty-connection-reattach-mode-reset.test.ts`
- `src/renderer/src/components/terminal-pane/pty-connection-hibernation-wake.test.ts`

Did not rebuild or run the desktop app; CI should cover `pnpm lint` / `pnpm typecheck` / full `pnpm test`.

## AI Disclosure

Implemented with Grok 4.6 (xAI) in a local coding session.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Cross-platform: terminal protocol only; no OS-specific code.
- SSH / remote / mobile: `rehydrateSequences` is the same prefix the daemon snapshot uses for those consumers.
- Live TUI scroll/hover: programs re-send mouse DECSET on startup. Distinct from #11176 (OpenCode wheel after restore).
- Full `pnpm lint` / `pnpm typecheck` / `pnpm build` not run locally (CI).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)