### PR TITLE
perf: reuse pending filesystem watcher debounce timers

### DIFF
--- a/src/main/ipc/filesystem-watcher-local-events.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-events.test.ts
@@ -91,7 +91,7 @@ describe('local filesystem watcher flush serialization', () => {
     expect(root.batch.timer).toBeNull()
   })
 
-  it('can schedule a late event after an error clears the pending timer', async () => {
+  it('discards queued and late events after a terminal watcher error', async () => {
     const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {})
     try {
       const root = await createLocalWatcher('/repo', '/repo')
@@ -102,7 +102,35 @@ describe('local filesystem watcher flush serialization', () => {
       watcherCallback?.(null, [{ type: 'delete', path: '/repo/file.ts' }])
       vi.advanceTimersByTime(WATCH_BATCH_TRAILING_MS)
       await flushMicrotasks()
-      expect(sender.send).toHaveBeenCalledTimes(2)
+      expect(sender.send).toHaveBeenCalledTimes(1)
+      expect(root.batch.cancelled).toBe(true)
+      expect(root.batch.events).toEqual([])
+      expect(root.batch.timer).toBeNull()
+    } finally {
+      errorLog.mockRestore()
+    }
+  })
+
+  it('suppresses an inflight batch and its queued drain after a terminal watcher error', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const pendingStat = deferred<{ isDirectory: () => boolean }>()
+    statMock.mockReturnValueOnce(pendingStat.promise)
+    try {
+      const root = await createLocalWatcher('/repo', '/repo')
+      root.listeners.set(1, sender as never)
+      watcherCallback?.(null, [{ type: 'update', path: '/repo/first.ts' }])
+      vi.advanceTimersByTime(WATCH_BATCH_TRAILING_MS)
+      await flushMicrotasks()
+      expect(statMock).toHaveBeenCalledTimes(1)
+      watcherCallback?.(null, [{ type: 'update', path: '/repo/queued.ts' }])
+      watcherCallback?.(new Error('watcher interrupted'), [])
+      pendingStat.resolve({ isDirectory: () => false })
+      vi.advanceTimersByTime(WATCH_BATCH_MAX_WAIT_MS)
+      await flushMicrotasks()
+      expect(sender.send).toHaveBeenCalledTimes(1)
+      expect(statMock).toHaveBeenCalledTimes(1)
+      expect(root.batch.events).toEqual([])
+      expect(root.batch.timer).toBeNull()
     } finally {
       errorLog.mockRestore()
     }

--- a/src/main/ipc/filesystem-watcher-local-events.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-events.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Event as WatcherEvent } from '@parcel/watcher'
 import type { FsChangedPayload } from '../../shared/filesystem-entry-types'
-import { WATCH_BATCH_TRAILING_MS } from '../../shared/filesystem-watch-batch-window'
+import {
+  WATCH_BATCH_MAX_WAIT_MS,
+  WATCH_BATCH_TRAILING_MS
+} from '../../shared/filesystem-watch-batch-window'
 
 const { statMock, subscribeMock } = vi.hoisted(() => ({
   statMock: vi.fn(),
@@ -44,6 +47,65 @@ describe('local filesystem watcher flush serialization', () => {
       watcherCallback = callback
       return { unsubscribe: vi.fn() }
     })
+  })
+
+  it('extends the trailing window from the latest batch', async () => {
+    const root = await createLocalWatcher('/repo', '/repo')
+    root.listeners.set(1, sender as never)
+    watcherCallback?.(null, [{ type: 'delete', path: '/repo/file.ts' }])
+    vi.advanceTimersByTime(100)
+    watcherCallback?.(null, [{ type: 'delete', path: '/repo/file.ts' }])
+    vi.advanceTimersByTime(WATCH_BATCH_TRAILING_MS - 1)
+    await flushMicrotasks()
+    expect(sender.send).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    await flushMicrotasks()
+    expect(sender.send).toHaveBeenCalledTimes(1)
+    expect(root.batch.timer).toBeNull()
+  })
+
+  it('flushes sustained batches at the maximum wait', async () => {
+    const root = await createLocalWatcher('/repo', '/repo')
+    root.listeners.set(1, sender as never)
+    watcherCallback?.(null, [{ type: 'delete', path: '/repo/file.ts' }])
+    for (let elapsed = 100; elapsed <= WATCH_BATCH_MAX_WAIT_MS; elapsed += 100) {
+      vi.advanceTimersByTime(100)
+      expect(sender.send).not.toHaveBeenCalled()
+      watcherCallback?.(null, [{ type: 'delete', path: '/repo/file.ts' }])
+    }
+    await flushMicrotasks()
+    expect(sender.send).toHaveBeenCalledTimes(1)
+    expect(root.batch.timer).toBeNull()
+  })
+
+  it('cancels a refreshed trailing window without a later flush', async () => {
+    const root = await createLocalWatcher('/repo', '/repo')
+    root.listeners.set(1, sender as never)
+    watcherCallback?.(null, [{ type: 'delete', path: '/repo/file.ts' }])
+    vi.advanceTimersByTime(100)
+    watcherCallback?.(null, [{ type: 'delete', path: '/repo/file.ts' }])
+    cancelLocalBatchFlush(root)
+    vi.advanceTimersByTime(WATCH_BATCH_MAX_WAIT_MS)
+    await flushMicrotasks()
+    expect(sender.send).not.toHaveBeenCalled()
+    expect(root.batch.timer).toBeNull()
+  })
+
+  it('can schedule a late event after an error clears the pending timer', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const root = await createLocalWatcher('/repo', '/repo')
+      root.listeners.set(1, sender as never)
+      watcherCallback?.(null, [{ type: 'delete', path: '/repo/file.ts' }])
+      watcherCallback?.(new Error('watcher interrupted'), [])
+      expect(sender.send).toHaveBeenCalledTimes(1)
+      watcherCallback?.(null, [{ type: 'delete', path: '/repo/file.ts' }])
+      vi.advanceTimersByTime(WATCH_BATCH_TRAILING_MS)
+      await flushMicrotasks()
+      expect(sender.send).toHaveBeenCalledTimes(2)
+    } finally {
+      errorLog.mockRestore()
+    }
   })
 
   it('serializes an inflight flush and drains one follow-up without overlap', async () => {

--- a/src/main/ipc/filesystem-watcher-local-events.ts
+++ b/src/main/ipc/filesystem-watcher-local-events.ts
@@ -210,7 +210,8 @@ export function scheduleLocalBatchFlush(root: WatchedRoot): void {
 
   // Trailing-edge debounce: reset timer on each new event
   if (root.batch.timer) {
-    clearTimeout(root.batch.timer)
+    root.batch.timer.refresh()
+    return
   }
   // Why: clear the handle as it fires so `batch.timer` means "a debounce window is still open", which gates the queued drain.
   root.batch.timer = setTimeout(() => {
@@ -259,6 +260,7 @@ export async function createLocalWatcher(
           // Why: after an error the native subscription may be invalid (deleted root); tear down the dead watcher so it doesn't dangle (§7.3).
           if (root.batch.timer) {
             clearTimeout(root.batch.timer)
+            root.batch.timer = null
           }
           // Why: error callback can fire before subscribe() assigns root.subscription; guard against null so cleanup doesn't crash.
           if (root.subscription) {

--- a/src/main/ipc/filesystem-watcher-local-events.ts
+++ b/src/main/ipc/filesystem-watcher-local-events.ts
@@ -16,7 +16,7 @@ import {
   retainLocalWatcherPhysicalFailure,
   trackDetachedLocalUnsubscribe
 } from './filesystem-watcher-listener-lifecycle'
-import { createDebouncedBatch } from './filesystem-watcher-batch-control'
+import { cancelLocalBatchFlush, createDebouncedBatch } from './filesystem-watcher-batch-control'
 import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 
 // Why: matches the watcher subprocess budget in parcel-watcher-event-delivery.ts.
@@ -258,10 +258,7 @@ export async function createLocalWatcher(
           console.error(`[filesystem-watcher] error for ${rootKey}:`, err)
           emitOverflowPayload(root)
           // Why: after an error the native subscription may be invalid (deleted root); tear down the dead watcher so it doesn't dangle (§7.3).
-          if (root.batch.timer) {
-            clearTimeout(root.batch.timer)
-            root.batch.timer = null
-          }
+          cancelLocalBatchFlush(root)
           // Why: error callback can fire before subscribe() assigns root.subscription; guard against null so cleanup doesn't crash.
           if (root.subscription) {
             retainLocalWatcherPhysicalFailure(rootKey, err)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Filesystem watcher bursts reuse one pending timer. If the watcher fails, its leftover work is discarded so stale events cannot arrive after the failure notice.

## What Changed

Refresh the existing Node timeout when extending the trailing window. The 150 ms trailing delay, 500 ms maximum wait, cancellation and flush serialization remain unchanged. Clear the timer reference on watcher errors so a late event can create a new timer after the old one was cancelled.

## Why

Windows Node benchmark using the actual scheduler function, real Node timers and a fixed event timestamp to isolate burst scheduling. Median of 20 measured batches after 5 warmups, alternating original/modified order:

| Incoming batches in one burst | Before | After | Timer allocations |
| --- | ---: | ---: | ---: |
| 1,000 | 0.367 ms | 0.133 ms | 1,000 → 1 |
| 100,000 | 30.18 ms | 11.54 ms | 100,000 → 1 |

These synthetic measurements isolate scheduling overhead; they exclude filesystem work and do not claim reduced debounce latency.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — no visual or interaction change.

## Testing

- Four added tests pass: trailing deadline, maximum wait, cancellation and scheduling after an error clears the timer.
- Six existing large-batch and event-batch tests pass.
- The unsubscribe suite has 17 passing and seven failing tests on Windows. All seven failures reproduce with the original implementation: path expectations and lifecycle timeouts.
- The existing local-events suite has two passing and four failing tests on Windows path expectations; all four failures also reproduce with the original implementation. The four added tests pass independently.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

No event filtering, freshness, concurrency, IPC payload or execution-host routing changes. Timer reuse stays in Node main-process watcher code. Folder workspaces and Windows/WSL watcher callers retain their existing batching policy.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant validation complete; baseline failures documented.


## Review follow-up

Terminal watcher errors now call the existing cancelLocalBatchFlush cleanup. The overflow notification still tells subscribers to rescan; queued, late and in-flight events from the torn-down watcher are suppressed. This closes a race where clearing the timer reference could let a queued flush drain after an error.

Two regression tests fail against the original PR error handler and pass with the fix. Five focused debounce/error tests, Node typecheck, lint and formatting passed. Existing Windows slash-assertion failures in unrelated cases remain baseline limitations and are not counted as passing tests.

