### PR TITLE
perf: compile nested repository ignore patterns once

### DIFF
--- a/src/main/project-groups/nested-repo-scan-rules.test.ts
+++ b/src/main/project-groups/nested-repo-scan-rules.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isIgnoredNestedRepoDirectory,
+  readNestedRepoGitignoreRules
+} from './nested-repo-scan-rules'
+
+async function readRules(content: string, baseSegments: string[] = []) {
+  return readNestedRepoGitignoreRules({
+    folderPath: '/workspace',
+    entries: [{ name: '.gitignore', isDirectory: false }],
+    baseSegments,
+    filesystem: {
+      readDirectory: async () => [],
+      readTextFile: async () => content,
+      joinPath: (parent, child) => `${parent}/${child}`,
+      basename: (path) => path.split('/').at(-1) ?? '',
+      hasGitMarker: () => false,
+      isSelectedPathGitRepo: () => false
+    }
+  })
+}
+
+describe('nested repository ignore rules', () => {
+  it.each([
+    ['cache*', ['parent', 'cache-data', 'child'], true],
+    ['cache*\n!cache-keep', ['parent', 'cache-keep'], false],
+    ['/cache*', ['parent', 'cache-data'], false],
+    ['/cache*', ['cache-data'], true],
+    ['packages/*/output?', ['packages', 'app', 'output1'], true],
+    ['packages/*/output?', ['packages', 'app', 'nested', 'output1'], false],
+    ['packages/**/output?', ['packages', 'output1'], true],
+    ['packages/**/output?', ['packages', 'app', 'nested', 'output1'], true],
+    ['**', ['anything', 'child'], true],
+    ['/**', ['anything', 'child'], true],
+    ['**\n!**', ['anything', 'child'], false],
+    ['[literal]+.*', ['[literal]+.suffix'], true],
+    ['[literal]+.*', ['literal-suffix'], false]
+  ])('matches %s against %j', async (content, segments, expected) => {
+    const rules = await readRules(content)
+    for (let repeat = 0; repeat < 3; repeat++) {
+      expect(isIgnoredNestedRepoDirectory(segments.at(-1)!, segments, rules)).toBe(expected)
+    }
+  })
+
+  it('scopes inherited anchored patterns to the directory that declared them', async () => {
+    const rules = await readRules('/cache*', ['parent'])
+    expect(isIgnoredNestedRepoDirectory('cache-data', ['parent', 'cache-data'], rules)).toBe(true)
+    expect(
+      isIgnoredNestedRepoDirectory('cache-data', ['parent', 'child', 'cache-data'], rules)
+    ).toBe(false)
+    expect(isIgnoredNestedRepoDirectory('parent', ['parent'], rules)).toBe(false)
+  })
+})

--- a/src/main/project-groups/nested-repo-scan-rules.ts
+++ b/src/main/project-groups/nested-repo-scan-rules.ts
@@ -17,6 +17,7 @@ export type NestedRepoScanFilesystem = {
 
 type IgnoreRule = {
   pattern: string
+  segmentPatterns: (string | RegExp)[]
   negate: boolean
   basenameOnly: boolean
   baseSegments: string[]
@@ -82,16 +83,22 @@ function shouldSkipDirectory(name: string, depth: number): boolean {
   return depth > 0 && name.startsWith('.')
 }
 
-function globSegmentMatches(pattern: string, value: string): boolean {
+function compileGlobSegment(pattern: string): string | RegExp {
   if (!pattern.includes('*') && !pattern.includes('?')) {
-    return pattern === value
+    return pattern
   }
   const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
-  const regex = new RegExp(`^${escaped.replace(/\*/g, '[^/]*').replace(/\?/g, '[^/]')}$`)
-  return regex.test(value)
+  return new RegExp(`^${escaped.replace(/\*/g, '[^/]*').replace(/\?/g, '[^/]')}$`)
 }
 
-function pathSegmentsMatch(patternSegments: string[], candidateSegments: string[]): boolean {
+function globSegmentMatches(pattern: string | RegExp, value: string): boolean {
+  return typeof pattern === 'string' ? pattern === value : pattern.test(value)
+}
+
+function pathSegmentsMatch(
+  patternSegments: (string | RegExp)[],
+  candidateSegments: string[]
+): boolean {
   const matchFrom = (patternIndex: number, candidateIndex: number): boolean => {
     if (patternIndex >= patternSegments.length) {
       return candidateIndex >= candidateSegments.length
@@ -122,10 +129,16 @@ function parseGitignoreRules(content: string, baseSegments: string[]): IgnoreRul
       const unprefixed = negate ? line.slice(1) : line
       const anchored = unprefixed.startsWith('/')
       const pattern = unprefixed.replace(/^\/+/, '').replace(/\/+$/, '')
+      const basenameOnly = !anchored && !pattern.includes('/')
       return {
         pattern,
+        segmentPatterns: basenameOnly
+          ? [compileGlobSegment(pattern)]
+          : pattern
+              .split('/')
+              .map((segment) => (segment === '**' ? segment : compileGlobSegment(segment))),
         negate,
-        basenameOnly: !anchored && !pattern.includes('/'),
+        basenameOnly,
         baseSegments
       }
     })
@@ -143,10 +156,9 @@ export function isIgnoredNestedRepoDirectory(
       continue
     }
     const relativeSegments = segments.slice(rule.baseSegments.length)
-    const patternSegments = rule.pattern.split('/')
     const matches = rule.basenameOnly
-      ? relativeSegments.some((segment) => globSegmentMatches(rule.pattern, segment))
-      : pathSegmentsMatch(patternSegments, relativeSegments)
+      ? relativeSegments.some((segment) => globSegmentMatches(rule.segmentPatterns[0], segment))
+      : pathSegmentsMatch(rule.segmentPatterns, relativeSegments)
     if (matches) {
       ignored = !rule.negate
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

Nested repository discovery prepares each ignore pattern once instead of rebuilding it for every folder it visits.

## What Changed

Store compiled segment patterns alongside each parsed ignore rule. Literal segments retain string equality; wildcard segments reuse a non-global RegExp. Path `**` retains its recursive matching behavior, while basename `**` still uses ordinary segment matching. Rule order, negation, anchoring and inherited base directories are unchanged.

## Why

Windows Node benchmark of the exported rule parser and matcher, including parsing once per scan, with 43 mixed ignore rules. Median of 20 measured batches after 5 warmups, alternating before/after order:

| Directories | Before | After |
| --- | ---: | ---: |
| 1 | 0.0487 ms | 0.0222 ms |
| 32 | 1.4594 ms | 0.0786 ms |
| 10,000 | 613.68 ms | 26.49 ms |

These are synthetic CPU-processing measurements on Windows, excluding filesystem and Git latency; they are not end-to-end scan latency claims. Compiled patterns live only as long as their parsed rules, with no filesystem freshness cache.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — no visual or interaction change.

## Testing

- 30 tests passed, 1 skipped across nested-repository discovery and rule tests on Windows.
- 50,000 generated original-versus-modified matcher comparisons matched.
- Added coverage for wildcard segments, literal regex punctuation, negation order, repeated use, basename versus path `**`, and inherited anchored rules.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

Scan traversal, limits, abort checks and filesystem-provider routing are unchanged. The same pure matcher serves folder scans without assumptions about Git worktrees, SSH ownership or Windows/WSL path separators. No wire format changes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Typecheck, relevant tests, lint and formatting passed.
