### PR TITLE
perf: normalize title evidence once per label search

### DIFF
--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -165,7 +165,8 @@ function agentForBareName(text: string): TuiAgent | null {
   const stripped = stripBareNameDecoration(trimmed)
   // Why labels too: an agent may write its own display name as the entire title (`⠐ Claude Code`).
   // That is the same claim as a bare token, just spelled the way the vendor spells it.
-  const label = DISPLAY_LABELS.find(([text]) => text === stripped.toLowerCase())
+  const normalized = stripped.toLowerCase()
+  const label = DISPLAY_LABELS.find(([text]) => text === normalized)
   if (label) {
     return label[1]
   }
@@ -182,7 +183,8 @@ function agentForWholeTitle(text: string): TuiAgent | null {
     return null
   }
   const stripped = stripBareNameDecoration(trimmed)
-  const label = DISPLAY_LABELS.find(([text]) => text === stripped.toLowerCase())
+  const normalized = stripped.toLowerCase()
+  const label = DISPLAY_LABELS.find(([text]) => text === normalized)
   if (label) {
     return label[1]
   }
@@ -255,9 +257,8 @@ function namesConsumedByAnchoredLabels(
 ): Set<TuiAgent> {
   const consumed = new Set<TuiAgent>()
   for (const segment of segments) {
-    const label = DISPLAY_LABELS.find(
-      ([text]) => text === stripBareNameDecoration(segment).toLowerCase()
-    )
+    const normalized = stripBareNameDecoration(segment).toLowerCase()
+    const label = DISPLAY_LABELS.find(([text]) => text === normalized)
     if (label && anchoredNames.has(label[1])) {
       for (const name of namesIn(label[0])) {
         consumed.add(name)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## Change
Hoist invariant title normalization out of three display-label searches in `src/shared/agent-title-evidence.ts`. Keep the same Unicode decoration regexes, lowercase operation, label order, early exits and evidence classification. No cache, scheduling, provider lookup, wire change or extra persistent state.

## Why
Changing terminal titles can repeat a trim/two Unicode-regex/lowercase chain up to eight times per segment. Normalize once before the existing find. This is redundant-work removal, not a new recognition policy.

## Evidence
Isolated production `collectAgentTitleEvidence`, bundled from exact baseline and candidate source with the same dependencies, Node v24.18.0 / macOS arm64:
- Full ordered evidence objects matched for 1,617 controlled and generated inputs: repository test literals, 0–9 wrapper segments, mixed agent names, empty/decorated strings, Windows/POSIX paths, Unicode/combining marks/emoji and lone surrogates.
- Instrumented lowercase calls: ordinary nonmatch 33 → 19; three-segment nonmatch 99 → 57; first-label match 19 → 19. Instrumentation was removed for timing.
- Seven alternating before/after samples, 4,851 calls/sample rotating wrapped corpus: median 987.57 ms → 304.95 ms (3.24x). Simple nonmatch 60.05 → 59.96 ms/20k calls and first-label match 44.91 → 44.17 ms/20k calls are effectively noise; no universal speedup claimed.
- Existing focused tests: 3 files, 145 tests passed, 418 ms total. Command: `ORCA_BACKGROUND_LAUNCH=1 node node_modules/vitest/vitest.mjs run --config config/vitest.config.ts src/shared/agent-title-evidence.test.ts src/shared/terminal-title-agent-type.test.ts src/shared/pane-agent-identity-adapter.test.ts`.

## Reliability and limitations
- Class: agent-session.provider-ownership adjacency. Invariant: exact ordered title evidence, ambiguity and selected agent remain unchanged; no title acquires new authority.
- Failure source: repeated changing-title classification on wrapped terminal titles; identity mistakes could misattribute panes.
- Oracle: full baseline/candidate evidence equality plus existing parser and identity adapter contracts.
- Gate gap: `agent-session.provider-ownership` is an experimental resume/attach gate, not a title-normalization gate; that broad lifecycle/Electron gate was not run. No new authority/resume behavior is introduced.
- Local/daemon/SSH/WSL/remote/mobile and macOS/Linux/Windows execution boundaries, folder/git paths and remote wire behavior are structurally unaffected by function-local string hoists. Live platform/provider and packaged Electron measurements were not performed; this proves parser equivalence on the exercised corpus, not absolute zero risk or whole-app latency improvement.
- No UI change; no visual claim. No project-wide tests, typecheck, formatters or linters run. `pnpm exec` failed before execution because managed pnpm v12 launcher returned ENOEXEC; the installed Vitest entry was invoked directly.
- No persistent regression test added: existing behavior tests retained; differential measurement scripts stayed under /tmp and were removed after proof. Raw user title history was not accessed.

Audit reports and quantified evidence are retained locally under `/tmp/orca-free-perf-zUCWLb/transport-shared-report.json` and `transport-shared-title-proof.json`. Existing open PRs were checked for title-parser/normalization overlap; no equivalent normalization hoist was identified. Related identity feature/fix PRs remain independent.
