### PR TITLE
perf(mobile): normalize history scope paths once per candidate

### DIFF
--- a/config/scripts/mobile-history-scope-paths-benchmark.mjs
+++ b/config/scripts/mobile-history-scope-paths-benchmark.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const baseline = process.argv[2]
+if (!baseline) {
+  throw new Error(
+    'Usage: node config/scripts/mobile-history-scope-paths-benchmark.mjs <baseline-ref>'
+  )
+}
+const file = 'mobile/src/agent-history/agent-history-scope-paths.ts'
+async function load(contents) {
+  const result = await build({
+    stdin: { contents, loader: 'ts', resolveDir: dirname(resolve(file)) },
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    logLevel: 'silent',
+    tsconfigRaw: {}
+  })
+  return (
+    await import(
+      `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+    )
+  ).deriveMobileAiVaultScopePaths
+}
+const arms = {
+  before: await load(execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8' })),
+  after: await load(readFileSync(file, 'utf8'))
+}
+const iterations = 200
+const results = []
+for (const [count, unique] of [
+  [1, 1],
+  [16, 16],
+  [64, 64],
+  [1000, 32]
+]) {
+  for (const root of ['/home/ada/café/project', 'C:\\Users\\ada\\café\\project']) {
+    const rows = Array.from({ length: count }, (_, index) => ({
+      worktreeId: `w-${index}`,
+      repoId: 'repo',
+      path: `${root}/workspace-${index % unique}`
+    }))
+    const expected = arms.before('project', rows[0], rows)
+    assert.deepEqual(arms.after('project', rows[0], rows), expected)
+    const samples = { before: [], after: [] }
+    function run(arm) {
+      let length = 0
+      const start = performance.now()
+      for (let i = 0; i < iterations; i++) {
+        length += arms[arm]('project', rows[0], rows).length
+      }
+      const elapsed = performance.now() - start
+      assert.equal(length, iterations * expected.length)
+      return elapsed / iterations
+    }
+    for (const arm of ['before', 'after']) {
+      run(arm)
+    }
+    for (const pair of buildCounterbalancedSchedule(10, 'before', 'after')) {
+      for (const arm of pair) {
+        samples[arm].push(run(arm))
+      }
+    }
+    const median = (values) => {
+      const sorted = [...values].sort((a, b) => a - b)
+      return (sorted[4] + sorted[5]) / 2
+    }
+    results.push({
+      count,
+      unique,
+      root,
+      beforeMs: median(samples.before),
+      afterMs: median(samples.after),
+      samples
+    })
+  }
+}
+console.log(
+  JSON.stringify(
+    { baseline, node: process.version, platform: process.platform, iterations, results },
+    null,
+    2
+  )
+)

--- a/mobile/src/agent-history/agent-history-scope-paths.test.ts
+++ b/mobile/src/agent-history/agent-history-scope-paths.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import * as runtimePaths from '../../../src/shared/cross-platform-path'
 import type { Worktree } from '../worktree/workspace-list-types'
 import { deriveMobileAiVaultScopePaths } from './agent-history-scope-paths'
 
@@ -56,5 +57,52 @@ describe('deriveMobileAiVaultScopePaths', () => {
     expect(deriveMobileAiVaultScopePaths('project', active, [active, dupe, relative])).toEqual([
       '/Users/ada/repo/app'
     ])
+  })
+
+  it('retains first spelling and host-specific path equivalence', () => {
+    const paths = [
+      ' /repo/café/ ',
+      '/repo/cafe\u0301',
+      '/repo//café',
+      '/repo/Café',
+      'C:\\Repo\\App',
+      'c:/repo/app/',
+      '\\\\server\\share\\App',
+      '//SERVER/share/app/',
+      '\\\\wsl.localhost\\Ubuntu\\home\\App',
+      '//wsl$/ubuntu/home/App/',
+      '//wsl$/ubuntu/home/app',
+      '//wsl$/Debian/home/App',
+      '/repo/back\\slash',
+      '/repo/back/slash',
+      'relative/path',
+      ' '
+    ]
+    const rows = paths.map((path, index) => worktree({ path, worktreeId: `w-${index}` }))
+    expect(deriveMobileAiVaultScopePaths('project', rows[0], rows)).toEqual([
+      '/repo/café/',
+      '/repo/Café',
+      'C:\\Repo\\App',
+      '\\\\server\\share\\App',
+      '\\\\wsl.localhost\\Ubuntu\\home\\App',
+      '//wsl$/ubuntu/home/app',
+      '//wsl$/Debian/home/App',
+      '/repo/back\\slash',
+      '/repo/back/slash'
+    ])
+  })
+
+  it('normalizes each candidate once even with many duplicate siblings below the cap', () => {
+    const rows = Array.from({ length: 1000 }, (_, index) =>
+      worktree({ path: `/repo/app-${index % 32}`, worktreeId: `w-${index}` })
+    )
+    const normalize = vi.spyOn(runtimePaths, 'normalizeRuntimePathForComparison')
+    try {
+      const result = deriveMobileAiVaultScopePaths('project', rows[0], rows)
+      expect(result).toEqual(Array.from({ length: 32 }, (_, index) => `/repo/app-${index}`))
+      expect(normalize).toHaveBeenCalledTimes(rows.length + 1)
+    } finally {
+      normalize.mockRestore()
+    }
   })
 })

--- a/mobile/src/agent-history/agent-history-scope-paths.ts
+++ b/mobile/src/agent-history/agent-history-scope-paths.ts
@@ -25,7 +25,8 @@ export function deriveMobileAiVaultScopePaths(
   }
 
   const paths: string[] = []
-  addScopePath(paths, activeWorktree.path)
+  const comparisonPaths = new Set<string>()
+  addScopePath(paths, comparisonPaths, activeWorktree.path)
 
   // Workspace scope = the active worktree only. Project scope additionally
   // covers same-repo sibling worktrees so the project view stays complete.
@@ -37,7 +38,7 @@ export function deriveMobileAiVaultScopePaths(
         break
       }
       if (worktree.repoId === activeWorktree.repoId) {
-        addScopePath(paths, worktree.path)
+        addScopePath(paths, comparisonPaths, worktree.path)
       }
     }
   }
@@ -45,16 +46,19 @@ export function deriveMobileAiVaultScopePaths(
   return paths
 }
 
-function addScopePath(paths: string[], pathValue: string | undefined): void {
+function addScopePath(
+  paths: string[],
+  comparisonPaths: Set<string>,
+  pathValue: string | undefined
+): void {
   const trimmedPath = pathValue?.trim()
   if (!trimmedPath || !isRuntimePathAbsolute(trimmedPath)) {
     return
   }
   const comparisonPath = normalizeRuntimePathForComparison(trimmedPath)
-  if (
-    paths.some((existingPath) => normalizeRuntimePathForComparison(existingPath) === comparisonPath)
-  ) {
+  if (comparisonPaths.has(comparisonPath)) {
     return
   }
+  comparisonPaths.add(comparisonPath)
   paths.push(trimmedPath)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 |

<!-- /orca-pr-loc -->

## ELI5
Mobile session history repeatedly cleaned up paths it had already checked. Remembering their comparison keys removes that repeated work.

## What Changed
Use a call-local Set for scope-path deduplication, following the existing desktop pattern. Preserve first spelling, order, same-repo selection, invalid-path rejection, and the 64-path cap. No cache survives a call and no RPC content changes.

## Why
The project-scope helper runs when mobile history loads or refreshes. With 1,000 candidate rows spanning 32 paths, the old implementation normalized paths 17,374 times; the new implementation does so 1,001 times. The count regression fails on the original implementation.

Counterbalanced benchmark on macOS / Node, ten samples per arm, 200 calls per sample, baseline `20ab9950654`:

| Candidates | Path syntax | Before per call | After per call |
| --- | --- | --- | --- |
| 16 unique | POSIX | 0.0189 ms | 0.0032 ms |
| 64 unique | POSIX | 0.2567 ms | 0.0114 ms |
| 64 unique | Windows | 0.5555 ms | 0.0248 ms |
| 1,000 / 32 unique | POSIX | 2.2094 ms | 0.1576 ms |
| 1,000 / 32 unique | Windows | 4.5882 ms | 0.3584 ms |

Single-row calls remain approximately 0.0005 ms POSIX / 0.0010 ms Windows in both arms. These are helper microbenchmarks, not end-to-end phone latency. The benchmark bundles both production versions with the same current dependencies and asserts output parity.

## Linked Issue
User-requested codebase performance audit; no linked issue supplied.

## Visual Proof
N/A — pure computation change with identical outputs and no visual or interaction change.

## Testing
- `ORCA_BACKGROUND_LAUNCH=1 pnpm --dir mobile test src/agent-history` — 41 tests passed.
- `ORCA_BACKGROUND_LAUNCH=1 pnpm --dir mobile typecheck` — passed after generating the normal webview assets.
- Changed-file oxlint, formatter, diff checks and commit hooks passed.
- `node config/scripts/mobile-history-scope-paths-benchmark.mjs 20ab9950654` — output parity and timings above.
- Cross-platform fixtures cover POSIX case sensitivity, NFC/NFD, Windows drives, UNC, WSL aliases/distro boundaries, trailing/repeated separators, and literal POSIX backslashes. Executed on macOS; native Windows/Linux and device UI execution are left to CI.

## Review
The Set is bounded by the existing 64-path output cap and discarded after each derivation. Folder workspace behavior and remote host path interpretation remain unchanged; no local filesystem access, status ownership, wire, or provider behavior is introduced.

## Agent skill upstream boundary
- [x] Not applicable.

## Checklist
- [x] Small, focused change with measurements and regression coverage.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and folder-workspace impact considered.
- [x] Mobile history tests, mobile typecheck, and changed-file lint/format passed. Full application build and broader suites left to CI.
