### PR TITLE
perf(wsl): release environment probe deadline timers

### DIFF
--- a/src/main/wsl/wsl-guest-environment.test.ts
+++ b/src/main/wsl/wsl-guest-environment.test.ts
@@ -58,6 +58,33 @@ describe('probing', () => {
     await getWslGuestEnvironment('Debian')
     expect(runProcessMock).toHaveBeenCalledTimes(2)
   })
+
+  it('does not retain deadline timers after a concurrent probe settles', async () => {
+    vi.useFakeTimers()
+    try {
+      respondWithPayload(GOOD)
+      await Promise.all(Array.from({ length: 32 }, () => getWslGuestEnvironment('Ubuntu')))
+      expect(vi.getTimerCount()).toBe(0)
+      expect(runProcessMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reads a warm cache without allocating deadline timers', async () => {
+    respondWithPayload(GOOD)
+    const environment = await getWslGuestEnvironment('Ubuntu')
+    const timeout = vi.spyOn(globalThis, 'setTimeout')
+    try {
+      for (let index = 0; index < 100; index++) {
+        expect(await getWslGuestEnvironment('Ubuntu')).toBe(environment)
+      }
+      expect(timeout).not.toHaveBeenCalled()
+      expect(runProcessMock).toHaveBeenCalledTimes(1)
+    } finally {
+      timeout.mockRestore()
+    }
+  })
 })
 
 describe('bad answers are not cached as good ones', () => {

--- a/src/main/wsl/wsl-guest-environment.ts
+++ b/src/main/wsl/wsl-guest-environment.ts
@@ -125,6 +125,10 @@ export function getWslGuestEnvironment(
   budgetMs = PROBE_TIMEOUT_MS
 ): Promise<WslGuestEnvironment | null> {
   const key = cacheKey(distro)
+  const cached = resolved.get(key)
+  if (cached) {
+    return Promise.resolve(cached)
+  }
   const retry = retryAfter.get(key)
   if (retry !== undefined && Date.now() >= retry) {
     inFlight.delete(key)
@@ -154,13 +158,14 @@ export function getWslGuestEnvironment(
     // Why race: joining an in-flight probe used to mean waiting out the
     // *starter's* budget, so a joiner could reach its own command with 1ms --
     // the exact hazard the budget plumbing was added to remove.
+    let timer: ReturnType<typeof setTimeout>
     return Promise.race([
       existing,
       new Promise<null>((resolve) => {
-        const timer = setTimeout(() => resolve(null), budgetMs)
+        timer = setTimeout(() => resolve(null), budgetMs)
         timer.unref?.()
       })
-    ])
+    ]).finally(() => clearTimeout(timer))
   }
   // Store before awaiting so a burst collapses into one probe.
   // Why catch: runProcess REJECTS when the child cannot be started (ENOENT on a


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5
Cached WSL environment reads no longer leave unused timeout timers alive.

## What Changed
Return successful cached environments directly and clear a pending caller's deadline timer when its shared probe settles. Probe budgets, retry gates, invalidation, and per-distro isolation remain unchanged.

## Why
Windows Node 24 synthetic measurement, 10,000 sequential warm reads: 10,000 pending timers to zero; retained heap after GC approximately 8.39 MB to 0.10 MB. Single-sample loop time was 11.9 ms to 2.66 ms. These are allocation measurements, not end-to-end application latency claims.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — no visual or interaction change.

## Testing
- 50 focused WSL environment/runner tests passed, including new timer-retention assertions.
- Node typecheck and targeted lint passed on Windows; formatting checked.
- pnpm attempted dependency installation and native rebuild failed with FTK1011 long-path tracking errors. Validation used installed Vitest/TypeScript binaries directly with ORCA_BACKGROUND_LAUNCH=1.
- No native GUI launched; real guest startup speed is not claimed.

## Review
Success cache entries have no expiry today; invalidation clears both maps. Pending callers retain their individual deadlines. No RPC, SSH routing, filesystem, or workspace-type change.

## Agent skill upstream boundary
- [x] Not applicable.
