### PR TITLE
perf: collect terminal snapshot replay without wrapper arrays

### DIFF
--- a/src/main/ipc/terminal-preview-output-stream.ts
+++ b/src/main/ipc/terminal-preview-output-stream.ts
@@ -120,9 +120,12 @@ export class TerminalPreviewOutputStream {
   }
 
   completeSnapshot(snapshotSeq?: number): TerminalPreviewReplayChunk[] {
-    const replay = this.initialPending.flatMap((output) => {
+    const replay: TerminalPreviewReplayChunk[] = []
+    this.initialPending.forEach((output) => {
       const uncovered = outputAfterSnapshotSeq(output, snapshotSeq)
-      return uncovered && uncovered.data.length > 0 ? [uncovered] : []
+      if (uncovered && uncovered.data.length > 0) {
+        replay.push(uncovered)
+      }
     })
     this.initialPending = []
     this.initialPendingBytes = 0

--- a/src/main/windows/windows-pty-job.win32.test.ts
+++ b/src/main/windows/windows-pty-job.win32.test.ts
@@ -170,7 +170,7 @@ describeOnWindows('ConPTY job ownership', () => {
 
     await vi.waitFor(() => expect(existsSync(marker)).toBe(true), { timeout: 15_000 })
     expect(output).not.toMatch(/Access is denied/i)
-    rmSync(marker, { force: true })
+    await vi.waitFor(() => rmSync(marker, { force: true }))
   }, 60_000)
 
   it('stops answering once the tree is gone, rather than claiming it is empty', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

Collect terminal preview replay chunks directly instead of allocating a tiny array for every buffered chunk.

## What Changed

Replace completeSnapshot's flatMap with forEach and push. The existing sequence-boundary helper still decides whether to drop, slice, replay or treat each chunk as live. Queue reset behavior remains identical.

## Why

Windows Node benchmark of the actual stream class, populated through append. Only completeSnapshot is timed; the snapshot covers half the buffered one-byte chunks. Median of 15 batches after five warmups, alternating original/modified order, 100 samples per batch:

| Buffered chunks | Before ms | After ms |
| --- | ---: | ---: |
| 0 | 0.000063 | 0.000052 |
| 10 | 0.000247 | 0.000115 |
| 1,000 | 0.009413 | 0.004500 |
| 10,000 | 0.106574 | 0.046403 |

Synthetic CPU measurements, not end-to-end reconnect latency. All fixtures fit inside the existing 256 KB snapshot queue limit. No queue limit, batching interval or flow control changes.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical replay output.

## Testing

- All six existing output-stream tests passed.
- 2,000 original/modified public-API comparisons matched, including empty chunks, Unicode, escapes, missing metadata, transformed chunks, overlapping sequences and repeated completion.
- Public append/consumeInitialOverflow/completeSnapshot checks preserved overflow recovery.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

Live versus replay classification and raw sequence slicing are untouched, preserving kitty keyboard state behavior. No wire or execution-host policy changes; native, WSL and SSH terminal data follow the same existing contract. No repository assumptions. Tests ran with background launch policy; no app launched.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, SSH and folder workspace behavior considered.
- [x] Relevant tests, typecheck and lint passed.


## CI review follow-up

Included a test-only correction for the unrelated Windows packaging test failure: the background-child test retries marker cleanup within Vitest's bounded wait, because file creation can be observed before the child closes its file handle. The real ConPTY test passes on Windows; production terminal behavior is unchanged. Targeted lint and formatting pass. This small test fix addresses the EPERM cleanup failure observed in CI and is separate from the replay optimization.
