### PR TITLE
perf(chat): reuse streamed delta byte lengths

### DIFF
--- a/src/main/native-chat/agent-session-wire/agent-session-delta-coalescer.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-delta-coalescer.ts
@@ -165,7 +165,8 @@ export function createAgentSessionDeltaCoalescer(
       } else if (deps.isProtected?.(key)) {
         evictable.delete(key)
       }
-      stream.observedBytes += Buffer.byteLength(delta, 'utf8')
+      const deltaBytes = Buffer.byteLength(delta, 'utf8')
+      stream.observedBytes += deltaBytes
       if (!stream.truncated) {
         const availableTotal = Math.max(0, maxTotalRetainedBytes - totalRetainedBytes)
         const streamLimit = Math.min(maxRetainedBytes, stream.retainedBytes + availableTotal)
@@ -173,6 +174,7 @@ export function createAgentSessionDeltaCoalescer(
           stream.chunks,
           stream.retainedBytes,
           delta,
+          deltaBytes,
           streamLimit
         )
         totalRetainedBytes += next.retainedBytes - stream.retainedBytes
@@ -221,17 +223,17 @@ function appendWithinUtf8ByteLimit(
   current: string[],
   currentBytes: number,
   delta: string,
+  deltaBytes: number,
   maxBytes: number
 ): { chunks: string[]; retainedBytes: number; truncated: boolean } {
   const available = Math.max(0, maxBytes - currentBytes)
-  const deltaBuffer = Buffer.from(delta, 'utf8')
-  if (deltaBuffer.byteLength <= available) {
+  if (deltaBytes <= available) {
     // The caller owns the per-stream array; append in place so each token is
     // amortized O(1) instead of copying the complete prefix on every delta.
     current.push(delta)
     return {
       chunks: current,
-      retainedBytes: currentBytes + deltaBuffer.byteLength,
+      retainedBytes: currentBytes + deltaBytes,
       truncated: false
     }
   }
@@ -239,7 +241,7 @@ function appendWithinUtf8ByteLimit(
   const headBytes = Math.max(0, maxBytes - marker.byteLength)
   const combined = Buffer.concat([
     ...current.map((chunk) => Buffer.from(chunk, 'utf8')),
-    deltaBuffer
+    Buffer.from(delta, 'utf8')
   ])
   let end = Math.min(combined.byteLength, headBytes)
   while (end > 0 && (combined[end] & 0b1100_0000) === 0b1000_0000) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5
Streaming assistant text no longer allocates a temporary buffer for every token just to count its bytes.

## What Changed
Reuse the UTF-8 byte length already calculated for observedBytes when deciding whether the delta fits the retained-text budget. Allocate the delta buffer only in the existing truncation branch.

## Why
Windows Node24 public coalescer append benchmark, median11 samples:

| Input | Appends | Before | After |
| --- | --- | --- | --- |
| hello |100,000|6.48 ms|3.11 ms|
| mixed CJK/emoji |100,000|8.37 ms|2.91 ms|
|1 KiB ASCII |10,000|5.67 ms|2.31 ms|

Synthetic in-memory append measurements; no end-to-end UI latency claim. Removes one Buffer.from allocation per untruncated delta.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — emitted text, byte counts, scheduling and truncation are unchanged.

## Testing
-14 existing coalescer/protected-stream tests passed on Windows.
-Complete before/after snapshot and emission parity across nine byte caps, multiple streams, CJK, emoji and isolated surrogate inputs.
-Node typecheck, targeted lint and formatting passed with ORCA_BACKGROUND_LAUNCH=1 using installed tools.
-Existing tests cover the behavior; no new test for passing an already-computed byte count.

## Review
Buffer.byteLength(delta, utf8) equals Buffer.from(delta, utf8).byteLength for the same string. Truncation still encodes the same bytes. No wire format, host ownership, workspace or client-version behavior changes.

## Agent skill upstream boundary
- [x] Not applicable.
