### PR TITLE
fix(workspaces): route duplicate folders through the active host

### DIFF
--- a/src/renderer/src/lib/connection-context.test.ts
+++ b/src/renderer/src/lib/connection-context.test.ts
@@ -513,7 +513,8 @@ function makeProjectGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
 type ConnectionContextState = Pick<
   AppState,
   'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'
->
+> &
+  Partial<Pick<AppState, 'activeWorktreeId' | 'activeWorkspaceExecutionHostId'>>
 
 describe('getConnectionIdFromState', () => {
   afterEach(() => {
@@ -751,5 +752,42 @@ describe('getConnectionIdFromState', () => {
       repos: [makeRepo({ id: 'repo-ssh', connectionId: 'ssh-hydrated' })]
     }
     expect(selector(hydrated)).toBe('ssh-hydrated')
+  })
+
+  it('recomputes a retained folder selector when the active host changes', () => {
+    const workspaceKey = folderWorkspaceKey('folder-workspace-1')
+    const selector = createConnectionIdForFileSelector(workspaceKey, '/srv/shared/README.md')
+    const folderWorkspaces = [
+      makeFolderWorkspace({ folderPath: '/srv/shared', executionHostId: 'local' }),
+      makeFolderWorkspace({
+        folderPath: '/srv/shared',
+        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1'
+      })
+    ]
+    const projectGroups = [
+      makeProjectGroup({ parentPath: '/srv/shared', executionHostId: 'local' }),
+      makeProjectGroup({
+        parentPath: '/srv/shared',
+        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1'
+      })
+    ]
+    const base = { folderWorkspaces, projectGroups, repos: [], worktreesByRepo: {} }
+
+    expect(
+      selector({
+        ...base,
+        activeWorktreeId: workspaceKey,
+        activeWorkspaceExecutionHostId: 'local'
+      })
+    ).toBeNull()
+    expect(
+      selector({
+        ...base,
+        activeWorktreeId: workspaceKey,
+        activeWorkspaceExecutionHostId: 'ssh:ssh-1'
+      })
+    ).toBe('ssh-1')
   })
 })

--- a/src/renderer/src/lib/connection-owner-resolution.ts
+++ b/src/renderer/src/lib/connection-owner-resolution.ts
@@ -21,7 +21,8 @@ import {
 type ConnectionOwnerState = Pick<
   AppState,
   'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'
->
+> &
+  Partial<Pick<AppState, 'activeWorktreeId' | 'activeWorkspaceExecutionHostId'>>
 
 export function createConnectionIdForFileSelector(
   worktreeId: string | null,
@@ -38,7 +39,9 @@ export function createConnectionIdForFileSelector(
       previousSlices?.folderWorkspaces === state.folderWorkspaces &&
       previousSlices.projectGroups === state.projectGroups &&
       previousSlices.repos === state.repos &&
-      previousSlices.worktreesByRepo === state.worktreesByRepo
+      previousSlices.worktreesByRepo === state.worktreesByRepo &&
+      previousSlices.activeWorktreeId === state.activeWorktreeId &&
+      previousSlices.activeWorkspaceExecutionHostId === state.activeWorkspaceExecutionHostId
     ) {
       return previousResult
     }
@@ -46,7 +49,9 @@ export function createConnectionIdForFileSelector(
       folderWorkspaces: state.folderWorkspaces,
       projectGroups: state.projectGroups,
       repos: state.repos,
-      worktreesByRepo: state.worktreesByRepo
+      worktreesByRepo: state.worktreesByRepo,
+      activeWorktreeId: state.activeWorktreeId,
+      activeWorkspaceExecutionHostId: state.activeWorkspaceExecutionHostId
     }
     previousResult = getConnectionIdForFileFromState(state, worktreeId, filePath)
     return previousResult
@@ -62,7 +67,15 @@ export function getConnectionIdFromState(
   }
   const parsedWorkspaceKey = parseWorkspaceKey(worktreeId)
   if (parsedWorkspaceKey?.type === 'folder') {
-    return getFolderWorkspaceConnectionId(state, parsedWorkspaceKey.folderWorkspaceId)
+    const selectedHostId =
+      state.activeWorktreeId === worktreeId
+        ? (state.activeWorkspaceExecutionHostId ?? undefined)
+        : undefined
+    return getFolderWorkspaceConnectionId(
+      state,
+      parsedWorkspaceKey.folderWorkspaceId,
+      selectedHostId
+    )
   }
   // Why: owner resolution runs from retained Zustand selectors, so unrelated
   // store writes must not flatten every worktree or scan every repository.

--- a/src/renderer/src/lib/folder-workspace-connection.ts
+++ b/src/renderer/src/lib/folder-workspace-connection.ts
@@ -1,4 +1,5 @@
 import type { Repo } from '../../../shared/repo-types'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
 import {
   findFolderWorkspaceCandidateRepos,
   resolveFolderWorkspaceHost,
@@ -14,11 +15,16 @@ export function getFolderWorkspaceCandidateRepos(
   return findFolderWorkspaceCandidateRepos(state, folderWorkspaceId)
 }
 
-/** Legacy tri-state view of the shared resolution: `undefined` = gone or ambiguous. */
+/** Resolves an explicit host directly; without one, `undefined` means gone or ambiguous. */
 export function getFolderWorkspaceConnectionId(
   state: FolderWorkspaceConnectionState,
-  folderWorkspaceId: string
+  folderWorkspaceId: string,
+  executionHostId?: ExecutionHostId
 ): string | null | undefined {
+  const selectedHost = parseExecutionHostId(executionHostId)
+  if (selectedHost) {
+    return selectedHost.kind === 'ssh' ? selectedHost.targetId : null
+  }
   const host = resolveFolderWorkspaceHost(state, folderWorkspaceId)
   if (host.kind === 'ssh') {
     return host.targetId

--- a/src/renderer/src/store/terminals/terminal-workspace-routing.scale.test.ts
+++ b/src/renderer/src/store/terminals/terminal-workspace-routing.scale.test.ts
@@ -6,6 +6,7 @@ import {
   worktreeUsesWslPath
 } from './terminal-workspace-routing'
 import { rightSidebarShowsPullRequestData } from '@/lib/right-sidebar-visibility'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 
 const REPO_COUNT = 10
 const WORKTREE_COUNT = 400
@@ -94,5 +95,40 @@ describe('terminal workspace routing scales with tab count, not workspace count'
     const { state } = buildCountingState()
     expect(getRemoteConnectionIdForWorktree(state, 'ghost::/nowhere')).toBeNull()
     expect(worktreeUsesRemoteConnection(state, 'ghost::/nowhere')).toBe(false)
+  })
+
+  it('routes a duplicate folder id through its active host', () => {
+    const worktreeId = folderWorkspaceKey('folder-1')
+    const base = {
+      folderWorkspaces: [
+        {
+          id: 'folder-1',
+          projectGroupId: 'group-1',
+          folderPath: '/srv/shared',
+          executionHostId: 'ssh:ssh-1',
+          connectionId: 'ssh-1'
+        },
+        {
+          id: 'folder-1',
+          projectGroupId: 'group-1',
+          folderPath: String.raw`\\wsl.localhost\Ubuntu\srv\shared`,
+          executionHostId: 'local'
+        }
+      ],
+      projectGroups: [],
+      repos: [],
+      worktreesByRepo: {},
+      activeWorktreeId: worktreeId
+    } as unknown as AppState
+
+    const local = { ...base, activeWorkspaceExecutionHostId: 'local' } as AppState
+    expect(worktreeUsesRemoteConnection(local, worktreeId)).toBe(false)
+    expect(getRemoteConnectionIdForWorktree(local, worktreeId)).toBeNull()
+    expect(worktreeUsesWslPath(local, worktreeId)).toBe(true)
+
+    const ssh = { ...base, activeWorkspaceExecutionHostId: 'ssh:ssh-1' } as AppState
+    expect(worktreeUsesRemoteConnection(ssh, worktreeId)).toBe(true)
+    expect(getRemoteConnectionIdForWorktree(ssh, worktreeId)).toBe('ssh-1')
+    expect(worktreeUsesWslPath(ssh, worktreeId)).toBe(false)
   })
 })

--- a/src/renderer/src/store/terminals/terminal-workspace-routing.ts
+++ b/src/renderer/src/store/terminals/terminal-workspace-routing.ts
@@ -3,11 +3,26 @@ import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree/id'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
 import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { resolveLocalWindowsTerminalShellOverrideForTab } from '../../../../shared/local-windows-terminal-runtime'
 import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
 import { getFolderWorkspaceConnectionId } from '@/lib/folder-workspace-connection'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { getCatalogOwnerHostId } from '@/lib/worktree-runtime-owner-index'
 import { getIndexedRepoMap, getIndexedWorktreeMap } from '../worktree-repo-index'
+
+type ActiveWorkspaceHostState = Partial<
+  Pick<AppState, 'activeWorktreeId' | 'activeWorkspaceExecutionHostId'>
+>
+
+function getSelectedExecutionHostId(
+  state: ActiveWorkspaceHostState,
+  worktreeId: string
+): ExecutionHostId | undefined {
+  return state.activeWorktreeId === worktreeId
+    ? (state.activeWorkspaceExecutionHostId ?? undefined)
+    : undefined
+}
 
 export function isWindowsRendererRuntime(): boolean {
   return typeof navigator !== 'undefined' && navigator.userAgent.includes('Windows')
@@ -52,13 +67,16 @@ export function resolveCreatedTabShellOverride(
 }
 
 export function worktreeUsesWslPath(
-  state: Pick<AppState, 'folderWorkspaces' | 'worktreesByRepo'>,
+  state: Pick<AppState, 'folderWorkspaces' | 'worktreesByRepo'> & ActiveWorkspaceHostState,
   worktreeId: string
 ): boolean {
   const parsed = parseWorkspaceKey(worktreeId)
   if (parsed?.type === 'folder') {
+    const selectedHostId = getSelectedExecutionHostId(state, worktreeId)
     const folderWorkspace = state.folderWorkspaces.find(
-      (workspace) => workspace.id === parsed.folderWorkspaceId
+      (workspace) =>
+        workspace.id === parsed.folderWorkspaceId &&
+        (!selectedHostId || getCatalogOwnerHostId(workspace) === selectedHostId)
     )
     return folderWorkspace ? isWslUncPath(folderWorkspace.folderPath) : false
   }
@@ -67,12 +85,19 @@ export function worktreeUsesWslPath(
 }
 
 export function worktreeUsesRemoteConnection(
-  state: Pick<AppState, 'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'>,
+  state: Pick<AppState, 'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'> &
+    ActiveWorkspaceHostState,
   worktreeId: string
 ): boolean {
   const parsedWorkspaceKey = parseWorkspaceKey(worktreeId)
   if (parsedWorkspaceKey?.type === 'folder') {
-    return Boolean(getFolderWorkspaceConnectionId(state, parsedWorkspaceKey.folderWorkspaceId))
+    return Boolean(
+      getFolderWorkspaceConnectionId(
+        state,
+        parsedWorkspaceKey.folderWorkspaceId,
+        getSelectedExecutionHostId(state, worktreeId)
+      )
+    )
   }
   const repoMap = getIndexedRepoMap(state.repos)
   const directRepo = repoMap.get(getRepoIdFromWorktreeId(worktreeId))
@@ -85,12 +110,19 @@ export function worktreeUsesRemoteConnection(
 }
 
 export function getRemoteConnectionIdForWorktree(
-  state: Pick<AppState, 'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'>,
+  state: Pick<AppState, 'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'> &
+    ActiveWorkspaceHostState,
   worktreeId: string
 ): string | null {
   const parsedWorkspaceKey = parseWorkspaceKey(worktreeId)
   if (parsedWorkspaceKey?.type === 'folder') {
-    return getFolderWorkspaceConnectionId(state, parsedWorkspaceKey.folderWorkspaceId) ?? null
+    return (
+      getFolderWorkspaceConnectionId(
+        state,
+        parsedWorkspaceKey.folderWorkspaceId,
+        getSelectedExecutionHostId(state, worktreeId)
+      ) ?? null
+    )
   }
   const repoMap = getIndexedRepoMap(state.repos)
   const directRepo = repoMap.get(getRepoIdFromWorktreeId(worktreeId))


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |

<!-- /orca-pr-loc -->

## User-visible symptom

When the same folder ID/path is registered on multiple execution hosts, terminal and file routing can choose the first catalog row instead of the host the user activated. An SSH folder can therefore be treated as local, or a local/WSL folder can inherit the wrong remote connection.

## Mechanism and fix

`getFolderWorkspaceConnectionId` previously had no execution-host discriminator, so duplicate folder rows resolved as gone/ambiguous and terminal routing could fall back to the wrong row. This recovers the five routing changes from `278e5ed3ca`: the folder resolver accepts an optional explicit host, owner resolution and terminal routing pass `activeWorkspaceExecutionHostId` only for the active workspace, and the retained selector memo key observes active-workspace/host changes. Existing two-argument callers remain valid.

The correctness test registers the same `/srv/shared` folder on `local` and `ssh:ssh-1` and proves a retained selector changes from local to `ssh-1`; the routing scale test covers the same duplicate ID across local WSL and SSH rows. Git-worktree routing keeps its existing indexed path.

## Why #20182 is not sufficient

The real seeder calls `store.createTab`, and tab creation consults `getRemoteConnectionIdForWorktree` at `src/renderer/src/store/terminals/terminal-tab-creation.ts:98`. On main, the unhinted folder resolver chooses the first matching folder ID at `src/shared/folder-workspace-execution-host.ts:117` and uses that row's host. The sibling reseed PR (#20182) does not fix that routing: its folder tests assert the active ID, selected-host field, and tab count, but not the execution target of the spawned PTY. This PR is therefore the change that actually closes duplicate-folder host routing.

## Memo-key performance measurement

The added memo fields make every retained, non-skipped selector recompute when the active workspace or active host changes. I measured selector self-time with a temporary, non-committed Vitest harness on `origin/main` (`fa3d29fa11`) and this PR (`b6fa4d14b4`), using stable catalog identities, 40 folder rows, 200 repo rows, eight retained previews, and nine samples of 1,000 alternating workspace switches. All eight previews were inactive and unpinned; each had mixed local/SSH repo ownership, so the ambiguous file-owner path also performed path filtering and sorting.

| Version | Median self-time / 1,000 switches | Median / switch (8 selectors) | p95 / 1,000 | Folder-row visits / switch | Repo-row visits / switch |
| --- | ---: | ---: | ---: | ---: | ---: |
| `origin/main` | 0.412 ms | 0.412 µs | 0.688 ms | 0 | 0 |
| PR head | 2,356.551 ms | 2.357 ms | 2,646.724 ms | 876 | 3,200 |

Folder visits count `id` reads during folder-array lookup; repo visits count `projectGroupId` reads during candidate scans. The timing includes the additional path filtering/sorting, but excludes rendering and effects. The result is real and fanout-sensitive—about 2.4 ms per switch in this deliberately scan-heavy eight-preview case—but is not a demonstrated blocker. It does **not** rebuild the worktree or repo owner indexes: those remain WeakMap-cached by immutable catalog identity in `src/renderer/src/lib/worktree-runtime-owner-index.ts:124` and `:198`.

## Known follow-up

This active-selection hint does not solve inactive/background-folder ownership or paired-runtime ownership. Those need an ownership source independent of whichever workspace is currently active.

## Mixed versions and platforms

This is renderer-only routing logic: it changes no IPC/RPC parameters, stream frames, or published wire content, so mixed client/server versions need no negotiation. It preserves execution-host authority for SSH/remote work and does not alter `live` / `unverifiable` / `exited` lifecycle semantics. The selected host is applied to existing macOS, Linux, Windows, WSL, folder-workspace, and git-worktree paths without adding platform-specific behavior.

## Validation

- Recovered-content check: all five final file blobs match `278e5ed3ca` byte-for-byte, using `git show "278e5ed3ca:$file_path"` with the path held in a shell variable.
- `pnpm test src/renderer/src/lib/connection-context.test.ts src/renderer/src/store/terminals/terminal-workspace-routing.scale.test.ts` — 2 files, 29 tests passed.
- Ablated final head by temporarily reversing the active-selection/memo-key source hunk, then ran `pnpm test src/renderer/src/lib/connection-context.test.ts -t "recomputes a retained folder selector when the active host changes"` — exit 1, 1 failed / 24 skipped, expected `ssh-1` but received `null`.
- Restored the source at final head and ran the same command — exit 0, 1 passed / 24 skipped.
- `pnpm tc` — passed.
- `pnpm run check:code-quality:changed` — 0 new findings across exactly 5 changed files.

Split from #20182 so the green, release-bound reseed fix remains untouched.
