### PR TITLE
perf(tooling): reuse directory entry types in source scans

### DIFF
--- a/config/scripts/source-tree-walk-benchmark.mjs
+++ b/config/scripts/source-tree-walk-benchmark.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { stripTypeScriptTypes } from 'node:module'
+import { resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+import { summarizeBenchmarkSamples } from './benchmark-sample-summary.mjs'
+
+// git show <baseline-ref>:src/shared/source-scan/source-tree-scan.ts | node config/scripts/source-tree-walk-benchmark.mjs
+async function load(source) {
+  const code = stripTypeScriptTypes(source)
+  return (await import(`data:text/javascript;base64,${Buffer.from(code).toString('base64')}`))
+    .scanSourceTree
+}
+const baseline = readFileSync(0, 'utf8')
+assert.ok(baseline.includes('function scanSourceTree'), 'Pipe the baseline source into stdin')
+const implementations = {
+  before: await load(baseline),
+  after: await load(readFileSync('src/shared/source-scan/source-tree-scan.ts', 'utf8'))
+}
+function fingerprint(files) {
+  const hash = createHash('sha256')
+  for (const file of files) {
+    for (const value of [file.path, file.relativePath, file.source]) {
+      hash
+        .update(String(Buffer.byteLength(value)))
+        .update(':')
+        .update(value)
+    }
+  }
+  return hash.digest('hex')
+}
+const results = []
+for (const directory of ['src', 'mobile/src', 'cloud/apps']) {
+  const root = resolve(directory)
+  const original = implementations.before(root)
+  const expected = fingerprint(original)
+  assert.deepEqual(implementations.after(root), original)
+  const samples = { before: [], after: [] }
+  for (let warmup = 0; warmup < 2; warmup += 1) {
+    for (const run of Object.values(implementations)) {
+      run(root)
+    }
+  }
+  for (const pair of buildCounterbalancedSchedule(8, 'before', 'after')) {
+    for (const arm of pair) {
+      const started = performance.now()
+      const files = implementations[arm](root)
+      samples[arm].push(performance.now() - started)
+      assert.equal(fingerprint(files), expected, `${directory} ${arm} inventory changed`)
+    }
+  }
+  results.push({
+    directory,
+    files: original.length,
+    sourceBytes: original.reduce((bytes, file) => bytes + Buffer.byteLength(file.source), 0),
+    fingerprint: expected,
+    before: summarizeBenchmarkSamples(samples.before),
+    after: summarizeBenchmarkSamples(samples.after)
+  })
+}
+console.log(JSON.stringify({ node: process.version, platform: process.platform, results }, null, 2))

--- a/src/shared/source-scan/source-tree-scan.ts
+++ b/src/shared/source-scan/source-tree-scan.ts
@@ -46,16 +46,18 @@ export function scanSourceTree(
   const extensions = options.extensions ?? /\.tsx?$/
   const found: ScannedFile[] = []
   const visit = (directory: string): void => {
-    for (const entry of readdirSync(directory)) {
-      if (IGNORED_DIRECTORIES.has(entry) || entry.startsWith('.') || entry === '__fixtures__') {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const name = entry.name
+      if (IGNORED_DIRECTORIES.has(name) || name.startsWith('.') || name === '__fixtures__') {
         continue
       }
-      const path = join(directory, entry)
-      if (statSync(path).isDirectory()) {
+      const path = join(directory, name)
+      // Preserve link traversal; ordinary entries already carry their type from readdir.
+      if (entry.isSymbolicLink() ? statSync(path).isDirectory() : entry.isDirectory()) {
         visit(path)
         continue
       }
-      if (!extensions.test(entry)) {
+      if (!extensions.test(name)) {
         continue
       }
       const relativePath = relative(root, path).replace(/\\/g, '/')

--- a/src/shared/source-scan/source-tree-walk.test.ts
+++ b/src/shared/source-scan/source-tree-walk.test.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs'
+import type * as Fs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { scanSourceTree } from './source-tree-scan'
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof Fs>()
+  return { ...actual, statSync: vi.fn(actual.statSync) }
+})
+
+let root: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'orca-source-tree-walk-'))
+  vi.mocked(statSync).mockClear()
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+function file(relativePath: string, contents = relativePath): void {
+  writeFileSync(join(root, relativePath), contents)
+}
+
+describe('scanSourceTree filesystem traversal', () => {
+  it('reads nested source files without stat calls for ordinary directory entries', () => {
+    mkdirSync(join(root, 'nested'))
+    file('first.ts')
+    file(join('nested', 'second.tsx'), 'nested/second.tsx')
+    file('ignored.txt')
+    file('first.test.ts')
+
+    const files = scanSourceTree(root)
+
+    expect(files).toEqual([
+      { path: join(root, 'first.ts'), relativePath: 'first.ts', source: 'first.ts' },
+      {
+        path: join(root, 'nested', 'second.tsx'),
+        relativePath: 'nested/second.tsx',
+        source: 'nested/second.tsx'
+      }
+    ])
+    expect(statSync).not.toHaveBeenCalled()
+  })
+
+  it('keeps ignored directories, dotfiles, and test exclusions out of the inventory', () => {
+    for (const directory of ['node_modules', 'dist', 'out', 'build', '.cache', '__fixtures__']) {
+      mkdirSync(join(root, directory))
+      file(join(directory, 'hidden.ts'))
+    }
+    file('.hidden.ts')
+    file('sample.test.ts')
+    file('sample.spec.tsx')
+    file('test-harness.ts')
+    file('production.ts')
+
+    expect(scanSourceTree(root).map((entry) => entry.relativePath)).toEqual(['production.ts'])
+  })
+
+  it('keeps extension and test-inclusion options', () => {
+    file('module.mjs')
+    file('module.ts')
+    file('module.test.ts')
+
+    expect(scanSourceTree(root, { includeTests: true }).map((entry) => entry.relativePath)).toEqual(
+      ['module.test.ts', 'module.ts']
+    )
+    expect(
+      scanSourceTree(root, { extensions: /\.mjs$/ }).map((entry) => entry.relativePath)
+    ).toEqual(['module.mjs'])
+  })
+
+  it('follows directory links with stat while preserving the lexical path', () => {
+    const target = join(root, '.target')
+    mkdirSync(target)
+    writeFileSync(join(target, 'linked.ts'), 'linked source')
+    symlinkSync(target, join(root, 'alias'), 'junction')
+
+    expect(scanSourceTree(root)).toEqual([
+      {
+        path: join(root, 'alias', 'linked.ts'),
+        relativePath: 'alias/linked.ts',
+        source: 'linked source'
+      }
+    ])
+    expect(statSync).toHaveBeenCalledExactlyOnceWith(join(root, 'alias'))
+  })
+
+  it('still reports a broken link instead of silently dropping it', () => {
+    const target = join(root, '.target')
+    mkdirSync(target)
+    symlinkSync(target, join(root, 'alias'), 'junction')
+    rmSync(target, { recursive: true })
+
+    expect(() => scanSourceTree(root)).toThrow(/ENOENT/)
+    expect(statSync).toHaveBeenCalledExactlyOnceWith(join(root, 'alias'))
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​144 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​144 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 |

<!-- /orca-pr-loc -->

## ELI5

Repository checks were asking the filesystem for each file's type separately. Directory listings already supply that information, so use it and keep the extra lookup only for symbolic links.

## What Changed

Use `readdirSync(..., { withFileTypes: true })` in the existing `scanSourceTree` walker. Preserve directory traversal, ignored names, test/extension filtering, lexical paths, and symlink handling. Symbolic links still go through `statSync`, including its error for broken links.

## Why

Several repository-wide safety checks share this walker. Each walk previously called `statSync` for every nonignored entry, including files it subsequently excluded.

Measured the actual baseline and candidate functions over the current checkout, with eight counterbalanced pairs after warmup (macOS arm64, Node 26.6.0):

| Tree | Scanned files | Before median | After median |
| --- | ---: | ---: | ---: |
| `src` | 12,789 | 264.5 ms | 236.5 ms |
| `mobile/src` | 998 | 18.8 ms | 16.2 ms |
| `cloud/apps` | 100 | 2.0 ms | 1.7 ms |

The main tree walk is about 11% faster. This improves development/CI scanning; it is not a claim about application latency. The benchmark compares complete results up front and verifies ordered path/content fingerprints after every measured walk. OS-specific directory-type fallback costs can differ.

## Linked Issue

Refs #20206. Performance audit PR 2, independent of PR #20208.

## Visual Proof

N/A — no application UI or interactions change.

## Testing

- [x] 85 tests pass across the walker, source parsing, and every direct scanner-dependent test suite found in the checkout.
- [x] Real filesystem fixtures cover nested files, ignored paths, options, directory links/junctions, and broken links. Operation-count tests fail on the baseline and pass after the change: ordinary directory entries require no explicit stat calls; link traversal retains its stat call.
- [x] `ORCA_BACKGROUND_LAUNCH=1 pnpm tc` passes; `pnpm tc:node` passes after the test type-import cleanup.
- [x] Changed-code quality gate passes.
- [x] Locally verified on macOS. Windows/Linux execution remains CI coverage; the directory-link fixtures use junctions on Windows without requiring file-symlink privileges.

Reproduce from the repository root:

```sh
git show 20ab99506541:src/shared/source-scan/source-tree-scan.ts | node config/scripts/source-tree-walk-benchmark.mjs
```

## Review

No Git subprocess, remote execution, RPC, agent status, or workspace assumptions change. The walker continues to use Node path utilities and preserve normalized relative paths. Existing symlink traversal is retained rather than silently excluding linked source.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] Small, focused change with measured benefit.
- [x] Self-reviewed and compatible behavior covered by tests.
- [x] Targeted tests, full typecheck and changed-file lint pass.
- [ ] Full lint, full test suite and build: CI coverage pending.
