### PR TITLE
perf(browser): index iframe session refs for snapshot lookup

### DIFF
--- a/src/main/browser/snapshot-engine-iframe-sessions.test.ts
+++ b/src/main/browser/snapshot-engine-iframe-sessions.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AXNode } from './snapshot-ax-tree-walk'
+import { buildSnapshot, type CdpCommandSender } from './snapshot-engine'
+
+function buttonTree(count: number, name = 'Submit'): AXNode[] {
+  const buttons = Array.from({ length: count }, (_, i) => ({
+    nodeId: String(i + 2),
+    backendDOMNodeId: i + 10,
+    role: { type: 'role', value: 'button' },
+    name: { type: 'computedString', value: name }
+  }))
+  return [
+    {
+      nodeId: '1',
+      role: { type: 'role', value: 'WebArea' },
+      childIds: buttons.map((n) => n.nodeId)
+    },
+    ...buttons
+  ]
+}
+
+function sender(nodes: AXNode[], cursor = false): CdpCommandSender {
+  return vi.fn(async (method, params) => {
+    if (method === 'Accessibility.enable') {
+      return {}
+    }
+    if (method === 'Accessibility.getFullAXTree') {
+      return { nodes }
+    }
+    if (method === 'DOM.describeNode') {
+      return { node: { backendNodeId: 100 } }
+    }
+    if (method === 'Runtime.evaluate') {
+      if (params?.expression === 'window.__orcaCursorInteractive[0]') {
+        return { result: { objectId: 'cursor-object' } }
+      }
+      return { result: { value: JSON.stringify(cursor ? [{ text: 'Cursor', tag: 'div' }] : []) } }
+    }
+    throw new Error(`Unexpected CDP method: ${method}`)
+  })
+}
+
+describe('buildSnapshot iframe sessions', () => {
+  it('preserves ref order, within-frame duplicate names and session ownership', async () => {
+    const parent = sender(buttonTree(1, 'Parent'), true)
+    const frameA = sender(buttonTree(2, 'Frame A'))
+    const frameB = sender(buttonTree(1, 'Frame B'))
+    const empty = sender([])
+    const stale = vi.fn(async () => {
+      throw new Error('Session closed')
+    })
+    const senders = new Map<string, CdpCommandSender>([
+      ['session-a', frameA],
+      ['session-empty', empty],
+      ['session-stale', stale],
+      ['session-b', frameB]
+    ])
+    const makeIframeSender = vi.fn((sessionId: string) => senders.get(sessionId)!)
+    const sessions = new Map([
+      ['frame-a', 'session-a'],
+      ['frame-empty', 'session-empty'],
+      ['frame-stale', 'session-stale'],
+      ['frame-b', 'session-b']
+    ])
+
+    const result = await buildSnapshot(parent, sessions, makeIframeSender)
+
+    expect(result.snapshot).toBe(
+      [
+        '[@e1] button "Parent"',
+        '[@e2] clickable "Cursor"',
+        '  [@e3] button "Frame A"',
+        '  [@e4] button "Frame A (2nd)"',
+        '  [@e5] button "Frame B"'
+      ].join('\n')
+    )
+    expect(result.refs).toEqual([
+      { ref: '@e1', role: 'button', name: 'Parent' },
+      { ref: '@e2', role: 'clickable', name: 'Cursor' },
+      { ref: '@e3', role: 'button', name: 'Frame A' },
+      { ref: '@e4', role: 'button', name: 'Frame A (2nd)' },
+      { ref: '@e5', role: 'button', name: 'Frame B' }
+    ])
+    expect([...result.refMap]).toEqual([
+      [
+        '@e1',
+        {
+          backendDOMNodeId: 10,
+          role: 'button',
+          name: 'Parent',
+          sessionId: undefined,
+          nth: undefined
+        }
+      ],
+      [
+        '@e2',
+        {
+          backendDOMNodeId: 100,
+          role: 'clickable',
+          name: 'Cursor',
+          sessionId: undefined,
+          nth: undefined
+        }
+      ],
+      [
+        '@e3',
+        { backendDOMNodeId: 10, role: 'button', name: 'Frame A', sessionId: 'session-a', nth: 1 }
+      ],
+      [
+        '@e4',
+        { backendDOMNodeId: 11, role: 'button', name: 'Frame A', sessionId: 'session-a', nth: 2 }
+      ],
+      [
+        '@e5',
+        {
+          backendDOMNodeId: 10,
+          role: 'button',
+          name: 'Frame B',
+          sessionId: 'session-b',
+          nth: undefined
+        }
+      ]
+    ])
+    expect(makeIframeSender.mock.calls.flat()).toEqual([...sessions.values()])
+    for (const frame of [frameA, empty, frameB]) {
+      expect(vi.mocked(frame).mock.calls.map(([method]) => method)).toEqual([
+        'Accessibility.enable',
+        'Accessibility.getFullAXTree'
+      ])
+    }
+    expect(stale).toHaveBeenCalledExactlyOnceWith('Accessibility.enable')
+  })
+
+  it('does not reuse session mappings across snapshots', async () => {
+    const sessions = new Map([['frame', 'session-a']])
+    const withFrame = await buildSnapshot(sender(buttonTree(1)), sessions, () =>
+      sender(buttonTree(1))
+    )
+    const withoutFrame = await buildSnapshot(sender(buttonTree(2)))
+    expect(withFrame.refMap.get('@e2')?.sessionId).toBe('session-a')
+    expect(withoutFrame.refMap.get('@e2')?.sessionId).toBeUndefined()
+  })
+
+  it.each([0, 100, 1000])(
+    'uses one indexed lookup per emitted ref with %i iframe refs',
+    async (iframeCount) => {
+      const parentCount = 100
+      const sessions = new Map([
+        ['frame-a', 'session-a'],
+        ['frame-b', 'session-b']
+      ])
+      let lookups = 0
+      const originalGet = Map.prototype.get
+      const getSpy = vi.spyOn(Map.prototype, 'get').mockImplementation(function (
+        this: Map<unknown, unknown>,
+        key: unknown
+      ) {
+        if (typeof key === 'string' && key.startsWith('@e')) {
+          lookups++
+        }
+        return originalGet.call(this, key)
+      })
+      let result: Awaited<ReturnType<typeof buildSnapshot>>
+      try {
+        result = await buildSnapshot(sender(buttonTree(parentCount)), sessions, () =>
+          sender(buttonTree(iframeCount / 2))
+        )
+      } finally {
+        getSpy.mockRestore()
+      }
+
+      expect(result.refs).toHaveLength(parentCount + iframeCount)
+      expect(lookups).toBe(parentCount + iframeCount)
+      const legacySessions = Array.from({ length: iframeCount }, (_, i) => ({
+        ref: `@e${parentCount + i + 1}`,
+        sessionId: i < iframeCount / 2 ? 'session-a' : 'session-b'
+      }))
+      let legacyComparisons = 0
+      for (const [ref, entry] of result.refMap) {
+        const legacySession = legacySessions.find((candidate) => {
+          legacyComparisons++
+          return candidate.ref === ref
+        })
+        expect(entry.sessionId).toBe(legacySession?.sessionId)
+      }
+      expect(legacyComparisons).toBe(
+        parentCount * iframeCount + (iframeCount * (iframeCount + 1)) / 2
+      )
+    }
+  )
+})

--- a/src/main/browser/snapshot-engine.ts
+++ b/src/main/browser/snapshot-engine.ts
@@ -61,7 +61,7 @@ export async function buildSnapshot(
   // Why: cross-origin iframes have their own AX trees accessible only through
   // their dedicated CDP session. Append their elements after the parent tree
   // so the agent can see and interact with iframe content.
-  const iframeRefSessions: { ref: string; sessionId: string }[] = []
+  const iframeRefSessions = new Map<string, string>()
   if (iframeSessions && makeIframeSender && iframeSessions.size > 0) {
     for (const [_frameId, sessionId] of iframeSessions) {
       try {
@@ -82,7 +82,7 @@ export async function buildSnapshot(
           const startRef = refCounter
           walkTree(iframeRoot, iframeNodeById, 1, entries, () => refCounter++)
           for (let i = startRef; i < refCounter; i++) {
-            iframeRefSessions.push({ ref: `@e${i}`, sessionId })
+            iframeRefSessions.set(`@e${i}`, sessionId)
           }
         }
       } catch {
@@ -120,12 +120,11 @@ export async function buildSnapshot(
       }
       lines.push(`${indent}[${entry.ref}] ${entry.role} "${displayName}"`)
       refs.push({ ref: entry.ref, role: entry.role, name: displayName })
-      const iframeSession = iframeRefSessions.find((s) => s.ref === entry.ref)
       refMap.set(entry.ref, {
         backendDOMNodeId: entry.backendDOMNodeId,
         role: entry.role,
         name: entry.name,
-        sessionId: iframeSession?.sessionId,
+        sessionId: iframeRefSessions.get(entry.ref),
         nth: total > 1 ? nth : undefined
       })
     } else {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​191 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​191 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

When the agent asks the browser "what's on this page?", we hand back a numbered list of every clickable thing, like `@e1`, `@e2`, `@e3`. Things inside an embedded box on the page (an iframe) have to be talked to through a separate channel, so we also record which channel each number belongs to. Before, that record was a plain list, and for *every* numbered item we walked the whole list from the top asking "is this one yours?" — like re-reading an entire guest list from the first name for each person arriving. Now we write it down in a lookup table and check each number once, the way a hotel looks up a room by name. The answer is identical either way; only the amount of rummaging changed. Honestly: on a normal page you will not notice this at all, and on a page with no iframes nothing changes whatsoever.

## What

`buildSnapshot` collected iframe refs into an array and ran `iframeRefSessions.find(...)` once per emitted ref while writing the ref map — a linear scan per row. It now builds a snapshot-local `Map<ref, sessionId>` during the iframe walk and reads it directly.

## Behavior preserved

- The map is per-snapshot (`src/main/browser/snapshot-engine.ts:64`): it is a function-local `const`, never returned, never captured by an escaping closure, and never stored on tab state. Only the `string` session ids are copied into the returned `refMap`.
- Generated refs come from a single monotonic counter (`snapshot-engine.ts:41`) that is only ever `refCounter++`. Each iframe captures `startRef = refCounter` (line 82) immediately before a synchronous `walkTree`, and the mapping loop (lines 84–86) runs with no `await` in between, so iframe ranges `[startRef, refCounter)` are disjoint from the parent walk, from the cursor-interactive refs, and from each other. No key can be written twice, so `Map.set` last-write-wins is equivalent to the old `find()` first-match.
- A missing session still yields `undefined` (non-iframe refs are simply absent from the map).
- Keying by ref (not backend DOM node id) keeps session ownership correct when ids overlap between sessions.
- No change to CDP call order, concurrency, or error boundaries. The stale-session `catch` still skips a frame silently.

## Measurement

For P parent refs and I iframe refs, comparisons go from `P×I + I×(I+1)/2` to `P+I` indexed reads plus I insertions. At P=100, I=1,000 that is 600,500 → 1,100. Operation counts only — these are not CPU-time or latency measurements, and no wall-clock benchmark was run. Iframe-free snapshots see no benefit (the map stays empty and each lookup is a single miss).

## Tests

`src/main/browser/snapshot-engine-iframe-sessions.test.ts` covers ref ordering across parent, cursor-interactive and multiple frames; duplicate names within a frame; overlapping backend node ids across sessions; empty and stale/throwing sessions; snapshot isolation (a later iframe-free snapshot gets no session id); and asserts the observed lookup count against the old linear-scan formula at I = 0 / 100 / 1000.

Re-verified on this branch at `eef98e2da6c`:

```
ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts \
  src/main/browser/snapshot-engine.test.ts \
  src/main/browser/snapshot-engine-iframe-sessions.test.ts
```
→ 2 files / 17 tests passed. Also green on this branch: `pnpm tc`; `pnpm test:perf:contracts` (11 files / 74 tests); `ORCA_CODE_QUALITY_BASE=main pnpm run check:code-quality:changed` (0 new findings across 2 changed files, incl. type-aware and React Doctor); scoped `oxfmt` (no reformat).

## Merge risk

**Low.**

- **Blast radius**: three lines in one function, `buildSnapshot`. The only consumer of the changed value is `RefEntry.sessionId`, read by `CdpRefResolution` (`src/main/browser/cdp-ref-resolution.ts:17,40,52,171`) to pick the CDP sender, skip the parent navigation-id staleness check, and add the iframe coordinate offset. Nothing is persisted, serialized, or sent over IPC/the remote wire — `refMap` never leaves the main process (`cdp-page-commands.ts:31` keeps it on in-memory tab state; only `snapshot` and `refs` are returned to callers).
- **Riskiest line**: `src/main/browser/snapshot-engine.ts:85` — ``iframeRefSessions.set(`@e${i}`, sessionId)``. It converts first-match-wins into last-write-wins. It is safe only because ref allocation is monotonic and per-iframe ranges are disjoint.
- **If that reasoning is wrong**: a ref would be attributed to the wrong iframe session. Symptom would be a click/type on an iframe element being dispatched through the wrong CDP session — the element would fail to resolve (`browser_stale_ref` / `browser_ref_not_found`) or land at the wrong page coordinates because `getPageCoordinates` would add the other frame's offset. That is loud and immediate in agent browser use, not silent data corruption. The `i = 0/100/1000` test asserts exact per-session ownership across two frames, so a regression of this shape fails CI.
- **Revert**: single commit `eef98e2da6c`; `git revert eef98e2da6c` restores the array + `find()` with no migration, no state to unwind, and no cross-version coordination.

## User-facing trade-offs

**None identified.**

Checked to justify that:
- Output equality: snapshot text, `refs` array, and every `refMap` entry (including `sessionId`, `nth`, `backendDOMNodeId`) are asserted field-by-field in the new test against the pre-change expectations, including the cursor-interactive ref and frames with colliding backend node ids.
- No behavioral surface moved: no signature, type, IPC payload, persisted schema, settings key, or remote-wire field changed; `RefEntry` is unchanged.
- Error handling unchanged: an empty iframe AX tree still `continue`s and a stale/throwing session is still swallowed, verified by the empty-frame and throwing-frame cases.
- No lifetime extension: the new `Map` is function-local and unreachable after `buildSnapshot` returns; the "does not reuse session mappings across snapshots" test pins that a second snapshot starts with no session attributions.

Trade-offs that exist but are not user-perceivable:
- **Allocation shape**: a `Map` with I string keys/values replaces an array of I `{ref, sessionId}` objects. Both are O(I), both are freed when the snapshot returns, and the map drops one object allocation per iframe ref while adding hash-table overhead. Net memory is comparable; neither version caps I, which is bounded by the page's accessibility tree either way.
- **Upfront cost**: hashing I ref strings now happens during the iframe walk instead of never. For a page with a single iframe element the win is negligible and this is marginally more upfront work; it only pays off as I grows.

Unproven / not covered:
- No wall-clock or CPU profile; the improvement is stated as operation counts only.
- Verified on macOS (darwin) only. Not run on Windows, Linux, WSL, SSH-remote, relay, paired web, iOS, or Android. The change is platform-agnostic JavaScript with no paths, processes, or native modules, but that is an argument, not a run.
- No live-browser end-to-end run against a real cross-origin iframe page; coverage is via CDP-mocked senders.

## Pre-existing issue, deliberately not fixed here

Snapshot `nth` counts matching role/name occurrences **globally** across the parent page and all iframe sessions (`src/main/browser/snapshot-engine.ts:101–117`), while stale-ref recovery in `src/main/browser/cdp-ref-resolution.ts:176–207` re-queries only the ref's own CDP session and indexes into that session-local match list with the global `entry.nth`. Identical role+name pairs spread across sessions can therefore recover the wrong local occurrence. That predates this change, is untouched by it, and is out of scope for a strictly behavior-preserving perf PR. The ordering test uses distinct per-frame names, and the scale test asserts only ref counts and session ownership, so neither test asserts — or enshrines — the incorrect ordinals.

Also pre-existing and untouched: `walkChildren` in `src/main/browser/snapshot-ax-tree-walk.ts:139` has no visited set, so a cyclic `childIds` graph would recurse unboundedly. This affects the parent walk identically and is unrelated to the indexing change.
