### PR TITLE
fix(stats): rank heatmap days by quartile and cover the full 42-day window

### DIFF
--- a/src/renderer/src/components/stats/UsageOverviewPane.tsx
+++ b/src/renderer/src/components/stats/UsageOverviewPane.tsx
@@ -5,7 +5,11 @@ import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { StatCard } from './StatCard'
-import { buildDailyOverview, getRecentUsageDays } from './usage-overview-daily-series'
+import {
+  buildDailyOverview,
+  getRecentUsageDays,
+  rankUsageIntensities
+} from './usage-overview-daily-series'
 import type { UsageOverviewDailyPoint, UsageOverviewInput } from './usage-overview-types'
 import { buildUsageOverview, formatUsageCost, formatUsageTokens } from './usage-overview-model'
 import { DailyIntensityGrid, ProviderUsageRow, TokenMixBar } from './usage-overview-sections'
@@ -117,29 +121,41 @@ export function UsageOverviewPane(): React.JSX.Element {
   ].join('|')
   useEffect(() => {
     let cancelled = false
+    // Why: one provider failing must not blank the others' cells.
+    const loadDaily = <Daily,>(
+      name: string,
+      enabled: boolean,
+      fetch: () => Promise<{ daily?: Daily[] } | undefined>
+    ): Promise<Daily[]> =>
+      enabled
+        ? fetch()
+            .then((snapshot) => snapshot?.daily ?? [])
+            .catch((error: unknown) => {
+              console.error(`Failed to load ${name} usage heatmap:`, error)
+              return []
+            })
+        : Promise.resolve([])
     const load = async (): Promise<void> => {
       const [claude, codex, opencode] = await Promise.all([
-        claudeEnabled
-          ? window.api.claudeUsage
-              .getSnapshot({ scope: claudeScope, range: HEATMAP_RANGE, limit: 1 })
-              .then((snapshot) => snapshot?.daily ?? [])
-          : Promise.resolve([]),
-        codexEnabled
-          ? window.api.codexUsage
-              .getSnapshot({ scope: codexScope, range: HEATMAP_RANGE, limit: 1 })
-              .then((snapshot) => snapshot?.daily ?? [])
-          : Promise.resolve([]),
-        openCodeEnabled
-          ? window.api.openCodeUsage
-              .getSnapshot({ scope: openCodeScope, range: HEATMAP_RANGE, limit: 1 })
-              .then((snapshot) => snapshot?.daily ?? [])
-          : Promise.resolve([])
+        loadDaily('Claude', claudeEnabled, () =>
+          window.api.claudeUsage.getSnapshot({ scope: claudeScope, range: HEATMAP_RANGE, limit: 1 })
+        ),
+        loadDaily('Codex', codexEnabled, () =>
+          window.api.codexUsage.getSnapshot({ scope: codexScope, range: HEATMAP_RANGE, limit: 1 })
+        ),
+        loadDaily('OpenCode', openCodeEnabled, () =>
+          window.api.openCodeUsage.getSnapshot({
+            scope: openCodeScope,
+            range: HEATMAP_RANGE,
+            limit: 1
+          })
+        )
       ])
       if (!cancelled) {
         setHeatmapDaily({ claude, codex, opencode })
       }
     }
-    load().catch((error: unknown) => console.error('Failed to load usage heatmap:', error))
+    void load()
     return () => {
       cancelled = true
     }
@@ -152,34 +168,31 @@ export function UsageOverviewPane(): React.JSX.Element {
     openCodeScope,
     scanKey
   ])
-  const recentDays = useMemo(
-    () =>
-      getRecentUsageDays(
-        buildDailyOverview({
-          claude: {
-            scanState: claudeScanState,
-            summary: claudeSummary,
-            daily: heatmapDaily.claude
-          },
-          codex: { scanState: codexScanState, summary: codexSummary, daily: heatmapDaily.codex },
-          opencode: {
-            scanState: openCodeScanState,
-            summary: openCodeSummary,
-            daily: heatmapDaily.opencode
-          }
-        }),
-        RECENT_DAY_COUNT
-      ),
-    [
-      claudeScanState,
-      claudeSummary,
-      codexScanState,
-      codexSummary,
-      heatmapDaily,
-      openCodeScanState,
-      openCodeSummary
-    ]
-  )
+  const recentDays = useMemo(() => {
+    const windowed = getRecentUsageDays(
+      buildDailyOverview({
+        claude: { scanState: claudeScanState, summary: claudeSummary, daily: heatmapDaily.claude },
+        codex: { scanState: codexScanState, summary: codexSummary, daily: heatmapDaily.codex },
+        opencode: {
+          scanState: openCodeScanState,
+          summary: openCodeSummary,
+          daily: heatmapDaily.opencode
+        }
+      }),
+      RECENT_DAY_COUNT
+    )
+    // Why: shades are quartiles of the days on screen, not of the whole fetched history.
+    const intensities = rankUsageIntensities(windowed.map((entry) => entry.totalTokens))
+    return windowed.map((entry, index) => ({ ...entry, intensity: intensities[index] ?? 0 }))
+  }, [
+    claudeScanState,
+    claudeSummary,
+    codexScanState,
+    codexSummary,
+    heatmapDaily,
+    openCodeScanState,
+    openCodeSummary
+  ])
   const heatmapBestDay = useMemo(() => pickBestDay(recentDays), [recentDays])
   const isScanning = overview.providers.some((provider) => provider.isScanning)
 

--- a/src/renderer/src/components/stats/UsageOverviewPane.tsx
+++ b/src/renderer/src/components/stats/UsageOverviewPane.tsx
@@ -1,16 +1,35 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Activity, CalendarDays, Coins, DatabaseZap, RefreshCw, Sparkles } from 'lucide-react'
 import { useAppStore } from '../../store'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { StatCard } from './StatCard'
-import { getRecentUsageDays } from './usage-overview-daily-series'
+import { buildDailyOverview, getRecentUsageDays } from './usage-overview-daily-series'
+import type { UsageOverviewDailyPoint, UsageOverviewInput } from './usage-overview-types'
 import { buildUsageOverview, formatUsageCost, formatUsageTokens } from './usage-overview-model'
 import { DailyIntensityGrid, ProviderUsageRow, TokenMixBar } from './usage-overview-sections'
 import { translate } from '@/i18n/i18n'
 
 const RECENT_DAY_COUNT = 42
+// Why: the provider tabs default to a 30d range but the heatmap draws 42 days,
+// so it fetches its own series wide enough to cover every cell it renders.
+const HEATMAP_RANGE = '90d'
+
+type HeatmapDaily = {
+  claude: UsageOverviewInput['claude']['daily']
+  codex: UsageOverviewInput['codex']['daily']
+  opencode: UsageOverviewInput['opencode']['daily']
+}
+
+const EMPTY_HEATMAP_DAILY: HeatmapDaily = { claude: [], codex: [], opencode: [] }
+
+function pickBestDay(days: UsageOverviewDailyPoint[]): UsageOverviewDailyPoint | null {
+  return days.reduce<UsageOverviewDailyPoint | null>(
+    (best, entry) => (!best || entry.totalTokens > best.totalTokens ? entry : best),
+    null
+  )
+}
 
 function formatPercent(value: number | null): string {
   if (value === null) {
@@ -36,6 +55,9 @@ export function UsageOverviewPane(): React.JSX.Element {
   const openCodeScanState = useAppStore((state) => state.openCodeUsageScanState)
   const openCodeSummary = useAppStore((state) => state.openCodeUsageSummary)
   const openCodeDaily = useAppStore((state) => state.openCodeUsageDaily)
+  const claudeScope = useAppStore((state) => state.claudeUsageScope)
+  const codexScope = useAppStore((state) => state.codexUsageScope)
+  const openCodeScope = useAppStore((state) => state.openCodeUsageScope)
   const fetchClaudeUsage = useAppStore((state) => state.fetchClaudeUsage)
   const fetchCodexUsage = useAppStore((state) => state.fetchCodexUsage)
   const fetchOpenCodeUsage = useAppStore((state) => state.fetchOpenCodeUsage)
@@ -84,10 +106,81 @@ export function UsageOverviewPane(): React.JSX.Element {
       openCodeSummary
     ]
   )
+  const [heatmapDaily, setHeatmapDaily] = useState<HeatmapDaily>(EMPTY_HEATMAP_DAILY)
+  const claudeEnabled = claudeScanState?.enabled === true
+  const codexEnabled = codexScanState?.enabled === true
+  const openCodeEnabled = openCodeScanState?.enabled === true
+  const scanKey = [
+    claudeScanState?.lastScanCompletedAt,
+    codexScanState?.lastScanCompletedAt,
+    openCodeScanState?.lastScanCompletedAt
+  ].join('|')
+  useEffect(() => {
+    let cancelled = false
+    const load = async (): Promise<void> => {
+      const [claude, codex, opencode] = await Promise.all([
+        claudeEnabled
+          ? window.api.claudeUsage
+              .getSnapshot({ scope: claudeScope, range: HEATMAP_RANGE, limit: 1 })
+              .then((snapshot) => snapshot?.daily ?? [])
+          : Promise.resolve([]),
+        codexEnabled
+          ? window.api.codexUsage
+              .getSnapshot({ scope: codexScope, range: HEATMAP_RANGE, limit: 1 })
+              .then((snapshot) => snapshot?.daily ?? [])
+          : Promise.resolve([]),
+        openCodeEnabled
+          ? window.api.openCodeUsage
+              .getSnapshot({ scope: openCodeScope, range: HEATMAP_RANGE, limit: 1 })
+              .then((snapshot) => snapshot?.daily ?? [])
+          : Promise.resolve([])
+      ])
+      if (!cancelled) {
+        setHeatmapDaily({ claude, codex, opencode })
+      }
+    }
+    load().catch((error: unknown) => console.error('Failed to load usage heatmap:', error))
+    return () => {
+      cancelled = true
+    }
+  }, [
+    claudeEnabled,
+    claudeScope,
+    codexEnabled,
+    codexScope,
+    openCodeEnabled,
+    openCodeScope,
+    scanKey
+  ])
   const recentDays = useMemo(
-    () => getRecentUsageDays(overview.daily, RECENT_DAY_COUNT),
-    [overview.daily]
+    () =>
+      getRecentUsageDays(
+        buildDailyOverview({
+          claude: {
+            scanState: claudeScanState,
+            summary: claudeSummary,
+            daily: heatmapDaily.claude
+          },
+          codex: { scanState: codexScanState, summary: codexSummary, daily: heatmapDaily.codex },
+          opencode: {
+            scanState: openCodeScanState,
+            summary: openCodeSummary,
+            daily: heatmapDaily.opencode
+          }
+        }),
+        RECENT_DAY_COUNT
+      ),
+    [
+      claudeScanState,
+      claudeSummary,
+      codexScanState,
+      codexSummary,
+      heatmapDaily,
+      openCodeScanState,
+      openCodeSummary
+    ]
   )
+  const heatmapBestDay = useMemo(() => pickBestDay(recentDays), [recentDays])
   const isScanning = overview.providers.some((provider) => provider.isScanning)
 
   const handleRefresh = (): void => {
@@ -233,7 +326,7 @@ export function UsageOverviewPane(): React.JSX.Element {
               </div>
             ) : (
               <div className="mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
-                <DailyIntensityGrid days={recentDays} bestDay={overview.bestDay} />
+                <DailyIntensityGrid days={recentDays} bestDay={heatmapBestDay} />
                 <TokenMixBar overview={overview} />
               </div>
             )}

--- a/src/renderer/src/components/stats/UsageOverviewPane.tsx
+++ b/src/renderer/src/components/stats/UsageOverviewPane.tsx
@@ -28,6 +28,11 @@ type HeatmapDaily = {
 
 const EMPTY_HEATMAP_DAILY: HeatmapDaily = { claude: [], codex: [], opencode: [] }
 
+/**
+ * Highest-volume day in a series.
+ * @param days - Daily points, any order.
+ * @returns The day with the most tokens, or `null` for an empty series.
+ */
 function pickBestDay(days: UsageOverviewDailyPoint[]): UsageOverviewDailyPoint | null {
   return days.reduce<UsageOverviewDailyPoint | null>(
     (best, entry) => (!best || entry.totalTokens > best.totalTokens ? entry : best),
@@ -49,6 +54,11 @@ function formatUpdatedAt(timestamp: number | null): string {
   return `Updated ${new Date(timestamp).toLocaleString()}`
 }
 
+/**
+ * Combined Claude, Codex, and OpenCode usage: totals, a 42-day intensity heatmap,
+ * token mix, and per-provider rows.
+ * @returns The Stats & Usage overview pane.
+ */
 export function UsageOverviewPane(): React.JSX.Element {
   const claudeScanState = useAppStore((state) => state.claudeUsageScanState)
   const claudeSummary = useAppStore((state) => state.claudeUsageSummary)

--- a/src/renderer/src/components/stats/usage-overview-daily-series.ts
+++ b/src/renderer/src/components/stats/usage-overview-daily-series.ts
@@ -8,7 +8,8 @@ export function getClaudeDailyTotal(entry: ClaudeUsageDailyPoint): number {
 type UsageIntensity = 0 | 1 | 2 | 3 | 4
 
 /**
- * Rank-based intensity: each non-zero level holds a quarter of the active days.
+ * Rank-based intensity: each non-zero level holds a quarter of the active days
+ * among `totals`, so callers rank exactly the set of days they render.
  *
  * Why: daily volume spans orders of magnitude across providers, so a linear
  * ramp against the single best day left most active days at the faintest
@@ -18,15 +19,17 @@ type UsageIntensity = 0 | 1 | 2 | 3 | 4
  */
 export function rankUsageIntensities(totals: number[]): UsageIntensity[] {
   const active = totals.filter((total) => total > 0).sort((left, right) => left - right)
+  // Why: a value -> cumulative-count map keeps each lookup O(1); ties share the
+  // higher rank (the last index written) so equal days never render differently.
+  const countAtOrBelow = new Map<number, number>()
+  for (let index = 0; index < active.length; index += 1) {
+    countAtOrBelow.set(active[index], index + 1)
+  }
   return totals.map((total) => {
     if (total <= 0) {
       return 0
     }
-    // Ties share the higher rank so equal days never render differently.
-    let atOrBelow = active.length
-    while (atOrBelow > 0 && active[atOrBelow - 1] > total) {
-      atOrBelow -= 1
-    }
+    const atOrBelow = countAtOrBelow.get(total) ?? 0
     return Math.max(1, Math.ceil((atOrBelow / active.length) * 4)) as UsageIntensity
   })
 }

--- a/src/renderer/src/components/stats/usage-overview-daily-series.ts
+++ b/src/renderer/src/components/stats/usage-overview-daily-series.ts
@@ -5,21 +5,30 @@ export function getClaudeDailyTotal(entry: ClaudeUsageDailyPoint): number {
   return entry.inputTokens + entry.outputTokens + entry.cacheReadTokens + entry.cacheWriteTokens
 }
 
-function getIntensity(totalTokens: number, maxTokens: number): 0 | 1 | 2 | 3 | 4 {
-  if (totalTokens <= 0 || maxTokens <= 0) {
-    return 0
-  }
-  const ratio = totalTokens / maxTokens
-  if (ratio <= 0.25) {
-    return 1
-  }
-  if (ratio <= 0.5) {
-    return 2
-  }
-  if (ratio <= 0.75) {
-    return 3
-  }
-  return 4
+type UsageIntensity = 0 | 1 | 2 | 3 | 4
+
+/**
+ * Rank-based intensity: each non-zero level holds a quarter of the active days.
+ *
+ * Why: daily volume spans orders of magnitude across providers, so a linear
+ * ramp against the single best day left most active days at the faintest
+ * level and indistinguishable from idle ones.
+ * @param totals - Token totals of every day, zero for idle days.
+ * @returns Intensity per index of `totals`; idle days stay 0, the best day is 4.
+ */
+export function rankUsageIntensities(totals: number[]): UsageIntensity[] {
+  const active = totals.filter((total) => total > 0).sort((left, right) => left - right)
+  return totals.map((total) => {
+    if (total <= 0) {
+      return 0
+    }
+    // Ties share the higher rank so equal days never render differently.
+    let atOrBelow = active.length
+    while (atOrBelow > 0 && active[atOrBelow - 1] > total) {
+      atOrBelow -= 1
+    }
+    return Math.max(1, Math.ceil((atOrBelow / active.length) * 4)) as UsageIntensity
+  })
 }
 
 export function countActiveDays(days: string[]): number {
@@ -69,18 +78,9 @@ export function buildDailyOverview(input: UsageOverviewInput): UsageOverviewDail
     byDay.set(entry.day, current)
   }
 
-  let maxTokens = 0
-  // Why: usage history can be large enough to exceed V8's argument limit if
-  // every day is spread into Math.max.
-  for (const entry of byDay.values()) {
-    maxTokens = Math.max(maxTokens, entry.totalTokens)
-  }
-  return [...byDay.values()]
-    .sort((left, right) => left.day.localeCompare(right.day))
-    .map((entry) => ({
-      ...entry,
-      intensity: getIntensity(entry.totalTokens, maxTokens)
-    }))
+  const entries = [...byDay.values()].sort((left, right) => left.day.localeCompare(right.day))
+  const intensities = rankUsageIntensities(entries.map((entry) => entry.totalTokens))
+  return entries.map((entry, index) => ({ ...entry, intensity: intensities[index] ?? 0 }))
 }
 
 function formatLocalDay(date: Date): string {

--- a/src/renderer/src/components/stats/usage-overview-daily-series.ts
+++ b/src/renderer/src/components/stats/usage-overview-daily-series.ts
@@ -8,8 +8,10 @@ export function getClaudeDailyTotal(entry: ClaudeUsageDailyPoint): number {
 type UsageIntensity = 0 | 1 | 2 | 3 | 4
 
 /**
- * Rank-based intensity: each non-zero level holds a quarter of the active days
- * among `totals`, so callers rank exactly the set of days they render.
+ * Rank-based intensity: each non-zero level holds roughly a quarter of the
+ * active days among `totals`, so callers rank exactly the set of days they
+ * render. With fewer than four active days the lower levels go unused (one
+ * active day is level 4, three distinct days are 2/3/4).
  *
  * Why: daily volume spans orders of magnitude across providers, so a linear
  * ramp against the single best day left most active days at the faintest
@@ -34,10 +36,20 @@ export function rankUsageIntensities(totals: number[]): UsageIntensity[] {
   })
 }
 
+/**
+ * Count distinct days in a list of `YYYY-MM-DD` keys.
+ * @param days - Day keys, possibly repeated across providers.
+ * @returns Number of distinct days.
+ */
 export function countActiveDays(days: string[]): number {
   return new Set(days).size
 }
 
+/**
+ * Merge every provider's daily series into one per-day total with a rank intensity.
+ * @param input - Per-provider scan state, summary, and daily series.
+ * @returns One point per day, sorted ascending, ranked across all days present.
+ */
 export function buildDailyOverview(input: UsageOverviewInput): UsageOverviewDailyPoint[] {
   const byDay = new Map<string, Omit<UsageOverviewDailyPoint, 'intensity'>>()
 
@@ -93,6 +105,13 @@ function formatLocalDay(date: Date): string {
   return `${year}-${month}-${day}`
 }
 
+/**
+ * Pad a daily series to a fixed trailing window ending at `anchorDate`.
+ * @param daily - Ranked daily points, any order.
+ * @param dayCount - Number of trailing days to return.
+ * @param anchorDate - Last day of the window; defaults to today.
+ * @returns Exactly `dayCount` points, idle days filled with zero tokens and intensity 0.
+ */
 export function getRecentUsageDays(
   daily: UsageOverviewDailyPoint[],
   dayCount: number,

--- a/src/renderer/src/components/stats/usage-overview-model.test.ts
+++ b/src/renderer/src/components/stats/usage-overview-model.test.ts
@@ -14,7 +14,7 @@ import type {
   OpenCodeUsageScanState,
   OpenCodeUsageSummary
 } from '../../../../shared/opencode-usage-types'
-import { getRecentUsageDays } from './usage-overview-daily-series'
+import { getRecentUsageDays, rankUsageIntensities } from './usage-overview-daily-series'
 import { buildUsageOverview, formatUsageCost, formatUsageTokens } from './usage-overview-model'
 
 function enabledClaudeScanState(): ClaudeUsageScanState {
@@ -189,6 +189,20 @@ describe('usage overview model', () => {
       cacheTokens: 250,
       totalTokens: 1_600
     })
+  })
+
+  it('ranks active days into quartiles instead of scaling against the best day', () => {
+    // A 200x spread: linear scaling would leave every day but the last at level 1.
+    expect(rankUsageIntensities([0, 1, 2, 5, 10, 20, 50, 100, 200, 0])).toEqual([
+      0, 1, 1, 2, 2, 3, 3, 4, 4, 0
+    ])
+  })
+
+  it('gives tied days the same intensity and a lone active day the top level', () => {
+    expect(rankUsageIntensities([7, 7, 0, 7])).toEqual([4, 4, 0, 4])
+    expect(rankUsageIntensities([3])).toEqual([4])
+    expect(rankUsageIntensities([0, 0])).toEqual([0, 0])
+    expect(rankUsageIntensities([])).toEqual([])
   })
 
   it('pads recent usage days with zero-token cells', () => {


### PR DESCRIPTION
## ELI5

Two reasons the "Daily intensity" heatmap on Stats & Usage looked empty even on busy days:

1. It shaded each day relative to your single biggest day. When one provider has multi-billion-token days and another has hundred-million-token days, the second one's days all land in the faintest shade, which in the dark theme reads as "no activity". Days are now ranked: the top quarter of active days get the darkest shade, the next quarter the next, and so on. Idle days still render empty, and the best day is still the darkest.
2. It draws 42 days but was fed the provider tabs' data, whose range defaults to 30 days, so the first twelve cells were always blank no matter what you did. The heatmap now fetches a window that covers every cell it draws.

## What Changed

**Rank scale** (`usage-overview-daily-series.ts`): `buildDailyOverview` no longer computes `intensity` as `totalTokens / maxTokens` bucketed at 25/50/75%. A new exported `rankUsageIntensities(totals)` sorts the non-zero days and assigns each level a quartile of them via a value-to-cumulative-count map (O(n log n)); ties share the higher rank so equal days never render differently, a lone active day is level 4, and idle days stay 0. The overview pane re-ranks over the 42 days it actually draws, so shades are quartiles of the visible window rather than of all-time history. Tests cover a 200x spread, ties, the single-day case, and empty input; the existing `bestDay` and zero-padding expectations are unchanged.

**Heatmap window** (`UsageOverviewPane.tsx`): the pane now fetches its own daily series per enabled provider with `range: '90d'` (covering the 42 rendered days) while keeping each tab's current scope, rebuilds the grid from that series, and picks the `Best:` badge from the same window. It refetches when a scope changes or a scan completes, and a failed provider fetch logs and contributes an empty series instead of blanking the others. The totals cards, the provider rows, and "Active days" still follow the tab filters exactly as before.

No markup or styling changes; the legend and tooltips are untouched.

## Why

Linear scaling answers "how close is this day to my record", which is what the `Best:` badge already shows. The heatmap's job is to show *when* you were active and roughly how much, and a rank scale keeps that legible regardless of how far apart providers are in volume. And a 42-cell grid backed by 30 days of data cannot be read at all: the leading cells look identical to idle days. On my machine (Claude + Codex + OpenCode, best day 3.5B tokens), 30 of 33 active days in the last six weeks rendered at level 1, and Aug 1–12 rendered idle despite daily activity.

## Linked Issue

Fixes #20193 (heatmap). The token-count defect it was first noticed alongside is #20186 / #20187.

## Visual Proof

Both screenshots are local packaged builds of the same profile, taken minutes apart. **Before** is #20187's branch alone (token fix, unchanged heatmap) with the default filters (Orca worktrees only, 30d). **After** is this branch on top of #20187 with the three provider tabs set to "All local usage / All", which is why the totals and active-day count also differ; the heatmap changes themselves are the shading spread and the previously blank Aug 1–12 cells.

### Before
<img width="1039" height="521" alt="image" src="https://github.com/user-attachments/assets/97c2ae1c-982c-4177-b637-1a1b99d1f5b1" />

### After
<img width="1041" height="524" alt="image" src="https://github.com/user-attachments/assets/4aa7bf11-083b-4507-9851-1eb393002eb6" />


## Testing

- `pnpm test src/renderer/src/components/stats/` — 5 files, 15 tests pass
- `tsc --noEmit -p config/tsconfig.tc.web.json` — clean
- `oxlint src/renderer/src/components/stats/` — clean
- Rank scale verified in a local packaged build on macOS (Apple Silicon); the window fix is built and the screenshots above will come from that build. Renderer-only change; no platform, SSH, or mobile surface. The extra fetch is one `getSnapshot` per enabled provider on mount, scope change, or scan completion.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Fable 5.1 (via Claude Code) implemented the change and tests and drafted this description; I reviewed the diff and the rendered result.

## Review

Small, renderer-only: one function replaced plus a heatmap-scoped fetch in the overview pane. Independent of #20187 (different files); either can merge first.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Pure presentation change; no data, security, or cross-platform impact. In paired web clients the usage APIs resolve `undefined`, which the fetch treats as an empty series, matching the existing slices.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


