### PR TITLE
perf(mobile): reuse numeric collators across source control sorts

### DIFF
--- a/config/scripts/mobile-source-control-collation-benchmark.mjs
+++ b/config/scripts/mobile-source-control-collation-benchmark.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const baseline = process.argv[2]
+if (!baseline) {
+  throw new Error(
+    'Usage: node config/scripts/mobile-source-control-collation-benchmark.mjs <baseline-ref>'
+  )
+}
+async function load(file, contents, name) {
+  const result = await build({
+    stdin: { contents, loader: 'ts', resolveDir: dirname(resolve(file)) },
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    logLevel: 'silent',
+    tsconfigRaw: {}
+  })
+  return (
+    await import(
+      `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+    )
+  )[name]
+}
+// Match git's path order, including its numeric-looking names, instead of inflating sort work with a shuffle.
+const paths = execFileSync('git', ['ls-files', '-z'], { maxBuffer: 16 * 1024 * 1024 })
+  .toString()
+  .split('\0')
+  .filter(Boolean)
+const results = []
+for (const [file, name] of [
+  ['mobile/src/source-control/mobile-git-status.ts', 'buildMobileSourceControlSections'],
+  ['mobile/src/source-control/mobile-branch-compare.ts', 'buildMobileBranchCompareSection'],
+  ['mobile/src/session/mobile-diff-review-queue.ts', 'buildMobileDiffReviewQueue']
+]) {
+  const arms = {
+    before: await load(
+      file,
+      execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8' }),
+      name
+    ),
+    after: await load(file, readFileSync(file, 'utf8'), name)
+  }
+  for (const count of [0, 1, 17, 63, 1000]) {
+    const step = Math.max(1, Math.floor(paths.length / Math.max(1, count)))
+    const entries = Array.from({ length: count }, (_, index) => ({
+      path: paths[index * step],
+      area: 'unstaged',
+      status: 'modified',
+      ...(index % 37 === 0 ? { conflictStatus: 'unresolved' } : {})
+    }))
+    const input =
+      name === 'buildMobileDiffReviewQueue'
+        ? {
+            worktreeId: 'workspace',
+            statusEntries: entries,
+            branchEntries: [],
+            comments: [],
+            reviewState: { version: 1, files: {} }
+          }
+        : entries
+    assert.deepEqual(arms.after(input), arms.before(input))
+    const iterations = count < 100 ? 100 : 10
+    function run(arm) {
+      const start = performance.now()
+      for (let index = 0; index < iterations; index++) {
+        arms[arm](input)
+      }
+      return (performance.now() - start) / iterations
+    }
+    const samples = { before: [], after: [] }
+    run('before')
+    run('after')
+    for (const pair of buildCounterbalancedSchedule(10, 'before', 'after')) {
+      for (const arm of pair) {
+        samples[arm].push(run(arm))
+      }
+    }
+    function median(values) {
+      const sorted = [...values].sort((a, b) => a - b)
+      return (sorted[4] + sorted[5]) / 2
+    }
+    results.push({
+      name,
+      count,
+      beforeMs: median(samples.before),
+      afterMs: median(samples.after),
+      samples
+    })
+  }
+}
+console.log(
+  JSON.stringify(
+    {
+      baseline,
+      node: process.version,
+      platform: process.platform,
+      locale: new Intl.Collator().resolvedOptions().locale,
+      results
+    },
+    null,
+    2
+  )
+)

--- a/mobile/src/session/mobile-diff-review-queue.ts
+++ b/mobile/src/session/mobile-diff-review-queue.ts
@@ -233,26 +233,25 @@ function branchEntryToQueueItem(
   }
 }
 
-function compareQueueItems(
-  first: MobileDiffReviewQueueItem,
-  second: MobileDiffReviewQueueItem
-): number {
-  return (
-    SCOPE_SORT_ORDER[first.scope] - SCOPE_SORT_ORDER[second.scope] ||
-    Number(first.isGeneratedOrLockFile) - Number(second.isGeneratedOrLockFile) ||
-    first.filePath.localeCompare(second.filePath, undefined, { numeric: true })
-  )
-}
-
 export function buildMobileDiffReviewQueue(
   input: BuildMobileDiffReviewQueueInput
 ): MobileDiffReviewQueueItem[] {
-  return [
+  const queue = [
     ...input.statusEntries.map((entry) =>
       statusEntryToQueueItem(entry, input.comments, input.reviewState)
     ),
     ...input.branchEntries.map((entry) => branchEntryToQueueItem(entry, input))
-  ].sort(compareQueueItems)
+  ]
+  if (queue.length > 1) {
+    const collator = new Intl.Collator(undefined, { numeric: true })
+    queue.sort(
+      (first, second) =>
+        SCOPE_SORT_ORDER[first.scope] - SCOPE_SORT_ORDER[second.scope] ||
+        Number(first.isGeneratedOrLockFile) - Number(second.isGeneratedOrLockFile) ||
+        collator.compare(first.filePath, second.filePath)
+    )
+  }
+  return queue
 }
 
 export function filterMobileDiffReviewQueue(

--- a/mobile/src/source-control/mobile-branch-compare.ts
+++ b/mobile/src/source-control/mobile-branch-compare.ts
@@ -15,22 +15,20 @@ export type MobileBranchCompareSection<
   data: TEntry[]
 }
 
-function compareBranchEntries(
-  a: MobileGitBranchChangeEntry,
-  b: MobileGitBranchChangeEntry
-): number {
-  return a.path.localeCompare(b.path, undefined, { numeric: true })
-}
-
 export function buildMobileBranchCompareSection<TEntry extends MobileGitBranchChangeEntry>(
   entries: readonly TEntry[]
 ): MobileBranchCompareSection<TEntry> | null {
   if (entries.length === 0) {
     return null
   }
+  const data = [...entries]
+  if (data.length > 1) {
+    const collator = new Intl.Collator(undefined, { numeric: true })
+    data.sort((a, b) => collator.compare(a.path, b.path))
+  }
   return {
     title: 'Committed on Branch',
-    data: [...entries].sort(compareBranchEntries)
+    data
   }
 }
 

--- a/mobile/src/source-control/mobile-git-status.ts
+++ b/mobile/src/source-control/mobile-git-status.ts
@@ -36,13 +36,6 @@ export const MOBILE_GIT_STATUS_LABELS: Record<MobileGitFileStatus, string> = {
   copied: 'C'
 }
 
-function compareGitStatusEntries(a: MobileGitStatusEntry, b: MobileGitStatusEntry): number {
-  return (
-    getConflictSortRank(a) - getConflictSortRank(b) ||
-    a.path.localeCompare(b.path, undefined, { numeric: true })
-  )
-}
-
 function getConflictSortRank(entry: MobileGitStatusEntry): number {
   if (entry.conflictStatus === 'unresolved') {
     return 0
@@ -56,11 +49,21 @@ function getConflictSortRank(entry: MobileGitStatusEntry): number {
 export function buildMobileSourceControlSections<TEntry extends MobileGitStatusEntry>(
   entries: readonly TEntry[]
 ): MobileSourceControlSection<TEntry>[] {
-  return AREA_ORDER.map((area) => ({
+  const sections = AREA_ORDER.map((area) => ({
     area,
     title: AREA_TITLES[area],
-    data: entries.filter((entry) => entry.area === area).sort(compareGitStatusEntries)
+    data: entries.filter((entry) => entry.area === area)
   })).filter((section) => section.data.length > 0)
+  if (sections.some((section) => section.data.length > 1)) {
+    const collator = new Intl.Collator(undefined, { numeric: true })
+    for (const section of sections) {
+      section.data.sort(
+        (a, b) =>
+          getConflictSortRank(a) - getConflictSortRank(b) || collator.compare(a.path, b.path)
+      )
+    }
+  }
+  return sections
 }
 
 export function countStagedEntries(entries: readonly MobileGitStatusEntry[]): number {

--- a/mobile/src/source-control/mobile-path-sort.test.ts
+++ b/mobile/src/source-control/mobile-path-sort.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+import { buildMobileDiffReviewQueue } from '../session/mobile-diff-review-queue'
+import { buildMobileBranchCompareSection } from './mobile-branch-compare'
+import { buildMobileSourceControlSections, type MobileGitStatusEntry } from './mobile-git-status'
+
+const paths = [
+  'file10.ts',
+  'file2.ts',
+  'file02.ts',
+  'café.ts',
+  'cafe\u0301.ts',
+  'Z.ts',
+  'a.ts',
+  'Ä.ts',
+  'İ.ts',
+  'package-lock.json'
+]
+const entries = paths.flatMap((path, index) =>
+  (['staged', 'untracked', 'unstaged'] as const).map((area) => ({
+    path,
+    oldPath: `old-${index}`,
+    area,
+    status: 'modified' as const,
+    conflictStatus:
+      index % 3 === 0
+        ? ('unresolved' as const)
+        : index % 3 === 1
+          ? ('resolved_locally' as const)
+          : undefined
+  }))
+)
+const reviewInput = {
+  worktreeId: 'workspace',
+  statusEntries: entries,
+  branchEntries: entries.filter((entry) => entry.area === 'staged'),
+  comments: [],
+  reviewState: { version: 1 as const, files: {} }
+}
+const comparePath = (a: string, b: string) => a.localeCompare(b, undefined, { numeric: true })
+const conflictRank = (entry: MobileGitStatusEntry) =>
+  entry.conflictStatus === 'unresolved' ? 0 : entry.conflictStatus === 'resolved_locally' ? 1 : 2
+
+describe('mobile path sort collation', () => {
+  it('preserves numeric ties, Unicode equivalence, conflict rank, and section order', () => {
+    const original = [...entries]
+    const sections = buildMobileSourceControlSections(entries)
+    expect(sections.map((section) => section.area)).toEqual(['unstaged', 'untracked', 'staged'])
+    for (const section of sections) {
+      expect(section.data).toEqual(
+        entries
+          .filter((entry) => entry.area === section.area)
+          .sort((a, b) => conflictRank(a) - conflictRank(b) || comparePath(a.path, b.path))
+      )
+    }
+    expect(buildMobileBranchCompareSection(entries)?.data).toEqual(
+      [...entries].sort((a, b) => comparePath(a.path, b.path))
+    )
+    expect(entries).toEqual(original)
+  })
+
+  it('preserves review scope and generated-file precedence before numeric path order', () => {
+    const unsorted = [
+      ...entries.flatMap((entry) =>
+        buildMobileDiffReviewQueue({ ...reviewInput, statusEntries: [entry], branchEntries: [] })
+      ),
+      ...reviewInput.branchEntries.flatMap((entry) =>
+        buildMobileDiffReviewQueue({ ...reviewInput, statusEntries: [], branchEntries: [entry] })
+      )
+    ]
+    const scopeRank = { unstaged: 0, staged: 1, branch: 2 }
+    const expected = unsorted.sort(
+      (a, b) =>
+        scopeRank[a.scope] - scopeRank[b.scope] ||
+        Number(a.isGeneratedOrLockFile) - Number(b.isGeneratedOrLockFile) ||
+        comparePath(a.filePath, b.filePath)
+    )
+    expect(buildMobileDiffReviewQueue(reviewInput)).toEqual(expected)
+  })
+
+  it('resolves the current locale once per populated sort and never per comparison', () => {
+    const localeCompare = vi.spyOn(String.prototype, 'localeCompare')
+    const NativeCollator = Intl.Collator
+    const collator = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new NativeCollator(locales, options)
+    })
+    try {
+      for (let call = 0; call < 2; call++) {
+        buildMobileSourceControlSections(entries)
+        buildMobileBranchCompareSection(entries)
+        buildMobileDiffReviewQueue(reviewInput)
+      }
+      expect(localeCompare).not.toHaveBeenCalled()
+      expect(collator).toHaveBeenCalledTimes(6)
+      expect(collator).toHaveBeenCalledWith(undefined, { numeric: true })
+    } finally {
+      localeCompare.mockRestore()
+      collator.mockRestore()
+    }
+  })
+
+  it('does not initialize collation for empty or singleton collections', () => {
+    const collator = vi.spyOn(Intl, 'Collator')
+    try {
+      for (const rows of [[], [entries[0]]]) {
+        buildMobileSourceControlSections(rows)
+        buildMobileBranchCompareSection(rows)
+        buildMobileDiffReviewQueue({ ...reviewInput, statusEntries: rows, branchEntries: [] })
+      }
+      expect(collator).not.toHaveBeenCalled()
+    } finally {
+      collator.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​140 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 |

<!-- /orca-pr-loc -->

## ELI5
Mobile source control repeatedly initialized numeric string comparison while sorting files. Each populated sort now reuses one collator.

## What Changed
Reuse a call-local `Intl.Collator(undefined, { numeric: true })` in status sections, branch changes, and the diff review queue. Empty and singleton collections skip collator construction. Preserve current-locale behavior, stable numeric ties, conflict priority, section/scope order, and generated-file priority. The existing shared filename collator is deliberately not reused because it pins English and adds a code-unit tie-breaker, which would change these lists.

## Why
The old comparators pass options to `localeCompare` for every comparison. The production-path regression measures 466 such calls across six fixture sorts before the change and six collator constructions afterward. The count test fails against baseline `20ab9950654`, while ordering parity tests pass in both versions.

Counterbalanced benchmark, macOS / Node 24.18.0 / en-US, ten samples per arm. Input samples real tracked paths in Git order, without shuffling. Full production function outputs are compared before timing.

| 1,000 files | Before per call | After per call |
| --- | --- | --- |
| Status sections | 8.358 ms | 0.391 ms |
| Branch comparison | 4.845 ms | 0.200 ms |
| Review queue construction | 12.040 ms | 2.610 ms |

At 17 files the same functions measured 0.0294 → 0.0041 ms, 0.0307 → 0.0032 ms, and 0.0454 → 0.0191 ms. Empty/singleton calls remain sub-microsecond except review item construction (~0.0015 ms). These are Node microbenchmarks, not Hermes/device or end-to-end phone measurements.

## Linked Issue
User-requested codebase performance audit; no linked issue supplied.

## Visual Proof
N/A — identical sorted outputs, no visual or interaction changes.

## Testing
- `ORCA_BACKGROUND_LAUNCH=1 pnpm --dir mobile test src/source-control src/session/mobile-diff-review-queue.test.ts` — 203 tests across 27 files passed.
- Four additional collation tests passed separately under both `sv-SE` and `tr-TR` process locales; the locale selections were verified with `Intl.Collator().resolvedOptions().locale`.
- `ORCA_BACKGROUND_LAUNCH=1 pnpm --dir mobile typecheck` — passed.
- Changed-file mobile/root oxlint, formatter, and diff checks passed.
- `node config/scripts/mobile-source-control-collation-benchmark.mjs 20ab9950654` — reproducible parity-checked timings above.
- Regression coverage includes NFC/NFD, case/accent differences, numeric ties, input preservation, conflict order, generated files, scope order, repeated calls, and empty/singleton inputs.

## Review
Collators live only for one derivation, so future calls resolve the current default locale. No global cache or invalidation policy. Client-local presentation computation only: no Git commands, RPC/wire changes, host execution changes, or workspace-kind assumptions. Existing desktop/remote/folder behavior is preserved.

## Agent skill upstream boundary
- [x] Not applicable.

## Checklist
- [x] One focused performance improvement, independent of the previous audit PRs.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and folder workspace impact considered.
- [x] Relevant tests, mobile typecheck, lint, and formatting pass; broader checks and native platform execution remain with CI.
