### PR TITLE
perf: bound raw Markdown document-link closing searches

### DIFF
--- a/config/scripts/raw-markdown-doc-link-scan-benchmark.mjs
+++ b/config/scripts/raw-markdown-doc-link-scan-benchmark.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const baseline = process.argv[2] ?? '20ab9950654'
+const file = 'src/renderer/src/components/editor/raw-markdown-html.ts'
+async function load(contents) {
+  const result = await build({
+    stdin: {
+      contents: `${contents}\nexport { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'`,
+      loader: 'ts',
+      resolveDir: dirname(resolve(file))
+    },
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    banner: {
+      js: `import { createRequire } from 'node:module'; const require = createRequire(${JSON.stringify(resolve('package.json'))});`
+    }
+  })
+  return import(
+    `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+  )
+}
+const arms = {
+  before: await load(
+    execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8', windowsHide: true })
+  ),
+  after: await load(readFileSync(file, 'utf8'))
+}
+const key = '0123456789abcdef0123456789abcdef'
+const codecs = Object.fromEntries(
+  Object.entries(arms).map(([arm, module]) => [arm, module.createRichMarkdownEditorCodec(key)])
+)
+const results = []
+for (const [name, input] of [
+  ['plain', '# Heading\nOrdinary prose.'],
+  ['complete', 'prefix [[README.md]] text '.repeat(100)],
+  ['unclosed-1000', `prefix ${'[[x'.repeat(1000)}`],
+  ['unclosed-8000', `prefix ${'[[x'.repeat(8000)} <b>tail</b>`],
+  ['invalid-closed-8000', `prefix ${'[[x'.repeat(8000)}]]`],
+  ['authored-1000', `prefix ${`[[ORCA_RICH_MD:${key}:`.repeat(1000)}`],
+  ['protected', '\\[[README.md]] `[[code.md]]`\n```md\n[[fenced.md]]\n```\n[[tail'],
+  ['transport', `before [[ORCA_RICH_MD:${key}:literal:hello]] [[tail`]
+]) {
+  for (const htmlSuperscriptLinks of [false, true]) {
+    const options = { htmlSuperscriptLinks }
+    const invoke = (arm) =>
+      arms[arm].encodeRawMarkdownHtmlForRichEditor(input, codecs[arm], options)
+    assert.equal(invoke('after'), invoke('before'))
+    const iterations = name.includes('8000') || name.includes('1000') ? 2 : 100
+    function run(arm) {
+      global.gc?.()
+      const start = performance.now()
+      const cpuStart = process.cpuUsage()
+      for (let i = 0; i < iterations; i++) {
+        invoke(arm)
+      }
+      const cpu = process.cpuUsage(cpuStart)
+      return {
+        ms: (performance.now() - start) / iterations,
+        cpuMs: (cpu.user + cpu.system) / 1000 / iterations
+      }
+    }
+    run('before')
+    run('after')
+    const samples = { before: [], after: [] }
+    for (const pair of buildCounterbalancedSchedule(10, 'before', 'after')) {
+      for (const arm of pair) {
+        samples[arm].push(run(arm))
+      }
+    }
+    const median = (values) => {
+      const sorted = [...values].sort((a, b) => a - b)
+      return (sorted[4] + sorted[5]) / 2
+    }
+    results.push({
+      name,
+      htmlSuperscriptLinks,
+      beforeCpuMs: median(samples.before.map((s) => s.cpuMs)),
+      afterCpuMs: median(samples.after.map((s) => s.cpuMs)),
+      beforeMs: median(samples.before.map((s) => s.ms)),
+      afterMs: median(samples.after.map((s) => s.ms)),
+      samples
+    })
+  }
+}
+console.log(
+  JSON.stringify({ baseline, node: process.version, platform: process.platform, results }, null, 2)
+)

--- a/src/renderer/src/components/editor/raw-markdown-doc-link-scan.test.ts
+++ b/src/renderer/src/components/editor/raw-markdown-doc-link-scan.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import { encodeRawMarkdownHtmlForRichEditor } from './raw-markdown-html'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+
+const key = '0123456789abcdef0123456789abcdef'
+
+describe('raw Markdown document-link closing searches', () => {
+  it.each([false, true])('skips impossible suffix searches (superscript links: %s)', (enabled) => {
+    const codec = createRichMarkdownEditorCodec(key)
+    const suffix = '[[missing '.repeat(300)
+    const input = `prefix [[README.md]] ${suffix}`
+    const original = String.prototype.indexOf
+    let searches = 0
+    const spy = vi.spyOn(String.prototype, 'indexOf').mockImplementation(function (
+      this: string,
+      search: string,
+      position?: number
+    ) {
+      if (search === ']]') {
+        searches++
+      }
+      return original.call(this, search, position)
+    })
+    let output: string
+    try {
+      output = encodeRawMarkdownHtmlForRichEditor(input, codec, { htmlSuperscriptLinks: enabled })
+    } finally {
+      spy.mockRestore()
+    }
+    expect(output).toBe(`prefix ${codec.transport.create('document-link', 'README.md')} ${suffix}`)
+    expect(searches).toBe(1)
+  })
+
+  it('protects every unclosed authored prefix without rescanning the suffix', () => {
+    const codec = createRichMarkdownEditorCodec(key)
+    const prefix = codec.transport.authoredPrefix
+    const input = `before ${`${prefix}x `.repeat(300)}`
+    const spy = vi.spyOn(String.prototype, 'indexOf')
+    let output: string
+    let searches: number
+    try {
+      output = encodeRawMarkdownHtmlForRichEditor(input, codec)
+      searches = spy.mock.calls.filter(([search]) => search === ']]').length
+    } finally {
+      spy.mockRestore()
+    }
+    expect(output).toBe(`before ${`${codec.transport.create('literal', prefix)}x `.repeat(300)}`)
+    expect(searches).toBe(0)
+  })
+
+  it('preserves escaped and code-protected links around the final closing marker', () => {
+    const codec = createRichMarkdownEditorCodec(key)
+    const input = '\\[[README.md]] `[[inline.md]]`\n```md\n[[fenced.md]]\n```\n[[unclosed'
+    expect(encodeRawMarkdownHtmlForRichEditor(input, codec)).toBe(input)
+  })
+
+  it('preserves a complete authored envelope before an unclosed document link', () => {
+    const codec = createRichMarkdownEditorCodec(key)
+    const authored = `${codec.transport.authoredPrefix}literal:hello]]`
+    expect(encodeRawMarkdownHtmlForRichEditor(`before ${authored} [[tail`, codec)).toBe(
+      `before ${codec.transport.create('literal', authored)} [[tail`
+    )
+  })
+})

--- a/src/renderer/src/components/editor/raw-markdown-html.ts
+++ b/src/renderer/src/components/editor/raw-markdown-html.ts
@@ -59,6 +59,7 @@ export function encodeRawMarkdownHtmlForRichEditor(
   { htmlSuperscriptLinks = false }: { htmlSuperscriptLinks?: boolean } = {}
 ): string {
   const normalizedContent = normalizeMarkdownReferenceLinks(content)
+  const lastBracketClose = normalizedContent.lastIndexOf(']]')
   const { transport } = codec
   let index = 0
   let isLineStart = true
@@ -156,7 +157,10 @@ export function encodeRawMarkdownHtmlForRichEditor(
     // Why: authored text that happens to contain this editor's random envelope
     // prefix must remain literal even in HTML-free documents and after edits.
     if (normalizedContent.startsWith(transport.authoredPrefix, index)) {
-      const authoredEnd = normalizedContent.indexOf(']]', index + transport.authoredPrefix.length)
+      const authoredEnd =
+        index + transport.authoredPrefix.length > lastBracketClose
+          ? -1
+          : normalizedContent.indexOf(']]', index + transport.authoredPrefix.length)
       const authoredOccurrence =
         authoredEnd === -1
           ? transport.authoredPrefix
@@ -190,7 +194,8 @@ export function encodeRawMarkdownHtmlForRichEditor(
       normalizedContent[index + 1] === '[' &&
       !isEscaped(normalizedContent, index)
     ) {
-      const closingIndex = normalizedContent.indexOf(']]', index + 2)
+      const closingIndex =
+        index + 2 > lastBracketClose ? -1 : normalizedContent.indexOf(']]', index + 2)
       if (closingIndex !== -1) {
         const rawTarget = normalizedContent.slice(index + 2, closingIndex)
         const link = parseMarkdownDocLink(rawTarget)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​64 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​64 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 |

<!-- /orca-pr-loc -->

## ELI5

Pasting Markdown with many unfinished `[[` links made the rich-editor encoder search the rest of the document for `]]` repeatedly. Locate the final closing marker once so impossible suffix searches can be skipped.

## What Changed

Compute the final `]]` position after reference-link normalization and use it to bound the existing closing searches for document links and authored transport prefixes. The original parser, escaping, code protection, token generation, and complete-link behavior remain intact. Independent baseline branch; #20293's HTML-comment optimization is not included.

## Why

The new count tests fail on baseline: 300 unfinished links after one valid link perform 301 closing searches, and 300 unfinished authored prefixes perform 300. They now perform one and zero, respectively, with identical encoded output.

Counterbalanced full-encoder benchmark on macOS/Node 24.18.0, median CPU time per call, including normalization and the real codec (10 pairs, GC outside samples):

| Input | Before | After |
| --- | ---: | ---: |
| 1,000 unmatched openers | 0.245 ms | 0.045 ms |
| 8,000 unmatched openers | 2.406 ms | 0.688 ms |
| 1,000 authored prefixes | 1.031 ms | 0.631 ms |
| 100 complete links | 0.032 ms | 0.032 ms |
| 8,000 invalid openers with a final close | 4.394 ms | 4.453 ms |

With superscript-link handling enabled, the 8,000-opener case improves from 2.450 to 0.711 ms. Plain text, protected code, and complete transport envelopes remain essentially unchanged. These are synthetic computation measurements, not rendered UI latency. A final closing marker still permits repeated invalid-target parsing; this PR does not claim to fix that separate cost.

## Linked Issue

User-requested repository performance audit; no linked issue.

## Visual Proof

N/A — pure encoder optimization with matching output; no visual or interaction change.

## Testing

- 83 tests across six suites passed with `ORCA_BACKGROUND_LAUNCH=1`: new closing-search tests, Markdown round-trip, superscript links, programmatic sync, inline image paragraphs, and link shortcuts.
- New count regressions fail against baseline and pass after the change; authored-prefix literal encoding and escaped/fenced/backtick protection are covered.
- `pnpm tc:web`, targeted oxlint, formatting, and commit hooks passed.
- Reproduce exact baseline/current output comparisons and raw CPU/wall measurements with `node --expose-gc config/scripts/raw-markdown-doc-link-scan-benchmark.mjs`. Both superscript-link options are tested.
- macOS/Node execution; no Electron launch or live SSH/Linux/Windows test. No platform-specific code, filesystem access, host routing, or workspace identity changes.

## Review

Self-reviewed source offsets: the bound uses normalized input, never generated transport output, and equality still permits a closing marker at the requested search position.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small and focused
- [x] Change and rationale explained
- [x] N/A visual proof with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform and SSH/remote impact considered
- [x] Focused lint, typecheck, and tests passed; CI covers remaining checks/build


## Merge order
Stacked on #20293. Merge #20293 first, then retarget this PR to `main`. Both comment and document-link search bounds are retained; 16 combined tests, lint and formatting pass.
