### PR TITLE
perf: defer scrollback pruning indexes until needed

### DIFF
--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -626,8 +626,8 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     expect(statCalls.filter((path) => path === worktreesDir)).toHaveLength(1)
     await vi.waitFor(() => {
       expect(subscribeMock).toHaveBeenCalledTimes(2)
+      expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
     })
-    expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
   })
 
   it('resumes polling when the dir is still absent on show', async () => {

--- a/src/shared/workspace-session-terminal-buffers.ts
+++ b/src/shared/workspace-session-terminal-buffers.ts
@@ -77,20 +77,23 @@ export function pruneLocalTerminalScrollbackBuffers(
   session: WorkspaceSessionState,
   repos: readonly RepoConnection[]
 ): WorkspaceSessionState {
-  const repoById = new Map(repos.map((repo) => [repo.id, repo] as const))
-  const worktreeIdByTabId = new Map<string, string>()
+  let repoById: Map<string, RepoConnection> | null = null
+  let worktreeIdByTabId: Map<string, string> | null = null
   const tabsByWorktree = session.tabsByWorktree ?? {}
   const terminalLayoutsByTabIdForRead = session.terminalLayoutsByTabId ?? {}
-  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
-    for (const tab of tabs) {
-      worktreeIdByTabId.set(tab.id, worktreeId)
-    }
-  }
-
   let terminalLayoutsByTabId: WorkspaceSessionState['terminalLayoutsByTabId'] | null = null
   for (const [tabId, layout] of Object.entries(terminalLayoutsByTabIdForRead)) {
     if (!layout.buffersByLeafId && !layout.scrollbackRefsByLeafId) {
       continue
+    }
+    repoById ??= new Map(repos.map((repo) => [repo.id, repo] as const))
+    if (!worktreeIdByTabId) {
+      worktreeIdByTabId = new Map()
+      for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+        for (const tab of tabs) {
+          worktreeIdByTabId.set(tab.id, worktreeId)
+        }
+      }
     }
     const worktreeId = worktreeIdByTabId.get(tabId)
     if (shouldPreserveTerminalScrollbackBuffersForRepoMap(worktreeId, repoById)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

Skip building repo and tab indexes when a saved workspace has no terminal scrollback to process.

## What Changed

Create the existing indexes lazily at the first layout containing buffers or scrollback references. Later layouts reuse those indexes. Keep the same last-wins indexing, local pruning, remote preservation and byte caps.

## Why

Windows Node benchmark of the full exported pruning function, median of 15 measured batches after five warmups, 100 calls per batch, alternating original/modified order:

| Fixture | Before | After |
| --- | ---: | ---: |
| 100 tabs, no layouts | 0.0102 ms | <0.0001 ms |
| 100 tabs, layouts without scrollback | 0.0174 ms | 0.0063 ms |
| 1,000 tabs, no layouts | 0.1315 ms | <0.0001 ms |
| 1,000 tabs, layouts without scrollback | 0.2672 ms | 0.0872 ms |
| 1,000 tabs, local scrollback | 0.8778 ms | 0.8798 ms |
| 1,000 tabs, remote scrollback | 0.3447 ms | 0.3383 ms |

Synthetic CPU measurements exclude disk writes and UI rendering. Buffer-bearing workloads are effectively unchanged; clean sessions avoid unnecessary map allocation and tab traversal.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — no rendered behavior change.

## Testing

- 11 existing scrollback-preservation tests passed, including SSH/runtime ownership, orphaned layouts, unresolved catalogs, floating terminals and UTF-8 caps.
- Original/modified outputs matched all eight benchmark fixtures; clean fixtures retained the original session object.
- Node and renderer TypeScript checks, targeted oxlint and formatting passed.

## Review

Read the SSH execution boundary. Ownership decisions, catalog fallback, persisted shape, and folder/worktree identifiers are unchanged. Indexes remain scoped to this synchronous call; no persistent cache or freshness change.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typechecks and lint passed.


## CI review follow-up

Included a test-only correction for the unrelated watcher CI failure: the test now waits for the reconciliation event as well as subscription setup. Production watcher code is unchanged. The exact previously failing case passes on Windows with the correction. Targeted lint and formatting pass. This small test fix is included to remove the CI race observed while reviewing this PR; it is separate from the scrollback optimization.
