### PR TITLE
perf(plugins): stop collection traversal at message size limit

### DIFF
--- a/config/scripts/plugin-message-budget-benchmark.mjs
+++ b/config/scripts/plugin-message-budget-benchmark.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const baseline = process.argv[2] ?? '20ab9950654'
+const file = 'src/shared/plugins/plugin-panel-message-budget.ts'
+async function load(contents) {
+  const result = await build({
+    stdin: { contents, loader: 'ts', resolveDir: dirname(resolve(file)) },
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false
+  })
+  return import(
+    `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+  )
+}
+const before = await load(
+  execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8' })
+)
+const after = await load(readFileSync(file, 'utf8'))
+const results = []
+for (const count of [5, 1000, 100000]) {
+  const entries = Array.from({ length: count }, (_, i) => [`key-${i}`, `value-${i}`])
+  for (const [kind, value] of [
+    ['array', entries.map(([, value]) => value)],
+    ['map', new Map(entries)],
+    ['set', new Set(entries.map(([, value]) => value))],
+    ['object', Object.fromEntries(entries)]
+  ]) {
+    const input = structuredClone(value)
+    for (const cap of [0, 1, 64, 1024, 65536, Infinity]) {
+      assert.equal(
+        after.structuredCloneMessageBytes(input, cap),
+        before.structuredCloneMessageBytes(input, cap)
+      )
+    }
+    const arms = { before, after }
+    const iterations = count < 100 ? 1000 : 10
+    const run = (arm) => {
+      global.gc?.()
+      const start = performance.now()
+      const cpuStart = process.cpuUsage()
+      for (let i = 0; i < iterations; i++) {
+        arms[arm].structuredCloneMessageBytes(input)
+      }
+      const cpu = process.cpuUsage(cpuStart)
+      return {
+        ms: (performance.now() - start) / iterations,
+        cpuMs: (cpu.user + cpu.system) / 1000 / iterations
+      }
+    }
+    for (let i = 0; i < 3; i++) {
+      run('before')
+      run('after')
+    }
+    const samples = { before: [], after: [] }
+    for (const pair of buildCounterbalancedSchedule(10, 'before', 'after')) {
+      for (const arm of pair) {
+        samples[arm].push(run(arm))
+      }
+    }
+    const median = (values) => {
+      const sorted = [...values].sort((a, b) => a - b)
+      return (sorted[4] + sorted[5]) / 2
+    }
+    results.push({
+      count,
+      kind,
+      beforeMs: median(samples.before.map((sample) => sample.ms)),
+      beforeCpuMs: median(samples.before.map((sample) => sample.cpuMs)),
+      afterMs: median(samples.after.map((sample) => sample.ms)),
+      afterCpuMs: median(samples.after.map((sample) => sample.cpuMs)),
+      samples
+    })
+  }
+}
+console.log(
+  JSON.stringify(
+    {
+      baseline,
+      node: process.version,
+      platform: process.platform,
+      forcedGc: Boolean(global.gc),
+      results
+    },
+    null,
+    2
+  )
+)

--- a/src/shared/plugins/plugin-panel-message-budget-traversal.test.ts
+++ b/src/shared/plugins/plugin-panel-message-budget-traversal.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { structuredCloneMessageBytes } from './plugin-panel-message-budget'
+
+const factories: [string, () => Iterable<unknown>][] = [
+  ['array', () => Array.from({ length: 10_000 }, (_, i) => `value-${i}`)],
+  ['set', () => new Set(Array.from({ length: 10_000 }, (_, i) => `value-${i}`))],
+  ['map', () => new Map(Array.from({ length: 10_000 }, (_, i) => [`key-${i}`, i]))]
+]
+
+describe('plugin message budget traversal', () => {
+  it.each(factories)('stops consuming an oversized %s', (_name, create) => {
+    const value = create()
+    const iterate = value[Symbol.iterator].bind(value)
+    let visits = 0
+    value[Symbol.iterator] = function* () {
+      for (const entry of { [Symbol.iterator]: iterate }) {
+        visits++
+        yield entry
+      }
+    }
+    expect(structuredCloneMessageBytes(value, 64)).toBe(65)
+    expect(visits).toBeLessThan(10)
+  })
+
+  it('stops reading object values after an earlier property exceeds the budget', () => {
+    const value: Record<string, unknown> = { first: 'x'.repeat(1000) }
+    let reads = 0
+    for (let i = 0; i < 1000; i++) {
+      Object.defineProperty(value, `tail-${i}`, {
+        enumerable: true,
+        get: () => {
+          reads++
+          return i
+        }
+      })
+    }
+    expect(structuredCloneMessageBytes(value, 64)).toBe(65)
+    expect(reads).toBe(0)
+  })
+
+  it.each([
+    ['array', [1, 2], 32],
+    ['set', new Set([1, 2]), 32],
+    [
+      'map',
+      new Map([
+        ['a', 1],
+        ['b', 2]
+      ]),
+      34
+    ],
+    ['object', { a: 1, b: 2 }, 26]
+  ] as const)(
+    'preserves the exact %s estimate at both sides of the boundary',
+    (_name, value, bytes) => {
+      expect(structuredCloneMessageBytes(value, bytes - 1)).toBe(bytes)
+      expect(structuredCloneMessageBytes(value, bytes)).toBe(bytes)
+      expect(structuredCloneMessageBytes(value, bytes + 1)).toBe(bytes)
+    }
+  )
+
+  it('unwinds all enclosing collections after a nested value exceeds the cap', () => {
+    let reads = 0
+    const value = [new Map([['nested', new Set(['x'.repeat(1000)])]])]
+    Object.defineProperty(value, 1, {
+      get: () => {
+        reads++
+        return 1
+      }
+    })
+    expect(structuredCloneMessageBytes(value, 64)).toBe(65)
+    expect(reads).toBe(0)
+  })
+})

--- a/src/shared/plugins/plugin-panel-message-budget.ts
+++ b/src/shared/plugins/plugin-panel-message-budget.ts
@@ -159,6 +159,9 @@ export function structuredCloneMessageBytes(
         add(4)
         visit(key, depth + 1)
         visit(entry, depth + 1)
+        if (total > stopAfter) {
+          return
+        }
       }
       return
     }
@@ -167,6 +170,9 @@ export function structuredCloneMessageBytes(
       for (const entry of object) {
         add(4)
         visit(entry, depth + 1)
+        if (total > stopAfter) {
+          return
+        }
       }
       return
     }
@@ -175,6 +181,9 @@ export function structuredCloneMessageBytes(
       for (const entry of object) {
         add(4)
         visit(entry, depth + 1)
+        if (total > stopAfter) {
+          return
+        }
       }
       return
     }
@@ -188,6 +197,9 @@ export function structuredCloneMessageBytes(
         add(4)
         add(utf8Bytes(key, stopAfter - total))
         visit((object as Record<string, unknown>)[key], depth + 1)
+        if (total > stopAfter) {
+          return
+        }
       }
     } catch {
       total = stopAfter + 1


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​107 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​107 |

<!-- /orca-pr-loc -->

## ELI5

Stop measuring a plugin message as soon as it is already too large.

The plugin message-size estimator stops visiting nested values after exceeding its cap, but its parent array/Map/Set/object loops continue consuming the entire remainder. Oversized panel messages can therefore keep the renderer or runtime admission path busy after rejection is already decided. Return from each collection loop as soon as the existing capped total exceeds the limit.

The estimator keeps the same byte counts, exact-boundary handling, and rejection decisions. Message-rate charging, the reserved pong lane, and RPC content remain unchanged. Plain objects still enumerate their own keys with `Object.keys`; this change skips unnecessary value reads and encoding after that enumeration.

Evidence:

- Regression: a 10,000-entry array/Map/Set at a 64-byte cap consumes fewer than 10 entries instead of all 10,000. A first oversized object property prevents all 1,000 remaining value reads. These assertions fail on baseline.
- Before/after parity for structured-cloned arrays, Maps, Sets, and objects at six caps, including infinity; exact boundary and nested-unwinding tests.
- Counterbalanced Node 24/macOS benchmark, forced GC outside each sample: process CPU time for 100,000 entries falls from 5.270 → 2.258 ms (Map), 4.091 → 2.046 ms (Set), 3.973 → 1.959 ms (array), and 18.132 → 12.633 ms (object). Below-limit 1,000-entry Map/Set CPU samples are within 3%; array/object improve. Wall-clock samples were noisy on the shared machine, so these are CPU measurements, not UI latency claims.

Reproduce: `ORCA_BACKGROUND_LAUNCH=1 node --expose-gc config/scripts/plugin-message-budget-benchmark.mjs` (raw wall and CPU samples included in output).

Validation: 29 focused estimator, admission, and renderer bridge tests pass; `pnpm tc:node`, `pnpm tc:web`, lint, and formatting pass.
