### PR TITLE
perf: eliminate quadratic palette phrase placement scans

### DIFF
--- a/src/renderer/src/lib/palette-match/palette-assignment-ranking.ts
+++ b/src/renderer/src/lib/palette-match/palette-assignment-ranking.ts
@@ -34,12 +34,10 @@ function phrasePlacement(field: PaletteIndexedField, normalizedQuery: string): n
   if (text.startsWith(normalizedQuery)) {
     return 0
   }
-  let index = text.indexOf(normalizedQuery, 1)
-  while (index !== -1) {
-    if (field.words.some((word) => word.start === index)) {
+  for (const word of field.words) {
+    if (text.startsWith(normalizedQuery, word.start)) {
       return 1
     }
-    index = text.indexOf(normalizedQuery, index + 1)
   }
   return 2
 }

--- a/src/renderer/src/lib/palette-match/palette-phrase-placement.test.ts
+++ b/src/renderer/src/lib/palette-match/palette-phrase-placement.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { buildPaletteTabDocument } from './tab-document'
+import { matchPaletteTabDocument, preparePaletteTabQuery } from './tab-match'
+
+function documentWithTitle(title: string) {
+  return buildPaletteTabDocument({
+    id: 'page',
+    title,
+    secondaryTexts: [],
+    worktreeName: '',
+    branch: '',
+    repoName: ''
+  })
+}
+
+describe('palette phrase placement', () => {
+  it.each([
+    ['aa example', 'aa', 0],
+    ['baaa aa example', 'aa', 1],
+    ['baaa baaa', 'aa', 2],
+    ['prefix fooBar baz', 'bar baz', 1],
+    ['prefix café noir', 'café noir', 1],
+    ['prefix foo/bar baz', 'bar baz', 1],
+    ['prefix 123abc', 'abc', 1],
+    ['prefix baaa aa', 'aa', 1]
+  ])('preserves placement for %s / %s', (title, query, placement) => {
+    expect(
+      matchPaletteTabDocument(documentWithTitle(title), preparePaletteTabQuery(query)!)?.rank
+        .placement
+    ).toBe(placement)
+  })
+
+  it('bounds word-start reads with repeated interior substring matches', () => {
+    const document = documentWithTitle('baaa '.repeat(1000))
+    const field = document.visibleFields[0]
+    let reads = 0
+    for (const word of field.words) {
+      const start = word.start
+      Object.defineProperty(word, 'start', {
+        get: () => {
+          reads += 1
+          return start
+        }
+      })
+    }
+    const match = matchPaletteTabDocument(document, preparePaletteTabQuery('aa')!)
+    expect(match?.rank.placement).toBe(2)
+    expect(match?.titleRanges).toEqual([{ start: 1, end: 3 }])
+    expect(reads).toBeLessThanOrEqual(field.words.length * 10)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

This speeds up **Orca’s jump/search palettes**, including the workspace/worktree jump palette and browser/tab search that use the shared palette matcher. It is not file-content search or AI Vault scanning.

When ranking a result, Orca checks whether the typed phrase starts at the beginning of a word in the result’s title or other searchable field. Previously, repeated text made it search the same word boundaries over and over, blocking typing. Now it checks each word boundary once. Results keep the same matching and ranking rules.

Example: searching `aa` against a 150 KB repetitive title took about 6.86 seconds before and 3.5 milliseconds after in the production ranking function. This is an adverse-input ranking measurement, not an end-to-end palette timing.

Validation: focused ranking tests and 100,000 additional old/new comparisons using the actual text indexer matched exactly, including Unicode, paths, separators, and camelCase. No known result-quality or user-facing trade-off.
