### PR TITLE
perf(git): classify bulk discard paths once

### DIFF
--- a/src/main/git/source-control/discard-changes.ts
+++ b/src/main/git/source-control/discard-changes.ts
@@ -117,12 +117,12 @@ export async function bulkDiscardChanges(
     }
 
     const trackedPathSpecs = await listTrackedPathSpecs(worktreePath, filePaths, options)
-    const trackedPaths = filePaths.filter((filePath) =>
-      isTrackedPathSpec(filePath, trackedPathSpecs)
-    )
-    const untrackedPaths = filePaths.filter(
-      (filePath) => !isTrackedPathSpec(filePath, trackedPathSpecs)
-    )
+    const trackedPaths: string[] = []
+    const untrackedPaths: string[] = []
+    filePaths.forEach((filePath) => {
+      const targetPaths = isTrackedPathSpec(filePath, trackedPathSpecs) ? trackedPaths : untrackedPaths
+      targetPaths.push(filePath)
+    })
     await removeSafeUntrackedDiscardTargets(
       worktreePath,
       untrackedPaths,

--- a/src/main/git/source-control/discard-changes.ts
+++ b/src/main/git/source-control/discard-changes.ts
@@ -120,7 +120,9 @@ export async function bulkDiscardChanges(
     const trackedPaths: string[] = []
     const untrackedPaths: string[] = []
     filePaths.forEach((filePath) => {
-      const targetPaths = isTrackedPathSpec(filePath, trackedPathSpecs) ? trackedPaths : untrackedPaths
+      const targetPaths = isTrackedPathSpec(filePath, trackedPathSpecs)
+        ? trackedPaths
+        : untrackedPaths
       targetPaths.push(filePath)
     })
     await removeSafeUntrackedDiscardTargets(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

Bulk discard was asking the same tracked-or-untracked question twice for every selected path. Ask once and put the original path into the same ordered group.

## What Changed

Replace two `filter` passes in `bulkDiscardChanges` with one stable `forEach` partition. Keep `isTrackedPathSpec`, the two result arrays, original path strings, duplicates, validation, literal pathspec chunking, and Git command order unchanged. No cache, index, new asynchronous boundary, or provider request change.

## Why

The predicate normalizes the requested path and scans/normalizes tracked paths, so repeating it is costly for large selections. Production-code replay showed exactly half the predicate calls and tracked-path normalization visits:

| Selected / tracked paths | Predicate calls before → after | Tracked normalization visits before → after | Replay median before → after |
| --- | --- | --- | --- |
| 1 / 1 | 2 → 1 | 2 → 1 | 0.0093 → 0.0098 ms |
| 10 / 10 | 20 → 10 | 110 → 55 | 0.0865 → 0.0432 ms |
| 1,000 / 1,000 | 2,000 → 1,000 | 1,001,000 → 500,500 | 114.54 → 109.99 ms |
| 5,000 / 5,000 | 10,000 → 5,000 | 25,005,000 → 12,502,500 | 2,533.82 → 1,039.82 ms |

Timings are seven retained samples after three warm-up pairs, with alternating baseline/patched order, on macOS Node. They replay the actual transpiled production discard/pathspec code with synthetic Git/filesystem responses and injected native resolver shape/invalidation observation; they are **not** application or real-Git end-to-end latency. Concurrent audit activity makes timings noisy; deterministic operation counts are the stronger evidence. The one-path timing difference is below one microsecond. Complexity remains O(selected × tracked); this removes duplicate work, not the underlying scan.

## Linked Issue

User-requested repository performance audit; no separate issue was filed. Related historical PR #3743 fixed the large-array spread limit and is not duplicated here. Existing discard-from-index proposals (#16440, #5880) change behavior; this PR deliberately retains current HEAD/index semantics.

## Visual Proof

N/A — main-process redundant computation only; no rendering or interaction change.

## Testing

- [ ] Interactive manual testing not performed; scripted production-code and real-Git smoke below
- [x] Automated tests added/updated, or explained why not below

Production-code baseline/patched replay: **111 equivalence cases** plus concurrent-call isolation. Compared complete ordered Git argv/options, filesystem validation traces, errors and cache invalidations; included mixed paths, duplicate paths, directory-prefix boundaries, Unicode/composed-decomposed strings, literal glob characters, WSL relative separators, empty/sparse inputs, failed `ls-files`/`restore`/`clean`, and escape rejection. Every applicable replay halves predicate calls.

Disposable real repositories with **macOS Git 2.55.0**: identical baseline/patched ordered argv, status, index and filesystem outcomes. Checked tracked restoration, untracked removal, duplicate and directory paths, Unicode, literal `[ab].txt`, unchanged staged index and unselected files, symlink-parent escape rejecting all mutation, and symlink-leaf removal without target deletion. Temporary repositories/scripts removed after verification; detailed JSON retained outside the repository.

Existing tests run once, **5 files / 31 tests passed**:

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts \
  src/main/git/status-discard-and-bulk-staging.test.ts \
  src/main/git/status-discard-symlink.test.ts \
  src/main/git/status-wsl-pathspecs.test.ts \
  src/main/git/source-control/wsl-tracked-pathspec-banner.test.ts \
  src/main/git/source-control/bulk-pathspec-command-line-budget.test.ts \
  --maxWorkers 1 --no-file-parallelism
```

No permanent test added: existing destructive-path regressions remain valid; extra comparison/measurement cases were throwaway production-code smoke evidence rather than another maintained suite.

**Limitations:** no live Windows, Linux, WSL or SSH run; WSL coverage above is mocked existing regression coverage. No Electron launch. No project-wide build/typecheck/lint/formatter/suite per audit instructions; commit hooks disabled for that same scope restriction. pnpm automatically installed missing worktree dependencies and ran its normal native postinstall setup before the targeted suite. Relay has a separate implementation, forwarded to its owner and not changed here.

## AI Disclosure

Prepared with Oh My Pi coding assistance and three independent read-only category audits; coordinator review completed; evidence is linked below.

## Review

The operation is destructive: a classification bug could be serious. This deliberately keeps the predicate and all safety checks unchanged, including validation before tracked mutation and the fresh second validation before clean. Same API, host routing, auth context, error handling, command order, and wire payloads. Evidence supports this narrow transformation; it is not an absolute zero-risk claim.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill source copied or translated.

## Notes

Three independent audits accounted for the exclusive 793-file category inventory (456 runtime sources, 329 tests, 8 support files; no missing/data/asset entries). Broad pattern screening is not an exhaustive semantic review of every line. Only the measured candidate is retained; no unrelated parser, cache, scheduling, or provider changes included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full lint/typecheck/test/build not run locally; targeted verification above only

## Independent verification update

[Coordinator verification and limitations](https://github.com/stablyai/orca/pull/20274#issuecomment-5644171504). Earlier test/tooling statements describe author-time verification; this update records the subsequent independent checks. Coordinator reran the focused tests and relevant TypeScript typecheck, and completed changed-file lint/format verification. CI remains separate; ready-for-review does not mean CI-green or merged.
