### PR TITLE
fix(codex): recover structured sessions from unlisted models

### DIFF
--- a/src/main/codex/codex-structured-model-restoration-acquire.test.ts
+++ b/src/main/codex/codex-structured-model-restoration-acquire.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  AgentJournalItemBody,
+  AgentJournalItemIdentity,
+  AgentJournalMessageItem,
+  AgentSessionJournalIdentity
+} from '../../shared/agent-session-journal-types'
+import { CodexAppServerRequestError } from './codex-app-server-connection'
+import type {
+  CodexAppServerConnection,
+  CodexAppServerConnectionHandlers,
+  CodexAppServerLaunch,
+  openCodexAppServerConnection
+} from './codex-app-server-connection'
+import { CodexStructuredSessionAdapter } from './codex-structured-session-adapter'
+import type { CodexStructuredLaunch } from './codex-structured-session-state'
+import type { StructuredAgentSessionEventSink } from '../native-chat/agent-session-wire/structured-agent-session-event-sink'
+
+const THREAD_ID = 'thread-restored'
+const USER_MESSAGE: AgentJournalMessageItem = {
+  kind: 'message',
+  role: 'user',
+  blocks: [{ type: 'text', text: 'continue' }]
+}
+
+function identity(): AgentSessionJournalIdentity {
+  return {
+    sessionId: 'session-1',
+    workspaceId: 'workspace-1',
+    hostId: 'host-1',
+    agent: 'codex',
+    providerHandle: { kind: 'codex', threadId: THREAD_ID }
+  }
+}
+
+type Route = (params: Record<string, unknown> | undefined) => unknown
+type FakeConnection = Omit<CodexAppServerConnection, 'closed'> & {
+  closed: boolean
+  launch: CodexAppServerLaunch
+  handlers: CodexAppServerConnectionHandlers
+  calls: { method: string; params?: Record<string, unknown> }[]
+  closeCount: number
+}
+
+function fakeCodex(routes: Record<string, Route> = {}) {
+  const connections: FakeConnection[] = []
+  const openConnection = (async (launch, handlers = {}) => {
+    const connection: FakeConnection = {
+      launch,
+      handlers,
+      calls: [],
+      closeCount: 0,
+      pid: 4321,
+      closed: false,
+      request: async (method, params) => {
+        connection.calls.push({ method, params })
+        return routes[method]?.(params) ?? {}
+      },
+      notify: () => undefined,
+      respond: () => undefined,
+      respondWithError: () => undefined,
+      close: async () => {
+        connection.closeCount += 1
+        connection.closed = true
+        return true
+      }
+    }
+    connections.push(connection)
+    return connection
+  }) as typeof openCodexAppServerConnection
+  routes['thread/start'] ??= () => ({
+    thread: { id: THREAD_ID },
+    model: 'listed-default',
+    reasoningEffort: 'medium'
+  })
+  routes['thread/resume'] ??= () => ({
+    thread: { id: THREAD_ID },
+    model: 'listed-default',
+    reasoningEffort: 'medium'
+  })
+  routes['model/list'] ??= () => ({
+    data: [
+      {
+        model: 'listed-default',
+        isDefault: true,
+        supportedReasoningEfforts: [{ reasoningEffort: 'medium' }],
+        defaultReasoningEffort: 'medium'
+      }
+    ],
+    nextCursor: null
+  })
+  return { connections, openConnection, routes }
+}
+
+function adapterFor(
+  codex: ReturnType<typeof fakeCodex>,
+  launch: Partial<CodexStructuredLaunch> = {},
+  onEvent = vi.fn(),
+  readProcessStartTime: (pid: number) => Promise<number | null> = async () => 1_700_000_000_000
+): CodexStructuredSessionAdapter {
+  return new CodexStructuredSessionAdapter({
+    resolveLaunch: async () => ({
+      command: 'codex',
+      args: ['app-server'],
+      cwd: '/work/repo',
+      codexHome: null,
+      resumeThreadId: null,
+      ...launch
+    }),
+    openConnection: codex.openConnection,
+    readProcessStartTime,
+    captureTurnProcesses: async () => ({ platform: 'win32', identities: new Map() }),
+    terminateTurnProcesses: async () => true,
+    mintAcquisitionGeneration: () => 'generation-restored',
+    onEvent
+  })
+}
+
+function recordingSink(): {
+  sink: StructuredAgentSessionEventSink
+  items: { identity: AgentJournalItemIdentity; body: AgentJournalItemBody }[]
+  publish: ReturnType<typeof vi.fn>
+} {
+  const items: { identity: AgentJournalItemIdentity; body: AgentJournalItemBody }[] = []
+  const publish = vi.fn()
+  return {
+    items,
+    publish,
+    sink: {
+      appendItem: (itemIdentity, body) => items.push({ identity: itemIdentity, body }),
+      appendTombstone: vi.fn(),
+      publish
+    }
+  }
+}
+
+async function dispatch(adapter: CodexStructuredSessionAdapter, clientMessageId: string) {
+  return adapter.dispatch({
+    sessionId: 'session-1',
+    clientMessageId,
+    body: USER_MESSAGE,
+    fence: 7
+  })
+}
+
+describe('Codex structured model restoration acquisition', () => {
+  it.each([
+    { name: 'thread/start', launch: {} },
+    { name: 'thread/resume', launch: { resumeThreadId: THREAD_ID } }
+  ])('acquires and dispatches twice after refusing a stale pick on $name', async ({ launch }) => {
+    const onEvent = vi.fn()
+    const codex = fakeCodex()
+    let turn = 0
+    codex.routes['turn/start'] = () => {
+      turn += 1
+      codex.connections[0].handlers.onNotification?.('item/completed', {
+        threadId: THREAD_ID,
+        turnId: `turn-${turn}`,
+        item: { id: `message-${turn}`, type: 'agentMessage', text: 'done' }
+      })
+      codex.connections[0].handlers.onNotification?.('turn/completed', {
+        threadId: THREAD_ID,
+        turn: { id: `turn-${turn}`, status: 'completed', items: [] }
+      })
+      return { turn: { id: `turn-${turn}` } }
+    }
+    const adapter = adapterFor(codex, launch, onEvent)
+
+    await expect(
+      adapter.acquire({
+        identity: identity(),
+        fence: 7,
+        spawnToken: 'spawn-1',
+        options: { model: 'retired-id', effort: 'high', approvalPolicy: 'never' }
+      })
+    ).resolves.toMatchObject({ link: { handle: { threadId: THREAD_ID } } })
+    await expect(dispatch(adapter, 'client-1')).resolves.toMatchObject({ state: 'accepted' })
+    await expect(dispatch(adapter, 'client-2')).resolves.toMatchObject({ state: 'accepted' })
+
+    const turns = codex.connections[0].calls.filter((call) => call.method === 'turn/start')
+    expect(turns).toHaveLength(2)
+    expect(turns.map((call) => call.params)).toEqual([
+      expect.objectContaining({
+        model: 'listed-default',
+        effort: 'medium',
+        approvalPolicy: 'never'
+      }),
+      expect.objectContaining({
+        model: 'listed-default',
+        effort: 'medium',
+        approvalPolicy: 'never'
+      })
+    ])
+    expect(onEvent.mock.calls.some(([event]) => event.method === 'turn/completed')).toBe(true)
+    expect(codex.connections[0].closeCount).toBe(0)
+  })
+
+  it('overrides an unlisted resumed model before the first turn', async () => {
+    const codex = fakeCodex({
+      'thread/resume': () => ({
+        thread: { id: THREAD_ID },
+        model: 'retired-resume',
+        reasoningEffort: 'high'
+      }),
+      'turn/start': () => ({ turn: { id: 'turn-1' } })
+    })
+    const adapter = adapterFor(codex, { resumeThreadId: THREAD_ID })
+
+    await adapter.acquire({ identity: identity(), fence: 7, spawnToken: 'spawn-1' })
+    await dispatch(adapter, 'client-1')
+
+    expect(codex.connections[0].calls.find((call) => call.method === 'turn/start')?.params).toEqual(
+      expect.objectContaining({ model: 'listed-default', effort: 'medium' })
+    )
+  })
+
+  it('shows the automatic model substitution in the conversation', async () => {
+    const codex = fakeCodex()
+    const journal = recordingSink()
+    const adapter = adapterFor(codex)
+
+    await adapter.acquire({
+      identity: identity(),
+      fence: 7,
+      spawnToken: 'spawn-1',
+      options: { model: 'retired-id' },
+      events: journal.sink
+    })
+
+    expect(journal.items).toContainEqual({
+      identity: {
+        provider: 'orca',
+        clientMessageId: 'codex-model-restoration:generation-restored'
+      },
+      body: {
+        kind: 'status',
+        text: expect.stringMatching(/retired-id.*provider-listed default "listed-default"/),
+        tone: 'warning'
+      }
+    })
+    expect(journal.publish).toHaveBeenCalled()
+    await expect(adapter.readOptions({ sessionId: 'session-1', fence: 7 })).resolves.toMatchObject({
+      current: { model: 'listed-default' }
+    })
+  })
+
+  it('preserves admitted restored picks and other turn options', async () => {
+    const codex = fakeCodex({
+      'model/list': () => ({
+        data: [
+          {
+            model: 'account-private',
+            supportedReasoningEfforts: [{ reasoningEffort: 'high' }]
+          },
+          { model: 'listed-default', isDefault: true }
+        ],
+        nextCursor: null
+      }),
+      'turn/start': () => ({ turn: { id: 'turn-1' } })
+    })
+    const journal = recordingSink()
+    const adapter = adapterFor(codex)
+
+    await adapter.acquire({
+      identity: identity(),
+      fence: 7,
+      spawnToken: 'spawn-1',
+      options: { model: 'account-private', effort: 'high', approvalPolicy: 'never' },
+      events: journal.sink
+    })
+    await dispatch(adapter, 'client-1')
+
+    expect(codex.connections[0].calls.find((call) => call.method === 'turn/start')?.params).toEqual(
+      expect.objectContaining({ model: 'account-private', effort: 'high', approvalPolicy: 'never' })
+    )
+    expect(journal.items).toEqual([])
+  })
+
+  it.each([
+    {
+      name: 'unsupported method',
+      route: () => {
+        throw new CodexAppServerRequestError('model/list', -32601, 'method not found')
+      }
+    },
+    {
+      name: 'timeout',
+      route: () => {
+        throw new Error('model/list timed out')
+      }
+    },
+    { name: 'empty list', route: () => ({ data: [], nextCursor: null }) }
+  ])('does not fail adapter acquisition for $name', async ({ route }) => {
+    const codex = fakeCodex({
+      'model/list': route,
+      'turn/start': () => ({ turn: { id: 'turn-1' } })
+    })
+    const adapter = adapterFor(codex)
+
+    await expect(
+      adapter.acquire({
+        identity: identity(),
+        fence: 7,
+        spawnToken: 'spawn-1',
+        options: { model: 'unknown-restored', effort: 'high' }
+      })
+    ).resolves.toBeDefined()
+    await dispatch(adapter, 'client-1')
+
+    expect(codex.connections[0].calls.find((call) => call.method === 'turn/start')?.params).toEqual(
+      expect.objectContaining({ model: 'unknown-restored', effort: 'high' })
+    )
+    expect(codex.connections[0].closeCount).toBe(0)
+  })
+
+  it('does not publish a superseded acquisition after catalog enumeration', async () => {
+    const catalogStarted = Promise.withResolvers<void>()
+    const catalog = Promise.withResolvers<unknown>()
+    const codex = fakeCodex({
+      'model/list': () => {
+        catalogStarted.resolve()
+        return catalog.promise
+      }
+    })
+    const readProcessStartTime = vi.fn(async () => 1_700_000_000_000)
+    const adapter = adapterFor(codex, {}, vi.fn(), readProcessStartTime)
+    const acquiring = adapter.acquire({
+      identity: identity(),
+      fence: 7,
+      spawnToken: 'spawn-1',
+      options: { model: 'retired-id' }
+    })
+    await catalogStarted.promise
+
+    const closing = adapter.closeAll()
+    catalog.resolve({
+      data: [{ model: 'listed-default', isDefault: true }],
+      nextCursor: null
+    })
+
+    await expect(acquiring).rejects.toThrow('superseded while being acquired')
+    await closing
+    await expect(dispatch(adapter, 'client-1')).rejects.toThrow('no live codex app-server')
+    expect(codex.connections[0].calls.some((call) => call.method === 'turn/start')).toBe(false)
+    expect(codex.connections[0].closeCount).toBe(2)
+    expect(readProcessStartTime).not.toHaveBeenCalled()
+  })
+
+  it('does not treat an unlisted current model as membership evidence during acquisition', async () => {
+    const codex = fakeCodex({
+      'thread/resume': () => ({ thread: { id: THREAD_ID }, model: 'retired-id' }),
+      'turn/start': () => ({ turn: { id: 'turn-1' } })
+    })
+    const adapter = adapterFor(codex, { resumeThreadId: THREAD_ID })
+
+    await adapter.acquire({
+      identity: identity(),
+      fence: 7,
+      spawnToken: 'spawn-1',
+      options: { model: 'retired-id' }
+    })
+    await dispatch(adapter, 'client-1')
+
+    expect(codex.connections[0].calls.find((call) => call.method === 'turn/start')?.params).toEqual(
+      expect.objectContaining({ model: 'listed-default' })
+    )
+  })
+})

--- a/src/main/codex/codex-structured-model-restoration.test.ts
+++ b/src/main/codex/codex-structured-model-restoration.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveCodexAcquiredSessionOptions } from './codex-structured-model-restoration'
+
+function listedModel(input: {
+  id: string
+  isDefault?: boolean
+  defaultEffort?: string
+  efforts?: string[]
+}): Record<string, unknown> {
+  return {
+    model: input.id,
+    isDefault: input.isDefault ?? false,
+    supportedReasoningEfforts: (input.efforts ?? []).map((reasoningEffort) => ({
+      reasoningEffort
+    })),
+    ...(input.defaultEffort ? { defaultReasoningEffort: input.defaultEffort } : {})
+  }
+}
+
+function resolveWith(input: {
+  options?: Readonly<Record<string, string>>
+  opened?: { model?: string; effort?: string }
+  request: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+}) {
+  return resolveCodexAcquiredSessionOptions({
+    connection: { request: input.request } as never,
+    options: input.options,
+    opened: {
+      threadId: 'thread-1',
+      historyPath: null,
+      ...input.opened
+    },
+    timeoutMs: 456
+  })
+}
+
+describe('Codex structured model restoration', () => {
+  it('recovers a refused restored pick using the uniquely listed default', async () => {
+    const result = await resolveWith({
+      options: {
+        model: 'retired-id',
+        effort: 'high',
+        approvalPolicy: 'never',
+        personality: 'friendly'
+      },
+      opened: { model: 'reported-good', effort: 'medium' },
+      request: vi.fn(async () => ({
+        data: [
+          listedModel({ id: 'reported-good', efforts: ['medium'] }),
+          listedModel({
+            id: 'listed-default',
+            isDefault: true,
+            defaultEffort: 'low',
+            efforts: ['low', 'high']
+          })
+        ],
+        nextCursor: null
+      }))
+    })
+
+    expect(Object.fromEntries(result.options)).toEqual({
+      approvalPolicy: 'never',
+      personality: 'friendly',
+      model: 'listed-default',
+      effort: 'low'
+    })
+    expect(result.reportedOptions).toEqual({ model: 'reported-good', effort: 'medium' })
+    expect(result.notice).toContain('retired-id')
+    expect(result.notice).toContain('listed-default')
+    expect(result.notice).toContain('Orca selected the provider-listed default')
+  })
+
+  it('recovers an unlisted resumed report with no restored model', async () => {
+    const result = await resolveWith({
+      opened: { model: 'retired-resume', effort: 'high' },
+      request: vi.fn(async () => ({
+        data: [listedModel({ id: 'listed-default', isDefault: true })],
+        nextCursor: null
+      }))
+    })
+
+    expect(Object.fromEntries(result.options)).toEqual({ model: 'listed-default' })
+    expect(result.reportedOptions).toEqual({})
+    expect(result.notice).toContain('retired-resume')
+  })
+
+  it('keeps a valid restored choice when the opened report is unlisted', async () => {
+    const result = await resolveWith({
+      options: { model: 'account-private', effort: 'high', approvalPolicy: 'never' },
+      opened: { model: 'retired-resume', effort: 'low' },
+      request: vi.fn(async () => ({
+        data: [
+          listedModel({ id: 'account-private', efforts: ['high'] }),
+          listedModel({ id: 'listed-default', isDefault: true })
+        ],
+        nextCursor: null
+      }))
+    })
+
+    expect(Object.fromEntries(result.options)).toEqual({
+      model: 'account-private',
+      effort: 'high',
+      approvalPolicy: 'never'
+    })
+    expect(result.reportedOptions).toEqual({})
+    expect(result.notice).toContain('existing restored choice "account-private"')
+    expect(result.notice).not.toContain('Orca selected the provider-listed default')
+  })
+
+  it.each([
+    {
+      name: 'method failure',
+      request: async () => {
+        throw new Error('method not found')
+      },
+      calls: 1
+    },
+    {
+      name: 'later-page failure',
+      request: async (_method: string, params?: Record<string, unknown>) => {
+        if (params?.cursor) {
+          throw new Error('page unavailable')
+        }
+        return { data: [listedModel({ id: 'partial-only' })], nextCursor: 'page-2' }
+      },
+      calls: 2
+    },
+    { name: 'malformed result', request: async () => 'malformed', calls: 1 },
+    { name: 'empty result', request: async () => ({ data: [], nextCursor: null }), calls: 1 },
+    {
+      name: 'bounded incomplete result',
+      request: async () => ({ data: [listedModel({ id: 'partial-only' })], nextCursor: 'more' }),
+      calls: 20
+    }
+  ])('admits unknown picks when model enumeration has $name', async ({ request, calls }) => {
+    const routed = vi.fn(request)
+    const result = await resolveWith({
+      options: { model: 'restored-unknown', effort: 'high' },
+      opened: { model: 'reported-unknown', effort: 'medium' },
+      request: routed
+    })
+
+    expect(Object.fromEntries(result.options)).toEqual({
+      model: 'restored-unknown',
+      effort: 'high'
+    })
+    expect(result.reportedOptions).toEqual({ model: 'reported-unknown', effort: 'medium' })
+    expect(result.notice).toBeUndefined()
+    expect(routed).toHaveBeenCalledTimes(calls)
+  })
+
+  it.each([
+    {
+      name: 'missing',
+      rows: [listedModel({ id: 'listed-nondefault' })]
+    },
+    {
+      name: 'ambiguous',
+      rows: [
+        listedModel({ id: 'default-one', isDefault: true }),
+        listedModel({ id: 'default-two', isDefault: true })
+      ]
+    }
+  ])('preserves the pick and explains a $name provider default', async ({ rows }) => {
+    const result = await resolveWith({
+      options: { model: 'retired-id', effort: 'high', approvalPolicy: 'never' },
+      opened: { model: 'retired-report', effort: 'low' },
+      request: vi.fn(async () => ({ data: rows, nextCursor: null }))
+    })
+
+    expect(Object.fromEntries(result.options)).toEqual({
+      model: 'retired-id',
+      effort: 'high',
+      approvalPolicy: 'never'
+    })
+    expect(result.reportedOptions).toEqual({ model: 'retired-report', effort: 'low' })
+    expect(result.notice).toContain('did not identify a unique provider default')
+    expect(result.notice).toContain('retired-id')
+    expect(result.notice).toContain('retired-report')
+  })
+
+  it('uses one connection-local catalog snapshot for both candidates', async () => {
+    const request = vi.fn(async (_method: string, params?: Record<string, unknown>) =>
+      params?.cursor
+        ? { data: [listedModel({ id: 'listed-default', isDefault: true })], nextCursor: null }
+        : { data: [listedModel({ id: 'account-private' })], nextCursor: 'page-2' }
+    )
+    const result = await resolveWith({
+      options: { model: 'account-private' },
+      opened: { model: 'retired-report' },
+      request
+    })
+
+    expect(Object.fromEntries(result.options)).toEqual({ model: 'account-private' })
+    expect(result.reportedOptions).toEqual({})
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not substitute a seed default for an account-private default', async () => {
+    const result = await resolveWith({
+      options: { model: 'gpt-5.6-sol', effort: 'high' },
+      request: vi.fn(async () => ({
+        data: [
+          listedModel({
+            id: 'account-private-default',
+            isDefault: true,
+            defaultEffort: 'medium',
+            efforts: ['medium']
+          })
+        ],
+        nextCursor: null
+      }))
+    })
+
+    expect(Object.fromEntries(result.options)).toEqual({
+      model: 'account-private-default',
+      effort: 'medium'
+    })
+  })
+
+  it('does not carry an unadvertised default effort to the replacement', async () => {
+    const result = await resolveWith({
+      options: { model: 'retired-id', effort: 'high' },
+      request: vi.fn(async () => ({
+        data: [
+          listedModel({
+            id: 'listed-default',
+            isDefault: true,
+            defaultEffort: 'ultra',
+            efforts: ['medium']
+          })
+        ],
+        nextCursor: null
+      }))
+    })
+
+    expect(Object.fromEntries(result.options)).toEqual({ model: 'listed-default' })
+  })
+
+  it('never carries an empty model into turn options', async () => {
+    const result = await resolveWith({
+      options: { model: '', approvalPolicy: 'never' },
+      request: vi.fn(async () => ({
+        data: [listedModel({ id: 'listed-default', isDefault: true })],
+        nextCursor: null
+      }))
+    })
+
+    expect(Object.fromEntries(result.options)).toEqual({ approvalPolicy: 'never' })
+    expect(result.notice).toBeUndefined()
+  })
+
+  it('bounds exceptionally long model ids in notices', async () => {
+    const result = await resolveWith({
+      options: { model: `retired-${'x'.repeat(10_000)}` },
+      request: vi.fn(async () => ({
+        data: [listedModel({ id: `default-${'y'.repeat(10_000)}`, isDefault: true })],
+        nextCursor: null
+      }))
+    })
+
+    expect(result.notice?.length).toBeLessThan(500)
+    expect(result.notice).toContain('…')
+  })
+})

--- a/src/main/codex/codex-structured-model-restoration.ts
+++ b/src/main/codex/codex-structured-model-restoration.ts
@@ -1,0 +1,115 @@
+import type { CodexAppServerConnection } from './codex-app-server-connection'
+import {
+  codexCatalogAdmitsModel,
+  readCodexStructuredSessionOptions,
+  reportedCodexThreadOptions,
+  restoredCodexSessionOptions,
+  type CodexModelCatalog
+} from './codex-structured-session-options'
+import type { CodexSession } from './codex-structured-session-state'
+import type { CodexOpenedThread } from './codex-structured-thread-open'
+
+export type CodexAcquiredSessionOptions = {
+  options: Map<string, string>
+  reportedOptions: CodexSession['reportedOptions']
+  notice?: string
+}
+
+const NOTICE_MODEL_ID_LIMIT = 160
+
+function displayedModelId(modelId: string): string {
+  const bounded =
+    modelId.length > NOTICE_MODEL_ID_LIMIT
+      ? `${modelId.slice(0, NOTICE_MODEL_ID_LIMIT - 1)}…`
+      : modelId
+  return JSON.stringify(bounded)
+}
+
+function rejectedModelDescription(input: {
+  restored: string | undefined
+  reported: string | undefined
+}): string {
+  if (input.restored && input.reported && input.restored !== input.reported) {
+    return `restored model ${displayedModelId(input.restored)} and provider-reported model ${displayedModelId(input.reported)}`
+  }
+  return `model ${displayedModelId(input.restored ?? input.reported ?? 'unknown')}`
+}
+
+function catalogCurrent(input: {
+  options: Readonly<Record<string, string>> | undefined
+  opened: CodexOpenedThread
+}): { model?: string; effort?: string } {
+  const restoredModel = input.options?.model || undefined
+  const restoredEffort = input.options?.effort || undefined
+  const model = restoredModel ?? input.opened.model
+  const effort = restoredEffort ?? input.opened.effort
+  return { ...(model ? { model } : {}), ...(effort ? { effort } : {}) }
+}
+
+async function readCatalog(input: {
+  connection: Pick<CodexAppServerConnection, 'request'>
+  options: Readonly<Record<string, string>> | undefined
+  opened: CodexOpenedThread
+  timeoutMs: number | undefined
+}): Promise<CodexModelCatalog> {
+  return readCodexStructuredSessionOptions({
+    connection: input.connection,
+    current: catalogCurrent(input),
+    timeoutMs: input.timeoutMs
+  }).catch(() => null)
+}
+
+export async function resolveCodexAcquiredSessionOptions(input: {
+  connection: Pick<CodexAppServerConnection, 'request'>
+  options: Readonly<Record<string, string>> | undefined
+  opened: CodexOpenedThread
+  timeoutMs: number | undefined
+}): Promise<CodexAcquiredSessionOptions> {
+  const catalog = await readCatalog(input)
+  const restoredModel = input.options?.model || undefined
+  const reportedModel = input.opened.model
+  const restoredRefused = Boolean(restoredModel && !codexCatalogAdmitsModel(catalog, restoredModel))
+  const reportedRefused = Boolean(reportedModel && !codexCatalogAdmitsModel(catalog, reportedModel))
+  const options = restoredCodexSessionOptions(input.options, catalog)
+  const reportedOptions = reportedCodexThreadOptions(input.opened, catalog)
+
+  if (!restoredRefused && !reportedRefused) {
+    return { options, reportedOptions }
+  }
+
+  const rejected = rejectedModelDescription({
+    restored: restoredRefused ? restoredModel : undefined,
+    reported: reportedRefused ? reportedModel : undefined
+  })
+  if (restoredModel && !restoredRefused && reportedRefused) {
+    return {
+      options,
+      reportedOptions,
+      notice: `Codex no longer lists ${rejected}. Orca will use the existing restored choice ${displayedModelId(restoredModel)} for this session.`
+    }
+  }
+
+  const defaults = catalog?.models.filter((model) => model.isDefault) ?? []
+  if (defaults.length !== 1) {
+    return {
+      options: restoredCodexSessionOptions(input.options, null),
+      reportedOptions: reportedCodexThreadOptions(input.opened, null),
+      notice: `Codex no longer lists ${rejected}, but did not identify a unique provider default. Orca left the model unchanged; choose an available model to continue.`
+    }
+  }
+
+  const replacement = defaults[0]
+  options.set('model', replacement.id)
+  options.delete('effort')
+  if (
+    replacement.defaultEffort &&
+    replacement.efforts.some((effort) => effort.value === replacement.defaultEffort)
+  ) {
+    options.set('effort', replacement.defaultEffort)
+  }
+  return {
+    options,
+    reportedOptions,
+    notice: `Codex no longer lists ${rejected}. Orca selected the provider-listed default ${displayedModelId(replacement.id)} for this session.`
+  }
+}

--- a/src/main/codex/codex-structured-session-acquire.ts
+++ b/src/main/codex/codex-structured-session-acquire.ts
@@ -19,10 +19,7 @@ import {
   closeCodexPublishedSession,
   handleCodexSessionExit
 } from './codex-structured-session-close'
-import {
-  reportedCodexThreadOptions,
-  restoredCodexSessionOptions
-} from './codex-structured-session-options'
+import { resolveCodexAcquiredSessionOptions } from './codex-structured-model-restoration'
 import {
   codexSessionLifecycle,
   mintCodexAcquisitionGeneration,
@@ -169,6 +166,13 @@ export async function acquireCodexStructuredSession(input: {
     acquisitions.assertCurrent(sessionId, attempt)
     const opened = await openCodexThread(connection, launch, deps.requestTimeoutMs)
     acquisitions.assertCurrent(sessionId, attempt)
+    const resolvedOptions = await resolveCodexAcquiredSessionOptions({
+      connection,
+      options: acquireInput.options,
+      opened,
+      timeoutMs: deps.requestTimeoutMs
+    })
+    acquisitions.assertCurrent(sessionId, attempt)
     primaryThreadId = opened.threadId
     const restoreAdmission = translator?.restoreThread(opened.threadId, opened.thread ?? {})
     if (restoreAdmission && !restoreAdmission.accepted) {
@@ -205,8 +209,8 @@ export async function acquireCodexStructuredSession(input: {
       historyMode: opened.historyMode,
       activeTurnIds: new Set(),
       prompts: acquisition.prompts,
-      options: restoredCodexSessionOptions(acquireInput.options),
-      reportedOptions: reportedCodexThreadOptions(opened),
+      options: resolvedOptions.options,
+      reportedOptions: resolvedOptions.reportedOptions,
       turnIdWaiters: [],
       translator,
       backgroundTasks: new CodexBackgroundTaskTracker(opened.threadId, subagentExecutions),
@@ -221,6 +225,16 @@ export async function acquireCodexStructuredSession(input: {
     }
     turnCancellation.register(session)
     sessions.set(sessionId, session)
+    if (resolvedOptions.notice && acquireInput.events) {
+      acquireInput.events.appendItem(
+        {
+          provider: 'orca',
+          clientMessageId: `codex-model-restoration:${acquired.acquisitionGeneration}`
+        },
+        { kind: 'status', text: resolvedOptions.notice, tone: 'warning' }
+      )
+      acquireInput.events.publish()
+    }
     for (const event of acquisition.drain()) {
       event()
     }

--- a/src/main/codex/codex-structured-session-adapter.test.ts
+++ b/src/main/codex/codex-structured-session-adapter.test.ts
@@ -455,15 +455,17 @@ describe('CodexStructuredSessionAdapter.dispatch', () => {
       state: 'accepted',
       providerIdentity: { provider: 'codex', threadId: THREAD_ID, turnId: 'turn-1', ordinal: 0 }
     })
-    expect(codex.connections[0].calls[1].params).toEqual({
-      threadId: THREAD_ID,
-      clientUserMessageId: 'client-1',
-      input: [
-        { type: 'text', text: 'ship it' },
-        { type: 'localImage', path: '/tmp/shot.png' },
-        { type: 'image', url: 'https://example.test/a.png' }
-      ]
-    })
+    expect(codex.connections[0].calls.find((call) => call.method === 'turn/start')?.params).toEqual(
+      {
+        threadId: THREAD_ID,
+        clientUserMessageId: 'client-1',
+        input: [
+          { type: 'text', text: 'ship it' },
+          { type: 'localImage', path: '/tmp/shot.png' },
+          { type: 'image', url: 'https://example.test/a.png' }
+        ]
+      }
+    )
   })
 
   it('accepts a turn named only by the notification that raced the ack', async () => {

--- a/src/main/codex/codex-structured-session-options.test.ts
+++ b/src/main/codex/codex-structured-session-options.test.ts
@@ -3,6 +3,7 @@ import type { CodexAppServerConnection } from './codex-app-server-connection'
 import { CodexAcquisitionWindow } from './codex-structured-acquisition-window'
 import {
   applyCodexStructuredSessionOption,
+  codexCatalogAdmitsModel,
   readCodexStructuredSessionOptions,
   reportedCodexThreadOptions,
   restoredCodexSessionOptions
@@ -40,14 +41,34 @@ describe('structured Codex session options', () => {
   it('filters restored records to recognized turn options', () => {
     expect(
       Object.fromEntries(
-        restoredCodexSessionOptions({
-          model: 'gpt-live',
-          effort: 'high',
-          threadId: 'thread-injected',
-          input: 'input-injected'
-        })
+        restoredCodexSessionOptions(
+          {
+            model: 'gpt-live',
+            effort: 'high',
+            threadId: 'thread-injected',
+            input: 'input-injected'
+          },
+          null
+        )
       )
     ).toEqual({ model: 'gpt-live', effort: 'high' })
+  })
+
+  it('does not fabricate a provider row for an unlisted current model', async () => {
+    const request = vi.fn(async () => ({
+      data: [{ model: 'listed-default', isDefault: true }],
+      nextCursor: null
+    }))
+
+    await expect(
+      readCodexStructuredSessionOptions({
+        connection: { request } as never,
+        current: { model: 'retired-id' }
+      })
+    ).resolves.toEqual({
+      models: [{ id: 'listed-default', label: 'listed-default', isDefault: true, efforts: [] }],
+      current: { model: 'retired-id' }
+    })
   })
 
   it('hydrates paged provider models and their supported efforts', async () => {
@@ -123,15 +144,131 @@ describe('structured Codex session options', () => {
     )
   })
 
+  it('uses every model-list page as membership evidence', async () => {
+    const request = vi.fn(async (_method: string, params?: Record<string, unknown>) =>
+      params?.cursor
+        ? { data: [{ model: 'page-two-private' }], nextCursor: null }
+        : { data: [{ model: 'listed-default', isDefault: true }], nextCursor: 'page-2' }
+    )
+
+    const catalog = await readCodexStructuredSessionOptions({
+      connection: { request } as never,
+      current: { model: 'page-two-private' },
+      timeoutMs: 321
+    })
+
+    expect(codexCatalogAdmitsModel(catalog, 'page-two-private')).toBe(true)
+    expect(catalog.models.map((model) => model.id)).toEqual(['listed-default', 'page-two-private'])
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      'model/list',
+      { limit: 100, includeHidden: false, cursor: 'page-2' },
+      { timeoutMs: 321 }
+    )
+  })
+
   it('hydrates current values from thread start or resume', () => {
     expect(
-      reportedCodexThreadOptions({
-        threadId: 'thread-1',
-        historyPath: null,
-        model: 'gpt-live',
-        effort: 'high'
-      })
+      reportedCodexThreadOptions(
+        {
+          threadId: 'thread-1',
+          historyPath: null,
+          model: 'gpt-live',
+          effort: 'high'
+        },
+        null
+      )
     ).toEqual({ model: 'gpt-live', effort: 'high' })
+  })
+
+  it('admits only provider-listed models when enumeration is nonempty', () => {
+    const catalog = {
+      models: [{ id: 'account-private', label: 'Private', isDefault: true, efforts: [] }]
+    }
+
+    expect(codexCatalogAdmitsModel(catalog, 'account-private')).toBe(true)
+    expect(codexCatalogAdmitsModel(catalog, 'gpt-5.6-sol')).toBe(false)
+  })
+
+  it.each([null, undefined, { models: [] }])(
+    'admits every model without catalog evidence %#',
+    (catalog) => {
+      expect(codexCatalogAdmitsModel(catalog, 'arbitrary-private-model')).toBe(true)
+    }
+  )
+
+  it('drops a refused restored model and its effort but retains recognized options', () => {
+    const persisted = {
+      model: 'retired-id',
+      effort: 'high',
+      approvalPolicy: 'never',
+      personality: 'friendly',
+      threadId: 'thread-injected',
+      input: 'input-injected'
+    }
+
+    expect(
+      Object.fromEntries(
+        restoredCodexSessionOptions(persisted, {
+          models: [{ id: 'listed-default', label: 'Default', isDefault: true, efforts: [] }]
+        })
+      )
+    ).toEqual({ approvalPolicy: 'never', personality: 'friendly' })
+    expect(persisted).toEqual({
+      model: 'retired-id',
+      effort: 'high',
+      approvalPolicy: 'never',
+      personality: 'friendly',
+      threadId: 'thread-injected',
+      input: 'input-injected'
+    })
+  })
+
+  it('filters a refused thread report without claiming a replacement was reported', () => {
+    expect(
+      reportedCodexThreadOptions(
+        { threadId: 'thread-1', historyPath: null, model: 'retired-id', effort: 'high' },
+        {
+          models: [{ id: 'listed-default', label: 'Default', isDefault: true, efforts: [] }]
+        }
+      )
+    ).toEqual({})
+  })
+
+  it('preserves listed and unavailable-evidence restore and report values', () => {
+    const opened = {
+      threadId: 'thread-1',
+      historyPath: null,
+      model: 'account-private',
+      effort: 'high'
+    }
+    const persisted = { model: 'account-private', effort: 'high' }
+    const catalog = {
+      models: [{ id: 'account-private', label: 'Private', isDefault: true, efforts: [] }]
+    }
+
+    expect(Object.fromEntries(restoredCodexSessionOptions(persisted, catalog))).toEqual(persisted)
+    expect(reportedCodexThreadOptions(opened, catalog)).toEqual(persisted)
+    expect(Object.fromEntries(restoredCodexSessionOptions(persisted, null))).toEqual(persisted)
+    expect(reportedCodexThreadOptions(opened, null)).toEqual(persisted)
+  })
+
+  it('does not expose an incomplete bounded enumeration as an authoritative list', async () => {
+    const request = vi.fn(async () => ({ data: [], nextCursor: 'more' }))
+
+    await expect(
+      readCodexStructuredSessionOptions({
+        connection: { request } as never,
+        current: { model: 'retired-id' },
+        timeoutMs: 321
+      })
+    ).rejects.toThrow('model enumeration exceeded 20 pages')
+    expect(request).toHaveBeenCalledTimes(20)
+    expect(request).toHaveBeenLastCalledWith(
+      'model/list',
+      { limit: 100, includeHidden: false, cursor: 'more' },
+      { timeoutMs: 321 }
+    )
   })
 
   it('reconciles an incompatible effort when only the model changes', async () => {
@@ -172,5 +309,70 @@ describe('structured Codex session options', () => {
     await expect(
       applyCodexStructuredSessionOption(session, 'effort', 'high', undefined)
     ).rejects.toThrow('does not support high')
+  })
+
+  it.each(['options', 'reportedOptions'] as const)(
+    'rejects reapplying an unlisted model already seeded in %s',
+    async (source) => {
+      const session = optionSession(
+        vi.fn(async () => ({
+          data: [{ model: 'listed-default', supportedReasoningEfforts: [] }],
+          nextCursor: null
+        }))
+      )
+      if (source === 'options') {
+        session.options.set('model', 'retired-id')
+      } else {
+        session.reportedOptions = { model: 'retired-id', effort: 'high' }
+      }
+      const before = {
+        options: Object.fromEntries(session.options),
+        reportedOptions: { ...session.reportedOptions }
+      }
+
+      await expect(
+        applyCodexStructuredSessionOption(session, 'model', 'retired-id', undefined)
+      ).rejects.toMatchObject({ name: 'AgentSessionOptionRejectedError' })
+      expect({
+        options: Object.fromEntries(session.options),
+        reportedOptions: session.reportedOptions
+      }).toEqual(before)
+    }
+  )
+
+  it('allows reapplying a listed current model', async () => {
+    const session = optionSession(
+      vi.fn(async () => ({
+        data: [
+          {
+            model: 'gpt-live',
+            supportedReasoningEfforts: [{ reasoningEffort: 'high' }],
+            defaultReasoningEffort: 'high'
+          }
+        ],
+        nextCursor: null
+      }))
+    )
+
+    await expect(
+      applyCodexStructuredSessionOption(session, 'model', 'gpt-live', undefined)
+    ).resolves.toEqual({ model: 'gpt-live', effort: 'high' })
+  })
+
+  it('keeps explicit model writes strict when the catalog is empty or unavailable', async () => {
+    const empty = optionSession(vi.fn(async () => ({ data: [], nextCursor: null })))
+    empty.options.set('model', 'gpt-live')
+    await expect(
+      applyCodexStructuredSessionOption(empty, 'model', 'gpt-live', undefined)
+    ).rejects.toThrow('does not offer model gpt-live')
+
+    const unavailable = optionSession(
+      vi.fn(async () => {
+        throw new Error('model/list unavailable')
+      })
+    )
+    await expect(
+      applyCodexStructuredSessionOption(unavailable, 'model', 'gpt-live', undefined)
+    ).rejects.toThrow('model/list unavailable')
   })
 })

--- a/src/main/codex/codex-structured-session-options.ts
+++ b/src/main/codex/codex-structured-session-options.ts
@@ -12,10 +12,23 @@ import { AgentSessionOptionRejectedError } from '../native-chat/agent-session-wi
 const MODEL_PAGE_LIMIT = 100
 const MAX_MODEL_PAGES = 20
 
+export type CodexModelCatalog = Pick<AgentSessionOptionsResult, 'models'> | null | undefined
+
 export function restoredCodexSessionOptions(
-  options: Readonly<Record<string, string>> | undefined
+  options: Readonly<Record<string, string>> | undefined,
+  catalog: CodexModelCatalog
 ): Map<string, string> {
-  return new Map(Object.entries(options ?? {}).filter(([key]) => isCodexTurnOptionKey(key)))
+  const restored = new Map(
+    Object.entries(options ?? {}).filter(
+      ([key, value]) => isCodexTurnOptionKey(key) && (key !== 'model' || value.length > 0)
+    )
+  )
+  const model = restored.get('model')
+  if (model && !codexCatalogAdmitsModel(catalog, model)) {
+    restored.delete('model')
+    restored.delete('effort')
+  }
+  return restored
 }
 
 function record(value: unknown): Record<string, unknown> | null {
@@ -102,13 +115,8 @@ export async function readCodexStructuredSessionOptions(input: {
       break
     }
   }
-  if (input.current.model && !models.some((model) => model.id === input.current.model)) {
-    models.push({
-      id: input.current.model,
-      label: input.current.model,
-      isDefault: false,
-      efforts: []
-    })
+  if (cursor) {
+    throw new Error(`codex app-server model enumeration exceeded ${MAX_MODEL_PAGES} pages`)
   }
   const model = input.current.model ?? models.find((entry) => entry.isDefault)?.id ?? models[0]?.id
   if (!model) {
@@ -120,12 +128,23 @@ export async function readCodexStructuredSessionOptions(input: {
   }
 }
 
+/** Returns the final admission decision, including unavailable evidence's permissive case. */
+export function codexCatalogAdmitsModel(catalog: CodexModelCatalog, modelId: string): boolean {
+  const models = catalog?.models ?? []
+  // An empty list identifies no model, so it is not evidence against one — a
+  // CLI unable to answer model/list must not have every model refused under it.
+  // Do not turn this into a refusal.
+  return models.length === 0 || models.some((model) => model.id === modelId)
+}
+
 export function reportedCodexThreadOptions(
-  opened: CodexOpenedThread
+  opened: CodexOpenedThread,
+  catalog: CodexModelCatalog
 ): CodexSession['reportedOptions'] {
+  const modelAdmitted = !opened.model || codexCatalogAdmitsModel(catalog, opened.model)
   return {
-    ...(opened.model ? { model: opened.model } : {}),
-    ...(opened.effort ? { effort: opened.effort } : {})
+    ...(opened.model && modelAdmitted ? { model: opened.model } : {}),
+    ...(opened.effort && modelAdmitted ? { effort: opened.effort } : {})
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​858 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​837 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​148 |

<!-- /orca-pr-loc -->

## ELI5

A structured Codex session could remember a model that the running provider no longer lists. Orca then sent that stale model on every turn, leaving the Codex process alive while every turn returned a 400 and produced no output. Orca now validates restored and resumed model ids against one catalog snapshot, chooses only the uniquely marked provider-listed default when recovery is needed, and shows a warning that attributes the choice to Orca.

## What Changed

- Removed the fabricated current-model row from the live model catalog. The current id remains observed state, but it can no longer prove its own provider membership.
- Added one connection-local catalog authority for restored and provider-reported model ids. Empty or unavailable evidence remains permissive for acquisition only.
- Added acquisition-time recovery that preserves valid account-private models, drops refused model effort, retains unrelated turn options, and selects only one row explicitly marked isDefault. Missing or ambiguous defaults preserve the original pick and emit an unresolved warning instead of guessing.
- Added a post-enumeration acquisition fence and an Orca-origin warning row naming both the refused and replacement ids.
- Refused empty-string model overrides and accepted a replacement default effort only when that effort is advertised by the replacement row.
- Added focused unit and adapter integration coverage for fresh and resumed threads, pagination, unavailable catalogs, notice provenance, supersession, and two consecutive recovered turns.

The bounded model-list reader now throws when page 20 still returns a cursor. This intentionally changes the existing explicit option setter too: it no longer treats a bounded partial list as complete. No existing test encoded the old first-page or partial-list behavior.

The explicit setter otherwise keeps its established strict behavior. Empty or unavailable model lists are permissive only during acquisition; an explicit user model write still errors when model/list is empty or unavailable.

## Why

The load-bearing bug was the deleted current-model push: an unlisted restored or reported id was appended to the provider rows before any membership check, so every check became self-validating. Static Codex seed rows are intentionally incomplete and are not used as entitlement or default evidence.

A separate real-binary probe on codex-cli 0.153.4 established that omitting turn/start.model does not recover a poisoned thread: Codex inherits the stored stale model and returns the same 400. The recovered id therefore stays in session options and is sent on every Orca turn.

The probe also measured thread/settings/update successfully healing a poisoned thread with no turn and no tokens. This PR deliberately does not use it because it would add a provider-owned acquisition-time write plus capability and version handling outside the reviewed scope. The selected turn override heals provider thread state only after the first successful turn; until then, another client that resumes the thread outside Orca still sees the stale provider value, while every Orca turn carries the listed override.

This does not make every listed model usable. A model that model/list includes but the account cannot actually use still fails with a 400 saying the model is not supported with a ChatGPT account.

## Linked Issue

No issue was supplied for this dispatched implementation plan.

## Visual Proof

N/A — backend structured-session acquisition and turn parameters only; no renderer or wire type changed.

## Testing

- 97 unique tests passed across nine Codex option, restoration, adapter, acquisition, cancel, close, and shutdown suites.
- npx tsc --noEmit -p config/tsconfig.node.json — exit 0
- npx tsc --noEmit -p config/tsconfig.tc.cli.json — exit 0
- npx tsc --noEmit -p config/tsconfig.tc.web.json — exit 0
- npx oxlint on all seven changed files — exit 0, zero warnings and errors
- NUL scans and git diff --check passed; neither lockfile is in either commit.

Ablations were applied by hand, verified red with nonzero test counts, reversed by patch, and checked against recorded SHA-256 values:

- Restoring the fabricated current-model row: 2 targeted failures, including the direct reader and acquisition-to-turn regressions.
- Making admission always permissive: 6 targeted failures.
- Removing the empty/unavailable permissive case: 6 targeted failures.
- Accepting a bounded partial enumeration: 2 targeted failures.
- Removing replacement assignment: 5 targeted failures.
- Selecting the first row instead of a unique default: 2 targeted failures.
- Masking an invalid report behind a valid restore: 1 targeted failure.
- Fetching separate catalog snapshots: 1 targeted failure.
- Removing the post-enumeration acquisition fence: 1 targeted failure.
- Suppressing the Orca warning: 1 targeted failure.
- Removing the explicit-setter membership gate: 2 targeted failures.
- Retaining stale effort, stopping pagination early, hardcoding a seed model, propagating an empty model, or accepting an unadvertised default effort: 1 targeted failure each.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

The reviewed plan was implemented without importing or depending on unmerged discovery work. One wording assumption in the plan was corrected from account default to provider-listed default because the real-binary probe showed that the catalog isDefault row can differ from the thread/config default.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No new process, path, platform, SSH, folder-workspace, remote-wire, or mobile behavior was added. Enumeration remains on the existing execution-host connection and keeps existing timeout, hidden-row, deduplication, and 20-page bounds.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why, including ELI5
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered, or N/A
- [ ] Full pnpm lint, typecheck, test, and build scripts were not run; the task-required focused Vitest, oxlint, and three sequential TypeScript projects passed, and CI will cover the full matrix.
