### PR TITLE
fix(accounts): flag signed-out system-default Claude login in Accounts pane

### DIFF
--- a/src/main/rate-limits/claude-active-usage-fetch.ts
+++ b/src/main/rate-limits/claude-active-usage-fetch.ts
@@ -144,6 +144,19 @@ export async function fetchActiveClaudeRateLimits(
     managedRefreshDeferredByLivePty: options?.authPreparation?.managedRefreshDeferredByLivePty
   })
 
+  // Why: terminal signed-out means there is no token to try and no CLI
+  // fallback is sanctioned — return before any refresh or PTY attempts.
+  if (credentialClassification.failureKind === 'signed-out') {
+    return makeClaudeUsageResult('error', 'Claude sign-in expired', {
+      ...metadataForClaudeUsageAttempt({
+        attemptedSources: attempts.attemptedSources,
+        oauthCredentials,
+        authPreparation: options?.authPreparation,
+        failureKind: 'signed-out'
+      })
+    })
+  }
+
   if (shouldDeferClaudeUsageForLiveSession(options?.authPreparation, credentialClassification)) {
     return makeLiveClaudeUsageDeferredResult({
       attempts,
@@ -236,19 +249,6 @@ export async function fetchActiveClaudeRateLimits(
     } catch (error) {
       warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, error)
     }
-  }
-
-  // Why: an emptied credential store means signed-out, not never-configured —
-  // surface it as an error so the status bar shows a sign-in state instead of hiding.
-  if (credentialClassification.failureKind === 'signed-out') {
-    return makeClaudeUsageResult('error', 'Claude sign-in expired', {
-      ...metadataForClaudeUsageAttempt({
-        attemptedSources: attempts.attemptedSources,
-        oauthCredentials,
-        authPreparation: options?.authPreparation,
-        failureKind: 'signed-out'
-      })
-    })
   }
 
   return makeClaudeUsageResult('unavailable', 'No subscription plan — API key billing', {

--- a/src/main/rate-limits/claude-active-usage-fetch.ts
+++ b/src/main/rate-limits/claude-active-usage-fetch.ts
@@ -139,6 +139,7 @@ export async function fetchActiveClaudeRateLimits(
 
   const credentialClassification = classifyClaudeCredentialAbsence({
     hasRefreshableCredentials: oauthCredentials.hasRefreshableCredentials,
+    hasEmptyStoredEntry: oauthCredentials.hasEmptyStoredEntry,
     keychainUnavailable: oauthCredentials.keychainUnavailable,
     managedRefreshDeferredByLivePty: options?.authPreparation?.managedRefreshDeferredByLivePty
   })
@@ -235,6 +236,19 @@ export async function fetchActiveClaudeRateLimits(
     } catch (error) {
       warnClaudeUsageFetchFailure(options?.authPreparation, oauthCredentials, error)
     }
+  }
+
+  // Why: an emptied credential store means signed-out, not never-configured —
+  // surface it as an error so the status bar shows a sign-in state instead of hiding.
+  if (credentialClassification.failureKind === 'signed-out') {
+    return makeClaudeUsageResult('error', 'Claude sign-in expired', {
+      ...metadataForClaudeUsageAttempt({
+        attemptedSources: attempts.attemptedSources,
+        oauthCredentials,
+        authPreparation: options?.authPreparation,
+        failureKind: 'signed-out'
+      })
+    })
   }
 
   return makeClaudeUsageResult('unavailable', 'No subscription plan — API key billing', {

--- a/src/main/rate-limits/claude-fetcher-keychain-credentials.test.ts
+++ b/src/main/rate-limits/claude-fetcher-keychain-credentials.test.ts
@@ -469,9 +469,9 @@ describe('fetchClaudeRateLimits', () => {
         })
       )
 
-    await expect(
-      fetchClaudeRateLimits({ authPreparation, allowPtyFallback: false })
-    ).resolves.toMatchObject({
+    // Why: no allowPtyFallback override — signed-out must return before the
+    // generic CLI plan step even when the caller allows PTY fallback.
+    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
       provider: 'claude',
       status: 'error',
       error: 'Claude sign-in expired',

--- a/src/main/rate-limits/claude-fetcher-keychain-credentials.test.ts
+++ b/src/main/rate-limits/claude-fetcher-keychain-credentials.test.ts
@@ -452,6 +452,56 @@ describe('fetchClaudeRateLimits', () => {
     )
   })
 
+  it('reports signed-out instead of unavailable when the Keychain entry holds no tokens', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      runtime: 'host',
+      envPatch: {},
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          claudeAiOauth: { accessToken: '', refreshToken: '', expiresAt: 0 }
+        })
+      )
+
+    await expect(
+      fetchClaudeRateLimits({ authPreparation, allowPtyFallback: false })
+    ).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'Claude sign-in expired',
+      usageMetadata: {
+        failureKind: 'signed-out',
+        credentialSource: 'legacy-keychain',
+        authProvenance: 'system'
+      }
+    })
+
+    expect(netFetchMock).not.toHaveBeenCalled()
+    expect(fetchViaPty).not.toHaveBeenCalled()
+  })
+
+  it('reports signed-out when only the credentials file holds an emptied entry', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({ claudeAiOauth: { accessToken: '', refreshToken: '' } })
+    )
+
+    await expect(fetchClaudeRateLimits({ allowPtyFallback: false })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'error',
+      error: 'Claude sign-in expired',
+      usageMetadata: { failureKind: 'signed-out', credentialSource: 'credentials-file' }
+    })
+
+    expect(netFetchMock).not.toHaveBeenCalled()
+    expect(fetchViaPty).not.toHaveBeenCalled()
+  })
+
   it('tries OAuth usage even when local credential metadata is expired', async () => {
     const configDir = '/Users/test/.claude'
     const authPreparation: ClaudeRuntimeAuthPreparation = {

--- a/src/main/rate-limits/claude-oauth-credentials.ts
+++ b/src/main/rate-limits/claude-oauth-credentials.ts
@@ -44,7 +44,13 @@ export function parseClaudeOAuthCredentialsJson(
     const oauth = (JSON.parse(raw) as ClaudeCredentials)?.claudeAiOauth
     const hasRefreshableCredentials =
       typeof oauth?.refreshToken === 'string' && oauth.refreshToken.trim() !== ''
-    if (!oauth?.accessToken || typeof oauth.accessToken !== 'string') {
+    // Why: a whitespace-only token is unusable — treat it as absent so the
+    // entry counts as emptied (signed-out) instead of reaching the OAuth path.
+    const accessToken =
+      typeof oauth?.accessToken === 'string' && oauth.accessToken.trim() !== ''
+        ? oauth.accessToken.trim()
+        : null
+    if (accessToken == null) {
       return {
         token: null,
         hasRefreshableCredentials,
@@ -55,7 +61,7 @@ export function parseClaudeOAuthCredentialsJson(
       }
     }
     // Why: expiresAt is not authoritative for the usage endpoint; let the server decide.
-    return { token: oauth.accessToken, hasRefreshableCredentials, source }
+    return { token: accessToken, hasRefreshableCredentials, source }
   } catch {
     return emptyClaudeOAuthCredentialReadResult()
   }

--- a/src/main/rate-limits/claude-oauth-credentials.ts
+++ b/src/main/rate-limits/claude-oauth-credentials.ts
@@ -26,6 +26,9 @@ export type ClaudeOAuthCredentialReadResult = {
   hasRefreshableCredentials: boolean
   source: ClaudeOAuthCredentialSource
   keychainUnavailable?: boolean
+  // Why: a stored entry with blank tokens means signed-out, not
+  // never-configured — the status bar shows a sign-in state instead of hiding.
+  hasEmptyStoredEntry?: boolean
 }
 
 type ClaudeOAuthCredentialReadOptions = {
@@ -42,7 +45,14 @@ export function parseClaudeOAuthCredentialsJson(
     const hasRefreshableCredentials =
       typeof oauth?.refreshToken === 'string' && oauth.refreshToken.trim() !== ''
     if (!oauth?.accessToken || typeof oauth.accessToken !== 'string') {
-      return { token: null, hasRefreshableCredentials, source }
+      return {
+        token: null,
+        hasRefreshableCredentials,
+        source,
+        ...(oauth != null && !hasRefreshableCredentials
+          ? { hasEmptyStoredEntry: true as const }
+          : {})
+      }
     }
     // Why: expiresAt is not authoritative for the usage endpoint; let the server decide.
     return { token: oauth.accessToken, hasRefreshableCredentials, source }
@@ -86,9 +96,10 @@ async function readFromKeychain(configDir?: string): Promise<ClaudeOAuthCredenti
     if (legacy.hasRefreshableCredentials) {
       return legacy
     }
-    return scoped.keychainUnavailable || legacy.keychainUnavailable
-      ? unavailableKeychainResult()
-      : legacy
+    if (scoped.keychainUnavailable || legacy.keychainUnavailable) {
+      return unavailableKeychainResult()
+    }
+    return scoped.hasEmptyStoredEntry ? scoped : legacy
   }
 
   try {
@@ -144,7 +155,16 @@ export async function readClaudeOAuthCredentials(
   if (file.token || file.hasRefreshableCredentials) {
     return file
   }
-  return keychain.keychainUnavailable ? keychain : emptyClaudeOAuthCredentialReadResult()
+  if (keychain.keychainUnavailable) {
+    return keychain
+  }
+  if (keychain.hasEmptyStoredEntry) {
+    return keychain
+  }
+  if (file.hasEmptyStoredEntry) {
+    return file
+  }
+  return emptyClaudeOAuthCredentialReadResult()
 }
 
 export function resolveClaudeOAuthCredentialReadOptions(

--- a/src/main/rate-limits/claude-usage-error-classification.test.ts
+++ b/src/main/rate-limits/claude-usage-error-classification.test.ts
@@ -70,6 +70,20 @@ describe('classifyClaudeCredentialAbsence', () => {
     })
   })
 
+  it('classifies a stored-but-empty entry as signed-out, not missing', () => {
+    expect(
+      classifyClaudeCredentialAbsence({
+        hasRefreshableCredentials: false,
+        hasEmptyStoredEntry: true
+      })
+    ).toMatchObject({
+      failureKind: 'signed-out',
+      shouldAttemptCliFallback: false,
+      shouldAttemptDelegatedRefresh: false,
+      terminal: true
+    })
+  })
+
   it('classifies live Claude ownership as a deferred state', () => {
     expect(
       classifyClaudeCredentialAbsence({

--- a/src/main/rate-limits/claude-usage-error-classification.ts
+++ b/src/main/rate-limits/claude-usage-error-classification.ts
@@ -41,11 +41,15 @@ export function classifyClaudeOAuthUsageError(error: unknown): ClaudeUsageErrorC
 
 export function classifyClaudeCredentialAbsence(input: {
   hasRefreshableCredentials: boolean
+  hasEmptyStoredEntry?: boolean
   keychainUnavailable?: boolean
   managedRefreshDeferredByLivePty?: boolean
 }): ClaudeUsageErrorClassification {
   if (input.managedRefreshDeferredByLivePty) {
     return terminal('deferred-by-live-session')
+  }
+  if (input.hasEmptyStoredEntry) {
+    return terminal('signed-out')
   }
   if (input.keychainUnavailable) {
     return fallbackOnly('keychain-unavailable')

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -142,6 +142,7 @@ export function AccountsPane({
   const [codexAction, setCodexAction] = useState<CodexAccountAction>('idle')
   const [claudeAccounts, setClaudeAccounts] =
     useState<ClaudeRateLimitAccountsState>(emptyClaudeAccountsState)
+  const [claudeAccountsLoaded, setClaudeAccountsLoaded] = useState(false)
   const [claudeAction, setClaudeAction] = useState<ClaudeAccountAction>('idle')
   // Why: capture the account's runtime slot when the dialog opens; the roster
   // can change underneath an open dialog and lose the slot to diff for restarts.
@@ -214,12 +215,14 @@ export function AccountsPane({
   const systemCodexNeedsSignIn = activeCodexAccountId === null && Boolean(activeCodexAuthWarning)
   // Why: remote snapshots own their system-default login, but the desktop's
   // usage poll must not be misattributed to a remote account owner (#7973).
-  const systemClaudeNeedsSignIn = getClaudeSystemDefaultSignInWarning({
-    limits: isRemoteAccountScope ? null : claudeRateLimits,
-    target: claudeRateLimitTarget,
-    runtime: accountRuntime,
-    systemActive: systemClaudeActive
-  })
+  const systemClaudeNeedsSignIn =
+    claudeAccountsLoaded &&
+    getClaudeSystemDefaultSignInWarning({
+      limits: isRemoteAccountScope ? null : claudeRateLimits,
+      target: claudeRateLimitTarget,
+      runtime: accountRuntime,
+      systemActive: systemClaudeActive
+    })
   const accountRuntimeUnavailable =
     accountRuntime.runtime === 'wsl' && !wslAvailable && !wslCapabilitiesLoading
 
@@ -251,6 +254,10 @@ export function AccountsPane({
   }, [])
 
   useEffect(() => {
+    // Why: a runtime switch replaces the roster underneath; keep the loaded
+    // gate shut until the new owner's snapshot arrives so empty-roster
+    // derivations (like the system-default warning) cannot flash stale state.
+    setClaudeAccountsLoaded(false)
     // Why: remote snapshots stream usage refreshes after the synchronous ready
     // message, so the watcher stays open for the pane's lifetime; the local
     // path resolves once and the close() is a no-op.
@@ -266,6 +273,7 @@ export function AccountsPane({
           }
           if (!snapshot.failedProviders?.includes('claude')) {
             setClaudeAccounts(snapshot.claude)
+            setClaudeAccountsLoaded(true)
           }
         },
         onError: (error) => {
@@ -301,6 +309,7 @@ export function AccountsPane({
     isRemoteAccountScope,
     claudeAccounts,
     setClaudeAccounts,
+    setClaudeAccountsLoaded,
     setClaudeAction,
     fetchSettings,
     recordFeatureInteraction

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -27,6 +27,7 @@ import {
 import { getRemoteAccountsPaneScope } from './provider-account-scope'
 import { ProviderHostScopeControl } from './ProviderHostScopeControl'
 import { matchesSettingsSearch } from './settings-search'
+import { getClaudeSystemDefaultSignInWarning } from './claude-account-auth-warning'
 import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
 import { getCodexConfigSyncWarning } from './codex-config-sync-warning'
 import {
@@ -72,6 +73,8 @@ export function AccountsPane({
   accountOwnerPlatform = null
 }: AccountsPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
+  const claudeRateLimits = useAppStore((s) => s.rateLimits.claude)
+  const claudeRateLimitTarget = useAppStore((s) => s.rateLimits.claudeTarget)
   const codexRateLimits = useAppStore((s) => s.rateLimits.codex)
   const codexRateLimitTarget = useAppStore((s) => s.rateLimits.codexTarget)
   const miniMaxRateLimits = useAppStore((s) => s.rateLimits.minimax)
@@ -209,6 +212,14 @@ export function AccountsPane({
   const codexConfigSyncWarning = getCodexConfigSyncWarning(codexConfigSync)
   const systemCodexMissingSignIn = activeCodexAuthWarning === 'missing-sign-in'
   const systemCodexNeedsSignIn = activeCodexAccountId === null && Boolean(activeCodexAuthWarning)
+  // Why: remote snapshots own their system-default login, but the desktop's
+  // usage poll must not be misattributed to a remote account owner (#7973).
+  const systemClaudeNeedsSignIn = getClaudeSystemDefaultSignInWarning({
+    limits: isRemoteAccountScope ? null : claudeRateLimits,
+    target: claudeRateLimitTarget,
+    runtime: accountRuntime,
+    systemActive: systemClaudeActive
+  })
   const accountRuntimeUnavailable =
     accountRuntime.runtime === 'wsl' && !wslAvailable && !wslCapabilitiesLoading
 
@@ -316,6 +327,7 @@ export function AccountsPane({
     claudeAction,
     visibleClaudeAccounts,
     systemClaudeActive,
+    systemClaudeNeedsSignIn,
     setRemoveClaudeTarget,
     runClaudeAccountAction,
     codexAccounts,

--- a/src/renderer/src/components/settings/accounts-pane-account-actions.ts
+++ b/src/renderer/src/components/settings/accounts-pane-account-actions.ts
@@ -138,6 +138,7 @@ type ClaudeActionContext = {
   isRemoteAccountScope: boolean
   claudeAccounts: ClaudeRateLimitAccountsState
   setClaudeAccounts: Dispatch<SetStateAction<ClaudeRateLimitAccountsState>>
+  setClaudeAccountsLoaded: Dispatch<SetStateAction<boolean>>
   setClaudeAction: Dispatch<SetStateAction<ClaudeAccountAction>>
   fetchSettings: () => Promise<void>
   recordFeatureInteraction: (featureId: FeatureInteractionId) => void
@@ -153,10 +154,12 @@ export function createClaudeAccountActionRunner(
     isRemoteAccountScope,
     recordFeatureInteraction,
     setClaudeAccounts,
+    setClaudeAccountsLoaded,
     setClaudeAction
   } = context
   const syncClaudeAccounts = async (next: ClaudeRateLimitAccountsState): Promise<void> => {
     setClaudeAccounts(next)
+    setClaudeAccountsLoaded(true)
     if (!isRemoteAccountScope) {
       await fetchSettings()
     }

--- a/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
@@ -27,6 +27,7 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
     setRemoveClaudeTarget,
     settings,
     systemClaudeActive,
+    systemClaudeNeedsSignIn,
     visibleClaudeAccounts,
     wslCapabilitiesLoading
   } = model
@@ -131,9 +132,11 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
             }
             disabled={claudeAction !== 'idle' || accountRuntimeUnavailable}
             className={`flex w-full items-center justify-between gap-3 rounded-md border px-3 py-2.5 text-left transition-colors ${
-              systemClaudeActive
-                ? 'border-foreground/20 bg-accent/15'
-                : 'border-border/70 hover:border-border hover:bg-accent/8'
+              systemClaudeNeedsSignIn
+                ? 'border-destructive/50 bg-destructive/5'
+                : systemClaudeActive
+                  ? 'border-foreground/20 bg-accent/15'
+                  : 'border-border/70 hover:border-border hover:bg-accent/8'
             } disabled:cursor-default disabled:opacity-100`}
           >
             <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -149,8 +152,20 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
                     {translate('auto.components.settings.AccountsPane.e74831fb6b', 'Active')}
                   </Badge>
                 ) : null}
+                {systemClaudeNeedsSignIn ? (
+                  <Badge
+                    variant="destructive"
+                    className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none"
+                  >
+                    {translate('auto.components.settings.AccountsPane.93c47b333a', 'Needs sign-in')}
+                  </Badge>
+                ) : null}
               </div>
-              <span className="truncate text-[11px] text-muted-foreground">
+              <span
+                className={`truncate text-[11px] ${
+                  systemClaudeNeedsSignIn ? 'text-destructive' : 'text-muted-foreground'
+                }`}
+              >
                 {translate(
                   'auto.components.settings.AccountsPane.e05d0ff737',
                   'Use your current {{value0}} Claude login.',

--- a/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-claude-section.tsx
@@ -144,7 +144,8 @@ export function renderClaudeAccountsSection(model: AccountsPaneSectionModel): Re
                 <span className="truncate text-sm font-medium">
                   {translate('auto.components.settings.AccountsPane.f2a265f8c7', 'System default')}
                 </span>
-                {systemClaudeActive ? (
+                {/* Why: a row cannot read as both selected-healthy and broken — the warning replaces Active, not joins it. */}
+                {systemClaudeActive && !systemClaudeNeedsSignIn ? (
                   <Badge
                     variant="outline"
                     className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/80"

--- a/src/renderer/src/components/settings/accounts-pane-types.ts
+++ b/src/renderer/src/components/settings/accounts-pane-types.ts
@@ -81,6 +81,7 @@ export type AccountsPaneSectionModel = {
   claudeAction: ClaudeAccountAction
   visibleClaudeAccounts: ClaudeRateLimitAccountsState['accounts']
   systemClaudeActive: boolean
+  systemClaudeNeedsSignIn: boolean
   setRemoveClaudeTarget: Dispatch<SetStateAction<RemoveAccountTarget | null>>
   runClaudeAccountAction: ClaudeAccountActionRunner
   codexAccounts: CodexRateLimitAccountsState

--- a/src/renderer/src/components/settings/claude-account-auth-warning.test.ts
+++ b/src/renderer/src/components/settings/claude-account-auth-warning.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ProviderRateLimits,
+  UsageRateLimitFailureKind
+} from '../../../../shared/rate-limit-types'
+import {
+  claudeRateLimitTargetMatchesAccountRuntime,
+  getClaudeSystemDefaultSignInWarning
+} from './claude-account-auth-warning'
+
+function claudeLimits(
+  status: ProviderRateLimits['status'],
+  failureKind: UsageRateLimitFailureKind = 'signed-out'
+): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: null,
+    weekly: null,
+    updatedAt: 1,
+    error: 'Claude sign-in expired',
+    status,
+    usageMetadata: { failureKind }
+  }
+}
+
+const hostTarget = { runtime: 'host', wslDistro: null } as const
+
+describe('claude system default sign-in warning', () => {
+  it('warns when the host snapshot reports signed-out', () => {
+    expect(
+      getClaudeSystemDefaultSignInWarning({
+        limits: claudeLimits('error'),
+        target: hostTarget,
+        runtime: { runtime: 'host' },
+        systemActive: true
+      })
+    ).toBe(true)
+  })
+
+  it('stays quiet when a managed account is selected', () => {
+    expect(
+      getClaudeSystemDefaultSignInWarning({
+        limits: claudeLimits('error'),
+        target: hostTarget,
+        runtime: { runtime: 'host' },
+        systemActive: false
+      })
+    ).toBe(false)
+  })
+
+  it('stays quiet for other failure kinds and non-error snapshots', () => {
+    const base = {
+      target: hostTarget,
+      runtime: { runtime: 'host' },
+      systemActive: true
+    } as const
+    expect(
+      getClaudeSystemDefaultSignInWarning({
+        ...base,
+        limits: claudeLimits('error', 'missing-credentials')
+      })
+    ).toBe(false)
+    expect(
+      getClaudeSystemDefaultSignInWarning({
+        ...base,
+        limits: claudeLimits('unavailable', 'signed-out')
+      })
+    ).toBe(false)
+    expect(getClaudeSystemDefaultSignInWarning({ ...base, limits: null })).toBe(false)
+  })
+
+  it('stays quiet when the snapshot target does not match the viewed runtime', () => {
+    expect(
+      getClaudeSystemDefaultSignInWarning({
+        limits: claudeLimits('error'),
+        target: hostTarget,
+        runtime: { runtime: 'wsl', wslDistro: 'Ubuntu' },
+        systemActive: true
+      })
+    ).toBe(false)
+    expect(
+      getClaudeSystemDefaultSignInWarning({
+        limits: claudeLimits('error'),
+        target: { runtime: 'wsl', wslDistro: 'Ubuntu' },
+        runtime: { runtime: 'wsl', wslDistro: 'Ubuntu' },
+        systemActive: true
+      })
+    ).toBe(true)
+  })
+
+  it('matches targets the same way the Codex warning does', () => {
+    expect(claudeRateLimitTargetMatchesAccountRuntime(hostTarget, { runtime: 'host' })).toBe(true)
+    expect(
+      claudeRateLimitTargetMatchesAccountRuntime(hostTarget, {
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu'
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/settings/claude-account-auth-warning.ts
+++ b/src/renderer/src/components/settings/claude-account-auth-warning.ts
@@ -1,0 +1,39 @@
+import type {
+  ProviderRateLimits,
+  RateLimitRuntimeTarget
+} from '../../../../shared/rate-limit-types'
+
+type AccountRuntime = {
+  runtime: 'host' | 'wsl'
+  wslDistro?: string | null
+}
+
+export function claudeRateLimitTargetMatchesAccountRuntime(
+  target: RateLimitRuntimeTarget,
+  runtime: AccountRuntime
+): boolean {
+  if (target.runtime !== runtime.runtime) {
+    return false
+  }
+  if (runtime.runtime === 'host') {
+    return true
+  }
+  return !runtime.wslDistro || target.wslDistro === runtime.wslDistro
+}
+
+// Why: the desktop usage snapshot describes the viewed login only when its
+// target matches; otherwise the warning would blame the wrong environment.
+export function getClaudeSystemDefaultSignInWarning(args: {
+  limits: ProviderRateLimits | null
+  target: RateLimitRuntimeTarget
+  runtime: AccountRuntime
+  systemActive: boolean
+}): boolean {
+  if (!args.systemActive) {
+    return false
+  }
+  if (!claudeRateLimitTargetMatchesAccountRuntime(args.target, args.runtime)) {
+    return false
+  }
+  return args.limits?.status === 'error' && args.limits.usageMetadata?.failureKind === 'signed-out'
+}

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -259,6 +259,18 @@ describe('getVisibleUsageProvider', () => {
     ).toBe(unavailable)
   })
 
+  it('keeps a signed-out provider visible without any managed account', () => {
+    // Why: an emptied credential store reports status error (not unavailable)
+    // so the bar shows a sign-in state instead of vanishing with no affordance.
+    const signedOut = provider('error', {
+      provider: 'claude',
+      error: 'Claude sign-in expired',
+      usageMetadata: { failureKind: 'signed-out' }
+    })
+
+    expect(getVisibleUsageProvider('claude', signedOut, usageSettings())).toBe(signedOut)
+  })
+
   it('hides providers with no live data or durable configuration', () => {
     expect(getVisibleUsageProvider('codex', null, usageSettings())).toBe(null)
     expect(getVisibleUsageProvider('grok', undefined, usageSettings())).toBe(null)

--- a/src/renderer/src/components/status-bar/usage-error-copy.test.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.test.ts
@@ -4,7 +4,25 @@ vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
 }))
 
-import { getProviderDisplayName } from './usage-error-copy'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import {
+  getProviderDisplayName,
+  getProviderUsageErrorMessage,
+  getProviderUsageStatusLabel
+} from './usage-error-copy'
+
+function claudeError(overrides: Partial<ProviderRateLimits> = {}): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: 'Claude sign-in expired',
+    status: 'error',
+    usageMetadata: { failureKind: 'signed-out' },
+    ...overrides
+  }
+}
 
 describe('getProviderDisplayName', () => {
   it('returns the Antigravity brand name', () => {
@@ -22,6 +40,14 @@ describe('getProviderDisplayName', () => {
     expect(getProviderDisplayName('opencode-go')).toBe('OpenCode Go')
     expect(getProviderDisplayName('kimi')).toBe('Kimi')
     expect(getProviderDisplayName('grok')).toBe('Grok')
+  })
+
+  it('labels a signed-out Claude snapshot as not signed in', () => {
+    expect(getProviderUsageStatusLabel(claudeError())).toBe('not signed in')
+  })
+
+  it('surfaces the signed-out message instead of generic auth copy', () => {
+    expect(getProviderUsageErrorMessage(claudeError())).toBe('Claude sign-in expired')
   })
 
   it('falls back to the raw provider id when no mapping exists', () => {

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -174,6 +174,10 @@ export function getProviderUsageErrorMessage(p: ProviderRateLimits): string {
           'auto.components.status.bar.tooltip.a7517cccb6',
           'Claude usage is unavailable right now.'
         )
+      // Why: the main-process 'Claude sign-in expired' string is intentionally
+      // pattern-safe (matches no auth-error rewrite), so it surfaces verbatim.
+      case 'signed-out':
+        return p.error ?? fallback
       case 'missing-credentials':
       case 'rate-limited':
       case 'unknown':

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -85,6 +85,8 @@ export function getProviderUsageStatusLabel(p: ProviderRateLimits): string {
   }
   if (p.provider === 'claude') {
     switch (p.usageMetadata?.failureKind) {
+      case 'signed-out':
+        return translate('auto.components.status.bar.UsageRosterPanel.notSignedIn', 'not signed in')
       case 'deferred-by-live-session':
         return translate(
           'auto.components.status.bar.tooltip.0d8d7cfe15',

--- a/src/renderer/src/components/status-bar/usage-roster-row-state.test.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-row-state.test.ts
@@ -60,6 +60,16 @@ describe('getUsageRosterRowState', () => {
     expect(
       getUsageRosterRowState(
         provider({
+          status: 'error',
+          error: 'Claude sign-in expired',
+          usageMetadata: { failureKind: 'signed-out' }
+        }),
+        false
+      )
+    ).toEqual({ kind: 'sign-in', statusLabel: 'not signed in' })
+    expect(
+      getUsageRosterRowState(
+        provider({
           provider: 'codex',
           status: 'error',
           error: 'ChatGPT authentication required to read rate limits'

--- a/src/renderer/src/components/status-bar/usage-roster-row-state.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-row-state.ts
@@ -18,7 +18,10 @@ const CONFIRMED_SIGN_OUT_PATTERNS = [
 ]
 
 function isConfirmedSignedOut(provider: ProviderRateLimits): boolean {
-  if (provider.usageMetadata?.failureKind === 'missing-credentials') {
+  if (
+    provider.usageMetadata?.failureKind === 'missing-credentials' ||
+    provider.usageMetadata?.failureKind === 'signed-out'
+  ) {
     return true
   }
   // Why: credential refresh and network failures can mention auth while live

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -19,6 +19,9 @@ export type UsageRateLimitSource = 'oauth' | 'cli' | 'web' | 'live-session'
 
 export type UsageRateLimitFailureKind =
   | 'missing-credentials'
+  // Why: a stored-but-empty credential entry proves the CLI was set up and
+  // lost its tokens (signed out), unlike never-configured (hide the bar).
+  | 'signed-out'
   | 'stale-token'
   | 'refreshable-credentials-without-token'
   | 'delegated-refresh-required'


### PR DESCRIPTION
## ELI5

The status-bar fix shows "not signed in" when Claude's stored login is emptied — but Settings → Accounts still showed the System default row as a healthy active login. This makes the Accounts pane agree with the meter, using the same warning pattern Codex already has.

## What Changed

- **New** `src/renderer/src/components/settings/claude-account-auth-warning.ts` — `getClaudeSystemDefaultSignInWarning`, mirroring `getCodexAccountAuthWarning`: true only when the system-default login is the active selection, the usage snapshot target matches the viewed runtime, and the snapshot reports the `signed-out` failure kind.
- `AccountsPane.tsx` derives `systemClaudeNeedsSignIn` from the local snapshot (`limits: isRemoteAccountScope ? null : claudeRateLimits`, so remote owners never inherit the desktop reading) and passes it into the section model.
- `accounts-pane-claude-section.tsx`: the System default row gets the Codex treatment — destructive border plus the existing "Needs sign-in" badge (`AccountsPane.93c47b333a`, reused, no new strings).
- Stacked on #20120, which introduces the `signed-out` snapshot this consumes (branch contains its commits until it merges; diff narrows automatically).

## Why

Two components had two definitions of "logged in": the usage fetcher verified tokens while the Accounts pane asserted the environment login works without checking. Users saw "Active" in Settings and a dead meter with no path between them. Now both surfaces agree.

## Linked Issue

Fixes #20131. Depends on #20120 — merge that first; this diff then narrows to the Accounts-pane commits.

## Visual Proof

No screenshots: headless Linux worktree, affected surface is desktop Settings. Verified via unit tests (warning derivation incl. target-mismatch and remote-scope suppression) and the shared-badge render path already exercised by the Codex section. Happy to attach macOS shots on request.

## Testing

- [ ] I manually tested these changes locally (headless worktree — see above)
- [x] Automated tests added (`claude-account-auth-warning.test.ts`: signed-out→warn, managed-selection/other-kinds/non-error→quiet, target mismatch→quiet, remote scope handled by null limits at the call site)
- Platforms: Linux unit/typecheck. Change is renderer-only, platform-agnostic, no new strings/locales, no new host assumptions (remote scope explicitly suppressed).

## AI Disclosure

Implemented with Muse Spark via the Pi coding agent under the author's direction.

## Review

Self-review (AI agent): mirrors the existing Codex warning path field-for-field (same badge key, same border classes, same remote-scope nulling); snapshot→row attribution guarded by target matching; no secrets touched (reads only status/failureKind); no perf impact (one store selector + boolean derivation on render).

## Agent skill upstream boundary

- [x] Not applicable — no skill sources copied or translated.

## Notes

Security, cross-platform, remote SSH (explicitly suppressed for remote owners per #7973), backwards compatibility, performance considered above. Mobile untouched.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason (see Visual Proof)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint` (changed-code quality gate: 0 findings), `pnpm typecheck`, `pnpm test` pass locally (`pnpm build` covered on the base branch; renderer-only delta)
