### PR TITLE
perf: avoid duplicate repository directory probes

### DIFF
--- a/src/main/git/repo-detection.ts
+++ b/src/main/git/repo-detection.ts
@@ -13,7 +13,7 @@ let warnedMarkerFallbackThisSession = false
 /** Check if a path is a valid git repository (regular or bare). */
 export function isGitRepo(path: string): boolean {
   try {
-    if (!existsSync(path) || !statSync(path).isDirectory()) {
+    if (!statSync(path, { throwIfNoEntry: false })?.isDirectory()) {
       return false
     }
   } catch {
@@ -104,7 +104,7 @@ function canonicalizeGitDirPath(path: string): string {
 /** Return the main-checkout path only when `path` is a linked worktree. */
 export function getLinkedWorktreeMainRepoRoot(path: string): string | null {
   try {
-    if (!existsSync(path) || !statSync(path).isDirectory()) {
+    if (!statSync(path, { throwIfNoEntry: false })?.isDirectory()) {
       return null
     }
     if (gitExecFileSync(['rev-parse', '--is-inside-work-tree'], { cwd: path }).trim() !== 'true') {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Repository checks ask the filesystem once whether a directory exists, instead of checking existence and then requesting the same path's metadata.

## What Changed

Use `statSync` with `throwIfNoEntry: false` in `isGitRepo` and `getLinkedWorktreeMainRepoRoot`. Missing paths still return false/null, files still fail directory validation, symlinks still resolve through stat, and other filesystem errors keep the existing catch behavior.

`getGitRepoRoot` has a different fallback policy after errors and retains its existing checks. No Git commands changed.

## Why

Actual filesystem-probe measurements on Windows Node 24, alternating before/after order over 11 batches of 100 probes:

| Existing directory | Exists + stat | Stat only |
| --- | ---: | ---: |
| Local Windows worktree | 0.0137 ms | 0.0035 ms |
| Ubuntu 24.04 WSL UNC `/tmp` | 1.3775 ms | 0.5550 ms |

These isolate the directory preflight and exclude Git execution. The larger gain comes from avoiding a second lookup across the WSL filesystem boundary.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical repository results; no visual or interaction change.

## Testing

- 30 tests passed across repository detection and API parity on Windows.
- Two existing `getGitRepoRoot` tests fail on Windows slash-vs-backslash expectations; both failures reproduced with the original implementation restored. That function is unchanged. This remains a local suite limitation.
- Existing tests exercise real Git repositories, bare/linked worktrees, symlinks, marker fallback and missing paths.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

No new filesystem cache, freshness changes, Git flags, SSH routing or folder-workspace assumptions. `throwIfNoEntry` is supported by the project's Node runtime baseline.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Typecheck/lint passed; relevant test results and baseline failures documented.
