### PR TITLE
perf: avoid rescanning partial browser sidecar responses

### DIFF
--- a/src/main/orcad/orcad-sidecar-runtime-client.test.ts
+++ b/src/main/orcad/orcad-sidecar-runtime-client.test.ts
@@ -34,6 +34,30 @@ afterEach(() => {
 })
 
 describe('sidecar response framing', () => {
+  it('does not rescan the accumulated response for each partial chunk', async () => {
+    const { socket, result, id } = startRequest()
+    const wire = `${JSON.stringify({ id, ok: true, result: 'x'.repeat(1024 * 1024) })}\n`
+    const originalIndexOf = String.prototype.indexOf
+    let searchedCharacters = 0
+    const search = vi
+      .spyOn(String.prototype, 'indexOf')
+      .mockImplementation(function (this: string, value, position) {
+        if (value === '\n') {
+          searchedCharacters += this.length - (position ?? 0)
+        }
+        return originalIndexOf.call(this, value, position)
+      })
+    try {
+      for (let offset = 0; offset < wire.length; offset += 256) {
+        socket.emit('data', wire.slice(offset, offset + 256))
+      }
+    } finally {
+      search.mockRestore()
+    }
+    await expect(result).resolves.toHaveLength(1024 * 1024)
+    expect(searchedCharacters).toBe(wire.length)
+  })
+
   it('assembles a large response after fragmented keepalive and empty lines', async () => {
     const { socket, result, id } = startRequest()
     const expected = { image: 'A'.repeat(1024 * 1024), text: '😀é' }

--- a/src/main/orcad/orcad-sidecar-runtime-client.test.ts
+++ b/src/main/orcad/orcad-sidecar-runtime-client.test.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeMetadata } from '../../shared/runtime-bootstrap'
+
+const { createConnection } = vi.hoisted(() => ({ createConnection: vi.fn() }))
+vi.mock('node:net', () => ({ createConnection }))
+
+import { sendOrcadSidecarRequest } from './orcad-sidecar-runtime-client'
+
+function startRequest(timeout = 1000) {
+  const socket = Object.assign(new EventEmitter(), {
+    setEncoding: vi.fn(),
+    write: vi.fn(),
+    end: vi.fn(),
+    destroy: vi.fn()
+  })
+  createConnection.mockReturnValue(socket)
+  const metadata: RuntimeMetadata = {
+    runtimeId: 'test',
+    pid: 1,
+    startedAt: 0,
+    authToken: null,
+    transports: [{ kind: 'named-pipe', endpoint: 'test-pipe' }]
+  }
+  const result = sendOrcadSidecarRequest(metadata, 'browser.screenshot', {}, timeout)
+  socket.emit('connect')
+  const request = JSON.parse(socket.write.mock.calls[0][0]) as { id: string }
+  return { socket, result, id: request.id }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('sidecar response framing', () => {
+  it('assembles a large response after fragmented keepalive and empty lines', async () => {
+    const { socket, result, id } = startRequest()
+    const expected = { image: 'A'.repeat(1024 * 1024), text: '😀é' }
+    const wire = `\n${JSON.stringify({ _keepalive: true })}\n${JSON.stringify({ id, ok: true, result: expected })}\r\n`
+    for (let offset = 0; offset < wire.length; offset += 8192) {
+      socket.emit('data', wire.slice(offset, offset + 8192))
+    }
+    await expect(result).resolves.toEqual(expected)
+    expect(socket.end).toHaveBeenCalledOnce()
+  })
+
+  it('refreshes the deadline for completed keepalive frames', async () => {
+    vi.useFakeTimers()
+    const { socket, result, id } = startRequest()
+    await vi.advanceTimersByTimeAsync(600)
+    socket.emit('data', '{"_keepalive":')
+    socket.emit('data', 'true}\n')
+    await vi.advanceTimersByTimeAsync(600)
+    expect(socket.destroy).not.toHaveBeenCalled()
+    socket.emit('data', `${JSON.stringify({ id, ok: true, result: 'done' })}\n`)
+    await expect(result).resolves.toBe('done')
+  })
+
+  it('rejects oversized unterminated data before waiting for a newline', async () => {
+    const { socket, result } = startRequest()
+    const rejected = expect(result).rejects.toThrow('response is too large')
+    const chunk = 'a'.repeat(1024 * 1024)
+    for (let index = 0; index < 64; index += 1) {
+      socket.emit('data', chunk)
+    }
+    expect(socket.destroy).not.toHaveBeenCalled()
+    socket.emit('data', 'a')
+    await rejected
+    expect(socket.destroy).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a fragmented response carrying another request id', async () => {
+    const { socket, result } = startRequest()
+    const rejected = expect(result).rejects.toThrow('invalid response')
+    socket.emit('data', '{"id":"other",')
+    socket.emit('data', '"ok":true,"result":null}\n')
+    await rejected
+  })
+})

--- a/src/main/orcad/orcad-sidecar-runtime-client.ts
+++ b/src/main/orcad/orcad-sidecar-runtime-client.ts
@@ -79,6 +79,10 @@ export async function sendOrcadSidecarRequest(
         finish(new BrowserError('browser_error', 'Electron browser sidecar response is too large.'))
         return
       }
+      // The retained tail has no newline; avoid flattening it for each partial chunk.
+      if (!chunk.includes('\n')) {
+        return
+      }
       let newline = buffer.indexOf('\n')
       while (newline !== -1 && !settled) {
         const line = buffer.slice(0, newline)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

Large browser-sidecar responses assemble faster because each new chunk no longer triggers a search through the entire response received so far.

## What Changed

Return early from response framing when the new decoded socket chunk has no newline. The byte limit is checked first. Keepalive handling, response validation, request IDs, deadlines and error handling retain their existing paths.

## Why

A real Windows named-pipe benchmark of `sendOrcadSidecarRequest`, with a local synthetic server sending a keepalive followed by a response in 64 KiB writes, measured:

| Image-value size | Before | After |
| --- | ---: | ---: |
| 1 MiB | 5.66 ms | 3.17 ms |
| 4 MiB | 53.02 ms | 14.08 ms |
| 16 MiB stress case | 434.90 ms | 46.22 ms |

Windows Node 24; nine samples with alternating before/after order, medians shown. Measurements include request exchange, server serialization, transfer, response assembly and parsing, but no browser capture. Every result matched exactly.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical response delivery; no visual or interaction change.

## Testing

- 17 tests passed on Windows: response framing and existing browser-sidecar process tests.
- Added large fragmented responses, empty lines/CRLF, keepalive deadline refresh, rejection above 64 MiB before newline, and mismatched response IDs.
- Node TypeScript check, targeted oxlint and formatting passed.
- Real named-pipe measurements used a synthetic local server; process tests use the existing Node sidecar fixture. No browser window launched.

## Review

No protocol, process policy, screenshot quality, buffer-cap, host-ownership, filesystem or freshness changes. The same implementation supports Unix sockets and Windows named pipes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant local tests, typecheck and lint passed; full build covered by CI.


## Review follow-up

Added a regression test that feeds a 1 MB response in 256-character fragments and counts newline-search work. The accumulated response is searched only when a newline arrives; the test guards against restoring quadratic rescanning. All five sidecar framing tests pass, including fragmentation, keepalives, byte limits and invalid request IDs. Targeted lint and formatting pass.
