### PR TITLE
fix(git): keep pushed but unmerged branches after workspace removal

### DIFF
--- a/src/main/git/remove-worktree-branch-cleanup.test.ts
+++ b/src/main/git/remove-worktree-branch-cleanup.test.ts
@@ -81,7 +81,9 @@ describe('removeWorktree', () => {
   it('keeps removal successful when branch cleanup fails', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     mockGitCommands({
-      'git worktree list --porcelain': {
+      'git rev-parse --verify --quiet HEAD^{commit}': { stdout: 'abc123\n' },
+      'git merge-base abc123 def456': { stdout: 'def456\n' },
+      'git worktree list --porcelain -z': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -91,15 +93,8 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain#2': {
-        stdout: `worktree /repo
-HEAD abc123
-branch refs/heads/main
-`
-      },
-      'git branch -d -- feature/test': {
-        error: new Error('branch delete failed'),
-        stderr: 'branch delete failed'
+      'git worktree list --porcelain': {
+        error: new Error('branch cleanup failed')
       }
     })
 
@@ -108,9 +103,11 @@ branch refs/heads/main
     })
 
     expect(warnSpy).toHaveBeenCalledWith(
-      '[git] Preserved local branch "feature/test" after removing worktree (not fully merged)',
-      expect.any(Error)
+      '[git] Preserved local branch "feature/test" after removing worktree',
+      expect.objectContaining({ message: 'branch cleanup failed' })
     )
+    expect(getGitCalls()).toContain('git merge-base abc123 def456')
+    expect(getGitCalls()).not.toContain('git update-ref -d refs/heads/feature/test def456')
 
     warnSpy.mockRestore()
   })
@@ -127,27 +124,11 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
-        stdout: `worktree /repo
-HEAD abc123
-branch refs/heads/main
-`
-      },
       'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
 `
-      },
-      'git worktree list --porcelain#2': {
-        stdout: `worktree /repo
-HEAD abc123
-branch refs/heads/main
-`
-      },
-      'git branch -d -- feature/test': {
-        error: new Error('branch delete failed'),
-        stderr: 'error: the branch feature/test is not fully merged'
       },
       'git config --get branch.feature/test.base': {
         stdout: 'refs/remotes/origin/main\n'
@@ -158,7 +139,7 @@ branch refs/heads/main
       'git rev-parse --verify --quiet HEAD^{commit}': {
         stdout: 'base123\n'
       },
-      'git merge-tree --write-tree base123 refs/heads/feature/test': {
+      'git merge-tree --write-tree base123 def456': {
         stdout: 'tree123\n'
       },
       'git rev-parse --verify --quiet base123^{tree}': {
@@ -169,11 +150,11 @@ branch refs/heads/main
     await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({})
 
     const calls = getGitCalls()
-    expect(calls).toContain('git branch -d -- feature/test')
-    expect(calls).toContain('git merge-tree --write-tree base123 refs/heads/feature/test')
+    expect(calls).not.toContain('git branch -d -- feature/test')
+    expect(calls).toContain('git merge-tree --write-tree base123 def456')
     expect(calls).toContain('git update-ref -d refs/heads/feature/test def456')
     expect(calls).toContain('git config --remove-section branch.feature/test')
-    expect(calls).not.toContain('git remote')
+    expect(calls).toContain('git remote')
   })
 
   it('deletes a squash-merged branch with branch-only merge commits via expected head', async () => {
@@ -188,21 +169,11 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
-        stdout: `worktree /repo
-HEAD abc123
-branch refs/heads/main
-`
-      },
       'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
 `
-      },
-      'git branch -d -- feature/test': {
-        error: new Error('branch delete failed'),
-        stderr: 'error: the branch feature/test is not fully merged'
       },
       'git config --get branch.feature/test.base': {
         stdout: 'refs/remotes/origin/main\n'
@@ -210,19 +181,19 @@ branch refs/heads/main
       'git rev-parse --verify --quiet refs/remotes/origin/main^{commit}': {
         stdout: 'target123\n'
       },
-      'git merge-tree --write-tree target123 refs/heads/feature/test': {
+      'git merge-tree --write-tree target123 def456': {
         stdout: 'merged-tree\n'
       },
       'git rev-parse --verify --quiet target123^{tree}': {
         stdout: 'target-tree\n'
       },
-      'git rev-list --right-only --merges --count target123...refs/heads/feature/test': {
+      'git rev-list --right-only --merges --count target123...def456': {
         stdout: '1\n'
       },
-      'git merge-base target123 refs/heads/feature/test': {
+      'git merge-base target123 def456': {
         stdout: 'base123\n'
       },
-      'git diff base123 refs/heads/feature/test': {
+      'git diff base123 def456': {
         stdout: 'branch net diff\n'
       },
       'git patch-id --stable#1': {
@@ -237,7 +208,7 @@ branch refs/heads/main
       'git patch-id --stable#2': {
         stdout: 'patch123 squash123\n'
       },
-      'git merge-tree --write-tree squash123 refs/heads/feature/test': {
+      'git merge-tree --write-tree squash123 def456': {
         stdout: 'squash-tree\n'
       },
       'git rev-parse --verify --quiet squash123^{tree}': {
@@ -260,7 +231,7 @@ branch refs/heads/main
     ])
   })
 
-  it('refreshes the saved remote base before deleting a safe-delete-rejected branch', async () => {
+  it('refreshes the saved remote base before proving the captured branch head merged', async () => {
     mockGitCommands({
       'git worktree list --porcelain -z': {
         stdout: `worktree /repo
@@ -272,27 +243,11 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
-        stdout: `worktree /repo
-HEAD abc123
-branch refs/heads/main
-`
-      },
       'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
 `
-      },
-      'git worktree list --porcelain#2': {
-        stdout: `worktree /repo
-HEAD abc123
-branch refs/heads/main
-`
-      },
-      'git branch -d -- feature/test': {
-        error: new Error('branch delete failed'),
-        stderr: 'error: the branch feature/test is not fully merged'
       },
       'git config --get branch.feature/test.base': {
         stdout: 'refs/remotes/origin/main\n'
@@ -306,7 +261,7 @@ branch refs/heads/main
       'git rev-parse --verify --quiet refs/remotes/origin/main^{commit}': {
         stdout: 'base123\n'
       },
-      'git merge-tree --write-tree base123 refs/heads/feature/test': {
+      'git merge-tree --write-tree base123 def456': {
         stdout: 'tree123\n'
       },
       'git rev-parse --verify --quiet base123^{tree}': {
@@ -317,7 +272,7 @@ branch refs/heads/main
     await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({})
 
     const calls = getGitCalls()
-    const mergeTreeCall = 'git merge-tree --write-tree base123 refs/heads/feature/test'
+    const mergeTreeCall = 'git merge-tree --write-tree base123 def456'
     const mergeTreeIndexes = calls.flatMap((call, index) => (call === mergeTreeCall ? [index] : []))
     const fetchIndex = calls.indexOf('git fetch --prune origin')
     const updateRefIndex = calls.indexOf('git update-ref -d refs/heads/feature/test def456')
@@ -346,21 +301,11 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain -z#2': {
-        stdout: `worktree /repo
-HEAD abc123
-branch refs/heads/main
-`
-      },
       'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
 `
-      },
-      'git branch -d -- feature/test': {
-        error: new Error('branch delete failed'),
-        stderr: 'error: the branch feature/test is not fully merged'
       },
       'git config --get branch.feature/test.base': {
         stdout: 'refs/remotes/origin/main\n'
@@ -368,10 +313,10 @@ branch refs/heads/main
       'git rev-parse --verify --quiet refs/remotes/origin/main^{commit}': {
         stdout: 'base123\n'
       },
-      'git rev-list --right-only --merges --count base123...refs/heads/feature/test': {
+      'git rev-list --right-only --merges --count base123...def456': {
         stdout: '0\n'
       },
-      'git cherry -v base123 refs/heads/feature/test': {
+      'git cherry -v base123 def456': {
         stdout: '- def456 fix: already squash-merged\n'
       },
       'git update-ref -d refs/heads/feature/test def456': {
@@ -384,13 +329,14 @@ branch refs/heads/main
     })
 
     expect(warnSpy).toHaveBeenCalledWith(
-      '[git] Failed to delete already-merged local branch "feature/test" after removing worktree',
-      expect.any(Error)
+      '[git] Preserved local branch "feature/test" after removing worktree',
+      expect.objectContaining({
+        message:
+          'Local branch "feature/test" changed after the workspace was deleted. Review it before deleting it.'
+      })
     )
-    expect(warnSpy).toHaveBeenCalledWith(
-      '[git] Preserved local branch "feature/test" after removing worktree (not fully merged)',
-      expect.any(Error)
-    )
+    expect(getGitCalls()).toContain('git update-ref -d refs/heads/feature/test def456')
+    expect(getGitCalls()).not.toContain('git config --remove-section branch.feature/test')
     warnSpy.mockRestore()
   })
 

--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -84,7 +84,9 @@ describe('removeWorktree', () => {
 
   it('removes the worktree and deletes its local branch', async () => {
     mockGitCommands({
-      'git worktree list --porcelain': {
+      'git rev-parse --verify --quiet HEAD^{commit}': { stdout: 'abc123\n' },
+      'git merge-base abc123 def456': { stdout: 'def456\n' },
+      'git worktree list --porcelain -z': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -94,7 +96,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain#2': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -102,14 +104,27 @@ branch refs/heads/main
       }
     })
 
-    await removeWorktree('/repo', '/repo-feature')
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({})
 
     const calls = getGitCalls()
     expect(calls).toEqual(
-      expect.arrayContaining(['git worktree remove /repo-feature', 'git branch -d -- feature/test'])
+      expect.arrayContaining([
+        'git worktree remove /repo-feature',
+        'git update-ref -d refs/heads/feature/test def456'
+      ])
     )
     expect(calls).not.toContain('git worktree prune')
-    expectGitCallOrder(calls, 'git worktree remove /repo-feature', 'git branch -d -- feature/test')
+    expect(calls).not.toContain('git branch -d -- feature/test')
+    expectGitCallOrder(
+      calls,
+      'git merge-base abc123 def456',
+      'git update-ref -d refs/heads/feature/test def456'
+    )
+    expectGitCallOrder(
+      calls,
+      'git worktree remove /repo-feature',
+      'git update-ref -d refs/heads/feature/test def456'
+    )
   })
 
   it('preserves the branch when requested for a pre-existing local branch checkout', async () => {
@@ -133,11 +148,14 @@ branch refs/heads/feature/test
     expect(calls).not.toContain('git worktree prune')
     expect(calls).not.toContain('git branch -d -- feature/test')
     expect(calls).not.toContain('git branch -D -- feature/test')
+    expect(calls).not.toContain('git update-ref -d refs/heads/feature/test def456')
   })
 
   it('skips branch deletion when another worktree still points at the branch', async () => {
     mockGitCommands({
-      'git worktree list --porcelain': {
+      'git rev-parse --verify --quiet HEAD^{commit}': { stdout: 'abc123\n' },
+      'git merge-base abc123 def456': { stdout: 'def456\n' },
+      'git worktree list --porcelain -z': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -151,7 +169,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain#2': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -160,36 +178,31 @@ worktree /repo-feature-copy
 HEAD def456
 branch refs/heads/feature/test
 `
-      },
-      'git branch -d -- feature/test': {
-        error: new Error(
-          "cannot delete branch 'feature/test' used by worktree at '/repo-feature-copy'"
-        )
-      },
-      'git branch -d -- feature/test#2': {
-        error: new Error(
-          "cannot delete branch 'feature/test' used by worktree at '/repo-feature-copy'"
-        )
       }
     })
 
-    await removeWorktree('/repo', '/repo-feature')
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({
+      preservedBranch: { branchName: 'feature/test', head: 'def456' }
+    })
 
     const calls = getGitCalls()
     expect(calls).toEqual(
       expect.arrayContaining([
         'git worktree remove /repo-feature',
-        'git branch -d -- feature/test',
+        'git merge-base abc123 def456',
         'git worktree prune'
       ])
     )
-    expect(calls.filter((call) => call === 'git branch -d -- feature/test')).toHaveLength(2)
+    expect(calls.filter((call) => call === 'git worktree list --porcelain')).toHaveLength(2)
+    expect(calls).not.toContain('git update-ref -d refs/heads/feature/test def456')
     expect(calls).not.toContain('git branch -D -- feature/test')
   })
 
   it('deletes the branch after prune removes stale sibling worktree entries', async () => {
     mockGitCommands({
-      'git worktree list --porcelain': {
+      'git rev-parse --verify --quiet HEAD^{commit}': { stdout: 'abc123\n' },
+      'git merge-base abc123 def456': { stdout: 'def456\n' },
+      'git worktree list --porcelain -z': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -204,37 +217,54 @@ branch refs/heads/feature/test
 prunable gitdir file points to non-existent location
 `
       },
-      'git worktree list --porcelain#2': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
 `
       },
-      'git branch -d -- feature/test': {
-        error: new Error("cannot delete branch 'feature/test' used by worktree at '/repo-stale'")
-      },
-      'git branch -d -- feature/test#2': {
-        stdout: ''
+      'git worktree list --porcelain#1': {
+        stdout: `worktree /repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repo-stale
+HEAD 0000000
+branch refs/heads/feature/test
+prunable gitdir file points to non-existent location
+`
       }
     })
 
-    await removeWorktree('/repo', '/repo-feature')
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({})
 
     const calls = getGitCalls()
-    expect(calls).toEqual([
-      'git worktree list --porcelain -z',
-      // The cleanliness probe that decides whether the checkout may be renamed aside.
-      'git status --porcelain --untracked-files=all',
+    expectGitCallOrder(
+      calls,
       'git worktree remove /repo-feature',
-      'git branch -d -- feature/test',
+      'git update-ref -d refs/heads/feature/test def456'
+    )
+    expect(
+      calls.filter(
+        (call) =>
+          call === 'git worktree list --porcelain' ||
+          call === 'git worktree prune' ||
+          call.startsWith('git update-ref')
+      )
+    ).toEqual([
+      'git worktree list --porcelain',
       'git worktree prune',
-      'git branch -d -- feature/test'
+      'git worktree list --porcelain',
+      'git update-ref -d refs/heads/feature/test def456',
+      'git worktree list --porcelain'
     ])
   })
 
   it('renames the checkout aside and deregisters the missing path', async () => {
     mockGitCommands({
-      'git worktree list --porcelain': {
+      'git rev-parse --verify --quiet HEAD^{commit}': { stdout: 'abc123\n' },
+      'git merge-base abc123 def456': { stdout: 'def456\n' },
+      'git worktree list --porcelain -z': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -244,7 +274,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain#2': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -265,7 +295,7 @@ branch refs/heads/main
     )
     expect(calls).not.toContain('git worktree remove /repo-feature')
     expect(calls).not.toContain('git worktree prune')
-    expect(calls).toContain('git branch -d -- feature/test')
+    expect(calls).toContain('git update-ref -d refs/heads/feature/test def456')
   })
 
   it('prunes the registration when deregistering the moved checkout fails', async () => {
@@ -462,7 +492,9 @@ branch refs/heads/main
 
   it('force-retries removal when git refuses a clean worktree containing an initialised submodule', async () => {
     mockGitCommands({
-      'git worktree list --porcelain': {
+      'git rev-parse --verify --quiet HEAD^{commit}': { stdout: 'abc123\n' },
+      'git merge-base abc123 def456': { stdout: 'def456\n' },
+      'git worktree list --porcelain -z': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -472,7 +504,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain#2': {
+      'git worktree list --porcelain': {
         stdout: `worktree /repo
 HEAD abc123
 branch refs/heads/main
@@ -500,7 +532,7 @@ branch refs/heads/main
     expect(calls.lastIndexOf('git status --porcelain --untracked-files=all')).toBeLessThan(
       calls.indexOf('git worktree remove --force /repo-feature')
     )
-    expect(calls).toContain('git branch -d -- feature/test')
+    expect(calls).toContain('git update-ref -d refs/heads/feature/test def456')
   })
 
   it('surfaces uncommitted changes instead of force-removing a dirty submodule worktree', async () => {
@@ -624,7 +656,9 @@ locked active agent session
 
   it('matches Windows worktree paths before deleting the branch', async () => {
     mockGitCommands({
-      'git worktree list --porcelain': {
+      'git rev-parse --verify --quiet HEAD^{commit}': { stdout: 'abc123\n' },
+      'git merge-base abc123 def456': { stdout: 'def456\n' },
+      'git worktree list --porcelain -z': {
         stdout: `worktree C:/repo
 HEAD abc123
 branch refs/heads/main
@@ -634,7 +668,7 @@ HEAD def456
 branch refs/heads/feature/test
 `
       },
-      'git worktree list --porcelain#2': {
+      'git worktree list --porcelain': {
         stdout: `worktree C:/repo
 HEAD abc123
 branch refs/heads/main
@@ -648,7 +682,7 @@ branch refs/heads/main
     expect(calls).toEqual(
       expect.arrayContaining([
         'git worktree remove c:\\workspaces\\delete-branch-ui-test',
-        'git branch -d -- feature/test'
+        'git update-ref -d refs/heads/feature/test def456'
       ])
     )
     expect(calls).not.toContain('git worktree prune')

--- a/src/main/git/worktree-branch-removal.ts
+++ b/src/main/git/worktree-branch-removal.ts
@@ -8,6 +8,10 @@ import { withRepoRefMaintenancePaused } from './local-repo-ref-maintenance'
 import { gitExecFileAsync } from './runner'
 import { parseWorktreeList } from '../../shared/git-worktree-porcelain-parser'
 import { isBranchCheckedOutInWorktreeError } from '../../shared/git-branch-delete-refusal'
+import {
+  BranchDeletionUnverifiedError,
+  verifyDeletedBranchCheckout
+} from '../../shared/git-branch-delete-verification'
 import type { GitWorktreeExecOptions, RemoveWorktreeOptions } from './worktree-operation-options'
 import { gitExecOptions, normalizeLocalBranchRef } from './worktree-operation-options'
 
@@ -18,61 +22,34 @@ export async function deleteBranchAfterWorktreeRemoval(
   options: RemoveWorktreeOptions
 ): Promise<RemoveWorktreeResult> {
   try {
-    // Why: also drop the now-orphaned branch so delete-worktree leaves none; `-d` (not `-D`) preserves
-    // unmerged work, and forceBranchDelete opts into `-D` for failed-creation rollback.
-    const branchDeleteResult = await deleteLocalBranchAfterWorktreeRemoval(
-      repoPath,
-      branchName,
-      options.forceBranchDelete === true,
-      options
-    )
-    if (branchDeleteResult === 'checked-out') {
+    if (options.forceBranchDelete) {
+      await forceDeleteBranchAfterRollback(repoPath, branchName, options)
       return {}
     }
-    return {}
-  } catch (error) {
-    if (!options.forceBranchDelete && branchHead) {
-      try {
-        if (
-          await deleteAlreadyMergedBranchAfterSafeDeleteFailure(
-            repoPath,
-            branchName,
-            branchHead,
-            options
-          )
-        ) {
-          return {}
-        }
-      } catch (alreadyMergedDeleteError) {
-        // Why: worktree is already gone; a raced branch cleanup should degrade to preserved-branch recovery, not fail delete.
-        console.warn(
-          `[git] Failed to delete already-merged local branch "${branchName}" after removing worktree`,
-          alreadyMergedDeleteError
-        )
-      }
+    if (
+      branchHead &&
+      (await deleteMergedBranchAfterWorktreeRemoval(repoPath, branchName, branchHead, options))
+    ) {
+      return {}
     }
-    // Keep an unmerged/unpublished branch: deleting a worktree must never silently discard commits.
-    console.warn(
-      `[git] Preserved local branch "${branchName}" after removing worktree (not fully merged)`,
-      error
-    )
-    return { preservedBranch: { branchName, ...(branchHead ? { head: branchHead } : {}) } }
+  } catch (error) {
+    if (error instanceof BranchDeletionUnverifiedError) {
+      throw error
+    }
+    // Removal already succeeded; a failed or raced proof must preserve the branch.
+    console.warn(`[git] Preserved local branch "${branchName}" after removing worktree`, error)
   }
+  return { preservedBranch: { branchName, ...(branchHead ? { head: branchHead } : {}) } }
 }
 
-async function deleteLocalBranchAfterWorktreeRemoval(
+async function forceDeleteBranchAfterRollback(
   repoPath: string,
   branchName: string,
-  forceBranchDelete: boolean,
   options: GitWorktreeExecOptions = {}
-): Promise<'deleted' | 'checked-out'> {
-  const deleteFlag = forceBranchDelete ? '-D' : '-d'
+): Promise<void> {
   try {
-    await gitExecFileAsync(
-      ['branch', deleteFlag, '--', branchName],
-      gitExecOptions(repoPath, options)
-    )
-    return 'deleted'
+    await gitExecFileAsync(['branch', '-D', '--', branchName], gitExecOptions(repoPath, options))
+    return
   } catch (error) {
     if (!isBranchCheckedOutInWorktreeError(error)) {
       throw error
@@ -80,28 +57,24 @@ async function deleteLocalBranchAfterWorktreeRemoval(
   }
 
   try {
-    // Why: only pay for `worktree prune` when a stale admin record may be blocking `branch -d`.
+    // Prune only when a stale checkout registration may block rollback.
     await gitExecFileAsync(['worktree', 'prune'], gitExecOptions(repoPath, options))
   } catch (error) {
     console.warn(`[git] Failed to prune worktrees before deleting branch "${branchName}"`, error)
-    return 'checked-out'
+    return
   }
 
   try {
-    await gitExecFileAsync(
-      ['branch', deleteFlag, '--', branchName],
-      gitExecOptions(repoPath, options)
-    )
-    return 'deleted'
+    await gitExecFileAsync(['branch', '-D', '--', branchName], gitExecOptions(repoPath, options))
   } catch (error) {
     if (isBranchCheckedOutInWorktreeError(error)) {
-      return 'checked-out'
+      return
     }
     throw error
   }
 }
 
-async function deleteAlreadyMergedBranchAfterSafeDeleteFailure(
+async function deleteMergedBranchAfterWorktreeRemoval(
   repoPath: string,
   branchName: string,
   branchHead: string,
@@ -113,17 +86,27 @@ async function deleteAlreadyMergedBranchAfterSafeDeleteFailure(
       ...(execOptions?.stdin !== undefined ? { stdin: execOptions.stdin } : {})
     })
   const targetRefs = await getBranchCleanupTargetRefs(runGit, branchName)
-  // Why: squash merges rewrite commit IDs, so `branch -d` rejects already-merged branches; delete only when Git proves no unmerged tree changes.
+  // A tracking branch proves publication, not integration into the base.
   const hasNoUnmergedChanges = await withLocalGitCapabilityCacheForExecution(
     { cwd: repoPath, wslDistro: options.wslDistro, signal: options.signal },
     (capabilities) =>
-      branchHasNoUnmergedChangesWithLazyTargetRefresh(runGit, branchName, targetRefs, capabilities)
+      branchHasNoUnmergedChangesWithLazyTargetRefresh(
+        runGit,
+        branchName,
+        targetRefs,
+        capabilities,
+        branchHead
+      )
   )
   if (!hasNoUnmergedChanges) {
     return false
   }
-  await forceDeleteLocalBranch(repoPath, branchName, branchHead, (args, cwd) =>
-    gitExecFileAsync(args, gitExecOptions(cwd, options))
+  await forceDeleteLocalBranch(
+    repoPath,
+    branchName,
+    branchHead,
+    (args, cwd) => gitExecFileAsync(args, gitExecOptions(cwd, options)),
+    { pruneStaleWorktrees: true }
   )
   return true
 }
@@ -135,7 +118,8 @@ export async function forceDeleteLocalBranch(
   runGit: (args: string[], cwd: string) => Promise<{ stdout: string; stderr: string }> = (
     args,
     cwd
-  ) => gitExecFileAsync(args, { cwd })
+  ) => gitExecFileAsync(args, { cwd }),
+  options: { pruneStaleWorktrees?: boolean } = {}
 ): Promise<void> {
   if (!branchName || branchName.includes('\0')) {
     throw new Error('Invalid branch name')
@@ -145,7 +129,12 @@ export async function forceDeleteLocalBranch(
       `Cannot force-delete local branch "${branchName}" without the commit Git preserved.`
     )
   }
-  if (await isLocalBranchCheckedOut(repoPath, branchName, runGit)) {
+  let checkedOut = await isLocalBranchCheckedOut(repoPath, branchName, runGit)
+  if (checkedOut && options.pruneStaleWorktrees) {
+    await runGit(['worktree', 'prune'], repoPath)
+    checkedOut = await isLocalBranchCheckedOut(repoPath, branchName, runGit)
+  }
+  if (checkedOut) {
     throw new Error(`Local branch "${branchName}" is checked out in another worktree.`)
   }
   // Why: stale toast actions must not delete a branch that moved; `update-ref -d` deletes only if the ref still == expectedHead.
@@ -160,17 +149,11 @@ export async function forceDeleteLocalBranch(
       `Local branch "${branchName}" changed after the workspace was deleted. Review it before deleting it.`
     )
   }
-  if (await isLocalBranchCheckedOut(repoPath, branchName, runGit)) {
-    try {
-      await runGit(['update-ref', `refs/heads/${branchName}`, expectedHead, ''], repoPath)
-    } catch (restoreError) {
-      console.warn(
-        `[git] Failed to restore local branch "${branchName}" after concurrent checkout`,
-        restoreError
-      )
-    }
-    throw new Error(`Local branch "${branchName}" is checked out in another worktree.`)
-  }
+  await verifyDeletedBranchCheckout(
+    branchName,
+    () => isLocalBranchCheckedOut(repoPath, branchName, runGit),
+    () => runGit(['update-ref', `refs/heads/${branchName}`, expectedHead, ''], repoPath)
+  )
   try {
     await runGit(['config', '--remove-section', `branch.${branchName}`], repoPath)
   } catch {

--- a/src/main/git/worktree-branch-retention-real-git.test.ts
+++ b/src/main/git/worktree-branch-retention-real-git.test.ts
@@ -1,0 +1,167 @@
+import { access, mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runProcess } from '../../shared/child-process/run-process'
+import { GitCapabilityCache } from '../../shared/git-capability-cache'
+import { removeWorktreeOp } from '../../relay/git-handler-worktree-remove'
+import type { GitExec } from '../../relay/git-handler-ops'
+import { deleteBranchAfterWorktreeRemoval, forceDeleteLocalBranch } from './worktree-branch-removal'
+import { forceDeletePreservedRelayBranch } from '../../relay/git-handler-branch-cleanup'
+import { BranchDeletionUnverifiedError } from '../../shared/git-branch-delete-verification'
+import { removeWorktree } from './worktree-removal'
+import { whenWorktreeTrashDeletionsSettled } from '../worktree-trash'
+
+let root: string
+let repo: string
+let worktree: string
+let branchHead: string
+
+const executeGit: GitExec = async (args, cwd, options) => {
+  const result = await runProcess({ program: 'git', args, cwd, input: options?.stdin })
+  if (result.code !== 0) {
+    throw Object.assign(new Error(result.stderr), result)
+  }
+  return result
+}
+
+async function git(args: string[], cwd = repo): Promise<string> {
+  return (await executeGit(args, cwd)).stdout.trim()
+}
+
+beforeEach(async () => {
+  root = await realpath(await mkdtemp(join(tmpdir(), 'orca-branch-retention-')))
+  repo = join(root, 'repo')
+  worktree = join(root, 'feature')
+  await mkdir(repo)
+  await git(['init', '-q'])
+  await git(['symbolic-ref', 'HEAD', 'refs/heads/main'])
+  await git(['config', 'user.name', 'Branch Retention'])
+  await git(['config', 'user.email', 'retention@example.invalid'])
+  await writeFile(join(repo, 'base.txt'), 'base\n')
+  await git(['add', '.'])
+  await git(['commit', '-qm', 'base'])
+  await git(['init', '--bare', '-q', join(root, 'remote.git')])
+  await git(['remote', 'add', 'origin', join(root, 'remote.git')])
+  await git(['push', '-u', 'origin', 'main'])
+  await git(['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/main'])
+  await git(['worktree', 'add', '-q', '-b', 'feature/test', worktree])
+  await git(['config', 'branch.feature/test.base', 'refs/remotes/origin/main'])
+  await writeFile(join(worktree, 'change.txt'), 'unmerged work\n')
+  await git(['add', '.'], worktree)
+  await git(['commit', '-qm', 'feature'], worktree)
+  await git(['push', '-u', 'origin', 'feature/test'], worktree)
+  branchHead = await git(['rev-parse', 'feature/test'])
+})
+
+afterEach(async () => {
+  await whenWorktreeTrashDeletionsSettled()
+  await rm(root, { recursive: true, force: true })
+})
+
+describe.each(['local', 'relay'] as const)(
+  '%s worktree branch retention against real Git',
+  (executor) => {
+    function remove(force = false, forceBranchDelete = false) {
+      return executor === 'local'
+        ? removeWorktree(repo, worktree, force, { forceBranchDelete })
+        : removeWorktreeOp(
+            executeGit,
+            { worktreePath: worktree, force, forceBranchDelete },
+            new GitCapabilityCache()
+          )
+    }
+
+    it.each([false, true])(
+      'preserves pushed unmerged commits when removing a worktree (force=%s)',
+      async (force) => {
+        expect(await git(['rev-list', '--count', 'origin/main..feature/test'])).toBe('1')
+        expect(await git(['rev-list', '--count', 'origin/feature/test..feature/test'])).toBe('0')
+
+        expect(await remove(force)).toEqual({
+          preservedBranch: { branchName: 'feature/test', head: branchHead }
+        })
+        expect(await git(['rev-parse', 'feature/test'])).toBe(branchHead)
+        expect(await git(['worktree', 'list', '--porcelain'])).not.toContain(
+          'refs/heads/feature/test'
+        )
+        await expect(access(worktree)).rejects.toMatchObject({ code: 'ENOENT' })
+      }
+    )
+
+    it.each(['merge', 'squash'] as const)(
+      'cleans up a branch after a %s into the base',
+      async (kind) => {
+        await git(
+          kind === 'merge'
+            ? ['merge', '--ff-only', 'feature/test']
+            : ['merge', '--squash', 'feature/test']
+        )
+        if (kind === 'squash') {
+          await git(['commit', '-qm', 'squash feature'])
+        }
+        await git(['push', 'origin', 'main'])
+        expect(await remove()).toEqual({})
+        expect(await git(['branch', '--list', 'feature/test'])).toBe('')
+      }
+    )
+
+    it('keeps explicit failed-creation rollback force deletion', async () => {
+      expect(await remove(false, true)).toEqual({})
+      expect(await git(['branch', '--list', 'feature/test'])).toBe('')
+    })
+
+    it('keeps the branch when only an unrelated primary checkout contains its commits', async () => {
+      await git(['checkout', '-qb', 'feature/other', 'feature/test'])
+      expect(await remove()).toEqual({
+        preservedBranch: { branchName: 'feature/test', head: branchHead }
+      })
+      expect(await git(['rev-parse', 'feature/test'])).toBe(branchHead)
+      expect(await git(['rev-list', '--count', 'origin/main..feature/test'])).toBe('1')
+    })
+
+    it.each([false, true])(
+      'does not claim a branch was kept after a failed post-delete scan (restore fails=%s)',
+      async (failRestore) => {
+        await git(['worktree', 'remove', worktree])
+        let deleted = false
+        const interruptedGit: GitExec = async (args, cwd, options) => {
+          if (deleted && args[0] === 'worktree') {
+            throw new Error('checkout scan failed')
+          }
+          if (deleted && args[0] === 'update-ref' && failRestore) {
+            throw new Error('restore failed')
+          }
+          const result = await executeGit(args, cwd, options)
+          if (args[0] === 'update-ref' && args[1] === '-d') {
+            deleted = true
+          }
+          return result
+        }
+        const deletion =
+          executor === 'local'
+            ? forceDeleteLocalBranch(repo, 'feature/test', branchHead, interruptedGit)
+            : forceDeletePreservedRelayBranch(interruptedGit, repo, 'feature/test', branchHead)
+        if (failRestore) {
+          await expect(deletion).rejects.toBeInstanceOf(BranchDeletionUnverifiedError)
+        } else {
+          await expect(deletion).rejects.toThrow('checkout scan failed')
+          expect(await git(['rev-parse', 'feature/test'])).toBe(branchHead)
+        }
+      }
+    )
+  }
+)
+
+it('keeps a branch whose head changed after removal captured it', async () => {
+  await git(['worktree', 'remove', worktree])
+  await git(['merge', '--ff-only', 'feature/test'])
+  await git(['push', 'origin', 'main'])
+  const tree = await git(['rev-parse', 'HEAD^{tree}'])
+  const newer = await git(['commit-tree', tree, '-p', branchHead, '-m', 'newer work'])
+  await git(['update-ref', 'refs/heads/feature/test', newer])
+  expect(await deleteBranchAfterWorktreeRemoval(repo, 'feature/test', branchHead, {})).toEqual({
+    preservedBranch: { branchName: 'feature/test', head: branchHead }
+  })
+  expect(await git(['rev-parse', 'feature/test'])).toBe(newer)
+})

--- a/src/main/git/worktree-remove-branch-deletion.test.ts
+++ b/src/main/git/worktree-remove-branch-deletion.test.ts
@@ -31,9 +31,41 @@ import { registerWorktreeSuiteHooks } from './worktree-test-harness'
 
 registerWorktreeSuiteHooks()
 
-describe('removeWorktree', () => {
+describe('removeWorktree branch retention', () => {
   const beforeRemoval =
     'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo-feature\nHEAD def456\nbranch refs/heads/feature/test\n'
+  const afterRemoval = 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
+  const preserved = { preservedBranch: { branchName: 'feature/test', head: 'def456' } }
+
+  function mockRepo(
+    options: { merged?: boolean; checkedOut?: boolean; prunable?: boolean; moved?: boolean } = {}
+  ) {
+    let pruned = false
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const command = args.join(' ')
+      if (command === 'worktree list --porcelain -z') {
+        return { stdout: beforeRemoval }
+      }
+      if (command === 'worktree list --porcelain') {
+        return {
+          stdout: options.checkedOut && !(options.prunable && pruned) ? beforeRemoval : afterRemoval
+        }
+      }
+      if (command === 'worktree prune') {
+        pruned = true
+      }
+      if (command === 'rev-parse --verify --quiet HEAD^{commit}') {
+        return { stdout: 'abc123' }
+      }
+      if (command === 'merge-base abc123 def456') {
+        return { stdout: options.merged ? 'def456' : 'abc123' }
+      }
+      if (command === 'update-ref -d refs/heads/feature/test def456' && options.moved) {
+        throw new Error('reference changed')
+      }
+      return { stdout: '', stderr: '' }
+    })
+  }
 
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
@@ -41,77 +73,55 @@ describe('removeWorktree', () => {
     translateWslOutputPathsMock.mockClear()
   })
 
-  it('uses safe `branch -d` and preserves a branch with unmerged commits', async () => {
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // list before
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // clean probe before the rename attempt
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
-    // Git refuses to delete an unmerged branch with `-d`.
-    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('not fully merged')) // branch -d
-
-    // Should not throw — the unmerged branch is preserved, not force-deleted.
-    await expect(removeWorktree('/repo', '/repo-feature', false)).resolves.toEqual({
-      preservedBranch: { branchName: 'feature/test', head: 'def456' }
-    })
-
-    const calls = gitExecFileAsyncMock.mock.calls.map((call) => call[0])
-    expect(calls).toContainEqual(['branch', '-d', '--', 'feature/test'])
-    expect(calls).not.toContainEqual(['branch', '-D', '--', 'feature/test'])
+  it('preserves an unmerged branch without asking Git to delete against its upstream', async () => {
+    mockRepo()
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual(preserved)
+    expect(
+      gitExecFileAsyncMock.mock.calls.some(
+        ([args]) => args[0] === 'branch' || args[0] === 'update-ref'
+      )
+    ).toBe(false)
   })
 
-  it('deletes the branch when `branch -d` succeeds (fully merged)', async () => {
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // list before
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // clean probe before the rename attempt
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -d succeeds
-
-    await removeWorktree('/repo', '/repo-feature', false)
-
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
-      'branch',
-      '-d',
-      '--',
-      'feature/test'
-    ])
+  it('deletes only the captured commit after proving it merged', async () => {
+    mockRepo({ merged: true })
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({})
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['update-ref', '-d', 'refs/heads/feature/test', 'def456'],
+      expect.anything()
+    )
   })
 
-  it('reuses known removed worktree metadata instead of relisting before removal', async () => {
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // clean probe before the rename attempt
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -d succeeds
+  it('preserves a branch moved after the merge proof', async () => {
+    mockRepo({ merged: true, moved: true })
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual(preserved)
+  })
 
+  it('reuses known removed worktree metadata', async () => {
+    mockRepo({ merged: true })
     await removeWorktree('/repo', '/repo-feature', false, {
-      knownRemovedWorktree: {
-        branch: 'refs/heads/feature/test',
-        head: 'def456'
-      }
+      knownRemovedWorktree: { branch: 'refs/heads/feature/test', head: 'def456' }
     })
-
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
-      ['status', '--porcelain', '--untracked-files=all'],
-      ['worktree', 'remove', '/repo-feature'],
-      ['branch', '-d', '--', 'feature/test']
+    expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).not.toContainEqual([
+      'worktree',
+      'list',
+      '--porcelain',
+      '-z'
     ])
   })
 
-  it('prunes and retries branch deletion only when Git reports a checked-out branch', async () => {
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: beforeRemoval }) // list before
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // clean probe before the rename attempt
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree remove
-    gitExecFileAsyncMock.mockRejectedValueOnce(
-      new Error("error: cannot delete branch 'feature/test' used by worktree at '/repo-stale'")
-    ) // branch -d hits stale worktree metadata
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree prune
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // branch -d retry succeeds
-
-    await expect(removeWorktree('/repo', '/repo-feature', false)).resolves.toEqual({})
-
-    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toEqual([
-      ['worktree', 'list', '--porcelain', '-z'],
-      ['status', '--porcelain', '--untracked-files=all'],
-      ['worktree', 'remove', '/repo-feature'],
-      ['branch', '-d', '--', 'feature/test'],
-      ['worktree', 'prune'],
-      ['branch', '-d', '--', 'feature/test']
+  it('prunes a stale checkout registration before deleting the merged branch', async () => {
+    mockRepo({ merged: true, checkedOut: true, prunable: true })
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual({})
+    expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toContainEqual([
+      'worktree',
+      'prune'
     ])
+  })
+
+  it('preserves a merged branch another live checkout still holds', async () => {
+    mockRepo({ merged: true, checkedOut: true })
+    await expect(removeWorktree('/repo', '/repo-feature')).resolves.toEqual(preserved)
+    expect(gitExecFileAsyncMock.mock.calls.some(([args]) => args[0] === 'update-ref')).toBe(false)
   })
 })

--- a/src/main/git/worktree-remove-branch-deletion.test.ts
+++ b/src/main/git/worktree-remove-branch-deletion.test.ts
@@ -34,6 +34,7 @@ registerWorktreeSuiteHooks()
 describe('removeWorktree branch retention', () => {
   const beforeRemoval =
     'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo-feature\nHEAD def456\nbranch refs/heads/feature/test\n'
+  const beforeRemovalNul = `${beforeRemoval.replaceAll('\n', '\0')}\0`
   const afterRemoval = 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
   const preserved = { preservedBranch: { branchName: 'feature/test', head: 'def456' } }
 
@@ -44,7 +45,7 @@ describe('removeWorktree branch retention', () => {
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
       const command = args.join(' ')
       if (command === 'worktree list --porcelain -z') {
-        return { stdout: beforeRemoval }
+        return { stdout: beforeRemovalNul }
       }
       if (command === 'worktree list --porcelain') {
         return {

--- a/src/main/local-worktree-removal-recovery.test.ts
+++ b/src/main/local-worktree-removal-recovery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BranchDeletionUnverifiedError } from '../shared/git-branch-delete-verification'
 
 const { gitExecFileAsyncMock, listWorktreesStrictMock, removeLocalWorktreePathMock } = vi.hoisted(
   () => ({
@@ -47,6 +48,24 @@ describe('recoverLocalWindowsWorktreeRemoval', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  it('does not report a branch as preserved after deletion and restoration could not be verified', async () => {
+    await withPlatform('win32', async () => {
+      const result = await recoverLocalWindowsWorktreeRemoval({
+        error: new BranchDeletionUnverifiedError('feature/test', new Error('restore failed')),
+        force: false,
+        canonicalWorktreePath: 'C:/repo/feature',
+        repoPath: 'C:/repo',
+        localWorktreeGitOptions: {},
+        registeredWorktree: { branch: 'refs/heads/feature/test', head: 'abc123' },
+        deleteBranch: true,
+        closeWatcher: vi.fn()
+      })
+      expect(result).toBeUndefined()
+      expect(listWorktreesStrictMock).not.toHaveBeenCalled()
+      expect(removeLocalWorktreePathMock).not.toHaveBeenCalled()
+    })
   })
 
   it('recovers Git for Windows partial filesystem deletion failures', async () => {

--- a/src/main/local-worktree-removal-recovery.ts
+++ b/src/main/local-worktree-removal-recovery.ts
@@ -1,6 +1,7 @@
 import type { RemoveWorktreeResult } from '../shared/worktree/create-types'
 import type { GitWorktreeInfo } from '../shared/worktree/types'
 import { assertWorktreeUnlockedForRemoval } from '../shared/worktree/removal'
+import { BranchDeletionUnverifiedError } from '../shared/git-branch-delete-verification'
 import { areWorktreePathsEqual, formatWorktreeRemovalError } from './ipc/worktree-logic'
 import { gitExecFileAsync } from './git/runner'
 import { listWorktreesStrict, type GitWorktreeExecOptions } from './git/worktree'
@@ -114,6 +115,10 @@ export async function recoverLocalWindowsWorktreeRemoval(
   // Why: recovery can recursively delete the remaining directory, so a Git
   // lock must reject the attempt before classification or any side effects.
   assertWorktreeUnlockedForRemoval(args.registeredWorktree)
+
+  if (args.error instanceof BranchDeletionUnverifiedError) {
+    return undefined
+  }
 
   if (!(await isRecoverableWindowsFilesystemRemovalFailure(args))) {
     return undefined

--- a/src/relay/git-branch-delete-refusal-parity.test.ts
+++ b/src/relay/git-branch-delete-refusal-parity.test.ts
@@ -1,15 +1,4 @@
-/**
- * The relay and the desktop each carried their own `getErrorText`, and they had
- * drifted: the relay read `message` + `stderr` + `stdout`, the desktop only
- * `message` + `stderr`. So a `git branch -d` refusal that arrived on `stdout`
- * routed the SSH removal through prune-and-retry while the local removal gave up
- * and preserved the branch.
- *
- * These tests push the same failure through both published removal entry points —
- * `removeWorktreeOp` (what `git.removeWorktree` runs on the host) and `removeWorktree`
- * (the local runner) — and require the same branch-deletion commands and the same
- * `RemoveWorktreeResult`. A second error-text reader on either side fails here.
- */
+// Rollback must recognize checkout refusals from either stream on both execution paths.
 import type * as FsPromises from 'node:fs/promises'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -85,18 +74,18 @@ type RefusalStream = 'stdout' | 'stderr'
 const REFUSAL_TEXT = `error: cannot delete branch '${BRANCH}' used by worktree at '/repo-stale'`
 
 /**
- * A `branch -d` rejection carrying the refusal on exactly one stream. `message` stays
+ * A `branch -D` rejection carrying the refusal on exactly one stream. `message` stays
  * generic so the assertion is about the stream, not about Node's stderr echo.
  */
 function branchDeleteRefusal(stream: RefusalStream): Error {
-  return Object.assign(new Error('Command failed: git branch -d'), {
+  return Object.assign(new Error('Command failed: git branch -D'), {
     code: 1,
     stdout: stream === 'stdout' ? REFUSAL_TEXT : '',
     stderr: stream === 'stderr' ? REFUSAL_TEXT : ''
   })
 }
 
-/** Refuses the first `branch -d`, accepts the retry that follows `worktree prune`. */
+/** Refuses the first `branch -D`, accepts the retry that follows `worktree prune`. */
 function scriptRelayGit(stream: RefusalStream): {
   git: GitExec
   calls: string[][]
@@ -111,7 +100,7 @@ function scriptRelayGit(stream: RefusalStream): {
     if (args[0] === 'worktree' && args[1] === 'list') {
       return { stdout: worktreeListPorcelain(true), stderr: '' }
     }
-    if (args[0] === 'branch' && args[1] === '-d') {
+    if (args[0] === 'branch' && args[1] === '-D') {
       branchDeleteCount += 1
       if (branchDeleteCount === 1) {
         throw branchDeleteRefusal(stream)
@@ -131,7 +120,7 @@ function scriptDesktopGit(stream: RefusalStream): string[][] {
     if (args[0] === 'worktree' && args[1] === 'list') {
       return { stdout: worktreeListPorcelain(branchDeleteCount === 0), stderr: '' }
     }
-    if (args[0] === 'branch' && args[1] === '-d') {
+    if (args[0] === 'branch' && args[1] === '-D') {
       branchDeleteCount += 1
       if (branchDeleteCount === 1) {
         throw branchDeleteRefusal(stream)
@@ -149,7 +138,7 @@ async function removeOverRelay(
   const { git, calls } = scriptRelayGit(stream)
   const result = await removeWorktreeOp(
     git,
-    { worktreePath: WORKTREE_PATH },
+    { worktreePath: WORKTREE_PATH, forceBranchDelete: true },
     new GitCapabilityCache()
   )
   return { result, branchCalls: branchDeletionCalls(calls) }
@@ -159,7 +148,7 @@ async function removeLocally(
   stream: RefusalStream
 ): Promise<{ result: RemoveWorktreeResult; branchCalls: string[] }> {
   const calls = scriptDesktopGit(stream)
-  const result = await removeWorktree(REPO_PATH, WORKTREE_PATH)
+  const result = await removeWorktree(REPO_PATH, WORKTREE_PATH, false, { forceBranchDelete: true })
   return { result, branchCalls: branchDeletionCalls(calls) }
 }
 
@@ -175,7 +164,7 @@ beforeEach(() => {
   moveWorktreeDirectoryToTrashMock.mockResolvedValue(undefined)
 })
 
-describe('relay/desktop branch-delete refusal parity', () => {
+describe('relay/desktop rollback branch-delete refusal parity', () => {
   it('prunes and retries on both paths when the refusal arrives on stdout', async () => {
     const relay = await removeOverRelay('stdout')
     const local = await removeLocally('stdout')
@@ -183,9 +172,9 @@ describe('relay/desktop branch-delete refusal parity', () => {
     expect(relay.branchCalls).toEqual(local.branchCalls)
     expect(relay.result).toEqual(local.result)
     expect(local.branchCalls).toEqual([
-      `branch -d -- ${BRANCH}`,
+      `branch -D -- ${BRANCH}`,
       'worktree prune',
-      `branch -d -- ${BRANCH}`
+      `branch -D -- ${BRANCH}`
     ])
     expect(local.result).toEqual({})
   })
@@ -197,9 +186,9 @@ describe('relay/desktop branch-delete refusal parity', () => {
     expect(relay.branchCalls).toEqual(local.branchCalls)
     expect(relay.result).toEqual(local.result)
     expect(local.branchCalls).toEqual([
-      `branch -d -- ${BRANCH}`,
+      `branch -D -- ${BRANCH}`,
       'worktree prune',
-      `branch -d -- ${BRANCH}`
+      `branch -D -- ${BRANCH}`
     ])
   })
 })

--- a/src/relay/git-handler-branch-cleanup.test.ts
+++ b/src/relay/git-handler-branch-cleanup.test.ts
@@ -160,30 +160,77 @@ describe('forceDeletePreservedRelayBranch', () => {
 })
 
 describe('removeWorktreeOp branch cleanup', () => {
+  it.each([false, true])(
+    'prunes stale checkout registrations before deletion (prune fails: %s)',
+    async (pruneFails) => {
+      let pruned = false
+      const git = vi.fn<GitExec>(async (args) => {
+        if (args.join(' ') === 'rev-parse --git-common-dir') {
+          return { stdout: '/repo/.git\n', stderr: '' }
+        }
+        if (args.join(' ') === 'rev-parse --verify --quiet HEAD^{commit}') {
+          return { stdout: 'base123\n', stderr: '' }
+        }
+        if (args.join(' ') === 'merge-base base123 1') {
+          return { stdout: '1\n', stderr: '' }
+        }
+        if (args[0] === 'worktree' && args[1] === 'list') {
+          return {
+            stdout: worktreeList(
+              { path: '/repo', branch: 'main' },
+              ...(args.includes('-z')
+                ? [{ path: '/repo-feature', branch: 'feature/test' }]
+                : pruned
+                  ? []
+                  : [{ path: '/repo-stale', branch: 'feature/test' }])
+            ),
+            stderr: ''
+          }
+        }
+        if (args.join(' ') === 'worktree prune') {
+          if (pruneFails) {
+            throw new Error('prune failed')
+          }
+          pruned = true
+        }
+        return { stdout: '', stderr: '' }
+      })
+
+      await expect(
+        removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+      ).resolves.toEqual(
+        pruneFails ? { preservedBranch: { branchName: 'feature/test', head: '1' } } : {}
+      )
+
+      expect(git).toHaveBeenCalledWith(['worktree', 'prune'], resolvedRepoPath())
+      const deletion = ['update-ref', '-d', 'refs/heads/feature/test', '1']
+      if (pruneFails) {
+        expect(git).not.toHaveBeenCalledWith(deletion, resolvedRepoPath())
+      } else {
+        expect(git).toHaveBeenCalledWith(deletion, resolvedRepoPath())
+        expect(
+          git.mock.calls.filter(([args]) => args.join(' ') === 'worktree list --porcelain')
+        ).toHaveLength(3)
+      }
+    }
+  )
+
   it('deletes a squash-merged SSH branch when merging it into the base is a no-op', async () => {
-    let zListCount = 0
     const git = vi.fn<GitExec>(async (args) => {
       if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list' && args.includes('-z')) {
-        zListCount += 1
         return {
-          stdout:
-            zListCount === 1
-              ? worktreeList(
-                  { path: '/repo', branch: 'main' },
-                  { path: '/repo-feature', branch: 'feature/test' }
-                )
-              : worktreeList({ path: '/repo', branch: 'main' }),
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
           stderr: ''
         }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
         return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
-      }
-      if (args[0] === 'branch' && args[1] === '-d') {
-        throw new Error('error: the branch feature/test is not fully merged')
       }
       if (args[0] === 'config' && args[1] === '--get') {
         return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
@@ -207,9 +254,9 @@ describe('removeWorktreeOp branch cleanup', () => {
       removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
     ).resolves.toEqual({})
 
-    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
+    expect(git).not.toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
     expect(git).toHaveBeenCalledWith(
-      ['merge-tree', '--write-tree', 'base123', 'refs/heads/feature/test'],
+      ['merge-tree', '--write-tree', 'base123', '1'],
       expect.any(String)
     )
     expect(git).toHaveBeenCalledWith(
@@ -220,33 +267,25 @@ describe('removeWorktreeOp branch cleanup', () => {
       ['config', '--remove-section', 'branch.feature/test'],
       expect.any(String)
     )
-    expect(git).not.toHaveBeenCalledWith(['remote'], expect.any(String))
+    expect(git).toHaveBeenCalledWith(['remote'], expect.any(String))
   })
 
   it('deletes a squash-merged SSH branch with branch-only merge commits via expected head', async () => {
-    let zListCount = 0
     const git = vi.fn<GitExec>(async (args, _cwd, opts) => {
       if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list' && args.includes('-z')) {
-        zListCount += 1
         return {
-          stdout:
-            zListCount === 1
-              ? worktreeList(
-                  { path: '/repo', branch: 'main' },
-                  { path: '/repo-feature', branch: 'feature/test' }
-                )
-              : worktreeList({ path: '/repo', branch: 'main' }),
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
           stderr: ''
         }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
         return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
-      }
-      if (args[0] === 'branch' && args[1] === '-d') {
-        throw new Error('error: the branch feature/test is not fully merged')
       }
       if (args[0] === 'config' && args[1] === '--get') {
         return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
@@ -301,6 +340,11 @@ describe('removeWorktreeOp branch cleanup', () => {
       ['update-ref', '-d', 'refs/heads/feature/test', '1'],
       expect.any(String)
     )
+    expect(git).toHaveBeenCalledWith(['diff', 'base123', '1'], resolvedRepoPath())
+    expect(git).toHaveBeenCalledWith(
+      ['merge-tree', '--write-tree', 'squash123', '1'],
+      resolvedRepoPath()
+    )
     expect(git).toHaveBeenCalledWith(['patch-id', '--stable'], expect.any(String), {
       stdin: 'branch net diff\n'
     })
@@ -309,32 +353,24 @@ describe('removeWorktreeOp branch cleanup', () => {
     })
   })
 
-  it('refreshes the saved remote base before deleting a safe-delete-rejected SSH branch', async () => {
+  it('refreshes the saved remote base before proving the captured branch head merged', async () => {
     const calls: { args: string[]; cwd: string }[] = []
-    let zListCount = 0
     const git = vi.fn<GitExec>(async (args, cwd) => {
       calls.push({ args, cwd })
       if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list' && args.includes('-z')) {
-        zListCount += 1
         return {
-          stdout:
-            zListCount === 1
-              ? worktreeList(
-                  { path: '/repo', branch: 'main' },
-                  { path: '/repo-feature', branch: 'feature/test' }
-                )
-              : worktreeList({ path: '/repo', branch: 'main' }),
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
           stderr: ''
         }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
         return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
-      }
-      if (args[0] === 'branch' && args[1] === '-d') {
-        throw new Error('error: the branch feature/test is not fully merged')
       }
       if (args[0] === 'config' && args[1] === '--get') {
         return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
@@ -364,7 +400,7 @@ describe('removeWorktreeOp branch cleanup', () => {
     const commandIndex = (expectedArgs: string[]) =>
       calls.findIndex(({ args }) => JSON.stringify(args) === JSON.stringify(expectedArgs))
     const fetchIndex = commandIndex(['fetch', '--prune', 'origin'])
-    const mergeTreeArgs = ['merge-tree', '--write-tree', 'base123', 'refs/heads/feature/test']
+    const mergeTreeArgs = ['merge-tree', '--write-tree', 'base123', '1']
     const mergeTreeIndexes = calls.flatMap(({ args }, index) =>
       JSON.stringify(args) === JSON.stringify(mergeTreeArgs) ? [index] : []
     )
@@ -380,29 +416,21 @@ describe('removeWorktreeOp branch cleanup', () => {
 
   it('preserves an already-merged SSH branch when cleanup races after worktree removal', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    let zListCount = 0
     const git = vi.fn<GitExec>(async (args) => {
       if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list' && args.includes('-z')) {
-        zListCount += 1
         return {
-          stdout:
-            zListCount === 1
-              ? worktreeList(
-                  { path: '/repo', branch: 'main' },
-                  { path: '/repo-feature', branch: 'feature/test' }
-                )
-              : worktreeList({ path: '/repo', branch: 'main' }),
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
           stderr: ''
         }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
         return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
-      }
-      if (args[0] === 'branch' && args[1] === '-d') {
-        throw new Error('error: the branch feature/test is not fully merged')
       }
       if (args[0] === 'config' && args[1] === '--get') {
         return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
@@ -429,12 +457,17 @@ describe('removeWorktreeOp branch cleanup', () => {
     })
 
     expect(warnSpy).toHaveBeenCalledWith(
-      'relay removeWorktree: failed to delete already-merged local branch "feature/test" after removing worktree',
+      'relay removeWorktree: preserved local branch "feature/test" after removing worktree',
       expect.objectContaining({ message: 'cannot lock ref' })
     )
-    expect(warnSpy).toHaveBeenCalledWith(
-      'relay removeWorktree: preserved local branch "feature/test" after removing worktree (not fully merged)',
-      expect.any(Error)
+    expect(git).toHaveBeenCalledWith(['cherry', '-v', 'base123', '1'], resolvedRepoPath())
+    expect(git).toHaveBeenCalledWith(
+      ['update-ref', '-d', 'refs/heads/feature/test', '1'],
+      resolvedRepoPath()
+    )
+    expect(git).not.toHaveBeenCalledWith(
+      ['config', '--remove-section', 'branch.feature/test'],
+      resolvedRepoPath()
     )
     warnSpy.mockRestore()
   })

--- a/src/relay/git-handler-branch-cleanup.ts
+++ b/src/relay/git-handler-branch-cleanup.ts
@@ -5,8 +5,9 @@ import {
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
 import type { GitExec } from './git-handler-ops'
 import { parseWorktreeList } from '../shared/git-worktree-porcelain-parser'
+import { verifyDeletedBranchCheckout } from '../shared/git-branch-delete-verification'
 
-export async function deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure(
+export async function deleteMergedRelayBranchAfterWorktreeRemoval(
   git: GitExec,
   repoPath: string,
   branchName: string,
@@ -16,20 +17,21 @@ export async function deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure(
   const runGit = (args: string[], options?: { stdin?: string }) =>
     options ? git(args, repoPath, options) : git(args, repoPath)
   const targetRefs = await getBranchCleanupTargetRefs(runGit, branchName)
-  // Why: SSH worktrees hit the same squash-merge shape as local worktrees.
-  // Git's no-op merge proof lets us clean up only branches whose changes
-  // already exist on the saved base ref.
+  // A tracking branch proves publication, not integration into the base.
   if (
     !(await branchHasNoUnmergedChangesWithLazyTargetRefresh(
       runGit,
       branchName,
       targetRefs,
-      capabilities
+      capabilities,
+      branchHead
     ))
   ) {
     return false
   }
-  await deleteRelayBranchAtExpectedHead(git, repoPath, branchName, branchHead)
+  await deleteRelayBranchAtExpectedHead(git, repoPath, branchName, branchHead, {
+    pruneStaleWorktrees: true
+  })
   return true
 }
 
@@ -45,10 +47,11 @@ export async function forceDeletePreservedRelayBranch(
   if (!expectedHead) {
     throw new Error('Expected branch head is required for preserved branch delete.')
   }
-  await deleteRelayBranchAtExpectedHead(git, repoPath, branchName, expectedHead, () => {
-    return new Error(
-      `Local branch "${branchName}" changed after the workspace was deleted. Review it before deleting it.`
-    )
+  await deleteRelayBranchAtExpectedHead(git, repoPath, branchName, expectedHead, {
+    mapUpdateRefError: () =>
+      new Error(
+        `Local branch "${branchName}" changed after the workspace was deleted. Review it before deleting it.`
+      )
   })
 }
 
@@ -57,9 +60,17 @@ async function deleteRelayBranchAtExpectedHead(
   repoPath: string,
   branchName: string,
   expectedHead: string,
-  mapUpdateRefError?: (error: unknown) => Error
+  options: {
+    mapUpdateRefError?: (error: unknown) => Error
+    pruneStaleWorktrees?: boolean
+  } = {}
 ): Promise<void> {
-  if (await isRelayBranchCheckedOut(git, repoPath, branchName)) {
+  let checkedOut = await isRelayBranchCheckedOut(git, repoPath, branchName)
+  if (checkedOut && options.pruneStaleWorktrees) {
+    await git(['worktree', 'prune'], repoPath)
+    checkedOut = await isRelayBranchCheckedOut(git, repoPath, branchName)
+  }
+  if (checkedOut) {
     throw new Error(`Local branch "${branchName}" is checked out in another worktree.`)
   }
   try {
@@ -67,19 +78,13 @@ async function deleteRelayBranchAtExpectedHead(
   } catch (error) {
     // Why: only stale ref writes get the force-delete message; checkout guards
     // and removeWorktree cleanup still rely on their distinct/raw failures.
-    throw mapUpdateRefError?.(error) ?? error
+    throw options.mapUpdateRefError?.(error) ?? error
   }
-  if (await isRelayBranchCheckedOut(git, repoPath, branchName)) {
-    try {
-      await git(['update-ref', `refs/heads/${branchName}`, expectedHead, ''], repoPath)
-    } catch (restoreError) {
-      console.warn(
-        `relay removeWorktree: failed to restore local branch "${branchName}" after concurrent checkout`,
-        restoreError
-      )
-    }
-    throw new Error(`Local branch "${branchName}" is checked out in another worktree.`)
-  }
+  await verifyDeletedBranchCheckout(
+    branchName,
+    () => isRelayBranchCheckedOut(git, repoPath, branchName),
+    () => git(['update-ref', `refs/heads/${branchName}`, expectedHead, ''], repoPath)
+  )
   try {
     await git(['config', '--remove-section', `branch.${branchName}`], repoPath)
   } catch {

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -224,7 +224,7 @@ describe('addWorktreeOp', () => {
 describe('removeWorktreeOp', () => {
   it('rejects a locked SSH worktree before invoking remove', async () => {
     const git = vi.fn<GitExec>(async (args) => {
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
@@ -248,13 +248,19 @@ describe('removeWorktreeOp', () => {
     )
   })
 
-  it('deletes the now-unused branch after removing an SSH worktree', async () => {
+  it('deletes the merged branch at its captured head after removing an SSH worktree', async () => {
     const calls: string[] = []
     let listCount = 0
     const git = vi.fn<GitExec>(async (args, cwd) => {
       calls.push(`${cwd}$ ${args.join(' ')}`)
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args.join(' ') === 'rev-parse --verify --quiet HEAD^{commit}') {
+        return { stdout: 'base123\n', stderr: '' }
+      }
+      if (args.join(' ') === 'merge-base base123 1') {
+        return { stdout: '1\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
         listCount += 1
@@ -278,7 +284,14 @@ describe('removeWorktreeOp', () => {
       '/repo-feature$ rev-parse --git-common-dir',
       `${resolvedRepoPath()}$ worktree list --porcelain -z`,
       `${resolvedRepoPath()}$ worktree remove /repo-feature`,
-      `${resolvedRepoPath()}$ branch -d -- feature/test`
+      `${resolvedRepoPath()}$ config --get branch.feature/test.base`,
+      `${resolvedRepoPath()}$ symbolic-ref --quiet refs/remotes/origin/HEAD`,
+      `${resolvedRepoPath()}$ rev-parse --verify --quiet HEAD^{commit}`,
+      `${resolvedRepoPath()}$ merge-base base123 1`,
+      `${resolvedRepoPath()}$ worktree list --porcelain`,
+      `${resolvedRepoPath()}$ update-ref -d refs/heads/feature/test 1`,
+      `${resolvedRepoPath()}$ worktree list --porcelain`,
+      `${resolvedRepoPath()}$ config --remove-section branch.feature/test`
     ])
   })
 
@@ -287,8 +300,14 @@ describe('removeWorktreeOp', () => {
     let listCount = 0
     const git = vi.fn<GitExec>(async (args, cwd) => {
       calls.push(`${cwd}$ ${args.join(' ')}`)
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args.join(' ') === 'rev-parse --verify --quiet HEAD^{commit}') {
+        return { stdout: 'base123\n', stderr: '' }
+      }
+      if (args.join(' ') === 'merge-base base123 1') {
+        return { stdout: '1\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
         listCount += 1
@@ -319,13 +338,20 @@ describe('removeWorktreeOp', () => {
       `${resolvedRepoPath()}$ worktree remove /repo-feature`,
       '/repo-feature$ status --porcelain --untracked-files=all',
       `${resolvedRepoPath()}$ worktree remove --force /repo-feature`,
-      `${resolvedRepoPath()}$ branch -d -- feature/test`
+      `${resolvedRepoPath()}$ config --get branch.feature/test.base`,
+      `${resolvedRepoPath()}$ symbolic-ref --quiet refs/remotes/origin/HEAD`,
+      `${resolvedRepoPath()}$ rev-parse --verify --quiet HEAD^{commit}`,
+      `${resolvedRepoPath()}$ merge-base base123 1`,
+      `${resolvedRepoPath()}$ worktree list --porcelain`,
+      `${resolvedRepoPath()}$ update-ref -d refs/heads/feature/test 1`,
+      `${resolvedRepoPath()}$ worktree list --porcelain`,
+      `${resolvedRepoPath()}$ config --remove-section branch.feature/test`
     ])
   })
 
   it('surfaces uncommitted changes instead of force-removing a dirty submodule worktree', async () => {
     const git = vi.fn<GitExec>(async (args) => {
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
@@ -359,7 +385,7 @@ describe('removeWorktreeOp', () => {
 
   it('does not force-retry when the caller already forced SSH removal', async () => {
     const git = vi.fn<GitExec>(async (args) => {
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
@@ -393,46 +419,74 @@ describe('removeWorktreeOp', () => {
     )
   })
 
-  it('preserves the branch (does not throw) when `branch -d` refuses an unmerged branch', async () => {
-    let listCount = 0
-    const git = vi.fn<GitExec>(async (args) => {
-      if (args[0] === 'rev-parse') {
-        return { stdout: '/repo/.git\n', stderr: '' }
-      }
-      if (args[0] === 'worktree' && args[1] === 'list') {
-        listCount += 1
-        return {
-          stdout:
-            listCount === 1
-              ? worktreeList(
-                  { path: '/repo', branch: 'main' },
-                  { path: '/repo-feature', branch: 'feature/test' }
-                )
-              : worktreeList({ path: '/repo', branch: 'main' }),
-          stderr: ''
+  it.each([true, false])(
+    'preserves an unmerged branch when tracking-branch deletion would succeed: %s',
+    async (trackingBranchContainsHead) => {
+      let listCount = 0
+      const git = vi.fn<GitExec>(async (args) => {
+        if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+          return { stdout: '/repo/.git\n', stderr: '' }
         }
-      }
-      if (args[0] === 'branch' && args[1] === '-d') {
-        throw new Error('error: the branch feature/test is not fully merged')
-      }
-      return { stdout: '', stderr: '' }
-    })
+        if (args.join(' ') === 'rev-parse --verify --quiet HEAD^{commit}') {
+          return { stdout: 'base123\n', stderr: '' }
+        }
+        if (args.join(' ') === 'merge-base base123 1') {
+          return { stdout: 'ancestor123\n', stderr: '' }
+        }
+        if (args.join(' ') === 'merge-tree --write-tree base123 1') {
+          throw new Error('merge conflict')
+        }
+        if (args.join(' ') === 'rev-list --right-only --merges --count base123...1') {
+          return { stdout: '0\n', stderr: '' }
+        }
+        if (args.join(' ') === 'cherry -v base123 1') {
+          return { stdout: '+ 1 Unmerged change\n', stderr: '' }
+        }
+        if (args[0] === 'worktree' && args[1] === 'list') {
+          listCount += 1
+          return {
+            stdout:
+              listCount === 1
+                ? worktreeList(
+                    { path: '/repo', branch: 'main' },
+                    { path: '/repo-feature', branch: 'feature/test' }
+                  )
+                : worktreeList({ path: '/repo', branch: 'main' }),
+            stderr: ''
+          }
+        }
+        if (args[0] === 'branch' && args[1] === '-d') {
+          if (trackingBranchContainsHead) {
+            return { stdout: 'Deleted branch feature/test\n', stderr: '' }
+          }
+          throw new Error('error: the branch feature/test is not fully merged')
+        }
+        return { stdout: '', stderr: '' }
+      })
 
-    // The unmerged-branch refusal must be surfaced without failing workspace removal.
-    await expect(
-      removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
-    ).resolves.toEqual({
-      preservedBranch: { branchName: 'feature/test', head: '1' }
-    })
+      await expect(
+        removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+      ).resolves.toEqual({
+        preservedBranch: { branchName: 'feature/test', head: '1' }
+      })
 
-    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
-    expect(git).not.toHaveBeenCalledWith(['branch', '-D', '--', 'feature/test'], expect.any(String))
-  })
+      expect(git).toHaveBeenCalledWith(['merge-base', 'base123', '1'], resolvedRepoPath())
+      expect(git).not.toHaveBeenCalledWith(
+        ['branch', '-d', '--', 'feature/test'],
+        expect.any(String)
+      )
+      expect(git).not.toHaveBeenCalledWith(
+        ['branch', '-D', '--', 'feature/test'],
+        expect.any(String)
+      )
+      expect(git.mock.calls.some(([args]) => args[0] === 'update-ref')).toBe(false)
+    }
+  )
 
   it('force-deletes the just-created branch during failed sparse setup rollback', async () => {
     let listCount = 0
     const git = vi.fn<GitExec>(async (args) => {
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
@@ -467,7 +521,7 @@ describe('removeWorktreeOp', () => {
 
   it('does not let force override a locked SSH worktree', async () => {
     const git = vi.fn<GitExec>(async (args) => {
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
@@ -496,7 +550,7 @@ describe('removeWorktreeOp', () => {
     const calls: string[] = []
     const git = vi.fn<GitExec>(async (args, cwd) => {
       calls.push(`${cwd}$ ${args.join(' ')}`)
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
@@ -526,8 +580,14 @@ describe('removeWorktreeOp', () => {
   it('keeps the branch when Git reports another SSH worktree still uses it', async () => {
     let listCount = 0
     const git = vi.fn<GitExec>(async (args, _cwd) => {
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args.join(' ') === 'rev-parse --verify --quiet HEAD^{commit}') {
+        return { stdout: 'base123\n', stderr: '' }
+      }
+      if (args.join(' ') === 'merge-base base123 1') {
+        return { stdout: '1\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
         listCount += 1
@@ -545,18 +605,18 @@ describe('removeWorktreeOp', () => {
           stderr: ''
         }
       }
-      if (args[0] === 'branch' && args[1] === '-d') {
-        throw new Error(
-          "error: cannot delete branch 'feature/test' used by worktree at '/repo-other'"
-        )
-      }
       return { stdout: '', stderr: '' }
     })
 
-    await removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+    await expect(
+      removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+    ).resolves.toEqual({ preservedBranch: { branchName: 'feature/test', head: '1' } })
 
-    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
+    expect(listCount).toBe(3)
+    expect(git).toHaveBeenCalledWith(['merge-base', 'base123', '1'], resolvedRepoPath())
+    expect(git).not.toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
     expect(git).toHaveBeenCalledWith(['worktree', 'prune'], expect.any(String))
     expect(git).not.toHaveBeenCalledWith(['branch', '-D', '--', 'feature/test'], expect.any(String))
+    expect(git.mock.calls.some(([args]) => args[0] === 'update-ref')).toBe(false)
   })
 })

--- a/src/relay/git-handler-worktree-paths.test.ts
+++ b/src/relay/git-handler-worktree-paths.test.ts
@@ -45,8 +45,14 @@ describe('relay worktree path parsing', () => {
     const worktreePath = '/repo-feature\nremote'
     let listCount = 0
     const git = vi.fn<GitExec>(async (args) => {
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args.join(' ') === 'rev-parse --verify --quiet HEAD^{commit}') {
+        return { stdout: 'base123\n', stderr: '' }
+      }
+      if (args.join(' ') === 'merge-base base123 1') {
+        return { stdout: '1\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list') {
         listCount += 1
@@ -57,7 +63,7 @@ describe('relay worktree path parsing', () => {
                   { path: '/repo', branch: 'main' },
                   { path: worktreePath, branch: 'feature/newline' }
                 )
-              : nulWorktreeList({ path: '/repo', branch: 'main' }),
+              : lineWorktreeList({ path: '/repo', branch: 'main' }),
           stderr: ''
         }
       }
@@ -66,7 +72,16 @@ describe('relay worktree path parsing', () => {
 
     await removeWorktreeWithCapabilityCache(git, { worktreePath })
 
-    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/newline'], resolvedRepoPath())
+    expect(git).toHaveBeenCalledWith(['worktree', 'remove', worktreePath], resolvedRepoPath())
+    expect(git).toHaveBeenCalledWith(['merge-base', 'base123', '1'], resolvedRepoPath())
+    expect(git).toHaveBeenCalledWith(
+      ['update-ref', '-d', 'refs/heads/feature/newline', '1'],
+      resolvedRepoPath()
+    )
+    expect(git).not.toHaveBeenCalledWith(
+      ['branch', '-d', '--', 'feature/newline'],
+      expect.any(String)
+    )
   })
 
   it('falls back to line-block worktree listing when remote Git rejects -z', async () => {
@@ -74,8 +89,14 @@ describe('relay worktree path parsing', () => {
     let listCount = 0
     const git = vi.fn<GitExec>(async (args, cwd) => {
       calls.push(`${cwd}$ ${args.join(' ')}`)
-      if (args[0] === 'rev-parse') {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
         return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args.join(' ') === 'rev-parse --verify --quiet HEAD^{commit}') {
+        return { stdout: 'base123\n', stderr: '' }
+      }
+      if (args.join(' ') === 'merge-base base123 1') {
+        return { stdout: '1\n', stderr: '' }
       }
       if (args[0] === 'worktree' && args[1] === 'list' && args.includes('-z')) {
         throw Object.assign(new Error("unknown switch `z'"), {
@@ -105,7 +126,14 @@ describe('relay worktree path parsing', () => {
       `${resolvedRepoPath()}$ worktree list --porcelain -z`,
       `${resolvedRepoPath()}$ worktree list --porcelain`,
       `${resolvedRepoPath()}$ worktree remove /repo-feature`,
-      `${resolvedRepoPath()}$ branch -d -- feature/test`
+      `${resolvedRepoPath()}$ config --get branch.feature/test.base`,
+      `${resolvedRepoPath()}$ symbolic-ref --quiet refs/remotes/origin/HEAD`,
+      `${resolvedRepoPath()}$ rev-parse --verify --quiet HEAD^{commit}`,
+      `${resolvedRepoPath()}$ merge-base base123 1`,
+      `${resolvedRepoPath()}$ worktree list --porcelain`,
+      `${resolvedRepoPath()}$ update-ref -d refs/heads/feature/test 1`,
+      `${resolvedRepoPath()}$ worktree list --porcelain`,
+      `${resolvedRepoPath()}$ config --remove-section branch.feature/test`
     ])
   })
 })

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -1,9 +1,10 @@
 import * as path from 'node:path'
 import type { RemoveWorktreeResult } from '../shared/worktree/create-types'
 import { isBranchCheckedOutInWorktreeError } from '../shared/git-branch-delete-refusal'
+import { BranchDeletionUnverifiedError } from '../shared/git-branch-delete-verification'
 import { assertWorktreeUnlockedForRemoval } from '../shared/worktree/removal'
 import { isSubmoduleWorktreeRemovalRefusal } from '../shared/worktree/submodule-removal'
-import { deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure } from './git-handler-branch-cleanup'
+import { deleteMergedRelayBranchAfterWorktreeRemoval } from './git-handler-branch-cleanup'
 import type { GitExec } from './git-handler-ops'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
 import { readRelayWorktreeList } from './git-handler-worktree-list'
@@ -61,16 +62,14 @@ async function listRelayWorktreesForRemoval(
   }
 }
 
-async function deleteRelayBranchAfterWorktreeRemoval(
+async function forceDeleteRelayBranchAfterRollback(
   git: GitExec,
   repoPath: string,
-  branchName: string,
-  forceBranchDelete: boolean
-): Promise<'deleted' | 'checked-out'> {
-  const deleteFlag = forceBranchDelete ? '-D' : '-d'
+  branchName: string
+): Promise<void> {
   try {
-    await git(['branch', deleteFlag, '--', branchName], repoPath)
-    return 'deleted'
+    await git(['branch', '-D', '--', branchName], repoPath)
+    return
   } catch (error) {
     if (!isBranchCheckedOutInWorktreeError(error)) {
       throw error
@@ -78,23 +77,21 @@ async function deleteRelayBranchAfterWorktreeRemoval(
   }
 
   try {
-    // Why: branch deletion is the cheap live-checkout guard. Only prune when
-    // Git reports a checked-out branch, which may be stale worktree metadata.
+    // Prune only when a stale checkout registration may block rollback.
     await git(['worktree', 'prune'], repoPath)
   } catch (error) {
     console.warn(
       `relay removeWorktree: failed to prune worktrees before deleting branch "${branchName}"`,
       error
     )
-    return 'checked-out'
+    return
   }
 
   try {
-    await git(['branch', deleteFlag, '--', branchName], repoPath)
-    return 'deleted'
+    await git(['branch', '-D', '--', branchName], repoPath)
   } catch (error) {
     if (isBranchCheckedOutInWorktreeError(error)) {
-      return 'checked-out'
+      return
     }
     throw error
   }
@@ -160,48 +157,32 @@ export async function removeWorktreeOp(
     return {}
   }
 
-  // Why: SSH worktree deletion should mirror local deletion. Dropping the
-  // branch also removes its upstream config, which lets fork-remotes cleanup
-  // after the last PR review worktree is gone.
   try {
-    // Why: use `-d` (not `-D`) to mirror the local removeWorktree fix.
-    const branchDeleteResult = await deleteRelayBranchAfterWorktreeRemoval(
-      git,
-      repoPath,
-      branchName,
-      forceBranchDelete
-    )
-    if (branchDeleteResult === 'checked-out') {
+    if (forceBranchDelete) {
+      await forceDeleteRelayBranchAfterRollback(git, repoPath, branchName)
       return {}
     }
-    return {}
-  } catch (error) {
-    if (!forceBranchDelete && branchHead) {
-      try {
-        if (
-          await deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure(
-            git,
-            repoPath,
-            branchName,
-            branchHead,
-            capabilities
-          )
-        ) {
-          return {}
-        }
-      } catch (alreadyMergedDeleteError) {
-        // Why: worktree is gone; preserve branch recovery on cleanup races.
-        console.warn(
-          `relay removeWorktree: failed to delete already-merged local branch "${branchName}" after removing worktree`,
-          alreadyMergedDeleteError
-        )
-      }
+    if (
+      branchHead &&
+      (await deleteMergedRelayBranchAfterWorktreeRemoval(
+        git,
+        repoPath,
+        branchName,
+        branchHead,
+        capabilities
+      ))
+    ) {
+      return {}
     }
-    // Expected when the branch still has unmerged/unpublished commits: keep it.
+  } catch (error) {
+    // Removal already succeeded; a failed or raced proof must preserve the branch.
+    if (error instanceof BranchDeletionUnverifiedError) {
+      throw error
+    }
     console.warn(
-      `relay removeWorktree: preserved local branch "${branchName}" after removing worktree (not fully merged)`,
+      `relay removeWorktree: preserved local branch "${branchName}" after removing worktree`,
       error
     )
-    return { preservedBranch: { branchName, ...(branchHead ? { head: branchHead } : {}) } }
   }
+  return { preservedBranch: { branchName, ...(branchHead ? { head: branchHead } : {}) } }
 }

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -9,6 +9,8 @@ import {
   isUnsupportedMergeTreeWriteTreeError
 } from './git-merge-tree-capability'
 import { isBranchCheckedOutInWorktreeError } from './git-branch-delete-refusal'
+import { branchHasNoUnmergedChangesOnAnyTarget } from './git-branch-cleanup'
+import { GitCapabilityCache } from './git-capability-cache'
 import { isForEachRefExcludeUnsupportedError } from './git-ref-command-capabilities'
 import { isNoWriteFetchHeadUnsupportedError } from './git-fetch-head-capability'
 import {
@@ -404,6 +406,43 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
     await expect(
       runGit(['show-ref', '--verify', '--quiet', '--', 'refs/remotes/origin/compat-parent'])
     ).rejects.toMatchObject({ code: 1 })
+  })
+
+  it('proves a captured branch commit merged without relying on its tracking branch', async () => {
+    const base = (await runGit(['rev-parse', 'HEAD'])).stdout.trim()
+    await writeFile(join(repoPath, 'retention.txt'), 'unmerged change\n')
+    await runGit(['add', 'retention.txt'])
+    const tree = (await runGit(['write-tree'])).stdout.trim()
+    const feature = (
+      await runGit(['commit-tree', tree, '-p', base, '-m', 'retention'])
+    ).stdout.trim()
+    await runGit(['reset', '--hard', 'HEAD'])
+    await runGit(['update-ref', 'refs/heads/compat-retention', feature])
+    await runGit(['update-ref', 'refs/remotes/origin/compat-retention', feature])
+    await runGit(['config', 'branch.compat-retention.remote', 'origin'])
+    await runGit(['config', 'branch.compat-retention.merge', 'refs/heads/compat-retention'])
+    const capabilities = new GitCapabilityCache()
+
+    expect(
+      await branchHasNoUnmergedChangesOnAnyTarget(
+        runGit,
+        'compat-retention',
+        [base],
+        capabilities,
+        feature
+      )
+    ).toBe(false)
+    expect(
+      await branchHasNoUnmergedChangesOnAnyTarget(
+        runGit,
+        'compat-retention',
+        [feature],
+        capabilities,
+        feature
+      )
+    ).toBe(true)
+    await runGit(['update-ref', '-d', 'refs/heads/compat-retention', feature])
+    await runGit(['config', '--remove-section', 'branch.compat-retention'])
   })
 
   it('packs loose refs and reads the maintenance opt-out at the baseline', async () => {

--- a/src/shared/git-branch-cleanup.test.ts
+++ b/src/shared/git-branch-cleanup.test.ts
@@ -3,9 +3,30 @@ import {
   branchHasNoUnmergedChangesOnAnyTarget,
   branchHasNoUnmergedChangesWithLazyTargetRefresh,
   refreshBranchCleanupTargetRefs,
+  getBranchCleanupTargetRefs,
   type GitBranchCleanupExec
 } from './git-branch-cleanup'
 import { GitCapabilityCache } from './git-capability-cache'
+
+describe('getBranchCleanupTargetRefs', () => {
+  it.each([
+    [
+      'refs/remotes/upstream/release',
+      'refs/remotes/origin/main',
+      ['refs/remotes/upstream/release']
+    ],
+    ['', 'refs/remotes/origin/main', ['refs/remotes/origin/main']],
+    ['', '', ['HEAD']]
+  ])(
+    'uses the saved base, then repository default, then HEAD (%s)',
+    async (base, defaultRef, expected) => {
+      const runGit = vi.fn<GitBranchCleanupExec>(async (args) => ({
+        stdout: String(args[0] === 'config' ? base : defaultRef)
+      }))
+      expect(await getBranchCleanupTargetRefs(runGit, 'feature/test')).toEqual(expected)
+    }
+  )
+})
 
 function baseProofResponses(
   responses: Partial<Record<string, string | Error>> = {}
@@ -92,6 +113,56 @@ describe('refreshBranchCleanupTargetRefs', () => {
 })
 
 describe('branchHasNoUnmergedChangesOnAnyTarget', () => {
+  it('uses the captured commit for an ancestry proof even if the named branch moved', async () => {
+    const runGit = vi.fn<GitBranchCleanupExec>(async (args) => {
+      if (args.join(' ') === 'rev-parse --verify --quiet HEAD^{commit}') {
+        return { stdout: 'base-tip\n' }
+      }
+      if (args.join(' ') === 'merge-base base-tip captured-head') {
+        return { stdout: 'captured-head\n' }
+      }
+      throw new Error(`Unexpected proof: ${args.join(' ')}`)
+    })
+    expect(
+      await branchHasNoUnmergedChangesOnAnyTarget(
+        runGit,
+        'feature/test',
+        ['HEAD'],
+        new GitCapabilityCache(),
+        'captured-head'
+      )
+    ).toBe(true)
+    expect(runGit.mock.calls.flatMap(([args]) => args)).not.toContain('refs/heads/feature/test')
+  })
+
+  it('pins the squash and patch-equivalence proofs to the captured commit', async () => {
+    const runGit = vi.fn<GitBranchCleanupExec>(async (args) => {
+      const responses: Record<string, string> = {
+        'rev-parse --verify --quiet HEAD^{commit}': 'base-tip\n',
+        'merge-base base-tip captured-head': 'ancestor\n',
+        'merge-tree --write-tree base-tip captured-head': 'changed-tree\n',
+        'rev-parse --verify --quiet base-tip^{tree}': 'base-tree\n',
+        'rev-list --right-only --merges --count base-tip...captured-head': '0\n',
+        'cherry -v base-tip captured-head': '- captured-head already integrated\n'
+      }
+      const response = responses[args.join(' ')]
+      if (response === undefined) {
+        throw new Error(`Unexpected proof: ${args.join(' ')}`)
+      }
+      return { stdout: response }
+    })
+    expect(
+      await branchHasNoUnmergedChangesOnAnyTarget(
+        runGit,
+        'feature/test',
+        ['HEAD'],
+        new GitCapabilityCache(),
+        'captured-head'
+      )
+    ).toBe(true)
+    expect(runGit).toHaveBeenCalledWith(['cherry', '-v', 'base-tip', 'captured-head'], undefined)
+  })
+
   it('accepts a branch with merge commits when a target squash commit matches its net patch', async () => {
     const runGit = baseProofResponses()
 
@@ -121,6 +192,25 @@ describe('branchHasNoUnmergedChangesOnAnyTarget', () => {
       )
     ).resolves.toBe(false)
   })
+
+  it.each(['', 'invalid', new Error('history unavailable')])(
+    'preserves patch-equivalent commits when merge history cannot be verified (%s)',
+    async (mergeCount) => {
+      const runGit = baseProofResponses({
+        'rev-list --right-only --merges --count target...refs/heads/feature/test': mergeCount,
+        'cherry -v target refs/heads/feature/test': '- branch-only patch\n'
+      })
+
+      await expect(
+        branchHasNoUnmergedChangesOnAnyTarget(
+          runGit,
+          'feature/test',
+          ['refs/remotes/origin/main'],
+          new GitCapabilityCache()
+        )
+      ).resolves.toBe(false)
+    }
+  )
 
   it('preserves when a matching squash candidate still changes after merging the branch', async () => {
     const runGit = baseProofResponses({

--- a/src/shared/git-branch-cleanup.ts
+++ b/src/shared/git-branch-cleanup.ts
@@ -54,11 +54,16 @@ export async function getBranchCleanupTargetRefs(
     candidates,
     await readOptionalGitStdout(runGit, ['config', '--get', `branch.${branchName}.base`])
   )
+  if (candidates.length > 0) {
+    return candidates
+  }
   addCandidateRef(
     candidates,
     await readOptionalGitStdout(runGit, ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'])
   )
-  addCandidateRef(candidates, 'HEAD')
+  if (candidates.length === 0) {
+    addCandidateRef(candidates, 'HEAD')
+  }
   return candidates
 }
 
@@ -91,11 +96,11 @@ async function resolveCommitOid(runGit: GitBranchCleanupExec, ref: string): Prom
   return readOptionalGitStdout(runGit, ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`])
 }
 
-async function hasBranchOnlyMergeCommits(
+async function readBranchOnlyMergeCount(
   runGit: GitBranchCleanupExec,
   targetOid: string,
   branchRef: string
-): Promise<boolean> {
+): Promise<number | null> {
   const stdout = await readOptionalGitStdout(runGit, [
     'rev-list',
     '--right-only',
@@ -103,7 +108,7 @@ async function hasBranchOnlyMergeCommits(
     '--count',
     `${targetOid}...${branchRef}`
   ])
-  return Number(stdout ?? 0) > 0
+  return stdout !== null && /^\d+$/.test(stdout) ? Number(stdout) : null
 }
 
 async function branchMergesWithoutTreeChanges(
@@ -230,19 +235,31 @@ export async function branchHasNoUnmergedChangesOnAnyTarget(
   runGit: GitBranchCleanupExec,
   branchName: string,
   targetRefs: string[],
-  capabilities: GitCapabilityCache
+  capabilities: GitCapabilityCache,
+  expectedHead?: string
 ): Promise<boolean> {
-  const branchRef = `refs/heads/${branchName}`
+  const branchRef = expectedHead ?? `refs/heads/${branchName}`
 
   for (const targetRef of targetRefs) {
     const targetOid = await resolveCommitOid(runGit, targetRef)
     if (!targetOid) {
       continue
     }
+    if (
+      expectedHead &&
+      (await readOptionalGitStdout(runGit, ['merge-base', targetOid, expectedHead])) ===
+        expectedHead
+    ) {
+      return true
+    }
     if (await branchMergesWithoutTreeChanges(runGit, targetOid, branchRef, capabilities)) {
       return true
     }
-    if (await hasBranchOnlyMergeCommits(runGit, targetOid, branchRef)) {
+    const mergeCount = await readBranchOnlyMergeCount(runGit, targetOid, branchRef)
+    if (mergeCount === null) {
+      continue
+    }
+    if (mergeCount > 0) {
       if (
         await branchNetPatchMatchesTargetSquashCommit(runGit, targetOid, branchRef, capabilities)
       ) {
@@ -262,13 +279,20 @@ export async function branchHasNoUnmergedChangesWithLazyTargetRefresh(
   runGit: GitBranchCleanupExec,
   branchName: string,
   targetRefs: string[],
-  capabilities: GitCapabilityCache
+  capabilities: GitCapabilityCache,
+  expectedHead?: string
 ): Promise<boolean> {
   // Why: an unrefreshed remote-tracking ref may no longer represent the remote's branch contents.
   const localTargetRefs = targetRefs.filter(isLocalTargetRef)
   const refreshDependentTargetRefs = targetRefs.filter((targetRef) => !isLocalTargetRef(targetRef))
   if (
-    await branchHasNoUnmergedChangesOnAnyTarget(runGit, branchName, localTargetRefs, capabilities)
+    await branchHasNoUnmergedChangesOnAnyTarget(
+      runGit,
+      branchName,
+      localTargetRefs,
+      capabilities,
+      expectedHead
+    )
   ) {
     return true
   }
@@ -277,6 +301,7 @@ export async function branchHasNoUnmergedChangesWithLazyTargetRefresh(
     runGit,
     branchName,
     refreshDependentTargetRefs,
-    capabilities
+    capabilities,
+    expectedHead
   )
 }

--- a/src/shared/git-branch-delete-verification.ts
+++ b/src/shared/git-branch-delete-verification.ts
@@ -1,0 +1,29 @@
+export class BranchDeletionUnverifiedError extends Error {
+  constructor(branchName: string, cause: unknown) {
+    super(
+      `Could not verify or restore branch "${branchName}" after deletion. Review the repository before continuing.`,
+      { cause }
+    )
+    this.name = 'BranchDeletionUnverifiedError'
+  }
+}
+
+export async function verifyDeletedBranchCheckout(
+  branchName: string,
+  isCheckedOut: () => Promise<boolean>,
+  restoreExpectedHead: () => Promise<unknown>
+): Promise<void> {
+  try {
+    if (await isCheckedOut()) {
+      throw new Error(`Local branch "${branchName}" is checked out in another worktree.`)
+    }
+  } catch (error) {
+    // A failed checkout scan is no evidence that the deleted ref is safe to leave absent.
+    try {
+      await restoreExpectedHead()
+    } catch (cause) {
+      throw new BranchDeletionUnverifiedError(branchName, cause)
+    }
+    throw error
+  }
+}

--- a/tests/e2e/worktree-branch-retention.spec.ts
+++ b/tests/e2e/worktree-branch-retention.spec.ts
@@ -81,6 +81,10 @@ for (const theme of ['dark', 'light'] as const) {
     await dialog.getByRole('button', { name: 'Delete Workspace', exact: true }).click()
     await expect(row).toHaveCount(0)
     await expect(orcaPage.getByText('Deleting workspace…', { exact: true })).toHaveCount(0)
+    await expect(orcaPage.getByText('Worktree deleted, branch kept', { exact: true })).toBeVisible()
+    await expect(
+      orcaPage.getByRole('button', { name: 'Force Delete Branch', exact: true })
+    ).toBeVisible()
 
     const screenshot = testInfo.outputPath(`retained-branch-${theme}.png`)
     await orcaPage.screenshot({ path: screenshot, animations: 'disabled' })
@@ -88,10 +92,6 @@ for (const theme of ['dark', 'light'] as const) {
       path: screenshot,
       contentType: 'image/png'
     })
-    await expect(orcaPage.getByText('Worktree deleted, branch kept', { exact: true })).toBeVisible()
-    await expect(
-      orcaPage.getByRole('button', { name: 'Force Delete Branch', exact: true })
-    ).toBeVisible()
     expect(await git(seededRepoPath, ['rev-parse', 'feature/unmerged-work'])).toBe(head)
   })
 }

--- a/tests/e2e/worktree-branch-retention.spec.ts
+++ b/tests/e2e/worktree-branch-retention.spec.ts
@@ -1,0 +1,97 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runProcess } from '../../src/shared/child-process/run-process'
+import { test as base, expect } from './helpers/orca-app'
+import { pressShortcut } from './helpers/shortcuts'
+import { worktreeRow } from './worktree-row-locators'
+
+async function git(repo: string, args: string[]): Promise<string> {
+  const result = await runProcess({ program: 'git', args, cwd: repo })
+  if (result.code !== 0) {
+    throw new Error(result.stderr)
+  }
+  return result.stdout.trim()
+}
+
+const test = base.extend({
+  seededRepoPath: async ({ registerPostElectronShutdownCleanup }, provideFixture) => {
+    const root = await realpath(await mkdtemp(join(tmpdir(), 'orca-retained-branch-e2e-')))
+    registerPostElectronShutdownCleanup(async () => rm(root, { recursive: true, force: true }))
+    const repo = join(root, 'repo')
+    const feature = join(root, 'feature')
+    await mkdir(repo)
+    await git(repo, ['init', '-q'])
+    await git(repo, ['symbolic-ref', 'HEAD', 'refs/heads/main'])
+    await git(repo, ['config', 'user.name', 'Branch Retention'])
+    await git(repo, ['config', 'user.email', 'retention@example.invalid'])
+    await writeFile(join(repo, 'README.md'), '# Branch retention proof\n')
+    await git(repo, ['add', '.'])
+    await git(repo, ['commit', '-qm', 'base'])
+    await git(repo, ['init', '--bare', '-q', join(root, 'remote.git')])
+    await git(repo, ['remote', 'add', 'origin', join(root, 'remote.git')])
+    await git(repo, ['push', '-u', 'origin', 'main'])
+    await git(repo, ['symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/main'])
+    await git(repo, ['worktree', 'add', '-q', '-b', 'feature/unmerged-work', feature])
+    await git(repo, ['config', 'branch.feature/unmerged-work.base', 'refs/remotes/origin/main'])
+    await writeFile(join(feature, 'feature.txt'), 'Work that has been pushed, but not merged.\n')
+    await git(feature, ['add', '.'])
+    await git(feature, ['commit', '-qm', 'unmerged feature'])
+    await git(feature, ['push', '-u', 'origin', 'feature/unmerged-work'])
+    await provideFixture(repo)
+  }
+})
+
+for (const theme of ['dark', 'light'] as const) {
+  test(`deleting a pushed unmerged workspace keeps its branch (${theme})`, async ({
+    orcaPage,
+    seededRepoPath
+  }, testInfo) => {
+    await orcaPage.setViewportSize({ width: 1200, height: 900 })
+    const id = await orcaPage.evaluate(async (theme) => {
+      const state = window.__store!.getState()
+      await state.updateSettingsOrThrow({ theme })
+      const feature = Object.values(state.worktreesByRepo)
+        .flat()
+        .find(
+          (worktree) => worktree.branch?.replace(/^refs\/heads\//, '') === 'feature/unmerged-work'
+        )
+      if (!feature) {
+        throw new Error('Expected seeded feature workspace')
+      }
+      return feature.id
+    }, theme)
+    const head = await git(seededRepoPath, ['rev-parse', 'feature/unmerged-work'])
+    expect(
+      await git(seededRepoPath, ['rev-list', '--count', 'origin/main..feature/unmerged-work'])
+    ).toBe('1')
+    expect(
+      await git(seededRepoPath, [
+        'rev-list',
+        '--count',
+        'origin/feature/unmerged-work..feature/unmerged-work'
+      ])
+    ).toBe('0')
+    const row = worktreeRow(orcaPage, id)
+    await expect(row).toBeVisible()
+    await row.hover()
+    await pressShortcut(orcaPage, 'Backspace', { shift: true })
+    const dialog = orcaPage.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'Delete Workspace', exact: true }).click()
+    await expect(row).toHaveCount(0)
+    await expect(orcaPage.getByText('Deleting workspace…', { exact: true })).toHaveCount(0)
+
+    const screenshot = testInfo.outputPath(`retained-branch-${theme}.png`)
+    await orcaPage.screenshot({ path: screenshot, animations: 'disabled' })
+    await testInfo.attach(`retained-branch-${theme}`, {
+      path: screenshot,
+      contentType: 'image/png'
+    })
+    await expect(orcaPage.getByText('Worktree deleted, branch kept', { exact: true })).toBeVisible()
+    await expect(
+      orcaPage.getByRole('button', { name: 'Force Delete Branch', exact: true })
+    ).toBeVisible()
+    expect(await git(seededRepoPath, ['rev-parse', 'feature/unmerged-work'])).toBe(head)
+  })
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​841 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​328 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​513 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​181 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​153 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |

<!-- /orca-pr-loc -->

## ELI5

Pushing a branch saves a copy; merging incorporates its changes into the base branch. Orca previously treated “fully pushed” as safe to delete when removing a workspace. It now keeps the local branch until it can prove those changes reached its cleanup target, and shows the existing “branch kept” recovery action.

## What Changed

- Prove the captured branch commit is integrated **before** automatic deletion. Prefer its configured base, otherwise the repository default, using HEAD only when neither is known.
- Reuse existing merge/squash/patch proofs and expected-head compare-and-swap deletion, so a concurrent commit cannot be deleted using stale evidence.
- Preserve branches on missing/failed proof, unknown merge history, or active checkout. A failed post-delete checkout scan attempts safe restoration; failed restoration stays an explicit error rather than claiming the branch was kept, including Windows recovery.
- Apply the same logic to the relay implementation. Explicit failed-creation rollback still permits force deletion.

## Why

`git branch -d` considers the tracking upstream. A branch that is fully pushed to `origin/feature` can therefore be deleted even when `origin/main` is missing its commits. Running that command first bypassed Orca’s existing integration proof entirely.

## Linked Issue

Fixes #19728

## Visual Proof

The same real Electron deletion flow runs against a temporary repository and local bare remote: the feature is one commit ahead of main and zero commits ahead of its tracking upstream. Before: workspace and local branch disappear with no retention notice. After: workspace disappears, branch remains at the exact commit, and the existing recovery toast appears.

| Theme | Before | After |
| --- | --- | --- |
| Dark | ![Before: branch silently removed](https://github.com/user-attachments/assets/aa856626-d36e-44b3-9deb-7e39bc4a3e8a) | ![After: local branch kept with recovery action](https://github.com/user-attachments/assets/9acb6be1-e4a4-411a-802e-472eb5117227) |
| Light | ![Before: no branch retention notice](https://github.com/user-attachments/assets/9505b65f-a197-40d0-9ffd-d360a4b2c545) | ![After: branch retained in light theme](https://github.com/user-attachments/assets/ebec585d-4b19-4949-a1a7-85bcffbbe2c8) |

## Testing

- [x] Real UI deletion tested locally through Playwright CDP; screenshots inspected.
- [x] Automated regressions added and existing cleanup expectations updated.

- 120 focused tests passed across 10 files, including 17 real-Git cases spanning local and relay removal, ordinary/forced workspace removal, normal/squash merges, explicit rollback, moved branch heads, unrelated primary HEAD, and failed verification/restoration.
- Real Git 2.50.1 compatibility contract: 19 tests passed.
- `pnpm tc` passed; changed-code quality gate (lint, type-aware lint, React Doctor), formatting, and diff checks passed.
- `electron-vite build --mode e2e` passed; both light/dark deletion scenarios passed. The same scenarios fail on the unmodified baseline at the missing retention notice.
- All tests/apps ran with `ORCA_BACKGROUND_LAUNCH=1`; no native window activation.

**Verification scope:** fully verified the reported pushed/unmerged branch loss on macOS with real Git, including the actual UI → IPC → filesystem flow. Local and relay execution functions are both exercised against real temporary repositories. Native Windows/Linux desktops, a live SSH connection, and the Git 2.25.5/2.38.1/2.49.1 matrix were not run locally; the existing PR compatibility matrix includes the new contract. No new Git flags or wire fields are introduced.

## Review

Independent review and an elegance pass completed. Review-driven regressions cover unrelated primary HEAD, failed post-delete verification/restoration, and Windows filesystem recovery. The two execution paths reuse the same proof and post-delete verification logic. Worktree-list fixtures use Git’s NUL-delimited format, and screenshot capture waits for the visible retention notice and recovery action; the six focused removal cases and both rendered scenarios pass with those review corrections.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer content used.

## Notes

With a configured remote base, merging locally without pushing that base preserves the feature branch conservatively. Folder workspace removal is unaffected; this cleanup applies to Git worktrees. No provider-specific review logic is introduced.

## Checklist

- [x] This PR is small and focused on one cleanup bug
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full repository test/package build left to CI; focused checks listed above
