### PR TITLE
perf: defer browser search row formatting until matched

### DIFF
--- a/src/renderer/src/lib/browser-palette-search.ts
+++ b/src/renderer/src/lib/browser-palette-search.ts
@@ -223,14 +223,14 @@ export function searchBrowserPages(
 
   const results: BrowserPaletteSearchResult[] = []
   for (const entry of entries) {
-    const base = baseResult(entry, context)
-    const secondaryTexts = browserPaletteSecondaryTexts(entry.page)
     const match = matchPaletteTabDocument(entry.document, prepared, {
       isFieldAllowed: options.fieldMode === 'omnibox' ? isOmniboxPaletteTabFieldAllowed : undefined
     })
     if (!match) {
       continue
     }
+    const base = baseResult(entry, context)
+    const secondaryTexts = browserPaletteSecondaryTexts(entry.page)
     results.push({
       ...base,
       secondaryText:


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Browser search prepares display rows only for pages that match the query.

## What Changed

Move base-row formatting and secondary URL text construction after the existing match check. Query matching uses the prepared document, so unmatched entries need neither transformation. Matching results, ordering, highlights and empty-query behavior remain unchanged.

## Why

Windows Node 24 synthetic full-function benchmark, median of 15 batches of 20 searches:

- 100 pages, no matches: 0.121 → 0.048 ms.
- 1,000 pages, no matches: 1.186 → 0.483 ms.
- 1,000 pages, all matching: 2.921 → 2.859 ms (approximately unchanged).
- 1,000 pages, empty query: 0.398 → 0.395 ms (unchanged).

These measure search computation, not rendering or perceived typing latency. Before/after outputs matched exactly for every scenario.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical search results and interaction; no styling or UI behavior change.

## Testing

- 35 existing browser-palette and browser-history tests passed on Windows.
- Renderer TypeScript check, targeted oxlint and formatting passed.
- Full-function before/after output parity for empty, matching and nonmatching queries.
- No new test: the existing suite covers search output and ordering; only two pure computations moved.

## Review

No caching, freshness, execution-host ownership, protocol or platform behavior changes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant local tests, typecheck and lint passed; full build covered by CI.
