### PR TITLE
perf: accept UTF-8 text that fits the worst-case byte bound

### DIFF
--- a/src/shared/utf8-byte-limits.ts
+++ b/src/shared/utf8-byte-limits.ts
@@ -66,6 +66,10 @@ export function isUtf8ByteLengthWithinLimit(text: string, maxBytes: number): boo
   if (text.length > maxBytes) {
     return false
   }
+  // UTF-8 needs at most three bytes per UTF-16 unit, including unpaired surrogates.
+  if (text.length * 3 <= maxBytes) {
+    return true
+  }
   if (Number.isSafeInteger(maxBytes) && maxBytes <= MAX_UTF8_SCRATCH_BYTES) {
     if (utf8Scratch.length < maxBytes) {
       utf8Scratch = new Uint8Array(maxBytes)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

Terminal scrollback size checks skip encoding when the text is guaranteed to fit the byte limit.

## What Changed

After the existing empty/oversized character-count checks, accept text when three times its UTF-16 length fits the limit. Three bytes per code unit bounds UTF-8, including lone surrogates; paired surrogates need four bytes for two units. Other inputs retain the existing bounded encoder/scanner.

## Why

Windows Node benchmark of the exported size predicate, median of 15 measured batches after five warmups, alternating original/modified order, 1,000 calls per batch:

| Input / limit | Before | After |
| --- | ---: | ---: |
| 3,000 ASCII units / 1 MiB | 0.00109 ms | <0.00001 ms |
| 100,000 CJK units / 1 MiB | 0.1321 ms | <0.00001 ms |
| 350,000 CJK units / 1 MiB | 0.6774 ms | 0.6751 ms |
| 3,000 lone surrogates / 9,000 bytes | 0.00654 ms | <0.00001 ms |

Synthetic CPU measurements isolate the predicate, not persistence or rendered terminal latency. Near-limit encoding remains effectively unchanged.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical size decisions; no rendered behavior changes.

## Testing

- 35 tests passed across UTF-8 limits and terminal session buffer preservation.
- Existing boundary tests include multibyte strings, pairs, lone surrogates, NaN and infinite limits.
- 120 additional original/modified boundary comparisons matched.
- Renderer TypeScript check, targeted oxlint and formatting passed.

## Review

No limits, encoding rules, persisted formats, cache ownership or SSH/WSL routing changes. Remote buffer preservation and local daemon ownership remain unchanged.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck, lint and formatting passed.
