### PR TITLE
fix(rpc): validate provider-specific fields in TaskProviderIdentity

### DIFF
--- a/docs/reference/task-provider-identity-validation.md
+++ b/docs/reference/task-provider-identity-validation.md
@@ -1,0 +1,78 @@
+# Task provider identity RPC validation
+
+The automation RPC identity schema follows `src/shared/task-provider-identity.ts`,
+re-exported by `src/shared/task-source-context.ts`. Only GitHub requires fields beyond
+`provider`: `owner` and `repo` are strings, and `host` is optional. GitLab, Linear,
+and Jira fields are optional nullable strings. Requiring a GitLab project or a
+Linear workspace/Jira site would contradict the domain type and account-wide scopes.
+
+The discriminated union validates these existing field types without trimming,
+coercing, or stripping identity fields. Unknown fields pass through as they did under
+`z.custom`, including fields from newer clients. Absent and explicit-null identities
+remain distinct. The schema does not infer providers from owner/repo or require a
+git worktree, repository slug, or local execution host for a source context.
+
+## Producer census
+
+Paths below are relative to the repository root. Searches covered production
+`providerIdentity`, `TaskProviderIdentity`, `sourceContext`, and
+`linkedTaskSourceContext` uses across desktop, shared code, mobile, and CLI.
+
+| Producer or forwarding path                                                                | Populated verdict                                                                                                                                                                                                            |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/shared/project-host-setup-projection.ts`: `getProjectProviderIdentity`                | GitHub owner/repo populated together, or no identity. Supplies project identities consumed by desktop and migration.                                                                                                         |
+| `src/renderer/src/components/task-page-source-context.tsx`: `getTaskPageRepoSourceContext` | GitHub fields populated through projection, or null. GitLab uses explicit provider and `buildGitLabProviderIdentity`; projectId/project/webUrl populated, namespace can be null.                                             |
+| Same file: `buildGitLabProviderIdentity`                                                   | GitLab fields come from project path/host; missing path components become null. No required GitLab field is invented.                                                                                                        |
+| `src/renderer/src/hooks/composer-state/source-context-state.ts`                            | Derived GitHub context carries a complete project identity or null. Jira folder/project-group context explicitly has null identity. Draft/linked contexts are forwarded.                                                     |
+| `src/renderer/src/components/use-task-page-source-availability.ts`                         | Linear workspaceId/name and Jira siteId/URL can be null for account-wide selections; team/project fields are not populated. Valid under the existing optional-field contract.                                                |
+| `src/renderer/src/components/task-page-jira-item-source-context.ts`                        | Bound issue context populates siteId, siteUrl, projectKey.                                                                                                                                                                   |
+| `src/renderer/src/components/new-workspace/use-jira-url-source.ts`                         | Bound URL issue context populates siteId, siteUrl, projectKey.                                                                                                                                                               |
+| `src/renderer/src/components/worktree-jump-palette-create-worktree.ts`                     | Linear teamId/key populated; workspaceId/name may be null.                                                                                                                                                                   |
+| `src/shared/task-source-context.ts`: normalize/build functions                             | GitHub missing owner/repo becomes null identity; other providers' missing fields become null. Provider mismatch becomes null, never an inferred provider.                                                                    |
+| `src/cli/handlers/automation-handler-flags.ts`, `src/cli/handlers/automations.ts`          | Explicit JSON source-context input is normalized before create/update. GitHub fields populated or null identity; other fields nullable. Omitted/null context preserved by flag handling.                                     |
+| `src/main/persistence/scheduling-automations/automation-context-migration.ts`              | Builds source context from projected complete GitHub identity, or null context.                                                                                                                                              |
+| Desktop automation save/scoped-list/host clients and web transport                         | Forward existing source contexts, not new identity constructors. `automation-orca-save.ts` forwards the current automation context or null. Legacy arbitrary malformed RPC input is deliberately rejected by the new schema. |
+| Mobile                                                                                     | No task-provider identity/source-context constructor or sender found. `mobile/src/components/new-workspace-project-targets.ts` uses project identity solely for display.                                                     |
+
+## Compatibility evidence and limits
+
+Read `docs/reference/remote-wire-compatibility.md` before changing validation.
+A source search against release tag `v1.4.199` also finds no mobile
+`sourceContext`/`linkedTaskSourceContext` sender; its sole `providerIdentity` use
+is the display-only project target above. The released CLI flag reader also calls
+`normalizeTaskSourceContext`. This is source-level evidence for the checked release,
+not a claim to have executed every historical mobile binary.
+
+No shipped mobile producer with a newly rejected payload was found. No new required
+field was added to the domain contract. GitLab, Linear, and Jira discriminant-only
+identities remain valid. Folder-workspace null/absent identities remain valid on
+both local and SSH hosts. No execution/status logic or client-side parsing changed.
+
+## Regression evidence
+
+`src/main/runtime/rpc/methods/task-provider-identity.test.ts` checks unchanged valid
+identities for all four providers, required GitHub fields, every declared field's
+type, optional/null non-GitHub fields, unknown-field preservation, explicit GitLab
+discrimination with owner/repo present, local/SSH folder contexts, and update patches.
+
+The focused run passed 74 tests. Temporarily replacing GitHub's field validators
+with optional `z.unknown()` validators (discriminant-only acceptance) caused 16
+failures and 58 passes. The mutation was restored before running the gates.
+
+## Gate results
+
+All commands ran with `ORCA_BACKGROUND_LAUNCH=1`.
+
+- `pnpm tc`: exit 0; completed the repository typecheck runner.
+- `pnpm exec vitest run src/main/runtime/rpc`: exit 1; 277 files passed,
+  one failed; 2,462 tests passed, one failed, one skipped. The only failure was
+  the unrelated `structured-agent-session-adoption-replay.test.ts` hitting its
+  5,000 ms timeout. All identity tests passed.
+- `pnpm --dir mobile typecheck`: exit 0; `tsc --noEmit` passed.
+- `pnpm run check:code-quality:changed`: exit 0; zero new code-quality,
+  type-aware, or React Doctor findings across the two changed code files.
+- Isolated retry of `structured-agent-session-adoption-replay.test.ts`: exit 0;
+  one test passed, with the test body completing in 358 ms.
+- Full RPC retry with `pnpm exec vitest run src/main/runtime/rpc --maxWorkers=4`:
+  exit 0; all 278 files passed, 2,463 tests passed, one skipped (97.24 seconds).
+  The bounded-concurrency rerun resolved the timeout without changing test code.

--- a/src/main/runtime/rpc/methods/task-provider-identity.test.ts
+++ b/src/main/runtime/rpc/methods/task-provider-identity.test.ts
@@ -108,3 +108,34 @@ describe('task provider identity RPC validation', () => {
     ).toBe(false)
   })
 })
+
+describe('github identity blank fields', () => {
+  // The normalizer treats a blank owner or repo as no identity, so the schema must agree.
+  it.each(['', '   ', '\t'])('rejects a blank owner %j', (owner) => {
+    expect(
+      TaskProviderIdentity.safeParse({ provider: 'github', owner, repo: 'orca' }).success
+    ).toBe(false)
+  })
+
+  it.each(['', '  '])('rejects a blank repo %j', (repo) => {
+    expect(
+      TaskProviderIdentity.safeParse({ provider: 'github', owner: 'stablyai', repo }).success
+    ).toBe(false)
+  })
+
+  it('still accepts a populated identity', () => {
+    expect(
+      TaskProviderIdentity.safeParse({ provider: 'github', owner: 'stablyai', repo: 'orca' })
+        .success
+    ).toBe(true)
+  })
+
+  it('leaves the parsed value untrimmed, so no wire bytes change', () => {
+    const parsed = TaskProviderIdentity.safeParse({
+      provider: 'github',
+      owner: ' stablyai ',
+      repo: 'orca'
+    })
+    expect(parsed.success && parsed.data?.owner).toBe(' stablyai ')
+  })
+})

--- a/src/main/runtime/rpc/methods/task-provider-identity.test.ts
+++ b/src/main/runtime/rpc/methods/task-provider-identity.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AutomationUpdate,
+  TaskProviderIdentity,
+  TaskSourceContext
+} from '../../../../shared/rpc-contract/automation-params'
+import type { TaskProviderIdentity as ProviderIdentity } from '../../../../shared/task-source-context'
+
+const identities = [
+  { provider: 'github', owner: 'Acme', repo: 'Orca', host: 'github.example.com' },
+  {
+    provider: 'gitlab',
+    projectId: '123',
+    namespace: 'acme/team',
+    project: 'orca',
+    webUrl: 'https://gitlab.example.com/acme/team/orca'
+  },
+  {
+    provider: 'linear',
+    workspaceId: 'workspace',
+    workspaceName: 'Acme',
+    teamId: 'team',
+    teamKey: 'ENG'
+  },
+  { provider: 'jira', siteId: 'site', siteUrl: 'https://acme.atlassian.net', projectKey: 'ENG' }
+] satisfies ProviderIdentity[]
+
+describe('task provider identity RPC validation', () => {
+  it.each(identities)('preserves valid $provider identities', (identity) => {
+    expect(TaskProviderIdentity.parse(identity)).toEqual(identity)
+  })
+
+  it.each(['owner', 'repo'])('requires the GitHub %s', (field) => {
+    const identity: Record<string, unknown> = { ...identities[0] }
+    delete identity[field]
+    expect(TaskProviderIdentity.safeParse(identity).success).toBe(false)
+    expect(TaskProviderIdentity.safeParse({ ...identity, [field]: null }).success).toBe(false)
+  })
+
+  for (const identity of identities) {
+    for (const field of Object.keys(identity).filter((key) => key !== 'provider')) {
+      it.each([42, false, [], {}])(
+        `rejects non-string ${identity.provider}.${field}: %j`,
+        (value) => {
+          expect(TaskProviderIdentity.safeParse({ ...identity, [field]: value }).success).toBe(
+            false
+          )
+        }
+      )
+    }
+  }
+
+  it.each(['gitlab', 'linear', 'jira'])('keeps %s fields optional and nullable', (provider) => {
+    expect(TaskProviderIdentity.parse({ provider })).toEqual({ provider })
+    const full = identities.find((identity) => identity.provider === provider)!
+    const nullable = Object.fromEntries(
+      Object.keys(full).map((key) => [key, key === 'provider' ? provider : null])
+    )
+    expect(TaskProviderIdentity.parse(nullable)).toEqual(nullable)
+  })
+
+  it('preserves unknown fields and never infers GitHub from owner/repo', () => {
+    const identity = { provider: 'gitlab', owner: 'acme', repo: 'orca', futureField: 'value' }
+    expect(TaskProviderIdentity.parse(identity)).toEqual(identity)
+  })
+
+  it.each([{}, { provider: 'github' }, { provider: 'unknown' }, [], 'github', 1])(
+    'rejects invalid identities: %j',
+    (identity) => {
+      expect(TaskProviderIdentity.safeParse(identity).success).toBe(false)
+    }
+  )
+
+  it('preserves absent and explicit-null identities in folder contexts on local and SSH hosts', () => {
+    expect(TaskProviderIdentity.parse(undefined)).toBeUndefined()
+    expect(TaskProviderIdentity.parse(null)).toBeNull()
+    for (const hostId of ['local', 'ssh:host']) {
+      const context = { kind: 'task-source', provider: 'github', projectId: 'folder', hostId }
+      expect(TaskSourceContext.parse(context)).not.toHaveProperty('providerIdentity')
+      expect(TaskSourceContext.parse({ ...context, providerIdentity: null })).toEqual({
+        ...context,
+        providerIdentity: null
+      })
+    }
+  })
+
+  it('validates identities in automation updates without collapsing absent and null patches', () => {
+    expect(AutomationUpdate.parse({ id: 'automation', updates: {} }).updates).not.toHaveProperty(
+      'sourceContext'
+    )
+    expect(
+      AutomationUpdate.parse({ id: 'automation', updates: { sourceContext: null } }).updates
+        .sourceContext
+    ).toBeNull()
+    expect(
+      AutomationUpdate.safeParse({
+        id: 'automation',
+        updates: {
+          sourceContext: {
+            kind: 'task-source',
+            provider: 'github',
+            projectId: 'project',
+            hostId: 'local',
+            providerIdentity: { provider: 'github' }
+          }
+        }
+      }).success
+    ).toBe(false)
+  })
+})

--- a/src/shared/rpc-contract/automation-params.ts
+++ b/src/shared/rpc-contract/automation-params.ts
@@ -14,7 +14,6 @@ import {
   MAX_AUTOMATION_PRECHECK_TIMEOUT_SECONDS,
   normalizeAutomationPrecheckTimeoutSeconds
 } from '../automation-precheck'
-import type { TaskProviderIdentity as SharedTaskProviderIdentity } from '../task-source-context'
 
 export const TuiAgent = requiredString('Missing provider').refine(isTuiAgent, {
   message: 'Unknown provider'
@@ -59,13 +58,42 @@ export const OptionalNullablePlainString = z
   .optional()
 
 export const TaskProviderIdentity = z
-  .custom<SharedTaskProviderIdentity>(
-    (value) =>
-      value !== null &&
-      typeof value === 'object' &&
-      'provider' in value &&
-      ['github', 'gitlab', 'linear', 'jira'].includes(String(value.provider))
-  )
+  .discriminatedUnion('provider', [
+    z
+      .object({
+        provider: z.literal('github'),
+        owner: z.string(),
+        repo: z.string(),
+        host: z.string().optional()
+      })
+      .passthrough(),
+    z
+      .object({
+        provider: z.literal('gitlab'),
+        projectId: z.string().nullable().optional(),
+        namespace: z.string().nullable().optional(),
+        project: z.string().nullable().optional(),
+        webUrl: z.string().nullable().optional()
+      })
+      .passthrough(),
+    z
+      .object({
+        provider: z.literal('linear'),
+        workspaceId: z.string().nullable().optional(),
+        workspaceName: z.string().nullable().optional(),
+        teamId: z.string().nullable().optional(),
+        teamKey: z.string().nullable().optional()
+      })
+      .passthrough(),
+    z
+      .object({
+        provider: z.literal('jira'),
+        siteId: z.string().nullable().optional(),
+        siteUrl: z.string().nullable().optional(),
+        projectKey: z.string().nullable().optional()
+      })
+      .passthrough()
+  ])
   .optional()
   .nullable()
 

--- a/src/shared/rpc-contract/automation-params.ts
+++ b/src/shared/rpc-contract/automation-params.ts
@@ -57,13 +57,21 @@ export const OptionalNullablePlainString = z
   .pipe(z.union([z.string(), z.null(), z.undefined()]))
   .optional()
 
+// A GitHub identity is only usable with both fields present and non-blank.
+const GithubIdentityField = z.string().refine((value) => value.trim().length > 0, {
+  message: 'Required'
+})
+
 export const TaskProviderIdentity = z
   .discriminatedUnion('provider', [
     z
       .object({
         provider: z.literal('github'),
-        owner: z.string(),
-        repo: z.string(),
+        // Why refine, not .trim(): normalizeTaskProviderIdentity treats a blank owner or repo as
+        // no identity at all, so blank must be rejected here — but trimming would rewrite the
+        // parsed value and change what the handler receives.
+        owner: GithubIdentityField,
+        repo: GithubIdentityField,
         host: z.string().optional()
       })
       .passthrough(),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 |

<!-- /orca-pr-loc -->

## What

`TaskProviderIdentity` was a single `z.custom` that checked only the discriminant, so `{ provider: 'github' }` passed with no `owner` and no `repo` and crossed the RPC boundary typed as a complete `SharedTaskProviderIdentity`. Replaced with provider-specific schemas so each provider's required fields are actually required.

Pre-existing: byte-identical to `automation-schemas.ts:57` before #19961 relocated it, deliberately left alone there. This is the promised follow-up.

## The census, which is the actual work

| Producer / path | Verdict |
|---|---|
| `src/shared/task-source-context.ts` normalize/build | GitHub missing owner/repo already becomes **null identity**; other providers' missing fields likewise. Provider mismatch becomes null, never an inferred provider. |
| `source-context-state.ts` | Derived GitHub context carries a complete identity or null. Jira folder/project-group context explicitly has null identity. |
| Desktop automation save / scoped-list / host clients, web transport | Forward existing contexts; they do not construct new identities. |

So the normal path already cannot produce a malformed identity — what the new schema rejects is legacy arbitrary malformed RPC input, which is the intent.

## Two traps checked, not assumed

- **Folder workspaces.** A folder workspace legitimately has no owner/repo. Null and absent identities remain valid; no operation now requires a git worktree that did not before.
- **No provider inference.** A GitLab identity that happens to carry owner/repo is still GitLab. Provider mismatch resolves to null rather than being reinterpreted.

`.optional().nullable()` is kept exactly as-is — absent and explicit-null are distinct today and callers depend on that.

## Evidence

Tests cover each provider's required fields, discrimination with owner/repo present, local and SSH folder contexts, and update patches. Loosening one provider back to discriminant-only fails a test.

No shipped mobile producer with a newly rejected payload was found.

## Gates

`pnpm tc` · `vitest run src/main/runtime/rpc` 278 files / 2,463 passed · `check:code-quality:changed` 0 new findings.