### PR TITLE
perf: eliminate mobile review table delimiter backtracking

### DIFF
--- a/mobile/src/components/pr-sidebar/markdown-blocks.ts
+++ b/mobile/src/components/pr-sidebar/markdown-blocks.ts
@@ -30,8 +30,6 @@ const HEADING = /^(#{1,6})\s+(.*)$/
 const FENCE = /^```/
 // Captures the fence info string (language) on the opening fence, e.g. ```mermaid.
 const FENCE_OPEN = /^```\s*([^\s`]*)/
-// A GFM table delimiter row: cells of dashes with optional leading/trailing colons.
-const TABLE_DELIM = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$/
 const QUOTE = /^>\s?(.*)$/
 const HR = /^(?:---+|\*\*\*+|___+)\s*$/
 const UNORDERED = /^\s*[-*+]\s+(.*)$/
@@ -114,7 +112,7 @@ function parseLines(content: string): MarkdownBlock[] {
 
     // GFM pipe table: a header row immediately followed by a delimiter row.
     // Requires the delimiter row so plain prose with a stray `|` isn't captured.
-    if (line.includes('|') && i + 1 < lines.length && TABLE_DELIM.test(lines[i + 1])) {
+    if (line.includes('|') && i + 1 < lines.length && isTableDelimiter(lines[i + 1])) {
       flushParagraph()
       const headers = splitTableRow(line)
       const align = parseAlignRow(lines[i + 1])
@@ -215,6 +213,10 @@ function splitTableRow(line: string): string[] {
   }
   cells.push(cell.trim())
   return cells
+}
+
+function isTableDelimiter(line: string): boolean {
+  return splitTableRow(line).every((cell) => /^:?-+:?$/.test(cell))
 }
 
 // Reads alignment from a delimiter row's colons: `:--` left, `:-:` center, `--:` right.

--- a/mobile/src/components/pr-sidebar/markdown-table-delimiter-performance.test.ts
+++ b/mobile/src/components/pr-sidebar/markdown-table-delimiter-performance.test.ts
@@ -1,0 +1,36 @@
+import { runInNewContext } from 'node:vm'
+import { describe, expect, it } from 'vitest'
+import { parseMarkdownBlocks } from './markdown-blocks'
+
+const ORIGINAL_DELIMITER = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)*\|?\s*$/
+
+function isParsedTable(delimiter: string): boolean {
+  return parseMarkdownBlocks(`a|b\n${delimiter}`)[0]?.kind === 'table'
+}
+
+describe('review Markdown table delimiter cost', () => {
+  it.each([
+    { name: 'leading whitespace', delimiter: ' '.repeat(60_000) + 'x' },
+    { name: 'trailing cell whitespace', delimiter: '-|-' + ' '.repeat(60_000) + 'x' }
+  ])('rejects $name without backtracking', ({ delimiter }) => {
+    // Interrupt synchronous regex regressions instead of hanging the test worker.
+    const blocks = runInNewContext(
+      'parse(input)',
+      { parse: parseMarkdownBlocks, input: `a|b\n${delimiter}` },
+      { timeout: 250 }
+    )
+    expect(blocks).toEqual([{ kind: 'paragraph', text: `a|b\n${delimiter}` }])
+  })
+
+  it('preserves the original delimiter grammar over generated rows', () => {
+    const parts = ['', '-', '--', ':', ':-:', ':--', '--:', '|', ' ', '\t', '\r', '\\|', 'x']
+    for (const left of parts) {
+      for (const middle of parts) {
+        for (const right of parts) {
+          const row = left + middle + right
+          expect(isParsedTable(row), JSON.stringify(row)).toBe(ORIGINAL_DELIMITER.test(row))
+        }
+      }
+    }
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

A review body/comment containing a pipe line followed by a whitespace-heavy malformed delimiter can stall mobile Markdown parsing. The table regex backtracks over overlapping whitespace quantifiers. Reuse the existing row splitter and validate each trimmed cell, preserving the existing optional pipes, whitespace, dash and colon grammar.

Production `parseMarkdownBlocks` diagnostic: `a|b` followed by a line containing 60,000 spaces and `x` takes 1,871ms before and 0.86ms after, returning the same paragraph. This is an adversarial parser measurement, not a native-device frame-time claim. `CommentMarkdown` calls the parser synchronously during rendering without truncating its input.

Validation: 21 tests across three review Markdown suites; 2,197 generated rows match the original delimiter grammar; both large malformed-row regressions hit their 250ms VM deadline on the original and pass with the fix. Full mobile typecheck and changed-code quality pass. No host execution, wire or provider behavior changes.
