### PR TITLE
fix(e2e): run worktree first-paint probe on a mapped window

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -173,6 +173,11 @@ jobs:
       - name: Run E2E tests (${{ matrix.shard_name }})
         run: xvfb-run --auto-servernum bash .github/scripts/e2e-with-window-manager.sh env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 ORCA_E2E_WEB_CLIENT=1 ORCA_RELAY_PATH="$GITHUB_WORKSPACE/out/relay" pnpm run test:e2e --shard=${{ matrix.shard }}
 
+      # The frame benchmark needs a mapped window, which the headless shards exclude.
+      - name: Run worktree first-paint benchmark
+        if: matrix.shard == '1/14'
+        run: xvfb-run --auto-servernum bash .github/scripts/e2e-with-window-manager.sh env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm exec playwright test tests/e2e/worktree-switch-first-paint.spec.ts --config tests/playwright.config.ts --project=electron-headful --workers=1
+
       # Why: Playwright retains traces/screenshots only on failure. Uploading
       # them as an artifact makes post-mortem debugging on CI possible without
       # re-running locally.

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -179,6 +179,13 @@ describe('PR E2E gate contract', () => {
       'pnpm run test:e2e "${TEST_FILES[@]}" --workers=1 "${E2E_PROJECT_ARGS[@]}"'
     )
     expect(playwrightConfig).toContain('retries: 0')
+    const steps = e2eWorkflow.jobs.e2e.steps.filter((step) =>
+      step.run?.includes('tests/e2e/worktree-switch-first-paint.spec.ts')
+    )
+    expect(steps).toHaveLength(1)
+    expect(steps[0].if).toBe("matrix.shard == '1/14'")
+    expect(steps[0].run).toContain('xvfb-run --auto-servernum')
+    expect(steps[0].run).toContain('--project=electron-headful --workers=1')
   })
 
   it('keeps startup-exec live parity in the isolated SSH lane', () => {

--- a/tests/e2e/worktree-switch-first-paint.spec.ts
+++ b/tests/e2e/worktree-switch-first-paint.spec.ts
@@ -372,7 +372,12 @@ function median(values: readonly number[]): number {
   return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
 }
 
-test.describe('Worktree switch first paint', () => {
+// Linux needs a mapped window for animation frames after reload; run on an isolated display.
+test.describe('Worktree switch first paint @headful', () => {
+  test.skip(
+    process.env.ORCA_BACKGROUND_LAUNCH === '1',
+    'First-paint measurement requires a mapped window'
+  )
   test('repaints an unmounted worktree within the switch budget', async ({
     orcaPage,
     testRepoPath


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

The first-paint test waited for animation frames from a window that Linux never displayed. Its clock never ticked, so it reported missing terminal content even when the terminal buffer was restored.

## What Changed

- Run the existing benchmark in the mapped-window (`@headful`) project on isolated Xvfb.
- Preserve scheduled full-suite coverage with an explicit invocation on one shard and a workflow contract assertion.
- Respect explicit background launches by not running a mapped-window benchmark in them.
- Keep the frame probe, timeouts, restoration checks, one-pane activation assertion, and deferred warm-set checks unchanged. No production changes.

## Why

The main-branch baseline fails with the same 30-second timeout as #20069: https://github.com/stablyai/orca/actions/runs/34668815923 . A Linux diagnostic run recorded zero animation frames and null activation/mount timestamps while the viewport buffer contained the expected WTB_T2 lines. Background-throttling switches and CDP focus emulation did not resume frames; mapping the test window did.

## Linked Issue

Related: #20069 (CI investigation; does not close the mobile PR).

## Visual Proof

N/A — test-environment correction only; no application UI or production behavior changes.

## Testing

- [x] Linux/Xvfb reproduction: old hidden-window test fails with zero sampled frames.
- [x] Fixed test on the same PR build: three consecutive runs, five switches each; restoration medians 133.3, 126.3, and 138.4 ms. One pane mounted at activation in all 15 switches; all deferred tabs warmed.
- [x] Workflow contract suite: 42 tests passed.
- [x] Targeted lint and diff whitespace checks passed.
- Windows/macOS mapped-window execution not repeated; no production platform/provider paths changed. CI validates the main-based fix separately.

## Review

The test requires a real frame-producing surface; adding sleeps or replacing its frame clock with a timer would change the measurement. Changed-spec CI already selects the headful project for tagged tests. The explicit scheduled invocation prevents a silent loss of full-suite coverage.

## Reliability

- Invariant/oracle: revealed terminal content becomes renderable; activation mounts one pane and deferred panes join the warm set. Existing first-paint E2E assertions remain unchanged.
- Failure source: repeated Linux CI failures on #20069 and its main baseline.
- Gate: existing E2E workflow; no new production reliability surface.
- Performance: no runtime polling, cache, subprocess, or ownership changes. One scheduled benchmark invocation replaces its former headless selection.
- Diagnostics: Linux red/green measurements above and existing Playwright traces.
- Coverage: local Linux PTY exercised; daemon/SSH/WSL/mobile wire behavior unaffected by this test-only change. Real-GPU and Windows/macOS frame timing remain unverified here.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill source copied.

## Checklist

- [x] Small, focused change with root-cause evidence.
- [x] Existing assertions and timeout budgets preserved.
- [x] No production code or mobile behavior changed.
- [x] Local targeted tests passed; full checks run in CI.
