### PR TITLE
perf(session): reuse persisted tab membership set

### DIFF
--- a/src/renderer/src/lib/workspace-session-unified-tabs.ts
+++ b/src/renderer/src/lib/workspace-session-unified-tabs.ts
@@ -7,10 +7,6 @@ type PersistedUnifiedTabSessionData = Pick<
   'activeGroupIdByWorktree' | 'tabGroupLayouts' | 'tabGroups' | 'unifiedTabs'
 >
 
-function dedupePersistedTabIds(tabIds: string[]): string[] {
-  return Array.from(new Set(tabIds))
-}
-
 function prunePersistedLayoutForGroups(
   root: TabGroupLayoutNode,
   validGroupIds: Set<string>
@@ -43,17 +39,18 @@ function buildPersistedGroupsForWorktree(tabs: Tab[], groups: TabGroup[]): TabGr
 
   return groups
     .map((group) => {
-      const tabOrder = dedupePersistedTabIds([
+      const orderedTabIds = new Set([
         ...group.tabOrder.filter((tabId) => validTabIds.has(tabId)),
         ...(tabIdsByGroup.get(group.id) ?? [])
       ])
+      const tabOrder = Array.from(orderedTabIds)
       const activeTabId =
-        group.activeTabId && tabOrder.includes(group.activeTabId) ? group.activeTabId : null
+        group.activeTabId && orderedTabIds.has(group.activeTabId) ? group.activeTabId : null
       return {
         ...group,
         activeTabId,
         tabOrder,
-        recentTabIds: group.recentTabIds?.filter((tabId) => tabOrder.includes(tabId))
+        recentTabIds: group.recentTabIds?.filter((tabId) => orderedTabIds.has(tabId))
       }
     })
     .filter((group) => group.tabOrder.length > 0)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5
Saving workspace sessions reuses the tab-ID Set it already built instead of repeatedly searching the tab array.

## What Changed
Keep the existing deduplication Set available for active/recent-tab membership checks. Preserve insertion order when converting to tabOrder. Remove the single-use wrapper that previously discarded the Set.

## Why
Windows Node24 full buildPersistedUnifiedTabSessionData benchmark, median11 batches of100 calls, one group with equally sized recent-tab history:

| Tabs | Before | After |
| --- | --- | --- |
|10|0.00236 ms|0.00197 ms|
|100|0.01323 ms|0.00792 ms|
|1,000|0.59013 ms|0.06740 ms|

Synthetic in-memory persistence projection; no end-to-end UI or disk latency claim. Avoids quadratic membership work without adding another Set.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — saved session data, ordering and UI behavior are unchanged.

## Testing
-16 local structured-session synchronization tests passed on Windows.
-Complete before/after output parity at benchmark sizes, including duplicate order entries, repeated recent IDs and stale IDs.
-Renderer typecheck, targeted lint and formatting passed with ORCA_BACKGROUND_LAUNCH=1 using installed tools.
-No new test for reusing existing Set membership; existing synchronization coverage plus differential measurement used.

## Review
Set.has and Array.includes have the same equality for string IDs. Set insertion order preserves the old deduplication order. Recent IDs remain filtered without additional deduplication. No wire, host ownership or folder/worktree assumptions change.

## Agent skill upstream boundary
- [x] Not applicable.
