### PR TITLE
Fix landing footer menu placement

### DIFF
--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -98,6 +98,12 @@ function GitHubStarButton({
             'cursor-pointer border-amber-500/50 bg-amber-400/10 text-amber-700 dark:border-amber-400/25 dark:bg-amber-400/[0.06] dark:text-amber-400/60'
         )}
         onClick={handleClick}
+        onContextMenu={(event) => {
+          if (state === 'starred') {
+            event.preventDefault()
+            setMenuOpen(true)
+          }
+        }}
         disabled={state === 'loading'}
       >
         {state === 'web-fallback' ? (
@@ -119,7 +125,7 @@ function GitHubStarButton({
             : translate('auto.components.Landing.0d0ace8861', 'Star on GitHub')}
       </button>
       {state === 'starred' && menuOpen && (
-        <div className="absolute right-0 top-[calc(100%+4px)] z-10 min-w-[100px] rounded-md border border-border bg-popover py-1 shadow-md">
+        <div className="absolute right-0 bottom-[calc(100%+4px)] z-10 min-w-[100px] rounded-md border border-border bg-popover py-1 shadow-floating">
           <button
             className="w-full px-3 py-1.5 text-left text-[13px] text-foreground hover:bg-muted"
             onClick={() => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

The landing footer's Hide menu now opens upward, so the bottom status bar no longer covers it.

## What Changed

- Anchor the menu above its button with the existing four-pixel gap and documented floating shadow.
- Open the same menu on right click; preserve left click and outside-click dismissal.

## Why

The button sits near the bottom edge. Opening its menu downward places the Hide action beneath the status bar.

## Linked Issue

Reported directly by the maintainer; no separate issue.

## Visual Proof

Real Electron renderer, captured via Playwright CDP with every window hidden. Before captures use a build with the original menu positioning.

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before, dark](https://github.com/user-attachments/assets/bf077856-d151-46c7-bc56-e7dfa96daa64) | ![After, dark](https://github.com/user-attachments/assets/d407ac9d-9971-411f-882f-013f02ed78e1) |
| Light | ![Before, light](https://github.com/user-attachments/assets/e8d56686-fef7-400c-b0db-dd0c0a4956fa) | ![After, light](https://github.com/user-attachments/assets/7c17e482-00b4-4f16-b1bd-812e03966092) |

## Testing

- `pnpm tc:web` passed.
- `pnpm run check:code-quality:changed` passed with zero new findings.
- Electron E2E build and formatting check passed.
- One-off Playwright check passed on Windows: right and left click, menu geometry and hit testing, outside-click dismissal, Hide, and hidden-window verification. Screenshots cover both themes.
- No permanent test added for this small presentation fix. Full native rebuild remains unavailable without Python/C++ build tools; the built Electron app ran successfully for UI validation.

## Review

Self-reviewed. Presentation-only change; no host execution, provider routing, workspace-kind assumptions, or wire changes. macOS, Linux, and SSH were considered but not exercised locally.

## Agent skill upstream boundary

- [x] Not applicable.
