### PR TITLE
fix(terminal): let a titled pane still be dragged by its header

### DIFF
--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -339,11 +339,15 @@
   color: inherit;
   font: inherit;
   text-align: left;
-  /* Why: override main.css's global `:where(button:not(:disabled))` pointer
-     cursor — inherit the bar's grab cursor instead, so a single click/drag on
-     the title text drags the pane; double-click still renames. */
-  cursor: inherit;
+  /* Why: no cursor override here — a <span> has no default cursor style, so it
+     shows the bar's grab cursor by inheritance, letting a single click/drag on
+     the title text drag the pane; double-click still renames. */
   line-height: var(--orca-pane-title-height);
+}
+
+.pane-title-text:focus-visible {
+  outline: 1px solid var(--ring);
+  outline-offset: 1px;
 }
 
 .pane-title-bar[data-chromeless] {

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -291,36 +291,14 @@
   user-select: none;
 }
 
-.pane-title-drag-handle {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  width: 32px;
-  height: var(--orca-pane-title-height);
-  z-index: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+/* Why: the bar itself is the pane-drag surface once a title exists (matches the
+   chromeless pointer-events:none pass-through to the underlying .pane-drag-handle
+   strip); title text/rename input/action buttons override with their own cursor. */
+.pane-title-bar:not([data-editing]) {
   cursor: grab;
-  opacity: 0;
-  background: color-mix(in srgb, var(--orca-pane-title-fg) 36%, transparent);
-  transform: translateX(-50%);
-  transition: opacity 150ms ease;
 }
 
-.pane-title-drag-handle::after {
-  content: '...';
-  font-size: 10px;
-  line-height: 1;
-  letter-spacing: 0;
-  color: var(--orca-pane-title-button-hover-fg);
-}
-
-.pane-title-drag-handle:hover {
-  opacity: 1;
-}
-
-.pane-title-drag-handle:active {
+.pane-title-bar:not([data-editing]):active {
   cursor: grabbing;
 }
 
@@ -361,13 +339,11 @@
   color: inherit;
   font: inherit;
   text-align: left;
-  cursor: pointer;
+  /* Why: override main.css's global `:where(button:not(:disabled))` pointer
+     cursor — inherit the bar's grab cursor instead, so a single click/drag on
+     the title text drags the pane; double-click still renames. */
+  cursor: inherit;
   line-height: var(--orca-pane-title-height);
-}
-
-.pane-title-text:focus-visible {
-  outline: 1px solid var(--ring);
-  outline-offset: 1px;
 }
 
 .pane-title-bar[data-chromeless] {

--- a/src/renderer/src/components/terminal-pane/PaneTitleActions.tsx
+++ b/src/renderer/src/components/terminal-pane/PaneTitleActions.tsx
@@ -1,0 +1,206 @@
+import {
+  MessageSquare,
+  MessageSquarePlus,
+  SquareSplitVertical,
+  SquareTerminal,
+  X
+} from 'lucide-react'
+import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+
+type PaneTitleActionsProps = {
+  pane: ManagedPane
+  title: string
+  isActivePane: boolean
+  paneCount: number
+  showAlwaysOnHeaders: boolean
+  showSplitButton: boolean
+  splitRightLabel: string
+  canContinueAgentSessionInNewSession?: boolean
+  onContinueAgentSessionInNewSession?: (pane: ManagedPane) => void
+  canToggleNativeChat?: boolean
+  isChatViewMode?: boolean
+  onToggleNativeChat?: () => void
+  onSplitPane: (pane: ManagedPane, direction: 'vertical' | 'horizontal') => void
+  onRemoveTitle: (paneId: number) => void
+  onClosePane: (paneId: number) => void
+}
+
+/** The [continue-in-new-session][chat][split][×] button cluster at the end of a
+ *  pane's title bar. Every button stops propagation on both pointerdown (so it
+ *  doesn't also start the bar's pane-drag) and dblclick (a native dblclick is a
+ *  separate event the click handler's stopPropagation doesn't touch, and would
+ *  otherwise bubble up into the bar's rename handler). */
+export default function PaneTitleActions({
+  pane,
+  title,
+  isActivePane,
+  paneCount,
+  showAlwaysOnHeaders,
+  showSplitButton,
+  splitRightLabel,
+  canContinueAgentSessionInNewSession,
+  onContinueAgentSessionInNewSession,
+  canToggleNativeChat,
+  isChatViewMode,
+  onToggleNativeChat,
+  onSplitPane,
+  onRemoveTitle,
+  onClosePane
+}: PaneTitleActionsProps): React.JSX.Element {
+  return (
+    <div className="pane-title-actions ml-auto flex shrink-0 items-center gap-0">
+      {canContinueAgentSessionInNewSession && isActivePane ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="pane-title-split-trigger"
+              aria-label={translate(
+                'components.agentSessionContinuation.continueInNewSession',
+                'Continue in New Session…'
+              )}
+              onPointerDown={(event) => event.stopPropagation()}
+              onDoubleClick={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation()
+                onContinueAgentSessionInNewSession?.(pane)
+              }}
+            >
+              <MessageSquarePlus className="size-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={4}>
+            {translate(
+              'components.agentSessionContinuation.continueInNewSession',
+              'Continue in New Session…'
+            )}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+      {canToggleNativeChat && isActivePane ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              // Same class as split so it shares the hover/active reveal
+              // and sits as a peer in the [chat][split][×] cluster.
+              className="pane-title-split-trigger"
+              aria-label={
+                isChatViewMode
+                  ? translate('components.native-chat.toggle.showTerminal', 'Show terminal')
+                  : translate('components.native-chat.toggle.showChat', 'Show chat view')
+              }
+              aria-pressed={isChatViewMode}
+              onPointerDown={(event) => event.stopPropagation()}
+              onDoubleClick={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation()
+                onToggleNativeChat?.()
+              }}
+            >
+              {isChatViewMode ? (
+                <SquareTerminal className="size-3" />
+              ) : (
+                <MessageSquare className="size-3" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={4}>
+            {isChatViewMode
+              ? translate('components.native-chat.toggle.showTerminal', 'Show terminal')
+              : translate('components.native-chat.toggle.showChat', 'Show chat view')}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+      {showAlwaysOnHeaders && showSplitButton ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="pane-title-split-trigger"
+              data-contextual-tour-target={isActivePane ? 'terminal-pane-split-target' : undefined}
+              aria-label={splitRightLabel}
+              onPointerDown={(event) => event.stopPropagation()}
+              onDoubleClick={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation()
+                onSplitPane(pane, 'vertical')
+              }}
+            >
+              <SquareSplitVertical className="size-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={4}>
+            {splitRightLabel}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+      {title ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="pane-title-close"
+              onPointerDown={(event) => event.stopPropagation()}
+              onDoubleClick={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation()
+                onRemoveTitle(pane.id)
+              }}
+              aria-label={translate(
+                'auto.components.terminal.pane.TerminalPane.f984ab2a30',
+                'Remove pane title: {{value0}}',
+                { value0: title }
+              )}
+            >
+              <X className="size-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={4}>
+            {translate('auto.components.terminal.pane.TerminalPane.ac112e9036', 'Remove title')}
+          </TooltipContent>
+        </Tooltip>
+      ) : paneCount > 1 && showAlwaysOnHeaders ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="pane-title-close"
+              onPointerDown={(event) => event.stopPropagation()}
+              onDoubleClick={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation()
+                onClosePane(pane.id)
+              }}
+              aria-label={translate(
+                'auto.components.terminal.pane.TerminalContextMenu.8c17d6786d',
+                'Close Pane'
+              )}
+            >
+              <X className="size-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={4}>
+            {translate(
+              'auto.components.terminal.pane.TerminalContextMenu.8c17d6786d',
+              'Close Pane'
+            )}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
@@ -6,8 +6,17 @@ import { createRoot, type Root } from 'react-dom/client'
 import path from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import { WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
 import type { PtyTransport } from './pty-transport'
 import TerminalPaneHeaderOverlay from './TerminalPaneHeaderOverlay'
+
+const { handleInternalTerminalFileDropMock } = vi.hoisted(() => ({
+  handleInternalTerminalFileDropMock: vi.fn()
+}))
+
+vi.mock('./terminal-drop-handler', () => ({
+  handleInternalTerminalFileDrop: handleInternalTerminalFileDropMock
+}))
 
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children?: ReactNode }) => children,
@@ -47,10 +56,13 @@ function renderOverlay({
   onClosePane = vi.fn(),
   onRemoveTitle = vi.fn(),
   onRenameSubmit = vi.fn(),
+  onBeginPaneDrag = vi.fn(),
+  onStartRename = vi.fn(),
   canContinueAgentSessionInNewSession = false,
   onContinueAgentSessionInNewSession = vi.fn(),
   renameValue = '',
-  renamingPaneId = null
+  renamingPaneId = null,
+  managerRef = { current: null } as RefObject<PaneManager | null>
 }: {
   paneTitles: Record<number, string>
   paneCount?: number
@@ -59,15 +71,20 @@ function renderOverlay({
   onClosePane?: ReturnType<typeof vi.fn>
   onRemoveTitle?: ReturnType<typeof vi.fn>
   onRenameSubmit?: ReturnType<typeof vi.fn>
+  onBeginPaneDrag?: ReturnType<typeof vi.fn>
+  onStartRename?: ReturnType<typeof vi.fn>
   canContinueAgentSessionInNewSession?: boolean
   onContinueAgentSessionInNewSession?: ReturnType<typeof vi.fn>
   renameValue?: string
   renamingPaneId?: number | null
+  managerRef?: RefObject<PaneManager | null>
 }): {
   container: HTMLDivElement
   onClosePane: ReturnType<typeof vi.fn>
   onRemoveTitle: ReturnType<typeof vi.fn>
   onRenameSubmit: ReturnType<typeof vi.fn>
+  onBeginPaneDrag: ReturnType<typeof vi.fn>
+  onStartRename: ReturnType<typeof vi.fn>
 } {
   const panes = [makePane(1), makePane(2)]
   const container = document.createElement('div')
@@ -96,17 +113,19 @@ function renderOverlay({
         paneTitleBackground="transparent"
         terminalContentVisible
         hiddenStartupStyle={{}}
-        managerRef={{ current: null } as RefObject<PaneManager | null>}
+        managerRef={managerRef}
         paneTransportsRef={{ current: new Map() } as RefObject<Map<number, PtyTransport>>}
         canContinueAgentSessionInNewSession={canContinueAgentSessionInNewSession}
         onContinueAgentSessionInNewSession={
           onContinueAgentSessionInNewSession as (pane: ManagedPane) => void
         }
         onSplitPane={vi.fn()}
-        onBeginPaneDrag={vi.fn()}
+        onBeginPaneDrag={
+          onBeginPaneDrag as (paneId: number, handle: HTMLElement, event: PointerEvent) => void
+        }
         onActivatePaneTitleInteraction={vi.fn()}
         onPaneTitleContextMenu={vi.fn()}
-        onStartRename={vi.fn()}
+        onStartRename={onStartRename as (paneId: number) => void}
         onRemoveTitle={onRemoveTitle as (paneId: number) => void}
         onClosePane={onClosePane as (paneId: number) => void}
         onRenameValueChange={vi.fn()}
@@ -117,7 +136,15 @@ function renderOverlay({
     )
   })
   mounted.push({ container, root })
-  return { container, onClosePane, onRemoveTitle, onRenameSubmit }
+  return { container, onClosePane, onRemoveTitle, onRenameSubmit, onBeginPaneDrag, onStartRename }
+}
+
+function firePointerDown(target: Element): void {
+  act(() => {
+    target.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, cancelable: true, button: 0, pointerId: 1 })
+    )
+  })
 }
 
 function pressInputKey(
@@ -223,5 +250,148 @@ describe('TerminalPaneHeaderOverlay', () => {
     expect(onContinueAgentSessionInNewSession).toHaveBeenCalledWith(
       expect.objectContaining({ id: 1 })
     )
+  })
+
+  // Regression for https://github.com/stablyai/orca/issues/19727: once a pane
+  // has a title, its .pane-title-bar becomes pointer-events:auto and fully
+  // occludes the pane's underlying full-width drag strip. These tests pin the
+  // fix's contract: the bar (including the title text, which is a plain drag
+  // surface renamed only via double-click) starts the pane drag on
+  // pointerdown, while the rename input and every action button opt out via
+  // stopPropagation so their own rename/close behavior is preserved — mirrors
+  // SortableTab.tsx's tab-label/rename-input split.
+  describe('pane drag after a title is set', () => {
+    it('starts a pane drag from pointerdown on the titled bar itself', () => {
+      const { container, onBeginPaneDrag } = renderOverlay({
+        paneTitles: { 1: 'server', 2: '' }
+      })
+      const bar = container.querySelectorAll('.pane-title-bar')[0] as HTMLElement
+
+      firePointerDown(bar)
+
+      expect(onBeginPaneDrag).toHaveBeenCalledTimes(1)
+      expect(onBeginPaneDrag).toHaveBeenCalledWith(1, bar, expect.any(PointerEvent))
+    })
+
+    it('starts a pane drag from pointerdown on the title text (single click/drag drags; double-click renames)', () => {
+      const { container, onBeginPaneDrag } = renderOverlay({
+        paneTitles: { 1: 'server', 2: '' }
+      })
+      const titleText = container.querySelector<HTMLSpanElement>('.pane-title-text')
+
+      expect(titleText).not.toBeNull()
+      firePointerDown(titleText as HTMLSpanElement)
+
+      expect(onBeginPaneDrag).toHaveBeenCalledTimes(1)
+      expect(onBeginPaneDrag).toHaveBeenCalledWith(
+        1,
+        expect.any(HTMLElement),
+        expect.any(PointerEvent)
+      )
+    })
+
+    it('opens rename on double-click of the title text instead of a single click', () => {
+      const { container, onStartRename } = renderOverlay({
+        paneTitles: { 1: 'server', 2: '' }
+      })
+      const titleText = container.querySelector<HTMLSpanElement>('.pane-title-text')
+
+      expect(titleText).not.toBeNull()
+      // Why: a plain click on the title text (or anywhere else on the bar) must
+      // never rename — only pointer movement (drag) or dblclick does anything.
+      act(() => titleText?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+      expect(onStartRename).not.toHaveBeenCalled()
+
+      // Why: dispatched on the title text and asserted via bubbling, matching
+      // production — beginPaneDragFromPointerDown captures the pointer on the
+      // bar itself, so the real dblclick actually lands on the bar, not this
+      // child; the rename handler lives there for exactly that reason.
+      act(() => titleText?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true })))
+      expect(onStartRename).toHaveBeenCalledWith(1)
+    })
+
+    it('does not open rename on double-click of an action button', () => {
+      // Why: an action button's pointerdown stops propagation, so the bar never
+      // captures the pointer for that gesture — its native dblclick is a
+      // separate event the click handler's stopPropagation doesn't touch, and
+      // would otherwise bubble up and incorrectly trigger rename.
+      const { container, onStartRename } = renderOverlay({
+        paneTitles: { 1: 'server', 2: '' }
+      })
+      const removeTitle = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Remove pane title: server"]'
+      )
+
+      expect(removeTitle).not.toBeNull()
+      act(() => removeTitle?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true })))
+
+      expect(onStartRename).not.toHaveBeenCalled()
+    })
+
+    it('does not start a pane drag from pointerdown on the rename input', () => {
+      const { container, onBeginPaneDrag } = renderOverlay({
+        paneTitles: { 1: 'server', 2: '' },
+        renamingPaneId: 1,
+        renameValue: 'server'
+      })
+      const input = container.querySelector<HTMLInputElement>('.pane-title-input')
+
+      expect(input).not.toBeNull()
+      firePointerDown(input as HTMLInputElement)
+
+      expect(onBeginPaneDrag).not.toHaveBeenCalled()
+    })
+
+    it('does not start a pane drag from pointerdown on the split action button', () => {
+      const { container, onBeginPaneDrag } = renderOverlay({
+        paneTitles: { 1: 'server', 2: '' }
+      })
+      const splitButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Split Terminal Right"]'
+      )
+
+      expect(splitButton).not.toBeNull()
+      firePointerDown(splitButton as HTMLButtonElement)
+
+      expect(onBeginPaneDrag).not.toHaveBeenCalled()
+    })
+
+    it('does not start a pane drag from pointerdown on the remove-title action button', () => {
+      const { container, onBeginPaneDrag } = renderOverlay({
+        paneTitles: { 1: 'server', 2: '' }
+      })
+      const removeTitle = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Remove pane title: server"]'
+      )
+
+      expect(removeTitle).not.toBeNull()
+      firePointerDown(removeTitle as HTMLButtonElement)
+
+      expect(onBeginPaneDrag).not.toHaveBeenCalled()
+    })
+
+    it('still accepts an external workspace-file drag-over/drop on the titled bar', () => {
+      const manager = {} as PaneManager
+      const { container } = renderOverlay({
+        paneTitles: { 1: 'server', 2: '' },
+        managerRef: { current: manager } as RefObject<PaneManager | null>
+      })
+      const bar = container.querySelectorAll('.pane-title-bar')[0] as HTMLElement
+
+      // Why: happy-dom's DragEvent constructor doesn't wire the `dataTransfer`
+      // option through (a known limitation), so attach it directly.
+      const dataTransfer = new DataTransfer()
+      dataTransfer.setData(WORKSPACE_FILE_PATH_MIME, '/tmp/example.txt')
+      const dragOverEvent = new DragEvent('dragover', { bubbles: true, cancelable: true })
+      Object.defineProperty(dragOverEvent, 'dataTransfer', { value: dataTransfer })
+      act(() => bar.dispatchEvent(dragOverEvent))
+      expect(dragOverEvent.defaultPrevented).toBe(true)
+      expect(dataTransfer.dropEffect).toBe('copy')
+
+      const dropEvent = new DragEvent('drop', { bubbles: true, cancelable: true })
+      Object.defineProperty(dropEvent, 'dataTransfer', { value: dataTransfer })
+      act(() => bar.dispatchEvent(dropEvent))
+      expect(handleInternalTerminalFileDropMock).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.test.tsx
@@ -310,6 +310,30 @@ describe('TerminalPaneHeaderOverlay', () => {
       expect(onStartRename).toHaveBeenCalledWith(1)
     })
 
+    // Why: the title text moved from a <button> to a plain <span> so a single
+    // click/drag isn't stolen from the bar (see the drag tests above). That
+    // dropped native keyboard activation, so it's restored explicitly here —
+    // a keyboard-only user must still be able to reach rename without a mouse.
+    it('is keyboard-focusable and opens rename on Enter/Space', () => {
+      const { container, onStartRename } = renderOverlay({
+        paneTitles: { 1: 'server', 2: '' }
+      })
+      const titleText = container.querySelector<HTMLSpanElement>('.pane-title-text')
+
+      expect(titleText).not.toBeNull()
+      expect(titleText?.getAttribute('role')).toBe('button')
+      expect(titleText?.getAttribute('tabindex')).toBe('0')
+
+      act(() =>
+        titleText?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+      )
+      expect(onStartRename).toHaveBeenCalledWith(1)
+
+      onStartRename.mockClear()
+      act(() => titleText?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true })))
+      expect(onStartRename).toHaveBeenCalledWith(1)
+    })
+
     it('does not open rename on double-click of an action button', () => {
       // Why: an action button's pointerdown stops propagation, so the bar never
       // captures the pointer for that gesture — its native dblclick is a

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
@@ -1,19 +1,11 @@
 import type { CSSProperties, RefObject } from 'react'
-import {
-  MessageSquare,
-  MessageSquarePlus,
-  SquareSplitVertical,
-  SquareTerminal,
-  X
-} from 'lucide-react'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import { WORKSPACE_FILE_PATH_MIME, WORKSPACE_FILE_PATHS_MIME } from '@/lib/workspace-file-drag'
 import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import type { PtyTransport } from './pty-transport'
 import { handleInternalTerminalFileDrop } from './terminal-drop-handler'
+import PaneTitleActions from './PaneTitleActions'
 
 export type PaneTitleOverlayRect = {
   left: number
@@ -126,6 +118,13 @@ export default function TerminalPaneHeaderOverlay({
         const isActivePane = activePaneId === pane.id
         const isChromeless = showAlwaysOnHeaders && !title && !isEditing
         const showHeader = overlayRect && (showAlwaysOnHeaders || Boolean(title) || isEditing)
+        const editTitleLabel = title
+          ? translate(
+              'auto.components.terminal.pane.TerminalPane.cc5a2dc706',
+              'Edit pane title: {{value0}}',
+              { value0: title }
+            )
+          : ''
         if (!showHeader || !overlayRect) {
           return null
         }
@@ -144,10 +143,12 @@ export default function TerminalPaneHeaderOverlay({
               title || isEditing ? () => onActivatePaneTitleInteraction(pane.id) : undefined
             }
             onPointerDown={(event) => {
-              // Why: the bar itself is the drag-initiating surface (title text,
-              // rename input, and every action button stop propagation on their
-              // own pointerdown so this only fires for the empty bar area) —
-              // matches SortableTab.tsx's root-drag/child-stopPropagation split.
+              // Why: the bar itself is the drag-initiating surface. The title
+              // text deliberately does NOT stop propagation — it's part of the
+              // drag surface too (single click/drag drags; double-click
+              // renames) — only the rename input and the action buttons opt
+              // out, matching SortableTab.tsx's root-drag/child-stopPropagation
+              // split.
               if (paneCount > 1 && !isEditing) {
                 onBeginPaneDrag(pane.id, event.currentTarget, event.nativeEvent)
               }
@@ -248,200 +249,44 @@ export default function TerminalPaneHeaderOverlay({
             ) : (
               <>
                 {title ? (
-                  // Why: plain drag surface, not a button — double-click-to-rename
-                  // is wired on the bar itself (see onDoubleClick above), because
-                  // pointer capture retargets the dblclick there, not to a child.
-                  // Matches SortableTab.tsx's tab label (also a plain span).
+                  // Why: a plain drag surface (not a <button>) so click/drag
+                  // isn't stolen from the bar; rename is on double-click (on
+                  // the bar itself — see onDoubleClick above, pointer capture
+                  // retargets there) plus tabIndex/role/Enter-Space so a
+                  // keyboard-only user can still reach it.
                   <span
                     className="pane-title-text"
-                    title={translate(
-                      'auto.components.terminal.pane.TerminalPane.cc5a2dc706',
-                      'Edit pane title: {{value0}}',
-                      { value0: title }
-                    )}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={editTitleLabel}
+                    title={editTitleLabel}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault()
+                        onStartRename(pane.id)
+                      }
+                    }}
                   >
                     {title}
                   </span>
                 ) : null}
-                <div className="pane-title-actions ml-auto flex shrink-0 items-center gap-0">
-                  {canContinueAgentSessionInNewSession && isActivePane ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-xs"
-                          className="pane-title-split-trigger"
-                          aria-label={translate(
-                            'components.agentSessionContinuation.continueInNewSession',
-                            'Continue in New Session…'
-                          )}
-                          onPointerDown={(event) => event.stopPropagation()}
-                          // Why: a native dblclick isn't blocked by the click
-                          // handler's stopPropagation above (a separate event)
-                          // — without this it would bubble up and incorrectly
-                          // trigger the bar's rename handler (same reasoning
-                          // applies to every action button below).
-                          onDoubleClick={(event) => event.stopPropagation()}
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            onContinueAgentSessionInNewSession?.(pane)
-                          }}
-                        >
-                          <MessageSquarePlus className="size-3" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" sideOffset={4}>
-                        {translate(
-                          'components.agentSessionContinuation.continueInNewSession',
-                          'Continue in New Session…'
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : null}
-                  {canToggleNativeChat && isActivePane ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-xs"
-                          // Same class as split so it shares the hover/active reveal
-                          // and sits as a peer in the [chat][split][×] cluster.
-                          className="pane-title-split-trigger"
-                          aria-label={
-                            isChatViewMode
-                              ? translate(
-                                  'components.native-chat.toggle.showTerminal',
-                                  'Show terminal'
-                                )
-                              : translate(
-                                  'components.native-chat.toggle.showChat',
-                                  'Show chat view'
-                                )
-                          }
-                          aria-pressed={isChatViewMode}
-                          onPointerDown={(event) => event.stopPropagation()}
-                          // Why: see the first action button's comment above —
-                          // a native dblclick would otherwise bubble up and
-                          // incorrectly trigger the bar's rename handler.
-                          onDoubleClick={(event) => event.stopPropagation()}
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            onToggleNativeChat?.()
-                          }}
-                        >
-                          {isChatViewMode ? (
-                            <SquareTerminal className="size-3" />
-                          ) : (
-                            <MessageSquare className="size-3" />
-                          )}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" sideOffset={4}>
-                        {isChatViewMode
-                          ? translate('components.native-chat.toggle.showTerminal', 'Show terminal')
-                          : translate('components.native-chat.toggle.showChat', 'Show chat view')}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : null}
-                  {showAlwaysOnHeaders && showSplitButton ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-xs"
-                          className="pane-title-split-trigger"
-                          data-contextual-tour-target={
-                            isActivePane ? 'terminal-pane-split-target' : undefined
-                          }
-                          aria-label={splitRightLabel}
-                          onPointerDown={(event) => event.stopPropagation()}
-                          // Why: see the first action button's comment above —
-                          // a native dblclick would otherwise bubble up and
-                          // incorrectly trigger the bar's rename handler.
-                          onDoubleClick={(event) => event.stopPropagation()}
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            onSplitPane(pane, 'vertical')
-                          }}
-                        >
-                          <SquareSplitVertical className="size-3" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" sideOffset={4}>
-                        {splitRightLabel}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : null}
-                  {title ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-xs"
-                          className="pane-title-close"
-                          onPointerDown={(event) => event.stopPropagation()}
-                          // Why: see the first action button's comment above —
-                          // a native dblclick would otherwise bubble up and
-                          // incorrectly trigger the bar's rename handler.
-                          onDoubleClick={(event) => event.stopPropagation()}
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            onRemoveTitle(pane.id)
-                          }}
-                          aria-label={translate(
-                            'auto.components.terminal.pane.TerminalPane.f984ab2a30',
-                            'Remove pane title: {{value0}}',
-                            { value0: title }
-                          )}
-                        >
-                          <X className="size-3" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" sideOffset={4}>
-                        {translate(
-                          'auto.components.terminal.pane.TerminalPane.ac112e9036',
-                          'Remove title'
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : paneCount > 1 && showAlwaysOnHeaders ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-xs"
-                          className="pane-title-close"
-                          onPointerDown={(event) => event.stopPropagation()}
-                          // Why: see the first action button's comment above —
-                          // a native dblclick would otherwise bubble up and
-                          // incorrectly trigger the bar's rename handler.
-                          onDoubleClick={(event) => event.stopPropagation()}
-                          onClick={(event) => {
-                            event.stopPropagation()
-                            onClosePane(pane.id)
-                          }}
-                          aria-label={translate(
-                            'auto.components.terminal.pane.TerminalContextMenu.8c17d6786d',
-                            'Close Pane'
-                          )}
-                        >
-                          <X className="size-3" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" sideOffset={4}>
-                        {translate(
-                          'auto.components.terminal.pane.TerminalContextMenu.8c17d6786d',
-                          'Close Pane'
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : null}
-                </div>
+                <PaneTitleActions
+                  pane={pane}
+                  title={title}
+                  isActivePane={isActivePane}
+                  paneCount={paneCount}
+                  showAlwaysOnHeaders={showAlwaysOnHeaders}
+                  showSplitButton={showSplitButton}
+                  splitRightLabel={splitRightLabel}
+                  canContinueAgentSessionInNewSession={canContinueAgentSessionInNewSession}
+                  onContinueAgentSessionInNewSession={onContinueAgentSessionInNewSession}
+                  canToggleNativeChat={canToggleNativeChat}
+                  isChatViewMode={isChatViewMode}
+                  onToggleNativeChat={onToggleNativeChat}
+                  onSplitPane={onSplitPane}
+                  onRemoveTitle={onRemoveTitle}
+                  onClosePane={onClosePane}
+                />
               </>
             )}
           </div>

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
@@ -143,6 +143,28 @@ export default function TerminalPaneHeaderOverlay({
             onPointerDownCapture={
               title || isEditing ? () => onActivatePaneTitleInteraction(pane.id) : undefined
             }
+            onPointerDown={(event) => {
+              // Why: the bar itself is the drag-initiating surface (title text,
+              // rename input, and every action button stop propagation on their
+              // own pointerdown so this only fires for the empty bar area) —
+              // matches SortableTab.tsx's root-drag/child-stopPropagation split.
+              if (paneCount > 1 && !isEditing) {
+                onBeginPaneDrag(pane.id, event.currentTarget, event.nativeEvent)
+              }
+            }}
+            onDoubleClick={(event) => {
+              // Why: beginPaneDragFromPointerDown calls handle.setPointerCapture()
+              // on this bar (the `handle` it's given), which retargets every
+              // subsequent mouse-compatibility event for that pointer — including
+              // dblclick — to the bar itself, not whatever child was under the
+              // cursor. A dblclick handler on the inner title text/span would
+              // never receive it, so it has to live here instead.
+              if (!title || isEditing) {
+                return
+              }
+              event.stopPropagation()
+              onStartRename(pane.id)
+            }}
             onDragOver={(event) => {
               onActivatePaneTitleInteraction(pane.id)
               if (
@@ -197,6 +219,9 @@ export default function TerminalPaneHeaderOverlay({
                   'Pane title'
                 )}
                 value={renameValue}
+                // Why: stop the bar's own pointerdown from starting a pane drag
+                // while the rename input is focused/being clicked into.
+                onPointerDown={(event) => event.stopPropagation()}
                 onChange={(event) => onRenameValueChange(event.target.value)}
                 onKeyDown={(event) => {
                   // Why: an Enter that only confirms a CJK IME candidate must
@@ -222,28 +247,21 @@ export default function TerminalPaneHeaderOverlay({
               />
             ) : (
               <>
-                {paneCount > 1 && !isChromeless && (
-                  <div
-                    className="pane-title-drag-handle"
-                    aria-hidden="true"
-                    onPointerDown={(event) => {
-                      onBeginPaneDrag(pane.id, event.currentTarget, event.nativeEvent)
-                    }}
-                  />
-                )}
                 {title ? (
-                  <button
-                    type="button"
+                  // Why: plain drag surface, not a button — double-click-to-rename
+                  // is wired on the bar itself (see onDoubleClick above), because
+                  // pointer capture retargets the dblclick there, not to a child.
+                  // Matches SortableTab.tsx's tab label (also a plain span).
+                  <span
                     className="pane-title-text"
-                    onClick={() => onStartRename(pane.id)}
-                    aria-label={translate(
+                    title={translate(
                       'auto.components.terminal.pane.TerminalPane.cc5a2dc706',
                       'Edit pane title: {{value0}}',
                       { value0: title }
                     )}
                   >
                     {title}
-                  </button>
+                  </span>
                 ) : null}
                 <div className="pane-title-actions ml-auto flex shrink-0 items-center gap-0">
                   {canContinueAgentSessionInNewSession && isActivePane ? (
@@ -258,6 +276,13 @@ export default function TerminalPaneHeaderOverlay({
                             'components.agentSessionContinuation.continueInNewSession',
                             'Continue in New Session…'
                           )}
+                          onPointerDown={(event) => event.stopPropagation()}
+                          // Why: a native dblclick isn't blocked by the click
+                          // handler's stopPropagation above (a separate event)
+                          // — without this it would bubble up and incorrectly
+                          // trigger the bar's rename handler (same reasoning
+                          // applies to every action button below).
+                          onDoubleClick={(event) => event.stopPropagation()}
                           onClick={(event) => {
                             event.stopPropagation()
                             onContinueAgentSessionInNewSession?.(pane)
@@ -296,6 +321,11 @@ export default function TerminalPaneHeaderOverlay({
                                 )
                           }
                           aria-pressed={isChatViewMode}
+                          onPointerDown={(event) => event.stopPropagation()}
+                          // Why: see the first action button's comment above —
+                          // a native dblclick would otherwise bubble up and
+                          // incorrectly trigger the bar's rename handler.
+                          onDoubleClick={(event) => event.stopPropagation()}
                           onClick={(event) => {
                             event.stopPropagation()
                             onToggleNativeChat?.()
@@ -327,6 +357,11 @@ export default function TerminalPaneHeaderOverlay({
                             isActivePane ? 'terminal-pane-split-target' : undefined
                           }
                           aria-label={splitRightLabel}
+                          onPointerDown={(event) => event.stopPropagation()}
+                          // Why: see the first action button's comment above —
+                          // a native dblclick would otherwise bubble up and
+                          // incorrectly trigger the bar's rename handler.
+                          onDoubleClick={(event) => event.stopPropagation()}
                           onClick={(event) => {
                             event.stopPropagation()
                             onSplitPane(pane, 'vertical')
@@ -348,6 +383,11 @@ export default function TerminalPaneHeaderOverlay({
                           variant="ghost"
                           size="icon-xs"
                           className="pane-title-close"
+                          onPointerDown={(event) => event.stopPropagation()}
+                          // Why: see the first action button's comment above —
+                          // a native dblclick would otherwise bubble up and
+                          // incorrectly trigger the bar's rename handler.
+                          onDoubleClick={(event) => event.stopPropagation()}
                           onClick={(event) => {
                             event.stopPropagation()
                             onRemoveTitle(pane.id)
@@ -376,6 +416,11 @@ export default function TerminalPaneHeaderOverlay({
                           variant="ghost"
                           size="icon-xs"
                           className="pane-title-close"
+                          onPointerDown={(event) => event.stopPropagation()}
+                          // Why: see the first action button's comment above —
+                          // a native dblclick would otherwise bubble up and
+                          // incorrectly trigger the bar's rename handler.
+                          onDoubleClick={(event) => event.stopPropagation()}
                           onClick={(event) => {
                             event.stopPropagation()
                             onClosePane(pane.id)

--- a/src/renderer/src/lib/pane-manager/pane-drag-pointer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-drag-pointer.ts
@@ -24,7 +24,11 @@ export function beginPaneDragFromPointerDown(
   if ((e.button ?? 0) !== 0 || e.ctrlKey || callbacks.getPanes().size < 2) {
     return null
   }
-  e.preventDefault()
+  // Why: no preventDefault() here — Chromium suppresses the mousedown/click/
+  // dblclick compatibility events for a pointer sequence whose pointerdown was
+  // prevented, which broke double-click-to-rename once the pane title text
+  // became a drag surface (#19727). Defer it to pointermove, once an actual
+  // drag is detected, so a plain click/double-click still reaches the DOM.
   e.stopPropagation()
   handle.setPointerCapture(e.pointerId)
   activePointerId = e.pointerId
@@ -97,6 +101,7 @@ export function beginPaneDragFromPointerDown(
     const dy = ev.clientY - startY
     if (!dragging && Math.hypot(dx, dy) >= DRAG_THRESHOLD) {
       dragging = true
+      ev.preventDefault()
       state.dragSourcePaneId = paneId
       callbacks.getRoot().classList.add('is-pane-dragging')
       callbacks.onDragActiveChange?.(true)

--- a/src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-drag-reorder.test.ts
@@ -236,6 +236,82 @@ describe('attachPaneDrag', () => {
     expect(insertPaneNextTo).not.toHaveBeenCalled()
   })
 
+  // Regression for https://github.com/stablyai/orca/issues/19727: preventDefault()
+  // on pointerdown suppresses Chromium's mousedown/click/dblclick compatibility
+  // events for the whole pointer gesture. Calling it unconditionally on every
+  // qualifying pointerdown silently broke double-click-to-rename once the pane
+  // title text became a drag surface (single click/drag drags; double-click
+  // renames) — a plain click's pointerdown/pointerup never gets to become a
+  // native click/dblclick if preventDefault already fired. It must stay
+  // deferred until an actual drag (movement past the threshold) is detected.
+  it('does not preventDefault a pointerdown/pointerup with no movement, so a click/double-click can still reach the DOM', () => {
+    const handle = new FakeElement()
+    const root = new FakeElement(['pane-manager-root'])
+    const sourceContainer = new FakeElement(['pane'])
+    const targetContainer = new FakeElement(['pane'])
+    const sourcePane = createPane(1, sourceContainer)
+    const targetPane = createPane(2, targetContainer)
+    const panes = new Map<number, ManagedPaneInternal>([
+      [sourcePane.id, sourcePane],
+      [targetPane.id, targetPane]
+    ])
+    const state = createDragReorderState()
+
+    attachPaneDrag(handle as unknown as HTMLElement, sourcePane.id, state, {
+      getPanes: () => panes,
+      getRoot: () => root as unknown as HTMLElement,
+      getStyleOptions: () => ({}),
+      isDestroyed: () => false,
+      safeFit: vi.fn(),
+      applyPaneOpacity: vi.fn(),
+      applyDividerStyles: vi.fn(),
+      refitPanesUnder: vi.fn(),
+      onDragActiveChange: vi.fn()
+    })
+
+    const pointerDownEvent = pointerEvent({ clientX: 10, clientY: 10 })
+    handle.dispatchPointer('pointerdown', pointerDownEvent)
+    handle.dispatchPointer('pointerup', pointerEvent({ pointerId: 1, clientX: 10, clientY: 10 }))
+
+    expect(pointerDownEvent.preventDefault).not.toHaveBeenCalled()
+    expect(root.classList.contains('is-pane-dragging')).toBe(false)
+  })
+
+  it('still preventDefaults once the drag threshold is crossed', () => {
+    const handle = new FakeElement()
+    const root = new FakeElement(['pane-manager-root'])
+    const sourceContainer = new FakeElement(['pane'])
+    const targetContainer = new FakeElement(['pane'])
+    const sourcePane = createPane(1, sourceContainer)
+    const targetPane = createPane(2, targetContainer)
+    const panes = new Map<number, ManagedPaneInternal>([
+      [sourcePane.id, sourcePane],
+      [targetPane.id, targetPane]
+    ])
+    const state = createDragReorderState()
+
+    attachPaneDrag(handle as unknown as HTMLElement, sourcePane.id, state, {
+      getPanes: () => panes,
+      getRoot: () => root as unknown as HTMLElement,
+      getStyleOptions: () => ({}),
+      isDestroyed: () => false,
+      safeFit: vi.fn(),
+      applyPaneOpacity: vi.fn(),
+      applyDividerStyles: vi.fn(),
+      refitPanesUnder: vi.fn(),
+      onDragActiveChange: vi.fn()
+    })
+
+    const pointerDownEvent = pointerEvent({ clientX: 10, clientY: 10 })
+    handle.dispatchPointer('pointerdown', pointerDownEvent)
+    const pointerMoveEvent = pointerEvent({ clientX: 50, clientY: 10 })
+    handle.dispatchPointer('pointermove', pointerMoveEvent)
+
+    expect(pointerDownEvent.preventDefault).not.toHaveBeenCalled()
+    expect(pointerMoveEvent.preventDefault).toHaveBeenCalledTimes(1)
+    expect(root.classList.contains('is-pane-dragging')).toBe(true)
+  })
+
   it('cleans pane drag state if releasing pointer capture fails during drop', () => {
     const handle = new FakeElement()
     const root = new FakeElement(['pane-manager-root'])

--- a/tests/e2e/terminal-pane-title-strip-placement.spec.ts
+++ b/tests/e2e/terminal-pane-title-strip-placement.spec.ts
@@ -147,9 +147,7 @@ test.describe('Terminal Panes', () => {
     await expectPaneTitleAttachedToLeaf(orcaPage, title, titledLeafId)
   })
 
-  test('Set Title keeps the pane drag handle available over the title strip', async ({
-    orcaPage
-  }) => {
+  test('Set Title keeps the whole title bar available as a drag surface', async ({ orcaPage }) => {
     const title = `Draggable title ${Date.now()}`
 
     await setPaneTitleFromTerminalMenu(orcaPage, title)
@@ -163,42 +161,40 @@ test.describe('Terminal Panes', () => {
     await waitForPaneCount(orcaPage, 2)
     await expectPaneTitleAttachedToLeaf(orcaPage, title, titledLeafId)
 
+    // Why: the bar itself is the drag surface now (no dedicated drag-handle
+    // child), so hit-testing a point on it — away from the action-button
+    // cluster on the right — should land on the bar with pointer events on.
     const titleTopHit = await orcaPage.evaluate(
       ({ title, titledLeafId }) => {
         const titleBar = Array.from(document.querySelectorAll<HTMLElement>('.pane-title-bar')).find(
           (element) => element.textContent?.includes(title)
         )
-        const titleDragHandle =
-          titleBar.querySelector<HTMLElement>('.pane-title-drag-handle') ?? null
         const pane = document.querySelector<HTMLElement>(`.pane[data-leaf-id="${titledLeafId}"]`)
-        if (!titleBar || !pane || !titleDragHandle) {
+        if (!titleBar || !pane) {
           return null
         }
         const titleRect = titleBar.getBoundingClientRect()
-        const hitElement = document.elementFromPoint(
-          titleRect.left + titleRect.width / 2,
-          titleRect.top + 4
-        )
+        const hitElement = document.elementFromPoint(titleRect.left + 8, titleRect.top + 4)
         return {
-          hitDragHandle:
-            hitElement instanceof HTMLElement &&
-            hitElement.closest('.pane-title-drag-handle') !== null,
-          pointerEvents: getComputedStyle(titleDragHandle).pointerEvents,
-          titleTop: titleRect.top,
-          handleTop: titleDragHandle.getBoundingClientRect().top
+          hitTitleBar:
+            hitElement instanceof HTMLElement && hitElement.closest('.pane-title-bar') !== null,
+          pointerEvents: getComputedStyle(titleBar).pointerEvents
         }
       },
       { title, titledLeafId }
     )
 
     expect(titleTopHit).not.toBeNull()
-    expect(titleTopHit?.hitDragHandle).toBe(true)
+    expect(titleTopHit?.hitTitleBar).toBe(true)
     expect(titleTopHit?.pointerEvents).toBe('auto')
-    expect(Math.abs((titleTopHit?.handleTop ?? 0) - (titleTopHit?.titleTop ?? 0))).toBeLessThan(1)
 
-    await orcaPage.locator('.pane-title-bar', { hasText: title }).click({
-      position: { x: 20, y: 18 }
-    })
+    // Why: a single click on the title bar (or the title text itself) now
+    // drags the pane instead of renaming it — only double-click renames.
+    const titleBarLocator = orcaPage.locator('.pane-title-bar', { hasText: title })
+    await titleBarLocator.click({ position: { x: 20, y: 18 } })
+    await expect(orcaPage.locator('.pane-title-input')).toBeHidden()
+
+    await titleBarLocator.dblclick({ position: { x: 20, y: 18 } })
     await expect(orcaPage.locator('.pane-title-input')).toBeVisible()
   })
 
@@ -221,11 +217,12 @@ test.describe('Terminal Panes', () => {
     }
     const beforeOrder = await readTerminalPaneDomLeafOrder(orcaPage)
 
-    const titleDragHandle = orcaPage
-      .locator('.pane-title-bar', { hasText: title })
-      .locator('.pane-title-drag-handle')
-    await expect(titleDragHandle).toBeVisible({ timeout: 3_000 })
-    const sourceBox = await titleDragHandle.boundingBox()
+    // Why: no dedicated drag-handle child anymore — the title bar itself is
+    // the drag surface, so grab it directly. A point near its left edge stays
+    // clear of the right-aligned action-button cluster.
+    const titleBarLocator = orcaPage.locator('.pane-title-bar', { hasText: title })
+    await expect(titleBarLocator).toBeVisible({ timeout: 3_000 })
+    const sourceBox = await titleBarLocator.boundingBox()
     const targetBox = await orcaPage.locator(`.pane[data-leaf-id="${target.leafId}"]`).boundingBox()
     expect(sourceBox).not.toBeNull()
     expect(targetBox).not.toBeNull()
@@ -234,7 +231,7 @@ test.describe('Terminal Panes', () => {
     const targetDropX =
       sourceIndex < targetIndex ? targetBox!.x + targetBox!.width - 8 : targetBox!.x + 8
 
-    await orcaPage.mouse.move(sourceBox!.x + sourceBox!.width / 2, sourceBox!.y + 4)
+    await orcaPage.mouse.move(sourceBox!.x + 20, sourceBox!.y + 4)
     await orcaPage.mouse.down()
     await orcaPage.mouse.move(targetDropX, targetBox!.y + targetBox!.height / 2, {
       steps: 20


### PR DESCRIPTION
**Author (X/Twitter):** SyedZohaib2623


## ELI5

Splitting a terminal and giving one of the panes a title used to make that pane
impossible to drag by its header — the title bar quietly ate up the entire
draggable area, leaving only an invisible pixel-sized spot that worked. This
fixes it so the whole title bar drags again, and adds double-click-to-rename
so renaming still works without a full-width button getting in the way.

## What Changed

- `TerminalPaneHeaderOverlay.tsx` / `terminal.css`: the pane title bar itself
  is now the drag-initiating surface (matching `SortableTab.tsx`'s pattern),
  replacing the old, barely-discoverable 32px drag pill. The title text is a
  plain span (single click/drag drags the pane; double-click opens rename).
  Action buttons and the rename input opt out of drag via `stopPropagation`.
- `pane-drag-pointer.ts`: deferred `preventDefault()` on pane-drag pointerdown
  until the drag threshold is actually crossed, instead of calling it
  unconditionally — that was silently suppressing native double-click once the
  title text became a drag surface.
- Added regression tests for both the drag-target and the double-click fix.

## Why

Once a pane had a title, its `.pane-title-bar` switched from
`pointer-events:none` (chromeless, letting pointerdowns fall through to the
pane's full-width drag strip underneath) to `pointer-events:auto`, occluding
that strip entirely. The only surviving drag target was a hidden 32px pill,
which most users would never find — reported as "can't drag a pane after
adding a title" in #19727.

## Linked Issue

Fixes #19727

## Visual Proof
https://www.loom.com/share/72667ea405074d8b935bc01428297c5e

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated
- Platforms tested: Windows <!-- update if you also tested macOS/Linux/SSH -->

## AI Disclosure

Claude (Sonnet 5, via Claude Code) was used throughout — root-cause
investigation, plan creation, and test authoring. Implementation and all steps were reviewed and directed
by me at each step.

## Review

- **Cross-platform**: pure renderer DOM/CSS/pointer-event logic; no
  platform-specific APIs touched. No Windows/macOS/Linux divergence expected.
- **SSH/remote**: no execution-host or remote-specific code involved — this is
  local UI interaction only.
- **Agent/integration compatibility**: not applicable, no agent/provider code
  touched.
- **Performance**: no new listeners beyond what already existed on the bar;
  `preventDefault()` timing change reduces work on a plain click (skips it
  entirely) and is unchanged for an actual drag.
- **Security**: no new external input handling, no changes to IPC/file
  system/network surfaces.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

No known issues across security, cross-platform, remote SSH, mobile, or
backwards compatibility. Pure interaction-model fix scoped to the terminal
pane title bar.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass