### PR TITLE
feat(terminal): seed MacPorts /opt/local when port is installed

### DIFF
--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -3,6 +3,12 @@ import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const isMacPortsPortExecutablePresent = vi.hoisted(() => vi.fn(() => false))
+
+vi.mock('../../shared/macports-port-executable', () => ({
+  isMacPortsPortExecutablePresent
+}))
+
 vi.mock('electron', () => {
   const paths = new Map<string, string>([['appData', '/tmp/app-data']])
   return {
@@ -41,6 +47,7 @@ describe('patchPackagedProcessPath', () => {
   }
 
   afterEach(() => {
+    isMacPortsPortExecutablePresent.mockReturnValue(false)
     if (originalPlatform) {
       Object.defineProperty(process, 'platform', originalPlatform)
     }
@@ -96,6 +103,29 @@ describe('patchPackagedProcessPath', () => {
     expect(segments).toContain('/nix/var/nix/profiles/default/bin')
     expect(segments).toContain('/opt/homebrew/bin')
     expect(segments).toContain('/usr/local/bin')
+    expect(segments).not.toContain('/opt/local/bin')
+    expect(segments).not.toContain('/opt/local/sbin')
+  })
+
+  it('seeds MacPorts dirs on packaged darwin runs only when port is executable', async () => {
+    const { app } = await import('electron')
+    const { patchPackagedProcessPath } = await import('./configure-process')
+
+    setPlatform('darwin')
+    Object.defineProperty(app, 'isPackaged', { configurable: true, value: true })
+    process.env.HOME = '/Users/tester'
+    process.env.PATH = '/usr/bin:/bin'
+    isMacPortsPortExecutablePresent.mockReturnValue(true)
+
+    patchPackagedProcessPath()
+
+    const segments = (process.env.PATH ?? '').split(':')
+    expect(segments).toContain('/opt/local/bin')
+    expect(segments).toContain('/opt/local/sbin')
+    expect(segments.indexOf('/usr/local/sbin')).toBeLessThan(segments.indexOf('/opt/local/bin'))
+    expect(segments.indexOf('/opt/local/sbin')).toBeLessThan(
+      segments.indexOf('/nix/var/nix/profiles/default/bin')
+    )
   })
 
   it('keeps snap, Linuxbrew, and Nix dirs for packaged linux runs', async () => {
@@ -113,6 +143,8 @@ describe('patchPackagedProcessPath', () => {
     expect(segments).toContain('/snap/bin')
     expect(segments).toContain('/home/linuxbrew/.linuxbrew/bin')
     expect(segments).toContain('/nix/var/nix/profiles/default/bin')
+    expect(segments).not.toContain('/opt/local/bin')
+    expect(segments).not.toContain('/opt/local/sbin')
     expect(segments.indexOf('/usr/local/sbin')).toBeLessThan(segments.indexOf('/snap/bin'))
     expect(segments.indexOf('/home/linuxbrew/.linuxbrew/bin')).toBeLessThan(
       segments.indexOf('/nix/var/nix/profiles/default/bin')
@@ -133,6 +165,8 @@ describe('patchPackagedProcessPath', () => {
     const segments = (process.env.PATH ?? '').split(':')
     expect(segments).not.toContain('/snap/bin')
     expect(segments).not.toContain('/home/linuxbrew/.linuxbrew/bin')
+    expect(segments).not.toContain('/opt/local/bin')
+    expect(segments).not.toContain('/opt/local/sbin')
     expect(segments).toContain('/nix/var/nix/profiles/default/bin')
     expect(segments).toContain('/usr/local/bin')
   })
@@ -140,25 +174,33 @@ describe('patchPackagedProcessPath', () => {
   // Why derived, not a second literal: system-cli-install-dirs.ts documents its
   // order as matching this seed's system block, and hardcoding the order in the
   // fallback's own test lets a reorder here break that parity while both stay green.
-  it('seeds the system block in the order the install-dir fallback expects', async () => {
-    const { app } = await import('electron')
-    const { patchPackagedProcessPath } = await import('./configure-process')
-    const { getSystemCliInstallDirectories } = await import('../../shared/system-cli-install-dirs')
+  it.each([
+    { platform: 'linux' as const, home: '/home/tester' },
+    { platform: 'darwin' as const, home: '/Users/tester' }
+  ])(
+    'seeds the system block in the order the install-dir fallback expects on $platform',
+    async ({ platform, home }) => {
+      const { app } = await import('electron')
+      const { patchPackagedProcessPath } = await import('./configure-process')
+      const { getSystemCliInstallDirectories } =
+        await import('../../shared/system-cli-install-dirs')
 
-    setPlatform('linux')
-    Object.defineProperty(app, 'isPackaged', { configurable: true, value: true })
-    process.env.HOME = '/home/tester'
-    process.env.PATH = '/usr/bin:/bin'
+      setPlatform(platform)
+      Object.defineProperty(app, 'isPackaged', { configurable: true, value: true })
+      process.env.HOME = home
+      process.env.PATH = '/usr/bin:/bin'
+      isMacPortsPortExecutablePresent.mockReturnValue(platform === 'darwin')
 
-    patchPackagedProcessPath()
+      patchPackagedProcessPath()
 
-    const segments = (process.env.PATH ?? '').split(':')
-    const offsets = getSystemCliInstallDirectories('linux', '/home/tester').map((directory) =>
-      segments.indexOf(directory)
-    )
-    expect(offsets.every((offset) => offset >= 0)).toBe(true)
-    expect([...offsets].sort((a, b) => a - b)).toEqual(offsets)
-  })
+      const segments = (process.env.PATH ?? '').split(':')
+      const offsets = getSystemCliInstallDirectories(platform, home).map((directory) =>
+        segments.indexOf(directory)
+      )
+      expect(offsets.every((offset) => offset >= 0)).toBe(true)
+      expect([...offsets].sort((a, b) => a - b)).toEqual(offsets)
+    }
+  )
 
   // Why this ordering is load-bearing (#18234): a seed exists so a GUI-launched
   // Electron can *find* a tool, not to re-rank tools the user already has.

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { isMacPortsPortExecutablePresent } from '../../shared/macports-port-executable'
 import { getVersionManagerBinPaths } from '../codex-cli/command'
 import { getMainE2EConfig } from '../e2e-config'
 import { DISABLED_CHROMIUM_FEATURES } from './disabled-chromium-features'
@@ -145,6 +146,11 @@ export function patchPackagedProcessPath(): void {
 
   if (process.platform !== 'win32') {
     appendPaths.push('/opt/homebrew/bin', '/opt/homebrew/sbin', '/usr/local/bin', '/usr/local/sbin')
+
+    if (process.platform === 'darwin' && isMacPortsPortExecutablePresent()) {
+      // Why gated unlike Homebrew: Intel-Mac leftover after brew dropped Intel; don't seed /opt/local unless `port` is actually installed.
+      appendPaths.push('/opt/local/bin', '/opt/local/sbin')
+    }
 
     if (process.platform === 'linux') {
       // Why: snap and Linuxbrew ship on Linux only, so seeding them elsewhere adds phantom PATH entries every spawn must stat.

--- a/src/shared/agent-cli-install-dir-fallback.test.ts
+++ b/src/shared/agent-cli-install-dir-fallback.test.ts
@@ -99,6 +99,19 @@ describe('agent CLI install-dir fallback', () => {
     })
   })
 
+  it('finds a macOS CLI in /opt/local/bin only when port is executable', () => {
+    const home = '/Users/tester'
+    stage(join('/opt/local/bin', 'codex'))
+    expect(resolveAll(['codex'], { platform: 'darwin', homePath: home })).toEqual({
+      codex: 'codex'
+    })
+
+    stage(join('/opt/local/bin', 'port'))
+    expect(resolveAll(['codex'], { platform: 'darwin', homePath: home })).toEqual({
+      codex: join('/opt/local/bin', 'codex')
+    })
+  })
+
   it('finds Linux CLIs in Linuxbrew, snap and nix prefixes, not the macOS brew prefix', () => {
     const home = '/home/tester'
     stage(
@@ -203,6 +216,7 @@ describe('agent CLI install-dir fallback', () => {
       for (const directory of [
         '/opt/homebrew/bin',
         '/usr/local/bin',
+        '/opt/local/bin',
         '/snap/bin',
         '/home/linuxbrew/.linuxbrew/bin',
         '/nix/var/nix/profiles/default/bin',

--- a/src/shared/macports-port-executable.test.ts
+++ b/src/shared/macports-port-executable.test.ts
@@ -1,0 +1,42 @@
+import { accessSync, statSync } from 'node:fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isMacPortsPortExecutablePresent } from './macports-port-executable'
+
+vi.mock('node:fs', () => ({
+  accessSync: vi.fn(),
+  statSync: vi.fn(),
+  constants: { X_OK: 1 }
+}))
+
+const PORT_PATH = '/opt/local/bin/port'
+
+describe('isMacPortsPortExecutablePresent', () => {
+  afterEach(() => {
+    vi.mocked(statSync).mockReset()
+    vi.mocked(accessSync).mockReset()
+  })
+
+  it('is true for an executable file at the default MacPorts prefix', () => {
+    vi.mocked(statSync).mockReturnValue({ isFile: () => true } as ReturnType<typeof statSync>)
+    vi.mocked(accessSync).mockReturnValue(undefined)
+
+    expect(isMacPortsPortExecutablePresent()).toBe(true)
+    expect(statSync).toHaveBeenCalledWith(PORT_PATH)
+  })
+
+  it('is false when port is missing, not a file, or not executable', () => {
+    vi.mocked(statSync).mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+    expect(isMacPortsPortExecutablePresent()).toBe(false)
+
+    vi.mocked(statSync).mockReturnValue({ isFile: () => false } as ReturnType<typeof statSync>)
+    expect(isMacPortsPortExecutablePresent()).toBe(false)
+
+    vi.mocked(statSync).mockReturnValue({ isFile: () => true } as ReturnType<typeof statSync>)
+    vi.mocked(accessSync).mockImplementation(() => {
+      throw new Error('EACCES')
+    })
+    expect(isMacPortsPortExecutablePresent()).toBe(false)
+  })
+})

--- a/src/shared/macports-port-executable.ts
+++ b/src/shared/macports-port-executable.ts
@@ -1,0 +1,20 @@
+import { accessSync, constants, statSync } from 'node:fs'
+
+const MACPORTS_PORT_PATH = '/opt/local/bin/port'
+
+/**
+ * Default-prefix MacPorts sentinel. GUI PATH will not contain `/opt/local` yet,
+ * so a PATH lookup cannot see it. Only `/opt/local/bin/port` — a custom prefix
+ * under `/usr/local` is already on the seed.
+ */
+export function isMacPortsPortExecutablePresent(): boolean {
+  try {
+    if (!statSync(MACPORTS_PORT_PATH).isFile()) {
+      return false
+    }
+    accessSync(MACPORTS_PORT_PATH, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/shared/system-cli-install-dirs.ts
+++ b/src/shared/system-cli-install-dirs.ts
@@ -1,8 +1,9 @@
 import { join } from 'node:path'
+import { isMacPortsPortExecutablePresent } from './macports-port-executable'
 
 /**
  * Where an agent CLI lands when no version manager installed it: Homebrew (both
- * prefixes), npm's default global prefix, snap, nix, or the CLI's own installer
+ * prefixes), MacPorts, npm's default global prefix, snap, nix, or the CLI's own installer
  * (#829 named `~/.opencode/bin` and `~/.vite-plus/bin` as the motivating cases,
  * but only for the login-shell probe; the fallback used when that probe fails
  * never gained either).
@@ -45,6 +46,10 @@ export function getSystemCliInstallDirectories(
     directories.push('/opt/homebrew/bin')
   }
   directories.push('/usr/local/bin')
+  if (platform === 'darwin' && isMacPortsPortExecutablePresent()) {
+    // Why gated unlike Homebrew: Intel-Mac leftover; keep Homebrew/npm ranking and skip unless `port` exists.
+    directories.push('/opt/local/bin')
+  }
   if (platform === 'linux') {
     // Gated like the seed: snap and Linuxbrew ship on Linux only, so elsewhere they are phantom stats.
     directories.push('/snap/bin', '/home/linuxbrew/.linuxbrew/bin')


### PR DESCRIPTION
## ELI5

A terminal opened from the Dock does not get your shell PATH. Orca already tucks Homebrew into that short GUI PATH so `brew`-installed tools show up. It never did the same for MacPorts.

On Intel Macs that moved to MacPorts after Homebrew dropped official Intel support, tools live in `/opt/local/bin` and were invisible inside Orca unless you aliased them into `~/.local/bin`.

If `/opt/local/bin/port` is actually there, we now append `/opt/local/bin` (and `sbin`). If MacPorts is not installed, we add nothing.

## What Changed

- Packaged PATH seed (`patchPackagedProcessPath`) appends `/opt/local/bin` and `/opt/local/sbin` on darwin when the default `port` binary is executable.
- The CLI install-dir fallback stays in the same order, so a tool in two of these dirs resolves the same way in the seed and in detection.
- Linux / FreeBSD / Windows are unchanged. Homebrew ranking is unchanged (`/opt/local` sits after `/usr/local`).

## Why

Homebrew dropped official Intel support; MacPorts is the leftover prefix on those machines. The seed already knows Homebrew and `/usr/local`, so GUI-launched terminals could find brew tools but not MacPorts ones.

The existence gate is deliberate and unlike Homebrew: this is an Intel-Mac leftover, not a default install. Seeding a phantom `/opt/local` on every Mac would add a useless stat on every spawn. We look at `/opt/local/bin/port` on disk, not `which port` — GUI PATH cannot see MacPorts yet, so a PATH lookup would always miss.

A custom MacPorts prefix under `/usr/local` is already covered by the existing `/usr/local/bin` seed.

## Linked Issue

Fixes #20145

## Visual Proof

N/A — no UI. This only changes the packaged process PATH seed and the matching CLI install-dir list.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Covered:

- darwin seeds MacPorts dirs only when `port` is executable; omits them otherwise
- linux / freebsd never get `/opt/local`
- seed order still matches `getSystemCliInstallDirectories` on linux and darwin
- install-dir fallback finds a CLI in `/opt/local/bin` only after `port` is present
- `isMacPortsPortExecutablePresent` true/false cases (missing, not a file, not executable)

`pnpm test src/main/startup/configure-process.test.ts src/shared/agent-cli-install-dir-fallback.test.ts src/shared/macports-port-executable.test.ts` — 64 passed. Changed-code quality gate passed.

## Review

Cross-platform: darwin-only, behind `process.platform === 'darwin'`. Linux/Windows PATH seeds are untouched.

SSH / remote: the seed is local packaged-process PATH. Remote hosts keep their own PATH; this does not change SSH execution.

Agents / integrations: the install-dir fallback only gains `/opt/local/bin` when MacPorts is installed, after Homebrew/npm prefixes, so it cannot shadow a version-manager or `/usr/local` install.

Performance: one `stat`+`access` of `/opt/local/bin/port` at packaged startup, and the same check when resolving CLI install dirs. No hot-path work.

UI: none.

Security: append-only, and only if `port` is a real executable at the well-known prefix. Does not prepend, so it cannot re-rank tools already on PATH (#18234).

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No visual change. Login-shell PATH hydration still wins when it succeeds; this seed is the GUI-launch / hydration-failure fallback.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
