### PR TITLE
perf: scan chat activity text from its last line

### DIFF
--- a/src/shared/native-chat-activity-tail-line.test.ts
+++ b/src/shared/native-chat-activity-tail-line.test.ts
@@ -1,0 +1,87 @@
+import { expect, it, vi } from 'vitest'
+import { normalizePromptField } from './agent-status-field-normalization'
+import type { AgentJournalRenderItem } from './agent-session-journal-types'
+import { selectStructuredAgentTurnActivity } from './native-chat-turn-activity'
+
+function status(text: string): AgentJournalRenderItem {
+  return {
+    itemId: 'status',
+    revision: 1,
+    sequence: 1,
+    observedAt: 1,
+    body: { kind: 'status', text }
+  }
+}
+
+it('does not trim every preceding status line to select the final activity', () => {
+  const text = `${'Previous activity\n'.repeat(500)}Preparing the answer`
+  const trim = vi.spyOn(String.prototype, 'trim')
+  try {
+    expect(selectStructuredAgentTurnActivity([status(text)], 'turn')).toEqual({
+      kind: 'description',
+      text: 'Preparing the answer'
+    })
+    expect(trim.mock.calls.length).toBeLessThan(10)
+  } finally {
+    trim.mockRestore()
+  }
+})
+
+it('preserves the last nonempty LF-delimited line before prompt normalization', () => {
+  const texts = [
+    '',
+    '\n',
+    '\n\n',
+    ' \r\n\t',
+    'first\rsecond',
+    '\nfirst\r\nsecond\r\n',
+    'first\n\u00a0\u2003\n',
+    'first\n\u2028second\u2029',
+    'a\n😀',
+    'a\n\ud800',
+    'a\n\udc00',
+    `a\n${'x'.repeat(199)}😀`,
+    `first\n${' '.repeat(3000)}last`,
+    'first\n\0\n',
+    'first\n\ufeff\n'
+  ]
+  const alphabet = [
+    'a',
+    ' ',
+    '\n',
+    '\r',
+    '\t',
+    '\u00a0',
+    '\u2003',
+    '\u2028',
+    '\ufeff',
+    '😀',
+    '\ud800',
+    '\udc00'
+  ]
+  let seed = 57
+  const next = () => {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+    return seed
+  }
+  for (let index = 0; index < 1000; index++) {
+    let text = ''
+    const length = next() % 300
+    for (let offset = 0; offset < length; offset++) {
+      text += alphabet[next() % alphabet.length]
+    }
+    texts.push(text)
+  }
+  for (const text of texts) {
+    const line = text
+      .split('\n')
+      .map((part) => part.trim())
+      .findLast((part) => part.length > 0)
+    const normalized = line ? normalizePromptField(line) : ''
+    const expected = normalized ? { kind: 'description', text: normalized } : null
+    expect(selectStructuredAgentTurnActivity([status(text)], 'turn')).toEqual(expected)
+    expect(selectStructuredAgentTurnActivity([], 'turn', { turnId: 'turn', text })).toEqual(
+      expected
+    )
+  }
+})

--- a/src/shared/native-chat-turn-activity.ts
+++ b/src/shared/native-chat-turn-activity.ts
@@ -7,12 +7,19 @@ import { describeActiveToolCall, formatActiveToolLabel } from './native-chat-too
 export type NativeChatTurnActivity = { kind: 'description'; text: string }
 
 function activityLine(text: string): string | null {
-  const lines = text
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-  const latest = lines.at(-1)
-  return latest ? normalizePromptField(latest) || null : null
+  let end = text.length
+  while (end > 0) {
+    const start = text.lastIndexOf('\n', end - 1) + 1
+    const latest = text.slice(start, end).trim()
+    if (latest) {
+      return normalizePromptField(latest) || null
+    }
+    if (start === 0) {
+      break
+    }
+    end = start - 1
+  }
+  return null
 }
 
 function recentToolActivityLabels(items: readonly AgentJournalRenderItem[]): Set<string> {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## ELI5
The chat activity indicator needs the last nonempty line. Read backward until that line is found instead of splitting and trimming the entire text.

## What Changed
Replace full LF splitting, per-line trimming, and filtering with a reverse LF search. Preserve whitespace trimming, prompt normalization, turn selection, and recent-tool-label suppression. Carriage returns inside a line remain part of that line until the existing normalizer processes them.

## Why
Codex plan documents become multiline status rows, and both desktop and mobile use this selector. Translated text is capped at 16 KiB, so the primary measurements stay within that bound.

Full-selector CPU probe, median of 10 counterbalanced batches of 100 calls:

| Input | Before | After |
| --- | ---: | ---: |
| Short status | 0.00239 ms | 0.00158 ms |
| 500 earlier lines, about 11 KB | 0.02154 ms | 0.00072 ms |
| 3,500 blank lines, 14 KB | 0.11204 ms | 0.06848 ms |
| Activity plus 3,500 blank lines | 0.10451 ms | 0.06767 ms |

These are isolated computation timings, not rendered latency. The deterministic supported-size regression reduces line trims from 501 to fewer than 10. An earlier larger stress input was above the translated-plan cap and is not used for the performance claim here.

## Linked Issue
No linked issue: user-requested performance audit, one separate PR per improvement.

## Visual Proof
N/A — selected text and activity behavior are preserved; internal allocation change only.

## Testing
- 43 tests pass across shared selection, new tail-line coverage, desktop structured-session hooks, and mobile structured-session hooks.
- 1,015 whitespace/Unicode inputs match the original computation through both journal and provider activity paths. Covers empty lines, CRLF, lone CR, Unicode whitespace, NUL, lone surrogates, and truncation boundaries.
- Supported-size trim-count test fails on baseline (501) and passes after; the parity test passes both versions.
- Full root `pnpm tc`, targeted oxlint, formatting, and commit hooks pass.
- macOS with `ORCA_BACKGROUND_LAUNCH=1`; no desktop windows launched. Actual SSH/Windows/Linux were not exercised; CI pending.

## Review
- [x] Independent computation change; no upstream agent skill source copied.
- [x] No agent-status producer, cache, precedence, execution-host, RPC, or Git-provider changes.
- [x] Existing shared desktop/mobile behavior and folder-workspace compatibility preserved.
