### PR TITLE
fix(stats): count OpenCode cache tokens in usage totals

### DIFF
--- a/src/main/opencode-usage/opencode-usage-provider.ts
+++ b/src/main/opencode-usage/opencode-usage-provider.ts
@@ -6,8 +6,9 @@ import type {
   OpenCodeUsageSession
 } from './types'
 
-// Why: v2 adds per-database session ownership (stale sibling-copy dedupe).
-// Older caches were built without it and can carry doubled sessions (#8006).
+// Why: v2 added per-database session ownership (stale sibling-copy dedupe, #8006);
+// v3 counts cache.read + cache.write in input, so v2 snapshots under-count
+// OpenCode tokens and are rebuilt.
 export const OPENCODE_USAGE_SCHEMA_VERSION = 3
 
 export const openCodeUsageProvider = {

--- a/src/main/opencode-usage/opencode-usage-provider.ts
+++ b/src/main/opencode-usage/opencode-usage-provider.ts
@@ -8,7 +8,7 @@ import type {
 
 // Why: v2 adds per-database session ownership (stale sibling-copy dedupe).
 // Older caches were built without it and can carry doubled sessions (#8006).
-export const OPENCODE_USAGE_SCHEMA_VERSION = 2
+export const OPENCODE_USAGE_SCHEMA_VERSION = 3
 
 export const openCodeUsageProvider = {
   id: 'opencode',

--- a/src/main/opencode-usage/opencode-usage-row-parsing.ts
+++ b/src/main/opencode-usage/opencode-usage-row-parsing.ts
@@ -66,6 +66,15 @@ function extractTimestamp(data: Record<string, unknown>, row: OpenCodeUsageRow):
   return millis ? new Date(millis).toISOString() : null
 }
 
+/**
+ * Parse one OpenCode usage row into a provider-neutral event.
+ *
+ * OpenCode's `tokens.input` excludes cache hits and `tokens.total` includes
+ * them; the event folds cache read + write into `inputTokens` so
+ * `newInput = inputTokens - cachedInputTokens` holds like the other providers.
+ * @param row - A row from `selectUsageRows`.
+ * @returns The parsed event, or `null` when the row carries no token data or timestamp.
+ */
 export function parseOpenCodeUsageRow(row: OpenCodeUsageRow): OpenCodeUsageParsedEvent | null {
   const data = parseJsonObject(row.data)
   if (!data) {

--- a/src/main/opencode-usage/opencode-usage-row-parsing.ts
+++ b/src/main/opencode-usage/opencode-usage-row-parsing.ts
@@ -77,16 +77,18 @@ export function parseOpenCodeUsageRow(row: OpenCodeUsageRow): OpenCodeUsageParse
     return null
   }
   const cache = parseJsonObject(tokens.cache)
-  const inputTokens = ensureNumber(tokens.input)
+  // Why: OpenCode's `input` excludes cache hits and its `total` includes them;
+  // Orca counts cached tokens inside inputTokens so newInput = input - cached.
+  const cachedInputTokens = ensureNumber(cache?.read) + ensureNumber(cache?.write)
+  const inputTokens = ensureNumber(tokens.input) + cachedInputTokens
   const outputTokens = ensureNumber(tokens.output)
   const reasoningOutputTokens = ensureNumber(tokens.reasoning)
-  const cachedInputTokens = Math.min(ensureNumber(cache?.read), inputTokens)
   const totalTokens =
     ensureNumber(tokens.total) > 0
       ? ensureNumber(tokens.total)
       : inputTokens + outputTokens + reasoningOutputTokens
 
-  if (inputTokens + outputTokens + reasoningOutputTokens + cachedInputTokens + totalTokens <= 0) {
+  if (inputTokens + outputTokens + reasoningOutputTokens + totalTokens <= 0) {
     return null
   }
 

--- a/src/main/opencode-usage/opencode-usage-row-queries.ts
+++ b/src/main/opencode-usage/opencode-usage-row-queries.ts
@@ -53,7 +53,12 @@ function getAssistantSessionMessageCount(db: Database.Database): number {
   return row?.count ?? 0
 }
 
-// Why: tokens_cache_write arrived after the other counters; older DBs lack it.
+/**
+ * SQL expression for a session's cache-write counter.
+ * @param db - A readonly SyncDatabase instance for opencode.db.
+ * @param alias - Table alias prefix, e.g. `s.`, when the column is used in a join.
+ * @returns The qualified column name, or `0` when the DB predates `tokens_cache_write`.
+ */
 function getSessionCacheWriteColumn(db: Database.Database, alias = ''): string {
   return columnExists(db, 'session', 'tokens_cache_write') ? `${alias}tokens_cache_write` : '0'
 }
@@ -67,6 +72,11 @@ function canReadSessionUsageRows(db: Database.Database): boolean {
   )
 }
 
+/**
+ * Count sessions with materialized token totals, cache columns included.
+ * @param db - A readonly SyncDatabase instance for opencode.db.
+ * @returns Number of sessions with any usage, or 0 when the totals columns are absent.
+ */
 function getSessionUsageRowCount(db: Database.Database): number {
   if (!canReadSessionUsageRows(db)) {
     return 0
@@ -82,6 +92,12 @@ function getSessionUsageRowCount(db: Database.Database): number {
   return row?.count ?? 0
 }
 
+/**
+ * Read one usage row per session from the materialized `session.tokens_*` columns.
+ * @param db - A readonly SyncDatabase instance for opencode.db.
+ * @returns Rows whose `data` mirrors OpenCode's message `tokens` shape, so
+ *   `parseOpenCodeUsageRow` treats them exactly like per-message rows.
+ */
 function selectSessionUsageRows(db: Database.Database): OpenCodeUsageRow[] {
   const projectJoin = getProjectJoin(db)
   const sessionModelSelect = getSessionModelSelect(db)
@@ -131,6 +147,12 @@ function selectSessionUsageRows(db: Database.Database): OpenCodeUsageRow[] {
   }))
 }
 
+/**
+ * Select usage rows from whichever schema generation the database has.
+ * @param db - A readonly SyncDatabase instance for opencode.db.
+ * @returns Materialized session rows when available, else `session_message`
+ *   rows, else legacy `message` rows; empty when no usage tables exist.
+ */
 export function selectUsageRows(db: Database.Database): OpenCodeUsageRow[] {
   if (!tableExists(db, 'session')) {
     return []

--- a/src/main/opencode-usage/opencode-usage-row-queries.ts
+++ b/src/main/opencode-usage/opencode-usage-row-queries.ts
@@ -53,6 +53,11 @@ function getAssistantSessionMessageCount(db: Database.Database): number {
   return row?.count ?? 0
 }
 
+// Why: tokens_cache_write arrived after the other counters; older DBs lack it.
+function getSessionCacheWriteColumn(db: Database.Database, alias = ''): string {
+  return columnExists(db, 'session', 'tokens_cache_write') ? `${alias}tokens_cache_write` : '0'
+}
+
 function canReadSessionUsageRows(db: Database.Database): boolean {
   if (!tableExists(db, 'session')) {
     return false
@@ -66,11 +71,12 @@ function getSessionUsageRowCount(db: Database.Database): number {
   if (!canReadSessionUsageRows(db)) {
     return 0
   }
+  const cacheWrite = getSessionCacheWriteColumn(db)
   const row = db
     .prepare(
       `SELECT COUNT(*) AS count
        FROM session
-       WHERE tokens_input + tokens_output + tokens_reasoning + tokens_cache_read > 0`
+       WHERE tokens_input + tokens_output + tokens_reasoning + tokens_cache_read + ${cacheWrite} > 0`
     )
     .get() as { count?: number } | undefined
   return row?.count ?? 0
@@ -79,18 +85,16 @@ function getSessionUsageRowCount(db: Database.Database): number {
 function selectSessionUsageRows(db: Database.Database): OpenCodeUsageRow[] {
   const projectJoin = getProjectJoin(db)
   const sessionModelSelect = getSessionModelSelect(db)
-  const cacheWriteSelect = columnExists(db, 'session', 'tokens_cache_write')
-    ? 's.tokens_cache_write'
-    : '0 AS tokens_cache_write'
+  const cacheWrite = getSessionCacheWriteColumn(db, 's.')
   const rows = db
     .prepare(
       `SELECT s.id, s.id AS session_id, s.time_created, s.time_updated,
               s.directory, s.title, p.worktree, ${sessionModelSelect},
               s.cost, s.tokens_input, s.tokens_output, s.tokens_reasoning, s.tokens_cache_read,
-              ${cacheWriteSelect}
+              ${cacheWrite} AS tokens_cache_write
        FROM session s
        ${projectJoin}
-       WHERE s.tokens_input + s.tokens_output + s.tokens_reasoning + s.tokens_cache_read > 0
+       WHERE s.tokens_input + s.tokens_output + s.tokens_reasoning + s.tokens_cache_read + ${cacheWrite} > 0
        ORDER BY s.time_created, s.id`
     )
     .all() as OpenCodeSessionUsageRow[]

--- a/src/main/opencode-usage/opencode-usage-row-queries.ts
+++ b/src/main/opencode-usage/opencode-usage-row-queries.ts
@@ -27,6 +27,7 @@ type OpenCodeSessionUsageRow = {
   tokens_output: number
   tokens_reasoning: number
   tokens_cache_read: number
+  tokens_cache_write: number
 }
 
 function getProjectJoin(db: Database.Database): string {
@@ -78,11 +79,15 @@ function getSessionUsageRowCount(db: Database.Database): number {
 function selectSessionUsageRows(db: Database.Database): OpenCodeUsageRow[] {
   const projectJoin = getProjectJoin(db)
   const sessionModelSelect = getSessionModelSelect(db)
+  const cacheWriteSelect = columnExists(db, 'session', 'tokens_cache_write')
+    ? 's.tokens_cache_write'
+    : '0 AS tokens_cache_write'
   const rows = db
     .prepare(
       `SELECT s.id, s.id AS session_id, s.time_created, s.time_updated,
               s.directory, s.title, p.worktree, ${sessionModelSelect},
-              s.cost, s.tokens_input, s.tokens_output, s.tokens_reasoning, s.tokens_cache_read
+              s.cost, s.tokens_input, s.tokens_output, s.tokens_reasoning, s.tokens_cache_read,
+              ${cacheWriteSelect}
        FROM session s
        ${projectJoin}
        WHERE s.tokens_input + s.tokens_output + s.tokens_reasoning + s.tokens_cache_read > 0
@@ -99,16 +104,23 @@ function selectSessionUsageRows(db: Database.Database): OpenCodeUsageRow[] {
     title: row.title,
     worktree: row.worktree,
     session_model: row.session_model,
+    // Why: mirror OpenCode's own message `tokens` shape (total includes cache)
+    // so materialized and per-message rows parse identically.
     data: JSON.stringify({
       cost: row.cost,
       tokens: {
         input: row.tokens_input,
         output: row.tokens_output,
         reasoning: row.tokens_reasoning,
-        total: row.tokens_input + row.tokens_output + row.tokens_reasoning,
+        total:
+          row.tokens_input +
+          row.tokens_output +
+          row.tokens_reasoning +
+          row.tokens_cache_read +
+          row.tokens_cache_write,
         cache: {
           read: row.tokens_cache_read,
-          write: 0
+          write: row.tokens_cache_write
         }
       }
     })

--- a/src/main/opencode-usage/scanner.test.ts
+++ b/src/main/opencode-usage/scanner.test.ts
@@ -337,6 +337,53 @@ describe('parseOpenCodeUsageDatabase', () => {
     })
   })
 
+  it('counts a materialized session whose only usage is cache writes', async () => {
+    const { db, path } = createTempDb()
+    db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        directory TEXT,
+        title TEXT,
+        time_created INTEGER,
+        time_updated INTEGER,
+        cost REAL,
+        tokens_input INTEGER,
+        tokens_output INTEGER,
+        tokens_reasoning INTEGER,
+        tokens_cache_read INTEGER,
+        tokens_cache_write INTEGER
+      );
+    `)
+    db.prepare(
+      `INSERT INTO session (
+        id, directory, title, time_created, time_updated, cost,
+        tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'session-1',
+      WORKTREE,
+      'Session',
+      1_777_777_700_000,
+      1_777_777_800_000,
+      0,
+      0,
+      0,
+      0,
+      0,
+      2_313
+    )
+    db.close()
+
+    const parsed = await parseOpenCodeUsageDatabase(path, worktrees())
+
+    expect(parsed.sessions).toHaveLength(1)
+    expect(parsed.sessions[0]).toMatchObject({
+      totalInputTokens: 2_313,
+      totalCachedInputTokens: 2_313,
+      totalTokens: 2_313
+    })
+  })
+
   it('counts materialized session totals the same as the per-message rows they summarize', async () => {
     // Real OpenCode shape: `input` is uncached, cache hits dominate, `total` sums everything.
     const tokens = {

--- a/src/main/opencode-usage/scanner.test.ts
+++ b/src/main/opencode-usage/scanner.test.ts
@@ -110,7 +110,7 @@ describe('parseOpenCodeUsageRow', () => {
           input: 1000,
           output: 250,
           reasoning: 100,
-          total: 1350,
+          total: 1775,
           cache: { read: 400, write: 25 }
         },
         time: {
@@ -125,11 +125,11 @@ describe('parseOpenCodeUsageRow', () => {
       cwd: `${WORKTREE}/packages/app`,
       model: 'anthropic/claude-sonnet-4-5',
       estimatedCostUsd: 0.0123,
-      inputTokens: 1000,
-      cachedInputTokens: 400,
+      inputTokens: 1425,
+      cachedInputTokens: 425,
       outputTokens: 250,
       reasoningOutputTokens: 100,
-      totalTokens: 1350
+      totalTokens: 1775
     })
   })
 })
@@ -195,6 +195,7 @@ describe('parseOpenCodeUsageDatabase', () => {
         tokens_output INTEGER,
         tokens_reasoning INTEGER,
         tokens_cache_read INTEGER,
+        tokens_cache_write INTEGER,
         time_created INTEGER,
         time_updated INTEGER
       );
@@ -203,9 +204,9 @@ describe('parseOpenCodeUsageDatabase', () => {
     db.prepare(
       `INSERT INTO session (
         id, project_id, directory, title, model, cost,
-        tokens_input, tokens_output, tokens_reasoning, tokens_cache_read,
+        tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write,
         time_created, time_updated
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       'session-1',
       'project-1',
@@ -217,6 +218,7 @@ describe('parseOpenCodeUsageDatabase', () => {
       500,
       100,
       250,
+      50,
       1_777_777_700_000,
       1_777_777_800_000
     )
@@ -230,21 +232,21 @@ describe('parseOpenCodeUsageDatabase', () => {
       primaryModel: 'anthropic/claude-sonnet-4-5',
       primaryProjectLabel: 'Repo',
       eventCount: 1,
-      totalInputTokens: 1000,
-      totalCachedInputTokens: 250,
+      totalInputTokens: 1300,
+      totalCachedInputTokens: 300,
       totalOutputTokens: 500,
       totalReasoningOutputTokens: 100,
-      totalTokens: 1600,
+      totalTokens: 1900,
       estimatedCostUsd: 0.06
     })
     expect(parsed.dailyAggregates).toEqual([
       expect.objectContaining({
         projectLabel: 'Repo',
-        inputTokens: 1000,
-        cachedInputTokens: 250,
+        inputTokens: 1300,
+        cachedInputTokens: 300,
         outputTokens: 500,
         reasoningOutputTokens: 100,
-        totalTokens: 1600,
+        totalTokens: 1900,
         estimatedCostUsd: 0.06
       })
     ])
@@ -297,9 +299,141 @@ describe('parseOpenCodeUsageDatabase', () => {
     expect(parsed.sessions[0]).toMatchObject({
       primaryModel: 'openai/gpt-5.5',
       primaryProjectLabel: 'Repo',
-      totalTokens: 1050,
+      totalTokens: 1150,
       estimatedCostUsd: 0.03
     })
+  })
+
+  it('treats a session table without tokens_cache_write as zero cache writes', async () => {
+    const { db, path } = createTempDb()
+    createSessionTotalsSchema(db)
+    db.prepare(
+      `INSERT INTO session (
+        id, directory, title, model, cost,
+        tokens_input, tokens_output, tokens_reasoning, tokens_cache_read,
+        time_created, time_updated
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      'session-1',
+      WORKTREE,
+      'Session',
+      null,
+      0,
+      10,
+      5,
+      0,
+      1000,
+      1_777_777_700_000,
+      1_777_777_800_000
+    )
+    db.close()
+
+    const parsed = await parseOpenCodeUsageDatabase(path, worktrees())
+
+    expect(parsed.sessions[0]).toMatchObject({
+      totalInputTokens: 1010,
+      totalCachedInputTokens: 1000,
+      totalTokens: 1015
+    })
+  })
+
+  it('counts materialized session totals the same as the per-message rows they summarize', async () => {
+    // Real OpenCode shape: `input` is uncached, cache hits dominate, `total` sums everything.
+    const tokens = {
+      input: 638,
+      output: 390,
+      reasoning: 120,
+      cache: { read: 642_944, write: 2_313 }
+    }
+    const total = 638 + 390 + 120 + 642_944 + 2_313
+
+    const materialized = createTempDb()
+    materialized.db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        directory TEXT,
+        title TEXT,
+        time_created INTEGER,
+        time_updated INTEGER,
+        cost REAL,
+        tokens_input INTEGER,
+        tokens_output INTEGER,
+        tokens_reasoning INTEGER,
+        tokens_cache_read INTEGER,
+        tokens_cache_write INTEGER
+      );
+    `)
+    materialized.db
+      .prepare(
+        `INSERT INTO session (
+          id, directory, title, time_created, time_updated, cost,
+          tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        'session-1',
+        WORKTREE,
+        'Session',
+        1_777_777_700_000,
+        1_777_777_800_000,
+        0,
+        tokens.input,
+        tokens.output,
+        tokens.reasoning,
+        tokens.cache.read,
+        tokens.cache.write
+      )
+    materialized.db.close()
+
+    const perMessage = createTempDb()
+    perMessage.db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        directory TEXT,
+        title TEXT,
+        time_created INTEGER,
+        time_updated INTEGER
+      );
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT,
+        time_created INTEGER,
+        time_updated INTEGER,
+        data TEXT
+      );
+    `)
+    perMessage.db
+      .prepare(
+        'INSERT INTO session (id, directory, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?)'
+      )
+      .run('session-1', WORKTREE, 'Session', 1_777_777_700_000, 1_777_777_800_000)
+    perMessage.db
+      .prepare(
+        'INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)'
+      )
+      .run(
+        'message-1',
+        'session-1',
+        1_777_777_700_000,
+        1_777_777_800_000,
+        JSON.stringify({ role: 'assistant', tokens: { ...tokens, total } })
+      )
+    perMessage.db.close()
+
+    const [fromTotals, fromMessages] = await Promise.all([
+      parseOpenCodeUsageDatabase(materialized.path, worktrees()),
+      parseOpenCodeUsageDatabase(perMessage.path, worktrees())
+    ])
+    const pick = (session: (typeof fromTotals.sessions)[number] | undefined) => ({
+      totalInputTokens: session?.totalInputTokens,
+      totalCachedInputTokens: session?.totalCachedInputTokens,
+      totalOutputTokens: session?.totalOutputTokens,
+      totalReasoningOutputTokens: session?.totalReasoningOutputTokens,
+      totalTokens: session?.totalTokens
+    })
+
+    expect(pick(fromTotals.sessions[0])).toEqual(pick(fromMessages.sessions[0]))
+    expect(fromTotals.sessions[0]?.totalTokens).toBe(total)
   })
 
   it('reports the session ids the database counted', async () => {
@@ -374,7 +508,7 @@ describe('parseOpenCodeUsageDatabase', () => {
 
     const parsed = await parseOpenCodeUsageDatabase(path, worktrees())
 
-    expect(parsed.sessions[0]?.totalTokens).toBe(120)
+    expect(parsed.sessions[0]?.totalTokens).toBe(130)
     expect(parsed.sessions[0]?.eventCount).toBe(1)
   })
 })

--- a/src/main/opencode-usage/store.test.ts
+++ b/src/main/opencode-usage/store.test.ts
@@ -36,7 +36,7 @@ function createEmptyScanResult() {
 
 function getDefaultState(): OpenCodeUsagePersistedState {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     worktreeFingerprint: null,
     processedDatabases: [],
     sessions: [],

--- a/src/renderer/src/components/stats/CodexUsageDailyChart.tsx
+++ b/src/renderer/src/components/stats/CodexUsageDailyChart.tsx
@@ -48,7 +48,9 @@ export function CodexUsageDailyChart({ daily }: CodexUsageDailyChartProps): Reac
             {
               key: 'input',
               label: translate('auto.components.stats.CodexUsageDailyChart.99a91d3143', 'Input'),
-              value: entry.inputTokens,
+              // Why: inputTokens already includes cachedInputTokens for Codex and
+              // OpenCode; the segments must partition the day, not overlap.
+              value: Math.max(entry.inputTokens - entry.cachedInputTokens, 0),
               className: 'bg-sky-500/80'
             },
             {


### PR DESCRIPTION
## ELI5

Orca was adding up OpenCode usage but leaving out the biggest line item. OpenCode reports cache hits separately from "input", and its `total` already includes them; Orca's scanner assumed the opposite, so for anyone using prompt caching (everyone, in practice) 97% of OpenCode tokens vanished. On my machine Orca showed 350M OpenCode tokens where the database holds 24.7B, and OpenCode-only days looked empty on the Stats heatmap.

## What Changed

Two places in `src/main/opencode-usage/` read `opencode.db` with the wrong token model; both now follow OpenCode's own semantics (`tokens.input` is uncached input; `tokens.total = input + output + reasoning + cache.read + cache.write`).

- `selectSessionUsageRows` (the fast path used whenever `session.tokens_*` columns exist) synthesized `total` from `input + output + reasoning` and hard-coded `cache.write: 0`. It now mirrors OpenCode's message `tokens` shape, reading `tokens_cache_write` when the column exists and treating it as 0 otherwise, so materialized rows parse exactly like per-message rows.
- `parseOpenCodeUsageRow` clamped `cachedInputTokens = min(cache.read, input)`, which is ≈ `input` on real data (`input: 638`, `cache.read: 642944`). It now counts `cache.read + cache.write` as cached input and includes them in `inputTokens`, matching Orca's contract where `newInput = inputTokens - cachedInputTokens` (same shape `createCodexProvider` relies on).
- Both session-eligibility predicates (`getSessionUsageRowCount` and the `WHERE` in `selectSessionUsageRows`) now include `tokens_cache_write`, so a session whose only usage is cache writes is no longer skipped (CodeRabbit finding).
- `OPENCODE_USAGE_SCHEMA_VERSION` 2 → 3 so existing `orca-opencode-usage.json` snapshots are rebuilt instead of keeping the under-counted numbers.

Tests: fixtures updated to real OpenCode token shapes, plus three new cases: a session table without `tokens_cache_write` still counts cache reads, a cache-write-only session is counted, and materialized session totals produce the same numbers as the per-message rows they summarize. JSDoc added to the touched readers.

## Why

Verified against a 5.4 GB production `opencode.db` (99,153 assistant messages): zero rows where `tokens.total` differs from `input + output + reasoning + cache.read + cache.write`, and `input` is clearly uncached-only (rows with `input: 2`, `cache.read: 456941`). Orca's recorded per-day numbers equal `SUM(tokens_input + tokens_output + tokens_reasoning)` from the `session` table exactly, which pins the dropped columns as the cause.

Fixing the parser rather than only the session synthesis keeps both read paths (materialized totals, `session_message`, legacy `message`) consistent, and makes "New input" and "Cache" in the overview mean the same thing for OpenCode as they do for Claude and Codex.

## Linked Issue

Fixes #20186

## Visual Proof

The change is numeric; the same Stats & Usage page renders with corrected figures. Before/after from the machine in #20186 (Orca 1.4.197):

| | Before | After |
|---|---|---|
| All-time OpenCode tokens | 350,043,216 | 24,686,009,276 |
| 2026-08-13 | 7,303,115 | 1,261,349,924 |
| 2026-08-10 | 22,171,623 | 644,128,839 |
| 2026-08-22 | 1,180,128 | 11,093,344 |

"After" values are the sums the fixed query now produces from that database; the daily-intensity cells for those days move from empty to lit once the snapshot rebuilds.

## Testing

- `pnpm test src/main/opencode-usage/` — 4 files, 27 tests pass
- `tsc --noEmit -p tsconfig.node.json` — clean
- `oxlint src/main/opencode-usage/` — clean
- Verified the before/after sums above with sqlite against a real `opencode.db` on macOS (Apple Silicon). Not tested on Linux / Windows / SSH; the change is pure SQL + arithmetic with no platform-specific code.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Fable 5.1 (via Claude Code) investigated the discrepancy, wrote the fix and tests, and drafted this description; I reviewed the diff and the database evidence.

## Review

Small, contained to `src/main/opencode-usage/`. The one behavioural consequence beyond the numbers: the schema bump forces a one-time full rescan of every `opencode.db` on next launch.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security, cross-platform, SSH, or mobile surface; read-only SQLite queries only. Backwards compatible with older OpenCode databases (missing `tokens_cache_write` column, `session_message`, and legacy `message` shapes are all covered by tests).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

