### PR TITLE
perf(checks): bound log excerpt byte-limit checks

### DIFF
--- a/config/scripts/check-job-log-byte-cap-benchmark.mjs
+++ b/config/scripts/check-job-log-byte-cap-benchmark.mjs
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+
+// Pipe the baseline check-job-log-tail-slice.ts on stdin; both arms use the actual UTF-8 implementation.
+const entry = path.resolve('src/shared/check-job-log-tail-slice.ts')
+const sources = [readFileSync(0, 'utf8'), readFileSync(entry, 'utf8')]
+assert(sources.every((source) => source.includes('export function sliceCheckLogTail')))
+
+async function load(source) {
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    plugins: [
+      {
+        name: 'log-excerpt-source',
+        setup(builder) {
+          builder.onLoad({ filter: /check-job-log-tail-slice\.ts$/ }, () => ({
+            contents: source,
+            loader: 'ts',
+            resolveDir: path.dirname(entry)
+          }))
+        }
+      }
+    ]
+  })
+  const bundled = `${result.outputFiles[0].text}\n//# sourceURL=check-log-byte-cap-benchmark-bundle.js`
+  return import(`data:text/javascript;base64,${Buffer.from(bundled).toString('base64')}`)
+}
+
+const modules = await Promise.all(sources.map(load))
+const arms = modules.map((module) => module.sliceCheckLogTail)
+const limit = modules[0].PR_CHECK_LOG_TAIL_BYTES
+assert.equal(modules[1].PR_CHECK_LOG_TAIL_BYTES, limit)
+let seed = 0xc0ffee16
+function random(max) {
+  seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+  return (seed >>> 8) % max
+}
+
+let comparisons = 0
+function compare(text) {
+  const expected = arms[0](text)
+  assert.equal(arms[1](text), expected)
+  assert(Buffer.byteLength(expected, 'utf8') <= limit)
+  comparisons++
+  return expected
+}
+
+const units = ['x', 'é', '界', '😀', '\ud83d', '\udc00', 'x\ud83d界\udc00']
+for (const unit of units) {
+  for (let delta = -4; delta <= 4; delta++) {
+    const text = unit.repeat(Math.floor(limit / Buffer.byteLength(unit)) + delta)
+    compare(text)
+    compare(`error: ${text}\n${'recent\n'.repeat(103)}`)
+  }
+}
+const endings = ['\n', '\r\n', '\r', '']
+const tokens = [
+  'plain text',
+  '##[error]',
+  '::error::',
+  'error:',
+  'FAILED',
+  'exit code',
+  'ENOENT',
+  'EACCES',
+  'panic:',
+  'AssertionError',
+  'emoji 😀',
+  '\ud83d',
+  '\udc00',
+  '\0',
+  '界',
+  'é',
+  '\r'
+]
+for (let iteration = 0; iteration < 5000; iteration++) {
+  const rows = Array.from({ length: random(250) }, (_, index) => {
+    const token = tokens[random(tokens.length)]
+    if (index === 0 && iteration % 20 === 0) {
+      return `${token}${units[random(units.length)].repeat(limit + random(4))}`
+    }
+    return `${token} ${index} ${units[random(units.length)].repeat(random(30))}`
+  })
+  compare(rows.join(endings[random(endings.length)]) + endings[random(endings.length)])
+}
+console.log(`${comparisons} full-output differential cases passed`)
+
+const workloads = [
+  ['short ASCII', 'log '.repeat(16)],
+  ['short Unicode', '🦀界'.repeat(20)],
+  ['8KiB ASCII', 'x'.repeat(8192)],
+  ['16KiB ASCII exact cap', 'x'.repeat(limit)],
+  ['8Ki code units / 24KiB Unicode', '界'.repeat(8192)],
+  ['2MiB ASCII line', 'x'.repeat(2 * 1024 * 1024)],
+  ['8MiB ASCII line', 'x'.repeat(8 * 1024 * 1024)],
+  ['2MiB Unicode line', '界'.repeat(Math.floor((2 * 1024 * 1024) / 3))],
+  [
+    '2MiB earlier error context',
+    `error: ${'x'.repeat(2 * 1024 * 1024)}\n${'recent\n'.repeat(103)}`
+  ],
+  [
+    '220 ordinary lines',
+    Array.from({ length: 220 }, (_, i) => `line ${i} ${'text'.repeat(8)}`).join('\n')
+  ],
+  [
+    '220 lines / small earlier error',
+    Array.from(
+      { length: 220 },
+      (_, i) => `${i === 30 ? 'error:' : 'line'} ${i} ${'text'.repeat(8)}`
+    ).join('\n')
+  ]
+]
+
+function sample(arm, input, expected, repeats) {
+  const started = performance.now()
+  let output
+  for (let i = 0; i < repeats; i++) {
+    output = arm(input)
+  }
+  const elapsed = (performance.now() - started) / repeats
+  assert.equal(output, expected)
+  return elapsed
+}
+
+console.log(
+  JSON.stringify({
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    pairs: 8,
+    unit: 'ms'
+  })
+)
+for (const [name, input] of workloads) {
+  const expected = compare(input)
+  for (const arm of arms) {
+    const until = performance.now() + 80
+    while (performance.now() < until) {
+      sample(arm, input, expected, 1)
+    }
+  }
+  const repeats = Math.max(1, Math.min(100000, Math.ceil(40 / sample(arms[0], input, expected, 1))))
+  /** @type {number[][]} */
+  const samples = [[], []]
+  for (let pair = 0; pair < 8; pair++) {
+    for (const index of pair % 2 ? [1, 0] : [0, 1]) {
+      samples[index].push(sample(arms[index], input, expected, repeats))
+    }
+  }
+  const median = samples.map((values) => {
+    values.sort((a, b) => a - b)
+    return (values[3] + values[4]) / 2
+  })
+  console.log(JSON.stringify({ name, repeats, median, samples }))
+}

--- a/src/shared/check-job-log-byte-cap.test.ts
+++ b/src/shared/check-job-log-byte-cap.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as byteLimits from './utf8-byte-limits'
+import {
+  PR_CHECK_LOG_TAIL_BYTES,
+  PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR,
+  sliceCheckLogTail
+} from './check-job-log-tail-slice'
+
+describe('check log excerpt byte-cap work', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it.each(['recent', 'earlier'] as const)('bounds byte counting for a long %s line', (position) => {
+    const longLine = `error: ${'x'.repeat(2 * 1024 * 1024)}`
+    const input = position === 'recent' ? longLine : `${longLine}\n${'recent\n'.repeat(100)}`
+    const byteLength = vi.spyOn(byteLimits, 'getUtf8ByteLength')
+    const output = sliceCheckLogTail(input)
+    const countedUnits = byteLength.mock.calls.reduce((total, [text]) => total + text.length, 0)
+
+    expect(countedUnits).toBeLessThanOrEqual(PR_CHECK_LOG_TAIL_BYTES)
+    expect(Buffer.byteLength(output)).toBe(PR_CHECK_LOG_TAIL_BYTES)
+    if (position === 'recent') {
+      expect(output).toBe('x'.repeat(PR_CHECK_LOG_TAIL_BYTES))
+    } else {
+      expect(output.endsWith(PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR)).toBe(true)
+      expect(output).toContain('\nrecent\n')
+    }
+  })
+
+  it.each(['x', 'é', '界', '😀', '\ud83d', '\udc00'])(
+    'preserves byte boundaries for %j',
+    (unit) => {
+      const width = Buffer.byteLength(unit)
+      for (const delta of [-1, 0, 1]) {
+        const count = Math.floor(PR_CHECK_LOG_TAIL_BYTES / width) + delta
+        const input = unit.repeat(count)
+        const output = sliceCheckLogTail(input)
+        expect(output).toBe(
+          unit.repeat(Math.min(count, Math.floor(PR_CHECK_LOG_TAIL_BYTES / width)))
+        )
+        expect(Buffer.byteLength(output)).toBeLessThanOrEqual(PR_CHECK_LOG_TAIL_BYTES)
+      }
+    }
+  )
+
+  it('retains earlier multibyte context whose byte count exceeds its code-unit count', () => {
+    const failure = `error: ${'界'.repeat(6000)}`
+    const input = `${failure}\n${'recent\n'.repeat(103)}`
+    const prefix = `${failure}\nrecent\nrecent\n${PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR}`
+    expect(prefix.length).toBeLessThan(PR_CHECK_LOG_TAIL_BYTES)
+    expect(Buffer.byteLength(prefix)).toBeGreaterThan(PR_CHECK_LOG_TAIL_BYTES)
+    expect(sliceCheckLogTail(input)).toBe(
+      byteLimits.clampUtf8TextTail(prefix, PR_CHECK_LOG_TAIL_BYTES).text
+    )
+  })
+})

--- a/src/shared/check-job-log-tail-slice.ts
+++ b/src/shared/check-job-log-tail-slice.ts
@@ -1,4 +1,8 @@
-import { clampUtf8TextTail, getUtf8ByteLength } from './utf8-byte-limits'
+import {
+  clampUtf8TextTail,
+  getUtf8ByteLength,
+  isUtf8ByteLengthWithinLimit
+} from './utf8-byte-limits'
 
 export const PR_CHECK_LOG_TAIL_LINES = 200
 export const PR_CHECK_LOG_TAIL_RECENT_LINES = 100
@@ -13,7 +17,7 @@ const ERROR_LINE_PATTERN =
   /(?:##\[error\]|::error::|::error\b|\berror:|FAILED|exit code|ENOENT|EACCES|panic:|AssertionError)/i
 
 function applyLogTailByteCap(text: string): string {
-  if (getUtf8ByteLength(text) <= PR_CHECK_LOG_TAIL_BYTES) {
+  if (isUtf8ByteLengthWithinLimit(text, PR_CHECK_LOG_TAIL_BYTES)) {
     return text
   }
   return clampUtf8TextTail(text, PR_CHECK_LOG_TAIL_BYTES).text
@@ -21,7 +25,9 @@ function applyLogTailByteCap(text: string): string {
 
 function joinLogExcerptWithByteCap(prefixLines: string[], recentLines: string[]): string {
   const prefix = prefixLines.join('\n')
-  const prefixByteLength = getUtf8ByteLength(prefix)
+  // UTF-16 length is a lower bound; oversized prefixes need no exact byte count.
+  const prefixByteLength =
+    prefix.length >= PR_CHECK_LOG_TAIL_BYTES ? PR_CHECK_LOG_TAIL_BYTES : getUtf8ByteLength(prefix)
   if (prefixByteLength >= PR_CHECK_LOG_TAIL_BYTES) {
     return clampUtf8TextTail(prefix, PR_CHECK_LOG_TAIL_BYTES).text
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​171 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​168 |

<!-- /orca-pr-loc -->

## Summary

Reuse `isUtf8ByteLengthWithinLimit` when a check-log excerpt only needs a yes/no byte-limit decision. That existing helper rejects text whose UTF-16 length already exceeds the limit and otherwise uses bounded native encoding. For earlier-error prefixes, avoid exact byte counting when the code-unit length already proves the prefix will take the clamp branch.

Same selected lines, earlier-error priority, separator, CRLF normalization, UTF-8 cap, and returned text. No download/cache/transport changes. Both GitHub and GitLab callers benefit; no local-worktree assumption or change to host execution ownership.

Independent of #20208: that PR changes earlier-error selection; this one changes only byte-cap checks in separate functions. Based on `20ab99506541`, not stacked or bundled.

## Measured result

Full actual `sliceCheckLogTail` before/current, with the actual shared UTF-8 implementation. Node 26.6.0 / macOS arm64, eight counterbalanced pairs. Median CPU time:

| Input | Before | After |
| --- | ---: | ---: |
| Short ASCII | 0.174 µs | 0.102 µs |
| Short Unicode | 0.199 µs | 0.180 µs |
| 8 KiB ASCII | 0.0179 ms | 0.000533 ms |
| 16 KiB ASCII, exact cap | 0.0365 ms | 0.000902 ms |
| 24 KiB Unicode / 8 Ki code units | 0.0393 ms | 0.0218 ms |
| 2 MiB ASCII line | 4.777 ms | 0.128 ms |
| 8 MiB ASCII line | 18.77 ms | 0.322 ms |
| 2 MiB Unicode line | 1.864 ms | 0.202 ms |
| 2 MiB earlier-error context | 4.340 ms | 0.665 ms |
| 220 ordinary lines | 0.0269 ms | 0.0126 ms |
| 220 lines, small earlier-error context | 0.02275 ms | 0.02275 ms |

The existing GitHub log fetch allows 64 MiB; GitLab bounds raw trace input to 512 Ki characters before normalization. Long single-line cases demonstrate the unnecessary byte-counting cost, not typical log shape. These synthetic CPU timings include line splitting/selection/capping, not log download or app-wide latency. Full line splitting and other excerpt allocations remain unchanged; the bounded encoder reuses its existing shared scratch buffer.

## Verification

- 5,126 full-output differential cases cover empty input, newlines/CRLF/bare CR, dense/sparse error markers, Unicode, lone surrogates, and exact/under/over-cap boundaries in recent and earlier context.
- Deterministic regression: baseline sends 2,097,159 / 2,097,185 code units to the full byte counter for long recent/earlier lines; current stays under the 16,384-unit bound. The seven new behavior cases also pass on baseline.
- 82 tests across 8 files pass, including UTF-8 primitives and GitHub/GitLab check-log callers.
- `pnpm tc:node`, changed-code quality gate and formatting pass. All checks use `ORCA_BACKGROUND_LAUNCH=1`; no app windows launched.

Reproduce:

```sh
git show 20ab99506541:src/shared/check-job-log-tail-slice.ts | ORCA_BACKGROUND_LAUNCH=1 node config/scripts/check-job-log-byte-cap-benchmark.mjs
ORCA_BACKGROUND_LAUNCH=1 pnpm test src/shared/check-job-log src/shared/utf8-byte-limits.test.ts src/shared/gitlab-job src/shared/gitlab-pipeline-checks.test.ts src/main/github/client-pr-check-details.test.ts src/main/github/client-pr-checks.test.ts
ORCA_BACKGROUND_LAUNCH=1 pnpm tc:node
ORCA_BACKGROUND_LAUNCH=1 ORCA_CODE_QUALITY_BASE=20ab99506541 pnpm run check:code-quality:changed
```

Tracking: #20206. Does not close the broader performance audit.
