### PR TITLE
fix(sidebar): keep fallback worktree cards provisional until the scan lands

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
@@ -1,0 +1,228 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import React, { type ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { Repo } from '../../../../shared/repo-types'
+import type { WorktreeCardProperty } from '../../../../shared/ui-chrome-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+let worktreeCardProperties: WorktreeCardProperty[] = ['status', 'branch']
+let settings: Partial<GlobalSettings> | null = { experimentalNewWorktreeCardStyle: true }
+let detectedWorktreesByRepo: Record<string, unknown> = {}
+let startupWorktreeRefreshCompleted = false
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      agentActivityDisplayMode: undefined,
+      browserTabsByWorktree: {},
+      createBrowserTab: vi.fn(),
+      deleteStateByWorktreeId: {},
+      detectedWorktreesByRepo,
+      fetchHostedReviewForBranch: vi.fn(),
+      fetchIssue: vi.fn(),
+      fetchLinearIssue: vi.fn(),
+      gitConflictOperationByWorktree: {},
+      hostedReviewCache: {},
+      issueCache: {},
+      linearIssueCache: {},
+      openModal: vi.fn(),
+      openTaskPage: vi.fn(),
+      projectGroups: [],
+      ptyIdsByTabId: {},
+      recordFeatureInteraction: vi.fn(),
+      remoteBranchConflictByWorktreeId: {},
+      replaceWorkspacePortScans: vi.fn(),
+      setRemoteBrowserPageHandle: vi.fn(),
+      setWorkspacePortScanRefreshing: vi.fn(),
+      settings,
+      sshConnectionStates: new Map(),
+      sshTargetLabels: new Map(),
+      startupWorktreeRefreshCompleted,
+      tabsByWorktree: {},
+      updateWorktreeMeta: vi.fn(),
+      workspacePortScan: null,
+      worktreeCardProperties
+    })
+}))
+
+vi.mock('@/components/ui/hover-card', () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  HoverCardContent: ({ children }: { children: ReactNode }) => (
+    <div data-hover-card-content="">{children}</div>
+  ),
+  HoverCardTrigger: ({ children }: { children: ReactNode }) =>
+    React.isValidElement(children) ? (
+      React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+        'data-hover-card-trigger': ''
+      })
+    ) : (
+      <>{children}</>
+    )
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/lib/sidebar-worktree-activation', () => ({
+  activateWorktreeFromSidebar: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  getActiveRuntimeTarget: () => ({ kind: 'local' })
+}))
+
+vi.mock('./use-worktree-activity-status', () => ({
+  useWorktreeActivityStatus: () => 'active'
+}))
+
+vi.mock('./CacheTimer', () => ({
+  default: () => null,
+  usePromptCacheCountdownStartedAt: vi.fn(() => null)
+}))
+
+vi.mock('./useWorktreeAgentRows', () => ({
+  useWorktreeAgentRows: vi.fn(() => [])
+}))
+
+vi.mock('./WorktreeCardAgents', () => ({
+  default: () => <div data-worktree-agents="" />
+}))
+
+vi.mock('./WorktreeContextMenu', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+  CLOSE_ALL_CONTEXT_MENUS_EVENT: 'orca:test-close-context-menus',
+  WORKTREE_CONTEXT_MENU_SCOPE_ATTR: 'data-orca-context-menu-scope',
+  WORKTREE_NATIVE_CONTEXT_MENU_ATTR: 'data-worktree-native-context-menu'
+}))
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'orca',
+    badgeColor: '#999999',
+    addedAt: 1,
+    ...overrides
+  }
+}
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'repo-1::/repo/worktrees/main',
+    repoId: 'repo-1',
+    path: '/repo/worktrees/main',
+    displayName: 'main',
+    branch: 'main',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    ...overrides
+  }
+}
+
+function makeDetected(authoritative: boolean): unknown {
+  return {
+    repoId: 'repo-1',
+    authoritative,
+    source: authoritative ? 'git' : 'metadata-fallback',
+    worktrees: []
+  }
+}
+
+function getInlineRenameTitleTag(markup: string): string {
+  const match = markup.match(/<span[^>]*data-worktree-title-inline-rename=""[^>]*>/)
+  expect(match).not.toBeNull()
+  return match?.[0] ?? ''
+}
+
+function getCardSurfaceTag(markup: string): string {
+  const match = markup.match(/<div[^>]*data-worktree-card-surface="true"[^>]*>/)
+  expect(match).not.toBeNull()
+  return match?.[0] ?? ''
+}
+
+async function renderCard(overrides: Partial<Worktree> = {}, repo: Repo = makeRepo()) {
+  const { default: WorktreeCard } = await import('./WorktreeCard')
+  return renderToStaticMarkup(
+    <WorktreeCard worktree={makeWorktree(overrides)} repo={repo} isActive={false} />
+  )
+}
+
+describe('WorktreeCard provisional startup rows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    worktreeCardProperties = ['status', 'branch']
+    settings = { experimentalNewWorktreeCardStyle: true }
+    detectedWorktreesByRepo = { 'repo-1': makeDetected(false) }
+    startupWorktreeRefreshCompleted = false
+  })
+
+  it('dims the title and reserves the identity row while the catalog is a fallback', async () => {
+    // A synthesized fallback row carries no head either; a detached badge is not its shape.
+    const markup = await renderCard({ displayName: 'hetzner-vps', branch: '', head: '' })
+
+    expect(markup).toContain('data-worktree-card-meta-row=""')
+    expect(markup).toContain('data-worktree-card-identity-placeholder=""')
+    expect(markup).toContain('animate-pulse')
+    expect(markup).toContain('motion-reduce:animate-none')
+    expect(getInlineRenameTitleTag(markup)).toContain('text-muted-foreground')
+    // A reserved identity row keeps the settled card padding instead of the title-only `py-2`.
+    expect(getCardSurfaceTag(markup)).toContain('pt-1.25')
+    expect(getCardSurfaceTag(markup)).not.toContain('py-2')
+  })
+
+  it('renders the settled card once the scan is authoritative', async () => {
+    detectedWorktreesByRepo = { 'repo-1': makeDetected(true) }
+    const markup = await renderCard({ displayName: 'main', branch: 'main' })
+
+    expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
+    expect(getInlineRenameTitleTag(markup)).not.toContain('text-muted-foreground')
+    expect(markup).toContain('data-worktree-card-meta-row=""')
+  })
+
+  it('settles after startup completes even when the catalog stays non-authoritative', async () => {
+    startupWorktreeRefreshCompleted = true
+    const markup = await renderCard({ displayName: 'hetzner-vps', branch: '' })
+
+    expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
+    expect(getInlineRenameTitleTag(markup)).not.toContain('text-muted-foreground')
+  })
+
+  it('leaves the legacy card style untouched', async () => {
+    settings = { experimentalNewWorktreeCardStyle: false, compactWorktreeCards: false }
+    const markup = await renderCard({ displayName: 'hetzner-vps', branch: '' })
+
+    expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
+    expect(getInlineRenameTitleTag(markup)).not.toContain('text-muted-foreground')
+  })
+
+  it('does not reserve an identity row when the fallback row already has meta content', async () => {
+    // Detached-head rows keep their real badge instead of a placeholder.
+    const markup = await renderCard({ displayName: 'hetzner-vps', branch: '', head: 'abc123' })
+
+    expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
+    expect(markup).toContain('Detached HEAD')
+  })
+
+  it('does not reserve an identity row for folder workspaces', async () => {
+    const markup = await renderCard(
+      { id: 'repo-1::/repo/folder', path: '/repo/folder', displayName: 'Folder', branch: '' },
+      makeRepo({ kind: 'folder' })
+    )
+
+    expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
@@ -233,6 +233,36 @@ describe('WorktreeCard provisional startup rows', () => {
     expect(markup).toContain('live-branch')
   })
 
+  it('holds rows that carry no git evidence even when the catalog reads authoritative', async () => {
+    // Appended fallback rows inherit a settled repo-level flag by design, so the row
+    // itself has to prove it was scanned. #20119
+    detectedWorktreesByRepo = { 'repo-1': makeDetected(true) }
+    const markup = await renderCard({
+      displayName: 'hetzner-vps',
+      branch: '',
+      head: '',
+      displayNameMode: 'automatic'
+    })
+
+    expect(markup).toContain('data-worktree-card-title-placeholder=""')
+    expect(markup).toContain('data-worktree-card-identity-placeholder=""')
+  })
+
+  it('leaves bare checkouts settled since they can never resolve a branch', async () => {
+    detectedWorktreesByRepo = { 'repo-1': makeDetected(true) }
+    const markup = await renderCard({
+      displayName: 'bare-repo',
+      branch: '',
+      head: '',
+      isBare: true,
+      displayNameMode: 'automatic'
+    })
+
+    expect(markup).not.toContain('data-worktree-card-title-placeholder=""')
+    expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
+    expect(getInlineRenameTitleText(markup)).toContain('bare-repo')
+  })
+
   it('reserves the identity slot alongside existing host meta', async () => {
     const markup = await renderCard(
       { displayName: 'hetzner-vps', branch: '', head: '', displayNameMode: 'automatic' },

--- a/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
@@ -142,10 +142,9 @@ function makeDetected(authoritative: boolean): unknown {
   }
 }
 
-function getInlineRenameTitleTag(markup: string): string {
-  const match = markup.match(/<span[^>]*data-worktree-title-inline-rename=""[^>]*>/)
-  expect(match).not.toBeNull()
-  return match?.[0] ?? ''
+function getInlineRenameTitleText(markup: string): string {
+  const match = markup.match(/<span[^>]*data-worktree-title-inline-rename=""[^>]*>([^<]*)</)
+  return match?.[1] ?? ''
 }
 
 function getCardSurfaceTag(markup: string): string {
@@ -154,10 +153,14 @@ function getCardSurfaceTag(markup: string): string {
   return match?.[0] ?? ''
 }
 
-async function renderCard(overrides: Partial<Worktree> = {}, repo: Repo = makeRepo()) {
+async function renderCard(
+  overrides: Partial<Worktree> = {},
+  repo: Repo = makeRepo(),
+  cardProps: { hostContextLabel?: string } = {}
+) {
   const { default: WorktreeCard } = await import('./WorktreeCard')
   return renderToStaticMarkup(
-    <WorktreeCard worktree={makeWorktree(overrides)} repo={repo} isActive={false} />
+    <WorktreeCard worktree={makeWorktree(overrides)} repo={repo} isActive={false} {...cardProps} />
   )
 }
 
@@ -170,59 +173,122 @@ describe('WorktreeCard provisional startup rows', () => {
     startupWorktreeRefreshCompleted = false
   })
 
-  it('dims the title and reserves the identity row while the catalog is a fallback', async () => {
+  it('holds the auto title and reserves the identity row while the catalog is a fallback', async () => {
     // A synthesized fallback row carries no head either; a detached badge is not its shape.
-    const markup = await renderCard({ displayName: 'hetzner-vps', branch: '', head: '' })
+    const markup = await renderCard({
+      displayName: 'hetzner-vps',
+      branch: '',
+      head: '',
+      displayNameMode: 'automatic'
+    })
 
     expect(markup).toContain('data-worktree-card-meta-row=""')
+    expect(markup).toContain('data-worktree-card-title-placeholder=""')
     expect(markup).toContain('data-worktree-card-identity-placeholder=""')
+    // The hover popover may still echo the persisted name; the card title must not.
+    expect(markup.split('data-hover-card-content')[0]).not.toContain(
+      'data-worktree-title-inline-rename='
+    )
     expect(markup).toContain('animate-pulse')
     expect(markup).toContain('motion-reduce:animate-none')
-    expect(getInlineRenameTitleTag(markup)).toContain('text-muted-foreground')
     // A reserved identity row keeps the settled card padding instead of the title-only `py-2`.
     expect(getCardSurfaceTag(markup)).toContain('pt-1.25')
     expect(getCardSurfaceTag(markup)).not.toContain('py-2')
   })
 
+  it('reserves the identity slot alongside existing host meta', async () => {
+    const markup = await renderCard(
+      { displayName: 'hetzner-vps', branch: '', head: '', displayNameMode: 'automatic' },
+      makeRepo(),
+      { hostContextLabel: 'Hetzner VPS' }
+    )
+
+    expect(markup).toContain('Hetzner VPS')
+    expect(markup).toContain('data-worktree-card-identity-placeholder=""')
+  })
+
+  it('keeps an explicit fixed label visible while reserving the identity slot', async () => {
+    const markup = await renderCard({
+      displayName: 'Fixed label',
+      branch: '',
+      head: '',
+      displayNameMode: 'fixed'
+    })
+
+    expect(markup).not.toContain('data-worktree-card-title-placeholder=""')
+    expect(getInlineRenameTitleText(markup)).toContain('Fixed label')
+    expect(markup).toContain('data-worktree-card-identity-placeholder=""')
+  })
+
   it('renders the settled card once the scan is authoritative', async () => {
     detectedWorktreesByRepo = { 'repo-1': makeDetected(true) }
-    const markup = await renderCard({ displayName: 'main', branch: 'main' })
+    const markup = await renderCard({
+      displayName: 'main',
+      branch: 'main',
+      displayNameMode: 'automatic'
+    })
 
     expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
-    expect(getInlineRenameTitleTag(markup)).not.toContain('text-muted-foreground')
+    expect(markup).not.toContain('data-worktree-card-title-placeholder=""')
+    expect(getInlineRenameTitleText(markup)).toContain('main')
     expect(markup).toContain('data-worktree-card-meta-row=""')
   })
 
   it('settles after startup completes even when the catalog stays non-authoritative', async () => {
     startupWorktreeRefreshCompleted = true
-    const markup = await renderCard({ displayName: 'hetzner-vps', branch: '' })
+    const markup = await renderCard({
+      displayName: 'hetzner-vps',
+      branch: '',
+      head: '',
+      displayNameMode: 'automatic'
+    })
 
     expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
-    expect(getInlineRenameTitleTag(markup)).not.toContain('text-muted-foreground')
+    expect(markup).not.toContain('data-worktree-card-title-placeholder=""')
+    expect(getInlineRenameTitleText(markup)).toContain('hetzner-vps')
   })
 
   it('leaves the legacy card style untouched', async () => {
     settings = { experimentalNewWorktreeCardStyle: false, compactWorktreeCards: false }
-    const markup = await renderCard({ displayName: 'hetzner-vps', branch: '' })
+    const markup = await renderCard({
+      displayName: 'hetzner-vps',
+      branch: '',
+      head: '',
+      displayNameMode: 'automatic'
+    })
 
     expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
-    expect(getInlineRenameTitleTag(markup)).not.toContain('text-muted-foreground')
+    expect(markup).not.toContain('data-worktree-card-title-placeholder=""')
+    expect(getInlineRenameTitleText(markup)).toContain('hetzner-vps')
   })
 
-  it('does not reserve an identity row when the fallback row already has meta content', async () => {
-    // Detached-head rows keep their real badge instead of a placeholder.
-    const markup = await renderCard({ displayName: 'hetzner-vps', branch: '', head: 'abc123' })
+  it('keeps a real detached badge instead of an identity placeholder', async () => {
+    const markup = await renderCard({
+      displayName: 'hetzner-vps',
+      branch: '',
+      head: 'abc123',
+      displayNameMode: 'automatic'
+    })
 
     expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
     expect(markup).toContain('Detached HEAD')
+    expect(markup).toContain('data-worktree-card-title-placeholder=""')
   })
 
   it('does not reserve an identity row for folder workspaces', async () => {
     const markup = await renderCard(
-      { id: 'repo-1::/repo/folder', path: '/repo/folder', displayName: 'Folder', branch: '' },
+      {
+        id: 'repo-1::/repo/folder',
+        path: '/repo/folder',
+        displayName: 'Folder',
+        branch: '',
+        head: '',
+        displayNameMode: 'automatic'
+      },
       makeRepo({ kind: 'folder' })
     )
 
     expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
+    expect(markup).not.toContain('data-worktree-card-title-placeholder=""')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
@@ -210,6 +210,13 @@ describe('WorktreeCard provisional startup rows', () => {
     expect(markup).not.toContain('data-worktree-card-meta-row=""')
   })
 
+  it('holds the title for legacy rows with an omitted display name mode', async () => {
+    // Older-host merge rows can carry no mode at all while still being automatic labels.
+    const markup = await renderCard({ displayName: 'hetzner-vps', branch: '', head: '' })
+
+    expect(markup).toContain('data-worktree-card-title-placeholder=""')
+  })
+
   it('reserves the identity slot alongside existing host meta', async () => {
     const markup = await renderCard(
       { displayName: 'hetzner-vps', branch: '', head: '', displayNameMode: 'automatic' },

--- a/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
@@ -217,6 +217,22 @@ describe('WorktreeCard provisional startup rows', () => {
     expect(markup).toContain('data-worktree-card-title-placeholder=""')
   })
 
+  it('renders real identity and title for cached rows that already resolved a branch', async () => {
+    // A non-authoritative catalog can coexist with richer cached rows that already carry
+    // a branch; those are settled data and must not be masked. #20119
+    const markup = await renderCard({
+      displayName: 'Live feature',
+      branch: 'live-branch',
+      head: 'abc123',
+      displayNameMode: 'automatic'
+    })
+
+    expect(markup).not.toContain('data-worktree-card-title-placeholder=""')
+    expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
+    expect(getInlineRenameTitleText(markup)).toContain('Live feature')
+    expect(markup).toContain('live-branch')
+  })
+
   it('reserves the identity slot alongside existing host meta', async () => {
     const markup = await renderCard(
       { displayName: 'hetzner-vps', branch: '', head: '', displayNameMode: 'automatic' },

--- a/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.provisional-startup.test.tsx
@@ -196,6 +196,20 @@ describe('WorktreeCard provisional startup rows', () => {
     expect(getCardSurfaceTag(markup)).not.toContain('py-2')
   })
 
+  it('skips the identity slot but still holds the title when the branch display is off', async () => {
+    worktreeCardProperties = ['status']
+    const markup = await renderCard({
+      displayName: 'hetzner-vps',
+      branch: '',
+      head: '',
+      displayNameMode: 'automatic'
+    })
+
+    expect(markup).not.toContain('data-worktree-card-identity-placeholder=""')
+    expect(markup).toContain('data-worktree-card-title-placeholder=""')
+    expect(markup).not.toContain('data-worktree-card-meta-row=""')
+  })
+
   it('reserves the identity slot alongside existing host meta', async () => {
     const markup = await renderCard(
       { displayName: 'hetzner-vps', branch: '', head: '', displayNameMode: 'automatic' },

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
@@ -42,6 +42,12 @@ export function useWorktreeCardFoundation({
   const projectGroups = useAppStore((s) => s.projectGroups)
   const newCardStyle = settings?.experimentalNewWorktreeCardStyle === true
   const compactCards = !newCardStyle && settings?.compactWorktreeCards === true
+  // Why: a non-authoritative catalog is a metadata fallback (remote/SSH before its scan
+  // lands), so its rows are placeholders, not settled answers. #20119
+  const provisionalWorktreeCatalog = useAppStore((s) => {
+    const detected = s.detectedWorktreesByRepo?.[worktree.repoId]
+    return detected?.authoritative === false && s.startupWorktreeRefreshCompleted !== true
+  })
   const handleEditIssue = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -209,6 +215,7 @@ export function useWorktreeCardFoundation({
     agentActivityDisplayMode,
     projectGroups,
     newCardStyle,
+    provisionalWorktreeCatalog,
     compactCards,
     handleEditIssue,
     handleEditComment,

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
@@ -43,10 +43,19 @@ export function useWorktreeCardFoundation({
   const newCardStyle = settings?.experimentalNewWorktreeCardStyle === true
   const compactCards = !newCardStyle && settings?.compactWorktreeCards === true
   // Why: a non-authoritative catalog is a metadata fallback (remote/SSH before its scan
-  // lands), so its rows are placeholders, not settled answers. #20119
+  // lands), so its rows are placeholders, not settled answers. A row with no git evidence
+  // at all is unscanned even when its repo-level entry reads authoritative, because appended
+  // fallback rows inherit the flag by design — while bare checkouts can never resolve a
+  // branch, so they are always settled. #20119
   const provisionalWorktreeCatalog = useAppStore((s) => {
+    if (s.startupWorktreeRefreshCompleted === true) {
+      return false
+    }
     const detected = s.detectedWorktreesByRepo?.[worktree.repoId]
-    return detected?.authoritative === false && s.startupWorktreeRefreshCompleted !== true
+    if (detected?.authoritative === false) {
+      return true
+    }
+    return !worktree.branch && !worktree.head && !worktree.isBare
   })
   const handleEditIssue = useCallback(
     (e: React.MouseEvent) => {

--- a/src/renderer/src/components/sidebar/worktree-card-header.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-header.tsx
@@ -87,7 +87,7 @@ export function WorktreeCardHeader({
     showTitleRowIndicators,
     titleRowIndicators,
     titleWrapper,
-    showProvisionalCardTreatment
+    titleIsProvisional
   } = presentation
 
   return (
@@ -168,25 +168,32 @@ export function WorktreeCardHeader({
         )}
 
         {/* Why: unread alert lives in the left status lane; title-row contrast comes from weight and dimmed read titles. */}
-        <WorktreeTitleInlineRename
-          displayName={visibleCardTitle}
-          disabled={isDeleting || affiliateListMode}
-          showUnreadEmphasis={showUnreadEmphasis}
-          dimReadTitle={newCardStyle}
-          className={cn(
-            'text-[13px] leading-5',
-            showProvisionalCardTreatment && 'text-muted-foreground'
-          )}
-          editingClassName="flex-1"
-          titleWrapper={titleWrapper}
-          onEditingChange={affiliateListMode ? undefined : setTitleRenaming}
-          onRename={handleRenameTitle}
-          beginEditing={
-            !affiliateListMode &&
-            shouldBeginWorktreeRename(renamingWorktreeId, worktree.id, renameRowKey)
-          }
-          onBeginEditingConsumed={affiliateListMode ? undefined : () => setRenamingWorktreeId(null)}
-        />
+        {titleIsProvisional ? (
+          <span
+            data-worktree-card-title-placeholder=""
+            aria-hidden="true"
+            className="h-3.5 w-24 shrink-0 animate-pulse rounded-sm bg-muted-foreground/20 motion-reduce:animate-none"
+          />
+        ) : (
+          <WorktreeTitleInlineRename
+            displayName={visibleCardTitle}
+            disabled={isDeleting || affiliateListMode}
+            showUnreadEmphasis={showUnreadEmphasis}
+            dimReadTitle={newCardStyle}
+            className="text-[13px] leading-5"
+            editingClassName="flex-1"
+            titleWrapper={titleWrapper}
+            onEditingChange={affiliateListMode ? undefined : setTitleRenaming}
+            onRename={handleRenameTitle}
+            beginEditing={
+              !affiliateListMode &&
+              shouldBeginWorktreeRename(renamingWorktreeId, worktree.id, renameRowKey)
+            }
+            onBeginEditingConsumed={
+              affiliateListMode ? undefined : () => setRenamingWorktreeId(null)
+            }
+          />
+        )}
 
         {typeof worktree.firstAgentMessageRenameError === 'string' &&
         worktree.firstAgentMessageRenameError.length > 0 &&

--- a/src/renderer/src/components/sidebar/worktree-card-header.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-header.tsx
@@ -86,7 +86,8 @@ export function WorktreeCardHeader({
     showDeleteQuickAction,
     showTitleRowIndicators,
     titleRowIndicators,
-    titleWrapper
+    titleWrapper,
+    showProvisionalCardTreatment
   } = presentation
 
   return (
@@ -172,7 +173,10 @@ export function WorktreeCardHeader({
           disabled={isDeleting || affiliateListMode}
           showUnreadEmphasis={showUnreadEmphasis}
           dimReadTitle={newCardStyle}
-          className="text-[13px] leading-5"
+          className={cn(
+            'text-[13px] leading-5',
+            showProvisionalCardTreatment && 'text-muted-foreground'
+          )}
           editingClassName="flex-1"
           titleWrapper={titleWrapper}
           onEditingChange={affiliateListMode ? undefined : setTitleRenaming}

--- a/src/renderer/src/components/sidebar/worktree-card-meta-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-meta-row.tsx
@@ -35,6 +35,7 @@ export function WorktreeCardMetaRow({
     showRepoBadgeInMetaRow,
     showHostContextBadge,
     showIdentityInNewCard,
+    reserveProvisionalIdentityRow,
     hasHoverDetails,
     showBranch,
     showDetachedHeadInMetaRow,
@@ -64,7 +65,13 @@ export function WorktreeCardMetaRow({
           </Badge>
         )}
 
-        {showIdentityInNewCard ? (
+        {reserveProvisionalIdentityRow ? (
+          <span
+            data-worktree-card-identity-placeholder=""
+            aria-hidden="true"
+            className="h-3 w-24 shrink-0 animate-pulse rounded-sm bg-muted-foreground/20 motion-reduce:animate-none"
+          />
+        ) : showIdentityInNewCard ? (
           <TruncatedSidebarLabel
             text={identityDisplay!}
             className="text-[11px] text-muted-foreground leading-none"

--- a/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
@@ -119,9 +119,11 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
   const reserveProvisionalIdentityRow =
     showProvisionalCardTreatment && detachedHeadDisplay === null && cardProps.includes('branch')
   // Why: an automatic name is branch-derived upstream, so showing the fallback basename would
-  // change under the user; hold the title slot until the scan resolves it. #20119
+  // change under the user; hold the title slot until the scan resolves it. An omitted mode is
+  // legacy rows that predate the field and behave as automatic. #20119
   const titleIsProvisional =
-    showProvisionalCardTreatment && worktree.displayNameMode === 'automatic'
+    showProvisionalCardTreatment &&
+    (worktree.displayNameMode === undefined || worktree.displayNameMode === 'automatic')
   const hasMetaRow = baseHasMetaRow || reserveProvisionalIdentityRow
   const showHeaderActions = showTitleRowPrimary || showDeleteQuickAction
   // Why: normalize the title once so title/branch de-dupe and identity-only hover eligibility stay in sync.

--- a/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
@@ -110,10 +110,14 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
   const baseHasMetaRow = compactCards
     ? hasMetadataBadge || cacheStartedAt != null
     : hasDetailedMetaRowContent
-  // Why: a provisional row has no branch identity yet; keep the settled silhouette and
-  // leave the identity slot blank so the scan only fills it in. #20119
+  // Why: a provisional row has no branch identity yet; keep the settled silhouette while the
+  // scan fills the identity slot, even when other meta (host badge) already occupies the row. #20119
   const showProvisionalCardTreatment = provisionalWorktreeCatalog && newCardStyle && !isFolder
-  const reserveProvisionalIdentityRow = showProvisionalCardTreatment && !baseHasMetaRow
+  const reserveProvisionalIdentityRow = showProvisionalCardTreatment && detachedHeadDisplay === null
+  // Why: an automatic name is branch-derived upstream, so showing the fallback basename would
+  // change under the user; hold the title slot until the scan resolves it. #20119
+  const titleIsProvisional =
+    showProvisionalCardTreatment && worktree.displayNameMode === 'automatic'
   const hasMetaRow = baseHasMetaRow || reserveProvisionalIdentityRow
   const showHeaderActions = showTitleRowPrimary || showDeleteQuickAction
   // Why: normalize the title once so title/branch de-dupe and identity-only hover eligibility stay in sync.
@@ -282,7 +286,7 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
     showMetaRowDetails,
     showTitleRowIndicators,
     hasMetaRow,
-    showProvisionalCardTreatment,
+    titleIsProvisional,
     reserveProvisionalIdentityRow,
     showHeaderActions,
     showDeleteQuickAction,

--- a/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
@@ -113,7 +113,11 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
   // Why: a provisional row has no branch identity yet; keep the settled silhouette while the
   // scan fills the identity slot, even when other meta (host badge) already occupies the row. #20119
   const showProvisionalCardTreatment = provisionalWorktreeCatalog && newCardStyle && !isFolder
-  const reserveProvisionalIdentityRow = showProvisionalCardTreatment && detachedHeadDisplay === null
+  // Why: only reserve a slot the scan will actually fill. Without the branch card property
+  // the identity row never renders and the placeholder would vanish into nothing.
+  // Mirrors showIdentityInNewCard's hasPathIdentityEnabled gate. #20119
+  const reserveProvisionalIdentityRow =
+    showProvisionalCardTreatment && detachedHeadDisplay === null && cardProps.includes('branch')
   // Why: an automatic name is branch-derived upstream, so showing the fallback basename would
   // change under the user; hold the title slot until the scan resolves it. #20119
   const titleIsProvisional =

--- a/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
@@ -117,12 +117,18 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
   // the identity row never renders and the placeholder would vanish into nothing.
   // Mirrors showIdentityInNewCard's hasPathIdentityEnabled gate. #20119
   const reserveProvisionalIdentityRow =
-    showProvisionalCardTreatment && detachedHeadDisplay === null && cardProps.includes('branch')
+    showProvisionalCardTreatment &&
+    !identityDisplay &&
+    detachedHeadDisplay === null &&
+    cardProps.includes('branch')
   // Why: an automatic name is branch-derived upstream, so showing the fallback basename would
   // change under the user; hold the title slot until the scan resolves it. An omitted mode is
-  // legacy rows that predate the field and behave as automatic. #20119
+  // legacy rows that predate the field and behave as automatic. A row that already resolves
+  // its own identity (a richer cached SSH row alongside a non-authoritative catalog) is
+  // settled data, so it must not be masked. #20119
   const titleIsProvisional =
     showProvisionalCardTreatment &&
+    !identityDisplay &&
     (worktree.displayNameMode === undefined || worktree.displayNameMode === 'automatic')
   const hasMetaRow = baseHasMetaRow || reserveProvisionalIdentityRow
   const showHeaderActions = showTitleRowPrimary || showDeleteQuickAction

--- a/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
@@ -23,6 +23,7 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
     flushSurface,
     contentIndent,
     newCardStyle,
+    provisionalWorktreeCatalog,
     compactCards,
     isFolder,
     detachedHeadDisplay,
@@ -106,9 +107,14 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
     cacheStartedAt != null ||
     showMetaRowDetails
   )
-  const hasMetaRow = compactCards
+  const baseHasMetaRow = compactCards
     ? hasMetadataBadge || cacheStartedAt != null
     : hasDetailedMetaRowContent
+  // Why: a provisional row has no branch identity yet; keep the settled silhouette and
+  // leave the identity slot blank so the scan only fills it in. #20119
+  const showProvisionalCardTreatment = provisionalWorktreeCatalog && newCardStyle && !isFolder
+  const reserveProvisionalIdentityRow = showProvisionalCardTreatment && !baseHasMetaRow
+  const hasMetaRow = baseHasMetaRow || reserveProvisionalIdentityRow
   const showHeaderActions = showTitleRowPrimary || showDeleteQuickAction
   // Why: normalize the title once so title/branch de-dupe and identity-only hover eligibility stay in sync.
   const trimmedVisibleCardTitle = visibleCardTitle.trim()
@@ -276,6 +282,8 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
     showMetaRowDetails,
     showTitleRowIndicators,
     hasMetaRow,
+    showProvisionalCardTreatment,
+    reserveProvisionalIdentityRow,
     showHeaderActions,
     showDeleteQuickAction,
     hoverBranchName,


### PR DESCRIPTION
## What this fixes

On cold launch against remote hosts, the sidebar's worktree cards first painted from the repo's **non-authoritative metadata-fallback catalog** (remote/SSH before its scan lands): an automatic title fell back to the directory basename (`hetzner-vps`), and there was no branch identity. A few seconds later the scan replaced the row and the card visibly changed — title became the branch-derived name (`main`), identity and metadata rows appeared. With **New card style** on this read as the setting not applying until loading finished.

The card was rendering unknown state as a settled answer. This keeps provisional rows visibly provisional and reveals their real title/identity once, when the scan lands.

Fixes #20119

## What changed

- `useWorktreeCardFoundation` exposes `provisionalWorktreeCatalog`: true while the repo's detected catalog is non-authoritative and `startupWorktreeRefreshCompleted` is still false.
- In the new card style (non-folder rows), a provisional card:
  - **holds an automatic title** (the branch-derived display name) behind a placeholder, so a basename never appears and then changes; an explicit fixed label stays visible, and
  - **reserves the identity slot** with a small pulse placeholder — including when the row already shows other meta such as the host badge, but only when the branch display is enabled so the slot is one the scan will actually fill — so the scan fills the slot instead of reshaping the card.
- Rows stay visible, draggable, and clickable. Detached-HEAD rows keep their real badge instead of a placeholder.
- Once the scan is authoritative — or `startupWorktreeRefreshCompleted` flips, including degraded startup recovery — rendering is byte-identical to today. Legacy and compact styles never take the new path.
- Folder workspaces are excluded: their identity comes from project groups, not the scan.

This complements #16255 rather than replacing it: that PR decides *which* rows exist during startup (and keeps restored rows visible through reconnect), while this one keeps the rows that do exist from impersonating a settled card.

## Tests

`WorktreeCard.provisional-startup.test.tsx`:

- holds the auto title and reserves the identity row while the catalog is a fallback
- reserves the identity slot alongside existing host meta
- keeps an explicit fixed label visible while reserving the identity slot
- renders the settled card once the scan is authoritative
- settles after startup completes even when the catalog stays non-authoritative
- leaves the legacy card style untouched
- keeps a real detached badge instead of an identity placeholder
- does not reserve an identity row for folder workspaces

Also run locally: `pnpm tc:web`, the sidebar suite (2514 tests), and `check:code-quality:changed` — all pass.

## Screenshots

Recorded in the same Orca Dev window against the same seeded profile (one runtime project + six SSH demo projects): cold start, cropped to the window's first paint through settle.

**Before** (`main`, `Before-cropped.gif`) — fallback rows paint as basename titles (`checkout-web`) with no identity, then flip to the branch name (`main`) and grow the identity/status presentation:

<img width="2000" height="1178" alt="Before-cropped" src="https://github.com/user-attachments/assets/d59d2467-d729-4f6f-99ab-40c9ca43e78d" />

**After** (this branch, `After-cropped.gif`) — the same rows render as title + identity skeleton slots alongside the settled chrome (`primary`, host badge), then reveal `main` once; no wrong title is ever painted:

<img width="1728" height="1018" alt="After-cropped" src="https://github.com/user-attachments/assets/d68d19be-3865-4372-998b-6df4bca4dac2" />

## AI agent review

- **Cross-platform** — renderer-only classes and data attributes. No paths, shortcuts, or platform branches.
- **SSH / remote** — this is the remote path; local repos reach an authoritative scan immediately and are unaffected.
- **Folder workspaces** — excluded explicitly.
- **Performance** — one O(1) store subscription per card, boolean result; no extra work after startup settles.
- **UI quality** — reuses the `muted-foreground` placeholder tone and the app's existing `animate-pulse` skeleton convention, with `motion-reduce:animate-none`; no new tokens.
- **Security** — none.

## Risk

Confined to the startup window. When `startupWorktreeRefreshCompleted` is set, provisional is false and every card renders exactly as before; folder, legacy, and compact cards never take the new path.

