### PR TITLE
fix(crash-reporting): record a pending minidump status so an unresolved pairing is visible

### DIFF
--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { appMetricsMock } = vi.hoisted(() => ({
@@ -16,6 +19,7 @@ import {
   getCrashBreadcrumbSnapshot,
   recordCrashBreadcrumb
 } from './crash-breadcrumb-store'
+import { CrashReportStore } from './crash-report-store'
 import { ProcessGoneDedupe } from './process-gone-dedupe'
 import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
 import { resetProcessGoneSiblingCorrelationForTest } from './process-gone-sibling-correlation'
@@ -52,6 +56,7 @@ function event(overrides: Partial<ProcessGoneCrashEvent> = {}): ProcessGoneCrash
 }
 
 let sink: CapturingSink
+const tempDirs: string[] = []
 
 beforeEach(() => {
   sink = capturingSink()
@@ -60,12 +65,13 @@ beforeEach(() => {
   resetProcessGoneSiblingCorrelationForTest()
 })
 
-afterEach(() => {
+afterEach(async () => {
   vi.useRealTimers()
   vi.restoreAllMocks()
   _resetTracerForTests()
   clearCrashBreadcrumbsForTest()
   resetProcessGoneSiblingCorrelationForTest()
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
 })
 
 describe('recordProcessGoneCrash', () => {
@@ -712,6 +718,43 @@ describe('minidump signature attachment', () => {
     expect(JSON.stringify(attach.mock.calls[0]?.[1])).not.toContain('abc123')
     expect(JSON.stringify(sink.records)).not.toContain('alice')
     expect(JSON.stringify(sink.records)).not.toContain('abc123')
+  })
+
+  // Crash 8d4a8d01 (v1.4.200, win32) reached triage with no minidumpStatus at all, which reads
+  // identically to "pairing ran and found nothing". Only the async attach below ever wrote the
+  // field, so a session that ends first leaves it absent.
+  it('records a pending minidump status so an unfinished pairing stays distinguishable', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const neverSettles = () => new Promise<never>(() => {})
+
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      event(),
+      new ProcessGoneDedupe(),
+      neverSettles
+    )
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledOnce())
+    expect(record.mock.calls[0]?.[0]).toMatchObject({
+      details: expect.objectContaining({ minidumpStatus: 'pending' })
+    })
+  })
+
+  it('resolves the seeded pending status in the persisted report, keeping the diagnostics', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'orca-process-gone-'))
+    tempDirs.push(dir)
+    const store = new CrashReportStore(path.join(dir, 'crash-reports.json'))
+
+    recordProcessGoneCrash(store, event(), new ProcessGoneDedupe(), noMinidump)
+
+    await vi.waitFor(async () => {
+      const [persisted] = await store.listRecent()
+      expect(persisted?.details.minidumpStatus).toBe('absent')
+    })
+    // Why: the seed only stays safe while attachDetails merges -- a replacing write would
+    // resolve the status and silently drop every diagnostic recorded alongside it.
+    const [persisted] = await store.listRecent()
+    expect(persisted?.details.mainProcessPid).toBe(process.pid)
   })
 
   it('marks the report when no dump was produced, so absence is visible', async () => {

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -297,7 +297,10 @@ export function recordProcessGoneCrash(
     arch: process.arch,
     electronVersion: process.versions.electron ?? 'unknown',
     chromeVersion: process.versions.chrome ?? 'unknown',
-    details: crashDetails,
+    // Why: attachMinidumpSignature below is the only writer of minidumpStatus, so a session that
+    // ends before it settles left the field absent -- indistinguishable from a paired dump that
+    // found nothing. Seed the unresolved state so the report says which happened.
+    details: { ...crashDetails, minidumpStatus: 'pending' },
     breadcrumbs: reportBreadcrumbs
   })
   trackRendererSiblingAttribution(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## What

Crash report **`8d4a8d01-98ca-47b7-843e-a5810081ad14`** (released **v1.4.200**, win32 10.0.26200,
renderer, `Reason: crashed`, `Exit code: -1`) reached triage carrying **no `minidumpStatus` field at
all** — so there was no way to tell whether Crashpad pairing ran and found nothing, or never
finished. Without that, the faulting module cannot be resolved and the whole Windows `crashed`/`-1`
family is undiagnosable.

`attachMinidumpSignature` (`process-gone-recorder.ts:136-153`) guarantees `'absent'` or `'captured'`
on every path — but it runs **asynchronously** off `recorded.then(...)`, and `store.record` persisted
no value of its own. If the session ends before that chain settles, the field is simply missing.

This seeds `'pending'` at record time.

```diff
-    details: crashDetails,
+    details: { ...crashDetails, minidumpStatus: 'pending' },
```

## Fix evidence

**Reproduced first.** Both new tests fail against `origin/main` with the field absent, and pass with
the one-line change.

Two independent mutations, each killing exactly one test — and a *different* test:

```
MUTATION A — revert process-gone-recorder.ts to origin/main
 × records a pending minidump status so an unfinished pairing stays distinguishable
      Tests  1 failed | 27 passed (28)

MUTATION B — change attachDetails from a merge into a replace
 × resolves the seeded pending status in the persisted report, keeping the diagnostics
   AssertionError: expected undefined to be 64156
      Tests  1 failed | 27 passed (28)
```

That is the point of having two: the first uses a mock store and cannot see merge semantics at all;
the second drives a **real `CrashReportStore`** on a tmpdir end-to-end.

**Gates:** `pnpm test src/main/crash-reporting/` → 27 files / **284 tests pass** · `pnpm tc` exit 0 ·
`oxlint` clean · `oxfmt --list-different` clean.

## Why this is safe

- **`attachDetails` merges, it does not replace** (`crash-report-store.ts:127`:
  `details: { ...report.details, ...sanitize(extraDetails) }`), so the terminal value overwrites the
  seed and nothing recorded alongside it is dropped. Mutation B is the regression guard for exactly
  this.
- **No race.** `withWrite` (`crash-report-store.ts:203-219`) serializes every mutation on
  `writeChain`, and the attach is queued strictly after `record`'s write resolves. There is no
  ordering where `'pending'` lands after `'captured'`/`'absent'`.
- **Nothing branches on `minidumpStatus`.** A repo-wide search finds only write sites and tests — no
  reader, no union type, no exhaustive switch, no submission gating, no dedupe input. A third value
  breaks nothing.
- **No wire impact.** Crash reports never cross the client/host wire; they travel main→renderer over
  local IPC, and `details` is a freeform `Record<string, CrashReportDetailValue>`, so a new key is
  additive with no opcode and no decoder change.
- **Early-return paths untouched** — the edit sits after the suppressed-classification,
  store-unavailable and dedupe-claim returns.

## ELI5

When Orca's renderer dies, Orca writes down what happened, then goes looking for the crash dump —
which takes a moment, so it writes the dump's outcome down *later*. If Orca is closed in that
moment, the outcome never gets written, and the report just doesn't mention dumps at all. Reading it
afterwards, you cannot tell "we looked and there was no dump" from "we never got to look."

Now Orca writes **"still looking"** immediately, and replaces it with the real answer when it has
one. If it never gets one, the report says "still looking" — which is the honest answer, and the one
that tells whoever reads it not to conclude there was no dump.

## Trade-offs

- **User-visible text change.** A report submitted while pairing is unresolved now renders a
  `- minidumpStatus: pending` line where previously the line was absent. That is the intended effect
  — absence was the ambiguity — but it *is* a new string in a user-facing `.txt`.
- **Does not fix `8d4a8d01` itself.** That crash remains **unexplained**; this only ensures the next
  one in its family carries enough state to be diagnosed. Filed deliberately as a diagnosability fix,
  not as a cause fix, because nothing in that payload attributes the crash to Orca code.
- **Does not address the second half of the gap.** When pairing *throws*, the
  `minidump_signature_attach_failed` breadcrumb goes only to the global durable ring, not into the
  report's own details, so it never reaches the snapshot the user submits. Left out to keep this
  change to one line; worth a follow-up.
- **`'pending'` is a terminal state in practice when a session dies mid-pairing.** It is not
  reconciled on next launch. Doing so would mean re-running Crashpad pairing against a stale dump
  directory at startup — more risk than the ambiguity it removes.

## Adversarial review

**1 loop, which found a major and fixed it.** The reviewer attacked the highest-risk hypothesis
first — that `attachDetails` might *replace* and the seed could destroy a captured signature — and
disproved it by mutation rather than by reading.

It then found that the **second test did not test what its name claimed**: `'overwrites the pending
status once pairing resolves'` asserted only on the `record` mock (identical to test 1) plus an
`attach` assertion byte-identical to the pre-existing test at line 769. With the store's merge
mutated to a replace, **it still passed** — it had zero coverage of the overwrite property its name
asserted, which is the single riskiest property of this change. Replaced with the real-store
integration test above, which does catch that mutation. Also removed a stray double blank line
flagged by `oxfmt` (the project formats with `oxfmt`, not prettier).
