### PR TITLE
feat(editor): give the file editor its own font weight and line height

### DIFF
--- a/src/renderer/src/components/automations/AutomationEditorPromptEditor.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorPromptEditor.tsx
@@ -4,7 +4,11 @@ import type { editor } from 'monaco-editor'
 import { installMonacoEditorFindShortcut } from '@/components/editor/editor-shortcuts'
 import { syncContentOnMount, syncContentUpdate } from '@/components/editor/monaco-content-sync'
 import { isMonacoFindWidgetOpen } from '@/components/editor/monaco-find-widget'
-import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
+import {
+  computeEditorFontSize,
+  resolveEditorFontFamily,
+  resolveEditorFontWeight
+} from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
 import '@/lib/monaco-setup'
 import { useAppStore } from '@/store'
@@ -74,6 +78,7 @@ export function AutomationEditorPromptEditor({
 
   const fontSize = computeEditorFontSize(settings?.terminalFontSize ?? 13, editorFontZoomLevel)
   const fontFamily = resolveEditorFontFamily(settings)
+  const fontWeight = resolveEditorFontWeight(settings)
   const isDark = resolveDocumentTheme(settings?.theme ?? 'system')
   const options = useMemo(
     () =>
@@ -81,9 +86,10 @@ export function AutomationEditorPromptEditor({
         ariaLabel,
         fontFamily,
         fontSize,
+        fontWeight,
         placeholder
       }),
-    [ariaLabel, fontFamily, fontSize, placeholder]
+    [ariaLabel, fontFamily, fontSize, fontWeight, placeholder]
   )
 
   const handleChange = useCallback(

--- a/src/renderer/src/components/automations/automation-editor-prompt-options.test.ts
+++ b/src/renderer/src/components/automations/automation-editor-prompt-options.test.ts
@@ -8,6 +8,7 @@ describe('buildAutomationPromptEditorOptions', () => {
       ariaLabel: 'Prompt',
       fontFamily: 'Geist',
       fontSize: 14,
+      fontWeight: '500',
       placeholder: 'Run the weekly dependency audit'
     })
 

--- a/src/renderer/src/components/automations/automation-editor-prompt-options.ts
+++ b/src/renderer/src/components/automations/automation-editor-prompt-options.ts
@@ -5,6 +5,7 @@ export function buildAutomationPromptEditorOptions(args: {
   ariaLabel: string
   fontFamily: string
   fontSize: number
+  fontWeight: string
   placeholder: string
 }): editor.IStandaloneEditorConstructionOptions {
   return {
@@ -14,6 +15,7 @@ export function buildAutomationPromptEditorOptions(args: {
     folding: false,
     fontFamily: args.fontFamily,
     fontSize: args.fontSize,
+    fontWeight: args.fontWeight,
     find: monacoFindOptions,
     glyphMargin: false,
     hover: { enabled: false },

--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -43,6 +43,7 @@ type DiffSectionBodyProps = {
   diffWordWrap?: boolean
   diffShowWhitespace?: boolean
   editorFontFamily?: string
+  editorFontWeight?: string
   onCancelComment: () => void
   onSubmitComment: (body: string) => Promise<void>
   onRetrySection: (index: number) => void
@@ -70,6 +71,7 @@ export function DiffSectionBody({
   diffWordWrap,
   diffShowWhitespace,
   editorFontFamily,
+  editorFontWeight,
   onCancelComment,
   onSubmitComment,
   onRetrySection,
@@ -211,6 +213,7 @@ export function DiffSectionBody({
             scrollBeyondLastLine: false,
             fontSize: diffEditorFontSize,
             fontFamily: editorFontFamily || 'monospace',
+            fontWeight: editorFontWeight,
             lineNumbers: 'on',
             ...buildDiffEditorWordWrapOptions(diffWordWrap),
             ...buildDiffEditorWhitespaceOptions(diffShowWhitespace),

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -4,7 +4,11 @@ import type { editor as monacoEditor } from 'monaco-editor'
 import { monaco } from '@/lib/monaco-setup'
 import { detectLanguage } from '@/lib/language-detect'
 import { useAppStore } from '@/store'
-import { computeDiffEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
+import {
+  computeDiffEditorFontSize,
+  resolveEditorFontFamily,
+  resolveEditorFontWeight
+} from '@/lib/editor-font-zoom'
 import { selectWorktreeDiffComments } from '@/store/worktree-diff-comments-selector'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import {
@@ -375,6 +379,7 @@ export function DiffSectionItem({
           diffWordWrap={settings?.diffWordWrap}
           diffShowWhitespace={settings?.diffShowWhitespace}
           editorFontFamily={resolveEditorFontFamily(settings)}
+          editorFontWeight={resolveEditorFontWeight(settings)}
           onCancelComment={() => setPopover(null)}
           onSubmitComment={handleSubmitComment}
           onRetrySection={retrySection}

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -4,7 +4,7 @@ import type { editor } from 'monaco-editor'
 import { useAppStore } from '@/store'
 import { diffViewStateCache, setWithLRU } from '@/lib/scroll-cache'
 import { monaco } from '@/lib/monaco-setup'
-import { computeDiffEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
+import { computeDiffEditorFontSize, resolveEditorFontOptions } from '@/lib/editor-font-zoom'
 import { useContextualCopySetup } from './useContextualCopySetup'
 import { selectWorktreeDiffComments } from '@/store/worktree-diff-comments-selector'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
@@ -424,7 +424,7 @@ export default function DiffViewer({
               minimap: { enabled: false },
               scrollBeyondLastLine: false,
               fontSize: diffEditorFontSize,
-              fontFamily: resolveEditorFontFamily(settings),
+              ...resolveEditorFontOptions(settings),
               lineNumbers: 'on',
               ...buildDiffEditorWordWrapOptions(settings?.diffWordWrap),
               ...buildDiffEditorWhitespaceOptions(settings?.diffShowWhitespace),

--- a/src/renderer/src/components/editor/IpynbCellEditor.tsx
+++ b/src/renderer/src/components/editor/IpynbCellEditor.tsx
@@ -5,7 +5,7 @@ import rehypeRaw from 'rehype-raw'
 import rehypeSanitize from 'rehype-sanitize'
 import remarkGfm from 'remark-gfm'
 import { monaco } from '@/lib/monaco-setup'
-import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
+import { computeEditorFontSize, resolveEditorFontOptions } from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
 import { useAppStore } from '@/store'
 import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
@@ -130,7 +130,7 @@ function IpynbCodeCellEditor({
         onChange={(value) => onChange(value ?? '')}
         options={{
           automaticLayout: true,
-          fontFamily: resolveEditorFontFamily(settings),
+          ...resolveEditorFontOptions(settings),
           fontSize,
           glyphMargin: false,
           lineNumbersMinChars: 3,

--- a/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
+++ b/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { monaco } from '@/lib/monaco-setup'
-import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
+import {
+  computeEditorFontSize,
+  resolveEditorFontFamily,
+  resolveEditorFontWeight
+} from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -52,6 +56,7 @@ export default function MonacoCodeExcerpt({
     editorFontZoomLevel
   )
   const fontFamily = resolveEditorFontFamily(settings)
+  const fontWeight = resolveEditorFontWeight(settings)
   const isDark = resolveDocumentTheme(settings?.theme ?? 'system')
   const code = useMemo(() => lines.join('\n'), [lines])
   const [htmlLines, setHtmlLines] = useState<string[]>(() => lines.map(() => ''))
@@ -89,7 +94,7 @@ export default function MonacoCodeExcerpt({
   return (
     <div
       className="overflow-x-auto py-1 text-[12px] leading-5"
-      style={{ fontFamily, fontSize: editorFontSize }}
+      style={{ fontFamily, fontWeight, fontSize: editorFontSize }}
     >
       {lines.map((codeLine, index) => {
         const lineNumber = firstLineNumber + index

--- a/src/renderer/src/components/editor/MonacoEditor.font-weight.test.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.font-weight.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const editorProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
+const storeState = vi.hoisted(() => ({
+  current: {
+    theme: 'dark',
+    terminalFontSize: 13,
+    terminalFontWeight: 500,
+    editorFontWeight: 0
+  } as Record<string, unknown>
+}))
+
+vi.mock('@monaco-editor/react', () => ({
+  default: (props: Record<string, unknown>) => {
+    editorProps.current = props
+    return null
+  },
+  loader: { config: vi.fn() }
+}))
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      settings: storeState.current,
+      editorFontZoomLevel: 0,
+      setPendingEditorReveal: vi.fn(),
+      setEditorCursorLine: vi.fn(),
+      addDiffComment: vi.fn(),
+      deleteDiffComment: vi.fn(),
+      updateDiffComment: vi.fn(),
+      scrollToDiffCommentId: null,
+      setScrollToDiffCommentId: vi.fn(),
+      worktreeDiffComments: {}
+    })
+}))
+vi.mock('../diff-comments/useDiffCommentDecorator', () => ({
+  useDiffCommentDecorator: vi.fn()
+}))
+vi.mock('./useContextualCopySetup', () => ({
+  useContextualCopySetup: () => ({ setupCopy: vi.fn(), toastNode: null })
+}))
+
+import MonacoEditor from './MonacoEditor'
+
+function renderEditor(): void {
+  render(
+    <MonacoEditor
+      fileId="file"
+      filePath="/repo/file.ts"
+      viewStateKey="pane:file"
+      relativePath="file.ts"
+      content="const answer = 42"
+      language="typescript"
+      onContentChange={vi.fn()}
+      onSave={vi.fn()}
+      readOnly
+    />
+  )
+}
+
+function renderedFontWeight(): unknown {
+  const options = editorProps.current?.options as Record<string, unknown> | undefined
+  return options?.fontWeight
+}
+
+afterEach(() => {
+  cleanup()
+  editorProps.current = null
+})
+
+describe('MonacoEditor font weight', () => {
+  it('follows the terminal weight when no editor weight override is set', () => {
+    storeState.current = {
+      theme: 'dark',
+      terminalFontSize: 13,
+      terminalFontWeight: 600,
+      editorFontWeight: 0
+    }
+    renderEditor()
+    expect(renderedFontWeight()).toBe('600')
+  })
+
+  it('uses the opt-in editor weight override instead of the terminal weight', () => {
+    storeState.current = {
+      theme: 'dark',
+      terminalFontSize: 13,
+      terminalFontWeight: 600,
+      editorFontWeight: 300
+    }
+    renderEditor()
+    expect(renderedFontWeight()).toBe('300')
+  })
+})

--- a/src/renderer/src/components/editor/MonacoEditor.line-height.test.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.line-height.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const editorProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
+const storeState = vi.hoisted(() => ({
+  current: { theme: 'dark', terminalFontSize: 13, editorLineHeight: 0 } as Record<string, unknown>
+}))
+
+vi.mock('@monaco-editor/react', () => ({
+  default: (props: Record<string, unknown>) => {
+    editorProps.current = props
+    return null
+  },
+  loader: { config: vi.fn() }
+}))
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      settings: storeState.current,
+      editorFontZoomLevel: 0,
+      setPendingEditorReveal: vi.fn(),
+      setEditorCursorLine: vi.fn(),
+      addDiffComment: vi.fn(),
+      deleteDiffComment: vi.fn(),
+      updateDiffComment: vi.fn(),
+      scrollToDiffCommentId: null,
+      setScrollToDiffCommentId: vi.fn(),
+      worktreeDiffComments: {}
+    })
+}))
+vi.mock('../diff-comments/useDiffCommentDecorator', () => ({
+  useDiffCommentDecorator: vi.fn()
+}))
+vi.mock('./useContextualCopySetup', () => ({
+  useContextualCopySetup: () => ({ setupCopy: vi.fn(), toastNode: null })
+}))
+
+import MonacoEditor from './MonacoEditor'
+
+function renderEditor(): void {
+  render(
+    <MonacoEditor
+      fileId="file"
+      filePath="/repo/file.ts"
+      viewStateKey="pane:file"
+      relativePath="file.ts"
+      content="const answer = 42"
+      language="typescript"
+      onContentChange={vi.fn()}
+      onSave={vi.fn()}
+      readOnly
+    />
+  )
+}
+
+function renderedLineHeight(): unknown {
+  const options = editorProps.current?.options as Record<string, unknown> | undefined
+  return options?.lineHeight
+}
+
+afterEach(() => {
+  cleanup()
+  editorProps.current = null
+})
+
+describe('MonacoEditor line height', () => {
+  // Monaco reads 0 as "compute the line height from the font size", so an untouched
+  // profile must keep exactly the spacing it had before this setting existed.
+  it('leaves Monaco automatic spacing when the setting is untouched', () => {
+    storeState.current = { theme: 'dark', terminalFontSize: 13, editorLineHeight: 0 }
+    renderEditor()
+    expect(renderedLineHeight()).toBe(0)
+  })
+
+  it('passes the opted-in multiplier through to Monaco', () => {
+    storeState.current = { theme: 'dark', terminalFontSize: 13, editorLineHeight: 1.2 }
+    renderEditor()
+    expect(renderedLineHeight()).toBe(1.2)
+  })
+})

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -5,7 +5,11 @@ import type { editor } from 'monaco-editor'
 import type { MarkdownDocument } from '../../../../shared/filesystem-entry-types'
 import { useAppStore } from '@/store'
 import '@/lib/monaco-setup'
-import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
+import {
+  computeEditorFontSize,
+  resolveEditorFontFamily,
+  resolveEditorFontWeight
+} from '@/lib/editor-font-zoom'
 
 import { useContextualCopySetup } from './useContextualCopySetup'
 import { MonacoGutterContextMenu } from './MonacoGutterContextMenu'
@@ -94,6 +98,7 @@ export default function MonacoEditor({
     editorFontZoomLevel
   )
   const editorFontFamily = resolveEditorFontFamily(settings)
+  const editorFontWeight = resolveEditorFontWeight(settings)
   const editorWordWrap = settings?.editorWordWrap
   const estimatedAutoHeight = useMemo(() => {
     if (!autoHeight) {
@@ -163,9 +168,10 @@ export default function MonacoEditor({
     editorRef.current.updateOptions({
       fontSize: editorFontSize,
       fontFamily: editorFontFamily,
+      fontWeight: editorFontWeight,
       ...buildFileEditorWordWrapOptions(editorWordWrap)
     })
-  }, [editorFontFamily, editorFontSize, editorWordWrap])
+  }, [editorFontFamily, editorFontWeight, editorFontSize, editorWordWrap])
 
   const decorations = useMonacoEditorDecorations({
     editorRef,
@@ -247,6 +253,7 @@ export default function MonacoEditor({
           ...buildFileEditorWordWrapOptions(editorWordWrap),
           fontSize: editorFontSize,
           fontFamily: editorFontFamily,
+          fontWeight: editorFontWeight,
           lineNumbers: 'on',
           renderLineHighlight: 'line',
           automaticLayout: true,

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -8,7 +8,8 @@ import '@/lib/monaco-setup'
 import {
   computeEditorFontSize,
   resolveEditorFontFamily,
-  resolveEditorFontWeight
+  resolveEditorFontWeight,
+  resolveEditorLineHeight
 } from '@/lib/editor-font-zoom'
 
 import { useContextualCopySetup } from './useContextualCopySetup'
@@ -99,6 +100,7 @@ export default function MonacoEditor({
   )
   const editorFontFamily = resolveEditorFontFamily(settings)
   const editorFontWeight = resolveEditorFontWeight(settings)
+  const editorLineHeight = resolveEditorLineHeight(settings)
   const editorWordWrap = settings?.editorWordWrap
   const estimatedAutoHeight = useMemo(() => {
     if (!autoHeight) {
@@ -169,9 +171,10 @@ export default function MonacoEditor({
       fontSize: editorFontSize,
       fontFamily: editorFontFamily,
       fontWeight: editorFontWeight,
+      lineHeight: editorLineHeight,
       ...buildFileEditorWordWrapOptions(editorWordWrap)
     })
-  }, [editorFontFamily, editorFontWeight, editorFontSize, editorWordWrap])
+  }, [editorFontFamily, editorFontWeight, editorLineHeight, editorFontSize, editorWordWrap])
 
   const decorations = useMonacoEditorDecorations({
     editorRef,
@@ -254,6 +257,7 @@ export default function MonacoEditor({
           fontSize: editorFontSize,
           fontFamily: editorFontFamily,
           fontWeight: editorFontWeight,
+          lineHeight: editorLineHeight,
           lineNumbers: 'on',
           renderLineHighlight: 'line',
           automaticLayout: true,

--- a/src/renderer/src/components/editor/diff-section-item-props.ts
+++ b/src/renderer/src/components/editor/diff-section-item-props.ts
@@ -12,6 +12,8 @@ export type DiffSectionItemProps = {
   settings: {
     terminalFontSize?: number
     terminalFontFamily?: string
+    terminalFontWeight?: number
+    editorFontWeight?: number
     diffWordWrap?: boolean
     diffShowWhitespace?: boolean
   } | null

--- a/src/renderer/src/components/settings/EditorFontWeightSetting.test.tsx
+++ b/src/renderer/src/components/settings/EditorFontWeightSetting.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { EditorFontWeightSetting } from './EditorFontWeightSetting'
+
+afterEach(cleanup)
+
+function renderSetting(
+  editorFontWeight: number | undefined,
+  updateSettings = vi.fn()
+): { updateSettings: ReturnType<typeof vi.fn>; input: HTMLInputElement } {
+  render(
+    <EditorFontWeightSetting
+      settings={{ terminalFontWeight: 500, editorFontWeight } as unknown as GlobalSettings}
+      updateSettings={updateSettings}
+    />
+  )
+  return {
+    updateSettings,
+    input: screen.getByLabelText('Editor Font Weight') as HTMLInputElement
+  }
+}
+
+describe('EditorFontWeightSetting', () => {
+  // Why this renders rather than asserting on a resolver: the unset state reaches
+  // NumberField as a prop, and an "empty" sentinel it compares with !== (NaN) sets
+  // state on every render and trips React's re-render limit. Only a render catches it.
+  it('renders the inheriting state as an empty field without re-rendering forever', () => {
+    const { input } = renderSetting(0)
+    expect(input.value).toBe('')
+    expect(input.getAttribute('placeholder')).toBe('Same as terminal font weight')
+  })
+
+  it('shows the pinned weight when the editor opts out of the terminal weight', () => {
+    const { input } = renderSetting(350)
+    expect(input.value).toBe('350')
+  })
+
+  it('clamps a committed weight into the supported band', () => {
+    const { updateSettings, input } = renderSetting(undefined)
+    fireEvent.change(input, { target: { value: '5000' } })
+    fireEvent.blur(input)
+    expect(updateSettings).toHaveBeenCalledWith({ editorFontWeight: 900 })
+  })
+
+  it('goes back to inheriting when the field is emptied', () => {
+    const { updateSettings, input } = renderSetting(350)
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+    expect(updateSettings).toHaveBeenCalledWith({ editorFontWeight: 0 })
+  })
+})

--- a/src/renderer/src/components/settings/EditorFontWeightSetting.test.tsx
+++ b/src/renderer/src/components/settings/EditorFontWeightSetting.test.tsx
@@ -29,7 +29,8 @@ describe('EditorFontWeightSetting', () => {
   it('renders the inheriting state as an empty field without re-rendering forever', () => {
     const { input } = renderSetting(0)
     expect(input.value).toBe('')
-    expect(input.getAttribute('placeholder')).toBe('Same as terminal font weight')
+    // The placeholder is the live terminal weight, so the empty row still shows what it inherits.
+    expect(input.getAttribute('placeholder')).toBe('500')
   })
 
   it('shows the pinned weight when the editor opts out of the terminal weight', () => {

--- a/src/renderer/src/components/settings/EditorFontWeightSetting.tsx
+++ b/src/renderer/src/components/settings/EditorFontWeightSetting.tsx
@@ -29,10 +29,9 @@ export function EditorFontWeightSetting({
       ? normalizeTerminalFontWeight(editorFontWeight)
       : undefined
 
-  // Why the terminal weight as the shown default: this setting has no fixed default
-  // of its own — leaving it empty inherits whatever the terminal is on — so surfacing
-  // the live inherited number reads like the terminal's own weight field instead of
-  // leaving the user to guess what "same as terminal" currently resolves to.
+  // Why the terminal weight is the placeholder: this setting has no fixed default of
+  // its own — leaving it empty inherits whatever the terminal is on — so the greyed
+  // number shows what the editor resolves to today without claiming to be a default.
   const inheritedWeight = normalizeTerminalFontWeight(settings.terminalFontWeight)
 
   return (
@@ -57,16 +56,12 @@ export function EditorFontWeightSetting({
           'Weight used by file editors and diff views. Leave empty to follow the terminal font weight.'
         )}
         value={value}
-        defaultValue={inheritedWeight}
         min={TERMINAL_FONT_WEIGHT_MIN}
         max={TERMINAL_FONT_WEIGHT_MAX}
         step={TERMINAL_FONT_WEIGHT_STEP}
         integer
         suffix="100-900"
-        placeholder={translate(
-          'auto.components.settings.EditorFontWeightSetting.placeholder',
-          'Same as terminal font weight'
-        )}
+        placeholder={String(inheritedWeight)}
         onChange={(next) => updateSettings({ editorFontWeight: normalizeTerminalFontWeight(next) })}
         onClear={() => updateSettings({ editorFontWeight: 0 })}
       />

--- a/src/renderer/src/components/settings/EditorFontWeightSetting.tsx
+++ b/src/renderer/src/components/settings/EditorFontWeightSetting.tsx
@@ -1,0 +1,68 @@
+import type React from 'react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import {
+  TERMINAL_FONT_WEIGHT_MAX,
+  TERMINAL_FONT_WEIGHT_MIN,
+  TERMINAL_FONT_WEIGHT_STEP,
+  normalizeTerminalFontWeight
+} from '../../../../shared/terminal-fonts'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { NumberField } from './SettingsFormControls'
+
+type EditorFontWeightSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function EditorFontWeightSetting({
+  settings,
+  updateSettings
+}: EditorFontWeightSettingProps): React.JSX.Element {
+  const editorFontWeight = settings.editorFontWeight
+
+  // Why NaN when unset: NumberField renders an empty input — and therefore the
+  // "same as terminal" placeholder — for a non-finite value, which is what tells
+  // the user the editor is still inheriting rather than pinned to its own weight.
+  const value =
+    typeof editorFontWeight === 'number' && editorFontWeight > 0
+      ? normalizeTerminalFontWeight(editorFontWeight)
+      : Number.NaN
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.EditorFontWeightSetting.title',
+        'Editor Font Weight'
+      )}
+      description={translate(
+        'auto.components.settings.EditorFontWeightSetting.description',
+        'Weight used by file editors and diff views. Leave empty to follow the terminal font weight.'
+      )}
+      keywords={['editor', 'font', 'typography', 'weight', 'code', 'bold', 'thin']}
+    >
+      <NumberField
+        label={translate(
+          'auto.components.settings.EditorFontWeightSetting.title',
+          'Editor Font Weight'
+        )}
+        description={translate(
+          'auto.components.settings.EditorFontWeightSetting.description',
+          'Weight used by file editors and diff views. Leave empty to follow the terminal font weight.'
+        )}
+        value={value}
+        min={TERMINAL_FONT_WEIGHT_MIN}
+        max={TERMINAL_FONT_WEIGHT_MAX}
+        step={TERMINAL_FONT_WEIGHT_STEP}
+        integer
+        suffix="100-900"
+        placeholder={translate(
+          'auto.components.settings.EditorFontWeightSetting.placeholder',
+          'Same as terminal font weight'
+        )}
+        onChange={(next) => updateSettings({ editorFontWeight: normalizeTerminalFontWeight(next) })}
+        onClear={() => updateSettings({ editorFontWeight: 0 })}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/EditorFontWeightSetting.tsx
+++ b/src/renderer/src/components/settings/EditorFontWeightSetting.tsx
@@ -21,13 +21,19 @@ export function EditorFontWeightSetting({
 }: EditorFontWeightSettingProps): React.JSX.Element {
   const editorFontWeight = settings.editorFontWeight
 
-  // Why NaN when unset: NumberField renders an empty input — and therefore the
-  // "same as terminal" placeholder — for a non-finite value, which is what tells
-  // the user the editor is still inheriting rather than pinned to its own weight.
+  // Why undefined when unset: NumberField documents undefined as the empty state
+  // that pairs with `placeholder` and `onClear`, which is what shows the user the
+  // editor is still inheriting rather than pinned to its own weight.
   const value =
     typeof editorFontWeight === 'number' && editorFontWeight > 0
       ? normalizeTerminalFontWeight(editorFontWeight)
-      : Number.NaN
+      : undefined
+
+  // Why the terminal weight as the shown default: this setting has no fixed default
+  // of its own — leaving it empty inherits whatever the terminal is on — so surfacing
+  // the live inherited number reads like the terminal's own weight field instead of
+  // leaving the user to guess what "same as terminal" currently resolves to.
+  const inheritedWeight = normalizeTerminalFontWeight(settings.terminalFontWeight)
 
   return (
     <SearchableSetting
@@ -51,6 +57,7 @@ export function EditorFontWeightSetting({
           'Weight used by file editors and diff views. Leave empty to follow the terminal font weight.'
         )}
         value={value}
+        defaultValue={inheritedWeight}
         min={TERMINAL_FONT_WEIGHT_MIN}
         max={TERMINAL_FONT_WEIGHT_MAX}
         step={TERMINAL_FONT_WEIGHT_STEP}

--- a/src/renderer/src/components/settings/EditorLineHeightSetting.test.tsx
+++ b/src/renderer/src/components/settings/EditorLineHeightSetting.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+
+// Why pin the platform: Monaco's automatic ratio is 1.5 on macOS and 1.35 elsewhere,
+// and that number is what the empty row shows, so the assertion needs a fixed host.
+vi.mock('@/lib/renderer-app-platform', () => ({
+  getRendererAppPlatform: () => 'darwin',
+  resetRendererAppPlatformCacheForTests: vi.fn()
+}))
+
+import { EditorLineHeightSetting } from './EditorLineHeightSetting'
+
+afterEach(cleanup)
+
+function renderSetting(
+  editorLineHeight: number | undefined,
+  updateSettings = vi.fn()
+): { updateSettings: ReturnType<typeof vi.fn>; input: HTMLInputElement } {
+  render(
+    <EditorLineHeightSetting
+      settings={{ editorLineHeight } as unknown as GlobalSettings}
+      updateSettings={updateSettings}
+    />
+  )
+  return {
+    updateSettings,
+    input: screen.getByLabelText('Editor Line Height') as HTMLInputElement
+  }
+}
+
+describe('EditorLineHeightSetting', () => {
+  it('shows Monaco automatic spacing as an empty field with its resolved ratio', () => {
+    const { input } = renderSetting(0)
+    expect(input.value).toBe('')
+    expect(input.getAttribute('placeholder')).toBe('1.5')
+  })
+
+  it('shows the pinned multiplier once the user opts in', () => {
+    const { input } = renderSetting(1.2)
+    expect(input.value).toBe('1.2')
+  })
+
+  it('clamps a committed multiplier into the supported band', () => {
+    const { updateSettings, input } = renderSetting(undefined)
+    fireEvent.change(input, { target: { value: '9' } })
+    fireEvent.blur(input)
+    expect(updateSettings).toHaveBeenCalledWith({ editorLineHeight: 3 })
+  })
+
+  it('returns to automatic spacing when the field is emptied', () => {
+    const { updateSettings, input } = renderSetting(1.2)
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+    expect(updateSettings).toHaveBeenCalledWith({ editorLineHeight: 0 })
+  })
+})

--- a/src/renderer/src/components/settings/EditorLineHeightSetting.tsx
+++ b/src/renderer/src/components/settings/EditorLineHeightSetting.tsx
@@ -1,0 +1,67 @@
+import type React from 'react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import {
+  EDITOR_LINE_HEIGHT_AUTO,
+  EDITOR_LINE_HEIGHT_MAX,
+  EDITOR_LINE_HEIGHT_MIN,
+  EDITOR_LINE_HEIGHT_STEP,
+  monacoAutomaticLineHeightRatio,
+  normalizeEditorLineHeight
+} from '@/lib/editor-font-zoom'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { NumberField } from './SettingsFormControls'
+
+type EditorLineHeightSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function EditorLineHeightSetting({
+  settings,
+  updateSettings
+}: EditorLineHeightSettingProps): React.JSX.Element {
+  const lineHeight = normalizeEditorLineHeight(settings.editorLineHeight)
+
+  // Why undefined when automatic: NumberField documents undefined as the empty state
+  // that pairs with `placeholder` and `onClear`, and an empty row is what tells the
+  // user Monaco is still picking the spacing rather than this setting.
+  const value = lineHeight === EDITOR_LINE_HEIGHT_AUTO ? undefined : lineHeight
+
+  // Why show Monaco's own ratio: "automatic" is 1.5 on macOS and 1.35 elsewhere, so
+  // the greyed number is the only way to know what the editor is spacing at today.
+  const automaticRatio = monacoAutomaticLineHeightRatio()
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.EditorLineHeightSetting.title',
+        'Editor Line Height'
+      )}
+      description={translate(
+        'auto.components.settings.EditorLineHeightSetting.description',
+        'Line spacing in file editors, as a multiple of the font size. Leave empty to keep the editor default.'
+      )}
+      keywords={['editor', 'line height', 'spacing', 'typography', 'code', 'leading']}
+    >
+      <NumberField
+        label={translate(
+          'auto.components.settings.EditorLineHeightSetting.title',
+          'Editor Line Height'
+        )}
+        description={translate(
+          'auto.components.settings.EditorLineHeightSetting.description',
+          'Line spacing in file editors, as a multiple of the font size. Leave empty to keep the editor default.'
+        )}
+        value={value}
+        min={EDITOR_LINE_HEIGHT_MIN}
+        max={EDITOR_LINE_HEIGHT_MAX}
+        step={EDITOR_LINE_HEIGHT_STEP}
+        suffix="1-3"
+        placeholder={String(automaticRatio)}
+        onChange={(next) => updateSettings({ editorLineHeight: normalizeEditorLineHeight(next) })}
+        onClear={() => updateSettings({ editorLineHeight: EDITOR_LINE_HEIGHT_AUTO })}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -21,6 +21,7 @@ import { DiffShowWhitespaceSetting } from './DiffShowWhitespaceSetting'
 import { EditorWordWrapSetting } from './EditorWordWrapSetting'
 import { EditorFontFamilySetting } from './EditorFontFamilySetting'
 import { EditorFontWeightSetting } from './EditorFontWeightSetting'
+import { EditorLineHeightSetting } from './EditorLineHeightSetting'
 import {
   createAutoSaveDelayDraftState,
   resolveAutoSaveDelayDraftState,
@@ -233,6 +234,8 @@ export function GeneralEditorSettingsSection({
       />
 
       <EditorFontWeightSetting settings={settings} updateSettings={updateSettings} />
+
+      <EditorLineHeightSetting settings={settings} updateSettings={updateSettings} />
 
       <EditorWordWrapSetting settings={settings} updateSettings={updateSettings} />
 

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -20,6 +20,7 @@ import { RichMarkdownSpellcheckSetting } from './RichMarkdownSpellcheckSetting'
 import { DiffShowWhitespaceSetting } from './DiffShowWhitespaceSetting'
 import { EditorWordWrapSetting } from './EditorWordWrapSetting'
 import { EditorFontFamilySetting } from './EditorFontFamilySetting'
+import { EditorFontWeightSetting } from './EditorFontWeightSetting'
 import {
   createAutoSaveDelayDraftState,
   resolveAutoSaveDelayDraftState,
@@ -230,6 +231,8 @@ export function GeneralEditorSettingsSection({
         fontSuggestions={fontSuggestions}
         onRequestFontSuggestions={onRequestFontSuggestions}
       />
+
+      <EditorFontWeightSetting settings={settings} updateSettings={updateSettings} />
 
       <EditorWordWrapSetting settings={settings} updateSettings={updateSettings} />
 

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -64,6 +64,24 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate(
+      'auto.components.settings.general.search.editorLineHeight',
+      'Editor Line Height'
+    ),
+    description: translate(
+      'auto.components.settings.general.search.editorLineHeightDesc',
+      'Line spacing in file editors, as a multiple of the font size. Leave empty to keep the editor default.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.e1ee631696', 'editor'),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.editorLineHeightKw',
+        'line height'
+      ),
+      ...translateSearchKeyword('auto.components.settings.general.search.3ca5ab78a5', 'code')
+    ]
+  },
+  {
     title: translate('auto.components.settings.general.search.e61157e926', 'Editor Word Wrap'),
     description: translate(
       'auto.components.settings.general.search.005be5c699',

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -45,6 +45,25 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate(
+      'auto.components.settings.general.search.editorFontWeight',
+      'Editor Font Weight'
+    ),
+    description: translate(
+      'auto.components.settings.general.search.editorFontWeightDesc',
+      'Weight used by file editors and diff views. Leave empty to follow the terminal font weight.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.e1ee631696', 'editor'),
+      ...translateSearchKeyword('auto.components.settings.general.search.editorFontKw', 'font'),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.editorFontWeightKw',
+        'weight'
+      ),
+      ...translateSearchKeyword('auto.components.settings.general.search.3ca5ab78a5', 'code')
+    ]
+  },
+  {
     title: translate('auto.components.settings.general.search.e61157e926', 'Editor Word Wrap'),
     description: translate(
       'auto.components.settings.general.search.005be5c699',

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -4,6 +4,7 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalFontSize: 'Font Size',
   terminalFontFamily: 'Font Family',
   editorFontFamily: 'Editor Font Family',
+  editorFontWeight: 'Editor Font Weight',
   terminalFontWeight: 'Font Weight',
   terminalLineHeight: 'Line Height',
   terminalScrollSensitivity: 'Normal Scroll Speed',

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -5,6 +5,7 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalFontFamily: 'Font Family',
   editorFontFamily: 'Editor Font Family',
   editorFontWeight: 'Editor Font Weight',
+  editorLineHeight: 'Editor Line Height',
   terminalFontWeight: 'Font Weight',
   terminalLineHeight: 'Line Height',
   terminalScrollSensitivity: 'Normal Scroll Speed',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9655,7 +9655,10 @@
             "afa37a34e1": "close",
             "editorFontWeight": "Editor Font Weight",
             "editorFontWeightDesc": "Weight used by file editors and diff views. Leave empty to follow the terminal font weight.",
-            "editorFontWeightKw": "weight"
+            "editorFontWeightKw": "weight",
+            "editorLineHeight": "Editor Line Height",
+            "editorLineHeightDesc": "Line spacing in file editors, as a multiple of the font size. Leave empty to keep the editor default.",
+            "editorLineHeightKw": "line height"
           }
         },
         "git": {
@@ -11167,6 +11170,10 @@
         "EditorFontWeightSetting": {
           "title": "Editor Font Weight",
           "description": "Weight used by file editors and diff views. Leave empty to follow the terminal font weight."
+        },
+        "EditorLineHeightSetting": {
+          "title": "Editor Line Height",
+          "description": "Line spacing in file editors, as a multiple of the font size. Leave empty to keep the editor default."
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11166,8 +11166,7 @@
         },
         "EditorFontWeightSetting": {
           "title": "Editor Font Weight",
-          "description": "Weight used by file editors and diff views. Leave empty to follow the terminal font weight.",
-          "placeholder": "Same as terminal font weight"
+          "description": "Weight used by file editors and diff views. Leave empty to follow the terminal font weight."
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9652,7 +9652,10 @@
             "sidebar": "sidebar",
             "867dddea41": "pinned",
             "5250cf0e48": "pin",
-            "afa37a34e1": "close"
+            "afa37a34e1": "close",
+            "editorFontWeight": "Editor Font Weight",
+            "editorFontWeightDesc": "Weight used by file editors and diff views. Leave empty to follow the terminal font weight.",
+            "editorFontWeightKw": "weight"
           }
         },
         "git": {
@@ -11160,6 +11163,11 @@
           "title": "Editor Font Family",
           "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
           "placeholder": "Same as terminal font"
+        },
+        "EditorFontWeightSetting": {
+          "title": "Editor Font Weight",
+          "description": "Weight used by file editors and diff views. Leave empty to follow the terminal font weight.",
+          "placeholder": "Same as terminal font weight"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8409,7 +8409,9 @@
             "externalWorktrees": "Worktrees externos",
             "externalWorktreesDescription": "Elige si los worktrees creados fuera de Orca aparecen de forma predeterminada.",
             "editorFontWeight": "Peso de fuente del editor",
-            "editorFontWeightDesc": "Peso utilizado por los editores de archivos y vistas de diferencias. Dejar vacío para seguir el peso de fuente de la terminal."
+            "editorFontWeightDesc": "Peso utilizado por los editores de archivos y vistas de diferencias. Dejar vacío para seguir el peso de fuente de la terminal.",
+            "editorLineHeight": "Interlineado del editor",
+            "editorLineHeightDesc": "Espaciado entre líneas en los editores de archivos, como múltiplo del tamaño de fuente. Dejar vacío para mantener el valor predeterminado del editor."
           }
         },
         "git": {
@@ -9866,6 +9868,10 @@
         "EditorFontWeightSetting": {
           "title": "Peso de fuente del editor",
           "description": "Peso utilizado por los editores de archivos y vistas de diferencias. Dejar vacío para seguir el peso de fuente de la terminal."
+        },
+        "EditorLineHeightSetting": {
+          "title": "Interlineado del editor",
+          "description": "Espaciado entre líneas en los editores de archivos, como múltiplo del tamaño de fuente. Dejar vacío para mantener el valor predeterminado del editor."
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -8407,7 +8407,9 @@
             "editorFontFamily": "Fuente del editor",
             "editorFontFamilyDesc": "Fuente utilizada por los editores de archivos y vistas de diferencias. Dejar vacío para seguir la fuente de la terminal.",
             "externalWorktrees": "Worktrees externos",
-            "externalWorktreesDescription": "Elige si los worktrees creados fuera de Orca aparecen de forma predeterminada."
+            "externalWorktreesDescription": "Elige si los worktrees creados fuera de Orca aparecen de forma predeterminada.",
+            "editorFontWeight": "Peso de fuente del editor",
+            "editorFontWeightDesc": "Peso utilizado por los editores de archivos y vistas de diferencias. Dejar vacío para seguir el peso de fuente de la terminal."
           }
         },
         "git": {
@@ -9860,6 +9862,11 @@
           "title": "Fuente del editor",
           "description": "Fuente utilizada por los editores de archivos y vistas de diferencias. Dejar vacío para seguir la fuente de la terminal.",
           "placeholder": "Igual que la fuente de la terminal"
+        },
+        "EditorFontWeightSetting": {
+          "title": "Peso de fuente del editor",
+          "description": "Peso utilizado por los editores de archivos y vistas de diferencias. Dejar vacío para seguir el peso de fuente de la terminal.",
+          "placeholder": "Igual que el peso de la terminal"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9865,8 +9865,7 @@
         },
         "EditorFontWeightSetting": {
           "title": "Peso de fuente del editor",
-          "description": "Peso utilizado por los editores de archivos y vistas de diferencias. Dejar vacío para seguir el peso de fuente de la terminal.",
-          "placeholder": "Igual que el peso de la terminal"
+          "description": "Peso utilizado por los editores de archivos y vistas de diferencias. Dejar vacío para seguir el peso de fuente de la terminal."
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -10698,8 +10698,7 @@
         },
         "EditorFontWeightSetting": {
           "title": "Graisse de la police de l'éditeur",
-          "description": "Graisse utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la graisse de la police du terminal.",
-          "placeholder": "Identique à la graisse du terminal"
+          "description": "Graisse utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la graisse de la police du terminal."
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} serveurs jumelés",

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -9255,7 +9255,9 @@
             "externalWorktrees": "Worktrees externes",
             "externalWorktreesDescription": "Choisissez si les worktrees créés en dehors d'Orca apparaissent par défaut.",
             "editorFontWeight": "Graisse de la police de l'éditeur",
-            "editorFontWeightDesc": "Graisse utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la graisse de la police du terminal."
+            "editorFontWeightDesc": "Graisse utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la graisse de la police du terminal.",
+            "editorLineHeight": "Interligne de l'éditeur",
+            "editorLineHeightDesc": "Espacement des lignes dans les éditeurs de fichiers, en multiple de la taille de police. Laissez vide pour conserver la valeur par défaut de l'éditeur."
           }
         },
         "git": {
@@ -10699,6 +10701,10 @@
         "EditorFontWeightSetting": {
           "title": "Graisse de la police de l'éditeur",
           "description": "Graisse utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la graisse de la police du terminal."
+        },
+        "EditorLineHeightSetting": {
+          "title": "Interligne de l'éditeur",
+          "description": "Espacement des lignes dans les éditeurs de fichiers, en multiple de la taille de police. Laissez vide pour conserver la valeur par défaut de l'éditeur."
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} serveurs jumelés",

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -9253,7 +9253,9 @@
             "editorFontFamily": "Police de l'éditeur",
             "editorFontFamilyDesc": "Police utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la police du terminal.",
             "externalWorktrees": "Worktrees externes",
-            "externalWorktreesDescription": "Choisissez si les worktrees créés en dehors d'Orca apparaissent par défaut."
+            "externalWorktreesDescription": "Choisissez si les worktrees créés en dehors d'Orca apparaissent par défaut.",
+            "editorFontWeight": "Graisse de la police de l'éditeur",
+            "editorFontWeightDesc": "Graisse utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la graisse de la police du terminal."
           }
         },
         "git": {
@@ -10693,6 +10695,11 @@
           "title": "Police de l'éditeur",
           "description": "Police utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la police du terminal.",
           "placeholder": "Identique à la police du terminal"
+        },
+        "EditorFontWeightSetting": {
+          "title": "Graisse de la police de l'éditeur",
+          "description": "Graisse utilisée par les éditeurs de fichiers et les vues de diff. Laissez vide pour suivre la graisse de la police du terminal.",
+          "placeholder": "Identique à la graisse du terminal"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} serveurs jumelés",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9865,8 +9865,7 @@
         },
         "EditorFontWeightSetting": {
           "title": "エディターフォントの太さ",
-          "description": "ファイルエディターと差分ビューで使用されるフォントの太さ。空の場合はターミナルフォントの太さに従います。",
-          "placeholder": "ターミナルフォントの太さと同じ"
+          "description": "ファイルエディターと差分ビューで使用されるフォントの太さ。空の場合はターミナルフォントの太さに従います。"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "ペアリング済みサーバー {{value0}} 台",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8431,7 +8431,9 @@
             "externalWorktrees": "外部ワークツリー",
             "externalWorktreesDescription": "Orca 外で作成されたワークツリーをデフォルトで表示するかどうかを選択します。",
             "editorFontWeight": "エディターフォントの太さ",
-            "editorFontWeightDesc": "ファイルエディターと差分ビューで使用されるフォントの太さ。空の場合はターミナルフォントの太さに従います。"
+            "editorFontWeightDesc": "ファイルエディターと差分ビューで使用されるフォントの太さ。空の場合はターミナルフォントの太さに従います。",
+            "editorLineHeight": "エディターの行の高さ",
+            "editorLineHeightDesc": "ファイルエディターの行間。フォントサイズの倍数で指定します。空の場合はエディターの既定値を使用します。"
           }
         },
         "git": {
@@ -9866,6 +9868,10 @@
         "EditorFontWeightSetting": {
           "title": "エディターフォントの太さ",
           "description": "ファイルエディターと差分ビューで使用されるフォントの太さ。空の場合はターミナルフォントの太さに従います。"
+        },
+        "EditorLineHeightSetting": {
+          "title": "エディターの行の高さ",
+          "description": "ファイルエディターの行間。フォントサイズの倍数で指定します。空の場合はエディターの既定値を使用します。"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "ペアリング済みサーバー {{value0}} 台",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -8429,7 +8429,9 @@
             "editorFontFamily": "エディターフォント",
             "editorFontFamilyDesc": "ファイルエディターと差分ビューで使用されるフォント。空の場合はターミナルフォントに従います。",
             "externalWorktrees": "外部ワークツリー",
-            "externalWorktreesDescription": "Orca 外で作成されたワークツリーをデフォルトで表示するかどうかを選択します。"
+            "externalWorktreesDescription": "Orca 外で作成されたワークツリーをデフォルトで表示するかどうかを選択します。",
+            "editorFontWeight": "エディターフォントの太さ",
+            "editorFontWeightDesc": "ファイルエディターと差分ビューで使用されるフォントの太さ。空の場合はターミナルフォントの太さに従います。"
           }
         },
         "git": {
@@ -9860,6 +9862,11 @@
           "title": "エディターフォント",
           "description": "ファイルエディターと差分ビューで使用されるフォント。空の場合はターミナルフォントに従います。",
           "placeholder": "ターミナルフォントと同じ"
+        },
+        "EditorFontWeightSetting": {
+          "title": "エディターフォントの太さ",
+          "description": "ファイルエディターと差分ビューで使用されるフォントの太さ。空の場合はターミナルフォントの太さに従います。",
+          "placeholder": "ターミナルフォントの太さと同じ"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "ペアリング済みサーバー {{value0}} 台",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8397,7 +8397,9 @@
             "editorFontFamily": "편집기 글꼴",
             "editorFontFamilyDesc": "파일 편집기 및 diff 보기에서 사용되는 글꼴입니다. 비워두면 터미널 글꼴을 따릅니다.",
             "externalWorktrees": "외부 작업 트리",
-            "externalWorktreesDescription": "Orca 외부에서 만든 작업 트리를 기본적으로 표시할지 선택합니다."
+            "externalWorktreesDescription": "Orca 외부에서 만든 작업 트리를 기본적으로 표시할지 선택합니다.",
+            "editorFontWeight": "편집기 글꼴 두께",
+            "editorFontWeightDesc": "파일 편집기 및 diff 보기에서 사용되는 글꼴 두께입니다. 비워두면 터미널 글꼴 두께를 따릅니다."
           }
         },
         "git": {
@@ -9865,6 +9867,11 @@
           "title": "편집기 글꼴",
           "description": "파일 편집기 및 diff 보기에서 사용되는 글꼴입니다. 비워두면 터미널 글꼴을 따릅니다.",
           "placeholder": "터미널 글꼴과 동일"
+        },
+        "EditorFontWeightSetting": {
+          "title": "편집기 글꼴 두께",
+          "description": "파일 편집기 및 diff 보기에서 사용되는 글꼴 두께입니다. 비워두면 터미널 글꼴 두께를 따릅니다.",
+          "placeholder": "터미널 글꼴 두께와 동일"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9870,8 +9870,7 @@
         },
         "EditorFontWeightSetting": {
           "title": "편집기 글꼴 두께",
-          "description": "파일 편집기 및 diff 보기에서 사용되는 글꼴 두께입니다. 비워두면 터미널 글꼴 두께를 따릅니다.",
-          "placeholder": "터미널 글꼴 두께와 동일"
+          "description": "파일 편집기 및 diff 보기에서 사용되는 글꼴 두께입니다. 비워두면 터미널 글꼴 두께를 따릅니다."
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -8399,7 +8399,9 @@
             "externalWorktrees": "외부 작업 트리",
             "externalWorktreesDescription": "Orca 외부에서 만든 작업 트리를 기본적으로 표시할지 선택합니다.",
             "editorFontWeight": "편집기 글꼴 두께",
-            "editorFontWeightDesc": "파일 편집기 및 diff 보기에서 사용되는 글꼴 두께입니다. 비워두면 터미널 글꼴 두께를 따릅니다."
+            "editorFontWeightDesc": "파일 편집기 및 diff 보기에서 사용되는 글꼴 두께입니다. 비워두면 터미널 글꼴 두께를 따릅니다.",
+            "editorLineHeight": "편집기 줄 높이",
+            "editorLineHeightDesc": "파일 편집기의 줄 간격으로, 글꼴 크기의 배수입니다. 비워두면 편집기 기본값을 유지합니다."
           }
         },
         "git": {
@@ -9871,6 +9873,10 @@
         "EditorFontWeightSetting": {
           "title": "편집기 글꼴 두께",
           "description": "파일 편집기 및 diff 보기에서 사용되는 글꼴 두께입니다. 비워두면 터미널 글꼴 두께를 따릅니다."
+        },
+        "EditorLineHeightSetting": {
+          "title": "편집기 줄 높이",
+          "description": "파일 편집기의 줄 간격으로, 글꼴 크기의 배수입니다. 비워두면 편집기 기본값을 유지합니다."
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9935,8 +9935,7 @@
         },
         "EditorFontWeightSetting": {
           "title": "编辑器字体粗细",
-          "description": "文件编辑器和差异视图使用的字体粗细，留空则跟随终端字体粗细。",
-          "placeholder": "与终端字体粗细相同"
+          "description": "文件编辑器和差异视图使用的字体粗细，留空则跟随终端字体粗细。"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8462,7 +8462,9 @@
             "editorFontFamily": "编辑器字体",
             "editorFontFamilyDesc": "文件编辑器和差异视图使用的字体，留空则跟随终端字体。",
             "externalWorktrees": "外部工作树",
-            "externalWorktreesDescription": "选择是否默认显示在 Orca 外部创建的工作树。"
+            "externalWorktreesDescription": "选择是否默认显示在 Orca 外部创建的工作树。",
+            "editorFontWeight": "编辑器字体粗细",
+            "editorFontWeightDesc": "文件编辑器和差异视图使用的字体粗细，留空则跟随终端字体粗细。"
           }
         },
         "git": {
@@ -9930,6 +9932,11 @@
           "title": "编辑器字体",
           "description": "文件编辑器和差异视图使用的字体，留空则跟随终端字体。",
           "placeholder": "与终端字体相同"
+        },
+        "EditorFontWeightSetting": {
+          "title": "编辑器字体粗细",
+          "description": "文件编辑器和差异视图使用的字体粗细，留空则跟随终端字体粗细。",
+          "placeholder": "与终端字体粗细相同"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -8464,7 +8464,9 @@
             "externalWorktrees": "外部工作树",
             "externalWorktreesDescription": "选择是否默认显示在 Orca 外部创建的工作树。",
             "editorFontWeight": "编辑器字体粗细",
-            "editorFontWeightDesc": "文件编辑器和差异视图使用的字体粗细，留空则跟随终端字体粗细。"
+            "editorFontWeightDesc": "文件编辑器和差异视图使用的字体粗细，留空则跟随终端字体粗细。",
+            "editorLineHeight": "编辑器行高",
+            "editorLineHeightDesc": "文件编辑器的行间距，以字体大小的倍数表示，留空则保持编辑器默认值。"
           }
         },
         "git": {
@@ -9936,6 +9938,10 @@
         "EditorFontWeightSetting": {
           "title": "编辑器字体粗细",
           "description": "文件编辑器和差异视图使用的字体粗细，留空则跟随终端字体粗细。"
+        },
+        "EditorLineHeightSetting": {
+          "title": "编辑器行高",
+          "description": "文件编辑器的行间距，以字体大小的倍数表示，留空则保持编辑器默认值。"
         },
         "GeneralRemoteServerUpdates": {
           "serverCount": "{{value0}} paired servers",

--- a/src/renderer/src/lib/editor-font-zoom.test.ts
+++ b/src/renderer/src/lib/editor-font-zoom.test.ts
@@ -4,7 +4,8 @@ import {
   computeDiffEditorFontSize,
   computeEditorFontSize,
   resolveEditorFontFamily,
-  resolveEditorFontFamilyOrInherit
+  resolveEditorFontFamilyOrInherit,
+  resolveEditorFontWeight
 } from './editor-font-zoom'
 
 describe('editor font zoom', () => {
@@ -64,5 +65,26 @@ describe('resolveEditorFontFamilyOrInherit', () => {
         terminalFontFamily: 'Menlo'
       })
     ).toBe('Fira Code')
+  })
+})
+
+describe('resolveEditorFontWeight', () => {
+  it('follows the terminal weight when no editor override is set', () => {
+    expect(resolveEditorFontWeight({ terminalFontWeight: 400 })).toBe('400')
+    expect(resolveEditorFontWeight({ editorFontWeight: 0, terminalFontWeight: 400 })).toBe('400')
+  })
+
+  it('uses the opt-in editor weight override instead of the terminal weight', () => {
+    expect(resolveEditorFontWeight({ editorFontWeight: 300, terminalFontWeight: 600 })).toBe('300')
+  })
+
+  it('falls back to the default terminal weight when neither weight is set', () => {
+    expect(resolveEditorFontWeight(undefined)).toBe('500')
+    expect(resolveEditorFontWeight({})).toBe('500')
+  })
+
+  it('clamps out-of-range overrides into the supported 100-900 band', () => {
+    expect(resolveEditorFontWeight({ editorFontWeight: 5000 })).toBe('900')
+    expect(resolveEditorFontWeight({ editorFontWeight: 50 })).toBe('100')
   })
 })

--- a/src/renderer/src/lib/editor-font-zoom.test.ts
+++ b/src/renderer/src/lib/editor-font-zoom.test.ts
@@ -5,7 +5,10 @@ import {
   computeEditorFontSize,
   resolveEditorFontFamily,
   resolveEditorFontFamilyOrInherit,
-  resolveEditorFontWeight
+  resolveEditorFontWeight,
+  monacoAutomaticLineHeightRatio,
+  normalizeEditorLineHeight,
+  resolveEditorLineHeight
 } from './editor-font-zoom'
 
 describe('editor font zoom', () => {
@@ -86,5 +89,37 @@ describe('resolveEditorFontWeight', () => {
   it('clamps out-of-range overrides into the supported 100-900 band', () => {
     expect(resolveEditorFontWeight({ editorFontWeight: 5000 })).toBe('900')
     expect(resolveEditorFontWeight({ editorFontWeight: 50 })).toBe('100')
+  })
+})
+
+describe('resolveEditorLineHeight', () => {
+  // Monaco reads 0 as "compute from the font size", so an unset setting must stay 0
+  // rather than re-flowing every open file the first time this ships.
+  it('stays on Monaco automatic spacing when unset', () => {
+    expect(resolveEditorLineHeight(undefined)).toBe(0)
+    expect(resolveEditorLineHeight({})).toBe(0)
+    expect(resolveEditorLineHeight({ editorLineHeight: 0 })).toBe(0)
+  })
+
+  it('passes an opted-in multiplier through', () => {
+    expect(resolveEditorLineHeight({ editorLineHeight: 1.2 })).toBe(1.2)
+  })
+
+  it('clamps out-of-range values into the supported band', () => {
+    expect(normalizeEditorLineHeight(9)).toBe(3)
+    expect(normalizeEditorLineHeight(0.2)).toBe(1)
+  })
+
+  it('rejects values Monaco would misread as absolute pixels', () => {
+    expect(normalizeEditorLineHeight(Number.NaN)).toBe(0)
+    expect(normalizeEditorLineHeight(-4)).toBe(0)
+  })
+})
+
+describe('monacoAutomaticLineHeightRatio', () => {
+  it('mirrors Monaco GOLDEN_LINE_HEIGHT_RATIO per platform', () => {
+    expect(monacoAutomaticLineHeightRatio('darwin')).toBe(1.5)
+    expect(monacoAutomaticLineHeightRatio('linux')).toBe(1.35)
+    expect(monacoAutomaticLineHeightRatio('win32')).toBe(1.35)
   })
 })

--- a/src/renderer/src/lib/editor-font-zoom.ts
+++ b/src/renderer/src/lib/editor-font-zoom.ts
@@ -1,3 +1,5 @@
+import { normalizeTerminalFontWeight } from '../../../shared/terminal-fonts'
+
 const EDITOR_FONT_ZOOM_MIN = -6
 const EDITOR_FONT_ZOOM_MAX = 18
 const EDITOR_FONT_ZOOM_STEP = 1
@@ -49,4 +51,41 @@ export function resolveEditorFontFamilyOrInherit(
   settings?: EditorFontFamilySettings | null
 ): string | undefined {
   return settings?.editorFontFamily?.trim() || settings?.terminalFontFamily || undefined
+}
+
+export type EditorFontWeightSettings = {
+  editorFontWeight?: number
+  terminalFontWeight?: number
+}
+
+/**
+ * Why: the editor weight is opt-in and defaults to 0, so an unset value must keep
+ * following the terminal weight exactly as before the setting existed. Returns a
+ * string because that is the type Monaco's `fontWeight` editor option accepts.
+ */
+export function resolveEditorFontWeight(settings?: EditorFontWeightSettings | null): string {
+  const editorFontWeight = settings?.editorFontWeight
+  const weight =
+    typeof editorFontWeight === 'number' && editorFontWeight > 0
+      ? editorFontWeight
+      : settings?.terminalFontWeight
+
+  return String(normalizeTerminalFontWeight(weight))
+}
+
+export type EditorFontSettings = EditorFontFamilySettings & EditorFontWeightSettings
+
+/**
+ * Why grouped: every Monaco surface sets family and weight together, so resolving
+ * them in one call keeps option objects (and their import lists) from growing a
+ * line per typography knob.
+ */
+export function resolveEditorFontOptions(settings?: EditorFontSettings | null): {
+  fontFamily: string
+  fontWeight: string
+} {
+  return {
+    fontFamily: resolveEditorFontFamily(settings),
+    fontWeight: resolveEditorFontWeight(settings)
+  }
 }

--- a/src/renderer/src/lib/editor-font-zoom.ts
+++ b/src/renderer/src/lib/editor-font-zoom.ts
@@ -1,4 +1,5 @@
 import { normalizeTerminalFontWeight } from '../../../shared/terminal-fonts'
+import { getRendererAppPlatform } from './renderer-app-platform'
 
 const EDITOR_FONT_ZOOM_MIN = -6
 const EDITOR_FONT_ZOOM_MAX = 18
@@ -88,4 +89,41 @@ export function resolveEditorFontOptions(settings?: EditorFontSettings | null): 
     fontFamily: resolveEditorFontFamily(settings),
     fontWeight: resolveEditorFontWeight(settings)
   }
+}
+
+/** Monaco reads 0 as "compute the line height from the font size". */
+export const EDITOR_LINE_HEIGHT_AUTO = 0
+export const EDITOR_LINE_HEIGHT_MIN = 1
+export const EDITOR_LINE_HEIGHT_MAX = 3
+export const EDITOR_LINE_HEIGHT_STEP = 0.1
+
+/**
+ * Monaco's GOLDEN_LINE_HEIGHT_RATIO — the multiplier it applies when no line height
+ * is set. Mirrored here so the setting can show what "automatic" resolves to.
+ */
+export function monacoAutomaticLineHeightRatio(
+  platform: NodeJS.Platform = getRendererAppPlatform()
+): number {
+  return platform === 'darwin' ? 1.5 : 1.35
+}
+
+export function normalizeEditorLineHeight(lineHeight: number | null | undefined): number {
+  if (typeof lineHeight !== 'number' || !Number.isFinite(lineHeight) || lineHeight <= 0) {
+    return EDITOR_LINE_HEIGHT_AUTO
+  }
+
+  return (
+    Math.round(
+      Math.min(EDITOR_LINE_HEIGHT_MAX, Math.max(EDITOR_LINE_HEIGHT_MIN, lineHeight)) * 10
+    ) / 10
+  )
+}
+
+/**
+ * Why a multiplier rather than pixels: Monaco treats a value between 0 and 8 as a
+ * multiple of the font size, which is the same shape as the terminal's Line Height,
+ * so the two settings stay comparable while editor zoom keeps working.
+ */
+export function resolveEditorLineHeight(settings?: { editorLineHeight?: number } | null): number {
+  return normalizeEditorLineHeight(settings?.editorLineHeight)
 }

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -52,6 +52,8 @@ export function buildDefaultSettings(args: {
     editorMinimapEnabled: false,
     // Why empty: the editor keeps following the terminal font unless the user opts in.
     editorFontFamily: '',
+    // Why zero: the editor keeps following the terminal font weight unless the user opts in.
+    editorFontWeight: 0,
     editorWordWrap: true,
     richMarkdownSpellcheckEnabled: true,
     markdownReviewToolsEnabled: true,

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -54,6 +54,9 @@ export function buildDefaultSettings(args: {
     editorFontFamily: '',
     // Why zero: the editor keeps following the terminal font weight unless the user opts in.
     editorFontWeight: 0,
+    // Why zero: Monaco reads 0 as "compute from the font size", so the editor keeps its
+    // current spacing until the user opts in instead of silently re-flowing every file.
+    editorLineHeight: 0,
     editorWordWrap: true,
     richMarkdownSpellcheckEnabled: true,
     markdownReviewToolsEnabled: true,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -91,6 +91,8 @@ export type GlobalSettings = {
   editorFontFamily?: string
   /** Opt-in code-editor font weight; 0 (the default) keeps following `terminalFontWeight`. */
   editorFontWeight?: number
+  /** Opt-in file-editor line height, as a multiple of the font size; 0 (the default) leaves Monaco's automatic spacing. */
+  editorLineHeight?: number
   /** Defaults on for profiles saved before file-editor wrapping became configurable. */
   editorWordWrap?: boolean
   /** Persisted opt-out for browser spellcheck noise in rich Markdown editing surfaces. */

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -89,6 +89,8 @@ export type GlobalSettings = {
   editorMinimapEnabled: boolean
   /** Opt-in code-editor font; empty (the default) keeps following `terminalFontFamily`. */
   editorFontFamily?: string
+  /** Opt-in code-editor font weight; 0 (the default) keeps following `terminalFontWeight`. */
+  editorFontWeight?: number
   /** Defaults on for profiles saved before file-editor wrapping became configurable. */
   editorWordWrap?: boolean
   /** Persisted opt-out for browser spellcheck noise in rich Markdown editing surfaces. */


### PR DESCRIPTION
## ELI5

The file editor could already borrow the terminal's font and font size, but not its **weight**, and it had no say over its **line spacing** at all. So a file open in the editor could look lighter and airier than the exact same text in a terminal pane right next to it, with no setting anywhere to fix it. This adds those two knobs. Leave them empty and nothing changes — the weight keeps following the terminal, and the spacing stays exactly where Monaco had it.

## What Changed

Two new opt-in settings under General → Editor, next to Editor Font Family:

- **Editor Font Weight** — empty follows `terminalFontWeight`, or pin 100–900. Resolution reuses the terminal's existing `normalizeTerminalFontWeight`, so the two settings share one clamp instead of duplicating validation.
- **Editor Line Height** — empty keeps Monaco's automatic spacing, or pin a 1–3 multiple of the font size.

Both are wired the same way `editorFontFamily` already is. Family and weight now resolve together through a small `resolveEditorFontOptions()` helper, because every Monaco surface sets them as a pair.

The empty field shows the value it resolves to today — the live terminal weight, or Monaco's own ratio (1.5 on macOS, 1.35 elsewhere) — so "inheriting" is never a guess.

## Why

`fontFamily` and `fontSize` were the only typography options reaching Monaco. Everything else fell back to Monaco's defaults regardless of what the terminal was set to, and there was no editor-side setting to compensate — the only lever was moving the terminal, which is backwards if you want the terminal compact.

Defaults were chosen so this change is invisible until someone opts in:

- Font weight defaults to following the terminal, matching how `editorFontFamily` already behaves. A fixed default would have pinned the editor and quietly broken that inheritance for everyone.
- Line height defaults to `0`, which Monaco reads as "compute from the font size" — byte-for-byte today's behavior. #14257 also proposed inheriting the terminal's Line Height instead, but the terminal defaults to 1 against Monaco's 1.5, so that would have recompressed every existing user's editor by a third on upgrade.

**Line height is scoped to the file editor on purpose.** Diff views size their virtualized rows from a fixed `DIFF_LINE_HEIGHT` in `diff-section-layout.ts`, so making their line height configurable would desync the virtualizer's height estimates from what Monaco actually renders. That belongs in its own change. Font weight has no such coupling and applies to every surface that already honors the editor font.

## Linked Issue

Fixes #20183
Fixes #14257

## Visual Proof

<!-- BEFORE / AFTER of General → Editor, same framing -->

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS (darwin arm64) in a dev build: setting weight 600 and line height 1.2 changes the file editor only — terminal panes, chat, and the shell prompt are untouched. Clearing either field returns it to inheriting.

`pnpm lint`, `pnpm typecheck` and `pnpm build` all exit 0. New tests:

- `editor-font-zoom.test.ts` — inheritance, opt-in override, clamping, and the per-platform Monaco ratio
- `EditorFontWeightSetting.test.tsx` / `EditorLineHeightSetting.test.tsx` — the four states each row can be in
- `MonacoEditor.font-weight.test.tsx` / `MonacoEditor.line-height.test.tsx` — the options actually reaching Monaco

The setting render tests are not redundant coverage: an earlier revision passed `NaN` as NumberField's unset value, and since `NaN !== NaN` its render-phase sync set state on every render and tripped React's re-render limit the moment Settings opened. Resolver tests and mocked-editor tests both passed through that bug — only rendering the row caught it. I re-introduced the bug to confirm these tests fail against it before keeping them.

`pnpm test` reports 15 pre-existing failures in `cross-version-wire`, `claude-real-cli`, `relay` and `codex-pty`, all from my shallow clone (`release-checkout` needs release tags locally). Confirmed identical on a clean checkout of the base commit with none of these changes applied.

## Author

X: @prosnaghi

## AI Disclosure

Written with Claude Opus 5 (Claude Code), reviewed and directed by me.

## Review

Agent review summary:

- **Cross-platform** — no platform branches except `monacoAutomaticLineHeightRatio()`, which mirrors Monaco's own `isMacintosh ? 1.5 : 1.35` and exists only to label the placeholder. It takes the platform as a parameter and is unit-tested for darwin/linux/win32. No paths, shells or shortcuts touched.
- **Remote/SSH/local** — settings-only; no process, filesystem or network assumptions. Values travel through the existing global-settings pipeline.
- **Agents and integrations** — none touched; nothing here is provider-specific.
- **Backwards compatibility** — both settings are optional and default to today's behavior. Profiles saved before this change deserialize with the field absent, which the resolvers read as "inherit". No migration needed.
- **Performance** — two arithmetic resolvers per render, no allocation in a hot path. The line-height dependency was added to the existing `updateOptions` effect rather than creating a new one.
- **UI quality** — follows the `editorFontFamily` row it sits beside; uses `NumberField` and `SearchableSetting` rather than custom controls, no hardcoded colors. Verified in dark mode on macOS.
- **Security** — no new inputs, IPC, or file access. Both values are clamped before use.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Localization: English plus es/fr/ja/ko/zh, reusing each catalog's existing wording for "font weight" and the sibling editor font setting. Added via `pnpm run sync:localization-catalog`, not hand-edited.

Both rows live in General → Editor because that is where Editor Font Family already is. Grouping the editor's typography under Appearance next to IDE Font would arguably suit it better — #14257 assumes it is already there — but moving existing settings is a product call, so I kept these next to their sibling rather than deciding it inside a feature PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
