### PR TITLE
fix(native-chat): shrink skill pill text

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatPromptEditor.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatPromptEditor.test.tsx
@@ -34,7 +34,10 @@ describe('native chat skill editor', () => {
   it('renders only picker insertions as pills and serializes the exact invocation', () => {
     const { input, container } = setup('Please $rev')
     act(() => input.insertSkill!(7, 11, '$review'))
-    expect(container.querySelector('[data-native-chat-skill]')?.textContent).toBe('Review')
+    const pill = container.querySelector('[data-native-chat-skill]')
+    expect(pill?.textContent).toBe('Review')
+    expect(pill?.classList.contains('text-xs')).toBe(true)
+    expect(pill?.classList.contains('text-sm')).toBe(false)
     expect(input.value).toBe('Please $review ')
     expect(input.selectionStart).toBe(15)
     act(() => {

--- a/src/renderer/src/components/native-chat/NativeChatSkillPill.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatSkillPill.tsx
@@ -18,9 +18,9 @@ export function NativeChatSkillPill({ node, selected }: NodeViewProps): React.JS
       <Badge
         variant="secondary"
         data-native-chat-skill={token}
-        className={`gap-1 border-border px-1.5 py-0 text-sm font-medium text-muted-foreground align-baseline ${selected ? 'ring-1 ring-ring' : ''}`}
+        className={`border-border px-1.5 py-0 text-muted-foreground align-baseline ${selected ? 'ring-1 ring-ring' : ''}`}
       >
-        <Package className="size-4" aria-hidden="true" />
+        <Package aria-hidden="true" />
         {skillLabel(token)}
       </Badge>
     </NodeViewWrapper>

--- a/src/renderer/src/components/native-chat/native-chat-prompt-document.ts
+++ b/src/renderer/src/components/native-chat/native-chat-prompt-document.ts
@@ -17,7 +17,7 @@ export const NativeChatSkill = Node.create({
       'data-native-chat-skill': node.attrs.token,
       contenteditable: 'false',
       class:
-        'inline-flex items-center gap-1 rounded-full border border-border bg-muted px-1.5 text-sm font-medium text-muted-foreground align-baseline select-none'
+        'inline-flex items-center gap-1 rounded-full border border-border bg-muted px-1.5 text-xs font-medium text-muted-foreground align-baseline select-none'
     },
     ['span', { 'aria-hidden': 'true' }, 'ϟ'],
     ['span', {}, String(node.attrs.token).slice(1)]


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Skill pills in native chat looked larger than the surrounding composer text. They now use the compact badge typography and icon sizing already defined by the design system.

## What Changed

- Removed native-chat overrides that enlarged the skill pill label and icon.
- Aligned the fallback skill markup with the same `text-xs` typography.
- Added regression assertions for the compact pill text class.

## Why

The native chat skill pill was overriding the Badge primitive with `text-sm` and a 16px icon, making it visually heavier than intended. Inheriting the Badge defaults keeps the label and icon at 12px and makes the token sit naturally within the 14px composer text.

## Linked Issue

N/A — reported directly during native chat review.

## Visual Proof

| Before | After |
| --- | --- |
| ![Oversized skill pill before the change](https://github.com/user-attachments/assets/dd5bb06f-a8f8-4571-961d-92f737843271) | ![Compact skill pill after the change](https://github.com/user-attachments/assets/7cb0376f-aac6-4f65-a5d5-8d1040305b76) |

After validation measured the pill at 12px font with a 12px icon, alongside 14px composer text.

## Testing

- [x] Manually tested on macOS in the hidden Electron renderer via Playwright CDP.
- [x] Opened native Codex chat, typed `/rev`, and selected `$review-llm-counsel`.
- [x] `pnpm test src/renderer/src/components/native-chat/NativeChatPromptEditor.test.tsx` — 8 passed.
- [x] `pnpm tc:web`.
- [x] `pnpm run check:code-quality:changed`.
- [x] `git diff --check`.

## Review

- Security and performance: presentation-only class changes; no new data flow, dependencies, or runtime work.
- Cross-platform: shared design-system classes only; no platform-specific behavior.
- SSH/remote and mobile: not applicable to native chat pill rendering.
- Gemini review was unavailable because the workspace was not trusted; trust settings were left unchanged.

## Agent skill upstream boundary

- [x] Not applicable; this change does not copy or translate upstream skill-installer material.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why.
- [x] Before/after screenshots are attached.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and mobile impact considered.
- [x] Targeted tests, renderer typecheck, changed-file quality checks, and Electron validation pass; CI will cover the full suite.