### PR TITLE
perf: fast-path Windows arguments without escapes

### DIFF
--- a/src/shared/child-process/windows-command-line.ts
+++ b/src/shared/child-process/windows-command-line.ts
@@ -32,6 +32,9 @@
  * because that part `CommandLineToArgvW` does interpret.
  */
 function quoteWindows(value: string, escapePercent: boolean): string {
+  if (!(escapePercent ? /[\\"%]/ : /[\\"]/).test(value)) {
+    return `"${value}"`
+  }
   let quoted = '"'
   let backslashes = 0
   for (const char of value) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

Quote Windows arguments without walking every character when nothing inside needs escaping.

## What Changed

Return the quoted string directly when it contains no backslash or quote, and no percent sign for the cmd variant. Otherwise keep the existing escaping loop. Arguments remain quoted, including empty strings and spaces.

## Why

Windows Node benchmark of the exported quoting functions, median of 15 measured batches after five warmups, 1,000 calls per batch, alternating original/modified order:

| Function / fixture | Before | After |
| --- | ---: | ---: |
| Native / plain argument | 0.000156 ms | 0.000035 ms |
| Native / Windows path | 0.000304 ms | 0.000301 ms |
| Native / 10,000 plain characters | 0.09263 ms | 0.00026 ms |
| Native / 1,500 escaping characters | 0.01325 ms | 0.01326 ms |
| Cmd / plain argument | 0.000200 ms | 0.000032 ms |
| Cmd / Windows path | 0.000369 ms | 0.000378 ms |
| Cmd / 10,000 plain characters | 0.11204 ms | 0.00037 ms |
| Cmd / 1,500 escaping characters | 0.01816 ms | 0.01819 ms |

Synthetic quoting CPU measurements, not process-launch latency. Escaping-heavy cases are effectively unchanged. The long cmd fixture benchmarks the exported encoder, not a claim that cmd accepts command lines of that length.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical command-line strings.

## Testing

- 66 existing tests passed, including actual Windows `.cmd` round-trips through `runProcess`, the adversarial argument corpus, and operator-injection regression coverage.
- 40,000 deterministic original/modified quoting comparisons matched across both variants, including whitespace, metacharacters, CR/LF, Unicode and lone surrogates.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

No launcher, shell flags, newline rejection or cmd percent-escaping policy changed. Tests ran with background launch policy; no visible app launched. The native variant continues treating percent as ordinary text.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform and SSH behavior considered.
- [x] Relevant tests, typecheck and lint passed.
