### PR TITLE
perf: stop preparing over-limit palette queries

### DIFF
--- a/src/renderer/src/lib/palette-match/palette-query.ts
+++ b/src/renderer/src/lib/palette-match/palette-query.ts
@@ -103,13 +103,13 @@ export function preparePaletteQuery(query: string): PreparedPaletteQuery {
     }
     seen.add(raw)
     tokens.push(createPaletteQueryToken(raw, tokens.length))
+    if (tokens.length > PALETTE_QUERY_MAX_TOKENS) {
+      return { state: 'invalid', reason: 'too-many-tokens' }
+    }
   }
 
   if (!tokens.length) {
     return { state: 'empty' }
-  }
-  if (tokens.length > PALETTE_QUERY_MAX_TOKENS) {
-    return { state: 'invalid', reason: 'too-many-tokens' }
   }
   return {
     state: 'ready',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Search stops preparing tokens once the query exceeds its existing token limit.

## What Changed

Move the existing 16-unique-token rejection inside the token-building loop. The seventeenth unique token produces the same `too-many-tokens` result immediately. Duplicate handling, byte limits, normalization and valid-query output remain unchanged.

## Why

Windows Node 24 full-parser benchmark, median of 15 batches of 100 calls: 100 unique tokens improved from 0.0164 to 0.0060 ms; 300 tokens from 0.0505 to 0.0118 ms. The 16-token valid boundary and 17-token rejection boundary were approximately unchanged. All inputs fit the existing 2 KiB byte limit.

This is a small reduction in unnecessary work on rejected pasted queries, not a typing-latency claim. Before/after return values matched, including repeated tokens and Unicode.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical query acceptance, rejection and search results; no visual or interaction change.

## Testing

- 126 existing tests passed across core matching, matching performance, ranking contracts, multi-keyword search and browser search.
- Renderer TypeScript check, targeted oxlint and formatting passed.
- Exact before/after output comparisons at 16, 17, 100 and 300 unique tokens, plus empty, duplicate-heavy, Unicode and oversized queries.
- No new tests: existing boundary and ranking tests cover the unchanged contract.

## Review

No query policy, limits, ranking, cache, execution-host ownership or protocol changes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant local tests, typecheck and lint passed; full build covered by CI.
