### PR TITLE
feat(native-chat): open mermaid diagrams in a zoomable fullscreen lightbox

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -731,6 +731,22 @@
   height: auto;
 }
 
+/* Fullscreen mermaid lightbox: the zoom wrapper owns layout size, so the SVG
+   must fill it instead of capping itself to the inline chat column. */
+.mermaid-diagram-lightbox-canvas {
+  min-width: 0;
+  min-height: 0;
+}
+.mermaid-diagram-lightbox-canvas .mermaid-block {
+  width: 100%;
+  height: 100%;
+}
+.mermaid-diagram-lightbox-canvas .mermaid-block svg {
+  max-width: none;
+  width: 100%;
+  height: 100%;
+}
+
 .markdown-body ul,
 .markdown-body ol {
   margin: 0.75em 0;

--- a/src/renderer/src/components/editor/MermaidDiagramLightbox.test.tsx
+++ b/src/renderer/src/components/editor/MermaidDiagramLightbox.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ExpandableMermaidDiagram } from './MermaidDiagramLightbox'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+vi.mock('./MermaidBlock', () => ({
+  default: function MermaidBlock() {
+    return (
+      <div className="mermaid-block">
+        <svg viewBox="0 0 800 400" />
+      </div>
+    )
+  }
+}))
+
+afterEach(() => {
+  cleanup()
+})
+
+function renderDiagram(): void {
+  render(
+    <TooltipProvider>
+      <ExpandableMermaidDiagram content="graph TD; A-->B;" isDark />
+    </TooltipProvider>
+  )
+}
+
+describe('ExpandableMermaidDiagram', () => {
+  it('opens an accessible fullscreen diagram dialog from the expand control', async () => {
+    const user = userEvent.setup()
+    renderDiagram()
+
+    const trigger = await screen.findByRole('button', { name: 'Expand diagram' })
+    await user.click(trigger)
+    const dialog = screen.getByRole('dialog', { name: 'Diagram' })
+    expect(dialog).toBeTruthy()
+    expect(screen.getAllByText('100%').length).toBeGreaterThan(0)
+    expect(document.activeElement).toBe(dialog)
+
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Diagram' })).toBeNull())
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('zooms in from the dialog toolbar and can reset', async () => {
+    renderDiagram()
+    fireEvent.click(await screen.findByRole('button', { name: 'Expand diagram' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }))
+    expect(screen.getByText('125%')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset zoom' }))
+    expect(screen.getAllByText('100%').length).toBeGreaterThan(0)
+  })
+
+  it('closes from the dialog close button', async () => {
+    renderDiagram()
+    fireEvent.click(await screen.findByRole('button', { name: 'Expand diagram' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(screen.queryByRole('dialog', { name: 'Diagram' })).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/MermaidDiagramLightbox.tsx
+++ b/src/renderer/src/components/editor/MermaidDiagramLightbox.tsx
@@ -1,0 +1,286 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { Maximize2, RotateCcw, X, ZoomIn, ZoomOut } from 'lucide-react'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import MermaidBlock from './MermaidBlock'
+import {
+  findMermaidSvg,
+  mermaidDiagramCanExpand,
+  prepareMermaidSvgForZoom,
+  readMermaidSvgSize
+} from './mermaid-svg-size'
+import { useMermaidDiagramZoom } from './use-mermaid-diagram-zoom'
+
+type ExpandableMermaidDiagramProps = {
+  content: string
+  isDark: boolean
+  htmlLabels?: boolean
+  className?: string
+}
+
+function MermaidZoomToolbar({
+  canReset,
+  canZoomIn,
+  canZoomOut,
+  onReset,
+  onZoomIn,
+  onZoomOut,
+  zoomPercent
+}: {
+  canReset: boolean
+  canZoomIn: boolean
+  canZoomOut: boolean
+  onReset: () => void
+  onZoomIn: () => void
+  onZoomOut: () => void
+  zoomPercent: number
+}): React.JSX.Element {
+  const zoomOutLabel = translate(
+    'auto.components.editor.MermaidDiagramLightbox.zoomOut',
+    'Zoom out'
+  )
+  const resetLabel = translate(
+    'auto.components.editor.MermaidDiagramLightbox.resetZoom',
+    'Reset zoom'
+  )
+  const zoomInLabel = translate('auto.components.editor.MermaidDiagramLightbox.zoomIn', 'Zoom in')
+
+  return (
+    <div className="flex items-center gap-1 text-muted-foreground">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={zoomOutLabel}
+            disabled={!canZoomOut}
+            onClick={onZoomOut}
+          >
+            <ZoomOut />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4}>
+          {zoomOutLabel}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={resetLabel}
+            disabled={!canReset}
+            onClick={onReset}
+          >
+            <RotateCcw />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4}>
+          {resetLabel}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={zoomInLabel}
+            disabled={!canZoomIn}
+            onClick={onZoomIn}
+          >
+            <ZoomIn />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={4}>
+          {zoomInLabel}
+        </TooltipContent>
+      </Tooltip>
+      <span className="ml-1 min-w-10 text-xs tabular-nums">{zoomPercent}%</span>
+    </div>
+  )
+}
+
+function MermaidDiagramLightbox({
+  content,
+  htmlLabels,
+  isDark
+}: {
+  content: string
+  htmlLabels: boolean
+  isDark: boolean
+}): React.JSX.Element {
+  const canvasRef = useRef<HTMLDivElement>(null)
+  const title = translate('auto.components.editor.MermaidDiagramLightbox.title', 'Diagram')
+  const closeLabel = translate('auto.components.editor.MermaidDiagramLightbox.close', 'Close')
+  const {
+    canReset,
+    canZoomIn,
+    canZoomOut,
+    layoutStyle,
+    resetZoom,
+    setDiagramSize,
+    setSurfaceNode,
+    zoomIn,
+    zoomOut,
+    zoomPercent
+  } = useMermaidDiagramZoom()
+
+  useEffect(() => {
+    const root = canvasRef.current
+    if (!root) {
+      return
+    }
+
+    const syncSvg = (): void => {
+      const svg = findMermaidSvg(root)
+      if (!svg) {
+        setDiagramSize(null)
+        return
+      }
+      const size = readMermaidSvgSize(svg)
+      prepareMermaidSvgForZoom(svg)
+      setDiagramSize(size)
+    }
+
+    syncSvg()
+    const observer = new MutationObserver(syncSvg)
+    observer.observe(root, { childList: true, subtree: true })
+    return () => observer.disconnect()
+  }, [content, htmlLabels, isDark, setDiagramSize])
+
+  return (
+    <DialogContent
+      showCloseButton={false}
+      onOpenAutoFocus={(event) => {
+        event.preventDefault()
+        if (event.currentTarget instanceof HTMLElement) {
+          event.currentTarget.focus()
+        }
+      }}
+      className="flex h-[92dvh] w-[96vw] max-w-[96vw] flex-col gap-0 overflow-hidden p-0 sm:max-w-[96vw]"
+    >
+      <DialogTitle className="sr-only">{title}</DialogTitle>
+      <DialogDescription className="sr-only">
+        {translate(
+          'auto.components.editor.MermaidDiagramLightbox.preview',
+          'Full-screen diagram preview. Pinch or hold Ctrl and scroll to zoom. Scroll to pan.'
+        )}
+      </DialogDescription>
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border px-3 py-2">
+        <span className="min-w-0 truncate text-sm font-medium text-foreground">{title}</span>
+        <div className="flex shrink-0 items-center gap-2">
+          <MermaidZoomToolbar
+            canReset={canReset}
+            canZoomIn={canZoomIn}
+            canZoomOut={canZoomOut}
+            onReset={resetZoom}
+            onZoomIn={zoomIn}
+            onZoomOut={zoomOut}
+            zoomPercent={zoomPercent}
+          />
+          <DialogClose asChild>
+            <Button type="button" variant="ghost" size="icon-sm" aria-label={closeLabel}>
+              <X className="size-4" />
+            </Button>
+          </DialogClose>
+        </div>
+      </div>
+      <div
+        ref={setSurfaceNode}
+        className="min-h-0 flex-1 cursor-grab overflow-auto bg-muted/20 scrollbar-editor active:cursor-grabbing"
+      >
+        <div className="flex h-max min-h-full w-max min-w-full items-center justify-center p-4">
+          <div
+            ref={canvasRef}
+            className="mermaid-diagram-lightbox-canvas flex items-center justify-center"
+            style={layoutStyle}
+          >
+            <MermaidBlock content={content} htmlLabels={htmlLabels} isDark={isDark} />
+          </div>
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center border-t border-border px-3 py-2 text-xs text-muted-foreground">
+        {translate(
+          'auto.components.editor.MermaidDiagramLightbox.escToClose',
+          'Press Esc to close'
+        )}
+      </div>
+    </DialogContent>
+  )
+}
+
+export function ExpandableMermaidDiagram({
+  content,
+  isDark,
+  htmlLabels = false,
+  className
+}: ExpandableMermaidDiagramProps): React.JSX.Element {
+  const inlineRef = useRef<HTMLDivElement>(null)
+  const [open, setOpen] = useState(false)
+  const [canExpand, setCanExpand] = useState(false)
+  const expandLabel = translate(
+    'auto.components.editor.MermaidDiagramLightbox.expand',
+    'Expand diagram'
+  )
+
+  useEffect(() => {
+    const root = inlineRef.current
+    if (!root) {
+      return
+    }
+    const sync = (): void => setCanExpand(mermaidDiagramCanExpand(root))
+    sync()
+    const observer = new MutationObserver(sync)
+    observer.observe(root, { childList: true, subtree: true })
+    return () => observer.disconnect()
+  }, [content, htmlLabels, isDark])
+
+  return (
+    <div className={cn('group/mermaid-diagram relative min-w-0 max-w-full', className)}>
+      <Dialog open={open} onOpenChange={setOpen}>
+        {canExpand ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DialogTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-xs"
+                  aria-label={expandLabel}
+                  className="absolute top-2 right-2 z-10 bg-background/90 text-muted-foreground shadow-xs transition-opacity can-hover:opacity-0 group-focus-within/mermaid-diagram:opacity-100 group-hover/mermaid-diagram:opacity-100"
+                  onClick={(event) => {
+                    event.stopPropagation()
+                  }}
+                >
+                  <Maximize2 />
+                </Button>
+              </DialogTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={4}>
+              {expandLabel}
+            </TooltipContent>
+          </Tooltip>
+        ) : null}
+        {open ? (
+          <MermaidDiagramLightbox content={content} htmlLabels={htmlLabels} isDark={isDark} />
+        ) : null}
+      </Dialog>
+      <div ref={inlineRef} className="overflow-x-auto">
+        <MermaidBlock content={content} htmlLabels={htmlLabels} isDark={isDark} />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -5,7 +5,7 @@ import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
 import { useAppStore } from '@/store'
-import MermaidBlock from './MermaidBlock'
+import { ExpandableMermaidDiagram } from './MermaidDiagramLightbox'
 import { translate } from '@/i18n/i18n'
 import {
   getCodeBlockLanguageLabel,
@@ -151,7 +151,11 @@ export function RichMarkdownCodeBlock({
           Mermaid HTML labels just like markdown preview to keep labels visible. */}
       {isMermaid && node.textContent.trim() && (
         <div contentEditable={false} className="mermaid-preview">
-          <MermaidBlock content={node.textContent.trim()} isDark={isDark} htmlLabels={false} />
+          <ExpandableMermaidDiagram
+            content={node.textContent.trim()}
+            isDark={isDark}
+            htmlLabels={false}
+          />
         </div>
       )}
     </NodeViewWrapper>

--- a/src/renderer/src/components/editor/mermaid-svg-size.test.ts
+++ b/src/renderer/src/components/editor/mermaid-svg-size.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import {
+  mermaidDiagramCanExpand,
+  prepareMermaidSvgForZoom,
+  readMermaidSvgSize
+} from './mermaid-svg-size'
+
+function svgFromMarkup(markup: string): SVGSVGElement {
+  const container = document.createElement('div')
+  container.innerHTML = markup
+  const svg = container.querySelector('svg')
+  if (!svg) {
+    throw new Error('svg not found')
+  }
+  return svg
+}
+
+describe('mermaid svg size', () => {
+  it('reads width and height from the viewBox attribute', () => {
+    const svg = svgFromMarkup(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400"></svg>'
+    )
+    expect(readMermaidSvgSize(svg)).toEqual({ width: 800, height: 400 })
+  })
+
+  it('treats a rendered svg without an error banner as expandable', () => {
+    const root = document.createElement('div')
+    root.innerHTML =
+      '<div class="mermaid-block"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"></svg></div>'
+    expect(mermaidDiagramCanExpand(root)).toBe(true)
+  })
+
+  it('does not expand a failed mermaid fallback', () => {
+    const root = document.createElement('div')
+    root.innerHTML = '<div class="mermaid-block"><div class="mermaid-error">bad</div></div>'
+    expect(mermaidDiagramCanExpand(root)).toBe(false)
+  })
+
+  it('clears mermaid inline size caps so zoom can grow the svg', () => {
+    const svg = svgFromMarkup(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400" style="max-width: 800px; height: 400px;"></svg>'
+    )
+    prepareMermaidSvgForZoom(svg)
+    expect(svg.getAttribute('width')).toBeNull()
+    expect(svg.getAttribute('height')).toBeNull()
+    expect(svg.style.maxWidth).toBe('none')
+    expect(svg.style.width).toBe('100%')
+    expect(svg.style.height).toBe('100%')
+    expect(svg.getAttribute('preserveAspectRatio')).toBe('xMidYMid meet')
+  })
+})

--- a/src/renderer/src/components/editor/mermaid-svg-size.ts
+++ b/src/renderer/src/components/editor/mermaid-svg-size.ts
@@ -1,0 +1,72 @@
+export type MermaidSvgSize = {
+  width: number
+  height: number
+}
+
+function positiveSize(width: number, height: number): MermaidSvgSize | null {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null
+  }
+  return { width, height }
+}
+
+function sizeFromViewBoxAttr(svg: SVGSVGElement): MermaidSvgSize | null {
+  const viewBoxAttr = svg.getAttribute('viewBox')
+  if (!viewBoxAttr) {
+    return null
+  }
+  const parts = viewBoxAttr
+    .trim()
+    .split(/[\s,]+/)
+    .map(Number)
+  return parts.length === 4 ? positiveSize(parts[2], parts[3]) : null
+}
+
+export function readMermaidSvgSize(svg: SVGSVGElement): MermaidSvgSize | null {
+  const fromAttr = sizeFromViewBoxAttr(svg)
+  if (fromAttr) {
+    return fromAttr
+  }
+
+  const viewBox = svg.viewBox?.baseVal
+  if (viewBox) {
+    const fromViewBox = positiveSize(viewBox.width, viewBox.height)
+    if (fromViewBox) {
+      return fromViewBox
+    }
+  }
+
+  try {
+    const box = svg.getBBox()
+    const fromBox = positiveSize(box.width, box.height)
+    if (fromBox) {
+      return fromBox
+    }
+  } catch {
+    // SVG is not in a rendered layout yet.
+  }
+
+  return positiveSize(svg.clientWidth, svg.clientHeight)
+}
+
+export function findMermaidSvg(root: ParentNode | null): SVGSVGElement | null {
+  return root?.querySelector('svg') ?? null
+}
+
+export function mermaidDiagramCanExpand(root: ParentNode | null): boolean {
+  return findMermaidSvg(root) != null && root?.querySelector('.mermaid-error') == null
+}
+
+// Why: mermaid writes fixed max-width/height onto the SVG. Zoom layout sizes a
+// wrapper instead, so those inline caps have to come off or the diagram cannot
+// grow past its original pixel box.
+export function prepareMermaidSvgForZoom(svg: SVGSVGElement): void {
+  svg.style.maxWidth = 'none'
+  svg.style.width = '100%'
+  svg.style.height = '100%'
+  svg.removeAttribute('width')
+  svg.removeAttribute('height')
+  if (!svg.getAttribute('preserveAspectRatio')) {
+    svg.setAttribute('preserveAspectRatio', 'xMidYMid meet')
+  }
+}

--- a/src/renderer/src/components/editor/use-markdown-preview-components.tsx
+++ b/src/renderer/src/components/editor/use-markdown-preview-components.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import type { Components } from 'react-markdown'
 import type { MarkdownDocument } from '../../../../shared/filesystem-entry-types'
 import CodeBlockCopyButton from './CodeBlockCopyButton'
+import { ExpandableMermaidDiagram } from './MermaidDiagramLightbox'
 import MermaidBlock from './MermaidBlock'
 import {
   getMarkdownDocLinkAnchor,
@@ -156,7 +157,11 @@ export function useMarkdownPreviewComponents({
       code: ({ className, children, ...props }) => {
         if (/language-mermaid/.test(className || '')) {
           return (
-            <MermaidBlock content={String(children).trimEnd()} isDark={isDark} htmlLabels={false} />
+            <ExpandableMermaidDiagram
+              content={String(children).trimEnd()}
+              isDark={isDark}
+              htmlLabels={false}
+            />
           )
         }
         return (
@@ -167,7 +172,10 @@ export function useMarkdownPreviewComponents({
       },
       pre: ({ node, children, ...props }) => {
         const child = React.Children.toArray(children)[0]
-        if (React.isValidElement(child) && child.type === MermaidBlock) {
+        if (
+          React.isValidElement(child) &&
+          (child.type === ExpandableMermaidDiagram || child.type === MermaidBlock)
+        ) {
           return <>{children}</>
         }
         return wrapAnnotatedBlock(

--- a/src/renderer/src/components/editor/use-mermaid-diagram-zoom.ts
+++ b/src/renderer/src/components/editor/use-mermaid-diagram-zoom.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type ApplyImageViewerZoomChange,
+  applyAnchoredImageViewerZoomChange,
+  applyImageSurfaceWheel,
+  getElementSurfaceSize,
+  getImageLayoutStyle
+} from './image-viewer-dom-zoom'
+import {
+  IMAGE_VIEWER_ZOOM_STEP,
+  MAX_IMAGE_VIEWER_ZOOM,
+  MIN_IMAGE_VIEWER_ZOOM,
+  type ImageViewerImageDimensions,
+  type ImageViewerSurfaceSize,
+  getZoomedImageLayoutSize
+} from './image-viewer-zoom'
+
+export function useMermaidDiagramZoom(): {
+  zoomPercent: number
+  layoutStyle: ReturnType<typeof getImageLayoutStyle>
+  canZoomIn: boolean
+  canZoomOut: boolean
+  canReset: boolean
+  setSurfaceNode: (surface: HTMLDivElement | null) => void
+  setDiagramSize: (size: ImageViewerImageDimensions | null) => void
+  zoomIn: () => void
+  zoomOut: () => void
+  resetZoom: () => void
+} {
+  const [zoom, setZoom] = useState(1)
+  const [surfaceEl, setSurfaceEl] = useState<HTMLDivElement | null>(null)
+  const [surfaceSize, setSurfaceSize] = useState<ImageViewerSurfaceSize | null>(null)
+  const [diagramSize, setDiagramSize] = useState<ImageViewerImageDimensions | null>(null)
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
+
+  const applyZoomChange = useCallback<ApplyImageViewerZoomChange>((getNextZoom, anchor) => {
+    applyAnchoredImageViewerZoomChange(surfaceRef.current, setZoom, getNextZoom, anchor)
+  }, [])
+
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      applyImageSurfaceWheel(event, applyZoomChange)
+    },
+    [applyZoomChange]
+  )
+
+  const setSurfaceNode = useCallback((surface: HTMLDivElement | null) => {
+    surfaceRef.current = surface
+    setSurfaceEl(surface)
+    setSurfaceSize(surface ? getElementSurfaceSize(surface) : null)
+  }, [])
+
+  useEffect(() => {
+    if (!surfaceEl) {
+      return
+    }
+
+    const updateSize = (): void => setSurfaceSize(getElementSurfaceSize(surfaceEl))
+    updateSize()
+    surfaceEl.addEventListener('wheel', handleWheel, { passive: false })
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateSize)
+    observer?.observe(surfaceEl)
+    return () => {
+      surfaceEl.removeEventListener('wheel', handleWheel)
+      observer?.disconnect()
+    }
+  }, [handleWheel, surfaceEl])
+
+  const zoomIn = useCallback(() => {
+    applyZoomChange((currentZoom) => currentZoom * IMAGE_VIEWER_ZOOM_STEP)
+  }, [applyZoomChange])
+  const zoomOut = useCallback(() => {
+    applyZoomChange((currentZoom) => currentZoom / IMAGE_VIEWER_ZOOM_STEP)
+  }, [applyZoomChange])
+  const resetZoom = useCallback(() => {
+    applyZoomChange(() => 1)
+  }, [applyZoomChange])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) {
+        return
+      }
+      if (event.key === '+' || event.key === '=') {
+        event.preventDefault()
+        zoomIn()
+        return
+      }
+      if (event.key === '-') {
+        event.preventDefault()
+        zoomOut()
+        return
+      }
+      if (event.key === '0') {
+        event.preventDefault()
+        resetZoom()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [resetZoom, zoomIn, zoomOut])
+
+  const layoutSize = useMemo(
+    () =>
+      getZoomedImageLayoutSize({
+        imageDimensions: diagramSize,
+        surfaceSize,
+        zoom
+      }),
+    [diagramSize, surfaceSize, zoom]
+  )
+
+  return {
+    zoomPercent: Math.round(zoom * 100),
+    layoutStyle: getImageLayoutStyle(layoutSize),
+    canZoomIn: zoom < MAX_IMAGE_VIEWER_ZOOM,
+    canZoomOut: zoom > MIN_IMAGE_VIEWER_ZOOM,
+    canReset: zoom !== 1,
+    setSurfaceNode,
+    setDiagramSize,
+    zoomIn,
+    zoomOut,
+    resetZoom
+  }
+}

--- a/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
@@ -221,6 +221,7 @@ describe('CommentMarkdown', () => {
     expect(markup).toContain('mermaid-block')
     expect(markup).toContain('overflow-x-auto')
     expect(markup).toContain('[&amp;_.mermaid-block_pre]:max-h-80')
+    expect(markup).toContain('group/mermaid-diagram')
     expect(markup).not.toContain('<pre')
   })
 

--- a/src/renderer/src/components/sidebar/CommentMermaidBlock.tsx
+++ b/src/renderer/src/components/sidebar/CommentMermaidBlock.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import MermaidBlock from '@/components/editor/MermaidBlock'
+import { ExpandableMermaidDiagram } from '@/components/editor/MermaidDiagramLightbox'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 
 // Why: comment markdown components are module-level constants without access to
 // the live theme, so this wrapper resolves dark mode from the app store (same
-// logic the editor uses) and reuses the editor's MermaidBlock renderer. Mermaid
-// HTML labels are disabled because MermaidBlock sanitizes the SVG, and sanitized
+// logic the editor uses) and reuses the editor's mermaid renderer. Mermaid HTML
+// labels are disabled because MermaidBlock sanitizes the SVG, and sanitized
 // foreignObject labels disappear on some platforms.
 export default function CommentMermaidBlock({
   content,
@@ -21,8 +21,11 @@ export default function CommentMermaidBlock({
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
   return (
-    <div className={cn(className)}>
-      <MermaidBlock content={content} isDark={isDark} htmlLabels={false} />
-    </div>
+    <ExpandableMermaidDiagram
+      content={content}
+      isDark={isDark}
+      htmlLabels={false}
+      className={cn(className)}
+    />
   )
 }

--- a/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
@@ -248,7 +248,7 @@ export function createDocumentCommentMarkdownComponents(
       isMermaidFence(className) ? (
         renderMermaidFence(
           children,
-          'my-3 min-w-0 max-w-full overflow-x-auto rounded-md border border-border/60 p-3 [&_.mermaid-block]:min-w-0 [&_.mermaid-block_pre]:my-0 [&_.mermaid-block_pre]:max-h-80 [&_.mermaid-block_pre]:max-w-full [&_.mermaid-block_pre]:overflow-x-auto [&_.mermaid-block_pre]:rounded-md [&_.mermaid-block_pre]:bg-accent [&_.mermaid-block_pre]:p-3 [&_.mermaid-block_pre]:font-mono [&_.mermaid-block_pre]:text-[12px]'
+          'my-3 min-w-0 max-w-full rounded-md border border-border/60 p-3 [&_.mermaid-block]:min-w-0 [&_.mermaid-block_pre]:my-0 [&_.mermaid-block_pre]:max-h-80 [&_.mermaid-block_pre]:max-w-full [&_.mermaid-block_pre]:overflow-x-auto [&_.mermaid-block_pre]:rounded-md [&_.mermaid-block_pre]:bg-accent [&_.mermaid-block_pre]:p-3 [&_.mermaid-block_pre]:font-mono [&_.mermaid-block_pre]:text-[12px]'
         )
       ) : (
         <code className="rounded bg-accent px-1.5 py-0.5 font-mono text-[0.92em] [overflow-wrap:anywhere]">

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14800,6 +14800,16 @@
         "MermaidBlock": {
           "dcc132e691": "Diagram error:"
         },
+        "MermaidDiagramLightbox": {
+          "zoomOut": "Zoom out",
+          "resetZoom": "Reset zoom",
+          "zoomIn": "Zoom in",
+          "title": "Diagram",
+          "close": "Close",
+          "preview": "Full-screen diagram preview. Pinch or hold Ctrl and scroll to zoom. Scroll to pan.",
+          "escToClose": "Press Esc to close",
+          "expand": "Expand diagram"
+        },
         "MonacoEditor": {
           "68cb83f4a7": "Add note on selected text",
           "fd68ae03b3": "Search in Files",


### PR DESCRIPTION
## ELI5

Large mermaid diagrams in Chat UI and markdown preview can now be opened in a nearly fullscreen popup, then zoomed and panned so the labels stay readable.

## What Changed

- Add an expand control on rendered mermaid diagrams (hover on pointer devices, always visible on touch).
- Open the diagram in a dialog with zoom in/out/reset, pinch or Ctrl-scroll zoom, scroll-to-pan, and Escape to close.
- Wire it through Chat UI / comment markdown, markdown preview, and the rich-markdown mermaid live preview.
- Reuse the existing image-viewer zoom math so mermaid zoom/pan matches the image lightbox.

## Why

Wide mermaid diagrams were stuck in the chat/preview column. There was no focused canvas to inspect them without zooming the whole document. This is the Chat UI + zoom version of that gap.

## Linked Issue

Fixes #8731

Related: #8955 covers markdown-preview full-size viewing without zoom/pan. This PR also covers Chat UI and adds zoom.

## Visual Proof

Verified locally on a packaged macOS arm64 build (`dist/mac-arm64/Orca.app`): expand control on a Chat UI mermaid render, fullscreen dialog, zoom toolbar, pinch/Ctrl-scroll, Escape to close. Screenshots can be attached in review if needed.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm test src/renderer/src/components/editor/MermaidDiagramLightbox.test.tsx src/renderer/src/components/editor/mermaid-svg-size.test.ts src/renderer/src/components/sidebar/CommentMarkdown.test.tsx` — expand/open/zoom/close, SVG sizing, document mermaid fence wiring
- `pnpm tc:web` — passed
- oxlint + react-doctor on the touched renderer files — passed
- Manual: Chat UI mermaid on macOS arm64 local build

Not retested on Linux/Windows/SSH in this pass. Behavior is renderer-only (React dialog + CSS transform/layout zoom); WSL/SSH hosts still use terminal chat, so this path is local Chat UI / markdown preview.

## AI Disclosure

Implemented with Cursor Grok 4.6 in the local Orca checkout.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Standalone `.mmd` / `MermaidViewer` is unchanged (see #18467). Compact comment markdown still shows mermaid source, not a live diagram.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


Made with [Cursor](https://cursor.com)