### PR TITLE
fix(updater): open background check errors from the status bar

### DIFF
--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -317,8 +317,8 @@ type VisibilityInput = {
   status: UpdateStatus
   dismissedVersion: string | null
   cachedVersion: string | null
-  hasStartedDownload: boolean
   updateUserInitiatedCycle?: boolean
+  collapsed?: boolean
 }
 
 type VisibilityResult = 'hidden' | 'visible'
@@ -338,8 +338,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'idle' },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('hidden')
   })
@@ -353,8 +352,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'checking' },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('hidden')
   })
@@ -364,8 +362,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'checking', userInitiated: true },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('visible')
   })
@@ -375,8 +372,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'not-available' },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('hidden')
   })
@@ -386,8 +382,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'not-available', userInitiated: true },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('visible')
   })
@@ -397,8 +392,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'available', version: '1.2.0', changelog: null },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('visible')
   })
@@ -408,8 +402,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'available', version: '1.2.0', changelog: RICH_CHANGELOG },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('visible')
   })
@@ -419,8 +412,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'available', version: '1.2.0', changelog: null },
         dismissedVersion: '1.2.0',
-        cachedVersion: '1.2.0',
-        hasStartedDownload: false
+        cachedVersion: '1.2.0'
       })
     ).toBe('hidden')
   })
@@ -431,7 +423,6 @@ describe('UpdateCard visibility gates', () => {
         status: { state: 'available', version: '1.2.0', changelog: null },
         dismissedVersion: '1.2.0',
         cachedVersion: '1.2.0',
-        hasStartedDownload: false,
         updateUserInitiatedCycle: true
       })
     ).toBe('visible')
@@ -442,8 +433,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'downloading', percent: 42, version: '1.2.0' },
         dismissedVersion: '1.2.0',
-        cachedVersion: '1.2.0',
-        hasStartedDownload: true
+        cachedVersion: '1.2.0'
       })
     ).toBe('visible')
   })
@@ -453,19 +443,22 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'downloaded', version: '1.2.0' },
         dismissedVersion: '1.2.0',
-        cachedVersion: '1.2.0',
-        hasStartedDownload: false
+        cachedVersion: '1.2.0'
       })
     ).toBe('hidden')
   })
 
   it('hides background errors silently', () => {
+    const store = createTestStore()
+    setState(store, { state: 'checking' })
+    setState(store, { state: 'error', message: 'network' })
+
     expect(
       computeVisibility({
-        status: { state: 'error', message: 'network' },
+        status: store.getState().updateStatus,
+        collapsed: store.getState().updateCardCollapsed,
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('hidden')
   })
@@ -475,8 +468,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'error', message: 'network', userInitiated: true },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('visible')
   })
@@ -486,8 +478,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'error', message: 'ENOSPC' },
         dismissedVersion: null,
-        cachedVersion: '1.2.0',
-        hasStartedDownload: true
+        cachedVersion: '1.2.0'
       })
     ).toBe('visible')
   })
@@ -497,8 +488,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'error', message: 'ENOSPC' },
         dismissedVersion: null,
-        cachedVersion: '1.2.0',
-        hasStartedDownload: false
+        cachedVersion: '1.2.0'
       })
     ).toBe('visible')
   })
@@ -517,8 +507,7 @@ describe('UpdateCard visibility gates', () => {
           }
         },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('visible')
   })
@@ -528,8 +517,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'error', message: 'invalid metadata', version: '1.2.0' },
         dismissedVersion: null,
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('visible')
   })
@@ -539,8 +527,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'downloaded', version: '1.2.0' },
         dismissedVersion: null,
-        cachedVersion: '1.2.0',
-        hasStartedDownload: true
+        cachedVersion: '1.2.0'
       })
     ).toBe('visible')
   })
@@ -550,8 +537,7 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'available', version: '1.3.0', changelog: null },
         dismissedVersion: '1.2.0',
-        cachedVersion: '1.3.0',
-        hasStartedDownload: false
+        cachedVersion: '1.3.0'
       })
     ).toBe('visible')
   })
@@ -561,19 +547,23 @@ describe('UpdateCard visibility gates', () => {
       computeVisibility({
         status: { state: 'error', message: 'fail', userInitiated: true },
         dismissedVersion: '1.2.0',
-        cachedVersion: '1.2.0',
-        hasStartedDownload: false
+        cachedVersion: '1.2.0'
       })
     ).toBe('visible')
   })
 
   it('hides check errors once a new checking cycle cleared the cached version', () => {
+    const store = createTestStore()
+    setState(store, { state: 'available', version: '1.2.0', changelog: null })
+    setState(store, { state: 'checking' })
+    setState(store, { state: 'error', message: 'network timeout' })
+
     expect(
       computeVisibility({
-        status: { state: 'error', message: 'network timeout' },
+        status: store.getState().updateStatus,
+        collapsed: store.getState().updateCardCollapsed,
         dismissedVersion: '1.2.0',
-        cachedVersion: null,
-        hasStartedDownload: false
+        cachedVersion: null
       })
     ).toBe('hidden')
   })
@@ -649,8 +639,7 @@ describe('full update lifecycle through setUpdateStatus', () => {
       computeVisibility({
         status: store.getState().updateStatus,
         dismissedVersion: store.getState().dismissedUpdateVersion,
-        cachedVersion: '1.3.0',
-        hasStartedDownload: false
+        cachedVersion: '1.3.0'
       })
     ).toBe('visible')
   })

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -108,7 +108,6 @@ export function UpdateCard(): React.JSX.Element | null {
       status,
       dismissedVersion,
       cachedVersion,
-      hasStartedDownload: hasStartedDownload.current,
       updateUserInitiatedCycle,
       autoDismissed,
       collapsed

--- a/src/renderer/src/components/maintenance/update-card/update-card-visibility.ts
+++ b/src/renderer/src/components/maintenance/update-card/update-card-visibility.ts
@@ -4,7 +4,6 @@ export function isUpdateCardVisible({
   status,
   dismissedVersion,
   cachedVersion,
-  hasStartedDownload,
   updateUserInitiatedCycle,
   autoDismissed = false,
   collapsed = false
@@ -12,18 +11,11 @@ export function isUpdateCardVisible({
   status: UpdateStatus
   dismissedVersion: string | null
   cachedVersion: string | null
-  hasStartedDownload: boolean
   updateUserInitiatedCycle: boolean
   autoDismissed?: boolean
   collapsed?: boolean
 }): boolean {
   const isUserInitiated = 'userInitiated' in status && Boolean(status.userInitiated)
-  const shouldShowDetailedErrorCard =
-    status.state === 'error' &&
-    (hasStartedDownload ||
-      cachedVersion !== null ||
-      status.version !== undefined ||
-      status.recovery?.kind === 'linux-package-install')
 
   if (status.state === 'checking' && !isUserInitiated) {
     return false
@@ -32,9 +24,6 @@ export function isUpdateCardVisible({
     return false
   }
   if (status.state === 'idle') {
-    return false
-  }
-  if (status.state === 'error' && !shouldShowDetailedErrorCard && !isUserInitiated) {
     return false
   }
   if (cachedVersion && dismissedVersion === cachedVersion && !updateUserInitiatedCycle) {

--- a/src/renderer/src/components/status-bar/UpdateStatusSegment.test.tsx
+++ b/src/renderer/src/components/status-bar/UpdateStatusSegment.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UpdateStatus } from '../../../../shared/update-status-types'
+import { useAppStore } from '../../store'
+import { UpdateCard } from '../UpdateCard'
+import { TooltipProvider } from '../ui/tooltip'
+import { UpdateStatusSegment } from './UpdateStatusSegment'
+
+const check = vi.fn()
+const message = 'Could not reach the update server: net::ERR_CONNECTION_REFUSED'
+const error: UpdateStatus = { state: 'error', message }
+const actionableErrors: UpdateStatus[] = [
+  { ...error, userInitiated: true },
+  { ...error, version: '1.4.200' },
+  {
+    ...error,
+    recovery: {
+      kind: 'linux-package-install',
+      packageType: 'deb',
+      reason: 'manual-install-required',
+      version: '1.4.200'
+    }
+  }
+]
+
+function setStatus(status: UpdateStatus): void {
+  act(() => useAppStore.getState().setUpdateStatus(status))
+}
+
+function renderUpdateControls(): void {
+  render(
+    <TooltipProvider>
+      <UpdateCard />
+      <UpdateStatusSegment compact={false} iconOnly={false} />
+    </TooltipProvider>
+  )
+}
+
+function errorToggle(): HTMLElement {
+  return screen.getByRole('button', { name: 'Update failed. Click to expand.' })
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState(), true)
+  check.mockReset().mockResolvedValue(undefined)
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
+  )
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { updater: { check } }
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  useAppStore.setState(useAppStore.getInitialState(), true)
+  vi.unstubAllGlobals()
+})
+
+describe('update status disclosure', () => {
+  it('opens background check failure details on the first click and offers a re-check', () => {
+    renderUpdateControls()
+    setStatus({ state: 'checking' })
+    setStatus(error)
+
+    expect(screen.queryByRole('complementary', { name: 'Update error' })).toBeNull()
+    fireEvent.click(errorToggle())
+
+    expect(screen.getByRole('complementary', { name: 'Update error' })).toBeTruthy()
+    expect(errorToggle().getAttribute('aria-expanded')).toBe('true')
+    fireEvent.click(screen.getByRole('button', { name: 'Show details' }))
+    expect(screen.getByText(message)).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Re-check' }))
+    expect(check).toHaveBeenCalledWith({ includePrerelease: false })
+
+    fireEvent.click(errorToggle())
+    expect(screen.queryByRole('complementary', { name: 'Update error' })).toBeNull()
+    expect(errorToggle().getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('announces a quiet automatic check failure as collapsed', () => {
+    setStatus(error)
+    renderUpdateControls()
+
+    expect(screen.queryByRole('complementary', { name: 'Update error' })).toBeNull()
+    expect(errorToggle().getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('preserves the disclosure choice until the next automatic check', () => {
+    renderUpdateControls()
+    setStatus(error)
+    fireEvent.click(errorToggle())
+    setStatus({ ...error, message: 'Still unavailable' })
+    expect(screen.getByRole('complementary', { name: 'Update error' })).toBeTruthy()
+
+    fireEvent.click(errorToggle())
+    setStatus(error)
+    expect(screen.queryByRole('complementary', { name: 'Update error' })).toBeNull()
+    fireEvent.click(errorToggle())
+
+    setStatus({ state: 'checking' })
+    setStatus(error)
+    expect(screen.queryByRole('complementary', { name: 'Update error' })).toBeNull()
+    expect(errorToggle().getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it.each<UpdateStatus>([
+    { state: 'checking', userInitiated: true },
+    { state: 'available', version: '1.4.200', changelog: null },
+    { state: 'downloading', version: '1.4.200', percent: 50 },
+    { state: 'downloaded', version: '1.4.200' }
+  ])('opens an error after $state without requiring a status click', (previousStatus) => {
+    setStatus(previousStatus)
+    setStatus(error)
+    renderUpdateControls()
+
+    expect(screen.getByRole('complementary', { name: 'Update error' })).toBeTruthy()
+    expect(errorToggle().getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it.each(actionableErrors)(
+    'opens an explicit actionable error on initial receipt: %j',
+    (status) => {
+      setStatus(status)
+      renderUpdateControls()
+
+      expect(screen.getByRole('complementary', { name: 'Update error' })).toBeTruthy()
+      expect(
+        screen.getByRole('button', { name: /Click to expand/ }).getAttribute('aria-expanded')
+      ).toBe('true')
+    }
+  )
+
+  it.each(actionableErrors)(
+    'opens a newly actionable error and preserves dismissal on repeat: %j',
+    (status) => {
+      renderUpdateControls()
+      setStatus(error)
+      expect(screen.queryByRole('complementary', { name: 'Update error' })).toBeNull()
+
+      setStatus(status)
+      expect(screen.getByRole('complementary', { name: 'Update error' })).toBeTruthy()
+
+      fireEvent.click(screen.getByRole('button', { name: /Click to expand/ }))
+      setStatus({ ...status })
+      expect(screen.queryByRole('complementary', { name: 'Update error' })).toBeNull()
+    }
+  )
+})

--- a/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-contract-preferences.ts
@@ -182,7 +182,7 @@ export type UISlicePersistence = {
   /** Dev-only channel override; null follows the running build's own channel. */
   releaseChannelOverride: ReleaseChannel | null
   setReleaseChannelOverride: (channel: ReleaseChannel | null) => void
-  // Why: ephemeral, renderer-only — never persisted; resets each session and on every phase transition (see setUpdateStatus).
+  // Ephemeral disclosure state; setUpdateStatus initializes it when the phase or error actionability changes.
   updateCardCollapsed: boolean
   setUpdateCardCollapsed: (collapsed: boolean) => void
   updateReassuranceSeen: boolean

--- a/src/renderer/src/store/slices/ui/ui-slice-update-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-update-actions.ts
@@ -8,7 +8,7 @@ export function createUiUpdateActions(set: UISliceSet, get: UISliceGet): Partial
   return {
     updateStatus: { state: 'idle' },
     setUpdateStatus: (status) => {
-      const prevState = get().updateStatus.state
+      const { updateStatus: previousStatus, updateUserInitiatedCycle } = get()
       const update: Partial<
         Pick<
           UISlice,
@@ -34,9 +34,22 @@ export function createUiUpdateActions(set: UISliceSet, get: UISliceGet): Partial
         update.updateChangelog = null
       }
       // 'downloading'/'downloaded'/'error': leave updateChangelog untouched to keep the original 'available' content.
-      if (status.state !== prevState) {
-        // Why: re-surface the card on each phase transition so a collapsed `downloading` doesn't bury `downloaded`/`error`.
-        update.updateCardCollapsed = false
+      const errorBecameActionable =
+        status.state === 'error' &&
+        previousStatus.state === 'error' &&
+        ((status.userInitiated === true && !previousStatus.userInitiated) ||
+          (status.version !== undefined && previousStatus.version === undefined) ||
+          (status.recovery?.kind === 'linux-package-install' &&
+            previousStatus.recovery?.kind !== 'linux-package-install'))
+      if (status.state !== previousStatus.state || errorBecameActionable) {
+        // Quiet check failures start collapsed so the status bar can still disclose them.
+        update.updateCardCollapsed =
+          status.state === 'error' &&
+          !status.userInitiated &&
+          !updateUserInitiatedCycle &&
+          status.version === undefined &&
+          status.recovery?.kind !== 'linux-package-install' &&
+          !('version' in previousStatus && previousStatus.version !== undefined)
       }
       set(update)
     },

--- a/tests/e2e/update-status-error-details.spec.ts
+++ b/tests/e2e/update-status-error-details.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+const CHECK_ERROR = 'E2E update check failed: connection refused'
+
+test.use({ seedTestRepo: false })
+
+for (const theme of ['dark', 'light'] as const) {
+  test(`automatic update failure opens details from the status bar (${theme})`, async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await orcaPage.setViewportSize({ width: 1200, height: 800 })
+    await orcaPage.evaluate(async (theme) => {
+      const state = window.__store!.getState()
+      await state.updateSettingsOrThrow({ theme })
+      state.setUpdateStatus({ state: 'checking', userInitiated: false })
+    }, theme)
+    await expect(orcaPage.locator('html')).toHaveClass(theme === 'dark' ? /\bdark\b/ : /\blight\b/)
+    await orcaPage.evaluate((message) => {
+      window.__store!.getState().setUpdateStatus({
+        state: 'error',
+        message,
+        userInitiated: false
+      })
+    }, CHECK_ERROR)
+
+    const statusButton = orcaPage.getByRole('button', {
+      name: 'Update failed. Click to expand.',
+      exact: true
+    })
+    const card = orcaPage.getByRole('complementary', { name: 'Update error', exact: true })
+    await expect(statusButton).toBeVisible()
+    await expect(card).toBeHidden()
+
+    await statusButton.click()
+    // Capture before the assertion so the broken build provides the same visual evidence.
+    const statusClickScreenshot = testInfo.outputPath(
+      `update-error-after-status-click-${theme}.png`
+    )
+    await orcaPage.screenshot({ path: statusClickScreenshot, animations: 'disabled' })
+    await testInfo.attach(`update-error-after-status-click-${theme}`, {
+      path: statusClickScreenshot,
+      contentType: 'image/png'
+    })
+    await expect(card).toBeVisible()
+    await expect(statusButton).toHaveAttribute('aria-expanded', 'true')
+    await expect(card.getByRole('heading', { name: 'Update Check Failed' })).toBeVisible()
+    await expect(card.getByRole('button', { name: 'Re-check', exact: true })).toBeVisible()
+
+    await card.getByRole('button', { name: 'Show details', exact: true }).click()
+    await expect(card.getByText(CHECK_ERROR, { exact: true })).toBeVisible()
+    const detailsScreenshot = testInfo.outputPath(`update-error-expanded-details-${theme}.png`)
+    await orcaPage.screenshot({ path: detailsScreenshot, animations: 'disabled' })
+    await testInfo.attach(`update-error-expanded-details-${theme}`, {
+      path: detailsScreenshot,
+      contentType: 'image/png'
+    })
+
+    await card.getByRole('button', { name: 'Minimize to status bar', exact: true }).click()
+    await expect(card).toBeHidden()
+    await expect(statusButton).toHaveAttribute('aria-expanded', 'false')
+    await statusButton.click()
+    await expect(card).toBeVisible()
+    await expect(statusButton).toHaveAttribute('aria-expanded', 'true')
+  })
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​258 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​46 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​212 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

When Orca says “Update failed,” clicking it should explain what went wrong. The first click now opens the existing error card, with details and a Re-check button. Automatic check failures still stay quiet until requested.

## What Changed

- Initialize quiet check failures as collapsed in the existing update store; remove the competing render-time error-hiding rule. The status bar and card now use the same visibility state, including `aria-expanded`.
- Keep manual check, download/install, versioned, and Linux package recovery errors visible. Newly actionable errors also reopen when a preflight failure occurs before a new `checking` event; repeated equivalent errors preserve the user's collapse choice.
- Add rendered component and Electron regressions. Remove the visibility function's now-unused download-start input.

## Why

Previously the status button toggled `updateCardCollapsed`, but a second condition always hid automatic errors with no known update version. Clicking could never override it. One existing state now owns the disclosure decision; no new state or wire fields are needed.

## Linked Issue

Fixes #20200

At triage, the issue was unassigned, had no linked PR, and had no matching open updater fix. This is a concrete broken interaction; it has no SSH/remote or CoW scope.

## Visual Proof

Same automatic failure and same click, captured from hidden Electron renderers via Playwright CDP. Baseline `fa3d29fa11` fails the card-visible assertion in both themes; the fixed build passes both.

| Theme | Before: after clicking “Update failed” | After: same click |
| --- | --- | --- |
| Dark | ![Before: status click leaves error card absent](https://github.com/user-attachments/assets/cabc403f-9a2a-4611-895e-861759a10044) | ![After: status click opens the error card](https://github.com/user-attachments/assets/5ddaa78d-ba4f-4c8b-97e0-ca6a0caa41ed) |
| Light | ![Before in light theme](https://github.com/user-attachments/assets/47c70d3f-2d15-4cc5-a45f-79ac34e691bb) | ![After in light theme](https://github.com/user-attachments/assets/615ecbf1-b627-4cdc-8d49-5f2287085832) |

After choosing **Show details**:

![The original diagnostic and Re-check control are visible](https://github.com/user-attachments/assets/38afc8b1-2dea-47b4-bf5c-1c9b4dc32830)

## Testing

**Fully verified for the reported renderer interaction on macOS**, in light and dark themes. Setup injects a deterministic automatic updater failure through the real store; assertions and screenshots exercise actual rendered controls. No live release-server outage, download/install, native Windows/Linux, or SSH run was performed.

- [x] Locally exercised the real app via background Playwright CDP; inspected the screenshots.
- [x] Added automated regressions: 86 tests pass across the four update card/status/error-model suites, including disclosure, retry dispatch, cycle reset, initial actionable errors, same-state promotion, and preserving collapse on repeat.
- [x] Two Electron regressions pass: first-click disclosure, raw details, retry-control visibility, minimize and reopen.
- [x] `pnpm tc`, changed-file oxlint + React Doctor, oxfmt, and `git diff --check` pass.
- [x] Electron build in `e2e` mode and bundled CLI build pass. Every app/test run used `ORCA_BACKGROUND_LAUNCH=1`; windows remained hidden.

Reproduce the UI check:

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm run test:e2e update-status-error-details.spec.ts --project=electron-headless --workers=1
```

### CI follow-up

The previous full CI run had one unrelated failure in `skill-install-lock.test.ts` (concurrent lock acquisition, `ENOENT scandir`); 9,711 tests in that shard passed. Active PR #17118 already addresses that exact lock-release race. This PR does not touch skill-lock code. The final review follow-up only corrects the disclosure-state contract comment; current CI is pending.

## Review

Independent review found a same-state manual-error edge case; fixed it and added regression coverage. Final code review and elegance pass are clean.

## Agent skill upstream boundary

- [x] Not applicable; no skill-installer source or data changed.

## Checklist

- [x] Small, focused bug fix with ELI5 and before/after proof.
- [x] Self-review and independent review complete.
- [x] Cross-platform and folder-workspace impact considered: renderer-only logic, no paths, shortcuts, workspace assumptions, IPC, or remote execution changes.
- [x] Focused tests, full typecheck, changed-file lint/format, and Electron build pass. Full-repository lint/test and release packaging were not run.

