### PR TITLE
perf: index Hermes session correlation instead of rescanning history

### DIFF
--- a/config/scripts/hermes-run-correlation-benchmark.mjs
+++ b/config/scripts/hermes-run-correlation-benchmark.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { readFile, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, basename } from 'node:path'
+import { createRequire } from 'node:module'
+import { fileURLToPath } from 'node:url'
+import { build } from 'esbuild'
+
+const root = fileURLToPath(new URL('../..', import.meta.url))
+const fixture = await mkdtemp(join(tmpdir(), 'orca-hermes-correlation-'))
+const baselineDirectory = process.argv[2]
+const key = (seconds) =>
+  new Date(Date.UTC(2026, 0, 1) + seconds * 1000)
+    .toISOString()
+    .replace(/[-:]/g, '')
+    .replace('T', '_')
+    .slice(0, 15)
+try {
+  for (const host of ['native', 'relay']) {
+    const entry =
+      host === 'native'
+        ? 'src/main/automations/hermes-cron-run-content.ts'
+        : 'src/relay/hermes-run-correlation.ts'
+    const readers = []
+    for (const mode of baselineDirectory ? ['baseline', 'current'] : ['current']) {
+      const bundle = join(fixture, `${host}-${mode}.cjs`)
+      await build({
+        entryPoints: [join(root, entry)],
+        bundle: true,
+        platform: 'node',
+        format: 'cjs',
+        outfile: bundle,
+        plugins:
+          mode === 'baseline'
+            ? [
+                {
+                  name: 'baseline-correlation',
+                  setup(builder) {
+                    builder.onLoad(
+                      { filter: /hermes-(cron-run-content|run-correlation)\.ts$/ },
+                      async (args) => ({
+                        contents: await readFile(
+                          join(baselineDirectory, basename(args.path)),
+                          'utf8'
+                        ),
+                        loader: 'ts'
+                      })
+                    )
+                  }
+                }
+              ]
+            : []
+      })
+      readers.push({ mode, ...createRequire(import.meta.url)(bundle) })
+    }
+    if (readers.length === 2) {
+      let seed = 92817
+      const random = (max) => {
+        seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+        return seed % max
+      }
+      const pool = [
+        null,
+        '',
+        'invalid',
+        '20260101_000000',
+        '20260101_000200',
+        '20260102_000000',
+        '20260103_000000',
+        '20260101_240000'
+      ]
+      for (let trial = 0; trial < 200; trial++) {
+        const sessions = Array.from({ length: random(70) }, (_, i) => ({
+          kind: 'session',
+          id: `session-${i}`,
+          job_id: 'job',
+          run_at: null,
+          run_key: pool[random(pool.length)],
+          output_content: `session ${i}`
+        }))
+        const outputs = Array.from({ length: random(70) }, (_, i) => ({
+          kind: 'output',
+          id: `output-${i}`,
+          job_id: 'job',
+          run_at: null,
+          run_key: pool[random(pool.length)],
+          output_path: 'unused',
+          output_content: `output ${i}`
+        }))
+        for (const method of [
+          'mergeHermesOutputAndSessionRunRefs',
+          'mergeHermesOutputAndSessionRuns'
+        ]) {
+          assert.deepEqual(
+            readers[1][method](outputs, sessions),
+            readers[0][method](outputs, sessions)
+          )
+        }
+      }
+      console.log(JSON.stringify({ host, randomizedParityCases: 400 }))
+    }
+    for (const runs of [100, 1000, 5000]) {
+      const sessions = Array.from({ length: runs }, (_, i) => ({
+        kind: 'session',
+        id: `session-${i}`,
+        job_id: 'job',
+        run_at: null,
+        run_key: key(i * 3600)
+      })).toReversed()
+      const outputs = Array.from({ length: runs }, (_, i) => ({
+        kind: 'output',
+        id: `output-${i}`,
+        job_id: 'job',
+        run_at: null,
+        run_key: key(i * 3600 + 120),
+        output_path: 'unused'
+      }))
+      let expected
+      for (const reader of [...readers, ...readers.toReversed()]) {
+        const start = performance.now()
+        const result = reader.mergeHermesOutputAndSessionRunRefs(outputs, sessions)
+        const durationMs = performance.now() - start
+        assert.equal(result.length, runs)
+        result.forEach((row, i) => assert.equal(row.session.id, `session-${i}`))
+        if (expected) {
+          assert.deepEqual(result, expected)
+        }
+        expected = result
+        console.log(JSON.stringify({ host, mode: reader.mode, runs, durationMs }))
+      }
+    }
+  }
+} finally {
+  await rm(fixture, { recursive: true, force: true })
+}

--- a/src/main/automations/hermes-cron-run-content.ts
+++ b/src/main/automations/hermes-cron-run-content.ts
@@ -1,3 +1,4 @@
+import { HermesSessionRunIndex } from '../../shared/hermes-session-run-index'
 import { open, readFile, realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
@@ -152,59 +153,21 @@ function mergeOutputAndSessionContent(
   return `${outputContent}\n\n---\n\n${FULL_SESSION_LOG_HEADING}\n\n${sessionContent}`
 }
 
-function findMatchingSessionRunIndex(
-  outputRun: unknown,
-  sessionRuns: unknown[],
-  usedSessionRunIndexes: Set<number>
-): number | null {
-  const outputRunKey = getRunKey(outputRun)
-  const exactMatchIndex = sessionRuns.findIndex(
-    (sessionRun, index) =>
-      !usedSessionRunIndexes.has(index) && getRunKey(sessionRun) === outputRunKey
-  )
-  if (exactMatchIndex !== -1) {
-    return exactMatchIndex
-  }
-
-  const outputTime = sortableTimeFromRunKey(outputRunKey)
-  if (!Number.isFinite(outputTime)) {
-    return null
-  }
-
-  let bestIndex: number | null = null
-  let bestGap = Number.POSITIVE_INFINITY
-  for (let index = 0; index < sessionRuns.length; index += 1) {
-    if (usedSessionRunIndexes.has(index)) {
-      continue
-    }
-    const sessionTime = sortableTimeFromRunKey(getRunKey(sessionRuns[index]))
-    if (!Number.isFinite(sessionTime)) {
-      continue
-    }
-    const gap = outputTime - sessionTime
-    if (gap < 0 || gap > MAX_SESSION_OUTPUT_GAP_MS || gap >= bestGap) {
-      continue
-    }
-    bestIndex = index
-    bestGap = gap
-  }
-  return bestIndex
-}
-
 export function mergeHermesOutputAndSessionRuns(
   outputRuns: unknown[],
   sessionRuns: unknown[]
 ): unknown[] {
-  const usedSessionRunIndexes = new Set<number>()
+  const sessionIndex = new HermesSessionRunIndex(
+    outputRuns.length > 0 ? sessionRuns.map(getRunKey) : [],
+    sortableTimeFromRunKey,
+    MAX_SESSION_OUTPUT_GAP_MS
+  )
+  const usedSessionRunIndexes = sessionIndex.used
   const mergedOutputRuns = outputRuns.map((outputRun) => {
     if (!isRecord(outputRun)) {
       return outputRun
     }
-    const sessionRunIndex = findMatchingSessionRunIndex(
-      outputRun,
-      sessionRuns,
-      usedSessionRunIndexes
-    )
+    const sessionRunIndex = sessionIndex.find(getRunKey(outputRun))
     if (sessionRunIndex === null) {
       return outputRun
     }
@@ -212,7 +175,7 @@ export function mergeHermesOutputAndSessionRuns(
     if (!isRecord(sessionRun)) {
       return outputRun
     }
-    usedSessionRunIndexes.add(sessionRunIndex)
+    sessionIndex.use(sessionRunIndex)
     // Hermes writes the markdown output at completion, while state.db keeps
     // the actual turn-by-turn transcript under the cron session start time.
     return {
@@ -234,16 +197,17 @@ export function mergeHermesOutputAndSessionRunRefs(
   outputRefs: HermesOutputRunRef[],
   sessionRefs: HermesSessionRunRef[]
 ): HermesMergedRunRef[] {
-  const usedSessionRunIndexes = new Set<number>()
+  const sessionIndex = new HermesSessionRunIndex(
+    outputRefs.length > 0 ? sessionRefs.map(getRunKey) : [],
+    sortableTimeFromRunKey,
+    MAX_SESSION_OUTPUT_GAP_MS
+  )
+  const usedSessionRunIndexes = sessionIndex.used
   const mergedOutputRefs = outputRefs.map((outputRef) => {
-    const sessionRunIndex = findMatchingSessionRunIndex(
-      outputRef,
-      sessionRefs,
-      usedSessionRunIndexes
-    )
+    const sessionRunIndex = sessionIndex.find(getRunKey(outputRef))
     const sessionRef = sessionRunIndex === null ? null : sessionRefs[sessionRunIndex]
     if (sessionRunIndex !== null) {
-      usedSessionRunIndexes.add(sessionRunIndex)
+      sessionIndex.use(sessionRunIndex)
     }
     return {
       id: outputRef.id,

--- a/src/relay/hermes-run-correlation.ts
+++ b/src/relay/hermes-run-correlation.ts
@@ -1,3 +1,4 @@
+import { HermesSessionRunIndex } from '../shared/hermes-session-run-index'
 const HERMES_RUN_KEY_PATTERN = /^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})$/
 const MAX_SESSION_OUTPUT_GAP_MS = 24 * 60 * 60 * 1000
 const FULL_SESSION_LOG_HEADING = '## Full session log'
@@ -67,43 +68,6 @@ function sortableTimeFromRunKey(runKey: string | null): number {
   )
 }
 
-function findMatchingSessionRunIndex(
-  outputRun: unknown,
-  sessionRuns: unknown[],
-  usedSessionRunIndexes: Set<number>
-): number | null {
-  const outputRunKey = getRunKey(outputRun)
-  const exactMatchIndex = sessionRuns.findIndex(
-    (sessionRun, index) =>
-      !usedSessionRunIndexes.has(index) && getRunKey(sessionRun) === outputRunKey
-  )
-  if (exactMatchIndex !== -1) {
-    return exactMatchIndex
-  }
-  const outputTime = sortableTimeFromRunKey(outputRunKey)
-  if (!Number.isFinite(outputTime)) {
-    return null
-  }
-  let bestIndex: number | null = null
-  let bestGap = Number.POSITIVE_INFINITY
-  for (let index = 0; index < sessionRuns.length; index += 1) {
-    if (usedSessionRunIndexes.has(index)) {
-      continue
-    }
-    const sessionTime = sortableTimeFromRunKey(getRunKey(sessionRuns[index]))
-    if (!Number.isFinite(sessionTime)) {
-      continue
-    }
-    const gap = outputTime - sessionTime
-    if (gap < 0 || gap > MAX_SESSION_OUTPUT_GAP_MS || gap >= bestGap) {
-      continue
-    }
-    bestIndex = index
-    bestGap = gap
-  }
-  return bestIndex
-}
-
 function mergeOutputAndSessionContent(
   outputContent: string | null,
   sessionContent: string | null
@@ -124,16 +88,17 @@ export function mergeHermesOutputAndSessionRuns(
   outputRuns: unknown[],
   sessionRuns: unknown[]
 ): unknown[] {
-  const usedSessionRunIndexes = new Set<number>()
+  const sessionIndex = new HermesSessionRunIndex(
+    outputRuns.length > 0 ? sessionRuns.map(getRunKey) : [],
+    sortableTimeFromRunKey,
+    MAX_SESSION_OUTPUT_GAP_MS
+  )
+  const usedSessionRunIndexes = sessionIndex.used
   const mergedOutputRuns = outputRuns.map((outputRun) => {
     if (!isRecord(outputRun)) {
       return outputRun
     }
-    const sessionRunIndex = findMatchingSessionRunIndex(
-      outputRun,
-      sessionRuns,
-      usedSessionRunIndexes
-    )
+    const sessionRunIndex = sessionIndex.find(getRunKey(outputRun))
     if (sessionRunIndex === null) {
       return outputRun
     }
@@ -141,7 +106,7 @@ export function mergeHermesOutputAndSessionRuns(
     if (!isRecord(sessionRun)) {
       return outputRun
     }
-    usedSessionRunIndexes.add(sessionRunIndex)
+    sessionIndex.use(sessionRunIndex)
     return {
       ...outputRun,
       output_preview: getRunOutputPreview(outputRun) ?? getRunOutputPreview(sessionRun),
@@ -161,16 +126,17 @@ export function mergeHermesOutputAndSessionRunRefs(
   outputRefs: HermesOutputRunRef[],
   sessionRefs: HermesSessionRunRef[]
 ): HermesMergedRunRef[] {
-  const usedSessionRunIndexes = new Set<number>()
+  const sessionIndex = new HermesSessionRunIndex(
+    outputRefs.length > 0 ? sessionRefs.map(getRunKey) : [],
+    sortableTimeFromRunKey,
+    MAX_SESSION_OUTPUT_GAP_MS
+  )
+  const usedSessionRunIndexes = sessionIndex.used
   const mergedOutputRefs = outputRefs.map((outputRef) => {
-    const sessionRunIndex = findMatchingSessionRunIndex(
-      outputRef,
-      sessionRefs,
-      usedSessionRunIndexes
-    )
+    const sessionRunIndex = sessionIndex.find(getRunKey(outputRef))
     const sessionRef = sessionRunIndex === null ? null : sessionRefs[sessionRunIndex]
     if (sessionRunIndex !== null) {
-      usedSessionRunIndexes.add(sessionRunIndex)
+      sessionIndex.use(sessionRunIndex)
     }
     return {
       id: outputRef.id,

--- a/src/shared/hermes-session-run-index.test.ts
+++ b/src/shared/hermes-session-run-index.test.ts
@@ -1,0 +1,72 @@
+import { expect, it, vi } from 'vitest'
+import { HermesSessionRunIndex } from './hermes-session-run-index'
+
+const time = (key: string | null): number =>
+  key === null || key === 'invalid' ? Number.NaN : Number(key)
+
+function legacyMatch(
+  keys: (string | null)[],
+  used: Set<number>,
+  key: string | null
+): number | null {
+  const exact = keys.findIndex((candidate, index) => !used.has(index) && candidate === key)
+  if (exact !== -1) {
+    return exact
+  }
+  const outputTime = time(key)
+  if (!Number.isFinite(outputTime)) {
+    return null
+  }
+  let best: number | null = null
+  let bestGap = Infinity
+  keys.forEach((candidate, index) => {
+    const gap = outputTime - time(candidate)
+    if (!used.has(index) && Number.isFinite(gap) && gap >= 0 && gap <= 24 && gap < bestGap) {
+      best = index
+      bestGap = gap
+    }
+  })
+  return best
+}
+
+it('preserves exact, null, invalid, duplicate-time, source-order, and maximum-gap matching', () => {
+  let seed = 70291
+  const random = (max: number): number => {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+    return seed % max
+  }
+  const pool = [null, 'invalid', '-1', '0', '00', '1', '2', '24', '25', '26', '50']
+  for (let trial = 0; trial < 500; trial++) {
+    const keys = Array.from({ length: random(60) }, () => pool[random(pool.length)])
+    const index = new HermesSessionRunIndex(keys, time, 24)
+    const used = new Set<number>()
+    for (let query = 0; query < 80; query++) {
+      const key = pool[random(pool.length)]
+      const expected = legacyMatch(keys, used, key)
+      expect(index.find(key)).toBe(expected)
+      // Invalid source rows can decline a match; find must leave it available.
+      if (expected !== null && random(4) !== 0) {
+        used.add(expected)
+        index.use(expected)
+      }
+    }
+    expect(index.used).toEqual(used)
+  }
+})
+
+it('parses each session timestamp once across a long run history', () => {
+  const parse = vi.fn(time)
+  const count = 5000
+  const index = new HermesSessionRunIndex(
+    Array.from({ length: count }, (_, i) => String(i * 60)),
+    parse,
+    24
+  )
+  for (let i = count - 1; i >= 0; i--) {
+    const match = index.find(String(i * 60 + 2))
+    expect(match).toBe(i)
+    index.use(match!)
+  }
+  expect(parse).toHaveBeenCalledTimes(count * 2)
+  expect(index.find('9999999')).toBeNull()
+})

--- a/src/shared/hermes-session-run-index.ts
+++ b/src/shared/hermes-session-run-index.ts
@@ -1,0 +1,85 @@
+/** Exact keys win; otherwise select the nearest unused earlier session, with source-order ties. */
+export class HermesSessionRunIndex {
+  readonly used = new Set<number>()
+  private readonly exact = new Map<string | null, { indices: number[]; cursor: number }>()
+  private readonly timed: { time: number; index: number }[] = []
+  private readonly positionByIndex = new Map<number, number>()
+  private readonly predecessors: number[]
+
+  constructor(
+    keys: (string | null)[],
+    private readonly parseTime: (key: string | null) => number,
+    private readonly maxGapMs: number
+  ) {
+    keys.forEach((key, index) => {
+      let group = this.exact.get(key)
+      if (!group) {
+        group = { indices: [], cursor: 0 }
+        this.exact.set(key, group)
+      }
+      group.indices.push(index)
+      const time = parseTime(key)
+      if (Number.isFinite(time)) {
+        this.timed.push({ time, index })
+      }
+    })
+    // The rightmost equal-time row must be the first row in source order.
+    this.timed.sort((a, b) => a.time - b.time || b.index - a.index)
+    this.timed.forEach((row, position) => this.positionByIndex.set(row.index, position + 1))
+    // Zero is the sentinel before the first row; consumed rows link to their predecessor.
+    this.predecessors = Array.from({ length: this.timed.length + 1 }, (_, position) => position)
+  }
+
+  find(key: string | null): number | null {
+    const group = this.exact.get(key)
+    if (group) {
+      while (group.cursor < group.indices.length && this.used.has(group.indices[group.cursor])) {
+        group.cursor++
+      }
+      if (group.cursor < group.indices.length) {
+        return group.indices[group.cursor]
+      }
+    }
+    const time = this.parseTime(key)
+    if (!Number.isFinite(time)) {
+      return null
+    }
+    let low = 0
+    let high = this.timed.length
+    while (low < high) {
+      const mid = low + Math.floor((high - low) / 2)
+      if (this.timed[mid].time <= time) {
+        low = mid + 1
+      } else {
+        high = mid
+      }
+    }
+    const position = this.findPredecessor(low)
+    if (position === 0) {
+      return null
+    }
+    const candidate = this.timed[position - 1]
+    return time - candidate.time <= this.maxGapMs ? candidate.index : null
+  }
+
+  use(index: number): void {
+    this.used.add(index)
+    const position = this.positionByIndex.get(index)
+    if (position !== undefined) {
+      this.predecessors[position] = this.findPredecessor(position - 1)
+    }
+  }
+
+  private findPredecessor(position: number): number {
+    let root = position
+    while (this.predecessors[root] !== root) {
+      root = this.predecessors[root]
+    }
+    while (this.predecessors[position] !== position) {
+      const next = this.predecessors[position]
+      this.predecessors[position] = root
+      position = next
+    }
+    return root
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​255 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​104 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 |

<!-- /orca-pr-loc -->

Opening Hermes history correlates all output files with session refs before pagination, including for badge counts. The old matcher rescanned and reparsed the session list for every output. A fixture with 5,000 hourly runs (about seven months), each output two minutes after its session, took **5,865 ms native / 6,221 ms relay** in an initial paired measurement; the indexed matcher took **7.4 ms / 11.9 ms**, with identical returned objects.

Both native and relay readers now use one shared index. Exact-key queues preserve first-unused matching (including null/invalid keys); a sorted timestamp index with removable predecessor links preserves nearest-earlier matching, source-order ties, and the 24-hour limit. Selection and consumption remain separate, so a rejected source row stays available. Output/session ordering and merged content are unchanged. Session-only histories skip session indexing.

Validation:
- 19 focused tests passed across the index, native reader, relay history, and relay correlation.
- 500 deterministic randomized index scenarios / 40,000 queries match a reference implementation, including duplicates, equivalent timestamps, null/invalid keys, declined matches, and gap boundaries.
- The benchmark compared both ref and full-content pipelines against extracted baseline source in 800 randomized cases; all objects matched exactly.
- A deterministic count test limits timestamp parsing to one per session plus one per non-exact output.
- Node typecheck, changed-code quality, and commit lint/format checks passed.

Reproduce current timings: `ORCA_BACKGROUND_LAUNCH=1 node config/scripts/hermes-run-correlation-benchmark.mjs`. For AB/BA timing and old/new randomized parity, pass a directory containing `hermes-run-correlation.ts` and `hermes-cron-run-content.ts` from baseline commit `20ab99506541`. Under heavier contention the AB/BA 5,000-run baseline samples were 14–17 seconds; current samples were 4.4–60.9 ms. These are production-function timings with synthetic refs, not end-to-end disk, network, or UI measurements.

No wire fields, host ownership, file I/O, database queries, or UI changed. Actual SSH and Windows/Linux execution were not exercised. The index adds linear temporary metadata storage in exchange for removing quadratic scans. This PR is independent of #20265 (summary/detail loading).

Memory validation at exact head: the temporary index used 0.40 MiB at 1,000 sessions, 2.06 MiB at 5,000, and 37.88 MiB at 100,000. All four production native/relay full/ref merge paths completed 30 refreshes each with 100,000 output and session rows under a 512 MiB V8 heap cap, with no OOM and 0.001–0.009 MiB post-GC drift. Whole-process peak RSS was about 280 MiB, including fixtures and results. The index is local to each merge; no persistent cache or transcript copies are retained. This supports low memory risk for measured histories, not an arbitrary-size OOM guarantee.
