### PR TITLE
perf(browser): skip unneeded inventory compaction planning

### DIFF
--- a/src/main/browser/browser-client-page-inventory.test.ts
+++ b/src/main/browser/browser-client-page-inventory.test.ts
@@ -3,6 +3,12 @@ import type { BrowserClientHostedPageInventory } from '../../shared/browser-clie
 import { prepareBrowserClientPageInventoryForAttach } from './browser-client-page-inventory'
 
 describe('browser client page inventory', () => {
+  it('keeps URLs and duplicate-page validation when the inventory fits', () => {
+    const page = { ...inventoryPage('page-a'), currentUrl: 'https://example.test/' }
+    expect(prepareBrowserClientPageInventoryForAttach([page])).toEqual([page])
+    expect(prepareBrowserClientPageInventoryForAttach([page, page])).toBeUndefined()
+  })
+
   it('uses codepoint order to break equal URL-compaction ties across input order', () => {
     const pageIds = [
       'ä-page',

--- a/src/main/browser/browser-client-page-inventory.ts
+++ b/src/main/browser/browser-client-page-inventory.ts
@@ -103,6 +103,10 @@ export function prepareBrowserClientPageInventoryForAttach(
     inventory.push(parsed.data)
   }
   let inventoryBytes = browserClientHostedPageInventoryByteLength(inventory)
+  if (inventoryBytes <= BROWSER_CLIENT_HOST_PAGE_INVENTORY_MAX_BYTES) {
+    const prepared = BrowserClientHostedPageInventoryList.safeParse(inventory)
+    return prepared.success ? prepared.data : undefined
+  }
   const optionalUrls = inventory
     .flatMap((page, index) => {
       if (page.currentUrl === undefined) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5
Browser attach requests skip calculating which URLs to remove when the page inventory already fits the payload limit.

## What Changed
Return through the existing full list schema validation before building and sorting optional URL-compaction candidates when the inventory is within its byte budget. Oversized inventories follow the existing compaction path.

## Why
Windows Node24 full prepareBrowserClientPageInventoryForAttach benchmark, median11 batches of100 calls:10 pages0.0785 to0.0568 ms;100 pages0.7559 to0.5416 ms. This is a small behavior-preserving allocation/serialization saving, not an end-to-end attach latency claim. At256 pages the observed difference was only1.945 to1.884 ms.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — inventory fields, URL retention and interaction behavior are unchanged.

## Testing
-20 inventory/protocol tests passed on Windows, including new under-budget URL preservation and duplicate-page rejection coverage.
-Before/after results deep-equal for benchmark sizes, duplicates, invalid records and oversized URL sets.
-Node typecheck, targeted lint and formatting passed using installed tools with ORCA_BACKGROUND_LAUNCH=1.

## Review
The fast path retains full list validation, including duplicate IDs and byte limits. No wire schema, host ownership, workspace or mixed-version behavior changes.

## Agent skill upstream boundary
- [x] Not applicable.
