### PR TITLE
perf: index pending terminal reconnect tab lookups

### DIFF
--- a/src/renderer/src/store/terminals/workspace-terminal-reconnect.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-reconnect.ts
@@ -51,10 +51,11 @@ export function createWorkspaceTerminalReconnectActions(
       for (const worktreeId of ids) {
         const tabs = tabsByWorktree[worktreeId] ?? []
         const targetTabIds = pendingReconnectTabByWorktree[worktreeId] ?? []
+        const tabById = targetTabIds.length > 1 ? buildByIdIndex(tabs) : null
         const tabsToReconnect: TerminalTab[] =
           targetTabIds.length > 0
             ? targetTabIds
-                .map((id) => tabs.find((t) => t.id === id))
+                .map((id) => (tabById ? tabById.get(id) : tabs.find((t) => t.id === id)))
                 .filter((t): t is TerminalTab => t != null)
             : tabs.slice(0, 1)
         if (tabsToReconnect.length === 0) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Restoring several terminal tabs now looks up saved IDs in one index instead of repeatedly searching the same tab list.

## What Changed

Reuse `buildByIdIndex` when a workspace has more than one pending tab ID. Its first-entry-wins behavior matches the previous `find`, including duplicate IDs. Target ordering, duplicate requests, missing IDs, SSH authority checks and deferred attachment remain unchanged. Zero/single-target restoration keeps the existing path.

## Why

Removes quadratic tab selection during restoration on Windows and WSL clients. A Windows Node 24 benchmark of the complete reconnect action with synthetic saved pane layouts measured median 0.971 ms before and 0.173 ms after for 1,000 tabs; 100 tabs measured 0.0168 versus 0.0126 ms. The separate path that also rewrites tab-level PTY IDs showed no reliable improvement (4.92 versus 5.06 ms at 1,000 tabs). These are local bookkeeping measurements, not terminal readiness or application startup latency.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical state transformation; no visual or interaction change.

## Testing

- 27 existing reconnect, relay-identity and first-wins-index tests passed on Windows.
- Renderer TypeScript check, targeted oxlint and formatting passed.
- Full-action before/after output parity at 1, 10, 100 and 1,000 tabs, including duplicate and missing IDs, with both saved pane layouts and tab-level PTY IDs.
- No new test added: existing tests cover restoration and the reused index contract.

## Review

No path handling, wire format, execution-host ownership, process launches or state freshness changes. Folder workspaces and SSH checks retain their existing behavior.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant local tests, typecheck and lint pass; full build remains covered by CI.
