### PR TITLE
perf: accelerate cancellable remote transcript line scanning

### DIFF
--- a/src/main/ai-vault/remote-session-content-lines.test.ts
+++ b/src/main/ai-vault/remote-session-content-lines.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { remoteSessionContentLines } from './remote-session-content-lines'
+
+async function collect(content: string, signal: AbortSignal): Promise<string[]> {
+  const lines: string[] = []
+  for await (const line of remoteSessionContentLines(content, signal)) {
+    lines.push(line)
+  }
+  return lines
+}
+
+describe('remote session content lines', () => {
+  it.each([
+    ['', ['']],
+    ['\n', ['', '']],
+    ['one\r\ntwo\n', ['one', 'two', '']],
+    ['one\rtwo\r', ['one\rtwo']],
+    ['x'.repeat(300_000), ['x'.repeat(300_000)]]
+  ])('preserves line boundaries for input %#', async (content, expected) => {
+    expect(await collect(content as string, new AbortController().signal)).toEqual(expected)
+  })
+
+  it('rejects an already cancelled scan even for empty content', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    await expect(collect('', controller.signal)).rejects.toThrow()
+  })
+
+  it.each(['\n'.repeat(400), `${'x'.repeat(300_000)}\nlast`])(
+    'observes cancellation at an event-loop yield for input %#',
+    async (content) => {
+      const controller = new AbortController()
+      setImmediate(() => controller.abort())
+      await expect(collect(content, controller.signal)).rejects.toThrow()
+    }
+  )
+})

--- a/src/main/ai-vault/remote-session-content-lines.ts
+++ b/src/main/ai-vault/remote-session-content-lines.ts
@@ -27,7 +27,8 @@ async function* cancellableContentLines(
 
   for (let index = 0; index <= content.length; index++) {
     if (index < content.length && content.charCodeAt(index) !== 10) {
-      continue
+      const newline = content.indexOf('\n', index)
+      index = newline === -1 ? content.length : newline
     }
     const lineEnd = index > lineStart && content.charCodeAt(index - 1) === 13 ? index - 1 : index
     yield content.slice(lineStart, lineEnd)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

## ELI5

Find transcript newlines directly instead of checking every character when a remote session scan supports cancellation.

## What Changed

Use native string newline search in the existing cancellable line generator. Preserve empty-line fast paths, CRLF and EOF handling, line/character yield thresholds, and all abort checks. The no-signal path is unchanged.

## Why

Windows Node benchmark of the actual bundled generator, including asynchronous consumption. Median of 15 batches after five warmups, alternating order, 10 calls per batch:

| Input | Before ms | After ms |
| --- | ---: | ---: |
| One 1 MB line | 0.902570 | 0.017680 |
| 1,000 CRLF records of 1 KB | 1.290630 | 0.093510 |
| 10,000 blank lines | 0.683030 | 0.670510 |
| Short three-line input | 0.000820 | 0.000650 |

Synthetic CPU measurements, not network or end-to-end scan latency. No concurrency or cache policy changes.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — parsing output is identical.

## Testing

- 31 tests across line generation, remote session scanning and batching pass.
- New coverage verifies newline/EOF behavior, pre-aborted empty content, and cancellation during both line-count and character-count event-loop yields.
- Original/modified generator output parity on seven boundary fixtures.
- Node TypeScript check, targeted oxlint and formatting pass.

- Independent review reran the exact baseline and PR-head generators on eight inputs under normal completion, pre-abort, and event-loop abort: all 24 output/cancellation traces matched, including a 1 MB newline-free input.

## Review

Loop index after search equals the original newline/EOF position, so yield thresholds and cancellation checks retain their meaning. In the baseline, the non-newline branch already continued before the yield checks: both versions check the character budget only at a newline or EOF, not midway through a line. This PR preserves that existing cancellation granularity; it does not introduce a new uninterruptible span. Execution-host ownership, remote transport and folder workspace behavior remain unchanged. Tests ran with background launch policy; no app launched.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, SSH and folder workspace behavior considered.
- [x] Relevant tests, typecheck and lint passed.

