### PR TITLE
test(windows): tolerate transient ConPTY marker locks

### DIFF
--- a/src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts
+++ b/src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts
@@ -1,10 +1,11 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import { build as buildVite } from 'vite'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import { resolveElectronProbeLaunch } from './electron-probe-display-launch'
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
@@ -22,7 +23,7 @@ type FixtureResult = {
 
 afterAll(() => {
   for (const root of fixtureRoots) {
-    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+    removeTreeSync(root)
   }
 })
 

--- a/src/main/browser/browser-route-webrtc-egress.electron.test.ts
+++ b/src/main/browser/browser-route-webrtc-egress.electron.test.ts
@@ -1,9 +1,10 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import { resolveElectronProbeLaunch } from './electron-probe-display-launch'
 
 const electronBinary = createRequire(import.meta.url)('electron') as string
@@ -19,7 +20,7 @@ afterAll(() => {
   const failures: unknown[] = []
   for (const root of fixtureRoots) {
     try {
-      rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+      removeTreeSync(root)
     } catch (error) {
       failures.push(error)
     }

--- a/src/main/windows/windows-pty-job.win32.test.ts
+++ b/src/main/windows/windows-pty-job.win32.test.ts
@@ -1,8 +1,9 @@
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { IPty } from 'node-pty'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import {
   isPtyJobOwnershipAvailable,
   listPtyJobProcessIds,
@@ -152,7 +153,8 @@ describeOnWindows('ConPTY job ownership', () => {
     // regardless of its other limits) and is not covered by a test here.
     // Covering it needs a helper that passes the flag to CreateProcess.
     const nodePty = await import('node-pty')
-    const marker = join(mkdtempSync(join(tmpdir(), 'orca-breakaway-')), 'marker.txt')
+    const markerDir = mkdtempSync(join(tmpdir(), 'orca-breakaway-'))
+    const marker = join(markerDir, 'marker.txt')
     const proc = nodePty.spawn('cmd.exe', [], {
       name: 'xterm-256color',
       cols: 100,
@@ -168,9 +170,12 @@ describeOnWindows('ConPTY job ownership', () => {
     })
     proc.write(`start /b cmd /c "echo ORCA_BREAKAWAY> ${marker}"\r`)
 
-    await vi.waitFor(() => expect(existsSync(marker)).toBe(true), { timeout: 15_000 })
-    expect(output).not.toMatch(/Access is denied/i)
-    rmSync(marker, { force: true })
+    try {
+      await vi.waitFor(() => expect(existsSync(marker)).toBe(true), { timeout: 15_000 })
+      expect(output).not.toMatch(/Access is denied/i)
+    } finally {
+      removeTreeSync(markerDir)
+    }
   }, 60_000)
 
   it('stops answering once the tree is gone, rather than claiming it is empty', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Summary

Fixes the pre-existing ConPTY marker-handle cleanup flake seen in [job 103493401573](https://github.com/stablyai/orca/actions/runs/34671155006/job/103493401573), step **Test Windows-specific boundaries** (`.github/workflows/pr.yml:841`). This is pre-existing on `main` and is not caused by any PR currently in flight.

The `start /b cmd /c` child can create the marker while its redirection handle is still open; the test observes existence, completes the real assertions, and then a raw `rmSync` can lose the Windows handle-release race. Cleanup now removes the whole temp directory through the existing transient-lock retry policy and runs from `finally`.

**The assertions are unchanged:** the 15-second `vi.waitFor` around `existsSync(marker)` and the `expect(output).not.toMatch(/Access is denied/i)` check remain exact. This is a flake fix, not a behavior change.

## Sibling audit

Sibling files changed in this PR:

- `src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts` — same shape and fixed: the spawned Electron process and renderer helpers use the temp fixture/profile tree, so teardown now uses the shared late-handle retry policy.
- `src/main/browser/browser-route-webrtc-egress.electron.test.ts` — same shape and fixed: spawned Electron/Chromium processes use the temp fixture/profile tree, so teardown now uses the shared late-handle retry policy while preserving aggregated cleanup failures.

Sibling files left unchanged:

- `config/scripts/rebuild-native-deps.test.mjs` — not the same remaining `rmSync` shape: it deletes fixture `path.txt` before the synchronous child launch; project-tree teardown is already in `finally` with `removeTreeSync`.
- `src/shared/child-process/windows-command-line.win32.test.ts` — not the same remaining `rmSync` shape: that call is the negative assertion that no marker exists; suite teardown already uses `removeTreeSync`.
- `src/shared/child-process/windows-cmd-shim-resolution.test.ts` — not the same shape: no child is launched against the fixture paths, and `rmSync(nodeExe)` deliberately simulates an uninstall; teardown already uses `removeTreeSync`.
- `src/main/startup/windows-install-dir-acl-repair.win32.test.ts` — same child/temp teardown shape, but it is already fixed on `main` with `removeTreeSync` after the real `icacls.exe` children, so no further change is needed.

## Timing/load sensitivity

This can fire on any Windows run: the marker becomes observable before the detached child is guaranteed to have closed its redirection handle, so no special load condition is required. It is timing-sensitive, and full parallelism or other load can increase the probability by delaying the child after file creation and widening the cleanup race, so I judge it load-amplified rather than load-dependent.

## Verification

- `ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/windows/windows-pty-job.win32.test.ts` — 1 file / 6 tests skipped on macOS because the suite is Windows-gated (not a local pass).
- `ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/browser/browser-client-page-renderer-lifecycle.electron.test.ts` — 1 test passed.
- `ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/browser/browser-route-webrtc-egress.electron.test.ts` — 1 test passed.
- `pnpm tc` — passed.
- `pnpm run check:code-quality:changed` — passed with 0 new findings across 3 files.

Windows CI is the behavioral evidence; this macOS machine cannot run the gated ConPTY suite.