### PR TITLE
perf: defer closed menus to speed up cold worktree switching

### DIFF
--- a/src/renderer/src/components/tab-bar/tab-bar-static-create-menu.tsx
+++ b/src/renderer/src/components/tab-bar/tab-bar-static-create-menu.tsx
@@ -13,7 +13,7 @@ import {
 import type { TabBarProps } from './tab-bar-props'
 import { resolveWindowsShellLaunchTarget } from './windows-shell-launch'
 
-export function renderTabBarStaticCreateMenu({
+export function TabBarStaticCreateMenu({
   terminalOnly,
   mobileEmulatorEnabled,
   managedBrowserCreationEnabled,

--- a/src/renderer/src/components/tab-bar/tab-bar-surface.tsx
+++ b/src/renderer/src/components/tab-bar/tab-bar-surface.tsx
@@ -22,7 +22,7 @@ import type { TabBarCreateMenuController } from './use-tab-bar-create-menu-contr
 import type { TabBarItemProjection } from './use-tab-bar-item-projection'
 import type { TabBarItem } from './tab-bar-item-model'
 import { renderTabBarItems } from './tab-bar-item-surface'
-import { renderTabBarStaticCreateMenu } from './tab-bar-static-create-menu'
+import { TabBarStaticCreateMenu } from './tab-bar-static-create-menu'
 import ClientHostedBrowserTabRows from './ClientHostedBrowserTabRows'
 import type { ClientHostedBrowserRow } from '../../../../shared/client-hosted-browser-rows'
 
@@ -98,24 +98,6 @@ export function renderTabBarSurface({
     includeTopTabBorder,
     activeClientHostedBrowserRowId,
     togglePinned
-  })
-  const standardCreateMenuItems = renderTabBarStaticCreateMenu({
-    props,
-    terminalOnly,
-    mobileEmulatorEnabled,
-    managedBrowserCreationEnabled,
-    mobileEmulatorCreationEnabled,
-    workspaceHasSimulatorTab,
-    showMobileEmulatorIntroCallout,
-    windowsShellEntries,
-    defaultWindowsPowerShellImplementation,
-    pwshAvailable: windowsTerminalCapabilities.pwshAvailable,
-    newTerminalShortcut,
-    newBrowserShortcut,
-    newSimulatorShortcut,
-    newFileShortcut,
-    openMarkdownShortcut,
-    queueNewActiveTerminalFocusAfterNewTabMenuClose
   })
 
   return (
@@ -263,7 +245,28 @@ export function renderTabBarSurface({
               {showStaticCreateMenuItems ? <DropdownMenuSeparator /> : null}
             </>
           ) : null}
-          {showStaticCreateMenuItems ? standardCreateMenuItems : null}
+          {showStaticCreateMenuItems ? (
+            <TabBarStaticCreateMenu
+              props={props}
+              terminalOnly={terminalOnly}
+              mobileEmulatorEnabled={mobileEmulatorEnabled}
+              managedBrowserCreationEnabled={managedBrowserCreationEnabled}
+              mobileEmulatorCreationEnabled={mobileEmulatorCreationEnabled}
+              workspaceHasSimulatorTab={workspaceHasSimulatorTab}
+              showMobileEmulatorIntroCallout={showMobileEmulatorIntroCallout}
+              windowsShellEntries={windowsShellEntries}
+              defaultWindowsPowerShellImplementation={defaultWindowsPowerShellImplementation}
+              pwshAvailable={windowsTerminalCapabilities.pwshAvailable}
+              newTerminalShortcut={newTerminalShortcut}
+              newBrowserShortcut={newBrowserShortcut}
+              newSimulatorShortcut={newSimulatorShortcut}
+              newFileShortcut={newFileShortcut}
+              openMarkdownShortcut={openMarkdownShortcut}
+              queueNewActiveTerminalFocusAfterNewTabMenuClose={
+                queueNewActiveTerminalFocusAfterNewTabMenuClose
+              }
+            />
+          ) : null}
           {showStaticCreateMenuItems && showAgentLaunchItems ? (
             <>
               <DropdownMenuSeparator />

--- a/src/renderer/src/components/terminal-pane/CloseTerminalDialog.test.tsx
+++ b/src/renderer/src/components/terminal-pane/CloseTerminalDialog.test.tsx
@@ -4,6 +4,11 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import CloseTerminalDialog from './CloseTerminalDialog'
+import { translate } from '@/i18n/i18n'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: vi.fn((_key: string, fallback: string) => fallback)
+}))
 
 const mountedRoots: Root[] = []
 
@@ -47,6 +52,22 @@ describe('CloseTerminalDialog', () => {
       }
     })
     document.body.innerHTML = ''
+  })
+
+  it('does no dialog-copy work while closed, then builds the opened confirmation', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    mountedRoots.push(root)
+    const props = { onCancel: vi.fn(), onConfirm: vi.fn() }
+    vi.mocked(translate).mockClear()
+
+    await act(async () => root.render(<CloseTerminalDialog open={false} {...props} />))
+    expect(translate).not.toHaveBeenCalled()
+
+    await act(async () => root.render(<CloseTerminalDialog open {...props} />))
+    expect(document.body.textContent).toContain('Stop running command?')
+    expect(translate).toHaveBeenCalled()
   })
 
   it('renders running command copy and confirms without skipping by default', async () => {

--- a/src/renderer/src/components/terminal-pane/CloseTerminalDialog.tsx
+++ b/src/renderer/src/components/terminal-pane/CloseTerminalDialog.tsx
@@ -70,71 +70,104 @@ export default function CloseTerminalDialog({
       }}
     >
       <DialogContent className="max-w-sm" showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle className="text-sm">
-            {isAgent
-              ? translate(
-                  'auto.components.terminal.pane.CloseTerminalDialog.stop_agent_title',
-                  'Stop this agent?'
-                )
-              : translate(
-                  'auto.components.terminal.pane.CloseTerminalDialog.stop_command_title',
-                  'Stop running command?'
-                )}
-          </DialogTitle>
-          <DialogDescription className="text-xs">
-            {isAgent
-              ? translate(
-                  'auto.components.terminal.pane.CloseTerminalDialog.stop_agent_description',
-                  "Closing this terminal will stop the agent's current work."
-                )
-              : translate(
-                  'auto.components.terminal.pane.CloseTerminalDialog.stop_command_description',
-                  'Closing this terminal will stop the command running inside it.'
-                )}
-          </DialogDescription>
-        </DialogHeader>
-        {trimmedTabLabel ? (
-          <p className="truncate text-xs font-medium text-foreground" title={trimmedTabLabel}>
-            {trimmedTabLabel}
-          </p>
-        ) : null}
-        <div className="flex items-center gap-2">
-          <Checkbox
-            id={checkboxId}
-            checked={dontAskAgain}
-            onCheckedChange={(checked) => setDontAskAgain(checked === true)}
-          />
-          <Label htmlFor={checkboxId} className="text-xs font-normal text-muted-foreground">
-            {translate(
-              'auto.components.terminal.pane.CloseTerminalDialog.dont_ask_again',
-              "Don't ask again for running terminals"
-            )}
-          </Label>
-        </div>
-        <DialogFooter className="gap-2">
-          <Button type="button" variant="outline" size="sm" onClick={onCancel}>
-            {translate('auto.components.terminal.pane.CloseTerminalDialog.1d1a7a9c1f', 'Cancel')}
-          </Button>
-          <Button
-            type="button"
-            variant="destructive"
-            size="sm"
-            autoFocus
-            onClick={() => onConfirm(dontAskAgain)}
-          >
-            {isAgent
-              ? translate(
-                  'auto.components.terminal.pane.CloseTerminalDialog.stop_agent_confirm',
-                  'Stop Agent'
-                )
-              : translate(
-                  'auto.components.terminal.pane.CloseTerminalDialog.stop_command_confirm',
-                  'Stop and Close'
-                )}
-          </Button>
-        </DialogFooter>
+        <CloseTerminalDialogBody
+          isAgent={isAgent}
+          trimmedTabLabel={trimmedTabLabel}
+          checkboxId={checkboxId}
+          dontAskAgain={dontAskAgain}
+          setDontAskAgain={setDontAskAgain}
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+        />
       </DialogContent>
     </Dialog>
+  )
+}
+
+// Keep translation and element construction behind the dialog portal's mount boundary.
+function CloseTerminalDialogBody({
+  isAgent,
+  trimmedTabLabel,
+  checkboxId,
+  dontAskAgain,
+  setDontAskAgain,
+  onCancel,
+  onConfirm
+}: {
+  isAgent: boolean
+  trimmedTabLabel: string | undefined
+  checkboxId: string
+  dontAskAgain: boolean
+  setDontAskAgain: (value: boolean) => void
+  onCancel: () => void
+  onConfirm: (dontAskAgain: boolean) => void
+}): React.JSX.Element {
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="text-sm">
+          {isAgent
+            ? translate(
+                'auto.components.terminal.pane.CloseTerminalDialog.stop_agent_title',
+                'Stop this agent?'
+              )
+            : translate(
+                'auto.components.terminal.pane.CloseTerminalDialog.stop_command_title',
+                'Stop running command?'
+              )}
+        </DialogTitle>
+        <DialogDescription className="text-xs">
+          {isAgent
+            ? translate(
+                'auto.components.terminal.pane.CloseTerminalDialog.stop_agent_description',
+                "Closing this terminal will stop the agent's current work."
+              )
+            : translate(
+                'auto.components.terminal.pane.CloseTerminalDialog.stop_command_description',
+                'Closing this terminal will stop the command running inside it.'
+              )}
+        </DialogDescription>
+      </DialogHeader>
+      {trimmedTabLabel ? (
+        <p className="truncate text-xs font-medium text-foreground" title={trimmedTabLabel}>
+          {trimmedTabLabel}
+        </p>
+      ) : null}
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id={checkboxId}
+          checked={dontAskAgain}
+          onCheckedChange={(checked) => setDontAskAgain(checked === true)}
+        />
+        <Label htmlFor={checkboxId} className="text-xs font-normal text-muted-foreground">
+          {translate(
+            'auto.components.terminal.pane.CloseTerminalDialog.dont_ask_again',
+            "Don't ask again for running terminals"
+          )}
+        </Label>
+      </div>
+      <DialogFooter className="gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+          {translate('auto.components.terminal.pane.CloseTerminalDialog.1d1a7a9c1f', 'Cancel')}
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          autoFocus
+          onClick={() => onConfirm(dontAskAgain)}
+        >
+          {isAgent
+            ? translate(
+                'auto.components.terminal.pane.CloseTerminalDialog.stop_agent_confirm',
+                'Stop Agent'
+              )
+            : translate(
+                'auto.components.terminal.pane.CloseTerminalDialog.stop_command_confirm',
+                'Stop and Close'
+              )}
+        </Button>
+      </DialogFooter>
+    </>
   )
 }

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import TerminalContextMenu from './TerminalContextMenu'
+import { translate } from '@/i18n/i18n'
 import type { KeybindingOverrides } from '../../../../shared/keybindings'
 
 type ItemProps = { onSelect?: () => void; children?: React.ReactNode }
@@ -13,9 +14,12 @@ vi.mock('@/components/ui/dropdown-menu', async () => {
   const React_ = await import('react')
   const passthrough = ({ children }: { children?: React.ReactNode }) =>
     React_.createElement(React_.Fragment, null, children)
+  const OpenContext = React_.createContext(false)
   return {
-    DropdownMenu: passthrough,
-    DropdownMenuContent: passthrough,
+    DropdownMenu: ({ open, children }: { open: boolean; children?: React.ReactNode }) =>
+      React_.createElement(OpenContext.Provider, { value: open }, children),
+    DropdownMenuContent: ({ children }: { children?: React.ReactNode }) =>
+      React_.useContext(OpenContext) ? passthrough({ children }) : null,
     DropdownMenuLabel: passthrough,
     DropdownMenuSeparator: () => null,
     DropdownMenuShortcut: ({ children }: { children?: React.ReactNode }) => {
@@ -36,7 +40,7 @@ vi.mock('@/components/ui/dropdown-menu', async () => {
     }
   }
 })
-vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+vi.mock('@/i18n/i18n', () => ({ translate: vi.fn((_key: string, fallback: string) => fallback) }))
 vi.mock('@/lib/agent-catalog', () => ({ AgentIcon: () => null }))
 vi.mock('./terminal-context-menu-dismiss', () => ({
   shouldIgnoreTerminalMenuPointerDownOutside: () => false
@@ -104,6 +108,7 @@ function renderMenu(overrides: Record<string, unknown> = {}): string {
 
 describe('TerminalContextMenu', () => {
   beforeEach(() => {
+    vi.mocked(translate).mockClear()
     items.list = []
     shortcuts.list = []
     vi.stubGlobal('navigator', { userAgent: 'Linux' })
@@ -111,6 +116,16 @@ describe('TerminalContextMenu', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('does no menu-copy work while closed, then builds the opened menu', () => {
+    renderMenu({ open: false })
+    expect(translate).not.toHaveBeenCalled()
+    expect(items.list).toHaveLength(0)
+
+    renderMenu()
+    expect(translate).toHaveBeenCalled()
+    expect(items.list.length).toBeGreaterThan(0)
   })
 
   it('renders a "Copy Context" item that triggers onCopyAgentSessionContext (issue #5020)', () => {
@@ -167,6 +182,7 @@ describe('TerminalContextMenu', () => {
     item?.onSelect?.()
     expect(onCopyAgentSessionId).toHaveBeenCalledTimes(1)
 
+    vi.mocked(translate).mockClear()
     items.list = []
     renderMenu({ canCopyAgentSessionId: false })
     expect(

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -78,11 +78,59 @@ type TerminalContextMenuProps = {
   onCopyAgentSessionId: () => void
 }
 
-export default function TerminalContextMenu({
-  open,
+export default function TerminalContextMenu(props: TerminalContextMenuProps): React.JSX.Element {
+  const { open, onOpenChange, menuPoint, menuOpenedAtRef } = props
+  return (
+    <DropdownMenu
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && Date.now() - menuOpenedAtRef.current < 100) {
+          return
+        }
+        onOpenChange(nextOpen)
+      }}
+      modal={false}
+    >
+      <DropdownMenuTrigger asChild>
+        <button
+          aria-hidden
+          tabIndex={-1}
+          className="pointer-events-none absolute size-px opacity-0"
+          style={{ left: menuPoint.x, top: menuPoint.y }}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-60"
+        sideOffset={0}
+        align="start"
+        onCloseAutoFocus={(e) => {
+          // Keep xterm focused instead of Radix's hidden trigger.
+          e.preventDefault()
+        }}
+        onFocusOutside={(e) => {
+          // xterm reclaiming focus after contextmenu is not an outside dismissal.
+          e.preventDefault()
+        }}
+        onPointerDownOutside={(e) => {
+          if (
+            shouldIgnoreTerminalMenuPointerDownOutside({
+              openedAtMs: menuOpenedAtRef.current,
+              nowMs: Date.now()
+            })
+          ) {
+            e.preventDefault()
+          }
+        }}
+      >
+        <TerminalContextMenuItems {...props} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+// Build menu rows only when Radix mounts the open content, after terminal activation.
+function TerminalContextMenuItems({
   onOpenChange,
-  menuPoint,
-  menuOpenedAtRef,
   canClosePane,
   canExpandPane,
   menuPaneIsExpanded,
@@ -139,219 +187,169 @@ export default function TerminalContextMenu({
   const showSetTitleShortcut = shortcuts.setTitle !== 'Unassigned'
   const showClearPaneTitleShortcut = shortcuts.clearPaneTitle !== 'Unassigned'
   return (
-    <DropdownMenu
-      open={open}
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen && Date.now() - menuOpenedAtRef.current < 100) {
-          return
-        }
-        onOpenChange(nextOpen)
-      }}
-      modal={false}
-    >
-      <DropdownMenuTrigger asChild>
-        <button
-          aria-hidden
-          tabIndex={-1}
-          className="pointer-events-none absolute size-px opacity-0"
-          style={{ left: menuPoint.x, top: menuPoint.y }}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        className="w-60"
-        sideOffset={0}
-        align="start"
-        onCloseAutoFocus={(e) => {
-          // Keep xterm focused instead of Radix's hidden trigger.
-          e.preventDefault()
-        }}
-        onFocusOutside={(e) => {
-          // xterm reclaiming focus after contextmenu is not an outside dismissal.
-          e.preventDefault()
-        }}
-        onPointerDownOutside={(e) => {
-          if (
-            shouldIgnoreTerminalMenuPointerDownOutside({
-              openedAtMs: menuOpenedAtRef.current,
-              nowMs: Date.now()
-            })
-          ) {
-            e.preventDefault()
-          }
-        }}
-      >
-        <DropdownMenuItem onSelect={onCopy}>
-          <Copy />
-          {translate('auto.components.terminal.pane.TerminalContextMenu.f3eeb1de13', 'Copy')}
-          <DropdownMenuShortcut>{shortcuts.copy}</DropdownMenuShortcut>
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onSelectAll}>
-          <TextSelect />
-          {translate('auto.components.terminal.pane.TerminalContextMenu.selectAll', 'Select All')}
-          <DropdownMenuShortcut>{shortcuts.selectAll}</DropdownMenuShortcut>
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onPaste}>
-          <Clipboard />
-          {translate('auto.components.terminal.pane.TerminalContextMenu.0a917b591a', 'Paste')}
-          <DropdownMenuShortcut>{shortcuts.paste}</DropdownMenuShortcut>
-        </DropdownMenuItem>
-        <TerminalQuickCommandsSubmenu
-          hosts={quickCommandHosts}
-          hostLoadFailed={quickCommandHostLoadFailed}
-          hostOwnershipPending={quickCommandHostOwnershipPending}
-          repoLabel={quickCommandRepoLabel}
-          onRun={onQuickCommand}
-          onClose={() => onOpenChange(false)}
-          onAdd={onAddQuickCommand}
-        />
-        {canContinueAgentSessionInNewSession ? (
-          <AgentSessionContinuationMenuItem onSelect={onContinueAgentSessionInNewSession} />
-        ) : null}
-        <DropdownMenuItem onSelect={onForkAgentSession}>
-          <GitFork />
-          {translate(
-            'auto.components.terminal.pane.TerminalContextMenu.8a7ddb8b8a',
-            'Fork Agent Session…'
-          )}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onCopyAgentSessionContext}>
-          <ClipboardCopy />
-          {translate(
-            'auto.components.terminal.pane.TerminalContextMenu.cff67afad1',
-            'Copy Context'
-          )}
-        </DropdownMenuItem>
-        {canToggleNativeChat ? (
-          <DropdownMenuItem onSelect={onToggleNativeChat}>
-            {isNativeChatView ? <SquareTerminal /> : <MessageSquare />}
-            {isNativeChatView
-              ? translate(
-                  'components.tab.bar.SortableTabContextMenu.switchToTerminalView',
-                  'Switch to terminal view'
-                )
-              : translate(
-                  'components.tab.bar.SortableTabContextMenu.switchToChatView',
-                  'Switch to chat view'
-                )}
-            <DropdownMenuShortcut>{shortcuts.nativeChat}</DropdownMenuShortcut>
-          </DropdownMenuItem>
-        ) : null}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem className="whitespace-nowrap" onSelect={onSplitRight}>
-          <PanelRightClose />
-          {translate(
-            'auto.components.terminal.pane.TerminalContextMenu.20e565d865',
-            'Split Terminal Right'
-          )}
-          <DropdownMenuShortcut>{shortcuts.splitRight}</DropdownMenuShortcut>
-        </DropdownMenuItem>
-        <DropdownMenuItem className="whitespace-nowrap" onSelect={onSplitDown}>
-          <PanelBottomClose />
-          {translate(
-            'auto.components.terminal.pane.TerminalContextMenu.98bccf4fa2',
-            'Split Terminal Down'
-          )}
-          <DropdownMenuShortcut>{shortcuts.splitDown}</DropdownMenuShortcut>
-        </DropdownMenuItem>
-        {canEqualizePaneSizes && (
-          <DropdownMenuItem onSelect={onEqualizePaneSizes}>
-            <PanelsTopLeft />
-            {translate(
-              'auto.components.terminal.pane.TerminalContextMenu.06c2b0f043',
-              'Equalize Pane Sizes'
-            )}
-            {showEqualizeShortcut ? (
-              <DropdownMenuShortcut>{shortcuts.equalize}</DropdownMenuShortcut>
-            ) : null}
-          </DropdownMenuItem>
+    <>
+      <DropdownMenuItem onSelect={onCopy}>
+        <Copy />
+        {translate('auto.components.terminal.pane.TerminalContextMenu.f3eeb1de13', 'Copy')}
+        <DropdownMenuShortcut>{shortcuts.copy}</DropdownMenuShortcut>
+      </DropdownMenuItem>
+      <DropdownMenuItem onSelect={onSelectAll}>
+        <TextSelect />
+        {translate('auto.components.terminal.pane.TerminalContextMenu.selectAll', 'Select All')}
+        <DropdownMenuShortcut>{shortcuts.selectAll}</DropdownMenuShortcut>
+      </DropdownMenuItem>
+      <DropdownMenuItem onSelect={onPaste}>
+        <Clipboard />
+        {translate('auto.components.terminal.pane.TerminalContextMenu.0a917b591a', 'Paste')}
+        <DropdownMenuShortcut>{shortcuts.paste}</DropdownMenuShortcut>
+      </DropdownMenuItem>
+      <TerminalQuickCommandsSubmenu
+        hosts={quickCommandHosts}
+        hostLoadFailed={quickCommandHostLoadFailed}
+        hostOwnershipPending={quickCommandHostOwnershipPending}
+        repoLabel={quickCommandRepoLabel}
+        onRun={onQuickCommand}
+        onClose={() => onOpenChange(false)}
+        onAdd={onAddQuickCommand}
+      />
+      {canContinueAgentSessionInNewSession ? (
+        <AgentSessionContinuationMenuItem onSelect={onContinueAgentSessionInNewSession} />
+      ) : null}
+      <DropdownMenuItem onSelect={onForkAgentSession}>
+        <GitFork />
+        {translate(
+          'auto.components.terminal.pane.TerminalContextMenu.8a7ddb8b8a',
+          'Fork Agent Session…'
         )}
-        {canExpandPane && (
-          <DropdownMenuItem onSelect={onToggleExpand}>
-            {menuPaneIsExpanded ? <Minimize2 /> : <Maximize2 />}
-            {menuPaneIsExpanded
-              ? translate(
-                  'auto.components.terminal.pane.TerminalContextMenu.df766809e0',
-                  'Collapse Pane'
-                )
-              : translate(
-                  'auto.components.terminal.pane.TerminalContextMenu.925f49f210',
-                  'Expand Pane'
-                )}
-            <DropdownMenuShortcut>{shortcuts.expand}</DropdownMenuShortcut>
-          </DropdownMenuItem>
+      </DropdownMenuItem>
+      <DropdownMenuItem onSelect={onCopyAgentSessionContext}>
+        <ClipboardCopy />
+        {translate('auto.components.terminal.pane.TerminalContextMenu.cff67afad1', 'Copy Context')}
+      </DropdownMenuItem>
+      {canToggleNativeChat ? (
+        <DropdownMenuItem onSelect={onToggleNativeChat}>
+          {isNativeChatView ? <SquareTerminal /> : <MessageSquare />}
+          {isNativeChatView
+            ? translate(
+                'components.tab.bar.SortableTabContextMenu.switchToTerminalView',
+                'Switch to terminal view'
+              )
+            : translate(
+                'components.tab.bar.SortableTabContextMenu.switchToChatView',
+                'Switch to chat view'
+              )}
+          <DropdownMenuShortcut>{shortcuts.nativeChat}</DropdownMenuShortcut>
+        </DropdownMenuItem>
+      ) : null}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem className="whitespace-nowrap" onSelect={onSplitRight}>
+        <PanelRightClose />
+        {translate(
+          'auto.components.terminal.pane.TerminalContextMenu.20e565d865',
+          'Split Terminal Right'
         )}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          onSelect={() => {
-            // Why: Set Title moves focus into an overlay input. Force-close
-            // before opening it so the menu's focus guards are not still active.
-            onOpenChange(false)
-            onSetTitle()
-          }}
-        >
-          <Pencil />
-          {translate('auto.components.terminal.pane.TerminalContextMenu.39809d152f', 'Set Title…')}
-          {showSetTitleShortcut ? (
-            <DropdownMenuShortcut>{shortcuts.setTitle}</DropdownMenuShortcut>
+        <DropdownMenuShortcut>{shortcuts.splitRight}</DropdownMenuShortcut>
+      </DropdownMenuItem>
+      <DropdownMenuItem className="whitespace-nowrap" onSelect={onSplitDown}>
+        <PanelBottomClose />
+        {translate(
+          'auto.components.terminal.pane.TerminalContextMenu.98bccf4fa2',
+          'Split Terminal Down'
+        )}
+        <DropdownMenuShortcut>{shortcuts.splitDown}</DropdownMenuShortcut>
+      </DropdownMenuItem>
+      {canEqualizePaneSizes && (
+        <DropdownMenuItem onSelect={onEqualizePaneSizes}>
+          <PanelsTopLeft />
+          {translate(
+            'auto.components.terminal.pane.TerminalContextMenu.06c2b0f043',
+            'Equalize Pane Sizes'
+          )}
+          {showEqualizeShortcut ? (
+            <DropdownMenuShortcut>{shortcuts.equalize}</DropdownMenuShortcut>
           ) : null}
         </DropdownMenuItem>
-        {canClearPaneTitle ? (
-          <DropdownMenuItem onSelect={onClearPaneTitle}>
+      )}
+      {canExpandPane && (
+        <DropdownMenuItem onSelect={onToggleExpand}>
+          {menuPaneIsExpanded ? <Minimize2 /> : <Maximize2 />}
+          {menuPaneIsExpanded
+            ? translate(
+                'auto.components.terminal.pane.TerminalContextMenu.df766809e0',
+                'Collapse Pane'
+              )
+            : translate(
+                'auto.components.terminal.pane.TerminalContextMenu.925f49f210',
+                'Expand Pane'
+              )}
+          <DropdownMenuShortcut>{shortcuts.expand}</DropdownMenuShortcut>
+        </DropdownMenuItem>
+      )}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        onSelect={() => {
+          // Why: Set Title moves focus into an overlay input. Force-close
+          // before opening it so the menu's focus guards are not still active.
+          onOpenChange(false)
+          onSetTitle()
+        }}
+      >
+        <Pencil />
+        {translate('auto.components.terminal.pane.TerminalContextMenu.39809d152f', 'Set Title…')}
+        {showSetTitleShortcut ? (
+          <DropdownMenuShortcut>{shortcuts.setTitle}</DropdownMenuShortcut>
+        ) : null}
+      </DropdownMenuItem>
+      {canClearPaneTitle ? (
+        <DropdownMenuItem onSelect={onClearPaneTitle}>
+          <X />
+          {translate(
+            'auto.components.terminal.pane.TerminalContextMenu.clearPaneTitle',
+            'Clear Pane Title'
+          )}
+          {showClearPaneTitleShortcut ? (
+            <DropdownMenuShortcut>{shortcuts.clearPaneTitle}</DropdownMenuShortcut>
+          ) : null}
+        </DropdownMenuItem>
+      ) : null}
+      {canCopyAgentSessionId ? (
+        <DropdownMenuItem onSelect={onCopyAgentSessionId}>
+          <Copy />
+          {translate(
+            'components.terminalPane.TerminalContextMenu.copySessionId',
+            'Copy Session ID'
+          )}
+        </DropdownMenuItem>
+      ) : null}
+      <DropdownMenuItem onSelect={onCopyTerminalId}>
+        <Copy />
+        {translate(
+          'auto.components.terminal.pane.TerminalContextMenu.copyTerminalId',
+          'Copy Terminal ID'
+        )}
+      </DropdownMenuItem>
+      <DropdownMenuItem onSelect={onCopyPaneId}>
+        <Copy />
+        {translate('auto.components.terminal.pane.TerminalContextMenu.2cf85a6a55', 'Copy Pane ID')}
+      </DropdownMenuItem>
+      {canClosePane && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onSelect={onClosePane}>
             <X />
             {translate(
-              'auto.components.terminal.pane.TerminalContextMenu.clearPaneTitle',
-              'Clear Pane Title'
+              'auto.components.terminal.pane.TerminalContextMenu.8c17d6786d',
+              'Close Pane'
             )}
-            {showClearPaneTitleShortcut ? (
-              <DropdownMenuShortcut>{shortcuts.clearPaneTitle}</DropdownMenuShortcut>
-            ) : null}
+            <DropdownMenuShortcut>{shortcuts.close}</DropdownMenuShortcut>
           </DropdownMenuItem>
-        ) : null}
-        {canCopyAgentSessionId ? (
-          <DropdownMenuItem onSelect={onCopyAgentSessionId}>
-            <Copy />
-            {translate(
-              'components.terminalPane.TerminalContextMenu.copySessionId',
-              'Copy Session ID'
-            )}
-          </DropdownMenuItem>
-        ) : null}
-        <DropdownMenuItem onSelect={onCopyTerminalId}>
-          <Copy />
-          {translate(
-            'auto.components.terminal.pane.TerminalContextMenu.copyTerminalId',
-            'Copy Terminal ID'
-          )}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onCopyPaneId}>
-          <Copy />
-          {translate(
-            'auto.components.terminal.pane.TerminalContextMenu.2cf85a6a55',
-            'Copy Pane ID'
-          )}
-        </DropdownMenuItem>
-        {canClosePane && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem variant="destructive" onSelect={onClosePane}>
-              <X />
-              {translate(
-                'auto.components.terminal.pane.TerminalContextMenu.8c17d6786d',
-                'Close Pane'
-              )}
-              <DropdownMenuShortcut>{shortcuts.close}</DropdownMenuShortcut>
-            </DropdownMenuItem>
-          </>
-        )}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onClearScreen}>
-          <Eraser />
-          {translate(
-            'auto.components.terminal.pane.TerminalContextMenu.b4cdd9314e',
-            'Clear Screen'
-          )}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </>
+      )}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem onSelect={onClearScreen}>
+        <Eraser />
+        {translate('auto.components.terminal.pane.TerminalContextMenu.b4cdd9314e', 'Clear Screen')}
+      </DropdownMenuItem>
+    </>
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​320 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​286 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |

<!-- /orca-pr-loc -->

## ELI5

Returning to a worktree after a while briefly shows a blank terminal while Orca rebuilds its renderer. That rebuild also prepared menus and a confirmation dialog that were closed. This PR waits until those surfaces open to construct their contents, leaving less work ahead of terminal restoration.

## What Changed

- Move terminal context-menu rows and shortcut computation into a component beneath `DropdownMenuContent`.
- Move close-confirmation content beneath `DialogContent`, while keeping checkbox/reset state with its existing owner so reopening and queued confirmations retain their behavior.
- Render the static New Tab entries as a component beneath the dropdown, instead of eagerly calling a render function.
- Add regression tests proving closed context menus/dialogs do not translate their body copy. The original code fails with 13 and 5 translations respectively; the changed code performs zero.

## Why

This removes repeated work from cold activation without extending terminal retention or adding a cache. It targets the reported case of returning after a while; it does not eliminate snapshot restore latency.

In a hidden macOS Electron test app using a production-built renderer served through Vite, real sidebar clicks switched between two Git worktrees with three terminals each and 1,500 lines of scrollback. Cold samples reload onto the other worktree first and verify that the target terminal manager is absent.

| Measurement | Before | After |
| --- | --- | --- |
| Cold restoration, four samples (ms) | 104.2, 119.7, 115.7, 86.1 | 91.6, 73.4, 93.3, 63.6 |
| Cold median | 110.0 ms | 82.5 ms (~25% lower) |
| Warm switches, two samples (ms) | 24.0, 19.4 | 24.4, 20.6 |

The metric is pointerdown to the first animation-frame sample containing restored terminal-buffer text, **not pixel-paint timing or a packaged-app benchmark**. This is a small local sample, not a guaranteed improvement on every machine. A separate development-renderer folder-workspace fixture with 10,000 lines improved from 194.8 ms to 156.1 ms median.

### User trade-offs and remaining opportunities

No observed loss of functionality or visible menu regression. The deliberate trade-off is that menu/dialog body construction and translation now happen when opened, rather than repeatedly while closed. Opening could absorb that small amount of work; menu-opening latency was not separately benchmarked. Existing Radix mount/exit behavior and confirmation state ownership are preserved.

There is no additional terminal memory retention, no shorter scrollback, and no change to PTY identity, replay ordering, geometry settling, repaint safeguards, SSH/remote protocols, or resource policies. A brief cold-restore blank interval remains.

No further material, trade-off-free improvement is established by this investigation. Hidden sibling admission did not delay initial content in the three-tab fixture. Additional probes saw snapshot writes at 62–74 ms and restored content at 73–97 ms; the startup-command grid-settle gate does not apply to that fixture. Keeping more renderers alive would spend memory, while skipping geometry/repaint safeguards risks incorrect or stale terminal rendering. Further elimination of redundant UI work remains a profiling candidate, not a claimed benefit.

## Linked Issue

Fixes #20308

## Visual Proof

These before/after screenshots verify equivalent restored terminal content and layout; the timing samples above provide the performance evidence. They do not capture the duration of the blank interval.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/bb5d44d2-de8b-4efc-9be8-57ef32cbdb8d) | ![After](https://github.com/user-attachments/assets/d40fa4b3-b4a4-4a2a-874a-b7e9a12a2fcf) |

## Testing

- [x] Manually tested locally in an agent-launched hidden Electron app with `ORCA_BACKGROUND_LAUNCH=1`, through Playwright CDP.
- [x] Automated tests added/updated.

23 tests passed across `TerminalContextMenu`, `CloseTerminalDialog`, and the TabBar Windows shell launch / SSH host / remote runtime suites. New closed-copy tests were verified failing against the original source and passing with the change.

`pnpm tc:web`, `pnpm run check:code-quality:changed`, formatting checks, and `git diff --check` passed. Production renderer builds succeeded for both benchmark variants.

Rendered checks covered the terminal context menu, New Tab menu, creating a terminal, and opening/cancelling the running-command close confirmation. A live alternate-screen redraw fixture survived sidebar switches and one renderer reload with the same PTY ID, continued advancing frames, and restored its normal buffer on completion.

Actual runtime testing was on macOS, with local Git and folder workspaces. Windows/SSH routing was covered by automated tests; Linux, Windows, and live SSH performance were not benchmarked. Full repository checks remain for CI.

## Review

Self-reviewed component boundaries, event callbacks, confirmation state resets, and unchanged platform/remote routing. No new effect, cache, timer, IPC, or lifecycle policy.

## Agent skill upstream boundary

- [x] Not applicable; no skill source changes.

## Checklist

- [x] This PR is small and focused
- [x] Explained what changed and why, including user trade-offs
- [x] Before/after screenshots attached, with measurement limitations
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and shortcut impact considered
- [x] Targeted checks passed; full repository checks left to CI
