### PR TITLE
perf: stop building chat diff sections beyond preview limit

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-diff.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-diff.test.ts
@@ -63,6 +63,27 @@ describe('diffFromToolCall', () => {
     ])
   })
 
+  it.each([31_999, 32_000, 32_001])(
+    'preserves multi-file truncation at %i characters before the next section',
+    (length) => {
+      const header = '--- a\n+++ a\n'
+      const diff = '@@ -1 +1 @@\n-old\n+new\n'
+      const first = diff + 'x'.repeat(length - header.length - diff.length)
+      const changes = [
+        { path: 'a', diff: first },
+        null,
+        { path: 'ignored' },
+        { path: 'b', kind: { move_path: 'c' }, diff: '@@ -1 +1 @@\n-b\n+c' }
+      ]
+      const text = `${header}${first}\n--- b\n+++ c\n@@ -1 +1 @@\n-b\n+c`
+      for (const maxLines of [2, 120, 40_000]) {
+        expect(diffFromToolCall('apply_patch', { changes }, maxLines)).toEqual(
+          diffFromText(text, maxLines)
+        )
+      }
+    }
+  )
+
   it('returns null when there is no old/new payload', () => {
     expect(diffFromToolCall('Edit', { file_path: '/x' })).toBeNull()
   })

--- a/src/shared/native-chat-diff.ts
+++ b/src/shared/native-chat-diff.ts
@@ -100,13 +100,15 @@ function patchTextFromToolInput(value: Record<string, unknown>): string | null {
   if (!Array.isArray(value.changes)) {
     return null
   }
-  const sections = value.changes.flatMap((entry) => {
+  const sections: string[] = []
+  let length = 0
+  for (const entry of value.changes) {
     if (typeof entry !== 'object' || entry === null) {
-      return []
+      continue
     }
     const change = entry as Record<string, unknown>
     if (typeof change.diff !== 'string') {
-      return []
+      continue
     }
     const path = typeof change.path === 'string' ? change.path : 'file'
     const kind =
@@ -114,8 +116,14 @@ function patchTextFromToolInput(value: Record<string, unknown>): string | null {
         ? (change.kind as Record<string, unknown>)
         : null
     const nextPath = kind && typeof kind.move_path === 'string' ? kind.move_path : path
-    return [`--- ${path}\n+++ ${nextPath}\n${change.diff}`]
-  })
+    const section = `--- ${path}\n+++ ${nextPath}\n${change.diff}`
+    length += section.length + (sections.length > 0 ? 1 : 0)
+    sections.push(section)
+    // Keep the extra character that tells toLines the diff was truncated.
+    if (length > MAX_DIFF_CHARS) {
+      break
+    }
+  }
   return sections.length > 0 ? sections.join('\n') : null
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |

<!-- /orca-pr-loc -->

## ELI5

Stop assembling file-change text once the chat diff's existing character limit is exceeded. Large multi-file edits display the same preview without constructing discarded sections.

## What Changed

Track section and separator lengths while collecting structured `changes`. Stop strictly beyond 32,000 characters, preserving the extra character needed by the existing truncation logic. Direct patch/diff strings and line classification remain unchanged.

## Why

Windows Node benchmark of `diffFromToolCall`, alternating original/modified order, five warmups followed by 15 measured batches; median milliseconds per call. Each file has a hunk and 100 context lines.

| Files | Before | After |
| --- | ---: | ---: |
| 1 | 0.00354 | 0.00346 |
| 10 | 0.00497 | 0.00480 |
| 1,000 | 0.27422 | 0.00794 |
| 10,000 | 2.64110 | 0.00853 |

These are synthetic CPU measurements on Windows, not measured application latency. The optimization skips later file sections; it does not bound the size of an individual section. No cache, I/O, process or host-ownership changes.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — displayed diff output is unchanged.

## Testing

- All 26 diff tests pass, including added 31,999/32,000/32,001-character boundary cases with skipped invalid entries, rename headers, and multiple line limits.
- 15,000 deterministic original/modified output comparisons match, including Unicode, varying file counts and line limits.
- Node and renderer TypeScript checks, targeted oxlint and formatting pass.

## Review

The strict greater-than boundary preserves truncation even when an additional separator crosses the limit. All sections preceding that point are unchanged. The formatter handles native, WSL and SSH tool inputs identically and has no repository assumptions. Tests ran with background launch policy; no app launched.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, SSH and folder workspace behavior considered.
- [x] Relevant tests, typechecks and lint passed.
