### PR TITLE
perf(files): skip unused Quick Open byte accounting

### DIFF
--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -132,12 +132,14 @@ export async function listQuickOpenFiles(
         if (maxResults !== undefined && files.size >= maxResults) {
           return true
         }
-        const nextBytes = serializedQuickOpenPathBytes(relPath) + (files.size === 0 ? 0 : 1)
-        if (maxSerializedBytes !== undefined && serializedBytes + nextBytes > maxSerializedBytes) {
-          return true
+        if (maxSerializedBytes !== undefined) {
+          const nextBytes = serializedQuickOpenPathBytes(relPath) + (files.size === 0 ? 0 : 1)
+          if (serializedBytes + nextBytes > maxSerializedBytes) {
+            return true
+          }
+          serializedBytes += nextBytes
         }
         files.add(relPath)
-        serializedBytes += nextBytes
         return maxResults !== undefined && files.size >= maxResults
       }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5
Quick Open stops serializing file paths to enforce a byte limit when the caller did not request one.

## What Changed
Only calculate and accumulate serializedQuickOpenPathBytes when maxSerializedBytes is defined. Local runtime listing callers omit the limit. Calls with remote transport budgets retain the same accounting, cutoff, ordering and cancellation behavior.

## Why
Windows Node24 isolated path-collection loop, 100,000 representative source paths, median11:12.30 ms with JSON byte accounting versus5.36 ms without. This measures Set insertion plus the removed accounting only; it does not include filesystem traversal or the full Quick Open call. Saves one JSON serialization/byte count per accepted path on unbounded calls.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — file results and interaction behavior are unchanged.

## Testing
-27 tests passed and one skipped across filesystem-list-files, install-rg and quick-open-transport-budget suites on Windows.
-Node typecheck, targeted lint, formatting and diff whitespace checks passed with ORCA_BACKGROUND_LAUNCH=1 using installed tools.
-Existing tests exercise result budgets and remote serialized-byte limits; no new test for this equivalent conditional accounting.

## Review
The request-scoped limit never changes during a listing. The accumulated count has no consumer when the limit is undefined. No Git commands, host routing, path authorization or folder/worktree behavior changed.

## Agent skill upstream boundary
- [x] Not applicable.
