### PR TITLE
perf: reuse computed project identity in projection

### DIFF
--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -251,12 +251,12 @@ export function mergeCatalogUpdatedAt(left: number, right: number): number {
   return Math.max(known, other)
 }
 
-function createProjectFromRepo(repo: Repo): Project {
+function createProjectFromRepo(repo: Repo, projectId: string): Project {
   const identity = getProjectProviderIdentity(repo)
   const gitRemoteIdentity = getProjectGitRemoteIdentity(repo)
   const addedAt = catalogTimestampFromAddedAt(repo.addedAt)
   return {
-    id: getProjectId(repo),
+    id: projectId,
     displayName: repo.displayName,
     badgeColor: repo.badgeColor,
     ...(repo.repoIcon !== undefined ? { repoIcon: repo.repoIcon } : {}),
@@ -319,7 +319,7 @@ export function projectHostSetupProjectionFromRepos(
     if (existing) {
       mergeProjectRepo(existing, repo)
     } else {
-      const project = createProjectFromRepo(repo)
+      const project = createProjectFromRepo(repo, projectId)
       projectById.set(projectId, { project, sourceRepoIds: new Set(project.sourceRepoIds) })
     }
     // Why normalize here: a repo row is untrusted persisted/wire data too, and these


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Reuse the project ID already computed while projecting repositories into projects and host setups.

## What Changed

Pass the existing ID into the private project-row constructor instead of parsing the same repository identity again. Project grouping and row normalization stay unchanged.

## Why

Windows Node benchmark of the full exported projection, median of 15 measured batches after five warmups, 20 calls per batch, alternating original/modified order:

| Fixture | Before | After |
| --- | ---: | ---: |
| 100 distinct GitHub repos | 0.211 ms | 0.149 ms |
| 100 distinct GitLab repos | 0.275 ms | 0.189 ms |
| 1,000 distinct GitHub repos | 2.210 ms | 1.696 ms |
| 1,000 distinct GitLab repos | 4.090 ms | 3.043 ms |
| 1,000 folder repos | 0.353 ms | 0.332 ms |
| 1,000 repos sharing one project | 1.069 ms | 1.098 ms |

Synthetic CPU measurements exclude filesystem work and rendering. Shared-project inputs avoid almost all project-row construction already, so that case shows no gain. Distinct remote identities avoid one redundant URL/identity parse per project.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical projected rows.

## Testing

- 32 existing project projection tests passed.
- Exact original/modified output parity across eight folder/GitHub/GitLab/shared-project fixtures.
- Node and renderer TypeScript checks, targeted oxlint and formatting passed.

## Review

No provider recognition, IDs, SSH/WSL host ownership, folder support, timestamps or persisted formats changed. No cache or new identity implementation.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, GitLab and SSH behavior considered.
- [x] Relevant tests, typechecks and lint passed.
