### PR TITLE
perf: skip ordinary strings in JSON structure checks

### DIFF
--- a/src/shared/json-text-structure-limit.test.ts
+++ b/src/shared/json-text-structure-limit.test.ts
@@ -37,4 +37,28 @@ describe('JSON text structure admission', () => {
       })
     ).not.toThrow()
   })
+
+  it.each([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])('handles a quote preceded by %i backslashes', (count) => {
+    const content = `"${'\\'.repeat(count)}"[[]]`
+    const check = () =>
+      assertJsonTextStructureWithinLimits(content, {
+        structuralTokens: 3,
+        nestingDepth: 2
+      })
+    if (count % 2 === 0) {
+      expect(check).toThrowError(new JsonTextStructureCapacityError('structuralTokens', 3))
+    } else {
+      expect(check).not.toThrow()
+    }
+  })
+
+  it('resumes counting after escaped quotes and long string values', () => {
+    const content = JSON.stringify({ value: 'ordinary text [{,}] \\" '.repeat(10_000), next: [] })
+    expect(() =>
+      assertJsonTextStructureWithinLimits(content, { structuralTokens: 7, nestingDepth: 2 })
+    ).not.toThrow()
+    expect(() =>
+      assertJsonTextStructureWithinLimits(content, { structuralTokens: 6, nestingDepth: 2 })
+    ).toThrowError(new JsonTextStructureCapacityError('structuralTokens', 6))
+  })
 })

--- a/src/shared/json-text-structure-limit.ts
+++ b/src/shared/json-text-structure-limit.ts
@@ -25,23 +25,37 @@ export function assertJsonTextStructureWithinLimits(
   assertLimit(limits.nestingDepth)
   let structuralTokens = 0
   let depth = 0
-  let inString = false
-  let escaped = false
-
   for (let index = 0; index < content.length; index += 1) {
     const character = content[index]
-    if (inString) {
-      if (escaped) {
-        escaped = false
-      } else if (character === '\\') {
-        escaped = true
-      } else if (character === '"') {
-        inString = false
-      }
-      continue
-    }
     if (character === '"') {
-      inString = true
+      let quote = content.indexOf('"', index + 1)
+      if (quote !== -1) {
+        // Only an odd backslash run escapes the quote.
+        let backslashes = 0
+        for (let at = quote - 1; at > index && content[at] === '\\'; at -= 1) {
+          backslashes += 1
+        }
+        if (backslashes % 2 !== 0) {
+          // Escape-heavy strings use the linear scan to avoid repeated native searches.
+          let escaped = false
+          for (quote += 1; quote < content.length; quote += 1) {
+            if (escaped) {
+              escaped = false
+            } else if (content[quote] === '\\') {
+              escaped = true
+            } else if (content[quote] === '"') {
+              break
+            }
+          }
+          if (quote === content.length) {
+            quote = -1
+          }
+        }
+      }
+      if (quote === -1) {
+        return
+      }
+      index = quote
       continue
     }
     if (!isStructuralToken(character)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |

<!-- /orca-pr-loc -->

## ELI5

The JSON input-limit check can skip ordinary string contents instead of inspecting every character. This reduces parsing overhead for text-heavy search results and terminal messages.

## What Changed

Use `indexOf` to find the first candidate closing quote, then count its preceding backslashes to distinguish a closing quote from an escaped quote. After an escaped quote, retain a linear scan through the rest of the string so escape-heavy input does not incur repeated native searches. Structural-token counting, nesting limits, error ordering and malformed-input handling remain unchanged.

## Why

Windows Node 24 measurements of the complete structure-check function, median of 15 batches of 100 calls:

| Synthetic input | Before | After |
| --- | ---: | ---: |
| 250 KB ordinary text value | 0.2063 ms | 0.0033 ms |
| 60 KB punctuation inside a string | 0.0449 ms | 0.0009 ms |
| 2,000 small objects | 0.0688 ms | 0.0653 ms |

Separate stress checks found 100,000 escaped quotes improved from 0.169 to 0.107 ms; an all-backslash string was approximately unchanged (0.169 versus 0.175 ms). These measure admission-check CPU time, not overall search or terminal latency. The shared check runs on Windows clients and WSL/SSH hosts without changing transport or platform behavior.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — internal processing only; no visual or interaction change.

## Testing

- 136 tests passed on Windows across structure admission, text search, terminal streams, remote request frames, agent state files, hook request memory limits, agent status and screencast protocol.
- Added odd/even backslash-run boundaries and long strings containing escaped quotes followed by additional structural tokens.
- 50,000 deterministic randomized malformed inputs matched the original function's acceptance or exact error details at varied token/depth limits.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

Input-size and structure limits remain enforced. This check still does not replace JSON parsing. No wire, filesystem, execution-host ownership, polling, caching or freshness changes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant local tests, typecheck and lint passed; full build covered by CI.
