### PR TITLE
refactor(native-chat): give each structured dispatch state exactly one meaning

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-31",
+  "updatedAt": "2026-09-11",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -161,6 +161,153 @@
         "Mobile native presentation and dismissal integration belongs to the subsequent mobile PR."
       ],
       "demotionRule": "Keep experimental if lifecycle or policy assertions fail; do not weaken them to bypass platform delivery gaps."
+    },
+    {
+      "id": "agent-session.structured-send-at-most-once",
+      "title": "Ambiguous structured sends never become a second provider delivery",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "agent-session-runtime",
+      "layer": "shared-host-renderer-and-mobile-unit",
+      "surfaces": ["desktop native chat", "mobile native chat", "structured agent-session RPC"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "ssh", "remote-runtime", "mobile"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "mobile"],
+      "coverageNotes": "Deterministic host, renderer, direct/Relay transport, and mobile hook tests cover durable identity, caller changes, journal loss, acknowledgement loss, expiry, and remount. The host code is execution-location neutral, but live SSH/remote runtimes and physical iOS/Android lifecycle are not exercised.",
+      "motivatingLinks": ["https://github.com/stablyai/orca/pull/20133"],
+      "invariant": "One structured-send operation id causes at most one provider dispatch. A recorded or transport-ambiguous send reuses that id across retry, caller reconnect, client remount, and journal recovery; only a terminal rejection may rotate to a first delivery.",
+      "oracle": "Inject adapter acknowledgement loss, RPC response loss, caller replacement, logical-client close after response, auth recovery with a written request, missing journal submissions, legacy pending rows, stale fences, operation expiry, mobile remount, and durable-journal capacity. Assert one provider dispatch or one operation id for every ambiguous retry, fresh identity only after rejection, and no eviction of ambiguous mobile ids.",
+      "commands": [
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/shared/agent-session-operation-ledger.test.ts src/shared/structured-agent-session-send-disposition.test.ts src/main/runtime/agent-session-operation-admission.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts src/main/runtime/orchestration/structured-pointer-operation-id.test.ts src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx src/renderer/src/lib/launch-structured-agent-session.test.ts",
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm --dir mobile test ../mobile/src/session/mobile-native-chat-image-attachment.test.ts ../mobile/src/session/use-mobile-native-chat-image-attachments.test.ts ../mobile/src/session/mobile-structured-send-operation-journal.test.ts ../mobile/src/session/mobile-structured-session-operation-retention.test.ts ../mobile/src/session/mobile-structured-send-delivery.test.ts ../mobile/src/session/use-mobile-structured-agent-session-send.test.tsx ../mobile/src/session/use-mobile-structured-agent-session.test.tsx ../mobile/src/transport/mobile-relay-rpc-session.test.ts ../mobile/src/transport/rpc-client-delivery-ambiguity.test.ts ../mobile/src/transport/stable-logical-rpc-client.test.ts"
+      ],
+      "testFiles": [
+        "src/shared/agent-session-operation-ledger.test.ts",
+        "src/shared/structured-agent-session-send-disposition.test.ts",
+        "src/main/runtime/agent-session-operation-admission.test.ts",
+        "src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts",
+        "src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts",
+        "src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts",
+        "src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts",
+        "src/main/runtime/orchestration/structured-pointer-operation-id.test.ts",
+        "src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx",
+        "src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx",
+        "src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx",
+        "src/renderer/src/lib/launch-structured-agent-session.test.ts",
+        "mobile/src/session/mobile-native-chat-image-attachment.test.ts",
+        "mobile/src/session/use-mobile-native-chat-image-attachments.test.ts",
+        "mobile/src/session/mobile-structured-send-operation-journal.test.ts",
+        "mobile/src/session/mobile-structured-session-operation-retention.test.ts",
+        "mobile/src/session/mobile-structured-send-delivery.test.ts",
+        "mobile/src/session/use-mobile-structured-agent-session-send.test.tsx",
+        "mobile/src/session/use-mobile-structured-agent-session.test.tsx",
+        "mobile/src/transport/mobile-relay-rpc-session.test.ts",
+        "mobile/src/transport/rpc-client-delivery-ambiguity.test.ts",
+        "mobile/src/transport/stable-logical-rpc-client.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts",
+          "assertions": [
+            "never redelivers after admission survives without its journal submission",
+            "fails closed when a legacy pending row survives without its submission",
+            "never reruns an admission-only send after the caller changes",
+            "settles a submission write failure as rejected before provider dispatch"
+          ]
+        },
+        {
+          "file": "src/main/runtime/agent-session-operation-admission.test.ts",
+          "assertions": ["replays the original row after the caller identity changes"]
+        },
+        {
+          "file": "mobile/src/session/use-mobile-structured-agent-session-send.test.tsx",
+          "assertions": [
+            "keeps one id across acknowledgement loss and host unknown replays",
+            "reuses an ambiguous id after the session hook remounts",
+            "keeps an ambiguous id after the host replay window expires",
+            "reuses the original uploaded attachment identity after acknowledgement loss",
+            "rotates after a %s pre-handler RPC refusal that proves the send did not run"
+          ]
+        },
+        {
+          "file": "src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts",
+          "assertions": ["retries a rejected nudge on the next journal edge"]
+        },
+        {
+          "file": "src/main/runtime/orchestration/structured-pointer-operation-id.test.ts",
+          "assertions": ["never re-mints an ambiguous batch after the host replay window expires"]
+        },
+        {
+          "file": "mobile/src/transport/rpc-client-delivery-ambiguity.test.ts",
+          "assertions": [
+            "marks a written request unknown when another request triggers auth recovery"
+          ]
+        },
+        {
+          "file": "mobile/src/transport/stable-logical-rpc-client.test.ts",
+          "assertions": ["preserves a committed response when logical close wins the callback race"]
+        },
+        {
+          "file": "mobile/src/transport/mobile-relay-rpc-session.test.ts",
+          "assertions": ["keeps a synchronous pre-write relay failure definite"]
+        },
+        {
+          "file": "src/shared/structured-agent-session-send-disposition.test.ts",
+          "assertions": ["never rotates $state operation after its host tombstone expires"]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-11",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/shared/agent-session-operation-ledger.test.ts src/shared/structured-agent-session-send-disposition.test.ts src/main/runtime/agent-session-operation-admission.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts src/main/runtime/orchestration/structured-pointer-operation-id.test.ts src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx src/renderer/src/lib/launch-structured-agent-session.test.ts",
+          "result": "passed",
+          "durationSeconds": 25.61,
+          "summary": "Twelve focused host, shared, renderer, and orchestration files passed 133 tests."
+        },
+        {
+          "date": "2026-09-11",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm --dir mobile test ../mobile/src/session/mobile-native-chat-image-attachment.test.ts ../mobile/src/session/use-mobile-native-chat-image-attachments.test.ts ../mobile/src/session/mobile-structured-send-operation-journal.test.ts ../mobile/src/session/mobile-structured-session-operation-retention.test.ts ../mobile/src/session/mobile-structured-send-delivery.test.ts ../mobile/src/session/use-mobile-structured-agent-session-send.test.tsx ../mobile/src/session/use-mobile-structured-agent-session.test.tsx ../mobile/src/transport/mobile-relay-rpc-session.test.ts ../mobile/src/transport/rpc-client-delivery-ambiguity.test.ts ../mobile/src/transport/stable-logical-rpc-client.test.ts",
+          "result": "passed",
+          "durationSeconds": 2.62,
+          "summary": "Ten focused mobile session, attachment, and transport files passed 112 tests."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 45,
+        "scope": "Two deterministic unit commands; initial target pending CI soak."
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "Focused local runs pass; repeated CI history is not established."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Three targeted ablations were run: spending the mobile id after acknowledgement loss made three retries use two ids; settling cross-caller recovery under the new caller left the original ledger row pending; and returning no synthetic result for an admission-only replay dispatched it as a new accepted send. The focused tests pass again with the production fixes restored; a byte-identical old-production run is not recorded."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "No polling, timers, subprocesses, or provider fanout were added. Each mobile journal mutation parses the bounded journal and performs at most one full AsyncStorage rewrite; entries retain hashes, ids, and original attachment paths, cap at 4,096, and fail closed at capacity. A first host send performs three serialized whole-store durable transactions: admission, the pre-effect unknown tombstone, and final settlement. No capacity-scale host fsync or mobile AsyncStorage latency benchmark is recorded."
+      },
+      "promotionCriteria": [
+        "Soak both commands in CI with zero unexplained flakes.",
+        "Add live physical-mobile and remote-runtime interruption evidence before claiming full provider coverage."
+      ],
+      "knownGaps": [
+        "A payload-keyed mobile ambiguity cannot distinguish retrying the original send from an intentional later send with identical content. It fails closed until authoritative settlement, so the claim that retention costs no liveness is false without a durable composer-action identity.",
+        "Clearing or externally corrupting desktop localStorage or mobile AsyncStorage can erase a client-owned ambiguous identity.",
+        "An ambiguous id retained past host tombstone expiry remains safely blocked rather than becoming live again.",
+        "A host crash after premarking the operation unknown but before journal append or provider dispatch can conservatively suppress a message that never reached the provider.",
+        "A replay synthesized from an operation row whose journal submission is missing is not republished into the journal; desktop stops automatic polling but remains safely blocked on that FIFO head.",
+        "The changed send guarantee is not capability-negotiated. New mobile clients fail closed across caller-identity change, but old clients can rotate an ambiguous id against a new host, and an old mobile client can interpret an ok response carrying unknown as accepted.",
+        "An ambiguous attachment retry depends on the original host temp path remaining usable when the first request never reached the host; if it is gone, the retry rejects rather than rotating.",
+        "No live SSH, remote-runtime, physical iOS/Android, Linux, or Windows interruption run is recorded."
+      ],
+      "demotionRule": "Keep experimental or demote if any ambiguous retry changes operation id, provider dispatch count exceeds one, durable identity is evicted by age or capacity, or the focused commands flake without a diagnosed harness defect."
     },
     {
       "id": "agent-session.completed-turn-duration",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -179,7 +179,7 @@
       "invariant": "One structured-send operation id causes at most one provider dispatch. A recorded or transport-ambiguous send reuses that id across retry, caller reconnect, client remount, and journal recovery; only a terminal rejection may rotate to a first delivery.",
       "oracle": "Inject adapter acknowledgement loss, RPC response loss, caller replacement, logical-client close after response, auth recovery with a written request, missing journal submissions, legacy pending rows, stale fences, operation expiry, mobile remount, and durable-journal capacity. Assert one provider dispatch or one operation id for every ambiguous retry, fresh identity only after rejection, and no eviction of ambiguous mobile ids.",
       "commands": [
-        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/shared/agent-session-operation-ledger.test.ts src/shared/structured-agent-session-send-disposition.test.ts src/main/runtime/agent-session-operation-admission.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts src/main/runtime/orchestration/structured-pointer-operation-id.test.ts src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx src/renderer/src/lib/launch-structured-agent-session.test.ts",
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/shared/agent-session-operation-ledger.test.ts src/shared/structured-agent-session-send-disposition.test.ts src/main/runtime/agent-session-operation-admission.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts src/main/runtime/orchestration/structured-pointer-operation-id.test.ts src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx src/renderer/src/lib/launch-structured-agent-session.test.ts",
         "ORCA_BACKGROUND_LAUNCH=1 pnpm --dir mobile test ../mobile/src/session/mobile-native-chat-image-attachment.test.ts ../mobile/src/session/use-mobile-native-chat-image-attachments.test.ts ../mobile/src/session/mobile-structured-send-operation-journal.test.ts ../mobile/src/session/mobile-structured-session-operation-retention.test.ts ../mobile/src/session/mobile-structured-send-delivery.test.ts ../mobile/src/session/use-mobile-structured-agent-session-send.test.tsx ../mobile/src/session/use-mobile-structured-agent-session.test.tsx ../mobile/src/transport/mobile-relay-rpc-session.test.ts ../mobile/src/transport/rpc-client-delivery-ambiguity.test.ts ../mobile/src/transport/stable-logical-rpc-client.test.ts"
       ],
       "testFiles": [
@@ -192,6 +192,7 @@
         "src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts",
         "src/main/runtime/orchestration/structured-pointer-operation-id.test.ts",
         "src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx",
+        "src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx",
         "src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx",
         "src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx",
         "src/renderer/src/lib/launch-structured-agent-session.test.ts",
@@ -213,6 +214,7 @@
             "never redelivers after admission survives without its journal submission",
             "fails closed when a legacy pending row survives without its submission",
             "never reruns an admission-only send after the caller changes",
+            "reuses a pending send admission after the client refreshes its fence",
             "settles a submission write failure as rejected before provider dispatch"
           ]
         },
@@ -227,8 +229,13 @@
             "reuses an ambiguous id after the session hook remounts",
             "keeps an ambiguous id after the host replay window expires",
             "reuses the original uploaded attachment identity after acknowledgement loss",
+            "keeps the send id after a pending-admission refusal",
             "rotates after a %s pre-handler RPC refusal that proves the send did not run"
           ]
+        },
+        {
+          "file": "src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx",
+          "assertions": ["reuses an option operation after a pending admission refusal"]
         },
         {
           "file": "src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts",
@@ -259,22 +266,22 @@
       ],
       "evidenceRuns": [
         {
-          "date": "2026-09-11",
+          "date": "2026-09-12",
           "runner": "local",
           "platform": "macos",
-          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/shared/agent-session-operation-ledger.test.ts src/shared/structured-agent-session-send-disposition.test.ts src/main/runtime/agent-session-operation-admission.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts src/main/runtime/orchestration/structured-pointer-operation-id.test.ts src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx src/renderer/src/lib/launch-structured-agent-session.test.ts",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/shared/agent-session-operation-ledger.test.ts src/shared/structured-agent-session-send-disposition.test.ts src/main/runtime/agent-session-operation-admission.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts src/main/runtime/orchestration/structured-pointer-operation-id.test.ts src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx src/renderer/src/lib/launch-structured-agent-session.test.ts",
           "result": "passed",
-          "durationSeconds": 25.61,
-          "summary": "Twelve focused host, shared, renderer, and orchestration files passed 133 tests."
+          "durationSeconds": 22.1,
+          "summary": "Thirteen focused host, shared, renderer, and orchestration files passed 148 tests."
         },
         {
-          "date": "2026-09-11",
+          "date": "2026-09-12",
           "runner": "local",
           "platform": "macos",
           "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm --dir mobile test ../mobile/src/session/mobile-native-chat-image-attachment.test.ts ../mobile/src/session/use-mobile-native-chat-image-attachments.test.ts ../mobile/src/session/mobile-structured-send-operation-journal.test.ts ../mobile/src/session/mobile-structured-session-operation-retention.test.ts ../mobile/src/session/mobile-structured-send-delivery.test.ts ../mobile/src/session/use-mobile-structured-agent-session-send.test.tsx ../mobile/src/session/use-mobile-structured-agent-session.test.tsx ../mobile/src/transport/mobile-relay-rpc-session.test.ts ../mobile/src/transport/rpc-client-delivery-ambiguity.test.ts ../mobile/src/transport/stable-logical-rpc-client.test.ts",
           "result": "passed",
-          "durationSeconds": 2.62,
-          "summary": "Ten focused mobile session, attachment, and transport files passed 112 tests."
+          "durationSeconds": 2.37,
+          "summary": "Ten focused mobile session, attachment, and transport files passed 113 tests."
         }
       ],
       "runtimeBudget": {
@@ -287,11 +294,11 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Three targeted ablations were run: spending the mobile id after acknowledgement loss made three retries use two ids; settling cross-caller recovery under the new caller left the original ledger row pending; and returning no synthetic result for an admission-only replay dispatched it as a new accepted send. The focused tests pass again with the production fixes restored; a byte-identical old-production run is not recorded."
+        "evidence": "Four targeted failures were observed: spending the mobile id after acknowledgement loss made three retries use two ids; settling cross-caller recovery under the new caller left the original ledger row pending; returning no synthetic result for a legacy or crash-left pending row dispatched it as a new accepted send; and a8d3de8d20's blanket settlement rotated a stale-fence option id and failed the renderer invariant. The focused tests pass with the production fixes restored; a byte-identical old-production run is not recorded."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "No polling, timers, subprocesses, or provider fanout were added. Each mobile journal mutation parses the bounded journal and performs at most one full AsyncStorage rewrite; entries retain hashes, ids, and original attachment paths, cap at 4,096, and fail closed at capacity. A first host send performs three serialized whole-store durable transactions: admission, the pre-effect unknown tombstone, and final settlement. No capacity-scale host fsync or mobile AsyncStorage latency benchmark is recorded."
+        "evidence": "No polling, timers, subprocesses, or provider fanout were added. Each mobile journal mutation parses the bounded journal and performs at most one full AsyncStorage rewrite; entries retain hashes, ids, and original attachment paths, cap at 4,096, and fail closed at capacity. A first host send performs three serialized whole-store durable transactions: admission, the pre-effect unknown tombstone, and final settlement. Lease and fence admission now share one transaction with the operation row, so a transient pre-effect refusal leaves no row and, absent pruning, performs no store write. No capacity-scale host fsync or mobile AsyncStorage latency benchmark is recorded."
       },
       "promotionCriteria": [
         "Soak both commands in CI with zero unexplained flakes.",

--- a/mobile/src/session/mobile-native-chat-controller-contract.ts
+++ b/mobile/src/session/mobile-native-chat-controller-contract.ts
@@ -75,6 +75,7 @@ export type MobileNativeChatController = {
       id?: string
       path: string
       previewUri: string
+      contentFingerprint?: string
     }[]
   ) => Promise<MobileNativeChatSendOutcome>
   /** Launch-context text still parked on the agent's TUI input line, or null.

--- a/mobile/src/session/mobile-native-chat-image-attachment.test.ts
+++ b/mobile/src/session/mobile-native-chat-image-attachment.test.ts
@@ -50,7 +50,13 @@ describe('uploadMobileNativeChatImages', () => {
       pickImages: vi.fn().mockResolvedValue([{ base64: 'AAAA', uri: 'file:///photo.jpg' }])
     })
 
-    expect(result).toEqual([{ path: '/tmp/orca-attach.png', previewUri: 'file:///photo.jpg' }])
+    expect(result).toEqual([
+      {
+        path: '/tmp/orca-attach.png',
+        previewUri: 'file:///photo.jpg',
+        contentFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/)
+      }
+    ])
     // Native chat defers the paste to submit — nothing is sent to the terminal here.
     expect(client.calls.some((call) => call.method === 'terminal.send')).toBe(false)
     const saveCall = client.calls.find((c) => c.method === 'clipboard.saveImageAsTempFile')
@@ -86,9 +92,21 @@ describe('uploadMobileNativeChatImages', () => {
     })
 
     expect(result).toEqual([
-      { path: '/tmp/a.png', previewUri: 'file:///a.jpg' },
-      { path: '/tmp/b.png', previewUri: 'file:///b.jpg' },
-      { path: '/tmp/c.png', previewUri: 'file:///c.jpg' }
+      {
+        path: '/tmp/a.png',
+        previewUri: 'file:///a.jpg',
+        contentFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/)
+      },
+      {
+        path: '/tmp/b.png',
+        previewUri: 'file:///b.jpg',
+        contentFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/)
+      },
+      {
+        path: '/tmp/c.png',
+        previewUri: 'file:///c.jpg',
+        contentFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/)
+      }
     ])
     expect(order).toEqual([
       'read:file:///a.jpg',
@@ -136,7 +154,8 @@ describe('uploadMobileNativeChatImages', () => {
     expect(onImageUploaded).toHaveBeenCalledOnce()
     expect(onImageUploaded).toHaveBeenCalledWith({
       path: '/tmp/a.png',
-      previewUri: 'file:///a.jpg'
+      previewUri: 'file:///a.jpg',
+      contentFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/)
     })
   })
 
@@ -149,7 +168,13 @@ describe('uploadMobileNativeChatImages', () => {
       pickImages: vi.fn().mockResolvedValue([{ base64: 'BBBB' }])
     })
 
-    expect(result).toEqual([{ path: '/tmp/x.png', previewUri: 'data:image/png;base64,BBBB' }])
+    expect(result).toEqual([
+      {
+        path: '/tmp/x.png',
+        previewUri: 'data:image/png;base64,BBBB',
+        contentFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/)
+      }
+    ])
   })
 
   it('signals upload start only after a real image is picked', async () => {

--- a/mobile/src/session/mobile-native-chat-image-attachment.ts
+++ b/mobile/src/session/mobile-native-chat-image-attachment.ts
@@ -1,6 +1,6 @@
 import type { RpcClient } from '../transport/rpc-client'
 import { saveMobileClipboardImageAsTempFile } from './mobile-clipboard-image'
-import { structuredAgentSessionPayloadFingerprint } from '../../../src/shared/structured-agent-session-mutation'
+import { structuredAgentSessionDomainFingerprint } from '../../../src/shared/structured-agent-session-mutation'
 // Type-only import so this module (and its unit test) stays free of the expo/
 // react-native picker chain; the concrete `pickImage` is injected by the hook.
 import type { MobileImageSource, PickedMobileImage } from './mobile-image-source-picker'
@@ -17,8 +17,8 @@ export type PendingNativeChatImage = {
 }
 
 export function mobileNativeChatImageContentFingerprint(base64: string): string {
-  return structuredAgentSessionPayloadFingerprint({
-    method: 'mobile.nativeChat.image',
+  return structuredAgentSessionDomainFingerprint({
+    domain: 'mobile.nativeChat.image',
     sessionId: '',
     fields: { base64 }
   })

--- a/mobile/src/session/mobile-native-chat-image-attachment.ts
+++ b/mobile/src/session/mobile-native-chat-image-attachment.ts
@@ -1,5 +1,6 @@
 import type { RpcClient } from '../transport/rpc-client'
 import { saveMobileClipboardImageAsTempFile } from './mobile-clipboard-image'
+import { structuredAgentSessionPayloadFingerprint } from '../../../src/shared/structured-agent-session-mutation'
 // Type-only import so this module (and its unit test) stays free of the expo/
 // react-native picker chain; the concrete `pickImage` is injected by the hook.
 import type { MobileImageSource, PickedMobileImage } from './mobile-image-source-picker'
@@ -11,6 +12,16 @@ export type PendingNativeChatImage = {
   readonly id: string
   readonly path: string
   readonly previewUri: string
+  /** Stable across repeat uploads of the same bytes; never contains the image. */
+  readonly contentFingerprint?: string
+}
+
+export function mobileNativeChatImageContentFingerprint(base64: string): string {
+  return structuredAgentSessionPayloadFingerprint({
+    method: 'mobile.nativeChat.image',
+    sessionId: '',
+    fields: { base64 }
+  })
 }
 
 export function appendPendingNativeChatImages(
@@ -71,7 +82,11 @@ export async function uploadMobileNativeChatImages(
     // Prefer the picker's local URI for the thumbnail; fall back to an inline data
     // URI when the source omitted one (RN <Image> renders both).
     const previewUri = image.uri ?? `data:image/png;base64,${image.base64}`
-    const result = { path, previewUri }
+    const result = {
+      path,
+      previewUri,
+      contentFingerprint: mobileNativeChatImageContentFingerprint(image.base64)
+    }
     uploaded.push(result)
     onImageUploaded?.(result)
   }

--- a/mobile/src/session/mobile-structured-agent-session-rpc.ts
+++ b/mobile/src/session/mobile-structured-agent-session-rpc.ts
@@ -1,8 +1,12 @@
 import {
-  AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS,
+  AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS,
+  AGENT_SESSION_OPERATION_FUTURE_SKEW_MS,
   parseAgentSessionOperationTimestamp
 } from '../../../src/shared/agent-session-host-authority'
-import type { AgentSessionMutationResult } from '../../../src/shared/agent-session-wire'
+import type {
+  AgentSessionMutationResult,
+  AgentSessionWireRefusalCode
+} from '../../../src/shared/agent-session-wire'
 import {
   createStructuredAgentSessionOperationId,
   structuredAgentSessionPayloadFingerprint
@@ -16,7 +20,7 @@ export const STRUCTURED_SEND_TIMEOUT_MS = 15_000
 
 export type StructuredAgentSessionMutationCallResult<TValue> =
   | { status: 'accepted'; value: TValue }
-  | { status: 'refused'; message: string }
+  | { status: 'refused'; code: AgentSessionWireRefusalCode; message: string }
   | { status: 'failed'; message: string }
   | { status: 'unknown' }
 
@@ -31,6 +35,22 @@ export type StructuredAgentSessionMutate = <TValue>(
   fields: Record<string, unknown>
 ) => Promise<StructuredAgentSessionMutationResult<TValue>>
 
+class AgentSessionRpcResponseError extends Error {
+  constructor(
+    readonly code: string,
+    message: string
+  ) {
+    super(message)
+  }
+}
+
+const PRE_HANDLER_RPC_REFUSALS = new Set([
+  'invalid_argument',
+  'method_not_found',
+  'method_not_supported',
+  'unauthorized'
+])
+
 export async function callAgentSession<TResult>(
   client: RpcClient,
   method: string,
@@ -44,7 +64,7 @@ export async function callAgentSession<TResult>(
     ...(options?.failWhenDisconnected ? { failWhenDisconnected: true } : {})
   })
   if (!response.ok) {
-    throw new Error(response.error.message)
+    throw new AgentSessionRpcResponseError(response.error.code, response.error.message)
   }
   return response.result as TResult
 }
@@ -57,34 +77,44 @@ export function structuredSessionRandomUuid(): string {
     : Array.from({ length: 32 }, () => Math.floor(Math.random() * 16).toString(16)).join('')
 }
 
-export function structuredSessionOperationId(): string {
-  return createStructuredAgentSessionOperationId(structuredSessionRandomUuid)
+export function structuredSessionOperationId(now: number = Date.now()): string {
+  return createStructuredAgentSessionOperationId(structuredSessionRandomUuid, now)
+}
+
+function isReplayableStructuredSessionOperationId(operationId: string, now: number): boolean {
+  const timestamp = parseAgentSessionOperationTimestamp(operationId)
+  return (
+    timestamp !== null &&
+    timestamp <= now + AGENT_SESSION_OPERATION_FUTURE_SKEW_MS &&
+    now - timestamp <= AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS
+  )
 }
 
 /**
- * Bounded by expiry, never by count: every retained id belongs to a send whose outcome is still
- * unknown, so dropping one turns the user's retry into a second message on the host. Only an id
- * the host would already refuse — unparseable, or past the window in which it can be admitted —
- * is safe to release, which matches the host's own tombstone retention.
+ * Retains transient non-send mutation ids while the host can still replay them. Structured sends
+ * use the durable journal because delivery ambiguity itself does not expire.
  */
 export function retainStructuredSessionOperationId(
   operationIds: Map<string, string>,
   key: string,
-  operationId = structuredSessionOperationId(),
+  operationId?: string,
   now: number = Date.now()
 ): string {
+  const retainedOperationId =
+    operationId && isReplayableStructuredSessionOperationId(operationId, now)
+      ? operationId
+      : structuredSessionOperationId(now)
   operationIds.delete(key)
-  operationIds.set(key, operationId)
+  operationIds.set(key, retainedOperationId)
   for (const [retainedKey, retainedId] of operationIds) {
     if (retainedKey === key) {
       continue
     }
-    const timestamp = parseAgentSessionOperationTimestamp(retainedId)
-    if (timestamp === null || now - timestamp > AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS) {
+    if (!isReplayableStructuredSessionOperationId(retainedId, now)) {
       operationIds.delete(retainedKey)
     }
   }
-  return operationId
+  return retainedOperationId
 }
 
 export function timeoutForDeadline(deadline: number | undefined): number | null {
@@ -103,7 +133,6 @@ export async function requestStructuredAgentSessionMutation<TValue>(args: {
   expectedRuntimeFence: number
   fields: Record<string, unknown>
   clientOperationId?: string
-  retryUnknown?: boolean
   timeoutMs?: number
 }): Promise<StructuredAgentSessionMutationCallResult<TValue>> {
   const {
@@ -114,7 +143,6 @@ export async function requestStructuredAgentSessionMutation<TValue>(args: {
     expectedRuntimeFence,
     fields,
     clientOperationId,
-    retryUnknown,
     timeoutMs
   } = args
   try {
@@ -132,23 +160,29 @@ export async function requestStructuredAgentSessionMutation<TValue>(args: {
             fields
           })
         },
-        ...(retryUnknown ? { retryUnknown: true } : {}),
         ...fields
       },
       timeoutMs
     )
     if (
       !result.ok &&
-      method === 'agentSession.conversationCommand' &&
+      (method === 'agentSession.cancel' || method === 'agentSession.conversationCommand') &&
       result.refusal.code === 'agent_session_operation_unknown'
     ) {
       return { status: 'unknown' }
     }
     return result.ok
       ? { status: 'accepted', value: result.value }
-      : { status: 'refused', message: result.refusal.message }
+      : { status: 'refused', code: result.refusal.code, message: result.refusal.message }
   } catch (error) {
-    if (isRpcDeliveryUnknown(error) || isLogicalClientCutoverError(error)) {
+    if (error instanceof AgentSessionRpcResponseError && PRE_HANDLER_RPC_REFUSALS.has(error.code)) {
+      return { status: 'failed', message: error.message }
+    }
+    if (
+      isRpcDeliveryUnknown(error) ||
+      isLogicalClientCutoverError(error) ||
+      error instanceof AgentSessionRpcResponseError
+    ) {
       return { status: 'unknown' }
     }
     return {

--- a/mobile/src/session/mobile-structured-agent-session-send.ts
+++ b/mobile/src/session/mobile-structured-agent-session-send.ts
@@ -3,7 +3,10 @@ import {
   structuredAgentSessionSendBody,
   type StructuredAgentSessionAttachment
 } from '../../../src/shared/structured-agent-session-outbox'
-import { structuredAgentSessionPayloadFingerprint } from '../../../src/shared/structured-agent-session-mutation'
+import {
+  structuredAgentSessionDomainFingerprint,
+  structuredAgentSessionPayloadFingerprint
+} from '../../../src/shared/structured-agent-session-mutation'
 import type { RpcClient } from '../transport/rpc-client'
 import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
 import {
@@ -40,16 +43,16 @@ export async function sendMobileStructuredAgentSessionMessage(input: {
     sessionId: input.sessionId,
     fields: { body: requestedBody }
   })
-  const intentFingerprint = structuredAgentSessionPayloadFingerprint({
-    method: 'mobile.agentSession.send.intent',
+  const intentFingerprint = structuredAgentSessionDomainFingerprint({
+    domain: 'mobile.agentSession.send.intent',
     sessionId: input.sessionKey,
     fields: {
       text: input.text.trimEnd(),
       attachments: input.attachments.map(
         (attachment) =>
           attachment.contentFingerprint ??
-          structuredAgentSessionPayloadFingerprint({
-            method: 'mobile.nativeChat.image.preview',
+          structuredAgentSessionDomainFingerprint({
+            domain: 'mobile.nativeChat.image.preview',
             sessionId: '',
             fields: { previewUri: attachment.previewUri }
           })

--- a/mobile/src/session/mobile-structured-agent-session-send.ts
+++ b/mobile/src/session/mobile-structured-agent-session-send.ts
@@ -1,0 +1,115 @@
+import type { AgentSessionSendResult } from '../../../src/shared/agent-session-wire'
+import {
+  structuredAgentSessionSendBody,
+  type StructuredAgentSessionAttachment
+} from '../../../src/shared/structured-agent-session-outbox'
+import { structuredAgentSessionPayloadFingerprint } from '../../../src/shared/structured-agent-session-mutation'
+import type { RpcClient } from '../transport/rpc-client'
+import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
+import {
+  requestStructuredAgentSessionMutation,
+  structuredSessionOperationId,
+  timeoutForDeadline
+} from './mobile-structured-agent-session-rpc'
+import { mobileStructuredSendDelivery } from './mobile-structured-send-delivery'
+import {
+  clearMobileStructuredSendOperation,
+  getOrCreateMobileStructuredSendOperation,
+  mobileStructuredSendOperationKey
+} from './mobile-structured-send-operation-journal'
+
+export async function sendMobileStructuredAgentSessionMessage(input: {
+  client: RpcClient
+  sessionId: string
+  sessionKey: string
+  callerIdentity: string
+  expectedRuntimeFence: number
+  text: string
+  attachments: readonly (StructuredAgentSessionAttachment & { contentFingerprint?: string })[]
+  deadline?: number
+  onError: (message: string) => void
+}): Promise<MobileNativeChatSendOutcome> {
+  const timeoutMs = timeoutForDeadline(input.deadline)
+  if (timeoutMs === null) {
+    input.onError('Message not sent')
+    return 'rejected'
+  }
+  const requestedBody = structuredAgentSessionSendBody(input.text, input.attachments)
+  const requestedPayloadFingerprint = structuredAgentSessionPayloadFingerprint({
+    method: 'agentSession.send',
+    sessionId: input.sessionId,
+    fields: { body: requestedBody }
+  })
+  const intentFingerprint = structuredAgentSessionPayloadFingerprint({
+    method: 'mobile.agentSession.send.intent',
+    sessionId: input.sessionKey,
+    fields: {
+      text: input.text.trimEnd(),
+      attachments: input.attachments.map(
+        (attachment) =>
+          attachment.contentFingerprint ??
+          structuredAgentSessionPayloadFingerprint({
+            method: 'mobile.nativeChat.image.preview',
+            sessionId: '',
+            fields: { previewUri: attachment.previewUri }
+          })
+      )
+    }
+  })
+  const operationKey = mobileStructuredSendOperationKey({
+    sessionKey: input.sessionKey,
+    intentFingerprint
+  })
+  let operation: Awaited<ReturnType<typeof getOrCreateMobileStructuredSendOperation>>
+  try {
+    operation = await getOrCreateMobileStructuredSendOperation({
+      operationKey,
+      callerIdentity: input.callerIdentity,
+      payloadFingerprint: requestedPayloadFingerprint,
+      attachmentPaths: input.attachments.map((attachment) => attachment.path),
+      createOperationId: structuredSessionOperationId
+    })
+  } catch {
+    input.onError('Message not sent')
+    return 'rejected'
+  }
+  const body = structuredAgentSessionSendBody(
+    input.text,
+    operation.attachmentPaths.map((path) => ({ path, previewUri: '' }))
+  )
+  const payloadFingerprint = structuredAgentSessionPayloadFingerprint({
+    method: 'agentSession.send',
+    sessionId: input.sessionId,
+    fields: { body }
+  })
+  if (payloadFingerprint !== operation.payloadFingerprint) {
+    input.onError('Message not sent')
+    return 'rejected'
+  }
+  const result = await requestStructuredAgentSessionMutation<AgentSessionSendResult>({
+    client: input.client,
+    method: 'agentSession.send',
+    fingerprintMethod: 'agentSession.send',
+    sessionId: input.sessionId,
+    expectedRuntimeFence: input.expectedRuntimeFence,
+    fields: { body },
+    clientOperationId: operation.operationId,
+    timeoutMs
+  })
+  const delivery = mobileStructuredSendDelivery(result, operation.retained)
+  if (delivery.operationIdSpent) {
+    try {
+      await clearMobileStructuredSendOperation({
+        operationKey,
+        operationId: operation.operationId
+      })
+    } catch {
+      // A retained settled id can suppress a later identical send, never
+      // duplicate this one; the next replay gets another clear chance.
+    }
+  }
+  if (delivery.error !== null) {
+    input.onError(delivery.error)
+  }
+  return delivery.outcome
+}

--- a/mobile/src/session/mobile-structured-composer-command.test.ts
+++ b/mobile/src/session/mobile-structured-composer-command.test.ts
@@ -66,6 +66,16 @@ describe('mobile structured conversation commands', () => {
     expect(await dispatchMobileStructuredCommand(input)).toBe('accepted')
     expect(sendRequest.mock.calls[0]?.[1]).toEqual(sendRequest.mock.calls[1]?.[1])
   })
+  it('retains operation identity when the host fails after starting the command', async () => {
+    const { input, sendRequest } = setup()
+    sendRequest.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'runtime_error', message: 'settlement failed' }
+    } as never)
+    expect(await dispatchMobileStructuredCommand(input)).toBe('unknown')
+    expect(await dispatchMobileStructuredCommand(input)).toBe('accepted')
+    expect(sendRequest.mock.calls[0]?.[1]).toEqual(sendRequest.mock.calls[1]?.[1])
+  })
   it.each(['attachments', 'old host', 'arguments', 'pending work'])(
     'guards %s without provider dispatch',
     async (reason) => {

--- a/mobile/src/session/mobile-structured-send-delivery.test.ts
+++ b/mobile/src/session/mobile-structured-send-delivery.test.ts
@@ -86,7 +86,7 @@ describe('mobileStructuredSendDelivery', () => {
         code: 'agent_session_checkpoint_stale',
         message: 'Fence moved'
       })
-    ).toEqual({ outcome: 'rejected', operationIdSpent: true, error: 'Fence moved' })
+    ).toEqual({ outcome: 'rejected', operationIdSpent: false, error: 'Fence moved' })
     expect(
       mobileStructuredSendDelivery({
         status: 'refused',

--- a/mobile/src/session/mobile-structured-send-delivery.test.ts
+++ b/mobile/src/session/mobile-structured-send-delivery.test.ts
@@ -39,6 +39,16 @@ describe('mobileStructuredSendDelivery', () => {
     }
   })
 
+  it('does not report a retained payload replay as a new accepted send', () => {
+    for (const dispatchState of ['accepted', 'pending'] as const) {
+      expect(mobileStructuredSendDelivery(accepted(dispatchState), true)).toEqual({
+        outcome: 'unknown',
+        operationIdSpent: false,
+        error: null
+      })
+    }
+  })
+
   it('spends the id of a rejection and withholds its internal reason', () => {
     // Provably undelivered and terminal, so the id can only replay it: spending the
     // id makes the retry a first delivery. The marker itself names nothing a person
@@ -62,12 +72,28 @@ describe('mobileStructuredSendDelivery', () => {
     })
   })
 
-  it('keeps a refusal a refusal and renames only the bare transport failure', () => {
-    expect(mobileStructuredSendDelivery({ status: 'refused', message: 'Fence moved' })).toEqual({
-      outcome: 'rejected',
-      operationIdSpent: true,
-      error: 'Fence moved'
-    })
+  it('spends only refusals that prove the operation is settled', () => {
+    expect(
+      mobileStructuredSendDelivery({
+        status: 'refused',
+        code: 'agent_session_operation_invalid',
+        message: 'Invalid operation'
+      })
+    ).toEqual({ outcome: 'rejected', operationIdSpent: true, error: 'Invalid operation' })
+    expect(
+      mobileStructuredSendDelivery({
+        status: 'refused',
+        code: 'agent_session_checkpoint_stale',
+        message: 'Fence moved'
+      })
+    ).toEqual({ outcome: 'rejected', operationIdSpent: true, error: 'Fence moved' })
+    expect(
+      mobileStructuredSendDelivery({
+        status: 'refused',
+        code: 'agent_session_operation_unknown',
+        message: 'Outcome unknown'
+      })
+    ).toEqual({ outcome: 'unknown', operationIdSpent: false, error: null })
     expect(mobileStructuredSendDelivery({ status: 'failed', message: 'Request not sent' })).toEqual(
       {
         outcome: 'rejected',
@@ -77,16 +103,30 @@ describe('mobileStructuredSendDelivery', () => {
     )
   })
 
-  it('treats a submission-less acknowledgement as the send it has always been', () => {
-    // A host that answers without a durable row claims nothing about dispatch;
-    // inventing doubt here would wedge sends against one that predates the row.
+  it('never releases an ambiguous id on a later RPC refusal or failure', () => {
+    expect(
+      mobileStructuredSendDelivery(
+        {
+          status: 'refused',
+          code: 'agent_session_operation_expired',
+          message: 'Operation expired'
+        },
+        true
+      )
+    ).toEqual({ outcome: 'rejected', operationIdSpent: false, error: 'Operation expired' })
+    expect(
+      mobileStructuredSendDelivery({ status: 'failed', message: 'Request not sent' }, true)
+    ).toEqual({ outcome: 'rejected', operationIdSpent: false, error: 'Message not sent' })
+  })
+
+  it('fails closed when an invalid host response omits the required submission', () => {
     const result = {
       status: 'accepted',
       value: { clientMessageId: 'msg-1' }
     } as unknown as StructuredAgentSessionMutationCallResult<AgentSessionSendResult>
     expect(mobileStructuredSendDelivery(result)).toEqual({
-      outcome: 'accepted',
-      operationIdSpent: true,
+      outcome: 'unknown',
+      operationIdSpent: false,
       error: null
     })
   })

--- a/mobile/src/session/mobile-structured-send-delivery.test.ts
+++ b/mobile/src/session/mobile-structured-send-delivery.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentJournalDispatchState } from '../../../src/shared/agent-session-journal-types'
+import type { AgentSessionSendResult } from '../../../src/shared/agent-session-wire'
+import { mobileStructuredSendDelivery } from './mobile-structured-send-delivery'
+import type { StructuredAgentSessionMutationCallResult } from './mobile-structured-agent-session-rpc'
+import { structuredSendResultFixture } from './structured-agent-send-result.test-fixture'
+
+function accepted(
+  dispatchState: AgentJournalDispatchState,
+  reason: string | null = null
+): StructuredAgentSessionMutationCallResult<AgentSessionSendResult> {
+  return { status: 'accepted', value: structuredSendResultFixture(dispatchState, reason) }
+}
+
+describe('mobileStructuredSendDelivery', () => {
+  it('keeps the operation id for every unknown, host-recorded or ack-lost', () => {
+    // The one answer that may be a delivery. Spending the id here turns the next
+    // identical send into a second copy in front of the model.
+    expect(mobileStructuredSendDelivery({ status: 'unknown' })).toEqual({
+      outcome: 'unknown',
+      operationIdSpent: false,
+      error: null
+    })
+    expect(mobileStructuredSendDelivery(accepted('unknown'))).toEqual({
+      outcome: 'unknown',
+      operationIdSpent: false,
+      error: null
+    })
+  })
+
+  it('reports a written send as sent and spends its id', () => {
+    // `pending` is written and awaiting the provider's acknowledgement — not doubt.
+    for (const dispatchState of ['accepted', 'pending'] as const) {
+      expect(mobileStructuredSendDelivery(accepted(dispatchState))).toEqual({
+        outcome: 'accepted',
+        operationIdSpent: true,
+        error: null
+      })
+    }
+  })
+
+  it('spends the id of a rejection and withholds its internal reason', () => {
+    // Provably undelivered and terminal, so the id can only replay it: spending the
+    // id makes the retry a first delivery. The marker itself names nothing a person
+    // can act on, so it must not reach the screen.
+    expect(
+      mobileStructuredSendDelivery(accepted('rejected', 'provider_write_failed: broken pipe'))
+    ).toEqual({
+      outcome: 'rejected',
+      operationIdSpent: true,
+      error: "Couldn't reach the agent. Your message was not sent — Retry to send it again."
+    })
+  })
+
+  it('shows a provider content rejection verbatim', () => {
+    expect(
+      mobileStructuredSendDelivery(accepted('rejected', 'Claude does not support .bmp'))
+    ).toEqual({
+      outcome: 'rejected',
+      operationIdSpent: true,
+      error: 'Claude does not support .bmp'
+    })
+  })
+
+  it('keeps a refusal a refusal and renames only the bare transport failure', () => {
+    expect(mobileStructuredSendDelivery({ status: 'refused', message: 'Fence moved' })).toEqual({
+      outcome: 'rejected',
+      operationIdSpent: true,
+      error: 'Fence moved'
+    })
+    expect(mobileStructuredSendDelivery({ status: 'failed', message: 'Request not sent' })).toEqual(
+      {
+        outcome: 'rejected',
+        operationIdSpent: true,
+        error: 'Message not sent'
+      }
+    )
+  })
+
+  it('treats a submission-less acknowledgement as the send it has always been', () => {
+    // A host that answers without a durable row claims nothing about dispatch;
+    // inventing doubt here would wedge sends against one that predates the row.
+    const result = {
+      status: 'accepted',
+      value: { clientMessageId: 'msg-1' }
+    } as unknown as StructuredAgentSessionMutationCallResult<AgentSessionSendResult>
+    expect(mobileStructuredSendDelivery(result)).toEqual({
+      outcome: 'accepted',
+      operationIdSpent: true,
+      error: null
+    })
+  })
+})

--- a/mobile/src/session/mobile-structured-send-delivery.ts
+++ b/mobile/src/session/mobile-structured-send-delivery.ts
@@ -22,43 +22,59 @@
 //     model five times.
 
 import type { AgentSessionSendResult } from '../../../src/shared/agent-session-wire'
+import { agentSessionRefusalOperationState } from '../../../src/shared/agent-session-refusal-retry'
 import { structuredAgentSessionRejectionNotice } from '../../../src/shared/structured-agent-session-send-disposition'
 import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
 import type { StructuredAgentSessionMutationCallResult } from './mobile-structured-agent-session-rpc'
 
 export type MobileStructuredSendDelivery = {
   outcome: MobileNativeChatSendOutcome
-  /** True when a further send under the same operation id could only replay this answer. */
+  /** True when a retry is safe under a fresh operation id. */
   operationIdSpent: boolean
   /** Copy for the user, or null when the outcome needs none. */
   error: string | null
 }
 
 export function mobileStructuredSendDelivery(
-  result: StructuredAgentSessionMutationCallResult<AgentSessionSendResult>
+  result: StructuredAgentSessionMutationCallResult<AgentSessionSendResult>,
+  retained = false
 ): MobileStructuredSendDelivery {
   if (result.status === 'unknown') {
     return { outcome: 'unknown', operationIdSpent: false, error: null }
   }
+  if (result.status === 'refused') {
+    const refusalState = agentSessionRefusalOperationState('agentSession.send', result.code)
+    if (refusalState === 'unknown') {
+      return { outcome: 'unknown', operationIdSpent: false, error: null }
+    }
+    return {
+      outcome: 'rejected',
+      operationIdSpent: !retained,
+      error: result.message
+    }
+  }
   if (result.status !== 'accepted') {
     return {
       outcome: 'rejected',
-      operationIdSpent: true,
+      operationIdSpent: !retained,
       error: result.message === 'Request not sent' ? 'Message not sent' : result.message
     }
   }
-  // A host that answered without a submission row claims nothing about dispatch;
-  // treat it as the acknowledgement it has always been rather than inventing doubt.
   const submission = result.value.submission as AgentSessionSendResult['submission'] | undefined
-  if (submission?.dispatchState === 'unknown') {
+  if (!submission || submission.dispatchState === 'unknown') {
     return { outcome: 'unknown', operationIdSpent: false, error: null }
   }
-  if (submission?.dispatchState === 'rejected') {
+  if (submission.dispatchState === 'rejected') {
     return {
       outcome: 'rejected',
       operationIdSpent: true,
       error: structuredAgentSessionRejectionNotice(submission.reason)
     }
+  }
+  if (retained) {
+    // A payload match cannot distinguish retrying the ambiguous action from a
+    // later identical intent. Wait for the stream to settle and release it.
+    return { outcome: 'unknown', operationIdSpent: false, error: null }
   }
   return { outcome: 'accepted', operationIdSpent: true, error: null }
 }

--- a/mobile/src/session/mobile-structured-send-delivery.ts
+++ b/mobile/src/session/mobile-structured-send-delivery.ts
@@ -13,9 +13,9 @@
 //
 //   accepted/pending — the send happened. The id is spent; a later identical
 //     message is a new message and must carry a new id.
-//   rejected — provably did not happen, and terminal in the reducer. Reusing the
-//     id could only replay that rejection forever, so it is spent too; the next
-//     attempt is a first delivery under a fresh id and cannot duplicate.
+//   rejected — a terminal refusal or rejected submission spends a fresh id. A
+//     pending-admission refusal, or any refusal after earlier transport doubt,
+//     keeps it because neither proves a retained delivery did not happen.
 //   unknown — the one answer that KEEPS its id, whether it came from the host or
 //     from an ack-loss on the way back. The message may be with the provider, so
 //     the retry has to stay a replay. Rotating here is what sent one message to a
@@ -49,7 +49,7 @@ export function mobileStructuredSendDelivery(
     }
     return {
       outcome: 'rejected',
-      operationIdSpent: !retained,
+      operationIdSpent: refusalState === 'settled-rejected' && !retained,
       error: result.message
     }
   }

--- a/mobile/src/session/mobile-structured-send-delivery.ts
+++ b/mobile/src/session/mobile-structured-send-delivery.ts
@@ -1,0 +1,64 @@
+// What one `agentSession.send` answer means to a client with no outbox.
+//
+// The desktop reads the same four dispatch states through
+// `disposeStructuredAgentSessionSendResult`; mobile has no queue to move, so it
+// needs only two facts: the outcome to report, and whether the operation id it
+// sent under is spent.
+//
+// The id is the whole safety mechanism here. Mobile keys its retained ids by
+// message body, so re-sending the same text reuses the id — and one id is one
+// delivery: `performSend` answers a second request under a recorded id from the
+// ledger and never puts it back on the wire. Releasing the id turns that replay
+// into a genuine second delivery, which is why only a settled answer releases it:
+//
+//   accepted/pending — the send happened. The id is spent; a later identical
+//     message is a new message and must carry a new id.
+//   rejected — provably did not happen, and terminal in the reducer. Reusing the
+//     id could only replay that rejection forever, so it is spent too; the next
+//     attempt is a first delivery under a fresh id and cannot duplicate.
+//   unknown — the one answer that KEEPS its id, whether it came from the host or
+//     from an ack-loss on the way back. The message may be with the provider, so
+//     the retry has to stay a replay. Rotating here is what sent one message to a
+//     model five times.
+
+import type { AgentSessionSendResult } from '../../../src/shared/agent-session-wire'
+import { structuredAgentSessionRejectionNotice } from '../../../src/shared/structured-agent-session-send-disposition'
+import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
+import type { StructuredAgentSessionMutationCallResult } from './mobile-structured-agent-session-rpc'
+
+export type MobileStructuredSendDelivery = {
+  outcome: MobileNativeChatSendOutcome
+  /** True when a further send under the same operation id could only replay this answer. */
+  operationIdSpent: boolean
+  /** Copy for the user, or null when the outcome needs none. */
+  error: string | null
+}
+
+export function mobileStructuredSendDelivery(
+  result: StructuredAgentSessionMutationCallResult<AgentSessionSendResult>
+): MobileStructuredSendDelivery {
+  if (result.status === 'unknown') {
+    return { outcome: 'unknown', operationIdSpent: false, error: null }
+  }
+  if (result.status !== 'accepted') {
+    return {
+      outcome: 'rejected',
+      operationIdSpent: true,
+      error: result.message === 'Request not sent' ? 'Message not sent' : result.message
+    }
+  }
+  // A host that answered without a submission row claims nothing about dispatch;
+  // treat it as the acknowledgement it has always been rather than inventing doubt.
+  const submission = result.value.submission as AgentSessionSendResult['submission'] | undefined
+  if (submission?.dispatchState === 'unknown') {
+    return { outcome: 'unknown', operationIdSpent: false, error: null }
+  }
+  if (submission?.dispatchState === 'rejected') {
+    return {
+      outcome: 'rejected',
+      operationIdSpent: true,
+      error: structuredAgentSessionRejectionNotice(submission.reason)
+    }
+  }
+  return { outcome: 'accepted', operationIdSpent: true, error: null }
+}

--- a/mobile/src/session/mobile-structured-send-operation-journal.test.ts
+++ b/mobile/src/session/mobile-structured-send-operation-journal.test.ts
@@ -1,0 +1,348 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS } from '../../../src/shared/agent-session-host-authority'
+import { AGENT_SESSION_DURABLE_OPERATION_GLOBAL_LIMIT } from '../../../src/shared/agent-session-operation-ledger'
+
+const asyncStorage = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn()
+}))
+
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: asyncStorage }))
+
+import {
+  clearMobileStructuredSendOperation,
+  clearMobileStructuredSettledSendOperations,
+  getOrCreateMobileStructuredSendOperation as getOrCreatePersistedOperation,
+  mobileStructuredSendCallerFingerprint,
+  mobileStructuredSendOperationKey,
+  resetMobileStructuredSendOperationJournalForTests
+} from './mobile-structured-send-operation-journal'
+
+const NOW = 1_900_000_000_000
+const OPERATION_KEY = 'a'.repeat(64)
+const CALLER_IDENTITY = 'mobile-device-a'
+
+function getOrCreateMobileStructuredSendOperation(
+  input: Omit<
+    Parameters<typeof getOrCreatePersistedOperation>[0],
+    'callerIdentity' | 'payloadFingerprint' | 'attachmentPaths'
+  > & { payloadFingerprint?: string; attachmentPaths?: readonly string[] }
+) {
+  const { payloadFingerprint = 'b'.repeat(64), attachmentPaths = [], ...operation } = input
+  return getOrCreatePersistedOperation({
+    ...operation,
+    callerIdentity: CALLER_IDENTITY,
+    payloadFingerprint,
+    attachmentPaths
+  }).then(({ operationId, retained }) => ({ operationId, retained }))
+}
+
+function operationIdAt(timestamp: number, entropy: string): string {
+  return `${timestamp}-${entropy.repeat(32).slice(0, 32)}`
+}
+
+describe('mobile structured send operation journal', () => {
+  let values: Map<string, string>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMobileStructuredSendOperationJournalForTests()
+    values = new Map()
+    asyncStorage.getItem.mockImplementation(async (key: string) => values.get(key) ?? null)
+    asyncStorage.setItem.mockImplementation(async (key: string, value: string) => {
+      values.set(key, value)
+    })
+    asyncStorage.removeItem.mockImplementation(async (key: string) => {
+      values.delete(key)
+    })
+  })
+
+  it('persists an ambiguous id before dispatch and reuses it after remount', async () => {
+    const firstId = operationIdAt(NOW, '1')
+    await expect(
+      getOrCreateMobileStructuredSendOperation({
+        operationKey: OPERATION_KEY,
+        createOperationId: () => firstId,
+        now: NOW
+      })
+    ).resolves.toEqual({ operationId: firstId, retained: false })
+
+    resetMobileStructuredSendOperationJournalForTests()
+    const createAfterRemount = vi.fn(() => operationIdAt(NOW, '2'))
+    await expect(
+      getOrCreateMobileStructuredSendOperation({
+        operationKey: OPERATION_KEY,
+        createOperationId: createAfterRemount,
+        now: NOW
+      })
+    ).resolves.toEqual({ operationId: firstId, retained: true })
+    expect(createAfterRemount).not.toHaveBeenCalled()
+  })
+
+  it('clears only the exact settled operation', async () => {
+    const firstId = operationIdAt(NOW, '3')
+    await getOrCreateMobileStructuredSendOperation({
+      operationKey: OPERATION_KEY,
+      createOperationId: () => firstId,
+      now: NOW
+    })
+
+    await expect(
+      clearMobileStructuredSendOperation({
+        operationKey: OPERATION_KEY,
+        operationId: operationIdAt(NOW, '4')
+      })
+    ).rejects.toThrow('identity changed')
+    await clearMobileStructuredSendOperation({
+      operationKey: OPERATION_KEY,
+      operationId: firstId
+    })
+
+    const secondId = operationIdAt(NOW, '5')
+    await expect(
+      getOrCreateMobileStructuredSendOperation({
+        operationKey: OPERATION_KEY,
+        createOperationId: () => secondId,
+        now: NOW
+      })
+    ).resolves.toEqual({ operationId: secondId, retained: false })
+  })
+
+  it('clears an ack-lost id only when its journal submission settles', async () => {
+    const sessionKey = 'host-a:session-a'
+    const payloadFingerprint = 'c'.repeat(64)
+    const operationKey = mobileStructuredSendOperationKey({
+      sessionKey,
+      intentFingerprint: payloadFingerprint
+    })
+    const operationId = operationIdAt(NOW, 'd')
+    await getOrCreateMobileStructuredSendOperation({
+      operationKey,
+      payloadFingerprint,
+      createOperationId: () => operationId,
+      now: NOW
+    })
+    const submission = {
+      clientMessageId: operationId,
+      fence: 1,
+      payloadFingerprint,
+      dispatchState: 'unknown' as const,
+      providerItemId: null,
+      reason: 'ack lost',
+      submittedAt: NOW,
+      resolvedAt: NOW
+    }
+
+    await clearMobileStructuredSettledSendOperations({ submissions: [submission] })
+    expect(values.size).toBe(1)
+
+    await clearMobileStructuredSettledSendOperations({
+      submissions: [{ ...submission, dispatchState: 'accepted', reason: null }]
+    })
+    expect(values.size).toBe(0)
+  })
+
+  it('does not clear a newer id for an older matching-payload submission', async () => {
+    const sessionKey = 'host-a:session-a'
+    const payloadFingerprint = 'e'.repeat(64)
+    const operationKey = mobileStructuredSendOperationKey({
+      sessionKey,
+      intentFingerprint: payloadFingerprint
+    })
+    const operationId = operationIdAt(NOW, 'f')
+    await getOrCreateMobileStructuredSendOperation({
+      operationKey,
+      payloadFingerprint,
+      createOperationId: () => operationId,
+      now: NOW
+    })
+
+    await clearMobileStructuredSettledSendOperations({
+      submissions: [
+        {
+          clientMessageId: operationIdAt(NOW - 1, '1'),
+          fence: 1,
+          payloadFingerprint,
+          dispatchState: 'accepted',
+          providerItemId: null,
+          reason: null,
+          submittedAt: NOW - 1,
+          resolvedAt: NOW - 1
+        }
+      ]
+    })
+
+    await expect(
+      getOrCreateMobileStructuredSendOperation({
+        operationKey,
+        createOperationId: () => operationIdAt(NOW, '2'),
+        now: NOW
+      })
+    ).resolves.toEqual({ operationId, retained: true })
+  })
+
+  it('reuses the original attachment paths for an ambiguous repeat upload', async () => {
+    const operationId = operationIdAt(NOW, 'e')
+    const payloadFingerprint = 'd'.repeat(64)
+    await getOrCreatePersistedOperation({
+      operationKey: OPERATION_KEY,
+      callerIdentity: CALLER_IDENTITY,
+      payloadFingerprint,
+      attachmentPaths: ['/tmp/original.png'],
+      createOperationId: () => operationId,
+      now: NOW
+    })
+
+    await expect(
+      getOrCreatePersistedOperation({
+        operationKey: OPERATION_KEY,
+        callerIdentity: CALLER_IDENTITY,
+        payloadFingerprint: 'e'.repeat(64),
+        attachmentPaths: ['/tmp/reuploaded.png'],
+        createOperationId: () => operationIdAt(NOW, 'f'),
+        now: NOW
+      })
+    ).resolves.toEqual({
+      operationId,
+      retained: true,
+      payloadFingerprint,
+      attachmentPaths: ['/tmp/original.png']
+    })
+  })
+
+  it('keeps an ambiguous id after the host replay window closes', async () => {
+    const expired = operationIdAt(NOW - AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS - 1, '6')
+    asyncStorage.getItem.mockResolvedValueOnce(
+      JSON.stringify({
+        v: 1,
+        entries: [
+          {
+            operationKey: OPERATION_KEY,
+            operationId: expired,
+            callerFingerprint: mobileStructuredSendCallerFingerprint(CALLER_IDENTITY),
+            payloadFingerprint: 'b'.repeat(64),
+            attachmentPaths: []
+          }
+        ]
+      })
+    )
+
+    await expect(
+      getOrCreateMobileStructuredSendOperation({
+        operationKey: OPERATION_KEY,
+        createOperationId: () => operationIdAt(NOW, '7'),
+        now: NOW
+      })
+    ).resolves.toEqual({ operationId: expired, retained: true })
+  })
+
+  it('fails closed when a retained operation id is malformed', async () => {
+    asyncStorage.getItem.mockResolvedValueOnce(
+      JSON.stringify({
+        v: 1,
+        entries: [
+          {
+            operationKey: OPERATION_KEY,
+            operationId: 'not-an-operation-id',
+            callerFingerprint: mobileStructuredSendCallerFingerprint(CALLER_IDENTITY),
+            payloadFingerprint: 'b'.repeat(64),
+            attachmentPaths: []
+          }
+        ]
+      })
+    )
+
+    await expect(
+      getOrCreateMobileStructuredSendOperation({
+        operationKey: OPERATION_KEY,
+        createOperationId: () => operationIdAt(NOW, '8'),
+        now: NOW
+      })
+    ).rejects.toThrow('unreadable')
+  })
+
+  it('fails closed when durable identity cannot be read or written', async () => {
+    asyncStorage.getItem.mockRejectedValueOnce(new Error('storage unavailable'))
+    await expect(
+      getOrCreateMobileStructuredSendOperation({
+        operationKey: OPERATION_KEY,
+        createOperationId: () => operationIdAt(NOW, '9'),
+        now: NOW
+      })
+    ).rejects.toThrow('storage unavailable')
+
+    asyncStorage.setItem.mockRejectedValueOnce(new Error('disk full'))
+    await expect(
+      getOrCreateMobileStructuredSendOperation({
+        operationKey: OPERATION_KEY,
+        createOperationId: () => operationIdAt(NOW, 'a'),
+        now: NOW
+      })
+    ).rejects.toThrow('disk full')
+    expect(values.size).toBe(0)
+  })
+
+  it('refuses new sends rather than evicting an ambiguous id at capacity', async () => {
+    asyncStorage.getItem.mockResolvedValueOnce(
+      JSON.stringify({
+        v: 1,
+        entries: Array.from(
+          { length: AGENT_SESSION_DURABLE_OPERATION_GLOBAL_LIMIT },
+          (_, index) => ({
+            operationKey: index.toString(16).padStart(64, '0'),
+            operationId: operationIdAt(NOW, index.toString(16).padStart(32, '0')),
+            callerFingerprint: mobileStructuredSendCallerFingerprint(CALLER_IDENTITY),
+            payloadFingerprint: 'b'.repeat(64),
+            attachmentPaths: []
+          })
+        )
+      })
+    )
+
+    await expect(
+      getOrCreateMobileStructuredSendOperation({
+        operationKey: OPERATION_KEY,
+        createOperationId: () => operationIdAt(NOW, 'b'),
+        now: NOW
+      })
+    ).rejects.toThrow('journal is full')
+  })
+
+  it('hashes the session scope and payload instead of retaining message bodies', () => {
+    const first = mobileStructuredSendOperationKey({
+      sessionKey: 'host-a:session-a',
+      intentFingerprint: 'message-body-fingerprint'
+    })
+    const second = mobileStructuredSendOperationKey({
+      sessionKey: 'host-b:session-a',
+      intentFingerprint: 'message-body-fingerprint'
+    })
+
+    expect(first).toMatch(/^[0-9a-f]{64}$/)
+    expect(second).not.toBe(first)
+    expect(first).not.toContain('message-body')
+  })
+
+  it('fails closed when a retained id crosses authenticated caller identities', async () => {
+    await getOrCreatePersistedOperation({
+      operationKey: OPERATION_KEY,
+      callerIdentity: 'mobile-device-before-repair',
+      payloadFingerprint: 'b'.repeat(64),
+      attachmentPaths: [],
+      createOperationId: () => operationIdAt(NOW, '3'),
+      now: NOW
+    })
+
+    await expect(
+      getOrCreatePersistedOperation({
+        operationKey: OPERATION_KEY,
+        callerIdentity: 'mobile-device-after-repair',
+        payloadFingerprint: 'b'.repeat(64),
+        attachmentPaths: [],
+        createOperationId: () => operationIdAt(NOW, '4'),
+        now: NOW
+      })
+    ).rejects.toThrow('caller identity changed')
+  })
+})

--- a/mobile/src/session/mobile-structured-send-operation-journal.ts
+++ b/mobile/src/session/mobile-structured-send-operation-journal.ts
@@ -7,7 +7,7 @@ import {
   parseAgentSessionOperationTimestamp
 } from '../../../src/shared/agent-session-host-authority'
 import { AGENT_SESSION_DURABLE_OPERATION_GLOBAL_LIMIT } from '../../../src/shared/agent-session-operation-ledger'
-import { structuredAgentSessionPayloadFingerprint } from '../../../src/shared/structured-agent-session-mutation'
+import { structuredAgentSessionDomainFingerprint } from '../../../src/shared/structured-agent-session-mutation'
 
 const STORAGE_KEY = 'orca:mobileStructuredSendOperations:v1'
 const OperationEntrySchema = z
@@ -35,16 +35,16 @@ export function mobileStructuredSendOperationKey(input: {
   sessionKey: string
   intentFingerprint: string
 }): string {
-  return structuredAgentSessionPayloadFingerprint({
-    method: 'mobile.agentSession.send.operation',
+  return structuredAgentSessionDomainFingerprint({
+    domain: 'mobile.agentSession.send.operation',
     sessionId: input.sessionKey,
     fields: { intentFingerprint: input.intentFingerprint }
   })
 }
 
 export function mobileStructuredSendCallerFingerprint(callerIdentity: string): string {
-  return structuredAgentSessionPayloadFingerprint({
-    method: 'mobile.agentSession.send.caller',
+  return structuredAgentSessionDomainFingerprint({
+    domain: 'mobile.agentSession.send.caller',
     sessionId: callerIdentity,
     fields: {}
   })

--- a/mobile/src/session/mobile-structured-send-operation-journal.ts
+++ b/mobile/src/session/mobile-structured-send-operation-journal.ts
@@ -1,0 +1,207 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { z } from 'zod'
+import type { AgentJournalSubmission } from '../../../src/shared/agent-session-journal-types'
+import {
+  AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS,
+  AGENT_SESSION_OPERATION_FUTURE_SKEW_MS,
+  parseAgentSessionOperationTimestamp
+} from '../../../src/shared/agent-session-host-authority'
+import { AGENT_SESSION_DURABLE_OPERATION_GLOBAL_LIMIT } from '../../../src/shared/agent-session-operation-ledger'
+import { structuredAgentSessionPayloadFingerprint } from '../../../src/shared/structured-agent-session-mutation'
+
+const STORAGE_KEY = 'orca:mobileStructuredSendOperations:v1'
+const OperationEntrySchema = z
+  .object({
+    operationKey: z.string().regex(/^[0-9a-f]{64}$/),
+    operationId: z.string().max(128),
+    callerFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+    payloadFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
+    attachmentPaths: z.array(z.string().max(4096)).max(128)
+  })
+  .strict()
+const OperationJournalSchema = z
+  .object({
+    v: z.literal(1),
+    entries: z.array(OperationEntrySchema).max(AGENT_SESSION_DURABLE_OPERATION_GLOBAL_LIMIT)
+  })
+  .strict()
+
+type OperationEntry = z.infer<typeof OperationEntrySchema>
+type OperationJournal = z.infer<typeof OperationJournalSchema>
+
+const mutations: { tail: Promise<void> } = { tail: Promise.resolve() }
+
+export function mobileStructuredSendOperationKey(input: {
+  sessionKey: string
+  intentFingerprint: string
+}): string {
+  return structuredAgentSessionPayloadFingerprint({
+    method: 'mobile.agentSession.send.operation',
+    sessionId: input.sessionKey,
+    fields: { intentFingerprint: input.intentFingerprint }
+  })
+}
+
+export function mobileStructuredSendCallerFingerprint(callerIdentity: string): string {
+  return structuredAgentSessionPayloadFingerprint({
+    method: 'mobile.agentSession.send.caller',
+    sessionId: callerIdentity,
+    fields: {}
+  })
+}
+
+function newOperationIdIsAdmissible(operationId: string, now: number): boolean {
+  const timestamp = parseAgentSessionOperationTimestamp(operationId)
+  return (
+    timestamp !== null &&
+    timestamp <= now + AGENT_SESSION_OPERATION_FUTURE_SKEW_MS &&
+    now - timestamp <= AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS
+  )
+}
+
+function parseJournal(raw: string | null): OperationJournal {
+  if (raw === null) {
+    return { v: 1, entries: [] }
+  }
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch {
+    throw new Error('Structured send operation journal is unreadable')
+  }
+  const parsed = OperationJournalSchema.safeParse(value)
+  if (!parsed.success) {
+    throw new Error('Structured send operation journal is unreadable')
+  }
+  if (
+    new Set(parsed.data.entries.map((entry) => entry.operationKey)).size !==
+      parsed.data.entries.length ||
+    parsed.data.entries.some(
+      (entry) => parseAgentSessionOperationTimestamp(entry.operationId) === null
+    )
+  ) {
+    throw new Error('Structured send operation journal is unreadable')
+  }
+  return parsed.data
+}
+
+async function writeEntries(entries: OperationEntry[]): Promise<void> {
+  if (entries.length === 0) {
+    await AsyncStorage.removeItem(STORAGE_KEY)
+    return
+  }
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ v: 1, entries }))
+}
+
+async function serialize<T>(action: () => Promise<T>): Promise<T> {
+  const operation = mutations.tail.then(action, action)
+  mutations.tail = operation.then(
+    () => undefined,
+    () => undefined
+  )
+  return operation
+}
+
+export async function getOrCreateMobileStructuredSendOperation(input: {
+  operationKey: string
+  callerIdentity: string
+  payloadFingerprint: string
+  attachmentPaths: readonly string[]
+  createOperationId: () => string
+  now?: number
+}): Promise<{
+  operationId: string
+  retained: boolean
+  payloadFingerprint: string
+  attachmentPaths: string[]
+}> {
+  return serialize(async () => {
+    const now = input.now ?? Date.now()
+    const callerFingerprint = mobileStructuredSendCallerFingerprint(input.callerIdentity)
+    const journal = parseJournal(await AsyncStorage.getItem(STORAGE_KEY))
+    const entries = journal.entries
+    const existing = entries.find((entry) => entry.operationKey === input.operationKey)
+    if (existing) {
+      if (existing.callerFingerprint !== callerFingerprint) {
+        throw new Error('Structured send caller identity changed')
+      }
+      return {
+        operationId: existing.operationId,
+        retained: true,
+        payloadFingerprint: existing.payloadFingerprint,
+        attachmentPaths: [...existing.attachmentPaths]
+      }
+    }
+    // Ambiguity has no TTL. At the fixed capacity, refusing a new send is safer
+    // than evicting an id whose message may already be in provider context.
+    if (entries.length >= AGENT_SESSION_DURABLE_OPERATION_GLOBAL_LIMIT) {
+      throw new Error('Structured send operation journal is full')
+    }
+    const operationId = input.createOperationId()
+    if (!newOperationIdIsAdmissible(operationId, now)) {
+      throw new Error('Structured send operation id is invalid')
+    }
+    const entry = OperationEntrySchema.parse({
+      operationKey: input.operationKey,
+      operationId,
+      callerFingerprint,
+      payloadFingerprint: input.payloadFingerprint,
+      attachmentPaths: [...input.attachmentPaths]
+    })
+    await writeEntries([...entries, entry])
+    return {
+      operationId,
+      retained: false,
+      payloadFingerprint: input.payloadFingerprint,
+      attachmentPaths: [...input.attachmentPaths]
+    }
+  })
+}
+
+export async function clearMobileStructuredSendOperation(input: {
+  operationKey: string
+  operationId: string
+}): Promise<void> {
+  return serialize(async () => {
+    const journal = parseJournal(await AsyncStorage.getItem(STORAGE_KEY))
+    const entries = journal.entries
+    const existing = entries.find((entry) => entry.operationKey === input.operationKey)
+    if (!existing) {
+      return
+    }
+    if (existing.operationId !== input.operationId) {
+      throw new Error('Structured send operation identity changed')
+    }
+    await writeEntries(entries.filter((entry) => entry !== existing))
+  })
+}
+
+/** Reconcile an ack-lost operation once the authoritative journal settles it. */
+export async function clearMobileStructuredSettledSendOperations(input: {
+  submissions: readonly AgentJournalSubmission[]
+}): Promise<void> {
+  const settled = new Set(
+    input.submissions.flatMap((submission) =>
+      submission.dispatchState === 'accepted' || submission.dispatchState === 'rejected'
+        ? [`${submission.payloadFingerprint}\u0000${submission.clientMessageId}`]
+        : []
+    )
+  )
+  if (settled.size === 0) {
+    return
+  }
+  return serialize(async () => {
+    const journal = parseJournal(await AsyncStorage.getItem(STORAGE_KEY))
+    const entries = journal.entries.filter(
+      (entry) => !settled.has(`${entry.payloadFingerprint}\u0000${entry.operationId}`)
+    )
+    if (entries.length !== journal.entries.length) {
+      await writeEntries(entries)
+    }
+  })
+}
+
+/** Test-only: drain in-memory serialization while preserving durable storage. */
+export function resetMobileStructuredSendOperationJournalForTests(): void {
+  mutations.tail = Promise.resolve()
+}

--- a/mobile/src/session/mobile-structured-session-operation-retention.test.ts
+++ b/mobile/src/session/mobile-structured-session-operation-retention.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS } from '../../../src/shared/agent-session-host-authority'
+import { AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS } from '../../../src/shared/agent-session-host-authority'
 import { retainStructuredSessionOperationId } from './mobile-structured-agent-session-rpc'
 
 const NOW = 1_900_000_000_000
@@ -21,16 +21,17 @@ describe('structured session operation retention', () => {
     }
 
     expect(operationIds.size).toBe(400)
-    // Why: the first send is exactly the one a retry would duplicate if it were evicted.
+    // Why: the first mutation still needs its id if the user returns to it.
     expect(operationIds.get('request-0')).toBe(operationIdAt(NOW, 'a'))
   })
 
   it('releases only ids the host would already refuse as expired', () => {
-    const operationIds = new Map<string, string>()
-    const expired = operationIdAt(NOW - AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS - 1, 'b')
-    const admissible = operationIdAt(NOW - AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS, 'c')
-    retainStructuredSessionOperationId(operationIds, 'stale', expired, NOW)
-    retainStructuredSessionOperationId(operationIds, 'live', admissible, NOW)
+    const expired = operationIdAt(NOW - AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS - 1, 'b')
+    const admissible = operationIdAt(NOW - AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS, 'c')
+    const operationIds = new Map([
+      ['stale', expired],
+      ['live', admissible]
+    ])
 
     retainStructuredSessionOperationId(operationIds, 'fresh', operationIdAt(NOW, 'd'), NOW)
 
@@ -39,20 +40,40 @@ describe('structured session operation retention', () => {
     expect(operationIds.get('fresh')).toBe(operationIdAt(NOW, 'd'))
   })
 
-  it('drops ids the host could never admit and re-keys a repeated send', () => {
-    const operationIds = new Map<string, string>()
-    retainStructuredSessionOperationId(operationIds, 'unparseable', 'not-an-operation-id', NOW)
+  it('drops ids the host could never admit and re-keys a repeated mutation', () => {
+    const operationIds = new Map([['unparseable', 'not-an-operation-id']])
     const reused = retainStructuredSessionOperationId(
       operationIds,
-      'send',
+      'mutation',
       operationIdAt(NOW, 'e'),
       NOW
     )
 
-    // A retry of the same send reuses the retained id rather than minting a duplicate.
+    // A retry of the same mutation reuses the retained id rather than minting a duplicate.
     expect(
-      retainStructuredSessionOperationId(operationIds, 'send', operationIds.get('send'), NOW)
+      retainStructuredSessionOperationId(
+        operationIds,
+        'mutation',
+        operationIds.get('mutation'),
+        NOW
+      )
     ).toBe(reused)
     expect(operationIds.has('unparseable')).toBe(false)
+  })
+
+  it('rotates a transient mutation id once the host would refuse it', () => {
+    const expired = operationIdAt(NOW - AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS - 1, 'f')
+    const operationIds = new Map([['mutation', expired]])
+
+    const rotated = retainStructuredSessionOperationId(
+      operationIds,
+      'mutation',
+      operationIds.get('mutation'),
+      NOW
+    )
+
+    expect(rotated).not.toBe(expired)
+    expect(rotated.startsWith(`${NOW}-`)).toBe(true)
+    expect(operationIds.get('mutation')).toBe(rotated)
   })
 })

--- a/mobile/src/session/structured-agent-send-result.test-fixture.ts
+++ b/mobile/src/session/structured-agent-send-result.test-fixture.ts
@@ -1,0 +1,26 @@
+// The shape a real host answers `agentSession.send` with: the durable submission row
+// IS the answer, and its `dispatchState` is the only thing that says whether the
+// message landed. A fixture that omits it lets a client claim delivery from `ok`
+// alone, which is the bug these tests exist to hold shut.
+
+import type { AgentJournalDispatchState } from '../../../src/shared/agent-session-journal-types'
+import type { AgentSessionSendResult } from '../../../src/shared/agent-session-wire'
+
+export function structuredSendResultFixture(
+  dispatchState: AgentJournalDispatchState,
+  reason: string | null = null
+): AgentSessionSendResult {
+  return {
+    clientMessageId: 'msg-1',
+    submission: {
+      clientMessageId: 'msg-1',
+      fence: 3,
+      payloadFingerprint: 'fingerprint',
+      dispatchState,
+      providerItemId: null,
+      reason,
+      submittedAt: 10,
+      resolvedAt: dispatchState === 'pending' ? null : 10
+    }
+  }
+}

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -87,6 +87,7 @@ export function useMobileNativeChatController(args: {
       transcriptPath: activeChatResolution?.transcriptPath ?? null,
       sessionId: activeChatSessionId,
       sourceIdentity,
+      callerIdentity: deviceTokenRef.current ?? '',
       enabled: showNativeChat,
       connState,
       onSendError

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
@@ -127,7 +127,12 @@ describe('useMobileNativeChatImageAttachments', () => {
     })
 
     expect(hook!.attachments).toEqual([
-      { id: 'img-1', path: '/tmp/a.png', previewUri: 'file:///a.jpg' }
+      {
+        id: 'img-1',
+        path: '/tmp/a.png',
+        previewUri: 'file:///a.jpg',
+        contentFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/)
+      }
     ])
     expect(client.calls.some((c) => c.method === 'terminal.send')).toBe(false)
   })

--- a/mobile/src/session/use-mobile-native-chat-session-lane.ts
+++ b/mobile/src/session/use-mobile-native-chat-session-lane.ts
@@ -14,6 +14,7 @@ export function useMobileNativeChatSessionLane({
   transcriptPath,
   sessionId,
   sourceIdentity,
+  callerIdentity,
   enabled,
   connState,
   onSendError
@@ -27,6 +28,7 @@ export function useMobileNativeChatSessionLane({
   transcriptPath: string | null
   sessionId: string | null
   sourceIdentity: Parameters<typeof useMobileNativeChatSession>[0]['sourceIdentity']
+  callerIdentity: string
   enabled: boolean
   connState: ConnectionState
   onSendError: (message: string) => void
@@ -45,6 +47,7 @@ export function useMobileNativeChatSessionLane({
     client,
     sessionId: structured ? sessionId : null,
     sourceIdentity,
+    callerIdentity,
     enabled,
     // Holds are connection-scoped; dropping this on transport loss lets the hook
     // reacquire the provider without clearing the cached transcript.

--- a/mobile/src/session/use-mobile-session-image-attachments.ts
+++ b/mobile/src/session/use-mobile-session-image-attachments.ts
@@ -34,6 +34,7 @@ type Args = {
       id: string
       path: string
       previewUri: string
+      contentFingerprint?: string
     }[]
   ) => Promise<MobileNativeChatSendOutcome>
   /** Structured agent sessions do not have a terminal paste path. */

--- a/mobile/src/session/use-mobile-structured-agent-session-send.test.tsx
+++ b/mobile/src/session/use-mobile-structured-agent-session-send.test.tsx
@@ -329,6 +329,35 @@ describe('mobile structured send retries', () => {
     }
   )
 
+  it('keeps the send id after a pending-admission refusal', async () => {
+    let attempts = 0
+    sendRequest.mockImplementation(async (method) => {
+      if (method !== 'agentSession.send') {
+        return method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+      }
+      attempts += 1
+      return attempts === 1
+        ? ok({
+            ok: false,
+            refusal: {
+              code: 'agent_session_checkpoint_stale',
+              message: 'Fence moved',
+              currentFence: 3
+            }
+          })
+        : sendResult('accepted')
+    })
+    await mountSession()
+
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('retry at the current fence')).toBe('rejected')
+      expect(await hook!.sendWithOutcome('retry at the current fence')).toBe('unknown')
+    })
+
+    expect(sentIds()).toHaveLength(2)
+    expect(new Set(sentIds()).size).toBe(1)
+  })
+
   it('keeps the id when an older host refuses an unknown replay', async () => {
     let attempts = 0
     sendRequest.mockImplementation(async (method) => {

--- a/mobile/src/session/use-mobile-structured-agent-session-send.test.tsx
+++ b/mobile/src/session/use-mobile-structured-agent-session-send.test.tsx
@@ -1,0 +1,404 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentJournalDispatchState } from '../../../src/shared/agent-session-journal-types'
+import type { AgentSessionSubscribeEvent } from '../../../src/shared/agent-session-wire'
+import type { RpcClient } from '../transport/rpc-client'
+import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
+import { resetMobileStructuredSendOperationJournalForTests } from './mobile-structured-send-operation-journal'
+import { structuredSendResultFixture } from './structured-agent-send-result.test-fixture'
+import { useMobileStructuredAgentSession } from './use-mobile-structured-agent-session'
+
+const asyncStorage = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn()
+}))
+
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: asyncStorage }))
+
+function ok(result: unknown) {
+  return { ok: true, result, _meta: { runtimeId: 'runtime-1' } }
+}
+
+function sendResult(dispatchState: AgentJournalDispatchState) {
+  return ok({
+    ok: true,
+    replayed: false,
+    fence: 3,
+    cursor: { epoch: 'epoch-1', sequence: 1 },
+    value: structuredSendResultFixture(dispatchState)
+  })
+}
+
+function snapshotEvent(): AgentSessionSubscribeEvent {
+  return {
+    type: 'snapshot',
+    sessionId: 'session-1',
+    fence: 3,
+    page: {
+      sessionId: 'session-1',
+      epoch: 'epoch-1',
+      fence: 3,
+      direction: 'tail',
+      items: [],
+      removedItemIds: [],
+      submissions: [],
+      window: {
+        oldest: null,
+        newest: null,
+        nextCursor: { epoch: 'epoch-1', sequence: 0 }
+      },
+      liveCursor: { epoch: 'epoch-1', sequence: 0 },
+      hasOlder: false,
+      hasNewer: false
+    }
+  }
+}
+
+describe('mobile structured send retries', () => {
+  let renderer: ReactTestRenderer | null = null
+  let hook: ReturnType<typeof useMobileStructuredAgentSession> | null = null
+  let listener: ((value: unknown) => void) | null = null
+  let storedOperations: Map<string, string>
+  const onSendError = vi.fn()
+  const sendRequest = vi.fn()
+  const subscribe = vi.fn((_method: string, _params: unknown, onData: (value: unknown) => void) => {
+    listener = onData
+    return vi.fn()
+  })
+  const client = { sendRequest, subscribe } as unknown as RpcClient
+
+  function Harness(): null {
+    hook = useMobileStructuredAgentSession({
+      client,
+      sessionId: 'session-1',
+      sourceIdentity: 'host-a\0workspace-a',
+      enabled: true,
+      connected: true,
+      agent: 'codex',
+      onSendError
+    } as never)
+    return null
+  }
+
+  async function mountSession(): Promise<void> {
+    act(() => {
+      renderer = create(createElement(Harness))
+    })
+    await vi.waitFor(() => expect(listener).toEqual(expect.any(Function)))
+    act(() => listener?.(snapshotEvent()))
+  }
+
+  function calls() {
+    return sendRequest.mock.calls.filter(([method]) => method === 'agentSession.send')
+  }
+
+  function sentIds(): string[] {
+    return calls().map(
+      ([, params]) =>
+        (params as { envelope: { clientOperationId: string } }).envelope.clientOperationId
+    )
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMobileStructuredSendOperationJournalForTests()
+    storedOperations = new Map()
+    asyncStorage.getItem.mockImplementation(
+      async (key: string) => storedOperations.get(key) ?? null
+    )
+    asyncStorage.setItem.mockImplementation(async (key: string, value: string) => {
+      storedOperations.set(key, value)
+    })
+    asyncStorage.removeItem.mockImplementation(async (key: string) => {
+      storedOperations.delete(key)
+    })
+    sendRequest.mockImplementation(async (method) =>
+      method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+    )
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    hook = null
+    listener = null
+  })
+
+  it('keeps one id across acknowledgement loss and host unknown replays', async () => {
+    let attempts = 0
+    sendRequest.mockImplementation(async (method) => {
+      if (method !== 'agentSession.send') {
+        return method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+      }
+      attempts += 1
+      if (attempts === 1) {
+        throw markRpcDeliveryUnknown(new Error('Connection closed'))
+      }
+      return sendResult('unknown')
+    })
+    await mountSession()
+
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('retry me')).toBe('unknown')
+      expect(await hook!.sendWithOutcome('retry me')).toBe('unknown')
+      expect(await hook!.sendWithOutcome('retry me')).toBe('unknown')
+    })
+
+    expect(calls()).toHaveLength(3)
+    expect(new Set(sentIds()).size).toBe(1)
+    expect(calls().every(([, params]) => !('retryUnknown' in (params as object)))).toBe(true)
+  })
+
+  it('releases an ack-lost id after the journal accepts it for a later identical intent', async () => {
+    let attempts = 0
+    sendRequest.mockImplementation(async (method) => {
+      if (method !== 'agentSession.send') {
+        return method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+      }
+      attempts += 1
+      return attempts === 1
+        ? Promise.reject(markRpcDeliveryUnknown(new Error('Connection closed')))
+        : sendResult('accepted')
+    })
+    await mountSession()
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('same text, later intent')).toBe('unknown')
+    })
+    const firstRequest = calls()[0]![1] as {
+      envelope: { clientOperationId: string; payloadFingerprint: string }
+    }
+    const event = snapshotEvent()
+    act(() =>
+      listener?.({
+        ...event,
+        page: {
+          ...event.page,
+          submissions: [
+            {
+              ...structuredSendResultFixture('accepted').submission,
+              clientMessageId: firstRequest.envelope.clientOperationId,
+              payloadFingerprint: firstRequest.envelope.payloadFingerprint
+            }
+          ]
+        }
+      })
+    )
+    await vi.waitFor(() => expect(storedOperations.size).toBe(0))
+
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('same text, later intent')).toBe('accepted')
+    })
+
+    expect(sentIds()).toHaveLength(2)
+    expect(new Set(sentIds()).size).toBe(2)
+  })
+
+  it('reuses an ambiguous id after the session hook remounts', async () => {
+    let attempts = 0
+    sendRequest.mockImplementation(async (method) => {
+      if (method !== 'agentSession.send') {
+        return method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+      }
+      attempts += 1
+      return attempts === 1
+        ? Promise.reject(markRpcDeliveryUnknown(new Error('Connection closed')))
+        : sendResult('unknown')
+    })
+    await mountSession()
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('survive remount')).toBe('unknown')
+    })
+    act(() => renderer?.unmount())
+    renderer = null
+    hook = null
+    listener = null
+
+    await mountSession()
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('survive remount')).toBe('unknown')
+    })
+
+    expect(new Set(sentIds()).size).toBe(1)
+    expect(calls().every(([, params]) => !('retryUnknown' in (params as object)))).toBe(true)
+    expect(asyncStorage.setItem.mock.invocationCallOrder[0]).toBeLessThan(
+      sendRequest.mock.invocationCallOrder.find(
+        (_, index) => sendRequest.mock.calls[index]?.[0] === 'agentSession.send'
+      )!
+    )
+  })
+
+  it('keeps the id when the host fails after provider dispatch', async () => {
+    let attempts = 0
+    sendRequest.mockImplementation(async (method) => {
+      if (method !== 'agentSession.send') {
+        return method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+      }
+      attempts += 1
+      return attempts === 1
+        ? {
+            id: 'request-1',
+            ok: false as const,
+            error: { code: 'runtime_error', message: 'journal resolve failed' },
+            _meta: { runtimeId: 'runtime-1' }
+          }
+        : sendResult('unknown')
+    })
+    await mountSession()
+
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('possibly delivered')).toBe('unknown')
+      expect(await hook!.sendWithOutcome('possibly delivered')).toBe('unknown')
+    })
+
+    expect(calls()).toHaveLength(2)
+    expect(new Set(sentIds()).size).toBe(1)
+    expect(calls().every(([, params]) => !('retryUnknown' in (params as object)))).toBe(true)
+  })
+
+  it('reuses the original uploaded attachment identity after acknowledgement loss', async () => {
+    let attempts = 0
+    sendRequest.mockImplementation(async (method) => {
+      if (method !== 'agentSession.send') {
+        return method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+      }
+      attempts += 1
+      return attempts === 1
+        ? Promise.reject(markRpcDeliveryUnknown(new Error('Connection closed')))
+        : sendResult('unknown')
+    })
+    await mountSession()
+    const contentFingerprint = 'f'.repeat(64)
+
+    await act(async () => {
+      expect(
+        await hook!.sendWithOutcome('describe', undefined, undefined, [
+          {
+            path: '/tmp/original.png',
+            previewUri: 'file:///photo.jpg',
+            contentFingerprint
+          }
+        ])
+      ).toBe('unknown')
+      expect(
+        await hook!.sendWithOutcome('describe', undefined, undefined, [
+          {
+            path: '/tmp/reuploaded.png',
+            previewUri: 'file:///photo.jpg',
+            contentFingerprint
+          }
+        ])
+      ).toBe('unknown')
+    })
+
+    expect(new Set(sentIds()).size).toBe(1)
+    expect(calls()[1]?.[1]).toMatchObject({
+      body: {
+        blocks: expect.arrayContaining([{ type: 'image-ref', path: '/tmp/original.png' }])
+      }
+    })
+  })
+
+  it.each(['invalid_argument', 'unauthorized'])(
+    'rotates after a %s pre-handler RPC refusal that proves the send did not run',
+    async (code) => {
+      let attempts = 0
+      sendRequest.mockImplementation(async (method) => {
+        if (method !== 'agentSession.send') {
+          return method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+        }
+        attempts += 1
+        return attempts === 1
+          ? {
+              ok: false as const,
+              error: { code, message: 'Message is not authorized' },
+              _meta: { runtimeId: 'runtime-1' }
+            }
+          : sendResult('accepted')
+      })
+      await mountSession()
+
+      await act(async () => {
+        expect(await hook!.sendWithOutcome('never reached the handler')).toBe('rejected')
+        expect(await hook!.sendWithOutcome('never reached the handler')).toBe('accepted')
+      })
+
+      expect(sentIds()).toHaveLength(2)
+      expect(new Set(sentIds()).size).toBe(2)
+    }
+  )
+
+  it('keeps the id when an older host refuses an unknown replay', async () => {
+    let attempts = 0
+    sendRequest.mockImplementation(async (method) => {
+      if (method !== 'agentSession.send') {
+        return method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+      }
+      attempts += 1
+      if (attempts === 1) {
+        throw markRpcDeliveryUnknown(new Error('Connection closed'))
+      }
+      return attempts === 2
+        ? ok({
+            ok: false,
+            refusal: {
+              code: 'agent_session_operation_unknown',
+              message: 'The outcome is unknown.'
+            }
+          })
+        : sendResult('unknown')
+    })
+    await mountSession()
+
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('old host replay')).toBe('unknown')
+      expect(await hook!.sendWithOutcome('old host replay')).toBe('unknown')
+      expect(await hook!.sendWithOutcome('old host replay')).toBe('unknown')
+    })
+
+    expect(new Set(sentIds()).size).toBe(1)
+    expect(calls().every(([, params]) => !('retryUnknown' in (params as object)))).toBe(true)
+  })
+
+  it('keeps an ambiguous id after the host replay window expires', async () => {
+    let attempts = 0
+    sendRequest.mockImplementation(async (method) => {
+      if (method !== 'agentSession.send') {
+        return method === 'agentSession.options' ? ok({ models: [], current: {} }) : ok({})
+      }
+      attempts += 1
+      if (attempts === 1) {
+        throw markRpcDeliveryUnknown(new Error('Connection closed'))
+      }
+      return ok({
+        ok: false,
+        refusal: {
+          code: 'agent_session_operation_expired',
+          message: 'Operation expired.'
+        }
+      })
+    })
+    await mountSession()
+
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('old ambiguity')).toBe('unknown')
+      expect(await hook!.sendWithOutcome('old ambiguity')).toBe('rejected')
+      expect(await hook!.sendWithOutcome('old ambiguity')).toBe('rejected')
+    })
+
+    expect(calls()).toHaveLength(3)
+    expect(new Set(sentIds()).size).toBe(1)
+  })
+
+  it('does not retain an id when the action budget expires before dispatch', async () => {
+    await mountSession()
+
+    await act(async () => {
+      expect(await hook!.sendWithOutcome('never attempted', undefined, 0)).toBe('rejected')
+    })
+
+    expect(calls()).toHaveLength(0)
+    expect(asyncStorage.setItem).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/session/use-mobile-structured-agent-session.test.tsx
+++ b/mobile/src/session/use-mobile-structured-agent-session.test.tsx
@@ -13,6 +13,16 @@ import { formatQuestionFreeTextAnswer } from './mobile-native-chat-question'
 import { structuredSendResultFixture } from './structured-agent-send-result.test-fixture'
 import { useMobileStructuredAgentSession } from './use-mobile-structured-agent-session'
 
+const asyncStorage = vi.hoisted(() => ({
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn()
+}))
+
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: asyncStorage }))
+
+import { resetMobileStructuredSendOperationJournalForTests } from './mobile-structured-send-operation-journal'
+
 function ok(result: unknown) {
   return { ok: true, result, _meta: { runtimeId: 'runtime-1' } }
 }
@@ -233,6 +243,7 @@ describe('useMobileStructuredAgentSession', () => {
     sendRequest,
     subscribe
   } as unknown as RpcClient
+  let storedOperations: Map<string, string>
 
   function Harness({
     sessionId = 'session-1',
@@ -259,6 +270,17 @@ describe('useMobileStructuredAgentSession', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    resetMobileStructuredSendOperationJournalForTests()
+    storedOperations = new Map()
+    asyncStorage.getItem.mockImplementation(
+      async (key: string) => storedOperations.get(key) ?? null
+    )
+    asyncStorage.setItem.mockImplementation(async (key: string, value: string) => {
+      storedOperations.set(key, value)
+    })
+    asyncStorage.removeItem.mockImplementation(async (key: string) => {
+      storedOperations.delete(key)
+    })
     sendRequest.mockImplementation(defaultSendRequest)
     listener = null
   })
@@ -677,46 +699,6 @@ describe('useMobileStructuredAgentSession', () => {
     expect(firstId).toMatch(/^\d{13}-[0-9a-f]{32}$/)
     expect(retryId).toMatch(/^\d{13}-[0-9a-f]{32}$/)
     expect(retryId).not.toBe(firstId)
-  })
-
-  it('keeps one operation id across an ambiguous send and its unknown replays', async () => {
-    act(() => {
-      renderer = create(createElement(Harness))
-    })
-    await vi.waitFor(() => expect(listener).toEqual(expect.any(Function)))
-    act(() => listener?.(snapshotEvent(3)))
-    let attempts = 0
-    sendRequest.mockImplementation(async (method, params) => {
-      if (method !== 'agentSession.send') {
-        return defaultSendRequest(method, params)
-      }
-      // Ack-loss first, then the durable row the host replays: both say the
-      // provider may have the message, so neither may release the id.
-      attempts += 1
-      if (attempts === 1) {
-        throw markRpcDeliveryUnknown(new Error('Connection closed'))
-      }
-      return sendResult('unknown')
-    })
-
-    await act(async () => {
-      expect(await hook!.sendWithOutcome('retry me')).toBe('unknown')
-      // Never 'accepted': a replayed unknown is not an acknowledgement, and
-      // reporting one clears the composer as if the message had landed.
-      expect(await hook!.sendWithOutcome('retry me')).toBe('unknown')
-      expect(await hook!.sendWithOutcome('retry me')).toBe('unknown')
-    })
-
-    const calls = sendRequest.mock.calls.filter(([method]) => method === 'agentSession.send')
-    expect(calls).toHaveLength(3)
-    const ids = calls.map(
-      ([, params]) =>
-        (params as { envelope: { clientOperationId: string } }).envelope.clientOperationId
-    )
-    // One id for all three: each retry is a replay the host answers from the
-    // ledger. A rotated id would be a second delivery of the same message.
-    expect(new Set(ids).size).toBe(1)
-    expect(calls.every(([, params]) => !('retryUnknown' in (params as object)))).toBe(true)
   })
 
   it('keeps structured option changes dispatched after unknown delivery', async () => {

--- a/mobile/src/session/use-mobile-structured-agent-session.test.tsx
+++ b/mobile/src/session/use-mobile-structured-agent-session.test.tsx
@@ -673,7 +673,7 @@ describe('useMobileStructuredAgentSession', () => {
     expect(retryId).not.toBe(firstId)
   })
 
-  it('marks a retried send as retryUnknown after ambiguous delivery', async () => {
+  it('uses a fresh operation id when a send delivery is ambiguous', async () => {
     act(() => {
       renderer = create(createElement(Harness))
     })
@@ -695,12 +695,12 @@ describe('useMobileStructuredAgentSession', () => {
     const calls = sendRequest.mock.calls.filter(([method]) => method === 'agentSession.send')
     expect(calls).toHaveLength(2)
     expect(calls[0]![1]).not.toHaveProperty('retryUnknown')
-    expect(calls[1]![1]).toMatchObject({ retryUnknown: true })
+    expect(calls[1]![1]).not.toHaveProperty('retryUnknown')
     const firstId = (calls[0]![1] as { envelope: { clientOperationId: string } }).envelope
       .clientOperationId
     const retryId = (calls[1]![1] as { envelope: { clientOperationId: string } }).envelope
       .clientOperationId
-    expect(retryId).toBe(firstId)
+    expect(retryId).not.toBe(firstId)
   })
 
   it('keeps structured option changes dispatched after unknown delivery', async () => {

--- a/mobile/src/session/use-mobile-structured-agent-session.test.tsx
+++ b/mobile/src/session/use-mobile-structured-agent-session.test.tsx
@@ -2,6 +2,7 @@ import { createElement } from 'react'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type {
+  AgentJournalDispatchState,
   AgentJournalRenderItem,
   AgentJournalResolution
 } from '../../../src/shared/agent-session-journal-types'
@@ -9,6 +10,7 @@ import type { AgentSessionSubscribeEvent } from '../../../src/shared/agent-sessi
 import type { RpcClient } from '../transport/rpc-client'
 import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
 import { formatQuestionFreeTextAnswer } from './mobile-native-chat-question'
+import { structuredSendResultFixture } from './structured-agent-send-result.test-fixture'
 import { useMobileStructuredAgentSession } from './use-mobile-structured-agent-session'
 
 function ok(result: unknown) {
@@ -138,15 +140,19 @@ function runningStatusItem(): AgentJournalRenderItem {
   }
 }
 
+function sendResult(dispatchState: AgentJournalDispatchState, reason: string | null = null) {
+  return ok({
+    ok: true,
+    replayed: false,
+    fence: 3,
+    cursor: { epoch: 'epoch-1', sequence: 1 },
+    value: structuredSendResultFixture(dispatchState, reason)
+  })
+}
+
 async function defaultSendRequest(method: string, params?: Record<string, unknown>) {
   if (method === 'agentSession.send') {
-    return ok({
-      ok: true,
-      replayed: false,
-      fence: 3,
-      cursor: { epoch: 'epoch-1', sequence: 1 },
-      value: { turnId: 'turn-1' }
-    })
+    return sendResult('accepted')
   }
   if (method === 'agentSession.options') {
     return ok({
@@ -673,7 +679,7 @@ describe('useMobileStructuredAgentSession', () => {
     expect(retryId).not.toBe(firstId)
   })
 
-  it('uses a fresh operation id when a send delivery is ambiguous', async () => {
+  it('keeps one operation id across an ambiguous send and its unknown replays', async () => {
     act(() => {
       renderer = create(createElement(Harness))
     })
@@ -681,26 +687,36 @@ describe('useMobileStructuredAgentSession', () => {
     act(() => listener?.(snapshotEvent(3)))
     let attempts = 0
     sendRequest.mockImplementation(async (method, params) => {
-      if (method === 'agentSession.send' && attempts++ === 0) {
+      if (method !== 'agentSession.send') {
+        return defaultSendRequest(method, params)
+      }
+      // Ack-loss first, then the durable row the host replays: both say the
+      // provider may have the message, so neither may release the id.
+      attempts += 1
+      if (attempts === 1) {
         throw markRpcDeliveryUnknown(new Error('Connection closed'))
       }
-      return defaultSendRequest(method, params)
+      return sendResult('unknown')
     })
 
     await act(async () => {
       expect(await hook!.sendWithOutcome('retry me')).toBe('unknown')
-      expect(await hook!.sendWithOutcome('retry me')).toBe('accepted')
+      // Never 'accepted': a replayed unknown is not an acknowledgement, and
+      // reporting one clears the composer as if the message had landed.
+      expect(await hook!.sendWithOutcome('retry me')).toBe('unknown')
+      expect(await hook!.sendWithOutcome('retry me')).toBe('unknown')
     })
 
     const calls = sendRequest.mock.calls.filter(([method]) => method === 'agentSession.send')
-    expect(calls).toHaveLength(2)
-    expect(calls[0]![1]).not.toHaveProperty('retryUnknown')
-    expect(calls[1]![1]).not.toHaveProperty('retryUnknown')
-    const firstId = (calls[0]![1] as { envelope: { clientOperationId: string } }).envelope
-      .clientOperationId
-    const retryId = (calls[1]![1] as { envelope: { clientOperationId: string } }).envelope
-      .clientOperationId
-    expect(retryId).not.toBe(firstId)
+    expect(calls).toHaveLength(3)
+    const ids = calls.map(
+      ([, params]) =>
+        (params as { envelope: { clientOperationId: string } }).envelope.clientOperationId
+    )
+    // One id for all three: each retry is a replay the host answers from the
+    // ledger. A rotated id would be a second delivery of the same message.
+    expect(new Set(ids).size).toBe(1)
+    expect(calls.every(([, params]) => !('retryUnknown' in (params as object)))).toBe(true)
   })
 
   it('keeps structured option changes dispatched after unknown delivery', async () => {

--- a/mobile/src/session/use-mobile-structured-agent-session.ts
+++ b/mobile/src/session/use-mobile-structured-agent-session.ts
@@ -1,16 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { dispatchMobileStructuredCommand } from './mobile-structured-composer-command'
-import type {
-  AgentSessionCancelResult,
-  AgentSessionSendResult
-} from '../../../src/shared/agent-session-wire'
+import type { AgentSessionCancelResult } from '../../../src/shared/agent-session-wire'
 import {
   structuredAgentSessionSendBody,
   type StructuredAgentSessionAttachment
 } from '../../../src/shared/structured-agent-session-outbox'
 import { encodeNativeChatTranscriptIdentity } from '../../../src/shared/native-chat-transcript-retention'
 import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
-import { mobileStructuredSendDelivery } from './mobile-structured-send-delivery'
 import { projectStructuredAgentSessionMessages } from '../../../src/shared/structured-agent-session-message-projection'
 import { hasUnansweredStructuredAgentSessionDispatch } from '../../../src/shared/structured-agent-session-projection'
 import {
@@ -39,8 +35,13 @@ import { useMobileStructuredAgentState } from './use-mobile-structured-agent-sta
 import { useMobileStructuredPromptResponses } from './use-mobile-structured-prompt-responses'
 import { useMobileStructuredAgentOptions } from './use-mobile-structured-agent-options'
 import { useMobileStructuredAgentTurnTiming } from './use-mobile-structured-agent-turn-timing'
+import { sendMobileStructuredAgentSessionMessage } from './mobile-structured-agent-session-send'
+import { useMobileStructuredSendOperationReconciliation } from './use-mobile-structured-send-operation-reconciliation'
 
-type StructuredMobileAttachment = StructuredAgentSessionAttachment & { id?: string }
+type StructuredMobileAttachment = StructuredAgentSessionAttachment & {
+  id?: string
+  contentFingerprint?: string
+}
 
 type StructuredMobileSession = ReturnType<typeof useMobileStructuredAgentOptions> &
   ReturnType<typeof useMobileStructuredAgentTurnTiming> & {
@@ -67,13 +68,24 @@ export function useMobileStructuredAgentSession(args: {
   sessionId: string | null
   /** Host/workspace scope used to keep same provider ids isolated. */
   sourceIdentity?: string
+  /** Authenticated identity the host keys mutation admission under. */
+  callerIdentity?: string
   enabled: boolean
   /** Live transport only; gates the connection-scoped hold, nothing else. */
   connected: boolean
   agent: string | null
   onSendError: (message: string) => void
 }): StructuredMobileSession {
-  const { agent, client, connected, sessionId, sourceIdentity = '', enabled, onSendError } = args
+  const {
+    agent,
+    callerIdentity = '',
+    client,
+    connected,
+    sessionId,
+    sourceIdentity = '',
+    enabled,
+    onSendError
+  } = args
   const sessionKey = encodeNativeChatTranscriptIdentity([sourceIdentity, agent, sessionId])
   const operationIdsRef = useRef(new Map<string, string>())
   const commandPendingRef = useRef(false)
@@ -82,6 +94,7 @@ export function useMobileStructuredAgentSession(args: {
     retainStructuredOpId(operationIdsRef.current, key, operationId)
   const stateArgs = { client, sessionId, sessionKey, enabled, connected }
   const { state, stateRef, loadingOlder, loadEarlier } = useMobileStructuredAgentState(stateArgs)
+  useMobileStructuredSendOperationReconciliation(state.submissions)
 
   const mutate = useCallback(
     async <TValue>(
@@ -114,7 +127,7 @@ export function useMobileStructuredAgentSession(args: {
         }
       }
       if (result.status === 'unknown') {
-        // Prompt/option/cancel plans cannot redispatch an unknown ledger row;
+        // Prompt/option plans cannot repeat a harmful effect under a fresh id;
         // issue a fresh id so a retry can be admitted after the user checks the
         // stream. Sends keep theirs — see `mobile-structured-send-delivery.ts`.
         operationIdsRef.current.delete(key)
@@ -187,35 +200,25 @@ export function useMobileStructuredAgentSession(args: {
       if (commandOutcome !== null) {
         return commandOutcome
       }
-      const fields = { body: structuredAgentSessionSendBody(text, sendAttachments) }
-      if (fields.body.blocks.length === 0) {
+      const body = structuredAgentSessionSendBody(text, sendAttachments)
+      if (body.blocks.length === 0) {
         return 'rejected'
       }
-      const key = `${sessionKey}:agentSession.send:${JSON.stringify(fields)}`
-      // No `retryUnknown`: the host never re-delivers a recorded send whatever the
-      // flag says, so asking would only skip the cached answer and re-read the same
-      // row. Reusing the retained id is what keeps the retry a replay.
-      const result = await requestStructuredAgentSessionMutation<AgentSessionSendResult>({
+      return sendMobileStructuredAgentSessionMessage({
         client,
-        method: 'agentSession.send',
-        fingerprintMethod: 'agentSession.send',
         sessionId,
+        sessionKey,
+        callerIdentity,
         expectedRuntimeFence: currentFence,
-        fields,
-        clientOperationId: retainOperationId(key, operationIdsRef.current.get(key)),
-        timeoutMs
+        text,
+        attachments: sendAttachments,
+        deadline,
+        onError: onSendError
       })
-      const delivery = mobileStructuredSendDelivery(result)
-      if (delivery.operationIdSpent) {
-        operationIdsRef.current.delete(key)
-      }
-      if (delivery.error !== null) {
-        onSendError(delivery.error)
-      }
-      return delivery.outcome
     },
     [
       agent,
+      callerIdentity,
       client,
       conversationCommands,
       enabled,

--- a/mobile/src/session/use-mobile-structured-agent-session.ts
+++ b/mobile/src/session/use-mobile-structured-agent-session.ts
@@ -186,11 +186,10 @@ export function useMobileStructuredAgentSession(args: {
       if (commandOutcome !== null) {
         return commandOutcome
       }
-      const body = structuredAgentSessionSendBody(text, sendAttachments)
-      if (body.blocks.length === 0) {
+      const fields = { body: structuredAgentSessionSendBody(text, sendAttachments) }
+      if (fields.body.blocks.length === 0) {
         return 'rejected'
       }
-      const fields = { body }
       const key = `${sessionKey}:agentSession.send:${JSON.stringify(fields)}`
       const priorOperationId = operationIdsRef.current.get(key)
       const clientOperationId = retainOperationId(key, priorOperationId)
@@ -210,6 +209,7 @@ export function useMobileStructuredAgentSession(args: {
         return 'accepted'
       }
       if (result.status === 'unknown') {
+        operationIdsRef.current.delete(key)
         return 'unknown'
       }
       operationIdsRef.current.delete(key)

--- a/mobile/src/session/use-mobile-structured-agent-session.ts
+++ b/mobile/src/session/use-mobile-structured-agent-session.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../src/shared/structured-agent-session-outbox'
 import { encodeNativeChatTranscriptIdentity } from '../../../src/shared/native-chat-transcript-retention'
 import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
+import { mobileStructuredSendDelivery } from './mobile-structured-send-delivery'
 import { projectStructuredAgentSessionMessages } from '../../../src/shared/structured-agent-session-message-projection'
 import { hasUnansweredStructuredAgentSessionDispatch } from '../../../src/shared/structured-agent-session-projection'
 import {
@@ -115,7 +116,7 @@ export function useMobileStructuredAgentSession(args: {
       if (result.status === 'unknown') {
         // Prompt/option/cancel plans cannot redispatch an unknown ledger row;
         // issue a fresh id so a retry can be admitted after the user checks the
-        // stream. Sends rotate operation ids on retry below.
+        // stream. Sends keep theirs — see `mobile-structured-send-delivery.ts`.
         operationIdsRef.current.delete(key)
         return result
       }
@@ -191,8 +192,9 @@ export function useMobileStructuredAgentSession(args: {
         return 'rejected'
       }
       const key = `${sessionKey}:agentSession.send:${JSON.stringify(fields)}`
-      const priorOperationId = operationIdsRef.current.get(key)
-      const clientOperationId = retainOperationId(key, priorOperationId)
+      // No `retryUnknown`: the host never re-delivers a recorded send whatever the
+      // flag says, so asking would only skip the cached answer and re-read the same
+      // row. Reusing the retained id is what keeps the retry a replay.
       const result = await requestStructuredAgentSessionMutation<AgentSessionSendResult>({
         client,
         method: 'agentSession.send',
@@ -200,21 +202,17 @@ export function useMobileStructuredAgentSession(args: {
         sessionId,
         expectedRuntimeFence: currentFence,
         fields,
-        clientOperationId,
-        ...(priorOperationId ? { retryUnknown: true } : {}),
+        clientOperationId: retainOperationId(key, operationIdsRef.current.get(key)),
         timeoutMs
       })
-      if (result.status === 'accepted') {
+      const delivery = mobileStructuredSendDelivery(result)
+      if (delivery.operationIdSpent) {
         operationIdsRef.current.delete(key)
-        return 'accepted'
       }
-      if (result.status === 'unknown') {
-        operationIdsRef.current.delete(key)
-        return 'unknown'
+      if (delivery.error !== null) {
+        onSendError(delivery.error)
       }
-      operationIdsRef.current.delete(key)
-      onSendError(result.message === 'Request not sent' ? 'Message not sent' : result.message)
-      return 'rejected'
+      return delivery.outcome
     },
     [
       agent,

--- a/mobile/src/session/use-mobile-structured-agent-session.ts
+++ b/mobile/src/session/use-mobile-structured-agent-session.ts
@@ -115,7 +115,7 @@ export function useMobileStructuredAgentSession(args: {
       if (result.status === 'unknown') {
         // Prompt/option/cancel plans cannot redispatch an unknown ledger row;
         // issue a fresh id so a retry can be admitted after the user checks the
-        // stream. Sends opt into explicit retryUnknown below.
+        // stream. Sends rotate operation ids on retry below.
         operationIdsRef.current.delete(key)
         return result
       }

--- a/mobile/src/session/use-mobile-structured-native-chat-send-bridge.ts
+++ b/mobile/src/session/use-mobile-structured-native-chat-send-bridge.ts
@@ -8,6 +8,7 @@ type StructuredNativeChatAttachment = {
   id?: string
   path: string
   previewUri: string
+  contentFingerprint?: string
 }
 
 export function useMobileStructuredNativeChatSendBridge(args: {

--- a/mobile/src/session/use-mobile-structured-send-operation-reconciliation.ts
+++ b/mobile/src/session/use-mobile-structured-send-operation-reconciliation.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react'
+import type { AgentJournalSubmission } from '../../../src/shared/agent-session-journal-types'
+import { clearMobileStructuredSettledSendOperations } from './mobile-structured-send-operation-journal'
+
+export function useMobileStructuredSendOperationReconciliation(
+  submissions: readonly AgentJournalSubmission[]
+): void {
+  useEffect(() => {
+    void clearMobileStructuredSettledSendOperations({ submissions }).catch(() => undefined)
+  }, [submissions])
+}

--- a/mobile/src/transport/direct-rpc-client.ts
+++ b/mobile/src/transport/direct-rpc-client.ts
@@ -250,8 +250,9 @@ export class DirectRpcClient implements RpcClient {
       return
     }
     if (!response.ok && response.error.code === 'unauthorized') {
-      this.authenticationRetry.reject('Unauthorized — pairing may be revoked')
-      return
+      // Settle this correlated refusal before marking other written requests unknown.
+      this.requests.resolve(response)
+      return this.authenticationRetry.reject('Unauthorized — pairing may be revoked')
     }
     if (!this.streams.handleResponse(response)) {
       this.requests.resolve(response)
@@ -270,7 +271,7 @@ export class DirectRpcClient implements RpcClient {
     this.socketSession = null
     closing?.clearKey()
     this.streams.markForReplay()
-    this.requests.rejectAll(reason)
+    this.requests.rejectAll(reason, { deliveryUnknown: true })
     closing?.close()
     this.connectionState.publish('reconnecting')
     this.reconnect.schedule()
@@ -281,7 +282,7 @@ export class DirectRpcClient implements RpcClient {
     this.socketSession?.close()
     this.socketSession = null
     this.connectionState.publish('auth-failed')
-    this.requests.rejectAll(reason)
+    this.requests.rejectAll(reason, { deliveryUnknown: true })
   }
 
   private sendEncrypted(request: unknown): boolean {

--- a/mobile/src/transport/mobile-relay-rpc-session.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.test.ts
@@ -322,6 +322,21 @@ describe('mobile relay RPC session', () => {
     expect(session.getState()).toBe('disconnected')
   })
 
+  it('keeps a synchronous pre-write relay failure definite', async () => {
+    const { session } = await authenticateSession()
+    fakes.sendText.mockImplementationOnce(() => {
+      fakes.linkOptions!.onError(new Error('relay outbound overflow'))
+      return false
+    })
+
+    const error = await session
+      .sendRequest('terminal.send', { terminal: 'term', text: 'hi' })
+      .catch((cause: unknown) => cause)
+
+    expect((error as Error).message).toBe('relay outbound overflow')
+    expect(isRpcDeliveryUnknown(error)).toBe(false)
+  })
+
   it('marks in-flight requests delivery-unknown when the session closes', async () => {
     const { session } = await authenticateSession()
     const pending = session.sendRequest('terminal.send', { terminal: 'term', text: 'hi' })

--- a/mobile/src/transport/mobile-relay-rpc-session.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.ts
@@ -216,12 +216,14 @@ export function connectMobileRelayRpcSession(args: {
         // Why: the frame was written long ago — the desktop may have processed it.
         reject(markRpcDeliveryUnknown(new Error(`relay RPC timed out: ${method}`)))
       }, timeoutMs)
-      pending.track(id, { resolve, reject, timer })
+      pending.track(id, { resolve, reject, timer, written: false })
       if (!sendFrame({ id, method, params })) {
         clearTimeout(timer)
         pending.drop(id)
         reject(new Error('relay E2EE channel not ready'))
+        return
       }
+      pending.markWritten(id)
     })
   }
 

--- a/mobile/src/transport/relay-pending-requests.ts
+++ b/mobile/src/transport/relay-pending-requests.ts
@@ -5,6 +5,7 @@ type PendingRequest = {
   resolve: (response: RpcResponse) => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
+  written: boolean
 }
 
 /** In-flight relay RPC requests awaiting their response frame, keyed by request id. */
@@ -24,6 +25,13 @@ export class RelayPendingRequests {
     this.pending.delete(id)
   }
 
+  markWritten(id: string): void {
+    const request = this.pending.get(id)
+    if (request) {
+      request.written = true
+    }
+  }
+
   /** Settle the waiter for this response; false when no request owns it. */
   settle(response: RpcResponse): boolean {
     const request = this.pending.get(response.id)
@@ -40,13 +48,9 @@ export class RelayPendingRequests {
     if (this.pending.size === 0) {
       return
     }
-    // Why: pending entries only exist after their frame reached the authenticated
-    // link (sendFrame failures delete them synchronously), so the desktop may
-    // have processed them — mark the ambiguity for callers.
-    markRpcDeliveryUnknown(error)
     for (const request of this.pending.values()) {
       clearTimeout(request.timer)
-      request.reject(error)
+      request.reject(request.written ? markRpcDeliveryUnknown(new Error(error.message)) : error)
     }
     this.pending.clear()
   }

--- a/mobile/src/transport/rpc-client-delivery-ambiguity.test.ts
+++ b/mobile/src/transport/rpc-client-delivery-ambiguity.test.ts
@@ -148,6 +148,34 @@ describe('mobile rpc-client delivery ambiguity marking', () => {
     client.close()
   })
 
+  it('marks a written request unknown when another request triggers auth recovery', async () => {
+    const { client, socket } = connectAuthenticated()
+    const sendError = client.sendRequest('terminal.send', { terminal: 't' }).then(
+      () => null,
+      (error: Error) => error
+    )
+    const authProbe = client.sendRequest('status.get')
+    await Promise.resolve()
+    const probe = socket.sent
+      .map(
+        (payload) =>
+          JSON.parse(payload.replace(/^encrypted:/, '')) as { id: string; method: string }
+      )
+      .find((request) => request.method === 'status.get')!
+
+    socket.receive(
+      `encrypted:${JSON.stringify({ id: probe.id, ok: false, error: { code: 'unauthorized', message: 'Unauthorized' } })}`
+    )
+    await expect(authProbe).resolves.toMatchObject({
+      ok: false,
+      error: { code: 'unauthorized' }
+    })
+
+    const error = await sendError
+    expect(isRpcDeliveryUnknown(error)).toBe(true)
+    client.close()
+  })
+
   it('does not mark requests whose frame never reached the wire', async () => {
     const { client, socket } = connectAuthenticated()
     // Simulate RN dropping onclose: the socket is dead but state is still 'connected'.

--- a/mobile/src/transport/stable-logical-rpc-client.test.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.test.ts
@@ -206,6 +206,19 @@ describe('stable logical RPC client', () => {
     )
   })
 
+  it('preserves a committed response when logical close wins the callback race', async () => {
+    const session = new FakeSession('connected')
+    const inFlight = deferred<RpcResponse>()
+    session.sendRequest.mockReturnValue(inFlight.promise)
+    const client = createStableLogicalRpcClient(session, 'lan')
+    const request = client.sendRequest('terminal.send', { terminal: 'term', text: 'hi' })
+
+    inFlight.resolve(success('accepted'))
+    client.close()
+
+    await expect(request).resolves.toEqual(success('accepted'))
+  })
+
   it('publishes the replacement dial phases while the client is suspended', async () => {
     const oldSession = new FakeSession('connected')
     const replacement = new FakeSession('connecting')

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -90,7 +90,6 @@ export function createStableLogicalRpcClient(
       if (suspended) {
         return Promise.reject(new Error('Client suspended'))
       }
-      const requestGeneration = generation
       const session = activeSession
       return new Promise<RpcResponse>((resolve, reject) => {
         const pending = { reject }
@@ -100,13 +99,9 @@ export function createStableLogicalRpcClient(
           .then(
             (response) => {
               pendingRequests.delete(pending)
-              if (closed) {
-                reject(new Error('Client closed'))
-              } else if (requestGeneration !== generation) {
-                reject(new LogicalClientCutoverError())
-              } else {
-                resolve(response)
-              }
+              // A correlated response is definitive even if close/cutover won the
+              // callback race after the physical promise had already settled.
+              resolve(response)
             },
             (error: unknown) => {
               pendingRequests.delete(pending)

--- a/src/main/claude/claude-structured-compaction.ts
+++ b/src/main/claude/claude-structured-compaction.ts
@@ -2,7 +2,6 @@ import type { ClaudeSession, ClaudeStructuredSessionEvent } from './claude-struc
 import type { StructuredSessionCompaction } from '../native-chat/agent-session-wire/structured-session-compaction'
 import { dispatchClaudeTurn } from './claude-structured-dispatch'
 import type { StructuredAgentSessionAdapter } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
-import { dispatchDoubtProvesUndelivered } from '../native-chat/agent-session-journal/journal-dispatch-doubt-reasons'
 /** Compaction needs no ack deadline of its own: `compactions.run` keeps its own
  *  180s completion window and settles on Claude's terminal `result` frame, so
  *  the dispatch here only has to report a refusal to send. */
@@ -18,10 +17,7 @@ export function compactClaudeSession(
       const result = await dispatchClaudeTurn(session, {
         body: { kind: 'message', role: 'user', blocks: [{ type: 'text', text: '/compact' }] }
       })
-      if (
-        result.state === 'rejected' ||
-        (result.state === 'unknown' && dispatchDoubtProvesUndelivered(result.reason))
-      ) {
+      if (result.state === 'rejected') {
         return { error: result.reason }
       }
       return undefined

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -372,14 +372,13 @@ describe('Claude structured dispatch image limits', () => {
       .fn()
       .mockRejectedValue(claudeUnwrittenUserMessageError(new Error('broken pipe')))
 
-    // A refused write is a transport fact, and the only thing besides child exit
-    // that puts one message's delivery in doubt.
+    // A refused write is not doubt: the frame never left, so it is a rejection.
     await expect(
       dispatchClaudeTurn(session, {
         clientMessageId: 'client-2',
         body: userMessage([{ type: 'text', text: 'two' }])
       })
-    ).resolves.toEqual({ state: 'unknown', reason: 'provider_write_failed: broken pipe' })
+    ).resolves.toEqual({ state: 'rejected', reason: 'provider_write_failed: broken pipe' })
     expect(session.dispatchWaiters).toEqual([firstWaiter])
 
     const firstUuid = (firstWaiter as { sentUuid?: string }).sentUuid
@@ -401,7 +400,7 @@ describe('Claude structured dispatch image limits', () => {
 
     await expect(
       dispatchClaudeTurn(session, { clientMessageId: 'client-1', body })
-    ).resolves.toEqual({ state: 'unknown', reason: 'provider_write_failed: broken pipe' })
+    ).resolves.toEqual({ state: 'rejected', reason: 'provider_write_failed: broken pipe' })
     expect(session.dispatchWaiters).toHaveLength(0)
     expect(session.retiredDispatchWaiters).toHaveLength(0)
 

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -15,10 +15,8 @@ import {
   claudeDispatchInvokesSlashCommand,
   claudeDispatchMessageContent
 } from './claude-structured-dispatch-content'
-import {
-  dispatchWriteFailureReason,
-  dispatchWriteOutcomeUnknownReason
-} from '../native-chat/agent-session-journal/journal-dispatch-doubt-reasons'
+import { dispatchWriteOutcomeUnknownReason } from '../native-chat/agent-session-journal/journal-dispatch-doubt-reasons'
+import { dispatchWriteFailureReason } from '../../shared/structured-agent-session-dispatch-rejection'
 import { claudeUserMessageWasProvablyUnwritten } from './claude-agent-sdk-user-message-queue'
 
 const MAX_RETIRED_DISPATCH_WAITERS = 64
@@ -299,21 +297,19 @@ export async function dispatchClaudeTurn(
         }
       }
     }
-    const provablyUnwritten = claudeUserMessageWasProvablyUnwritten(error)
-    if (provablyUnwritten) {
+    if (claudeUserMessageWasProvablyUnwritten(error)) {
       forgetWaiter(session, waiter)
       forgetRetiredWaiter(session, waiter)
       waiter.resolve(null)
-    } else if (!waiter.retired) {
+      // The frame was never handed to the SDK's input pump, so this is not doubt:
+      // the message provably did not happen, which is what `rejected` means.
+      return { state: 'rejected', reason: dispatchWriteFailureReason(error) }
+    }
+    if (!waiter.retired) {
       retireWaiter(session, waiter)
       waiter.resolve(null)
     }
-    return {
-      state: 'unknown',
-      reason: provablyUnwritten
-        ? dispatchWriteFailureReason(error)
-        : dispatchWriteOutcomeUnknownReason(error)
-    }
+    return { state: 'unknown', reason: dispatchWriteOutcomeUnknownReason(error) }
   }
   // The write is the admission signal. Awaiting the echo here would block on the
   // turn already running, which is why the deadline this replaces kept declaring

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -16,7 +16,10 @@ import {
   claudeDispatchMessageContent
 } from './claude-structured-dispatch-content'
 import { dispatchWriteOutcomeUnknownReason } from '../native-chat/agent-session-journal/journal-dispatch-doubt-reasons'
-import { dispatchWriteFailureReason } from '../../shared/structured-agent-session-dispatch-rejection'
+import {
+  DISPATCH_REJECTED_QUEUE_FULL,
+  dispatchWriteFailureReason
+} from '../../shared/structured-agent-session-dispatch-rejection'
 import { claudeUserMessageWasProvablyUnwritten } from './claude-agent-sdk-user-message-queue'
 
 const MAX_RETIRED_DISPATCH_WAITERS = 64
@@ -261,7 +264,7 @@ export async function dispatchClaudeTurn(
     return { state: 'rejected', reason: (error as Error).message }
   }
   if (session.dispatchWaiters.length >= MAX_ACTIVE_DISPATCH_WAITERS) {
-    return { state: 'rejected', reason: 'claude structured dispatch queue is full' }
+    return { state: 'rejected', reason: DISPATCH_REJECTED_QUEUE_FULL }
   }
   const dispatchSequence = ++session.dispatchSequence
   // Read the sent content, not the journal blocks: only the mapped trailing prompt decides

--- a/src/main/claude/claude-structured-session-adapter-turns.test.ts
+++ b/src/main/claude/claude-structured-session-adapter-turns.test.ts
@@ -55,7 +55,7 @@ describe('ClaudeStructuredSessionAdapter turns and controls', () => {
     expect(settled).not.toHaveBeenCalled()
   })
 
-  it('puts delivery in doubt only when the write itself fails', async () => {
+  it('rejects a send whose frame the transport never took', async () => {
     const claude = fakeClaude({ replayUuid: null })
     const adapter = await acquired(claude)
     claude.connections[0]!.send = async () => {
@@ -68,7 +68,7 @@ describe('ClaudeStructuredSessionAdapter turns and controls', () => {
         body: USER_MESSAGE,
         fence: 7
       })
-    ).resolves.toEqual({ state: 'unknown', reason: 'provider_write_failed: broken pipe' })
+    ).resolves.toEqual({ state: 'rejected', reason: 'provider_write_failed: broken pipe' })
   })
 
   it('requires an acknowledged interrupt and supports controlled options', async () => {

--- a/src/main/native-chat/agent-session-journal/journal-crash-boundary.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-crash-boundary.test.ts
@@ -16,10 +16,8 @@ import type {
   AgentSessionJournalIdentity
 } from '../../../shared/agent-session-journal-types'
 import { hasUnansweredStructuredAgentSessionDispatch } from '../../../shared/structured-agent-session-projection'
-import {
-  DISPATCH_DOUBT_RETRY_IN_PROGRESS,
-  dispatchDoubtProvesUndelivered
-} from './journal-dispatch-doubt-reasons'
+import { DISPATCH_DOUBT_CODEX_TURN_UNNAMED } from './journal-dispatch-doubt-reasons'
+import { dispatchWriteFailureReason } from '../../../shared/structured-agent-session-dispatch-rejection'
 import { digestPayload } from './journal-payload-bounds'
 import {
   reconcileSubmissions,
@@ -170,56 +168,59 @@ describe('crash between provider accept and journal commit', () => {
     expect(restarted.cursor()).toEqual(cursor)
   })
 
-  it('preserves a proven write failure while retiring its live dispatch', async () => {
+  it('leaves a rejected write failure settled across a restart', async () => {
     const journal = await open()
     await journal.appendSubmission({
       clientMessageId: 'cm_write_failed',
-      payloadFingerprint: digestPayload('safe to retry'),
-      body: userMessage('safe to retry'),
+      payloadFingerprint: digestPayload('never left the process'),
+      body: userMessage('never left the process'),
       fence: 1
     })
     await journal.resolveDispatch({
       clientMessageId: 'cm_write_failed',
-      state: 'unknown',
-      reason: 'provider_write_failed: broken pipe',
+      state: 'rejected',
+      reason: dispatchWriteFailureReason(new Error('broken pipe')),
       fence: 1
     })
 
     const restarted = await open()
     await restarted.markPendingSubmissionsUnknown(2)
 
+    // A restart re-opens what it could not answer. This one is already answered,
+    // so recovery must not reopen it as doubt.
     expect(restarted.submissions()[0]).toMatchObject({
-      dispatchState: 'unknown',
-      reason: 'provider_write_failed: broken pipe',
-      recovered: true
+      dispatchState: 'rejected',
+      reason: 'provider_write_failed: broken pipe'
     })
-    expect(dispatchDoubtProvesUndelivered(restarted.submissions()[0]?.reason)).toBe(true)
+    expect(restarted.submissions()[0]?.recovered).toBeUndefined()
+    expect(hasUnansweredStructuredAgentSessionDispatch(restarted.submissions())).toBe(false)
   })
 
-  it('turns an interrupted retry marker into recovery doubt', async () => {
+  it('keeps a codex turn it could not name in doubt, never rejected', async () => {
     const journal = await open()
     await journal.appendSubmission({
-      clientMessageId: 'cm_retrying',
-      payloadFingerprint: digestPayload('retry interrupted'),
-      body: userMessage('retry interrupted'),
+      clientMessageId: 'cm_codex_unnamed',
+      payloadFingerprint: digestPayload('codex is running this'),
+      body: userMessage('codex is running this'),
       fence: 1
     })
     await journal.resolveDispatch({
-      clientMessageId: 'cm_retrying',
+      clientMessageId: 'cm_codex_unnamed',
       state: 'unknown',
-      reason: DISPATCH_DOUBT_RETRY_IN_PROGRESS,
+      reason: DISPATCH_DOUBT_CODEX_TURN_UNNAMED,
       fence: 1
     })
 
     const restarted = await open()
     await restarted.markPendingSubmissionsUnknown(2, 'provider_exited_before_acknowledgement')
 
+    // The turn IS started; recovery may not overwrite that with a weaker guess,
+    // and it may never become a rejection, which would license a re-delivery.
     expect(restarted.submissions()[0]).toMatchObject({
       dispatchState: 'unknown',
-      reason: 'provider_exited_before_acknowledgement',
+      reason: DISPATCH_DOUBT_CODEX_TURN_UNNAMED,
       recovered: true
     })
-    expect(dispatchDoubtProvesUndelivered(restarted.submissions()[0]?.reason)).toBe(false)
   })
 
   it('reports a rejected submission as never delivered, and never re-sends it', async () => {

--- a/src/main/native-chat/agent-session-journal/journal-dispatch-doubt-reasons.ts
+++ b/src/main/native-chat/agent-session-journal/journal-dispatch-doubt-reasons.ts
@@ -3,7 +3,7 @@
 // `unknown` is never raised by elapsed time; what survives is a process fact that
 // ENDS THE WAIT without answering it. Nothing here proves a message reached a
 // provider, and nothing here proves it did not: a fact that proves non-delivery
-// is a rejection and lives in `journal-dispatch-rejection-reasons.ts`.
+// is a rejection and lives in `structured-agent-session-dispatch-rejection.ts`.
 //
 // That leaves the invariant this file exists to state: Orca NEVER re-delivers a
 // message under its own id on the strength of an `unknown`, whatever the reason

--- a/src/main/native-chat/agent-session-journal/journal-dispatch-doubt-reasons.ts
+++ b/src/main/native-chat/agent-session-journal/journal-dispatch-doubt-reasons.ts
@@ -20,6 +20,9 @@ export const DISPATCH_DOUBT_PROVIDER_EXITED = 'provider_exited_before_acknowledg
 /** The adapter took the message and only the journal write failed after it. */
 export const DISPATCH_DOUBT_PERSISTENCE_FAILED = 'dispatch_result_persistence_failed'
 
+/** The operation tombstone survived recovery but its journal submission did not. */
+export const DISPATCH_DOUBT_SUBMISSION_MISSING = 'durable_send_submission_missing'
+
 /** Codex owns a turn it started but did not name, because its turn-start still
  *  settles on a deadline. The turn IS running, so this must never be treated as
  *  proof of non-delivery. Delete it once Codex settles on the app-server's

--- a/src/main/native-chat/agent-session-journal/journal-dispatch-doubt-reasons.ts
+++ b/src/main/native-chat/agent-session-journal/journal-dispatch-doubt-reasons.ts
@@ -1,17 +1,15 @@
-// Why a submission is in doubt, and whether Orca may put the message on the
-// wire a second time.
-
-import type { AgentJournalDispatchState } from '../../../shared/agent-session-journal-types'
+// Why a submission is `unknown` — the one state that admits it cannot tell.
 //
-// `unknown` is never raised by elapsed time; what survives is a process fact.
-// But a process fact that ends the WAIT is not the same claim as one that
-// proves the message never reached a provider, and only the second justifies a
-// re-delivery. The allowlist below names the reasons that carry the stronger
-// claim, and it is deliberately FAIL-CLOSED: a reason nobody adds to it is
-// refused. Refusing a legitimate retry costs the user one re-typed message;
-// allowing an illegitimate one silently sends the model a second copy, which is
-// the harm this whole path exists to remove. When those two are in tension,
-// choose the re-type.
+// `unknown` is never raised by elapsed time; what survives is a process fact that
+// ENDS THE WAIT without answering it. Nothing here proves a message reached a
+// provider, and nothing here proves it did not: a fact that proves non-delivery
+// is a rejection and lives in `journal-dispatch-rejection-reasons.ts`.
+//
+// That leaves the invariant this file exists to state: Orca NEVER re-delivers a
+// message under its own id on the strength of an `unknown`, whatever the reason
+// says. A retry that could be a second delivery is the harm this whole path
+// exists to remove, and a user who wants the message sent anyway rotates the id
+// — one re-typed message, and a first delivery by construction.
 
 /** A previous process wrote the message and died before learning its outcome. */
 export const DISPATCH_DOUBT_HOST_RESTARTED = 'host_restarted_before_acknowledgement'
@@ -22,53 +20,17 @@ export const DISPATCH_DOUBT_PROVIDER_EXITED = 'provider_exited_before_acknowledg
 /** The adapter took the message and only the journal write failed after it. */
 export const DISPATCH_DOUBT_PERSISTENCE_FAILED = 'dispatch_result_persistence_failed'
 
-/** A retry was durably armed but had not yet recorded its dispatch outcome. */
-export const DISPATCH_DOUBT_RETRY_IN_PROGRESS = 'dispatch_retry_in_progress'
-
 /** Codex owns a turn it started but did not name, because its turn-start still
- *  settles on a deadline. Delete this once Codex settles on the app-server's
- *  turn-start response instead; until then this reason is never re-delivered,
- *  which is what the allowlist below already does by omitting it. */
+ *  settles on a deadline. The turn IS running, so this must never be treated as
+ *  proof of non-delivery. Delete it once Codex settles on the app-server's
+ *  turn-start response instead. */
 export const DISPATCH_DOUBT_CODEX_TURN_UNNAMED =
   'codex app-server started a turn it did not name in time'
-
-/** The transport refused the frame; the underlying error follows the colon. */
-export const DISPATCH_DOUBT_WRITE_FAILED = 'provider_write_failed'
 
 /** The SDK took the frame, but its input pump did not prove whether the write completed. */
 export const DISPATCH_DOUBT_WRITE_OUTCOME_UNKNOWN = 'provider_write_outcome_unknown'
 
-export function dispatchWriteFailureReason(error: unknown): string {
-  const detail = error instanceof Error ? error.message : String(error)
-  return `${DISPATCH_DOUBT_WRITE_FAILED}: ${detail}`
-}
-
 export function dispatchWriteOutcomeUnknownReason(error: unknown): string {
   const detail = error instanceof Error ? error.message : String(error)
   return `${DISPATCH_DOUBT_WRITE_OUTCOME_UNKNOWN}: ${detail}`
-}
-
-/**
- * The allowlist. True only where the frame is known never to have been taken by
- * a provider, so sending it again is a first delivery rather than a second.
- *
- * A dead child and a dead host are NOT on this list. Both end the wait, neither
- * proves non-delivery: the message was already written to that child's stdin,
- * and Claude resumes the same provider session by id, so a message that child
- * processed before dying is in the conversation Orca resumes. Deciding those
- * needs the message matched against provider history — which is exactly what
- * `journal-submission-reconciler.ts` does, and that module has no caller yet.
- */
-export function dispatchDoubtProvesUndelivered(reason: string | null | undefined): boolean {
-  return (
-    reason === DISPATCH_DOUBT_WRITE_FAILED ||
-    reason?.startsWith(`${DISPATCH_DOUBT_WRITE_FAILED}: `) === true
-  )
-}
-
-export function dispatchMayMatchProviderEcho(
-  state: AgentJournalDispatchState,
-  reason: string | null
-): boolean {
-  return state !== 'rejected' && !(state === 'unknown' && dispatchDoubtProvesUndelivered(reason))
 }

--- a/src/main/native-chat/agent-session-journal/journal-pending-submission-recovery.ts
+++ b/src/main/native-chat/agent-session-journal/journal-pending-submission-recovery.ts
@@ -1,11 +1,8 @@
-import {
-  DISPATCH_DOUBT_HOST_RESTARTED,
-  DISPATCH_DOUBT_RETRY_IN_PROGRESS
-} from './journal-dispatch-doubt-reasons'
+import { DISPATCH_DOUBT_HOST_RESTARTED } from './journal-dispatch-doubt-reasons'
 import type { AgentSessionJournal } from './journal-store'
 
-/** Settles every submission a process fact left unanswerable. The retry policy
- *  separately decides whether that fact proves the provider never received it. */
+/** Settles every submission a process fact left unanswerable. Doubt is never
+ *  proof of non-delivery, so nothing here ever becomes re-deliverable. */
 export async function markJournalPendingSubmissionsUnknown(
   journal: AgentSessionJournal,
   fence: number,
@@ -19,12 +16,9 @@ export async function markJournalPendingSubmissionsUnknown(
         (entry.dispatchState === 'unknown' && entry.recovered !== true)
     )
   for (const entry of unresolved) {
+    // An earlier reason already names a sharper fact than "the host restarted".
     const resolvedReason =
-      entry.dispatchState === 'unknown' &&
-      entry.reason !== null &&
-      entry.reason !== DISPATCH_DOUBT_RETRY_IN_PROGRESS
-        ? entry.reason
-        : reason
+      entry.dispatchState === 'unknown' && entry.reason !== null ? entry.reason : reason
     await journal.resolveDispatch({
       clientMessageId: entry.clientMessageId,
       state: 'unknown',

--- a/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
@@ -251,7 +251,7 @@ describe('submission and dispatch state machine', () => {
       {
         kind: 'dispatch',
         clientMessageId: 'cm_1',
-        state: 'unknown',
+        state: 'rejected',
         providerItemId: null,
         reason: 'provider_write_failed: closed before enqueue',
         ...base(2)
@@ -272,7 +272,7 @@ describe('submission and dispatch state machine', () => {
       }
     ])
 
-    expect(state.submissions.get('cm_1')?.dispatchState).toBe('unknown')
+    expect(state.submissions.get('cm_1')?.dispatchState).toBe('rejected')
     expect(state.submissions.get('cm_2')).toMatchObject({
       dispatchState: 'accepted',
       providerItemId: 'claude:session-1:user-1'
@@ -484,13 +484,13 @@ describe('submission and dispatch state machine', () => {
     expect(state.receipts.get('cm_1')).toBeTruthy()
   })
 
-  it('returns a proven retry to pending without moving its original submission', () => {
+  it('keeps a refused write rejected and leaves its bubble where it was', () => {
     const state = fold([
       submission,
       {
         kind: 'dispatch',
         clientMessageId: 'cm_1',
-        state: 'unknown',
+        state: 'rejected',
         providerItemId: null,
         reason: 'provider_write_failed: closed before enqueue',
         ...base(2)
@@ -505,11 +505,12 @@ describe('submission and dispatch state machine', () => {
       }
     ])
 
+    // `rejected` is terminal, so nothing can put this id back on the wire; the
+    // user's Retry sends a new message under a new id instead.
     expect(state.submissions.get('cm_1')).toMatchObject({
-      dispatchState: 'pending',
+      dispatchState: 'rejected',
       submittedAt: submission.ts,
-      reason: null,
-      resolvedAt: null
+      reason: 'provider_write_failed: closed before enqueue'
     })
     expect(renderJournalState(state).items[0]?.sequence).toBe(submission.seq)
   })

--- a/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
@@ -281,6 +281,39 @@ describe('submission and dispatch state machine', () => {
     expect(state.receipts.get('cm_2')?.providerItemId).toBe('claude:session-1:user-1')
   })
 
+  it('does not give a newer identical echo to a legacy unknown write failure', () => {
+    const body = userText('same message')
+    const state = fold([
+      { ...submission, body, payloadFingerprint: sendFingerprint(body) },
+      {
+        kind: 'dispatch',
+        clientMessageId: 'cm_1',
+        state: 'unknown',
+        providerItemId: null,
+        reason: 'provider_write_failed: closed before enqueue',
+        ...base(2)
+      },
+      {
+        ...submission,
+        clientMessageId: 'cm_2',
+        body,
+        payloadFingerprint: sendFingerprint(body),
+        ...base(3)
+      },
+      { kind: 'item', itemId: 'claude:session-1:user-1', revision: 1, body, ...base(4) }
+    ])
+
+    // A journal written before a refused write became `rejected` still holds it as
+    // `unknown`. Replay must not let that row claim the echo of a later send that
+    // genuinely landed, which would attach the delivery to the wrong message.
+    expect(state.submissions.get('cm_1')?.dispatchState).toBe('unknown')
+    expect(state.submissions.get('cm_2')).toMatchObject({
+      dispatchState: 'accepted',
+      providerItemId: 'claude:session-1:user-1'
+    })
+    expect(state.receipts.has('cm_1')).toBe(false)
+  })
+
   it('does not accept a submission from a stale provider item behind its tombstone', () => {
     const body = userText('hi')
     const providerItemId = 'claude:session-1:user-1'

--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -18,7 +18,6 @@ import {
   parseAgentJournalItemKey
 } from '../../../shared/agent-session-journal-item-key'
 import { structuredAgentSessionPayloadFingerprint } from '../../../shared/structured-agent-session-mutation'
-import { dispatchMayMatchProviderEcho } from './journal-dispatch-doubt-reasons'
 import { journalItemRevisionIsStale } from './journal-item-revision'
 import type { JournalRow } from './journal-row-schema'
 
@@ -159,11 +158,13 @@ export function resolveJournalItemId(
     fields: { body }
   })
   // Exact payload plus queue order preserves repeated identical sends one-for-one.
+  // `rejected` is the one state an echo may not claim: it says this message never
+  // reached the provider, so an item that looks like it is somebody else's.
   const submission = [...state.submissions.values()]
     .sort((left, right) => left.submittedAt - right.submittedAt)
     .find(
       (candidate) =>
-        dispatchMayMatchProviderEcho(candidate.dispatchState, candidate.reason) &&
+        candidate.dispatchState !== 'rejected' &&
         candidate.payloadFingerprint === fingerprint &&
         state.items.get(agentJournalSubmissionKey(candidate.clientMessageId))?.revision === 0
     )

--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -20,6 +20,7 @@ import {
 import { structuredAgentSessionPayloadFingerprint } from '../../../shared/structured-agent-session-mutation'
 import { journalItemRevisionIsStale } from './journal-item-revision'
 import type { JournalRow } from './journal-row-schema'
+import { dispatchRejectionWasTransportWriteFailure } from '../../../shared/structured-agent-session-dispatch-rejection'
 
 export const MAX_JOURNAL_APPLIED_SETTLEMENT_IDS = 4_096
 
@@ -158,13 +159,17 @@ export function resolveJournalItemId(
     fields: { body }
   })
   // Exact payload plus queue order preserves repeated identical sends one-for-one.
-  // `rejected` is the one state an echo may not claim: it says this message never
-  // reached the provider, so an item that looks like it is somebody else's.
+  // A submission an echo may not claim is one that says the message never reached
+  // the provider, so an item resembling it is somebody else's. That is `rejected`
+  // now — and, in journals written before this state moved, an `unknown` carrying
+  // the transport marker. Replaying an older journal must not let such a row alias
+  // the echo of a later, genuinely delivered resend of the same text.
   const submission = [...state.submissions.values()]
     .sort((left, right) => left.submittedAt - right.submittedAt)
     .find(
       (candidate) =>
         candidate.dispatchState !== 'rejected' &&
+        !dispatchRejectionWasTransportWriteFailure(candidate.reason) &&
         candidate.payloadFingerprint === fingerprint &&
         state.items.get(agentJournalSubmissionKey(candidate.clientMessageId))?.revision === 0
     )

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-admission.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-admission.ts
@@ -52,8 +52,7 @@ export async function admitAndRunAgentSessionMutation<TValue>(
   request: AgentSessionMutationRequest<TValue>
 ): Promise<AgentSessionMutationResult<TValue>> {
   const { envelope, plan, journal } = request
-  const record = request.store.getRecord(envelope.sessionId)
-  if (!journal || !record) {
+  if (!journal) {
     return refuseAgentSessionMutation(AGENT_SESSION_NOT_ATTACHED)
   }
   const hostFingerprint = computeAgentSessionPayloadFingerprint({
@@ -65,34 +64,18 @@ export async function admitAndRunAgentSessionMutation<TValue>(
   if (conflict) {
     return refuseAgentSessionMutation(conflict)
   }
-  const ledger = await request.store[
-    plan.operationIdScope === 'global' ? 'admitGlobalOperation' : 'admitOperation'
-  ]({
+  const admitted = await request.store.admitMutationOperation({
     callerKey: request.callerKey,
-    operationId: envelope.clientOperationId,
-    fingerprint: hostFingerprint,
-    now: request.now()
-  })
-  const admission = admitAgentSessionMutation({
     envelope,
     hostFingerprint,
-    ledger,
-    lease: record.lease
+    now: request.now(),
+    ...(plan.operationIdScope ? { operationIdScope: plan.operationIdScope } : {})
   })
+  if (!admitted) {
+    return refuseAgentSessionMutation(AGENT_SESSION_NOT_ATTACHED)
+  }
+  const { admission, record } = admitted
   if (admission.decision === 'refused') {
-    // A fresh row plus a pre-effect refusal proves the mutation did not run.
-    // Settle it so a same-id retry replays that fact instead of inventing doubt.
-    if (ledger.decision === 'admit') {
-      await request.store.recordOperationOutcome({
-        callerKey: ledger.row.callerKey,
-        operationId: envelope.clientOperationId,
-        outcome: {
-          status: 'failed',
-          code: admission.refusal.code,
-          message: admission.refusal.message
-        }
-      })
-    }
     return refuseAgentSessionMutation(admission.refusal)
   }
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-admission.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-admission.ts
@@ -65,18 +65,34 @@ export async function admitAndRunAgentSessionMutation<TValue>(
   if (conflict) {
     return refuseAgentSessionMutation(conflict)
   }
+  const ledger = await request.store[
+    plan.operationIdScope === 'global' ? 'admitGlobalOperation' : 'admitOperation'
+  ]({
+    callerKey: request.callerKey,
+    operationId: envelope.clientOperationId,
+    fingerprint: hostFingerprint,
+    now: request.now()
+  })
   const admission = admitAgentSessionMutation({
     envelope,
     hostFingerprint,
-    ledger: await request.store.admitOperation({
-      callerKey: request.callerKey,
-      operationId: envelope.clientOperationId,
-      fingerprint: hostFingerprint,
-      now: request.now()
-    }),
+    ledger,
     lease: record.lease
   })
   if (admission.decision === 'refused') {
+    // A fresh row plus a pre-effect refusal proves the mutation did not run.
+    // Settle it so a same-id retry replays that fact instead of inventing doubt.
+    if (ledger.decision === 'admit') {
+      await request.store.recordOperationOutcome({
+        callerKey: ledger.row.callerKey,
+        operationId: envelope.clientOperationId,
+        outcome: {
+          status: 'failed',
+          code: admission.refusal.code,
+          message: admission.refusal.message
+        }
+      })
+    }
     return refuseAgentSessionMutation(admission.refusal)
   }
 
@@ -111,10 +127,11 @@ export async function admitAndRunAgentSessionMutation<TValue>(
     }
   }
 
-  plan.beforeRun?.()
   const outcome = await runSettledAgentSessionMutation({
     store: request.store,
-    callerKey: request.callerKey,
+    // A global send replay can cross caller identities. Settlement still owns
+    // the durable row admitted by the original caller.
+    operationCallerKey: admission.row.callerKey,
     envelope,
     plan,
     context

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
@@ -2,9 +2,8 @@
 // answer is rebuilt on a replay.
 //
 // The replay half matters more than it looks. The ledger records only that an
-// operation happened, so the durable answer has to come back out of the journal.
-// A plan that cannot find its effect returns null, and the call runs for real —
-// which is exactly right when the crash landed before the journal write.
+// operation happened, so the durable answer usually comes back out of the
+// journal. Send is fail-closed: admission alone cannot prove non-delivery.
 
 import type { AgentJournalMessageItem } from '../../../shared/agent-session-journal-types'
 import type { AgentSessionOperationOutcome } from '../../../shared/agent-session-operation-ledger'
@@ -15,6 +14,7 @@ import type {
   AgentSessionPromptResult,
   AgentSessionSendResult
 } from '../../../shared/agent-session-wire'
+import { DISPATCH_DOUBT_SUBMISSION_MISSING } from '../agent-session-journal/journal-dispatch-doubt-reasons'
 import {
   performCancel,
   performPrompt,
@@ -27,6 +27,8 @@ import {
 export type MutationPlan<TValue> = {
   method: string
   fields: Record<string, unknown>
+  operationIdScope?: 'global'
+  markUnknownBeforeRun?: boolean
   beforeRun?: () => void
   run: (ctx: AgentSessionTurnContext) => Promise<TurnOutcome<TValue>>
   replay: (ctx: AgentSessionTurnContext, outcome: AgentSessionOperationOutcome) => TValue | null
@@ -46,32 +48,45 @@ export function sendPlan(params: {
   const clientMessageId = params.envelope.clientOperationId
   return {
     method: 'agentSession.send',
-    // A control signal is not payload; only a matching durable unknown permits the
-    // ledger to re-enter the plan and preserve its recorded outcome.
+    operationIdScope: 'global',
+    markUnknownBeforeRun: true,
+    // A control signal is not payload; it cannot alter durable replay.
     fields: { body: params.body },
     ...(params.beforeRun ? { beforeRun: params.beforeRun } : {}),
-    rerunWhenReplayMissing: (ctx) =>
-      params.retryUnknown === true &&
-      ctx.journal
-        .submissions()
-        .some(
-          (entry) => entry.clientMessageId === clientMessageId && entry.dispatchState === 'unknown'
-        ),
-    // No `retryUnknown` reaches `performSend`: it decides only whether the ledger
-    // re-reads the submission or replays a cached one, never whether Orca re-sends.
+    recoverUnknownFromDurableState: true,
+    // `retryUnknown` is a compatibility-only client signal. A recorded send
+    // always replays and never reaches the provider twice.
     run: (ctx) =>
       performSend(ctx, {
         clientMessageId,
         payloadFingerprint: params.envelope.payloadFingerprint,
         body: params.body
       }),
-    replay: (ctx) => {
+    replay: (ctx, outcome) => {
       const submission = ctx.journal
         .submissions()
         .find((entry) => entry.clientMessageId === clientMessageId)
-      return submission && !(params.retryUnknown && submission.dispatchState === 'unknown')
-        ? { clientMessageId, submission }
-        : null
+      if (submission) {
+        return { clientMessageId, submission }
+      }
+      if (outcome.status === 'failed') {
+        return null
+      }
+      const resolvedAt = ctx.now()
+      return {
+        clientMessageId,
+        submission: {
+          clientMessageId,
+          fence: ctx.fence,
+          payloadFingerprint: params.envelope.payloadFingerprint,
+          dispatchState: 'unknown',
+          providerItemId: null,
+          reason: DISPATCH_DOUBT_SUBMISSION_MISSING,
+          submittedAt: resolvedAt,
+          resolvedAt,
+          recovered: true
+        }
+      }
     }
   }
 }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
@@ -56,12 +56,13 @@ export function sendPlan(params: {
         .some(
           (entry) => entry.clientMessageId === clientMessageId && entry.dispatchState === 'unknown'
         ),
+    // No `retryUnknown` reaches `performSend`: it decides only whether the ledger
+    // re-reads the submission or replays a cached one, never whether Orca re-sends.
     run: (ctx) =>
       performSend(ctx, {
         clientMessageId,
         payloadFingerprint: params.envelope.payloadFingerprint,
-        body: params.body,
-        retryUnknown: params.retryUnknown
+        body: params.body
       }),
     replay: (ctx) => {
       const submission = ctx.journal

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
@@ -46,7 +46,8 @@ export function sendPlan(params: {
   const clientMessageId = params.envelope.clientOperationId
   return {
     method: 'agentSession.send',
-    // A control signal is not payload; only the matching durable unknown unlocks redispatch.
+    // A control signal is not payload; only a matching durable unknown permits the
+    // ledger to re-enter the plan and preserve its recorded outcome.
     fields: { body: params.body },
     ...(params.beforeRun ? { beforeRun: params.beforeRun } : {}),
     rerunWhenReplayMissing: (ctx) =>

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-operation-settlement.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-operation-settlement.ts
@@ -5,7 +5,7 @@ import type { AgentSessionTurnContext, TurnOutcome } from './structured-agent-se
 
 export async function runSettledAgentSessionMutation<TValue>(input: {
   store: AgentSessionRecordStore
-  callerKey: string
+  operationCallerKey: string
   envelope: AgentSessionMutationEnvelope
   plan: MutationPlan<TValue>
   context: AgentSessionTurnContext
@@ -14,11 +14,15 @@ export async function runSettledAgentSessionMutation<TValue>(input: {
     outcome: Parameters<AgentSessionRecordStore['recordOperationOutcome']>[0]['outcome']
   ) =>
     input.store.recordOperationOutcome({
-      callerKey: input.callerKey,
+      callerKey: input.operationCallerKey,
       operationId: input.envelope.clientOperationId,
       outcome
     })
   try {
+    if (input.plan.markUnknownBeforeRun) {
+      await settle({ status: 'unknown' })
+    }
+    input.plan.beforeRun?.()
     const outcome = await input.plan.run(input.context)
     await settle(
       outcome.ok

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts
@@ -171,7 +171,7 @@ async function assertHostAgreement(
   harness: Harness,
   spec: CallSpec,
   code: AgentSessionWireRefusalCode,
-  retryOnFreshHost = false
+  retry?: () => Promise<{ harness: Harness; spec: CallSpec }>
 ): Promise<Pair> {
   try {
     const result = await invoke(harness, spec)
@@ -187,12 +187,15 @@ async function assertHostAgreement(
     oracle = 'unknown'
   } else if (outcome?.status === 'pending') {
     oracle = 'pending-admission'
+  } else if (retry) {
+    const next = await retry()
+    await expect(invoke(next.harness, next.spec)).resolves.toMatchObject({
+      ok: true,
+      replayed: false
+    })
+    oracle = 'pending-admission'
   } else {
-    const retryHarness = retryOnFreshHost ? await createHarness() : harness
-    await invoke(retryHarness, spec)
-    oracle = operationState(retryHarness, spec.operationId)
-      ? 'pending-admission'
-      : 'settled-rejected'
+    oracle = 'settled-rejected'
   }
   expect(agentSessionRefusalOperationState(spec.method, code), `${spec.method}:${code}`).toBe(
     oracle
@@ -241,51 +244,56 @@ const UNREACHABLE = new Set<Pair>([
 ])
 
 describe('agentSessionRefusalOperationState host oracle', () => {
-  // 25 real host round trips, each committing the store — and every commit now also rotates a
-  // durable backup, so this does substantially more fsync work than the budget was set for.
+  // Full host retries touch the durable store and successful cases rotate its backup.
   it('agrees with every refusal the real host path can produce', { timeout: 90_000 }, async () => {
     const produced = new Set<Pair>()
     const record = (pair: Pair) => produced.add(pair)
 
     const stale = await createHarness()
     for (const method of METHODS) {
+      const spec = {
+        method,
+        operationId: operationId(),
+        expectedRuntimeFence: 99
+      }
       record(
-        await assertHostAgreement(
-          stale,
-          {
-            method,
-            operationId: operationId(),
-            expectedRuntimeFence: 99
-          },
-          'agent_session_checkpoint_stale'
-        )
+        await assertHostAgreement(stale, spec, 'agent_session_checkpoint_stale', async () => ({
+          harness: stale,
+          spec: {
+            ...spec,
+            expectedRuntimeFence: stale.store.getRecord(SESSION)?.lease.runtimeFence ?? 1
+          }
+        }))
       )
     }
+    expect(stale.setOption).toHaveBeenCalledTimes(1)
 
     const conflict = await createHarness({ transport: true })
-    await setLease(conflict, (current) => ({
-      ...current,
-      lease: { ...current.lease, runtimeKind: 'tui' }
-    }))
     for (const method of ['agentSession.setOption', 'agentSession.send'] as const) {
+      await setLease(conflict, (current) => ({
+        ...current,
+        lease: { ...current.lease, runtimeKind: 'tui' }
+      }))
+      const spec = { method, operationId: operationId() }
       record(
-        await assertHostAgreement(
-          conflict,
-          { method, operationId: operationId() },
-          'agent_session_conflict'
-        )
+        await assertHostAgreement(conflict, spec, 'agent_session_conflict', async () => {
+          await setLease(conflict, (current) => ({
+            ...current,
+            lease: { ...current.lease, runtimeKind: 'native' }
+          }))
+          return { harness: conflict, spec }
+        })
       )
     }
 
     const absent = await createHarness({ attached: false })
     for (const method of METHODS) {
+      const spec = { method, operationId: operationId() }
       record(
-        await assertHostAgreement(
-          absent,
-          { method, operationId: operationId() },
-          'agent_session_ownership_unknown',
-          true
-        )
+        await assertHostAgreement(absent, spec, 'agent_session_ownership_unknown', async () => ({
+          harness: await createHarness(),
+          spec
+        }))
       )
     }
 
@@ -325,13 +333,12 @@ describe('agentSessionRefusalOperationState host oracle', () => {
     const capacity = await createHarness()
     await fillOperationLedger(capacity)
     for (const method of METHODS) {
+      const spec = { method, operationId: operationId() }
       record(
-        await assertHostAgreement(
-          capacity,
-          { method, operationId: operationId() },
-          'agent_session_operation_capacity',
-          true
-        )
+        await assertHostAgreement(capacity, spec, 'agent_session_operation_capacity', async () => ({
+          harness: await createHarness(),
+          spec
+        }))
       )
     }
 
@@ -342,17 +349,20 @@ describe('agentSessionRefusalOperationState host oracle', () => {
     record(await assertHostAgreement(unknown, optionUnknown, 'agent_session_operation_unknown'))
 
     const reconciling = await createHarness()
-    await setLease(reconciling, (current) => ({
-      ...current,
-      lease: { ...current.lease, unreconciled: true }
-    }))
     for (const method of ['agentSession.setOption', 'agentSession.send'] as const) {
+      await setLease(reconciling, (current) => ({
+        ...current,
+        lease: { ...current.lease, unreconciled: true }
+      }))
+      const spec = { method, operationId: operationId() }
       record(
-        await assertHostAgreement(
-          reconciling,
-          { method, operationId: operationId() },
-          'execution_owner_reconciling'
-        )
+        await assertHostAgreement(reconciling, spec, 'execution_owner_reconciling', async () => {
+          await setLease(reconciling, (current) => ({
+            ...current,
+            lease: { ...current.lease, unreconciled: false }
+          }))
+          return { harness: reconciling, spec }
+        })
       )
     }
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-refusal-retry.test.ts
@@ -17,7 +17,6 @@ import {
   type AgentSessionRefusalOperationState
 } from '../../../shared/agent-session-refusal-retry'
 import { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
-import { AgentSessionJournal } from '../agent-session-journal/journal-store'
 import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
 import { StructuredAgentSessionHost } from './structured-agent-session-host'
 import {
@@ -236,11 +235,13 @@ const UNREACHABLE = new Set<Pair>([
   'agentSession.send:agent_session_identity_required',
   // No structured-agent-session host branch emits agent_session_journal_unreadable.
   'agentSession.setOption:agent_session_journal_unreadable',
-  'agentSession.send:agent_session_journal_unreadable'
+  'agentSession.send:agent_session_journal_unreadable',
+  // Send reconstructs doubt from its global tombstone instead of refusing it.
+  'agentSession.send:agent_session_operation_unknown'
 ])
 
 describe('agentSessionRefusalOperationState host oracle', () => {
-  // 26 real host round trips, each committing the store — and every commit now also rotates a
+  // 25 real host round trips, each committing the store — and every commit now also rotates a
   // durable backup, so this does substantially more fsync work than the budget was set for.
   it('agrees with every refusal the real host path can produce', { timeout: 90_000 }, async () => {
     const produced = new Set<Pair>()
@@ -339,14 +340,6 @@ describe('agentSessionRefusalOperationState host oracle', () => {
     const optionUnknown = { method: 'agentSession.setOption' as const, operationId: operationId() }
     await expect(invoke(unknown, optionUnknown)).rejects.toThrow('reply lost')
     record(await assertHostAgreement(unknown, optionUnknown, 'agent_session_operation_unknown'))
-
-    const appendFailure = vi
-      .spyOn(AgentSessionJournal.prototype, 'appendSubmission')
-      .mockRejectedValueOnce(new Error('journal write failed'))
-    const sendUnknown = { method: 'agentSession.send' as const, operationId: operationId() }
-    await expect(invoke(unknown, sendUnknown)).rejects.toThrow('journal write failed')
-    appendFailure.mockRestore()
-    record(await assertHostAgreement(unknown, sendUnknown, 'agent_session_operation_unknown'))
 
     const reconciling = await createHarness()
     await setLease(reconciling, (current) => ({

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-send-idempotency.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-send-idempotency.test.ts
@@ -8,6 +8,7 @@ import { structuredAgentSessionPayloadFingerprint } from '../../../shared/struct
 import { createTrackedJournalOpener } from '../agent-session-journal/journal-store-test-open'
 import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
 import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
+import { DISPATCH_DOUBT_CODEX_TURN_UNNAMED } from '../agent-session-journal/journal-dispatch-doubt-reasons'
 import { performSend, type AgentSessionTurnContext } from './structured-agent-session-turns'
 
 const journals = createTrackedJournalOpener()
@@ -35,7 +36,11 @@ afterEach(async () => {
 })
 
 describe('structured send idempotency', () => {
-  it('publishes a recovered retry as working before waiting for its provider', async () => {
+  it.each([
+    ['a refused write', 'provider_write_failed: broken pipe'],
+    ['a dead host', 'host_restarted_before_acknowledgement'],
+    ['a codex turn it could not name', DISPATCH_DOUBT_CODEX_TURN_UNNAMED]
+  ])('never puts an unknown back on the wire after %s', async (_case, reason) => {
     const body: AgentJournalMessageItem = {
       kind: 'message',
       role: 'user',
@@ -43,15 +48,11 @@ describe('structured send idempotency', () => {
     }
     const input = { clientMessageId: 'retry-id', payloadFingerprint: 'fingerprint', body }
     await journal.appendSubmission({ ...input, fence: 1 })
-    await journal.markPendingSubmissionsUnknown(2, 'provider_write_failed: broken pipe')
-    const originalItem = journal.snapshot().items[0]
-    const publish = vi.fn()
-    const dispatch = vi.fn(async () => {
-      expect(publish).toHaveBeenCalledOnce()
-      expect(hasUnansweredStructuredAgentSessionDispatch(journal.submissions(), 2)).toBe(true)
-      return { state: 'unknown' as const, reason: 'ack timeout' }
-    })
-    await performSend(
+    await journal.markPendingSubmissionsUnknown(2, reason)
+    const before = journal.snapshot()
+    const dispatch = vi.fn(async () => ({ state: 'admitted' as const }))
+
+    const result = await performSend(
       {
         sessionId: 'session-1',
         journal,
@@ -59,13 +60,22 @@ describe('structured send idempotency', () => {
         adapter: { dispatch } as unknown as StructuredAgentSessionAdapter,
         persistOptions: async () => undefined,
         resolvedBy: 'caller',
-        publish,
+        publish: vi.fn(),
         now: () => 1
       },
-      { ...input, retryUnknown: true }
+      input
     )
-    expect(hasUnansweredStructuredAgentSessionDispatch(journal.submissions(), 2)).toBe(true)
-    expect(journal.snapshot().items).toEqual([originalItem])
+
+    // The recorded outcome comes back verbatim: no dispatch, no new row, and the
+    // doubt is neither cleared nor sharpened into a rejection.
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      ok: true,
+      value: { submission: { dispatchState: 'unknown', reason } }
+    })
+    expect(journal.snapshot()).toEqual(before)
+    // And the refusal does not resurrect a recovered submission as still working.
+    expect(hasUnansweredStructuredAgentSessionDispatch(journal.submissions(), 2)).toBe(false)
   })
 
   it('does not redispatch one send id reused across caller ledgers', async () => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts
@@ -80,8 +80,8 @@ describe('send', () => {
       ok: true,
       value: { submission: { dispatchState: 'unknown' } }
     })
-    // A thrown adapter call is indistinguishable from a lost reply, so it is not
-    // on the allowlist: Retry replays the recorded outcome.
+    // A thrown adapter call is indistinguishable from a lost reply, so Retry
+    // replays the recorded outcome.
     await expect(host.send(CALLER, { ...params, retryUnknown: true })).resolves.toMatchObject({
       ok: true,
       value: { submission: { dispatchState: 'unknown' } }
@@ -91,8 +91,11 @@ describe('send', () => {
     expect(state.ok && state.page.submissions).toHaveLength(1)
   })
 
-  it('redispatches an explicitly retried unknown the write itself refused', async () => {
+  it('refuses to redeliver an unknown however strongly its reason reads', async () => {
     await attach()
+    // The reason that used to be the sole entry on the redelivery allowlist. It
+    // is now a rejection when it is real, so an `unknown` still carrying it is
+    // only a claim -- and no claim unlocks a second delivery under one id.
     dispatch
       .mockImplementationOnce(async () => ({
         state: 'unknown' as const,
@@ -103,38 +106,47 @@ describe('send', () => {
     const params = { envelope: envelope('agentSession.send', { body }), body }
 
     await host.send(CALLER, params)
-    // The only doubt on the allowlist: the transport refused the frame, so this
-    // is a first delivery and not a second.
     await expect(host.send(CALLER, { ...params, retryUnknown: true })).resolves.toMatchObject({
+      ok: true,
+      value: {
+        submission: { dispatchState: 'unknown', reason: 'provider_write_failed: broken pipe' }
+      }
+    })
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    const state = host.history({ sessionId: SESSION, direction: 'tail' })
+    expect(state.ok && state.page.submissions).toHaveLength(1)
+  })
+
+  it('settles a refused write as rejected and delivers a rotated id exactly once', async () => {
+    await attach()
+    dispatch
+      .mockImplementationOnce(async () => ({
+        state: 'rejected' as const,
+        reason: 'provider_write_failed: broken pipe'
+      }))
+      .mockImplementationOnce(async () => accepted())
+    const body = hostTestMessage('never written')
+    const params = { envelope: envelope('agentSession.send', { body }), body }
+
+    await expect(host.send(CALLER, params)).resolves.toMatchObject({
+      ok: true,
+      value: {
+        submission: { dispatchState: 'rejected', reason: 'provider_write_failed: broken pipe' }
+      }
+    })
+    // What the user's Retry does with a rejection: a fresh client message id,
+    // which is a first delivery by construction and cannot duplicate the frame
+    // that never left the process.
+    await expect(
+      host.send(CALLER, { envelope: envelope('agentSession.send', { body }), body })
+    ).resolves.toMatchObject({
       ok: true,
       replayed: false,
       value: { submission: { dispatchState: 'accepted' } }
     })
     expect(dispatch).toHaveBeenCalledTimes(2)
     const state = host.history({ sessionId: SESSION, direction: 'tail' })
-    expect(state.ok && state.page.submissions).toHaveLength(1)
-  })
-
-  it('returns an admitted retry to pending until the provider echo accepts it', async () => {
-    await attach()
-    dispatch
-      .mockImplementationOnce(async () => ({
-        state: 'unknown' as const,
-        reason: 'provider_write_failed: connection closed before enqueue'
-      }))
-      .mockImplementationOnce(async () => ({ state: 'admitted' as const }))
-    const body = hostTestMessage('admitted on retry')
-    const params = { envelope: envelope('agentSession.send', { body }), body }
-
-    await host.send(CALLER, params)
-    await expect(host.send(CALLER, { ...params, retryUnknown: true })).resolves.toMatchObject({
-      ok: true,
-      replayed: false,
-      value: {
-        submission: { dispatchState: 'pending', reason: null, resolvedAt: null }
-      }
-    })
-    expect(dispatch).toHaveBeenCalledTimes(2)
+    expect(state.ok && state.page.submissions).toHaveLength(2)
   })
 
   it('refuses to redeliver a retry for a turn the provider already owns', async () => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts
@@ -6,6 +6,7 @@ import type { AgentSessionRecordStore } from '../../runtime/agent-session-record
 import type { StructuredAgentSessionHost } from './structured-agent-session-host'
 import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
 import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
+import { DISPATCH_DOUBT_SUBMISSION_MISSING } from '../agent-session-journal/journal-dispatch-doubt-reasons'
 import {
   accepted,
   attach,
@@ -46,6 +47,25 @@ describe('send', () => {
     expect(page.ok && page.page.fence).toBe(1)
     expect(page.page.hostNow).toBe(NOW)
     expect(page.providerSession).toEqual({ key: 'session_id', id: THREAD })
+  })
+
+  it('settles a submission write failure as rejected before provider dispatch', async () => {
+    await attach()
+    const journal = (
+      host as unknown as { sessions: Map<string, { journal: AgentSessionJournal }> }
+    ).sessions.get(SESSION)!.journal
+    vi.spyOn(journal, 'appendSubmission').mockRejectedValueOnce(new Error('disk full'))
+    const body = hostTestMessage('not durably recorded')
+    const params = { envelope: envelope('agentSession.send', { body }), body }
+
+    await expect(host.send(CALLER, params)).resolves.toMatchObject({
+      ok: false,
+      refusal: { code: 'agent_session_operation_invalid' }
+    })
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(
+      store.listOperationRows().find((row) => row.operationId === params.envelope.clientOperationId)
+    ).toMatchObject({ outcome: { status: 'failed' } })
   })
 
   it('settles a thrown dispatch as unknown, never as a rejection', async () => {
@@ -241,6 +261,127 @@ describe('send', () => {
     expect(journal.submissions()).toHaveLength(1)
   })
 
+  it('reconstructs an accepted send after the ledger settlement is lost', async () => {
+    await attach()
+    const persist = store.recordOperationOutcome.bind(store)
+    let failSettlement = true
+    vi.spyOn(store, 'recordOperationOutcome').mockImplementation(async (input) => {
+      if (failSettlement && input.outcome.status === 'succeeded') {
+        failSettlement = false
+        throw new Error('operation settlement failed')
+      }
+      return persist(input)
+    })
+    const body = hostTestMessage('accepted before settlement failed')
+    const params = { envelope: envelope('agentSession.send', { body }), body }
+
+    await expect(host.send(CALLER, params)).rejects.toThrow('operation settlement failed')
+    await expect(host.send(CALLER, params)).resolves.toMatchObject({
+      ok: true,
+      replayed: true,
+      value: { submission: { dispatchState: 'accepted' } }
+    })
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('never reruns an admission-only send after the caller changes', async () => {
+    await attach()
+    const settlement = vi
+      .spyOn(store, 'recordOperationOutcome')
+      .mockRejectedValue(new Error('operation settlement failed'))
+    const body = hostTestMessage('first delivery after caller recovery')
+    const params = { envelope: envelope('agentSession.send', { body }), body }
+
+    await expect(host.send(CALLER, params)).rejects.toThrow('operation settlement failed')
+    expect(dispatch).not.toHaveBeenCalled()
+    settlement.mockRestore()
+
+    await expect(host.send({ callerKey: 'client-after-recovery' }, params)).resolves.toMatchObject({
+      ok: true,
+      replayed: true,
+      value: {
+        submission: {
+          dispatchState: 'unknown',
+          reason: DISPATCH_DOUBT_SUBMISSION_MISSING
+        }
+      }
+    })
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(
+      store.listOperationRows().find((row) => row.operationId === params.envelope.clientOperationId)
+    ).toMatchObject({ callerKey: CALLER.callerKey, outcome: { status: 'pending' } })
+  })
+
+  it('never redelivers after admission survives without its journal submission', async () => {
+    await attach()
+    const persist = store.recordOperationOutcome.bind(store)
+    const settlement = vi
+      .spyOn(store, 'recordOperationOutcome')
+      .mockImplementation(async (input) => {
+        if (input.outcome.status === 'succeeded') {
+          throw new Error('operation settlement failed')
+        }
+        return persist(input)
+      })
+    const body = hostTestMessage('delivered before epoch recovery')
+    const params = { envelope: envelope('agentSession.send', { body }), body }
+
+    await expect(host.send(CALLER, params)).rejects.toThrow('operation settlement failed')
+    settlement.mockRestore()
+    const journal = (
+      host as unknown as { sessions: Map<string, { journal: AgentSessionJournal }> }
+    ).sessions.get(SESSION)!.journal
+    await journal.rollEpoch('schema_unreadable', store.getRecord(SESSION)?.lease.runtimeFence ?? 1)
+    expect(journal.submissions()).toHaveLength(0)
+
+    await expect(
+      host.send({ callerKey: 'client-after-recovery' }, { ...params, retryUnknown: true })
+    ).resolves.toMatchObject({
+      ok: true,
+      replayed: true,
+      value: {
+        submission: {
+          dispatchState: 'unknown',
+          reason: DISPATCH_DOUBT_SUBMISSION_MISSING,
+          recovered: true
+        }
+      }
+    })
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(journal.submissions()).toHaveLength(0)
+  })
+
+  it('fails closed when a legacy pending row survives without its submission', async () => {
+    await attach()
+    const body = hostTestMessage('legacy pending send after caller recovery')
+    const params = { envelope: envelope('agentSession.send', { body }), body }
+
+    await host.send(CALLER, params)
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    await store.recordOperationOutcome({
+      callerKey: CALLER.callerKey,
+      operationId: params.envelope.clientOperationId,
+      outcome: { status: 'pending' }
+    })
+
+    const journal = (
+      host as unknown as { sessions: Map<string, { journal: AgentSessionJournal }> }
+    ).sessions.get(SESSION)!.journal
+    await journal.rollEpoch('schema_unreadable', store.getRecord(SESSION)?.lease.runtimeFence ?? 1)
+
+    await expect(host.send({ callerKey: 'client-after-recovery' }, params)).resolves.toMatchObject({
+      ok: true,
+      replayed: true,
+      value: {
+        submission: {
+          dispatchState: 'unknown',
+          reason: DISPATCH_DOUBT_SUBMISSION_MISSING
+        }
+      }
+    })
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
   it('refuses to redeliver an admitted send whose child exited first', async () => {
     await attach()
     dispatch.mockImplementationOnce(async () => ({ state: 'admitted' as const }))
@@ -284,8 +425,9 @@ describe('send', () => {
 
     await journal.markPendingSubmissionsUnknown(store.getRecord(SESSION)?.lease.runtimeFence ?? 1)
     await expect(host.send(CALLER, params)).resolves.toMatchObject({
-      ok: false,
-      refusal: { code: 'agent_session_operation_unknown' }
+      ok: true,
+      replayed: true,
+      value: { submission: { dispatchState: 'unknown' } }
     })
     expect(dispatch).toHaveBeenCalledTimes(1)
 
@@ -316,7 +458,7 @@ describe('send', () => {
     })
   })
 
-  it('does not let a refused call leave a ledger row that replays past the fence', async () => {
+  it('settles a refused send so its admission row cannot replay past the fence', async () => {
     const record = await attach()
     const body = hostTestMessage('add a retry')
     const params = {
@@ -333,6 +475,9 @@ describe('send', () => {
       refusal: { code: 'agent_session_checkpoint_stale' }
     })
     expect(dispatch).not.toHaveBeenCalled()
+    expect(
+      store.listOperationRows().find((row) => row.operationId === params.envelope.clientOperationId)
+    ).toMatchObject({ outcome: { status: 'failed', code: 'agent_session_checkpoint_stale' } })
   })
 
   it('refuses any mutation against a session this host has not attached', async () => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-send.test.ts
@@ -458,7 +458,7 @@ describe('send', () => {
     })
   })
 
-  it('settles a refused send so its admission row cannot replay past the fence', async () => {
+  it('reuses a pending send admission after the client refreshes its fence', async () => {
     const record = await attach()
     const body = hostTestMessage('add a retry')
     const params = {
@@ -469,15 +469,29 @@ describe('send', () => {
       ),
       body
     }
-    await host.send(CALLER, params)
     expect(await host.send(CALLER, params)).toMatchObject({
       ok: false,
       refusal: { code: 'agent_session_checkpoint_stale' }
     })
-    expect(dispatch).not.toHaveBeenCalled()
     expect(
-      store.listOperationRows().find((row) => row.operationId === params.envelope.clientOperationId)
-    ).toMatchObject({ outcome: { status: 'failed', code: 'agent_session_checkpoint_stale' } })
+      store
+        .listOperationRows()
+        .filter((row) => row.operationId === params.envelope.clientOperationId)
+    ).toEqual([])
+    const retry = {
+      ...params,
+      envelope: {
+        ...params.envelope,
+        expectedRuntimeFence: record?.lease.runtimeFence ?? 1
+      }
+    }
+    expect(await host.send(CALLER, retry)).toMatchObject({
+      ok: true,
+      replayed: false,
+      value: { submission: { dispatchState: 'accepted' } }
+    })
+    expect(await host.send(CALLER, retry)).toMatchObject({ ok: true, replayed: true })
+    expect(dispatch).toHaveBeenCalledTimes(1)
   })
 
   it('refuses any mutation against a session this host has not attached', async () => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
@@ -15,11 +15,7 @@ import type {
   AgentSessionSendResult,
   AgentSessionWireRefusal
 } from '../../../shared/agent-session-wire'
-import {
-  DISPATCH_DOUBT_PERSISTENCE_FAILED,
-  DISPATCH_DOUBT_RETRY_IN_PROGRESS,
-  dispatchDoubtProvesUndelivered
-} from '../agent-session-journal/journal-dispatch-doubt-reasons'
+import { DISPATCH_DOUBT_PERSISTENCE_FAILED } from '../agent-session-journal/journal-dispatch-doubt-reasons'
 import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
 import type {
   AgentSessionDispatchOutcome,
@@ -82,22 +78,19 @@ async function appendStatus(
 }
 
 /**
- * Whether a user's Retry may put this message on the wire again: only where the
- * recorded doubt proves the frame never reached a provider. Everything else
- * replays the recorded outcome instead — one message reached the model five
- * times through this path. Orca never re-sends on its own either way.
+ * One id, one delivery. A submission that already exists replays its recorded
+ * outcome and NEVER goes back on the wire, whatever state it is in and whatever
+ * `retryUnknown` the client sent: `unknown` cannot prove non-delivery — that is
+ * the whole content of the word — and one message reached the model five times
+ * when this was a judgement call instead of an invariant. A user who wants the
+ * message sent anyway retries under a fresh id, which is a first delivery.
  */
-function retryWouldRedeliver(existing: AgentJournalSubmission | undefined): boolean {
-  return existing?.dispatchState === 'unknown' && dispatchDoubtProvesUndelivered(existing.reason)
-}
-
 export async function performSend(
   ctx: AgentSessionTurnContext,
   input: {
     clientMessageId: string
     payloadFingerprint: string
     body: AgentJournalMessageItem
-    retryUnknown?: true
   }
 ): Promise<TurnOutcome<AgentSessionSendResult>> {
   const existing = ctx.journal
@@ -106,39 +99,18 @@ export async function performSend(
   if (existing && existing.payloadFingerprint !== input.payloadFingerprint) {
     return invalid(`Message id ${input.clientMessageId} was already used for another send.`)
   }
-  const redeliver = input.retryUnknown === true && retryWouldRedeliver(existing)
-  if (existing && !redeliver) {
+  if (existing) {
     return {
       ok: true,
       value: { clientMessageId: input.clientMessageId, submission: existing }
     }
   }
-  if (!redeliver) {
-    await ctx.journal.appendSubmission({ ...input, fence: ctx.fence })
-    ctx.publish()
-  } else {
-    // Retry resumes work without moving or duplicating the original message.
-    await ctx.journal.resolveDispatch({
-      clientMessageId: input.clientMessageId,
-      state: 'unknown',
-      reason: DISPATCH_DOUBT_RETRY_IN_PROGRESS,
-      fence: ctx.fence
-    })
-    ctx.publish()
-  }
+  await ctx.journal.appendSubmission({ ...input, fence: ctx.fence })
+  ctx.publish()
 
   const outcome = await dispatchSafely(ctx, input.clientMessageId, input.body)
-  // A first admission needs no dispatch row: the submission is already pending.
-  // A retry must durably clear the old doubt so clients do not mistake a
-  // successful re-admission for a refused redelivery.
+  // An admission needs no dispatch row: the submission is already pending.
   if (outcome.state === 'admitted') {
-    if (redeliver) {
-      await ctx.journal.resolveDispatch({
-        clientMessageId: input.clientMessageId,
-        state: 'pending',
-        fence: ctx.fence
-      })
-    }
     ctx.publish()
     return {
       ok: true,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
@@ -82,8 +82,8 @@ async function appendStatus(
  * outcome and NEVER goes back on the wire, whatever state it is in and whatever
  * `retryUnknown` the client sent: `unknown` cannot prove non-delivery — that is
  * the whole content of the word — and one message reached the model five times
- * when this was a judgement call instead of an invariant. A user who wants the
- * message sent anyway retries under a fresh id, which is a first delivery.
+ * when this was a judgement call instead of an invariant. A distinct send after
+ * a terminal rejection uses a fresh id, which is a first delivery.
  */
 export async function performSend(
   ctx: AgentSessionTurnContext,
@@ -105,7 +105,11 @@ export async function performSend(
       value: { clientMessageId: input.clientMessageId, submission: existing }
     }
   }
-  await ctx.journal.appendSubmission({ ...input, fence: ctx.fence })
+  try {
+    await ctx.journal.appendSubmission({ ...input, fence: ctx.fence })
+  } catch {
+    return invalid('The message could not be recorded and was not sent.')
+  }
   ctx.publish()
 
   const outcome = await dispatchSafely(ctx, input.clientMessageId, input.body)

--- a/src/main/runtime/agent-session-operation-admission.test.ts
+++ b/src/main/runtime/agent-session-operation-admission.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { agentSessionOperationKey } from '../../shared/agent-session-operation-ledger'
+import {
+  admitAgentSessionGlobalOperationRow,
+  admitAgentSessionOperationRow
+} from './agent-session-operation-admission'
+
+const NOW = 1_900_000_000_000
+const OPERATION_ID = `${NOW}-${'a'.repeat(32)}`
+
+describe('global agent-session operation admission', () => {
+  it('replays the original row after the caller identity changes', () => {
+    const first = admitAgentSessionOperationRow(new Map(), {
+      callerKey: 'caller-before-reconnect',
+      operationId: OPERATION_ID,
+      fingerprint: 'send-fingerprint',
+      now: NOW
+    })
+
+    const replay = admitAgentSessionGlobalOperationRow(first.rows, {
+      callerKey: 'caller-after-reconnect',
+      operationId: OPERATION_ID,
+      fingerprint: 'send-fingerprint',
+      now: NOW + 1
+    })
+
+    expect(replay.decision).toMatchObject({
+      decision: 'replay',
+      row: { callerKey: 'caller-before-reconnect' }
+    })
+    expect(replay.rows.has(agentSessionOperationKey('caller-after-reconnect', OPERATION_ID))).toBe(
+      false
+    )
+  })
+
+  it('refuses the same id under a different send fingerprint', () => {
+    const first = admitAgentSessionOperationRow(new Map(), {
+      callerKey: 'caller-before-reconnect',
+      operationId: OPERATION_ID,
+      fingerprint: 'first-send',
+      now: NOW
+    })
+
+    expect(
+      admitAgentSessionGlobalOperationRow(first.rows, {
+        callerKey: 'caller-after-reconnect',
+        operationId: OPERATION_ID,
+        fingerprint: 'different-send',
+        now: NOW + 1
+      }).decision
+    ).toEqual({ decision: 'refused', code: 'agent_session_operation_conflict' })
+  })
+})

--- a/src/main/runtime/agent-session-operation-admission.ts
+++ b/src/main/runtime/agent-session-operation-admission.ts
@@ -8,6 +8,13 @@ import {
   type AgentSessionOperationDecision,
   type AgentSessionOperationRow
 } from '../../shared/agent-session-operation-ledger'
+import {
+  admitAgentSessionMutation,
+  type AgentSessionMutationAdmission
+} from '../../shared/agent-session-mutation-envelope'
+import type { AgentSessionMutationEnvelope } from '../../shared/agent-session-wire'
+import type { AgentSessionRecord } from '../../shared/agent-session-record'
+import type { AgentSessionStoreState } from './agent-session-record-store-file'
 
 export type AgentSessionOperationAdmission = {
   callerKey: string
@@ -17,6 +24,19 @@ export type AgentSessionOperationAdmission = {
 }
 
 type OperationRows = Map<string, AgentSessionOperationRow>
+
+export type AgentSessionMutationOperationAdmission = {
+  callerKey: string
+  envelope: AgentSessionMutationEnvelope
+  hostFingerprint: string
+  now: number
+  operationIdScope?: 'global'
+}
+
+export type AgentSessionMutationOperationDecision = {
+  admission: AgentSessionMutationAdmission
+  record: AgentSessionRecord
+} | null
 
 /** Prune, evaluate, and (on admit) place the row. The caller runs this inside one
  *  transaction, so two concurrent copies of an operation id cannot both admit. */
@@ -55,4 +75,35 @@ export function admitAgentSessionGlobalOperationRow(
     rows: pruned,
     decision: evaluateAgentSessionOperation({ rows: syntheticRows, ...args })
   }
+}
+
+/** Admit the ledger row and its lease/fence preconditions in one durable transaction. */
+export function admitAgentSessionMutationOperation(
+  state: AgentSessionStoreState,
+  args: AgentSessionMutationOperationAdmission
+): AgentSessionMutationOperationDecision {
+  const record = state.records.get(args.envelope.sessionId)
+  if (!record) {
+    return null
+  }
+  const operation = {
+    callerKey: args.callerKey,
+    operationId: args.envelope.clientOperationId,
+    fingerprint: args.hostFingerprint,
+    now: args.now
+  }
+  const ledger = args.operationIdScope
+    ? admitAgentSessionGlobalOperationRow(state.operations, operation)
+    : admitAgentSessionOperationRow(state.operations, operation)
+  const admission = admitAgentSessionMutation({
+    envelope: args.envelope,
+    hostFingerprint: args.hostFingerprint,
+    ledger: ledger.decision,
+    lease: record.lease
+  })
+  if (ledger.decision.decision === 'admit' && admission.decision === 'refused') {
+    ledger.rows.delete(agentSessionOperationKey(operation.callerKey, operation.operationId))
+  }
+  state.operations = ledger.rows
+  return { admission, record }
 }

--- a/src/main/runtime/agent-session-operation-admission.ts
+++ b/src/main/runtime/agent-session-operation-admission.ts
@@ -31,3 +31,28 @@ export function admitAgentSessionOperationRow(
   }
   return { rows: pruned, decision }
 }
+
+/** Send ids name one provider delivery even when the authenticated caller changes. */
+export function admitAgentSessionGlobalOperationRow(
+  rows: OperationRows,
+  args: AgentSessionOperationAdmission
+): { rows: OperationRows; decision: AgentSessionOperationDecision } {
+  let existing: AgentSessionOperationRow | undefined
+  for (const row of rows.values()) {
+    if (row.expiresAt > args.now && row.operationId === args.operationId) {
+      existing = row
+      break
+    }
+  }
+  if (!existing) {
+    return admitAgentSessionOperationRow(rows, args)
+  }
+  const pruned = pruneAgentSessionOperationRows(rows, args.now)
+  const syntheticRows = new Map([
+    [agentSessionOperationKey(args.callerKey, args.operationId), existing]
+  ])
+  return {
+    rows: pruned,
+    decision: evaluateAgentSessionOperation({ rows: syntheticRows, ...args })
+  }
+}

--- a/src/main/runtime/agent-session-record-store.ts
+++ b/src/main/runtime/agent-session-record-store.ts
@@ -10,6 +10,7 @@ import {
   type AgentSessionOperationRow
 } from '../../shared/agent-session-operation-ledger'
 import {
+  admitAgentSessionGlobalOperationRow,
   admitAgentSessionOperationRow,
   type AgentSessionOperationAdmission
 } from './agent-session-operation-admission'
@@ -275,6 +276,17 @@ export class AgentSessionRecordStore {
   ): Promise<AgentSessionOperationDecision> {
     return this.transact(() => {
       const admitted = admitAgentSessionOperationRow(this.state.operations, args)
+      this.state.operations = admitted.rows
+      return admitted.decision
+    })
+  }
+
+  /** Send ids stay global after a caller reconnects under a different identity. */
+  async admitGlobalOperation(
+    args: AgentSessionOperationAdmission
+  ): Promise<AgentSessionOperationDecision> {
+    return this.transact(() => {
+      const admitted = admitAgentSessionGlobalOperationRow(this.state.operations, args)
       this.state.operations = admitted.rows
       return admitted.decision
     })

--- a/src/main/runtime/agent-session-record-store.ts
+++ b/src/main/runtime/agent-session-record-store.ts
@@ -11,7 +11,9 @@ import {
 } from '../../shared/agent-session-operation-ledger'
 import {
   admitAgentSessionGlobalOperationRow,
+  admitAgentSessionMutationOperation,
   admitAgentSessionOperationRow,
+  type AgentSessionMutationOperationAdmission,
   type AgentSessionOperationAdmission
 } from './agent-session-operation-admission'
 import type { AgentSessionOwnerProbe } from '../../shared/agent-session-lease-adjudication'
@@ -291,6 +293,9 @@ export class AgentSessionRecordStore {
       return admitted.decision
     })
   }
+
+  admitMutationOperation = (args: AgentSessionMutationOperationAdmission) =>
+    this.transact(() => admitAgentSessionMutationOperation(this.state, args))
 
   async recordOperationOutcome(args: {
     callerKey?: string

--- a/src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts
+++ b/src/main/runtime/orchestration/structured-mailbox-pointer-delivery.test.ts
@@ -280,9 +280,11 @@ describe('structured mailbox pointer delivery', () => {
     await flush()
     expect(send).toHaveBeenCalledTimes(1)
     expect(markAsDelivered).not.toHaveBeenCalled()
+    const first = send.mock.calls[0]![0].operationId
     delivery.onJournalActivity('session-1')
     await flush()
     expect(send).toHaveBeenCalledTimes(2)
+    expect(send.mock.calls[1]![0].operationId).not.toBe(first)
   })
 
   it('reuses one operation id for the same batch and re-mints when it grows', async () => {

--- a/src/main/runtime/orchestration/structured-mailbox-pointer-delivery.ts
+++ b/src/main/runtime/orchestration/structured-mailbox-pointer-delivery.ts
@@ -238,6 +238,9 @@ export class OrchestrationStructuredMailboxPointerDelivery<
       return
     }
     if (!structuredDispatchDelivered(outcome.state)) {
+      if (outcome.state === 'rejected') {
+        db.deleteStructuredPointerOperation(mailboxHandle)
+      }
       this.retain(
         mailboxHandle,
         sessionId,

--- a/src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts
+++ b/src/main/runtime/orchestration/structured-mailbox-pointer-host.test.ts
@@ -104,7 +104,7 @@ describe('structured mailbox pointer host', () => {
     ).resolves.toEqual({ kind: 'sent', state: expected })
     // Per-dispatch, so one worker's nudges cannot exhaust the shared operation-ledger budget.
     expect(send.mock.calls[0]![0]).toEqual({ callerKey: structuredPointerCallerKey('d1') })
-    expect(send.mock.calls[0]![1]!.retryUnknown).toBe(true)
+    expect(send.mock.calls[0]![1]!.retryUnknown).toBeUndefined()
   })
 
   it('scopes direct peer mail to the session when there is no dispatch to scope to', async () => {

--- a/src/main/runtime/orchestration/structured-mailbox-pointer-host.ts
+++ b/src/main/runtime/orchestration/structured-mailbox-pointer-host.ts
@@ -86,9 +86,7 @@ export function createStructuredMailboxPointerHost(): StructuredMailboxPointerHo
             expectedRuntimeFence: input.expectedRuntimeFence,
             payloadFingerprint: input.payloadFingerprint
           },
-          body: input.body,
-          // The recorded unknown is the only thing that unlocks a redispatch of the same id.
-          retryUnknown: true
+          body: input.body
         }
       )
       if (!result.ok) {

--- a/src/main/runtime/orchestration/structured-pointer-operation-id.test.ts
+++ b/src/main/runtime/orchestration/structured-pointer-operation-id.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS } from '../../../shared/agent-session-host-authority'
+import { AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS } from '../../../shared/agent-session-host-authority'
 import type { AgentJournalMessageItem } from '../../../shared/agent-session-journal-types'
 import {
   mintAgentSessionOperationId,
@@ -71,7 +71,7 @@ describe('structured pointer operation id', () => {
     expect(grown.operationId).not.toBe(first.operationId)
   })
 
-  it('re-mints once the host would refuse the id as expired', () => {
+  it('never re-mints an ambiguous batch after the host replay window expires', () => {
     const db = fakeDb()
     const first = resolveStructuredPointerOperation({
       db,
@@ -87,9 +87,9 @@ describe('structured pointer operation id', () => {
       sessionId: 's1',
       body: body('2 messages'),
       messageIds: ['m1', 'm2'],
-      now: 1_000 + AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS
+      now: 1_000 + AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS + 1
     })
-    expect(aged.operationId).not.toBe(first.operationId)
+    expect(aged.operationId).toBe(first.operationId)
   })
 
   it('re-mints for a different batch of the same size', () => {

--- a/src/main/runtime/orchestration/structured-pointer-operation-id.ts
+++ b/src/main/runtime/orchestration/structured-pointer-operation-id.ts
@@ -5,7 +5,7 @@
  * refused before the first send, so the id is minted here instead. It is durable and reused across
  * retries, because the id IS the send's idempotency key: a fresh id for the same nudge would land
  * as a second turn. It is re-minted only when the send is genuinely a different call — a different
- * batch of mail, or a different session — or when the host would reject it as too old to admit.
+ * batch of mail, or a different session. Age cannot resolve delivery ambiguity.
  *
  * Reuse is keyed on the MESSAGE IDS in the batch, never on the pointer body: the body names only
  * how many messages are waiting, so two unrelated same-size batches share a fingerprint. Reusing a
@@ -16,7 +16,6 @@
 import { createHash, randomBytes } from 'node:crypto'
 import type { AgentJournalMessageItem } from '../../../shared/agent-session-journal-types'
 import { computeAgentSessionPayloadFingerprint } from '../../../shared/agent-session-mutation-envelope'
-import { AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS } from '../../../shared/agent-session-host-authority'
 import type { OrchestrationDb } from './db'
 
 export function mintAgentSessionOperationId(now: number): string {
@@ -60,8 +59,7 @@ export function resolveStructuredPointerOperation(args: {
   if (
     stored &&
     stored.session_id === args.sessionId &&
-    stored.batch_fingerprint === batchFingerprint &&
-    now - stored.minted_at_ms < AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS
+    stored.batch_fingerprint === batchFingerprint
   ) {
     return { operationId: stored.operation_id, payloadFingerprint }
   }

--- a/src/main/runtime/rpc/errors.test.ts
+++ b/src/main/runtime/rpc/errors.test.ts
@@ -276,3 +276,24 @@ describe('nested worker depth cap', () => {
     })
   })
 })
+
+describe('structured worker dispatch preamble errors', () => {
+  it('preserves the undelivered verdict across runtime RPC', () => {
+    const failure = mapRuntimeError(
+      'rpc_dispatch_preamble',
+      { runtimeId: 'runtime-1' },
+      new OrchestrationError(
+        'dispatch_preamble_undelivered',
+        'The dispatch preamble was not delivered: provider_write_failed: broken pipe.'
+      )
+    )
+
+    expect(failure).toMatchObject({
+      ok: false,
+      error: {
+        code: 'dispatch_preamble_undelivered',
+        message: 'The dispatch preamble was not delivered: provider_write_failed: broken pipe.'
+      }
+    })
+  })
+})

--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -120,6 +120,7 @@ const STRUCTURED_RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
   'legacy_read_only',
   'orchestration_migration_required',
   'operation_unknown',
+  'dispatch_preamble_undelivered',
   'question_not_found',
   'answer_conflict',
   'stale_delivery',

--- a/src/main/runtime/rpc/methods/orchestration-structured-worker-session.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-structured-worker-session.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { dispatchWriteFailureReason } from '../../../../shared/structured-agent-session-dispatch-rejection'
 
 const hostRef: { current: unknown } = { current: null }
 const createSpy = vi.fn()
@@ -255,11 +256,28 @@ describe('structured worker dispatch preamble', () => {
     }
   })
 
-  it('keeps a rejected preamble a proven failure rather than an unknown one', async () => {
+  it('keeps a rejected preamble a proven failure under a code of its own', async () => {
     const error = await send(
       hostWithSubmission({ dispatchState: 'rejected', reason: 'fence moved' })
     ).catch((thrown: unknown) => thrown)
-    expect((error as Error).message).toMatch(/rejected: fence moved/)
+    // A verdict, not prose. A coordinator must be able to tell "we could not send it"
+    // from `operation_unknown`'s "it may be running, go look" without parsing a message,
+    // which a bare `Error` forced it to do.
+    expect((error as { code?: string }).code).toBe('dispatch_preamble_undelivered')
+    expect((error as Error).message).toMatch(/not delivered: fence moved/)
+    expect(isUnknownWorkerStartOutcome(error, 'dispatch_input')).toBe(false)
+  })
+
+  it('reports a refused transport write as undelivered, never as unknown', async () => {
+    // The state a provably-unwritten frame now settles. Nothing reached the provider,
+    // so there is no running turn for a coordinator to go and look at.
+    const error = await send(
+      hostWithSubmission({
+        dispatchState: 'rejected',
+        reason: dispatchWriteFailureReason(new Error('broken pipe'))
+      })
+    ).catch((thrown: unknown) => thrown)
+    expect((error as { code?: string }).code).toBe('dispatch_preamble_undelivered')
     expect(isUnknownWorkerStartOutcome(error, 'dispatch_input')).toBe(false)
   })
 })

--- a/src/main/runtime/rpc/methods/orchestration-structured-worker-session.ts
+++ b/src/main/runtime/rpc/methods/orchestration-structured-worker-session.ts
@@ -238,8 +238,7 @@ export async function sendStructuredWorkerPreamble(args: {
         expectedRuntimeFence: fence,
         payloadFingerprint: structuredPointerPayloadFingerprint(args.sessionId, body)
       },
-      body,
-      retryUnknown: true
+      body
     }
   )
   if (!result.ok) {

--- a/src/main/runtime/rpc/methods/orchestration-structured-worker-session.ts
+++ b/src/main/runtime/rpc/methods/orchestration-structured-worker-session.ts
@@ -250,7 +250,15 @@ export async function sendStructuredWorkerPreamble(args: {
     return
   }
   if (submission.dispatchState === 'rejected') {
-    throw new Error(`The dispatch preamble was rejected: ${submission.reason ?? 'no reason given'}`)
+    // A rejection is a verdict, not a mystery: the preamble provably did not happen.
+    // `dispatch_preamble_undelivered` says exactly that, and says it as a code rather
+    // than as prose, so a coordinator can tell "we could not send it" apart from
+    // `operation_unknown`'s "it may be running and you must go look". Both discard the
+    // pending receipt; only this one lets the caller retry knowing nothing landed.
+    throw new OrchestrationError(
+      'dispatch_preamble_undelivered',
+      `The dispatch preamble was not delivered: ${submission.reason ?? 'no reason given'}.`
+    )
   }
   // Only `accepted` is an acknowledgement — the same rule the mail lane already applies. A thrown
   // adapter call settles as `unknown`, which is indistinguishable from a lost reply, so the start

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.transport-probe.test.tsx
@@ -97,7 +97,7 @@ describe('NativeChatStructuredSession transport-unconfirmed sends', () => {
     await waitFor(() => expect(screen.queryByText('Message delivery is unconfirmed.')).toBeNull())
   }, 20000)
 
-  it('probes without retryUnknown so the host cannot redispatch', async () => {
+  it('probes the same operation without marking an explicit user retry', async () => {
     mocks.mode = 'outbox'
     mocks.submissions = []
     mocks.call.mockRejectedValueOnce(new Error('socket closed')).mockResolvedValue({
@@ -156,7 +156,7 @@ describe('NativeChatStructuredSession transport-unconfirmed sends', () => {
     await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
 
     const sent = mocks.call.mock.calls[0]?.[2] as { envelope: { clientOperationId: string } }
-    // The host now reports it as an unresolved unknown: redispatch is the user's call.
+    // The host now reports an unresolved unknown: another replay is the user's call.
     mocks.submissions = [
       {
         clientMessageId: sent.envelope.clientOperationId,
@@ -295,14 +295,14 @@ describe('NativeChatStructuredSession transport-unconfirmed sends', () => {
     await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
     await waitFor(() => expect(screen.getByText('Message delivery is unconfirmed.')).toBeTruthy())
 
-    // User force-retries: this request legitimately carries retryUnknown.
+    // User retries with the same envelope and no legacy redelivery signal.
     fireEvent.click(screen.getByRole('button', { name: /Retry/ }))
     await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2))
     const forcedRequest = mocks.call.mock.calls[1]?.[2] as Record<string, unknown> | undefined
-    expect(forcedRequest?.retryUnknown).toBe(true)
+    expect(forcedRequest?.retryUnknown).toBeUndefined()
 
-    // That retry also failed at the transport. The probe must NOT pick it up, or it
-    // would re-send retryUnknown automatically and redispatch to the agent.
+    // That retry also failed at the transport. The probe must not repeat an
+    // explicit retry automatically.
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 3000))
     })

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSessionDelivery.test.tsx
@@ -339,7 +339,7 @@ describe('NativeChatStructuredSession delivery', () => {
     await waitFor(() => expect(screen.queryByText('Message delivery is unconfirmed.')).toBeNull())
   }, 20000)
 
-  it('probes without retryUnknown so the host cannot redispatch', async () => {
+  it('probes the same operation without marking an explicit user retry', async () => {
     mocks.mode = 'outbox'
     mocks.submissions = []
     mocks.call.mockRejectedValueOnce(new Error('socket closed')).mockResolvedValue({
@@ -398,7 +398,7 @@ describe('NativeChatStructuredSession delivery', () => {
     await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
 
     const sent = mocks.call.mock.calls[0]?.[2] as { envelope: { clientOperationId: string } }
-    // The host now reports it as an unresolved unknown: redispatch is the user's call.
+    // The host now reports an unresolved unknown: another replay is the user's call.
     mocks.submissions = [
       {
         clientMessageId: sent.envelope.clientOperationId,
@@ -537,14 +537,14 @@ describe('NativeChatStructuredSession delivery', () => {
     await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
     await waitFor(() => expect(screen.getByText('Message delivery is unconfirmed.')).toBeTruthy())
 
-    // User force-retries: this request legitimately carries retryUnknown.
+    // User retries with the same envelope and no legacy redelivery signal.
     fireEvent.click(screen.getByRole('button', { name: /Retry/ }))
     await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2))
     const forcedRequest = mocks.call.mock.calls[1]?.[2] as Record<string, unknown> | undefined
-    expect(forcedRequest?.retryUnknown).toBe(true)
+    expect(forcedRequest?.retryUnknown).toBeUndefined()
 
-    // That retry also failed at the transport. The probe must NOT pick it up, or it
-    // would re-send retryUnknown automatically and redispatch to the agent.
+    // That retry also failed at the transport. The probe must not repeat an
+    // explicit retry automatically.
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 3000))
     })

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
@@ -437,9 +437,8 @@ describe('useStructuredAgentSessionOutbox', () => {
     )
   })
 
-  it('rotates a send operation after a settled stale-fence rejection', async () => {
+  it('retains a send operation after a pending-admission refusal', async () => {
     mocks.call
-      .mockResolvedValueOnce(refusedResult('agent_session_checkpoint_stale'))
       .mockResolvedValueOnce(refusedResult('agent_session_checkpoint_stale'))
       .mockResolvedValueOnce(acceptedResult(1))
     const { result } = renderHook(() =>
@@ -455,25 +454,14 @@ describe('useStructuredAgentSessionOutbox', () => {
     await waitFor(() => expect(result.current.outbox[0]?.state).toBe('queued'))
     const firstId = (mocks.call.mock.calls[0]![2] as { envelope: { clientOperationId: string } })
       .envelope.clientOperationId
-    const retryId = result.current.outbox[0]!.clientMessageId
-    expect(retryId).not.toBe(firstId)
+    expect(result.current.outbox[0]?.clientMessageId).toBe(firstId)
 
-    act(() => result.current.retry(retryId))
+    act(() => result.current.retry(firstId))
     await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2))
-    await waitFor(() => expect(result.current.outbox[0]?.state).toBe('queued'))
-    const secondRetryId = result.current.outbox[0]!.clientMessageId
-    expect(secondRetryId).not.toBe(retryId)
     expect(
       (mocks.call.mock.calls[1]![2] as { envelope: { clientOperationId: string } }).envelope
         .clientOperationId
-    ).toBe(retryId)
-
-    act(() => result.current.retry(secondRetryId))
-    await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(3))
-    expect(
-      (mocks.call.mock.calls[2]![2] as { envelope: { clientOperationId: string } }).envelope
-        .clientOperationId
-    ).toBe(secondRetryId)
+    ).toBe(firstId)
   })
 
   it('persists and dispatches an attachment-only structured send', async () => {

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
@@ -122,12 +122,16 @@ function refusedResult(code: AgentSessionWireRefusalCode) {
 }
 
 describe('useStructuredAgentSessionOutbox', () => {
+  let randomUuidSequence = 0
+
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
-    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(
-      '11111111-1111-4111-8111-111111111111'
-    )
+    randomUuidSequence = 0
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(() => {
+      randomUuidSequence += 1
+      return `11111111-1111-4111-8111-${randomUuidSequence.toString(16).padStart(12, '0')}`
+    })
   })
 
   it('requeues across a fence change and ignores the stale settlement', async () => {
@@ -433,7 +437,7 @@ describe('useStructuredAgentSessionOutbox', () => {
     )
   })
 
-  it('rotates a send operation after a pending-admission refusal', async () => {
+  it('rotates a send operation after a settled stale-fence rejection', async () => {
     mocks.call
       .mockResolvedValueOnce(refusedResult('agent_session_checkpoint_stale'))
       .mockResolvedValueOnce(refusedResult('agent_session_checkpoint_stale'))

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
@@ -433,8 +433,9 @@ describe('useStructuredAgentSessionOutbox', () => {
     )
   })
 
-  it('retains a send operation after a pending-admission refusal', async () => {
+  it('rotates a send operation after a pending-admission refusal', async () => {
     mocks.call
+      .mockResolvedValueOnce(refusedResult('agent_session_checkpoint_stale'))
       .mockResolvedValueOnce(refusedResult('agent_session_checkpoint_stale'))
       .mockResolvedValueOnce(acceptedResult(1))
     const { result } = renderHook(() =>
@@ -450,14 +451,25 @@ describe('useStructuredAgentSessionOutbox', () => {
     await waitFor(() => expect(result.current.outbox[0]?.state).toBe('queued'))
     const firstId = (mocks.call.mock.calls[0]![2] as { envelope: { clientOperationId: string } })
       .envelope.clientOperationId
-    expect(result.current.outbox[0]?.clientMessageId).toBe(firstId)
+    const retryId = result.current.outbox[0]!.clientMessageId
+    expect(retryId).not.toBe(firstId)
 
-    act(() => result.current.retry(firstId))
+    act(() => result.current.retry(retryId))
     await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.outbox[0]?.state).toBe('queued'))
+    const secondRetryId = result.current.outbox[0]!.clientMessageId
+    expect(secondRetryId).not.toBe(retryId)
     expect(
       (mocks.call.mock.calls[1]![2] as { envelope: { clientOperationId: string } }).envelope
         .clientOperationId
-    ).toBe(firstId)
+    ).toBe(retryId)
+
+    act(() => result.current.retry(secondRetryId))
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(3))
+    expect(
+      (mocks.call.mock.calls[2]![2] as { envelope: { clientOperationId: string } }).envelope
+        .clientOperationId
+    ).toBe(secondRetryId)
   })
 
   it('persists and dispatches an attachment-only structured send', async () => {
@@ -546,7 +558,7 @@ describe('useStructuredAgentSessionOutbox', () => {
     await waitFor(() => expect(mocks.call).toHaveBeenCalledTimes(3))
     await waitFor(() => expect(result.current.outbox).toHaveLength(0))
     const retryParams = mocks.call.mock.calls[1]?.[2] as { retryUnknown?: true } | undefined
-    expect(retryParams?.retryUnknown).toBe(true)
+    expect(retryParams?.retryUnknown).toBeUndefined()
   })
 
   it('rotates a history-rejected unknown head so the queued tail can advance', async () => {

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
@@ -609,6 +609,81 @@ describe('useStructuredAgentSessionOutbox', () => {
     expect(retryParams?.envelope.clientOperationId).not.toBe(firstId)
   })
 
+  it('rotates the id after a refused write and delivers the message exactly once', async () => {
+    vi.mocked(globalThis.crypto.randomUUID)
+      .mockReturnValueOnce('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')
+      .mockReturnValueOnce('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb')
+    const writeFailed = (clientMessageId: string) => ({
+      clientMessageId,
+      fence: 1,
+      payloadFingerprint: 'fingerprint',
+      dispatchState: 'rejected' as const,
+      providerItemId: null,
+      reason: 'provider_write_failed: broken pipe',
+      submittedAt: 10,
+      resolvedAt: 10
+    })
+    mocks.call
+      .mockImplementationOnce(async (_target, _method, params) => ({
+        ok: true,
+        replayed: false,
+        fence: 1,
+        cursor: { epoch: 'epoch-1', sequence: 10 },
+        value: {
+          clientMessageId: (params as { envelope: { clientOperationId: string } }).envelope
+            .clientOperationId,
+          submission: writeFailed(
+            (params as { envelope: { clientOperationId: string } }).envelope.clientOperationId
+          )
+        }
+      }))
+      .mockImplementationOnce(async (_target, _method, params) =>
+        acceptedResultFor(
+          (params as { envelope: { clientOperationId: string } }).envelope.clientOperationId,
+          11
+        )
+      )
+    const { result, rerender } = renderHook(
+      ({ submissions }: { submissions: readonly AgentJournalSubmission[] }) =>
+        useStructuredAgentSessionOutbox({
+          sessionId: 'session-1',
+          target: LOCAL_TARGET,
+          fence: 1,
+          submissions
+        }),
+      { initialProps: { submissions: [] as readonly AgentJournalSubmission[] } }
+    )
+
+    act(() => expect(result.current.send('first')).toBe(true))
+    await waitFor(() => expect(mocks.call).toHaveBeenCalledOnce())
+    const firstId = mocks.call.mock.calls[0]![2].envelope.clientOperationId as string
+
+    // A refused write is answered, not doubted: the entry parks with human copy
+    // rather than under the "delivery is unconfirmed" banner. The durable reason
+    // stays `provider_write_failed: …`; it must not reach the screen.
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        "Couldn't reach the agent. Your message was not sent — Retry to send it again."
+      )
+    )
+    expect(result.current.outbox[0]?.state).toBe('queued')
+    expect(result.current.blockedClientMessageId).toBe(firstId)
+
+    rerender({ submissions: [writeFailed(firstId)] })
+    act(() => result.current.retry(firstId))
+    await waitFor(() => expect(result.current.outbox).toHaveLength(0))
+
+    // Exactly one further delivery, under a new id, and with no `retryUnknown`:
+    // this is a first delivery of a new message, so it cannot duplicate.
+    expect(mocks.call).toHaveBeenCalledTimes(2)
+    const retryParams = mocks.call.mock.calls[1]?.[2] as {
+      envelope: { clientOperationId: string }
+      retryUnknown?: true
+    }
+    expect(retryParams.envelope.clientOperationId).not.toBe(firstId)
+    expect(retryParams.retryUnknown).toBeUndefined()
+  })
+
   it('loads the new session outbox when a pane switches sessions', async () => {
     mocks.call.mockImplementationOnce(async (_target, _method, params) => {
       const clientMessageId = (params as { envelope: { clientOperationId: string } }).envelope

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.test.tsx
@@ -643,7 +643,7 @@ describe('useStructuredAgentSessionOutbox', () => {
           11
         )
       )
-    const { result, rerender } = renderHook(
+    const { result } = renderHook(
       ({ submissions }: { submissions: readonly AgentJournalSubmission[] }) =>
         useStructuredAgentSessionOutbox({
           sessionId: 'session-1',
@@ -669,7 +669,7 @@ describe('useStructuredAgentSessionOutbox', () => {
     expect(result.current.outbox[0]?.state).toBe('queued')
     expect(result.current.blockedClientMessageId).toBe(firstId)
 
-    rerender({ submissions: [writeFailed(firstId)] })
+    // Retry immediately, before the journal subscription can publish the rejected row.
     act(() => result.current.retry(firstId))
     await waitFor(() => expect(result.current.outbox).toHaveLength(0))
 

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
@@ -52,6 +52,7 @@ export function useStructuredAgentSessionOutbox(args: {
   const dispatchingRef = useRef(false)
   const dispatchGenerationRef = useRef(0)
   const blockedIdRef = useRef<string | null>(null)
+  const retryWithFreshClientMessageIdRef = useRef<string | null>(null)
   const probeAttemptsRef = useRef({ id: null as string | null, attempts: 0 })
   const [error, setError] = useState<string | null>(null)
   const [errorSession, setErrorSession] = useState(sessionId)
@@ -70,6 +71,7 @@ export function useStructuredAgentSessionOutbox(args: {
     dispatchGenerationRef.current += 1
     dispatchingRef.current = false
     blockedIdRef.current = null
+    retryWithFreshClientMessageIdRef.current = null
     probeAttemptsRef.current = { id: null, attempts: 0 }
   }, [fence, sessionId, targetKey])
 
@@ -125,6 +127,7 @@ export function useStructuredAgentSessionOutbox(args: {
   const applyDisposition = useCallback(
     (disposition: StructuredAgentSessionSendDisposition): void => {
       blockedIdRef.current = disposition.blockedClientMessageId
+      retryWithFreshClientMessageIdRef.current = disposition.retryWithFreshClientMessageId
       setError(disposition.error)
       outboxRef.current = disposition.entries
       setOutbox(disposition.entries)
@@ -275,7 +278,12 @@ export function useStructuredAgentSessionOutbox(args: {
     // A provider-history reconciliation can settle an earlier unknown as
     // rejected before the user presses Retry. Reusing that operation id only
     // replays the settled rejection forever, so rotate the id for a safe resend.
-    if (current && submission?.dispatchState === 'rejected') {
+    if (
+      current &&
+      (submission?.dispatchState === 'rejected' ||
+        retryWithFreshClientMessageIdRef.current === clientMessageId)
+    ) {
+      retryWithFreshClientMessageIdRef.current = null
       const rotated = outboxRef.current.map((entry) =>
         entry.clientMessageId === clientMessageId
           ? {

--- a/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session-outbox.ts
@@ -206,14 +206,14 @@ export function useStructuredAgentSessionOutbox(args: {
   // moves it out of `unconfirmed`, so one wedges the whole FIFO queue. Re-issuing
   // the same envelope without `retryUnknown` is idempotent: the operation ledger
   // replays a recorded outcome, or the host performs a genuine first delivery.
-  // A host-confirmed unknown stays parked — forcing past that redispatches, which
-  // is the user's call via Retry.
+  // A host-confirmed unknown stays parked until the user explicitly asks Retry
+  // to replay the same operation.
   const head = outbox[0]
   // Depend on primitives: `submissions` is rebuilt on every streaming batch, so an
   // array-identity dep would reset the backoff forever while the agent is working.
-  // A non-null `retryAfterUnknownSubmittedAt` means the user already force-retried,
-  // so the request would carry `retryUnknown` and redispatch host-side. Only entries
-  // that have never been force-retried are safe to re-issue automatically.
+  // A non-null `retryAfterUnknownSubmittedAt` means the user already retried, so
+  // another request would repeat that explicit action. Only entries that have
+  // never been retried are safe to probe automatically.
   const probeId =
     head &&
     head.sessionId === sessionId &&
@@ -290,6 +290,7 @@ export function useStructuredAgentSessionOutbox(args: {
               ...entry,
               clientMessageId: structuredSessionOperationId(),
               state: 'queued' as const,
+              lastAttemptAt: null,
               retryAfterUnknownSubmittedAt: null
             }
           : entry

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
@@ -294,7 +294,7 @@ describe('useStructuredAgentSession options', () => {
     ).toEqual(['operation-1', 'operation-2'])
   })
 
-  it('rotates an option operation after a settled stale-fence rejection', async () => {
+  it('reuses an option operation after a pending admission refusal', async () => {
     let attempts = 0
     mocks.call.mockImplementation((_target, method) => {
       if (method !== 'agentSession.setOption') {
@@ -351,15 +351,14 @@ describe('useStructuredAgentSession options', () => {
         ([, , params]) =>
           (params as { envelope: { clientOperationId: string } }).envelope.clientOperationId
       )
-    ).toEqual(['operation-1', 'operation-2'])
+    ).toEqual(['operation-1', 'operation-1'])
     expect(
       mutations.map(
         ([, , params]) =>
           (params as { envelope: { expectedRuntimeFence: number } }).envelope.expectedRuntimeFence
       )
     ).toEqual([3, 4])
-    // The host settled the first id before returning, so reusing it can only replay rejection.
-    expect(mocks.operationId).toHaveBeenCalledTimes(2)
+    expect(mocks.operationId).toHaveBeenCalledTimes(1)
   })
 
   it('ignores an option failure from a superseded fence', async () => {

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
@@ -294,7 +294,7 @@ describe('useStructuredAgentSession options', () => {
     ).toEqual(['operation-1', 'operation-2'])
   })
 
-  it('reuses an option operation after a pending admission refusal', async () => {
+  it('rotates an option operation after a settled stale-fence rejection', async () => {
     let attempts = 0
     mocks.call.mockImplementation((_target, method) => {
       if (method !== 'agentSession.setOption') {
@@ -351,14 +351,15 @@ describe('useStructuredAgentSession options', () => {
         ([, , params]) =>
           (params as { envelope: { clientOperationId: string } }).envelope.clientOperationId
       )
-    ).toEqual(['operation-1', 'operation-1'])
+    ).toEqual(['operation-1', 'operation-2'])
     expect(
       mutations.map(
         ([, , params]) =>
           (params as { envelope: { expectedRuntimeFence: number } }).envelope.expectedRuntimeFence
       )
     ).toEqual([3, 4])
-    expect(mocks.operationId).toHaveBeenCalledTimes(1)
+    // The host settled the first id before returning, so reusing it can only replay rejection.
+    expect(mocks.operationId).toHaveBeenCalledTimes(2)
   })
 
   it('ignores an option failure from a superseded fence', async () => {

--- a/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBar.context-menu.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { expandNode } from './tab-bar-dropdown-menu-item-probe'
 import { stubHeadlessReact, stubShallowSelector } from './tab-bar-windows-shell-launch-render-stubs'
 
 const appStoreSnapshot: {
@@ -175,6 +176,12 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   }
 }))
 
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: 'Tooltip',
+  TooltipContent: 'TooltipContent',
+  TooltipTrigger: 'TooltipTrigger'
+}))
+
 type ReactElementLike = {
   type: unknown
   props: Record<string, unknown>
@@ -230,22 +237,24 @@ async function renderTabBar(props: Record<string, unknown>): Promise<unknown> {
     | ((props: Record<string, unknown>) => unknown)
     | { type: (props: Record<string, unknown>) => unknown }
   const TabBar = typeof candidate === 'function' ? candidate : candidate.type
-  return TabBar({
-    activeTabId: null,
-    worktreeId: 'wt-1',
-    expandedPaneByTabId: {},
-    onActivate: () => {},
-    onClose: () => {},
-    onCloseOthers: () => {},
-    onCloseToRight: () => {},
-    onCloseToLeft: () => {},
-    onNewTerminalTab: () => {},
-    onNewBrowserTab: () => {},
-    onSetCustomTitle: () => {},
-    onSetTabColor: () => {},
-    onTogglePaneExpand: () => {},
-    ...props
-  })
+  return expandNode(
+    TabBar({
+      activeTabId: null,
+      worktreeId: 'wt-1',
+      expandedPaneByTabId: {},
+      onActivate: () => {},
+      onClose: () => {},
+      onCloseOthers: () => {},
+      onCloseToRight: () => {},
+      onCloseToLeft: () => {},
+      onNewTerminalTab: () => {},
+      onNewBrowserTab: () => {},
+      onSetCustomTitle: () => {},
+      onSetTabColor: () => {},
+      onTogglePaneExpand: () => {},
+      ...props
+    })
+  )
 }
 
 const TERMINAL_TAB = {

--- a/src/renderer/src/lib/structured-agent-session-launch-prompt.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch-prompt.ts
@@ -57,8 +57,11 @@ async function dispatchStructuredLaunchPrompt(
     )
     if (!result.ok) {
       mutateEntry(entry, (current) =>
-        requeueStructuredAgentSessionSendRefusal(current, result.refusal.code, () =>
-          createStructuredAgentSessionOperationId(() => crypto.randomUUID())
+        requeueStructuredAgentSessionSendRefusal(
+          current,
+          result.refusal.code,
+          () => createStructuredAgentSessionOperationId(() => crypto.randomUUID()),
+          entry.lastAttemptAt !== null
         )
       )
       return false

--- a/src/shared/agent-session-host-authority.ts
+++ b/src/shared/agent-session-host-authority.ts
@@ -35,6 +35,9 @@ export const AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION = 1 as const
 
 export const AGENT_SESSION_OPERATION_FUTURE_SKEW_MS = 5 * 60 * 1000
 export const AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS = 24 * 60 * 60 * 1000
+/** Oldest an operation can be when admitted, plus the host tombstone lifetime after admission. */
+export const AGENT_SESSION_MAX_OPERATION_REPLAY_AGE_MS =
+  AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS * 2 + AGENT_SESSION_OPERATION_FUTURE_SKEW_MS
 
 const AGENT_SESSION_OPERATION_ID_PATTERN = /^(\d{13})-[0-9a-f]{32}$/
 

--- a/src/shared/agent-session-refusal-retry.ts
+++ b/src/shared/agent-session-refusal-retry.ts
@@ -17,8 +17,6 @@ export function agentSessionRefusalOperationState(
     return 'settled-rejected'
   }
   switch (code) {
-    case 'agent_session_checkpoint_stale':
-    case 'agent_session_conflict':
     case 'agent_session_operation_conflict':
     case 'agent_session_operation_expired':
     case 'agent_session_operation_invalid':
@@ -28,12 +26,14 @@ export function agentSessionRefusalOperationState(
     case 'agent_session_operation_unknown':
       return 'unknown'
     case 'structured_agent_session_unsupported':
+    case 'agent_session_checkpoint_stale':
+    case 'agent_session_conflict':
     case 'agent_session_ownership_unknown':
     case 'agent_session_operation_capacity':
     case 'agent_session_identity_required':
     case 'agent_session_journal_unreadable':
-      return 'pending-admission'
     case 'execution_owner_reconciling':
-      return 'settled-rejected'
+      // These refusals do not prove the operation reached durable settlement.
+      return 'pending-admission'
   }
 }

--- a/src/shared/agent-session-refusal-retry.ts
+++ b/src/shared/agent-session-refusal-retry.ts
@@ -17,6 +17,8 @@ export function agentSessionRefusalOperationState(
     return 'settled-rejected'
   }
   switch (code) {
+    case 'agent_session_checkpoint_stale':
+    case 'agent_session_conflict':
     case 'agent_session_operation_conflict':
     case 'agent_session_operation_expired':
     case 'agent_session_operation_invalid':
@@ -26,14 +28,12 @@ export function agentSessionRefusalOperationState(
     case 'agent_session_operation_unknown':
       return 'unknown'
     case 'structured_agent_session_unsupported':
-    case 'agent_session_checkpoint_stale':
-    case 'agent_session_conflict':
     case 'agent_session_ownership_unknown':
     case 'agent_session_operation_capacity':
     case 'agent_session_identity_required':
     case 'agent_session_journal_unreadable':
-    case 'execution_owner_reconciling':
-      // These refusals do not prove the operation reached durable settlement.
       return 'pending-admission'
+    case 'execution_owner_reconciling':
+      return 'settled-rejected'
   }
 }

--- a/src/shared/structured-agent-session-dispatch-rejection.ts
+++ b/src/shared/structured-agent-session-dispatch-rejection.ts
@@ -1,0 +1,36 @@
+// Why a submission is `rejected`: the message provably did not happen.
+//
+// Two different facts reach this state, and the reason string is what tells them
+// apart. A CONTENT rejection is permanent — the provider looked at this payload
+// and refused it, and it would refuse the same payload again; its reason is the
+// provider's own explanation ("Claude messages support at most 20 images") and is
+// meant to be read. A TRANSPORT rejection is transient — the frame was never
+// handed to the provider at all, so the same text under a fresh id is a first
+// delivery and the next attempt may well succeed; its reason names an internal
+// cause and must NOT be put in front of a person.
+//
+// Both are `rejected` because both make the single claim that state exists to
+// make: this message did not reach the provider. Neither is ever re-delivered
+// under its own id — `rejected` is terminal in the reducer — so a retry rotates
+// the client message id, which is a new message and cannot duplicate.
+//
+// Shared rather than main-only because both sides need it: the host writes the
+// reason, and a client has to know which kind it is holding before it can decide
+// whether the string is showable.
+
+export const DISPATCH_REJECTED_WRITE_FAILED = 'provider_write_failed'
+
+export function dispatchWriteFailureReason(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error)
+  return `${DISPATCH_REJECTED_WRITE_FAILED}: ${detail}`
+}
+
+/** True for the internal transport marker, false for a provider's own words. */
+export function dispatchRejectionWasTransportWriteFailure(
+  reason: string | null | undefined
+): boolean {
+  return (
+    reason === DISPATCH_REJECTED_WRITE_FAILED ||
+    reason?.startsWith(`${DISPATCH_REJECTED_WRITE_FAILED}: `) === true
+  )
+}

--- a/src/shared/structured-agent-session-dispatch-rejection.ts
+++ b/src/shared/structured-agent-session-dispatch-rejection.ts
@@ -20,6 +20,9 @@
 
 export const DISPATCH_REJECTED_WRITE_FAILED = 'provider_write_failed'
 
+/** Local admission refused the frame before any transport was involved. */
+export const DISPATCH_REJECTED_QUEUE_FULL = 'claude structured dispatch queue is full'
+
 export function dispatchWriteFailureReason(error: unknown): string {
   const detail = error instanceof Error ? error.message : String(error)
   return `${DISPATCH_REJECTED_WRITE_FAILED}: ${detail}`
@@ -32,5 +35,16 @@ export function dispatchRejectionWasTransportWriteFailure(
   return (
     reason === DISPATCH_REJECTED_WRITE_FAILED ||
     reason?.startsWith(`${DISPATCH_REJECTED_WRITE_FAILED}: `) === true
+  )
+}
+
+/**
+ * True when the reason is ours rather than the provider's, so it must not be
+ * shown verbatim. A content rejection carries the provider's own explanation and
+ * is the only kind a person should read.
+ */
+export function dispatchRejectionReasonIsInternal(reason: string | null | undefined): boolean {
+  return (
+    dispatchRejectionWasTransportWriteFailure(reason) || reason === DISPATCH_REJECTED_QUEUE_FULL
   )
 }

--- a/src/shared/structured-agent-session-mutation.test.ts
+++ b/src/shared/structured-agent-session-mutation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { structuredAgentSessionPayloadFingerprint } from './structured-agent-session-mutation'
+import {
+  structuredAgentSessionDomainFingerprint,
+  structuredAgentSessionPayloadFingerprint
+} from './structured-agent-session-mutation'
 import { computeAgentSessionPayloadFingerprint } from './agent-session-mutation-envelope'
 
 describe('structured agent session client mutations', () => {
@@ -28,6 +31,24 @@ describe('structured agent session client mutations', () => {
 
     expect(structuredAgentSessionPayloadFingerprint(input)).toBe(
       computeAgentSessionPayloadFingerprint(input)
+    )
+  })
+
+  it('preserves the digest when a local fingerprint domain is not an RPC method', () => {
+    const fields = { text: 'hello' }
+
+    expect(
+      structuredAgentSessionDomainFingerprint({
+        domain: 'mobile.agentSession.send.intent',
+        sessionId: 'session-1',
+        fields
+      })
+    ).toBe(
+      structuredAgentSessionPayloadFingerprint({
+        method: 'mobile.agentSession.send.intent',
+        sessionId: 'session-1',
+        fields
+      })
     )
   })
 })

--- a/src/shared/structured-agent-session-mutation.ts
+++ b/src/shared/structured-agent-session-mutation.ts
@@ -26,6 +26,18 @@ export function structuredAgentSessionPayloadFingerprint(input: {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
 }
 
+export function structuredAgentSessionDomainFingerprint(input: {
+  domain: string
+  sessionId: string
+  fields: Record<string, unknown>
+}): string {
+  return structuredAgentSessionPayloadFingerprint({
+    method: input.domain,
+    sessionId: input.sessionId,
+    fields: input.fields
+  })
+}
+
 export function structuredAgentSessionCreateFingerprint(input: {
   sessionId: string
   worktree: string

--- a/src/shared/structured-agent-session-outbox.ts
+++ b/src/shared/structured-agent-session-outbox.ts
@@ -76,7 +76,7 @@ export function requeueStructuredAgentSessionSendRefusal(
 ): StructuredAgentSessionOutboxEntry {
   const refusalState = agentSessionRefusalOperationState('agentSession.send', code)
   if (
-    refusalState === 'unknown' ||
+    refusalState !== 'settled-rejected' ||
     retainOperationId ||
     entry.state === 'unconfirmed' ||
     entry.retryAfterUnknownSubmittedAt !== null

--- a/src/shared/structured-agent-session-outbox.ts
+++ b/src/shared/structured-agent-session-outbox.ts
@@ -71,15 +71,23 @@ export function updateStructuredAgentSessionOutboxEntry(
 export function requeueStructuredAgentSessionSendRefusal(
   entry: StructuredAgentSessionOutboxEntry,
   code: AgentSessionWireRefusalCode,
-  createOperationId: () => string
+  createOperationId: () => string,
+  retainOperationId = false
 ): StructuredAgentSessionOutboxEntry {
-  if (agentSessionRefusalOperationState('agentSession.send', code) !== 'settled-rejected') {
+  const refusalState = agentSessionRefusalOperationState('agentSession.send', code)
+  if (
+    refusalState === 'unknown' ||
+    retainOperationId ||
+    entry.state === 'unconfirmed' ||
+    entry.retryAfterUnknownSubmittedAt !== null
+  ) {
     return { ...entry, state: 'queued' }
   }
   return {
     ...entry,
     clientMessageId: createOperationId(),
     state: 'queued',
+    lastAttemptAt: null,
     retryAfterUnknownSubmittedAt: null
   }
 }
@@ -162,7 +170,6 @@ export function structuredAgentSessionSendRequest(
         fields
       })
     },
-    ...(entry.retryAfterUnknownSubmittedAt !== null ? { retryUnknown: true } : {}),
     ...fields
   }
 }

--- a/src/shared/structured-agent-session-send-disposition.test.ts
+++ b/src/shared/structured-agent-session-send-disposition.test.ts
@@ -85,3 +85,58 @@ describe('what a rejection shows the user', () => {
     expect(shown).toBe('Orca could not send your message — Retry to send it again.')
   })
 })
+
+describe('ambiguous operation refusals', () => {
+  it.each([
+    { ...entry, state: 'unconfirmed' as const, lastAttemptAt: 10 },
+    { ...entry, state: 'queued' as const, lastAttemptAt: 10, retryAfterUnknownSubmittedAt: 10 }
+  ])('never rotates $state operation after its host tombstone expires', (ambiguous) => {
+    const disposition = disposeStructuredAgentSessionSendResult({
+      entries: [ambiguous],
+      entry: ambiguous,
+      blockedClientMessageId: null,
+      result: {
+        ok: false,
+        refusal: {
+          code: 'agent_session_operation_expired',
+          message: 'Operation expired.'
+        }
+      },
+      createOperationId: () => 'fresh-id'
+    })
+
+    expect(disposition.entries).toMatchObject([
+      { clientMessageId: entry.clientMessageId, state: 'queued' }
+    ])
+    expect(disposition.blockedClientMessageId).toBe(entry.clientMessageId)
+  })
+
+  it('parks a recovered missing submission without polling forever', () => {
+    const result = rejectedWith(null)
+    if (!result.ok) {
+      throw new Error('expected a send result')
+    }
+    result.value.submission = {
+      ...result.value.submission,
+      dispatchState: 'unknown',
+      reason: 'durable_send_submission_missing',
+      recovered: true
+    }
+
+    const disposition = disposeStructuredAgentSessionSendResult({
+      entries: [entry],
+      entry,
+      blockedClientMessageId: null,
+      result,
+      createOperationId: () => 'unused'
+    })
+
+    expect(disposition.entries).toMatchObject([
+      {
+        clientMessageId: entry.clientMessageId,
+        state: 'unconfirmed',
+        retryAfterUnknownSubmittedAt: -1
+      }
+    ])
+  })
+})

--- a/src/shared/structured-agent-session-send-disposition.test.ts
+++ b/src/shared/structured-agent-session-send-disposition.test.ts
@@ -6,7 +6,10 @@
 import { describe, expect, it } from 'vitest'
 import type { AgentJournalSubmission } from './agent-session-journal-types'
 import type { AgentSessionMutationResult, AgentSessionSendResult } from './agent-session-wire'
-import { dispatchWriteFailureReason } from './structured-agent-session-dispatch-rejection'
+import {
+  dispatchWriteFailureReason,
+  DISPATCH_REJECTED_QUEUE_FULL
+} from './structured-agent-session-dispatch-rejection'
 import { disposeStructuredAgentSessionSendResult } from './structured-agent-session-send-disposition'
 import {
   createStructuredAgentSessionOutboxEntry,
@@ -72,5 +75,13 @@ describe('what a rejection shows the user', () => {
 
   it('claims no cause when the rejection names none', () => {
     expect(notice(null)).toBe('Message was not sent.')
+  })
+
+  it('never puts a local-capacity marker on screen either', () => {
+    // Neither the provider's words nor a transport failure: a refusal we minted
+    // ourselves. It has no user-facing meaning, so it gets copy rather than the token.
+    const shown = notice(DISPATCH_REJECTED_QUEUE_FULL)
+    expect(shown).not.toContain('queue is full')
+    expect(shown).toBe('Orca could not send your message — Retry to send it again.')
   })
 })

--- a/src/shared/structured-agent-session-send-disposition.test.ts
+++ b/src/shared/structured-agent-session-send-disposition.test.ts
@@ -1,0 +1,76 @@
+// What a rejection puts on the user's screen.
+//
+// The module is pure so this can be asserted directly instead of through the hook,
+// which is the whole reason it was split out.
+
+import { describe, expect, it } from 'vitest'
+import type { AgentJournalSubmission } from './agent-session-journal-types'
+import type { AgentSessionMutationResult, AgentSessionSendResult } from './agent-session-wire'
+import { dispatchWriteFailureReason } from './structured-agent-session-dispatch-rejection'
+import { disposeStructuredAgentSessionSendResult } from './structured-agent-session-send-disposition'
+import {
+  createStructuredAgentSessionOutboxEntry,
+  type StructuredAgentSessionOutboxEntry
+} from './structured-agent-session-outbox'
+
+const entry: StructuredAgentSessionOutboxEntry = createStructuredAgentSessionOutboxEntry({
+  clientMessageId: 'client-1',
+  sessionId: 'session-1',
+  text: 'hello',
+  attachments: [],
+  queuedAt: 1
+})
+
+function rejectedWith(reason: string | null): AgentSessionMutationResult<AgentSessionSendResult> {
+  const submission: AgentJournalSubmission = {
+    clientMessageId: 'client-1',
+    fence: 1,
+    payloadFingerprint: 'fingerprint',
+    dispatchState: 'rejected',
+    providerItemId: null,
+    reason,
+    submittedAt: 10,
+    resolvedAt: 10
+  }
+  return {
+    ok: true,
+    replayed: false,
+    fence: 1,
+    cursor: { epoch: 'epoch-1', sequence: 10 },
+    value: { clientMessageId: 'client-1', submission }
+  } as AgentSessionMutationResult<AgentSessionSendResult>
+}
+
+function notice(reason: string | null): string | null {
+  return disposeStructuredAgentSessionSendResult({
+    entries: [entry],
+    entry,
+    blockedClientMessageId: null,
+    result: rejectedWith(reason),
+    createOperationId: () => 'unused'
+  }).error
+}
+
+describe('what a rejection shows the user', () => {
+  it('never puts the transport marker on screen', () => {
+    const shown = notice(dispatchWriteFailureReason(new Error('broken pipe')))
+    // `provider_write_failed: broken pipe` names nothing a person can act on.
+    expect(shown).not.toContain('provider_write_failed')
+    expect(shown).not.toContain('broken pipe')
+    // And it says the message is safe to send again, which it is: the frame never left.
+    expect(shown).toBe(
+      "Couldn't reach the agent. Your message was not sent — Retry to send it again."
+    )
+  })
+
+  it('shows a content rejection in the provider own words', () => {
+    // The provider explaining itself IS the answer; a generic string throws it away.
+    expect(notice('Claude messages support at most 20 images')).toBe(
+      'Claude messages support at most 20 images'
+    )
+  })
+
+  it('claims no cause when the rejection names none', () => {
+    expect(notice(null)).toBe('Message was not sent.')
+  })
+})

--- a/src/shared/structured-agent-session-send-disposition.ts
+++ b/src/shared/structured-agent-session-send-disposition.ts
@@ -24,6 +24,8 @@ export type StructuredAgentSessionSendDisposition = {
   /** The entry the queue is stuck on, or null when nothing blocks it. Always the
    *  next value, never "unchanged": the caller assigns it verbatim. */
   blockedClientMessageId: string | null
+  /** A rejected result arrived before the journal snapshot; Retry must rotate this id. */
+  retryWithFreshClientMessageId: string | null
 }
 
 type SendDispositionInput = {
@@ -118,7 +120,8 @@ export function disposeStructuredAgentSessionSendResult(
     return {
       entries,
       error: result.refusal.message,
-      blockedClientMessageId: entries[0]?.clientMessageId ?? null
+      blockedClientMessageId: entries[0]?.clientMessageId ?? null,
+      retryWithFreshClientMessageId: null
     }
   }
   const submission = result.value.submission
@@ -126,21 +129,24 @@ export function disposeStructuredAgentSessionSendResult(
     return {
       entries: dropEntry(input),
       error: 'Message delivery is unconfirmed and Orca will not send it again',
-      blockedClientMessageId: input.blockedClientMessageId
+      blockedClientMessageId: input.blockedClientMessageId,
+      retryWithFreshClientMessageId: null
     }
   }
   if (submission.dispatchState === 'accepted') {
     return {
       entries: dropEntry(input),
       error: null,
-      blockedClientMessageId: input.blockedClientMessageId
+      blockedClientMessageId: input.blockedClientMessageId,
+      retryWithFreshClientMessageId: null
     }
   }
   if (submission.dispatchState === 'rejected') {
     return {
       entries: replaceEntryState(input, 'queued'),
       error: rejectionNotice(submission.reason),
-      blockedClientMessageId: input.entry.clientMessageId
+      blockedClientMessageId: input.entry.clientMessageId,
+      retryWithFreshClientMessageId: input.entry.clientMessageId
     }
   }
   // `pending` is the host saying the message was written and is awaiting the
@@ -153,7 +159,8 @@ export function disposeStructuredAgentSessionSendResult(
       submission.dispatchState === 'unknown' ? 'unconfirmed' : 'dispatching'
     ),
     error: null,
-    blockedClientMessageId: input.blockedClientMessageId
+    blockedClientMessageId: input.blockedClientMessageId,
+    retryWithFreshClientMessageId: null
   }
 }
 
@@ -170,6 +177,7 @@ export function disposeStructuredAgentSessionSendFailure(
     error: deliveryUnknown ? 'Message delivery is unconfirmed' : String(input.cause),
     blockedClientMessageId: deliveryUnknown
       ? input.blockedClientMessageId
-      : input.entry.clientMessageId
+      : input.entry.clientMessageId,
+    retryWithFreshClientMessageId: null
   }
 }

--- a/src/shared/structured-agent-session-send-disposition.ts
+++ b/src/shared/structured-agent-session-send-disposition.ts
@@ -8,6 +8,7 @@
 // entry's state.
 
 import type { AgentSessionMutationResult, AgentSessionSendResult } from './agent-session-wire'
+import { dispatchRejectionWasTransportWriteFailure } from './structured-agent-session-dispatch-rejection'
 import {
   classifyStructuredAgentSessionSendFailure,
   requeueStructuredAgentSessionSendRefusal,
@@ -44,11 +45,16 @@ function dropEntry(input: SendDispositionInput): StructuredAgentSessionOutboxEnt
 }
 
 /**
- * The user force-retried and got the same observation back, so the host will not
- * put this message on the wire again — it cannot prove doing so would be a first
- * delivery. Parking the entry would offer a Retry that does nothing in front of
- * a queue nothing can drain, so it leaves the outbox. Nothing is lost from the
- * conversation: the durable submission row already renders the message.
+ * The user force-retried a host-confirmed `unknown` and got the same submission
+ * back. That is now the only answer such a retry can get: `unknown` means the
+ * host cannot tell whether the provider has the message, and no reason it
+ * records ever makes a second delivery safe. Parking the entry would offer a
+ * Retry that does nothing in front of a queue nothing can drain, so it leaves
+ * the outbox. Nothing is lost from the conversation: the durable submission row
+ * already renders the message.
+ *
+ * A `rejected` submission takes the other path — the message provably did not
+ * happen, so Retry rotates the id and sends it as a genuinely new message.
  */
 function refusedRedelivery(
   entry: StructuredAgentSessionOutboxEntry,
@@ -59,6 +65,29 @@ function refusedRedelivery(
     submission.dispatchState === 'unknown' &&
     submission.submittedAt === entry.retryAfterUnknownSubmittedAt
   )
+}
+
+/**
+ * What to put on screen for a rejection.
+ *
+ * A content rejection's reason is the provider explaining itself, so it is shown
+ * verbatim — "Claude does not support the image type .bmp" is the whole answer and
+ * a generic string would throw it away. A transport rejection's reason is an
+ * internal marker; printing it put `provider_write_failed: broken pipe` in front of
+ * users, which names nothing they can act on. That case gets copy that says what
+ * happened and that the message is safe to send again — which it is, because the
+ * frame provably never left, so a resend cannot duplicate.
+ *
+ * The null default claims no cause, because at that point we know none: all it
+ * asserts is the one thing every rejection shares.
+ */
+function rejectionNotice(reason: string | null): string {
+  if (reason === null) {
+    return 'Message was not sent.'
+  }
+  return dispatchRejectionWasTransportWriteFailure(reason)
+    ? "Couldn't reach the agent. Your message was not sent — Retry to send it again."
+    : reason
 }
 
 export function disposeStructuredAgentSessionSendResult(
@@ -102,7 +131,7 @@ export function disposeStructuredAgentSessionSendResult(
   if (submission.dispatchState === 'rejected') {
     return {
       entries: replaceEntryState(input, 'queued'),
-      error: submission.reason ?? 'Message was not accepted',
+      error: rejectionNotice(submission.reason),
       blockedClientMessageId: input.entry.clientMessageId
     }
   }

--- a/src/shared/structured-agent-session-send-disposition.ts
+++ b/src/shared/structured-agent-session-send-disposition.ts
@@ -116,7 +116,8 @@ export function disposeStructuredAgentSessionSendResult(
         ? requeueStructuredAgentSessionSendRefusal(
             candidate,
             result.refusal.code,
-            input.createOperationId
+            input.createOperationId,
+            input.entry.lastAttemptAt !== null
           )
         : candidate
     )
@@ -150,6 +151,18 @@ export function disposeStructuredAgentSessionSendResult(
       error: structuredAgentSessionRejectionNotice(submission.reason),
       blockedClientMessageId: input.entry.clientMessageId,
       retryWithFreshClientMessageId: input.entry.clientMessageId
+    }
+  }
+  if (submission.dispatchState === 'unknown' && submission.recovered) {
+    return {
+      entries: input.entries.map((candidate) =>
+        candidate.clientMessageId === input.entry.clientMessageId
+          ? { ...candidate, state: 'unconfirmed', retryAfterUnknownSubmittedAt: -1 }
+          : candidate
+      ),
+      error: null,
+      blockedClientMessageId: input.blockedClientMessageId,
+      retryWithFreshClientMessageId: null
     }
   }
   // `pending` is the host saying the message was written and is awaiting the

--- a/src/shared/structured-agent-session-send-disposition.ts
+++ b/src/shared/structured-agent-session-send-disposition.ts
@@ -85,8 +85,11 @@ function refusedRedelivery(
  *
  * The null default claims no cause, because at that point we know none: all it
  * asserts is the one thing every rejection shares.
+ *
+ * Exported because a client without an outbox needs the same copy: the rule about
+ * which reasons a person may read is a property of the reason, not of the queue.
  */
-function rejectionNotice(reason: string | null): string {
+export function structuredAgentSessionRejectionNotice(reason: string | null): string {
   if (reason === null) {
     return 'Message was not sent.'
   }
@@ -144,7 +147,7 @@ export function disposeStructuredAgentSessionSendResult(
   if (submission.dispatchState === 'rejected') {
     return {
       entries: replaceEntryState(input, 'queued'),
-      error: rejectionNotice(submission.reason),
+      error: structuredAgentSessionRejectionNotice(submission.reason),
       blockedClientMessageId: input.entry.clientMessageId,
       retryWithFreshClientMessageId: input.entry.clientMessageId
     }

--- a/src/shared/structured-agent-session-send-disposition.ts
+++ b/src/shared/structured-agent-session-send-disposition.ts
@@ -8,7 +8,10 @@
 // entry's state.
 
 import type { AgentSessionMutationResult, AgentSessionSendResult } from './agent-session-wire'
-import { dispatchRejectionWasTransportWriteFailure } from './structured-agent-session-dispatch-rejection'
+import {
+  dispatchRejectionReasonIsInternal,
+  dispatchRejectionWasTransportWriteFailure
+} from './structured-agent-session-dispatch-rejection'
 import {
   classifyStructuredAgentSessionSendFailure,
   requeueStructuredAgentSessionSendRefusal,
@@ -85,8 +88,13 @@ function rejectionNotice(reason: string | null): string {
   if (reason === null) {
     return 'Message was not sent.'
   }
-  return dispatchRejectionWasTransportWriteFailure(reason)
-    ? "Couldn't reach the agent. Your message was not sent — Retry to send it again."
+  if (dispatchRejectionWasTransportWriteFailure(reason)) {
+    return "Couldn't reach the agent. Your message was not sent — Retry to send it again."
+  }
+  // Any other reason we minted is an internal cause with no user-facing meaning;
+  // only a provider's own explanation is worth reading verbatim.
+  return dispatchRejectionReasonIsInternal(reason)
+    ? 'Orca could not send your message — Retry to send it again.'
     : reason
 }
 


### PR DESCRIPTION
## ELI5

When a message can't be sent, Orca now says which of two things happened — "it definitely didn't go" or "I genuinely can't tell" — instead of saying "I can't tell" for both. That matters because Retry is safe in the first case and dangerous in the second.

## The critical change, in one sentence

**Retry's safety stops depending on a list being correct, and starts depending on the state itself.**

Before, every failed send landed in one state — `unknown`, "delivery in doubt" — and Retry consulted a lookup of *reasons* to decide whether re-delivering that particular `unknown` was safe:

```
dispatchState = 'unknown'
reason        = 'provider_write_failed: broken pipe'   <- allowlisted, re-delivery permitted
reason        = 'provider_exited_before_acknowledgement' <- not allowlisted, refused
reason        = 'host_restarted_before_acknowledgement'  <- not allowlisted, refused
```

That is a runtime judgement call standing in front of a duplicate-delivery hazard. It is only safe while the list is right, and nothing fails when somebody adds a new reason and forgets it.

After, the one case that was provably safe is **not an `unknown` at all** — a write the agent's input pump never took resolves `rejected`, because "provably did not happen" is what `rejected` already means. With that case gone, the allowlist has no entries left and is deleted. Retry's rule becomes unconditional:

> **Never re-deliver an `unknown`. No exceptions, nothing to look up.**

Re-sending after a `rejected` is safe by construction rather than by permission: it goes out under a fresh client message id, so it is a new message and cannot duplicate an old one.

**That is the whole change.** A judgement call became a structural invariant. Everything below — the copy fixes, the mobile fixes — follows from the states now meaning one thing each.

## What you see today vs after

**Case A — the agent's input pipe breaks (agent crashed, was killed, restarted).** The message provably never left your machine.

| | Today | After |
|---|---|---|
| Banner | "Message delivery is unconfirmed." | "Message was not sent." |
| Second line | `provider_write_failed: broken pipe` **in red** | "Couldn't reach the agent. Your message was not sent — Retry to send it again." |
| Retry | Refuses — nothing happens, forever | Sends it as a genuinely new message |

Today that red line is an internal identifier on your screen. There is nothing you can do with it, and the Retry button next to it is inert.

**Case B — Orca genuinely can't tell (host restarted mid-send, ack lost).** The agent may or may not have it.

Unchanged on purpose: still "Message delivery is unconfirmed.", still refuses to re-deliver. That refusal is the point — see Why.

**On mobile.** Today, a send whose outcome is unknown reports as *sent*: the composer clears your draft and the message looks delivered. After: it reports unknown, keeps your draft, and says "Delivery unconfirmed — check chat before retrying."

## Why

Retry used to re-deliver messages that had already reached the model. In one measured session a single message reached the model **five times**. The root cause was fixed in #19863 (a 10-second timer that declared healthy sends "unconfirmed" — 25% of all sends tripped it). This PR fixes the state model underneath it.

`unknown` meant five different things, only one of which was real ambiguity. A one-entry allowlist then existed to teach Retry that one particular `unknown` was safe. That is a judgement call sitting in front of a duplicate-delivery hazard.

Moving the provable case to `rejected` deletes the allowlist and makes it an **invariant**: Retry never re-delivers an `unknown`, no exceptions to reason about. The asymmetry justifies being strict — refusing a legitimate retry costs you a retype; allowing a bad one silently puts a second copy of your message in the model's context, where you won't see it.

Four states, one meaning each:

| state | means |
|---|---|
| `pending` | written, waiting for the agent to acknowledge |
| `accepted` | the agent has it |
| `rejected` | provably did not happen |
| `unknown` | genuinely cannot tell |

## What changed in the code

- A transport write the agent's input pump never took now resolves `rejected` instead of `unknown`.
- The redelivery allowlist is deleted; `performSend` cannot re-deliver an `unknown` at all.
- Rejection reasons split into *the provider's own words* (shown verbatim — "Claude does not support the image type .bmp" is the whole answer) and *internal causes* (never shown; replaced with copy you can act on).
- Mobile reads the send's real state instead of treating any successful RPC as delivered, and **keeps** its operation id when delivery is unknown — reusing that id delivers if nothing landed and replays if something did, so it can't duplicate.
- A refused worker-start preamble throws a typed code instead of prose a caller has to parse.

## Review history worth knowing

A mid-review commit made mobile **rotate** its operation id on unknown, which host-side is a second dispatch — the exact defect this PR removes, reintroduced on another surface. It was caught, reverted, and the guard restored with a test that fails against the pre-fix code. The mobile send fixture was also replaced: it returned a shape that structurally could not express this bug, which is why the inversion passed review.

## Testing

`pnpm tc` clean. Affected suites green; mobile `src/session` 160 files / 1511 tests. Every new test ablated — including an arm running the production file at the pre-fix commit with the new tests kept, which fails.

One pre-existing failure, `claude-structured-real-cli.test.ts`, verified to fail identically on plain `main`.

## Visual proof

The only user-visible change is copy, tabulated above. Not run in the app — flagging that rather than claiming N/A.

## Notes

- **Wire**: a semantic shift inside the existing `dispatchState` enum — no new value, no codec change, no capability gate. Verified against shipped code: the id-rotating `rejected` branch predates #19863, so already-shipped clients handle it.
- **Not fixed here**: a message left `unknown` by a dead child or host restart still has no recourse but retyping. #20139 is the fix for that.
- `journal-reducer.ts` is at 299 of its 300 counted lines. The next statement added there needs a split, not a shave.
