### PR TITLE
perf: skip nonmatching spans in Quick Open scoring

### DIFF
--- a/src/shared/quick-open-fuzzy-scan.test.ts
+++ b/src/shared/quick-open-fuzzy-scan.test.ts
@@ -1,0 +1,118 @@
+import { expect, it } from 'vitest'
+import { compareFileNames } from './file-name-sort'
+import {
+  prepareQuickOpenFiles,
+  QuickOpenPathRanker,
+  rankQuickOpenFiles,
+  type QuickOpenIndexedFile
+} from './quick-open-path-search'
+
+function referenceScore(query: string, file: QuickOpenIndexedFile): number {
+  let qi = 0
+  let score = 0
+  let lastMatch = -1
+  for (let ti = 0; ti < file.lowerPath.length && qi < query.length; ti++) {
+    if (file.lowerPath[ti] !== query[qi]) {
+      continue
+    }
+    score += lastMatch === -1 ? 0 : ti - lastMatch - 1
+    if (ti > 0 && '/.-'.includes(file.lowerPath[ti - 1])) {
+      score -= 5
+    }
+    lastMatch = ti
+    qi++
+  }
+  if (qi < query.length) {
+    return -1
+  }
+  return score - (file.lowerFilename.includes(query) ? 100 : 0)
+}
+
+it.each(['az', 'aq'])('skips nonmatching path spans for %s', (query) => {
+  const [prepared] = prepareQuickOpenFiles([`a/${'x'.repeat(4000)}/z.ts`])
+  let pathReads = 0
+  const measured = {
+    ...prepared,
+    get lowerPath() {
+      pathReads++
+      return prepared.lowerPath
+    }
+  }
+  expect(rankQuickOpenFiles(query, [measured])).toEqual(rankQuickOpenFiles(query, [prepared]))
+  expect(pathReads).toBeLessThanOrEqual(20)
+})
+
+it('preserves code-unit scores and ordering for generated Unicode paths and queries', () => {
+  const alphabet = [
+    'a',
+    'b',
+    'c',
+    '/',
+    '\\',
+    '.',
+    '-',
+    '2',
+    '0',
+    'é',
+    'e\u0301',
+    'İ',
+    '😀',
+    '\ud800',
+    '\udc00'
+  ]
+  let seed = 43
+  const next = () => {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+    return seed
+  }
+  const paths = ['a.../b', 'a/x/z', 'a/z', '😀.ts', 'a'.repeat(110), 'aa', 'same', 'same', '']
+  for (let index = 0; index < 1000; index++) {
+    const length = next() % 80
+    let path = ''
+    for (let offset = 0; offset < length; offset++) {
+      path += alphabet[next() % alphabet.length]
+    }
+    paths.push(path)
+  }
+  const files = prepareQuickOpenFiles(paths)
+  const queries = [
+    '',
+    ' ',
+    'az',
+    'ab',
+    'a',
+    'aa',
+    'q',
+    '😀',
+    '\ud800',
+    '\udc00',
+    'é',
+    'e\u0301',
+    'İ',
+    'a\\b',
+    '  A  '
+  ]
+  for (let index = 0; index < 100; index++) {
+    queries.push(`${alphabet[next() % alphabet.length]}${alphabet[next() % alphabet.length]}`)
+  }
+  for (const query of queries) {
+    const normalized = query.trim().replace(/\\/g, '/').toLowerCase()
+    const expected = files
+      .map((file) => ({ ...file, score: normalized ? referenceScore(normalized, file) : 0 }))
+      .filter((file) => file.score !== -1)
+      .sort(
+        (a, b) =>
+          a.score - b.score || compareFileNames(a.path, b.path) || a.inputIndex - b.inputIndex
+      )
+    for (const limit of [1, 16, 50]) {
+      const selected = expected.slice(0, limit).map(({ path, score }) => ({ path, score }))
+      expect(rankQuickOpenFiles(query, files, limit)).toEqual(selected)
+      const streamed = new QuickOpenPathRanker(query, limit)
+      paths.forEach((path) => streamed.consider(path))
+      expect(streamed.result()).toEqual({
+        paths: selected.map((entry) => entry.path),
+        totalCount: expected.length
+      })
+    }
+  }
+})

--- a/src/shared/quick-open-path-search.ts
+++ b/src/shared/quick-open-path-search.ts
@@ -126,9 +126,12 @@ function fuzzyMatchIndexedFile(query: string, file: QuickOpenIndexedFile): numbe
   let score = 0
   let lastMatchIdx = -1
 
-  for (let ti = 0; ti < file.lowerPath.length && qi < query.length; ti++) {
-    if (file.lowerPath[ti] !== query[qi]) {
-      continue
+  while (qi < query.length) {
+    const next = lastMatchIdx + 1
+    const ti =
+      file.lowerPath[next] === query[qi] ? next : file.lowerPath.indexOf(query[qi], next + 1)
+    if (ti === -1) {
+      return -1
     }
     const gap = lastMatchIdx === -1 ? 0 : ti - lastMatchIdx - 1
     score += gap


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5
Quick Open can skip over path characters that cannot match the next query character, instead of checking each one in JavaScript.

## What Changed
Keep the adjacent-character check for contiguous matches, then use native `indexOf` to find the next matching UTF-16 code unit. The same positions feed the existing gap and boundary scores. Query normalization, filename bonus, top-result selection, and streaming behavior retain their existing rules.

## Why
Measured full ranking over this checkout's 25,244 file paths with prebuilt indexes, using eight counterbalanced batches of 12 calls and median CPU time per call:

| Query | Before | After |
| --- | ---: | ---: |
| src | 2.10 ms | 2.04 ms |
| worktree | 4.33 ms | 1.15 ms |
| qzv | 3.82 ms | 0.54 ms |
| test | 4.73 ms | 2.67 ms |
| abc | 4.18 ms | 1.17 ms |
| mobile/session | 4.17 ms | 1.43 ms |

Every file's score and the final results matched in that probe. These are CPU measurements of ranking, excluding file enumeration, rendering, and network time. The committed regression proves that long nonmatching spans drop from over 8,000 indexed-path reads to at most 20.

## Linked Issue
No linked issue: user-requested performance audit, one PR per independent improvement.

## Visual Proof
N/A — scoring output and ordering are preserved; internal search computation only.

## Testing
- 69 tests pass across shared fuzzy scoring, renderer Quick Open, tab creation, native search, and relay listing/cancellation/ignore behavior.
- Generated corpus: 1,009 paths and 115 queries, three result limits, prepared and streaming rankers checked against the original scorer. Includes Unicode, decomposed text, lone surrogates, Windows separators, empty queries, ties, duplicate paths, and the existing score -1 exclusion.
- Both operation-count regressions fail on baseline and pass after; the reference-corpus test passes both versions. Final expanded corpus rerun passes.
- Full `pnpm tc`, targeted oxlint, formatting, and commit hooks pass.
- macOS with `ORCA_BACKGROUND_LAUNCH=1`; no app windows launched. Actual Windows/Linux and SSH hosts were not exercised; CI pending.

## Review
- [x] Small independent change; no upstream agent skill code copied.
- [x] Shared by local, SSH/remote, and renderer search; no host ownership, Git commands, RPC, or provider-specific changes.
- [x] Original path representation and folder-workspace behavior preserved.
