### PR TITLE
perf: avoid rescanning partial transcript records

### DIFF
--- a/src/main/native-chat/transcript-stream-lines.test.ts
+++ b/src/main/native-chat/transcript-stream-lines.test.ts
@@ -11,6 +11,30 @@ const decode = (line: string, id: string) => ({
 })
 
 describe('decodeTranscriptStream', () => {
+  it.each([true, false])('preserves chunked record offsets with trailing=%s', async (trailing) => {
+    const first = `${'long record '.repeat(10_000)}😀`
+    const prefix = `\r\n${first}\r\n\n`
+    const partial = 'unfinished é'
+    const bytes = Buffer.from(prefix + partial)
+    const chunks: Buffer[] = []
+    for (let offset = 0; offset < bytes.length; offset += 1024) {
+      chunks.push(bytes.subarray(offset, offset + 1024))
+    }
+    const result = await decodeTranscriptStream(
+      Readable.from(chunks),
+      '/chat.jsonl',
+      100,
+      decode,
+      trailing
+    )
+    expect(result.messages.map((message) => message.blocks[0])).toEqual([
+      { type: 'text', text: first },
+      ...(trailing ? [{ type: 'text', text: partial }] : [])
+    ])
+    expect(result.messages[0]?.id).toBe('/chat.jsonl:0000000000000102')
+    expect(result.consumedBytes).toBe(trailing ? bytes.length : Buffer.byteLength(prefix))
+  })
+
   it('uses identical absolute byte ids for full and incremental reads', async () => {
     const prefix = '{"first":"é"}\r\n'
     const appended = '{"second":true}\n'

--- a/src/main/native-chat/transcript-stream-lines.ts
+++ b/src/main/native-chat/transcript-stream-lines.ts
@@ -20,7 +20,12 @@ export async function decodeTranscriptStream(
   let consumedBytes = 0
 
   for await (const chunk of stream) {
-    pending += typeof chunk === 'string' ? chunk : decoder.write(Buffer.from(chunk))
+    const decoded = typeof chunk === 'string' ? chunk : decoder.write(Buffer.from(chunk))
+    pending += decoded
+    // A partial record cannot finish until the new chunk contains a newline.
+    if (!decoded.includes('\n')) {
+      continue
+    }
     let newlineIndex = pending.indexOf('\n')
     while (newlineIndex !== -1) {
       const segment = pending.slice(0, newlineIndex + 1)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

Reading a long transcript record no longer searches all the text received so far after every chunk.

## What Changed

Skip the accumulated-line search when the newly decoded chunk contains no newline. The retained tail cannot contain a complete line, so that chunk cannot complete it. UTF-8 decoding, CRLF handling, consumed byte counts, fallback IDs and trailing-record behavior remain unchanged.

## Why

Windows Node 24 measurements of the complete `decodeTranscriptStream` function with a lightweight record decoder, string input in 64 KiB chunks, median of 15 runs:

| Synthetic record | Before | After |
| --- | ---: | ---: |
| 1 MiB | 2.87 ms | 0.69 ms |
| 4 MiB | 43.17 ms | 2.61 ms |
| 16 MiB stress case | 391.71 ms | 10.83 ms |

This is stream assembly and callback time, not disk/WSL I/O or full provider JSON decoding. Both transcript reads and legacy journal import use this function.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical decoded messages and offsets; no visual or interaction change.

## Testing

- 17 transcript stream/reader/WSL-stall tests passed on Windows.
- Added long chunked records with blank lines, CRLF, absolute offsets and both trailing-record modes.
- Exact before/after result parity at all benchmark sizes and byte-split Unicode/partial records.
- Node TypeScript check, targeted oxlint and formatting passed.
- Journal-import suite: 7 passed, 12 failed on Windows SQLite cleanup (`EBUSY` unlinking journal DB/WAL files). Repeated with the unchanged stream implementation: the same 7 passed/12 cleanup failures. This local suite remains a validation limitation; no journal code changed.

## Review

No filesystem routing, read limits, process ownership, protocol, state freshness or provider decoding changes. WSL and folder-workspace reads retain their existing routing.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests/typecheck/lint passed; broader local test limitation documented above.
