### PR TITLE
fix(editor): eliminate multi-second Markdown blank-run scans

### DIFF
--- a/config/scripts/markdown-blank-run-scan-benchmark.mjs
+++ b/config/scripts/markdown-blank-run-scan-benchmark.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Adverse-input audit: compares the previous scanner with the production line-bounded implementation.
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+import { summarizeBenchmarkSamples } from './benchmark-sample-summary.mjs'
+
+const entry = fileURLToPath(
+  new URL(
+    '../../src/renderer/src/components/editor/monaco-markdown-doc-link-decorations.ts',
+    import.meta.url
+  )
+)
+const source = await readFile(entry, 'utf8')
+const current = `${String.raw`/\s*(?:`}\`\`\`|~~~)/y`
+const replacement = `${String.raw`/[^\S\n]*(?:`}\`\`\`|~~~)/y`
+assert.ok(
+  source.includes(replacement),
+  'Production fence regex changed; re-review benchmark candidate'
+)
+async function load(candidate) {
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    plugins: candidate
+      ? [
+          {
+            name: 'line-bounded-candidate',
+            setup(plugin) {
+              plugin.onLoad({ filter: /monaco-markdown-doc-link-decorations\.ts$/ }, () => ({
+                contents: source.replace(replacement, current),
+                loader: 'ts',
+                resolveDir: fileURLToPath(
+                  new URL('../../src/renderer/src/components/editor/', import.meta.url)
+                )
+              }))
+            }
+          }
+        ]
+      : []
+  })
+  return (
+    await import(
+      `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+    )
+  ).getMarkdownDocLinkDecorationRanges
+}
+const baseline = await load(true)
+const candidate = await load(false)
+const corpus = [
+  '',
+  '\n```\n[[hidden.md]]\n```\n[[shown.md]]',
+  ' \t\r\n~~~\r\n[[hidden.md]]\r\n~~~\r\n[[shown.md]]',
+  '\u00a0\u2028```\n[[hidden.md]]\n```\n[[shown.md]]',
+  '`code` [[shown.md]]'
+]
+for (const content of corpus) {
+  assert.deepEqual(candidate(content), baseline(content))
+}
+const scenarios = [
+  ['ordinary-100k-lines', 'ordinary prose\n'.repeat(100_000)],
+  ['blank-10k-lines', '\n'.repeat(10_000)],
+  ['blank-30k-lines', '\n'.repeat(30_000)],
+  ['blank-100k-lines', '\n'.repeat(100_000)],
+  ['indented-blank-10k-lines', `${' '.repeat(80)}\n`.repeat(10_000)]
+]
+for (const [name, content] of scenarios) {
+  const samples = { baseline: [], candidate: [] }
+  const scanners = { baseline, candidate }
+  let expected
+  for (const arms of buildCounterbalancedSchedule(2, 'baseline', 'candidate')) {
+    for (const arm of arms) {
+      const started = performance.now()
+      const ranges = scanners[arm](content)
+      samples[arm].push(performance.now() - started)
+      expected ??= ranges
+      assert.deepEqual(ranges, expected)
+    }
+  }
+  console.log(
+    JSON.stringify({
+      name,
+      bytes: Buffer.byteLength(content),
+      samples,
+      baseline: summarizeBenchmarkSamples(samples.baseline),
+      candidate: summarizeBenchmarkSamples(samples.candidate)
+    })
+  )
+}

--- a/config/scripts/rich-markdown-blank-run-benchmark.mjs
+++ b/config/scripts/rich-markdown-blank-run-benchmark.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { readFile, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+import { summarizeBenchmarkSamples } from './benchmark-sample-summary.mjs'
+
+const root = fileURLToPath(new URL('../..', import.meta.url))
+const entry = join(root, 'src/renderer/src/components/editor/raw-markdown-html.ts')
+const source = await readFile(entry, 'utf8')
+const cachedProbe =
+  /if \(index > fenceProbe\) \{[\s\S]*?fenceMatch = fencePrefix.exec\(normalizedContent\)\n      \}/
+assert.match(source, cachedProbe)
+const oldProbe = String.raw`fenceMatch = normalizedContent.slice(index).match(/^\s*(\x60{3,}|~{3,})/)`
+const temp = await mkdtemp(join(tmpdir(), 'orca-rich-blank-bench-'))
+try {
+  const scanners = {}
+  for (const arm of ['baseline', 'current']) {
+    const outfile = join(temp, `${arm}.cjs`)
+    await build({
+      stdin: {
+        contents: `export { encodeRawMarkdownHtmlForRichEditor as encode } from './src/renderer/src/components/editor/raw-markdown-html'; export { createRichMarkdownEditorCodec as codec } from './src/renderer/src/components/editor/rich-markdown-source-transport';`,
+        resolveDir: root
+      },
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      outfile,
+      plugins:
+        arm === 'baseline'
+          ? [
+              {
+                name: 'old-probe',
+                setup(plugin) {
+                  plugin.onLoad({ filter: /raw-markdown-html\.ts$/ }, () => ({
+                    contents: source.replace(cachedProbe, oldProbe),
+                    loader: 'ts',
+                    resolveDir: join(root, 'src/renderer/src/components/editor')
+                  }))
+                }
+              }
+            ]
+          : []
+    })
+    const { encode, codec } = createRequire(import.meta.url)(outfile)
+    scanners[arm] = (content) => encode(content, codec('0'.repeat(32)))
+  }
+  const fragments = [
+    '\n',
+    ' \r\n',
+    '\u00a0\u2028',
+    '```\n',
+    '~~~~\n',
+    '<div>\n',
+    '</div>\n',
+    '[[doc.md]]\n',
+    '`inline`\n',
+    'prose\n'
+  ]
+  let seed = 42
+  for (let sample = 0; sample < 256; sample++) {
+    let content = ''
+    for (let i = 0; i < 20; i++) {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+      content += fragments[seed % fragments.length]
+    }
+    assert.equal(scanners.current(content), scanners.baseline(content))
+  }
+  for (const [name, content] of [
+    ['ordinary', 'ordinary prose\n'.repeat(10000)],
+    ['blank-100k', '\n'.repeat(100000)],
+    ['blank-before-fence', `${'\n'.repeat(30000)}\x60\x60\x60\n<div>\n\x60\x60\x60\n[[doc.md]]`]
+  ]) {
+    const samples = { baseline: [], current: [] }
+    let expected
+    for (const arms of buildCounterbalancedSchedule(2, 'baseline', 'current')) {
+      for (const arm of arms) {
+        const start = performance.now()
+        const result = scanners[arm](content)
+        samples[arm].push(performance.now() - start)
+        expected ??= result
+        assert.equal(result, expected)
+      }
+    }
+    console.log(
+      JSON.stringify({
+        name,
+        bytes: Buffer.byteLength(content),
+        samples,
+        baseline: summarizeBenchmarkSamples(samples.baseline),
+        current: summarizeBenchmarkSamples(samples.current)
+      })
+    )
+  }
+} finally {
+  await rm(temp, { recursive: true, force: true })
+}

--- a/src/renderer/src/components/editor/monaco-markdown-doc-link-decorations.offset-scan.test.ts
+++ b/src/renderer/src/components/editor/monaco-markdown-doc-link-decorations.offset-scan.test.ts
@@ -76,6 +76,14 @@ function referenceDecorationRanges(content: string): IRange[] {
 
 const CORPUS: { name: string; content: string }[] = [
   { name: 'empty', content: '' },
+  {
+    name: 'Unicode whitespace before fences',
+    content: '\u00a0\u2028```\n[[hidden]]\n```\n[[shown]]'
+  },
+  {
+    name: 'indented blank run before fences',
+    content: `${`${' '.repeat(80)}\r\n`.repeat(1000)}\`\`\`\n[[hidden]]\n\`\`\`\n[[shown]]`
+  },
   { name: 'no links', content: '# Title\n\nJust prose.\n' },
   { name: 'single link', content: '# Title\n\nSee [[notes.md]] for details.\n' },
   { name: 'two links on one line', content: 'See [[a.md]] and [[b.md]].\n' },

--- a/src/renderer/src/components/editor/monaco-markdown-doc-link-decorations.ts
+++ b/src/renderer/src/components/editor/monaco-markdown-doc-link-decorations.ts
@@ -41,12 +41,11 @@ function isInsideSpan(index: number, spans: number[]): boolean {
   return false
 }
 
-const FENCE_PREFIX_RE = /\s*(?:```|~~~)/y
+const FENCE_PREFIX_RE = /[^\S\n]*(?:```|~~~)/y
 
 function startsCodeFence(content: string, lineStart: number, lineEnd: number): boolean {
   FENCE_PREFIX_RE.lastIndex = lineStart
-  // Why: a sticky `\s*` run can cross the newline into the next line, so an
-  // out-of-line match is rejected to stay identical to the old per-line regex.
+  // Bound whitespace to this line so blank runs cannot trigger repeated suffix scans.
   return FENCE_PREFIX_RE.test(content) && FENCE_PREFIX_RE.lastIndex <= lineEnd
 }
 

--- a/src/renderer/src/components/editor/raw-markdown-html.blank-run.test.ts
+++ b/src/renderer/src/components/editor/raw-markdown-html.blank-run.test.ts
@@ -1,0 +1,34 @@
+import { runInNewContext } from 'node:vm'
+import { describe, expect, it } from 'vitest'
+import { encodeRawMarkdownHtmlForRichEditor } from './raw-markdown-html'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+
+function encodeWithDeadline(content: string): string {
+  // Interrupt a quadratic regression without hanging the synchronous test worker.
+  return runInNewContext(
+    'encode(content, codec)',
+    {
+      encode: encodeRawMarkdownHtmlForRichEditor,
+      content,
+      codec: createRichMarkdownEditorCodec('0'.repeat(32))
+    },
+    { timeout: 1500 }
+  )
+}
+
+describe('rich Markdown blank-run encoding', () => {
+  it('preserves a long blank document without repeatedly searching its suffix', () => {
+    const content = '\n'.repeat(100_000)
+    expect(encodeWithDeadline(content)).toBe(content)
+  })
+
+  it('preserves code and surrounding HTML after a long blank prefix', () => {
+    const blankPrefix = '\n'.repeat(100_000)
+    const content = '```\n<div>inside</div>\n```\n<b>after</b>'
+    const codec = createRichMarkdownEditorCodec('0'.repeat(32))
+    const expected = encodeRawMarkdownHtmlForRichEditor(content, codec)
+    expect(expected).toContain('<div>inside</div>')
+    expect(expected).not.toContain('<b>after</b>')
+    expect(encodeWithDeadline(blankPrefix + content)).toBe(blankPrefix + expected)
+  })
+})

--- a/src/renderer/src/components/editor/raw-markdown-html.ts
+++ b/src/renderer/src/components/editor/raw-markdown-html.ts
@@ -65,14 +65,20 @@ export function encodeRawMarkdownHtmlForRichEditor(
   let activeFence: '`' | '~' | null = null
   let activeFenceLength = 0
   let result = ''
+  const nonWhitespace = /\S/g
+  const fencePrefix = /(`{3,}|~{3,})/y
+  let fenceProbe = -1
+  let fenceMatch: RegExpExecArray | null = null
 
   while (index < normalizedContent.length) {
     if (isLineStart) {
-      // Why: only line starts inspect the rest of the line, so slicing the suffix on every
-      // character (one throwaway string per char) is pure waste — compute it here. On a large
-      // doc this drops O(n) suffix allocations from the rich-editor open path (#7056).
-      const lineRest = normalizedContent.slice(index)
-      const fenceMatch = lineRest.match(/^\s*(`{3,}|~{3,})/)
+      // Reuse the lookahead across blank lines, preserving cross-line fence semantics.
+      if (index > fenceProbe) {
+        nonWhitespace.lastIndex = index
+        fenceProbe = nonWhitespace.exec(normalizedContent)?.index ?? normalizedContent.length
+        fencePrefix.lastIndex = fenceProbe
+        fenceMatch = fencePrefix.exec(normalizedContent)
+      }
       if (fenceMatch) {
         const fenceChar = fenceMatch[1][0] as '`' | '~'
         const fenceLength = fenceMatch[1].length


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​219 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​209 |

<!-- /orca-pr-loc -->

Opening or editing Markdown containing long blank-line runs synchronously rescanned the remaining whitespace at every line start. This made a 100 KB document block the source scanner for 9.1 seconds and rich-editor preprocessing for 8.0 seconds.

Bound the source-editor fence match to one line and reuse rich-editor fence lookahead across blank lines, preserving its existing cross-line semantics. Counterbalanced production-function benchmarks measured 1.3 ms and 8.3 ms respectively; ordinary prose was unchanged. Both benchmark scripts retain the previous implementation as an in-memory comparison and verify output parity.

Validation: 118 editor tests, web typecheck, changed-code quality, and hidden Electron CDP opening/editing/mode-switch checks passed. Existing performance contracts also passed (74 tests). Rich preprocessing comparison includes 256 deterministic generated cases.

These are adverse-input scanner improvements, not whole-editor latency claims. Rich mode still creates roughly 50,000 paragraphs for this fixture and exhibited separate ~1.6-second rendering tasks. No document whitespace is discarded.
