### PR TITLE
fix(main): dispose the agent-awake service on committed quit, not attempted quit

### DIFF
--- a/src/main/quit-teardown-agent-awake-service.test.ts
+++ b/src/main/quit-teardown-agent-awake-service.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * `before-quit` fires on attempted quits, not committed ones — a renderer beforeunload can
+ * still veto it. Disposing the agent-awake service there killed the macOS `caffeinate`
+ * assertion for the rest of the session on a vetoed quit, with no reconstruction path
+ * (main-process-observers.ts only constructs it once, at app-ready). Follows the same
+ * committed-quit precedent already used for the Windows tray icon.
+ */
+const source = readFileSync(join(__dirname, 'startup', 'main-process-quit.ts'), 'utf8')
+
+function handlerBody(eventName: string, nextEventName: string): string {
+  const start = source.indexOf(`app.on('${eventName}'`)
+  const end = source.indexOf(`app.on('${nextEventName}'`, start)
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('quit teardown of the agent-awake service', () => {
+  it('is untouched by a vetoable before-quit', () => {
+    const beforeQuit = handlerBody('before-quit', 'will-quit')
+    expect(beforeQuit).not.toContain('agentAwakeService')
+    expect(beforeQuit).not.toContain('unsubscribeAgentAwakeStatusChanges')
+  })
+
+  it('is disposed exactly once, after the will-quit commit gate', () => {
+    const willQuit = handlerBody('will-quit', 'window-all-closed')
+    const commitIndex = willQuit.indexOf('quitTeardownStartGate.tryStart(event)')
+    const unsubscribeIndex = willQuit.indexOf('state.unsubscribeAgentAwakeStatusChanges?.()')
+    const disposeIndex = willQuit.indexOf('state.agentAwakeService?.dispose()')
+
+    expect(commitIndex).toBeGreaterThanOrEqual(0)
+    expect(unsubscribeIndex).toBeGreaterThan(commitIndex)
+    expect(disposeIndex).toBeGreaterThan(unsubscribeIndex)
+    // Why: proves there's no second, earlier-returning duplicate of the teardown in this handler.
+    expect(willQuit.match(/state\.agentAwakeService\?\.dispose\(\)/g)).toHaveLength(1)
+  })
+})

--- a/src/main/startup/main-process-quit.ts
+++ b/src/main/startup/main-process-quit.ts
@@ -73,10 +73,6 @@ function installBeforeQuitHandler(): void {
     state.isQuitting = true
     state.desktopRelayService?.fenceAndCloseNow()
     state.runtimeRpc?.setMobileRelayPairingProvider(null)
-    state.unsubscribeAgentAwakeStatusChanges?.()
-    state.unsubscribeAgentAwakeStatusChanges = null
-    state.agentAwakeService?.dispose()
-    state.agentAwakeService = null
     // Why wait but not uninstall: a renderer beforeunload can still veto this
     // quit, and tearing the sweep down here would kill it for the rest of the
     // session. `isQuitting` already vetoes new attempts; will-quit does the teardown.
@@ -119,8 +115,14 @@ function installWillQuitHandler(): void {
         { message: 'will-quit cleanup for update install; daemonTeardown=disconnect' }
       )
     }
-    // Why: before-quit can still be aborted by renderer beforeunload; only remove the Windows tray icon on the committed quit path.
+    // Why: before-quit can still be aborted by renderer beforeunload; only remove the Windows tray icon
+    // and dispose the caffeinate assertion on the committed quit path — disposing on the vetoed path
+    // would silently stop "keep computer awake" for the rest of the session.
     destroySystemTray()
+    state.unsubscribeAgentAwakeStatusChanges?.()
+    state.unsubscribeAgentAwakeStatusChanges = null
+    state.agentAwakeService?.dispose()
+    state.agentAwakeService = null
     // Why: an agent still working at quit gets no terminating hook, so stats.flushAsync() closes those sessions out synchronously (only the write is deferred) — otherwise their duration is lost.
     state.starNag?.stop()
     state.automations?.stop()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## What broke

`before-quit` fires on **attempted** quits, not committed ones — a renderer `beforeunload` can still veto it. The awake-service teardown ran there unconditionally:

```ts
state.unsubscribeAgentAwakeStatusChanges?.()
state.unsubscribeAgentAwakeStatusChanges = null
state.agentAwakeService?.dispose()   // kills the macOS caffeinate child
state.agentAwakeService = null       // and nothing ever rebuilds it
```

`main-process-observers.ts:30` is the **only** construction site in the codebase and runs once at app-ready. So on a vetoed quit the app keeps running with the assertion killed and the service permanently null: "Keep computer awake" silently does nothing for the rest of the session, and the machine sleeps under running agents.

## This is completing an existing migration, not a new pattern

On `main`, the sibling power teardown is already handled correctly:

| Teardown | Handler on `main` |
|---|---|
| `unsubscribeSystemResumeBroadcast` | `will-quit` (committed) — pinned by a test |
| `agentAwakeService.dispose()` | `before-quit` (vetoable) |

Both are registered together in `main-process-observers`. The resume broadcast was moved to the committed path and guarded by `desktop-startup-ordering.test.ts:375` ("keeps the power bridge through vetoable before-quit and disposes after commit"); the awake service four lines away was left behind.

The file states the hazard twice in its own comments — at the sweep teardown ("a renderer beforeunload can still veto this quit") and at the tray icon ("only remove the Windows tray icon on the committed quit path"). Both are guarded. This one was not.

## The fix

Move the unsubscribe/dispose to `installWillQuitHandler`, beside `destroySystemTray()`, behind the existing `quitTeardownStartGate.tryStart(event)` commit gate and the once-only guard already wrapping that body. No new "is the quit committed?" mechanism, no re-initialization path. Release on real exit is preserved — no caffeinate leaks past app exit.

## Ablation

Restoring only `main-process-quit.ts` to `origin/main` and keeping the new test:

```
× is untouched by a vetoable before-quit
× is disposed exactly once, after the will-quit commit gate
  Tests  2 failed (2)
```

With the fix: 2 passed. Run independently twice, by the implementing agent and again by the reviewer.

## On the test shape

It is source-text region scanning, which matches the established convention for these `app.on` handlers — `desktop-startup-ordering.test.ts` uses `readFileSync` 31 times, and the power-bridge precedent at line 375 asserts the same way: slice between `app.on(...)` boundaries, require the symbol absent from `before-quit`, and require its index in `will-quit` to follow `quitTeardownStartGate.tryStart(event)`. The new test mirrors that mechanism, and additionally pins the dispose call to exactly one occurrence so no earlier-returning duplicate can creep in.

## Validation

- `pnpm test src/main/quit-teardown-agent-awake-service.test.ts` — 2 passed
- With precedent suites (`desktop-startup-ordering`, `quit-teardown-agent-browser-daemons`) — 21 passed
- `pnpm tc` — clean (verified from output, not just exit code)
- `pnpm run check:code-quality:changed` — 0 new findings
- `agent-awake-service.ts` untouched (it sits at exactly the 300-line `max-lines` cap)

## Scope

One of four independent defects in this subsystem. This one is **latent** — it did not cause the measured outage, which followed a committed auto-update quit. It is a second, independent path to the identical dead-service state. Companions: #20130 (assertion liveness, the actual cause), #20143 (badge reporting the setting instead of the state, which hid it).