### PR TITLE
fix(relay): bound idle rehome polling and skip disabled scans

### DIFF
--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -3351,6 +3351,10 @@ export class RelayAssignmentStore {
   ): Promise<Array<IdleRegionalRehomeRequest & { sourceCellUrl: string }>> {
     const now = this.now()
     if (!processSafety || this.regionalRehomeCohortPercent === 0) return []
+    const control = (await this.database.query(
+      "SELECT enabled, not_before FROM relay_region_rehome_control WHERE control_id = 'global'"
+    ))[0]
+    if (!control || Number(control.enabled) !== 1 || Number(control.not_before) > now) return []
     const fleetSafety = await this.readRegionalRehomeFleetSafety(this.database, now)
     if (regionalRehomeFleetSafetyFailure(processSafety, fleetSafety, now)) return []
     const candidates = await selectIdleRegionalRehomes({

--- a/cloud/apps/relay/src/idle-regional-rehome-store.test.ts
+++ b/cloud/apps/relay/src/idle-regional-rehome-store.test.ts
@@ -111,6 +111,52 @@ async function setup() {
 }
 
 describe('constrained idle regional assignment transaction', () => {
+  it.each(['missing', 'disabled', 'future'] as const)(
+    'does only one read per tick with %s durable control and sees later enablement',
+    async (state) => {
+      const { store, database, safety } = await setup()
+      const control = (await database.query(
+        "SELECT * FROM relay_region_rehome_control WHERE control_id = 'global'"
+      ))[0]!
+      if (state === 'missing') {
+        await database.query('DELETE FROM relay_region_rehome_control')
+      } else {
+        await database.query(
+          "UPDATE relay_region_rehome_control SET enabled = ?, not_before = ? WHERE control_id = 'global'",
+          [state === 'disabled' ? 0 : 1, safety.observedAt + (state === 'future' ? 1 : 0)]
+        )
+      }
+      const query = vi.spyOn(database, 'query')
+      const transaction = vi.spyOn(database, 'transaction')
+      for (let tick = 0; tick < 3; tick++) {
+        query.mockClear()
+        expect(await store.selectIdleRegionalRehomeCandidates(safety)).toEqual([])
+        expect(query).toHaveBeenCalledTimes(1)
+        expect(query.mock.calls[0]![0]).toMatch(/^SELECT .*FROM relay_region_rehome_control/s)
+        expect(transaction).not.toHaveBeenCalled()
+      }
+      if (state === 'missing') {
+        const columns = Object.keys(control)
+        await database.query(
+          `INSERT INTO relay_region_rehome_control (${columns.join(',')}) VALUES (${columns.map(() => '?').join(',')})`,
+          Object.values(control)
+        )
+      } else {
+        await database.query(
+          "UPDATE relay_region_rehome_control SET enabled = 1, not_before = ? WHERE control_id = 'global'",
+          [safety.observedAt]
+        )
+      }
+      query.mockClear()
+      expect(await store.selectIdleRegionalRehomeCandidates(safety)).toHaveLength(1)
+      expect(query.mock.calls.length).toBeGreaterThan(1)
+      await database.query("UPDATE relay_region_rehome_control SET enabled = 0 WHERE control_id = 'global'")
+      query.mockClear()
+      expect(await store.selectIdleRegionalRehomeCandidates(safety)).toEqual([])
+      expect(query).toHaveBeenCalledTimes(1)
+    }
+  )
+
   it.each([10, 11])('reserves source activity plus assignment at target capacity %i', async (capacity) => {
     const { store, database, safety, request } = await setup()
     // Model three source activity units and seven units already reserved at the target.

--- a/cloud/apps/relay/src/regional-rehome-worker.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-worker.test.ts
@@ -11,6 +11,31 @@ import { startRegionalRehomeWorker } from './regional-rehome-worker.js'
 describe('regional rehome worker', () => {
   afterEach(() => vi.restoreAllMocks())
 
+  it('bounds empty polling to the six-second cadence and stops its timer', async () => {
+    vi.useFakeTimers()
+    const selectIdleRegionalRehomeCandidates = vi.fn().mockResolvedValue([])
+    const worker = startRegionalRehomeWorker(config(), {
+      selectIdleRegionalRehomeCandidates
+    } as unknown as RelayAssignmentStore, {
+      safetySnapshot: () => safety(Date.now()),
+      random: () => 0
+    })!
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+      expect(selectIdleRegionalRehomeCandidates).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(5_999)
+      expect(selectIdleRegionalRehomeCandidates).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(selectIdleRegionalRehomeCandidates).toHaveBeenCalledTimes(2)
+      worker.stop()
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(selectIdleRegionalRehomeCandidates).toHaveBeenCalledTimes(2)
+    } finally {
+      worker.stop()
+      vi.useRealTimers()
+    }
+  })
+
   it('passes unsafe process telemetry to the durable claim gate', async () => {
     let now = 0
     let sqlFailures = 0

--- a/cloud/apps/relay/src/regional-rehome-worker.ts
+++ b/cloud/apps/relay/src/regional-rehome-worker.ts
@@ -97,7 +97,8 @@ export function startRegionalRehomeWorker(
   }
   const timer = setInterval(
     () => void run(),
-    options.intervalMs ?? jitteredSweepIntervalMs(1_000, options.random)
+    // Match the initial ten-moves/minute budget without replanning the join every second.
+    options.intervalMs ?? jitteredSweepIntervalMs(6_000, options.random)
   )
   timer.unref()
   void run()

--- a/cloud/apps/relay/src/relay-sweep-schedule.test.ts
+++ b/cloud/apps/relay/src/relay-sweep-schedule.test.ts
@@ -19,7 +19,7 @@ describe('sweep schedule jitter', () => {
     expect(SWEEP_JITTER_FRACTION).toBeGreaterThan(0)
   })
 
-  it('jitters the regional rehome dispatch tick, which every director runs each second', () => {
+  it('jitters the six-second regional rehome dispatch tick across directors', () => {
     const timers: number[] = []
     const setIntervalSpy = vi
       .spyOn(globalThis, 'setInterval')
@@ -42,7 +42,7 @@ describe('sweep schedule jitter', () => {
       setIntervalSpy.mockRestore()
     }
 
-    expect(timers).toEqual([1_100])
+    expect(timers).toEqual([6_600])
   })
 
   // Why: index.ts boots a server on import, so its wiring can only be read.


### PR DESCRIPTION
Setting the regional-correction cohort above zero started fleet/headroom/candidate scans on every director even while durable rehoming was disabled. During the production test, shared SQL CPU rose to 88–94%; cohort 0 was restored before enabling any migration, and CPU subsequently returned toward baseline.

Read the durable control before expensive selection and return for missing, disabled or future control. Space enabled polls by 6–7.2 seconds using the existing jitter, instead of 1–1.2 seconds. Transactional idle, capacity and enablement checks remain authoritative. This adds a few seconds of detection delay and reduces periodic scan frequency sixfold; it does not introduce a scheduler or cache.

Validation:
- Disabled-control regression: red at five queries per tick, green at one; covers later enable/disable on the same store.
- Cadence regression: red at six calls before six seconds, green at one; verifies timer cleanup.
- Focused relay suite: 62 passed, one SQLite-only skip; PostgreSQL 16 store suite: 13 passed, no skips. Relay typecheck passed.
- Updated the pre-existing sweep-jitter expectation to 6.6 seconds. Fresh Cloud Verify 34671652208 passed all jobs at e638d3df9769.
- Full local PostgreSQL run: 687 passed/1 failed; legacy-lock recovery fixture also reproduces wrong_assignment without the new control gate. CI passes this suite; the local baseline discrepancy is recorded rather than hidden.
- Local PostgreSQL benchmark: 30 cells, 10,000 synthetic hosts, six concurrent pollers and zero eligible moves. SQL rate 36→6 queries/sec with the cadence change; disabled gate costs one read per tick. Candidate query planning was ~104ms versus ~18ms execution. These are local measurements, not a production capacity guarantee.

Deploy to the director with cohort 0 first, then repeat monitored enablement. The two upgraded cells need no additional rollout for this director-only polling change. Production migration and phone reconnection remain unproven.
