### PR TITLE
perf: select matching model IDs without sorting

### DIFF
--- a/src/shared/native-chat-session-option-state.test.ts
+++ b/src/shared/native-chat-session-option-state.test.ts
@@ -48,6 +48,15 @@ describe('applyNativeChatReportedSessionOptions', () => {
 })
 
 describe('matchNativeChatCatalogModelId', () => {
+  it('prefers the longest contained id and keeps catalog order for ties', () => {
+    const catalog = {
+      ...CLAUDE_SESSION_OPTION_CATALOG,
+      models: ['a', 'abc', 'xyz'].map((id) => ({ id, label: id, options: [] }))
+    }
+    expect(matchNativeChatCatalogModelId(catalog, 'provider-xyz-abc')).toBe('abc')
+    expect(catalog.models.map((model) => model.id)).toEqual(['a', 'abc', 'xyz'])
+  })
+
   it('matches exact ids, labels, and provider-id containment', () => {
     expect(matchNativeChatCatalogModelId(CLAUDE_SESSION_OPTION_CATALOG, 'sonnet')).toBe('sonnet')
     expect(matchNativeChatCatalogModelId(CLAUDE_SESSION_OPTION_CATALOG, 'Sonnet 5')).toBe('sonnet')

--- a/src/shared/native-chat-session-option-state.ts
+++ b/src/shared/native-chat-session-option-state.ts
@@ -167,8 +167,14 @@ export function matchNativeChatCatalogModelId(
   if (byLabel) {
     return byLabel.id
   }
-  const containing = [...catalog.models]
-    .sort((left, right) => right.id.length - left.id.length)
-    .find((model) => normalized.includes(model.id.toLowerCase()))
-  return containing?.id ?? null
+  let containingId: string | null = null
+  for (const model of catalog.models) {
+    if (
+      (containingId === null || model.id.length > containingId.length) &&
+      normalized.includes(model.id.toLowerCase())
+    ) {
+      containingId = model.id
+    }
+  }
+  return containingId
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

Find the longest matching model ID without sorting a copy of the model catalog.

## What Changed

Keep exact ID and exact label lookup unchanged. For containment fallback, scan the catalog once and retain a match only when its ID is longer than the current match. Equal-length matches therefore keep the original catalog order, as the stable sort did.

## Why

Windows Node benchmark of the actual exported helper, median of 15 measured batches after five warmups, alternating original/modified order, 1,000 calls per batch:

| Catalog / lookup | Before ms | After ms |
| --- | ---: | ---: |
| 5 / containment | 0.000219 | 0.000133 |
| 5 / unknown | 0.000208 | 0.000105 |
| 50 / containment | 0.002375 | 0.001298 |
| 50 / unknown | 0.002289 | 0.001055 |
| 500 / containment | 0.030155 | 0.012851 |
| 500 / unknown | 0.030610 | 0.010862 |
| 500 / exact ID | 0.0000130 | 0.0000126 |
| 500 / exact label | 0.004253 | 0.004135 |

Synthetic CPU measurements, not app latency. Large catalogs are stress fixtures; the absolute savings for small catalogs are tiny. The fallback removes a copied array and a sort without introducing a cache.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — same model selection.

## Testing

- Seven session-option state tests passed, including added longest-ID and stable-tie coverage.
- 10,000 deterministic original/modified comparisons matched, covering duplicate IDs, case folding, empty IDs, labels, whitespace and Unicode.
- Renderer TypeScript check, targeted oxlint and formatting passed.

## Review

Exact ID and label priority, lowercase containment, and original ID spelling remain unchanged. The catalog is not mutated. No process, I/O, wire or host-ownership changes; native, WSL and SSH reports use the same pure matching function. No repository assumptions. Tests ran with background launch policy; no app launched.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, SSH and folder workspace behavior considered.
- [x] Relevant tests, typecheck and lint passed.
