### PR TITLE
perf: skip impossible inline HTML comment matches during encoding

### DIFF
--- a/config/scripts/raw-markdown-comment-scan-benchmark.mjs
+++ b/config/scripts/raw-markdown-comment-scan-benchmark.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const baseline = process.argv[2] ?? '20ab9950654'
+const file = 'src/renderer/src/components/editor/raw-markdown-html.ts'
+async function load(contents) {
+  const result = await build({
+    stdin: {
+      contents: `${contents}\nexport { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'`,
+      loader: 'ts',
+      resolveDir: dirname(resolve(file))
+    },
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    banner: {
+      js: `import { createRequire } from 'node:module'; const require = createRequire(${JSON.stringify(resolve('package.json'))});`
+    }
+  })
+  return import(
+    `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+  )
+}
+const arms = {
+  before: await load(
+    execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8', windowsHide: true })
+  ),
+  after: await load(readFileSync(file, 'utf8'))
+}
+const key = '0123456789abcdef0123456789abcdef'
+const codecs = Object.fromEntries(
+  Object.entries(arms).map(([arm, module]) => [arm, module.createRichMarkdownEditorCodec(key)])
+)
+const results = []
+for (const [name, input] of [
+  ['plain', '# Heading\nOrdinary prose.'],
+  ['complete', 'before <!--metadata--> after <b>text</b>\n'.repeat(100)],
+  ['unclosed-1000', `prefix ${'<!--x'.repeat(1000)}`],
+  ['unclosed-8000', `prefix ${'<!--x'.repeat(8000)} <b>tail</b>`],
+  ['mixed-8000', `prefix <!--complete-->${'<!--x'.repeat(8000)} <b>tail</b>`],
+  ['protected', '\\<!--x `<!--x`\n```html\n<!--x\n```\n'],
+  ['transport', `before [[ORCA_RICH_MD:${key}:inline-html:%3Cb%3E]] and [[README.md]]`]
+]) {
+  for (const htmlSuperscriptLinks of [false, true]) {
+    const options = { htmlSuperscriptLinks }
+    const invoke = (arm) =>
+      arms[arm].encodeRawMarkdownHtmlForRichEditor(input, codecs[arm], options)
+    assert.equal(invoke('after'), invoke('before'))
+    const iterations = name.includes('8000') || name.includes('1000') ? 2 : 100
+    function run(arm) {
+      global.gc?.()
+      const start = performance.now()
+      const cpuStart = process.cpuUsage()
+      for (let i = 0; i < iterations; i++) {
+        invoke(arm)
+      }
+      const cpu = process.cpuUsage(cpuStart)
+      return {
+        ms: (performance.now() - start) / iterations,
+        cpuMs: (cpu.user + cpu.system) / 1000 / iterations
+      }
+    }
+    run('before')
+    run('after')
+    const samples = { before: [], after: [] }
+    for (const pair of buildCounterbalancedSchedule(10, 'before', 'after')) {
+      for (const arm of pair) {
+        samples[arm].push(run(arm))
+      }
+    }
+    const median = (values) => {
+      const sorted = [...values].sort((a, b) => a - b)
+      return (sorted[4] + sorted[5]) / 2
+    }
+    results.push({
+      name,
+      htmlSuperscriptLinks,
+      beforeCpuMs: median(samples.before.map((s) => s.cpuMs)),
+      afterCpuMs: median(samples.after.map((s) => s.cpuMs)),
+      beforeMs: median(samples.before.map((s) => s.ms)),
+      afterMs: median(samples.after.map((s) => s.ms)),
+      samples
+    })
+  }
+}
+console.log(
+  JSON.stringify({ baseline, node: process.version, platform: process.platform, results }, null, 2)
+)

--- a/src/renderer/src/components/editor/raw-markdown-comment-scan.test.ts
+++ b/src/renderer/src/components/editor/raw-markdown-comment-scan.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { encodeRawMarkdownHtmlForRichEditor } from './raw-markdown-html'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+
+const key = '0123456789abcdef0123456789abcdef'
+afterEach(() => vi.restoreAllMocks())
+
+describe('raw Markdown HTML comment scanning', () => {
+  it('does not repeatedly match a suffix with no comment closer', () => {
+    const codec = createRichMarkdownEditorCodec(key)
+    const input = `prefix ${'<!--x'.repeat(8000)} <b>tail</b>`
+    const match = vi.spyOn(String.prototype, 'match')
+    const output = encodeRawMarkdownHtmlForRichEditor(input, codec)
+    const scans = match.mock.calls.filter(
+      ([pattern]) => pattern instanceof RegExp && pattern.source.startsWith('^<!--')
+    ).length
+    expect(output).toBe(
+      `prefix ${'<!--x'.repeat(8000)} ${codec.transport.create('inline-html', '<b>')}tail${codec.transport.create('inline-html', '</b>')}`
+    )
+    expect(scans).toBe(2)
+  })
+
+  it('preserves complete comments and an unterminated tail', () => {
+    const codec = createRichMarkdownEditorCodec(key)
+    const input = 'before <!--outer<!--inner--> after <!--unfinished'
+    expect(encodeRawMarkdownHtmlForRichEditor(input, codec)).toBe(
+      `before ${codec.transport.create('inline-html', '<!--outer<!--inner-->')} after <!--unfinished`
+    )
+  })
+
+  it.each(['`<!--x`', '```html\n<!--x\n```\n', '\\<!--x', 'prefix <!--->'])(
+    'keeps protected or incomplete text literal: %j',
+    (input) => {
+      expect(encodeRawMarkdownHtmlForRichEditor(input, createRichMarkdownEditorCodec(key))).toBe(
+        input
+      )
+    }
+  )
+  it('retains the existing block-only handling of an overlapping marker', () => {
+    const codec = createRichMarkdownEditorCodec(key)
+    expect(encodeRawMarkdownHtmlForRichEditor('<!--->', codec)).toBe(
+      codec.transport.create('block-html', '<!--->')
+    )
+  })
+})

--- a/src/renderer/src/components/editor/raw-markdown-html.ts
+++ b/src/renderer/src/components/editor/raw-markdown-html.ts
@@ -59,6 +59,7 @@ export function encodeRawMarkdownHtmlForRichEditor(
   { htmlSuperscriptLinks = false }: { htmlSuperscriptLinks?: boolean } = {}
 ): string {
   const normalizedContent = normalizeMarkdownReferenceLinks(content)
+  const lastCommentClose = normalizedContent.lastIndexOf('-->')
   const { transport } = codec
   let index = 0
   let isLineStart = true
@@ -175,7 +176,11 @@ export function encodeRawMarkdownHtmlForRichEditor(
           continue
         }
       }
-      const inlineHtml = matchInlineHtml(normalizedContent.slice(index))
+      // An unterminated comment cannot match; later tags must still be encoded.
+      const inlineHtml =
+        normalizedContent.startsWith('<!--', index) && index + 4 > lastCommentClose
+          ? null
+          : matchInlineHtml(normalizedContent.slice(index))
       if (inlineHtml) {
         result += transport.create('inline-html', inlineHtml)
         index += inlineHtml.length


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​99 |

<!-- /orca-pr-loc -->

## ELI5

Skip impossible HTML-comment matches while converting Markdown for the editor.

The rich-editor source encoder tries its inline HTML regex at every unescaped `<`. Repeated unclosed comment openers therefore rescan the remaining document even though no later comment can match. Record the last comment closer once and skip only impossible inline-comment matches; keep scanning and encoding later HTML tags.

Block HTML, inline escapes, code spans/fences, superscript links, document links, and authored transport envelopes retain their existing behavior. Tests explicitly preserve the existing difference between a standalone `<!--->` block and the same text inline.

Evidence against `20ab9950654`:

- A 40 KB fixture containing 8,000 unclosed openers followed by two valid tags invokes the inline regex 2 times instead of 8,002, with identical encoded output. The regression assertion fails on baseline.
- Counterbalanced Node 24/macOS benchmark with the real editor codec and fixed transport key: CPU time falls from 42.269 → 0.840 ms with superscript links off, and 41.380 → 0.874 ms with them on. A complete comment followed by an unclosed suffix shows similar gains.
- Output parity is asserted for plain text, complete/malformed comments, protected code, escapes, and transport/document-link fixtures in both options. Typical fixture timing differences are under 2 microseconds CPU. These are encoder timings, not a full editor-open measurement.

Reproduce: `ORCA_BACKGROUND_LAUNCH=1 node --expose-gc config/scripts/raw-markdown-comment-scan-benchmark.mjs`.

Validation: 85 tests across the new regression suite and existing round-trip, superscript-link, link-shortcut, inline-image, and programmatic-update suites pass. Web typecheck, lint, and formatting pass.
