### PR TITLE
perf(history): scan legacy alternate-screen markers linearly

### DIFF
--- a/config/scripts/legacy-alt-screen-scan-benchmark.mjs
+++ b/config/scripts/legacy-alt-screen-scan-benchmark.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const modulePath = 'src/main/daemon/terminal-history-legacy-scrollback-restore.ts'
+const baselineSource = readFileSync(0, 'utf8')
+assert.ok(
+  baselineSource.includes('function truncateAltScreen'),
+  'Pipe the baseline module on stdin'
+)
+const arms = {}
+for (const [name, source] of [
+  ['baseline', baselineSource],
+  ['indexed', readFileSync(modulePath, 'utf8')]
+]) {
+  const result = await build({
+    stdin: {
+      contents: `export { truncateAltScreen } from './${modulePath}'`,
+      resolveDir: process.cwd(),
+      loader: 'ts'
+    },
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    write: false,
+    plugins: [
+      {
+        name: 'private-export',
+        setup(api) {
+          api.onLoad({ filter: /terminal-history-legacy-scrollback-restore\.ts$/ }, () => ({
+            contents: `${source}\nexport { truncateAltScreen }`,
+            loader: 'ts',
+            resolveDir: dirname(resolve(modulePath))
+          }))
+        }
+      }
+    ]
+  })
+  arms[name] = (
+    await import(
+      `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+    )
+  ).truncateAltScreen
+}
+
+const on = '\x1b[?1049h'
+const off = '\x1b[?1049l'
+let differentialCases = 0
+function verify(input) {
+  assert.equal(arms.indexed(input), arms.baseline(input))
+  differentialCases++
+}
+const tokens = [on, off, '\x1b[?1049', 'h', 'l', 'x']
+function enumerate(prefix, depth) {
+  verify(prefix)
+  if (depth === 0) {
+    return
+  }
+  for (const token of tokens) {
+    enumerate(prefix + token, depth - 1)
+  }
+}
+enumerate('', 6)
+
+let seed = 90211
+function random(max) {
+  seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+  return Math.floor((seed / 0x100000000) * max)
+}
+const fragments = [...tokens, '\r\n', '\x1b[?1047h', '\x1b[0m', 'é中😀', '\ud800', '\x00']
+for (let trial = 0; trial < 5000; trial++) {
+  verify(Array.from({ length: random(300) }, () => fragments[random(fragments.length)]).join(''))
+}
+console.log(
+  JSON.stringify({
+    differentialCases,
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch
+  })
+)
+
+const workloads = [
+  ['empty', ''],
+  ['plain 4KiB', 'x'.repeat(4096)],
+  ['plain 16MiB', 'x'.repeat(16 * 1024 * 1024)],
+  ['8 balanced', `${'x'.repeat(256)}${on}TUI${off}`.repeat(8)],
+  ['1024 balanced', (on + 'x'.repeat(4096) + off + 'x'.repeat(4096)).repeat(1024)],
+  ['1024 off', ('x'.repeat(8192) + off).repeat(1024)],
+  ['1024 nested on', ('x'.repeat(8192) + on).repeat(1024)],
+  [
+    '1024 nested closed',
+    ('x'.repeat(4096) + on).repeat(1024) + ('x'.repeat(4096) + off).repeat(1024)
+  ],
+  ['4096 off near 16MiB limit', ('x'.repeat(4088) + off).repeat(4096)]
+]
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b)
+  return (sorted[3] + sorted[4]) / 2
+}
+for (const [name, input] of workloads) {
+  const expected = arms.baseline(input)
+  assert.equal(arms.indexed(input), expected)
+  const samples = { baseline: [], indexed: [] }
+  const repeats = input.length < 8192 ? 10000 : 1
+  for (const arm of Object.values(arms)) {
+    for (let warmup = 0; warmup < Math.min(100, repeats); warmup++) {
+      assert.equal(arm(input), expected)
+    }
+  }
+  for (const pair of buildCounterbalancedSchedule(8, 'baseline', 'indexed')) {
+    for (const name of pair) {
+      const start = performance.now()
+      let result
+      for (let repeat = 0; repeat < repeats; repeat++) {
+        result = arms[name](input)
+      }
+      samples[name].push((performance.now() - start) / repeats)
+      assert.equal(result, expected)
+    }
+  }
+  console.log(
+    JSON.stringify({
+      name,
+      bytes: Buffer.byteLength(input),
+      medianMs: Object.fromEntries(
+        Object.entries(samples).map(([name, values]) => [name, median(values)])
+      )
+    })
+  )
+}

--- a/src/main/daemon/history-reader.test.ts
+++ b/src/main/daemon/history-reader.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
@@ -429,6 +429,36 @@ describe('HistoryReader', () => {
   })
 
   describe('TUI truncation (scrollback.bin fallback path)', () => {
+    it.each(['\x1b[?1049h', '\x1b[?1049l'])(
+      'does not rescan the remaining history for each %j marker',
+      async (marker) => {
+        const scrollback = `normal\r\n${`output${marker}`.repeat(1000)}`
+        writeSessionWithScrollback(dir, 'repeated-switch', makeMeta(), scrollback)
+        let searchedCharacters = 0
+        const originalIndexOf = String.prototype.indexOf
+        const spy = vi.spyOn(String.prototype, 'indexOf').mockImplementation(function (
+          this: string,
+          search: string,
+          position?: number
+        ) {
+          const found = originalIndexOf.call(this, search, position)
+          if (search === '\x1b[?1049h' || search === '\x1b[?1049l') {
+            searchedCharacters +=
+              (found < 0 ? this.length : found + search.length) - (position ?? 0)
+          }
+          return found
+        })
+        let info
+        try {
+          info = await reader.detectColdRestore('repeated-switch')
+        } finally {
+          spy.mockRestore()
+        }
+        expect(info?.snapshotAnsi).toBe(marker.endsWith('h') ? 'normal\r\noutput' : scrollback)
+        expect(searchedCharacters).toBeLessThanOrEqual(2 * scrollback.length)
+      }
+    )
+
     it('preserves content when alt-screen is properly closed', async () => {
       const scrollback = [
         'before vim\r\n',

--- a/src/main/daemon/terminal-history-legacy-scrollback-restore.ts
+++ b/src/main/daemon/terminal-history-legacy-scrollback-restore.ts
@@ -53,26 +53,20 @@ function truncateAltScreen(data: string): string {
   let depth = 0
   let outermostUnmatchedOnIdx = -1
 
-  let searchFrom = 0
-  while (searchFrom < data.length) {
-    const onIdx = data.indexOf(ALT_SCREEN_ON, searchFrom)
-    const offIdx = data.indexOf(ALT_SCREEN_OFF, searchFrom)
-
-    if (onIdx === -1 && offIdx === -1) {
-      break
-    }
-
+  let onIdx = data.indexOf(ALT_SCREEN_ON)
+  let offIdx = data.indexOf(ALT_SCREEN_OFF)
+  while (onIdx !== -1 || offIdx !== -1) {
     if (onIdx !== -1 && (offIdx === -1 || onIdx < offIdx)) {
       if (depth === 0) {
         outermostUnmatchedOnIdx = onIdx
       }
       depth++
-      searchFrom = onIdx + ALT_SCREEN_ON.length
+      onIdx = data.indexOf(ALT_SCREEN_ON, onIdx + ALT_SCREEN_ON.length)
     } else {
       if (depth > 0) {
         depth--
       }
-      searchFrom = offIdx + ALT_SCREEN_OFF.length
+      offIdx = data.indexOf(ALT_SCREEN_OFF, offIdx + ALT_SCREEN_OFF.length)
     }
   }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​139 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​128 |

<!-- /orca-pr-loc -->

## Summary

Keep the next alternate-screen-on and alternate-screen-off positions while inspecting legacy `scrollback.bin` recovery text. Advance only the marker that was consumed. Previously, every marker caused both searches to restart over the remaining history, even when one kind never appeared again.

The original depth accounting and outermost-unmatched-on truncation remain intact. Closed/nested sessions, unmatched off markers, partial sequences, and ordinary text produce exactly the same restored bytes. This changes only the legacy fallback when a usable checkpoint is absent; current checkpoint recovery, the 16 MiB legacy limit, metadata, mode flags and error handling are untouched.

No daemon endpoint, process lifecycle, status, execution-host, workspace, provider or wire change. Independent performance improvement 11; tracks #20206.

## Measurement

Actual baseline/current private production functions are selected with an esbuild-only export (no production API added). Eight counterbalanced pairs, Node v26.6.0/macOS arm64, after local tests/typechecks completed. Median milliseconds:

| History text | Before | After |
| --- | ---: | ---: |
| Plain 16 MiB, no markers | 0.642 | 0.617 |
| 8 balanced switches, 2.2 KiB | 0.000528 | 0.000357 |
| 1,024 balanced switches, 8.0 MiB | 0.592 | 0.396 |
| 1,024 off-only switches, 8.0 MiB | 270.6 | 0.706 |
| 1,024 nested on switches, 8.0 MiB | 275.4 | 0.704 |
| 1,024 nested on then off switches, 8.0 MiB | 290.5 | 0.750 |
| 4,096 off-only switches, exactly 16 MiB | 2,245 | 1.49 |

These are synthetic parser CPU measurements, not end-to-end recovery or typical current-version history. The large pathological cases stay within the existing input limit. Plain 4 KiB input is effectively unchanged (0.181 → 0.183 microseconds). Cost is two numeric cursors, with no new retained buffer or cache.

```sh
git show 20ab99506541:src/main/daemon/terminal-history-legacy-scrollback-restore.ts | ORCA_BACKGROUND_LAUNCH=1 node config/scripts/legacy-alt-screen-scan-benchmark.mjs
```

## Verification

- 83 tests pass across six history-reader, memory-limit, checkpoint/cold-restore, daemon-adapter and headless-emulator test files.
- 60,987 differential cases: exhaustive marker/partial-sequence combinations plus randomized controls, Unicode and malformed code units; exact output-string equality.
- Regression exercises the real disk-backed HistoryReader fallback. With 1,000 same-kind markers, baseline searches 7,021,016 characters versus a 28,016-character linear bound; current passes.
- `pnpm tc:node` and changed-code quality gate pass.
- Tests use `ORCA_BACKGROUND_LAUNCH=1`; no visible app windows launched. Actual host is macOS; no native Windows/Linux timing claim.

## Visual Proof

N/A — restored text and recovery behavior are unchanged.
