### PR TITLE
feat(tab-group): auto-hide a pane's tab bar while it holds a single tab

### DIFF
--- a/src/renderer/src/app-shell/AppWorkspaceShell.tsx
+++ b/src/renderer/src/app-shell/AppWorkspaceShell.tsx
@@ -133,7 +133,8 @@ export function AppWorkspaceShell(props: {
                     // Why: floating titlebar-left occludes the center column's border-l seam; border-r restores that line, w-max sizes it to its own controls.
                     className={`titlebar-left${
                       layout.leftTitlebarChromeLayout.isFloating
-                        ? ' titlebar-left-floating absolute top-0 left-0 z-10 w-max border-r border-border'
+                        ? // Why: above z-20 — an auto-hidden tab strip reveals over the pane and would otherwise bury this floating header.
+                          ' titlebar-left-floating absolute top-0 left-0 z-30 w-max border-r border-border'
                         : ''
                     }`}
                     style={{
@@ -165,7 +166,8 @@ export function AppWorkspaceShell(props: {
                 {/* Why: match the RightSidebar header's 36px/top-0 so the toggle's vertical center is identical open vs closed — else the icon jitters. */}
                 {layout.workspaceChromeActive && !layout.rightSidebarOpen && (
                   <div
-                    className="absolute top-0 z-10 flex items-center h-[36px]"
+                    // Why: above z-20 — an auto-hidden tab strip reveals over the pane and would otherwise bury this toggle.
+                    className="absolute top-0 z-30 flex items-center h-[36px]"
                     style={
                       {
                         // Why: --window-controls-width keeps the toggle clear of the fixed window-controls overlay (138px on custom chrome, 0px otherwise); no internal spacer — one would cover the pane-actions Ellipsis button with an unclickable div.

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -158,6 +158,32 @@ export function GeneralPane({
             }
           />
         </SearchableSetting>
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.GeneralPane.autoHideSingleTabStrip',
+            'Hide the tab bar when a pane has one tab'
+          )}
+          description={translate(
+            'auto.components.settings.GeneralPane.autoHideSingleTabStripDescription',
+            'Collapse the tab bar until you hover the top edge of the pane.'
+          )}
+          keywords={['tab', 'tab bar', 'hide', 'auto hide', 'single', 'strip']}
+        >
+          <SettingsSwitchRow
+            label={translate(
+              'auto.components.settings.GeneralPane.autoHideSingleTabStrip',
+              'Hide the tab bar when a pane has one tab'
+            )}
+            description={translate(
+              'auto.components.settings.GeneralPane.autoHideSingleTabStripDescription',
+              'Collapse the tab bar until you hover the top edge of the pane.'
+            )}
+            checked={settings.autoHideSingleTabStrip === true}
+            onChange={() =>
+              updateSettings({ autoHideSingleTabStrip: settings.autoHideSingleTabStrip !== true })
+            }
+          />
+        </SearchableSetting>
       </section>
     ) : null,
     matchesSettingsSearch(searchQuery, getGeneralWorkspaceSearchEntries()) ? (

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -62,17 +62,22 @@ export function shouldShowProjectRuntimeSection(
   )
 }
 
+// Why: the row's own filter must match the same localized terms as the catalog that reveals the
+// section, or a non-English query shows the Navigation section with this row filtered out of it.
+function flattenNavigationSearchEntry(entry: GeneralSearchEntry | undefined): string[] {
+  return entry ? [entry.title, entry.description ?? '', ...(entry.keywords ?? [])] : []
+}
+
 export function getTabOrderControlSearchKeywords(
   navigationEntries: GeneralSearchEntry[] = getGeneralNavigationSearchEntries()
 ): string[] {
-  const tabOrderSearchEntry = navigationEntries[0]
-  return tabOrderSearchEntry
-    ? [
-        tabOrderSearchEntry.title,
-        tabOrderSearchEntry.description ?? '',
-        ...(tabOrderSearchEntry.keywords ?? [])
-      ]
-    : []
+  return flattenNavigationSearchEntry(navigationEntries[0])
+}
+
+export function getAutoHideSingleTabStripSearchKeywords(
+  navigationEntries: GeneralSearchEntry[] = getGeneralNavigationSearchEntries()
+): string[] {
+  return flattenNavigationSearchEntry(navigationEntries[2])
 }
 
 const EMPTY_WSL_DISTROS: string[] = []
@@ -117,6 +122,9 @@ export function GeneralPane({
       activeRuntimeTarget.environmentId === sourceDefaultsSupportedRuntimeEnvironmentId)
   const generalNavigationSearchEntries = getGeneralNavigationSearchEntries()
   const tabOrderKeywords = getTabOrderControlSearchKeywords(generalNavigationSearchEntries)
+  const autoHideStripKeywords = getAutoHideSingleTabStripSearchKeywords(
+    generalNavigationSearchEntries
+  )
   const projectRuntimeSearchEntries = wslSupportedPlatform
     ? getGeneralProjectRuntimeSearchEntries()
     : []
@@ -167,7 +175,7 @@ export function GeneralPane({
             'auto.components.settings.GeneralPane.autoHideSingleTabStripDescription',
             'Collapse the tab bar until you hover the top edge of the pane.'
           )}
-          keywords={['tab', 'tab bar', 'hide', 'auto hide', 'single', 'strip']}
+          keywords={autoHideStripKeywords}
         >
           <SettingsSwitchRow
             label={translate(

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -151,6 +151,39 @@ export const getGeneralNavigationSearchEntries = createLocalizedCatalog(() => [
       ...translateSearchKeyword('auto.components.settings.general.search.9f8558233a', 'confirm'),
       ...translateSearchKeyword('auto.components.settings.general.search.afa37a34e1', 'close')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.general.search.autoHideSingleTabStrip',
+      'Hide the tab bar when a pane has one tab'
+    ),
+    description: translate(
+      'auto.components.settings.general.search.autoHideSingleTabStripDescription',
+      'Collapse the tab bar until you hover the top edge of the pane.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.2a254b725e', 'tab'),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.autoHideSingleTabStripKeywordBar',
+        'tab bar'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.autoHideSingleTabStripKeywordHide',
+        'hide'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.autoHideSingleTabStripKeywordAutoHide',
+        'auto hide'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.autoHideSingleTabStripKeywordSingle',
+        'single'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.autoHideSingleTabStripKeywordStrip',
+        'strip'
+      )
+    ]
   }
 ])
 

--- a/src/renderer/src/components/tab-group/TabGroupPaneActionsMenu.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPaneActionsMenu.tsx
@@ -1,0 +1,53 @@
+import { Ellipsis, X } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+
+const TRIGGER_CLASS_NAME =
+  'my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
+
+/** The focused split pane's "…" menu on the tab strip. */
+export function TabGroupPaneActionsMenu({
+  onCloseGroup
+}: {
+  onCloseGroup: () => void
+}): React.JSX.Element {
+  const label = translate('auto.components.tab.group.TabGroupPanel.9acaf92093', 'Pane Actions')
+  return (
+    <Tooltip>
+      <DropdownMenu modal={false}>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label={label}
+              onClick={(event) => {
+                event.stopPropagation()
+              }}
+              className={TRIGGER_CLASS_NAME}
+            >
+              <Ellipsis className="size-4" />
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <DropdownMenuContent align="end" side="bottom" sideOffset={4}>
+          <DropdownMenuItem variant="destructive" onSelect={onCloseGroup}>
+            <X className="size-4" />
+            {translate(
+              'auto.components.tab.group.TabGroupPanel.closePaneColumn',
+              'Close split pane'
+            )}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -11,6 +11,7 @@ import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
 import { getTabPaneBodyDroppableId, type HoveredTabInsertion } from './useTabDragSplit'
 import { tabGroupBodyAnchorName } from './tab-group-body-anchor'
+import { isAutoHideSingleTabStripEnabled } from './auto-hide-single-tab-strip-preference'
 import { resolveSingleTabStripVisibility } from './single-tab-strip-visibility'
 import { useTabStripRevealHover } from './tab-strip-reveal-hover'
 import { TabGroupPaneActionsMenu } from './TabGroupPaneActionsMenu'
@@ -80,8 +81,8 @@ export default function TabGroupPanel({
   const clientHostedRows = ownsClientHostedRows
     ? worktreeClientHostedRows
     : EMPTY_CLIENT_HOSTED_ROWS
-  const autoHideSingleTabStrip = useAppStore(
-    (state) => state.settings?.autoHideSingleTabStrip === true
+  const autoHideSingleTabStrip = useAppStore((state) =>
+    isAutoHideSingleTabStripEnabled(state.settings)
   )
   const [stripHovered, setStripHovered] = useState(false)
   const { autoHidden: stripAutoHidden, revealed: stripRevealed } = resolveSingleTabStripVisibility({

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -263,7 +263,7 @@ export default function TabGroupPanel({
           : 'h-[32px] shrink-0 border-b border-border bg-card'
       }${unfocusedDimClassName}`}
       // Why: a drag region swallows renderer pointer events, so a revealed strip that kept one would lose the hover that holds it open.
-      // Why: collapsed, the hover wrapper carries the strip identity — pane-detach drops hit-test the topmost element, and a translated-away strip is never it.
+      // Why: collapsed, the hover wrapper carries the strip identity instead — the translated-away strip has no rect a drop could land in.
       {...(stripAutoHidden
         ? {}
         : {
@@ -338,10 +338,10 @@ export default function TabGroupPanel({
       onFocusCapture={commands.focusGroup}
     >
       {/* Why: each split group needs its own tab row because multiple groups can show at once but the titlebar has only one shared center slot. */}
-      {/* Why: macOS hiddenInset titleBarStyle makes -webkit-app-region: drag the only way to move the window from this tab row. */}
+      {/* Why: macOS hiddenInset titleBarStyle makes -webkit-app-region: drag the only way to move the window from this tab row — except while auto-hide holds the row collapsed, which trades that drag surface away. */}
       {stripAutoHidden ? (
-        // Why: while collapsed this carries the strip's identity for pane-detach drops but stays
-        // click-through, so the pane keeps its own top rows until the strip actually reveals.
+        // Why: click-through while collapsed, so the pane keeps its own top rows. It still carries
+        // the strip identity, which pane-detach matches by rect since hit-testing skips this.
         <div
           className={`absolute inset-x-0 top-0 z-20 h-[32px] ${
             stripRevealed ? '' : 'pointer-events-none'

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,15 +1,8 @@
-import { Suspense, useMemo } from 'react'
+import { Suspense, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { useDroppable } from '@dnd-kit/core'
-import { Ellipsis, X } from 'lucide-react'
+import { SYNC_FIT_PANES_EVENT } from '@/constants/terminal'
 import { useAppStore } from '../../store'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger
-} from '@/components/ui/dropdown-menu'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import TabBar from '../tab-bar/TabBar'
 
 import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
@@ -18,6 +11,9 @@ import { closeTerminalTab } from '../terminal/terminal-tab-actions'
 import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
 import { getTabPaneBodyDroppableId, type HoveredTabInsertion } from './useTabDragSplit'
 import { tabGroupBodyAnchorName } from './tab-group-body-anchor'
+import { resolveSingleTabStripVisibility } from './single-tab-strip-visibility'
+import { useTabStripRevealHover } from './tab-strip-reveal-hover'
+import { TabGroupPaneActionsMenu } from './TabGroupPaneActionsMenu'
 import { translate } from '@/i18n/i18n'
 import type { TabGroup } from '../../../../shared/tab-types'
 import type { ClientHostedBrowserRow } from '../../../../shared/client-hosted-browser-rows'
@@ -84,6 +80,38 @@ export default function TabGroupPanel({
   const clientHostedRows = ownsClientHostedRows
     ? worktreeClientHostedRows
     : EMPTY_CLIENT_HOSTED_ROWS
+  const autoHideSingleTabStrip = useAppStore(
+    (state) => state.settings?.autoHideSingleTabStrip === true
+  )
+  const [stripHovered, setStripHovered] = useState(false)
+  const { autoHidden: stripAutoHidden, revealed: stripRevealed } = resolveSingleTabStripVisibility({
+    autoHideEnabled: autoHideSingleTabStrip,
+    groupTabCount: model.groupTabs.length,
+    clientHostedRowCount: clientHostedRows.length,
+    stripHovered,
+    tabDragActive: isTabDragActive
+  })
+  // Why: the watcher stops with the collapsed strip, so a reveal that ends by gaining a tab never
+  // sees the pointer leave and would come back already revealed once the group drops to one tab again.
+  if (!stripAutoHidden && stripHovered) {
+    setStripHovered(false)
+  }
+  const panelRef = useRef<HTMLDivElement | null>(null)
+  useTabStripRevealHover({
+    enabled: stripAutoHidden && isVisible,
+    panelRef,
+    onHoverChange: setStripHovered
+  })
+  // Why: this transition moves the pane body by 32px and xterm only reflows on this event; skipping
+  // the mount run matters because every worktree's groups stay mounted and each would refit them all.
+  const didSyncStripHeightRef = useRef(false)
+  useLayoutEffect(() => {
+    if (!didSyncStripHeightRef.current) {
+      didSyncStripHeightRef.current = true
+      return
+    }
+    window.dispatchEvent(new CustomEvent(SYNC_FIT_PANES_EVENT))
+  }, [stripAutoHidden])
   const { setNodeRef: setBodyDropRef } = useDroppable({
     id: getTabPaneBodyDroppableId(groupId),
     data: {
@@ -217,14 +245,79 @@ export default function TabGroupPanel({
     />
   )
 
-  const menuButtonClassName =
-    'my-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
   // Why: focused-only so quick commands and Close split pane stay with the active pane and unfocused strips stay compact.
   const focusedActionChromeClassName = `flex shrink-0 items-center gap-0.5 overflow-hidden transition-[opacity] duration-150 ${
     isFocused ? 'ml-1.5 pointer-events-auto opacity-100' : 'pointer-events-none opacity-0 w-0'
   }`
+  // Why: dim the children, not the root — root opacity opens a stacking context that traps the revealed strip under the worktree-level pane overlays.
+  const unfocusedDimClassName = hasSplitGroups && !isFocused ? ' opacity-95' : ''
+  const stripRow = (
+    <div
+      className={`${
+        stripAutoHidden
+          ? // Why: no slide during a tab drag — dnd-kit measures droppable rects once at drag start and would record the strip mid-animation.
+            `absolute inset-x-0 top-0 h-[32px] border-b border-border bg-card ${
+              isTabDragActive ? '' : 'transition-transform duration-150'
+            } ${stripRevealed ? 'translate-y-0' : '-translate-y-full'}`
+          : 'h-[32px] shrink-0 border-b border-border bg-card'
+      }${unfocusedDimClassName}`}
+      // Why: a drag region swallows renderer pointer events, so a revealed strip that kept one would lose the hover that holds it open.
+      // Why: collapsed, the hover wrapper carries the strip identity — pane-detach drops hit-test the topmost element, and a translated-away strip is never it.
+      {...(stripAutoHidden
+        ? {}
+        : {
+            'data-terminal-focus-release-surface': 'true',
+            'data-tab-group-strip-id': groupId,
+            'data-worktree-id': worktreeId
+          })}
+      inert={stripAutoHidden && !stripRevealed}
+    >
+      <div className="flex h-full items-stretch pr-1.5">
+        {/* Why: Electron drag hit-test respects no-drag only on DOM descendants, not z-index siblings, so this no-drag spacer keeps the collapsed left-sidebar's floating toggle clickable. */}
+        {reserveCollapsedSidebarHeaderSpace && !sidebarOpen ? (
+          <div
+            className="shrink-0"
+            style={
+              {
+                width: 'var(--collapsed-sidebar-header-width)',
+                WebkitAppRegion: 'no-drag'
+              } as React.CSSProperties
+            }
+          />
+        ) : null}
+        <div className="min-w-0 flex-1 h-full">{tabBar}</div>
+        <div
+          className="ml-1.5 flex shrink-0 items-center gap-0.5"
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        >
+          <div className={focusedActionChromeClassName}>
+            {isFocused ? (
+              <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
+            ) : null}
+            {isFocused && hasSplitGroups ? (
+              <TabGroupPaneActionsMenu onCloseGroup={commands.closeGroup} />
+            ) : null}
+          </div>
+        </div>
+        {/* Why: Electron drag hit-test respects no-drag only on DOM descendants, not z-index siblings, so this no-drag spacer keeps the floating right-sidebar toggle + window controls clickable. */}
+        {reserveClosedExplorerToggleSpace && !rightSidebarOpen ? (
+          <div
+            className="shrink-0"
+            style={
+              {
+                width: 'calc(40px + var(--window-controls-width, 0px))',
+                WebkitAppRegion: 'no-drag'
+              } as React.CSSProperties
+            }
+          />
+        ) : null}
+      </div>
+    </div>
+  )
+
   return (
     <div
+      ref={panelRef}
       // Why: vertical borders stay `border-border` so the focus highlight (--accent ~#f5f5f5 in light) doesn't paint a near-white strip by the resize handle; only the bottom border changes on focus.
       // Why: unfocused split groups dim subtly so the focused one reads as selected; only when hasSplitGroups since a lone group has nothing to contrast against.
       className={`group/tab-group relative flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden${
@@ -236,7 +329,7 @@ export default function TabGroupPanel({
               touchesBottomEdge || suppressBottomBorder ? '' : 'border-b'
             } border-border ${
               isFocused && !touchesBottomEdge && !suppressBottomBorder ? 'border-b-accent' : ''
-            } ${isFocused ? '' : 'opacity-95'}`
+            }`
           : ''
       }`}
       onPointerDown={commands.focusGroup}
@@ -245,99 +338,28 @@ export default function TabGroupPanel({
     >
       {/* Why: each split group needs its own tab row because multiple groups can show at once but the titlebar has only one shared center slot. */}
       {/* Why: macOS hiddenInset titleBarStyle makes -webkit-app-region: drag the only way to move the window from this tab row. */}
-      <div
-        className="h-[32px] shrink-0 border-b border-border bg-card"
-        data-tab-group-strip-id={groupId}
-        data-terminal-focus-release-surface="true"
-        data-worktree-id={worktreeId}
-      >
-        <div className="flex h-full items-stretch pr-1.5">
-          {/* Why: Electron drag hit-test respects no-drag only on DOM descendants, not z-index siblings, so this no-drag spacer keeps the collapsed left-sidebar's floating toggle clickable. */}
-          {reserveCollapsedSidebarHeaderSpace && !sidebarOpen ? (
-            <div
-              className="shrink-0"
-              style={
-                {
-                  width: 'var(--collapsed-sidebar-header-width)',
-                  WebkitAppRegion: 'no-drag'
-                } as React.CSSProperties
-              }
-            />
-          ) : null}
-          <div className="min-w-0 flex-1 h-full">{tabBar}</div>
-          <div
-            className="ml-1.5 flex shrink-0 items-center gap-0.5"
-            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-          >
-            <div className={focusedActionChromeClassName}>
-              {isFocused ? (
-                <TabBarQuickCommandsButton worktreeId={worktreeId} groupId={groupId} />
-              ) : null}
-              {isFocused && hasSplitGroups ? (
-                <Tooltip>
-                  <DropdownMenu modal={false}>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          type="button"
-                          aria-label={translate(
-                            'auto.components.tab.group.TabGroupPanel.9acaf92093',
-                            'Pane Actions'
-                          )}
-                          onClick={(event) => {
-                            event.stopPropagation()
-                          }}
-                          className={menuButtonClassName}
-                        >
-                          <Ellipsis className="size-4" />
-                        </button>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <DropdownMenuContent align="end" side="bottom" sideOffset={4}>
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onSelect={() => {
-                          commands.closeGroup()
-                        }}
-                      >
-                        <X className="size-4" />
-                        {translate(
-                          'auto.components.tab.group.TabGroupPanel.closePaneColumn',
-                          'Close split pane'
-                        )}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                  <TooltipContent side="bottom" sideOffset={6}>
-                    {translate(
-                      'auto.components.tab.group.TabGroupPanel.9acaf92093',
-                      'Pane Actions'
-                    )}
-                  </TooltipContent>
-                </Tooltip>
-              ) : null}
-            </div>
-          </div>
-          {/* Why: Electron drag hit-test respects no-drag only on DOM descendants, not z-index siblings, so this no-drag spacer keeps the floating right-sidebar toggle + window controls clickable. */}
-          {reserveClosedExplorerToggleSpace && !rightSidebarOpen ? (
-            <div
-              className="shrink-0"
-              style={
-                {
-                  width: 'calc(40px + var(--window-controls-width, 0px))',
-                  WebkitAppRegion: 'no-drag'
-                } as React.CSSProperties
-              }
-            />
-          ) : null}
+      {stripAutoHidden ? (
+        // Why: while collapsed this carries the strip's identity for pane-detach drops but stays
+        // click-through, so the pane keeps its own top rows until the strip actually reveals.
+        <div
+          className={`absolute inset-x-0 top-0 z-20 h-[32px] ${
+            stripRevealed ? '' : 'pointer-events-none'
+          }`}
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          data-tab-group-strip-id={groupId}
+          data-worktree-id={worktreeId}
+        >
+          {stripRow}
         </div>
-      </div>
+      ) : (
+        stripRow
+      )}
 
       <div
         ref={setBodyDropRef}
         data-tab-group-body-id={groupId}
         data-worktree-id={worktreeId}
-        className="relative flex-1 min-h-0 overflow-hidden"
+        className={`relative flex-1 min-h-0 overflow-hidden${unfocusedDimClassName}`}
         style={bodyAnchorStyle}
       >
         {/* Why: empty anchor so the agent-sessions tour reads as a terminal-area tip, not toolbar chrome. */}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.drag.test.tsx
@@ -17,8 +17,15 @@ vi.mock('../../store', () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       recordFeatureInteraction: recordFeatureInteractionMock,
-      setTabGroupSplitRatio: setTabGroupSplitRatioMock
+      setTabGroupSplitRatio: setTabGroupSplitRatioMock,
+      groupsByWorktree: {},
+      unifiedTabsByWorktree: {},
+      settings: {}
     })
+}))
+
+vi.mock('@/lib/pane-manager/client-hosted-browser-row-state', () => ({
+  useClientHostedBrowserRows: () => []
 }))
 
 vi.mock('./TabGroupPanel', () => ({

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -4,25 +4,28 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const setTabGroupSplitRatioMock = vi.fn()
 const recordFeatureInteractionMock = vi.fn()
 const setDragRootNodeMock = vi.fn()
-const useAppStoreMock = vi.fn(
-  (
-    selector: (state: {
-      recordFeatureInteraction: typeof recordFeatureInteractionMock
-      setTabGroupSplitRatio: typeof setTabGroupSplitRatioMock
-    }) => unknown
-  ) =>
-    selector({
-      recordFeatureInteraction: recordFeatureInteractionMock,
-      setTabGroupSplitRatio: setTabGroupSplitRatioMock
-    })
+type MockStoreState = {
+  recordFeatureInteraction: typeof recordFeatureInteractionMock
+  setTabGroupSplitRatio: typeof setTabGroupSplitRatioMock
+  groupsByWorktree: Record<string, unknown[]>
+  unifiedTabsByWorktree: Record<string, unknown[]>
+  settings: Record<string, unknown>
+}
+const useAppStoreMock = vi.fn((selector: (state: MockStoreState) => unknown) =>
+  selector({
+    recordFeatureInteraction: recordFeatureInteractionMock,
+    setTabGroupSplitRatio: setTabGroupSplitRatioMock,
+    groupsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    settings: {}
+  })
 )
 vi.mock('../../store', () => ({
-  useAppStore: (
-    selector: (state: {
-      recordFeatureInteraction: typeof recordFeatureInteractionMock
-      setTabGroupSplitRatio: typeof setTabGroupSplitRatioMock
-    }) => unknown
-  ) => useAppStoreMock(selector)
+  useAppStore: (selector: (state: MockStoreState) => unknown) => useAppStoreMock(selector)
+}))
+
+vi.mock('@/lib/pane-manager/client-hosted-browser-row-state', () => ({
+  useClientHostedBrowserRows: () => []
 }))
 
 vi.mock('./TabGroupPanel', () => ({

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { DndContext, DragOverlay } from '@dnd-kit/core'
-import type { TabGroupLayoutNode } from '../../../../shared/tab-types'
+import type { Tab, TabGroup, TabGroupLayoutNode } from '../../../../shared/tab-types'
 import { useAppStore } from '../../store'
+import { useClientHostedBrowserRows } from '@/lib/pane-manager/client-hosted-browser-row-state'
+import { areAllTabStripsAutoHidden } from './single-tab-strip-visibility'
 import TabGroupPanel from './TabGroupPanel'
 import TabDragPreview from '../tab-bar/TabDragPreview'
 import { TabDragProvider } from './tab-drag-context'
@@ -10,6 +12,9 @@ import { type HoveredTabInsertion, useTabDragSplit } from './useTabDragSplit'
 
 const MIN_RATIO = 0.15
 const MAX_RATIO = 0.85
+// Why: stable fallbacks — a fresh `?? []` breaks Zustand v5 snapshot identity and loops renders.
+const EMPTY_GROUPS: readonly TabGroup[] = []
+const EMPTY_UNIFIED_TABS: readonly Tab[] = []
 
 function ResizeHandle({
   direction,
@@ -275,6 +280,16 @@ export default function TabGroupSplitLayout({
 }): React.JSX.Element {
   const dragSplit = useTabDragSplit({ worktreeId, enabled: isWorktreeActive })
   const hasSplits = layout.type === 'split'
+  const clientHostedRowCount = useClientHostedBrowserRows(worktreeId).length
+  const allStripsAutoHidden = useAppStore((state) => {
+    const groups = state.groupsByWorktree[worktreeId] ?? EMPTY_GROUPS
+    const tabs = state.unifiedTabsByWorktree[worktreeId] ?? EMPTY_UNIFIED_TABS
+    return areAllTabStripsAutoHidden({
+      autoHideEnabled: state.settings?.autoHideSingleTabStrip === true,
+      groupTabCounts: groups.map((group) => tabs.filter((tab) => tab.groupId === group.id).length),
+      clientHostedRowCount
+    })
+  })
 
   return (
     <TabDragProvider
@@ -316,7 +331,11 @@ export default function TabGroupSplitLayout({
           ref={dragSplit.setDragRootNode}
           className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-l border-border"
         >
-          <div className="h-[4px] shrink-0 bg-card" data-terminal-focus-release-surface="true" />
+          {/* Why: with every strip collapsed there is no 32px row to pair with, and the band is left
+            reading as a stray 4px ledge above the pane — drop it and let the pane reach the window edge. */}
+          {allStripsAutoHidden ? null : (
+            <div className="h-[4px] shrink-0 bg-card" data-terminal-focus-release-surface="true" />
+          )}
           <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
             <SplitNode
               node={layout}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -3,6 +3,7 @@ import { DndContext, DragOverlay } from '@dnd-kit/core'
 import type { Tab, TabGroup, TabGroupLayoutNode } from '../../../../shared/tab-types'
 import { useAppStore } from '../../store'
 import { useClientHostedBrowserRows } from '@/lib/pane-manager/client-hosted-browser-row-state'
+import { isAutoHideSingleTabStripEnabled } from './auto-hide-single-tab-strip-preference'
 import { areAllTabStripsAutoHidden } from './single-tab-strip-visibility'
 import TabGroupPanel from './TabGroupPanel'
 import TabDragPreview from '../tab-bar/TabDragPreview'
@@ -285,7 +286,7 @@ export default function TabGroupSplitLayout({
     const groups = state.groupsByWorktree[worktreeId] ?? EMPTY_GROUPS
     const tabs = state.unifiedTabsByWorktree[worktreeId] ?? EMPTY_UNIFIED_TABS
     return areAllTabStripsAutoHidden({
-      autoHideEnabled: state.settings?.autoHideSingleTabStrip === true,
+      autoHideEnabled: isAutoHideSingleTabStripEnabled(state.settings),
       groupTabCounts: groups.map((group) => tabs.filter((tab) => tab.groupId === group.id).length),
       clientHostedRowCount
     })

--- a/src/renderer/src/components/tab-group/auto-hide-single-tab-strip-preference.test.ts
+++ b/src/renderer/src/components/tab-group/auto-hide-single-tab-strip-preference.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function loadModule(getSync?: () => unknown): Promise<{
+  isAutoHideSingleTabStripEnabled: (settings: unknown) => boolean
+}> {
+  vi.resetModules()
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: getSync ? { api: { settings: { getSync } } } : {}
+  })
+  return (await import('./auto-hide-single-tab-strip-preference')) as never
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, 'window')
+})
+
+describe('isAutoHideSingleTabStripEnabled', () => {
+  it('reads hydrated settings without touching the sync bridge', async () => {
+    const getSync = vi.fn(() => ({ autoHideSingleTabStrip: true }))
+    const { isAutoHideSingleTabStripEnabled } = await loadModule(getSync)
+    expect(isAutoHideSingleTabStripEnabled({ autoHideSingleTabStrip: false })).toBe(false)
+    expect(getSync).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the persisted flag before settings hydrate', async () => {
+    const { isAutoHideSingleTabStripEnabled } = await loadModule(() => ({
+      autoHideSingleTabStrip: true
+    }))
+    expect(isAutoHideSingleTabStripEnabled(null)).toBe(true)
+    expect(isAutoHideSingleTabStripEnabled(undefined)).toBe(true)
+  })
+
+  it('reads the sync bridge once per session', async () => {
+    const getSync = vi.fn(() => ({ autoHideSingleTabStrip: true }))
+    const { isAutoHideSingleTabStripEnabled } = await loadModule(getSync)
+    isAutoHideSingleTabStripEnabled(null)
+    isAutoHideSingleTabStripEnabled(null)
+    expect(getSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays off when the bridge is missing or throws', async () => {
+    const missing = await loadModule()
+    expect(missing.isAutoHideSingleTabStripEnabled(null)).toBe(false)
+
+    const throwing = await loadModule(() => {
+      throw new Error('ipc down')
+    })
+    expect(throwing.isAutoHideSingleTabStripEnabled(null)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/tab-group/auto-hide-single-tab-strip-preference.ts
+++ b/src/renderer/src/components/tab-group/auto-hide-single-tab-strip-preference.ts
@@ -1,0 +1,29 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+
+// Why: cached once per session — the blocking read should only ever run on the pre-hydration
+// startup path, never per render.
+let persistedAutoHideFlagCache: boolean | undefined
+
+function readPersistedAutoHideFlagSync(): boolean {
+  if (persistedAutoHideFlagCache === undefined) {
+    try {
+      const getSync = (globalThis as { window?: Window }).window?.api?.settings?.getSync
+      persistedAutoHideFlagCache =
+        typeof getSync === 'function' ? getSync()?.autoHideSingleTabStrip === true : false
+    } catch {
+      persistedAutoHideFlagCache = false
+    }
+  }
+  return persistedAutoHideFlagCache
+}
+
+export function isAutoHideSingleTabStripEnabled(
+  settings: Pick<GlobalSettings, 'autoHideSingleTabStrip'> | null | undefined
+): boolean {
+  if (settings) {
+    return settings.autoHideSingleTabStrip === true
+  }
+  // Why: settings hydrate asynchronously, and a group rendered before that would show the strip and
+  // then collapse it — a 32px jump plus a pane refit on every launch.
+  return readPersistedAutoHideFlagSync()
+}

--- a/src/renderer/src/components/tab-group/single-tab-strip-visibility.test.ts
+++ b/src/renderer/src/components/tab-group/single-tab-strip-visibility.test.ts
@@ -20,9 +20,12 @@ describe('resolveSingleTabStripVisibility', () => {
     })
   })
 
-  it('collapses a lone tab and an empty group', () => {
+  it('collapses a lone tab', () => {
     expect(resolveSingleTabStripVisibility(base).autoHidden).toBe(true)
-    expect(resolveSingleTabStripVisibility({ ...base, groupTabCount: 0 }).autoHidden).toBe(true)
+  })
+
+  it('keeps the strip for an empty group, which has no other way back to a tab', () => {
+    expect(resolveSingleTabStripVisibility({ ...base, groupTabCount: 0 }).autoHidden).toBe(false)
   })
 
   it('keeps the strip for a second tab', () => {

--- a/src/renderer/src/components/tab-group/single-tab-strip-visibility.test.ts
+++ b/src/renderer/src/components/tab-group/single-tab-strip-visibility.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  areAllTabStripsAutoHidden,
+  resolveSingleTabStripVisibility
+} from './single-tab-strip-visibility'
+
+const base = {
+  autoHideEnabled: true,
+  groupTabCount: 1,
+  clientHostedRowCount: 0,
+  stripHovered: false,
+  tabDragActive: false
+}
+
+describe('resolveSingleTabStripVisibility', () => {
+  it('keeps the strip in the flow while the setting is off', () => {
+    expect(resolveSingleTabStripVisibility({ ...base, autoHideEnabled: false })).toEqual({
+      autoHidden: false,
+      revealed: false
+    })
+  })
+
+  it('collapses a lone tab and an empty group', () => {
+    expect(resolveSingleTabStripVisibility(base).autoHidden).toBe(true)
+    expect(resolveSingleTabStripVisibility({ ...base, groupTabCount: 0 }).autoHidden).toBe(true)
+  })
+
+  it('keeps the strip for a second tab', () => {
+    expect(resolveSingleTabStripVisibility({ ...base, groupTabCount: 2 }).autoHidden).toBe(false)
+  })
+
+  it('keeps the strip when a client-hosted browser row shares it', () => {
+    expect(resolveSingleTabStripVisibility({ ...base, clientHostedRowCount: 1 }).autoHidden).toBe(
+      false
+    )
+  })
+
+  it('reveals a collapsed strip on hover and for the duration of a tab drag', () => {
+    expect(resolveSingleTabStripVisibility({ ...base, stripHovered: true }).revealed).toBe(true)
+    expect(resolveSingleTabStripVisibility({ ...base, tabDragActive: true }).revealed).toBe(true)
+  })
+
+  it('never reports a reveal for a strip that was never collapsed', () => {
+    expect(
+      resolveSingleTabStripVisibility({ ...base, groupTabCount: 3, stripHovered: true }).revealed
+    ).toBe(false)
+  })
+})
+
+describe('areAllTabStripsAutoHidden', () => {
+  const base = { autoHideEnabled: true, clientHostedRowCount: 0 }
+
+  it('holds only when every group collapsed', () => {
+    expect(areAllTabStripsAutoHidden({ ...base, groupTabCounts: [1, 1] })).toBe(true)
+    expect(areAllTabStripsAutoHidden({ ...base, groupTabCounts: [1, 2] })).toBe(false)
+  })
+
+  it('does not hold for a worktree with no groups or with the setting off', () => {
+    expect(areAllTabStripsAutoHidden({ ...base, groupTabCounts: [] })).toBe(false)
+    expect(
+      areAllTabStripsAutoHidden({ ...base, autoHideEnabled: false, groupTabCounts: [1] })
+    ).toBe(false)
+  })
+
+  it('does not hold while a client-hosted browser row still needs the strip', () => {
+    expect(
+      areAllTabStripsAutoHidden({ ...base, groupTabCounts: [1], clientHostedRowCount: 1 })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/tab-group/single-tab-strip-visibility.ts
+++ b/src/renderer/src/components/tab-group/single-tab-strip-visibility.ts
@@ -46,8 +46,9 @@ export function resolveSingleTabStripVisibility({
   stripHovered: boolean
   tabDragActive: boolean
 }): SingleTabStripVisibility {
-  // Why: client-hosted browser rows share the strip, so a lone tab beside a row is not a lone row.
-  const autoHidden = autoHideEnabled && groupTabCount <= 1 && clientHostedRowCount === 0
+  // Why: exactly one — an empty group's strip is its only visible way back to a tab, and
+  // client-hosted browser rows share the strip, so a lone tab beside a row is not a lone row.
+  const autoHidden = autoHideEnabled && groupTabCount === 1 && clientHostedRowCount === 0
   return {
     autoHidden,
     // Why: a tab drag needs the strip on screen in every group, or there is nothing to drop onto.

--- a/src/renderer/src/components/tab-group/single-tab-strip-visibility.ts
+++ b/src/renderer/src/components/tab-group/single-tab-strip-visibility.ts
@@ -1,0 +1,56 @@
+export type SingleTabStripVisibility = {
+  /** The strip leaves the flow and hands its height to the pane body. */
+  autoHidden: boolean
+  /** The collapsed strip is currently sliding back over the pane. */
+  revealed: boolean
+}
+
+/**
+ * Whether no group in the worktree keeps a strip in the flow, which leaves the drag band above the
+ * split layout with no 32px row to pair into one titlebar-height top band.
+ */
+export function areAllTabStripsAutoHidden({
+  autoHideEnabled,
+  groupTabCounts,
+  clientHostedRowCount
+}: {
+  autoHideEnabled: boolean
+  groupTabCounts: readonly number[]
+  clientHostedRowCount: number
+}): boolean {
+  return (
+    groupTabCounts.length > 0 &&
+    groupTabCounts.every(
+      (groupTabCount) =>
+        resolveSingleTabStripVisibility({
+          autoHideEnabled,
+          groupTabCount,
+          clientHostedRowCount,
+          stripHovered: false,
+          tabDragActive: false
+        }).autoHidden
+    )
+  )
+}
+
+export function resolveSingleTabStripVisibility({
+  autoHideEnabled,
+  groupTabCount,
+  clientHostedRowCount,
+  stripHovered,
+  tabDragActive
+}: {
+  autoHideEnabled: boolean
+  groupTabCount: number
+  clientHostedRowCount: number
+  stripHovered: boolean
+  tabDragActive: boolean
+}): SingleTabStripVisibility {
+  // Why: client-hosted browser rows share the strip, so a lone tab beside a row is not a lone row.
+  const autoHidden = autoHideEnabled && groupTabCount <= 1 && clientHostedRowCount === 0
+  return {
+    autoHidden,
+    // Why: a tab drag needs the strip on screen in every group, or there is nothing to drop onto.
+    revealed: autoHidden && (stripHovered || tabDragActive)
+  }
+}

--- a/src/renderer/src/components/tab-group/tab-drop-zone.test.ts
+++ b/src/renderer/src/components/tab-group/tab-drop-zone.test.ts
@@ -29,4 +29,22 @@ describe('resolvePaneColumnEdgeZone', () => {
       })
     ).toBe('up')
   })
+
+  it('keeps both vertical zones when an auto-hidden strip lets the body start at the panel top', () => {
+    // A short pane whose body reaches panelTop: measuring `up` from the body top would leave the
+    // zone entirely inside the strip band and drop it.
+    const shortPanel = { left: 0, top: 0, width: 300, height: 120 }
+    const bodyRect = { left: 0, top: 0, width: 300, height: 120 }
+    expect(
+      resolvePaneColumnEdgeZone(
+        shortPanel,
+        { x: 150, y: TAB_GROUP_TAB_STRIP_HEIGHT_PX + 5 },
+        {
+          bodyRect
+        }
+      )
+    ).toBe('up')
+    expect(resolvePaneColumnEdgeZone(shortPanel, { x: 150, y: 115 }, { bodyRect })).toBe('down')
+    expect(resolvePaneColumnEdgeZone(shortPanel, { x: 150, y: 75 }, { bodyRect })).toBeNull()
+  })
 })

--- a/src/renderer/src/components/tab-group/tab-drop-zone.ts
+++ b/src/renderer/src/components/tab-group/tab-drop-zone.ts
@@ -76,13 +76,21 @@ export function resolvePaneColumnEdgeZone(
     return null
   }
 
-  const bodyLocalY = point.y - bodyRect.top
-  const verticalEdge = bodyRect.height * 0.2
+  // Why: an auto-hidden strip leaves the flow, so the body reaches under the revealed strip. Split
+  // zones must be measured from the first pixel the drop can actually land on, or `up` degenerates.
+  const reachableTop = Math.max(bodyRect.top, tabStripBottom)
+  const reachableHeight = bodyRect.top + bodyRect.height - reachableTop
+  if (reachableHeight <= 0) {
+    return null
+  }
+
+  const bodyLocalY = point.y - reachableTop
+  const verticalEdge = reachableHeight * 0.2
 
   if (bodyLocalY < verticalEdge) {
     return 'up'
   }
-  if (bodyLocalY > bodyRect.height - verticalEdge) {
+  if (bodyLocalY > reachableHeight - verticalEdge) {
     return 'down'
   }
   return null

--- a/src/renderer/src/components/tab-group/tab-strip-reveal-hover.lifecycle.test.ts
+++ b/src/renderer/src/components/tab-group/tab-strip-reveal-hover.lifecycle.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+// Why: the sibling tab-strip-reveal-hover.test.ts covers the pure zone rule; these drive the hook
+// itself, because the latched-reveal bugs live in its subscribe/teardown, not in the geometry.
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useTabStripRevealHover, TAB_STRIP_REVEAL_HOVER_ZONE_PX } from './tab-strip-reveal-hover'
+
+function panelAt(rect: { left: number; right: number; top: number }): HTMLElement {
+  const panel = document.createElement('div')
+  panel.getBoundingClientRect = () =>
+    ({ left: rect.left, right: rect.right, top: rect.top, bottom: rect.top + 600 }) as DOMRect
+  return panel
+}
+
+function movePointer(clientX: number, clientY: number): void {
+  const event = new Event('pointermove', { bubbles: true })
+  Object.defineProperty(event, 'clientX', { value: clientX })
+  Object.defineProperty(event, 'clientY', { value: clientY })
+  window.dispatchEvent(event)
+}
+
+function renderHover(enabled: boolean, onHoverChange: (hovered: boolean) => void) {
+  const panelRef = { current: panelAt({ left: 0, right: 400, top: 100 }) }
+  return renderHook(
+    ({ enabled: isEnabled }: { enabled: boolean }) =>
+      useTabStripRevealHover({ enabled: isEnabled, panelRef, onHoverChange }),
+    { initialProps: { enabled } }
+  )
+}
+
+/** Pointer moves are coalesced through requestAnimationFrame, so flush one frame. */
+async function flushFrame(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+  })
+}
+
+describe('useTabStripRevealHover', () => {
+  it('reports a hover once the pointer enters the zone', async () => {
+    const onHoverChange = vi.fn()
+    renderHover(true, onHoverChange)
+
+    act(() => movePointer(200, 105))
+    await flushFrame()
+
+    expect(onHoverChange).toHaveBeenCalledWith(true)
+  })
+
+  it('clears a latched reveal when the group stops being watched', async () => {
+    const onHoverChange = vi.fn()
+    const { rerender } = renderHover(true, onHoverChange)
+
+    act(() => movePointer(200, 105))
+    await flushFrame()
+    onHoverChange.mockClear()
+
+    // A worktree switch disables the hook mid-hover; the next enabled run restarts from
+    // `hovered = false` and would never emit the clearing call on its own.
+    rerender({ enabled: false })
+
+    expect(onHoverChange).toHaveBeenCalledWith(false)
+  })
+
+  it('does not emit a clearing call when teardown finds no active hover', async () => {
+    const onHoverChange = vi.fn()
+    const { rerender } = renderHover(true, onHoverChange)
+
+    act(() => movePointer(200, 100 + TAB_STRIP_REVEAL_HOVER_ZONE_PX + 50))
+    await flushFrame()
+    onHoverChange.mockClear()
+
+    rerender({ enabled: false })
+
+    expect(onHoverChange).not.toHaveBeenCalled()
+  })
+
+  it('stops watching the pointer while disabled', async () => {
+    const onHoverChange = vi.fn()
+    renderHover(false, onHoverChange)
+
+    act(() => movePointer(200, 105))
+    await flushFrame()
+
+    expect(onHoverChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/tab-group/tab-strip-reveal-hover.test.ts
+++ b/src/renderer/src/components/tab-group/tab-strip-reveal-hover.test.ts
@@ -26,6 +26,12 @@ describe('resolveTabStripRevealHover', () => {
     expect(hover(501, 45)).toBe(false)
   })
 
+  it('treats the right boundary as outside, where a split puts its resize handle', () => {
+    expect(hover(panelRect.left, 45)).toBe(true)
+    expect(hover(panelRect.right, 45)).toBe(false)
+    expect(hover(panelRect.right - 1, 45)).toBe(true)
+  })
+
   it('holds an open strip across its full height even past the zone', () => {
     // The zone is narrower than the 32px strip, so without hysteresis the row would close under the
     // pointer while it travels toward a tab.

--- a/src/renderer/src/components/tab-group/tab-strip-reveal-hover.test.ts
+++ b/src/renderer/src/components/tab-group/tab-strip-reveal-hover.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveTabStripRevealHover,
+  TAB_STRIP_REVEAL_HOVER_ZONE_PX
+} from './tab-strip-reveal-hover'
+
+const panelRect = { left: 100, right: 500, top: 40 }
+
+function hover(clientX: number, clientY: number, currentlyHovered = false): boolean {
+  return resolveTabStripRevealHover({ panelRect, clientX, clientY, currentlyHovered })
+}
+
+describe('resolveTabStripRevealHover', () => {
+  it('reveals anywhere inside the zone below the group top edge', () => {
+    expect(hover(300, 40)).toBe(true)
+    expect(hover(300, 40 + TAB_STRIP_REVEAL_HOVER_ZONE_PX - 1)).toBe(true)
+  })
+
+  it('stays closed below the zone and above the group', () => {
+    expect(hover(300, 40 + TAB_STRIP_REVEAL_HOVER_ZONE_PX)).toBe(false)
+    expect(hover(300, 39)).toBe(false)
+  })
+
+  it('ignores a pointer in a neighbouring split column', () => {
+    expect(hover(99, 45)).toBe(false)
+    expect(hover(501, 45)).toBe(false)
+  })
+
+  it('holds an open strip across its full height even past the zone', () => {
+    // The zone is narrower than the 32px strip, so without hysteresis the row would close under the
+    // pointer while it travels toward a tab.
+    expect(hover(300, 40 + 31, true)).toBe(true)
+    expect(hover(300, 40 + 32, true)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/tab-group/tab-strip-reveal-hover.ts
+++ b/src/renderer/src/components/tab-group/tab-strip-reveal-hover.ts
@@ -15,7 +15,9 @@ export function resolveTabStripRevealHover({
   clientY: number
   currentlyHovered: boolean
 }): boolean {
-  if (clientX < panelRect.left || clientX > panelRect.right) {
+  // Why: half-open on the right — a horizontal split puts its resize handle exactly on that
+  // boundary, and hovering the divider must not reveal the panel's strip.
+  if (clientX < panelRect.left || clientX >= panelRect.right) {
     return false
   }
   // Why: once open the strip itself must hold the hover, or a 30px zone would drop it mid-row.
@@ -82,6 +84,11 @@ export function useTabStripRevealHover({
       window.removeEventListener('pointermove', onPointerMove, true)
       if (frame !== 0) {
         cancelAnimationFrame(frame)
+      }
+      // Why: the next enabled run restarts from `hovered = false`, so a reveal left latched here —
+      // a worktree switched away mid-hover — would survive until the pointer re-crossed the zone.
+      if (hovered) {
+        onHoverChangeRef.current(false)
       }
     }
   }, [enabled, panelRef])

--- a/src/renderer/src/components/tab-group/tab-strip-reveal-hover.ts
+++ b/src/renderer/src/components/tab-group/tab-strip-reveal-hover.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react'
+import { TAB_GROUP_TAB_STRIP_HEIGHT_PX } from './tab-drop-zone'
+
+/** How far below the group's top edge a pointer still counts as reaching for the collapsed strip. */
+export const TAB_STRIP_REVEAL_HOVER_ZONE_PX = 30
+
+export function resolveTabStripRevealHover({
+  panelRect,
+  clientX,
+  clientY,
+  currentlyHovered
+}: {
+  panelRect: { left: number; right: number; top: number }
+  clientX: number
+  clientY: number
+  currentlyHovered: boolean
+}): boolean {
+  if (clientX < panelRect.left || clientX > panelRect.right) {
+    return false
+  }
+  // Why: once open the strip itself must hold the hover, or a 30px zone would drop it mid-row.
+  const zone = currentlyHovered
+    ? Math.max(TAB_STRIP_REVEAL_HOVER_ZONE_PX, TAB_GROUP_TAB_STRIP_HEIGHT_PX)
+    : TAB_STRIP_REVEAL_HOVER_ZONE_PX
+  const offsetY = clientY - panelRect.top
+  return offsetY >= 0 && offsetY < zone
+}
+
+/**
+ * Watches the pointer for the top edge of a group whose strip is collapsed.
+ *
+ * Why window and not a sensor element: a sensor wide enough to feel right would swallow clicks on
+ * the pane underneath, and pane-detach drags capture the pointer, so element enter/leave never fire.
+ */
+export function useTabStripRevealHover({
+  enabled,
+  panelRef,
+  onHoverChange
+}: {
+  enabled: boolean
+  panelRef: React.RefObject<HTMLElement | null>
+  onHoverChange: (hovered: boolean) => void
+}): void {
+  const onHoverChangeRef = useRef(onHoverChange)
+  onHoverChangeRef.current = onHoverChange
+
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    let frame = 0
+    let hovered = false
+    const evaluate = (clientX: number, clientY: number): void => {
+      const panel = panelRef.current
+      if (!panel) {
+        return
+      }
+      const next = resolveTabStripRevealHover({
+        panelRect: panel.getBoundingClientRect(),
+        clientX,
+        clientY,
+        currentlyHovered: hovered
+      })
+      if (next !== hovered) {
+        hovered = next
+        onHoverChangeRef.current(next)
+      }
+    }
+    const onPointerMove = (event: PointerEvent): void => {
+      if (frame !== 0) {
+        return
+      }
+      const { clientX, clientY } = event
+      frame = requestAnimationFrame(() => {
+        frame = 0
+        evaluate(clientX, clientY)
+      })
+    }
+    // Capture: a pane-detach drag stops propagation, and that drag is exactly when the strip is needed.
+    window.addEventListener('pointermove', onPointerMove, true)
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove, true)
+      if (frame !== 0) {
+        cancelAnimationFrame(frame)
+      }
+    }
+  }, [enabled, panelRef])
+}

--- a/src/renderer/src/components/terminal-pane/terminal-pane-tab-detach.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-tab-detach.test.ts
@@ -180,7 +180,8 @@ describe('resolveTerminalTabStripDropTarget', () => {
     const child = { closest: () => strip }
     vi.stubGlobal('document', {
       elementsFromPoint: vi.fn(() => [overlay, child]),
-      elementFromPoint: vi.fn()
+      elementFromPoint: vi.fn(),
+      querySelectorAll: vi.fn(() => [])
     })
 
     expect(
@@ -219,7 +220,8 @@ describe('resolveTerminalTabStripDropTarget', () => {
     }
     vi.stubGlobal('document', {
       elementsFromPoint: vi.fn(() => [{ closest: () => firstTab }, { closest: () => strip }]),
-      elementFromPoint: vi.fn()
+      elementFromPoint: vi.fn(),
+      querySelectorAll: vi.fn(() => [])
     })
 
     expect(
@@ -254,7 +256,67 @@ describe('resolveTerminalTabStripDropTarget', () => {
     }
     vi.stubGlobal('document', {
       elementsFromPoint: vi.fn(() => [{ closest: () => strip }]),
-      elementFromPoint: vi.fn()
+      elementFromPoint: vi.fn(),
+      querySelectorAll: vi.fn(() => [])
+    })
+
+    expect(
+      resolveTerminalTabStripDropTarget({
+        clientX: 10,
+        clientY: 10,
+        groupsByWorktree: {
+          [WORKTREE_ID]: [{ id: TARGET_GROUP_ID } as AppState['groupsByWorktree'][string][number]]
+        },
+        worktreeId: WORKTREE_ID
+      })
+    ).toBeNull()
+  })
+
+  it('matches a click-through strip by geometry when hit-testing skips it', () => {
+    // An auto-hidden strip is `pointer-events: none` until its hover reveal commits, so
+    // elementsFromPoint never returns it. A pane drag reads its target on pointermove and reuses it
+    // on pointerup, so a release on the first move into the band would otherwise resolve nothing.
+    const stripRect = rect({ left: 0, top: 0, width: 300, height: 32 })
+    const strip = {
+      dataset: { tabGroupStripId: TARGET_GROUP_ID, worktreeId: WORKTREE_ID },
+      getBoundingClientRect: () => stripRect,
+      querySelectorAll: () => [],
+      closest: () => strip
+    }
+    vi.stubGlobal('document', {
+      elementsFromPoint: vi.fn(() => []),
+      elementFromPoint: vi.fn(),
+      querySelectorAll: vi.fn(() => [strip])
+    })
+
+    expect(
+      resolveTerminalTabStripDropTarget({
+        clientX: 10,
+        clientY: 10,
+        groupsByWorktree: {
+          [WORKTREE_ID]: [{ id: TARGET_GROUP_ID } as AppState['groupsByWorktree'][string][number]]
+        },
+        worktreeId: WORKTREE_ID
+      })
+    ).toEqual({
+      id: TARGET_GROUP_ID,
+      groupId: TARGET_GROUP_ID,
+      worktreeId: WORKTREE_ID,
+      rect: stripRect
+    })
+  })
+
+  it('does not match a geometry candidate outside the pointer', () => {
+    const strip = {
+      dataset: { tabGroupStripId: TARGET_GROUP_ID, worktreeId: WORKTREE_ID },
+      getBoundingClientRect: () => rect({ left: 400, top: 0, width: 300, height: 32 }),
+      querySelectorAll: () => [],
+      closest: () => strip
+    }
+    vi.stubGlobal('document', {
+      elementsFromPoint: vi.fn(() => []),
+      elementFromPoint: vi.fn(),
+      querySelectorAll: vi.fn(() => [strip])
     })
 
     expect(

--- a/src/renderer/src/components/terminal-pane/terminal-tab-strip-drop-target.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-strip-drop-target.ts
@@ -107,6 +107,22 @@ function getElementsFromPoint(clientX: number, clientY: number): Element[] {
   return element ? [element] : []
 }
 
+// Why: an auto-hidden strip is click-through until its hover reveal commits, and hit-testing skips
+// `pointer-events: none`. A pane drag reads its target on pointermove and reuses it on pointerup, so
+// a release on the first move into the band would resolve nothing. Match those strips by geometry.
+function getStripsByGeometry(clientX: number, clientY: number): HTMLElement[] {
+  if (typeof document === 'undefined') {
+    return []
+  }
+  const strips: HTMLElement[] = []
+  for (const strip of document.querySelectorAll<HTMLElement>(TAB_GROUP_STRIP_SELECTOR)) {
+    if (pointWithinRect(clientX, clientY, strip.getBoundingClientRect())) {
+      strips.push(strip)
+    }
+  }
+  return strips
+}
+
 export function resolveTerminalTabStripDropTarget(args: {
   clientX: number
   clientY: number
@@ -120,7 +136,11 @@ export function resolveTerminalTabStripDropTarget(args: {
     return null
   }
 
-  for (const element of getElementsFromPoint(args.clientX, args.clientY)) {
+  const candidates: Element[] = [
+    ...getElementsFromPoint(args.clientX, args.clientY),
+    ...getStripsByGeometry(args.clientX, args.clientY)
+  ]
+  for (const element of candidates) {
     const strip = element.closest<HTMLElement>(TAB_GROUP_STRIP_SELECTOR)
     const groupId = strip?.dataset.tabGroupStripId
     const worktreeId = strip?.dataset.worktreeId

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7123,7 +7123,9 @@
           "5cb5475664": "Confirm before closing pinned tabs",
           "36b2a5dc6d": "Show a confirmation dialog before a pinned tab is closed.",
           "projectRuntime": "Project Runtime",
-          "projectRuntimeDescription": "Default runtime for local Windows projects that do not override it."
+          "projectRuntimeDescription": "Default runtime for local Windows projects that do not override it.",
+          "autoHideSingleTabStrip": "Hide the tab bar when a pane has one tab",
+          "autoHideSingleTabStripDescription": "Collapse the tab bar until you hover the top edge of the pane."
         },
         "GeneralSupportSection": {
           "af7d9f4396": "Thanks for the support!",
@@ -9652,7 +9654,14 @@
             "sidebar": "sidebar",
             "867dddea41": "pinned",
             "5250cf0e48": "pin",
-            "afa37a34e1": "close"
+            "afa37a34e1": "close",
+            "autoHideSingleTabStrip": "Hide the tab bar when a pane has one tab",
+            "autoHideSingleTabStripDescription": "Collapse the tab bar until you hover the top edge of the pane.",
+            "autoHideSingleTabStripKeywordBar": "tab bar",
+            "autoHideSingleTabStripKeywordHide": "hide",
+            "autoHideSingleTabStripKeywordAutoHide": "auto hide",
+            "autoHideSingleTabStripKeywordSingle": "single",
+            "autoHideSingleTabStripKeywordStrip": "strip"
           }
         },
         "git": {

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -134,6 +134,7 @@ export function buildDefaultSettings(args: {
     sourceControlGroupOrder: DEFAULT_SOURCE_CONTROL_GROUP_ORDER,
     sourceControlCompareAgainstUpstream: false,
     showTitlebarAppName: true,
+    autoHideSingleTabStrip: false,
     showTasksButton: true,
     showAutomationsButton: true,
     artifactsEnabled: true,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -229,6 +229,8 @@ export type GlobalSettings = {
   sourceControlCompareAgainstUpstream: boolean
   /** Whether to show the Orca app name in the titlebar. */
   showTitlebarAppName: boolean
+  /** Collapse a tab group's strip while it holds a single tab; hovering the group's top edge reveals it. */
+  autoHideSingleTabStrip?: boolean
   /** Hides the Tasks sidebar button (also removes it from keyboard navigation). */
   showTasksButton: boolean
   /** Only toggles the sidebar shortcut; Automations stay reachable from Settings/View menu. */


### PR DESCRIPTION
## ELI5

If a pane only has one tab, the tab bar above it is not doing anything — there is nothing to switch to, but it still eats 32px at the top of your terminal for the whole session. Turn on a setting and that bar gets out of the way. Move the mouse to the top edge of the pane and it slides back down, so the `+` button and everything else on it is still one gesture away.

Off by default.

## What Changed

**New setting** `autoHideSingleTabStrip` under Settings → General → Navigation, default off.

**When on**, a group holding exactly one tab drops its strip out of the layout flow and the pane body takes the height. The strip comes back as an absolutely positioned overlay on hover, not by re-entering the flow, so revealing it never resizes the pane and xterm never reflows on a hover.

Scope is per group — one half of a split can collapse while the other keeps its tabs. A group that owns client-hosted browser rows keeps its strip, since those rows live in it.

**Reveal is detected from a window-level `pointermove`**, throttled through `requestAnimationFrame` and bound only for a visible worktree's collapsed groups. An element sensor wide enough to feel right would swallow clicks on the pane under it, and pane-detach drags call `setPointerCapture`, so element enter/leave never fire during the one gesture that needs the strip most.

Smaller pieces the change had to get right:

- A tab drag reveals every collapsed strip for its duration, or there is nothing to drop onto. The slide animation is skipped while a drag is active because dnd-kit measures droppable rects once at drag start and would record the strip mid-animation.
- The revealed strip is `no-drag` end to end. A drag region swallows renderer pointer events, which would kill the hover holding it open.
- The 4px band above the split layout exists to pair with the 32px row into one titlebar-height top band. With every strip in the worktree collapsed it has nothing to pair with and reads as a stray ledge, so it collapses too.
- The unfocused-split dim moves from the group root onto its children. Root `opacity` opens a stacking context, which trapped the revealed strip beneath the worktree-level pane overlays.
- `resolvePaneColumnEdgeZone` measured split zones from the body top, which now reaches the panel top. The `up` zone degenerated to nothing on panes under 160px tall.
- The floating sidebar header and explorer toggle move above the revealed strip so they stay clickable.
- The preference falls back to the cached sync settings bridge before hydration, the same way `terminal-hidden-delivery-gate` does. Without it a group rendered pre-hydration showed the strip and collapsed it a moment later — a 32px jump and a pane refit on every launch.

## Why

The single-tab workspace is the common Orca layout — one workspace, one agent, one terminal — and it is the one paying for a row that offers no choice. In the workspace view that row doubles as the window's top chrome, so it is never scrolled away.

Hiding it outright was the obvious approach and it is wrong: the row also carries the `+` button, quick commands, the split-pane menu and the drop target for tab and pane drags. Hover-reveal keeps every one of those one gesture away while still handing the pixels back, which is the same trade VS Code makes with `workbench.editor.showTabs: "single"`.

Overlay rather than flow for the reveal because the alternative reflows xterm on every hover in and out.

## Linked Issue

Fixes #20167

## Visual Proof

**After** — setting on, single-tab pane. The strip is out of the flow and the terminal starts at the window edge; moving the pointer to the top edge slides it back over the pane without resizing anything.

<img width="800" height="517" alt="CleanShot 2026-09-12 at 01 32 16" src="https://github.com/user-attachments/assets/3d84a70d-536c-446e-ad32-15c345dbaeaf" />

**Before** — setting off (current `main` behaviour): the 32px strip is always in the flow above the pane.

<img width="1707" height="1412" alt="CleanShot 2026-09-12 at 15 53 05" src="https://github.com/user-attachments/assets/b0f35c23-42bc-411e-b1ec-0863b08c1e33" />


## Testing

Verified in a local dev build on macOS (Apple Silicon): collapse and reveal on a single-tab terminal group, the `+` → new tab → close cycle, a split where one half is collapsed, window dragging with the band gone, and the settings toggle both ways.

Automated coverage is on the decision rules rather than the DOM: `single-tab-strip-visibility`, `tab-strip-reveal-hover` (including the hysteresis that keeps an open strip from closing under the pointer), `auto-hide-single-tab-strip-preference` (hydration fallback, one bridge read per session, bridge missing or throwing), and a new `tab-drop-zone` case pinning the split zone that used to degenerate.

Not tested on hardware: Windows and Linux. The change is platform-neutral — no `metaKey`, no paths, no process spawning — but the floating window-controls overlay is 138×36 there instead of 0, so that corner overlap is more visible than on macOS. SSH and remote paths are untouched; this is renderer layout only and reads no host state.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Opus 5). The design trade-offs — hover-reveal over plain hiding, accepting the chrome overlap rather than suppressing the feature where chrome floats — were chosen by me; the implementation and tests were agent-written and reviewed.

## Review

Reviewed by two independent agents (Claude and Codex) over the full diff, then re-reviewed after fixes. Findings that survived verification and were fixed:

- **Localization gate.** New `translate` keys were missing from `en.json`, which fails `verify:localization-catalog` in `pnpm lint`. Synced.
- **Pane refit.** `SYNC_FIT_PANES_EVENT` fired on every group mount and did not fire when the setting was switched off. Now gated on an actual `stripAutoHidden` transition.
- **Stuck hover.** Revealing, then gaining a tab, left the hover latched, so dropping back to one tab came back already revealed.
- **Drag measurement.** dnd-kit recorded the strip mid-animation on cross-group drops.
- **Stacking.** The revealed strip buried the floating sidebar toggles; they now sit above it.
- **Split zones.** The `up` drop zone degenerated on short panes.

Checked explicitly: **cross-platform** — no platform-conditional code added; the Windows/Linux window-controls overlay is the one behavioural difference and is called out above. **SSH/remote/local** — no host, process, path or credential access; renderer layout only. **Agents and integrations** — no agent, provider or git-provider surface touched. **Performance** — one rAF-throttled `pointermove` listener, bound only for a visible worktree's collapsed groups, doing one `getBoundingClientRect` per frame; the settings bridge is read at most once per session. **UI quality** — tokens and existing sizes reused, no new colors or shadow tiers. **Security** — no new IPC surface; the new setting is a boolean read through the existing settings channel.

Known trade-offs, accepted deliberately rather than missed:

- Where floating chrome overlaps a collapsed group's corner it paints over the pane's first rows. Suppressing the feature there instead would disable it permanently for the top-right group on Windows and Linux.
- With every strip collapsed, the 4px drag band goes with them, so the window drags from the sidebar header and the right sidebar rather than the top of the center column.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No data, IPC contract, migration or persisted format changes beyond one optional boolean in `GlobalSettings`. An older build ignores the key; a newer build reading a profile without it treats it as off. Backing the feature out is a binary rollback with no residue.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

