### PR TITLE
perf(checks): bound earlier error context selection

### DIFF
--- a/config/scripts/check-job-log-tail-benchmark.mjs
+++ b/config/scripts/check-job-log-tail-benchmark.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+import { summarizeBenchmarkSamples } from './benchmark-sample-summary.mjs'
+
+// git show <baseline-ref>:src/shared/check-job-log-tail-slice.ts | node config/scripts/check-job-log-tail-benchmark.mjs
+const target = resolve('src/shared/check-job-log-tail-slice.ts')
+async function load(source) {
+  const result = await build({
+    stdin: { contents: source, loader: 'ts', resolveDir: dirname(target) },
+    bundle: true,
+    write: false,
+    platform: 'node',
+    format: 'esm'
+  })
+  return (
+    await import(
+      `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+    )
+  ).sliceCheckLogTail
+}
+const baseline = readFileSync(0, 'utf8')
+assert.ok(baseline.includes('function sliceCheckLogTail'), 'Pipe the baseline source into stdin')
+const implementations = {
+  before: await load(baseline),
+  after: await load(readFileSync(target, 'utf8'))
+}
+let seed = 20260911
+function random() {
+  seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+  return seed
+}
+for (let sample = 0; sample < 2000; sample += 1) {
+  const input = Array.from({ length: random() % 1000 }, (_, index) => {
+    const token = ['ok', 'error:', 'FAILED', 'AssertionError', '', '🙂', '\r', '\ud800'][
+      (random() >>> 16) % 8
+    ]
+    return `${index} ${token} ${'x'.repeat(random() % 250)}`
+  }).join(sample % 2 === 0 ? '\n' : '\r\n')
+  assert.equal(implementations.after(input), implementations.before(input), `sample ${sample}`)
+}
+const results = []
+for (const lines of [200, 10_000, 100_000]) {
+  for (const shape of ['no-errors', 'early-error', 'dense-errors', 'spaced-errors']) {
+    const input = Array.from({ length: lines }, (_, index) => {
+      const error =
+        index < lines - 100 &&
+        ((shape === 'early-error' && index === 2) ||
+          shape === 'dense-errors' ||
+          (shape === 'spaced-errors' && index % 100 === 0))
+      return `${index} ${error ? 'error: failed assertion' : 'running installation'} ${'x'.repeat(64)}`
+    }).join('\n')
+    const expected = implementations.before(input)
+    assert.equal(implementations.after(input), expected)
+    const iterations = Math.max(1, Math.floor(100_000 / lines))
+    for (let warmup = 0; warmup < 4; warmup += 1) {
+      for (const run of Object.values(implementations)) {
+        run(input)
+      }
+    }
+    const samples = { before: [], after: [] }
+    for (const pair of buildCounterbalancedSchedule(8, 'before', 'after')) {
+      for (const arm of pair) {
+        const started = performance.now()
+        let actual
+        for (let repeat = 0; repeat < iterations; repeat += 1) {
+          actual = implementations[arm](input)
+        }
+        samples[arm].push(performance.now() - started)
+        assert.equal(actual, expected)
+      }
+    }
+    results.push({
+      lines,
+      shape,
+      inputBytes: Buffer.byteLength(input),
+      iterations,
+      before: summarizeBenchmarkSamples(samples.before),
+      after: summarizeBenchmarkSamples(samples.after)
+    })
+  }
+}
+console.log(
+  JSON.stringify(
+    { node: process.version, platform: process.platform, differentialCases: 2000, results },
+    null,
+    2
+  )
+)

--- a/src/shared/check-job-log-tail-slice.test.ts
+++ b/src/shared/check-job-log-tail-slice.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   PR_CHECK_LOG_TAIL_BYTES,
   PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR,
+  PR_CHECK_LOG_TAIL_MAX_EARLIER_LINES,
   sliceCheckLogTail
 } from './check-job-log-tail-slice'
 
@@ -49,5 +50,61 @@ describe('sliceCheckLogTail', () => {
     expect(sliced).toContain(PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR)
     expect(sliced).toContain('recent line 99')
     expect(Buffer.from(sliced, 'utf8').byteLength).toBeLessThanOrEqual(PR_CHECK_LOG_TAIL_BYTES)
+  })
+
+  it('stops searching once the most recent error context fills the excerpt', () => {
+    const earlier = Array.from({ length: 10_000 }, (_, index) => `error: failure ${index}`)
+    const recent = Array.from({ length: 100 }, (_, index) => `recent ${index}`)
+    const test = vi.spyOn(RegExp.prototype, 'test')
+    let sliced: string
+    let scanned: number
+    try {
+      sliced = sliceCheckLogTail([...earlier, ...recent].join('\n'))
+      scanned = test.mock.calls.length
+    } finally {
+      test.mockRestore()
+    }
+
+    expect(sliced).toBe(
+      [...earlier.slice(-30), PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR, ...recent].join('\n')
+    )
+    expect(scanned).toBeLessThanOrEqual(PR_CHECK_LOG_TAIL_MAX_EARLIER_LINES)
+  })
+
+  it('deduplicates overlapping windows and clips the oldest window at 30 lines', () => {
+    const earlier = Array.from({ length: 80 }, (_, index) => `line ${index}`)
+    for (const index of [2, 3, 20, 21, 35, 44, 53, 62, 71]) {
+      earlier[index] = `FAILED ${index}`
+    }
+    const recent = Array.from({ length: 100 }, (_, index) => `recent ${index}`)
+    const expectedIndexes = [
+      23,
+      ...[35, 44, 53, 62, 71].flatMap((index) => [
+        index - 2,
+        index - 1,
+        index,
+        index + 1,
+        index + 2
+      ])
+    ]
+    // The overlapping errors at 20 and 21 contribute four more retained lines.
+    expectedIndexes.unshift(19, 20, 21, 22)
+
+    expect(sliceCheckLogTail([...earlier, ...recent].join('\r\n'))).toBe(
+      [
+        ...expectedIndexes.map((index) => earlier[index]),
+        PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR,
+        ...recent
+      ].join('\n')
+    )
+  })
+
+  it('clips context at the first line and the recent-tail boundary', () => {
+    const earlier = ['error: first', 'one', 'two', 'three', 'four', 'error: last']
+    const recent = Array.from({ length: 100 }, (_, index) => `recent ${index}`)
+
+    expect(sliceCheckLogTail([...earlier, ...recent].join('\n'))).toBe(
+      [...earlier, PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR, ...recent].join('\n')
+    )
   })
 })

--- a/src/shared/check-job-log-tail-slice.ts
+++ b/src/shared/check-job-log-tail-slice.ts
@@ -34,14 +34,22 @@ function joinLogExcerptWithByteCap(prefixLines: string[], recentLines: string[])
 
 function collectEarlierErrorLineIndexes(lines: string[], recentStart: number): number[] {
   const indexes = new Set<number>()
-  for (let index = 0; index < recentStart; index += 1) {
+  // Only the latest context survives; older windows cannot contribute once it is full.
+  for (let index = recentStart - 1; index >= 0; index -= 1) {
     if (!ERROR_LINE_PATTERN.test(lines[index] ?? '')) {
       continue
     }
     const contextStart = Math.max(0, index - PR_CHECK_LOG_TAIL_ERROR_CONTEXT_LINES)
     const contextEnd = Math.min(recentStart - 1, index + PR_CHECK_LOG_TAIL_ERROR_CONTEXT_LINES)
-    for (let contextIndex = contextStart; contextIndex <= contextEnd; contextIndex += 1) {
+    for (
+      let contextIndex = contextEnd;
+      contextIndex >= contextStart && indexes.size < PR_CHECK_LOG_TAIL_MAX_EARLIER_LINES;
+      contextIndex -= 1
+    ) {
       indexes.add(contextIndex)
+    }
+    if (indexes.size === PR_CHECK_LOG_TAIL_MAX_EARLIER_LINES) {
+      break
     }
   }
   return [...indexes].sort((left, right) => left - right)
@@ -61,8 +69,7 @@ export function sliceCheckLogTail(logText: string): string {
     return applyLogTailByteCap(lines.slice(-PR_CHECK_LOG_TAIL_LINES).join('\n'))
   }
 
-  const cappedEarlierIndexes = earlierIndexes.slice(-PR_CHECK_LOG_TAIL_MAX_EARLIER_LINES)
-  const earlierLines = cappedEarlierIndexes.map((index) => lines[index] ?? '')
+  const earlierLines = earlierIndexes.map((index) => lines[index] ?? '')
   // Why: if the recent tail alone exceeds the byte cap, keep the earlier error
   // context visible instead of truncating it back out of the combined excerpt.
   return joinLogExcerptWithByteCap(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​99 |

<!-- /orca-pr-loc -->

## ELI5

Failed CI logs can contain thousands of errors, but Orca shows only the latest 30 lines of earlier error context. Find those lines from the end and stop as soon as the excerpt is full.

## What Changed

Scan earlier log lines backwards, deduplicate overlapping context windows in a set capped at 30 entries, then restore chronological order. Preserve the existing error patterns, two-line context, recent tail, UTF-8 byte budget, and exact excerpt text.

## Why

The old implementation scans every earlier line and stores/sorts every matching context index before discarding almost all of them. GitHub job logs can reach the existing 64 MiB download cap; this code runs synchronously when showing failed check details. GitLab uses the same excerpt function after its existing trace normalization.

Measured actual baseline and candidate functions on synthetic 100,000-line logs (~9 MB), macOS arm64, Node 26.6.0. Eight counterbalanced before/after pairs per workload; medians per call:

| Log shape | Before | After |
| --- | ---: | ---: |
| Dense earlier errors | 8.9 ms | 1.7 ms |
| Earlier errors every 100 lines | 14.0 ms | 1.8 ms |
| No errors | 13.9 ms | 14.0 ms |
| One error near the beginning | 13.9 ms | 13.8 ms |

These measure excerpt generation, not network downloads or app-wide latency. The existing full-log split remains. No output is truncated differently and no new cache or state is introduced.

## Linked Issue

Refs #20206. Performance audit PR 1; the broader audit remains open.

## Visual Proof

N/A — the excerpt text and interactions are unchanged.

## Testing

- [x] Automated verification on macOS; no visible Electron windows launched.
- [x] 37 tests pass across excerpt selection, GitLab trace normalization, and GitHub check details/checks.
- [x] Regression test fails on the baseline: 10,000 regex evaluations, versus at most 30 after the change. Boundary and overlapping-window tests preserve exact text.
- [x] 2,000 seeded differential inputs match the baseline exactly, including CRLF, Unicode, overlapping errors and byte-capped output. Benchmarks also cover 200 and 10,000 lines.
- [x] `ORCA_BACKGROUND_LAUNCH=1 pnpm tc` and changed-code quality checks pass.

Reproduce measurements from the repository root:

```sh
git show 20ab99506541:src/shared/check-job-log-tail-slice.ts | node config/scripts/check-job-log-tail-benchmark.mjs
```

## Review

Descending error positions have descending context endpoints, so once the most recent 30 unique lines are selected, earlier errors cannot contribute a newer line. Both Git providers use the same pure function; no path, platform, Git command, SSH execution boundary, or wire format changes.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] Small, focused change with measured benefit.
- [x] Exact output and compatibility considered.
- [x] Self-reviewed; targeted tests, full typecheck and changed-file lint pass.
- [ ] Full lint, full test suite and build: CI coverage pending.
