### PR TITLE
fix: prevent infinite loops in mobile Markdown rendering

### DIFF
--- a/mobile/src/components/mobile-markdown-parser-progress.test.ts
+++ b/mobile/src/components/mobile-markdown-parser-progress.test.ts
@@ -1,0 +1,46 @@
+import { runInNewContext } from 'node:vm'
+import { describe, expect, it } from 'vitest'
+import { normalizeMobileMarkdownPreviewHtml } from './mobile-markdown-preview-html'
+import { parseMobileMarkdown } from './mobile-markdown-parser'
+
+function parseWithDeadline(input: string) {
+  // A synchronous parser loop must fail without hanging the test worker.
+  return runInNewContext('parse(input)', { parse: parseMobileMarkdown, input }, { timeout: 250 })
+}
+
+describe('mobile Markdown parser progress', () => {
+  it.each(['```c++', '```c#', '``` ts', '```ts title="file.ts"', '````', '```!'])(
+    'retains unsupported fence %s as paragraph text',
+    (fence) => {
+      expect(parseWithDeadline(fence)).toEqual([{ type: 'paragraph', text: fence }])
+      expect(parseWithDeadline(`before\n${fence}\nafter`)).toEqual([
+        { type: 'paragraph', text: `before\n${fence}\nafter` }
+      ])
+    }
+  )
+
+  it.each(['# ', '## ', '###### ', '#\t'])('consumes incomplete heading %s', (heading) => {
+    expect(parseWithDeadline(`${heading}\nnext`)).toEqual([
+      { type: 'paragraph', text: `${heading}\nnext` }
+    ])
+  })
+
+  it('handles unsupported fences through the production preview normalization', () => {
+    const input = normalizeMobileMarkdownPreviewHtml('```c++\nint x = 1;')
+    expect(parseWithDeadline(input)).toEqual([{ type: 'paragraph', text: input }])
+  })
+
+  it('recognizes a supported fence after unsupported fence text', () => {
+    expect(parseWithDeadline('```c++\n```ts\nconst x = 1\n```')).toEqual([
+      { type: 'paragraph', text: '```c++' },
+      { type: 'code', text: 'const x = 1', language: 'ts', closed: true }
+    ])
+  })
+
+  it('preserves supported fences and their streaming state', () => {
+    expect(parseWithDeadline('before\n```ts\nconst x = 1')).toEqual([
+      { type: 'paragraph', text: 'before' },
+      { type: 'code', text: 'const x = 1', language: 'ts', closed: false }
+    ])
+  })
+})

--- a/mobile/src/components/mobile-markdown-parser.ts
+++ b/mobile/src/components/mobile-markdown-parser.ts
@@ -8,6 +8,9 @@ export type MobileMarkdownBlock =
   | { type: 'table'; headers: string[]; rows: string[][] }
   | { type: 'rule' }
 
+const HEADING = /^(#{1,6})\s+(.+)$/
+const CODE_FENCE = /^```([A-Za-z0-9_-]+)?\s*$/
+
 function splitTableRow(line: string): string[] {
   return line
     .trim()
@@ -34,7 +37,7 @@ export function parseMobileMarkdown(content: string): MobileMarkdownBlock[] {
       continue
     }
 
-    const fence = line.match(/^```([A-Za-z0-9_-]+)?\s*$/)
+    const fence = line.match(CODE_FENCE)
     if (fence) {
       index += 1
       const code: string[] = []
@@ -80,7 +83,7 @@ export function parseMobileMarkdown(content: string): MobileMarkdownBlock[] {
       continue
     }
 
-    const heading = line.match(/^(#{1,6})\s+(.+)$/)
+    const heading = line.match(HEADING)
     if (heading) {
       blocks.push({ type: 'heading', level: heading[1]!.length, text: heading[2]!.trim() })
       index += 1
@@ -121,8 +124,8 @@ export function parseMobileMarkdown(content: string): MobileMarkdownBlock[] {
     while (
       index < lines.length &&
       lines[index]?.trim() &&
-      !(lines[index] ?? '').startsWith('```') &&
-      !/^(#{1,6})\s+/.test(lines[index] ?? '') &&
+      !CODE_FENCE.test(lines[index] ?? '') &&
+      !HEADING.test(lines[index] ?? '') &&
       !/^>\s?/.test(lines[index] ?? '') &&
       !/^\s*(?:[-*+]|\d+[.)])\s+/.test(lines[index] ?? '') &&
       !/^\s*(-{3,}|\*{3,}|_{3,})\s*$/.test(lines[index] ?? '')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

Mobile Markdown rendering can enter an infinite loop on tiny inputs such as an unsupported `c++` code fence or an incomplete heading (`# ` followed by another line). The block parser rejects these lines, while the paragraph parser stops before them, so neither advances the input cursor. Native chat and Markdown previews call this parser synchronously during rendering.

Use the same heading and fence predicates for block recognition and paragraph termination. Unsupported syntax remains literal paragraph text; supported code fences and streaming state retain their existing behavior.

Validation: 12 of the 13 new regression cases hit a 250ms VM execution deadline on the original parser; all pass with the fix. Separate production-parser diagnostics for three tiny fence inputs hit a 100ms cutoff before the fix and finish in 0.2–1.6ms afterward. 50 tests across five Markdown suites, full mobile typecheck, and changed-code quality pass. Tests include preview normalization. This validates parser termination; no native-device frame-time measurement was performed. No host execution, wire, or provider behavior changes.
