### PR TITLE
perf(automations): skip sorting count-only Hermes history

### DIFF
--- a/src/main/automations/hermes-cron-output.test.ts
+++ b/src/main/automations/hermes-cron-output.test.ts
@@ -277,6 +277,31 @@ Run summary: monitor automation completed successfully.
     expect(fakePrepareSqls.some((sql) => sql.includes('FROM messages'))).toBe(false)
   })
 
+  it('skips date sorting for counts while keeping paginated runs newest first', async () => {
+    const home = await createHermesHome()
+    await writeFile(join(home, 'state.db'), '')
+    fakeDbRows.sessions = [
+      { id: 'cron_job-1_older', started_at: 1000 },
+      { id: 'cron_job-1_newer', started_at: 2000 }
+    ]
+    const { readHermesCronOutputRunsPage } = await loadReader()
+    const parse = vi.spyOn(Date, 'parse')
+    try {
+      await expect(
+        readHermesCronOutputRunsPage('job-1', { page: 1, pageSize: 0 })
+      ).resolves.toEqual({
+        total: 2,
+        runs: []
+      })
+      expect(parse).not.toHaveBeenCalled()
+    } finally {
+      parse.mockRestore()
+    }
+    const page = await readHermesCronOutputRunsPage('job-1', { page: 1, pageSize: 1 })
+    expect(page.total).toBe(2)
+    expect(page.runs).toMatchObject([{ id: 'cron_job-1_newer' }])
+  })
+
   it('caches count-only reads until the cache is cleared', async () => {
     const home = await createHermesHome()
     const outputDir = join(home, 'cron', 'output', 'job-1')

--- a/src/main/automations/hermes-cron-output.ts
+++ b/src/main/automations/hermes-cron-output.ts
@@ -65,16 +65,7 @@ export async function readHermesCronOutputRuns(jobId: string): Promise<unknown[]
 
 async function readHermesCronOutputRunRefs(jobId: string): Promise<HermesMergedRunRef[]> {
   const outputRuns = await readHermesOutputFileRunRefs(jobId)
-  return mergeHermesOutputAndSessionRunRefs(outputRuns, readHermesSessionDbRunRefs(jobId)).sort(
-    (a, b) => {
-      const aTime = getRawRunTime(a)
-      const bTime = getRawRunTime(b)
-      if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
-        return bTime - aTime
-      }
-      return getRawRunId(b).localeCompare(getRawRunId(a))
-    }
-  )
+  return mergeHermesOutputAndSessionRunRefs(outputRuns, readHermesSessionDbRunRefs(jobId))
 }
 
 // Why: opening the Automations page calls readHermesCronOutputRunsPage with
@@ -127,6 +118,14 @@ export async function readHermesCronOutputRunsPage(
     return { total: await readHermesCronOutputRunCount(jobId), runs: [] }
   }
   const runRefs = await readHermesCronOutputRunRefs(jobId)
+  runRefs.sort((a, b) => {
+    const aTime = getRawRunTime(a)
+    const bTime = getRawRunTime(b)
+    if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
+      return bTime - aTime
+    }
+    return getRawRunId(b).localeCompare(getRawRunId(a))
+  })
   const start = (safePage - 1) * safePageSize
   const pageRefs = runRefs.slice(start, start + safePageSize)
   return {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5
Refreshing Hermes automation run counts no longer sorts history that will never be displayed.

## What Changed
Move the existing date/ID sort from shared reference loading to the paginated listing path. Count-only reads keep the same merged and deduplicated references, cache behavior and result.

## Why
Windows Node 24 measurement of readHermesCronOutputRunsPage(pageSize:0), median of15 cold count-cache samples: 1,000 session refs 0.817 to0.663 ms; 10,000 refs 7.652 to5.704 ms. Database retrieval was mocked with ordered session rows; real filesystem existence checks and all reference conversion/merge work ran. This isolates local processing and does not claim disk or end-to-end UI speedup.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — counts and displayed run ordering are unchanged.

## Testing
- Eight existing/new Hermes reader tests passed on Windows.
- Regression test verifies count-only reads perform no Date.parse sorting, while a subsequent paginated read returns the newest run.
- Node typecheck, targeted lint and formatting passed using installed binaries with ORCA_BACKGROUND_LAUNCH=1.
- pnpm dependency rebuilding is unavailable locally due to native FTK1011 long-path tracking errors.

## Review
The same comparator now runs immediately before pagination. No cache TTL, hydration, merge matching, remote routing or workspace assumptions change.

## Agent skill upstream boundary
- [x] Not applicable.
