### PR TITLE
fix(browser): keep embedded user agent consistent across requests

### DIFF
--- a/src/main/browser/browser-google-auth-ua.test.ts
+++ b/src/main/browser/browser-google-auth-ua.test.ts
@@ -4,6 +4,7 @@ import {
   googleAuthUserAgent,
   isGoogleAuthUrl,
   setUserAgentHeader,
+  shouldUseGoogleAuthIdentity,
   stripClientHints
 } from './browser-google-auth-ua'
 
@@ -30,6 +31,28 @@ describe('googleAuthUserAgent', () => {
     expect(ua).toMatch(/^Mozilla\/5\.0 \(.+; rv:\d+\.0\) Gecko\/20100101 Firefox\/\d+\.0$/)
     expect(ua).not.toContain('Chrome')
     expect(ua).not.toContain('Electron')
+  })
+})
+
+describe('shouldUseGoogleAuthIdentity', () => {
+  it('includes cross-host subresources referred by an auth document', () => {
+    expect(
+      shouldUseGoogleAuthIdentity(
+        'https://www.gstatic.com/accounts/signin.js',
+        'https://accounts.google.com/v3/signin/identifier',
+        'script'
+      )
+    ).toBe(true)
+  })
+
+  it('excludes a post-auth main-frame exit even when the auth document referred it', () => {
+    expect(
+      shouldUseGoogleAuthIdentity(
+        'https://mail.google.com/',
+        'https://accounts.google.com/v3/signin/identifier',
+        'mainFrame'
+      )
+    ).toBe(false)
   })
 })
 

--- a/src/main/browser/browser-google-auth-ua.ts
+++ b/src/main/browser/browser-google-auth-ua.ts
@@ -20,6 +20,19 @@ export function isGoogleAuthUrl(rawUrl: string): boolean {
   }
 }
 
+export function shouldUseGoogleAuthIdentity(
+  url: string,
+  referrer: string,
+  resourceType: string
+): boolean {
+  if (isGoogleAuthUrl(url)) {
+    return true
+  }
+  // Why: early cross-host subresources can leave before the WebContents Firefox override lands;
+  // the auth referrer identifies their owning flow. Main-frame exits must restore the profile UA.
+  return resourceType !== 'mainFrame' && isGoogleAuthUrl(referrer)
+}
+
 // Why: rv:/Gecko/Firefox tokens must line up with a real released build and the
 // platform token must match the host OS, or the UA is internally inconsistent and
 // itself a bot tell.

--- a/src/main/browser/browser-manager-auth-user-agent.test.ts
+++ b/src/main/browser/browser-manager-auth-user-agent.test.ts
@@ -51,7 +51,8 @@ import {
 import {
   createViewportGuestFactory,
   flushViewportOps,
-  GUEST_CLEAN_UA
+  GUEST_CLEAN_UA,
+  GUEST_ELECTRON_UA
 } from './browser-manager-viewport-test-fixtures'
 
 const {
@@ -63,6 +64,12 @@ const {
   webContentsFromIdMock
 } = browserMocks
 const makeViewportGuest = createViewportGuestFactory(browserMocks)
+const MOBILE_VIEWPORT_OVERRIDE = {
+  width: 375,
+  height: 667,
+  deviceScaleFactor: 2,
+  mobile: true
+} as const
 
 describe('browserManager', () => {
   beforeEach(() => {
@@ -72,6 +79,49 @@ describe('browserManager', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('resolves request identity from the guest viewport and auth state', async () => {
+    const { guest } = makeViewportGuest(4245)
+    webContentsFromIdMock.mockReturnValue(guest)
+    browserManager.attachGuestPolicies(guest as never)
+    browserManager.registerGuest({
+      browserPageId: 'tab-request-identity',
+      webContentsId: guest.id as number,
+      rendererWebContentsId
+    })
+
+    // Ablation: with no mobile preset, the clean session identity is resolved.
+    expect(
+      browserManager.resolveBrowserGuestRequestUserAgent({
+        url: 'https://example.com/logo.png',
+        webContentsId: guest.id as number,
+        currentUserAgent: GUEST_CLEAN_UA,
+        baseUserAgent: GUEST_ELECTRON_UA
+      })
+    ).toBe(GUEST_CLEAN_UA)
+
+    await browserManager.setViewportOverride('tab-request-identity', MOBILE_VIEWPORT_OVERRIDE)
+    await flushViewportOps()
+    const mobile = browserManager.resolveBrowserGuestRequestUserAgent({
+      url: 'https://example.com/logo.png',
+      webContentsId: guest.id as number,
+      currentUserAgent: GUEST_CLEAN_UA,
+      baseUserAgent: GUEST_ELECTRON_UA
+    })
+    expect(mobile).toContain('CriOS/134')
+    expect(mobile).toContain('iPhone')
+
+    // Negative control: auth-document fan-out remains Firefox even while mobile emulation is active.
+    expect(
+      browserManager.resolveBrowserGuestRequestUserAgent({
+        url: 'https://www.gstatic.com/_/signin/log',
+        webContentsId: guest.id as number,
+        currentUserAgent: GUEST_ELECTRON_UA,
+        effectiveUserAgent: googleAuthUserAgent(),
+        baseUserAgent: GUEST_ELECTRON_UA
+      })
+    ).toBe(googleAuthUserAgent())
   })
 
   it('presents the Firefox UA on Google auth hosts and restores the base UA off them', async () => {

--- a/src/main/browser/browser-manager-auth-user-agent.test.ts
+++ b/src/main/browser/browser-manager-auth-user-agent.test.ts
@@ -94,34 +94,81 @@ describe('browserManager', () => {
     // Ablation: with no mobile preset, the clean session identity is resolved.
     expect(
       browserManager.resolveBrowserGuestRequestUserAgent({
+        session: guest.session as Electron.Session,
         url: 'https://example.com/logo.png',
         webContentsId: guest.id as number,
         currentUserAgent: GUEST_CLEAN_UA,
         baseUserAgent: GUEST_ELECTRON_UA
       })
-    ).toBe(GUEST_CLEAN_UA)
+    ).toEqual({ userAgent: GUEST_CLEAN_UA })
 
     await browserManager.setViewportOverride('tab-request-identity', MOBILE_VIEWPORT_OVERRIDE)
     await flushViewportOps()
     const mobile = browserManager.resolveBrowserGuestRequestUserAgent({
+      session: guest.session as Electron.Session,
       url: 'https://example.com/logo.png',
       webContentsId: guest.id as number,
       currentUserAgent: GUEST_CLEAN_UA,
       baseUserAgent: GUEST_ELECTRON_UA
     })
-    expect(mobile).toContain('CriOS/134')
-    expect(mobile).toContain('iPhone')
+    expect(mobile.userAgent).toContain('CriOS/134')
+    expect(mobile.userAgent).toContain('iPhone')
+    expect(mobile.userAgentMetadata).toMatchObject({
+      mobile: true,
+      platform: 'iOS',
+      model: 'iPhone'
+    })
+
+    // A service-worker request has no webContentsId; the Session is its only surviving owner.
+    const workerMobile = browserManager.resolveBrowserGuestRequestUserAgent({
+      session: guest.session as Electron.Session,
+      url: 'https://example.com/worker-beacon',
+      baseUserAgent: GUEST_ELECTRON_UA
+    })
+    expect(workerMobile.userAgent).toBe(mobile.userAgent)
+    expect(workerMobile.userAgentMetadata).toEqual(mobile.userAgentMetadata)
 
     // Negative control: auth-document fan-out remains Firefox even while mobile emulation is active.
     expect(
       browserManager.resolveBrowserGuestRequestUserAgent({
+        session: guest.session as Electron.Session,
         url: 'https://www.gstatic.com/_/signin/log',
         webContentsId: guest.id as number,
         currentUserAgent: GUEST_ELECTRON_UA,
         effectiveUserAgent: googleAuthUserAgent(),
         baseUserAgent: GUEST_ELECTRON_UA
       })
-    ).toBe(googleAuthUserAgent())
+    ).toEqual({ userAgent: googleAuthUserAgent() })
+
+    await browserManager.setViewportOverride('tab-request-identity', null)
+    expect(
+      browserManager.resolveBrowserGuestRequestUserAgent({
+        session: guest.session as Electron.Session,
+        url: 'https://example.com/worker-beacon',
+        baseUserAgent: GUEST_ELECTRON_UA
+      })
+    ).toEqual({ userAgent: GUEST_CLEAN_UA })
+
+    await browserManager.setViewportOverride('tab-request-identity', MOBILE_VIEWPORT_OVERRIDE)
+    browserManager.unregisterGuest('tab-request-identity')
+    expect(
+      browserManager.resolveBrowserGuestRequestUserAgent({
+        session: guest.session as Electron.Session,
+        url: 'https://example.com/worker-after-tab-close',
+        baseUserAgent: GUEST_ELECTRON_UA
+      })
+    ).toEqual({ userAgent: GUEST_CLEAN_UA })
+  })
+
+  it('keeps an unscoped worker request on the desktop identity without a mobile preset', () => {
+    const { guest } = makeViewportGuest(4246)
+    expect(
+      browserManager.resolveBrowserGuestRequestUserAgent({
+        session: guest.session as Electron.Session,
+        url: 'https://example.com/desktop-worker',
+        baseUserAgent: GUEST_ELECTRON_UA
+      })
+    ).toEqual({ userAgent: GUEST_CLEAN_UA })
   })
 
   it('presents the Firefox UA on Google auth hosts and restores the base UA off them', async () => {

--- a/src/main/browser/browser-manager-auth-user-agent.test.ts
+++ b/src/main/browser/browser-manager-auth-user-agent.test.ts
@@ -209,10 +209,13 @@ describe('browserManager', () => {
     setUserAgent.mockClear()
 
     didStartNavigation(null, 'https://accounts.google.com/v3/signin/identifier', false, true)
-    expect(setUserAgent).toHaveBeenLastCalledWith(googleAuthUserAgent())
+    expect(setUserAgent).not.toHaveBeenCalled()
+    expect(sendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+      userAgent: googleAuthUserAgent()
+    })
 
-    // A redirect off the auth host must derive the CDP write from the session UA, not the stale
-    // Firefox WebContents UA installed by the direct navigation.
+    // A redirect off the auth host must derive the CDP write from the session UA, not the standing
+    // Firefox CDP override installed by the direct navigation.
     sendCommand.mockClear()
     willRedirect(null, 'https://myaccount.google.com/', false, true)
     const uaOverrideIndex = sendCommand.mock.calls.findIndex(
@@ -555,9 +558,9 @@ describe('browserManager', () => {
     )
   })
 
-  // Why: a direct load reaches did-start-navigation before the request is dispatched, so the
-  // WebContents write is safe there and must stay — CDP is the redirect-path mechanism only.
-  it('still uses the WebContents UA write for navigations that are not redirects', () => {
+  // Why: WebContents.setUserAgent() after a direct navigation starts replays that document and all
+  // of its subresources. The auth identity must use the cancel-free CDP path for direct loads too.
+  it('retargets direct auth navigation over CDP without writing the WebContents UA', () => {
     const guest = {
       id: 420,
       isDestroyed: vi.fn(() => false),
@@ -587,18 +590,14 @@ describe('browserManager', () => {
 
     didStartNavigation(null, 'https://accounts.google.com/v3/signin/identifier', false, true)
 
-    expect(guest.setUserAgent).toHaveBeenLastCalledWith(googleAuthUserAgent())
-    expect(guest.debugger.sendCommand).not.toHaveBeenCalledWith(
-      'Emulation.setUserAgentOverride',
-      expect.anything()
-    )
+    expect(guest.setUserAgent).not.toHaveBeenCalled()
+    expect(guest.debugger.sendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+      userAgent: googleAuthUserAgent()
+    })
   })
 
-  // Why: the direct-navigation branch still writes the Firefox UA through WebContents.setUserAgent,
-  // and nothing ever restores it once the guest switches to the CDP override. A viewport preset that
-  // read getUserAgent() back as its base identity would therefore republish Firefox on every ordinary
-  // host — the wire UA saying Firefox while sec-ch-ua still says Chrome, the exact cross-layer tell
-  // this scope exists to remove.
+  // Why: a viewport preset must derive its base from the session identity, independent of the
+  // standing auth CDP override, or it can republish Firefox on an ordinary host.
   it('keeps a viewport preset on the session identity after an auth-host visit', async () => {
     const { guest, debuggerSendCommand } = makeViewportGuest(9001)
     webContentsFromIdMock.mockReturnValue(guest)
@@ -625,8 +624,10 @@ describe('browserManager', () => {
 
     didStartNavigation(null, 'https://accounts.google.com/v3/signin/identifier', false, true)
     await flushViewportOps()
-    // The direct branch pins the WebContents UA to Firefox and never restores it.
-    expect((guest.getUserAgent as () => string)()).toBe(googleAuthUserAgent())
+    expect(guest.setUserAgent).not.toHaveBeenCalled()
+    expect(debuggerSendCommand).toHaveBeenLastCalledWith('Emulation.setUserAgentOverride', {
+      userAgent: googleAuthUserAgent()
+    })
 
     willRedirect({ preventDefault: vi.fn() }, 'https://myaccount.google.com/', false, true)
     await flushViewportOps()

--- a/src/main/browser/browser-manager-guest-navigation-policy.ts
+++ b/src/main/browser/browser-manager-guest-navigation-policy.ts
@@ -35,7 +35,7 @@ export abstract class BrowserManagerGuestNavigationPolicy extends BrowserManager
         return
       }
       this.updatePendingNavigationForRedirect(guest.id, url)
-      this.applyGoogleAuthUserAgent(guest, url, { duringRedirect: true })
+      this.applyGoogleAuthUserAgent(guest, url)
     }
 
     const didFailLoadHandler = (

--- a/src/main/browser/browser-manager-navigation.ts
+++ b/src/main/browser/browser-manager-navigation.ts
@@ -5,7 +5,10 @@ import {
 } from './browser-session-ua'
 import { getBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
 import { googleAuthUserAgent, isGoogleAuthUrl } from './browser-google-auth-ua'
-import { buildViewportUserAgentOverride } from './browser-viewport-user-agent'
+import {
+  buildViewportUserAgentOverride,
+  type ViewportUserAgentOverride
+} from './browser-viewport-user-agent'
 import {
   safeOrigin,
   type AuthUserAgentOverrideOperation,
@@ -17,7 +20,7 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
   /** Resolve the one legacy User-Agent value the session hook must enforce for this guest request. */
   resolveBrowserGuestRequestUserAgent(
     request: Parameters<BrowserSessionRequestUserAgentResolver>[0]
-  ): string {
+  ): ViewportUserAgentOverride {
     const firefoxUa = googleAuthUserAgent()
     const pendingNavigation =
       request.webContentsId === undefined
@@ -29,7 +32,7 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
       request.currentUserAgent === firefoxUa &&
       (!pendingNavigation || isGoogleAuthUrl(pendingNavigation.currentUrl))
     ) {
-      return firefoxUa
+      return { userAgent: firefoxUa }
     }
     const overrideState =
       request.webContentsId === undefined
@@ -47,10 +50,10 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
     ) {
       // Direct auth navigations use WebContents.setUserAgent, which Electron fails to carry onto
       // image/XHR/fetch requests. Read that effective guest identity so those paths stay Firefox.
-      return firefoxUa
+      return { userAgent: firefoxUa }
     }
     if (currentOverride?.userAgent === firefoxUa) {
-      return firefoxUa
+      return { userAgent: firefoxUa }
     }
     const browserPageId =
       request.webContentsId === undefined
@@ -58,12 +61,12 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
         : this.tabIdByWebContentsId.get(request.webContentsId)
     const mobile = browserPageId
       ? (this.viewportUaOverrideMobileByTabId.get(browserPageId) ?? false)
-      : false
+      : this.hasSessionMobileViewportIntent(request.session)
     return buildViewportUserAgentOverride({
       url: request.url,
       mobile,
       baseUserAgent: cleanElectronUserAgent(request.baseUserAgent)
-    }).userAgent
+    })
   }
 
   // Why: navigator.userAgent (read by Google's auth JS) reflects the WebContents UA,

--- a/src/main/browser/browser-manager-navigation.ts
+++ b/src/main/browser/browser-manager-navigation.ts
@@ -74,11 +74,7 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
   // must be matched here per navigation or the two layers disagree — itself a bot tell.
   // Restores the session's base identity off the auth hosts. Native-UA profiles opt out
   // of the whole clean-UA path, so they keep their untouched identity everywhere.
-  protected applyGoogleAuthUserAgent(
-    guest: Electron.WebContents,
-    url: string,
-    options: { duringRedirect?: boolean } = {}
-  ): void {
+  protected applyGoogleAuthUserAgent(guest: Electron.WebContents, url: string): void {
     const browserPageId = this.tabIdByWebContentsId.get(guest.id)
     // Why: popup child windows get these policies but are never in tabIdByWebContentsId, so a direct
     // lookup misses the native-UA opt-out and would hand a native profile's popup the Firefox UA.
@@ -110,32 +106,24 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
         : null
     let authOverrideIssuedOverCdp = false
     if (nextUa !== null && nextUa !== currentUa) {
-      // Why: WebContents.setUserAgent() during a redirect makes Chromium cancel the in-flight
-      // navigation (ERR_ABORTED) and replay the original request, which a POST-started OAuth chain
-      // cannot survive — the sign-in lands on a blank tab. CDP retargets navigator.userAgent without
-      // touching the navigation, and it outranks the WebContents UA from then on, so a guest that
-      // switches to it stays on it. The wire UA never depended on this write:
-      // setupGoogleAuthUserAgentOverride rewrites User-Agent per request for auth-host URLs on its own.
-      if (options.duringRedirect === true || overrideState !== undefined) {
-        if (this.canOverrideUserAgentOverCdp(guest)) {
-          authOverrideIssuedOverCdp = true
-          // Why: go through the viewport builder rather than writing nextUa raw, so both CDP writers
-          // resolve one identity for this URL — Firefox on auth hosts, the profile's clean base off
-          // them, any mobile preset preserved. Writing the session UA directly would put the
-          // unlaundered Electron token back on the wire.
-          void this.applyAuthUserAgentOverrideOverCdp(
-            guest,
-            (browserPageId ? this.viewportUaOverrideMobileByTabId.get(browserPageId) : undefined) ??
-              false,
-            url,
-            nextUa
-          )
-        }
-        // Why: with no debugger there is no way to retarget the identity without cancelling the
-        // redirect. A stale navigator.userAgent is recoverable; a dead navigation is not.
-      } else {
-        guest.setUserAgent(nextUa)
+      // Why: WebContents.setUserAgent() after navigation starts cancels and replays the document,
+      // including direct loads. CDP retargets navigator.userAgent without duplicating its requests.
+      if (this.ensureAuthUserAgentDebugger(guest)) {
+        authOverrideIssuedOverCdp = true
+        // Why: go through the viewport builder rather than writing nextUa raw, so both CDP writers
+        // resolve one identity for this URL — Firefox on auth hosts, the profile's clean base off
+        // them, any mobile preset preserved. Writing the session UA directly would put the
+        // unlaundered Electron token back on the wire.
+        void this.applyAuthUserAgentOverrideOverCdp(
+          guest,
+          (browserPageId ? this.viewportUaOverrideMobileByTabId.get(browserPageId) : undefined) ??
+            false,
+          url,
+          nextUa
+        )
       }
+      // Why: with no debugger there is no cancel-free way to retarget navigator.userAgent. The
+      // request layer still presents Firefox; a stale JS value is preferable to replaying the page.
     }
     // Why: gate on the DIRECT page id, not ownerTabId — a popup has no device-metrics override of
     // its own, so inheriting the owner tab's preset UA would pair a mobile UA with a desktop viewport.
@@ -144,9 +132,15 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
     }
   }
 
-  protected canOverrideUserAgentOverCdp(guest: Electron.WebContents): boolean {
+  protected ensureAuthUserAgentDebugger(guest: Electron.WebContents): boolean {
     try {
-      return !guest.isDestroyed() && guest.debugger.isAttached()
+      if (guest.isDestroyed()) {
+        return false
+      }
+      if (!guest.debugger.isAttached()) {
+        guest.debugger.attach('1.3')
+      }
+      return true
     } catch {
       return false
     }
@@ -158,7 +152,7 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
     url: string,
     userAgent: string
   ): Promise<boolean> {
-    if (!this.canOverrideUserAgentOverCdp(guest)) {
+    if (!this.ensureAuthUserAgentDebugger(guest)) {
       return Promise.resolve(false)
     }
     const state = this.authUserAgentOverrideStateByGuestId.get(guest.id) ?? {
@@ -277,8 +271,8 @@ export abstract class BrowserManagerNavigation extends BrowserManagerVisibility 
       buildViewportUserAgentOverride({
         url: url ?? this.resolveTabNavigationUrl(guest),
         mobile,
-        // Why: the session UA is the profile's stable base identity. guest.getUserAgent() is not:
-        // applyGoogleAuthUserAgent leaves it pinned to the Firefox auth UA once a guest switches to
+        // Why: the session UA is the profile's stable base identity. guest.getUserAgent() does not
+        // expose the standing CDP auth override once a guest switches to
         // the CDP override, so reading it back here would republish that identity on ordinary hosts.
         baseUserAgent: cleanElectronUserAgent(baseUserAgent ?? guest.session.getUserAgent())
       })

--- a/src/main/browser/browser-manager-navigation.ts
+++ b/src/main/browser/browser-manager-navigation.ts
@@ -1,5 +1,8 @@
 import { openPopupWithOriginBar, type PopupChildWindowOptions } from './popup-origin-bar-window'
-import { cleanElectronUserAgent } from './browser-session-ua'
+import {
+  cleanElectronUserAgent,
+  type BrowserSessionRequestUserAgentResolver
+} from './browser-session-ua'
 import { getBrowserSessionUserAgentMode } from './browser-session-user-agent-mode'
 import { googleAuthUserAgent, isGoogleAuthUrl } from './browser-google-auth-ua'
 import { buildViewportUserAgentOverride } from './browser-viewport-user-agent'
@@ -11,6 +14,58 @@ import {
 import { BrowserManagerVisibility } from './browser-manager-visibility'
 
 export abstract class BrowserManagerNavigation extends BrowserManagerVisibility {
+  /** Resolve the one legacy User-Agent value the session hook must enforce for this guest request. */
+  resolveBrowserGuestRequestUserAgent(
+    request: Parameters<BrowserSessionRequestUserAgentResolver>[0]
+  ): string {
+    const firefoxUa = googleAuthUserAgent()
+    const pendingNavigation =
+      request.webContentsId === undefined
+        ? undefined
+        : this.pendingNavigationByGuestId.get(request.webContentsId)
+    // A navigation on the auth document fans out to non-auth hosts. Its current request identity
+    // is authoritative for that flow and must not be replaced by the profile/mobile default.
+    if (
+      request.currentUserAgent === firefoxUa &&
+      (!pendingNavigation || isGoogleAuthUrl(pendingNavigation.currentUrl))
+    ) {
+      return firefoxUa
+    }
+    const overrideState =
+      request.webContentsId === undefined
+        ? undefined
+        : this.authUserAgentOverrideStateByGuestId.get(request.webContentsId)
+    const currentOverride =
+      overrideState?.pending.at(-1) &&
+      overrideState.pending.at(-1)!.sequence > (overrideState.confirmed?.sequence ?? -1)
+        ? overrideState.pending.at(-1)
+        : overrideState?.confirmed
+    if (
+      !currentOverride &&
+      request.effectiveUserAgent === firefoxUa &&
+      (!pendingNavigation || isGoogleAuthUrl(pendingNavigation.currentUrl))
+    ) {
+      // Direct auth navigations use WebContents.setUserAgent, which Electron fails to carry onto
+      // image/XHR/fetch requests. Read that effective guest identity so those paths stay Firefox.
+      return firefoxUa
+    }
+    if (currentOverride?.userAgent === firefoxUa) {
+      return firefoxUa
+    }
+    const browserPageId =
+      request.webContentsId === undefined
+        ? undefined
+        : this.tabIdByWebContentsId.get(request.webContentsId)
+    const mobile = browserPageId
+      ? (this.viewportUaOverrideMobileByTabId.get(browserPageId) ?? false)
+      : false
+    return buildViewportUserAgentOverride({
+      url: request.url,
+      mobile,
+      baseUserAgent: cleanElectronUserAgent(request.baseUserAgent)
+    }).userAgent
+  }
+
   // Why: navigator.userAgent (read by Google's auth JS) reflects the WebContents UA,
   // not the request header, so the header-level Firefox switch in setupGoogleAuthUserAgentOverride
   // must be matched here per navigation or the two layers disagree — itself a bot tell.

--- a/src/main/browser/browser-manager-registration.ts
+++ b/src/main/browser/browser-manager-registration.ts
@@ -48,6 +48,7 @@ export abstract class BrowserManagerRegistration extends BrowserManagerGuestPoli
     const previousWebContentsId = this.webContentsIdByTabId.get(browserTabId)
     if (previousWebContentsId !== undefined && previousWebContentsId !== webContentsId) {
       this.retireStaleGuestWebContents(previousWebContentsId)
+      this.clearSessionMobileViewportIntent(browserTabId)
       this.viewportPresetActiveByTabId.delete(browserTabId)
       this.viewportScrollStateByTabId.delete(browserTabId)
     }
@@ -61,6 +62,10 @@ export abstract class BrowserManagerRegistration extends BrowserManagerGuestPoli
       this.userAgentModeByPageId.set(browserTabId, userAgentMode)
     } else {
       this.userAgentModeByPageId.delete(browserTabId)
+    }
+    if (userAgentMode === 'native') {
+      this.clearSessionMobileViewportIntent(browserTabId)
+      this.viewportUaOverrideMobileByTabId.delete(browserTabId)
     }
     this.rendererWebContentsIdByTabId.set(browserTabId, rendererWebContentsId)
     if (worktreeId) {
@@ -133,6 +138,7 @@ export abstract class BrowserManagerRegistration extends BrowserManagerGuestPoli
     this.worktreeIdByTabId.delete(browserTabId)
     // Why: drop the viewport-op chain so the Map doesn't retain a promise keyed to a destroyed guest.
     this.viewportOpsByTabId.delete(browserTabId)
+    this.clearSessionMobileViewportIntent(browserTabId)
     this.viewportUaOverrideMobileByTabId.delete(browserTabId)
     this.viewportPresetActiveByTabId.delete(browserTabId)
     this.viewportScrollStateByTabId.delete(browserTabId)
@@ -171,6 +177,7 @@ export abstract class BrowserManagerRegistration extends BrowserManagerGuestPoli
     const previousWebContentsId = this.webContentsIdByTabId.get(browserPageId)
     if (previousWebContentsId !== undefined && previousWebContentsId !== webContentsId) {
       this.retireStaleGuestWebContents(previousWebContentsId)
+      this.clearSessionMobileViewportIntent(browserPageId)
       this.viewportPresetActiveByTabId.delete(browserPageId)
       this.viewportScrollStateByTabId.delete(browserPageId)
     }
@@ -181,6 +188,10 @@ export abstract class BrowserManagerRegistration extends BrowserManagerGuestPoli
       this.userAgentModeByPageId.set(browserPageId, userAgentMode)
     } else {
       this.userAgentModeByPageId.delete(browserPageId)
+    }
+    if (userAgentMode === 'native') {
+      this.clearSessionMobileViewportIntent(browserPageId)
+      this.viewportUaOverrideMobileByTabId.delete(browserPageId)
     }
     if (worktreeId) {
       this.worktreeIdByTabId.set(browserPageId, worktreeId)
@@ -213,6 +224,7 @@ export abstract class BrowserManagerRegistration extends BrowserManagerGuestPoli
     this.sessionProfileIdByPageId.clear()
     this.userAgentModeByPageId.clear()
     this.viewportUaOverrideMobileByTabId.clear()
+    this.mobileViewportTabIdsBySession.clear()
     this.viewportPresetActiveByTabId.clear()
     this.viewportScrollStateByTabId.clear()
     this.authUserAgentOverrideStateByGuestId.clear()

--- a/src/main/browser/browser-manager-state.ts
+++ b/src/main/browser/browser-manager-state.ts
@@ -129,6 +129,9 @@ export abstract class BrowserManagerState extends BrowserManagerViewportScrollSt
   // Why: presence means the preset requires a CDP UA override (installed or in flight), so navigation
   // can re-issue it against the target URL's identity.
   protected readonly viewportUaOverrideMobileByTabId = new Map<string, boolean>()
+  // Worker requests omit webContentsId, so retain the mobile intent at the Session boundary where
+  // webRequest can still resolve it. Values contain only live tabs and are cleared with registration.
+  protected readonly mobileViewportTabIdsBySession = new Map<Electron.Session, Set<string>>()
   // Why: the confirmed CDP identity outranks getUserAgent; pending intent keeps rapid navigations
   // ordered without claiming a failed write was installed.
   protected readonly authUserAgentOverrideStateByGuestId = new Map<
@@ -162,6 +165,33 @@ export abstract class BrowserManagerState extends BrowserManagerViewportScrollSt
   protected readonly pendingDownloadIdsByGuestId = new Map<number, string[]>()
   protected readonly downloadsById = new Map<string, ActiveDownload>()
   protected readonly grabSessionController = new BrowserGrabSessionController()
+
+  protected setSessionMobileViewportIntent(
+    browserTabId: string,
+    session: Electron.Session,
+    mobile: boolean
+  ): void {
+    this.clearSessionMobileViewportIntent(browserTabId)
+    if (!mobile) {
+      return
+    }
+    const tabIds = this.mobileViewportTabIdsBySession.get(session) ?? new Set<string>()
+    tabIds.add(browserTabId)
+    this.mobileViewportTabIdsBySession.set(session, tabIds)
+  }
+
+  protected clearSessionMobileViewportIntent(browserTabId: string): void {
+    for (const [session, tabIds] of this.mobileViewportTabIdsBySession) {
+      tabIds.delete(browserTabId)
+      if (tabIds.size === 0) {
+        this.mobileViewportTabIdsBySession.delete(session)
+      }
+    }
+  }
+
+  protected hasSessionMobileViewportIntent(session: Electron.Session): boolean {
+    return (this.mobileViewportTabIdsBySession.get(session)?.size ?? 0) > 0
+  }
 
   setDictationShortcutForwardingPredicate(predicate: (() => boolean) | null): void {
     this.shouldForwardDictationShortcut = predicate

--- a/src/main/browser/browser-manager-viewport-override.test.ts
+++ b/src/main/browser/browser-manager-viewport-override.test.ts
@@ -49,8 +49,7 @@ import {
 import {
   createViewportGuestFactory,
   flushViewportOps,
-  GUEST_CLEAN_UA,
-  GUEST_ELECTRON_UA
+  GUEST_CLEAN_UA
 } from './browser-manager-viewport-test-fixtures'
 
 const { guestOnMock, webContentsFromIdMock } = browserMocks
@@ -377,7 +376,7 @@ describe('browserManager', () => {
       didFailLoad(null, -3, 'Aborted', 'https://accounts.google.com/', true)
       await flushViewportOps()
 
-      expect(guest.setUserAgent).toHaveBeenLastCalledWith(GUEST_ELECTRON_UA)
+      expect(guest.setUserAgent).not.toHaveBeenCalled()
       expect(lastUserAgentOverride(debuggerSendCommand)).toEqual({ userAgent: GUEST_CLEAN_UA })
 
       // A later preset must also resolve the committed, non-auth URL.
@@ -636,7 +635,7 @@ describe('browserManager', () => {
       await presetDone
     })
 
-    it('does not reinstall a preset while its final UA clear is in flight', async () => {
+    it('preserves the auth-owned UA while a preset UA clear is in flight', async () => {
       const { guest, debuggerSendCommand } = makeGuest(4258, 'https://example.com/')
       webContentsFromIdMock.mockReturnValue(guest)
       browserManager.attachGuestPolicies(guest as never)
@@ -671,7 +670,7 @@ describe('browserManager', () => {
       debuggerSendCommand.mockClear()
       didStartNavigation(null, 'https://accounts.google.com/', false, true)
       await flushViewportOps()
-      expect(debuggerSendCommand).not.toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+      expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
         userAgent: googleAuthUserAgent()
       })
 
@@ -725,7 +724,7 @@ describe('browserManager', () => {
       })
     })
 
-    it('does not touch the UA override on navigation when no preset is standing', async () => {
+    it('applies the auth-owned UA on navigation when no preset is standing', async () => {
       const { guest, debuggerSendCommand } = makeGuest(4248)
       webContentsFromIdMock.mockReturnValue(guest)
       browserManager.attachGuestPolicies(guest as never)
@@ -740,13 +739,12 @@ describe('browserManager', () => {
 
       didStartNavigation(null, 'https://accounts.google.com/', false, true)
       await flushViewportOps()
-      expect(debuggerSendCommand).not.toHaveBeenCalledWith(
-        'Emulation.setUserAgentOverride',
-        expect.anything()
-      )
+      expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+        userAgent: googleAuthUserAgent()
+      })
     })
 
-    it('stops re-issuing the UA override once the preset is cleared', async () => {
+    it('keeps applying the auth-owned UA once the preset is cleared', async () => {
       const { guest, debuggerSendCommand } = makeGuest(4249)
       webContentsFromIdMock.mockReturnValue(guest)
       browserManager.attachGuestPolicies(guest as never)
@@ -770,10 +768,9 @@ describe('browserManager', () => {
       debuggerSendCommand.mockClear()
       didStartNavigation(null, 'https://accounts.google.com/', false, true)
       await flushViewportOps()
-      expect(debuggerSendCommand).not.toHaveBeenCalledWith(
-        'Emulation.setUserAgentOverride',
-        expect.anything()
-      )
+      expect(debuggerSendCommand).toHaveBeenCalledWith('Emulation.setUserAgentOverride', {
+        userAgent: googleAuthUserAgent()
+      })
     })
 
     it('leaves the UA override alone on navigation for native-UA profiles', async () => {

--- a/src/main/browser/browser-manager-viewport.ts
+++ b/src/main/browser/browser-manager-viewport.ts
@@ -167,6 +167,7 @@ export abstract class BrowserManagerViewport extends BrowserManagerDownloadLifec
         if (this.userAgentModeByPageId.get(browserTabId) !== 'native') {
           // Navigation must see the preset intent while the final CDP command is in flight.
           this.viewportUaOverrideMobileByTabId.set(browserTabId, override.mobile)
+          this.setSessionMobileViewportIntent(browserTabId, guest.session, override.mobile)
           // Why: same sender as the navigation path, so both resolve the tab's host identically.
           await this.sendViewportUserAgentOverride(guest, override.mobile)
         }
@@ -185,6 +186,7 @@ export abstract class BrowserManagerViewport extends BrowserManagerDownloadLifec
         const trackedMobile = this.viewportUaOverrideMobileByTabId.get(browserTabId)
         // A navigation after this point must not re-install the override behind the clear.
         this.viewportUaOverrideMobileByTabId.delete(browserTabId)
+        this.clearSessionMobileViewportIntent(browserTabId)
         try {
           if (this.authUserAgentOverrideStateByGuestId.has(guest.id)) {
             const url = this.resolveTabNavigationUrl(guest)
@@ -204,6 +206,7 @@ export abstract class BrowserManagerViewport extends BrowserManagerDownloadLifec
         } catch (error) {
           if (trackedMobile !== undefined) {
             this.viewportUaOverrideMobileByTabId.set(browserTabId, trackedMobile)
+            this.setSessionMobileViewportIntent(browserTabId, guest.session, trackedMobile)
           }
           throw error
         }

--- a/src/main/browser/browser-session-partition-policies.ts
+++ b/src/main/browser/browser-session-partition-policies.ts
@@ -95,7 +95,9 @@ export function installBrowserSessionPartitionPolicies(
   if (profile.userAgentMode !== 'native' && typeof sess.getUserAgent === 'function') {
     const cleanUA = cleanElectronUserAgent(sess.getUserAgent())
     sess.setUserAgent(cleanUA)
-    setupGoogleAuthUserAgentOverride(sess)
+    setupGoogleAuthUserAgentOverride(sess, (request) =>
+      browserManager.resolveBrowserGuestRequestUserAgent(request)
+    )
   }
   if (options?.permissions === 'deny') {
     sess.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false))
@@ -195,7 +197,9 @@ export function applyBrowserSessionUserAgentModes(profiles: BrowserSessionProfil
       // Why: imported sessions need the same Chrome-shaped identity after app restart.
       const cleanUA = cleanElectronUserAgent(sess.getUserAgent())
       sess.setUserAgent(cleanUA)
-      setupGoogleAuthUserAgentOverride(sess)
+      setupGoogleAuthUserAgentOverride(sess, (request) =>
+        browserManager.resolveBrowserGuestRequestUserAgent(request)
+      )
     } catch {
       /* session not available yet (e.g. unit tests or pre-ready) */
     }

--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -255,7 +255,10 @@ describe('BrowserSessionRegistry persistence', () => {
     const profileSession = sessionFromPartitionMock.mock.results.at(-1)?.value
     expect(cleanElectronUserAgentMock).toHaveBeenCalledWith(RAW_ELECTRON_USER_AGENT)
     expect(profileSession.setUserAgent).toHaveBeenCalledWith(CLEAN_USER_AGENT)
-    expect(setupGoogleAuthUserAgentOverrideMock).toHaveBeenCalledWith(profileSession)
+    expect(setupGoogleAuthUserAgentOverrideMock).toHaveBeenCalledWith(
+      profileSession,
+      expect.any(Function)
+    )
   })
 
   it('leaves UA and client hints untouched for native-mode profiles', async () => {

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -608,6 +608,46 @@ describe('BrowserSessionRegistry', () => {
       expect(modified['sec-ch-ua-mobile']).toBeUndefined()
     })
 
+    it('presents the Firefox identity on cross-host subresources referred by Google auth', () => {
+      const callback = vi.fn()
+      install()(
+        {
+          url: 'https://www.gstatic.com/accounts/signin.js',
+          referrer: 'https://accounts.google.com/v3/signin/identifier',
+          resourceType: 'script',
+          requestHeaders: {
+            'User-Agent': 'Chrome/150',
+            'sec-ch-ua': 'browser-owned',
+            'sec-ch-ua-platform': '"macOS"'
+          }
+        },
+        callback
+      )
+
+      const modified = callback.mock.calls[0][0].requestHeaders
+      expect(modified['User-Agent']).toBe(googleAuthUserAgent())
+      expect(modified['sec-ch-ua']).toBeUndefined()
+      expect(modified['sec-ch-ua-platform']).toBeUndefined()
+    })
+
+    it('keeps the session identity on a post-auth main frame referred by Google auth', () => {
+      const callback = vi.fn()
+      install()(
+        {
+          url: 'https://mail.google.com/',
+          referrer: 'https://accounts.google.com/v3/signin/identifier',
+          resourceType: 'mainFrame',
+          requestHeaders: { 'User-Agent': 'Chrome/150', 'sec-ch-ua': 'browser-owned' }
+        },
+        callback
+      )
+
+      expect(callback.mock.calls[0][0].requestHeaders).toEqual({
+        'User-Agent': 'Chrome/150',
+        'sec-ch-ua': 'browser-owned'
+      })
+    })
+
     it('keeps the session identity on Google app subdomains', () => {
       const callback = vi.fn()
       install()(

--- a/src/main/browser/browser-session-ua.test.ts
+++ b/src/main/browser/browser-session-ua.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { googleAuthUserAgent } from './browser-google-auth-ua'
 import { cleanElectronUserAgent, setupGoogleAuthUserAgentOverride } from './browser-session-ua'
+import { buildViewportUserAgentOverride } from './browser-viewport-user-agent'
 
 type RequestDetails = {
   url: string
@@ -34,15 +35,23 @@ function runRequest(listener: RequestListener, details: RequestDetails): Record<
 }
 
 describe('browser session request identity', () => {
-  it('ablates the resolver on an image request while enforcing its per-guest value when enabled', () => {
-    const mobileUa =
-      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/134.0.0.0 Mobile/15E148 Safari/604.1'
+  it('ablates the resolver on a worker request while enforcing its mobile identity when enabled', () => {
+    const mobileIdentity = buildViewportUserAgentOverride({
+      url: 'https://example.com/worker-beacon',
+      mobile: true,
+      baseUserAgent: 'Chrome/134.0.0.0'
+    })
     const request = {
-      url: 'https://example.com/logo.png',
-      webContentsId: 44,
+      url: 'https://example.com/worker-beacon',
       requestHeaders: {
         'User-Agent': 'Electron/30 Chrome/134',
-        'sec-ch-ua': 'browser-owned'
+        'sec-ch-ua': 'desktop brands',
+        'sec-ch-ua-full-version-list': 'desktop versions',
+        'sec-ch-ua-platform': '"macOS"',
+        'sec-ch-ua-platform-version': '"15.0.0"',
+        'sec-ch-ua-mobile': '?0',
+        'sec-ch-ua-model': '""',
+        'sec-ch-ua-form-factors': '"Desktop"'
       }
     }
 
@@ -53,19 +62,27 @@ describe('browser session request identity', () => {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) orca/1.0.0 Chrome/134.0.0.0 Electron/30.0.0 Safari/537.36'
       )
     )
+    expect(disabled['sec-ch-ua-platform']).toBe('"macOS"')
 
-    const resolver = vi.fn(() => mobileUa)
+    const resolver = vi.fn(() => mobileIdentity)
     const enabled = runRequest(install(resolver), structuredClone(request))
-    expect(enabled['User-Agent']).toBe(mobileUa)
+    expect(enabled['User-Agent']).toBe(mobileIdentity.userAgent)
     expect(resolver).toHaveBeenCalledWith(
-      expect.objectContaining({ url: request.url, webContentsId: request.webContentsId })
+      expect.objectContaining({ url: request.url, webContentsId: undefined })
     )
-    // Negative control: the resolver does not alter Chromium-owned client hints.
-    expect(enabled['sec-ch-ua']).toBe('browser-owned')
+    expect(enabled['sec-ch-ua']).toContain('"Google Chrome";v="134"')
+    expect(enabled['sec-ch-ua-full-version-list']).toContain('"Google Chrome";v="134.0.0.0"')
+    expect(enabled['sec-ch-ua-platform']).toBe('"iOS"')
+    expect(enabled['sec-ch-ua-platform-version']).toBe('"17.0"')
+    expect(enabled['sec-ch-ua-mobile']).toBe('?1')
+    expect(enabled['sec-ch-ua-model']).toBe('"iPhone"')
+    expect(enabled['sec-ch-ua-form-factors']).toBeUndefined()
   })
 
   it('keeps Firefox across auth-document cross-host requests and strips its hints', () => {
-    const listener = install(({ effectiveUserAgent }) => effectiveUserAgent)
+    const listener = install(({ effectiveUserAgent }) =>
+      effectiveUserAgent ? { userAgent: effectiveUserAgent } : undefined
+    )
     const headers = runRequest(listener, {
       url: 'https://www.gstatic.com/_/signin/log',
       webContentsId: 7,
@@ -82,7 +99,7 @@ describe('browser session request identity', () => {
   })
 
   it('keeps the Firefox auth-host branch independent of the resolver', () => {
-    const resolver = vi.fn(() => 'unexpected Chrome identity')
+    const resolver = vi.fn(() => ({ userAgent: 'unexpected Chrome identity' }))
     const headers = runRequest(install(resolver), {
       url: 'https://accounts.google.com/v3/signin/identifier',
       requestHeaders: {

--- a/src/main/browser/browser-session-ua.test.ts
+++ b/src/main/browser/browser-session-ua.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest'
+import { googleAuthUserAgent } from './browser-google-auth-ua'
+import { cleanElectronUserAgent, setupGoogleAuthUserAgentOverride } from './browser-session-ua'
+
+type RequestDetails = {
+  url: string
+  webContentsId?: number
+  webContents?: { getUserAgent: () => string }
+  requestHeaders: Record<string, string>
+}
+
+type RequestListener = (
+  details: RequestDetails,
+  callback: (response: { requestHeaders: Record<string, string> }) => void
+) => void
+
+function install(resolveRequestUserAgent?: Parameters<typeof setupGoogleAuthUserAgentOverride>[1]) {
+  const onBeforeSendHeaders = vi.fn()
+  const sess = {
+    getUserAgent: vi.fn(
+      () =>
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) orca/1.0.0 Chrome/134.0.0.0 Electron/30.0.0 Safari/537.36'
+    ),
+    webRequest: { onBeforeSendHeaders }
+  }
+  setupGoogleAuthUserAgentOverride(sess as never, resolveRequestUserAgent)
+  return onBeforeSendHeaders.mock.calls[0][1] as RequestListener
+}
+
+function runRequest(listener: RequestListener, details: RequestDetails): Record<string, string> {
+  const callback = vi.fn()
+  listener(details, callback)
+  return callback.mock.calls[0][0].requestHeaders
+}
+
+describe('browser session request identity', () => {
+  it('ablates the resolver on an image request while enforcing its per-guest value when enabled', () => {
+    const mobileUa =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/134.0.0.0 Mobile/15E148 Safari/604.1'
+    const request = {
+      url: 'https://example.com/logo.png',
+      webContentsId: 44,
+      requestHeaders: {
+        'User-Agent': 'Electron/30 Chrome/134',
+        'sec-ch-ua': 'browser-owned'
+      }
+    }
+
+    // Ablation: with the new resolver disabled, the clean session identity is the only fallback.
+    const disabled = runRequest(install(), structuredClone(request))
+    expect(disabled['User-Agent']).toBe(
+      cleanElectronUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) orca/1.0.0 Chrome/134.0.0.0 Electron/30.0.0 Safari/537.36'
+      )
+    )
+
+    const resolver = vi.fn(() => mobileUa)
+    const enabled = runRequest(install(resolver), structuredClone(request))
+    expect(enabled['User-Agent']).toBe(mobileUa)
+    expect(resolver).toHaveBeenCalledWith(
+      expect.objectContaining({ url: request.url, webContentsId: request.webContentsId })
+    )
+    // Negative control: the resolver does not alter Chromium-owned client hints.
+    expect(enabled['sec-ch-ua']).toBe('browser-owned')
+  })
+
+  it('keeps Firefox across auth-document cross-host requests and strips its hints', () => {
+    const listener = install(({ effectiveUserAgent }) => effectiveUserAgent)
+    const headers = runRequest(listener, {
+      url: 'https://www.gstatic.com/_/signin/log',
+      webContentsId: 7,
+      requestHeaders: {
+        'User-Agent': googleAuthUserAgent(),
+        'sec-ch-ua': 'browser-owned',
+        'sec-ch-ua-platform': '"macOS"'
+      },
+      webContents: { getUserAgent: () => googleAuthUserAgent() } as never
+    })
+    expect(headers['User-Agent']).toBe(googleAuthUserAgent())
+    expect(headers['sec-ch-ua']).toBeUndefined()
+    expect(headers['sec-ch-ua-platform']).toBeUndefined()
+  })
+
+  it('keeps the Firefox auth-host branch independent of the resolver', () => {
+    const resolver = vi.fn(() => 'unexpected Chrome identity')
+    const headers = runRequest(install(resolver), {
+      url: 'https://accounts.google.com/v3/signin/identifier',
+      requestHeaders: {
+        'User-Agent': 'Chrome/134',
+        'sec-ch-ua': 'browser-owned'
+      }
+    })
+    expect(headers['User-Agent']).toBe(googleAuthUserAgent())
+    expect(headers['sec-ch-ua']).toBeUndefined()
+    expect(resolver).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/browser/browser-session-ua.ts
+++ b/src/main/browser/browser-session-ua.ts
@@ -22,14 +22,38 @@ export function cleanElectronUserAgent(ua: string): string {
   )
 }
 
+export type BrowserSessionRequestUserAgentResolver = (args: {
+  url: string
+  webContentsId?: number
+  currentUserAgent?: string
+  effectiveUserAgent?: string
+  baseUserAgent: string
+}) => string | undefined
+
 // Why: Chromium already publishes one internally consistent client-hint identity through both
-// request headers and navigator.userAgentData. This handler only owns the host-scoped Firefox
-// exception; synthesizing Chrome brands here would make those two browser-owned surfaces disagree.
-export function setupGoogleAuthUserAgentOverride(sess: Session): void {
+// request headers and navigator.userAgentData. This handler owns the legacy User-Agent header on
+// the wire; synthesizing Chrome brands here would make those browser-owned surfaces disagree.
+export function setupGoogleAuthUserAgentOverride(
+  sess: Session,
+  resolveRequestUserAgent?: BrowserSessionRequestUserAgentResolver
+): void {
   const firefoxUa = googleAuthUserAgent()
 
   sess.webRequest.onBeforeSendHeaders({ urls: ['https://*/*'] }, (details, callback) => {
     const headers = details.requestHeaders
+    const requestUserAgent = currentUserAgent(headers)
+    let effectiveUserAgent: string | undefined
+    try {
+      effectiveUserAgent = details.webContents?.getUserAgent()
+    } catch {
+      // The request can race guest teardown; the header and manager state still provide a fallback.
+    }
+    // The resolver is supplied by the browser manager so this layer can enforce viewport and
+    // auth identities without importing manager state into the session policy (which would cycle).
+    const baseUserAgent =
+      typeof sess.getUserAgent === 'function'
+        ? cleanElectronUserAgent(sess.getUserAgent())
+        : (requestUserAgent ?? '')
     if (isGoogleAuthUrl(details.url)) {
       // Why: present a Firefox identity on Google's sign-in hosts so the user logs
       // in inside the app and Google issues self-refreshing bound cookies. Strip
@@ -39,7 +63,27 @@ export function setupGoogleAuthUserAgentOverride(sess: Session): void {
       callback({ requestHeaders: headers })
       return
     }
-    if (currentUserAgent(headers) === firefoxUa) {
+    const userAgent =
+      // Requests from an auth document fan out to gstatic and other non-auth hosts. Preserve the
+      // Firefox identity already placed on those requests instead of switching them to Chrome.
+      requestUserAgent === firefoxUa
+        ? firefoxUa
+        : resolveRequestUserAgent
+          ? (resolveRequestUserAgent({
+              url: details.url,
+              webContentsId: details.webContentsId,
+              currentUserAgent: requestUserAgent,
+              effectiveUserAgent,
+              baseUserAgent
+            }) ??
+            (baseUserAgent || requestUserAgent))
+          : effectiveUserAgent === firefoxUa
+            ? firefoxUa
+            : baseUserAgent || requestUserAgent
+    if (userAgent) {
+      setUserAgentHeader(headers, userAgent)
+    }
+    if (userAgent === firefoxUa) {
       // Why: while the auth document is on screen the WebContents UA is Firefox,
       // so its cross-host subresource/XHR requests (gstatic, play.google.com, the
       // sign-in challenge endpoints) reach here carrying the Firefox UA yet still

--- a/src/main/browser/browser-session-ua.ts
+++ b/src/main/browser/browser-session-ua.ts
@@ -1,4 +1,5 @@
 import type { Session } from 'electron'
+import type { ViewportUserAgentOverride } from './browser-viewport-user-agent'
 
 import {
   currentUserAgent,
@@ -23,22 +24,59 @@ export function cleanElectronUserAgent(ua: string): string {
 }
 
 export type BrowserSessionRequestUserAgentResolver = (args: {
+  session: Session
   url: string
   webContentsId?: number
   currentUserAgent?: string
   effectiveUserAgent?: string
   baseUserAgent: string
-}) => string | undefined
+}) => ViewportUserAgentOverride | undefined
 
-// Why: Chromium already publishes one internally consistent client-hint identity through both
-// request headers and navigator.userAgentData. This handler owns the legacy User-Agent header on
-// the wire; synthesizing Chrome brands here would make those browser-owned surfaces disagree.
+function quoteClientHint(value: string): string {
+  return `"${value.replace(/["\\]/g, '\\$&')}"`
+}
+
+function formatClientHintBrands(brands: { brand: string; version: string }[]): string {
+  return brands
+    .map(({ brand, version }) => `${quoteClientHint(brand)};v=${quoteClientHint(version)}`)
+    .join(', ')
+}
+
+function applyUserAgentMetadataHeaders(
+  headers: Record<string, string>,
+  metadata: NonNullable<ViewportUserAgentOverride['userAgentMetadata']>
+): void {
+  const values: Record<string, string> = {
+    'sec-ch-ua': formatClientHintBrands(metadata.brands),
+    'sec-ch-ua-full-version-list': formatClientHintBrands(metadata.fullVersionList),
+    'sec-ch-ua-full-version': quoteClientHint(metadata.fullVersion),
+    'sec-ch-ua-platform': quoteClientHint(metadata.platform),
+    'sec-ch-ua-platform-version': quoteClientHint(metadata.platformVersion),
+    'sec-ch-ua-arch': quoteClientHint(metadata.architecture),
+    'sec-ch-ua-model': quoteClientHint(metadata.model),
+    'sec-ch-ua-mobile': metadata.mobile ? '?1' : '?0'
+  }
+  for (const key of Object.keys(headers)) {
+    const lowerKey = key.toLowerCase()
+    if (!lowerKey.startsWith('sec-ch-ua')) {
+      continue
+    }
+    const value = values[lowerKey]
+    if (value === undefined) {
+      delete headers[key]
+    } else {
+      headers[key] = value
+    }
+  }
+}
+
+// Desktop client hints remain browser-owned. Mobile overrides carry the same metadata CDP used,
+// so worker requests can replace only hints Chromium already chose to emit without inventing them.
 export function setupGoogleAuthUserAgentOverride(
   sess: Session,
   resolveRequestUserAgent?: BrowserSessionRequestUserAgentResolver
 ): void {
   const firefoxUa = googleAuthUserAgent()
-
   sess.webRequest.onBeforeSendHeaders({ urls: ['https://*/*'] }, (details, callback) => {
     const headers = details.requestHeaders
     const requestUserAgent = currentUserAgent(headers)
@@ -63,27 +101,27 @@ export function setupGoogleAuthUserAgentOverride(
       callback({ requestHeaders: headers })
       return
     }
-    const userAgent =
+    const identity =
       // Requests from an auth document fan out to gstatic and other non-auth hosts. Preserve the
       // Firefox identity already placed on those requests instead of switching them to Chrome.
       requestUserAgent === firefoxUa
-        ? firefoxUa
+        ? { userAgent: firefoxUa }
         : resolveRequestUserAgent
           ? (resolveRequestUserAgent({
+              session: sess,
               url: details.url,
               webContentsId: details.webContentsId,
               currentUserAgent: requestUserAgent,
               effectiveUserAgent,
               baseUserAgent
-            }) ??
-            (baseUserAgent || requestUserAgent))
+            }) ?? { userAgent: baseUserAgent || requestUserAgent || '' })
           : effectiveUserAgent === firefoxUa
-            ? firefoxUa
-            : baseUserAgent || requestUserAgent
-    if (userAgent) {
-      setUserAgentHeader(headers, userAgent)
+            ? { userAgent: firefoxUa }
+            : { userAgent: baseUserAgent || requestUserAgent || '' }
+    if (identity.userAgent) {
+      setUserAgentHeader(headers, identity.userAgent)
     }
-    if (userAgent === firefoxUa) {
+    if (identity.userAgent === firefoxUa) {
       // Why: while the auth document is on screen the WebContents UA is Firefox,
       // so its cross-host subresource/XHR requests (gstatic, play.google.com, the
       // sign-in challenge endpoints) reach here carrying the Firefox UA yet still
@@ -94,6 +132,9 @@ export function setupGoogleAuthUserAgentOverride(
       stripClientHints(headers)
       callback({ requestHeaders: headers })
       return
+    }
+    if (identity.userAgentMetadata) {
+      applyUserAgentMetadataHeaders(headers, identity.userAgentMetadata)
     }
     callback({ requestHeaders: headers })
   })

--- a/src/main/browser/browser-session-ua.ts
+++ b/src/main/browser/browser-session-ua.ts
@@ -4,8 +4,8 @@ import type { ViewportUserAgentOverride } from './browser-viewport-user-agent'
 import {
   currentUserAgent,
   googleAuthUserAgent,
-  isGoogleAuthUrl,
   setUserAgentHeader,
+  shouldUseGoogleAuthIdentity,
   stripClientHints
 } from './browser-google-auth-ua'
 
@@ -92,10 +92,10 @@ export function setupGoogleAuthUserAgentOverride(
       typeof sess.getUserAgent === 'function'
         ? cleanElectronUserAgent(sess.getUserAgent())
         : (requestUserAgent ?? '')
-    if (isGoogleAuthUrl(details.url)) {
+    if (shouldUseGoogleAuthIdentity(details.url, details.referrer, details.resourceType)) {
       // Why: present a Firefox identity on Google's sign-in hosts so the user logs
-      // in inside the app and Google issues self-refreshing bound cookies. Strip
-      // sec-ch-ua* because real Firefox sends none.
+      // in inside the app and Google issues self-refreshing bound cookies. Auth-page
+      // subresources share that identity even before the WebContents override lands.
       setUserAgentHeader(headers, firefoxUa)
       stripClientHints(headers)
       callback({ requestHeaders: headers })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​310 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​275 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​249 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​50 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​199 |

<!-- /orca-pr-loc -->

## Summary

- Resolve and apply one browser identity to every request in a guest session, including Image, XHR, Fetch, worker, and service-worker traffic.
- Carry the active mobile preset identity into partition/session fallback handling for requests that have no `webContentsId`.
- Preserve the Firefox identity for early Google-auth subresources and use debugger navigation for the direct auth hop so Orca does not issue a duplicate request.

Closes #13822

## Failure mechanism

Electron `session.setUserAgent()` covered the document-oriented paths but did not cover every network path. Cloudflare therefore saw cleaned Chrome or CriOS on some requests and native Electron/Orca on others; the Turnstile failure followed that split identity, not the claimed browser family.

The first two commits fixed the Cloudflare paths. Validation then found a Google-auth race: 7 early `gstatic` resources escaped with cleaned Chrome before `did-start-navigation` applied Firefox. The final commit integrates the resolver/navigation mechanism from sibling commit `34f24fc2ff`, so auth-context subresources are classified immediately and the direct auth navigation is not replayed.

## Real-app evidence

All runs used the hidden real Orca Electron renderer through named Playwright CDP sessions. Counts below are deduplicated Cloudflare requests carrying a User-Agent; request volume varies because Cloudflare changes resources between loads.

| arm | UA-bearing requests | distinct UAs | identity counts | challenge host | blob-originated |
| --- | ---: | ---: | --- | --- | --- |
| `origin/main`, default | 104 | 2 | 41 cleaned Chrome + 63 native Electron/Orca | 16 cleaned + 62 native | 16 native |
| final branch, default | 86 | 1 | 86 cleaned Chrome | 7 cleaned | 1 cleaned |
| `origin/main`, mobile preset | 165 | 2 | 93 CriOS + 72 native Electron/Orca | 21 CriOS + 72 native | 18 native |
| final branch, mobile preset | 80 | 1 | 80 CriOS | 7 CriOS | 1 CriOS |

Resource-type breakdown:

- Main default: Document 17 cleaned; Script 3 cleaned; Fetch 19 cleaned + 17 native; XHR 2 cleaned + 31 native; Image 15 native.
- Final default: Document 2, Script 50, Font 3, Stylesheet 1, XHR 4, Fetch 22, Other 3, Image 1; every one cleaned Chrome.
- Main mobile: Document 20 CriOS; Script 50 CriOS; Font 3 CriOS; Stylesheet 1 CriOS; XHR 2 CriOS + 36 native; Fetch 15 CriOS + 18 native; Other 2 CriOS; Image 18 native.
- Final mobile: Document 2, Script 50, Font 3, Stylesheet 1, XHR 4, Fetch 17, Other 2, Image 1; every one CriOS.

The bounded final-head path trace recorded 86 per-guest and 2 partition/session-fallback requests in the default arm, then 81 per-guest and 1 fallback request in the mobile arm. Both arms exercised `https://dash.cloudflare.com/tether/sw.js` through the fallback without a guest ID; the mobile fallback carried CriOS, proving the worker case did not pass only because fallback stayed idle.

## Turnstile outcome

The arms were first interleaved before the Google regression integration: `origin/main` passed 0/5 and showed the literal verification error in 5/5, while the Cloudflare-fix lineage passed 5/5 with no error. After integrating the Google fix and rebasing on current `origin/main`, the final head was run through five fresh isolated profiles and passed 5/5 again; the per-run relevant request counts were 85, 85, 86, 85, and 86, each with one UA, challenge-host traffic, blob-originated traffic, and no verification-error text.

## Regression evidence

- Google auth: 25/25 relevant requests carried Firefox and 0 carried cleaned Chrome: `accounts.google.com` 7, `www.gstatic.com` 12, `fonts.gstatic.com` 1, `accounts.youtube.com` 1, `play.google.com` 4. The auth document `navigator.userAgent` was Firefox.
- Same-partition isolation: a second tab opened during Google auth used cleaned Chrome for both its document header and `navigator.userAgent`; navigating the auth tab away to `example.com` restored cleaned Chrome in both places.
- Native profile on final head: the `example.org` document header and `navigator.userAgent` both retained native OrcaDev/Electron identity.
- Focused unit tests: 5 files, 82 tests passed.
- `pnpm tc:node` passed.
- `pnpm run check:code-quality:changed` passed with 0 findings across 14 changed files.

## Remaining gaps

This validation did not submit Cloudflare or Google credentials, did not exercise an authenticated Cloudflare session, and did not run a live cookie-import debugger-detach interaction. Debugger detach/retry and reapplication are covered by focused tests; the real-app measurements were on macOS.