### PR TITLE
perf: reuse diagnostic bundle byte count

### DIFF
--- a/src/main/observability/bundle.test.ts
+++ b/src/main/observability/bundle.test.ts
@@ -58,6 +58,25 @@ describe('bundle — submission ID', () => {
 })
 
 describe('bundle — collection', () => {
+  it.each([
+    { kind: 'empty', names: [] },
+    { kind: 'ASCII', names: ['plain'] },
+    { kind: 'Unicode', names: ['漢字🙂', '\ud800'] },
+    { kind: 'capped', names: Array.from({ length: 600 }, () => '漢字🙂'.repeat(1000)) }
+  ])('reports the exact UTF-8 payload size for $kind records', ({ names }) => {
+    writeFileSync(traceFile, makeNDJSON(names.map((name) => makeSpan({ name }))))
+    const bundle = collectBundle({
+      traceFilePath: traceFile,
+      maxFiles: 1,
+      appVersion: '1',
+      platform: 'win32',
+      arch: 'x64',
+      osRelease: 'test',
+      orcaChannel: 'dev'
+    })
+    expect(bundle.bytes).toBe(Buffer.byteLength(bundle.payload))
+  })
+
   it('emits a header line with bundle_submission_id, app_version, platform', () => {
     writeFileSync(traceFile, makeNDJSON([makeSpan()]))
     const bundle = collectBundle({

--- a/src/main/observability/bundle.ts
+++ b/src/main/observability/bundle.ts
@@ -167,7 +167,7 @@ export function collectBundle(opts: CollectBundleOptions): CollectedBundle {
   return {
     bundleSubmissionId,
     payload,
-    bytes: Buffer.byteLength(payload),
+    bytes: currentBytes,
     spanCount
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Reuse the diagnostic bundle's existing byte count instead of scanning the completed payload again.

## What Changed

Return `currentBytes`, which already includes the UTF-8 header, every accepted redacted record, and every newline. Collection order, redaction, size limits and upload contents stay identical.

## Why

Windows Node measurement of the full exported collector, including local file reads and redaction: median of 30 samples after four warmups, alternating original/modified order.

| Fixture | Before | After |
| --- | ---: | ---: |
| Empty | 0.056 ms | 0.058 ms |
| 400 ASCII records, about 4 MB | 15.99 ms | 14.36 ms |
| 400 Unicode records, about 4 MB | 20.92 ms | 19.29 ms |

Synthetic fixtures measure collection on Windows, not upload latency. The change removes one full-payload byte scan and its forced string flattening.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — no UI or payload changes.

## Testing

- 34 bundle tests passed, including exact byte counts for empty, ASCII, Unicode/lone surrogate and size-capped inputs.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

Each JSON record ends before an ASCII newline, so UTF-8 byte counts add exactly across payload boundaries. No cache, filesystem freshness, SSH execution ownership, workspace assumptions or wire format changes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused; self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck, lint and formatting passed.
