### PR TITLE
perf: stop heading lookup at the requested occurrence

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-toc-heading-target.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-toc-heading-target.test.ts
@@ -14,6 +14,14 @@ function makeTocItem(
 }
 
 describe('findRichMarkdownTocHeadingTarget', () => {
+  it('returns undefined when the requested duplicate occurrence is missing', () => {
+    const container = document.createElement('div')
+    container.innerHTML = '<h2>Repeat</h2><h2>Other</h2>'
+    const items = [makeTocItem('repeat', 2, 'Repeat'), makeTocItem('repeat-1', 2, 'Repeat')]
+    expect(findRichMarkdownTocHeadingTarget(container, items, 'repeat-1')).toBeUndefined()
+    expect(findRichMarkdownTocHeadingTarget(container, items, 'missing')).toBeUndefined()
+  })
+
   it('finds deep headings that the table of contents exposes', () => {
     const container = document.createElement('div')
     container.innerHTML = `

--- a/src/renderer/src/components/editor/rich-markdown-toc-heading-target.ts
+++ b/src/renderer/src/components/editor/rich-markdown-toc-heading-target.ts
@@ -18,9 +18,16 @@ export function findRichMarkdownTocHeadingTarget(
   const sameTitleIndex = items
     .filter((item) => item.title === target.title)
     .findIndex((item) => item.id === target.id)
-  const matchingHeadings = Array.from(
-    container.querySelectorAll<HTMLElement>(RICH_MARKDOWN_TOC_HEADING_SELECTOR)
-  ).filter((candidate) => candidate.textContent?.trim() === target.title)
-
-  return matchingHeadings.at(Math.max(0, sameTitleIndex))
+  let remaining = Math.max(0, sameTitleIndex)
+  for (const candidate of container.querySelectorAll<HTMLElement>(
+    RICH_MARKDOWN_TOC_HEADING_SELECTOR
+  )) {
+    if (candidate.textContent?.trim() === target.title) {
+      if (remaining === 0) {
+        return candidate
+      }
+      remaining -= 1
+    }
+  }
+  return undefined
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## ELI5

Finding a Markdown heading stops at the requested occurrence instead of reading every remaining heading's text.

## What Changed

Walk the existing heading query result and return when the requested same-title occurrence is reached. This avoids creating and filtering a second array. Heading levels, duplicate-title ordering, missing-target results and DOM selection remain unchanged.

## Why

Synthetic happy-dom benchmark on Windows Node 24, full exported lookup function, median of 11 batches of 50 calls:

| Document / target | Before | After |
| --- | ---: | ---: |
| 100 headings / first | 0.0056 ms | 0.0009 ms |
| 1,000 headings / first | 0.0719 ms | 0.0017 ms |
| 1,000 headings / last | 0.0651 ms | 0.0431 ms |

This is a small allocation/lookup improvement. These are synthetic DOM measurements, not Chromium rendering or navigation latency. Before/after results selected the same element.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — same selected DOM element and navigation behavior; no visual or interaction change.

## Testing

- All three heading-target tests passed, covering deep heading levels, duplicate order, missing IDs and missing duplicate occurrences.
- Renderer TypeScript check, targeted oxlint and formatting passed.
- Before/after element-identity parity at 100 and 1,000 headings, first and last target.

## Review

No styling, scrolling, filesystem, platform shortcuts, execution-host ownership or protocol changes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant local tests, typecheck and lint passed; full build covered by CI.
