### PR TITLE
fix(status-bar): surface signed-out Claude usage instead of hiding the segment

### DIFF
--- a/src/main/rate-limits/claude-active-usage-fetch.ts
+++ b/src/main/rate-limits/claude-active-usage-fetch.ts
@@ -144,6 +144,19 @@ export async function fetchActiveClaudeRateLimits(
     managedRefreshDeferredByLivePty: options?.authPreparation?.managedRefreshDeferredByLivePty
   })
 
+  // Why: terminal signed-out means there is no token to try and no CLI
+  // fallback is sanctioned — return before any refresh or PTY attempts.
+  if (credentialClassification.failureKind === 'signed-out') {
+    return makeClaudeUsageResult('error', 'Claude sign-in expired', {
+      ...metadataForClaudeUsageAttempt({
+        attemptedSources: attempts.attemptedSources,
+        oauthCredentials,
+        authPreparation: options?.authPreparation,
+        failureKind: 'signed-out'
+      })
+    })
+  }
+
   if (shouldDeferClaudeUsageForLiveSession(options?.authPreparation, credentialClassification)) {
     return makeLiveClaudeUsageDeferredResult({
       attempts,
@@ -236,19 +249,6 @@ export async function fetchActiveClaudeRateLimits(
     } catch (error) {
       warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, error)
     }
-  }
-
-  // Why: an emptied credential store means signed-out, not never-configured —
-  // surface it as an error so the status bar shows a sign-in state instead of hiding.
-  if (credentialClassification.failureKind === 'signed-out') {
-    return makeClaudeUsageResult('error', 'Claude sign-in expired', {
-      ...metadataForClaudeUsageAttempt({
-        attemptedSources: attempts.attemptedSources,
-        oauthCredentials,
-        authPreparation: options?.authPreparation,
-        failureKind: 'signed-out'
-      })
-    })
   }
 
   return makeClaudeUsageResult('unavailable', 'No subscription plan — API key billing', {

--- a/src/main/rate-limits/claude-active-usage-fetch.ts
+++ b/src/main/rate-limits/claude-active-usage-fetch.ts
@@ -139,6 +139,7 @@ export async function fetchActiveClaudeRateLimits(
 
   const credentialClassification = classifyClaudeCredentialAbsence({
     hasRefreshableCredentials: oauthCredentials.hasRefreshableCredentials,
+    hasEmptyStoredEntry: oauthCredentials.hasEmptyStoredEntry,
     keychainUnavailable: oauthCredentials.keychainUnavailable,
     managedRefreshDeferredByLivePty: options?.authPreparation?.managedRefreshDeferredByLivePty
   })
@@ -235,6 +236,19 @@ export async function fetchActiveClaudeRateLimits(
     } catch (error) {
       warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, error)
     }
+  }
+
+  // Why: an emptied credential store means signed-out, not never-configured —
+  // surface it as an error so the status bar shows a sign-in state instead of hiding.
+  if (credentialClassification.failureKind === 'signed-out') {
+    return makeClaudeUsageResult('error', 'Claude sign-in expired', {
+      ...metadataForClaudeUsageAttempt({
+        attemptedSources: attempts.attemptedSources,
+        oauthCredentials,
+        authPreparation: options?.authPreparation,
+        failureKind: 'signed-out'
+      })
+    })
   }
 
   return makeClaudeUsageResult('unavailable', 'No subscription plan — API key billing', {

--- a/src/main/rate-limits/claude-fetcher-keychain-credentials.test.ts
+++ b/src/main/rate-limits/claude-fetcher-keychain-credentials.test.ts
@@ -469,9 +469,9 @@ describe('fetchClaudeRateLimits', () => {
         })
       )
 
-    await expect(
-      fetchClaudeRateLimits({ authPreparation, allowPtyFallback: false })
-    ).resolves.toMatchObject({
+    // Why: no allowPtyFallback override — signed-out must return before the
+    // generic CLI plan step even when the caller allows PTY fallback.
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
       provider: 'claude',
       status: 'error',
       error: 'Claude sign-in expired',

--- a/src/main/rate-limits/claude-fetcher-keychain-credentials.test.ts
+++ b/src/main/rate-limits/claude-fetcher-keychain-credentials.test.ts
@@ -452,6 +452,56 @@ describe('fetchClaudeRateLimits', () => {
     )
   })
 
+  it('reports signed-out instead of unavailable when the Keychain entry holds no tokens', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      runtime: 'host',
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          claudeAiOauth: { accessToken: '', refreshToken: '', expiresAt: 0 }
+        })
+      )
+
+    await expect(
+      fetchClaudeRateLimits({ authPreparation, allowPtyFallback: false })
+    ).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'Claude sign-in expired',
+      usageMetadata: {
+        failureKind: 'signed-out',
+        credentialSource: 'legacy-keychain',
+        authProvenance: 'system'
+      }
+    })
+
+    expect(netFetchMock).not.toHaveBeenCalled()
+    expect(fetchViaPty).not.toHaveBeenCalled()
+  })
+
+  it('reports signed-out when only the credentials file holds an emptied entry', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ claudeAiOauth: { accessToken: '', refreshToken: '' } })
+    )
+
+    await expect(fetchClaudeRateLimits({ allowPtyFallback: false })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'Claude sign-in expired',
+      usageMetadata: { failureKind: 'signed-out', credentialSource: 'credentials-file' }
+    })
+
+    expect(netFetchMock).not.toHaveBeenCalled()
+    expect(fetchViaPty).not.toHaveBeenCalled()
+  })
+
   it('tries OAuth usage even when local credential metadata is expired', async () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {

--- a/src/main/rate-limits/claude-oauth-credentials.ts
+++ b/src/main/rate-limits/claude-oauth-credentials.ts
@@ -44,7 +44,13 @@ export function parseClaudeOAuthCredentialsJson(
     const oauth = (JSON.parse(raw) as ClaudeCredentials)?.claudeAiOauth
     const hasRefreshableCredentials =
       typeof oauth?.refreshToken === 'string' && oauth.refreshToken.trim() !== ''
-    if (!oauth?.accessToken || typeof oauth.accessToken !== 'string') {
+    // Why: a whitespace-only token is unusable — treat it as absent so the
+    // entry counts as emptied (signed-out) instead of reaching the OAuth path.
+    const accessToken =
+      typeof oauth?.accessToken === 'string' && oauth.accessToken.trim() !== ''
+        ? oauth.accessToken.trim()
+        : null
+    if (accessToken == null) {
       return {
         token: null,
         hasRefreshableCredentials,
@@ -55,7 +61,7 @@ export function parseClaudeOAuthCredentialsJson(
       }
     }
     // Why: expiresAt is not authoritative for the usage endpoint; let the server decide.
-    return { token: oauth.accessToken, hasRefreshableCredentials, source }
+    return { token: accessToken, hasRefreshableCredentials, source }
   } catch {
     return emptyClaudeOAuthCredentialReadResult()
   }

--- a/src/main/rate-limits/claude-oauth-credentials.ts
+++ b/src/main/rate-limits/claude-oauth-credentials.ts
@@ -26,6 +26,9 @@ export type ClaudeOAuthCredentialReadResult = {
   hasRefreshableCredentials: boolean
   source: ClaudeOAuthCredentialSource
   keychainUnavailable?: boolean
+  // Why: a stored entry with blank tokens means signed-out, not
+  // never-configured — the status bar shows a sign-in state instead of hiding.
+  hasEmptyStoredEntry?: boolean
 }
 
 type ClaudeOAuthCredentialReadOptions = {
@@ -42,7 +45,14 @@ export function parseClaudeOAuthCredentialsJson(
     const hasRefreshableCredentials =
       typeof oauth?.refreshToken === 'string' && oauth.refreshToken.trim() !== ''
     if (!oauth?.accessToken || typeof oauth.accessToken !== 'string') {
-      return { token: null, hasRefreshableCredentials, source }
+      return {
+        token: null,
+        hasRefreshableCredentials,
+        source,
+        ...(oauth != null && !hasRefreshableCredentials
+          ? { hasEmptyStoredEntry: true as const }
+          : {})
+      }
     }
     // Why: expiresAt is not authoritative for the usage endpoint; let the server decide.
     return { token: oauth.accessToken, hasRefreshableCredentials, source }
@@ -86,9 +96,10 @@ async function readFromKeychain(configDir?: string): Promise<ClaudeOAuthCredenti
     if (legacy.hasRefreshableCredentials) {
       return legacy
     }
-    return scoped.keychainUnavailable || legacy.keychainUnavailable
-      ? unavailableKeychainResult()
-      : legacy
+    if (scoped.keychainUnavailable || legacy.keychainUnavailable) {
+      return unavailableKeychainResult()
+    }
+    return scoped.hasEmptyStoredEntry ? scoped : legacy
   }
 
   try {
@@ -144,7 +155,16 @@ export async function readClaudeOAuthCredentials(
   if (file.token || file.hasRefreshableCredentials) {
     return file
   }
-  return keychain.keychainUnavailable ? keychain : emptyClaudeOAuthCredentialReadResult()
+  if (keychain.keychainUnavailable) {
+    return keychain
+  }
+  if (keychain.hasEmptyStoredEntry) {
+    return keychain
+  }
+  if (file.hasEmptyStoredEntry) {
+    return file
+  }
+  return emptyClaudeOAuthCredentialReadResult()
 }
 
 export function resolveClaudeOAuthCredentialReadOptions(

--- a/src/main/rate-limits/claude-usage-error-classification.test.ts
+++ b/src/main/rate-limits/claude-usage-error-classification.test.ts
@@ -70,6 +70,20 @@ describe('classifyClaudeCredentialAbsence', () => {
     })
   })
 
+  it('classifies a stored-but-empty entry as signed-out, not missing', () => {
+    expect(
+      classifyClaudeCredentialAbsence({
+        hasRefreshableCredentials: false,
+        hasEmptyStoredEntry: true
+      })
+    ).toMatchObject({
+      failureKind: 'signed-out',
+      shouldAttemptCliFallback: false,
+      shouldAttemptDelegatedRefresh: false,
+      terminal: true
+    })
+  })
+
   it('classifies live Claude ownership as a deferred state', () => {
     expect(
       classifyClaudeCredentialAbsence({

--- a/src/main/rate-limits/claude-usage-error-classification.ts
+++ b/src/main/rate-limits/claude-usage-error-classification.ts
@@ -41,11 +41,15 @@ export function classifyClaudeOAuthUsageError(error: unknown): ClaudeUsageErrorC
 
 export function classifyClaudeCredentialAbsence(input: {
   hasRefreshableCredentials: boolean
+  hasEmptyStoredEntry?: boolean
   keychainUnavailable?: boolean
   managedRefreshDeferredByLivePty?: boolean
 }): ClaudeUsageErrorClassification {
   if (input.managedRefreshDeferredByLivePty) {
     return terminal('deferred-by-live-session')
+  }
+  if (input.hasEmptyStoredEntry) {
+    return terminal('signed-out')
   }
   if (input.keychainUnavailable) {
     return fallbackOnly('keychain-unavailable')

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -259,6 +259,18 @@ describe('getVisibleUsageProvider', () => {
     ).toBe(unavailable)
   })
 
+  it('keeps a signed-out provider visible without any managed account', () => {
+    // Why: an emptied credential store reports status error (not unavailable)
+    // so the bar shows a sign-in state instead of vanishing with no affordance.
+    const signedOut = provider('error', {
+      provider: 'claude',
+      error: 'Claude sign-in expired',
+      usageMetadata: { failureKind: 'signed-out' }
+    })
+
+    expect(getVisibleUsageProvider('claude', signedOut, usageSettings())).toBe(signedOut)
+  })
+
   it('hides providers with no live data or durable configuration', () => {
     expect(getVisibleUsageProvider('codex', null, usageSettings())).toBe(null)
     expect(getVisibleUsageProvider('grok', undefined, usageSettings())).toBe(null)

--- a/src/renderer/src/components/status-bar/usage-error-copy.test.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.test.ts
@@ -4,7 +4,25 @@ vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
 }))
 
-import { getProviderDisplayName } from './usage-error-copy'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import {
+  getProviderDisplayName,
+  getProviderUsageErrorMessage,
+  getProviderUsageStatusLabel
+} from './usage-error-copy'
+
+function claudeError(overrides: Partial<ProviderRateLimits> = {}): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: 'Claude sign-in expired',
+    status: 'error',
+    usageMetadata: { failureKind: 'signed-out' },
+    ...overrides
+  }
+}
 
 describe('getProviderDisplayName', () => {
   it('returns the Antigravity brand name', () => {
@@ -22,6 +40,14 @@ describe('getProviderDisplayName', () => {
     expect(getProviderDisplayName('opencode-go')).toBe('OpenCode Go')
     expect(getProviderDisplayName('kimi')).toBe('Kimi')
     expect(getProviderDisplayName('grok')).toBe('Grok')
+  })
+
+  it('labels a signed-out Claude snapshot as not signed in', () => {
+    expect(getProviderUsageStatusLabel(claudeError())).toBe('not signed in')
+  })
+
+  it('surfaces the signed-out message instead of generic auth copy', () => {
+    expect(getProviderUsageErrorMessage(claudeError())).toBe('Claude sign-in expired')
   })
 
   it('falls back to the raw provider id when no mapping exists', () => {

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -174,6 +174,10 @@ export function getProviderUsageErrorMessage(p: ProviderRateLimits): string {
           'auto.components.status.bar.tooltip.a7517cccb6',
           'Claude usage is unavailable right now.'
         )
+      // Why: the main-process 'Claude sign-in expired' string is intentionally
+      // pattern-safe (matches no auth-error rewrite), so it surfaces verbatim.
+      case 'signed-out':
+        return p.error ?? fallback
       case 'missing-credentials':
       case 'rate-limited':
       case 'unknown':

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -85,6 +85,8 @@ export function getProviderUsageStatusLabel(p: ProviderRateLimits): string {
   }
   if (p.provider === 'claude') {
     switch (p.usageMetadata?.failureKind) {
+      case 'signed-out':
+        return translate('auto.components.status.bar.UsageRosterPanel.notSignedIn', 'not signed in')
       case 'deferred-by-live-session':
         return translate(
           'auto.components.status.bar.tooltip.0d8d7cfe15',

--- a/src/renderer/src/components/status-bar/usage-roster-row-state.test.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-row-state.test.ts
@@ -60,6 +60,16 @@ describe('getUsageRosterRowState', () => {
     expect(
       getUsageRosterRowState(
         provider({
+          status: 'error',
+          error: 'Claude sign-in expired',
+          usageMetadata: { failureKind: 'signed-out' }
+        }),
+        false
+      )
+    ).toEqual({ kind: 'sign-in', statusLabel: 'not signed in' })
+    expect(
+      getUsageRosterRowState(
+        provider({
           provider: 'codex',
           status: 'error',
           error: 'ChatGPT authentication required to read rate limits'

--- a/src/renderer/src/components/status-bar/usage-roster-row-state.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-row-state.ts
@@ -18,7 +18,10 @@ const CONFIRMED_SIGN_OUT_PATTERNS = [
 ]
 
 function isConfirmedSignedOut(provider: ProviderRateLimits): boolean {
-  if (provider.usageMetadata?.failureKind === 'missing-credentials') {
+  if (
+    provider.usageMetadata?.failureKind === 'missing-credentials' ||
+    provider.usageMetadata?.failureKind === 'signed-out'
+  ) {
     return true
   }
   // Why: credential refresh and network failures can mention auth while live

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -19,6 +19,9 @@ export type UsageRateLimitSource = 'oauth' | 'cli' | 'web' | 'live-session'
 
 export type UsageRateLimitFailureKind =
   | 'missing-credentials'
+  // Why: a stored-but-empty credential entry proves the CLI was set up and
+  // lost its tokens (signed out), unlike never-configured (hide the bar).
+  | 'signed-out'
   | 'stale-token'
   | 'refreshable-credentials-without-token'
   | 'delegated-refresh-required'


### PR DESCRIPTION
## ELI5

When your Claude sign-in quietly expires, Orca's status bar used to just delete the Claude usage meter with no explanation. Now it keeps the meter and says "not signed in", with the usual sign-in button in the usage popover.

## What Changed

- `src/main/rate-limits/claude-oauth-credentials.ts`: credential reads now report `hasEmptyStoredEntry` when the Keychain item / credentials file parses but holds no usable tokens (previously this collapsed into "no credentials at all").
- `src/main/rate-limits/claude-usage-error-classification.ts`: that state classifies as a new terminal `signed-out` failure kind.
- `src/main/rate-limits/claude-active-usage-fetch.ts`: the no-credentials fallback returns status `error` (`Claude sign-in expired`) for `signed-out` instead of `unavailable`, so existing visibility logic keeps the segment rendered. Truly-never-configured setups still return `unavailable` and stay hidden.
- `src/shared/rate-limit-types.ts`: added `'signed-out'` to `UsageRateLimitFailureKind`.
- `src/renderer/src/components/status-bar/usage-error-copy.ts`: signed-out Claude labels as "not signed in" (reuses the existing roster key, no new strings).
- `src/renderer/src/components/status-bar/usage-roster-row-state.ts`: `signed-out` earns the sign-in CTA row, which opens Settings → Accounts.

## Why

`unavailable` is the one snapshot status that hides a status-bar segment entirely (by design, for never-configured providers). An emptied credential store was misreported as `unavailable`/`missing-credentials`, so users with a checked "Claude Usage" toggle and a seemingly-connected account got a silently vanishing meter and no path to recovery. `error` snapshots stay visible by design (same convention as Grok's "sign-in expired"), so mapping signed-out to `error` restores the affordance with minimal new machinery.

## Linked Issue

Fixes #20118

## Visual Proof

No screenshots attached: this was developed in a headless Linux worktree and the affected surface is the desktop status bar. Verified instead via unit tests covering the full chain (empty-store fetch result → visibility gate → segment label → roster sign-in row) plus the live `unavailable` snapshot captured while diagnosing #20118. Happy to attach macOS before/after shots on request.

## Testing

- [x] Reproduced from live app state first (`rateLimits.claude`: `unavailable`/`missing-credentials`/`credentialSource: 'none'` with an existing-but-empty Keychain entry), then added regression tests:
  - fetch-level: empty-token Keychain entry and empty-token credentials file both yield `error`/`signed-out` with no network or PTY calls
  - classification, visibility gate, segment label/message, roster sign-in row
- [ ] I manually tested these changes locally (headless worktree — see Visual Proof)
- [x] Automated tests added
- Platforms actually tested: Linux (unit/typecheck/build). Logic is platform-agnostic (no new platform branches; Keychain path unchanged and still darwin-guarded; file path uses existing joins). SSH/remote: snapshot keeps its `authProvenance`; no new host assumptions. Complements (does not touch) open #6828, which covers re-auth for managed accounts — this covers system-default.

## AI Disclosure

Implemented with Muse Spark via the Pi coding agent under the author's direction; diagnosis verified against live app state on the author's Mac.

## Review

Self-review (AI agent): cross-platform safe (no new OS branches, paths, or shortcuts); SSH/remote safe (provenance preserved, generic message with no host-specific command); provider-scoped to Claude (other providers' `failureKind` switches have fallthrough defaults; service policies only special-case `rate-limited`); no perf impact (parse-time boolean, and the error streak feeds the existing poll backoff); no security impact (no secrets read differently or logged — the existing warn log already emits only booleans/source names).

## Agent skill upstream boundary

- [x] Not applicable — no skill sources copied or translated.

## Notes

Security, cross-platform (Linux/Windows/Mac), remote SSH, backwards compatibility, and performance considered above; mobile untouched (shared union addition only, no mobile consumers of the new kind).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason (see Visual Proof)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint` (changed-code quality gate: 0 findings), `pnpm typecheck`, `pnpm test`, and `pnpm build` pass locally
