### PR TITLE
fix(terminal): compose Option keys on the macOS US-International-PC layout

### DIFF
--- a/src/renderer/src/lib/keyboard-layout/detect-option-as-alt.ts
+++ b/src/renderer/src/lib/keyboard-layout/detect-option-as-alt.ts
@@ -10,9 +10,11 @@
  * The only defensible default is the one that varies per layout. This
  * module fingerprints the active layout from Chromium's
  * navigator.keyboard.getLayoutMap() (ships in Chrome 69+, so every Electron
- * we could run). We match Ghostty's taxonomy: US / US-International map to
- * `true`; everything else — including Dvorak, Colemak, UK, every
- * international layout — maps to `false`.
+ * we could run). The base layer cannot separate US from US-International or
+ * ABC, so every US-shaped layout maps to `true` here and `input-source-id.ts`
+ * narrows that to plain US whenever macOS gives us the real input source ID.
+ * Everything else — Dvorak, Colemak, UK, every international layout — maps
+ * to `false`.
  *
  * Reference implementation in Ghostty:
  *   ~/projects/ghostty/src/input/keyboard.zig:25-57 (Layout enum + detectOptionAsAlt)
@@ -61,7 +63,8 @@ export type DetectedLayoutCategory =
  * Semicolon (`o` vs `;`). Dvorak fails KeyQ immediately. Both get classified
  * as `non-us` and default to `'false'`; users who want `'true'` flip the
  * explicit override. Matches Ghostty (Ghostty only whitelists
- * com.apple.keylayout.US and com.apple.keylayout.USInternational).
+ * com.apple.keylayout.US; see input-source-id.ts for why we drop
+ * USInternational-PC from that allowlist).
  */
 const US_FINGERPRINT: Record<string, string> = {
   KeyQ: 'q',

--- a/src/renderer/src/lib/keyboard-layout/input-source-id.test.ts
+++ b/src/renderer/src/lib/keyboard-layout/input-source-id.test.ts
@@ -12,8 +12,11 @@ describe('classifyInputSourceId', () => {
     expect(classifyInputSourceId('com.apple.keylayout.US')).toBe('meta')
   })
 
-  it('allowlists US International PC as meta', () => {
-    expect(classifyInputSourceId('com.apple.keylayout.USInternational-PC')).toBe('meta')
+  it('classifies US International PC as compose (Option+C → ç repro)', () => {
+    // The International variant is picked precisely to type accented
+    // characters, and its Option layer composes them: Option+C → ç,
+    // Option+Shift+C → Ç, Option+A → å, Option+E → dead acute.
+    expect(classifyInputSourceId('com.apple.keylayout.USInternational-PC')).toBe('compose')
   })
 
   it('is case-insensitive on the allowlist (defaults differ between macOS versions)', () => {
@@ -38,9 +41,9 @@ describe('classifyInputSourceId', () => {
   })
 
   it('classifies every other Apple-shipped layout as compose (default-deny)', () => {
-    // Matches Ghostty: only US and USInternational-PC are allowlisted;
-    // everything else (Dvorak, Colemak, German, French, Turkish, Spanish,
-    // Swedish, every CJK Roman IME) falls back to compose.
+    // Only plain US is allowlisted; everything else (Dvorak, Colemak,
+    // German, French, Turkish, Spanish, Swedish, every CJK Roman IME)
+    // falls back to compose.
     expect(classifyInputSourceId('com.apple.keylayout.Dvorak')).toBe('compose')
     expect(classifyInputSourceId('com.apple.keylayout.Colemak')).toBe('compose')
     expect(classifyInputSourceId('com.apple.keylayout.German')).toBe('compose')

--- a/src/renderer/src/lib/keyboard-layout/input-source-id.ts
+++ b/src/renderer/src/lib/keyboard-layout/input-source-id.ts
@@ -13,12 +13,14 @@
  * an Esc+letter readline chord — so typing å, ą, ï, etc., fails with no
  * visible feedback (issue #1205).
  *
- * The only layouts where Option-as-Meta is the right default are plain
- * US Standard and US-International-PC — matching Ghostty's
- * `detectOptionAsAlt` (~/projects/ghostty/src/input/keyboard.zig:25-57
- * + ~/projects/ghostty/macos/Sources/Helpers/KeyboardLayout.swift,
- * which whitelists only `com.apple.keylayout.US` and
- * `com.apple.keylayout.USInternational-PC`).
+ * Plain US Standard is the only layout where Option-as-Meta is the right
+ * default: its Option layer carries glyphs (ç, å, ∫) nobody selected that
+ * layout to type. US-International-PC is deliberately NOT allowlisted even
+ * though Ghostty allowlists it — picking the International variant over US
+ * is itself the statement that accented input matters, and its Option layer
+ * is a composition layer (Option+C → ç, Option+Shift+C → Ç, Option+A → å,
+ * Option+E → dead acute, verified with UCKeyTranslate against the shipped
+ * keylayout). Treating it as Meta swallows every one of those keystrokes.
  *
  * When the main-process IPC returns a non-null ID, this classifier is
  * authoritative: `'meta'` → Option-as-Meta is safe; `'compose'` →
@@ -27,21 +29,16 @@
  */
 
 /**
- * Input source IDs where Option-as-Meta is the correct default. The
- * shipped US Standard and US-International-PC layouts are the only
- * Apple layouts that don't use Option for composition. Everything else
- * — including ABC, Polish Pro, US Extended, ABC Extended, every
- * international layout, every CJK Roman IME — composes via Option and
- * must stay `'false'`.
+ * Input source IDs where Option-as-Meta is the correct default. Every
+ * other Apple layout — ABC, Polish Pro, US Extended, ABC Extended,
+ * US-International-PC, every international layout, every CJK Roman IME —
+ * composes via Option and must stay `'false'`.
  *
  * Matching is case-insensitive full-ID. We deliberately do NOT prefix-
  * match here: `com.apple.keylayout.US` must not silently allowlist
  * `com.apple.keylayout.USExtended`.
  */
-const META_INPUT_SOURCE_IDS: readonly string[] = [
-  'com.apple.keylayout.us',
-  'com.apple.keylayout.usinternational-pc'
-]
+const META_INPUT_SOURCE_IDS: readonly string[] = ['com.apple.keylayout.us']
 
 export type InputSourceOverride =
   /** Option-as-Meta is safe on this input source. Resolves to `'us'`
@@ -68,9 +65,9 @@ export function classifyInputSourceId(id: string | null | undefined): InputSourc
   }
   // Why: any other macOS input source ID composes via Option. This
   // includes ABC (not to be confused with US), Polish Pro, US Extended,
-  // ABC Extended, every international layout, Dvorak, Colemak, and
-  // every CJK Roman IME. Forcing `'compose'` matches Ghostty's
-  // allowlist-only behavior and prevents the #1205-style silent-swallow
-  // bug from recurring for any future Apple-shipped layout.
+  // ABC Extended, US-International-PC, every international layout,
+  // Dvorak, Colemak, and every CJK Roman IME. Allowlist-only keeps the
+  // #1205-style silent-swallow bug from recurring on any future
+  // Apple-shipped layout.
   return 'compose'
 }


### PR DESCRIPTION
## ELI5

On the `U.S. International - PC` keyboard layout, pressing Option+C in an Orca terminal produced nothing at all. No `ç`, no error, no feedback. Same for `Ç`, `å`, and the dead-key accents.

Orca had that layout on the list of keyboards where Option means Alt, so it turned every Option+letter into a readline chord instead of letting macOS compose the character. On a layout whose whole point is typing accented characters, that is the wrong end of the trade.

## Problem

`classifyInputSourceId` allowlists two input sources as Option-as-Meta:

```ts
const META_INPUT_SOURCE_IDS: readonly string[] = [
  'com.apple.keylayout.us',
  'com.apple.keylayout.usinternational-pc'
]
```

With the default `terminalMacOptionAsAlt: 'auto'`, the second entry sends US-International users down this path: classifier returns `'meta'` → `effectiveMacOptionAsAlt` resolves to `'true'` → `macOptionIsMeta` turns on → `resolveTerminalOptionShortcutAction` emits `\x1b` + the base character. In a shell, in Claude Code, in Codex CLI, `Esc c` is a no-op with no output, so the keystroke looks like it was dropped.

This is #1205 again — Polish Pro, ABC, US Extended, all silently swallowed by the same mechanism — on a layout that fix did not cover.

The entry came from Ghostty's allowlist rather than from the layout itself. The shipped keylayout says the opposite; `UCKeyTranslate` against the active input source:

| Key | Plain | Option | Option+Shift |
|-----|-------|--------|--------------|
| C | `c` | `ç` | `Ç` |
| A | `a` | `å` | `Å` |
| E | `e` | `´` (dead) | `´` |
| N | `n` | `˜` (dead) | `˜` |
| U | `u` | `¨` (dead) | `¨` |

That is a composition layer, structurally identical to the layouts already classified `compose`. And unlike plain `U.S.`, where the Option glyphs are incidental and nobody selected the layout for them, picking the International variant is itself the statement that accented input matters.

## Fix

Drop `com.apple.keylayout.usinternational-pc` from the allowlist. Plain `com.apple.keylayout.US` stays the only entry, so nothing changes for US users, who keep Option as Alt.

The fingerprint probe in `detect-option-as-alt.ts` is untouched: `getLayoutMap()` only exposes the base layer, which is identical across US, US-International and ABC, so it cannot separate them and still maps every US-shaped layout to `true`. `input-source-id.ts` is what narrows that to plain US whenever macOS hands us a real input source ID, and it stays authoritative. Comments in both files now say which one decides what.

Users who prefer the old behaviour set `Settings > Terminal > Option as Alt` to `Both`. Users on the fix keep Option+B / Option+F / Option+D word navigation regardless, since `terminal-option-shortcut-policy.ts` sends those explicitly when Option is not Meta.

## Linked Issue

Fixes #20163

## Visual Proof

N/A. The observable difference is one character appearing in a terminal where nothing appeared before, so a screenshot shows a `ç` without showing which keystroke produced it. The mechanical evidence is the `UCKeyTranslate` table above and `input-source-id.test.ts`, which pins the exact input source ID.

## Testing

macOS 26 (Darwin 25.6.0), Apple silicon, local execution host, input source `com.apple.keylayout.USInternational-PC`, `terminalMacOptionAsAlt` left at `auto`.

Manual, in a terminal pane on a dev build: Option+C → `ç`, Option+Shift+C → `Ç`, Option+A → `å`, Option+E then `e` → `é`. Option+B / Option+F / Option+D still move by word, so the readline compensation survives the flip.

- `pnpm test src/renderer/src/lib/keyboard-layout src/renderer/src/components/terminal-pane/terminal-shortcut-option-compose.test.ts src/renderer/src/components/terminal-pane/terminal-option-kitty-release.test.ts src/renderer/src/components/settings` — 181 files, 1250 tests, all pass
- `pnpm tc` — clean
- `pnpm run check:code-quality:changed` — 0 new findings across 3 changed files

`input-source-id.test.ts` had a case asserting the old behaviour; it now asserts `compose` for that ID and carries the layout evidence as a comment, so the next person reading the allowlist does not re-add the entry from Ghostty's list.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

macOS-only code path, behind the existing `isMac` guard. No wire format, no IPC shape, no persisted setting changed, so remote hosts and older clients are unaffected and the setting keeps its four explicit modes plus `auto`. Windows and Linux never reach this classifier. Anyone who had already set an explicit `Option as Alt` value keeps it: only `auto` resolves differently, and only on this one input source.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
