### PR TITLE
perf(checks): bound earlier error context collection

### DIFF
--- a/src/shared/check-job-log-tail-slice.test.ts
+++ b/src/shared/check-job-log-tail-slice.test.ts
@@ -6,6 +6,31 @@ import {
 } from './check-job-log-tail-slice'
 
 describe('sliceCheckLogTail', () => {
+  it.each([1, 2, 3, 5, 7, 11, 31, 100])(
+    'preserves the newest 30 earlier context lines with errors every %i lines',
+    (spacing) => {
+      const lines = Array.from({ length: 500 }, (_, index) =>
+        index % spacing === 0 ? `error: failure ${index}` : `line ${index}`
+      )
+      const selected = new Set<number>()
+      for (let error = 0; error < 400; error += spacing) {
+        for (let offset = -2; offset <= 2; offset++) {
+          if (error + offset >= 0 && error + offset < 400) {
+            selected.add(error + offset)
+          }
+        }
+      }
+      const context = [...selected].sort((a, b) => a - b).slice(-30)
+      expect(sliceCheckLogTail(lines.join('\n'))).toBe(
+        [
+          ...context.map((index) => lines[index]),
+          PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR,
+          ...lines.slice(400)
+        ].join('\n')
+      )
+    }
+  )
+
   it('keeps the recent tail when no earlier error markers are present', () => {
     const logLines = Array.from({ length: 210 }, (_, index) => `line ${index}`)
     const sliced = sliceCheckLogTail(logLines.join('\n'))

--- a/src/shared/check-job-log-tail-slice.ts
+++ b/src/shared/check-job-log-tail-slice.ts
@@ -34,14 +34,17 @@ function joinLogExcerptWithByteCap(prefixLines: string[], recentLines: string[])
 
 function collectEarlierErrorLineIndexes(lines: string[], recentStart: number): number[] {
   const indexes = new Set<number>()
-  for (let index = 0; index < recentStart; index += 1) {
+  for (let index = recentStart - 1; index >= 0; index -= 1) {
     if (!ERROR_LINE_PATTERN.test(lines[index] ?? '')) {
       continue
     }
     const contextStart = Math.max(0, index - PR_CHECK_LOG_TAIL_ERROR_CONTEXT_LINES)
     const contextEnd = Math.min(recentStart - 1, index + PR_CHECK_LOG_TAIL_ERROR_CONTEXT_LINES)
-    for (let contextIndex = contextStart; contextIndex <= contextEnd; contextIndex += 1) {
+    for (let contextIndex = contextEnd; contextIndex >= contextStart; contextIndex -= 1) {
       indexes.add(contextIndex)
+      if (indexes.size === PR_CHECK_LOG_TAIL_MAX_EARLIER_LINES) {
+        return [...indexes].sort((left, right) => left - right)
+      }
     }
   }
   return [...indexes].sort((left, right) => left - right)

--- a/src/shared/check-job-log-tail-slice.ts
+++ b/src/shared/check-job-log-tail-slice.ts
@@ -34,6 +34,7 @@ function joinLogExcerptWithByteCap(prefixLines: string[], recentLines: string[])
 
 function collectEarlierErrorLineIndexes(lines: string[], recentStart: number): number[] {
   const indexes = new Set<number>()
+  // Newest-first errors and descending windows add the newest unique indexes first.
   for (let index = recentStart - 1; index >= 0; index -= 1) {
     if (!ERROR_LINE_PATTERN.test(lines[index] ?? '')) {
       continue


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5
Large failed-job logs produce the same excerpt without collecting thousands of error lines that will be discarded.

## What Changed
Scan earlier error markers backwards and stop once the newest 30 context lines are known. Retain ascending output order, overlapping-context deduplication and existing byte caps. Shared by GitHub and GitLab.

## Why
Measured the full sliceCheckLogTail operation on Windows Node 24, 200,000-line synthetic logs, median of 11 samples:

| Error spacing | Before | After |
| --- | --- | --- |
| Every line (4.29 MB) | 20.75 ms | 3.69 ms |
| Every 10 lines | 10.98 ms | 3.63 ms |
| Every 1,000 lines | 6.60 ms | 3.78 ms |
| Only first line | 6.95 ms | 6.65 ms |

Log splitting still processes the full input. These measure local excerpt generation, not download latency.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — excerpt content and interaction behavior remain identical.

## Testing
- 12 focused tests passed on Windows, including eight dense/sparse/overlapping context fixtures checked against the original forward-collection algorithm.
- All benchmark inputs produced identical complete excerpts before and after.
- Node typecheck, targeted lint and formatting passed.
- Installed tools invoked directly with ORCA_BACKGROUND_LAUNCH=1; pnpm dependency rebuilding encountered native FTK1011 long-path errors.

## Review
Descending error windows add context in descending order, so earlier windows cannot add a newer index once 30 unique indexes are retained. No API, SSH routing, git command or workspace assumptions change.

## Agent skill upstream boundary
- [x] Not applicable.


## Review follow-up

Documented the descending-addition invariant beside the loop: newest-first errors and descending context windows produce the newest unique indexes first. This explains why stopping at the existing cap preserves the original excerpt. All 12 log-excerpt tests and targeted lint/format checks pass.
