### PR TITLE
perf: remove duplicate empty-file filtering from search finalization

### DIFF
--- a/src/shared/text-search.ts
+++ b/src/shared/text-search.ts
@@ -348,7 +348,7 @@ export function ingestGitGrepLine(
 
 export function finalize(acc: SearchAccumulator): SearchResult {
   return normalizeSearchResult({
-    files: Array.from(acc.fileMap.values()).filter((file) => file.matches.length > 0),
+    files: Array.from(acc.fileMap.values()),
     totalMatches: acc.totalMatches,
     truncated: acc.truncated
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Filter empty search files once instead of twice during finalization.

## What Changed

Pass the accumulator's file rows directly to normalizeSearchResult, which already removes rows without preview matches. Remove only the duplicate filter in finalize.

## Why

Windows Node benchmark of the actual bundled finalize export, median of 15 batches after five warmups, alternating original/modified order:

| Files / populated fraction | Before ms | After ms |
| --- | ---: | ---: |
| 0 | 0.000024 | 0.000019 |
| 10 / all | 0.000204 | 0.000157 |
| 1,000 / half | 0.011160 | 0.008807 |
| 1,000 / all | 0.018610 | 0.014059 |
| 10,000 / half | 0.121354 | 0.095485 |
| 10,000 / all | 0.194925 | 0.148883 |

Synthetic CPU measurements, not end-to-end search latency. An all-empty 10,000-row stress fixture measured 0.039291 versus 0.041097 ms: both versions must inspect every row, so that case has no expected scan reduction. Populated results avoid a duplicate scan and intermediate array.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical search results.

## Testing

- All 43 text-search and match-count tests passed.
- Original/modified outputs matched for empty, mixed and populated fixtures at 0, 10, 1,000 and 10,000 files, including invalid match counts.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

The remaining normalizer performs the identical empty-row predicate and count repair. Result order, metadata, cloning and accumulator ownership remain unchanged. No Git commands, filesystem calls, host boundaries or wire formats change. Native, WSL and SSH searches share the pure result processing. Tests ran with background launch policy; no app launched.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, SSH and folder workspace behavior considered.
- [x] Relevant tests, typecheck and lint passed.
