### PR TITLE
perf: avoid flattening tabs for smart-sort liveness check

### DIFF
--- a/src/renderer/src/components/sidebar/smart-sort.ts
+++ b/src/renderer/src/components/sidebar/smart-sort.ts
@@ -188,9 +188,9 @@ export function sortWorktreesSmart(
   // Why: `tabHasLivePty` (over `ptyIdsByTabId`) is the source of truth for
   // liveness — slept terminals retain `tab.ptyId` as a wake hint, so reading
   // it directly would falsely keep cold-start ordering off after restart.
-  const hasAnyLivePty = Object.values(tabsByWorktree)
-    .flat()
-    .some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
+  const hasAnyLivePty = Object.values(tabsByWorktree).some((tabs) =>
+    tabs.some((tab) => tabHasLivePty(ptyIdsByTabId, tab.id))
+  )
 
   const now = Date.now()
   const labels = buildWorktreeSortLabels(worktrees)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Smart sorting checks workspace tab lists directly instead of flattening all tabs into a temporary array first.

## What Changed

Use nested `some` calls for the existing live-PTY predicate. The scan still reads the live-PTY map, not persisted wake hints. Cold/warm ordering, attention calculation and comparators are unchanged.

## Why

Windows Node benchmark of the complete exported smart sorter, median of 15 batches after five warmups, alternating original/modified order, 30 calls per batch:

| Workspaces / tabs | Live PTY | Before | After |
| --- | --- | ---: | ---: |
| 100 / 1,000 | None | 0.0182 ms | 0.0084 ms |
| 100 / 1,000 | First tab | 0.0644 ms | 0.0596 ms |
| 1,000 / 10,000 | None | 0.8389 ms | 0.7778 ms |
| 1,000 / 10,000 | First tab | 1.7354 ms | 1.6631 ms |

This is a modest allocation/CPU improvement measured with synthetic state, not a rendered UI latency claim. Outputs matched in all benchmark cases.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — no rendered behavior or ordering change; pure data-processing edit.

## Testing

- All 35 smart-sort tests passed, covering cold/warm behavior and attention ordering.
- Renderer TypeScript check, targeted oxlint and formatting passed.

## Review

No status producer, cache, precedence, host routing or persisted state changes. Folder workspaces and SSH/WSL tabs use the existing live-PTY predicate and sorting rules.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck, lint and formatting passed.
