### PR TITLE
fix(ai-vault): re-read a transcript rewritten to its previous size

### DIFF
--- a/src/main/ai-vault/session-parse-cache-store.ts
+++ b/src/main/ai-vault/session-parse-cache-store.ts
@@ -9,6 +9,8 @@ const MAX_CACHE_ENTRIES = 4096
 
 export type SessionParseResumePoint = {
   state: ResumableSessionParseState
+  mtimeMs: number
+  sizeBytes: number | undefined
   // Byte offset just past the last complete ('\n'-terminated) line consumed;
   // a trailing unterminated line is deliberately left before this point.
   byteOffset: number

--- a/src/main/ai-vault/session-transcript-consumers.test.ts
+++ b/src/main/ai-vault/session-transcript-consumers.test.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, rm, stat, truncate, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, expect, it, vi } from 'vitest'
@@ -170,6 +170,8 @@ it('replays only the appended lines on a resumed read', async () => {
   expect(firstRead?.outcome?.incomplete).toBe(false)
 
   await appendFile(transcript, `${jsonLines(claudeTurns(5, 5))}\n`)
+  const changedAt = new Date(firstRead!.start.candidate.file.mtimeMs + 2000)
+  await utimes(transcript, changedAt, changedAt)
   consumer.reads.length = 0
   await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
 
@@ -182,6 +184,38 @@ it('replays only the appended lines on a resumed read', async () => {
     'tool:Bash: ls 5'
   ])
 })
+
+it.each(['rewrite', 'truncate then regrow'])(
+  're-reads a same-size %s from zero',
+  async (operation) => {
+    const { transcript } = await writeClaudeFixture()
+    const before = await claudeCandidate(transcript)
+    await parseAgentSessionFileCached(before, 'darwin')
+    const consumer = recordingConsumer()
+    const rewritten = `${jsonLines(claudeTurns(1, 4))}\n`.replace('reply 4', 'fresh 4')
+    expect(Buffer.byteLength(rewritten)).toBe(before.file.sizeBytes)
+
+    if (operation === 'truncate then regrow') {
+      await truncate(transcript, 0)
+      await appendFile(transcript, rewritten)
+    } else {
+      await writeFile(transcript, rewritten)
+    }
+    const changedAt = new Date(before.file.mtimeMs + 2000)
+    await utimes(transcript, changedAt, changedAt)
+    const session = await parseAgentSessionFileCached(await claudeCandidate(transcript), 'darwin')
+
+    expect(consumer.reads).toHaveLength(1)
+    expect(consumer.reads[0].start.mode).toBe('replace')
+    expect(consumer.reads[0].start.previousByteOffset).toBe(0)
+    expect(textsFor(consumer.reads, 'claude')).toContain('assistant:fresh 4')
+    expect(textsFor(consumer.reads, 'claude')).not.toContain('assistant:reply 4')
+    resetSessionParseCacheForTests()
+    expect(session).toEqual(
+      await parseAgentSessionFileCached(await claudeCandidate(transcript), 'darwin')
+    )
+  }
+)
 
 it('publishes a trailing unterminated line once, when it is complete', async () => {
   const { roots, transcript } = await writeClaudeFixture()

--- a/src/main/ai-vault/session-transcript-reader.ts
+++ b/src/main/ai-vault/session-transcript-reader.ts
@@ -68,6 +68,9 @@ export async function readResumableTranscript(args: {
     resume !== null &&
     typeof file.sizeBytes === 'number' &&
     file.sizeBytes >= resume.byteOffset &&
+    file.mtimeMs >= resume.mtimeMs &&
+    // A changed timestamp without growth signals a rewrite, even at a valid line boundary.
+    (file.mtimeMs === resume.mtimeMs || file.sizeBytes > (resume.sizeBytes ?? resume.byteOffset)) &&
     (resume.byteOffset === 0 || (await endsWithNewlineAt(file.path, resume.byteOffset)))
 
   // Clone before consuming: a failed read must not corrupt the cached state,
@@ -127,7 +130,13 @@ export async function readResumableTranscript(args: {
     channel.finishRead({ session, byteOffset: readResult.consumedThrough, incomplete: false })
     return {
       session,
-      resume: { state, byteOffset: readResult.consumedThrough, channel }
+      resume: {
+        state,
+        byteOffset: readResult.consumedThrough,
+        mtimeMs: file.mtimeMs,
+        sizeBytes: file.sizeBytes,
+        channel
+      }
     }
   } catch (error) {
     channel.finishRead({ session: null, byteOffset: startOffset, incomplete: true })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

If a transcript is replaced with different text of exactly the same length, Orca now reads the new text instead of keeping the old sidebar preview and search content.

## What Changed

Record the observed mtime and file size in the in-memory resume point. Resume only when mtime has not moved backward and the existing size/newline checks pass; a changed mtime also requires growth beyond the previously observed size. Recording file size separately from the consumed offset covers unfinished final lines.

## Why

A same-size rewrite can leave the old cursor at EOF immediately after a newline. The old guard accepted that cursor and published an empty append. Checking only `mtime >= previous mtime` would still accept a newer same-size rewrite, so growth is required when mtime changes. Normal appends retain incremental parsing.

## Linked Issue

N/A: standalone fix requested in the supplied reader bug brief; no issue number supplied.

## Visual Proof

N/A: reader logic

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

On macOS, using only temporary synthetic transcripts and `ORCA_BACKGROUND_LAUNCH=1`:

- Before the fix, both new same-size regression cases failed: expected `replace`, received `append`.
- After the fix, same-size rewrite and truncate-then-regrow start at byte zero, publish the replacement text, and match a fresh sidebar parse.
- The existing append test now explicitly advances mtime and still verifies resuming at the previous byte offset.
- `pnpm tc`
- `pnpm test src/main/ai-vault`
- `pnpm run check:code-quality:changed`
- `pnpm run check:react-doctor:changed`

## AI Disclosure

## Review

Self-reviewed the resume guard, cache producer, native/WSL stat discovery, and separate SSH parse cache.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Native and WSL reader candidates already require mtime; no missing-mtime fallback is needed. SSH uses a separate mtime/size cache and reparses changed transcripts. Resume points are in-memory only, so there is no persisted or remote wire format change. Folder workspaces and git worktrees use the same reader.

As before, a rewrite preserving both mtime and size cannot be detected by these stats, and a growing rewrite retaining the old newline boundary can resemble an append. Linux, Windows, WSL, and SSH were not exercised live.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Local checks are the four scoped gates above; CI covers full lint, the remaining tests, and build.
