### PR TITLE
perf(daemon): bound immediate flush queue scans

### DIFF
--- a/src/main/daemon/daemon-stream-data-batcher.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.ts
@@ -86,7 +86,7 @@ export class DaemonStreamDataBatcher {
 
     if (
       options.flushImmediately === true &&
-      this.queuedCharsForSession(batch, sessionId) <=
+      this.queuedCharsForSession(batch, sessionId, options.flushMaxChars) <=
         (options.flushMaxChars ?? Number.POSITIVE_INFINITY)
     ) {
       this.flushSession(clientId, sessionId)
@@ -249,11 +249,18 @@ export class DaemonStreamDataBatcher {
     })
   }
 
-  private queuedCharsForSession(batch: PendingStreamDataBatch, sessionId: string): number {
+  private queuedCharsForSession(
+    batch: PendingStreamDataBatch,
+    sessionId: string,
+    stopAfter = Number.POSITIVE_INFINITY
+  ): number {
     let chars = 0
     for (const entry of batch.queue) {
       if (entry.sessionId === sessionId) {
         chars += entry.data.length
+        if (chars > stopAfter) {
+          return chars
+        }
       }
     }
     return chars


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## ELI5
A busy terminal stops counting queued text once it already knows the output is too large for an immediate flush.

## What Changed
Short-circuit the existing per-session queue sum above flushMaxChars. Keep the same queue and flush policy, including Unicode handling, interleaved sessions and backpressure.

## Why
Windows Node 24 synthetic benchmark, median of nine samples of 10,000 enqueues: with 2,048 queued entries, 31.78 ms to 0.23 ms; with 16,384 entries, 356.80 ms to 0.31 ms. This measures the enqueue hot path under backlog, not overall app speed.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — output bytes, timing policy and interaction behavior are unchanged.

## Testing
- 37 existing batcher, droppable-membership and lifecycle tests passed on Windows.
- 1,000 deterministic randomized scenarios (100,000 enqueues) matched original output bytes and pending counts, including Unicode, transformed entries, backpressure and unusual limits.
- Node typecheck, targeted lint and formatting passed.
- No new unit test for this simple equivalent short-circuit; existing behavior tests cover the flush policy.
- Installed tools invoked directly with ORCA_BACKGROUND_LAUNCH=1 because pnpm native dependency rebuilding hit FTK1011 long-path tracking errors.

## Review
Each string length is nonnegative, so exceeding the limit is conclusive. Undefined/Infinity and NaN retain their original results. Uses actual queue entries instead of trusting separate counters. No transport, host routing or workspace changes.

## Agent skill upstream boundary
- [x] Not applicable.
