### PR TITLE
perf: reuse Windows PATH normalization within merges

### DIFF
--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process'
 import { delimiter, win32 as pathWin32 } from 'node:path'
 import type { ShellHydrationFailureReason } from '../../shared/shell-path-hydration-types'
 import { resolveWindowsShellStartupFamily } from '../../shared/windows-terminal-shell'
-import { WindowsShellPathOwnership, windowsPathSegmentKey } from './windows-shell-path-ownership'
+import { WindowsShellPathOwnership, createWindowsPathKey } from './windows-shell-path-ownership'
 
 // Why: GUI-launched Electron can miss PATH entries added by shell profiles.
 // Tools installed into ~/.opencode/bin, ~/.cargo/bin, pyenv/volta/fnm
@@ -374,7 +374,7 @@ export function mergePathSegments(segments: string[]): string[] {
   const pathDelimiter = process.platform === 'win32' ? pathWin32.delimiter : delimiter
   const currentSegments = current.split(pathDelimiter).filter(Boolean)
   const pathKey =
-    process.platform === 'win32' ? windowsPathSegmentKey : (segment: string): string => segment
+    process.platform === 'win32' ? createWindowsPathKey() : (segment: string): string => segment
   const shellSegments = uniquePathSegments(segments, pathKey)
   const shellSegmentSet = new Set(shellSegments.map(pathKey))
   const existing = new Set(currentSegments.map(pathKey))

--- a/src/main/startup/windows-shell-path-ownership.ts
+++ b/src/main/startup/windows-shell-path-ownership.ts
@@ -24,6 +24,18 @@ function splitPath(pathValue: string): string[] {
   return pathValue.split(pathWin32.delimiter).filter(Boolean)
 }
 
+export function createWindowsPathKey(): (segment: string) => string {
+  const keys = new Map<string, string>()
+  return (segment) => {
+    let key = keys.get(segment)
+    if (key === undefined) {
+      key = windowsPathSegmentKey(segment)
+      keys.set(segment, key)
+    }
+    return key
+  }
+}
+
 function externalAdditions(application: AppliedWindowsPath, currentValue: string): string[] {
   if (currentValue === application.appliedValue) {
     return []


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

Normalize each distinct Windows PATH spelling once while merging the shell's PATH.

## What Changed

Create a key reader scoped to one Windows merge in the existing Windows PATH module. Reuse its normalized keys across deduplication, membership checks, and output filtering. The reader is discarded after the merge; non-Windows behavior stays unchanged.

## Why

Windows Node benchmark of exported `mergePathSegments`, median of 15 measured batches after five warmups, 100 calls per batch, alternating original/modified order. Each call resets hydration state and restores a controlled inherited PATH; that setup is included in both timings. Half the shell entries overlap inherited PATH, which also contains duplicate external entries.

| Shell entries | Before | After |
| --- | ---: | ---: |
| 5 | 0.02845 ms | 0.02344 ms |
| 50 | 0.09527 ms | 0.05162 ms |
| 200 | 0.28825 ms | 0.13995 ms |

This measures merging CPU and environment updates, not shell-profile startup. No shell subprocesses run in the benchmark.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — same PATH and returned additions.

## Testing

- 42 hydration and Windows PATH ownership tests passed, including case/trailing-separator deduplication, shell changes and external additions.
- Exact original/modified PATH and additions matched all benchmark fixtures.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

Uses the existing Windows normalization function. Preserves first-wins shell order, duplicate inherited entries, drive roots and ownership restoration. No process launch, SSH/WSL execution routing or persistent cache changes. No max-lines exception added.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck and lint passed.
