### PR TITLE
fix(hooks): stop orphaned managed markers from consuming user TOML

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -11,6 +11,7 @@
     "../src/main/agent-hooks/installer-utils.ts",
     "../src/main/agent-hooks/installer-utils-remote.ts",
     "../src/main/agent-hooks/local-agent-cli-presence.ts",
+    "../src/main/agent-hooks/managed-toml-ownership.ts",
     "../src/main/agent-hooks/managed-agent-hook-controls.ts",
     "../src/main/agent-hooks/managed-agent-hook-registry.ts",
     "../src/main/agent-hooks/managed-hook-script-refresh.ts",

--- a/src/main/agent-hooks/managed-toml-ownership.test.ts
+++ b/src/main/agent-hooks/managed-toml-ownership.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findManagedTomlBlocks,
+  findRecognizedManagedTables,
+  stripManagedTomlRegions,
+  type ManagedTomlMarkers
+} from './managed-toml-ownership'
+
+const START = '# >>> start >>>'
+const END = '# <<< end <<<'
+const MARKERS: ManagedTomlMarkers = { startMarker: START, endMarker: END }
+
+// Recognizes an `[owned]` table plus its `k = ...` lines; anything else is user text.
+const recognizeOwned = (
+  lines: readonly string[],
+  index: number
+): { lineCount: number; value: string } | null => {
+  if (lines[index].trim() !== '[owned]') {
+    return null
+  }
+  let cursor = index + 1
+  while (cursor < lines.length && /^k\d* = /.test(lines[cursor].trim())) {
+    cursor++
+  }
+  return { lineCount: cursor - index, value: lines[index].trim() }
+}
+
+function strip(text: string): string {
+  return stripManagedTomlRegions(text, [
+    ...findManagedTomlBlocks(text, MARKERS),
+    ...findRecognizedManagedTables(text, recognizeOwned)
+  ]).text
+}
+
+describe('managed TOML marker blocks', () => {
+  it('finds nothing in a file without the start marker', () => {
+    expect(findManagedTomlBlocks('a = 1\n', MARKERS)).toEqual([])
+    expect(stripManagedTomlRegions('a = 1\n', [])).toMatchObject({
+      text: 'a = 1\n',
+      changed: false
+    })
+  })
+
+  it('owns everything between the markers regardless of content', () => {
+    const text = `a = 1\n\n${START}\n[whatever]\nx = 2\n${END}\nb = 3\n`
+    expect(findManagedTomlBlocks(text, MARKERS)[0].terminated).toBe(true)
+    expect(strip(text)).toBe('a = 1\nb = 3\n')
+  })
+
+  it('an orphaned block owns only its stray marker line', () => {
+    const text = `${START}\n[anything]\nkeep = true\n`
+    const [region] = findManagedTomlBlocks(text, MARKERS)
+    expect(region.terminated).toBe(false)
+    expect(stripManagedTomlRegions(text, [region]).text).toBe('[anything]\nkeep = true\n')
+  })
+
+  it('does not let a terminated block swallow a later stray start marker', () => {
+    const text = `${START}\n[owned]\nk = 1\n${END}\n${START}\n[user]\nkeep = true\n`
+    expect(findManagedTomlBlocks(text, MARKERS).map((region) => region.terminated)).toEqual([
+      true,
+      false
+    ])
+    expect(strip(text)).toBe('[user]\nkeep = true\n')
+  })
+
+  it('absorbs the blank run above the marker without crossing the block above', () => {
+    expect(strip(`a = 1\n\n\n${START}\nx\n${END}\n`)).toBe('a = 1\n')
+  })
+
+  // CodeRabbit on #20148: a prefix match let a user's own comment open or close
+  // a region, deleting every byte between two quoted markers.
+  it("ignores a marker line carrying a trailing comment of the user's own", () => {
+    const text = [
+      'a = 1',
+      `${START} (example from the docs)`,
+      '[user]',
+      'keep = true',
+      `${END} (end of example)`,
+      'b = 2'
+    ].join('\n')
+    expect(findManagedTomlBlocks(text, MARKERS)).toEqual([])
+    expect(strip(text)).toBe(text)
+  })
+
+  it('ignores a marker line with a prefix or altered text', () => {
+    for (const near of [`x ${START}`, START.replace('>>>', '>>'), `${START}x`]) {
+      expect(findManagedTomlBlocks(`${near}\n[user]\nkeep = true\n`, MARKERS)).toEqual([])
+    }
+  })
+
+  it('still matches a marker indented or with trailing whitespace', () => {
+    const text = `a = 1\n   ${START}   \n[owned]\nk = 1\n  ${END}\nb = 2\n`
+    expect(findManagedTomlBlocks(text, MARKERS)[0].terminated).toBe(true)
+    expect(strip(text)).toBe('a = 1\nb = 2\n')
+  })
+
+  it('handles a marker on the last line with no trailing newline', () => {
+    expect(strip(`a = 1\n${START}`)).toBe('a = 1\n')
+    expect(strip(`a = 1\n${START}\n[owned]\nk = 1`)).toBe('a = 1\n')
+  })
+})
+
+describe('recognized managed tables', () => {
+  it('reclaims a recognized table wherever it sits, and nothing else', () => {
+    const text = `[user]\nkeep = true\n\n[owned]\nk = 1\nk2 = 2\n\n[user2]\nalso = true\n`
+    expect(findRecognizedManagedTables(text, recognizeOwned)).toHaveLength(1)
+    expect(strip(text)).toBe('[user]\nkeep = true\n\n[user2]\nalso = true\n')
+  })
+
+  it('reclaims tables stranded below user text after an orphaned marker', () => {
+    const text = `${START}\n[owned]\nk = 1\n[user]\nkeep = true\n[owned]\nk = 2\n`
+    expect(strip(text)).toBe('[user]\nkeep = true\n')
+  })
+
+  it('leaves an unrecognized table alone', () => {
+    const text = `${START}\n[user]\nkeep = true\n`
+    expect(strip(text)).toBe('[user]\nkeep = true\n')
+  })
+
+  it('reports each recognized table to readers', () => {
+    const text = `[owned]\nk = 1\n[user]\nx = 1\n[owned]\nk = 2\n`
+    expect(findRecognizedManagedTables(text, recognizeOwned).map((t) => t.value)).toEqual([
+      '[owned]',
+      '[owned]'
+    ])
+  })
+
+  it('clamps a recognizer that claims more lines than the file has', () => {
+    const greedy = (): { lineCount: number; value: null } => ({ lineCount: 999, value: null })
+    const text = 'a = 1\n'
+    expect(stripManagedTomlRegions(text, findRecognizedManagedTables(text, greedy)).text).toBe('')
+  })
+})
+
+describe('splicing owned regions', () => {
+  it('merges a recognized table nested inside a marker block', () => {
+    const text = `a = 1\n${START}\n[owned]\nk = 1\n${END}\nb = 2\n`
+    const regions = [
+      ...findManagedTomlBlocks(text, MARKERS),
+      ...findRecognizedManagedTables(text, recognizeOwned)
+    ]
+    expect(regions).toHaveLength(2)
+    expect(stripManagedTomlRegions(text, regions).text).toBe('a = 1\nb = 2\n')
+  })
+
+  it('splices CRLF text back verbatim', () => {
+    expect(strip(`a = 1\r\n\r\n${START}\r\n[owned]\r\nk = 1\r\n${END}\r\nb = 2\r\n`)).toBe(
+      'a = 1\r\nb = 2\r\n'
+    )
+    expect(strip(`${START}\r\n[owned]\r\nk = 1\r\n[user]\r\nkeep = true\r\n`)).toBe(
+      '[user]\r\nkeep = true\r\n'
+    )
+  })
+})

--- a/src/main/agent-hooks/managed-toml-ownership.ts
+++ b/src/main/agent-hooks/managed-toml-ownership.ts
@@ -1,0 +1,161 @@
+// Orca appends marker-delimited blocks to user-owned TOML config files. Two
+// independent things can make a byte Orca's: it sits between a matched start and
+// end marker, or the provider positively recognizes it as content Orca emitted.
+// The end marker is the only proof of a block's extent, so once a hand-edit
+// deletes it the rest of the file is unknown text — #18861: assuming otherwise
+// deleted user tables through EOF. An orphaned block therefore owns nothing but
+// its own stray marker line, and anything Orca actually wrote is reclaimed by
+// recognition instead, wherever in the file it ended up.
+
+export type ManagedTomlMarkers = {
+  startMarker: string
+  endMarker: string
+}
+
+export type ManagedTomlRegion = {
+  /** First removable offset — includes the blank-line run above the content. */
+  startOffset: number
+  /** Offset one past the last owned line, terminator included. */
+  endOffset: number
+}
+
+export type ManagedTomlBlockRegion = ManagedTomlRegion & {
+  /** Offset of the start-marker line itself. */
+  markerOffset: number
+  /** End marker found: everything between the markers is Orca's. */
+  terminated: boolean
+}
+
+export type RecognizedManagedTable<T> = ManagedTomlRegion & { value: T }
+
+/** Line count of the table starting at `index` plus what the reader needs, or null. */
+export type ManagedTableRecognizer<T> = (
+  lines: readonly string[],
+  index: number
+) => { lineCount: number; value: T } | null
+
+type ScannedLine = {
+  text: string
+  offset: number
+  endOffset: number
+}
+
+// Keeps offsets on the raw text so CRLF terminators are spliced back verbatim.
+function scanLines(text: string): ScannedLine[] {
+  const lines: ScannedLine[] = []
+  let offset = 0
+  while (offset < text.length) {
+    const newlineIndex = text.indexOf('\n', offset)
+    const endOffset = newlineIndex === -1 ? text.length : newlineIndex + 1
+    lines.push({
+      text: text.slice(offset, endOffset).replace(/\r?\n$/, ''),
+      offset,
+      endOffset
+    })
+    offset = endOffset
+  }
+  return lines
+}
+
+// Absorb the blank run above so install/remove cycles do not accumulate
+// whitespace; overlapping runs are merged away by stripManagedTomlRegions.
+function startOffsetAbsorbingBlanksAbove(lines: readonly ScannedLine[], index: number): number {
+  let startLine = index
+  while (startLine > 0 && lines[startLine - 1].text.trim() === '') {
+    startLine--
+  }
+  return lines[startLine].offset
+}
+
+export function findManagedTomlBlocks(
+  text: string,
+  markers: ManagedTomlMarkers
+): ManagedTomlBlockRegion[] {
+  const lines = scanLines(text)
+  // Exact, not startsWith: a user quoting a marker in a comment of their own
+  // ("# >>> ... >>> (example from the docs)") would otherwise open or close a
+  // region and take every byte between the two quoted lines. Both emitters
+  // write the marker as its own line, so nothing legitimate carries a suffix.
+  const isStart = (index: number): boolean => lines[index].text.trim() === markers.startMarker
+  const isEnd = (index: number): boolean => lines[index].text.trim() === markers.endMarker
+
+  const regions: ManagedTomlBlockRegion[] = []
+  for (let index = 0; index < lines.length; index++) {
+    if (!isStart(index)) {
+      continue
+    }
+    let last = index
+    let terminated = false
+    for (let cursor = index + 1; cursor < lines.length; cursor++) {
+      // A second start marker never belongs to the block already open.
+      if (isStart(cursor)) {
+        break
+      }
+      if (isEnd(cursor)) {
+        last = cursor
+        terminated = true
+        break
+      }
+    }
+    // Not terminated: `last` stays on the marker line, so the orphan owns only
+    // the stray marker. Its body, if Orca wrote it, is reclaimed by recognition.
+    regions.push({
+      startOffset: startOffsetAbsorbingBlanksAbove(lines, index),
+      markerOffset: lines[index].offset,
+      endOffset: lines[last].endOffset,
+      terminated
+    })
+    index = last
+  }
+  return regions
+}
+
+/**
+ * Every table the provider recognizes as its own, anywhere in the file. Marker
+ * position is irrelevant: content Orca emitted is Orca's to remove even when a
+ * hand-edit stranded it outside the block (#18861).
+ */
+export function findRecognizedManagedTables<T>(
+  text: string,
+  recognize: ManagedTableRecognizer<T>
+): RecognizedManagedTable<T>[] {
+  const lines = scanLines(text)
+  const texts = lines.map((line) => line.text)
+  const tables: RecognizedManagedTable<T>[] = []
+  for (let index = 0; index < lines.length; index++) {
+    const match = recognize(texts, index)
+    if (!match || match.lineCount <= 0) {
+      continue
+    }
+    const last = Math.min(index + match.lineCount, lines.length) - 1
+    tables.push({
+      startOffset: startOffsetAbsorbingBlanksAbove(lines, index),
+      endOffset: lines[last].endOffset,
+      value: match.value
+    })
+    index = last
+  }
+  return tables
+}
+
+/** Splices every owned region out in one pass, merging overlaps and nesting. */
+export function stripManagedTomlRegions(
+  text: string,
+  regions: readonly ManagedTomlRegion[]
+): { text: string; changed: boolean } {
+  if (regions.length === 0) {
+    return { text, changed: false }
+  }
+  const ordered = [...regions].sort((a, b) => a.startOffset - b.startOffset)
+  let stripped = ''
+  let cursor = 0
+  for (const region of ordered) {
+    if (region.endOffset <= cursor) {
+      continue
+    }
+    stripped += text.slice(cursor, Math.max(cursor, region.startOffset))
+    cursor = region.endOffset
+  }
+  stripped += text.slice(cursor)
+  return { text: stripped, changed: stripped !== text }
+}

--- a/src/main/codex/codex-hook-legacy-cleanup.ts
+++ b/src/main/codex/codex-hook-legacy-cleanup.ts
@@ -9,6 +9,7 @@ import {
 } from '../agent-hooks/installer-utils'
 import { resolveHooksJsonWritePath } from '../agent-hooks/hook-config-write-path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
+import { findManagedTomlBlocks } from '../agent-hooks/managed-toml-ownership'
 import { writeConfigAtomically, type CodexTrustEntry } from './config-toml-trust'
 import {
   getConfigPath,
@@ -149,22 +150,37 @@ async function sweepLegacySystemManagedHooks(): Promise<void> {
   }
 }
 
-function stripLegacyManagedProfileBlock(content: string): string {
-  const start = content.indexOf(LEGACY_ORCA_PROFILE_BLOCK_START)
-  if (start === -1) {
+export function stripLegacyManagedProfileBlock(content: string): string {
+  const regions = findManagedTomlBlocks(content, {
+    startMarker: LEGACY_ORCA_PROFILE_BLOCK_START,
+    endMarker: LEGACY_ORCA_PROFILE_BLOCK_END
+  })
+  // A stray marker above a complete block must not hide it: take the first
+  // terminated region and leave the orphan (and the user text around it) alone.
+  const region = regions.find((candidate) => candidate.terminated) ?? regions[0]
+  if (!region) {
     return content
   }
-  const endMarker = content.indexOf(LEGACY_ORCA_PROFILE_BLOCK_END, start)
-  const end = endMarker === -1 ? content.length : endMarker + LEGACY_ORCA_PROFILE_BLOCK_END.length
-  const before = content.slice(0, start).replace(/[ \t]*(?:\r?\n)*$/, '')
-  const after = content.slice(end).replace(/^(?:\r?\n)+/, '')
+  if (!region.terminated) {
+    // #18861: deleting to EOF took user text appended below the block. This
+    // legacy body's shape is not knowable from current source, so there is
+    // nothing to recognize it by; leave the whole thing alone. The stale profile
+    // is inert (runtime CODEX_HOME supersedes it), so that costs nothing next to
+    // destroying the user's trust entries.
+    return content
+  }
+  // Rejoin with the file's own terminator; a bare \n seam here left Windows
+  // configs with mixed endings.
+  const eol = content.includes('\r\n') ? '\r\n' : '\n'
+  const before = content.slice(0, region.markerOffset).replace(/[ \t]*(?:\r?\n)*$/, '')
+  const after = content.slice(region.endOffset).replace(/^(?:\r?\n)+/, '')
   if (!before) {
     return after
   }
   if (!after) {
-    return before.endsWith('\n') ? before : `${before}\n`
+    return before.endsWith('\n') ? before : `${before}${eol}`
   }
-  return `${before}\n\n${after}`
+  return `${before}${eol}${eol}${after}`
 }
 
 function cleanupLegacyCodexProfileHooks(): void {

--- a/src/main/codex/codex-hook-legacy-profile-block.test.ts
+++ b/src/main/codex/codex-hook-legacy-profile-block.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { stripLegacyManagedProfileBlock } from './codex-hook-legacy-cleanup'
+
+const START = '# BEGIN ORCA AGENT STATUS HOOKS'
+const END = '# END ORCA AGENT STATUS HOOKS'
+
+describe('legacy Codex managed profile block', () => {
+  it('strips a well-formed block and keeps the surrounding config', () => {
+    const content = `model = "o3"\n\n${START}\n[[hooks]]\nx = 1\n${END}\n\ntail = true\n`
+    expect(stripLegacyManagedProfileBlock(content)).toBe('model = "o3"\n\ntail = true\n')
+  })
+
+  it('leaves a file with no managed block untouched', () => {
+    expect(stripLegacyManagedProfileBlock('model = "o3"\n')).toBe('model = "o3"\n')
+  })
+
+  it('rejoins a CRLF config with CRLF', () => {
+    const content = `model = "o3"\r\n\r\n${START}\r\n[[hooks]]\r\n${END}\r\n\r\ntail = true\r\n`
+    const next = stripLegacyManagedProfileBlock(content)
+    expect(next).toBe('model = "o3"\r\n\r\ntail = true\r\n')
+    expect(next).not.toMatch(/[^\r]\n/)
+  })
+
+  // CodeRabbit on #20148: a stray marker above a complete block must not hide it.
+  it('removes a complete block that sits below an orphaned marker', () => {
+    const content = `${START}\nstray = 1\n\n${START}\n[[hooks]]\nx = 1\n${END}\n\ntail = true\n`
+    const next = stripLegacyManagedProfileBlock(content)
+    expect(next).not.toContain('[[hooks]]')
+    expect(next).toContain('stray = 1')
+    expect(next).toContain('tail = true')
+  })
+
+  // #18861: the old strip ran to EOF whenever the end marker was gone.
+  it('fails closed when the end marker was hand-deleted', () => {
+    const content = `model = "o3"\n${START}\n[[hooks]]\nx = 1\n\n[user.table]\nkeep = "mine"\n`
+    expect(stripLegacyManagedProfileBlock(content)).toBe(content)
+  })
+})

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -51,6 +51,10 @@ function getConfigPath(): string {
 // single curl-based script body works on every platform.
 const MANAGED_SCRIPT_FILE_NAME = 'kimi-hook.sh'
 
+// Ownership test for every managed-block path: status, install, remove and the
+// bounded orphan recovery all agree on what counts as an Orca-written hook.
+const isManagedKimiCommand = createManagedCommandMatcher(MANAGED_SCRIPT_FILE_NAME)
+
 function getManagedScriptPath(): string {
   return getSharedManagedScriptPath(MANAGED_SCRIPT_FILE_NAME)
 }
@@ -194,8 +198,7 @@ export class KimiHookService {
         detail: 'Could not read Kimi config.toml'
       }
     }
-    const isManagedCommand = createManagedCommandMatcher(MANAGED_SCRIPT_FILE_NAME)
-    return buildStatus(readManagedKimiHookEvents(text, isManagedCommand), configPath)
+    return buildStatus(readManagedKimiHookEvents(text, isManagedKimiCommand), configPath)
   }
 
   install(): AgentHookInstallStatus {
@@ -214,7 +217,7 @@ export class KimiHookService {
     const command = getManagedCommand(scriptPath)
     // Write the script first so config.toml never points at a missing script.
     writeManagedScript(scriptPath, getManagedScript())
-    writeConfigToml(configPath, applyManagedKimiHooks(text, command))
+    writeConfigToml(configPath, applyManagedKimiHooks(text, command, isManagedKimiCommand))
     return this.getStatus()
   }
 
@@ -235,7 +238,11 @@ export class KimiHookService {
       const command = wrapPosixHookCommand(remoteScriptPath)
       // Write the script first so config.toml never points at a missing script.
       await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript('posix'))
-      await writeTextFileRemoteAtomic(sftp, remoteConfigPath, applyManagedKimiHooks(text, command))
+      await writeTextFileRemoteAtomic(
+        sftp,
+        remoteConfigPath,
+        applyManagedKimiHooks(text, command, isManagedKimiCommand)
+      )
       return {
         agent: 'kimi',
         state: 'installed',
@@ -266,7 +273,7 @@ export class KimiHookService {
         detail: 'Could not read Kimi config.toml'
       }
     }
-    const { text: nextText, changed } = removeManagedKimiHooks(text)
+    const { text: nextText, changed } = removeManagedKimiHooks(text, isManagedKimiCommand)
     if (changed) {
       writeConfigToml(configPath, nextText)
     }

--- a/src/main/kimi/kimi-hook-config-toml.test.ts
+++ b/src/main/kimi/kimi-hook-config-toml.test.ts
@@ -12,6 +12,14 @@ const COMMAND =
 const isManaged = (command: string | undefined): boolean =>
   typeof command === 'string' && command.includes('agent-hooks/kimi-hook.sh')
 
+const END_MARKER_LINE = '# <<< orca-managed-kimi-hooks <<<'
+const START_MARKER = '# >>> orca-managed-kimi-hooks (managed by Orca; do not edit) >>>'
+
+/** Drops only the `# <<< ... <<<` line, the hand-edit that orphans the block. */
+function deleteEndMarker(text: string): string {
+  return text.replace(/\r?\n# <<< orca-managed-kimi-hooks <<<(?=\r?\n|$)/, '')
+}
+
 describe('kimi managed hooks TOML block', () => {
   it('installs every managed event without a matcher', () => {
     const block = buildManagedKimiHooksBlock(COMMAND)
@@ -20,9 +28,9 @@ describe('kimi managed hooks TOML block', () => {
     }
     // Kimi treats matcher as a regex; omitting it matches all tools.
     expect(block).not.toContain('matcher')
-    expect(readManagedKimiHookEvents(applyManagedKimiHooks('', COMMAND), isManaged)).toEqual(
-      new Set(KIMI_HOOK_EVENTS)
-    )
+    expect(
+      readManagedKimiHookEvents(applyManagedKimiHooks('', COMMAND, isManaged), isManaged)
+    ).toEqual(new Set(KIMI_HOOK_EVENTS))
   })
 
   it('preserves existing user config above the managed block', () => {
@@ -40,7 +48,7 @@ describe('kimi managed hooks TOML block', () => {
       ''
     ].join('\n')
 
-    const next = applyManagedKimiHooks(userConfig, COMMAND)
+    const next = applyManagedKimiHooks(userConfig, COMMAND, isManaged)
     expect(next).toContain('default_model = "kimi-k2.6"')
     expect(next).toContain('api_key = "sk-secret"')
     // The user's own hook survives untouched.
@@ -49,8 +57,8 @@ describe('kimi managed hooks TOML block', () => {
   })
 
   it('is idempotent — reinstalling does not duplicate the block', () => {
-    const once = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
-    const twice = applyManagedKimiHooks(once, COMMAND)
+    const once = applyManagedKimiHooks('default_model = "x"\n', COMMAND, isManaged)
+    const twice = applyManagedKimiHooks(once, COMMAND, isManaged)
     expect(twice).toBe(once)
     const markerCount = (twice.match(/orca-managed-kimi-hooks \(/g) ?? []).length
     expect(markerCount).toBe(1)
@@ -58,52 +66,385 @@ describe('kimi managed hooks TOML block', () => {
 
   it('removes the managed block and restores the user config', () => {
     const userConfig = 'default_model = "kimi-k2.6"\n'
-    const installed = applyManagedKimiHooks(userConfig, COMMAND)
-    const { text, changed } = removeManagedKimiHooks(installed)
+    const installed = applyManagedKimiHooks(userConfig, COMMAND, isManaged)
+    const { text, changed } = removeManagedKimiHooks(installed, isManaged)
     expect(changed).toBe(true)
     expect(text).toBe(userConfig)
     expect(readManagedKimiHookEvents(text, isManaged).size).toBe(0)
   })
 
   it('reports no change when removing from a config without the managed block', () => {
-    const { text, changed } = removeManagedKimiHooks('default_model = "x"\n')
+    const { text, changed } = removeManagedKimiHooks('default_model = "x"\n', isManaged)
     expect(changed).toBe(false)
     expect(text).toBe('default_model = "x"\n')
   })
 
   it('is stable across repeated calls (no stateful global-regex lastIndex drift)', () => {
-    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND, isManaged)
     // Repeated detection/removal on the same and on a clean input must be
     // consistent — a `g`-flagged .test() would drift lastIndex and flip results.
-    expect(removeManagedKimiHooks(installed).changed).toBe(true)
-    expect(removeManagedKimiHooks(installed).changed).toBe(true)
-    expect(removeManagedKimiHooks('default_model = "x"\n').changed).toBe(false)
-    expect(removeManagedKimiHooks(installed).changed).toBe(true)
+    expect(removeManagedKimiHooks(installed, isManaged).changed).toBe(true)
+    expect(removeManagedKimiHooks(installed, isManaged).changed).toBe(true)
+    expect(removeManagedKimiHooks('default_model = "x"\n', isManaged).changed).toBe(false)
+    expect(removeManagedKimiHooks(installed, isManaged).changed).toBe(true)
     expect(readManagedKimiHookEvents(installed, isManaged)).toEqual(new Set(KIMI_HOOK_EVENTS))
     expect(readManagedKimiHookEvents(installed, isManaged)).toEqual(new Set(KIMI_HOOK_EVENTS))
   })
 
   it('recovers when a hand-edit deletes only the trailing end marker', () => {
-    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
-    // Simulate a user deleting just the `# <<< ... <<<` end-marker line.
-    const orphaned = installed.replace(/\n# <<< orca-managed-kimi-hooks <<<\n?/, '\n')
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND, isManaged)
+    const orphaned = deleteEndMarker(installed)
     expect(orphaned).not.toContain('<<<')
     // The orphaned (still-active) hook tables are still recognized...
     expect(readManagedKimiHookEvents(orphaned, isManaged)).toEqual(new Set(KIMI_HOOK_EVENTS))
     // ...remove strips them...
-    expect(removeManagedKimiHooks(orphaned)).toEqual({
+    expect(removeManagedKimiHooks(orphaned, isManaged)).toEqual({
       text: 'default_model = "x"\n',
       changed: true
     })
     // ...and reinstall converges to a single block instead of duplicating.
-    const reinstalled = applyManagedKimiHooks(orphaned, COMMAND)
+    const reinstalled = applyManagedKimiHooks(orphaned, COMMAND, isManaged)
     expect((reinstalled.match(/orca-managed-kimi-hooks \(/g) ?? []).length).toBe(1)
   })
 
   it('treats stale managed entries pointing at a moved script path as managed', () => {
     const staleCommand =
       "if [ -x '/old/userData/agent-hooks/kimi-hook.sh' ]; then /bin/sh '/old/userData/agent-hooks/kimi-hook.sh'; fi"
-    const stale = applyManagedKimiHooks('', staleCommand)
+    const stale = applyManagedKimiHooks('', staleCommand, isManaged)
     expect(readManagedKimiHookEvents(stale, isManaged)).toEqual(new Set(KIMI_HOOK_EVENTS))
+  })
+})
+
+// #18861: an orphaned start marker used to make every following byte "managed".
+describe('orphaned managed block ownership (#18861)', () => {
+  const USER_TAIL = [
+    '[providers."mine"]',
+    'type = "openai"',
+    'api_key = "sk-secret"',
+    '',
+    '[[hooks]]',
+    'event = "Stop"',
+    'command = "node my-own-hook.mjs"'
+  ].join('\n')
+
+  function orphanedWithUserTail(): string {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND, isManaged)
+    return `${deleteEndMarker(installed)}\n${USER_TAIL}\n`
+  }
+
+  it('keeps user tables appended after an orphaned block through remove', () => {
+    const { text, changed } = removeManagedKimiHooks(orphanedWithUserTail(), isManaged)
+    expect(changed).toBe(true)
+    expect(text).toContain('api_key = "sk-secret"')
+    expect(text).toContain('command = "node my-own-hook.mjs"')
+    expect(text).toContain('default_model = "x"')
+    // The reclaimed managed tables and the stray marker are gone.
+    expect(text).not.toContain(START_MARKER)
+    expect(text).not.toContain('agent-hooks/kimi-hook.sh')
+  })
+
+  it('keeps user tables appended after an orphaned block through reinstall', () => {
+    const reinstalled = applyManagedKimiHooks(orphanedWithUserTail(), COMMAND, isManaged)
+    expect(reinstalled).toContain('api_key = "sk-secret"')
+    expect(reinstalled).toContain('command = "node my-own-hook.mjs"')
+    // Exactly one well-formed block, appended after the surviving user bytes.
+    expect((reinstalled.match(/orca-managed-kimi-hooks \(/g) ?? []).length).toBe(1)
+    expect(reinstalled.indexOf('sk-secret')).toBeLessThan(reinstalled.indexOf(START_MARKER))
+    expect(readManagedKimiHookEvents(reinstalled, isManaged)).toEqual(new Set(KIMI_HOOK_EVENTS))
+    // And a second install is a no-op, so the recovery converges.
+    expect(applyManagedKimiHooks(reinstalled, COMMAND, isManaged)).toBe(reinstalled)
+  })
+
+  it('reclaims a genuinely managed orphan table but stops at the first user line', () => {
+    const orphan = [
+      'default_model = "x"',
+      '',
+      START_MARKER,
+      '[[hooks]]',
+      `event = "Stop"`,
+      `command = "${COMMAND.replaceAll('"', '')}"`,
+      'timeout = 10',
+      '[hand.written]',
+      'value = "keep"',
+      ''
+    ].join('\n')
+    const { text, changed } = removeManagedKimiHooks(orphan, isManaged)
+    expect(changed).toBe(true)
+    expect(text).toBe('default_model = "x"\n[hand.written]\nvalue = "keep"\n')
+  })
+
+  it('removes only the stray marker when an orphan owns no managed content', () => {
+    const orphan = `default_model = "x"\n\n${START_MARKER}\n[user.table]\nvalue = "keep"\n`
+    const { text, changed } = removeManagedKimiHooks(orphan, isManaged)
+    expect(changed).toBe(true)
+    expect(text).toBe('default_model = "x"\n[user.table]\nvalue = "keep"\n')
+  })
+
+  it('does not treat a user [[hooks]] table as Orca-owned content', () => {
+    const orphan = [
+      START_MARKER,
+      '[[hooks]]',
+      'event = "Stop"',
+      'command = "node my-own-hook.mjs"',
+      'timeout = 10',
+      ''
+    ].join('\n')
+    const { text } = removeManagedKimiHooks(orphan, isManaged)
+    expect(text).toContain('command = "node my-own-hook.mjs"')
+    expect(text).not.toContain(START_MARKER)
+  })
+
+  // A user adding keys has customised Orca's hook, not authored their own: the
+  // command path is what makes it fire. Leaving it would keep sending Orca their
+  // events after uninstall, and reinstall would double-fire the event.
+  it('owns a managed table the user added an extra key to', () => {
+    const orphan = [
+      START_MARKER,
+      '[[hooks]]',
+      'event = "Stop"',
+      `command = "${COMMAND.replaceAll('"', '')}"`,
+      'timeout = 10',
+      'matcher = "Bash"',
+      ''
+    ].join('\n')
+    expect(removeManagedKimiHooks(orphan, isManaged).text).toBe('')
+  })
+
+  it('owns a customised managed table sitting outside any marker', () => {
+    const customised = [
+      'default_model = "x"',
+      '',
+      '[[hooks]]',
+      'event = "Stop"',
+      `command = "${COMMAND.replaceAll('"', '')}"`,
+      'timeout = 10',
+      'matcher = "Bash"',
+      ''
+    ].join('\n')
+    expect(removeManagedKimiHooks(customised, isManaged).text).toBe('default_model = "x"\n')
+    // Status agrees, so install cannot append a second table for the same event.
+    expect(readManagedKimiHookEvents(customised, isManaged)).toEqual(new Set(['Stop']))
+    const reinstalled = applyManagedKimiHooks(customised, COMMAND, isManaged)
+    expect((reinstalled.match(/event = "Stop"/g) ?? []).length).toBe(1)
+  })
+
+  // Extent safety: a multi-line value means the table's end is not knowable by
+  // line scanning, so splicing it would take the wrong bytes.
+  it('fails closed on a table whose value spans lines', () => {
+    const orphan = [
+      START_MARKER,
+      '[[hooks]]',
+      'event = "Stop"',
+      `command = "${COMMAND.replaceAll('"', '')}"`,
+      'args = [',
+      '  "a"',
+      ']',
+      ''
+    ].join('\n')
+    const { text } = removeManagedKimiHooks(orphan, isManaged)
+    expect(text).toContain('args = [')
+    expect(text).not.toContain(START_MARKER)
+  })
+
+  // CodeRabbit on #20148: the old regex reader matched key *suffixes* and
+  // commented-out keys. Keys are parsed exactly now; these must not register.
+  it('does not read a managed event from key suffixes or commented keys', () => {
+    const nearMiss = [
+      START_MARKER,
+      '[[hooks]]',
+      'previous_event = "Stop"',
+      `fallback_command = "${COMMAND.replaceAll('"', '')}"`,
+      'timeout = 10',
+      END_MARKER_LINE,
+      '',
+      '[[hooks]]',
+      '# event = "PreToolUse"',
+      `# command = "${COMMAND.replaceAll('"', '')}"`,
+      ''
+    ].join('\n')
+    expect(readManagedKimiHookEvents(nearMiss, isManaged)).toEqual(new Set())
+  })
+
+  // CodeRabbit on #20148: a blank or comment between keys does not end a TOML
+  // table. Splicing the bounded run would strand `timeout` without its header.
+  it('fails closed when more keys follow a gap inside the table', () => {
+    for (const gap of ['', '# note']) {
+      const orphan = [
+        START_MARKER,
+        '[[hooks]]',
+        'event = "Stop"',
+        `command = "${COMMAND.replaceAll('"', '')}"`,
+        gap,
+        'timeout = 10',
+        ''
+      ].join('\n')
+      const { text } = removeManagedKimiHooks(orphan, isManaged)
+      expect(text).toContain('timeout = 10')
+      expect(text).toContain('[[hooks]]')
+      expect(text).not.toContain(START_MARKER)
+    }
+  })
+
+  it('still owns a table whose keys are followed by a gap and a new table', () => {
+    const orphan = [
+      START_MARKER,
+      '[[hooks]]',
+      'event = "Stop"',
+      `command = "${COMMAND.replaceAll('"', '')}"`,
+      'timeout = 10',
+      '',
+      '# a user comment',
+      '',
+      '[user.table]',
+      'v = 1',
+      ''
+    ].join('\n')
+    const { text } = removeManagedKimiHooks(orphan, isManaged)
+    expect(text).not.toContain(START_MARKER)
+    expect(text).not.toContain('agent-hooks/kimi-hook.sh')
+    // The user's comment and table are theirs; only the managed table goes.
+    expect(text).toContain('# a user comment')
+    expect(text).toContain('[user.table]')
+  })
+
+  // pullfrog on #20148: ownership keys on `command`, so an `event` Orca cannot
+  // parse must never let status claim nothing is installed.
+  it('never reports not_installed for a table remove() would strip', () => {
+    for (const eventLine of [`event = 'Stop'`, 'event = "Stop" # note', 'event = 12']) {
+      const config = [
+        START_MARKER,
+        '[[hooks]]',
+        eventLine,
+        `command = "${COMMAND.replaceAll('"', '')}"`,
+        'timeout = 10',
+        END_MARKER_LINE,
+        ''
+      ].join('\n')
+      // remove() strips it, so status must see it too.
+      expect(removeManagedKimiHooks(config, isManaged).changed).toBe(true)
+      expect(readManagedKimiHookEvents(config, isManaged).size).toBeGreaterThan(0)
+    }
+    // The single-quoted form resolves to the real event name.
+    const singleQuoted = [
+      START_MARKER,
+      '[[hooks]]',
+      `event = 'Stop'`,
+      `command = "${COMMAND.replaceAll('"', '')}"`,
+      'timeout = 10',
+      END_MARKER_LINE,
+      ''
+    ].join('\n')
+    expect(readManagedKimiHookEvents(singleQuoted, isManaged)).toEqual(new Set(['Stop']))
+  })
+
+  it('leaves a hook table that does not invoke the managed script', () => {
+    const orphan = [
+      START_MARKER,
+      '[[hooks]]',
+      'event = "Stop"',
+      'command = "node my-own-hook.mjs"',
+      'timeout = 10',
+      'matcher = "Bash"',
+      ''
+    ].join('\n')
+    const { text } = removeManagedKimiHooks(orphan, isManaged)
+    expect(text).toContain('command = "node my-own-hook.mjs"')
+    expect(text).toContain('matcher = "Bash"')
+  })
+
+  // A stranded managed table still executes, so remove() must reclaim it wherever
+  // a hand-edit left it; only the user's own bytes are off limits.
+  it('reclaims managed tables stranded below user text', () => {
+    const managedTable = [
+      '[[hooks]]',
+      'event = "Stop"',
+      `command = "${COMMAND.replaceAll('"', '')}"`,
+      'timeout = 10'
+    ].join('\n')
+    const orphan = `${START_MARKER}\n${managedTable}\n[user.table]\nv = 1\n${managedTable}\n`
+    const { text } = removeManagedKimiHooks(orphan, isManaged)
+    expect(text).toBe('[user.table]\nv = 1\n')
+  })
+
+  it('reports a stranded managed table as live so status cannot claim uninstalled', () => {
+    const stranded = [
+      '[user.table]',
+      'v = 1',
+      '',
+      '[[hooks]]',
+      'event = "PreToolUse"',
+      `command = "${COMMAND.replaceAll('"', '')}"`,
+      'timeout = 10',
+      ''
+    ].join('\n')
+    expect(readManagedKimiHookEvents(stranded, isManaged)).toEqual(new Set(['PreToolUse']))
+  })
+
+  it('reinstalling over a stranded table does not double-register its event', () => {
+    const stranded = [
+      '[user.table]',
+      'v = 1',
+      '',
+      '[[hooks]]',
+      'event = "PreToolUse"',
+      `command = "${COMMAND.replaceAll('"', '')}"`,
+      'timeout = 10',
+      ''
+    ].join('\n')
+    const reinstalled = applyManagedKimiHooks(stranded, COMMAND, isManaged)
+    expect((reinstalled.match(/event = "PreToolUse"/g) ?? []).length).toBe(1)
+    expect(reinstalled).toContain('[user.table]')
+    expect(readManagedKimiHookEvents(reinstalled, isManaged)).toEqual(new Set(KIMI_HOOK_EVENTS))
+  })
+
+  it('stops an orphaned block at a second start marker', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND, isManaged)
+    const duplicated = `${deleteEndMarker(installed)}\n${START_MARKER}\n[user.table]\nv = 1\n`
+    const { text, changed } = removeManagedKimiHooks(duplicated, isManaged)
+    expect(changed).toBe(true)
+    expect(text).toContain('[user.table]')
+    expect(text).not.toContain(START_MARKER)
+    expect(text).not.toContain('agent-hooks/kimi-hook.sh')
+  })
+
+  it('removes both blocks when the markers are duplicated wholesale', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND, isManaged)
+    const block = buildManagedKimiHooksBlock(COMMAND)
+    const doubled = `${installed}\n${block}\n[user.table]\nv = 1\n`
+    const { text, changed } = removeManagedKimiHooks(doubled, isManaged)
+    expect(changed).toBe(true)
+    expect(text).toBe('default_model = "x"\n[user.table]\nv = 1\n')
+  })
+
+  it('leaves a stray start marker after a well-formed block bounded', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND, isManaged)
+    const withStray = `${installed}${START_MARKER}\n[user.table]\nv = 1\n`
+    const { text } = removeManagedKimiHooks(withStray, isManaged)
+    expect(text).toBe('default_model = "x"\n[user.table]\nv = 1\n')
+  })
+})
+
+describe('CRLF configs', () => {
+  const userConfig = 'default_model = "kimi-k2.6"\r\n'
+
+  it('writes the managed block with the file’s existing CRLF endings', () => {
+    const installed = applyManagedKimiHooks(userConfig, COMMAND, isManaged)
+    expect(installed).not.toMatch(/[^\r]\n/)
+    expect(readManagedKimiHookEvents(installed, isManaged)).toEqual(new Set(KIMI_HOOK_EVENTS))
+    expect(applyManagedKimiHooks(installed, COMMAND, isManaged)).toBe(installed)
+    expect(removeManagedKimiHooks(installed, isManaged)).toEqual({
+      text: userConfig,
+      changed: true
+    })
+  })
+
+  it('keeps CRLF user bytes after an orphaned block', () => {
+    const installed = applyManagedKimiHooks(userConfig, COMMAND, isManaged)
+    const orphaned = `${deleteEndMarker(installed)}\r\n[providers."mine"]\r\napi_key = "sk-secret"\r\n`
+    const { text, changed } = removeManagedKimiHooks(orphaned, isManaged)
+    expect(changed).toBe(true)
+    expect(text).toContain('api_key = "sk-secret"')
+    expect(text).not.toContain('agent-hooks/kimi-hook.sh')
+    expect(text).not.toMatch(/[^\r]\n/)
   })
 })

--- a/src/main/kimi/kimi-hook-config-toml.ts
+++ b/src/main/kimi/kimi-hook-config-toml.ts
@@ -2,12 +2,19 @@
 // lifecycle hooks from an array of `[[hooks]]` tables. There is no JSON settings
 // file to reuse the shared JSON installer with, and no TOML library is vendored,
 // so Orca manages only its own marker-delimited block: install rewrites the
-// block, remove strips it, and arbitrary user config outside the markers is left
-// untouched. Appending table headers is always valid TOML, so the block can live
-// at the end of any existing file.
+// block, remove strips it, and user config is left untouched apart from hook
+// tables Orca itself emitted. Appending table headers is always valid TOML, so
+// the block can live at the end of any existing file.
 
 import { MANAGED_HOOK_TIMEOUT_SECONDS } from '../agent-hooks/installer-utils'
-import { escapeRegex } from '../../shared/string-utils'
+import {
+  findManagedTomlBlocks,
+  findRecognizedManagedTables,
+  stripManagedTomlRegions,
+  type ManagedTomlMarkers,
+  type ManagedTomlRegion,
+  type RecognizedManagedTable
+} from '../agent-hooks/managed-toml-ownership'
 
 // Why: mirror the Claude-compatible events Orca normalizes for status. Kimi uses
 // these exact event names (see normalizeKimiEvent), so each maps to a
@@ -22,19 +29,112 @@ export const KIMI_HOOK_EVENTS = [
   'StopFailure'
 ] as const
 
-const BLOCK_START = '# >>> orca-managed-kimi-hooks (managed by Orca; do not edit) >>>'
-const BLOCK_END = '# <<< orca-managed-kimi-hooks <<<'
+const MARKERS: ManagedTomlMarkers = {
+  startMarker: '# >>> orca-managed-kimi-hooks (managed by Orca; do not edit) >>>',
+  endMarker: '# <<< orca-managed-kimi-hooks <<<'
+}
+const HOOK_TABLE_HEADER = '[[hooks]]'
 
-// Matches the managed block plus any blank lines immediately preceding it so
-// repeated install/remove cycles do not accumulate whitespace. The `|$`
-// fallback also matches from BLOCK_START to end-of-file when the trailing
-// BLOCK_END marker is missing (e.g. a hand-edit deleted it): the managed block
-// is always written last, so this recovers orphaned hook tables and lets
-// install re-converge in one step instead of appending a duplicate block.
-const MANAGED_BLOCK_RE = new RegExp(
-  `\\n*${escapeRegex(BLOCK_START)}[\\s\\S]*?(?:${escapeRegex(BLOCK_END)}[^\\n]*|$)`,
-  'g'
-)
+export type ManagedCommandMatcher = (command: string | undefined) => boolean
+
+// A `[[hooks]]` table that invokes Orca's managed script is Orca's hook: that
+// command path is the only reason it fires, and it is there because Orca put it
+// there. Extra keys are a user customising our hook, not authoring their own, so
+// uninstall still owns it — leaving it would keep feeding Orca their events
+// after they asked it to stop, and reinstall would double-fire the event.
+//
+// The key run is still parsed strictly: an unrecognized line shape (a multi-line
+// array or string, say) means the table's extent is unknown, and guessing it
+// would splice the wrong bytes. That case fails closed.
+function matchManagedHookTable(
+  lines: readonly string[],
+  index: number,
+  isManagedCommand: ManagedCommandMatcher
+): { lineCount: number; value: string | null } | null {
+  if (lines[index].trim() !== HOOK_TABLE_HEADER) {
+    return null
+  }
+  const pairs = new Map<string, string>()
+  let cursor = index + 1
+  while (cursor < lines.length) {
+    const line = lines[cursor].trim()
+    // A blank, the next table header or a comment (the end marker included)
+    // ends the table's key run.
+    if (line === '' || line.startsWith('[') || line.startsWith('#')) {
+      break
+    }
+    const pair = line.match(/^([A-Za-z_][\w-]*)\s*=\s*(.*)$/)
+    if (!pair || pairs.has(pair[1])) {
+      return null
+    }
+    pairs.set(pair[1], pair[2].trim())
+    cursor++
+  }
+  // TOML lets blank lines and comments sit between keys of one table, so a gap
+  // is not proof the table ended. If more keys follow it, the run above covered
+  // only part of the table and splicing it would strand the rest without its
+  // header — the extent is unknown, so fail closed.
+  if (keysFollowGap(lines, cursor)) {
+    return null
+  }
+  // Raw (still-escaped) literal; createManagedCommandMatcher normalizes separators itself.
+  const command = readTomlString(pairs.get('command'))
+  if (!isManagedCommand(command)) {
+    return null
+  }
+  return { lineCount: cursor - index, value: readEventName(pairs.get('event')) }
+}
+
+// True when a key line follows the gap before the next table header, meaning
+// the table extends past the bounded key run above.
+function keysFollowGap(lines: readonly string[], from: number): boolean {
+  for (let cursor = from; cursor < lines.length; cursor++) {
+    const line = lines[cursor].trim()
+    if (line === '' || line.startsWith('#')) {
+      continue
+    }
+    return !line.startsWith('[')
+  }
+  return false
+}
+
+// Basic or literal TOML string, ignoring any inline comment after it.
+function readTomlString(value: string | undefined): string | undefined {
+  return value?.match(/^"((?:[^"\\]|\\.)*)"/)?.[1] ?? value?.match(/^'([^']*)'/)?.[1]
+}
+
+// Ownership keys on the command, so an event Orca cannot parse must still
+// register: status reporting `not_installed` for a table remove() will strip is
+// the exact split this recognizer exists to close. An unreadable literal falls
+// back to its raw text, which matches no known event and lands status on
+// `partial` rather than claiming nothing is installed.
+function readEventName(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null
+  }
+  return readTomlString(value) ?? value.trim() ?? null
+}
+
+function recognizeManagedTables(
+  configText: string,
+  isManagedCommand: ManagedCommandMatcher
+): RecognizedManagedTable<string | null>[] {
+  return findRecognizedManagedTables(configText, (lines, index) =>
+    matchManagedHookTable(lines, index, isManagedCommand)
+  )
+}
+
+// Orca owns two things here: whatever sits inside a matched marker pair, and
+// every table it can positively recognize wherever that table ended up.
+function findOwnedRegions(
+  configText: string,
+  isManagedCommand: ManagedCommandMatcher
+): ManagedTomlRegion[] {
+  return [
+    ...findManagedTomlBlocks(configText, MARKERS),
+    ...recognizeManagedTables(configText, isManagedCommand)
+  ]
+}
 
 // TOML basic (double-quoted) string. The managed command may contain single
 // quotes (from POSIX quoting) but no double quotes or backslashes on the paths
@@ -50,7 +150,7 @@ function tomlBasicString(value: string): string {
   return `"${escaped}"`
 }
 
-export function buildManagedKimiHooksBlock(command: string): string {
+export function buildManagedKimiHooksBlock(command: string, eol = '\n'): string {
   const commandLiteral = tomlBasicString(command)
   // Omit `matcher`: Kimi treats it as a regex (so Claude's literal "*" is
   // invalid) and an absent matcher already matches every tool.
@@ -58,52 +158,64 @@ export function buildManagedKimiHooksBlock(command: string): string {
   // the normal dead-endpoint bound.
   const entries = KIMI_HOOK_EVENTS.map((event) =>
     [
-      `[[hooks]]`,
+      HOOK_TABLE_HEADER,
       `event = "${event}"`,
       `command = ${commandLiteral}`,
       `timeout = ${MANAGED_HOOK_TIMEOUT_SECONDS}`
-    ].join('\n')
+    ].join(eol)
   )
-  return [BLOCK_START, ...entries, BLOCK_END].join('\n')
+  return [MARKERS.startMarker, ...entries, MARKERS.endMarker].join(eol)
 }
 
-export function applyManagedKimiHooks(configText: string, command: string): string {
-  const withoutManaged = configText.replace(MANAGED_BLOCK_RE, '').replace(/\s+$/, '')
-  const block = buildManagedKimiHooksBlock(command)
-  return withoutManaged.length > 0 ? `${withoutManaged}\n\n${block}\n` : `${block}\n`
+function detectEol(configText: string): string {
+  return configText.includes('\r\n') ? '\r\n' : '\n'
 }
 
-export function removeManagedKimiHooks(configText: string): { text: string; changed: boolean } {
-  // Why: compare instead of MANAGED_BLOCK_RE.test() — the regex carries the `g`
-  // flag, so .test() advances lastIndex and would behave inconsistently across
-  // calls. .replace() ignores/resets lastIndex, so it is safe to reuse.
-  const stripped = configText.replace(MANAGED_BLOCK_RE, '')
-  if (stripped === configText) {
+export function applyManagedKimiHooks(
+  configText: string,
+  command: string,
+  isManagedCommand: ManagedCommandMatcher
+): string {
+  const eol = detectEol(configText)
+  const withoutManaged = stripManagedTomlRegions(
+    configText,
+    findOwnedRegions(configText, isManagedCommand)
+  ).text.replace(/\s+$/, '')
+  const block = buildManagedKimiHooksBlock(command, eol)
+  return withoutManaged.length > 0
+    ? `${withoutManaged}${eol}${eol}${block}${eol}`
+    : `${block}${eol}`
+}
+
+export function removeManagedKimiHooks(
+  configText: string,
+  isManagedCommand: ManagedCommandMatcher
+): { text: string; changed: boolean } {
+  const stripped = stripManagedTomlRegions(
+    configText,
+    findOwnedRegions(configText, isManagedCommand)
+  )
+  if (!stripped.changed) {
     return { text: configText, changed: false }
   }
-  const trimmed = stripped.replace(/\s+$/, '')
-  return { text: trimmed.length > 0 ? `${trimmed}\n` : '', changed: true }
+  const eol = detectEol(configText)
+  const trimmed = stripped.text.replace(/\s+$/, '')
+  return { text: trimmed.length > 0 ? `${trimmed}${eol}` : '', changed: true }
 }
 
-// Returns the managed events present in the block whose command still matches an
-// Orca-managed script (by filename, so a moved userData path is still swept).
+// Events a managed table is live for, counted wherever the table sits (by script
+// filename, so a moved userData path is still seen). Status must include tables
+// stranded outside the markers — those still fire, so reporting them absent
+// would tell the user a hook is uninstalled while Orca keeps receiving events.
 export function readManagedKimiHookEvents(
   configText: string,
-  isManagedCommand: (command: string | undefined) => boolean
+  isManagedCommand: ManagedCommandMatcher
 ): Set<string> {
-  const present = new Set<string>()
-  const match = configText.match(MANAGED_BLOCK_RE)
-  if (!match) {
-    return present
-  }
-  const blockText = match[0]
-  // Split on each table header and pair the `event`/`command` lines within.
-  for (const chunk of blockText.split('[[hooks]]').slice(1)) {
-    const event = chunk.match(/event\s*=\s*"([^"]+)"/)?.[1]
-    const command = chunk.match(/command\s*=\s*"((?:[^"\\]|\\.)*)"/)?.[1]
-    if (event && isManagedCommand(command)) {
-      present.add(event)
+  const events = new Set<string>()
+  for (const table of recognizeManagedTables(configText, isManagedCommand)) {
+    if (table.value) {
+      events.add(table.value)
     }
   }
-  return present
+  return events
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​553 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​533 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​359 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​62 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​297 |

<!-- /orca-pr-loc -->

Fixes #18861

## ELI5

Orca adds its own section to the bottom of some agent config files, and wraps that section in two comment lines that say "Orca's stuff starts here" and "Orca's stuff ends here". If the "ends here" line went missing — someone tidied the file, or a config tool rewrote it — Orca assumed everything from "starts here" to the end of the file was its own, and deleted all of it the next time it installed or uninstalled. Anything you had added below, like an API key or another tool's settings, silently disappeared. On top of that, if the marker comments went missing entirely, "uninstall" quietly found nothing to remove and left Orca's hooks running on your machine after you'd turned them off.

Now Orca only deletes two kinds of thing: what sits between a matched pair of markers, and lines it can positively recognise as text it wrote itself. If it can't prove a line is its own, it leaves it alone. So your settings survive, and uninstall actually removes the hooks even when the markers are long gone.

## Why no screenshots

There is no UI for this. Managed hook install/remove is deliberately never exposed to the renderer (`src/main/ipc/agent-hooks.ts`: *"install/remove are intentionally not exposed to the renderer"* — Orca auto-installs at startup), so the only human-facing surfaces are the `orca agent hooks status` CLI output and the config file itself. Both are captured below as literal text. A screenshot here would be theatre.

## The bug (data loss, two separate paths)

Orca appends marker-delimited blocks to **user-owned** TOML config files. The end marker is the only proof of where Orca's bytes stop. Both managed-TOML-block implementations treated a *missing* end marker as "Orca owns everything through EOF" — so a single hand-edit that dropped the end marker turned the next uninstall or reinstall into a silent delete of every table the user had appended below.

**Path 1 — Kimi `~/.kimi-code/config.toml`** (`src/main/kimi/kimi-hook-config-toml.ts`). The block regex ended in `(?:BLOCK_END[^\n]*|$)`; the `$` alternative swallowed the rest of the file.

**Path 2 — Codex legacy profile `~/.codex/orca-agent-status.config.toml`** (`src/main/codex/codex-hook-legacy-cleanup.ts`). Same shape, spelled differently:

```ts
const end = endMarker === -1 ? content.length : endMarker + LEGACY_ORCA_PROFILE_BLOCK_END.length
```

This second one runs from `cleanupLegacyManagedHookRepresentations()` on **every** Codex hook cleanup, against a file that also holds the user's `[projects.*]` trust entries. It is not a footnote — it is an independent way to lose user config.

I re-swept `src/main/` for a third instance: there are exactly two paired start/end marker conventions in the codebase (`kimi-hook-config-toml.ts`, `codex-hook-legacy-cleanup.ts`), both fixed here. The other `=== -1 ? content.length` hits in `config-toml-hook-trust-blocks.ts`, `config-toml-hook-trust-read.ts` and `config-toml-project-trust.ts` are **not** affected: those bound a block by *the next TOML table header*, which is the actual TOML grammar for a table's extent, not a marker convention that can go missing. The `.orca-managed-*` / `@orca-managed-pi-extension` markers are whole-file ownership flags with no extent to get wrong.

## The policy

New shared module `src/main/agent-hooks/managed-toml-ownership.ts`. Two independent things make a byte Orca's, and separating them is the whole fix:

**Marker extent** — where a block starts and stops.

1. A block opens at a line whose **trimmed** text starts with the start marker.
2. **Terminated block**: everything between the markers is Orca's. The end marker is proof of extent, regardless of content.
3. **Orphaned block**: owns *only* its own stray marker line. Never any content, for any caller, no exceptions. Without the end marker there is no evidence of extent, so there is nothing to infer from.
4. A second start marker always closes a preceding orphan.
5. Splicing is offset-based on the raw text, so CRLF round-trips verbatim.

**Recognition** — content Orca can prove it wrote.

6. A provider may supply a recognizer. Every table it positively identifies is Orca's **wherever it sits in the file**, inside a block or not.
7. A provider with no recognizer owns nothing beyond rules 1–5 (fail closed).
8. Both sets of regions are merged and spliced in a single pass, so overlaps and nesting cannot double-remove.

Kimi's recognizer: a `[[hooks]]` table whose `command` is accepted by `createManagedCommandMatcher('kimi-hook.sh')`. That command path is the only reason the table fires, and it is there because Orca put it there — so the table is Orca's, extra keys and all. A table invoking anything else is the user's and is never touched. One shape guard remains: if a line in the table is not a simple `key = value` pair (a multi-line array or string, say) the table's extent is not knowable by line scanning, so recognition fails closed rather than splicing the wrong bytes.

Ownership is deliberately the *same* test for remove, install and status. An asymmetry here is not a safety margin — it is a bug: if status cannot see a table that install does not remove, install appends a second table for the same event and the hook double-fires.

Codex's legacy block gets **no** recognizer on purpose. That body's shape is not derivable from current source (it was written by a version that no longer exists), so there is nothing to positively recognize and rule 7 applies.

Recovery therefore never has to guess. Orphan handling does not try to infer where Orca's bytes end — it deletes the stray marker and lets recognition reclaim the actual content, wherever a hand-edit or a rewriter left it.

## Evidence on real files

Driven through the **real** code paths — `kimiHookService.install()` / `.remove()` and `cleanupLegacyManagedHookRepresentations()` — against real files on disk, not test doubles. Pre-fix results come from running the parent commit's functions on byte-identical input.

### Kimi: end marker hand-deleted, user tables appended below

BEFORE (`3308` bytes; end marker absent; managed `[[hooks]]` bodies elided for length):

```toml
default_model = "kimi-k2.6"

[providers."mine"]
type = "openai"
base_url = "https://example.com/v1"
api_key = "sk-SECRET-DO-NOT-LOSE"

# >>> orca-managed-kimi-hooks (managed by Orca; do not edit) >>>
[[hooks]]
event = "UserPromptSubmit"
command = "<managed kimi-hook.sh launcher>"
timeout = 10
... 6 more managed tables ...
                              <-- end marker was here, deleted by hand

[providers."work"]
type = "anthropic"
api_key = "sk-USER-APPENDED-AFTER-THE-ORPHAN"

[[hooks]]
event = "Stop"
command = "node /home/u/my-own-hook.mjs"
timeout = 30
```

**PRE-FIX `remove()` → 134 bytes.** Everything from the stray marker to EOF is gone:

```toml
default_model = "kimi-k2.6"

[providers."mine"]
type = "openai"
base_url = "https://example.com/v1"
api_key = "sk-SECRET-DO-NOT-LOSE"
```

```
sk-USER-APPENDED-AFTER-THE-ORPHAN survived? 0
user's own [[hooks]] survived?            0
[providers."work"] survived?              0
```

`install()` on the same input loses the same bytes (`3177` bytes out, `0` occurrences of either user string).

**FIXED `remove()` → 299 bytes:**

```toml
default_model = "kimi-k2.6"

[providers."mine"]
type = "openai"
base_url = "https://example.com/v1"
api_key = "sk-SECRET-DO-NOT-LOSE"

[providers."work"]
type = "anthropic"
api_key = "sk-USER-APPENDED-AFTER-THE-ORPHAN"

[[hooks]]
event = "Stop"
command = "node /home/u/my-own-hook.mjs"
timeout = 30
```

```
$ diff <before user-owned tail> <after user-owned tail>
IDENTICAL (164 bytes preserved verbatim)
stray start marker gone?          0 occurrences
managed kimi-hook.sh tables gone? 0 occurrences
```

**FIXED `install()` on the same orphan** keeps both user tables, emits exactly `1` start marker and `1` end marker, and a second `install()` is byte-identical — the recovery converges in one step.

### Kimi: the other cases

| Case | Result |
|---|---|
| Intact block, `remove()` | restored to exactly the 134-byte pre-install user config (`diff` clean) |
| Duplicate start markers (orphan + a full block) | both reclaimed; `0` markers and `0` managed commands left, `[user.kept]` intact |
| Genuinely managed orphan table + `[hand.written]` below | managed table reclaimed (540 → 62 bytes), `[hand.written]` kept |
| Managed table stranded below user text | reclaimed (916 → 20 bytes); 0 live hooks left, `[user.table]` kept |
| User's own `[[hooks]]` table outside any marker | untouched (`diff` clean) |
| Managed table with a user-added `matcher` key | untouched (`diff` clean) |

### Kimi: CRLF

Install onto a CRLF config, delete the end marker, append CRLF user tables, run the real `remove()`:

```
$ od -c ~/.kimi-code/config.toml
0000000  d e f a u l t _ m o d e l   =
0000020  " k i m i - k 2 . 6 "  \r  \n  \r  \n   [
...
0000220  E - O R P H A N "  \r  \n
$ file ~/.kimi-code/config.toml
ASCII text, with CRLF line terminators
bare LF count: 0
```

For contrast, the pre-fix builder had no EOL detection at all and wrote LF into a CRLF file: `with CRLF, LF line terminators`, `bare LF count: 32`.

### Codex legacy profile

BEFORE (`200` bytes, end marker hand-deleted):

```toml
model = "o3"
model_provider = "openai"

# BEGIN ORCA AGENT STATUS HOOKS
[[hooks]]
event = "Stop"
command = "/home/u/.orca/agent-hooks/codex-hook.sh"

[projects."/home/u/work"]
trust_level = "trusted"
```

**PRE-FIX → 39 bytes.** The user's trust grant is gone:

```toml
model = "o3"
model_provider = "openai"
```

**FIXED → 200 bytes**, `diff` against the input is empty: fail closed, file untouched byte-for-byte.

Intact-block removal still works (230 → 90 bytes; managed block gone, `trust_level` kept), and the splice seam now rejoins with the file's own terminator, so a CRLF profile comes back `with CRLF line terminators` / `bare LF count: 0` instead of the previous mixed endings.

### The CLI surface

`orca agent hooks status` on a config whose markers were dropped by a TOML rewriter (7 managed hook tables, 0 markers):

```
main   $ orca agent hooks status
       kimi: not_installed          <- wrong; 7 hooks are live and unreachable

this   $ orca agent hooks status
       kimi: installed
```

And on a config where only some managed tables survive, this PR reports the truth instead of silence:

```
$ orca agent hooks status
kimi: partial
  detail: Managed hook missing for events: UserPromptSubmit, PostToolUse, PostToolUseFailure, PermissionRequest, StopFailure
```

## Known behaviour changes

Called out so they are not a surprise in review:

- **Uninstall now removes an Orca-shaped hook table sitting outside the markers.** A `[[hooks]]` table with exactly `event`/`command`/`timeout`, a known Kimi event and a command pointing at `agent-hooks/kimi-hook.sh` is Orca's wherever it sits. On main such a table survived `remove()`; now it does not. That is the point of the change, but a user who deliberately copied Orca's table into their own section will find it gone after uninstall.
- **Status can now say `installed` for a config containing no Orca markers.** Correct — the hooks really are live — but it may look odd to someone reading their config for the marker comments.
- **Orca's managed hook table cannot be customised by adding keys to it.** Adding `matcher = "Bash"` to a table that invokes `kimi-hook.sh` no longer protects it: uninstall removes it and reinstall replaces it with the canonical block. This matches what the markers already say (*"managed by Orca; do not edit"*) and what happens to a customised table inside an intact block today. The alternative was worse — an earlier revision of this PR exempted such tables, which left the hook running after uninstall and double-fired `Stop` after the next startup install.
- **Removing a block that starts at byte 0 can leave one leading blank line.** Cosmetic; valid TOML.

## Bonus: uninstall now works on a marker-less config

Recognition fixes a second, more reachable problem that predates #18861. Markers are TOML **comments**, so anything that round-trips the file through a TOML serializer — `kimi config set`, a dotfile manager, any config editor — drops both markers while keeping the hook tables. Pre-fix, `remove()` then found nothing and left **all 7** managed hooks live, permanently, with no way for Orca to ever find them again:

```
config after a TOML-aware rewrite: 0 start markers, 0 end markers, 7 managed [[hooks]] tables

PRE-FIX  remove() -> 7 managed hooks still live after "uninstall"
FIXED    remove() -> 0 managed hooks live; user config preserved verbatim
```

Unlike the interleaved-orphan case, this one needs no hand-editing at all.

## The one remaining fail-closed trade

**An orphaned legacy Codex block is never removed.** Rule 7 means the block stays in `orca-agent-status.config.toml` forever. That is acceptable because the stale profile is inert — the runtime `CODEX_HOME` supersedes it, and it defines no live hook — so leaving it costs nothing next to destroying the `[projects.*]` trust entries sitting below it. The failure mode is "a stale comment block remains", not "a hook keeps running".

There is deliberately **no** equivalent trade on the Kimi side. An earlier revision of this PR bounded orphan recovery at the first unrecognized line and accepted that managed tables stranded below user text would survive `remove()`. That was wrong: those tables still execute. Verified against a real config — after `remove()` a TOML reader still saw `event=PreToolUse managed=true`, `~/.orca/agent-hooks/kimi-hook.sh` was still present and executable, and that script spools agent events to disk and POSTs them to Orca's hook server. `getStatus()` meanwhile reported `not_installed`, and a subsequent `install()` produced **two** `PreToolUse` tables and double-fired the event. Fail-closed on *user* bytes is right; fail-silent on Orca's own leftovers is a different thing and does not inherit the same justification. Recognition-based ownership removes the trade entirely:

| After `remove()` on a stranded managed table | Earlier revision | Now |
|---|---|---|
| Managed `[[hooks]]` a TOML reader sees | 1 (`PreToolUse`, live) | 0 |
| `getStatus()` | `not_installed` (wrong) | `not_installed` (true) |
| `install()` afterwards | `PreToolUse` **×2**, double-fires | ×1, converges, byte-identical on a second run |

## Relationship to open community PRs

**#19033 — @cat-xierluo, "fix(kimi): bound orphaned managed-block recovery to installer-shaped tables".** Same root cause, and their bounded-recovery mechanism is exactly the rule this PR started with: stop orphan recovery at the first line that is not installer-shaped. They are credited as co-author. Their patch is careful in ways I had to rediscover — CRLF-aware line boundaries, and a boundary check so a user table that reuses the installer field order but carries extra keys is left whole rather than truncated to its installer-shaped prefix.

This PR then goes further in three places, all found by pushing on that shared design:

1. **A second instance.** `src/main/codex/codex-hook-legacy-cleanup.ts` had the same "no end marker means delete to EOF" shape against a file that also holds the user's `[projects.*]` trust entries. #19033 fixes Kimi only.
2. **Bounded recovery leaves a live hook.** Stopping at the first unrecognized line means a managed table stranded below user text survives uninstall and keeps firing, invisible to status — and the next startup install then double-fires that event. That is why ownership here is by recognition wherever the table sits, not by position, and why remove, install and status share one test.
3. **Marker matching must be exact.** #19033's regex embeds `escapeRegex(BLOCK_START)` without a line anchor, so — like this PR before review — a user quoting the marker in a comment of their own opens a region. CodeRabbit caught it here; both markers are now compared against the whole trimmed line.

**#18813 — @Djiit, "feat(vibe): add managed hook transport, live status, and session resume".** Not a fix for #18861, but it is **not unrelated**: it adds `src/main/vibe/hook-config-toml.ts` containing a verbatim copy of the pre-fix regex, `` `\n*${escapeRegex(BLOCK_START)}[\s\S]*?(?:${escapeRegex(BLOCK_END)}[^\n]*|$)` ``, so merging it as-is reintroduces this data-loss bug for Vibe. @cat-xierluo flagged this lockstep risk on #19033 and they were right. Vibe is not on `main`, so this PR cannot fix it; #18813 should adopt `managed-toml-ownership.ts` instead of cloning the regex. Commented there.


## Verification

- `pnpm test src/main/kimi src/main/codex src/main/agent-hooks/managed-toml-ownership.test.ts src/main/agent-hooks/installer-utils.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts src/main/agent-hooks/managed-hook-detection-commands.test.ts` — 8 files, 141 passed / 3 skipped
- `pnpm tc` — clean
- `oxlint` — clean; `oxfmt --check` — clean
- `pnpm run check:code-quality:changed` — 0 new findings across 7 changed files

SSH: `installRemote` shares the same recognizer, so a remote Kimi config orphaned or rewritten the same way recovers identically. No mobile-facing surface touched.

Orca's own `writeConfigToml` is temp+rename atomic, so Orca cannot itself truncate a config into the orphaned state — it takes an external edit or an external writer. The marker-less case above needs neither.



