### PR TITLE
perf(plugins): reconcile shortcut conflicts once per owner

### DIFF
--- a/config/scripts/plugin-shortcut-conflicts-benchmark.mjs
+++ b/config/scripts/plugin-shortcut-conflicts-benchmark.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const baseline = process.argv[2]
+if (!baseline) {
+  throw new Error(
+    'Usage: node config/scripts/plugin-shortcut-conflicts-benchmark.mjs <baseline-ref>'
+  )
+}
+async function load(file, contents, name) {
+  const result = await build({
+    stdin: { contents, loader: 'ts', resolveDir: dirname(resolve(file)) },
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    logLevel: 'silent',
+    tsconfigRaw: {},
+    banner: {
+      js: "import { createRequire as benchmarkRequire } from 'node:module'; import { resolve as benchmarkPath } from 'node:path'; const require = benchmarkRequire(benchmarkPath('package.json'));"
+    }
+  })
+  return (
+    await import(
+      `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+    )
+  )[name]
+}
+const file = 'src/main/plugins/plugin-command-registry.ts'
+const before = await load(
+  file,
+  execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8' }),
+  'PluginCommandRegistry'
+)
+const after = await load(file, readFileSync(file, 'utf8'), 'PluginCommandRegistry')
+const results = []
+for (const count of [1, 8, 32, 128]) {
+  const plugins = Array.from({ length: count }, (_, index) => ({
+    pluginKey: `sample.plugin-${index}`,
+    manifest: {
+      contributes: {
+        commands: [
+          {
+            id: 'open',
+            title: 'Open',
+            action: 'view.tasks',
+            context: index % 2 ? 'worktree' : 'global'
+          }
+        ],
+        keybindings: [{ command: 'open', key: 'Mod+Alt+T' }]
+      }
+    }
+  }))
+  const arms = { before: new before(), after: new after() }
+  for (const platform of ['darwin', 'linux', 'win32']) {
+    for (const arm of Object.values(arms)) {
+      arm.reconcile(plugins, () => true, {}, platform)
+    }
+    const snapshot = (registry) => ({
+      active: registry.list(),
+      previews: plugins.map((plugin) => registry.preview(plugin.pluginKey)),
+      errors: plugins.map((plugin) => registry.error(plugin.pluginKey))
+    })
+    assert.deepEqual(snapshot(arms.after), snapshot(arms.before))
+  }
+  const iterations = 100
+  function run(arm) {
+    const start = performance.now()
+    for (let i = 0; i < iterations; i++) {
+      arms[arm].reconcile(plugins, () => true, {}, 'linux')
+    }
+    return (performance.now() - start) / iterations
+  }
+  const samples = { before: [], after: [] }
+  run('before')
+  run('after')
+  for (const pair of buildCounterbalancedSchedule(10, 'before', 'after')) {
+    for (const arm of pair) {
+      samples[arm].push(run(arm))
+    }
+  }
+  function median(values) {
+    const sorted = [...values].sort((a, b) => a - b)
+    return (sorted[4] + sorted[5]) / 2
+  }
+  results.push({ count, beforeMs: median(samples.before), afterMs: median(samples.after), samples })
+}
+console.log(
+  JSON.stringify({ baseline, node: process.version, platform: process.platform, results }, null, 2)
+)

--- a/src/main/plugins/plugin-command-registry.test.ts
+++ b/src/main/plugins/plugin-command-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { fingerprintPluginConsent } from '../../shared/plugins/plugin-consent-fingerprint'
 import { pluginManifestSchema } from '../../shared/plugins/plugin-manifest'
 import type { ValidDiscoveredPlugin } from './plugin-discovery'
@@ -37,6 +37,50 @@ function commandPlugin(
 }
 
 describe('PluginCommandRegistry', () => {
+  it('records each conflicting owner once instead of every pair', () => {
+    const plugins = Array.from({ length: 128 }, (_, index) =>
+      commandPlugin(`plugin-${index}`, {
+        commands: [{ id: 'tasks', title: 'Tasks', action: 'view.tasks' }],
+        keybindings: [{ command: 'tasks', key: 'Mod+Alt+T' }]
+      })
+    )
+    const registry = new PluginCommandRegistry()
+    const errors = (registry as unknown as { errors: Map<string, string> }).errors
+    const writes = vi.spyOn(errors, 'set')
+    registry.reconcile(plugins, () => true)
+    expect(registry.list()).toEqual([])
+    for (const plugin of plugins) {
+      expect(registry.preview(plugin.pluginKey)).toHaveLength(1)
+      expect(registry.error(plugin.pluginKey)).toBe(
+        'plugin keybinding Mod+Alt+T conflicts with another plugin'
+      )
+    }
+    expect(writes).toHaveBeenCalledTimes(plugins.length)
+  })
+
+  it('preserves the last conflicting spelling for repeated owners and chord groups', () => {
+    const plugin = commandPlugin('repeat', {
+      commands: [
+        { id: 'one', title: 'One', action: 'view.tasks' },
+        { id: 'two', title: 'Two', action: 'view.tasks', context: 'worktree' }
+      ]
+    })
+    const registry = new PluginCommandRegistry()
+    registry.reconcile(
+      [plugin],
+      () => true,
+      {
+        'plugin:orca-samples.repeat/one': ['Mod+Alt+T', 'Mod+Alt+Y'],
+        'plugin:orca-samples.repeat/two': ['Ctrl+Alt+T', 'Ctrl+Alt+Y']
+      },
+      'linux'
+    )
+    expect(registry.list()).toEqual([])
+    expect(registry.error(plugin.pluginKey)).toBe(
+      'plugin keybinding Ctrl+Alt+Y conflicts with another plugin'
+    )
+  })
+
   it('retains pending previews and exposes only approved commands', () => {
     const plugin = commandPlugin('aliases', {
       commands: [{ id: 'tasks', title: 'Open Tasks', action: 'view.tasks' }],

--- a/src/main/plugins/plugin-command-registry.ts
+++ b/src/main/plugins/plugin-command-registry.ts
@@ -30,7 +30,6 @@ export type PluginCommandRegistration = {
 
 type CommandOwner = {
   pluginKey: string
-  context: PluginCommandKeybinding['when']
   key: string
 }
 
@@ -82,7 +81,6 @@ export class PluginCommandRegistry {
           const owners = chordOwners.get(identity) ?? []
           owners.push({
             pluginKey: plugin.pluginKey,
-            context: keybinding.when,
             key: keybinding.key
           })
           chordOwners.set(identity, owners)
@@ -92,24 +90,16 @@ export class PluginCommandRegistry {
 
     const conflicted = new Set<string>()
     for (const owners of chordOwners.values()) {
-      for (let index = 0; index < owners.length; index += 1) {
-        for (let compared = index + 1; compared < owners.length; compared += 1) {
-          const first = owners[index]!
-          const second = owners[compared]!
-          if (!contextsOverlap(first.context, second.context)) {
-            continue
-          }
-          conflicted.add(first.pluginKey)
-          conflicted.add(second.pluginKey)
-          this.errors.set(
-            first.pluginKey,
-            `plugin keybinding ${first.key} conflicts with another plugin`
-          )
-          this.errors.set(
-            second.pluginKey,
-            `plugin keybinding ${second.key} conflicts with another plugin`
-          )
-        }
+      // Global/worktree are the only contexts, so all owners of the same chord overlap.
+      if (owners.length < 2) {
+        continue
+      }
+      for (const owner of owners) {
+        conflicted.add(owner.pluginKey)
+        this.errors.set(
+          owner.pluginKey,
+          `plugin keybinding ${owner.key} conflicts with another plugin`
+        )
       }
     }
 
@@ -157,11 +147,4 @@ function keybindingsForCommand(
       key: keybinding.key,
       when: keybinding.when ?? command.context ?? 'global'
     }))
-}
-
-function contextsOverlap(
-  first: PluginCommandKeybinding['when'],
-  second: PluginCommandKeybinding['when']
-): boolean {
-  return first === 'global' || second === 'global' || first === second
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 |

<!-- /orca-pr-loc -->

## ELI5
When plugins claim the same shortcut, reconciliation now marks each owner once instead of revisiting every pair of owners.

## What Changed
Keep the existing platform-aware chord grouping, then mark all owners in groups of two or more. The supported contexts are only `global` and `worktree`, so any two owners of the same chord overlap. Remove the redundant pair comparison and unused owner-context copy.

The pass retains owner order and chord-group order. Each plugin therefore keeps the same final conflicting key spelling, including duplicate owners introduced through saved overrides.

## Why
At 128 owners of one chord, the production-path regression records 16,256 error-map writes before and 128 after. The count assertion fails on baseline `20ab9950654`; all semantic assertions pass there. Full reconciliation measured approximately 0.555 → 0.051 ms at 128 plugins (Node 24/macOS, counterbalanced ten samples per arm). Eight plugins measured 0.0048 → 0.0036 ms; 32 measured 0.0358 → 0.0120 ms. This is a synthetic conflict-heavy microbenchmark, not an end-to-end UI latency claim.

## Linked Issue
User-requested codebase performance audit; no linked issue supplied.

## Visual Proof
N/A — unchanged active commands, previews, and conflict messages.

## Testing
- `ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/plugins/plugin-command-registry.test.ts src/main/plugins/plugin-content-pack-registry.test.ts src/shared/plugins/plugin-manifest.test.ts` — 16 tests passed.
- The fixtures include approval changes, inherited contexts, saved overrides, repeated owners across multiple chords, last error spelling, and Mod/Ctrl equivalence.
- `ORCA_BACKGROUND_LAUNCH=1 pnpm tc:node` — passed.
- Changed-file oxlint, formatting/diff checks, and commit hooks passed.
- `node config/scripts/plugin-shortcut-conflicts-benchmark.mjs 20ab9950654` bundles both production registries and checks full active-command/preview/error parity under darwin, linux, and win32 shortcut semantics before timing. Executed on macOS, not native Linux/Windows.

## Review
No persistent cache, lifecycle change, permission/approval change, or new process/IO. Singleton chords remain conflict-free. The existing manifest restricts command contexts to global/worktree; a future new non-overlapping context would require revisiting this algorithm. Workspace kind and execution host do not affect this registry computation, so folder and SSH behavior remain unchanged.

## Agent skill upstream boundary
- [x] Not applicable.

## Checklist
- [x] One focused backend performance improvement.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and folder-workspace impact considered.
- [x] Relevant tests, main-process typecheck, lint, and formatting pass; broader checks remain with CI.
