### PR TITLE
sycn fork

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0
+        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.0.0':
+    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
+
+  '@pnpm/exe@12.0.0':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -21,6 +21,7 @@ import { normalizeAppIconId } from '../../shared/app-icon'
 import { normalizeUiLanguage } from '../../shared/ui-language'
 import { applyAppIcon } from '../app-icon'
 import { normalizeTerminalCustomThemes } from '../../shared/terminal-custom-themes'
+import { normalizeQuickNotes } from '../../shared/quick-notes'
 import { normalizeDesktopTerminalScrollbackRows } from '../../shared/terminal-scrollback-policy'
 import { normalizeTerminalLineHeight } from '../../shared/terminal-line-height-settings'
 import { prepareLocalWorktreeRootsForRepos } from '../worktree-root-preparation'
@@ -162,6 +163,9 @@ export function registerSettingsHandlers(
     }
     if ('terminalCustomThemes' in args) {
       sanitizedArgs.terminalCustomThemes = normalizeTerminalCustomThemes(args.terminalCustomThemes)
+    }
+    if ('quickNotes' in args) {
+      sanitizedArgs.quickNotes = normalizeQuickNotes(args.quickNotes)
     }
     if ('terminalScrollbackRows' in args) {
       sanitizedArgs.terminalScrollbackRows = normalizeDesktopTerminalScrollbackRows(

--- a/src/main/persistence/applying-settings/settings-update.ts
+++ b/src/main/persistence/applying-settings/settings-update.ts
@@ -6,6 +6,7 @@ import {
   normalizeTuiAgentEnvRecord
 } from '../../../shared/tui-agent-launch-defaults'
 import { normalizeTerminalQuickCommands } from '../../../shared/terminal-quick-commands'
+import { normalizeQuickNotes } from '../../../shared/quick-notes'
 import { normalizeTerminalCustomThemes } from '../../../shared/terminal-custom-themes'
 import { normalizeTerminalCursorStyleDefault } from '../../../shared/terminal-cursor-style-settings'
 import { normalizeDesktopTerminalScrollbackRows } from '../../../shared/terminal-scrollback-policy'
@@ -104,6 +105,9 @@ export function updateSettings(
     sanitizedUpdates.terminalQuickCommands = normalizeTerminalQuickCommands(
       updates.terminalQuickCommands
     )
+  }
+  if ('quickNotes' in updates) {
+    sanitizedUpdates.quickNotes = normalizeQuickNotes(updates.quickNotes)
   }
   if ('terminalCustomThemes' in updates) {
     sanitizedUpdates.terminalCustomThemes = normalizeTerminalCustomThemes(

--- a/src/main/persistence/loading-store/normalize-loaded-global-settings.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-global-settings.ts
@@ -1,6 +1,7 @@
 import { getDefaultVoiceSettings } from '../../../shared/constants'
 import { normalizePRBotAuthorOverrides } from '../../../shared/pr-bot-author-overrides'
 import { normalizeTerminalQuickCommands } from '../../../shared/terminal-quick-commands'
+import { normalizeQuickNotes } from '../../../shared/quick-notes'
 import { normalizeOpenInApplications } from '../../../shared/open-in-applications'
 import { normalizeTerminalShortcutPolicy } from '../../../shared/keybindings'
 import { normalizeAppIconId } from '../../../shared/app-icon'
@@ -105,6 +106,7 @@ export function normalizeLoadedGlobalSettings(
     floatingTerminalCwdMigratedToAppWorkspace: true,
     terminalScrollbackRows: migratedTerminalScrollback.rows,
     terminalQuickCommands: normalizeTerminalQuickCommands(parsed.settings?.terminalQuickCommands),
+    quickNotes: normalizeQuickNotes(parsed.settings?.quickNotes),
     terminalCustomThemes: normalizeTerminalCustomThemes(parsed.settings?.terminalCustomThemes),
     appIcon: normalizeAppIconId(parsed.settings?.appIcon),
     mobilePairingCustomAddress,

--- a/src/renderer/src/components/cmd-j/palette-results.ts
+++ b/src/renderer/src/components/cmd-j/palette-results.ts
@@ -75,6 +75,7 @@ const SETTINGS_ALIASES: Record<string, string[]> = {
   appearance: ['theme', 'themes'],
   agents: ['ai agents'],
   'quick-commands': ['quick commands', 'quick command'],
+  'quick-notes': ['quick notes', 'quick note'],
   repo: ['repository settings', 'project settings'],
   integrations: ['gitlab', 'github', 'linear'],
   notifications: ['notification settings'],

--- a/src/renderer/src/components/quick-notes/QuickNoteDialog.test.tsx
+++ b/src/renderer/src/components/quick-notes/QuickNoteDialog.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, params?: Record<string, unknown>) =>
+    params ? fallback.replace(/\{\{value0\}\}/g, String(params.value0)) : fallback
+}))
+vi.mock('@/lib/screen-submit-shortcut', () => ({
+  isScreenSubmitShortcut: (e: { key: string; metaKey?: boolean; ctrlKey?: boolean }) =>
+    e.key === 'Enter' && (Boolean(e.metaKey) || Boolean(e.ctrlKey)),
+  getScreenSubmitShortcutLabel: () => '⌘ Enter'
+}))
+
+import { createQuickNoteDraft, QuickNoteDialog } from './QuickNoteDialog'
+
+afterEach(cleanup)
+
+describe('QuickNoteDialog', () => {
+  it('disables Save until both label and body are non-empty', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(
+      <QuickNoteDialog
+        open
+        mode="add"
+        note={createQuickNoteDraft()}
+        onOpenChange={() => {}}
+        onSave={onSave}
+      />
+    )
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeDisabled()
+
+    await user.type(screen.getByLabelText('Label'), 'Signature')
+    expect(saveButton).toBeDisabled()
+    await user.type(screen.getByLabelText('Text'), 'Best,\nFrank')
+    expect(saveButton).toBeEnabled()
+  })
+
+  it('emits a trimmed note on save', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(
+      <QuickNoteDialog
+        open
+        mode="edit"
+        note={{ id: 'n1', label: '', body: '' }}
+        onOpenChange={() => {}}
+        onSave={onSave}
+      />
+    )
+    await user.type(screen.getByLabelText('Label'), '  Signature  ')
+    await user.type(screen.getByLabelText('Text'), 'line 1  ')
+    await user.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith({ id: 'n1', label: 'Signature', body: 'line 1' })
+  })
+
+  it('submits with the platform submit shortcut', async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+    render(
+      <QuickNoteDialog
+        open
+        mode="add"
+        note={{ id: 'n2', label: 'L', body: 'B' }}
+        onOpenChange={() => {}}
+        onSave={onSave}
+      />
+    )
+    await user.click(screen.getByLabelText('Text'))
+    await user.keyboard('{Meta>}{Enter}{/Meta}')
+    expect(onSave).toHaveBeenCalledWith({ id: 'n2', label: 'L', body: 'B' })
+  })
+})

--- a/src/renderer/src/components/quick-notes/QuickNoteDialog.tsx
+++ b/src/renderer/src/components/quick-notes/QuickNoteDialog.tsx
@@ -1,0 +1,139 @@
+import { useRef, useState } from 'react'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+import {
+  MAX_QUICK_NOTE_BODY_LENGTH,
+  MAX_QUICK_NOTE_LABEL_LENGTH
+} from '../../../../shared/quick-notes'
+import { createBrowserUuid } from '@/lib/browser-uuid'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { getScreenSubmitShortcutLabel, isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
+import { translate } from '@/i18n/i18n'
+
+type QuickNoteDialogMode = 'add' | 'edit'
+
+type QuickNoteDialogProps = {
+  open: boolean
+  mode: QuickNoteDialogMode
+  note: QuickNote
+  onOpenChange: (open: boolean) => void
+  onSave: (note: QuickNote) => void
+}
+
+export function createQuickNoteDraft(): QuickNote {
+  return { id: `quick-note-${createBrowserUuid()}`, label: '', body: '' }
+}
+
+export function QuickNoteDialog({
+  open,
+  mode,
+  note,
+  onOpenChange,
+  onSave
+}: QuickNoteDialogProps): React.JSX.Element {
+  const [draft, setDraft] = useState<QuickNote>(note)
+  const syncedNoteRef = useRef<QuickNote | null>(null)
+
+  // Why: re-seed the local draft whenever the dialog (re)opens for a new note.
+  if (open && syncedNoteRef.current !== note) {
+    syncedNoteRef.current = note
+    setDraft({ ...note })
+  } else if (!open && syncedNoteRef.current !== null) {
+    syncedNoteRef.current = null
+  }
+
+  const canSave = draft.label.trim().length > 0 && draft.body.trim().length > 0
+
+  const save = (): void => {
+    if (!canSave) {
+      return
+    }
+    onSave({ id: draft.id, label: draft.label.trim(), body: draft.body.trimEnd() })
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-lg gap-4"
+        onKeyDown={(event) => {
+          if (isScreenSubmitShortcut(event) && canSave) {
+            event.preventDefault()
+            save()
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-sm">
+            {mode === 'edit'
+              ? translate(
+                  'auto.components.quick.notes.QuickNoteDialog.editTitle',
+                  'Edit Quick Note'
+                )
+              : translate('auto.components.quick.notes.QuickNoteDialog.addTitle', 'Add Quick Note')}
+          </DialogTitle>
+          <DialogDescription className="text-xs">
+            {translate(
+              'auto.components.quick.notes.QuickNoteDialog.description',
+              'Saved notes appear in the tab bar menu; picking one copies it to the clipboard.'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="quick-note-label">
+            {translate('auto.components.quick.notes.QuickNoteDialog.labelField', 'Label')}
+          </Label>
+          <Input
+            id="quick-note-label"
+            autoFocus
+            value={draft.label}
+            maxLength={MAX_QUICK_NOTE_LABEL_LENGTH}
+            placeholder={translate(
+              'auto.components.quick.notes.QuickNoteDialog.labelPlaceholder',
+              'Email signature'
+            )}
+            onChange={(event) => setDraft((current) => ({ ...current, label: event.target.value }))}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="quick-note-body">
+            {translate('auto.components.quick.notes.QuickNoteDialog.bodyField', 'Text')}
+          </Label>
+          <Textarea
+            id="quick-note-body"
+            className="min-h-[180px] font-mono text-xs"
+            value={draft.body}
+            maxLength={MAX_QUICK_NOTE_BODY_LENGTH}
+            placeholder={translate(
+              'auto.components.quick.notes.QuickNoteDialog.bodyPlaceholder',
+              'The text copied to your clipboard when you pick this note.'
+            )}
+            onChange={(event) => setDraft((current) => ({ ...current, body: event.target.value }))}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            {translate('auto.components.quick.notes.QuickNoteDialog.cancel', 'Cancel')}
+          </Button>
+          <Button type="button" disabled={!canSave} onClick={save}>
+            {translate('auto.components.quick.notes.QuickNoteDialog.save', 'Save')}
+            <span className="ml-1.5 text-[11px] opacity-60">{getScreenSubmitShortcutLabel()}</span>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/quick-notes/copy-quick-note.test.ts
+++ b/src/renderer/src/components/quick-notes/copy-quick-note.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { copyQuickNoteToClipboard } from './copy-quick-note'
+
+const writeClipboardText = vi.fn<(text: string) => Promise<void>>()
+const success = vi.fn()
+const error = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: { success: (...a: unknown[]) => success(...a), error: (...a: unknown[]) => error(...a) }
+}))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  ;(window as unknown as { api: unknown }).api = { ui: { writeClipboardText } }
+})
+
+describe('copyQuickNoteToClipboard', () => {
+  it('writes the note body to the clipboard and toasts success', async () => {
+    writeClipboardText.mockResolvedValue()
+    const ok = await copyQuickNoteToClipboard({ id: 'n1', label: 'Sig', body: 'line 1\nline 2' })
+    expect(ok).toBe(true)
+    expect(writeClipboardText).toHaveBeenCalledWith('line 1\nline 2')
+    expect(success).toHaveBeenCalledOnce()
+    expect(error).not.toHaveBeenCalled()
+  })
+
+  it('toasts an error and returns false when the clipboard write rejects', async () => {
+    writeClipboardText.mockRejectedValue(new Error('unfocused'))
+    const ok = await copyQuickNoteToClipboard({ id: 'n1', label: 'Sig', body: 'x' })
+    expect(ok).toBe(false)
+    expect(error).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/quick-notes/copy-quick-note.ts
+++ b/src/renderer/src/components/quick-notes/copy-quick-note.ts
@@ -1,0 +1,21 @@
+import { toast } from 'sonner'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+import { translate } from '@/i18n/i18n'
+
+/** Copy a quick note's body to the system clipboard, with toast feedback. */
+export async function copyQuickNoteToClipboard(note: QuickNote): Promise<boolean> {
+  try {
+    await window.api.ui.writeClipboardText(note.body)
+    toast.success(
+      translate('auto.components.quick.notes.copyQuickNote.copied', '"{{value0}}" copied', {
+        value0: note.label
+      })
+    )
+    return true
+  } catch {
+    toast.error(
+      translate('auto.components.quick.notes.copyQuickNote.failed', 'Failed to copy note')
+    )
+    return false
+  }
+}

--- a/src/renderer/src/components/quick-notes/quick-note-search.test.ts
+++ b/src/renderer/src/components/quick-notes/quick-note-search.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { searchQuickNotes } from './quick-note-search'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+
+const notes: QuickNote[] = [
+  { id: '1', label: 'Email signature', body: 'Best regards' },
+  { id: '2', label: 'Deploy block', body: 'kubectl rollout status' },
+  { id: '3', label: 'PR template', body: 'signature verification steps' }
+]
+
+describe('searchQuickNotes', () => {
+  it('returns all notes for an empty query', () => {
+    expect(searchQuickNotes(notes, '  ')).toEqual(notes)
+  })
+
+  it('matches on label and body, ranking label matches first', () => {
+    const result = searchQuickNotes(notes, 'signature')
+    expect(result.map((n) => n.id)).toEqual(['1', '3'])
+  })
+
+  it('is case-insensitive', () => {
+    expect(searchQuickNotes(notes, 'DEPLOY').map((n) => n.id)).toEqual(['2'])
+  })
+
+  it('returns [] when nothing matches', () => {
+    expect(searchQuickNotes(notes, 'zzz')).toEqual([])
+  })
+})

--- a/src/renderer/src/components/quick-notes/quick-note-search.ts
+++ b/src/renderer/src/components/quick-notes/quick-note-search.ts
@@ -1,0 +1,26 @@
+import type { QuickNote } from '../../../../shared/quick-note-types'
+import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
+
+const QUERY_MAX_BYTES = 2 * 1024
+
+/** Case-insensitive substring filter over label + body, label matches ranked first. */
+export function searchQuickNotes(notes: readonly QuickNote[], rawQuery: string): QuickNote[] {
+  if (isClipboardTextByteLengthOverLimit(rawQuery, QUERY_MAX_BYTES)) {
+    return []
+  }
+  const query = rawQuery.trim().toLowerCase()
+  if (!query) {
+    return [...notes]
+  }
+  const ranked: { note: QuickNote; score: number; index: number }[] = []
+  notes.forEach((note, index) => {
+    const label = note.label.toLowerCase()
+    const body = note.body.toLowerCase()
+    const score = label.includes(query) ? 0 : body.includes(query) ? 1 : -1
+    if (score !== -1) {
+      ranked.push({ note, score, index })
+    }
+  })
+  ranked.sort((a, b) => a.score - b.score || a.index - b.index)
+  return ranked.map((entry) => entry.note)
+}

--- a/src/renderer/src/components/settings/QuickNotesList.tsx
+++ b/src/renderer/src/components/settings/QuickNotesList.tsx
@@ -1,0 +1,141 @@
+import { Check, Copy, Pencil, StickyNote, Trash2 } from 'lucide-react'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+import { useClipboardTextCopyFeedback } from '@/hooks/use-clipboard-text-copy-feedback'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+
+function QuickNoteRow({
+  note,
+  onEdit,
+  onRemove
+}: {
+  note: QuickNote
+  onEdit: (note: QuickNote) => void
+  onRemove: (note: QuickNote) => void
+}): React.JSX.Element {
+  const { canCopy, copyText, status } = useClipboardTextCopyFeedback(note.body)
+  const name =
+    note.label || translate('auto.components.settings.QuickNotesList.untitled', 'Untitled')
+
+  const copyLabel =
+    status === 'copied'
+      ? translate('auto.components.settings.QuickNotesList.copied', 'Copied')
+      : status === 'failed'
+        ? translate('auto.components.settings.QuickNotesList.copyFailed', "Couldn't copy")
+        : translate('auto.components.settings.QuickNotesList.copy', 'Copy {{value0}}', {
+            value0: name
+          })
+  const editLabel = translate('auto.components.settings.QuickNotesList.edit', 'Edit {{value0}}', {
+    value0: name
+  })
+
+  return (
+    <div className="group/qn flex items-center gap-3 rounded-md px-2 py-2.5 transition-colors hover:bg-accent/60 focus-within:bg-accent/60">
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium">{name}</div>
+        <div className="mt-0.5 truncate font-mono text-xs text-muted-foreground">
+          {note.body
+            .split(/\r\n|\r|\n/)
+            .find((line) => line.trim().length > 0)
+            ?.trim() || translate('auto.components.settings.QuickNotesList.noText', 'No text')}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-0.5 transition-opacity can-hover:opacity-0 group-hover/qn:opacity-100 group-focus-within/qn:opacity-100">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={editLabel}
+          title={editLabel}
+          onClick={() => onEdit(note)}
+        >
+          <Pencil />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          disabled={!canCopy}
+          aria-label={copyLabel}
+          title={copyLabel}
+          onClick={() => void copyText()}
+          className={cn(
+            status === 'copied' && 'text-status-success',
+            status === 'failed' && 'text-destructive'
+          )}
+        >
+          {status === 'copied' ? <Check /> : <Copy />}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={translate(
+            'auto.components.settings.QuickNotesList.remove',
+            'Remove {{value0}}',
+            {
+              value0: name
+            }
+          )}
+          onClick={() => onRemove(note)}
+          className="text-muted-foreground hover:text-destructive"
+        >
+          <Trash2 />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function QuickNotesList({
+  notes,
+  visibleNotes,
+  hasQuery,
+  onEdit,
+  onRemove
+}: {
+  notes: QuickNote[]
+  visibleNotes: QuickNote[]
+  hasQuery: boolean
+  onEdit: (note: QuickNote) => void
+  onRemove: (note: QuickNote) => void
+}): React.JSX.Element {
+  if (visibleNotes.length === 0) {
+    if (notes.length > 0) {
+      return (
+        <div className="px-2 py-10 text-center text-sm text-muted-foreground">
+          {hasQuery
+            ? translate(
+                'auto.components.settings.QuickNotesList.noSearchMatches',
+                'No notes match this search.'
+              )
+            : translate('auto.components.settings.QuickNotesList.none', 'No notes saved.')}
+        </div>
+      )
+    }
+    return (
+      <div className="flex flex-col items-center gap-3 px-2 py-10 text-center">
+        <StickyNote className="size-7 text-muted-foreground/50" />
+        <div className="space-y-1">
+          <p className="text-sm text-muted-foreground">
+            {translate('auto.components.settings.QuickNotesList.none', 'No notes saved.')}
+          </p>
+          <p className="text-xs text-muted-foreground/80">
+            {translate(
+              'auto.components.settings.QuickNotesList.hint',
+              'Pick one from the Note button in the tab bar to copy it to the clipboard.'
+            )}
+          </p>
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className="-mx-2 divide-y divide-border/50">
+      {visibleNotes.map((note) => (
+        <QuickNoteRow key={note.id} note={note} onEdit={onEdit} onRemove={onRemove} />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/QuickNotesPane.test.tsx
+++ b/src/renderer/src/components/settings/QuickNotesPane.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+
+const upsertQuickNote = vi.fn().mockResolvedValue(true)
+const deleteQuickNote = vi.fn().mockResolvedValue(true)
+const recordFeatureInteraction = vi.fn()
+const confirm = vi.fn().mockResolvedValue(true)
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_k: string, fallback: string, p?: Record<string, unknown>) =>
+    p ? fallback.replace(/\{\{value0\}\}/g, String(p.value0)) : fallback
+}))
+vi.mock('@/lib/screen-submit-shortcut', () => ({
+  isScreenSubmitShortcut: () => false,
+  getScreenSubmitShortcutLabel: () => '⌘ Enter'
+}))
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => confirm
+}))
+vi.mock('../../store', () => ({
+  useAppStore: Object.assign(() => undefined, {
+    getState: () => ({ upsertQuickNote, deleteQuickNote, recordFeatureInteraction })
+  })
+}))
+
+import { QuickNotesPane } from './QuickNotesPane'
+
+const notes: QuickNote[] = [
+  { id: 'a', label: 'Email signature', body: 'Best' },
+  { id: 'b', label: 'Deploy block', body: 'kubectl' }
+]
+
+const renderPane = (quickNotes = notes) =>
+  render(<QuickNotesPane settings={{ ...getDefaultSettings('/tmp'), quickNotes }} />)
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('QuickNotesPane', () => {
+  it('filters the list with the search field', async () => {
+    const user = userEvent.setup()
+    renderPane()
+    await user.type(screen.getByLabelText('Search notes'), 'deploy')
+    expect(screen.queryByText('Email signature')).not.toBeInTheDocument()
+    expect(screen.getByText('Deploy block')).toBeInTheDocument()
+  })
+
+  it('saves a new note through the store and records the interaction', async () => {
+    const user = userEvent.setup()
+    renderPane([])
+    await user.click(screen.getByRole('button', { name: 'Add Note' }))
+    await user.type(screen.getByLabelText('Label'), 'Greeting')
+    await user.type(screen.getByLabelText('Text'), 'Hello there')
+    await user.click(screen.getByRole('button', { name: /save/i }))
+    expect(upsertQuickNote).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Greeting', body: 'Hello there' })
+    )
+    expect(recordFeatureInteraction).toHaveBeenCalledWith('quick-notes')
+  })
+
+  it('confirms then deletes a note', async () => {
+    const user = userEvent.setup()
+    renderPane()
+    await user.click(screen.getByRole('button', { name: 'Remove Email signature' }))
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(deleteQuickNote).toHaveBeenCalledWith('a')
+  })
+})

--- a/src/renderer/src/components/settings/QuickNotesPane.tsx
+++ b/src/renderer/src/components/settings/QuickNotesPane.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import { Plus, Search } from 'lucide-react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+import { useAppStore } from '../../store'
+import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
+import { createQuickNoteDraft, QuickNoteDialog } from '@/components/quick-notes/QuickNoteDialog'
+import { searchQuickNotes } from '@/components/quick-notes/quick-note-search'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { QuickNotesList } from './QuickNotesList'
+
+type QuickNotesPaneProps = {
+  settings: GlobalSettings
+}
+
+export function QuickNotesPane({ settings }: QuickNotesPaneProps): React.JSX.Element {
+  const confirm = useConfirmationDialog()
+  const notes = settings.quickNotes ?? []
+  const [query, setQuery] = useState('')
+  const [editor, setEditor] = useState<{ mode: 'add' | 'edit'; note: QuickNote } | null>(null)
+
+  const visibleNotes = searchQuickNotes(notes, query)
+  const searchLabel = translate('auto.components.settings.QuickNotesPane.search', 'Search notes')
+
+  const save = (next: QuickNote): void => {
+    useAppStore.getState().recordFeatureInteraction('quick-notes')
+    void useAppStore.getState().upsertQuickNote(next)
+  }
+
+  const remove = async (note: QuickNote): Promise<void> => {
+    const confirmed = await confirm({
+      title: translate(
+        'auto.components.settings.QuickNotesPane.deleteTitle',
+        'Delete "{{value0}}"?',
+        {
+          value0: note.label || 'Untitled'
+        }
+      ),
+      description: translate(
+        'auto.components.settings.QuickNotesPane.deleteDescription',
+        'This quick note will be removed from your saved list.'
+      ),
+      confirmLabel: translate('auto.components.settings.QuickNotesPane.delete', 'Delete'),
+      confirmVariant: 'destructive'
+    })
+    if (!confirmed) {
+      return
+    }
+    void useAppStore.getState().deleteQuickNote(note.id)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-52 flex-1">
+          <Search className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={searchLabel}
+            aria-label={searchLabel}
+            className="h-8 pl-8 text-xs"
+          />
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="ml-auto"
+          onClick={() => setEditor({ mode: 'add', note: createQuickNoteDraft() })}
+        >
+          <Plus />
+          {translate('auto.components.settings.QuickNotesPane.add', 'Add Note')}
+        </Button>
+      </div>
+
+      <QuickNotesList
+        notes={notes}
+        visibleNotes={visibleNotes}
+        hasQuery={query.trim().length > 0}
+        onEdit={(note) => setEditor({ mode: 'edit', note })}
+        onRemove={(note) => void remove(note)}
+      />
+
+      {editor !== null ? (
+        <QuickNoteDialog
+          open
+          mode={editor.mode}
+          note={editor.note}
+          onOpenChange={(open) => !open && setEditor(null)}
+          onSave={save}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/quick-notes-search.ts
+++ b/src/renderer/src/components/settings/quick-notes-search.ts
@@ -1,0 +1,26 @@
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+
+export const getQuickNotesPaneSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate('auto.components.settings.quick.notes.search.title', 'Quick Notes'),
+    description: translate(
+      'auto.components.settings.quick.notes.search.description',
+      'Reusable plain-text snippets; picking one from the tab bar copies it to the clipboard.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.quick.notes.search.kwQuick', 'quick'),
+      ...translateSearchKeyword('auto.components.settings.quick.notes.search.kwNote', 'note'),
+      ...translateSearchKeyword('auto.components.settings.quick.notes.search.kwNotes', 'notes'),
+      ...translateSearchKeyword('auto.components.settings.quick.notes.search.kwSnippet', 'snippet'),
+      ...translateSearchKeyword(
+        'auto.components.settings.quick.notes.search.kwClipboard',
+        'clipboard'
+      ),
+      ...translateSearchKeyword('auto.components.settings.quick.notes.search.kwCopy', 'copy'),
+      ...translateSearchKeyword('auto.components.settings.quick.notes.search.kwText', 'text'),
+      ...translateSearchKeyword('auto.components.settings.quick.notes.search.kwPaste', 'paste')
+    ]
+  }
+])

--- a/src/renderer/src/components/settings/settings-interface-primary-section-renderers.tsx
+++ b/src/renderer/src/components/settings/settings-interface-primary-section-renderers.tsx
@@ -2,6 +2,7 @@ import { BrowserPane } from './BrowserPane'
 import { FloatingWorkspacePane } from './FloatingWorkspacePane'
 import { MobileEmulatorSettingsPane } from './MobileEmulatorSettingsPane'
 import { QuickCommandsPane } from './QuickCommandsPane'
+import { QuickNotesPane } from './QuickNotesPane'
 import { TerminalPane } from './TerminalPane'
 import { SettingsSection } from './SettingsSection'
 import { translate } from '@/i18n/i18n'
@@ -57,6 +58,23 @@ export function renderQuickCommandsSettingsSection(
           addCommandIntentSignal={model.quickCommandAddIntentSignal}
         />
       ) : null}
+    </SettingsSection>
+  )
+}
+
+export function renderQuickNotesSettingsSection(context: SettingsRenderContext): React.JSX.Element {
+  const { model, navigation, view } = context
+  return (
+    <SettingsSection
+      id="quick-notes"
+      title={translate('auto.components.settings.Settings.quickNotesTitle', 'Quick Notes')}
+      description={translate(
+        'auto.components.settings.Settings.quickNotesDescription',
+        'Saved snippets of text you can copy to the clipboard.'
+      )}
+      searchEntries={navigation.getSectionSearchEntries('quick-notes')}
+    >
+      {view.isSectionMounted('quick-notes') ? <QuickNotesPane settings={model.settings} /> : null}
     </SettingsSection>
   )
 }

--- a/src/renderer/src/components/settings/settings-page-renderer.tsx
+++ b/src/renderer/src/components/settings/settings-page-renderer.tsx
@@ -30,6 +30,7 @@ import {
   renderFloatingWorkspaceSettingsSection,
   renderMobileEmulatorSettingsSection,
   renderQuickCommandsSettingsSection,
+  renderQuickNotesSettingsSection,
   renderTerminalSettingsSection
 } from './settings-interface-primary-section-renderers'
 import {
@@ -131,6 +132,7 @@ export function renderSettingsPage(context: SettingsRenderContext): React.JSX.El
                 {renderTasksSettingsSection(context)}
                 {renderTerminalSettingsSection(context)}
                 {renderQuickCommandsSettingsSection(context)}
+                {renderQuickNotesSettingsSection(context)}
                 {renderBrowserSettingsSection(context)}
                 {renderMobileEmulatorSettingsSection(context)}
                 {renderFloatingWorkspaceSettingsSection(context)}

--- a/src/renderer/src/components/tab-bar/TabBarQuickNoteItem.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickNoteItem.tsx
@@ -1,0 +1,94 @@
+import type { MouseEvent, PointerEvent } from 'react'
+import { Pencil, StickyNote, Trash2 } from 'lucide-react'
+import { CommandItem } from '@/components/ui/command'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+import { translate } from '@/i18n/i18n'
+
+type TabBarQuickNoteItemProps = {
+  note: QuickNote
+  onCopy: () => void
+  onEdit: () => void
+  onDelete: () => void
+}
+
+function stopRowSelect(event: MouseEvent | PointerEvent): void {
+  // Why: cmdk selects the parent CommandItem on click; nested actions must not
+  // also copy the note.
+  event.preventDefault()
+  event.stopPropagation()
+}
+
+/** First non-empty line of the note body, for the row preview. */
+function bodyPreview(body: string): string {
+  return (
+    body
+      .split(/\r\n|\r|\n/)
+      .find((line) => line.trim().length > 0)
+      ?.trim() ?? ''
+  )
+}
+
+export function TabBarQuickNoteItem({
+  note,
+  onCopy,
+  onEdit,
+  onDelete
+}: TabBarQuickNoteItemProps): React.JSX.Element {
+  return (
+    <CommandItem
+      value={note.id}
+      keywords={[note.label, note.body]}
+      onSelect={onCopy}
+      className="group/qn mx-1 my-0.5 cursor-pointer items-center gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground"
+    >
+      <StickyNote className="size-3 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium text-foreground">{note.label}</span>
+        <span className="block truncate font-mono text-[11px] text-muted-foreground">
+          {bodyPreview(note.body)}
+        </span>
+      </span>
+      <span
+        role="group"
+        aria-label={translate(
+          'auto.components.tab.bar.TabBarQuickNoteItem.actions',
+          'Quick note actions'
+        )}
+        className="flex shrink-0 items-center gap-0.5 can-hover:opacity-0 transition-opacity group-hover/qn:opacity-100 group-data-[selected=true]/qn:opacity-100"
+      >
+        <button
+          type="button"
+          onPointerDown={stopRowSelect}
+          onClick={(event) => {
+            stopRowSelect(event)
+            onEdit()
+          }}
+          className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label={translate(
+            'auto.components.tab.bar.TabBarQuickNoteItem.edit',
+            'Edit {{value0}}',
+            { value0: note.label }
+          )}
+        >
+          <Pencil className="size-3" />
+        </button>
+        <button
+          type="button"
+          onPointerDown={stopRowSelect}
+          onClick={(event) => {
+            stopRowSelect(event)
+            onDelete()
+          }}
+          className="cursor-pointer rounded p-1 text-muted-foreground hover:bg-accent hover:text-destructive"
+          aria-label={translate(
+            'auto.components.tab.bar.TabBarQuickNoteItem.remove',
+            'Remove {{value0}}',
+            { value0: note.label }
+          )}
+        >
+          <Trash2 className="size-3" />
+        </button>
+      </span>
+    </CommandItem>
+  )
+}

--- a/src/renderer/src/components/tab-bar/TabBarQuickNotesButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickNotesButton.tsx
@@ -1,0 +1,111 @@
+import { useMemo, useState } from 'react'
+import { StickyNote } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
+import { translate } from '@/i18n/i18n'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+import { createQuickNoteDraft, QuickNoteDialog } from '@/components/quick-notes/QuickNoteDialog'
+import { copyQuickNoteToClipboard } from '@/components/quick-notes/copy-quick-note'
+import { TabBarQuickNotesMenu } from './TabBarQuickNotesMenu'
+
+const EMPTY_NOTES: QuickNote[] = []
+
+export function TabBarQuickNotesButton(): React.JSX.Element {
+  const notes = useAppStore((s) => s.settings?.quickNotes ?? EMPTY_NOTES)
+  const recentQuickNoteId = useAppStore((s) => s.recentQuickNoteId)
+  const confirm = useConfirmationDialog()
+  const [editor, setEditor] = useState<{ mode: 'add' | 'edit'; note: QuickNote } | null>(null)
+
+  const mostRecent = useMemo(
+    () => notes.find((note) => note.id === recentQuickNoteId) ?? notes[0] ?? null,
+    [notes, recentQuickNoteId]
+  )
+
+  const openAdd = (): void => setEditor({ mode: 'add', note: createQuickNoteDraft() })
+
+  const handleSave = (next: QuickNote): void => {
+    void useAppStore.getState().upsertQuickNote(next)
+  }
+
+  const handleCopy = (note: QuickNote): void => {
+    void copyQuickNoteToClipboard(note)
+    useAppStore.getState().setRecentQuickNoteId(note.id)
+  }
+
+  const handleDelete = async (note: QuickNote): Promise<void> => {
+    const confirmed = await confirm({
+      title: translate(
+        'auto.components.tab.bar.TabBarQuickNotesButton.deleteTitle',
+        'Delete "{{value0}}"?',
+        { value0: note.label }
+      ),
+      description: translate(
+        'auto.components.tab.bar.TabBarQuickNotesButton.deleteDescription',
+        'This quick note will be removed from your saved list.'
+      ),
+      confirmLabel: translate('auto.components.tab.bar.TabBarQuickNotesButton.delete', 'Delete'),
+      confirmVariant: 'destructive'
+    })
+    if (!confirmed) {
+      return
+    }
+    void useAppStore.getState().deleteQuickNote(note.id)
+  }
+
+  const dialog = (
+    <QuickNoteDialog
+      open={editor !== null}
+      mode={editor?.mode ?? 'add'}
+      note={editor?.note ?? createQuickNoteDraft()}
+      onOpenChange={(open) => !open && setEditor(null)}
+      onSave={handleSave}
+    />
+  )
+
+  if (notes.length === 0) {
+    return (
+      <>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={openAdd}
+              className="my-auto flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              aria-label={translate(
+                'auto.components.tab.bar.TabBarQuickNotesButton.addAria',
+                'Add quick note'
+              )}
+            >
+              <StickyNote className="size-3.5" />
+              <span className="text-[12px] font-medium">
+                {translate('auto.components.tab.bar.TabBarQuickNotesButton.note', 'Note')}
+              </span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {translate(
+              'auto.components.tab.bar.TabBarQuickNotesButton.addTooltip',
+              'Save a reusable note you can copy to the clipboard'
+            )}
+          </TooltipContent>
+        </Tooltip>
+        {dialog}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <TabBarQuickNotesMenu
+        notes={notes}
+        mostRecent={mostRecent}
+        onCopyNote={handleCopy}
+        onAddNote={openAdd}
+        onEditNote={(note) => setEditor({ mode: 'edit', note })}
+        onDeleteNote={(note) => void handleDelete(note)}
+      />
+      {dialog}
+    </>
+  )
+}

--- a/src/renderer/src/components/tab-bar/TabBarQuickNotesMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickNotesMenu.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, params?: Record<string, unknown>) =>
+    params ? fallback.replace(/\{\{value0\}\}/g, String(params.value0)) : fallback
+}))
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+import { TabBarQuickNotesMenu } from './TabBarQuickNotesMenu'
+
+const notes: QuickNote[] = [
+  { id: 'a', label: 'Email signature', body: 'Best,\nFrank' },
+  { id: 'b', label: 'Deploy block', body: 'kubectl rollout status' }
+]
+
+function renderMenu(over: Partial<Parameters<typeof TabBarQuickNotesMenu>[0]> = {}) {
+  const props = {
+    notes,
+    mostRecent: notes[1],
+    onCopyNote: vi.fn(),
+    onAddNote: vi.fn(),
+    onEditNote: vi.fn(),
+    onDeleteNote: vi.fn(),
+    ...over
+  }
+  render(<TabBarQuickNotesMenu {...props} />)
+  return props
+}
+
+afterEach(cleanup)
+
+describe('TabBarQuickNotesMenu', () => {
+  it('copies the most recent note from the primary split-button', async () => {
+    const user = userEvent.setup()
+    const props = renderMenu()
+    await user.click(screen.getByRole('button', { name: 'Copy quick note: Deploy block' }))
+    expect(props.onCopyNote).toHaveBeenCalledWith(notes[1])
+  })
+
+  it('copies a note picked from the list', async () => {
+    const user = userEvent.setup()
+    const props = renderMenu()
+    await user.click(screen.getByText('Email signature'))
+    expect(props.onCopyNote).toHaveBeenCalledWith(notes[0])
+  })
+
+  it('filters the list by the search query', async () => {
+    const user = userEvent.setup()
+    renderMenu()
+    await user.type(screen.getByPlaceholderText('Search quick notes...'), 'deploy')
+    expect(screen.queryByText('Email signature')).not.toBeInTheDocument()
+    // Body preview is unique to the list row (not shown on the split-button).
+    expect(screen.getByText('kubectl rollout status')).toBeInTheDocument()
+  })
+
+  it('routes the row actions to edit and delete', async () => {
+    const user = userEvent.setup()
+    const props = renderMenu()
+    await user.click(screen.getByRole('button', { name: 'Edit Email signature' }))
+    expect(props.onEditNote).toHaveBeenCalledWith(notes[0])
+    await user.click(screen.getByRole('button', { name: 'Remove Deploy block' }))
+    expect(props.onDeleteNote).toHaveBeenCalledWith(notes[1])
+  })
+
+  it('invokes onAddNote from the footer button', async () => {
+    const user = userEvent.setup()
+    const props = renderMenu()
+    await user.click(screen.getByRole('button', { name: 'Note' }))
+    expect(props.onAddNote).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/tab-bar/TabBarQuickNotesMenu.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickNotesMenu.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, Copy, Plus } from 'lucide-react'
+import { Command, CommandEmpty, CommandInput, CommandList } from '@/components/ui/command'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { searchQuickNotes } from '@/components/quick-notes/quick-note-search'
+import { TabBarQuickNoteItem } from './TabBarQuickNoteItem'
+
+type TabBarQuickNotesMenuProps = {
+  notes: readonly QuickNote[]
+  mostRecent: QuickNote | null
+  onCopyNote: (note: QuickNote) => void
+  onAddNote: () => void
+  onEditNote: (note: QuickNote) => void
+  onDeleteNote: (note: QuickNote) => void
+}
+
+export function TabBarQuickNotesMenu({
+  notes,
+  mostRecent,
+  onCopyNote,
+  onAddNote,
+  onEditNote,
+  onDeleteNote
+}: TabBarQuickNotesMenuProps): React.JSX.Element {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+  const showSearch = notes.length > 1
+
+  const filtered = useMemo(() => searchQuickNotes(notes, query), [notes, query])
+  const commandValue = filtered[0]?.id ?? ''
+
+  useEffect(() => {
+    if (!menuOpen) {
+      setQuery('')
+    }
+  }, [menuOpen])
+
+  useEffect(() => {
+    if (!menuOpen || !showSearch) {
+      return undefined
+    }
+    // Why: cmdk needs the input focused so Enter copies the highlighted note.
+    const frame = requestAnimationFrame(() => searchInputRef.current?.focus())
+    return () => cancelAnimationFrame(frame)
+  }, [menuOpen, showSearch])
+
+  const copyAndClose = (note: QuickNote): void => {
+    setMenuOpen(false)
+    onCopyNote(note)
+  }
+
+  const moreLabel = translate(
+    'auto.components.tab.bar.TabBarQuickNotesMenu.more',
+    'More quick notes'
+  )
+  const splitButtonClass =
+    'my-auto flex h-7 shrink-0 items-stretch overflow-hidden rounded-md border border-border/60 text-muted-foreground'
+  const innerButtonBase =
+    'flex items-center bg-transparent leading-none text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+
+  return (
+    <div className={splitButtonClass}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => mostRecent && copyAndClose(mostRecent)}
+            disabled={!mostRecent}
+            className={cn(innerButtonBase, 'gap-1.5 rounded-l-md rounded-r-none px-1.5')}
+            aria-label={
+              mostRecent
+                ? translate(
+                    'auto.components.tab.bar.TabBarQuickNotesMenu.copyNamed',
+                    'Copy quick note: {{value0}}',
+                    { value0: mostRecent.label }
+                  )
+                : translate('auto.components.tab.bar.TabBarQuickNotesMenu.copy', 'Copy quick note')
+            }
+          >
+            <Copy className="size-3 shrink-0" />
+            <span className="max-w-[160px] truncate text-[12px] font-medium">
+              {mostRecent?.label ??
+                translate('auto.components.tab.bar.TabBarQuickNotesMenu.note', 'Note')}
+            </span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {mostRecent
+            ? translate(
+                'auto.components.tab.bar.TabBarQuickNotesMenu.copyTooltip',
+                'Copy "{{value0}}" to the clipboard',
+                { value0: mostRecent.label }
+              )
+            : translate('auto.components.tab.bar.TabBarQuickNotesMenu.copy', 'Copy quick note')}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenu modal={false} open={menuOpen} onOpenChange={setMenuOpen}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className={cn(
+                  innerButtonBase,
+                  'justify-center rounded-l-none rounded-r-md border-l border-border/60 px-1'
+                )}
+                aria-label={moreLabel}
+              >
+                <ChevronDown className="size-3" strokeWidth={2.5} />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={6}>
+            {moreLabel}
+          </TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end" side="bottom" sideOffset={6} className="w-80 p-0">
+          <Command shouldFilter={false} loop value={commandValue} className="bg-transparent">
+            {showSearch ? (
+              <CommandInput
+                ref={searchInputRef}
+                autoFocus
+                placeholder={translate(
+                  'auto.components.tab.bar.TabBarQuickNotesMenu.searchPlaceholder',
+                  'Search quick notes...'
+                )}
+                value={query}
+                onValueChange={setQuery}
+                className="h-9 py-2 text-[12px]"
+                wrapperClassName="border-b border-border/50 px-2"
+                iconClassName="h-3.5 w-3.5"
+              />
+            ) : null}
+            <CommandList className="max-h-72 py-1">
+              {filtered.length === 0 ? (
+                <CommandEmpty className="py-4 text-center text-[11px]">
+                  {query.trim()
+                    ? translate(
+                        'auto.components.tab.bar.TabBarQuickNotesMenu.noMatch',
+                        'No notes match'
+                      )
+                    : translate('auto.components.tab.bar.TabBarQuickNotesMenu.empty', 'No notes')}
+                </CommandEmpty>
+              ) : null}
+              {filtered.map((note) => (
+                <TabBarQuickNoteItem
+                  key={note.id}
+                  note={note}
+                  onCopy={() => copyAndClose(note)}
+                  onEdit={() => {
+                    setMenuOpen(false)
+                    onEditNote(note)
+                  }}
+                  onDelete={() => {
+                    setMenuOpen(false)
+                    onDeleteNote(note)
+                  }}
+                />
+              ))}
+            </CommandList>
+            <div className="border-t border-border/50 p-1">
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false)
+                  onAddNote()
+                }}
+                className="flex w-full cursor-pointer items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <Plus className="size-3.5" />
+                {translate('auto.components.tab.bar.TabBarQuickNotesMenu.add', 'Note')}
+              </button>
+            </div>
+          </Command>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -13,6 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import TabBar from '../tab-bar/TabBar'
 
 import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
+import { TabBarQuickNotesButton } from '../tab-bar/TabBarQuickNotesButton'
 import { useTabGroupWorkspaceModel } from './useTabGroupWorkspaceModel'
 import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
@@ -273,6 +274,7 @@ export default function TabGroupPanel({
               {isFocused ? (
                 <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
               ) : null}
+              {isFocused ? <TabBarQuickNotesButton /> : null}
               {isFocused && hasSplitGroups ? (
                 <Tooltip>
                   <DropdownMenu modal={false}>

--- a/src/renderer/src/hooks/settings-navigation-workflow-sections.ts
+++ b/src/renderer/src/hooks/settings-navigation-workflow-sections.ts
@@ -7,6 +7,7 @@ import { getGitProviderApiBudgetSearchEntries } from '@/components/settings/git-
 import { getGitPaneSearchEntries } from '@/components/settings/git-search'
 import { getMobileEmulatorSearchEntries } from '@/components/settings/mobile-emulator-search'
 import { getQuickCommandsPaneSearchEntries } from '@/components/settings/quick-commands-search'
+import { getQuickNotesPaneSearchEntries } from '@/components/settings/quick-notes-search'
 import { getShareSkillsSettingsSearchEntries } from '@/components/settings/share-skills-settings-search'
 import { getTasksPaneSearchEntries } from '@/components/settings/tasks-search'
 import { translate } from '@/i18n/i18n'
@@ -21,6 +22,7 @@ import {
   PanelsTopLeft,
   Play,
   SquareTerminal,
+  StickyNote,
   TabletSmartphone
 } from 'lucide-react'
 import type { SettingsNavigationBuildOptions } from './settings-navigation-build-options'
@@ -119,6 +121,17 @@ export function buildWorkflowSettingsSections(
       ),
       icon: Play,
       searchEntries: getQuickCommandsPaneSearchEntries(),
+      group: 'workflows'
+    },
+    {
+      id: 'quick-notes',
+      title: translate('auto.hooks.useSettingsNavigationMetadata.quickNotesTitle', 'Quick Notes'),
+      description: translate(
+        'auto.hooks.useSettingsNavigationMetadata.quickNotesDescription',
+        'Saved snippets of text you can copy to the clipboard.'
+      ),
+      icon: StickyNote,
+      searchEntries: getQuickNotesPaneSearchEntries(),
       group: 'workflows'
     },
     ...(showDesktopOnlySettings

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -543,6 +543,11 @@
               }
             }
           }
+        },
+        "quick": {
+          "notes": {
+            "saveFailed": "Failed to save quick note"
+          }
         }
       }
     },
@@ -1113,7 +1118,9 @@
         "automationsDescription": "Schedule agent work and choose whether Automations appears in the sidebar.",
         "shareSkillsTitle": "Share Skills",
         "shareSkillsDescription": "Share your skills with an unlisted link. Anyone who has it can install them.",
-        "floatingWorkspaceWebDescription": "Global terminal and markdown tabs."
+        "floatingWorkspaceWebDescription": "Global terminal and markdown tabs.",
+        "quickNotesTitle": "Quick Notes",
+        "quickNotesDescription": "Saved snippets of text you can copy to the clipboard."
       },
       "useAppMenuPaste": {
         "pasteTooLarge": "Paste is too large."
@@ -3542,6 +3549,30 @@
           "TabBarQuickCommandHostLoadStatus": {
             "82e294f3ca": "Host unavailable",
             "7c129b08ff": "Loading host…"
+          },
+          "TabBarQuickNoteItem": {
+            "actions": "Quick note actions",
+            "edit": "Edit {{value0}}",
+            "remove": "Remove {{value0}}"
+          },
+          "TabBarQuickNotesButton": {
+            "deleteTitle": "Delete \"{{value0}}\"?",
+            "deleteDescription": "This quick note will be removed from your saved list.",
+            "delete": "Delete",
+            "addAria": "Add quick note",
+            "note": "Note",
+            "addTooltip": "Save a reusable note you can copy to the clipboard"
+          },
+          "TabBarQuickNotesMenu": {
+            "more": "More quick notes",
+            "copyNamed": "Copy quick note: {{value0}}",
+            "copy": "Copy quick note",
+            "note": "Note",
+            "copyTooltip": "Copy \"{{value0}}\" to the clipboard",
+            "searchPlaceholder": "Search quick notes...",
+            "noMatch": "No notes match",
+            "empty": "No notes",
+            "add": "Note"
           }
         }
       },
@@ -8209,7 +8240,9 @@
           "devDescription": "Dev-only tools for exercising UI states.",
           "linearTitle": "Linear",
           "linearDescription": "How Linear works in Orca, setup checklist, agent skill, and example prompts.",
-          "tasksDescription": "Connect providers, install the Linear skill, and choose what appears in Tasks."
+          "tasksDescription": "Connect providers, install the Linear skill, and choose what appears in Tasks.",
+          "quickNotesTitle": "Quick Notes",
+          "quickNotesDescription": "Saved snippets of text you can copy to the clipboard."
         },
         "SettingsFormControls": {
           "42a4d15a30": "No matching fonts.",
@@ -10029,6 +10062,20 @@
               "d691c4e8d8": "Saved terminal commands that can be launched from any terminal, scoped globally or to a specific project.",
               "4c8945952b": "Quick Commands"
             }
+          },
+          "notes": {
+            "search": {
+              "title": "Quick Notes",
+              "description": "Reusable plain-text snippets; picking one from the tab bar copies it to the clipboard.",
+              "kwQuick": "quick",
+              "kwNote": "note",
+              "kwNotes": "notes",
+              "kwSnippet": "snippet",
+              "kwClipboard": "clipboard",
+              "kwCopy": "copy",
+              "kwText": "text",
+              "kwPaste": "paste"
+            }
           }
         },
         "repository": {
@@ -11839,6 +11886,25 @@
           "targetDescription": "Higher values increase contrast where possible. Background colors stay unchanged.",
           "subtle": "Subtle",
           "strong": "Strong"
+        },
+        "QuickNotesList": {
+          "untitled": "Untitled",
+          "copied": "Copied",
+          "copyFailed": "Couldn't copy",
+          "copy": "Copy {{value0}}",
+          "edit": "Edit {{value0}}",
+          "noText": "No text",
+          "remove": "Remove {{value0}}",
+          "noSearchMatches": "No notes match this search.",
+          "none": "No notes saved.",
+          "hint": "Pick one from the Note button in the tab bar to copy it to the clipboard."
+        },
+        "QuickNotesPane": {
+          "search": "Search notes",
+          "deleteTitle": "Delete \"{{value0}}\"?",
+          "deleteDescription": "This quick note will be removed from your saved list.",
+          "delete": "Delete",
+          "add": "Add Note"
         }
       },
       "right": {
@@ -16885,6 +16951,25 @@
       "HostedReviewUnlinkMenuItem": {
         "label": "Unlink {{value0}} from workspace",
         "description": "Orca will hide {{value0}} {{value1}} details for this workspace. The {{value0}} and branch on {{value2}} won’t be changed."
+      },
+      "quick": {
+        "notes": {
+          "QuickNoteDialog": {
+            "editTitle": "Edit Quick Note",
+            "addTitle": "Add Quick Note",
+            "description": "Saved notes appear in the tab bar menu; picking one copies it to the clipboard.",
+            "labelField": "Label",
+            "labelPlaceholder": "Email signature",
+            "bodyField": "Text",
+            "bodyPlaceholder": "The text copied to your clipboard when you pick this note.",
+            "cancel": "Cancel",
+            "save": "Save"
+          },
+          "copyQuickNote": {
+            "copied": "\"{{value0}}\" copied",
+            "failed": "Failed to copy note"
+          }
+        }
       }
     },
     "i18n": {

--- a/src/renderer/src/lib/settings-navigation-types.ts
+++ b/src/renderer/src/lib/settings-navigation-types.ts
@@ -24,6 +24,7 @@ const SETTINGS_NAV_TARGETS = [
   'floating-workspace',
   'terminal',
   'quick-commands',
+  'quick-notes',
   'notifications',
   'computer-use',
   'developer-permissions',

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -45,6 +45,7 @@ import { createNewIssueDraftSlice } from './slices/new-issue-draft'
 import { createTaskCreationDraftsSlice } from './slices/task-creation-drafts'
 import { createRemoteServerUpdatesSlice } from './slices/remote-server-updates'
 import { createTerminalQuickCommandHostsSlice } from './slices/terminal-quick-command-hosts'
+import { createQuickNotesSlice } from './slices/quick-notes'
 import { e2eConfig } from '@/lib/e2e-config'
 import type { createWebRuntimeSessionTerminal } from '@/runtime/web-runtime-session'
 import {
@@ -116,7 +117,8 @@ export const useAppStore = create<AppState>()(
         ...createNewIssueDraftSlice(...a),
         ...createTaskCreationDraftsSlice(...a),
         ...createRemoteServerUpdatesSlice(...a),
-        ...createTerminalQuickCommandHostsSlice(...a)
+        ...createTerminalQuickCommandHostsSlice(...a),
+        ...createQuickNotesSlice(...a)
       }
     })
   )

--- a/src/renderer/src/store/slices/quick-notes.test.ts
+++ b/src/renderer/src/store/slices/quick-notes.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+
+const noteA: QuickNote = { id: 'a', label: 'A', body: 'body a' }
+const noteB: QuickNote = { id: 'b', label: 'B', body: 'body b' }
+
+function storeWithNotes(
+  notes: QuickNote[],
+  updateSettingsOrThrow = vi.fn().mockResolvedValue(undefined)
+) {
+  const store = createTestStore()
+  store.setState({
+    settings: { ...getDefaultSettings('/tmp'), quickNotes: notes },
+    updateSettingsOrThrow
+  })
+  return { store, updateSettingsOrThrow }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('quick notes slice', () => {
+  it('upsert appends a new note through updateSettingsOrThrow', async () => {
+    const { store, updateSettingsOrThrow } = storeWithNotes([noteA])
+    await store.getState().upsertQuickNote(noteB)
+    expect(updateSettingsOrThrow).toHaveBeenCalledWith({ quickNotes: [noteA, noteB] })
+  })
+
+  it('upsert replaces an existing note by id', async () => {
+    const { store, updateSettingsOrThrow } = storeWithNotes([noteA, noteB])
+    const renamed = { ...noteA, label: 'A2' }
+    await store.getState().upsertQuickNote(renamed)
+    expect(updateSettingsOrThrow).toHaveBeenCalledWith({ quickNotes: [renamed, noteB] })
+  })
+
+  it('delete removes a note by id', async () => {
+    const { store, updateSettingsOrThrow } = storeWithNotes([noteA, noteB])
+    await store.getState().deleteQuickNote('a')
+    expect(updateSettingsOrThrow).toHaveBeenCalledWith({ quickNotes: [noteB] })
+  })
+
+  it('returns false and does not throw when persistence rejects', async () => {
+    const { store } = storeWithNotes([], vi.fn().mockRejectedValue(new Error('disk full')))
+    await expect(store.getState().upsertQuickNote(noteA)).resolves.toBe(false)
+  })
+
+  it('setRecentQuickNoteId updates state', () => {
+    const { store } = storeWithNotes([noteA])
+    store.getState().setRecentQuickNoteId('a')
+    expect(store.getState().recentQuickNoteId).toBe('a')
+  })
+})

--- a/src/renderer/src/store/slices/quick-notes.ts
+++ b/src/renderer/src/store/slices/quick-notes.ts
@@ -1,0 +1,41 @@
+import type { StateCreator } from 'zustand'
+import { toast } from 'sonner'
+import type { AppState } from '../types'
+import type { QuickNote } from '../../../../shared/quick-note-types'
+import { applyQuickNoteMutation, type QuickNoteMutation } from '../../../../shared/quick-notes'
+import { translate } from '@/i18n/i18n'
+
+export type QuickNotesSlice = {
+  /** Last note the user copied; drives the split-button's primary action. */
+  recentQuickNoteId: string | null
+  setRecentQuickNoteId: (id: string) => void
+  upsertQuickNote: (note: QuickNote) => Promise<boolean>
+  deleteQuickNote: (id: string) => Promise<boolean>
+}
+
+async function mutateQuickNotes(
+  get: Parameters<StateCreator<AppState>>[1],
+  mutation: QuickNoteMutation
+): Promise<boolean> {
+  try {
+    const current = get().settings?.quickNotes ?? []
+    await get().updateSettingsOrThrow({ quickNotes: applyQuickNoteMutation(current, mutation) })
+    return true
+  } catch (error) {
+    toast.error(
+      translate('auto.store.slices.quick.notes.saveFailed', 'Failed to save quick note'),
+      { description: error instanceof Error ? error.message : undefined }
+    )
+    return false
+  }
+}
+
+export const createQuickNotesSlice: StateCreator<AppState, [], [], QuickNotesSlice> = (
+  _set,
+  get
+) => ({
+  recentQuickNoteId: null,
+  setRecentQuickNoteId: (id) => _set({ recentQuickNoteId: id }),
+  upsertQuickNote: (note) => mutateQuickNotes(get, { type: 'upsert', note }),
+  deleteQuickNote: (id) => mutateQuickNotes(get, { type: 'delete', id })
+})

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -10,6 +10,7 @@ import {
 import { assertRuntimeStatusCompatible } from '@/runtime/runtime-protocol-compat'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import { normalizeTerminalQuickCommands } from '../../../../shared/terminal-quick-commands'
+import { normalizeQuickNotes } from '../../../../shared/quick-notes'
 import { normalizeTerminalCustomThemes } from '../../../../shared/terminal-custom-themes'
 import { normalizeTaskProviderSettings } from '../../../../shared/task-providers'
 import { normalizeOpenInApplications } from '../../../../shared/open-in-applications'
@@ -75,6 +76,9 @@ function normalizeSettingsUpdates(
     sanitizedUpdates.terminalQuickCommands = normalizeTerminalQuickCommands(
       updates.terminalQuickCommands
     )
+  }
+  if ('quickNotes' in updates) {
+    sanitizedUpdates.quickNotes = normalizeQuickNotes(updates.quickNotes)
   }
   if ('terminalCustomThemes' in updates) {
     sanitizedUpdates.terminalCustomThemes = normalizeTerminalCustomThemes(

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -49,6 +49,7 @@ import { createNewIssueDraftSlice } from './new-issue-draft'
 import { createTaskCreationDraftsSlice } from './task-creation-drafts'
 import { createRemoteServerUpdatesSlice } from './remote-server-updates'
 import { createTerminalQuickCommandHostsSlice } from './terminal-quick-command-hosts'
+import { createQuickNotesSlice } from './quick-notes'
 import { translate } from '@/i18n/i18n'
 
 export const TEST_REPO = {
@@ -103,7 +104,8 @@ export function createTestStore() {
     ...createNewIssueDraftSlice(...a),
     ...createTaskCreationDraftsSlice(...a),
     ...createRemoteServerUpdatesSlice(...a),
-    ...createTerminalQuickCommandHostsSlice(...a)
+    ...createTerminalQuickCommandHostsSlice(...a),
+    ...createQuickNotesSlice(...a)
   }))
 }
 

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -43,6 +43,7 @@ import type { NewIssueDraftSlice } from './slices/new-issue-draft'
 import type { TaskCreationDraftsSlice } from './slices/task-creation-drafts'
 import type { RemoteServerUpdatesSlice } from './slices/remote-server-updates'
 import type { TerminalQuickCommandHostsSlice } from './slices/terminal-quick-command-hosts'
+import type { QuickNotesSlice } from './slices/quick-notes'
 
 export type AppState = RepoSlice &
   SparsePresetsSlice &
@@ -86,4 +87,5 @@ export type AppState = RepoSlice &
   NewIssueDraftSlice &
   TaskCreationDraftsSlice &
   RemoteServerUpdatesSlice &
-  TerminalQuickCommandHostsSlice
+  TerminalQuickCommandHostsSlice &
+  QuickNotesSlice

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -3,6 +3,7 @@ import type { NotificationSettings } from './notification-settings-types'
 import type { VoiceSettings } from './speech-types'
 import { DEFAULT_TERMINAL_FONT_WEIGHT, DEFAULT_TERMINAL_FONT_WEIGHT_BOLD } from './terminal-fonts'
 import { getDefaultTerminalQuickCommands } from './terminal-quick-commands'
+import { getDefaultQuickNotes } from './quick-notes'
 import { TASK_PROVIDERS } from './task-providers'
 import { getDefaultSourceControlAiSettings } from './source-control-ai'
 import { DEFAULT_APP_ICON_ID } from './app-icon'
@@ -98,6 +99,7 @@ export function buildDefaultSettings(args: {
     terminalWindowsPowerShellImplementation: 'auto',
     terminalMouseHideWhileTyping: false,
     terminalQuickCommands: getDefaultTerminalQuickCommands(),
+    quickNotes: getDefaultQuickNotes(),
     // Why: opt-in only, matching Ghostty's default (upgrades never enable it unexpectedly).
     terminalFocusFollowsMouse: false,
     windowBackgroundBlur: false,

--- a/src/shared/feature-interaction-catalog.ts
+++ b/src/shared/feature-interaction-catalog.ts
@@ -43,6 +43,7 @@ export type FeatureInteractionId =
   | 'notifications'
   | 'ports'
   | 'quick-commands'
+  | 'quick-notes'
   | 'resource-manager'
   | 'review-notes'
   | 'ssh'
@@ -137,6 +138,7 @@ export const FEATURE_INTERACTIONS = [
   { id: 'notifications', interaction: 'desktop notifications enabled or tested' },
   { id: 'ports', interaction: 'Ports popover opened, configured, or port action used' },
   { id: 'quick-commands', interaction: 'terminal quick command created or edited' },
+  { id: 'quick-notes', interaction: 'quick note created or edited' },
   { id: 'resource-manager', interaction: 'Resource Manager opened or configured' },
   { id: 'review-notes', interaction: 'review note added or sent to an agent' },
   {

--- a/src/shared/feature-interaction-categories.ts
+++ b/src/shared/feature-interaction-categories.ts
@@ -64,6 +64,7 @@ export const FEATURE_INTERACTION_CATEGORY_BY_ID = {
   notifications: 'settings',
   ports: 'resource_management',
   'quick-commands': 'launcher',
+  'quick-notes': 'launcher',
   'resource-manager': 'resource_management',
   'review-notes': 'review',
   ssh: 'setup',

--- a/src/shared/feature-interactions.test.ts
+++ b/src/shared/feature-interactions.test.ts
@@ -76,6 +76,7 @@ describe('feature interactions', () => {
       'notifications',
       'ports',
       'quick-commands',
+      'quick-notes',
       'resource-manager',
       'review-notes',
       'ssh',

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -24,6 +24,7 @@ import type { NotificationSettings } from './notification-settings-types'
 import type { CtrlTabOrderMode } from './tab-types'
 import type { TerminalColorOverrides } from './terminal-color-overrides'
 import type { TerminalQuickCommand } from './terminal-quick-command-types'
+import type { QuickNote } from './quick-note-types'
 import type { TuiAgent } from './tui-agent'
 import type {
   AgentDashboardMode,
@@ -155,6 +156,8 @@ export type GlobalSettings = {
   terminalWordSeparator?: string
   terminalCursorOpacity?: number
   terminalQuickCommands?: TerminalQuickCommand[]
+  /** Reusable plain-text snippets; picking one copies its body to the clipboard. Global scope only. */
+  quickNotes?: QuickNote[]
   windowBackgroundBlur?: boolean
   /** Windows-only: close (X) hides to tray instead of quitting; the tray icon is always present regardless. */
   minimizeToTrayOnClose?: boolean

--- a/src/shared/quick-note-types.ts
+++ b/src/shared/quick-note-types.ts
@@ -1,0 +1,6 @@
+export type QuickNote = {
+  id: string
+  label: string
+  /** Plain multi-line text copied verbatim to the clipboard when the note is picked. */
+  body: string
+}

--- a/src/shared/quick-notes.test.ts
+++ b/src/shared/quick-notes.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyQuickNoteMutation,
+  MAX_QUICK_NOTES,
+  MAX_QUICK_NOTE_BODY_LENGTH,
+  MAX_QUICK_NOTE_LABEL_LENGTH,
+  normalizeQuickNotes
+} from './quick-notes'
+import type { QuickNote } from './quick-note-types'
+
+const note = (over: Partial<QuickNote> = {}): QuickNote => ({
+  id: 'quick-note-1',
+  label: 'Signature',
+  body: 'Best,\nFrank',
+  ...over
+})
+
+describe('normalizeQuickNotes', () => {
+  it('returns [] for non-arrays', () => {
+    expect(normalizeQuickNotes(undefined)).toEqual([])
+    expect(normalizeQuickNotes(null)).toEqual([])
+    expect(normalizeQuickNotes('nope')).toEqual([])
+  })
+
+  it('drops non-object entries and entries with neither label nor body', () => {
+    expect(normalizeQuickNotes([1, 'x', null, {}, { id: 'a' }])).toEqual([])
+  })
+
+  it('trims and caps label and body', () => {
+    const [out] = normalizeQuickNotes([
+      { id: 'a', label: `  ${'x'.repeat(200)}  `, body: `${'y'.repeat(20000)}\n\n` }
+    ])
+    expect(out.label).toHaveLength(MAX_QUICK_NOTE_LABEL_LENGTH)
+    expect(out.body).toHaveLength(MAX_QUICK_NOTE_BODY_LENGTH)
+  })
+
+  it('generates ids when missing and dedupes collisions', () => {
+    const out = normalizeQuickNotes([
+      { label: 'one', body: 'a' },
+      { id: 'dup', label: 'two', body: 'b' },
+      { id: 'dup', label: 'three', body: 'c' }
+    ])
+    expect(out.map((n) => n.id)).toEqual(['quick-note-1', 'dup', 'dup-2'])
+  })
+
+  it('keeps a half-filled row (label only) so a fresh add is not dropped mid-edit', () => {
+    expect(normalizeQuickNotes([{ id: 'a', label: 'Draft' }])).toEqual([
+      { id: 'a', label: 'Draft', body: '' }
+    ])
+  })
+
+  it('caps the list at MAX_QUICK_NOTES', () => {
+    const many = Array.from({ length: MAX_QUICK_NOTES + 5 }, (_, i) => ({
+      id: `n${i}`,
+      label: `n${i}`,
+      body: 'x'
+    }))
+    expect(normalizeQuickNotes(many)).toHaveLength(MAX_QUICK_NOTES)
+  })
+})
+
+describe('applyQuickNoteMutation', () => {
+  it('appends a new note on upsert', () => {
+    expect(applyQuickNoteMutation([], { type: 'upsert', note: note() })).toEqual([note()])
+  })
+
+  it('replaces an existing note by id on upsert', () => {
+    const next = note({ label: 'Renamed' })
+    expect(applyQuickNoteMutation([note()], { type: 'upsert', note: next })).toEqual([next])
+  })
+
+  it('removes a note on delete', () => {
+    expect(applyQuickNoteMutation([note()], { type: 'delete', id: 'quick-note-1' })).toEqual([])
+  })
+})

--- a/src/shared/quick-notes.ts
+++ b/src/shared/quick-notes.ts
@@ -1,0 +1,75 @@
+import type { QuickNote } from './quick-note-types'
+
+export const MAX_QUICK_NOTES = 40
+export const MAX_QUICK_NOTE_ID_LENGTH = 80
+export const MAX_QUICK_NOTE_LABEL_LENGTH = 80
+export const MAX_QUICK_NOTE_BODY_LENGTH = 10000
+
+export type QuickNoteMutation = { type: 'upsert'; note: QuickNote } | { type: 'delete'; id: string }
+
+export function getDefaultQuickNotes(): QuickNote[] {
+  return []
+}
+
+export function normalizeQuickNotes(input: unknown): QuickNote[] {
+  if (!Array.isArray(input)) {
+    return []
+  }
+
+  const normalized: QuickNote[] = []
+  const seenIds = new Set<string>()
+
+  for (const item of input) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      continue
+    }
+    const record = item as Record<string, unknown>
+    const hasLabel = typeof record.label === 'string'
+    const hasBody = typeof record.body === 'string'
+    // Why: settings saves on every edit; keep half-filled rows so a freshly
+    // added note is not dropped before the user finishes typing.
+    if (!hasLabel && !hasBody) {
+      continue
+    }
+
+    const rawId = typeof record.id === 'string' ? record.id.trim() : ''
+    const idBase = rawId || `quick-note-${normalized.length + 1}`
+    let id = idBase.slice(0, MAX_QUICK_NOTE_ID_LENGTH)
+    let suffix = 2
+    while (seenIds.has(id)) {
+      id = `${idBase.slice(0, MAX_QUICK_NOTE_ID_LENGTH - 4)}-${suffix}`
+      suffix += 1
+    }
+    seenIds.add(id)
+
+    normalized.push({
+      id,
+      label: (hasLabel ? String(record.label).trim() : '').slice(0, MAX_QUICK_NOTE_LABEL_LENGTH),
+      body: (hasBody ? String(record.body).trimEnd() : '').slice(0, MAX_QUICK_NOTE_BODY_LENGTH)
+    })
+
+    if (normalized.length >= MAX_QUICK_NOTES) {
+      break
+    }
+  }
+
+  return normalized
+}
+
+export function isQuickNoteComplete(note: QuickNote): boolean {
+  return note.label.trim().length > 0 && note.body.trim().length > 0
+}
+
+export function applyQuickNoteMutation(
+  notes: readonly QuickNote[],
+  mutation: QuickNoteMutation
+): QuickNote[] {
+  if (mutation.type === 'delete') {
+    return notes.filter((note) => note.id !== mutation.id)
+  }
+  const existingIndex = notes.findIndex((note) => note.id === mutation.note.id)
+  if (existingIndex === -1) {
+    return [...notes, mutation.note]
+  }
+  return notes.map((note, index) => (index === existingIndex ? mutation.note : note))
+}


### PR DESCRIPTION
## ELI5

<!-- Simple high-level explanation -->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- What problem does this solve, and why is this approach right? -->

## Linked Issue

<!-- Link the issue this PR addresses, there should ALWAYS be one -->

Fixes #

## Visual Proof

<!-- REQUIRED for UI / behavior changes. Please attach a BEFORE and AFTER that can easily tabbed/switched. Use videos for when appropriate over screenshots -->
<!-- If there is truly no visual or interaction change, write exactly: `N/A` and briefly say why. -->
<!-- For attachments NEVER add directly to the PR files (do not commit to files), use `gh image` extension or drag + drop (works for any attachment) -->

## Testing

<!-- How did you verify this? Steps a reviewer can follow. Which platforms did you actually test (macOS / Linux / Windows / SSH)? -->

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->
<!-- Which AI model if anyone was used, please state the details -->

## Review

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
