### PR TITLE
perf: encode skill Git tree sort keys once

### DIFF
--- a/src/main/skills/skill-git-tree-identity.ts
+++ b/src/main/skills/skill-git-tree-identity.ts
@@ -57,18 +57,18 @@ export function skillPackageGitTreeSha(entries: readonly SkillGitTreeFileEntry[]
       ...[...directory.directories].map(([name, child]) => ({
         mode: '40000',
         name,
+        sortKey: Buffer.from(`${name}/`),
         hash: hashDirectory(child)
       })),
       ...directory.files.map((file) => ({
         mode: file.executable ? '100755' : '100644',
         name: file.filename,
+        sortKey: Buffer.from(file.filename),
         hash: file.blobSha
       }))
     ].sort((left, right) => {
       // Git orders tree entries as raw bytes with directory names read as `name/`.
-      const leftName = left.mode === '40000' ? `${left.name}/` : left.name
-      const rightName = right.mode === '40000' ? `${right.name}/` : right.name
-      return Buffer.from(leftName).compare(Buffer.from(rightName))
+      return left.sortKey.compare(right.sortKey)
     })
     const body = Buffer.concat(
       children.map(({ mode, name, hash }) =>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Skill package checks encode each filename once when sorting a Git tree, instead of encoding it again for every comparison.

## What Changed

Prepare a UTF-8 Buffer sort key for each child entry. Directory keys still append `/`, and comparisons still use raw Buffer ordering. Tree serialization and hashing are unchanged.

## Why

Windows benchmark of the complete exported tree-identity function, median of 15 measured batches after five warmups, alternating original/modified order, 100 calls per batch:

| Files | Before | After |
| --- | ---: | ---: |
| 10 | 0.0121 ms | 0.0093 ms |
| 100 | 0.1068 ms | 0.0533 ms |
| 512 | 0.7212 ms | 0.2965 ms |

Synthetic CPU measurements exclude filesystem reads. This removes repeated encoding and Buffer allocation in the comparator; it does not claim faster Git execution.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — no visual or interaction change.

## Testing

- 15 tests passed, two skipped on Windows across tree identity and package identity.
- Existing real-Git test verifies nesting, executables, binary content and file-versus-directory sorting against `git write-tree`.
- Every shipped skill still matches its recorded manifest tree digest.
- 1,000 generated original/modified tree comparisons matched, including Unicode and directory ordering cases.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

No Git command changes, cache, persisted format or filesystem routing changes. The same byte-level identity applies to Windows, WSL and SSH-sourced package contents.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck, lint and formatting passed.
