### PR TITLE
fix(main): verify the macOS sleep assertion is still held

### DIFF
--- a/src/main/macos-system-sleep-assertion.test.ts
+++ b/src/main/macos-system-sleep-assertion.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 import {
   MACOS_SYSTEM_SLEEP_ASSERTION_RETRY_MS,
+  MACOS_SYSTEM_SLEEP_ASSERTION_WATCHDOG_MS,
   MacosSystemSleepAssertion
 } from './macos-system-sleep-assertion'
 
@@ -56,6 +57,7 @@ describe('MacosSystemSleepAssertion', () => {
     const assertion = new MacosSystemSleepAssertion({
       logger: createLogger(),
       platform: 'darwin',
+      isProcessAlive: () => true,
       spawn
     })
 
@@ -219,5 +221,71 @@ describe('MacosSystemSleepAssertion', () => {
     expect(logger.warn).toHaveBeenCalledTimes(2)
     expect(logger.debug).toHaveBeenCalledTimes(1)
     assertion.dispose()
+  })
+
+  it('respawns when the recorded child vanished without an exit event', () => {
+    const spawn = vi.fn(() => new FakeCaffeinateProcess())
+    const assertion = new MacosSystemSleepAssertion({
+      logger: createLogger(),
+      platform: 'darwin',
+      isProcessAlive: () => false,
+      spawn
+    })
+
+    assertion.start('status-change')
+    expect(assertion.start('status-change')).toBe(true)
+
+    // Without a liveness check the second start short-circuits and the OS holds nothing.
+    expect(spawn).toHaveBeenCalledTimes(2)
+    assertion.dispose()
+  })
+
+  it('reports a vanished assertion from the watchdog so the service re-arms', () => {
+    vi.useFakeTimers()
+    try {
+      let alive = true
+      const onUnexpectedFailure = vi.fn()
+      const assertion = new MacosSystemSleepAssertion({
+        logger: createLogger(),
+        platform: 'darwin',
+        isProcessAlive: () => alive,
+        onUnexpectedFailure,
+        spawn: vi.fn(() => new FakeCaffeinateProcess())
+      })
+
+      assertion.start('status-change')
+      vi.advanceTimersByTime(MACOS_SYSTEM_SLEEP_ASSERTION_WATCHDOG_MS)
+      expect(onUnexpectedFailure).not.toHaveBeenCalled()
+
+      alive = false
+      vi.advanceTimersByTime(MACOS_SYSTEM_SLEEP_ASSERTION_WATCHDOG_MS)
+
+      expect(onUnexpectedFailure).toHaveBeenCalledWith('macos-assertion-vanished')
+      assertion.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops the watchdog once the assertion is intentionally released', () => {
+    vi.useFakeTimers()
+    try {
+      const onUnexpectedFailure = vi.fn()
+      const assertion = new MacosSystemSleepAssertion({
+        logger: createLogger(),
+        platform: 'darwin',
+        isProcessAlive: () => false,
+        onUnexpectedFailure,
+        spawn: vi.fn(() => new FakeCaffeinateProcess())
+      })
+
+      assertion.start('status-change')
+      assertion.stop('settings-change')
+      vi.advanceTimersByTime(MACOS_SYSTEM_SLEEP_ASSERTION_WATCHDOG_MS * 3)
+
+      expect(onUnexpectedFailure).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/macos-system-sleep-assertion.ts
+++ b/src/main/macos-system-sleep-assertion.ts
@@ -1,6 +1,9 @@
 import { spawn as nodeSpawn } from 'node:child_process'
 
 export const MACOS_SYSTEM_SLEEP_ASSERTION_RETRY_MS = 30_000
+// Why: a killed or reaped caffeinate can leave `child` set with no exit event, and the
+// service stops the Electron blocker on that word — so the belief must be re-verified.
+export const MACOS_SYSTEM_SLEEP_ASSERTION_WATCHDOG_MS = 30_000
 
 type Logger = Pick<Console, 'debug' | 'warn'>
 
@@ -28,6 +31,8 @@ type MacosSystemSleepAssertionOptions = {
   onUnexpectedFailure?: (reason: string) => void
   platform?: NodeJS.Platform
   spawn?: CaffeinateSpawn
+  isProcessAlive?: (pid: number) => boolean
+  watchdogIntervalMs?: number
 }
 
 export class MacosSystemSleepAssertion {
@@ -36,7 +41,11 @@ export class MacosSystemSleepAssertion {
   private readonly onUnexpectedFailure: (reason: string) => void
   private readonly platform: NodeJS.Platform
   private readonly spawn: CaffeinateSpawn
+  private readonly isProcessAlive: (pid: number) => boolean
+  private readonly watchdogIntervalMs: number
   private child: CaffeinateProcess | null = null
+  private childPid: number | null = null
+  private watchdogTimer: ReturnType<typeof setInterval> | null = null
   private retryNotBefore: number | null = null
   private retryTimer: ReturnType<typeof setTimeout> | null = null
   private lastFailureKey: string | null = null
@@ -51,6 +60,8 @@ export class MacosSystemSleepAssertion {
     this.onUnexpectedFailure = options.onUnexpectedFailure ?? (() => {})
     this.platform = options.platform ?? process.platform
     this.spawn = options.spawn ?? nodeSpawn
+    this.isProcessAlive = options.isProcessAlive ?? processIsAlive
+    this.watchdogIntervalMs = options.watchdogIntervalMs ?? MACOS_SYSTEM_SLEEP_ASSERTION_WATCHDOG_MS
   }
 
   start(reason: string): boolean {
@@ -58,7 +69,10 @@ export class MacosSystemSleepAssertion {
       return false
     }
     if (this.child) {
-      return true
+      if (this.isChildAlive()) {
+        return true
+      }
+      this.forgetChild()
     }
     if (this.retryNotBefore !== null && this.now() < this.retryNotBefore) {
       this.scheduleRetry()
@@ -77,6 +91,7 @@ export class MacosSystemSleepAssertion {
     }
 
     this.child = child
+    this.childPid = typeof child.pid === 'number' ? child.pid : null
     const onError: CaffeinateErrorListener = (error) => {
       this.handleChildFailure(child, `error:${String(error.message)}`, 'error', reason, error)
     }
@@ -92,6 +107,7 @@ export class MacosSystemSleepAssertion {
     })
     child.on('error', onError)
     child.on('exit', onExit)
+    this.armWatchdog()
     this.resetRetrySuppression()
     this.resetFailureStreak()
     return true
@@ -105,6 +121,8 @@ export class MacosSystemSleepAssertion {
     }
     const child = this.child
     this.child = null
+    this.childPid = null
+    this.clearWatchdog()
     this.intentionalStops.add(child)
     this.detachChildListeners(child)
     try {
@@ -139,7 +157,7 @@ export class MacosSystemSleepAssertion {
     }
     this.reportedFailures.add(child)
     if (this.child === child) {
-      this.child = null
+      this.forgetChild()
     }
     this.handleFailure(failureKey, startReason, details, failureType)
   }
@@ -185,6 +203,44 @@ export class MacosSystemSleepAssertion {
     this.logger.warn('[agent-awake] macOS system sleep assertion failed', payload)
   }
 
+  private isChildAlive(): boolean {
+    // No pid means an injected test double; there is nothing to verify against.
+    return this.childPid === null ? true : this.isProcessAlive(this.childPid)
+  }
+
+  private forgetChild(): void {
+    const child = this.child
+    this.child = null
+    this.childPid = null
+    this.clearWatchdog()
+    if (child) {
+      this.detachChildListeners(child)
+    }
+  }
+
+  private armWatchdog(): void {
+    this.clearWatchdog()
+    this.watchdogTimer = setInterval(() => {
+      if (this.isChildAlive()) {
+        return
+      }
+      this.logger.warn('[agent-awake] macOS system sleep assertion vanished without an exit event')
+      this.forgetChild()
+      this.onUnexpectedFailure('macos-assertion-vanished')
+    }, this.watchdogIntervalMs)
+    if (typeof this.watchdogTimer.unref === 'function') {
+      this.watchdogTimer.unref()
+    }
+  }
+
+  private clearWatchdog(): void {
+    if (!this.watchdogTimer) {
+      return
+    }
+    clearInterval(this.watchdogTimer)
+    this.watchdogTimer = null
+  }
+
   private scheduleRetry(): void {
     if (this.retryNotBefore === null || this.retryTimer) {
       return
@@ -211,6 +267,16 @@ export class MacosSystemSleepAssertion {
   private resetFailureStreak(): void {
     this.lastFailureKey = null
     this.warnedForLastFailure = false
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    // EPERM means the pid is live but not ours; only ESRCH proves it is gone.
+    return !isEsrchError(error)
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |

<!-- /orca-pr-loc -->

## What broke

On a real machine the "Keep computer awake" badge read **On · Active** for 15h49m while the OS held no sleep assertion at all.

```
persisted setting:                    "computerAwakeMode":"on"
Orca-owned power assertions:          NONE
caffeinate -i -s anywhere:            NONE
pmset system-wide PreventSystemSleep: 0
```

The machine idle-slept repeatedly under running agents (`Entering Sleep state due to 'Idle Sleep'`), on AC at 100%.

## Mechanism

`MacosSystemSleepAssertion.start()` returned `true` on `this.child !== null` alone — it tracked *intent*, never verified OS state. `AgentAwakeService.refresh()` then *stops* the Electron `powerSaveBlocker` on that word:

```ts
const macosAssertionActive = this.startMacosAssertion(reason)
if (this.platform !== 'darwin' || !macosAssertionActive) {
  this.startBlocker(reason, runningStatusCount)
} else {
  this.stopBlocker('macos-assertion-active', runningStatusCount)
}
```

So a caffeinate that died without delivering an exit event leaves **both** mechanisms off, and nothing re-checks. `setMode` early-returns on an unchanged value, so even re-selecting the same mode cannot recover it.

Note the asymmetry this fixes: `reconcileBlocker()` already re-checks the Electron blocker with `isStarted(id)`. The caffeinate child had no equivalent.

## The fix

- `start()` verifies the recorded pid with `process.kill(pid, 0)` instead of trusting the handle, and respawns when the assertion is actually gone. `EPERM` counts as alive; only `ESRCH` proves death.
- A watchdog re-checks liveness every 30s while the assertion is meant to be held and reports `macos-assertion-vanished`, so the service re-arms through its existing failure path. Cleared on `stop()` / `dispose()`.

All of it lives in the assertion class, which owns the child. **`agent-awake-service.ts` is deliberately untouched** — it sits at exactly 300 counted lines, the oxlint `max-lines` cap, so any added line would redden lint on CI's merge ref.

## Ablation

Two isolated arms; a test green in both states proves nothing.

| Arm | Reverted | Result |
|---|---|---|
| A | `start()` back to blind `if (this.child) return true` | `respawns when the recorded child vanished` FAILS (1 failed, 12 passed) |
| B | `armWatchdog()` call removed | `reports a vanished assertion from the watchdog` FAILS (1 failed, 12 passed) |
| — | restored | 13 passed |

Each arm failed exactly its target test and nothing else.

## Validation

- `pnpm test src/main/macos-system-sleep-assertion.test.ts` — 13 passed
- `pnpm test` on `agent-awake-service`, platform assertions, `ipc/settings` — 55 passed
- `pnpm tc` — clean (verified from output, not just exit code)
- `pnpm run check:code-quality:changed` — 0 new findings
- pre-commit hook (oxlint, react-doctor, oxfmt) — passed

## Scope

One of four independent defects found in this subsystem; the other three are separate PRs (badge reporting the setting instead of the state, nothing re-arming after launch, and the `before-quit` teardown running on vetoed quits).

**Not fixed here, and worth knowing:** `caffeinate -i -s` cannot prevent lid-close sleep on macOS at all, and `-s` is AC-power-only.