### PR TITLE
perf: bound HTML comment replacement to the last closing marker

### DIFF
--- a/config/scripts/html-comment-scan-benchmark.mjs
+++ b/config/scripts/html-comment-scan-benchmark.mjs
@@ -40,7 +40,7 @@ for (const [name, file, invoke] of [
   const arms = {
     before: await load(
       file,
-      execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8' })
+      execFileSync('git', ['show', `${baseline}:${String(file)}`], { encoding: 'utf8' })
     ),
     after: await load(file, readFileSync(file, 'utf8'))
   }

--- a/config/scripts/html-comment-scan-benchmark.mjs
+++ b/config/scripts/html-comment-scan-benchmark.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const baseline = process.argv[2] ?? '20ab9950654'
+async function load(file, contents) {
+  const result = await build({
+    stdin: { contents, loader: 'ts', resolveDir: dirname(resolve(file)) },
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false
+  })
+  return import(
+    `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+  )
+}
+const results = []
+for (const [name, file, invoke] of [
+  [
+    'preview',
+    'mobile/src/components/mobile-markdown-preview-html.ts',
+    (module, text) => module.normalizeMobileMarkdownPreviewHtml(text)
+  ],
+  [
+    'comment-blocks',
+    'mobile/src/components/pr-sidebar/markdown-blocks.ts',
+    (module, text) => module.parseMarkdownBlocks(text)
+  ],
+  [
+    'ack-label',
+    'src/renderer/src/components/right-sidebar/pr-comment-fixing-reply-body.ts',
+    (module, text) => module.describePRCommentAckTarget({ body: text, url: '' })
+  ]
+]) {
+  const arms = {
+    before: await load(
+      file,
+      execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8' })
+    ),
+    after: await load(file, readFileSync(file, 'utf8'))
+  }
+  for (const [shape, text] of [
+    ['plain', '# Heading\nA normal document.'],
+    ['complete', 'text<!--hidden-->more\n'.repeat(100)],
+    ['unclosed-1000', '<!--x'.repeat(1000)],
+    ['unclosed-4000', '<!--x'.repeat(4000)],
+    ['unclosed-8000', '<!--x'.repeat(8000)],
+    ['mixed-8000', `a<!--complete-->b${'<!--x'.repeat(8000)}`]
+  ]) {
+    assert.deepEqual(invoke(arms.after, text), invoke(arms.before, text))
+    const iterations = shape.startsWith('unclosed') || shape.startsWith('mixed') ? 1 : 100
+    const run = (arm) => {
+      global.gc?.()
+      const start = performance.now()
+      const cpuStart = process.cpuUsage()
+      for (let i = 0; i < iterations; i++) {
+        invoke(arms[arm], text)
+      }
+      const cpu = process.cpuUsage(cpuStart)
+      return {
+        ms: (performance.now() - start) / iterations,
+        cpuMs: (cpu.user + cpu.system) / 1000 / iterations
+      }
+    }
+    run('before')
+    run('after')
+    const samples = { before: [], after: [] }
+    for (const pair of buildCounterbalancedSchedule(10, 'before', 'after')) {
+      for (const arm of pair) {
+        samples[arm].push(run(arm))
+      }
+    }
+    const median = (values) => {
+      const sorted = [...values].sort((a, b) => a - b)
+      return (sorted[4] + sorted[5]) / 2
+    }
+    results.push({
+      name,
+      shape,
+      beforeMs: median(samples.before.map((s) => s.ms)),
+      afterMs: median(samples.after.map((s) => s.ms)),
+      beforeCpuMs: median(samples.before.map((s) => s.cpuMs)),
+      afterCpuMs: median(samples.after.map((s) => s.cpuMs)),
+      samples
+    })
+  }
+}
+console.log(
+  JSON.stringify({ baseline, node: process.version, platform: process.platform, results }, null, 2)
+)

--- a/mobile/src/components/mobile-markdown-preview-html.ts
+++ b/mobile/src/components/mobile-markdown-preview-html.ts
@@ -1,3 +1,4 @@
+import { replaceHtmlComments } from '../../../src/shared/html-comment-replacement'
 import {
   findMobileMarkdownMarkupTagEnd,
   findNextPairedMarkupOpener,
@@ -47,7 +48,7 @@ function decodeHtmlEntities(value: string, preserveEscapedEntities = false): str
 function stripTags(value: string): string {
   const { protectedText, codeSpans, placeholderPrefix } = protectMarkdownCode(value)
   const stripped = decodeHtmlEntities(
-    stripMobileMarkdownMarkupTags(protectedText.replace(/<!--[\s\S]*?-->/g, '')),
+    stripMobileMarkdownMarkupTags(replaceHtmlComments(protectedText)),
     true
   )
     .replace(/[ \t]+\n/g, '\n')

--- a/mobile/src/components/pr-sidebar/markdown-blocks.ts
+++ b/mobile/src/components/pr-sidebar/markdown-blocks.ts
@@ -1,3 +1,5 @@
+import { replaceHtmlComments } from '../../../../src/shared/html-comment-replacement'
+
 // Tiny, dependency-free markdown model for PR comment bodies. We render GitHub
 // markdown without a third-party RN markdown library (the previous dependency hung
 // the JS thread when a comment list mounted). Scope is deliberately small — the
@@ -49,7 +51,7 @@ export function stripHtmlTags(text: string): string {
 
 export function parseMarkdownBlocks(content: string): MarkdownBlock[] {
   // Drop HTML comments and normalize <br> before block parsing.
-  const cleaned = content.replace(/<!--[\s\S]*?-->/g, '').replace(/<br\s*\/?>/gi, '\n')
+  const cleaned = replaceHtmlComments(content).replace(/<br\s*\/?>/gi, '\n')
   return parseSegment(cleaned)
 }
 

--- a/src/renderer/src/components/right-sidebar/pr-comment-ack-summary.test.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-ack-summary.test.ts
@@ -58,7 +58,7 @@ describe('review acknowledgement summary', () => {
     const replaces = replace.mock.calls.length
     const splits = split.mock.calls.length
     expect(actual).toBe('comment — Heading')
-    expect(replaces).toBe(3)
+    expect(replaces).toBe(2)
     expect(splits).toBe(0)
   })
 })

--- a/src/renderer/src/components/right-sidebar/pr-comment-fixing-reply-body.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-fixing-reply-body.ts
@@ -1,3 +1,4 @@
+import { replaceHtmlComments } from '../../../../shared/html-comment-replacement'
 import type { PRComment } from '../../../../shared/github/comment-types'
 
 /** Posted when a selected review comment is sent to AI. */
@@ -24,8 +25,7 @@ const ACK_SNIPPET_MAX_LENGTH = 72
 
 /** First readable line of a comment body, minus HTML comments and markdown markers. */
 function summarizePRCommentBody(body: string): string {
-  const line = body
-    .replace(/<!--[\s\S]*?-->/g, ' ')
+  const line = replaceHtmlComments(body, ' ')
     .split('\n')
     .map((candidate) =>
       candidate

--- a/src/shared/html-comment-replacement.test.ts
+++ b/src/shared/html-comment-replacement.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { replaceHtmlComments } from './html-comment-replacement'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('HTML comment replacement', () => {
+  it.each(['', ' '] as const)('matches the regex with replacement %j', (replacement) => {
+    const fragments = [
+      '',
+      'a',
+      '\r\n',
+      '😀',
+      '<!--',
+      '-->',
+      '<!---->',
+      '<!--->',
+      '<!--x-->',
+      '<!--x'
+    ]
+    for (const first of fragments) {
+      for (const second of fragments) {
+        for (const third of fragments) {
+          const input = first + second + third
+          expect(replaceHtmlComments(input, replacement)).toBe(
+            input.replace(/<!--[\s\S]*?-->/g, replacement)
+          )
+        }
+      }
+    }
+  })
+
+  it('keeps an unmatched suffix out of the regex scan', () => {
+    const prefix = 'a<!--complete-->'
+    const suffix = `b${'<!--unfinished'.repeat(8000)}`
+    const replace = vi.spyOn(String.prototype, 'replace')
+    const actual = replaceHtmlComments(prefix + suffix, ' ')
+    const scanned = [...replace.mock.contexts]
+    replace.mockRestore()
+    expect(actual).toBe(`a ${suffix}`)
+    expect(scanned).toEqual([prefix])
+  })
+
+  it('skips the regex entirely when there are no closing markers', () => {
+    const input = '<!--x'.repeat(8000)
+    const replace = vi.spyOn(String.prototype, 'replace')
+    const actual = replaceHtmlComments(input)
+    const scans = replace.mock.calls.length
+    replace.mockRestore()
+    expect(actual).toBe(input)
+    expect(scans).toBe(0)
+  })
+})

--- a/src/shared/html-comment-replacement.ts
+++ b/src/shared/html-comment-replacement.ts
@@ -1,0 +1,10 @@
+/** Replaces complete HTML comments, leaving an unterminated suffix intact. */
+export function replaceHtmlComments(content: string, replacement: '' | ' ' = ''): string {
+  const lastClose = content.lastIndexOf('-->')
+  if (lastClose === -1) {
+    return content
+  }
+  // Exclude the suffix where each unmatched opener would rescan for a nonexistent closer.
+  const end = lastClose + 3
+  return content.slice(0, end).replace(/<!--[\s\S]*?-->/g, replacement) + content.slice(end)
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​112 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 |

<!-- /orca-pr-loc -->

## ELI5

Stop searching for HTML comments where no closing marker remains.

Repeated unclosed HTML-comment openers make the global comment-removal regex rescan the remaining text from every opener. A 40 KB malformed comment body can spend tens of milliseconds in this scan before mobile rendering or review acknowledgement formatting.

Share a replacement helper across mobile Markdown previews, mobile PR-comment blocks, and desktop review acknowledgement labels. It finds the last closing marker and runs the existing regex only through that marker, then appends the untouched suffix. If no closing marker exists, it returns the input directly. The suffix cannot contain a complete match, so replacement output stays identical while avoiding quadratic failed searches. Each caller keeps its existing empty-string or single-space replacement.

Counterbalanced Node 24/macOS process CPU measurements of the full callers, with GC outside samples and output parity asserted:

| 8,000 unclosed openers / 40 KB | Before | After |
| --- | ---: | ---: |
| Mobile Markdown preview | 43.748 ms | 2.046 ms |
| Mobile PR-comment block parser | 43.800 ms | 0.057 ms |
| Review acknowledgement label | 46.047 ms | 0.052 ms |

A complete comment followed by the same malformed suffix shows similar gains. Complete-comment fixtures remain close to baseline (differences below 2 microseconds CPU). These are synthetic Node helper measurements, not device or end-to-end UI timings. Reproduce with `ORCA_BACKGROUND_LAUNCH=1 node --expose-gc config/scripts/html-comment-scan-benchmark.mjs`.

Validation: 43 shared/renderer tests and 35 mobile tests pass; web and mobile typechecks, lint, and formatting pass. Exhaustive combinations of 10 fragments across three positions assert parity for both replacement modes (2,000 cases), including nested-looking/overlapping markers and Unicode. Two work-bound tests fail with the original regex and pass after bounding the scan. Existing mobile code-span protection and acknowledgement behavior remain covered.


## Merge order
Stacked on #20263. Merge #20263 first, then retarget this PR to `main`. The lazy acknowledgement scan uses the bounded HTML-comment helper; 21 combined tests, lint and formatting pass. The count regression now expects two replacements because the combined helper also skips absent comments.
