### PR TITLE
perf: reuse formatter within reset timestamp conversion

### DIFF
--- a/src/main/rate-limits/time-zone-wall-clock.ts
+++ b/src/main/rate-limits/time-zone-wall-clock.ts
@@ -15,34 +15,6 @@ export function buildWallClockTimestamp(
     return isMatchingDateParts(localDate, parts) ? localDate.getTime() : null
   }
 
-  const timestamp = buildTimeZoneTimestamp(parts, timeZone)
-  if (timestamp === null) {
-    return null
-  }
-  const resolvedParts = getTimeZoneDateParts(timestamp, timeZone)
-  return resolvedParts && areMatchingWallClockParts(resolvedParts, parts) ? timestamp : null
-}
-
-function buildTimeZoneTimestamp(parts: WallClockDateParts, timeZone: string): number | null {
-  const utcGuess = Date.UTC(parts.year, parts.monthIndex, parts.day, parts.hour, parts.minute)
-  const firstOffset = getTimeZoneOffsetMs(utcGuess, timeZone)
-  if (firstOffset === null) {
-    return null
-  }
-  const firstTimestamp = utcGuess - firstOffset
-  const secondOffset = getTimeZoneOffsetMs(firstTimestamp, timeZone)
-  return secondOffset === null ? null : utcGuess - secondOffset
-}
-
-function getTimeZoneOffsetMs(timestamp: number, timeZone: string): number | null {
-  const parts = getTimeZoneDateParts(timestamp, timeZone)
-  if (!parts) {
-    return null
-  }
-  return Date.UTC(parts.year, parts.monthIndex, parts.day, parts.hour, parts.minute) - timestamp
-}
-
-function getTimeZoneDateParts(timestamp: number, timeZone: string): WallClockDateParts | null {
   const formatter = new Intl.DateTimeFormat('en-US', {
     timeZone,
     hourCycle: 'h23',
@@ -52,6 +24,40 @@ function getTimeZoneDateParts(timestamp: number, timeZone: string): WallClockDat
     hour: '2-digit',
     minute: '2-digit'
   })
+  const timestamp = buildTimeZoneTimestamp(parts, formatter)
+  if (timestamp === null) {
+    return null
+  }
+  const resolvedParts = getTimeZoneDateParts(timestamp, formatter)
+  return resolvedParts && areMatchingWallClockParts(resolvedParts, parts) ? timestamp : null
+}
+
+function buildTimeZoneTimestamp(
+  parts: WallClockDateParts,
+  formatter: Intl.DateTimeFormat
+): number | null {
+  const utcGuess = Date.UTC(parts.year, parts.monthIndex, parts.day, parts.hour, parts.minute)
+  const firstOffset = getTimeZoneOffsetMs(utcGuess, formatter)
+  if (firstOffset === null) {
+    return null
+  }
+  const firstTimestamp = utcGuess - firstOffset
+  const secondOffset = getTimeZoneOffsetMs(firstTimestamp, formatter)
+  return secondOffset === null ? null : utcGuess - secondOffset
+}
+
+function getTimeZoneOffsetMs(timestamp: number, formatter: Intl.DateTimeFormat): number | null {
+  const parts = getTimeZoneDateParts(timestamp, formatter)
+  if (!parts) {
+    return null
+  }
+  return Date.UTC(parts.year, parts.monthIndex, parts.day, parts.hour, parts.minute) - timestamp
+}
+
+function getTimeZoneDateParts(
+  timestamp: number,
+  formatter: Intl.DateTimeFormat
+): WallClockDateParts | null {
   const parts = Object.fromEntries(
     formatter.formatToParts(new Date(timestamp)).map((part) => [part.type, part.value])
   )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

Reuse one timezone formatter while converting a usage reset time, instead of constructing the same formatter three times.

## What Changed

Build the formatter once within `buildWallClockTimestamp` and pass it through both offset probes and final wall-clock validation. The local-time path still creates no formatter. No persistent cache is introduced.

## Why

Windows Node benchmark of the complete exported conversion, median of 15 measured batches after five warmups, 200 calls per batch, alternating original/modified order:

| Timezone | Before | After |
| --- | ---: | ---: |
| Local (null) | 0.000104 ms | 0.000105 ms |
| UTC | 0.0868 ms | 0.0437 ms |
| America/Los_Angeles | 0.0890 ms | 0.0447 ms |
| Europe/Berlin | 0.0887 ms | 0.0456 ms |
| Asia/Kolkata | 0.0869 ms | 0.0453 ms |
| Australia/Lord_Howe | 0.0886 ms | 0.0418 ms |

This measures date-conversion CPU, not CLI startup or total usage-refresh latency.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical parsed timestamps and no rendered changes.

## Testing

- 18 existing Claude/Codex usage parser tests passed.
- 840 original/modified comparisons matched across local time, five named zones, invalid zone, invalid dates, and DST transition dates/hours, including thrown error names/messages.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

Timezone options and both offset passes are unchanged. No transcript recognition rules, refresh timing, credential access, process launches, SSH routing, or WSL behavior changed.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck and lint passed.
