### PR TITLE
perf: avoid copying completed terminal source ranges

### DIFF
--- a/src/main/runtime/rpc/methods/terminal/terminal-output-batcher.test.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-output-batcher.test.ts
@@ -1,0 +1,47 @@
+import { expect, it } from 'vitest'
+import type { TerminalOutputSourceRange } from '../../../../../shared/terminal-output-source-range'
+import { createTerminalOutputBatcher } from './terminal-output-batcher'
+
+function range(start: number): TerminalOutputSourceRange {
+  return {
+    id: 'pty',
+    providerGeneration: 1,
+    clientGeneration: 1,
+    ownerGeneration: 1,
+    ptyIncarnation: 'incarnation',
+    deliveryToken: 'delivery',
+    spanId: `span-${start}`,
+    sourceStartSu: start,
+    sourceEndSu: start + 1,
+    displayStart: start,
+    displayEnd: start + 1,
+    splittable: true,
+    transform: { transformed: false, rawLengthSu: 1, scalarSafe: true }
+  }
+}
+
+it('keeps delivered ranges frozen and isolated from reentrant flushes and disposal', () => {
+  const firstRange = range(0)
+  const secondRange = range(1)
+  const sourceRanges = [firstRange]
+  const delivered: (readonly TerminalOutputSourceRange[])[] = []
+  const batcher = createTerminalOutputBatcher((_data, meta) => {
+    delivered.push(meta!.sourceRanges!)
+    if (delivered.length === 1) {
+      batcher.push('b', { sourceRanges: [secondRange] })
+      batcher.flush()
+    }
+  })
+  try {
+    batcher.push('a', { sourceRanges })
+    batcher.flush()
+    sourceRanges.push(secondRange)
+    batcher.dispose()
+    expect(delivered).toEqual([[firstRange], [secondRange]])
+    expect(delivered[0]).not.toBe(delivered[1])
+    expect(delivered.every(Object.isFrozen)).toBe(true)
+    expect(Object.isFrozen(sourceRanges)).toBe(false)
+  } finally {
+    batcher.dispose()
+  }
+})

--- a/src/main/runtime/rpc/methods/terminal/terminal-output-batcher.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-output-batcher.ts
@@ -44,7 +44,7 @@ export function createTerminalOutputBatcher(
             ...(typeof lastSeq === 'number' ? { seq: lastSeq, rawLength: pendingRawLength } : {}),
             ...(pendingCwd !== undefined ? { cwd: pendingCwd } : {}),
             ...(pendingSourceRanges.length > 0
-              ? { sourceRanges: Object.freeze(pendingSourceRanges.slice()) }
+              ? { sourceRanges: Object.freeze(pendingSourceRanges) }
               : {})
           }
         : undefined


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Terminal output batches freeze their completed source-range list without first copying it.

## What Changed

Freeze the private accumulated range array directly. The batcher replaces its private array before invoking the delivery callback, so later pushes and reentrant flushes continue to use separate arrays. Incoming arrays remain untouched.

## Why

Windows benchmark of the full batcher push/flush path with real Node timers, median of 15 batches after five warmups, alternating original/modified order:

| Ranges per flush | 5,000 flushes before | After |
| --- | ---: | ---: |
| 1 | 0.708 ms | 0.685 ms |
| 16 | 1.309 ms | 1.238 ms |
| 128 | 2.731 ms | 2.573 ms |

This is a small synthetic CPU/allocation improvement, not a network or rendered-terminal latency claim. It removes one array allocation per range-bearing flush.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical delivered output and metadata.

## Testing

- Five tests passed across terminal output batching and the direct batcher regression test.
- Added coverage for frozen delivered arrays, reentrant delivery, later input mutation and disposal.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

No source-credit values, wire formats, batch timing, byte limits or execution-host ownership changes. Source-range objects retain their existing shallow-freeze semantics.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck, lint and formatting passed.
