### PR TITLE
perf: skip dominated quick command search fields

### DIFF
--- a/src/renderer/src/lib/terminal-quick-command-score-budget.test.ts
+++ b/src/renderer/src/lib/terminal-quick-command-score-budget.test.ts
@@ -1,0 +1,49 @@
+import { expect, it } from 'vitest'
+import type { TerminalQuickCommand } from '../../../shared/terminal-quick-command-types'
+import { searchTerminalQuickCommands } from './terminal-quick-command-search'
+
+it.each(['Review', 'codex'])('does not scan prompts that cannot improve the %s match', (query) => {
+  let promptReads = 0
+  const commands: TerminalQuickCommand[] = Array.from({ length: 40 }, (_, index) => ({
+    id: String(index),
+    label: `Review changes ${index}`,
+    action: 'agent-prompt',
+    agent: 'codex',
+    get prompt() {
+      promptReads++
+      return 'Inspect all source code. '.repeat(240)
+    }
+  }))
+  expect(searchTerminalQuickCommands(commands, query)).toEqual(commands)
+  expect(promptReads).toBe(0)
+})
+
+it('keeps body matches that beat an agent substring match', () => {
+  const commands: TerminalQuickCommand[] = [
+    { id: 'agent-only', label: 'Other', action: 'agent-prompt', agent: 'codex', prompt: 'nothing' },
+    { id: 'body-exact', label: 'Other', action: 'agent-prompt', agent: 'codex', prompt: 'dex' },
+    { id: 'label', label: 'dex', command: 'nothing', appendEnter: true }
+  ]
+  expect(searchTerminalQuickCommands(commands, 'dex').map((command) => command.id)).toEqual([
+    'label',
+    'body-exact',
+    'agent-only'
+  ])
+})
+
+it('keeps equal scores in input order and still searches bodies without a metadata match', () => {
+  const commands: TerminalQuickCommand[] = [
+    { id: 'first', label: 'codex', command: 'codex', appendEnter: true },
+    { id: 'second', label: 'codex', action: 'agent-prompt', agent: 'codex', prompt: 'codex' },
+    { id: 'body', label: 'Other', command: 'run the task', appendEnter: true },
+    { id: 'none', label: 'Other', command: 'nothing', appendEnter: true }
+  ]
+  expect(searchTerminalQuickCommands(commands, 'codex').map((command) => command.id)).toEqual([
+    'first',
+    'second'
+  ])
+  expect(searchTerminalQuickCommands(commands, 'task').map((command) => command.id)).toEqual([
+    'body'
+  ])
+  expect(searchTerminalQuickCommands(commands, 'absent')).toEqual([])
+})

--- a/src/renderer/src/lib/terminal-quick-command-search.ts
+++ b/src/renderer/src/lib/terminal-quick-command-search.ts
@@ -73,12 +73,15 @@ export function getTerminalQuickCommandPickerValue({
 }
 
 function scoreQuickCommand(command: TerminalQuickCommand, query: string): number {
-  const body = getTerminalQuickCommandBody(command)
-  const scores = [scoreCandidate(query, command.label, 0), scoreCandidate(query, body, 400)]
-  if (isTerminalAgentQuickCommand(command)) {
-    scores.push(scoreCandidate(query, command.agent, 200))
+  let score = scoreCandidate(query, command.label, 0)
+  // A field cannot improve a score already at or below its base score.
+  if (score > 200 && isTerminalAgentQuickCommand(command)) {
+    score = Math.min(score, scoreCandidate(query, command.agent, 200))
   }
-  return Math.min(...scores)
+  if (score > 400) {
+    score = Math.min(score, scoreCandidate(query, getTerminalQuickCommandBody(command), 400))
+  }
+  return score
 }
 
 function scoreCandidate(query: string, rawCandidate: string, baseScore: number): number {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5
When a saved command's name already matches well, command search does not need to read and normalize its entire prompt too.

## What Changed
Score the label first, then the agent name only when its minimum score of 200 could improve the result, then the command body only when its minimum score of 400 could improve it. Preserve the existing normalization and stable result ordering.

## Why
Saved quick commands permit 40 entries with 6,000-character agent prompts. The old scorer normalized every body even when a label or agent match already had a better score than any body could achieve.

With 40 supported-size prompts, warmed full-search CPU measurements (16 counterbalanced batches of 50 calls) were:

| Query kind | Before | After |
| --- | ---: | ---: |
| Label | 2.197 ms | 0.0078 ms |
| Agent | 2.442 ms | 0.0102 ms |
| Body only | 2.003 ms | 1.958 ms |
| No match | 2.324 ms | 2.281 ms |

Earlier runs without mixed-query warmup showed roughly 3% slower body-only timings. That difference did not reproduce after warming both implementations across all query types; the reliable claim is removed body work for metadata matches, not a body-only speedup. These are synthetic search CPU timings, excluding rendering and terminal launch.

## Linked Issue
No linked issue: user-requested performance audit, separate PR per independent improvement.

## Visual Proof
N/A — result scores and ordering are preserved; no visual or interaction change.

## Testing
- 30 tests pass across quick-command search, the new score-bound tests, and command normalization.
- Label and agent match regressions fail on baseline with 40 prompt reads and pass after with zero. Tests also preserve body matches that beat agent substring scores, ties, and nonmatches.
- Additional actual-module probe verifies exact score parity over 3,000 generated Unicode command/query cases.
- `pnpm tc:web`, targeted oxlint, formatting, and commit hooks pass.
- macOS with `ORCA_BACKGROUND_LAUNCH=1`. No app windows launched. Windows/Linux/SSH were not exercised locally; CI pending.

## Review
- [x] Focused computation change; no upstream skill code copied.
- [x] No terminal execution, agent status, host ownership, RPC, or Git-provider behavior changes.
- [x] Both shell commands and agent prompts covered; shared search is used by settings and the hosted command picker.
