### PR TITLE
perf(ssh): skip terminal source spans awaiting ACK publication

### DIFF
--- a/config/scripts/ssh-source-frontier-benchmark.mjs
+++ b/config/scripts/ssh-source-frontier-benchmark.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+// git show <base>:src/main/ipc/ssh-pty-source-obligation-state.ts | node config/scripts/ssh-source-frontier-benchmark.mjs
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const statePath = 'src/main/ipc/ssh-pty-source-obligation-state.ts'
+const baselineSource = readFileSync(0, 'utf8')
+assert(baselineSource.includes('export function advanceSourceTerminalEnd'))
+
+async function loadLedger(source) {
+  const result = await build({
+    entryPoints: ['src/main/ipc/ssh-pty-source-obligation-ledger.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    plugins: [
+      {
+        name: 'source-obligation-state',
+        setup(builder) {
+          builder.onLoad({ filter: /ssh-pty-source-obligation-state\.ts$/ }, (args) => ({
+            contents: source,
+            loader: 'ts',
+            resolveDir: path.dirname(args.path)
+          }))
+        }
+      }
+    ]
+  })
+  const encoded = Buffer.from(result.outputFiles[0].text).toString('base64')
+  return (await import(`data:text/javascript;base64,${encoded}`)).SshPtySourceObligationLedger
+}
+
+const [Baseline, Current] = await Promise.all([
+  loadLedger(baselineSource),
+  loadLedger(readFileSync(statePath, 'utf8'))
+])
+
+function identity(index = 0) {
+  return Object.freeze({
+    id: `pty-${index}`,
+    providerGeneration: index + 1,
+    clientGeneration: 2,
+    ownerGeneration: 3,
+    ptyIncarnation: `incarnation-${index}`,
+    deliveryToken: `token-${index}`
+  })
+}
+
+function sourceSpan(owner, id, start, length) {
+  return Object.freeze({
+    ...owner,
+    spanId: id,
+    sourceStartSu: start,
+    sourceEndSu: start + length,
+    displayStart: start,
+    displayEnd: start + length,
+    data: 'x'.repeat(length),
+    splittable: true,
+    transform: Object.freeze({ transformed: false, rawLengthSu: length, scalarSafe: true })
+  })
+}
+
+function trace(Ledger, seed) {
+  let randomState = seed
+  const random = (bound) => {
+    randomState = (Math.imul(randomState, 1664525) + 1013904223) >>> 0
+    return Math.floor((randomState / 2 ** 32) * bound)
+  }
+  const closed = []
+  const ledger = new Ledger((owner) => closed.push(owner))
+  const owners = [identity(), identity(1)]
+  const starts = [seed % 3 === 0 ? Number.MAX_SAFE_INTEGER - 10_000 : 0, 100]
+  const reservations = []
+  const publications = []
+  const spans = []
+  const consumers = ['model', 'desktop', 'remote:viewer']
+  owners.forEach((owner, index) => ledger.open(owner, starts[index]))
+  const results = []
+  const rememberAck = (publication) => {
+    if (publication) {
+      publications.push(publication)
+    }
+    return publication?.ack ?? null
+  }
+  for (let step = 0; step < 120; step += 1) {
+    const owner = owners[random(owners.length)]
+    const selectedSpan = spans[random(spans.length)]
+    const spanId = selectedSpan?.spanId ?? 'missing'
+    const consumer = consumers[random(consumers.length)]
+    const operation = step < 20 ? random(2) : random(14)
+    try {
+      let value
+      switch (operation) {
+        case 0:
+        case 1: {
+          const start = ledger.snapshot(owner).receivedEndSu
+          const span = sourceSpan(owner, `span-${step}`, start, random(5))
+          spans.push(span)
+          const reservation = ledger.reserve(owner, span, consumers)
+          reservations.push(reservation)
+          value = random(8) === 0 ? ledger.rollback(reservation) : ledger.commit(reservation)
+          break
+        }
+        case 2:
+        case 3:
+          value = ledger.settle(spanId, consumer, 'accepted')
+          break
+        case 4:
+          value = ledger.beginTransfer(spanId, consumer, 'model', 'hidden')
+          break
+        case 5:
+          value = ledger.commitTransfer(spanId, consumer)
+          break
+        case 6:
+          value = ledger.cancelTransfer(spanId, consumer, 'canceled')
+          break
+        case 7:
+          value = ledger.rollbackTransfer(spanId, consumer)
+          break
+        case 8:
+          value = rememberAck(ledger.queueAck(owner))
+          break
+        case 9:
+          value = rememberAck(ledger.retryQueuedAck(owner))
+          break
+        case 10: {
+          const publication = publications[random(publications.length)]
+          const result = random(4) ? { ok: true } : { ok: false, error: new Error('write failed') }
+          value = publication?.onSettled(result)
+          break
+        }
+        case 11: {
+          const reservation = reservations[random(reservations.length)]
+          value = reservation ? ledger.rollbackCommitted(reservation) : false
+          break
+        }
+        case 12:
+          value = ledger.modelAcceptedEnd(owner)
+          break
+        case 13:
+          value = step < 100 ? ledger.spanIdentity(spanId) : ledger.seal(owner)
+          break
+      }
+      results.push({ operation, value })
+    } catch (error) {
+      results.push({ operation, error: [error.name, error.message] })
+    }
+    results.push(owners.map((entry) => ledger.snapshot(entry)))
+  }
+  for (const span of spans) {
+    if (ledger.hasRetainedSpan(span.spanId)) {
+      results.push(consumers.map((consumer) => ledger.obligation(span.spanId, consumer)))
+      for (const consumer of consumers) {
+        const obligation = ledger.obligation(span.spanId, consumer)
+        if (obligation.state === 'open') {
+          ledger.settle(span.spanId, consumer, 'drained')
+        } else if (obligation.state === 'transferring') {
+          ledger.commitTransfer(span.spanId, consumer)
+        }
+      }
+      results.push(owners.map((owner) => ledger.snapshot(owner)))
+      rememberAck(ledger.queueAck(span))
+      if (random(3) === 0) {
+        publications[random(publications.length)]?.onSettled({ ok: true })
+      }
+    } else {
+      results.push(null)
+    }
+  }
+  results.push(ledger.closeGeneration(1, 'connection closed'))
+  for (const publication of publications) {
+    publication.onSettled({ ok: true })
+  }
+  results.push(
+    ledger.closeAll('disposed'),
+    closed,
+    owners.map((owner) => ledger.snapshot(owner))
+  )
+  return results
+}
+
+for (let seed = 1; seed <= 2_000; seed += 1) {
+  assert.deepEqual(trace(Current, seed), trace(Baseline, seed), `seed ${seed}`)
+}
+console.log('2,000 differential traces / 240,000 commands passed (plus snapshots and cleanup).')
+
+function runBatch(Ledger, spans, mode) {
+  const ledger = new Ledger()
+  const owner = spans[0]
+  ledger.open(owner)
+  const settle = (span) => {
+    ledger.settle(span.spanId, 'model', 'accepted')
+    ledger.settle(span.spanId, 'desktop', 'parsed')
+  }
+  for (const span of spans) {
+    ledger.commit(ledger.reserve(owner, span, ['model', 'desktop']))
+    if (mode !== 'backlog') {
+      settle(span)
+      if (mode === 'immediate') {
+        ledger.queueAck(owner)?.onSettled({ ok: true })
+      }
+    }
+  }
+  if (mode === 'backlog') {
+    for (const span of spans) {
+      settle(span)
+    }
+  }
+  ledger.queueAck(owner)?.onSettled({ ok: true })
+  return ledger.snapshot(owner)
+}
+
+function median(values) {
+  const ordered = values.toSorted((left, right) => left - right)
+  return (ordered[ordered.length / 2 - 1] + ordered[ordered.length / 2]) / 2
+}
+
+console.log(
+  JSON.stringify({ node: process.version, platform: process.platform, arch: process.arch })
+)
+const rows = []
+for (const mode of ['immediate', 'delayed', 'backlog']) {
+  for (const count of [1, 16, 64, 256, 1_024]) {
+    const spans = Array.from({ length: count }, (_, index) =>
+      sourceSpan(identity(), `span-${index}`, index * 128, 128)
+    )
+    const expected = runBatch(Baseline, spans, mode)
+    assert.deepEqual(runBatch(Current, spans, mode), expected)
+    const iterations = Math.max(20, Math.floor(8_192 / count))
+    const measure = (Ledger) => {
+      let result
+      const start = performance.now()
+      for (let index = 0; index < iterations; index += 1) {
+        result = runBatch(Ledger, spans, mode)
+      }
+      const elapsed = (performance.now() - start) / iterations
+      assert.deepEqual(result, expected)
+      return elapsed
+    }
+    measure(Baseline)
+    measure(Current)
+    const samples = { baseline: [], current: [] }
+    for (const pair of buildCounterbalancedSchedule(8, 'baseline', 'current')) {
+      for (const arm of pair) {
+        samples[arm].push(measure(arm === 'baseline' ? Baseline : Current))
+      }
+    }
+    rows.push({
+      mode,
+      spans: count,
+      beforeMs: median(samples.baseline),
+      afterMs: median(samples.current)
+    })
+  }
+}
+console.table(rows)
+console.log('Synthetic ledger CPU only; no network, renderer, or end-to-end latency measurement.')

--- a/src/main/ipc/ssh-pty-source-obligation-ledger.test.ts
+++ b/src/main/ipc/ssh-pty-source-obligation-ledger.test.ts
@@ -64,6 +64,95 @@ function commitSpan(
 }
 
 describe('SshPtySourceObligationLedger', () => {
+  it('skips the terminal prefix while successful ACK publication is delayed', () => {
+    const count = 1_024
+    const ledger = new SshPtySourceObligationLedger()
+    const owner = identity()
+    ledger.open(owner)
+    let endReads = 0
+    for (let index = 0; index < count; index += 1) {
+      const original = span(owner, `span-${index}`, index, 'x')
+      commitSpan(
+        ledger,
+        owner,
+        Object.freeze({
+          ...original,
+          get sourceEndSu() {
+            endReads += 1
+            return original.sourceEndSu
+          }
+        })
+      )
+    }
+    endReads = 0
+    for (let index = 0; index < count; index += 1) {
+      ledger.settle(`span-${index}`, 'model', 'accepted')
+      ledger.settle(`span-${index}`, 'desktop', 'parsed')
+    }
+    expect(endReads).toBeLessThanOrEqual(count * 32)
+    expect(ledger.snapshot(owner)).toMatchObject({
+      obligationsTerminalEndSu: count,
+      ackPublishedEndSu: 0,
+      openSpans: count
+    })
+    ledger.queueAck(owner)!.onSettled({ ok: false, error: new Error('write failed') })
+    expect(ledger.hasRetainedSpan('span-0')).toBe(true)
+    ledger.retryQueuedAck(owner)!.onSettled({ ok: true })
+    expect(ledger.snapshot(owner)).toMatchObject({ ackPublishedEndSu: count, openSpans: 0 })
+  })
+
+  it('keeps an open gap authoritative across late settlements and prefix reclamation', () => {
+    const ledger = new SshPtySourceObligationLedger()
+    const owner = identity()
+    ledger.open(owner, 100)
+    for (let index = 0; index < 8; index += 1) {
+      commitSpan(ledger, owner, span(owner, `span-${index}`, 100 + index, 'x'))
+      ledger.settle(`span-${index}`, 'model', 'accepted')
+    }
+    for (const index of [0, 1, 7, 6, 5, 4]) {
+      ledger.settle(`span-${index}`, 'desktop', 'parsed')
+    }
+    const earlyAck = ledger.queueAck(owner)!
+    earlyAck.onSettled({ ok: true })
+    expect(ledger.snapshot(owner)).toMatchObject({
+      obligationsTerminalEndSu: 102,
+      ackPublishedEndSu: 102,
+      openSpans: 6
+    })
+    ledger.beginTransfer('span-2', 'desktop', 'model', 'hidden')
+    ledger.commitTransfer('span-2', 'desktop')
+    expect(ledger.snapshot(owner).obligationsTerminalEndSu).toBe(103)
+    ledger.beginTransfer('span-3', 'desktop', 'model', 'hidden')
+    ledger.rollbackTransfer('span-3', 'desktop')
+    expect(ledger.snapshot(owner).obligationsTerminalEndSu).toBe(103)
+    ledger.settle('span-3', 'desktop', 'parsed')
+    expect(ledger.snapshot(owner).obligationsTerminalEndSu).toBe(108)
+    ledger.queueAck(owner)!.onSettled({ ok: true })
+    earlyAck.onSettled({ ok: true })
+    expect(ledger.snapshot(owner)).toMatchObject({ ackPublishedEndSu: 108, openSpans: 0 })
+  })
+
+  it('preserves zero-width span skipping and committed-tail rollback', () => {
+    const ledger = new SshPtySourceObligationLedger()
+    const owner = identity()
+    ledger.open(owner)
+    commitSpan(ledger, owner, span(owner, 'empty-start', 0, ''))
+    commitSpan(ledger, owner, span(owner, 'first', 0, 'x'))
+    commitSpan(ledger, owner, span(owner, 'empty-middle', 1, ''))
+    const tail = commitSpan(ledger, owner, span(owner, 'tail', 1, 'x'))
+    ledger.settle('first', 'model', 'accepted')
+    ledger.settle('first', 'desktop', 'parsed')
+    expect(ledger.snapshot(owner).obligationsTerminalEndSu).toBe(1)
+    expect(ledger.rollbackCommitted(tail)).toBe(true)
+    commitSpan(ledger, owner, span(owner, 'replacement', 1, 'yy'))
+    ledger.settle('replacement', 'desktop', 'parsed')
+    expect(ledger.snapshot(owner).obligationsTerminalEndSu).toBe(1)
+    ledger.settle('replacement', 'model', 'accepted')
+    expect(ledger.snapshot(owner).obligationsTerminalEndSu).toBe(3)
+    ledger.queueAck(owner)!.onSettled({ ok: true })
+    expect(ledger.snapshot(owner).openSpans).toBe(0)
+  })
+
   it('looks up retained spans directly by ID as the ledger grows', () => {
     const spanCount = 1_024
     const ledger = new SshPtySourceObligationLedger()

--- a/src/main/ipc/ssh-pty-source-obligation-state.ts
+++ b/src/main/ipc/ssh-pty-source-obligation-state.ts
@@ -133,7 +133,21 @@ export function snapshotSourceToken(token: TokenRecord): SshPtySourceTokenSnapsh
 
 export function advanceSourceTerminalEnd(token: TokenRecord): void {
   let endSu = token.obligationsTerminalEndSu
-  for (const record of token.spans) {
+  let low = 0
+  let high = token.spans.length
+  // Committed spans are contiguous; skip the terminal prefix retained until ACK publication.
+  if (token.spans[0]?.span.sourceEndSu <= endSu) {
+    while (low < high) {
+      const middle = low + Math.floor((high - low) / 2)
+      if (token.spans[middle]!.span.sourceEndSu <= endSu) {
+        low = middle + 1
+      } else {
+        high = middle
+      }
+    }
+  }
+  for (let index = low; index < token.spans.length; index += 1) {
+    const record = token.spans[index]!
     if (record.span.sourceEndSu <= endSu) {
       continue
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​277 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​276 |

<!-- /orca-pr-loc -->

## Summary

Skip the already-terminal source-span prefix when advancing the SSH client obligation ledger. That prefix must remain retained until successful ACK publication, but rechecking it on every model/desktop/remote-consumer transition is unnecessary.

The existing ledger only commits contiguous, nondecreasing source ranges (including zero-width spans). A lower-bound search finds the first range beyond the existing terminal endpoint; the existing gap and obligation checks continue from there. The common case with no terminal prefix bypasses the search.

No extra cache/index state, retention-policy changes, ACK changes, execution ownership changes, new IPC/RPC fields, or process-liveness decisions. Folder workspaces and git worktrees use the same ledger. This is independent of the other performance PRs.

## Evidence

The default relay source window is 256 Ki source units and the retained-span budget is 1,024. The benchmark uses 128-unit spans (128 Ki units at 1,024 spans), not an unbounded or above-budget workload. ACKs are normally coalesced for 8 ms and publication can be delayed; these synthetic bursts exercise that retained-prefix case without claiming it represents every session.

Actual production ledger with baseline/current state module, Node 26.6.0, macOS arm64, eight counterbalanced pairs. Median CPU time per batch:

| Workload | Baseline | Change |
| --- | ---: | ---: |
| Immediate ACK / 64 spans | 0.0391 ms | 0.0394 ms |
| Immediate ACK / 1,024 spans | 0.615 ms | 0.616 ms |
| Delayed ACK / 16 spans | 0.00908 ms | 0.00910 ms |
| Delayed ACK / 64 spans | 0.0400 ms | 0.0378 ms |
| Delayed ACK / 256 spans | 0.226 ms | 0.155 ms |
| Delayed ACK / 1,024 spans | 3.129 ms | 0.662 ms |
| Pre-admitted backlog / 1,024 spans | 3.063 ms | 0.776 ms |

Single-span immediate ACK: 0.852 -> 0.877 microseconds. Pre-admitted 16-span backlog: 9.24 -> 9.45 microseconds. Small-case differences are disclosed; no claim of app-wide/network/renderer speedup.

Deterministic regression: 1,024 in-order settlements with delayed publication read source endpoints 1,051,647 times on the baseline; the change satisfies a 32,768-read bound. Other new baseline behavior tests pass.

## Verification

- 2,000 differential traces / 240,000 generated commands, plus per-command snapshots, ordered draining, ACKs, and cleanup. Compares outcomes/errors, snapshots, retained obligations, model checkpoints and closed-token notifications across zero-width spans, large offsets, multiple identities, gaps, transfers, rollback, failed/repeated/out-of-order publications and late callbacks after generation close.
- 202 tests across 23 related unit/integration files and `pnpm tc:node` pass; changed-code quality gate passes.
- All checks use `ORCA_BACKGROUND_LAUNCH=1`; no app windows launched.

Reproduce:

```sh
git show 20ab99506541:src/main/ipc/ssh-pty-source-obligation-state.ts | ORCA_BACKGROUND_LAUNCH=1 node config/scripts/ssh-source-frontier-benchmark.mjs
ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/ipc/ssh-pty- src/main/ssh/ssh-relay-session-data-delivery src/main/ssh/ssh-relay-session-recovery-races src/main/ssh/ssh-relay-session-rejected-delivery
ORCA_BACKGROUND_LAUNCH=1 pnpm tc:node
```

Tracking: #20206. One focused improvement; does not close the broader audit.
