### PR TITLE
perf: stop archive size scan once over budget

### DIFF
--- a/src/main/runtime/orchestration/worker-output-archive.ts
+++ b/src/main/runtime/orchestration/worker-output-archive.ts
@@ -190,6 +190,9 @@ export function boundArchiveLines(lines: string[]): { lines: string[]; truncated
   let total = 0
   for (const line of lines) {
     total += line.length + 1
+    if (total > TERMINAL_ARCHIVE_MAX_CHARS) {
+      break
+    }
   }
   if (total <= TERMINAL_ARCHIVE_MAX_CHARS) {
     return { lines, truncated: false }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

Stop counting archive characters once the archive is known to need clipping.

## What Changed

Break the initial size scan above the existing 262,144-character budget. Every remaining line adds a nonnegative cost, so it cannot change the decision. The newest-first clipping pass stays unchanged.

## Why

Windows Node benchmark of the exact bounding function extracted from original/modified source, median of 15 measured batches after five warmups, 20 calls per batch, alternating order:

| Fixture | Before | After |
| --- | ---: | ---: |
| 100 lines × 100 characters | 0.000820 ms | 0.000815 ms |
| 100,000 lines × 100 characters | 0.04646 ms | 0.00620 ms |
| 10,000 lines × 1,000 characters | 0.00440 ms | 0.00067 ms |
| 500,000 blank lines | 3.398 ms | 3.284 ms |

These are synthetic CPU stress fixtures, not measured end-to-end archive latency or claims about typical terminal tail size. This removes redundant scanning without changing limits or content.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — same archive lines and truncation flag.

## Testing

- Four existing archive bounding tests passed, covering untouched input, clipped tail, oversized final line and blank-line storms.
- Original/modified outputs matched all four benchmark fixtures.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

No archive format, redaction, capture source, SSH/WSL ownership, process-state verdict, or persisted-content change. Under-budget arrays retain their original identity.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck and lint passed.
