### PR TITLE
perf: avoid per-item arrays in journal projection

### DIFF
--- a/src/shared/structured-agent-session-projection.ts
+++ b/src/shared/structured-agent-session-projection.ts
@@ -137,10 +137,14 @@ const projectedItems = new WeakMap<AgentJournalRenderItem, NativeChatMessage | n
 export function projectStructuredItemsToNativeChat(
   items: readonly AgentJournalRenderItem[]
 ): NativeChatMessage[] {
-  return items.flatMap((item) => {
+  const messages: NativeChatMessage[] = []
+  items.forEach((item) => {
     const projected = projectStructuredItemToNativeChat(item)
-    return projected ? [projected] : []
+    if (projected) {
+      messages.push(projected)
+    }
   })
+  return messages
 }
 
 export function projectStructuredItemToNativeChat(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

Collect projected journal messages without allocating a temporary array for every item.

## What Changed

Replace `flatMap`'s one-element/empty arrays with direct appends to the result array. Keep the existing per-item projector and WeakMap cache. `forEach` preserves skipping sparse array holes.

## Why

Windows Node benchmark of the full exported projection, median of 15 measured batches after five warmups, alternating original/modified order. Fresh input creation excluded from timings; 100 calls per small batch, 10 per large batch. Fixtures contain two message rows for each omitted lifecycle row.

| Fixture | Before | After |
| --- | ---: | ---: |
| 100 items, cached | 0.00130 ms | 0.00043 ms |
| 100 items, uncached | 0.00662 ms | 0.00649 ms |
| 10,000 items, cached | 0.22449 ms | 0.13355 ms |
| 10,000 items, uncached | 1.17903 ms | 1.09311 ms |

Synthetic CPU measurements, not rendered chat or archive latency. Cached items still avoid reconstruction and now also avoid per-item wrapper arrays.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — same messages and order; no rendered behavior changes.

## Testing

- 73 tests passed across shared projection and Codex notice, stream, and compaction translation suites.
- Original/modified outputs matched benchmark fixtures and sparse-array input.
- Node and renderer TypeScript checks, targeted oxlint and formatting passed.

## Review

No message translation, cache lifetime, omission rules, wire format, SSH/WSL ownership or persisted data changes. Existing message object references are returned unchanged.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typechecks and lint passed.
