### PR TITLE
fix(ui): stop synthesizing the caffeinate badge's active state from settings

### DIFF
--- a/src/renderer/src/components/status-bar/CaffeinateStatusSegment.truth.test.tsx
+++ b/src/renderer/src/components/status-bar/CaffeinateStatusSegment.truth.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CaffeinateStatusSegment } from './CaffeinateStatusSegment'
+
+const storeMocks = vi.hoisted(() => ({
+  settings: {
+    computerAwakeMode: 'on',
+    keepComputerAwakeWhileAgentsRun: true
+  },
+  updateSettings: vi.fn()
+}))
+
+const awakeMocks = vi.hoisted(() => ({
+  status: { mode: 'on', active: true },
+  unsubscribe: vi.fn(),
+  getStatus: vi.fn(),
+  onChangedHandler: undefined as ((status: { mode: string; active: boolean }) => void) | undefined
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ settings: storeMocks.settings, updateSettings: storeMocks.updateSettings })
+}))
+
+vi.mock('@/lib/desktop-window-chrome', () => ({
+  isPairedWebClientWindow: () => false
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div role="tooltip">{children}</div>
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div role="menu">{children}</div>,
+  DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuRadioGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuRadioItem: ({ children }: { children: ReactNode }) => (
+    <div role="menuitemradio" aria-checked="false">
+      {children}
+    </div>
+  ),
+  DropdownMenuSeparator: () => <hr />
+}))
+
+beforeEach(() => {
+  storeMocks.settings = {
+    computerAwakeMode: 'on',
+    keepComputerAwakeWhileAgentsRun: true
+  }
+  awakeMocks.status = { mode: 'on', active: true }
+  awakeMocks.unsubscribe.mockClear()
+  awakeMocks.onChangedHandler = undefined
+  // getStatus never resolves within these tests unless a test awaits it explicitly - this lets
+  // us assert the pre-first-status render without racing a real promise resolution.
+  awakeMocks.getStatus.mockReset()
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      agentAwake: {
+        getStatus: awakeMocks.getStatus,
+        onChanged: vi.fn().mockImplementation((handler) => {
+          awakeMocks.onChangedHandler = handler
+          return awakeMocks.unsubscribe
+        })
+      }
+    }
+  })
+})
+
+afterEach(cleanup)
+
+describe('CaffeinateStatusSegment status truth', () => {
+  it('does not flash Inactive before the first status arrives when configured mode is on', async () => {
+    // getStatus deliberately never resolves in this test - only the pre-status render is asserted.
+    awakeMocks.getStatus.mockReturnValue(new Promise(() => {}))
+
+    render(<CaffeinateStatusSegment iconOnly={false} />)
+
+    const trigger = await screen.findByRole('button')
+    expect(trigger.getAttribute('aria-label')).toContain('Active')
+    expect(trigger.getAttribute('aria-label')).not.toContain('Inactive')
+  })
+
+  it('reports Inactive once the service disagrees with an "on" configured setting', async () => {
+    awakeMocks.getStatus.mockResolvedValue({ mode: 'off', active: false })
+
+    render(<CaffeinateStatusSegment iconOnly={false} />)
+
+    const trigger = await screen.findByRole('button')
+    await vi.waitFor(() => {
+      expect(trigger.getAttribute('aria-label')).toContain('Inactive')
+    })
+    expect(trigger.getAttribute('aria-label')).not.toContain('· Active')
+  })
+
+  it('reports Inactive when a later onChanged push disagrees with the configured setting', async () => {
+    awakeMocks.getStatus.mockResolvedValue({ mode: 'on', active: true })
+
+    render(<CaffeinateStatusSegment iconOnly={false} />)
+
+    const trigger = await screen.findByRole('button')
+    await vi.waitFor(() => {
+      expect(trigger.getAttribute('aria-label')).toContain('· Active')
+    })
+
+    awakeMocks.onChangedHandler?.({ mode: 'off', active: false })
+
+    await vi.waitFor(() => {
+      expect(trigger.getAttribute('aria-label')).toContain('Inactive')
+    })
+  })
+})

--- a/src/renderer/src/components/status-bar/CaffeinateStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/CaffeinateStatusSegment.tsx
@@ -44,12 +44,14 @@ export function CaffeinateStatusSegment({
     settings?.keepComputerAwakeWhileAgentsRun
   )
   const [serviceStatus, setServiceStatus] = useState<ComputerAwakeStatus>(INACTIVE_STATUS)
+  const [hasServiceStatus, setHasServiceStatus] = useState(false)
 
   useEffect(() => {
     let mounted = true
     const unsubscribe = window.api.agentAwake.onChanged((status) => {
       if (mounted) {
         setServiceStatus(status)
+        setHasServiceStatus(true)
       }
     })
     void window.api.agentAwake
@@ -57,6 +59,7 @@ export function CaffeinateStatusSegment({
       .then((status) => {
         if (mounted) {
           setServiceStatus(status)
+          setHasServiceStatus(true)
         }
       })
       .catch(() => {})
@@ -70,9 +73,11 @@ export function CaffeinateStatusSegment({
     return null
   }
 
-  const mode = serviceStatus.mode === configuredMode ? serviceStatus.mode : configuredMode
-  const active =
-    serviceStatus.mode === configuredMode ? serviceStatus.active : configuredMode === 'on'
+  // Before the first real status arrives, show the configured setting optimistically to avoid
+  // an inactive flash. Once the service has reported in, its `active` value is the truth — never
+  // synthesize activity from the setting alone, or a real outage would read as "Active".
+  const mode = configuredMode
+  const active = hasServiceStatus ? serviceStatus.active : configuredMode === 'on'
   const title = getAgentAwakeTitle()
   const statusText = `${getAgentAwakeModeLabel(mode)} · ${activityLabel(active)}`
   const ariaLabel = translate(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## What broke

The "Keep computer awake" status badge reported the **setting**, not the **state**.

Measured on a real machine: the badge read **On · Active** for 15h49m while `pmset -g assertions` showed Orca owned no sleep assertion at all and the Mac idle-slept repeatedly under running agents. Nothing in the UI ever indicated a problem.

## Mechanism

```ts
const mode = serviceStatus.mode === configuredMode ? serviceStatus.mode : configuredMode
const active =
  serviceStatus.mode === configuredMode ? serviceStatus.active : configuredMode === 'on'
```

When the main-process `AgentAwakeService` reports a mode that disagrees with the persisted setting — which is exactly what a dead or never-armed service does, since the IPC returns `{mode:'off', active:false}` — the renderer discards the real status and **synthesizes** `active` from the setting. A service holding nothing therefore displays "Active" indefinitely.

## Why the fallback existed

`serviceStatus` starts at `INACTIVE_STATUS` and is only replaced once the async `getStatus()` IPC resolves. Without a fallback the badge would flash "Off · Inactive" on every mount. That flash-avoidance is legitimate and is preserved.

## The fix

Distinguish *no status yet* from *service disagrees with the setting*:

- `hasServiceStatus` is set in both the `onChanged` subscription and the `getStatus()` resolution.
- Before the first real status: show the configured setting optimistically (unchanged, no flash).
- After: `serviceStatus.active` is authoritative. Never synthesized from the setting again.

`mode` is now plainly `configuredMode`. That is a no-op simplification, not a behavior change — the old ternary returned `configuredMode` in both branches.

## Ablation

Reverting only the two derived lines, keeping the new tests:

```
× reports Inactive once the service disagrees with an "on" configured setting
× reports Inactive when a later onChanged push disagrees with the configured setting
  Tests  2 failed | 1 passed (3)
```

Both failures are the exact field bug: `expected 'Keep computer awake, On · Active' to contain 'Inactive'`. Restored: 3 passed. The no-flash test stays green in both arms by design — that path is not touched by the reverted line.

Ablation was run independently twice, by the implementing agent and again by the reviewer.

## Validation

- New `CaffeinateStatusSegment.truth.test.tsx` — 3 tests: no-flash before first status, disagreement via initial fetch, disagreement via later push
- Sibling `CaffeinateStatusSegment.localization.test.tsx` — 5 passed, no regression
- `pnpm tc` — clean (verified from output, not just exit code)
- `pnpm run check:code-quality:changed` — 0 new findings across code quality, type-aware, and React Doctor

## Scope

One of four independent defects in this subsystem. This one did not cause the outage — it **hid** it. Companion: #20130 (assertion liveness).