### PR TITLE
docs(linux): isolate NVIDIA/X11 diagnostic rollback

### DIFF
--- a/docs/readme/linux-nvidia-x11-crash.md
+++ b/docs/readme/linux-nvidia-x11-crash.md
@@ -1,0 +1,59 @@
+# Linux NVIDIA/X11 startup and typing crash
+
+[Issue #20081](https://github.com/stablyai/orca/issues/20081) reports that Orca
+1.4.198 works with Electron 43.4.1, while 1.4.199/1.4.200 crash with Electron
+43.6.0 on Ubuntu, X11, and NVIDIA driver 580.178.04.
+
+The reporter confirmed that a local `1.4.200-nvidia.1` amd64 package using
+Electron 43.4.1 opened and accepted typing in the composer and terminal.
+
+Electron 43.4.1 is affected by
+[GHSA-qmv3-fv6v-rmhq](https://github.com/electron/electron/security/advisories/GHSA-qmv3-fv6v-rmhq).
+Keep the shared manifest, lockfile, and normal release builds on the current
+patched Electron version. The older runtime is only a temporary diagnostic
+comparison, not a release fix or a recommendation for daily use.
+
+## Opt-in Linux diagnostic package
+
+On Linux x64, use Bash, Node 24, pnpm 12, Git, and the normal Linux packaging
+prerequisites. Run the following from the repository root. It snapshots the
+committed source into a separate directory; it does not include uncommitted
+changes. Only that snapshot receives the Electron downgrade. Do not commit its
+manifest or lockfile back to the release branch.
+
+```bash
+set -euo pipefail
+diagnostic_dir=$(mktemp -d "${TMPDIR:-/tmp}/orca-nvidia-20081.XXXXXX")
+git archive HEAD | tar -x -C "$diagnostic_dir"
+(
+  cd "$diagnostic_dir"
+  export ORCA_BACKGROUND_LAUNCH=1
+  pnpm install --frozen-lockfile
+  pnpm add --save-dev --save-exact electron@43.4.1
+  pnpm run build:desktop
+  pnpm run ensure:electron-runtime
+  ORCA_LOCAL_BUILD_VERSION=1.4.200-nvidia.1 pnpm exec electron-builder \
+    --config config/electron-builder.config.cjs --linux deb --x64 --publish never
+)
+printf 'Diagnostic package: %s/dist/orca-ide_1.4.200-nvidia.1_amd64.deb\n' "$diagnostic_dir"
+```
+
+The explicit `--publish never` keeps this package local. The normal native
+rebuild, glibc compatibility, packaged daemon, and CLI checks still run against
+the snapshot's installed dependencies. Keep this workflow out of release CI.
+
+## Validate the comparison
+
+Quit the installed Orca process before installing and launching the diagnostic
+package from the desktop. Test typing in both the composer and terminal, then
+quit, relaunch, and repeat. Record the package version, Electron version, GPU
+driver, and display session type with the result in #20081.
+
+The report says `--in-process-gpu --disable-gpu-sandbox` still crashes on the
+first keystroke; do not add those flags or override the user's IBus settings as
+a fix for this issue.
+
+A successful diagnostic run would narrow the regression, not resolve the
+security issue. A permanent fix still needs a security-patched Electron build
+that passes the same checks on the affected NVIDIA/X11 machine. A successful
+build or unit test alone does not establish that this native-driver crash is fixed.


### PR DESCRIPTION
## ELI5

Document a local diagnostic package for the NVIDIA/X11 crash in #20081 while keeping the vulnerable Electron rollback out of normal releases.

## What Changed

- Add an opt-in Linux x64 recipe that snapshots committed source into a temporary directory and installs Electron 43.4.1 only in that snapshot.
- Reuse the existing desktop build, native rebuild, and packaging checks; label the artifact `1.4.200-nvidia.1` and pass `--publish never`.
- Explain the security limitation, the reporter's successful diagnostic result, and the validation still needed for a permanent fix.

The shared `package.json`, `pnpm-lock.yaml`, and release workflows are unchanged and retain Electron 43.6.0.

## Why

The reporter confirmed that a local Electron 43.4.1 diagnostic .deb opens and accepts typing in the composer and terminal. However, that Electron version is affected by GHSA-qmv3-fv6v-rmhq, so a shared dependency rollback would expose Windows, macOS, and unaffected Linux releases too. This documents a reproducible, isolated comparison while investigation of a patched-runtime fix continues.

## Linked Issue

Related to #20081. This draft does not close the native crash issue or claim a security-patched fix.

## Visual Proof

N/A — documentation only; no renderer or interaction code changes.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Executed the exact documented Bash recipe end to end on Linux x64. It produced `orca-ide_1.4.200-nvidia.1_amd64.deb` in an isolated `/tmp` snapshot. The desktop typechecks/build, CLI checks, native rebuild, packaged daemon check, plugin check, and Ubuntu 20.04 glibc compatibility gate passed. The source checkout's manifest and lockfile remained byte-identical to upstream and on Electron 43.6.0.

Bash syntax and document formatting checks passed. An independent read-only review found no substantive defects. No new unit tests were added because this changes only a human-facing diagnostic guide. The reporter supplied the GUI startup/typing confirmation for the earlier diagnostic package; the agent did not launch a visible application or test macOS/Windows.

## AI Disclosure

Prepared with OpenAI Codex assistance, including an independent Codex review.

## Review

Addresses the P1 review finding that the vulnerable rollback must not become the shared release default.

## Agent skill upstream boundary

- [x] Not applicable; no agent skill source or documentation is copied.

## Notes

Electron 43.4.1 remains vulnerable and this package is for a temporary diagnostic comparison only. A permanent resolution needs a patched Electron runtime validated on the affected NVIDIA/X11 machine. No production, SSH, mobile, macOS, or Windows behavior is changed by this PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] Full repository lint and test suites were not rerun for this documentation-only PR; exact recipe build and targeted validation are listed above.
