### PR TITLE
perf: load Hermes run logs only when selected

### DIFF
--- a/config/scripts/hermes-history-payload-benchmark.mjs
+++ b/config/scripts/hermes-history-payload-benchmark.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { build } from 'esbuild'
+
+const root = fileURLToPath(new URL('../..', import.meta.url))
+const fixture = await mkdtemp(join(tmpdir(), 'orca-hermes-payload-'))
+const previousHome = process.env.HERMES_HOME
+try {
+  process.env.HERMES_HOME = fixture
+  const bundle = join(fixture, 'benchmark.cjs')
+  await build({
+    stdin: {
+      contents: `export { HermesRunHistory } from './src/relay/hermes-run-history'; export { prepareJsonRpcPayload } from './src/relay/protocol';`,
+      resolveDir: root
+    },
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    outfile: bundle
+  })
+  const { HermesRunHistory, prepareJsonRpcPayload } = createRequire(import.meta.url)(bundle)
+  const outputDir = join(fixture, 'cron', 'output', 'job-1')
+  await mkdir(outputDir, { recursive: true })
+  const logPath = join(fixture, 'run.log')
+  await writeFile(logPath, 'x'.repeat(5 * 1024 * 1024))
+  for (let day = 1; day <= 25; day++) {
+    await writeFile(
+      join(outputDir, `2026-09-${String(day).padStart(2, '0')}_09-00-00.md`),
+      `# Cron Job: benchmark\n## Response\nLatest log path: ${logPath}\nRun summary: completed\n`
+    )
+  }
+  for (const pageSize of [1, 4, 8, 25]) {
+    const history = new HermesRunHistory()
+    const start = performance.now()
+    const result = await history.listRuns({ provider: 'hermes', jobId: 'job-1', pageSize })
+    const listMs = performance.now() - start
+    assert.equal(result.runs.length, pageSize)
+    const encodedStart = performance.now()
+    const bytes = Buffer.byteLength(JSON.stringify({ jsonrpc: '2.0', id: 1, result }))
+    const stringifyMs = performance.now() - encodedStart
+    let transportError = null
+    try {
+      prepareJsonRpcPayload({ jsonrpc: '2.0', id: 1, result })
+    } catch (error) {
+      transportError = error.message
+    }
+    assert.equal(transportError !== null, pageSize >= 4)
+    const summaryStart = performance.now()
+    const summaryResult = await history.listRuns({
+      provider: 'hermes',
+      jobId: 'job-1',
+      pageSize,
+      summaryOnly: true
+    })
+    const summaryMs = performance.now() - summaryStart
+    assert.equal(summaryResult.runs.length, pageSize)
+    assert.ok(
+      summaryResult.runs.every((run) => run.output_content === null && run.output_content_deferred)
+    )
+    const summaryPayload = prepareJsonRpcPayload({ jsonrpc: '2.0', id: 1, result: summaryResult })
+    const detail = await history.listRuns({
+      provider: 'hermes',
+      jobId: 'job-1',
+      runId: summaryResult.runs[0].id
+    })
+    assert.deepEqual(detail.runs, [result.runs[0]])
+    prepareJsonRpcPayload({ jsonrpc: '2.0', id: 1, result: detail })
+    console.log(
+      JSON.stringify({
+        pageSize,
+        bytes,
+        listMs,
+        stringifyMs,
+        transportError,
+        summaryMs,
+        summaryBytes: summaryPayload.byteLength
+      })
+    )
+  }
+} finally {
+  if (previousHome === undefined) {
+    delete process.env.HERMES_HOME
+  } else {
+    process.env.HERMES_HOME = previousHome
+  }
+  await rm(fixture, { recursive: true, force: true })
+}

--- a/src/main/automations/external-job-mappers.ts
+++ b/src/main/automations/external-job-mappers.ts
@@ -79,6 +79,7 @@ function mapExternalRuns({
         runAt,
         status: asExternalRunStatus(run.status),
         outputPreview: asString(run.output_preview) ?? asString(run.outputPreview),
+        ...(run.output_content_deferred === true ? { outputContentDeferred: true as const } : {}),
         outputContent: asString(run.output_content) ?? asString(run.outputContent),
         error: asString(run.error),
         outputPath: asString(run.output_path) ?? asString(run.outputPath)

--- a/src/main/automations/external-manager-run-history.test.ts
+++ b/src/main/automations/external-manager-run-history.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import { listExternalAutomationRuns } from './external-manager-runs'
+import { getActiveMultiplexer } from '../ssh/ssh-target-registry'
+import type { ExternalAutomationRunsInput } from '../../shared/automations-types'
+
+vi.mock('../ssh/ssh-target-registry', () => ({ getActiveMultiplexer: vi.fn() }))
+const input: ExternalAutomationRunsInput = {
+  managerId: 'hermes:ssh:box',
+  provider: 'hermes',
+  target: { type: 'ssh', connectionId: 'box' },
+  jobId: 'job-1',
+  page: 1,
+  pageSize: 8,
+  summaryOnly: true
+}
+afterEach(() => vi.resetAllMocks())
+
+function relay(request: ReturnType<typeof vi.fn>) {
+  vi.mocked(getActiveMultiplexer).mockReturnValue({ request, isDisposed: () => false } as never)
+}
+
+it('preserves full output when an older relay declines the opt-in method', async () => {
+  const request = vi
+    .fn()
+    .mockRejectedValueOnce({ code: -32601 })
+    .mockResolvedValueOnce({
+      total: 1,
+      runs: [{ id: 'run-1', output_content: 'legacy full log' }]
+    })
+  relay(request)
+  const result = await listExternalAutomationRuns(input)
+  expect(request.mock.calls.map(([method]) => method)).toEqual([
+    'externalAutomations.runHistory',
+    'externalAutomations.runs'
+  ])
+  expect(result.runs[0]).toMatchObject({ outputContent: 'legacy full log' })
+  expect(result.runs[0].outputContentDeferred).toBeUndefined()
+})
+
+it('does not retry transport failures or turn unsupported detail into a different run', async () => {
+  const request = vi.fn().mockRejectedValue(new Error('connection lost'))
+  relay(request)
+  await expect(listExternalAutomationRuns(input)).rejects.toThrow('connection lost')
+  expect(request).toHaveBeenCalledTimes(1)
+  request.mockReset().mockRejectedValue({ code: -32601 })
+  await expect(
+    listExternalAutomationRuns({ ...input, summaryOnly: false, runId: 'run-1' })
+  ).rejects.toThrow()
+  expect(request).toHaveBeenCalledTimes(1)
+})
+
+it('maps summary state only when explicitly supplied by the host', async () => {
+  const request = vi.fn().mockResolvedValue({
+    total: 1,
+    runs: [{ id: 'run-1', output_content: null, output_content_deferred: true }]
+  })
+  relay(request)
+  const result = await listExternalAutomationRuns(input)
+  expect(result.runs[0]).toMatchObject({ outputContent: null, outputContentDeferred: true })
+  expect(request).toHaveBeenCalledWith(
+    'externalAutomations.runHistory',
+    expect.objectContaining({ summaryOnly: true })
+  )
+})

--- a/src/main/automations/external-manager-runs.ts
+++ b/src/main/automations/external-manager-runs.ts
@@ -26,11 +26,21 @@ import { readHermesCronOutputRunsPage } from './hermes-cron-output'
  */
 async function requestRemoteExternalRuns(
   connectionId: string,
-  params: { provider: ExternalAutomationProvider; jobId: string; page: number; pageSize: number }
+  params: {
+    provider: ExternalAutomationProvider
+    jobId: string
+    page: number
+    pageSize: number
+    summaryOnly?: boolean
+    runId?: string
+  }
 ): Promise<{ total?: number; runs?: unknown[] }> {
   try {
+    // Old relays ignore optional flags, so negotiate projection through a distinct method.
     return (await requireExternalAutomationMultiplexer(connectionId).request(
-      'externalAutomations.runs',
+      params.summaryOnly || params.runId !== undefined
+        ? 'externalAutomations.runHistory'
+        : 'externalAutomations.runs',
       params
     )) as {
       total?: number
@@ -38,6 +48,9 @@ async function requestRemoteExternalRuns(
     }
   } catch (error) {
     if (isRelayMethodNotFoundError(error)) {
+      if (params.summaryOnly && params.runId === undefined) {
+        return requestRemoteExternalRuns(connectionId, { ...params, summaryOnly: false })
+      }
       throw new ExternalAutomationScopeError(EXTERNAL_AUTOMATION_SCOPE_CODES.runsUnsupported)
     }
     throw error
@@ -65,12 +78,19 @@ export async function listExternalAutomationRuns(
   }
   const result =
     input.target.type === 'local'
-      ? await readHermesCronOutputRunsPage(input.jobId, { page, pageSize })
+      ? await readHermesCronOutputRunsPage(input.jobId, {
+          page,
+          pageSize,
+          summaryOnly: input.summaryOnly,
+          runId: input.runId
+        })
       : await requestRemoteExternalRuns(input.target.connectionId, {
           provider: input.provider,
           jobId: input.jobId,
           page,
-          pageSize
+          pageSize,
+          summaryOnly: input.summaryOnly,
+          runId: input.runId
         })
   return {
     ...identity,

--- a/src/main/automations/external-manager.ts
+++ b/src/main/automations/external-manager.ts
@@ -102,7 +102,9 @@ export function createScopedExternalAutomations(
         target: scope.target,
         jobId: request.jobId,
         page: request.page,
-        pageSize: request.pageSize
+        pageSize: request.pageSize,
+        summaryOnly: request.summaryOnly,
+        runId: request.runId
       })
     },
     async create(request) {

--- a/src/main/automations/hermes-cron-output.test.ts
+++ b/src/main/automations/hermes-cron-output.test.ts
@@ -1,3 +1,4 @@
+import type * as FsPromises from 'node:fs/promises'
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -10,6 +11,18 @@ const fakeDbRows = vi.hoisted(() => ({
   sessions: [] as Record<string, unknown>[],
   messages: [] as Record<string, unknown>[]
 }))
+const readFileSpy = vi.hoisted(() => vi.fn())
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromises>()
+  return {
+    ...actual,
+    readFile: (...args: Parameters<typeof actual.readFile>) => {
+      readFileSpy(...args)
+      return actual.readFile(...args)
+    }
+  }
+})
+
 const fakePrepareSqls = vi.hoisted(() => [] as string[])
 const fakeDatabase = vi.hoisted(() =>
   vi.fn(function FakeDatabase() {
@@ -118,8 +131,33 @@ Run summary: monitor automation completed successfully.
     ]
 
     const { readHermesCronOutputRunsPage } = await loadReader()
+    readFileSpy.mockClear()
+    const summary = await readHermesCronOutputRunsPage('job-1', {
+      page: 1,
+      pageSize: 25,
+      summaryOnly: true
+    })
+    expect(summary.runs).toHaveLength(1)
+    expect(summary.runs[0]).toMatchObject({ output_content: null, output_content_deferred: true })
+    expect(readFileSpy.mock.calls.some(([filename]) => filename === scriptLogPath)).toBe(false)
+    expect(fakePrepareSqls.some((sql) => sql.includes('FROM messages'))).toBe(false)
     const page = await readHermesCronOutputRunsPage('job-1', { page: 1, pageSize: 25 })
 
+    const detail = await readHermesCronOutputRunsPage('job-1', {
+      page: 1,
+      pageSize: 1,
+      runId: 'job-1:2026-05-15_09-02-00.md'
+    })
+    expect(detail.runs).toEqual(page.runs)
+    expect(
+      (
+        await readHermesCronOutputRunsPage('other-job', {
+          page: 1,
+          pageSize: 1,
+          runId: 'job-1:2026-05-15_09-02-00.md'
+        })
+      ).runs
+    ).toEqual([])
     expect(page.total).toBe(1)
     expect(page.runs[0]).toMatchObject({
       id: 'job-1:2026-05-15_09-02-00.md',

--- a/src/main/automations/hermes-cron-output.ts
+++ b/src/main/automations/hermes-cron-output.ts
@@ -92,10 +92,16 @@ async function readHermesCronOutputRunCount(jobId: string): Promise<number> {
   })
 }
 
-async function hydrateHermesRunRef(jobId: string, ref: HermesMergedRunRef): Promise<unknown> {
-  const outputRun = ref.output ? await readHermesOutputFileRun(ref.output) : null
-  const sessionRun = ref.session ? readHermesSessionDbRunById(jobId, ref.session.id) : null
-  return (
+async function hydrateHermesRunRef(
+  jobId: string,
+  ref: HermesMergedRunRef,
+  summaryOnly = false
+): Promise<unknown> {
+  const outputRun = ref.output ? await readHermesOutputFileRun(ref.output, summaryOnly) : null
+  const sessionRun = ref.session
+    ? readHermesSessionDbRunById(jobId, ref.session.id, summaryOnly)
+    : null
+  const run =
     mergeHermesOutputAndSessionRuns(
       outputRun ? [outputRun] : [],
       sessionRun ? [sessionRun] : []
@@ -103,17 +109,23 @@ async function hydrateHermesRunRef(jobId: string, ref: HermesMergedRunRef): Prom
     outputRun ??
     sessionRun ??
     ref
-  )
+  return summaryOnly && typeof run === 'object' && run !== null
+    ? { ...run, output_content: null, output_content_deferred: true }
+    : run
 }
 
 export async function readHermesCronOutputRunsPage(
   jobId: string,
   {
     page,
-    pageSize
+    pageSize,
+    summaryOnly = false,
+    runId
   }: {
     page: number
     pageSize: number
+    summaryOnly?: boolean
+    runId?: string
   }
 ): Promise<HermesCronOutputRunsPage> {
   if (!EXTERNAL_JOB_ID_PATTERN.test(jobId)) {
@@ -128,10 +140,13 @@ export async function readHermesCronOutputRunsPage(
   }
   const runRefs = await readHermesCronOutputRunRefs(jobId)
   const start = (safePage - 1) * safePageSize
-  const pageRefs = runRefs.slice(start, start + safePageSize)
+  const pageRefs =
+    runId !== undefined
+      ? runRefs.filter((ref) => ref.id === runId)
+      : runRefs.slice(start, start + safePageSize)
   return {
     total: runRefs.length,
-    runs: await Promise.all(pageRefs.map((ref) => hydrateHermesRunRef(jobId, ref)))
+    runs: await Promise.all(pageRefs.map((ref) => hydrateHermesRunRef(jobId, ref, summaryOnly)))
   }
 }
 
@@ -168,11 +183,14 @@ async function readHermesOutputFileRunRefs(jobId: string): Promise<HermesOutputR
     }))
 }
 
-async function readHermesOutputFileRun(ref: HermesOutputRunRef): Promise<unknown> {
+async function readHermesOutputFileRun(
+  ref: HermesOutputRunRef,
+  summaryOnly = false
+): Promise<unknown> {
   try {
     const content = await readFile(ref.output_path, 'utf-8')
     const parsed = parseHermesOutput(content)
-    const outputContent = await appendReferencedLogFile(parsed.outputContent)
+    const outputContent = summaryOnly ? null : await appendReferencedLogFile(parsed.outputContent)
     return {
       id: ref.id,
       job_id: ref.job_id,
@@ -233,7 +251,7 @@ function readHermesSessionDbRunRefs(jobId: string): HermesSessionRunRef[] {
   }
 }
 
-function readHermesSessionDbRunById(jobId: string, runId: string): unknown {
+function readHermesSessionDbRunById(jobId: string, runId: string, summaryOnly = false): unknown {
   if (!existsSync(HERMES_STATE_DB)) {
     return null
   }
@@ -251,14 +269,16 @@ function readHermesSessionDbRunById(jobId: string, runId: string): unknown {
       if (!row) {
         return null
       }
-      const messages = db
-        .prepare(
-          `SELECT role, content, tool_name, reasoning, reasoning_content
+      const messages = summaryOnly
+        ? []
+        : (db
+            .prepare(
+              `SELECT role, content, tool_name, reasoning, reasoning_content
                FROM messages
               WHERE session_id = ?
               ORDER BY timestamp, id`
-        )
-        .all(runId) as Record<string, unknown>[]
+            )
+            .all(runId) as Record<string, unknown>[])
       const title = typeof row.title === 'string' && row.title.trim() ? row.title.trim() : null
       const model = typeof row.model === 'string' && row.model.trim() ? row.model.trim() : null
       const messageCount = typeof row.message_count === 'number' ? row.message_count : null

--- a/src/relay/external-automations-handler.test.ts
+++ b/src/relay/external-automations-handler.test.ts
@@ -33,9 +33,10 @@ beforeEach(() => {
 })
 
 describe('ExternalAutomationsHandler', () => {
-  it('preserves the five external automation routes', () => {
+  it('preserves legacy routes and registers opt-in run history', () => {
     expect([...createHandlerHarness().keys()]).toEqual([
       'externalAutomations.list',
+      'externalAutomations.runHistory',
       'externalAutomations.runs',
       'externalAutomations.create',
       'externalAutomations.update',

--- a/src/relay/external-automations-handler.ts
+++ b/src/relay/external-automations-handler.ts
@@ -31,6 +31,9 @@ export class ExternalAutomationsHandler {
 
   constructor(dispatcher: RelayDispatcher) {
     dispatcher.onRequest('externalAutomations.list', (params) => this.providers.listJobs(params))
+    dispatcher.onRequest('externalAutomations.runHistory', (params) =>
+      this.runHistory.listRuns(params)
+    )
     dispatcher.onRequest('externalAutomations.runs', (params) => this.runHistory.listRuns(params))
     dispatcher.onRequest('externalAutomations.create', (params) => this.commands.createJob(params))
     dispatcher.onRequest('externalAutomations.update', (params) => this.commands.updateJob(params))

--- a/src/relay/hermes-output-run-files.ts
+++ b/src/relay/hermes-output-run-files.ts
@@ -160,11 +160,14 @@ export async function readHermesOutputFileRunRefs(jobId: string): Promise<Hermes
     }))
 }
 
-export async function readHermesOutputFileRun(ref: HermesOutputRunRef): Promise<unknown> {
+export async function readHermesOutputFileRun(
+  ref: HermesOutputRunRef,
+  summaryOnly = false
+): Promise<unknown> {
   try {
     const content = await readFile(ref.output_path, 'utf-8')
     const parsed = parseHermesOutput(content)
-    const outputContent = await appendReferencedLogFile(parsed.outputContent)
+    const outputContent = summaryOnly ? null : await appendReferencedLogFile(parsed.outputContent)
     return {
       id: ref.id,
       job_id: ref.job_id,

--- a/src/relay/hermes-run-history.test.ts
+++ b/src/relay/hermes-run-history.test.ts
@@ -136,3 +136,30 @@ describe('HermesRunHistory', () => {
     expect(readOutputRefs).toHaveBeenCalledTimes(202)
   })
 })
+
+it('loads summaries without hydrating logs and resolves selected IDs within the job refs', async () => {
+  const readOutputRun = vi.fn(async (ref: HermesOutputRunRef, summaryOnly?: boolean) => ({
+    ...ref,
+    output_content: summaryOnly ? null : 'full log'
+  }))
+  const history = new HermesRunHistory(
+    sources({ readOutputRefs: async () => [outputRef(16), outputRef(15)], readOutputRun })
+  )
+  const summary = await history.listRuns({ provider: 'hermes', jobId: 'job-1', summaryOnly: true })
+  expect(summary.runs).toHaveLength(2)
+  expect(summary.runs[0]).toMatchObject({ output_content: null, output_content_deferred: true })
+  expect(readOutputRun).toHaveBeenCalledWith(outputRef(16), true)
+  readOutputRun.mockClear()
+  const detail = await history.listRuns({
+    provider: 'hermes',
+    jobId: 'job-1',
+    runId: outputRef(15).id
+  })
+  expect(detail.runs).toEqual([{ ...outputRef(15), output_content: 'full log' }])
+  expect(readOutputRun).toHaveBeenCalledTimes(1)
+  readOutputRun.mockClear()
+  expect(
+    (await history.listRuns({ provider: 'hermes', jobId: 'job-1', runId: '../other' })).runs
+  ).toEqual([])
+  expect(readOutputRun).not.toHaveBeenCalled()
+})

--- a/src/relay/hermes-run-history.ts
+++ b/src/relay/hermes-run-history.ts
@@ -26,8 +26,8 @@ type HermesRunCountCacheEntry = {
 export type HermesRunHistorySources = {
   readOutputRefs: (jobId: string) => Promise<HermesOutputRunRef[]>
   readSessionRefs: (jobId: string) => HermesSessionRunRef[]
-  readOutputRun: (ref: HermesOutputRunRef) => Promise<unknown>
-  readSessionRun: (jobId: string, runId: string) => unknown
+  readOutputRun: (ref: HermesOutputRunRef, summaryOnly?: boolean) => Promise<unknown>
+  readSessionRun: (jobId: string, runId: string, summaryOnly?: boolean) => unknown
 }
 
 const DEFAULT_SOURCES: HermesRunHistorySources = {
@@ -84,7 +84,10 @@ export class HermesRunHistory {
     return {
       total: runRefs.length,
       runs: await Promise.all(
-        runRefs.slice(start, start + pageSize).map((ref) => this.hydrateRunRef(jobId, ref))
+        (typeof params.runId === 'string'
+          ? runRefs.filter((ref) => ref.id === params.runId)
+          : runRefs.slice(start, start + pageSize)
+        ).map((ref) => this.hydrateRunRef(jobId, ref, params.summaryOnly === true))
       )
     }
   }
@@ -111,10 +114,16 @@ export class HermesRunHistory {
     )
   }
 
-  private async hydrateRunRef(jobId: string, ref: HermesMergedRunRef): Promise<unknown> {
-    const outputRun = ref.output ? await this.sources.readOutputRun(ref.output) : null
-    const sessionRun = ref.session ? this.sources.readSessionRun(jobId, ref.session.id) : null
-    return (
+  private async hydrateRunRef(
+    jobId: string,
+    ref: HermesMergedRunRef,
+    summaryOnly = false
+  ): Promise<unknown> {
+    const outputRun = ref.output ? await this.sources.readOutputRun(ref.output, summaryOnly) : null
+    const sessionRun = ref.session
+      ? this.sources.readSessionRun(jobId, ref.session.id, summaryOnly)
+      : null
+    const run =
       mergeHermesOutputAndSessionRuns(
         outputRun ? [outputRun] : [],
         sessionRun ? [sessionRun] : []
@@ -122,7 +131,9 @@ export class HermesRunHistory {
       outputRun ??
       sessionRun ??
       ref
-    )
+    return summaryOnly && typeof run === 'object' && run !== null
+      ? { ...run, output_content: null, output_content_deferred: true }
+      : run
   }
 
   private async readRunCount(jobId: string): Promise<number> {

--- a/src/relay/hermes-session-run-database.ts
+++ b/src/relay/hermes-session-run-database.ts
@@ -143,7 +143,11 @@ export function readHermesSessionDbRunRefs(jobId: string): HermesSessionRunRef[]
   }
 }
 
-export function readHermesSessionDbRunById(jobId: string, runId: string): unknown {
+export function readHermesSessionDbRunById(
+  jobId: string,
+  runId: string,
+  summaryOnly = false
+): unknown {
   if (!existsSync(HERMES_STATE_DB)) {
     return null
   }
@@ -165,14 +169,16 @@ export function readHermesSessionDbRunById(jobId: string, runId: string): unknow
       if (!row) {
         return null
       }
-      const messages = db
-        .prepare(
-          `SELECT role, content, tool_name, reasoning, reasoning_content
+      const messages = summaryOnly
+        ? []
+        : (db
+            .prepare(
+              `SELECT role, content, tool_name, reasoning, reasoning_content
              FROM messages
             WHERE session_id = ?
             ORDER BY timestamp, id`
-        )
-        .all(runId) as Record<string, unknown>[]
+            )
+            .all(runId) as Record<string, unknown>[])
       const title = typeof row.title === 'string' && row.title.trim() ? row.title.trim() : null
       const model = typeof row.model === 'string' && row.model.trim() ? row.model.trim() : null
       const messageCount = typeof row.message_count === 'number' ? row.message_count : null

--- a/src/renderer/src/components/automations/AutomationsDetailPane.tsx
+++ b/src/renderer/src/components/automations/AutomationsDetailPane.tsx
@@ -12,7 +12,7 @@ import type {
 } from '../../../../shared/automations-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { AutomationDetail } from './AutomationDetail'
-import { HermesCronOutputView } from './HermesCronOutputView'
+import { ExternalAutomationRunOutput } from './ExternalAutomationRunOutput'
 import { AutomationRunPageFrame } from './AutomationRunPageFrame'
 import { AutomationRunHistory } from './AutomationRunHistory'
 import { ExternalAutomationManagers } from './ExternalAutomationManagers'
@@ -22,7 +22,6 @@ import type { ExternalAutomationScope } from './external-automation-scope-client
 import {
   formatExternalDate,
   getExternalProviderLabel,
-  getExternalRunContent,
   getExternalRunStatusLabel,
   getExternalRunStatusVariant
 } from './external-automation-display'
@@ -68,7 +67,8 @@ type AutomationsDetailPaneProps = {
   openExternalRunPage: (
     manager: ExternalAutomationManager,
     job: ExternalAutomationJob,
-    run: ExternalAutomationRun
+    run: ExternalAutomationRun,
+    scope: ExternalAutomationScope
   ) => void
   openEditExternalDialog: (
     manager: ExternalAutomationManager,
@@ -181,7 +181,7 @@ export function AutomationsDetailPane({
               statusVariant={getExternalRunStatusVariant(selectedExternalRunPage.run)}
               onBack={onClearExternalRunPage}
             >
-              <HermesCronOutputView content={getExternalRunContent(selectedExternalRunPage.run)} />
+              <ExternalAutomationRunOutput selected={selectedExternalRunPage} />
             </AutomationRunPageFrame>
           ) : (
             <ExternalAutomationManagers

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
@@ -47,7 +47,8 @@ type ExternalAutomationManagersProps = {
   onOpenRun?: (
     manager: ExternalAutomationManager,
     job: ExternalAutomationJob,
-    run: ExternalAutomationRun
+    run: ExternalAutomationRun,
+    scope: ExternalAutomationScope
   ) => void
   onEdit?: (
     manager: ExternalAutomationManager,
@@ -326,7 +327,7 @@ export function ExternalAutomationManagers({
                           job={job}
                           now={now}
                           onFetchRuns={onFetchRuns}
-                          onOpenRun={(run) => onOpenRun?.(manager, job, run)}
+                          onOpenRun={(run) => onOpenRun?.(manager, job, run, scope)}
                         />
                       </div>
                     ) : null}

--- a/src/renderer/src/components/automations/ExternalAutomationRunOutput.test.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationRunOutput.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { ExternalAutomationRunOutput } from './ExternalAutomationRunOutput'
+import { makeExternalManager, makeExternalAutomationScope } from './automations-page-fixtures'
+import type { SelectedExternalRunPage } from './automation-page-state'
+
+vi.mock('./HermesCronOutputView', () => ({
+  HermesCronOutputView: ({ content }: { content: string }) => <pre>{content}</pre>
+}))
+const request = vi.fn()
+let root: Root
+let container: HTMLDivElement
+function selection(id: string): SelectedExternalRunPage {
+  const manager = makeExternalManager()
+  return {
+    manager,
+    job: manager.jobs[0],
+    scope: makeExternalAutomationScope(),
+    run: {
+      id,
+      managerId: manager.id,
+      jobId: 'job-1',
+      provider: 'hermes',
+      runAt: null,
+      status: 'completed',
+      outputPreview: 'preview',
+      outputContent: null,
+      outputContentDeferred: true,
+      outputPath: null,
+      error: null
+    }
+  }
+}
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  request.mockReset()
+  vi.stubGlobal('api', undefined)
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { automations: { listExternalRunsForOwner: request } }
+  })
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+})
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+it('drops late responses after selecting a different run and carries the captured owner', async () => {
+  let finishOld!: (page: unknown) => void
+  let finishNew!: (page: unknown) => void
+  request
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishOld = resolve
+        })
+    )
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishNew = resolve
+        })
+    )
+  vi.useFakeTimers()
+  const old = selection('old')
+  const next = selection('next')
+  next.scope = makeExternalAutomationScope({
+    owner: {
+      authority: { kind: 'desktop' },
+      selector: { kind: 'ssh', targetId: 'box', targetGeneration: 3 }
+    }
+  })
+  await act(async () => root.render(<ExternalAutomationRunOutput selected={old} />))
+  await act(async () => vi.advanceTimersByTimeAsync(250))
+  expect(container.querySelector('[role="status"]')?.textContent).toContain('Loading run output')
+  await act(async () => root.render(<ExternalAutomationRunOutput selected={next} />))
+  expect(request).toHaveBeenLastCalledWith(
+    expect.objectContaining({ owner: next.scope.owner, runId: 'next', jobId: 'job-1' })
+  )
+  await act(async () =>
+    finishNew({
+      runs: [{ ...next.run, outputContentDeferred: undefined, outputContent: 'new log' }]
+    })
+  )
+  await act(async () =>
+    finishOld({
+      runs: [{ ...old.run, outputContentDeferred: undefined, outputContent: 'old log' }]
+    })
+  )
+  expect(container.textContent).toBe('new log')
+})
+
+it('renders old-host full content without a detail fetch', async () => {
+  const selected = selection('legacy')
+  delete selected.run.outputContentDeferred
+  selected.run.outputContent = 'legacy log'
+  await act(async () => root.render(<ExternalAutomationRunOutput selected={selected} />))
+  expect(container.textContent).toBe('legacy log')
+  expect(request).not.toHaveBeenCalled()
+})
+
+it('shows a persistent error with retry when the selected output disappeared', async () => {
+  request.mockResolvedValueOnce({ runs: [] }).mockResolvedValueOnce({
+    runs: [
+      { ...selection('run').run, outputContentDeferred: undefined, outputContent: 'restored log' }
+    ]
+  })
+  await act(async () => root.render(<ExternalAutomationRunOutput selected={selection('run')} />))
+  expect(container.querySelector('[role="alert"]')?.textContent).toContain('unavailable')
+  await act(async () => container.querySelector('button')!.click())
+  expect(container.textContent).toBe('restored log')
+})

--- a/src/renderer/src/components/automations/ExternalAutomationRunOutput.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationRunOutput.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import type { ExternalAutomationRun } from '../../../../shared/automations-types'
+import type { SelectedExternalRunPage } from './automation-page-state'
+import { externalAutomationRunKey } from './external-automation-scope-keys'
+import { getExternalRunContent } from './external-automation-display'
+import { HermesCronOutputView } from './HermesCronOutputView'
+
+export function ExternalAutomationRunOutput({ selected }: { selected: SelectedExternalRunPage }) {
+  return selected.run.outputContentDeferred ? (
+    <DeferredRunOutput
+      key={externalAutomationRunKey(selected.scope, selected.job.id, selected.run.id)}
+      selected={selected}
+    />
+  ) : (
+    <HermesCronOutputView content={getExternalRunContent(selected.run)} />
+  )
+}
+
+function DeferredRunOutput({ selected }: { selected: SelectedExternalRunPage }) {
+  const [result, setResult] = useState<ExternalAutomationRun | Error | null>(null)
+  const [attempt, setAttempt] = useState(0)
+  const [showLoading, setShowLoading] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    const timer = setTimeout(() => setShowLoading(true), 200)
+    void window.api.automations
+      .listExternalRunsForOwner({
+        ...selected.scope,
+        jobId: selected.job.id,
+        runId: selected.run.id,
+        page: 1,
+        pageSize: 1
+      })
+      .then((page) => {
+        if (cancelled) {
+          return
+        }
+        const run = page.runs.find((candidate) => candidate.id === selected.run.id)
+        setResult(run && !run.outputContentDeferred ? run : new Error('Run output is unavailable.'))
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setResult(error instanceof Error ? error : new Error(String(error)))
+        }
+      })
+      .finally(() => clearTimeout(timer))
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [selected, attempt])
+
+  if (result instanceof Error) {
+    return (
+      <div className="space-y-2 p-4 text-sm">
+        <p role="alert" className="text-destructive">
+          {result.message}
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setResult(null)
+            setShowLoading(false)
+            setAttempt((value) => value + 1)
+          }}
+        >
+          {translate('common.retry', 'Retry')}
+        </Button>
+      </div>
+    )
+  }
+  if (result) {
+    return <HermesCronOutputView content={getExternalRunContent(result)} />
+  }
+  return showLoading ? (
+    <div role="status" className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+      <Loader2 className="size-4 animate-spin" />
+      {translate('automations.runOutput.loading', 'Loading run output...')}
+    </div>
+  ) : null
+}

--- a/src/renderer/src/components/automations/automation-page-state.ts
+++ b/src/renderer/src/components/automations/automation-page-state.ts
@@ -1,3 +1,4 @@
+import type { ExternalAutomationScope } from './external-automation-scope-client'
 import type {
   ExternalAutomationJob,
   ExternalAutomationManager,
@@ -14,6 +15,7 @@ export type AutomationRunPageOrigin = 'runs' | 'automation'
 
 /** External run opened as a full page inside the detail pane. */
 export type SelectedExternalRunPage = {
+  scope: ExternalAutomationScope
   manager: ExternalAutomationManager
   job: ExternalAutomationJob
   run: ExternalAutomationRun

--- a/src/renderer/src/components/automations/external-automation-scope-client.ts
+++ b/src/renderer/src/components/automations/external-automation-scope-client.ts
@@ -175,7 +175,8 @@ export async function listScopedExternalAutomationRuns(
     jobId: job.id,
     // The engine pages from one; the table's page index is zero-based.
     page: page + 1,
-    pageSize
+    pageSize,
+    summaryOnly: true
   })
   return { runs: result.runs, totalCount: result.total }
 }

--- a/src/renderer/src/components/automations/use-external-automation-actions.ts
+++ b/src/renderer/src/components/automations/use-external-automation-actions.ts
@@ -114,9 +114,10 @@ export function useExternalAutomationActions({
   const openExternalRunPage = (
     manager: ExternalAutomationManager,
     job: ExternalAutomationJob,
-    run: ExternalAutomationRun
+    run: ExternalAutomationRun,
+    scope: ExternalAutomationScope
   ): void => {
-    setSelectedExternalRunPage({ manager, job, run })
+    setSelectedExternalRunPage({ manager, job, run, scope })
   }
   const openAutomationRunPage = (run: AutomationRun): void => {
     setSelectedAutomationRunPageId(run.id)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17846,5 +17846,13 @@
       "stopped": "stopped",
       "finished": "finished"
     }
+  },
+  "common": {
+    "retry": "Retry"
+  },
+  "automations": {
+    "runOutput": {
+      "loading": "Loading run output..."
+    }
   }
 }

--- a/src/shared/automations-types.ts
+++ b/src/shared/automations-types.ts
@@ -279,6 +279,7 @@ export type ExternalAutomationJob = {
 }
 
 export type ExternalAutomationRun = {
+  outputContentDeferred?: true
   id: string
   managerId: string
   provider: ExternalAutomationProvider
@@ -304,6 +305,8 @@ export type ExternalAutomationRunsPage = {
 }
 
 export type ExternalAutomationRunsInput = {
+  summaryOnly?: boolean
+  runId?: string
   managerId: string
   provider: ExternalAutomationProvider
   target: ExternalAutomationTarget

--- a/src/shared/external-automation-scope.ts
+++ b/src/shared/external-automation-scope.ts
@@ -107,6 +107,8 @@ export type ScopedExternalManagerListRequest = ScopedExternalAutomationRequest &
 }
 
 export type ScopedExternalManagerRunsRequest = ScopedExternalAutomationRequest & {
+  summaryOnly?: boolean
+  runId?: string
   jobId: string
   page: number
   pageSize: number


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​348 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​347 |
| Prod | 18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​375 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​48 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​327 |

<!-- /orca-pr-loc -->

Hermes history pages eagerly loaded every referenced log and session transcript. Eight runs referring to 5 MiB logs produced a **41,949,127-byte response**, rejected by the relay's 16 MiB encoder. The table now requests summaries (**3,871 bytes** on the same fixture) and loads one selected run's full output on demand.

The existing readers retain their full-content defaults. A distinct opt-in relay method prevents older hosts from silently ignoring the summary flag; an explicit method-not-found response falls back to their existing full-history behavior. Detail requests carry the captured desktop/SSH owner, resolve IDs within that job's correlated refs, and discard late responses after selection changes. Paired runtime hosts remain excluded by the existing scope gate.

Validation:
- 69 tests across 10 files passed, including legacy content, scoped routing, unknown-method fallback, and summary/detail parity. The delayed-selection test also passes with 250 ms simulated latency.
- Native reader tests assert zero referenced-log reads and zero session-message queries for summaries. Selected output matches the legacy result.
- Node and web typechecks, changed-code quality, and commit lint/format checks passed.
- Hidden Electron CDP validation in a disposable profile: opened the eight-row table, selected September 1, expanded and verified the full 5 MiB log; inspected dark and light screenshots. No window was revealed or focused; the app was stopped afterwards.
- Reproduce the real reader/encoder fixture with `ORCA_BACKGROUND_LAUNCH=1 node config/scripts/hermes-history-payload-benchmark.mjs`. It asserts summary encoding succeeds and selected content equals legacy content. Timing samples were noisy; this claim is payload/I/O reduction, not a whole-app latency estimate.

Limits: older relays keep their existing oversized-response limitation until updated. An individual detail response can still exceed the relay limit if its combined output is unusually large. Summary parsing still reads each run's own Markdown file; the avoided work is referenced-log and session-message hydration. Real SSH and Windows/Linux execution were not exercised.

Fresh exact-head local Electron check: navigated Automations → Hermes job → run output through the rendered UI. The summary response was 555 bytes with deferred output and no referenced log content; selecting the run rendered all 1,000 fixture lines and both boundary markers. Reopening loaded a changed log. Removing the run file showed the unavailable error and Retry; restoring it and clicking Retry recovered the full output. Inspected a hidden-renderer screenshot. Real SSH E2E remains untested.

User-visible trade-off: opening/reopening deferred output performs a request, so previously unloaded remote logs require a connection. Already loaded output remains visible during disconnect.
