### PR TITLE
test(relay): harden regional rehome race coverage

### DIFF
--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -6601,6 +6601,7 @@ export class RelayAssignmentStore {
         })
         .catch((error: unknown): boolean => {
           // Expiry is durable; another director settling this row is not a failure.
+          // Invariant failures remain fatal so operators see corrupt migration state.
           if (!isDatabaseLockUnavailable(error)) throw error
           inventoryBusy++
           return false

--- a/cloud/apps/relay/src/regional-rehome-store.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-store.test.ts
@@ -1714,7 +1714,7 @@ function hookAfterCandidateScan(
   const decorate = (delegate: RelayDatabase): RelayDatabase => ({
     query: async (sql, params) => {
       const rows = await delegate.query(sql, params)
-      if (!fired && sql.includes('FROM relay_region_rehome_control policy')) {
+      if (!fired && sql.includes('SELECT a.user_id, a.relay_host_id')) {
         fired = true
         await hook(delegate)
       }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

Follow-up to #20105. Use a stable production-query anchor in the scan/claim race test and document why invariant failures remain fatal during expired-migration cleanup. No behavior change to the idle cutover path.