### PR TITLE
fix(crash-reporting): name the faulting module on POSIX crashes

### DIFF
--- a/src/main/crash-reporting/minidump-crash-signature.test.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.test.ts
@@ -3,7 +3,15 @@ import { minidumpSignatureDetails, parseMinidumpCrashSignature } from './minidum
 
 const STREAM_TYPE_MODULE_LIST = 4
 const STREAM_TYPE_EXCEPTION = 6
+const STREAM_TYPE_SYSTEM_INFO = 7
 const STREAM_TYPE_CRASHPAD_INFO = 0x43500001
+
+// MINIDUMP_SYSTEM_INFO.PlatformId (Crashpad's MinidumpOS). A module is only
+// attributed to ExceptionAddress on Windows, where that field is the faulting
+// instruction; elsewhere it is a data address, so the dump has to say which.
+const SYSTEM_INFO_BYTES = 56
+const PLATFORM_ID = { windows: 2, macos: 0x8101, linux: 0x8201 } as const
+const CONTEXT_AMD64_BYTES = 1232
 
 /**
  * Builds real Crashpad-layout minidumps so the parser is tested against the
@@ -87,11 +95,22 @@ type BuiltDump = { dump: Buffer }
 function buildDump(options: {
   annotations?: Record<string, string>
   simpleAnnotations?: Record<string, string>
-  exception?: { code: number; address: bigint }
+  exception?: {
+    code: number
+    address: bigint
+    /** MINIDUMP_SYSTEM_INFO.PlatformId; omitted for a dump that names no platform. */
+    platform?: keyof typeof PLATFORM_ID
+    /** Crashing thread's CONTEXT Rip, where the faulting instruction really lives. */
+    instructionPointer?: bigint
+  }
   modules?: { base: bigint; size: number; name: string }[]
 }): BuiltDump {
+  const platform = options.exception?.platform
   const streamCount =
-    1 + (options.exception ? 1 : 0) + (options.modules && options.modules.length > 0 ? 1 : 0)
+    1 +
+    (options.exception ? 1 : 0) +
+    (platform ? 1 : 0) +
+    (options.modules && options.modules.length > 0 ? 1 : 0)
   const builder = new MinidumpBuilder(32 + streamCount * 12)
   const streams: { type: number; size: number; rva: number }[] = []
 
@@ -162,6 +181,17 @@ function buildDump(options: {
     rva: crashpadInfoRva
   })
 
+  if (platform) {
+    const systemInfo = Buffer.alloc(SYSTEM_INFO_BYTES)
+    systemInfo.writeUInt16LE(9, 0) // PROCESSOR_ARCHITECTURE_AMD64
+    systemInfo.writeUInt32LE(PLATFORM_ID[platform], 20) // PlatformId
+    streams.push({
+      type: STREAM_TYPE_SYSTEM_INFO,
+      size: SYSTEM_INFO_BYTES,
+      rva: builder.append(systemInfo)
+    })
+  }
+
   if (options.modules && options.modules.length > 0) {
     const nameRvas = options.modules.map((module) => builder.utf16String(module.name))
     const listBuf = Buffer.alloc(4 + options.modules.length * 108)
@@ -184,6 +214,14 @@ function buildDump(options: {
     exceptionBuf.writeUInt32LE(1234, 0) // ThreadId
     exceptionBuf.writeUInt32LE(options.exception.code, 8)
     exceptionBuf.writeBigUInt64LE(options.exception.address, 24)
+    if (options.exception.instructionPointer !== undefined) {
+      const context = Buffer.alloc(CONTEXT_AMD64_BYTES)
+      context.writeUInt32LE(0x0010000f, 0x30) // CONTEXT_AMD64 | CONTEXT_FULL
+      context.writeBigUInt64LE(options.exception.instructionPointer, 0xf8) // Rip
+      const contextRva = builder.append(context)
+      exceptionBuf.writeUInt32LE(context.length, 160) // ThreadContext
+      exceptionBuf.writeUInt32LE(contextRva, 164)
+    }
     streams.push({
       type: STREAM_TYPE_EXCEPTION,
       size: exceptionBuf.length,
@@ -333,7 +371,11 @@ describe('parseMinidumpCrashSignature', () => {
 
   it('resolves the faulting module from the exception address', () => {
     const { dump } = buildDump({
-      exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
+      exception: {
+        code: 0x80000003,
+        address: 0x7ff8_0000_1234n,
+        platform: 'windows'
+      },
       modules: [
         {
           base: 0x7ff7_0000_0000n,
@@ -365,7 +407,14 @@ describe('parseMinidumpCrashSignature', () => {
       name: `/Applications/Orca.app/Contents/Frameworks/lib${index}.dylib`
     }))
     const { dump } = buildDump({
-      exception: { code: 11, address: 0x1_0000_0000n + 1030n * 0x1_0000n + 0x24n },
+      // EXC_BAD_ACCESS is the one Mach class whose ExceptionAddress is a data
+      // address, so the module has to come through the thread context.
+      exception: {
+        code: 1,
+        address: 0x1_0000_0000n + 1030n * 0x1_0000n + 0x24n,
+        platform: 'macos',
+        instructionPointer: 0x1_0000_0000n + 1030n * 0x1_0000n + 0x24n
+      },
       modules
     })
 
@@ -377,7 +426,8 @@ describe('parseMinidumpCrashSignature', () => {
 
   it('still drops the module list when the claimed module count is absurd', () => {
     const { dump } = buildDump({
-      exception: { code: 11, address: 0x7ff7_0000_0010n },
+      // Windows: ExceptionAddress is the instruction, so the lookup really runs.
+      exception: { code: 11, address: 0x7ff7_0000_0010n, platform: 'windows' },
       modules: [{ base: 0x7ff7_0000_0000n, size: 0x1000, name: '/opt/orca/orca' }]
     })
     const corrupt = Buffer.from(dump)
@@ -389,7 +439,7 @@ describe('parseMinidumpCrashSignature', () => {
 
   it('omits the faulting module when no image range covers the address', () => {
     const { dump } = buildDump({
-      exception: { code: 11, address: 0x10n },
+      exception: { code: 11, address: 0x10n, platform: 'windows' },
       modules: [{ base: 0x7ff7_0000_0000n, size: 0x1000, name: '/opt/orca/orca' }]
     })
 
@@ -431,7 +481,11 @@ describe('minidumpSignatureDetails', () => {
         ptype: 'renderer',
         channel: 'stable'
       },
-      exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
+      exception: {
+        code: 0x80000003,
+        address: 0x7ff8_0000_1234n,
+        platform: 'windows'
+      },
       modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }]
     })
 

--- a/src/main/crash-reporting/minidump-crash-signature.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.ts
@@ -12,10 +12,10 @@
 // reporting.
 
 import { findStream, isMinidump, MinidumpView } from './minidump-stream-reader'
+import { readExceptionRecord, type AccessViolationKind } from './minidump-exception-record'
 import { readCrashpadAnnotations } from './minidump-crashpad-annotations'
 
 const STREAM_TYPE_MODULE_LIST = 4
-const STREAM_TYPE_EXCEPTION = 6
 
 const MODULE_RECORD_SIZE = 108
 // 8x headroom over a measured 1042-image macOS renderer, whose whole list a
@@ -24,11 +24,6 @@ const MAX_MODULE_LIST_MODULES = 8_192
 const MODULE_BASE_OFFSET = 0
 const MODULE_SIZE_OFFSET = 8
 const MODULE_NAME_RVA_OFFSET = 20
-
-// MINIDUMP_EXCEPTION_STREAM: ThreadId u32, __alignment u32, then MINIDUMP_EXCEPTION.
-const EXCEPTION_RECORD_OFFSET = 8
-const EXCEPTION_CODE_OFFSET = EXCEPTION_RECORD_OFFSET + 0
-const EXCEPTION_ADDRESS_OFFSET = EXCEPTION_RECORD_OFFSET + 16
 
 const CHROMIUM_LOG_MARKERS = [
   Buffer.from(':FATAL:', 'ascii'),
@@ -53,10 +48,32 @@ export type MinidumpCrashSignature = {
   readonly processType?: string
   /** Win32 exception code / POSIX signal, e.g. 0x80000003 STATUS_BREAKPOINT. */
   readonly exceptionCode?: number
+  /**
+   * Raw MINIDUMP_EXCEPTION.ExceptionAddress. Windows writes the faulting
+   * instruction here; Crashpad's POSIX and Mach snapshots write si_addr and
+   * EXC_BAD_ACCESS's code[1], which are the faulting instruction for some
+   * exception classes and the data address the fault touched for others (0x0
+   * where si_addr is undefined, e.g. SIGTRAP). Reported as-is; never substituted.
+   */
   readonly exceptionAddress?: string
-  /** Module whose image range contains `exceptionAddress`. */
+  /**
+   * Faulting instruction, read from the crashing thread's CONTEXT. A trap frame
+   * (x86 int3, arm64 BRK) can report past the trapping instruction, so treat
+   * this as a disassembly starting point rather than an exact address.
+   */
+  readonly instructionPointer?: string
+  /**
+   * Module whose image range contains the faulting *instruction*. Derived from
+   * `exceptionAddress` only where the platform and exception class say that
+   * field is an instruction; otherwise the image it lands in is memory the
+   * crash touched, not code that ran. See `minidump-exception-record`.
+   */
   readonly faultingModule?: string
   readonly faultingModuleOffset?: string
+  /** Windows access violations only: what the faulting instruction attempted. */
+  readonly accessKind?: AccessViolationKind
+  /** Windows access violations only: the address that could not be accessed. */
+  readonly accessAddress?: string
   /** Allowlisted Crashpad annotations, verbatim. */
   readonly annotations: Readonly<Record<string, string>>
 }
@@ -240,16 +257,26 @@ export function parseMinidumpCrashSignature(
       signature.checkLine = location.line
     }
   }
-  const exception = findStream(view, STREAM_TYPE_EXCEPTION)
+  const exception = readExceptionRecord(view)
   if (exception) {
-    const code = view.u32(exception.rva + EXCEPTION_CODE_OFFSET)
-    const address = view.u64(exception.rva + EXCEPTION_ADDRESS_OFFSET)
-    if (code !== null) {
+    const { code, address, instructionPointer, codeAddress, accessKind, accessAddress } = exception
+    if (code !== undefined) {
       signature.exceptionCode = code
     }
-    if (address !== null) {
+    if (address !== undefined) {
       signature.exceptionAddress = toHex(address)
-      const faulting = findFaultingModule(readModules(view), address)
+    }
+    if (instructionPointer !== undefined) {
+      signature.instructionPointer = toHex(instructionPointer)
+    }
+    if (accessKind) {
+      signature.accessKind = accessKind
+    }
+    if (accessAddress !== undefined) {
+      signature.accessAddress = toHex(accessAddress)
+    }
+    if (codeAddress !== undefined) {
+      const faulting = findFaultingModule(readModules(view), codeAddress)
       if (faulting) {
         signature.faultingModule = faulting.name
         signature.faultingModuleOffset = faulting.offset
@@ -282,6 +309,15 @@ export function minidumpSignatureDetails(
   }
   if (signature.exceptionAddress) {
     details.minidumpExceptionAddress = signature.exceptionAddress
+  }
+  if (signature.instructionPointer) {
+    details.minidumpInstructionPointer = signature.instructionPointer
+  }
+  if (signature.accessKind) {
+    details.minidumpAccessKind = signature.accessKind
+  }
+  if (signature.accessAddress) {
+    details.minidumpAccessAddress = signature.accessAddress
   }
   if (signature.faultingModule) {
     details.minidumpFaultingModule = signature.faultingModule

--- a/src/main/crash-reporting/minidump-exception-record.ts
+++ b/src/main/crash-reporting/minidump-exception-record.ts
@@ -1,0 +1,348 @@
+// Decodes MINIDUMP_EXCEPTION_STREAM: what faulted, where, and the instruction
+// that did it.
+//
+// Why the instruction needs its own decode: ExceptionAddress means different
+// things per platform *and* per exception class.
+//
+//  - Windows writes EXCEPTION_RECORD.ExceptionAddress, always the faulting
+//    instruction.
+//  - Crashpad's Mach snapshot writes code[1] — the inaccessible data address —
+//    for EXC_BAD_ACCESS, and the CONTEXT instruction pointer for every other
+//    Mach exception (snapshot/mac/exception_snapshot_mac.cc).
+//  - Crashpad's POSIX snapshot writes siginfo.si_addr, which sigaction(2)
+//    defines as the faulting instruction for SIGILL/SIGFPE but as the memory
+//    reference that faulted for SIGSEGV/SIGBUS, and leaves undefined for the
+//    rest — SIGTRAP arrives as 0x0.
+//
+// A data address lands inside a mapped image often enough to name the wrong
+// module — a store through a bad pointer into a shared object's read-only page
+// is the everyday shape — so for those classes the instruction pointer is read
+// from the crashing thread's CONTEXT instead.
+//
+// Layouts are from Crashpad's minidump_extensions.h and the Windows MINIDUMP_*
+// structs; every read is bounds-checked and a malformed dump degrades to null.
+
+import { findStream, type LocationDescriptor, type MinidumpView } from './minidump-stream-reader'
+
+const STREAM_TYPE_EXCEPTION = 6
+
+// MINIDUMP_EXCEPTION_STREAM: ThreadId u32, __alignment u32, then MINIDUMP_EXCEPTION
+// (ExceptionCode, ExceptionFlags, ExceptionRecord, ExceptionAddress,
+// NumberParameters, __unusedAlignment, ExceptionInformation[15]), then ThreadContext.
+const EXCEPTION_RECORD_OFFSET = 8
+const EXCEPTION_CODE_OFFSET = EXCEPTION_RECORD_OFFSET + 0
+const EXCEPTION_ADDRESS_OFFSET = EXCEPTION_RECORD_OFFSET + 16
+const EXCEPTION_NUMBER_PARAMETERS_OFFSET = EXCEPTION_RECORD_OFFSET + 24
+const EXCEPTION_INFORMATION_OFFSET = EXCEPTION_RECORD_OFFSET + 32
+const EXCEPTION_THREAD_CONTEXT_OFFSET = 160
+const EXCEPTION_STREAM_SIZE = 168
+
+// MINIDUMP_SYSTEM_INFO: ProcessorArchitecture u16 at +0, PlatformId u32 at +20.
+const STREAM_TYPE_SYSTEM_INFO = 7
+const SYSTEM_INFO_PLATFORM_ID_OFFSET = 20
+// Crashpad's MinidumpOS. WIN32_NT is the one platform whose ExceptionAddress is
+// contractually the faulting instruction whatever the exception class.
+const PLATFORM_WIN32_NT = 2
+const PLATFORM_MACOS = 0x8101
+const PLATFORM_IOS = 0x8102
+const PLATFORM_LINUX = 0x8201
+const PLATFORM_ANDROID = 0x8203
+
+const MACH_PLATFORMS = [PLATFORM_MACOS, PLATFORM_IOS]
+const POSIX_PLATFORMS = [PLATFORM_LINUX, PLATFORM_ANDROID]
+
+// The one Mach exception whose ExceptionAddress Crashpad takes from code[1].
+const EXC_BAD_ACCESS = 1
+// Signals whose si_addr sigaction(2) defines as the faulting instruction...
+const SIGILL = 4
+const SIGFPE = 8
+// ...and the two where it is the memory reference that faulted instead.
+const SIGBUS = 7
+const SIGSEGV = 11
+
+const CPU_ARCHITECTURE_AMD64 = 9
+const CPU_ARCHITECTURE_ARM64 = 12
+// Breakpad's pre-standard arm64 selector, still emitted by some producers.
+const CPU_ARCHITECTURE_ARM64_BREAKPAD = 0x8003
+
+const ARM64_ARCHITECTURES = [CPU_ARCHITECTURE_ARM64, CPU_ARCHITECTURE_ARM64_BREAKPAD]
+// Windows' ARM64_NT_CONTEXT: the largest arm64 CONTEXT any producer writes.
+const ARM64_CONTEXT_MAX_BYTES = 912
+
+// CONTEXT_CONTROL: Rip/Pc live in the control group of the Windows-shaped contexts.
+const CONTEXT_CONTROL_FLAG = 0x1
+// Breakpad's legacy arm64 context has no control group; Pc is iregs[32], so the
+// integer group is what says it is populated (there is no MD_CONTEXT_ARM64_CONTROL_OLD).
+const CONTEXT_INTEGER_FLAG = 0x2
+
+type ContextLayout = {
+  readonly architectures: readonly number[]
+  /** Smallest CONTEXT any producer writes for this layout. */
+  readonly minBytes: number
+  /**
+   * Largest CONTEXT any producer writes for this layout, where one exists.
+   * Every arm64 struct is smaller than CONTEXT_AMD64, so without a ceiling an
+   * amd64 context that fails to name its own architecture — ContextFlags zeroed
+   * by a partial write, or a MINIDUMP_SYSTEM_INFO that disagrees with it —
+   * reaches the arm64 layouts, which read CONTEXT_AMD64's P1Home as
+   * context_flags and a float-save-area word as Pc. amd64 needs no ceiling: its
+   * floor already sits above every arm64 struct, and an XSTATE-extended x64
+   * context runs past 1232 bytes.
+   */
+  readonly maxBytes?: number
+  readonly flagsOffset: number
+  /** CONTEXT_<arch> selector; a context has to name its own architecture. */
+  readonly architectureFlag: number
+  /** Group flag that has to be set for the instruction pointer to be populated. */
+  readonly instructionPointerFlag: number
+  readonly instructionPointerOffset: number
+}
+
+/**
+ * Only x86-64 and arm64 CONTEXTs are decoded — those are what Orca ships (x64
+ * everywhere, arm64 on Apple Silicon and Linux). An x86-32, arm32 or any other
+ * dump reports no instruction pointer rather than misreading foreign registers.
+ *
+ * The two arm64 entries are different structs, not one struct with two names:
+ * Breakpad's legacy MDRawContextARM64_Old opens with a u64 context_flags and
+ * puts iregs[33] straight after it, while the modern MDRawContextARM64 (and
+ * Crashpad's) opens u32 context_flags + u32 cpsr. Pc lands at +0x108 either way
+ * — 8 + 32*8 in the old layout, after regs[31]+sp in the new one — so only the
+ * flags differ, and the flags are what tells the two apart.
+ */
+const CONTEXT_LAYOUTS: readonly ContextLayout[] = [
+  {
+    architectures: [CPU_ARCHITECTURE_AMD64],
+    minBytes: 1_232,
+    flagsOffset: 0x30, // after P1Home..P6Home
+    architectureFlag: 0x0010_0000,
+    instructionPointerFlag: CONTEXT_CONTROL_FLAG,
+    instructionPointerOffset: 0xf8 // Rip
+  },
+  {
+    architectures: ARM64_ARCHITECTURES,
+    minBytes: 792, // Crashpad's MinidumpContextARM64; Windows' ARM64_NT_CONTEXT is 912
+    maxBytes: ARM64_CONTEXT_MAX_BYTES,
+    flagsOffset: 0,
+    architectureFlag: 0x0040_0000,
+    instructionPointerFlag: CONTEXT_CONTROL_FLAG,
+    instructionPointerOffset: 0x108 // Pc
+  },
+  {
+    architectures: ARM64_ARCHITECTURES,
+    minBytes: 796, // MDRawContextARM64_Old; producers emit 796 packed or 800 naturally aligned
+    maxBytes: ARM64_CONTEXT_MAX_BYTES,
+    flagsOffset: 0, // low half of the u64 context_flags
+    architectureFlag: 0x8000_0000,
+    instructionPointerFlag: CONTEXT_INTEGER_FLAG,
+    instructionPointerOffset: 0x108 // iregs[32], the Pc
+  }
+]
+
+/** `&` yields an int32, so bit 31 has to be folded back to unsigned before comparing. */
+function hasFlags(flags: number, mask: number): boolean {
+  return (flags & mask) >>> 0 === mask
+}
+
+const STATUS_ACCESS_VIOLATION = 0xc0000005
+const STATUS_IN_PAGE_ERROR = 0xc0000006
+
+export type AccessViolationKind = 'read' | 'write' | 'execute'
+
+const ACCESS_VIOLATION_KINDS: Readonly<Record<number, AccessViolationKind>> = {
+  0: 'read',
+  1: 'write',
+  8: 'execute'
+}
+
+export type MinidumpExceptionRecord = {
+  /** Win32 exception code / POSIX signal number. */
+  readonly code?: number
+  /** ExceptionAddress verbatim: the instruction on Windows, si_addr on POSIX. */
+  readonly address?: bigint
+  /** Faulting instruction, from the crashing thread's CONTEXT. */
+  readonly instructionPointer?: bigint
+  /**
+   * The address a module may be attributed to: ExceptionAddress wherever the
+   * platform and exception class say it is an instruction, else the CONTEXT
+   * instruction pointer. Absent rather than falling back to a POSIX/Mach data
+   * address, which would name whatever image the crash touched as the code
+   * that ran.
+   */
+  readonly codeAddress?: bigint
+  readonly accessKind?: AccessViolationKind
+  readonly accessAddress?: bigint
+}
+
+type SystemInfo = {
+  readonly architecture: number | null
+  readonly platformId: number | null
+}
+
+function readSystemInfo(view: MinidumpView): SystemInfo {
+  const stream = findStream(view, STREAM_TYPE_SYSTEM_INFO)
+  if (!stream) {
+    return { architecture: null, platformId: null }
+  }
+  return {
+    architecture: view.u16(stream.rva),
+    platformId: view.u32(stream.rva + SYSTEM_INFO_PLATFORM_ID_OFFSET)
+  }
+}
+
+/**
+ * MINIDUMP_SYSTEM_INFO.ProcessorArchitecture narrows the candidate layouts, but
+ * only when it names an architecture a layout covers: a zeroed or truncated
+ * stream reads back as 0 (PROCESSOR_ARCHITECTURE_INTEL), and treating that as
+ * authoritative would kill the instruction pointer outright — worse than the
+ * dump carrying no system info at all. An unrecognised value therefore falls
+ * back to matching on the declared context size and the context's own
+ * CONTEXT_<arch> selector, which is the real guard either way.
+ */
+function candidateArchitecture(architecture: number | null): number | null {
+  if (architecture === null) {
+    return null
+  }
+  const known = CONTEXT_LAYOUTS.some((layout) => layout.architectures.includes(architecture))
+  return known ? architecture : null
+}
+
+function readInstructionPointer(
+  view: MinidumpView,
+  exception: LocationDescriptor,
+  architecture: number | null
+): bigint | null {
+  if (exception.size < EXCEPTION_STREAM_SIZE) {
+    return null
+  }
+  const context = view.location(exception.rva + EXCEPTION_THREAD_CONTEXT_OFFSET)
+  if (!context) {
+    return null
+  }
+  const declared = candidateArchitecture(architecture)
+  for (const layout of CONTEXT_LAYOUTS) {
+    if (declared !== null && !layout.architectures.includes(declared)) {
+      continue
+    }
+    // Outside the architecture's own struct size the context is truncated or
+    // foreign; the layouts' byte windows do not overlap, so a context of one
+    // architecture's size is never offered to another's struct.
+    if (context.size < layout.minBytes || context.size > (layout.maxBytes ?? Infinity)) {
+      continue
+    }
+    if (context.rva + layout.minBytes > view.byteLength) {
+      continue
+    }
+    const flags = view.u32(context.rva + layout.flagsOffset)
+    if (flags === null || !hasFlags(flags, layout.architectureFlag)) {
+      continue
+    }
+    // The context named this layout's architecture, so this layout decodes it or
+    // nothing does. Falling through to the next would re-read the same bytes
+    // under a foreign struct — CONTEXT_AMD64's P1Home doubles as the arm64
+    // context_flags slot — and hand back a float-save-area word as a Pc.
+    if (!hasFlags(flags, layout.instructionPointerFlag)) {
+      return null
+    }
+    const pointer = view.u64(context.rva + layout.instructionPointerOffset)
+    return pointer === null || pointer === 0n ? null : pointer
+  }
+  return null
+}
+
+type ExceptionAddressKind = 'instruction' | 'data' | 'unknown'
+
+/**
+ * What ExceptionAddress holds for this platform and exception class — see the
+ * file header. Anything the dump does not pin down stays `unknown`, which
+ * attributes no module rather than a guessed one.
+ */
+function classifyExceptionAddress(
+  platformId: number | null,
+  code: number | null
+): ExceptionAddressKind {
+  if (platformId === PLATFORM_WIN32_NT) {
+    return 'instruction'
+  }
+  if (code === null || platformId === null) {
+    return 'unknown'
+  }
+  if (MACH_PLATFORMS.includes(platformId)) {
+    return code === EXC_BAD_ACCESS ? 'data' : 'instruction'
+  }
+  if (POSIX_PLATFORMS.includes(platformId)) {
+    if (code === SIGILL || code === SIGFPE) {
+      return 'instruction'
+    }
+    return code === SIGSEGV || code === SIGBUS ? 'data' : 'unknown'
+  }
+  return 'unknown'
+}
+
+/**
+ * 0x0 is Crashpad's "no address", not an address: SIGTRAP's undefined si_addr
+ * and a Windows dump captured with no exception pointers both land there.
+ */
+function presentAddress(address: bigint | null): bigint | null {
+  return address === null || address === 0n ? null : address
+}
+
+/**
+ * ExceptionInformation[0]/[1] of a Windows access violation: access kind and
+ * the inaccessible address, which is what separates a null deref from a wild
+ * pointer from a write to read-only memory. Gated on the Win32 status codes
+ * because Crashpad's POSIX writer puts si_code in the same slot.
+ */
+function readAccessViolation(
+  view: MinidumpView,
+  exception: LocationDescriptor,
+  code: number
+): { kind?: AccessViolationKind; address: bigint } | null {
+  if (code !== STATUS_ACCESS_VIOLATION && code !== STATUS_IN_PAGE_ERROR) {
+    return null
+  }
+  const parameters = view.u32(exception.rva + EXCEPTION_NUMBER_PARAMETERS_OFFSET)
+  if (parameters === null || parameters < 2 || exception.size < EXCEPTION_INFORMATION_OFFSET + 16) {
+    return null
+  }
+  const kind = view.u64(exception.rva + EXCEPTION_INFORMATION_OFFSET)
+  const address = view.u64(exception.rva + EXCEPTION_INFORMATION_OFFSET + 8)
+  if (kind === null || address === null) {
+    return null
+  }
+  return { kind: ACCESS_VIOLATION_KINDS[Number(kind)], address }
+}
+
+/** Reads the exception stream, or null when the dump carries none. */
+export function readExceptionRecord(view: MinidumpView): MinidumpExceptionRecord | null {
+  const exception = findStream(view, STREAM_TYPE_EXCEPTION)
+  if (!exception) {
+    return null
+  }
+  const systemInfo = readSystemInfo(view)
+  const code = view.u32(exception.rva + EXCEPTION_CODE_OFFSET)
+  const address = view.u64(exception.rva + EXCEPTION_ADDRESS_OFFSET)
+  const instructionPointer = readInstructionPointer(view, exception, systemInfo.architecture)
+  const access = code === null ? null : readAccessViolation(view, exception, code)
+  const exceptionAddressInstruction =
+    classifyExceptionAddress(systemInfo.platformId, code) === 'instruction'
+      ? presentAddress(address)
+      : null
+  // Windows leads with ExceptionAddress: it is what the whole Win64 field corpus
+  // already resolves from, and Windows defines it as the faulting instruction
+  // for every exception class. Elsewhere the CONTEXT leads, with ExceptionAddress
+  // kept as the fallback for the classes that do set it from the instruction —
+  // a Mach EXC_BREAKPOINT resolves from it today and must keep doing so.
+  const codeAddress =
+    systemInfo.platformId === PLATFORM_WIN32_NT
+      ? (exceptionAddressInstruction ?? instructionPointer)
+      : (instructionPointer ?? exceptionAddressInstruction)
+  return {
+    ...(code === null ? {} : { code }),
+    ...(address === null ? {} : { address }),
+    ...(instructionPointer === null ? {} : { instructionPointer }),
+    ...(codeAddress === null ? {} : { codeAddress }),
+    ...(access?.kind ? { accessKind: access.kind } : {}),
+    ...(access ? { accessAddress: access.address } : {})
+  }
+}

--- a/src/main/crash-reporting/minidump-exception-record.ts
+++ b/src/main/crash-reporting/minidump-exception-record.ts
@@ -40,6 +40,7 @@ const EXCEPTION_STREAM_SIZE = 168
 // MINIDUMP_SYSTEM_INFO: ProcessorArchitecture u16 at +0, PlatformId u32 at +20.
 const STREAM_TYPE_SYSTEM_INFO = 7
 const SYSTEM_INFO_PLATFORM_ID_OFFSET = 20
+const SYSTEM_INFO_MIN_BYTES = SYSTEM_INFO_PLATFORM_ID_OFFSET + 4
 // Crashpad's MinidumpOS. WIN32_NT is the one platform whose ExceptionAddress is
 // contractually the faulting instruction whatever the exception class.
 const PLATFORM_WIN32_NT = 2
@@ -160,7 +161,11 @@ export type MinidumpExceptionRecord = {
   readonly code?: number
   /** ExceptionAddress verbatim: the instruction on Windows, si_addr on POSIX. */
   readonly address?: bigint
-  /** Faulting instruction, from the crashing thread's CONTEXT. */
+  /**
+   * Faulting instruction, from the crashing thread's CONTEXT. A trap frame
+   * (x86 int3) can report past the trapping instruction, so this is a
+   * disassembly starting point rather than an exact address.
+   */
   readonly instructionPointer?: bigint
   /**
    * The address a module may be attributed to: ExceptionAddress wherever the
@@ -181,7 +186,9 @@ type SystemInfo = {
 
 function readSystemInfo(view: MinidumpView): SystemInfo {
   const stream = findStream(view, STREAM_TYPE_SYSTEM_INFO)
-  if (!stream) {
+  // A stream too short to hold PlatformId would otherwise read it from whatever
+  // follows, and a stray 2 there classifies a POSIX dump as Windows.
+  if (!stream || stream.size < SYSTEM_INFO_MIN_BYTES) {
     return { architecture: null, platformId: null }
   }
   return {

--- a/src/main/crash-reporting/minidump-posix-faulting-module.test.ts
+++ b/src/main/crash-reporting/minidump-posix-faulting-module.test.ts
@@ -141,6 +141,8 @@ type DumpOptions = {
   platform?: Platform
   /** MINIDUMP_EXCEPTION.ExceptionInformation[0..n]. */
   exceptionInformation?: bigint[]
+  /** Overrides the size the MINIDUMP_SYSTEM_INFO stream directory declares. */
+  systemInfoDeclaredSize?: number
 }
 
 function buildDump(options: DumpOptions): Buffer {
@@ -159,7 +161,7 @@ function buildDump(options: DumpOptions): Buffer {
     }
     streams.push({
       type: STREAM_TYPE_SYSTEM_INFO,
-      size: SYSTEM_INFO_SIZE,
+      size: options.systemInfoDeclaredSize ?? SYSTEM_INFO_SIZE,
       rva: builder.append(systemInfo)
     })
   }
@@ -421,6 +423,21 @@ describe('a data address never names a faulting module', () => {
       modules: WINDOWS_MODULES,
       exceptionCode: STATUS_ACCESS_VIOLATION,
       exceptionAddress: WIN_FAULT_ADDRESS
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBeUndefined()
+  })
+
+  it('ignores a system-info stream too short to hold PlatformId', () => {
+    // The stream is declared 16 bytes but a WIN32_NT-shaped 2 sits at +20.
+    // Reading it anyway would call this SIGSEGV dump Windows and let si_addr —
+    // an address inside libc — name libc as the faulting module.
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: SI_ADDR_IN_LIBC,
+      platform: 'windows',
+      systemInfoDeclaredSize: 16
     })
 
     expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBeUndefined()

--- a/src/main/crash-reporting/minidump-posix-faulting-module.test.ts
+++ b/src/main/crash-reporting/minidump-posix-faulting-module.test.ts
@@ -1,0 +1,946 @@
+import { describe, expect, it } from 'vitest'
+import { minidumpSignatureDetails, parseMinidumpCrashSignature } from './minidump-crash-signature'
+
+// scan5: report 6c1f4289 (v1.4.200, linux x64, renderer SIGSEGV) carried
+// minidumpExceptionCode 0xb and minidumpExceptionAddress 0x31b58e9fc608 but no
+// minidumpFaultingModule, while every Win64 report in the same scan resolved one
+// (45/45 vs 0/3 on Linux).
+//
+// Crashpad's POSIX snapshot sets exception_address_ = siginfo.si_addr, which
+// sigaction(2) defines for SIGSEGV as the memory reference that faulted; the
+// Windows snapshot sets it from EXCEPTION_RECORD.ExceptionAddress, the faulting
+// instruction. The parser matched ExceptionAddress against the module ranges
+// unconditionally, so on Linux it looked up the address the fault *touched*. The faulting
+// instruction is in the dump — MINIDUMP_EXCEPTION_STREAM's ThreadContext at
+// +160 points at a CONTEXT whose Rip is at +0xf8 (arm64 Pc at +0x108) — and was
+// never read.
+
+const STREAM_TYPE_MODULE_LIST = 4
+const STREAM_TYPE_EXCEPTION = 6
+const STREAM_TYPE_SYSTEM_INFO = 7
+
+const MODULE_RECORD_SIZE = 108
+const EXCEPTION_STREAM_SIZE = 168
+const EXCEPTION_INFORMATION_OFFSET = 40
+const EXCEPTION_THREAD_CONTEXT_OFFSET = 160
+const SYSTEM_INFO_SIZE = 56
+const SYSTEM_INFO_PLATFORM_ID_OFFSET = 20
+
+// Crashpad's MinidumpOS, written to MINIDUMP_SYSTEM_INFO.PlatformId.
+const PLATFORM_ID = { windows: 2, macos: 0x8101, linux: 0x8201 } as const
+type Platform = keyof typeof PLATFORM_ID
+
+// arm64Breakpad is MD_CPU_ARCHITECTURE_ARM64_OLD, the pre-standard selector.
+const CPU_ARCHITECTURE = {
+  amd64: 9,
+  arm64: 12,
+  arm64Breakpad: 0x8003
+} as const
+type Architecture = keyof typeof CPU_ARCHITECTURE
+
+/** Per-architecture CONTEXT shape: total bytes, ContextFlags, and the IP slot. */
+const CONTEXT_SHAPES = {
+  amd64: {
+    bytes: 1232,
+    flagsOffset: 0x30,
+    flags: 0x0010000f,
+    pointerOffset: 0xf8
+  },
+  arm64: {
+    bytes: 912,
+    flagsOffset: 0,
+    flags: 0x00400003,
+    pointerOffset: 0x108
+  },
+  // MDRawContextARM64_Old: u64 context_flags then iregs[33], so Pc (iregs[32])
+  // still lands at 0x108. MD_CONTEXT_ARM64_ALL_OLD is INTEGER_OLD|FLOATING_POINT_OLD
+  // = 0x80000006 — the _OLD family defines no CONTROL bit at all.
+  arm64Breakpad: {
+    bytes: 796,
+    flagsOffset: 0,
+    flags: 0x80000006,
+    pointerOffset: 0x108
+  }
+} as const
+
+type DumpModule = { base: bigint; size: number; path: string }
+
+/** Appends regions after the header+directory and references them by RVA, as Crashpad emits. */
+class DumpBuilder {
+  private readonly regions: Buffer[] = []
+  private cursor: number
+
+  constructor(private readonly prefixBytes: number) {
+    this.cursor = prefixBytes
+  }
+
+  append(buf: Buffer): number {
+    const rva = this.cursor
+    this.regions.push(buf)
+    this.cursor += buf.length
+    return rva
+  }
+
+  /** MINIDUMP_STRING: u32 byte length, then UTF-16LE, NUL-terminated. */
+  utf16String(value: string): number {
+    const data = Buffer.from(value, 'utf16le')
+    const buf = Buffer.alloc(4 + data.length + 2)
+    buf.writeUInt32LE(data.length, 0)
+    data.copy(buf, 4)
+    return this.append(buf)
+  }
+
+  build(streams: { type: number; size: number; rva: number }[]): Buffer {
+    const header = Buffer.alloc(32)
+    header.writeUInt32LE(0x504d444d, 0) // 'MDMP'
+    header.writeUInt32LE(0xa793, 4)
+    header.writeUInt32LE(streams.length, 8)
+    header.writeUInt32LE(32, 12)
+    const directory = Buffer.alloc(streams.length * 12)
+    streams.forEach((stream, index) => {
+      directory.writeUInt32LE(stream.type, index * 12)
+      directory.writeUInt32LE(stream.size, index * 12 + 4)
+      directory.writeUInt32LE(stream.rva, index * 12 + 8)
+    })
+    const prefix = Buffer.concat([header, directory])
+    expect(prefix.length).toBe(this.prefixBytes)
+    return Buffer.concat([prefix, ...this.regions])
+  }
+}
+
+type DumpOptions = {
+  modules: DumpModule[]
+  /** POSIX signal number or Win32 status code. */
+  exceptionCode: number
+  /** si_addr on POSIX, the faulting instruction on Windows. */
+  exceptionAddress: bigint
+  /** Omitted entirely for a dump with no thread context, as pre-Crashpad producers emit. */
+  context?: {
+    architecture: Architecture
+    instructionPointer: bigint
+    /** Overrides the size the ThreadContext location descriptor declares. */
+    declaredSize?: number
+    /** Overrides how many context bytes are actually present in the file. */
+    presentBytes?: number
+    /** Overrides the shape's default ContextFlags. */
+    flags?: number
+    /**
+     * u32 at context offset 0 — context_flags in both arm64 layouts, but
+     * P1Home (uninitialised home space) in CONTEXT_AMD64.
+     */
+    leadingWord?: number
+    /**
+     * u64 at +0x108 — the arm64 Pc slot, which in CONTEXT_AMD64 is inside the
+     * floating-point save area (Rip is at 0xf8, the FP union starts at 0x100).
+     */
+    arm64PcSlot?: bigint
+  }
+  /** MINIDUMP_SYSTEM_INFO architecture; omitted to test the no-system-info path. */
+  systemInfo?: Architecture
+  /** MINIDUMP_SYSTEM_INFO.PlatformId; omitted to test the unknown-platform path. */
+  platform?: Platform
+  /** MINIDUMP_EXCEPTION.ExceptionInformation[0..n]. */
+  exceptionInformation?: bigint[]
+}
+
+function buildDump(options: DumpOptions): Buffer {
+  const hasSystemInfo = Boolean(options.systemInfo || options.platform)
+  const streamCount = 2 + (hasSystemInfo ? 1 : 0)
+  const builder = new DumpBuilder(32 + streamCount * 12)
+  const streams: { type: number; size: number; rva: number }[] = []
+
+  if (hasSystemInfo) {
+    const systemInfo = Buffer.alloc(SYSTEM_INFO_SIZE)
+    if (options.systemInfo) {
+      systemInfo.writeUInt16LE(CPU_ARCHITECTURE[options.systemInfo], 0)
+    }
+    if (options.platform) {
+      systemInfo.writeUInt32LE(PLATFORM_ID[options.platform], SYSTEM_INFO_PLATFORM_ID_OFFSET)
+    }
+    streams.push({
+      type: STREAM_TYPE_SYSTEM_INFO,
+      size: SYSTEM_INFO_SIZE,
+      rva: builder.append(systemInfo)
+    })
+  }
+
+  const nameRvas = options.modules.map((module) => builder.utf16String(module.path))
+  const listBuf = Buffer.alloc(4 + options.modules.length * MODULE_RECORD_SIZE)
+  listBuf.writeUInt32LE(options.modules.length, 0)
+  options.modules.forEach((module, index) => {
+    const at = 4 + index * MODULE_RECORD_SIZE
+    listBuf.writeBigUInt64LE(module.base, at) // BaseOfImage
+    listBuf.writeUInt32LE(module.size, at + 8) // SizeOfImage
+    listBuf.writeUInt32LE(nameRvas[index], at + 20) // ModuleNameRva
+  })
+  streams.push({
+    type: STREAM_TYPE_MODULE_LIST,
+    size: listBuf.length,
+    rva: builder.append(listBuf)
+  })
+
+  const exceptionBuf = Buffer.alloc(EXCEPTION_STREAM_SIZE)
+  exceptionBuf.writeUInt32LE(4242, 0) // ThreadId
+  exceptionBuf.writeUInt32LE(options.exceptionCode, 8) // ExceptionCode
+  exceptionBuf.writeBigUInt64LE(options.exceptionAddress, 24) // ExceptionAddress
+  const parameters = options.exceptionInformation ?? []
+  exceptionBuf.writeUInt32LE(parameters.length, 32) // NumberParameters
+  parameters.forEach((parameter, index) => {
+    exceptionBuf.writeBigUInt64LE(parameter, EXCEPTION_INFORMATION_OFFSET + index * 8)
+  })
+
+  if (options.context) {
+    const shape = CONTEXT_SHAPES[options.context.architecture]
+    const context = Buffer.alloc(shape.bytes)
+    context.writeUInt32LE(options.context.flags ?? shape.flags, shape.flagsOffset)
+    context.writeBigUInt64LE(options.context.instructionPointer, shape.pointerOffset)
+    if (options.context.arm64PcSlot !== undefined) {
+      context.writeBigUInt64LE(options.context.arm64PcSlot, 0x108)
+    }
+    if (options.context.leadingWord !== undefined) {
+      context.writeUInt32LE(options.context.leadingWord, 0)
+    }
+    const contextRva = builder.append(
+      context.subarray(0, options.context.presentBytes ?? shape.bytes)
+    )
+    exceptionBuf.writeUInt32LE(
+      options.context.declaredSize ?? shape.bytes,
+      EXCEPTION_THREAD_CONTEXT_OFFSET
+    )
+    exceptionBuf.writeUInt32LE(contextRva, EXCEPTION_THREAD_CONTEXT_OFFSET + 4)
+  }
+
+  streams.push({
+    type: STREAM_TYPE_EXCEPTION,
+    size: exceptionBuf.length,
+    rva: builder.append(exceptionBuf)
+  })
+
+  return builder.build(streams)
+}
+
+const ORCA_BASE = 0x55e1c2a00000n
+const ORCA_SIZE = 0x0a000000
+const RIP_OFFSET = 0x134c608n
+// Verbatim from report 6c1f4289: a PartitionAlloc/V8-cage-shaped data pointer,
+// outside every ELF load range (PIE at 0x55xx…, shared objects at 0x7fxx…).
+const REPORTED_SI_ADDR = 0x31b58e9fc608n
+
+const LINUX_MODULES: DumpModule[] = [
+  { base: ORCA_BASE, size: ORCA_SIZE, path: '/opt/Orca/orca' },
+  {
+    base: 0x7f3a1c000000n,
+    size: 0x200000,
+    path: '/usr/lib/x86_64-linux-gnu/libc.so.6'
+  }
+]
+
+const WINDOWS_MODULES: DumpModule[] = [
+  {
+    base: 0x7ff629_1a0000n,
+    size: 0x0a000000,
+    path: 'C:\\Program Files\\Orca\\Orca.exe'
+  },
+  {
+    base: 0x7ffc12_000000n,
+    size: 0x100000,
+    path: 'C:\\Windows\\System32\\ntdll.dll'
+  }
+]
+const WIN_FAULT_ADDRESS = 0x7ff62adde94an // report-verbatim: Orca.exe+0x1c3e94a
+const STATUS_ACCESS_VIOLATION = 0xc0000005
+const STATUS_IN_PAGE_ERROR = 0xc0000006
+
+describe('Linux minidump faulting-module resolution', () => {
+  it('parses the Linux MINIDUMP_MODULE_LIST correctly (the walk is not PE-only)', () => {
+    // Control: when the address handed to the lookup IS an instruction address,
+    // the ELF module resolves. So neither MODULE_LIST parsing nor the range
+    // match is the defect.
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: ORCA_BASE + RIP_OFFSET,
+      context: {
+        architecture: 'amd64',
+        instructionPointer: ORCA_BASE + RIP_OFFSET
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('orca')
+    expect(signature?.faultingModuleOffset).toBe('0x134c608')
+  })
+
+  it('si_addr alone resolves nothing — the gap, reproduced with no thread context', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.exceptionCode).toBe(0xb)
+    expect(signature?.exceptionAddress).toBe('0x31b58e9fc608')
+    expect(signature?.instructionPointer).toBeUndefined()
+    expect(signature?.faultingModule).toBeUndefined()
+  })
+
+  it('recovers the faulting module from the thread context RIP', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      systemInfo: 'amd64',
+      context: {
+        architecture: 'amd64',
+        instructionPointer: ORCA_BASE + RIP_OFFSET
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('orca')
+    expect(signature?.faultingModuleOffset).toBe('0x134c608')
+    // si_addr is real information (it IS the faulting data address); it stays.
+    expect(signature?.exceptionAddress).toBe('0x31b58e9fc608')
+    expect(signature?.instructionPointer).toBe('0x55e1c3d4c608')
+  })
+
+  // Same bundle (submission xjAexdQDFZnRLSZECj3ETw), reports 7040cec8 and
+  // 40120f54: two more v1.4.200 Linux renderer crashes, exit 133 SIGTRAP —
+  // Chromium's IMMEDIATE_CRASH(). si_addr is undefined for SIGTRAP, so Crashpad
+  // wrote 0x0 and the address field carries no information at all.
+  // Caveat: an int3 trap frame's RIP points one byte PAST the trapping
+  // instruction, so the offset is a disassembly starting point, not the exact
+  // faulting byte. Module attribution is unaffected.
+  it('resolves a Linux SIGTRAP whose si_addr is 0x0, leaving RIP the only locator', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0x5,
+      exceptionAddress: 0x0n,
+      systemInfo: 'amd64',
+      context: {
+        architecture: 'amd64',
+        instructionPointer: ORCA_BASE + RIP_OFFSET
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.exceptionCode).toBe(0x5)
+    expect(signature?.exceptionAddress).toBe('0x0')
+    expect(signature?.faultingModule).toBe('orca')
+  })
+
+  it('never invents an instruction pointer when the context reports 0x0', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0x5,
+      exceptionAddress: 0x0n,
+      systemInfo: 'amd64',
+      context: { architecture: 'amd64', instructionPointer: 0x0n }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.instructionPointer).toBeUndefined()
+    expect(signature?.faultingModule).toBeUndefined()
+  })
+})
+
+// Adversarial review: si_addr is not confined to unmapped memory. A store
+// through a bad pointer into a shared object's read-only page (SEGV_ACCERR) puts
+// it squarely inside that image, as do SIGBUS on an mmap'ed module page and
+// SEGV_PKUERR; Crashpad's Mach snapshot has the same shape, writing code[1] —
+// the inaccessible data address — for EXC_BAD_ACCESS. So matching it against
+// module ranges does not merely fail to resolve: it resolves to the wrong
+// module, and `Faulting module: libc.so.6+0x1234` headlines a libc frame that
+// never executed. Only an instruction address may name a faulting module.
+describe('a data address never names a faulting module', () => {
+  // Inside libc's image (base 0x7f3a1c000000, size 0x200000).
+  const SI_ADDR_IN_LIBC = 0x7f3a1c001234n
+  // A V8 JIT page: real code, in no mapped module.
+  const JIT_INSTRUCTION_POINTER = 0x2f1a00001000n
+
+  it('reports the JIT instruction pointer and no module, not libc from si_addr', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: SI_ADDR_IN_LIBC,
+      systemInfo: 'amd64',
+      platform: 'linux',
+      context: {
+        architecture: 'amd64',
+        instructionPointer: JIT_INSTRUCTION_POINTER
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.instructionPointer).toBe('0x2f1a00001000')
+    expect(signature?.exceptionAddress).toBe('0x7f3a1c001234')
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.faultingModuleOffset).toBeUndefined()
+  })
+
+  it('stays blank on Linux when there is no context to fall back from', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: SI_ADDR_IN_LIBC,
+      systemInfo: 'amd64',
+      platform: 'linux'
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBeUndefined()
+  })
+
+  it('stays blank for a Mach EXC_BAD_ACCESS, whose address is code[1]', () => {
+    const dump = buildDump({
+      modules: [
+        {
+          base: 0x1a0_0000_0000n,
+          size: 0x0a000000,
+          path: '/Applications/Orca.app/MacOS/Orca'
+        }
+      ],
+      exceptionCode: 1, // EXC_BAD_ACCESS
+      exceptionAddress: 0x1a0_0000_04c8n,
+      systemInfo: 'arm64',
+      platform: 'macos'
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBeUndefined()
+  })
+
+  // A dump that does not say it is Windows is not assumed to be.
+  it('stays blank when the dump declares no platform at all', () => {
+    const dump = buildDump({
+      modules: WINDOWS_MODULES,
+      exceptionCode: STATUS_ACCESS_VIOLATION,
+      exceptionAddress: WIN_FAULT_ADDRESS
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBeUndefined()
+  })
+})
+
+// The flip side of the block above: ExceptionAddress is not a data address on
+// every non-Windows dump. Crashpad's Mach snapshot only takes code[1] for
+// EXC_BAD_ACCESS and otherwise sets exception_address_ from the thread
+// context's instruction pointer, and sigaction(2) defines si_addr as the
+// faulting *instruction* for SIGILL and SIGFPE. A platform-blanket gate would
+// throw those away — including the corpus's only macOS report (v1.4.197,
+// EXC_BREAKPOINT), which resolves Electron Framework+0xe8ab78 from
+// ExceptionAddress alone.
+describe('an instruction ExceptionAddress still names a module', () => {
+  const FRAMEWORK_BASE = 0x1_0000_0000n
+  const MAC_MODULES: DumpModule[] = [
+    {
+      base: FRAMEWORK_BASE,
+      size: 0x0200_0000,
+      path: '/Applications/Orca.app/Contents/Frameworks/Electron Framework.framework/Electron Framework'
+    }
+  ]
+
+  it('resolves a Mach EXC_BREAKPOINT from ExceptionAddress with no context to fall back on', () => {
+    const dump = buildDump({
+      modules: MAC_MODULES,
+      exceptionCode: 0x6, // EXC_BREAKPOINT
+      exceptionAddress: FRAMEWORK_BASE + 0xe8ab78n,
+      systemInfo: 'arm64',
+      platform: 'macos'
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('Electron Framework')
+    expect(signature?.faultingModuleOffset).toBe('0xe8ab78')
+  })
+
+  it.each([
+    ['SIGILL', 0x4],
+    ['SIGFPE', 0x8]
+  ])('resolves a Linux %s, whose si_addr is the faulting instruction', (_name, code) => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: code,
+      exceptionAddress: ORCA_BASE + RIP_OFFSET,
+      systemInfo: 'amd64',
+      platform: 'linux'
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBe('orca')
+  })
+
+  it('still prefers the context over si_addr for SIGILL when both are present', () => {
+    // si_addr and Rip agree in practice; if a producer disagrees, the register
+    // the CPU actually faulted on wins.
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0x4,
+      exceptionAddress: 0x7f3a1c001234n, // inside libc
+      systemInfo: 'amd64',
+      platform: 'linux',
+      context: { architecture: 'amd64', instructionPointer: ORCA_BASE + RIP_OFFSET }
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBe('orca')
+  })
+
+  it('attributes nothing for a Linux SIGTRAP, whose si_addr is undefined', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0x5,
+      exceptionAddress: ORCA_BASE + RIP_OFFSET, // plausible-looking, still not si_addr
+      systemInfo: 'amd64',
+      platform: 'linux'
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBeUndefined()
+  })
+})
+
+describe('instruction pointer across architectures', () => {
+  const ARM64_BASE = 0x1a0_0000_0000n
+  const ARM64_MODULES: DumpModule[] = [
+    {
+      base: ARM64_BASE,
+      size: 0x0a000000,
+      path: '/Applications/Orca.app/Contents/MacOS/Orca'
+    }
+  ]
+
+  it('reads Pc at +0x108 from an arm64 context (Apple Silicon, arm64 Linux)', () => {
+    const dump = buildDump({
+      modules: ARM64_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      systemInfo: 'arm64',
+      context: {
+        architecture: 'arm64',
+        instructionPointer: ARM64_BASE + 0x4c8n
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.instructionPointer).toBe('0x1a0000004c8')
+    expect(signature?.faultingModule).toBe('Orca')
+    expect(signature?.faultingModuleOffset).toBe('0x4c8')
+  })
+
+  // The lower edge of the arm64 byte window: Crashpad's MinidumpContextARM64 is
+  // exactly 792 bytes, which is what a real Apple Silicon or arm64 Linux dump
+  // declares. Windows' 912-byte ARM64_NT_CONTEXT is the upper edge, above.
+  it('reads Pc from a 792-byte Crashpad arm64 context', () => {
+    const dump = buildDump({
+      modules: ARM64_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      systemInfo: 'arm64',
+      context: {
+        architecture: 'arm64',
+        instructionPointer: ARM64_BASE + 0x4c8n,
+        declaredSize: 792,
+        presentBytes: 792
+      }
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBe('Orca')
+  })
+
+  // Breakpad's legacy arm64 context is a different struct reached by a different
+  // flag: MD_CONTEXT_ARM64_OLD is 0x80000000, i.e. bit 31. A `flags & selector`
+  // comparison against it is an int32 compare that can never equal the unsigned
+  // selector, so this whole family silently lost its instruction pointer.
+  it('reads Pc from a Breakpad-legacy arm64 context (bit-31 selector, no CONTROL bit)', () => {
+    const dump = buildDump({
+      modules: ARM64_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      systemInfo: 'arm64Breakpad',
+      context: {
+        architecture: 'arm64Breakpad',
+        instructionPointer: ARM64_BASE + 0x4c8n
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.instructionPointer).toBe('0x1a0000004c8')
+    expect(signature?.faultingModule).toBe('Orca')
+  })
+
+  it('reads a Breakpad-legacy arm64 context under the modern arch id and with no system info', () => {
+    for (const systemInfo of ['arm64', undefined] as const) {
+      const dump = buildDump({
+        modules: ARM64_MODULES,
+        exceptionCode: 0xb,
+        exceptionAddress: REPORTED_SI_ADDR,
+        ...(systemInfo ? { systemInfo } : {}),
+        context: {
+          architecture: 'arm64Breakpad',
+          instructionPointer: ARM64_BASE + 0x4c8n
+        }
+      })
+
+      expect(parseMinidumpCrashSignature(dump)?.instructionPointer).toBe('0x1a0000004c8')
+    }
+  })
+
+  // Pc is iregs[32] in the legacy struct, so the integer group — not a control
+  // group the _OLD family never defined — is what says it is populated.
+  it('skips a Breakpad-legacy arm64 context that omits the integer register group', () => {
+    const dump = buildDump({
+      modules: ARM64_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      systemInfo: 'arm64Breakpad',
+      context: {
+        architecture: 'arm64Breakpad',
+        instructionPointer: ARM64_BASE + 0x4c8n,
+        // FLOATING_POINT_OLD alone: the iregs array is not populated.
+        flags: 0x80000004
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.instructionPointer).toBeUndefined()
+    expect(signature?.faultingModule).toBeUndefined()
+  })
+
+  it('still reads an arm64 context when the dump carries no system-info stream', () => {
+    const dump = buildDump({
+      modules: ARM64_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: 0x0n,
+      context: {
+        architecture: 'arm64',
+        instructionPointer: ARM64_BASE + 0x4c8n
+      }
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBe('Orca')
+  })
+
+  it('skips a context the system-info architecture disagrees with', () => {
+    // An amd64 CONTEXT under an arm64 system info: reading Pc at +0x108 would
+    // hand back a float-save-area word. The system info rules the amd64 layout
+    // out, so what rejects the arm64 layouts is the context's size — and it has
+    // to, because P1Home (where they read context_flags) is uninitialised
+    // home space, not a zeroed field, so it is set here to the exact bits that
+    // would wave the context through.
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      systemInfo: 'arm64',
+      context: {
+        architecture: 'amd64',
+        instructionPointer: ORCA_BASE + RIP_OFFSET,
+        leadingWord: 0x00400001, // CONTEXT_ARM64 | CONTEXT_ARM64_CONTROL
+        arm64PcSlot: ORCA_BASE + RIP_OFFSET
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.instructionPointer).toBeUndefined()
+    expect(signature?.faultingModule).toBeUndefined()
+  })
+
+  it('skips a context whose declared size is too short to be one', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      systemInfo: 'amd64',
+      context: {
+        architecture: 'amd64',
+        instructionPointer: ORCA_BASE + RIP_OFFSET,
+        declaredSize: 256
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.instructionPointer).toBeUndefined()
+    expect(signature?.faultingModule).toBeUndefined()
+  })
+
+  // A layout whose CONTEXT_<arch> selector matched owns the context: re-reading
+  // the same bytes under the next layout's struct would hand back a foreign
+  // register. CONTEXT_AMD64's P1Home sits exactly where the arm64 layouts read
+  // context_flags, so an uninitialised home-space slot can masquerade as one.
+  it('does not re-read an amd64 context whose Rip is 0 as an arm64 one', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0x5,
+      exceptionAddress: 0x0n,
+      // No system-info stream, so nothing narrows the candidate layouts.
+      context: {
+        architecture: 'amd64',
+        instructionPointer: 0x0n,
+        // CONTEXT_ARM64 | CONTEXT_ARM64_CONTROL, as the arm64 layout reads it.
+        leadingWord: 0x00400001,
+        arm64PcSlot: ORCA_BASE + RIP_OFFSET
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.instructionPointer).toBeUndefined()
+    expect(signature?.faultingModule).toBeUndefined()
+  })
+
+  // ...and the same when ContextFlags does not name amd64 either, so the amd64
+  // layout declines the context rather than owning it. A partially written or
+  // foreign-producer context reads back as flags 0; the layouts' byte windows
+  // are what keep the arm64 structs off a 1232-byte record.
+  it('does not re-read an amd64-sized context with cleared ContextFlags as an arm64 one', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0x5,
+      exceptionAddress: 0x0n,
+      // No system-info stream, so nothing narrows the candidate layouts.
+      context: {
+        architecture: 'amd64',
+        instructionPointer: ORCA_BASE + RIP_OFFSET,
+        flags: 0,
+        leadingWord: 0x00400001,
+        arm64PcSlot: ORCA_BASE + RIP_OFFSET
+      }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.instructionPointer).toBeUndefined()
+    expect(signature?.faultingModule).toBeUndefined()
+  })
+
+  // A zeroed or truncated MINIDUMP_SYSTEM_INFO reads back as architecture 0
+  // (PROCESSOR_ARCHITECTURE_INTEL). Trusting that would be strictly worse than
+  // the no-system-info dump above, which still recovers Rip.
+  it('falls back to size and flags when system info names an architecture it does not decode', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      platform: 'linux', // system-info stream present, ProcessorArchitecture left 0
+      context: { architecture: 'amd64', instructionPointer: ORCA_BASE + RIP_OFFSET }
+    })
+
+    expect(parseMinidumpCrashSignature(dump)?.faultingModule).toBe('orca')
+  })
+
+  it('degrades instead of throwing when a full-size context is cut off by the file end', () => {
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      systemInfo: 'amd64',
+      context: {
+        architecture: 'amd64',
+        instructionPointer: ORCA_BASE + RIP_OFFSET,
+        presentBytes: 0x40
+      }
+    })
+
+    expect(() => parseMinidumpCrashSignature(dump)).not.toThrow()
+    expect(parseMinidumpCrashSignature(dump)?.instructionPointer).toBeUndefined()
+  })
+})
+
+describe('Windows keeps attributing from ExceptionAddress', () => {
+  it('resolves from ExceptionAddress when the dump has no thread context', () => {
+    const dump = buildDump({
+      modules: WINDOWS_MODULES,
+      exceptionCode: STATUS_ACCESS_VIOLATION,
+      exceptionAddress: WIN_FAULT_ADDRESS,
+      platform: 'windows'
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('Orca.exe')
+    expect(signature?.faultingModuleOffset).toBe('0x1c3e94a')
+  })
+
+  it('resolves the same module when the context Rip matches ExceptionAddress', () => {
+    const dump = buildDump({
+      modules: WINDOWS_MODULES,
+      exceptionCode: STATUS_ACCESS_VIOLATION,
+      exceptionAddress: WIN_FAULT_ADDRESS,
+      systemInfo: 'amd64',
+      platform: 'windows',
+      context: { architecture: 'amd64', instructionPointer: WIN_FAULT_ADDRESS }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('Orca.exe')
+    expect(signature?.faultingModuleOffset).toBe('0x1c3e94a')
+    expect(signature?.exceptionAddress).toBe('0x7ff62adde94a')
+  })
+
+  // The shape every real Crashpad dump has: MinidumpExceptionWriter always
+  // emits a ThreadContext, so the context is present on all 45 resolving Win64
+  // reports. Windows defines ExceptionAddress as the faulting instruction for
+  // every exception class, so it stays the attribution source and the offsets
+  // already filed keep matching.
+  it('attributes from ExceptionAddress, not the context Rip, when the two differ', () => {
+    const dump = buildDump({
+      modules: WINDOWS_MODULES,
+      exceptionCode: 0x80000003, // STATUS_BREAKPOINT: a Chromium IMMEDIATE_CRASH
+      exceptionAddress: WIN_FAULT_ADDRESS,
+      systemInfo: 'amd64',
+      platform: 'windows',
+      context: { architecture: 'amd64', instructionPointer: WIN_FAULT_ADDRESS + 1n }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('Orca.exe')
+    expect(signature?.faultingModuleOffset).toBe('0x1c3e94a')
+    expect(signature?.instructionPointer).toBe('0x7ff62adde94b')
+  })
+
+  // Crashpad writes 0x0 when it captures a Windows process with no exception
+  // pointers; the context is then the only locator left.
+  it('falls back to the context Rip when ExceptionAddress is 0x0', () => {
+    const dump = buildDump({
+      modules: WINDOWS_MODULES,
+      exceptionCode: STATUS_ACCESS_VIOLATION,
+      exceptionAddress: 0x0n,
+      systemInfo: 'amd64',
+      platform: 'windows',
+      context: { architecture: 'amd64', instructionPointer: WIN_FAULT_ADDRESS }
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.exceptionAddress).toBe('0x0')
+    expect(signature?.faultingModule).toBe('Orca.exe')
+    expect(signature?.faultingModuleOffset).toBe('0x1c3e94a')
+  })
+
+  // The renderer use-after-free family (v1.4.197–v1.4.199) is all
+  // STATUS_ACCESS_VIOLATION; read-vs-write and the inaccessible address are what
+  // separate a null deref from a wild pointer.
+  it('captures ExceptionInformation[0]/[1] on an access violation', () => {
+    const dump = buildDump({
+      modules: WINDOWS_MODULES,
+      exceptionCode: STATUS_ACCESS_VIOLATION,
+      exceptionAddress: WIN_FAULT_ADDRESS,
+      platform: 'windows',
+      exceptionInformation: [1n, 0x1n]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.accessKind).toBe('write')
+    expect(signature?.accessAddress).toBe('0x1')
+  })
+
+  it('reports a DEP execute fault, and keeps the address when the kind is unknown', () => {
+    const execute = parseMinidumpCrashSignature(
+      buildDump({
+        modules: WINDOWS_MODULES,
+        exceptionCode: STATUS_ACCESS_VIOLATION,
+        exceptionAddress: WIN_FAULT_ADDRESS,
+        platform: 'windows',
+        exceptionInformation: [8n, 0x2b0000n]
+      })
+    )
+    expect(execute?.accessKind).toBe('execute')
+    expect(execute?.accessAddress).toBe('0x2b0000')
+
+    const unknown = parseMinidumpCrashSignature(
+      buildDump({
+        modules: WINDOWS_MODULES,
+        exceptionCode: STATUS_ACCESS_VIOLATION,
+        exceptionAddress: WIN_FAULT_ADDRESS,
+        platform: 'windows',
+        exceptionInformation: [99n, 0x2b0000n]
+      })
+    )
+    expect(unknown?.accessKind).toBeUndefined()
+    expect(unknown?.accessAddress).toBe('0x2b0000')
+  })
+
+  it('reports no access kind when the record declares fewer than two parameters', () => {
+    // A zeroed ExceptionInformation array would otherwise read as a confident
+    // `read` of 0x0 — a null deref the dump never claimed.
+    const dump = buildDump({
+      modules: WINDOWS_MODULES,
+      exceptionCode: STATUS_ACCESS_VIOLATION,
+      exceptionAddress: WIN_FAULT_ADDRESS,
+      platform: 'windows',
+      exceptionInformation: [0n]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.accessKind).toBeUndefined()
+    expect(signature?.accessAddress).toBeUndefined()
+    expect(signature?.faultingModule).toBe('Orca.exe')
+  })
+
+  it('captures the access record of an in-page error too', () => {
+    const dump = buildDump({
+      modules: WINDOWS_MODULES,
+      exceptionCode: STATUS_IN_PAGE_ERROR,
+      exceptionAddress: WIN_FAULT_ADDRESS,
+      platform: 'windows',
+      exceptionInformation: [0n, 0x2b0000n]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.accessKind).toBe('read')
+    expect(signature?.accessAddress).toBe('0x2b0000')
+  })
+
+  it('does not read ExceptionInformation as an access kind on a POSIX signal', () => {
+    // Crashpad's POSIX writer puts si_code in the same slot; 2 would decode as a
+    // bogus access kind and si_code-adjacent data as a bogus address.
+    const dump = buildDump({
+      modules: LINUX_MODULES,
+      exceptionCode: 0xb,
+      exceptionAddress: REPORTED_SI_ADDR,
+      platform: 'linux',
+      exceptionInformation: [1n, 0x31b58e9fc608n]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.accessKind).toBeUndefined()
+    expect(signature?.accessAddress).toBeUndefined()
+  })
+
+  it('surfaces the new fields as details a report reader can see', () => {
+    const dump = buildDump({
+      modules: WINDOWS_MODULES,
+      exceptionCode: STATUS_ACCESS_VIOLATION,
+      exceptionAddress: WIN_FAULT_ADDRESS,
+      systemInfo: 'amd64',
+      platform: 'windows',
+      context: { architecture: 'amd64', instructionPointer: WIN_FAULT_ADDRESS },
+      exceptionInformation: [0n, 0x0n]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(minidumpSignatureDetails(signature!)).toMatchObject({
+      minidumpExceptionAddress: '0x7ff62adde94a',
+      minidumpInstructionPointer: '0x7ff62adde94a',
+      minidumpAccessKind: 'read',
+      minidumpAccessAddress: '0x0',
+      minidumpFaultingModule: 'Orca.exe'
+    })
+  })
+})


### PR DESCRIPTION
## What

`MINIDUMP_EXCEPTION.ExceptionAddress` does not mean the same thing on every platform, and Orca's
crash-signature parser treated it as if it did.

- **Windows** — Crashpad writes `EXCEPTION_RECORD.ExceptionAddress`, always the faulting **instruction**.
- **POSIX** — Crashpad writes `siginfo.si_addr`, which `sigaction(2)` defines as the **memory reference
  that faulted** for SIGSEGV/SIGBUS, and leaves **undefined** for the rest (SIGTRAP arrives as `0x0`).
- **Mach** — `code[1]` (a data address) for `EXC_BAD_ACCESS`, the context instruction pointer otherwise.

`minidump-crash-signature.ts` fed that raw field to `findFaultingModule()` unconditionally. A data
address by construction cannot fall inside a mapped executable image, so on POSIX the lookup silently
resolved nothing.

Found while triaging crash report **`6c1f4289-0127-42c9-b1f8-41943fe74aaf`** — the only report in
scan 5 whose payload `App version:` is **v1.4.200**, the currently released build.

## CLEAR, UNDENIABLE fix evidence

### 1. The field corpus, before the fix

98 crash payloads carrying `minidumpExceptionAddress`, keyed on the in-payload `App version:` line
(never the Slack header):

| platform | resolve a faulting module | example address |
| --- | --- | --- |
| Win64 | **45 / 45** | `0x7ff62adde94a` → `Orca.exe+0x1c3e94a` (code-shaped) |
| macOS | **1 / 1** | `0x10eb2eb78` → `Electron Framework+0xe8ab78` (a Mach exception, not a signal) |
| Linux | **0 / 3** | `0x31b58e9fc608`, `0x297a59b0330`, `0x5d1c000004f0` (all data-pointer shaped) |

Report `6c1f4289` verbatim — note what is *missing*:

```
App version: 1.4.200
Platform: linux 7.0.0-31-generic x64
Exit code: 139 (SIGSEGV, core dumped)
- minidumpExceptionCode: 0xb
- minidumpExceptionAddress: 0x31b58e9fc608
- minidumpStatus: captured
- minidumpBytes: 200480
        <- no minidumpFaultingModule, no minidumpFaultingModuleOffset
```

The same bundle holds two further **v1.4.200** Linux renderer crashes (`7040cec8`, `40120f54`), both
exit 133 SIGTRAP — Chromium `IMMEDIATE_CRASH()`/CHECK failures — both with `exceptionAddress 0x0`,
because si_addr is undefined for SIGTRAP. Deterministic CHECK failures shipped with **zero** locator.
The equivalent Windows `STATUS_BREAKPOINT` reports resolve 2/2, at a byte-identical offset — a working
dedupe fingerprint we simply do not get off Windows.

### 2. Primary source, not inference

- `snapshot/win/exception_snapshot_win.cc` → `exception_address_ = first_record.ExceptionAddress;`
- `snapshot/linux/exception_snapshot_linux.cc`, `ReadSiginfo` → `exception_address_ = siginfo.address;`
- `snapshot/mac/exception_snapshot_mac.cc` → `code[1]` for `EXC_BAD_ACCESS`, context IP otherwise

The pre-existing comment at `minidump-crash-signature.ts:54` already documented that the *code* field
is platform-divergent. That knowledge was never carried across to the *address* field.

### 3. Repro test, failing before / passing after

`src/main/crash-reporting/minidump-posix-faulting-module.test.ts` (36 tests) builds real
minidump bytes. Before the fix, on `origin/main`:

```
✓ parses the Linux MINIDUMP_MODULE_LIST correctly (the walk is not PE-only)
✓ si_addr alone resolves nothing — the gap, reproduced
× the faulting module is recoverable from the thread context RIP   AssertionError: expected undefined to be 'orca'
× a Linux SIGTRAP writes si_addr 0x0, leaving RIP the only locator  AssertionError: expected undefined to be 'orca'
```

The first control test is the load-bearing one: **the ELF module-list walk was never broken.** This is
not a parsing bug — the input to the lookup was wrong. After the fix all 36 pass.

### 4. Windows proved unchanged — measured, not asserted

A reviewer extracted the **pre-patch parser from `HEAD` as a second module** and ran both over 120
realistic Crashpad Windows dumps (8 exception codes × 5 addresses × 3 Rip relationships, including the
adversarial case where Rip points into a *different module* than ExceptionAddress):

> **120 / 120 byte-identical** on `faultingModule`, `faultingModuleOffset`, `exceptionAddress`,
> `exceptionCode`. Across the full 384-cell matrix the only Windows-platform divergence is
> `ExceptionAddress == 0` now resolving from Rip (previously blank) — a gain.

### 5. Mutation testing

24 mutants run against the suite; 18 killed. Every mechanism the tests name is load-bearing —
including both directions of the Windows precedence rule:

| mutation | result |
| --- | --- |
| Windows branch → `exceptionAddressInstruction` only | kills *'falls back to the context Rip when ExceptionAddress is 0x0'* |
| Windows branch → `instructionPointer ?? exceptionAddress` | kills *'attributes from ExceptionAddress, not the context Rip, when the two differ'* |
| `hasFlags` without `>>> 0` | kills 2 Breakpad arm64 tests |
| drop the arm64 `maxBytes` ceiling | kills 2 |
| drop the `parameters < 2` guard | kills *'reports no access kind when the record declares fewer than two parameters'* |
| `readAccessViolation` without its Win32 code gate | kills *'does not read ExceptionInformation as an access kind on a POSIX signal'* |

### Verification

```
pnpm test src/main/crash-reporting/ src/shared/crash-reporting.test.ts  ->  31 files, 360 tests passed
pnpm tc:node                                                            ->  clean
oxlint src/main/crash-reporting/                                        ->  0 warnings, 0 errors (59 files)
```

## ELI5

When Orca crashes it writes a little black-box file, then reads one number back out to say *where* it
crashed — so we can tell "we died in the graphics driver" from "we died in our own code."

On Windows that number is **the instruction that crashed**. On Linux and macOS it is often **the piece
of memory the crash was reaching for** instead. We were treating the second like the first. It is the
difference between "the driver crashed at line 40 of the driver" and "the driver crashed while
touching your photo album" — the second one never tells you which program to go look at, because a
photo isn't code. So every Linux crash came back saying *"crashed somewhere, no idea where."*

Now we read the CPU's own "what was I executing" register instead, which is the right number, and we
still print the memory address next to it because that is genuinely useful too. On Windows nothing
changes — it was already right. And if a crash file is too damaged to tell us which case we're in, we
print **nothing** rather than a confident guess. A blank is honest; a wrong module name sends the next
person debugging in the wrong direction for a day.

## Trade-offs / negative behaviour changes

Being straight about these — all three are deliberate:

1. **A dump with no decodable `MINIDUMP_SYSTEM_INFO` now attributes no module, where it previously
   attributed one from ExceptionAddress.** Without a platform we cannot know what that field means, so
   we decline. Real Crashpad always writes the stream and always sets `platform_id` on Windows, so this
   is not expected in the field — but it is a genuine regression in one corner, and it is the price of
   never emitting a wrong attribution. Codified by test, not accidental.
2. **A trap frame's instruction pointer can point past the trapping instruction** (x86 `int3`, arm64
   `BRK`), so for SIGTRAP/CHECK reports the offset is a disassembly *starting point*, not the exact
   faulting byte. Module attribution is unaffected. Documented on the field.
3. **Only x86-64 and arm64 CONTEXTs are decoded.** x86-32, arm32 and anything else fall back to
   ExceptionAddress-only behaviour — i.e. exactly what they do today — rather than misreading foreign
   registers. Stated in the code.

No user-facing behaviour changes: this is crash-report content only. No wire-format, SSH, or
folder-workspace surface is touched.

## Adversarial review

**6 loops, each a fresh sub-agent, run until clean.**

| loop | lens | outcome |
| --- | --- | --- |
| 1 | binary-format correctness | **major** — `(flags & 0x8000_0000) === 0x8000_0000` is unreachable in JS (int32 coercion), making the Breakpad-legacy arm64 selector dead code that the comment claimed was supported |
| 2 | regression & field-truth | **major** — the POSIX fallback could still attribute a module from a *data* address, i.e. a confidently-wrong answer |
| 3 | adversarial semantics | **2 blockers** — Windows silently moved off ExceptionAddress onto Rip in every real dump; and a blanket "never attribute off Windows" rule discarded *correct* instruction addresses for SIGILL/SIGFPE and non-`EXC_BAD_ACCESS` Mach |
| 4 | fresh eyes, full sweep | 8 findings, 2 blockers; fixes applied |
| 5 | confirmation + prior-fix audit | verified loops 1–4 genuinely resolved; proved Windows unchanged via the 120-cell differential; **1 major** — two pre-existing guard tests had been silently defanged into passing *vacuously* |
| 6 | final confirming pass | **no blockers, no majors**; 24 mutation tests (18 killed a named test); the 7 survivors were uncovered guards, since closed |

Loop 6 also independently re-derived every struct constant by hand rather than reading the comments
(`CONTEXT_AMD64` 1232 / flags `0x30` / Rip `0xf8`; Crashpad `MinidumpContextARM64` 792 with Pc at
`0x108`; `ARM64_NT_CONTEXT` 912; `MDRawContextARM64_Old` 796 packed / 800 aligned), and verified the
new detail keys survive `sanitizeCrashReportDetails` with no key cap and no path-redaction collision.

**Follow-up commit from loop 6's findings** — three guards it proved were uncovered now have tests
that kill their mutants, and one was a real hole rather than a coverage gap:

- `readSystemInfo` did not bound its reads to the declared stream size. A `MINIDUMP_SYSTEM_INFO`
  stream shorter than PlatformId's offset still had PlatformId read out of the bytes that followed
  it; a stray `2` there classifies a POSIX dump as Windows, and si_addr then names whatever image the
  crash touched. **That is exactly the wrong attribution this PR exists to prevent**, so it is now
  gated — with a test that fails when the gate is removed.
- `parameters < 2` on `ExceptionInformation` was uncovered. Had it regressed, a Windows access
  violation with `NumberParameters: 0` would have reported a fabricated `accessKind: read,
  accessAddress: 0x0` — a very convincing null deref the dump never claimed.
- `STATUS_IN_PAGE_ERROR` (`0xc0000006`) had no coverage of any kind.

Loop 3 is why this PR is correct rather than merely plausible: the first implementation would have
changed Windows attribution in every real dump — the one thing the change must not do. Loop 5 is why
the tests are trustworthy: two guard tests had become vacuous (they built dumps with no platform, so
`readModules()` was never reached), and both now fail under mutation as they should.

Closes the triage gap for crash report `6c1f4289` (v1.4.200).
