### PR TITLE
fix(codex): stop a Codex pane launch from deleting another profile's real-home hooks (STA-5679)

### DIFF
--- a/src/main/startup/codex-launch-preparation.test.ts
+++ b/src/main/startup/codex-launch-preparation.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Why the mocks: this file proves only the hooks-off gate in front of the real-home installer;
+// the real import graph reaches electron, the codex app-server grant client, and WSL discovery.
+// `managed-agent-hook-controls` is deliberately NOT mocked so the gate reads the real predicate.
+const { ensureRealHomeCodexHookState, prepareRuntimeHomeForLaunch } = vi.hoisted(() => ({
+  ensureRealHomeCodexHookState: vi.fn(() => Promise.resolve('installed')),
+  prepareRuntimeHomeForLaunch: vi.fn(() => Promise.resolve({ state: 'installed' }))
+}))
+vi.mock('electron', () => ({ app: { getPath: () => '/user-data' } }))
+vi.mock('../codex/codex-real-home-hook-install', () => ({ ensureRealHomeCodexHookState }))
+vi.mock('../codex/hook-service', () => ({ codexHookService: { prepareRuntimeHomeForLaunch } }))
+vi.mock('../agent-trust-presets', () => ({ markCodexProjectTrusted: vi.fn() }))
+vi.mock('../wsl', () => ({ getDefaultWslDistro: () => 'Ubuntu' }))
+
+import { prepareCodexRuntimeHomeForLaunch } from './codex-launch-preparation'
+import { mainProcessState } from './main-process-state'
+
+function setUpSystemDefaultRealHome(agentStatusHooksEnabled: boolean | undefined): void {
+  mainProcessState.store = {
+    getSettings: () => ({ agentStatusHooksEnabled })
+  } as unknown as typeof mainProcessState.store
+  mainProcessState.codexRuntimeHome = {
+    isHostSystemDefaultRealHomeSelected: () => true,
+    // Why null: "system default", i.e. the pane runs on the user's real ~/.codex.
+    prepareForCodexLaunchAsync: () => Promise.resolve(null)
+  } as unknown as typeof mainProcessState.codexRuntimeHome
+}
+
+beforeEach(() => {
+  ensureRealHomeCodexHookState.mockClear()
+  prepareRuntimeHomeForLaunch.mockClear()
+})
+
+describe('prepareCodexRuntimeHomeForLaunch real-home hooks', () => {
+  it('never touches the user-global ~/.codex when this profile has status hooks off', async () => {
+    setUpSystemDefaultRealHome(false)
+
+    await expect(prepareCodexRuntimeHomeForLaunch()).resolves.toBeNull()
+
+    expect(ensureRealHomeCodexHookState).not.toHaveBeenCalled()
+  })
+
+  it('installs into the real home when status hooks are on', async () => {
+    setUpSystemDefaultRealHome(true)
+
+    await expect(prepareCodexRuntimeHomeForLaunch()).resolves.toBeNull()
+
+    expect(ensureRealHomeCodexHookState).toHaveBeenCalledTimes(1)
+    expect(ensureRealHomeCodexHookState).toHaveBeenCalledWith({
+      hooksEnabled: true,
+      userDataPath: '/user-data'
+    })
+  })
+
+  it('installs into the real home when the preference is unset', async () => {
+    setUpSystemDefaultRealHome(undefined)
+
+    await prepareCodexRuntimeHomeForLaunch()
+
+    expect(ensureRealHomeCodexHookState).toHaveBeenCalledWith({
+      hooksEnabled: true,
+      userDataPath: '/user-data'
+    })
+  })
+})

--- a/src/main/startup/codex-launch-preparation.ts
+++ b/src/main/startup/codex-launch-preparation.ts
@@ -30,15 +30,22 @@ export async function prepareCodexRuntimeHomeForLaunch(
     }
   }
   const ensureRealHomeHooksIfSelected = async (): Promise<boolean> => {
-    if (target?.runtime === 'wsl' || !runtimeHome.isHostSystemDefaultRealHomeSelected(launchEnv)) {
+    if (
+      target?.runtime === 'wsl' ||
+      // Why skip rather than sweep: ~/.codex is user-global and Orca entries are matched by
+      // script filename, so honoring THIS profile's off switch here deletes the hook and trust
+      // records another Orca profile installed (STA-5679). Removal stays on the Settings toggle.
+      !isAgentStatusHooksEnabled(state.store?.getSettings()) ||
+      !runtimeHome.isHostSystemDefaultRealHomeSelected(launchEnv)
+    ) {
       return false
     }
-    // Why (flag ON, system default): the hook entry must exist — appended last
-    // and trusted by codex's own app-server grant — in the real ~/.codex before
+    // Why (flag ON, hooks on, system default): the hook entry must exist — appended
+    // last and trusted by codex's own app-server grant — in the real ~/.codex before
     // the pane spawns. An incapable grant flips the lane gate so the launch
     // below falls back to the managed home instead of a status-blind pane.
     await ensureRealHomeCodexHookState({
-      hooksEnabled: isAgentStatusHooksEnabled(state.store?.getSettings()),
+      hooksEnabled: true,
       userDataPath: app.getPath('userData')
     })
     return true

--- a/src/main/startup/codex-session-resume-launch.test.ts
+++ b/src/main/startup/codex-session-resume-launch.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentProviderSessionMetadata } from '../../shared/agent-session-resume'
+
+// Why the mocks: this file proves only the hooks-off gate in front of the resume hook repair;
+// the real import graph reaches electron, rollout discovery on disk, and the codex grant client.
+// `managed-agent-hook-controls` is deliberately NOT mocked so the gate reads the real predicate.
+const {
+  ensureRealHomeCodexHookState,
+  installForLaunchPrep,
+  refreshRuntimeUserHooksForLaunchPrep,
+  resumeHomePath
+} = vi.hoisted(() => ({
+  ensureRealHomeCodexHookState: vi.fn(() => Promise.resolve('installed')),
+  installForLaunchPrep: vi.fn(() => Promise.resolve({ state: 'installed' })),
+  refreshRuntimeUserHooksForLaunchPrep: vi.fn(() => Promise.resolve({ state: 'installed' })),
+  resumeHomePath: { current: '/home/user/.codex' }
+}))
+vi.mock('electron', () => ({ app: { getPath: () => '/user-data' } }))
+vi.mock('../codex/codex-real-home-hook-install', () => ({ ensureRealHomeCodexHookState }))
+vi.mock('../codex/hook-service', () => ({
+  codexHookService: { installForLaunchPrep, refreshRuntimeUserHooksForLaunchPrep }
+}))
+vi.mock('../agent-trust-presets', () => ({ markCodexProjectTrusted: vi.fn() }))
+vi.mock('../codex/codex-legacy-session-resume', () => ({
+  prepareLegacySharedCodexSessionResume: () => Promise.resolve({ useRealCodexHome: false })
+}))
+vi.mock('../codex/codex-home-paths', () => ({
+  getSystemCodexHomePath: () => '/home/user/.codex',
+  getOrcaManagedCodexHomePath: () => '/user-data/codex-home'
+}))
+vi.mock('../codex/codex-session-resume-preparation', () => ({
+  prepareCodexSessionResume: async (args: {
+    resolveVerifiedResumeHome: (source: {
+      transcriptPath: string
+      homePath: string
+    }) => Promise<string>
+  }) => ({
+    outcome: 'resume' as const,
+    codexHomePath: await args.resolveVerifiedResumeHome({
+      transcriptPath: '/rollout.jsonl',
+      homePath: resumeHomePath.current
+    })
+  })
+}))
+
+import { prepareCodexSessionResumeForLaunch } from './codex-session-resume-launch'
+import { mainProcessState } from './main-process-state'
+
+const PROVIDER_SESSION = {
+  id: 'session-1',
+  transcriptPath: '/rollout.jsonl'
+} as unknown as AgentProviderSessionMetadata
+
+function setUpResume(agentStatusHooksEnabled: boolean | undefined, homePath: string): void {
+  resumeHomePath.current = homePath
+  mainProcessState.store = {
+    getSettings: () => ({ agentStatusHooksEnabled })
+  } as unknown as typeof mainProcessState.store
+  mainProcessState.codexRuntimeHome = {
+    getHostCodexHomePathsForSessionDiscovery: () => [],
+    resolveSelectedHostAccountCodexHomePathForResume: () => null,
+    isHostSystemDefaultRealHome: () => true
+  } as unknown as typeof mainProcessState.codexRuntimeHome
+}
+
+function launch(): ReturnType<typeof prepareCodexSessionResumeForLaunch> {
+  return prepareCodexSessionResumeForLaunch({
+    providerSession: PROVIDER_SESSION,
+    target: { runtime: 'host' },
+    workspacePath: '/repo/wt'
+  })
+}
+
+beforeEach(() => {
+  ensureRealHomeCodexHookState.mockClear()
+  installForLaunchPrep.mockClear()
+  refreshRuntimeUserHooksForLaunchPrep.mockClear()
+})
+
+describe('prepareCodexSessionResumeForLaunch hook repair', () => {
+  it('never touches the user-global ~/.codex when this profile has status hooks off', async () => {
+    setUpResume(false, '/home/user/.codex')
+
+    await expect(launch()).resolves.toMatchObject({ codexHomePath: '/home/user/.codex' })
+
+    expect(ensureRealHomeCodexHookState).not.toHaveBeenCalled()
+  })
+
+  it('skips the legacy runtime-user refresh, which sweeps ~/.codex too, when hooks are off', async () => {
+    setUpResume(false, '/user-data/codex-home')
+
+    await expect(launch()).resolves.toMatchObject({ codexHomePath: '/user-data/codex-home' })
+
+    expect(refreshRuntimeUserHooksForLaunchPrep).not.toHaveBeenCalled()
+    expect(installForLaunchPrep).not.toHaveBeenCalled()
+  })
+
+  it('installs into the real home when status hooks are on', async () => {
+    setUpResume(true, '/home/user/.codex')
+
+    await launch()
+
+    expect(ensureRealHomeCodexHookState).toHaveBeenCalledTimes(1)
+    expect(ensureRealHomeCodexHookState).toHaveBeenCalledWith({
+      hooksEnabled: true,
+      userDataPath: '/user-data'
+    })
+  })
+
+  it('installs into a managed resume home when status hooks are on', async () => {
+    setUpResume(undefined, '/user-data/codex-home')
+
+    await launch()
+
+    expect(installForLaunchPrep).toHaveBeenCalledWith('/user-data/codex-home')
+    expect(ensureRealHomeCodexHookState).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/startup/codex-session-resume-launch.ts
+++ b/src/main/startup/codex-session-resume-launch.ts
@@ -87,21 +87,23 @@ export async function prepareCodexSessionResumeForLaunch(args: {
           console.warn('[codex-project-trust] failed to pre-mark resumed workspace:', error)
         }
       }
+      if (!isAgentStatusHooksEnabled(store.getSettings())) {
+        // Why nothing at all: both branches below reach the user-global ~/.codex — the sweep
+        // directly, the runtime-user refresh through its legacy system-home cleanup — and match
+        // Orca entries by script filename, so THIS profile's off switch would delete the hook and
+        // trust records another profile installed (STA-5679). Removal stays on the Settings toggle.
+        return resumeHome
+      }
       const isSystemHome =
         normalizeRuntimePathForComparison(resumeHome) ===
         normalizeRuntimePathForComparison(systemHomePath)
-      const hooksEnabled = isAgentStatusHooksEnabled(store.getSettings())
       try {
-        if (isSystemHome) {
-          await ensureRealHomeCodexHookState({
-            hooksEnabled,
-            userDataPath: app.getPath('userData')
-          })
-        } else if (hooksEnabled) {
-          await codexHookService.installForLaunchPrep(resumeHome)
-        } else {
-          await codexHookService.refreshRuntimeUserHooksForLaunchPrep(resumeHome)
-        }
+        await (isSystemHome
+          ? ensureRealHomeCodexHookState({
+              hooksEnabled: true,
+              userDataPath: app.getPath('userData')
+            })
+          : codexHookService.installForLaunchPrep(resumeHome))
       } catch (error) {
         // Why: hook repair is best-effort; session provenance must still win over the currently selected home.
         console.warn('[codex-hook-service] failed to prepare automatic resume home:', error)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​184 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​184 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## ELI5

Two Orca windows can be signed into different profiles, but they share one `~/.codex` folder. If you turned agent status hooks **off** in one of them, simply launching or resuming a Codex pane there deleted the Codex hook — and its trust records — that the *other* profile had installed. This makes both of those code paths install-only: with hooks off they now do nothing instead of deleting.

## What Changed

Two per-pane Codex launch paths stopped forwarding this profile's `agentStatusHooksEnabled` preference into the real-home hook writer, and now gate on it instead:

- `src/main/startup/codex-launch-preparation.ts` — `ensureRealHomeHooksIfSelected` gains the preference in its existing early-return guard and passes a hard `hooksEnabled: true`.
- `src/main/startup/codex-session-resume-launch.ts` — the preference is resolved once and returns early before the `isSystemHome` test, so neither the real-home lane nor the managed-home lane runs.

Adds the first test files for both modules. No production behavior changes when hooks are on.

## Why

This is a **pre-existing** bug, split out of #19974. That PR does not cause it; it makes it easy to reach, because its first-run checkbox fires only on fresh profiles — exactly the second-profile scenario where the damage shows up.

**The mechanism.** `~/.codex/hooks.json` and `~/.codex/config.toml` are user-global, one copy shared by every Orca profile on the machine. `sweepRealHomeCodexHook` identifies Orca-managed entries by **script filename** (`createManagedCommandMatcher(getCodexManagedScriptFileName())`), not by which profile installed them. So a sweep driven by *this* profile's off switch removes the hook entry, and `removeCodexManagedHookTrustEntries` removes the `[hooks.state]` trust record, that *another* running profile depends on. That is STA-5679.

`ensureRealHomeCodexHookState` is `hooksEnabled ? install : sweep` (`src/main/codex/codex-real-home-hook-install.ts:101`), so forwarding a `false` preference *is* requesting the destructive branch. On the resume path the non-system-home `else` branch was just as bad in a less obvious way: `refreshRuntimeUserHooksForLaunchPrep` ends in `cleanupLegacyManagedHookRepresentations()` → `cleanupLegacySystemManagedHooks()`, which mutates the real `~/.codex/config.toml` — and the sweep-suppression gate in `main-process-account-services.ts` deliberately re-arms exactly when hooks are off.

**Why mirroring startup is the right fix.** Startup was already fixed this way in 4ff07da23c: it gates on the preference and then passes a hard `hooksEnabled: true`, with the reasoning recorded on `resolveStartupManagedHookAction` — *"Honoring the off switch only requires skipping the install; removal stays on the explicit Settings toggle, which is the user-initiated path that should own it."* These two paths are the per-pane twins of that same decision, and were simply missed.

**Nothing legitimate is lost.**

- *Routing is unchanged.* `isRealHomeCodexHookLaneUsable()` is `currentLane !== 'unavailable'`, so the lane reads as usable whether it sits at `'pending'` (never attempted) or `'removed'` (swept). PTY env, rate limits, and commit-message routing all see the same answer.
- *Opt-out still converges.* The Settings toggle calls `applyAgentStatusHooksEnabled(false)` → `removeManagedAgentHooks()` → `codexHookService.remove()` → `removeCodexHooksExclusively` → `cleanupLegacyManagedHookRepresentations()` → `cleanupLegacySystemManagedHooks()`, which sweeps the real home. That is user-initiated, which is where STA-5679 says removal belongs.

**The stale exemption.** The commit that exempted Codex from the original STA-5679 fix justified it in its own message: *"Codex is unaffected either way because its hooks live in an Orca-owned runtime home"* — 4ff07da23c, 2026-08-27. That had stopped being true six weeks earlier: c3f37e5500 (2026-07-14) moved the system-default lane onto the user's real `~/.codex`. The exemption was written against a world that no longer existed.

## Adjacent site deliberately left alone

`src/main/startup/codex-launch-preparation.ts:73-80` still passes the raw `agentStatusHooksEnabled` preference into `codexHookService.prepareRuntimeHomeForLaunch(runtimeHomePath, hookTarget, hooksEnabled)`. Its hooks-off branch reaches `refreshRuntimeUserHooks` → `cleanupLegacyManagedHookRepresentations()` → `cleanupLegacySystemManagedHooks()`, which mutates the real `~/.codex/config.toml` — and `systemCodexHomeHookSweepSuppressed` requires `isAgentStatusHooksEnabled`, so hooks-off is exactly the state that un-suppresses that sweep. It is unreachable on the system-default lane, which returns `null` at line 64 before ever getting there, so it only fires for managed-home and WSL launches.

It is excluded from this PR on purpose. The two sites fixed here are unambiguous: they sweep the real `~/.codex` on behalf of a profile that may own nothing in it, and the intent (don't reinstall) and the effect (delete) plainly diverge. The third is a different trade. The legacy cleanup exists to converge **old** system-home representations after the move to managed homes — downgrade and rollback convergence, not current-preference enforcement. Whether that convergence should also be Settings-toggle-only is a separate question from the one this PR answers, and changing it would alter behaviour for managed-home and WSL users who are not the population this fix is about. That deserves its own decision rather than riding along on this one. (An earlier draft of this section claimed dropping it would strand stale legacy entries — that was speculation and is withdrawn; the argument here is scope, not consequence.)

A reviewer who thinks the legacy sweep should also be Settings-toggle-only should say so — it will be a follow-up, not a change to this PR.

## Linked Issue

STA-5679 (Linear). No GitHub issue exists for this one; split out of #19974.

## Visual Proof

`N/A` — there is no UI change. This PR only removes calls into a hook/config writer on a disabled-hooks code path; nothing rendered changes in either state.

## Testing

`codex-launch-preparation.ts` and `codex-session-resume-launch.ts` had no test files. Both now have one, each with a hooks-OFF assertion and a hooks-ON anti-vacuity anchor. `isAgentStatusHooksEnabled` is deliberately **not** mocked in either file, so the gate is read through the real predicate rather than a stub.

Every hooks-OFF assertion was ablated at the final commit — production change reverted, test confirmed failing, restored, confirmed green:

- revert `codex-launch-preparation.ts` → `never touches the user-global ~/.codex when this profile has status hooks off` fails with `expected "vi.fn()" to not be called at all, but actually been called 1 times` / `{ "hooksEnabled": false, "userDataPath": "/user-data" }`
- revert `codex-session-resume-launch.ts` → both its hooks-OFF tests fail, the second showing the legacy refresh called with `"/user-data/codex-home"`
- both production files at main → 3 failed | 4 passed (7)
- both restored → 7 passed (7)

Gates, all green: `pnpm tc`, `pnpm test src/main/startup src/main/codex/codex-real-home-hook-install.test.ts src/main/agent-hooks` (1334 passed | 17 skipped), `oxlint`, `check:code-quality:changed`, `check:react-doctor:changed`, `check:max-lines-ratchet`, `pnpm format`, and all four `verify:localization-*` scripts.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platforms: logic is platform-independent and exercised on macOS. The WSL branch in `codex-launch-preparation.ts` is untouched, and the real-home lane is native-only. No SSH surface: this is local `~/.codex` state on the execution host.

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security:** strictly reduces writes to user-global files; no new file or process surface.
- **Cross-platform:** no platform-dependent logic added; the WSL guard is preserved unchanged.
- **Remote SSH:** none — the real-home lane is local-only, and nothing about remote execution-host reporting changes.
- **Mobile:** no surface.
- **Backwards compatibility:** a profile with hooks off that previously swept on launch now leaves the entry in place; the Settings toggle still removes it. No wire, schema, or persisted-state change.
- **Performance:** removes a file read/write and a trust-config mutation from every hooks-off pane launch.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)