### PR TITLE
perf(agents): avoid cloning lineage ancestor sets

### DIFF
--- a/config/scripts/agent-lineage-reachability-benchmark.mjs
+++ b/config/scripts/agent-lineage-reachability-benchmark.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { performance } from 'node:perf_hooks'
+import { transform } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+import { summarizeBenchmarkSamples } from './benchmark-sample-summary.mjs'
+
+// git show <ref>:src/renderer/src/components/dashboard/agent-row-lineage-model.ts | node config/scripts/agent-lineage-reachability-benchmark.mjs
+async function load(source) {
+  const { code } = await transform(source, { loader: 'ts', format: 'esm' })
+  return (await import(`data:text/javascript;base64,${Buffer.from(code).toString('base64')}`))
+    .buildAgentRowLineageTree
+}
+const implementations = {
+  before: await load(readFileSync(0, 'utf8')),
+  after: await load(
+    readFileSync('src/renderer/src/components/dashboard/agent-row-lineage-model.ts', 'utf8')
+  )
+}
+function orderedTree(tree) {
+  return {
+    roots: tree.rootRows,
+    children: [...tree.childrenByParentPaneKey],
+    childKeys: [...tree.childPaneKeys]
+  }
+}
+
+let seed = 42
+const random = (max) => {
+  seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+  return Math.floor((seed / 2 ** 32) * max)
+}
+let differentialCases = 0
+for (let trial = 0; trial < 5000; trial += 1) {
+  const count = random(100)
+  const rows = Object.freeze(
+    Array.from({ length: count }, (_, index) =>
+      Object.freeze({
+        paneKey: `pane-${random(count + 4)}`,
+        index,
+        entry: Object.freeze({
+          terminalHandle: random(2) ? `term-${random(count)}` : undefined,
+          orchestration: Object.freeze({
+            parentPaneKey: random(3) ? `pane-${random(count + 4)}` : undefined,
+            parentTerminalHandle: random(2) ? `term-${random(count)}` : undefined,
+            coordinatorHandle: random(2) ? `term-${random(count)}` : undefined
+          })
+        })
+      })
+    )
+  )
+  assert.deepEqual(
+    orderedTree(implementations.after(rows)),
+    orderedTree(implementations.before(rows))
+  )
+  differentialCases += 1
+}
+
+const results = []
+for (const count of [8, 32, 128, 512, 1024]) {
+  for (const shape of ['flat', 'fanout', 'balanced', 'chain']) {
+    const rows = Array.from({ length: count }, (_, index) => {
+      const parent =
+        shape === 'fanout' ? 0 : shape === 'balanced' ? Math.floor((index - 1) / 4) : index - 1
+      return {
+        paneKey: `pane-${index}`,
+        entry: {
+          orchestration:
+            index > 0 && shape !== 'flat' ? { parentPaneKey: `pane-${parent}` } : undefined
+        }
+      }
+    })
+    const expected = orderedTree(implementations.before(rows))
+    assert.deepEqual(orderedTree(implementations.after(rows)), expected)
+    const iterations = Math.max(5, Math.floor(10_000 / count))
+    for (let warmup = 0; warmup < 20; warmup += 1) {
+      implementations.before(rows)
+      implementations.after(rows)
+    }
+    /** @type {{ before: number[], after: number[] }} */
+    const samples = { before: [], after: [] }
+    for (const pair of buildCounterbalancedSchedule(8, 'before', 'after')) {
+      for (const arm of pair) {
+        let result
+        const started = performance.now()
+        for (let repeat = 0; repeat < iterations; repeat += 1) {
+          result = implementations[arm](rows)
+        }
+        samples[arm].push(performance.now() - started)
+        assert.deepEqual(orderedTree(result), expected)
+      }
+    }
+    results.push({
+      count,
+      shape,
+      iterations,
+      meanMicrosecondsPerTree: Object.fromEntries(
+        Object.entries(samples).map(([arm, values]) => [
+          arm,
+          (values.reduce((sum, ms) => sum + ms, 0) * 1000) / values.length / iterations
+        ])
+      ),
+      before: summarizeBenchmarkSamples(samples.before),
+      after: summarizeBenchmarkSamples(samples.after)
+    })
+  }
+}
+console.log(
+  JSON.stringify(
+    { node: process.version, platform: process.platform, differentialCases, results },
+    null,
+    2
+  )
+)

--- a/src/renderer/src/components/dashboard/agent-row-lineage-model.test.ts
+++ b/src/renderer/src/components/dashboard/agent-row-lineage-model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { DashboardAgentRow } from './useDashboardData'
@@ -139,5 +139,76 @@ describe('buildAgentRowLineageTree', () => {
     expect(tree.rootRows.map((row) => row.paneKey)).toEqual(['root:1', 'cycle-a:1', 'cycle-b:1'])
     expect(tree.childrenByParentPaneKey.size).toBe(0)
     expect(tree.childPaneKeys.size).toBe(0)
+  })
+
+  it('preserves duplicate rows, child ordering, and object identities', () => {
+    const root = makeRow('root:1')
+    const child = makeRow('child:1', { parentPaneKey: root.paneKey })
+    const duplicate = makeRow('child:1', { parentPaneKey: root.paneKey })
+    const grandchild = makeRow('grandchild:1', { parentPaneKey: child.paneKey })
+    const otherRoot = makeRow('other:1')
+    const tree = buildAgentRowLineageTree([grandchild, root, duplicate, otherRoot, child, root])
+    expect(tree.rootRows).toEqual([root, otherRoot, root])
+    expect([...tree.childrenByParentPaneKey.keys()]).toEqual(['child:1', 'root:1'])
+    expect(tree.childrenByParentPaneKey.get('root:1')).toEqual([duplicate, child])
+    expect(tree.childrenByParentPaneKey.get('root:1')?.[0]).toBe(duplicate)
+    expect(tree.childrenByParentPaneKey.get('child:1')?.[0]).toBe(grandchild)
+    expect([...tree.childPaneKeys]).toEqual(['grandchild:1', 'child:1'])
+  })
+
+  it('traverses a deep lineage without copying every ancestor set', () => {
+    const rows = Array.from({ length: 500 }, (_, index) =>
+      makeRow(`pane-${index}`, index > 0 ? { parentPaneKey: `pane-${index - 1}` } : {})
+    )
+    const iterate = Set.prototype[Symbol.iterator]
+    let visitedSetEntries = 0
+    const spy = vi
+      .spyOn(Set.prototype, Symbol.iterator)
+      .mockImplementation(function (this: Set<unknown>) {
+        const iterator = iterate.call(this)
+        const next = iterator.next.bind(iterator)
+        iterator.next = () => {
+          const result = next()
+          if (!result.done) {
+            visitedSetEntries += 1
+          }
+          return result
+        }
+        return iterator
+      })
+    let tree: ReturnType<typeof buildAgentRowLineageTree>
+    try {
+      tree = buildAgentRowLineageTree(rows)
+    } finally {
+      spy.mockRestore()
+    }
+    expect(tree.rootRows).toEqual([rows[0]])
+    expect(tree.childPaneKeys.size).toBe(rows.length - 1)
+    expect(visitedSetEntries).toBeLessThanOrEqual(rows.length * 2)
+  })
+
+  it('does not use the call stack for a long parent chain', () => {
+    const rows = Array.from({ length: 10_000 }, (_, index) =>
+      makeRow(`pane-${index}`, index > 0 ? { parentPaneKey: `pane-${index - 1}` } : {})
+    )
+    const tree = buildAgentRowLineageTree(rows)
+    expect(tree.rootRows).toEqual([rows[0]])
+    expect(tree.childPaneKeys.size).toBe(rows.length - 1)
+    expect(tree.childrenByParentPaneKey.get('pane-9998')?.[0]).toBe(rows[9999])
+  })
+
+  it('terminates a reachable cycle introduced by duplicate pane rows', () => {
+    const root = makeRow('root')
+    const first = makeRow('first', { parentPaneKey: 'root' })
+    const second = makeRow('second', { parentPaneKey: 'first' })
+    const duplicate = makeRow('first', { parentPaneKey: 'second' })
+    const tree = buildAgentRowLineageTree([root, first, second, duplicate])
+    expect(tree.rootRows).toEqual([root])
+    expect([...tree.childPaneKeys]).toEqual(['first', 'second'])
+    expect([...tree.childrenByParentPaneKey]).toEqual([
+      ['root', [first]],
+      ['first', [second]],
+      ['second', [duplicate]]
+    ])
   })
 })

--- a/src/renderer/src/components/dashboard/agent-row-lineage-model.ts
+++ b/src/renderer/src/components/dashboard/agent-row-lineage-model.ts
@@ -90,19 +90,14 @@ export function buildAgentRowLineageTree<T extends AgentLineageSourceRow>(
   }
 
   const reachablePaneKeys = new Set<string>()
-  const markReachable = (row: T, ancestorPaneKeys: ReadonlySet<string> = new Set()): void => {
-    if (reachablePaneKeys.has(row.paneKey) || ancestorPaneKeys.has(row.paneKey)) {
-      return
-    }
-    reachablePaneKeys.add(row.paneKey)
-    const descendantAncestorPaneKeys = new Set(ancestorPaneKeys)
-    descendantAncestorPaneKeys.add(row.paneKey)
-    for (const childRow of childrenByParentPaneKey.get(row.paneKey) ?? []) {
-      markReachable(childRow, descendantAncestorPaneKeys)
-    }
-  }
   for (const rootRow of rootRows) {
-    markReachable(rootRow)
+    reachablePaneKeys.add(rootRow.paneKey)
+  }
+  // Set iteration visits newly added descendants once, including cyclic/duplicate edges.
+  for (const paneKey of reachablePaneKeys) {
+    for (const childRow of childrenByParentPaneKey.get(paneKey) ?? []) {
+      reachablePaneKeys.add(childRow.paneKey)
+    }
   }
 
   const unreachableRows = rows.filter((row) => !reachablePaneKeys.has(row.paneKey))


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​121 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 |

<!-- /orca-pr-loc -->

## Summary

Use the lineage model's existing visited set as its reachability traversal. Set iteration visits newly discovered descendants once, so copying a full ancestor set at each depth is unnecessary. Returned root rows, child arrays, identities, map/set ordering, parent selection, and malformed-cycle normalization are unchanged.

This pure model feeds the dashboard, worktree agent cards, and activity child-agent classification. No status producers, execution-host ownership, wire payloads, workspace/provider policy, or rendered layout change.

## Measurement

Actual baseline/current production functions, 5,000 seeded differential graphs and eight counterbalanced timing pairs, Node v26.6.0/macOS arm64. Mean microseconds per tree:

| Rows / shape | Before | After |
| --- | ---: | ---: |
| 8 / flat | 1.14 | 0.96 |
| 8 / fanout | 1.16 | 1.23 |
| 32 / balanced | 3.84 | 2.93 |
| 128 / balanced | 15.6 | 11.5 |
| 128 / chain | 46.2 | 12.3 |
| 512 / chain | 597 | 54.9 |
| 1,024 / balanced | 156 | 104 |
| 1,024 / chain | 2,401 | 134 |

Small inputs are effectively unchanged; larger shallow trees save roughly 25–35%, with the largest gain in deep chains. These are synthetic model timings, not app-wide rendering measurements. The reachability phase becomes linear and no longer grows the call stack; downstream presentation traversals are not changed by this PR.

```sh
git show 20ab99506541:src/renderer/src/components/dashboard/agent-row-lineage-model.ts | ORCA_BACKGROUND_LAUNCH=1 node config/scripts/agent-lineage-reachability-benchmark.mjs
```

## Verification

- 122 tests pass across the model and its dashboard, activity, and worktree-card consumers (6 files).
- Operation regression fails baseline with 124,750 copied set entries for a 500-row chain; optimized traversal visits 500.
- Tests cover a 10,000-row chain, duplicate identities/order, a reachable duplicate-key cycle, unreachable cycles, and parent-handle fallbacks.
- 5,000 differential graphs include duplicate panes/handles, missing parents, cycles, and frozen input rows. Explicitly compare map/set iteration order as well as complete row data.
- Renderer typecheck and changed-code quality gate pass.
- All tests run with `ORCA_BACKGROUND_LAUNCH=1`; no app windows launched.

Independent performance improvement 7; tracks #20206. No dependency on the other performance PRs.
