### PR TITLE
perf(computer): avoid rescanning fragmented native provider replies

### DIFF
--- a/config/scripts/native-provider-line-gate-benchmark.mjs
+++ b/config/scripts/native-provider-line-gate-benchmark.mjs
@@ -1,0 +1,320 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+
+// Pipe the baseline client module on stdin. Native process/filesystem operations are forbidden here.
+const entry = path.resolve('src/main/computer/macos-native-provider-client.ts')
+const sources = [readFileSync(0, 'utf8'), readFileSync(entry, 'utf8')]
+assert(sources.every((source) => source.includes('export class MacOSNativeProviderClient')))
+async function load(source) {
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    write: false,
+    plugins: [
+      {
+        name: 'native-client-receive-fixture',
+        setup(builder) {
+          builder.onLoad({ filter: /macos-native-provider-client\.ts$/ }, () => ({
+            contents: `${source}\nexport { NativeProviderLineBuffer, consumeNativeProviderLines } from './macos-native-provider-transport';`,
+            loader: 'ts',
+            resolveDir: path.dirname(entry)
+          }))
+          builder.onResolve({ filter: /^node:(fs|child_process)$/ }, (args) => ({
+            path: args.path,
+            namespace: 'forbidden-native-operation'
+          }))
+          builder.onLoad({ filter: /.*/, namespace: 'forbidden-native-operation' }, (args) => ({
+            contents: `function forbidden() { throw new Error('Native operations are forbidden in this benchmark'); }
+            export { forbidden as ${
+              args.path === 'node:fs'
+                ? 'chmodSync, forbidden as mkdtempSync, forbidden as rmSync, forbidden as writeFileSync, forbidden as existsSync'
+                : 'spawn'
+            } };`,
+            loader: 'js'
+          }))
+        }
+      }
+    ]
+  })
+  const bundled = `${result.outputFiles[0].text}\n//# sourceURL=native-provider-line-gate-benchmark-bundle.js`
+  return import(`data:text/javascript;base64,${Buffer.from(bundled).toString('base64')}`)
+}
+const modules = await Promise.all(sources.map(load))
+
+class FixtureSocket {
+  destroyed = false
+  writes = []
+  write(line) {
+    this.writes.push(line)
+  }
+  end() {
+    this.destroyed = true
+  }
+  destroy() {
+    this.destroyed = true
+  }
+}
+
+function clientFixture(module) {
+  const client = new module.MacOSNativeProviderClient()
+  const socket = new FixtureSocket()
+  client.socket = socket
+  return { client, socket, stale: new FixtureSocket(), events: [] }
+}
+
+function state(fixture) {
+  const { client, socket, events } = fixture
+  return {
+    buffered:
+      typeof client.socketBuffer === 'string' ? client.socketBuffer : client.socketBuffer.pending,
+    pending: [...client.pending.keys()],
+    active: client.socket === socket,
+    generation: client.socketStartGeneration,
+    destroyed: socket.destroyed,
+    writes: socket.writes,
+    events
+  }
+}
+
+function register(fixture, id, throwCallback) {
+  fixture.client.pending.set(id, {
+    timer: undefined,
+    resolve(value) {
+      fixture.events.push(['resolve', id, value])
+      if (throwCallback) {
+        throw new Error('fixture callback failure')
+      }
+    },
+    reject(error) {
+      fixture.events.push(['reject', id, error.code, error.message])
+      if (throwCallback) {
+        throw new Error('fixture callback failure')
+      }
+    }
+  })
+}
+
+let seed = 0x18c0ffee
+function random(max) {
+  seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+  return (seed >>> 8) % max
+}
+for (let trace = 0; trace < 2000; trace++) {
+  const fixtures = modules.map(clientFixture)
+  let remainder = ''
+  for (let step = 0; step < 40; step++) {
+    const op = random(20)
+    const id = random(8)
+    const throwCallback = random(12) === 0
+    if (!remainder) {
+      remainder = [
+        `${JSON.stringify({ id, ok: true, result: { text: 'Unicode 界😀', value: step } })}\n`,
+        `${JSON.stringify({ id, ok: false, error: { code: 'fixture', message: 'failed' } })}\r\n`,
+        `${JSON.stringify({ id, ok: false })}\n`,
+        ' \t\r\n',
+        'invalid json\n',
+        'null\n',
+        '\ud83d\udc00\n'
+      ][random(7)]
+    }
+    const length = random(remainder.length + 1)
+    const chunk = remainder.slice(0, length)
+    if (op > 5) {
+      remainder = remainder.slice(length)
+    }
+    for (const fixture of fixtures) {
+      const { client, socket } = fixture
+      try {
+        if (op === 0) {
+          client.shutdown()
+        } else if (op === 1) {
+          client.handleSocketClose(socket)
+        } else if (op === 2) {
+          client.handleTransportError(socket, new Error('fixture transport error'))
+        } else if (op === 3) {
+          client.invalidateActiveSocketAfterWriteFailure(socket, new Error('fixture write error'))
+        } else if (op === 4) {
+          fixture.stale = socket
+          fixture.socket = new FixtureSocket()
+          client.socket = fixture.socket
+        } else if (op === 5) {
+          register(fixture, id, throwCallback)
+        } else {
+          client.handleSocketData(op === 6 ? fixture.stale : socket, chunk)
+        }
+      } catch (error) {
+        fixture.events.push(['throw', error.name, error.message])
+      }
+    }
+    assert.deepEqual(state(fixtures[1]), state(fixtures[0]))
+  }
+}
+console.log('2,000 actual client receive/lifecycle traces / 80,000 commands match')
+
+for (let trace = 0; trace < 1000; trace++) {
+  const fixtures = modules.map(clientFixture)
+  const failThird = random(2) === 0
+  for (const fixture of fixtures) {
+    for (let id = 1; id <= 4; id++) {
+      register(fixture, id, id === 3 && failThird)
+    }
+  }
+  const input = [
+    JSON.stringify({ id: 1, ok: true, result: { text: `界😀 ${trace}` } }),
+    JSON.stringify({ id: 2, ok: false, error: { code: 'fixture', message: 'failed' } }),
+    JSON.stringify({ id: 3, ok: true, result: trace }),
+    JSON.stringify({ id: 4, ok: true, result: 'final reply' }),
+    ''
+  ].join('\n')
+  let offset = 0
+  while (offset < input.length) {
+    const length = 1 + random(80)
+    const chunk = input.slice(offset, offset + length)
+    offset += length
+    for (const fixture of fixtures) {
+      try {
+        fixture.client.handleSocketData(fixture.socket, chunk)
+      } catch (error) {
+        fixture.events.push(['throw', error.name, error.message])
+      }
+    }
+    assert.deepEqual(state(fixtures[1]), state(fixtures[0]))
+  }
+  for (const fixture of fixtures) {
+    fixture.client.handleSocketData(fixture.socket, '')
+    assert.equal(fixture.client.pending.size, 0)
+    assert.deepEqual(fixture.events.at(-1), ['resolve', 4, 'final reply'])
+  }
+  assert.deepEqual(state(fixtures[1]), state(fixtures[0]))
+}
+console.log('1,000 fragmented multi-reply client journeys / 4,000 request settlements match')
+
+class BaselineBuffer {
+  pending = ''
+  push(chunk, onLine) {
+    this.pending += chunk
+    this.pending = modules[0].consumeNativeProviderLines(this.pending, onLine)
+  }
+  clear() {
+    this.pending = ''
+  }
+}
+for (let trace = 0; trace < 3000; trace++) {
+  const buffers = [new BaselineBuffer(), new modules[1].NativeProviderLineBuffer()]
+  const events = [[], []]
+  for (let step = 0; step < 30; step++) {
+    const clear = random(25) === 0
+    const fail = random(10) === 0
+    const chunk = ['abc', '\n', '\r\n', '\ud83d', '\udc00', '\n\n', '界', '', 'ok\nfault\npartial'][
+      random(9)
+    ]
+    buffers.forEach((buffer, index) => {
+      if (clear) {
+        buffer.clear()
+      }
+      try {
+        buffer.push(chunk, (line) => {
+          events[index].push(line)
+          if (fail) {
+            throw new Error('fixture callback failure')
+          }
+        })
+      } catch (error) {
+        events[index].push({ error: error.message })
+      }
+    })
+    assert.deepEqual(events[1], events[0])
+    assert.equal(buffers[1].pending, buffers[0].pending)
+  }
+}
+console.log('3,000 actual line-buffer traces / 90,000 feeds match')
+
+function receiveArm(module) {
+  const fixture = clientFixture(module)
+  return (chunks) => {
+    let result
+    fixture.client.pending.set(1, {
+      timer: undefined,
+      resolve: (value) => {
+        result = value
+      },
+      reject: (error) => {
+        throw error
+      }
+    })
+    for (const chunk of chunks) {
+      fixture.client.handleSocketData(fixture.socket, chunk)
+    }
+    return result
+  }
+}
+function sample(arm, input, repeats) {
+  const start = performance.now()
+  let result
+  for (let i = 0; i < repeats; i++) {
+    result = arm(input)
+  }
+  return { elapsed: (performance.now() - start) / repeats, result }
+}
+
+console.log(
+  JSON.stringify({
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    unit: 'ms',
+    pairs: 8
+  })
+)
+for (const [size, chunkBytes] of [
+  [64, 65536],
+  [120000, 65536],
+  [1200000, 65536],
+  [1200000, 4096],
+  [4800000, 65536],
+  [1200000, Number.POSITIVE_INFINITY]
+]) {
+  const expected = { screenshot: { data: 'A'.repeat(size) }, text: 'fixture' }
+  const input = `${JSON.stringify({ id: 1, ok: true, result: expected })}\n`
+  const chunks = []
+  for (let offset = 0; offset < input.length; offset += chunkBytes) {
+    chunks.push(input.slice(offset, offset + chunkBytes))
+  }
+  const arms = modules.map(receiveArm)
+  for (const arm of arms) {
+    assert.deepEqual(arm(chunks), expected)
+    const until = performance.now() + 150
+    while (performance.now() < until) {
+      sample(arm, chunks, 1)
+    }
+  }
+  const repeats = Math.max(3, Math.min(100000, Math.ceil(50 / sample(arms[0], chunks, 1).elapsed)))
+  /** @type {number[][]} */
+  const times = [[], []]
+  for (let pair = 0; pair < 8; pair++) {
+    for (const index of pair % 2 ? [1, 0] : [0, 1]) {
+      const result = sample(arms[index], chunks, repeats)
+      assert.deepEqual(result.result, expected)
+      times[index].push(result.elapsed)
+    }
+  }
+  const median = times.map((values) => {
+    values.sort((a, b) => a - b)
+    return (values[3] + values[4]) / 2
+  })
+  console.log(
+    JSON.stringify({
+      size,
+      chunkBytes: Number.isFinite(chunkBytes) ? chunkBytes : 'whole frame',
+      chunks: chunks.length,
+      repeats,
+      median,
+      times
+    })
+  )
+}

--- a/src/main/computer/macos-native-provider-client.test.ts
+++ b/src/main/computer/macos-native-provider-client.test.ts
@@ -117,6 +117,76 @@ describe('MacOSNativeProviderClient', () => {
     vi.useRealTimers()
   })
 
+  it('does not rescan a growing fragmented screenshot reply', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+    const call = client.snapshot({ app: 'fixture' })
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    const socket = sockets[0]!
+    await vi.waitFor(() => expect(socket.writes).toHaveLength(1))
+    const handshake = JSON.parse(socket.writes[0]!) as { id: number }
+    socket.emit(
+      'data',
+      `${JSON.stringify({ id: handshake.id, ok: true, result: macOSProviderCapabilities() })}\n`
+    )
+    await vi.waitFor(() => expect(socket.writes).toHaveLength(2))
+    const request = JSON.parse(socket.writes[1]!) as { id: number }
+    const result = { screenshot: { data: 'A'.repeat(1_200_000) }, text: 'fixture' }
+    const reply = `${JSON.stringify({ id: request.id, ok: true, result })}\n`
+    const originalIndexOf = String.prototype.indexOf
+    const originalIncludes = String.prototype.includes
+    let searchedUnits = 0
+    const search = vi.spyOn(String.prototype, 'indexOf').mockImplementation(function (
+      this: string,
+      needle: string,
+      fromIndex?: number
+    ) {
+      if (needle === '\n') {
+        searchedUnits += Math.max(0, this.length - (fromIndex ?? 0))
+      }
+      return originalIndexOf.call(this, needle, fromIndex)
+    })
+    const includes = vi.spyOn(String.prototype, 'includes').mockImplementation(function (
+      this: string,
+      needle: string,
+      fromIndex?: number
+    ) {
+      if (needle === '\n') {
+        searchedUnits += Math.max(0, this.length - (fromIndex ?? 0))
+      }
+      return originalIncludes.call(this, needle, fromIndex)
+    })
+    try {
+      for (let offset = 0; offset < reply.length; offset += 4096) {
+        socket.emit('data', reply.slice(offset, offset + 4096))
+      }
+    } finally {
+      search.mockRestore()
+      includes.mockRestore()
+    }
+    await expect(call).resolves.toEqual(result)
+    expect(searchedUnits).toBeLessThanOrEqual(reply.length * 3)
+    client.shutdown()
+  })
+
+  it('retries buffered replies on an empty chunk after a malformed reply throws', async () => {
+    const { MacOSNativeProviderClient } = await loadClientModule()
+    const client = new MacOSNativeProviderClient()
+    void client.capabilities().catch(() => {})
+    const secondCall = client.capabilities()
+    await vi.waitFor(() => expect(sockets).toHaveLength(1))
+    const socket = sockets[0]!
+    await vi.waitFor(() => expect(socket.writes).toHaveLength(2))
+    const first = JSON.parse(socket.writes[0]!) as { id: number }
+    const second = JSON.parse(socket.writes[1]!) as { id: number }
+    const malformed = JSON.stringify({ id: first.id, ok: false })
+    const valid = JSON.stringify({ id: second.id, ok: true, result: macOSProviderCapabilities() })
+    expect(() => socket.emit('data', `${malformed}\n${valid}\n`)).toThrow(TypeError)
+    socket.emit('data', '')
+    await expect(secondCall).resolves.toEqual(macOSProviderCapabilities())
+    client.shutdown()
+  })
+
   it('ignores stale socket data, close, and error after a replacement socket starts', async () => {
     const { MacOSNativeProviderClient } = await loadClientModule()
     const client = new MacOSNativeProviderClient()
@@ -128,6 +198,7 @@ describe('MacOSNativeProviderClient', () => {
     await vi.waitFor(() => expect(sockets).toHaveLength(1))
     const firstSocket = sockets[0]!
 
+    firstSocket.emit('data', '{"id":999,"result":"partial')
     await vi.advanceTimersByTimeAsync(60_000)
     await firstRejection
     expect(firstSocket.destroyed).toBe(true)
@@ -170,6 +241,7 @@ describe('MacOSNativeProviderClient', () => {
     const firstSocketDirectory = mkdtempSyncMock.mock.results[0]?.value as string
     await vi.waitFor(() => expect(firstSocket.writes).toHaveLength(1))
 
+    firstSocket.emit('data', '{"id":999,"result":"partial')
     firstSocket.emit('error', new Error('active helper failed'))
     await firstRejection
     expect(firstSocket.destroyed).toBe(true)

--- a/src/main/computer/macos-native-provider-client.ts
+++ b/src/main/computer/macos-native-provider-client.ts
@@ -20,7 +20,7 @@ import {
 import { resolveMacOSComputerUseExecutablePath } from './macos-native-provider-paths'
 import {
   attachMacOSNativeProviderSocketListeners,
-  consumeNativeProviderLines,
+  NativeProviderLineBuffer,
   startMacOSNativeProviderSocket
 } from './macos-native-provider-transport'
 import { validateComputerProviderActionParams } from './computer-provider-action-validation'
@@ -37,7 +37,7 @@ export class MacOSNativeProviderClient {
   private socketToken: string | null = null
   private nextId = 1
   private pending = new Map<number, PendingNativeRequest>()
-  private socketBuffer = ''
+  private readonly socketBuffer = new NativeProviderLineBuffer()
   private providerCapabilities: ComputerProviderCapabilities | null = null
   private socketListenerCleanup: (() => void) | null = null
   private socketStartGeneration = 0
@@ -70,7 +70,7 @@ export class MacOSNativeProviderClient {
     this.socketStartPromise = null
     this.socketStartGeneration++
     this.providerCapabilities = null
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     this.cleanupActiveSocketListeners()
     if (socket && !socket.destroyed) {
       const id = this.nextId++
@@ -199,7 +199,7 @@ export class MacOSNativeProviderClient {
     this.socketToken = started.socketToken
     const socket = started.socket
     socket.setEncoding('utf8')
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     this.socketListenerCleanup = attachMacOSNativeProviderSocketListeners(socket, {
       data: (chunk) => this.handleSocketData(socket, chunk),
       close: () => this.handleSocketClose(socket),
@@ -214,10 +214,7 @@ export class MacOSNativeProviderClient {
     if (this.socket !== socket) {
       return
     }
-    this.socketBuffer += chunk
-    this.socketBuffer = consumeNativeProviderLines(this.socketBuffer, (line) =>
-      this.handleLine(line)
-    )
+    this.socketBuffer.push(chunk, (line) => this.handleLine(line))
   }
   private handleLine(line: string): void {
     let response: NativeResponse
@@ -245,7 +242,7 @@ export class MacOSNativeProviderClient {
     }
     this.cleanupActiveSocketListeners()
     this.socket = null
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     this.cleanupSocketDirectory()
     this.rejectPending(
       new RuntimeClientError('accessibility_error', 'native macOS helper app connection closed')
@@ -259,7 +256,7 @@ export class MacOSNativeProviderClient {
     this.cleanupActiveSocketListeners()
     // Why: an active transport error makes the helper socket unreliable for the next request.
     this.socket = null
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     if (!socket.destroyed) {
       socket.destroy()
     }
@@ -275,7 +272,7 @@ export class MacOSNativeProviderClient {
     }
     this.cleanupActiveSocketListeners()
     this.socket = null
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     if (!socket.destroyed) {
       socket.destroy()
     }

--- a/src/main/computer/macos-native-provider-line-buffer.test.ts
+++ b/src/main/computer/macos-native-provider-line-buffer.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { NativeProviderLineBuffer } from './macos-native-provider-transport'
+
+describe('NativeProviderLineBuffer', () => {
+  it('keeps partial lines and original whitespace while omitting blank lines', () => {
+    const buffer = new NativeProviderLineBuffer()
+    const lines: string[] = []
+    const record = (line: string): void => {
+      lines.push(line)
+    }
+    buffer.push(' \t\r\n  first\r\nsecond', record)
+    expect(lines).toEqual(['  first\r'])
+    buffer.push(' half\n\nthird\npartial', record)
+    expect(lines).toEqual(['  first\r', 'second half', 'third'])
+    buffer.push('', record)
+    buffer.push(' tail\n', record)
+    expect(lines).toEqual(['  first\r', 'second half', 'third', 'partial tail'])
+  })
+
+  it('preserves split surrogate pairs and lone surrogate code units', () => {
+    const buffer = new NativeProviderLineBuffer()
+    const lines: string[] = []
+    for (const chunk of ['\ud83d', '\ude00\n\ud83d', '\n\udc00', '\n']) {
+      buffer.push(chunk, (line) => {
+        lines.push(line)
+      })
+    }
+    expect(lines).toEqual(['😀', '\ud83d', '\udc00'])
+  })
+
+  it.each(['', 'suffix'])('retries all complete lines after callback failure on %j', (suffix) => {
+    const buffer = new NativeProviderLineBuffer()
+    const lines: string[] = []
+    expect(() =>
+      buffer.push('first\nsecond\npartial', (line) => {
+        lines.push(line)
+        if (line === 'second') {
+          throw new Error('callback failure')
+        }
+      })
+    ).toThrow('callback failure')
+    buffer.push(suffix, (line) => {
+      lines.push(line)
+    })
+    buffer.push('\n', (line) => {
+      lines.push(line)
+    })
+    expect(lines).toEqual(['first', 'second', 'first', 'second', `partial${suffix}`])
+  })
+
+  it('clears both partial and callback-failed buffers', () => {
+    const buffer = new NativeProviderLineBuffer()
+    buffer.push('old partial', () => {
+      throw new Error('unexpected line')
+    })
+    buffer.clear()
+    expect(() =>
+      buffer.push('failed\n', () => {
+        throw new Error('callback failure')
+      })
+    ).toThrow()
+    buffer.clear()
+    const lines: string[] = []
+    buffer.push('new', (line) => {
+      lines.push(line)
+    })
+    expect(lines).toEqual([])
+    buffer.push('\n', (line) => {
+      lines.push(line)
+    })
+    expect(lines).toEqual(['new'])
+  })
+
+  it('preserves reentrant feed ordering and the outer call remainder', () => {
+    const buffer = new NativeProviderLineBuffer()
+    const lines: string[] = []
+    let reentered = false
+    const record = (line: string): void => {
+      lines.push(line)
+      if (!reentered) {
+        reentered = true
+        buffer.push('extra\n', record)
+      }
+    }
+    buffer.push('first\nsecond\npartial', record)
+    buffer.push('\n', record)
+    expect(lines).toEqual(['first', 'first', 'second', 'partialextra', 'second', 'partial'])
+  })
+
+  it('preserves a reentrant clear and partial feed when the outer callback throws', () => {
+    const buffer = new NativeProviderLineBuffer()
+    const lines: string[] = []
+    const record = (line: string): void => {
+      lines.push(line)
+    }
+    expect(() =>
+      buffer.push('old\npartial', () => {
+        buffer.clear()
+        buffer.push('new', record)
+        throw new Error('callback failure')
+      })
+    ).toThrow('callback failure')
+    buffer.push(' tail', record)
+    expect(lines).toEqual([])
+    buffer.push('\n', record)
+    expect(lines).toEqual(['new tail'])
+  })
+})

--- a/src/main/computer/macos-native-provider-transport.ts
+++ b/src/main/computer/macos-native-provider-transport.ts
@@ -45,6 +45,27 @@ export function attachMacOSNativeProviderSocketListeners(
   }
 }
 
+export class NativeProviderLineBuffer {
+  private pending = ''
+  private hasCompleteLine = false
+
+  push(chunk: string, handleLine: (line: string) => void): void {
+    this.pending += chunk
+    this.hasCompleteLine ||= chunk.endsWith('\n') || chunk.includes('\n')
+    if (!this.hasCompleteLine) {
+      return
+    }
+    // Keep complete lines retryable if a callback throws.
+    this.pending = consumeNativeProviderLines(this.pending, handleLine)
+    this.hasCompleteLine = false
+  }
+
+  clear(): void {
+    this.pending = ''
+    this.hasCompleteLine = false
+  }
+}
+
 export function consumeNativeProviderLines(
   buffer: string,
   handleLine: (line: string) => void


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​349 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​338 |

<!-- /orca-pr-loc -->

## Summary

Avoid rescanning the growing native macOS provider reply buffer on every fragment. The existing `consumeNativeProviderLines` stays unchanged; a small `NativeProviderLineBuffer` remembers whether a complete line is available and invokes that parser only when needed. Newline-terminated chunks have a constant-time gate, so complete single-chunk replies do not add another full scan.

The flag is cleared only after successful parsing. If a callback throws, a later empty/non-newline chunk still retries the complete buffered replies exactly as before. All existing socket-buffer resets now clear both pieces of state. Stale-socket guards, startup, timeouts, response parsing/error handling, helper launch, capabilities, and wire contents are unchanged.

This is a pure receive-path optimization: no screen capture, focus changes, process-ownership changes, new byte limits, or folder/git-worktree assumptions. Independent branch from `20ab99506541`.

## Measured result

Actual baseline/current `MacOSNativeProviderClient.handleSocketData` and response parser, using fake sockets and pending requests. Native process and filesystem operations throw in the benchmark. Node 26.6.0 / macOS arm64, eight counterbalanced pairs. Median receive CPU time:

| Screenshot data characters / chunk size | Before | After |
| --- | ---: | ---: |
| 64 / whole frame | 0.445 µs | 0.455 µs |
| 120,000 / 64 KiB (2 chunks) | 0.04037 ms | 0.04034 ms |
| 1,200,000 / 64 KiB (19 chunks) | 0.939 ms | 0.478 ms |
| 1,200,000 / 4 KiB (293 chunks) | 12.13 ms | 0.519 ms |
| 4,800,000 / 64 KiB (74 chunks) | 13.97 ms | 2.008 ms |
| 1,200,000 / whole frame | 0.385 ms | 0.390 ms |

Small/single-frame differences are disclosed. The native helper targets 900,000 PNG bytes (about 1,200,000 base64 characters), although its final resize fallback is not a hard size cap. The 4.8-million-character case is a stress case, not a typical screenshot claim. Timings include framing, JSON parsing and pending-request settlement callbacks, not PNG capture, helper launch, OS/socket I/O, or app-wide latency. String contents and retention policy stay unchanged; incomplete strings need not be flattened for repeated full-buffer searches.

## Verification

- Public client regression: a fragmented 1.2-million-character screenshot reply resolves identically. Baseline searches 176,418,760 character units; current satisfies a 3,600,216-unit bound across both `indexOf` and `includes` newline searches.
- Existing stale-socket timeout and transport-error tests now include a partial old reply. New public-client test preserves recovery of subsequent buffered replies after a malformed response throws, even on an empty next chunk.
- Line-buffer tests cover whitespace, CRLF, split/lone UTF-16 surrogates, callback errors, resets, and reentrant callbacks/clears.
- 2,000 actual-client receive/lifecycle traces (80,000 commands), 1,000 fragmented multi-reply journeys (4,000 request settlements), and 3,000 line-buffer traces (90,000 feeds) match baseline state, outputs, errors and ordering.
- 24 relevant provider and normalization tests across five files, `pnpm tc:node`, formatting and changed-code quality gate pass.
- All checks use `ORCA_BACKGROUND_LAUNCH=1`; helper startup is mocked and no app windows are launched.

Reproduce:

```sh
git show 20ab99506541:src/main/computer/macos-native-provider-client.ts | ORCA_BACKGROUND_LAUNCH=1 node config/scripts/native-provider-line-gate-benchmark.mjs
ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/computer/macos-native-provider src/main/computer/computer-action-verification-normalization.test.ts
ORCA_BACKGROUND_LAUNCH=1 pnpm tc:node
ORCA_BACKGROUND_LAUNCH=1 ORCA_CODE_QUALITY_BASE=20ab99506541 pnpm run check:code-quality:changed
```

Tracking: #20206. Does not close the broader performance audit.
