### PR TITLE
perf: use native newline search in rich Markdown code stripping

### DIFF
--- a/config/scripts/rich-markdown-line-scan-benchmark.mjs
+++ b/config/scripts/rich-markdown-line-scan-benchmark.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+const baseline = process.argv[2] ?? '20ab9950654'
+const file = 'src/renderer/src/components/editor/markdown-rich-mode.ts'
+async function load(contents) {
+  const result = await build({
+    stdin: { contents, loader: 'ts', resolveDir: dirname(resolve(file)) },
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    plugins: [
+      {
+        name: 'cached-round-trip',
+        setup(bundler) {
+          bundler.onResolve({ filter: /markdown-round-trip$|^@\/i18n\/i18n$/ }, (args) => ({
+            path: args.path,
+            namespace: 'bench'
+          }))
+          bundler.onLoad({ filter: /.*/, namespace: 'bench' }, (args) => ({
+            contents: args.path.endsWith('markdown-round-trip')
+              ? 'export const getRichMarkdownRoundTripOutput = () => { throw new Error("unexpected editor round trip") }'
+              : 'export const translate = (_key, fallback) => fallback',
+            loader: 'js'
+          }))
+        }
+      }
+    ]
+  })
+  return import(
+    `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+  )
+}
+const arms = {
+  before: await load(
+    execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8', windowsHide: true })
+  ),
+  after: await load(readFileSync(file, 'utf8'))
+}
+const results = []
+for (const size of [20_000, 200_000, 600_000]) {
+  for (const shape of ['lines', 'long-line']) {
+    const phrase =
+      shape === 'lines'
+        ? 'Ordinary prose with a little `code`.\n'
+        : 'Ordinary prose with a little `code`. '
+    const content = phrase.repeat(Math.ceil(size / phrase.length)).slice(0, size)
+    const invoke = (arm) =>
+      arms[arm].getMarkdownRichModeEligibilityDecision({ content, sizeOverridden: false })
+    assert.deepEqual(invoke('after'), invoke('before'))
+    assert.equal(invoke('after').exceedsSizeLimit, false)
+    for (let i = 0; i < 10; i++) {
+      invoke('before')
+      invoke('after')
+    }
+    const samples = { before: [], after: [] }
+    for (const pair of buildCounterbalancedSchedule(8, 'before', 'after')) {
+      for (const arm of pair) {
+        global.gc?.()
+        const cpuStart = process.cpuUsage()
+        const start = performance.now()
+        for (let i = 0; i < 20; i++) {
+          invoke(arm)
+        }
+        const ms = (performance.now() - start) / 20
+        const cpu = process.cpuUsage(cpuStart)
+        samples[arm].push({ ms, cpuMs: (cpu.user + cpu.system) / 20_000 })
+      }
+    }
+    results.push({ size, shape, samples })
+  }
+}
+console.log(
+  JSON.stringify(
+    {
+      baseline,
+      node: process.version,
+      roundTrip: 'throwing stub; these inputs must never invoke it',
+      results
+    },
+    null,
+    2
+  )
+)

--- a/src/renderer/src/components/editor/markdown-rich-line-scan.test.ts
+++ b/src/renderer/src/components/editor/markdown-rich-line-scan.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getMarkdownRichModeEligibilityDecision } from './markdown-rich-mode'
+
+const decide = (content: string) =>
+  getMarkdownRichModeEligibilityDecision({ content, sizeOverridden: false })
+
+describe('rich Markdown line scanning', () => {
+  it('does not inspect every prose character to find newline boundaries', () => {
+    const content = 'Ordinary prose '.repeat(10_000)
+    const spy = vi.spyOn(String.prototype, 'charCodeAt')
+    let decision: ReturnType<typeof decide>
+    let calls: number
+    try {
+      decision = decide(content)
+      calls = spy.mock.calls.length
+    } finally {
+      spy.mockRestore()
+    }
+    expect(decision).toEqual({ exceedsSizeLimit: false, unsupportedReason: null })
+    expect(calls).toBeLessThan(10)
+  })
+
+  it.each(['\n', '\r\n'])(
+    'preserves fences and reference visibility with %j endings',
+    (newline) => {
+      for (const fence of ['```', '~~~']) {
+        const protectedSource = [`${fence}md`, '[ref]: /hidden', fence].join(newline)
+        expect(decide(protectedSource).unsupportedReason).toBeNull()
+        expect(decide(protectedSource + newline).unsupportedReason).toBeNull()
+        expect(decide(`${protectedSource}${newline}[ref]: /visible`).unsupportedReason).toBe(
+          'reference-links'
+        )
+      }
+    }
+  )
+
+  it.each(['', '\n', '\r', '\r\n', '`[ref]: /hidden`', '```\n[ref]: /hidden\r'])(
+    'preserves empty, final-CR, inline-code and unclosed-fence input %j',
+    (content) => expect(decide(content).unsupportedReason).toBeNull()
+  )
+})

--- a/src/renderer/src/components/editor/markdown-rich-mode.ts
+++ b/src/renderer/src/components/editor/markdown-rich-mode.ts
@@ -185,10 +185,9 @@ function stripMarkdownCode(content: string): string {
   let activeFence: '`' | '~' | null = null
   let lineStart = 0
 
-  for (let index = 0; index <= content.length; index += 1) {
-    if (index < content.length && content.charCodeAt(index) !== 10) {
-      continue
-    }
+  while (lineStart <= content.length) {
+    const newlineIndex = content.indexOf('\n', lineStart)
+    const index = newlineIndex === -1 ? content.length : newlineIndex
     const lineEnd = index > lineStart && content.charCodeAt(index - 1) === 13 ? index - 1 : index
     const line = content.slice(lineStart, lineEnd)
     const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 |

<!-- /orca-pr-loc -->

## ELI5

Rich-mode eligibility checked every character just to find line boundaries before removing code spans and fences. Native newline search finds those same boundaries with less JavaScript work.

## What Changed

Replace the character loop in `stripMarkdownCode` with a forward `indexOf('\n')` cursor. Keep the existing CR removal, final-line handling, fence rules, inline-code expression, and eligibility checks unchanged. Independent baseline branch; #20287's comment-scanning changes are not included.

## Why

A 150 KB prose line previously caused 150,001 `charCodeAt` calls. The new regression passes with fewer than ten; the retained CR boundary check is still performed.

Full `getMarkdownRichModeEligibilityDecision` benchmark includes the size check and matches baseline decisions. Inputs fit the 600 KiB limit. Counterbalanced 8 pairs, 20 calls per arm, GC outside samples, macOS/Node 24:

| Input | Before CPU | After CPU |
| --- | ---: | ---: |
| 20 KB multiline | 0.161 ms | 0.129 ms |
| 200 KB multiline | 1.089 ms | 0.770 ms |
| 600 KB multiline | 3.294 ms | 2.148 ms |
| 600 KB single line | 2.194 ms | 1.097 ms |

Wall time varied with shared-machine load: the earlier 600 KB multiline probe was 3.494→2.103 ms, while the final run was 7.237→4.989 ms. CPU measurements and deterministic operation counts support the improvement without attributing scheduling noise to the change. These are computation timings, not rendered UI latency. The benchmark throws if the editor round-trip path is invoked; these prose inputs never invoke it.

## Linked Issue

User-requested repository performance audit; no linked issue.

## Visual Proof

N/A — pure parsing-loop change preserving eligibility and displayed behavior.

## Testing

- 51 tests across line-scan, rich-mode eligibility, eligibility cache, and size-limit suites passed with `ORCA_BACKGROUND_LAUNCH=1`.
- New scan-count regression fails on baseline and passes after. LF/CRLF, final CR, empty/trailing lines, both fence markers, unclosed fences, inline code, and reference visibility cases pass.
- Renderer typecheck, regular lint, benchmark type-aware lint, formatting, and commit hooks passed.
- Reproduce exact baseline/current decisions and raw CPU/wall samples with `node --expose-gc config/scripts/rich-markdown-line-scan-benchmark.mjs`.
- macOS/Node only; no Electron launch or live SSH/Linux/Windows testing. No platform-dependent code, host routing, workspace identity, or wire changes.

## Review

Self-reviewed final empty-line processing and cursor advance: a missing newline maps to source length, then the next cursor exits. Lone CR behavior remains the same.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Small, focused, and explained
- [x] N/A visual proof with reason
- [x] Self-reviewed for correctness and performance
- [x] Cross-platform and remote impact considered
- [x] Focused tests, typecheck, lint passed; CI covers remaining checks/build
