### PR TITLE
perf(diff): skip unused extension extraction during search

### DIFF
--- a/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-filter.ts
+++ b/src/renderer/src/components/editor/combined-diff/browse-files/combined-diff-file-tree-filter.ts
@@ -66,7 +66,7 @@ export function getCombinedDiffFileTreeEntriesMatchingStaticFilters({
     return entries
   }
   return entries.filter((entry) => {
-    if (excludedExtensions.has(getEntryExtension(entry))) {
+    if (excludedExtensions.size > 0 && excludedExtensions.has(getEntryExtension(entry))) {
       return false
     }
     return normalizedQuery.length === 0 || getEntrySearchText(entry).includes(normalizedQuery)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## ELI5
Searching changed files no longer extracts every file extension when the user has excluded no extensions.

## What Changed
Check whether the exclusion Set is nonempty before computing basename, last-dot position and lowercase extension. Text matching and active exclusion behavior are unchanged.

## Why
Windows Node24 full getCombinedDiffFileTreeEntriesMatchingStaticFilters benchmark, median15, representative TSX paths and matching text query with empty exclusion Set:1,000 files0.167 to0.064 ms;10,000 files1.565 to0.570 ms. Measures filtering only, not rendering or full interaction latency.

## Linked Issue
User-requested Windows/WSL performance audit; no existing issue linked.

## Visual Proof
N/A — matching files, ordering and UI behavior are identical.

## Testing
-11 combined-diff file-tree tests passed on Windows.
-Complete before/after output parity for empty/matching/nonmatching queries and empty/matching/nonmatching extension exclusions at both benchmark sizes.
-Renderer typecheck, targeted lint and formatting passed with ORCA_BACKGROUND_LAUNCH=1 using installed tools.
-Existing tests cover the filtering contract; no new test for this single-condition fast path.

## Review
An empty exclusion Set cannot reject an extension. No path parsing behavior changes when exclusions are active. No Git command, remote protocol, host routing or workspace assumptions change.

## Agent skill upstream boundary
- [x] Not applicable.
