### PR TITLE
perf: avoid repeated unclosed-tag scans in mobile reviews

### DIFF
--- a/mobile/src/components/pr-sidebar/markdown-blocks.ts
+++ b/mobile/src/components/pr-sidebar/markdown-blocks.ts
@@ -44,7 +44,14 @@ const SUMMARY = /<summary\b[^>]*>([\s\S]*?)<\/summary>/i
 // show literally. Conservative: only matches `<tag ...>` / `</tag>` shapes, so a bare
 // "a < b" in prose is left alone.
 export function stripHtmlTags(text: string): string {
-  return text.replace(/<\/?[a-zA-Z][a-zA-Z0-9-]*(?:\s[^>]*)?\/?>/g, '')
+  const end = text.lastIndexOf('>') + 1
+  if (end === 0) {
+    return text
+  }
+  // No tag can close in this suffix; keep it literal without retrying every opener.
+  return (
+    text.slice(0, end).replace(/<\/?[a-zA-Z][a-zA-Z0-9-]*(?:\s[^>]*)?\/?>/g, '') + text.slice(end)
+  )
 }
 
 export function parseMarkdownBlocks(content: string): MarkdownBlock[] {

--- a/mobile/src/components/pr-sidebar/markdown-tag-stripping-performance.test.ts
+++ b/mobile/src/components/pr-sidebar/markdown-tag-stripping-performance.test.ts
@@ -1,0 +1,47 @@
+import { runInNewContext } from 'node:vm'
+import { describe, expect, it } from 'vitest'
+import { parseInline, stripHtmlTags } from './markdown-blocks'
+
+const ORIGINAL_TAGS = /<\/?[a-zA-Z][a-zA-Z0-9-]*(?:\s[^>]*)?\/?>/g
+
+describe('review Markdown unclosed tags', () => {
+  it.each(['', '<b>before</b> '])('preserves an unclosed suffix after %s', (prefix) => {
+    const suffix = '<a '.repeat(20_000)
+    const text = prefix + suffix
+    const result = runInNewContext('parse(text)', { parse: parseInline, text }, { timeout: 250 })
+    expect(result).toEqual([{ kind: 'text', text: prefix.replace(ORIGINAL_TAGS, '') + suffix }])
+  })
+
+  it('preserves the original stripping grammar over generated markup', () => {
+    const parts = [
+      '<a ',
+      '<b>',
+      '</b>',
+      '<a href="x">',
+      '<custom-tag x>',
+      '<',
+      '>',
+      'a',
+      ' ',
+      '/',
+      '\n',
+      '"',
+      '<1>',
+      '<a/>',
+      '<a x<',
+      '<a'
+    ]
+    let seed = 17
+    const random = () => {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+      return seed
+    }
+    for (let index = 0; index < 5000; index++) {
+      const text = Array.from(
+        { length: 1 + (random() % 40) },
+        () => parts[random() % parts.length]
+      ).join('')
+      expect(stripHtmlTags(text), text).toBe(text.replace(ORIGINAL_TAGS, ''))
+    }
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

Unclosed HTML-like fragments in mobile review comments can stall inline parsing because the tag regex retries the remaining suffix at every opener. Match tags only through the final `>` and preserve the remaining suffix literally. Every removable tag needs a closing `>`, so stripping behavior stays the same.

Production `parseInline` diagnostic with a valid bold prefix followed by 20,000 unclosed `<a ` fragments (60 KB): 693ms before, 0.47ms after, identical 60,007-character output. An earlier regex-only diagnostic exceeded a one-second cutoff. These are host-side adversarial parser measurements, not native-device frame timings.

Validation: 21 tests across three review Markdown suites; 5,000 generated exact stripping comparisons; both new deadline regressions fail the original at 250ms and pass with the fix. Full mobile typecheck and changed-code quality pass. No host execution, wire or provider behavior changes.
