### PR TITLE
perf: reject file-count labels before parsing edit patches

### DIFF
--- a/src/shared/native-chat-edit-patch-files.ts
+++ b/src/shared/native-chat-edit-patch-files.ts
@@ -44,6 +44,10 @@ export function editFilesFromPatchText(
   callerPath: string | null,
   summaryOnly = false
 ): NativeChatEditFileSummary[] | null {
+  if (callerPath !== null && FILE_COUNT_PATH.test(callerPath)) {
+    // A file count cannot name a card, regardless of the patch contents.
+    return null
+  }
   // The body carries its own marker when the journal clipped it. Read as
   // content it becomes a numbered line of the file, and the rows that follow
   // are reported complete.
@@ -52,12 +56,6 @@ export function editFilesFromPatchText(
   // One card per file the patch touches: run together, the later files' rows
   // and gutter numbers sit under the first file's name.
   const split = unifiedPatchSections(moved.body)
-  if (callerPath !== null && FILE_COUNT_PATH.test(callerPath)) {
-    // The producer joined several files' patches and kept a count in place of a
-    // path, so nothing here can name a file. Naming the card after the count
-    // would assert a file that does not exist.
-    return null
-  }
   // A patch that names one file is the file the call is reporting on, so the
   // call's own path wins — it is the provider's, where the header's is relative
   // to the patch. A patch naming several has no one path, and a rename's


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

Skip parsing a patch when its caller path is a file count that the formatter already rejects.

## What Changed

Move the existing file-count path guard ahead of bounded-marker stripping, move-marker parsing and section splitting. The rejection regex and result remain identical. Accepted paths still execute the same parsing code.

## Why

Windows Node benchmark of the actual bundled exported helper, alternating original/modified order, 10 warmup batches then 20 measured batches. Median milliseconds per call:

| Patch sections / caller path | Before | After |
| --- | ---: | ---: |
| 1 / 2 files | 0.000339 | 0.000017 |
| 100 / 2 files | 0.019060 | 0.000015 |
| 10,000 / 2 files | 0.973893 | 0.000037 |
| 1 / src/file.ts | 0.000727 | 0.000761 |
| 100 / src/file.ts | 0.041474 | 0.040914 |
| 10,000 / src/file.ts | 1.819333 | 1.789247 |
| 10,000 / null | 1.817077 | 1.785560 |

Synthetic CPU measurements, not application latency. Accepted-input work is unchanged; the smallest accepted fixture varied by approximately 34 ns. The section count describes input size; existing parser caps still apply.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical formatting results.

## Testing

- All 50 edit-normalization tests passed, including the existing file-count rejection regression.
- 12,000 original/modified comparisons matched across full and summary modes, empty input, Unicode, rename text, rejected labels, accepted paths and near-miss labels.
- Renderer TypeScript check, targeted oxlint and formatting passed.

## Review

The skipped functions are pure string parsing. No filesystem, process, host-ownership, wire or repository assumptions change. Native, WSL and SSH-originated tool results retain the same formatting behavior. Tests ran with background launch policy; no app launched.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, SSH and folder workspace behavior considered.
- [x] Relevant tests, typecheck and lint passed.
