### PR TITLE
perf: skip decoding discarded diagnostic error bodies

### DIFF
--- a/src/main/observability/diagnostic-upload-http.test.ts
+++ b/src/main/observability/diagnostic-upload-http.test.ts
@@ -23,6 +23,22 @@ class FakeResponse extends EventEmitter {
 }
 
 describe('diagnostic upload HTTP', () => {
+  it('reports only the status for an error response with an invalid JSON body', async () => {
+    const request = new FakeRequest()
+    const response = new FakeResponse()
+    response.statusCode = 503
+    httpRequestMock.mockImplementationOnce((_options, callback) => {
+      callback(response)
+      return request
+    })
+    const result = postJsonForJson('http://diagnostics.example/upload', {}, 1000)
+    response.emit('data', Buffer.from('private backend details: not JSON'))
+    response.emit('end')
+    await expect(result).rejects.toThrow(/^HTTP 503$/)
+    expect(response.listenerCount('data')).toBe(0)
+    expect(request.listenerCount('error')).toBe(0)
+  })
+
   it('removes request and response listeners after a successful response', async () => {
     const request = new FakeRequest()
     const response = new FakeResponse()

--- a/src/main/observability/diagnostic-upload-http.ts
+++ b/src/main/observability/diagnostic-upload-http.ts
@@ -89,8 +89,8 @@ function postRaw(
     }
     function onResponseEnd(): void {
       const status = res?.statusCode ?? 0
-      const text = Buffer.concat(chunks).toString('utf8')
       if (status >= 200 && status < 300) {
+        const text = Buffer.concat(chunks).toString('utf8')
         try {
           resolveOnce(text.length > 0 ? JSON.parse(text) : {})
         } catch {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Failed diagnostic requests no longer copy and decode a response body that will be discarded.

## What Changed

Concatenate and UTF-8 decode the response only for a successful HTTP status. Non-2xx responses retain the same status-only error. Response draining, byte limits, timeout behavior and listener cleanup are unchanged.

## Why

Real localhost HTTP benchmark on Windows, complete exported request function receiving HTTP 503, median of 20 measured requests after five warmups, alternating original/modified order:

| Error response | Before | After |
| --- | ---: | ---: |
| 1 KB | 0.196 ms | 0.201 ms |
| 1 MB | 1.428 ms | 1.044 ms |

Small responses are effectively unchanged; large discarded bodies avoid a Buffer copy and string allocation. Localhost measurements exclude internet latency and do not claim a faster upload.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — same success results and user-facing errors.

## Testing

- Three HTTP tests passed: successful parsing/cleanup, oversized rejection/cleanup, and status-only errors for invalid JSON bodies.
- Real HTTP benchmark verified the same error for both implementations and response sizes.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

No protocol, payload, privacy, SSH routing or folder-workspace behavior changes. The existing one-megabyte cap still applies to unsuccessful responses.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck, lint and formatting passed.
