### PR TITLE
perf(ai-vault): deduplicate session scan batches incrementally

### DIFF
--- a/config/scripts/session-dedup-batches-benchmark.mjs
+++ b/config/scripts/session-dedup-batches-benchmark.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const bundled = await build({
+  stdin: {
+    contents: "export * from './src/main/ai-vault/codex-session-root-dedup.ts'",
+    resolveDir: process.cwd(),
+    loader: 'ts'
+  },
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  write: false
+})
+const production = await import(
+  `data:text/javascript;base64,${Buffer.from(bundled.outputFiles[0].text).toString('base64')}`
+)
+
+function baseline(input) {
+  const sessions = []
+  for (let offset = 0; offset < input.length; offset += 8) {
+    sessions.push(...input.slice(offset, offset + 8))
+    const unique = production.dedupeCodexSessionsBySessionId(sessions)
+    sessions.splice(0, sessions.length, ...unique)
+  }
+  return sessions
+}
+
+function incremental(input) {
+  const sessions = new production.CodexSessionCollection()
+  for (let offset = 0; offset < input.length; offset += 8) {
+    for (const session of input.slice(offset, offset + 8)) {
+      sessions.add(session)
+    }
+  }
+  return [...sessions.values()]
+}
+
+function makeSession(index, overrides = {}) {
+  return Object.freeze({
+    agent: 'codex',
+    executionHostId: 'local',
+    sessionId: `session-${index}`,
+    filePath: `/home/ada/.codex/sessions/2026/09/11/rollout-session-${index}.jsonl`,
+    codexHome: null,
+    updatedAt: '2026-09-11T10:00:00.000Z',
+    createdAt: null,
+    modifiedAt: '2026-09-11T10:00:00.000Z',
+    ...overrides
+  })
+}
+
+function checkIdentities(actual, expected) {
+  assert.equal(actual.length, expected.length)
+  actual.forEach((session, index) => assert.equal(session, expected[index]))
+}
+
+let seed = 90211
+function random(max) {
+  seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+  return Math.floor((seed / 0x100000000) * max)
+}
+
+if (production.CodexSessionCollection) {
+  let batches = 0
+  for (let trial = 0; trial < 2000; trial++) {
+    const input = []
+    const current = new production.CodexSessionCollection()
+    let expected = []
+    for (let batch = 0; batch < 20; batch++) {
+      const added = Array.from({ length: 1 + random(8) }, () => {
+        if (input.length && random(4) === 0) {
+          return input[random(input.length)]
+        }
+        const index = random(12)
+        const root = [
+          '/home/ada/.codex',
+          '/tmp/codex-runtime-home/home',
+          '/tmp/codex-accounts/account/home',
+          '/tmp/custom',
+          '\\\\wsl$\\Ubuntu\\home\\ada\\.codex',
+          '\\\\wsl.localhost\\ubuntu\\home\\ada\\.codex',
+          '\\\\wsl$\\Debian\\home\\ada\\.codex',
+          'C:\\Users\\Ada\\.codex'
+        ][random(8)]
+        return makeSession(index, {
+          agent: random(6) ? 'codex' : 'claude',
+          executionHostId: random(5) ? 'local' : 'ssh:dev',
+          sessionId: `session-${random(3)}`,
+          codexHome: random(4) ? root : null,
+          filePath: `${root}/sessions/${random(6) ? 'rollout-' : ''}${index}.jsonl`,
+          updatedAt: [null, 'invalid', '2026-09-11T10:00:00Z', '2026-09-11T10:01:00Z'][random(4)],
+          modifiedAt: random(4) ? '2026-09-11T10:00:00Z' : 'invalid'
+        })
+      })
+      input.push(...added)
+      expected = production.dedupeCodexSessionsBySessionId([...expected, ...added])
+      added.forEach((session) => current.add(session))
+      checkIdentities([...current.values()], expected)
+      assert.equal(current.size, expected.length)
+      batches++
+    }
+  }
+  console.log(JSON.stringify({ differentialBatches: batches }))
+}
+
+const workloads = []
+if (process.argv.includes('--verify-only')) {
+  process.exit(0)
+}
+for (const count of [8, 100, 1000, 5000, 10000]) {
+  workloads.push([`${count} unique Codex`, Array.from({ length: count }, (_, i) => makeSession(i))])
+  workloads.push([
+    `${count} Claude`,
+    Array.from({ length: count }, (_, i) => makeSession(i, { agent: 'claude' }))
+  ])
+}
+for (const count of [1000, 5000]) {
+  const input = Array.from({ length: count }, (_, i) => makeSession(i))
+  const aliases = input.map((session) =>
+    makeSession(0, {
+      ...session,
+      codexHome: '/tmp/custom',
+      filePath: session.filePath.replace('/home/ada/.codex', '/tmp/custom')
+    })
+  )
+  workloads.push([`${count} late preferred roots`, [...aliases, ...input]])
+  workloads.push([`${count} late losing roots`, [...input, ...aliases]])
+}
+
+function median(samples) {
+  const sorted = [...samples].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+console.log(
+  JSON.stringify({ node: process.version, platform: process.platform, arch: process.arch })
+)
+for (const [name, input] of workloads) {
+  const expected = baseline(input)
+  const arms = { baseline, ...(production.CodexSessionCollection ? { incremental } : {}) }
+  const repeats = Math.max(1, Math.floor(5000 / input.length))
+  const samples = { baseline: [], incremental: [] }
+  for (const run of Object.values(arms)) {
+    checkIdentities(run(input), expected)
+  }
+  for (const pair of buildCounterbalancedSchedule(8, 'baseline', 'incremental')) {
+    for (const arm of pair) {
+      if (!arms[arm]) {
+        continue
+      }
+      const start = performance.now()
+      let result
+      for (let repeat = 0; repeat < repeats; repeat++) {
+        result = arms[arm](input)
+      }
+      samples[arm].push((performance.now() - start) / repeats)
+      checkIdentities(result, expected)
+    }
+  }
+  console.log(
+    JSON.stringify({
+      name,
+      medianMs: Object.fromEntries(
+        Object.entries(samples)
+          .filter(([, values]) => values.length)
+          .map(([arm, values]) => [arm, median(values)])
+      )
+    })
+  )
+}
+
+if (global.gc && production.CodexSessionCollection) {
+  for (const count of [1000, 10000]) {
+    const input = Array.from({ length: count }, (_, index) => makeSession(index))
+    global.gc()
+    const before = process.memoryUsage().heapUsed
+    const collection = new production.CodexSessionCollection()
+    input.forEach((session) => collection.add(session))
+    global.gc()
+    const retainedBytes = process.memoryUsage().heapUsed - before
+    checkIdentities([...collection.values()], input)
+    console.log(JSON.stringify({ name: `${count} scan-local index`, retainedBytes }))
+  }
+}

--- a/src/main/ai-vault/codex-session-collection.test.ts
+++ b/src/main/ai-vault/codex-session-collection.test.ts
@@ -65,6 +65,31 @@ describe('CodexSessionCollection', () => {
     ).toEqual([first, first, first])
   })
 
+  it('preserves order as winning rows alternate between single and repeated occurrences', () => {
+    const other = session({ agent: 'claude' })
+    const custom = session({ codexHome: '/tmp/custom' })
+    const managed = session({ codexHome: '/tmp/codex-runtime-home/home' })
+    const newerManaged = session({ ...managed, updatedAt: '1970-01-01T00:00:03Z' })
+    const real = session()
+    const newerReal = session({ updatedAt: '1970-01-01T00:00:05Z' })
+    const tied = session({ ...newerReal })
+
+    expect(
+      checkBatches([
+        [custom, other],
+        [managed],
+        [managed, other, managed],
+        [newerManaged],
+        [real],
+        [real],
+        [real, other],
+        [newerReal],
+        [newerReal],
+        [tied]
+      ])
+    ).toEqual([other, other, other, newerReal, newerReal])
+  })
+
   it('retains non-Codex and non-rollout occurrences unchanged', () => {
     const claude = session({ agent: 'claude' })
     const otherFile = session({ filePath: '/tmp/session.jsonl' })

--- a/src/main/ai-vault/codex-session-collection.test.ts
+++ b/src/main/ai-vault/codex-session-collection.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { CodexSessionCollection, dedupeCodexSessionsBySessionId } from './codex-session-root-dedup'
+import { createAccumulator, finalizeSession } from './session-scanner-accumulator'
+
+function session(overrides: Partial<AiVaultSession> = {}): AiVaultSession {
+  const parsed = finalizeSession(
+    createAccumulator({
+      agent: 'codex',
+      sessionId: 'session',
+      file: {
+        path: '/home/ada/.codex/rollout-session.jsonl',
+        mtimeMs: 1000,
+        modifiedAt: '1970-01-01T00:00:01.000Z'
+      }
+    }),
+    'linux'
+  )
+  if (!parsed) {
+    throw new Error('Expected a session fixture')
+  }
+  return Object.freeze({ ...parsed, ...overrides })
+}
+
+function checkBatches(batches: AiVaultSession[][]): AiVaultSession[] {
+  const collection = new CodexSessionCollection()
+  let expected: AiVaultSession[] = []
+  for (const batch of batches) {
+    expected = dedupeCodexSessionsBySessionId([...expected, ...batch])
+    for (const value of batch) {
+      collection.add(value)
+    }
+    const actual = [...collection.values()]
+    expect(collection.size).toBe(expected.length)
+    expect(actual).toHaveLength(expected.length)
+    actual.forEach((value, index) => expect(value).toBe(expected[index]))
+  }
+  return [...collection.values()]
+}
+
+describe('CodexSessionCollection', () => {
+  it('keeps winner occurrences in input order across replacements and batches', () => {
+    const other = session({ agent: 'claude' })
+    const real = session()
+    const managed = session({ codexHome: '/tmp/codex-runtime-home/home' })
+    const custom = session({ codexHome: '/tmp/custom' })
+    expect(
+      checkBatches([
+        [custom, other, custom],
+        [managed, other, managed],
+        [custom],
+        [real, other, real]
+      ])
+    ).toEqual([other, other, real, other, real])
+  })
+
+  it('keeps identical winning objects, not distinct tied objects', () => {
+    const first = session()
+    const tied = session()
+    expect(
+      checkBatches([
+        [first, tied, first],
+        [tied, first]
+      ])
+    ).toEqual([first, first, first])
+  })
+
+  it('retains non-Codex and non-rollout occurrences unchanged', () => {
+    const claude = session({ agent: 'claude' })
+    const otherFile = session({ filePath: '/tmp/session.jsonl' })
+    expect(
+      checkBatches([
+        [claude, otherFile],
+        [claude, otherFile]
+      ])
+    ).toEqual([claude, otherFile, claude, otherFile])
+  })
+
+  it('preserves timestamp, root, path tie-breaks and invalid-date comparisons', () => {
+    const older = session({ updatedAt: '1970-01-01T00:00:00Z' })
+    const newer = session({ updatedAt: '1970-01-01T00:00:03Z' })
+    const smallerPath = session({ ...newer, filePath: '/a/rollout-session.jsonl' })
+    const invalid = session({ modifiedAt: 'invalid' })
+    const account = session({ codexHome: '/tmp/codex-accounts/account/home' })
+    const custom = session({ codexHome: '/tmp/custom' })
+    expect(checkBatches([[custom], [account], [older], [newer], [smallerPath]])).toEqual([
+      smallerPath
+    ])
+    expect(
+      checkBatches([
+        [invalid, older],
+        [newer, smallerPath]
+      ])
+    ).toEqual([invalid])
+    expect(checkBatches([[older], [invalid], [newer]])).toEqual([newer])
+  })
+
+  it('isolates execution hosts, WSL distros, parsed ids and rollout names', () => {
+    const native = session()
+    const ssh = session({ executionHostId: 'ssh:dev' })
+    const ubuntu = session({ filePath: '\\\\wsl$\\Ubuntu\\home\\ada\\rollout-session.jsonl' })
+    const ubuntuAlias = session({
+      filePath: '\\\\wsl.localhost\\ubuntu\\home\\ada\\rollout-session.jsonl',
+      codexHome: '/custom'
+    })
+    const debian = session({ filePath: '\\\\wsl$\\Debian\\home\\ada\\rollout-session.jsonl' })
+    const otherId = session({ sessionId: 'other' })
+    const otherName = session({ filePath: '/tmp/rollout-other.jsonl' })
+    expect(
+      checkBatches([
+        [native, ssh, ubuntu],
+        [ubuntuAlias, debian, otherId, otherName]
+      ])
+    ).toEqual([native, ssh, ubuntu, debian, otherId, otherName])
+  })
+
+  it('does not rescan retained rows on admission', () => {
+    let pathReads = 0
+    const collection = new CodexSessionCollection()
+    for (let index = 0; index < 1000; index++) {
+      const value = session({ sessionId: `session-${index}` })
+      collection.add({
+        ...value,
+        get filePath() {
+          pathReads++
+          return value.filePath
+        }
+      })
+    }
+    expect(collection.size).toBe(1000)
+    expect([...collection.values()]).toHaveLength(1000)
+    expect(pathReads).toBeLessThanOrEqual(2000)
+  })
+})

--- a/src/main/ai-vault/codex-session-root-dedup.ts
+++ b/src/main/ai-vault/codex-session-root-dedup.ts
@@ -255,7 +255,10 @@ export function dedupeCodexSessionsBySessionId(
 /** Scan-local accumulation; parsed rows must not be mutated after admission. */
 export class CodexSessionCollection {
   private readonly sessions = new Map<number, AiVaultSession>()
-  private readonly bestByKey = new Map<string, { session: AiVaultSession; indices: number[] }>()
+  private readonly bestByKey = new Map<
+    string,
+    { session: AiVaultSession; indices: number | number[] }
+  >()
   private nextIndex = 0
 
   get size(): number {
@@ -273,17 +276,25 @@ export class CodexSessionCollection {
       const best = this.bestByKey.get(key)
       if (best?.session === session) {
         // The batch filter retains every occurrence of the winning object.
-        best.indices.push(index)
+        if (typeof best.indices === 'number') {
+          best.indices = [best.indices, index]
+        } else {
+          best.indices.push(index)
+        }
       } else {
         if (best) {
           if (!codexSessionAliasBeats(session, best.session)) {
             return
           }
-          for (const previousIndex of best.indices) {
-            this.sessions.delete(previousIndex)
+          if (typeof best.indices === 'number') {
+            this.sessions.delete(best.indices)
+          } else {
+            for (const previousIndex of best.indices) {
+              this.sessions.delete(previousIndex)
+            }
           }
         }
-        this.bestByKey.set(key, { session, indices: [index] })
+        this.bestByKey.set(key, { session, indices: index })
       }
     }
     this.sessions.set(index, session)

--- a/src/main/ai-vault/codex-session-root-dedup.ts
+++ b/src/main/ai-vault/codex-session-root-dedup.ts
@@ -252,6 +252,44 @@ export function dedupeCodexSessionsBySessionId(
   })
 }
 
+/** Scan-local accumulation; parsed rows must not be mutated after admission. */
+export class CodexSessionCollection {
+  private readonly sessions = new Map<number, AiVaultSession>()
+  private readonly bestByKey = new Map<string, { session: AiVaultSession; indices: number[] }>()
+  private nextIndex = 0
+
+  get size(): number {
+    return this.sessions.size
+  }
+
+  values(): IterableIterator<AiVaultSession> {
+    return this.sessions.values()
+  }
+
+  add(session: AiVaultSession): void {
+    const key = codexSessionAliasKey(session)
+    const index = this.nextIndex++
+    if (key) {
+      const best = this.bestByKey.get(key)
+      if (best?.session === session) {
+        // The batch filter retains every occurrence of the winning object.
+        best.indices.push(index)
+      } else {
+        if (best) {
+          if (!codexSessionAliasBeats(session, best.session)) {
+            return
+          }
+          for (const previousIndex of best.indices) {
+            this.sessions.delete(previousIndex)
+          }
+        }
+        this.bestByKey.set(key, { session, indices: [index] })
+      }
+    }
+    this.sessions.set(index, session)
+  }
+}
+
 function codexSessionAliasKey(session: AiVaultSession): string | null {
   if (session.agent !== 'codex') {
     return null

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -8,6 +8,7 @@ import type { ExecutionHostId } from '../../shared/execution-host'
 import { setImmediate as yieldToEventLoop } from 'node:timers/promises'
 import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
 import {
+  CodexSessionCollection,
   codexRolloutHardlinkIdentity,
   dedupeCodexRolloutFileAliases,
   dedupeCodexSessionsBySessionId
@@ -139,7 +140,7 @@ async function parseRemoteSessionCandidates(args: {
   issues: AiVaultScanIssue[]
   limit: number
 }): Promise<{ sessions: AiVaultSession[]; parsedFilePaths: Set<string> }> {
-  const sessions: AiVaultSession[] = []
+  const sessions = new CodexSessionCollection()
   const parsedFilePaths = new Set<string>()
   let index = 0
 
@@ -149,7 +150,7 @@ async function parseRemoteSessionCandidates(args: {
     }
 
     const remaining = args.candidates.length - index
-    const needed = Math.max(args.limit - sessions.length, 1)
+    const needed = Math.max(args.limit - sessions.size, 1)
     const batchSize = Math.min(REMOTE_SCAN_CONCURRENCY, needed, remaining)
     const batch = args.candidates.slice(index, index + batchSize)
     for (const candidate of batch) {
@@ -159,9 +160,11 @@ async function parseRemoteSessionCandidates(args: {
     const results = await Promise.all(
       batch.map((candidate) => parseRemoteSessionCandidate(candidate, args.context, args.issues))
     )
-    sessions.push(...results.filter(isAiVaultSession))
-    const uniqueSessions = dedupeCodexSessionsBySessionId(sessions)
-    sessions.splice(0, sessions.length, ...uniqueSessions)
+    for (const session of results) {
+      if (session) {
+        sessions.add(session)
+      }
+    }
     index += batchSize
     await yieldToEventLoop()
   }
@@ -169,7 +172,7 @@ async function parseRemoteSessionCandidates(args: {
   // The loop can terminate on the yield after its final batch, so re-check
   // rather than letting a cancelled scan return a partial parse as a success.
   throwIfAiVaultScanCancelled(args.context.signal)
-  return { sessions, parsedFilePaths }
+  return { sessions: [...sessions.values()], parsedFilePaths }
 }
 
 async function scanRemoteInScopeSessions(args: {
@@ -309,15 +312,14 @@ function normalizeRemoteScopePaths(scopePaths: readonly string[]): string[] {
 }
 
 function canStopParsingRemoteSessions(
-  sessions: AiVaultSession[],
+  sessions: CodexSessionCollection,
   limit: number,
   nextCandidateMtimeMs: number | undefined
 ): boolean {
-  if (sessions.length < limit || typeof nextCandidateMtimeMs !== 'number') {
+  if (sessions.size < limit || typeof nextCandidateMtimeMs !== 'number') {
     return false
   }
-  const visibleCutoff = sessions
-    .map(sessionSortTime)
+  const visibleCutoff = Array.from(sessions.values(), sessionSortTime)
     .sort((left, right) => right - left)
     .at(limit - 1)
 

--- a/src/main/ai-vault/session-scanner-dedup-batches.test.ts
+++ b/src/main/ai-vault/session-scanner-dedup-batches.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { scanRemoteAiVaultSessions } from './remote-session-scanner'
+import { MemoryRemoteProvider } from './remote-session-scanner-test-fixtures'
+import { scanAiVaultSessions } from './session-scanner'
+import { isolatedScanRoots, jsonLines } from './session-scanner-test-fixtures'
+
+const tempRoots: string[] = []
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('session scan batch deduplication', () => {
+  it.each(['native', 'remote'] as const)(
+    '%s does not rederive every retained rollout alias after each batch',
+    async (host) => {
+      const count = 128
+      const provider = new MemoryRemoteProvider()
+      const root = await mkdtemp(join(tmpdir(), 'orca-session-dedup-'))
+      tempRoots.push(root)
+      const roots = isolatedScanRoots(root)
+      await mkdir(roots.codexSessionsDir, { recursive: true })
+      for (let index = 0; index < count; index++) {
+        const name = `rollout-session-${index}.jsonl`
+        const content = jsonLines([
+          { type: 'session_meta', payload: { id: `session-${index}`, cwd: '/repo/folder' } },
+          { type: 'event_msg', payload: { type: 'user_message', message: 'Check this session' } }
+        ])
+        if (host === 'native') {
+          await writeFile(join(roots.codexSessionsDir, name), content)
+        } else {
+          provider.addFile(`/home/ada/.codex/sessions/${name}`, content, count - index)
+        }
+      }
+      let aliasChecks = 0
+      const originalTest = RegExp.prototype.test
+      vi.spyOn(RegExp.prototype, 'test').mockImplementation(function (this: RegExp, value) {
+        if (this.source === '^rollout-.+\\.jsonl$') {
+          aliasChecks++
+        }
+        return originalTest.call(this, value)
+      })
+      const scan = () =>
+        host === 'native'
+          ? scanAiVaultSessions({ ...roots, unlimited: true })
+          : scanRemoteAiVaultSessions({
+              provider,
+              remoteHome: '/home/ada',
+              hostPlatform: getRemoteHostPlatform('linux-x64'),
+              executionHostId: 'ssh:dedup-batches',
+              unlimited: true
+            })
+
+      for (let pass = 0; pass < 2; pass++) {
+        aliasChecks = 0
+        const result = await scan()
+        expect(result.issues).toEqual([])
+        expect(result.sessions).toHaveLength(count)
+        expect(new Set(result.sessions.map((session) => session.sessionId)).size).toBe(count)
+        expect(aliasChecks).toBeLessThanOrEqual(count * 8)
+      }
+    }
+  )
+
+  it('replaces aliases across remote batches without consuming the unique-session budget', async () => {
+    const provider = new MemoryRemoteProvider()
+    const managedHome = '/home/ada/.local/share/orca/codex-runtime-home/home'
+    const content = (id: string) =>
+      jsonLines([
+        { type: 'session_meta', payload: { id, cwd: '/repo/folder' } },
+        { type: 'event_msg', payload: { type: 'user_message', message: 'Session' } }
+      ])
+    for (let index = 0; index < 8; index++) {
+      const name = `rollout-${index}.jsonl`
+      provider.addFile(`/home/ada/.codex/sessions/${name}`, content(`${index}`), 1000 - index)
+      provider.addFile(`${managedHome}/sessions/${name}`, content(`${index}`), 500 - index)
+    }
+    provider.addFile('/home/ada/.codex/sessions/rollout-unique.jsonl', content('unique'), 100)
+    const tooOld = '/home/ada/.codex/sessions/rollout-too-old.jsonl'
+    provider.addFile(tooOld, content('too-old'), 50)
+    const reads = vi.spyOn(provider, 'readFile')
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64'),
+      executionHostId: 'ssh:batch-replacements',
+      limit: 9
+    })
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.sessionId)).toEqual([
+      '0',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      'unique'
+    ])
+    expect(result.sessions.slice(0, 8).every((session) => session.codexHome === managedHome)).toBe(
+      true
+    )
+    expect(reads).not.toHaveBeenCalledWith(tooOld)
+  })
+})

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -6,7 +6,7 @@ import type {
 import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../shared/execution-host'
 import { withSpan } from '../observability/tracer'
 import { sessionSortTime } from './session-scanner-accumulator'
-import { dedupeCodexSessionsBySessionId } from './codex-session-root-dedup'
+import { CodexSessionCollection, dedupeCodexSessionsBySessionId } from './codex-session-root-dedup'
 import {
   createAntigravityWorkspaceResolver,
   readLocalAntigravityHistory,
@@ -211,7 +211,7 @@ async function parseSessionCandidates(args: {
   signal?: AbortSignal
   antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
 }): Promise<AiVaultSession[]> {
-  const sessions: AiVaultSession[] = []
+  const sessions = new CodexSessionCollection()
   let index = 0
 
   while (index < args.candidates.length) {
@@ -221,7 +221,7 @@ async function parseSessionCandidates(args: {
     }
 
     const remaining = args.candidates.length - index
-    const needed = Math.max(args.limit - sessions.length, 1)
+    const needed = Math.max(args.limit - sessions.size, 1)
     const batchSize = Math.min(SESSION_PARSE_CONCURRENCY, needed, remaining)
     const batch = args.candidates.slice(index, index + batchSize)
     const results = await Promise.all(
@@ -241,14 +241,9 @@ async function parseSessionCandidates(args: {
         recordSessionScanIssue(args.issues, result.issue)
       }
       if (result.session) {
-        sessions.push(result.session)
+        sessions.add(result.session)
       }
     }
-
-    // Why: cross-volume backfill copies have no shared inode, so collapse
-    // parsed aliases before they can crowd the unique-session parse budget.
-    const uniqueSessions = dedupeCodexSessionsBySessionId(sessions)
-    sessions.splice(0, sessions.length, ...uniqueSessions)
 
     index += batchSize
   }
@@ -256,7 +251,7 @@ async function parseSessionCandidates(args: {
   // An abort can land while the final batch settles; observe it here so a
   // partial parse is never cached or returned as a complete scan.
   throwIfAiVaultScanCancelled(args.signal)
-  return sessions
+  return [...sessions.values()]
 }
 
 async function parseSessionCandidate(
@@ -303,15 +298,14 @@ function withSessionExecutionHost(
 }
 
 function canStopParsingSessions(
-  sessions: AiVaultSession[],
+  sessions: CodexSessionCollection,
   limit: number,
   nextCandidateMtimeMs: number | undefined
 ): boolean {
-  if (sessions.length < limit || typeof nextCandidateMtimeMs !== 'number') {
+  if (sessions.size < limit || typeof nextCandidateMtimeMs !== 'number') {
     return false
   }
-  const visibleCutoff = sessions
-    .map(sessionSortTime)
+  const visibleCutoff = Array.from(sessions.values(), sessionSortTime)
     .sort((left, right) => right - left)
     .at(limit - 1)
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​269 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​269 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​257 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​233 |

<!-- /orca-pr-loc -->

## Summary

Local and SSH session scanners currently deduplicate the entire accumulated result after every batch of eight parsed files. Use a scan-local collection to admit each parsed row once, reusing the existing alias-key and canonical-root comparison functions. The standalone batch deduplicator remains unchanged.

An insertion-ordered map preserves surviving row order; replacements delete prior winning occurrences instead of moving another row into their position. Identical-object duplicates, distinct tied objects, invalid dates, canonical root/time/path preferences, native/WSL namespaces, execution-host isolation, unique-session parse budgets, cancellation and remote event-loop yields retain their existing behavior. Parsed sessions and title refreshes are replaced/cloned, not mutated after admission.

No new persisted cache, wire fields, execution ownership, agent status, workspace assumptions, or provider-specific behavior. Independent performance improvement 9; tracks #20206.

## Measurement

The benchmark bundles the unchanged production batch deduplicator and the new collection, exercising the scanners' eight-row accumulation policy. Eight counterbalanced pairs, Node v26.6.0/macOS arm64, after all local tests and typechecks finished. Median milliseconds:

| Workload | Before | After |
| --- | ---: | ---: |
| 100 unique Codex sessions | 0.422 | 0.033 |
| 1,000 unique Codex sessions | 36.7 | 0.331 |
| 5,000 unique Codex sessions | 933 | 1.79 |
| 10,000 unique Codex sessions | 3,735 | 3.70 |
| 1,000 Claude sessions | 0.558 | 0.018 |
| 1,000 sessions followed by preferred-root aliases | 102.7 | 0.742 |
| 1,000 sessions followed by losing-root aliases | 106.3 | 0.664 |
| 5,000 sessions followed by preferred-root aliases | 2,729 | 4.08 |
| 5,000 sessions followed by losing-root aliases | 3,237 | 4.33 |

Synthetic deduplication CPU only: no disk/network, parser, final sorting or app-wide latency claim. Eight-row Claude batches change from 0.132 to 0.181 microseconds; ordinary 100+ row workloads improve. The collection retains O(surviving rows) scan-local indexing metadata, releases losing session objects, and becomes unreachable when the scan returns its array. Forced-GC retained heap growth while holding the index was about 221 KiB for 1,000 unique rows and 2.70 MiB for 10,000; this is not a peak-RSS measurement.

```sh
ORCA_BACKGROUND_LAUNCH=1 node --expose-gc config/scripts/session-dedup-batches-benchmark.mjs
```

## Verification

- All 880 AI Vault tests pass across 112 files.
- 40,000 seeded differential batches compare count, ordering and object identities against the unchanged batch deduplicator, including same-reference duplicates and frozen inputs.
- Real native/remote cold and warm scanner operation tests: baseline fails with 2,688/2,560 rollout checks for 128 files; the new version satisfies the linear bound of 1,024 checks.
- Cross-batch SSH test verifies eight later preferred aliases do not consume the unique-session budget and older candidates still early-stop.
- `pnpm tc:node` and changed-code quality gate pass.
- All tests use `ORCA_BACKGROUND_LAUNCH=1`; no app windows launched. Actual OS validation is macOS; SSH tests use an in-memory provider, with Windows/WSL paths covered by unit/differential tests.

## Visual Proof

N/A — session contents, ordering and UI behavior are unchanged.

## Independent review follow-up

Commit `7fd3aae222178e993d3598e7d406bb5e9984bd81` reduces the scan-local index's memory cost. A unique winning session stores one numeric occurrence index; an array is allocated only when the identical winning object occurs repeatedly. Winner selection, insertion order, duplicate-object handling, host/WSL isolation, cancellation and scan budgets are unchanged.

Eight-pair forced-GC measurements with the same pre-created input rows held constant, comparing the original PR head with the applied fix:

| Unique Codex rows | Original PR index | Fixed index |
| --- | ---: | ---: |
| 1,000 | 217,080 bytes | 161,080 bytes |
| 10,000 | 2,517,576 bytes | 1,957,688 bytes |
| 100,000 | 23,345,808 bytes | 17,746,296 bytes |

That removes approximately 56 bytes per ordinary unique row (22–26% in these fixtures). This is retained collection overhead, not peak RSS; the necessary O(surviving rows) temporary index remains a real trade-off.

Fresh verification: 608 tests across 88 AI Vault files; an additional alternating single/repeated-winner regression; 40,000 unchanged-batch-oracle cases; another 40,000 original-PR-vs-fix batches; Node typecheck, changed-code gate and commit hooks all pass. All checks use `ORCA_BACKGROUND_LAUNCH=1`; no app/native windows launched.

The dependent #20301 branch also includes this mitigation. Merge this PR first, then retarget/revalidate #20301 against main. No PR has been merged by this review.

