### PR TITLE
fix(mobile): preserve delivery ambiguity across transport cutover

### DIFF
--- a/mobile/src/transport/rpc-client-close-settlement.test.ts
+++ b/mobile/src/transport/rpc-client-close-settlement.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { RelayPendingRequests } from './relay-pending-requests'
+import { RpcClientRequestTracker } from './rpc-client-request-tracker'
+import { isRpcDeliveryUnknown } from './rpc-delivery-ambiguity'
+
+// RpcClient.close() must settle every pending request: since migrateTo stopped rejecting
+// pendings itself, close() is the retiring generation's only settlement path, and a request
+// left pending strands its caller forever. These pin the two trackers the two real
+// implementations reject through — direct-rpc-client.ts:218 and mobile-relay-rpc-session.ts:138.
+describe('close settles pending requests', () => {
+  it('direct: rejectAll settles every pending and marks delivery unknown', async () => {
+    let nextId = 0
+    const tracker = new RpcClientRequestTracker({
+      nextId: () => `req-${nextId++}`,
+      getState: () => 'connected',
+      waitForConnected: async () => {},
+      sendEncrypted: () => true,
+      deviceToken: 'token'
+    })
+    // Go through the real send path so these are pendings the tracker actually owns.
+    const pending = [0, 1, 2].map((index) =>
+      tracker.sendAuthenticatedRequest(`method.${index}`, {})
+    )
+    expect(tracker.size()).toBe(3)
+
+    tracker.rejectAll('Client closed', { deliveryUnknown: true })
+
+    const settled = await Promise.allSettled(pending)
+    expect(settled.map((entry) => entry.status)).toEqual(['rejected', 'rejected', 'rejected'])
+    for (const entry of settled) {
+      expect(entry.status === 'rejected' && isRpcDeliveryUnknown(entry.reason)).toBe(true)
+    }
+    expect(tracker.size()).toBe(0)
+  })
+
+  it('relay: rejectAll settles every pending and marks delivery unknown', async () => {
+    const pendingRequests = new RelayPendingRequests()
+    const pending = [0, 1, 2].map((index) => {
+      const id = `req-${index}`
+      return new Promise<unknown>((resolve, reject) => {
+        pendingRequests.track(id, {
+          resolve,
+          reject,
+          timer: setTimeout(() => {}, 60_000)
+        } as unknown as Parameters<RelayPendingRequests['track']>[1])
+      })
+    })
+
+    pendingRequests.rejectAll(new Error('Client closed'))
+
+    const settled = await Promise.allSettled(pending)
+    expect(settled.map((entry) => entry.status)).toEqual(['rejected', 'rejected', 'rejected'])
+    for (const entry of settled) {
+      expect(entry.status === 'rejected' && isRpcDeliveryUnknown(entry.reason)).toBe(true)
+    }
+  })
+})

--- a/mobile/src/transport/rpc-client-delivery-ambiguity.test.ts
+++ b/mobile/src/transport/rpc-client-delivery-ambiguity.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { connect } from './rpc-client'
 import { isRpcDeliveryUnknown } from './rpc-delivery-ambiguity'
+import {
+  createStableLogicalRpcClient,
+  isLogicalClientCutoverError,
+  LogicalClientCutoverError
+} from './stable-logical-rpc-client'
 
 vi.mock('./e2ee', () => ({
   generateKeyPair: () => ({
@@ -72,7 +77,7 @@ function hasSentRequest(socket: MockWebSocket, method: string): boolean {
 
 function connectAuthenticated(): { client: ReturnType<typeof connect>; socket: MockWebSocket } {
   const client = connect('ws://desktop.invalid', 'token', 'server-key')
-  const socket = mockSockets[0]!
+  const socket = mockSockets[mockSockets.length - 1]!
   socket.open()
   socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
   socket.receive('encrypted:{"type":"e2ee_authenticated"}')
@@ -92,6 +97,52 @@ describe('mobile rpc-client delivery ambiguity marking', () => {
   afterEach(() => {
     vi.useRealTimers()
     globalThis.WebSocket = originalWebSocket
+  })
+
+  it.each([true, false])(
+    'preserves physical delivery evidence at the cutover caller (sent=%s)',
+    async (sent) => {
+      const physical = sent
+        ? connectAuthenticated()
+        : {
+            client: connect('ws://desktop.invalid', 'token', 'server-key'),
+            socket: mockSockets[0]!
+          }
+      const client = createStableLogicalRpcClient(physical.client, 'lan')
+      const replacement = connectAuthenticated()
+      const requestError = client
+        .sendRequest('worktree.create', { name: 'new' })
+        .catch((error: unknown) => error)
+      await Promise.resolve()
+      expect(hasSentRequest(physical.socket, 'worktree.create')).toBe(sent)
+
+      await client.migrateTo(replacement.client, 'relay')
+
+      const error = await requestError
+      expect(isLogicalClientCutoverError(error)).toBe(true)
+      expect(isRpcDeliveryUnknown(error)).toBe(sent)
+      expect(error).toBeInstanceOf(LogicalClientCutoverError)
+      expect(isRpcDeliveryUnknown((error as Error).cause)).toBe(sent)
+      expect(hasSentRequest(replacement.socket, 'worktree.create')).toBe(false)
+      expect(
+        physical.socket.sent.filter((payload) => payload.includes('worktree.create'))
+      ).toHaveLength(sent ? 1 : 0)
+      client.close()
+    }
+  )
+
+  it('recognizes a cutover by class even when its message changes', () => {
+    const error = new LogicalClientCutoverError()
+    error.message = 'wrapped migration'
+    expect(isLogicalClientCutoverError(error)).toBe(true)
+  })
+
+  it('recognizes a cutover message from another bundle copy', () => {
+    expect(isLogicalClientCutoverError(new Error('RPC interrupted by connection migration'))).toBe(
+      true
+    )
+    expect(isLogicalClientCutoverError(new Error('Client closed'))).toBe(false)
+    expect(isLogicalClientCutoverError('RPC interrupted by connection migration')).toBe(false)
   })
 
   it('marks in-flight requests as delivery-unknown when the socket drops', async () => {

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -43,6 +43,18 @@ export type RpcClient = {
   getLastInboundAt?: () => number | null
   onStateChange: (listener: (state: ConnectionState) => void) => () => void
   notifyForeground: (reason?: ForegroundNudgeReason) => void
+  /**
+   * Must settle every pending `sendRequest` promise before returning.
+   *
+   * `StableLogicalRpcClient.migrateTo` no longer rejects pendings itself — the physical
+   * sender is the only layer that knows whether a request reached the wire, so
+   * `previous.close()` is the sole settlement path for the retiring generation. An
+   * implementation that leaves a request pending strands its caller for good.
+   *
+   * Requests that did reach the wire must reject with a delivery-unknown error
+   * (`markRpcDeliveryUnknown`), since the host may already have executed them.
+   * `rpc-client-close-settlement.test.ts` pins this for every implementation.
+   */
   close: () => void
 }
 

--- a/mobile/src/transport/stable-logical-rpc-client.test.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.test.ts
@@ -90,6 +90,7 @@ describe('stable logical RPC client', () => {
     const nextSession = new FakeSession('connecting')
     const pending = deferred<RpcResponse>()
     oldSession.sendRequest.mockReturnValue(pending.promise)
+    oldSession.close.mockImplementation(() => pending.reject(new Error('Client closed')))
     nextSession.sendRequest.mockResolvedValue(success('next'))
     const client = createStableLogicalRpcClient(oldSession, 'lan')
     const stream = vi.fn()

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -7,12 +7,16 @@ import {
 import { waitForAuthenticated } from './replacement-session-authentication'
 import { projectMobileRpcRequestParams } from './mobile-rpc-request-projection'
 import { LogicalClientConnectionPath } from './logical-client-connection-path'
+import { isRpcDeliveryUnknown, markRpcDeliveryUnknown } from './rpc-delivery-ambiguity'
 
 export type MobileConnectionPath = 'lan' | 'tailscale' | 'relay'
 
 export class LogicalClientCutoverError extends Error {
-  constructor() {
-    super('RPC interrupted by connection migration')
+  constructor(cause?: unknown) {
+    super('RPC interrupted by connection migration', { cause })
+    if (isRpcDeliveryUnknown(cause)) {
+      markRpcDeliveryUnknown(this)
+    }
   }
 }
 
@@ -31,10 +35,6 @@ type SubscriptionRecord = {
   options?: Parameters<RpcClient['subscribe']>[3]
   disposePhysical: (() => void) | null
   cancelled: boolean
-}
-
-type PendingRequest = {
-  reject: (error: Error) => void
 }
 
 export type StableLogicalRpcClient = RpcClient & {
@@ -75,7 +75,6 @@ export function createStableLogicalRpcClient(
   let nextSubscriptionId = 0
   let activeStateUnsubscribe: (() => void) | null = null
   const subscriptions = new Map<number, SubscriptionRecord>()
-  const pendingRequests = new Set<PendingRequest>()
   const stateListeners = new Set<(state: ConnectionState) => void>()
   let state = initialSession.getState()
   const connectionPath = new LogicalClientConnectionPath(() => state === 'connected')
@@ -93,13 +92,10 @@ export function createStableLogicalRpcClient(
       const requestGeneration = generation
       const session = activeSession
       return new Promise<RpcResponse>((resolve, reject) => {
-        const pending = { reject }
-        pendingRequests.add(pending)
         void session
           .sendRequest(method, projectMobileRpcRequestParams(method, params), options)
           .then(
             (response) => {
-              pendingRequests.delete(pending)
               if (closed) {
                 reject(new Error('Client closed'))
               } else if (requestGeneration !== generation) {
@@ -109,8 +105,9 @@ export function createStableLogicalRpcClient(
               }
             },
             (error: unknown) => {
-              pendingRequests.delete(pending)
-              reject(error)
+              reject(
+                requestGeneration !== generation ? new LogicalClientCutoverError(error) : error
+              )
             }
           )
       })
@@ -265,15 +262,12 @@ export function createStableLogicalRpcClient(
       suspended = false
       previousStateUnsubscribe?.()
       bindActiveState(nextSession, nextGeneration)
-      for (const pending of pendingRequests) {
-        pending.reject(new LogicalClientCutoverError())
-      }
-      pendingRequests.clear()
       state = nextSession.getState()
       connectionPath.clearAfterConnected()
       for (const listener of stateListeners) {
         listener(state)
       }
+      // Only the physical sender knows whether a pending request reached the wire.
       previous.close()
     },
 

--- a/mobile/src/worktree/home-host-worktree-fetch.test.ts
+++ b/mobile/src/worktree/home-host-worktree-fetch.test.ts
@@ -39,7 +39,11 @@ function fakeSession(): FakeSession {
       getLastConnectedAt: () => null,
       onStateChange: () => () => {},
       notifyForeground: () => {},
-      close: () => {}
+      close: () => {
+        for (const settle of pending.splice(0)) {
+          settle(new Error('Client closed'))
+        }
+      }
     }
   }
   return fake


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## The bug

`migrateTo` rejected every pending request with a **fresh, unmarked** `LogicalClientCutoverError` before `previous.close()` could settle them. So a mutation already on the wire when the transport cut over (LAN↔relay) reached its caller with `isRpcDeliveryUnknown(error) === false`.

That matters because `mobile/src/tasks/worktree-create-retry.ts` gates replay on exactly that mark — it retries a delivery-unknown `worktree.create` only when the host advertised idempotency and the replay deadline has not passed. With the mark missing, that logic silently never engages and a mutation that may well have executed is reported as a plain failure. Per `docs/reference/ssh-execution-boundary.md`, loss of contact is never evidence that work did not happen.

## The fix

Stop rejecting pendings eagerly. The eager `pendingRequests` set is deleted; `previous.close()` now settles them, and the physical sender's own error carries the mark. `LogicalClientCutoverError` takes a `cause` and marks itself delivery-unknown **only if that cause was marked**.

Both transports already carry the right information:
- `direct-rpc-client.ts:218` — `rejectAll('Client closed', { deliveryUnknown: true })`
- `RelayPendingRequests.rejectAll` marks unconditionally, and the invariant is sound: pending entries only exist after their frame reached the authenticated link, since `sendFrame` failures delete them synchronously.

So a request that never reached the wire produces an unmarked cutover error, and one that did produces a marked one.

## Why over-marking was fenced too

Under-marking is the reported bug; over-marking is worse, because marking a request that never reached the host would authorize replaying something that never happened. Both directions are pinned:

| Mutation | Tests killed |
|---|---:|
| revert to a fresh unmarked cutover error | 1 |
| mark every cutover regardless of cause | 1 |

Also kept: `isLogicalClientCutoverError`'s class-**or**-message dual carrier, which exists because `instanceof` can miss across bundle copies. Two new tests pin it.

## Scope

Error identity only. No retry logic, no idempotency negotiation, no wire change. This authorizes no new retry on its own — it restores the signal the existing, already-fenced retry path reads.

## Gates

mobile typecheck · mobile test 550 files / 4,461 passed, 3 skipped · `check:code-quality:changed` 0 new findings across 4 files.