### PR TITLE
test(rpc): add a compile-time params catalog parity gate

### DIFF
--- a/config/scripts/generate-rpc-params-catalog.mjs
+++ b/config/scripts/generate-rpc-params-catalog.mjs
@@ -51,7 +51,14 @@ function indexableModules() {
     const source = readFileSync(path.join(RPC_DIR, file), 'utf8')
     for (const [, specifier] of source.matchAll(/from\s+'(\.[^']+)'/g)) {
       const resolved = `${path.resolve(path.dirname(path.join(RPC_DIR, file)), specifier)}.ts`
-      if (resolved.startsWith(`${SHARED_DIR}${path.sep}`) && existsSync(resolved)) {
+      // Never re-add the generator's own output: a module under RPC_DIR may import the
+      // catalog for a type-only contract, and bundling a stale catalog makes regeneration
+      // crash in exactly the state that requires regenerating.
+      if (
+        resolved !== OUTPUT_PATH &&
+        resolved.startsWith(`${SHARED_DIR}${path.sep}`) &&
+        existsSync(resolved)
+      ) {
         modules.add(resolved)
       }
     }

--- a/src/main/runtime/rpc/rpc-params-type-parity.ts
+++ b/src/main/runtime/rpc/rpc-params-type-parity.ts
@@ -1,0 +1,42 @@
+import type {
+  RpcMethodName,
+  RpcParams
+} from '../../../shared/rpc-contract/rpc-params-catalog.generated'
+import type { RpcAnyMethodDeclaration } from './core'
+import type { ALL_RPC_METHODS } from './methods'
+
+type RegisteredMethod = (typeof ALL_RPC_METHODS)[number]
+
+// These schemas reach into src/main and have no shared catalog entry.
+type UncataloguedMethod = 'emulator.install' | 'orchestration.send' | 'orchestration.taskUpdate'
+
+type IsAny<T> = 0 extends 1 & T ? true : false
+
+type ParamsMatch<Host, Catalog> =
+  IsAny<Host> extends true
+    ? false
+    : IsAny<Catalog> extends true
+      ? false
+      : [Host] extends [Catalog]
+        ? [Catalog] extends [Host]
+          ? true
+          : false
+        : false
+
+// Distribute over declarations so each handler is checked, including streaming handlers.
+type MismatchedMethod<Method extends RpcAnyMethodDeclaration> =
+  Method extends RpcAnyMethodDeclaration
+    ? Method['name'] extends RpcMethodName
+      ? ParamsMatch<Parameters<Method['handler']>[0], RpcParams<Method['name']>> extends true
+        ? never
+        : Method['name']
+      : Exclude<Method['name'], UncataloguedMethod>
+    : never
+
+type AssertNever<T extends never> = T
+
+// Type-only gates belong in the node typecheck; runtime parsing is a separate contract.
+export type RpcParamsTypeParity = AssertNever<MismatchedMethod<RegisteredMethod>>
+export type RpcParamsUncataloguedMethods = AssertNever<
+  Exclude<UncataloguedMethod, Exclude<RegisteredMethod['name'], RpcMethodName>>
+>


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 |

<!-- /orca-pr-loc -->

## What

Asserts that `RpcParams<M>` from the generated catalog matches the parsed-params type of method `M`'s own `defineMethod` declaration, for every registered method.

The catalog maps method → schema **by object identity**, and a byte-comparison drift gate already catches regeneration changes. Neither checks that the resulting *types* agree with the host's. This closes that.

Cheap now because #20016 stopped erasing the parsed-params type from `defineMethod`.

## Not a rebuild of the gate we deleted

The previous runtime parity gate was removed for cause: 22,772 probes of which ~88% were vacuous (each set one field and omitted every required sibling, so both sides rejected them for the same unrelated reason), and it was red in CI because it resolved `mobile/node_modules/zod`, which the unit-test workflow never installs. This is type-level, runs inside the existing node typecheck, and adds no probes.

## Design

- Driven off `typeof ALL_RPC_METHODS`, so a newly registered method is covered with nothing to remember.
- **Mutual** assignability, not one direction — a one-way check misses a widening.
- An `IsAny` guard so `any` on either side **fails** rather than silently satisfying `extends` both ways. That is the usual way a gate like this rots.
- A second assertion keeps the uncatalogued allow-list from going stale: if one of those methods ever gains a catalog entry, the exclusion itself fails.

Three methods are excluded as uncatalogued (`emulator.install`, `orchestration.send`, `orchestration.taskUpdate`). Verified: they are the three already listed as omitted-by-design in the generated catalog, not silent drops.

## Evidence

Widening one catalog entry to `any` fails the node typecheck and **names the method**:

```
rpc-params-type-parity.ts(39,47): error TS2344: Type '"worktree.ps"' does not satisfy the constraint 'never'.
```

## What it does not catch

It is a type gate. It cannot prove runtime parse behaviour — identical types can still parse differently. The byte-comparison drift gate and the host's own `safeParse` path remain the runtime contract.

## Gates

`pnpm tc` · `typecheck:tsc` · `vitest run src/main/runtime/rpc` · `verify:rpc-params-catalog` · `check:code-quality:changed`.