### PR TITLE
perf: avoid rescanning partial Windows desktop responses

### DIFF
--- a/src/main/computer/desktop-script-serve-channel.test.ts
+++ b/src/main/computer/desktop-script-serve-channel.test.ts
@@ -59,6 +59,38 @@ describe('DesktopScriptServeChannel', () => {
     expect(handlers.onGone).toHaveBeenCalledWith('code 1: it broke')
   })
 
+  it('reassembles chunked responses with split UTF-8 and CRLF boundaries', () => {
+    const { child, handlers } = createChannel()
+    const payload = Buffer.from('hello 😀\r\n\nnext\ntrailing', 'utf8')
+    for (const byte of payload) {
+      child.stdout.emit('data', Buffer.from([byte]))
+    }
+    expect(handlers.onLine.mock.calls.map(([line]) => line)).toEqual(['hello 😀', 'next'])
+    child.stdout.emit('data', '\n')
+    expect(handlers.onLine).toHaveBeenLastCalledWith('trailing')
+  })
+
+  it('enforces the buffer cap before a terminating newline arrives', () => {
+    const { child, handlers } = createChannel()
+    const chunk = 'a'.repeat(1024 * 1024)
+    for (let index = 0; index < 20; index += 1) {
+      child.stdout.emit('data', chunk)
+    }
+    expect(handlers.onOverflow).not.toHaveBeenCalled()
+    child.stdout.emit('data', 'a')
+    expect(handlers.onOverflow).toHaveBeenCalledOnce()
+    expect(handlers.onLine).not.toHaveBeenCalled()
+    child.stdout.emit('data', 'recovered\n')
+    expect(handlers.onLine).toHaveBeenCalledWith('recovered')
+  })
+
+  it('stops delivering a chunk when its line handler closes the channel', () => {
+    const { channel, child, handlers } = createChannel()
+    handlers.onLine.mockImplementation(() => channel.stop())
+    child.stdout.emit('data', 'first\nsecond\n')
+    expect(handlers.onLine.mock.calls.map(([line]) => line)).toEqual(['first'])
+  })
+
   describe('once stopped', () => {
     /**
      * The channel's half of the stale-callback guard, pinned here rather than

--- a/src/main/computer/desktop-script-serve-channel.ts
+++ b/src/main/computer/desktop-script-serve-channel.ts
@@ -112,10 +112,15 @@ export class DesktopScriptServeChannel {
     if (this.closed) {
       return
     }
-    this.buffer += typeof chunk === 'string' ? chunk : this.decoder.write(chunk)
+    const decoded = typeof chunk === 'string' ? chunk : this.decoder.write(chunk)
+    this.buffer += decoded
     if (this.buffer.length > MAX_RESPONSE_CHARS) {
       this.buffer = ''
       this.handlers.onOverflow()
+      return
+    }
+    // The retained tail has no newline; avoid rescanning and flattening it for every chunk.
+    if (!decoded.includes('\n')) {
       return
     }
     for (let newline = this.buffer.indexOf('\n'); newline >= 0;) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​99 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​99 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## ELI5

Large Windows computer-use screenshot responses now assemble without repeatedly searching all the data received so far.

## What Changed

Check each decoded chunk for a newline before scanning the accumulated NDJSON response. The retained tail has no complete line, so a chunk without a newline cannot complete it. This avoids repeated searches and flattening of a growing string. The buffer cap is still checked before the fast return, and the existing UTF-8 decoder, CRLF handling and closed-channel checks remain in place.

## Why

Windows Node 24 benchmark of the complete serve-channel assembly path, Buffer input in 64 KiB chunks, median of 15 runs:

| Synthetic response | Before | After |
| --- | ---: | ---: |
| 1 MiB image value | 2.68 ms | 0.75 ms |
| 4 MiB image value | 41.75 ms | 3.14 ms |
| 16 MiB stress case | 399.91 ms | 8.56 ms |

The channel's documented workload routinely includes megabyte-scale base64 screenshots. These measurements cover transport assembly, not screenshot capture or UI Automation time.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical response delivery; no visual or interaction change.

## Testing

- 51 tests passed on Windows for serve-channel framing, runtime-host lifecycle and provider routing.
- Added split UTF-8/CRLF, buffer-limit enforcement before newline, and close-during-delivery cases.
- Before/after response parity for all measured sizes, byte-split Unicode, multiple/empty lines and overflow recovery.
- Node TypeScript check, targeted oxlint and formatting passed.
- No desktop app launched or focused; the benchmark uses an in-memory child-process transport.

## Review

No process policy, retries, request ordering, wire format, buffer limits, snapshot freshness, SSH ownership or screenshot quality changes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant local tests, typecheck and lint passed; full build covered by CI.
