### PR TITLE
perf(browser): fill plain fields in one stdin edit

### DIFF
--- a/src/main/browser/agent-browser-bridge-core-commands.ts
+++ b/src/main/browser/agent-browser-bridge-core-commands.ts
@@ -6,14 +6,10 @@ import type {
 } from '../../shared/runtime-types'
 import { assertClipboardTextWriteWithinLimitWithYield } from '../../shared/clipboard-text'
 import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
-import { iterateBrowserTextInsertionChunks } from './browser-text-insertion'
 import { BrowserError } from './cdp-bridge'
 import { ORCA_TAB_SESSION_PREFIX } from './agent-browser-orphan-sweep'
 import { focusedValueSetExpression } from './agent-browser-bridge-input'
-import {
-  AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES,
-  EMBEDDED_NAVIGATION_TIMEOUT_MS
-} from './agent-browser-bridge-types'
+import { EMBEDDED_NAVIGATION_TIMEOUT_MS } from './agent-browser-bridge-types'
 import {
   isAbortedNavigationError,
   waitForAbortedNavigationReplacement
@@ -157,23 +153,10 @@ export abstract class AgentBrowserBridgeCoreCommands extends AgentBrowserBridgeQ
       async (sessionName) => {
         if (!(await this.isExplicitContentEditableTarget(sessionName, element))) {
           await this.execAgentBrowser(sessionName, ['focus', element])
-          await this.execAgentBrowser(sessionName, [
-            'eval',
-            focusedValueSetExpression(JSON.stringify(''))
-          ])
-          for (const chunk of iterateBrowserTextInsertionChunks(
-            value,
-            AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
-          )) {
-            await this.execAgentBrowser(sessionName, [
-              'eval',
-              focusedValueSetExpression(JSON.stringify(chunk), { append: true })
-            ])
-          }
-          await this.execAgentBrowser(sessionName, [
-            'eval',
-            focusedValueSetExpression(JSON.stringify(''), { append: true, dispatchEvents: true })
-          ])
+          // One stdin edit avoids argv limits and repeated copying of the growing field value.
+          await this.execAgentBrowser(sessionName, ['eval', '--stdin'], {
+            stdinText: focusedValueSetExpression(JSON.stringify(value), { dispatchEvents: true })
+          })
           return { filled: element } as BrowserFillResult
         }
 

--- a/src/main/browser/agent-browser-bridge-text-input.test.ts
+++ b/src/main/browser/agent-browser-bridge-text-input.test.ts
@@ -278,8 +278,9 @@ describe('AgentBrowserBridge', () => {
     )
     expect(evalCall).toBeDefined()
     const args = evalCall![1] as string[]
-    const expression = args[args.indexOf('eval') + 1]
-    expect(() => new Function(expression)).not.toThrow()
+    expect(args[args.indexOf('eval') + 1]).toBe('--stdin')
+    expect(stdinWrites).toHaveLength(1)
+    expect(() => new Function(stdinWrites[0])).not.toThrow()
   })
 
   it('replaces contenteditable text through the browser editing pipeline', async () => {
@@ -359,12 +360,7 @@ describe('AgentBrowserBridge', () => {
 
     await bridge.fill('@spinbutton', '200')
 
-    const expressions = execFileMock.mock.calls
-      .filter((call: unknown[]) => (call[1] as string[]).includes('eval'))
-      .map((call: unknown[]) => {
-        const args = call[1] as string[]
-        return args[args.indexOf('eval') + 1]
-      })
+    const expressions = stdinWrites
 
     const input = createFillEvalNode({ tagName: 'INPUT' })
     const wrapper = createFillEvalNode({
@@ -389,12 +385,7 @@ describe('AgentBrowserBridge', () => {
 
     await bridge.fill('@spinbutton', '200')
 
-    const expressions = execFileMock.mock.calls
-      .filter((call: unknown[]) => (call[1] as string[]).includes('eval'))
-      .map((call: unknown[]) => {
-        const args = call[1] as string[]
-        return args[args.indexOf('eval') + 1]
-      })
+    const expressions = stdinWrites
 
     const input = createFillEvalNode({ tagName: 'INPUT' })
     const wrapper = createFillEvalNode({
@@ -419,12 +410,7 @@ describe('AgentBrowserBridge', () => {
 
     await bridge.fill('@spinbutton', '200')
 
-    const expressions = execFileMock.mock.calls
-      .filter((call: unknown[]) => (call[1] as string[]).includes('eval'))
-      .map((call: unknown[]) => {
-        const args = call[1] as string[]
-        return args[args.indexOf('eval') + 1]
-      })
+    const expressions = stdinWrites
 
     const input = createFillEvalNode({ tagName: 'INPUT' })
     const controlled = createFillEvalNode({ tagName: 'DIV', descendant: input.node })
@@ -452,12 +438,7 @@ describe('AgentBrowserBridge', () => {
 
     await bridge.fill('@spinbutton', '200')
 
-    const expressions = execFileMock.mock.calls
-      .filter((call: unknown[]) => (call[1] as string[]).includes('eval'))
-      .map((call: unknown[]) => {
-        const args = call[1] as string[]
-        return args[args.indexOf('eval') + 1]
-      })
+    const expressions = stdinWrites
 
     const hiddenInput = createFillEvalNode({ tagName: 'INPUT', type: 'hidden' })
     const numberInput = createFillEvalNode({ tagName: 'INPUT', type: 'number' })
@@ -485,12 +466,7 @@ describe('AgentBrowserBridge', () => {
 
     await bridge.fill('@input', '200')
 
-    const expressions = execFileMock.mock.calls
-      .filter((call: unknown[]) => (call[1] as string[]).includes('eval'))
-      .map((call: unknown[]) => {
-        const args = call[1] as string[]
-        return args[args.indexOf('eval') + 1]
-      })
+    const expressions = stdinWrites
 
     const input = createFillEvalNode({ tagName: 'INPUT' })
 
@@ -503,8 +479,8 @@ describe('AgentBrowserBridge', () => {
     expect(input.events.map((event) => event.type)).toEqual(['input', 'change'])
   })
 
-  it('chunks large agent-browser fill values before eval transport', async () => {
-    const text = ['x'.repeat(AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES), 'tail'].join('')
+  it('fills large plain fields with one stdin edit and one event pair', async () => {
+    const text = `${'é\n'.repeat(512 * 1024)}tail'\\`
     succeedWith({ ok: true })
 
     await bridge.fill('@textarea', text)
@@ -512,15 +488,17 @@ describe('AgentBrowserBridge', () => {
     const evalCalls = execFileMock.mock.calls.filter((call: unknown[]) =>
       (call[1] as string[]).includes('eval')
     )
-    const appendExpressions = evalCalls.slice(1, -1).map((call: unknown[]) => {
-      const args = call[1] as string[]
-      return args[args.indexOf('eval') + 1]
+    expect(evalCalls).toHaveLength(1)
+    expect(evalCalls[0][1]).toContain('--stdin')
+    expect(stdinWrites).toHaveLength(1)
+    expect((evalCalls[0][1] as string[]).join('')).not.toContain(text)
+    const input = createFillEvalNode({ tagName: 'TEXTAREA' })
+    runFillEvalExpressions(stdinWrites, {
+      activeElement: input.node,
+      getElementById: () => null
     })
-
-    expect(appendExpressions).toHaveLength(2)
-    expect(appendExpressions.some((expression) => expression.includes(text))).toBe(false)
-    expect(appendExpressions[0]).toContain('x'.repeat(AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES))
-    expect(appendExpressions[1]).toContain('tail')
+    expect(input.value).toBe(text)
+    expect(input.events.map((event) => event.type)).toEqual(['input', 'change'])
   })
 
   it.each([


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​42 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 |

<!-- /orca-pr-loc -->

Plain browser fills launched a helper process for every 8 KiB of text and repeatedly rewrote the growing field value. A 1 MiB textarea fill took 24.45 seconds and 132 helper calls in an isolated hidden Electron renderer. Send the complete edit through the existing `eval --stdin` transport: the same fill takes 0.57 seconds and 3 calls, with exact text and one input/change event pair.

Reuses the existing native setter and spinbutton target resolution; clipboard size checks and rich-text editing remain in place. The measurement uses the production bridge and installed agent-browser binary with a fixture page/manager, not the full app or an SSH latency simulation.

Validation: 81 focused tests passed; node typecheck and changed-code quality passed. Playwright CDP screenshot inspected on the hidden renderer. Large Unicode/multiline fill, spinbutton routing, and event-pair checks cover the new transport.
