### PR TITLE
perf: reuse normalized executable during agent recognition

### DIFF
--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -289,7 +289,7 @@ export function recognizeAgentProcessFromCommandLine(
   const keep = options?.includeHeadlessOneShot === true
   const tokens = tokenizeCommandLine(commandLine)
   const firstNormalized = normalizeProcessName(tokens[0])
-  let direct = recognizeAgentProcess(tokens[0])
+  let direct = recognizedAgentForProcess(firstNormalized)
   // Why: the generic Orca CLI is not an agent; only this subcommand launches its TUI mode.
   if (direct?.agent === 'claude-agent-teams' && tokens[1]?.toLowerCase() !== 'claude-teams') {
     direct = null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Reuse the executable name already normalized during command-line agent recognition.

## What Changed

Pass firstNormalized to the existing internal lookup instead of normalizing tokens[0] a second time. Recognition, interpreter handling and headless-command filtering remain identical.

## Why

Windows benchmark of the actual bundled recognizer; median of 15 batches after five warmups, alternating order, 10,000 calls per batch:

| Command shape | Before ms | After ms |
| --- | ---: | ---: |
| claude.exe | 0.000271 | 0.000200 |
| Quoted Windows Claude path with resume args | 0.001350 | 0.001159 |
| Node with Windows Codex package path | 0.002592 | 0.002514 |
| Node inline script | 0.000562 | 0.000475 |
| Python module | 0.000724 | 0.000627 |
| PowerShell | 0.000599 | 0.000497 |
| Headless Claude | 0.000439 | 0.000360 |

Small absolute CPU savings per call, not end-to-end latency. The Windows foreground-process reader calls this function when recognizing process-table candidates. This removes redundant work without caching or changing freshness.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — no presentation changes.

## Testing

- All 26 agent-process recognition tests pass.
- Original/modified parity for seven command shapes, both default and includeHeadlessOneShot modes.
- Node TypeScript check, targeted oxlint and formatting pass.

## Review

The replaced public wrapper normalizes its argument and immediately calls the same internal lookup. firstNormalized uses exactly that normalization on exactly that token. No execution-host, agent-status producer, wire or workspace policy changes. Background test launch policy applied; no app launched.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, SSH and folder workspace behavior considered.
- [x] Relevant tests, typecheck and lint passed.
