### PR TITLE
perf(ipc): bound SSH ACK batch selection scans

### DIFF
--- a/src/main/ipc/ssh-pty-source-ack-coalescer.ts
+++ b/src/main/ipc/ssh-pty-source-ack-coalescer.ts
@@ -82,9 +82,16 @@ export class SshPtySourceAckCoalescer {
     }
     const providerGeneration = this.pending.values().next().value!.publication
       .identity.providerGeneration
-    const selected = Array.from(this.pending.entries())
-      .filter(([, entry]) => entry.publication.identity.providerGeneration === providerGeneration)
-      .slice(0, MAX_PTY_ACK_ENTRIES)
+    const selected: [string, CoalescedEntry][] = []
+    for (const pair of this.pending) {
+      if (pair[1].publication.identity.providerGeneration !== providerGeneration) {
+        continue
+      }
+      selected.push(pair)
+      if (selected.length === MAX_PTY_ACK_ENTRIES) {
+        break
+      }
+    }
     for (const [key] of selected) {
       this.pending.delete(key)
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## ELI5
When SSH terminal acknowledgements queue up, select only the next existing 64-entry batch instead of copying and filtering the entire queue first.

## What Changed
`SshPtySourceAckCoalescer.flush` now walks pending entries in insertion order and stops at the 64th entry matching the first pending provider generation. Selected-key deletion, batch construction, publication, scheduling, cancellation and settlement remain unchanged. No new cache, threshold, timer, wire field or result policy.

## Why
The old `Array.from(...).filter(...).slice(0, 64)` scans every queued token on each flush. A complete drain of 1,024 same-generation tokens visited 8,704 entries before and 1,024 after in a production-class measurement. Mixed-generation selection still scans nonmatching entries; this is not a universal O(64) claim.

## Linked Issue
User-requested repository-wide performance audit; no existing issue is linked. Duplicate search found no matching ACK-selection optimization. A separate Quick Open candidate was rejected as already covered by #20216 rather than included here.

## Visual Proof
N/A — no visual or interaction behavior is intentionally changed; this is internal ACK batch selection.

## Testing
- [x] Exercised complete before/current production coalescer classes on macOS arm64 using controlled scheduler/transport settlements.
- [x] Existing behavioral tests retained unchanged; no new permanent test necessary for the unchanged batching contract.
- 112 before/after scenarios produced identical publication payloads/order, pending-count transitions, schedule/cancel traces and settlement traces: 0/1/16/64/65/256/1024 tokens, one/three interleaved generations, cumulative duplicate credits, synchronous/asynchronous settlements, throwing transport, generation cancellation, dispose/late callbacks, publish reentry and member callback reentry, Unicode IDs.
- `ORCA_BACKGROUND_LAUNCH=1 node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/main/ipc/ssh-pty-source-ack-coalescer.test.ts src/main/ipc/ssh-pty-source-obligation-coordinator.test.ts src/main/ipc/ssh-pty-output-model-migration.test.ts` — 3 files / 16 tests passed.

Full enqueue-and-drain production-class timings (median milliseconds; controlled transport, not end-to-end SSH):

| Tokens | Before | After | Before visits | After visits |
| --- | ---: | ---: | ---: | ---: |
| 1 | 0.00474 | 0.00441 | 1 | 1 |
| 16 | 0.01517 | 0.01630 | 16 | 16 |
| 64 | 0.07194 | 0.05411 | 64 | 64 |
| 65 | 0.04808 | 0.04792 | 66 | 65 |
| 256 | 0.22109 | 0.16546 | 640 | 256 |
| 1024 | 1.29491 | 1.06246 | 8704 | 1024 |

The 16-token sample was ~1.14 microseconds slower; timings are nonuniform microbenchmarks, not a claim of universal latency improvement. Deterministic evidence is fewer visited entries for queued batches and removal of whole-queue temporary arrays. No real SSH network, Electron window, Linux, Windows/WSL, live reconnect soak, native heap profile or full project gates were run. Full suite, formatter, lint, typecheck and build were intentionally omitted for this focused audit.

## AI Disclosure
AI-assisted audit, implementation and verification.

## Review
Independent coordinator review completed; ready for review, not merged. `terminal-performance.output-backpressure-budget` remains experimental/partial: the focused coalescer/source-obligation/migration contracts above were exercised, not the entire gate. Invariant: exact first-generation/first-64 ordering and cumulative source-credit settlement are unchanged; failure source is queued SSH ACK fanout, and the oracle is identical complete event traces against the original production class. Local/daemon PTY paths, path resolution and folder workspace logic are untouched. SSH and mobile/paired-runtime content/capability semantics are unchanged; live platform/provider validation remains a gap. No absolute zero-risk claim.

## Agent skill upstream boundary
- [x] Not applicable; no skill-installer content changed.

## Notes
Only one production file changed. No persistent state is added. Detailed local evidence: `/tmp/orca-free-perf-zUCWLb/main-runtime-ack-proof.json` and category audit report; temporary benchmark scripts removed after proof per audit constraints.

## Checklist
- [x] Small focused change
- [x] Explained change and motivation
- [x] N/A visual evidence reason supplied
- [x] Self-reviewed ordering, generation identity, errors and reentrancy
- [x] Cross-platform and SSH/remote impact considered; untested surfaces disclosed
- [ ] Full lint/typecheck/test/build gates (not run; focused audit only)

## Follow-up counterbalanced small-batch acceptance

The initial 16-token slowdown did not persist in an isolated full production-class rerun with a separately compiled unchanged baseline control, 30 trials, all six execution-order permutations repeated five times, warmup, and GC before each timed batch. This follow-up times complete enqueue/flush/settlement/dispose without event-log instrumentation; it is not directly comparable in absolute duration to the original trace-capturing run.

| Tokens | Baseline median µs | Unchanged control median µs | Changed median µs | Paired changed delta µs | Median absolute control delta µs |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1 | 3.391 | 3.261 | 3.006 | -0.336 | 0.097 |
| 16 | 12.072 | 12.630 | 11.562 | -0.543 | 0.683 |
| 64 | 42.419 | 44.288 | 42.405 | 0.309 | 1.846 |
| 1024 | 787.094 | 806.817 | 613.864 | -167.604 | 24.031 |

No small-case slowdown exceeded the baseline-vs-baseline control noise in this follow-up. The 64-token paired delta is +0.309 µs against 1.846 µs median absolute control delta; no universal speedup claim. Full samples are in `/tmp/orca-free-perf-zUCWLb/main-runtime-ack-control-proof.json`. The original 112 equivalence cases and 16 existing test results remain unchanged.

## Independent verification update

[Coordinator verification and limitations](https://github.com/stablyai/orca/pull/20288#issuecomment-5644171498). Earlier test/tooling statements describe author-time verification; this update records the subsequent independent checks. Coordinator reran the focused tests and relevant TypeScript typecheck, and completed changed-file lint/format verification. CI remains separate; ready-for-review does not mean CI-green or merged.
