### PR TITLE
perf: reuse accepted project group IDs for parent validation

### DIFF
--- a/src/shared/project-groups.ts
+++ b/src/shared/project-groups.ts
@@ -91,9 +91,8 @@ export function normalizeProjectGroups(value: unknown): ProjectGroup[] {
   groups.sort(
     (left, right) => left.tabOrder - right.tabOrder || left.name.localeCompare(right.name)
   )
-  const groupIds = new Set(groups.map((group) => group.id))
   for (const group of groups) {
-    if (group.parentGroupId === group.id || !groupIds.has(group.parentGroupId ?? '')) {
+    if (group.parentGroupId === group.id || !seen.has(group.parentGroupId ?? '')) {
       group.parentGroupId = null
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Reuse the accepted project-group IDs instead of constructing the same set twice.

## What Changed

Parent-reference validation uses the existing deduplication set. Every accepted ID is already in that set; sorting groups does not change membership. Remove the extra map and Set allocation.

## Why

Windows Node benchmark of the actual exported normalizer, median of 15 batches after five warmups, alternating original/modified order:

| Groups | Before ms | After ms |
| --- | ---: | ---: |
| 0 | 0.000049 | 0.000022 |
| 10 | 0.001001 | 0.000853 |
| 1,000 | 0.100146 | 0.084471 |
| 10,000 | 1.994747 | 1.507060 |

Synthetic CPU measurements, not app latency. Large group counts are stress fixtures. No persistent cache or changed validation policy.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — identical normalized groups.

## Testing

- All nine project-group tests passed.
- 1,000 deterministic original/modified comparisons matched with fixed clock, duplicate IDs, invalid entries, self/known/missing parents and differing sort order.
- Node TypeScript check, targeted oxlint and formatting passed.

## Review

The existing first-ID-wins behavior, sort order and parent cleanup remain unchanged. All accepted IDs enter the set before their group is appended; no later path silently drops an accepted group. Native, WSL, SSH and folder-workspace ownership fields retain their existing normalization. No I/O or wire changes. Tests ran with background launch policy; no app launched.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, SSH and folder workspace behavior considered.
- [x] Relevant tests, typecheck and lint passed.
