### PR TITLE
perf(usage): skip session scans for empty breakdowns

### DIFF
--- a/src/main/codex-usage/codex-usage-rollup-projections.ts
+++ b/src/main/codex-usage/codex-usage-rollup-projections.ts
@@ -111,6 +111,9 @@ export function buildBreakdown(
 ): CodexUsageBreakdownRow[] {
   const rows = new Map<string, CodexUsageBreakdownRow>()
   const filteredDaily = getFilteredDaily(state, scope, range)
+  if (filteredDaily.length === 0) {
+    return []
+  }
   const filteredSessions = getFilteredSessions(state, scope, range)
 
   for (const daily of filteredDaily) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5
An empty Codex usage breakdown no longer scans retained session history before returning no rows.

## What Changed
Return early when the requested scope/range has no matching daily aggregates. Those aggregates are the only source of breakdown rows; the later session loop only increments counts on existing rows.

## Why
Windows Node24 full buildBreakdown synthetic benchmark, median15, no matching daily aggregates:1,000 retained sessions0.2195 ms to below0.001 ms;10,000 sessions1.4895 ms to below0.001 ms. No disk access or UI latency included. Model/project results match before and after.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — breakdown rows remain identical.

## Testing
-12 tests passed across Codex usage scope, model pricing, automation usage and snapshot benchmark suites on Windows.
-Node typecheck, targeted lint and formatting passed using installed tools with ORCA_BACKGROUND_LAUNCH=1.
-Existing tests cover scope/aggregation behavior; no new test for this simple empty-input short circuit.

## Review
No session can introduce a breakdown row. The populated path is unchanged. No history cache, file identity, timestamp policy, host routing or wire changes.

## Agent skill upstream boundary
- [x] Not applicable.
