### PR TITLE
test: replace fixed UI waits with observable readiness

### DIFF
--- a/tests/e2e/helpers/source-control-ai-generation.ts
+++ b/tests/e2e/helpers/source-control-ai-generation.ts
@@ -53,7 +53,6 @@ export async function openChecks(page: Page, worktreeId: string): Promise<void> 
           // instead of hanging on a locator that stopped matching mid-action.
           await checksButton.click({ timeout: 2_000 }).catch(() => undefined)
         }
-        await page.waitForTimeout(250)
         return page.evaluate(() => window.__store?.getState().rightSidebarTab)
       },
       { timeout: 10_000 }

--- a/tests/e2e/pr-comments-sidebar-cards.spec.ts
+++ b/tests/e2e/pr-comments-sidebar-cards.spec.ts
@@ -138,15 +138,21 @@ test.describe('PR comments sidebar cards view', () => {
     await orcaPage.screenshot({ path: testInfo.outputPath('reaction-before.png') })
     await threadReactionButton.click()
     await expect(orcaPage.getByRole('group', { name: 'Add reaction' })).toBeFocused()
-    await orcaPage.waitForTimeout(300)
-    await orcaPage.screenshot({ path: testInfo.outputPath('reaction-picker.png') })
+    await expect(orcaPage.getByRole('button', { name: 'Add rocket reaction' })).toBeVisible()
+    await orcaPage.screenshot({
+      path: testInfo.outputPath('reaction-picker.png'),
+      animations: 'disabled'
+    })
     await orcaPage.getByRole('button', { name: 'Add rocket reaction' }).click()
     await expect(orcaPage.getByRole('group', { name: 'Add reaction' })).toBeHidden()
     const selectedRocket = reviewThreadCard.getByRole('button', { name: '1 rocket reaction' })
     await expect(selectedRocket).toHaveAttribute('aria-pressed', 'true')
     await selectedRocket.focus()
-    await orcaPage.waitForTimeout(300)
-    await orcaPage.screenshot({ path: testInfo.outputPath('reaction-after.png') })
+    await expect(selectedRocket).toBeFocused()
+    await orcaPage.screenshot({
+      path: testInfo.outputPath('reaction-after.png'),
+      animations: 'disabled'
+    })
     await selectedRocket.press('Enter')
     await expect(selectedRocket).toHaveCount(0)
     await expect(threadReactionButton).toBeFocused()

--- a/tests/e2e/quick-open-file-paths.spec.ts
+++ b/tests/e2e/quick-open-file-paths.spec.ts
@@ -42,19 +42,20 @@ test('cmd+p quick open prioritizes the filename and reveals the full path on hov
     rowText?.indexOf('packages/orca/src/renderer/src/components/navigation/') ?? -1
   )
 
-  // Two hovers on purpose: results stream in and remount the row, and Radix only
-  // opens on a pointermove it actually receives. A single hover can land before
-  // the remount and leave the cursor sitting still over a row that never saw it.
-  await row.hover({ position: { x: 20, y: 12 } })
-  await orcaPage.waitForTimeout(250)
-  await row.hover({ position: { x: 40, y: 12 } })
+  const tooltip = orcaPage
+    .locator('[data-slot="tooltip-content"]')
+    .filter({ hasText: relativeFilePath })
+  // Streaming results can remount the row under a stationary pointer.
+  await expect(async () => {
+    await row.hover({ position: { x: 20, y: 12 }, timeout: 1_000 })
+    await row.hover({ position: { x: 40, y: 12 }, timeout: 1_000 })
+    await expect(tooltip).toBeVisible({ timeout: 1_000 })
+  }).toPass({ timeout: 10_000, intervals: [100, 250, 500] })
 
   // Exact cursor placement is arithmetic, unit-tested via cursorTooltipOffsets.
   // Asserting it here measures the app mid-reflow and is flaky; what E2E is
   // uniquely good for is that the tooltip really opens with the whole path.
-  await expect(
-    orcaPage.locator('[data-slot="tooltip-content"]').filter({ hasText: relativeFilePath })
-  ).toBeVisible()
+  await expect(tooltip).toBeVisible()
 
   const proofPath = process.env.ORCA_QUICK_OPEN_PROOF_PATH
   if (proofPath) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Let selected UI tests continue as soon as the UI is ready instead of always sleeping.

## What Changed

- Retry the quick-open hover against tooltip visibility to handle streamed rows remounting.
- Wait for reaction controls and focus explicitly, disabling screenshot animations for stable captures.
- Remove the unconditional 250 ms delay inside the existing bounded checks-tab poll.

## Why

These fixed waits add latency without proving readiness. Observable conditions handle both fast and slow rendering while preserving intentional reconnect, backoff, and performance dwell waits.

## Linked Issue

Part of #20366. This PR is independent and targets `main`.

## Visual Proof

N/A — this changes CI or test synchronization only; no application UI or interaction behavior changes.

## Testing

- Fresh Electron E2E and CLI builds passed.
- All seven targeted Electron tests passed in 33 seconds on macOS with `ORCA_BACKGROUND_LAUNCH=1`, hidden renderers, and no native window activation. The reaction picker screenshot was inspected.
- Lint and formatting passed.
- The broader E2E typecheck reports 217 diagnostics; a comparison against the pre-change sources produced exactly the same diagnostics.

- [x] Automated checks run locally; scope and limitations listed above.
- [x] Automated tests added/updated, or existing targeted E2E tests exercised.

## Review

Self-reviewed for scope, failure handling, cross-platform effects, and compatibility. No application execution-host, SSH, folder-workspace, or wire behavior changes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer content is copied.

## Notes

Application behavior is unchanged. Linux/Windows coverage and hosted timing comparisons remain with CI; the shared checks-tab helper retains its existing bounded poll.

## Checklist

- [x] Scope is focused and the change is explained.
- [x] Visual proof is N/A with a reason.
- [x] Cross-platform and SSH/remote impact considered.
- [x] Local validation and remaining CI checks are documented above.


## Measured impact before merge

Same built app, same seven tests, one worker, hidden Electron on macOS, alternating order base/head/head/base/base/head. All 42 test executions passed, with no skips or retries.

| Version | End-to-end elapsed seconds | Median |
| --- | --- | --- |
| Base | 33.85, 32.45, 32.52 | 32.52s |
| PR | 30.78, 31.39, 32.04 | 31.39s |

Measured median improvement: **1.13 seconds / 3.5%** for these seven tests. This is a local measurement, not a claim about full CI elapsed time. Every candidate run was faster than every baseline run. JSON reports are retained in `/tmp/orca-ci-impact/readiness-*.json` in the measurement workspace.

Merge validation: no required checks are configured/reported for this PR, no review blockers were present, and the PR was mergeable at `29d6f4c868263377068dea2e92f47badbfaacfc4`. Hosted checks were still queued; local validation above is the completed evidence.
