### PR TITLE
perf: find path basename without splitting all segments

### DIFF
--- a/src/shared/cross-platform-path.ts
+++ b/src/shared/cross-platform-path.ts
@@ -165,7 +165,8 @@ export function getRuntimePathBasename(value: string): string {
   if (!trimmed) {
     return ''
   }
-  return trimmed.split(/[\\/]/).findLast(Boolean) ?? ''
+  const separator = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'))
+  return trimmed.slice(separator + 1)
 }
 
 /**


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Find a path's final segment without splitting the entire path into an array.

## What Changed

After the existing trailing-separator trim, find the last slash or backslash and slice past it. Keep empty/root paths and mixed-separator behavior unchanged.

## Why

Windows Node benchmark of the exported basename function, median of 15 measured batches after five warmups, 10,000 calls per batch, alternating original/modified order:

| Input | Before | After |
| --- | ---: | ---: |
| Bare filename | 0.000054 ms | 0.000043 ms |
| Windows drive path | 0.000154 ms | 0.000072 ms |
| WSL UNC path | 0.000196 ms | 0.000085 ms |
| POSIX path | 0.000139 ms | 0.000079 ms |
| Synthetic 1,000-segment path | 0.02184 ms | 0.00613 ms |

This is a small CPU/allocation improvement, not an app-latency claim. The long path is a stress fixture.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — same path labels.

## Testing

- 26 cross-platform path and guard tests passed.
- 10,000 deterministic original/modified comparisons matched, including empty paths, repeated/mixed separators, Unicode and lone surrogates.
- Node and renderer TypeScript checks, targeted oxlint and formatting passed.

## Review

No filesystem calls, path normalization, ownership, case folding, SSH/WSL routing or folder-workspace behavior changed.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typechecks and lint passed.
