### PR TITLE
perf: avoid copying single-chunk process output

### DIFF
--- a/src/shared/child-process/bounded-output-sink.test.ts
+++ b/src/shared/child-process/bounded-output-sink.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { createOutputSink } from './bounded-output-sink'
+
+describe('bounded process output', () => {
+  it('can read empty output and continue collecting', () => {
+    const sink = createOutputSink(10)
+    expect(sink.text()).toBe('')
+    sink.write('one')
+    expect(sink.text()).toBe('one')
+    sink.write('two')
+    expect(sink.text()).toBe('onetwo')
+    expect(sink.truncated()).toBe(false)
+  })
+
+  it('decodes UTF-8 across every chunk boundary and byte limit', () => {
+    const bytes = Buffer.from('a💻é\r\nb')
+    for (let split = 0; split <= bytes.length; split += 1) {
+      for (let cap = 0; cap <= bytes.length + 1; cap += 1) {
+        const sink = createOutputSink(cap)
+        sink.write(bytes.subarray(0, split))
+        sink.write(bytes.subarray(split))
+        expect(sink.text()).toBe(bytes.subarray(0, cap).toString('utf8'))
+        expect(sink.truncated()).toBe(bytes.length > cap)
+      }
+    }
+  })
+
+  it('clips a single string chunk at the byte limit', () => {
+    const sink = createOutputSink(3)
+    sink.write('a💻')
+    expect(sink.text()).toBe('a�')
+    expect(sink.truncated()).toBe(true)
+  })
+})

--- a/src/shared/child-process/bounded-output-sink.ts
+++ b/src/shared/child-process/bounded-output-sink.ts
@@ -25,7 +25,10 @@ export function createOutputSink(maxBytes: number): {
       chunks.push(chunk.length > remaining ? chunk.subarray(0, remaining) : chunk)
       bytes += chunk.length
     },
-    text: () => Buffer.concat(chunks).toString('utf8'),
+    text: () =>
+      chunks.length === 0
+        ? ''
+        : (chunks.length === 1 ? chunks[0] : Buffer.concat(chunks)).toString('utf8'),
     // Why: callers that parse the output need to tell a short answer from a
     // clipped one -- truncated JSON or JSONL parses as a smaller valid result.
     truncated: () => bytes > maxBytes


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

Decode process output directly when it arrived in one chunk, and return an empty string immediately when nothing arrived.

## What Changed

Avoid Buffer.concat in the empty/single-chunk cases of the shared bounded output sink. Multiple chunks still concatenate before UTF-8 decoding. Byte caps and truncation reporting are unchanged.

## Why

Windows Node benchmark of the actual bundled sink, including creation, writes and text decoding. Median of 15 batches after five warmups, alternating order, 1,000 calls per batch:

| Output | Before ms | After ms |
| --- | ---: | ---: |
| Empty | 0.000092 | 0.000052 |
| Short single chunk | 0.000174 | 0.000090 |
| 64 KB single chunk | 0.015322 | 0.002372 |
| Two 32 KB chunks | 0.010490 | 0.009169 |

The multiple-chunk path is unchanged; its timing difference is benchmark variation. Synthetic CPU measurements, not process-spawn or app latency. runProcess uses this collector for stdout and stderr, including Windows and WSL commands.

## Linked Issue

User-requested Windows/WSL performance audit; no linked issue.

## Visual Proof

N/A — output is identical.

## Testing

- 18 tests passed, one existing platform skip, across bounded output and runProcess.
- New tests cover empty reads followed by writes, repeated reads, string clipping, and every UTF-8 chunk boundary/byte cap for a multibyte fixture.
- 220 original/modified boundary comparisons pass.
- Node TypeScript check, targeted oxlint and formatting pass.

## Review

Decoding a single chunk directly produces the same string as decoding its temporary copy. No retained-result cache or Buffer ownership changes. SSH execution ownership, command launching and folder workspace behavior are unchanged. Tests use background launch policy.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Checklist

- [x] Focused and self-reviewed.
- [x] Cross-platform, SSH and folder workspace behavior considered.
- [x] Relevant tests, typecheck and lint passed.
