### PR TITLE
fix(tabs): cancel split drags when the window loses focus

### DIFF
--- a/src/renderer/src/components/tab-group/tab-drag-pointer-sensor.test.ts
+++ b/src/renderer/src/components/tab-group/tab-drag-pointer-sensor.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import type { PointerSensorOptions, SensorProps } from '@dnd-kit/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TabDragPointerSensor } from './tab-drag-pointer-sensor'
+
+function startSensor(options: PointerSensorOptions = {}) {
+  const callbacks = {
+    onAbort: vi.fn(),
+    onPending: vi.fn(),
+    onStart: vi.fn(),
+    onCancel: vi.fn(),
+    onMove: vi.fn(),
+    onEnd: vi.fn()
+  }
+  new TabDragPointerSensor({
+    active: 'tab-1',
+    event: new PointerEvent('pointerdown', { clientX: 10, clientY: 10 }),
+    options,
+    ...callbacks
+  } as unknown as SensorProps<PointerSensorOptions>)
+  return callbacks
+}
+
+function movePointer(): void {
+  document.dispatchEvent(new PointerEvent('pointermove', { clientX: 100, clientY: 50 }))
+}
+
+beforeEach(() => vi.useFakeTimers())
+
+afterEach(() => {
+  window.dispatchEvent(new Event('resize'))
+  vi.runOnlyPendingTimers()
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('tab drag pointer sensor cancellation', () => {
+  it('cancels an active gesture on blur and stops subsequent moves and drops', () => {
+    const callbacks = startSensor()
+    expect(callbacks.onStart).toHaveBeenCalledOnce()
+    movePointer()
+    expect(callbacks.onMove).toHaveBeenCalledOnce()
+
+    window.dispatchEvent(new Event('blur'))
+    expect(callbacks.onCancel).toHaveBeenCalledOnce()
+    expect(callbacks.onAbort).not.toHaveBeenCalled()
+    movePointer()
+    document.dispatchEvent(new PointerEvent('pointerup'))
+
+    expect(callbacks.onMove).toHaveBeenCalledOnce()
+    expect(callbacks.onEnd).not.toHaveBeenCalled()
+  })
+
+  it.each<PointerSensorOptions['activationConstraint']>([
+    { distance: 12 },
+    { delay: 100, tolerance: 10 }
+  ])('aborts a pending gesture on blur before activation: %j', (activationConstraint) => {
+    const callbacks = startSensor({ activationConstraint })
+    expect(callbacks.onStart).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event('blur'))
+    expect(callbacks.onAbort).toHaveBeenCalledWith('tab-1')
+    expect(callbacks.onCancel).toHaveBeenCalledOnce()
+    vi.advanceTimersByTime(150)
+    movePointer()
+    movePointer()
+    document.dispatchEvent(new PointerEvent('pointerup'))
+
+    expect(callbacks.onStart).not.toHaveBeenCalled()
+    expect(callbacks.onMove).not.toHaveBeenCalled()
+    expect(callbacks.onEnd).not.toHaveBeenCalled()
+  })
+
+  it('still completes an uninterrupted gesture on pointerup', () => {
+    const callbacks = startSensor()
+    movePointer()
+    document.dispatchEvent(new PointerEvent('pointerup'))
+    window.dispatchEvent(new Event('blur'))
+    movePointer()
+
+    expect(callbacks.onEnd).toHaveBeenCalledOnce()
+    expect(callbacks.onMove).toHaveBeenCalledOnce()
+    expect(callbacks.onCancel).not.toHaveBeenCalled()
+    expect(callbacks.onAbort).not.toHaveBeenCalled()
+  })
+
+  it('does not restart when a captured activation callback arrives after cancellation', () => {
+    const schedule = vi.spyOn(window, 'setTimeout')
+    const callbacks = startSensor({ activationConstraint: { delay: 100, tolerance: 10 } })
+    const activate = schedule.mock.calls[0]?.[0]
+    expect(activate).toBeTypeOf('function')
+    window.dispatchEvent(new Event('blur'))
+    ;(activate as () => void)()
+
+    expect(callbacks.onStart).not.toHaveBeenCalled()
+    expect(callbacks.onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('ignores the old Escape listener while a new gesture is active', () => {
+    const previous = startSensor()
+    window.dispatchEvent(new Event('blur'))
+    const current = startSensor()
+    movePointer()
+    document.dispatchEvent(new KeyboardEvent('keydown', { code: 'Escape' }))
+    document.dispatchEvent(new PointerEvent('pointerup'))
+
+    expect(previous.onCancel).toHaveBeenCalledOnce()
+    expect(previous.onMove).not.toHaveBeenCalled()
+    expect(current.onStart).toHaveBeenCalledOnce()
+    expect(current.onMove).toHaveBeenCalledOnce()
+    expect(current.onCancel).toHaveBeenCalledOnce()
+    expect(current.onEnd).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/tab-group/tab-drag-pointer-sensor.ts
+++ b/src/renderer/src/components/tab-group/tab-drag-pointer-sensor.ts
@@ -140,6 +140,7 @@ export class TabDragPointerSensor implements SensorInstance {
   autoScrollEnabled = true
 
   private activated = false
+  private ended = false
   private readonly document: Document
   private readonly initialCoordinates: PointerCoordinates
   private readonly pointerDownTime = performance.now()
@@ -174,6 +175,7 @@ export class TabDragPointerSensor implements SensorInstance {
     this.windowListeners.add(win, 'dragstart', preventDefault)
     this.windowListeners.add(win, 'visibilitychange', this.handleCancel)
     this.windowListeners.add(win, 'contextmenu', preventDefault)
+    this.windowListeners.add(win, 'blur', this.handleCancel)
     this.windowListeners.add(win, 'focus', this.handleCancel)
     this.documentListeners.add(this.document, 'keydown', this.handleKeydown)
 
@@ -200,6 +202,7 @@ export class TabDragPointerSensor implements SensorInstance {
   }
 
   private detach(): void {
+    this.ended = true
     this.pointerListeners.removeAll()
     this.windowListeners.removeAll()
     window.setTimeout(this.documentListeners.removeAll, 50)
@@ -217,7 +220,7 @@ export class TabDragPointerSensor implements SensorInstance {
   }
 
   private handleStart(): void {
-    if (this.activated) {
+    if (this.activated || this.ended) {
       return
     }
     this.activated = true
@@ -228,6 +231,9 @@ export class TabDragPointerSensor implements SensorInstance {
   }
 
   private handleMove(event: PointerEvent): void {
+    if (this.ended) {
+      return
+    }
     const coordinates = getPointerCoordinates(event)
     const { activationConstraint } = this.props.options
     if (!coordinates) {
@@ -277,6 +283,9 @@ export class TabDragPointerSensor implements SensorInstance {
   }
 
   private handleEnd(): void {
+    if (this.ended) {
+      return
+    }
     this.detach()
     if (!this.activated) {
       this.props.onAbort(this.props.active)
@@ -285,6 +294,9 @@ export class TabDragPointerSensor implements SensorInstance {
   }
 
   private handleCancel(): void {
+    if (this.ended) {
+      return
+    }
     this.detach()
     if (!this.activated) {
       this.props.onAbort(this.props.active)

--- a/src/renderer/src/components/tab-group/useTabDragSplit.test.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.test.ts
@@ -16,6 +16,8 @@ import {
   useTabDragSplit
 } from './useTabDragSplit'
 
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
 vi.mock('../browser-pane/host-guest/webview-registry', () => ({
   acquireWebviewsDragPassthrough: vi.fn(() => vi.fn())
 }))
@@ -94,10 +96,13 @@ function makeDragEvent(activeData: TabDragItemData, pointer: { x: number; y: num
   }
 }
 
-function renderDragHook(): ReturnType<typeof useTabDragSplit> {
+function renderDragHook(
+  onRender?: (drag: ReturnType<typeof useTabDragSplit>) => void
+): ReturnType<typeof useTabDragSplit> {
   let result: ReturnType<typeof useTabDragSplit> | null = null
   function Probe(): null {
     result = useTabDragSplit({ worktreeId: WT })
+    onRender?.(result)
     return null
   }
 
@@ -267,6 +272,68 @@ describe('canDropTabIntoPaneBody', () => {
 })
 
 describe('useTabDragSplit', () => {
+  it.each(['split', 'insertion'])(
+    'does not restore a %s preview after blur cleared the drag',
+    async (preview) => {
+      if (preview === 'split') {
+        addPanelGeometry(
+          'group-2',
+          rect({ left: 500, top: 0, width: 400, height: 600 }),
+          rect({ left: 500, top: 32, width: 400, height: 568 })
+        )
+      }
+      const onRender = vi.fn()
+      const drag = renderDragHook(onRender)
+      const event = {
+        ...makeDragEvent(makeDragData('group-1'), { x: 880, y: 300 }),
+        ...(preview === 'insertion'
+          ? {
+              over: {
+                data: { current: makeDragData('group-2', 'tab-2') },
+                rect: rect({ left: 500, top: 0, width: 400, height: 32 })
+              }
+            }
+          : {})
+      }
+      const previewKey = preview === 'split' ? 'hoveredDropTarget' : 'hoveredTabInsertion'
+      act(() => drag.onDragStart(event as unknown as Parameters<typeof drag.onDragStart>[0]))
+      act(() => drag.onDragMove(event as unknown as Parameters<typeof drag.onDragMove>[0]))
+      expect(onRender.mock.lastCall?.[0][previewKey]).not.toBeNull()
+
+      await act(async () => {
+        window.dispatchEvent(new Event('blur'))
+        await new Promise((resolve) => window.setTimeout(resolve, 0))
+      })
+      expect(onRender.mock.lastCall?.[0][previewKey]).toBeNull()
+      act(() => drag.onDragMove(event as unknown as Parameters<typeof drag.onDragMove>[0]))
+
+      expect(onRender.mock.lastCall?.[0][previewKey]).toBeNull()
+      expect(drag.isTabDragActiveRef.current).toBe(false)
+    }
+  )
+
+  it('does not commit a drop after blur cleared the drag', async () => {
+    addPanelGeometry(
+      'group-2',
+      rect({ left: 500, top: 0, width: 400, height: 600 }),
+      rect({ left: 500, top: 32, width: 400, height: 568 })
+    )
+    const dropUnifiedTab = vi.fn(() => true)
+    const reorderUnifiedTabs = vi.fn()
+    useAppStore.setState({ dropUnifiedTab, reorderUnifiedTabs })
+    const drag = renderDragHook()
+    const event = makeDragEvent(makeDragData('group-1'), { x: 880, y: 300 })
+    act(() => drag.onDragStart(event as unknown as Parameters<typeof drag.onDragStart>[0]))
+    await act(async () => {
+      window.dispatchEvent(new Event('blur'))
+      await new Promise((resolve) => window.setTimeout(resolve, 0))
+    })
+    act(() => drag.onDragEnd(event as unknown as Parameters<typeof drag.onDragEnd>[0]))
+
+    expect(dropUnifiedTab).not.toHaveBeenCalled()
+    expect(reorderUnifiedTabs).not.toHaveBeenCalled()
+  })
+
   it.each(['pointerup', 'pointercancel', 'blur', 'focus'])(
     'clears a stuck active drag when %s arrives without a dnd end event',
     async (eventName) => {

--- a/src/renderer/src/components/tab-group/useTabDragSplit.ts
+++ b/src/renderer/src/components/tab-group/useTabDragSplit.ts
@@ -209,6 +209,10 @@ export function useTabDragSplit({
 
   const onDragMove = useCallback(
     (event: DragMoveEvent) => {
+      // A missed-end cleanup can run before dnd-kit delivers its last move.
+      if (!tabDragActiveRef.current) {
+        return
+      }
       handleDragUpdate(event)
     },
     [handleDragUpdate]
@@ -221,6 +225,10 @@ export function useTabDragSplit({
 
   const onDragEnd = useCallback(
     (event: DragEndEvent) => {
+      if (!tabDragActiveRef.current) {
+        finishDrag(true)
+        return
+      }
       commitTabDragDrop({
         event,
         worktreeId,

--- a/tests/e2e/tab-drag-blur-cancel.spec.ts
+++ b/tests/e2e/tab-drag-blur-cancel.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from './helpers/orca-app'
+
+for (const theme of ['dark', 'light'] as const) {
+  test(`tab drag stays cancelled after blur and a later drag still splits (${theme})`, async ({
+    orcaPage
+  }, testInfo) => {
+    await orcaPage.setViewportSize({ width: 1200, height: 900 })
+    await orcaPage.evaluate(async (theme) => {
+      const state = window.__store!.getState()
+      await state.updateSettingsOrThrow({ theme })
+      const worktreeId = state.activeWorktreeId!
+      const tabs = state.tabsByWorktree[worktreeId] ?? []
+      for (let index = tabs.length; index < 2; index++) {
+        state.createTab(worktreeId)
+      }
+    }, theme)
+
+    const tabs = orcaPage.locator('[data-testid="sortable-tab"]:visible')
+    const panels = orcaPage.locator('[data-tab-group-body-id]:visible')
+    const preview = orcaPage.getByText('New split', { exact: true })
+    await expect(tabs).toHaveCount(2)
+    await expect(panels).toHaveCount(1)
+    const panel = (await panels.boundingBox())!
+    const target = { x: panel.x + panel.width - 30, y: panel.y + panel.height / 2 }
+    const startDrag = async (): Promise<void> => {
+      const tab = (await tabs.first().boundingBox())!
+      await orcaPage.mouse.move(tab.x + tab.width / 2, tab.y + tab.height / 2)
+      await orcaPage.mouse.down()
+      await orcaPage.mouse.move(target.x, target.y, { steps: 12 })
+      await expect(preview).toBeVisible()
+    }
+
+    await startDrag()
+    // Exercise the window event without changing native focus on the developer's desktop.
+    await orcaPage.evaluate(async () => {
+      window.dispatchEvent(new Event('blur'))
+      await new Promise((resolve) => window.setTimeout(resolve, 0))
+    })
+    await expect(preview).toHaveCount(0)
+    await orcaPage.mouse.move(target.x - 10, target.y + 10, { steps: 3 })
+
+    const screenshot = testInfo.outputPath(`tab-drag-after-blur-${theme}.png`)
+    await orcaPage.screenshot({ path: screenshot, animations: 'disabled' })
+    await testInfo.attach(`tab-drag-after-blur-${theme}`, {
+      path: screenshot,
+      contentType: 'image/png'
+    })
+    await expect(preview).toHaveCount(0)
+    await orcaPage.mouse.up()
+    await expect(panels).toHaveCount(1)
+
+    await startDrag()
+    await orcaPage.mouse.up()
+    await expect(preview).toHaveCount(0)
+    await expect(panels).toHaveCount(2)
+  })
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​239 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​238 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

## ELI5

If a tab drag loses focus, Orca should stop dragging. Previously, moving the pointer afterward could bring back a stuck blue “New split” rectangle, and releasing could still split the pane. This change ends the drag completely; a new drag still works normally.

## What Changed

- Cancel the owning pointer sensor on window blur, including gestures waiting for activation; ignore callbacks from an ended sensor.
- Ignore move and drop callbacks after gesture teardown, covering split previews, insertion markers, and unintended drops.
- Add sensor, hook, and hidden Electron regressions.

## Why

The missed-end listener cleared Orca’s gesture state on blur, but its pointer sensor continued emitting events. Guarding the render condition alone would leave insertion previews and drop mutations alive. This closes the gesture at its source and enforces its lifetime at both callback entry points.

## Linked Issue

Fixes #19967

## Visual Proof

Same real CDP pointer sequence in both builds: drag a terminal tab to the pane edge → dispatch window blur → move again. The baseline screenshots show the revived overlay; the fixed screenshots show the cancelled drag. Blur is synthetic so these checks never change desktop focus.

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before: late movement revives New split](https://github.com/user-attachments/assets/56edd0e5-b2f6-4c4c-a25b-008109048da2) | ![After: cancelled drag stays cleared](https://github.com/user-attachments/assets/8047e498-eef6-4a92-985e-1ae578d5a700) |
| Light | ![Before: stuck New split in light theme](https://github.com/user-attachments/assets/d3522ee8-b8f2-4d4e-bd4f-97cdad75aff1) | ![After: cancelled drag stays cleared in light theme](https://github.com/user-attachments/assets/c559f42b-5d3c-411f-812b-66c025f73472) |

## Testing

- [x] Automated rendered interaction tested locally; before/after screenshots inspected.
- [x] Automated regressions added.

- 35 focused tests across five files passed, including failing-before regressions.
- `pnpm tc` passed (Node, CLI, renderer).
- Changed-code quality gate passed: lint, type-aware lint, and React Doctor; formatting clean.
- `electron-vite build --mode e2e` passed.
- Both dark/light Electron scenarios passed. The same new scenarios fail on the baseline at the reported bug.
- All tests/apps ran with `ORCA_BACKGROUND_LAUNCH=1`; no native window activation.

The optional, currently unenforced whole-E2E typecheck still reports existing cloud-dependency and test errors documented in `config/tsconfig.e2e.json`; the new specs introduce no diagnostics in that project.

**Verification scope:** the reported renderer sequence is verified on macOS with real CDP pointer input and a synthetic blur event in a hidden Electron window. Native OS focus switching, embedded-webview focus loss, and Windows/Linux desktop interaction were not exercised locally. No SSH execution or wire contract changes.

## Review

Independent review and an elegance pass completed. Review caught the sensor’s retained Escape listener firing cancellation twice during its cleanup delay; an ended-state guard and regression now cover that case. The reviewer independently passed 17 guest passthrough, drag-focus, and activation-restoration tests.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer content used.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full repository lint/test/package build left to CI; targeted checks listed above
