### PR TITLE
perf: count local RPC request bytes incrementally

### DIFF
--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { StringDecoder } from 'node:string_decoder'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Socket } from 'node:net'
 import { UnixSocketTransport } from './unix-socket-transport'
@@ -11,6 +12,7 @@ class FakeSocket extends EventEmitter {
   setEncoding(): void {}
   setNoDelay(): void {}
   setTimeout(): void {}
+  end(): void {}
 
   write(data: string): boolean {
     this.writes.push(data)
@@ -38,6 +40,47 @@ describe('UnixSocketTransport', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  function createReceiver() {
+    const transport = new UnixSocketTransport({ endpoint: 'test-pipe', kind: 'named-pipe' })
+    const socket = new FakeSocket()
+    const received: string[] = []
+    transport.onMessage((message, reply) => {
+      received.push(message)
+      reply('ok')
+    })
+    ;(transport as unknown as UnixSocketTransportInternals).handleConnection(
+      socket as unknown as Socket
+    )
+    return { socket, received }
+  }
+
+  it.each([false, true])('preserves the UTF-8 byte boundary with oversized=%s', (oversized) => {
+    const { socket, received } = createReceiver()
+    const message = `${'é'.repeat(524287)}a${oversized ? 'x' : ''}`
+    const wire = Buffer.from(`${message}\n`)
+    const decoder = new StringDecoder('utf8')
+    for (let offset = 0; offset < wire.length; offset += 4095) {
+      socket.emit('data', decoder.write(wire.subarray(offset, offset + 4095)))
+    }
+    expect(received).toEqual([oversized ? '' : message])
+  })
+
+  it('retains only the byte count of the partial tail between messages', () => {
+    const { socket, received } = createReceiver()
+    const large = 'a'.repeat(700000)
+    socket.emit('data', `${large}\npart`)
+    socket.emit('data', `ial\r\n\n${large}\n`)
+    expect(received).toEqual([large, 'partial', large])
+  })
+
+  it('checks the combined incoming buffer before dispatching any complete messages', () => {
+    const { socket, received } = createReceiver()
+    socket.emit('data', `${'a'.repeat(700000)}\n${'b'.repeat(700000)}\n`)
+    expect(received).toEqual([''])
+    socket.emit('data', 'later\n')
+    expect(received).toEqual([''])
   })
 
   it('clears request keepalive timers when the socket closes before a reply', () => {

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -105,6 +105,7 @@ export class UnixSocketTransport implements RpcTransport {
   private handleConnection(socket: Socket): void {
     this.activeSockets.add(socket)
     let buffer = ''
+    let retainedBytes = 0
     let oversized = false
     // Why: each in-flight dispatch registers its own AbortController here so
     // `socket.on('close')` can abort them all at once. Keeping the set scoped
@@ -134,15 +135,20 @@ export class UnixSocketTransport implements RpcTransport {
         return
       }
       buffer += chunk
+      // setEncoding('utf8') keeps split codepoints intact, so chunk byte lengths add exactly.
+      retainedBytes += Buffer.byteLength(chunk, 'utf8')
       // Why: the Orca runtime lives in Electron main, so it must reject
       // oversized local RPC frames instead of letting a local client grow an
       // unbounded buffer and stall the app.
-      if (Buffer.byteLength(buffer, 'utf8') > MAX_RUNTIME_RPC_MESSAGE_BYTES) {
+      if (retainedBytes > MAX_RUNTIME_RPC_MESSAGE_BYTES) {
         oversized = true
         this.messageHandler?.('', (response) => {
           socket.write(`${response}\n`)
           socket.end()
         })
+        return
+      }
+      if (!chunk.includes('\n')) {
         return
       }
       let newlineIndex = buffer.indexOf('\n')
@@ -154,6 +160,7 @@ export class UnixSocketTransport implements RpcTransport {
         }
         newlineIndex = buffer.indexOf('\n')
       }
+      retainedBytes = Buffer.byteLength(buffer, 'utf8')
     })
   }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## ELI5

Large local RPC requests no longer repeatedly count and search all the data received so far.

## What Changed

Track retained UTF-8 bytes per connection by counting incoming decoded chunks, and skip line searches until a chunk contains a newline. Recalculate the retained tail after complete messages are dispatched. The socket's existing UTF-8 decoder keeps split codepoints intact, making chunk byte lengths additive.

The 1 MiB cap still applies to the combined buffer before any complete messages are dispatched. Oversize rejection, whitespace handling, keepalives, connection limits and cancellation retain their existing behavior.

## Why

Real Windows named-pipe benchmark of `UnixSocketTransport`, 4 KiB client writes, median of 15 request/reply samples using Node 24:

| Request text size | Before | After |
| --- | ---: | ---: |
| 256 KiB | 2.97 ms | 0.65 ms |
| 768 KiB | 19.07 ms | 1.71 ms |
| 1 MiB minus newline | 31.77 ms | 2.28 ms |

The benchmark includes transfer, assembly and a simple reply; it excludes RPC application work. Every delivered message matched the input exactly. The same transport serves Windows named pipes and Unix sockets on WSL/other hosts.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — internal request assembly only; no visual or interaction change.

## Testing

- 33 tests passed on Windows across socket transport, long-poll transport, request authorization and request parsing.
- Added exact/oversized UTF-8 byte limits with split multibyte input, partial-tail accounting across messages, and combined-buffer rejection before dispatch.
- Node TypeScript check, targeted oxlint and formatting passed.
- Real named-pipe benchmark uses synthetic requests; no desktop UI launched.

## Review

No protocol, authorization, filesystem, host-ownership or request freshness changes. Reuses the existing connection-local byte-count pattern used by other socket clients; no shared cache or new subsystem.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant local tests, typecheck and lint passed; full build covered by CI.
