### PR TITLE
perf: index relay drain migration inventories once

### DIFF
--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -1,3 +1,4 @@
+import { createDrainMigrationRowLookup } from './drain-migration-row-lookup.js'
 import { IDLE_REHOME_PAGE_SIZE, selectIdleRegionalRehomes } from './idle-regional-rehome-selection.js'
 import { readRegionCorrectionOutcomes } from './region-correction-outcomes.js'
 import {
@@ -2187,22 +2188,16 @@ export class RelayAssignmentStore {
         [input.cellId]
       )
       const cells = await this.lockCellInventory(transaction, 'request')
+      const assignmentRows = createDrainMigrationRowLookup(assignments, text)
+      const leaseRows = createDrainMigrationRowLookup(activityLeases, text)
       for (const migrationRow of migrations) {
         const identity = {
           userId: text(migrationRow, 'user_id'),
           relayHostId: text(migrationRow, 'relay_host_id')
         }
-        const assignment = assignments.find(
-          (candidate) =>
-            text(candidate, 'user_id') === identity.userId &&
-            text(candidate, 'relay_host_id') === identity.relayHostId
-        )
+        const assignment = assignmentRows.first(identity)
         assertCurrentMigrationAssignment(assignment, migrationRow)
-        const leases = activityLeases.filter(
-          (lease) =>
-            text(lease, 'user_id') === identity.userId &&
-            text(lease, 'relay_host_id') === identity.relayHostId
-        )
+        const leases = leaseRows.all(identity)
         const migrationLeases = leases.filter(
           (lease) => text(lease, 'activity_kind') === 'migration'
         )
@@ -2377,22 +2372,16 @@ export class RelayAssignmentStore {
       ) {
         throw new Error('drain_migration_source_incarnation_mismatch')
       }
+      const assignmentRows = createDrainMigrationRowLookup(assignments, text)
+      const leaseRows = createDrainMigrationRowLookup(activityLeases, text)
       for (const migrationRow of migrationIncarnations) {
-        const assignment = assignments.find(
-          (candidate) =>
-            text(candidate, 'user_id') === text(migrationRow, 'user_id') &&
-            text(candidate, 'relay_host_id') === text(migrationRow, 'relay_host_id')
-        )
+        const identity = {
+          userId: text(migrationRow, 'user_id'),
+          relayHostId: text(migrationRow, 'relay_host_id')
+        }
+        const assignment = assignmentRows.first(identity)
         assertCurrentMigrationAssignment(assignment, migrationRow)
-        assertAssignmentActivityAccounting(
-          assignment,
-          activityLeases.filter(
-            (lease) =>
-              text(lease, 'user_id') === text(migrationRow, 'user_id') &&
-              text(lease, 'relay_host_id') === text(migrationRow, 'relay_host_id')
-          ),
-          migrationRow
-        )
+        assertAssignmentActivityAccounting(assignment, leaseRows.all(identity), migrationRow)
       }
       const sendPermitExpiresAt = now + CELL_DRAIN_SEND_PERMIT_MS
       await transaction.query(

--- a/cloud/apps/relay/src/drain-migration-row-lookup.test.ts
+++ b/cloud/apps/relay/src/drain-migration-row-lookup.test.ts
@@ -1,0 +1,62 @@
+import { expect, it } from 'vitest'
+import { createDrainMigrationRowLookup } from './drain-migration-row-lookup.js'
+import type { SqlRow } from './database.js'
+
+function text(row: SqlRow, field: string): string {
+  const value = row[field]
+  if (typeof value !== 'string') {
+    throw new Error(`invalid_${field}`)
+  }
+  return value
+}
+
+it('keeps first assignment matches, lease order, row identity, and separate identity components', () => {
+  const rows = [
+    { user_id: 'a:b', relay_host_id: 'c', value: 1 },
+    { user_id: 'a', relay_host_id: 'b:c', value: 2 },
+    { user_id: 'a:b', relay_host_id: 'c', value: 3 },
+    { user_id: '', relay_host_id: '', value: 4 }
+  ]
+  const lookup = createDrainMigrationRowLookup(rows, text)
+  for (const identity of [
+    { userId: 'a:b', relayHostId: 'c' },
+    { userId: 'a', relayHostId: 'b:c' },
+    { userId: '', relayHostId: '' },
+    { userId: 'missing', relayHostId: 'c' }
+  ]) {
+    const expected = rows.filter(
+      (row) =>
+        row.user_id === identity.userId && row.relay_host_id === identity.relayHostId
+    )
+    expect(lookup.first(identity)).toBe(expected[0])
+    expect(lookup.all(identity)).toEqual(expected)
+    lookup.all(identity).forEach((row, index) => expect(row).toBe(expected[index]))
+  }
+})
+
+it('retains lazy validation and short circuiting when an inventory is malformed', () => {
+  const first = { user_id: 'user', relay_host_id: 'host' }
+  const identity = { userId: 'user', relayHostId: 'host' }
+  const lookup = createDrainMigrationRowLookup(
+    [first, { user_id: null, relay_host_id: 'bad' }],
+    text
+  )
+  expect(lookup.first(identity)).toBe(first)
+  expect(() => lookup.all(identity)).toThrow('invalid_user_id')
+  const unrelated = createDrainMigrationRowLookup(
+    [first, { user_id: 'other', relay_host_id: null }],
+    text
+  )
+  expect(unrelated.all(identity)).toEqual([first])
+  expect(() => unrelated.first({ userId: 'other', relayHostId: 'host' })).toThrow(
+    'invalid_relay_host_id'
+  )
+})
+
+it('does not share an index between refreshed inventories', () => {
+  const identity = { userId: 'user', relayHostId: 'host' }
+  const oldRow = { user_id: 'user', relay_host_id: 'host', version: 1 }
+  const newRow = { ...oldRow, version: 2 }
+  expect(createDrainMigrationRowLookup([oldRow], text).first(identity)).toBe(oldRow)
+  expect(createDrainMigrationRowLookup([newRow], text).first(identity)).toBe(newRow)
+})

--- a/cloud/apps/relay/src/drain-migration-row-lookup.ts
+++ b/cloud/apps/relay/src/drain-migration-row-lookup.ts
@@ -1,0 +1,58 @@
+import type { SqlRow } from './database.js'
+
+type Identity = { userId: string; relayHostId: string }
+type RowIndex = Map<string, Map<string, SqlRow[]>>
+
+/** A single locked inventory, never retained across transactions or refreshed queries. */
+export function createDrainMigrationRowLookup(
+  rows: SqlRow[],
+  readText: (row: SqlRow, field: string) => string
+): {
+  first: (identity: Identity) => SqlRow | undefined
+  all: (identity: Identity) => SqlRow[]
+} {
+  let index: RowIndex | null | undefined
+  const indexed = (identity: Identity): SqlRow[] | undefined => {
+    if (index === undefined) {
+      index = indexRows(rows)
+    }
+    return index?.get(identity.userId)?.get(identity.relayHostId)
+  }
+  const matches = (row: SqlRow, identity: Identity): boolean =>
+    readText(row, 'user_id') === identity.userId &&
+    readText(row, 'relay_host_id') === identity.relayHostId
+  return {
+    first(identity) {
+      const group = indexed(identity)
+      return index === null ? rows.find((row) => matches(row, identity)) : group?.[0]
+    },
+    all(identity) {
+      const group = indexed(identity)
+      return index === null ? rows.filter((row) => matches(row, identity)) : (group ?? [])
+    }
+  }
+}
+
+function indexRows(rows: SqlRow[]): RowIndex | null {
+  const index: RowIndex = new Map()
+  for (const row of rows) {
+    const userId = row.user_id
+    const hostId = row.relay_host_id
+    // Preserve the original lazy validation and refusal order for malformed database rows.
+    if (typeof userId !== 'string' || typeof hostId !== 'string') {
+      return null
+    }
+    let hosts = index.get(userId)
+    if (!hosts) {
+      hosts = new Map()
+      index.set(userId, hosts)
+    }
+    const group = hosts.get(hostId)
+    if (group) {
+      group.push(row)
+    } else {
+      hosts.set(hostId, [row])
+    }
+  }
+  return index
+}

--- a/cloud/apps/relay/src/drain-migration-row-scaling.test.ts
+++ b/cloud/apps/relay/src/drain-migration-row-scaling.test.ts
@@ -1,0 +1,121 @@
+import { ASSIGNMENT_LIMITS } from '@orca-cloud/relay-contract'
+import { afterEach, expect, it } from 'vitest'
+import { RelayAssignmentStore } from './assignment-store.js'
+import { openInMemoryRelayDatabase, type RelayDatabase, type SqlRow } from './database.js'
+
+let database: RelayDatabase | undefined
+afterEach(async () => await database?.close())
+
+it.each([false, true])(
+  'looks up a whole drain inventory with linear identity reads (expired: %s)',
+  async (expired) => {
+    database = await openInMemoryRelayDatabase()
+    let measuring = false
+    let identityReads = 0
+    let indexedRows = 0
+    const instrument = (delegate: RelayDatabase): RelayDatabase => ({
+      query: (sql, params) => delegate.query(sql, params),
+      queryLocked: async (sql, params, options) => {
+        const rows = await delegate.queryLocked(sql, params, options)
+        if (
+          !measuring ||
+          !sql.includes('WHERE EXISTS') ||
+          !(sql.includes('SELECT assignment.*') || sql.includes('SELECT lease.*'))
+        ) {
+          return rows
+        }
+        indexedRows += rows.length
+        return rows.map(
+          (row): SqlRow =>
+            new Proxy(row, {
+              get(target, key) {
+                if (key === 'user_id' || key === 'relay_host_id') {
+                  identityReads++
+                }
+                return Reflect.get(target, key)
+              }
+            })
+        )
+      },
+      transaction: (operation, options) =>
+        delegate.transaction((tx) => operation(instrument(tx)), options),
+      close: () => delegate.close()
+    })
+    let now = 100
+    const store = new RelayAssignmentStore(instrument(database), () => now, {
+      requireLiveCells: true
+    })
+    const cells = ['a', 'b'].map((id) => ({
+      id: `cell-${id}`,
+      url: `https://relay-${id}.example.com`,
+      capacityRequests: 500
+    }))
+    await store.reconcileCells(cells)
+    const incarnation = '11111111-1111-4111-8111-111111111111'
+    for (const cell of cells) {
+      await store.recordCellHeartbeat({
+        cellId: cell.id,
+        cellUrl: cell.url,
+        cellIncarnation: incarnation,
+        startedAt: 50,
+        ready: true,
+        observedRequests: 0
+      })
+    }
+    await store.setCellEnabled('cell-b', false)
+    const identities = Array.from({ length: 50 }, (_, index) => ({
+      userId: `user-${index % 5}`,
+      relayHostId: `host${String(index).padStart(12, '0')}`
+    }))
+    for (const identity of identities) {
+      await store.assign(identity)
+    }
+    await store.setCellEnabled('cell-b', true)
+    await store.setCellEnabled('cell-a', false)
+    for (const identity of identities) {
+      const migration = await store.startEvacuation(identity, 'cell-b')
+      await store.markMigrationTargetRegistered(identity, {
+        cellId: 'cell-b',
+        assignmentEpoch: migration.assignmentEpoch
+      })
+    }
+    const attempt = {
+      attemptId: '55555555-5555-4555-8555-555555555555',
+      cellId: 'cell-a',
+      cellIncarnation: incarnation,
+      traceValue: '66666666-6666-4666-8666-666666666666',
+      plannedGraceMs: 120_000
+    }
+    await store.prepareCellDrainAttempt(attempt)
+    if (expired) {
+      now += ASSIGNMENT_LIMITS.migrationLeaseMs + 1
+      await store.releaseExpiredActivityLeases()
+      for (const cell of cells) {
+        await store.recordCellHeartbeat({
+          cellId: cell.id,
+          cellUrl: cell.url,
+          cellIncarnation: incarnation,
+          startedAt: 50,
+          ready: true,
+          observedRequests: 0
+        })
+      }
+    }
+    measuring = true
+    await expect(store.beginCellDrainSend(attempt)).resolves.toMatchObject({
+      state: 'send-may-have-started',
+      shouldSend: true
+    })
+    expect(indexedRows).toBeGreaterThanOrEqual(100)
+    expect(identityReads).toBeLessThanOrEqual(indexedRows * 2)
+    const migrations = await database.query(
+      'SELECT expires_at FROM relay_assignment_migrations'
+    )
+    expect(migrations).toHaveLength(50)
+    expect(
+      migrations.every(
+        (row) => row.expires_at === now + ASSIGNMENT_LIMITS.migrationLeaseMs
+      )
+    ).toBe(true)
+  }
+)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​183 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​183 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |

<!-- /orca-pr-loc -->

## ELI5
Draining a relay cell repeatedly searched the same host inventory. Group those rows once so each host can find its own assignment and leases directly.

## What Changed
Use a transaction-local lookup in drain-send validation and drain migration lease refresh. Nested maps preserve both identity components, first assignment matches, lease ordering, and row identity. Each inventory gets a fresh lookup. Malformed identity fields fall back to the original scans and lazy validation.

## Why
The old per-migration find/filter work grows quadratically while the transaction holds its inventory locks. A real SQLite public-drain regression with 50 hosts measures identity-field reads dropping from 9,000 to at most 300 for live leases, and 4,550 to at most 200 for expired registered leases.

An isolated CPU probe using the actual baseline selection loop and final lookup, with 1,000 migrations and 4,000 leases, measured 35.35 → 0.226 ms. At 100 migrations it measured 0.538 → 0.038 ms. These synthetic selection timings exclude SQL and network latency; the integration tests prove the operation-count improvement through the full drain path.

SQL, lock acquisition, transaction boundaries, lease-accounting checks, recovery writes, and published payloads retain their existing rules. The temporary index is linear in the current inventory and dies with that transaction.

## Linked Issue
No linked issue: user-requested performance audit with separate PRs per independent improvement.

## Visual Proof
N/A — internal relay inventory lookup only; no UI or interaction change.

## Testing
- 116 tests pass: full assignment-store suite, cell inventory lock census, new lookup parity/refusal tests, and two real SQLite drain scaling cases.
- Both scaling cases fail against baseline and pass with this change. Cases exercise live and expired registered leases and verify refreshed expiry values.
- Relay typecheck passes. New files pass targeted oxlint with the root rules and cloud exclusion removed, plus formatting. Root commit hooks exclude cloud files.
- macOS, `ORCA_BACKGROUND_LAUNCH=1`; no app windows launched. PostgreSQL, Linux/Windows, and actual remote deployments not exercised locally; CI pending.

## Review
- [x] Focused independent change; no agent skill upstream code copied.
- [x] Considered host isolation, malformed identities, duplicate keys, lease ordering, and refreshed inventories.
- [x] No git-provider, folder-workspace, or SSH process-status assumptions introduced.
