### PR TITLE
perf(native): avoid sanitizing snapshot values twice

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/SnapshotRendering.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/SnapshotRendering.swift
@@ -238,11 +238,10 @@ public enum SnapshotRenderHeuristics {
         if roleText == "heading", Int(value) != nil {
             return nil
         }
-        let clean = sanitize(value)
         if roleText == "text" || roleText == "text entry area" || roleText == "scroll bar" || roleText == "value indicator" {
-            return " \(clean)"
+            return " \(value)"
         }
-        return ", Value: \(clean)"
+        return ", Value: \(value)"
     }
 
     private static func markdownEscaped(_ value: String) -> String {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

The macOS accessibility snapshot formatter cleaned each displayed value twice. Reuse the value already cleaned by `clean` instead of scanning it for line breaks again.

## What Changed

Remove the second `sanitize(value)` in `SnapshotRenderHeuristics.formattedValueSegment`; interpolate the already-clean local value in both output branches. No API, ordering, I/O, cache, polling, permission, or screenshot behavior changes.

## Why

`clean(value)` already replaces LF and CR with spaces. Applying the same replacements again cannot change that immutable string. This removes two redundant Foundation replacement passes for each value that reaches formatting, without adding retained state or a fast-path threshold.

Optimized production-source measurements (`swiftc -O`, Apple Silicon macOS, nine counterbalanced before/after samples):

| Workload | Before median | After median | Reduction |
| --- | ---: | ---: | ---: |
| 12,000 `line` calls with a 560-character text-field value | 165.119 ms | 84.164 ms | 49.0% |
| 12,000 `line` calls cycling through mixed roles/actions/values | 70.324 ms | 61.867 ms | 12.0% |

These are formatter microbenchmarks using the actual production Swift file, not whole-app or AX collection latency claims. Unchanged action-only control measurements varied by approximately 0.7–6.3%, so smaller timing differences should be treated as noise.

## Linked Issue

Relates to #20206 (performance-audit tracking; does not close the umbrella issue).

## Visual Proof

N/A — no visual or interaction change. Before/after production drivers emitted byte-identical formatted results for 512 combinations of roles, actions, and values, including empty/nil/equal-to-name values, numeric headings, CR/LF, Unicode and combining characters, and duplicate actions. The serialized parity result was 102,603 bytes, SHA-256 `ca3cad6ef4cbb2d5a8ec430436e8b9e12cb80bcef64a85fcddd391e0d263c029`.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `ORCA_BACKGROUND_LAUNCH=1 swift test --filter SnapshotRenderingTests` from `native/computer-use-macos`: **19 tests passed**. Existing output contracts remain unchanged, so no permanent tests were added just to assert implementation shape.
- Compiled baseline and changed `SnapshotRendering.swift` with the same throwaway Swift driver using `swiftc -O`; compared complete output bytes and benchmark checksums before timing nine alternating-order samples.
- Baseline source commit: `341b13cf679892102d2db8bf74024ae963f1cdd1`. No upstream difference in this source was present on the inspected `origin/main`.

Minimal reproducible value benchmark: save this as `/tmp/main.swift`, compile it alongside the production `SnapshotRendering.swift` from each revision using `swiftc -O`, run each binary alternately nine times, and compare medians/checksums:

```swift
import Foundation
let node = SnapshotRenderNode(
    role: "AXTextField", title: "Name",
    value: String(repeating: "visible value ", count: 40)
)
var checksum = 0
let start = DispatchTime.now().uptimeNanoseconds
for index in 0..<12000 {
    checksum &+= SnapshotRenderHeuristics.line(index: index % 1200, node: node).utf8.count
}
print(Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000, checksum)
```

Expected checksum: `7056900`. Full audit/measurement evidence is retained for the coordinating reviewer; temporary benchmark scripts/binaries are not committed.

## AI Disclosure

Prepared with an AI coding agent under the requested performance audit; coordinator independent review completed; evidence is linked below.

## Review

Self-review checked optional-value and heading guards, exact output identity, immutable-string ownership, error behavior, and platform/execution boundaries. The public callsites and downstream rendering are untouched. Independent coordinator review completed; ready for review, not merged.

## Agent skill upstream boundary

- [x] Not applicable: no agent-skill installer source or metadata changes.

## Notes

Only the macOS native core formatter changed. Linux/Windows native implementations, SSH execution, folder/git workspace handling, mobile, and wire formats are untouched. No real AX desktop capture, Electron UI, SSH session, Linux/Windows runtime, or end-to-end latency measurement was performed. No windows were focused or revealed. Focused Swift compilation emitted an existing `CGWindowListCreateImage` deprecation warning in the unchanged executable source. No absolute zero-risk claim is made.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Project-wide gates, formatters, and linters intentionally not run under audit instructions; focused native compilation and rendering tests are the local evidence.

## Independent verification update

[Coordinator verification and limitations](https://github.com/stablyai/orca/pull/20271#issuecomment-5643951906). Earlier test/tooling statements describe author-time verification; this update records the subsequent independent checks. Coordinator rebuilt both production Swift versions, confirmed byte parity and reran all 19 focused native tests. CI remains separate; ready-for-review does not mean CI-green or merged.
