### PR TITLE
fix: make numbered shortcuts follow the activity sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarAgentsList.tsx
+++ b/src/renderer/src/components/sidebar/SidebarAgentsList.tsx
@@ -10,6 +10,7 @@ import { ActivityThreadListPane } from '@/components/activity/activity-thread-li
 import { useAgentPaneThreads } from '@/components/activity/use-agent-pane-threads'
 import { ActivityThreadOptionsMenu } from '@/components/activity/activity-thread-controls'
 import type { ActivityGroupBy, ThreadReadFilter } from '@/components/activity/activity-thread-types'
+import { useSidebarAgentIndexShortcut } from './use-sidebar-agent-index-shortcut'
 
 /**
  * The Activity thread list, hosted in the sidebar as a navigator: selecting a
@@ -93,6 +94,8 @@ export default function SidebarAgentsList({
     unacknowledgeAgents: storeData.unacknowledgeAgents,
     setSelectedPaneKey
   })
+
+  useSidebarAgentIndexShortcut(visibleThreadGroups, groupBy, selectThread)
 
   const canJumpToWorkspace = useCallback(
     (thread: Parameters<typeof hasActivityThreadWorkspace>[0]) =>

--- a/src/renderer/src/components/sidebar/use-sidebar-agent-index-shortcut.test.tsx
+++ b/src/renderer/src/components/sidebar/use-sidebar-agent-index-shortcut.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { ActivityThreadCollapseContext } from '@/components/activity/activity-thread-collapse-context'
+import { makeTab, makeWorktree } from '@/components/activity/ActivityPrototypePage-test-fixtures'
+import type {
+  ActivityThreadGroup,
+  AgentPaneThread
+} from '@/components/activity/activity-thread-types'
+import {
+  SIDEBAR_AGENT_INDEX_JUMP_EVENT,
+  useSidebarAgentIndexShortcut
+} from './use-sidebar-agent-index-shortcut'
+
+const thread = (paneKey: string): AgentPaneThread => ({
+  paneKey,
+  tab: makeTab(),
+  worktree: makeWorktree(),
+  repo: null,
+  currentAgentState: null,
+  currentAgentEntry: null,
+  latestEvent: null,
+  latestTimestamp: 1000,
+  agentType: 'claude',
+  unread: false,
+  paneTitle: paneKey,
+  responsePreview: '',
+  events: []
+})
+const collapse = { collapsedGroupKeys: new Set(['one']), onToggleGroupCollapse: vi.fn() }
+const first = thread('first')
+const second = thread('second')
+const third = thread('third')
+const groups: ActivityThreadGroup[] = [
+  { key: 'one', label: 'One', threads: [first, third] },
+  { key: 'two', label: 'Two', threads: [second] }
+]
+const jump = (index: number): void => {
+  act(() => {
+    window.dispatchEvent(new CustomEvent(SIDEBAR_AGENT_INDEX_JUMP_EVENT, { detail: index }))
+  })
+}
+afterEach(cleanup)
+
+it('follows rendered group order, skips headers, and refreshes after filtering', () => {
+  const select = vi.fn()
+  const view = renderHook(({ rows }) => useSidebarAgentIndexShortcut(rows, 'project', select), {
+    initialProps: { rows: groups }
+  })
+  jump(0)
+  jump(1)
+  jump(2)
+  expect(select.mock.calls.map(([row]) => row)).toEqual([first, third, second])
+  view.rerender({ rows: [groups[1]] })
+  jump(0)
+  expect(select).toHaveBeenLastCalledWith(second)
+  select.mockClear()
+  for (const index of [-1, 1, 9, 0.5, Number.NaN]) {
+    jump(index)
+  }
+  expect(select).not.toHaveBeenCalled()
+  view.unmount()
+  jump(0)
+  expect(select).not.toHaveBeenCalled()
+})
+
+it('honors the sidebar collapse context without renumbering by scroll position', () => {
+  const select = vi.fn()
+  renderHook(() => useSidebarAgentIndexShortcut(groups, 'project', select), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <ActivityThreadCollapseContext.Provider value={collapse}>
+        {children}
+      </ActivityThreadCollapseContext.Provider>
+    )
+  })
+  jump(0)
+  jump(1)
+  expect(select).toHaveBeenCalledExactlyOnceWith(second)
+})
+
+it('ignores saved collapsed groups when grouping is disabled and handles an empty list', () => {
+  const select = vi.fn()
+  const view = renderHook(({ rows }) => useSidebarAgentIndexShortcut(rows, 'none', select), {
+    initialProps: { rows: groups },
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <ActivityThreadCollapseContext.Provider value={collapse}>
+        {children}
+      </ActivityThreadCollapseContext.Provider>
+    )
+  })
+  jump(0)
+  expect(select).toHaveBeenCalledExactlyOnceWith(first)
+  select.mockClear()
+  view.rerender({ rows: [] })
+  jump(0)
+  expect(select).not.toHaveBeenCalled()
+})

--- a/src/renderer/src/components/sidebar/use-sidebar-agent-index-shortcut.ts
+++ b/src/renderer/src/components/sidebar/use-sidebar-agent-index-shortcut.ts
@@ -1,0 +1,36 @@
+import { useContext, useEffect } from 'react'
+import { ActivityThreadCollapseContext } from '@/components/activity/activity-thread-collapse-context'
+import { buildActivityVirtualItems } from '@/components/activity/activity-thread-virtual-items'
+import type {
+  ActivityGroupBy,
+  ActivityThreadGroup,
+  AgentPaneThread
+} from '@/components/activity/activity-thread-types'
+
+export const SIDEBAR_AGENT_INDEX_JUMP_EVENT = 'orca:sidebar-agent-index-jump'
+const EMPTY_COLLAPSED_GROUPS: ReadonlySet<string> = new Set()
+
+export function useSidebarAgentIndexShortcut(
+  groups: ActivityThreadGroup[],
+  groupBy: ActivityGroupBy,
+  selectThread: (thread: AgentPaneThread) => void
+): void {
+  const collapse = useContext(ActivityThreadCollapseContext)
+  const collapsedGroupKeys = collapse?.collapsedGroupKeys ?? EMPTY_COLLAPSED_GROUPS
+
+  useEffect(() => {
+    const onJump = (event: Event): void => {
+      if (!(event instanceof CustomEvent) || !Number.isInteger(event.detail) || event.detail < 0) {
+        return
+      }
+      // Index the same rows as rendering, not the ungrouped thread array or mounted viewport.
+      const items = buildActivityVirtualItems({ groups, groupBy, collapsedGroupKeys })
+      const target = items.filter((item) => item.type === 'thread')[event.detail]
+      if (target) {
+        selectThread(target.thread)
+      }
+    }
+    window.addEventListener(SIDEBAR_AGENT_INDEX_JUMP_EVENT, onJump)
+    return () => window.removeEventListener(SIDEBAR_AGENT_INDEX_JUMP_EVENT, onJump)
+  }, [groups, groupBy, collapsedGroupKeys, selectThread])
+}

--- a/src/renderer/src/hooks/ipc-events/workspace-shortcut-ipc-bridge.test.ts
+++ b/src/renderer/src/hooks/ipc-events/workspace-shortcut-ipc-bridge.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { useSidebarAgentIndexShortcut } from '@/components/sidebar/use-sidebar-agent-index-shortcut'
+import {
+  makeActivityResult,
+  makeThreads,
+  makeWorkingEntryWithoutHistory,
+  PANE_KEY
+} from '@/components/activity/ActivityPrototypePage-test-fixtures'
+import { useAppStore } from '@/store'
+import { activateAndRevealWorkspace } from '@/lib/worktree-activation'
+import { subscribeCmdJRowIndexJump } from '@/lib/cmd-j-row-index-jump'
+import { registerWorkspaceShortcutIpcBridge } from './workspace-shortcut-ipc-bridge'
+
+vi.mock('@/lib/worktree-activation', () => ({ activateAndRevealWorkspace: vi.fn() }))
+vi.mock('@/components/sidebar/visible-worktrees', () => ({
+  getVisibleWorktreeShortcutTargets: () => [{ id: 'workspace', executionHostId: 'ssh:host' }]
+}))
+
+let jump: (index: number) => void
+const unsubs: (() => void)[] = []
+
+beforeEach(() => {
+  useAppStore.setState({
+    activeView: 'terminal',
+    activeModal: 'none',
+    sidebarOpen: true,
+    sidebarBody: 'agents'
+  })
+  vi.stubGlobal('api', {
+    ui: new Proxy(
+      {},
+      {
+        get: (_target, key) => (listener: (index: number) => void) => {
+          if (key === 'onJumpToWorktreeIndex') {
+            jump = listener
+          }
+          return () => {}
+        }
+      }
+    )
+  })
+  registerWorkspaceShortcutIpcBridge(unsubs)
+})
+
+afterEach(() => {
+  cleanup()
+  unsubs.splice(0).forEach((unsubscribe) => unsubscribe())
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+it('routes digits to the displayed Agents list without revealing a hidden workspace', () => {
+  const listener = vi.fn()
+  window.addEventListener('orca:sidebar-agent-index-jump', listener)
+  try {
+    jump(0)
+    expect(listener).toHaveBeenCalledOnce()
+    expect((listener.mock.calls[0][0] as CustomEvent<number>).detail).toBe(0)
+    expect(activateAndRevealWorkspace).not.toHaveBeenCalled()
+    expect(useAppStore.getState().sidebarBody).toBe('agents')
+  } finally {
+    window.removeEventListener('orca:sidebar-agent-index-jump', listener)
+  }
+})
+
+it.each([{ sidebarBody: 'workspaces' as const }, { sidebarOpen: false }])(
+  'preserves workspace navigation when Agents are not displayed: %o',
+  (state) => {
+    useAppStore.setState(state)
+    jump(0)
+    expect(activateAndRevealWorkspace).toHaveBeenCalledWith('workspace', {
+      executionHostId: 'ssh:host'
+    })
+  }
+)
+
+it('delivers the IPC index through the mounted activity hook to its selection callback', () => {
+  const threads = makeThreads(
+    makeActivityResult({ entries: { [PANE_KEY]: makeWorkingEntryWithoutHistory() } })
+  )
+  const select = vi.fn()
+  renderHook(() =>
+    useSidebarAgentIndexShortcut([{ key: 'all', label: '', threads }], 'none', select)
+  )
+  act(() => jump(0))
+  expect(threads).toHaveLength(1)
+  expect(select).toHaveBeenCalledExactlyOnceWith(threads[0])
+  expect(activateAndRevealWorkspace).not.toHaveBeenCalled()
+})
+
+it('keeps the command palette ahead of sidebar navigation', () => {
+  const listener = vi.fn()
+  unsubs.push(subscribeCmdJRowIndexJump(listener))
+  useAppStore.setState({ activeModal: 'worktree-palette' })
+  jump(1)
+  expect(listener).toHaveBeenCalledWith(1)
+  expect(activateAndRevealWorkspace).not.toHaveBeenCalled()
+})
+
+it('does not navigate behind a non-terminal view', () => {
+  useAppStore.setState({ activeView: 'settings' })
+  jump(0)
+  expect(activateAndRevealWorkspace).not.toHaveBeenCalled()
+})

--- a/src/renderer/src/hooks/ipc-events/workspace-shortcut-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/workspace-shortcut-ipc-bridge.ts
@@ -3,6 +3,7 @@ import { TOGGLE_WORKSPACE_BOARD_EVENT } from '@/components/sidebar/useWorkspaceB
 import { activateTabNumberShortcut } from '@/lib/tab-number-shortcuts'
 import { emitCmdJRowIndexJump } from '@/lib/cmd-j-row-index-jump'
 import { getVisibleWorktreeShortcutTargets } from '@/components/sidebar/visible-worktrees'
+import { SIDEBAR_AGENT_INDEX_JUMP_EVENT } from '@/components/sidebar/use-sidebar-agent-index-shortcut'
 import { activateAndRevealWorkspace } from '@/lib/worktree-activation'
 import { deleteHoveredWorkspaceImmediately } from '@/components/sidebar/hovered-workspace-delete'
 import { isFloatingWorkspacePanelFocused } from '@/lib/floating-workspace-terminal-actions'
@@ -88,6 +89,10 @@ export function registerWorkspaceShortcutIpcBridge(unsubs: (() => void)[]): void
         return
       }
       if (store.activeView !== 'terminal') {
+        return
+      }
+      if (store.sidebarOpen && store.sidebarBody === 'agents') {
+        window.dispatchEvent(new CustomEvent(SIDEBAR_AGENT_INDEX_JUMP_EVENT, { detail: index }))
         return
       }
       const visibleTargets = getVisibleWorktreeShortcutTargets()


### PR DESCRIPTION
## ELI5

The sidebar has a normal workspace view and an Activity view, switched with the bell button. In Activity view, numbered shortcuts now select agent rows instead of following the normal view's workspace order. The sidebar stays in Activity view, just as when clicking a row.

## What Changed

The existing numbered shortcut follows Activity's filtered and grouped row order, excluding headings and collapsed groups. Missing rows are a no-op, and scrolling does not change the numbering. Normal workspace navigation, custom bindings, and command-palette precedence remain unchanged.

## Why

The sidebar remains visible when I switch it from the normal workspace view to Activity view using the bell button. In Activity view, I press Cmd+1 expecting to select the first agent in the list. Instead, the shortcut still follows the normal view's workspace order and selects its first workspace. The sidebar is showing agents, but the shortcut selects a workspace according to a different view's ordering, which is confusing.

This change makes the numbered shortcut follow the sidebar's current view: Cmd+1 selects the first agent row in Activity view, while normal view retains its existing workspace navigation. The same behavior applies to Ctrl+1 on Windows/Linux. This is a UX improvement based on that experience, not a claim that global workspace targeting was unintended. No compatibility setting is added initially; feedback on that design choice is welcome.

Together, the two changes would enable a keyboard-only flow: press Cmd/Ctrl+Shift+Y to open Activity, then Cmd/Ctrl+1–9 to select an agent without leaving Activity. The toggle change is still open and is not included or required by this PR; this change also works when Activity is opened by clicking the bell.

## Linked Issue

Fixes #20099

Related: https://github.com/stablyai/orca/pull/19210 — Add keyboard shortcut for activity view (`sidebar.activity.toggle`, default Cmd/Ctrl+Shift+Y).

## Visual Proof

A hidden-Electron interaction check passed on macOS at 1280×800 in dark mode. A synthetic `before-input-event` entered the real main-process shortcut handler and traversed IPC to select the second Activity row's pane, keeping the workspace and Activity sidebar unchanged. All Electron windows remained hidden.

The captures below show interaction states on the patched build, not an unpatched-versus-patched comparison. Setup prompts were dismissed before capture; only the sidebar is included.

| Before numbered input: first visible row selected | After Cmd+2: second visible row selected |
| --- | --- |
| ![Before numbered input](https://github.com/user-attachments/assets/4401a39c-d70e-4a93-bf4e-186ee8457c57) | ![After numbered input](https://github.com/user-attachments/assets/0b696b0c-8f62-43e2-ae63-6edfe5616b68) |

Direct Playwright/CDP key input did not reach Electron's main `before-input-event` handler in this environment, so this is not physical-keyboard evidence.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

On macOS, the committed change passes 59 targeted tests across 6 files, including IPC-to-hook selection, grouping/filtering/collapse behavior, workspace fallback, command-palette precedence, existing activity actions, and digit shortcut policy. The new regression failed before the routing change.

Full validation was rerun in a clean detached worktree at `afac1e45c15c6560998e1ee49bd2293d6aa3649c`, with its own frozen-lockfile dependency install, Node 24.14.0, pnpm 12.0.0, and background launches. The worktree and index remained clean; no source, test, or config was changed to make checks pass.

| Full command | Result |
| --- | --- |
| `pnpm lint` | Passed (65.79s) |
| `pnpm typecheck` | Passed (50.34s) |
| `pnpm test` | Failed (960.26s wall): 16 failed, 78,826 passed, 433 skipped tests; 14 failed, 8,462 passed, 62 skipped files |
| `pnpm build` | Passed (54.18s) |

### Base/head comparison and full rerun

All 14 failed files were rerun on base `94c2f96ea46e9f0a182eb2c7ad18068ab08a2b91` and PR head `afac1e45c15c6560998e1ee49bd2293d6aa3649c`, with the same dependencies, separate temporary directories, and `--no-file-parallelism --maxWorkers=1`. Both runs produced **2 failed, 168 passed, 7 skipped tests** across **2 failed and 12 passed files**. No assertions, timeouts, source, or test configuration were changed.

The two identical failures on both commits are:
- `config/scripts/skill-recipe-shell.test.mjs`: expected the sandbox cleanup error, but received `vercel_args[@]: unbound variable`.
- `src/main/claude/claude-structured-real-cli.test.ts`: the real CLI command catalog did not contain `orca-init-catalog-proof`.

A subsequent **full, unfiltered head rerun** used `node config/scripts/ensure-native-runtime.mjs --runtime=node && pnpm exec vitest run --config config/vitest.config.ts --no-file-parallelism --maxWorkers=1`. It completed in 4,206.30s wall time with **78,877 passed, 2 failed, 396 skipped tests** across **8,475 passed, 2 failed, 61 skipped files**. Only the two independently reproduced baseline failures remained, with no unhandled errors. The original cross-version, history, and SSH failures cleared under bounded concurrency; none was excluded from the run.

The full suite is still **not green** (exit 1). The evidence supports review of this PR without attributing those two baseline failures to this change; it does not claim a globally passing suite. Available missing release tags were fetched explicitly; `v1.4.181` and `v1.4.43` remained unavailable from origin but did not fail the bounded rerun.

This clean run supersedes the earlier dirty-checkout results, which included unrelated local lint/typecheck errors and 591 test failures. Changed-code quality and commit-time lint/format checks also passed.

The hidden rendered interaction check passed twice with synthetic main-process input. Physical-keyboard input, Windows/Linux, and live SSH behavior remain unverified.

## AI Disclosure

AI assistance was used for implementation, tests, and source review.

## Review

Independent read-only source review found no actionable issues. It did not run the app or tests. Ready for review following the matched base/head comparison and full rerun above, with the two baseline failures and manual-input limitations explicitly retained.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Activation reuses the same SSH/folder-aware action as row clicks. No wire format, shortcut binding, or color/layout change is introduced. The relevant upstream routing files remain unchanged at `a0799d8f1c`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
