### PR TITLE
fix(source-control): pass the Antigravity prompt to agy --print

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -573,10 +573,23 @@ describe('buildArgs (OpenCode)', () => {
 describe('buildArgs (Antigravity)', () => {
   const spec = getCommitMessageAgentSpec('antigravity')!
 
-  it('runs agy with --print, --sandbox, and --model flags', () => {
-    const args = spec.buildArgs({ prompt: '', model: 'Gemini 3.5 Flash (Medium)' })
-    expect(args).toEqual(['--print', '--sandbox', '--model', 'Gemini 3.5 Flash (Medium)'])
-    expect(spec.promptDelivery).toBe('stdin')
+  it('runs agy with the prompt attached to --print, then --sandbox and --model flags', () => {
+    const args = spec.buildArgs({
+      prompt: 'real commit prompt',
+      model: 'Gemini 3.5 Flash (Medium)'
+    })
+    expect(args).toEqual([
+      '--print=real commit prompt',
+      '--sandbox',
+      '--model',
+      'Gemini 3.5 Flash (Medium)'
+    ])
+    expect(spec.promptDelivery).toBe('argv')
+  })
+
+  it('binds a leading-dash prompt to --print instead of letting it parse as an option', () => {
+    const args = spec.buildArgs({ prompt: '--sandbox', model: 'Gemini 3.5 Flash (Medium)' })
+    expect(args[0]).toBe('--print=--sandbox')
   })
 
   it('uses dynamic model discovery via agy models', () => {

--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -588,6 +588,15 @@ describe('buildArgs (Antigravity)', () => {
   })
 
   it('binds a leading-dash prompt to --print instead of letting it parse as an option', () => {
+    const args = spec.buildArgs({ prompt: '-fix: something', model: 'Gemini 3.5 Flash (Medium)' })
+    expect(args[0]).toBe('--print=-fix: something')
+  })
+
+  // Why: pins argv construction only. Real agy 1.2.1 separately rejects a --print value
+  // that exactly matches a registered flag name (its own heuristic, independent of this
+  // fix) — verified `agy --print=--sandbox` still errors there. Real prompts are never
+  // literally a bare flag name, so this doesn't affect actual generation.
+  it('still glues a prompt that collides with a flag name onto --print', () => {
     const args = spec.buildArgs({ prompt: '--sandbox', model: 'Gemini 3.5 Flash (Medium)' })
     expect(args[0]).toBe('--print=--sandbox')
   })

--- a/src/shared/commit-message-agent-specs-secondary.ts
+++ b/src/shared/commit-message-agent-specs-secondary.ts
@@ -212,8 +212,11 @@ export function buildSecondaryCommitMessageAgentSpecs({
       id: 'antigravity',
       label: 'Antigravity',
       binary: 'agy',
-      promptDelivery: 'stdin',
-      buildArgs: ({ model }) => ['--print', '--sandbox', '--model', model],
+      // agy's --print takes the prompt as its value (#19539, #14059). Deliver on argv
+      // using `--print=<value>` so a leading-dash prompt binds to the flag instead of
+      // being parsed as its own option, and --sandbox/--model stay separate options.
+      promptDelivery: 'argv',
+      buildArgs: ({ prompt, model }) => [`--print=${prompt}`, '--sandbox', '--model', model],
       modelSource: 'dynamic',
       modelDiscovery: { binary: 'agy', args: ['models'], parse: parseAntigravityModels },
       models: [

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -201,6 +201,23 @@ describe('planCommitMessageGeneration', () => {
   it('keeps a leading-dash Antigravity prompt bound to --print instead of the sandbox flag', () => {
     const result = planCommitMessageGeneration(
       { agentId: 'antigravity', model: 'Gemini 3.5 Flash (Medium)' },
+      '-fix: something'
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.plan.args.slice(0, 2)).toEqual([
+      '--print=-fix: something',
+      '--sandbox'
+    ])
+  })
+
+  // Why: pins argv construction only. Real agy 1.2.1 separately rejects a --print value
+  // that exactly matches a registered flag name (its own heuristic, independent of this
+  // fix) — verified `agy --print=--sandbox` still errors there. Real prompts are never
+  // literally a bare flag name, so this doesn't affect actual generation.
+  it('still glues an Antigravity prompt that collides with a flag name onto --print', () => {
+    const result = planCommitMessageGeneration(
+      { agentId: 'antigravity', model: 'Gemini 3.5 Flash (Medium)' },
       '--sandbox'
     )
 

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -178,6 +178,98 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
+  it('plans Antigravity generation with the prompt attached to --print, not stdin (#19539, #14059)', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'antigravity',
+        model: 'Gemini 3.5 Flash (Medium)'
+      },
+      'real commit prompt'
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        binary: 'agy',
+        args: ['--print=real commit prompt', '--sandbox', '--model', 'Gemini 3.5 Flash (Medium)'],
+        stdinPayload: null,
+        label: 'Antigravity'
+      }
+    })
+  })
+
+  it('keeps a leading-dash Antigravity prompt bound to --print instead of the sandbox flag', () => {
+    const result = planCommitMessageGeneration(
+      { agentId: 'antigravity', model: 'Gemini 3.5 Flash (Medium)' },
+      '--sandbox'
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.plan.args.slice(0, 2)).toEqual(['--print=--sandbox', '--sandbox'])
+  })
+
+  // Why: agy has no documented stdin mode for --print (#19539's body: "--print ... is
+  // not a boolean flag that automatically reads from stdin; it expects the prompt
+  // string as its option argument"), so a large staged patch now rides on argv. This
+  // is the same unguarded argv delivery cursor/kimi/copilot already use (see the
+  // parity assertion below) — pinned here as a known property, not a regression.
+  it('puts a large Antigravity prompt on argv with no size guard, same as other argv-delivery agents', () => {
+    const bigPrompt = 'y'.repeat(70_000)
+    const result = planCommitMessageGeneration(
+      { agentId: 'antigravity', model: 'Gemini 3.5 Flash (Medium)' },
+      bigPrompt
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.ok && result.plan.args[0]).toBe(`--print=${bigPrompt}`)
+    expect(result.ok && result.plan.stdinPayload).toBeNull()
+
+    const cursorResult = planCommitMessageGeneration(
+      { agentId: 'cursor', model: 'auto' },
+      bigPrompt
+    )
+    expect(cursorResult.ok).toBe(true)
+    expect(cursorResult.ok && cursorResult.plan.args.at(-1)).toBe(bigPrompt)
+    expect(cursorResult.ok && cursorResult.plan.stdinPayload).toBeNull()
+  })
+
+  // Why: real #14059 reproduction config — CLI arguments field repeats --model and adds
+  // --add-dir/--effort/--dangerously-skip-permissions. Confirms none of it gets swallowed
+  // into the --print operand and the duplicate --model is deduped the same way every
+  // other spec's recipe args already are (DEFAULT_SINGLETON_OPTIONS, unaffected by
+  // argument order).
+  it('keeps #14059-style recipe CLI arguments intact and deduped around the print operand', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'antigravity',
+        model: 'Gemini 3.5 Flash (Medium)',
+        agentArgs:
+          '--add-dir . --model gemini-3.6-flash --effort low --dangerously-skip-permissions'
+      },
+      'Generate a concise git commit message for the currently staged changes.'
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        binary: 'agy',
+        args: [
+          '--print=Generate a concise git commit message for the currently staged changes.',
+          '--sandbox',
+          '--model',
+          'gemini-3.6-flash',
+          '--add-dir',
+          '.',
+          '--effort',
+          'low',
+          '--dangerously-skip-permissions'
+        ],
+        stdinPayload: null,
+        label: 'Antigravity'
+      }
+    })
+  })
+
   it('plans Codex exec as non-interactive read-only generation with the prompt on stdin only', () => {
     const result = planCommitMessageGeneration(
       {

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -198,7 +198,7 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
-  it('keeps a leading-dash Antigravity prompt bound to --print instead of the sandbox flag', () => {
+  it('keeps a leading-dash Antigravity prompt bound to --print instead of parsing as an option', () => {
     const result = planCommitMessageGeneration(
       { agentId: 'antigravity', model: 'Gemini 3.5 Flash (Medium)' },
       '-fix: something'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​135 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## In plain terms

If you asked Orca to write your commit message using "Antigravity" (the `agy` CLI) as the AI agent, it either produced a nonsense commit message or just failed outright with a confusing error. That's because Orca was accidentally handing `agy` the wrong piece of text as the actual prompt — it gave `agy` the word `--sandbox` (an unrelated setting) instead of the real instructions to write a commit message, so `agy` either used that garbage as its "prompt" or refused to run at all. This fix makes Orca pass the real prompt to `agy` correctly, the same way `agy` itself documents. Now picking Antigravity for commit-message generation actually generates a commit message from your real changes, instead of erroring or producing garbage.

## Summary

- `agy`'s `--print` flag takes the prompt as its **operand**, not from stdin. The old spec sent `['--print', '--sandbox', '--model', model]` with the prompt piped to stdin, so `--print` consumed the literal string `--sandbox` as its prompt argument. Older `agy` builds silently generated from that garbage prompt; current `agy` (1.2.1) detects the misparse and exits 2 with `Error: --print took "--sandbox" as its prompt...`.
- Fix: `promptDelivery: 'argv'` with `buildArgs: ({ prompt, model }) => ['--print=' + prompt, '--sandbox', '--model', model]`. The `--print=<value>` combined form is exactly what agy's own error message recommends, and it keeps a leading-dash prompt bound to the flag instead of letting it parse as a separate option.

## Known limitation (design boundary — read this)

Real `agy` 1.2.1 has its own separate heuristic that rejects `--print=<value>` when `<value>` is an **exact match for a registered flag name** (e.g. a prompt that is literally the string `--sandbox`) — this fires even with the corrected `--print=<value>` combined form; confirmed `agy --print=--sandbox` still errors there. This is a property of agy itself, independent of this fix — there's nothing this spec can do to neutralize it, since the value is byte-for-byte a flag name. It only matters for a prompt whose *entire* text equals a known flag string, which real diff-derived commit prompts never do (confirmed a merely leading-dash, non-flag-name prompt like `-fix: something` parses cleanly). Not a regression from this change; just the exact boundary of what `--print=<value>` protects against.

## Closure condition

- Fixes #19539: `agy --print` no longer swallows `--sandbox` as the prompt; the real Antigravity commit-message prompt reaches the model.
- Fixes #14059: the full real-world recipe config (`--add-dir . --model gemini-3.6-flash --effort low --dangerously-skip-permissions`) is preserved intact around the `--print=<prompt>` operand, with `--model` deduped the same way every other spec's recipe args already are.

## Verification (real `agy` 1.2.1 binary on this machine, no billed generation run)

Reproduced the bug with the **old** argv shape, confirming it hits the exact #19539 error:

```
$ echo "real commit prompt text" | agy --print --sandbox --model gemini-3.6-flash
Error: --print took "--sandbox" as its prompt, so the intended prompt was left as an argument and ignored.
Attach the prompt to the flag (--print='your prompt') and move --sandbox elsewhere on the command line.
EXIT: 2
```

Same reproduction using the real #14059 recipe args:

```
$ echo 'Generate a concise git commit message for the currently staged changes.' | agy --print --sandbox --model gemini-3.6-flash --add-dir . --effort low --dangerously-skip-permissions
Error: --print took "--sandbox" as its prompt, so the intended prompt was left as an argument and ignored.
EXIT: 2
```

End-to-end proof through the **real production code path** (`planCommitMessageGeneration` from `src/shared/commit-message-plan.ts`, piped straight into a real `spawnSync(plan.binary, plan.args)` against the installed `agy` binary, API key intentionally unset to stop short of a billed call):

```
PLAN binary: agy
PLAN args: ["--print=Generate a concise git commit message for the currently staged changes.","--sandbox","--model","gemini-3.6-flash","--add-dir",".","--effort","low","--dangerously-skip-permissions"]
PLAN stdinPayload: null
EXIT CODE: 1
STDOUT: 
STDERR: modelProvider is set to "gemini" in settings.json, but the GEMINI_API_KEY environment variable is not set. Set GEMINI_API_KEY to your Gemini API key, or remove "modelProvider" from settings.json to use the default backend.
```

No exit-2, no "as its prompt" error — the fixed argv clears parsing entirely and fails only at the (deliberately broken) auth stage, proving the whole pipeline from plan to spawn is correct.

The temporary probe test file used to produce this was not committed; unit tests in this PR (`commit-message-agent-spec.test.ts`, `commit-message-plan.test.ts`) cover the same argv shape as pure assertions, using a prompt (`-fix: something`) verified to parse cleanly against real agy for the "this is real protection" case, and a separately-labeled case pinning the flag-name-collision argv shape with a why-comment noting it does not claim real-agy safety.

## Visual proof (real Orca UI, real click, real `agy` subprocess)

Ran the actual dev build, set the "Commit message" AI recipe to **Antigravity** in Settings → Git & Source Control, staged a trivial change, and clicked the real "Generate commit message with AI" button. `GEMINI_API_KEY` was intentionally unset for this app instance to guarantee no billed generation could occur.

1. Antigravity selected as the commit-message agent in Settings:
   ![01-settings-antigravity-selected.png](https://github.com/user-attachments/assets/90a7ba96-0f26-4788-8a56-4d3ca25ad78b)
2. After clicking "Generate commit message with AI" — the panel shows `Antigravity CLI command failed with code 1: modelProvider is set to "gemini"... GEMINI_API_KEY environment variable is not set`, the same auth-stage error from the terminal verification above, **not** the old #19539 exit-2 "as its prompt" parse failure:
   ![02-generate-clicked-error.png](https://github.com/user-attachments/assets/227736be-b300-4679-bf74-674a4c354080)

This confirms the fix through the real UI surface end to end, short of the billed model call itself (deliberately excluded).

## Test plan

- [x] `npx vitest run --config config/vitest.config.ts src/shared/commit-message-agent-spec.test.ts src/shared/commit-message-plan.test.ts` — 77 passed
- [x] `oxlint` on changed files — clean
- [x] `oxfmt --check` on changed files — clean
- [x] `node config/scripts/run-typecheck-projects-in-parallel.mjs` — exit 0
- [x] Manual E2E against real `agy` 1.2.1 binary (see verification above)
- [x] Manual E2E through the real Orca UI (see visual proof above)

Fixes #19539
Fixes #14059
