### PR TITLE
fix(browser): allow certificate bypass for local aliases

### DIFF
--- a/src/main/browser/browser-certificate-challenge.ts
+++ b/src/main/browser/browser-certificate-challenge.ts
@@ -21,6 +21,11 @@ export type BrowserCertificateTrustControllerDependencies = {
     failure: BrowserCertificateFailure | null,
     navigationUrl?: string
   ) => void
+  isEligibleCertificateHost?: (
+    hostname: string,
+    url: string,
+    session: Electron.Session
+  ) => Promise<boolean>
   now?: () => number
   createChallengeId?: () => string
 }

--- a/src/main/browser/browser-certificate-error-handler.ts
+++ b/src/main/browser/browser-certificate-error-handler.ts
@@ -1,0 +1,135 @@
+import type { ManagedBrowserGuestContext } from './browser-certificate-challenge'
+import {
+  getLeafCertificateSha256,
+  normalizeCertificateError,
+  SUPPORTED_CERTIFICATE_ERROR
+} from './browser-certificate-identity'
+import { isEligibleResolvedLocalCertificateHost } from './browser-certificate-host-eligibility'
+import {
+  isEligibleLocalCertificateHost,
+  toSecureCertificateEndpoint
+} from '../../shared/browser-url'
+
+type CertificateIdentity = {
+  secureEndpoint: string
+  leafCertificateSha256: string
+  error: string
+}
+
+export type BrowserCertificateChallengeInput = CertificateIdentity & {
+  webContentsId: number
+  browserPageId: string | null
+  navigationUrl: string
+  origin: string
+  displayHost: string
+}
+
+type BrowserCertificateErrorEvent = {
+  event: Pick<Electron.Event, 'preventDefault'>
+  webContents: Electron.WebContents
+  url: string
+  error: string
+  certificate: Electron.Certificate
+  callback: (isTrusted: boolean) => void
+  isMainFrame: boolean
+}
+
+type BrowserCertificateErrorHandlerDependencies = {
+  resolveManagedGuestContext: (webContentsId: number) => ManagedBrowserGuestContext | null
+  shouldTrustCertificate: (
+    session: Electron.Session,
+    webContentsId: number,
+    identity: CertificateIdentity
+  ) => boolean
+  canOfferCertificate: (session: Electron.Session, identity: CertificateIdentity) => boolean
+  getNavigationSequence: (webContentsId: number) => number
+  recordPendingChallenge: (challenge: BrowserCertificateChallengeInput) => void
+  isEligibleCertificateHost?: (
+    hostname: string,
+    url: string,
+    session: Electron.Session
+  ) => Promise<boolean>
+  onError: (error: unknown) => void
+}
+
+export function handleBrowserCertificateError(
+  args: BrowserCertificateErrorEvent,
+  dependencies: BrowserCertificateErrorHandlerDependencies
+): void {
+  let answered = false
+  const answer = (trusted: boolean): void => {
+    if (!answered) {
+      answered = true
+      args.callback(trusted)
+    }
+  }
+  try {
+    const context = dependencies.resolveManagedGuestContext(args.webContents.id)
+    const parsed = new URL(args.url)
+    const secureEndpoint = toSecureCertificateEndpoint(args.url)
+    const leafCertificateSha256 = getLeafCertificateSha256(args.certificate)
+    const error = normalizeCertificateError(args.error)
+    if (!context || !secureEndpoint || !leafCertificateSha256) {
+      answer(false)
+      return
+    }
+    const identity = { secureEndpoint, leafCertificateSha256, error }
+    if (
+      dependencies.shouldTrustCertificate(args.webContents.session, args.webContents.id, identity)
+    ) {
+      args.event.preventDefault()
+      answer(true)
+      return
+    }
+    if (
+      !args.isMainFrame ||
+      parsed.protocol !== 'https:' ||
+      error !== SUPPORTED_CERTIFICATE_ERROR ||
+      !dependencies.canOfferCertificate(args.webContents.session, identity)
+    ) {
+      answer(false)
+      return
+    }
+    const challenge = {
+      webContentsId: args.webContents.id,
+      browserPageId: context.browserPageId,
+      navigationUrl: args.url,
+      origin: parsed.origin,
+      displayHost: parsed.host,
+      ...identity
+    }
+    if (isEligibleLocalCertificateHost(parsed.hostname)) {
+      dependencies.recordPendingChallenge(challenge)
+      answer(false)
+      return
+    }
+    const navigationSequence = dependencies.getNavigationSequence(args.webContents.id)
+    answer(false)
+    const isEligibleCertificateHost =
+      dependencies.isEligibleCertificateHost ??
+      ((hostname, url, session) =>
+        isEligibleResolvedLocalCertificateHost(hostname, url, (targetUrl) =>
+          session.resolveProxy(targetUrl)
+        ))
+    void isEligibleCertificateHost(parsed.hostname, args.url, args.webContents.session)
+      .then((eligible) => {
+        const currentContext = dependencies.resolveManagedGuestContext(args.webContents.id)
+        if (
+          !eligible ||
+          !currentContext ||
+          navigationSequence !== dependencies.getNavigationSequence(args.webContents.id) ||
+          !dependencies.canOfferCertificate(args.webContents.session, identity)
+        ) {
+          return
+        }
+        dependencies.recordPendingChallenge({
+          ...challenge,
+          browserPageId: currentContext.browserPageId
+        })
+      })
+      .catch(dependencies.onError)
+  } catch (error) {
+    dependencies.onError(error)
+    answer(false)
+  }
+}

--- a/src/main/browser/browser-certificate-host-eligibility.test.ts
+++ b/src/main/browser/browser-certificate-host-eligibility.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { isEligibleResolvedLocalCertificateHost } from './browser-certificate-host-eligibility'
+
+describe('isEligibleResolvedLocalCertificateHost', () => {
+  it('accepts canonical loopback hosts without a DNS lookup', async () => {
+    const resolveProxy = vi.fn()
+    const lookupAddresses = vi.fn()
+
+    await expect(
+      isEligibleResolvedLocalCertificateHost(
+        'localhost',
+        'https://localhost:3443/',
+        resolveProxy,
+        lookupAddresses
+      )
+    ).resolves.toBe(true)
+    expect(resolveProxy).not.toHaveBeenCalled()
+    expect(lookupAddresses).not.toHaveBeenCalled()
+  })
+
+  it('accepts a custom hostname only when every address resolves to loopback', async () => {
+    const lookupAddresses = vi.fn(async () => [{ address: '127.0.0.1' }, { address: '::1' }])
+
+    await expect(
+      isEligibleResolvedLocalCertificateHost(
+        'localhost.bswhealth.com',
+        'https://localhost.bswhealth.com:44302/',
+        vi.fn(async () => 'DIRECT'),
+        lookupAddresses
+      )
+    ).resolves.toBe(true)
+    expect(lookupAddresses).toHaveBeenCalledWith('localhost.bswhealth.com', {
+      all: true,
+      verbatim: true
+    })
+  })
+
+  it('rejects public, mixed, empty, and failed DNS results', async () => {
+    await expect(
+      isEligibleResolvedLocalCertificateHost(
+        'example.com',
+        'https://example.com/',
+        vi.fn(async () => 'DIRECT'),
+        vi.fn(async () => [{ address: '203.0.113.10' }])
+      )
+    ).resolves.toBe(false)
+    await expect(
+      isEligibleResolvedLocalCertificateHost(
+        'mixed.example',
+        'https://mixed.example/',
+        vi.fn(async () => 'DIRECT'),
+        vi.fn(async () => [{ address: '127.0.0.1' }, { address: '203.0.113.10' }])
+      )
+    ).resolves.toBe(false)
+    await expect(
+      isEligibleResolvedLocalCertificateHost(
+        'empty.example',
+        'https://empty.example/',
+        vi.fn(async () => 'DIRECT'),
+        vi.fn(async () => [])
+      )
+    ).resolves.toBe(false)
+    await expect(
+      isEligibleResolvedLocalCertificateHost(
+        'missing.example',
+        'https://missing.example/',
+        vi.fn(async () => 'DIRECT'),
+        vi.fn(async () => {
+          throw new Error('not found')
+        })
+      )
+    ).resolves.toBe(false)
+  })
+
+  it('rejects a loopback-resolving hostname when Chromium uses a proxy', async () => {
+    const lookupAddresses = vi.fn(async () => [{ address: '127.0.0.1' }])
+
+    await expect(
+      isEligibleResolvedLocalCertificateHost(
+        'local.example',
+        'https://local.example:3443/',
+        vi.fn(async () => 'PROXY proxy.example:8080; DIRECT'),
+        lookupAddresses
+      )
+    ).resolves.toBe(false)
+    expect(lookupAddresses).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/browser/browser-certificate-host-eligibility.ts
+++ b/src/main/browser/browser-certificate-host-eligibility.ts
@@ -1,0 +1,32 @@
+import { lookup } from 'node:dns/promises'
+
+import { isEligibleLocalCertificateHost } from '../../shared/browser-url'
+
+type LookupAddresses = (
+  hostname: string,
+  options: { all: true; verbatim: true }
+) => Promise<readonly { address: string }[]>
+
+export async function isEligibleResolvedLocalCertificateHost(
+  hostname: string,
+  url: string,
+  resolveProxy: (url: string) => Promise<string>,
+  lookupAddresses: LookupAddresses = lookup
+): Promise<boolean> {
+  if (isEligibleLocalCertificateHost(hostname)) {
+    return true
+  }
+  try {
+    // Why: local DNS must not authorize a certificate for a request Chromium sends through a proxy.
+    if ((await resolveProxy(url)).trim().toUpperCase() !== 'DIRECT') {
+      return false
+    }
+    const addresses = await lookupAddresses(hostname, { all: true, verbatim: true })
+    return (
+      addresses.length > 0 &&
+      addresses.every(({ address }) => isEligibleLocalCertificateHost(address))
+    )
+  } catch {
+    return false
+  }
+}

--- a/src/main/browser/browser-certificate-trust-controller.test.ts
+++ b/src/main/browser/browser-certificate-trust-controller.test.ts
@@ -102,6 +102,9 @@ describe('BrowserCertificateTrustController', () => {
   let pageByGuestId: Map<number, string | null>
   let guestByPageId: Map<string, number>
   let guestById: Map<number, Electron.WebContents>
+  let isEligibleCertificateHost: ReturnType<
+    typeof vi.fn<(hostname: string, url: string, session: Electron.Session) => Promise<boolean>>
+  >
   let controller: BrowserCertificateTrustController
 
   beforeEach(() => {
@@ -125,6 +128,7 @@ describe('BrowserCertificateTrustController', () => {
       [guest.id, guest],
       [otherGuest.id, otherGuest]
     ])
+    isEligibleCertificateHost = vi.fn(async () => false)
     controller = new BrowserCertificateTrustController({
       resolveManagedGuestContext: (webContentsId) => {
         if (!pageByGuestId.has(webContentsId)) {
@@ -140,6 +144,7 @@ describe('BrowserCertificateTrustController', () => {
       resolveWebContentsIdForPage: (browserPageId) => guestByPageId.get(browserPageId) ?? null,
       resolveWebContents: (webContentsId) => guestById.get(webContentsId) ?? null,
       onFailureChanged,
+      isEligibleCertificateHost,
       now: () => now,
       createChallengeId: () => `challenge-${++challengeNumber}`
     })
@@ -298,6 +303,42 @@ describe('BrowserCertificateTrustController', () => {
       expect(event.callback).toHaveBeenCalledWith(false)
       expect(event.preventDefault).not.toHaveBeenCalled()
     }
+    expect(controller.getFailure('page-1')).toBeNull()
+    expect(onFailureChanged).not.toHaveBeenCalled()
+  })
+
+  it('offers approval when a custom hostname resolves only to loopback', async () => {
+    isEligibleCertificateHost.mockResolvedValue(true)
+
+    certificateEvent({ controller, guest, url: 'https://localhost.bswhealth.com:44302/' })
+
+    expect(controller.getFailure('page-1')).toBeNull()
+    await vi.waitFor(() =>
+      expect(controller.getFailure('page-1')).toMatchObject({
+        origin: 'https://localhost.bswhealth.com:44302',
+        canProceed: true
+      })
+    )
+    expect(isEligibleCertificateHost).toHaveBeenCalledWith(
+      'localhost.bswhealth.com',
+      'https://localhost.bswhealth.com:44302/',
+      browserSession
+    )
+  })
+
+  it('does not publish a resolved-host challenge after navigation changes', async () => {
+    let resolveEligibility: ((eligible: boolean) => void) | undefined
+    isEligibleCertificateHost.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveEligibility = resolve
+      })
+    )
+
+    certificateEvent({ controller, guest, url: 'https://local.example:3443/' })
+    controller.onMainFrameNavigationStarted(guest.id)
+    resolveEligibility?.(true)
+    await Promise.resolve()
+
     expect(controller.getFailure('page-1')).toBeNull()
     expect(onFailureChanged).not.toHaveBeenCalled()
   })

--- a/src/main/browser/browser-certificate-trust-controller.ts
+++ b/src/main/browser/browser-certificate-trust-controller.ts
@@ -4,10 +4,6 @@ import type {
   BrowserCertificateProceedResult
 } from '../../shared/browser-workspace-types'
 import {
-  isEligibleLocalCertificateHost,
-  toSecureCertificateEndpoint
-} from '../../shared/browser-url'
-import {
   certificateChallengeIdentityMatches,
   CERTIFICATE_CHALLENGE_TTL_MS,
   MAX_PENDING_CERTIFICATE_CHALLENGES,
@@ -16,13 +12,14 @@ import {
   type PendingCertificateChallenge
 } from './browser-certificate-challenge'
 import {
-  getLeafCertificateSha256,
   getSupportedCertificateErrorCode,
-  normalizeCertificateError,
-  SUPPORTED_CERTIFICATE_ERROR,
   SUPPORTED_CERTIFICATE_ERROR_CODE
 } from './browser-certificate-identity'
 import { BrowserCertificateRequestGuard } from './browser-certificate-request-guard'
+import {
+  handleBrowserCertificateError,
+  type BrowserCertificateChallengeInput
+} from './browser-certificate-error-handler'
 
 export type { ManagedBrowserGuestContext } from './browser-certificate-challenge'
 
@@ -62,61 +59,19 @@ export class BrowserCertificateTrustController {
     callback: (isTrusted: boolean) => void
     isMainFrame: boolean
   }): void {
-    let answered = false
-    const answer = (trusted: boolean): void => {
-      if (!answered) {
-        answered = true
-        args.callback(trusted)
-      }
-    }
-    try {
-      const context = this.dependencies.resolveManagedGuestContext(args.webContents.id)
-      const parsed = new URL(args.url)
-      const endpoint = toSecureCertificateEndpoint(args.url)
-      const digest = getLeafCertificateSha256(args.certificate)
-      const error = normalizeCertificateError(args.error)
-      if (!context || !endpoint || !digest) {
-        answer(false)
-        return
-      }
-      const identity = { secureEndpoint: endpoint, leafCertificateSha256: digest, error }
-      if (
-        this.requestGuard.shouldTrustCertificate(
-          args.webContents.session,
-          args.webContents.id,
-          identity
-        )
-      ) {
-        args.event.preventDefault()
-        answer(true)
-        return
-      }
-      if (
-        args.isMainFrame &&
-        parsed.protocol === 'https:' &&
-        error === SUPPORTED_CERTIFICATE_ERROR &&
-        isEligibleLocalCertificateHost(parsed.hostname) &&
-        this.requestGuard.canOfferCertificate(args.webContents.session, identity)
-      ) {
-        this.recordPendingChallenge({
-          webContentsId: args.webContents.id,
-          browserPageId: context.browserPageId,
-          navigationUrl: args.url,
-          origin: parsed.origin,
-          displayHost: parsed.host,
-          secureEndpoint: endpoint,
-          leafCertificateSha256: digest,
-          error
-        })
-      }
-      answer(false)
-    } catch (error) {
-      // Why: fail closed, but log first — a throw in challenge recording would
-      // otherwise present as "the cert prompt never appears" with no trace,
-      // matching the logging catch in browser-manager's guest-state notifier.
-      console.error('[browser-certificate-trust-controller] handleCertificateError failed', error)
-      answer(false)
-    }
+    handleBrowserCertificateError(args, {
+      resolveManagedGuestContext: this.dependencies.resolveManagedGuestContext,
+      shouldTrustCertificate: (session, webContentsId, identity) =>
+        this.requestGuard.shouldTrustCertificate(session, webContentsId, identity),
+      canOfferCertificate: (session, identity) =>
+        this.requestGuard.canOfferCertificate(session, identity),
+      getNavigationSequence: (webContentsId) =>
+        this.navigationSequenceByGuestId.get(webContentsId) ?? 0,
+      recordPendingChallenge: (challenge) => this.recordPendingChallenge(challenge),
+      isEligibleCertificateHost: this.dependencies.isEligibleCertificateHost,
+      onError: (error) =>
+        console.error('[browser-certificate-trust-controller] handleCertificateError failed', error)
+    })
   }
 
   onGuestRegistered(webContentsId: number, browserPageId: string): void {
@@ -198,16 +153,7 @@ export class BrowserCertificateTrustController {
     return { ok: true }
   }
 
-  private recordPendingChallenge(args: {
-    webContentsId: number
-    browserPageId: string | null
-    navigationUrl: string
-    origin: string
-    displayHost: string
-    secureEndpoint: string
-    leafCertificateSha256: string
-    error: string
-  }): void {
+  private recordPendingChallenge(args: BrowserCertificateChallengeInput): void {
     const navigationSequence = this.navigationSequenceByGuestId.get(args.webContentsId) ?? 0
     const existing = this.pendingByGuestId.get(args.webContentsId)
     if (


### PR DESCRIPTION
## Summary
- offer the existing certificate bypass for custom hostnames that resolve entirely to loopback
- require Chromium to use a direct route before treating a DNS alias as local
- discard asynchronous eligibility results after navigation changes

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-certificate-host-eligibility.test.ts src/main/browser/browser-certificate-trust-controller.test.ts`
- `pnpm exec tsc --noEmit -p config/tsconfig.node.json`
- `pnpm run check:code-quality:changed`
- `pnpm exec playwright test --config tests/playwright.config.ts --project=electron-headless tests/e2e/browser-local-https-certificate-trust.spec.ts`