### PR TITLE
perf(browser): index snapshot iframe reference sessions

### DIFF
--- a/src/main/browser/snapshot-engine.test.ts
+++ b/src/main/browser/snapshot-engine.test.ts
@@ -46,6 +46,25 @@ function node(
 }
 
 describe('buildSnapshot', () => {
+  it('keeps references routed to their own iframe session', async () => {
+    const tree = [
+      node('1', 'WebArea', 'page', { childIds: ['2'] }),
+      node('2', 'button', 'Submit', { backendDOMNodeId: 10 })
+    ]
+    const sessions = new Map([
+      ['frame-a', 'session-a'],
+      ['frame-b', 'session-b']
+    ])
+    const result = await buildSnapshot(makeSender(tree), sessions, () => makeSender(tree))
+    expect(result.refs.map((ref) => ref.ref)).toEqual(['@e1', '@e2', '@e3'])
+    expect([...result.refMap.values()].map((entry) => entry.sessionId)).toEqual([
+      undefined,
+      'session-a',
+      'session-b'
+    ])
+    expect([...result.refMap.values()].map((entry) => entry.backendDOMNodeId)).toEqual([10, 10, 10])
+  })
+
   it('returns empty snapshot for empty tree', async () => {
     const result = await buildSnapshot(makeSender([]))
     expect(result.snapshot).toBe('')

--- a/src/main/browser/snapshot-engine.ts
+++ b/src/main/browser/snapshot-engine.ts
@@ -61,7 +61,7 @@ export async function buildSnapshot(
   // Why: cross-origin iframes have their own AX trees accessible only through
   // their dedicated CDP session. Append their elements after the parent tree
   // so the agent can see and interact with iframe content.
-  const iframeRefSessions: { ref: string; sessionId: string }[] = []
+  const iframeRefSessions = new Map<string, string>()
   if (iframeSessions && makeIframeSender && iframeSessions.size > 0) {
     for (const [_frameId, sessionId] of iframeSessions) {
       try {
@@ -82,7 +82,7 @@ export async function buildSnapshot(
           const startRef = refCounter
           walkTree(iframeRoot, iframeNodeById, 1, entries, () => refCounter++)
           for (let i = startRef; i < refCounter; i++) {
-            iframeRefSessions.push({ ref: `@e${i}`, sessionId })
+            iframeRefSessions.set(`@e${i}`, sessionId)
           }
         }
       } catch {
@@ -120,12 +120,11 @@ export async function buildSnapshot(
       }
       lines.push(`${indent}[${entry.ref}] ${entry.role} "${displayName}"`)
       refs.push({ ref: entry.ref, role: entry.role, name: displayName })
-      const iframeSession = iframeRefSessions.find((s) => s.ref === entry.ref)
       refMap.set(entry.ref, {
         backendDOMNodeId: entry.backendDOMNodeId,
         role: entry.role,
         name: entry.name,
-        sessionId: iframeSession?.sessionId,
+        sessionId: iframeRefSessions.get(entry.ref),
         nth: total > 1 ? nth : undefined
       })
     } else {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5
Browser snapshots stop searching every iframe reference for each interactive element.

## What Changed
Store generated iframe reference IDs in a Map and look up their CDP session directly. The monotonically increasing reference counter guarantees unique keys. Snapshot text, reference numbering, duplicate-name ordinals and routing stay unchanged.

## Why
Windows Node24 full buildSnapshot benchmark with mocked main/iframe accessibility responses, median11:

| Controls per main page and iframe | Before | After |
| --- | --- | --- |
|100 each|0.269 ms|0.188 ms|
|1,000 each|4.118 ms|1.165 ms|
|5,000 each|90.099 ms|6.900 ms|

Includes tree walking and complete snapshot construction, excludes real CDP transport/page time. All benchmark results deep-equal before and after, including refMap.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — no rendered UI or snapshot content changes; this replaces internal reference lookup only.

## Testing
-13 snapshot tests passed on Windows, including new multi-iframe routing coverage with repeated backend node IDs.
-Complete before/after result parity at all benchmark sizes.
-Node typecheck, targeted lint and formatting passed using installed tools with ORCA_BACKGROUND_LAUNCH=1.
-No GUI launched; browser transport is mocked in the measurement.

## Review
References are assigned once by a shared counter across main page and iframe trees. Each map key has one writer, preserving the former first-match behavior. No remote protocol, host routing or workspace assumptions change.

## Agent skill upstream boundary
- [x] Not applicable.
