### PR TITLE
fix(e2e): remove four real flake sources and one caret race

### DIFF
--- a/src/renderer/src/components/new-workspace/smart-workspace-name-input-surface.tsx
+++ b/src/renderer/src/components/new-workspace/smart-workspace-name-input-surface.tsx
@@ -192,6 +192,8 @@ export function renderSmartWorkspaceNameInput(
             applyEmojiReplacement(completedEmoji)
             return
           }
+          // A pending emoji caret frame would otherwise yank the caret back mid-typing.
+          cancelLocalInputFocusFrame()
           onValueChange(nextValue)
           setEmojiCursor(nextCursor)
           if (!disabled && mode !== 'text') {

--- a/tests/e2e/linear-url-workspace-entry.spec.ts
+++ b/tests/e2e/linear-url-workspace-entry.spec.ts
@@ -97,6 +97,10 @@ async function releaseHeldLinearLookup(page: Page): Promise<void> {
 
 async function pasteLinearUrl(page: Page, input: ReturnType<Page['locator']>): Promise<void> {
   await page.evaluate((text) => window.api.ui.writeClipboardText(text), LINEAR_URL)
+  // X selection ownership is async; pasting before it lands delivers stale text.
+  await expect
+    .poll(() => page.evaluate(() => window.api.ui.readClipboardText()), { timeout: 5_000 })
+    .toBe(LINEAR_URL)
   await input.focus()
   await page.keyboard.press(pasteChord())
 }

--- a/tests/e2e/native-chat-first-flush-race.spec.ts
+++ b/tests/e2e/native-chat-first-flush-race.spec.ts
@@ -141,10 +141,24 @@ test.describe('Native chat first-flush transcript race (#8401)', () => {
         path: path.join(screenshotDir, '01-loading-no-error.png')
       })
 
-      // Why: a short real delay proves the first readSession attempt already
-      // hit the not-yet-flushed file (returning notFound) and the renderer's
-      // backoff retry — not a lucky first read — is what picks it up below.
-      await orcaPage.waitForTimeout(1_500)
+      // Why observe, not sleep: 1_500ms is exactly UNFLUSHED_SETTLE_MS, so a fixed
+      // wait straddles the boundary where the host reports the transcript pending
+      // and the renderer cancels its own retry. Read through the same IPC instead,
+      // proving the miss directly. A notFound is never cached, so this cannot
+      // perturb the hydration the assertions below measure.
+      await expect
+        .poll(
+          () =>
+            orcaPage.evaluate(
+              ({ id, file }) =>
+                window.api.nativeChat
+                  .readSession('claude', id, 50, file)
+                  .then((result) => Boolean(result && 'error' in result && result.notFound)),
+              { id: sessionId, file: transcriptPath }
+            ),
+          { timeout: 10_000, message: 'transcript resolved before the first flush' }
+        )
+        .toBe(true)
       await expect(orcaPage.getByText(ERROR_TITLE)).toHaveCount(0)
 
       const userText = 'Explain the native chat first-flush race fix for #8401'

--- a/tests/e2e/orchestration-idle-mail-delivery.spec.ts
+++ b/tests/e2e/orchestration-idle-mail-delivery.spec.ts
@@ -653,7 +653,12 @@ test.describe('orchestration delivery to a cold-parked agent', () => {
   const parkingDelayMs = 500
 
   test.use({
-    orcaAppExtraEnv: { ORCA_E2E_TERMINAL_PARKING_DELAY_MS: String(parkingDelayMs) }
+    orcaAppExtraEnv: {
+      ORCA_E2E_TERMINAL_PARKING_DELAY_MS: String(parkingDelayMs),
+      // The working-title round trip (PTY -> daemon -> main) must beat the Enter
+      // timer; 500ms is a production heuristic, not a budget CI can honour.
+      ORCA_E2E_ORCHESTRATION_POINTER_ENTER_DELAY_MS: '5000'
+    }
   })
 
   test('keeps one pointer and one idempotent prompt on the same parked PTY', async ({

--- a/tests/e2e/slept-workspace-remount-wake.spec.ts
+++ b/tests/e2e/slept-workspace-remount-wake.spec.ts
@@ -66,7 +66,7 @@ test('remounting a slept hidden pane does not respawn its PTY', async ({ orcaPag
   expect(sample.tabPtyHints[0], 'sleep must keep the session id as a wake hint').toBeTruthy()
 
   const remounted = await orcaPage.evaluate(
-    (tabId) => window.__store?.getState().remountTerminalTabForRecovery(tabId) ?? false,
+    (tabId) => window.__store?.getState().remountTerminalTabForRecovery(tabId).remounted ?? false,
     sleptTabId
   )
   expect(remounted, 'remountTerminalTabForRecovery did not find the slept tab').toBe(true)

--- a/tests/e2e/tasks-page.spec.ts
+++ b/tests/e2e/tasks-page.spec.ts
@@ -13,6 +13,9 @@ import { GITHUB_TASK_SEARCH_IDLE_MS } from '../../src/renderer/src/components/us
 // on a loaded runner, so one slow keystroke committed a prefix and failed the assertion.
 const TASK_SEARCH_TYPING_DELAY_MS = Math.round(GITHUB_TASK_SEARCH_IDLE_MS / 6)
 const TASK_SEARCH_SETTLE_MS = GITHUB_TASK_SEARCH_IDLE_MS + 50
+// Why derived: the probe must outlast the idle window plus a React commit and two
+// store round trips; a flat 2s left ~1.2s of slack on a single-worker runner.
+const TASK_SEARCH_PROBE_TIMEOUT_MS = GITHUB_TASK_SEARCH_IDLE_MS * 6
 
 type RenderedTaskSource = {
   source: string
@@ -411,7 +414,9 @@ test.describe('Tasks page', () => {
 
     await input.fill('')
     await expect
-      .poll(async () => readTaskSearchRequestProbe(orcaPage), { timeout: 2_000 })
+      .poll(async () => readTaskSearchRequestProbe(orcaPage), {
+        timeout: TASK_SEARCH_PROBE_TIMEOUT_MS
+      })
       .toEqual({ countQueries: ['is:issue is:open'], fetchQueries: ['is:issue is:open'] })
     await resetTaskSearchRequestProbe(orcaPage)
 
@@ -422,7 +427,9 @@ test.describe('Tasks page', () => {
     // The contract is that no prefix of the typed query is ever queried, not that the
     // probe is empty at one instant: exactly one request per surface, for the final value.
     await expect
-      .poll(async () => readTaskSearchRequestProbe(orcaPage), { timeout: 2_000 })
+      .poll(async () => readTaskSearchRequestProbe(orcaPage), {
+        timeout: TASK_SEARCH_PROBE_TIMEOUT_MS
+      })
       .toEqual({ countQueries: ['is:issue rate'], fetchQueries: ['is:issue rate'] })
 
     await resetTaskSearchRequestProbe(orcaPage)
@@ -430,7 +437,9 @@ test.describe('Tasks page', () => {
     await input.press('Enter')
 
     await expect
-      .poll(async () => readTaskSearchRequestProbe(orcaPage), { timeout: 2_000 })
+      .poll(async () => readTaskSearchRequestProbe(orcaPage), {
+        timeout: TASK_SEARCH_PROBE_TIMEOUT_MS
+      })
       .toEqual({ countQueries: ['is:issue ratex'], fetchQueries: ['is:issue ratex'] })
     await orcaPage.waitForTimeout(TASK_SEARCH_SETTLE_MS)
     expect(await readTaskSearchRequestProbe(orcaPage)).toEqual({


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## What

Five E2E specs were treated as "flaky main". Investigating each against CI history showed only some of them were.

Four are genuine flakes — each existed since 2026-08-27, ran in all six recent main runs, and failed exactly once. Each fails on a timing boundary the test cannot control:

| Spec | Root cause | Fix |
| --- | --- | --- |
| `linear-url-workspace-entry` | Pasted before X selection ownership landed, so `onPaste` saw empty clipboard data and returned early | Gate the paste on a clipboard read-back |
| `native-chat-first-flush-race` | A bare `waitForTimeout(1_500)` is *exactly* `UNFLUSHED_SETTLE_MS`, so it straddled the boundary deciding which of two hydration paths carried the test | Observe the not-yet-flushed read through the same IPC |
| `orchestration-idle-mail-delivery` | Asserted a PTY to daemon to main round trip beats a 500 ms production heuristic | Use the existing `ORCA_E2E_ORCHESTRATION_POINTER_ENTER_DELAY_MS` knob |
| `tasks-page` | The probe timeout was the one figure in the file not derived from `GITHUB_TASK_SEARCH_IDLE_MS` | Derive it, as the file already does for two other timings |

No timeout was raised except `tasks-page`, which is called out below.

## One real product bug

`worktree.spec.ts` was not a test problem. `cancelLocalInputFocusFrame` was destructured but only called in the emoji branch, so the caret-restore `requestAnimationFrame` stayed armed through ordinary typing. A late frame could yank the caret back to the post-emoji position mid-input and scramble the value.

This affects any fast typist, key repeat, or IME commit immediately after an emoji shortcode completes — not just tests. Fixed by cancelling the pending frame on the non-emoji `onChange` path.

## One stale assertion, not a flake

`slept-workspace-remount-wake` looked like a 1-in-6 flake but is deterministic. #20025 changed `remountTerminalTabForRecovery` to return `TerminalRecoveryRemountResult` and updated the sibling call site in `terminal-quick-command-pre-bind-recovery.spec.ts`, but missed this one, which still compared the whole object to `true`.

Ancestry confirms it: the spec failed in the single run containing #20025 and passed in all five predating it. Typecheck cannot catch this because the call goes through `window.__store` inside `page.evaluate`.

## Caveat

The `tasks-page` change is a timeout raise, just a derived one. It does not address the secondary mode where a keystroke gap above 750 ms commits a prefix and the assertion can then never match. The durable fix is an env-overridable idle constant.

## Validation

- `pnpm tc` — clean
- `pnpm run check:code-quality:changed` — 0 findings across all three sub-gates, React Doctor included
- `pnpm test src/renderer/src/components/new-workspace/` — 18 files, 164 tests passing (covers the product change)

E2E itself is not run here; these are main-branch flakes and the proof is the CI history cited above.
