### PR TITLE
feat(nix): add a Nix flake to install Orca from the release AppImage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1789006805,
+        "narHash": "sha256-xB8mKMOx1IA9vTDNLmJZ6n4wCMq/cuWBBOzGCRnqxrU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "8ce4ef6cb6f871616146b9fe26d2a5ae594e94fe",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,87 @@
+{
+  description = "Orca — next-gen IDE for parallel agentic development";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      version = "1.4.200";
+
+      # Prebuilt AppImages published with every Orca release. Bump `version` and
+      # both hashes together (`nix-prefetch-url --type sha256 <url>` to refresh).
+      sources = {
+        x86_64-linux = {
+          url = "https://github.com/stablyai/orca/releases/download/v${version}/orca-linux.AppImage";
+          hash = "sha256-yC2d31MkMeDaUexdGJmg4xWqu453/ORezOf61HM/yWo=";
+        };
+        aarch64-linux = {
+          url = "https://github.com/stablyai/orca/releases/download/v${version}/orca-linux-arm64.AppImage";
+          hash = "sha256-PrD/mxEbg4Trm4/pjYCa7zVG9pVIF3WciCh3tHFgQUQ=";
+        };
+      };
+
+      systems = builtins.attrNames sources;
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      orcaFor =
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          inherit (pkgs) lib appimageTools fetchurl;
+
+          # Why: Ubuntu's `orca` is the GNOME screen reader, so Orca ships its
+          # Linux binary and desktop entry as `orca-ide` to avoid the clash.
+          pname = "orca-ide";
+          src = fetchurl sources.${system};
+          appimageContents = appimageTools.extractType2 { inherit pname version src; };
+        in
+        appimageTools.wrapType2 {
+          inherit pname version src;
+
+          # Ship the .desktop entry and full icon set the AppImage carries, and
+          # point Exec at the wrapped binary instead of the bundled AppRun.
+          extraInstallCommands = ''
+            install -Dm444 ${appimageContents}/${pname}.desktop -t $out/share/applications
+            substituteInPlace $out/share/applications/${pname}.desktop \
+              --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+            for size in 16 24 32 48 64 128 256 512; do
+              install -Dm444 \
+                "${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/${pname}.png" \
+                "$out/share/icons/hicolor/''${size}x''${size}/apps/${pname}.png"
+            done
+          '';
+
+          meta = {
+            description = "Next-gen IDE for parallel agentic development";
+            homepage = "https://github.com/stablyai/orca";
+            downloadPage = "https://github.com/stablyai/orca/releases";
+            changelog = "https://github.com/stablyai/orca/releases/tag/v${version}";
+            license = lib.licenses.mit;
+            sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+            platforms = systems;
+            mainProgram = pname;
+          };
+        };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          orca = orcaFor system;
+        in
+        {
+          default = orca;
+          orca = orca;
+        }
+      );
+
+      apps = forAllSystems (system: rec {
+        default = orca;
+        orca = {
+          type = "app";
+          program = nixpkgs.lib.getExe self.packages.${system}.orca;
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Orca — next-gen IDE for parallel agentic development";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs =
     { self, nixpkgs }:


### PR DESCRIPTION
Closes #20128.

Adds a root `flake.nix` (+ locked `flake.lock`) so Nix users can install and run Orca reproducibly, wrapping the AppImage published with each release. There's no from-source build here — that would mean a bespoke pnpm + Electron + native-module derivation; wrapping the official AppImage is the low-friction path and stays in lockstep with releases.

## What it provides
- `packages.{x86_64-linux,aarch64-linux}.default` (and `.orca`) — `appimageTools.wrapType2` around the release AppImage, installing the `orca-ide.desktop` entry (with `Exec` rewritten from `AppRun` to the wrapped binary) and the full hicolor icon set (16→512).
- `apps.default` (and `.orca`) — so `nix run github:stablyai/orca` launches it.
- Binary / desktop id is **`orca-ide`** to match the Linux packaging in `config/electron-builder.config.cjs` (avoids the clash with GNOME Orca's `/usr/bin/orca`); `meta.mainProgram = "orca-ide"`.

## Usage
```sh
# run without installing
nix run github:stablyai/orca

# install into a profile
nix profile install github:stablyai/orca
```
Flake input for NixOS / home-manager:
```nix
inputs.orca.url = "github:stablyai/orca";
# environment.systemPackages = [ inputs.orca.packages.${pkgs.system}.default ];
```

## Verified on Linux
Built and checked on Ubuntu 24.04 (rootless, via `nix-portable`):
- `nix flake check` passes; evaluates on both `x86_64-linux` and `aarch64-linux`.
- `nix build .#packages.x86_64-linux.default` succeeds; the output contains `bin/orca-ide`, `share/applications/orca-ide.desktop` (`Exec=orca-ide %U`, `Icon=orca-ide`), and `share/icons/hicolor/{16,24,32,48,64,128,256,512}/apps/orca-ide.png`.
- The pinned `sha256` values are the real published **v1.4.200** AppImage assets (`orca-linux.AppImage`, `orca-linux-arm64.AppImage`).

## Maintenance
On each release, bump `version` and both `sources.*.hash` values together (`nix-prefetch-url --type sha256 <AppImage url>`). A small CI step on tag could automate this — happy to follow up. A nixpkgs submission (`pkgs/by-name/or/orca`) with an update script is a natural next step so `nixpkgs#orca` works out of the box.

Orca is MIT-licensed, so redistributing the release artifact via Nix is unencumbered.

---
*Related: #18086 (signed apt/yum repositories) — same OS-native install goal for a different ecosystem.*
