### PR TITLE
fix(automations): advance cron schedules past a DST fall-back hour

### DIFF
--- a/src/shared/automation-cron-occurrence.ts
+++ b/src/shared/automation-cron-occurrence.ts
@@ -10,9 +10,9 @@ export function startOfLocalDay(timestamp: number): number {
 }
 
 export function floorToMinute(timestamp: number): number {
-  const date = new Date(timestamp)
-  date.setSeconds(0, 0)
-  return date.getTime()
+  // Why: recomposing local wall-clock fields resolves an ambiguous DST fall-back minute to the
+  // earlier offset, moving the result backwards in absolute time.
+  return timestamp - (timestamp % 60_000)
 }
 
 export function cronMatches(rule: ParsedCron, timestamp: number): boolean {

--- a/src/shared/automation-cron-occurrence.ts
+++ b/src/shared/automation-cron-occurrence.ts
@@ -9,9 +9,12 @@ export function startOfLocalDay(timestamp: number): number {
   return date.getTime()
 }
 
+/**
+ * Floors to the start of the minute in absolute time. Pure UTC arithmetic:
+ * recomposing local wall-clock fields would resolve an ambiguous DST
+ * fall-back minute to the earlier offset, moving the result backwards.
+ */
 export function floorToMinute(timestamp: number): number {
-  // Why: recomposing local wall-clock fields resolves an ambiguous DST fall-back minute to the
-  // earlier offset, moving the result backwards in absolute time.
   return timestamp - (timestamp % 60_000)
 }
 

--- a/src/shared/automation-schedule-occurrences.test.ts
+++ b/src/shared/automation-schedule-occurrences.test.ts
@@ -2,18 +2,25 @@ import { afterAll, describe, expect, it } from 'vitest'
 import { floorToMinute } from './automation-cron-occurrence'
 import { nextAutomationOccurrenceAfter } from './automation-schedule-occurrences'
 
+// Why: Node on Windows ignores runtime TZ changes; skip there instead of failing opaquely.
+const originalTz = process.env.TZ
 process.env.TZ = 'America/New_York'
 
-const originalTz = process.env.TZ
-
-// Why: Node on Windows ignores runtime TZ changes, so the suite self-checks instead of failing opaquely.
+/** Whether the TZ override above actually took effect for this process. */
 function newYorkTzApplied(): boolean {
   return new Date('2026-11-01T01:30:00-04:00').getTimezoneOffset() === 240
 }
 
-afterAll(() => {
-  process.env.TZ = originalTz
-})
+/** Restore the process timezone exactly as it started (unset stays unset). */
+function restoreOriginalTimezone(): void {
+  if (originalTz === undefined) {
+    delete process.env.TZ
+  } else {
+    process.env.TZ = originalTz
+  }
+}
+
+afterAll(restoreOriginalTimezone)
 
 describe.skipIf(!newYorkTzApplied())('automation schedule occurrences across DST', () => {
   const dtstart = new Date('2026-10-31T12:00:00-04:00').getTime()

--- a/src/shared/automation-schedule-occurrences.test.ts
+++ b/src/shared/automation-schedule-occurrences.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, describe, expect, it } from 'vitest'
+import { floorToMinute } from './automation-cron-occurrence'
+import { nextAutomationOccurrenceAfter } from './automation-schedule-occurrences'
+
+process.env.TZ = 'America/New_York'
+
+const originalTz = process.env.TZ
+
+// Why: Node on Windows ignores runtime TZ changes, so the suite self-checks instead of failing opaquely.
+function newYorkTzApplied(): boolean {
+  return new Date('2026-11-01T01:30:00-04:00').getTimezoneOffset() === 240
+}
+
+afterAll(() => {
+  process.env.TZ = originalTz
+})
+
+describe.skipIf(!newYorkTzApplied())('automation schedule occurrences across DST', () => {
+  const dtstart = new Date('2026-10-31T12:00:00-04:00').getTime()
+  const firstHalfOfRepeatedHour = new Date('2026-11-01T01:30:00-04:00').getTime()
+  const secondHalfOfRepeatedHour = new Date('2026-11-01T01:30:00-05:00').getTime()
+  const nextDay = new Date('2026-11-02T01:30:00-05:00').getTime()
+
+  it('floors a fall-back ambiguous minute without moving backwards in absolute time', () => {
+    const duringSecondRepeatedMinute = secondHalfOfRepeatedHour + 45_000
+    expect(floorToMinute(duringSecondRepeatedMinute)).toBe(secondHalfOfRepeatedHour)
+  })
+
+  it('fires both repeats of a cron minute in the DST fall-back hour', () => {
+    const expression = '30 1 * * *'
+    expect(nextAutomationOccurrenceAfter(expression, dtstart, dtstart)).toBe(
+      firstHalfOfRepeatedHour
+    )
+    expect(nextAutomationOccurrenceAfter(expression, dtstart, firstHalfOfRepeatedHour)).toBe(
+      secondHalfOfRepeatedHour
+    )
+  })
+
+  it('advances past the repeated hour instead of returning the after instant', () => {
+    const expression = '30 1 * * *'
+    const next = nextAutomationOccurrenceAfter(expression, dtstart, secondHalfOfRepeatedHour)
+    expect(next).toBe(nextDay)
+  })
+
+  it('returns strictly-later instants for every after value inside the repeated hour', () => {
+    const expression = '30 1 * * *'
+    for (let after = secondHalfOfRepeatedHour; after < secondHalfOfRepeatedHour + 3_600_000; after += 60_000) {
+      const next = nextAutomationOccurrenceAfter(expression, dtstart, after)
+      expect(next).toBeGreaterThan(after)
+    }
+  })
+
+  it('still skips the nonexistent spring-forward minute', () => {
+    const springStart = new Date('2026-03-07T12:00:00-05:00').getTime()
+    const next = nextAutomationOccurrenceAfter('30 2 * * *', springStart, springStart)
+    expect(next).toBe(new Date('2026-03-09T02:30:00-04:00').getTime())
+  })
+})


### PR DESCRIPTION
## ELI5

Every autumn, when clocks fall back, a cron automation whose fire time lands inside the repeated hour could fire once per scheduler tick (~60s) for that entire hour. The "find the next run" function got confused by the duplicated wall-clock hour and picked the run it had just fired — over and over.

## What Changed

`floorToMinute` (`src/shared/automation-cron-occurrence.ts`) now drops sub-minute components with pure UTC arithmetic instead of recomposing local wall-clock fields via `setSeconds(0, 0)`. Plus a colocated regression test file (`src/shared/automation-schedule-occurrences.test.ts`) driving the real America/New_York 2026 fall-back.

## Why

`floorToMinute` round-tripped local wall-clock fields, so an ambiguous fall-back minute resolved to the **earlier** offset — one hour *before* its input. `nextAutomationOccurrenceAfter` then started its minute-walk before the transition, the walk crossed the fall-back boundary and re-entered the same wall-clock hour in the new offset, and matched `after` itself:

```
expression: 30 1 * * *   (America/New_York, 2026-11-01 fall-back)
  fire #1: 2026-11-01 01:30 EDT   ✓
  fire #2: 2026-11-01 01:30 EST   ✓ (second repeat — correct)
  fire #3: 2026-11-01 01:30 EST   ✗ same instant as #2 — violated strictly-after
```

That broke the "strictly after `after`" contract, and `advanceAutomationNextRun` computing `nextRunAt` from `now` then saw `nextRunAt <= now` on every tick and re-launched the agent — each launch consuming tokens and, in `new_per_run` mode, creating a worktree.

UTC arithmetic cannot move backwards in absolute time, so the floor is always `<=` its input and the walk starts inside the second (EST) pass of the repeated hour. Semantics after the fix:

- Both repeats of a scheduled minute in the fall-back hour fire exactly once each.
- The nonexistent spring-forward minute is still skipped (covered by a test).

## Linked Issue

Fixes #20154

## Visual Proof

N/A — scheduler arithmetic, no UI or interaction change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Ran on macOS (arm64, Node 22):

- `vitest run src/shared/automation-schedule-occurrences.test.ts` — 5 new tests, all passing; before the fix, 3 of them fail with exactly the trace from the issue (`expected 1793514600000 to be greater than 1793514600000`).
- `vitest run src/shared/automation-schedules.test.ts` — all 23 existing schedule tests still pass.
- `typecheck` (parallel projects script) exits 0; `oxlint` on both changed files reports 0 warnings/errors.

Full gates have since been run locally (the toolchain obstacle above was repaired — SDK pin for the node-pty rebuild): full `pnpm lint` exits 0, and full `pnpm test` passes 79,008 tests with 17 failures across 13 files, all environmental and unrelated to the scheduler — the cross-version-wire/release-checkout family (shallow clone without release tags), real-CLI binary handshakes, and daemon/PTY timing probes; the three changed files pass everywhere. `pnpm build` fails only at the macOS native helper's universal-binary `lipo` step, which is the SwiftPM 6.4 build-system change tracked in #21145 (independent of this change; fix up in #21146).

The test file sets `TZ=America/New_York` and guards with `describe.skipIf` on a timezone-offset probe, so it runs on POSIX (including the ubuntu CI) and skips honestly on Windows-local runs where Node ignores runtime `TZ` changes.

## AI Disclosure

Root-cause mechanism was traced from the repro in #20154 and verified locally by driving the real `nextAutomationOccurrenceAfter`/`floorToMinute` before writing any fix. Implementation and tests were drafted with AI assistance (GLM, via ZCode); the approach matches the plan posted when claiming the issue, and the author reviewed the diff and test output.

## Review

AI-assisted review summary per the contributing guide:

- **Cross-platform**: change is pure epoch arithmetic, no platform-specific behavior; the only platform-sensitive piece is the test's `TZ` guard (skips on Windows-local, always runs on ubuntu CI).
- **SSH / remote / local**: `floorToMinute` runs in the scheduling host's process; behavior is identical regardless of where the automation executes.
- **Agent / integration compatibility**: no agent-, integration-, or git-provider-specific logic touched.
- **Performance**: strictly cheaper than before — one arithmetic op instead of a `Date` allocation plus field recomposition; called twice per schedule computation, not in a hot loop.
- **UI quality**: N/A, no UI change.
- **Security**: no new inputs, no parsing, no process spawning.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Cross-platform, SSH, mobile, backwards-compatibility, and performance checked above — no issues found. The only observable behavior change is the intended one: automations whose local fire time falls inside a DST fall-back hour now fire twice (once per wall-clock repeat) instead of ~60 times.

Out-of-scope observation, no change made here: `startOfLocalDay` and `atLocalTime` in the same files use the same local-field recomposition pattern and have their own theoretical DST edge cases (e.g. zones whose fall-back crosses midnight). Happy to look at those separately if wanted.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — typecheck, full lint, and full test pass locally (17 environmental failures documented in Testing); build blocked only by the Xcode 27 toolchain issue #21145, independent of this change

---

**Author**: X — [@eatmoremoreduck](https://x.com/eatmoremoreduck) · GitHub — [@eatmoreduck](https://github.com/eatmoreduck)

