### PR TITLE
perf: normalize manifest text files once

### DIFF
--- a/config/scripts/generate-skill-bundle-manifest.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.mjs
@@ -6,8 +6,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { isDeepStrictEqual } from 'node:util'
 
-// Why: the three artifacts version independently — bumping one shape must not
-// rewrite the others or bypass the registry's schema-gated append-only guard.
+// Version artifacts independently to preserve the registry's schema-gated append-only guard.
 const CURRENT_MANIFEST_SCHEMA_VERSION = 2
 const SNAPSHOT_REGISTRY_SCHEMA_VERSION = 1
 const RELEASE_MAPPING_SCHEMA_VERSION = 1
@@ -41,17 +40,18 @@ function normalizeText(bytes) {
   return Buffer.from(text.replace(/\r\n/g, '\n').replace(/\r/g, '\n'), 'utf8')
 }
 
-function classifyFile(bytes) {
+function normalizedTextOrNull(bytes) {
   if (bytes.includes(0)) {
-    return 'binary'
+    return null
   }
   try {
-    normalizeText(bytes)
-    return 'text'
+    return normalizeText(bytes)
   } catch {
-    return 'binary'
+    return null
   }
 }
+
+const classifyFile = (bytes) => (normalizedTextOrNull(bytes) === null ? 'binary' : 'text')
 
 function assertSafeRelativePath(relativePath) {
   if (
@@ -64,17 +64,17 @@ function assertSafeRelativePath(relativePath) {
 }
 
 function describeFile(manifestPath, bytes, executable) {
-  const classification = classifyFile(bytes)
+  const normalized = normalizedTextOrNull(bytes)
   const exactSha256 = sha256(bytes)
-  const textNormalizedSha256 = classification === 'text' ? sha256(normalizeText(bytes)) : null
+  const textNormalizedSha256 = normalized === null ? null : sha256(normalized)
   return {
     path: manifestPath,
     size: bytes.length,
     executable,
-    classification,
+    classification: normalized === null ? 'binary' : 'text',
     exactSha256,
     textNormalizedSha256,
-    identitySha256: classification === 'text' && !executable ? textNormalizedSha256 : exactSha256,
+    identitySha256: normalized !== null && !executable ? textNormalizedSha256 : exactSha256,
     gitBlobSha: gitObjectSha('blob', bytes).toString('hex')
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | 0 |

<!-- /orca-pr-loc -->

## ELI5

The skill manifest generator now normalizes each text file once instead of twice.

## What Changed

Reuse normalized bytes from binary/text detection when computing the normalized digest. Keep the exported classification function and all identity rules unchanged, including NUL rejection, fatal UTF-8 validation, BOM decoding, newline normalization and executable identity.

## Why

Windows Node benchmark of exported `describeFile`, alternating original/modified order, 15 measured batches after five warmups:

| Input | Before | After |
| --- | ---: | ---: |
| 1.9 KB LF text | 0.00581 ms | 0.00508 ms |
| 2 MB CRLF text | 9.61 ms | 5.63 ms |
| 1.2 MB Unicode CRLF text | 9.51 ms | 5.22 ms |
| 2 MB binary | 1.010 ms | 1.012 ms |

All eight current skill files (18,306 bytes) together: 0.112 → 0.073 ms median over 20 measured batches. This is a small current build-time gain with no output change; benchmarks exclude filesystem reads and full build startup.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — build-time calculation only.

## Testing

- Generator suite: 21 passed, 3 existing platform skips.
- Exact original/modified description parity for all current skill files and synthetic empty, invalid UTF-8, binary, LF, CRLF and Unicode inputs with both executable flags.
- Node syntax check, targeted oxlint and formatting passed. No TypeScript changed.

## Review

No generated artifacts, Git commands, filesystem traversal, runtime behavior or SSH ownership changed. Reuses the existing normalization implementation; does not add a cache or change manifest schemas.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests and lint passed; no max-lines exception added.
