### PR TITLE
perf(relay): reuse host data attachment owner without inventory copies

### DIFF
--- a/cloud/apps/relay/src/host-session-client-accept.test.ts
+++ b/cloud/apps/relay/src/host-session-client-accept.test.ts
@@ -424,6 +424,8 @@ describe('successful client accept timing', () => {
       ) as { connId: string; connTicket: string }
       // The desktop's data leg is the attach window this is meant to expose.
       now += 23
+      const session = h.registry.get({ userId: identity.sub, relayHostId: identity.relayHostId })!
+      const ownerProbe = vi.spyOn(session.pendingConns, 'has')
       const accepted = await h.registry.acceptHostData(
         hostData as unknown as WebSocket,
         connOpen.connId,
@@ -432,6 +434,7 @@ describe('successful client accept timing', () => {
       )
 
       expect(accepted).toBe(true)
+      expect(ownerProbe).toHaveBeenCalledOnce()
       expect(h.observer.recordClientAcceptCompleted).toHaveBeenCalledWith({
         totalMs: 49,
         stageMs: { assignment: 5, credential: 7, activity: 11, attach: 23, basis: 3 }

--- a/cloud/apps/relay/src/host-session-owner-scan.test.ts
+++ b/cloud/apps/relay/src/host-session-owner-scan.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import type WebSocket from 'ws'
+import { RELAY_CLOSE_CODE } from '@orca-cloud/relay-contract'
+import { HostSessionRegistry, type HostSession } from './host-session-registry.js'
+
+describe('host data owner lookup', () => {
+  it.each([0, 299, 599, -1])('stops at the first owner (position %s)', async (ownerIndex) => {
+    const recordAuth = vi.fn()
+    const registry = new HostSessionRegistry(
+      ...([{}, vi.fn(), {}, {}, {}, { recordAuth }] as unknown as ConstructorParameters<
+        typeof HostSessionRegistry
+      >)
+    )
+    const sessions = (registry as unknown as { sessions: Map<string, HostSession> }).sessions
+    for (let index = 0; index < 600; index++) {
+      sessions.set(`host-${index}`, {
+        relayHostId: `host-${index}`,
+        pendingConns: new Map(index === ownerIndex ? [['connection', { connTicket: 'secret' }]] : [])
+      } as unknown as HostSession)
+    }
+    let visited = 0
+    const values = sessions.values.bind(sessions)
+    vi.spyOn(sessions, 'values').mockImplementation(() => {
+      const iterator = values()
+      const next = iterator.next.bind(iterator)
+      iterator.next = () => {
+        const result = next()
+        if (!result.done) visited++
+        return result
+      }
+      return iterator
+    })
+    const close = vi.fn()
+    expect(
+      await registry.acceptHostData({ close } as unknown as WebSocket, 'connection', 'wrong', 1)
+    ).toBe(false)
+    expect(close).toHaveBeenCalledWith(
+      RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL,
+      'invalid host data ticket'
+    )
+    expect(recordAuth).toHaveBeenCalledExactlyOnceWith(false)
+    expect(visited).toBe(ownerIndex === -1 ? 600 : ownerIndex + 1)
+  })
+})

--- a/cloud/apps/relay/src/host-session-registry.ts
+++ b/cloud/apps/relay/src/host-session-registry.ts
@@ -511,16 +511,20 @@ export class HostSessionRegistry {
     connTicket: string,
     generation: number
   ): Promise<boolean> {
-    const owner = [...this.sessions.values()].find((candidate) =>
-      candidate.pendingConns.has(connId)
-    )
+    let owner: HostSession | undefined
+    for (const candidate of this.sessions.values()) {
+      if (candidate.pendingConns.has(connId)) {
+        owner = candidate
+        break
+      }
+    }
     const release = owner ? this.beginIdleWork(owner.relayHostId) : () => {}
     if (!release) {
       socket.close(RELAY_CLOSE_CODE.WRONG_CELL, 'idle cutover in progress')
       return false
     }
     try {
-      return await this.acceptHostDataUnfenced(socket, connId, connTicket, generation)
+      return await this.acceptHostDataUnfenced(socket, connId, connTicket, generation, owner)
     } finally {
       release()
     }
@@ -530,11 +534,9 @@ export class HostSessionRegistry {
     socket: WebSocket,
     connId: string,
     connTicket: string,
-    generation: number
+    generation: number,
+    session: HostSession | undefined
   ): Promise<boolean> {
-    const session = [...this.sessions.values()].find((candidate) =>
-      candidate.pendingConns.has(connId)
-    )
     const pending = session?.pendingConns.get(connId)
     if (
       !session ||


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5
When a host attaches a data socket, the relay now finds its pending connection once instead of copying and searching the host inventory twice.

## What Changed
Walk the session Map until the first owner matches, then pass that same owner to the existing attachment method. Remove both temporary inventory arrays and the redundant lookup.

## Why
There is no await or external callback between owner lookup, `beginIdleWork`, and attachment validation. `beginIdleWork` only checks and updates internal Maps. Reusing this owner therefore preserves the existing fence and validation behavior, while the post-await generation/retirement checks remain intact.

A deterministic production-path test at 600 sessions measures the number of entries consumed from the inventory:

| Owner position | Before | After |
| --- | --- | --- |
| First | 1,200 | 1 |
| Middle | 1,200 | 300 |
| Last | 1,200 | 600 |
| Missing | 1,200 | 600 |

The successful-attachment test additionally observes one pending-owner probe instead of two. All five new count assertions fail against the baseline. This measures removed work; it does not claim an end-to-end network latency improvement.

## Linked Issue
User-requested performance audit; no linked issue supplied.

## Visual Proof
N/A — internal cloud relay computation only; no visual or interaction change.

## Testing
Executed locally on macOS with `ORCA_BACKGROUND_LAUNCH=1`:
- `pnpm --dir cloud --filter @orca-cloud/relay test src/host-session-owner-scan.test.ts src/host-session-client-accept.test.ts src/host-session-registry.test.ts` — 65 passed.
- `pnpm --dir cloud --filter @orca-cloud/relay exec vitest run src/relay.blackbox.test.ts src/relay-first-frame-failure.blackbox.test.ts` — 30 passed, including real server/socket flows.
- `pnpm --dir cloud --filter @orca-cloud/relay typecheck` — passed after the contract packages were built.
- `git diff --check` — passed.

## Review
Preserves Map insertion-order owner selection, missing-owner and bad-ticket rejection, idle cutover fencing, and fence release through asynchronous cleanup. Existing tests cover generation retirement while persistence is pending and idle-rehome ownership during failure cleanup. No new cache, invalidation rule, protocol field, database operation, filesystem dependency, or platform branch. The cloud relay still owns attachment for local, SSH, and folder-workspace clients.

## Agent skill upstream boundary
- [x] Not applicable.

## Checklist
- [x] Small, focused change independent of the mobile history PR.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and folder-workspace impact considered.
- [x] Focused tests, black-box tests, and relay typecheck passed; broader CI remains authoritative for the full cloud suite.
