### PR TITLE
perf(daemon): reuse encoded unsplit NDJSON frames

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-31",
+  "updatedAt": "2026-09-11",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -15543,6 +15543,93 @@
         "Existing perf scripts are not registered with explicit budgets or flake history."
       ],
       "demotionRule": "Cannot promote without metric artifacts and stable p95 runtime history."
+    },
+    {
+      "id": "terminal-performance.daemon-ndjson-wire-parity-and-serialization",
+      "title": "Daemon NDJSON preserves wire bytes within a serialization count budget",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-performance",
+      "layer": "daemon-provider-contract",
+      "surfaces": ["daemon stream", "NDJSON framing", "stream data batching"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["daemon"],
+      "coverageNotes": "Deterministic writer, batcher, droppability and NDJSON suites run locally on macOS with mocked socket/process boundaries. An SSH-shaped session ID is a string fixture, not SSH transport evidence. No live daemon, platform integration or mixed-version client/host pair is exercised; folder and git workspaces are not distinguished by these stream contracts.",
+      "motivatingLinks": ["src/main/daemon/daemon-stream-data-split.ts"],
+      "invariant": "Reusing an encoded unsplit metadata-free frame must preserve the previous writer's exact wire bytes and chunk boundaries while reducing that path to one encode; oversized and metadata-bearing writes retain existing semantics and transformed writes remain uncapped single frames.",
+      "oracle": "Compare emitted lines to the previous writer algorithm across byte caps, escaped and Unicode payloads, session IDs, raw lengths, sequence numbers and transformed spans; assert exact newline framing, reconstruct split payloads, check surrogate boundaries and sequence spans, and count encodeNdjson calls.",
+      "commands": [
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/daemon/daemon-stream-data-split.test.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-stream-droppable-membership.test.ts src/main/daemon/daemon-stream-droppability-lifecycle.test.ts src/main/daemon/ndjson.test.ts"
+      ],
+      "testFiles": [
+        "src/main/daemon/daemon-stream-data-split.test.ts",
+        "src/main/daemon/daemon-stream-data-batcher.test.ts",
+        "src/main/daemon/daemon-stream-droppable-membership.test.ts",
+        "src/main/daemon/daemon-stream-droppability-lifecycle.test.ts",
+        "src/main/daemon/ndjson.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/daemon/daemon-stream-data-split.test.ts",
+          "assertions": [
+            "encodes an unsplit metadata-free frame once: %j",
+            "reuses the encoded frame exactly at the inclusive byte cap",
+            "does not add a duplicate full-data sizing probe to oversized writes",
+            "keeps transformed writes at one encode without applying the ordinary byte cap",
+            "preserves exact frames, chunk boundaries and metadata across payloads and caps",
+            "keeps JSON escaping, Unicode and newline framing byte-for-byte",
+            "keeps split frames within the byte cap and preserves code points and sequence spans"
+          ]
+        },
+        {
+          "file": "src/main/daemon/daemon-stream-data-batcher.test.ts",
+          "assertions": ["writes large stream data as parser-sized NDJSON events"]
+        },
+        {
+          "file": "src/main/daemon/ndjson.test.ts",
+          "assertions": ["measures multibyte payloads in UTF-8 bytes, not characters"]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-11",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/daemon/daemon-stream-data-split.test.ts src/main/daemon/daemon-stream-data-batcher.test.ts src/main/daemon/daemon-stream-droppable-membership.test.ts src/main/daemon/daemon-stream-droppability-lifecycle.test.ts src/main/daemon/ndjson.test.ts",
+          "result": "passed",
+          "summary": "Five daemon suites passed: 70 tests total, including the new 12-test splitter suite. Vitest reported 14.76 seconds; no app or live transport validation was performed.",
+          "durationSeconds": 14.76
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 60,
+        "scope": "Target budget for the five deterministic suites; one local Vitest run took 14.76 seconds, not an established p95. Native-runtime setup is excluded from the reported Vitest duration."
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "Fresh local five-suite run passed; no sustained CI soak history is established."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Historical report states serialization-count tests failed against the old writer. That baseline run was not repeated for this registration; the fresh candidate run passed all 70 tests. The previous-writer oracle checks byte parity, not live cross-version compatibility."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Unsplit metadata-free frames, including the inclusive byte-cap boundary, require exactly one encodeNdjson call; oversized writes must not exceed the previous writer's encode count; transformed writes require one encode. These are deterministic call-count budgets, not measured throughput, CPU, heap or input-latency improvements."
+      },
+      "promotionCriteria": [
+        "Capture reproducible old-writer red and candidate green artifacts for the serialization-count assertions.",
+        "Collect CI soak evidence before promotion and validate Linux/Windows runtimes and live SSH/remote and mixed-version pairs before claiming those integrations."
+      ],
+      "knownGaps": [
+        "No live daemon/Electron, Linux, Windows, WSL, SSH, remote-runtime or mixed-version client/host evidence.",
+        "The historical red run has not been independently reproduced for this registration; the parity oracle reuses current splitter/encoder helpers.",
+        "No sustained soak, measured p95, wall-clock performance benchmark or native socket backpressure guarantee.",
+        "Byte-cap assertions cover ordinary split frames at a viable cap; tiny caps and transformed frames retain legacy behavior rather than gaining a universal cap guarantee."
+      ],
+      "demotionRule": "Keep experimental until reproducible red/green and soak evidence exist; do not relax exact wire-byte, chunk-boundary or encode-count assertions to hide regressions."
     },
     {
       "id": "terminal-performance.daemon-stream-backpressure",

--- a/src/main/daemon/daemon-stream-data-split.test.ts
+++ b/src/main/daemon/daemon-stream-data-split.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Socket } from 'node:net'
+import {
+  encodeStreamDataEvent,
+  splitStreamDataForNdjson,
+  writeStreamDataEvents
+} from './daemon-stream-data-split'
+import { encodeNdjson } from './ndjson'
+
+vi.mock('./ndjson', async (importOriginal) => {
+  const actual = await importOriginal<{ encodeNdjson: typeof encodeNdjson }>()
+  return { ...actual, encodeNdjson: vi.fn(actual.encodeNdjson) }
+})
+
+function write(
+  data: string,
+  maxLineBytes: number,
+  rawLength = data.length,
+  seq?: number,
+  transformed = false,
+  sessionId = 'session-1'
+): string[] {
+  const lines: string[] = []
+  const socket: Pick<Socket, 'write'> = {
+    write: vi.fn((line: string) => {
+      lines.push(line)
+      return true
+    })
+  }
+  writeStreamDataEvents(socket, sessionId, data, maxLineBytes, rawLength, seq, transformed)
+  return lines
+}
+
+// Preserve the pre-optimization writer as a byte-for-byte oracle.
+function previousWrites(
+  data: string,
+  maxLineBytes: number,
+  rawLength = data.length,
+  seq?: number,
+  transformed = false,
+  sessionId = 'session-1'
+): string[] {
+  const explicitRawLength = rawLength === data.length ? undefined : rawLength
+  if (transformed) {
+    return [encodeStreamDataEvent(sessionId, data, rawLength, seq, true)]
+  }
+  const carriesMetadata = explicitRawLength !== undefined || seq !== undefined
+  const chunks = splitStreamDataForNdjson(
+    sessionId,
+    data,
+    carriesMetadata ? Math.max(1, maxLineBytes - 96) : maxLineBytes,
+    explicitRawLength
+  )
+  let consumed = 0
+  return chunks.map((chunk) => {
+    consumed += chunk.length
+    const chunkEndSeq = seq === undefined ? undefined : seq - (data.length - consumed)
+    const chunkRawLength = explicitRawLength === 0 ? 0 : carriesMetadata ? chunk.length : undefined
+    return encodeStreamDataEvent(sessionId, chunk, chunkRawLength, chunkEndSeq)
+  })
+}
+
+beforeEach(() => {
+  vi.mocked(encodeNdjson).mockClear()
+})
+
+describe('writeStreamDataEvents serialization budget', () => {
+  it.each(['', 'x', '\x1b[2K\rredraw', '"\\\n\t\u0000', 'é中🐙', '\ud800x\udc00'])(
+    'encodes an unsplit metadata-free frame once: %j',
+    (data) => {
+      const expected = previousWrites(data, 4096)
+      expect(encodeNdjson).toHaveBeenCalledTimes(2)
+      vi.mocked(encodeNdjson).mockClear()
+      expect(write(data, 4096)).toEqual(expected)
+      expect(encodeNdjson).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('reuses the encoded frame exactly at the inclusive byte cap', () => {
+    const data = 'é🐙\x1b[0m'
+    const line = encodeStreamDataEvent('session-1', data)
+    vi.mocked(encodeNdjson).mockClear()
+    expect(write(data, Buffer.byteLength(line))).toEqual([line])
+    expect(encodeNdjson).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not add a duplicate full-data sizing probe to oversized writes', () => {
+    const data = '🐙\x1b[0m'.repeat(100)
+    const expected = previousWrites(data, 160)
+    const previousCount = vi.mocked(encodeNdjson).mock.calls.length
+    vi.mocked(encodeNdjson).mockClear()
+    expect(write(data, 160)).toEqual(expected)
+    expect(encodeNdjson).toHaveBeenCalledTimes(previousCount)
+  })
+
+  it('keeps transformed writes at one encode without applying the ordinary byte cap', () => {
+    const data = '🐙'.repeat(100)
+    const lines = write(data, 1, 1234, 5000, true)
+    expect(encodeNdjson).toHaveBeenCalledTimes(1)
+    expect(lines).toEqual([encodeStreamDataEvent('session-1', data, 1234, 5000, true)])
+  })
+})
+
+describe('writeStreamDataEvents wire parity', () => {
+  it('preserves exact frames, chunk boundaries and metadata across payloads and caps', () => {
+    const payloads = [
+      '',
+      'x',
+      'plain output\r\n'.repeat(24),
+      '"\\\n\t\u0000'.repeat(40),
+      'é中🐙'.repeat(40),
+      '\ud800x\udc00🐙'.repeat(20)
+    ]
+    for (const sessionId of ['session-1', 'ssh/"中🐙']) {
+      for (const data of payloads) {
+        for (const maxLineBytes of [1, 96, 160, 256, 4096]) {
+          for (const [rawLength, seq, transformed] of [
+            [data.length, undefined, false],
+            [data.length, 0, false],
+            [data.length, 9000, false],
+            [0, 9000, false],
+            [7, undefined, false],
+            [data.length + 99, 9000, false],
+            [1234, 9000, true]
+          ] as const) {
+            const expected = previousWrites(
+              data,
+              maxLineBytes,
+              rawLength,
+              seq,
+              transformed,
+              sessionId
+            )
+            expect(write(data, maxLineBytes, rawLength, seq, transformed, sessionId)).toEqual(
+              expected
+            )
+          }
+        }
+      }
+    }
+  })
+
+  it('keeps JSON escaping, Unicode and newline framing byte-for-byte', () => {
+    expect(write('"\\\n\t\u0000é中🐙', 4096)).toEqual([
+      '{"type":"event","event":"data","sessionId":"session-1","payload":{"data":"\\\"\\\\\\n\\t\\u0000é中🐙"}}\n'
+    ])
+  })
+
+  it('keeps split frames within the byte cap and preserves code points and sequence spans', () => {
+    const data = '🐙é中\x1b[0m"\\\n'.repeat(100)
+    for (const seq of [undefined, 9000]) {
+      const lines = write(data, 256, data.length, seq)
+      expect(lines.length).toBeGreaterThan(1)
+      let consumed = 0
+      const chunks = lines.map((line) => {
+        expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(256)
+        expect(line.endsWith('\n')).toBe(true)
+        const { payload } = JSON.parse(line)
+        expect(payload.data).not.toMatch(/^[\udc00-\udfff]|[\ud800-\udbff]$/)
+        consumed += payload.data.length
+        if (seq !== undefined) {
+          expect(payload.seq).toBe(seq - data.length + consumed)
+          expect(payload.rawLength).toBe(payload.data.length)
+          expect(payload.sequenceChars).toBe(payload.data.length)
+        } else {
+          expect(Object.keys(payload)).toEqual(['data'])
+        }
+        return payload.data as string
+      })
+      expect(chunks.join('')).toBe(data)
+    }
+  })
+})

--- a/src/main/daemon/daemon-stream-data-split.ts
+++ b/src/main/daemon/daemon-stream-data-split.ts
@@ -70,6 +70,15 @@ export function splitStreamDataForNdjson(
     return [data]
   }
 
+  return splitOversizedStreamDataForNdjson(sessionId, data, maxLineBytes, sequenceChars)
+}
+
+function splitOversizedStreamDataForNdjson(
+  sessionId: string,
+  data: string,
+  maxLineBytes: number,
+  sequenceChars?: number
+): string[] {
   const chunks: string[] = []
   let start = 0
   while (start < data.length) {
@@ -118,12 +127,22 @@ export function writeStreamDataEvents(
     return
   }
   const carriesMetadata = explicitRawLength !== undefined || seq !== undefined
-  const chunks = splitStreamDataForNdjson(
-    sessionId,
-    data,
-    carriesMetadata ? Math.max(1, maxLineBytes - 96) : maxLineBytes,
-    explicitRawLength
-  )
+  let chunks: string[]
+  if (!carriesMetadata) {
+    const line = encodeStreamDataEvent(sessionId, data)
+    if (Buffer.byteLength(line, 'utf8') <= maxLineBytes) {
+      streamSocket.write(line)
+      return
+    }
+    chunks = splitOversizedStreamDataForNdjson(sessionId, data, maxLineBytes)
+  } else {
+    chunks = splitStreamDataForNdjson(
+      sessionId,
+      data,
+      Math.max(1, maxLineBytes - 96),
+      explicitRawLength
+    )
+  }
   let consumed = 0
   for (const chunk of chunks) {
     consumed += chunk.length


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​173 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​173 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 |

<!-- /orca-pr-loc -->

## ELI5

Every time a terminal program prints something, the daemon has to wrap that text in a small JSON envelope before sending it to the app. The old code built the envelope once just to measure whether it was small enough to send, threw that copy in the bin, and then built the exact same envelope a second time to actually send it. Now it keeps the first one and sends that, because it was already the right envelope. It's like addressing a parcel, weighing it, binning it, and re-addressing an identical parcel — we just weigh the one we already addressed. The bytes that leave the daemon are the same bytes as before, so nothing you see on screen changes. Honestly: you will almost certainly not perceive a difference; this removes CPU work in a hot path, it does not add a feature or visibly speed anything up.

## What

`writeStreamDataEvents` serialized every ordinary terminal write twice: once inside `splitStreamDataForNdjson` to measure the encoded line, then again to transmit the identical unsplit frame. This reuses the sizing encode for the metadata-free unsplit path and extracts the existing oversized splitter (`splitOversizedStreamDataForNdjson`) so oversized writes no longer repeat the whole-payload probe.

Production callers are the daemon batcher's `flush()` / `flushSession()`.

## Behavior preserved

- Metadata-bearing sizing and its 96-byte reserve are unchanged.
- Transformed output keeps its existing single-encode bypass.
- No scheduling, threshold, timer, lifecycle, provider, or wire-content change.
- The reused frame is literally `encodeStreamDataEvent(sessionId, data)` — the same call the old loop made, since `chunkRawLength` and `chunkEndSeq` are both `undefined` whenever `carriesMetadata` is false.
- Socket `write()` calls per invocation, and therefore the batcher's `onAfterSocketWrite` cadence and its shallow-socket hold/valve logic, are unchanged.

## Measurement

Ordinary unsplit writes go from two `encodeNdjson` calls to one — 2,000 → 1,000 encodes for 1,000 tiny writes. Oversized writes are unchanged in encode count (the probe moved, it was not removed). This is a **serialization-call count**, not a measured CPU, throughput, memory, or terminal-latency improvement.

## Tests

`src/main/daemon/daemon-stream-data-split.test.ts` compares emitted lines byte-for-byte against the pre-optimization writer as an oracle, across 420 combinations of session IDs, Unicode, JSON escapes, lone surrogates, empty output, metadata, and five byte caps — plus the inclusive cap boundary, oversized encode-count parity, transformed output, reconstruction, framing, surrogate-safe splitting, and sequence spans.

```
ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts \
  src/main/daemon/daemon-stream-data-split.test.ts \
  src/main/daemon/daemon-stream-data-batcher.test.ts \
  src/main/daemon/ndjson.test.ts \
  src/main/daemon/daemon-stream-droppability-lifecycle.test.ts \
  src/main/daemon/daemon-stream-droppable-membership.test.ts
```
→ 5 files / 70 tests passed (re-run on this exact branch). Also green on this branch: `pnpm tc` (exit 0), `pnpm test:perf:contracts` (11 files / 74 tests), `ORCA_CODE_QUALITY_BASE=main pnpm run check:code-quality:changed` (0 new findings), scoped `oxfmt`/`oxlint` (clean, no reformat), and `node config/scripts/check-reliability-gates.mjs` (123 gates).

A whole-directory `vitest run src/main/daemon` run was also done: 166 files / 1870 tests passed, with 5 failures in `repro-13767-shell-ready-marker-lost-to-exec.test.ts` from `createPtySubprocess`. That file passes 16/16 in isolation on this branch; the failures are PTY-spawn contention under full-directory parallelism, not a regression from this diff.

Registers experimental gate `terminal-performance.daemon-ndjson-wire-parity-and-serialization` in `config/reliability-gates.jsonc`.

## Merge risk

**Low.**

- **Blast radius:** one function, `writeStreamDataEvents`, reached only from the daemon stream batcher's `flush()` / `flushSession()`. Every terminal pane on local, daemon, SSH, and relay paths goes through it, so the radius is wide in *traffic* but narrow in *surface*: 24 changed lines, no new state, no new allocation that outlives the call, no timer, threshold, or lifecycle touched.
- **What breaks if the reasoning is wrong:** the reasoning is "the reused frame is byte-identical to the one the old loop emitted". If that were false, receivers would get either corrupted JSON (parse error, stream teardown) or a line above the receiver's NDJSON cap, which the parser rejects — in both cases the user loses terminal output on the affected pane.
- **Riskiest line:** `src/main/daemon/daemon-stream-data-split.ts:133` — `if (Buffer.byteLength(line, 'utf8') <= maxLineBytes)`. This inclusive comparison is the only thing standing between the fast path and emitting an over-cap line. An off-by-one here (`<` vs `<=` is safe; the dangerous direction would be comparing the wrong string or the wrong cap) sends a frame the receiver's parser rejects. It is covered by a dedicated test that writes a payload sitting exactly on the cap.
- **How it would be noticed:** immediately and loudly — missing or garbled terminal output, or `NdjsonLineTooLongError` on the client parser. Not a silent slow corruption.
- **Revert:** single commit. `git revert 47791d8e626` restores the prior writer; the extracted helper and the new test/gate go with it and nothing else depends on them.

## User-facing trade-offs

**None identified.** What was actually checked to justify that:

- **Wire bytes:** the fast path emits the exact string the old loop emitted for the same input (verified by a byte-for-byte oracle over 420 input combinations, plus a literal expected-frame assertion covering quote/backslash/newline/tab/NUL escaping and multibyte + astral characters).
- **Chunk boundaries:** oversized and metadata-bearing writes still produce identical chunk splits, `seq` spans, `rawLength`/`sequenceChars`, and surrogate-safe cut points.
- **Mixed-version peers:** no field added, removed, renamed, or re-typed; no new stream opcode; the host publishes identical content on an existing path. Rules 1, 2 and 3 of `docs/reference/remote-wire-compatibility.md` are satisfied trivially because nothing observable changed — an older or newer peer cannot tell this commit apart.
- **Backpressure:** unchanged. One `socket.write()` per unsplit event as before, so the batcher's `writableLength` gate, held-session ordering, small-session bypass, write-through valve, and `armHeldQueueRefill` see the same sequence of writes.
- **Memory/allocation:** strictly non-increasing. The commit deletes one transient encoded string per unsplit write (the measurement copy that was discarded). Nothing is cached or retained across calls; no new Map, array, or buffer. Peak live bytes during a write are the same or one string lower.
- **Error behavior:** `encodeNdjson`'s 16MB hard throw still fires at the same point for the same inputs — the full-payload encode still happens before the size check on both the old and new path.

Unproven (residual risk, not a known trade-off):

- Unit evidence only: no live daemon/PTY delivery, no Electron run, no live SSH, relay, remote-runtime, or mixed-version client/host pairing was exercised.
- macOS only. Linux, Windows, and WSL were not run; the code is platform-agnostic string/Buffer work with no path, shell, or process assumptions, but that is reasoning, not a run.
- No wall-clock, CPU, heap, or terminal-latency benchmark. The only performance claim is a deterministic serialization-call count.
- The previous-writer oracle reuses the production splitter/encoder, so a pre-existing splitter bug would be reproduced identically rather than caught; independent literal-framing, cap, and sequence assertions mitigate but do not remove that shared-oracle blind spot.

## Limitations

- Unit evidence only: no live daemon/PTY delivery, Linux/Windows/WSL, SSH/remote-runtime, or mixed-version pairing run.
- The previous-writer oracle reuses the production splitter/encoder; independent literal-framing and sequence assertions mitigate but do not remove that shared-oracle blind spot.
- No throughput, CPU, or heap benchmark.
